### PR TITLE
feat(api,web,shared): sourced script parameters (#3409 PR3)

### DIFF
--- a/apps/api/src/db/schema/scripts.ts
+++ b/apps/api/src/db/schema/scripts.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm';
 import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, integer, numeric, index, primaryKey, type AnyPgColumn } from 'drizzle-orm/pg-core';
+import type { ScriptParameterDefinition } from '@breeze/shared';
 import { organizations, partners } from './orgs';
 import { devices } from './devices';
 import { users } from './users';
@@ -25,7 +26,12 @@ export const scripts = pgTable('scripts', {
   osTypes: text('os_types').array().notNull(),
   language: scriptLanguageEnum('language').notNull(),
   content: text('content').notNull(),
-  parameters: jsonb('parameters'),
+  // Parameter DEFINITIONS (the authoring-time contract), validated by
+  // `scriptParameterDefinitionsSchema` in @breeze/shared. Note the deliberate
+  // asymmetry with `script_executions.parameters` / `script_execution_batches
+  // .parameters` below, which hold run-time VALUES and are typed by
+  // `scriptParametersSchema` instead.
+  parameters: jsonb('parameters').$type<ScriptParameterDefinition[]>(),
   timeoutSeconds: integer('timeout_seconds').notNull().default(300),
   runAs: scriptRunAsEnum('run_as').notNull().default('system'),
   isSystem: boolean('is_system').notNull().default(false),
@@ -100,7 +106,9 @@ export const scriptTemplates = pgTable('script_templates', {
   category: varchar('category', { length: 100 }),
   language: scriptLanguageEnum('language'),
   content: text('content').notNull(),
-  parameters: jsonb('parameters'),
+  // Definitions, same as `scripts.parameters` — a template is a script
+  // blueprint, so what it stores is the parameter contract, not values.
+  parameters: jsonb('parameters').$type<ScriptParameterDefinition[]>(),
   isBuiltIn: boolean('is_built_in').notNull().default(false),
   downloads: integer('downloads').notNull().default(0),
   rating: numeric('rating', { precision: 2, scale: 1 })
@@ -125,6 +133,8 @@ export const scriptExecutions = pgTable('script_executions', {
   // a bare uuid. Readers filter on it (`WHERE automation_run_id = $run`), so a
   // stale id left behind by a purged run simply matches nothing.
   automationRunId: uuid('automation_run_id'),
+  // Run-time VALUES supplied by the caller, NOT definitions — do not annotate
+  // this with ScriptParameterDefinition[]. Shape: `scriptParametersSchema`.
   parameters: jsonb('parameters'),
   status: executionStatusEnum('status').notNull().default('pending'),
   startedAt: timestamp('started_at'),
@@ -151,6 +161,7 @@ export const scriptExecutionBatches = pgTable('script_execution_batches', {
   orgId: uuid('org_id').references(() => organizations.id),
   triggeredBy: uuid('triggered_by').references(() => users.id),
   triggerType: triggerTypeEnum('trigger_type').notNull().default('manual'),
+  // Run-time VALUES, as on script_executions above — not definitions.
   parameters: jsonb('parameters'),
   devicesTargeted: integer('devices_targeted').notNull(),
   devicesCompleted: integer('devices_completed').notNull().default(0),

--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -1554,6 +1554,8 @@ describe('mobile routes', () => {
         executions: [
           { executionId: 'exec-1', deviceId: '11111111-2222-4333-8444-555555555555', commandId: 'cmd-1' }
         ],
+        failures: [],
+        ignoredParameters: [],
         status: 'queued',
         triggerType: 'manual',
         runAs: 'system',
@@ -1597,6 +1599,96 @@ describe('mobile routes', () => {
           })
         })
       );
+    });
+
+    // #3409 PR3 §2.2 — this endpoint accepts `parameters`, so a mobile caller
+    // can supply a value for a parameter that is BOUND to a source. The
+    // binding wins and the value is dropped; surfacing it here keeps the
+    // mobile client's contract consistent with POST /scripts/:id/execute.
+    it('surfaces ignored bound parameter keys in the body and the audit', async () => {
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectLimitChain([
+          { id: '11111111-2222-4333-8444-555555555555', orgId: 'org-123', status: 'online', osType: 'linux', siteId: null }
+        ]) as any
+      );
+      executeScriptOnDevicesMock.mockResolvedValueOnce({
+        ok: true,
+        batchId: 'batch-1',
+        scriptId: '22222222-2222-2222-2222-222222222222',
+        script: { id: '22222222-2222-2222-2222-222222222222' } as any,
+        devicesTargeted: 1,
+        maintenanceSuppressedDeviceIds: [],
+        executions: [
+          { executionId: 'exec-1', deviceId: '11111111-2222-4333-8444-555555555555', commandId: 'cmd-1' }
+        ],
+        failures: [],
+        ignoredParameters: ['api_key'],
+        status: 'queued',
+        triggerType: 'manual',
+        runAs: 'system',
+        auditOrgId: 'org-123'
+      });
+
+      const res = await app.request('/mobile/devices/11111111-2222-4333-8444-555555555555/actions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'run_script',
+          scriptId: '22222222-2222-2222-2222-222222222222',
+          parameters: { api_key: 'caller-supplied-secret' }
+        })
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.ignoredParameters).toEqual(['api_key']);
+      expect(writeRouteAuditMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          details: expect.objectContaining({ ignoredParameterKeys: ['api_key'] })
+        })
+      );
+      // Keys only — the caller's value must never reach an audit row.
+      const auditDetails = writeRouteAuditMock.mock.calls.at(-1)?.[1]?.details ?? {};
+      expect(JSON.stringify(auditDetails)).not.toContain('caller-supplied-secret');
+    });
+
+    it('omits ignoredParameters entirely when nothing was ignored', async () => {
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectLimitChain([
+          { id: '11111111-2222-4333-8444-555555555555', orgId: 'org-123', status: 'online', osType: 'linux', siteId: null }
+        ]) as any
+      );
+      executeScriptOnDevicesMock.mockResolvedValueOnce({
+        ok: true,
+        batchId: 'batch-1',
+        scriptId: '22222222-2222-2222-2222-222222222222',
+        script: { id: '22222222-2222-2222-2222-222222222222' } as any,
+        devicesTargeted: 1,
+        maintenanceSuppressedDeviceIds: [],
+        executions: [
+          { executionId: 'exec-1', deviceId: '11111111-2222-4333-8444-555555555555', commandId: 'cmd-1' }
+        ],
+        failures: [],
+        ignoredParameters: [],
+        status: 'queued',
+        triggerType: 'manual',
+        runAs: 'system',
+        auditOrgId: 'org-123'
+      });
+
+      const res = await app.request('/mobile/devices/11111111-2222-4333-8444-555555555555/actions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'run_script',
+          scriptId: '22222222-2222-2222-2222-222222222222'
+        })
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect('ignoredParameters' in body).toBe(false);
     });
 
     it.skip('should submit device action commands', async () => {
@@ -1691,6 +1783,8 @@ describe('mobile routes', () => {
           devicesTargeted: 1,
           maintenanceSuppressedDeviceIds: [],
           executions: [{ executionId: 'exec-1', deviceId: DEVICE_ID, commandId: 'cmd-1' }],
+          failures: [],
+          ignoredParameters: [],
           status: 'queued',
           triggerType: 'manual',
           runAs: 'system',
@@ -1720,6 +1814,8 @@ describe('mobile routes', () => {
           devicesTargeted: 1,
           maintenanceSuppressedDeviceIds: [],
           executions: [{ executionId: 'exec-1', deviceId: DEVICE_ID, commandId: 'cmd-1' }],
+          failures: [],
+          ignoredParameters: [],
           status: 'queued',
           triggerType: 'manual',
           runAs: 'system',

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -1235,6 +1235,12 @@ mobileRoutes.post(
           scriptId: result.scriptId,
           executionId: execution.executionId,
           commandId: execution.commandId,
+          // #3409 PR3 §2.2 — bound parameter keys whose caller-supplied value
+          // was dropped in favour of the binding. KEYS ONLY, never values.
+          // Named distinctly rather than folded into an existing key: audit
+          // `details` is an untyped shared bag and overloading a generic name
+          // there has already caused one cross-meaning collision (`deviceId`).
+          ignoredParameterKeys: result.ignoredParameters,
         },
       });
 
@@ -1242,6 +1248,13 @@ mobileRoutes.post(
         action: data.action,
         executionId: execution.executionId,
         commandId: execution.commandId,
+        // This endpoint accepts `parameters`, so the mobile client is just as
+        // able to supply a value for a bound key as the web one — the warning
+        // is surfaced here for the same reason and in the same shape as
+        // POST /scripts/:id/execute (omitted when empty, so the clean-run
+        // response shape mobile already parses is unchanged). The single-
+        // device shape needs no aggregation: the fan-out is one device.
+        ignoredParameters: result.ignoredParameters.length > 0 ? result.ignoredParameters : undefined,
       }, 201);
     }
 

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -1013,6 +1013,7 @@ describe('scripts routes', () => {
           code: 'unresolved_variables',
           error: 'Unresolved tenant variable(s): no value set for {{var.api_key}}',
         }],
+        ignoredParameters: [],
         status: 'queued',
         triggerType: 'manual',
         runAs: 'system',
@@ -1049,6 +1050,7 @@ describe('scripts routes', () => {
           commandId: 'cmd-1',
         }],
         failures: [],
+        ignoredParameters: [],
         status: 'queued',
         triggerType: 'manual',
         runAs: 'system',
@@ -1063,6 +1065,104 @@ describe('scripts routes', () => {
       expect(res.status).toBe(201);
       const body = await res.json();
       expect(body.failures).toBeUndefined();
+    });
+  });
+
+  // #3409 PR3 §2.2: a caller-supplied value for a parameter BOUND to a source
+  // (tenantVariable / deviceCustomField / builtin) is ignored — the binding
+  // wins — rather than 400'd, so a stored automation cannot be broken by a
+  // script author flipping a parameter to bound. That makes the ignore
+  // otherwise SILENT, which is why it has to reach both the response body and
+  // the audit trail.
+  describe('ignored bound parameters on execute (#3409 PR3)', () => {
+    const executeWithParameters = (parameters: Record<string, unknown>) => ({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({
+        deviceIds: ['11111111-1111-1111-1111-111111111111'],
+        parameters,
+      }),
+    });
+
+    const okResultWithIgnored = (ignoredParameters: string[]) => ({
+      ok: true,
+      batchId: null,
+      batchIds: [],
+      scriptId: SCRIPT_ID_1,
+      script: { id: SCRIPT_ID_1, name: 'Script One' },
+      devicesTargeted: 1,
+      maintenanceSuppressedDeviceIds: [],
+      executions: [{
+        executionId: 'exec-1',
+        deviceId: '11111111-1111-1111-1111-111111111111',
+        commandId: 'cmd-1',
+      }],
+      failures: [],
+      ignoredParameters,
+      status: 'queued' as const,
+      triggerType: 'manual' as const,
+      runAs: 'system',
+      auditOrgId: ORG_ID,
+    });
+
+    it('returns the ignored bound keys on the 201 body', async () => {
+      executeScriptOnDevicesMock.mockResolvedValueOnce(okResultWithIgnored(['api_key', 'site_code']));
+
+      const res = await app.request(
+        `/scripts/${SCRIPT_ID_1}/execute`,
+        executeWithParameters({ api_key: 'caller-supplied', site_code: 'caller-supplied' }),
+      );
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.ignoredParameters).toEqual(['api_key', 'site_code']);
+      // The run still succeeded — ignoring is not failing.
+      expect(body.executions).toHaveLength(1);
+      expect(body.failures).toBeUndefined();
+    });
+
+    it('audits the ignored KEYS (and no values) under a dedicated details field', async () => {
+      executeScriptOnDevicesMock.mockResolvedValueOnce(okResultWithIgnored(['api_key']));
+
+      const res = await app.request(
+        `/scripts/${SCRIPT_ID_1}/execute`,
+        executeWithParameters({ api_key: 's3cret-value-the-caller-sent' }),
+      );
+
+      expect(res.status).toBe(201);
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'script.execute',
+          details: expect.objectContaining({ ignoredParameterKeys: ['api_key'] }),
+        }),
+      );
+      // Keys only: whatever the caller sent under a bound key must never land
+      // in an audit row, which is long-lived and widely readable.
+      const auditDetails = vi.mocked(writeRouteAudit).mock.calls.at(-1)?.[1].details ?? {};
+      expect(JSON.stringify(auditDetails)).not.toContain('s3cret-value-the-caller-sent');
+    });
+
+    it('omits ignoredParameters entirely on a clean run', async () => {
+      executeScriptOnDevicesMock.mockResolvedValueOnce(okResultWithIgnored([]));
+
+      const res = await app.request(
+        `/scripts/${SCRIPT_ID_1}/execute`,
+        executeWithParameters({ runtime_param: 'value' }),
+      );
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      // ABSENT, not an empty array — the common clean-run shape is unchanged,
+      // so a client can treat presence alone as "warn the user".
+      expect(body.ignoredParameters).toBeUndefined();
+      expect('ignoredParameters' in body).toBe(false);
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          details: expect.objectContaining({ ignoredParameterKeys: [] }),
+        }),
+      );
     });
   });
 

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -1946,4 +1946,138 @@ describe('scripts routes', () => {
       expect(vi.mocked(writeRouteAudit)).not.toHaveBeenCalled();
     });
   });
+
+  // -------------------------------------------------------------------
+  // Parameter DEFINITION validation + version bump (#3409 PR3)
+  // -------------------------------------------------------------------
+  // `parameters` was `z.any()` on both create and update, so definitions
+  // reached jsonb entirely unchecked; and `version` only tracked content, so
+  // a parameter rename or a source rebinding was invisible to anything
+  // pinning the version.
+  describe('parameter definitions + version bump', () => {
+    function mockCreateInsert(): void {
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'P', orgId: ORG_ID }]),
+        }),
+      } as any);
+    }
+
+    /** Mock the PUT read + capture what `.set()` receives. */
+    function mockUpdate(stored: Record<string, unknown>): { set: ReturnType<typeof vi.fn> } {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              { id: SCRIPT_ID_1, name: 'S', content: 'echo hi', version: 7, isSystem: false, orgId: ORG_ID, ...stored },
+            ]),
+          }),
+        }),
+      } as any);
+      const set = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'S' }]),
+        }),
+      });
+      vi.mocked(db.update).mockReturnValue({ set } as any);
+      return { set };
+    }
+
+    const put = (body: unknown) =>
+      app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify(body),
+      });
+
+    const post = (parameters: unknown) =>
+      app.request('/scripts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ name: 'P', osTypes: ['linux'], language: 'bash', content: 'echo hi', parameters }),
+      });
+
+    it('accepts a legacy definition with no source on create', async () => {
+      mockCreateInsert();
+      expect((await post([{ name: 'target', type: 'string' }])).status).toBe(201);
+    });
+
+    it('accepts every bound source on create', async () => {
+      mockCreateInsert();
+      const res = await post([
+        { name: 'apiKey', type: 'string', source: 'tenantVariable', variableKey: 'vendor_api_key' },
+        { name: 'assetTag', type: 'string', source: 'deviceCustomField', fieldKey: 'asset_tag' },
+        { name: 'orgName', type: 'string', source: 'builtin', builtinKey: 'org.name' },
+      ]);
+      expect(res.status).toBe(201);
+    });
+
+    it('rejects a definition whose name could not become an env var', async () => {
+      expect((await post([{ name: 'has space', type: 'string' }])).status).toBe(400);
+    });
+
+    it('rejects a bound definition missing its binding key', async () => {
+      expect((await post([{ name: 'x', type: 'string', source: 'tenantVariable' }])).status).toBe(400);
+    });
+
+    it('rejects two names that collide as one BREEZE_PARAM_* env var', async () => {
+      // Previously accepted, with a nondeterministic winner per run.
+      expect((await post([{ name: 'log-level', type: 'string' }, { name: 'log_level', type: 'string' }])).status).toBe(400);
+    });
+
+    it('rejects a non-array parameters value', async () => {
+      expect((await post({ notAnArray: true })).status).toBe(400);
+    });
+
+    it('bumps version when a parameter definition changes', async () => {
+      const { set } = mockUpdate({ parameters: [{ name: 'a', type: 'string' }] });
+      expect((await put({ parameters: [{ name: 'a', type: 'number' }] })).status).toBe(200);
+      expect(set.mock.calls[0]![0]).toMatchObject({ version: 8 });
+    });
+
+    it('bumps version when a parameter is rebound to a tenant variable', async () => {
+      const { set } = mockUpdate({ parameters: [{ name: 'a', type: 'string' }] });
+      await put({ parameters: [{ name: 'a', type: 'string', source: 'tenantVariable', variableKey: 'api_key' }] });
+      expect(set.mock.calls[0]![0]).toMatchObject({ version: 8 });
+    });
+
+    it('bumps version when a parameter is added', async () => {
+      const { set } = mockUpdate({ parameters: [] });
+      await put({ parameters: [{ name: 'a', type: 'string' }] });
+      expect(set.mock.calls[0]![0]).toMatchObject({ version: 8 });
+    });
+
+    it('does NOT bump version when the definitions are unchanged', async () => {
+      // The stored row is in the LEGACY shape (no `source`, no `required`)
+      // while the request carries the schema's materialized defaults. Comparing
+      // raw would report a change on every save of an untouched script.
+      const { set } = mockUpdate({ parameters: [{ name: 'a', type: 'string' }] });
+      await put({ parameters: [{ name: 'a', type: 'string', required: false, source: 'runtime' }] });
+      expect(set.mock.calls[0]![0]).not.toHaveProperty('version');
+    });
+
+    it('does NOT bump version when parameters are omitted entirely', async () => {
+      const { set } = mockUpdate({ parameters: [{ name: 'a', type: 'string' }] });
+      await put({ name: 'Renamed' });
+      expect(set.mock.calls[0]![0]).not.toHaveProperty('version');
+    });
+
+    it('bumps version exactly once when content and parameters both change', async () => {
+      const { set } = mockUpdate({ parameters: [{ name: 'a', type: 'string' }] });
+      await put({ content: 'echo bye', parameters: [{ name: 'b', type: 'string' }] });
+      expect(set.mock.calls[0]![0]).toMatchObject({ version: 8 });
+    });
+
+    it('still bumps version for a content-only change', async () => {
+      const { set } = mockUpdate({});
+      await put({ content: 'echo bye' });
+      expect(set.mock.calls[0]![0]).toMatchObject({ version: 8 });
+    });
+
+    it('rejects a colliding definition on update', async () => {
+      mockUpdate({});
+      const res = await put({ parameters: [{ name: 'logLevel', type: 'string' }, { name: 'LOGLEVEL', type: 'string' }] });
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -1,7 +1,12 @@
 import { Hono } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
-import { exitCodeSeverityMappingSchema, scriptParametersSchema } from '@breeze/shared';
+import {
+  exitCodeSeverityMappingSchema,
+  scriptParameterDefinitionsEqual,
+  scriptParameterDefinitionsSchema,
+  scriptParametersSchema,
+} from '@breeze/shared';
 import { and, eq, sql, desc, like, inArray, or, isNull } from 'drizzle-orm';
 import { escapeLike } from '../utils/sql';
 import { db } from '../db';
@@ -232,7 +237,10 @@ const createScriptSchema = z.object({
   osTypes: z.array(z.enum(['windows', 'macos', 'linux'])).min(1),
   language: z.enum(['powershell', 'bash', 'python', 'cmd']),
   content: z.string().min(1),
-  parameters: z.any().optional(),
+  // Was `z.any()` — definitions reached the database entirely unvalidated
+  // (#3409 PR3). See scriptParameterDefinitions.ts for the union + the
+  // BREEZE_PARAM_* collision rule.
+  parameters: scriptParameterDefinitionsSchema.optional(),
   // Max 3600: the agent executor clamps script timeouts to 1 hour
   // (agent/internal/executor/executor.go MaxTimeout) — accepting more
   // at intake is silent false configurability (#2398).
@@ -250,7 +258,7 @@ const updateScriptSchema = z.object({
   osTypes: z.array(z.enum(['windows', 'macos', 'linux'])).min(1).optional(),
   language: z.enum(['powershell', 'bash', 'python', 'cmd']).optional(),
   content: z.string().min(1).optional(),
-  parameters: z.any().optional(),
+  parameters: scriptParameterDefinitionsSchema.optional(),
   timeoutSeconds: z.number().int().min(1).max(3600).optional(),
   runAs: z.enum(['system', 'user', 'elevated']).optional(),
   exitCodeSeverityMapping: exitCodeSeverityMappingSchema.nullable().optional(),
@@ -760,12 +768,29 @@ scriptRoutes.put(
     if (data.category !== undefined) updates.category = data.category;
     if (data.osTypes !== undefined) updates.osTypes = data.osTypes;
     if (data.language !== undefined) updates.language = data.language;
-    if (data.parameters !== undefined) updates.parameters = data.parameters;
     if (data.timeoutSeconds !== undefined) updates.timeoutSeconds = data.timeoutSeconds;
     if (data.runAs !== undefined) updates.runAs = data.runAs;
     if (data.exitCodeSeverityMapping !== undefined) updates.exitCodeSeverityMapping = data.exitCodeSeverityMapping;
 
-    // Increment version if content changes
+    // The version bump covers BOTH halves of what a run consumes: the content
+    // and the parameter contract (#3409 PR3). It used to track content alone,
+    // so flipping a parameter to a bound source — or renaming one — left the
+    // version untouched, which PR4's effect digest pins. Both branches feed
+    // one bump so a save that changes both still moves the version by 1.
+    let versionChanged = false;
+
+    if (data.parameters !== undefined) {
+      updates.parameters = data.parameters;
+      // Compare NORMALIZED definitions: `script.parameters` may be a legacy
+      // value stored under the old `z.any()` intake with no `source` /
+      // `required` keys, and `data.parameters` always arrives with the
+      // schema's defaults materialized. A raw comparison would report every
+      // save of an untouched legacy script as a change.
+      if (!scriptParameterDefinitionsEqual(script.parameters, data.parameters)) {
+        versionChanged = true;
+      }
+    }
+
     if (data.content !== undefined && data.content !== script.content) {
       // Save-time {{var.<secret>}} rejection (#3409 PR2), against the
       // EFFECTIVE (post-rescope) scope. An UNKNOWN key is allowed — see
@@ -775,6 +800,10 @@ scriptRoutes.put(
         return c.json({ error: describeSecretVariableRejection(secretRefs) }, 400);
       }
       updates.content = data.content;
+      versionChanged = true;
+    }
+
+    if (versionChanged) {
       updates.version = script.version + 1;
     }
 

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -984,6 +984,18 @@ scriptRoutes.post(
         maintenanceSuppressedDeviceIds: result.maintenanceSuppressedDeviceIds,
         triggerType: result.triggerType,
         runAs: result.runAs,
+        // #3409 PR3 §2.2 — bound parameters the caller supplied a value for.
+        // The binding won and the supplied value was dropped, so the audit
+        // trail must record that the run did NOT use what the caller sent.
+        // KEYS ONLY, never values: a caller can send anything under a bound
+        // key (including the secret they thought they were overriding), and
+        // audit details are long-lived and widely readable.
+        //
+        // A distinct, self-describing field rather than folding these into an
+        // existing one: audit `details` is an untyped jsonb bag shared across
+        // every action in this repo, and overloading a generic key there has
+        // already produced one cross-meaning collision (`deviceId`).
+        ignoredParameterKeys: result.ignoredParameters,
       }
     });
 
@@ -1000,6 +1012,11 @@ scriptRoutes.post(
       // all-failed case returned 422 above). Omitted when empty so the
       // common clean-run response shape is unchanged.
       failures: result.failures.length > 0 ? result.failures : undefined,
+      // Bound parameter keys whose caller-supplied value was ignored (#3409
+      // PR3 §2.2) — the binding is authoritative. Omitted when empty, exactly
+      // like `failures` above, so the common clean-run response shape is
+      // unchanged and a client can treat presence alone as "warn the user".
+      ignoredParameters: result.ignoredParameters.length > 0 ? result.ignoredParameters : undefined,
       status: result.status,
     }, 201);
   }

--- a/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
+++ b/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
@@ -391,3 +391,53 @@ describe('run_script keeps per-device failures isolated in the shared results ac
     });
   });
 });
+
+// #3409 PR3 P1 — the scope-preload gate must look past the content.
+//
+// Every fixture here is TOKEN-FREE on purpose: under the old
+// `hasVariableTokens(script.content)` gate the AI run_script path passes `[]`
+// to loadTenantVariableScope, dispatch then resolves the binding against an
+// EMPTY scope, and the device fails with "no value set" for a variable that
+// exists. Asserting the loaded org list — not merely that the loader was
+// called — is what makes these non-vacuous.
+//
+// MUTATION-VERIFIED: forcing `scriptNeedsVariableScope` to return `false`
+// fails the first test below (plus the scriptExecution / automationRuntime
+// siblings) and nothing else.
+describe('run_script variable-scope preload gate (#3409 PR3 P1)', () => {
+  const scriptRow = (parameters: unknown) => ({
+    id: SCRIPT_ID,
+    orgId: ORG_B,
+    partnerId: null,
+    language: 'powershell',
+    content: 'echo hi', // no {{var.*}} token
+    parameters,
+    timeoutSeconds: 60,
+    runAs: 'system',
+  });
+  const deviceRow = { id: DEVICE_B, orgId: ORG_B, hostname: 'devB', siteId: null, status: 'online' };
+
+  it('loads the org scope for a token-free script whose PARAMETERS bind a tenant variable', async () => {
+    mockDb(scriptRow([{ name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' }]), deviceRow);
+
+    await runScriptTool().handler({ scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] }, makeAuth());
+
+    expect(loadTenantVariableScope).toHaveBeenCalledWith([ORG_B]);
+  });
+
+  it('passes the empty org list when the script needs no scope at all', async () => {
+    mockDb(scriptRow([{ name: 'level', type: 'string', source: 'runtime' }]), deviceRow);
+
+    await runScriptTool().handler({ scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] }, makeAuth());
+
+    expect(loadTenantVariableScope).toHaveBeenCalledWith([]);
+  });
+
+  it('still loads for a content token, with no parameter definitions at all', async () => {
+    mockDb({ ...scriptRow(null), content: 'curl {{var.repo_url}}' }, deviceRow);
+
+    await runScriptTool().handler({ scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] }, makeAuth());
+
+    expect(loadTenantVariableScope).toHaveBeenCalledWith([ORG_B]);
+  });
+});

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -33,7 +33,7 @@ import type { AiTool } from './aiTools';
 import { dispatchScriptToDevice } from './scriptDispatch';
 import { loadTenantVariableScope } from './tenantVariableResolution';
 import { captureException } from './sentry';
-import { hasVariableTokens } from '@breeze/shared';
+import { scriptNeedsVariableScope } from './sourcedParameters';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -292,8 +292,12 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
           // preload — there is no wider fan-out to batch it against.
           const dispatch = await runOutsideDbContext(() =>
             withSystemDbAccessContext(async () => {
+              // #3409 PR3 P1: gated on `scriptNeedsVariableScope`, not
+              // content tokens alone — a `tenantVariable`-bound parameter
+              // lives in `scripts.parameters`, and a content-only gate would
+              // hand dispatch an empty scope for it.
               const variableScope = await loadTenantVariableScope(
-                hasVariableTokens(script.content) ? [access.device.orgId] : []
+                scriptNeedsVariableScope(script) ? [access.device.orgId] : []
               );
               return dispatchScriptToDevice({
                 device: access.device,

--- a/apps/api/src/services/automationRuntime.configPolicy.test.ts
+++ b/apps/api/src/services/automationRuntime.configPolicy.test.ts
@@ -704,7 +704,7 @@ describe('executeConfigPolicyAutomationRun', () => {
     } as any);
 
     vi.mocked(dispatchScriptToDevice).mockResolvedValue({
-      ok: true, commandId: 'cmd-1', executionId: null, delivered: true, deliveryOutcome: 'sent', executedAt: new Date(),
+      ok: true, commandId: 'cmd-1', executionId: null, delivered: true, deliveryOutcome: 'sent', executedAt: new Date(), ignoredParameters: [],
     } as any);
 
     const result = await executeConfigPolicyAutomationRun(

--- a/apps/api/src/services/automationRuntime.configPolicy.test.ts
+++ b/apps/api/src/services/automationRuntime.configPolicy.test.ts
@@ -18,7 +18,7 @@ vi.mock('../db/schema', () => ({
   configPolicyFeatureLinks: { id: 'id', configPolicyId: 'configPolicyId' },
   configurationPolicies: { id: 'id', orgId: 'orgId' },
   devices: { id: 'id', hostname: 'hostname', osType: 'osType', status: 'status' },
-  scripts: { id: 'id' },
+  scripts: { id: 'id', deletedAt: 'deletedAt' },
   notificationChannels: { id: 'id', orgId: 'orgId' },
   automations: { id: 'id', runCount: 'runCount' },
   alerts: { id: 'id' },
@@ -39,6 +39,12 @@ vi.mock('./scriptDispatch', () => ({
   dispatchScriptToDevice: vi.fn().mockResolvedValue({ ok: false, code: 'insert_failed', error: 'mocked' }),
 }));
 
+// #3409 PR3 P2: spied so the per-run call COUNT is assertable. The resolver's
+// own behaviour is covered in tenantVariableResolution.test.ts.
+vi.mock('./tenantVariableResolution', () => ({
+  loadTenantVariableScope: vi.fn().mockResolvedValue({ orgIds: new Set() }),
+}));
+
 vi.mock('./notificationSenders', () => ({
   getEmailRecipients: vi.fn().mockReturnValue([]),
   sendEmailNotification: vi.fn().mockResolvedValue({ success: false }),
@@ -49,6 +55,7 @@ import { db } from '../db';
 import { createConfigPolicyAutomationRun, executeConfigPolicyAutomationRun } from './automationRuntime';
 import { dispatchScriptToDevice } from './scriptDispatch';
 import { publishEvent } from './eventBus';
+import { loadTenantVariableScope } from './tenantVariableResolution';
 
 function makeConfigPolicyAutomation(overrides: Record<string, unknown> = {}): any {
   return {
@@ -614,6 +621,109 @@ describe('executeConfigPolicyAutomationRun', () => {
     // Verify final status was persisted to DB
     const lastSetCall = setMock.mock.calls[setMock.mock.calls.length - 1]![0];
     expect(lastSetCall.status).toBe('partial');
+  });
+
+  // #3409 PR3 P2 — the N-connection trap. Before the hoist,
+  // executeRunScriptAction called loadTenantVariableScope itself, so this run
+  // (4 devices × 1 run_script action, inside runWithConcurrency(…, 5, …))
+  // issued FOUR scope loads, each escaping the ambient context and taking a
+  // second pooled connection. It must now issue exactly ONE, covering the
+  // run's distinct org set.
+  //
+  // Mutation check for this test: move the load back inside
+  // executeRunScriptAction and the call count becomes 4.
+  it('loads the tenant-variable scope ONCE per run, not once per device (#3409 PR3 P2)', async () => {
+    const automation = makeConfigPolicyAutomation({
+      actions: [{ type: 'run_script', scriptId: 'script-1' }],
+    });
+
+    const scope = { orgIds: new Set(['org-1', 'org-2']) };
+    vi.mocked(loadTenantVariableScope).mockResolvedValue(scope as any);
+
+    // Four devices spread over two orgs — the load must be keyed by the
+    // DISTINCT org set, not by the device list.
+    const deviceRows = [
+      { id: 'dev-1', orgId: 'org-1', hostname: 'host-1', displayName: null, osType: 'linux', status: 'online', agentId: 'a1', siteId: 'site-1', customFields: {} },
+      { id: 'dev-2', orgId: 'org-2', hostname: 'host-2', displayName: null, osType: 'linux', status: 'online', agentId: 'a2', siteId: 'site-2', customFields: {} },
+      { id: 'dev-3', orgId: 'org-1', hostname: 'host-3', displayName: null, osType: 'linux', status: 'online', agentId: 'a3', siteId: 'site-1', customFields: {} },
+      { id: 'dev-4', orgId: 'org-2', hostname: 'host-4', displayName: null, osType: 'linux', status: 'online', agentId: 'a4', siteId: 'site-2', customFields: {} },
+    ];
+
+    // The script content MUST carry a {{var.*}} token: the preload is gated on
+    // it, so a token-free fixture would still pass with the gate forced false.
+    const scriptRows = [
+      { id: 'script-1', orgId: null, osTypes: ['linux'], runAs: 'system', content: 'curl {{var.repo_url}}', language: 'bash', timeoutSeconds: 60 },
+    ];
+
+    let selectCallCount = 0;
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCallCount++;
+      if (selectCallCount === 1) {
+        // resolveConfigPolicyOrgId
+        return {
+          from: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ orgId: 'org-1' }]),
+              }),
+            }),
+          }),
+        } as any;
+      }
+      if (selectCallCount === 2) {
+        // resolveConfigPolicyId (featureLink -> configurationPolicies.id)
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ configPolicyId: 'cp-1' }]),
+            }),
+          }),
+        } as any;
+      }
+      if (selectCallCount === 3) {
+        return {
+          from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(deviceRows) }),
+        } as any;
+      }
+      if (selectCallCount === 4) {
+        return {
+          from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(scriptRows) }),
+        } as any;
+      }
+      return {
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+      } as any;
+    });
+
+    const run = { id: 'run-1', automationId: null, status: 'running', logs: [] };
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([run]) }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+
+    vi.mocked(dispatchScriptToDevice).mockResolvedValue({
+      ok: true, commandId: 'cmd-1', executionId: null, delivered: true, deliveryOutcome: 'sent', executedAt: new Date(),
+    } as any);
+
+    const result = await executeConfigPolicyAutomationRun(
+      automation,
+      deviceRows.map((d) => d.id),
+      'scheduler',
+    );
+
+    expect(result.devicesSucceeded).toBe(4);
+    expect(dispatchScriptToDevice).toHaveBeenCalledTimes(4);
+
+    // The assertion this test exists for.
+    expect(loadTenantVariableScope).toHaveBeenCalledTimes(1);
+    expect(loadTenantVariableScope).toHaveBeenCalledWith(['org-1', 'org-2']);
+
+    // ...and every device's dispatch got that one snapshot.
+    for (const [args] of vi.mocked(dispatchScriptToDevice).mock.calls) {
+      expect((args as any).variableScope).toBe(scope);
+    }
   });
 
   it('publishes automation.completed event on success', async () => {

--- a/apps/api/src/services/automationRuntime.runScript.test.ts
+++ b/apps/api/src/services/automationRuntime.runScript.test.ts
@@ -111,6 +111,7 @@ beforeEach(() => {
     executionId: EXECUTION_ID,
     delivered: true,
     executedAt: new Date('2026-08-14T00:00:00.000Z'),
+    ignoredParameters: [],
   });
 });
 
@@ -179,6 +180,7 @@ describe('executeRunScriptAction — dispatch via scriptDispatch core (#3409 PR0
       executionId: EXECUTION_ID,
       delivered: false,
       executedAt: null,
+      ignoredParameters: [],
     });
 
     await executeRunScriptAction(
@@ -197,6 +199,7 @@ describe('executeRunScriptAction — dispatch via scriptDispatch core (#3409 PR0
       executionId: EXECUTION_ID,
       delivered: false,
       executedAt: null,
+      ignoredParameters: [],
     });
 
     const whereArgs: unknown[] = [];
@@ -231,6 +234,7 @@ describe('executeRunScriptAction — dispatch via scriptDispatch core (#3409 PR0
       executionId: null,
       delivered: false,
       executedAt: null,
+      ignoredParameters: [],
     });
 
     await executeRunScriptAction(

--- a/apps/api/src/services/automationRuntime.test.ts
+++ b/apps/api/src/services/automationRuntime.test.ts
@@ -28,6 +28,7 @@ import {
   AutomationValidationError,
   executeRunScriptAction,
   isCronDue,
+  loadAutomationRunVariableScope,
   normalizeAutomationActions,
   normalizeAutomationTrigger,
   normalizeNotificationTargets,
@@ -135,37 +136,129 @@ describe('automationRuntime', () => {
     expect(actions[0]).toMatchObject({ parameters: undefined });
   });
 
-  it('preloads a variable scope for the device org before dispatching a run_script action (#3409 PR2 Task 4)', async () => {
-    const scope = { orgIds: new Set(['org-a']) };
-    vi.mocked(loadTenantVariableScope).mockResolvedValue(scope as any);
-    const context = {
-      automation: { id: 'auto-1', orgId: 'org-a', name: 'Test automation', createdBy: 'user-1' },
-      runId: 'run-1',
-      device: {
-        id: 'device-1', orgId: 'org-a', hostname: 'host-1', displayName: null,
-        osType: 'linux' as const, status: 'online' as const, agentId: 'agent-1',
-      },
-      scriptsById: new Map([
-        // Content MUST carry a {{var.*}} token — the preload is gated on it,
-        // so a token-free fixture would assert nothing.
-        [
-          'script-1',
-          { id: 'script-1', orgId: 'org-a', osTypes: ['linux'], runAs: 'system', content: 'curl {{var.repo_url}}' } as any,
-        ],
-      ]),
-      channelsById: new Map(),
-    };
+  // Content MUST carry a {{var.*}} token — the preload is gated on it, so a
+  // token-free fixture would pass with the gate wired to constant false.
+  const TOKEN_SCRIPT = {
+    id: 'script-1',
+    orgId: 'org-a',
+    osTypes: ['linux'],
+    runAs: 'system',
+    content: 'curl {{var.repo_url}}',
+  } as any;
 
-    const result = await executeRunScriptAction(
+  const contextFor = (deviceId: string, orgId: string, variableScope: unknown) => ({
+    automation: { id: 'auto-1', orgId: 'org-a', name: 'Test automation', createdBy: 'user-1' },
+    runId: 'run-1',
+    device: {
+      id: deviceId, orgId, hostname: `host-${deviceId}`, displayName: null,
+      osType: 'linux' as const, status: 'online' as const, agentId: `agent-${deviceId}`,
+      siteId: `site-${orgId}`, customFields: { owner: 'ops' },
+    },
+    scriptsById: new Map([['script-1', TOKEN_SCRIPT]]),
+    channelsById: new Map(),
+    variableScope,
+  }) as any;
+
+  it('takes the variable scope from the run context and never loads one itself (#3409 PR3 P2)', async () => {
+    // The hoist's whole point: executeRunScriptAction runs once PER DEVICE PER
+    // run_script action inside runWithConcurrency. Calling it N times must
+    // therefore issue ZERO scope loads — the run-level preload already ran.
+    const scope = { orgIds: new Set(['org-a']) };
+
+    for (const deviceId of ['device-1', 'device-2', 'device-3']) {
+      const result = await executeRunScriptAction(
+        { type: 'run_script', scriptId: 'script-1' },
+        0,
+        contextFor(deviceId, 'org-a', scope),
+      );
+      expect(result.success).toBe(true);
+    }
+
+    expect(loadTenantVariableScope).not.toHaveBeenCalled();
+    const calls = vi.mocked(dispatchScriptToDevice).mock.calls;
+    expect(calls).toHaveLength(3);
+    for (const [args] of calls) {
+      expect(args.variableScope).toBe(scope);
+    }
+  });
+
+  it('carries the widened device projection through to dispatch (#3409 PR3 P3)', async () => {
+    await executeRunScriptAction(
       { type: 'run_script', scriptId: 'script-1' },
       0,
-      context,
+      contextFor('device-1', 'org-a', { orgIds: new Set(['org-a']) }),
     );
 
-    expect(result.success).toBe(true);
-    expect(loadTenantVariableScope).toHaveBeenCalledWith(['org-a']);
     const dispatchArgs = vi.mocked(dispatchScriptToDevice).mock.calls[0]![0];
-    expect(dispatchArgs.variableScope).toBe(scope);
+    expect(dispatchArgs.device).toMatchObject({
+      hostname: 'host-device-1',
+      siteId: 'site-org-a',
+      customFields: { owner: 'ops' },
+    });
+  });
+
+  describe('loadAutomationRunVariableScope (#3409 PR3 P2)', () => {
+    const scriptsById = new Map<string, any>([
+      ['script-1', TOKEN_SCRIPT],
+      ['script-plain', { id: 'script-plain', content: 'echo hi' } as any],
+    ]);
+
+    it('loads ONCE for the run over the distinct org set, not once per device', async () => {
+      const scope = { orgIds: new Set(['org-a', 'org-b']) };
+      vi.mocked(loadTenantVariableScope).mockResolvedValue(scope as any);
+
+      // Five devices, two orgs, two run_script actions — one call, two orgs.
+      const result = await loadAutomationRunVariableScope(
+        [
+          { type: 'run_script', scriptId: 'script-1' },
+          { type: 'run_script', scriptId: 'script-plain' },
+        ] as any,
+        scriptsById,
+        ['org-a', 'org-b', 'org-a', 'org-b', 'org-a'],
+      );
+
+      expect(result).toBe(scope);
+      expect(loadTenantVariableScope).toHaveBeenCalledTimes(1);
+      expect(loadTenantVariableScope).toHaveBeenCalledWith(['org-a', 'org-b']);
+    });
+
+    it('passes the empty org list when no run_script action uses a {{var.*}} token', async () => {
+      await loadAutomationRunVariableScope(
+        [
+          { type: 'run_script', scriptId: 'script-plain' },
+          { type: 'execute_command', command: 'echo {{var.not_a_script}}' },
+        ] as any,
+        scriptsById,
+        ['org-a', 'org-b'],
+      );
+
+      // [] is loadTenantVariableScope's documented no-op path — it
+      // short-circuits before touching the DB.
+      expect(loadTenantVariableScope).toHaveBeenCalledWith([]);
+    });
+
+    it('loads when ANY run_script action in the set uses a token, not only the first', async () => {
+      await loadAutomationRunVariableScope(
+        [
+          { type: 'run_script', scriptId: 'script-plain' },
+          { type: 'run_script', scriptId: 'script-1' },
+        ] as any,
+        scriptsById,
+        ['org-a'],
+      );
+
+      expect(loadTenantVariableScope).toHaveBeenCalledWith(['org-a']);
+    });
+
+    it('does not throw when an action references a script that failed to load', async () => {
+      await loadAutomationRunVariableScope(
+        [{ type: 'run_script', scriptId: 'deleted-script' }] as any,
+        scriptsById,
+        ['org-a'],
+      );
+
+      expect(loadTenantVariableScope).toHaveBeenCalledWith([]);
+    });
   });
 
   it('normalizes notification targets from legacy and canonical payloads', () => {

--- a/apps/api/src/services/automationRuntime.test.ts
+++ b/apps/api/src/services/automationRuntime.test.ts
@@ -15,6 +15,7 @@ vi.mock('./scriptDispatch', () => ({
     delivered: true,
     deliveryOutcome: 'sent',
     executedAt: new Date('2026-08-11T00:00:00Z'),
+    ignoredParameters: [],
   }),
 }));
 // See scriptExecution.test.ts for why the resolver itself is stubbed here
@@ -47,6 +48,7 @@ describe('automationRuntime', () => {
       delivered: true,
       deliveryOutcome: 'sent',
       executedAt: new Date('2026-08-11T00:00:00Z'),
+      ignoredParameters: [],
     } as any);
     vi.mocked(loadTenantVariableScope).mockResolvedValue({ orgIds: new Set() } as any);
   });
@@ -197,6 +199,45 @@ describe('automationRuntime', () => {
     });
   });
 
+  // #3409 PR3 §2.2: an automation whose action configures a value for a
+  // parameter that is BOUND to a source has that value dropped. Automations
+  // have no parameter-capture UI, so the run log is the ONLY surface where an
+  // author can ever see it — without this the ignore is completely silent for
+  // exactly the consumer the "ignore, don't 400" decision was made for.
+  it('records ignored bound parameter keys on the run log', async () => {
+    vi.mocked(dispatchScriptToDevice).mockResolvedValue({
+      ok: true,
+      commandId: 'cmd-1',
+      executionId: 'exec-1',
+      delivered: true,
+      deliveryOutcome: 'sent',
+      executedAt: new Date('2026-08-11T00:00:00Z'),
+      ignoredParameters: ['api_key'],
+    } as any);
+
+    const result = await executeRunScriptAction(
+      { type: 'run_script', scriptId: 'script-1', parameters: { api_key: 'configured-in-the-automation' } },
+      0,
+      contextFor('device-1', 'org-a', { orgIds: new Set(['org-a']) }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.log.details).toMatchObject({ ignoredParameterKeys: ['api_key'] });
+    // KEYS ONLY — the configured value must not be copied into the run log.
+    expect(JSON.stringify(result.log.details)).not.toContain('configured-in-the-automation');
+  });
+
+  it('leaves the run log untouched when nothing was ignored', async () => {
+    const result = await executeRunScriptAction(
+      { type: 'run_script', scriptId: 'script-1' },
+      0,
+      contextFor('device-1', 'org-a', { orgIds: new Set(['org-a']) }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.log.details).not.toHaveProperty('ignoredParameterKeys');
+  });
+
   describe('loadAutomationRunVariableScope (#3409 PR3 P2)', () => {
     const scriptsById = new Map<string, any>([
       ['script-1', TOKEN_SCRIPT],
@@ -248,6 +289,45 @@ describe('automationRuntime', () => {
       );
 
       expect(loadTenantVariableScope).toHaveBeenCalledWith(['org-a']);
+    });
+
+    // #3409 PR3 P1. The fixture below is deliberately TOKEN-FREE so the
+    // assertion is not vacuous: under the old content-only gate this run
+    // passes `[]`, and every bound parameter then resolves against an empty
+    // scope at dispatch.
+    //
+    // MUTATION-VERIFIED: forcing `scriptNeedsVariableScope` to `false` fails
+    // this test (and the two sibling gate tests) and nothing else.
+    it('loads a scope for a token-free script whose PARAMETERS bind a tenant variable', async () => {
+      const boundScript = {
+        id: 'script-bound',
+        content: 'echo hi',
+        parameters: [{ name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' }],
+      } as any;
+
+      await loadAutomationRunVariableScope(
+        [{ type: 'run_script', scriptId: 'script-bound' }] as any,
+        new Map([['script-bound', boundScript]]),
+        ['org-a'],
+      );
+
+      expect(loadTenantVariableScope).toHaveBeenCalledWith(['org-a']);
+    });
+
+    it('does not load a scope for a token-free script whose parameters are all runtime', async () => {
+      const runtimeScript = {
+        id: 'script-runtime',
+        content: 'echo hi',
+        parameters: [{ name: 'level', type: 'string', source: 'runtime' }],
+      } as any;
+
+      await loadAutomationRunVariableScope(
+        [{ type: 'run_script', scriptId: 'script-runtime' }] as any,
+        new Map([['script-runtime', runtimeScript]]),
+        ['org-a'],
+      );
+
+      expect(loadTenantVariableScope).toHaveBeenCalledWith([]);
     });
 
     it('does not throw when an action references a script that failed to load', async () => {

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -20,7 +20,7 @@ import {
 import { resolveDeploymentTargets } from './deploymentEngine';
 import { canAccessSite, type UserPermissions } from './permissions';
 import { dispatchScriptToDevice } from './scriptDispatch';
-import { loadTenantVariableScope } from './tenantVariableResolution';
+import { loadTenantVariableScope, type TenantVariableScope } from './tenantVariableResolution';
 import { publishEvent } from './eventBus';
 import { captureException } from './sentry';
 import {
@@ -846,10 +846,68 @@ type ActionExecutionContext = {
     // Needed by dispatchScriptToDevice (#3409 PR0) for WS delivery — carried
     // through the device snapshot rather than re-queried per action.
     agentId: string;
+    // #3409 PR3: sourced script parameters bind to device/site properties
+    // (`builtin`) and to the device's custom fields (`deviceCustomField`).
+    // They ride the run's ONE device snapshot — a per-device re-query at
+    // resolution time would reintroduce exactly the N-query shape the
+    // variable-scope hoist below removes. Not consumed yet; the resolver
+    // lands in a later task.
+    siteId: (typeof devices.$inferSelect)['siteId'];
+    customFields: (typeof devices.$inferSelect)['customFields'];
   };
   scriptsById: Map<string, typeof scripts.$inferSelect>;
   channelsById: Map<string, typeof notificationChannels.$inferSelect>;
+  /**
+   * Preloaded ONCE per run over the run's distinct org set — see
+   * {@link loadAutomationRunVariableScope}. Required (not optional) on
+   * purpose: an absent scope would silently resolve every `{{var.*}}` token
+   * to "missing" rather than failing loudly, so the type forces every runner
+   * to have done the preload.
+   */
+  variableScope: TenantVariableScope;
 };
+
+/**
+ * Preloads the tenant-variable scope ONCE per automation run (#3409 PR3 P2).
+ *
+ * Previously `executeRunScriptAction` called `loadTenantVariableScope` itself,
+ * which put the load inside `runWithConcurrency(deviceRows, 5, …)` × the
+ * action loop — i.e. once PER DEVICE PER run_script action, each one escaping
+ * the ambient context and taking a second pooled connection. A 200-device
+ * automation with two run_script actions issued 400 of them. `scriptExecution.ts`
+ * has always done this correctly (once per fan-out over the distinct org set);
+ * this is the automation path catching up, and it must happen BEFORE PR3 adds
+ * a second (parameter-level) resolver on the same code path, which would
+ * otherwise compound the trap.
+ *
+ * The gate is preserved, just widened from one script to the run's script set:
+ * if no `run_script` action references a script whose content carries a
+ * `{{var.*}}` token, we pass `[]` and `loadTenantVariableScope` short-circuits
+ * without querying at all (tenantVariableResolution.ts) — so a token-free run,
+ * which is the overwhelming majority, still does exactly zero work.
+ *
+ * NOTE for PR3's sourced parameters: this gate is content-only. When bound
+ * parameters land, extend it to `hasTenantVariableBoundParameters(parameters)`
+ * as well (plan §3 P1) — a parameter binding lives in `scripts.parameters`,
+ * not in the content, and would resolve against an empty scope here.
+ *
+ * `loadTenantVariableScope` owns the `runOutsideDbContext(() =>
+ * withSystemDbAccessContext(...))` double wrapper; do not add or unwrap one
+ * here. Both wrappers, in that order, are load-bearing — a bare system
+ * context nested inside a held org-scoped transaction does not elevate.
+ */
+export async function loadAutomationRunVariableScope(
+  actions: AutomationAction[],
+  scriptsById: Map<string, typeof scripts.$inferSelect>,
+  deviceOrgIds: string[],
+): Promise<TenantVariableScope> {
+  const anyScriptUsesVariables = actions.some(
+    (action) =>
+      action.type === 'run_script' &&
+      hasVariableTokens(scriptsById.get(action.scriptId)?.content ?? ''),
+  );
+  return loadTenantVariableScope(anyScriptUsesVariables ? [...new Set(deviceOrgIds)] : []);
+}
 
 type ActionExecutionResult = {
   success: boolean;
@@ -894,14 +952,12 @@ export async function executeRunScriptAction(
 
   const parameters = action.parameters ?? {};
 
-  // Preload ONCE for this single-device dispatch (#3409 PR2 Task 4). Only
-  // run_script needs a scope — execute_command below dispatches a
-  // {kind:'raw'} source, which scriptDispatch deliberately never substitutes.
-  // Gated on the content: an unconditional preload would take a second
-  // connection per automation run to build a snapshot nothing consults.
-  const variableScope = await loadTenantVariableScope(
-    hasVariableTokens(script.content) ? [context.device.orgId] : []
-  );
+  // #3409 PR3 P2: the scope is preloaded ONCE per run by the caller (see
+  // loadAutomationRunVariableScope) and threaded in on the context. Do NOT
+  // load it here — this function runs once per device per run_script action,
+  // inside runWithConcurrency, which is exactly the N-connection trap the
+  // hoist removed.
+  const variableScope = context.variableScope;
 
   // #3409 PR0: dispatchScriptToDevice owns the script_executions insert (#3162
   // — a REAL uuid row so handleScriptResult can correlate the agent's result),
@@ -1750,6 +1806,11 @@ async function executeAutomationRunInner(
         osType: devices.osType,
         status: devices.status,
         agentId: devices.agentId,
+        // #3409 PR3 P3 — sourced parameters (`builtin` / `deviceCustomField`)
+        // resolve against these. Selected once here with the rest of the run's
+        // device snapshot; see ActionExecutionContext.device.
+        siteId: devices.siteId,
+        customFields: devices.customFields,
       })
       .from(devices)
       .where(inArray(devices.id, targetDeviceIds))
@@ -1809,6 +1870,14 @@ async function executeAutomationRunInner(
   let devicesSucceeded = 0;
   let devicesFailed = 0;
 
+  // ONE preload for the whole run, over the distinct org set of every device
+  // this run targets (#3409 PR3 P2) — never inside the concurrency loop below.
+  const variableScope = await loadAutomationRunVariableScope(
+    normalized.actions,
+    scriptsById,
+    deviceRows.map((device) => device.orgId),
+  );
+
   await runWithConcurrency(deviceRows, 5, async (device) => {
     let deviceFailed = false;
     const deviceStartedAt = new Date();
@@ -1827,6 +1896,7 @@ async function executeAutomationRunInner(
           device,
           scriptsById,
           channelsById,
+          variableScope,
         });
 
         logs.push(result.log);
@@ -2314,6 +2384,10 @@ export async function executeConfigPolicyAutomationRun(
         osType: devices.osType,
         status: devices.status,
         agentId: devices.agentId,
+        // #3409 PR3 P3 — mirrors the standalone runner's projection above;
+        // both feed the same ActionExecutionContext.device.
+        siteId: devices.siteId,
+        customFields: devices.customFields,
       })
       .from(devices)
       .where(inArray(devices.id, targetDeviceIds))
@@ -2365,6 +2439,13 @@ export async function executeConfigPolicyAutomationRun(
   let devicesSucceeded = 0;
   let devicesFailed = 0;
 
+  // ONE preload for the whole run (#3409 PR3 P2) — see the standalone runner.
+  const variableScope = await loadAutomationRunVariableScope(
+    actions,
+    scriptsById,
+    deviceRows.map((device) => device.orgId),
+  );
+
   await runWithConcurrency(deviceRows, 5, async (device) => {
     let deviceFailed = false;
 
@@ -2377,6 +2458,7 @@ export async function executeConfigPolicyAutomationRun(
         device,
         scriptsById,
         channelsById,
+        variableScope,
       });
 
       logs.push(result.log);

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'crypto';
 import { and, eq, inArray, isNull, ne, or, sql, type SQL } from 'drizzle-orm';
-import { hasVariableTokens, scriptParametersSchema, type DeploymentTargetConfig } from '@breeze/shared';
+import { scriptParametersSchema, type DeploymentTargetConfig } from '@breeze/shared';
 import { db } from '../db';
 import {
   alertRules,
@@ -21,6 +21,7 @@ import { resolveDeploymentTargets } from './deploymentEngine';
 import { canAccessSite, type UserPermissions } from './permissions';
 import { dispatchScriptToDevice } from './scriptDispatch';
 import { loadTenantVariableScope, type TenantVariableScope } from './tenantVariableResolution';
+import { scriptNeedsVariableScope } from './sourcedParameters';
 import { publishEvent } from './eventBus';
 import { captureException } from './sentry';
 import {
@@ -881,15 +882,16 @@ type ActionExecutionContext = {
  * otherwise compound the trap.
  *
  * The gate is preserved, just widened from one script to the run's script set:
- * if no `run_script` action references a script whose content carries a
- * `{{var.*}}` token, we pass `[]` and `loadTenantVariableScope` short-circuits
- * without querying at all (tenantVariableResolution.ts) — so a token-free run,
- * which is the overwhelming majority, still does exactly zero work.
+ * if no `run_script` action references a script that needs a scope, we pass
+ * `[]` and `loadTenantVariableScope` short-circuits without querying at all
+ * (tenantVariableResolution.ts) — so a variable-free run, which is the
+ * overwhelming majority, still does exactly zero work.
  *
- * NOTE for PR3's sourced parameters: this gate is content-only. When bound
- * parameters land, extend it to `hasTenantVariableBoundParameters(parameters)`
- * as well (plan §3 P1) — a parameter binding lives in `scripts.parameters`,
- * not in the content, and would resolve against an empty scope here.
+ * #3409 PR3 P1: the per-script predicate is `scriptNeedsVariableScope`, NOT
+ * `hasVariableTokens(content)`. A `tenantVariable`-bound parameter lives in
+ * `scripts.parameters`, not in the content, so a content-only gate would pass
+ * `[]` here and every bound parameter would then resolve against an EMPTY
+ * scope at dispatch — failing as "no value set" for a variable that exists.
  *
  * `loadTenantVariableScope` owns the `runOutsideDbContext(() =>
  * withSystemDbAccessContext(...))` double wrapper; do not add or unwrap one
@@ -901,11 +903,11 @@ export async function loadAutomationRunVariableScope(
   scriptsById: Map<string, typeof scripts.$inferSelect>,
   deviceOrgIds: string[],
 ): Promise<TenantVariableScope> {
-  const anyScriptUsesVariables = actions.some(
-    (action) =>
-      action.type === 'run_script' &&
-      hasVariableTokens(scriptsById.get(action.scriptId)?.content ?? ''),
-  );
+  const anyScriptUsesVariables = actions.some((action) => {
+    if (action.type !== 'run_script') return false;
+    const script = scriptsById.get(action.scriptId);
+    return script !== undefined && scriptNeedsVariableScope(script);
+  });
   return loadTenantVariableScope(anyScriptUsesVariables ? [...new Set(deviceOrgIds)] : []);
 }
 
@@ -1018,7 +1020,22 @@ export async function executeRunScriptAction(
       // "queued, agent offline" (no_agent) from "we had a socket and failed
       // to reach it" (claim_lost/decrypt_failed/send_failed) — see
       // scriptDispatch.ts's DispatchScriptResult for the full enum.
-      details: { scriptId: script.id, executionId: dispatch.executionId, deliveryOutcome: dispatch.deliveryOutcome },
+      details: {
+        scriptId: script.id,
+        executionId: dispatch.executionId,
+        deliveryOutcome: dispatch.deliveryOutcome,
+        // #3409 PR3 §2.2 — the automation configured a value for a parameter
+        // that is BOUND to a source, so the binding won and the configured
+        // value was dropped. Automations have no parameter-capture UI, so the
+        // run log is the ONLY place this warning can surface for them: an
+        // author who set `parameters: {api_key: '...'}` before the script's
+        // author flipped that key to a binding otherwise sees a silently
+        // different run. Spread conditionally so a run log for the ~all of
+        // today's automations is byte-identical to before.
+        ...(dispatch.ignoredParameters.length > 0
+          ? { ignoredParameterKeys: dispatch.ignoredParameters }
+          : {}),
+      },
     }),
   };
 }

--- a/apps/api/src/services/scriptBuilderTools.ts
+++ b/apps/api/src/services/scriptBuilderTools.ts
@@ -12,6 +12,7 @@ import { dbAccessContextFromAuth } from '../middleware/auth';
 import { executeTool } from './aiTools';
 import { withDbAccessContext, runOutsideDbContext } from '../db';
 import type { AiToolTier } from '@breeze/shared/types/ai';
+import { scriptParameterDefinitionsSchema } from '@breeze/shared';
 import { compactToolResultForChat } from './aiToolOutput';
 import { captureException } from './sentry';
 import type { PreToolUseCallback, PostToolUseCallback } from './aiAgentSdkTools';
@@ -171,13 +172,10 @@ export const applyScriptMetadataInputShape = {
   description: z.string().max(2000).optional().describe('Script description'),
   category: z.enum(['Maintenance', 'Security', 'Monitoring', 'Deployment', 'Backup', 'Network', 'User Management', 'Software', 'Custom']).optional(),
   osTypes: z.array(z.enum(['windows', 'macos', 'linux'])).optional(),
-  parameters: z.array(z.object({
-    name: z.string(),
-    type: z.enum(['string', 'number', 'boolean', 'select']),
-    defaultValue: z.string().optional(),
-    required: z.boolean().optional(),
-    options: z.string().optional(),
-  })).optional(),
+  // The one definition schema (#3409 PR3) — same shape, same env-var collision
+  // rule, and the same 64-parameter cap the API itself now enforces, so the
+  // builder can no longer propose a definition list the save endpoint rejects.
+  parameters: scriptParameterDefinitionsSchema.optional(),
   runAs: z.enum(['system', 'user', 'elevated']).optional(),
   // 3600 = agent executor MaxTimeout — higher values are silently clamped
   // on-device, so don't let the builder propose them (#2398).

--- a/apps/api/src/services/scriptBundle/schema.ts
+++ b/apps/api/src/services/scriptBundle/schema.ts
@@ -10,10 +10,10 @@
  *   `isSystem` are not part of the schema; Zod object parsing strips unknown
  *   keys, so their presence in an uploaded file cannot carry through to the
  *   import path (the #633 hole in a new costume — never read the field).
- * - `parameters` is bounded at intake (size + depth). The route-level
- *   `createScriptSchema` types it `z.any()` and the 64KB cap at
- *   `routes/scripts.ts` is execute-time only; a bundle must not deliver an
- *   arbitrary attacker-authored jsonb blob into storage.
+ * - `parameters` is bounded at intake (size + depth) BEFORE being parsed as
+ *   real parameter definitions (#3409 PR3). A bundle must not deliver an
+ *   arbitrary attacker-authored jsonb blob into storage, and must not be able
+ *   to store a definition shape that `POST /scripts` would reject.
  * - An `exitCodeSeverityMapping` that maps every exit code to `null` is
  *   rejected: it would ship a SYSTEM-level script pre-configured never to
  *   raise an alert, neutering the after-the-fact abuse detection.
@@ -24,7 +24,7 @@
  * across instances and would leak the source tenant's identifiers.
  */
 import { z } from 'zod';
-import { exitCodeSeverityMappingSchema } from '@breeze/shared';
+import { exitCodeSeverityMappingSchema, scriptParameterDefinitionsSchema } from '@breeze/shared';
 
 export const SCRIPT_BUNDLE_VERSION = 1;
 /** Server-side cap on scripts per bundle. */
@@ -107,7 +107,13 @@ export const bundleScriptEntrySchema = z.object({
   osTypes: z.array(z.enum(['windows', 'macos', 'linux'])).min(1),
   language: z.enum(['powershell', 'bash', 'python', 'cmd']),
   content: z.string().min(1).max(MAX_BUNDLE_CONTENT_LENGTH),
-  parameters: boundedParametersSchema.optional(),
+  // Size/depth first (so an oversized blob still reports "too large" rather
+  // than 64 array-shape errors), THEN the real definition schema (#3409 PR3).
+  // The importer writes straight into `scripts.parameters`, which is now
+  // typed `ScriptParameterDefinition[]` — validating only size and depth here
+  // would let a bundle put a shape into that column that `POST /scripts` and
+  // `PUT /scripts/:id` both reject.
+  parameters: boundedParametersSchema.pipe(scriptParameterDefinitionsSchema).nullish(),
   // Same bounds as createScriptSchema (agent executor clamps at 1 hour).
   timeoutSeconds: z.number().int().min(1).max(3600).default(300),
   runAs: z.enum(['system', 'user', 'elevated']).default('system'),

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -29,9 +29,10 @@ const savedScript = (o = {}) => ({
   timeoutSeconds: 60, runAs: 'system', deletedAt: null, ...o,
 }) as any;
 
-// hostname/siteId/customFields joined the projection in #3409 PR3 P3 for
-// sourced parameters. Nothing in scriptDispatch reads them yet — they are on
-// the fixture so the shape here matches what real callers now supply.
+// hostname/siteId/customFields joined the projection in #3409 PR3 P3 and are
+// read by the sourced-parameter resolver (the `builtin` and
+// `deviceCustomField` sources) — see the sourced-parameters describe block
+// at the bottom of this file.
 const device = (o = {}) => ({
   id: 'device-1', orgId: 'org-a', osType: 'linux', status: 'online', agentId: null,
   hostname: 'host-1', siteId: 'site-1', customFields: { assetTag: 'A-1' }, ...o,
@@ -47,7 +48,7 @@ const device = (o = {}) => ({
 // exactly (orgIds + byOrg); TenantVariableScope itself only declares
 // `orgIds`, so this is cast through `unknown`.
 const resolvedVar = (key: string, value: string, isSecret = false): ResolvedVariable => ({
-  key, value, isSecret, variableId: `var-${key}`, version: 1,
+  key, value, isSecret, variableId: `var-${key}`, version: 1, ownerScope: 'organization',
 });
 
 const buildScope = (orgId: string, vars: ResolvedVariable[] = []): TenantVariableScope => ({
@@ -540,5 +541,285 @@ describe('dispatchScriptToDevice — {{var.*}} resolution', () => {
     expect(r.ok).toBe(true);
     const [, , payload] = vi.mocked(queueCommand).mock.calls[0]!;
     expect((payload as Record<string, unknown>).content).toBe('curl {{var.repo_url}}');
+  });
+});
+
+// #3409 PR3: sourced-parameter resolution at the dispatch chokepoint.
+describe('dispatchScriptToDevice — sourced parameters', () => {
+  const scriptWithParams = (parameters: unknown[], overrides = {}) =>
+    savedScript({ parameters, ...overrides });
+
+  const payloadParameters = () => {
+    const [, , payload] = vi.mocked(queueCommand).mock.calls[0]!;
+    return (payload as Record<string, unknown>).parameters;
+  };
+
+  const executionParameters = () =>
+    vi.mocked(db.insert).mock.results[0]!.value.values.mock.calls[0]![0].parameters;
+
+  it('pre-fills a bound parameter from the device row and drops the caller override', async () => {
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: {
+        kind: 'saved',
+        script: scriptWithParams([
+          { name: 'host', type: 'string', source: 'builtin', builtinKey: 'device.hostname' },
+          { name: 'level', type: 'string', source: 'runtime' },
+        ]),
+      },
+      parameters: { host: 'caller-tried-this', level: 'debug' },
+    });
+
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.ignoredParameters).toEqual(['host']);
+    expect(payloadParameters()).toEqual({ host: 'host-1', level: 'debug' });
+    expect(JSON.stringify(payloadParameters())).not.toContain('caller-tried-this');
+  });
+
+  it('resolves a tenantVariable-bound parameter from the preloaded scope', async () => {
+    const scope = buildScope('org-a', [resolvedVar('api_token', 'tok-123')]);
+    await dispatchScriptToDevice({
+      device: device(),
+      source: {
+        kind: 'saved',
+        script: scriptWithParams([
+          { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' },
+        ]),
+      },
+      variableScope: scope,
+    });
+
+    expect(payloadParameters()).toEqual({ token: 'tok-123' });
+  });
+
+  it('fails the device with unresolved_parameters — DISTINCT from unresolved_variables', async () => {
+    const scope = buildScope('org-a', []);
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: {
+        kind: 'saved',
+        script: scriptWithParams([
+          { name: 'token', type: 'string', required: true, source: 'tenantVariable', variableKey: 'api_token' },
+        ]),
+      },
+      variableScope: scope,
+    });
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('unresolved_parameters');
+      expect(r.code).not.toBe('unresolved_variables');
+      expect(r.error).toContain('token');
+    }
+  });
+
+  // Same rule PR2 established for content substitution: resolution runs
+  // BEFORE the insert, so a failing device leaves no orphan 'pending' row.
+  it('leaves no orphan execution row when a device fails resolution', async () => {
+    const scope = buildScope('org-a', []);
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: {
+        kind: 'saved',
+        script: scriptWithParams([
+          { name: 'token', type: 'string', required: true, source: 'tenantVariable', variableKey: 'api_token' },
+        ]),
+      },
+      variableScope: scope,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(queueCommand).not.toHaveBeenCalled();
+  });
+
+  it('fails the device when a bound parameter targets a SECRET tenant variable', async () => {
+    const SECRET_VALUE = 'sup3r-s3cret-xyz';
+    const scope = buildScope('org-a', [resolvedVar('api_token', SECRET_VALUE, true)]);
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: {
+        kind: 'saved',
+        script: scriptWithParams([
+          // A default IS present — the denial must not fall back to it.
+          { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token', defaultValue: 'the-default' },
+        ]),
+      },
+      parameters: { token: 'caller-supplied' },
+      variableScope: scope,
+    });
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('unresolved_parameters');
+      expect(r.error).toMatch(/secret/i);
+    }
+    expect(queueCommand).not.toHaveBeenCalled();
+    expect(JSON.stringify(vi.mocked(queueCommand).mock.calls)).not.toContain(SECRET_VALUE);
+  });
+
+  it('requires a variableScope only for a tenantVariable binding, not for the other sources', async () => {
+    const r = await dispatchScriptToDevice({
+      device: device({ customFields: { asset_tag: 'A-1' } }),
+      source: {
+        kind: 'saved',
+        script: scriptWithParams([
+          { name: 'lic', type: 'string', source: 'deviceCustomField', fieldKey: 'asset_tag' },
+        ]),
+      },
+      // deliberately no variableScope — must not throw
+    });
+
+    expect(r.ok).toBe(true);
+    expect(payloadParameters()).toEqual({ lic: 'A-1' });
+  });
+
+  it('throws when a tenantVariable binding is dispatched with no scope (call-site bug)', async () => {
+    await expect(dispatchScriptToDevice({
+      device: device(),
+      source: {
+        kind: 'saved',
+        script: scriptWithParams([
+          { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' },
+        ]),
+      },
+    })).rejects.toThrow(/variableScope is required/i);
+  });
+
+  it('skips resolution entirely for a raw execute_command source', async () => {
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'raw', content: 'ipconfig', language: 'powershell', provenance: 'automation:auto-1' },
+      parameters: { anything: 'kept' },
+    });
+
+    expect(r.ok).toBe(true);
+    expect(payloadParameters()).toEqual({ anything: 'kept' });
+  });
+
+  it('leaves a script with no parameter definitions byte-identical to PR2 behaviour', async () => {
+    await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'saved', script: savedScript() },
+      parameters: { a: '1' },
+    });
+
+    expect(payloadParameters()).toEqual({ a: '1' });
+    expect(executionParameters()).toEqual({ a: '1' });
+  });
+
+  // Plan §3 P4 — the persistence rule.
+  describe('P4: resolved values never enter script_executions.parameters', () => {
+    it('stores the CALLER parameters plus an identity-only $bindings descriptor', async () => {
+      const scope = buildScope('org-a', [resolvedVar('api_token', 'tok-123')]);
+      await dispatchScriptToDevice({
+        device: device(),
+        source: {
+          kind: 'saved',
+          script: scriptWithParams([
+            { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' },
+            { name: 'level', type: 'string', source: 'runtime' },
+          ]),
+        },
+        parameters: { level: 'debug' },
+        variableScope: scope,
+      });
+
+      const stored = executionParameters();
+      expect(stored).toEqual({
+        level: 'debug',
+        $bindings: [
+          { key: 'token', source: 'tenantVariable', variableId: 'var-api_token', ownerScope: 'organization', version: 1 },
+        ],
+      });
+      // The resolved value exists ONLY in the command payload.
+      expect(JSON.stringify(stored)).not.toContain('tok-123');
+      expect(payloadParameters()).toMatchObject({ token: 'tok-123' });
+    });
+
+    it('does not add a $bindings key when the script has no bound parameters', async () => {
+      await dispatchScriptToDevice({
+        device: device(),
+        source: {
+          kind: 'saved',
+          script: scriptWithParams([{ name: 'level', type: 'string', source: 'runtime' }]),
+        },
+        parameters: { level: 'debug' },
+      });
+
+      expect(executionParameters()).toEqual({ level: 'debug' });
+      expect(executionParameters()).not.toHaveProperty('$bindings');
+    });
+
+    it('never persists a builtin- or custom-field-resolved value either', async () => {
+      await dispatchScriptToDevice({
+        device: device({ customFields: { asset_tag: 'A-1' } }),
+        source: {
+          kind: 'saved',
+          script: scriptWithParams([
+            { name: 'host', type: 'string', source: 'builtin', builtinKey: 'device.hostname' },
+            { name: 'lic', type: 'string', source: 'deviceCustomField', fieldKey: 'asset_tag' },
+          ]),
+        },
+      });
+
+      const stored = executionParameters();
+      expect(stored).toEqual({
+        $bindings: [
+          { key: 'host', source: 'builtin' },
+          { key: 'lic', source: 'deviceCustomField' },
+        ],
+      });
+      expect(JSON.stringify(stored)).not.toContain('host-1');
+      expect(JSON.stringify(stored)).not.toContain('A-1');
+    });
+  });
+
+  describe('builtin name lookups', () => {
+    // `loadBuiltinNameContext` is the only db.select this codepath makes
+    // (requireOnline is off in these tests), so one chain models both.
+    const mockNameSelect = (rows: unknown[]) => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+        }),
+      } as any);
+    };
+
+    it('looks up org.name / site.name and resolves them', async () => {
+      mockNameSelect([{ name: 'Acme Corp' }]);
+      await dispatchScriptToDevice({
+        device: device(),
+        source: {
+          kind: 'saved',
+          script: scriptWithParams([
+            { name: 'org_name', type: 'string', source: 'builtin', builtinKey: 'org.name' },
+            { name: 'site_name', type: 'string', source: 'builtin', builtinKey: 'site.name' },
+          ]),
+        },
+      });
+
+      expect(db.select).toHaveBeenCalledTimes(2); // one org query, one site query
+      expect(payloadParameters()).toEqual({ org_name: 'Acme Corp', site_name: 'Acme Corp' });
+    });
+
+    // The two name queries are the only per-device cost this feature adds;
+    // a script that binds no NAME builtin must not pay it.
+    it('issues NO lookup for the id/hostname builtins', async () => {
+      await dispatchScriptToDevice({
+        device: device(),
+        source: {
+          kind: 'saved',
+          script: scriptWithParams([
+            { name: 'org_id', type: 'string', source: 'builtin', builtinKey: 'org.id' },
+            { name: 'site_id', type: 'string', source: 'builtin', builtinKey: 'site.id' },
+            { name: 'host', type: 'string', source: 'builtin', builtinKey: 'device.hostname' },
+          ]),
+        },
+      });
+
+      expect(db.select).not.toHaveBeenCalled();
+      expect(payloadParameters()).toEqual({ org_id: 'org-a', site_id: 'site-1', host: 'host-1' });
+    });
   });
 });

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -29,8 +29,12 @@ const savedScript = (o = {}) => ({
   timeoutSeconds: 60, runAs: 'system', deletedAt: null, ...o,
 }) as any;
 
+// hostname/siteId/customFields joined the projection in #3409 PR3 P3 for
+// sourced parameters. Nothing in scriptDispatch reads them yet — they are on
+// the fixture so the shape here matches what real callers now supply.
 const device = (o = {}) => ({
-  id: 'device-1', orgId: 'org-a', osType: 'linux', status: 'online', agentId: null, ...o,
+  id: 'device-1', orgId: 'org-a', osType: 'linux', status: 'online', agentId: null,
+  hostname: 'host-1', siteId: 'site-1', customFields: { assetTag: 'A-1' }, ...o,
 }) as any;
 
 // #3409 PR2 Task 4: builds a TenantVariableScope directly, bypassing

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -37,7 +37,19 @@ export type ScriptDispatchSource =
   | { kind: 'raw'; content: string; language: string; provenance: string };
 
 export type DispatchScriptInput = {
-  device: Pick<typeof devices.$inferSelect, 'id' | 'orgId' | 'osType' | 'status' | 'agentId'>;
+  // `hostname`, `siteId`, and `customFields` are carried for #3409 PR3's
+  // sourced parameters: a `deviceCustomField` binding reads `customFields`
+  // and the `builtin` source reads device/site/org properties. Nothing in
+  // THIS file consumes them yet — widening the projection is deliberately a
+  // separate step from adding the resolver, so every call site is already
+  // supplying the data before resolution starts depending on it. Every
+  // caller either selects whole device rows (scriptExecution.ts,
+  // aiToolsScripts.ts via verifyDeviceAccess) or carries a run-level device
+  // snapshot that was widened to match (automationRuntime.ts).
+  device: Pick<
+    typeof devices.$inferSelect,
+    'id' | 'orgId' | 'osType' | 'status' | 'agentId' | 'hostname' | 'siteId' | 'customFields'
+  >;
   source: ScriptDispatchSource;
   parameters?: Record<string, unknown>;
   triggerType?: 'manual' | 'scheduled' | 'alert' | 'policy' | 'automation';

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -2,7 +2,7 @@ import { and, eq } from 'drizzle-orm';
 import { canonicalizeScriptParameters, hasVariableTokens } from '@breeze/shared';
 
 import { db } from '../db';
-import { devices, scriptExecutions, scripts } from '../db/schema';
+import { devices, organizations, scriptExecutions, scripts, sites } from '../db/schema';
 import {
   claimPendingCommandForDelivery,
   releaseClaimedCommandDelivery,
@@ -18,8 +18,17 @@ import {
   describeVariableFailure,
   resolveForOrg,
   substituteTenantVariables,
+  type ResolvedVariable,
   type TenantVariableScope,
 } from './tenantVariableResolution';
+import {
+  builtinNameContextNeeds,
+  EXECUTION_PARAMETER_BINDINGS_KEY,
+  hasTenantVariableBoundParameters,
+  resolveSourcedParameters,
+  type ScriptParameterBindingDescriptor,
+  type SourcedParameterNameContext,
+} from './sourcedParameters';
 
 /**
  * Single seam through which every script reaches a device (#3409 PR 0).
@@ -79,6 +88,12 @@ export type DispatchScriptResult =
       // reach it — operationally different, and worth a log line (see below).
       deliveryOutcome: 'sent' | 'claim_lost' | 'decrypt_failed' | 'send_failed' | 'no_agent';
       executedAt: Date | null;
+      // Bound parameter keys the caller supplied a value for (#3409 PR3
+      // §2.2). The binding wins authoritatively and the supplied value is
+      // dropped — reported rather than rejected, because a stored automation
+      // action is validated without consulting the referenced script's
+      // definitions and so literally cannot pre-validate against a binding.
+      ignoredParameters: string[];
     }
   | {
       ok: false;
@@ -92,7 +107,14 @@ export type DispatchScriptResult =
         // resolved to a secret) for this device's org. Per-device — Task 4
         // (#3409 PR2) is what actually produces this code; this task only
         // gives the fan-out a channel to carry it without aborting the batch.
-        | 'unresolved_variables';
+        | 'unresolved_variables'
+        // A SOURCED PARAMETER could not be resolved for this device (#3409
+        // PR3): a required parameter with no source value and no default, or
+        // a `tenantVariable` binding whose target is a secret. Deliberately
+        // distinct from 'unresolved_variables' above — a parameter-binding
+        // failure and a content-token failure are different operational
+        // conditions and must stay distinguishable in execution history.
+        | 'unresolved_parameters';
       error: string;
     };
 
@@ -173,6 +195,49 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
     content = outcome.content;
   }
 
+  // #3409 PR3: sourced-parameter resolution. Sits AFTER content substitution
+  // and BEFORE the script_executions insert below, for the same reason PR2's
+  // substitution does — a device that fails resolution must leave no orphan
+  // 'pending' row behind for the reaper to later mislabel 'timeout'.
+  //
+  // `{kind:'raw'}` (execute_command) is skipped entirely: there is no
+  // declaring script, so there are no definitions to bind and nothing to
+  // resolve.
+  let resolvedParameters: Record<string, string | number | boolean> = parameters as Record<
+    string,
+    string | number | boolean
+  >;
+  let parameterBindings: ScriptParameterBindingDescriptor[] = [];
+  let ignoredParameters: string[] = [];
+  if (source.kind === 'saved' && Array.isArray(source.script.parameters) && source.script.parameters.length > 0) {
+    const definitions = source.script.parameters;
+    // Only a tenantVariable binding needs the snapshot; the other three
+    // sources read the device row (or the name lookup below), so a script
+    // with no such binding never requires a scope — mirroring the
+    // content-token gate directly above.
+    let variables: Map<string, ResolvedVariable> | undefined;
+    if (hasTenantVariableBoundParameters(definitions)) {
+      if (!input.variableScope) {
+        throw new Error('variableScope is required to dispatch a script with a tenantVariable-bound parameter');
+      }
+      variables = resolveForOrg(input.variableScope, device.orgId);
+    }
+
+    const resolution = resolveSourcedParameters({
+      definitions,
+      callerParameters: parameters,
+      device,
+      names: await loadBuiltinNameContext(definitions, device),
+      variables,
+    });
+    if (!resolution.ok) {
+      return { ok: false, code: resolution.code, error: resolution.error };
+    }
+    resolvedParameters = resolution.parameters;
+    parameterBindings = resolution.bindings;
+    ignoredParameters = resolution.ignoredParameters;
+  }
+
   let executionId: string | null = null;
   if (source.kind === 'saved') {
     // Child rows always take the DEVICE's org (partner-wide fan-out rule).
@@ -185,7 +250,15 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
         triggeredBy: input.triggeredBy ?? null,
         triggerType: input.triggerType ?? 'manual',
         ...(source.automationRunId ? { automationRunId: source.automationRunId } : {}),
-        parameters,
+        // #3409 PR3 P4: the CALLER's raw parameters, never the resolved map.
+        // A resolved bound value must not be persisted — in PR4 that would
+        // mean writing a resolved SECRET into execution history, exactly the
+        // leak the out-of-band delivery channel exists to prevent. What IS
+        // persisted alongside is an identity-only binding descriptor
+        // (`{key, source, variableId?, ownerScope?, version?}`), so history
+        // can answer "which variable fed this run" without carrying what it
+        // was worth.
+        parameters: buildExecutionParameters(parameters, parameterBindings),
         status: 'pending',
       })
       .returning({ id: scriptExecutions.id });
@@ -250,7 +323,11 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
       // Every ingress (route, mobile, automation, AI tools, script builder,
       // remediation suggestions) funnels through here, so this is the one
       // place that guarantees the wire form regardless of caller.
-      parameters: canonicalizeScriptParameters(parameters as Record<string, string | number | boolean>),
+      // #3409 PR3: the RESOLVED map (caller runtime values + server-resolved
+      // bound values) — the only place a resolved value is ever allowed to
+      // exist. For a script with no parameter definitions this is the
+      // caller's map unchanged, i.e. exactly PR2's behaviour.
+      parameters: canonicalizeScriptParameters(resolvedParameters),
       timeoutSeconds,
       runAs,
       ...(input.targetSessionId != null ? { targetSessionId: input.targetSessionId } : {}),
@@ -305,5 +382,68 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
     }
   }
 
-  return { ok: true, commandId: command.id, executionId, delivered, deliveryOutcome, executedAt };
+  return { ok: true, commandId: command.id, executionId, delivered, deliveryOutcome, executedAt, ignoredParameters };
+}
+
+/**
+ * The value written to `script_executions.parameters` — the caller's raw
+ * parameters, plus the binding descriptors under a reserved `$bindings` key
+ * when there are any (#3409 PR3 P4).
+ *
+ * The descriptors ride INSIDE the existing jsonb rather than in a new sibling
+ * column because PR3 ships no migration: `script_executions` carries an
+ * `org_id`, so a new column would also have to be classified in
+ * `CORE_TENANT_EXPORT_POLICY` (the registration step this repo has shipped
+ * bugs on five times), and a `jsonb` column would land in `excludedOpen`
+ * anyway. `$` can never start a parameter name
+ * (`SCRIPT_PARAMETER_KEY_PATTERN`), so the reserved key cannot collide with a
+ * real one; when there are no bindings the stored value is byte-identical to
+ * what PR2 wrote.
+ */
+function buildExecutionParameters(
+  callerParameters: Record<string, unknown>,
+  bindings: ScriptParameterBindingDescriptor[],
+): Record<string, unknown> {
+  if (bindings.length === 0) return callerParameters;
+  return { ...callerParameters, [EXECUTION_PARAMETER_BINDINGS_KEY]: bindings };
+}
+
+/**
+ * Load the two builtin values that are not columns on the device row.
+ * `org.id`, `site.id` and `device.hostname` come off the widened device
+ * projection for free; only `org.name` / `site.name` cost a query, and
+ * {@link builtinNameContextNeeds} keeps both queries off the path for every
+ * script that doesn't bind them — which is all of them today.
+ *
+ * Runs in the caller's ambient DB context deliberately: the caller was
+ * already authorized to dispatch to this device, so an org-scoped request
+ * transaction can read its own org/site, and the system-context callers
+ * (automation worker, AI tools) are unconstrained. No context escape is
+ * needed or wanted here.
+ */
+async function loadBuiltinNameContext(
+  definitions: unknown,
+  device: Pick<typeof devices.$inferSelect, 'orgId' | 'siteId'>,
+): Promise<SourcedParameterNameContext> {
+  const needs = builtinNameContextNeeds(definitions);
+  if (!needs.orgName && !needs.siteName) return {};
+
+  const context: SourcedParameterNameContext = {};
+  if (needs.orgName) {
+    const [org] = await db
+      .select({ name: organizations.name })
+      .from(organizations)
+      .where(eq(organizations.id, device.orgId))
+      .limit(1);
+    context.orgName = org?.name ?? null;
+  }
+  if (needs.siteName && device.siteId) {
+    const [site] = await db
+      .select({ name: sites.name })
+      .from(sites)
+      .where(eq(sites.id, device.siteId))
+      .limit(1);
+    context.siteName = site?.name ?? null;
+  }
+  return context;
 }

--- a/apps/api/src/services/scriptExecution.test.ts
+++ b/apps/api/src/services/scriptExecution.test.ts
@@ -24,6 +24,8 @@ vi.mock('./scriptDispatch', () => ({
     executionId: 'exec-1',
     delivered: false,
     executedAt: null,
+    // Required on the success arm since #3409 PR3 — the fan-out unions it.
+    ignoredParameters: [],
   }),
 }));
 
@@ -262,9 +264,9 @@ describe('executeScriptOnDevices — per-device dispatch failures (#3409 PR2 Tas
         baseDevice({ id: 'device-c', orgId: 'org-b' }),
       ]) as any);
     vi.mocked(dispatchScriptToDevice)
-      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null })
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, ignoredParameters: [] })
       .mockResolvedValueOnce({ ok: false, code: 'unresolved_variables', error: 'Could not resolve variable(s): repo_url' })
-      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-c', executionId: 'exec-c', delivered: false, deliveryOutcome: 'no_agent', executedAt: null });
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-c', executionId: 'exec-c', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, ignoredParameters: [] });
 
     const result = await executeScriptOnDevices({
       scriptId: 'script-1',
@@ -290,7 +292,7 @@ describe('executeScriptOnDevices — per-device dispatch failures (#3409 PR2 Tas
         baseDevice({ id: 'device-b', orgId: 'org-b' }),
       ]) as any);
     vi.mocked(dispatchScriptToDevice)
-      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null })
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, ignoredParameters: [] })
       .mockResolvedValueOnce({ ok: false, code: 'unresolved_variables', error: 'Could not resolve variable(s): repo_url' });
 
     await executeScriptOnDevices({
@@ -325,7 +327,7 @@ describe('executeScriptOnDevices — per-device dispatch failures (#3409 PR2 Tas
         baseDevice({ id: 'device-b', orgId: 'org-b' }),
       ]) as any);
     vi.mocked(dispatchScriptToDevice)
-      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null })
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, ignoredParameters: [] })
       .mockResolvedValueOnce({ ok: false, code: 'unresolved_variables', error: 'Could not resolve variable(s): repo_url' });
 
     const result = await executeScriptOnDevices({
@@ -346,6 +348,87 @@ describe('executeScriptOnDevices — per-device dispatch failures (#3409 PR2 Tas
     expect(updateCalls).toHaveLength(2);
     const devicesFailedSetCall = updateCalls[0]!.value.set.mock.calls[0][0];
     expect(devicesFailedSetCall).toHaveProperty('devicesFailed');
+  });
+});
+
+describe('executeScriptOnDevices — ignored bound parameters (#3409 PR3 §2.2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.insert).mockReturnValue(insertReturning([{ id: 'inserted-1' }]) as any);
+    vi.mocked(db.update).mockReturnValue(updateChain() as any);
+  });
+
+  it('unions the per-device ignored keys and de-duplicates them', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-b' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([
+        baseDevice({ id: 'device-a', orgId: 'org-b' }),
+        baseDevice({ id: 'device-b', orgId: 'org-b' }),
+      ]) as any);
+    // Definitions belong to the SCRIPT, so in practice every device reports
+    // the same set — the caller must still see each key exactly once, and a
+    // key only one device reported must not be dropped.
+    vi.mocked(dispatchScriptToDevice)
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, ignoredParameters: ['api_key', 'site_code'] })
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-b', executionId: 'exec-b', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, ignoredParameters: ['api_key'] });
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-a', 'device-b'],
+      parameters: { api_key: 'caller-supplied', site_code: 'caller-supplied' },
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.ignoredParameters).toEqual(['api_key', 'site_code']);
+  });
+
+  it('is an empty array when no bound key was supplied', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-b' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([baseDevice({ id: 'device-a', orgId: 'org-b' })]) as any);
+    vi.mocked(dispatchScriptToDevice)
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, ignoredParameters: [] });
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-a'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // The SERVICE always reports the field; it is the ROUTE that omits it from
+    // the wire when empty (see scripts.test.ts / mobile.test.ts).
+    expect(result.ignoredParameters).toEqual([]);
+  });
+
+  it('still reports keys from the devices that dispatched when another device failed', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-b' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([
+        baseDevice({ id: 'device-a', orgId: 'org-b' }),
+        baseDevice({ id: 'device-b', orgId: 'org-b' }),
+      ]) as any);
+    vi.mocked(dispatchScriptToDevice)
+      // The failure arm of DispatchScriptResult carries no ignored keys, so a
+      // failed device contributes nothing — the surviving device is what keeps
+      // the warning alive for the run.
+      .mockResolvedValueOnce({ ok: false, code: 'unresolved_parameters', error: 'Unresolved script parameter(s): no value for required parameter(s) "region"' })
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-b', executionId: 'exec-b', delivered: false, deliveryOutcome: 'no_agent', executedAt: null, ignoredParameters: ['api_key'] });
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-a', 'device-b'],
+      parameters: { api_key: 'caller-supplied' },
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.ignoredParameters).toEqual(['api_key']);
+    expect(result.failures).toHaveLength(1);
   });
 });
 
@@ -397,6 +480,49 @@ describe('executeScriptOnDevices — tenant variable scope preload (#3409 PR2 Ta
     // Called with an EMPTY org list, which loadTenantVariableScope
     // short-circuits without querying — no escape from the request
     // transaction, no second connection.
+    const [orgIds] = vi.mocked(loadTenantVariableScope).mock.calls[0]!;
+    expect(orgIds).toEqual([]);
+  });
+
+  // #3409 PR3 P1 — the gap that makes the extended gate load-bearing. The
+  // content here is deliberately TOKEN-FREE: with the old
+  // `hasVariableTokens(script.content)` gate this run passes `[]`, dispatch
+  // then resolves the binding against an EMPTY scope, and the device fails
+  // with "no value set" for a variable that exists.
+  //
+  // MUTATION-VERIFIED: forcing `scriptNeedsVariableScope` to `false` fails
+  // this test and the sibling `aiToolsScripts` / `automationRuntime` gate
+  // tests, and nothing else.
+  it('loads a scope for a token-free script whose PARAMETERS bind a tenant variable', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([
+        baseScript({
+          orgId: 'org-a',
+          content: 'echo hi',
+          parameters: [{ name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' }],
+        }),
+      ]) as any)
+      .mockReturnValueOnce(devicesSelectChain([baseDevice({ id: 'device-1', orgId: 'org-a' })]) as any);
+
+    await executeScriptOnDevices({ scriptId: 'script-1', deviceIds: ['device-1'], auth: multiOrgAuth });
+
+    const [orgIds] = vi.mocked(loadTenantVariableScope).mock.calls[0]!;
+    expect(orgIds).toEqual(['org-a']);
+  });
+
+  it('does NOT load a scope for a token-free script whose parameters are all runtime', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([
+        baseScript({
+          orgId: 'org-a',
+          content: 'echo hi',
+          parameters: [{ name: 'level', type: 'string', source: 'runtime' }],
+        }),
+      ]) as any)
+      .mockReturnValueOnce(devicesSelectChain([baseDevice({ id: 'device-1', orgId: 'org-a' })]) as any);
+
+    await executeScriptOnDevices({ scriptId: 'script-1', deviceIds: ['device-1'], auth: multiOrgAuth });
+
     const [orgIds] = vi.mocked(loadTenantVariableScope).mock.calls[0]!;
     expect(orgIds).toEqual([]);
   });

--- a/apps/api/src/services/scriptExecution.ts
+++ b/apps/api/src/services/scriptExecution.ts
@@ -11,7 +11,7 @@ import { checkDeviceMaintenanceWindow } from './featureConfigResolver';
 import { canAccessSite, type UserPermissions } from './permissions';
 import { dispatchScriptToDevice } from './scriptDispatch';
 import { loadTenantVariableScope } from './tenantVariableResolution';
-import { hasVariableTokens } from '@breeze/shared';
+import { scriptNeedsVariableScope } from './sourcedParameters';
 
 type ScriptExecutionAuth = {
   user: { id: string };
@@ -52,6 +52,23 @@ type ExecuteScriptOnDevicesSuccess = {
   // gets its own 'failed' script_executions row (see the dispatch loop below)
   // so `devicesTargeted` never outlives the rows a caller can find.
   failures: Array<{ deviceId: string; code: string; error: string }>;
+  // Bound parameter keys the caller supplied a value for, unioned across the
+  // fan-out and de-duplicated (#3409 PR3 §2.2). The binding is authoritative,
+  // so the supplied value was DROPPED — it is reported rather than rejected
+  // because a stored automation action is validated without consulting the
+  // referenced script's definitions and so cannot pre-validate against a
+  // binding; a 400 would turn a previously-valid stored automation into a
+  // delayed runtime failure the moment an author flips a parameter to bound.
+  //
+  // Parameter definitions belong to the script, not the device, so in practice
+  // every device in a fan-out produces the identical set — the union is
+  // defensive, and keeps this a property of THE RUN rather than of whichever
+  // device happened to be dispatched first. Devices that failed to dispatch
+  // contribute nothing (the failure arm of DispatchScriptResult carries no
+  // ignored keys); with a per-script set that loses information only when
+  // EVERY device failed, which the caller already surfaces as a 422 naming the
+  // real failure.
+  ignoredParameters: string[];
   status: 'queued';
   triggerType: 'manual' | 'scheduled' | 'alert' | 'policy';
   runAs: string;
@@ -160,14 +177,20 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
   // Preload ONCE per fan-out (#3409 PR2 Task 4), never per device — one
   // snapshot covers every org in this batch's executable device set.
   //
-  // Gated on the script actually containing a {{var.*}} token. Without the
-  // gate EVERY script run — the overwhelming majority of which reference no
-  // variable at all — would escape the request transaction via
-  // runOutsideDbContext and take a second connection to run a join that is
-  // then never consulted. loadTenantVariableScope short-circuits on an empty
-  // org list without querying, so passing [] is the no-op path.
+  // Gated on the script actually needing a scope. Without the gate EVERY
+  // script run — the overwhelming majority of which reference no variable at
+  // all — would escape the request transaction via runOutsideDbContext and
+  // take a second connection to run a join that is then never consulted.
+  // loadTenantVariableScope short-circuits on an empty org list without
+  // querying, so passing [] is the no-op path.
+  //
+  // #3409 PR3 P1: the gate is `scriptNeedsVariableScope`, not
+  // `hasVariableTokens(content)` — a `tenantVariable`-bound parameter lives
+  // in `scripts.parameters`, not in the content, and a content-only gate
+  // would hand dispatch an EMPTY scope for it, making every bound parameter
+  // resolve as "no value set" for a variable that exists.
   const variableScope = await loadTenantVariableScope(
-    hasVariableTokens(script.content) ? [...new Set(executableDevices.map((d) => d.orgId))] : []
+    scriptNeedsVariableScope(script) ? [...new Set(executableDevices.map((d) => d.orgId))] : []
   );
 
   // A multi-org run (partner/system script fanned out across orgs) must not
@@ -213,6 +236,9 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
 
   const executions: Array<{ executionId: string; deviceId: string; commandId: string }> = [];
   const failures: Array<{ deviceId: string; code: string; error: string }> = [];
+  // A Set, not an array: see `ignoredParameters` on the success type. Insertion
+  // order is preserved so the reported order matches definition order.
+  const ignoredParameters = new Set<string>();
   // This loop itself is sequential/awaited and therefore bounded, but
   // queueCommand (inside dispatchScriptToDevice) fires an un-awaited,
   // fire-and-forget audit transaction PER DEVICE for 'script' commands
@@ -240,10 +266,11 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
     if (!dispatch.ok) {
       // 'insert_failed' means queueCommand/the execution insert itself broke
       // — a programming error, not a per-device condition. Every other code
-      // (today: 'unresolved_variables', once Task 4 wires resolution in) is a
-      // condition specific to this device and must not truncate the rest of
-      // the fan-out — see softwareDeployment.ts:399-414 for the pattern this
-      // mirrors.
+      // ('unresolved_variables' from PR2's content substitution,
+      // 'unresolved_parameters' from PR3's sourced parameters, plus the
+      // device-state codes) is a condition specific to this device and must
+      // not truncate the rest of the fan-out — see
+      // softwareDeployment.ts:399-414 for the pattern this mirrors.
       if (dispatch.code === 'insert_failed') {
         throw new Error(dispatch.error);
       }
@@ -269,6 +296,9 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
       }
       failures.push({ deviceId: device.id, code: dispatch.code, error: dispatch.error });
       continue;
+    }
+    for (const key of dispatch.ignoredParameters) {
+      ignoredParameters.add(key);
     }
     executions.push({
       executionId: dispatch.executionId!,
@@ -302,6 +332,7 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
     maintenanceSuppressedDeviceIds,
     executions,
     failures,
+    ignoredParameters: [...ignoredParameters],
     status: 'queued',
     triggerType,
     runAs,

--- a/apps/api/src/services/scriptWrite.ts
+++ b/apps/api/src/services/scriptWrite.ts
@@ -8,6 +8,7 @@
  * lived only in route handlers with no service-layer chokepoint — this module
  * is that chokepoint. Do not add a second script-insert path that bypasses it.
  */
+import type { ScriptParameterDefinition } from '@breeze/shared';
 import { db } from '../db';
 import { scripts } from '../db/schema';
 import type { AuthContext } from '../middleware/auth';
@@ -95,7 +96,10 @@ export type ScriptInsertInput = {
   osTypes: string[];
   language: 'powershell' | 'bash' | 'python' | 'cmd';
   content: string;
-  parameters?: unknown;
+  // Validated DEFINITIONS, never raw jsonb (#3409 PR3): both callers —
+  // `POST /scripts` and the bundle importer — now parse through
+  // `scriptParameterDefinitionsSchema` before reaching here.
+  parameters?: ScriptParameterDefinition[] | null;
   timeoutSeconds: number;
   runAs: 'system' | 'user' | 'elevated';
   exitCodeSeverityMapping?: Record<string, 'critical' | 'high' | 'medium' | 'low' | 'info' | null> | null;

--- a/apps/api/src/services/sourcedParameters.test.ts
+++ b/apps/api/src/services/sourcedParameters.test.ts
@@ -1,0 +1,711 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  builtinNameContextNeeds,
+  hasTenantVariableBoundParameters,
+  resolveSourcedParameters,
+  scriptNeedsVariableScope,
+  type ResolveSourcedParametersInput,
+  type SourcedParameterDevice,
+} from './sourcedParameters';
+import type { ResolvedVariable } from './tenantVariableResolution';
+
+/**
+ * #3409 PR3 — the sourced-parameter resolver.
+ *
+ * The whole precedence table (plan §2.1) is exercised here rather than
+ * through `dispatchScriptToDevice`, because the resolver is pure: every case
+ * below is a direct input/output assertion with no DB, no mocks and no
+ * ambient context to get wrong.
+ */
+
+const DEVICE: SourcedParameterDevice = {
+  id: 'device-1',
+  orgId: 'org-a',
+  hostname: 'WKS-014',
+  siteId: 'site-1',
+  customFields: { license_key: 'LK-1', blank_field: '   ', object_field: { nested: true } },
+};
+
+const variable = (overrides: Partial<ResolvedVariable> & { key: string }): ResolvedVariable => ({
+  value: 'from-variable',
+  isSecret: false,
+  variableId: `var-${overrides.key}`,
+  version: 7,
+  ownerScope: 'organization',
+  ...overrides,
+});
+
+const varsWith = (...entries: ResolvedVariable[]): Map<string, ResolvedVariable> =>
+  new Map(entries.map((entry) => [entry.key, entry]));
+
+function resolve(overrides: Partial<ResolveSourcedParametersInput> = {}) {
+  return resolveSourcedParameters({
+    definitions: [],
+    callerParameters: {},
+    device: DEVICE,
+    ...overrides,
+  });
+}
+
+/** Narrowing helper — every success assertion below wants `.parameters`. */
+function expectOk(result: ReturnType<typeof resolve>) {
+  if (!result.ok) throw new Error(`expected ok, got: ${result.error}`);
+  return result;
+}
+
+function expectFailed(result: ReturnType<typeof resolve>) {
+  if (result.ok) throw new Error(`expected failure, got: ${JSON.stringify(result.parameters)}`);
+  return result;
+}
+
+describe('resolveSourcedParameters — BOUND precedence (source -> default -> missing)', () => {
+  it('uses the resolved source value, ignoring both the default and a caller value', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token', defaultValue: 'the-default' },
+        ],
+        callerParameters: { token: 'caller-supplied' },
+        variables: varsWith(variable({ key: 'api_token', value: 'from-variable' })),
+      }),
+    );
+
+    expect(result.parameters).toEqual({ token: 'from-variable' });
+  });
+
+  it('falls back to the definition default when the source has no value', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'absent', defaultValue: 'the-default' },
+        ],
+        variables: varsWith(),
+      }),
+    );
+
+    expect(result.parameters).toEqual({ token: 'the-default' });
+  });
+
+  it('treats an empty-string source value as blank and falls back to the default', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token', defaultValue: 'the-default' },
+        ],
+        variables: varsWith(variable({ key: 'api_token', value: '' })),
+      }),
+    );
+
+    expect(result.parameters).toEqual({ token: 'the-default' });
+  });
+
+  // The blank rule is widened past `installerVariables.ts:91-95`'s `=== ''`
+  // to whitespace-only (plan §2.1): '   ' would otherwise ship as a
+  // BREEZE_PARAM_* value that looks set but carries nothing.
+  it('treats a WHITESPACE-ONLY source value as blank', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token', defaultValue: 'the-default' },
+        ],
+        variables: varsWith(variable({ key: 'api_token', value: '   \t\n ' })),
+      }),
+    );
+
+    expect(result.parameters).toEqual({ token: 'the-default' });
+  });
+
+  it('treats a whitespace-only DEFAULT as no default at all', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [
+          { name: 'token', type: 'string', required: true, source: 'tenantVariable', variableKey: 'absent', defaultValue: '  ' },
+        ],
+        variables: varsWith(),
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+  });
+
+  it('OMITS an optional bound parameter that resolves to nothing (never an empty value)', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'absent' },
+          { name: 'other', type: 'string', source: 'runtime' },
+        ],
+        callerParameters: { other: 'kept' },
+        variables: varsWith(),
+      }),
+    );
+
+    expect(result.parameters).toEqual({ other: 'kept' });
+    expect(result.parameters).not.toHaveProperty('token');
+  });
+
+  it('FAILS the device for a required bound parameter with no source value and no default', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [
+          { name: 'token', type: 'string', required: true, source: 'tenantVariable', variableKey: 'absent' },
+        ],
+        variables: varsWith(),
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+    expect(result.error).toContain('token');
+  });
+
+  it('does NOT use a caller value to satisfy a required bound parameter', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [
+          { name: 'token', type: 'string', required: true, source: 'tenantVariable', variableKey: 'absent' },
+        ],
+        callerParameters: { token: 'caller-supplied' },
+        variables: varsWith(),
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+    expect(result.ignoredParameters).toEqual(['token']);
+  });
+});
+
+describe('resolveSourcedParameters — RUNTIME precedence (caller -> default -> missing)', () => {
+  it('uses the caller value over the definition default', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'level', type: 'string', source: 'runtime', defaultValue: 'info' }],
+        callerParameters: { level: 'debug' },
+      }),
+    );
+
+    expect(result.parameters).toEqual({ level: 'debug' });
+  });
+
+  it('applies the definition default when the caller supplied nothing', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'level', type: 'string', source: 'runtime', defaultValue: 'info' }],
+      }),
+    );
+
+    expect(result.parameters).toEqual({ level: 'info' });
+  });
+
+  it('treats an explicit null as absent and falls through to the default', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'level', type: 'string', source: 'runtime', defaultValue: 'info' }],
+        callerParameters: { level: null },
+      }),
+    );
+
+    expect(result.parameters).toEqual({ level: 'info' });
+  });
+
+  it('preserves a non-string caller value (canonicalization happens later, at dispatch)', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'count', type: 'number', source: 'runtime' }],
+        callerParameters: { count: 3 },
+      }),
+    );
+
+    expect(result.parameters).toEqual({ count: 3 });
+  });
+
+  it('OMITS an optional runtime parameter with neither a caller value nor a default', () => {
+    const result = expectOk(
+      resolve({ definitions: [{ name: 'level', type: 'string', source: 'runtime' }] }),
+    );
+
+    expect(result.parameters).toEqual({});
+  });
+
+  it('FAILS the device for a required runtime parameter with neither', () => {
+    const result = expectFailed(
+      resolve({ definitions: [{ name: 'level', type: 'string', required: true, source: 'runtime' }] }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+    expect(result.error).toContain('level');
+  });
+
+  // `required` is evaluated AFTER precedence, never before (plan §2.1) — a
+  // default satisfies it, so a required parameter with a default never fails.
+  it('satisfies `required` from the default rather than failing', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'level', type: 'string', required: true, source: 'runtime', defaultValue: 'info' }],
+      }),
+    );
+
+    expect(result.parameters).toEqual({ level: 'info' });
+  });
+
+  it('defaults `source` to runtime for a legacy definition that carries no source key', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'level', type: 'string', defaultValue: 'info' }],
+        callerParameters: { level: 'debug' },
+      }),
+    );
+
+    expect(result.parameters).toEqual({ level: 'debug' });
+    expect(result.ignoredParameters).toEqual([]);
+  });
+});
+
+// Plan §2.4 — the subtle one. A secret target is a POLICY DENIAL, not
+// "missing": falling back to the default, honouring a caller value, or
+// omitting the parameter would each silently bypass an operator's deliberate
+// reclassification of that variable as secret.
+describe('resolveSourcedParameters — secret denial', () => {
+  const secretDefinition = (extra: Record<string, unknown> = {}) => ({
+    name: 'token',
+    type: 'string',
+    source: 'tenantVariable',
+    variableKey: 'api_token',
+    ...extra,
+  });
+
+  it('fails the device rather than falling back to the definition default', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [secretDefinition({ defaultValue: 'the-default' })],
+        variables: varsWith(variable({ key: 'api_token', value: 'sup3r-s3cret', isSecret: true })),
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+    expect(result.error).toMatch(/secret/i);
+    // The proof that this is a denial and not a "missing" fallthrough.
+    expect(result.error).not.toContain('the-default');
+  });
+
+  it('fails even when the parameter is OPTIONAL (not omitted)', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [secretDefinition({ required: false })],
+        variables: varsWith(variable({ key: 'api_token', value: 'sup3r-s3cret', isSecret: true })),
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+    expect(result.error).toMatch(/secret/i);
+  });
+
+  it('fails even when the caller supplied a value for the key', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [secretDefinition()],
+        callerParameters: { token: 'caller-supplied' },
+        variables: varsWith(variable({ key: 'api_token', value: 'sup3r-s3cret', isSecret: true })),
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+    expect(result.error).not.toContain('caller-supplied');
+  });
+
+  it('names the parameter key and the variable key, never the secret value', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [secretDefinition({ defaultValue: 'the-default' })],
+        variables: varsWith(variable({ key: 'api_token', value: 'sup3r-s3cret', isSecret: true })),
+      }),
+    );
+
+    expect(result.error).toContain('token');
+    expect(result.error).toContain('api_token');
+    expect(result.error).not.toContain('sup3r-s3cret');
+  });
+
+  it('reports a secret denial and a genuine missing parameter distinctly in one pass', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [
+          secretDefinition(),
+          { name: 'gone', type: 'string', required: true, source: 'tenantVariable', variableKey: 'absent' },
+        ],
+        variables: varsWith(variable({ key: 'api_token', value: 'sup3r-s3cret', isSecret: true })),
+      }),
+    );
+
+    expect(result.error).toMatch(/secret/i);
+    expect(result.error).toContain('gone');
+    expect(result.error).not.toContain('sup3r-s3cret');
+  });
+});
+
+// Plan §2.2 — ignored, not rejected. A stored automation action is validated
+// without consulting the referenced script's definitions, so a hard reject
+// would turn a previously-valid automation into a delayed runtime failure the
+// moment a script author flips a parameter to bound.
+describe('resolveSourcedParameters — caller override of a bound key', () => {
+  it('drops the caller value, reports the key, and still succeeds', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' },
+          { name: 'site', type: 'string', source: 'builtin', builtinKey: 'site.id' },
+        ],
+        callerParameters: { token: 'caller-supplied', site: 'caller-site', free: 'kept' },
+        variables: varsWith(variable({ key: 'api_token', value: 'from-variable' })),
+      }),
+    );
+
+    expect(result.parameters).toEqual({ token: 'from-variable', site: 'site-1', free: 'kept' });
+    expect(result.ignoredParameters).toEqual(['token', 'site']);
+    expect(JSON.stringify(result.parameters)).not.toContain('caller-supplied');
+  });
+
+  it('reports nothing when the caller supplied only runtime keys', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' },
+          { name: 'level', type: 'string', source: 'runtime' },
+        ],
+        callerParameters: { level: 'debug' },
+        variables: varsWith(variable({ key: 'api_token', value: 'from-variable' })),
+      }),
+    );
+
+    expect(result.ignoredParameters).toEqual([]);
+  });
+});
+
+describe('resolveSourcedParameters — the four sources', () => {
+  it('resolves a deviceCustomField binding from the device JSONB', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'lic', type: 'string', source: 'deviceCustomField', fieldKey: 'license_key' }],
+      }),
+    );
+
+    expect(result.parameters).toEqual({ lic: 'LK-1' });
+  });
+
+  it('treats an absent custom field as missing', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [
+          { name: 'lic', type: 'string', required: true, source: 'deviceCustomField', fieldKey: 'not_present' },
+        ],
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+  });
+
+  it('treats a whitespace-only custom field as blank', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'lic', type: 'string', source: 'deviceCustomField', fieldKey: 'blank_field', defaultValue: 'fallback' },
+        ],
+      }),
+    );
+
+    expect(result.parameters).toEqual({ lic: 'fallback' });
+  });
+
+  // `[object Object]` in a BREEZE_PARAM_* env var is worse than reporting the
+  // parameter unresolved, so a non-primitive JSONB value counts as blank.
+  it('treats an OBJECT custom field value as blank rather than stringifying it', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'lic', type: 'string', source: 'deviceCustomField', fieldKey: 'object_field', defaultValue: 'fallback' },
+        ],
+      }),
+    );
+
+    expect(result.parameters).toEqual({ lic: 'fallback' });
+  });
+
+  it('treats a null customFields column as having no fields', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'lic', type: 'string', source: 'deviceCustomField', fieldKey: 'license_key', defaultValue: 'fallback' },
+        ],
+        device: { ...DEVICE, customFields: null },
+      }),
+    );
+
+    expect(result.parameters).toEqual({ lic: 'fallback' });
+  });
+
+  it('resolves all five builtin keys', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'org_name', type: 'string', source: 'builtin', builtinKey: 'org.name' },
+          { name: 'org_id', type: 'string', source: 'builtin', builtinKey: 'org.id' },
+          { name: 'site_name', type: 'string', source: 'builtin', builtinKey: 'site.name' },
+          { name: 'site_id', type: 'string', source: 'builtin', builtinKey: 'site.id' },
+          { name: 'host', type: 'string', source: 'builtin', builtinKey: 'device.hostname' },
+        ],
+        names: { orgName: 'Acme Corp', siteName: 'Headquarters' },
+      }),
+    );
+
+    expect(result.parameters).toEqual({
+      org_name: 'Acme Corp',
+      org_id: 'org-a',
+      site_name: 'Headquarters',
+      site_id: 'site-1',
+      host: 'WKS-014',
+    });
+  });
+
+  it('treats a site builtin on a site-less device as missing, not as an empty value', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [
+          { name: 'site_id', type: 'string', required: true, source: 'builtin', builtinKey: 'site.id' },
+        ],
+        device: { ...DEVICE, siteId: null },
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+  });
+
+  it('treats an unavailable org name as missing rather than throwing', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'org_name', type: 'string', source: 'builtin', builtinKey: 'org.name', defaultValue: 'unknown-org' },
+        ],
+        names: {},
+      }),
+    );
+
+    expect(result.parameters).toEqual({ org_name: 'unknown-org' });
+  });
+});
+
+describe('resolveSourcedParameters — unknown and absent definitions', () => {
+  it('passes caller parameters through untouched when the script declares none', () => {
+    for (const definitions of [[], null, undefined, 'not-an-array']) {
+      const result = expectOk(resolve({ definitions, callerParameters: { a: '1', b: 2 } }));
+      expect(result.parameters).toEqual({ a: '1', b: 2 });
+      expect(result.bindings).toEqual([]);
+    }
+  });
+
+  it('leaves a caller parameter with no matching definition alone', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'level', type: 'string', source: 'runtime' }],
+        callerParameters: { level: 'debug', undeclared: 'still-here' },
+      }),
+    );
+
+    expect(result.parameters).toEqual({ level: 'debug', undeclared: 'still-here' });
+  });
+
+  // `scripts.parameters` was `z.any()` before this PR, so live databases hold
+  // definition lists that do not satisfy the new schema. An unparseable
+  // UNBOUND element is ignored (nothing validated it before either) — but an
+  // unparseable BOUND one must never be downgraded to "the caller may supply
+  // it", which is what silently discarding it would do.
+  it('ignores an unparseable definition that declares no binding', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'junk' }, { name: 'level', type: 'string', source: 'runtime' }],
+        callerParameters: { level: 'debug', junk: 'passthrough' },
+      }),
+    );
+
+    expect(result.parameters).toEqual({ level: 'debug', junk: 'passthrough' });
+  });
+
+  it('FAILS the device on an unparseable definition that declares a BOUND source', () => {
+    const result = expectFailed(
+      resolve({
+        // `tenantVariable` with no `variableKey` — unresolvable by construction.
+        definitions: [{ name: 'token', type: 'string', source: 'tenantVariable' }],
+        callerParameters: { token: 'caller-supplied' },
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+    expect(result.error).toContain('token');
+  });
+
+  it('throws (call-site programming error) when a tenantVariable binding gets no variables map', () => {
+    expect(() =>
+      resolve({
+        definitions: [{ name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' }],
+      }),
+    ).toThrow(/variables map is required/i);
+  });
+
+  it('needs no variables map for the non-tenantVariable sources', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'host', type: 'string', source: 'builtin', builtinKey: 'device.hostname' },
+          { name: 'lic', type: 'string', source: 'deviceCustomField', fieldKey: 'license_key' },
+        ],
+      }),
+    );
+
+    expect(result.parameters).toEqual({ host: 'WKS-014', lic: 'LK-1' });
+  });
+});
+
+// Plan §3 P4 — what dispatch is allowed to PERSIST about a binding.
+describe('resolveSourcedParameters — binding descriptors', () => {
+  it('records tenant-variable identity and version, never the value', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' }],
+        variables: varsWith(
+          variable({ key: 'api_token', value: 'from-variable', variableId: 'tv-1', version: 9, ownerScope: 'partner' }),
+        ),
+      }),
+    );
+
+    expect(result.bindings).toEqual([
+      { key: 'token', source: 'tenantVariable', variableId: 'tv-1', ownerScope: 'partner', version: 9 },
+    ]);
+    expect(JSON.stringify(result.bindings)).not.toContain('from-variable');
+  });
+
+  it('records the other bound sources by key and source alone', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'lic', type: 'string', source: 'deviceCustomField', fieldKey: 'license_key' },
+          { name: 'host', type: 'string', source: 'builtin', builtinKey: 'device.hostname' },
+        ],
+      }),
+    );
+
+    expect(result.bindings).toEqual([
+      { key: 'lic', source: 'deviceCustomField' },
+      { key: 'host', source: 'builtin' },
+    ]);
+    expect(JSON.stringify(result.bindings)).not.toContain('LK-1');
+    expect(JSON.stringify(result.bindings)).not.toContain('WKS-014');
+  });
+
+  it('emits no descriptor for a runtime parameter (its value is already persisted as a value)', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'level', type: 'string', source: 'runtime' }],
+        callerParameters: { level: 'debug' },
+      }),
+    );
+
+    expect(result.bindings).toEqual([]);
+  });
+
+  it('still records the binding when the value came from the default', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'absent', defaultValue: 'the-default' },
+        ],
+        variables: varsWith(),
+      }),
+    );
+
+    expect(result.bindings).toEqual([{ key: 'token', source: 'tenantVariable' }]);
+  });
+});
+
+describe('hasTenantVariableBoundParameters', () => {
+  it('detects a tenantVariable binding', () => {
+    expect(hasTenantVariableBoundParameters([{ name: 'x', type: 'string', source: 'tenantVariable', variableKey: 'k' }])).toBe(true);
+  });
+
+  it('is false for the other sources and for legacy definitions', () => {
+    expect(hasTenantVariableBoundParameters([{ name: 'x', type: 'string' }])).toBe(false);
+    expect(hasTenantVariableBoundParameters([{ name: 'x', type: 'string', source: 'builtin', builtinKey: 'org.id' }])).toBe(false);
+    expect(hasTenantVariableBoundParameters(null)).toBe(false);
+    expect(hasTenantVariableBoundParameters('nonsense')).toBe(false);
+  });
+
+  // The gate it feeds guards a CHEAP action, so the failure to avoid is a
+  // false NEGATIVE: one unparseable sibling must not hide a real binding.
+  it('still detects a binding when a SIBLING definition is unparseable', () => {
+    expect(
+      hasTenantVariableBoundParameters([
+        { name: 'junk' },
+        { name: 'x', type: 'string', source: 'tenantVariable', variableKey: 'k' },
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe('scriptNeedsVariableScope (plan §3 P1)', () => {
+  it('is true for a script whose CONTENT carries a {{var.*}} token', () => {
+    expect(scriptNeedsVariableScope({ content: 'curl {{var.repo_url}}', parameters: [] })).toBe(true);
+  });
+
+  // The gap this predicate exists to close: the binding is in
+  // `scripts.parameters`, so a content-only gate reports false here and every
+  // bound parameter then resolves against an EMPTY scope.
+  it('is true for a script with a tenantVariable-bound PARAMETER and no content token', () => {
+    expect(
+      scriptNeedsVariableScope({
+        content: 'echo hi',
+        parameters: [{ name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' }],
+      }),
+    ).toBe(true);
+  });
+
+  it('is false for a script with neither', () => {
+    expect(scriptNeedsVariableScope({ content: 'echo hi', parameters: [] })).toBe(false);
+    expect(scriptNeedsVariableScope({ content: 'echo hi', parameters: null })).toBe(false);
+    expect(
+      scriptNeedsVariableScope({
+        content: 'echo hi',
+        parameters: [{ name: 'level', type: 'string', source: 'runtime' }],
+      }),
+    ).toBe(false);
+  });
+
+  it('tolerates a null content column', () => {
+    expect(scriptNeedsVariableScope({ content: null, parameters: null })).toBe(false);
+  });
+});
+
+describe('builtinNameContextNeeds', () => {
+  it('asks for a lookup only for the two NAME builtins', () => {
+    expect(
+      builtinNameContextNeeds([
+        { name: 'a', type: 'string', source: 'builtin', builtinKey: 'org.id' },
+        { name: 'b', type: 'string', source: 'builtin', builtinKey: 'site.id' },
+        { name: 'c', type: 'string', source: 'builtin', builtinKey: 'device.hostname' },
+      ]),
+    ).toEqual({ orgName: false, siteName: false });
+
+    expect(
+      builtinNameContextNeeds([{ name: 'a', type: 'string', source: 'builtin', builtinKey: 'org.name' }]),
+    ).toEqual({ orgName: true, siteName: false });
+
+    expect(
+      builtinNameContextNeeds([{ name: 'a', type: 'string', source: 'builtin', builtinKey: 'site.name' }]),
+    ).toEqual({ orgName: false, siteName: true });
+  });
+
+  it('asks for nothing when there is no builtin binding at all', () => {
+    expect(builtinNameContextNeeds([{ name: 'a', type: 'string', source: 'runtime' }])).toEqual({
+      orgName: false,
+      siteName: false,
+    });
+    expect(builtinNameContextNeeds(null)).toEqual({ orgName: false, siteName: false });
+  });
+});

--- a/apps/api/src/services/sourcedParameters.ts
+++ b/apps/api/src/services/sourcedParameters.ts
@@ -1,0 +1,479 @@
+import {
+  hasVariableTokens,
+  SCRIPT_BUILTIN_PARAMETER_KEYS,
+  scriptParameterDefinitionSchema,
+  type ScriptBuiltinParameterKey,
+  type ScriptParameterDefinition,
+  type ScriptParameterSource,
+} from '@breeze/shared';
+
+import type { ResolvedVariable } from './tenantVariableResolution';
+
+/**
+ * Sourced script parameters (#3409 PR3) — per-device resolution of a script's
+ * parameter DEFINITIONS into the value map that reaches the agent.
+ *
+ * This module is deliberately pure: no DB access, no ambient context, no
+ * clock. Everything it needs — the device row's own columns, the org/site
+ * display names, and the already-resolved tenant-variable map for the
+ * device's org — is handed in by `scriptDispatch.ts`, which owns the loading.
+ * That is what makes the precedence table below exhaustively unit-testable
+ * without a database, and it keeps the ONE place that decides "what value
+ * does this parameter have on this device" free of any I/O that could fail
+ * halfway and leave a half-resolved map.
+ *
+ * The precedence table (plan §2.1) is the whole point of the module:
+ *
+ *   BOUND   (source !== 'runtime'):  source value -> definition default -> missing
+ *   RUNTIME (source === 'runtime'):  caller value -> definition default -> missing
+ *
+ * A caller-supplied value is NOT a candidate for a bound parameter. If it
+ * were, a binding would be a suggested default rather than an authoritative
+ * source, and an invoker could override the org's configured value simply by
+ * naming the key. The supplied value is ignored (not rejected — see
+ * {@link ResolveSourcedParametersSuccess.ignoredParameters}) and reported.
+ */
+
+/** Where `scriptDispatch` reads device-scoped sources from. */
+export interface SourcedParameterDevice {
+  id: string;
+  orgId: string;
+  hostname: string | null;
+  siteId: string | null;
+  /** `devices.custom_fields`, raw JSONB — arbitrary shape until proven otherwise. */
+  customFields: unknown;
+}
+
+/**
+ * The two builtin values that are NOT columns on the device row and therefore
+ * need a lookup the caller performs. Both are optional: a script with no
+ * `org.name` / `site.name` binding never causes the lookup, and an absent
+ * name resolves as missing (default -> required check) rather than throwing.
+ */
+export interface SourcedParameterNameContext {
+  orgName?: string | null;
+  siteName?: string | null;
+}
+
+/**
+ * What dispatch PERSISTS about a bound parameter — identity, never value
+ * (plan §3 P4). A resolved value exists only in the command payload that
+ * reaches the agent; putting one in `script_executions.parameters` would, in
+ * PR4, mean persisting a resolved secret, which is exactly the leak the
+ * separate delivery channel exists to prevent.
+ *
+ * Emitted only for BOUND parameters. A runtime parameter's value is already
+ * persisted as a value (it is caller input, in the caller's trust domain), so
+ * a descriptor for it would carry no information.
+ */
+export interface ScriptParameterBindingDescriptor {
+  key: string;
+  source: ScriptParameterSource;
+  /** Present only when the value actually came from a tenant_variables row. */
+  variableId?: string;
+  ownerScope?: 'organization' | 'partner';
+  version?: number;
+}
+
+export interface ResolveSourcedParametersInput {
+  /** `scripts.parameters` exactly as stored — unvalidated jsonb. */
+  definitions: unknown;
+  /** The invoker's parameter map (`input.parameters ?? {}` at the dispatch seam). */
+  callerParameters: Record<string, unknown>;
+  device: SourcedParameterDevice;
+  names?: SourcedParameterNameContext;
+  /**
+   * The tenant-variable map for THIS device's org — i.e. `resolveForOrg(scope,
+   * device.orgId)`. Required only when a `tenantVariable` binding is present;
+   * an absent map with such a binding is a programming error at the call site
+   * and throws, matching the content-substitution path's contract.
+   */
+  variables?: ReadonlyMap<string, ResolvedVariable>;
+}
+
+export interface ResolveSourcedParametersSuccess {
+  ok: true;
+  /** The map that goes on the wire — caller runtime values plus resolved bound values. */
+  parameters: Record<string, string | number | boolean>;
+  /** Identity-only record of the bound parameters, for `script_executions`. */
+  bindings: ScriptParameterBindingDescriptor[];
+  /** Bound keys the caller supplied a value for. Ignored, never rejected (plan §2.2). */
+  ignoredParameters: string[];
+}
+
+export interface ResolveSourcedParametersFailure {
+  ok: false;
+  /**
+   * Deliberately DISTINCT from PR2's `unresolved_variables`: a parameter
+   * binding failing is not the same operational condition as a `{{var.*}}`
+   * token in the content failing, and conflating them would make the two
+   * indistinguishable in execution history.
+   */
+  code: 'unresolved_parameters';
+  /** Names KEYS only, never values — this string reaches `script_executions.error_message`. */
+  error: string;
+  ignoredParameters: string[];
+}
+
+export type ResolveSourcedParametersResult =
+  | ResolveSourcedParametersSuccess
+  | ResolveSourcedParametersFailure;
+
+/**
+ * Reserved key under which the binding descriptors ride inside the existing
+ * `script_executions.parameters` jsonb.
+ *
+ * Chosen over a new sibling column because PR3 ships NO migration (plan §7) —
+ * and a new column on an org-cascade table is not a free action here: it
+ * would also require a `CORE_TENANT_EXPORT_POLICY` classification, which is
+ * the registration step this repo has shipped bugs on five times.
+ *
+ * `$` cannot begin a parameter name (`SCRIPT_PARAMETER_KEY_PATTERN` requires
+ * `[A-Za-z_]` first), so this key can never collide with a real parameter,
+ * and readers that render the map as key/value pairs see one extra,
+ * obviously-reserved entry rather than a corrupted parameter.
+ */
+export const EXECUTION_PARAMETER_BINDINGS_KEY = '$bindings';
+
+/**
+ * Blank rule, mirroring the installer resolver (`installerVariables.ts:91-95`)
+ * and widened by plan §2.1 to whitespace-only: a device must never ship a
+ * parameter whose value is a blank segment, so `null`, absent, `''` and
+ * `'   '` are all "no value" and fall through to the next precedence step.
+ *
+ * Non-primitive JSONB (an object or array in `custom_fields`) also counts as
+ * blank: `String(value)` on it produces `[object Object]`, and injecting that
+ * into a `BREEZE_PARAM_*` env var is worse than reporting the parameter
+ * unresolved.
+ */
+function toNonBlankString(value: unknown): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === 'object') return undefined;
+  if (typeof value === 'function' || typeof value === 'symbol') return undefined;
+  const asString = String(value);
+  return asString.trim() === '' ? undefined : asString;
+}
+
+/** A definition element we could not parse, retained so a BOUND one can fail loudly. */
+interface MalformedDefinition {
+  name: string | null;
+  boundSource: string | null;
+}
+
+interface ParsedDefinitions {
+  definitions: ScriptParameterDefinition[];
+  malformed: MalformedDefinition[];
+}
+
+function readSource(element: unknown): string | null {
+  if (element === null || typeof element !== 'object') return null;
+  const source = (element as { source?: unknown }).source;
+  return typeof source === 'string' ? source : null;
+}
+
+function readName(element: unknown): string | null {
+  if (element === null || typeof element !== 'object') return null;
+  const name = (element as { name?: unknown }).name;
+  return typeof name === 'string' ? name : null;
+}
+
+/**
+ * Parse the stored definition list ELEMENT BY ELEMENT rather than through
+ * `scriptParameterDefinitionsSchema` as a whole.
+ *
+ * `scripts.parameters` was `z.any()` until this PR, so a live database
+ * contains definition lists that do not satisfy the new schema. Parsing the
+ * whole array would make one malformed legacy element (say, a stray
+ * `{name:'x'}` with no `type`) discard EVERY definition in the list —
+ * including a `tenantVariable` binding to a secret, whose whole purpose is to
+ * deny. Per element instead:
+ *
+ * - parses           -> honoured normally
+ * - fails, unbound   -> ignored, exactly as before PR3 (nothing validated it then either)
+ * - fails, BOUND     -> fails the device; a binding we cannot read is never
+ *                       silently downgraded to "the caller may supply it"
+ *
+ * The array-level rules the full schema adds (length cap, env-var collision
+ * `superRefine`) are save-time concerns, already enforced at the route; they
+ * would only cause a dispatch-time false failure if applied here.
+ */
+function parseDefinitions(value: unknown): ParsedDefinitions {
+  if (!Array.isArray(value)) return { definitions: [], malformed: [] };
+
+  const definitions: ScriptParameterDefinition[] = [];
+  const malformed: MalformedDefinition[] = [];
+  for (const element of value) {
+    const parsed = scriptParameterDefinitionSchema.safeParse(element);
+    if (parsed.success) {
+      definitions.push(parsed.data);
+      continue;
+    }
+    const source = readSource(element);
+    malformed.push({
+      name: readName(element),
+      boundSource: source !== null && source !== 'runtime' ? source : null,
+    });
+  }
+  return { definitions, malformed };
+}
+
+/**
+ * Does this script's stored definition list contain a `tenantVariable`
+ * binding?
+ *
+ * Deliberately tolerant — it scans raw elements rather than requiring the
+ * whole list to parse. This predicate gates a CHEAP action (loading the
+ * variable scope), so the failure it must avoid is a false negative: a list
+ * with one unparseable element must not cause every binding in it to resolve
+ * against an empty scope.
+ */
+export function hasTenantVariableBoundParameters(parameters: unknown): boolean {
+  if (!Array.isArray(parameters)) return false;
+  return parameters.some((element) => readSource(element) === 'tenantVariable');
+}
+
+/**
+ * The extended scope-preload gate (plan §3 P1).
+ *
+ * `hasVariableTokens(script.content)` alone is not sufficient once parameters
+ * can bind to tenant variables: a binding lives in `scripts.parameters`, not
+ * in the content, so a content-only gate passes `[]` to
+ * `loadTenantVariableScope`, every bound parameter then resolves against an
+ * EMPTY scope, and the device fails with "no value set" for a variable that
+ * exists. Silent, and indistinguishable from a genuinely-unset variable.
+ *
+ * Used at all three preload sites: `scriptExecution.ts` (route fan-out),
+ * `aiToolsScripts.ts` (AI run_script) and `loadAutomationRunVariableScope`
+ * (automation runs).
+ */
+export function scriptNeedsVariableScope(script: {
+  content?: string | null;
+  parameters?: unknown;
+}): boolean {
+  return hasVariableTokens(script.content ?? '') || hasTenantVariableBoundParameters(script.parameters);
+}
+
+/**
+ * Which builtin names the caller must look up before resolving. `org.id`,
+ * `site.id` and `device.hostname` come off the device row for free; only the
+ * two display names cost a query, so dispatch skips both queries entirely for
+ * the overwhelming majority of scripts.
+ */
+export function builtinNameContextNeeds(definitions: unknown): { orgName: boolean; siteName: boolean } {
+  if (!Array.isArray(definitions)) return { orgName: false, siteName: false };
+  let orgName = false;
+  let siteName = false;
+  for (const element of definitions) {
+    if (readSource(element) !== 'builtin') continue;
+    const key = (element as { builtinKey?: unknown }).builtinKey;
+    if (key === 'org.name') orgName = true;
+    if (key === 'site.name') siteName = true;
+  }
+  return { orgName, siteName };
+}
+
+function resolveBuiltin(
+  key: ScriptBuiltinParameterKey,
+  device: SourcedParameterDevice,
+  names: SourcedParameterNameContext,
+): unknown {
+  switch (key) {
+    case 'org.name':
+      return names.orgName;
+    case 'org.id':
+      return device.orgId;
+    case 'site.name':
+      return names.siteName;
+    case 'site.id':
+      return device.siteId;
+    case 'device.hostname':
+      return device.hostname;
+  }
+}
+
+function readCustomField(customFields: unknown, fieldKey: string): unknown {
+  if (customFields === null || typeof customFields !== 'object' || Array.isArray(customFields)) return undefined;
+  return (customFields as Record<string, unknown>)[fieldKey];
+}
+
+/** One bound parameter's source lookup, before default fallback. */
+type SourceLookup =
+  | { kind: 'value'; value: string; descriptor: ScriptParameterBindingDescriptor }
+  | { kind: 'missing' }
+  | { kind: 'secret'; variableKey: string };
+
+function lookupBoundSource(
+  definition: Exclude<ScriptParameterDefinition, { source: 'runtime' }>,
+  input: ResolveSourcedParametersInput,
+): SourceLookup {
+  switch (definition.source) {
+    case 'tenantVariable': {
+      if (!input.variables) {
+        throw new Error(
+          'variables map is required to dispatch a script with a tenantVariable-bound parameter',
+        );
+      }
+      const variable = input.variables.get(definition.variableKey);
+      if (!variable) return { kind: 'missing' };
+      // PLAN §2.4 — a secret target is a POLICY DENIAL, not "missing". It must
+      // not fall through to the definition default (which would silently
+      // substitute a stale plaintext an operator deliberately reclassified),
+      // must not fall back to a caller value, and must not be omitted. PR4
+      // adds the out-of-band channel; until then the device fails.
+      if (variable.isSecret) return { kind: 'secret', variableKey: definition.variableKey };
+      const value = toNonBlankString(variable.value);
+      if (value === undefined) return { kind: 'missing' };
+      return {
+        kind: 'value',
+        value,
+        descriptor: {
+          key: definition.name,
+          source: 'tenantVariable',
+          variableId: variable.variableId,
+          ownerScope: variable.ownerScope,
+          version: variable.version,
+        },
+      };
+    }
+    case 'deviceCustomField': {
+      const value = toNonBlankString(readCustomField(input.device.customFields, definition.fieldKey));
+      if (value === undefined) return { kind: 'missing' };
+      return { kind: 'value', value, descriptor: { key: definition.name, source: 'deviceCustomField' } };
+    }
+    case 'builtin': {
+      const value = toNonBlankString(resolveBuiltin(definition.builtinKey, input.device, input.names ?? {}));
+      if (value === undefined) return { kind: 'missing' };
+      return { kind: 'value', value, descriptor: { key: definition.name, source: 'builtin' } };
+    }
+  }
+}
+
+/**
+ * Resolve one device's parameter map. Never throws for a per-device
+ * condition — an unresolvable REQUIRED parameter fails THAT device
+ * (`{ok:false}`) so the fan-out continues, exactly like the content-token
+ * path. The only throw is a call-site programming error (a
+ * `tenantVariable` binding with no variables map), which is not a per-device
+ * condition and must not be swallowed.
+ */
+export function resolveSourcedParameters(
+  input: ResolveSourcedParametersInput,
+): ResolveSourcedParametersResult {
+  const { definitions, malformed } = parseDefinitions(input.definitions);
+
+  const parameters: Record<string, unknown> = { ...input.callerParameters };
+  const bindings: ScriptParameterBindingDescriptor[] = [];
+  const ignoredParameters: string[] = [];
+  const missing: string[] = [];
+  const secretDenied: Array<{ key: string; variableKey: string }> = [];
+
+  for (const definition of definitions) {
+    const name = definition.name;
+    // The definition owns this key from here on: whatever the caller sent is
+    // either the runtime candidate (below) or discarded. Deleting first means
+    // every "missing, optional" path lands on "omit the parameter" without a
+    // second delete at each branch.
+    const callerValue = Object.prototype.hasOwnProperty.call(input.callerParameters, name)
+      ? input.callerParameters[name]
+      : undefined;
+    delete parameters[name];
+
+    let resolved: string | number | boolean | undefined;
+
+    if (definition.source === 'runtime') {
+      // "Explicit invoker value" (plan §2.1) — key present with a non-nullish
+      // value. Note the blank rule is NOT applied here: it is specified for
+      // bound sources, and treating an explicitly-supplied '' as missing
+      // would silently change what today's callers already dispatch.
+      if (callerValue !== undefined && callerValue !== null) {
+        resolved = callerValue as string | number | boolean;
+      }
+    } else {
+      if (callerValue !== undefined) ignoredParameters.push(name);
+      const lookup = lookupBoundSource(definition, input);
+      if (lookup.kind === 'secret') {
+        secretDenied.push({ key: name, variableKey: lookup.variableKey });
+        continue; // no default, no caller value, no omission — the device fails
+      }
+      if (lookup.kind === 'value') {
+        resolved = lookup.value;
+        bindings.push(lookup.descriptor);
+      }
+    }
+
+    if (resolved === undefined) {
+      const fallback = toNonBlankString(definition.defaultValue);
+      if (fallback !== undefined) {
+        resolved = fallback;
+        if (definition.source !== 'runtime') {
+          bindings.push({ key: name, source: definition.source });
+        }
+      }
+    }
+
+    // `required` is evaluated AFTER precedence, never before (plan §2.1).
+    if (resolved === undefined) {
+      if (definition.required) missing.push(name);
+      continue;
+    }
+    parameters[name] = resolved;
+  }
+
+  // A definition we could not parse but that clearly declares a BOUND source
+  // cannot be honoured, and downgrading it to "caller may supply it" would
+  // undo the binding's authority. Fail the device instead.
+  const malformedBound = malformed.filter((entry) => entry.boundSource !== null);
+
+  if (missing.length > 0 || secretDenied.length > 0 || malformedBound.length > 0) {
+    return {
+      ok: false,
+      code: 'unresolved_parameters',
+      error: describeParameterFailure(missing, secretDenied, malformedBound),
+      ignoredParameters,
+    };
+  }
+
+  return {
+    ok: true,
+    parameters: parameters as Record<string, string | number | boolean>,
+    bindings,
+    ignoredParameters,
+  };
+}
+
+const quoteList = (values: string[]): string => values.map((value) => `"${value}"`).join(', ');
+
+/**
+ * User-facing failure text. Carries parameter KEY NAMES and tenant-variable
+ * KEYS only — never a resolved value, secret or otherwise — because this
+ * string is written to `script_executions.error_message` and rendered in the
+ * UI.
+ */
+function describeParameterFailure(
+  missing: string[],
+  secretDenied: Array<{ key: string; variableKey: string }>,
+  malformedBound: MalformedDefinition[],
+): string {
+  const parts: string[] = [];
+  if (missing.length > 0) {
+    parts.push(`no value for required parameter(s) ${quoteList(missing)}`);
+  }
+  if (secretDenied.length > 0) {
+    parts.push(
+      `${quoteList(secretDenied.map((entry) => entry.key))} ${
+        secretDenied.length === 1 ? 'is bound to secret tenant variable' : 'are bound to secret tenant variables'
+      } ${quoteList(secretDenied.map((entry) => entry.variableKey))}, which cannot be used in script parameters`,
+    );
+  }
+  if (malformedBound.length > 0) {
+    parts.push(
+      `invalid ${quoteList(malformedBound.map((entry) => entry.boundSource ?? 'unknown'))} binding on parameter(s) ${quoteList(
+        malformedBound.map((entry) => entry.name ?? '<unnamed>'),
+      )}`,
+    );
+  }
+  return `Unresolved script parameter(s): ${parts.join('; ')}`;
+}
+
+/** Re-exported so a caller can validate a builtin key without reaching into shared. */
+export { SCRIPT_BUILTIN_PARAMETER_KEYS };

--- a/apps/api/src/services/tenantVariableResolution.test.ts
+++ b/apps/api/src/services/tenantVariableResolution.test.ts
@@ -125,7 +125,8 @@ function mapWith(entry: Partial<ResolvedVariable> & { key: string }): Map<string
         value: entry.value ?? 'v',
         isSecret: entry.isSecret ?? false,
         variableId: entry.variableId ?? ROW_ORG,
-        version: entry.version ?? 1
+        version: entry.version ?? 1,
+        ownerScope: entry.ownerScope ?? 'organization'
       }
     ]
   ]);
@@ -166,6 +167,20 @@ describe('loadTenantVariableScope', () => {
     stubSelect([encryptedRow(ROW_PARTNER, 'partner-value', { key: 'k', ownerOrgId: null, forOrgId: ORG_A })]);
     const scope = await loadTenantVariableScope([ORG_A]);
     expect(resolveForOrg(scope, ORG_A).get('k')?.value).toBe('partner-value');
+  });
+
+  // #3409 PR3 carries `ownerScope` on every resolved row so a persisted
+  // binding descriptor can say WHICH axis a device actually resolved on —
+  // `variableId` alone can't, once an org override shadows a partner-wide
+  // row of the same key.
+  it('tags each resolved row with the axis it was owned on', async () => {
+    stubSelect([
+      encryptedRow(ROW_PARTNER, 'partner-value', { key: 'inherited', ownerOrgId: null, forOrgId: ORG_A }),
+      encryptedRow(ROW_ORG, 'org-value', { key: 'overridden', ownerOrgId: ORG_A, forOrgId: ORG_A })
+    ]);
+    const resolved = resolveForOrg(await loadTenantVariableScope([ORG_A]), ORG_A);
+    expect(resolved.get('inherited')?.ownerScope).toBe('partner');
+    expect(resolved.get('overridden')?.ownerScope).toBe('organization');
   });
 
   it('never leaks another org value into this org resolution', async () => {
@@ -247,8 +262,8 @@ describe('substituteTenantVariables', () => {
 
   it('mixes a resolved, a missing, and a secret key correctly in one pass', () => {
     const resolved = new Map<string, ResolvedVariable>([
-      ['ok', { key: 'ok', value: 'fine', isSecret: false, variableId: ROW_ORG, version: 1 }],
-      ['sekret', { key: 'sekret', value: 'nope', isSecret: true, variableId: ROW_SECRET, version: 1 }]
+      ['ok', { key: 'ok', value: 'fine', isSecret: false, variableId: ROW_ORG, version: 1, ownerScope: 'organization' }],
+      ['sekret', { key: 'sekret', value: 'nope', isSecret: true, variableId: ROW_SECRET, version: 1, ownerScope: 'partner' }]
     ]);
     const out = substituteTenantVariables('{{var.ok}} {{var.sekret}} {{var.gone}}', resolved);
     expect(out.content).toBe('fine {{var.sekret}} {{var.gone}}');

--- a/apps/api/src/services/tenantVariableResolution.ts
+++ b/apps/api/src/services/tenantVariableResolution.ts
@@ -32,6 +32,16 @@ export interface ResolvedVariable {
   isSecret: boolean;
   variableId: string;
   version: number;
+  /**
+   * Which axis this row was owned on — `'partner'` for a partner-wide row
+   * (`tenant_variables.org_id IS NULL`), `'organization'` for an org override.
+   *
+   * Carried because #3409 PR3 persists a binding DESCRIPTOR (never a value)
+   * on `script_executions`, and "which variable did this device actually
+   * resolve" is not answerable from `variableId` alone once an org override
+   * can shadow a partner-wide row of the same key.
+   */
+  ownerScope: 'organization' | 'partner';
 }
 
 /**
@@ -82,7 +92,14 @@ interface RawResolvedRow {
 function decryptRow(row: RawResolvedRow): ResolvedVariable | null {
   try {
     const value = decryptTenantVariableValue(row);
-    return { key: row.key, value, isSecret: row.isSecret, variableId: row.id, version: row.version };
+    return {
+      key: row.key,
+      value,
+      isSecret: row.isSecret,
+      variableId: row.id,
+      version: row.version,
+      ownerScope: row.ownerOrgId === null ? 'partner' : 'organization'
+    };
   } catch (err) {
     console.warn('[tenant-variable-resolution] failed to decrypt tenant variable value', { id: row.id });
     return null;

--- a/apps/web/src/components/devices/ScriptPickerModal.test.tsx
+++ b/apps/web/src/components/devices/ScriptPickerModal.test.tsx
@@ -42,6 +42,37 @@ const SCRIPTS_DATA = [
       { name: 'count', type: 'number', required: false, defaultValue: '5' },
     ],
   },
+  // #3409 PR3: one runtime parameter + one bound to a tenant variable. The
+  // bound one is `required` on purpose — dispatch resolves it per device, so it
+  // must not gate the Run button here.
+  {
+    id: 'p3',
+    name: 'Mixed Params',
+    language: 'bash',
+    category: 'General',
+    osTypes: ['linux'],
+    parameters: [
+      { name: 'message', type: 'string', required: true, defaultValue: '' },
+      {
+        name: 'api_key',
+        type: 'string',
+        required: true,
+        defaultValue: 'fallback',
+        source: 'tenantVariable',
+        variableKey: 'vendor_token',
+      },
+    ],
+  },
+  {
+    id: 'p4',
+    name: 'All Bound',
+    language: 'bash',
+    category: 'General',
+    osTypes: ['linux'],
+    parameters: [
+      { name: 'org', type: 'string', required: true, source: 'builtin', builtinKey: 'org.name' },
+    ],
+  },
 ];
 
 // Live-sessions fixture (GET /devices/:id/sessions/live)
@@ -242,6 +273,66 @@ describe('ScriptPickerModal', () => {
     });
 
     expect(screen.queryByText('Configure Parameters')).toBeNull();
+  });
+});
+
+describe('ScriptPickerModal sourced parameters (#3409 PR3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse(SCRIPTS_DATA));
+  });
+
+  it('counts only runtime parameters in the list badge', async () => {
+    render(<ScriptPickerModal isOpen onClose={vi.fn()} onSelect={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('Mixed Params')).toBeDefined());
+
+    const mixedRow = screen.getByText('Mixed Params').closest('button') as HTMLElement;
+    expect(mixedRow).toHaveTextContent('1 param(s)');
+    // A fully-bound script asks for nothing, so it carries no badge at all.
+    const allBoundRow = screen.getByText('All Bound').closest('button') as HTMLElement;
+    expect(allBoundRow).not.toHaveTextContent('param(s)');
+  });
+
+  it('runs a fully-bound script immediately instead of opening an input-less step', async () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(<ScriptPickerModal isOpen onClose={onClose} onSelect={onSelect} />);
+    await waitFor(() => expect(screen.getByText('All Bound')).toBeDefined());
+
+    fireEvent.click(screen.getByText('All Bound'));
+
+    expect(screen.queryByText('Configure Parameters')).toBeNull();
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'p4' }),
+      'system',
+      undefined,
+      undefined
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows a bound parameter read-only and never sends it in the parameters map', async () => {
+    const onSelect = vi.fn();
+    render(<ScriptPickerModal isOpen onClose={vi.fn()} onSelect={onSelect} />);
+    await waitFor(() => expect(screen.getByText('Mixed Params')).toBeDefined());
+
+    fireEvent.click(screen.getByText('Mixed Params'));
+
+    // The bound parameter is visible, but as a chip — not an input, and its
+    // definition default ("fallback") must NOT be seeded into paramValues.
+    const chip = screen.getByTestId('script-bound-parameter-api_key');
+    expect(chip).toHaveTextContent('Supplied automatically from variable vendor_token');
+    expect(chip.querySelector('input')).toBeNull();
+    expect(screen.queryByDisplayValue('fallback')).toBeNull();
+
+    // Required-but-bound must not block the run.
+    fireEvent.change(screen.getByDisplayValue(''), { target: { value: 'hello' } });
+    fireEvent.click(screen.getByText('Run Script'));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    const submitted = onSelect.mock.calls[0][2] as Record<string, unknown>;
+    expect(submitted).toEqual({ message: 'hello' });
+    expect(submitted).not.toHaveProperty('api_key');
   });
 });
 

--- a/apps/web/src/components/devices/ScriptPickerModal.test.tsx
+++ b/apps/web/src/components/devices/ScriptPickerModal.test.tsx
@@ -282,18 +282,29 @@ describe('ScriptPickerModal sourced parameters (#3409 PR3)', () => {
     fetchWithAuthMock.mockResolvedValue(makeJsonResponse(SCRIPTS_DATA));
   });
 
-  it('counts only runtime parameters in the list badge', async () => {
+  it('counts only runtime parameters in the prompt badge and names the injected ones separately', async () => {
     render(<ScriptPickerModal isOpen onClose={vi.fn()} onSelect={vi.fn()} />);
     await waitFor(() => expect(screen.getByText('Mixed Params')).toBeDefined());
 
+    // "param(s)" stays the number the operator will be ASKED for; the injected
+    // ones get their own badge so neither fact is over- or under-reported.
     const mixedRow = screen.getByText('Mixed Params').closest('button') as HTMLElement;
     expect(mixedRow).toHaveTextContent('1 param(s)');
-    // A fully-bound script asks for nothing, so it carries no badge at all.
+    expect(mixedRow).toHaveTextContent('1 auto-supplied');
+
+    // A fully-bound script asks for nothing, so it carries no prompt badge —
+    // but it must not look parameterless either.
     const allBoundRow = screen.getByText('All Bound').closest('button') as HTMLElement;
     expect(allBoundRow).not.toHaveTextContent('param(s)');
+    expect(allBoundRow).toHaveTextContent('1 auto-supplied');
+
+    // A script with no parameters at all carries neither badge.
+    const noneRow = screen.getByText('No Params').closest('button') as HTMLElement;
+    expect(noneRow).not.toHaveTextContent('param(s)');
+    expect(noneRow).not.toHaveTextContent('auto-supplied');
   });
 
-  it('runs a fully-bound script immediately instead of opening an input-less step', async () => {
+  it('opens the params step for a fully-bound script and shows the injected contract', async () => {
     const onSelect = vi.fn();
     const onClose = vi.fn();
     render(<ScriptPickerModal isOpen onClose={onClose} onSelect={onSelect} />);
@@ -301,9 +312,46 @@ describe('ScriptPickerModal sourced parameters (#3409 PR3)', () => {
 
     fireEvent.click(screen.getByText('All Bound'));
 
-    expect(screen.queryByText('Configure Parameters')).toBeNull();
+    // The step is reachable, shows the chips, and fires nothing on its own.
+    expect(screen.getByText('Configure Parameters')).toBeDefined();
+    expect(screen.getByTestId('script-bound-parameter-org')).toHaveTextContent(
+      'Supplied automatically from org.name'
+    );
+    expect(screen.getByTestId('script-parameters-all-supplied')).toBeDefined();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('lets a fully-bound script be run from the params step with an empty parameters map', async () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(<ScriptPickerModal isOpen onClose={onClose} onSelect={onSelect} />);
+    await waitFor(() => expect(screen.getByText('All Bound')).toBeDefined());
+
+    fireEvent.click(screen.getByText('All Bound'));
+    // Nothing to fill in — the operator must still be able to continue.
+    fireEvent.click(screen.getByText('Run Script'));
+
+    expect(screen.queryByText(/is required/)).toBeNull();
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'p4' }),
+      'system',
+      {},
+      undefined
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('still runs a parameterless script immediately, with no params step', async () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(<ScriptPickerModal isOpen onClose={onClose} onSelect={onSelect} />);
+    await waitFor(() => expect(screen.getByText('No Params')).toBeDefined());
+
+    fireEvent.click(screen.getByText('No Params'));
+
+    expect(screen.queryByText('Configure Parameters')).toBeNull();
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'p1' }),
       'system',
       undefined,
       undefined

--- a/apps/web/src/components/devices/ScriptPickerModal.tsx
+++ b/apps/web/src/components/devices/ScriptPickerModal.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { Dialog } from '../shared/Dialog';
 import { fetchLiveSessions, type LiveSession } from '../../services/deviceActions';
-import type { ScriptParameter } from '../scripts/ScriptFormSchema';
+import { runtimeParameters, type ScriptParameter } from '../scripts/ScriptFormSchema';
 import ScriptParametersForm, { validateParameters } from '../scripts/ScriptParametersForm';
 import { fetchAllScripts } from '@/lib/scriptsFetch';
 
@@ -155,10 +155,15 @@ export default function ScriptPickerModal({
   }, [scripts, query, categoryFilter, deviceOs]);
 
   const handleSelect = (script: Script) => {
-    if (script.parameters && script.parameters.length > 0) {
+    // Runtime parameters only (#3409 PR3). A bound parameter is resolved per
+    // target device by the server, so it must neither open the parameter step
+    // on its own nor enter `paramValues` — a supplied value would be ignored
+    // and reported back in `ignoredParameters`.
+    const askable = runtimeParameters(script.parameters);
+    if (askable.length > 0) {
       // Seed param values from defaults
       const defaults: Record<string, unknown> = {};
-      for (const param of script.parameters) {
+      for (const param of askable) {
         if (param.defaultValue !== undefined) {
           if (param.type === 'number') {
             defaults[param.name] = Number(param.defaultValue) || 0;
@@ -319,9 +324,9 @@ export default function ScriptPickerModal({
                         <span>
                           {script.osTypes.join(', ')}
                         </span>
-                        {script.parameters && script.parameters.length > 0 && (
+                        {runtimeParameters(script.parameters).length > 0 && (
                           <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5">
-                            {t('scriptPickerModal.paramCount', { count: script.parameters.length })}
+                            {t('scriptPickerModal.paramCount', { count: runtimeParameters(script.parameters).length })}
                           </span>
                         )}
                       </div>

--- a/apps/web/src/components/devices/ScriptPickerModal.tsx
+++ b/apps/web/src/components/devices/ScriptPickerModal.tsx
@@ -155,35 +155,38 @@ export default function ScriptPickerModal({
   }, [scripts, query, categoryFilter, deviceOs]);
 
   const handleSelect = (script: Script) => {
-    // Runtime parameters only (#3409 PR3). A bound parameter is resolved per
-    // target device by the server, so it must neither open the parameter step
-    // on its own nor enter `paramValues` — a supplied value would be ignored
-    // and reported back in `ignoredParameters`.
-    const askable = runtimeParameters(script.parameters);
-    if (askable.length > 0) {
-      // Seed param values from defaults
-      const defaults: Record<string, unknown> = {};
-      for (const param of askable) {
-        if (param.defaultValue !== undefined) {
-          if (param.type === 'number') {
-            defaults[param.name] = Number(param.defaultValue) || 0;
-          } else if (param.type === 'boolean') {
-            defaults[param.name] = param.defaultValue === 'true';
-          } else {
-            defaults[param.name] = param.defaultValue;
-          }
-        } else {
-          defaults[param.name] = param.type === 'boolean' ? false : param.type === 'number' ? 0 : '';
-        }
-      }
-      setParamValues(defaults);
-      setSelectedScript(script);
-      setParamError(undefined);
-      setView('params');
-    } else {
+    // The parameter STEP is gated on the whole definition list: a fully-bound
+    // script asks for nothing but still injects values per device, so the
+    // operator sees the contract (and a Run button) rather than a run that
+    // fires the instant they click the row. Only a script with no parameters
+    // at all runs straight through.
+    if (!script.parameters || script.parameters.length === 0) {
       onSelect(script, runAs, undefined, showSessionTarget ? targetSessionId : undefined);
       onClose();
+      return;
     }
+
+    // Seeding stays runtime-only (#3409 PR3). A bound parameter is resolved per
+    // target device by the server, so it must never enter `paramValues` — a
+    // supplied value would be ignored and reported back in `ignoredParameters`.
+    const defaults: Record<string, unknown> = {};
+    for (const param of runtimeParameters(script.parameters)) {
+      if (param.defaultValue !== undefined) {
+        if (param.type === 'number') {
+          defaults[param.name] = Number(param.defaultValue) || 0;
+        } else if (param.type === 'boolean') {
+          defaults[param.name] = param.defaultValue === 'true';
+        } else {
+          defaults[param.name] = param.defaultValue;
+        }
+      } else {
+        defaults[param.name] = param.type === 'boolean' ? false : param.type === 'number' ? 0 : '';
+      }
+    }
+    setParamValues(defaults);
+    setSelectedScript(script);
+    setParamError(undefined);
+    setView('params');
   };
 
   const handleBack = () => {
@@ -297,43 +300,61 @@ export default function ScriptPickerModal({
               </div>
             ) : (
               <div className="space-y-2">
-                {filteredScripts.map(script => (
-                  <button
-                    key={script.id}
-                    type="button"
-                    onClick={() => handleSelect(script)}
-                    className="flex w-full items-start gap-3 rounded-lg border p-4 text-left transition hover:bg-muted/50"
-                  >
-                    <div className={cn(
-                      'flex h-8 w-8 shrink-0 items-center justify-center rounded text-xs font-bold',
-                      languageConfig[script.language].color
-                    )}>
-                      {languageConfig[script.language].icon}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="font-medium">{script.name}</p>
-                      {script.description && (
-                        <p className="mt-0.5 text-sm text-muted-foreground line-clamp-2">
-                          {script.description}
-                        </p>
-                      )}
-                      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                        <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5">
-                          {script.category}
-                        </span>
-                        <span>
-                          {script.osTypes.join(', ')}
-                        </span>
-                        {runtimeParameters(script.parameters).length > 0 && (
-                          <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5">
-                            {t('scriptPickerModal.paramCount', { count: runtimeParameters(script.parameters).length })}
-                          </span>
-                        )}
+                {filteredScripts.map(script => {
+                  // Two separate facts, so two separate badges: how many values
+                  // the operator will be asked for, and how many the server
+                  // injects. Collapsing them into one total would over-report
+                  // the work ("2 param(s)" for one question) and hiding the
+                  // bound ones would under-report what actually reaches the
+                  // device — a fully-bound script would look parameterless.
+                  const runtimeCount = runtimeParameters(script.parameters).length;
+                  const boundCount = (script.parameters?.length ?? 0) - runtimeCount;
+                  return (
+                    <button
+                      key={script.id}
+                      type="button"
+                      onClick={() => handleSelect(script)}
+                      className="flex w-full items-start gap-3 rounded-lg border p-4 text-left transition hover:bg-muted/50"
+                    >
+                      <div className={cn(
+                        'flex h-8 w-8 shrink-0 items-center justify-center rounded text-xs font-bold',
+                        languageConfig[script.language].color
+                      )}>
+                        {languageConfig[script.language].icon}
                       </div>
-                    </div>
-                    <Play className="h-4 w-4 shrink-0 text-muted-foreground" />
-                  </button>
-                ))}
+                      <div className="flex-1 min-w-0">
+                        <p className="font-medium">{script.name}</p>
+                        {script.description && (
+                          <p className="mt-0.5 text-sm text-muted-foreground line-clamp-2">
+                            {script.description}
+                          </p>
+                        )}
+                        <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                          <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5">
+                            {script.category}
+                          </span>
+                          <span>
+                            {script.osTypes.join(', ')}
+                          </span>
+                          {runtimeCount > 0 && (
+                            <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5">
+                              {t('scriptPickerModal.paramCount', { count: runtimeCount })}
+                            </span>
+                          )}
+                          {boundCount > 0 && (
+                            <span
+                              data-testid={`script-bound-param-count-${script.id}`}
+                              className="inline-flex items-center rounded-full bg-muted px-2 py-0.5"
+                            >
+                              {t('scriptPickerModal.boundParamCount', { count: boundCount })}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <Play className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    </button>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/apps/web/src/components/scripts/ScriptExecutionModal.test.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.test.tsx
@@ -1,0 +1,121 @@
+import '@/lib/i18n';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ScriptExecutionModal, { type Device } from './ScriptExecutionModal';
+import type { ScriptParameter } from './ScriptFormSchema';
+import type { Script } from './ScriptList';
+
+// The advanced-filter panel is closed on open, so `useFilterPreview` is disabled
+// and never fetches — no transport stub is needed for these cases.
+
+const devices: Device[] = [
+  { id: 'd-1', hostname: 'ws-01', os: 'windows', status: 'online', siteId: 's-1', siteName: 'HQ' },
+];
+
+const baseScript: Script = {
+  id: 'sc-1',
+  name: 'Rotate token',
+  language: 'powershell',
+  category: 'Maintenance',
+  osTypes: ['windows'],
+  createdAt: '2026-08-13T00:00:00.000Z',
+  updatedAt: '2026-08-13T00:00:00.000Z',
+};
+
+function renderModal(parameters: ScriptParameter[], onExecute = vi.fn().mockResolvedValue(undefined)) {
+  render(
+    <ScriptExecutionModal
+      script={{ ...baseScript, parameters }}
+      devices={devices}
+      isOpen
+      onClose={vi.fn()}
+      onExecute={onExecute}
+    />
+  );
+  return { onExecute };
+}
+
+/** Select the one online device and drive the two-step execute button. */
+async function execute() {
+  fireEvent.click(screen.getByRole('checkbox'));
+  fireEvent.click(screen.getByText('Execute'));
+  fireEvent.click(await screen.findByText('Confirm Execute'));
+}
+
+describe('ScriptExecutionModal sourced parameters (#3409 PR3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prompts for runtime parameters and shows bound ones read-only', () => {
+    renderModal([
+      { name: 'message', type: 'string', required: true },
+      { name: 'api_key', type: 'string', required: true, source: 'tenantVariable', variableKey: 'vendor_token' },
+    ]);
+
+    expect(screen.getByText('Parameters')).toBeInTheDocument();
+    const chip = screen.getByTestId('script-bound-parameter-api_key');
+    expect(chip).toHaveTextContent('Supplied automatically from variable vendor_token');
+    expect(chip.querySelector('input')).toBeNull();
+  });
+
+  it('hides the parameters section entirely when every parameter is bound', () => {
+    renderModal([
+      { name: 'org', type: 'string', required: true, source: 'builtin', builtinKey: 'org.name' },
+    ]);
+
+    expect(screen.queryByText('Parameters')).toBeNull();
+  });
+
+  it('does not seed a bound parameter\'s default and never submits it', async () => {
+    const { onExecute } = renderModal([
+      { name: 'message', type: 'string', defaultValue: 'hello' },
+      {
+        name: 'api_key',
+        type: 'string',
+        required: true,
+        defaultValue: 'fallback',
+        source: 'tenantVariable',
+        variableKey: 'vendor_token',
+      },
+    ]);
+
+    // The runtime default IS seeded; the bound one's fallback is not — it is the
+    // server's business, and a supplied value would come back in
+    // `ignoredParameters`.
+    expect(screen.getByDisplayValue('hello')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('fallback')).toBeNull();
+
+    await execute();
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute.mock.calls[0][2]).toEqual({ message: 'hello' });
+  });
+
+  it('lets a run proceed when the only unfilled required parameter is bound', async () => {
+    const { onExecute } = renderModal([
+      { name: 'api_key', type: 'string', required: true, source: 'tenantVariable', variableKey: 'vendor_token' },
+      { name: 'message', type: 'string' },
+    ]);
+
+    await execute();
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText(/is required/)).toBeNull();
+  });
+
+  it('still blocks on a missing required RUNTIME parameter', () => {
+    const { onExecute } = renderModal([
+      { name: 'message', type: 'string', required: true },
+      { name: 'api_key', type: 'string', required: true, source: 'tenantVariable', variableKey: 'vendor_token' },
+    ]);
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByText('Execute'));
+
+    expect(screen.getByText('Parameter "message" is required')).toBeInTheDocument();
+    expect(onExecute).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/scripts/ScriptExecutionModal.test.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.test.tsx
@@ -61,10 +61,35 @@ describe('ScriptExecutionModal sourced parameters (#3409 PR3)', () => {
     expect(chip.querySelector('input')).toBeNull();
   });
 
-  it('hides the parameters section entirely when every parameter is bound', () => {
+  it('shows the parameters section as read-only chips when every parameter is bound', () => {
     renderModal([
       { name: 'org', type: 'string', required: true, source: 'builtin', builtinKey: 'org.name' },
     ]);
+
+    // The operator is about to run this on customer machines — the injected
+    // contract must be visible even though there is nothing to fill in.
+    expect(screen.getByText('Parameters')).toBeInTheDocument();
+    const chip = screen.getByTestId('script-bound-parameter-org');
+    expect(chip).toHaveTextContent('Supplied automatically from org.name');
+    expect(chip.querySelector('input')).toBeNull();
+    expect(screen.getByTestId('script-parameters-all-supplied')).toBeInTheDocument();
+  });
+
+  it('executes a fully-bound script and submits an empty parameters map', async () => {
+    const { onExecute } = renderModal([
+      { name: 'org', type: 'string', required: true, source: 'builtin', builtinKey: 'org.name' },
+      { name: 'api_key', type: 'string', required: true, defaultValue: 'fallback', source: 'tenantVariable', variableKey: 'vendor_token' },
+    ]);
+
+    await execute();
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute.mock.calls[0][2]).toEqual({});
+    expect(screen.queryByText(/is required/)).toBeNull();
+  });
+
+  it('renders no parameters section when the script has no parameters at all', () => {
+    renderModal([]);
 
     expect(screen.queryByText('Parameters')).toBeNull();
   });

--- a/apps/web/src/components/scripts/ScriptExecutionModal.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 import { Dialog } from '../shared/Dialog';
 import ProgressBar, { ProgressItemList, type ProgressItem } from '../shared/ProgressBar';
 import type { Script } from './ScriptList';
-import type { ScriptParameter } from './ScriptForm';
+import { runtimeParameters, type ScriptParameter } from './ScriptFormSchema';
 import type { FilterConditionGroup } from '@breeze/shared';
 import { FilterBuilder, DEFAULT_FILTER_FIELDS } from '../filters/FilterBuilder';
 import { useFilterPreview } from '../../hooks/useFilterPreview';
@@ -74,11 +74,16 @@ export default function ScriptExecutionModal({
     return new Set(filterPreview.devices.map(d => d.id));
   }, [showAdvancedFilter, filterPreview]);
 
+  // Runtime parameters only (#3409 PR3): a bound parameter is resolved per
+  // target device by the server, so it is neither prompted for nor seeded — a
+  // value supplied for one is ignored and reported in `ignoredParameters`.
+  const runtimeParams = useMemo(() => runtimeParameters(script.parameters), [script.parameters]);
+
   // Initialize parameters with defaults
   useEffect(() => {
     if (script.parameters) {
       const defaults: Record<string, string | number | boolean> = {};
-      script.parameters.forEach(param => {
+      runtimeParameters(script.parameters).forEach(param => {
         if (param.defaultValue !== undefined) {
           if (param.type === 'number') {
             defaults[param.name] = Number(param.defaultValue) || 0;
@@ -253,8 +258,9 @@ export default function ScriptExecutionModal({
             </p>
           </div>
 
-          {/* Parameters */}
-          {script.parameters && script.parameters.length > 0 && (
+          {/* Parameters — gated on the RUNTIME count: an all-bound script has
+              nothing to ask for, so the section would be an empty shell. */}
+          {runtimeParams.length > 0 && script.parameters && (
             <ScriptParametersForm
               parameters={script.parameters}
               values={parameters}

--- a/apps/web/src/components/scripts/ScriptExecutionModal.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.tsx
@@ -74,12 +74,10 @@ export default function ScriptExecutionModal({
     return new Set(filterPreview.devices.map(d => d.id));
   }, [showAdvancedFilter, filterPreview]);
 
-  // Runtime parameters only (#3409 PR3): a bound parameter is resolved per
-  // target device by the server, so it is neither prompted for nor seeded — a
-  // value supplied for one is ignored and reported in `ignoredParameters`.
-  const runtimeParams = useMemo(() => runtimeParameters(script.parameters), [script.parameters]);
-
-  // Initialize parameters with defaults
+  // Initialize parameters with defaults. Runtime parameters only (#3409 PR3):
+  // a bound parameter is resolved per target device by the server, so it is
+  // neither prompted for nor seeded — a value supplied for one is ignored and
+  // reported in `ignoredParameters`.
   useEffect(() => {
     if (script.parameters) {
       const defaults: Record<string, string | number | boolean> = {};
@@ -258,9 +256,11 @@ export default function ScriptExecutionModal({
             </p>
           </div>
 
-          {/* Parameters — gated on the RUNTIME count: an all-bound script has
-              nothing to ask for, so the section would be an empty shell. */}
-          {runtimeParams.length > 0 && script.parameters && (
+          {/* Parameters — shown whenever the script HAS parameters, bound or
+              not. The form prompts only for the runtime ones; an all-bound
+              script still shows its read-only chips so the operator can see
+              what will be injected into a run on customer machines. */}
+          {script.parameters && script.parameters.length > 0 && (
             <ScriptParametersForm
               parameters={script.parameters}
               values={parameters}

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -361,3 +361,212 @@ describe('ScriptForm unknown-variable notice', () => {
     expect(screen.queryByTestId('script-variable-warning')).toBeNull();
   });
 });
+
+// #3409 PR3: a parameter definition can be BOUND to a tenant variable, a device
+// custom field or a built-in property instead of being asked for at run time.
+describe('ScriptForm sourced parameters', () => {
+  const variableRow = (key: string, description: string, isSecret: boolean) => ({
+    id: `tv-${key}`,
+    key,
+    value: 'x',
+    isSecret,
+    description,
+    ownerScope: 'partner' as const,
+    orgId: null,
+    partnerId: 'p-1',
+    version: 1,
+    createdAt: '2026-08-13T00:00:00.000Z',
+    updatedAt: '2026-08-13T00:00:00.000Z',
+  });
+
+  const draft = { name: 'Draft', category: 'Custom', language: 'powershell' as const, content: 'echo hi' };
+
+  beforeEach(() => {
+    editorInstances.length = 0;
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'o-1' });
+    orgStoreMock.mockReturnValue({ organizations: [], partners: [], sites: [] });
+    fetchWithAuthMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            variableRow('vendor_token', 'Vendor portal token', false),
+            variableRow('api_password', 'Vendor API password', true),
+          ],
+        }),
+        { status: 200 }
+      )
+    );
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps a legacy parameter (no `source`) on the runtime behaviour with no binding field', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{ ...draft, parameters: [{ name: 'message', type: 'string' }] }}
+      />
+    );
+
+    const sourceSelect = await screen.findByLabelText('Source for parameter 1');
+    expect((sourceSelect as HTMLSelectElement).value).toBe('runtime');
+    expect(screen.queryByPlaceholderText('e.g. vendor_token')).toBeNull();
+    expect(screen.getByText('Default Value')).toBeInTheDocument();
+  });
+
+  it('reveals the variable key picker when the row is switched to a variable source', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{ ...draft, parameters: [{ name: 'message', type: 'string' }] }}
+      />
+    );
+
+    const sourceSelect = await screen.findByLabelText('Source for parameter 1');
+    fireEvent.change(sourceSelect, { target: { value: 'tenantVariable' } });
+
+    expect(screen.getByPlaceholderText('e.g. vendor_token')).toBeInTheDocument();
+    // A bound parameter's default is a fallback, not a prefilled answer.
+    expect(screen.getByText('Fallback value')).toBeInTheDocument();
+  });
+
+  it('stores the bare KEY when a variable is picked from the menu — never a {{var.x}} token', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [{ name: 'token', type: 'string', source: 'tenantVariable', variableKey: '' }],
+        }}
+      />
+    );
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    fireEvent.click(screen.getByTitle('Choose a variable'));
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Vendor portal token/i }));
+
+    const keyInput = screen.getByPlaceholderText('e.g. vendor_token') as HTMLInputElement;
+    await waitFor(() => expect(keyInput.value).toBe('vendor_token'));
+    expect(keyInput.value).not.toContain('{{');
+  });
+
+  it('offers secret variables as disabled rows in the key picker', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [{ name: 'token', type: 'string', source: 'tenantVariable', variableKey: '' }],
+        }}
+      />
+    );
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    fireEvent.click(screen.getByTitle('Choose a variable'));
+    expect(await screen.findByRole('menuitem', { name: /Vendor API password/i })).toBeDisabled();
+  });
+
+  it('warns before save when a binding targets a secret variable (the API 400s it)', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [
+            { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_password' },
+          ],
+        }}
+      />
+    );
+
+    const warning = await screen.findByTestId('script-parameter-secret-warning');
+    expect(warning).toHaveTextContent(/api_password/);
+    expect(warning).toHaveTextContent(/rejected/i);
+  });
+
+  it('gives every secret-bound row its own warning id so both announce', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [
+            { name: 'first', type: 'string', source: 'tenantVariable', variableKey: 'api_password' },
+            { name: 'second', type: 'string', source: 'tenantVariable', variableKey: 'api_password' },
+          ],
+        }}
+      />
+    );
+
+    const warnings = await screen.findAllByTestId('script-parameter-secret-warning');
+    expect(warnings).toHaveLength(2);
+    const ids = warnings.map(w => w.id);
+    expect(new Set(ids).size).toBe(2);
+    // Each input points at its OWN paragraph — a shared id would silently drop one.
+    const inputs = screen.getAllByPlaceholderText('e.g. vendor_token');
+    expect(inputs.map(i => i.getAttribute('aria-describedby'))).toEqual(ids);
+  });
+
+  it('does not warn for a non-secret binding', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [
+            { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'vendor_token' },
+          ],
+        }}
+      />
+    );
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
+    expect(screen.queryByTestId('script-parameter-secret-warning')).toBeNull();
+  });
+
+  it('hides the run-time options list for a bound select parameter', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [{ name: 'env', type: 'select', options: 'a,b', source: 'builtin', builtinKey: 'org.name' }],
+        }}
+      />
+    );
+
+    await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
+    expect(screen.queryByPlaceholderText('option1, option2, option3')).toBeNull();
+    // The built-in vocabulary comes from @breeze/shared, not a local copy.
+    expect(screen.getByText('device.hostname')).toBeInTheDocument();
+  });
+
+  it('clears the previous arm\'s binding key when the source changes', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [
+            { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_password' },
+          ],
+        }}
+      />
+    );
+
+    await screen.findByTestId('script-parameter-secret-warning');
+    fireEvent.change(screen.getByLabelText('Source for parameter 1'), {
+      target: { value: 'deviceCustomField' },
+    });
+
+    expect(screen.getByPlaceholderText('e.g. asset_tag')).toBeInTheDocument();
+    // Switching back must not resurrect the abandoned (secret) key.
+    fireEvent.change(screen.getByLabelText('Source for parameter 1'), {
+      target: { value: 'tenantVariable' },
+    });
+    expect((screen.getByPlaceholderText('e.g. vendor_token') as HTMLInputElement).value).toBe('');
+    expect(screen.queryByTestId('script-parameter-secret-warning')).toBeNull();
+  });
+});

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -1,8 +1,8 @@
-import { useMemo, useState, useEffect, useRef, useCallback, type ComponentType } from 'react';
-import { useForm, useFieldArray, Controller } from 'react-hook-form';
+import { useMemo, useState, useEffect, useId, useRef, useCallback, type ComponentType } from 'react';
+import { useForm, useFieldArray, Controller, type UseFormRegisterReturn } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Plus, Trash2, Sparkles, AlertTriangle } from 'lucide-react';
+import { Plus, Trash2, Sparkles, AlertTriangle, Braces } from 'lucide-react';
 import type { EditorProps } from '@monaco-editor/react';
 
 // Statically import Monaco's editor stylesheet so Astro bundles it into the
@@ -18,10 +18,12 @@ import type { EditorProps } from '@monaco-editor/react';
 // static bundle (see lib/monacoLoader.ts).
 import 'monaco-editor/min/vs/editor/editor.main.css';
 
+import { SCRIPT_BUILTIN_PARAMETER_KEYS, SCRIPT_PARAMETER_SOURCES } from '@breeze/shared';
 import ScriptAiPanel from './ScriptAiPanel';
 import CollapsibleSection from './CollapsibleSection';
 import ScriptVariablePicker from './ScriptVariablePicker';
-import { findUnknownVariableKeys, useTenantVariables } from '@/lib/tenantVariableTokens';
+import TenantVariableMenu from './TenantVariableMenu';
+import { findUnknownVariableKeys, useTenantVariables, type TenantVariableEntry } from '@/lib/tenantVariableTokens';
 import { cn } from '@/lib/utils';
 import { configureMonacoLoader } from '@/lib/monacoLoader';
 import { useScriptAiStore } from '@/stores/scriptAiStore';
@@ -33,16 +35,90 @@ import { getJwtClaims } from '@/lib/authScope';
 import {
   scriptSchema, languageOptions, categoryOptions,
   runAsOptions, parameterTypeOptions, severityOptions,
-  rowsToMapping,
-  type ScriptFormValues, type ScriptSubmitValues,
+  rowsToMapping, parameterBindingKey, parameterSource,
+  type ScriptFormDefaults, type ScriptFormValues, type ScriptSubmitValues,
 } from './ScriptFormSchema';
 
 export type { ScriptFormValues, ScriptParameter, ScriptSubmitValues } from './ScriptFormSchema';
 
+/**
+ * The `tenantVariable` binding cell: a free-text key plus the shared picker.
+ *
+ * Its own component purely so the secret warning can own a `useId` — the row
+ * lives inside a `.map`, where a hook cannot be called, and a single shared id
+ * would mean two parameters bound to two different secrets announce only one of
+ * them (the same rule `VariableInput` follows for its two warning paragraphs).
+ *
+ * The warning is deliberately advisory rather than a submit gate: the API
+ * rejects a secret binding with a 400 at save, so the point here is to say so
+ * BEFORE the round trip, not to re-implement the rule. Typing a key by hand is
+ * still allowed — the picker disables secret rows, but a key can also be
+ * classified secret after the script was authored.
+ */
+function TenantVariableBindingField({
+  registration,
+  value,
+  variables,
+  onPick,
+  error,
+}: {
+  registration: UseFormRegisterReturn;
+  value: string;
+  variables: TenantVariableEntry[];
+  onPick: (key: string) => void;
+  error?: string;
+}) {
+  const { t } = useTranslation('scripts');
+  const warnId = useId();
+  const isSecret = variables.some(v => v.key === value && v.isSecret);
+
+  return (
+    <div className="space-y-1 sm:col-span-2">
+      <label className="text-xs font-medium text-muted-foreground">
+        {t('scriptForm.parameterBinding.variableLabel')}
+      </label>
+      <div className="flex items-stretch gap-2">
+        <input
+          {...registration}
+          placeholder={t('scriptForm.parameterBinding.variablePlaceholder')}
+          aria-invalid={isSecret || undefined}
+          aria-describedby={isSecret ? warnId : undefined}
+          className={cn(
+            'h-9 min-w-0 flex-1 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring',
+            isSecret && 'border-destructive/60 focus:ring-destructive/40'
+          )}
+        />
+        <TenantVariableMenu
+          variables={variables}
+          onSelect={onPick}
+          // The parameter stores the bare KEY, so the row's secondary line is
+          // the key itself — showing `{{var.key}}` here would advertise a shape
+          // this field must not contain.
+          formatDetail={key => key}
+          trigger={<Braces className="h-3.5 w-3.5" />}
+          triggerTitle={t('scriptForm.parameterBinding.chooseTitle')}
+          triggerClassName="h-9 shrink-0 bg-background px-3"
+        />
+      </div>
+      {isSecret && (
+        <p
+          id={warnId}
+          data-testid="script-parameter-secret-warning"
+          className="flex items-start gap-1.5 text-xs text-destructive"
+        >
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>{t('scriptForm.parameterBinding.secretRejected', { key: value })}</span>
+        </p>
+      )}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
 type ScriptFormProps = {
   onSubmit?: (values: ScriptSubmitValues) => void | Promise<void>;
   onCancel?: () => void;
-  defaultValues?: Partial<ScriptFormValues>;
+  defaultValues?: ScriptFormDefaults;
   submitLabel?: string;
   loading?: boolean;
   isNew?: boolean;
@@ -316,6 +392,7 @@ export default function ScriptForm({
   const runAsLabel = (value: string) => t(/* i18n-dynamic */ `scriptForm.runAs.${value}.label`);
   const runAsDescription = (value: string) => t(/* i18n-dynamic */ `scriptForm.runAs.${value}.description`);
   const parameterTypeLabel = (value: string) => t(/* i18n-dynamic */ `scriptForm.parameterTypes.${value}`);
+  const parameterSourceLabel = (value: string) => t(/* i18n-dynamic */ `scriptForm.parameterSources.${value}`);
   const severityLabel = (value: string) => t(/* i18n-dynamic */ `scriptForm.severity.${value}`);
   const osLabel = (os: OSType) => t(/* i18n-dynamic */ `scriptForm.os.${os}`);
 
@@ -342,6 +419,41 @@ export default function ScriptForm({
       // parameters existed.
       source: 'runtime'
     });
+  };
+
+  /**
+   * Switch a row's source, clearing the other arms' binding keys.
+   *
+   * zodResolver strips them from the submitted values anyway (each union arm
+   * only declares its own key), but leaving them in form state makes a row that
+   * is switched back look bound to a key the user already abandoned — and the
+   * secret warning below would then fire off a key this row no longer uses.
+   * `builtin` is seeded with the first vocabulary entry so its `<select>` starts
+   * on the value it visually displays rather than on an empty non-option.
+   */
+  const handleParameterSourceChange = (index: number, next: string) => {
+    const set = (field: string, value: string | undefined) => {
+      setValue(
+        `parameters.${index}.${field}` as unknown as keyof ScriptFormValues,
+        value as never,
+        { shouldDirty: true }
+      );
+    };
+    set('source', next);
+    set('variableKey', '');
+    set('fieldKey', '');
+    set('builtinKey', next === 'builtin' ? SCRIPT_BUILTIN_PARAMETER_KEYS[0] : '');
+  };
+
+  /**
+   * Per-row field errors. The definitions schema is a discriminated union, so
+   * `errors.parameters[i]` is a union of per-arm error shapes and TS cannot see
+   * `variableKey` on the runtime arm — the error object itself is a plain
+   * record at runtime.
+   */
+  const parameterFieldError = (index: number, field: string): string | undefined => {
+    const row = errors.parameters?.[index] as Record<string, { message?: string }> | undefined;
+    return row?.[field]?.message;
   };
 
   return (
@@ -634,7 +746,11 @@ export default function ScriptForm({
               {t('scriptForm.parameters.emptySuffix')}
             </p>
           )}
-          {fields.map((field, index) => (
+          {fields.map((field, index) => {
+            const row = watchParameters?.[index];
+            const source = row ? parameterSource(row) : 'runtime';
+            const isBound = source !== 'runtime';
+            return (
             <div key={field.id} className="rounded-md border bg-muted/20 p-4">
               <div className="flex items-start gap-3">
                 <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground mt-2">{index + 1}</span>
@@ -642,16 +758,74 @@ export default function ScriptForm({
                   <div className="space-y-1">
                     <label className="text-xs font-medium text-muted-foreground">{t('common:labels.name')}</label>
                     <input placeholder={t('scriptForm.placeholders.parameterName')} className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring" {...register(`parameters.${index}.name`)} />
-                    {errors.parameters?.[index]?.name && <p className="text-xs text-destructive">{errors.parameters[index]?.name?.message}</p>}
+                    {parameterFieldError(index, 'name') && <p className="text-xs text-destructive">{parameterFieldError(index, 'name')}</p>}
                   </div>
+                  <div className="space-y-1">
+                    <label className="text-xs font-medium text-muted-foreground">{t('scriptForm.fields.source')}</label>
+                    {/* Deliberately controlled rather than `register`ed: changing
+                        the source must write the new arm AND clear the previous
+                        arm's binding key in one pass, and a registered select
+                        gives no ordering guarantee between RHF's own write and
+                        a user `onChange` hook. */}
+                    <select
+                      aria-label={t('scriptForm.parameters.sourceAriaLabel', { index: index + 1 })}
+                      className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                      value={source}
+                      onChange={e => handleParameterSourceChange(index, e.target.value)}
+                    >
+                      {SCRIPT_PARAMETER_SOURCES.map(value => <option key={value} value={value}>{parameterSourceLabel(value)}</option>)}
+                    </select>
+                  </div>
+                  {source === 'tenantVariable' && (
+                    <TenantVariableBindingField
+                      registration={register(`parameters.${index}.variableKey` as unknown as keyof ScriptFormValues)}
+                      value={(row && parameterBindingKey(row)) || ''}
+                      variables={tenantVariables}
+                      error={parameterFieldError(index, 'variableKey')}
+                      onPick={key => setValue(
+                        `parameters.${index}.variableKey` as unknown as keyof ScriptFormValues,
+                        key as never,
+                        { shouldDirty: true }
+                      )}
+                    />
+                  )}
+                  {source === 'deviceCustomField' && (
+                    <div className="space-y-1 sm:col-span-2">
+                      <label className="text-xs font-medium text-muted-foreground">{t('scriptForm.parameterBinding.fieldLabel')}</label>
+                      <input
+                        placeholder={t('scriptForm.parameterBinding.fieldPlaceholder')}
+                        className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                        {...register(`parameters.${index}.fieldKey` as unknown as keyof ScriptFormValues)}
+                      />
+                      {parameterFieldError(index, 'fieldKey') && <p className="text-xs text-destructive">{parameterFieldError(index, 'fieldKey')}</p>}
+                    </div>
+                  )}
+                  {source === 'builtin' && (
+                    <div className="space-y-1 sm:col-span-2">
+                      <label className="text-xs font-medium text-muted-foreground">{t('scriptForm.parameterBinding.builtinLabel')}</label>
+                      <select
+                        className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                        {...register(`parameters.${index}.builtinKey` as unknown as keyof ScriptFormValues)}
+                      >
+                        {SCRIPT_BUILTIN_PARAMETER_KEYS.map(key => <option key={key} value={key}>{key}</option>)}
+                      </select>
+                      {parameterFieldError(index, 'builtinKey') && <p className="text-xs text-destructive">{parameterFieldError(index, 'builtinKey')}</p>}
+                    </div>
+                  )}
                   <div className="space-y-1">
                     <label className="text-xs font-medium text-muted-foreground">{t('common:labels.type')}</label>
                     <select className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring" {...register(`parameters.${index}.type`)}>
                       {parameterTypeOptions.map(opt => <option key={opt.value} value={opt.value}>{parameterTypeLabel(opt.value)}</option>)}
                     </select>
                   </div>
+                  {/* Bound parameters keep a default — resolution is
+                      `resolved value -> definition default -> missing` — but it
+                      is a fallback, not a prefilled answer, so it is labelled as
+                      one. */}
                   <div className="space-y-1">
-                    <label className="text-xs font-medium text-muted-foreground">{t('scriptForm.fields.defaultValue')}</label>
+                    <label className="text-xs font-medium text-muted-foreground">
+                      {isBound ? t('scriptForm.fields.fallbackValue') : t('scriptForm.fields.defaultValue')}
+                    </label>
                     <input placeholder={t('scriptForm.placeholders.defaultValue')} className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring" {...register(`parameters.${index}.defaultValue`)} />
                   </div>
                   <div className="space-y-1">
@@ -661,11 +835,19 @@ export default function ScriptForm({
                       <span className="ml-2 text-sm">{t('common:labels.yes')}</span>
                     </div>
                   </div>
-                  {watchParameters?.[index]?.type === 'select' && (
+                  {/* `options` renders the run-time `<select>`. A bound parameter
+                      is never prompted for, so a choice list has nothing to
+                      drive and is hidden rather than silently ignored. */}
+                  {!isBound && row?.type === 'select' && (
                     <div className="space-y-1 sm:col-span-2 md:col-span-4">
                       <label className="text-xs font-medium text-muted-foreground">{t('scriptForm.fields.options')}</label>
                       <input placeholder={t('scriptForm.placeholders.options')} className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring" {...register(`parameters.${index}.options`)} />
                     </div>
+                  )}
+                  {isBound && (
+                    <p className="text-xs text-muted-foreground sm:col-span-2 md:col-span-4">
+                      {t('scriptForm.parameterBinding.hint')}
+                    </p>
                   )}
                 </div>
                 <button type="button" onClick={() => remove(index)} className="flex h-9 w-9 items-center justify-center rounded-md hover:bg-muted text-destructive" title={t('scriptForm.actions.removeParameter')}>
@@ -673,7 +855,8 @@ export default function ScriptForm({
                 </button>
               </div>
             </div>
-          ))}
+            );
+          })}
           <button type="button" onClick={addParameter} className="inline-flex items-center gap-1.5 rounded-md border border-dashed px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition">
             <Plus className="h-4 w-4" />
             {t('scriptForm.actions.addParameter')}

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -336,7 +336,11 @@ export default function ScriptForm({
       type: 'string',
       defaultValue: '',
       required: false,
-      options: ''
+      options: '',
+      // Seeded explicitly (#3409 PR3): a new row must start on the same
+      // invoker-supplied binding every parameter had before sourced
+      // parameters existed.
+      source: 'runtime'
     });
   };
 

--- a/apps/web/src/components/scripts/ScriptFormSchema.ts
+++ b/apps/web/src/components/scripts/ScriptFormSchema.ts
@@ -1,13 +1,15 @@
 import { z } from 'zod';
+import { scriptParameterDefinitionSchema, scriptParameterDefinitionsSchema } from '@breeze/shared';
 import type { ScriptLanguage, OSType } from './ScriptList';
 
-export const parameterSchema = z.object({
-  name: z.string().min(1, 'Parameter name is required'),
-  type: z.enum(['string', 'number', 'boolean', 'select']),
-  defaultValue: z.string().optional(),
-  required: z.boolean().optional().default(false),
-  options: z.string().optional() // comma-separated for select type
-});
+/**
+ * Re-exported from `@breeze/shared` rather than redeclared: this shape used to
+ * be hand-mirrored here, in `validators/ai.ts` and in `scriptBuilderTools.ts`,
+ * with the API accepting `z.any()`. `scriptParameterDefinitionsSchema` also
+ * carries the array-level env-var collision rule (`log-level` vs `log_level`),
+ * which no local copy had (#3409 PR3).
+ */
+export const parameterSchema = scriptParameterDefinitionSchema;
 
 export const severityValues = ['critical', 'high', 'medium', 'low', 'info'] as const;
 export type Severity = (typeof severityValues)[number];
@@ -34,7 +36,7 @@ export const scriptSchema = z.object({
   language: z.enum(['powershell', 'bash', 'python', 'cmd']),
   osTypes: z.array(z.enum(['windows', 'macos', 'linux'])).min(1, 'Select at least one OS'),
   content: z.string().min(1, 'Script content is required'),
-  parameters: z.array(parameterSchema).optional(),
+  parameters: scriptParameterDefinitionsSchema.optional(),
   timeoutSeconds: z.coerce
     .number({ error: 'Enter a timeout value' })
     .int('Timeout must be a whole number')
@@ -68,7 +70,14 @@ export const scriptSchema = z.object({
 });
 
 export type ScriptFormValues = z.infer<typeof scriptSchema>;
-export type ScriptParameter = z.infer<typeof parameterSchema>;
+/**
+ * The INPUT type, deliberately: `ScriptParameter` types definitions read back
+ * from the API, and every definition stored before #3409 PR3 has no `source`
+ * key (and often no `required`). The output type would claim both are always
+ * present, which is false for exactly the rows the UI spends most of its time
+ * rendering. Reading `source` therefore correctly forces a `?? 'runtime'`.
+ */
+export type ScriptParameter = z.input<typeof parameterSchema>;
 export type ExitCodeSeverityRow = z.infer<typeof exitCodeSeverityRowSchema>;
 
 // Wire shape sent to / received from the API. Form-side editing keeps an

--- a/apps/web/src/components/scripts/ScriptFormSchema.ts
+++ b/apps/web/src/components/scripts/ScriptFormSchema.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { scriptParameterDefinitionSchema, scriptParameterDefinitionsSchema } from '@breeze/shared';
+import {
+  scriptParameterDefinitionSchema,
+  scriptParameterDefinitionsSchema,
+  type ScriptParameterSource,
+} from '@breeze/shared';
 import type { ScriptLanguage, OSType } from './ScriptList';
 
 /**
@@ -79,6 +83,68 @@ export type ScriptFormValues = z.infer<typeof scriptSchema>;
  */
 export type ScriptParameter = z.input<typeof parameterSchema>;
 export type ExitCodeSeverityRow = z.infer<typeof exitCodeSeverityRowSchema>;
+
+/**
+ * What a caller may hand `ScriptForm` as `defaultValues`.
+ *
+ * `parameters` is the INPUT type: definitions come back from the API exactly as
+ * they were stored, and every one written before #3409 PR3 lacks `source` (and
+ * often `required`). Typing this half as the schema OUTPUT would make the
+ * majority of real edit-page loads a type error while changing nothing about
+ * what the form actually receives.
+ */
+export type ScriptFormDefaults = Partial<Omit<ScriptFormValues, 'parameters'>> & {
+  parameters?: ScriptParameter[];
+};
+
+/**
+ * Where this parameter's value comes from (#3409 PR3).
+ *
+ * Every definition stored before PR3 omits `source` entirely, so the fallback
+ * is not defensive padding — it is the shape the majority of rows still have.
+ * Read the source ONLY through this helper so no surface can drift into
+ * treating a legacy row as unbound-by-accident rather than
+ * unbound-by-definition.
+ */
+export function parameterSource(parameter: ScriptParameter): ScriptParameterSource {
+  return parameter.source ?? 'runtime';
+}
+
+/**
+ * Is this parameter supplied by the server per target device rather than by
+ * the invoker? Bound parameters are never prompted for, never required of the
+ * invoker, and must never appear in the outgoing parameters map — a supplied
+ * value would be ignored and reported back in `ignoredParameters`.
+ */
+export function isBoundParameter(parameter: ScriptParameter): boolean {
+  return parameterSource(parameter) !== 'runtime';
+}
+
+/** The parameters a run surface actually prompts for. */
+export function runtimeParameters(
+  parameters: readonly ScriptParameter[] | undefined
+): ScriptParameter[] {
+  return (parameters ?? []).filter(parameter => !isBoundParameter(parameter));
+}
+
+/**
+ * The binding target as a display string — the tenant-variable key, the device
+ * custom-field key, or the built-in property name. `null` for a runtime
+ * parameter, and for a bound row whose key hasn't been chosen yet (mid-edit in
+ * the authoring form).
+ */
+export function parameterBindingKey(parameter: ScriptParameter): string | null {
+  switch (parameter.source) {
+    case 'tenantVariable':
+      return parameter.variableKey || null;
+    case 'deviceCustomField':
+      return parameter.fieldKey || null;
+    case 'builtin':
+      return parameter.builtinKey || null;
+    default:
+      return null;
+  }
+}
 
 // Wire shape sent to / received from the API. Form-side editing keeps an
 // ordered list of rows for stable React keys + per-row error display; we

--- a/apps/web/src/components/scripts/ScriptParametersForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptParametersForm.test.tsx
@@ -1,6 +1,20 @@
-import { describe, expect, it } from 'vitest';
-import { validateParameters } from './ScriptParametersForm';
+import '@/lib/i18n';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ScriptParametersForm, { validateParameters } from './ScriptParametersForm';
 import type { ScriptParameter } from './ScriptFormSchema';
+
+// #3409 PR3 — a bound parameter is resolved per target device by the server.
+// Deliberately `required: true`: the whole point is that "required" is evaluated
+// at dispatch after resolution, so it must NOT make this form demand a value.
+const boundVariable: ScriptParameter = {
+  name: 'api_key',
+  type: 'string',
+  required: true,
+  source: 'tenantVariable',
+  variableKey: 'vendor_token',
+};
 
 describe('validateParameters', () => {
   it('returns null when there are no parameters', () => {
@@ -88,5 +102,78 @@ describe('validateParameters', () => {
       { name: 'count', type: 'number', required: true }
     ];
     expect(validateParameters(params, { count: NaN })).toBe('Parameter "count" must be a valid number');
+  });
+
+  it('never requires a value for a bound parameter — the server resolves it per device', () => {
+    expect(validateParameters([boundVariable], {})).toBeNull();
+  });
+
+  it('still enforces the runtime parameters alongside a bound one', () => {
+    const params: ScriptParameter[] = [
+      boundVariable,
+      { name: 'message', type: 'string', required: true },
+    ];
+    expect(validateParameters(params, {})).toBe('Parameter "message" is required');
+    expect(validateParameters(params, { message: 'hi' })).toBeNull();
+  });
+
+  it('does not number-check a bound parameter that happens to carry a stray value', () => {
+    const params: ScriptParameter[] = [
+      { name: 'count', type: 'number', required: false, source: 'builtin', builtinKey: 'org.id' },
+    ];
+    // A stale/injected value must not fail validation locally — dispatch ignores
+    // it and reports it back in `ignoredParameters`.
+    expect(validateParameters(params, { count: 'not-a-number' })).toBeNull();
+  });
+});
+
+describe('ScriptParametersForm rendering', () => {
+  it('renders a bound parameter read-only with its source, and no input', () => {
+    render(
+      <ScriptParametersForm
+        parameters={[{ name: 'message', type: 'string' }, boundVariable]}
+        values={{}}
+        onChange={vi.fn()}
+      />
+    );
+
+    // The runtime parameter is still an editable field.
+    expect(screen.getByPlaceholderText('')).toBeInTheDocument();
+
+    const chip = screen.getByTestId('script-bound-parameter-api_key');
+    expect(chip).toHaveTextContent('Supplied automatically from variable vendor_token');
+    // No control of any kind inside the bound cell — nothing can enter the
+    // outgoing parameters map.
+    expect(chip.querySelector('input')).toBeNull();
+    expect(chip.querySelector('select')).toBeNull();
+    expect(chip.querySelector('textarea')).toBeNull();
+  });
+
+  it('names the binding for each source', () => {
+    render(
+      <ScriptParametersForm
+        parameters={[
+          { name: 'message', type: 'string' },
+          { name: 'tag', type: 'string', source: 'deviceCustomField', fieldKey: 'asset_tag' },
+          { name: 'org', type: 'string', source: 'builtin', builtinKey: 'org.name' },
+        ]}
+        values={{}}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('script-bound-parameter-tag')).toHaveTextContent(
+      'Supplied automatically from device custom field asset_tag'
+    );
+    expect(screen.getByTestId('script-bound-parameter-org')).toHaveTextContent(
+      'Supplied automatically from org.name'
+    );
+  });
+
+  it('renders nothing when every parameter is bound — there is nothing to ask for', () => {
+    const { container } = render(
+      <ScriptParametersForm parameters={[boundVariable]} values={{}} onChange={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/apps/web/src/components/scripts/ScriptParametersForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptParametersForm.test.tsx
@@ -170,10 +170,37 @@ describe('ScriptParametersForm rendering', () => {
     );
   });
 
-  it('renders nothing when every parameter is bound — there is nothing to ask for', () => {
+  it('still shows the section when every parameter is bound — the operator must see what gets injected', () => {
     const { container } = render(
       <ScriptParametersForm parameters={[boundVariable]} values={{}} onChange={vi.fn()} />
     );
+
+    expect(screen.getByText('Parameters')).toBeInTheDocument();
+    expect(screen.getByTestId('script-bound-parameter-api_key')).toHaveTextContent(
+      'Supplied automatically from variable vendor_token'
+    );
+    // Visible, but nothing to prompt for: no control anywhere in the form, and
+    // an explicit note so the empty-looking section is not read as a bug.
+    expect(screen.getByTestId('script-parameters-all-supplied')).toBeInTheDocument();
+    expect(container.querySelector('input')).toBeNull();
+    expect(container.querySelector('select')).toBeNull();
+  });
+
+  it('renders nothing when the script has no parameters at all', () => {
+    const { container } = render(
+      <ScriptParametersForm parameters={[]} values={{}} onChange={vi.fn()} />
+    );
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not show the all-supplied note when there is a runtime parameter to fill', () => {
+    render(
+      <ScriptParametersForm
+        parameters={[{ name: 'message', type: 'string' }, boundVariable]}
+        values={{}}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId('script-parameters-all-supplied')).toBeNull();
   });
 });

--- a/apps/web/src/components/scripts/ScriptParametersForm.tsx
+++ b/apps/web/src/components/scripts/ScriptParametersForm.tsx
@@ -1,6 +1,13 @@
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
-import type { ScriptParameter } from './ScriptFormSchema';
+import { Lock } from 'lucide-react';
+import {
+  isBoundParameter,
+  parameterBindingKey,
+  parameterSource,
+  runtimeParameters,
+  type ScriptParameter,
+} from './ScriptFormSchema';
 
 type ScriptsT = TFunction<'scripts'>;
 
@@ -10,12 +17,23 @@ type ScriptParametersFormProps = {
   onChange: (name: string, value: unknown) => void;
 };
 
+/**
+ * The single validator for every run surface (execution modal, device picker,
+ * fleet fix picker).
+ *
+ * Bound parameters (#3409 PR3) are skipped outright: the invoker cannot supply
+ * one — the server resolves it per target device — so requiring a value here
+ * would block a run the server is perfectly able to complete. Their `required`
+ * flag still matters, but it is evaluated at dispatch AFTER resolution and the
+ * definition default, which is information this form does not have.
+ */
 export function validateParameters(
   parameters: ScriptParameter[],
   values: Record<string, unknown>,
   t?: ScriptsT
 ): string | null {
   for (const param of parameters) {
+    if (isBoundParameter(param)) continue;
     const value = values[param.name];
     if (param.required) {
       if (value === undefined || value === null || value === '' || (param.type === 'string' && String(value).trim() === '')) {
@@ -41,13 +59,19 @@ export default function ScriptParametersForm({
   onChange
 }: ScriptParametersFormProps) {
   const { t } = useTranslation('scripts');
-  if (parameters.length === 0) return null;
+  const runtimeParams = runtimeParameters(parameters);
+  const boundParams = parameters.filter(isBoundParameter);
+  // Nothing to ask for: a script whose parameters are ALL bound needs no run-time
+  // step at all. The gate is deliberately on the runtime count, not on
+  // `parameters.length` — otherwise a fully-bound script would open an
+  // input-less form the operator can only click through.
+  if (runtimeParams.length === 0) return null;
 
   return (
     <div className="space-y-4">
       <h3 className="text-sm font-semibold">{t('scriptParametersForm.title')}</h3>
       <div className="grid gap-4 sm:grid-cols-2">
-        {parameters.map(param => (
+        {runtimeParams.map(param => (
           <div key={param.name} className="space-y-1">
             <label className="text-sm font-medium">
               {param.name}
@@ -96,6 +120,28 @@ export default function ScriptParametersForm({
                 className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
               />
             )}
+          </div>
+        ))}
+
+        {/* Bound parameters are shown but never editable — the operator should be
+            able to see the whole parameter contract, not just the half they're
+            asked about. No input is rendered, so nothing can enter the outgoing
+            map (a supplied value would be ignored server-side anyway). */}
+        {boundParams.map(param => (
+          <div
+            key={param.name}
+            className="space-y-1"
+            data-testid={`script-bound-parameter-${param.name}`}
+          >
+            <label className="text-sm font-medium">{param.name}</label>
+            <div className="flex h-10 items-center gap-2 rounded-md border border-dashed bg-muted/30 px-3">
+              <Lock className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span className="truncate text-xs text-muted-foreground">
+                {t(/* i18n-dynamic */ `scriptParametersForm.suppliedBy.${parameterSource(param)}`, {
+                  key: parameterBindingKey(param) ?? param.name,
+                })}
+              </span>
+            </div>
           </div>
         ))}
       </div>

--- a/apps/web/src/components/scripts/ScriptParametersForm.tsx
+++ b/apps/web/src/components/scripts/ScriptParametersForm.tsx
@@ -61,15 +61,21 @@ export default function ScriptParametersForm({
   const { t } = useTranslation('scripts');
   const runtimeParams = runtimeParameters(parameters);
   const boundParams = parameters.filter(isBoundParameter);
-  // Nothing to ask for: a script whose parameters are ALL bound needs no run-time
-  // step at all. The gate is deliberately on the runtime count, not on
-  // `parameters.length` — otherwise a fully-bound script would open an
-  // input-less form the operator can only click through.
-  if (runtimeParams.length === 0) return null;
+  // VISIBILITY is gated on the whole parameter list; PROMPTING is gated on the
+  // runtime subset. These are deliberately different questions: a script whose
+  // parameters are ALL bound asks the operator for nothing, but it still
+  // injects values into a script about to run on customer machines, so the
+  // contract must be on screen. Only `parameters.length === 0` renders nothing.
+  if (parameters.length === 0) return null;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" data-testid="script-parameters">
       <h3 className="text-sm font-semibold">{t('scriptParametersForm.title')}</h3>
+      {runtimeParams.length === 0 && (
+        <p className="text-xs text-muted-foreground" data-testid="script-parameters-all-supplied">
+          {t('scriptParametersForm.allSupplied')}
+        </p>
+      )}
       <div className="grid gap-4 sm:grid-cols-2">
         {runtimeParams.map(param => (
           <div key={param.name} className="space-y-1">

--- a/apps/web/src/components/scripts/ScriptVariablePicker.tsx
+++ b/apps/web/src/components/scripts/ScriptVariablePicker.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useRef, useState, type RefObject } from 'react';
-import { Braces } from 'lucide-react';
+import { type RefObject } from 'react';
 import type { EditorProps } from '@monaco-editor/react';
 import { variableToken } from '@breeze/shared';
-import { useTranslation } from 'react-i18next';
 import type { TenantVariableEntry } from '@/lib/tenantVariableTokens';
+import TenantVariableMenu from './TenantVariableMenu';
 
 /** The live editor handed to `onMount` — the same type ScriptForm's ref holds. */
 export type ScriptEditorInstance = Parameters<NonNullable<EditorProps['onMount']>>[0];
@@ -27,6 +26,11 @@ export interface ScriptVariablePickerProps {
  * "Variables" menu for the script editor: inserts a `{{var.<key>}}` token at
  * the caret.
  *
+ * The menu itself lives in `TenantVariableMenu` — shared with the PR3
+ * parameter-binding key picker, which needs the same rows (and the same
+ * disabled-secret rule) but stores a bare key. This component is only the
+ * Monaco insertion half.
+ *
  * Insertion goes through `executeEdits` at the live selection rather than
  * string-slicing the content, so it lands where the cursor is (and replaces a
  * selection) inside a Monaco model — `VariableInput`'s `setSelectionRange`
@@ -38,39 +42,8 @@ export default function ScriptVariablePicker({
   content,
   onInsert,
 }: ScriptVariablePickerProps) {
-  const { t } = useTranslation('scripts');
-  const [open, setOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onPointer = (e: PointerEvent) => {
-      if (
-        !menuRef.current?.contains(e.target as Node) &&
-        !triggerRef.current?.contains(e.target as Node)
-      ) {
-        setOpen(false);
-      }
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.stopPropagation();
-        setOpen(false);
-        triggerRef.current?.focus();
-      }
-    };
-    document.addEventListener('pointerdown', onPointer, true);
-    document.addEventListener('keydown', onKey, true);
-    return () => {
-      document.removeEventListener('pointerdown', onPointer, true);
-      document.removeEventListener('keydown', onKey, true);
-    };
-  }, [open]);
-
   const insert = (key: string) => {
     const token = variableToken(key);
-    setOpen(false);
     const editor = editorRef.current;
     if (!editor) {
       // Monaco hasn't mounted (or failed to load) — append rather than drop the
@@ -97,58 +70,5 @@ export default function ScriptVariablePicker({
     editor.focus();
   };
 
-  return (
-    <div className="relative">
-      <button
-        ref={triggerRef}
-        type="button"
-        onClick={() => setOpen(o => !o)}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        title={t('scriptForm.variables.insertTitle')}
-        className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition hover:bg-muted"
-      >
-        <Braces className="h-3.5 w-3.5" />
-        {t('scriptForm.variables.button')}
-      </button>
-
-      {open && (
-        <div
-          ref={menuRef}
-          role="menu"
-          className="absolute right-0 z-50 mt-1 max-h-72 w-72 overflow-y-auto rounded-md border bg-card p-1 shadow-lg"
-        >
-          {variables.length === 0 ? (
-            <p className="px-2 py-2 text-xs text-muted-foreground">
-              {t('scriptForm.variables.empty')}
-            </p>
-          ) : (
-            variables.map(v => (
-              <button
-                key={v.key}
-                type="button"
-                role="menuitem"
-                disabled={v.isSecret}
-                aria-disabled={v.isSecret || undefined}
-                onClick={() => insert(v.key)}
-                className="w-full rounded px-2 py-1.5 text-left hover:bg-muted focus:bg-muted focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:bg-transparent"
-              >
-                <span className="block truncate text-sm text-foreground">
-                  {v.description || v.key}
-                </span>
-                <span className="block truncate font-mono text-[11px] text-muted-foreground">
-                  {variableToken(v.key)}
-                </span>
-                {v.isSecret && (
-                  <span className="mt-0.5 block text-[11px] text-amber-600 dark:text-amber-500">
-                    {t('scriptForm.variables.secretUnavailable')}
-                  </span>
-                )}
-              </button>
-            ))
-          )}
-        </div>
-      )}
-    </div>
-  );
+  return <TenantVariableMenu variables={variables} onSelect={insert} />;
 }

--- a/apps/web/src/components/scripts/TenantVariableMenu.tsx
+++ b/apps/web/src/components/scripts/TenantVariableMenu.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Braces } from 'lucide-react';
+import { variableToken } from '@breeze/shared';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import type { TenantVariableEntry } from '@/lib/tenantVariableTokens';
+
+export interface TenantVariableMenuProps {
+  /** Offerable variables; secrets render disabled (PR 4 delivers them out-of-band). */
+  variables: TenantVariableEntry[];
+  /**
+   * Receives the KEY, never a token. Callers that want `{{var.<key>}}` build it
+   * with `variableToken` themselves — the parameter-binding picker stores the
+   * bare key, so the menu cannot be the thing that decides the shape.
+   */
+  onSelect: (key: string) => void;
+  /**
+   * Secondary line under each row. Defaults to the `{{var.<key>}}` token, which
+   * is what the content editor inserts; the key picker passes identity.
+   */
+  formatDetail?: (key: string) => string;
+  /** Trigger contents. Defaults to the Braces icon + the "Variables" label. */
+  trigger?: ReactNode;
+  triggerTitle?: string;
+  triggerClassName?: string;
+}
+
+/**
+ * The shared "pick a tenant variable" dropdown (#3409).
+ *
+ * Extracted from `ScriptVariablePicker` when PR3 added parameter bindings: the
+ * two surfaces need the SAME menu — same ordering, same disabled-secret row
+ * with its amber reason — but different payloads (a `{{var.x}}` token at the
+ * caret vs. a bare key stored on a parameter definition). Only the payload and
+ * the trigger chrome are parameterised; the row rendering and the
+ * outside-click / Escape behaviour are shared so a secret can never become
+ * selectable on one surface but not the other.
+ */
+export default function TenantVariableMenu({
+  variables,
+  onSelect,
+  formatDetail = variableToken,
+  trigger,
+  triggerTitle,
+  triggerClassName,
+}: TenantVariableMenuProps) {
+  const { t } = useTranslation('scripts');
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointer = (e: PointerEvent) => {
+      if (
+        !menuRef.current?.contains(e.target as Node) &&
+        !triggerRef.current?.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    document.addEventListener('pointerdown', onPointer, true);
+    document.addEventListener('keydown', onKey, true);
+    return () => {
+      document.removeEventListener('pointerdown', onPointer, true);
+      document.removeEventListener('keydown', onKey, true);
+    };
+  }, [open]);
+
+  return (
+    <div className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={triggerTitle ?? t('scriptForm.variables.insertTitle')}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition hover:bg-muted',
+          triggerClassName
+        )}
+      >
+        {trigger ?? (
+          <>
+            <Braces className="h-3.5 w-3.5" />
+            {t('scriptForm.variables.button')}
+          </>
+        )}
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          role="menu"
+          className="absolute right-0 z-50 mt-1 max-h-72 w-72 overflow-y-auto rounded-md border bg-card p-1 shadow-lg"
+        >
+          {variables.length === 0 ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              {t('scriptForm.variables.empty')}
+            </p>
+          ) : (
+            variables.map(v => (
+              <button
+                key={v.key}
+                type="button"
+                role="menuitem"
+                disabled={v.isSecret}
+                aria-disabled={v.isSecret || undefined}
+                onClick={() => {
+                  setOpen(false);
+                  onSelect(v.key);
+                }}
+                className="w-full rounded px-2 py-1.5 text-left hover:bg-muted focus:bg-muted focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:bg-transparent"
+              >
+                <span className="block truncate text-sm text-foreground">
+                  {v.description || v.key}
+                </span>
+                <span className="block truncate font-mono text-[11px] text-muted-foreground">
+                  {formatDetail(v.key)}
+                </span>
+                {v.isSecret && (
+                  <span className="mt-0.5 block text-[11px] text-amber-600 dark:text-amber-500">
+                    {t('scriptForm.variables.secretUnavailable')}
+                  </span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -2229,6 +2229,7 @@
     },
     "generalCategory": "Allgemein",
     "paramCount": "{{count}} Parameter",
+    "boundParamCount": "{{count}} automatisch",
     "runAs": {
       "system": "Ausführen als: System",
       "user": "Ausführen als: Angemeldeter Benutzer"

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -1073,6 +1073,7 @@
     },
     "title": "Parameter",
     "selectPlaceholder": "Wählen Sie...",
+    "allSupplied": "Alle Parameter werden automatisch bereitgestellt – es ist nichts auszufüllen.",
     "suppliedBy": {
       "tenantVariable": "Wird automatisch aus der Variablen {{key}} übernommen",
       "deviceCustomField": "Wird automatisch aus dem benutzerdefinierten Gerätefeld {{key}} übernommen",

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -916,7 +916,9 @@
       "timeoutSeconds": "Timeout (Sekunden)",
       "runAs": "Ausführen als",
       "exitCode": "Exit-Code",
-      "severity": "Schweregrad"
+      "severity": "Schweregrad",
+      "source": "Quelle",
+      "fallbackValue": "Ersatzwert"
     },
     "placeholders": {
       "name": "Temporäre Dateien löschen",
@@ -939,7 +941,8 @@
     "parameters": {
       "emptyPrefix": "Noch keine Parameter. Mit Parametern können Benutzer zur Laufzeit Werte angeben – verweisen Sie sie in Ihrem Skript als",
       "emptyMiddle": "(PowerShell/Bash) oder",
-      "emptySuffix": "(Python)."
+      "emptySuffix": "(Python).",
+      "sourceAriaLabel": "Quelle für Parameter {{index}}"
     },
     "execution": {
       "timeoutHint": "Das Skript wird nach dieser Dauer beendet. Die Standardeinstellung von 300 Sekunden (5 Minuten) ist für die meisten Aufgaben geeignet. Maximal 3600 Sekunden (1 Stunde).",
@@ -997,6 +1000,22 @@
       "empty": "Noch keine Variablen.",
       "secretUnavailable": "Geheim – wird erst in einer späteren Version als Umgebungsvariable übergeben.",
       "unknown": "Für {{keys}} existiert keine Variable – die Ausführung schlägt auf jedem Zielgerät fehl, bis Sie sie anlegen."
+    },
+    "parameterSources": {
+      "runtime": "Wird bei der Ausführung abgefragt",
+      "tenantVariable": "Aus einer Variablen",
+      "deviceCustomField": "Aus einem benutzerdefinierten Gerätefeld",
+      "builtin": "Aus einer Geräteeigenschaft"
+    },
+    "parameterBinding": {
+      "variableLabel": "Variablenschlüssel",
+      "variablePlaceholder": "z.B. vendor_token",
+      "fieldLabel": "Schlüssel des benutzerdefinierten Felds",
+      "fieldPlaceholder": "z.B. asset_tag",
+      "builtinLabel": "Eigenschaft",
+      "chooseTitle": "Variable auswählen",
+      "secretRejected": "„{{key}}“ ist geheim – das Speichern wird abgelehnt. Wählen Sie eine Variable, die nicht geheim ist.",
+      "hint": "Wird bei der Ausführung für jedes Zielgerät aufgelöst – niemand wird danach gefragt."
     }
   },
   "scriptList": {
@@ -1053,7 +1072,12 @@
       "number": "Parameter „{{name}}“ muss eine gültige Zahl sein"
     },
     "title": "Parameter",
-    "selectPlaceholder": "Wählen Sie..."
+    "selectPlaceholder": "Wählen Sie...",
+    "suppliedBy": {
+      "tenantVariable": "Wird automatisch aus der Variablen {{key}} übernommen",
+      "deviceCustomField": "Wird automatisch aus dem benutzerdefinierten Gerätefeld {{key}} übernommen",
+      "builtin": "Wird automatisch aus {{key}} übernommen"
+    }
   },
   "scriptTagManager": {
     "errors": {

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -2229,6 +2229,7 @@
     },
     "generalCategory": "General",
     "paramCount": "{{count}} param(s)",
+    "boundParamCount": "{{count}} auto-supplied",
     "runAs": {
       "system": "Run as: System",
       "user": "Run as: Logged-in user"

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -916,7 +916,9 @@
       "timeoutSeconds": "Timeout (seconds)",
       "runAs": "Run As",
       "exitCode": "Exit code",
-      "severity": "Severity"
+      "severity": "Severity",
+      "source": "Source",
+      "fallbackValue": "Fallback value"
     },
     "placeholders": {
       "name": "Clear Temp Files",
@@ -939,7 +941,8 @@
     "parameters": {
       "emptyPrefix": "No parameters yet. Parameters let users supply values at runtime — reference them in your script as",
       "emptyMiddle": "(PowerShell/Bash) or",
-      "emptySuffix": "(Python)."
+      "emptySuffix": "(Python).",
+      "sourceAriaLabel": "Source for parameter {{index}}"
     },
     "execution": {
       "timeoutHint": "Script is killed after this duration. Default 300s (5 min) is suitable for most tasks. Maximum 3600s (1 hour).",
@@ -997,6 +1000,22 @@
       "empty": "No variables yet.",
       "secretUnavailable": "Secret — a later release delivers it as an environment variable.",
       "unknown": "No variable exists for {{keys}} — targeted devices will fail until you create it."
+    },
+    "parameterSources": {
+      "runtime": "Asked at run time",
+      "tenantVariable": "From a variable",
+      "deviceCustomField": "From a device custom field",
+      "builtin": "From a device property"
+    },
+    "parameterBinding": {
+      "variableLabel": "Variable key",
+      "variablePlaceholder": "e.g. vendor_token",
+      "fieldLabel": "Custom field key",
+      "fieldPlaceholder": "e.g. asset_tag",
+      "builtinLabel": "Property",
+      "chooseTitle": "Choose a variable",
+      "secretRejected": "\"{{key}}\" is a secret — the save will be rejected. Choose a variable that is not a secret.",
+      "hint": "Resolved for every target device when the script runs — nobody is asked for it."
     }
   },
   "scriptList": {
@@ -1053,7 +1072,12 @@
       "number": "Parameter \"{{name}}\" must be a valid number"
     },
     "title": "Parameters",
-    "selectPlaceholder": "Select..."
+    "selectPlaceholder": "Select...",
+    "suppliedBy": {
+      "tenantVariable": "Supplied automatically from variable {{key}}",
+      "deviceCustomField": "Supplied automatically from device custom field {{key}}",
+      "builtin": "Supplied automatically from {{key}}"
+    }
   },
   "scriptTagManager": {
     "errors": {

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -1073,6 +1073,7 @@
     },
     "title": "Parameters",
     "selectPlaceholder": "Select...",
+    "allSupplied": "Every parameter is supplied automatically — there is nothing to fill in.",
     "suppliedBy": {
       "tenantVariable": "Supplied automatically from variable {{key}}",
       "deviceCustomField": "Supplied automatically from device custom field {{key}}",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -2229,6 +2229,7 @@
     },
     "generalCategory": "General",
     "paramCount": "parámetros {{count}}",
+    "boundParamCount": "{{count}} automáticos",
     "runAs": {
       "system": "Ejecutar como: Sistema",
       "user": "Ejecutar como: usuario registrado"

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -916,7 +916,9 @@
       "timeoutSeconds": "Tiempo de espera (segundos)",
       "runAs": "Ejecutar como",
       "exitCode": "código de salida",
-      "severity": "Gravedad"
+      "severity": "Gravedad",
+      "source": "Origen",
+      "fallbackValue": "Valor de reserva"
     },
     "placeholders": {
       "name": "Borrar archivos temporales",
@@ -939,7 +941,8 @@
     "parameters": {
       "emptyPrefix": "Aún no hay parámetros. Los parámetros permiten a los usuarios proporcionar valores en tiempo de ejecución; haga referencia a ellos en su secuencia de comandos como",
       "emptyMiddle": "(PowerShell/Bash) o",
-      "emptySuffix": "(Python)."
+      "emptySuffix": "(Python).",
+      "sourceAriaLabel": "Origen del parámetro {{index}}"
     },
     "execution": {
       "timeoutHint": "El script se elimina después de esta duración. Los 300 segundos (5 min) predeterminados son adecuados para la mayoría de las tareas. Máximo 3600s (1 hora).",
@@ -997,6 +1000,22 @@
       "empty": "Aún no hay variables.",
       "secretUnavailable": "Secreto: una versión posterior lo entregará como variable de entorno.",
       "unknown": "No existe ninguna variable para {{keys}}: los dispositivos seleccionados fallarán hasta que la crees."
+    },
+    "parameterSources": {
+      "runtime": "Se pregunta al ejecutar",
+      "tenantVariable": "Desde una variable",
+      "deviceCustomField": "Desde un campo personalizado del dispositivo",
+      "builtin": "Desde una propiedad del dispositivo"
+    },
+    "parameterBinding": {
+      "variableLabel": "Clave de la variable",
+      "variablePlaceholder": "p.ej. vendor_token",
+      "fieldLabel": "Clave del campo personalizado",
+      "fieldPlaceholder": "p.ej. asset_tag",
+      "builtinLabel": "Propiedad",
+      "chooseTitle": "Elegir una variable",
+      "secretRejected": "\"{{key}}\" es secreta: se rechazará el guardado. Elige una variable que no sea secreta.",
+      "hint": "Se resuelve para cada dispositivo de destino al ejecutar el script: nadie tiene que indicarlo."
     }
   },
   "scriptList": {
@@ -1053,7 +1072,12 @@
       "number": "El parámetro \"{{name}}\" debe ser un número válido"
     },
     "title": "Parámetros",
-    "selectPlaceholder": "Seleccionar..."
+    "selectPlaceholder": "Seleccionar...",
+    "suppliedBy": {
+      "tenantVariable": "Se completa automáticamente desde la variable {{key}}",
+      "deviceCustomField": "Se completa automáticamente desde el campo personalizado del dispositivo {{key}}",
+      "builtin": "Se completa automáticamente desde {{key}}"
+    }
   },
   "scriptTagManager": {
     "errors": {

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -1073,6 +1073,7 @@
     },
     "title": "Parámetros",
     "selectPlaceholder": "Seleccionar...",
+    "allSupplied": "Todos los parámetros se proporcionan automáticamente: no hay nada que completar.",
     "suppliedBy": {
       "tenantVariable": "Se completa automáticamente desde la variable {{key}}",
       "deviceCustomField": "Se completa automáticamente desde el campo personalizado del dispositivo {{key}}",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -2229,6 +2229,7 @@
     },
     "generalCategory": "Généralités",
     "paramCount": "{{count}} paramètre(s)",
+    "boundParamCount": "{{count}} automatique(s)",
     "runAs": {
       "system": "Exécuter sous : Système",
       "user": "Exécuter en tant que : utilisateur connecté"

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -916,7 +916,9 @@
       "timeoutSeconds": "Délai d’expiration (secondes)",
       "runAs": "Exécuter en tant que",
       "exitCode": "Code de sortie",
-      "severity": "Gravité"
+      "severity": "Gravité",
+      "source": "Provenance",
+      "fallbackValue": "Valeur de repli"
     },
     "placeholders": {
       "name": "Nettoyer les fichiers temporaires",
@@ -939,7 +941,8 @@
     "parameters": {
       "emptyPrefix": "Aucun paramètre pour l’instant. Les paramètres permettent aux utilisateurs de fournir des valeurs à l’exécution — référencez-les dans votre script comme",
       "emptyMiddle": "(PowerShell/Bash) ou",
-      "emptySuffix": "(Python)."
+      "emptySuffix": "(Python).",
+      "sourceAriaLabel": "Provenance du paramètre {{index}}"
     },
     "execution": {
       "timeoutHint": "Le script est arrêté après cette durée. La valeur par défaut 300s (5 min) convient à la plupart des tâches. Maximum 3600s (1 heure).",
@@ -997,6 +1000,22 @@
       "empty": "Aucune variable pour l'instant.",
       "secretUnavailable": "Secret — une version ultérieure la transmettra comme variable d'environnement.",
       "unknown": "Aucune variable ne correspond à {{keys}} — les appareils ciblés échoueront tant qu'elle n'existe pas."
+    },
+    "parameterSources": {
+      "runtime": "Demandé à l’exécution",
+      "tenantVariable": "À partir d’une variable",
+      "deviceCustomField": "À partir d’un champ personnalisé de l’appareil",
+      "builtin": "À partir d’une propriété de l’appareil"
+    },
+    "parameterBinding": {
+      "variableLabel": "Clé de la variable",
+      "variablePlaceholder": "p. ex. vendor_token",
+      "fieldLabel": "Clé du champ personnalisé",
+      "fieldPlaceholder": "p. ex. asset_tag",
+      "builtinLabel": "Propriété",
+      "chooseTitle": "Choisir une variable",
+      "secretRejected": "« {{key}} » est un secret — l’enregistrement sera refusé. Choisissez une variable non secrète.",
+      "hint": "Résolu pour chaque appareil ciblé au moment de l’exécution — personne n’a à le saisir."
     }
   },
   "scriptList": {
@@ -1053,7 +1072,12 @@
       "number": "Le paramètre \"{{name}}\" doit être un nombre valide"
     },
     "title": "Paramètres",
-    "selectPlaceholder": "Sélectionner..."
+    "selectPlaceholder": "Sélectionner...",
+    "suppliedBy": {
+      "tenantVariable": "Fourni automatiquement par la variable {{key}}",
+      "deviceCustomField": "Fourni automatiquement par le champ personnalisé de l’appareil {{key}}",
+      "builtin": "Fourni automatiquement par {{key}}"
+    }
   },
   "scriptTagManager": {
     "errors": {

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -1073,6 +1073,7 @@
     },
     "title": "Paramètres",
     "selectPlaceholder": "Sélectionner...",
+    "allSupplied": "Tous les paramètres sont fournis automatiquement — il n'y a rien à saisir.",
     "suppliedBy": {
       "tenantVariable": "Fourni automatiquement par la variable {{key}}",
       "deviceCustomField": "Fourni automatiquement par le champ personnalisé de l’appareil {{key}}",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -2229,6 +2229,7 @@
     },
     "generalCategory": "Généralités",
     "paramCount": "{{count}} paramètre(s)",
+    "boundParamCount": "{{count}} automatique(s)",
     "runAs": {
       "system": "Exécuter sous : Système",
       "user": "Exécuter en tant que : utilisateur connecté"

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -916,7 +916,9 @@
       "timeoutSeconds": "Délai d’expiration (secondes)",
       "runAs": "Exécuter en tant que",
       "exitCode": "Code de sortie",
-      "severity": "Gravité"
+      "severity": "Gravité",
+      "source": "Provenance",
+      "fallbackValue": "Valeur de repli"
     },
     "placeholders": {
       "name": "Nettoyer les fichiers temporaires",
@@ -939,7 +941,8 @@
     "parameters": {
       "emptyPrefix": "Aucun paramètre pour l’instant. Les paramètres permettent aux utilisateurs de fournir des valeurs à l’exécution — référencez-les dans votre script comme",
       "emptyMiddle": "(PowerShell/Bash) ou",
-      "emptySuffix": "(Python)."
+      "emptySuffix": "(Python).",
+      "sourceAriaLabel": "Provenance du paramètre {{index}}"
     },
     "execution": {
       "timeoutHint": "Le script est arrêté après cette durée. La valeur par défaut 300s (5 min) convient à la plupart des tâches. Maximum 3600s (1 heure).",
@@ -997,6 +1000,22 @@
       "empty": "Aucune variable pour l'instant.",
       "secretUnavailable": "Secret — une version ultérieure la transmettra comme variable d'environnement.",
       "unknown": "Aucune variable ne correspond à {{keys}} — les appareils ciblés échoueront tant qu'elle n'existe pas."
+    },
+    "parameterSources": {
+      "runtime": "Demandé à l’exécution",
+      "tenantVariable": "À partir d’une variable",
+      "deviceCustomField": "À partir d’un champ personnalisé de l’appareil",
+      "builtin": "À partir d’une propriété de l’appareil"
+    },
+    "parameterBinding": {
+      "variableLabel": "Clé de la variable",
+      "variablePlaceholder": "p. ex. vendor_token",
+      "fieldLabel": "Clé du champ personnalisé",
+      "fieldPlaceholder": "p. ex. asset_tag",
+      "builtinLabel": "Propriété",
+      "chooseTitle": "Choisir une variable",
+      "secretRejected": "« {{key}} » est un secret — l’enregistrement sera refusé. Choisissez une variable non secrète.",
+      "hint": "Résolu pour chaque appareil ciblé au moment de l’exécution — personne n’a à le saisir."
     }
   },
   "scriptList": {
@@ -1053,7 +1072,12 @@
       "number": "Le paramètre \"{{name}}\" doit être un nombre valide"
     },
     "title": "Paramètres",
-    "selectPlaceholder": "Sélectionner..."
+    "selectPlaceholder": "Sélectionner...",
+    "suppliedBy": {
+      "tenantVariable": "Fourni automatiquement par la variable {{key}}",
+      "deviceCustomField": "Fourni automatiquement par le champ personnalisé de l’appareil {{key}}",
+      "builtin": "Fourni automatiquement par {{key}}"
+    }
   },
   "scriptTagManager": {
     "errors": {

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -1073,6 +1073,7 @@
     },
     "title": "Paramètres",
     "selectPlaceholder": "Sélectionner...",
+    "allSupplied": "Tous les paramètres sont fournis automatiquement — il n'y a rien à saisir.",
     "suppliedBy": {
       "tenantVariable": "Fourni automatiquement par la variable {{key}}",
       "deviceCustomField": "Fourni automatiquement par le champ personnalisé de l’appareil {{key}}",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -2229,6 +2229,7 @@
     },
     "generalCategory": "Generale",
     "paramCount": "{{count}} parametri",
+    "boundParamCount": "{{count}} automatici",
     "runAs": {
       "system": "Esegui come: System",
       "user": "Esegui come: utente connesso"

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -916,7 +916,9 @@
       "timeoutSeconds": "Timeout (secondi)",
       "runAs": "Esegui come",
       "exitCode": "Codice di uscita",
-      "severity": "Gravità"
+      "severity": "Gravità",
+      "source": "Origine",
+      "fallbackValue": "Valore di riserva"
     },
     "placeholders": {
       "name": "Cancella file temporanei",
@@ -939,7 +941,8 @@
     "parameters": {
       "emptyPrefix": "Non ci sono ancora parametri. I parametri consentono agli utenti di fornire valori in fase di esecuzione - referenziali nello script come",
       "emptyMiddle": "(PowerShell/Bash) o",
-      "emptySuffix": "(Python)."
+      "emptySuffix": "(Python).",
+      "sourceAriaLabel": "Origine del parametro {{index}}"
     },
     "execution": {
       "timeoutHint": "Lo script viene terminato dopo questa durata. Il valore predefinito di 300 s (5 min) è adatto alla maggior parte delle attività. Massimo 3600 s (1 ora).",
@@ -997,6 +1000,22 @@
       "empty": "Ancora nessuna variabile.",
       "secretUnavailable": "Segreto: una versione futura lo passerà come variabile d'ambiente.",
       "unknown": "Non esiste alcuna variabile per {{keys}}: i dispositivi selezionati falliranno finché non la crei."
+    },
+    "parameterSources": {
+      "runtime": "Richiesto all’esecuzione",
+      "tenantVariable": "Da una variabile",
+      "deviceCustomField": "Da un campo personalizzato del dispositivo",
+      "builtin": "Da una proprietà del dispositivo"
+    },
+    "parameterBinding": {
+      "variableLabel": "Chiave della variabile",
+      "variablePlaceholder": "es. vendor_token",
+      "fieldLabel": "Chiave del campo personalizzato",
+      "fieldPlaceholder": "es. asset_tag",
+      "builtinLabel": "Proprietà",
+      "chooseTitle": "Scegli una variabile",
+      "secretRejected": "\"{{key}}\" è segreta: il salvataggio verrà rifiutato. Scegli una variabile non segreta.",
+      "hint": "Viene risolto per ogni dispositivo di destinazione all’esecuzione dello script: nessuno deve indicarlo."
     }
   },
   "scriptList": {
@@ -1053,7 +1072,12 @@
       "number": "Il parametro \"{{name}}\" deve essere un numero valido"
     },
     "title": "Parametri",
-    "selectPlaceholder": "Seleziona..."
+    "selectPlaceholder": "Seleziona...",
+    "suppliedBy": {
+      "tenantVariable": "Fornito automaticamente dalla variabile {{key}}",
+      "deviceCustomField": "Fornito automaticamente dal campo personalizzato del dispositivo {{key}}",
+      "builtin": "Fornito automaticamente da {{key}}"
+    }
   },
   "scriptTagManager": {
     "errors": {

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -1073,6 +1073,7 @@
     },
     "title": "Parametri",
     "selectPlaceholder": "Seleziona...",
+    "allSupplied": "Tutti i parametri vengono forniti automaticamente: non c'è nulla da compilare.",
     "suppliedBy": {
       "tenantVariable": "Fornito automaticamente dalla variabile {{key}}",
       "deviceCustomField": "Fornito automaticamente dal campo personalizzato del dispositivo {{key}}",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -2229,6 +2229,7 @@
     },
     "generalCategory": "Geral",
     "paramCount": "Parâmetros: {{count}}",
+    "boundParamCount": "Automáticos: {{count}}",
     "runAs": {
       "system": "Executar como: Sistema",
       "user": "Executar como: usuário conectado"

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -1073,6 +1073,7 @@
     },
     "title": "Parâmetros",
     "selectPlaceholder": "Selecione...",
+    "allSupplied": "Todos os parâmetros são fornecidos automaticamente — não há nada para preencher.",
     "suppliedBy": {
       "tenantVariable": "Fornecido automaticamente pela variável {{key}}",
       "deviceCustomField": "Fornecido automaticamente pelo campo personalizado do dispositivo {{key}}",

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -916,7 +916,9 @@
       "timeoutSeconds": "Tempo limite (segundos)",
       "runAs": "Executar como",
       "exitCode": "Código de saída",
-      "severity": "Gravidade"
+      "severity": "Gravidade",
+      "source": "Origem",
+      "fallbackValue": "Valor de reserva"
     },
     "placeholders": {
       "name": "Limpar arquivos temporários",
@@ -939,7 +941,8 @@
     "parameters": {
       "emptyPrefix": "Ainda não há parâmetros. Parâmetros permitem que usuários informem valores em tempo de execução — referencie-os no script como",
       "emptyMiddle": "(PowerShell/Bash) ou",
-      "emptySuffix": "(Python)."
+      "emptySuffix": "(Python).",
+      "sourceAriaLabel": "Origem do parâmetro {{index}}"
     },
     "execution": {
       "timeoutHint": "O script é encerrado após essa duração. O padrão de 300s (5 min) é adequado para a maioria das tarefas. Máximo de 3600s (1 hora).",
@@ -997,6 +1000,22 @@
       "empty": "Nenhuma variável ainda.",
       "secretUnavailable": "Secreto — uma versão futura o entregará como variável de ambiente.",
       "unknown": "Não existe variável para {{keys}} — os dispositivos selecionados vão falhar até você criá-la."
+    },
+    "parameterSources": {
+      "runtime": "Perguntado na execução",
+      "tenantVariable": "De uma variável",
+      "deviceCustomField": "De um campo personalizado do dispositivo",
+      "builtin": "De uma propriedade do dispositivo"
+    },
+    "parameterBinding": {
+      "variableLabel": "Chave da variável",
+      "variablePlaceholder": "ex.: vendor_token",
+      "fieldLabel": "Chave do campo personalizado",
+      "fieldPlaceholder": "ex.: asset_tag",
+      "builtinLabel": "Propriedade",
+      "chooseTitle": "Escolher uma variável",
+      "secretRejected": "\"{{key}}\" é secreta — o salvamento será rejeitado. Escolha uma variável que não seja secreta.",
+      "hint": "Resolvido para cada dispositivo de destino quando o script é executado — ninguém precisa informar."
     }
   },
   "scriptList": {
@@ -1053,7 +1072,12 @@
       "number": "O parâmetro \"{{name}}\" deve ser um número válido"
     },
     "title": "Parâmetros",
-    "selectPlaceholder": "Selecione..."
+    "selectPlaceholder": "Selecione...",
+    "suppliedBy": {
+      "tenantVariable": "Fornecido automaticamente pela variável {{key}}",
+      "deviceCustomField": "Fornecido automaticamente pelo campo personalizado do dispositivo {{key}}",
+      "builtin": "Fornecido automaticamente por {{key}}"
+    }
   },
   "scriptTagManager": {
     "errors": {

--- a/docs/superpowers/plans/2026-08-13-pr3-sourced-parameters.md
+++ b/docs/superpowers/plans/2026-08-13-pr3-sourced-parameters.md
@@ -183,6 +183,9 @@ Automation parameter capture (`AutomationForm.tsx:61-69,676-690` has **no** para
 2. **Duplicate parameter keys that collide as env vars are now rejected** (`log-level` vs `log_level` vs `logLevel`). Previously accepted, with a **nondeterministic** winner per run.
 3. **A value supplied for a bound parameter is ignored**, reported in `ignoredParameters`, and audited.
 4. **`script.version` now increments when parameter definitions change**, not only content.
+5. **Required `runtime` parameters are now enforced server-side.** `required` was previously only checked in the browser (`ScriptParametersForm.validateParameters`) — the server had no definition schema at all, so it could not enforce it. Now a required runtime parameter with no caller value and no default fails that device.
+
+   > This mainly bites **automations**, which have no parameter-capture UI and send `{}`. Such a run was *already* broken — the agent received no value, left `{{param}}` verbatim in the script, and never set `BREEZE_PARAM_*` — so this converts a silent wrong-result into a loud failure rather than breaking something that worked. Same class as PR2's parameter-strictness item, and it must be release-noted with it.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-13-pr3-sourced-parameters.md
+++ b/docs/superpowers/plans/2026-08-13-pr3-sourced-parameters.md
@@ -1,0 +1,191 @@
+# PR3 — Sourced Script Parameters (#3409)
+
+**Branch:** `ToddHebebrand/tenant-variables-pr3` (off main) · **Stacked on:** nothing — PR1/PR2 are merged
+**Depends on:** `tenant_variables` (PR1 #3494), `{{var.*}}` resolver + `scriptDispatch` chokepoint (PR2 #3495)
+
+---
+
+## 1. What this delivers
+
+A script's parameter **definition** gains a `source` binding:
+
+| source | Value comes from |
+|---|---|
+| `runtime` | the invoker at run time (today's behaviour — the default) |
+| `tenantVariable` | a `tenant_variables` row, resolved per target device's org (org > partner) |
+| `deviceCustomField` | the target device's `custom_fields` JSONB |
+| `builtin` | org / site / device properties |
+
+At dispatch, bound parameters are pre-filled **per target device** by the server. The run modal prompts only for `runtime` parameters. The same resolver feeds both consumers.
+
+Secrets remain unusable in v1 — a `tenantVariable` binding to a secret is rejected at save and fails per device at dispatch. PR4 adds the out-of-band channel.
+
+---
+
+## 2. Settled design (advisor quorum: Opus + codex gpt-5.6-sol xhigh, 2026-08-13)
+
+### 2.1 Precedence
+
+**Bound parameter** (`source !== 'runtime'`):
+```
+resolved non-blank source value  →  definition default  →  missing
+```
+An invoker-supplied value is **not a candidate**. If it were, the binding would be a suggested default rather than an authoritative source.
+
+**Runtime parameter:**
+```
+explicit invoker value  →  definition default  →  missing
+```
+
+`required` is evaluated **after** precedence, never before. For bound sources, `null`, absent, empty string, and **whitespace-only** all count as missing — matching the existing installer resolver's blank rule (`installerVariables.ts:91-95`).
+
+### 2.2 Invoker override — ignored, not rejected
+
+A caller supplying a value for a bound key has that value **ignored**; the binding wins. The response carries a structured `ignoredParameters: string[]`, and it is audited.
+
+> **Why not 400.** `automationRuntime.ts:366` validates stored automation actions *without consulting the referenced script definition*, so an automation literally cannot pre-validate against a binding. A hard reject would convert a previously-valid stored automation into a delayed runtime failure the moment a script author flips a parameter to bound — with no authoring-time signal. The binding still wins authoritatively, so ignoring weakens nothing.
+
+> **Digest integrity is preserved separately, not by rejecting.** Raw caller parameters and the server-built resolved map are kept in **separate trust domains**: dispatch produces a `ResolvedParameterSnapshot` (definition version, binding identity, tenant-variable version, final canonical strings). PR4's four-eyes digest pins *that snapshot* and dispatches from it. Raw caller input must never masquerade as a pinned snapshot.
+
+**Known transition gap:** for automation consumers the warning has no UI surface today, so the ignore is effectively silent there. Mitigate by auditing it and projecting it onto execution history. Accepted for this PR; a strict mode belongs to a future versioned API.
+
+### 2.3 Required / missing
+
+Apply the default first, then:
+
+| Case | Behaviour |
+|---|---|
+| Required, nothing resolved and no default | **Fail that device** — `script_executions` row `status:'failed'`, fan-out continues |
+| Optional, nothing resolved and no default | **Omit the parameter** |
+| Any | Never abort the whole fan-out because some devices lack a binding |
+
+Failure code is **`unresolved_parameters`** — deliberately distinct from PR2's `unresolved_variables`, so parameter-binding failures are not conflated with content-token failures. Error messages carry **key names, never values**.
+
+The existing aggregate contract is preserved: all devices failed ⇒ 422 (`routes/scripts.ts:931`, shipped in PR2).
+
+### 2.4 Source flips to secret
+
+- **Save / import:** a `tenantVariable` binding whose target is currently `is_secret` ⇒ **400**.
+- **Dispatch:** re-check authoritatively; each affected device **fails**.
+
+**A secret result is a policy denial, not "missing".** Do *not* fall back to the definition default, do *not* use an invoker value, do *not* omit. Any of those would silently bypass an operator's deliberate classification change.
+
+*(PR4 note: a secret flip must also invalidate an already-pinned approval snapshot. "Dispatch the exact pinned snapshot" freezes values; it must not bypass a later security revocation.)*
+
+### 2.5 Definition schema
+
+Promote a single `scriptParameterDefinitionSchema` into `packages/shared/src/validators/` as a **discriminated union on `source`**, each arm requiring only its own binding field. This closes the `z.any()` gap at `routes/scripts.ts:235,253`.
+
+Today the shape is mirrored in three places with no authority — `apps/web/src/components/scripts/ScriptFormSchema.ts:4-10`, `packages/shared/src/validators/ai.ts:88-94`, `apps/api/src/services/scriptBuilderTools.ts:174-180`. All three must import the shared schema.
+
+**Collision detection** goes on the containing array via `superRefine`, normalizing **exactly as the agent does**: `name.toUpperCase().replaceAll('-','_')` (`agent/internal/executor/executor.go:339-341`). This rejects hyphen/underscore *and* case collisions.
+
+> This is a live nondeterminism bug, not a hypothetical. `log-level` and `log_level` are distinct JS keys, both pass today's validation, both reach the agent, and both map to `BREEZE_PARAM_LOG_LEVEL`. `Cmd.Env` keeps the last entry and Go randomizes map iteration order — **so the winner varies between runs of the same script.** Uppercasing widens it: `logLevel`/`LOGLEVEL`/`loglevel` collide too. Nothing tests this today.
+
+**`script.version` must increment when parameter definitions change.** Today only content changes bump it (`routes/scripts.ts:768`). PR4's digest pins definition version, so this gap must close here.
+
+---
+
+## 3. Prerequisites inside this PR
+
+These are not optional cleanups — sourced parameters are incorrect or pathological without them.
+
+### P1 — Extend the scope-preload gate beyond content
+
+`hasVariableTokens(script.content)` currently gates scope loading at `scriptExecution.ts:169-170`, `automationRuntime.ts:902-903`, `aiToolsScripts.ts:295-296`. Sourced parameters live in `scripts.parameters`, **not** content — so without extending the gate, every bound parameter resolves against an empty scope and silently fails.
+
+Add `scriptNeedsVariableScope(script)` = `hasVariableTokens(content) || hasTenantVariableBoundParameters(parameters)`.
+
+> **Test-design warning:** PR2 hit exactly this trap — its three preload tests were written against token-free fixtures and would have passed with the gate wired to constant `false`. Every gate test here must be **mutation-verified**: forcing the gate false must fail the new tests and nothing else.
+
+### P2 — Fix the automation N-connection trap *before* adding a second resolver
+
+`automationRuntime.ts:902` loads the variable scope **per device per `run_script` action** (device loop at `:1812` with concurrency 5; second runner at `:2368`), where `scriptExecution.ts:169` loads once per fan-out. Adding a second per-device loader on top would compound it. Hoist to once per action set, keyed by the distinct org set.
+
+### P3 — Widen the device projection
+
+`DispatchScriptInput.device` is `Pick<…,'id'|'orgId'|'osType'|'status'|'agentId'>` (`scriptDispatch.ts:40`) — no `customFields`, `siteId`, or `hostname`, all of which `deviceCustomField` and `builtin` need.
+
+- `scriptExecution.ts:99-102` already selects full device rows — no change needed.
+- `automationRuntime.ts:1743-1754` uses a **narrow** projection, mirrored in `ActionExecutionContext.device` (`:797-810`) — both must widen.
+
+### P4 — Resolved values must not enter `script_executions.parameters`
+
+`scriptDispatch.ts:176` inserts `parameters` **raw** into the execution row, before canonicalization. Resolved bound values must **not** flow into that insert.
+
+Per the issue's audit design, dispatch persists **bindings** `{key, source, variableId, ownerScope, version}` — *never values*. Execution history therefore records the caller-supplied runtime parameters plus a binding descriptor; the resolved values exist only in the command payload that reaches the agent. This is what keeps PR3 forward-compatible with PR4, where persisting a resolved secret would be exactly the leak the separate channel exists to prevent.
+
+---
+
+## 4. Where resolution happens
+
+One chokepoint, inside `dispatchScriptToDevice` (`scriptDispatch.ts:87`), ordered:
+
+```
+decommission check (:90)
+  → live status re-read if requireOnline (:106)
+  → org-equality + OS check (:122)
+  → parameters = input.parameters ?? {} (:135)
+  → [PR2] content {{var.*}} substitution (:152-162)
+  → [NEW] sourced-parameter resolution  ← here
+  → script_executions insert (:167-179)   ← runtime params + binding descriptor only
+  → payload build + canonicalizeScriptParameters (:241)
+  → queueCommand
+```
+
+Resolution lands **before** the execution insert so a failing device leaves no orphan `pending` row — the same rule PR2 established for content substitution.
+
+`{kind:'raw'}` (`execute_command`) is skipped: there is no declaring script, so there are no definitions to bind.
+
+---
+
+## 5. Reuse — do not reinvent
+
+| Reuse verbatim | Build new |
+|---|---|
+| `loadTenantVariableScope` / `resolveForOrg` / `TenantVariableScope` (`tenantVariableResolution.ts:121,205`) | Parameter-level resolver — today's substitution is content-only |
+| `runOutsideDbContext(() => withSystemDbAccessContext(...))` — **both** wrappers, in that order (`:127-128`) | Device custom-field lookup — no helper exists; `devices.customFields` is raw JSONB |
+| Per-device fail-don't-abort pattern (`scriptExecution.ts:245-260`) | API-side **builtin registry** — only five hand-written `switch` arms exist (`installerVariables.ts:50-65`), with the sole tripwire web-side (`installerVariables.test.ts:9-19`). Needs a shared constant + reciprocal test |
+| `canonicalizeScriptParameters` at `:241` — resolved values become `map[string]string` for free | Discriminated-union definition schema + array-level collision `superRefine` |
+| Secret policy: never substitute textually (`tenantVariableResolution.ts:234-258`) | `ResolvedParameterSnapshot` type (PR4 digests it) |
+
+---
+
+## 6. UI
+
+`ScriptParametersForm.tsx` is the **single shared renderer** for every run surface — so the "skip bound params" logic lands in one place.
+
+- `ScriptFormSchema.ts:4-10` — add `source` (default `'runtime'`) + binding key; `addParameter()` (`ScriptForm.tsx:333-341`) must seed `source:'runtime'` so existing rows keep today's behaviour.
+- `ScriptForm.tsx:632-670` — source `<select>` in the row; `defaultValue`/`required`/`options` become conditional; a key picker appears for bound sources. Reuse `ScriptVariablePicker`'s menu.
+- `ScriptParametersForm.tsx:13-36,44,46-102` — `validateParameters` must not require a value for bound params; render them read-only with a "supplied by <source>" chip; the `length === 0` early return becomes "no runtime params".
+- `ScriptExecutionModal.tsx:256-263` and `ScriptPickerModal.tsx:157-181,322-325` — visibility gate and default-seeding must count **runtime** params only.
+- **i18n:** new keys in `en/scripts.json` must be added to all seven locales in the same commit — `en`, `pt-BR`, `es-419`, `fr-FR`, `fr-CA`, `de-DE`, `it-IT` — exact key-set equality is asserted (`localeParity.test.ts:338-345`).
+
+Automation parameter capture (`AutomationForm.tsx:61-69,676-690` has **no** parameter UI today) is **out of scope** — noted as a follow-up.
+
+---
+
+## 7. Testing
+
+**Unit** — new: definition schema (each union arm, collision `superRefine` incl. case collisions, key grammar), parameter resolver (precedence table, blank/whitespace, required vs optional, secret denial). Updated: `scriptDispatch`, `scriptExecution`, `automationRuntime`, `scripts` routes, `scriptBundle`, `ScriptForm`, `ScriptParametersForm`, `ScriptExecutionModal`, `ScriptPickerModal`, locale parity, `astro check`.
+
+**Mutation-verify** (non-negotiable, per P1): disabling the extended preload gate must fail the new gate tests **and nothing else**. Same for the secret denial and the override-ignore path.
+
+**Integration** — extend `tenantVariableResolution.integration.test.ts`: a bound parameter resolving org-over-partner; partner inheritance; no cross-partner leak; resolution working from inside an org-scoped `withDbAccessContext`; secret binding denied at dispatch.
+
+**Contract suites** — no new tables and no migration, so RLS/cascade/export registries are unchanged. Still run `db:check-drift` (the `scripts.parameters` column gains a `$type<>()` annotation, which must not produce drift).
+
+---
+
+## 8. Release notes (0.106.0, alongside PR1/PR2's items)
+
+1. **Script parameter definitions are now validated.** Previously `z.any()` — malformed definitions were stored unchecked. Existing scripts whose definitions don't match the schema will fail on next save.
+2. **Duplicate parameter keys that collide as env vars are now rejected** (`log-level` vs `log_level` vs `logLevel`). Previously accepted, with a **nondeterministic** winner per run.
+3. **A value supplied for a bound parameter is ignored**, reported in `ignoredParameters`, and audited.
+4. **`script.version` now increments when parameter definitions change**, not only content.
+
+---
+
+## 9. Out of scope
+
+Automation parameter-capture UI · `BREEZE_VAR_*` / `secretEnv` secret delivery · redaction · effect-digest pinning (all PR4) · site-axis tenant variables · the `runAs:'user'` parameter outage (`userhelper/client.go:743`).

--- a/docs/superpowers/plans/2026-08-13-tenant-variables-handoff.md
+++ b/docs/superpowers/plans/2026-08-13-tenant-variables-handoff.md
@@ -1,0 +1,108 @@
+# Tenant Variables (#3409) — Session Handoff
+
+**Written:** 2026-08-13 · **Worktree:** `scripts-custom-variables` · **Status at handoff:** PR0/1/2 merged, unreleased
+
+---
+
+## 1. Where the initiative stands
+
+| PR | What it delivered | State |
+|---|---|---|
+| **PR0** — #3418 + #3438 | Extracted reusable `services/scriptDispatch.ts`; all 5 dispatch sites became thin callers | Merged |
+| **PR1** — #3494 (`da6a8efe9`) | `tenant_variables` table, CRUD, `variables:read`/`variables:manage`, Settings → Variables UI, 7 locales | Merged |
+| **PR2** — #3495 (`2e7ee0621`) | `{{var.*}}` resolution per device at dispatch, editor picker, per-device failure channel | Merged |
+| **PR3** | Sourced script parameters (`source: runtime \| tenantVariable \| deviceCustomField \| builtin`) | **Not started — this is next** |
+| **PR4** | Secret delivery (`BREEZE_VAR_*` / `secretEnv`), agent changes, redaction, effect-digest pinning | Not started |
+
+All merges are green on `main`, confirmed including the `Smoke Test` job that only runs on main (real Docker build + stack boot with both migrations applied).
+
+**Not in any release.** Latest tags are `v0.105.2`; PR0/1/2 all land in the next cut (0.106.0). Main has moved ~8 commits past our merge — rebase before starting PR3.
+
+---
+
+## 2. Release notes owed for 0.106.0
+
+These are behaviour changes for **existing** users, not new features. They are the highest-risk part of what shipped.
+
+**Script parameters are now strictly validated and canonicalized to strings.** One shared `scriptParametersSchema` is enforced at `routes/scripts.ts`, `routes/mobile.ts`, and `automationRuntime.ts`. Now rejected: `null`, objects, arrays, `NaN`, `Infinity`, and keys the agent can't turn into an env var name (`has space`, `a.b`, `a=b`). Caps: 64 parameters, 4096 chars/value. Numbers and booleans are now accepted and coerced to strings.
+
+This *fixes* a silent pre-existing outage — the wire type is `map[string]string` and the agent silently dropped every non-string value, so a number/boolean parameter left `{{name}}` verbatim in the script and never set `BREEZE_PARAM_*`. But callers sending malformed parameters now get a hard validation error instead of a silent drop.
+
+> **The surprising one:** `normalizeAutomationActions` runs at **runtime** against **stored** automation actions. So an automation nobody has edited can start failing loudly after upgrade. Call this out explicitly — it is the item most likely to generate support load.
+
+Also worth a line:
+- Script fan-out no longer aborts on the first per-device failure; failing devices get a `script_executions` row with `status:'failed'` and count toward `devicesFailed`.
+- Content containing a strictly-well-formed `{{var.<key>}}` is no longer passed through verbatim — it substitutes, or the device fails with `unresolved_variables`. (`${{var.x}}` and whitespace forms are unaffected.)
+- Saving/importing a script referencing a **secret** variable is now a 400.
+- PR1's migration grants `variables:read` + `variables:manage` to every existing **system** `Org Admin` role.
+
+---
+
+## 3. Known-open items (deliberately not fixed)
+
+Recorded so they aren't rediscovered as bugs:
+
+1. **`scriptDispatch.ts` canonicalizes unvalidated values on untouched ingresses.** `aiToolsScripts`, `aiAgentSdkTools`, `scriptBuilderTools`, `remediationSuggestions` don't run the strict schema, so `String({})` ships `"[object Object]"` where the agent previously dropped it. Asymmetric with the validated routes.
+2. **Parameter *definitions* are still `z.any()`** while execution is strict — a script defining `app.mode` or `Log Level` now 400s at run time with no migration path. Compounds with the hyphen collision: `log-level` and `log_level` both map to `BREEZE_PARAM_LOG_LEVEL`, and Go map order decides the winner.
+3. **PUT scope-change secret gate** — not tightened.
+4. **`loadTenantVariableScope` is per-device in `automationRuntime`** → N connection acquisitions for an N-device automation, where `scriptExecution` does 1. Hoisting it is a contained perf win.
+5. **Four-eyes effect digest is not extended.** It hashes `scripts.content` (the template) at both pin and release, so a variable's *value* changing between approval and release does not invalidate the digest. **PR4 must close this** — it's the security-relevant one.
+6. **`userhelper/client.go` drops parameters entirely for `runAs:'user'`** — pre-existing, needs a helper IPC change, PR4 territory.
+
+---
+
+## 4. Mechanics learned the hard way (read before opening PR3)
+
+**Rebase a days-old branch onto `main` *before* opening the PR, not after CI goes green.** Both PR1 and PR2 were cut before the Workspace-ee merge (`cfa16d03a`) and were honestly green on that base. Rebasing surfaced a real break that would have gone green on the PR and then reddened main.
+
+**Root-mounted routers need hand-registered namespaces.** `api.route('/', xRoutes)` is invisible to the extension guard's namespace derivation, so an extension could claim that segment and shadow core endpoints. Four places, all in the same PR:
+1. `RESERVED_ROUTE_NAMESPACES` in `packages/extension-sdk/src/manifest.ts`
+2. `RESERVED_ROUTE_NAMESPACES` in `packages/extension-api/src/legacy.ts` — **a separate copy**; one alone is still hijackable via the other code path
+3. the pinned `rootMounts` list in `packages/extension-api/src/index.test.ts` (+ its comment block)
+4. the `it.each` reserves-and-rejects list in the same file
+
+Fails as CI step **"Test legacy extension adapter"** inside the **Test API** job. The error names `src/index.test.ts`, which is the *extension-api package's* file — `apps/api/src/index.test.ts` does not exist. Repro: `pnpm --filter @breeze/extension-api test` (~300ms).
+
+**Stacked-PR CI.** A PR targeting a sibling branch gets **no CI at all** while `gh pr checks` reads green. Either dispatch per branch (`gh workflow run CI --ref <branch>`) or, better, retarget the base to `main` **first** and *then* force-push — the push fires a real `pull_request` run; changing the base alone does not.
+
+**After a parent squash-merge, restack with `git rebase --onto <new-main> <old-parent-tip> <branch>`** — never hand-resolve. Verify three ways rather than trusting the exit code: commit count, distance behind main (`rev-list --count branch..origin/main` must be 0), and that the parent's files are **absent** from the child's diff (proving the squashed content was absorbed, not duplicated).
+
+**Local full-suite runs:** don't pipe through `tail` — you lose all progress visibility and can't distinguish "slow" from "wedged". `NODE_OPTIONS=--max-old-space-size=8192` is required for API typecheck locally (known OOM, not a regression). And don't launch `sleep N && check` as a *background* task then poll immediately — you get an instant snapshot, not a delayed one.
+
+---
+
+## 5. Starting PR3
+
+Plan docs for the shipped work (useful as shape references):
+- `docs/superpowers/plans/2026-08-11-pr1-tenant-variables.md`
+- `docs/superpowers/plans/2026-08-11-pr2-tenant-variable-resolution.md`
+
+PR3 scope from the original breakdown: **sourced parameters** — a script parameter declares where its value comes from (`runtime | tenantVariable | deviceCustomField | builtin`) rather than always being caller-supplied.
+
+Design constraints inherited from PR2 that PR3 must respect:
+- Resolution must reuse the **scope snapshot** pattern: `runOutsideDbContext(() => withSystemDbAccessContext(...))` — **both** wrappers. A bare system context nested in a held org-scoped request txn does not elevate, and org tokens without a `partnerId` see zero partner-wide rows.
+- The snapshot carries its org set; `resolveForOrg` throws for an org outside it (TOCTOU guard).
+- Substitution belongs at the single `scriptDispatch.ts` chokepoint, gated so token-free scripts stay allocation- and query-free.
+- **Secrets stay blocked until PR4.** PR3 must not open a textual path for a secret value.
+- Item 2 in §3 (definitions still `z.any()`) is naturally PR3's problem — sourced parameters means definitions gain real structure. Fixing the definition schema and the hyphen collision fits here.
+
+Per repo convention, convene the advisor quorum (own position + `codex exec` read-only `xhigh`) before implementing — sourced parameters is a cross-module contract and a public API surface change.
+
+---
+
+## 6. Verification commands
+
+```bash
+# Targeted (fast)
+pnpm --filter @breeze/shared test
+pnpm --filter @breeze/extension-api test          # the namespace guard
+cd apps/api && pnpm exec vitest run src/routes/scripts.test.ts
+
+# Typecheck (needs the heap bump locally)
+NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @breeze/api exec tsc --noEmit
+
+# Contract suites — NOT covered by `pnpm test`; run when touching tenancy/cascade
+# (need a live DB; see the fsync=off tmpfs note in memory)
+```
+
+`pnpm test` misses the RLS/integration contract suites entirely — local green ≠ CI green. Integration Tests blocks PRs and runs in 4 shards.

--- a/packages/shared/src/validators/ai.ts
+++ b/packages/shared/src/validators/ai.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { scriptParameterDefinitionsSchema } from './scriptParameterDefinitions';
 
 // ============================================
 // Page Context Validators
@@ -85,13 +86,11 @@ export const scriptBuilderContextSchema = z.object({
     language: z.enum(['powershell', 'bash', 'python', 'cmd']).optional(),
     osTypes: z.array(z.enum(['windows', 'macos', 'linux'])).optional(),
     category: z.string().max(100).optional(),
-    parameters: z.array(z.object({
-      name: z.string(),
-      type: z.enum(['string', 'number', 'boolean', 'select']),
-      defaultValue: z.string().optional(),
-      required: z.boolean().optional(),
-      options: z.string().max(1000).optional(),
-    })).max(50).optional(),
+    // The one definition schema (#3409 PR3). The 50-item cap is kept as it
+    // was — it is narrower than the shared MAX_SCRIPT_PARAMETERS (64) because
+    // this snapshot is echoed into an LLM context window, not because the
+    // parameter list itself is bounded differently.
+    parameters: scriptParameterDefinitionsSchema.max(50).optional(),
     runAs: z.enum(['system', 'user', 'elevated']).optional(),
     // The editor snapshot echoes the current form values, which for legacy
     // scripts may hold timeouts saved under the old 86400 intake cap. Tolerate

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1019,6 +1019,7 @@ export * from './ai';
 export * from './tenantVariables';
 export * from './variableTokens';
 export * from './scriptParameters';
+export * from './scriptParameterDefinitions';
 
 // ============================================
 // Ticket Validators

--- a/packages/shared/src/validators/scriptParameterDefinitions.test.ts
+++ b/packages/shared/src/validators/scriptParameterDefinitions.test.ts
@@ -1,0 +1,441 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEVICE_CUSTOM_FIELD_KEY_PATTERN,
+  MAX_SCRIPT_PARAMETER_OPTIONS_LENGTH,
+  SCRIPT_BUILTIN_PARAMETER_KEYS,
+  SCRIPT_PARAMETER_SOURCES,
+  normalizeScriptParameterDefinitions,
+  scriptParameterDefinitionSchema,
+  scriptParameterDefinitionsEqual,
+  scriptParameterDefinitionsSchema,
+  scriptParameterEnvName,
+  scriptParameterEnvSuffix,
+} from './scriptParameterDefinitions';
+import { MAX_SCRIPT_PARAMETERS, MAX_SCRIPT_PARAMETER_VALUE_LENGTH } from './scriptParameters';
+
+const runtimeDefinition = (name: string) => ({ name, type: 'string' as const });
+
+describe('scriptParameterDefinitionSchema — source default', () => {
+  // The whole compatibility story: every definition stored before #3409 PR3
+  // has no `source` key at all. If this regresses, every existing script's
+  // parameters become unsaveable.
+  it('defaults a legacy definition with no source to runtime', () => {
+    const result = scriptParameterDefinitionSchema.safeParse({ name: 'target', type: 'string' });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ name: 'target', type: 'string', required: false, source: 'runtime' });
+  });
+
+  it('defaults source on a fully-populated legacy definition', () => {
+    const result = scriptParameterDefinitionSchema.safeParse({
+      name: 'mode',
+      type: 'select',
+      defaultValue: 'fast',
+      required: true,
+      options: 'fast,slow',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      name: 'mode',
+      type: 'select',
+      defaultValue: 'fast',
+      required: true,
+      options: 'fast,slow',
+      source: 'runtime',
+    });
+  });
+
+  it('defaults required to false when omitted', () => {
+    const result = scriptParameterDefinitionSchema.safeParse(runtimeDefinition('x'));
+    expect(result.success && result.data.required).toBe(false);
+  });
+
+  it('rejects an unknown source', () => {
+    expect(scriptParameterDefinitionSchema.safeParse({ name: 'x', type: 'string', source: 'magic' }).success).toBe(false);
+  });
+
+  it('enumerates exactly the four supported sources', () => {
+    expect([...SCRIPT_PARAMETER_SOURCES]).toEqual(['runtime', 'tenantVariable', 'deviceCustomField', 'builtin']);
+  });
+});
+
+describe('scriptParameterDefinitionSchema — runtime arm', () => {
+  it('accepts an explicit runtime source', () => {
+    expect(scriptParameterDefinitionSchema.safeParse({ name: 'x', type: 'number', source: 'runtime' }).success).toBe(true);
+  });
+
+  it.each(['string', 'number', 'boolean', 'select'])('accepts type %s', (type) => {
+    expect(scriptParameterDefinitionSchema.safeParse({ name: 'x', type }).success).toBe(true);
+  });
+
+  it('rejects an unknown type', () => {
+    expect(scriptParameterDefinitionSchema.safeParse({ name: 'x', type: 'json' }).success).toBe(false);
+  });
+
+  it('rejects a missing type', () => {
+    expect(scriptParameterDefinitionSchema.safeParse({ name: 'x' }).success).toBe(false);
+  });
+
+  it('strips a binding key that does not belong to the runtime arm', () => {
+    // Deliberately NOT strict: the three schemas this replaces were all plain
+    // (stripping) z.objects, and `scripts.parameters` was `z.any()` for years,
+    // so stored definitions may carry extra keys. Rejecting them would make
+    // untouched legacy scripts unsaveable. The arm still owns the shape — the
+    // stray key is dropped, never persisted.
+    const result = scriptParameterDefinitionSchema.safeParse({
+      name: 'x',
+      type: 'string',
+      source: 'runtime',
+      variableKey: 'api_key',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).not.toHaveProperty('variableKey');
+  });
+
+  it('rejects a defaultValue longer than the value cap', () => {
+    expect(
+      scriptParameterDefinitionSchema.safeParse({
+        name: 'x',
+        type: 'string',
+        defaultValue: 'a'.repeat(MAX_SCRIPT_PARAMETER_VALUE_LENGTH + 1),
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects an options list longer than the options cap', () => {
+    expect(
+      scriptParameterDefinitionSchema.safeParse({
+        name: 'x',
+        type: 'select',
+        options: 'a'.repeat(MAX_SCRIPT_PARAMETER_OPTIONS_LENGTH + 1),
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('scriptParameterDefinitionSchema — tenantVariable arm', () => {
+  it('accepts a valid tenant variable binding', () => {
+    const result = scriptParameterDefinitionSchema.safeParse({
+      name: 'apiKey',
+      type: 'string',
+      source: 'tenantVariable',
+      variableKey: 'vendor_api_key',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      name: 'apiKey',
+      type: 'string',
+      required: false,
+      source: 'tenantVariable',
+      variableKey: 'vendor_api_key',
+    });
+  });
+
+  it('requires variableKey', () => {
+    const result = scriptParameterDefinitionSchema.safeParse({ name: 'x', type: 'string', source: 'tenantVariable' });
+    expect(result.success).toBe(false);
+    // Arm-specific error, not a four-branch union failure — the discriminator
+    // fast path must still be doing the work.
+    expect(result.error?.issues[0]?.path).toEqual(['variableKey']);
+  });
+
+  it.each([
+    'Uppercase',
+    '9leading',
+    'has space',
+    'has-hyphen',
+    'trailing.',
+    '',
+    'a'.repeat(65),
+  ])('rejects variableKey %j (tenant-variable key grammar)', (variableKey) => {
+    expect(
+      scriptParameterDefinitionSchema.safeParse({ name: 'x', type: 'string', source: 'tenantVariable', variableKey }).success
+    ).toBe(false);
+  });
+
+  it('accepts the longest legal variableKey', () => {
+    expect(
+      scriptParameterDefinitionSchema.safeParse({
+        name: 'x',
+        type: 'string',
+        source: 'tenantVariable',
+        variableKey: `a${'b'.repeat(63)}`,
+      }).success
+    ).toBe(true);
+  });
+
+  it('strips a foreign binding key on the tenantVariable arm', () => {
+    const result = scriptParameterDefinitionSchema.safeParse({
+      name: 'x',
+      type: 'string',
+      source: 'tenantVariable',
+      variableKey: 'ok',
+      fieldKey: 'asset_tag',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).not.toHaveProperty('fieldKey');
+  });
+});
+
+describe('scriptParameterDefinitionSchema — deviceCustomField arm', () => {
+  it('accepts a valid custom-field binding', () => {
+    expect(
+      scriptParameterDefinitionSchema.safeParse({
+        name: 'assetTag',
+        type: 'string',
+        source: 'deviceCustomField',
+        fieldKey: 'asset_tag',
+      }).success
+    ).toBe(true);
+  });
+
+  it('requires fieldKey', () => {
+    const result = scriptParameterDefinitionSchema.safeParse({ name: 'x', type: 'string', source: 'deviceCustomField' });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['fieldKey']);
+  });
+
+  it.each(['Uppercase', '9leading', 'has-hyphen', 'has space', ''])('rejects fieldKey %j', (fieldKey) => {
+    expect(
+      scriptParameterDefinitionSchema.safeParse({ name: 'x', type: 'string', source: 'deviceCustomField', fieldKey }).success
+    ).toBe(false);
+  });
+
+  it('matches the custom_field_definitions.field_key grammar and column width', () => {
+    expect(DEVICE_CUSTOM_FIELD_KEY_PATTERN.test('a'.repeat(100))).toBe(true);
+    expect(DEVICE_CUSTOM_FIELD_KEY_PATTERN.test('a'.repeat(101))).toBe(false);
+  });
+});
+
+describe('scriptParameterDefinitionSchema — builtin arm', () => {
+  it.each(SCRIPT_BUILTIN_PARAMETER_KEYS)('accepts builtinKey %s', (builtinKey) => {
+    expect(
+      scriptParameterDefinitionSchema.safeParse({ name: 'x', type: 'string', source: 'builtin', builtinKey }).success
+    ).toBe(true);
+  });
+
+  it('requires builtinKey', () => {
+    const result = scriptParameterDefinitionSchema.safeParse({ name: 'x', type: 'string', source: 'builtin' });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['builtinKey']);
+  });
+
+  it('rejects a builtinKey with no resolver arm', () => {
+    expect(
+      scriptParameterDefinitionSchema.safeParse({ name: 'x', type: 'string', source: 'builtin', builtinKey: 'device.serial' })
+        .success
+    ).toBe(false);
+  });
+});
+
+describe('scriptParameterDefinitionSchema — name grammar', () => {
+  it.each(['log-level', 'log_level', '_private', 'A1', 'a'.repeat(64)])('accepts %j', (name) => {
+    expect(scriptParameterDefinitionSchema.safeParse({ name, type: 'string' }).success).toBe(true);
+  });
+
+  it.each(['-leading', '9leading', 'has space', 'a.b', 'a=b', '', 'a'.repeat(65)])('rejects %j', (name) => {
+    expect(scriptParameterDefinitionSchema.safeParse({ name, type: 'string' }).success).toBe(false);
+  });
+});
+
+describe('scriptParameterEnvSuffix / scriptParameterEnvName', () => {
+  // Must match agent/internal/executor/executor.go:339-341 exactly:
+  // "BREEZE_PARAM_" + strings.ToUpper(strings.ReplaceAll(key, "-", "_")).
+  it.each([
+    ['log-level', 'LOG_LEVEL'],
+    ['log_level', 'LOG_LEVEL'],
+    ['logLevel', 'LOGLEVEL'],
+    ['LOGLEVEL', 'LOGLEVEL'],
+    ['a-b-c', 'A_B_C'],
+  ])('normalizes %s to %s', (name, expected) => {
+    expect(scriptParameterEnvSuffix(name)).toBe(expected);
+    expect(scriptParameterEnvName(name)).toBe(`BREEZE_PARAM_${expected}`);
+  });
+});
+
+describe('scriptParameterDefinitionsSchema — collisions', () => {
+  it('accepts distinct parameter names', () => {
+    const result = scriptParameterDefinitionsSchema.safeParse([runtimeDefinition('alpha'), runtimeDefinition('beta')]);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an exact duplicate name', () => {
+    const result = scriptParameterDefinitionsSchema.safeParse([runtimeDefinition('alpha'), runtimeDefinition('alpha')]);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toContain('Duplicate parameter name "alpha"');
+    expect(result.error?.issues[0]?.path).toEqual([1, 'name']);
+  });
+
+  it('rejects a hyphen/underscore collision', () => {
+    const result = scriptParameterDefinitionsSchema.safeParse([runtimeDefinition('log-level'), runtimeDefinition('log_level')]);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toContain('BREEZE_PARAM_LOG_LEVEL');
+  });
+
+  it('rejects the reverse hyphen/underscore collision', () => {
+    expect(
+      scriptParameterDefinitionsSchema.safeParse([runtimeDefinition('log_level'), runtimeDefinition('log-level')]).success
+    ).toBe(false);
+  });
+
+  it.each([
+    ['logLevel', 'LOGLEVEL'],
+    ['logLevel', 'loglevel'],
+    ['LOGLEVEL', 'loglevel'],
+  ])('rejects the case collision %s vs %s', (a, b) => {
+    expect(scriptParameterDefinitionsSchema.safeParse([runtimeDefinition(a), runtimeDefinition(b)]).success).toBe(false);
+  });
+
+  it('rejects a mixed case + separator collision (log-Level vs LOG_LEVEL)', () => {
+    const result = scriptParameterDefinitionsSchema.safeParse([runtimeDefinition('log-Level'), runtimeDefinition('LOG_LEVEL')]);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toContain('collides with "log-Level"');
+  });
+
+  it('detects a collision across different sources', () => {
+    expect(
+      scriptParameterDefinitionsSchema.safeParse([
+        { name: 'api-key', type: 'string' },
+        { name: 'API_KEY', type: 'string', source: 'tenantVariable', variableKey: 'api_key' },
+      ]).success
+    ).toBe(false);
+  });
+
+  it('reports the collision at the later element, once per collision', () => {
+    const result = scriptParameterDefinitionsSchema.safeParse([
+      runtimeDefinition('a-b'),
+      runtimeDefinition('a_b'),
+      runtimeDefinition('A_B'),
+    ]);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path)).toEqual([
+      [1, 'name'],
+      [2, 'name'],
+    ]);
+  });
+});
+
+describe('scriptParameterDefinitionsSchema — array', () => {
+  it('accepts an empty list', () => {
+    expect(scriptParameterDefinitionsSchema.safeParse([]).success).toBe(true);
+  });
+
+  it(`accepts exactly ${MAX_SCRIPT_PARAMETERS} definitions`, () => {
+    const definitions = Array.from({ length: MAX_SCRIPT_PARAMETERS }, (_, i) => runtimeDefinition(`p${i}`));
+    expect(scriptParameterDefinitionsSchema.safeParse(definitions).success).toBe(true);
+  });
+
+  it(`rejects ${MAX_SCRIPT_PARAMETERS + 1} definitions`, () => {
+    const definitions = Array.from({ length: MAX_SCRIPT_PARAMETERS + 1 }, (_, i) => runtimeDefinition(`p${i}`));
+    expect(scriptParameterDefinitionsSchema.safeParse(definitions).success).toBe(false);
+  });
+
+  it('rejects a non-array', () => {
+    expect(scriptParameterDefinitionsSchema.safeParse({ name: 'x', type: 'string' }).success).toBe(false);
+  });
+
+  it('does not mutate when a caller applies a tighter cap', () => {
+    // ai.ts narrows to 50; that must not narrow the shared schema.
+    const narrowed = scriptParameterDefinitionsSchema.max(1);
+    const two = [runtimeDefinition('a'), runtimeDefinition('b')];
+    expect(narrowed.safeParse(two).success).toBe(false);
+    expect(scriptParameterDefinitionsSchema.safeParse(two).success).toBe(true);
+  });
+
+  it('still applies the collision rule under a tighter cap', () => {
+    expect(scriptParameterDefinitionsSchema.max(50).safeParse([runtimeDefinition('a-b'), runtimeDefinition('A_B')]).success).toBe(
+      false
+    );
+  });
+});
+
+describe('normalizeScriptParameterDefinitions', () => {
+  it('treats null and undefined as an empty list', () => {
+    expect(normalizeScriptParameterDefinitions(null)).toEqual([]);
+    expect(normalizeScriptParameterDefinitions(undefined)).toEqual([]);
+  });
+
+  it('materializes defaults', () => {
+    expect(normalizeScriptParameterDefinitions([{ name: 'x', type: 'string' }])).toEqual([
+      { name: 'x', type: 'string', required: false, source: 'runtime' },
+    ]);
+  });
+
+  it('returns null for an unparseable stored value', () => {
+    expect(normalizeScriptParameterDefinitions([{ nope: true }])).toBeNull();
+    expect(normalizeScriptParameterDefinitions('not an array')).toBeNull();
+  });
+});
+
+describe('scriptParameterDefinitionsEqual', () => {
+  it('treats a legacy definition as equal to its normalized form', () => {
+    expect(
+      scriptParameterDefinitionsEqual(
+        [{ name: 'x', type: 'string' }],
+        [{ name: 'x', type: 'string', required: false, source: 'runtime' }]
+      )
+    ).toBe(true);
+  });
+
+  it('ignores key order', () => {
+    expect(scriptParameterDefinitionsEqual([{ type: 'string', name: 'x' }], [{ name: 'x', type: 'string' }])).toBe(true);
+  });
+
+  it('treats null and [] as equal', () => {
+    expect(scriptParameterDefinitionsEqual(null, [])).toBe(true);
+  });
+
+  it('detects an added parameter', () => {
+    expect(scriptParameterDefinitionsEqual([{ name: 'x', type: 'string' }], [{ name: 'x', type: 'string' }, { name: 'y', type: 'string' }])).toBe(false);
+  });
+
+  it('detects a removed parameter', () => {
+    expect(scriptParameterDefinitionsEqual([{ name: 'x', type: 'string' }], [])).toBe(false);
+  });
+
+  it('detects a type change', () => {
+    expect(scriptParameterDefinitionsEqual([{ name: 'x', type: 'string' }], [{ name: 'x', type: 'number' }])).toBe(false);
+  });
+
+  it('detects a required flip', () => {
+    expect(scriptParameterDefinitionsEqual([{ name: 'x', type: 'string' }], [{ name: 'x', type: 'string', required: true }])).toBe(
+      false
+    );
+  });
+
+  it('detects a default-value change', () => {
+    expect(
+      scriptParameterDefinitionsEqual([{ name: 'x', type: 'string', defaultValue: 'a' }], [{ name: 'x', type: 'string', defaultValue: 'b' }])
+    ).toBe(false);
+  });
+
+  it('detects a source binding change', () => {
+    expect(
+      scriptParameterDefinitionsEqual(
+        [{ name: 'x', type: 'string' }],
+        [{ name: 'x', type: 'string', source: 'tenantVariable', variableKey: 'api_key' }]
+      )
+    ).toBe(false);
+  });
+
+  it('detects a rebinding to a different variable key', () => {
+    expect(
+      scriptParameterDefinitionsEqual(
+        [{ name: 'x', type: 'string', source: 'tenantVariable', variableKey: 'a' }],
+        [{ name: 'x', type: 'string', source: 'tenantVariable', variableKey: 'b' }]
+      )
+    ).toBe(false);
+  });
+
+  it('detects a reorder', () => {
+    expect(
+      scriptParameterDefinitionsEqual(
+        [{ name: 'a', type: 'string' }, { name: 'b', type: 'string' }],
+        [{ name: 'b', type: 'string' }, { name: 'a', type: 'string' }]
+      )
+    ).toBe(false);
+  });
+
+  it('reports changed when either side is unparseable', () => {
+    expect(scriptParameterDefinitionsEqual([{ garbage: 1 }], [{ garbage: 1 }])).toBe(false);
+  });
+});

--- a/packages/shared/src/validators/scriptParameterDefinitions.ts
+++ b/packages/shared/src/validators/scriptParameterDefinitions.ts
@@ -1,0 +1,260 @@
+import { z } from 'zod';
+import { MAX_SCRIPT_PARAMETERS, MAX_SCRIPT_PARAMETER_VALUE_LENGTH, SCRIPT_PARAMETER_KEY_PATTERN } from './scriptParameters';
+import { tenantVariableKeySchema } from './tenantVariables';
+
+/**
+ * Script parameter DEFINITIONS (#3409 PR3) — the authoring-time declaration of
+ * a script's parameters, as stored in `scripts.parameters` / `script_templates
+ * .parameters`.
+ *
+ * Distinct from `./scriptParameters`, which validates the run-time *values* a
+ * caller attaches to one execution. Definitions describe the contract; values
+ * satisfy it.
+ *
+ * This module is the ONE authority. Before it existed the same shape was
+ * hand-mirrored in three places with no relationship between them —
+ * `apps/web/src/components/scripts/ScriptFormSchema.ts`,
+ * `packages/shared/src/validators/ai.ts` (script-builder editor snapshot) and
+ * `apps/api/src/services/scriptBuilderTools.ts` (the MCP apply tool) — while
+ * the API's own intake was `z.any()`, so nothing validated definitions at all
+ * on the way into the database. All four now go through this schema.
+ */
+
+/**
+ * Where a parameter's value comes from at dispatch time.
+ *
+ * - `runtime` — the invoker supplies it (today's only behaviour, the default).
+ * - `tenantVariable` — a `tenant_variables` row, resolved per target device's
+ *   org (org > partner).
+ * - `deviceCustomField` — the target device's `custom_fields` JSONB.
+ * - `builtin` — an org / site / device property.
+ */
+export const SCRIPT_PARAMETER_SOURCES = ['runtime', 'tenantVariable', 'deviceCustomField', 'builtin'] as const;
+export type ScriptParameterSource = (typeof SCRIPT_PARAMETER_SOURCES)[number];
+
+export const SCRIPT_PARAMETER_TYPES = ['string', 'number', 'boolean', 'select'] as const;
+export type ScriptParameterType = (typeof SCRIPT_PARAMETER_TYPES)[number];
+
+/**
+ * `options` is a comma-separated list rendered as a `<select>`; 1000 chars was
+ * already the cap on the `ai.ts` mirror and is the strictest of the three
+ * pre-existing copies, so adopting it here loses no validation anywhere.
+ */
+export const MAX_SCRIPT_PARAMETER_OPTIONS_LENGTH = 1000;
+
+/**
+ * Mirrors `createCustomFieldSchema.fieldKey` (`apps/api/src/routes/
+ * customFields.ts`): lowercase, underscore-separated, `varchar(100)` column.
+ * A binding to a key outside this grammar could never match a stored
+ * definition, so it is rejected at save rather than failing per device.
+ */
+export const DEVICE_CUSTOM_FIELD_KEY_PATTERN = /^[a-z][a-z0-9_]{0,99}$/;
+
+/**
+ * The built-in vocabulary a parameter may bind to. Deliberately the SAME five
+ * keys the installer-variable resolver already supports
+ * (`BUILTIN_INSTALLER_VARIABLES` in `apps/web/src/lib/installerVariables.ts`,
+ * `resolveKey` in `apps/api/src/services/installerVariables.ts`) — the whole
+ * point of a shared constant is that a key offered by one surface is always
+ * resolvable by the other. Extending this list requires a matching resolver
+ * arm on the API side in the same change.
+ */
+export const SCRIPT_BUILTIN_PARAMETER_KEYS = [
+  'org.name',
+  'org.id',
+  'site.name',
+  'site.id',
+  'device.hostname',
+] as const;
+export type ScriptBuiltinParameterKey = (typeof SCRIPT_BUILTIN_PARAMETER_KEYS)[number];
+
+/**
+ * Fields every arm carries. `defaultValue` is meaningful for BOUND parameters
+ * too — the resolution precedence is
+ * `resolved source value -> definition default -> missing` — so it lives here
+ * rather than only on the `runtime` arm.
+ */
+const scriptParameterDefinitionBase = {
+  name: z
+    .string()
+    .regex(
+      SCRIPT_PARAMETER_KEY_PATTERN,
+      'Parameter names must start with a letter or underscore and contain only letters, digits, underscores and hyphens'
+    ),
+  type: z.enum(SCRIPT_PARAMETER_TYPES),
+  defaultValue: z.string().max(MAX_SCRIPT_PARAMETER_VALUE_LENGTH).optional(),
+  required: z.boolean().optional().default(false),
+  /** Comma-separated; only meaningful when `type` is `select`. */
+  options: z.string().max(MAX_SCRIPT_PARAMETER_OPTIONS_LENGTH).optional(),
+};
+
+const runtimeParameterDefinitionSchema = z.object({
+  ...scriptParameterDefinitionBase,
+  /**
+   * Defaulted so every definition stored before PR3 — none of which carry a
+   * `source` key — parses unchanged and keeps today's behaviour.
+   */
+  source: z.literal('runtime').default('runtime'),
+});
+
+const tenantVariableParameterDefinitionSchema = z.object({
+  ...scriptParameterDefinitionBase,
+  source: z.literal('tenantVariable'),
+  variableKey: tenantVariableKeySchema,
+});
+
+const deviceCustomFieldParameterDefinitionSchema = z.object({
+  ...scriptParameterDefinitionBase,
+  source: z.literal('deviceCustomField'),
+  fieldKey: z
+    .string()
+    .regex(
+      DEVICE_CUSTOM_FIELD_KEY_PATTERN,
+      'Custom field key must be lowercase letters, digits and underscores, and start with a letter'
+    ),
+});
+
+const builtinParameterDefinitionSchema = z.object({
+  ...scriptParameterDefinitionBase,
+  source: z.literal('builtin'),
+  builtinKey: z.enum(SCRIPT_BUILTIN_PARAMETER_KEYS),
+});
+
+/**
+ * One definition, discriminated on `source`, each arm requiring only its own
+ * binding field.
+ *
+ * `unionFallback` is what makes the `source` default reachable. Zod's fast
+ * discriminator path looks the RAW input value up in a map
+ * (`disc.value.get(input[discriminator])`), which for a legacy definition with
+ * no `source` key is `undefined` and matches nothing — the `.default()` never
+ * gets a chance to run. With the fallback enabled, that one case falls through
+ * to ordinary union matching, where the `runtime` arm applies its default and
+ * succeeds. Inputs that DO carry a valid `source` still take the fast path and
+ * still get arm-specific errors (e.g. a missing `variableKey` reports at
+ * `["variableKey"]`, not as a four-branch union failure).
+ */
+export const scriptParameterDefinitionSchema = z.discriminatedUnion(
+  'source',
+  [
+    runtimeParameterDefinitionSchema,
+    tenantVariableParameterDefinitionSchema,
+    deviceCustomFieldParameterDefinitionSchema,
+    builtinParameterDefinitionSchema,
+  ],
+  { unionFallback: true }
+);
+
+export type ScriptParameterDefinition = z.infer<typeof scriptParameterDefinitionSchema>;
+
+/**
+ * The name the agent derives from a parameter key when building the child
+ * process environment:
+ * `"BREEZE_PARAM_" + strings.ToUpper(strings.ReplaceAll(key, "-", "_"))`
+ * (`agent/internal/executor/executor.go:339-341`). Kept as a function so the
+ * collision rule below and any future consumer normalize identically to the
+ * agent instead of re-deriving it.
+ */
+export function scriptParameterEnvSuffix(name: string): string {
+  return name.toUpperCase().replaceAll('-', '_');
+}
+
+/** Full env var name, e.g. `log-level` -> `BREEZE_PARAM_LOG_LEVEL`. */
+export function scriptParameterEnvName(name: string): string {
+  return `BREEZE_PARAM_${scriptParameterEnvSuffix(name)}`;
+}
+
+/**
+ * Rejects two parameter names that collapse to the SAME `BREEZE_PARAM_*` env
+ * var on the agent.
+ *
+ * This is a live nondeterminism bug, not a hypothetical. `log-level` and
+ * `log_level` are distinct JS object keys, both pass every other check, and
+ * both reach the agent — where they produce two `BREEZE_PARAM_LOG_LEVEL=`
+ * entries in `Cmd.Env`. `exec.Cmd` keeps the LAST duplicate entry and Go
+ * randomizes map iteration order, so which value wins varies between runs of
+ * the same script on the same device. Uppercasing widens the equivalence
+ * class further: `logLevel`, `LOGLEVEL` and `loglevel` all collide too.
+ *
+ * Exported separately from the array schema so a caller that needs a different
+ * length cap can rebuild the array without re-implementing the rule.
+ */
+export function refineScriptParameterKeyCollisions(
+  definitions: ReadonlyArray<{ name: string }>,
+  ctx: z.RefinementCtx
+): void {
+  const seen = new Map<string, string>();
+  definitions.forEach((definition, index) => {
+    const envSuffix = scriptParameterEnvSuffix(definition.name);
+    const first = seen.get(envSuffix);
+    if (first !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: [index, 'name'],
+        message:
+          first === definition.name
+            ? `Duplicate parameter name "${definition.name}"`
+            : `Parameter "${definition.name}" collides with "${first}": both become ${scriptParameterEnvName(definition.name)} on the device`,
+      });
+      return;
+    }
+    seen.set(envSuffix, definition.name);
+  });
+}
+
+/**
+ * The array as stored in `scripts.parameters`. Capped at
+ * {@link MAX_SCRIPT_PARAMETERS}, the same bound the run-time value map uses —
+ * a definition list longer than the value map could accept would declare
+ * parameters that can never be supplied.
+ */
+export const scriptParameterDefinitionsSchema = z
+  .array(scriptParameterDefinitionSchema)
+  .max(MAX_SCRIPT_PARAMETERS, `A script cannot declare more than ${MAX_SCRIPT_PARAMETERS} parameters`)
+  .superRefine(refineScriptParameterKeyCollisions);
+
+/**
+ * Parse an unvalidated stored/incoming value into normalized definitions.
+ * `null` / `undefined` (the column is nullable) normalize to `[]`. Returns
+ * `null` when the value is not a valid definition list — callers must decide
+ * what an unparseable legacy value means for them rather than getting a
+ * silently empty array.
+ */
+export function normalizeScriptParameterDefinitions(value: unknown): ScriptParameterDefinition[] | null {
+  if (value === null || value === undefined) return [];
+  const parsed = scriptParameterDefinitionsSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+/** Stable serialization of one definition — key order independent, arm aware. */
+function canonicalizeDefinition(definition: ScriptParameterDefinition): string {
+  const entries = Object.entries(definition as Record<string, unknown>)
+    .filter(([, value]) => value !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return JSON.stringify(entries);
+}
+
+/**
+ * Do two definition lists describe the same parameter contract?
+ *
+ * Both sides are normalized through the schema first, so a legacy stored
+ * definition (`{name,type}`) compares equal to the same definition after the
+ * schema materializes its `required:false` / `source:'runtime'` defaults —
+ * without this, every save of an untouched legacy script would look like a
+ * change. Order IS significant: parameter order is user-visible in the run
+ * modal.
+ *
+ * An unparseable value on either side returns `false` (i.e. "changed"), which
+ * is the safe answer for the one caller that matters: `script.version` gets
+ * bumped rather than silently held back.
+ */
+export function scriptParameterDefinitionsEqual(a: unknown, b: unknown): boolean {
+  const left = normalizeScriptParameterDefinitions(a);
+  const right = normalizeScriptParameterDefinitions(b);
+  if (left === null || right === null) return false;
+  if (left.length !== right.length) return false;
+  return left.every((definition, index) => {
+    const other = right[index];
+    return other !== undefined && canonicalizeDefinition(definition) === canonicalizeDefinition(other);
+  });
+}


### PR DESCRIPTION
Part 3 of #3409, following PR0 (#3418/#3438), PR1 (#3494) and PR2 (#3495). Targets `main`.

Plan: `docs/superpowers/plans/2026-08-13-pr3-sourced-parameters.md` (included in this PR).

## What this delivers

A script's parameter **definition** gains a `source` binding:

| source | Value comes from |
|---|---|
| `runtime` | the invoker at run time — today's behaviour, and the default |
| `tenantVariable` | a `tenant_variables` row, resolved per target device's org (org > partner) |
| `deviceCustomField` | the target device's `custom_fields` |
| `builtin` | org / site / device properties |

At dispatch, bound parameters are pre-filled **per target device**; the run modal prompts only for `runtime` parameters. Secrets remain unusable in v1 — a binding to a secret variable is rejected at save and fails per device at dispatch. PR4 adds the out-of-band channel.

## Design decisions (advisor quorum)

PR2's plan deferred an explicit open spec item to this PR: *the precedence table, required/missing behaviour, whether invokers may override a binding, and what happens when a source flips to secret.* Settled by quorum and recorded in §2 of the plan doc so review doesn't re-derive it.

**Precedence.** Bound: `resolved non-blank source → definition default → missing`, with an invoker-supplied value **not** a candidate. Runtime: `invoker value → default → missing`. `required` is evaluated *after* precedence. Blank means null/absent/empty/whitespace-only, mirroring `installerVariables.ts:91-95`.

**Override is ignored, not rejected.** A caller value for a bound key is dropped, returned in `ignoredParameters`, and audited. This deliberately rejects a hard 400: `automationRuntime.ts:366` validates stored automation actions *without consulting the referenced script definition*, so an automation cannot pre-validate against a binding — a 400 would turn a valid stored automation into a delayed runtime failure the moment an author rebinds a parameter, with no authoring-time signal. Digest integrity is preserved a different way: raw caller input and the server-resolved map are kept in separate trust domains, so PR4's four-eyes digest pins the *resolved snapshot* rather than trusting caller input.

**A secret binding is a policy denial, not "missing".** No default fallback, no caller value, no omission — any of those would silently bypass an operator's deliberate classification change. The secret branch returns before the blank check so it structurally cannot fall through.

**Missing** → default first; then required fails *that device* (new code `unresolved_parameters`, distinct from PR2's `unresolved_variables`), optional is omitted. The fan-out never aborts; all-failed still yields 422.

## Fixes a live nondeterminism bug

`log-level` and `log_level` are distinct JS keys. Both pass today's validation, both reach the agent, and both map to `BREEZE_PARAM_LOG_LEVEL` at `executor.go:339-341`. `Cmd.Env` keeps the last entry and Go randomizes map iteration order — **so the winner varies between runs of the same script.** Uppercasing widens it to case collisions (`logLevel`/`LOGLEVEL`/`loglevel`). Nothing tested this.

Collision detection now lives on the definitions array via `superRefine`, normalizing exactly as the agent does.

## Prerequisites included (correctness, not cleanup)

- **Scope-preload gate extended past content.** `hasVariableTokens(content)` gated scope loading at three sites; sourced parameters live in `scripts.parameters`, so without this every bound parameter would resolve against an empty scope and fail silently. Mutation-verified.
- **Automation scope load hoisted.** It ran **per device per run_script action** across both runners; `scriptExecution` already did it once per fan-out. Adding a second per-device resolver on top would have compounded it.
- **Dispatch device projection widened** to carry `customFields`/`siteId`/`hostname`.
- **Resolved values kept out of execution history.** The `script_executions` row stores caller parameters plus a binding descriptor under reserved key `$bindings` (`$` can't start a parameter name, so collision is impossible; a bindings-free row is byte-identical to PR2's). Only the command payload carries resolved values — which is what keeps this forward-compatible with PR4, where persisting a resolved secret would be the exact leak the separate channel exists to prevent.

## ⚠️ Release notes for 0.106.0 (alongside PR1/PR2's items)

1. **Parameter definitions are now validated.** Previously `z.any()`. Existing scripts whose definitions don't match the schema will fail on next save. Definitions are non-strict (stray keys stripped, not rejected) precisely so untouched legacy scripts stay saveable, and `unionFallback` lets a definition with no `source` default to `runtime`.
2. **Colliding parameter keys are rejected** (`log-level` / `log_level` / `logLevel`). Previously accepted with a nondeterministic winner.
3. **A value supplied for a bound parameter is ignored**, reported in `ignoredParameters`, and audited (keys only — pinned by a test asserting the caller's value appears nowhere in the audit details).
4. **`script.version` now increments when parameter definitions change**, not only content. PR4's digest pins definition version.
5. **Required `runtime` parameters are now enforced server-side.** Previously browser-only — the server had no definition schema. This mainly affects automations, which send `{}`. Such a run was *already* broken (the agent left `{{param}}` literal and never set `BREEZE_PARAM_*`), so this converts a silent wrong result into a loud failure rather than breaking something that worked.

## Testing

No migration and no new tables — RLS/cascade/export registries are unchanged.

Full API suite, web suite, `astro check`, and API typecheck all green. Both risky paths are **mutation-verified**: forcing the preload gate false fails 11 genuine gate assertions across 5 files and nothing else; deleting the secret branch fails exactly the 6 secret tests. The automation hoist is proven by a call-count test driving the real runner loop (4 devices / 2 orgs → exactly one load), which fails with 5 calls when reverted.

The skip-required-for-bound UI test has a companion proving a required *runtime* param still blocks, so it can't pass vacuously.

## Follow-ups (deliberately not here)

- Automation parameter-capture UI — none exists today (`AutomationForm.tsx` captures only `scriptId`).
- `aiToolsScripts` run_script doesn't surface `ignoredParameters` (same invisibility as automations; one-liner, but it changes a model-facing tool output).
- `deviceCustomField` binding is a free-text key rather than a picker over live field definitions.
- Integration coverage for bound-parameter resolution against real Postgres (needs a live DB locally; the CI integration shards do run).
