### PR TITLE
fix(api): admit unsigned self-host Windows exes so binary sync stops aborting (#3504)

### DIFF
--- a/apps/api/src/services/releaseArtifactManifest.ts
+++ b/apps/api/src/services/releaseArtifactManifest.ts
@@ -5,7 +5,31 @@ import {
   verify as verifySignature,
   type KeyObject,
 } from "node:crypto";
-import { assertDistributableReleaseAsset } from './releaseAssetTrust';
+import { assertDistributableReleaseAsset, isUnsignedSelfHostAsset } from './releaseAssetTrust';
+
+// Warn once per asset name per process. This fires on the normal, intended path
+// for a stock public release (#3504) — every self-hoster on BINARY_SOURCE=github
+// sees it — so it must be visible without being a per-request flood. The point
+// is that "the download worked" should not read as "the binary is signed":
+// Windows will show a SmartScreen warning, and the BYO-signing flow
+// (docs: Sign Your Own Agent Packages) is what makes it go away.
+const unsignedSelfHostWarned = new Set<string>();
+
+function warnIfUnsignedSelfHostAsset(
+  assetName: string,
+  platformTrust: string | null,
+  edition: string | null,
+): void {
+  if (!isUnsignedSelfHostAsset({ assetName, platformTrust, edition })) return;
+  if (unsignedSelfHostWarned.has(assetName)) return;
+  unsignedSelfHostWarned.add(assetName);
+  console.warn(
+    `[releaseAssetTrust] Serving UNSIGNED self-host asset ${assetName} (edition=self-host, platformTrust=none). ` +
+      'The public release pipeline does not Authenticode-sign Windows agent binaries. ' +
+      'Windows will show a SmartScreen warning on install. ' +
+      'To serve signed binaries, re-sign the release with the breeze-selfhost-signing template.',
+  );
+}
 
 const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
 const MAX_MANIFEST_BYTES = 1024 * 1024;
@@ -320,6 +344,11 @@ function selectManifestAsset(args: {
     intendedUse: readIntendedUse(entry, args.assetName),
     edition: typeof entry.edition === 'string' ? entry.edition : null,
   });
+  warnIfUnsignedSelfHostAsset(
+    args.assetName,
+    typeof entry.platformTrust === 'string' ? entry.platformTrust : null,
+    typeof entry.edition === 'string' ? entry.edition : null,
+  );
   if (
     args.expectedPlatformTrust &&
     entry.platformTrust !== args.expectedPlatformTrust

--- a/apps/api/src/services/releaseAssetTrust.test.ts
+++ b/apps/api/src/services/releaseAssetTrust.test.ts
@@ -174,6 +174,105 @@ describe('releaseAssetTrust', () => {
       ).toThrow(/windows-authenticode-required/);
     });
 
+    // #3504: the public pipeline stopped Authenticode-signing the Windows agent
+    // family in #3351 ("the public pipeline no longer signs these",
+    // release.yml:419) but the unsigned exception here was never widened past
+    // breeze-agent.msi. The four exes were rejected, and because binarySync's
+    // Phase 1 aborts the whole sync on a trust failure by design (bbde37ea9),
+    // ONE rejected exe stopped Linux and macOS registering too — so a
+    // BINARY_SOURCE=github self-hoster got a 404 for every platform.
+    it.each([
+      'breeze-agent-windows-amd64.exe',
+      'breeze-backup-windows-amd64.exe',
+      'breeze-watchdog-windows-amd64.exe',
+      'breeze-user-helper-windows-amd64.exe',
+    ])('accepts unsigned self-host %s', (assetName) => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName,
+          platformTrust: PLATFORM_TRUST_NONE,
+          intendedUse: null,
+          edition: 'self-host',
+        }),
+      ).not.toThrow();
+    });
+
+    it.each([
+      'breeze-agent-windows-amd64.exe',
+      'breeze-backup-windows-amd64.exe',
+      'breeze-watchdog-windows-amd64.exe',
+      'breeze-user-helper-windows-amd64.exe',
+    ])('still accepts a signed self-host %s (BYO-resigned repos)', (assetName) => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName,
+          platformTrust: PLATFORM_TRUST_WINDOWS,
+          intendedUse: null,
+          edition: 'self-host',
+        }),
+      ).not.toThrow();
+    });
+
+    // The edition gate is the whole safety property of this relaxation: hosted
+    // artifacts are signed and privately distributed, so an unsigned exe
+    // claiming edition "hosted" is either a mislabel or an attack.
+    it.each([
+      'breeze-agent-windows-amd64.exe',
+      'breeze-backup-windows-amd64.exe',
+      'breeze-watchdog-windows-amd64.exe',
+      'breeze-user-helper-windows-amd64.exe',
+    ])('rejects unsigned %s labeled edition "hosted"', (assetName) => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName,
+          platformTrust: PLATFORM_TRUST_NONE,
+          intendedUse: null,
+          edition: 'hosted',
+        }),
+      ).toThrow(/windows-authenticode-required/);
+    });
+
+    it.each([
+      'breeze-agent-windows-amd64.exe',
+      'breeze-backup-windows-amd64.exe',
+      'breeze-watchdog-windows-amd64.exe',
+      'breeze-user-helper-windows-amd64.exe',
+    ])('rejects unsigned %s with no edition claim', (assetName) => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName,
+          platformTrust: PLATFORM_TRUST_NONE,
+          intendedUse: null,
+        }),
+      ).toThrow(/windows-authenticode-required/);
+    });
+
+    // Scoped to the exact four filenames the pipeline produces unsigned, not to
+    // "any windows exe" — an unrecognised exe must still require signing.
+    it('does NOT extend the unsigned exception to an unlisted Windows exe', () => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName: 'breeze-installer-windows-amd64.exe',
+          platformTrust: PLATFORM_TRUST_NONE,
+          intendedUse: null,
+          edition: 'self-host',
+        }),
+      ).toThrow(/windows-authenticode-required/);
+    });
+
+    // The signing-input guard runs BEFORE the trust comparison, so widening the
+    // exception must not make "-unsigned" inputs distributable.
+    it('still refuses the -unsigned signing input for an allowlisted exe', () => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName: 'breeze-agent-windows-amd64-unsigned.exe',
+          platformTrust: PLATFORM_TRUST_NONE,
+          intendedUse: null,
+          edition: 'self-host',
+        }),
+      ).toThrow(/signing input/);
+    });
+
     it('does NOT extend the unsigned exception to other .msi assets (e.g. helper)', () => {
       expect(() =>
         assertDistributableReleaseAsset({

--- a/apps/api/src/services/releaseAssetTrust.ts
+++ b/apps/api/src/services/releaseAssetTrust.ts
@@ -57,12 +57,32 @@ export const KNOWN_EDITION_VALUES: ReadonlySet<string> = new Set([
   EDITION_HOSTED,
 ]);
 
-// The one asset the public self-host release is expected to ship unsigned
-// (platformTrust "none"): the Windows MSI. Scoped to this exact filename —
-// NOT every .msi (e.g. breeze-helper-windows.msi stays signed regardless of
-// edition) — because that's the only asset the release pipeline currently
-// produces an unsigned self-host variant of.
-const SELF_HOST_UNSIGNED_MSI_ASSET_NAME = 'breeze-agent.msi';
+// The assets the public self-host release is expected to ship unsigned
+// (platformTrust "none"). An EXACT-FILENAME allowlist, deliberately not a
+// pattern: an unrecognised .exe/.msi must still require Authenticode, so a new
+// or renamed Windows asset fails closed until it is added here on purpose.
+// breeze-helper-windows.msi, for instance, stays signed regardless of edition.
+//
+// This list mirrors the assets .github/workflows/release.yml builds without
+// signing — the MSI (built by the "Build unsigned self-host MSI" step) and the
+// four exes it is built from. Keep it in sync when that job's asset set changes.
+//
+// #3504: the four exes were missing here. #3351 removed Authenticode signing
+// from the public pipeline ("the public pipeline no longer signs these",
+// release.yml:419) but this allowlist was not widened alongside it, so every
+// public release from v0.105.0 on was rejected at sync time. Because
+// binarySync's Phase 1 aborts the whole sync on a trust failure by design
+// (bbde37ea9, pinned by binarySync.test.ts), one rejected exe also prevented
+// the Linux and macOS assets from registering — surfacing to self-hosters as a
+// 404 "Version not found for the specified platform and architecture" on every
+// platform, which points at entirely the wrong thing.
+const SELF_HOST_UNSIGNED_ASSET_NAMES: ReadonlySet<string> = new Set([
+  'breeze-agent.msi',
+  'breeze-agent-windows-amd64.exe',
+  'breeze-backup-windows-amd64.exe',
+  'breeze-watchdog-windows-amd64.exe',
+  'breeze-user-helper-windows-amd64.exe',
+]);
 
 // Raw darwin Mach-O binaries carry Developer ID + notarization even though
 // they ship inside the .pkg (see release.yml DARWIN_BINARY_RE).
@@ -75,6 +95,27 @@ const SIGNING_INPUT_NAME_RE = /-unsigned(\.[A-Za-z0-9]+)*$/i;
 
 export function isSigningInputAssetName(assetName: string): boolean {
   return SIGNING_INPUT_NAME_RE.test(assetName);
+}
+
+/**
+ * True when this asset is being admitted ONLY because of the self-host unsigned
+ * relaxation — i.e. it would be refused if it were not labeled edition
+ * "self-host". Callers use this to warn that an unsigned binary is about to be
+ * served; it does not itself permit or refuse anything.
+ *
+ * Returns false for a signed self-host asset (a BYO-signing repo that re-signed
+ * before publishing), which is the case that needs no warning.
+ */
+export function isUnsignedSelfHostAsset(args: {
+  assetName: string;
+  platformTrust: string | null;
+  edition?: string | null;
+}): boolean {
+  return (
+    SELF_HOST_UNSIGNED_ASSET_NAMES.has(args.assetName) &&
+    args.edition === EDITION_SELF_HOST &&
+    args.platformTrust === PLATFORM_TRUST_NONE
+  );
 }
 
 /**
@@ -103,9 +144,11 @@ export function requiredPlatformTrustFor(assetName: string): string | null {
  * manifest predating the edition field (edition undefined/null) behaves
  * exactly as before this field existed.
  *
- * The one edition-aware relaxation: breeze-agent.msi with edition "self-host"
- * may carry platformTrust "none" (the public self-host release ships it
- * unsigned by default) in addition to the normal "windows-authenticode-required".
+ * The one edition-aware relaxation: an asset in SELF_HOST_UNSIGNED_ASSET_NAMES
+ * (breeze-agent.msi plus the four Windows exes) with edition "self-host" may
+ * carry platformTrust "none" — the public self-host release ships those
+ * unsigned by design — in addition to the normal "windows-authenticode-required".
+ * Any other edition value, or none, still requires the signed label.
  */
 export function assertDistributableReleaseAsset(args: {
   assetName: string;
@@ -140,13 +183,17 @@ export function assertDistributableReleaseAsset(args: {
   const required = requiredPlatformTrustFor(args.assetName);
   if (required === null) return;
 
-  const isUnsignedSelfHostMsi =
-    args.assetName === SELF_HOST_UNSIGNED_MSI_ASSET_NAME &&
+  // The edition check is the safety property of this relaxation, not a
+  // formality: hosted artifacts are signed and distributed privately, so an
+  // unsigned asset claiming edition "hosted" — or claiming no edition at all —
+  // is a mislabel or an attack and must still be refused.
+  const isUnsignedSelfHostAsset =
+    SELF_HOST_UNSIGNED_ASSET_NAMES.has(args.assetName) &&
     required === PLATFORM_TRUST_WINDOWS &&
     args.edition === EDITION_SELF_HOST &&
     args.platformTrust === PLATFORM_TRUST_NONE;
 
-  if (args.platformTrust !== required && !isUnsignedSelfHostMsi) {
+  if (args.platformTrust !== required && !isUnsignedSelfHostAsset) {
     throw new Error(
       `Release asset ${args.assetName} requires platformTrust "${required}", got ${
         args.platformTrust === null ? 'none recorded' : `"${args.platformTrust}"`


### PR DESCRIPTION
Fixes the self-host half of #3504. Does **not** fix the hosted fleet — see the bottom.

## Root cause

#3351 deliberately removed Authenticode signing from the public release pipeline — `.github/workflows/release.yml:419` says so outright: *"the public pipeline no longer signs these"*. The public release is now self-host edition and unsigned by design; BYO-signing repos re-sign it.

The API's allowlist never followed. `releaseAssetTrust.ts` granted the unsigned exception to exactly one filename:

```
const SELF_HOST_UNSIGNED_MSI_ASSET_NAME = 'breeze-agent.msi';
```

The four Windows `.exe` assets the pipeline now builds unsigned were not covered, so `assertDistributableReleaseAsset` rejected them on every release from v0.105.0 on.

## Why one rejected exe broke every platform

`binarySync`'s Phase 1 aborts the entire sync on a trust failure. That is deliberate and test-pinned (`bbde37ea9`, `binarySync.test.ts` — "writes nothing when a late-ordered asset fails the trust check"), and this PR does not touch it: aborting is correct, because a partial sync would promote Linux and macOS while freezing Windows.

The consequence was that a single rejected exe stopped Linux and macOS registering too. Self-hosters on `BINARY_SOURCE=github` got `404 "Version not found for the specified platform and architecture"` for **every** platform — a message pointing at entirely the wrong thing — and `smoke-binary-source-github` has been red on every `main` commit since.

## The change

Replaces the single-name constant with an exact-filename allowlist of the five assets the pipeline builds unsigned (the MSI plus the four exes).

Deliberately still an allowlist and not a pattern like `/\.exe$/`: an unrecognised or renamed Windows asset fails closed until someone adds it on purpose.

**The edition gate is unchanged and is the safety property.** The relaxation applies only when `edition === 'self-host'` **and** `platformTrust === 'none'`. Still refused: an unsigned asset labeled `edition: "hosted"`, an unsigned asset with no edition claim, any `-unsigned` signing input, and any unlisted Windows exe. `assertGithubFetchableEdition` is untouched.

Also adds a once-per-asset warning when an unsigned binary is served, so "the download worked" is not mistaken for "the binary is signed" — it names SmartScreen and points at the BYO-signing template. It sits in `releaseArtifactManifest.ts`, the chokepoint every path funnels through (sync, installer pre-flight, recovery media), rather than in `binarySync` alone.

## Tests

Added 18 cases: acceptance for all four exes unsigned; acceptance still holding when a BYO repo re-signs them; rejection under `edition: "hosted"`; rejection with no edition claim; rejection of an unlisted Windows exe; and rejection of a `-unsigned` signing input for an allowlisted name (the signing-input guard runs before the trust comparison, and widening must not weaken it).

Verified the tests fail before the fix — exactly the four acceptance cases, with every guard case already passing.

```
releaseAssetTrust + releaseArtifactManifest + binarySync + installerBuilder   149 passed
services/releaseAsset* releaseArtifact* binarySync* installerBuilder* routes/agents*   907 passed (49 files)
tsc --noEmit -p apps/api/tsconfig.json    exit 0
```

Not run locally: RLS and integration suites (need a live database). This touches no schema, no migration and no tenancy surface.

## What this does not fix

Hosted droplets run `BINARY_SOURCE=github` against the public release, which is self-host edition. `assertGithubFetchableEdition` correctly refuses hosted artifacts from public releases, and there is no signed hosted source yet — so **prod agents stay on 0.104.0 until the private hosted lane exists**. That is separate work, not something this PR should paper over.