### PR TITLE
feat(web,portal,api): proposal presentation system PR3 — renderers, document fonts, block authoring

### DIFF
--- a/apps/api/src/routes/portal/quotes.test.ts
+++ b/apps/api/src/routes/portal/quotes.test.ts
@@ -140,6 +140,27 @@ describe('portal quotes GET /quotes/:id', () => {
       theme: 'classic',
       pageSize: 'a4',
     });
+    // Sibling `presentation` field (Task 12) — same resolved values.
+    expect(body.data.presentation).toEqual({ theme: 'classic', pageSize: 'a4' });
+  });
+
+  it('resolves presentation.theme="condensed" from the partner default', async () => {
+    dbResults.push([{
+      id: QUOTE_ID, orgId: ORG_ID, partnerId: PARTNER_ID, status: 'sent',
+      quoteNumber: 'Q-1', currencyCode: 'USD', taxRate: null,
+      depositType: 'none', depositPercent: null, presentationSnapshot: null,
+    }]); // quote SELECT
+    dbResults.push([]); // quoteBlocks SELECT
+    dbResults.push([]); // quoteLines SELECT
+    dbResults.push([]); // markQuoteViewed's own quotes SELECT
+    dbResults.push([{ name: 'Lantern IT', documentTheme: 'condensed', documentPageSize: 'letter' }]); // partners SELECT (system ctx)
+    dbResults.push([]); // portalBranding SELECT
+
+    const res = await app().request(`/quotes/${QUOTE_ID}`, { method: 'GET' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.presentation).toEqual({ theme: 'condensed', pageSize: 'letter' });
+    expect(body.data.branding.theme).toBe('condensed');
   });
 
   it('falls back to null logo/color and a generic partner name when neither row exists', async () => {

--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -71,11 +71,12 @@ quoteRoutes.get('/quotes/:id', zValidator('param', idParam), async (c) => {
     // authoring content with the render contract the portal understands.
     const blocks = await renderContractBlocksForClient(rawBlocks, quote, (blockId) => `/portal/quotes/${id}/contract-file/${blockId}`);
     const serializedLines = attachCustomerLineImages(lines, (lineId) => `/portal/quotes/${id}/line-image/${lineId}`);
+    const theme = resolveThemeId(presentationSnap?.theme ?? partner?.documentTheme);
+    const pageSize = resolvePageSize(presentationSnap?.pageSize ?? partner?.documentPageSize);
     return c.json({ data: { quote: { ...quote, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal, depositDueTotal: totals.depositDueTotal, categoryBreakdown: totals.categoryBreakdown }, blocks, lines: serializedLines, branding: {
       partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
-      theme: resolveThemeId(presentationSnap?.theme ?? partner?.documentTheme),
-      pageSize: resolvePageSize(presentationSnap?.pageSize ?? partner?.documentPageSize),
-    } } });
+      theme, pageSize,
+    }, presentation: { theme, pageSize } } });
   } catch (err) {
     if (err instanceof ContractTemplateServiceError) return c.json({ error: err.message, code: err.code }, err.status);
     throw err;

--- a/apps/api/src/routes/quotes/quotes.test.ts
+++ b/apps/api/src/routes/quotes/quotes.test.ts
@@ -245,7 +245,25 @@ describe('quote crud + lines routes', () => {
       pax8OrderId: '55555555-5555-5555-5555-555555555555',
       pax8OrderLineCount: 2,
     });
+    // No partner/documentTheme row preset → resolveThemeId/resolvePageSize fall
+    // through to their defaults, same as `branding` (Task 12).
+    expect(body.data.presentation).toEqual({ theme: 'classic', pageSize: 'a4' });
     expect(svc.getQuote).toHaveBeenCalledWith(QUOTE_ID, expect.anything());
+  });
+
+  it('GET /:id resolves presentation.theme="condensed" from the partner default (no query beyond the existing branding selects)', async () => {
+    (svc.getQuote as any).mockResolvedValue({ quote: { id: QUOTE_ID, orgId: ORG_ID, partnerId: 'p1' }, blocks: [], lines: [] });
+    // Branding selects: partner row (documentTheme condensed/pageSize letter), then portal_branding row.
+    dbRows.next = [
+      [{ name: 'Acme MSP', documentTheme: 'condensed', documentPageSize: 'letter' }],
+      [{ logoUrl: null, primaryColor: null }],
+    ];
+    const res = await app().request(`/${QUOTE_ID}`, { method: 'GET' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.presentation).toEqual({ theme: 'condensed', pageSize: 'letter' });
+    expect(body.data.branding.theme).toBe('condensed');
+    expect(body.data.branding.pageSize).toBe('letter');
   });
 
   it('GET /:id denies callers without quotes:read before loading the staged-order summary', async () => {

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -130,7 +130,11 @@ quoteCrudRoutes.get('/:id', scopes, readPerm, zValidator('param', idParam), asyn
       acceptTokenExpiresAt: _exp, acceptTokenKid: _kid,
       ...quoteForClient
     } = detail.quote;
-    return c.json({ data: { ...detail, quote: quoteForClient, blocks: blocksForEditor, branding, recipients } });
+    // Sibling of `branding` — same resolved values (no extra query), typed
+    // explicitly so web doesn't have to depend on QuoteBranding growing new
+    // fields to pick up theme/pageSize (Task 12).
+    const presentation = { theme: branding.theme, pageSize: branding.pageSize };
+    return c.json({ data: { ...detail, quote: quoteForClient, blocks: blocksForEditor, branding, presentation, recipients } });
   } catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.patch('/:id', scopes, writePerm, zValidator('param', idParam), zValidator('json', updateQuoteSchema), async (c) => {

--- a/apps/api/src/routes/quotesPublic.test.ts
+++ b/apps/api/src/routes/quotesPublic.test.ts
@@ -180,6 +180,27 @@ describe('quotesPublic GET /:token', () => {
     ]);
     expect(JSON.stringify(header)).not.toContain('internal-');
     expect(JSON.stringify(header)).not.toContain('do-not-serialize');
+    // Sibling `presentation` field (Task 12) — no partner theme row preset, so
+    // it falls through to the defaults, same as `branding.theme`/`pageSize`.
+    expect(body.data.presentation).toEqual({ theme: 'classic', pageSize: 'a4' });
+  });
+
+  it('resolves presentation.theme="condensed" from the partner default', async () => {
+    dbResults.push([{
+      id: QUOTE_ID, partnerId: 'p1', orgId: 'org1', quoteNumber: 'Q-1', status: 'sent',
+      currencyCode: 'USD', taxRate: null, depositType: 'none', depositPercent: null,
+      presentationSnapshot: null,
+    }]);
+    dbResults.push([]); // quoteBlocks SELECT
+    dbResults.push([]); // quoteLines SELECT
+    dbResults.push([{ name: 'Lantern IT', documentTheme: 'condensed', documentPageSize: 'letter' }]); // partners SELECT
+    dbResults.push([]); // portalBranding SELECT
+
+    const res = await app().request(`/quotes/public/${TOKEN}`, { method: 'GET' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.presentation).toEqual({ theme: 'condensed', pageSize: 'letter' });
+    expect(body.data.branding.theme).toBe('condensed');
   });
 
   it('401s an invalid/expired token without querying the DB', async () => {

--- a/apps/api/src/routes/quotesPublic.ts
+++ b/apps/api/src/routes/quotesPublic.ts
@@ -21,7 +21,7 @@ import { createQuotePayLink } from '../services/quotePay';
 import { computeQuoteTotals, toQuoteDepositConfig, type QuoteLineForMath } from '../services/quoteMath';
 import { captureException } from '../services/sentry';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
-import { toPublicQuoteHeader } from '../services/publicQuoteDto';
+import { toPublicQuoteHeader, toPublicQuotePresentation } from '../services/publicQuoteDto';
 import { resolveThemeId, resolvePageSize } from '../services/documentThemes';
 
 /**
@@ -77,11 +77,12 @@ quotesPublicRoutes.get('/:token', zValidator('param', tokenParam), async (c) => 
       // sent quote's frozen presentation always wins over the partner's live
       // theme/pageSize columns.
       const presentationSnap = quote.presentationSnapshot as { theme?: string; pageSize?: string } | null;
+      const theme = resolveThemeId(presentationSnap?.theme ?? partner?.documentTheme);
+      const pageSize = resolvePageSize(presentationSnap?.pageSize ?? partner?.documentPageSize);
       return { quote: toPublicQuoteHeader(quote, totals), blocks, lines: serializedLines, branding: {
         partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
-        theme: resolveThemeId(presentationSnap?.theme ?? partner?.documentTheme),
-        pageSize: resolvePageSize(presentationSnap?.pageSize ?? partner?.documentPageSize),
-      } };
+        theme, pageSize,
+      }, presentation: toPublicQuotePresentation(theme, pageSize) };
     }));
     if (!data) return c.json({ error: 'Quote not found' }, 404);
     return c.json({ data });

--- a/apps/api/src/services/publicQuoteDto.test.ts
+++ b/apps/api/src/services/publicQuoteDto.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import type { PublicQuoteHeader } from '@breeze/shared';
 import type { QuoteTotals } from './quoteMath';
-import { toPublicQuoteHeader } from './publicQuoteDto';
+import { toPublicQuoteHeader, toPublicQuotePresentation } from './publicQuoteDto';
 
 const HEADER_KEYS = [
   'id',
@@ -214,5 +214,12 @@ describe('toPublicQuoteHeader', () => {
       preparedForName: null,
       showPreparedBy: true,
     });
+  });
+});
+
+describe('toPublicQuotePresentation', () => {
+  it('shapes the resolved theme/pageSize into the presentation DTO (Task 12)', () => {
+    expect(toPublicQuotePresentation('condensed', 'letter')).toEqual({ theme: 'condensed', pageSize: 'letter' });
+    expect(toPublicQuotePresentation('classic', 'a4')).toEqual({ theme: 'classic', pageSize: 'a4' });
   });
 });

--- a/apps/api/src/services/publicQuoteDto.ts
+++ b/apps/api/src/services/publicQuoteDto.ts
@@ -1,6 +1,7 @@
-import type { PublicQuoteCoverPage, PublicQuoteHeader, PublicQuoteSellerSnapshot } from '@breeze/shared';
+import type { PublicQuoteCoverPage, PublicQuoteHeader, PublicQuoteSellerSnapshot, QuotePresentation } from '@breeze/shared';
 import type { quotes } from '../db/schema/quotes';
 import type { QuoteTotals } from './quoteMath';
+import type { DocumentThemeId, DocumentPageSize } from './documentThemes';
 
 type QuoteRow = typeof quotes.$inferSelect;
 
@@ -53,6 +54,17 @@ function toPublicStatus(status: QuoteRow['status']): PublicQuoteHeader['status']
     throw new Error('Draft quotes cannot be serialized for public access');
   }
   return status === 'sent' ? 'viewed' : status;
+}
+
+/** Resolved document presentation, sibling of `branding` on the public
+ *  token-view payload (Task 12). Callers pass already-resolved theme/pageSize
+ *  (quoteBranding.ts's precedence) — this is a pure shaping function, not
+ *  another resolution point. */
+export function toPublicQuotePresentation(
+  theme: DocumentThemeId,
+  pageSize: DocumentPageSize,
+): QuotePresentation {
+  return { theme, pageSize };
 }
 
 export function toPublicQuoteHeader(

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@astrojs/node": "^11.1.0",
     "@astrojs/react": "^6.0.2",
+    "@fontsource/barlow-condensed": "^5.3.0",
+    "@fontsource/dm-sans": "^5.3.0",
     "@hookform/resolvers": "^5.4.0",
     "@tanstack/react-query": "^5.101.4",
     "astro": "^7.2.0",

--- a/apps/portal/src/components/portal/PublicQuoteView.test.tsx
+++ b/apps/portal/src/components/portal/PublicQuoteView.test.tsx
@@ -81,4 +81,19 @@ describe('PublicQuoteView exact public quote contract', () => {
     expect(screen.getByTestId('public-quote-terms-conditions').textContent)
       .toContain('Customer-facing terms and conditions.');
   });
+
+  it('stamps data-doc-theme="condensed" when the DTO resolves the condensed theme', () => {
+    render(
+      <PublicQuoteView
+        token="public-token"
+        initial={{ ...DETAIL, presentation: { theme: 'condensed', pageSize: 'letter' } }}
+      />
+    );
+    expect(screen.getByTestId('public-quote').getAttribute('data-doc-theme')).toBe('condensed');
+  });
+
+  it('defaults data-doc-theme to "classic" when the DTO omits presentation', () => {
+    render(<PublicQuoteView token="public-token" initial={DETAIL} />);
+    expect(screen.getByTestId('public-quote').getAttribute('data-doc-theme')).toBe('classic');
+  });
 });

--- a/apps/portal/src/components/portal/PublicQuoteView.tsx
+++ b/apps/portal/src/components/portal/PublicQuoteView.tsx
@@ -33,7 +33,7 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
     );
   }
 
-  const { quote, blocks, lines, branding } = initial;
+  const { quote, blocks, lines, branding, presentation } = initial;
   const currency = quote.currencyCode;
   const open = status === 'sent' || status === 'viewed';
   const hasRecurring =
@@ -111,7 +111,7 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
 
   return (
     <div className="mx-auto w-full max-w-3xl space-y-5 p-2 sm:p-4">
-      <DocumentPaper primaryColor={branding.primaryColor} testId="public-quote">
+      <DocumentPaper primaryColor={branding.primaryColor} testId="public-quote" docTheme={presentation?.theme}>
         <DocumentHeader
           logoUrl={branding.logoUrl}
           partnerName={branding.partnerName}

--- a/apps/portal/src/components/portal/QuoteDetailView.tsx
+++ b/apps/portal/src/components/portal/QuoteDetailView.tsx
@@ -65,7 +65,7 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
     );
   }
 
-  const { quote, blocks, lines, branding } = detail;
+  const { quote, blocks, lines, branding, presentation } = detail;
   const currency = quote.currencyCode;
   const open = status === 'sent' || status === 'viewed';
 
@@ -158,7 +158,7 @@ export function QuoteDetailView({ detail, error }: QuoteDetailViewProps) {
         </a>
       </div>
 
-      <DocumentPaper primaryColor={branding?.primaryColor}>
+      <DocumentPaper primaryColor={branding?.primaryColor} docTheme={presentation?.theme}>
         <DocumentHeader
           logoUrl={branding?.logoUrl}
           partnerName={branding?.partnerName}

--- a/apps/portal/src/components/portal/documentShell.tsx
+++ b/apps/portal/src/components/portal/documentShell.tsx
@@ -21,11 +21,12 @@ function accentVars(primaryColor?: string | null): CSSProperties {
 
 /** The bordered document card with a partner-accent top rule. */
 export function DocumentPaper({
-  primaryColor, children, testId,
-}: { primaryColor?: string | null; children: ReactNode; testId?: string }) {
+  primaryColor, children, testId, docTheme,
+}: { primaryColor?: string | null; children: ReactNode; testId?: string; docTheme?: string | null }) {
   return (
     <div
       data-testid={testId}
+      data-doc-theme={docTheme ?? 'classic'}
       style={accentVars(primaryColor)}
       className="overflow-hidden rounded-xl border bg-card shadow-xs"
     >

--- a/apps/portal/src/components/portal/quoteBlocks.test.tsx
+++ b/apps/portal/src/components/portal/quoteBlocks.test.tsx
@@ -140,3 +140,80 @@ describe('QuoteBlocks — line rendering (title/blurb + thumbnail)', () => {
     expect(screen.queryByTestId('quote-line-image-l4')).toBeNull();
   });
 });
+
+describe('QuoteBlocks — table block rendering', () => {
+  it('renders column labels, inline HTML cells, zebra striping and caption', () => {
+    const blocks: QuoteBlock[] = [
+      {
+        id: 'block-table-1',
+        blockType: 'table',
+        sortOrder: 0,
+        content: {
+          columns: [{ label: '<strong>Item</strong>' }, { label: 'Qty', align: 'right' }],
+          rows: [
+            { cells: ['Widget', '1'] },
+            { cells: ['Gadget', '2'] },
+          ],
+          caption: 'Pricing detail',
+          zebra: true,
+        },
+      },
+    ];
+    renderBlocks(blocks);
+
+    const table = screen.getByTestId('quote-table-block');
+    expect(table.querySelector('table')).not.toBeNull();
+    const header = screen.getByText('Item');
+    expect(header.tagName).toBe('STRONG');
+    expect(screen.getByText('Widget')).not.toBeNull();
+    expect(screen.getByText('Gadget')).not.toBeNull();
+    expect(screen.getByText('Pricing detail')).not.toBeNull();
+    const rows = table.querySelectorAll('tbody tr');
+    expect(rows[0].className).not.toContain('bg-muted/30');
+    expect(rows[1].className).toContain('bg-muted/30');
+  });
+
+  it('renders nothing for a table block with no columns or rows', () => {
+    const blocks: QuoteBlock[] = [
+      { id: 'block-table-empty', blockType: 'table', sortOrder: 0, content: { columns: [], rows: [] } },
+    ];
+    renderBlocks(blocks);
+    expect(screen.queryByTestId('quote-table-block')).toBeNull();
+  });
+});
+
+describe('QuoteBlocks — callout block rendering', () => {
+  it('renders a variant-tinted container with title and html', () => {
+    const blocks: QuoteBlock[] = [
+      {
+        id: 'block-callout-1',
+        blockType: 'callout',
+        sortOrder: 0,
+        content: { variant: 'warn', title: 'Heads up', html: '<p>Please read <strong>carefully</strong>.</p>' },
+      },
+    ];
+    renderBlocks(blocks);
+
+    const callout = screen.getByTestId('quote-callout-block');
+    expect(callout.className).toContain('border-amber-500/40');
+    expect(screen.getByText('Heads up')).not.toBeNull();
+    const strongEl = screen.getByText('carefully');
+    expect(strongEl.tagName).toBe('STRONG');
+  });
+
+  it('renders nothing for a callout block with no html', () => {
+    const blocks: QuoteBlock[] = [
+      { id: 'block-callout-empty', blockType: 'callout', sortOrder: 0, content: { html: '   ' } },
+    ];
+    renderBlocks(blocks);
+    expect(screen.queryByTestId('quote-callout-block')).toBeNull();
+  });
+
+  it('keeps returning null for an unknown block type (customers never see debris)', () => {
+    const blocks: QuoteBlock[] = [
+      { id: 'block-unknown-1', blockType: 'mystery_block', sortOrder: 0, content: { foo: 'bar' } },
+    ];
+    const { container } = renderBlocks(blocks);
+    expect(container.textContent).toBe('');
+  });
+});

--- a/apps/portal/src/components/portal/quoteBlocks.tsx
+++ b/apps/portal/src/components/portal/quoteBlocks.tsx
@@ -6,7 +6,7 @@
 // lines (no blockId) fall into a trailing default pricing table — same as the
 // PDF, which appends un-blocked lines after the block walk.
 import { Fragment } from 'react';
-import type { QuoteBlock, QuoteContractBlockContent, QuoteLine } from '@/lib/api';
+import type { QuoteBlock, QuoteCalloutContent, QuoteContractBlockContent, QuoteLine, QuoteTableContent } from '@/lib/api';
 
 export function money(value: string | number, currencyCode: string): string {
   const n = Number(value);
@@ -271,6 +271,66 @@ export function QuoteBlocks({
             <div className="rounded-lg border bg-muted/50 p-4 text-sm text-muted-foreground">Contract file unavailable</div>
           )}
           <p className="text-xs text-muted-foreground">{templateName} — v{versionNumber}</p>
+        </div>
+      );
+    }
+
+    if (block.blockType === 'table') {
+      // Structured JSON, never HTML-parsed — column labels and cell values are
+      // sanitized server-side with the inline-only profile (quoteService's
+      // read-path sanitizer), same precedent as rich_text above.
+      const c = content as unknown as Partial<QuoteTableContent>;
+      if (!c.columns?.length || !c.rows?.length) return null;
+      return (
+        <div key={block.id} className="overflow-x-auto" data-testid="quote-table-block">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className={c.headerStyle === 'plain' ? 'border-b-2' : 'border-b-2 bg-primary/10'}>
+                {c.columns.map((col, i) => (
+                  <th
+                    key={i}
+                    style={{ textAlign: col.align ?? 'left' }}
+                    className="px-3 py-2 font-semibold text-foreground"
+                    dangerouslySetInnerHTML={{ __html: col.label }}
+                  />
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {c.rows.map((row, ri) => (
+                <tr key={ri} className={c.zebra && ri % 2 === 1 ? 'bg-muted/30' : undefined}>
+                  {row.cells.map((cell, ci) => (
+                    <td
+                      key={ci}
+                      style={{ textAlign: c.columns?.[ci]?.align ?? 'left' }}
+                      className="px-3 py-2 align-top text-foreground/90"
+                      dangerouslySetInnerHTML={{ __html: cell }}
+                    />
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {c.caption && <p className="mt-1 text-xs text-muted-foreground">{c.caption}</p>}
+        </div>
+      );
+    }
+
+    if (block.blockType === 'callout') {
+      // Same sanitized-HTML precedent as rich_text — server-sanitized on both
+      // write and read before it ever reaches this component.
+      const c = content as unknown as Partial<QuoteCalloutContent>;
+      if (!c.html?.trim()) return null;
+      const tone =
+        c.variant === 'warn'
+          ? 'border-amber-500/40 bg-amber-500/10'
+          : c.variant === 'accent'
+            ? 'border-primary/40 bg-primary/10'
+            : 'border-border bg-muted/40';
+      return (
+        <div key={block.id} className={`rounded-lg border-l-4 p-4 ${tone}`} data-testid="quote-callout-block">
+          {c.title && <p className="mb-1 text-sm font-semibold text-foreground">{c.title}</p>}
+          <div className="quote-rich-text text-sm leading-relaxed text-foreground" dangerouslySetInnerHTML={{ __html: c.html }} />
         </div>
       );
     }

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -443,6 +443,27 @@ export interface QuoteContractBlockContent {
   authoring?: never;
 }
 
+/** Server-serialized shape of a `table` quote block's `content` (mirrors
+ *  `quoteTableContentSchema` in @breeze/shared/validators/quotes.ts). Column
+ *  labels and cell values are sanitized server-side with the inline-only
+ *  profile before ever reaching the portal, same precedent as rich_text. */
+export interface QuoteTableContent {
+  columns: Array<{ label: string; align?: 'left' | 'center' | 'right' }>;
+  rows: Array<{ cells: string[] }>;
+  caption?: string;
+  zebra?: boolean;
+  headerStyle?: 'accent' | 'plain';
+}
+
+/** Server-serialized shape of a `callout` quote block's `content` (mirrors
+ *  `quoteCalloutContentSchema` in @breeze/shared/validators/quotes.ts). `html`
+ *  is sanitized server-side, same precedent as rich_text. */
+export interface QuoteCalloutContent {
+  variant: 'info' | 'accent' | 'warn';
+  title?: string;
+  html: string;
+}
+
 export interface QuoteBlock {
   id: string;
   blockType: string;

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -7,7 +7,7 @@ import { navigateTo } from './navigation';
 // Invoice-domain enum SSOT lives in @breeze/shared (billing-enums.ts). Imported
 // into local scope for the InvoiceSummary/InvoiceDetail types below and re-exported
 // (type-only, erased at build) so '@/lib/api' consumers are unaffected.
-import type { InvoiceStatus, PublicQuoteHeader, TicketFormField } from '@breeze/shared';
+import type { InvoiceStatus, PublicQuoteHeader, QuotePresentation, TicketFormField } from '@breeze/shared';
 
 // Client API base. Empty (the default) → same-origin **relative** requests
 // (`/api/v1/...`), which the reverse proxy routes to the API under `/api/*`. This
@@ -526,6 +526,9 @@ export interface QuoteDetail {
   lines: QuoteLine[];
   /** Optional for API responses that predate the branding field. */
   branding?: QuoteBranding;
+  /** Resolved document theme/pageSize (Task 12). Optional: fixtures/older
+   *  payloads omit it, which must read as 'classic' (documentShell's fallback). */
+  presentation?: QuotePresentation;
 }
 
 export interface PublicQuoteDetail {
@@ -533,6 +536,9 @@ export interface PublicQuoteDetail {
   blocks: QuoteBlock[];
   lines: QuoteLine[];
   branding: QuoteBranding;
+  /** Resolved document theme/pageSize (Task 12). Optional: fixtures/older
+   *  payloads omit it, which must read as 'classic' (documentShell's fallback). */
+  presentation?: QuotePresentation;
 }
 
 export interface Profile {

--- a/apps/portal/src/styles/globals.css
+++ b/apps/portal/src/styles/globals.css
@@ -1,3 +1,15 @@
+/* Condensed document theme fonts (Task 12) — Barlow Condensed for headings,
+   DM Sans for body copy, scoped to [data-doc-theme='condensed'] documents
+   only (see the rule near the end of this file). Declared unconditionally: a
+   browser only fetches a face when a matched element actually uses it, so a
+   'classic' document downloads nothing. These @imports must stay above
+   `@import 'tailwindcss'` — Vite's postcss-import resolves @import at build
+   time and drops any @import that isn't first (same rule as apps/web). */
+@import '@fontsource/barlow-condensed/600.css';
+@import '@fontsource/dm-sans/400.css';
+@import '@fontsource/dm-sans/500.css';
+@import '@fontsource/dm-sans/700.css';
+
 @import 'tailwindcss';
 
 @plugin '@tailwindcss/forms';
@@ -173,4 +185,16 @@
   .quote-rich-text a {
     @apply text-primary underline underline-offset-2;
   }
+}
+
+/* Condensed document theme (Task 12) — plain CSS vars/selectors, not @theme
+   tokens. Scoped to [data-doc-theme='condensed'], stamped by documentShell's
+   DocumentPaper on the rendered quote/invoice root, so it never touches the
+   rest of the portal. */
+[data-doc-theme='condensed'] {
+  font-family: 'DM Sans', var(--font-sans, system-ui), sans-serif;
+}
+[data-doc-theme='condensed'] :is(h1, h2, h3, h4, th) {
+  font-family: 'Barlow Condensed', 'DM Sans', sans-serif;
+  letter-spacing: 0.01em;
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "@sentry/astro": "^10.62.0",
     "@simplewebauthn/browser": "^13.3.0",
     "@tanstack/react-query": "^5.101.4",
+    "@tiptap/core": "^3.28.0",
     "@tiptap/extension-link": "^3.28.0",
     "@tiptap/extension-underline": "^3.29.1",
     "@tiptap/pm": "^3.28.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,8 @@
     "@astrojs/node": "^11.1.0",
     "@astrojs/react": "^6.0.2",
     "@breeze/extension-web-sdk": "workspace:*",
+    "@fontsource/barlow-condensed": "^5.3.0",
+    "@fontsource/dm-sans": "^5.3.0",
     "@fontsource/plus-jakarta-sans": "^5.2.8",
     "@hookform/resolvers": "^5.4.0",
     "@monaco-editor/react": "^4.6.0",

--- a/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
@@ -22,6 +22,8 @@ import {
   type QuoteBlock,
   type QuoteLine,
   type QuoteLineRecurrence,
+  type QuoteTableContent,
+  type QuoteCalloutContent,
   formatMoney,
 } from './quoteTypes';
 import { type LineUpdate, SrSaved, fieldRing, pendingKey, seamless } from './quoteEditorShared';
@@ -379,6 +381,86 @@ export function BlockCard({
         {block.blockType === 'contract' && (
           <ContractBlockEditor block={block} canWrite={canWrite} onEditBlock={onEditBlock} />
         )}
+
+        {block.blockType === 'table' && (() => {
+          // Structured JSON, never HTML-parsed — column labels and cell values
+          // are sanitized server-side with the inline-only profile on both
+          // write and read (quoteService's read-path sanitizer), same
+          // dangerouslySetInnerHTML precedent as QuoteDocument.tsx's canonical
+          // table rendering, which this mirrors. Read-only for now (no inline
+          // edit affordance yet — remove-and-re-add is the only way to change
+          // a persisted table, same limitation the contract block used to
+          // have before ContractBlockEditor).
+          const content = block.content as Partial<QuoteTableContent> | undefined;
+          if (!content?.columns?.length || !content?.rows?.length) {
+            return (
+              <p className="text-sm text-muted-foreground" data-testid={`quote-block-table-content-${block.id}`}>
+                {t('quotes.editor.block.tableEmpty')}
+              </p>
+            );
+          }
+          return (
+            <div className="overflow-x-auto" data-testid={`quote-block-table-content-${block.id}`}>
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className={content.headerStyle === 'plain' ? 'border-b-2' : 'border-b-2 bg-primary/10'}>
+                    {content.columns.map((col, i) => (
+                      <th
+                        key={i}
+                        style={{ textAlign: col.align ?? 'left' }}
+                        className="px-3 py-2 font-semibold text-foreground"
+                        dangerouslySetInnerHTML={{ __html: col.label }}
+                      />
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {content.rows.map((row, ri) => (
+                    <tr key={ri} className={content.zebra && ri % 2 === 1 ? 'bg-muted/30' : undefined}>
+                      {row.cells.map((cell, ci) => (
+                        <td
+                          key={ci}
+                          style={{ textAlign: content.columns?.[ci]?.align ?? 'left' }}
+                          className="px-3 py-2 align-top text-foreground/90"
+                          dangerouslySetInnerHTML={{ __html: cell }}
+                        />
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {content.caption && <p className="mt-1 text-xs text-muted-foreground">{content.caption}</p>}
+            </div>
+          );
+        })()}
+
+        {block.blockType === 'callout' && (() => {
+          // Same server-sanitized-HTML precedent as rich_text. Read-only for
+          // now — see the table block's note above.
+          const content = block.content as Partial<QuoteCalloutContent> | undefined;
+          if (!content?.html?.trim()) {
+            return (
+              <p className="text-sm text-muted-foreground" data-testid={`quote-block-callout-content-${block.id}`}>
+                {t('quotes.editor.block.calloutEmpty')}
+              </p>
+            );
+          }
+          const tone =
+            content.variant === 'warn'
+              ? 'border-amber-500/40 bg-amber-500/10'
+              : content.variant === 'accent'
+                ? 'border-primary/40 bg-primary/10'
+                : 'border-border bg-muted/40';
+          return (
+            <div className={`rounded-lg border-l-4 p-4 ${tone}`} data-testid={`quote-block-callout-content-${block.id}`}>
+              {content.title && <p className="mb-1 text-sm font-semibold text-foreground">{content.title}</p>}
+              <div
+                className="quote-rich-text prose prose-sm max-w-prose dark:prose-invert"
+                dangerouslySetInnerHTML={{ __html: content.html }}
+              />
+            </div>
+          );
+        })()}
 
         {isTable && (
           <div className="space-y-3">

--- a/apps/web/src/components/billing/quotes/QuoteDocument.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.test.tsx
@@ -68,6 +68,31 @@ describe('QuoteDocument', () => {
     expect(screen.queryByTestId('quote-document-due')).toBeNull();
   });
 
+  it('stamps data-doc-theme="condensed" when the DTO resolves the condensed theme', () => {
+    render(
+      <QuoteDocument
+        detail={makeDetail({ presentation: { theme: 'condensed', pageSize: 'letter' } })}
+        customerName="Acme Industries"
+      />
+    );
+    expect(screen.getByTestId('quote-document')).toHaveAttribute('data-doc-theme', 'condensed');
+  });
+
+  it('stamps data-doc-theme="classic" when the DTO resolves the classic theme', () => {
+    render(
+      <QuoteDocument
+        detail={makeDetail({ presentation: { theme: 'classic', pageSize: 'a4' } })}
+        customerName="Acme Industries"
+      />
+    );
+    expect(screen.getByTestId('quote-document')).toHaveAttribute('data-doc-theme', 'classic');
+  });
+
+  it('defaults data-doc-theme to "classic" when the payload omits presentation', () => {
+    render(<QuoteDocument detail={makeDetail({ presentation: undefined })} customerName="Acme Industries" />);
+    expect(screen.getByTestId('quote-document')).toHaveAttribute('data-doc-theme', 'classic');
+  });
+
   it('falls back to a draft label and partner wordmark when number/logo are absent', () => {
     const d = makeDetail();
     d.quote.quoteNumber = null;

--- a/apps/web/src/components/billing/quotes/QuoteDocument.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { QuoteDocument } from './QuoteDocument';
 import QuoteDocumentPreview from './QuoteDocument';
-import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import type { QuoteDetail as QuoteDetailData, QuoteBlock } from './quoteTypes';
 import { fetchWithAuth } from '../../../stores/auth';
 
 // QuoteDocument is presentational, but its module imports the auth/org stores and
@@ -206,6 +206,74 @@ describe('QuoteDocument', () => {
     expect(screen.getByTestId('contract-block')).toHaveTextContent('Contract file unavailable');
     expect(document.querySelector('iframe')).toBeNull();
     expect(fetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it('renders a table block with column labels, inline HTML cells, zebra striping and caption', () => {
+    const d = makeDetail();
+    d.blocks = [
+      ...d.blocks,
+      {
+        id: 'b-6', quoteId: 'q-1', orgId: 'org-1', blockType: 'table',
+        content: {
+          columns: [{ label: '<strong>Item</strong>' }, { label: 'Qty', align: 'right' }],
+          rows: [
+            { cells: ['Widget', '1'] },
+            { cells: ['Gadget', '2'] },
+          ],
+          caption: 'Pricing detail',
+          zebra: true,
+        },
+        sortOrder: 2, createdAt: '2026-06-01T00:00:00Z',
+      },
+    ];
+    render(<QuoteDocument detail={d} customerName="Acme" />);
+
+    const table = screen.getByTestId('quote-table-block');
+    expect(table.querySelector('table')).not.toBeNull();
+    const header = screen.getByText('Item');
+    expect(header.tagName).toBe('STRONG');
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+    expect(screen.getByText('Gadget')).toBeInTheDocument();
+    expect(screen.getByText('Pricing detail')).toBeInTheDocument();
+    // Zebra striping: second row (index 1) gets the muted background class.
+    const rows = table.querySelectorAll('tbody tr');
+    expect(rows[0]).not.toHaveClass('bg-muted/30');
+    expect(rows[1]).toHaveClass('bg-muted/30');
+  });
+
+  it('renders a callout block with a variant-tinted container, title and html', () => {
+    const d = makeDetail();
+    d.blocks = [
+      ...d.blocks,
+      {
+        id: 'b-7', quoteId: 'q-1', orgId: 'org-1', blockType: 'callout',
+        content: { variant: 'warn', title: 'Heads up', html: '<p>Please read <strong>carefully</strong>.</p>' },
+        sortOrder: 2, createdAt: '2026-06-01T00:00:00Z',
+      },
+    ];
+    render(<QuoteDocument detail={d} customerName="Acme" />);
+
+    const callout = screen.getByTestId('quote-callout-block');
+    expect(callout).toHaveClass('border-amber-500/40');
+    expect(screen.getByText('Heads up')).toBeInTheDocument();
+    const strongEl = screen.getByText('carefully');
+    expect(strongEl.tagName).toBe('STRONG');
+  });
+
+  it('renders a visible placeholder for an unsupported/unknown block type', () => {
+    const d = makeDetail();
+    d.blocks = [
+      ...d.blocks,
+      {
+        // Intentionally a blockType the client doesn't know about (e.g. a
+        // future server-added type) — must fail visibly, not silently vanish.
+        id: 'b-8', quoteId: 'q-1', orgId: 'org-1', blockType: 'future_block_type' as unknown as QuoteBlock['blockType'],
+        content: {},
+        sortOrder: 3, createdAt: '2026-06-01T00:00:00Z',
+      },
+    ];
+    render(<QuoteDocument detail={d} customerName="Acme" />);
+    expect(screen.getByTestId('unsupported-block')).toBeInTheDocument();
   });
 
   it('never renders internal cost/markup/net on the customer document', () => {

--- a/apps/web/src/components/billing/quotes/QuoteDocument.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.tsx
@@ -372,7 +372,7 @@ interface DocumentProps {
  *  logo/accent. Works for drafts (no portal round-trip). */
 export function QuoteDocument({ detail, customerName }: DocumentProps) {
   const { t } = useTranslation('billing');
-  const { quote, blocks, lines, branding, billTo } = detail;
+  const { quote, blocks, lines, branding, billTo, presentation } = detail;
   // Customer billing address lines (resolved server-side from the org's Billing
   // settings for drafts, or the frozen snapshot once sent). Empty when the org
   // has saved no billing address — the block then shows just the name.
@@ -414,6 +414,7 @@ export function QuoteDocument({ detail, customerName }: DocumentProps) {
     <div
       style={accentStyle}
       data-testid="quote-document"
+      data-doc-theme={presentation?.theme ?? 'classic'}
       className="mx-auto max-w-3xl overflow-hidden rounded-xl border bg-card shadow-xs"
     >
       <div className="space-y-10 px-4 py-7 sm:px-12 sm:py-10">

--- a/apps/web/src/components/billing/quotes/QuoteDocument.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.tsx
@@ -10,6 +10,8 @@ import {
   type QuoteBlock,
   type QuoteLine,
   type ContractBlockContent,
+  type QuoteTableContent,
+  type QuoteCalloutContent,
   STATUS_ROLES,
   statusLabel,
   formatDate,
@@ -283,10 +285,80 @@ function DocBlock({ block, lines, quoteId, currency, taxRate, showTax }: { block
       </div>
     );
   }
-  // line_items
-  const label = (block.content?.label as string | undefined)?.trim() || t('quotes.document.pricing');
-  const showSubtotal = block.content?.showSubtotal === true;
-  return <PricingTable lines={lines} quoteId={quoteId} currency={currency} label={label} taxRate={taxRate} showTax={showTax} showSubtotal={showSubtotal} />;
+  if (block.blockType === 'table') {
+    // Structured JSON, never HTML-parsed — column labels and cell values are
+    // sanitized server-side with the inline-only profile (quoteService's
+    // read-path sanitizer), safe for dangerouslySetInnerHTML per the rich_text
+    // precedent above.
+    const content = block.content as Partial<QuoteTableContent> | undefined;
+    if (!content?.columns?.length || !content?.rows?.length) return null;
+    return (
+      <div className="overflow-x-auto" data-testid="quote-table-block">
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className={content.headerStyle === 'plain' ? 'border-b-2' : 'border-b-2 bg-primary/10'}>
+              {content.columns.map((col, i) => (
+                <th
+                  key={i}
+                  style={{ textAlign: col.align ?? 'left' }}
+                  className="px-3 py-2 font-semibold text-foreground"
+                  dangerouslySetInnerHTML={{ __html: col.label }}
+                />
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {content.rows.map((row, ri) => (
+              <tr key={ri} className={content.zebra && ri % 2 === 1 ? 'bg-muted/30' : undefined}>
+                {row.cells.map((cell, ci) => (
+                  <td
+                    key={ci}
+                    style={{ textAlign: content.columns?.[ci]?.align ?? 'left' }}
+                    className="px-3 py-2 align-top text-foreground/90"
+                    dangerouslySetInnerHTML={{ __html: cell }}
+                  />
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {content.caption && <p className="mt-1 text-xs text-muted-foreground">{content.caption}</p>}
+      </div>
+    );
+  }
+  if (block.blockType === 'callout') {
+    // Same sanitized-HTML precedent as rich_text — server-sanitized on both
+    // write and read before it ever reaches this component.
+    const content = block.content as Partial<QuoteCalloutContent> | undefined;
+    if (!content?.html?.trim()) return null;
+    const tone =
+      content.variant === 'warn'
+        ? 'border-amber-500/40 bg-amber-500/10'
+        : content.variant === 'accent'
+          ? 'border-primary/40 bg-primary/10'
+          : 'border-border bg-muted/40';
+    return (
+      <div className={`rounded-lg border-l-4 p-4 ${tone}`} data-testid="quote-callout-block">
+        {content.title && <p className="mb-1 text-sm font-semibold text-foreground">{content.title}</p>}
+        <div
+          className="quote-rich-text prose prose-sm max-w-prose dark:prose-invert"
+          dangerouslySetInnerHTML={{ __html: content.html }}
+        />
+      </div>
+    );
+  }
+  if (block.blockType === 'line_items') {
+    const label = (block.content?.label as string | undefined)?.trim() || t('quotes.document.pricing');
+    const showSubtotal = block.content?.showSubtotal === true;
+    return <PricingTable lines={lines} quoteId={quoteId} currency={currency} label={label} taxRate={taxRate} showTax={showTax} showSubtotal={showSubtotal} />;
+  }
+  // Unknown/future blockType — staff-facing visible placeholder rather than
+  // silently rendering nothing (spec §4).
+  return (
+    <div className="rounded-lg border border-dashed p-3 text-sm text-muted-foreground" data-testid="unsupported-block">
+      {t('quotes.document.unsupportedBlock')}
+    </div>
+  );
 }
 
 interface DocumentProps {

--- a/apps/web/src/components/billing/quotes/QuoteEditor.calloutblock.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.calloutblock.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuoteEditor from './QuoteEditor';
-import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import type { QuoteDetail as QuoteDetailData, QuoteBlock } from './quoteTypes';
 import { addBlock } from '../../../lib/api/quotes';
 
 // Same house pattern as TemplateEditor.test.tsx: swap the tiptap-backed
@@ -146,5 +146,26 @@ describe('QuoteEditor — add callout block', () => {
     // regression class this brief calls out explicitly.
     await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
     await waitFor(() => expect(submit).not.toBeDisabled());
+  });
+});
+
+describe('QuoteEditor — persisted callout block', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // Regression: after Task 13's initial cut, QuoteBlockCard had no branch for
+  // `table`/`callout`, so a just-created (or reloaded) callout block rendered
+  // as an empty block — invisible on the canvas even though it existed
+  // server-side. This proves the read-only display branch renders content.
+  it('renders the persisted callout content visibly (not blank) on the canvas', async () => {
+    const calloutBlock: QuoteBlock = {
+      id: 'blk-c', quoteId: 'q-1', orgId: 'org-1', blockType: 'callout',
+      content: { variant: 'warn', title: 'Heads up', html: '<p>Read carefully</p>' },
+      sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+    };
+    render(<QuoteEditor detail={{ ...detail, blocks: [calloutBlock] }} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-block-callout-content-blk-c')).toBeInTheDocument());
+    const content = screen.getByTestId('quote-block-callout-content-blk-c');
+    expect(content).toHaveTextContent('Heads up');
+    expect(content).toHaveTextContent('Read carefully');
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteEditor.calloutblock.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.calloutblock.test.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { addBlock } from '../../../lib/api/quotes';
+
+// Same house pattern as TemplateEditor.test.tsx: swap the tiptap-backed
+// RichTextEditor for a plain textarea so this test targets the callout form
+// (variant/title/body wiring, submit), not rich-text editing internals.
+vi.mock('../../common/RichTextEditor', () => ({
+  default: ({ value, onChange, testId }: { value: string; onChange: (v: string) => void; testId: string }) => (
+    <textarea data-testid={testId} value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+  polishTextRequest: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  updateBlock: vi.fn(),
+  updateQuote: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  addQuoteImageFromUrl: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const okRes = (data: unknown) =>
+  ({ ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data }) } as unknown as Response);
+const errRes = () =>
+  ({ ok: false, status: 502, statusText: 'Bad Gateway', json: vi.fn().mockResolvedValue({ error: 'x' }) } as unknown as Response);
+
+const detail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+    taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+    createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [],
+  lines: [],
+};
+
+const addBlockMock = vi.mocked(addBlock);
+
+async function openCalloutForm() {
+  render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+  await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+  fireEvent.click(screen.getByTestId('quote-add-block-type-callout'));
+  await waitFor(() => expect(screen.getByTestId('quote-block-callout')).toBeInTheDocument());
+}
+
+describe('QuoteEditor — add callout block', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows a "Callout" chip in the add-block picker', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-add-block-type-callout')).toBeInTheDocument();
+  });
+
+  it('defaults the variant to "info" and offers info/accent/warn', async () => {
+    await openCalloutForm();
+    const select = screen.getByTestId('quote-block-callout-variant');
+    expect(select).toHaveValue('info');
+    const options = Array.from((select as HTMLSelectElement).options).map((o) => o.value);
+    expect(options).toEqual(['info', 'accent', 'warn']);
+  });
+
+  it('submit is disabled until body text is entered', async () => {
+    await openCalloutForm();
+    expect(screen.getByTestId('quote-add-block-submit')).toBeDisabled();
+    fireEvent.change(screen.getByTestId('quote-block-callout-body'), { target: { value: '<p>Note</p>' } });
+    expect(screen.getByTestId('quote-add-block-submit')).not.toBeDisabled();
+  });
+
+  it('creating a callout POSTs blockType "callout" with variant/title/html', async () => {
+    addBlockMock.mockResolvedValue(okRes({ id: 'blk-c' }));
+    await openCalloutForm();
+
+    fireEvent.change(screen.getByTestId('quote-block-callout-variant'), { target: { value: 'warn' } });
+    fireEvent.change(screen.getByTestId('quote-block-callout-title'), { target: { value: 'Heads up' } });
+    fireEvent.change(screen.getByTestId('quote-block-callout-body'), { target: { value: '<p>Read carefully</p>' } });
+
+    fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+
+    await waitFor(() => expect(addBlockMock).toHaveBeenCalledWith('q-1', {
+      blockType: 'callout',
+      content: { variant: 'warn', title: 'Heads up', html: '<p>Read carefully</p>' },
+    }));
+  });
+
+  it('omits an empty title from the submitted content', async () => {
+    addBlockMock.mockResolvedValue(okRes({ id: 'blk-c' }));
+    await openCalloutForm();
+
+    fireEvent.change(screen.getByTestId('quote-block-callout-body'), { target: { value: '<p>Note</p>' } });
+    fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+
+    await waitFor(() => expect(addBlockMock).toHaveBeenCalledWith('q-1', {
+      blockType: 'callout',
+      content: { variant: 'info', html: '<p>Note</p>' },
+    }));
+  });
+
+  it('disables submit while add-block is in flight and re-enables with an error surfaced on failure', async () => {
+    addBlockMock.mockResolvedValue(errRes());
+    await openCalloutForm();
+    fireEvent.change(screen.getByTestId('quote-block-callout-body'), { target: { value: '<p>Note</p>' } });
+
+    const submit = screen.getByTestId('quote-add-block-submit');
+    fireEvent.click(submit);
+
+    // Rejected request: the pending guard must unlatch (not leave submit
+    // permanently disabled) and the failure must be visible — the #3519
+    // regression class this brief calls out explicitly.
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    await waitFor(() => expect(submit).not.toBeDisabled());
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tableblock.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tableblock.test.tsx
@@ -1,0 +1,196 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { addBlock } from '../../../lib/api/quotes';
+
+// This test targets the table-grid authoring UI (add/remove row+column, align,
+// zebra/headerStyle, submit wiring) — not TipTap internals, which
+// InlineRichTextEditor.test.tsx already covers on its own. Replacing it with a
+// plain textarea mirrors the established house pattern for RichTextEditor
+// (see TemplateEditor.test.tsx) and makes cell edits trivially simulatable via
+// fireEvent.change.
+vi.mock('../../common/InlineRichTextEditor', () => ({
+  default: ({ value, onChange, testId }: { value: string; onChange: (v: string) => void; testId: string }) => (
+    <textarea data-testid={testId} value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+  polishTextRequest: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  updateBlock: vi.fn(),
+  updateQuote: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  addQuoteImageFromUrl: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const okRes = (data: unknown) =>
+  ({ ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data }) } as unknown as Response);
+const errRes = () =>
+  ({ ok: false, status: 502, statusText: 'Bad Gateway', json: vi.fn().mockResolvedValue({ error: 'x' }) } as unknown as Response);
+
+const detail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+    taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+    createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [],
+  lines: [],
+};
+
+const addBlockMock = vi.mocked(addBlock);
+
+async function openTableForm() {
+  render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+  await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+  fireEvent.click(screen.getByTestId('quote-add-block-type-table'));
+  await waitFor(() => expect(screen.getByTestId('quote-block-table')).toBeInTheDocument());
+}
+
+describe('QuoteEditor — add table block', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows a "Table" chip in the add-block picker', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-add-block-type-table')).toBeInTheDocument();
+  });
+
+  it('starts with a 2x2 grid', async () => {
+    await openTableForm();
+    expect(screen.getByTestId('quote-block-table-column-label-0')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-block-table-column-label-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('quote-block-table-column-label-2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('quote-block-table-cell-0-0')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-block-table-cell-1-1')).toBeInTheDocument();
+  });
+
+  it('adding a column pads every existing row with an empty cell (cells.length === columns.length)', async () => {
+    await openTableForm();
+    fireEvent.change(screen.getByTestId('quote-block-table-cell-0-0'), { target: { value: 'A0' } });
+    fireEvent.change(screen.getByTestId('quote-block-table-cell-1-1'), { target: { value: 'B1' } });
+
+    fireEvent.click(screen.getByTestId('quote-block-table-add-column'));
+
+    expect(screen.getByTestId('quote-block-table-column-label-2')).toBeInTheDocument();
+    // Every row now has a 3rd (padded, empty) cell — existing content untouched.
+    expect(screen.getByTestId('quote-block-table-cell-0-2')).toHaveValue('');
+    expect(screen.getByTestId('quote-block-table-cell-1-2')).toHaveValue('');
+    expect(screen.getByTestId('quote-block-table-cell-0-0')).toHaveValue('A0');
+    expect(screen.getByTestId('quote-block-table-cell-1-1')).toHaveValue('B1');
+  });
+
+  it('removing a column removes that cell from every row', async () => {
+    await openTableForm();
+    fireEvent.click(screen.getByTestId('quote-block-table-remove-column-0'));
+    expect(screen.queryByTestId('quote-block-table-column-label-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('quote-block-table-column-label-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('quote-block-table-cell-0-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quote-block-table-cell-1-1')).not.toBeInTheDocument();
+  });
+
+  it('cannot remove the last remaining column', async () => {
+    await openTableForm();
+    fireEvent.click(screen.getByTestId('quote-block-table-remove-column-0'));
+    expect(screen.getByTestId('quote-block-table-remove-column-0')).toBeDisabled();
+  });
+
+  it('adding then removing a row works and cannot go below one row', async () => {
+    await openTableForm();
+    fireEvent.click(screen.getByTestId('quote-block-table-add-row'));
+    expect(screen.getByTestId('quote-block-table-cell-2-0')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('quote-block-table-remove-row-2'));
+    fireEvent.click(screen.getByTestId('quote-block-table-remove-row-1'));
+    expect(screen.queryByTestId('quote-block-table-cell-1-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('quote-block-table-remove-row-0')).toBeDisabled();
+  });
+
+  it('per-column align select and zebra/headerStyle toggles are present and changeable', async () => {
+    await openTableForm();
+    fireEvent.change(screen.getByTestId('quote-block-table-column-align-0'), { target: { value: 'right' } });
+    expect(screen.getByTestId('quote-block-table-column-align-0')).toHaveValue('right');
+
+    fireEvent.click(screen.getByTestId('quote-block-table-zebra'));
+    expect(screen.getByTestId('quote-block-table-zebra')).toBeChecked();
+
+    fireEvent.change(screen.getByTestId('quote-block-table-header-style'), { target: { value: 'accent' } });
+    expect(screen.getByTestId('quote-block-table-header-style')).toHaveValue('accent');
+  });
+
+  it('creating a table POSTs blockType "table" with the current grid content', async () => {
+    addBlockMock.mockResolvedValue(okRes({ id: 'blk-t' }));
+    await openTableForm();
+
+    fireEvent.change(screen.getByTestId('quote-block-table-column-label-0'), { target: { value: 'Item' } });
+    fireEvent.change(screen.getByTestId('quote-block-table-column-label-1'), { target: { value: 'Notes' } });
+    fireEvent.change(screen.getByTestId('quote-block-table-column-align-1'), { target: { value: 'right' } });
+    fireEvent.change(screen.getByTestId('quote-block-table-cell-0-0'), { target: { value: 'Router' } });
+    fireEvent.change(screen.getByTestId('quote-block-table-cell-0-1'), { target: { value: 'Optional' } });
+    fireEvent.change(screen.getByTestId('quote-block-table-caption'), { target: { value: 'Hardware' } });
+    fireEvent.click(screen.getByTestId('quote-block-table-zebra'));
+
+    fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+
+    await waitFor(() => expect(addBlockMock).toHaveBeenCalledWith('q-1', {
+      blockType: 'table',
+      content: {
+        columns: [{ label: 'Item' }, { label: 'Notes', align: 'right' }],
+        rows: [{ cells: ['Router', 'Optional'] }, { cells: ['', ''] }],
+        caption: 'Hardware',
+        zebra: true,
+        headerStyle: 'plain',
+      },
+    }));
+  });
+
+  it('disables submit while add-block is in flight and re-enables with an error surfaced on failure', async () => {
+    addBlockMock.mockResolvedValue(errRes());
+    await openTableForm();
+
+    const submit = screen.getByTestId('quote-add-block-submit');
+    fireEvent.click(submit);
+
+    // Rejected request: the pending guard must unlatch (not leave submit
+    // permanently disabled) and the failure must be visible — the #3519
+    // regression class this brief calls out explicitly.
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    await waitFor(() => expect(submit).not.toBeDisabled());
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tableblock.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tableblock.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuoteEditor from './QuoteEditor';
-import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import type { QuoteDetail as QuoteDetailData, QuoteBlock } from './quoteTypes';
 import { addBlock } from '../../../lib/api/quotes';
 
 // This test targets the table-grid authoring UI (add/remove row+column, align,
@@ -192,5 +192,31 @@ describe('QuoteEditor — add table block', () => {
     // regression class this brief calls out explicitly.
     await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
     await waitFor(() => expect(submit).not.toBeDisabled());
+  });
+});
+
+describe('QuoteEditor — persisted table block', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // Regression: after Task 13's initial cut, QuoteBlockCard had no branch for
+  // `table`/`callout`, so a just-created (or reloaded) table block rendered
+  // as an empty block — invisible on the canvas even though it existed
+  // server-side. This proves the read-only display branch renders content.
+  it('renders the persisted table content visibly (not blank) on the canvas', async () => {
+    const tableBlock: QuoteBlock = {
+      id: 'blk-t', quoteId: 'q-1', orgId: 'org-1', blockType: 'table',
+      content: {
+        columns: [{ label: 'Item' }, { label: 'Notes', align: 'right' }],
+        rows: [{ cells: ['Router', 'Optional'] }],
+        caption: 'Hardware',
+      },
+      sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+    };
+    render(<QuoteEditor detail={{ ...detail, blocks: [tableBlock] }} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-block-table-content-blk-t')).toBeInTheDocument());
+    const content = screen.getByTestId('quote-block-table-content-blk-t');
+    expect(content).toHaveTextContent('Item');
+    expect(content).toHaveTextContent('Router');
+    expect(content).toHaveTextContent('Hardware');
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -2291,6 +2291,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
                               <input
                                 type="text"
                                 value={col.label}
+                                maxLength={200}
                                 onChange={(e) => setTableColumnLabel(colIdx, e.target.value)}
                                 placeholder={t('quotes.editor.table.columnLabelPlaceholder')}
                                 data-testid={`quote-block-table-column-label-${colIdx}`}
@@ -2346,6 +2347,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
                                 onChange={(html) => setTableCell(rowIdx, colIdx, html)}
                                 ariaLabel={t('quotes.editor.table.cellAria', { row: rowIdx + 1, column: colIdx + 1 })}
                                 testId={`quote-block-table-cell-${rowIdx}-${colIdx}`}
+                                maxLength={2000}
                               />
                             </td>
                           ))}
@@ -2379,6 +2381,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
                 <input
                   type="text"
                   value={tableCaption}
+                  maxLength={300}
                   onChange={(e) => setTableCaption(e.target.value)}
                   placeholder={t('quotes.editor.table.captionPlaceholder')}
                   data-testid="quote-block-table-caption"

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -28,13 +28,14 @@ import {
   type ContractTemplateDetail,
   type TemplateVersionSummary,
 } from '../../../lib/api/contractTemplates';
-import type { QuoteBlockInput, CoverPage } from '@breeze/shared';
+import type { QuoteBlockInput, CoverPage, QuoteTableColumn, QuoteCalloutContent } from '@breeze/shared';
 import { computeQuoteTotals, computeQuoteProfit, priceFromMarkup, toQuoteDepositConfig, type QuoteLineForMath, type QuoteProfit, type QuoteTotals, type QuoteDepositType, type QuoteDepositConfig } from '@breeze/shared';
 import { listCatalog, createCatalogItem, type CatalogItem } from '../../../lib/api/catalog';
 import { ecExpressStatus, ecExpressImport, type EcProduct, type EcStatus, pax8Status, pax8Import, type Pax8Product, type Pax8PriceOption } from '../../../lib/api/distributors';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import { showToast } from '../../shared/Toast';
 import RichTextEditor from '../../common/RichTextEditor';
+import InlineRichTextEditor from '../../common/InlineRichTextEditor';
 import PolishButton from '../../catalog/PolishButton';
 import { BlockCard, QuoteImagePreview } from './QuoteBlockCard';
 import { QuoteBulkBar } from './QuoteBulkBar';
@@ -57,14 +58,29 @@ import {
 // the file first (POST /:id/images), then adds the block with `{ imageId }`.
 // Heading/rich-text block content is editable in place via PATCH /:id/blocks/:blockId
 // (updateBlock); the block type itself is immutable.
-type AddableBlockType = 'heading' | 'rich_text' | 'image' | 'line_items' | 'contract';
+// Phase 3: `table` and `callout` add structured JSON blocks (Task 2's
+// QuoteTableContent / QuoteCalloutContent) — never HTML-parsed like rich_text,
+// so their forms are a grid/select UI rather than a single editor.
+type AddableBlockType = 'heading' | 'rich_text' | 'image' | 'line_items' | 'contract' | 'table' | 'callout';
 const ADD_BLOCK_OPTIONS: { value: AddableBlockType; labelKey: string }[] = [
   { value: 'heading', labelKey: 'quotes.editor.blockTypes.heading' },
   { value: 'rich_text', labelKey: 'quotes.editor.blockTypes.richText' },
   { value: 'image', labelKey: 'quotes.editor.blockTypes.image' },
   { value: 'line_items', labelKey: 'quotes.editor.blockTypes.pricingTable' },
   { value: 'contract', labelKey: 'quotes.editor.blockTypes.contract' },
+  { value: 'table', labelKey: 'quotes.editor.blockTypes.table' },
+  { value: 'callout', labelKey: 'quotes.editor.blockTypes.callout' },
 ];
+
+/** Fresh 2x2 grid the table form starts from (and resets to after a submit) —
+ *  small enough to see the whole shape at a glance, with both add row/column
+ *  actions immediately meaningful (removing either lands at the 1x1 floor). */
+function freshTableColumns(): QuoteTableColumn[] {
+  return [{ label: '' }, { label: '' }];
+}
+function freshTableRows(columnCount: number): { cells: string[] }[] {
+  return [{ cells: Array(columnCount).fill('') }, { cells: Array(columnCount).fill('') }];
+}
 
 
 // Grace window for undo-able line/section deletion: the item leaves the UI
@@ -343,6 +359,59 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   const [imageCaption, setImageCaption] = useState('');
   const [imageSource, setImageSource] = useState<'file' | 'url'>('file');
   const [imageUrl, setImageUrl] = useState('');
+
+  // ---- add table block ------------------------------------------------------
+  // `tableRows[i].cells.length` is kept equal to `tableColumns.length` at every
+  // mutation (add/remove column pads/trims every row in the same setState) —
+  // the same exact-shape invariant quoteTableContentSchema enforces server-side,
+  // so the POST body can never trip its row-length refinement.
+  const [tableColumns, setTableColumns] = useState<QuoteTableColumn[]>(freshTableColumns);
+  const [tableRows, setTableRows] = useState<{ cells: string[] }[]>(() => freshTableRows(2));
+  const [tableCaption, setTableCaption] = useState('');
+  const [tableZebra, setTableZebra] = useState(false);
+  const [tableHeaderStyle, setTableHeaderStyle] = useState<'accent' | 'plain'>('plain');
+
+  const resetTableForm = useCallback(() => {
+    setTableColumns(freshTableColumns());
+    setTableRows(freshTableRows(2));
+    setTableCaption('');
+    setTableZebra(false);
+    setTableHeaderStyle('plain');
+  }, []);
+
+  const addTableColumn = useCallback(() => {
+    setTableColumns((cols) => (cols.length >= 8 ? cols : [...cols, { label: '' }]));
+    setTableRows((rows) => (rows.length > 0 && rows[0].cells.length >= 8 ? rows : rows.map((r) => ({ cells: [...r.cells, ''] }))));
+  }, []);
+  const removeTableColumn = useCallback((idx: number) => {
+    setTableColumns((cols) => (cols.length <= 1 ? cols : cols.filter((_, i) => i !== idx)));
+    setTableRows((rows) => (rows.length > 0 && rows[0].cells.length <= 1 ? rows : rows.map((r) => ({ cells: r.cells.filter((_, i) => i !== idx) }))));
+  }, []);
+  const addTableRow = useCallback(() => {
+    setTableRows((rows) => (rows.length >= 100 ? rows : [...rows, { cells: Array(tableColumns.length).fill('') }]));
+  }, [tableColumns.length]);
+  const removeTableRow = useCallback((idx: number) => {
+    setTableRows((rows) => (rows.length <= 1 ? rows : rows.filter((_, i) => i !== idx)));
+  }, []);
+  const setTableColumnLabel = useCallback((idx: number, label: string) => {
+    setTableColumns((cols) => cols.map((c, i) => (i === idx ? { ...c, label } : c)));
+  }, []);
+  const setTableColumnAlign = useCallback((idx: number, align: QuoteTableColumn['align']) => {
+    setTableColumns((cols) => cols.map((c, i) => (i === idx ? { ...c, align } : c)));
+  }, []);
+  const setTableCell = useCallback((rowIdx: number, colIdx: number, html: string) => {
+    setTableRows((rows) => rows.map((r, i) => (i === rowIdx ? { cells: r.cells.map((c, j) => (j === colIdx ? html : c)) } : r)));
+  }, []);
+
+  // ---- add callout block -----------------------------------------------------
+  const [calloutVariant, setCalloutVariant] = useState<QuoteCalloutContent['variant']>('info');
+  const [calloutTitle, setCalloutTitle] = useState('');
+  const [calloutHtml, setCalloutHtml] = useState('');
+  const resetCalloutForm = useCallback(() => {
+    setCalloutVariant('info');
+    setCalloutTitle('');
+    setCalloutHtml('');
+  }, []);
 
   // ---- add contract block --------------------------------------------------
   // The template library for the picker, loaded lazily the first time the
@@ -873,6 +942,14 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
       return label || t('quotes.editor.blockTypes.contract');
     }
     if (b.blockType === 'image') return t('quotes.editor.blockTypes.image');
+    if (b.blockType === 'table') {
+      const caption = ((b.content?.caption as string | undefined) ?? '').trim();
+      return caption || t('quotes.editor.blockTypes.table');
+    }
+    if (b.blockType === 'callout') {
+      const title = ((b.content?.title as string | undefined) ?? '').trim();
+      return title || t('quotes.editor.blockTypes.callout');
+    }
     return t('quotes.editor.blockTypes.richText');
   }, [pricingBlockLabel, t]);
   // Scroll-position highlight: the outline marks the topmost block currently in
@@ -1224,6 +1301,57 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
       return;
     }
 
+    if (addType === 'table') {
+      await runScoped('add-block', async () => {
+        const created = await runAction<{ id?: string }>({
+          request: () => addBlock(quote.id, {
+            blockType: 'table' as const,
+            content: {
+              columns: tableColumns,
+              rows: tableRows.map((r) => ({ cells: r.cells })),
+              ...(tableCaption.trim() ? { caption: tableCaption.trim() } : {}),
+              zebra: tableZebra,
+              headerStyle: tableHeaderStyle,
+            },
+          } as QuoteBlockInput),
+          errorFallback: t('quotes.editor.errors.addSection'),
+          // No success toast — the new table visibly appears in the block list.
+          onUnauthorized: UNAUTHORIZED,
+          parseSuccess: (d) => (d as { data: { id?: string } }).data,
+        });
+        await positionNewBlock(created);
+        resetTableForm();
+        setInsertAt(null);
+        refresh();
+      }, t('quotes.editor.errors.addSection'));
+      return;
+    }
+
+    if (addType === 'callout') {
+      if (!calloutHtml.trim()) return;
+      await runScoped('add-block', async () => {
+        const created = await runAction<{ id?: string }>({
+          request: () => addBlock(quote.id, {
+            blockType: 'callout' as const,
+            content: {
+              variant: calloutVariant,
+              ...(calloutTitle.trim() ? { title: calloutTitle.trim() } : {}),
+              html: calloutHtml,
+            },
+          } as QuoteBlockInput),
+          errorFallback: t('quotes.editor.errors.addSection'),
+          // No success toast — the new callout visibly appears in the block list.
+          onUnauthorized: UNAUTHORIZED,
+          parseSuccess: (d) => (d as { data: { id?: string } }).data,
+        });
+        await positionNewBlock(created);
+        resetCalloutForm();
+        setInsertAt(null);
+        refresh();
+      }, t('quotes.editor.errors.addSection'));
+      return;
+    }
+
     let body;
     if (addType === 'heading') {
       if (!headingText.trim()) return;
@@ -1250,7 +1378,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
       setInsertAt(null);
       refresh();
     }, t('quotes.editor.errors.addSection'));
-  }, [addType, headingText, richText, tableLabel, imageFile, imageCaption, imageSource, imageUrl, contractTemplateId, contractVersion, contractVarValues, contractLabel, resetContractForm, positionNewBlock, quote.id, refresh, runScoped, t]);
+  }, [addType, headingText, richText, tableLabel, imageFile, imageCaption, imageSource, imageUrl, contractTemplateId, contractVersion, contractVarValues, contractLabel, resetContractForm, tableColumns, tableRows, tableCaption, tableZebra, tableHeaderStyle, resetTableForm, calloutVariant, calloutTitle, calloutHtml, resetCalloutForm, positionNewBlock, quote.id, refresh, runScoped, t]);
 
 
   // Removing a line_items block cascades to every line under it (server-side), so
@@ -2151,6 +2279,173 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
               </div>
             )}
 
+            {addType === 'table' && (
+              <div className="mb-3 space-y-3" data-testid="quote-block-table">
+                <div className="overflow-x-auto">
+                  <table className="w-full min-w-[32rem] border-separate border-spacing-1 text-xs">
+                    <thead>
+                      <tr>
+                        {tableColumns.map((col, colIdx) => (
+                          <th key={colIdx} className="text-left font-normal">
+                            <div className="flex items-center gap-1">
+                              <input
+                                type="text"
+                                value={col.label}
+                                onChange={(e) => setTableColumnLabel(colIdx, e.target.value)}
+                                placeholder={t('quotes.editor.table.columnLabelPlaceholder')}
+                                data-testid={`quote-block-table-column-label-${colIdx}`}
+                                className="h-8 w-full rounded-md border bg-background px-2 text-xs focus:outline-hidden focus:ring-2 focus:ring-ring"
+                              />
+                              <select
+                                value={col.align ?? 'left'}
+                                onChange={(e) => setTableColumnAlign(colIdx, e.target.value as QuoteTableColumn['align'])}
+                                aria-label={t('quotes.editor.table.columnAlignAria')}
+                                data-testid={`quote-block-table-column-align-${colIdx}`}
+                                className="h-8 rounded-md border bg-background px-1 text-xs focus:outline-hidden focus:ring-2 focus:ring-ring"
+                              >
+                                <option value="left">{t('quotes.editor.table.alignLeft')}</option>
+                                <option value="center">{t('quotes.editor.table.alignCenter')}</option>
+                                <option value="right">{t('quotes.editor.table.alignRight')}</option>
+                              </select>
+                              <button
+                                type="button"
+                                onClick={() => removeTableColumn(colIdx)}
+                                disabled={tableColumns.length <= 1}
+                                aria-label={t('quotes.editor.table.removeColumn')}
+                                title={t('quotes.editor.table.removeColumn')}
+                                data-testid={`quote-block-table-remove-column-${colIdx}`}
+                                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted disabled:opacity-40"
+                              >
+                                &times;
+                              </button>
+                            </div>
+                          </th>
+                        ))}
+                        <th className="w-8">
+                          <button
+                            type="button"
+                            onClick={addTableColumn}
+                            disabled={tableColumns.length >= 8}
+                            aria-label={t('quotes.editor.table.addColumn')}
+                            title={t('quotes.editor.table.addColumn')}
+                            data-testid="quote-block-table-add-column"
+                            className="inline-flex h-8 w-8 items-center justify-center rounded-md border text-muted-foreground hover:bg-muted disabled:opacity-40"
+                          >
+                            +
+                          </button>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {tableRows.map((row, rowIdx) => (
+                        <tr key={rowIdx}>
+                          {row.cells.map((cell, colIdx) => (
+                            <td key={colIdx} className="align-top">
+                              <InlineRichTextEditor
+                                value={cell}
+                                onChange={(html) => setTableCell(rowIdx, colIdx, html)}
+                                ariaLabel={t('quotes.editor.table.cellAria', { row: rowIdx + 1, column: colIdx + 1 })}
+                                testId={`quote-block-table-cell-${rowIdx}-${colIdx}`}
+                              />
+                            </td>
+                          ))}
+                          <td className="align-top">
+                            <button
+                              type="button"
+                              onClick={() => removeTableRow(rowIdx)}
+                              disabled={tableRows.length <= 1}
+                              aria-label={t('quotes.editor.table.removeRow')}
+                              title={t('quotes.editor.table.removeRow')}
+                              data-testid={`quote-block-table-remove-row-${rowIdx}`}
+                              className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted disabled:opacity-40"
+                            >
+                              &times;
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                <button
+                  type="button"
+                  onClick={addTableRow}
+                  disabled={tableRows.length >= 100}
+                  data-testid="quote-block-table-add-row"
+                  className="inline-flex h-8 items-center justify-center rounded-md border px-3 text-xs font-medium text-muted-foreground hover:bg-muted disabled:opacity-40"
+                >
+                  {t('quotes.editor.table.addRow')}
+                </button>
+                <input
+                  type="text"
+                  value={tableCaption}
+                  onChange={(e) => setTableCaption(e.target.value)}
+                  placeholder={t('quotes.editor.table.captionPlaceholder')}
+                  data-testid="quote-block-table-caption"
+                  className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                />
+                <div className="flex flex-wrap items-center gap-4">
+                  <label className="inline-flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
+                    <input
+                      type="checkbox"
+                      checked={tableZebra}
+                      onChange={(e) => setTableZebra(e.target.checked)}
+                      data-testid="quote-block-table-zebra"
+                    />
+                    {t('quotes.editor.table.zebra')}
+                  </label>
+                  <label className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                    {t('quotes.editor.table.headerStyle')}
+                    <select
+                      value={tableHeaderStyle}
+                      onChange={(e) => setTableHeaderStyle(e.target.value as 'accent' | 'plain')}
+                      data-testid="quote-block-table-header-style"
+                      className="h-8 rounded-md border bg-background px-2 text-xs focus:outline-hidden focus:ring-2 focus:ring-ring"
+                    >
+                      <option value="plain">{t('quotes.editor.table.headerStylePlain')}</option>
+                      <option value="accent">{t('quotes.editor.table.headerStyleAccent')}</option>
+                    </select>
+                  </label>
+                </div>
+              </div>
+            )}
+
+            {addType === 'callout' && (
+              <div className="mb-3 space-y-3" data-testid="quote-block-callout">
+                <div>
+                  <label htmlFor="quote-block-callout-variant" className="mb-1 block text-xs text-muted-foreground">
+                    {t('quotes.editor.callout.variantLabel')}
+                  </label>
+                  <select
+                    id="quote-block-callout-variant"
+                    value={calloutVariant}
+                    onChange={(e) => setCalloutVariant(e.target.value as QuoteCalloutContent['variant'])}
+                    data-testid="quote-block-callout-variant"
+                    className="h-9 w-full rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                  >
+                    <option value="info">{t('quotes.editor.callout.variantInfo')}</option>
+                    <option value="accent">{t('quotes.editor.callout.variantAccent')}</option>
+                    <option value="warn">{t('quotes.editor.callout.variantWarn')}</option>
+                  </select>
+                </div>
+                <input
+                  type="text"
+                  value={calloutTitle}
+                  maxLength={200}
+                  onChange={(e) => setCalloutTitle(e.target.value)}
+                  placeholder={t('quotes.editor.callout.titlePlaceholder')}
+                  data-testid="quote-block-callout-title"
+                  className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                />
+                <RichTextEditor
+                  value={calloutHtml}
+                  onChange={setCalloutHtml}
+                  ariaLabel={t('quotes.editor.callout.bodyAria')}
+                  testId="quote-block-callout-body"
+                />
+              </div>
+            )}
+
             <div className="flex justify-end">
               <button
                 type="button"
@@ -2161,7 +2456,8 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
                   (addType === 'rich_text' && !richText.trim()) ||
                   (addType === 'image' && imageSource === 'file' && !imageFile) ||
                   (addType === 'image' && imageSource === 'url' && !imageUrl.trim()) ||
-                  (addType === 'contract' && !contractVersion)
+                  (addType === 'contract' && !contractVersion) ||
+                  (addType === 'callout' && !calloutHtml.trim())
                 }
                 data-testid="quote-add-block-submit"
                 className="inline-flex h-9 items-center justify-center rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:opacity-50"

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -6,8 +6,8 @@ import type { SellerSnapshot } from '../invoiceTypes';
 export type { SellerSnapshot } from '../invoiceTypes';
 export { sellerLines } from '../invoiceTypes';
 import { STATUS_PILL, type StatusPillRole } from '../invoiceTypes';
-import type { QuoteDepositType, QuoteCategorySubtotal, CoverPage, ContractVariable, Pax8SubmitState } from '@breeze/shared';
-export type { QuoteDepositType, QuoteCategorySubtotal, CoverPage, ContractVariable, Pax8SubmitState, QuoteTableContent, QuoteCalloutContent } from '@breeze/shared';
+import type { QuoteDepositType, QuoteCategorySubtotal, CoverPage, ContractVariable, Pax8SubmitState, QuotePresentation } from '@breeze/shared';
+export type { QuoteDepositType, QuoteCategorySubtotal, CoverPage, ContractVariable, Pax8SubmitState, QuoteTableContent, QuoteCalloutContent, QuotePresentation } from '@breeze/shared';
 // Type-only (erased at compile time), so this pulls no runtime dep on the API
 // client into the types module.
 import type { QuoteSendEmailReason } from '../../../lib/api/quotes';
@@ -287,6 +287,11 @@ export interface QuoteDetail {
   blocks: QuoteBlock[];
   lines: QuoteLine[];
   branding?: QuoteBranding;
+  /** Resolved document theme/pageSize (Task 12) — same values `branding`
+   *  carries server-side, typed explicitly so QuoteDocument doesn't need to
+   *  widen QuoteBranding to pick them up. Optional: fixtures/older payloads
+   *  omit it, which must read as 'classic' (QuoteDocument's fallback). */
+  presentation?: QuotePresentation;
   billTo?: QuoteBillTo;
   /** Email addresses this quote was sent to, oldest first — the authorized
    *  portal signers recorded at send time. Empty on drafts and on legacy sends

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -7,7 +7,7 @@ export type { SellerSnapshot } from '../invoiceTypes';
 export { sellerLines } from '../invoiceTypes';
 import { STATUS_PILL, type StatusPillRole } from '../invoiceTypes';
 import type { QuoteDepositType, QuoteCategorySubtotal, CoverPage, ContractVariable, Pax8SubmitState } from '@breeze/shared';
-export type { QuoteDepositType, QuoteCategorySubtotal, CoverPage, ContractVariable, Pax8SubmitState } from '@breeze/shared';
+export type { QuoteDepositType, QuoteCategorySubtotal, CoverPage, ContractVariable, Pax8SubmitState, QuoteTableContent, QuoteCalloutContent } from '@breeze/shared';
 // Type-only (erased at compile time), so this pulls no runtime dep on the API
 // client into the types module.
 import type { QuoteSendEmailReason } from '../../../lib/api/quotes';

--- a/apps/web/src/components/common/InlineRichTextEditor.test.tsx
+++ b/apps/web/src/components/common/InlineRichTextEditor.test.tsx
@@ -73,7 +73,7 @@ describe('InlineRichTextEditor', () => {
     // getHTML() serializes the whole (single-paragraph) document, so a <p>
     // wrapper is expected — the assertion is about what's INSIDE it.
     expect(emitted).toBe('<p><strong>Hello</strong></p>');
-    expect(emitted).not.toMatch(/<div>|<script|<blockquote/);
+    expect(emitted).not.toMatch(/<div>|<script|<blockquote/i);
   });
 
   it('does not create a second paragraph when Enter is pressed', () => {

--- a/apps/web/src/components/common/InlineRichTextEditor.test.tsx
+++ b/apps/web/src/components/common/InlineRichTextEditor.test.tsx
@@ -1,0 +1,161 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InlineRichTextEditor from './InlineRichTextEditor';
+
+// Same jsdom polyfills RichTextEditor.test.tsx needs — TipTap/ProseMirror wire
+// up clipboard + drag handlers and compute caret coordinates that jsdom
+// implements neither constructor nor geometry for (test-file scoped).
+class FakeDataTransfer {
+  items = [] as unknown[];
+  files = [] as unknown[];
+  getData() {
+    return '';
+  }
+  setData() {}
+}
+if (typeof (globalThis as { ClipboardEvent?: unknown }).ClipboardEvent === 'undefined') {
+  class ClipboardEventPolyfill extends Event {
+    clipboardData = new FakeDataTransfer();
+    constructor(type: string, init?: EventInit) {
+      super(type, init);
+    }
+  }
+  (globalThis as { ClipboardEvent?: unknown }).ClipboardEvent = ClipboardEventPolyfill;
+}
+if (typeof (globalThis as { DragEvent?: unknown }).DragEvent === 'undefined') {
+  class DragEventPolyfill extends Event {
+    dataTransfer = new FakeDataTransfer();
+    constructor(type: string, init?: EventInit) {
+      super(type, init);
+    }
+  }
+  (globalThis as { DragEvent?: unknown }).DragEvent = DragEventPolyfill;
+}
+const emptyRect = () =>
+  ({ x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0, toJSON: () => ({}) }) as DOMRect;
+const emptyRectList = () =>
+  ({ length: 0, item: () => null, [Symbol.iterator]: function* () {} }) as unknown as DOMRectList;
+for (const proto of [Range.prototype, Text.prototype, Element.prototype]) {
+  (proto as unknown as { getClientRects: () => DOMRectList }).getClientRects = emptyRectList;
+  (proto as unknown as { getBoundingClientRect: () => DOMRect }).getBoundingClientRect = emptyRect;
+}
+
+const TESTID = 'irte-cell-1';
+
+describe('InlineRichTextEditor', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exposes the editable region with the provided aria-label and testId', () => {
+    render(<InlineRichTextEditor value="<p>Hello</p>" onChange={() => {}} ariaLabel="Cell text" testId={TESTID} />);
+    const editable = screen.getByTestId(TESTID);
+    expect(editable).toHaveAttribute('contenteditable', 'true');
+    expect(editable).toHaveAttribute('aria-label', 'Cell text');
+    expect(editable.textContent).toContain('Hello');
+  });
+
+  it('renders bold/italic/underline/link toolbar buttons namespaced off testId', () => {
+    render(<InlineRichTextEditor value="<p>Hello</p>" onChange={() => {}} ariaLabel="Cell text" testId={TESTID} />);
+    expect(screen.getByTestId(`${TESTID}-bold`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${TESTID}-italic`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${TESTID}-underline`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${TESTID}-link`)).toBeInTheDocument();
+  });
+
+  it('emits inline-subset HTML through onChange when bold is toggled', async () => {
+    const onChange = vi.fn();
+    render(<InlineRichTextEditor value="<p>Hello</p>" onChange={onChange} ariaLabel="Cell text" testId={TESTID} />);
+    fireEvent.click(screen.getByTestId(`${TESTID}-bold`));
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    const emitted = onChange.mock.calls.at(-1)?.[0] as string;
+    // getHTML() serializes the whole (single-paragraph) document, so a <p>
+    // wrapper is expected — the assertion is about what's INSIDE it.
+    expect(emitted).toBe('<p><strong>Hello</strong></p>');
+    expect(emitted).not.toMatch(/<div>|<script|<blockquote/);
+  });
+
+  it('does not create a second paragraph when Enter is pressed', () => {
+    const onChange = vi.fn();
+    render(<InlineRichTextEditor value="<p>Hello</p>" onChange={onChange} ariaLabel="Cell text" testId={TESTID} />);
+    const editable = screen.getByTestId(TESTID);
+    fireEvent.keyDown(editable, { key: 'Enter', code: 'Enter' });
+    // Swallowed before any transaction is dispatched — no update fires and the
+    // document still contains exactly one paragraph.
+    expect(onChange).not.toHaveBeenCalled();
+    expect(editable.querySelectorAll('p').length).toBe(1);
+  });
+
+  it('normalizes marks to the subset (strong/em/u), never <b>/<i>', () => {
+    render(
+      <InlineRichTextEditor
+        value="<p><b>Bold</b> <i>Ital</i> <u>Und</u></p>"
+        onChange={() => {}}
+        ariaLabel="Cell text"
+        testId={TESTID}
+      />,
+    );
+    const editable = screen.getByTestId(TESTID);
+    expect(editable.querySelector('strong')).not.toBeNull();
+    expect(editable.querySelector('em')).not.toBeNull();
+    expect(editable.querySelector('u')).not.toBeNull();
+    expect(editable.querySelector('b')).toBeNull();
+    expect(editable.querySelector('i')).toBeNull();
+  });
+
+  it('strips block-level content outside the allowed subset (headings/lists/blockquote)', () => {
+    render(
+      <InlineRichTextEditor
+        value="<h1>Title</h1><ul><li>one</li></ul><blockquote><p>Quote</p></blockquote>"
+        onChange={() => {}}
+        ariaLabel="Cell text"
+        testId={TESTID}
+      />,
+    );
+    const editable = screen.getByTestId(TESTID);
+    expect(editable.querySelector('h1')).toBeNull();
+    expect(editable.querySelector('ul')).toBeNull();
+    expect(editable.querySelector('li')).toBeNull();
+    expect(editable.querySelector('blockquote')).toBeNull();
+    // The schema's `doc` node holds exactly one `paragraph` child, always —
+    // disallowed node types are unwrapped to their inline content, which
+    // flows into that single paragraph.
+    expect(editable.querySelectorAll('p').length).toBe(1);
+    expect(editable.textContent).toContain('Title');
+  });
+
+  it('flattens pasted multi-block HTML to the inline subset via transformPastedHTML', () => {
+    // Exercise the sanitize step directly through the same path the editor
+    // extension configuration wires up (editorProps.transformPastedHTML) by
+    // reaching for the exported pure function is not possible (kept private,
+    // by design, to the module) — so this asserts the *effective* outcome via
+    // the schema-level flattening test above, plus a targeted regression here
+    // that <script>/<style> never survive when fed as the initial value.
+    render(
+      <InlineRichTextEditor
+        value="<p>A<script>alert(1)</script><style>.x{}</style>B</p>"
+        onChange={() => {}}
+        ariaLabel="Cell text"
+        testId={TESTID}
+      />,
+    );
+    const editable = screen.getByTestId(TESTID);
+    expect(editable.querySelector('script')).toBeNull();
+    expect(editable.querySelector('style')).toBeNull();
+  });
+
+  it('rejects a non-http(s) link scheme (mailto:) with a validation alert and sets no link', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('mailto:evil@example.com');
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const onChange = vi.fn();
+    render(<InlineRichTextEditor value="<p>Hello</p>" onChange={onChange} ariaLabel="Cell text" testId={TESTID} />);
+
+    fireEvent.click(screen.getByTestId(`${TESTID}-link`));
+
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+    expect(promptSpy).toHaveBeenCalled();
+    const emitted = onChange.mock.calls.map((c) => c[0] as string).join('');
+    expect(emitted).not.toContain('mailto:');
+  });
+});

--- a/apps/web/src/components/common/InlineRichTextEditor.tsx
+++ b/apps/web/src/components/common/InlineRichTextEditor.tsx
@@ -31,6 +31,12 @@ export interface InlineRichTextEditorProps {
    *  namespaced off this so many instances (e.g. one per table cell) can
    *  render side by side without colliding testids. */
   testId: string;
+  /** Optional cap on the emitted HTML string length, mirroring the server
+   *  validator it feeds (e.g. quoteTableContentSchema's cell `z.string().max(2000)`).
+   *  An edit that would push `getHTML()` over the cap is reverted rather than
+   *  propagated — client-side defense so the field never drifts into a shape
+   *  the server would 422 on. */
+  maxLength?: number;
 }
 
 // Same allowlist logic as RichTextEditor.tsx — kept in sync deliberately
@@ -203,7 +209,7 @@ function Toolbar({ editor, testId }: { editor: Editor; testId: string }) {
   );
 }
 
-export default function InlineRichTextEditor({ value, onChange, ariaLabel, testId }: InlineRichTextEditorProps) {
+export default function InlineRichTextEditor({ value, onChange, ariaLabel, testId, maxLength }: InlineRichTextEditorProps) {
   const editor = useEditor({
     extensions: buildExtensions(),
     content: value,
@@ -229,7 +235,14 @@ export default function InlineRichTextEditor({ value, onChange, ariaLabel, testI
       transformPastedHTML: (html) => sanitizeToInlineHtml(html),
     },
     onUpdate: ({ editor: e }) => {
-      onChange(e.getHTML());
+      const html = e.getHTML();
+      if (maxLength != null && html.length > maxLength) {
+        // Revert rather than truncate: truncating mid-tag could produce
+        // malformed HTML, and undo cleanly restores the last valid state.
+        e.commands.undo();
+        return;
+      }
+      onChange(html);
     },
   });
 

--- a/apps/web/src/components/common/InlineRichTextEditor.tsx
+++ b/apps/web/src/components/common/InlineRichTextEditor.tsx
@@ -1,0 +1,249 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { EditorContent, useEditor, type Editor } from '@tiptap/react';
+import { Node as TiptapNode } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import Underline from '@tiptap/extension-underline';
+import Link from '@tiptap/extension-link';
+
+// A hard schema-level cap: StarterKit's own Document node accepts `block+`
+// (any number of paragraphs), which would let a paste insert extra
+// paragraphs even though typed Enter is swallowed (see handleKeyDown below —
+// that only guards keyboard input, not a paste's document-slice insertion).
+// Overriding just the top node's content expression to a single `paragraph`
+// makes "one paragraph, always" a property of the schema itself: ProseMirror
+// cannot construct a second block-level child no matter which path tries to
+// insert one.
+const SingleParagraphDocument = TiptapNode.create({
+  name: 'doc',
+  topNode: true,
+  content: 'paragraph',
+});
+
+export interface InlineRichTextEditorProps {
+  /** Current HTML value, constrained to the inline subset (strong/em/u/a/br). */
+  value: string;
+  /** Fired with `editor.getHTML()` whenever the document changes. */
+  onChange: (html: string) => void;
+  /** Accessible label for the editable region. */
+  ariaLabel: string;
+  /** `data-testid` applied to the editable region; toolbar buttons are
+   *  namespaced off this so many instances (e.g. one per table cell) can
+   *  render side by side without colliding testids. */
+  testId: string;
+}
+
+// Same allowlist logic as RichTextEditor.tsx — kept in sync deliberately
+// rather than shared, since the two editors' import graphs are meant to stay
+// independent (this one must never grow a dependency that pulls in
+// block-level extensions).
+function isHttpOrHttpsUri(uri: string): boolean {
+  const trimmed = uri.trim();
+  if (trimmed.startsWith('//')) return false;
+  const scheme = trimmed.match(/^([a-z][a-z0-9+.-]*):/i)?.[1]?.toLowerCase();
+  if (!scheme) return true;
+  return scheme === 'http' || scheme === 'https';
+}
+
+// Flattens arbitrary pasted HTML down to the inline subset the schema (and the
+// server's inline richTextSanitize profile) accept: strong, em, u, a, br. Runs
+// BEFORE ProseMirror's paste-HTML parser, so it's the thing standing between
+// "pasted a whole formatted document" and a doc that only ever contains one
+// paragraph — the schema alone doesn't stop a paste from inserting extra
+// paragraph/heading/list nodes, since Enter-swallowing only guards typing.
+// Block-level boundaries (p/div/li/headings) become a <br> so multi-line
+// pasted text doesn't collapse into one run-on word.
+function sanitizeToInlineHtml(html: string): string {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+
+  const BLOCK_TAGS = new Set(['P', 'DIV', 'LI', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'BLOCKQUOTE', 'TR']);
+
+  function walk(node: ChildNode, isLast: boolean): string {
+    if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? '';
+    if (node.nodeType !== Node.ELEMENT_NODE) return '';
+    const el = node as HTMLElement;
+    const tag = el.tagName;
+    const kids = Array.from(el.childNodes);
+    const inner = kids.map((k, i) => walk(k, i === kids.length - 1)).join('');
+
+    if (tag === 'BR') return '<br>';
+    if (tag === 'STRONG' || tag === 'B') return `<strong>${inner}</strong>`;
+    if (tag === 'EM' || tag === 'I') return `<em>${inner}</em>`;
+    if (tag === 'U') return `<u>${inner}</u>`;
+    if (tag === 'A') {
+      const href = el.getAttribute('href');
+      return href && isHttpOrHttpsUri(href) ? `<a href="${href}">${inner}</a>` : inner;
+    }
+    // Any other tag (script/style included) is unwrapped to its inline
+    // content — nothing outside the allowlist above is ever re-emitted.
+    if (tag === 'SCRIPT' || tag === 'STYLE') return '';
+    return BLOCK_TAGS.has(tag) && !isLast ? `${inner}<br>` : inner;
+  }
+
+  const top = Array.from(container.childNodes);
+  return top.map((n, i) => walk(n, i === top.length - 1)).join('');
+}
+
+// The document/paragraph/text/bold/italic node & mark set IS StarterKit's
+// minimal core — everything else it would otherwise register (headings,
+// lists, blockquote, code, horizontal rule, strike) is switched off so the
+// schema itself can never accept a second block or a disallowed mark.
+// Underline + Link are added standalone, same idiom as RichTextEditor.tsx.
+function buildExtensions() {
+  return [
+    SingleParagraphDocument,
+    StarterKit.configure({
+      document: false,
+      heading: false,
+      bulletList: false,
+      orderedList: false,
+      listItem: false,
+      listKeymap: false,
+      code: false,
+      codeBlock: false,
+      blockquote: false,
+      horizontalRule: false,
+      strike: false,
+      link: false,
+      underline: false,
+    }),
+    Underline,
+    Link.configure({
+      openOnClick: false,
+      protocols: ['http', 'https'],
+      autolink: false,
+      HTMLAttributes: { rel: 'noopener noreferrer' },
+      isAllowedUri: (uri) => isHttpOrHttpsUri(uri),
+    }),
+  ];
+}
+
+interface ToolbarButtonProps {
+  testId: string;
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+}
+
+function ToolbarButton({ testId, label, isActive, onClick }: ToolbarButtonProps) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      aria-label={label}
+      aria-pressed={isActive}
+      title={label}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className={`inline-flex h-6 min-w-6 items-center justify-center rounded px-1.5 text-xs font-medium transition-colors ${
+        isActive ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function Toolbar({ editor, testId }: { editor: Editor; testId: string }) {
+  const { t } = useTranslation('common');
+
+  // Marks apply to the whole cell in one click rather than requiring the user
+  // to drag-select first — a deliberate simplification for a single-line cell
+  // editor (see InlineRichTextEditor.test.tsx). selectAll is a ProseMirror
+  // command over the document model, not the DOM Selection API, so it also
+  // keeps this reliably testable.
+  const applyMark = (toggle: (chain: ReturnType<Editor['chain']>) => ReturnType<Editor['chain']>) => {
+    toggle(editor.chain().focus().selectAll()).run();
+  };
+
+  const setLink = () => {
+    const previous = editor.getAttributes('link').href as string | undefined;
+    const input = window.prompt(t('richTextEditor.linkPrompt'), previous ?? 'https://');
+    if (input === null) return;
+    const url = input.trim();
+    if (url === '') {
+      editor.chain().focus().selectAll().unsetLink().run();
+      return;
+    }
+    if (!isHttpOrHttpsUri(url)) {
+      window.alert(t('richTextEditor.linkInvalid'));
+      return;
+    }
+    editor.chain().focus().selectAll().setLink({ href: url }).run();
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-0.5 border-b bg-muted/40 px-1 py-0.5" role="toolbar" aria-label={t('richTextEditor.toolbarAria')}>
+      <ToolbarButton
+        testId={`${testId}-bold`}
+        label={t('richTextEditor.bold')}
+        isActive={editor.isActive('bold')}
+        onClick={() => applyMark((c) => c.toggleBold())}
+      />
+      <ToolbarButton
+        testId={`${testId}-italic`}
+        label={t('richTextEditor.italic')}
+        isActive={editor.isActive('italic')}
+        onClick={() => applyMark((c) => c.toggleItalic())}
+      />
+      <ToolbarButton
+        testId={`${testId}-underline`}
+        label={t('richTextEditor.underline')}
+        isActive={editor.isActive('underline')}
+        onClick={() => applyMark((c) => c.toggleUnderline())}
+      />
+      <ToolbarButton
+        testId={`${testId}-link`}
+        label={t('richTextEditor.link')}
+        isActive={editor.isActive('link')}
+        onClick={setLink}
+      />
+    </div>
+  );
+}
+
+export default function InlineRichTextEditor({ value, onChange, ariaLabel, testId }: InlineRichTextEditorProps) {
+  const editor = useEditor({
+    extensions: buildExtensions(),
+    content: value,
+    immediatelyRender: false,
+    editorProps: {
+      attributes: {
+        'aria-label': ariaLabel,
+        'data-testid': testId,
+        role: 'textbox',
+        'aria-multiline': 'false',
+        class: 'min-h-8 px-2 py-1 text-sm focus:outline-hidden',
+      },
+      // Enter never creates a second paragraph — this is a single-line cell
+      // editor. Returning true marks the keydown handled so ProseMirror's own
+      // Enter keymap (splitBlock) never runs.
+      handleKeyDown: (_view, event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          return true;
+        }
+        return false;
+      },
+      transformPastedHTML: (html) => sanitizeToInlineHtml(html),
+    },
+    onUpdate: ({ editor: e }) => {
+      onChange(e.getHTML());
+    },
+  });
+
+  useEffect(() => {
+    if (!editor) return;
+    if (value !== editor.getHTML()) {
+      editor.commands.setContent(value, { emitUpdate: false });
+    }
+  }, [value, editor]);
+
+  return (
+    <div className="rounded border bg-background focus-within:ring-2 focus-within:ring-ring">
+      {editor && <Toolbar editor={editor} testId={testId} />}
+      <EditorContent editor={editor} />
+    </div>
+  );
+}

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -1082,6 +1082,7 @@
         "subtotal": "Zwischensumme",
         "tax": "Steuer"
       },
+      "unsupportedBlock": "Dieser Blocktyp wird in dieser Ansicht noch nicht unterstützt.",
       "validUntil": "Gültig bis"
     },
     "page": {

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -517,7 +517,9 @@
         "image": "Bild",
         "pricingTable": "Preistabelle",
         "richText": "Rich-Text",
-        "contract": "Vertrag"
+        "contract": "Vertrag",
+        "table": "Tabelle",
+        "callout": "Hinweisbox"
       },
       "bulk": {
         "applied_one": "{{count}} Position aktualisiert.",
@@ -728,7 +730,22 @@
         "taxTitle": "Steuer pro Position. Maßgeblich ist die Überschrift „Steuersumme“, die um einen Rundungscent abweichen kann.",
         "taxable": "Steuerpflichtig",
         "total": "Insgesamt",
-        "unitPrice": "Stückpreis"
+        "unitPrice": "Stückpreis",
+        "columnLabelPlaceholder": "Spaltenbeschriftung",
+        "columnAlignAria": "Spaltenausrichtung",
+        "alignLeft": "Links",
+        "alignCenter": "Zentriert",
+        "alignRight": "Rechts",
+        "removeColumn": "Spalte entfernen",
+        "addColumn": "Spalte hinzufügen",
+        "removeRow": "Zeile entfernen",
+        "addRow": "Zeile hinzufügen",
+        "cellAria": "Zeile {{row}}, Spalte {{column}}",
+        "captionPlaceholder": "Beschriftung (optional)",
+        "zebra": "Zebrastreifen",
+        "headerStyle": "Kopfzeilenstil",
+        "headerStylePlain": "Einfach",
+        "headerStyleAccent": "Akzent"
       },
       "terms": {
         "placeholder": "Zahlungsbedingungen, Garantieklauseln usw.",
@@ -798,6 +815,14 @@
       },
       "unsavedField": {
         "lines": "Positionen"
+      },
+      "callout": {
+        "variantLabel": "Stil",
+        "variantInfo": "Hinweis",
+        "variantAccent": "Akzent",
+        "variantWarn": "Warnung",
+        "titlePlaceholder": "Titel (optional)",
+        "bodyAria": "Hinweistext"
       }
     },
     "actions": {

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -510,7 +510,9 @@
       "autosaveHint": "Änderungen werden automatisch gespeichert. Ein bernsteinfarbener Rahmen markiert eine ungespeicherte Änderung.",
       "block": {
         "imageSectionPdf": "Bildausschnitt (gerendert im PDF).",
-        "richTextContentAria": "Rich-Text-Inhalt"
+        "richTextContentAria": "Rich-Text-Inhalt",
+        "tableEmpty": "Leere Tabelle.",
+        "calloutEmpty": "Leere Hinweisbox."
       },
       "blockTypes": {
         "heading": "Überschrift",

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -517,7 +517,9 @@
         "image": "Image",
         "pricingTable": "Pricing table",
         "richText": "Rich text",
-        "contract": "Contract"
+        "contract": "Contract",
+        "table": "Table",
+        "callout": "Callout"
       },
       "bulk": {
         "applied_one": "Updated {{count}} line.",
@@ -728,7 +730,22 @@
         "taxTitle": "Per-line tax. The header Tax total is authoritative and may differ by a rounding cent.",
         "taxable": "Taxable",
         "total": "Total",
-        "unitPrice": "Unit price"
+        "unitPrice": "Unit price",
+        "columnLabelPlaceholder": "Column label",
+        "columnAlignAria": "Column alignment",
+        "alignLeft": "Left",
+        "alignCenter": "Center",
+        "alignRight": "Right",
+        "removeColumn": "Remove column",
+        "addColumn": "Add column",
+        "removeRow": "Remove row",
+        "addRow": "Add row",
+        "cellAria": "Row {{row}}, column {{column}}",
+        "captionPlaceholder": "Caption (optional)",
+        "zebra": "Zebra stripes",
+        "headerStyle": "Header style",
+        "headerStylePlain": "Plain",
+        "headerStyleAccent": "Accent"
       },
       "terms": {
         "placeholder": "Payment terms, warranty clauses, etc.",
@@ -798,6 +815,14 @@
       },
       "unsavedField": {
         "lines": "Line items"
+      },
+      "callout": {
+        "variantLabel": "Style",
+        "variantInfo": "Info",
+        "variantAccent": "Accent",
+        "variantWarn": "Warning",
+        "titlePlaceholder": "Title (optional)",
+        "bodyAria": "Callout text"
       }
     },
     "actions": {

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -1082,6 +1082,7 @@
         "subtotal": "Subtotal",
         "tax": "Tax"
       },
+      "unsupportedBlock": "This block type isn't supported by this viewer yet.",
       "validUntil": "Valid until"
     },
     "page": {

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -510,7 +510,9 @@
       "autosaveHint": "Changes save automatically. An amber outline marks an unsaved edit.",
       "block": {
         "imageSectionPdf": "Image section (rendered in the PDF).",
-        "richTextContentAria": "Rich text content"
+        "richTextContentAria": "Rich text content",
+        "tableEmpty": "Empty table.",
+        "calloutEmpty": "Empty callout."
       },
       "blockTypes": {
         "heading": "Heading",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -510,7 +510,9 @@
       "autosaveHint": "Los cambios se guardan automáticamente. Un contorno ámbar marca una edición sin guardar.",
       "block": {
         "imageSectionPdf": "Sección de imagen (representada en PDF).",
-        "richTextContentAria": "Contenido de texto enriquecido"
+        "richTextContentAria": "Contenido de texto enriquecido",
+        "tableEmpty": "Tabla vacía.",
+        "calloutEmpty": "Recuadro vacío."
       },
       "blockTypes": {
         "heading": "Título",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -517,7 +517,9 @@
         "image": "Imagen",
         "pricingTable": "tabla de precios",
         "richText": "Texto enriquecido",
-        "contract": "Contrato"
+        "contract": "Contrato",
+        "table": "Tabla",
+        "callout": "Recuadro"
       },
       "bulk": {
         "applied_one": "Se actualizó {{count}} línea.",
@@ -728,7 +730,22 @@
         "taxTitle": "Impuesto por línea. El encabezado Total de impuestos es determinante y puede diferir en un centavo redondeado.",
         "taxable": "Imponible",
         "total": "Total",
-        "unitPrice": "Precio unitario"
+        "unitPrice": "Precio unitario",
+        "columnLabelPlaceholder": "Etiqueta de columna",
+        "columnAlignAria": "Alineación de columna",
+        "alignLeft": "Izquierda",
+        "alignCenter": "Centro",
+        "alignRight": "Derecha",
+        "removeColumn": "Quitar columna",
+        "addColumn": "Agregar columna",
+        "removeRow": "Quitar fila",
+        "addRow": "Agregar fila",
+        "cellAria": "Fila {{row}}, columna {{column}}",
+        "captionPlaceholder": "Leyenda (opcional)",
+        "zebra": "Filas alternadas",
+        "headerStyle": "Estilo de encabezado",
+        "headerStylePlain": "Simple",
+        "headerStyleAccent": "Acento"
       },
       "terms": {
         "placeholder": "Condiciones de pago, cláusulas de garantía, etc.",
@@ -798,6 +815,14 @@
       },
       "unsavedField": {
         "lines": "Líneas"
+      },
+      "callout": {
+        "variantLabel": "Estilo",
+        "variantInfo": "Información",
+        "variantAccent": "Acento",
+        "variantWarn": "Advertencia",
+        "titlePlaceholder": "Título (opcional)",
+        "bodyAria": "Texto del recuadro"
       }
     },
     "actions": {

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -1082,6 +1082,7 @@
         "subtotal": "Total parcial",
         "tax": "Impuesto"
       },
+      "unsupportedBlock": "Este tipo de bloque aún no es compatible con este visor.",
       "validUntil": "Válido hasta"
     },
     "page": {

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -1082,6 +1082,7 @@
         "subtotal": "Sous-total",
         "tax": "Taxe"
       },
+      "unsupportedBlock": "Ce type de bloc n'est pas encore pris en charge par cette visionneuse.",
       "validUntil": "Valide jusqu'au"
     },
     "page": {

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -517,7 +517,9 @@
         "image": "Image",
         "pricingTable": "Tableau de prix",
         "richText": "Texte enrichi",
-        "contract": "Contrat"
+        "contract": "Contrat",
+        "table": "Tableau",
+        "callout": "Encadré"
       },
       "catalog": {
         "addSome": "Ajoutez-en dans Product Catalog",
@@ -699,7 +701,22 @@
         "unitPrice": "Prix unitaire",
         "collapsedSummary": "{{count}} lignes · {{amount}}",
         "collapsedSummary_one": "{{count}} ligne · {{amount}}",
-        "collapsedSummary_other": "{{count}} lignes · {{amount}}"
+        "collapsedSummary_other": "{{count}} lignes · {{amount}}",
+        "columnLabelPlaceholder": "Intitulé de colonne",
+        "columnAlignAria": "Alignement de la colonne",
+        "alignLeft": "Gauche",
+        "alignCenter": "Centre",
+        "alignRight": "Droite",
+        "removeColumn": "Supprimer la colonne",
+        "addColumn": "Ajouter une colonne",
+        "removeRow": "Supprimer la ligne",
+        "addRow": "Ajouter une ligne",
+        "cellAria": "Ligne {{row}}, colonne {{column}}",
+        "captionPlaceholder": "Légende (facultatif)",
+        "zebra": "Lignes zébrées",
+        "headerStyle": "Style d'en-tête",
+        "headerStylePlain": "Simple",
+        "headerStyleAccent": "Accentué"
       },
       "terms": {
         "placeholder": "Conditions de paiement, clauses de garantie, etc.",
@@ -798,6 +815,14 @@
       },
       "unsavedField": {
         "lines": "Lignes"
+      },
+      "callout": {
+        "variantLabel": "Style de bloc",
+        "variantInfo": "Information",
+        "variantAccent": "Accentué",
+        "variantWarn": "Avertissement",
+        "titlePlaceholder": "Titre (facultatif)",
+        "bodyAria": "Texte de l'encadré"
       }
     },
     "actions": {

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -510,7 +510,9 @@
       "autosaveHint": "Les modifications sont enregistrées automatiquement. Un contour ambre signale une modification non enregistrée.",
       "block": {
         "imageSectionPdf": "Section image (rendue dans le PDF).",
-        "richTextContentAria": "Contenu en texte enrichi"
+        "richTextContentAria": "Contenu en texte enrichi",
+        "tableEmpty": "Tableau vide.",
+        "calloutEmpty": "Encadré vide."
       },
       "blockTypes": {
         "heading": "Titre",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -517,7 +517,9 @@
         "image": "Image",
         "pricingTable": "Tableau de prix",
         "richText": "Texte enrichi",
-        "contract": "Contrat"
+        "contract": "Contrat",
+        "table": "Tableau",
+        "callout": "Encadré"
       },
       "bulk": {
         "applied_one": "{{count}} ligne mise à jour.",
@@ -728,7 +730,22 @@
         "taxTitle": "Taxe par ligne. L'en-tête Total taxe fait foi et peut différer d'un centime par arrondi.",
         "taxable": "Taxable",
         "total": "Total",
-        "unitPrice": "Prix unitaire"
+        "unitPrice": "Prix unitaire",
+        "columnLabelPlaceholder": "Intitulé de colonne",
+        "columnAlignAria": "Alignement de la colonne",
+        "alignLeft": "Gauche",
+        "alignCenter": "Centre",
+        "alignRight": "Droite",
+        "removeColumn": "Supprimer la colonne",
+        "addColumn": "Ajouter une colonne",
+        "removeRow": "Supprimer la ligne",
+        "addRow": "Ajouter une ligne",
+        "cellAria": "Ligne {{row}}, colonne {{column}}",
+        "captionPlaceholder": "Légende (facultatif)",
+        "zebra": "Lignes zébrées",
+        "headerStyle": "Style d'en-tête",
+        "headerStylePlain": "Simple",
+        "headerStyleAccent": "Accentué"
       },
       "terms": {
         "placeholder": "Conditions de paiement, clauses de garantie, etc.",
@@ -798,6 +815,14 @@
       },
       "unsavedField": {
         "lines": "Lignes"
+      },
+      "callout": {
+        "variantLabel": "Style de bloc",
+        "variantInfo": "Information",
+        "variantAccent": "Accentué",
+        "variantWarn": "Avertissement",
+        "titlePlaceholder": "Titre (facultatif)",
+        "bodyAria": "Texte de l'encadré"
       }
     },
     "actions": {

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -1082,6 +1082,7 @@
         "subtotal": "Sous-total",
         "tax": "Taxe"
       },
+      "unsupportedBlock": "Ce type de bloc n'est pas encore pris en charge par cette visionneuse.",
       "validUntil": "Valide jusqu'au"
     },
     "page": {

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -510,7 +510,9 @@
       "autosaveHint": "Les modifications sont enregistrées automatiquement. Un contour ambre signale une modification non enregistrée.",
       "block": {
         "imageSectionPdf": "Section image (rendue dans le PDF).",
-        "richTextContentAria": "Contenu en texte enrichi"
+        "richTextContentAria": "Contenu en texte enrichi",
+        "tableEmpty": "Tableau vide.",
+        "calloutEmpty": "Encadré vide."
       },
       "blockTypes": {
         "heading": "Titre",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -510,7 +510,9 @@
       "autosaveHint": "Le modifiche vengono salvate automaticamente. Un bordo ambra indica una modifica non salvata.",
       "block": {
         "imageSectionPdf": "Sezione immagine (renderizzata nel PDF).",
-        "richTextContentAria": "Contenuto di testo formattato"
+        "richTextContentAria": "Contenuto di testo formattato",
+        "tableEmpty": "Tabella vuota.",
+        "calloutEmpty": "Riquadro vuoto."
       },
       "blockTypes": {
         "heading": "Intestazione",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -517,7 +517,9 @@
         "image": "Immagine",
         "pricingTable": "Tabella prezzi",
         "richText": "Testo formattato",
-        "contract": "Contratto"
+        "contract": "Contratto",
+        "table": "Tabella",
+        "callout": "Riquadro"
       },
       "catalog": {
         "addSome": "Aggiungine alcuni nel Catalogo prodotti",
@@ -699,7 +701,22 @@
         "unitPrice": "Prezzo unitario",
         "collapsedSummary": "{{count}} righe · {{amount}}",
         "collapsedSummary_one": "{{count}} riga · {{amount}}",
-        "collapsedSummary_other": "{{count}} righe · {{amount}}"
+        "collapsedSummary_other": "{{count}} righe · {{amount}}",
+        "columnLabelPlaceholder": "Etichetta colonna",
+        "columnAlignAria": "Allineamento colonna",
+        "alignLeft": "Sinistra",
+        "alignCenter": "Centro",
+        "alignRight": "Destra",
+        "removeColumn": "Rimuovi colonna",
+        "addColumn": "Aggiungi colonna",
+        "removeRow": "Rimuovi riga",
+        "addRow": "Aggiungi riga",
+        "cellAria": "Riga {{row}}, colonna {{column}}",
+        "captionPlaceholder": "Didascalia (facoltativa)",
+        "zebra": "Righe alternate",
+        "headerStyle": "Stile intestazione",
+        "headerStylePlain": "Semplice",
+        "headerStyleAccent": "Accento"
       },
       "terms": {
         "placeholder": "Termini di pagamento, clausole di garanzia, ecc.",
@@ -798,6 +815,14 @@
       },
       "unsavedField": {
         "lines": "Righe"
+      },
+      "callout": {
+        "variantLabel": "Stile",
+        "variantInfo": "Informazione",
+        "variantAccent": "Accento",
+        "variantWarn": "Avviso",
+        "titlePlaceholder": "Titolo (facoltativo)",
+        "bodyAria": "Testo del riquadro"
       }
     },
     "actions": {

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -1082,6 +1082,7 @@
         "subtotal": "Subtotale",
         "tax": "Imposta"
       },
+      "unsupportedBlock": "Questo tipo di blocco non è ancora supportato da questo visualizzatore.",
       "validUntil": "Valido fino al"
     },
     "page": {

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -517,7 +517,9 @@
         "image": "Imagem",
         "pricingTable": "Tabela de preços",
         "richText": "Texto rico",
-        "contract": "Contrato"
+        "contract": "Contrato",
+        "table": "Tabela",
+        "callout": "Destaque"
       },
       "bulk": {
         "applied_one": "{{count}} linha atualizada.",
@@ -728,7 +730,22 @@
         "taxTitle": "Imposto por linha. O total de imposto do cabeçalho é autoritativo e pode diferir por um centavo de arredondamento.",
         "taxable": "Tributável",
         "total": "Total",
-        "unitPrice": "Preço unitário"
+        "unitPrice": "Preço unitário",
+        "columnLabelPlaceholder": "Rótulo da coluna",
+        "columnAlignAria": "Alinhamento da coluna",
+        "alignLeft": "Esquerda",
+        "alignCenter": "Centro",
+        "alignRight": "Direita",
+        "removeColumn": "Remover coluna",
+        "addColumn": "Adicionar coluna",
+        "removeRow": "Remover linha",
+        "addRow": "Adicionar linha",
+        "cellAria": "Linha {{row}}, coluna {{column}}",
+        "captionPlaceholder": "Legenda (opcional)",
+        "zebra": "Linhas alternadas",
+        "headerStyle": "Estilo do cabeçalho",
+        "headerStylePlain": "Simples",
+        "headerStyleAccent": "Destaque"
       },
       "terms": {
         "placeholder": "Termos de pagamento, cláusulas de garantia, etc.",
@@ -798,6 +815,14 @@
       },
       "unsavedField": {
         "lines": "Itens"
+      },
+      "callout": {
+        "variantLabel": "Estilo",
+        "variantInfo": "Informação",
+        "variantAccent": "Destaque",
+        "variantWarn": "Aviso",
+        "titlePlaceholder": "Título (opcional)",
+        "bodyAria": "Texto do destaque"
       }
     },
     "actions": {

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -510,7 +510,9 @@
       "autosaveHint": "As alterações são salvas automaticamente. Um contorno âmbar marca uma edição não salva.",
       "block": {
         "imageSectionPdf": "Seção de imagem (renderizada no PDF).",
-        "richTextContentAria": "Conteúdo de rich text"
+        "richTextContentAria": "Conteúdo de rich text",
+        "tableEmpty": "Tabela vazia.",
+        "calloutEmpty": "Destaque vazio."
       },
       "blockTypes": {
         "heading": "Título",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -1082,6 +1082,7 @@
         "subtotal": "Subtotal",
         "tax": "Imposto"
       },
+      "unsupportedBlock": "Este tipo de bloco ainda não é compatível com este visualizador.",
       "validUntil": "Válida até"
     },
     "page": {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -21,6 +21,17 @@
 @import '@fontsource/plus-jakarta-sans/latin-ext-600.css';
 @import '@fontsource/plus-jakarta-sans/latin-ext-700.css';
 
+/* Condensed document theme fonts (Task 12) — Barlow Condensed for headings,
+   DM Sans for body copy, scoped to [data-doc-theme='condensed'] documents
+   only (see the rule near the end of this file). Declared unconditionally,
+   same as the app fonts above: a browser only fetches a face when a matched
+   element actually uses it, so a 'classic' document downloads nothing. Plain
+   @import (no `layer(base)`) for the same cascade-ordering reason as above. */
+@import '@fontsource/barlow-condensed/600.css';
+@import '@fontsource/dm-sans/400.css';
+@import '@fontsource/dm-sans/500.css';
+@import '@fontsource/dm-sans/700.css';
+
 @import 'tailwindcss';
 
 @plugin '@tailwindcss/forms';
@@ -34622,4 +34633,17 @@
 [data-density='dense'] .sidebar-nav a {
   padding-top: 0.25rem !important;
   padding-bottom: 0.25rem !important;
+}
+
+/* Condensed document theme (Task 12) — plain CSS vars/selectors, deliberately
+   NOT @theme tokens (see the @theme inline self-reference NB near the top of
+   this file: a --font-sans self-reference there resolves to an invalid empty
+   value). Scoped to [data-doc-theme='condensed'], stamped by QuoteDocument.tsx
+   on the rendered proposal root, so it never touches the rest of the app. */
+[data-doc-theme='condensed'] {
+  font-family: 'DM Sans', var(--font-sans, system-ui), sans-serif;
+}
+[data-doc-theme='condensed'] :is(h1, h2, h3, h4, th) {
+  font-family: 'Barlow Condensed', 'DM Sans', sans-serif;
+  letter-spacing: 0.01em;
 }

--- a/packages/shared/src/types/publicQuote.ts
+++ b/packages/shared/src/types/publicQuote.ts
@@ -53,3 +53,21 @@ export interface PublicQuoteCoverPage {
   preparedForName: string | null;
   showPreparedBy: boolean;
 }
+
+/** Document theme/page-size identifiers — mirrors
+ *  apps/api/src/services/documentThemes.ts's DocumentThemeId/DocumentPageSize
+ *  (server-side source of truth; kept in sync manually, same as every other
+ *  type in this file). */
+export type DocumentThemeId = 'classic' | 'condensed';
+export type DocumentPageSize = 'letter' | 'a4';
+
+/** Resolved document presentation, sibling of `branding` on every quote-detail
+ *  DTO (staff, authed portal, public token). Precedence is resolved
+ *  server-side (quote.presentationSnapshot → partner defaults → 'classic'/
+ *  'a4') — see quoteBranding.ts's resolveQuoteBranding for the canonical
+ *  precedence this mirrors. Drives `data-doc-theme` on the rendered document
+ *  shell so a 'condensed' quote loads its themed fonts. */
+export interface QuotePresentation {
+  theme: DocumentThemeId;
+  pageSize: DocumentPageSize;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -984,6 +984,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
+      '@tiptap/core':
+        specifier: ^3.28.0
+        version: 3.28.0(@tiptap/pm@3.28.0)
       '@tiptap/extension-link':
         specifier: ^3.28.0
         version: 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
@@ -15502,7 +15505,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.2': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -756,6 +756,12 @@ importers:
       '@astrojs/react':
         specifier: ^6.0.2
         version: 6.0.2(@types/node@26.2.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)
+      '@fontsource/barlow-condensed':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/dm-sans':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.81.0(react@19.2.8))
@@ -951,6 +957,12 @@ importers:
       '@breeze/extension-web-sdk':
         specifier: workspace:*
         version: link:../../packages/extension-web-sdk
+      '@fontsource/barlow-condensed':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/dm-sans':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@fontsource/plus-jakarta-sans':
         specifier: ^5.2.8
         version: 5.2.8
@@ -2958,6 +2970,12 @@ packages:
 
   '@fontsource-variable/inter@5.3.0':
     resolution: {integrity: sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==}
+
+  '@fontsource/barlow-condensed@5.3.0':
+    resolution: {integrity: sha512-RA7MmIx0v3eQ6Gcf74qLVLOwLB0GpPOzx+eU9iG/AmCnSJGcIWYeU8y6CEMGZ210MGwGg5CZhzLkkvyZdTTk1g==}
+
+  '@fontsource/dm-sans@5.3.0':
+    resolution: {integrity: sha512-lYJtMXXO28q1z+yz+z8XKd0s4hXaa9QdkETzkyD760sidCv5heI86weYA0sx0Nc4pAMAQTUuyf4gO44cYKKS9g==}
 
   '@fontsource/plus-jakarta-sans@5.2.8':
     resolution: {integrity: sha512-P5qE49fqdeD+7DXH1KBxmMPlB17LTz1zvBhFH0tFzfnYTKVJVyb0pR6plh0ZGXxcB+Oayb54FZZw3V42/DawTw==}
@@ -13953,6 +13971,10 @@ snapshots:
   '@floating-ui/utils@0.2.12': {}
 
   '@fontsource-variable/inter@5.3.0': {}
+
+  '@fontsource/barlow-condensed@5.3.0': {}
+
+  '@fontsource/dm-sans@5.3.0': {}
 
   '@fontsource/plus-jakarta-sans@5.2.8': {}
 


### PR DESCRIPTION
Part 3 of 4 (follows #3526, #3535). Ships plan Tasks 10-13 — the feature becomes visible and authorable:

- **Web renderer** (`QuoteDocument.tsx`): table + callout blocks; unknown block types now render a visible staff-facing "unsupported block" placeholder instead of silently falling through (the old implicit fallback mis-rendered unknown types as a pricing table). i18n'd in all 7 locales.
- **Portal renderer** (`quoteBlocks.tsx`): same JSX minus i18n; unknown blocks keep rendering nothing (customers never see debris).
- **Document fonts + DTO**: `presentation: { theme, pageSize }` on the staff quote-detail, portal, and public DTOs (snapshot-first precedence, same resolver as the PDF path); `@fontsource` Barlow Condensed + DM Sans in web and portal; `[data-doc-theme='condensed']` CSS stamped from the DTO (classic = no-op, downloads nothing).
- **Authoring** (`QuoteEditor.tsx` + new `InlineRichTextEditor`): add-block picker entries, table grid editor (add/remove rows/columns with the cells===columns invariant kept client-side, per-column align, zebra/header toggles, inline-mark cell editing via a minimal single-paragraph TipTap), callout editor (variant/title/rich body). Submits ride the shared `runScoped`/`runAction` latch (#3519 class structurally prevented). Persisted blocks render read-only in the editor canvas; edit-in-place is a noted follow-up.

XSS surface: `dangerouslySetInnerHTML` only on server-sanitized fields (cells, labels, callout html); caption/title always plain text nodes — verified in review across all three renderers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)