### PR TITLE
fix(api): audit AI software-policy writes and gate remediation on policy arming (#3543)

### DIFF
--- a/apps/api/src/jobs/softwareRemediationWorker.test.ts
+++ b/apps/api/src/jobs/softwareRemediationWorker.test.ts
@@ -65,9 +65,12 @@ const ORG_ID = 'org-1';
 
 function chain(result: unknown): any {
   const p: any = Promise.resolve(result);
-  for (const m of ['from', 'innerJoin', 'where', 'limit', 'set', 'orderBy']) p[m] = () => p;
+  for (const m of ['from', 'innerJoin', 'where', 'limit', 'orderBy']) p[m] = () => p;
   return p;
 }
+
+/** Captures the payload passed to `db.update(...).set(...)`. */
+let setSpy: ReturnType<typeof vi.fn>;
 
 function policyRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -107,7 +110,8 @@ function primeDb(policy: unknown, opts: { compliance?: unknown } = {}) {
   ];
   let call = 0;
   selectMock.mockImplementation(() => chain(results[Math.min(call++, results.length - 1)]));
-  updateMock.mockImplementation(() => chain([]));
+  setSpy = vi.fn(() => chain([]));
+  updateMock.mockImplementation(() => ({ set: setSpy }));
 }
 
 function policyAuditActions(): string[] {
@@ -129,8 +133,18 @@ describe('processRemediateDevice — arming gate for automatic jobs (#3543)', ()
     const audit = recordPolicyAuditMock.mock.calls[0]![0] as any;
     expect(audit).toMatchObject({ orgId: ORG_ID, policyId: POLICY_ID, deviceId: DEVICE_ID, actor: 'system' });
     expect(audit.details).toMatchObject({ reason: 'enforce_mode_off', trigger: 'auto' });
-    // The gate must fire before the row is flipped to in_progress.
-    expect(updateMock).not.toHaveBeenCalled();
+
+    // The refusal must be reflected on the compliance row: leaving it at the
+    // enqueue-time 'pending' would later be rewritten to 'completed' by the
+    // compliance worker, falsely claiming the uninstall succeeded.
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    const written = setSpy.mock.calls[0]![0];
+    expect(written.remediationStatus).toBe('failed');
+    expect(written.remediationErrors[0].message).toMatch(/not armed/i);
+    expect(written.remediationErrors[0].message).toContain('enforce_mode_off');
+    // Crucially it must NOT be left pending, and must not be flipped to in_progress.
+    expect(written.remediationStatus).not.toBe('pending');
+    expect(written.remediationStatus).not.toBe('in_progress');
   });
 
   it('skips when enforceMode is on but autoUninstall is not armed', async () => {

--- a/apps/api/src/jobs/softwareRemediationWorker.test.ts
+++ b/apps/api/src/jobs/softwareRemediationWorker.test.ts
@@ -1,0 +1,247 @@
+/**
+ * #3543 — defense-in-depth arming gate in the remediation worker.
+ *
+ * This worker is the last hop before `software_uninstall` commands reach real
+ * machines. Before #3543 it uninstalled whatever it was handed: the gate
+ * (`enforceMode` + non-audit mode + `remediationOptions.autoUninstall`) existed
+ * only in the compliance evaluator that produces automatic jobs, so a stale,
+ * replayed or hand-enqueued job could still uninstall software from a policy
+ * that had since been disarmed (incident #3381: 259 devices mass-uninstalled).
+ *
+ * An explicit operator remediation (`trigger: 'manual'`, stamped server-side by
+ * the MFA-gated route) is deliberately exempt — `enforceMode`/`autoUninstall`
+ * authorise UNATTENDED remediation — but is loudly audited when the policy is
+ * unarmed. Anything that is not exactly 'manual' is treated as automatic and
+ * gated, so provenance fails closed.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { addMock, getJobMock, queueCommandMock, recordDecisionMock, recordPolicyAuditMock } = vi.hoisted(() => ({
+  addMock: vi.fn(async (..._args: any[]) => ({ id: 'queued-job-1' })),
+  getJobMock: vi.fn(async () => null),
+  queueCommandMock: vi.fn(async (..._args: any[]) => ({ id: 'cmd-1' })),
+  recordDecisionMock: vi.fn((..._args: any[]) => {}),
+  recordPolicyAuditMock: vi.fn(async (..._args: any[]) => {}),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class { add = addMock; getJob = getJobMock; close = vi.fn(); },
+  Worker: class { on = vi.fn(); close = vi.fn(); },
+  Job: class {},
+}));
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
+vi.mock('../routes/metrics', () => ({ recordSoftwareRemediationDecision: recordDecisionMock }));
+vi.mock('../services/commandQueue', () => ({
+  queueCommand: queueCommandMock,
+  CommandTypes: { SOFTWARE_UNINSTALL: 'software_uninstall' },
+}));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/bullmqUtils', () => ({ isReusableState: vi.fn(() => false) }));
+vi.mock('../services/softwarePolicyService', async (orig) => {
+  // Keep the REAL arming evaluator — the whole point of the suite is that the
+  // gate itself is correct, not that a stubbed gate was consulted.
+  const actual = await orig<typeof import('../services/softwarePolicyService')>();
+  return {
+    evaluateSoftwarePolicyArming: actual.evaluateSoftwarePolicyArming,
+    recordSoftwarePolicyAudit: recordPolicyAuditMock,
+  };
+});
+
+const { selectMock, updateMock } = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  updateMock: vi.fn(),
+}));
+vi.mock('../db', () => ({
+  db: { select: selectMock, update: updateMock },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+import { processRemediateDevice, scheduleSoftwareRemediation } from './softwareRemediationWorker';
+
+const POLICY_ID = 'pol-1';
+const DEVICE_ID = 'dev-1';
+const ORG_ID = 'org-1';
+
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'where', 'limit', 'set', 'orderBy']) p[m] = () => p;
+  return p;
+}
+
+function policyRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: POLICY_ID,
+    orgId: ORG_ID,
+    partnerId: null,
+    name: 'Blocklist policy',
+    isActive: true,
+    mode: 'blocklist',
+    enforceMode: false,
+    remediationOptions: null,
+    ...overrides,
+  };
+}
+
+const ARMED = { enforceMode: true, remediationOptions: { autoUninstall: true } };
+
+const COMPLIANCE_ROW = {
+  id: 'cs-1',
+  policyId: POLICY_ID,
+  deviceId: DEVICE_ID,
+  lastRemediationAttempt: null,
+  violations: [{ type: 'unauthorized', software: { name: 'Unwanted App', version: '1.0' } }],
+  remediationStatus: 'pending',
+};
+
+/**
+ * Drives db.select() through the worker's fixed call order:
+ * policy → device → compliance → in-flight uninstall commands.
+ */
+function primeDb(policy: unknown, opts: { compliance?: unknown } = {}) {
+  const results = [
+    [policy],
+    [{ orgId: ORG_ID, isEphemeral: false }],
+    [opts.compliance ?? COMPLIANCE_ROW],
+    [], // readInFlightUninstallKeys
+  ];
+  let call = 0;
+  selectMock.mockImplementation(() => chain(results[Math.min(call++, results.length - 1)]));
+  updateMock.mockImplementation(() => chain([]));
+}
+
+function policyAuditActions(): string[] {
+  return recordPolicyAuditMock.mock.calls.map((c: any[]) => c[0].action);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('processRemediateDevice — arming gate for automatic jobs (#3543)', () => {
+  it('skips an unarmed (detect-only) policy and queues NO uninstall command', async () => {
+    primeDb(policyRow({ enforceMode: false }));
+
+    const result = await processRemediateDevice({ type: 'remediate-device', policyId: POLICY_ID, deviceId: DEVICE_ID, trigger: 'auto' });
+
+    expect(result.commandsQueued).toBe(0);
+    expect(queueCommandMock).not.toHaveBeenCalled();
+    expect(recordDecisionMock).toHaveBeenCalledWith('policy_not_armed');
+    expect(policyAuditActions()).toContain('remediation_skipped_unarmed');
+    const audit = recordPolicyAuditMock.mock.calls[0]![0] as any;
+    expect(audit).toMatchObject({ orgId: ORG_ID, policyId: POLICY_ID, deviceId: DEVICE_ID, actor: 'system' });
+    expect(audit.details).toMatchObject({ reason: 'enforce_mode_off', trigger: 'auto' });
+    // The gate must fire before the row is flipped to in_progress.
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('skips when enforceMode is on but autoUninstall is not armed', async () => {
+    primeDb(policyRow({ enforceMode: true, remediationOptions: { autoUninstall: false } }));
+
+    const result = await processRemediateDevice({ type: 'remediate-device', policyId: POLICY_ID, deviceId: DEVICE_ID, trigger: 'auto' });
+
+    expect(result.commandsQueued).toBe(0);
+    expect(queueCommandMock).not.toHaveBeenCalled();
+    expect((recordPolicyAuditMock.mock.calls[0]![0] as any).details.reason).toBe('auto_uninstall_off');
+  });
+
+  it('skips an audit-mode policy even when otherwise armed', async () => {
+    primeDb(policyRow({ mode: 'audit', ...ARMED }));
+
+    await processRemediateDevice({ type: 'remediate-device', policyId: POLICY_ID, deviceId: DEVICE_ID, trigger: 'auto' });
+
+    expect(queueCommandMock).not.toHaveBeenCalled();
+    expect((recordPolicyAuditMock.mock.calls[0]![0] as any).details.reason).toBe('audit_mode');
+  });
+
+  it('treats a job with NO trigger field (enqueued before #3543) as automatic and gates it', async () => {
+    primeDb(policyRow({ enforceMode: false }));
+
+    await processRemediateDevice({ type: 'remediate-device', policyId: POLICY_ID, deviceId: DEVICE_ID });
+
+    expect(queueCommandMock).not.toHaveBeenCalled();
+    expect(recordDecisionMock).toHaveBeenCalledWith('policy_not_armed');
+  });
+
+  it('does not accept a forged/unknown trigger value as a manual override', async () => {
+    for (const forged of ['Manual', 'MANUAL', 'manual ', 'user', true, 1, null]) {
+      vi.clearAllMocks();
+      primeDb(policyRow({ enforceMode: false }));
+
+      await processRemediateDevice({
+        type: 'remediate-device', policyId: POLICY_ID, deviceId: DEVICE_ID, trigger: forged as any,
+      });
+
+      expect(queueCommandMock, `trigger ${String(forged)} must not bypass the gate`).not.toHaveBeenCalled();
+    }
+  });
+
+  it('proceeds normally for an armed policy (no regression)', async () => {
+    primeDb(policyRow(ARMED));
+
+    const result = await processRemediateDevice({ type: 'remediate-device', policyId: POLICY_ID, deviceId: DEVICE_ID, trigger: 'auto' });
+
+    expect(result.commandsQueued).toBe(1);
+    expect(queueCommandMock).toHaveBeenCalledTimes(1);
+    expect(queueCommandMock).toHaveBeenCalledWith(
+      DEVICE_ID,
+      'software_uninstall',
+      expect.objectContaining({ name: 'Unwanted App', policyId: POLICY_ID, source: 'software_policy' }),
+    );
+    expect(policyAuditActions()).toContain('remediation_queued');
+    expect(policyAuditActions()).not.toContain('remediation_skipped_unarmed');
+  });
+});
+
+describe('processRemediateDevice — explicit manual remediation (#3543)', () => {
+  it('still uninstalls for an unarmed policy but records a manual_override audit naming the requester', async () => {
+    primeDb(policyRow({ enforceMode: false }));
+
+    const result = await processRemediateDevice({
+      type: 'remediate-device', policyId: POLICY_ID, deviceId: DEVICE_ID,
+      trigger: 'manual', requestedByUserId: 'admin-9',
+    });
+
+    expect(result.commandsQueued).toBe(1);
+    expect(queueCommandMock).toHaveBeenCalledTimes(1);
+    expect(recordDecisionMock).toHaveBeenCalledWith('manual_override');
+
+    const override = recordPolicyAuditMock.mock.calls
+      .map((c: any[]) => c[0])
+      .find((a: any) => a.action === 'remediation_manual_override');
+    expect(override).toBeDefined();
+    expect(override).toMatchObject({ actor: 'user', actorId: 'admin-9', policyId: POLICY_ID, deviceId: DEVICE_ID });
+    expect(override.details).toMatchObject({ reason: 'enforce_mode_off' });
+  });
+
+  it('does not record a manual_override when the policy is armed anyway', async () => {
+    primeDb(policyRow(ARMED));
+
+    await processRemediateDevice({
+      type: 'remediate-device', policyId: POLICY_ID, deviceId: DEVICE_ID,
+      trigger: 'manual', requestedByUserId: 'admin-9',
+    });
+
+    expect(policyAuditActions()).not.toContain('remediation_manual_override');
+    expect(recordDecisionMock).not.toHaveBeenCalledWith('manual_override');
+  });
+});
+
+describe('scheduleSoftwareRemediation — trigger propagation (#3543)', () => {
+  it('defaults to the gated automatic trigger when the caller passes no options', async () => {
+    await scheduleSoftwareRemediation(POLICY_ID, [DEVICE_ID]);
+
+    expect(addMock).toHaveBeenCalledTimes(1);
+    expect(addMock.mock.calls[0]![1]).toMatchObject({ trigger: 'auto', requestedByUserId: null });
+  });
+
+  it('propagates an explicit manual trigger with the requesting user', async () => {
+    await scheduleSoftwareRemediation(POLICY_ID, [DEVICE_ID], { trigger: 'manual', requestedByUserId: 'admin-9' });
+
+    expect(addMock.mock.calls[0]![1]).toMatchObject({ trigger: 'manual', requestedByUserId: 'admin-9' });
+  });
+
+  it('never stamps a requester onto an automatic job', async () => {
+    await scheduleSoftwareRemediation(POLICY_ID, [DEVICE_ID], { trigger: 'auto', requestedByUserId: 'admin-9' });
+
+    expect(addMock.mock.calls[0]![1]).toMatchObject({ trigger: 'auto', requestedByUserId: null });
+  });
+});

--- a/apps/api/src/jobs/softwareRemediationWorker.ts
+++ b/apps/api/src/jobs/softwareRemediationWorker.ts
@@ -6,7 +6,7 @@ import { recordSoftwareRemediationDecision } from '../routes/metrics';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
 import { CommandTypes, queueCommand } from '../services/commandQueue';
-import { recordSoftwarePolicyAudit } from '../services/softwarePolicyService';
+import { evaluateSoftwarePolicyArming, recordSoftwarePolicyAudit } from '../services/softwarePolicyService';
 import { captureException } from '../services/sentry';
 
 const { db } = dbModule;
@@ -30,13 +30,45 @@ const SOFTWARE_REMEDIATION_QUEUE = 'software-remediation';
 const DEFAULT_REMEDIATION_COOLDOWN_MINUTES = 120;
 const IN_FLIGHT_LOOKBACK_MINUTES = 24 * 60;
 
+/**
+ * How a remediation job was produced (#3543).
+ *
+ * - `auto`   — the compliance evaluator queued it because the policy is armed.
+ *              The worker re-verifies arming before uninstalling anything.
+ * - `manual` — an operator explicitly requested it through the MFA-gated,
+ *              permission-gated `POST /software-policies/:id/remediate` route.
+ *              `enforceMode`/`autoUninstall` authorise UNATTENDED remediation
+ *              ("Enforce (auto-remediate)" in the UI), so they do not gate a
+ *              deliberate human action — forcing an admin to arm automatic
+ *              fleet-wide remediation just to run one reviewed uninstall would
+ *              be strictly more dangerous than the click they asked for.
+ *
+ * Anything else — including a job enqueued before this field existed — is
+ * treated as `auto` and therefore gated. Provenance fails closed.
+ */
+export type SoftwareRemediationTrigger = 'auto' | 'manual';
+
 type RemediateDeviceJobData = {
   type: 'remediate-device';
   policyId: string;
   deviceId: string;
+  /** Absent on jobs enqueued before #3543; read via readTrigger (fails closed). */
+  trigger?: SoftwareRemediationTrigger;
+  /** User id behind a `manual` trigger, for the audit trail. */
+  requestedByUserId?: string | null;
 };
 
 type SoftwareRemediationJobData = RemediateDeviceJobData;
+
+/**
+ * Job data is untrusted input: BullMQ payloads live in Redis and carry no
+ * authentication of their own. Only the exact literal 'manual' skips the arming
+ * gate, and the worker records a loud audit event when it does, so a forged
+ * override is at least always visible in the forensic trail.
+ */
+function readTrigger(data: RemediateDeviceJobData): SoftwareRemediationTrigger {
+  return data.trigger === 'manual' ? 'manual' : 'auto';
+}
 
 let softwareRemediationQueue: Queue<SoftwareRemediationJobData> | null = null;
 let softwareRemediationWorker: Worker<SoftwareRemediationJobData> | null = null;
@@ -90,7 +122,9 @@ async function readInFlightUninstallKeys(
   return keys;
 }
 
-async function processRemediateDevice(data: RemediateDeviceJobData): Promise<{
+/** Exported for tests — the arming gate (#3543) is the last hop before an
+ *  uninstall reaches a real machine and must be directly exercisable. */
+export async function processRemediateDevice(data: RemediateDeviceJobData): Promise<{
   policyId: string;
   deviceId: string;
   commandsQueued: number;
@@ -103,6 +137,8 @@ async function processRemediateDevice(data: RemediateDeviceJobData): Promise<{
       partnerId: softwarePolicies.partnerId,
       name: softwarePolicies.name,
       isActive: softwarePolicies.isActive,
+      mode: softwarePolicies.mode,
+      enforceMode: softwarePolicies.enforceMode,
       remediationOptions: softwarePolicies.remediationOptions,
     })
     .from(softwarePolicies)
@@ -146,6 +182,71 @@ async function processRemediateDevice(data: RemediateDeviceJobData): Promise<{
   }
 
   const auditOrgId = policy.orgId ?? deviceRow?.orgId ?? null;
+
+  // Arming re-check (#3543, incident #3381). This worker is the last hop before
+  // `software_uninstall` commands reach real machines, and until now it
+  // uninstalled whatever it was handed — the gate existed only in the compliance
+  // evaluator that produces `auto` jobs. Re-checking here means a policy
+  // disarmed AFTER a job was enqueued (or a stale/replayed/hand-enqueued job)
+  // can no longer uninstall anything.
+  //
+  // Note on the BullMQ jobId (`software-remediation-<policy>-<device>`): an auto
+  // and a manual job for the same pair share a key and can dedupe into each
+  // other. That cannot produce a wrong gate outcome — auto jobs are only ever
+  // produced for armed policies, so on an unarmed policy every job is manual,
+  // and on an armed policy both triggers pass the gate anyway.
+  const trigger = readTrigger(data);
+  const arming = evaluateSoftwarePolicyArming(policy);
+  if (trigger === 'manual') {
+    // Explicit human action: allowed regardless of arming, but never silent.
+    if (!arming.armed) {
+      fireAudit({
+        orgId: auditOrgId,
+        partnerId: policy.partnerId,
+        policyId: policy.id,
+        deviceId: data.deviceId,
+        action: 'remediation_manual_override',
+        actor: 'user',
+        actorId: data.requestedByUserId ?? null,
+        details: {
+          policyName: policy.name,
+          reason: arming.reason,
+          mode: policy.mode,
+          enforceMode: policy.enforceMode,
+        },
+      });
+      recordSoftwareRemediationDecision('manual_override');
+    }
+  } else if (!arming.armed) {
+    console.warn('[SoftwareRemediationWorker] Policy is not armed for uninstall, skipping remediation', {
+      policyId: policy.id,
+      deviceId: data.deviceId,
+      reason: arming.reason,
+    });
+    fireAudit({
+      orgId: auditOrgId,
+      partnerId: policy.partnerId,
+      policyId: policy.id,
+      deviceId: data.deviceId,
+      action: 'remediation_skipped_unarmed',
+      actor: 'system',
+      details: {
+        policyName: policy.name,
+        reason: arming.reason,
+        mode: policy.mode,
+        enforceMode: policy.enforceMode,
+        trigger,
+      },
+    });
+    recordSoftwareRemediationDecision('policy_not_armed');
+
+    return {
+      policyId: data.policyId,
+      deviceId: data.deviceId,
+      commandsQueued: 0,
+      errors: 0,
+    };
+  }
 
   const [compliance] = await db
     .select()
@@ -414,8 +515,12 @@ export async function shutdownSoftwareRemediationWorker(): Promise<void> {
 
 export async function scheduleSoftwareRemediation(
   policyId: string,
-  deviceIds: string[]
+  deviceIds: string[],
+  // Defaults to the gated path: a caller that says nothing gets `auto`, so a
+  // new producer cannot accidentally inherit the manual override (#3543).
+  options: { trigger?: SoftwareRemediationTrigger; requestedByUserId?: string | null } = {}
 ): Promise<number> {
+  const trigger: SoftwareRemediationTrigger = options.trigger === 'manual' ? 'manual' : 'auto';
   const uniqueDeviceIds = Array.from(new Set(deviceIds.filter((id) => typeof id === 'string' && id.length > 0)));
   if (uniqueDeviceIds.length === 0) {
     return 0;
@@ -443,6 +548,8 @@ export async function scheduleSoftwareRemediation(
         type: 'remediate-device',
         policyId,
         deviceId,
+        trigger,
+        requestedByUserId: trigger === 'manual' ? (options.requestedByUserId ?? null) : null,
       },
       {
         jobId,

--- a/apps/api/src/jobs/softwareRemediationWorker.ts
+++ b/apps/api/src/jobs/softwareRemediationWorker.ts
@@ -183,12 +183,36 @@ export async function processRemediateDevice(data: RemediateDeviceJobData): Prom
 
   const auditOrgId = policy.orgId ?? deviceRow?.orgId ?? null;
 
+  const [compliance] = await db
+    .select()
+    .from(softwareComplianceStatus)
+    .where(and(
+      eq(softwareComplianceStatus.policyId, data.policyId),
+      eq(softwareComplianceStatus.deviceId, data.deviceId),
+    ))
+    .limit(1);
+
+  if (!compliance) {
+    console.warn('[SoftwareRemediationWorker] Compliance record not found', {
+      policyId: data.policyId,
+      deviceId: data.deviceId,
+    });
+    return {
+      policyId: data.policyId,
+      deviceId: data.deviceId,
+      commandsQueued: 0,
+      errors: 0,
+    };
+  }
+
   // Arming re-check (#3543, incident #3381). This worker is the last hop before
   // `software_uninstall` commands reach real machines, and until now it
   // uninstalled whatever it was handed — the gate existed only in the compliance
   // evaluator that produces `auto` jobs. Re-checking here means a policy
   // disarmed AFTER a job was enqueued (or a stale/replayed/hand-enqueued job)
-  // can no longer uninstall anything.
+  // can no longer uninstall anything. It sits after the compliance READ so a
+  // refusal can be reflected on the row, but ahead of every mutation and of
+  // queueCommand.
   //
   // Note on the BullMQ jobId (`software-remediation-<policy>-<device>`): an auto
   // and a manual job for the same pair share a key and can dedupe into each
@@ -240,28 +264,24 @@ export async function processRemediateDevice(data: RemediateDeviceJobData): Prom
     });
     recordSoftwareRemediationDecision('policy_not_armed');
 
-    return {
-      policyId: data.policyId,
-      deviceId: data.deviceId,
-      commandsQueued: 0,
-      errors: 0,
-    };
-  }
+    // The row must not be left at the enqueue-time 'pending': softwareComplianceWorker
+    // rewrites any non-terminal remediationStatus to 'completed' once the device
+    // next scans compliant, which would claim Breeze's uninstall succeeded when it
+    // was refused and never ran. Record the refusal and its reason instead.
+    await db
+      .update(softwareComplianceStatus)
+      .set({
+        remediationStatus: 'failed',
+        remediationErrors: [{
+          message: `Remediation skipped: policy is not armed for uninstall (${arming.reason}).`,
+        }],
+      })
+      .where(eq(softwareComplianceStatus.id, compliance.id))
+      .catch((err: unknown) => {
+        console.error('[SoftwareRemediationWorker] Failed to record refused remediation status:', err);
+        captureException(err);
+      });
 
-  const [compliance] = await db
-    .select()
-    .from(softwareComplianceStatus)
-    .where(and(
-      eq(softwareComplianceStatus.policyId, data.policyId),
-      eq(softwareComplianceStatus.deviceId, data.deviceId),
-    ))
-    .limit(1);
-
-  if (!compliance) {
-    console.warn('[SoftwareRemediationWorker] Compliance record not found', {
-      policyId: data.policyId,
-      deviceId: data.deviceId,
-    });
     return {
       policyId: data.policyId,
       deviceId: data.deviceId,

--- a/apps/api/src/routes/softwarePolicies.test.ts
+++ b/apps/api/src/routes/softwarePolicies.test.ts
@@ -399,6 +399,27 @@ describe('POST /:id/remediate — site scope', () => {
     const targeted = vi.mocked(scheduleSoftwareRemediation).mock.calls[0]![1];
     expect(targeted).toEqual(expect.arrayContaining([DEVICE_ALLOWED, DEVICE_DENIED]));
   });
+
+  // #3543: the worker re-checks the policy's uninstall arming and skips jobs it
+  // did not authorise. This route stays an explicit operator override, so it
+  // must stamp `trigger: 'manual'` — server-side, never from the request body —
+  // together with the requester's id for the audit trail.
+  it('stamps the manual trigger and the requesting user, ignoring any body-supplied trigger', async () => {
+    setAuth();
+    mockPolicyLookup();
+    mockViolationsSelect([{ deviceId: DEVICE_ALLOWED }]);
+
+    const res = await app.request(`/software-policies/${POLICY_ID}/remediate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // A caller trying to steer the trigger must have no effect either way.
+      body: JSON.stringify({ trigger: 'auto', requestedByUserId: 'someone-else' }),
+    });
+
+    expect(res.status).toBe(200);
+    const options = vi.mocked(scheduleSoftwareRemediation).mock.calls[0]![2];
+    expect(options).toEqual({ trigger: 'manual', requestedByUserId: 'user-123' });
+  });
 });
 
 // ───────────────── POST /:id/check — authorization scope ─────────────────

--- a/apps/api/src/routes/softwarePolicies.ts
+++ b/apps/api/src/routes/softwarePolicies.ts
@@ -813,7 +813,15 @@ softwarePoliciesRoutes.post(
 
     let queued: number;
     try {
-      queued = await scheduleSoftwareRemediation(policy.id, targetDeviceIds);
+      // `trigger: 'manual'` is stamped server-side, never taken from the request
+      // body — it is what exempts this job from the worker's arming re-check
+      // (#3543). This route is already behind the execute permission, MFA, and
+      // tenant/site filtering, and `enforceMode`/`autoUninstall` authorise
+      // UNATTENDED remediation rather than a deliberate operator action.
+      queued = await scheduleSoftwareRemediation(policy.id, targetDeviceIds, {
+        trigger: 'manual',
+        requestedByUserId: auth.user.id,
+      });
     } catch (error) {
       console.error(`[softwarePolicies] Failed to schedule remediation for policy ${id}:`, error);
       captureException(error);

--- a/apps/api/src/services/aiToolsCompliance.auditAndArming.test.ts
+++ b/apps/api/src/services/aiToolsCompliance.auditAndArming.test.ts
@@ -1,0 +1,360 @@
+/**
+ * #3543 — AI software-policy tools must write BOTH audit stores, and
+ * remediate_software_violation must respect the policy's own uninstall arming.
+ *
+ * Context: incident #3381 (259 devices mass-uninstalled). The reporter's full
+ * `audit_logs` trail contained no policy-arming event, because these tools wrote
+ * to neither `audit_logs` nor `software_policy_audit`; and the remediation tool
+ * refused only `mode === 'audit'`, so a detect-only policy could still have
+ * fleet-wide uninstalls queued through the model.
+ *
+ * These assert on the actual audited VALUES (action names, actor, orgId, the
+ * enforcement fields) rather than merely "an audit function was called".
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn(), transaction: vi.fn() },
+}));
+vi.mock('../jobs/softwareComplianceWorker', () => ({ scheduleSoftwareComplianceCheck: vi.fn(async () => 'job-1') }));
+vi.mock('../jobs/softwareRemediationWorker', () => ({ scheduleSoftwareRemediation: vi.fn(async () => 1) }));
+
+// The two audit stores. `recordSoftwarePolicyAudit` (software_policy_audit) and
+// `writeAuditEvent` (audit_logs) are spied at their real module boundaries so
+// the shared aiToolsSoftwarePolicyAudit helper is exercised for real.
+vi.mock('./softwarePolicyService', async (orig) => {
+  const actual = await orig<typeof import('./softwarePolicyService')>();
+  return {
+    ...actual,
+    normalizeSoftwarePolicyRules: vi.fn((r: any) => ({
+      software: Array.isArray(r?.software) ? r.software : [],
+      allowUnknown: r?.allowUnknown === true,
+    })),
+    recordSoftwarePolicyAudit: vi.fn(async () => {}),
+  };
+});
+vi.mock('./auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
+}));
+
+import { db } from '../db';
+import { scheduleSoftwareRemediation } from '../jobs/softwareRemediationWorker';
+import { recordSoftwarePolicyAudit } from './softwarePolicyService';
+import { writeAuditEvent } from './auditEvents';
+import { registerComplianceTools } from './aiToolsCompliance';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const mockDb = db as unknown as {
+  select: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  transaction: ReturnType<typeof vi.fn>;
+};
+
+const USER_ID = 'user-1';
+const ORG_ID = 'org-1';
+const POLICY_ID = 'pol-1';
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerComplianceTools(reg);
+  return reg.get(name)!.handler;
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: USER_ID, email: 'ai@example.com', name: 'AI', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: ORG_ID,
+    scope: 'organization',
+    accessibleOrgIds: [ORG_ID],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+  } as unknown as AuthContext;
+}
+
+/** Generic chainable query mock that resolves to `result`. */
+function chain(result: unknown): any {
+  const p: any = Promise.resolve(result);
+  for (const m of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy', 'offset', 'set', 'values', 'returning']) {
+    p[m] = () => p;
+  }
+  return p;
+}
+
+function policyRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: POLICY_ID,
+    orgId: ORG_ID,
+    partnerId: null,
+    name: 'Blocklist policy',
+    mode: 'blocklist',
+    enforceMode: false,
+    remediationOptions: null,
+    isActive: true,
+    rules: { software: [{ name: 'Foo' }], allowUnknown: false },
+    ...overrides,
+  };
+}
+
+const ARMED = { enforceMode: true, remediationOptions: { autoUninstall: true } };
+
+function policyAuditCalls() {
+  return vi.mocked(recordSoftwarePolicyAudit).mock.calls.map((c) => c[0]);
+}
+function auditLogCalls() {
+  return vi.mocked(writeAuditEvent).mock.calls.map((c) => c[1]);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('manage_software_policy create — writes both audit stores (#3543)', () => {
+  it('records policy_created + software_policy.create with the AI actor and the enforcement fields', async () => {
+    const created = policyRow({ ...ARMED, name: 'Armed policy' });
+    mockDb.insert.mockImplementation(() => chain([created]));
+
+    const result = JSON.parse(await handlerFor('manage_software_policy')({
+      action: 'create',
+      name: 'Armed policy',
+      mode: 'blocklist',
+      software: [{ name: 'Foo' }],
+      enforceMode: true,
+      remediationOptions: { autoUninstall: true },
+    }, makeAuth()));
+
+    expect(result.success).toBe(true);
+
+    const [policyAudit] = policyAuditCalls();
+    expect(policyAudit).toMatchObject({
+      orgId: ORG_ID,
+      partnerId: null,
+      policyId: POLICY_ID,
+      action: 'policy_created',
+      actor: 'ai',
+      actorId: USER_ID,
+    });
+    // The arming decision must be legible in the trail, not just "something changed".
+    expect(policyAudit!.details).toMatchObject({
+      mode: 'blocklist',
+      enforceMode: true,
+      autoUninstall: true,
+      toolName: 'manage_software_policy',
+    });
+
+    const [auditLog] = auditLogCalls();
+    expect(auditLog).toMatchObject({
+      orgId: ORG_ID,
+      actorId: USER_ID,
+      actorEmail: 'ai@example.com',
+      action: 'software_policy.create',
+      resourceType: 'software_policy',
+      resourceId: POLICY_ID,
+      result: 'success',
+    });
+    expect(auditLog!.details).toMatchObject({ enforceMode: true, autoUninstall: true, tool_name: 'manage_software_policy' });
+  });
+
+  it('does not audit when the create is rejected before any row is written', async () => {
+    const result = JSON.parse(await handlerFor('manage_software_policy')({
+      action: 'create',
+      name: 'No rules',
+      mode: 'blocklist',
+      software: [],
+    }, makeAuth()));
+
+    expect(result.error).toBeTruthy();
+    expect(recordSoftwarePolicyAudit).not.toHaveBeenCalled();
+    expect(writeAuditEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('manage_software_policy update — writes both audit stores (#3543)', () => {
+  it('flags an enforceMode arming change explicitly and lists only persisted fields', async () => {
+    const existing = policyRow();
+    mockDb.select.mockImplementation(() => chain([existing]));
+    mockDb.update.mockImplementation(() => chain([{ ...existing, ...ARMED }]));
+
+    const result = JSON.parse(await handlerFor('manage_software_policy')({
+      action: 'update',
+      policyId: POLICY_ID,
+      enforceMode: true,
+      remediationOptions: { autoUninstall: true },
+    }, makeAuth()));
+
+    expect(result.success).toBe(true);
+
+    const [policyAudit] = policyAuditCalls();
+    expect(policyAudit).toMatchObject({
+      orgId: ORG_ID,
+      policyId: POLICY_ID,
+      action: 'policy_updated',
+      actor: 'ai',
+      actorId: USER_ID,
+    });
+    expect(policyAudit!.details).toMatchObject({ enforceMode: true, autoUninstall: true });
+    // `updatedFields` is derived from the columns written, so the routing keys
+    // `action`/`policyId` (present in `input`) must NOT appear.
+    const updatedFields = (policyAudit!.details as any).updatedFields as string[];
+    expect(updatedFields).toEqual(expect.arrayContaining(['enforceMode', 'remediationOptions']));
+    expect(updatedFields).not.toContain('action');
+    expect(updatedFields).not.toContain('policyId');
+    expect(updatedFields).not.toContain('updatedAt');
+
+    const [auditLog] = auditLogCalls();
+    expect(auditLog).toMatchObject({ action: 'software_policy.update', resourceId: POLICY_ID, actorId: USER_ID });
+  });
+
+  it('does not audit when the policy is not visible to the caller', async () => {
+    mockDb.select.mockImplementation(() => chain([]));
+
+    const result = JSON.parse(await handlerFor('manage_software_policy')({
+      action: 'update', policyId: POLICY_ID, enforceMode: true,
+    }, makeAuth()));
+
+    expect(result.error).toMatch(/not found or access denied/i);
+    expect(recordSoftwarePolicyAudit).not.toHaveBeenCalled();
+    expect(writeAuditEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('manage_software_policy delete — writes both audit stores (#3543)', () => {
+  it('records policy_deleted + software_policy.delete', async () => {
+    mockDb.select.mockImplementation(() => chain([policyRow()]));
+    mockDb.transaction.mockImplementation(async (fn: any) =>
+      fn({ update: () => chain([]), delete: () => chain([]) }));
+
+    const result = JSON.parse(await handlerFor('manage_software_policy')({
+      action: 'delete', policyId: POLICY_ID,
+    }, makeAuth()));
+
+    expect(result.success).toBe(true);
+    expect(policyAuditCalls()[0]).toMatchObject({ action: 'policy_deleted', actor: 'ai', actorId: USER_ID, policyId: POLICY_ID });
+    expect(auditLogCalls()[0]).toMatchObject({ action: 'software_policy.delete', resourceId: POLICY_ID });
+  });
+});
+
+describe('remediate_software_violation — arming gate (#3543 / incident #3381)', () => {
+  it('refuses a detect-only policy (enforceMode false) and queues NOTHING', async () => {
+    mockDb.select.mockImplementation(() => chain([policyRow({ enforceMode: false })]));
+
+    const result = JSON.parse(await handlerFor('remediate_software_violation')({
+      policyId: POLICY_ID, deviceIds: ['d1', 'd2'],
+    }, makeAuth()));
+
+    expect(result.error).toMatch(/enforceMode=false/);
+    expect(result.reason).toBe('enforce_mode_off');
+    expect(scheduleSoftwareRemediation).not.toHaveBeenCalled();
+  });
+
+  it('refuses when enforceMode is on but autoUninstall is not armed', async () => {
+    mockDb.select.mockImplementation(() => chain([
+      policyRow({ enforceMode: true, remediationOptions: { autoUninstall: false, notifyUser: true } }),
+    ]));
+
+    const result = JSON.parse(await handlerFor('remediate_software_violation')({
+      policyId: POLICY_ID, deviceIds: ['d1'],
+    }, makeAuth()));
+
+    expect(result.reason).toBe('auto_uninstall_off');
+    expect(scheduleSoftwareRemediation).not.toHaveBeenCalled();
+  });
+
+  it('refuses when remediationOptions is null (arming is opt-in, never inferred)', async () => {
+    mockDb.select.mockImplementation(() => chain([policyRow({ enforceMode: true, remediationOptions: null })]));
+
+    const result = JSON.parse(await handlerFor('remediate_software_violation')({
+      policyId: POLICY_ID, deviceIds: ['d1'],
+    }, makeAuth()));
+
+    expect(result.reason).toBe('auto_uninstall_off');
+    expect(scheduleSoftwareRemediation).not.toHaveBeenCalled();
+  });
+
+  it('still refuses an audit-mode policy, reported as audit_mode', async () => {
+    mockDb.select.mockImplementation(() => chain([policyRow({ mode: 'audit', ...ARMED })]));
+
+    const result = JSON.parse(await handlerFor('remediate_software_violation')({
+      policyId: POLICY_ID, deviceIds: ['d1'],
+    }, makeAuth()));
+
+    expect(result.reason).toBe('audit_mode');
+    expect(scheduleSoftwareRemediation).not.toHaveBeenCalled();
+  });
+
+  it('audits the refusal to both stores as a denied remediation', async () => {
+    mockDb.select.mockImplementation(() => chain([policyRow({ enforceMode: false })]));
+
+    await handlerFor('remediate_software_violation')({ policyId: POLICY_ID, deviceIds: ['d1', 'd2'] }, makeAuth());
+
+    expect(policyAuditCalls()[0]).toMatchObject({
+      policyId: POLICY_ID,
+      action: 'remediation_denied',
+      actor: 'ai',
+      actorId: USER_ID,
+    });
+    expect(policyAuditCalls()[0]!.details).toMatchObject({ reason: 'enforce_mode_off', requestedDeviceCount: 2 });
+    expect(auditLogCalls()[0]).toMatchObject({
+      action: 'software_policy.remediate',
+      resourceId: POLICY_ID,
+      result: 'denied',
+    });
+  });
+
+  it('there is no override input that re-enables an unarmed policy', async () => {
+    mockDb.select.mockImplementation(() => chain([policyRow({ enforceMode: false })]));
+
+    for (const override of [
+      { force: true },
+      { enforceMode: true },
+      { autoUninstall: true },
+      { remediationOptions: { autoUninstall: true } },
+      { override: true },
+    ]) {
+      vi.mocked(scheduleSoftwareRemediation).mockClear();
+      const result = JSON.parse(await handlerFor('remediate_software_violation')({
+        policyId: POLICY_ID, deviceIds: ['d1'], ...override,
+      }, makeAuth()));
+      expect(result.error, `override ${JSON.stringify(override)} must not be honoured`).toBeTruthy();
+      expect(scheduleSoftwareRemediation).not.toHaveBeenCalled();
+    }
+  });
+
+  it('an armed policy still remediates and audits remediation_requested', async () => {
+    mockDb.select.mockImplementation(() => chain([policyRow(ARMED)]));
+    vi.mocked(scheduleSoftwareRemediation).mockResolvedValue(2);
+
+    const result = JSON.parse(await handlerFor('remediate_software_violation')({
+      policyId: POLICY_ID, deviceIds: ['d1', 'd2'],
+    }, makeAuth()));
+
+    expect(result.error).toBeUndefined();
+    expect(result.queued).toBe(2);
+    expect(scheduleSoftwareRemediation).toHaveBeenCalledWith(POLICY_ID, ['d1', 'd2']);
+
+    expect(policyAuditCalls()[0]).toMatchObject({
+      policyId: POLICY_ID,
+      action: 'remediation_requested',
+      actor: 'ai',
+      actorId: USER_ID,
+    });
+    expect(policyAuditCalls()[0]!.details).toMatchObject({ requestedCount: 2, queued: 2 });
+    expect(auditLogCalls()[0]).toMatchObject({ action: 'software_policy.remediate', result: 'success' });
+  });
+
+  it('the AI path never requests the manual override trigger', async () => {
+    mockDb.select.mockImplementation(() => chain([policyRow(ARMED)]));
+    vi.mocked(scheduleSoftwareRemediation).mockResolvedValue(1);
+
+    await handlerFor('remediate_software_violation')({ policyId: POLICY_ID, deviceIds: ['d1'] }, makeAuth());
+
+    const options = vi.mocked(scheduleSoftwareRemediation).mock.calls[0]![2];
+    expect(options?.trigger).not.toBe('manual');
+  });
+});

--- a/apps/api/src/services/aiToolsCompliance.auditAndArming.test.ts
+++ b/apps/api/src/services/aiToolsCompliance.auditAndArming.test.ts
@@ -161,6 +161,22 @@ describe('manage_software_policy create — writes both audit stores (#3543)', (
     expect(auditLog!.details).toMatchObject({ enforceMode: true, autoUninstall: true, tool_name: 'manage_software_policy' });
   });
 
+  it('audits a partner-wide create on the partner axis (orgId NULL)', async () => {
+    mockDb.insert.mockImplementation(() => chain([
+      policyRow({ ...ARMED, orgId: null, partnerId: 'partner-9', name: 'Partner template' }),
+    ]));
+
+    await handlerFor('manage_software_policy')({
+      action: 'create', name: 'Partner template', mode: 'blocklist',
+      software: [{ name: 'Foo' }], enforceMode: true,
+    }, makeAuth());
+
+    expect(policyAuditCalls()[0]).toMatchObject({
+      orgId: null, partnerId: 'partner-9', action: 'policy_created', actor: 'ai',
+    });
+    expect(auditLogCalls()[0]).toMatchObject({ orgId: null, action: 'software_policy.create' });
+  });
+
   it('does not audit when the create is rejected before any row is written', async () => {
     const result = JSON.parse(await handlerFor('manage_software_policy')({
       action: 'create',
@@ -354,7 +370,25 @@ describe('remediate_software_violation — arming gate (#3543 / incident #3381)'
 
     await handlerFor('remediate_software_violation')({ policyId: POLICY_ID, deviceIds: ['d1'] }, makeAuth());
 
-    const options = vi.mocked(scheduleSoftwareRemediation).mock.calls[0]![2];
-    expect(options?.trigger).not.toBe('manual');
+    // Assert on ARITY, not on `options?.trigger` — the AI tool passes no options
+    // object at all, so `undefined?.trigger` would be vacuously non-'manual'
+    // even if a manual override were later introduced.
+    const call = vi.mocked(scheduleSoftwareRemediation).mock.calls[0]!;
+    expect(call.length).toBe(2);
+    expect(call[2]).toBeUndefined();
+  });
+
+  it('audits a partner-wide policy (orgId NULL) on the partner axis', async () => {
+    mockDb.select.mockImplementation(() => chain([
+      policyRow({ ...ARMED, orgId: null, partnerId: 'partner-9' }),
+    ]));
+    vi.mocked(scheduleSoftwareRemediation).mockResolvedValue(1);
+
+    await handlerFor('remediate_software_violation')({ policyId: POLICY_ID, deviceIds: ['d1'] }, makeAuth());
+
+    // recordSoftwarePolicyAudit throws when BOTH axes are null — a partner-wide
+    // policy must carry partnerId so the row is still writable and visible.
+    expect(policyAuditCalls()[0]).toMatchObject({ orgId: null, partnerId: 'partner-9' });
+    expect(auditLogCalls()[0]).toMatchObject({ orgId: null, resourceId: POLICY_ID });
   });
 });

--- a/apps/api/src/services/aiToolsCompliance.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsCompliance.siteScope.test.ts
@@ -8,7 +8,20 @@ vi.mock('../db', () => ({
 }));
 vi.mock('../jobs/softwareComplianceWorker', () => ({ scheduleSoftwareComplianceCheck: vi.fn() }));
 vi.mock('../jobs/softwareRemediationWorker', () => ({ scheduleSoftwareRemediation: vi.fn(async () => 1) }));
-vi.mock('./softwarePolicyService', () => ({ normalizeSoftwarePolicyRules: vi.fn((r: any) => r) }));
+vi.mock('./softwarePolicyService', async (orig) => {
+  // evaluateSoftwarePolicyArming is pure — keep the REAL gate so these fixtures
+  // have to be genuinely armed (#3543) rather than passing against a stub.
+  const actual = await orig<typeof import('./softwarePolicyService')>();
+  return {
+    normalizeSoftwarePolicyRules: vi.fn((r: any) => r),
+    evaluateSoftwarePolicyArming: actual.evaluateSoftwarePolicyArming,
+    recordSoftwarePolicyAudit: vi.fn(async () => {}),
+  };
+});
+vi.mock('./aiToolsSoftwarePolicyAudit', () => ({
+  auditSoftwarePolicyToolEvent: vi.fn(),
+  summarizeEnforcementChange: vi.fn(() => ({})),
+}));
 
 import { db } from '../db';
 import { scheduleSoftwareRemediation } from '../jobs/softwareRemediationWorker';
@@ -38,6 +51,17 @@ function isDeviceResolverSelect(cols: unknown): boolean {
     Object.keys(cols as object).length === 2
   );
 }
+/** A policy armed for uninstall: non-audit mode + enforceMode + autoUninstall (#3543). */
+const ARMED_POLICY = {
+  id: 'pol-1',
+  name: 'Policy',
+  mode: 'blocklist',
+  orgId: 'org-1',
+  partnerId: null,
+  enforceMode: true,
+  remediationOptions: { autoUninstall: true },
+};
+
 /** Generic chainable query mock that resolves to `result`. */
 function chain(result: unknown): any {
   const p: any = Promise.resolve(result);
@@ -142,7 +166,7 @@ describe('remediate_software_violation — site narrowing of the org-wide fallba
       }
       if (cols === undefined) {
         // policy lookup: db.select().from(softwarePolicies)...
-        return chain([{ id: 'pol-1', name: 'Policy', mode: 'blocklist' }]);
+        return chain([ARMED_POLICY]);
       }
       violationScanRan = true; // org-wide violation enumeration must not run
       return chain([{ deviceId: 'd-siteB' }]);
@@ -159,7 +183,7 @@ describe('remediate_software_violation — site narrowing of the org-wide fallba
   it('unrestricted caller remediates via the fallback enumeration normally (no regression)', async () => {
     mockDb.select.mockImplementation((cols?: unknown) => {
       if (cols === undefined) {
-        return chain([{ id: 'pol-1', name: 'Policy', mode: 'blocklist' }]);
+        return chain([ARMED_POLICY]);
       }
       return chain([{ deviceId: 'd1' }]);
     });

--- a/apps/api/src/services/aiToolsCompliance.ts
+++ b/apps/api/src/services/aiToolsCompliance.ts
@@ -22,11 +22,16 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { scheduleSoftwareComplianceCheck } from '../jobs/softwareComplianceWorker';
 import { scheduleSoftwareRemediation } from '../jobs/softwareRemediationWorker';
-import { normalizeSoftwarePolicyRules } from './softwarePolicyService';
+import { evaluateSoftwarePolicyArming, normalizeSoftwarePolicyRules } from './softwarePolicyService';
+import {
+  auditSoftwarePolicyToolEvent,
+  summarizeEnforcementChange,
+} from './aiToolsSoftwarePolicyAudit';
 import { canManagePartnerWidePolicies } from './partnerWideAccess';
 import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 
 type AiToolTier = 1 | 2 | 3 | 4;
+
 
 function resolveWritableToolOrgId(
   auth: AuthContext,
@@ -288,6 +293,22 @@ registerTool({
         scheduleWarning = error instanceof Error ? error.message : 'Failed to schedule compliance check';
         console.error(`[aiTools] Failed to schedule compliance check for policy ${policy.id}:`, error);
       }
+
+      auditSoftwarePolicyToolEvent(auth, 'manage_software_policy', {
+        orgId: policy.orgId,
+        partnerId: policy.partnerId,
+        policyId: policy.id,
+        policyName: policy.name,
+        policyAuditAction: 'policy_created',
+        auditLogAction: 'software_policy.create',
+        details: {
+          mode: policy.mode,
+          rules: rules.software.length,
+          scheduleWarning,
+          ...summarizeEnforcementChange(input),
+        },
+      });
+
       return JSON.stringify({ success: true, policyId: policy.id, name: policy.name, ...(scheduleWarning ? { warning: scheduleWarning } : {}) });
     }
 
@@ -352,6 +373,25 @@ registerTool({
         scheduleWarning = error instanceof Error ? error.message : 'Failed to schedule compliance check';
         console.error(`[aiTools] Failed to schedule compliance check for policy ${existing.id}:`, error);
       }
+
+      // `updates` (not raw `input`) is the set of columns actually written —
+      // `input` also carries routing keys like `action`/`policyId` that were
+      // never persisted, which would make the trail overstate the change.
+      const updatedFields = Object.keys(updates).filter((field) => field !== 'updatedAt');
+      auditSoftwarePolicyToolEvent(auth, 'manage_software_policy', {
+        orgId: existing.orgId,
+        partnerId: existing.partnerId,
+        policyId: existing.id,
+        policyName: updated?.name ?? existing.name,
+        policyAuditAction: 'policy_updated',
+        auditLogAction: 'software_policy.update',
+        details: {
+          updatedFields,
+          scheduleWarning,
+          ...summarizeEnforcementChange(input),
+        },
+      });
+
       return JSON.stringify({ success: true, policyId: existing.id, name: updated?.name ?? existing.name, ...(scheduleWarning ? { warning: scheduleWarning } : {}) });
     }
 
@@ -387,6 +427,16 @@ registerTool({
         await tx
           .delete(softwareComplianceStatus)
           .where(eq(softwareComplianceStatus.policyId, existing.id));
+      });
+
+      auditSoftwarePolicyToolEvent(auth, 'manage_software_policy', {
+        orgId: existing.orgId,
+        partnerId: existing.partnerId,
+        policyId: existing.id,
+        policyName: existing.name,
+        policyAuditAction: 'policy_deleted',
+        auditLogAction: 'software_policy.delete',
+        details: { name: existing.name },
       });
 
       return JSON.stringify({ success: true, message: `Policy "${existing.name}" disabled` });
@@ -429,7 +479,37 @@ registerTool({
 
     const [policy] = await db.select().from(softwarePolicies).where(and(...conditions)).limit(1);
     if (!policy) return JSON.stringify({ error: 'Policy not found or access denied' });
-    if (policy.mode === 'audit') return JSON.stringify({ error: 'Cannot remediate audit-only policy' });
+
+    // Arming gate (#3543, incident #3381). This tool used to refuse only
+    // `mode === 'audit'`, so a detect-only policy — enforcement deliberately
+    // left off by its owner — could still have fleet-wide uninstalls queued
+    // through the model. Tier-3 approval is a prompt-time check on the ACTION,
+    // not the policy's own enforcement setting, so it is not a substitute.
+    // Deliberately no override parameter: re-arming is an administrator's
+    // decision made on the policy, not an argument the model can supply.
+    const arming = evaluateSoftwarePolicyArming(policy);
+    if (!arming.armed) {
+      auditSoftwarePolicyToolEvent(auth, 'remediate_software_violation', {
+        orgId: policy.orgId,
+        partnerId: policy.partnerId,
+        policyId: policy.id,
+        policyName: policy.name,
+        policyAuditAction: 'remediation_denied',
+        auditLogAction: 'software_policy.remediate',
+        result: 'denied',
+        details: {
+          reason: arming.reason,
+          mode: policy.mode,
+          enforceMode: policy.enforceMode,
+          requestedDeviceCount: Array.isArray(input.deviceIds) ? input.deviceIds.length : 0,
+        },
+      });
+      return JSON.stringify({
+        error: `Cannot remediate: ${arming.message}`,
+        reason: arming.reason,
+        policyId: policy.id,
+      });
+    }
 
     let deviceIds = Array.isArray(input.deviceIds)
       ? Array.from(new Set((input.deviceIds as string[]).filter((id) => typeof id === 'string' && id.length > 0)))
@@ -485,6 +565,20 @@ registerTool({
       console.error(`[aiTools] Failed to schedule remediation for policy ${policy.id}:`, error);
       return JSON.stringify({ error: 'Failed to schedule remediation', policyId: policy.id });
     }
+
+    auditSoftwarePolicyToolEvent(auth, 'remediate_software_violation', {
+      orgId: policy.orgId,
+      partnerId: policy.partnerId,
+      policyId: policy.id,
+      policyName: policy.name,
+      policyAuditAction: 'remediation_requested',
+      auditLogAction: 'software_policy.remediate',
+      details: {
+        requestedCount: deviceIds.length,
+        queued,
+      },
+    });
+
     return JSON.stringify({
       message: `Remediation scheduled for ${queued} device(s)`,
       policyId: policy.id,

--- a/apps/api/src/services/aiToolsPolicyPrereqs.softwarePolicyAudit.test.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.softwarePolicyAudit.test.ts
@@ -1,0 +1,195 @@
+/**
+ * #3543 — `manage_software_policies` (aiToolsPolicyPrereqs) writes to both audit
+ * stores on create/update.
+ *
+ * This tool can set `enforceMode` and `remediationOptions.autoUninstall` — the
+ * two flags that arm a policy to uninstall software from real machines — and
+ * wrote to neither `audit_logs` nor `software_policy_audit`. During the #3381
+ * forensics that meant the arming of an enforcing policy was simply absent from
+ * the reporter's audit trail.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { insertMock, updateMock, selectMock, recordPolicyAuditMock, writeAuditEventMock } = vi.hoisted(() => ({
+  insertMock: vi.fn(),
+  updateMock: vi.fn(),
+  selectMock: vi.fn(),
+  recordPolicyAuditMock: vi.fn(async () => {}),
+  writeAuditEventMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({ db: { insert: insertMock, update: updateMock, select: selectMock } }));
+vi.mock('../db/schema/patches', () => ({ patchPolicies: {} }));
+vi.mock('../db/schema/softwarePolicies', () => ({ softwarePolicies: {} }));
+vi.mock('../db/schema/peripheralControl', () => ({ peripheralPolicies: {} }));
+vi.mock('../db/schema/backup', () => ({ backupConfigs: {}, backupProfiles: {} }));
+vi.mock('../db/schema/configurationPolicies', () => ({ configPolicyBackupSettings: {} }));
+
+// Spy the two audit stores at their real module boundaries so the shared
+// aiToolsSoftwarePolicyAudit helper is exercised for real.
+vi.mock('./softwarePolicyService', () => ({ recordSoftwarePolicyAudit: recordPolicyAuditMock }));
+vi.mock('./auditEvents', () => ({
+  writeAuditEvent: writeAuditEventMock,
+  requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
+}));
+
+import { registerPolicyPrereqTools } from './aiToolsPolicyPrereqs';
+
+const PARTNER_ID = '00000000-0000-0000-0000-000000000001';
+const ORG_ID = '33333333-3333-3333-3333-333333333333';
+const POLICY_ID = '55555555-5555-5555-5555-555555555555';
+const USER_ID = 'user-1';
+
+function makeOrgAuth() {
+  return {
+    user: { id: USER_ID, email: 'ai@example.com', name: 'AI' },
+    scope: 'organization',
+    partnerId: PARTNER_ID,
+    orgId: ORG_ID,
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: () => true,
+    orgCondition: () => undefined,
+  } as any;
+}
+
+function tool() {
+  const tools = new Map<string, any>();
+  registerPolicyPrereqTools(tools);
+  return tools.get('manage_software_policies');
+}
+
+function mockInsertReturns(row: unknown) {
+  const returning = vi.fn(async () => [row]);
+  const values = vi.fn(() => ({ returning }));
+  insertMock.mockReturnValue({ values });
+}
+
+function mockUpdate() {
+  const where = vi.fn(async () => undefined);
+  const set = vi.fn(() => ({ where }));
+  updateMock.mockReturnValue({ set });
+  return { set, where };
+}
+
+function mockSelectReturns(rows: unknown[]) {
+  selectMock.mockReturnValue({
+    from: () => ({ where: () => ({ limit: async () => rows }) }),
+  });
+}
+
+const policyAudit = () => recordPolicyAuditMock.mock.calls.map((c: any[]) => c[0]);
+const auditLog = () => writeAuditEventMock.mock.calls.map((c: any[]) => c[1]);
+
+beforeEach(() => {
+  insertMock.mockReset();
+  updateMock.mockReset();
+  selectMock.mockReset();
+  recordPolicyAuditMock.mockClear();
+  writeAuditEventMock.mockClear();
+});
+
+describe('manage_software_policies create — audit fan-out (#3543)', () => {
+  it('records policy_created + software_policy.create with actor "ai" and the arming fields', async () => {
+    mockInsertReturns({
+      id: POLICY_ID, name: 'Enforcing blocklist', orgId: ORG_ID, partnerId: null, mode: 'blocklist',
+    });
+
+    const out = JSON.parse(await tool().handler({
+      action: 'create',
+      name: 'Enforcing blocklist',
+      mode: 'blocklist',
+      enforceMode: true,
+      remediationOptions: { autoUninstall: true, cooldownMinutes: 30 },
+    }, makeOrgAuth()));
+
+    expect(out.error).toBeUndefined();
+
+    expect(policyAudit()[0]).toMatchObject({
+      orgId: ORG_ID,
+      partnerId: null,
+      policyId: POLICY_ID,
+      action: 'policy_created',
+      actor: 'ai',
+      actorId: USER_ID,
+    });
+    expect(policyAudit()[0]!.details).toMatchObject({
+      mode: 'blocklist',
+      ownerScope: 'organization',
+      enforceMode: true,
+      autoUninstall: true,
+      toolName: 'manage_software_policies',
+    });
+
+    expect(auditLog()[0]).toMatchObject({
+      orgId: ORG_ID,
+      actorId: USER_ID,
+      actorEmail: 'ai@example.com',
+      action: 'software_policy.create',
+      resourceType: 'software_policy',
+      resourceId: POLICY_ID,
+      result: 'success',
+    });
+    expect(auditLog()[0]!.details).toMatchObject({ enforceMode: true, autoUninstall: true });
+  });
+
+  it('reports autoUninstall:false when remediationOptions opts out', async () => {
+    mockInsertReturns({ id: POLICY_ID, name: 'Detect only', orgId: ORG_ID, partnerId: null, mode: 'blocklist' });
+
+    await tool().handler({
+      action: 'create', name: 'Detect only', mode: 'blocklist',
+      enforceMode: false, remediationOptions: { notifyUser: true },
+    }, makeOrgAuth());
+
+    expect(policyAudit()[0]!.details).toMatchObject({ enforceMode: false, autoUninstall: false });
+  });
+
+  it('writes no audit when the create is refused before any row exists', async () => {
+    const out = JSON.parse(await tool().handler({ action: 'create', mode: 'blocklist' }, makeOrgAuth()));
+
+    expect(out.error).toMatch(/name is required/);
+    expect(recordPolicyAuditMock).not.toHaveBeenCalled();
+    expect(writeAuditEventMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('manage_software_policies update — audit fan-out (#3543)', () => {
+  it('records policy_updated naming the arming change and only the persisted fields', async () => {
+    mockSelectReturns([{ id: POLICY_ID, name: 'Detect only', orgId: ORG_ID, partnerId: null, mode: 'blocklist' }]);
+    mockUpdate();
+
+    const out = JSON.parse(await tool().handler({
+      action: 'update',
+      policyId: POLICY_ID,
+      enforceMode: true,
+      remediationOptions: { autoUninstall: true },
+    }, makeOrgAuth()));
+
+    expect(out.success).toBe(true);
+
+    expect(policyAudit()[0]).toMatchObject({
+      orgId: ORG_ID, policyId: POLICY_ID, action: 'policy_updated', actor: 'ai', actorId: USER_ID,
+    });
+    expect(policyAudit()[0]!.details).toMatchObject({ enforceMode: true, autoUninstall: true });
+
+    const updatedFields = (policyAudit()[0]!.details as any).updatedFields as string[];
+    expect(updatedFields).toEqual(expect.arrayContaining(['enforceMode', 'remediationOptions']));
+    // Derived from the columns written, so routing keys present in `input` must not leak in.
+    expect(updatedFields).not.toContain('action');
+    expect(updatedFields).not.toContain('policyId');
+    expect(updatedFields).not.toContain('updatedAt');
+
+    expect(auditLog()[0]).toMatchObject({ action: 'software_policy.update', resourceId: POLICY_ID, actorId: USER_ID });
+  });
+
+  it('writes no audit when the policy is not visible to the caller', async () => {
+    mockSelectReturns([]);
+
+    const out = JSON.parse(await tool().handler({ action: 'update', policyId: POLICY_ID, enforceMode: true }, makeOrgAuth()));
+
+    expect(out.error).toMatch(/not found or access denied/i);
+    expect(recordPolicyAuditMock).not.toHaveBeenCalled();
+    expect(writeAuditEventMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
@@ -35,6 +35,12 @@ vi.mock('../db/schema/patches', () => ({
   },
 }));
 vi.mock('../db/schema/softwarePolicies', () => ({ softwarePolicies: {} }));
+// Cut the audit helper's transitive pull on the full schema barrel (#3543).
+// Audit-fan-out behaviour is covered by aiToolsPolicyPrereqs.softwarePolicyAudit.test.ts.
+vi.mock('./aiToolsSoftwarePolicyAudit', () => ({
+  auditSoftwarePolicyToolEvent: vi.fn(),
+  summarizeEnforcementChange: vi.fn(() => ({})),
+}));
 vi.mock('../db/schema/peripheralControl', () => ({ peripheralPolicies: {} }));
 vi.mock('../db/schema/backup', () => ({ backupConfigs: {} }));
 

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -22,6 +22,10 @@ import {
   backupProfileSelectionsSchema,
 } from '@breeze/shared/validators';
 import { canManagePartnerWidePolicies } from './partnerWideAccess';
+import {
+  auditSoftwarePolicyToolEvent,
+  summarizeEnforcementChange,
+} from './aiToolsSoftwarePolicyAudit';
 import { sanitizeThrownToolError } from './aiToolErrors';
 import { validateS3Details } from '../routes/backup/schemas';
 
@@ -423,6 +427,20 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
         const policy = rows[0];
         if (!policy) return JSON.stringify({ error: 'Failed to create software policy' });
 
+        auditSoftwarePolicyToolEvent(auth, 'manage_software_policies', {
+          orgId: policy.orgId,
+          partnerId: policy.partnerId,
+          policyId: policy.id,
+          policyName: policy.name,
+          policyAuditAction: 'policy_created',
+          auditLogAction: 'software_policy.create',
+          details: {
+            mode: policy.mode,
+            ownerScope: owner.partnerId ? 'partner' : 'organization',
+            ...summarizeEnforcementChange(input),
+          },
+        });
+
         return JSON.stringify({
           success: true,
           policyId: policy.id,
@@ -456,6 +474,22 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
         if (typeof input.isActive === 'boolean') updates.isActive = input.isActive;
 
         await db.update(softwarePolicies).set(updates).where(eq(softwarePolicies.id, existing.id));
+
+        auditSoftwarePolicyToolEvent(auth, 'manage_software_policies', {
+          orgId: existing.orgId,
+          partnerId: existing.partnerId,
+          policyId: existing.id,
+          policyName: (updates.name as string | undefined) ?? existing.name,
+          policyAuditAction: 'policy_updated',
+          auditLogAction: 'software_policy.update',
+          details: {
+            // Derived from the columns actually written, not raw `input` (which
+            // also carries routing keys like `action`/`policyId`).
+            updatedFields: Object.keys(updates).filter((field) => field !== 'updatedAt'),
+            ...summarizeEnforcementChange(input),
+          },
+        });
+
         return JSON.stringify({ success: true, message: `Software policy "${existing.name}" updated` });
       }
 

--- a/apps/api/src/services/aiToolsSoftwarePolicyAudit.ts
+++ b/apps/api/src/services/aiToolsSoftwarePolicyAudit.ts
@@ -1,0 +1,84 @@
+/**
+ * Audit fan-out for AI software-policy writes (#3543).
+ *
+ * The HTTP routes write BOTH stores — `software_policy_audit` (the feature's own
+ * forensic trail) and `audit_logs` (the platform-wide trail) — but the AI tools
+ * wrote neither, so "who armed enforcement on this policy" was unanswerable for
+ * any AI-driven change (the gap surfaced during incident #3381, where the
+ * reporter's complete `audit_logs` trail contained no arming event at all).
+ *
+ * AI tool handlers receive `auth`, not a Hono context, so `writeRouteAudit(c, …)`
+ * is unusable. This mirrors the context-less pattern established in
+ * aiToolsOrgs.ts: `requestLikeFromSnapshot({})`, with actor identity pulled off
+ * `auth.user`. No ip/userAgent is recoverable from an `AuthContext`.
+ *
+ * Both writes are best-effort and never fail the tool result, but neither is
+ * silent: `recordSoftwarePolicyAudit` reports to Sentry internally, and the
+ * `audit_logs` path logs here.
+ */
+
+import type { AuthContext } from '../middleware/auth';
+import { requestLikeFromSnapshot, writeAuditEvent } from './auditEvents';
+import { recordSoftwarePolicyAudit } from './softwarePolicyService';
+
+export type SoftwarePolicyToolAuditEntry = {
+  orgId: string | null;
+  partnerId?: string | null;
+  policyId: string;
+  policyName?: string | null;
+  /** `software_policy_audit.action` — e.g. 'policy_created'. */
+  policyAuditAction: string;
+  /** `audit_logs.action` — e.g. 'software_policy.create'. */
+  auditLogAction: string;
+  result?: 'success' | 'denied';
+  details?: Record<string, unknown>;
+};
+
+export function auditSoftwarePolicyToolEvent(
+  auth: AuthContext,
+  toolName: string,
+  entry: SoftwarePolicyToolAuditEntry
+): void {
+  recordSoftwarePolicyAudit({
+    orgId: entry.orgId,
+    partnerId: entry.partnerId ?? null,
+    policyId: entry.policyId,
+    action: entry.policyAuditAction,
+    actor: 'ai',
+    actorId: auth.user.id,
+    details: { ...entry.details, toolName },
+  }).catch((err) => {
+    console.error(`[aiTools] Software policy audit write failed for ${entry.policyAuditAction}:`, err);
+  });
+
+  try {
+    writeAuditEvent(requestLikeFromSnapshot({}), {
+      orgId: entry.orgId,
+      actorId: auth.user.id,
+      actorEmail: auth.user.email,
+      action: entry.auditLogAction,
+      resourceType: 'software_policy',
+      resourceId: entry.policyId,
+      resourceName: entry.policyName ?? undefined,
+      result: entry.result ?? 'success',
+      details: { ...entry.details, tool_name: toolName },
+    });
+  } catch (err) {
+    console.error(`[aiTools] Audit log write failed for ${entry.auditLogAction}:`, err);
+  }
+}
+
+/**
+ * Which enforcement-relevant fields an AI write touched. Surfaced explicitly in
+ * both audit stores so arming a policy is greppable, rather than buried inside a
+ * generic `updatedFields` list.
+ */
+export function summarizeEnforcementChange(input: Record<string, unknown>): Record<string, unknown> {
+  const summary: Record<string, unknown> = {};
+  if (typeof input.enforceMode === 'boolean') summary.enforceMode = input.enforceMode;
+  if (input.remediationOptions && typeof input.remediationOptions === 'object') {
+    summary.remediationOptions = input.remediationOptions;
+    summary.autoUninstall = (input.remediationOptions as Record<string, unknown>).autoUninstall === true;
+  }
+  return summary;
+}

--- a/apps/api/src/services/softwarePolicyArming.test.ts
+++ b/apps/api/src/services/softwarePolicyArming.test.ts
@@ -1,0 +1,126 @@
+/**
+ * #3543 — the uninstall-arming gate, unit-tested directly plus a drift guard.
+ *
+ * `evaluateSoftwarePolicyArming` is the shared definition of "this policy may
+ * uninstall software". `softwareComplianceWorker.ts` still carries its own
+ * inline copy of the same rule (deliberately left untouched by #3543 — it is the
+ * long-standing automatic-remediation path and rewriting it was out of scope).
+ * Two independent copies of a security gate drift, and drift in THAT file
+ * reintroduces the #3381 bug class, so the parity block below pins them together
+ * over a truth table: if someone changes one and not the other, this fails.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { evaluateSoftwarePolicyArming, readSoftwarePolicyAutoUninstall } from './softwarePolicyService';
+
+describe('readSoftwarePolicyAutoUninstall — arming is opt-in', () => {
+  it.each([
+    ['null', null, false],
+    ['undefined', undefined, false],
+    ['empty object', {}, false],
+    ['array', [], false],
+    ['string "true"', 'true', false],
+    ['number 1', 1, false],
+    ['boolean true', true, false],
+    ['autoUninstall: false', { autoUninstall: false }, false],
+    ['autoUninstall: "true" (string, not boolean)', { autoUninstall: 'true' }, false],
+    ['autoUninstall: 1 (truthy, not true)', { autoUninstall: 1 }, false],
+    ['autoUninstall: true', { autoUninstall: true }, true],
+  ])('%s -> %s', (_label, input, expected) => {
+    expect(readSoftwarePolicyAutoUninstall(input)).toBe(expected);
+  });
+});
+
+describe('evaluateSoftwarePolicyArming', () => {
+  const ARMED_OPTIONS = { autoUninstall: true };
+
+  it('is armed only when mode is non-audit AND enforceMode AND autoUninstall', () => {
+    expect(evaluateSoftwarePolicyArming({
+      mode: 'blocklist', enforceMode: true, remediationOptions: ARMED_OPTIONS,
+    })).toEqual({ armed: true });
+  });
+
+  it('reports audit_mode first, even when otherwise fully armed', () => {
+    const state = evaluateSoftwarePolicyArming({
+      mode: 'audit', enforceMode: true, remediationOptions: ARMED_OPTIONS,
+    });
+    expect(state.armed).toBe(false);
+    expect(state).toMatchObject({ reason: 'audit_mode' });
+  });
+
+  it('reports enforce_mode_off when enforcement is off', () => {
+    for (const enforceMode of [false, null, undefined]) {
+      const state = evaluateSoftwarePolicyArming({
+        mode: 'blocklist', enforceMode, remediationOptions: ARMED_OPTIONS,
+      });
+      expect(state).toMatchObject({ armed: false, reason: 'enforce_mode_off' });
+    }
+  });
+
+  it('reports auto_uninstall_off when enforcement is on but uninstall is not armed', () => {
+    const state = evaluateSoftwarePolicyArming({
+      mode: 'allowlist', enforceMode: true, remediationOptions: { autoUninstall: false },
+    });
+    expect(state).toMatchObject({ armed: false, reason: 'auto_uninstall_off' });
+  });
+
+  it('always carries an operator-legible message when unarmed', () => {
+    for (const policy of [
+      { mode: 'audit', enforceMode: true, remediationOptions: ARMED_OPTIONS },
+      { mode: 'blocklist', enforceMode: false, remediationOptions: ARMED_OPTIONS },
+      { mode: 'blocklist', enforceMode: true, remediationOptions: null },
+    ]) {
+      const state = evaluateSoftwarePolicyArming(policy);
+      expect(state.armed).toBe(false);
+      if (!state.armed) expect(state.message.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+/**
+ * Drift guard against the untouched inline gate in
+ * `apps/api/src/jobs/softwareComplianceWorker.ts` (~line 397):
+ *   policy.enforceMode && policy.mode !== 'audit' && remediationOptions.autoUninstallEnabled
+ * where `autoUninstallEnabled` comes from its local `readRemediationOptions`
+ * (`options.autoUninstall === true`). Reproduced here as the reference oracle.
+ */
+function complianceWorkerInlineGate(policy: {
+  mode: string | null | undefined;
+  enforceMode: boolean | null | undefined;
+  remediationOptions: unknown;
+}): boolean {
+  const raw = policy.remediationOptions;
+  const autoUninstallEnabled = !raw || typeof raw !== 'object'
+    ? false
+    : (raw as Record<string, unknown>).autoUninstall === true;
+  return Boolean(policy.enforceMode) && policy.mode !== 'audit' && autoUninstallEnabled;
+}
+
+describe('gate parity with the inline compliance-worker gate (#3543 drift guard)', () => {
+  const MODES = ['allowlist', 'blocklist', 'audit'];
+  const ENFORCE = [true, false, null, undefined];
+  const OPTIONS: unknown[] = [
+    null, undefined, {}, [], 'true', 1,
+    { autoUninstall: true }, { autoUninstall: false }, { autoUninstall: 'true' },
+    { autoUninstall: true, cooldownMinutes: 30 },
+  ];
+
+  it('agrees on every combination of mode / enforceMode / remediationOptions', () => {
+    const disagreements: string[] = [];
+    for (const mode of MODES) {
+      for (const enforceMode of ENFORCE) {
+        for (const remediationOptions of OPTIONS) {
+          const policy = { mode, enforceMode, remediationOptions };
+          const shared = evaluateSoftwarePolicyArming(policy).armed;
+          const inline = complianceWorkerInlineGate(policy);
+          if (shared !== inline) {
+            disagreements.push(
+              `mode=${mode} enforceMode=${String(enforceMode)} options=${JSON.stringify(remediationOptions)}: shared=${shared} inline=${inline}`
+            );
+          }
+        }
+      }
+    }
+    expect(disagreements).toEqual([]);
+  });
+});

--- a/apps/api/src/services/softwarePolicyService.ts
+++ b/apps/api/src/services/softwarePolicyService.ts
@@ -145,6 +145,66 @@ export function withStableViolationTimestamps(
   });
 }
 
+/**
+ * Uninstall-arming gate (#3543, incident #3381).
+ *
+ * A policy only authorises uninstall commands when all three are true:
+ * `mode !== 'audit'`, `enforceMode`, and `remediationOptions.autoUninstall`.
+ * Until #3543 the gate lived ONLY inline in softwareComplianceWorker.ts, so
+ * every other path that reached `scheduleSoftwareRemediation` (the AI tool, the
+ * manual route, a replayed BullMQ job) could queue mass uninstalls against a
+ * policy whose owner had deliberately left enforcement off. This is the single
+ * shared definition — callers must use it rather than re-deriving the check.
+ */
+export type SoftwarePolicyUnarmedReason = 'audit_mode' | 'enforce_mode_off' | 'auto_uninstall_off';
+
+export type SoftwarePolicyArmingState =
+  | { armed: true }
+  | { armed: false; reason: SoftwarePolicyUnarmedReason; message: string };
+
+export type SoftwarePolicyArmingInput = {
+  mode: string | null | undefined;
+  enforceMode: boolean | null | undefined;
+  remediationOptions: unknown;
+};
+
+/** `autoUninstall` is opt-in: absent or non-object options mean NOT armed. */
+export function readSoftwarePolicyAutoUninstall(raw: unknown): boolean {
+  if (!raw || typeof raw !== 'object') return false;
+  return (raw as Record<string, unknown>).autoUninstall === true;
+}
+
+export function evaluateSoftwarePolicyArming(
+  policy: SoftwarePolicyArmingInput
+): SoftwarePolicyArmingState {
+  if (policy.mode === 'audit') {
+    return {
+      armed: false,
+      reason: 'audit_mode',
+      message: 'Policy is audit-only (mode="audit"); it cannot uninstall software.',
+    };
+  }
+  if (policy.enforceMode !== true) {
+    return {
+      armed: false,
+      reason: 'enforce_mode_off',
+      message:
+        'Policy enforcement is off (enforceMode=false), so it is detect-only and must not uninstall software. '
+        + 'An administrator has to enable enforcement on the policy first.',
+    };
+  }
+  if (!readSoftwarePolicyAutoUninstall(policy.remediationOptions)) {
+    return {
+      armed: false,
+      reason: 'auto_uninstall_off',
+      message:
+        'Policy remediation is not armed (remediationOptions.autoUninstall is not true), so it must not uninstall software. '
+        + 'An administrator has to enable automatic uninstall on the policy first.',
+    };
+  }
+  return { armed: true };
+}
+
 export function normalizeSoftwarePolicyRules(rules: unknown): SoftwarePolicyRulesDefinition {
   if (!rules || typeof rules !== 'object') {
     return { software: [], allowUnknown: false };


### PR DESCRIPTION
Closes #3543.

Found while investigating the forensics in #3381 (259 devices mass-uninstalled) — that reporter's complete `audit_logs` trail contained **no policy-arming event**, which these gaps explain.

## The three gaps

1. **Neither audit store was written by the AI tools.** `manage_software_policy` (`aiToolsCompliance.ts`) and `manage_software_policies` (`aiToolsPolicyPrereqs.ts`) can set `enforceMode` and `remediationOptions` — the two flags that arm a policy to uninstall software from real machines — and contained zero audit writes. The equivalent web routes write to **both** `audit_logs` (`software_policy.create`/`.update`) and `software_policy_audit` (`policy_created`/`policy_updated`).
2. **`remediate_software_violation` ignored `enforceMode`.** It refused only `mode === 'audit'`, so a detect-only policy — enforcement deliberately left off by its owner — could still have fleet-wide uninstalls queued through the model. Tier-3 approval is a prompt-time check on the *action*, not the policy's own enforcement setting.
3. **The remediation worker never re-checked the gate.** It uninstalled whatever it was handed. The arming rule existed only inline in `softwareComplianceWorker.ts:397-402`.

## What changed

**Shared arming gate.** `evaluateSoftwarePolicyArming` in `services/softwarePolicyService.ts` is now the single definition of `mode !== 'audit' && enforceMode && remediationOptions.autoUninstall === true`, returning a machine-readable `reason` (`audit_mode` / `enforce_mode_off` / `auto_uninstall_off`) plus an operator-legible message. `autoUninstall` is opt-in — absent or non-object `remediationOptions` means **not** armed.

**Audit fan-out.** New `services/aiToolsSoftwarePolicyAudit.ts` writes both stores. AI tool handlers receive `auth`, not a Hono context, so `writeRouteAudit(c, …)` is unusable; this follows the context-less pattern already established in `aiToolsOrgs.ts` (`writeAuditEvent(requestLikeFromSnapshot({}), …)`, actor identity off `auth.user`). `recordSoftwarePolicyAudit` is called with `actor: 'ai'` and the acting user as `actorId`. `enforceMode`/`remediationOptions` changes are surfaced explicitly (`enforceMode`, `autoUninstall`) rather than buried in a generic `updatedFields` list — and `updatedFields` is derived from the columns actually written, not raw tool input, so routing keys like `action`/`policyId` don't overstate the change. Wired into create/update/delete on both tools and both outcomes of the remediation tool.

**`remediate_software_violation` hard-refuses** an unarmed policy, returns the reason to the model, and audits the refusal to both stores as `remediation_denied` / `result: 'denied'`. **There is deliberately no override parameter** — re-arming is an administrator's decision made on the policy, not an argument the model can supply.

**Worker re-check (defense in depth).** `softwareRemediationWorker.processRemediateDevice` re-evaluates arming before any `software_uninstall` is queued, and before it flips the compliance row to `in_progress`. Unarmed automatic jobs skip with `recordSoftwareRemediationDecision('policy_not_armed')` + a `remediation_skipped_unarmed` policy-audit row.

## Design call: the manual web route stays ungated

`POST /software-policies/:id/remediate` (execute permission + MFA + tenant/site filtering + both audit stores) keeps working on detect-only policies. Rationale:

- `enforceMode` authorises **unattended** remediation — the UI labels it "Enforce (auto-remediate)" and nests `autoUninstall` under it. Gating an explicit human action on an automation flag repurposes the field.
- Uniform gating would be **more** dangerous in practice: to run one reviewed uninstall an admin would first have to arm automatic fleet-wide remediation, which is a strictly larger grant than the click they wanted, and races the compliance evaluator.
- The UI deliberately shows Remediate for every non-audit policy, so gating it is a silent regression.

I formed this position first and then got an independent read from Codex (read-only, `xhigh`), which reached the same recommendation for the same reasons — so no quorum split to surface.

Mechanically: `scheduleSoftwareRemediation` takes an optional `{ trigger, requestedByUserId }`, defaulting to the **gated** `auto` path so a new producer cannot accidentally inherit the override. The route stamps `trigger: 'manual'` **server-side, never from the request body**. The worker exempts only the exact literal `'manual'` — `'Manual'`, `true`, a missing field, or a job enqueued before this change are all treated as automatic and gated, so provenance fails closed. A manual override against an unarmed policy is recorded as `remediation_manual_override` naming the requesting user.

**Known residual, called out honestly:** `trigger: 'manual'` is authorization state living in unauthenticated BullMQ job data. A Redis writer could forge it — though anyone with that access can already enqueue device commands directly. The stronger fix Codex proposed (a durable one-time remediation-request record consumed atomically by the worker) needs a new table, which is out of scope here; worth a follow-up issue if we want to close it properly. The forged case is at least always visible in the audit trail.

**BullMQ jobId collision:** auto and manual jobs share `software-remediation-<policy>-<device>` and can dedupe into each other. This cannot produce a wrong gate outcome — auto jobs are only ever produced for armed policies, so on an unarmed policy every job is manual, and on an armed policy both triggers pass anyway. Documented inline rather than changing the key (a per-trigger key would risk concurrent duplicate uninstall commands, since the in-flight check isn't atomic).

## Separate finding, not fixed here

`manage_software_policies` in `aiToolsPolicyPrereqs.ts` is registered **Tier 1 (auto-execute, no approval)** while being able to set `enforceMode` and `remediationOptions.autoUninstall`. Its sibling `manage_software_policy` in `aiToolsCompliance.ts` is Tier 3. Post-PR it is at least fully audited, but arming enforcement without approval looks like a tier misclassification. Raising it changes behaviour for existing workflows, so I've left it alone — flagging for a product call.

No schema or migration changes; both audit tables already exist. The compliance worker's existing gate is untouched.

## Verification

- `apps/api` affected suite, single fork: **9 files / 118 tests green** — `aiToolsCompliance.auditAndArming.test.ts` (new), `aiToolsPolicyPrereqs.softwarePolicyAudit.test.ts` (new), `softwareRemediationWorker.test.ts` (new), plus `aiToolsCompliance.siteScope`, `aiToolsPolicyPrereqs`, `softwarePolicies` (route), `softwareComplianceWorker`, `aiToolsRegistryParity`, `aiTools.deviceArgsCoverage.contract`.
- `npx tsc --noEmit` clean.
- **Mutation-checked, not just green:** stubbing `evaluateSoftwarePolicyArming` to always return `armed: true` kills **12** of the new tests, so the gate assertions are load-bearing rather than vacuous. Tests assert audited values (action names, `actor`, `orgId`, the enforcement fields, the refusal reason) rather than "an audit function was called", and the worker suite keeps the *real* evaluator so a stubbed gate can't pass for it.
- Two pre-existing suites needed fixture updates, both genuine consequences: `aiToolsCompliance.siteScope.test.ts` policies had to become actually armed, and `aiToolsPolicyPrereqs.test.ts` needed the new helper's transitive schema-barrel import cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)