### PR TITLE
fix(dev): mount apps/api/assets into dev API container (theme fonts)

### DIFF
--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -29,6 +29,7 @@ services:
     volumes:
       # Mount source code for hot-reloading
       - ./apps/api/src:/app/apps/api/src:cached
+      - ./apps/api/assets:/app/apps/api/assets:ro
       - ./apps/api/migrations:/app/apps/api/migrations:ro
       - ./packages/shared/src:/app/packages/shared/src:cached
       - ./ee/workspace/src:/app/ee/workspace/src:cached


### PR DESCRIPTION
Found during proposal-presentation acceptance testing: condensed-theme PDF renders were 500ing in dev with `document theme font missing: /app/apps/api/assets/fonts/BarlowCondensed-SemiBold.ttf`, because `docker-compose.override.yml.dev` code-mounts `apps/api/src`, migrations, and package config into the API container but never mounted `apps/api/assets` (the vendored fonts shipped in #3526). Both production Dockerfiles COPY the assets directory, so the gap only affected the dev override; this adds the missing `./apps/api/assets:/app/apps/api/assets:ro` mount alongside the other `apps/api` mounts. `docker-compose.override.yml.worktree` layers on top of dev without redefining the API service's `volumes`, so it inherits the fix automatically and needs no changes of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)