### PR TITLE
fix(api): table PDF row-height measurement + header inline marks

### DIFF
--- a/apps/api/src/services/calloutPdf.ts
+++ b/apps/api/src/services/calloutPdf.ts
@@ -110,6 +110,14 @@ export function renderCalloutIntoPdf(doc: PDFKit.PDFDocument, content: unknown, 
     return renderRichTextIntoPdf(doc, plainHtml, { x, width, startY: opts.startY, ensureRoom: ensureRoomPlain, fonts: fonts.body });
   }
 
+  // Resync doc.y to our own tracked position before the page-break decision —
+  // ensureRoom's underlying implementation (quotePdf.ts's ensureRoomRich)
+  // reads pdfkit's OWN doc.y cursor, which may be trailing opts.startY by
+  // whatever gap the PREVIOUS block left it at (e.g. a rich_text/heading
+  // block's own spacing-after isn't drawn as text, so doc.y sits short of the
+  // outer y the block walk actually advanced to). See renderTableIntoPdf in
+  // tablePdf.ts for the same fix against the same class of staleness.
+  doc.y = opts.startY;
   const room = opts.ensureRoom(boxHeight);
   const y = room.y;
   const barColor = barColorFor(variant, accent);

--- a/apps/api/src/services/richTextPdf.ts
+++ b/apps/api/src/services/richTextPdf.ts
@@ -546,7 +546,12 @@ export function measureRichText(doc: PDFKit.PDFDocument, html: string, width: nu
  *  continued-run paragraph, not per individual continued call. Restores
  *  doc.fillColor to TEXT_COLOR before returning (matching the block draw
  *  loop), but does NOT save/restore font state — callers already do that
- *  around their own measure+draw pair (see tablePdf.ts's renderTableIntoPdf). */
+ *  around their own measure+draw pair (see tablePdf.ts's renderTableIntoPdf).
+ *  `forceBold` ORs into every run's own bold state (mirrors styleFor(...).forceBold
+ *  in the block draw loop) — table headers use this instead of wrapping the
+ *  (already-sanitized, potentially tag-bearing) label HTML in a synthetic
+ *  `<strong>` string, which would double-encode any real `<strong>`/`<em>`/etc.
+ *  already in the label. */
 export function renderInlineRunsIntoPdf(
   doc: PDFKit.PDFDocument,
   html: string,
@@ -557,6 +562,7 @@ export function renderInlineRunsIntoPdf(
   fonts?: BodyFonts,
   align: 'left' | 'center' | 'right' = 'left',
   color: string = TEXT_COLOR,
+  forceBold = false,
 ): void {
   const bodyFonts = fonts ?? DEFAULT_BODY_FONTS;
   if (!html || !html.trim()) return;
@@ -565,7 +571,7 @@ export function renderInlineRunsIntoPdf(
   effectiveRuns.forEach((run, i) => {
     const isFirst = i === 0;
     const isLast = i === effectiveRuns.length - 1;
-    doc.font(fontFor(bodyFonts, run.bold, run.italic)).fontSize(fontSize).fillColor(run.link ? LINK_COLOR : color);
+    doc.font(fontFor(bodyFonts, forceBold || run.bold, run.italic)).fontSize(fontSize).fillColor(run.link ? LINK_COLOR : color);
     const textOptions: PDFKit.Mixins.TextOptions = {
       continued: !isLast,
       underline: run.underline || !!run.link,
@@ -582,16 +588,19 @@ export function renderInlineRunsIntoPdf(
 
 /** Same per-run measurement for a single inline-runs string (table cells):
  *  no block splitting — the whole string is one line-wrapped run sequence at
- *  a single caller-supplied font size. */
-export function measureInlineRuns(doc: PDFKit.PDFDocument, html: string, width: number, fontSize: number, fonts?: BodyFonts): number {
+ *  a single caller-supplied font size. `forceBold` must match whatever the
+ *  paired renderInlineRunsIntoPdf draw call passes — table headers measure
+ *  AND draw force-bold, so the reserved height accounts for the (often wider)
+ *  bold glyph metrics. */
+export function measureInlineRuns(doc: PDFKit.PDFDocument, html: string, width: number, fontSize: number, fonts?: BodyFonts, forceBold = false): number {
   const bodyFonts = fonts ?? DEFAULT_BODY_FONTS;
   const saved = saveFontState(doc);
   try {
     if (!html || !html.trim()) return 0;
     const runs = extractRuns(tokenize(html), BASE_CTX);
     const effectiveRuns = runs.length ? runs : [{ text: '', bold: false, italic: false, underline: false }];
-    const lines = countWrappedLines(doc, effectiveRuns, width, fontSize, bodyFonts, false);
-    const lineHeight = maxLineHeightForRuns(doc, effectiveRuns, fontSize, bodyFonts, false);
+    const lines = countWrappedLines(doc, effectiveRuns, width, fontSize, bodyFonts, forceBold);
+    const lineHeight = maxLineHeightForRuns(doc, effectiveRuns, fontSize, bodyFonts, forceBold);
     return lines * lineHeight;
   } finally {
     restoreFontState(doc, saved);

--- a/apps/api/src/services/tablePdf.test.ts
+++ b/apps/api/src/services/tablePdf.test.ts
@@ -67,6 +67,25 @@ function extractFilledRects(pdf: Buffer): { x: number; y: number; w: number; h: 
   return rects;
 }
 
+/** Positioned text fragments: each `BT ... Tm ... (text)/<hex> ... ET` text
+ *  object's origin (in top-down page coordinates) plus its decoded text —
+ *  needed to assert row N's last drawn line sits ABOVE (smaller y) row N+1's
+ *  first drawn line, i.e. no vertical overlap between rows. */
+function extractPositionedPdfText(pdf: Buffer, pageHeight = 841.89): { text: string; x: number; y: number }[] {
+  const fragments: { text: string; x: number; y: number }[] = [];
+  for (const body of inflatePdfStreams(pdf)) {
+    const textObjectRe = /BT\s+([\s\S]*?)\s+ET/g;
+    let textObject: RegExpExecArray | null;
+    while ((textObject = textObjectRe.exec(body))) {
+      const tm = /1 0 0 1 ([\d.]+) ([\d.]+) Tm/.exec(textObject[1]!);
+      if (!tm) continue;
+      const text = decodeShowTextTokens(textObject[1]!);
+      if (text) fragments.push({ text, x: Number(tm[1]), y: pageHeight - Number(tm[2]) });
+    }
+  }
+  return fragments;
+}
+
 function hexToRgbFrac(hex: string): [number, number, number] {
   const v = hex.replace('#', '');
   const num = parseInt(v, 16);
@@ -371,5 +390,96 @@ describe('renderTableIntoPdf', () => {
     const [ar, ag, ab] = hexToRgbFrac(ACCENT);
     const accentRect = rects.find((r) => Math.abs(r.r - ar) < 0.01 && Math.abs(r.g - ag) < 0.01 && Math.abs(r.b - ab) < 0.01);
     expect(accentRect).toBeUndefined();
+  });
+
+  // Regression tests for two acceptance-testing bugs found on a live stack
+  // after this table renderer first shipped:
+  //
+  //  Bug A (Critical): wrapped cell text overlapped the next row. Root cause —
+  //  ensureRoom's underlying implementation reads pdfkit's own doc.y cursor,
+  //  which drawHeader/drawRow's per-COLUMN doc.text() calls leave at wherever
+  //  the LAST-drawn column's cell ended (not the row's true bottom, since row
+  //  height is the MAX across cells). When the last-drawn column's cell was
+  //  shorter than another column's in the same row — e.g. a short "Qty"
+  //  column after a long wrapping "Description" column — the next row started
+  //  from that too-small stale y, overlapping the previous row's last line.
+  //  Fixed by resyncing doc.y to renderTableIntoPdf's own tracked `y`
+  //  immediately before every ensureRoom call.
+  //
+  //  Bug B (Important): a column label containing real inline HTML (e.g.
+  //  `<strong>Managed</strong>` — labels are sanitized inline-HTML per the
+  //  schema, same as body cells) rendered its literal tag characters, because
+  //  drawHeader escaped the label as plain text and then wrapped the escaped
+  //  string in a SYNTHETIC `<strong>`. Fixed by drawing the label as real
+  //  inline HTML (like body cells) with a `forceBold` draw/measure flag
+  //  instead of the escape-and-wrap trick.
+  it('Bug A regression: a wrapped middle-column cell does not overlap the next row, even when the LAST column is short', async () => {
+    // weights 2/4/1 mirrors the acceptance repro exactly: column 2 (index 2,
+    // drawn last) is short ("Qty"), column 1 (index 1) is the one that wraps.
+    const midText =
+      'Comprehensive managed detection and response coverage across every endpoint in the fleet monitored continuously by our SOC team around the clock every single day.';
+    const buf = await renderToBuffer((doc) => {
+      const theme = registerThemeFonts(doc, 'classic');
+      const model = buildMeasured(
+        {
+          columns: [{ label: 'Item', weight: 2 }, { label: 'Description', weight: 4 }, { label: 'Qty', weight: 1 }],
+          rows: [
+            { cells: ['Service A', midText, '1'] },
+            { cells: ['Service B', midText, '2'] },
+            { cells: ['Service C', midText, '3'] },
+          ],
+        },
+        doc,
+        doc.page.width - 100,
+      );
+      const yRef = { y: 100 };
+      const ensureRoom = makeEnsureRoomRich(doc, yRef);
+      renderTableIntoPdf(doc, model, { x: doc.page.margins.left, startY: yRef.y, accent: ACCENT, fonts: theme, ensureRoom });
+    });
+
+    const positioned = extractPositionedPdfText(buf);
+    const rowStarts = positioned.filter((f) => /^Service [ABC]$/.test(f.text)).sort((a, b) => a.y - b.y);
+    expect(rowStarts.length).toBe(3);
+    // The wrapped middle-column text's LAST line ("our SOC team...") for each
+    // row must sit ABOVE (smaller y, since y grows downward here) the NEXT
+    // row's label — i.e. real vertical separation, not overlap/collapse.
+    const lastLines = positioned.filter((f) => f.text.startsWith('our SOC team')).sort((a, b) => a.y - b.y);
+    expect(lastLines.length).toBe(3);
+    for (let i = 0; i < 2; i++) {
+      expect(rowStarts[i + 1]!.y).toBeGreaterThan(lastLines[i]!.y);
+    }
+    // Also assert the row-to-row spacing is at least the full 3-line cell
+    // height (a loose lower bound — well beyond what a collapsed-row bug like
+    // the one this regression guards against could produce).
+    const rowGap = rowStarts[1]!.y - rowStarts[0]!.y;
+    expect(rowGap).toBeGreaterThan(30);
+  });
+
+  it('Bug B regression: a header label with real inline HTML draws formatted text, not literal tag characters, and stays bold', async () => {
+    const buf = await renderToBuffer((doc) => {
+      const theme = registerThemeFonts(doc, 'classic');
+      const model = buildMeasured({ columns: [{ label: '<strong>Managed</strong> Services' }, { label: 'Price' }], rows: [{ cells: ['x', 'y'] }] }, doc);
+      const yRef = { y: 100 };
+      const ensureRoom = makeEnsureRoomRich(doc, yRef);
+      renderTableIntoPdf(doc, model, { x: doc.page.margins.left, startY: yRef.y, accent: ACCENT, fonts: theme, ensureRoom });
+    });
+    const text = extractPdfText(buf);
+    expect(text).not.toContain('<strong>');
+    expect(text).not.toContain('</strong>');
+    expect(text).toContain('Managed');
+    expect(text).toContain('Services');
+
+    // The header cell must draw at the BOLD font, not the regular one — check
+    // the content stream's font-selection operator (`/F<n> <size> Tf`)
+    // immediately preceding the "Managed" show-text op resolves to a bold
+    // BaseFont via the page's font resource dictionary. Simpler proxy: since
+    // renderInlineRunsIntoPdf's forceBold path selects fonts.body.bold for
+    // EVERY run regardless of the label's own <strong> tag, and Helvetica-Bold
+    // is a distinct Tf font name from Helvetica, assert the operator stream
+    // references Helvetica-Bold's font resource at least once (pdfkit names
+    // resources positionally, so we check for the BaseFont string directly
+    // in the (uncompressed) object bodies instead of the content stream).
+    const raw = buf.toString('latin1');
+    expect(raw).toContain('Helvetica-Bold');
   });
 });

--- a/apps/api/src/services/tablePdf.ts
+++ b/apps/api/src/services/tablePdf.ts
@@ -110,10 +110,14 @@ export function parseTable(content: unknown, availableWidth: number): TableModel
 /** Height a single cell/header value occupies at BODY_FONT_SIZE within
  *  `width` minus 2x CELL_PADDING, via Task 7's per-run measurer (so a
  *  bold-heavy cell measures at its actual bold glyph widths, not a flattened
- *  regular-face approximation). */
-function measureCellHeight(doc: PDFKit.PDFDocument, text: string, width: number, fonts: PdfThemeFonts): number {
+ *  regular-face approximation). `forceBold` must match whatever the paired
+ *  draw call passes to renderInlineRunsIntoPdf — header cells are always
+ *  drawn bold (see drawHeader below), so they must also be MEASURED bold: a
+ *  themed bold face can have taller line metrics than its regular face,
+ *  under-measuring the header height otherwise. */
+function measureCellHeight(doc: PDFKit.PDFDocument, text: string, width: number, fonts: PdfThemeFonts, forceBold = false): number {
   const innerWidth = Math.max(0, width - 2 * CELL_PADDING);
-  return measureInlineRuns(doc, text, innerWidth, BODY_FONT_SIZE, fonts.body) + 2 * CELL_PADDING;
+  return measureInlineRuns(doc, text, innerWidth, BODY_FONT_SIZE, fonts.body, forceBold) + 2 * CELL_PADDING;
 }
 
 /** Fill in `model.headerHeight` and every row's `height` (max cell height in
@@ -125,7 +129,7 @@ export function measureTable(doc: PDFKit.PDFDocument, model: TableModel, fonts: 
   const saved = saveFontState(doc);
   try {
     const headerHeight = model.columns.reduce(
-      (max, col) => Math.max(max, measureCellHeight(doc, col.label, col.width, fonts)),
+      (max, col) => Math.max(max, measureCellHeight(doc, col.label, col.width, fonts, true)),
       0,
     );
 
@@ -154,15 +158,6 @@ const HEADER_TEXT_ON_ACCENT = '#ffffff';
 const HEADER_TEXT_ON_PLAIN = '#111827';
 const BODY_TEXT_COLOR = '#1f2937';
 const BODY_FONT_SIZE_DRAW = 10;
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
 
 export interface RenderTableOpts {
   x: number;
@@ -200,9 +195,17 @@ export function renderTableIntoPdf(doc: PDFKit.PDFDocument, model: TableModel, o
     const textColor = model.headerStyle === 'accent' ? HEADER_TEXT_ON_ACCENT : HEADER_TEXT_ON_PLAIN;
     let cx = x;
     for (const col of model.columns) {
+      // col.label is already-sanitized inline HTML (quoteService.ts's
+      // sanitizeTableContent runs it through the inline profile on both
+      // write and read) — draw it AS HTML, not escaped-then-wrapped: the
+      // previous `<strong>${escapeHtml(label)}</strong>` treatment escaped
+      // any real <strong>/<em>/<u>/<a> tags already in the label into
+      // literal visible text. forceBold=true keeps every header cell bold
+      // regardless of the label's own formatting, matching measureCellHeight's
+      // forceBold=true above.
       renderInlineRunsIntoPdf(
         doc,
-        `<strong>${escapeHtml(col.label)}</strong>`,
+        col.label,
         cx + CELL_PADDING,
         atY + CELL_PADDING,
         Math.max(0, col.width - 2 * CELL_PADDING),
@@ -210,6 +213,7 @@ export function renderTableIntoPdf(doc: PDFKit.PDFDocument, model: TableModel, o
         fonts.body,
         col.align,
         textColor,
+        true,
       );
       cx += col.width;
     }
@@ -238,12 +242,28 @@ export function renderTableIntoPdf(doc: PDFKit.PDFDocument, model: TableModel, o
     });
   };
 
+  // ensureRoom's underlying implementation (quotePdf.ts's ensureRoomRich)
+  // bases its page-break decision on doc.y — pdfkit's OWN cursor — not on any
+  // y this function tracks itself. That cursor gets clobbered by every
+  // doc.text() call drawHeader/drawRow make (one per COLUMN), so after
+  // drawing a row it's left wherever the LAST-drawn column's cell ended, not
+  // at this row's true bottom (`y + row.height`). Since row height is the MAX
+  // across cells, whenever the last-drawn (highest-index) column's cell is
+  // SHORTER than another column's in the same row, ensureRoom's next call
+  // would silently substitute that stale, too-small doc.y as the next row's
+  // start — collapsing rows on top of each other. Explicitly resyncing
+  // doc.y = y immediately before every ensureRoom call (mirroring
+  // renderRichTextIntoPdf's own `doc.y = opts.startY` on entry) keeps
+  // ensureRoom's decision — and its returned y — anchored to the position
+  // THIS function actually tracks.
+  doc.y = opts.startY;
   const headerRoom = ensureRoom(model.headerHeight);
   let y = headerRoom.y;
   drawHeader(y);
   y += model.headerHeight;
 
   model.rows.forEach((row, i) => {
+    doc.y = y;
     const rowRoom = ensureRoom(row.height);
     y = rowRoom.y;
     if (rowRoom.didBreak) {
@@ -257,7 +277,12 @@ export function renderTableIntoPdf(doc: PDFKit.PDFDocument, model: TableModel, o
     if (row.height > usablePageHeight - model.headerHeight) {
       model.columns.forEach((col, idx) => {
         const cellHtml = row.cells[idx] ?? '';
-        const html = `<strong>${escapeHtml(col.label)}:</strong> ${cellHtml}`;
+        // col.label is already-sanitized inline HTML (see drawHeader above) —
+        // concatenate it raw, not escaped, so any real formatting tags in the
+        // label draw as formatting rather than literal text. The `<strong>`
+        // wrapper here only needs to survive nesting a label that may already
+        // contain its own <strong>/<em>/etc., which the tokenizer handles fine.
+        const html = `<strong>${col.label}:</strong> ${cellHtml}`;
         const numberAdapter = (needed: number): number => ensureRoom(needed).y;
         y = renderRichTextIntoPdf(doc, html, { x, width: totalWidth, startY: y, ensureRoom: numberAdapter, fonts: fonts.body });
       });


### PR DESCRIPTION
## Summary

Two rendering bugs found in acceptance testing of the proposal-presentation table PDF renderer (found in `proposal-presentation` acceptance).

- **Bug A (Critical) — wrapped cell text overlapped the next row.** `ensureRoom`'s underlying implementation (`quotePdf.ts`'s `ensureRoomRich` closure) decides whether to page-break, and what `y` to return, by reading pdfkit's own `doc.y` cursor. `renderTableIntoPdf` draws one `doc.text()` call per COLUMN in a row, and each call updates `doc.y` to wherever THAT column's text ended. Since row height is the max across cells, whenever the last-drawn (highest-index) column's cell was shorter than another column's in the same row — e.g. a short "Qty" column after a long wrapping "Description" column — the next row's `ensureRoom` call picked up that too-small stale `doc.y` instead of the row's true bottom, collapsing rows on top of each other. Fixed by resyncing `doc.y` to each function's own tracked `y` immediately before every `ensureRoom` call, in both `renderTableIntoPdf` and `renderCalloutIntoPdf` (same class of staleness, confirmed by inspection).
- **Bug B (Important) — header labels rendered literal HTML.** Column labels are sanitized inline-HTML per the schema (same as body cells), but `drawHeader` escaped the label as plain text and wrapped the escaped string in a synthetic `<strong>`, double-encoding any real formatting already in the label (e.g. `<strong>Managed</strong>` showed the literal tag characters). Fixed by drawing (and measuring) the label as real inline HTML with a new `forceBold` flag on `renderInlineRunsIntoPdf`/`measureInlineRuns`, instead of the escape-and-wrap trick.

Both root causes were confirmed by direct diagnostic instrumentation (content-stream position extraction) before writing the fix — not guessed.

## Test plan

- [x] New regression tests in `tablePdf.test.ts`: "Bug A regression" (3-row table, weights 2/4/1, asserts no vertical overlap between rows via positioned content-stream text) and "Bug B regression" (header label with `<strong>` renders without literal tag characters, and at the bold font)
- [x] Confirmed both new tests go RED against the pre-fix code (`git stash`) and GREEN after the fix
- [x] `cd apps/api && CI=true npx vitest run tablePdf quotePdf` — 64/64 passed, including the classic-regression suite (byte-for-byte content-stream + raster baseline)
- [x] `calloutPdf`, `richTextPdf`, `contractTemplateRender`, `documentThemes` suites also green (sanity-checked the new `forceBold` param / `doc.y` resync didn't regress adjacent renderers)
- [x] Repo-root typecheck (`tsc --noEmit --project apps/api/tsconfig.json`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)