### PR TITLE
harden(api): guard shared patch catalog rows against agent metadata drift

### DIFF
--- a/apps/api/src/routes/agents/helpers.patchSource.test.ts
+++ b/apps/api/src/routes/agents/helpers.patchSource.test.ts
@@ -85,7 +85,7 @@ vi.mock('../../jobs/softwareComplianceWorker', () => ({
 }));
 vi.mock('./policyProbeSafety', () => ({ isAllowedPolicyConfigProbe: vi.fn(() => true) }));
 
-import { buildPatchSourceConfigUpdate } from './helpers';
+import { buildPatchSourceConfigUpdate, sanitizeDate } from './helpers';
 
 const DEVICE_ID = '00000000-0000-4000-8000-000000000001';
 
@@ -125,5 +125,35 @@ describe('buildPatchSourceConfigUpdate (#1872)', () => {
     const result = await buildPatchSourceConfigUpdate(DEVICE_ID);
 
     expect(result).toEqual({ exclusiveWindowsUpdate: false });
+  });
+});
+
+describe('sanitizeDate', () => {
+  it('round-trips a valid date', () => {
+    expect(sanitizeDate('2026-01-05')).toBe('2026-01-05');
+  });
+
+  it('rejects an impossible calendar date instead of letting it roll over (regression)', () => {
+    // `new Date('2026-02-31')` silently rolls over to 2026-03-03; the old code
+    // returned the original string, which then hit Postgres 22008 and aborted
+    // the whole ingest transaction.
+    expect(sanitizeDate('2026-02-31')).toBeNull();
+  });
+
+  it('rejects a month 13 date', () => {
+    expect(sanitizeDate('2026-13-01')).toBeNull();
+  });
+
+  it('rejects Feb 29 in a non-leap year', () => {
+    expect(sanitizeDate('2025-02-29')).toBeNull();
+  });
+
+  it('rejects non-matching shapes', () => {
+    expect(sanitizeDate('01/05/2026')).toBeNull();
+    expect(sanitizeDate('')).toBeNull();
+    expect(sanitizeDate(12345)).toBeNull();
+    expect(sanitizeDate(null)).toBeNull();
+    expect(sanitizeDate(undefined)).toBeNull();
+    expect(sanitizeDate('2026-1-5')).toBeNull();
   });
 });

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -130,7 +130,13 @@ export function sanitizeDate(value: unknown): string | null {
   const trimmed = value.trim();
   if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return null;
   const d = new Date(trimmed + 'T00:00:00Z');
-  return Number.isNaN(d.getTime()) ? null : trimmed;
+  if (Number.isNaN(d.getTime())) return null;
+  // `new Date()` silently rolls impossible calendar dates over ('2026-02-31'
+  // becomes 2026-03-03) and is therefore NOT a validity check on its own. The
+  // original string would then reach a Postgres `date` column and raise 22008,
+  // aborting the entire enclosing ingest transaction. Round-trip to confirm the
+  // date the caller wrote is the date we parsed.
+  return d.toISOString().slice(0, 10) === trimmed ? trimmed : null;
 }
 
 /**

--- a/apps/api/src/routes/agents/patchIngestIdentity.test.ts
+++ b/apps/api/src/routes/agents/patchIngestIdentity.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizePatchIdentity,
+  admitPatchBatch,
+  PATCH_DESCRIPTION_LIMIT,
+  type PatchIdentityInput,
+} from './patchIngestIdentity';
+
+function baseInput(overrides: Partial<PatchIdentityInput> = {}): PatchIdentityInput {
+  return {
+    source: 'winget',
+    name: 'Some Package',
+    ...overrides,
+  };
+}
+
+describe('normalizePatchIdentity', () => {
+  it('happy path: explicit externalId used verbatim; other fields trimmed', () => {
+    const result = normalizePatchIdentity(
+      baseInput({
+        externalId: '  KB123456  ',
+        packageId: '  Some.Package.Id  ',
+        version: '  1.2.3  ',
+        vendor: '  Some Vendor  ',
+        category: '  Security  ',
+        description: '  Some description  ',
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.externalId).toBe('KB123456');
+    expect(result.value.packageId).toBe('Some.Package.Id');
+    expect(result.value.version).toBe('1.2.3');
+    expect(result.value.vendor).toBe('Some Vendor');
+    expect(result.value.category).toBe('Security');
+    expect(result.value.description).toBe('Some description');
+  });
+
+  describe('externalId derivation precedence', () => {
+    it('explicit externalId wins over kbNumber and composed form', () => {
+      const result = normalizePatchIdentity(
+        baseInput({ externalId: 'EXPLICIT', kbNumber: 'KB999', version: '1.0' })
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.externalId).toBe('EXPLICIT');
+    });
+
+    it('kbNumber wins over composed form when externalId absent', () => {
+      const result = normalizePatchIdentity(baseInput({ kbNumber: 'KB999', version: '1.0' }));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.externalId).toBe('KB999');
+    });
+
+    it('composes source:name:version when neither externalId nor kbNumber given', () => {
+      const result = normalizePatchIdentity(baseInput({ version: '1.0' }));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.externalId).toBe('winget:Some Package:1.0');
+    });
+
+    it('composed form falls back to "latest" when version absent', () => {
+      const result = normalizePatchIdentity(baseInput());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.externalId).toBe('winget:Some Package:latest');
+    });
+  });
+
+  it('accepts Apple-style values with spaces (regression guard)', () => {
+    const appleId = 'macOS Sonoma 14.5-23F79';
+    const result = normalizePatchIdentity(
+      baseInput({ source: 'apple-softwareupdate', externalId: appleId, packageId: appleId })
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.externalId).toBe(appleId);
+    expect(result.value.packageId).toBe(appleId);
+  });
+
+  describe('control character rejection', () => {
+    it('rejects externalId containing control characters', () => {
+      const result = normalizePatchIdentity(baseInput({ externalId: 'KB\x01123' }));
+      expect(result).toEqual({ ok: false, reason: 'external_id_control_chars' });
+    });
+
+    it('rejects externalId containing a newline', () => {
+      const result = normalizePatchIdentity(baseInput({ externalId: 'KB123\n456' }));
+      expect(result).toEqual({ ok: false, reason: 'external_id_control_chars' });
+    });
+
+    it('rejects packageId containing control characters', () => {
+      const result = normalizePatchIdentity(
+        baseInput({ externalId: 'KB123', packageId: 'pkg\x01id' })
+      );
+      expect(result).toEqual({ ok: false, reason: 'package_id_control_chars' });
+    });
+
+    it('rejects packageId containing a newline', () => {
+      const result = normalizePatchIdentity(
+        baseInput({ externalId: 'KB123', packageId: 'pkg\nid' })
+      );
+      expect(result).toEqual({ ok: false, reason: 'package_id_control_chars' });
+    });
+  });
+
+  describe('option-like id rejection', () => {
+    it('rejects a packageId that looks like a CLI flag', () => {
+      const result = normalizePatchIdentity(baseInput({ externalId: 'KB123', packageId: '--force' }));
+      expect(result).toEqual({ ok: false, reason: 'package_id_option_like' });
+    });
+
+    it('rejects a provider-prefixed packageId whose local segment is option-like', () => {
+      const result = normalizePatchIdentity(
+        baseInput({ externalId: 'KB123', packageId: 'apple-softwareupdate:--all' })
+      );
+      expect(result).toEqual({ ok: false, reason: 'package_id_option_like' });
+    });
+
+    it('rejects an externalId that looks like a CLI flag', () => {
+      const result = normalizePatchIdentity(baseInput({ externalId: '--force' }));
+      expect(result).toEqual({ ok: false, reason: 'external_id_option_like' });
+    });
+
+    it('rejects a provider-prefixed externalId whose local segment is option-like', () => {
+      const result = normalizePatchIdentity(
+        baseInput({ externalId: 'apple-softwareupdate:--all' })
+      );
+      expect(result).toEqual({ ok: false, reason: 'external_id_option_like' });
+    });
+  });
+
+  describe('length rejection', () => {
+    it('rejects when derived externalId exceeds 255 chars', () => {
+      const longId = 'K'.repeat(256);
+      const result = normalizePatchIdentity(baseInput({ externalId: longId }));
+      expect(result).toEqual({ ok: false, reason: 'external_id_too_long' });
+    });
+
+    it('rejects when packageId exceeds 256 chars', () => {
+      const longPkg = 'p'.repeat(257);
+      const result = normalizePatchIdentity(baseInput({ externalId: 'KB123', packageId: longPkg }));
+      expect(result).toEqual({ ok: false, reason: 'package_id_too_long' });
+    });
+  });
+
+  it('rejects whitespace-only name with empty_title', () => {
+    const result = normalizePatchIdentity(baseInput({ name: '   ' }));
+    expect(result).toEqual({ ok: false, reason: 'empty_title' });
+  });
+
+  describe('length policy split (truncate vs null)', () => {
+    it('truncates an over-length title to 500 and still admits the row', () => {
+      const longTitle = 'T'.repeat(600);
+      const result = normalizePatchIdentity(baseInput({ name: longTitle, externalId: 'KB123' }));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.title).toHaveLength(500);
+      expect(result.value.title).toBe(longTitle.slice(0, 500));
+    });
+
+    it('nulls out an over-length version (>64) instead of truncating, and still admits', () => {
+      const longVersion = '9'.repeat(65);
+      const result = normalizePatchIdentity(
+        baseInput({ externalId: 'KB123', version: longVersion })
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.version).toBeNull();
+    });
+
+    it('nulls out an over-length category (>100) instead of truncating, and still admits', () => {
+      const longCategory = 'c'.repeat(101);
+      const result = normalizePatchIdentity(
+        baseInput({ externalId: 'KB123', category: longCategory })
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.category).toBeNull();
+    });
+
+    it('truncates description beyond PATCH_DESCRIPTION_LIMIT', () => {
+      const longDescription = 'd'.repeat(PATCH_DESCRIPTION_LIMIT + 500);
+      const result = normalizePatchIdentity(
+        baseInput({ externalId: 'KB123', description: longDescription })
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.description).toHaveLength(PATCH_DESCRIPTION_LIMIT);
+      expect(result.value.description).toBe(longDescription.slice(0, PATCH_DESCRIPTION_LIMIT));
+    });
+  });
+
+  it('normalizes empty strings to null', () => {
+    const result = normalizePatchIdentity(
+      baseInput({
+        externalId: 'KB123',
+        packageId: '',
+        version: '',
+        vendor: '',
+        category: '',
+        description: '',
+      })
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.packageId).toBeNull();
+    expect(result.value.version).toBeNull();
+    expect(result.value.vendor).toBeNull();
+    expect(result.value.category).toBeNull();
+    expect(result.value.description).toBeNull();
+  });
+});
+
+describe('admitPatchBatch', () => {
+  it('splits a mixed batch into admitted (preserving order + original data) and rejected count', () => {
+    const good1 = baseInput({ externalId: 'KB1', name: 'Good One' });
+    const bad = baseInput({ externalId: '--bad', name: 'Bad One' });
+    const good2 = baseInput({ externalId: 'KB2', name: 'Good Two' });
+
+    const result = admitPatchBatch([good1, bad, good2]);
+
+    expect(result.admitted).toHaveLength(2);
+    expect(result.rejected).toBe(1);
+    expect(result.admitted[0]?.data).toBe(good1);
+    expect(result.admitted[0]?.identity.externalId).toBe('KB1');
+    expect(result.admitted[1]?.data).toBe(good2);
+    expect(result.admitted[1]?.identity.externalId).toBe('KB2');
+  });
+
+  it('reasons is a histogram keyed by rejection reason with correct counts', () => {
+    const row1 = baseInput({ externalId: 'KBbad1', name: 'Row One' });
+    const row2 = baseInput({ externalId: 'KBbad2', name: 'Row Two' });
+
+    const result = admitPatchBatch([row1, row2]);
+
+    expect(result.rejected).toBe(2);
+    expect(result.reasons).toEqual({ external_id_control_chars: 2 });
+  });
+
+  it('returns empty admission for empty input', () => {
+    const result = admitPatchBatch([]);
+    expect(result).toEqual({ admitted: [], rejected: 0, reasons: {} });
+  });
+});

--- a/apps/api/src/routes/agents/patchIngestIdentity.test.ts
+++ b/apps/api/src/routes/agents/patchIngestIdentity.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   normalizePatchIdentity,
   admitPatchBatch,
+  mergeRejectionReasons,
   PATCH_DESCRIPTION_LIMIT,
   type PatchIdentityInput,
 } from './patchIngestIdentity';
@@ -243,5 +244,39 @@ describe('admitPatchBatch', () => {
   it('returns empty admission for empty input', () => {
     const result = admitPatchBatch([]);
     expect(result).toEqual({ admitted: [], rejected: 0, reasons: {} });
+  });
+});
+
+describe('mergeRejectionReasons', () => {
+  it('sums counts for a reason present on both sides (load-bearing: object spread would drop one side)', () => {
+    const a = { external_id_too_long: 2 };
+    const b = { external_id_too_long: 3 };
+    const result = mergeRejectionReasons(a, b);
+    expect(result).toEqual({ external_id_too_long: 5 });
+  });
+
+  it('keeps disjoint keys from both sides', () => {
+    const a = { external_id_too_long: 1 };
+    const b = { package_id_option_like: 4 };
+    const result = mergeRejectionReasons(a, b);
+    expect(result).toEqual({ external_id_too_long: 1, package_id_option_like: 4 });
+  });
+
+  it('is a no-op when either side is empty', () => {
+    const populated = { empty_title: 2 };
+    expect(mergeRejectionReasons(populated, {})).toEqual({ empty_title: 2 });
+    expect(mergeRejectionReasons({}, populated)).toEqual({ empty_title: 2 });
+  });
+
+  it('does not mutate either input object', () => {
+    const a = { external_id_too_long: 2 };
+    const b = { external_id_too_long: 3, empty_title: 1 };
+    const aCopy = { ...a };
+    const bCopy = { ...b };
+
+    mergeRejectionReasons(a, b);
+
+    expect(a).toEqual(aCopy);
+    expect(b).toEqual(bCopy);
   });
 });

--- a/apps/api/src/routes/agents/patchIngestIdentity.ts
+++ b/apps/api/src/routes/agents/patchIngestIdentity.ts
@@ -228,3 +228,20 @@ export function admitPatchBatch<T extends PatchIdentityInput>(patchList: T[]): P
 
   return { admitted, rejected, reasons };
 }
+
+/**
+ * Combine two rejection histograms by SUMMING per reason. Object spread would
+ * silently drop the first side's count whenever both batches refused rows for
+ * the same reason, which is the common case (the pending and installed lists of
+ * one combined scan usually fail the same way).
+ */
+export function mergeRejectionReasons(
+  a: Partial<Record<PatchIdentityRejectionReason, number>>,
+  b: Partial<Record<PatchIdentityRejectionReason, number>>,
+): Partial<Record<PatchIdentityRejectionReason, number>> {
+  const merged: Partial<Record<PatchIdentityRejectionReason, number>> = { ...a };
+  for (const [reason, count] of Object.entries(b) as [PatchIdentityRejectionReason, number][]) {
+    merged[reason] = (merged[reason] ?? 0) + count;
+  }
+  return merged;
+}

--- a/apps/api/src/routes/agents/patchIngestIdentity.ts
+++ b/apps/api/src/routes/agents/patchIngestIdentity.ts
@@ -1,0 +1,230 @@
+/**
+ * Normalisation + admission rules for agent-reported patch metadata.
+ *
+ * `patches` is a deliberately GLOBAL, unscoped catalog table deduped on
+ * `(source, external_id)` — every tenant reads the same row, and
+ * `patch_approvals` / patch jobs hang off `patches.id`. Agent scan ingest is the
+ * only high-volume writer to it, so anything it puts in an identity-bearing
+ * column (`external_id`, `package_id`, `title`, `vendor`, `version`) is
+ * effectively shared state. Two consequences drive this module:
+ *
+ * 1. `package_id` and `external_id` are command-bearing, not decorative. The Go
+ *    agent resolves *which package to install* from them
+ *    (`resolvePatchInstallID` / `patchLocalID` in
+ *    `agent/internal/heartbeat/heartbeat.go`), and
+ *    `routes/devices/patches.ts` forwards `patches.package_id` verbatim into the
+ *    `install_patches` command payload. They must therefore be structurally
+ *    sane before they are allowed to create or update a shared row.
+ * 2. The column widths in `db/schema/patches.ts` are not enforced by the zod
+ *    request schemas, so an over-length value currently reaches Postgres and
+ *    raises `22001 value too long`, which aborts the whole scan transaction —
+ *    one malformed row takes down the entire submit for that device.
+ *
+ * The admission rules are deliberately narrow so no existing provider breaks:
+ * spaces stay legal (Apple `softwareupdate` labels such as
+ * `macOS Sonoma 14.5-23F79` are used verbatim as both externalId and packageId),
+ * and only control characters, option-like leading dashes and over-length
+ * identifiers are refused.
+ */
+
+/** Column widths from `apps/api/src/db/schema/patches.ts`. */
+export const PATCH_COLUMN_LIMITS = {
+  externalId: 255,
+  packageId: 256,
+  title: 500,
+  version: 64,
+  vendor: 255,
+  category: 100,
+} as const;
+
+/**
+ * `description` is an unbounded `text` column, so this is a policy cap rather
+ * than a schema limit: it bounds how much agent-supplied prose one shared row
+ * can carry when up to 5000 patches arrive per request.
+ */
+export const PATCH_DESCRIPTION_LIMIT = 8000;
+
+/** C0 controls + DEL. Never legitimate in an identifier; the injection-relevant class. */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\u0000-\u001f\u007f]/;
+
+export type PatchIdentityInput = {
+  source: string;
+  name: string;
+  externalId?: string | undefined;
+  kbNumber?: string | undefined;
+  packageId?: string | undefined;
+  version?: string | undefined;
+  vendor?: string | undefined;
+  category?: string | undefined;
+  description?: string | undefined;
+};
+
+export type NormalizedPatchIdentity = {
+  externalId: string;
+  packageId: string | null;
+  title: string;
+  version: string | null;
+  vendor: string | null;
+  category: string | null;
+  description: string | null;
+};
+
+export type PatchIdentityRejectionReason =
+  | 'empty_title'
+  | 'empty_external_id'
+  | 'external_id_control_chars'
+  | 'external_id_option_like'
+  | 'external_id_too_long'
+  | 'package_id_control_chars'
+  | 'package_id_option_like'
+  | 'package_id_too_long';
+
+export type PatchIdentityResult =
+  | { ok: true; value: NormalizedPatchIdentity }
+  | { ok: false; reason: PatchIdentityRejectionReason };
+
+function trimToNull(value: string | undefined | null): string | null {
+  const trimmed = (value ?? '').trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+function truncate(value: string | null, limit: number): string | null {
+  if (value === null) return null;
+  return value.length > limit ? value.slice(0, limit) : value;
+}
+
+function nullIfTooLong(value: string | null, limit: number): string | null {
+  if (value === null) return null;
+  return value.length > limit ? null : value;
+}
+
+/**
+ * An identifier that starts with `-` would be read as a flag by every package
+ * manager the agent shells out to (winget/choco/apt/yum/brew are invoked with
+ * an argv, so shell metacharacters are inert, but option injection is not).
+ *
+ * Checked per colon-separated segment, not just on the whole string: the agent
+ * splits provider-prefixed ids (`patchLocalID` / `splitPatchID` in
+ * `agent/internal/heartbeat/heartbeat.go`) and installs the *local* part, so
+ * `apple-softwareupdate:--all` passes a naive leading-dash test and still yields
+ * `--all` as the package to install.
+ */
+function isOptionLike(value: string): boolean {
+  return value.split(':').some((segment) => segment.startsWith('-'));
+}
+
+/**
+ * Derive the dedup key exactly as the ingest route always has: explicit
+ * `externalId`, else the KB number, else a composed `source:name:version`.
+ * Kept here so the admission checks below apply to the value that actually
+ * reaches the `(source, external_id)` conflict target.
+ */
+export function derivePatchExternalId(input: PatchIdentityInput): string {
+  return (
+    trimToNull(input.externalId) ??
+    trimToNull(input.kbNumber) ??
+    `${input.source}:${input.name.trim()}:${trimToNull(input.version) ?? 'latest'}`
+  );
+}
+
+/**
+ * Validate + normalise one agent-reported patch.
+ *
+ * Returns `ok: false` for a row that must not be admitted at all; the caller
+ * skips it and counts it rather than failing the batch, so one malformed entry
+ * cannot stop a device's whole patch scan from landing.
+ */
+export function normalizePatchIdentity(input: PatchIdentityInput): PatchIdentityResult {
+  const title = trimToNull(input.name);
+  if (title === null) {
+    return { ok: false, reason: 'empty_title' };
+  }
+
+  const externalId = derivePatchExternalId(input);
+  if (externalId === '') {
+    return { ok: false, reason: 'empty_external_id' };
+  }
+  if (CONTROL_CHARS.test(externalId)) {
+    return { ok: false, reason: 'external_id_control_chars' };
+  }
+  if (isOptionLike(externalId)) {
+    return { ok: false, reason: 'external_id_option_like' };
+  }
+  // Truncating instead would silently merge two distinct patches that share a
+  // 255-character prefix into one shared row, so an over-long key is refused.
+  if (externalId.length > PATCH_COLUMN_LIMITS.externalId) {
+    return { ok: false, reason: 'external_id_too_long' };
+  }
+
+  const packageId = trimToNull(input.packageId);
+  if (packageId !== null) {
+    if (CONTROL_CHARS.test(packageId)) {
+      return { ok: false, reason: 'package_id_control_chars' };
+    }
+    if (isOptionLike(packageId)) {
+      return { ok: false, reason: 'package_id_option_like' };
+    }
+    // Same reasoning as externalId: package_id selects what gets installed, so
+    // a truncated one is worse than none.
+    if (packageId.length > PATCH_COLUMN_LIMITS.packageId) {
+      return { ok: false, reason: 'package_id_too_long' };
+    }
+  }
+
+  return {
+    ok: true,
+    value: {
+      externalId,
+      packageId,
+      // `title`/`vendor`/`description` are matching or display surfaces where a
+      // truncated value is still better than losing the row.
+      title: truncate(title, PATCH_COLUMN_LIMITS.title) as string,
+      vendor: truncate(trimToNull(input.vendor), PATCH_COLUMN_LIMITS.vendor),
+      description: truncate(trimToNull(input.description), PATCH_DESCRIPTION_LIMIT),
+      // `version` and `category` are decision inputs — version drives the app
+      // pin comparison and category selects (terminal) ring category rules in
+      // `patchApprovalEvaluator`. A truncated value would silently compare or
+      // match as something it isn't, so an over-length one is dropped to NULL
+      // (no pin match, no category rule) instead.
+      version: nullIfTooLong(trimToNull(input.version), PATCH_COLUMN_LIMITS.version),
+      category: nullIfTooLong(trimToNull(input.category), PATCH_COLUMN_LIMITS.category),
+    },
+  };
+}
+
+export type AdmittedPatch<T> = { data: T; identity: NormalizedPatchIdentity };
+
+export type PatchAdmission<T> = {
+  admitted: AdmittedPatch<T>[];
+  rejected: number;
+  /** Bounded histogram of why rows were refused, for the audit trail. */
+  reasons: Partial<Record<PatchIdentityRejectionReason, number>>;
+};
+
+/**
+ * Admit a whole reported batch up front.
+ *
+ * Deliberately run BEFORE the tombstone sweep: the sweep marks a device's
+ * existing pending rows `missing` on the assumption that everything still
+ * applicable is about to be re-upserted. A row refused mid-loop would be swept
+ * but never re-reported, tombstoning a patch that is in fact still pending — so
+ * the caller needs the rejection count before it decides to sweep.
+ */
+export function admitPatchBatch<T extends PatchIdentityInput>(patchList: T[]): PatchAdmission<T> {
+  const admitted: AdmittedPatch<T>[] = [];
+  const reasons: Partial<Record<PatchIdentityRejectionReason, number>> = {};
+  let rejected = 0;
+
+  for (const data of patchList) {
+    const result = normalizePatchIdentity(data);
+    if (!result.ok) {
+      rejected++;
+      reasons[result.reason] = (reasons[result.reason] ?? 0) + 1;
+      continue;
+    }
+    admitted.push({ data, identity: result.value });
+  }
+
+  return { admitted, rejected, reasons };
+}

--- a/apps/api/src/routes/agents/patches.integration.test.ts
+++ b/apps/api/src/routes/agents/patches.integration.test.ts
@@ -354,6 +354,35 @@ describe('patch ingest — shared catalog metadata must not be clobbered (real P
     expect((await getDevicePatchRow(dev.id, keptId))?.status).toBe('pending');
   });
 
+  runDb('combined scan: a refused INSTALLED row also suppresses the full sweep', async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const dev = await insertDevice(env.organization.id, env.site.id);
+    const app = mountRoutes(env.organization.id, dev.agentId);
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const installedId = `itest.combined.installed.${stamp}`;
+
+    // Establish a genuinely-installed row via the combined endpoint.
+    await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches`, {
+      patches: [],
+      installed: [{
+        name: 'Installed Thing', source: 'third_party', externalId: installedId,
+        packageId: 'Installed.Thing', version: '1.0', installedAt: '2026-01-05T00:00:00Z',
+      }],
+    });
+    expect((await getDevicePatchRow(dev.id, installedId))?.status).toBe('installed');
+
+    // The combined route's sweep is markAllDevicePatchesMissing — it flips
+    // INSTALLED rows too — so a refusal on the installed list must suppress it.
+    // Gating on the pending list alone stranded this row at 'missing'.
+    const res = await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches`, {
+      patches: [],
+      installed: [{ name: 'Malformed', source: 'third_party', externalId: `itest.bad.${stamp}`, packageId: 'winget:--all' }],
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).rejected).toBe(1);
+    expect((await getDevicePatchRow(dev.id, installedId))?.status).toBe('installed');
+  });
+
   runDb('still accepts Apple softwareupdate labels, which legitimately contain spaces', async () => {
     const env = await setupTestEnvironment({ scope: 'organization' });
     const dev = await insertDevice(env.organization.id, env.site.id);

--- a/apps/api/src/routes/agents/patches.integration.test.ts
+++ b/apps/api/src/routes/agents/patches.integration.test.ts
@@ -76,6 +76,13 @@ async function putJson(app: Hono, orgId: string, path: string, body: unknown) {
   );
 }
 
+async function getPatchRow(externalId: string) {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db.select().from(patches).where(eq(patches.externalId, externalId));
+    return row ?? null;
+  });
+}
+
 async function getDevicePatchRow(deviceId: string, externalId: string) {
   return withSystemDbAccessContext(async () => {
     const [row] = await db
@@ -141,5 +148,227 @@ describe('patch ingest — installed inventory must not erase pending rows (real
     expect(healed?.status).toBe('installed');
     expect(healed?.installedVersion).toBe('2.55.0.3');
     expect(healed?.installedAt).not.toBeNull();
+  });
+});
+
+/**
+ * `patches` is a GLOBAL, un-tenanted catalog table deduped on
+ * `(source, external_id)`: every device that reports a colliding key writes the
+ * SAME row, and every tenant's UI, `patch_approvals` and patch jobs read it.
+ * The conflict-update classification (identity columns fill-only, operational
+ * columns refresh) is expressed as raw `COALESCE`/`CASE` fragments inside
+ * Drizzle's `onConflictDoUpdate`, which the mocked unit suite can only inspect
+ * as an object shape. These cases drive the real endpoints against Postgres so
+ * the fragments are proven to point the right way.
+ */
+describe('patch ingest — shared catalog metadata must not be clobbered (real Postgres)', () => {
+  runDb('keeps identity columns from the first report while operational columns keep refreshing', async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const first = await insertDevice(env.organization.id, env.site.id);
+    const second = await insertDevice(env.organization.id, env.site.id);
+    const externalId = `itest.clobber.${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    const firstRes = await putJson(
+      mountRoutes(env.organization.id, first.agentId),
+      env.organization.id,
+      `/agents/${first.agentId}/patches/pending`,
+      {
+        source: 'third_party',
+        patches: [{
+          name: 'Mozilla Firefox',
+          source: 'third_party',
+          externalId,
+          packageId: 'Mozilla.Firefox',
+          vendor: 'Mozilla',
+          version: '121.0',
+          severity: 'critical',
+          category: 'security',
+          requiresRestart: true,
+          description: 'Original vendor description',
+        }],
+      },
+    );
+    expect(firstRes.status).toBe(200);
+
+    // A second device reports the same (source, externalId) with entirely
+    // different metadata — the shape that used to rewrite the shared row.
+    const secondRes = await putJson(
+      mountRoutes(env.organization.id, second.agentId),
+      env.organization.id,
+      `/agents/${second.agentId}/patches/pending`,
+      {
+        source: 'third_party',
+        patches: [{
+          name: 'Totally Different Product',
+          source: 'third_party',
+          externalId,
+          packageId: 'Attacker.Package',
+          vendor: 'Someone Else',
+          version: '122.0',
+          severity: 'low',
+          category: 'application',
+          requiresRestart: false,
+          description: 'Rewritten description',
+        }],
+      },
+    );
+    expect(secondRes.status).toBe(200);
+
+    const row = await getPatchRow(externalId);
+    // Identity: unchanged by the second report.
+    expect(row?.packageId).toBe('Mozilla.Firefox');
+    expect(row?.title).toBe('Mozilla Firefox');
+    expect(row?.vendor).toBe('Mozilla');
+    // Operational: refreshed, exactly as the legitimate rescan flow needs.
+    expect(row?.version).toBe('122.0');
+    expect(row?.severity).toBe('low');
+    expect(row?.category).toBe('application');
+    expect(row?.requiresReboot).toBe(false);
+    expect(row?.description).toBe('Rewritten description');
+  });
+
+  runDb('does not blank operational columns when a later scan simply omits them', async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const dev = await insertDevice(env.organization.id, env.site.id);
+    const app = mountRoutes(env.organization.id, dev.agentId);
+    const externalId = `itest.nulldown.${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    // Deliberately a package the curated third-party catalog does NOT know, so
+    // this case isolates the null-downgrade guard from catalog enrichment
+    // (which legitimately overwrites title/vendor/category on a hit).
+    const packageId = 'AcmeCorp.InternalTool';
+    await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/pending`, {
+      source: 'third_party',
+      patches: [{
+        name: 'Acme Internal Tool', source: 'third_party', externalId, packageId,
+        version: '2.55.0', severity: 'critical', category: 'security',
+        requiresRestart: true, description: 'Security fix',
+      }],
+    });
+
+    // A sparser rescan: no description, no category, no reboot flag, and the
+    // agent's "I couldn't classify this" severity of 'unknown'.
+    const res = await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/pending`, {
+      source: 'third_party',
+      patches: [{ name: 'Acme Internal Tool', source: 'third_party', externalId, packageId, version: '2.55.1', severity: 'unknown' }],
+    });
+    expect(res.status).toBe(200);
+
+    const row = await getPatchRow(externalId);
+    expect(row?.description).toBe('Security fix');
+    expect(row?.category).toBe('security');
+    expect(row?.requiresReboot).toBe(true);
+    expect(row?.severity).toBe('critical');
+    // The one thing the sparser scan did report still lands.
+    expect(row?.version).toBe('2.55.1');
+  });
+
+  runDb('lets a later scan FILL columns the first report left empty', async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const dev = await insertDevice(env.organization.id, env.site.id);
+    const app = mountRoutes(env.organization.id, dev.agentId);
+    const externalId = `itest.fill.${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/pending`, {
+      source: 'microsoft',
+      patches: [{ name: 'Cumulative Update', source: 'microsoft', externalId }],
+    });
+    expect((await getPatchRow(externalId))?.packageId).toBeNull();
+
+    await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/pending`, {
+      source: 'microsoft',
+      patches: [{
+        name: 'Cumulative Update', source: 'microsoft', externalId,
+        packageId: 'KB5034441', vendor: 'Microsoft', version: '10.0.1',
+      }],
+    });
+
+    const row = await getPatchRow(externalId);
+    expect(row?.packageId).toBe('KB5034441');
+    expect(row?.vendor).toBe('Microsoft');
+    expect(row?.version).toBe('10.0.1');
+  });
+
+  runDb('installed inventory cannot drag the shared row back to the installed version', async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const dev = await insertDevice(env.organization.id, env.site.id);
+    const app = mountRoutes(env.organization.id, dev.agentId);
+    const externalId = `itest.installed.${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/pending`, {
+      source: 'third_party',
+      patches: [{ name: 'Git', source: 'third_party', externalId, packageId: 'Git.Git', version: '2.55.0.3', vendor: 'Git' }],
+    });
+
+    // The paired installed submit carries the *installed* version and no catalog
+    // enrichment at all — it is the lowest-authority writer on this row.
+    const res = await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/installed`, {
+      installed: [{
+        name: 'Something Else', source: 'third_party', externalId,
+        packageId: 'Other.Package', vendor: 'Other', version: '2.51.0.2',
+        category: 'application', installedAt: '2026-01-05T00:00:00Z',
+      }],
+    });
+    expect(res.status).toBe(200);
+
+    const row = await getPatchRow(externalId);
+    expect(row?.version).toBe('2.55.0.3');
+    expect(row?.title).toBe('Git');
+    expect(row?.packageId).toBe('Git.Git');
+    expect(row?.vendor).toBe('Git');
+    // The per-device observation is tenant-scoped and still records what is
+    // actually installed on this box.
+    expect((await getDevicePatchRow(dev.id, externalId))?.installedVersion).toBe('2.51.0.2');
+  });
+
+  runDb('refuses a malformed row, still ingests the rest, and skips the sweep that cycle', async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const dev = await insertDevice(env.organization.id, env.site.id);
+    const app = mountRoutes(env.organization.id, dev.agentId);
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const keptId = `itest.kept.${stamp}`;
+    const freshId = `itest.fresh.${stamp}`;
+
+    await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/pending`, {
+      source: 'third_party',
+      patches: [{ name: 'Kept', source: 'third_party', externalId: keptId, packageId: 'Kept.Pkg' }],
+    });
+    expect((await getDevicePatchRow(dev.id, keptId))?.status).toBe('pending');
+
+    const res = await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/pending`, {
+      source: 'third_party',
+      patches: [
+        { name: 'Fresh', source: 'third_party', externalId: freshId, packageId: 'Fresh.Pkg' },
+        // An option-like local segment behind a provider prefix: the agent
+        // splits on ':' and would install `--all`.
+        { name: 'Malformed', source: 'third_party', externalId: `itest.bad.${stamp}`, packageId: 'winget:--all' },
+      ],
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, pending: 1, rejected: 1 });
+
+    // The good row landed...
+    expect((await getDevicePatchRow(dev.id, freshId))?.status).toBe('pending');
+    // ...and the sweep was skipped, so the earlier row was not tombstoned by a
+    // scan we know to be incomplete.
+    expect((await getDevicePatchRow(dev.id, keptId))?.status).toBe('pending');
+  });
+
+  runDb('still accepts Apple softwareupdate labels, which legitimately contain spaces', async () => {
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const dev = await insertDevice(env.organization.id, env.site.id);
+    const app = mountRoutes(env.organization.id, dev.agentId);
+    const externalId = `macOS Sonoma 14.5-23F79 ${Date.now()}`;
+
+    const res = await putJson(app, env.organization.id, `/agents/${dev.agentId}/patches/pending`, {
+      source: 'apple',
+      patches: [{
+        name: 'macOS Sonoma 14.5', source: 'apple', externalId,
+        packageId: `apple-softwareupdate:${externalId}`, version: '14.5',
+      }],
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, pending: 1, rejected: 0 });
+    expect((await getPatchRow(externalId))?.packageId).toBe(`apple-softwareupdate:${externalId}`);
   });
 });

--- a/apps/api/src/routes/agents/patches.test.ts
+++ b/apps/api/src/routes/agents/patches.test.ts
@@ -4,6 +4,7 @@ import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { devices, patches } from '../../db/schema';
 import * as enrichmentModule from '../../services/thirdPartyEnrichment';
+import * as auditEvents from '../../services/auditEvents';
 import * as wingetWorker from '../../jobs/wingetReleaseTestWorker';
 import { patchesRoutes } from './patches';
 
@@ -347,6 +348,59 @@ describe('PUT /agents/:id/patches - third-party fields', () => {
     }));
 
     vi.mocked(enrichmentModule.enrichFromCatalog).mockRestore();
+  });
+
+  it('converts download size to whole MB and clamps it to the integer column ceiling', async () => {
+    async function submitSize(size: number | undefined) {
+      patchRows = [];
+      await app.request(`/agents/${AGENT_ID}/patches`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          patches: [{
+            name: 'Sized', source: 'third_party', externalId: 'sized-1',
+            packageId: 'Sized.Pkg', ...(size === undefined ? {} : { size }),
+          }],
+        }),
+      });
+      return patchRows[0]?.downloadSizeMb;
+    }
+
+    expect(await submitSize(5 * 1024 * 1024)).toBe(5);
+    // Rounds up: a partial megabyte still reports as one.
+    expect(await submitSize(1)).toBe(1);
+    expect(await submitSize(undefined)).toBeNull();
+    expect(await submitSize(0)).toBeNull();
+    // `download_size_mb` is a Postgres `integer` and the request schema puts no
+    // upper bound on `size`, so an absurd byte count must be clamped rather
+    // than overflowing the column and aborting the whole scan transaction.
+    expect(await submitSize(Number.MAX_SAFE_INTEGER)).toBe(2147483647);
+  });
+
+  it('audits refused rows with a reason histogram summed across both lists', async () => {
+    const res = await app.request(`/agents/${AGENT_ID}/patches`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        // Both lists refuse a row for the SAME reason. Merging the two
+        // histograms by object spread would drop one of the counts.
+        patches: [{ name: 'Bad pending', source: 'third_party', externalId: 'bad-p', packageId: 'winget:--all' }],
+        installed: [{ name: 'Bad installed', source: 'third_party', externalId: 'bad-i', packageId: 'winget:--all' }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(expect.objectContaining({ success: true, rejected: 2 }));
+    expect(auditEvents.writeAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'agent.patches.submit',
+        details: expect.objectContaining({
+          rejectedCount: 2,
+          rejectedReasons: { package_id_option_like: 2 },
+        }),
+      }),
+    );
   });
 
   it('persists agent-supplied version into patches.version', async () => {

--- a/apps/api/src/routes/agents/patches.test.ts
+++ b/apps/api/src/routes/agents/patches.test.ts
@@ -288,9 +288,25 @@ describe('PUT /agents/:id/patches - third-party fields', () => {
       packageId: 'Mozilla.Firefox',
       source: 'third_party',
     }));
-    expect(patchUpsertSet).toEqual(expect.objectContaining({
-      vendor: 'Mozilla',
-      packageId: 'Mozilla.Firefox',
+    // `patches` is a global, un-tenanted catalog row, so an uncurated (raw
+    // agent) report may only FILL the identity columns, never rewrite them: the
+    // conflict update has to render as COALESCE(existing, incoming) rather than
+    // a bare assignment. The real SQL semantics are proven against Postgres in
+    // patches.integration.test.ts; this only pins the generated shape.
+    expect(patchUpsertSet?.packageId).toEqual(expect.objectContaining({
+      op: 'sql',
+      strings: ['COALESCE(', ', ', ')'],
+      values: ['patches.packageId', 'Mozilla.Firefox'],
+    }));
+    expect(patchUpsertSet?.vendor).toEqual(expect.objectContaining({
+      op: 'sql',
+      strings: ['COALESCE(', ', ', ')'],
+      values: ['patches.vendor', 'Mozilla'],
+    }));
+    // Title is not rewritten at all without curation — it keeps the stored value.
+    expect(patchUpsertSet?.title).toEqual(expect.objectContaining({
+      op: 'sql',
+      values: ['patches.title'],
     }));
   });
 
@@ -506,7 +522,7 @@ describe('split patch ingest endpoints', () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ success: true, pending: 0 });
+    expect(body).toEqual({ success: true, pending: 0, rejected: 0 });
     expect(tx.update).toHaveBeenCalledWith(tables.devicePatches);
     expect(tx.insert).not.toHaveBeenCalled();
 
@@ -530,7 +546,7 @@ describe('split patch ingest endpoints', () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ success: true, pending: 0 });
+    expect(body).toEqual({ success: true, pending: 0, rejected: 0 });
     expect(tx.update).not.toHaveBeenCalled();
     expect(tx.insert).not.toHaveBeenCalled();
   });
@@ -556,7 +572,7 @@ describe('split patch ingest endpoints', () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ success: true, installed: 1, ignored: 0 });
+    expect(body).toEqual({ success: true, installed: 1, ignored: 0, rejected: 0 });
     expect(tx.update).not.toHaveBeenCalled();
     expect(tx.insert).toHaveBeenCalledWith(tables.patches);
     expect(tx.insert).toHaveBeenCalledWith(tables.devicePatches);
@@ -583,7 +599,7 @@ describe('split patch ingest endpoints', () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ success: true, installed: 0, ignored: 1 });
+    expect(body).toEqual({ success: true, installed: 0, ignored: 1, rejected: 0 });
     expect(tx.update).not.toHaveBeenCalled();
     expect(tx.insert).not.toHaveBeenCalled();
   });
@@ -634,7 +650,7 @@ describe('PUT /agents/:id/patches/pending - full scan coverage scoping (#2217)',
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ success: true, pending: 1 });
+    expect(body).toEqual({ success: true, pending: 1, rejected: 0 });
 
     expect(tx.update).toHaveBeenCalledTimes(1);
     expect(tx.update).toHaveBeenCalledWith(tables.devicePatches);
@@ -692,7 +708,7 @@ describe('PUT /agents/:id/patches/pending - full scan coverage scoping (#2217)',
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ success: true, pending: 0 });
+    expect(body).toEqual({ success: true, pending: 0, rejected: 0 });
     expect(tx.update).not.toHaveBeenCalled();
     expect(tx.insert).not.toHaveBeenCalled();
   });

--- a/apps/api/src/routes/agents/patches.ts
+++ b/apps/api/src/routes/agents/patches.ts
@@ -10,7 +10,7 @@ import { envInt } from '../../utils/envInt';
 import { enrichFromCatalog } from '../../services/thirdPartyEnrichment';
 import { submitInstalledPatchesSchema, submitPatchesSchema, submitPendingPatchesSchema } from './schemas';
 import { inferPatchOsType, parseDate, sanitizeDate } from './helpers';
-import { admitPatchBatch, type AdmittedPatch, type PatchAdmission } from './patchIngestIdentity';
+import { admitPatchBatch, mergeRejectionReasons, type AdmittedPatch, type PatchAdmission } from './patchIngestIdentity';
 import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 type PendingPatchData = z.infer<typeof submitPendingPatchesSchema>['patches'][number];
@@ -532,7 +532,12 @@ patchesRoutes.put('/:id/patches', zValidator('json', submitPatchesSchema), async
   let pendingCount = 0;
   let installedCount = 0;
   await db.transaction(async (tx) => {
-    if (sweepIsSafe(pending)) {
+    // Gated on BOTH admissions, unlike the pending-only route: this sweep is
+    // markAllDevicePatchesMissing, which flips *installed* rows to 'missing'
+    // too, on the assumption that both lists below fully restate the device.
+    // A refused installed row is never re-upserted, so sweeping on a partial
+    // installed list would strand a genuinely-installed patch at 'missing'.
+    if (sweepIsSafe(pending) && sweepIsSafe(installed)) {
       await markAllDevicePatchesMissing(tx, device.id);
     } else {
       console.warn(`[PATCHES] Agent ${agentId} combined scan had refused rows — skipping tombstone sweep this cycle`);
@@ -557,7 +562,7 @@ patchesRoutes.put('/:id/patches', zValidator('json', submitPatchesSchema), async
       pendingCount,
       installedCount,
       rejectedCount,
-      rejectedReasons: { ...pending.reasons, ...installed.reasons },
+      rejectedReasons: mergeRejectionReasons(pending.reasons, installed.reasons),
       ignoredLinuxPackageCount: installed.admitted.length - installedCount,
     },
   });

--- a/apps/api/src/routes/agents/patches.ts
+++ b/apps/api/src/routes/agents/patches.ts
@@ -10,12 +10,77 @@ import { envInt } from '../../utils/envInt';
 import { enrichFromCatalog } from '../../services/thirdPartyEnrichment';
 import { submitInstalledPatchesSchema, submitPatchesSchema, submitPendingPatchesSchema } from './schemas';
 import { inferPatchOsType, parseDate, sanitizeDate } from './helpers';
+import { admitPatchBatch, type AdmittedPatch, type PatchAdmission } from './patchIngestIdentity';
 import { requireAgentRole } from '../../middleware/requireAgentRole';
 
 type PendingPatchData = z.infer<typeof submitPendingPatchesSchema>['patches'][number];
 type InstalledPatchData = z.infer<typeof submitInstalledPatchesSchema>['installed'][number];
 type PatchIngestDevice = { id: string; orgId: string; osType: string | null };
 type PatchIngestExecutor = Pick<Database, 'insert' | 'update'>;
+/**
+ * A refused row means the sweep can no longer be trusted for this submission:
+ * the sweep tombstones every pending row for the covered sources on the
+ * assumption that everything still applicable is about to be re-upserted, and a
+ * row we refused to ingest is not. Skipping the sweep leaves stale rows for one
+ * cycle (self-healing on the next clean scan); sweeping anyway would tombstone
+ * a patch that is genuinely still pending. Same conservatism as the
+ * covered-zero-sources branch below (#2217).
+ */
+function sweepIsSafe(admission: PatchAdmission<unknown>): boolean {
+  return admission.rejected === 0;
+}
+
+function logRejections(agentId: string, kind: string, admission: PatchAdmission<unknown>): void {
+  if (admission.rejected === 0) return;
+  console.warn(
+    `[PATCHES] Agent ${agentId} ${kind}: refused ${admission.rejected} malformed row(s) ` +
+    `${JSON.stringify(admission.reasons)}`,
+  );
+}
+
+/**
+ * `patches` rows are GLOBAL: the table is deduped on `(source, external_id)`
+ * with no tenant column, so every device that reports a colliding key writes the
+ * same row, and every tenant's UI, `patch_approvals` and patch jobs read it.
+ * The two upserts below therefore classify each column:
+ *
+ * - **Volatile / operational** (`severity`, `category`, `description`,
+ *   `requires_reboot`, `os_types`): these genuinely change between scans and
+ *   keep refreshing. They are only hardened against *null downgrades* — a scan
+ *   that omits a field must not blank a value an earlier scan established.
+ * - **Identity-bearing** (`title`, `vendor`, `package_id`, `version`): these say
+ *   *what the row is* and, for `package_id`, what actually gets installed
+ *   (`routes/devices/patches.ts` forwards it into the `install_patches` command
+ *   payload). Raw agent strings may only **fill** them, never rewrite them;
+ *   overwriting is reserved for server-side catalog enrichment.
+ *
+ * `patches.version` is the one asymmetric case. On the pending path it is the
+ * *available* upgrade version and legitimately advances, so it keeps updating.
+ * The installed path carries the *currently-installed* version — a different
+ * value with the same shape — so letting it write this column drags the shared
+ * row backwards (and defeats the version pins in `patchApprovalEvaluator`); the
+ * installed path may only fill it when unset.
+ */
+
+/**
+ * `download_size_mb` is a Postgres `integer` and the request schema puts no
+ * upper bound on `size`, so an absurd byte count overflows the column and aborts
+ * the whole scan transaction. Clamp instead of failing the batch.
+ */
+function toDownloadSizeMb(size: number | undefined): number | null {
+  if (!size || !Number.isFinite(size) || size <= 0) return null;
+  return Math.min(Math.ceil(size / (1024 * 1024)), 2147483647);
+}
+
+/** Keep the stored value; only write when the column is currently NULL. */
+function fillIfNull(column: unknown, value: string | null) {
+  return value === null ? sql`${column}` : sql`COALESCE(${column}, ${value})`;
+}
+
+/** Refresh when this scan reported a value; keep the stored one when it didn't. */
+function updateIfReported<T>(column: unknown, value: T | null | undefined) {
+  return value === null || value === undefined ? sql`${column}` : value;
+}
 
 // Derive vendor from package id; ignore agent-supplied vendor for winget-style ids.
 function deriveVendor(packageId: string | null | undefined, fallback: string | null | undefined): string | null {
@@ -81,22 +146,25 @@ async function markPendingDevicePatchesMissing(
 async function upsertPendingPatches(
   executor: PatchIngestExecutor,
   device: PatchIngestDevice,
-  patchList: PendingPatchData[],
-): Promise<void> {
-  for (const patchData of patchList) {
-    const externalId = patchData.externalId ||
-      patchData.kbNumber ||
-      `${patchData.source}:${patchData.name}:${patchData.version || 'latest'}`;
+  admitted: AdmittedPatch<PendingPatchData>[],
+): Promise<number> {
+  let processed = 0;
+  for (const { data: patchData, identity } of admitted) {
+    const { externalId, packageId, title, version, vendor, category, description } = identity;
     const inferredOsType = inferPatchOsType(patchData.source, device.osType);
-    const derivedVendor = deriveVendor(patchData.packageId, patchData.vendor);
+    const derivedVendor = deriveVendor(packageId, vendor);
     const enriched = await enrichFromCatalog({
       source: patchData.source,
-      packageId: patchData.packageId ?? null,
-      title: patchData.name,
+      packageId: packageId,
+      title: title,
       vendor: derivedVendor,
       severity: patchData.severity ?? null,
-      category: patchData.category ?? null,
+      category: category,
     });
+    // `matchedCatalogId` is non-null exactly when title/vendor/category came
+    // from the server-side catalog rather than the agent's own strings — the
+    // only case in which an identity-bearing column may be rewritten.
+    const curated = enriched.matchedCatalogId !== null;
 
     const [patch] = await executor
       .insert(patches)
@@ -104,28 +172,39 @@ async function upsertPendingPatches(
         source: patchData.source,
         externalId: externalId,
         title: enriched.title,
-        description: patchData.description || null,
+        description: description,
         severity: enriched.severity ?? 'unknown',
         category: enriched.category,
         releaseDate: sanitizeDate(patchData.releaseDate),
         requiresReboot: patchData.requiresRestart || false,
-        downloadSizeMb: patchData.size ? Math.ceil(patchData.size / (1024 * 1024)) : null,
+        downloadSizeMb: toDownloadSizeMb(patchData.size),
         vendor: enriched.vendor,
-        packageId: patchData.packageId ?? null,
-        version: patchData.version ?? null,
+        packageId: packageId,
+        version: version,
         ...(inferredOsType ? { osTypes: [inferredOsType] } : {})
       })
       .onConflictDoUpdate({
         target: [patches.source, patches.externalId],
         set: {
-          title: enriched.title,
-          description: patchData.description || null,
-          severity: enriched.severity ?? 'unknown',
-          category: enriched.category,
-          requiresReboot: patchData.requiresRestart || false,
-          vendor: enriched.vendor ?? sql`${patches.vendor}`,
-          packageId: patchData.packageId ?? sql`${patches.packageId}`,
-          version: patchData.version ?? sql`${patches.version}`,
+          // Identity: curated catalog values may rewrite, raw agent strings may not.
+          title: curated ? enriched.title : sql`${patches.title}`,
+          vendor: curated
+            ? (enriched.vendor ?? sql`${patches.vendor}`)
+            : fillIfNull(patches.vendor, enriched.vendor),
+          packageId: fillIfNull(patches.packageId, packageId),
+          // Volatile: refresh, but never blank out what an earlier scan set.
+          description: updateIfReported(patches.description, description),
+          // `'unknown'` is the agent's "I couldn't tell", not an assessment —
+          // treat it as unreported so a scan that can't classify a patch doesn't
+          // reset a severity an earlier scan (or the CVE enrichment worker,
+          // which only ever raises severity) established.
+          severity: enriched.severity && enriched.severity !== 'unknown'
+            ? enriched.severity
+            : sql`COALESCE(${patches.severity}, 'unknown'::patch_severity)`,
+          category: updateIfReported(patches.category, enriched.category),
+          requiresReboot: updateIfReported(patches.requiresReboot, patchData.requiresRestart),
+          // The available upgrade version legitimately advances between scans.
+          version: updateIfReported(patches.version, version),
           ...(inferredOsType
             ? {
                 osTypes: sql`CASE
@@ -146,13 +225,13 @@ async function upsertPendingPatches(
 
     if (
       enriched.matchedCatalogId &&
-      patchData.version &&
+      version &&
       process.env.ENABLE_AI_PATCH_TESTING === '1'
     ) {
       // Fire-and-forget - don't block the patch submit on test queueing.
       enqueueWingetReleaseTest({
         catalogId: enriched.matchedCatalogId,
-        version: patchData.version,
+        version: version,
       }).catch((err) => {
         console.error('[ReleaseTest] enqueue failed', err);
       });
@@ -175,16 +254,18 @@ async function upsertPendingPatches(
           updatedAt: new Date()
         }
       });
+    processed++;
   }
+  return processed;
 }
 
 async function upsertInstalledPatches(
   executor: PatchIngestExecutor,
   device: PatchIngestDevice,
-  patchList: InstalledPatchData[],
+  admitted: AdmittedPatch<InstalledPatchData>[],
 ): Promise<number> {
   let processed = 0;
-  for (const patchData of patchList) {
+  for (const { data: patchData, identity } of admitted) {
     // Linux package-manager inventories are owned by software_inventory. They
     // are not installed patch/update records and must not be allowed to flip
     // actionable Linux update rows from pending to installed.
@@ -192,32 +273,35 @@ async function upsertInstalledPatches(
       continue;
     }
 
-    const externalId = patchData.externalId ||
-      patchData.kbNumber ||
-      `${patchData.source}:${patchData.name}:${patchData.version || 'latest'}`;
+    const { externalId, packageId, title, version, vendor, category } = identity;
     const inferredOsType = inferPatchOsType(patchData.source, device.osType);
+    const derivedVendor = deriveVendor(packageId, vendor);
 
     const [patch] = await executor
       .insert(patches)
       .values({
         source: patchData.source,
         externalId: externalId,
-        title: patchData.name,
+        title: title,
         severity: 'unknown',
-        category: patchData.category || null,
-        vendor: deriveVendor(patchData.packageId, patchData.vendor),
-        packageId: patchData.packageId ?? null,
-        version: patchData.version ?? null,
+        category: category,
+        vendor: derivedVendor,
+        packageId: packageId,
+        version: version,
         ...(inferredOsType ? { osTypes: [inferredOsType] } : {})
       })
       .onConflictDoUpdate({
         target: [patches.source, patches.externalId],
         set: {
-          title: patchData.name,
-          category: patchData.category || null,
-          vendor: deriveVendor(patchData.packageId, patchData.vendor) ?? sql`${patches.vendor}`,
-          packageId: patchData.packageId ?? sql`${patches.packageId}`,
-          version: patchData.version ?? sql`${patches.version}`,
+          // Installed inventory is the lowest-authority writer on this shared
+          // row: it carries no catalog enrichment, and its `version` is the
+          // *installed* version rather than the available one. It may only fill
+          // columns that are still unset — never rewrite them. `title` is NOT
+          // NULL, so it is simply never updated from this path.
+          category: fillIfNull(patches.category, category),
+          vendor: fillIfNull(patches.vendor, derivedVendor),
+          packageId: fillIfNull(patches.packageId, packageId),
+          version: fillIfNull(patches.version, version),
           ...(inferredOsType
             ? {
                 osTypes: sql`CASE
@@ -258,7 +342,7 @@ async function upsertInstalledPatches(
         patchId: patch.id,
         status: 'installed',
         installedAt: installedAt,
-        installedVersion: patchData.version || null,
+        installedVersion: version,
         lastCheckedAt: new Date()
       })
       .onConflictDoUpdate({
@@ -266,7 +350,7 @@ async function upsertInstalledPatches(
         set: {
           status: sql`CASE WHEN ${devicePatches.status} = 'pending' THEN ${devicePatches.status} ELSE 'installed' END`,
           installedAt: sql`CASE WHEN ${devicePatches.status} = 'pending' THEN ${devicePatches.installedAt} ELSE ${installedAtParam} END`,
-          installedVersion: patchData.version || null,
+          installedVersion: version,
           lastCheckedAt: new Date(),
           updatedAt: new Date()
         }
@@ -328,9 +412,15 @@ patchesRoutes.put('/:id/patches/pending', zValidator('json', submitPendingPatche
   }
 
   const sources = data.source ? [data.source] : uniqueSourcesFromPendingPatches(data.patches);
+  // Admit BEFORE the sweep — see sweepIsSafe.
+  const pending = admitPatchBatch(data.patches);
+  logRejections(agentId, 'pending scan', pending);
 
+  let pendingCount = 0;
   await db.transaction(async (tx) => {
-    if (data.full) {
+    if (!sweepIsSafe(pending)) {
+      console.warn(`[PATCHES] Agent ${agentId} pending scan had refused rows — skipping tombstone sweep this cycle`);
+    } else if (data.full) {
       if (data.coveredSources === undefined) {
         // Legacy agents send full scans without coverage info: sweep all sources.
         // Log the path so an operator can tell a legacy sweep-all from a
@@ -354,7 +444,7 @@ patchesRoutes.put('/:id/patches/pending', zValidator('json', submitPendingPatche
     } else if (sources.length > 0) {
       await markPendingDevicePatchesMissing(tx, device.id, sources);
     }
-    await upsertPendingPatches(tx, device, data.patches);
+    pendingCount = await upsertPendingPatches(tx, device, pending.admitted);
   });
 
   await pruneStaleTombstones(db, device.id, device.orgId);
@@ -367,14 +457,16 @@ patchesRoutes.put('/:id/patches/pending', zValidator('json', submitPendingPatche
     resourceType: 'device',
     resourceId: device.id,
     details: {
-      pendingCount: data.patches.length,
+      pendingCount,
+      rejectedCount: pending.rejected,
+      rejectedReasons: pending.reasons,
       source: data.source ?? null,
       full: data.full,
       coveredSources: data.coveredSources ?? null,
     },
   });
 
-  return c.json({ success: true, pending: data.patches.length });
+  return c.json({ success: true, pending: pendingCount, rejected: pending.rejected });
 });
 
 patchesRoutes.put('/:id/patches/installed', zValidator('json', submitInstalledPatchesSchema), async (c) => {
@@ -388,9 +480,12 @@ patchesRoutes.put('/:id/patches/installed', zValidator('json', submitInstalledPa
     return c.json({ error: 'Device not found' }, 404);
   }
 
+  const installed = admitPatchBatch(data.installed);
+  logRejections(agentId, 'installed inventory', installed);
+
   let installedCount = 0;
   await db.transaction(async (tx) => {
-    installedCount = await upsertInstalledPatches(tx, device, data.installed);
+    installedCount = await upsertInstalledPatches(tx, device, installed.admitted);
   });
 
   writeAuditEvent(c, {
@@ -402,11 +497,18 @@ patchesRoutes.put('/:id/patches/installed', zValidator('json', submitInstalledPa
     resourceId: device.id,
     details: {
       installedCount,
-      ignoredLinuxPackageCount: data.installed.length - installedCount,
+      rejectedCount: installed.rejected,
+      rejectedReasons: installed.reasons,
+      ignoredLinuxPackageCount: installed.admitted.length - installedCount,
     },
   });
 
-  return c.json({ success: true, installed: installedCount, ignored: data.installed.length - installedCount });
+  return c.json({
+    success: true,
+    installed: installedCount,
+    ignored: installed.admitted.length - installedCount,
+    rejected: installed.rejected,
+  });
 });
 
 patchesRoutes.put('/:id/patches', zValidator('json', submitPatchesSchema), async (c) => {
@@ -421,11 +523,22 @@ patchesRoutes.put('/:id/patches', zValidator('json', submitPatchesSchema), async
     return c.json({ error: 'Device not found' }, 404);
   }
 
+  const pending = admitPatchBatch(data.patches);
+  const installed = admitPatchBatch(data.installed ?? []);
+  logRejections(agentId, 'combined scan', pending);
+  logRejections(agentId, 'combined scan (installed)', installed);
+  const rejectedCount = pending.rejected + installed.rejected;
+
+  let pendingCount = 0;
   let installedCount = 0;
   await db.transaction(async (tx) => {
-    await markAllDevicePatchesMissing(tx, device.id);
-    await upsertPendingPatches(tx, device, data.patches);
-    installedCount = await upsertInstalledPatches(tx, device, data.installed ?? []);
+    if (sweepIsSafe(pending)) {
+      await markAllDevicePatchesMissing(tx, device.id);
+    } else {
+      console.warn(`[PATCHES] Agent ${agentId} combined scan had refused rows — skipping tombstone sweep this cycle`);
+    }
+    pendingCount = await upsertPendingPatches(tx, device, pending.admitted);
+    installedCount = await upsertInstalledPatches(tx, device, installed.admitted);
   });
 
   // Prune stale tombstones after the scan commits. Outside the txn on purpose:
@@ -441,16 +554,19 @@ patchesRoutes.put('/:id/patches', zValidator('json', submitPatchesSchema), async
     resourceType: 'device',
     resourceId: device.id,
     details: {
-      pendingCount: data.patches.length,
+      pendingCount,
       installedCount,
-      ignoredLinuxPackageCount: submittedInstalledCount - installedCount,
+      rejectedCount,
+      rejectedReasons: { ...pending.reasons, ...installed.reasons },
+      ignoredLinuxPackageCount: installed.admitted.length - installedCount,
     },
   });
 
   return c.json({
     success: true,
-    pending: data.patches.length,
+    pending: pendingCount,
     installed: installedCount,
-    ignored: submittedInstalledCount - installedCount
+    ignored: installed.admitted.length - installedCount,
+    rejected: rejectedCount
   });
 });


### PR DESCRIPTION
## What

Agent patch-scan ingest (`apps/api/src/routes/agents/patches.ts`) upserts into `patches` — a deliberately **global, un-tenanted** catalog table deduped on `(source, external_id)`. Both the pending and installed upserts rewrote every metadata column on conflict, so any device reporting a colliding key replaced the metadata that every tenant's UI, `patch_approvals` and patch jobs read from that shared row.

Inconsistent or untrusted agent-reported metadata could therefore overwrite an existing shared catalog row's identity. That matters most for `package_id`, which is not decorative:

- `routes/devices/patches.ts` forwards `patches.package_id` verbatim into the `install_patches` command payload, and the agent resolves *which package to install* from it (`resolvePatchInstallID` / `patchLocalID`).
- `packageId` + `version` drive the app **block/pin** rules in `patchApprovalEvaluator`.

No new columns and no migration. Everything stays inside the existing single upsert — this is hot-path ingest (up to 5000 rows per request), so there are no added per-row queries.

## The classification

| Class | Columns | Rule |
|---|---|---|
| Identity | `title`, `vendor`, `package_id`, `version` | A raw agent report may **fill** these, never rewrite them. Overwriting is reserved for server-side catalog enrichment (`matchedCatalogId != null`). |
| Operational | `severity`, `category`, `description`, `requires_reboot`, `os_types` | Keep refreshing — that flow is the whole point of a rescan — but no longer **null-downgrade** when a scan simply omits a field. |

Two specifics worth calling out:

- **`severity: 'unknown'`** is the agent's "I couldn't classify this", not an assessment. It no longer resets a severity an earlier scan — or `cveEnrichmentWorker`, which only ever *raises* severity — established.
- **The installed path is the lowest-authority writer.** It carries no enrichment, and its `version` is the *installed* version — a semantically different value landing in the same column. It previously dragged the shared row's available version backwards on every scan cycle (visible in the pre-existing `#2725` integration case: pending reports `2.55.0.3`, the paired installed submit reported `2.51.0.2` and overwrote it). It may now only fill.

## Batch-abort hardening

Three ways one malformed row could abort a whole device's scan transaction, plus narrow structural admission checks on the command-bearing identifiers:

- Reject control characters, option-like identifiers and over-length values in `external_id` / `package_id`. Checked **per colon-separated segment**, because the agent splits provider-prefixed ids and installs the local part — `apple-softwareupdate:--all` passes a naive leading-dash test. **Spaces stay legal**: Apple `softwareupdate` labels (`macOS Sonoma 14.5-23F79`) contain them and are used verbatim as both ids. There is an explicit regression test for this.
- `sanitizeDate` accepted impossible calendar dates (`2026-02-31`) — JS `Date` rolls them over silently and Postgres then raised `22008`.
- `download_size_mb` is clamped instead of overflowing the `integer` column.
- Over-length `version` / `category` become `NULL` rather than a truncated value that would compare or match as something it isn't. `title` / `vendor` / `description` are still truncated — losing the row would be worse.

Malformed rows are **skipped and counted** (response `rejected`, plus a bounded reason histogram in the audit event) rather than failing the batch. Admission runs **before** the tombstone sweep, and a scan with refused rows skips the sweep entirely — otherwise it would tombstone a patch it declined to re-ingest. Same conservatism as the covered-zero-sources branch from #2217.

## Provider compatibility

winget / chocolatey / apt / yum / homebrew / apple / windows-update dedup behavior is unchanged — the conflict target and the derived `external_id` precedence (explicit → `kbNumber` → composed) are untouched.

## Tests

- `patchIngestIdentity.test.ts` (new, 25) — pure admission/normalization: derivation precedence, the Apple-spaces regression guard, per-segment option-injection, the truncate-vs-null length policy, and the batch histogram.
- `helpers.patchSource.test.ts` — `sanitizeDate` calendar-rollover regression.
- `patches.integration.test.ts` (new cases, **real Postgres**) — this is the load-bearing evidence, since the rules are raw `COALESCE`/`CASE` fragments inside Drizzle's `onConflictDoUpdate` that a mocked suite can only inspect as an object shape:
  - identity columns survive a conflicting second report while operational columns still refresh;
  - a sparser rescan does not blank description/category/reboot/severity;
  - a later scan still **fills** columns the first report left empty;
  - installed inventory cannot drag the row back to the installed version (while `device_patches.installed_version` still records it);
  - a malformed row is refused, the rest of the batch lands, and the sweep is skipped;
  - Apple space-bearing labels still round-trip.

`apps/api` affected suites green (45 files / 769 tests), `patches.integration.test.ts` 7/7 against real Postgres, `tsc --noEmit` clean.

## Follow-ups (deliberately not in this PR)

1. **Third-party catalog enrichment appears not to match in the field.** The agent decorates ids with the provider prefix (`winget:Mozilla.Firefox`) while `third_party_package_catalog` stores the bare id (`Mozilla.Firefox`), and `enrichFromCatalog` does an exact `source::packageId` lookup. If that's right, curated enrichment rarely fires for winget today. This PR is forward-compatible either way — curated overwrite simply starts applying once the lookup matches — but the mismatch deserves its own investigation.
2. **Microsoft rows store a per-device WUA UpdateID in a global column.** `external_id` collapses on the KB while `package_id` can vary by device/revision, so neither last-writer-wins (before) nor first-writer-wins (now) is *right* — this change makes it stable rather than arbitrary. Preferring the KB for WUA installs would fix it properly.
3. **`installed < pending < curated` needs stored provenance**, not `COALESCE`. A row first created by the installed path keeps its unenriched title until a curated report arrives; a `metadata_authority` column would express this correctly.
4. **The available version is arguably a per-device observation** and would be better modelled on `device_patches` than as global state.
5. `release_date` is already first-writer-wins (it is in the insert but not the conflict update); it anchors auto-approval deferral windows and is worth revisiting alongside 3/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
