### PR TITLE
fix(api): gate enforcement-arming AI policy tools behind Tier 3 approval (#3552)

### DIFF
--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -304,7 +304,7 @@ function makeIntentRow(overrides?: Record<string, unknown>) {
     // 0) — tests exercising the tier3-supervised-four-eyes split override
     // these explicitly (see createIntentWith / echoInsertedIntent below).
     approvalScope: 'four_eyes',
-    classificationVersion: 1,
+    classificationVersion: 2,
     effectDigest: null,
     status: 'pending_approval',
     createdAt: new Date(),
@@ -753,7 +753,7 @@ describe('createActionIntent — supervised/four_eyes scope', () => {
 
     const captured = dbState.insertedActionIntentValues[0];
     expect(captured?.approvalScope).toBe('supervised');
-    expect(captured?.classificationVersion).toBe(1);
+    expect(captured?.classificationVersion).toBe(2);
     // Dual-write compat: legacy `expiresAt` still carries the same value as
     // the new `approvalExpiresAt` column (Plan 3 removes the legacy write).
     expect(captured?.expiresAt).toEqual(captured?.approvalExpiresAt);

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -165,8 +165,15 @@ export const RELEASE_LEASE_MS = 10 * 60 * 1000;
  * (Task 2) so a future ruleset change can be told apart from intents
  * classified under an older version. Bump when the classification logic
  * changes in a materially observable way.
+ *
+ * v2 (#3552, 2026-08-14): the policy-prerequisite mutators
+ * manage_update_rings / manage_software_policies / manage_peripheral_policies
+ * create+update moved from Tier 2 (auto-execute) to Tier 3 `supervised`, so
+ * they produce approval intents for the first time. Intents for those pairs
+ * only exist from v2 onward; their absence before v2 is a tier gap, not a
+ * gap in the record.
  */
-export const CLASSIFICATION_VERSION = 1;
+export const CLASSIFICATION_VERSION = 2;
 
 const MAX_ARG_VALUE_LEN = 80;
 

--- a/apps/api/src/services/aiAgentSdk.enforcementArmingGate.test.ts
+++ b/apps/api/src/services/aiAgentSdk.enforcementArmingGate.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Contract test: proves the #3552 enforcement-arming gate is actually WIRED,
+ * not just declared.
+ *
+ * PR #3561 re-tiered `manage_software_policies`, `manage_update_rings`,
+ * `manage_peripheral_policies` (create/update) and
+ * `manage_patches:setup_auto_approval` from auto-execute to Tier 3
+ * `supervised` in aiGuardrails.ts's TIER3_ACTIONS. That half of the contract
+ * is covered by aiGuardrails.enforcementArming.contract.test.ts, which calls
+ * checkGuardrails() directly and asserts tier === 3.
+ *
+ * The OTHER half — that createSessionPreToolUse actually consults the real
+ * checkGuardrails() and, on a tier-3 result, creates a durable action intent
+ * and blocks execution pending a decision — is proven separately in
+ * aiAgentSdk.test.ts, but that file `vi.mock('./aiGuardrails')`s the whole
+ * module, so the two halves are never joined for these specific tool names.
+ * A regression that dropped these tools back out of TIER3_ACTIONS would still
+ * pass every existing test.
+ *
+ * This file closes that gap: it exercises createSessionPreToolUse with the
+ * REAL aiGuardrails.checkGuardrails (deliberately NOT mocked — mocking it
+ * here would make the file pointless), for exactly the tool/action pairs
+ * #3552 was about, and confirms:
+ *   - auto_approve mode — the STRONGEST auto-execute setting — does not
+ *     bypass the gate: createActionIntent is called, and a rejected decision
+ *     blocks execution.
+ *   - the exact issue-#3552 payload (enforceMode + remediationOptions.
+ *     autoUninstall) is gated.
+ *   - manage_patches:setup_auto_approval is gated.
+ *   - reads (list/get) on the same tools still auto-execute — no approval
+ *     fatigue regression.
+ *
+ * checkToolPermission/checkToolRateLimit ARE spied (narrowly, via
+ * vi.spyOn — checkGuardrails itself stays real) because they need
+ * RBAC/Redis state this unit test has no business standing up; see the
+ * mock preamble below, modeled on aiAgentSdk.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createSessionPreToolUse } from './aiAgentSdk';
+import { db } from '../db';
+import * as aiGuardrails from './aiGuardrails';
+import { waitForApproval } from './aiAgent';
+
+// ============================================
+// Mocks (modeled on aiAgentSdk.test.ts)
+// ============================================
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    update: vi.fn(),
+    insert: vi.fn(),
+    select: vi.fn(),
+  },
+}));
+
+// Deliberately NOT mocked: '../db/schema' and '../db/schema/actionIntents'
+// stay REAL. aiGuardrails.ts is real too (see below), and it pulls in the
+// full aiTools.ts registry (getToolTier) — that registry chain imports real
+// schema table objects but never opens a live connection at import time, so
+// the real schema module loads safely as long as the `db` client itself
+// (mocked above) never actually executes a query.
+vi.mock('drizzle-orm', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('drizzle-orm')>()),
+  eq: vi.fn((...args: unknown[]) => ({ _eq: args })),
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  isNull: vi.fn((...args: unknown[]) => ({ _isNull: args })),
+}));
+
+const mockGetSession = vi.fn();
+const mockBuildSystemPrompt = vi.fn();
+vi.mock('./aiAgent', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+  buildSystemPrompt: (...args: unknown[]) => mockBuildSystemPrompt(...args),
+  waitForApproval: vi.fn(),
+}));
+
+const mockCheckAiRateLimit = vi.fn();
+const mockCheckBudget = vi.fn();
+const mockGetRemainingBudgetUsd = vi.fn();
+vi.mock('./aiCostTracker', () => ({
+  checkAiRateLimit: (...args: unknown[]) => mockCheckAiRateLimit(...args),
+  checkBudget: (...args: unknown[]) => mockCheckBudget(...args),
+  getRemainingBudgetUsd: (...args: unknown[]) => mockGetRemainingBudgetUsd(...args),
+}));
+
+const mockSanitizeUserMessage = vi.fn();
+const mockSanitizePageContext = vi.fn();
+vi.mock('./aiInputSanitizer', () => ({
+  sanitizeUserMessage: (...args: unknown[]) => mockSanitizeUserMessage(...args),
+  sanitizePageContext: (...args: unknown[]) => mockSanitizePageContext(...args),
+}));
+
+// NOTE: no vi.mock('./aiGuardrails') here. That is the entire point of this
+// file — see the header comment.
+
+const mockWriteAuditEvent = vi.fn();
+vi.mock('./auditEvents', () => ({
+  writeAuditEvent: (...args: unknown[]) => mockWriteAuditEvent(...args),
+  requestLikeFromSnapshot: vi.fn(),
+}));
+
+// TOOL_TIERS here is only consulted by createSessionPreToolUse as an
+// "is this tool known at all" whitelist gate (aiAgentSdk.ts's
+// `if (!TOOL_TIERS[toolName])` early-return) — the ACTUAL tier used for
+// every gating decision below comes from the real checkGuardrails(), not
+// this map. The values here are deliberately wrong/low, so a false pass
+// here can't hide a checkGuardrails regression.
+vi.mock('./aiAgentSdkTools', () => ({
+  TOOL_TIERS: {
+    manage_software_policies: 1,
+    manage_update_rings: 1,
+    manage_peripheral_policies: 1,
+    manage_patches: 1,
+  },
+  BREEZE_MCP_TOOL_NAMES: [],
+}));
+
+const mockGetUserPushTokens = vi.fn();
+const mockDispatchApprovalPushToTokens = vi.fn();
+const mockBuildApprovalPush = vi.fn((..._args: unknown[]) => ({
+  title: 'Approval requested',
+  body: 'Breeze AI: Manage software policy',
+  data: { type: 'approval', approvalId: 'x' },
+  sound: 'default' as const,
+  priority: 'high' as const,
+  channelId: 'approvals',
+  ttl: 60,
+}));
+vi.mock('./expoPush', () => ({
+  getUserPushTokens: (...args: unknown[]) => mockGetUserPushTokens(...args),
+  dispatchApprovalPushToTokens: (...args: unknown[]) => mockDispatchApprovalPushToTokens(...args),
+  buildApprovalPush: (...args: unknown[]) => mockBuildApprovalPush(...args),
+}));
+
+const mockDecideHelperToolAction = vi.fn();
+vi.mock('./pamToolActionGovernance', () => ({
+  decideHelperToolAction: (...args: unknown[]) => mockDecideHelperToolAction(...args),
+  mirrorElevationDecisionToExecution: vi.fn(),
+}));
+
+const mockCreateActionIntent = vi.fn();
+const mockWaitForIntentDecision = vi.fn();
+const mockTransitionIntent = vi.fn();
+vi.mock('./actionIntents/intentService', () => ({
+  createActionIntent: (...args: unknown[]) => mockCreateActionIntent(...args),
+  waitForIntentDecision: (...args: unknown[]) => mockWaitForIntentDecision(...args),
+  transitionIntent: (...args: unknown[]) => mockTransitionIntent(...args),
+}));
+
+const mockRevalidateApprovedIntentForRelease = vi.fn((..._args: unknown[]) =>
+  Promise.resolve({ ok: true, auth: {} }),
+);
+const mockRequiresDurableRelease = vi.fn((_name: string) => false);
+vi.mock('./actionIntents/durableRelease', () => ({
+  requiresDurableRelease: (name: string) => mockRequiresDurableRelease(name),
+  DURABLE_RELEASE_ONLY_TOOLS: new Set<string>(),
+}));
+
+vi.mock('./actionIntents/revalidateRelease', () => ({
+  revalidateApprovedIntentForRelease: (...args: unknown[]) =>
+    mockRevalidateApprovedIntentForRelease(...args),
+}));
+
+const mockComputeEffectDigest = vi.fn((..._args: unknown[]) => Promise.resolve<string | null>(null));
+vi.mock('./actionIntents/effectDigest', () => ({
+  computeEffectDigest: (...args: unknown[]) => mockComputeEffectDigest(...args),
+  hasPinnedDigest: (intent: { effectDigest?: string | null }) =>
+    typeof intent?.effectDigest === 'string' && intent.effectDigest.length > 0,
+}));
+
+const mockCaptureException = vi.fn();
+vi.mock('./sentry', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
+// ============================================
+// Test helpers
+// ============================================
+
+function makeAuth() {
+  return {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    canAccessOrg: () => true,
+    orgCondition: () => null,
+  } as any;
+}
+
+function makeActiveSession(overrides: Record<string, unknown> = {}) {
+  return {
+    breezeSessionId: 'session-1',
+    orgId: 'org-1',
+    auth: makeAuth(),
+    approvalMode: 'per_step',
+    isPaused: false,
+    eventBus: { publish: vi.fn() },
+    abortController: new AbortController(),
+    activePlanId: null,
+    approvedPlanSteps: new Map(),
+    currentPlanStepIndex: 0,
+    toolUseIdQueue: ['tool-use-1'],
+    auditSnapshot: null,
+    allowedTools: undefined,
+    ...overrides,
+  } as any;
+}
+
+function mockInsertReturning(row: Record<string, unknown>) {
+  const returning = vi.fn().mockResolvedValue([row]);
+  const values = vi.fn().mockReturnValue({ returning });
+  vi.mocked(db.insert).mockReturnValue({ values } as any);
+  return { values, returning };
+}
+
+/**
+ * The three tools escalated by #3552, plus manage_patches for the
+ * setup_auto_approval case (which is asserted separately below, since its
+ * gated action isn't create/update).
+ */
+const RETIERED_TOOLS = ['manage_software_policies', 'manage_update_rings', 'manage_peripheral_policies'] as const;
+
+// ============================================
+// Tests
+// ============================================
+
+describe('#3552: enforcement-arming AI tools are gated at the real checkGuardrails join point', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(aiGuardrails, 'checkToolPermission').mockResolvedValue(null);
+    vi.spyOn(aiGuardrails, 'checkToolRateLimit').mockResolvedValue(null);
+    mockGetUserPushTokens.mockResolvedValue([]);
+    mockDispatchApprovalPushToTokens.mockResolvedValue({ tokensFound: 0, dispatched: 0, errors: 0 });
+    mockRevalidateApprovedIntentForRelease.mockResolvedValue({ ok: true, auth: {} } as any);
+    vi.mocked(waitForApproval).mockResolvedValue(false);
+    // Chainable stand-in for the tier-3 branch's internal system-context
+    // reads (the M365 risk-summary lookup and the release-CAS intent read).
+    // Its contents are irrelevant to every test below — none of them exercise
+    // an 'approved' decision that would read further into the row.
+    const selectChain: Record<string, unknown> = {
+      from: vi.fn(() => selectChain),
+      where: vi.fn(() => selectChain),
+      limit: vi.fn(async () => [{ id: 'intent', boundArgumentDigest: 'digest' }]),
+    };
+    vi.mocked(db.select).mockReturnValue(selectChain as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    } as any);
+  });
+
+  describe.each(RETIERED_TOOLS)('%s', (toolName) => {
+    it.each([
+      { action: 'create', name: 'p' },
+      { action: 'update', policyId: '00000000-0000-4000-8000-000000000001' },
+    ])('creates a durable action intent under auto_approve and blocks on rejection: %j', async (input) => {
+      mockInsertReturning({ id: `exec-${toolName}-${input.action}` });
+      mockCreateActionIntent.mockResolvedValue({
+        id: `intent-${toolName}-${input.action}`,
+        status: 'pending_approval',
+        actionName: toolName,
+        argumentDigest: 'digest-1',
+        source: 'chat',
+        expiresAt: new Date(Date.now() + 300_000),
+        result: null,
+        errorCode: null,
+        approvalRequestIds: ['appr-1'],
+        requesterApprovalRequestId: 'appr-1',
+        approvalExpiresAt: new Date(Date.now() + 300_000),
+        fanOutUserIds: [],
+      });
+      mockWaitForIntentDecision.mockResolvedValue('rejected');
+      // auto_approve is the strongest auto-execute setting — the #3552 fix
+      // must gate these tools regardless.
+      const session = makeActiveSession({ approvalMode: 'auto_approve' });
+
+      const result = await createSessionPreToolUse(session)(toolName, input);
+
+      expect(mockCreateActionIntent).toHaveBeenCalledWith(
+        session.auth,
+        expect.objectContaining({ toolName }),
+      );
+      expect(result).toEqual({
+        allowed: false,
+        error: 'Tool execution was rejected, cancelled, or expired',
+      });
+    });
+  });
+
+  it('the specific #3552 payload — enforceMode + remediationOptions.autoUninstall — is gated under auto_approve', async () => {
+    mockInsertReturning({ id: 'exec-3552-payload' });
+    mockCreateActionIntent.mockResolvedValue({
+      id: 'intent-3552-payload',
+      status: 'pending_approval',
+      actionName: 'manage_software_policies',
+      argumentDigest: 'digest-1',
+      source: 'chat',
+      expiresAt: new Date(Date.now() + 300_000),
+      result: null,
+      errorCode: null,
+      approvalRequestIds: ['appr-1'],
+      requesterApprovalRequestId: 'appr-1',
+      approvalExpiresAt: new Date(Date.now() + 300_000),
+      fanOutUserIds: [],
+    });
+    mockWaitForIntentDecision.mockResolvedValue('rejected');
+    const session = makeActiveSession({ approvalMode: 'auto_approve' });
+
+    const result = await createSessionPreToolUse(session)('manage_software_policies', {
+      action: 'update',
+      policyId: '00000000-0000-4000-8000-000000000002',
+      enforceMode: true,
+      remediationOptions: { autoUninstall: true },
+    });
+
+    expect(mockCreateActionIntent).toHaveBeenCalledWith(
+      session.auth,
+      expect.objectContaining({ toolName: 'manage_software_policies' }),
+    );
+    expect(result).toEqual({
+      allowed: false,
+      error: 'Tool execution was rejected, cancelled, or expired',
+    });
+  });
+
+  it('manage_patches:setup_auto_approval is gated under auto_approve', async () => {
+    mockInsertReturning({ id: 'exec-setup-auto-approval' });
+    mockCreateActionIntent.mockResolvedValue({
+      id: 'intent-setup-auto-approval',
+      status: 'pending_approval',
+      actionName: 'manage_patches',
+      argumentDigest: 'digest-1',
+      source: 'chat',
+      expiresAt: new Date(Date.now() + 300_000),
+      result: null,
+      errorCode: null,
+      approvalRequestIds: ['appr-1'],
+      requesterApprovalRequestId: 'appr-1',
+      approvalExpiresAt: new Date(Date.now() + 300_000),
+      fanOutUserIds: [],
+    });
+    mockWaitForIntentDecision.mockResolvedValue('rejected');
+    const session = makeActiveSession({ approvalMode: 'auto_approve' });
+
+    const result = await createSessionPreToolUse(session)('manage_patches', {
+      action: 'setup_auto_approval',
+      autoApprove: true,
+    });
+
+    expect(mockCreateActionIntent).toHaveBeenCalledWith(
+      session.auth,
+      expect.objectContaining({ toolName: 'manage_patches' }),
+    );
+    expect(result).toEqual({
+      allowed: false,
+      error: 'Tool execution was rejected, cancelled, or expired',
+    });
+  });
+
+  describe.each(RETIERED_TOOLS)('%s reads still auto-execute', (toolName) => {
+    it.each([
+      { action: 'list' },
+      { action: 'get', policyId: '00000000-0000-4000-8000-000000000003' },
+    ])('does not create an action intent for a read: %j', async (input) => {
+      const session = makeActiveSession({ approvalMode: 'per_step' });
+
+      const result = await createSessionPreToolUse(session)(toolName, input);
+
+      expect(mockCreateActionIntent).not.toHaveBeenCalled();
+      expect(result.allowed).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/services/aiAgentSystemPrompt.ts
+++ b/apps/api/src/services/aiAgentSystemPrompt.ts
@@ -7,6 +7,7 @@ export const BREEZE_AI_GUARDRAILS_CORE = `## Important Rules
 1. Always verify device access before operations — you can only see devices in the user's organization; never act cross-tenant.
 2. Before any mutation, resolve and echo the target device + organization back to the user.
 3. For destructive operations (service restart, file delete, script/command execution, patch install, registry edits, elevation changes), require explicit human confirmation — these are approval-gated and the server will reject unauthorized calls.
+3a. Creating or updating a policy that ARMS unattended action is equally approval-gated: software policies (manage_software_policies), update rings (manage_update_rings) and peripheral policies (manage_peripheral_policies). Reading them (list/get) is not. Do not report a policy as created or changed until the approval has actually been granted and the call has returned.
 4. Never fabricate device data or metrics — always use tools to get real data.
 5. If a tool call is rejected by the server, surface the rejection to the user rather than retrying blindly.
 6. Never reveal internal IDs or user personal information.`;

--- a/apps/api/src/services/aiGuardrails.enforcementArming.contract.test.ts
+++ b/apps/api/src/services/aiGuardrails.enforcementArming.contract.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Contract test: an AI tool operation that can ARM unattended enforcement or
+ * remediation must require human approval (Tier 3). Issue #3552.
+ *
+ * The bug this exists to prevent: `manage_software_policies` was registered
+ * base Tier 1 with its create/update escalated only to Tier 2 — auto-execute
+ * plus an audit row, no approval — while its input schema accepted
+ * `enforceMode` and `remediationOptions.autoUninstall`. The AI agent could
+ * therefore flip a detect-only software allowlist into fleet-wide
+ * auto-uninstall with no human in the loop (the #3381 mass-uninstall failure
+ * mode), even though the singular-named sibling writing the SAME table
+ * (`manage_software_policy`, aiToolsCompliance.ts) was already Tier 3.
+ *
+ * The guard is STRUCTURAL rather than a fixed list of tool names, so a future
+ * tool cannot reintroduce the gap: any registered tool whose input schema
+ * exposes an arming field is swept, on BOTH schema surfaces (the Anthropic
+ * definition the model sees and the Zod schema validateToolInput enforces),
+ * and every non-read action it accepts must resolve to Tier 3.
+ *
+ * It fails CLOSED on action naming: only names on the explicit read allowlist
+ * are exempt. A new action called `arm`, `apply`, or `enforce` is treated as a
+ * mutation and must be gated — the test does not try to guess.
+ *
+ * No vi.mock: like the sibling guardrail contract suites this needs the REAL
+ * aiTools registry, because base tiers are half the answer.
+ */
+import { describe, it, expect } from 'vitest';
+import { checkGuardrails } from './aiGuardrails';
+import { getToolTier, getAllRegisteredToolNames, getToolDefinitions } from './aiTools';
+import { toolInputSchemas } from './aiToolSchemas';
+
+/**
+ * Input properties that arm unattended action on real endpoints — the agent
+ * subsequently uninstalls, blocks, installs, or reboots WITHOUT a further tool
+ * call, so gating the later action is not an option; the arming call is the
+ * only chokepoint.
+ *
+ * Matched case-insensitively against top-level schema property names AND
+ * against the documented sub-keys of object-typed properties (the description
+ * text is where `remediationOptions.autoUninstall` and `autoApprove.enabled`
+ * are actually specified — those properties are free-form objects with no
+ * nested JSON Schema to walk).
+ *
+ * Add to this list when a new "arm it and walk away" input is introduced.
+ */
+const ARMING_FIELDS = [
+  'enforceMode',
+  'remediationOptions',
+  'autoUninstall',
+  'autoApprove',
+] as const;
+
+/**
+ * Action names that are pure reads and therefore may stay auto-execute even on
+ * an arming-capable tool: the field is inert on them. Deliberately short and
+ * explicit — anything not listed counts as a mutation.
+ */
+const READ_ACTIONS = new Set([
+  'list', 'get', 'search', 'query', 'status', 'describe', 'preview', 'history',
+]);
+
+/** Top-level property names a tool accepts, unioned across both schema surfaces. */
+function schemaPropertyNames(toolName: string): string[] {
+  const names = new Set<string>();
+
+  const definition = getToolDefinitions().find((d) => d.name === toolName);
+  const properties = (definition?.input_schema as { properties?: Record<string, unknown> } | undefined)?.properties;
+  if (properties) for (const key of Object.keys(properties)) names.add(key);
+
+  const shape = (toolInputSchemas[toolName] as { shape?: Record<string, unknown> } | undefined)?.shape;
+  if (shape) for (const key of Object.keys(shape)) names.add(key);
+
+  return [...names];
+}
+
+/** `{ propertyName: description }` for a tool's JSON-schema properties. */
+function schemaPropertyDescriptions(toolName: string): Record<string, string> {
+  const definition = getToolDefinitions().find((d) => d.name === toolName);
+  const properties = (definition?.input_schema as { properties?: Record<string, unknown> } | undefined)?.properties;
+  if (!properties) return {};
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    const description = (value as { description?: unknown } | undefined)?.description;
+    if (typeof description === 'string') out[key] = description;
+  }
+  return out;
+}
+
+/**
+ * The arming fields a tool exposes, each with the actions it applies to.
+ *
+ * A field is detected either as a top-level property name or as a nested key
+ * named in some property's description — `remediationOptions.autoUninstall`
+ * and `autoApprove.enabled` live inside free-form `type: 'object'` properties
+ * with no nested JSON Schema to walk, so the prose is the only machine-readable
+ * record of them.
+ *
+ * `actions` narrows the field to the operations that can actually carry it,
+ * using the repo's "(for <action>)" description convention — e.g.
+ * manage_patches' `autoApprove` is documented "(for setup_auto_approval)" and
+ * is inert on approve/decline/defer. Narrowing only happens on action names
+ * that are REAL enum members of that tool, so a stale or misspelled name in a
+ * description cannot silently shrink the sweep; with no recognised name the
+ * field applies to every non-read action.
+ */
+function armingFieldsOf(toolName: string): Array<{ field: string; actions: Set<string> | null }> {
+  const propertyNames = new Set(schemaPropertyNames(toolName).map((n) => n.toLowerCase()));
+  const descriptions = schemaPropertyDescriptions(toolName);
+  const enumActions = new Set(realActionEnum(toolName) ?? []);
+
+  const found: Array<{ field: string; actions: Set<string> | null }> = [];
+  for (const field of ARMING_FIELDS) {
+    const lower = field.toLowerCase();
+    const carriers = Object.entries(descriptions).filter(
+      ([key, description]) => key.toLowerCase() === lower || description.toLowerCase().includes(lower),
+    );
+    if (!propertyNames.has(lower) && carriers.length === 0) continue;
+
+    // Union of real action names named by every property that carries the field.
+    const named = new Set<string>();
+    for (const [, description] of carriers) {
+      for (const action of enumActions) {
+        if (new RegExp(`\\b${action}\\b`).test(description)) named.add(action);
+      }
+    }
+    found.push({ field, actions: named.size > 0 ? named : null });
+  }
+  return found;
+}
+
+/** A tool's real action enum, unioned across both schema surfaces; null if not multiplexed. */
+function realActionEnum(toolName: string): string[] | null {
+  const values = new Set<string>();
+
+  const definition = getToolDefinitions().find((d) => d.name === toolName);
+  const properties = (definition?.input_schema as { properties?: Record<string, unknown> } | undefined)?.properties;
+  const jsonEnum = (properties?.action as { enum?: unknown[] } | undefined)?.enum;
+  if (Array.isArray(jsonEnum)) for (const v of jsonEnum) if (typeof v === 'string') values.add(v);
+
+  const zodAction = (toolInputSchemas[toolName] as { shape?: Record<string, unknown> } | undefined)?.shape?.action;
+  const zodEnum = (zodAction as { options?: unknown[] } | undefined)?.options;
+  if (Array.isArray(zodEnum)) for (const v of zodEnum) if (typeof v === 'string') values.add(v);
+
+  return values.size > 0 ? [...values] : null;
+}
+
+/** Tools that expose at least one arming field. */
+function armingTools(): Array<{ tool: string; fields: Array<{ field: string; actions: Set<string> | null }> }> {
+  return getAllRegisteredToolNames()
+    .map((tool) => ({ tool, fields: armingFieldsOf(tool) }))
+    .filter((entry) => entry.fields.length > 0);
+}
+
+/** The arming fields that action can actually carry. */
+function armingFieldsForAction(
+  fields: Array<{ field: string; actions: Set<string> | null }>,
+  action: string,
+): string[] {
+  return fields.filter((f) => f.actions === null || f.actions.has(action)).map((f) => f.field);
+}
+
+describe('enforcement-arming tools require approval (#3552)', () => {
+  it('finds arming tools at all — the sweep is not vacuously empty', () => {
+    const tools = armingTools().map((t) => t.tool);
+    // The two software-policy tools are the known members; if a refactor
+    // renames the arming fields out from under ARMING_FIELDS this trips
+    // instead of the whole suite silently passing over an empty set.
+    expect(tools).toContain('manage_software_policies');
+    expect(tools).toContain('manage_software_policy');
+    expect(tools.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('nested arming keys are detected through free-form object properties', () => {
+    // remediationOptions.autoUninstall has no nested JSON Schema — it is only
+    // named in the property description. If that detection path breaks, the
+    // #3552 field itself stops being swept.
+    const fields = armingFieldsOf('manage_software_policies').map((f) => f.field);
+    expect(fields).toContain('enforceMode');
+    expect(fields).toContain('autoUninstall');
+  });
+
+  it('action narrowing uses only real enum members', () => {
+    // manage_patches' autoApprove is documented "(for setup_auto_approval)" —
+    // it must narrow to that action and not fan out over approve/decline/defer.
+    const autoApprove = armingFieldsOf('manage_patches').find((f) => f.field === 'autoApprove');
+    expect(autoApprove, 'manage_patches must still be detected as arming-capable').toBeDefined();
+    expect([...(autoApprove!.actions ?? [])]).toEqual(['setup_auto_approval']);
+  });
+
+  it('no arming-capable mutation is auto-executable — every one resolves to Tier 3', () => {
+    const violations: string[] = [];
+
+    for (const { tool, fields } of armingTools()) {
+      const actions = realActionEnum(tool);
+
+      if (actions === null) {
+        // Not action-multiplexed: the whole tool must be base Tier 3 (or 4).
+        const tier = getToolTier(tool);
+        if (tier === undefined || tier < 3) {
+          const names = fields.map((f) => f.field).join('/');
+          violations.push(`${tool} (no action enum, arms ${names}) → base tier ${tier}, expected >= 3`);
+        }
+        continue;
+      }
+
+      for (const action of actions) {
+        if (READ_ACTIONS.has(action)) continue;
+        const carried = armingFieldsForAction(fields, action);
+        if (carried.length === 0) continue;
+        // Pass the arming fields in the input: a tool whose scope/tier is
+        // input-aware must see the same payload a real arming call carries.
+        const input: Record<string, unknown> = { action };
+        for (const field of carried) input[field] = true;
+
+        const check = checkGuardrails(tool, input);
+        if (check.tier !== 3 || !check.requiresApproval) {
+          violations.push(
+            `${tool}:${action} (arms ${carried.join('/')}) → tier ${check.tier}, ` +
+            `requiresApproval=${check.requiresApproval}; expected tier 3 + approval`,
+          );
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('reads on arming-capable tools still auto-execute (no approval fatigue)', () => {
+    for (const { tool } of armingTools()) {
+      for (const action of realActionEnum(tool) ?? []) {
+        if (!READ_ACTIONS.has(action)) continue;
+        if ((getToolTier(tool) ?? 1) >= 3) continue; // base-Tier-3 tools gate reads by design
+        const check = checkGuardrails(tool, { action });
+        expect(
+          { tool, action, requiresApproval: check.requiresApproval },
+          `${tool}:${action} is a read and must not prompt`,
+        ).toMatchObject({ requiresApproval: false });
+      }
+    }
+  });
+});
+
+describe('policy-prerequisite mutators are Tier 3 supervised (#3552)', () => {
+  const RETIERED = [
+    'manage_software_policies',
+    'manage_update_rings',
+    'manage_peripheral_policies',
+  ] as const;
+
+  it.each(RETIERED)('%s create/update requires supervised approval', (tool) => {
+    for (const action of ['create', 'update']) {
+      const check = checkGuardrails(tool, { action, name: 'p' });
+      expect(check.tier, `${tool}:${action}`).toBe(3);
+      expect(check.requiresApproval, `${tool}:${action}`).toBe(true);
+      expect(check.tier === 3 ? check.approvalScope : undefined, `${tool}:${action}`).toBe('supervised');
+    }
+  });
+
+  it.each(RETIERED)('%s list/get still auto-execute at Tier 1', (tool) => {
+    for (const action of ['list', 'get']) {
+      const check = checkGuardrails(tool, { action });
+      expect(check.tier, `${tool}:${action}`).toBe(1);
+      expect(check.requiresApproval, `${tool}:${action}`).toBe(false);
+    }
+  });
+
+  it('the specific #3552 payload — enforceMode + autoUninstall — is gated', () => {
+    const check = checkGuardrails('manage_software_policies', {
+      action: 'update',
+      policyId: '00000000-0000-4000-8000-000000000000',
+      enforceMode: true,
+      remediationOptions: { autoUninstall: true },
+    });
+    expect(check.tier).toBe(3);
+    expect(check.requiresApproval).toBe(true);
+  });
+
+  it('backup prereq tools are deliberately left at Tier 2 — change this consciously', () => {
+    // Documented judgment call in TIER3_ACTIONS: backup config/profile writes
+    // are protective scheduling, not enforcement. Pinned so a later decision to
+    // escalate them is an explicit edit here, not a silent drift.
+    for (const tool of ['manage_backup_configs', 'manage_backup_profiles']) {
+      const check = checkGuardrails(tool, { action: 'update' });
+      expect(check.tier, tool).toBe(2);
+      expect(check.requiresApproval, tool).toBe(false);
+    }
+  });
+});

--- a/apps/api/src/services/aiGuardrails.enforcementArming.contract.test.ts
+++ b/apps/api/src/services/aiGuardrails.enforcementArming.contract.test.ts
@@ -48,6 +48,14 @@ const ARMING_FIELDS = [
   'remediationOptions',
   'autoUninstall',
   'autoApprove',
+  // Peripheral control: `action_type: allow | block | read_only | alert` is
+  // the arming input — `block`/`read_only` cut off USB / Bluetooth /
+  // Thunderbolt across the target scope. Named `action_type` rather than
+  // `action` only to avoid colliding with the dispatch discriminator, and it
+  // is unique to manage_peripheral_policies repo-wide, so listing it here
+  // brings that tool under the structural sweep instead of leaving it
+  // protected by name-pinning alone.
+  'action_type',
 ] as const;
 
 /**
@@ -96,12 +104,18 @@ function schemaPropertyDescriptions(toolName: string): Record<string, string> {
  * record of them.
  *
  * `actions` narrows the field to the operations that can actually carry it,
- * using the repo's "(for <action>)" description convention — e.g.
+ * using the repo's "(for <action>)" APPLICABILITY convention — e.g.
  * manage_patches' `autoApprove` is documented "(for setup_auto_approval)" and
- * is inert on approve/decline/defer. Narrowing only happens on action names
- * that are REAL enum members of that tool, so a stale or misspelled name in a
- * description cannot silently shrink the sweep; with no recognised name the
- * field applies to every non-read action.
+ * is inert on approve/decline/defer.
+ *
+ * Two deliberate guards against a narrowing that under-covers:
+ *   - only a parenthetical opening with "for " counts. "(required for create)"
+ *     is a REQUIREDNESS note, not an applicability one — `action_type` is
+ *     required on create but equally settable on update — so it does not
+ *     narrow, and the field keeps applying to every non-read action.
+ *   - only names that are REAL enum members of that tool are honoured, so a
+ *     stale or misspelled action in a description cannot shrink the sweep.
+ * With no recognised annotation the field applies to every non-read action.
  */
 function armingFieldsOf(toolName: string): Array<{ field: string; actions: Set<string> | null }> {
   const propertyNames = new Set(schemaPropertyNames(toolName).map((n) => n.toLowerCase()));
@@ -116,11 +130,14 @@ function armingFieldsOf(toolName: string): Array<{ field: string; actions: Set<s
     );
     if (!propertyNames.has(lower) && carriers.length === 0) continue;
 
-    // Union of real action names named by every property that carries the field.
+    // Union of real action names named in an applicability clause — a
+    // parenthetical that OPENS with "for", e.g. "(for setup_auto_approval)".
     const named = new Set<string>();
     for (const [, description] of carriers) {
-      for (const action of enumActions) {
-        if (new RegExp(`\\b${action}\\b`).test(description)) named.add(action);
+      for (const clause of description.matchAll(/\(for ([^)]*)\)/gi)) {
+        for (const action of enumActions) {
+          if (new RegExp(`\\b${action}\\b`).test(clause[1] ?? '')) named.add(action);
+        }
       }
     }
     found.push({ field, actions: named.size > 0 ? named : null });
@@ -167,7 +184,21 @@ describe('enforcement-arming tools require approval (#3552)', () => {
     // instead of the whole suite silently passing over an empty set.
     expect(tools).toContain('manage_software_policies');
     expect(tools).toContain('manage_software_policy');
-    expect(tools.length).toBeGreaterThanOrEqual(2);
+    // All three re-tiered prereq tools must be inside the STRUCTURAL sweep,
+    // not merely name-pinned in the second describe block below.
+    expect(tools).toContain('manage_update_rings');
+    expect(tools).toContain('manage_peripheral_policies');
+    expect(tools.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('a requiredness note does not narrow a field away from update', () => {
+    // manage_peripheral_policies' action_type is "(required for create)" —
+    // a requiredness note, not an applicability one. It must stay applicable
+    // to `update` too, or the sweep would quietly stop covering the action
+    // that flips an existing policy to block.
+    const actionType = armingFieldsOf('manage_peripheral_policies').find((f) => f.field === 'action_type');
+    expect(actionType, 'action_type must be detected').toBeDefined();
+    expect(actionType!.actions, 'must not narrow to create only').toBeNull();
   });
 
   it('nested arming keys are detected through free-form object properties', () => {
@@ -273,6 +304,16 @@ describe('policy-prerequisite mutators are Tier 3 supervised (#3552)', () => {
     });
     expect(check.tier).toBe(3);
     expect(check.requiresApproval).toBe(true);
+  });
+
+  it('manage_patches:setup_auto_approval is Tier 3 supervised', () => {
+    // Pinned by name alongside RETIERED even though its handler is currently
+    // hard-disabled: the gate exists so re-enabling the handler cannot
+    // silently reopen the hole, which only holds if the gate is pinned.
+    const check = checkGuardrails('manage_patches', { action: 'setup_auto_approval', autoApprove: true });
+    expect(check.tier).toBe(3);
+    expect(check.requiresApproval).toBe(true);
+    expect(check.tier === 3 ? check.approvalScope : undefined).toBe('supervised');
   });
 
   it('backup prereq tools are deliberately left at Tier 2 — change this consciously', () => {

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -110,10 +110,13 @@ export const TIER2_ACTIONS: Record<string, string[]> = {
   // manage_alert_rules mutations disabled — managed via configuration policies
   // manage_service_monitors mutations disabled — managed via configuration policies
   generate_report: ['create', 'update', 'delete', 'generate'],
-  // Policy prerequisite tools — Tier 2 create/update actions
-  manage_update_rings: ['create', 'update'],
-  manage_software_policies: ['create', 'update'],
-  manage_peripheral_policies: ['create', 'update'],
+  // Policy prerequisite tools — Tier 2 create/update actions.
+  //
+  // #3552 (2026-08-14): manage_update_rings, manage_software_policies and
+  // manage_peripheral_policies were REMOVED from this list and escalated to
+  // Tier 3 in TIER3_ACTIONS below — their create/update payloads ARM
+  // unattended enforcement/remediation on the fleet. The two backup tools stay
+  // here deliberately; see the note in TIER3_ACTIONS for the full rationale.
   manage_backup_configs: ['create', 'update'],
   manage_backup_profiles: ['create', 'update', 'delete'],
   // Notification channel & saved filter tools — Tier 2 actions
@@ -183,12 +186,53 @@ export const TIER3_ACTIONS: Record<string, string[]> = {
   // Fleet tools — Tier 3 actions (require user approval)
   manage_configuration_policy: ['create', 'update', 'delete'],
   manage_deployments: ['create', 'start', 'cancel'],
-  manage_patches: ['install', 'rollback'],
+  // setup_auto_approval added #3552: it arms unattended patch approval +
+  // reboot policy, the same class as manage_update_rings.autoApprove below.
+  // Its handler is hard-disabled today (aiToolsFleet.ts returns "managed
+  // through configuration policies"), so the gate costs no live workflow —
+  // it is here so re-enabling the handler cannot silently reopen the hole.
+  manage_patches: ['install', 'rollback', 'setup_auto_approval'],
   manage_groups: ['create', 'update', 'delete'],
   manage_automations: ['run'],
   manage_processes: ['kill'],
   manage_policy_feature_link: ['remove'],
   registry_operations: ['set_value', 'create_key', 'delete_key'],
+  // Policy prerequisite tools (#3552) — the standalone feature policies that
+  // manage_configuration_policy links via featurePolicyId. These were Tier 2
+  // (auto-execute + audit, no approval) while the configuration policy that
+  // consumes them, and their singular-named siblings that write the SAME
+  // tables, are Tier 3:
+  //
+  //   manage_software_policies   ~ manage_software_policy   (aiToolsCompliance.ts, base tier 3)
+  //   manage_peripheral_policies ~ manage_peripheral_policy (aiToolsPeripherals.ts, base tier 3)
+  //   manage_update_rings        ~ manage_patches:install   (Tier 3 above)
+  //
+  // The tier gap was the reachable one: the prereq tools are the ones listed
+  // in aiAgentSdkTools' TOOL_TIERS, so they — not the Tier-3 singulars — are
+  // what chat/MCP actually calls. Each create/update payload ARMS unattended
+  // action on real endpoints with no human in the loop:
+  //   - software policies: `enforceMode` + `remediationOptions.autoUninstall`
+  //     turn a detect-only allowlist into fleet-wide auto-uninstall (the #3381
+  //     mass-uninstall failure mode).
+  //   - update rings: `autoApprove` + `deadlineDays` + `gracePeriodHours` arm
+  //     unattended patch installs with FORCED reboots — the standing-rule form
+  //     of manage_patches:install, which already requires approval.
+  //   - peripheral policies: `action_type: block | read_only` cuts off USB /
+  //     Bluetooth / Thunderbolt access across the target scope.
+  //
+  // `list`/`get` are deliberately NOT listed: the tools keep base tier 1, so
+  // reads still auto-execute with no prompt. Only the mutations escalate.
+  //
+  // Deliberately NOT escalated (judgment calls, left at Tier 2, #3552):
+  //   - manage_backup_configs / manage_backup_profiles. They change storage
+  //     destinations, credentials, retention and selection sets — real, but
+  //     PROTECTIVE scheduling rather than enforcement or remediation: no
+  //     payload there causes an agent to uninstall, block, or reboot anything.
+  //     Escalating them is defensible under a broader "any live linked policy
+  //     change needs approval" rule; that is a separate product decision.
+  manage_update_rings: ['create', 'update'],
+  manage_software_policies: ['create', 'update'],
+  manage_peripheral_policies: ['create', 'update'],
   // Backup & DR — Tier 3 actions (require user approval)
   manage_dr_plan: ['delete_group'],
   manage_hyperv_checkpoints: ['delete', 'apply'],
@@ -334,12 +378,22 @@ export const TIER3_SUPERVISED_ACTIONS: Record<string, string[]> = {
   manage_scheduled_tasks: ['run', 'disable', 'enable'],
   manage_configuration_policy: ['create', 'update', 'delete'],
   manage_deployments: ['create', 'start', 'cancel'],
-  manage_patches: ['install'],
+  manage_patches: ['install', 'setup_auto_approval'],
   manage_groups: ['create', 'update', 'delete'],
   manage_automations: ['run'],
   manage_processes: ['kill'],
   manage_policy_feature_link: ['remove'],
   registry_operations: ['set_value', 'create_key', 'delete_key'],
+  // #3552 policy-prerequisite escalations. `supervised`, matching the
+  // configuration policy they link into (manage_configuration_policy
+  // create/update/delete above), the Tier-3 singular siblings in
+  // TIER3_SUPERVISED_TOOLS below, and manage_patches:install. Spec §3.2
+  // reserves four_eyes for externally-binding, identity, and
+  // destroy/rewind actions; arming a policy is none of those, and
+  // blast-radius-based escalation is explicitly deferred in the design doc.
+  manage_update_rings: ['create', 'update'],
+  manage_software_policies: ['create', 'update'],
+  manage_peripheral_policies: ['create', 'update'],
   manage_dr_plan: ['delete_group'],
   manage_monitors: ['create', 'update', 'delete'],
   manage_contracts: ['pause', 'resume'],


### PR DESCRIPTION
## ⚠️ Behavior change — AI policy mutations now require approval

**This is the point of the PR, and it will be visible to users immediately.** Four AI tool operations that previously auto-executed now raise a Tier 3 `supervised` approval request (the requesting human approves their own AI action with one click, gated on their existing RBAC — no second approver):

| Tool | Actions now gated | Was |
|---|---|---|
| `manage_software_policies` | `create`, `update` | Tier 2 (auto-execute + audit) |
| `manage_update_rings` | `create`, `update` | Tier 2 |
| `manage_peripheral_policies` | `create`, `update` | Tier 2 |
| `manage_patches` | `setup_auto_approval` | Tier 1 (handler already disabled) |

**`list` / `get` on all of these still auto-execute at Tier 1** — no approval fatigue on reads. Only the mutations changed. Any AI workflow that creates or edits a software policy, update ring, or peripheral policy now pauses for one approval click instead of applying silently.

## The bug

`manage_software_policies` was registered base **Tier 1** with `create`/`update` escalated only to **Tier 2** — auto-execute plus an audit row, *no approval* — while its input schema accepts `enforceMode` and `remediationOptions.autoUninstall`. So the AI agent could flip a detect-only software allowlist into **fleet-wide auto-uninstall with no human in the loop**.

The singular-named sibling writing the **same `software_policies` table** (`manage_software_policy`, `aiToolsCompliance.ts`) has always been base Tier 3. The prereq tool is the *reachable* one: it — not the singular — is listed in `aiAgentSdkTools`' `TOOL_TIERS`, and `BREEZE_MCP_TOOL_NAMES` is derived from that map, so the plural tool is what chat and MCP actually call. The Tier 3 sibling is effectively unreachable from those surfaces. The gate that looked like it existed did not apply to the path in use.

Context from #3552: in the #3381 incident (259-device mass uninstall) the `audit_logs` trail shows no arming event. Before #3548 this path was both unaudited *and* unapproved.

## Sweep of the rest of `aiToolsPolicyPrereqs.ts` (scope item 2)

All five prereq tools were base Tier 1 with mutations at Tier 2. Findings:

**Re-tiered — clear-cut analogues (arm unattended action on real endpoints):**
- **`manage_update_rings`** — `autoApprove` + `deadlineDays` + `gracePeriodHours` arm unattended patch installs with **forced reboots**. This is the standing-rule form of `manage_patches:install`, which already requires approval; approving each patch but not the rule that auto-approves all of them was the same inversion as the reported bug.
- **`manage_peripheral_policies`** — `action_type: block | read_only` cuts off USB / Bluetooth / Thunderbolt across the target scope. Its singular sibling `manage_peripheral_policy` (`aiToolsPeripherals.ts`) is already base Tier 3 — the identical plural/singular tier gap.
- **`manage_patches:setup_auto_approval`** — not in `aiToolsPolicyPrereqs.ts`; surfaced by the new structural test. It arms auto-approval + reboot policy at **Tier 1**. Its handler is hard-disabled today ("managed through configuration policies"), so gating it costs no live workflow — it is here so re-enabling the handler cannot silently reopen the hole.

**Judgment calls — documented, left at Tier 2:**
- **`manage_backup_configs`** — changes storage destinations, credentials, retention on live backup config. Real impact, but *protective scheduling*, not enforcement or remediation: no payload causes an agent to uninstall, block, or reboot anything.
- **`manage_backup_profiles`** — selection sets only; `delete` is already refused while the profile is referenced.

Escalating the backup pair is defensible under a broader "any live linked policy change needs approval" rule, but that is a separate product decision. Both are pinned by an explicit test so a later decision to escalate is a conscious edit, not drift. The rationale is recorded inline in `TIER3_ACTIONS`.

## Why `supervised`, not `four_eyes`

Matches `manage_configuration_policy` `create`/`update`/`delete` (the policy these prereqs link into via `featurePolicyId`), `manage_patches:install`, and the Tier-3 singular siblings in `TIER3_SUPERVISED_TOOLS`. Spec `2026-08-05-tier3-supervised-four-eyes-split-design.md` §3.2 reserves `four_eyes` for externally-binding, identity-control, and destroy/rewind actions; blast-radius-based escalation is explicitly deferred there.

## How the gate is applied

The tier machinery is already per-`(tool, action)`: `checkGuardrails` overlays `TIER1/2/3_ACTIONS` on the tool's base tier. So the fix is table edits only — the tools **keep base Tier 1**, which is what preserves auto-execute on `list`/`get` and keeps them visible over MCP (a base-tier-3 tool would gate reads too). Both surfaces are covered by construction: the legacy registry path and the Agent SDK path share `checkGuardrails` as the single gate, and MCP annotates from the same resolution. `TOOL_PERMISSIONS` RBAC entries already existed for all three tools; no registry, `TOOL_TIERS`, or MCP change was needed. The three tools are deliberately **not** added to `TIER3_SUPERVISED_TOOLS` — that whole-tool set requires base Tier 3 members.

`CLASSIFICATION_VERSION` bumped 1 → 2: these pairs produce approval intents for the first time, so their absence before v2 is a tier gap, not a gap in the record.

## Regression test (scope item 3)

New `aiGuardrails.enforcementArming.contract.test.ts` — **structural, not a name list**, so a future tool cannot reintroduce the gap. It sweeps every registered core tool across **both** schema surfaces (the Anthropic definition the model sees and the Zod schema `validateToolInput` enforces) for arming fields — `enforceMode`, `remediationOptions`, `autoUninstall`, `autoApprove` — including nested keys that exist only in prose (`remediationOptions.autoUninstall` lives inside a free-form `type: 'object'` property with no nested schema to walk). Every non-read action that can carry one must resolve to Tier 3.

It **fails closed on action naming**: only an explicit read allowlist (`list`/`get`/`search`/…) is exempt, so a future action called `arm` or `enforce` must be gated or CI goes red. Action narrowing (the `"(for <action>)"` description convention that keeps `manage_patches`' `autoApprove` from fanning out over `approve`/`decline`/`defer`) only accepts **real enum members**, so a stale or misspelled name in a description cannot silently shrink the sweep.

Three anti-vacuity guards: the sweep asserts it finds arming tools at all, that the nested-key detection path still resolves `autoUninstall`, and that narrowing lands on exactly `setup_auto_approval`. **Verified non-vacuous by reverting the fix — 5 tests go red**, including the exact #3552 payload (`enforceMode: true` + `remediationOptions.autoUninstall: true`).

## Verification

- `aiGuardrails.enforcementArming.contract.test.ts` — 13 passed (new)
- `aiGuardrails.{test,approvalScope.contract,readonly.contract}.test.ts` — 180 passed
- Full AI + action-intent surface: **137 files / 2068 tests passed** (`src/services/ai*.test.ts`, `src/services/actionIntents/*.test.ts`, intent reaper jobs), single-fork
- `tsc --noEmit` clean
- Design quorum run before implementing (independent second opinion agreed on scope, `supervised`, the three re-tiers, and leaving the backup pair)

Refs #3552. Relates to #3543, #3548, #3381. Not auto-closing — leaving that to the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
