### PR TITLE
feat(agent): decode, gate and redact script secret variables (#3409 PR4b)

### DIFF
--- a/agent/internal/executor/executor.go
+++ b/agent/internal/executor/executor.go
@@ -39,6 +39,13 @@ type ScriptExecution struct {
 	Parameters map[string]string `json:"parameters,omitempty"`
 	Timeout    int               `json:"timeout"`
 	RunAs      string            `json:"runAs,omitempty"`
+
+	// #3409 PR4b — secret tenant variables, delivered as process environment
+	// rather than substituted into the script text. `json:"-"` because this
+	// struct must never carry a credential onto any wire or into any file;
+	// SecretEnv's own String/Format/MarshalJSON redact as a second layer.
+	// Populated only by heartbeat.handleScript, which validates it first.
+	SecretEnv SecretEnv `json:"-"`
 }
 
 // ScriptResult represents the result of a script execution
@@ -339,6 +346,19 @@ func (e *Executor) buildEnvironment(script ScriptExecution) []string {
 	for key, value := range script.Parameters {
 		envKey := "BREEZE_PARAM_" + strings.ToUpper(strings.ReplaceAll(key, "-", "_"))
 		env = append(env, envKey+"="+value)
+	}
+
+	// #3409 PR4b: secrets ride the environment, never the script text — the
+	// substituted script is written to a temp file on the customer's disk.
+	// Appended after os.Environ() on purpose: os/exec dedupes Cmd.Env keeping
+	// the LAST occurrence, so a pre-existing BREEZE_VAR_* in the machine
+	// environment cannot shadow a delivered secret.
+	//
+	// Keys were validated against the tenant-variable grammar by
+	// ParseSecretEnv, so no character mapping is needed here (unlike the
+	// parameter loop above, which has to fold "-" to "_").
+	for key, value := range script.SecretEnv {
+		env = append(env, script.SecretEnv.EnvKey(key)+"="+value)
 	}
 
 	return env

--- a/agent/internal/executor/executor_test.go
+++ b/agent/internal/executor/executor_test.go
@@ -1,6 +1,8 @@
 package executor
 
 import (
+	"encoding/json"
+	"fmt"
 	"os/exec"
 	"reflect"
 	"runtime"
@@ -198,5 +200,168 @@ func TestConfigureRunAsRootUsesSudoOnUnix(t *testing.T) {
 	}
 	if len(cmd.Args) < 3 || cmd.Args[0] != "sudo" || cmd.Args[1] != "-n" || cmd.Args[2] != "bash" {
 		t.Fatalf("unexpected sudo args: %#v", cmd.Args)
+	}
+}
+
+// countEnvEntries returns how many entries in env exactly equal key+"="+value.
+// os/exec dedupes Cmd.Env by keeping the LAST occurrence, but buildEnvironment
+// returns the raw (possibly duplicated) slice, so tests that care about
+// duplication count occurrences rather than relying on a single membership
+// check.
+func countEnvEntries(env []string, key, value string) int {
+	target := key + "=" + value
+	count := 0
+	for _, entry := range env {
+		if entry == target {
+			count++
+		}
+	}
+	return count
+}
+
+// lastEnvEntry returns the last entry in env whose key matches, or "" if none
+// exists. Mirrors the dedupe behavior os/exec applies to Cmd.Env (keep last).
+func lastEnvEntry(env []string, key string) (string, bool) {
+	prefix := key + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		if strings.HasPrefix(env[i], prefix) {
+			return strings.TrimPrefix(env[i], prefix), true
+		}
+	}
+	return "", false
+}
+
+func TestBuildEnvironmentIncludesSecretEnv(t *testing.T) {
+	e := newTestExecutor()
+	env := e.buildEnvironment(ScriptExecution{
+		ID:       "exec-secret",
+		ScriptID: "script-secret",
+		SecretEnv: SecretEnv{
+			"api_token": "super-secret-value",
+		},
+	})
+
+	if !hasEnvEntry(env, "BREEZE_VAR_API_TOKEN", "super-secret-value") {
+		t.Fatal("missing BREEZE_VAR_API_TOKEN")
+	}
+	if !hasEnvEntry(env, "BREEZE_EXECUTION_ID", "exec-secret") {
+		t.Fatal("missing BREEZE_EXECUTION_ID")
+	}
+	if !hasEnvEntry(env, "BREEZE_SCRIPT_ID", "script-secret") {
+		t.Fatal("missing BREEZE_SCRIPT_ID")
+	}
+}
+
+func TestBuildEnvironmentParamAndSecretNamespacesDoNotCollide(t *testing.T) {
+	e := newTestExecutor()
+	env := e.buildEnvironment(ScriptExecution{
+		ID:       "exec-both",
+		ScriptID: "script-both",
+		Parameters: map[string]string{
+			"token": "param-value",
+		},
+		SecretEnv: SecretEnv{
+			"token": "secret-value",
+		},
+	})
+
+	if !hasEnvEntry(env, "BREEZE_PARAM_TOKEN", "param-value") {
+		t.Fatal("missing BREEZE_PARAM_TOKEN")
+	}
+	if !hasEnvEntry(env, "BREEZE_VAR_TOKEN", "secret-value") {
+		t.Fatal("missing BREEZE_VAR_TOKEN")
+	}
+	if hasEnvEntry(env, "BREEZE_PARAM_TOKEN", "secret-value") {
+		t.Fatal("secret value leaked into the BREEZE_PARAM_ namespace")
+	}
+	if hasEnvEntry(env, "BREEZE_VAR_TOKEN", "param-value") {
+		t.Fatal("parameter value leaked into the BREEZE_VAR_ namespace")
+	}
+}
+
+func TestBuildEnvironmentSecretIsAppendedAfterOsEnvironAndWins(t *testing.T) {
+	// Seed a machine-environment value under the same BREEZE_VAR_ key the
+	// delivered secret will use. os/exec dedupes Cmd.Env keeping the LAST
+	// occurrence, so the delivered secret must be the last entry with this
+	// key or a hostile pre-existing environment variable could shadow it.
+	t.Setenv("BREEZE_VAR_API_TOKEN", "inherited-value")
+
+	e := newTestExecutor()
+	env := e.buildEnvironment(ScriptExecution{
+		ID:       "exec-shadow",
+		ScriptID: "script-shadow",
+		SecretEnv: SecretEnv{
+			"api_token": "delivered-value",
+		},
+	})
+
+	got, ok := lastEnvEntry(env, "BREEZE_VAR_API_TOKEN")
+	if !ok {
+		t.Fatal("missing BREEZE_VAR_API_TOKEN entry")
+	}
+	if got != "delivered-value" {
+		t.Fatalf("last BREEZE_VAR_API_TOKEN entry = %q, want %q (inherited value must not win)", got, "delivered-value")
+	}
+	if countEnvEntries(env, "BREEZE_VAR_API_TOKEN", "delivered-value") != 1 {
+		t.Fatalf("expected exactly one delivered-value entry, env: %#v", env)
+	}
+	if countEnvEntries(env, "BREEZE_VAR_API_TOKEN", "inherited-value") != 1 {
+		t.Fatalf("expected the inherited os.Environ() entry to still be present ahead of the delivered one, env: %#v", env)
+	}
+}
+
+func TestBuildEnvironmentEmptyOrNilSecretEnvAddsNoEntries(t *testing.T) {
+	e := newTestExecutor()
+
+	for name, secretEnv := range map[string]SecretEnv{
+		"nil":   nil,
+		"empty": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			env := e.buildEnvironment(ScriptExecution{
+				ID:        "exec-nosecrets",
+				ScriptID:  "script-nosecrets",
+				SecretEnv: secretEnv,
+			})
+			for _, entry := range env {
+				if strings.HasPrefix(entry, SecretEnvPrefix) {
+					t.Fatalf("unexpected %s entry with %s SecretEnv: %q", SecretEnvPrefix, name, entry)
+				}
+			}
+		})
+	}
+}
+
+func TestScriptExecutionRedactsSecretEnvUnderEveryVerbAndJSON(t *testing.T) {
+	const secretValue = "super-secret-value"
+	script := ScriptExecution{
+		ID:       "exec-redact",
+		ScriptID: "script-redact",
+		Script:   "echo hi",
+		SecretEnv: SecretEnv{
+			"api_token": secretValue,
+		},
+	}
+
+	renderings := map[string]string{
+		"%v":  fmt.Sprintf("%v", script),
+		"%+v": fmt.Sprintf("%+v", script),
+		"%#v": fmt.Sprintf("%#v", script),
+	}
+	for verb, rendered := range renderings {
+		if strings.Contains(rendered, secretValue) {
+			t.Fatalf("%s rendering of ScriptExecution leaked the secret value: %s", verb, rendered)
+		}
+	}
+
+	marshaled, err := json.Marshal(script)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	if strings.Contains(string(marshaled), secretValue) {
+		t.Fatalf("json.Marshal of ScriptExecution leaked the secret value: %s", marshaled)
+	}
+	if strings.Contains(string(marshaled), "SecretEnv") {
+		t.Fatalf("json.Marshal of ScriptExecution should omit SecretEnv entirely (json:\"-\"), got: %s", marshaled)
 	}
 }

--- a/agent/internal/executor/secretenv.go
+++ b/agent/internal/executor/secretenv.go
@@ -14,7 +14,8 @@ import (
 // marked secret, delivered to the agent encrypted in transit (the server seals
 // them into one AAD-bound envelope and opens it only at delivery — see
 // apps/api/src/services/scriptSecretEnvelope.ts) and injected here as process
-// environment.
+// environment. That file ships in PR4a (#3557), not present on this branch's
+// base yet — the citation is a forward reference, not an error.
 //
 // Environment, deliberately, and NOT parameter substitution: the substituted
 // script is written to a temp file on the customer's disk (shell.go
@@ -26,7 +27,9 @@ const (
 	SecretEnvPayloadKey = "secretEnv"
 
 	// MinSecretValueLength mirrors MIN_SECRET_TENANT_VARIABLE_VALUE_LENGTH in
-	// packages/shared/src/validators/tenantVariables.ts. A secret shorter than
+	// packages/shared/src/validators/tenantVariables.ts. That file already
+	// exists on this branch's base, but the constant itself ships in PR4a
+	// (#3557) — a forward reference, not an error. A secret shorter than
 	// this cannot be exact-value-redacted from script output without shredding
 	// the output itself (imagine redacting every "ab"), so rather than choose
 	// between destroying the operator's output and leaking the credential, the
@@ -35,8 +38,9 @@ const (
 	MinSecretValueLength = 4
 
 	// MaxSecretEnvEntries mirrors MAX_SECRET_ENV_ENTRIES in
-	// apps/api/src/services/scriptSecretEnvelope.ts. Bounds the redactor's work
-	// and the environment block.
+	// apps/api/src/services/scriptSecretEnvelope.ts (ships in PR4a, #3557 —
+	// not present on this branch's base yet). Bounds the redactor's work and
+	// the environment block.
 	MaxSecretEnvEntries = 32
 
 	// SecretEnvPrefix is the environment-variable namespace. A script reads a

--- a/agent/internal/executor/secretenv.go
+++ b/agent/internal/executor/secretenv.go
@@ -44,10 +44,20 @@ const (
 	SecretEnvPrefix = "BREEZE_VAR_"
 )
 
-// secretKeyPattern mirrors TENANT_VARIABLE_KEY_PATTERN on the server. Enforced
-// agent-side too so a malformed key cannot inject a second environment entry
-// (a key containing "=" or a newline would otherwise split the env block).
-var secretKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+// secretKeyPattern is EXACTLY TENANT_VARIABLE_KEY_PATTERN from the server
+// (packages/shared/src/validators/tenantVariables.ts), which the
+// tenant_variables_key_chk DB constraint also enforces. Re-enforced agent-side
+// so a malformed key cannot inject a second environment entry (a key containing
+// "=" or a newline would otherwise split the env block), and deliberately not
+// one character laxer than its only producer: anything outside this grammar is
+// something the server should never have sent, so refusing it is fail-closed.
+//
+// The lowercase-only grammar is also what makes EnvKey's ToUpper folding
+// injective: two distinct keys cannot collide on one BREEZE_VAR_* name. If this
+// pattern is ever widened to admit uppercase, that stops being true and
+// ParseSecretEnv must grow a collision check — otherwise which secret wins would
+// depend on Go's randomized map iteration order.
+var secretKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,63}$`)
 
 // SecretEnv holds the secret variable values for a single script execution.
 //
@@ -134,7 +144,6 @@ func ParseSecretEnv(raw any) (SecretEnv, error) {
 	}
 	sort.Strings(keys)
 
-	seenEnvKeys := make(map[string]string, len(m))
 	for _, key := range keys {
 		if !secretKeyPattern.MatchString(key) {
 			return nil, fmt.Errorf("secretEnv key %q is not a valid variable key", key)
@@ -149,16 +158,6 @@ func ParseSecretEnv(raw any) (SecretEnv, error) {
 				key, MinSecretValueLength,
 			)
 		}
-		envKey := out.EnvKey(key)
-		if prior, dup := seenEnvKeys[envKey]; dup {
-			// Two keys differing only in case would both become the same
-			// BREEZE_VAR_* entry, and which one won would depend on map
-			// iteration order. Refuse rather than run a coin flip.
-			return nil, fmt.Errorf(
-				"secretEnv keys %q and %q both map to %s", prior, key, envKey,
-			)
-		}
-		seenEnvKeys[envKey] = key
 		out[key] = value
 	}
 	return out, nil

--- a/agent/internal/executor/secretenv.go
+++ b/agent/internal/executor/secretenv.go
@@ -1,0 +1,165 @@
+package executor
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// #3409 PR4b — agent-side secret variable delivery.
+//
+// A `script` command may carry a `secretEnv` map: tenant variables the operator
+// marked secret, delivered to the agent encrypted in transit (the server seals
+// them into one AAD-bound envelope and opens it only at delivery — see
+// apps/api/src/services/scriptSecretEnvelope.ts) and injected here as process
+// environment.
+//
+// Environment, deliberately, and NOT parameter substitution: the substituted
+// script is written to a temp file on the customer's disk (shell.go
+// WriteScriptFile), so a substituted secret becomes a file on their filesystem.
+// SecretEnv values must therefore never reach SubstituteParameters or
+// validateScript.
+const (
+	// SecretEnvPayloadKey is the wire field name on a `script` command payload.
+	SecretEnvPayloadKey = "secretEnv"
+
+	// MinSecretValueLength mirrors MIN_SECRET_TENANT_VARIABLE_VALUE_LENGTH in
+	// packages/shared/src/validators/tenantVariables.ts. A secret shorter than
+	// this cannot be exact-value-redacted from script output without shredding
+	// the output itself (imagine redacting every "ab"), so rather than choose
+	// between destroying the operator's output and leaking the credential, the
+	// command is refused. The server rejects such a value at save time and at
+	// seal time; this is the fail-closed backstop.
+	MinSecretValueLength = 4
+
+	// MaxSecretEnvEntries mirrors MAX_SECRET_ENV_ENTRIES in
+	// apps/api/src/services/scriptSecretEnvelope.ts. Bounds the redactor's work
+	// and the environment block.
+	MaxSecretEnvEntries = 32
+
+	// SecretEnvPrefix is the environment-variable namespace. A script reads a
+	// secret as $BREEZE_VAR_API_TOKEN / $env:BREEZE_VAR_API_TOKEN.
+	SecretEnvPrefix = "BREEZE_VAR_"
+)
+
+// secretKeyPattern mirrors TENANT_VARIABLE_KEY_PATTERN on the server. Enforced
+// agent-side too so a malformed key cannot inject a second environment entry
+// (a key containing "=" or a newline would otherwise split the env block).
+var secretKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// SecretEnv holds the secret variable values for a single script execution.
+//
+// It is a distinct type rather than a bare map so that every representation Go
+// can produce for it redacts: a stray log line, a %+v on the enclosing
+// ScriptExecution, or an accidental json.Marshal can never emit a credential.
+// Same defense secmem.SecureString provides for the enrollment token
+// (agent/internal/secmem/secmem.go). Use Values() to reach the plaintext, which
+// only the environment builder and the output redactor do.
+type SecretEnv map[string]string
+
+// String redacts. This is what fmt uses for %v, %s and %+v.
+func (SecretEnv) String() string { return "[REDACTED]" }
+
+// GoString redacts %#v, which does not consult Stringer.
+func (SecretEnv) GoString() string { return "executor.SecretEnv{[REDACTED]}" }
+
+// Format catches every remaining verb (%q, %x, ...) so no format string can
+// coax the plaintext out.
+func (s SecretEnv) Format(f fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if f.Flag('#') {
+			_, _ = fmt.Fprint(f, s.GoString())
+			return
+		}
+	}
+	_, _ = fmt.Fprint(f, s.String())
+}
+
+// MarshalJSON redacts, so a SecretEnv can never be serialized back onto a wire
+// or into a result frame.
+func (SecretEnv) MarshalJSON() ([]byte, error) { return json.Marshal("[REDACTED]") }
+
+// UnmarshalJSON always fails: the only supported way to build a SecretEnv is
+// ParseSecretEnv, which validates. A silent json.Unmarshal would bypass every
+// check in this file.
+func (*SecretEnv) UnmarshalJSON([]byte) error {
+	return fmt.Errorf("executor: SecretEnv must be built with ParseSecretEnv")
+}
+
+// Values returns each secret value once, for the output redactor.
+func (s SecretEnv) Values() []string {
+	out := make([]string, 0, len(s))
+	for _, v := range s {
+		out = append(out, v)
+	}
+	return out
+}
+
+// EnvKey maps a variable key to its environment variable name.
+func (SecretEnv) EnvKey(key string) string {
+	return SecretEnvPrefix + strings.ToUpper(key)
+}
+
+// ParseSecretEnv validates a raw `secretEnv` payload value.
+//
+// Fail-closed by design: EVERY malformed entry is an error, and the caller must
+// refuse to run the script. Running with a credential env var unset is not a
+// degraded success — it can mean anonymous access, an auth fallback, an account
+// lockout, or a destructive operation against the wrong target.
+//
+// Errors name the offending KEY and never the value: these strings travel back
+// to the server as result.Error and land in logs.
+func ParseSecretEnv(raw any) (SecretEnv, error) {
+	if raw == nil {
+		return SecretEnv{}, nil
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("secretEnv must be an object")
+	}
+	if len(m) > MaxSecretEnvEntries {
+		return nil, fmt.Errorf("secretEnv has %d entries, maximum is %d", len(m), MaxSecretEnvEntries)
+	}
+
+	out := make(SecretEnv, len(m))
+	// Sorted so the error reported for a multi-fault map is deterministic —
+	// Go randomizes map iteration, and a test that asserts on error text would
+	// otherwise flake.
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	seenEnvKeys := make(map[string]string, len(m))
+	for _, key := range keys {
+		if !secretKeyPattern.MatchString(key) {
+			return nil, fmt.Errorf("secretEnv key %q is not a valid variable key", key)
+		}
+		value, ok := m[key].(string)
+		if !ok {
+			return nil, fmt.Errorf("secretEnv value for %q is not a string", key)
+		}
+		if len(value) < MinSecretValueLength {
+			return nil, fmt.Errorf(
+				"secretEnv value for %q is shorter than %d characters and cannot be redacted from output",
+				key, MinSecretValueLength,
+			)
+		}
+		envKey := out.EnvKey(key)
+		if prior, dup := seenEnvKeys[envKey]; dup {
+			// Two keys differing only in case would both become the same
+			// BREEZE_VAR_* entry, and which one won would depend on map
+			// iteration order. Refuse rather than run a coin flip.
+			return nil, fmt.Errorf(
+				"secretEnv keys %q and %q both map to %s", prior, key, envKey,
+			)
+		}
+		seenEnvKeys[envKey] = key
+		out[key] = value
+	}
+	return out, nil
+}

--- a/agent/internal/executor/secretenv_test.go
+++ b/agent/internal/executor/secretenv_test.go
@@ -1,0 +1,215 @@
+package executor
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestParseSecretEnv_Accepts(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+		want SecretEnv
+	}{
+		{
+			name: "nil payload yields empty SecretEnv",
+			raw:  nil,
+			want: SecretEnv{},
+		},
+		{
+			name: "empty object yields empty SecretEnv",
+			raw:  map[string]any{},
+			want: SecretEnv{},
+		},
+		{
+			name: "single valid entry",
+			raw:  map[string]any{"api_token": "super-secret-value"},
+			want: SecretEnv{"api_token": "super-secret-value"},
+		},
+		{
+			name: "leading underscore key",
+			raw:  map[string]any{"_token": "leading-underscore-ok"},
+			want: SecretEnv{"_token": "leading-underscore-ok"},
+		},
+		{
+			name: "digits after first char key",
+			raw:  map[string]any{"token2": "digits-after-first-ok"},
+			want: SecretEnv{"token2": "digits-after-first-ok"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSecretEnv(tt.raw)
+			if err != nil {
+				t.Fatalf("ParseSecretEnv(%#v) unexpected error: %v", tt.raw, err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseSecretEnv(%#v) = %d entries, want %d", tt.raw, len(got), len(tt.want))
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("ParseSecretEnv(%#v)[%q] = %q, want %q", tt.raw, k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestParseSecretEnv_RejectsMalformedShape(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+	}{
+		{"string instead of object", "nope"},
+		{"array instead of object", []any{"a"}},
+		{"number instead of object", 42},
+		{"non-string value", map[string]any{"api_token": 42}},
+		{"empty value", map[string]any{"api_token": ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseSecretEnv(tt.raw)
+			if err == nil {
+				t.Fatalf("ParseSecretEnv(%#v) = nil error, want error", tt.raw)
+			}
+		})
+	}
+}
+
+func TestParseSecretEnv_RejectsShortValue_WithoutLeakingIt(t *testing.T) {
+	_, err := ParseSecretEnv(map[string]any{"api_token": "ab"})
+	if err == nil {
+		t.Fatal("ParseSecretEnv with a 2-char value = nil error, want error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "api_token") {
+		t.Errorf("error %q does not name the offending key %q", msg, "api_token")
+	}
+	if strings.Contains(msg, "\"ab\"") {
+		t.Errorf("error %q leaks the rejected value", msg)
+	}
+	if !strings.Contains(msg, "4") {
+		t.Errorf("error %q does not mention the length floor (MinSecretValueLength=%d)", msg, MinSecretValueLength)
+	}
+}
+
+func TestParseSecretEnv_RejectsInvalidKeyGrammar(t *testing.T) {
+	badKeys := []string{"BAD KEY", "9lives", "a-b", ""}
+
+	for _, key := range badKeys {
+		t.Run(fmt.Sprintf("key=%q", key), func(t *testing.T) {
+			_, err := ParseSecretEnv(map[string]any{key: "valid-length-value"})
+			if err == nil {
+				t.Fatalf("ParseSecretEnv with key %q = nil error, want error", key)
+			}
+		})
+	}
+}
+
+func TestParseSecretEnv_RejectsTooManyEntries(t *testing.T) {
+	m := make(map[string]any, MaxSecretEnvEntries+1)
+	for i := 0; i < MaxSecretEnvEntries+1; i++ {
+		m[fmt.Sprintf("key_%02d", i)] = "valid-length-value"
+	}
+
+	_, err := ParseSecretEnv(m)
+	if err == nil {
+		t.Fatalf("ParseSecretEnv with %d entries = nil error, want error", len(m))
+	}
+}
+
+func TestParseSecretEnv_RejectsCaseCollision(t *testing.T) {
+	raw := map[string]any{
+		"api_token": "value-one-long",
+		"API_TOKEN": "value-two-long",
+	}
+
+	_, err := ParseSecretEnv(raw)
+	if err == nil {
+		t.Fatal("ParseSecretEnv with case-colliding keys = nil error, want error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "api_token") || !strings.Contains(msg, "API_TOKEN") {
+		t.Errorf("error %q does not name both colliding keys", msg)
+	}
+}
+
+// TestSecretEnv_RedactsEveryRepresentation is the empirical check the brief
+// calls out: NO format verb, and no serialization path, may extract the
+// plaintext value. Every representation must both omit the plaintext and
+// carry the [REDACTED] marker.
+func TestSecretEnv_RedactsEveryRepresentation(t *testing.T) {
+	const secretValue = "super-secret-value"
+	se := SecretEnv{"api_token": secretValue}
+
+	jsonBytes, err := json.Marshal(se)
+	if err != nil {
+		t.Fatalf("json.Marshal(se) unexpected error: %v", err)
+	}
+
+	reps := map[string]string{
+		"%v":           fmt.Sprintf("%v", se),
+		"%+v":          fmt.Sprintf("%+v", se),
+		"%#v":          fmt.Sprintf("%#v", se),
+		"%s":           fmt.Sprintf("%s", se),
+		"%q":           fmt.Sprintf("%q", se),
+		"%x":           fmt.Sprintf("%x", se),
+		"String()":     se.String(),
+		"json.Marshal": string(jsonBytes),
+	}
+
+	for label, rep := range reps {
+		if strings.Contains(rep, secretValue) {
+			t.Errorf("representation %s leaks the secret value: %q", label, rep)
+		}
+		if !strings.Contains(rep, "[REDACTED]") {
+			t.Errorf("representation %s = %q, want it to contain the [REDACTED] marker", label, rep)
+		}
+	}
+}
+
+func TestSecretEnv_UnmarshalJSON_AlwaysFails(t *testing.T) {
+	var se SecretEnv
+	err := json.Unmarshal([]byte(`{"api_token":"super-secret-value"}`), &se)
+	if err == nil {
+		t.Fatal("json.Unmarshal into SecretEnv = nil error, want error (ParseSecretEnv is the only supported constructor)")
+	}
+}
+
+func TestSecretEnv_Values(t *testing.T) {
+	se := SecretEnv{
+		"api_token":  "value-one-long",
+		"db_pass":    "value-two-long",
+		"webhook_id": "value-three-long",
+	}
+
+	got := se.Values()
+	if len(got) != len(se) {
+		t.Fatalf("Values() returned %d values, want %d", len(got), len(se))
+	}
+
+	want := map[string]int{}
+	for _, v := range se {
+		want[v]++
+	}
+	gotCount := map[string]int{}
+	for _, v := range got {
+		gotCount[v]++
+	}
+	for v, n := range want {
+		if gotCount[v] != n {
+			t.Errorf("Values() contains %q %d times, want %d", v, gotCount[v], n)
+		}
+	}
+}
+
+func TestSecretEnv_EnvKey(t *testing.T) {
+	var se SecretEnv
+	if got, want := se.EnvKey("api_token"), "BREEZE_VAR_API_TOKEN"; got != want {
+		t.Errorf("EnvKey(%q) = %q, want %q", "api_token", got, want)
+	}
+}

--- a/agent/internal/executor/secretenv_test.go
+++ b/agent/internal/executor/secretenv_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+// key64 is exactly 64 lowercase characters — the inclusive cap of
+// secretKeyPattern (^[a-z][a-z0-9_]{0,63}$: 1 leading letter + up to 63 more).
+// key65 is one character over that cap and must be rejected.
+var (
+	key64 = "a" + strings.Repeat("b", 63)
+	key65 = "a" + strings.Repeat("b", 64)
+)
+
 func TestParseSecretEnv_Accepts(t *testing.T) {
 	tests := []struct {
 		name string
@@ -29,14 +37,14 @@ func TestParseSecretEnv_Accepts(t *testing.T) {
 			want: SecretEnv{"api_token": "super-secret-value"},
 		},
 		{
-			name: "leading underscore key",
-			raw:  map[string]any{"_token": "leading-underscore-ok"},
-			want: SecretEnv{"_token": "leading-underscore-ok"},
-		},
-		{
 			name: "digits after first char key",
 			raw:  map[string]any{"token2": "digits-after-first-ok"},
 			want: SecretEnv{"token2": "digits-after-first-ok"},
+		},
+		{
+			name: "64-character key (cap is inclusive)",
+			raw:  map[string]any{key64: "cap-inclusive-ok"},
+			want: SecretEnv{key64: "cap-inclusive-ok"},
 		},
 	}
 
@@ -67,7 +75,6 @@ func TestParseSecretEnv_RejectsMalformedShape(t *testing.T) {
 		{"array instead of object", []any{"a"}},
 		{"number instead of object", 42},
 		{"non-string value", map[string]any{"api_token": 42}},
-		{"empty value", map[string]any{"api_token": ""}},
 	}
 
 	for _, tt := range tests {
@@ -81,24 +88,36 @@ func TestParseSecretEnv_RejectsMalformedShape(t *testing.T) {
 }
 
 func TestParseSecretEnv_RejectsShortValue_WithoutLeakingIt(t *testing.T) {
-	_, err := ParseSecretEnv(map[string]any{"api_token": "ab"})
-	if err == nil {
-		t.Fatal("ParseSecretEnv with a 2-char value = nil error, want error")
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"2-char value", "ab"},
+		{"empty value", ""},
 	}
-	msg := err.Error()
-	if !strings.Contains(msg, "api_token") {
-		t.Errorf("error %q does not name the offending key %q", msg, "api_token")
-	}
-	if strings.Contains(msg, "\"ab\"") {
-		t.Errorf("error %q leaks the rejected value", msg)
-	}
-	if !strings.Contains(msg, "4") {
-		t.Errorf("error %q does not mention the length floor (MinSecretValueLength=%d)", msg, MinSecretValueLength)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseSecretEnv(map[string]any{"api_token": tt.value})
+			if err == nil {
+				t.Fatalf("ParseSecretEnv with value %q = nil error, want error", tt.value)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, "api_token") {
+				t.Errorf("error %q does not name the offending key %q", msg, "api_token")
+			}
+			if tt.value != "" && strings.Contains(msg, fmt.Sprintf("%q", tt.value)) {
+				t.Errorf("error %q leaks the rejected value", msg)
+			}
+			if !strings.Contains(msg, "4") {
+				t.Errorf("error %q does not mention the length floor (MinSecretValueLength=%d)", msg, MinSecretValueLength)
+			}
+		})
 	}
 }
 
 func TestParseSecretEnv_RejectsInvalidKeyGrammar(t *testing.T) {
-	badKeys := []string{"BAD KEY", "9lives", "a-b", ""}
+	badKeys := []string{"BAD KEY", "9lives", "a-b", "", "API_TOKEN", "_token", key65}
 
 	for _, key := range badKeys {
 		t.Run(fmt.Sprintf("key=%q", key), func(t *testing.T) {
@@ -119,22 +138,6 @@ func TestParseSecretEnv_RejectsTooManyEntries(t *testing.T) {
 	_, err := ParseSecretEnv(m)
 	if err == nil {
 		t.Fatalf("ParseSecretEnv with %d entries = nil error, want error", len(m))
-	}
-}
-
-func TestParseSecretEnv_RejectsCaseCollision(t *testing.T) {
-	raw := map[string]any{
-		"api_token": "value-one-long",
-		"API_TOKEN": "value-two-long",
-	}
-
-	_, err := ParseSecretEnv(raw)
-	if err == nil {
-		t.Fatal("ParseSecretEnv with case-colliding keys = nil error, want error")
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, "api_token") || !strings.Contains(msg, "API_TOKEN") {
-		t.Errorf("error %q does not name both colliding keys", msg)
 	}
 }
 

--- a/agent/internal/executor/secretredact.go
+++ b/agent/internal/executor/secretredact.go
@@ -23,6 +23,12 @@ const SecretRedactionMarker = "[REDACTED]"
 // careless output, never as a control against a hostile script author — who
 // holds the credential by definition.
 //
+// It also runs LAST, after two earlier transforms, and only matches text that
+// survived them intact: a secret whose middle is consumed by a SanitizeOutput
+// pattern, or one straddling the 1 MB limitedWriter cap (executor.go), can
+// leave an unmatched fragment behind. Inherent to redact-last; the alternative
+// (redact first) would let the pattern layer re-mangle the markers.
+//
 // Mirrors apps/api/src/services/exactSecretRedaction.ts so the agent and the
 // server produce identical redacted text for the same input.
 func BuildSecretRedactor(values []string) func(string) string {

--- a/agent/internal/executor/secretredact.go
+++ b/agent/internal/executor/secretredact.go
@@ -1,0 +1,103 @@
+package executor
+
+import (
+	"sort"
+	"strings"
+)
+
+// #3409 PR4b — value-based output redactor.
+//
+// SecretRedactionMarker is deliberately generic. A marker naming the variable
+// key would CONFIRM which credential the script emitted, to an audience
+// (`scripts:read` on the server) wider than the script's author — the leak this
+// exists to prevent, minus the characters.
+const SecretRedactionMarker = "[REDACTED]"
+
+// BuildSecretRedactor returns a function that removes every literal occurrence
+// of the supplied secret values from a text.
+//
+// Honest scope: this is ACCIDENTAL-LEAK protection, not DLP. It removes a
+// credential a script echoed, logged, or included in an error message. It
+// cannot catch a value the script transformed, base64-encoded, hashed,
+// reversed, or printed one character per line. Treat it as a safety net over
+// careless output, never as a control against a hostile script author — who
+// holds the credential by definition.
+//
+// Mirrors apps/api/src/services/exactSecretRedaction.ts so the agent and the
+// server produce identical redacted text for the same input.
+func BuildSecretRedactor(values []string) func(string) string {
+	seen := make(map[string]struct{}, len(values))
+	filtered := make([]string, 0, len(values))
+	for _, v := range values {
+		if len(v) < MinSecretValueLength {
+			continue
+		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		filtered = append(filtered, v)
+	}
+
+	if len(filtered) == 0 {
+		return func(s string) string { return s }
+	}
+
+	return func(text string) string {
+		type span struct{ start, end int }
+
+		var spans []span
+		for _, v := range filtered {
+			offset := 0
+			for {
+				idx := strings.Index(text[offset:], v)
+				if idx < 0 {
+					break
+				}
+				start := offset + idx
+				end := start + len(v)
+				spans = append(spans, span{start, end})
+				// Advance by the match length, not by one, so a value never
+				// matches inside its own already-recorded match.
+				offset = end
+			}
+		}
+
+		if len(spans) == 0 {
+			return text
+		}
+
+		sort.Slice(spans, func(i, j int) bool {
+			if spans[i].start != spans[j].start {
+				return spans[i].start < spans[j].start
+			}
+			return spans[i].end < spans[j].end
+		})
+
+		merged := spans[:1]
+		for _, s := range spans[1:] {
+			last := &merged[len(merged)-1]
+			if s.start <= last.end {
+				// Overlapping or adjacent — extend the current run rather
+				// than starting a new one, so they collapse into one marker.
+				if s.end > last.end {
+					last.end = s.end
+				}
+				continue
+			}
+			merged = append(merged, s)
+		}
+
+		var b strings.Builder
+		b.Grow(len(text))
+		cursor := 0
+		for _, m := range merged {
+			b.WriteString(text[cursor:m.start])
+			b.WriteString(SecretRedactionMarker)
+			cursor = m.end
+		}
+		b.WriteString(text[cursor:])
+
+		return b.String()
+	}
+}

--- a/agent/internal/executor/secretredact.go
+++ b/agent/internal/executor/secretredact.go
@@ -29,8 +29,9 @@ const SecretRedactionMarker = "[REDACTED]"
 // leave an unmatched fragment behind. Inherent to redact-last; the alternative
 // (redact first) would let the pattern layer re-mangle the markers.
 //
-// Mirrors apps/api/src/services/exactSecretRedaction.ts so the agent and the
-// server produce identical redacted text for the same input.
+// Mirrors apps/api/src/services/exactSecretRedaction.ts (ships in PR4a,
+// #3557 — not present on this branch's base yet) so the agent and the server
+// produce identical redacted text for the same input.
 func BuildSecretRedactor(values []string) func(string) string {
 	seen := make(map[string]struct{}, len(values))
 	filtered := make([]string, 0, len(values))
@@ -83,9 +84,14 @@ func BuildSecretRedactor(values []string) func(string) string {
 		merged := spans[:1]
 		for _, s := range spans[1:] {
 			last := &merged[len(merged)-1]
-			if s.start <= last.end {
-				// Overlapping or adjacent — extend the current run rather
-				// than starting a new one, so they collapse into one marker.
+			// `<` (not `<=`): two ranges that merely ABUT (s.start == last.end)
+			// are distinct occurrences and each earns its own marker — mirrors
+			// the server's exactSecretRedaction.ts merge condition exactly, so
+			// abutting-but-non-overlapping secrets redact to two markers on
+			// both ends, not one.
+			if s.start < last.end {
+				// Genuinely overlapping — extend the current run rather than
+				// starting a new one, so they collapse into one marker.
 				if s.end > last.end {
 					last.end = s.end
 				}

--- a/agent/internal/executor/secretredact_test.go
+++ b/agent/internal/executor/secretredact_test.go
@@ -1,0 +1,134 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3409 PR4b — value-based output redactor. Mirrors
+// apps/api/src/services/exactSecretRedaction.ts (not present in this
+// worktree; behavior specified in the task brief).
+
+func TestBuildSecretRedactor_ReplacesEveryOccurrence(t *testing.T) {
+	redact := BuildSecretRedactor([]string{"hunter2000"})
+	got := redact("token=hunter2000 and again hunter2000")
+	want := "token=[REDACTED] and again [REDACTED]"
+	if got != want {
+		t.Fatalf("redact() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildSecretRedactor_NeverNamesTheVariable(t *testing.T) {
+	redact := BuildSecretRedactor([]string{"hunter2000"})
+	got := redact("hunter2000")
+	if got != SecretRedactionMarker {
+		t.Fatalf("redact() = %q, want exactly %q (marker must never name the variable)", got, SecretRedactionMarker)
+	}
+}
+
+func TestBuildSecretRedactor_LiteralNotPattern(t *testing.T) {
+	// "a.c*d" would match "abcd" as a regex (. and * are metacharacters).
+	// Treated as a literal, it must not.
+	redact := BuildSecretRedactor([]string{"a.c*d"})
+	got := redact("abcd a.c*d")
+	want := "abcd [REDACTED]"
+	if got != want {
+		t.Fatalf("redact() = %q, want %q (value must be matched literally, not compiled as regex)", got, want)
+	}
+}
+
+func TestBuildSecretRedactor_MergesOverlappingMatchesIntoOneMarker(t *testing.T) {
+	// "abcabc" matches [2,8) in "xxabcabcxx"; "bcab" matches [3,7). These
+	// overlap and must collapse into a single marker, not two adjacent ones.
+	redact := BuildSecretRedactor([]string{"abcabc", "bcab"})
+	got := redact("xxabcabcxx")
+	want := "xx[REDACTED]xx"
+	if got != want {
+		t.Fatalf("redact() = %q, want %q (overlapping ranges must merge into one marker)", got, want)
+	}
+}
+
+func TestBuildSecretRedactor_DoesNotRescanItsOwnMarker(t *testing.T) {
+	// "REDACTED" is itself a supplied secret value. The text "secret" does not
+	// contain "REDACTED" until AFTER redaction, so matching must happen only
+	// against the original text — never against intermediate output.
+	redact := BuildSecretRedactor([]string{"secret", "REDACTED"})
+	got := redact("secret")
+	if got != SecretRedactionMarker {
+		t.Fatalf("redact() = %q, want exactly %q (must not rescan its own marker text)", got, SecretRedactionMarker)
+	}
+}
+
+func TestBuildSecretRedactor_Idempotent(t *testing.T) {
+	redact := BuildSecretRedactor([]string{"hunter2000"})
+	once := redact("token=hunter2000 and again hunter2000")
+	twice := redact(once)
+	if twice != once {
+		t.Fatalf("redacting output again changed it: once=%q twice=%q", once, twice)
+	}
+}
+
+func TestBuildSecretRedactor_DedupesIdenticalValues(t *testing.T) {
+	redact := BuildSecretRedactor([]string{"hunter2000", "hunter2000"})
+	got := redact("token=hunter2000")
+	want := "token=[REDACTED]"
+	if got != want {
+		t.Fatalf("redact() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildSecretRedactor_IgnoresEmptyAndSubFloorValues(t *testing.T) {
+	if MinSecretValueLength <= 2 {
+		t.Fatalf("test assumes MinSecretValueLength > 2, got %d", MinSecretValueLength)
+	}
+	redact := BuildSecretRedactor([]string{"", "ab"})
+	input := "ab and an empty  gap"
+	got := redact(input)
+	if got != input {
+		t.Fatalf("redact() = %q, want input unchanged %q (empty and sub-floor values must be ignored, not shred output)", got, input)
+	}
+}
+
+func TestBuildSecretRedactor_PassthroughWhenNothingToRedact(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+	}{
+		{"nil slice", nil},
+		{"empty slice", []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			redact := BuildSecretRedactor(tt.values)
+			if redact == nil {
+				t.Fatalf("BuildSecretRedactor(%#v) returned a nil function, want a passthrough function", tt.values)
+			}
+			input := "nothing here should change"
+			got := redact(input)
+			if got != input {
+				t.Fatalf("redact() = %q, want input unchanged %q", got, input)
+			}
+		})
+	}
+}
+
+func TestBuildSecretRedactor_LargeInputNoQuadraticBlowup(t *testing.T) {
+	const secret = "super-secret-token-value-123456"
+	filler := strings.Repeat("x", 512*1024)
+	input := filler + secret + filler
+
+	redact := BuildSecretRedactor([]string{secret})
+	got := redact(input)
+
+	if !strings.Contains(got, SecretRedactionMarker) {
+		t.Fatalf("redact() output missing marker %q", SecretRedactionMarker)
+	}
+	if strings.Contains(got, secret) {
+		t.Fatalf("redact() output still contains the secret value")
+	}
+	wantLen := len(filler)*2 + len(SecretRedactionMarker)
+	if len(got) != wantLen {
+		t.Fatalf("redact() output length = %d, want %d", len(got), wantLen)
+	}
+}

--- a/agent/internal/executor/secretredact_test.go
+++ b/agent/internal/executor/secretredact_test.go
@@ -48,6 +48,19 @@ func TestBuildSecretRedactor_MergesOverlappingMatchesIntoOneMarker(t *testing.T)
 	}
 }
 
+func TestBuildSecretRedactor_AbuttingMatchesEarnSeparateMarkers(t *testing.T) {
+	// "abcd" matches [0,4) and "efgh" matches [4,8) in "abcdefgh" — they
+	// abut (end == next start) but do not overlap. The server's
+	// exactSecretRedaction.ts treats abutting ranges as two distinct
+	// occurrences, each earning its own marker, rather than merging them.
+	redact := BuildSecretRedactor([]string{"abcd", "efgh"})
+	got := redact("abcdefgh")
+	want := "[REDACTED][REDACTED]"
+	if got != want {
+		t.Fatalf("redact() = %q, want %q (abutting-but-non-overlapping matches must NOT merge)", got, want)
+	}
+}
+
 func TestBuildSecretRedactor_DoesNotRescanItsOwnMarker(t *testing.T) {
 	// "REDACTED" is itself a supplied secret value. The text "secret" does not
 	// contain "REDACTED" until AFTER redaction, so matching must happen only
@@ -68,7 +81,13 @@ func TestBuildSecretRedactor_Idempotent(t *testing.T) {
 	}
 }
 
-func TestBuildSecretRedactor_DedupesIdenticalValues(t *testing.T) {
+func TestBuildSecretRedactor_DuplicateValuesStillYieldOneMarker(t *testing.T) {
+	// Dedup is a performance guard (fewer redundant Index scans), not an
+	// observable-output guard: the two identical spans this would produce
+	// without dedup are identical ranges, which the merge step collapses to
+	// one marker regardless. This only proves duplicates don't crash or
+	// double-process — it does not pin dedup itself, which isn't otherwise
+	// observable from the output.
 	redact := BuildSecretRedactor([]string{"hunter2000", "hunter2000"})
 	got := redact("token=hunter2000")
 	want := "token=[REDACTED]"

--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -23,7 +23,49 @@ func init() {
 	handlerRegistry[tools.CmdScriptListRunning] = handleScriptListRunning
 }
 
+// handleScript is a thin wrapper that owns two invariants for EVERY exit path
+// of script execution — including early failures, the user-helper path, and
+// panicking-free error returns:
+//
+//  1. a malformed `secretEnv` fails the command before any script runs, and
+//  2. the delivered secret values are stripped from stdout, stderr AND error.
+//
+// `Error` in particular was copied raw out of the executor and out of the
+// helper IPC result, so a credential echoed into an error message reached the
+// server unredacted. Keeping the redaction here — rather than at the eight
+// executor sites that assign result.Error — means a new failure path cannot
+// silently opt out. Mirrors the server's own chokepoint invariant
+// (redactAgentResultErrorFields as the first statement of processCommandResult,
+// apps/api/src/routes/agentWs.ts).
 func handleScript(h *Heartbeat, cmd Command) tools.CommandResult {
+	start := time.Now()
+	secretEnv, err := executor.ParseSecretEnv(cmd.Payload[executor.SecretEnvPayloadKey])
+	if err != nil {
+		// Fail closed: never run a script whose secret map we could not
+		// validate. ParseSecretEnv error text names keys, never values.
+		return tools.CommandResult{
+			Status: "failed",
+			// Synthetic exit code: no process ran (see tools.CommandResult.ExitCode).
+			ExitCode:   1,
+			Error:      fmt.Sprintf("refusing to execute script: %v", err),
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+	res := handleScriptInner(h, cmd, secretEnv)
+	if len(secretEnv) == 0 {
+		return res
+	}
+	redact := executor.BuildSecretRedactor(secretEnv.Values())
+	res.Stdout = redact(res.Stdout)
+	res.Stderr = redact(res.Stderr)
+	res.Error = redact(res.Error)
+	return res
+}
+
+// handleScriptInner is the original handler body. Every return it makes flows
+// back through handleScript's redaction — do not call it (or the helper paths
+// it owns: executeViaUserHelper, executeScriptInSession) from anywhere else.
+func handleScriptInner(h *Heartbeat, cmd Command, secretEnv executor.SecretEnv) tools.CommandResult {
 	start := time.Now()
 	script := executor.ScriptExecution{
 		ID:         cmd.ID,
@@ -42,6 +84,11 @@ func handleScript(h *Heartbeat, cmd Command) tools.CommandResult {
 			}
 		}
 	}
+	// Validated by handleScript's ParseSecretEnv. Deliberately set AFTER the
+	// parameters block: secrets ride the process environment (buildEnvironment)
+	// and must never reach SubstituteParameters or validateScript, which would
+	// write them into the temp script file on the customer's disk.
+	script.SecretEnv = secretEnv
 	if script.Script == "" {
 		return tools.CommandResult{
 			Status: "failed",
@@ -55,6 +102,29 @@ func handleScript(h *Heartbeat, cmd Command) tools.CommandResult {
 	targetSessionID := -1
 	if ts, ok := cmd.Payload["targetSessionId"].(float64); ok && ts >= 0 && ts <= 65535 {
 		targetSessionID = int(ts)
+	}
+
+	// #3409 PR4b: secrets are delivered as process environment to the LOCAL
+	// executor only. The user-helper path forwards the raw payload over IPC and
+	// the helper never reads parameters or env (userhelper/client.go
+	// executeScript), so a user-context run would execute with the credential
+	// UNSET — anonymous access, an auth fallback, a lockout, or a destructive
+	// operation against the wrong target. Refuse instead. Lifting this needs a
+	// separately-versioned user-helper binary rollout (HelperVersion), which is
+	// deliberately out of scope for v1.
+	//
+	// Placed immediately after targetSessionID is derived so it precedes BOTH
+	// helper branches — the session-targeted one below and the
+	// resolveRunAsSession one after it.
+	if len(script.SecretEnv) > 0 && !runAsSupportsSecrets(script.RunAs, targetSessionID) {
+		return tools.CommandResult{
+			Status: "failed",
+			// Synthetic exit code: no process ran (see tools.CommandResult.ExitCode).
+			ExitCode: 1,
+			Error: "script uses secret variables, which require system-context execution; " +
+				"this script is configured to run as a user and was not executed",
+			DurationMs: time.Since(start).Milliseconds(),
+		}
 	}
 
 	// Explicit session targeting (RDS phase 1): route to exactly that
@@ -125,12 +195,33 @@ func handleScript(h *Heartbeat, cmd Command) tools.CommandResult {
 		status = "timeout"
 	}
 	return tools.CommandResult{
-		Status:     status,
-		ExitCode:   scriptResult.ExitCode,
-		Stdout:     executor.SanitizeOutput(scriptResult.Stdout),
-		Stderr:     executor.SanitizeOutput(scriptResult.Stderr),
-		Error:      scriptResult.Error,
+		Status:   status,
+		ExitCode: scriptResult.ExitCode,
+		Stdout:   executor.SanitizeOutput(scriptResult.Stdout),
+		Stderr:   executor.SanitizeOutput(scriptResult.Stderr),
+		// Error was the only result field that skipped the pattern sanitizer,
+		// so a credential shape in an executor error reached the server intact.
+		Error:      executor.SanitizeOutput(scriptResult.Error),
 		DurationMs: time.Since(start).Milliseconds(),
+	}
+}
+
+// runAsSupportsSecrets reports whether an execution with this runAs setting
+// will reach the LOCAL executor, which is the only path that carries
+// BREEZE_VAR_* environment. Mirrors resolveRunAsSession's contract: "", system
+// and elevated never resolve a helper session. An explicit username is refused
+// even though it currently falls through to local execution on an unresolved
+// lookup — that fall-through is a best-effort downgrade, and downgrading a
+// secret-bearing run is exactly what must not happen silently.
+func runAsSupportsSecrets(runAs string, targetSessionID int) bool {
+	if targetSessionID >= 0 {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(runAs)) {
+	case "", "system", "elevated":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -270,10 +361,12 @@ func (h *Heartbeat) executeViaUserHelper(session *sessionbroker.Session, cmd Com
 		)
 	}
 
-	// Translate IPC result to tools.CommandResult
+	// Translate IPC result to tools.CommandResult. Error was the only field
+	// copied straight out of the helper's IPC result without the pattern
+	// sanitizer that stdout/stderr get below.
 	cmdResult := tools.CommandResult{
 		Status:     result.Status,
-		Error:      result.Error,
+		Error:      executor.SanitizeOutput(result.Error),
 		DurationMs: time.Since(start).Milliseconds(),
 	}
 

--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/breeze-rmm/agent/internal/executor"
 	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/privilege"
 	"github.com/breeze-rmm/agent/internal/remote/tools"
 	"github.com/breeze-rmm/agent/internal/sessionbroker"
 )
@@ -32,8 +33,9 @@ func init() {
 //
 // `Error` in particular was copied raw out of the executor and out of the
 // helper IPC result, so a credential echoed into an error message reached the
-// server unredacted. Keeping the redaction here — rather than at the eight
-// executor sites that assign result.Error — means a new failure path cannot
+// server unredacted. BOTH error passes live here — the pattern-based
+// SanitizeOutput as well as the exact-value redactor — rather than at the eight
+// executor sites that assign result.Error, so a new failure path cannot
 // silently opt out. Mirrors the server's own chokepoint invariant
 // (redactAgentResultErrorFields as the first statement of processCommandResult,
 // apps/api/src/routes/agentWs.ts).
@@ -42,16 +44,25 @@ func handleScript(h *Heartbeat, cmd Command) tools.CommandResult {
 	secretEnv, err := executor.ParseSecretEnv(cmd.Payload[executor.SecretEnvPayloadKey])
 	if err != nil {
 		// Fail closed: never run a script whose secret map we could not
-		// validate. ParseSecretEnv error text names keys, never values.
+		// validate. ParseSecretEnv error text names keys, never values — but
+		// the key is server-supplied text, so it gets the same sanitizer as
+		// every other Error below.
 		return tools.CommandResult{
 			Status: "failed",
 			// Synthetic exit code: no process ran (see tools.CommandResult.ExitCode).
 			ExitCode:   1,
-			Error:      fmt.Sprintf("refusing to execute script: %v", err),
+			Error:      executor.SanitizeOutput(fmt.Sprintf("refusing to execute script: %v", err)),
 			DurationMs: time.Since(start).Milliseconds(),
 		}
 	}
 	res := handleScriptInner(h, cmd, secretEnv)
+	// Unconditional, and centralized here rather than at the result-build
+	// sites: the two tools.NewErrorResult returns (the executor error below and
+	// the helper IPC send failure in executeViaUserHelper — the latter is a
+	// live path) never had a sanitizer at all, which is precisely the "a new
+	// failure path silently opts out" failure this wrapper exists to prevent.
+	// Stdout/Stderr stay sanitized at their build sites; only Error moved.
+	res.Error = executor.SanitizeOutput(res.Error)
 	if len(secretEnv) == 0 {
 		return res
 	}
@@ -199,27 +210,46 @@ func handleScriptInner(h *Heartbeat, cmd Command, secretEnv executor.SecretEnv) 
 		ExitCode: scriptResult.ExitCode,
 		Stdout:   executor.SanitizeOutput(scriptResult.Stdout),
 		Stderr:   executor.SanitizeOutput(scriptResult.Stderr),
-		// Error was the only result field that skipped the pattern sanitizer,
-		// so a credential shape in an executor error reached the server intact.
-		Error:      executor.SanitizeOutput(scriptResult.Error),
+		// Error is deliberately raw here: handleScript sanitizes it for every
+		// exit path, including the NewErrorResult return above that never
+		// reached this build site. The timeout classification a few lines up
+		// also needs the unmodified text.
+		Error:      scriptResult.Error,
 		DurationMs: time.Since(start).Milliseconds(),
 	}
 }
 
+// isRunningElevated is an indirection over privilege.IsRunningAsRoot so the
+// elevated-path gate below can be tested deterministically on both root and
+// non-root hosts; CI runners differ.
+var isRunningElevated = privilege.IsRunningAsRoot
+
 // runAsSupportsSecrets reports whether an execution with this runAs setting
-// will reach the LOCAL executor, which is the only path that carries
-// BREEZE_VAR_* environment. Mirrors resolveRunAsSession's contract: "", system
-// and elevated never resolve a helper session. An explicit username is refused
-// even though it currently falls through to local execution on an unresolved
-// lookup — that fall-through is a best-effort downgrade, and downgrading a
-// secret-bearing run is exactly what must not happen silently.
+// will reach the LOCAL executor *with its environment intact* — the only way
+// BREEZE_VAR_* actually arrives.
+//
+// "" and system always do. An explicit username is refused even though it
+// currently falls through to local execution on an unresolved lookup — that
+// fall-through is a best-effort downgrade, and downgrading a secret-bearing run
+// is exactly what must not happen silently.
+//
+// `elevated` is admitted ONLY when the agent is already elevated, mirroring
+// executor.configureRunAs's own short-circuit. On a non-root Unix agent
+// configureRunAs re-execs the command through `sudo -n` with no -E /
+// --preserve-env, and sudo's default env_reset discards the BREEZE_VAR_*
+// entries built into cmd.Env — the script would run with the credential UNSET,
+// the same silent-wrong-run the helper IPC path is blocked for, reached by a
+// different mechanism. (-E is not the fix: it would change behavior for every
+// existing script and sudoers can refuse it outright.)
 func runAsSupportsSecrets(runAs string, targetSessionID int) bool {
 	if targetSessionID >= 0 {
 		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(runAs)) {
-	case "", "system", "elevated":
+	case "", "system":
 		return true
+	case "elevated":
+		return isRunningElevated()
 	default:
 		return false
 	}
@@ -361,12 +391,13 @@ func (h *Heartbeat) executeViaUserHelper(session *sessionbroker.Session, cmd Com
 		)
 	}
 
-	// Translate IPC result to tools.CommandResult. Error was the only field
-	// copied straight out of the helper's IPC result without the pattern
-	// sanitizer that stdout/stderr get below.
+	// Translate IPC result to tools.CommandResult. Error is copied raw and
+	// sanitized once, centrally, in handleScript — the send-failure return
+	// above never passes through here, so sanitizing at this site would have
+	// left that path uncovered.
 	cmdResult := tools.CommandResult{
 		Status:     result.Status,
-		Error:      executor.SanitizeOutput(result.Error),
+		Error:      result.Error,
 		DurationMs: time.Since(start).Milliseconds(),
 	}
 

--- a/agent/internal/heartbeat/handlers_script_secret_test.go
+++ b/agent/internal/heartbeat/handlers_script_secret_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/breeze-rmm/agent/internal/executor"
 	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/privilege"
 	"github.com/breeze-rmm/agent/internal/remote/tools"
 	"github.com/breeze-rmm/agent/internal/sessionbroker"
 )
@@ -157,6 +158,15 @@ func TestHandleScriptMalformedSecretEnvFailsClosed(t *testing.T) {
 			secretEnv: map[string]any{"API_TOKEN": testSecretValue},
 			wantIn:    []string{"API_TOKEN", "not a valid variable key"},
 			wantNotIn: []string{testSecretValue},
+		},
+		{
+			// The refusal quotes the offending key, which is server-supplied
+			// text — so even this earliest exit path runs through
+			// SanitizeOutput.
+			name:      "credential-shaped key is sanitized in the refusal",
+			secretEnv: map[string]any{awsKeyInError: testSecretValue},
+			wantIn:    []string{"[AWS_KEY_REDACTED]", "not a valid variable key"},
+			wantNotIn: []string{awsKeyInError, testSecretValue},
 		},
 	}
 
@@ -342,17 +352,65 @@ func TestHandleScriptSecretEnvRunsInSystemContexts(t *testing.T) {
 	}
 }
 
-func TestHandleScriptSecretEnvAllowsElevated(t *testing.T) {
-	// runAs=elevated stays a local execution (a sudo re-exec on unix), so the
-	// gate must let it through. Whether the sudo itself succeeds depends on the
-	// host, so assert only that the refusal did not fire.
+// stubElevated overrides the agent's own elevation check for one test. Tests in
+// this package do not run in parallel, so a package-level override is safe.
+func stubElevated(t *testing.T, elevated bool) {
+	t.Helper()
+	prev := isRunningElevated
+	isRunningElevated = func() bool { return elevated }
+	t.Cleanup(func() { isRunningElevated = prev })
+}
+
+// TestRunAsSupportsSecrets pins the gate decision itself, deterministically on
+// any host. The handleScript-level tests below cover the wiring; this covers
+// the matrix.
+func TestRunAsSupportsSecrets(t *testing.T) {
+	cases := []struct {
+		runAs           string
+		targetSessionID int
+		elevatedAgent   bool
+		want            bool
+	}{
+		{runAs: "", targetSessionID: -1, want: true},
+		{runAs: "system", targetSessionID: -1, want: true},
+		{runAs: "SYSTEM", targetSessionID: -1, want: true},
+		{runAs: " system ", targetSessionID: -1, want: true},
+		// elevated on an already-root agent keeps cmd.Env (configureRunAs
+		// short-circuits); on a non-root agent it re-execs through `sudo -n`,
+		// whose env_reset drops BREEZE_VAR_*.
+		{runAs: "elevated", targetSessionID: -1, elevatedAgent: true, want: true},
+		{runAs: "elevated", targetSessionID: -1, elevatedAgent: false, want: false},
+		{runAs: "Elevated", targetSessionID: -1, elevatedAgent: false, want: false},
+		{runAs: "user", targetSessionID: -1, want: false},
+		{runAs: "alice", targetSessionID: -1, want: false},
+		// Session targeting always routes to a helper, regardless of runAs.
+		{runAs: "system", targetSessionID: 7, want: false},
+		{runAs: "elevated", targetSessionID: 7, elevatedAgent: true, want: false},
+		{runAs: "", targetSessionID: 0, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("runAs=%q/target=%d/elevatedAgent=%v", tc.runAs, tc.targetSessionID, tc.elevatedAgent), func(t *testing.T) {
+			stubElevated(t, tc.elevatedAgent)
+			if got := runAsSupportsSecrets(tc.runAs, tc.targetSessionID); got != tc.want {
+				t.Fatalf("runAsSupportsSecrets(%q, %d) = %v, want %v", tc.runAs, tc.targetSessionID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHandleScriptSecretEnvRefusesElevatedOnUnelevatedAgent — the sudo re-exec
+// would strip BREEZE_VAR_* (env_reset), so the script must not run at all.
+func TestHandleScriptSecretEnvRefusesElevatedOnUnelevatedAgent(t *testing.T) {
+	stubElevated(t, false)
+	content, marker := markerScript(t)
 	h := newTestHeartbeat(nil)
 
 	res := handleScript(h, Command{
-		ID:   "cmd-secret-elevated",
+		ID:   "cmd-secret-elevated-unelevated",
 		Type: tools.CmdScript,
 		Payload: map[string]any{
-			"content":        "echo ok",
+			"content":        content,
 			"language":       "bash",
 			"runAs":          "elevated",
 			"timeoutSeconds": 10,
@@ -360,10 +418,78 @@ func TestHandleScriptSecretEnvAllowsElevated(t *testing.T) {
 		},
 	})
 
-	if strings.Contains(res.Error, "secret variables") {
-		t.Fatalf("runAs=elevated must not be refused by the secret gate, got %q", res.Error)
+	if res.Status != "failed" {
+		t.Fatalf("expected failed, got %q (error: %q)", res.Status, res.Error)
+	}
+	// Same failure shape as every other blocked path.
+	if !strings.Contains(res.Error, "secret variables") ||
+		!strings.Contains(res.Error, "system-context execution") ||
+		!strings.Contains(res.Error, "was not executed") {
+		t.Fatalf("unexpected refusal message: %q", res.Error)
+	}
+	assertScriptDidNotRun(t, marker)
+	assertNoSecretLeak(t, res)
+}
+
+// TestHandleScriptSecretEnvElevatedOnElevatedAgent — the delivery half. It
+// needs the agent to be genuinely elevated, because the stub governs only the
+// gate; executor.configureRunAs consults privilege.IsRunningAsRoot directly and
+// would otherwise sudo-re-exec (the exact env-stripping this gate blocks). The
+// gate's decision on a non-root host is covered deterministically by
+// TestRunAsSupportsSecrets.
+func TestHandleScriptSecretEnvElevatedOnElevatedAgent(t *testing.T) {
+	if !privilege.IsRunningAsRoot() {
+		t.Skip("agent is not elevated on this host; the executor would re-exec through sudo")
+	}
+	stubElevated(t, true)
+	h := newTestHeartbeat(nil)
+
+	res := handleScript(h, Command{
+		ID:   "cmd-secret-elevated-root",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        `printf 'len=%s\n' "${#BREEZE_VAR_API_TOKEN}"`,
+			"language":       "bash",
+			"runAs":          "elevated",
+			"timeoutSeconds": 10,
+			"secretEnv":      map[string]any{"api_token": testSecretValue},
+		},
+	})
+
+	if res.Status != "completed" {
+		t.Fatalf("expected completed, got %q (error: %q, stderr: %q)", res.Status, res.Error, res.Stderr)
+	}
+	want := fmt.Sprintf("len=%d", testSecretValueLen)
+	if got := strings.TrimSpace(res.Stdout); got != want {
+		t.Fatalf("elevated run did not receive the secret: got %q, want %q", got, want)
 	}
 	assertNoSecretLeak(t, res)
+}
+
+// TestHandleScriptElevatedWithoutSecretsUnaffected — the gate cannot fire
+// without delivered secrets, in either elevation state.
+func TestHandleScriptElevatedWithoutSecretsUnaffected(t *testing.T) {
+	for _, elevated := range []bool{true, false} {
+		t.Run(fmt.Sprintf("elevatedAgent=%v", elevated), func(t *testing.T) {
+			stubElevated(t, elevated)
+			h := newTestHeartbeat(nil)
+
+			res := handleScript(h, Command{
+				ID:   "cmd-elevated-no-secrets",
+				Type: tools.CmdScript,
+				Payload: map[string]any{
+					"content":        "echo ok",
+					"language":       "bash",
+					"runAs":          "elevated",
+					"timeoutSeconds": 10,
+				},
+			})
+
+			if strings.Contains(res.Error, "secret variables") {
+				t.Fatalf("runAs=elevated without secrets must never hit the secret gate, got %q", res.Error)
+			}
+		})
+	}
 }
 
 // TestHandleScriptEmptySecretEnvDoesNotGate — an empty object is "no secrets",

--- a/agent/internal/heartbeat/handlers_script_secret_test.go
+++ b/agent/internal/heartbeat/handlers_script_secret_test.go
@@ -1,0 +1,526 @@
+package heartbeat
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/executor"
+	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+	"github.com/breeze-rmm/agent/internal/sessionbroker"
+)
+
+// #3409 PR4b — handleScript's secret-variable invariants.
+//
+// These tests drive the REAL executor (h.executor is a concrete
+// *executor.Executor, not an interface), which is why "the script never ran" is
+// asserted against a marker file the script would have created rather than
+// against a call counter on a stub. That is the stronger claim anyway: it also
+// proves the BREEZE_VAR_* environment really reaches the spawned process.
+
+// testSecretValue is the delivered credential used throughout. It is
+// deliberately free of any `token=` / `password:` shape so SanitizeOutput's
+// pattern layer cannot take credit for a redaction that the exact-value
+// redactor is the one under test for. Length 16, asserted on below.
+const testSecretValue = "hunter2-nrfPQxKz"
+
+// testSecretValueLen lets the allowed-context test assert the script saw the
+// WHOLE value without ever printing it.
+const testSecretValueLen = len(testSecretValue)
+
+// awsKeyInError is an AKIA-shaped string (AKIA + 16 uppercase alphanumerics),
+// the SanitizeOutput pattern used to prove result.Error now goes through the
+// pattern layer as well.
+const awsKeyInError = "AKIAABCDEFGHIJKLMNOP"
+
+// markerScript returns a bash script that creates a file, and that file's path.
+// Asserting the file is absent after handleScript returns proves the command
+// never reached the executor — a stronger statement than "the result says
+// failed", which a post-execution failure would also satisfy.
+func markerScript(t *testing.T) (content string, markerPath string) {
+	t.Helper()
+	markerPath = filepath.Join(t.TempDir(), "executed.marker")
+	return "touch " + markerPath, markerPath
+}
+
+func assertScriptDidNotRun(t *testing.T, markerPath string) {
+	t.Helper()
+	_, err := os.Stat(markerPath)
+	if err == nil {
+		t.Fatalf("script executed but must not have: marker %s exists", markerPath)
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("stat marker %s: %v", markerPath, err)
+	}
+}
+
+func assertNoSecretLeak(t *testing.T, res tools.CommandResult) {
+	t.Helper()
+	for field, value := range map[string]string{
+		"Stdout": res.Stdout,
+		"Stderr": res.Stderr,
+		"Error":  res.Error,
+	} {
+		if strings.Contains(value, testSecretValue) {
+			t.Fatalf("%s leaked the secret value: %q", field, value)
+		}
+	}
+}
+
+// newFakeUserHelper wires a broker holding one run_as_user helper session whose
+// client end records whether it was ever contacted and answers with `reply`.
+// Same socket-pair pattern as TestExecuteViaUserHelperSuccess.
+func newFakeUserHelper(t *testing.T, username string, reply ipc.IPCCommandResult) (*sessionbroker.Broker, *atomic.Bool) {
+	t.Helper()
+
+	serverConn, clientConn := createTestSocketPair(t)
+	serverIPC := ipc.NewConn(serverConn)
+	clientIPC := ipc.NewConn(clientConn)
+	session := sessionbroker.NewSession(serverIPC, 1000, "1000", username, "quartz", "secret-helper-1", []string{"run_as_user"})
+
+	var contacted atomic.Bool
+	go func() {
+		_ = clientIPC.SetReadDeadline(time.Now().Add(3 * time.Second))
+		env, err := clientIPC.Recv()
+		if err != nil {
+			return
+		}
+		contacted.Store(true)
+		reply.CommandID = env.ID
+		payload, err := json.Marshal(reply)
+		if err != nil {
+			return
+		}
+		_ = clientIPC.Send(&ipc.Envelope{ID: env.ID, Type: ipc.TypeCommandResult, Payload: payload})
+	}()
+	go session.RecvLoop(func(*sessionbroker.Session, *ipc.Envelope) {})
+
+	t.Cleanup(func() {
+		_ = session.Close()
+		_ = clientIPC.Close()
+	})
+
+	return newTestBrokerWithSessions(t, session), &contacted
+}
+
+func helperOKReply(t *testing.T, stdout string) ipc.IPCCommandResult {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{"exitCode": 0, "stdout": stdout, "stderr": ""})
+	if err != nil {
+		t.Fatalf("marshal helper reply: %v", err)
+	}
+	return ipc.IPCCommandResult{Status: "completed", Result: payload}
+}
+
+// --- Decode / fail-closed -------------------------------------------------
+
+func TestHandleScriptMalformedSecretEnvFailsClosed(t *testing.T) {
+	cases := []struct {
+		name      string
+		secretEnv any
+		wantIn    []string
+		wantNotIn []string
+	}{
+		{
+			name:      "not an object",
+			secretEnv: "api_token=" + testSecretValue,
+			wantIn:    []string{"secretEnv", "must be an object"},
+			wantNotIn: []string{testSecretValue},
+		},
+		{
+			name:      "value below the redaction floor",
+			secretEnv: map[string]any{"api_token": "abc"},
+			wantIn:    []string{"api_token", "4 characters"},
+			// The refusal names the key; it must never quote the value, even a
+			// too-short one.
+			wantNotIn: []string{"abc"},
+		},
+		{
+			name:      "non-string value",
+			secretEnv: map[string]any{"api_token": float64(42)},
+			wantIn:    []string{"api_token", "not a string"},
+		},
+		{
+			name:      "key with a space",
+			secretEnv: map[string]any{"BAD KEY": testSecretValue},
+			wantIn:    []string{"BAD KEY", "not a valid variable key"},
+			wantNotIn: []string{testSecretValue},
+		},
+		{
+			name:      "uppercase key",
+			secretEnv: map[string]any{"API_TOKEN": testSecretValue},
+			wantIn:    []string{"API_TOKEN", "not a valid variable key"},
+			wantNotIn: []string{testSecretValue},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content, marker := markerScript(t)
+			h := newTestHeartbeat(nil)
+
+			res := handleScript(h, Command{
+				ID:   "cmd-secret-malformed",
+				Type: tools.CmdScript,
+				Payload: map[string]any{
+					"content":        content,
+					"language":       "bash",
+					"timeoutSeconds": 10,
+					"secretEnv":      tc.secretEnv,
+				},
+			})
+
+			if res.Status != "failed" {
+				t.Fatalf("expected failed status, got %q (error: %q)", res.Status, res.Error)
+			}
+			if res.ExitCode == 0 {
+				t.Fatalf("expected non-zero exit code, got %d", res.ExitCode)
+			}
+			for _, want := range tc.wantIn {
+				if !strings.Contains(res.Error, want) {
+					t.Fatalf("error %q does not mention %q", res.Error, want)
+				}
+			}
+			for _, unwanted := range tc.wantNotIn {
+				if strings.Contains(res.Error, unwanted) {
+					t.Fatalf("error %q must not contain %q", res.Error, unwanted)
+				}
+			}
+			assertScriptDidNotRun(t, marker)
+		})
+	}
+}
+
+// TestHandleScriptWithoutSecretEnvIsUnaffected is the regression guard for
+// existing traffic: the very same literal that gets redacted when it is
+// DELIVERED as a secret must pass through byte-for-byte when the payload
+// carries no secretEnv key at all.
+func TestHandleScriptWithoutSecretEnvIsUnaffected(t *testing.T) {
+	h := newTestHeartbeat(nil)
+
+	res := handleScript(h, Command{
+		ID:   "cmd-no-secretenv",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        "printf 'out %s\\n' " + testSecretValue,
+			"language":       "bash",
+			"timeoutSeconds": 10,
+		},
+	})
+
+	if res.Status != "completed" {
+		t.Fatalf("expected completed, got %q (error: %q, stderr: %q)", res.Status, res.Error, res.Stderr)
+	}
+	if got, want := strings.TrimSpace(res.Stdout), "out "+testSecretValue; got != want {
+		t.Fatalf("stdout must be untouched without secretEnv: got %q, want %q", got, want)
+	}
+	if strings.Contains(res.Stdout, executor.SecretRedactionMarker) {
+		t.Fatalf("no redactor may run without secretEnv, got %q", res.Stdout)
+	}
+	if res.Error != "" {
+		t.Fatalf("expected empty error, got %q", res.Error)
+	}
+}
+
+// --- runAs gating ---------------------------------------------------------
+
+func TestHandleScriptSecretEnvRefusesUserContext(t *testing.T) {
+	for _, runAs := range []string{"user", "alice"} {
+		t.Run("runAs="+runAs, func(t *testing.T) {
+			content, marker := markerScript(t)
+			broker, contacted := newFakeUserHelper(t, "alice", helperOKReply(t, "helper ran"))
+			h := newTestHeartbeat(broker)
+
+			res := handleScript(h, Command{
+				ID:   "cmd-secret-runas",
+				Type: tools.CmdScript,
+				Payload: map[string]any{
+					"content":        content,
+					"language":       "bash",
+					"runAs":          runAs,
+					"timeoutSeconds": 10,
+					"secretEnv":      map[string]any{"api_token": testSecretValue},
+				},
+			})
+
+			if res.Status != "failed" {
+				t.Fatalf("expected failed, got %q (error: %q)", res.Status, res.Error)
+			}
+			if !strings.Contains(res.Error, "secret variables") ||
+				!strings.Contains(res.Error, "system-context execution") {
+				t.Fatalf("error must explain the secret/system-context refusal, got %q", res.Error)
+			}
+			if !strings.Contains(res.Error, "was not executed") {
+				t.Fatalf("error must state the script did not run, got %q", res.Error)
+			}
+			if contacted.Load() {
+				t.Fatal("user helper was contacted; a helper run would drop the credential")
+			}
+			assertScriptDidNotRun(t, marker)
+			assertNoSecretLeak(t, res)
+		})
+	}
+}
+
+func TestHandleScriptSecretEnvRefusesSessionTargeting(t *testing.T) {
+	// runAs=user + targetSessionId is the RDS delivery path; runAs=system +
+	// targetSessionId would otherwise fall through to a LOCAL run, so it proves
+	// the guard keys on targetSessionId independently of runAs.
+	for _, runAs := range []string{"user", "system"} {
+		t.Run("runAs="+runAs, func(t *testing.T) {
+			content, marker := markerScript(t)
+			broker := sessionbroker.New("/tmp/test-broker-secret-target.sock", nil)
+			f := &fakeLifecycle{mode: "on-demand"}
+			h := newTestHeartbeat(broker)
+			h.helperLifecycle = f
+
+			res := handleScript(h, Command{
+				ID:   "cmd-secret-target",
+				Type: tools.CmdScript,
+				Payload: map[string]any{
+					"content":         content,
+					"language":        "bash",
+					"runAs":           runAs,
+					"timeoutSeconds":  10,
+					"targetSessionId": float64(7),
+					"secretEnv":       map[string]any{"api_token": testSecretValue},
+				},
+			})
+
+			if res.Status != "failed" {
+				t.Fatalf("expected failed, got %q (error: %q)", res.Status, res.Error)
+			}
+			if !strings.Contains(res.Error, "secret variables") ||
+				!strings.Contains(res.Error, "system-context execution") {
+				t.Fatalf("error must explain the secret/system-context refusal, got %q", res.Error)
+			}
+			if len(f.acquired) != 0 || len(f.released) != 0 {
+				t.Fatalf("session targeting must be refused before any lease, got acquired=%v released=%v", f.acquired, f.released)
+			}
+			assertScriptDidNotRun(t, marker)
+		})
+	}
+}
+
+// TestHandleScriptSecretEnvRunsInSystemContexts is the positive half of the
+// gate: the contexts that DO reach the local executor still run, and the
+// executor really receives the secrets as BREEZE_VAR_* environment. The script
+// prints the value's LENGTH, never the value, so a passing assertion cannot be
+// explained away by the redactor.
+func TestHandleScriptSecretEnvRunsInSystemContexts(t *testing.T) {
+	for _, runAs := range []string{"", "system"} {
+		t.Run("runAs="+runAs, func(t *testing.T) {
+			h := newTestHeartbeat(nil)
+
+			res := handleScript(h, Command{
+				ID:   "cmd-secret-local",
+				Type: tools.CmdScript,
+				Payload: map[string]any{
+					"content":        `printf 'len=%s\n' "${#BREEZE_VAR_API_TOKEN}"`,
+					"language":       "bash",
+					"runAs":          runAs,
+					"timeoutSeconds": 10,
+					"secretEnv":      map[string]any{"api_token": testSecretValue},
+				},
+			})
+
+			if res.Status != "completed" {
+				t.Fatalf("expected completed, got %q (error: %q, stderr: %q)", res.Status, res.Error, res.Stderr)
+			}
+			want := fmt.Sprintf("len=%d", testSecretValueLen)
+			if got := strings.TrimSpace(res.Stdout); got != want {
+				t.Fatalf("script did not see the full secret in BREEZE_VAR_API_TOKEN: got %q, want %q", got, want)
+			}
+			assertNoSecretLeak(t, res)
+		})
+	}
+}
+
+func TestHandleScriptSecretEnvAllowsElevated(t *testing.T) {
+	// runAs=elevated stays a local execution (a sudo re-exec on unix), so the
+	// gate must let it through. Whether the sudo itself succeeds depends on the
+	// host, so assert only that the refusal did not fire.
+	h := newTestHeartbeat(nil)
+
+	res := handleScript(h, Command{
+		ID:   "cmd-secret-elevated",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        "echo ok",
+			"language":       "bash",
+			"runAs":          "elevated",
+			"timeoutSeconds": 10,
+			"secretEnv":      map[string]any{"api_token": testSecretValue},
+		},
+	})
+
+	if strings.Contains(res.Error, "secret variables") {
+		t.Fatalf("runAs=elevated must not be refused by the secret gate, got %q", res.Error)
+	}
+	assertNoSecretLeak(t, res)
+}
+
+// TestHandleScriptEmptySecretEnvDoesNotGate — an empty object is "no secrets",
+// so the helper path stays available. Guards against gating on the presence of
+// the key rather than on delivered values.
+func TestHandleScriptEmptySecretEnvDoesNotGate(t *testing.T) {
+	broker, contacted := newFakeUserHelper(t, "alice", helperOKReply(t, "helper ran"))
+	h := newTestHeartbeat(broker)
+
+	res := handleScript(h, Command{
+		ID:   "cmd-empty-secretenv",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        "echo hi",
+			"language":       "bash",
+			"runAs":          "user",
+			"timeoutSeconds": 10,
+			"secretEnv":      map[string]any{},
+		},
+	})
+
+	if !contacted.Load() {
+		t.Fatalf("user helper must still be used when no secrets are delivered (result: %+v)", res)
+	}
+	if res.Status != "completed" {
+		t.Fatalf("expected completed from helper, got %q (error: %q)", res.Status, res.Error)
+	}
+}
+
+// TestHandleScriptWithoutSecretEnvStillUsesHelper is the runAs half of the
+// regression guard: existing runAs=user traffic keeps reaching the helper.
+func TestHandleScriptWithoutSecretEnvStillUsesHelper(t *testing.T) {
+	broker, contacted := newFakeUserHelper(t, "alice", helperOKReply(t, "helper ran"))
+	h := newTestHeartbeat(broker)
+
+	res := handleScript(h, Command{
+		ID:   "cmd-helper-no-secretenv",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        "echo hi",
+			"language":       "bash",
+			"runAs":          "user",
+			"timeoutSeconds": 10,
+		},
+	})
+
+	if !contacted.Load() {
+		t.Fatalf("user helper must still be used for runAs=user without secrets (result: %+v)", res)
+	}
+	if res.Status != "completed" || res.Stdout != "helper ran" {
+		t.Fatalf("unexpected helper result: %+v", res)
+	}
+}
+
+// --- Redaction on every exit path -----------------------------------------
+
+func TestHandleScriptRedactsSecretFromStdoutAndStderr(t *testing.T) {
+	h := newTestHeartbeat(nil)
+
+	res := handleScript(h, Command{
+		ID:   "cmd-secret-output",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        `printf 'out %s\n' "$BREEZE_VAR_API_TOKEN"; printf 'err %s\n' "$BREEZE_VAR_API_TOKEN" >&2`,
+			"language":       "bash",
+			"timeoutSeconds": 10,
+			"secretEnv":      map[string]any{"api_token": testSecretValue},
+		},
+	})
+
+	if res.Status != "completed" {
+		t.Fatalf("expected completed, got %q (error: %q, stderr: %q)", res.Status, res.Error, res.Stderr)
+	}
+	if got, want := strings.TrimSpace(res.Stdout), "out "+executor.SecretRedactionMarker; got != want {
+		t.Fatalf("stdout: got %q, want %q", got, want)
+	}
+	if got, want := strings.TrimSpace(res.Stderr), "err "+executor.SecretRedactionMarker; got != want {
+		t.Fatalf("stderr: got %q, want %q", got, want)
+	}
+	assertNoSecretLeak(t, res)
+}
+
+// TestHandleScriptRedactsSecretFromError covers the field this task exists to
+// fix. `language` is the one payload field the executor echoes verbatim into
+// result.Error ("unsupported script type: %s"), so setting it to the delivered
+// value is the honest way to make the executor produce an error containing the
+// credential without stubbing out the concrete *executor.Executor.
+func TestHandleScriptRedactsSecretFromError(t *testing.T) {
+	h := newTestHeartbeat(nil)
+
+	res := handleScript(h, Command{
+		ID:   "cmd-secret-error",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        "echo hi",
+			"language":       testSecretValue,
+			"timeoutSeconds": 10,
+			"secretEnv":      map[string]any{"api_token": testSecretValue},
+		},
+	})
+
+	if res.Status != "failed" {
+		t.Fatalf("expected failed, got %q", res.Status)
+	}
+	if got, want := res.Error, "unsupported script type: "+executor.SecretRedactionMarker; got != want {
+		t.Fatalf("error: got %q, want %q", got, want)
+	}
+	assertNoSecretLeak(t, res)
+}
+
+// TestHandleScriptSanitizesErrorPatterns proves change (d): Error now goes
+// through SanitizeOutput like Stdout/Stderr always have. No secretEnv here, so
+// the exact-value redactor is a no-op and only the pattern layer can produce
+// the marker.
+func TestHandleScriptSanitizesErrorPatterns(t *testing.T) {
+	h := newTestHeartbeat(nil)
+
+	res := handleScript(h, Command{
+		ID:   "cmd-error-sanitize",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        "echo hi",
+			"language":       awsKeyInError,
+			"timeoutSeconds": 10,
+		},
+	})
+
+	if got, want := res.Error, "unsupported script type: [AWS_KEY_REDACTED]"; got != want {
+		t.Fatalf("error: got %q, want %q", got, want)
+	}
+}
+
+// TestHandleScriptHelperErrorSanitized covers the second raw-Error copy: the
+// user-helper IPC result. Secrets can never reach this path (the gate refuses
+// them), but the pattern layer must still apply.
+func TestHandleScriptHelperErrorSanitized(t *testing.T) {
+	broker, contacted := newFakeUserHelper(t, "alice", ipc.IPCCommandResult{
+		Status: "failed",
+		Error:  "aws login failed for " + awsKeyInError,
+	})
+	h := newTestHeartbeat(broker)
+
+	res := handleScript(h, Command{
+		ID:   "cmd-helper-error-sanitize",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        "aws sts get-caller-identity",
+			"language":       "bash",
+			"runAs":          "user",
+			"timeoutSeconds": 10,
+		},
+	})
+
+	if !contacted.Load() {
+		t.Fatalf("expected the helper to be used (result: %+v)", res)
+	}
+	if got, want := res.Error, "aws login failed for [AWS_KEY_REDACTED]"; got != want {
+		t.Fatalf("helper error: got %q, want %q", got, want)
+	}
+}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -176,6 +176,13 @@ func migrationSignal(server, backup string) (edition string, migrationRequired b
 // enforces the policy this version number claims to be honoring.
 type SecurityCapabilities struct {
 	OutboundNetworkPolicyVersion int `json:"outboundNetworkPolicyVersion"`
+	// #3409 PR4b — this build decodes `secretEnv`, injects BREEZE_VAR_*, blocks
+	// user-context runs that would drop the credential, and redacts the values
+	// out of stdout/stderr/error. Declared unconditionally: the behavior is
+	// compiled in, not a runtime toggle. The server writes this non-sticky on
+	// every beat, so a DOWNGRADE to an older agent reports back down to 0 and
+	// the PR4c dispatch gate stops trusting a stale claim.
+	ScriptSecretEnvVersion int `json:"scriptSecretEnvVersion"`
 }
 
 type DesktopAccessState struct {
@@ -3869,7 +3876,10 @@ func (h *Heartbeat) sendHeartbeat() {
 		// so it always declares version 1. Unconditional (not gated on any
 		// runtime check): the enforcement is compiled in, not a runtime
 		// toggle.
-		SecurityCapabilities: SecurityCapabilities{OutboundNetworkPolicyVersion: 1},
+		SecurityCapabilities: SecurityCapabilities{
+			OutboundNetworkPolicyVersion: 1,
+			ScriptSecretEnvVersion:       1,
+		},
 	}
 	// Hosted/self-host build-edition + migration-needed telemetry (Task 8).
 	// Independent of hostpolicy.Strict() — see migrationSignal doc comment.

--- a/agent/internal/heartbeat/heartbeat_test.go
+++ b/agent/internal/heartbeat/heartbeat_test.go
@@ -232,15 +232,22 @@ func TestBootstrapRetryStopsOnContextCancel(t *testing.T) {
 
 // TestHeartbeatPayloadSecurityCapabilitiesJSON pins the exact wire shape the
 // server-side heartbeat schema expects (Wave 6 Task 4, security
-// remediation): `{"securityCapabilities":{"outboundNetworkPolicyVersion":1}}`.
+// remediation; #3409 PR4b):
+// `{"securityCapabilities":{"outboundNetworkPolicyVersion":1,"scriptSecretEnvVersion":1}}`.
 // A field rename, a dropped `omitempty`-less requirement, or a wrapper-type
 // change here would silently desync from apps/api/src/routes/agents/
-// schemas.ts without either side's own tests catching it.
+// schemas.ts without either side's own tests catching it. scriptSecretEnvVersion
+// in particular must be emitted even when it is the zero value — the server
+// distinguishes "old agent, whole object absent" from "capable agent
+// declaring 0" — so this also guards against a stray `omitempty` creeping in.
 func TestHeartbeatPayloadSecurityCapabilitiesJSON(t *testing.T) {
 	payload := HeartbeatPayload{
-		Status:               "ok",
-		AgentVersion:         "1.2.3",
-		SecurityCapabilities: SecurityCapabilities{OutboundNetworkPolicyVersion: 1},
+		Status:       "ok",
+		AgentVersion: "1.2.3",
+		SecurityCapabilities: SecurityCapabilities{
+			OutboundNetworkPolicyVersion: 1,
+			ScriptSecretEnvVersion:       1,
+		},
 	}
 
 	body, err := json.Marshal(&payload)
@@ -267,5 +274,39 @@ func TestHeartbeatPayloadSecurityCapabilitiesJSON(t *testing.T) {
 	}
 	if got, want := version, float64(1); got != want {
 		t.Fatalf("outboundNetworkPolicyVersion = %v, want %v", got, want)
+	}
+
+	secretEnvVersion, ok := caps["scriptSecretEnvVersion"]
+	if !ok {
+		t.Fatalf("scriptSecretEnvVersion key missing: %#v", caps)
+	}
+	if got, want := secretEnvVersion, float64(1); got != want {
+		t.Fatalf("scriptSecretEnvVersion = %v, want %v", got, want)
+	}
+
+	// Emitted unconditionally: a zero-value SecurityCapabilities must still
+	// produce the key (no omitempty), so the server can tell "old agent,
+	// object absent" apart from "capable agent declaring 0".
+	zeroBody, err := json.Marshal(&HeartbeatPayload{
+		Status:       "ok",
+		AgentVersion: "1.2.3",
+	})
+	if err != nil {
+		t.Fatalf("marshal zero-value payload: %v", err)
+	}
+	var zeroDecoded map[string]any
+	if err := json.Unmarshal(zeroBody, &zeroDecoded); err != nil {
+		t.Fatalf("unmarshal zero-value payload: %v", err)
+	}
+	zeroCaps, ok := zeroDecoded["securityCapabilities"].(map[string]any)
+	if !ok {
+		t.Fatalf("securityCapabilities missing/not an object on zero-value payload: %s", zeroBody)
+	}
+	zeroVersion, ok := zeroCaps["scriptSecretEnvVersion"]
+	if !ok {
+		t.Fatalf("scriptSecretEnvVersion key missing on zero-value payload (omitempty regression?): %#v", zeroCaps)
+	}
+	if got, want := zeroVersion, float64(0); got != want {
+		t.Fatalf("zero-value scriptSecretEnvVersion = %v, want %v", got, want)
 	}
 }

--- a/docs/superpowers/plans/2026-08-14-pr4b-agent-secret-env.md
+++ b/docs/superpowers/plans/2026-08-14-pr4b-agent-secret-env.md
@@ -21,8 +21,8 @@
 - **A secret value must never appear in an error message, a log line, or a script file on disk.** Error text names the *key*, never the value.
 - **Secrets never reach `SubstituteParameters` or `validateScript`.** The substituted script is written to a temp file (`agent/internal/executor/shell.go:118-127`, 0700 on Unix / 0600 on Windows) — putting a secret through substitution lands it on the customer's filesystem, which is the entire reason env delivery exists.
 - **Constants must match the server.** `MinSecretValueLength = 4` mirrors `MIN_SECRET_TENANT_VARIABLE_VALUE_LENGTH` (`packages/shared/src/validators/tenantVariables.ts`); `MaxSecretEnvEntries = 32` mirrors `MAX_SECRET_ENV_ENTRIES` (`apps/api/src/services/scriptSecretEnvelope.ts`). No cross-language drift guard is possible — carry the cross-reference in a comment at each constant.
-- **Key grammar is `^[A-Za-z_][A-Za-z0-9_]*$`**, matching `TENANT_VARIABLE_KEY_PATTERN`. Anything else is rejected so a malformed key cannot inject a second env entry.
-- **Test commands:** `cd agent && go test ./internal/executor/... ./internal/heartbeat/...` for a slice; before opening the PR, `cd agent && go build ./... && go vet ./... && gofmt -l . && CGO_ENABLED=0 go test ./... && go test -race ./internal/executor ./internal/heartbeat`.
+- **Key grammar is exactly `^[a-z][a-z0-9_]{0,63}$`** — the server's `TENANT_VARIABLE_KEY_PATTERN` (`packages/shared/src/validators/tenantVariables.ts:14`), also enforced by the `tenant_variables_key_chk` DB constraint. The agent mirrors it **exactly** rather than being laxer than its only producer: lowercase-only, must start with a letter, 64 characters max. Anything else is rejected so a malformed key cannot inject a second env entry. *(Corrected 2026-08-14 after Task 1 review — the plan originally specified a laxer `^[A-Za-z_][A-Za-z0-9_]*$`, which permitted uppercase and a leading underscore and made the "mirrors the server" comment false.)*
+- **Test commands:** `cd agent && go test ./internal/executor/... ./internal/heartbeat/...` for a slice; before opening the PR, `cd agent && go build ./... && go vet ./... && CGO_ENABLED=0 go test ./... && go test -race ./internal/executor ./internal/heartbeat`. **New files must be gofmt-clean, but `gofmt -l .` over the whole tree is NOT a gate** — `internal/executor/executor.go` and ~20 other files already fail it on `origin/main`. CI gates `go vet ./...` unconditionally and `golangci-lint --new-from-rev` in new-issues-only mode; do not reformat pre-existing files.
 - **Mutation-verify every guard.** For each new guard: force it off (invert the condition / return a constant), confirm the new tests fail *and nothing else does*, restore.
 - **Do not touch the user-helper binary.** Secrets are blocked from the helper path in v1; fixing the helper needs a separately-versioned binary rollout (`HelperVersion`, `agent/internal/heartbeat/heartbeat.go:99`) and is explicitly out of scope.
 
@@ -101,16 +101,15 @@ Create `agent/internal/executor/secretenv_test.go`. Pure stdlib `testing`, table
 - `nil` → empty `SecretEnv`, no error (the field is absent on every command today).
 - `map[string]any{}` → empty `SecretEnv`, no error.
 - `map[string]any{"api_token": "super-secret-value"}` → `SecretEnv{"api_token": "super-secret-value"}`.
-- A key with a leading underscore (`_token`) and a key with digits after the first char (`token2`).
+- A key with digits after the first character (`token2`) and a 64-character key (the cap, inclusive).
 
 *`ParseSecretEnv` rejects (error, and the error message must NOT contain the value):*
 - Not an object: `"nope"`, `[]any{"a"}`, `42`.
 - Non-string value: `map[string]any{"api_token": 42}`.
 - Value shorter than `MinSecretValueLength`: `map[string]any{"api_token": "ab"}` — error text must contain `api_token` and must not contain `ab` as a standalone leak (assert `!strings.Contains(err.Error(), "\"ab\"")` and that the message mentions the length floor).
 - Empty value: `map[string]any{"api_token": ""}`.
-- Key outside the grammar: `"BAD KEY"`, `"9lives"`, `"a-b"`, `""`.
+- Key outside the grammar: `"BAD KEY"`, `"9lives"`, `"a-b"`, `""`, `"API_TOKEN"` (uppercase), `"_token"` (leading underscore), and a 65-character key (one over the cap).
 - More than `MaxSecretEnvEntries` entries.
-- **Two distinct keys that collide after uppercasing** — `map[string]any{"api_token": "value-one", "API_TOKEN": "value-two"}` — because both would produce `BREEZE_VAR_API_TOKEN` and the winner would depend on Go's randomized map iteration order. Error must name both keys.
 
 *Redacting representation:* for `SecretEnv{"api_token": "super-secret-value"}`, assert that none of `fmt.Sprintf("%v", se)`, `%+v`, `%#v`, `%s`, `se.String()`, or `json.Marshal(se)` contains `super-secret-value`, and that each yields the `[REDACTED]` marker. Also assert the same holds for a `ScriptExecution` value carrying it once Task 2 lands — leave that assertion for Task 2's test file, not here.
 
@@ -174,10 +173,20 @@ const (
 	SecretEnvPrefix = "BREEZE_VAR_"
 )
 
-// secretKeyPattern mirrors TENANT_VARIABLE_KEY_PATTERN on the server. Enforced
-// agent-side too so a malformed key cannot inject a second environment entry
-// (a key containing "=" or a newline would otherwise split the env block).
-var secretKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+// secretKeyPattern is EXACTLY TENANT_VARIABLE_KEY_PATTERN from the server
+// (packages/shared/src/validators/tenantVariables.ts), which the
+// tenant_variables_key_chk DB constraint also enforces. Re-enforced agent-side
+// so a malformed key cannot inject a second environment entry (a key containing
+// "=" or a newline would otherwise split the env block), and deliberately not
+// one character laxer than its only producer: anything outside this grammar is
+// something the server should never have sent, so refusing it is fail-closed.
+//
+// The lowercase-only grammar is also what makes EnvKey's ToUpper folding
+// injective: two distinct keys cannot collide on one BREEZE_VAR_* name. If this
+// pattern is ever widened to admit uppercase, that stops being true and
+// ParseSecretEnv must grow a collision check — otherwise which secret wins would
+// depend on Go's randomized map iteration order.
+var secretKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,63}$`)
 
 // SecretEnv holds the secret variable values for a single script execution.
 //
@@ -264,7 +273,6 @@ func ParseSecretEnv(raw any) (SecretEnv, error) {
 	}
 	sort.Strings(keys)
 
-	seenEnvKeys := make(map[string]string, len(m))
 	for _, key := range keys {
 		if !secretKeyPattern.MatchString(key) {
 			return nil, fmt.Errorf("secretEnv key %q is not a valid variable key", key)
@@ -279,16 +287,6 @@ func ParseSecretEnv(raw any) (SecretEnv, error) {
 				key, MinSecretValueLength,
 			)
 		}
-		envKey := out.EnvKey(key)
-		if prior, dup := seenEnvKeys[envKey]; dup {
-			// Two keys differing only in case would both become the same
-			// BREEZE_VAR_* entry, and which one won would depend on map
-			// iteration order. Refuse rather than run a coin flip.
-			return nil, fmt.Errorf(
-				"secretEnv keys %q and %q both map to %s", prior, key, envKey,
-			)
-		}
-		seenEnvKeys[envKey] = key
 		out[key] = value
 	}
 	return out, nil
@@ -496,8 +494,7 @@ Create `agent/internal/heartbeat/handlers_script_secret_test.go`. Reuse the exis
 - Payload with `secretEnv` that is not an object → `Status: "failed"`, non-zero `ExitCode`, `Error` mentions `secretEnv`, and the executor was never invoked.
 - Payload with a 2-character secret value → failed, `Error` names the key and the length floor, never the value.
 - Payload with a non-string secret value → failed.
-- Payload with an invalid key (`"BAD KEY"`) → failed.
-- Payload with two case-colliding keys → failed.
+- Payload with an invalid key (`"BAD KEY"`, and separately an uppercase `"API_TOKEN"`) → failed.
 - Payload with **no** `secretEnv` key → behaves exactly as today (this is the regression guard proving the PR is inert for existing traffic).
 
 *runAs gating:*

--- a/docs/superpowers/plans/2026-08-14-pr4b-agent-secret-env.md
+++ b/docs/superpowers/plans/2026-08-14-pr4b-agent-secret-env.md
@@ -1,0 +1,757 @@
+# Tenant Variables #3409 — PR4b Implementation Plan (agent-side secret env delivery)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Teach the Go agent to accept an encrypted-in-transit `secretEnv` map on a `script` command, inject it as `BREEZE_VAR_*` process environment (never into the script text on disk), refuse every execution path that cannot carry it, redact the exact secret values out of stdout/stderr/**error** on every exit path, and advertise the `scriptSecretEnvVersion: 1` capability so the server can gate on it.
+
+**Nothing activates in this PR.** The server still never populates `secretEnv` (PR4c does that), so every new agent path is unreachable in production until PR4c ships and an operator saves a secret variable. This PR is the fleet-side half of the handshake and must be deployed and rolled out *before* PR4c.
+
+**Prior context:** `docs/superpowers/plans/2026-08-14-pr4-secret-delivery-handoff.md` §3 (settled design) and §4.3 (agent seams). PR4a (server machinery, inert) is PR #3557.
+
+**Tech Stack:** Go 1.25 (agent module), stdlib `testing` only — **no testify anywhere in `agent/`**.
+
+---
+
+## Global Constraints
+
+- **Branch:** `ToddHebebrand/tenant-variables-pr4b`, based on `origin/main` (NOT on the PR4a branch — this PR touches no TypeScript, so it must get full CI rather than the stacked-branch no-CI trap).
+- **Worktree:** `/Users/toddhebebrand/orca/workspaces/breeze/tenant-variables-pr4b`.
+- **Redaction marker is exactly `[REDACTED]`** — never a marker naming the variable key. Naming the key confirms *which* credential leaked to an audience (`scripts:read`) wider than the script's author.
+- **Fail loudly, never silently.** Any malformed, oversized, short, non-string, or duplicate-after-uppercasing secret entry **fails the command without running the script**. An agent that runs a script with the credential env var unset can mean anonymous access, auth fallback, lockouts, or destructive operations against the wrong target.
+- **A secret value must never appear in an error message, a log line, or a script file on disk.** Error text names the *key*, never the value.
+- **Secrets never reach `SubstituteParameters` or `validateScript`.** The substituted script is written to a temp file (`agent/internal/executor/shell.go:118-127`, 0700 on Unix / 0600 on Windows) — putting a secret through substitution lands it on the customer's filesystem, which is the entire reason env delivery exists.
+- **Constants must match the server.** `MinSecretValueLength = 4` mirrors `MIN_SECRET_TENANT_VARIABLE_VALUE_LENGTH` (`packages/shared/src/validators/tenantVariables.ts`); `MaxSecretEnvEntries = 32` mirrors `MAX_SECRET_ENV_ENTRIES` (`apps/api/src/services/scriptSecretEnvelope.ts`). No cross-language drift guard is possible — carry the cross-reference in a comment at each constant.
+- **Key grammar is `^[A-Za-z_][A-Za-z0-9_]*$`**, matching `TENANT_VARIABLE_KEY_PATTERN`. Anything else is rejected so a malformed key cannot inject a second env entry.
+- **Test commands:** `cd agent && go test ./internal/executor/... ./internal/heartbeat/...` for a slice; before opening the PR, `cd agent && go build ./... && go vet ./... && gofmt -l . && CGO_ENABLED=0 go test ./... && go test -race ./internal/executor ./internal/heartbeat`.
+- **Mutation-verify every guard.** For each new guard: force it off (invert the condition / return a constant), confirm the new tests fail *and nothing else does*, restore.
+- **Do not touch the user-helper binary.** Secrets are blocked from the helper path in v1; fixing the helper needs a separately-versioned binary rollout (`HelperVersion`, `agent/internal/heartbeat/heartbeat.go:99`) and is explicitly out of scope.
+
+---
+
+## Verified seams (do not re-derive — these were checked against this branch)
+
+| What | Where |
+|---|---|
+| `executor.ScriptExecution` struct | `agent/internal/executor/executor.go:34-42` |
+| `buildEnvironment` (incl. `BREEZE_PARAM_` loop) | `agent/internal/executor/executor.go:328-345`; applied at `:182` via `procoutput.ApplyEnv` |
+| `SubstituteParameters` call | `agent/internal/executor/executor.go:120` |
+| `validateScript` call | `agent/internal/executor/executor.go:123` |
+| Script written to temp file | `agent/internal/executor/shell.go:102-130`, called from `executor.go:132` |
+| `SanitizeOutput` (pattern-based, cannot see values) | `agent/internal/executor/security.go:199-242` |
+| `handleScript` — the ONLY entry point | `agent/internal/heartbeat/handlers_script.go:26` |
+| Payload decode (map-based; wire keys `scriptId`/`language`/`content`/`timeoutSeconds`/`runAs`/`parameters`) | `handlers_script.go:26-44` |
+| runAs branching (5 branches, first match wins) | `handlers_script.go:75-115` |
+| Local result build — `Error` copied RAW at `:132` | `handlers_script.go:127-134` |
+| Helper result build — `Error` copied RAW at `:276` | `handlers_script.go:273-296` |
+| `executeViaUserHelper` / `executeScriptInSession` — called ONLY from within `handleScript` | `handlers_script.go:252`, `:361`, `:408`, `:427` |
+| `tools.CommandResult` | `agent/internal/remote/tools/types.go:241-253`; `NewErrorResult` at `:280` |
+| `SecurityCapabilities` struct | `agent/internal/heartbeat/heartbeat.go:177-179`; populated at `:3828`; JSON pinned by `heartbeat_test.go:239` |
+| `secmem.SecureString` redaction precedent | `agent/internal/secmem/secmem.go:64-84` |
+| No `DisallowUnknownFields` anywhere in `agent/` | old agents ignore `secretEnv` silently — which is exactly why the capability gate (PR4c) is mandatory |
+| Nothing logs `cmd.Payload` in `internal/heartbeat` or `internal/websocket` | verified by grep; keep it that way |
+
+---
+
+## File Structure
+
+**Create**
+
+| File | Responsibility |
+|---|---|
+| `agent/internal/executor/secretenv.go` | `SecretEnv` type with redacting `String`/`GoString`/`Format`/`MarshalJSON`; constants; `ParseSecretEnv` (validate + fail-closed). |
+| `agent/internal/executor/secretenv_test.go` | Parse/validation/redacting-representation tests. |
+| `agent/internal/executor/secretredact.go` | `SecretRedactionMarker`, `BuildSecretRedactor(values) func(string) string`. |
+| `agent/internal/executor/secretredact_test.go` | Overlap merge, dedupe, idempotence, literal-not-pattern, large-input tests. |
+| `agent/internal/heartbeat/handlers_script_secret_test.go` | Decode failure modes, runAs blocking, env injection, every-exit-path redaction. |
+
+**Modify**
+
+| File | Change |
+|---|---|
+| `agent/internal/executor/executor.go` | `ScriptExecution.SecretEnv SecretEnv \`json:"-"\``; `buildEnvironment` emits `BREEZE_VAR_*`. |
+| `agent/internal/heartbeat/handlers_script.go` | Decode + validate `secretEnv`; block non-local execution paths; redaction wrapper over every exit path; sanitize `Error`. |
+| `agent/internal/heartbeat/heartbeat.go` | `SecurityCapabilities.ScriptSecretEnvVersion`, declared `1`. |
+| `agent/internal/heartbeat/heartbeat_test.go` | Extend the pinned capability JSON assertion. |
+
+---
+
+### Task 1: `SecretEnv` type, constants, and fail-closed parsing
+
+A dedicated type — not a bare `map[string]string` — so that a stray `%v`, `%+v`, `%#v`, or `json.Marshal` of a `ScriptExecution` can never emit a credential. This mirrors `secmem.SecureString` (`agent/internal/secmem/secmem.go:64-84`), which is the repo's established precedent.
+
+**Files:**
+- Create: `agent/internal/executor/secretenv.go`
+- Create: `agent/internal/executor/secretenv_test.go`
+
+**Interfaces produced:**
+- `const MinSecretValueLength = 4`
+- `const MaxSecretEnvEntries = 32`
+- `const SecretEnvPayloadKey = "secretEnv"`
+- `type SecretEnv map[string]string`
+- `func (SecretEnv) String() string` / `GoString() string` / `Format(fmt.State, rune)` / `MarshalJSON() ([]byte, error)` — all redacting
+- `func (SecretEnv) Values() []string`
+- `func (SecretEnv) EnvKey(key string) string` → `"BREEZE_VAR_" + strings.ToUpper(key)`
+- `func ParseSecretEnv(raw any) (SecretEnv, error)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agent/internal/executor/secretenv_test.go`. Pure stdlib `testing`, table-driven where the cases are homogeneous. Required cases:
+
+*`ParseSecretEnv` accepts:*
+- `nil` → empty `SecretEnv`, no error (the field is absent on every command today).
+- `map[string]any{}` → empty `SecretEnv`, no error.
+- `map[string]any{"api_token": "super-secret-value"}` → `SecretEnv{"api_token": "super-secret-value"}`.
+- A key with a leading underscore (`_token`) and a key with digits after the first char (`token2`).
+
+*`ParseSecretEnv` rejects (error, and the error message must NOT contain the value):*
+- Not an object: `"nope"`, `[]any{"a"}`, `42`.
+- Non-string value: `map[string]any{"api_token": 42}`.
+- Value shorter than `MinSecretValueLength`: `map[string]any{"api_token": "ab"}` — error text must contain `api_token` and must not contain `ab` as a standalone leak (assert `!strings.Contains(err.Error(), "\"ab\"")` and that the message mentions the length floor).
+- Empty value: `map[string]any{"api_token": ""}`.
+- Key outside the grammar: `"BAD KEY"`, `"9lives"`, `"a-b"`, `""`.
+- More than `MaxSecretEnvEntries` entries.
+- **Two distinct keys that collide after uppercasing** — `map[string]any{"api_token": "value-one", "API_TOKEN": "value-two"}` — because both would produce `BREEZE_VAR_API_TOKEN` and the winner would depend on Go's randomized map iteration order. Error must name both keys.
+
+*Redacting representation:* for `SecretEnv{"api_token": "super-secret-value"}`, assert that none of `fmt.Sprintf("%v", se)`, `%+v`, `%#v`, `%s`, `se.String()`, or `json.Marshal(se)` contains `super-secret-value`, and that each yields the `[REDACTED]` marker. Also assert the same holds for a `ScriptExecution` value carrying it once Task 2 lands — leave that assertion for Task 2's test file, not here.
+
+*`Values()`:* returns each value exactly once; length matches the map.
+
+*`EnvKey`:* `EnvKey("api_token") == "BREEZE_VAR_API_TOKEN"`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test ./internal/executor -run Secret
+```
+Expected: FAIL — `secretenv.go` does not exist.
+
+- [ ] **Step 3: Implement `agent/internal/executor/secretenv.go`**
+
+```go
+package executor
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// #3409 PR4b — agent-side secret variable delivery.
+//
+// A `script` command may carry a `secretEnv` map: tenant variables the operator
+// marked secret, delivered to the agent encrypted in transit (the server seals
+// them into one AAD-bound envelope and opens it only at delivery — see
+// apps/api/src/services/scriptSecretEnvelope.ts) and injected here as process
+// environment.
+//
+// Environment, deliberately, and NOT parameter substitution: the substituted
+// script is written to a temp file on the customer's disk (shell.go
+// WriteScriptFile), so a substituted secret becomes a file on their filesystem.
+// SecretEnv values must therefore never reach SubstituteParameters or
+// validateScript.
+const (
+	// SecretEnvPayloadKey is the wire field name on a `script` command payload.
+	SecretEnvPayloadKey = "secretEnv"
+
+	// MinSecretValueLength mirrors MIN_SECRET_TENANT_VARIABLE_VALUE_LENGTH in
+	// packages/shared/src/validators/tenantVariables.ts. A secret shorter than
+	// this cannot be exact-value-redacted from script output without shredding
+	// the output itself (imagine redacting every "ab"), so rather than choose
+	// between destroying the operator's output and leaking the credential, the
+	// command is refused. The server rejects such a value at save time and at
+	// seal time; this is the fail-closed backstop.
+	MinSecretValueLength = 4
+
+	// MaxSecretEnvEntries mirrors MAX_SECRET_ENV_ENTRIES in
+	// apps/api/src/services/scriptSecretEnvelope.ts. Bounds the redactor's work
+	// and the environment block.
+	MaxSecretEnvEntries = 32
+
+	// SecretEnvPrefix is the environment-variable namespace. A script reads a
+	// secret as $BREEZE_VAR_API_TOKEN / $env:BREEZE_VAR_API_TOKEN.
+	SecretEnvPrefix = "BREEZE_VAR_"
+)
+
+// secretKeyPattern mirrors TENANT_VARIABLE_KEY_PATTERN on the server. Enforced
+// agent-side too so a malformed key cannot inject a second environment entry
+// (a key containing "=" or a newline would otherwise split the env block).
+var secretKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// SecretEnv holds the secret variable values for a single script execution.
+//
+// It is a distinct type rather than a bare map so that every representation Go
+// can produce for it redacts: a stray log line, a %+v on the enclosing
+// ScriptExecution, or an accidental json.Marshal can never emit a credential.
+// Same defense secmem.SecureString provides for the enrollment token
+// (agent/internal/secmem/secmem.go). Use Values() to reach the plaintext, which
+// only the environment builder and the output redactor do.
+type SecretEnv map[string]string
+
+// String redacts. This is what fmt uses for %v, %s and %+v.
+func (SecretEnv) String() string { return "[REDACTED]" }
+
+// GoString redacts %#v, which does not consult Stringer.
+func (SecretEnv) GoString() string { return "executor.SecretEnv{[REDACTED]}" }
+
+// Format catches every remaining verb (%q, %x, ...) so no format string can
+// coax the plaintext out.
+func (s SecretEnv) Format(f fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if f.Flag('#') {
+			_, _ = fmt.Fprint(f, s.GoString())
+			return
+		}
+	}
+	_, _ = fmt.Fprint(f, s.String())
+}
+
+// MarshalJSON redacts, so a SecretEnv can never be serialized back onto a wire
+// or into a result frame.
+func (SecretEnv) MarshalJSON() ([]byte, error) { return json.Marshal("[REDACTED]") }
+
+// UnmarshalJSON always fails: the only supported way to build a SecretEnv is
+// ParseSecretEnv, which validates. A silent json.Unmarshal would bypass every
+// check in this file.
+func (*SecretEnv) UnmarshalJSON([]byte) error {
+	return fmt.Errorf("executor: SecretEnv must be built with ParseSecretEnv")
+}
+
+// Values returns each secret value once, for the output redactor.
+func (s SecretEnv) Values() []string {
+	out := make([]string, 0, len(s))
+	for _, v := range s {
+		out = append(out, v)
+	}
+	return out
+}
+
+// EnvKey maps a variable key to its environment variable name.
+func (SecretEnv) EnvKey(key string) string {
+	return SecretEnvPrefix + strings.ToUpper(key)
+}
+
+// ParseSecretEnv validates a raw `secretEnv` payload value.
+//
+// Fail-closed by design: EVERY malformed entry is an error, and the caller must
+// refuse to run the script. Running with a credential env var unset is not a
+// degraded success — it can mean anonymous access, an auth fallback, an account
+// lockout, or a destructive operation against the wrong target.
+//
+// Errors name the offending KEY and never the value: these strings travel back
+// to the server as result.Error and land in logs.
+func ParseSecretEnv(raw any) (SecretEnv, error) {
+	if raw == nil {
+		return SecretEnv{}, nil
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("secretEnv must be an object")
+	}
+	if len(m) > MaxSecretEnvEntries {
+		return nil, fmt.Errorf("secretEnv has %d entries, maximum is %d", len(m), MaxSecretEnvEntries)
+	}
+
+	out := make(SecretEnv, len(m))
+	// Sorted so the error reported for a multi-fault map is deterministic —
+	// Go randomizes map iteration, and a test that asserts on error text would
+	// otherwise flake.
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	seenEnvKeys := make(map[string]string, len(m))
+	for _, key := range keys {
+		if !secretKeyPattern.MatchString(key) {
+			return nil, fmt.Errorf("secretEnv key %q is not a valid variable key", key)
+		}
+		value, ok := m[key].(string)
+		if !ok {
+			return nil, fmt.Errorf("secretEnv value for %q is not a string", key)
+		}
+		if len(value) < MinSecretValueLength {
+			return nil, fmt.Errorf(
+				"secretEnv value for %q is shorter than %d characters and cannot be redacted from output",
+				key, MinSecretValueLength,
+			)
+		}
+		envKey := out.EnvKey(key)
+		if prior, dup := seenEnvKeys[envKey]; dup {
+			// Two keys differing only in case would both become the same
+			// BREEZE_VAR_* entry, and which one won would depend on map
+			// iteration order. Refuse rather than run a coin flip.
+			return nil, fmt.Errorf(
+				"secretEnv keys %q and %q both map to %s", prior, key, envKey,
+			)
+		}
+		seenEnvKeys[envKey] = key
+		out[key] = value
+	}
+	return out, nil
+}
+```
+
+Note: `MaxScriptSize` already caps total payload size (`shell.go:15`), so no separate per-value length ceiling is needed agent-side — the server enforces `MAX_TENANT_VARIABLE_VALUE_LENGTH` at seal time.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd agent && go test ./internal/executor -run Secret -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/executor/secretenv.go agent/internal/executor/secretenv_test.go
+git commit -m "feat(agent): fail-closed SecretEnv type for script secret delivery (#3409 PR4b)"
+```
+
+---
+
+### Task 2: Exact-value output redactor
+
+`executor.SanitizeOutput` (`security.go:199-242`) is **pattern-based**: it fires only when a credential sits next to a recognized key name or matches a known shape. A script that echoes a bare secret on its own line survives it entirely. This task adds the value-based layer. It is a pure function with no I/O and mirrors the server's `apps/api/src/services/exactSecretRedaction.ts` (PR4a) so both ends produce identical text.
+
+**Files:**
+- Create: `agent/internal/executor/secretredact.go`
+- Create: `agent/internal/executor/secretredact_test.go`
+
+**Interfaces produced:**
+- `const SecretRedactionMarker = "[REDACTED]"`
+- `func BuildSecretRedactor(values []string) func(string) string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agent/internal/executor/secretredact_test.go` with these cases:
+
+- Replaces every occurrence: `BuildSecretRedactor([]string{"hunter2000"})("token=hunter2000 and again hunter2000")` → `"token=[REDACTED] and again [REDACTED]"`.
+- Never names the variable: redacting the whole string yields exactly `[REDACTED]`.
+- **Literals, not patterns:** `BuildSecretRedactor([]string{"a.c*d"})("abcd a.c*d")` → `"abcd [REDACTED]"` (proves no regex compilation of the value).
+- **Merges overlapping matches into ONE marker:** `BuildSecretRedactor([]string{"abcabc", "bcab"})("xxabcabcxx")` → `"xx[REDACTED]xx"`. A naive longest-first pass would rescan its own marker and emit nested markers.
+- Does not rescan its own marker: `BuildSecretRedactor([]string{"secret", "REDACTED"})("secret")` → exactly `"[REDACTED]"`.
+- Idempotent: redacting the output again is a no-op.
+- Dedupes identical values.
+- Ignores empty and sub-`MinSecretValueLength` values rather than shredding output: `BuildSecretRedactor([]string{"", "ab"})("ab and an empty  gap")` returns the input unchanged.
+- Passthrough when there is nothing to redact (`nil` and `[]string{}`), and the returned function must be non-nil in both cases.
+- Handles a large output without quadratic blowup: 1 MB of filler around one match completes well under a second and contains the marker. Use `testing.Short()`-independent plain assertions; do **not** assert on wall-clock time (CI machines are contended) — assert only correctness, and keep the input at 1 MB so a quadratic implementation would visibly hang the suite.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test ./internal/executor -run Redact
+```
+Expected: FAIL — `secretredact.go` does not exist.
+
+- [ ] **Step 3: Implement `agent/internal/executor/secretredact.go`**
+
+Algorithm — **collect all match ranges of all values against the ORIGINAL text, merge overlapping/adjacent ranges, then rebuild the string in one pass.** Do not use `strings.ReplaceAll` per value: sequential replacement rescans text that already contains the marker, producing nested markers and non-idempotent output.
+
+```go
+package executor
+
+import (
+	"sort"
+	"strings"
+)
+
+// SecretRedactionMarker is deliberately generic. A marker naming the variable
+// key would CONFIRM which credential the script emitted, to an audience
+// (`scripts:read` on the server) wider than the script's author — the leak this
+// exists to prevent, minus the characters.
+const SecretRedactionMarker = "[REDACTED]"
+
+// BuildSecretRedactor returns a function that removes every literal occurrence
+// of the supplied secret values from a text.
+//
+// Honest scope: this is ACCIDENTAL-LEAK protection, not DLP. It removes a
+// credential a script echoed, logged, or included in an error message. It
+// cannot catch a value the script transformed, base64-encoded, hashed,
+// reversed, or printed one character per line. Treat it as a safety net over
+// careless output, never as a control against a hostile script author — who
+// holds the credential by definition.
+//
+// Mirrors apps/api/src/services/exactSecretRedaction.ts so the agent and the
+// server produce identical redacted text for the same input.
+func BuildSecretRedactor(values []string) func(string) string { ... }
+```
+
+Implementation requirements:
+- Filter out values shorter than `MinSecretValueLength` (this includes the empty string) and dedupe with a `map[string]struct{}`.
+- If nothing survives filtering, return `func(s string) string { return s }` (never `nil`).
+- For each surviving value, walk the original text with `strings.Index` on successive slices, recording `[start, end)` ranges; advance by the match length so a value never matches inside itself.
+- Sort ranges by start, then merge any range whose start is `<= ` the current end (overlapping **or** adjacent).
+- Rebuild with a `strings.Builder` sized `len(text)`, emitting the marker once per merged range.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd agent && go test ./internal/executor -run Redact -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/executor/secretredact.go agent/internal/executor/secretredact_test.go
+git commit -m "feat(agent): exact-value output redactor with overlap merging (#3409 PR4b)"
+```
+
+---
+
+### Task 3: Carry `SecretEnv` on `ScriptExecution` and inject `BREEZE_VAR_*`
+
+**Files:**
+- Modify: `agent/internal/executor/executor.go`
+- Test: `agent/internal/executor/executor_test.go` (append; do not restructure the file)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `agent/internal/executor/executor_test.go`:
+
+- `buildEnvironment` with `SecretEnv{"api_token": "super-secret-value"}` produces an entry `BREEZE_VAR_API_TOKEN=super-secret-value`, and still produces the existing `BREEZE_EXECUTION_ID` / `BREEZE_SCRIPT_ID` / `BREEZE_PARAM_*` entries.
+- A `ScriptExecution` with both a parameter and a secret produces both `BREEZE_PARAM_*` and `BREEZE_VAR_*` entries, and the two namespaces do not collide.
+- **The secret env entry is appended AFTER `os.Environ()`**: seed `t.Setenv("BREEZE_VAR_API_TOKEN", "inherited-value")`, then assert the *last* matching entry in the returned slice carries the delivered value. (`os/exec` dedupes `Cmd.Env` keeping the last occurrence, so a hostile pre-existing environment cannot shadow a delivered secret.)
+- Empty/nil `SecretEnv` adds no `BREEZE_VAR_` entries at all.
+- **A `ScriptExecution` carrying a secret redacts under every fmt verb and under `json.Marshal`** — `%v`, `%+v`, `%#v`, and `json.Marshal` of the struct must not contain `super-secret-value`. This is the test that proves the `json:"-"` tag plus the redacting methods actually hold at the enclosing-struct level.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test ./internal/executor -run 'Environment|ScriptExecution'
+```
+Expected: FAIL — field does not exist.
+
+- [ ] **Step 3: Implement**
+
+In `agent/internal/executor/executor.go`, add to `ScriptExecution` (after `RunAs`, `:41`):
+
+```go
+	// #3409 PR4b — secret tenant variables, delivered as process environment
+	// rather than substituted into the script text. `json:"-"` because this
+	// struct must never carry a credential onto any wire or into any file;
+	// SecretEnv's own String/Format/MarshalJSON redact as a second layer.
+	// Populated only by heartbeat.handleScript, which validates it first.
+	SecretEnv SecretEnv `json:"-"`
+```
+
+In `buildEnvironment` (`:328-345`), after the `BREEZE_PARAM_` loop and before `return env`:
+
+```go
+	// #3409 PR4b: secrets ride the environment, never the script text — the
+	// substituted script is written to a temp file on the customer's disk.
+	// Appended after os.Environ() on purpose: os/exec dedupes Cmd.Env keeping
+	// the LAST occurrence, so a pre-existing BREEZE_VAR_* in the machine
+	// environment cannot shadow a delivered secret.
+	//
+	// Keys were validated against the tenant-variable grammar by
+	// ParseSecretEnv, so no character mapping is needed here (unlike the
+	// parameter loop above, which has to fold "-" to "_").
+	for key, value := range script.SecretEnv {
+		env = append(env, script.SecretEnv.EnvKey(key)+"="+value)
+	}
+```
+
+**Do not** touch `executor.go:120` (`SubstituteParameters`) or `:123` (`validateScript`) — secrets must not reach either.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd agent && go test ./internal/executor/...
+```
+Expected: PASS, existing tests unchanged.
+
+**Mutation-verify:** temporarily move the `BREEZE_VAR_` loop *before* `os.Environ()` is appended — confirm only the shadowing test fails. Restore.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/executor/executor.go agent/internal/executor/executor_test.go
+git commit -m "feat(agent): inject validated secrets as BREEZE_VAR_* environment (#3409 PR4b)"
+```
+
+---
+
+### Task 4: Decode, gate, and redact in `handlers_script.go`
+
+The single highest-risk task. Three separate invariants land here, and each must hold on **every** exit path of `handleScript`:
+
+1. A malformed `secretEnv` fails the command **before** the script runs.
+2. A command carrying secrets never reaches an execution path that would drop them (user-helper / session-targeted), because such a run would execute with the credential unset.
+3. Every returned `Stdout`, `Stderr` **and `Error`** has the exact secret values removed — `Error` is currently copied raw at both `:132` (local) and `:276` (helper).
+
+**Files:**
+- Modify: `agent/internal/heartbeat/handlers_script.go`
+- Create: `agent/internal/heartbeat/handlers_script_secret_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agent/internal/heartbeat/handlers_script_secret_test.go`. Reuse the existing fakes in `agent/internal/heartbeat/test_helpers_test.go` and the patterns in `handlers_script_test.go` / `heartbeat_userhelper_test.go` — **do not invent a new harness.** Required cases:
+
+*Decode / fail-closed (script must NOT run):*
+- Payload with `secretEnv` that is not an object → `Status: "failed"`, non-zero `ExitCode`, `Error` mentions `secretEnv`, and the executor was never invoked.
+- Payload with a 2-character secret value → failed, `Error` names the key and the length floor, never the value.
+- Payload with a non-string secret value → failed.
+- Payload with an invalid key (`"BAD KEY"`) → failed.
+- Payload with two case-colliding keys → failed.
+- Payload with **no** `secretEnv` key → behaves exactly as today (this is the regression guard proving the PR is inert for existing traffic).
+
+*runAs gating:*
+- `secretEnv` present + `runAs: "user"` → failed, `Error` states that secret variables require system-context execution and that the agent will not run the script; the user-helper was never called.
+- `secretEnv` present + `runAs: "<username>"` → failed the same way.
+- `secretEnv` present + `targetSessionId >= 0` → failed the same way.
+- `secretEnv` present + `runAs: ""` / `"system"` / `"elevated"` → runs locally, and the executor receives a populated `SecretEnv`.
+- **No** `secretEnv` + `runAs: "user"` → unchanged behavior (helper path still used).
+
+*Redaction on every exit path:*
+- Executor returns stdout/stderr/error each containing the secret value → all three come back with `[REDACTED]` and none contains the value.
+- Executor returns `(nil, err)` where the error text contains the secret (the `NewErrorResult` path at `:117`) → the returned `Error` is redacted.
+- The helper path result (`executeViaUserHelper`) is redacted too.
+- `Error` is additionally run through `SanitizeOutput`: an error carrying `AKIA` + 16 uppercase alphanumerics comes back with `[AWS_KEY_REDACTED]`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test ./internal/heartbeat -run Secret
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Read `handlers_script.go:26-135` and `:250-300` before editing.
+
+**(a) Wrap every exit path.** Rename the existing `handleScript` body to `handleScriptInner(h *Heartbeat, cmd Command, secretEnv executor.SecretEnv) tools.CommandResult`, and introduce a new `handleScript` that owns the invariant:
+
+```go
+// handleScript is a thin wrapper that owns two invariants for EVERY exit path
+// of script execution — including early failures, the user-helper path, and
+// panicking-free error returns:
+//
+//  1. a malformed `secretEnv` fails the command before any script runs, and
+//  2. the delivered secret values are stripped from stdout, stderr AND error.
+//
+// `Error` in particular was copied raw out of the executor and out of the
+// helper IPC result, so a credential echoed into an error message reached the
+// server unredacted. Keeping the redaction here — rather than at the eight
+// executor sites that assign result.Error — means a new failure path cannot
+// silently opt out. Mirrors the server's own chokepoint invariant
+// (redactAgentResultErrorFields as the first statement of processCommandResult,
+// apps/api/src/routes/agentWs.ts).
+func handleScript(h *Heartbeat, cmd Command) tools.CommandResult {
+	start := time.Now()
+	secretEnv, err := executor.ParseSecretEnv(cmd.Payload[executor.SecretEnvPayloadKey])
+	if err != nil {
+		// Fail closed: never run a script whose secret map we could not
+		// validate. ParseSecretEnv error text names keys, never values.
+		return tools.CommandResult{
+			Status:     "failed",
+			ExitCode:   1,
+			Error:      fmt.Sprintf("refusing to execute script: %v", err),
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+	res := handleScriptInner(h, cmd, secretEnv)
+	if len(secretEnv) == 0 {
+		return res
+	}
+	redact := executor.BuildSecretRedactor(secretEnv.Values())
+	res.Stdout = redact(res.Stdout)
+	res.Stderr = redact(res.Stderr)
+	res.Error = redact(res.Error)
+	return res
+}
+```
+
+Confirm while editing that `executeViaUserHelper` and `executeScriptInSession` are reachable **only** from `handleScriptInner` — they are today (`:76`, `:82`, `:408`, `:427`, all inside that call tree). If a new caller appears, the wrapper invariant breaks; state this in the report.
+
+**(b) Populate the struct.** In `handleScriptInner`, after the `parameters` block (`:37-44`), set `script.SecretEnv = secretEnv`.
+
+**(c) Gate the non-local paths.** Immediately before the branch at `:75` (the `targetSessionID` branch), add:
+
+```go
+	// #3409 PR4b: secrets are delivered as process environment to the LOCAL
+	// executor only. The user-helper path forwards the raw payload over IPC and
+	// the helper never reads parameters or env (userhelper/client.go
+	// executeScript), so a user-context run would execute with the credential
+	// UNSET — anonymous access, an auth fallback, a lockout, or a destructive
+	// operation against the wrong target. Refuse instead. Lifting this needs a
+	// separately-versioned user-helper binary rollout (HelperVersion), which is
+	// deliberately out of scope for v1.
+	if len(script.SecretEnv) > 0 && !runAsSupportsSecrets(script.RunAs, targetSessionID) {
+		return tools.CommandResult{
+			Status:   "failed",
+			ExitCode: 1,
+			Error: "script uses secret variables, which require system-context execution; " +
+				"this script is configured to run as a user and was not executed",
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+```
+
+with
+
+```go
+// runAsSupportsSecrets reports whether an execution with this runAs setting
+// will reach the LOCAL executor, which is the only path that carries
+// BREEZE_VAR_* environment. Mirrors resolveRunAsSession's contract: "", system
+// and elevated never resolve a helper session. An explicit username is refused
+// even though it currently falls through to local execution on an unresolved
+// lookup — that fall-through is a best-effort downgrade, and downgrading a
+// secret-bearing run is exactly what must not happen silently.
+func runAsSupportsSecrets(runAs string, targetSessionID int) bool {
+	if targetSessionID >= 0 {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(runAs)) {
+	case "", "system", "elevated":
+		return true
+	default:
+		return false
+	}
+}
+```
+
+Place the guard so it runs after `targetSessionID` is computed. Read the surrounding code to confirm where that value is derived and adjust placement accordingly; the guard must precede **both** helper branches.
+
+**(d) Sanitize `Error`.** At the local result build (`:127-134`), change `Error: scriptResult.Error` to `Error: executor.SanitizeOutput(scriptResult.Error)`. At the helper result build (`:274-278`), change `Error: result.Error` to `Error: executor.SanitizeOutput(result.Error)`. Add a short comment at each noting that `Error` was previously the only unsanitized field.
+
+Ordering note: exact-value redaction (the wrapper) runs **after** `SanitizeOutput`, which is fine — the marker `[REDACTED]` contains no characters the exact redactor matches, and the exact redactor works against whatever text survived. Keep the pattern-based layer; it catches credential shapes that were never delivered as tenant variables.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd agent && go test ./internal/heartbeat/... ./internal/executor/...
+```
+Expected: PASS, including every pre-existing script handler test unchanged.
+
+**Mutation-verify, one at a time, restoring after each:**
+1. Make `ParseSecretEnv` return `(SecretEnv{}, nil)` unconditionally → the decode-failure tests must fail and nothing else.
+2. Make `runAsSupportsSecrets` return `true` unconditionally → the runAs-gating tests must fail and nothing else.
+3. Drop the `res.Error = redact(res.Error)` line → the error-redaction tests must fail and nothing else.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/heartbeat/handlers_script.go agent/internal/heartbeat/handlers_script_secret_test.go
+git commit -m "feat(agent): validate, gate and redact script secret variables (#3409 PR4b)
+
+Decodes secretEnv fail-closed before any script runs, refuses user-context
+execution paths that would drop the credential, and strips the exact secret
+values from stdout, stderr AND error on every exit path. Error was previously
+the only result field that reached the server unsanitized."
+```
+
+---
+
+### Task 5: Advertise the `scriptSecretEnvVersion` capability
+
+The server (PR4a) already stores `devices.script_secret_env_version` from `securityCapabilities.scriptSecretEnvVersion`, non-sticky so a downgrade is detected. PR4c gates dispatch on it at **enqueue and at claim**. This task makes the agent declare it.
+
+**Files:**
+- Modify: `agent/internal/heartbeat/heartbeat.go`
+- Modify: `agent/internal/heartbeat/heartbeat_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Extend `TestHeartbeatPayloadSecurityCapabilitiesJSON` (`heartbeat_test.go:239`) — do not add a parallel test — so it asserts the marshalled payload contains `"scriptSecretEnvVersion":1` alongside the existing `outboundNetworkPolicyVersion`, and that the field is emitted **unconditionally** (no `omitempty`), so the server can distinguish "old agent, object absent" from "capable agent declaring 0".
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd agent && go test ./internal/heartbeat -run SecurityCapabilities
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`heartbeat.go:177-179`:
+
+```go
+type SecurityCapabilities struct {
+	OutboundNetworkPolicyVersion int `json:"outboundNetworkPolicyVersion"`
+	// #3409 PR4b — this build decodes `secretEnv`, injects BREEZE_VAR_*, blocks
+	// user-context runs that would drop the credential, and redacts the values
+	// out of stdout/stderr/error. Declared unconditionally: the behavior is
+	// compiled in, not a runtime toggle. The server writes this non-sticky on
+	// every beat, so a DOWNGRADE to an older agent reports back down to 0 and
+	// the PR4c dispatch gate stops trusting a stale claim.
+	ScriptSecretEnvVersion int `json:"scriptSecretEnvVersion"`
+}
+```
+
+`heartbeat.go:3828`:
+
+```go
+		SecurityCapabilities: SecurityCapabilities{
+			OutboundNetworkPolicyVersion: 1,
+			ScriptSecretEnvVersion:       1,
+		},
+```
+
+- [ ] **Step 4: Run tests and commit**
+
+```bash
+cd agent && go test ./internal/heartbeat/...
+git add agent/internal/heartbeat/heartbeat.go agent/internal/heartbeat/heartbeat_test.go
+git commit -m "feat(agent): advertise scriptSecretEnvVersion 1 capability (#3409 PR4b)"
+```
+
+---
+
+### Task 6: Whole-agent verification and PR
+
+- [ ] **Step 1: Confirm no new leak surface**
+
+Run and report the output of each:
+
+```bash
+cd agent
+grep -rn "SecretEnv" internal/ --include='*.go' | grep -v '_test.go'
+grep -rn "BREEZE_VAR_" internal/ --include='*.go' | grep -v '_test.go'
+grep -rn "DisallowUnknownFields" .
+```
+
+Assert by inspection that: no `log.` call takes a `SecretEnv` or a secret value; `SecretEnv` appears on no struct that is marshalled to the wire, written to disk, or sent over IPC; and `SubstituteParameters` / `validateScript` / `WriteScriptFile` are not reachable with a secret value.
+
+- [ ] **Step 2: Full agent build, vet, format and suite**
+
+```bash
+cd agent
+go build ./...
+go vet ./...
+gofmt -l .            # must print nothing
+CGO_ENABLED=0 go test ./...        # matches the CI `test-agent` job
+go test -race ./internal/executor ./internal/heartbeat
+```
+
+Do not pipe these through `tail` — you lose progress and cannot tell slow from wedged.
+
+- [ ] **Step 3: Rebase onto current main BEFORE opening the PR**
+
+```bash
+git fetch origin main && git rebase origin/main
+cd agent && CGO_ENABLED=0 go test ./internal/executor ./internal/heartbeat
+```
+
+- [ ] **Step 4: Open the PR**
+
+Title: `feat(agent): decode, gate and redact script secret variables (#3409 PR4b)`
+
+Body must state: the feature is **inert** (the server never populates `secretEnv` until PR4c); this build must be **rolled out to the fleet before PR4c merges**; the `runAs: user` limitation and why lifting it needs a separate helper-binary rollout; and that exact-value redaction is accidental-leak protection, not DLP.
+
+---
+
+## Explicitly out of scope
+
+| Item | Where it belongs |
+|---|---|
+| Unblocking secrets at script save/import and at dispatch | PR4c |
+| Capability gate at enqueue and at claim | PR4c |
+| Digest pinning of variable references + canonicalized parameter definitions | PR4c |
+| User-helper support for secrets (needs a versioned helper-binary rollout) | Later, tracked separately |
+| `TruncatedFields` not propagated from the executor into `tools.CommandResult` (`handlers_script.go:127-134`) — pre-existing, unrelated | Own issue |
+| Docs / release notes for the feature | PR4c, when it becomes reachable |


### PR DESCRIPTION
Agent-side half of tenant-variable secret delivery (#3409 PR4b). Follows **PR4a (#3557)**, which landed the inert server machinery.

## The feature is inert on this branch

Nothing on the server populates `secretEnv` until PR4c. Every path added here is unreachable in production today, and a `script` command without a `secretEnv` key behaves exactly as before (pinned by `TestHandleScriptWithoutSecretEnvIsUnaffected`, `TestHandleScriptWithoutSecretEnvStillUsesHelper`, `TestHandleScriptElevatedWithoutSecretsUnaffected`, `TestBuildEnvironmentEmptyOrNilSecretEnvAddsNoEntries`).

**Rollout order is operational, not cosmetic: this build must reach the fleet BEFORE PR4c merges.** PR4c gates dispatch on the `scriptSecretEnvVersion: 1` capability this PR advertises; until an agent reports it, that agent gets no secrets.

**Merge order:** PR4a (#3557) should merge first. Several comments here cite server files it adds (`scriptSecretEnvelope.ts`, `exactSecretRedaction.ts`, `MIN_SECRET_TENANT_VARIABLE_VALUE_LENGTH`); each citation is marked as forward-referencing PR4a. This branch has no code dependency on it, which is why it targets `main` directly and gets full CI rather than the stacked-branch no-CI trap.

## What it does

- **Decode, fail-closed** — `executor.ParseSecretEnv` validates shape, key grammar, value floor and entry cap. Any fault fails the command *before the script runs*. An agent that ran the script anyway with the credential env var unset would not be degrading gracefully: that means anonymous access, an auth fallback, a lockout, or a destructive operation against the wrong target.
- **Deliver as environment, never as script text** — `BREEZE_VAR_<UPPER>` entries appended in `buildEnvironment`. Secrets deliberately never reach `SubstituteParameters` or `validateScript`, because the substituted script is written to a temp file on the customer's disk. Entries are appended after `os.Environ()` so `os/exec`'s last-wins dedupe stops a pre-existing `BREEZE_VAR_*` from shadowing a delivered secret.
- **Refuse every path that would drop the credential** — `runAs: user`, an explicit username, session-targeted execution, and `elevated` on a not-already-elevated agent. The last one is subtle: `configureRunAs` re-execs through `sudo -n` with no `-E`, so `env_reset` would discard the variables and the script would run with the credential unset.
- **Redact exact values from stdout, stderr AND error** — at a single chokepoint wrapping every exit path of `handleScript`, so a failure path added later cannot silently opt out. `Error` was previously the only result field reaching the server unsanitized.
- **Advertise `scriptSecretEnvVersion: 1`** — unconditional, no `omitempty`, following the `outboundNetworkPolicyVersion` precedent, so the server can tell "old agent, object absent" from "capable agent declaring 0" and detect a downgrade.

`SecretEnv` is a named type whose `String`/`GoString`/`Format`/`MarshalJSON` all redact and whose `UnmarshalJSON` always errors, so no format verb or serialization path can extract plaintext — same defense `secmem.SecureString` gives the enrollment token.

## One behavior change for existing traffic

`result.Error` now passes through `SanitizeOutput` on **all** script commands, not only secret-bearing ones. This closes the "`result.Error` unsanitized at 8 sites" item from the PR4 handoff: two `NewErrorResult` paths (one live, on helper IPC send failure) previously returned raw error text. The `"timed out"` status classification still reads the unmodified text, and the handler's own error strings were checked against all eight `SanitizeOutput` patterns for false positives.

## Known limitations, stated deliberately

- **Redaction is accidental-leak protection, not DLP.** It removes a credential a script echoed, logged, or put in an error. It cannot catch a value the script transformed, base64-encoded, hashed, reversed, or printed one character per line. The script author holds the credential by definition. It also runs after `SanitizeOutput` and after the 1 MB output truncation, so a secret whose middle is consumed by a sanitizer pattern or which straddles the cap can leave a fragment — recorded in the redactor's comment.
- **`runAs: user` is refused, not supported.** The user helper forwards the raw payload over IPC and reads only language/content/timeout. Supporting it needs a separately-versioned helper-binary rollout (`HelperVersion`) — a second rollout axis, deliberately out of scope for v1.
- The `elevated` *delivery* test skips unless the host is genuinely root; the gate *decision* is covered unconditionally in both stub states.

## Verification

`go build ./...`, `go vet ./...`, `CGO_ENABLED=0 go test ./...` (the CI `test-agent` command) and `go test -race ./internal/executor ./internal/heartbeat` all green, re-run after rebasing onto current `main`. Every new guard was mutation-verified: forced off, confirmed the new tests fail and nothing else does, restored.

Built with subagent-driven development from `docs/superpowers/plans/2026-08-14-pr4b-agent-secret-env.md`; each task got an independent review, and a whole-branch review caught two places where the plan itself was wrong (the key grammar was laxer than the server's, and the redactor merged abutting ranges where the server keeps them separate). Both are fixed and the plan doc is corrected.

## Follow-ups (not this PR)

- `handleScriptCancel` / `handleScriptListRunning` propagate helper-sourced error text through `NewErrorResult` with no `SanitizeOutput` — pre-existing, outside the `handleScript` chokepoint, no secret can reach those payloads.
- `TruncatedFields` is populated by the executor but never propagated into `tools.CommandResult`, so the server never sees it on the local path — pre-existing and unrelated.
