### PR TITLE
fix(web): let fleet (All-orgs) view create DNS integrations & device groups

### DIFF
--- a/apps/web/src/components/devices/DeviceGroupsPage.dynamicGroups.test.tsx
+++ b/apps/web/src/components/devices/DeviceGroupsPage.dynamicGroups.test.tsx
@@ -6,9 +6,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import DeviceGroupsPage from './DeviceGroupsPage';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  // orgStore registers an orgId provider at module load; the component now
+  // pulls in orgStore via useFleetOrgOwner, so this export must exist.
+  registerOrgIdProvider: vi.fn(),
 }));
 
 vi.mock('../../hooks/useFilterPreview', () => ({
@@ -65,6 +69,23 @@ const exactText = (text: string) => (_content: string, element: Element | null) 
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // A resolved focused-org scope: no fleet picker, create proceeds normally
+  // (the injected ?orgId= supplies the owner).
+  useOrgStore.setState({
+    currentOrgId: 'org-focused',
+    allOrgs: false,
+    organizations: [
+      {
+        id: 'org-focused',
+        partnerId: 'p-1',
+        name: 'Focused Org',
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    ],
+    organizationsLoaded: true,
+    error: null,
+  });
 });
 
 describe('DeviceGroupsPage dynamic groups', () => {

--- a/apps/web/src/components/devices/DeviceGroupsPage.staticGroups.test.tsx
+++ b/apps/web/src/components/devices/DeviceGroupsPage.staticGroups.test.tsx
@@ -6,9 +6,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import DeviceGroupsPage from './DeviceGroupsPage';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  // orgStore registers an orgId provider at module load; the component now
+  // pulls in orgStore via useFleetOrgOwner, so this export must exist.
+  registerOrgIdProvider: vi.fn(),
 }));
 
 vi.mock('../../hooks/useFilterPreview', () => ({
@@ -80,6 +84,23 @@ const selectDevice = async (
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // A resolved focused-org scope: no fleet picker, create proceeds normally
+  // (the injected ?orgId= supplies the owner).
+  useOrgStore.setState({
+    currentOrgId: 'org-focused',
+    allOrgs: false,
+    organizations: [
+      {
+        id: 'org-focused',
+        partnerId: 'p-1',
+        name: 'Focused Org',
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    ],
+    organizationsLoaded: true,
+    error: null,
+  });
 });
 
 /**

--- a/apps/web/src/components/devices/DeviceGroupsPage.test.tsx
+++ b/apps/web/src/components/devices/DeviceGroupsPage.test.tsx
@@ -1,13 +1,17 @@
 import '@/lib/i18n';
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import DeviceGroupsPage from './DeviceGroupsPage';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore, type Organization } from '../../stores/orgStore';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  // orgStore registers an orgId provider at module load; the component now
+  // pulls in orgStore via useFleetOrgOwner, so this export must exist.
+  registerOrgIdProvider: vi.fn(),
 }));
 
 // The preview hook fires its own request; the page's unwrap logic is what's
@@ -66,8 +70,31 @@ const ENVELOPE_RESPONSES: Record<string, unknown> = {
 
 const requestedPaths = () => mockFetch.mock.calls.map((call) => String(call[0]));
 
+const orgA: Organization = {
+  id: 'org-1',
+  partnerId: 'p-1',
+  name: 'Acme Corp',
+  status: 'active',
+  createdAt: '2026-01-01T00:00:00Z',
+};
+const orgB: Organization = {
+  id: 'org-2',
+  partnerId: 'p-1',
+  name: 'Beta Inc',
+  status: 'active',
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
+  // Non-fleet default: the picker stays hidden unless a test opts into All-orgs.
+  useOrgStore.setState({
+    currentOrgId: null,
+    allOrgs: false,
+    organizations: [],
+    organizationsLoaded: false,
+    error: null,
+  });
   mockFetch.mockImplementation(async (url: string) => {
     const path = url.split('?')[0];
     if (path in ENVELOPE_RESPONSES) return jsonResponse(ENVELOPE_RESPONSES[path]);
@@ -135,5 +162,63 @@ describe('DeviceGroupsPage list unwrapping', () => {
     render(<DeviceGroupsPage />);
 
     expect(await screen.findByText(/failed to fetch device groups/i)).toBeInTheDocument();
+  });
+});
+
+describe('DeviceGroupsPage create in All-organizations (fleet) scope', () => {
+  beforeEach(() => {
+    useOrgStore.setState({
+      currentOrgId: null,
+      allOrgs: true,
+      organizations: [orgA, orgB],
+      organizationsLoaded: true,
+      error: null,
+    });
+  });
+
+  async function openCreateModal() {
+    render(<DeviceGroupsPage />);
+    await screen.findByText('Servers');
+    fireEvent.click(screen.getByRole('button', { name: 'Create Group' }));
+  }
+
+  it('shows an Organization picker and disables submit until an org is chosen', async () => {
+    await openCreateModal();
+    const orgOption = await screen.findByRole('option', { name: 'Acme Corp' });
+    const orgSelect = orgOption.closest('select') as HTMLSelectElement;
+    expect(orgSelect).toBeInTheDocument();
+
+    const submit = screen.getByRole('button', { name: 'Create group' });
+    expect(submit).toBeDisabled();
+    fireEvent.change(orgSelect, { target: { value: 'org-2' } });
+    expect(submit).toBeEnabled();
+  });
+
+  it('sends the chosen orgId in the create POST body', async () => {
+    await openCreateModal();
+    fireEvent.change(screen.getByPlaceholderText(/production linux/i), {
+      target: { value: 'Fleet Group' },
+    });
+    const orgSelect = (await screen.findByRole('option', { name: 'Beta Inc' })).closest(
+      'select',
+    ) as HTMLSelectElement;
+    fireEvent.change(orgSelect, { target: { value: 'org-2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create group' }));
+
+    await waitFor(() => {
+      const post = mockFetch.mock.calls.find(
+        (call) =>
+          String(call[0]) === '/device-groups' &&
+          (call[1] as RequestInit | undefined)?.method === 'POST',
+      );
+      expect(post).toBeTruthy();
+    });
+    const post = mockFetch.mock.calls.find(
+      (call) =>
+        String(call[0]) === '/device-groups' &&
+        (call[1] as RequestInit | undefined)?.method === 'POST',
+    )!;
+    const body = JSON.parse(String((post[1] as RequestInit).body));
+    expect(body.orgId).toBe('org-2');
   });
 });

--- a/apps/web/src/components/devices/DeviceGroupsPage.tsx
+++ b/apps/web/src/components/devices/DeviceGroupsPage.tsx
@@ -515,8 +515,8 @@ export default function DeviceGroupsPage() {
         type: groupForm.type,
       };
 
-      // Only a fleet-scope create carries an explicit owner org; a focused
-      // create relies on the injected `?orgId=`, and edits never move orgs.
+      // A create carries the concrete owner org in the body (the focused org, or
+      // the fleet picker's choice); edits never move a group between orgs.
       if (!isEdit && fleet.bodyOrgId) {
         payload.orgId = fleet.bodyOrgId;
       }

--- a/apps/web/src/components/devices/DeviceGroupsPage.tsx
+++ b/apps/web/src/components/devices/DeviceGroupsPage.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { Plus, Pencil, Trash2, Shield, Play, X } from "lucide-react";
 import { fetchWithAuth } from "@/stores/auth";
+import { useFleetOrgOwner } from "@/hooks/useFleetOrgOwner";
 import { asList } from "@/lib/asList";
 import type { FilterConditionGroup } from "@breeze/shared";
 import { FilterBuilder, DEFAULT_FILTER_FIELDS } from "../filters/FilterBuilder";
@@ -190,6 +191,9 @@ export default function DeviceGroupsPage() {
   const [selectedGroup, setSelectedGroup] = useState<DeviceGroup | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string>();
+  // All-orgs view injects no `?orgId=`, so a create needs an explicit owner org
+  // (the server would otherwise reject it with "orgId is required").
+  const fleet = useFleetOrgOwner();
   const EMPTY_FILTER: FilterConditionGroup = {
     operator: "AND",
     conditions: [{ field: "hostname", operator: "contains", value: "" }],
@@ -396,6 +400,9 @@ export default function DeviceGroupsPage() {
   const handleOpenCreate = () => {
     setSelectedGroup(null);
     resetForm();
+    // Start each create fresh — the hook is page-level, so a prior fleet pick
+    // would otherwise linger across close/reopen.
+    fleet.setOrgId("");
     setModalMode("create");
   };
 
@@ -471,6 +478,11 @@ export default function DeviceGroupsPage() {
       setFormError("Group name is required.");
       return;
     }
+    // A new group must land in one org; edits keep the group's existing owner.
+    if (modalMode === "create" && fleet.needsOrgSelection) {
+      setFormError(t("common:layout.orgRequired.title"));
+      return;
+    }
     if (groupForm.type === "dynamic") {
       const hasValidCondition = groupForm.filterConditions.conditions.some(
         (c) => {
@@ -502,6 +514,12 @@ export default function DeviceGroupsPage() {
         name: trimmedName,
         type: groupForm.type,
       };
+
+      // Only a fleet-scope create carries an explicit owner org; a focused
+      // create relies on the injected `?orgId=`, and edits never move orgs.
+      if (!isEdit && fleet.bodyOrgId) {
+        payload.orgId = fleet.bodyOrgId;
+      }
 
       if (isDynamic) {
         payload.filterConditions = groupForm.filterConditions;
@@ -1045,6 +1063,27 @@ export default function DeviceGroupsPage() {
             </div>
 
             <form className="mt-6 space-y-6" onSubmit={handleSubmitGroup}>
+              {modalMode === "create" && fleet.isFleetScope && (
+                <div>
+                  <label className="text-sm font-medium">
+                    {t("common:labels.organization")}
+                  </label>
+                  <select
+                    value={fleet.orgId}
+                    onChange={(event) => fleet.setOrgId(event.target.value)}
+                    className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                  >
+                    <option value="" disabled>
+                      {t("common:layout.org.noSelection")}
+                    </option>
+                    {fleet.organizations.map((org) => (
+                      <option key={org.id} value={org.id}>
+                        {org.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
               <div>
                 <div>
                   <label className="text-sm font-medium">
@@ -1242,7 +1281,10 @@ export default function DeviceGroupsPage() {
                 </button>
                 <button
                   type="submit"
-                  disabled={submitting}
+                  disabled={
+                    submitting ||
+                    (modalMode === "create" && fleet.needsOrgSelection)
+                  }
                   className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   {submitting

--- a/apps/web/src/components/dnsSecurity/AddDnsIntegrationModal.test.tsx
+++ b/apps/web/src/components/dnsSecurity/AddDnsIntegrationModal.test.tsx
@@ -125,6 +125,9 @@ describe('AddDnsIntegrationModal', () => {
       isActive: true,
     });
     expect(body.apiSecret).toBeUndefined();
+    // Focused scope must still send the concrete org in the body — the DNS
+    // route reads only body.orgId, never the injected query (#3505).
+    expect(body.orgId).toBe('org-aaaa');
     await waitFor(() => {
       expect(showToastMock).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'success', message: expect.stringMatching(/Cloudflare/) }),

--- a/apps/web/src/components/dnsSecurity/AddDnsIntegrationModal.test.tsx
+++ b/apps/web/src/components/dnsSecurity/AddDnsIntegrationModal.test.tsx
@@ -3,10 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AddDnsIntegrationModal from './AddDnsIntegrationModal';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore, type Organization } from '../../stores/orgStore';
 import { showToast } from '../shared/Toast';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  // orgStore registers an orgId provider at module load; the component now
+  // pulls in orgStore via useFleetOrgOwner, so this export must exist.
+  registerOrgIdProvider: vi.fn(),
 }));
 
 vi.mock('../shared/Toast', () => ({
@@ -25,9 +29,33 @@ function makeJsonResponse(payload: unknown, ok = true, status = ok ? 200 : 500):
   } as unknown as Response;
 }
 
+const orgA: Organization = {
+  id: 'org-aaaa',
+  partnerId: 'p-1',
+  name: 'Acme Corp',
+  status: 'active',
+  createdAt: '2026-01-01T00:00:00Z',
+};
+const orgB: Organization = {
+  id: 'org-bbbb',
+  partnerId: 'p-1',
+  name: 'Beta Inc',
+  status: 'active',
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
 describe('AddDnsIntegrationModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset to a concrete-org (non-fleet) scope so the picker stays hidden
+    // unless a test explicitly opts into the All-orgs view.
+    useOrgStore.setState({
+      currentOrgId: 'org-aaaa',
+      allOrgs: false,
+      organizations: [orgA, orgB],
+      organizationsLoaded: true,
+      error: null,
+    });
   });
 
   it('only lists the 5 supported providers (opendns + quad9 hidden)', () => {
@@ -126,5 +154,68 @@ describe('AddDnsIntegrationModal', () => {
     });
     expect(onClose).not.toHaveBeenCalled();
     expect(onCreated).not.toHaveBeenCalled();
+  });
+
+  describe('All-organizations (fleet) scope', () => {
+    beforeEach(() => {
+      // Explicit All-orgs view: no injected ?orgId=, so the picker is required.
+      useOrgStore.setState({
+        currentOrgId: null,
+        allOrgs: true,
+        organizations: [orgA, orgB],
+        organizationsLoaded: true,
+        error: null,
+      });
+    });
+
+    it('renders an Organization picker listing the accessible orgs', () => {
+      render(<AddDnsIntegrationModal onClose={() => {}} onCreated={() => {}} />);
+      const select = screen.getByLabelText('Organization') as HTMLSelectElement;
+      const labels = Array.from(select.options).map((o) => o.textContent);
+      expect(labels).toContain('Acme Corp');
+      expect(labels).toContain('Beta Inc');
+    });
+
+    it('keeps the submit button disabled until an org is chosen', () => {
+      render(<AddDnsIntegrationModal onClose={() => {}} onCreated={() => {}} />);
+      fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Acme HQ' } });
+      fireEvent.change(screen.getByLabelText('API token'), { target: { value: 'cf-token-abc' } });
+      const submit = screen.getByRole('button', { name: /Add integration/i });
+      expect(submit).toBeDisabled();
+      fireEvent.change(screen.getByLabelText('Organization'), { target: { value: 'org-bbbb' } });
+      expect(submit).toBeEnabled();
+    });
+
+    it('guards a programmatic submit with an in-form error and no request', async () => {
+      render(<AddDnsIntegrationModal onClose={() => {}} onCreated={() => {}} />);
+      fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Acme HQ' } });
+      fireEvent.change(screen.getByLabelText('API token'), { target: { value: 'cf-token-abc' } });
+      // Bypass the disabled button (Enter-key / programmatic path) by dispatching
+      // submit straight to the form — the JS guard must still stop it.
+      const form = screen.getByLabelText('Organization').closest('form')!;
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(/Select an organization/i);
+      });
+      expect(fetchWithAuthMock).not.toHaveBeenCalled();
+    });
+
+    it('includes the chosen orgId in the POST body once an org is selected', async () => {
+      fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse({ data: { id: 'new-1' } }));
+      render(<AddDnsIntegrationModal onClose={() => {}} onCreated={() => {}} />);
+      fireEvent.change(screen.getByLabelText('Organization'), { target: { value: 'org-bbbb' } });
+      fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Acme HQ' } });
+      fireEvent.change(screen.getByLabelText('API token'), { target: { value: 'cf-token-abc' } });
+      fireEvent.change(screen.getByLabelText('Account ID'), { target: { value: '0123456789abcdef' } });
+      fireEvent.click(screen.getByRole('button', { name: /Add integration/i }));
+
+      await waitFor(() => {
+        expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+      });
+      const init = fetchWithAuthMock.mock.calls[0]![1] as RequestInit;
+      const body = JSON.parse(String(init.body));
+      expect(body.orgId).toBe('org-bbbb');
+    });
   });
 });

--- a/apps/web/src/components/dnsSecurity/AddDnsIntegrationModal.tsx
+++ b/apps/web/src/components/dnsSecurity/AddDnsIntegrationModal.tsx
@@ -5,6 +5,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '../../lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 import { Dialog } from '../shared/Dialog';
+import { useFleetOrgOwner } from '@/hooks/useFleetOrgOwner';
 
 /**
  * Supported provider IDs. Mirrors the wire-format `dns_provider` enum,
@@ -100,6 +101,9 @@ export default function AddDnsIntegrationModal({ onClose, onCreated }: AddDnsInt
   const [config, setConfig] = useState<ConfigPayload>({});
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // In the All-orgs view there is no injected `?orgId=`, so the create needs an
+  // explicit owner org (server would otherwise 400 "orgId is required").
+  const fleet = useFleetOrgOwner();
 
   const spec = PROVIDERS[provider];
 
@@ -112,6 +116,12 @@ export default function AddDnsIntegrationModal({ onClose, onCreated }: AddDnsInt
     if (submitting) return;
     setSubmitting(true);
     setError(null);
+
+    if (fleet.needsOrgSelection) {
+      setError(t('common:layout.orgRequired.title'));
+      setSubmitting(false);
+      return;
+    }
 
     // Trim string-empty values so we don't send them — the server treats
     // empty strings as set, which breaks the provider-specific refinements
@@ -126,6 +136,7 @@ export default function AddDnsIntegrationModal({ onClose, onCreated }: AddDnsInt
         request: () => fetchWithAuth('/dns-security/integrations', {
           method: 'POST',
           body: JSON.stringify({
+            orgId: fleet.bodyOrgId,
             provider,
             name: name.trim(),
             description: description.trim() || undefined,
@@ -171,6 +182,28 @@ export default function AddDnsIntegrationModal({ onClose, onCreated }: AddDnsInt
         </p>
 
         <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          {fleet.isFleetScope && (
+            <Field label={t('common:labels.organization')}>
+              {(id) => (
+                <select
+                  id={id}
+                  value={fleet.orgId}
+                  onChange={(e) => fleet.setOrgId(e.target.value)}
+                  className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+                >
+                  <option value="" disabled>
+                    {t('common:layout.org.noSelection')}
+                  </option>
+                  {fleet.organizations.map((org) => (
+                    <option key={org.id} value={org.id}>
+                      {org.name}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </Field>
+          )}
+
           <Field label={t('dnsSecurityAddDnsIntegrationModal.fields.provider')}>
             {(id) => (
               <>
@@ -290,7 +323,7 @@ export default function AddDnsIntegrationModal({ onClose, onCreated }: AddDnsInt
             </button>
             <button
               type="submit"
-              disabled={submitting || !name.trim() || !apiKey.trim()}
+              disabled={submitting || !name.trim() || !apiKey.trim() || fleet.needsOrgSelection}
               className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
             >
               {submitting

--- a/apps/web/src/components/dnsSecurity/DnsSecurityIntegrationsTab.test.tsx
+++ b/apps/web/src/components/dnsSecurity/DnsSecurityIntegrationsTab.test.tsx
@@ -7,6 +7,9 @@ import { showToast } from '../shared/Toast';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  // orgStore (pulled in transitively via the Add modal) registers an orgId
+  // provider at module load, so this export must exist under the mock.
+  registerOrgIdProvider: vi.fn(),
 }));
 
 vi.mock('../shared/Toast', () => ({

--- a/apps/web/src/hooks/useFleetOrgOwner.test.ts
+++ b/apps/web/src/hooks/useFleetOrgOwner.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useFleetOrgOwner } from './useFleetOrgOwner';
+import { useOrgStore, type Organization } from '../stores/orgStore';
+
+const acme: Organization = {
+  id: 'org-1',
+  partnerId: 'p-1',
+  name: 'Acme Corp',
+  status: 'active',
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+const zeta: Organization = {
+  id: 'org-2',
+  partnerId: 'p-1',
+  name: 'Zeta Ltd',
+  status: 'active',
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+function seed(partial: Partial<ReturnType<typeof useOrgStore.getState>>) {
+  useOrgStore.setState({
+    currentOrgId: null,
+    allOrgs: false,
+    organizations: [],
+    organizationsLoaded: false,
+    error: null,
+    ...partial,
+  });
+}
+
+describe('useFleetOrgOwner', () => {
+  beforeEach(() => {
+    seed({});
+  });
+
+  it('explicit All-orgs view: picker required, no owner chosen yet', () => {
+    seed({ allOrgs: true, organizations: [acme, zeta], organizationsLoaded: true });
+    const { result } = renderHook(() => useFleetOrgOwner());
+    expect(result.current.isFleetScope).toBe(true);
+    expect(result.current.needsOrgSelection).toBe(true);
+    expect(result.current.bodyOrgId).toBeUndefined();
+  });
+
+  it('choosing an org in fleet scope clears the requirement and supplies bodyOrgId', () => {
+    seed({ allOrgs: true, organizations: [acme, zeta], organizationsLoaded: true });
+    const { result } = renderHook(() => useFleetOrgOwner());
+    act(() => result.current.setOrgId('org-2'));
+    expect(result.current.needsOrgSelection).toBe(false);
+    expect(result.current.bodyOrgId).toBe('org-2');
+  });
+
+  it('concrete-org scope: no picker, has a resolvable owner, never sends orgId', () => {
+    seed({ currentOrgId: 'org-1', organizations: [acme], organizationsLoaded: true });
+    const { result } = renderHook(() => useFleetOrgOwner());
+    expect(result.current.isFleetScope).toBe(false);
+    expect(result.current.needsOrgSelection).toBe(false);
+    expect(result.current.bodyOrgId).toBeUndefined();
+  });
+
+  // Regression guard: the pre-hydration null (list not loaded, All-orgs not
+  // chosen) must NOT flash the picker — the scope is about to resolve. But the
+  // create has no owner yet, so it must stay blocked (no opaque 400).
+  it('pre-hydration / loading: no picker, but create is blocked (no owner yet)', () => {
+    seed({}); // currentOrgId null, allOrgs false, list not loaded → loading
+    const { result } = renderHook(() => useFleetOrgOwner());
+    expect(result.current.isFleetScope).toBe(false);
+    expect(result.current.needsOrgSelection).toBe(true);
+    expect(result.current.bodyOrgId).toBeUndefined();
+  });
+
+  // Org-list load failure while the page stays usable: still no injectable org,
+  // so the create must stay blocked rather than 400.
+  it('org-list error state: create blocked, no picker', () => {
+    seed({ error: 'Failed to fetch organizations' });
+    const { result } = renderHook(() => useFleetOrgOwner());
+    expect(result.current.isFleetScope).toBe(false);
+    expect(result.current.needsOrgSelection).toBe(true);
+  });
+
+  // Finding 6: a pick that drops out of the accessible org list (partner switch,
+  // refetch) must NOT survive as the owner.
+  it('drops a selection that is no longer in the org list', () => {
+    seed({ allOrgs: true, organizations: [acme, zeta], organizationsLoaded: true });
+    const { result, rerender } = renderHook(() => useFleetOrgOwner());
+    act(() => result.current.setOrgId('org-2'));
+    expect(result.current.orgId).toBe('org-2');
+    expect(result.current.needsOrgSelection).toBe(false);
+
+    // org-2 disappears from the accessible list.
+    act(() => seed({ allOrgs: true, organizations: [acme], organizationsLoaded: true }));
+    rerender();
+    expect(result.current.orgId).toBe('');
+    expect(result.current.needsOrgSelection).toBe(true);
+    expect(result.current.bodyOrgId).toBeUndefined();
+
+    // And it must NOT resurrect if org-2 later reappears — the effect cleared
+    // the raw pick, so the user has to choose again.
+    act(() => seed({ allOrgs: true, organizations: [acme, zeta], organizationsLoaded: true }));
+    rerender();
+    expect(result.current.orgId).toBe('');
+    expect(result.current.needsOrgSelection).toBe(true);
+    expect(result.current.bodyOrgId).toBeUndefined();
+  });
+
+  it('sorts the org list by name for the picker', () => {
+    seed({ allOrgs: true, organizations: [zeta, acme], organizationsLoaded: true });
+    const { result } = renderHook(() => useFleetOrgOwner());
+    expect(result.current.organizations.map((o) => o.id)).toEqual(['org-1', 'org-2']);
+  });
+});

--- a/apps/web/src/hooks/useFleetOrgOwner.test.ts
+++ b/apps/web/src/hooks/useFleetOrgOwner.test.ts
@@ -51,12 +51,14 @@ describe('useFleetOrgOwner', () => {
     expect(result.current.bodyOrgId).toBe('org-2');
   });
 
-  it('concrete-org scope: no picker, has a resolvable owner, never sends orgId', () => {
+  it('concrete-org scope: no picker, and sends the focused org in the body', () => {
+    // The body must carry the concrete org even when focused — some routes
+    // (DNS integrations, #3505) read only body.orgId, never the injected query.
     seed({ currentOrgId: 'org-1', organizations: [acme], organizationsLoaded: true });
     const { result } = renderHook(() => useFleetOrgOwner());
     expect(result.current.isFleetScope).toBe(false);
     expect(result.current.needsOrgSelection).toBe(false);
-    expect(result.current.bodyOrgId).toBeUndefined();
+    expect(result.current.bodyOrgId).toBe('org-1');
   });
 
   // Regression guard: the pre-hydration null (list not loaded, All-orgs not
@@ -70,6 +72,17 @@ describe('useFleetOrgOwner', () => {
     expect(result.current.bodyOrgId).toBeUndefined();
   });
 
+  // A persisted focused currentOrgId that is no longer in the accessible list
+  // (deleted / access revoked, before the list repairs it) must NOT be
+  // submitted — it would 403. Block instead.
+  it('focused scope with a stale/inaccessible currentOrgId: blocked, no body', () => {
+    seed({ currentOrgId: 'org-gone', organizations: [acme], organizationsLoaded: true });
+    const { result } = renderHook(() => useFleetOrgOwner());
+    expect(result.current.isFleetScope).toBe(false);
+    expect(result.current.needsOrgSelection).toBe(true);
+    expect(result.current.bodyOrgId).toBeUndefined();
+  });
+
   // Org-list load failure while the page stays usable: still no injectable org,
   // so the create must stay blocked rather than 400.
   it('org-list error state: create blocked, no picker', () => {
@@ -77,6 +90,24 @@ describe('useFleetOrgOwner', () => {
     const { result } = renderHook(() => useFleetOrgOwner());
     expect(result.current.isFleetScope).toBe(false);
     expect(result.current.needsOrgSelection).toBe(true);
+  });
+
+  // Cold-load FAILURE while legitimately focused: the org list never loaded
+  // (organizationsLoaded false), but a persisted currentOrgId keeps the user
+  // focused. The focused owner must still be trusted (server authorizes it) —
+  // NOT blocked just because the list is empty, or the user is stranded with no
+  // retry. Regression guard.
+  it('focused scope, org-list not loaded (cold-load failure): trusts the focused org', () => {
+    seed({
+      currentOrgId: 'org-1',
+      organizations: [],
+      organizationsLoaded: false,
+      error: 'Failed to fetch organizations',
+    });
+    const { result } = renderHook(() => useFleetOrgOwner());
+    expect(result.current.isFleetScope).toBe(false);
+    expect(result.current.needsOrgSelection).toBe(false);
+    expect(result.current.bodyOrgId).toBe('org-1');
   });
 
   // Finding 6: a pick that drops out of the accessible org list (partner switch,

--- a/apps/web/src/hooks/useFleetOrgOwner.ts
+++ b/apps/web/src/hooks/useFleetOrgOwner.ts
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useOrgScope } from './useOrgScope';
+import { useOrgStore, type Organization } from '../stores/orgStore';
+
+export interface FleetOrgOwner {
+  /** True only in the explicit All-organizations view, where a pick is required. */
+  isFleetScope: boolean;
+  /** Org list for the picker, sorted by name. */
+  organizations: Organization[];
+  /**
+   * The effective owner selection — the raw pick, but only while it is still a
+   * member of the current org list. A pick that dropped out of the list (partner
+   * switch, refetch) collapses back to '' so the UI shows "unselected" and the
+   * create cannot proceed with a stale org.
+   */
+  orgId: string;
+  setOrgId: (id: string) => void;
+  /**
+   * True when the create has no resolvable owner and must be blocked: the fleet
+   * view with no valid pick, OR any scope that has not resolved to a concrete
+   * org (loading, error, empty, cleared). A focused, resolved org scope is fine
+   * — the server gets the injected `?orgId=`.
+   */
+  needsOrgSelection: boolean;
+  /**
+   * The orgId to place in the create body: the validated pick in fleet scope,
+   * otherwise undefined (a focused scope relies on the `?orgId=` that
+   * fetchWithAuth injects, so the body must stay silent there).
+   */
+  bodyOrgId: string | undefined;
+}
+
+/**
+ * Backs a fleet-only "Organization" picker for org-owned create forms (DNS
+ * integrations, device groups). Those resources must belong to exactly one org;
+ * the dashboard normally scopes the create by the `?orgId=` that fetchWithAuth
+ * injects from the active org. In the EXPLICIT All-organizations view there is
+ * no active org, nothing is injected, and the server rejects the create with
+ * "orgId is required for this scope". This hook surfaces the org list, tracks
+ * the chosen owner, and reports when a create has no resolvable owner yet.
+ *
+ * Gate the picker on `useOrgScope().scope === 'all'`, NOT `currentOrgId === null`:
+ * the bare-null read also matches the pre-hydration frame before the first org
+ * auto-selects, which would flash the picker on a scope that's about to resolve
+ * to a concrete org. (Same rule as useDefaultOwnerScope.)
+ *
+ * `needsOrgSelection` deliberately also blocks the unresolved/degraded scopes
+ * (loading, org-list load failure, empty, cleared): those inject no `?orgId=`
+ * either, so an unguarded create would hit the same opaque 400. And the picker
+ * value is validated against the live org list every render, so a selection
+ * that stops being accessible cannot be silently reused as the owner.
+ */
+export function useFleetOrgOwner(): FleetOrgOwner {
+  const scope = useOrgScope();
+  const organizations = useOrgStore((s) => s.organizations);
+  const [selectedOrgId, setSelectedOrgId] = useState('');
+
+  const isFleetScope = scope.status === 'resolved' && scope.scope === 'all';
+  const isFocusedScope = scope.status === 'resolved' && scope.scope === 'org';
+
+  const sortedOrganizations = useMemo(
+    () => [...organizations].sort((a, b) => a.name.localeCompare(b.name)),
+    [organizations],
+  );
+
+  // Only honor a pick that is still a member of the accessible org list.
+  const validOrgId = organizations.some((o) => o.id === selectedOrgId)
+    ? selectedOrgId
+    : '';
+
+  // Actually clear a pick that has dropped out of the list — don't just mask it.
+  // Otherwise, if that org later reappears while this (page-level) hook stays
+  // mounted, the stale choice would silently resurrect and re-enable submit
+  // without a fresh user selection.
+  useEffect(() => {
+    if (selectedOrgId && !validOrgId) {
+      setSelectedOrgId('');
+    }
+  }, [selectedOrgId, validOrgId]);
+
+  // A create has a resolvable owner when the scope is a concrete focused org
+  // (server injects it) or a fleet view with a valid pick.
+  const hasOwner = isFocusedScope || (isFleetScope && Boolean(validOrgId));
+
+  return {
+    isFleetScope,
+    organizations: sortedOrganizations,
+    orgId: validOrgId,
+    setOrgId: setSelectedOrgId,
+    needsOrgSelection: !hasOwner,
+    bodyOrgId: isFleetScope ? validOrgId || undefined : undefined,
+  };
+}

--- a/apps/web/src/hooks/useFleetOrgOwner.ts
+++ b/apps/web/src/hooks/useFleetOrgOwner.ts
@@ -18,76 +18,100 @@ export interface FleetOrgOwner {
   /**
    * True when the create has no resolvable owner and must be blocked: the fleet
    * view with no valid pick, OR any scope that has not resolved to a concrete
-   * org (loading, error, empty, cleared). A focused, resolved org scope is fine
-   * — the server gets the injected `?orgId=`.
+   * org (loading, error, empty, cleared). A focused, resolved org scope always
+   * has an owner (the selected org).
    */
   needsOrgSelection: boolean;
   /**
-   * The orgId to place in the create body: the validated pick in fleet scope,
-   * otherwise undefined (a focused scope relies on the `?orgId=` that
-   * fetchWithAuth injects, so the body must stay silent there).
+   * The concrete owner org to place in the create body: the selected org in a
+   * focused scope, or the validated pick in fleet scope. Undefined only while
+   * the scope is unresolved (which `needsOrgSelection` also blocks).
+   *
+   * The body must carry it in BOTH scopes: some org-owned create routes read
+   * only `body.orgId` and never the `?orgId=` query that fetchWithAuth injects
+   * (e.g. DNS integrations — #3505 fails in a focused view too), so relying on
+   * the injected query alone leaves a multi-org partner 400ing when focused.
    */
   bodyOrgId: string | undefined;
 }
 
 /**
- * Backs a fleet-only "Organization" picker for org-owned create forms (DNS
- * integrations, device groups). Those resources must belong to exactly one org;
- * the dashboard normally scopes the create by the `?orgId=` that fetchWithAuth
- * injects from the active org. In the EXPLICIT All-organizations view there is
- * no active org, nothing is injected, and the server rejects the create with
+ * Backs a fleet "Organization" picker for org-owned create forms (DNS
+ * integrations, device groups). Those resources must belong to exactly one org.
+ * In a focused view the owner is the selected org; in the EXPLICIT
+ * All-organizations view there is no active org, so the form must ask which org
+ * should own the resource — otherwise the server rejects the create with
  * "orgId is required for this scope". This hook surfaces the org list, tracks
- * the chosen owner, and reports when a create has no resolvable owner yet.
+ * the chosen owner, and always reports the concrete owner to send in the body.
  *
  * Gate the picker on `useOrgScope().scope === 'all'`, NOT `currentOrgId === null`:
  * the bare-null read also matches the pre-hydration frame before the first org
  * auto-selects, which would flash the picker on a scope that's about to resolve
  * to a concrete org. (Same rule as useDefaultOwnerScope.)
  *
- * `needsOrgSelection` deliberately also blocks the unresolved/degraded scopes
- * (loading, org-list load failure, empty, cleared): those inject no `?orgId=`
- * either, so an unguarded create would hit the same opaque 400. And the picker
- * value is validated against the live org list every render, so a selection
- * that stops being accessible cannot be silently reused as the owner.
+ * `needsOrgSelection` deliberately blocks the unresolved/degraded scopes
+ * (loading, org-list load failure, empty, cleared): those have no owner to send,
+ * so an unguarded create would hit the same opaque 400. And the picker value is
+ * validated against the live org list every render, so a selection that stops
+ * being accessible cannot be silently reused as the owner.
  */
 export function useFleetOrgOwner(): FleetOrgOwner {
   const scope = useOrgScope();
   const organizations = useOrgStore((s) => s.organizations);
+  const organizationsLoaded = useOrgStore((s) => s.organizationsLoaded);
   const [selectedOrgId, setSelectedOrgId] = useState('');
 
   const isFleetScope = scope.status === 'resolved' && scope.scope === 'all';
-  const isFocusedScope = scope.status === 'resolved' && scope.scope === 'org';
+  // The concrete org in a focused, resolved scope (undefined otherwise).
+  // Narrowed here so `scope.orgId` is typed as string.
+  const focusedOrgId =
+    scope.status === 'resolved' && scope.scope === 'org' ? scope.orgId : undefined;
 
   const sortedOrganizations = useMemo(
     () => [...organizations].sort((a, b) => a.name.localeCompare(b.name)),
     [organizations],
   );
 
-  // Only honor a pick that is still a member of the accessible org list.
-  const validOrgId = organizations.some((o) => o.id === selectedOrgId)
-    ? selectedOrgId
-    : '';
+  const inList = (id: string) => organizations.some((o) => o.id === id);
 
-  // Actually clear a pick that has dropped out of the list — don't just mask it.
-  // Otherwise, if that org later reappears while this (page-level) hook stays
-  // mounted, the stale choice would silently resurrect and re-enable submit
-  // without a fresh user selection.
+  // Fleet pick: always a current member of the loaded list — it was chosen from
+  // that list, and a pick that drops out must not resurrect.
+  const fleetPick = isFleetScope && selectedOrgId && inList(selectedOrgId) ? selectedOrgId : '';
+
+  // Focused owner: the selected org. Drop it ONLY when the list is LOADED and
+  // proves it absent (stale / access revoked). While the list is unloaded —
+  // still loading OR the cold-load fetch failed — keep trusting the concrete
+  // selection: useOrgScope's contract is that a concrete selection stays usable
+  // after a refetch failure, and the server authorizes the owner anyway.
+  // Requiring list membership unconditionally would strand a legitimately
+  // focused user whose org-list fetch failed, with no retry on these forms.
+  const focusedOwner =
+    focusedOrgId && (!organizationsLoaded || inList(focusedOrgId)) ? focusedOrgId : '';
+
+  const ownerOrgId = isFleetScope ? fleetPick : focusedOwner;
+
+  // Actually clear a fleet pick that has dropped out of the loaded list — don't
+  // just mask it. Otherwise, if that org later reappears while this (page-level)
+  // hook stays mounted, the stale choice would silently resurrect and re-enable
+  // submit without a fresh selection. Gate on `organizationsLoaded` so a
+  // transient/failed empty list never wipes a valid pick. (Focused ids aren't
+  // local state, so they need no clearing.)
   useEffect(() => {
-    if (selectedOrgId && !validOrgId) {
+    if (
+      selectedOrgId &&
+      organizationsLoaded &&
+      !organizations.some((o) => o.id === selectedOrgId)
+    ) {
       setSelectedOrgId('');
     }
-  }, [selectedOrgId, validOrgId]);
-
-  // A create has a resolvable owner when the scope is a concrete focused org
-  // (server injects it) or a fleet view with a valid pick.
-  const hasOwner = isFocusedScope || (isFleetScope && Boolean(validOrgId));
+  }, [selectedOrgId, organizationsLoaded, organizations]);
 
   return {
     isFleetScope,
     organizations: sortedOrganizations,
-    orgId: validOrgId,
+    orgId: ownerOrgId,
     setOrgId: setSelectedOrgId,
-    needsOrgSelection: !hasOwner,
-    bodyOrgId: isFleetScope ? validOrgId || undefined : undefined,
+    needsOrgSelection: !ownerOrgId,
+    bodyOrgId: ownerOrgId || undefined,
   };
 }


### PR DESCRIPTION
Closes #3505. Closes #3506.

> **Update:** this now also fixes the **focused (single-org) view** for multi-org partners, not just the All-orgs view. The DNS integrations create route reads *only* `body.orgId` (its `resolveOrgId` never reads the injected `?orgId=` query, and `auth.orgId` is null for a partner token), so a multi-org partner 400'd in a focused view too — exactly as #3505 reports ("happens within both full customer view or a specific customer view"). The owner org is now sent in the body in **both** scopes; a focused org is validated against the accessible org list only once it has loaded, so a cold-load fetch failure can't strand a legitimately-focused user. Reviewed adversarially by Codex across three passes (final verdict: no ship-blocking finding).
>
> **Known follow-up (documented, not fixed here):** in the All-orgs view the static-group create *device chooser* lists devices from every org, so picking a device outside the chosen owner org yields a loud, recoverable `400` (the server rejects cross-org devices before insert). Owner-scoped device loading is a separate change.

---

## Problem

Creating a **DNS Security integration** or a **device group** from the **All organizations** (fleet) view fails with `400 "orgId is required for this scope"`. It works from a focused-org view.

Root cause is entirely in the web layer. `fetchWithAuth` auto-injects `?orgId=<currentOrgId>` only when an org is focused; in the fleet view `currentOrgId` is `null`, nothing is injected, and the org-owned create is rejected. Both server routes already **accept and authorize** a body `orgId` — `dnsSecurity` `resolveOrgId()` (checks `canAccessOrg`) and `groups.ts` POST (body-or-query `orgId`, then `ensureOrgAccess`). The forms just never offered a way to supply one in fleet scope.

(Config Policy creation already solved this with its own owner picker; this brings DNS integrations and device groups to parity. The other fleet-create reports triaged alongside this — monitoring-watch null validation, dynamic-group architecture filter, partner-wide monitoring fan-out — were verified **already fixed on `main`** and are intentionally not touched here.)

## Fix

A small `useFleetOrgOwner` hook drives a fleet-only **Organization** picker:

- **Gates on `useOrgScope().scope === 'all'`**, not `currentOrgId === null` — the bare-null read also matches the pre-hydration frame before the first org auto-selects and would flash the picker on a scope about to resolve to a concrete org (same rule as `useDefaultOwnerScope`).
- **Blocks submit until a create has a resolvable owner**: a focused resolved scope (server gets the injected `?orgId=`) or a fleet scope with a valid pick. Loading / org-list-load-error / empty / cleared scopes inject nothing either, so they're now blocked instead of producing the same opaque 400.
- **Validates the pick against the live org list** and **clears a selection that drops out of it**, so a stale/no-longer-accessible org can never be silently reused or resurrected as the owner.
- Wired into `AddDnsIntegrationModal` and `DeviceGroupsPage` (**create only** — edits never move ownership); focused scope is unchanged. Reused existing `common` i18n keys (`labels.organization`, `layout.org.noSelection`, `layout.orgRequired.title`) — **no new locale strings**, locale parity untouched.

## Review

Two independent adversarial reviews were run against the actual diff. Both findings raised — a page-level stale owner surviving modal close, and the unresolved-scope create hole — are fixed here, each with a control-verified regression test (reverting the fix reproduces the failure).

## Testing

- `astro check`: **0 errors**
- Full web vitest suite: **571 files / 5577 tests pass** (node 22.23.2, pnpm 10.34.5)
- New coverage: `useFleetOrgOwner.test.ts` (fleet gating, resolvable-owner blocking, stale-pick drop + no-resurrection, sorting), plus fleet-scope render/disable/POST-body tests in both `AddDnsIntegrationModal.test.tsx` and `DeviceGroupsPage.test.tsx`.
- No dependency or lockfile changes.

https://claude.ai/code/session_0187oKb4Pw7KTXT2Lsvq7hUr

