### PR TITLE
fix(web): Device Groups edit 404 (PUT→PATCH) + remove phantom form fields (#3554)

### DIFF
--- a/apps/web/src/components/devices/DeviceGroupsPage.staticGroups.test.tsx
+++ b/apps/web/src/components/devices/DeviceGroupsPage.staticGroups.test.tsx
@@ -195,12 +195,49 @@ describe('DeviceGroupsPage static groups', () => {
     await user.click(screen.getByRole('button', { name: 'Static' }));
     await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
-    await waitFor(() => expect(findWrite('PUT')).toBeDefined());
+    // The update route is PATCH /:id (#3554 — the app used to send PUT, which
+    // has no handler and 404s).
+    await waitFor(() => expect(findWrite('PATCH')).toBeDefined());
 
-    const body = parseBody(findWrite('PUT'));
+    const body = parseBody(findWrite('PATCH'));
     // Unlike create, the update path MUST say `null` out loud: the API reads an
     // absent key as "leave the filter alone", which would strand the old filter
     // on a group the user just made static.
     expect(body.filterConditions).toBeNull();
+    // Phantom fields are gone (#3554): no description column, no group policyId,
+    // and membership isn't editable on update.
+    expect(body.description).toBeUndefined();
+    expect(body.policyId).toBeUndefined();
+    expect(body.deviceIds).toBeUndefined();
+  });
+
+  // #3554: the form used to show Description and Policy Assignment controls that
+  // the API silently dropped (no column / no group-policy field). They're gone.
+  it('create form omits the phantom Description and Policy Assignment controls', async () => {
+    const user = userEvent.setup();
+    serveGroups([]);
+
+    render(<DeviceGroupsPage />);
+    await user.click(await screen.findByRole('button', { name: 'Create Group' }));
+
+    expect(screen.queryByText('Description')).toBeNull();
+    expect(screen.queryByText('Policy Assignment')).toBeNull();
+    // The real static membership chooser is still offered on create.
+    expect(screen.getByText('Manual Device Assignment')).toBeInTheDocument();
+  });
+
+  it('hides the static device chooser on edit (membership is not editable there)', async () => {
+    const user = userEvent.setup();
+    serveGroups([
+      { id: 'group-1', name: 'Web Servers', type: 'static', deviceCount: 1, deviceIds: ['device-1'] },
+    ]);
+
+    render(<DeviceGroupsPage />);
+    await screen.findByText('Web Servers');
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+    // Editing a static group must not present a membership chooser that a PATCH
+    // would silently ignore — it's create-only now.
+    expect(screen.queryByText('Manual Device Assignment')).toBeNull();
   });
 });

--- a/apps/web/src/components/devices/DeviceGroupsPage.tsx
+++ b/apps/web/src/components/devices/DeviceGroupsPage.tsx
@@ -48,7 +48,6 @@ type GroupType = "static" | "dynamic";
 type DeviceGroup = {
   id: string;
   name: string;
-  description?: string;
   type: GroupType;
   deviceCount?: number;
   deviceIds?: string[];
@@ -89,9 +88,7 @@ type ModalMode =
 
 type GroupFormState = {
   name: string;
-  description: string;
   type: GroupType;
-  policyId: string;
   deviceIds: string[];
   filterConditions: FilterConditionGroup;
 };
@@ -200,9 +197,7 @@ export default function DeviceGroupsPage() {
 
   const [groupForm, setGroupForm] = useState<GroupFormState>({
     name: "",
-    description: "",
     type: "static",
-    policyId: "",
     deviceIds: [],
     filterConditions: EMPTY_FILTER,
   });
@@ -380,9 +375,7 @@ export default function DeviceGroupsPage() {
 
       setGroupForm({
         name: group.name ?? "",
-        description: group.description ?? "",
         type: group.type ?? "static",
-        policyId: group.policyId ?? "",
         deviceIds: group.deviceIds
           ? [...group.deviceIds]
           : (group.devices?.map((device) => device.id) ?? []),
@@ -391,9 +384,7 @@ export default function DeviceGroupsPage() {
     } else {
       setGroupForm({
         name: "",
-        description: "",
         type: "static",
-        policyId: "",
         deviceIds: [],
         filterConditions: EMPTY_FILTER,
       });
@@ -459,10 +450,8 @@ export default function DeviceGroupsPage() {
     // legacy column leaves whatever a pre-FilterBuilder group already had.
     const payload = {
       name: nextGroup.name,
-      description: nextGroup.description ?? "",
       type: nextGroup.type,
       deviceIds: nextGroup.type === "static" ? (nextGroup.deviceIds ?? []) : [],
-      policyId: nextGroup.policyId || null,
     };
 
     const response = await fetchWithAuth(`/device-groups/${nextGroup.id}`, {
@@ -511,23 +500,21 @@ export default function DeviceGroupsPage() {
 
       const payload: Record<string, unknown> = {
         name: trimmedName,
-        description: groupForm.description.trim(),
         type: groupForm.type,
-        policyId: groupForm.policyId || null,
       };
 
       if (isDynamic) {
         payload.filterConditions = groupForm.filterConditions;
-      } else {
+      } else if (isEdit) {
         // A static group carries no filter, and the two verbs want that said
-        // differently (#3159). CREATE omits the key — the documented create
-        // payload, and what CreateGroupModal already sends. EDIT must send an
-        // explicit `null`, because the update route reads `undefined` as "leave
-        // the filter alone"; omitting it would strand a stale filter on a group
-        // converted from dynamic to static.
-        if (isEdit) {
-          payload.filterConditions = null;
-        }
+        // differently (#3159). EDIT must send an explicit `null`, because the
+        // update route reads `undefined` as "leave the filter alone"; omitting
+        // it would strand a stale filter on a group converted from dynamic to
+        // static. Membership is NOT sent on edit: the PATCH route ignores
+        // deviceIds, so sending it would silently no-op (#3554 follow-up) — the
+        // static device chooser is create-only for the same reason.
+        payload.filterConditions = null;
+      } else {
         // Devices are only meaningful for a static group. The create route
         // rejects a non-empty list on a dynamic one rather than ignoring it.
         payload.deviceIds = groupForm.deviceIds;
@@ -536,7 +523,9 @@ export default function DeviceGroupsPage() {
       const url = isEdit
         ? `/device-groups/${selectedGroup!.id}`
         : "/device-groups";
-      const method = isEdit ? "PUT" : "POST";
+      // The update route is PATCH /:id — the frontend historically sent PUT,
+      // which has no handler and 404s on every edit (#3554). Create stays POST.
+      const method = isEdit ? "PATCH" : "POST";
 
       const response = await fetchWithAuth(url, {
         method,
@@ -898,11 +887,6 @@ export default function DeviceGroupsPage() {
                               : t("deviceGroupsPage.static")}
                           </span>
                         </div>
-                        <p className="mt-1 text-sm text-muted-foreground">
-                          {group.description?.trim().length
-                            ? group.description
-                            : t("deviceGroupsPage.noDescriptionProvided")}
-                        </p>
                         <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
                           <span className="rounded-full border bg-muted px-2 py-0.5">
                             {deviceCount} {t("deviceGroupsPage.device")}
@@ -1061,7 +1045,7 @@ export default function DeviceGroupsPage() {
             </div>
 
             <form className="mt-6 space-y-6" onSubmit={handleSubmitGroup}>
-              <div className="grid gap-4 sm:grid-cols-2">
+              <div>
                 <div>
                   <label className="text-sm font-medium">
                     {t("deviceGroupsPage.groupName")}
@@ -1079,49 +1063,6 @@ export default function DeviceGroupsPage() {
                     placeholder={t("deviceGroupsPage.eGProductionLinux")}
                   />
                 </div>
-                <div>
-                  <label className="text-sm font-medium">
-                    {t("deviceGroupsPage.policyAssignment")}
-                  </label>
-                  <select
-                    value={groupForm.policyId}
-                    onChange={(event) =>
-                      setGroupForm((prev) => ({
-                        ...prev,
-                        policyId: event.target.value,
-                      }))
-                    }
-                    className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                  >
-                    <option value="">
-                      {t("deviceGroupsPage.noPolicyAssigned")}
-                    </option>
-                    {policies.map((policy) => (
-                      <option key={policy.id} value={policy.id}>
-                        {policy.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-
-              <div>
-                <label className="text-sm font-medium">
-                  {t("deviceGroupsPage.description")}
-                </label>
-                <textarea
-                  value={groupForm.description}
-                  onChange={(event) =>
-                    setGroupForm((prev) => ({
-                      ...prev,
-                      description: event.target.value,
-                    }))
-                  }
-                  className="mt-2 u-min-h-px-96 w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                  placeholder={t(
-                    "deviceGroupsPage.optionalDescriptionToHelpYourTeam",
-                  )}
-                />
               </div>
 
               <div>
@@ -1198,7 +1139,10 @@ export default function DeviceGroupsPage() {
                     onRefresh={formPreviewRefresh}
                   />
                 </div>
-              ) : (
+              ) : modalMode === "create" ? (
+                // Static membership is editable on CREATE only: the update route
+                // ignores deviceIds (#3554), so offering the chooser on edit
+                // would let a "Save" silently drop membership changes.
                 <div className="rounded-md border bg-muted/20 p-4">
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <div>
@@ -1280,7 +1224,7 @@ export default function DeviceGroupsPage() {
                     )}
                   </div>
                 </div>
-              )}
+              ) : null}
 
               {formError && (
                 <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">


### PR DESCRIPTION
Closes #3428.

Fixes #3554.

## Bug 1 — Edit 404s on every attempt

The dashboard sent `PUT /device-groups/:id`, but the router only defines `.patch('/:id')` — no PUT handler exists, so every edit 404'd before reaching any group logic (maintainer-confirmed root cause). **Switched the edit submission to `PATCH`;** create stays `POST`.

## Bug 2 — the form carried fields the API silently discards

While fixing the verb I verified the whole create/edit payload against `groups.ts` + the schema on `main`, and found the form submits several fields nothing persists:

| Field | Reality |
|---|---|
| `description` | `device_groups` has **no description column**; neither create nor update schema accepts it → every value typed was dropped. |
| per-group `policyId` selector | `device_groups` has **no policy column**; create/update handlers ignore it. Group→policy lives in `config_policy_assignments` via a separate flow. The selector never persisted anything. |
| `deviceIds` on update | `updateGroupSchema` omits it — the PATCH route **ignores membership**, so the static device chooser on *edit* was a silent no-op waiting for the verb fix. |

Simply flipping PUT→PATCH would have turned a loud 404 into a **silent partial save** (edit returns 200 while policy/membership changes vanish). To keep every "Save" truthful:

- Remove the **Description** field and the **per-group Policy Assignment** selector from the form (state, payloads, UI, and the always-empty card description line).
- Make the static device chooser **create-only** — editing a static group no longer offers a membership control the update route would ignore.
- Static edit now submits only `{ name, type, filterConditions: null }` (deliberate filter-clear, #3159); create still sends `deviceIds`.

Every field the edit dialog submits is now one the PATCH route actually persists.

## What this PR intentionally does **not** touch

All pre-existing, discovered while verifying, none introduced here — flagging for follow-ups:

- The **bulk** apply-policy / apply-script actions POST to `/device-groups/bulk`, which has **no route** (404). (Bulk routes exist for tickets/invoices/contracts/quotes, not device-groups.)
- The group **list API never returns `policyName`** (`mapGroupRow` omits it), so the card's policy chip always reads "Not assigned". The display is kept — it's a real concept (a config policy can target a group) with a data-population gap, not a phantom write.
- The drag-and-drop `updateGroup()` helper still uses `PUT` (404) and would need the add/remove **membership endpoints**, not PATCH, to work — PATCH deliberately ignores `deviceIds`.
- Editing static membership after create (needs a membership-reconciliation contract on update, or the existing membership endpoints).

## Review & testing

- Adversarial Codex review (scope + final diff): confirmed the JSX/ternary is balanced, the static-edit payload matches the PATCH schema, and no data-loss / silent-failure / cross-tenant path is introduced.
- Tests: edit now asserts `PATCH` and that the payload omits `description`/`policyId`/`deviceIds`; new tests assert the create form no longer renders the Description/Policy controls and the static chooser is hidden on edit; existing dynamic↔static conversion coverage retained.
- Local gate green: `astro check` 0 errors; full web vitest **570 files / 5566 tests**; eslint clean (node 22.23.2, pnpm 10.34.5). No dependency changes.

https://claude.ai/code/session_0187oKb4Pw7KTXT2Lsvq7hUr

