### PR TITLE
fix(api): match winget-prefixed patch ids against the bare catalog id (#3559)

### DIFF
--- a/apps/api/src/services/thirdPartyEnrichment.test.ts
+++ b/apps/api/src/services/thirdPartyEnrichment.test.ts
@@ -111,4 +111,65 @@ describe('enrichFromCatalog', () => {
     expect(out.vendor).toBe('Acme');
     expect(out.severity).toBe('low');
   });
+
+  // #3559: agents report provider-prefixed ids (formatPatchID → "winget:...")
+  // while the catalog stores bare ids. The prefixed id must still enrich.
+  it('matches a provider-prefixed packageId against the bare catalog id', async () => {
+    const out = await enrichFromCatalog({
+      source: 'third_party',
+      packageId: 'winget:Mozilla.Firefox',
+      title: 'firefox',
+      vendor: null,
+      severity: 'unknown',
+    });
+    expect(out.matchedCatalogId).toBe('cat-firefox');
+    expect(out.title).toBe('Mozilla Firefox');
+    expect(out.vendor).toBe('Mozilla');
+    expect(out.severity).toBe('important');
+  });
+
+  it('still misses when even the prefix-stripped packageId is not in the catalog', async () => {
+    const out = await enrichFromCatalog({
+      source: 'third_party',
+      packageId: 'winget:Unknown.Package',
+      title: 'Unknown',
+      vendor: 'Acme',
+      severity: 'low',
+    });
+    expect(out.matchedCatalogId).toBeNull();
+    expect(out.title).toBe('Unknown');
+    expect(out.vendor).toBe('Acme');
+  });
+
+  // Only the winget prefix is stripped. winget/chocolatey/homebrew all share
+  // source 'third_party' and the catalog has no provider dimension, so a
+  // non-winget provider must NOT inherit a winget-curated row (would be a
+  // cross-provider mis-enrichment).
+  it.each(['chocolatey:Mozilla.Firefox', 'homebrew:Mozilla.Firefox', 'anything:Mozilla.Firefox'])(
+    'does not enrich a non-winget prefixed id (%s) from the winget catalog row',
+    async (packageId) => {
+      const out = await enrichFromCatalog({
+        source: 'third_party',
+        packageId,
+        title: 'orig',
+        vendor: 'orig-vendor',
+        severity: 'low',
+      });
+      expect(out.matchedCatalogId).toBeNull();
+      expect(out.title).toBe('orig');
+      expect(out.vendor).toBe('orig-vendor');
+    },
+  );
+
+  it('prefers an exact catalog match over prefix-stripping (bare id already matches)', async () => {
+    // The bare id path still works unchanged.
+    const out = await enrichFromCatalog({
+      source: 'third_party',
+      packageId: 'Mozilla.Firefox',
+      title: 'firefox',
+      vendor: null,
+      severity: 'unknown',
+    });
+    expect(out.matchedCatalogId).toBe('cat-firefox');
+  });
 });

--- a/apps/api/src/services/thirdPartyEnrichment.ts
+++ b/apps/api/src/services/thirdPartyEnrichment.ts
@@ -17,6 +17,10 @@ function cacheKey(source: string, packageId: string): string {
   return `${source}::${packageId}`;
 }
 
+// The agent prefixes winget patch ids as "winget:<id>" (formatPatchID, provider
+// id "winget", ":" separator). The catalog stores the bare winget id.
+const WINGET_PACKAGE_ID_PREFIX = 'winget:';
+
 async function loadCache(): Promise<Map<string, CatalogEntry>> {
   const rows = await db.select({
     id: thirdPartyPackageCatalog.id,
@@ -97,7 +101,23 @@ export async function enrichFromCatalog(input: EnrichmentInput): Promise<Enrichm
   }
 
   const map = await getCache();
-  const hit = map.get(cacheKey(input.source, input.packageId));
+  let hit = map.get(cacheKey(input.source, input.packageId));
+
+  // Agents report provider-prefixed package ids ("winget:Mozilla.Firefox",
+  // built by formatPatchID with a ":" separator), but the catalog seeds bare
+  // winget ids ("Mozilla.Firefox"). On an exact-match miss, retry once with a
+  // leading "winget:" prefix stripped so curated title/vendor/severity/category
+  // still apply (#3559). ONLY the winget prefix is stripped: winget, chocolatey
+  // and homebrew all collapse to source 'third_party' and the catalog has no
+  // provider dimension, so stripping any prefix would let e.g. "chocolatey:foo"
+  // wrongly inherit a winget-curated "foo" row. The catalog's ids are winget's,
+  // so only winget-prefixed ids can safely resolve to a catalog row. Exact-match
+  // is tried first, so a bare (or already-exact) id keeps matching.
+  if (!hit && input.packageId.startsWith(WINGET_PACKAGE_ID_PREFIX)) {
+    const barePackageId = input.packageId.slice(WINGET_PACKAGE_ID_PREFIX.length);
+    hit = map.get(cacheKey(input.source, barePackageId));
+  }
+
   if (!hit) {
     return {
       title: input.title,


### PR DESCRIPTION
Closes #3559.

## Problem

Third-party patch enrichment never matches, so curated catalog metadata (friendly title, vendor, severity, category) is never applied to agent-reported patches.

The agent reports **provider-prefixed** package ids — `formatPatchID` builds `winget:Mozilla.Firefox` (provider id `winget`, `:` separator). The `third_party_package_catalog` seeds **bare** winget ids (`Mozilla.Firefox`), keyed by `(source, packageId)`. `enrichFromCatalog` did an exact-match lookup, always missed on real agent input, and returned the unenriched first-seen values. (Sharpened by #3556, which made identity columns fill-only with the catalog as the intended overwriter — so titles/vendors froze at whatever the first reporter sent.)

## Fix

On an exact-match miss, retry the catalog lookup once with a leading `winget:` prefix stripped.

**Only the `winget:` prefix is stripped — deliberately.** winget, chocolatey and homebrew all map to `source = 'third_party'`, and the catalog has no provider dimension. Stripping *any* prefix would collapse every provider into one bare-id namespace and let e.g. `chocolatey:foo` (or even `anything:foo`) inherit a winget-curated `foo` row — a cross-provider mis-enrichment. The catalog's ids are winget's, so only winget-prefixed ids can safely resolve to a row. Exact-match is tried first, so bare or already-exact ids are unaffected.

## Review

Two adversarial Codex passes: the first caught that stripping any prefix mis-enriches across providers; the winget-only restriction closes it. Final verdict: no shipping blocker — no false negatives (winget `PackageIdentifier`s are unique per winget's manifest contract), exact-match precedence preserved, no cross-provider path remaining.

## Follow-ups (out of scope here, flagged)

- `patchApprovalEvaluator.appRuleKey` keys block/pin rules on the **stored prefixed** `packageId`, while user-entered rules are bare — the same prefixed-vs-bare mismatch, on a different surface. Separate fix.
- A true multi-provider catalog needs **provider as part of the catalog identity** (source alone doesn't distinguish winget/chocolatey/homebrew).

## Testing

- `vitest thirdPartyEnrichment.test.ts` — **11/11**: winget-prefixed enriches; `chocolatey:` / `homebrew:` / `anything:` prefixed ids do **not** inherit the winget row; bare exact match still wins; prefix-stripped miss still misses.
- `tsc --noEmit` (apps/api) clean; eslint clean. No schema/migration changes.

https://claude.ai/code/session_0187oKb4Pw7KTXT2Lsvq7hUr
