### PR TITLE
fix(web): show "—" not fabricated zeros in security stat tiles on a 500 (#2485)

### DIFF
--- a/apps/web/src/components/security/AdminAuditPage.tsx
+++ b/apps/web/src/components/security/AdminAuditPage.tsx
@@ -175,6 +175,11 @@ export default function AdminAuditPage() {
       </div>
     );
   }
+  // On a 500/network failure (errorKind "other") the summary is still the zeroed
+  // initial state — show an em dash instead of fabricated zeros. A genuinely
+  // empty 200 tenant keeps its real 0s. Mirrors AntivirusPage (#2485).
+  const hasData = errorKind !== "other";
+  const stat = (value: number) => (hasData ? formatNumber(value) : "—");
   return (
     <div className="space-y-6">
       <SecurityPageHeader
@@ -190,36 +195,36 @@ export default function AdminAuditPage() {
         <SecurityStatCard
           icon={User}
           label={t("securityAdminAuditPage.totalDevices")}
-          value={formatNumber(summary.totalDevices)}
+          value={stat(summary.totalDevices)}
         />
         <SecurityStatCard
           icon={Shield}
           label={t("securityAdminAuditPage.withIssues")}
-          value={formatNumber(summary.devicesWithIssues)}
-          variant="warning"
+          value={stat(summary.devicesWithIssues)}
+          variant={hasData ? "warning" : "default"}
         />
         <SecurityStatCard
           icon={User}
           label={t("securityAdminAuditPage.totalAdmins")}
-          value={formatNumber(summary.totalAdmins)}
+          value={stat(summary.totalAdmins)}
         />
         <SecurityStatCard
           icon={User}
           label={t("securityAdminAuditPage.defaultAccts")}
-          value={formatNumber(summary.defaultAccounts)}
-          variant={summary.defaultAccounts > 0 ? "warning" : "default"}
+          value={stat(summary.defaultAccounts)}
+          variant={hasData && summary.defaultAccounts > 0 ? "warning" : "default"}
         />
         <SecurityStatCard
           icon={User}
           label={t("securityAdminAuditPage.weakPasswords")}
-          value={formatNumber(summary.weakPasswords)}
-          variant={summary.weakPasswords > 0 ? "danger" : "default"}
+          value={stat(summary.weakPasswords)}
+          variant={hasData && summary.weakPasswords > 0 ? "danger" : "default"}
         />
         <SecurityStatCard
           icon={User}
           label={t("securityAdminAuditPage.staleAccts")}
-          value={formatNumber(summary.staleAccounts)}
-          variant={summary.staleAccounts > 0 ? "warning" : "default"}
+          value={stat(summary.staleAccounts)}
+          variant={hasData && summary.staleAccounts > 0 ? "warning" : "default"}
         />
       </div>
 

--- a/apps/web/src/components/security/EncryptionPage.tsx
+++ b/apps/web/src/components/security/EncryptionPage.tsx
@@ -170,6 +170,11 @@ export default function EncryptionPage() {
     );
   }
   const mc = summary.methodCounts;
+  // On a 500/network failure (errorKind "other") the summary is still the zeroed
+  // initial state — show an em dash instead of fabricated zeros. A genuinely
+  // empty 200 tenant keeps its real 0s. Mirrors AntivirusPage (#2485).
+  const hasData = errorKind !== "other";
+  const stat = (value: number) => (hasData ? formatNumber(value) : "—");
   return (
     <div className="space-y-6">
       <SecurityPageHeader
@@ -183,25 +188,25 @@ export default function EncryptionPage() {
         <SecurityStatCard
           icon={Lock}
           label={t("securityEncryptionPage.totalDevices")}
-          value={formatNumber(summary.total)}
+          value={stat(summary.total)}
         />
         <SecurityStatCard
           icon={Lock}
           label={t("securityEncryptionPage.fullyEncrypted")}
-          value={formatNumber(summary.fullyEncrypted)}
-          variant="success"
+          value={stat(summary.fullyEncrypted)}
+          variant={hasData ? "success" : "default"}
         />
         <SecurityStatCard
           icon={HardDrive}
           label={t("securityEncryptionPage.partial")}
-          value={formatNumber(summary.partial)}
-          variant="warning"
+          value={stat(summary.partial)}
+          variant={hasData ? "warning" : "default"}
         />
         <SecurityStatCard
           icon={HardDrive}
           label={t("securityEncryptionPage.unencrypted")}
-          value={formatNumber(summary.unencrypted)}
-          variant="danger"
+          value={stat(summary.unencrypted)}
+          variant={hasData ? "danger" : "default"}
         />
       </div>
 
@@ -210,25 +215,25 @@ export default function EncryptionPage() {
           <p className="text-xs text-muted-foreground">
             {t("securityEncryptionPage.bitlocker")}
           </p>
-          <p className="text-lg font-semibold">{mc.bitlocker}</p>
+          <p className="text-lg font-semibold">{stat(mc.bitlocker)}</p>
         </div>
         <div className="rounded-md border bg-muted/30 p-3 text-center">
           <p className="text-xs text-muted-foreground">
             {t("securityEncryptionPage.filevault")}
           </p>
-          <p className="text-lg font-semibold">{mc.filevault}</p>
+          <p className="text-lg font-semibold">{stat(mc.filevault)}</p>
         </div>
         <div className="rounded-md border bg-muted/30 p-3 text-center">
           <p className="text-xs text-muted-foreground">
             {t("securityEncryptionPage.luks")}
           </p>
-          <p className="text-lg font-semibold">{mc.luks}</p>
+          <p className="text-lg font-semibold">{stat(mc.luks)}</p>
         </div>
         <div className="rounded-md border bg-muted/30 p-3 text-center">
           <p className="text-xs text-muted-foreground">
             {t("securityEncryptionPage.none")}
           </p>
-          <p className="text-lg font-semibold">{mc.none}</p>
+          <p className="text-lg font-semibold">{stat(mc.none)}</p>
         </div>
       </div>
 

--- a/apps/web/src/components/security/FirewallPage.tsx
+++ b/apps/web/src/components/security/FirewallPage.tsx
@@ -151,6 +151,11 @@ export default function FirewallPage() {
       </div>
     );
   }
+  // On a 500/network failure (errorKind "other") the summary is still the zeroed
+  // initial state — show an em dash instead of fabricated zeros. A genuinely
+  // empty 200 tenant keeps its real 0s. Mirrors AntivirusPage (#2485).
+  const hasData = errorKind !== "other";
+  const stat = (value: number) => (hasData ? formatNumber(value) : "—");
   return (
     <div className="space-y-6">
       <SecurityPageHeader
@@ -164,33 +169,39 @@ export default function FirewallPage() {
         <SecurityStatCard
           icon={Shield}
           label={t("securityFirewallPage.totalDevices")}
-          value={formatNumber(summary.total)}
+          value={stat(summary.total)}
         />
         <SecurityStatCard
           icon={Shield}
           label={t("securityFirewallPage.enabled")}
-          value={formatNumber(summary.enabled)}
-          variant="success"
+          value={stat(summary.enabled)}
+          variant={hasData ? "success" : "default"}
         />
         <SecurityStatCard
           icon={ShieldOff}
           label={t("securityFirewallPage.disabled")}
-          value={formatNumber(summary.disabled)}
-          variant="danger"
+          value={stat(summary.disabled)}
+          variant={hasData ? "danger" : "default"}
         />
         <SecurityStatCard
           icon={Shield}
           label={t("securityFirewallPage.coverage")}
-          value={`${summary.coveragePercent}%`}
-          variant={summary.coveragePercent >= 90 ? "success" : "warning"}
+          value={hasData ? `${summary.coveragePercent}%` : "—"}
+          variant={
+            hasData ? (summary.coveragePercent >= 90 ? "success" : "warning") : "default"
+          }
         />
       </div>
 
-      <div className="h-3 w-full rounded-full bg-muted">
-        <div
-          className={`h-3 rounded-full bg-sky-500 ${widthPercentClass(summary.coveragePercent)}`}
-        />
-      </div>
+      {/* Hide the coverage bar on a failed read — an empty (0%-width) bar reads
+          as "0% coverage", the same fabricated all-clear as the zeroed tiles. */}
+      {hasData && (
+        <div className="h-3 w-full rounded-full bg-muted">
+          <div
+            className={`h-3 rounded-full bg-sky-500 ${widthPercentClass(summary.coveragePercent)}`}
+          />
+        </div>
+      )}
 
       {error && (
         <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-center">

--- a/apps/web/src/components/security/PasswordPolicyPage.tsx
+++ b/apps/web/src/components/security/PasswordPolicyPage.tsx
@@ -160,6 +160,11 @@ export default function PasswordPolicyPage() {
       </div>
     );
   }
+  // On a 500/network failure (errorKind "other") the summary is still the zeroed
+  // initial state — show an em dash instead of fabricated zeros. A genuinely
+  // empty 200 tenant keeps its real 0s. Mirrors AntivirusPage (#2485).
+  const hasData = errorKind !== "other";
+  const stat = (value: number) => (hasData ? formatNumber(value) : "—");
   return (
     <div className="space-y-6">
       <SecurityPageHeader
@@ -175,25 +180,27 @@ export default function PasswordPolicyPage() {
         <SecurityStatCard
           icon={KeyRound}
           label={t("securityPasswordPolicyPage.totalDevices")}
-          value={formatNumber(summary.total)}
+          value={stat(summary.total)}
         />
         <SecurityStatCard
           icon={KeyRound}
           label={t("securityPasswordPolicyPage.compliant")}
-          value={formatNumber(summary.compliant)}
-          variant="success"
+          value={stat(summary.compliant)}
+          variant={hasData ? "success" : "default"}
         />
         <SecurityStatCard
           icon={KeyRound}
           label={t("securityPasswordPolicyPage.nonCompliant")}
-          value={formatNumber(summary.nonCompliant)}
-          variant="danger"
+          value={stat(summary.nonCompliant)}
+          variant={hasData ? "danger" : "default"}
         />
         <SecurityStatCard
           icon={KeyRound}
           label={t("securityPasswordPolicyPage.compliance")}
-          value={`${summary.compliancePercent}%`}
-          variant={summary.compliancePercent >= 90 ? "success" : "warning"}
+          value={hasData ? `${summary.compliancePercent}%` : "—"}
+          variant={
+            hasData ? (summary.compliancePercent >= 90 ? "success" : "warning") : "default"
+          }
         />
       </div>
 

--- a/apps/web/src/components/security/RecommendationsPage.tsx
+++ b/apps/web/src/components/security/RecommendationsPage.tsx
@@ -195,6 +195,11 @@ export default function RecommendationsPage() {
       </div>
     );
   }
+  // On a 500/network failure (errorKind "other") the summary is still the zeroed
+  // initial state — show an em dash instead of fabricated zeros. A genuinely
+  // empty 200 tenant keeps its real 0s. Mirrors AntivirusPage (#2485).
+  const hasData = errorKind !== "other";
+  const stat = (value: number) => (hasData ? formatNumber(value) : "—");
   return (
     <div className="space-y-6">
       <SecurityPageHeader
@@ -210,25 +215,25 @@ export default function RecommendationsPage() {
         <SecurityStatCard
           icon={Sparkles}
           label={t("securityRecommendationsPage.total")}
-          value={formatNumber(summary.total)}
+          value={stat(summary.total)}
         />
         <SecurityStatCard
           icon={Lightbulb}
           label={t("securityRecommendationsPage.open")}
-          value={formatNumber(summary.open)}
-          variant="warning"
+          value={stat(summary.open)}
+          variant={hasData ? "warning" : "default"}
         />
         <SecurityStatCard
           icon={Sparkles}
           label={t("securityRecommendationsPage.criticalHigh")}
-          value={formatNumber(summary.criticalAndHigh)}
-          variant="danger"
+          value={stat(summary.criticalAndHigh)}
+          variant={hasData ? "danger" : "default"}
         />
         <SecurityStatCard
           icon={Check}
           label={t("securityRecommendationsPage.completed")}
-          value={formatNumber(summary.completed)}
-          variant="success"
+          value={stat(summary.completed)}
+          variant={hasData ? "success" : "default"}
         />
       </div>
 

--- a/apps/web/src/components/security/VulnerabilitiesPage.tsx
+++ b/apps/web/src/components/security/VulnerabilitiesPage.tsx
@@ -174,6 +174,12 @@ export default function VulnerabilitiesPage() {
     setSelectedIds(next);
   };
   const { active, quarantined, critical } = summary;
+  // On a 500/network failure (errorKind "other") the summary is still the zeroed
+  // initial state — show an em dash instead of fabricated zeros. A genuinely
+  // empty 200 tenant (errorKind "none") keeps its real 0s. Mirrors AntivirusPage
+  // (#2485).
+  const hasData = errorKind !== "other";
+  const stat = (value: number) => (hasData ? formatNumber(value) : "—");
   // Cell pieces shared by the desktop table and the mobile cards.
   const renderSeverity = (t: Threat) => (
     <span
@@ -242,25 +248,25 @@ export default function VulnerabilitiesPage() {
         <SecurityStatCard
           icon={AlertTriangle}
           label={t("securityVulnerabilitiesPage.total")}
-          value={formatNumber(pagination.total)}
+          value={stat(pagination.total)}
         />
         <SecurityStatCard
           icon={Shield}
           label={t("securityVulnerabilitiesPage.critical")}
-          value={formatNumber(critical)}
-          variant="danger"
+          value={stat(critical)}
+          variant={hasData ? "danger" : "default"}
         />
         <SecurityStatCard
           icon={ShieldAlert}
           label={t("securityVulnerabilitiesPage.active")}
-          value={formatNumber(active)}
-          variant="warning"
+          value={stat(active)}
+          variant={hasData ? "warning" : "default"}
         />
         <SecurityStatCard
           icon={ShieldCheck}
           label={t("securityVulnerabilitiesPage.quarantined")}
-          value={formatNumber(quarantined)}
-          variant="success"
+          value={stat(quarantined)}
+          variant={hasData ? "success" : "default"}
         />
       </div>
 

--- a/apps/web/src/components/security/security403Sweep.test.tsx
+++ b/apps/web/src/components/security/security403Sweep.test.tsx
@@ -299,3 +299,52 @@ describe('a failed read is never rendered as an all-clear (#2472)', () => {
     expect(screen.getByTestId('vulnerabilities-action-error')).toBeInTheDocument();
   });
 });
+
+/**
+ * A 500 (errorKind "other") must not paint the summary stat tiles from the
+ * zeroed initial state — that's a confident, fabricated all-clear for a fleet we
+ * simply failed to read. Each tile shows an em dash instead; a genuinely empty
+ * 200 tenant still shows real 0s (covered by the pages' own tests). (#2485)
+ */
+const SUMMARY_TILE_PAGES = [
+  ['VulnerabilitiesPage', <VulnerabilitiesPage />, 4],
+  ['EncryptionPage', <EncryptionPage />, 4],
+  ['FirewallPage', <FirewallPage />, 4],
+  ['PasswordPolicyPage', <PasswordPolicyPage />, 4],
+  ['RecommendationsPage', <RecommendationsPage />, 4],
+  ['AdminAuditPage', <AdminAuditPage />, 6],
+] as const;
+
+describe('a 500 shows "—" in the security stat tiles, never fabricated zeros (#2485)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe.each(SUMMARY_TILE_PAGES)('%s', (_name, element, tileCount) => {
+    it('renders em dashes, not 0 / 0%, when the summary load 500s', async () => {
+      fetchWithAuth.mockResolvedValue(serverError());
+      const { container } = await renderSettled(element);
+
+      // Every summary tile is an em dash (the presence assertion also proves the
+      // flush is long enough for the absence assertion below to mean something).
+      expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(tileCount);
+
+      // No stat tile paints a bare 0 / 0% from the zeroed default.
+      const fabricatedZeros = Array.from(container.querySelectorAll('p'))
+        .map((el) => el.textContent?.trim() ?? '')
+        .filter((text) => /^0%?$/.test(text));
+      expect(fabricatedZeros).toEqual([]);
+    });
+  });
+});
+
+describe('FirewallPage hides its coverage bar on a failed read (#2485)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does not render the 0%-width coverage bar when the load 500s', async () => {
+    fetchWithAuth.mockResolvedValue(serverError());
+    const { container } = await renderSettled(<FirewallPage />);
+    // An empty (0%-width) bar reads as "0% coverage" — it must be gone on error.
+    expect(container.querySelector('.bg-sky-500')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #2485.

## Problem

On a **500 / network failure**, six security sub-pages render their summary stat tiles from the **zeroed initial state** — a confident fabricated all-clear ("0 critical vulnerabilities", "0% firewall coverage") for a fleet we simply failed to read. A **403** is already handled (the `errorKind === "denied"` guard renders `AccessDenied` before the tiles); only the `"other"` (500/network) path fell through, painting zeros with the error banner *below* the grid.

The in-tree template for the correct treatment already existed: **AntivirusPage** (`hasDashboard` / `stat()`).

## Fix

Each page — **VulnerabilitiesPage, EncryptionPage, FirewallPage, PasswordPolicyPage, RecommendationsPage, AdminAuditPage** — gates its tiles on `hasData = errorKind !== "other"`:

- tile value → `stat(v) = hasData ? formatNumber(v) : "—"`, variant → `"default"` when `!hasData` (so an em dash never keeps danger/warning coloring)
- a genuinely **empty 200 tenant** (`errorKind "none"`) still shows its real `0`s
- also gated: **Encryption's** secondary method-count breakdown, and **Firewall's coverage BAR** (an empty 0%-width bar reads as "0% coverage" exactly like a zeroed tile)

## Review

Two adversarial Codex passes. The first confirmed the tile gating and caught that Firewall's **coverage bar** still visualized a zeroed value; the second confirmed no remaining fabricated-zero surface on the 500 path (tiles, breakdown, bars) and no regression.

## Testing

`security403Sweep.test.tsx` gains a mutation-checked sweep: on a 500, all six pages render `"—"` (not `0`/`0%`) and Firewall's bar is hidden — through the existing **non-vacuous** `renderSettled` helper. Reverting any page's fix reds its case (verified). `astro check` 0 errors; full web vitest **570 files / 5570 tests**; eslint clean.

## Follow-ups (out of scope, flagged)

- A **malformed 200 without a `summary`** still shows zeros (each loader does `if (json.summary) setSummary(...)` and `errorKind` stays `"none"`). Closing that needs summary-presence tracking like AntivirusPage's `dashboard !== null` — a different class than the reported 500 path.
- `friendlyFetchError` (utils.ts) hardcodes English copy with the wrong verb for a mutation 403 — a small separate copy/i18n fix.

https://claude.ai/code/session_0187oKb4Pw7KTXT2Lsvq7hUr
