### PR TITLE
feat(abuse): recidivist-endpoint detection (rmm.recidivist_endpoint)

### DIFF
--- a/apps/api/migrations/2026-08-23-abuse-endpoint-fingerprints.sql
+++ b/apps/api/migrations/2026-08-23-abuse-endpoint-fingerprints.sql
@@ -1,0 +1,61 @@
+-- Recidivist-endpoint abuse detection support table (rmm.recidivist_endpoint):
+--   * abuse_endpoint_fingerprints — cross-partner corpus of endpoint
+--     fingerprints (ScreenConnect remote-tool GUIDs, hostnames, egress IPs)
+--     used to correlate the same physical/virtual endpoint re-enrolling under
+--     a different partner after a suspension. The correlation intentionally
+--     spans ALL partners (including suspended ones), so rows must outlive the
+--     device that produced them: device_id is ON DELETE SET NULL (a device
+--     hard-delete detaches the row rather than destroying it — see
+--     DEVICE_DETACH_DEVICE_ID_TABLES in routes/devices/core.ts) while
+--     partner_id is ON DELETE CASCADE, so a partner hard-delete (the GDPR
+--     erasure boundary) still removes every fingerprint row that partner
+--     contributed.
+--   * Retention is indefinite, deliberately: the whole point of this corpus
+--     is to catch a partner re-enrolling the same endpoint long after their
+--     original suspension, so there is no age-based purge here.
+-- System-scoped: forced RLS with a system-only policy — partners must never
+-- read the fingerprint corpus (it would reveal what the operator correlates
+-- on). All access via withSystemDbAccessContext.
+-- Mirrors 2026-07-25-abuse-script-hosts.sql. Idempotent.
+
+DO $$ BEGIN
+  CREATE TYPE abuse_endpoint_fingerprint_kind AS ENUM ('remote_tool_guid', 'hostname', 'egress_ip');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS abuse_endpoint_fingerprints (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id    uuid NOT NULL REFERENCES partners(id) ON DELETE CASCADE,
+  kind          abuse_endpoint_fingerprint_kind NOT NULL,
+  value         varchar(255) NOT NULL,
+  device_id     uuid REFERENCES devices(id) ON DELETE SET NULL,
+  first_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS abuse_endpoint_fingerprints_partner_kind_value_uq
+  ON abuse_endpoint_fingerprints(partner_id, kind, value);
+
+CREATE INDEX IF NOT EXISTS abuse_endpoint_fingerprints_kind_value_idx
+  ON abuse_endpoint_fingerprints(kind, value);
+
+ALTER TABLE abuse_endpoint_fingerprints ENABLE ROW LEVEL SECURITY;
+ALTER TABLE abuse_endpoint_fingerprints FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'abuse_endpoint_fingerprints'
+      AND policyname = 'abuse_endpoint_fingerprints_system_only'
+  ) THEN
+    EXECUTE $POLICY$
+      CREATE POLICY abuse_endpoint_fingerprints_system_only
+        ON abuse_endpoint_fingerprints
+        USING (current_setting('breeze.scope', true) = 'system')
+        WITH CHECK (current_setting('breeze.scope', true) = 'system')
+    $POLICY$;
+  END IF;
+END$$;

--- a/apps/api/src/__tests__/integration/recidivistEndpoint.integration.test.ts
+++ b/apps/api/src/__tests__/integration/recidivistEndpoint.integration.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Real-DB integration tests for the recidivist-endpoint abuse detector
+ * (services/abuseSignals/recidivistEndpoint.ts): `syncEndpointFingerprints`
+ * (the corpus-refresh write path, hand-written raw SQL), `loadRecidivistMatches`
+ * (the cross-partner correlation join, also raw SQL), and the RLS boundary on
+ * `abuse_endpoint_fingerprints`.
+ *
+ * The scorer itself (`computeRecidivistSignals`) is pure and already
+ * unit-tested in recidivistEndpoint.test.ts against hand-built RecidivistMatch
+ * arrays. What ISN'T covered there is whether the SQL actually produces those
+ * matches from real device/software_inventory rows, and whether the table's
+ * forced system-only RLS policy actually holds against `breeze_app` — both
+ * proven here, mirroring abuseSignalsAggregates.integration.test.ts and the
+ * abuse_script_hosts RLS lockout block in rls-coverage.integration.test.ts.
+ */
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
+import { partners, devices, softwareInventory, abuseEndpointFingerprints } from '../../db/schema';
+import {
+  syncEndpointFingerprints,
+  loadRecidivistMatches,
+  computeRecidivistSignals,
+} from '../../services/abuseSignals/recidivistEndpoint';
+import { loadSignalConfig } from '../../services/abuseSignals/config';
+import { createPartner, createOrganization, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+// No manual afterEach cleanup: `partners` is TRUNCATE ... CASCADE'd by
+// setup.ts's global beforeEach (cleanupDatabase), which transitively
+// truncates every table with a FK back to partners (organizations, devices,
+// software_inventory, abuse_endpoint_fingerprints, ...) — same isolation
+// mechanism every other integration test in this directory relies on.
+
+async function seedDevice(opts: {
+  orgId: string;
+  siteId: string;
+  hostname: string;
+  enrollmentIp: string;
+  lastSeenIp?: string | null;
+}) {
+  const testDb = getTestDb();
+  const [device] = await testDb
+    .insert(devices)
+    .values({
+      orgId: opts.orgId,
+      siteId: opts.siteId,
+      agentId: randomUUID(),
+      hostname: opts.hostname,
+      osType: 'windows',
+      osVersion: '11',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+      enrollmentIp: opts.enrollmentIp,
+      lastSeenIp: opts.lastSeenIp,
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+  if (!device) throw new Error('seedDevice: no row returned');
+  return device;
+}
+
+async function seedScreenConnectSoftware(opts: { orgId: string; deviceId: string; guid: string }) {
+  const testDb = getTestDb();
+  await testDb.insert(softwareInventory).values({
+    deviceId: opts.deviceId,
+    orgId: opts.orgId,
+    name: `ScreenConnect Client (${opts.guid})`,
+  });
+}
+
+async function seedPartnerOrgDeviceSite(status: 'active' | 'pending' | 'suspended') {
+  const partner = await createPartner({ status });
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+  return { partner, org, site };
+}
+
+/** Runs the full detector pipeline (sync -> load -> score) under a system DB context. */
+async function runDetector(now: Date) {
+  return withSystemDbAccessContext(async () => {
+    await syncEndpointFingerprints(now);
+    const { matches } = await loadRecidivistMatches();
+    return computeRecidivistSignals(matches, loadSignalConfig());
+  });
+}
+
+describe('recidivist-endpoint detector (real DB)', () => {
+  it('scenario 1: same ScreenConnect GUID on a suspended partner and an active partner fires exactly one signal, on the active partner, at fingerprint score', async () => {
+    const guid = 'aabbccdd11223344';
+    const suspended = await seedPartnerOrgDeviceSite('suspended');
+    const active = await seedPartnerOrgDeviceSite('active');
+
+    const suspendedDevice = await seedDevice({
+      orgId: suspended.org.id,
+      siteId: suspended.site.id,
+      hostname: `DESKTOP-SUS${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      enrollmentIp: '10.1.0.1',
+      lastSeenIp: '10.1.0.1',
+    });
+    const activeDevice = await seedDevice({
+      orgId: active.org.id,
+      siteId: active.site.id,
+      hostname: `DESKTOP-ACT${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      enrollmentIp: '10.2.0.1',
+      lastSeenIp: '10.2.0.1',
+    });
+
+    await seedScreenConnectSoftware({ orgId: suspended.org.id, deviceId: suspendedDevice.id, guid });
+    await seedScreenConnectSoftware({ orgId: active.org.id, deviceId: activeDevice.id, guid });
+
+    const signals = await runDetector(new Date());
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]!.partnerId).toBe(active.partner.id);
+    expect(signals[0]!.signalKey).toBe('rmm.recidivist_endpoint');
+    expect(signals[0]!.score).toBe(100);
+    expect(signals[0]!.severity).toBe('alert');
+  });
+
+  it('scenario 2: both partners active — no direction, no signal (backtest-replay assertion)', async () => {
+    const guid = 'aabbccdd11223344';
+    const a = await seedPartnerOrgDeviceSite('active');
+    const b = await seedPartnerOrgDeviceSite('active');
+
+    const deviceA = await seedDevice({
+      orgId: a.org.id,
+      siteId: a.site.id,
+      hostname: `DESKTOP-AAA${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      enrollmentIp: '10.3.0.1',
+      lastSeenIp: '10.3.0.1',
+    });
+    const deviceB = await seedDevice({
+      orgId: b.org.id,
+      siteId: b.site.id,
+      hostname: `DESKTOP-BBB${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      enrollmentIp: '10.4.0.1',
+      lastSeenIp: '10.4.0.1',
+    });
+
+    await seedScreenConnectSoftware({ orgId: a.org.id, deviceId: deviceA.id, guid });
+    await seedScreenConnectSoftware({ orgId: b.org.id, deviceId: deviceB.id, guid });
+
+    const signals = await runDetector(new Date());
+
+    expect(signals).toEqual([]);
+  });
+
+  it('scenario 3: both partners suspended — no signal', async () => {
+    const guid = 'aabbccdd11223344';
+    const a = await seedPartnerOrgDeviceSite('suspended');
+    const b = await seedPartnerOrgDeviceSite('suspended');
+
+    const deviceA = await seedDevice({
+      orgId: a.org.id,
+      siteId: a.site.id,
+      hostname: `DESKTOP-CCC${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      enrollmentIp: '10.5.0.1',
+      lastSeenIp: '10.5.0.1',
+    });
+    const deviceB = await seedDevice({
+      orgId: b.org.id,
+      siteId: b.site.id,
+      hostname: `DESKTOP-DDD${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      enrollmentIp: '10.6.0.1',
+      lastSeenIp: '10.6.0.1',
+    });
+
+    await seedScreenConnectSoftware({ orgId: a.org.id, deviceId: deviceA.id, guid });
+    await seedScreenConnectSoftware({ orgId: b.org.id, deviceId: deviceB.id, guid });
+
+    const signals = await runDetector(new Date());
+
+    expect(signals).toEqual([]);
+  });
+
+  it('scenario 4: hostname-only reuse scores 60 (watch); adding same-counterpart egress_ip evidence upgrades it to 90', async () => {
+    const sharedHostname = 'DESKTOP-ZZ9XY7Q';
+    const active = await seedPartnerOrgDeviceSite('active');
+    const suspended = await seedPartnerOrgDeviceSite('suspended');
+
+    const activeDevice = await seedDevice({
+      orgId: active.org.id,
+      siteId: active.site.id,
+      hostname: sharedHostname,
+      enrollmentIp: '10.7.0.1',
+      lastSeenIp: '10.7.0.1',
+    });
+    const suspendedDevice = await seedDevice({
+      orgId: suspended.org.id,
+      siteId: suspended.site.id,
+      hostname: sharedHostname,
+      enrollmentIp: '10.8.0.1',
+      lastSeenIp: '10.8.0.1', // distinct IP — no ip corroboration yet
+    });
+
+    const firstRun = await runDetector(new Date());
+    const firstForActive = firstRun.filter((s) => s.partnerId === active.partner.id);
+    expect(firstForActive).toHaveLength(1);
+    expect(firstForActive[0]!.score).toBe(60);
+    expect(firstForActive[0]!.severity).toBe('watch');
+    // No egress_ip corroboration yet — evidence axes must not claim hostname_ip.
+    expect(firstForActive[0]!.evidence.axes).toEqual(['hostname']);
+
+    // Now give both devices the SAME egress IP (same counterpart pair) and
+    // re-run the full pipeline — the corpus is a full re-derive every sweep
+    // (no high-water mark), so a fresh syncEndpointFingerprints call picks up
+    // the updated device state.
+    const sharedIp = '203.0.113.77';
+    const testDb = getTestDb();
+    await testDb.update(devices).set({ lastSeenIp: sharedIp }).where(eq(devices.id, activeDevice.id));
+    await testDb.update(devices).set({ lastSeenIp: sharedIp }).where(eq(devices.id, suspendedDevice.id));
+
+    const secondRun = await runDetector(new Date());
+    const secondForActive = secondRun.filter((s) => s.partnerId === active.partner.id);
+    expect(secondForActive).toHaveLength(1);
+    expect(secondForActive[0]!.score).toBe(90);
+    expect(secondForActive[0]!.severity).toBe('alert');
+    expect(secondForActive[0]!.evidence.axes).toEqual(['hostname_ip']);
+  });
+});
+
+/**
+ * RLS lockout — mirrors the abuse_script_hosts and partner_abuse_signals
+ * blocks in rls-coverage.integration.test.ts. Forges as `breeze_app` the
+ * specific threat abuse_endpoint_fingerprints exists to prevent: a partner
+ * reading (or writing) the cross-partner endpoint-fingerprint corpus, which
+ * would reveal what the operator correlates on. All legitimate access goes
+ * through withSystemDbAccessContext.
+ *
+ * Unlike the rls-coverage.integration.test.ts version of this block (which
+ * runs under vitest.config.rls-coverage.ts, deliberately WITHOUT setup.ts's
+ * per-test truncate), this file runs under vitest.integration.config.ts,
+ * which truncates core tenant tables in a global `beforeEach`. So fixtures
+ * are seeded fresh INSIDE each `it` rather than once via a module-level
+ * `ensureFixtures` cache — a cached partner id from an earlier test would be
+ * dangling by the time the next test runs.
+ */
+describe('abuse_endpoint_fingerprints RLS — system-only enforcement', () => {
+  const runSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  async function seedPartner(): Promise<string> {
+    return withSystemDbAccessContext(async () => {
+      const [partner] = await db
+        .insert(partners)
+        .values({
+          name: `RLS Endpoint Fingerprints Partner ${runSuffix}`,
+          slug: `rls-endpoint-fp-partner-${runSuffix}-${Math.random().toString(36).slice(2, 8)}`,
+          type: 'msp',
+          plan: 'pro',
+          status: 'active',
+        })
+        .returning({ id: partners.id });
+      if (!partner) throw new Error('failed to seed partner for abuse-endpoint-fingerprints RLS forge test');
+      return partner.id;
+    });
+  }
+
+  function partnerContext(accessiblePartnerId: string) {
+    return {
+      scope: 'partner' as const,
+      orgId: null,
+      accessibleOrgIds: [],
+      accessiblePartnerIds: [accessiblePartnerId],
+      userId: null,
+    };
+  }
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    'INSERT as breeze_app under a tenant (partner-scoped) context is rejected by RLS',
+    async () => {
+      const partnerId = await seedPartner();
+
+      let caught: unknown;
+      try {
+        await withDbAccessContext(partnerContext(partnerId), async () =>
+          db.insert(abuseEndpointFingerprints).values({
+            partnerId,
+            kind: 'hostname',
+            value: `rls-forge-deny-${runSuffix}`,
+          }),
+        );
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeDefined();
+      const cause = caught as { cause?: { message?: string }; message?: string } | undefined;
+      const message = cause?.cause?.message ?? cause?.message ?? '';
+      expect(message).toMatch(/row-level security|permission denied/i);
+    },
+  );
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    "SELECT under a partner context matching the row's own partner_id returns zero rows",
+    async () => {
+      const partnerId = await seedPartner();
+
+      const seeded = await withSystemDbAccessContext(async () => {
+        return db
+          .insert(abuseEndpointFingerprints)
+          .values({ partnerId, kind: 'hostname', value: `rls-forge-seed-${runSuffix}` })
+          .returning({ id: abuseEndpointFingerprints.id });
+      });
+      expect(seeded).toHaveLength(1);
+
+      let rows: unknown[] = [];
+      let err: unknown = null;
+      try {
+        rows = await withDbAccessContext(partnerContext(partnerId), async () =>
+          db
+            .select({ id: abuseEndpointFingerprints.id })
+            .from(abuseEndpointFingerprints)
+            .where(eq(abuseEndpointFingerprints.partnerId, partnerId)),
+        );
+      } catch (e) {
+        err = e;
+      }
+
+      if (err) {
+        const cause = err as { cause?: { message?: string }; message?: string };
+        const message = cause?.cause?.message ?? cause?.message ?? '';
+        expect(message).toMatch(/permission denied|row-level security/i);
+      } else {
+        expect(rows).toEqual([]);
+      }
+    },
+  );
+
+  it.runIf(!!process.env.DATABASE_URL)(
+    'withSystemDbAccessContext INSERT + SELECT round-trips successfully',
+    async () => {
+      const partnerId = await seedPartner();
+
+      const value = `rls-forge-system-${runSuffix}`;
+      const result = await withSystemDbAccessContext(async () => {
+        return db
+          .insert(abuseEndpointFingerprints)
+          .values({ partnerId, kind: 'egress_ip', value })
+          .returning({ id: abuseEndpointFingerprints.id, value: abuseEndpointFingerprints.value });
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0]!.value).toBe(value);
+
+      const readBack = await withSystemDbAccessContext(async () => {
+        return db
+          .select({ id: abuseEndpointFingerprints.id })
+          .from(abuseEndpointFingerprints)
+          .where(eq(abuseEndpointFingerprints.id, result[0]!.id));
+      });
+      expect(readBack).toHaveLength(1);
+    },
+  );
+});

--- a/apps/api/src/__tests__/integration/recidivistEndpoint.integration.test.ts
+++ b/apps/api/src/__tests__/integration/recidivistEndpoint.integration.test.ts
@@ -198,6 +198,12 @@ describe('recidivist-endpoint detector (real DB)', () => {
     });
 
     const firstRun = await runDetector(new Date());
+    // Total-count assertion: only the active partner may ever be scored (the
+    // suspended partner sits on the non-active side of the SQL join and must
+    // never produce a signal of its own), so this proves no unexpected
+    // second signal — on the suspended partner or otherwise — sneaks through
+    // unproven by the filtered assertion below.
+    expect(firstRun).toHaveLength(1);
     const firstForActive = firstRun.filter((s) => s.partnerId === active.partner.id);
     expect(firstForActive).toHaveLength(1);
     expect(firstForActive[0]!.score).toBe(60);

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -57,6 +57,7 @@ const EXEMPT_TABLES: ReadonlySet<string> = new Set<string>([
   'partner_abuse_signals',
   'abuse_script_hosts',
   'abuse_sweep_state',
+  'abuse_endpoint_fingerprints',
 ]);
 
 // System-scoped tables: forced RLS with either no permissive policies at all,
@@ -91,6 +92,7 @@ const INTENTIONAL_UNSCOPED: ReadonlySet<string> = new Set<string>([
   'partner_abuse_signals', // Operator abuse signals ABOUT partners. Forced RLS, system-only policy — partners must never see their own risk signals.
   'abuse_script_hosts', // Cross-partner download-host corpus for the script-content abuse detector. Carries partner_id but is deliberately operator-only (mirrors partner_abuse_signals). Forced RLS, system-only policy.
   'abuse_sweep_state', // Abuse-sweep scan state (incremental execution-scan high-water mark). No tenant column. Forced RLS, system-only policy.
+  'abuse_endpoint_fingerprints', // Cross-partner endpoint-fingerprint corpus for the recidivist-endpoint abuse detector. Carries partner_id but is deliberately operator-only (mirrors abuse_script_hosts). Forced RLS, system-only policy.
   'sso_sessions', // Pre-auth SSO CSRF/PKCE transaction store (state/nonce/code_verifier + link binding). No tenant column; written/consumed only by unauthenticated callback + system-context routes. Forced RLS, system-only policy → only system context.
   'installed_extensions', // Global runtime-extension operational state (version/trust/lifecycle/enabled). No tenant axis. Forced RLS, system-only policy → only system context.
   'extension_schema_history', // Global append-only record of the schema-compatibility floor each extension bundle version applied. No tenant axis. Forced RLS, system-only policy → only system context.

--- a/apps/api/src/db/schema/abuseSignals.ts
+++ b/apps/api/src/db/schema/abuseSignals.ts
@@ -2,6 +2,7 @@ import { pgTable, uuid, varchar, timestamp, jsonb, pgEnum, real, index, uniqueIn
 import { sql } from 'drizzle-orm';
 import { partners } from './orgs';
 import { scripts } from './scripts';
+import { devices } from './devices';
 
 export const abuseSignalSeverityEnum = pgEnum('abuse_signal_severity', ['info', 'watch', 'alert']);
 
@@ -46,6 +47,35 @@ export const abuseScriptHosts = pgTable('abuse_script_hosts', {
 }, (t) => [
   uniqueIndex('abuse_script_hosts_partner_host_source_uq').on(t.partnerId, t.host, t.source),
   index('abuse_script_hosts_host_idx').on(t.host),
+]);
+
+export const abuseEndpointFingerprintKindEnum = pgEnum('abuse_endpoint_fingerprint_kind', [
+  'remote_tool_guid',
+  'hostname',
+  'egress_ip',
+]);
+
+// Cross-partner corpus of endpoint fingerprints (ScreenConnect remote-tool
+// GUIDs, hostnames, egress IPs) used by the recidivist-endpoint detector
+// (rmm.recidivist_endpoint) to correlate the same endpoint re-enrolling under
+// a different partner after suspension. Deliberately spans ALL partners
+// regardless of status, and is retained indefinitely (see migration header).
+// device_id is SET NULL on device hard-delete (DEVICE_DETACH_DEVICE_ID_TABLES
+// in routes/devices/core.ts) so the corpus outlives the device; partner_id
+// still cascades on partner hard-delete (GDPR erasure boundary). System-only
+// RLS, same as partner_abuse_signals / abuse_script_hosts above: partners
+// must never see the corpus.
+export const abuseEndpointFingerprints = pgTable('abuse_endpoint_fingerprints', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  partnerId: uuid('partner_id').notNull().references(() => partners.id, { onDelete: 'cascade' }),
+  kind: abuseEndpointFingerprintKindEnum('kind').notNull(),
+  value: varchar('value', { length: 255 }).notNull(),
+  deviceId: uuid('device_id').references(() => devices.id, { onDelete: 'set null' }),
+  firstSeenAt: timestamp('first_seen_at', { withTimezone: true }).defaultNow().notNull(),
+  lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => [
+  uniqueIndex('abuse_endpoint_fingerprints_partner_kind_value_uq').on(t.partnerId, t.kind, t.value),
+  index('abuse_endpoint_fingerprints_kind_value_idx').on(t.kind, t.value),
 ]);
 
 // Tiny key/value scan state for the abuse sweep (e.g. the incremental

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -91,7 +91,11 @@ export const DEVICE_LINKED_DEVICE_ID_TABLES = [
 // row is the audit trail for an ad-hoc support session and must outlive the
 // ephemeral device the reaper purges 6h after the session ends. Its device_id
 // FK is declared ON DELETE SET NULL to match.
-export const DEVICE_DETACH_DEVICE_ID_TABLES = ['support_sessions', 'tickets'] as const;
+// abuse_endpoint_fingerprints (recidivist-endpoint abuse detector) also
+// detaches: it's an operator corpus that must survive device hard-delete so
+// cross-partner endpoint correlation still works after the originating
+// device is gone. Its device_id FK is declared ON DELETE SET NULL to match.
+export const DEVICE_DETACH_DEVICE_ID_TABLES = ['abuse_endpoint_fingerprints', 'support_sessions', 'tickets'] as const;
 
 /**
  * Subset of {@link getDeviceCascadeDeleteTables} ∪

--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -132,9 +132,11 @@ export const SIGNAL_DEFAULTS = {
   // same remote-management client identity and scores at the ceiling.
   // hostname_ip_score requires a hostname AND an egress_ip match against the
   // SAME other partner (strong corroboration, just short of a hard
-  // identifier) and sits just above severity.alert_score. hostname_score
-  // alone is weaker (hostnames can coincidentally collide, e.g. an unrenamed
-  // vendor image) but still clears alert on its own. ip_score is RESERVED
+  // identifier) and sits just above severity.alert_score, clearing alert on
+  // its own. hostname_score alone is weaker (hostnames can coincidentally
+  // collide, e.g. an unrenamed vendor image) and at defaults caps at
+  // severity.watch_score — it does NOT clear alert by itself; only the
+  // fingerprint and hostname_ip axes do that at defaults. ip_score is RESERVED
   // and never emitted alone in v1 — an IP alone is too easily explained by
   // NAT/ISP/hosting-range reuse, so it only exists to upgrade a hostname
   // match to hostname_ip; do not wire it to fire standalone without new

--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -119,6 +119,35 @@ export const SIGNAL_DEFAULTS = {
   'billing.card_testing.base_score': 50,
   'billing.card_testing.per_extra_method': 15,
   'billing.card_testing.per_failed_attempt': 5,
+  // Recidivist-endpoint detector (recidivistEndpoint.ts): a partner's box
+  // reappears in a DIFFERENT (non-active) partner's fingerprint corpus —
+  // same ScreenConnect client GUID, same hostname, same egress IP. Backtested
+  // against production fingerprint history with zero false positives across
+  // 10/10 flagged US matches and 1/1 EU match, so this ships at score 100
+  // rather than the corroboration-only ceiling other single-signal detectors
+  // in this file are held to.
+  //
+  // Axis scores (never summed — score is the max of whichever axes matched,
+  // see computeRecidivistSignals): fingerprint_score is a direct reuse of the
+  // same remote-management client identity and scores at the ceiling.
+  // hostname_ip_score requires a hostname AND an egress_ip match against the
+  // SAME other partner (strong corroboration, just short of a hard
+  // identifier) and sits just above severity.alert_score. hostname_score
+  // alone is weaker (hostnames can coincidentally collide, e.g. an unrenamed
+  // vendor image) but still clears alert on its own. ip_score is RESERVED
+  // and never emitted alone in v1 — an IP alone is too easily explained by
+  // NAT/ISP/hosting-range reuse, so it only exists to upgrade a hostname
+  // match to hostname_ip; do not wire it to fire standalone without new
+  // backtest evidence.
+  //
+  // Not age-decayed, same structural rule as the script/billing detectors
+  // above: see the no-clock comment on computeRecidivistSignals itself for
+  // why an aged account matching a suspended partner's fingerprint is MORE
+  // suspicious, not less.
+  'rmm.recidivist_endpoint.fingerprint_score': 100,
+  'rmm.recidivist_endpoint.hostname_ip_score': 90,
+  'rmm.recidivist_endpoint.hostname_score': 60,
+  'rmm.recidivist_endpoint.ip_score': 40,
 } as const satisfies Record<string, number>;
 
 export type SignalConfigKey = keyof typeof SIGNAL_DEFAULTS;

--- a/apps/api/src/services/abuseSignals/index.ts
+++ b/apps/api/src/services/abuseSignals/index.ts
@@ -7,6 +7,7 @@ import { computeInvariantSignals } from './invariants';
 import { loadPartnerAggregates, computeHeuristicSignals, loadHostnameIndicators } from './heuristics';
 import { loadScriptFindings, computeScriptSignals, loadScriptIndicators } from './scriptContent';
 import { loadBillingIdentityAggregates, computeBillingIdentitySignals } from './billingIdentity';
+import { syncEndpointFingerprints, loadRecidivistMatches, computeRecidivistSignals } from './recidivistEndpoint';
 import { persistSignals, markDelivered } from './persistence';
 import type { ComputedSignal } from './types';
 
@@ -47,12 +48,20 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
   const cfg = loadSignalConfig();
   const now = new Date();
 
-  const { invariants, aggregates, scriptFindings, billingIdentity } = await runSystemDbCompute(async () => ({
-    invariants: await computeInvariantSignals(),
-    aggregates: await loadPartnerAggregates(),
-    scriptFindings: await loadScriptFindings(now),
-    billingIdentity: await loadBillingIdentityAggregates(),
-  }));
+  const { invariants, aggregates, scriptFindings, billingIdentity, recidivist } = await runSystemDbCompute(
+    async () => {
+      // syncEndpointFingerprints refreshes the corpus before the correlation
+      // read below runs, same ordering scriptContent uses for its own scan.
+      await syncEndpointFingerprints(now);
+      return {
+        invariants: await computeInvariantSignals(),
+        aggregates: await loadPartnerAggregates(),
+        scriptFindings: await loadScriptFindings(now),
+        billingIdentity: await loadBillingIdentityAggregates(),
+        recidivist: await loadRecidivistMatches(),
+      };
+    },
+  );
 
   const computed = [
     ...invariants,
@@ -66,6 +75,11 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
     // scorer takes no clock at all; card-testing is scored on the span the
     // billing service recorded, not on how recently the sweep ran.
     ...computeBillingIdentitySignals(billingIdentity.aggregates, billingIdentity.sharedFingerprints, cfg),
+    // Recidivist-endpoint signals are likewise never age-decayed —
+    // computeRecidivistSignals takes no clock and no partner age at all; a
+    // re-established aged account matching a suspended partner's fingerprint
+    // is more suspicious, not less (see the scorer's own header comment).
+    ...computeRecidivistSignals(recidivist.matches, cfg),
   ];
   // Script-scanned and billing-scanned partners join the evaluated set so open
   // rows for those detectors stale-resolve when the evidence disappears
@@ -75,6 +89,7 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
     ...aggregates.map((a) => a.partnerId),
     ...scriptFindings.scannedPartnerIds,
     ...billingIdentity.scannedPartnerIds,
+    ...recidivist.scannedPartnerIds,
   ]);
   const { toNotify } = await runSystemDbCompute(() => persistSignals(computed, now, evaluatedPartnerIds));
 

--- a/apps/api/src/services/abuseSignals/recidivistEndpoint.test.ts
+++ b/apps/api/src/services/abuseSignals/recidivistEndpoint.test.ts
@@ -109,7 +109,7 @@ describe('syncEndpointFingerprints', () => {
     await syncEndpointFingerprints(now);
 
     expect(db.execute).toHaveBeenCalledTimes(3);
-    const upsertCall = vi.mocked(db.execute).mock.calls[2]![0] as { strings: string[]; queryChunks?: unknown };
+    const upsertCall = vi.mocked(db.execute).mock.calls[2]![0] as unknown;
     const upsertSql = JSON.stringify(upsertCall);
     expect(upsertSql).toContain('remote_tool_guid');
     expect(upsertSql).toContain('0123456789abcdef');

--- a/apps/api/src/services/abuseSignals/recidivistEndpoint.test.ts
+++ b/apps/api/src/services/abuseSignals/recidivistEndpoint.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../db', () => ({
+  db: { execute: vi.fn() },
+}));
+
+import { db } from '../../db';
+import {
+  extractScreenConnectGuids,
+  isDeniedHostname,
+  syncEndpointFingerprints,
+  loadRecidivistMatches,
+} from './recidivistEndpoint';
+
+// All fixture partner/device ids below are invented UUID-shaped fixture
+// values — never real tenants.
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('extractScreenConnectGuids', () => {
+  it('extracts a lowercase 16-hex GUID from a ScreenConnect Client display name', () => {
+    expect(extractScreenConnectGuids('ScreenConnect Client (0123456789abcdef)')).toEqual([
+      '0123456789abcdef',
+    ]);
+  });
+
+  it('is case-sensitive on the label and hex digits, matching the brief exactly', () => {
+    // Wrong case on the label: no match at all.
+    expect(extractScreenConnectGuids('screenconnect client (0123456789abcdef)')).toEqual([]);
+    // Uppercase hex digits: not [0-9a-f], so no match.
+    expect(extractScreenConnectGuids('ScreenConnect Client (ABCDEF0123456789)')).toEqual([]);
+  });
+
+  it('extracts multiple distinct GUIDs from one string', () => {
+    const name = 'ScreenConnect Client (0123456789abcdef); ScreenConnect Client (fedcba9876543210)';
+    expect(extractScreenConnectGuids(name)).toEqual(['0123456789abcdef', 'fedcba9876543210']);
+  });
+
+  it('de-duplicates a repeated GUID', () => {
+    const name = 'ScreenConnect Client (0123456789abcdef) ScreenConnect Client (0123456789abcdef)';
+    expect(extractScreenConnectGuids(name)).toEqual(['0123456789abcdef']);
+  });
+
+  it('returns empty for unrelated software names', () => {
+    expect(extractScreenConnectGuids('Google Chrome')).toEqual([]);
+    expect(extractScreenConnectGuids('AnyDesk')).toEqual([]);
+  });
+
+  it('does not match a GUID shorter than 16 hex digits', () => {
+    expect(extractScreenConnectGuids('ScreenConnect Client (abc123)')).toEqual([]);
+  });
+
+  it('does not match non-hex characters inside the parens', () => {
+    expect(extractScreenConnectGuids('ScreenConnect Client (zzzzzzzzzzzzzzzz)')).toEqual([]);
+  });
+});
+
+describe('isDeniedHostname', () => {
+  it('denies empty and blank hostnames', () => {
+    expect(isDeniedHostname('')).toBe(true);
+    expect(isDeniedHostname('   ')).toBe(true);
+  });
+
+  it('denies localhost (case-insensitive)', () => {
+    expect(isDeniedHostname('localhost')).toBe(true);
+    expect(isDeniedHostname('LOCALHOST')).toBe(true);
+  });
+
+  it('denies a short WIN- default hostname', () => {
+    expect(isDeniedHostname('WIN-ABC123')).toBe(true); // 10 chars, < 12
+    expect(isDeniedHostname('win-abcdefg')).toBe(true); // 11 chars, < 12
+  });
+
+  it('allows a WIN- hostname at or above the length threshold', () => {
+    expect(isDeniedHostname('WIN-ABCDEFGH')).toBe(false); // 12 chars
+    expect(isDeniedHostname('WIN-ABCDEFGHIJ')).toBe(false); // 14 chars
+  });
+
+  it('allows an ordinary managed-looking hostname', () => {
+    expect(isDeniedHostname('ACMEIT-DESKTOP-07')).toBe(false);
+    expect(isDeniedHostname('finance-pc-12')).toBe(false);
+  });
+});
+
+describe('syncEndpointFingerprints', () => {
+  const now = new Date('2026-08-15T12:00:00Z');
+
+  it('does nothing further when no software or device rows exist', async () => {
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce([] as never) // software_inventory scan
+      .mockResolvedValueOnce([] as never); // devices scan
+
+    await syncEndpointFingerprints(now);
+
+    expect(db.execute).toHaveBeenCalledTimes(2); // no upsert issued
+  });
+
+  it('extracts a remote_tool_guid fingerprint and issues an upsert', async () => {
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce([
+        { device_id: 'device-1', partner_id: 'partner-a', name: 'ScreenConnect Client (0123456789abcdef)' },
+      ] as never)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([] as never); // the upsert itself
+
+    await syncEndpointFingerprints(now);
+
+    expect(db.execute).toHaveBeenCalledTimes(3);
+    const upsertCall = vi.mocked(db.execute).mock.calls[2]![0] as { strings: string[]; queryChunks?: unknown };
+    const upsertSql = JSON.stringify(upsertCall);
+    expect(upsertSql).toContain('remote_tool_guid');
+    expect(upsertSql).toContain('0123456789abcdef');
+    expect(upsertSql).toContain('partner-a');
+  });
+
+  it('records a hostname fingerprint (lowercased) but skips a denied hostname', async () => {
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce([] as never) // software_inventory scan
+      .mockResolvedValueOnce([
+        { id: 'device-1', partner_id: 'partner-a', hostname: 'Finance-PC-01', last_seen_ip: null, enrollment_ip: null },
+        { id: 'device-2', partner_id: 'partner-a', hostname: 'WIN-ABC123', last_seen_ip: null, enrollment_ip: null },
+      ] as never)
+      .mockResolvedValueOnce([] as never); // the upsert
+
+    await syncEndpointFingerprints(now);
+
+    const upsertCall = vi.mocked(db.execute).mock.calls[2]![0] as unknown;
+    const upsertSql = JSON.stringify(upsertCall);
+    expect(upsertSql).toContain('finance-pc-01');
+    expect(upsertSql).not.toContain('win-abc123');
+    expect(upsertSql).not.toContain('WIN-ABC123');
+  });
+
+  it('records egress_ip from last_seen_ip, falling back to enrollment_ip', async () => {
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([
+        { id: 'device-1', partner_id: 'partner-a', hostname: '', last_seen_ip: '203.0.113.5', enrollment_ip: '198.51.100.9' },
+        { id: 'device-2', partner_id: 'partner-b', hostname: '', last_seen_ip: null, enrollment_ip: '198.51.100.10' },
+        { id: 'device-3', partner_id: 'partner-c', hostname: '', last_seen_ip: null, enrollment_ip: null },
+      ] as never)
+      .mockResolvedValueOnce([] as never);
+
+    await syncEndpointFingerprints(now);
+
+    const upsertCall = vi.mocked(db.execute).mock.calls[2]![0] as unknown;
+    const upsertSql = JSON.stringify(upsertCall);
+    expect(upsertSql).toContain('203.0.113.5'); // last_seen_ip wins over enrollment_ip
+    expect(upsertSql).not.toContain('198.51.100.9');
+    expect(upsertSql).toContain('198.51.100.10'); // fallback to enrollment_ip
+  });
+
+  it('de-dupes by (partnerId, kind, value) so one upsert row covers repeated observations', async () => {
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce([
+        { device_id: 'device-1', partner_id: 'partner-a', name: 'ScreenConnect Client (0123456789abcdef)' },
+        { device_id: 'device-2', partner_id: 'partner-a', name: 'ScreenConnect Client (0123456789abcdef)' },
+      ] as never)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([] as never);
+
+    await syncEndpointFingerprints(now);
+
+    // Exactly 3 execute calls total: no crash from Postgres's "affect row a
+    // second time" restriction would be visible here since db is mocked, but
+    // the dedup happens in JS before the SQL is built — assert only one
+    // occurrence of the guid value survives into the statement text.
+    const upsertCall = vi.mocked(db.execute).mock.calls[2]![0] as unknown;
+    const occurrences = JSON.stringify(upsertCall).split('0123456789abcdef').length - 1;
+    expect(occurrences).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('loadRecidivistMatches', () => {
+  it('shapes match rows and scanned partner ids from the two queries', async () => {
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce([
+        {
+          partner_id: 'partner-active',
+          kind: 'remote_tool_guid',
+          value: '0123456789abcdef',
+          other_partner_id: 'partner-suspended',
+          other_partner_name: 'Suspended Co',
+          other_partner_status: 'suspended',
+        },
+      ] as never)
+      .mockResolvedValueOnce([{ partner_id: 'partner-active' }] as never);
+
+    const result = await loadRecidivistMatches();
+
+    expect(result.matches).toEqual([
+      {
+        partnerId: 'partner-active',
+        kind: 'remote_tool_guid',
+        value: '0123456789abcdef',
+        otherPartnerId: 'partner-suspended',
+        otherPartnerName: 'Suspended Co',
+        otherPartnerStatus: 'suspended',
+      },
+    ]);
+    expect(result.scannedPartnerIds).toEqual(['partner-active']);
+    expect(db.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns empty matches and scannedPartnerIds when nothing correlates', async () => {
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([] as never);
+
+    const result = await loadRecidivistMatches();
+
+    expect(result.matches).toEqual([]);
+    expect(result.scannedPartnerIds).toEqual([]);
+  });
+});

--- a/apps/api/src/services/abuseSignals/recidivistEndpoint.test.ts
+++ b/apps/api/src/services/abuseSignals/recidivistEndpoint.test.ts
@@ -161,13 +161,15 @@ describe('syncEndpointFingerprints', () => {
 
     await syncEndpointFingerprints(now);
 
-    // Exactly 3 execute calls total: no crash from Postgres's "affect row a
-    // second time" restriction would be visible here since db is mocked, but
-    // the dedup happens in JS before the SQL is built — assert only one
-    // occurrence of the guid value survives into the statement text.
+    // Postgres rejects an INSERT ... ON CONFLICT DO UPDATE that hits the same
+    // row twice in one statement, so the dedup must collapse both software
+    // rows down to exactly ONE VALUES row for this (partner, kind, value).
+    // db is mocked, so that constraint can't fire here — instead assert the
+    // guid value appears exactly once in the built statement, which is what
+    // guarantees only one VALUES row was emitted for it.
     const upsertCall = vi.mocked(db.execute).mock.calls[2]![0] as unknown;
     const occurrences = JSON.stringify(upsertCall).split('0123456789abcdef').length - 1;
-    expect(occurrences).toBeGreaterThanOrEqual(1);
+    expect(occurrences).toBe(1);
   });
 });
 

--- a/apps/api/src/services/abuseSignals/recidivistEndpoint.test.ts
+++ b/apps/api/src/services/abuseSignals/recidivistEndpoint.test.ts
@@ -174,6 +174,64 @@ describe('syncEndpointFingerprints', () => {
     const occurrences = JSON.stringify(upsertCall).split('0123456789abcdef').length - 1;
     expect(occurrences).toBe(1);
   });
+
+  it('chunks the upsert into batches of at most 500 rows per statement when the corpus exceeds one chunk', async () => {
+    // 1,200 distinct hostname rows across 1,200 distinct devices/partners ->
+    // 1,200 distinct (partnerId, kind, value) keys, so none collapse in the
+    // de-dup map. At 500 rows/chunk that must issue 3 upsert statements
+    // (500 + 500 + 200), each with <= 500 VALUES tuples.
+    const deviceRows = Array.from({ length: 1200 }, (_, i) => ({
+      id: `device-${i}`,
+      partner_id: `partner-${i}`,
+      hostname: `finance-pc-${i}`,
+      last_seen_ip: null,
+      enrollment_ip: null,
+    }));
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce([] as never) // software_inventory scan
+      .mockResolvedValueOnce(deviceRows as never) // devices scan
+      .mockResolvedValue([] as never); // the chunked upserts
+
+    await syncEndpointFingerprints(now);
+
+    // 2 setup calls + 3 upsert chunk calls.
+    expect(db.execute).toHaveBeenCalledTimes(5);
+    const chunkSizes = vi.mocked(db.execute).mock.calls.slice(2).map((call) => {
+      const sqlObj = call[0] as { queryChunks?: unknown[] };
+      // Each VALUES tuple appears as its own queryChunks entry boundary —
+      // count occurrences of the fingerprint kind cast, one per row, as a
+      // stand-in for "how many VALUES tuples landed in this statement".
+      const asString = JSON.stringify(sqlObj);
+      return asString.split('hostname').length - 1;
+    });
+    expect(chunkSizes).toEqual([500, 500, 200]);
+    expect(chunkSizes.every((n) => n <= 500)).toBe(true);
+  });
+
+  it('truncates deterministically and warns when the corpus exceeds FINGERPRINT_UPSERTS_PER_SWEEP_CAP', async () => {
+    // 10,050 distinct rows -> exceeds the 10,000 cap by 50; the sync must
+    // truncate to exactly 10,000 (20 chunks of 500) and log a warning
+    // instead of silently dropping the overflow unnoticed.
+    const deviceRows = Array.from({ length: 10_050 }, (_, i) => ({
+      id: `device-${i}`,
+      partner_id: `partner-${i}`,
+      hostname: `finance-pc-${i}`,
+      last_seen_ip: null,
+      enrollment_ip: null,
+    }));
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce(deviceRows as never)
+      .mockResolvedValue([] as never);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await syncEndpointFingerprints(now);
+
+    // 2 setup calls + 20 upsert chunk calls (10,000 / 500).
+    expect(db.execute).toHaveBeenCalledTimes(22);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('FINGERPRINT_UPSERTS_PER_SWEEP_CAP'));
+    warnSpy.mockRestore();
+  });
 });
 
 describe('loadRecidivistMatches', () => {

--- a/apps/api/src/services/abuseSignals/recidivistEndpoint.test.ts
+++ b/apps/api/src/services/abuseSignals/recidivistEndpoint.test.ts
@@ -10,7 +10,10 @@ import {
   isDeniedHostname,
   syncEndpointFingerprints,
   loadRecidivistMatches,
+  computeRecidivistSignals,
+  type RecidivistMatch,
 } from './recidivistEndpoint';
+import { SIGNAL_DEFAULTS, type SignalConfig } from './config';
 
 // All fixture partner/device ids below are invented UUID-shaped fixture
 // values — never real tenants.
@@ -213,5 +216,132 @@ describe('loadRecidivistMatches', () => {
 
     expect(result.matches).toEqual([]);
     expect(result.scannedPartnerIds).toEqual([]);
+  });
+});
+
+describe('computeRecidivistSignals', () => {
+  const cfg: SignalConfig = SIGNAL_DEFAULTS;
+
+  function match(overrides: Partial<RecidivistMatch>): RecidivistMatch {
+    return {
+      partnerId: 'partner-active',
+      kind: 'remote_tool_guid',
+      value: 'v1',
+      otherPartnerId: 'partner-suspended',
+      otherPartnerName: 'Suspended Co',
+      otherPartnerStatus: 'suspended',
+      ...overrides,
+    };
+  }
+
+  it('fires the fingerprint axis at fingerprint_score for any remote_tool_guid match', () => {
+    const signals = computeRecidivistSignals([match({ kind: 'remote_tool_guid', value: 'abc' })], cfg);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]!.score).toBe(cfg['rmm.recidivist_endpoint.fingerprint_score']);
+    expect(signals[0]!.severity).toBe('alert');
+    expect((signals[0]!.evidence as { axes: string[] }).axes).toEqual(['fingerprint']);
+  });
+
+  it('fires the hostname axis alone at hostname_score when there is no same-counterpart ip match', () => {
+    const signals = computeRecidivistSignals([match({ kind: 'hostname', value: 'finance-pc-01' })], cfg);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]!.score).toBe(cfg['rmm.recidivist_endpoint.hostname_score']);
+    expect((signals[0]!.evidence as { axes: string[] }).axes).toEqual(['hostname']);
+  });
+
+  it('upgrades to hostname_ip when hostname and egress_ip match the SAME other partner', () => {
+    const signals = computeRecidivistSignals(
+      [
+        match({ kind: 'hostname', value: 'finance-pc-01', otherPartnerId: 'partner-suspended' }),
+        match({ kind: 'egress_ip', value: '203.0.113.5', otherPartnerId: 'partner-suspended' }),
+      ],
+      cfg,
+    );
+    expect(signals).toHaveLength(1);
+    expect(signals[0]!.score).toBe(cfg['rmm.recidivist_endpoint.hostname_ip_score']);
+    expect((signals[0]!.evidence as { axes: string[] }).axes).toEqual(['hostname_ip']);
+  });
+
+  it('stays at hostname_score (not hostname_ip) when the hostname and ip matches are against DIFFERENT other-partners', () => {
+    const signals = computeRecidivistSignals(
+      [
+        match({ kind: 'hostname', value: 'finance-pc-01', otherPartnerId: 'partner-suspended-a' }),
+        match({ kind: 'egress_ip', value: '203.0.113.5', otherPartnerId: 'partner-suspended-b' }),
+      ],
+      cfg,
+    );
+    expect(signals).toHaveLength(1);
+    expect(signals[0]!.score).toBe(cfg['rmm.recidivist_endpoint.hostname_score']);
+    expect((signals[0]!.evidence as { axes: string[] }).axes).toEqual(['hostname']);
+  });
+
+  it('emits no signal for an egress_ip-only match', () => {
+    const signals = computeRecidivistSignals([match({ kind: 'egress_ip', value: '203.0.113.5' })], cfg);
+    expect(signals).toEqual([]);
+  });
+
+  it('scores the MAX of matched axes, never the sum, when a partner matches all three', () => {
+    const signals = computeRecidivistSignals(
+      [
+        match({ kind: 'remote_tool_guid', value: 'abc', otherPartnerId: 'partner-suspended' }),
+        match({ kind: 'hostname', value: 'finance-pc-01', otherPartnerId: 'partner-suspended' }),
+        match({ kind: 'egress_ip', value: '203.0.113.5', otherPartnerId: 'partner-suspended' }),
+      ],
+      cfg,
+    );
+    expect(signals).toHaveLength(1);
+    // fingerprint (100) beats hostname_ip (90) — max, not 100+90+... summed.
+    expect(signals[0]!.score).toBe(cfg['rmm.recidivist_endpoint.fingerprint_score']);
+    expect((signals[0]!.evidence as { axes: string[] }).axes).toEqual(
+      expect.arrayContaining(['fingerprint', 'hostname_ip']),
+    );
+  });
+
+  it('maps severity at defaults: fingerprint and hostname_ip alert, hostname watch', () => {
+    const fingerprintSignal = computeRecidivistSignals([match({ kind: 'remote_tool_guid' })], cfg)[0]!;
+    expect(fingerprintSignal.score).toBe(100);
+    expect(fingerprintSignal.severity).toBe('alert');
+
+    const hostnameIpSignal = computeRecidivistSignals(
+      [
+        match({ kind: 'hostname', otherPartnerId: 'partner-suspended' }),
+        match({ kind: 'egress_ip', otherPartnerId: 'partner-suspended' }),
+      ],
+      cfg,
+    )[0]!;
+    expect(hostnameIpSignal.score).toBe(90);
+    expect(hostnameIpSignal.severity).toBe('alert');
+
+    const hostnameSignal = computeRecidivistSignals([match({ kind: 'hostname' })], cfg)[0]!;
+    expect(hostnameSignal.score).toBe(60);
+    expect(hostnameSignal.severity).toBe('watch');
+  });
+
+  it('respects overridden axis scores via injected SignalConfig', () => {
+    const overridden: SignalConfig = { ...cfg, 'rmm.recidivist_endpoint.fingerprint_score': 42 };
+    const signals = computeRecidivistSignals([match({ kind: 'remote_tool_guid' })], overridden);
+    expect(signals[0]!.score).toBe(42);
+  });
+
+  it('caps evidence.matches to the first 10 matches for a partner', () => {
+    const matches = Array.from({ length: 15 }, (_, i) =>
+      match({ kind: 'hostname', value: `host-${i}`, otherPartnerId: `partner-suspended-${i}` }),
+    );
+    const signals = computeRecidivistSignals(matches, cfg);
+    expect(signals).toHaveLength(1);
+    expect((signals[0]!.evidence as { matches: unknown[] }).matches).toHaveLength(10);
+  });
+
+  it('never re-checks partner status — trusts whatever matches it is given (direction rule enforced upstream in SQL)', () => {
+    // A match whose otherPartnerStatus is 'active' would never legitimately
+    // reach this function (Task 2's SQL join filters it out), but the scorer
+    // itself has no status-checking logic at all — it fires on the shape of
+    // the input alone, documenting that the contract lives in the SQL, not here.
+    const signals = computeRecidivistSignals(
+      [match({ kind: 'remote_tool_guid', otherPartnerStatus: 'active' })],
+      cfg,
+    );
+    expect(signals).toHaveLength(1);
+    expect(signals[0]!.score).toBe(cfg['rmm.recidivist_endpoint.fingerprint_score']);
   });
 });

--- a/apps/api/src/services/abuseSignals/recidivistEndpoint.ts
+++ b/apps/api/src/services/abuseSignals/recidivistEndpoint.ts
@@ -1,5 +1,7 @@
 import { sql } from 'drizzle-orm';
 import { db } from '../../db';
+import { scoreToSeverity, type SignalConfig } from './config';
+import type { ComputedSignal } from './types';
 
 // ---------------------------------------------------------------------------
 // Recidivist-endpoint detector: rmm.recidivist_endpoint
@@ -243,4 +245,101 @@ export async function loadRecidivistMatches(): Promise<{
     matches,
     scannedPartnerIds: scannedRows.map((r) => r.partner_id),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Scorer (pure)
+// ---------------------------------------------------------------------------
+
+/** Evidence is capped to the first N matches per partner, same shape as the corroborating detectors' bounded evidence. */
+const EVIDENCE_MATCH_CAP = 10;
+
+type RecidivistAxis = 'fingerprint' | 'hostname_ip' | 'hostname';
+
+/**
+ * Pure scoring: no I/O, no clock, no partner age — takes only the raw
+ * matches Task 2's SQL correlation produced. Unlike the other detectors in
+ * this module, there is no youngWeight() call here at all, deliberately: a
+ * re-established aged account matching a suspended partner's fingerprint is
+ * MORE suspicious than a freshly-created one doing the same (it means the
+ * operator sat on the reused hardware for a while before re-signing up), so
+ * decaying the score down for account age would run backwards against what
+ * the evidence means. Same structural argument as computeScriptSignals and
+ * computeBillingIdentitySignals: the scorer's signature enforces this rather
+ * than relying on a convention nobody checks.
+ *
+ * Per partner, three axes can fire (never summed — score is the MAX of
+ * whichever axes matched, because a fingerprint match and a hostname match
+ * against the same reused box are the same underlying event, not two
+ * independent pieces of evidence):
+ *   - fingerprint: any remote_tool_guid match, at any other partner.
+ *   - hostname_ip: a hostname match AND an egress_ip match against the SAME
+ *     other partner — the box kept both its hostname and its network egress,
+ *     which is stronger than either alone.
+ *   - hostname: a hostname match with no same-counterpart ip corroboration.
+ *   - egress_ip alone never fires (v1): an IP is far weaker evidence on its
+ *     own (NAT/ISP reuse, shared hosting ranges) — it only upgrades a
+ *     hostname match to hostname_ip. ip_score is reserved and unemitted here.
+ *
+ * The direction rule (active-side only, non-active counterpart) is already
+ * enforced by Task 2's SQL join — this function trusts its input and never
+ * re-checks partner status.
+ */
+export function computeRecidivistSignals(matches: RecidivistMatch[], cfg: SignalConfig): ComputedSignal[] {
+  const byPartner = new Map<string, RecidivistMatch[]>();
+  for (const m of matches) {
+    const list = byPartner.get(m.partnerId);
+    if (list) list.push(m);
+    else byPartner.set(m.partnerId, [m]);
+  }
+
+  const signals: ComputedSignal[] = [];
+
+  for (const [partnerId, partnerMatches] of byPartner) {
+    const hasFingerprint = partnerMatches.some((m) => m.kind === 'remote_tool_guid');
+    const hostnameCounterparts = new Set(
+      partnerMatches.filter((m) => m.kind === 'hostname').map((m) => m.otherPartnerId),
+    );
+    const ipCounterparts = new Set(
+      partnerMatches.filter((m) => m.kind === 'egress_ip').map((m) => m.otherPartnerId),
+    );
+    const hasHostname = hostnameCounterparts.size > 0;
+    // hostname_ip requires the SAME other-partner to hold both a hostname and
+    // an egress_ip match — a hostname match against one counterpart plus an
+    // ip match against an unrelated counterpart is two weaker, unrelated
+    // pieces of evidence, not one stronger one.
+    const hasHostnameIp = [...hostnameCounterparts].some((id) => ipCounterparts.has(id));
+
+    const axes: RecidivistAxis[] = [];
+    if (hasFingerprint) axes.push('fingerprint');
+    if (hasHostnameIp) axes.push('hostname_ip');
+    else if (hasHostname) axes.push('hostname');
+
+    if (axes.length === 0) continue; // ip-only (or no match at all) — no signal in v1
+
+    const axisScore: Record<RecidivistAxis, number> = {
+      fingerprint: cfg['rmm.recidivist_endpoint.fingerprint_score'],
+      hostname_ip: cfg['rmm.recidivist_endpoint.hostname_ip_score'],
+      hostname: cfg['rmm.recidivist_endpoint.hostname_score'],
+    };
+    const score = Math.max(...axes.map((axis) => axisScore[axis]));
+
+    signals.push({
+      partnerId,
+      signalKey: 'rmm.recidivist_endpoint',
+      score,
+      severity: scoreToSeverity(score, cfg),
+      evidence: {
+        axes,
+        matches: partnerMatches.slice(0, EVIDENCE_MATCH_CAP).map((m) => ({
+          kind: m.kind,
+          value: m.value,
+          otherPartnerName: m.otherPartnerName,
+          otherPartnerStatus: m.otherPartnerStatus,
+        })),
+      },
+    });
+  }
+
+  return signals;
 }

--- a/apps/api/src/services/abuseSignals/recidivistEndpoint.ts
+++ b/apps/api/src/services/abuseSignals/recidivistEndpoint.ts
@@ -59,10 +59,15 @@ const WIN_PREFIX_DENY_MAX_LENGTH = 12;
 
 /**
  * Hostnames that must never enter the corpus as a `hostname` fingerprint:
- * empty/blank, `localhost`, and any short auto-generated `WIN-` default
- * (Windows Setup stamps `WIN-<10 random chars>`, which is exactly the kind
- * of unrenamed-installer-default noise that would pollute cross-partner
- * correlation with false positives rather than catch a real recidivist).
+ * empty/blank, `localhost`, and a degenerate short `WIN-` name. Windows
+ * Setup's real default is `WIN-<10 random chars>` (14 characters total),
+ * which is AT the threshold and therefore NOT denied — a genuine
+ * unrenamed-installer default still enters the corpus and can still fire a
+ * match, which is intentional (see the module header: this is exactly the
+ * unrenamed-default-box signature the detector exists to catch). This deny
+ * only catches shorter, hand-typed or truncated `WIN-` stand-ins that carry
+ * no real per-install entropy and would otherwise pollute cross-partner
+ * correlation with coincidental collisions.
  *
  * Pure; exported for tests. Expects an already-lowercased/trimmed value —
  * callers normalize before checking (and before storing) so the deny-list
@@ -97,6 +102,22 @@ interface DeviceRow {
   last_seen_ip: string | null;
   enrollment_ip: string | null;
 }
+
+/**
+ * Sweep-level bound on the fingerprint upsert, same two-part shape as
+ * scriptContent.ts's HOST_UPSERTS_PER_SWEEP_CAP:
+ *
+ *  - FINGERPRINT_UPSERT_CHUNK_SIZE bounds each single INSERT statement. Each
+ *    VALUES row binds 6 params, so 500 rows/chunk = 3,000 params/statement —
+ *    comfortably under Postgres's 65,535-param Bind limit (which the old
+ *    single-statement upsert blew past once the corpus crossed ~10.9k rows).
+ *  - FINGERPRINT_UPSERTS_PER_SWEEP_CAP bounds total sweep cost: even chunked,
+ *    an unbounded fingerprint set means unbounded round trips per sweep.
+ *    Overflow truncates deterministically (first N of the de-duped set) and
+ *    logs a warning rather than silently dropping data unnoticed.
+ */
+const FINGERPRINT_UPSERT_CHUNK_SIZE = 500;
+const FINGERPRINT_UPSERTS_PER_SWEEP_CAP = 10_000;
 
 /**
  * Refreshes the abuse_endpoint_fingerprints corpus from current device and
@@ -142,30 +163,43 @@ export async function syncEndpointFingerprints(now: Date): Promise<void> {
       record({ partnerId: r.partner_id, kind: 'hostname', value: hostname, deviceId: r.id });
     }
 
-    const ip = (r.last_seen_ip ?? r.enrollment_ip ?? '').trim();
+    // `||`, not `??`: an empty-string last_seen_ip (device has never
+    // reported in) must also fall back to enrollment_ip, not short-circuit
+    // to an empty fingerprint value that then gets skipped below.
+    const ip = (r.last_seen_ip || r.enrollment_ip || '').trim();
     if (ip.length > 0) {
       record({ partnerId: r.partner_id, kind: 'egress_ip', value: ip, deviceId: r.id });
     }
   }
 
-  const rows = [...byKey.values()];
+  let rows = [...byKey.values()];
   if (rows.length === 0) return;
 
-  const values = sql.join(
-    rows.map(
-      (r) =>
-        sql`(${r.partnerId}::uuid, ${r.kind}::abuse_endpoint_fingerprint_kind, ${r.value}, ${r.deviceId}::uuid, ${now.toISOString()}::timestamptz, ${now.toISOString()}::timestamptz)`,
-    ),
-    sql`, `,
-  );
+  if (rows.length > FINGERPRINT_UPSERTS_PER_SWEEP_CAP) {
+    console.warn(
+      `[AbuseSignals] FINGERPRINT_UPSERTS_PER_SWEEP_CAP exceeded — truncating ${rows.length} fingerprint rows to ${FINGERPRINT_UPSERTS_PER_SWEEP_CAP} this sweep`,
+    );
+    rows = rows.slice(0, FINGERPRINT_UPSERTS_PER_SWEEP_CAP);
+  }
 
-  await db.execute(sql`
-    INSERT INTO abuse_endpoint_fingerprints (partner_id, kind, value, device_id, first_seen_at, last_seen_at)
-    VALUES ${values}
-    ON CONFLICT (partner_id, kind, value) DO UPDATE SET
-      last_seen_at = EXCLUDED.last_seen_at,
-      device_id = COALESCE(abuse_endpoint_fingerprints.device_id, EXCLUDED.device_id)
-  `);
+  for (let i = 0; i < rows.length; i += FINGERPRINT_UPSERT_CHUNK_SIZE) {
+    const chunk = rows.slice(i, i + FINGERPRINT_UPSERT_CHUNK_SIZE);
+    const values = sql.join(
+      chunk.map(
+        (r) =>
+          sql`(${r.partnerId}::uuid, ${r.kind}::abuse_endpoint_fingerprint_kind, ${r.value}, ${r.deviceId}::uuid, ${now.toISOString()}::timestamptz, ${now.toISOString()}::timestamptz)`,
+      ),
+      sql`, `,
+    );
+
+    await db.execute(sql`
+      INSERT INTO abuse_endpoint_fingerprints (partner_id, kind, value, device_id, first_seen_at, last_seen_at)
+      VALUES ${values}
+      ON CONFLICT (partner_id, kind, value) DO UPDATE SET
+        last_seen_at = EXCLUDED.last_seen_at,
+        device_id = COALESCE(abuse_endpoint_fingerprints.device_id, EXCLUDED.device_id)
+    `);
+  }
 }
 
 export interface RecidivistMatch {
@@ -221,7 +255,8 @@ export async function loadRecidivistMatches(): Promise<{
       AND af2.value = af1.value
       AND af2.partner_id != af1.partner_id
     JOIN partners p2 ON p2.id = af2.partner_id
-    WHERE p1.status IN ('active', 'pending')
+    WHERE p1.deleted_at IS NULL
+      AND p1.status IN ('active', 'pending')
       AND p2.status != 'active'
   `)) as unknown as MatchRow[];
 

--- a/apps/api/src/services/abuseSignals/recidivistEndpoint.ts
+++ b/apps/api/src/services/abuseSignals/recidivistEndpoint.ts
@@ -1,0 +1,246 @@
+import { sql } from 'drizzle-orm';
+import { db } from '../../db';
+
+// ---------------------------------------------------------------------------
+// Recidivist-endpoint detector: rmm.recidivist_endpoint
+//
+// The corpus (abuse_endpoint_fingerprints, Task 1) records three kinds of
+// endpoint fingerprint — remote_tool_guid, hostname, egress_ip — extracted
+// for EVERY partner regardless of status, mirroring the scriptContent.ts
+// corpus rule: a suspended partner's fingerprints must stay in the corpus or
+// the very correlation this detector exists for (a suspended operator
+// re-enrolling the same box under a fresh signup) becomes invisible.
+//
+// syncEndpointFingerprints() refreshes that corpus. loadRecidivistMatches()
+// does the cross-partner correlation entirely in SQL and returns raw matches
+// — scoring (max-of-axes, never sum; no age decay) is a separate concern
+// left to the caller/scorer (Task 3), same split as loadScriptFindings vs.
+// computeScriptSignals.
+//
+// Full-scan, no high-water mark: at current fleet size (~hundreds of
+// devices) a full re-derive of the corpus every sweep is cheap and, unlike
+// scriptContent's execution-stdout scan, there is no unboundedly-growing
+// event log here to make incremental scanning worth the extra state — every
+// row we'd scan is current device/software-inventory state, not history.
+// ---------------------------------------------------------------------------
+
+/**
+ * ScreenConnect embeds its client GUID directly in the installed-software
+ * display name: "ScreenConnect Client (0123456789abcdef)". v1 ships this
+ * pattern only — LogMeIn and others are unbacktested against real inventory
+ * data, and this detector fires at score 100, so an unverified pattern does
+ * not ship (see Global Constraints).
+ *
+ * Pattern is exactly the brief's spec, case-sensitive (ScreenConnect always
+ * emits this exact label + lowercase hex — a looser match risks false
+ * positives at score 100). Pure; exported for tests. `g` flag so a name
+ * mentioning the client twice (seen in some inventory dedupe edge cases)
+ * yields both.
+ */
+const SCREENCONNECT_GUID_RE = /ScreenConnect Client \(([0-9a-f]{16})\)/g;
+
+export function extractScreenConnectGuids(name: string): string[] {
+  const out = new Set<string>();
+  for (const match of name.matchAll(SCREENCONNECT_GUID_RE)) {
+    const guid = match[1];
+    if (guid) out.add(guid.toLowerCase());
+  }
+  return [...out];
+}
+
+// SQL-side prefilter mirroring SCREENCONNECT_GUID_RE, so software_inventory
+// rows that cannot possibly match never leave Postgres.
+const SCREENCONNECT_GUID_SQL_RE = 'ScreenConnect Client \\([0-9a-f]{16}\\)';
+
+/** A denied `WIN-` prefix must be shorter than this many characters total. */
+const WIN_PREFIX_DENY_MAX_LENGTH = 12;
+
+/**
+ * Hostnames that must never enter the corpus as a `hostname` fingerprint:
+ * empty/blank, `localhost`, and any short auto-generated `WIN-` default
+ * (Windows Setup stamps `WIN-<10 random chars>`, which is exactly the kind
+ * of unrenamed-installer-default noise that would pollute cross-partner
+ * correlation with false positives rather than catch a real recidivist).
+ *
+ * Pure; exported for tests. Expects an already-lowercased/trimmed value —
+ * callers normalize before checking (and before storing) so the deny-list
+ * and the stored value agree on casing.
+ */
+export function isDeniedHostname(h: string): boolean {
+  const trimmed = h.trim();
+  if (trimmed.length === 0) return true;
+  const lower = trimmed.toLowerCase();
+  if (lower === 'localhost') return true;
+  if (lower.startsWith('win-') && lower.length < WIN_PREFIX_DENY_MAX_LENGTH) return true;
+  return false;
+}
+
+interface FingerprintRow {
+  partnerId: string;
+  kind: 'remote_tool_guid' | 'hostname' | 'egress_ip';
+  value: string;
+  deviceId: string;
+}
+
+interface SoftwareInventoryRow {
+  device_id: string;
+  partner_id: string;
+  name: string;
+}
+
+interface DeviceRow {
+  id: string;
+  partner_id: string;
+  hostname: string;
+  last_seen_ip: string | null;
+  enrollment_ip: string | null;
+}
+
+/**
+ * Refreshes the abuse_endpoint_fingerprints corpus from current device and
+ * software-inventory state. MUST run inside a system DB context — this
+ * corpus is system-only RLS (bare breeze_app reads return 0 rows), and the
+ * sweep already provides that context (see class header).
+ */
+export async function syncEndpointFingerprints(now: Date): Promise<void> {
+  // --- 1. remote_tool_guid: ScreenConnect client GUIDs from software_inventory,
+  //        SQL-prefiltered before any name text leaves Postgres. -------------
+  const softwareRows = (await db.execute(sql`
+    SELECT si.device_id, o.partner_id, si.name
+    FROM software_inventory si
+    JOIN devices d ON d.id = si.device_id
+    JOIN organizations o ON o.id = d.org_id
+    WHERE si.name ~ ${SCREENCONNECT_GUID_SQL_RE}
+  `)) as unknown as SoftwareInventoryRow[];
+
+  // --- 2. hostname + egress_ip: current device state, all partners. --------
+  const deviceRows = (await db.execute(sql`
+    SELECT d.id, o.partner_id, d.hostname, d.last_seen_ip, d.enrollment_ip
+    FROM devices d
+    JOIN organizations o ON o.id = d.org_id
+  `)) as unknown as DeviceRow[];
+
+  // --- 3. Build the fingerprint set. De-duplicated by (partnerId, kind,
+  //        value) so the batched upsert below never targets the same row
+  //        twice in one statement (Postgres rejects that under
+  //        ON CONFLICT DO UPDATE). Last-observed device wins on collision —
+  //        same tie-break scriptContent.ts uses for its host upserts. -------
+  const byKey = new Map<string, FingerprintRow>();
+  const record = (row: FingerprintRow) => byKey.set(`${row.partnerId}|${row.kind}|${row.value}`, row);
+
+  for (const r of softwareRows) {
+    for (const guid of extractScreenConnectGuids(r.name)) {
+      record({ partnerId: r.partner_id, kind: 'remote_tool_guid', value: guid, deviceId: r.device_id });
+    }
+  }
+
+  for (const r of deviceRows) {
+    const hostname = (r.hostname ?? '').trim().toLowerCase();
+    if (!isDeniedHostname(hostname)) {
+      record({ partnerId: r.partner_id, kind: 'hostname', value: hostname, deviceId: r.id });
+    }
+
+    const ip = (r.last_seen_ip ?? r.enrollment_ip ?? '').trim();
+    if (ip.length > 0) {
+      record({ partnerId: r.partner_id, kind: 'egress_ip', value: ip, deviceId: r.id });
+    }
+  }
+
+  const rows = [...byKey.values()];
+  if (rows.length === 0) return;
+
+  const values = sql.join(
+    rows.map(
+      (r) =>
+        sql`(${r.partnerId}::uuid, ${r.kind}::abuse_endpoint_fingerprint_kind, ${r.value}, ${r.deviceId}::uuid, ${now.toISOString()}::timestamptz, ${now.toISOString()}::timestamptz)`,
+    ),
+    sql`, `,
+  );
+
+  await db.execute(sql`
+    INSERT INTO abuse_endpoint_fingerprints (partner_id, kind, value, device_id, first_seen_at, last_seen_at)
+    VALUES ${values}
+    ON CONFLICT (partner_id, kind, value) DO UPDATE SET
+      last_seen_at = EXCLUDED.last_seen_at,
+      device_id = COALESCE(abuse_endpoint_fingerprints.device_id, EXCLUDED.device_id)
+  `);
+}
+
+export interface RecidivistMatch {
+  partnerId: string;
+  kind: 'remote_tool_guid' | 'hostname' | 'egress_ip';
+  value: string;
+  otherPartnerId: string;
+  otherPartnerName: string;
+  otherPartnerStatus: string;
+}
+
+interface MatchRow {
+  partner_id: string;
+  kind: 'remote_tool_guid' | 'hostname' | 'egress_ip';
+  value: string;
+  other_partner_id: string;
+  other_partner_name: string;
+  other_partner_status: string;
+}
+
+interface ScannedPartnerRow {
+  partner_id: string;
+}
+
+/**
+ * The cross-partner correlation join, entirely in SQL: a corpus value+kind
+ * held by an active/pending partner that is ALSO held by a different partner
+ * whose status is not 'active' (suspended, churned, offboarding, or still
+ * pending). Same-partner rows can never match (the join excludes
+ * af1.partner_id = af2.partner_id), and a suspended<->suspended pair never
+ * fires because af1's partner is restricted to active/pending.
+ *
+ * scannedPartnerIds is every active/pending partner holding ANY corpus row —
+ * independent of whether it matched — so the caller can stale-resolve open
+ * signals for partners that no longer hold matching fingerprints.
+ */
+export async function loadRecidivistMatches(): Promise<{
+  matches: RecidivistMatch[];
+  scannedPartnerIds: string[];
+}> {
+  const matchRows = (await db.execute(sql`
+    SELECT
+      af1.partner_id AS partner_id,
+      af1.kind AS kind,
+      af1.value AS value,
+      af2.partner_id AS other_partner_id,
+      p2.name AS other_partner_name,
+      p2.status AS other_partner_status
+    FROM abuse_endpoint_fingerprints af1
+    JOIN partners p1 ON p1.id = af1.partner_id
+    JOIN abuse_endpoint_fingerprints af2
+      ON af2.kind = af1.kind
+      AND af2.value = af1.value
+      AND af2.partner_id != af1.partner_id
+    JOIN partners p2 ON p2.id = af2.partner_id
+    WHERE p1.status IN ('active', 'pending')
+      AND p2.status != 'active'
+  `)) as unknown as MatchRow[];
+
+  const scannedRows = (await db.execute(sql`
+    SELECT DISTINCT af.partner_id
+    FROM abuse_endpoint_fingerprints af
+    JOIN partners p ON p.id = af.partner_id
+    WHERE p.status IN ('active', 'pending')
+  `)) as unknown as ScannedPartnerRow[];
+
+  const matches: RecidivistMatch[] = matchRows.map((r) => ({
+    partnerId: r.partner_id,
+    kind: r.kind,
+    value: r.value,
+    otherPartnerId: r.other_partner_id,
+    otherPartnerName: r.other_partner_name,
+    otherPartnerStatus: r.other_partner_status,
+  }));
+
+  return {
+    matches,
+    scannedPartnerIds: scannedRows.map((r) => r.partner_id),
+  };
+}

--- a/apps/api/src/services/abuseSignals/sweep.test.ts
+++ b/apps/api/src/services/abuseSignals/sweep.test.ts
@@ -12,6 +12,9 @@ const {
   loadScriptIndicators,
   loadBillingIdentityAggregates,
   computeBillingIdentitySignals,
+  syncEndpointFingerprints,
+  loadRecidivistMatches,
+  computeRecidivistSignals,
   persistSignals,
   markDelivered,
   sendOpsAlert,
@@ -26,6 +29,9 @@ const {
   loadScriptIndicators: vi.fn(),
   loadBillingIdentityAggregates: vi.fn(),
   computeBillingIdentitySignals: vi.fn(),
+  syncEndpointFingerprints: vi.fn(),
+  loadRecidivistMatches: vi.fn(),
+  computeRecidivistSignals: vi.fn(),
   persistSignals: vi.fn(),
   markDelivered: vi.fn(),
   sendOpsAlert: vi.fn(),
@@ -47,6 +53,11 @@ vi.mock('./invariants', () => ({ computeInvariantSignals }));
 vi.mock('./heuristics', () => ({ loadPartnerAggregates, computeHeuristicSignals, loadHostnameIndicators }));
 vi.mock('./scriptContent', () => ({ loadScriptFindings, computeScriptSignals, loadScriptIndicators }));
 vi.mock('./billingIdentity', () => ({ loadBillingIdentityAggregates, computeBillingIdentitySignals }));
+vi.mock('./recidivistEndpoint', () => ({
+  syncEndpointFingerprints,
+  loadRecidivistMatches,
+  computeRecidivistSignals,
+}));
 vi.mock('./persistence', () => ({ persistSignals, markDelivered }));
 vi.mock('../opsAlerts', () => ({ sendOpsAlert, isOpsAlertingConfigured: vi.fn(() => true) }));
 vi.mock('../abuseMetrics', () => ({ recordAbuseSignalFired, recordAbuseSweepRun: vi.fn() }));
@@ -101,6 +112,9 @@ beforeEach(() => {
     scannedPartnerIds: [],
   });
   computeBillingIdentitySignals.mockReturnValue([]);
+  syncEndpointFingerprints.mockResolvedValue(undefined);
+  loadRecidivistMatches.mockResolvedValue({ matches: [], scannedPartnerIds: [] });
+  computeRecidivistSignals.mockReturnValue([]);
   persistSignals.mockResolvedValue({ toNotify: [] });
   markDelivered.mockResolvedValue(undefined);
 });
@@ -229,5 +243,35 @@ describe('runAbuseSweep', () => {
     expect(result.fired).toBe(1);
     const persisted = persistSignals.mock.calls[0]![0] as ComputedSignal[];
     expect(persisted).toContainEqual(scriptSignal);
+  });
+
+  it('includes computeRecidivistSignals output in the persisted signal set', async () => {
+    const recidivistSignal: ComputedSignal = {
+      partnerId: 'pR',
+      signalKey: 'rmm.recidivist_endpoint',
+      score: 100,
+      severity: 'alert',
+      evidence: {},
+    };
+    computeRecidivistSignals.mockReturnValue([recidivistSignal]);
+
+    const result = await runAbuseSweep();
+
+    expect(result.fired).toBe(1);
+    const persisted = persistSignals.mock.calls[0]![0] as ComputedSignal[];
+    expect(persisted).toContainEqual(recidivistSignal);
+  });
+
+  it('unions recidivist-scanned partner ids into evaluatedPartnerIds so recidivist signals can stale-resolve', async () => {
+    loadPartnerAggregates.mockResolvedValue([agg({ partnerId: 'pA' })]);
+    loadRecidivistMatches.mockResolvedValue({
+      matches: [],
+      scannedPartnerIds: ['pA', 'pRecidivist'],
+    });
+
+    await runAbuseSweep();
+
+    const evaluatedPartnerIds = persistSignals.mock.calls[0]![2] as Set<string>;
+    expect([...evaluatedPartnerIds].sort()).toEqual(['pA', 'pRecidivist']);
   });
 });

--- a/apps/api/src/services/deviceDeletion.ts
+++ b/apps/api/src/services/deviceDeletion.ts
@@ -65,6 +65,16 @@ export async function deleteDeviceCascade(
 
   // Tenant business records (tickets, support_sessions): preserve history,
   // detach the device.
+  //
+  // For abuse_endpoint_fingerprints specifically, this UPDATE is a structural
+  // no-op: it's a system-only-RLS corpus table, and this cascade runs inside
+  // the caller's tenant-scoped request context, so the tenant policy filters
+  // every row out before the UPDATE ever sees one. The real detach happens
+  // via the column's `device_id` FK, declared ON DELETE SET NULL — that fires
+  // unconditionally at the DB layer once the device row below is deleted, no
+  // RLS context involved. Listed here anyway for the single detach-tables
+  // contract (getDeviceCascadeDeleteTables et al.), not because this line
+  // does the work for that table.
   for (const detachTable of DEVICE_DETACH_DEVICE_ID_TABLES) {
     await tx.execute(sql`UPDATE ${sql.identifier(detachTable)} SET device_id = NULL WHERE device_id = ${deviceId}`);
   }

--- a/docs/superpowers/plans/security-auth/2026-08-15-recidivist-endpoint-detection.md
+++ b/docs/superpowers/plans/security-auth/2026-08-15-recidivist-endpoint-detection.md
@@ -1,0 +1,104 @@
+# Recidivist-endpoint detection — implementation plan
+
+**Spec (binding authority):** `docs/superpowers/specs/security-auth/2026-08-14-recidivist-endpoint-detection-design.md`
+**Branch:** `ToddHebebrand/recidivist-endpoint` (off main `835f7eb3d`)
+
+## Global Constraints
+
+- **Signal key:** `rmm.recidivist_endpoint`. New table: `abuse_endpoint_fingerprints`. New enum: `abuse_endpoint_fingerprint_kind` with values `'remote_tool_guid' | 'hostname' | 'egress_ip'`.
+- **Config keys and defaults** (added to `SIGNAL_DEFAULTS` in `apps/api/src/services/abuseSignals/config.ts`):
+  - `'rmm.recidivist_endpoint.fingerprint_score': 100`
+  - `'rmm.recidivist_endpoint.hostname_ip_score': 90`
+  - `'rmm.recidivist_endpoint.hostname_score': 60`
+  - `'rmm.recidivist_endpoint.ip_score': 40`
+- **Score = max of matched axes, never sum.** A partner matching fingerprint + hostname + ip scores 100, not 190.
+- **No age decay.** Follow the `computeScriptSignals` precedent: the scorer takes no partner age and no clock. Add a comment stating why (a re-established aged account is more suspicious, not less).
+- **Direction rule:** a signal fires ONLY on a partner whose status is `'active'` or `'pending'`, matched against corpus rows from a DIFFERENT partner whose status is NOT `'active'` (suspended/churned/etc.). Suspended↔suspended pairs produce no signal. Same-partner matches never fire.
+- **Extraction is ScreenConnect-only in v1:** pattern `/ScreenConnect Client \((\p{Hex_Digit}{16})\)/` — concretely `/ScreenConnect Client \(([0-9a-f]{16})\)/` against `software_inventory.name`. Do NOT ship the LogMeIn pattern (spec: unbacktested patterns don't ship at score 100).
+- **Hostname deny-list** (never recorded in the corpus as `hostname` rows): empty/blank, `localhost`, and any hostname starting `WIN-` shorter than 12 characters total.
+- **`egress_ip` corpus rows are recorded** (from `devices.last_seen_ip`, falling back to `devices.enrollment_ip`) but NEVER produce a signal alone — the `ip` axis only exists to upgrade `hostname` (60) to `hostname_ip` (90). An ip-only match produces no ComputedSignal in v1 (the 40 default is reserved; do not emit at it).
+- **Retention: indefinite, deliberately** — record that decision in the migration header comment.
+- **RLS: forced, system-only policy**, byte-for-byte pattern of `2026-07-25-abuse-script-hosts.sql` (`current_setting('breeze.scope', true) = 'system'`, `pg_policies` existence guard). All access via the sweep's existing system DB context.
+- **Migration filename must sort AFTER `2026-08-22-device-script-secret-env-capability.sql`** — use `2026-08-23-abuse-endpoint-fingerprints.sql`. Idempotent throughout (`IF NOT EXISTS` / `DO $$ ... duplicate_object`), no inner `BEGIN;`/`COMMIT;`.
+- **Registration ruling (supersedes spec checklist item 4):** the table registers in `DEVICE_DETACH_DEVICE_ID_TABLES` (`apps/api/src/routes/devices/core.ts`), NOT `CORE_DEVICE_CASCADE_DELETE_TABLES`. The FK is `device_id ... ON DELETE SET NULL` and the spec's storage rationale requires corpus rows to survive device deletion; cascade-deleting them would destroy exactly the history the detector depends on. Follow whatever handling the device hard-delete route applies to the existing detach tables (`support_sessions`, `tickets`) so `cascadeDelete.test.ts` passes.
+- **rls-coverage registration:** add `abuse_endpoint_fingerprints` to BOTH allowlists in `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` where `abuse_script_hosts` appears (~lines 57–58 and ~91–92), with a comment in the same style (system-only, operator corpus, partners must never read it).
+- No `org_id` column → no org-cascade or export-policy registration required.
+- Tests live alongside sources. Match existing file idioms exactly (`heuristics.test.ts`, `scriptContent.ts` loader style with raw `db.execute` SQL, `sweep.test.ts` mock style).
+- Run `pnpm --filter @breeze/api test` for unit suites. Integration suites need a real DB and are validated by CI; write them to the existing patterns in `apps/api/src/__tests__/integration/`.
+
+## Task 1 — Migration, Drizzle schema, tenancy registrations
+
+Files:
+- NEW `apps/api/migrations/2026-08-23-abuse-endpoint-fingerprints.sql`
+- `apps/api/src/db/schema/abuseSignals.ts` (add `abuseEndpointFingerprints` table + `abuseEndpointFingerprintKind` enum, modeled on `abuseScriptHosts`)
+- `apps/api/src/routes/devices/core.ts` (`DEVICE_DETACH_DEVICE_ID_TABLES` — see Global Constraints ruling; mirror whatever per-table handling the delete route needs)
+- `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` (both allowlists)
+
+Migration content (model: `2026-07-25-abuse-script-hosts.sql`):
+
+```sql
+DO $$ BEGIN
+  CREATE TYPE abuse_endpoint_fingerprint_kind AS ENUM ('remote_tool_guid', 'hostname', 'egress_ip');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS abuse_endpoint_fingerprints (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id    uuid NOT NULL REFERENCES partners(id) ON DELETE CASCADE,
+  kind          abuse_endpoint_fingerprint_kind NOT NULL,
+  value         varchar(255) NOT NULL,
+  device_id     uuid REFERENCES devices(id) ON DELETE SET NULL,
+  first_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at  timestamptz NOT NULL DEFAULT now()
+);
+```
+Plus: unique index on `(partner_id, kind, value)`, index on `(kind, value)`, forced RLS + system-only policy (existence-guarded), header comment covering: why the corpus outlives devices, the GDPR boundary (partner hard-delete still cascades), and the deliberate indefinite retention.
+
+Verify: `pnpm --filter @breeze/api test -- autoMigrate` (naming/ordering test), `cascadeDelete.test.ts` (device coverage contract — this is the one that fails if the detach registration is wrong), typecheck via the api test run.
+
+## Task 2 — Corpus extraction + correlation loader (`recidivistEndpoint.ts`)
+
+NEW file `apps/api/src/services/abuseSignals/recidivistEndpoint.ts` + NEW `recidivistEndpoint.test.ts`, following the `scriptContent.ts` loader idiom (raw SQL via `db.execute`, exported pure helpers for tests).
+
+Two exported functions:
+
+1. `syncEndpointFingerprints(now: Date): Promise<void>` — refresh the corpus:
+   - `remote_tool_guid`: scan `software_inventory.name` joined through devices→organizations for the ScreenConnect pattern; upsert one row per (partner, guid) with `device_id` of the observing device; bump `last_seen_at` on conflict (`ON CONFLICT (partner_id, kind, value) DO UPDATE SET last_seen_at = EXCLUDED.last_seen_at, device_id = COALESCE(abuse_endpoint_fingerprints.device_id, EXCLUDED.device_id)`).
+   - `hostname`: from `devices.hostname` (lowercased for value stability), applying the deny-list from Global Constraints.
+   - `egress_ip`: from `devices.last_seen_ip` (fallback `enrollment_ip`), skipping NULL/empty.
+   - Full-scan each sweep is acceptable at current fleet size (~hundreds of devices); no high-water mark in v1. Say so in a comment.
+2. `loadRecidivistMatches(): Promise<RecidivistMatch[]>` — the correlation join, entirely in SQL: for each corpus value+kind held by an `active`/`pending` partner where the SAME value+kind is held by a DIFFERENT partner whose status != 'active', return `{ partnerId, kind, value, otherPartnerId, otherPartnerName, otherPartnerStatus }`. Exclude self-pairs. Also return `scannedPartnerIds`: every active/pending partner that holds ANY corpus row (needed for stale-resolution).
+
+Extraction regex + deny-list live as exported pure helpers (`extractScreenConnectGuids(name: string)`, `isDeniedHostname(h: string)`) with direct unit tests. Loader SQL paths are tested with the mocked-`db` style used by `sweep.test.ts`/`digest.test.ts` (mock `db.execute`, assert row-shaping), not against live PG — the live behavior is Task 4's job.
+
+## Task 3 — Scorer + config + sweep wiring
+
+Files: NEW scorer in `recidivistEndpoint.ts` (same file as Task 2), `config.ts`, `index.ts` (`runAbuseSweep`), `sweep.test.ts`, `config.test.ts` if it asserts key inventory.
+
+- `computeRecidivistSignals(matches: RecidivistMatch[], cfg: SignalConfig): ComputedSignal[]` — pure, no clock, no age. Group matches by partnerId; per partner determine matched axes:
+  - any `remote_tool_guid` match → `fingerprint` axis (score `fingerprint_score`)
+  - a `hostname` match AND an `egress_ip` match **against the same other-partner** → `hostname_ip` axis
+  - `hostname` match alone → `hostname` axis
+  - `egress_ip` alone → NO signal (v1)
+  - score = max of matched axis scores; severity via `scoreToSeverity(score, cfg)`.
+  - evidence: `{ axes: [...], matches: [{kind, value, otherPartnerName, otherPartnerStatus}...] }` capped to the first 10 matches.
+- `config.ts`: add the four defaults under a comment block explaining the axis scores and citing the 10/10-US + 1/1-EU zero-FP backtest; note `ip_score` is reserved/unemitted in v1.
+- `index.ts`: inside the existing `runSystemDbCompute` block call `syncEndpointFingerprints(now)` then `loadRecidivistMatches()`; spread `...computeRecidivistSignals(recidivist.matches, cfg)` into `computed` with a no-decay comment matching the script/billing ones; add `recidivist.scannedPartnerIds` to `evaluatedPartnerIds` so open rows stale-resolve when the evidence disappears.
+- `sweep.test.ts`: mock the new module like `scriptContent` is mocked (empty defaults in `beforeEach`); one test that a computed recidivist signal flows through to `persistSignals`; one that its scannedPartnerIds join the evaluated set.
+- Scorer unit tests (in `recidivistEndpoint.test.ts`): each axis; max-not-sum on a partner matching all three; hostname+ip across *different* other-partners stays at `hostname` 60 (the 90 axis requires the same counterpart); ip-only emits nothing; severity mapping at defaults (100→alert, 90→alert, 60→watch); override respected via `loadSignalConfig` config injection.
+
+Note: the direction rule (active-side only, non-active counterpart) is enforced in Task 2's SQL — the scorer trusts its input. One scorer test documents this contract by asserting the scorer emits whatever matches it is given (no status re-checking).
+
+## Task 4 — Integration test against real Postgres
+
+NEW `apps/api/src/__tests__/integration/recidivistEndpoint.integration.test.ts`, modeled on the existing abuse integration suites (find the one exercising `partner_abuse_signals` persistence / `abuse_script_hosts` and copy its setup idiom, incl. migration replay and `withSystemDbAccessContext`).
+
+Scenarios (spec §Verification):
+1. Seed partner A (suspended) and partner B (active), each with an org+device; insert `software_inventory` rows on both devices carrying `ScreenConnect Client (aabbccdd11223344)`. Run `syncEndpointFingerprints` + `loadRecidivistMatches` + `computeRecidivistSignals` (or `runAbuseSweep` with ops-alerting unconfigured): assert **exactly one** signal row, on B, key `rmm.recidivist_endpoint`, score 100, severity alert.
+2. Same seed but both partners `active`: assert **zero** signals (backtest-replay assertion).
+3. Suspended↔suspended: zero signals.
+4. Hostname-only reuse (shared hostname `DESKTOP-ZZ9XY7Q`, distinct IPs, no GUID): score 60 watch on the active partner; then add matching `egress_ip` rows (same counterpart) and assert 90.
+5. RLS: as `breeze_app` without system scope, `SELECT` on `abuse_endpoint_fingerprints` returns zero rows / insert is rejected (match the `partner_abuse_signals` RLS lockout test idiom).
+
+## Explicitly out of scope
+
+Cross-region correlation; LogMeIn/other extraction patterns; any UI; retention job; backfill of historical suspended-partner fingerprints beyond what the first sweep's full scan captures (it scans current `software_inventory`, which still holds the suspended partners' rows — sufficient per the backtest).

--- a/docs/superpowers/specs/security-auth/2026-08-14-recidivist-endpoint-detection-design.md
+++ b/docs/superpowers/specs/security-auth/2026-08-14-recidivist-endpoint-detection-design.md
@@ -1,0 +1,209 @@
+# Recidivist-endpoint detection — design
+
+**Status:** proposed
+**Date:** 2026-08-14
+**Author:** abuse-signal round, 2026-08-14
+**Supersedes nothing. Extends:** `2026-07-11-signup-abuse-detection-design.md`
+
+## Problem
+
+An operator whose partner account is suspended re-registers and re-enrols **the
+same endpoints** under a fresh account. Every detector we ship today is blind to
+this, because each one scores a partner against *its own* devices, scripts, or
+card in isolation. Nothing correlates a new partner against the corpus of
+already-suspended ones.
+
+This is not hypothetical and it is not rare. It is the single most repeated shape
+in our incident history:
+
+| Date | Old (suspended) | New | How it was found |
+|---|---|---|---|
+| 2026-08-05 | Milofsky | palletessencehub | shared ScreenConnect thumbprint, by hand |
+| 2026-08-11 | Remon Sino | Tua Tops | shared ScreenConnect thumbprint, by hand |
+| 2026-08-14 | SSo (08-03) | zby | shared thumbprint **and** hostname **and** IP, by hand |
+
+In the 2026-08-14 case the operator re-enrolled the *identical victim machine*
+— hostname `DESKTOP-OK9NTO7`, egress `107.147.228.141`, ScreenConnect instance
+`3a1a6364add6e7bb` — ten days after SSo was contained. The only signal that
+fired was `rmm.session_intensity` at score 65 (`watch`), which is **below the
+alert threshold and was never delivered**. We learned about it only because a
+human ran the correlation query manually.
+
+`abuse_screenconnect_thumbprint_correlation` has recorded for weeks that this
+query is "decisive both ways; clears FPs AND finds unflagged accounts; still
+manual". This spec ends the "still manual".
+
+## Backtest
+
+Run against both prod regions on 2026-08-14, over the entire historical corpus.
+
+**Rule A — shared remote-tool instance fingerprint.** Extract the ScreenConnect
+instance GUID from `software_inventory.name` (`ScreenConnect Client (<16 hex>)`)
+and join partners on it.
+
+- **US: 10 distinct fingerprints shared across partners.** Every one of the
+  resulting pairs is suspended↔suspended: Pluto↔Oneal Studio (×3 fingerprints),
+  pluto↔Pluto (×3), sarahcomputersllc↔HillComputerTechLLC, Remon Sino↔Tua Tops,
+  cibrum↔palletessencehub, Coastal Titles↔Jzac Legal Group.
+- **EU: 1 shared fingerprint** — SSo (suspended) ↔ zby (active). The live case.
+- **False positives: zero.** Not one legitimate partner appears anywhere in the
+  cross-partner fingerprint set, in either region.
+
+That precision is not luck. A ScreenConnect instance GUID identifies one
+*operator-controlled server instance*. Two unrelated MSPs never share one; the
+only way the same GUID lands under two partners is that the same operator
+planted it.
+
+**Rule B — shared device hostname.** Four cross-partner hostnames total across
+both regions: `VM-1128dd88-…` (Coastal Titles↔Jzac Legal, both suspended),
+`HY-53494` (Boerum Hill↔King's Highway, both suspended), `DESKTOP-OK9NTO7`
+(SSo↔zby), and `DESKTOP-5KPVT1P` (concretcimento [suspended] ↔ **loja do
+mecanico [active]**).
+
+The last one is the proof of the "finds unflagged accounts" claim: it surfaced a
+surviving sibling of the suspended concretcimento operator (login
+`financeiro2@concretcimento.com.br`, same domain, created 07-02, never flagged)
+that the 08-12 containment missed entirely.
+
+**Rule B false positives: zero**, but the sample is small and the mechanism is
+weaker than Rule A — see Scoring.
+
+## Design
+
+### New signal: `rmm.recidivist_endpoint`
+
+Fires on partner P when an endpoint identifier observed under P has previously
+been observed under a **different** partner that is now non-`active`.
+
+Three evidence axes, scored by strength of the underlying mechanism:
+
+| Axis | Score | Severity | Rationale |
+|---|---|---|---|
+| `fingerprint` — shared remote-tool instance GUID | **100** | alert | Dispositive. Identifies one operator-controlled server. 10/10 historical pairs true, 0 FP. |
+| `hostname_ip` — same hostname **and** same `last_seen_ip`/`enrollment_ip` | **90** | alert | Same physical machine on the same line. |
+| `hostname` — same hostname alone | **60** | watch | `DESKTOP-XXXXXXX` has a 7-char random suffix so collisions are unlikely, but generic names (`WIN-…`, `PC`, `SERVER`) collide for real. |
+| `ip` — same egress IP alone | **40** | info | CGNAT and shared-office NAT make this weak on its own. Contributes only as a multiplier on the axes above. |
+
+Score is the **max** of the matched axes, not a sum — the axes are correlated
+(zby matched all three), and summing would just saturate.
+
+**Age decay does not apply.** The existing `rmm.*` heuristics zero out past
+`sweep.young_zero_weight_days` (90d). That is wrong for this signal for the same
+reason it is wrong for the content-based signals (`computeScriptSignals` is
+already exempt): a resold or re-established account is *more* suspicious when
+aged, not less. Follow the `scriptContent.ts` precedent and exempt it.
+
+**Direction matters.** Only fire on the partner that is *currently* active or
+pending. A suspended↔suspended pair is history, not a live lead — record it as
+evidence on the corpus but do not open a signal row nobody can act on. This
+directly avoids the `invariant.inactive_partner_with_agents` noise problem,
+where every suspension manufactures a permanent alert on itself.
+
+### Storage: `abuse_endpoint_fingerprints`
+
+A new cross-partner corpus table, modelled exactly on `abuse_script_hosts`
+(`2026-07-25-abuse-script-hosts.sql`).
+
+```sql
+CREATE TABLE IF NOT EXISTS abuse_endpoint_fingerprints (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id    uuid NOT NULL REFERENCES partners(id) ON DELETE CASCADE,
+  kind          abuse_endpoint_fingerprint_kind NOT NULL,  -- 'remote_tool_guid' | 'hostname' | 'egress_ip'
+  value         varchar(255) NOT NULL,
+  device_id     uuid REFERENCES devices(id) ON DELETE SET NULL,
+  first_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at  timestamptz NOT NULL DEFAULT now()
+);
+```
+
+Unique on `(partner_id, kind, value)`; index on `(kind, value)` for the
+correlation join. Forced RLS with a **system-only** policy, identical to
+`abuse_script_hosts` — partners must never read the corpus, because it would
+reveal what we correlate on.
+
+**Why a table rather than joining `software_inventory` live.** The corpus must
+outlive the devices it came from. When a suspended partner's org is erased or
+its device rows are cascade-deleted, a live join loses exactly the history the
+correlation depends on. `abuse_script_hosts` exists for this precise reason and
+its header comment says so: rows "persist independently of partner status". In
+the zby case the SSo device rows happened to survive only because the
+`self_uninstall` failed and nobody cleaned up — that is luck, not a design we
+should depend on. Note the `ON DELETE CASCADE` on `partner_id` still drops the
+corpus if the *partner* row is hard-deleted; that is the accepted GDPR-erasure
+boundary, same as `abuse_script_hosts`.
+
+### Tenancy registration checklist (new table — do not skip)
+
+Per CLAUDE.md, a new table is not done when RLS passes. `abuse_endpoint_fingerprints`
+has **no `org_id`**, which resolves most of the list, but each row must be
+consciously answered rather than assumed:
+
+1. RLS enabled + forced + system-only policy **in the creating migration**. ✅ as specced.
+2. Register in `rls-coverage.integration.test.ts` — this is a system-scoped
+   table, so it belongs with `partner_abuse_signals` / `abuse_script_hosts` in
+   whichever allowlist those two use, **not** in a tenant shape.
+3. `CORE_ORG_CASCADE_DELETE_ORDER` — **not required**, no `org_id` column.
+4. `CORE_DEVICE_CASCADE_DELETE_TABLES` — **required**, the table has a
+   `device_id` column. This is the one that will get missed.
+5. `CORE_DEVICE_ORG_DENORMALIZED_TABLES` — not required, no denormalised `org_id`.
+6. `CORE_TENANT_EXPORT_POLICY` — not required, not in the org-cascade list.
+
+Confirm 2 and 4 against the live allowlists at implementation time; the
+device-cascade one fails in the **Test API** unit job, so it will catch itself
+if forgotten — the RLS one will not.
+
+### Extraction
+
+Fingerprint extraction runs in the sweep's existing system DB context, alongside
+`loadScriptFindings`. Patterns, most-specific first:
+
+- ScreenConnect / ConnectWise Control: `/ScreenConnect Client \(([0-9a-f]{16})\)/`
+- LogMeIn Resolve: `/LogMeIn Resolve Endpoint (\d{10,})/` — observed as
+  `…Endpoint 7579707059599889961` on the zby victim box. Lower confidence than
+  ScreenConnect; treat as `hostname`-tier (60) until backtested.
+
+Start with ScreenConnect only. It is the one with a 10/10 backtest. Adding
+patterns later is cheap; shipping an untested pattern at score 100 is not.
+
+## Scope boundaries
+
+**Cross-region correlation is out of scope and stays a known gap.** US and EU
+are separate databases; this detector can only correlate within one. zby was
+EU-only, but H and S Electric (US) shared the same operator ASN, and the ring
+was only visible by running the query twice by hand.
+`cross_region_identity_gap_prepositioned_accounts` already tracks this — the
+right fix is a shared correlation corpus, which is a much larger piece of work
+and should not block this one.
+
+**Rule B (hostname) will eventually produce a false positive.** Golden-image
+fleets and MDM-templated names collide legitimately. Mitigations: (a) hostname
+alone caps at 60 = `watch`, never `alert`; (b) exclude a small deny-list of
+degenerate names (`localhost`, `WIN-`-prefixed default names shorter than 12
+chars, empty). Do not attempt to be clever beyond that — the score cap is doing
+the real work.
+
+## Verification
+
+1. Unit tests in `heuristics.test.ts` style: each axis, the max-not-sum rule, the
+   direction rule (no signal on suspended↔suspended), the age-decay exemption.
+2. One integration test against real Postgres that seeds two partners sharing a
+   fingerprint, suspends one, runs the sweep, and asserts exactly one signal row
+   on the *active* partner at score 100.
+3. **Replay the backtest in this document as an integration assertion**: the rule
+   must produce zero hits against a corpus of only-active partners.
+4. Post-deploy, expect it to immediately fire on any surviving pairs — as of
+   2026-08-14 that is `loja do mecanico` (US) via hostname, plus zby (EU) if not
+   yet finalised.
+
+## Open questions
+
+- Should `egress_ip` be recorded in the corpus at all given it never fires alone?
+  Argument for: it is the cheapest way to raise `hostname` 60 → `hostname_ip` 90.
+  Argument against: storing partner egress IPs in a cross-partner corpus is a
+  privacy surface we do not otherwise have. **Recommend recording it**, since
+  `devices.last_seen_ip` and `partners.signup_ip` already persist the same data
+  in less-protected tables.
+- Retention. `abuse_script_hosts` has none. A recidivist operator returning after
+  12 months is still a recidivist, so indefinite retention is defensible, but it
+  should be a deliberate decision rather than an oversight inherited from the
+  script-host table.

--- a/docs/superpowers/specs/security-auth/2026-08-14-recidivist-endpoint-detection-design.md
+++ b/docs/superpowers/specs/security-auth/2026-08-14-recidivist-endpoint-detection-design.md
@@ -61,9 +61,11 @@ both regions: `VM-1128dd88-…` (Coastal Titles↔Jzac Legal, both suspended),
 mecanico [active]**).
 
 The last one is the proof of the "finds unflagged accounts" claim: it surfaced a
-surviving sibling of the suspended concretcimento operator (login
-`financeiro2@concretcimento.com.br`, same domain, created 07-02, never flagged)
-that the 08-12 containment missed entirely.
+surviving sibling of the suspended operator — a login on the *same email domain*
+as the suspended account, created 07-02 and never flagged — that the 08-12
+containment missed entirely. (The address itself is deliberately not reproduced
+here: this repo is public, and `check-customer-pii.sh` blocks real customer
+domains. The concrete identifiers live in the incident record.)
 
 **Rule B false positives: zero**, but the sample is small and the mechanism is
 weaker than Rule A — see Scoring.


### PR DESCRIPTION
Implements `docs/superpowers/specs/security-auth/2026-08-14-recidivist-endpoint-detection-design.md`: a new abuse signal that correlates endpoint fingerprints of active/pending partners against a persistent cross-partner corpus, catching suspended operators who re-enrol the same endpoints under fresh accounts (the shape behind Milofsky→palletessencehub, Remon Sino→Tua Tops, and SSo→zby — all previously found only by hand-run SQL; the backtest across both prod regions is 11/11 shared fingerprints with zero false positives).

## What's in here

- **New table `abuse_endpoint_fingerprints`** (migration `2026-08-23-abuse-endpoint-fingerprints.sql`): system-only forced RLS modeled on `abuse_script_hosts`; corpus rows deliberately outlive the devices they came from (`device_id` FK `ON DELETE SET NULL`); indefinite retention is a recorded decision. Registered in both `rls-coverage` allowlists and `DEVICE_DETACH_DEVICE_ID_TABLES`.
- **Extraction + correlation loader** (`recidivistEndpoint.ts`): per-sweep full scan upserting ScreenConnect instance GUIDs (case-sensitive, ScreenConnect-only in v1 — the 10/10-backtested pattern), lowercased hostnames (deny-list for degenerate names), and egress IPs. Upserts are chunked (500 rows/statement) and capped (10k/sweep) so corpus growth can never take down the sweep. Correlation join enforces the direction rule in SQL: only active/pending partners fire, only against a different, non-active counterpart — suspending an operator manufactures no self-alert.
- **Scorer + sweep wiring**: score = max of matched axes, never sum — fingerprint 100 (alert), hostname+ip vs the same counterpart 90 (alert), hostname alone 60 (watch); egress-ip alone emits nothing. No age decay (a re-established aged account is more suspicious, not less). All four thresholds overridable via `ABUSE_SIGNAL_OVERRIDES`.
- **Integration suite** (executed against live Postgres, 7/7): the spec's scenarios incl. the zero-FP replay (active↔active must produce nothing) and `breeze_app` RLS lockout.

## Notes for review

- The table registers in the **detach** list, not the device-cascade list — the spec's checklist named the cascade list, but cascade-deleting corpus rows would destroy exactly the history the detector exists to keep; the FK's `ON DELETE SET NULL` performs the real detach (comment at the detach loop explains the RLS-inert no-op there).
- Migration is dated `2026-08-23` to sort after the already-shipped `2026-08-22-*` file.
- Follow-ups deliberately not in this PR: evidence-sample ordering by axis relevance, and bounding the pairwise egress-ip self-join under mass-shared CGNAT — both noted in the final review as non-blocking.

## Test plan

- Unit: `abuseSignals` suites 204/204 (chunking/cap tests assert per-statement row bounds, not call counts).
- Integration: `recidivistEndpoint.integration.test.ts` 7/7 against real Postgres; also runs in CI's Integration Tests job.
- Contract: `autoMigrate`, `cascadeDelete`, `moveOrg.coverage` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)