### PR TITLE
fix(api): paginate MCP get_quote blocks so large quotes don't overflow (#3485)

### DIFF
--- a/apps/api/src/services/aiAgentSdkTools.mcpCoverage.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.mcpCoverage.test.ts
@@ -318,3 +318,38 @@ describe('vulnerability tools reach the chat model (#2605)', () => {
     expect(description).toContain('get_device_vulnerabilities');
   });
 });
+
+/**
+ * #3485: get_quote gained block-pagination params, but the model only sees the
+ * shape declared in `tool('get_quote', ...)` inside createBreezeMcpServer. If
+ * that shape drifts from the canonical `toolInputSchemas` entry, the SDK strips
+ * the new params before the handler runs — the exact gap that shipped here.
+ */
+describe("get_quote's MCP declaration matches its canonical schema (#3485)", () => {
+  it('declares exactly the params the canonical get_quote schema validates', () => {
+    // Extract just the shape object — the 3rd argument to tool() — between the
+    // description and makeHandler, so comments/description text can't be mistaken
+    // for a declared key.
+    const shape = SOURCE.match(
+      /tool\(\s*'get_quote',[\s\S]*?registryDescription\('get_quote'\),[\s\S]*?\{([\s\S]*?)\},\s*makeHandler\('get_quote'/,
+    );
+    expect(shape, "tool('get_quote', registryDescription(...), { ... }) not found").not.toBeNull();
+    const shapeBody = shape![1]
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('//'))
+      .join('\n');
+    const declaredKeys = [...shapeBody.matchAll(/^\s*(\w+):/gm)].map((m) => m[1]).sort();
+
+    const canonicalKeys = Object.keys(
+      (toolInputSchemas['get_quote'] as z.ZodObject<z.ZodRawShape>).shape,
+    );
+    // Sanity: the canonical schema really did gain the pagination params (#3485).
+    expect(canonicalKeys).toEqual(
+      expect.arrayContaining(['quoteId', 'blocksOffset', 'blocksLimit', 'includeBlockContent']),
+    );
+    // Exact, bidirectional parity: the MCP declaration must not drift from the
+    // canonical schema in EITHER direction (a param the SDK strips, or one it
+    // advertises that nothing validates).
+    expect(declaredKeys).toEqual([...canonicalKeys].sort());
+  });
+});

--- a/apps/api/src/services/aiAgentSdkTools.mcpCoverage.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.mcpCoverage.test.ts
@@ -334,11 +334,14 @@ describe("get_quote's MCP declaration matches its canonical schema (#3485)", () 
       /tool\(\s*'get_quote',[\s\S]*?registryDescription\('get_quote'\),[\s\S]*?\{([\s\S]*?)\},\s*makeHandler\('get_quote'/,
     );
     expect(shape, "tool('get_quote', registryDescription(...), { ... }) not found").not.toBeNull();
-    const shapeBody = shape![1]
+    const shapeBody = (shape![1] ?? '')
       .split('\n')
       .filter((line) => !line.trim().startsWith('//'))
       .join('\n');
-    const declaredKeys = [...shapeBody.matchAll(/^\s*(\w+):/gm)].map((m) => m[1]).sort();
+    const declaredKeys = [...shapeBody.matchAll(/^\s*(\w+):/gm)]
+      .map((m) => m[1])
+      .filter((k): k is string => k !== undefined)
+      .sort();
 
     const canonicalKeys = Object.keys(
       (toolInputSchemas['get_quote'] as z.ZodObject<z.ZodRawShape>).shape,

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -2176,9 +2176,17 @@ export function createBreezeMcpServer(
 
     tool(
       'get_quote',
-      'Get the full view of one quote/proposal by id: header (with derived totals, deposit and category breakdown), content blocks, and line items — the same view the web UI shows. Read-only.',
+      // Single source of truth: the registry definition (aiToolsQuotes.ts) carries
+      // the pagination guidance, so the MCP description can't drift from it.
+      registryDescription('get_quote'),
       {
         quoteId: uuid,
+        // Large quotes exceed the MCP output cap — let the model page the content
+        // blocks or fetch a metadata-only overview (#3485). Must mirror the
+        // canonical get_quote schema in aiToolSchemas.ts.
+        blocksOffset: z.number().int().min(0).optional(),
+        blocksLimit: z.number().int().min(1).max(100).optional(),
+        includeBlockContent: z.boolean().optional(),
       },
       makeHandler('get_quote', getAuth, onPreToolUse, onPostToolUse)
     ),

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -304,6 +304,11 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
 
   get_quote: z.object({
     quoteId: uuid,
+    // Large quotes (many content blocks) can exceed the MCP output cap. These
+    // let the caller page the blocks or fetch a block-metadata overview (#3485).
+    blocksOffset: z.number().int().min(0).optional(),
+    blocksLimit: z.number().int().min(1).max(100).optional(),
+    includeBlockContent: z.boolean().optional(),
   }),
 
   list_organizations: z.object({

--- a/apps/api/src/services/aiToolsQuotes.test.ts
+++ b/apps/api/src/services/aiToolsQuotes.test.ts
@@ -467,6 +467,79 @@ describe('list_quotes / get_quote read tools (#2361)', () => {
     expect(JSON.parse(out)).toEqual({ error: 'Quote not found', code: 'QUOTE_NOT_FOUND' });
   });
 
+  // #3485: large quotes overflow the MCP output cap. get_quote can page its
+  // content blocks and return a metadata-only overview.
+  const multiBlockQuote = {
+    quote: { id: 'quote-1', status: 'draft' },
+    blocks: [
+      { id: 'b1', quoteId: 'quote-1', blockType: 'heading', content: { text: 'H', level: 2 }, sortOrder: 0 },
+      { id: 'b2', quoteId: 'quote-1', blockType: 'rich_text', content: { html: '<p>a</p>' }, sortOrder: 1 },
+      { id: 'b3', quoteId: 'quote-1', blockType: 'rich_text', content: { html: '<p>b</p>' }, sortOrder: 2 },
+      { id: 'b4', quoteId: 'quote-1', blockType: 'callout', content: { text: 'c' }, sortOrder: 3 },
+      { id: 'b5', quoteId: 'quote-1', blockType: 'table', content: { columns: [], rows: [] }, sortOrder: 4 },
+    ],
+    lines: [],
+  };
+
+  it('get_quote pages content blocks with blocksOffset/blocksLimit and reports pagination', async () => {
+    vi.mocked(quoteService.getQuote).mockResolvedValueOnce(multiBlockQuote as never);
+
+    const out = await getTool('get_quote').handler(
+      { quoteId: 'quote-1', blocksOffset: 1, blocksLimit: 2 },
+      auth,
+    );
+    const parsed = JSON.parse(out);
+
+    expect(parsed.blocks.map((b: { id: string }) => b.id)).toEqual(['b2', 'b3']);
+    expect(parsed.blocks[0].content).toBeDefined();
+    expect(parsed.blocksPagination).toMatchObject({
+      total: 5,
+      offset: 1,
+      limit: 2,
+      returned: 2,
+      hasMore: true,
+      includeBlockContent: true,
+    });
+  });
+
+  it('get_quote with includeBlockContent:false returns block metadata only (compact overview)', async () => {
+    vi.mocked(quoteService.getQuote).mockResolvedValueOnce(multiBlockQuote as never);
+
+    const out = await getTool('get_quote').handler(
+      { quoteId: 'quote-1', includeBlockContent: false },
+      auth,
+    );
+    const parsed = JSON.parse(out);
+
+    expect(parsed.blocks).toHaveLength(5);
+    expect(parsed.blocks[0].content).toBeUndefined();
+    expect(parsed.blocks[0].blockType).toBe('heading');
+    expect(parsed.blocksPagination).toMatchObject({
+      total: 5,
+      returned: 5,
+      hasMore: false,
+      includeBlockContent: false,
+    });
+  });
+
+  it('get_quote default is backward compatible: all blocks, full content, plus pagination metadata', async () => {
+    vi.mocked(quoteService.getQuote).mockResolvedValueOnce(multiBlockQuote as never);
+
+    const out = await getTool('get_quote').handler({ quoteId: 'quote-1' }, auth);
+    const parsed = JSON.parse(out);
+
+    expect(parsed.blocks).toHaveLength(5);
+    expect(parsed.blocks[4].content).toBeDefined();
+    expect(parsed.blocksPagination).toMatchObject({
+      total: 5,
+      offset: 0,
+      limit: null,
+      returned: 5,
+      hasMore: false,
+      includeBlockContent: true,
+    });
+  });
+
   it('update with an empty patch is rejected with VALIDATION_ERROR and does not touch the quote (#2361)', async () => {
     const out = await getTool().handler({ action: 'update', quoteId: 'quote-1', patch: {} }, auth);
 

--- a/apps/api/src/services/aiToolsQuotes.ts
+++ b/apps/api/src/services/aiToolsQuotes.ts
@@ -165,11 +165,20 @@ export function registerQuoteTools(aiTools: Map<string, AiTool>): void {
       name: 'get_quote',
       description:
         'Get the full view of one quote/proposal by id: header (with derived totals, deposit and category ' +
-        'breakdown), content blocks, and line items — the same view the web UI shows. Read-only.',
+        'breakdown), content blocks, and line items — the same view the web UI shows. Read-only. ' +
+        'Large quotes can exceed the output limit: page the content blocks with blocksOffset/blocksLimit, ' +
+        'or pass includeBlockContent:false first for a lightweight block overview (types + order, no content). ' +
+        'A blocksPagination object reports total/returned/hasMore.',
       input_schema: {
         type: 'object' as const,
         properties: {
-          quoteId: { type: 'string', description: 'Quote UUID' }
+          quoteId: { type: 'string', description: 'Quote UUID' },
+          blocksOffset: { type: 'number', description: 'Index of the first content block to return (default 0)' },
+          blocksLimit: { type: 'number', description: 'Max content blocks to return (1-100). Omit for all from the offset.' },
+          includeBlockContent: {
+            type: 'boolean',
+            description: 'Default true. false returns block metadata only (id/type/order, no content) — a compact overview of a large quote.'
+          }
         },
         required: ['quoteId']
       }
@@ -179,7 +188,34 @@ export function registerQuoteTools(aiTools: Map<string, AiTool>): void {
         return validationErrorJson('Missing required parameter: quoteId');
       }
       try {
-        return JSON.stringify(await getQuote(String(input.quoteId), actorFromAuth(auth)));
+        const full = await getQuote(String(input.quoteId), actorFromAuth(auth));
+        const allBlocks = full.blocks;
+        const offset = typeof input.blocksOffset === 'number' ? input.blocksOffset : 0;
+        const limit = typeof input.blocksLimit === 'number' ? input.blocksLimit : undefined;
+        const pagedBlocks =
+          limit != null ? allBlocks.slice(offset, offset + limit) : allBlocks.slice(offset);
+        // Default keeps the full block content (backward compatible); false drops
+        // the heavy `content` field for a compact metadata overview.
+        const includeBlockContent = input.includeBlockContent !== false;
+        const blocks = includeBlockContent
+          ? pagedBlocks
+          : pagedBlocks.map((block) => {
+              const withoutContent: Record<string, unknown> = { ...block };
+              delete withoutContent.content;
+              return withoutContent;
+            });
+        return JSON.stringify({
+          ...full,
+          blocks,
+          blocksPagination: {
+            total: allBlocks.length,
+            offset,
+            limit: limit ?? null,
+            returned: pagedBlocks.length,
+            hasMore: offset + pagedBlocks.length < allBlocks.length,
+            includeBlockContent,
+          },
+        });
       } catch (err) {
         const json = serviceErrorToJson(err) ?? zodErrorToJson(err);
         if (json) return json;


### PR DESCRIPTION
Closes #3485.

## Problem

The MCP `get_quote` tool returns the entire quote — header + **all** content blocks + line items — as one JSON string. A large quote (many `rich_text` / `table` / `image` blocks) exceeds the MCP per-call output cap and truncates, making the tool unusable. Same class as #3329 (`search_logs`, fixed in #3368).

## Fix

Add **optional** block pagination to `get_quote`:

- `blocksOffset` / `blocksLimit` — page the content blocks
- `includeBlockContent: false` — a compact **metadata-only overview** (id / type / order, no heavy content) of a large quote
- a `blocksPagination` `{ total, offset, limit, returned, hasMore, includeBlockContent }` so the model can discover there's more

Default (no params) is **unchanged and backward compatible**: all blocks, full content, plus the new metadata key. Line items stay unpaged — blocks carry the heavy content; lines are small — a deliberate scope boundary.

## The part an adversarial Codex pass caught

There are **two** `get_quote` surfaces: the internal execution registry (`aiToolsQuotes.ts`) and the **production MCP declaration** in `aiAgentSdkTools.ts` — the one the chat model actually sees. My first cut updated only the registry, so the MCP declaration still advertised just `quoteId` and the SDK stripped the new params before the handler. Fixed: the MCP declaration now carries all three params and uses `registryDescription('get_quote')` as the single source of truth for its description.

A new **contract test** extracts the `tool('get_quote', ...)` shape from source and asserts **bidirectional exact-key parity** with the canonical `toolInputSchemas` entry, so the two surfaces can't drift again in either direction (control-verified: removing a param from either side reds it).

## Review & testing

Two adversarial Codex passes (the first found the missing MCP surface; the second confirmed the runtime fix is correct and safe, and prompted the stronger bidirectional contract test). Params confirmed to flow SDK → `makeHandler` → `executeTool` → handler unchanged; retrieval still goes through `getQuote(actorFromAuth(auth))` (tenancy unchanged); content-strip clones each block (no mutation).

`tsc --noEmit` (apps/api) clean; vitest `aiToolsQuotes` + `aiAgentSdkTools.mcpCoverage` + `registryParity` **66/66**; eslint clean. No schema/migration changes.

https://claude.ai/code/session_0187oKb4Pw7KTXT2Lsvq7hUr
