### PR TITLE
docs(deploy): add the missing /portal proxy to the nginx TLS example (#3229)

### DIFF
--- a/apps/docs/src/content/docs/deploy/tls.mdx
+++ b/apps/docs/src/content/docs/deploy/tls.mdx
@@ -103,6 +103,28 @@ If you prefer nginx, here's an equivalent configuration:
             proxy_pass http://127.0.0.1:3001;
         }
 
+        # Customer portal (Astro SSR on :4322 under the /portal base path). This
+        # mirrors Caddy's `path /portal /portal/*`: an exact match for /portal
+        # plus a prefix match for everything under it (so it can't also grab an
+        # unrelated path like /portalX). The portal emits /portal-prefixed URLs,
+        # so keep the prefix — no trailing slash on proxy_pass. Its API calls
+        # stay on the /api/ block above.
+        location = /portal {
+            proxy_pass http://127.0.0.1:4322;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /portal/ {
+            proxy_pass http://127.0.0.1:4322;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # Web dashboard
         location / {
             proxy_pass http://127.0.0.1:4321;


### PR DESCRIPTION
Addresses defect 1 of #3229 (the nginx `/portal` doc gap).

## Problem

The nginx reverse-proxy example in `apps/docs/src/content/docs/deploy/tls.mdx` proxies `/api/`, `/health`, and a catch-all `/` (→ web dashboard on :4321) — but **never `/portal`**. Following it verbatim, `/portal` falls through to the web dashboard and 404s. The customer portal is a separate Astro SSR service on **:4322** under the `/portal` base path; the production `Caddyfile.prod` proxies it with an explicit `@portal path /portal /portal/*` → `reverse_proxy portal:4322` "before the web catch-all". The nginx example was simply missing the equivalent.

## Fix (docs-only)

Add, before the `location /` catch-all:

```nginx
location = /portal { proxy_pass http://127.0.0.1:4322; ... }
location /portal/ { proxy_pass http://127.0.0.1:4322; ... }
```

- **exact + prefix match** mirrors Caddy's `path /portal /portal/*` and, unlike a bare `location /portal`, can't also grab an unrelated path like `/portalX` (an adversarial Codex review flagged that footgun).
- **no trailing slash on `proxy_pass`** preserves the `/portal` prefix the portal emits (Astro `base`), matching Caddy's `handle` (not `handle_path`).
- port **4322** matches the portal container's `PORT`.

## Scope

This PR fixes **defect 1** only. Defect 2 of #3229 (org-level `enforceSSO` never surfacing on the login page) is a separate product/security decision — the login page only does partner-axis SSO via `/auth/login-context`; wiring org-axis `/sso/check/:orgId` needs a pre-auth email→org resolution step, which is a tenant-enumeration surface best decided by the maintainer. Left for a follow-up.

`astro check` + `astro build` (apps/docs) clean.

https://claude.ai/code/session_0187oKb4Pw7KTXT2Lsvq7hUr
