### PR TITLE
fix(api): cancel the queued command when a remediation target times out (#3302)

### DIFF
--- a/apps/api/src/services/fleetFindings/dispatch.test.ts
+++ b/apps/api/src/services/fleetFindings/dispatch.test.ts
@@ -1097,6 +1097,48 @@ describe('pollRunProgress', () => {
 
     const targetUpdate = h.capturedUpdates.find((u) => (u.values as Record<string, unknown>).skipReason === 'timeout')!;
     expect(targetUpdate.values).toMatchObject({ status: 'failed', skipReason: 'timeout' });
+
+    // #3302: the still-`pending` command is cancelled so a late-reconnecting
+    // agent can't claim and run a remediation the run already gave up on.
+    const cancel = h.capturedUpdates.find(
+      (u) => (u.values as Record<string, unknown>).status === 'cancelled',
+    );
+    expect(cancel).toBeDefined();
+    expect((cancel!.values as Record<string, unknown>).result).toMatchObject({
+      cancelReason: 'remediation_run_timeout',
+    });
+    // Crash safety: the command must be cancelled BEFORE the target is
+    // terminalized. A crash after the target write (but before cancel) would
+    // drop the target from the next tick's reconciliation set while leaving the
+    // command runnable — the exact #3302 defect. Cancel-first is recoverable.
+    const cancelIdx = h.capturedUpdates.findIndex(
+      (u) => (u.values as Record<string, unknown>).status === 'cancelled',
+    );
+    const timeoutIdx = h.capturedUpdates.findIndex(
+      (u) => (u.values as Record<string, unknown>).skipReason === 'timeout',
+    );
+    expect(cancelIdx).toBeLessThan(timeoutIdx);
+  });
+
+  it('does NOT cancel a command already sent to the agent when its target times out', async () => {
+    const staleQueuedAt = new Date(Date.now() - 31 * 60 * 1000);
+    h.selectQueue.push([runRow()]);
+    h.selectQueue.push([
+      { runId: RUN_1, targetDeviceUuid: DEVICE_1, status: 'queued', deviceCommandId: 'cmd-1', queuedAt: staleQueuedAt },
+    ]);
+    // Already delivered — the agent may run it; it can't be recalled.
+    h.selectQueue.push([{ id: 'cmd-1', status: 'sent', result: null }]);
+
+    await pollRunProgress(RUN_1);
+
+    // The target still times out...
+    expect(
+      h.capturedUpdates.find((u) => (u.values as Record<string, unknown>).skipReason === 'timeout'),
+    ).toBeDefined();
+    // ...but a `sent` command must not be cancelled (only `pending` is).
+    expect(
+      h.capturedUpdates.find((u) => (u.values as Record<string, unknown>).status === 'cancelled'),
+    ).toBeUndefined();
   });
 
   it('does NOT time out a target queued less than 30 minutes ago', async () => {

--- a/apps/api/src/services/fleetFindings/dispatch.test.ts
+++ b/apps/api/src/services/fleetFindings/dispatch.test.ts
@@ -210,6 +210,12 @@ vi.mock('../commandQueue', () => ({
 
 const { captureExceptionMock } = vi.hoisted(() => ({ captureExceptionMock: vi.fn() }));
 vi.mock('../sentry', () => ({ captureException: captureExceptionMock }));
+// terminalPayloadErasureSet builds a jsonb SQL expression off the real
+// deviceCommands schema; stub it so the schema-mocked pollRunProgress cancel
+// path doesn't need the full schema. The returned key just rides the SET clause.
+vi.mock('../sensitiveCommandPayload', () => ({
+  terminalPayloadErasureSet: () => ({ payload: 'ERASE_PAYLOAD' }),
+}));
 
 import { fleetRemediationRuns } from '../../db/schema/fleetFindings';
 import {

--- a/apps/api/src/services/fleetFindings/dispatch.ts
+++ b/apps/api/src/services/fleetFindings/dispatch.ts
@@ -44,6 +44,7 @@ import {
 } from '../../db/schema/fleetFindings';
 import type { AuthContext } from '../../middleware/auth';
 import { CommandTypes, queueCommandForExecution } from '../commandQueue';
+import { terminalPayloadErasureSet } from '../sensitiveCommandPayload';
 import { captureException } from '../sentry';
 import { getFleetFinding } from './query';
 
@@ -707,6 +708,10 @@ export async function pollRunProgress(runId: string): Promise<void> {
         status: 'cancelled',
         completedAt: now,
         result: { cancelReason: 'remediation_run_timeout' },
+        // Terminal writers must scrub sensitive payload keys (enforced by
+        // terminalPayloadErasure.coverage.test.ts) — a cancelled command's
+        // payload is no longer needed.
+        ...terminalPayloadErasureSet(),
       })
       .where(and(inArray(deviceCommands.id, chunk), eq(deviceCommands.status, 'pending')));
   }

--- a/apps/api/src/services/fleetFindings/dispatch.ts
+++ b/apps/api/src/services/fleetFindings/dispatch.ts
@@ -630,6 +630,10 @@ export async function pollRunProgress(runId: string): Promise<void> {
   // the poll would never catch up with the fleet it is meant to be tracking.
   const resolved: { deviceId: string; status: FleetTargetStatus; summary: string }[] = [];
   const timedOut: string[] = [];
+  // device_command ids for timed-out targets whose command is still `pending`
+  // (never delivered) — cancelled below so a late-reconnecting agent can't run
+  // a remediation the run already gave up on.
+  const timedOutCommandIds: string[] = [];
 
   for (const target of inFlight) {
     const command = target.deviceCommandId ? commandsById.get(target.deviceCommandId) : undefined;
@@ -652,6 +656,14 @@ export async function pollRunProgress(runId: string): Promise<void> {
 
     const referenceTime = target.queuedAt ?? run.createdAt;
     if (now.getTime() - new Date(referenceTime).getTime() > REMEDIATION_TIMEOUT_MS) {
+      // A command still `pending` was never delivered — cancel it (below) so an
+      // agent that reconnects after the run timed out can't claim and run it. A
+      // command already `sent` is in the agent's hands and can't be recalled;
+      // its target still times out here, and surfacing that honestly is a
+      // documented follow-up (#3302).
+      if (target.deviceCommandId && command?.status === 'pending') {
+        timedOutCommandIds.push(target.deviceCommandId);
+      }
       timedOut.push(target.targetDeviceUuid);
       target.status = 'failed';
     }
@@ -674,6 +686,29 @@ export async function pollRunProgress(runId: string): Promise<void> {
       FROM (VALUES ${values}) AS v(device_id, status, summary)
       WHERE t.run_id = ${runId} AND t.target_device_uuid = v.device_id
     `);
+  }
+
+  // Cancel the still-queued commands for timed-out targets BEFORE terminalizing
+  // those targets. Ordering matters for crash safety: a timed-out target is
+  // dropped from the next tick's `inFlight` set (only pending/queued targets are
+  // reconciled), so if the process died AFTER the target write but BEFORE the
+  // cancel, the pending command would be orphaned and a late-reconnecting agent
+  // could still run it — the exact bug. Cancelling first is recoverable: a crash
+  // after the cancel leaves the target in flight, and the next poll observes the
+  // now-`cancelled` command and reconciles the target via the terminal-status
+  // branch above. The `status = 'pending'` predicate also makes this race-safe
+  // against claimPendingCommandForDelivery (a CAS on the same predicate): if the
+  // agent claims first (pending → sent) this matches 0 rows and never clobbers
+  // an in-flight delivery; if we cancel first, the agent's later claim matches 0.
+  for (const chunk of chunkArray(timedOutCommandIds, TARGET_INSERT_CHUNK_SIZE)) {
+    await db
+      .update(deviceCommands)
+      .set({
+        status: 'cancelled',
+        completedAt: now,
+        result: { cancelReason: 'remediation_run_timeout' },
+      })
+      .where(and(inArray(deviceCommands.id, chunk), eq(deviceCommands.status, 'pending')));
   }
 
   // Timeouts are uniform, so one statement per chunk covers them.


### PR DESCRIPTION
Closes #3302.

## Problem

The fleet remediation poll's 30-minute timeout marked the target `failed` / `skipReason=timeout` but **never touched its `device_command`**. A device offline past the timeout would, on reconnect, still **claim and run** the remediation the run had already given up on.

## Fix

When a target times out, cancel its command **if it's still `pending`** (never delivered):

```sql
UPDATE device_commands SET status='cancelled', completed_at=now,
  result='{"cancelReason":"remediation_run_timeout"}'
WHERE id = ANY($ids) AND status='pending'
```

- The `status='pending'` predicate is a **CAS**, race-safe against `claimPendingCommandForDelivery` (a CAS on the same predicate): whoever wins, the other matches zero rows — no double-execution, no clobbered in-flight delivery.
- Only **never-delivered** (`pending`) commands are cancelled, so there's no agent-result conflict, and `cancelled` is already a legal `device_commands.status` (no migration).

## Crash-safety: cancel-first ordering

The cancel runs **before** the target is terminalized — this ordering is the safety guarantee. A timed-out target drops out of the next tick's reconciliation set (`inFlight` = pending/queued targets only), so cancelling *after* the target write would orphan a still-pending command if the process crashed between the two. Cancel-first is recoverable: a crash after the cancel leaves the target in flight, and the next poll reconciles it from the now-`cancelled` command via the existing terminal-status branch. The non-transactional states only ever progress in the safe direction: `pending+queued → cancelled+queued → cancelled+failed`.

The first adversarial Codex pass flagged the original cancel-*after* ordering as a crash-unsafe ship-blocker; the reorder closes it (final verdict: no ship-blocking findings).

## Known limitation (deferred follow-up)

A command already **`sent`** to the agent cannot be recalled — its target still times out while the agent may run it and later report a result. This PR prevents execution only for commands **still `pending` when the timeout wins**. Fully honest terminal-state reporting for the `sent` case (a distinct terminal status like `timeout_unknown`) would need a migration on the shipped `fleet_remediation_run_targets` CHECK constraint plus rollup-arithmetic and locale changes, and is intentionally left out of this PR.

## Testing

`dispatch.test.ts` asserts: a `pending` command is cancelled (with the reason) **and cancelled before the target is terminalized**; a `sent` command is **not** cancelled. Control-verified (reverting the fix / the ordering reds the respective assertions).

`tsc --noEmit` (apps/api) clean; vitest `fleetFindings` **97/97**; eslint clean.

https://claude.ai/code/session_0187oKb4Pw7KTXT2Lsvq7hUr
