### PR TITLE
fix(api,web,shared): record installer type for URL-created software packages

### DIFF
--- a/apps/api/migrations/2026-08-23-software-version-url-file-type.sql
+++ b/apps/api/migrations/2026-08-23-software-version-url-file-type.sql
@@ -1,45 +1,65 @@
--- Backfill software_versions.file_type for versions created from a download URL.
+-- Backfill software_versions.file_type for versions that never recorded one.
 --
 -- The JSON create-version route (POST /software/catalog/:id/versions) never
 -- accepted or derived a file_type -- only the upload paths did, from the
 -- uploaded filename. services/softwareDeployment.ts therefore dispatched
 -- `fileType: 'exe'` / `fileName: 'package.exe'` for every URL-created version,
--- and the agent's EXE branch execs the downloaded file DIRECTLY
--- (exec.CommandContext(ctx, localPath, ...) in software_install.go). For an MSI
--- that fails at CreateProcess with ERROR_BAD_EXE_FORMAT ("This version of %1 is
--- not compatible with the version of Windows you're running") and the
--- operator's `msiexec /i "{file}" ...` command is discarded unused.
+-- and the agent's Windows EXE branch execs the downloaded file DIRECTLY
+-- (exec.CommandContext(ctx, localPath, parts...) in software_install.go). For an
+-- MSI that fails at CreateProcess with ERROR_BAD_EXE_FORMAT ("This version of %1
+-- is not compatible with the version of Windows you're running"). The operator's
+-- `msiexec /i "{file}" ...` was not discarded but MISROUTED -- passed as argv to
+-- the MSI itself. On macOS/Linux the same 'exe' fallback failed earlier still,
+-- as `unsupported file type "exe" on <os>`, which is why dmg/deb/pkg rows are
+-- in scope here too.
 --
--- Only rows where the URL carries an unambiguous installer extension are
--- touched. A URL with no usable extension keeps file_type NULL and the
+-- Derivation order is original_file_name FIRST, then download_url. This is not
+-- arbitrary: the agent's validateInstallFileName rejects the command outright
+-- unless the filename's extension equals '.' || file_type, and
+-- softwareDeployment.ts sends original_file_name verbatim as the filename when
+-- it is set. So for those rows the filename is the ONLY source that yields a
+-- dispatchable pair -- deriving from the URL instead could stamp a file_type
+-- that contradicts the filename and convert a working install into a hard
+-- validation failure.
+--
+-- Only rows whose source carries an unambiguous installer extension are
+-- touched. A row with no usable extension keeps file_type NULL and the
 -- historical 'exe' dispatch behavior -- guessing there would trade one wrong
--- answer for another.
+-- answer for another. Those rows are counted and reported below, because THAT
+-- is the actionable number: they are the packages that will still fail their
+-- next deploy.
 --
 -- silent_install_args is deliberately NOT rewritten: with file_type corrected,
 -- buildMSIExecArgs already defaults an empty args string to
--- `/i <path> /qn /norestart` and strips a leading `msiexec` token from a
--- supplied one. Editing an operator's stored install command is out of scope
--- for a data repair.
+-- `/i <path> /qn /norestart`, strips a leading `msiexec` token from a supplied
+-- one, and prepends `/i <path>` when the supplied args don't already reference
+-- the file -- so stored bare switches like `/qn /norestart` keep working.
+-- Editing an operator's stored install command is out of scope for a data repair.
 
 DO $$
 DECLARE
   updated_count integer;
+  skipped_count integer;
 BEGIN
   WITH derived AS (
     SELECT
       id,
       lower(
-        substring(
+        coalesce(
+          -- The filename the agent will validate against, when we have one.
+          substring(original_file_name FROM '\.([A-Za-z0-9]+)$'),
           -- Path portion only: a presigned or tokenized URL puts the signature
           -- in the query string, and `{{org.name}}`-style deploy-time tokens can
           -- appear anywhere in it.
-          split_part(split_part(download_url, '#', 1), '?', 1)
-          FROM '\.([A-Za-z]+)$'
+          substring(
+            split_part(split_part(download_url, '#', 1), '?', 1)
+            FROM '\.([A-Za-z0-9]+)$'
+          )
         )
       ) AS ext
     FROM software_versions
     WHERE file_type IS NULL
-      AND download_url IS NOT NULL
+      AND (download_url IS NOT NULL OR original_file_name IS NOT NULL)
   )
   UPDATE software_versions sv
   SET file_type = derived.ext
@@ -48,7 +68,16 @@ BEGIN
     AND derived.ext IN ('msi', 'exe', 'dmg', 'deb', 'pkg');
 
   GET DIAGNOSTICS updated_count = ROW_COUNT;
-  IF updated_count > 0 THEN
-    RAISE WARNING 'backfilled file_type on % url-created software_versions row(s)', updated_count;
-  END IF;
+
+  -- Counted AFTER the update, so this is the residue: rows still unclassified.
+  SELECT count(*) INTO skipped_count
+  FROM software_versions
+  WHERE file_type IS NULL
+    AND (download_url IS NOT NULL OR original_file_name IS NOT NULL);
+
+  -- Reported unconditionally, including zero. A suppressed zero cannot be
+  -- distinguished from "the migration never ran", which is exactly the
+  -- forensic question someone asks when a deploy fails after this ships.
+  RAISE WARNING 'software_versions.file_type backfill: % row(s) classified, % row(s) still unclassified (these will dispatch as exe and fail for non-exe installers)',
+    updated_count, skipped_count;
 END $$;

--- a/apps/api/migrations/2026-08-23-software-version-url-file-type.sql
+++ b/apps/api/migrations/2026-08-23-software-version-url-file-type.sql
@@ -1,0 +1,54 @@
+-- Backfill software_versions.file_type for versions created from a download URL.
+--
+-- The JSON create-version route (POST /software/catalog/:id/versions) never
+-- accepted or derived a file_type -- only the upload paths did, from the
+-- uploaded filename. services/softwareDeployment.ts therefore dispatched
+-- `fileType: 'exe'` / `fileName: 'package.exe'` for every URL-created version,
+-- and the agent's EXE branch execs the downloaded file DIRECTLY
+-- (exec.CommandContext(ctx, localPath, ...) in software_install.go). For an MSI
+-- that fails at CreateProcess with ERROR_BAD_EXE_FORMAT ("This version of %1 is
+-- not compatible with the version of Windows you're running") and the
+-- operator's `msiexec /i "{file}" ...` command is discarded unused.
+--
+-- Only rows where the URL carries an unambiguous installer extension are
+-- touched. A URL with no usable extension keeps file_type NULL and the
+-- historical 'exe' dispatch behavior -- guessing there would trade one wrong
+-- answer for another.
+--
+-- silent_install_args is deliberately NOT rewritten: with file_type corrected,
+-- buildMSIExecArgs already defaults an empty args string to
+-- `/i <path> /qn /norestart` and strips a leading `msiexec` token from a
+-- supplied one. Editing an operator's stored install command is out of scope
+-- for a data repair.
+
+DO $$
+DECLARE
+  updated_count integer;
+BEGIN
+  WITH derived AS (
+    SELECT
+      id,
+      lower(
+        substring(
+          -- Path portion only: a presigned or tokenized URL puts the signature
+          -- in the query string, and `{{org.name}}`-style deploy-time tokens can
+          -- appear anywhere in it.
+          split_part(split_part(download_url, '#', 1), '?', 1)
+          FROM '\.([A-Za-z]+)$'
+        )
+      ) AS ext
+    FROM software_versions
+    WHERE file_type IS NULL
+      AND download_url IS NOT NULL
+  )
+  UPDATE software_versions sv
+  SET file_type = derived.ext
+  FROM derived
+  WHERE sv.id = derived.id
+    AND derived.ext IN ('msi', 'exe', 'dmg', 'deb', 'pkg');
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  IF updated_count > 0 THEN
+    RAISE WARNING 'backfilled file_type on % url-created software_versions row(s)', updated_count;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/softwareVersionFileTypeMigration.integration.test.ts
+++ b/apps/api/src/__tests__/integration/softwareVersionFileTypeMigration.integration.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Replays 2026-08-23-software-version-url-file-type.sql against seeded rows in
+ * the shapes production actually has.
+ *
+ * CI databases are migrated schema-fresh in globalSetup, so this backfill has
+ * only ever run against ZERO rows there — the CI log reads "0 row(s)
+ * classified, 0 row(s) still unclassified". A green migration therefore says
+ * nothing about whether the derivation is correct, and the derivation is the
+ * whole point: it decides whether an MSI reaches the agent as `fileType: 'msi'`
+ * (msiexec) or `fileType: 'exe'` (exec the file directly → ERROR_BAD_EXE_FORMAT
+ * on Windows, `unsupported file type` on macOS/Linux).
+ *
+ * It also pins the two things the SQL does that a reader would not assume:
+ *   - original_file_name takes PRECEDENCE over download_url, because
+ *     softwareDeployment.ts sends that filename verbatim and the agent's
+ *     validateInstallFileName rejects the command unless its extension matches
+ *     file_type. Deriving from a contradicting URL would convert a working
+ *     install into a hard validation failure;
+ *   - the stored value is lower-cased. software_install.go compares
+ *     `fileType == "msi"` case-SENSITIVELY while isSupportedInstallFileType is
+ *     case-INsensitive, so an uppercase 'MSI' would pass validation and then
+ *     fall through to "unsupported file type" — a silent, differently-shaped
+ *     failure.
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm --filter @breeze/api exec vitest run -c vitest.integration.config.ts \
+ *     src/__tests__/integration/softwareVersionFileTypeMigration.integration.test.ts
+ */
+import './setup';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { sql } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { createOrganization, createPartner } from './db-utils';
+import { getTestDb } from './setup';
+
+const MIGRATION_FILE = join(
+  __dirname,
+  '../../../migrations/2026-08-23-software-version-url-file-type.sql',
+);
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function replayMigration() {
+  await getTestDb().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')));
+}
+
+/** Inserts a version with file_type NULL, bypassing every route-level guard. */
+async function seedVersion(
+  catalogId: string,
+  version: string,
+  downloadUrl: string | null,
+  originalFileName: string | null,
+  fileType: string | null = null,
+): Promise<string> {
+  const rows = await getTestDb().execute<{ id: string }>(sql`
+    INSERT INTO software_versions
+      (catalog_id, version, download_url, original_file_name, file_type, is_latest)
+    VALUES (${catalogId}, ${version}, ${downloadUrl}, ${originalFileName}, ${fileType}, false)
+    RETURNING id
+  `);
+  return (rows as unknown as { id: string }[])[0]!.id;
+}
+
+async function fileTypeOf(id: string): Promise<string | null> {
+  const rows = await getTestDb().execute<{ file_type: string | null }>(
+    sql`SELECT file_type FROM software_versions WHERE id = ${id}`,
+  );
+  return (rows as unknown as { file_type: string | null }[])[0]!.file_type;
+}
+
+describe('2026-08-23 software_versions.file_type backfill', () => {
+  runDb('classifies, skips and lower-cases exactly as the derivation intends', async () => {
+    const partner = await createPartner({});
+    const org = await createOrganization({ partnerId: partner.id });
+    const catalogRows = await getTestDb().execute<{ id: string }>(sql`
+      INSERT INTO software_catalog (org_id, name, category)
+      VALUES (${org.id}, 'Migration Probe', 'utility')
+      RETURNING id
+    `);
+    const catalogId = (catalogRows as unknown as { id: string }[])[0]!.id;
+
+    const ids = {
+      urlMsi: await seedVersion(catalogId, 'url-msi', 'https://cdn.example/acme.msi', null),
+      // The double split_part in the SQL exists for exactly this shape.
+      presigned: await seedVersion(
+        catalogId,
+        'presigned',
+        'https://cdn.example/acme.msi?X-Amz-Signature=deadbeef&e=1',
+        null,
+      ),
+      fragment: await seedVersion(catalogId, 'fragment', 'https://cdn.example/acme.msi#sha256', null),
+      uppercase: await seedVersion(catalogId, 'uppercase', 'https://cdn.example/Acme.MSI', null),
+      // Deploy-time tokens survive in stored URLs; they must not defeat the regex.
+      tokenized: await seedVersion(
+        catalogId,
+        'tokenized',
+        'https://cdn.example/{{org.name}}/acme.msi',
+        null,
+      ),
+      urlExe: await seedVersion(catalogId, 'url-exe', 'https://cdn.example/setup.exe', null),
+      urlDeb: await seedVersion(catalogId, 'url-deb', 'https://cdn.example/agent.deb', null),
+      // Unusable: left NULL rather than guessed at.
+      noExtension: await seedVersion(catalogId, 'no-ext', 'https://vendor.example/latest', null),
+      scriptUrl: await seedVersion(
+        catalogId,
+        'script-url',
+        'https://vendor.example/download.php?product=acme',
+        null,
+      ),
+      unsupportedExt: await seedVersion(catalogId, 'zip', 'https://cdn.example/bundle.zip', null),
+      // Filename is authoritative: the URL here is an extensionless storage key.
+      legacyName: await seedVersion(catalogId, 'legacy', 'https://s3.example/key/abc123', 'agent.msi'),
+      // Filename CONTRADICTS the URL — the filename must still win.
+      nameWins: await seedVersion(
+        catalogId,
+        'name-wins',
+        'https://cdn.example/redirect.exe',
+        'real-agent.msi',
+      ),
+      // Already classified: must not be rewritten even though the URL says msi.
+      alreadySet: await seedVersion(catalogId, 'already', 'https://cdn.example/x.msi', null, 'exe'),
+      noSource: await seedVersion(catalogId, 'no-source', null, null),
+    };
+
+    await replayMigration();
+
+    expect(await fileTypeOf(ids.urlMsi)).toBe('msi');
+    expect(await fileTypeOf(ids.presigned)).toBe('msi');
+    expect(await fileTypeOf(ids.fragment)).toBe('msi');
+    expect(await fileTypeOf(ids.uppercase)).toBe('msi'); // lower-cased, not 'MSI'
+    expect(await fileTypeOf(ids.tokenized)).toBe('msi');
+    expect(await fileTypeOf(ids.urlExe)).toBe('exe');
+    expect(await fileTypeOf(ids.urlDeb)).toBe('deb');
+
+    expect(await fileTypeOf(ids.noExtension)).toBeNull();
+    expect(await fileTypeOf(ids.scriptUrl)).toBeNull();
+    expect(await fileTypeOf(ids.unsupportedExt)).toBeNull();
+    expect(await fileTypeOf(ids.noSource)).toBeNull();
+
+    expect(await fileTypeOf(ids.legacyName)).toBe('msi');
+    expect(await fileTypeOf(ids.nameWins)).toBe('msi');
+    expect(await fileTypeOf(ids.alreadySet)).toBe('exe');
+
+    // Replay is a true no-op — `WHERE file_type IS NULL` is the only thing
+    // making this idempotent, and nothing else proves it.
+    await replayMigration();
+    expect(await fileTypeOf(ids.urlMsi)).toBe('msi');
+    expect(await fileTypeOf(ids.alreadySet)).toBe('exe');
+    expect(await fileTypeOf(ids.scriptUrl)).toBeNull();
+  });
+});

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -672,6 +672,132 @@ describe('software routes', () => {
     });
   });
 
+  // A URL-created version never recorded a fileType, so softwareDeployment.ts
+  // fell back to `fileType: 'exe'` / `fileName: 'package.exe'`. The agent's EXE
+  // branch execs the downloaded file DIRECTLY, so an MSI died at CreateProcess
+  // with ERROR_BAD_EXE_FORMAT and the operator's msiexec command was discarded
+  // unused. These assert the recorded fileType, not just that the insert ran.
+  describe('POST /software/catalog/:id/versions (URL source) installer type', () => {
+    const catalogId = '11111111-1111-1111-1111-111111111111';
+
+    const selectResult = (rows: any): any => {
+      const p: any = new Proxy(() => p, {
+        get: (_t, prop) => (prop === 'then' ? (resolve: any) => resolve(rows) : () => p),
+      });
+      return p;
+    };
+
+    /** Runs insertLatestSoftwareVersion's real transaction body against a tx
+     *  that captures the inserted row, so the assertions below read the values
+     *  actually written rather than merely confirming a call happened. */
+    const captureInsert = () => {
+      const captured: { values?: Record<string, any> } = {};
+      vi.mocked(db.transaction).mockImplementationOnce(async (fn: any) =>
+        fn({
+          insert: () => ({
+            values: (v: Record<string, any>) => {
+              captured.values = v;
+              return { returning: async () => [{ id: 'ver-1', ...v }] };
+            },
+          }),
+          update: () => ({
+            set: () => ({
+              where: () => {
+                const res: any = {
+                  then: (resolve: any) => resolve(undefined),
+                  returning: async () => [{ id: 'ver-1', ...captured.values }],
+                };
+                return res;
+              },
+            }),
+          }),
+        }),
+      );
+      return captured;
+    };
+
+    const createVersion = async (body: Record<string, unknown>) => {
+      vi.mocked(db.select).mockReturnValueOnce(
+        selectResult([{ id: catalogId, orgId: 'org-123', name: 'Acme Tool' }]),
+      );
+      const captured = captureInsert();
+      const res = await app.request(`/software/catalog/${catalogId}/versions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ version: '1.0.0', ...body }),
+      });
+      return { res, captured };
+    };
+
+    it('records fileType msi from the URL extension and prefills msiexec args', async () => {
+      const { res, captured } = await createVersion({
+        downloadUrl: 'https://cdn.example.com/acme-agent-1.0.0.msi',
+      });
+
+      expect(res.status).toBe(201);
+      expect(captured.values?.fileType).toBe('msi');
+      expect(captured.values?.silentInstallArgs).toBe('msiexec /i "{file}" /qn /norestart');
+      expect(captured.values?.silentUninstallArgs).toBe('msiexec /x "{file}" /qn /norestart');
+    });
+
+    it('derives the type through a presigned query string', async () => {
+      const { captured } = await createVersion({
+        downloadUrl: 'https://cdn.example.com/acme.msi?X-Amz-Signature=deadbeef',
+      });
+      expect(captured.values?.fileType).toBe('msi');
+    });
+
+    it('honours an explicit fileType over the URL extension', async () => {
+      // A vendor URL whose path lies about the payload — the operator's choice wins.
+      const { captured } = await createVersion({
+        downloadUrl: 'https://cdn.example.com/download.exe',
+        fileType: 'msi',
+      });
+      expect(captured.values?.fileType).toBe('msi');
+    });
+
+    it('never overwrites an operator-supplied install command', async () => {
+      const { captured } = await createVersion({
+        downloadUrl: 'https://cdn.example.com/acme.msi',
+        silentInstallArgs: 'msiexec /i "{file}" /qn REBOOT=ReallySuppress',
+      });
+      expect(captured.values?.fileType).toBe('msi');
+      expect(captured.values?.silentInstallArgs).toBe(
+        'msiexec /i "{file}" /qn REBOOT=ReallySuppress',
+      );
+    });
+
+    it('leaves fileType null when the URL has no recognizable extension', async () => {
+      // Guessing here would just invert the bug; null preserves prior behavior.
+      const { captured } = await createVersion({
+        downloadUrl: 'https://vendor.example.com/download.php?product=acme',
+      });
+      expect(captured.values?.fileType).toBeNull();
+      expect(captured.values?.silentInstallArgs).toBeNull();
+    });
+
+    it('does not prefill msiexec args for a non-MSI installer', async () => {
+      const { captured } = await createVersion({
+        downloadUrl: 'https://cdn.example.com/acme-setup.exe',
+      });
+      expect(captured.values?.fileType).toBe('exe');
+      expect(captured.values?.silentInstallArgs).toBeNull();
+    });
+
+    it('rejects an unsupported explicit fileType with 400', async () => {
+      const res = await app.request(`/software/catalog/${catalogId}/versions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          version: '1.0.0',
+          downloadUrl: 'https://cdn.example.com/acme.zip',
+          fileType: 'zip',
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
   describe('POST /software/deploy validation', () => {
     it('rejects empty body with 400 (missing softwareId)', async () => {
       const res = await app.request('/software/deploy', {

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -8,7 +8,7 @@ import {
   S3ConfigError,
   S3OperationError,
 } from '../services/s3Storage';
-import { captureException } from '../services/sentry';
+import { captureException, captureMessage } from '../services/sentry';
 import { parseStreamingMultipart } from '../services/streamingUpload';
 import { createHash } from 'node:crypto';
 import { authMiddleware } from '../middleware/auth';
@@ -782,6 +782,51 @@ describe('software routes', () => {
       });
       expect(captured.values?.fileType).toBe('exe');
       expect(captured.values?.silentInstallArgs).toBeNull();
+    });
+
+    it('treats an explicitly-empty install command as absent, not as a value', async () => {
+      // `||` rather than `??`: a cleared form field posts '', and storing that
+      // literal empty string would suppress the MSI default for no reason.
+      const { captured } = await createVersion({
+        downloadUrl: 'https://cdn.example.com/acme.msi',
+        silentInstallArgs: '',
+      });
+      expect(captured.values?.silentInstallArgs).toBe('msiexec /i "{file}" /qn /norestart');
+    });
+
+    it('records the resolved type on the audit event', async () => {
+      // The only durable server-side trace of what was decided at write time.
+      await createVersion({ downloadUrl: 'https://cdn.example.com/acme.msi' });
+      expect(writeRouteAudit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'software.catalog.version.create',
+          details: expect.objectContaining({ fileType: 'msi' }),
+        }),
+      );
+    });
+
+    it('flags an undetermined installer type for non-web clients', async () => {
+      // The web forms warn in the UI, but an API/MCP/script client gets no
+      // prompt — without this nobody can count how often it happens.
+      await createVersion({
+        downloadUrl: 'https://vendor.example.com/download.php?product=acme',
+      });
+      expect(captureMessage).toHaveBeenCalledWith(
+        'software version created with undetermined installer type',
+        'warning',
+        expect.objectContaining({ downloadUrlHost: 'vendor.example.com' }),
+      );
+    });
+
+    it('does not log the presigned query string of a download URL', async () => {
+      // Managed-software URLs carry capability query strings that must never
+      // reach a log — host only.
+      await createVersion({
+        downloadUrl: 'https://vendor.example.com/get?token=SECRET-CAPABILITY',
+      });
+      const logged = vi.mocked(captureMessage).mock.calls.at(-1)?.[2];
+      expect(JSON.stringify(logged)).not.toContain('SECRET-CAPABILITY');
     });
 
     it('rejects an unsupported explicit fileType with 400', async () => {

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -376,6 +376,19 @@ const createVersionSchema = z.object({
   detectionRules: detectionRulesSchema.optional()
 });
 
+/**
+ * Host of a managed-software URL, for logging. Never the full URL: these carry
+ * presigned capability query strings, and a stored URL may still hold
+ * unresolved `{{org.name}}` deploy-time tokens that make `new URL()` throw.
+ */
+function safeUrlHost(rawUrl: string): string {
+  try {
+    return new URL(rawUrl).host || 'unparseable';
+  } catch {
+    return 'unparseable';
+  }
+}
+
 const listDeploymentsSchema = z.object({
   status: z.enum(['pending', 'in_progress', 'completed', 'completed_with_errors', 'failed', 'cancelled']).optional(),
   page: z.string().optional(),
@@ -802,11 +815,28 @@ softwareRoutes.post(
 
     // A URL-created version never recorded a fileType, so the dispatcher fell
     // back to 'exe' and the agent exec'd the downloaded file directly — which
-    // fails at CreateProcess for an MSI (ERROR_BAD_EXE_FORMAT) and silently
-    // discards the operator's msiexec command. Prefer an explicit fileType,
-    // otherwise infer it from the URL's extension; null keeps prior behavior.
+    // fails at CreateProcess for an MSI (ERROR_BAD_EXE_FORMAT) and misroutes the
+    // operator's msiexec command into the MSI's own argv. Prefer an explicit
+    // fileType, otherwise infer from the URL; null keeps prior behavior.
     const fileType = payload.fileType ?? deriveSoftwareFileTypeFromUrl(payload.downloadUrl);
     const silentDefaults = defaultSilentArgsForFileType(fileType);
+
+    // Storing NULL means committing to a row we will later GUESS about at
+    // dispatch. The web forms warn about it, but an API/MCP/script client gets
+    // no such prompt, so record it server-side — otherwise nobody can even
+    // count how often this happens in production. Not a 400: an extensionless
+    // URL serving a real EXE is legitimate, and rejecting would break existing
+    // scripted clients.
+    if (payload.downloadUrl && fileType === null) {
+      captureMessage('software version created with undetermined installer type', 'warning', {
+        orgId,
+        catalogId: id,
+        version: payload.version,
+        // Host only — a managed-software URL can carry a presigned capability
+        // query string that must never reach a log.
+        downloadUrlHost: safeUrlHost(payload.downloadUrl),
+      });
+    }
 
     const version = await insertLatestSoftwareVersion(id, {
       version: payload.version,

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -43,7 +43,13 @@ import {
   buildAndDispatchSoftwareInstalls,
   createSoftwareDeployment,
 } from '../services/softwareDeployment';
-import { detectionRulesSchema, softwareDownloadPolicySchema } from '@breeze/shared';
+import {
+  detectionRulesSchema,
+  softwareDownloadPolicySchema,
+  SOFTWARE_FILE_TYPES,
+  defaultSilentArgsForFileType,
+  deriveSoftwareFileTypeFromUrl,
+} from '@breeze/shared';
 import { terminalPayloadErasureSet } from '../services/sensitiveCommandPayload';
 import {
   ALLOWED_EXTENSIONS,
@@ -354,6 +360,11 @@ const createVersionSchema = z.object({
   releaseDate: z.string().datetime().optional(),
   releaseNotes: z.string().max(5000).optional(),
   downloadUrl: z.string().url().optional(),
+  // Explicit installer type, overriding what the URL's extension implies. The
+  // agent switches on this to pick msiexec vs. direct exec, so a URL-created
+  // version that omits it (and whose URL carries no usable extension) still
+  // reaches the device as the historical 'exe' default.
+  fileType: z.enum(SOFTWARE_FILE_TYPES).optional(),
   checksum: z.string().regex(/^[a-f0-9]{64}$/i).optional(),
   fileSize: z.number().min(0).optional(),
   supportedOs: z.array(platformSchema).optional(),
@@ -789,17 +800,26 @@ softwareRoutes.post(
       .where(and(eq(softwareCatalog.id, id), eq(softwareCatalog.orgId, orgId)));
     if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
 
+    // A URL-created version never recorded a fileType, so the dispatcher fell
+    // back to 'exe' and the agent exec'd the downloaded file directly — which
+    // fails at CreateProcess for an MSI (ERROR_BAD_EXE_FORMAT) and silently
+    // discards the operator's msiexec command. Prefer an explicit fileType,
+    // otherwise infer it from the URL's extension; null keeps prior behavior.
+    const fileType = payload.fileType ?? deriveSoftwareFileTypeFromUrl(payload.downloadUrl);
+    const silentDefaults = defaultSilentArgsForFileType(fileType);
+
     const version = await insertLatestSoftwareVersion(id, {
       version: payload.version,
       releaseDate: payload.releaseDate ? new Date(payload.releaseDate) : new Date(),
       releaseNotes: payload.releaseNotes ?? null,
       downloadUrl: payload.downloadUrl ?? null,
+      fileType,
       checksum: payload.checksum ?? null,
       fileSize: payload.fileSize ?? null,
       supportedOs: payload.supportedOs ?? null,
       architecture: payload.architecture ?? null,
-      silentInstallArgs: payload.silentInstallArgs ?? null,
-      silentUninstallArgs: payload.silentUninstallArgs ?? null,
+      silentInstallArgs: payload.silentInstallArgs || silentDefaults?.install || null,
+      silentUninstallArgs: payload.silentUninstallArgs || silentDefaults?.uninstall || null,
       preInstallScript: payload.preInstallScript ?? null,
       postInstallScript: payload.postInstallScript ?? null,
       detectionRules: payload.detectionRules ?? null,
@@ -815,7 +835,7 @@ softwareRoutes.post(
       resourceType: 'software_version',
       resourceId: version.id,
       resourceName: catalogItem.name,
-      details: { version: payload.version },
+      details: { version: payload.version, fileType },
     });
 
     return c.json({ data: version }, 201);
@@ -940,11 +960,12 @@ softwareRoutes.post(
       }
 
       // Auto-detect MSI silent args
-      if (fileType === 'msi' && !silentInstallArgs) {
-        silentInstallArgs = 'msiexec /i "{file}" /qn /norestart';
+      const silentDefaults = defaultSilentArgsForFileType(fileType);
+      if (silentDefaults && !silentInstallArgs) {
+        silentInstallArgs = silentDefaults.install;
       }
-      if (fileType === 'msi' && !silentUninstallArgs) {
-        silentUninstallArgs = 'msiexec /x "{file}" /qn /norestart';
+      if (silentDefaults && !silentUninstallArgs) {
+        silentUninstallArgs = silentDefaults.uninstall;
       }
 
       const checksum = file.checksum;

--- a/apps/api/src/routes/softwareUploads.ts
+++ b/apps/api/src/routes/softwareUploads.ts
@@ -64,7 +64,7 @@ import {
   insertLatestSoftwareVersion,
   resolveScopedOrgId,
 } from '../services/softwareVersionShared';
-import { detectionRulesSchema } from '@breeze/shared';
+import { detectionRulesSchema, defaultSilentArgsForFileType } from '@breeze/shared';
 
 export const softwareUploadRoutes = new Hono();
 
@@ -652,11 +652,12 @@ softwareUploadRoutes.post(
       // Auto-detect MSI silent args (parity with the legacy multipart route).
       let silentInstallArgs = meta.silentInstallArgs ?? null;
       let silentUninstallArgs = meta.silentUninstallArgs ?? null;
-      if (fileType === 'msi' && !silentInstallArgs) {
-        silentInstallArgs = 'msiexec /i "{file}" /qn /norestart';
+      const silentDefaults = defaultSilentArgsForFileType(fileType);
+      if (silentDefaults && !silentInstallArgs) {
+        silentInstallArgs = silentDefaults.install;
       }
-      if (fileType === 'msi' && !silentUninstallArgs) {
-        silentUninstallArgs = 'msiexec /x "{file}" /qn /norestart';
+      if (silentDefaults && !silentUninstallArgs) {
+        silentUninstallArgs = silentDefaults.uninstall;
       }
 
       const versionId = randomUUID();

--- a/apps/api/src/services/softwareDeployment.test.ts
+++ b/apps/api/src/services/softwareDeployment.test.ts
@@ -366,6 +366,96 @@ describe('createSoftwareDeployment', () => {
     );
   });
 
+  // The fileName/fileType pair the agent receives. This is the bridge the
+  // original MSI-by-URL bug lived on and nothing asserted it: every other
+  // dispatch fixture sets originalFileName, so the `package.${fileType}`
+  // fallback branch — the one every URL-created version takes, because
+  // original_file_name is NULL for all of them — was never evaluated by a test.
+  //
+  // The two fields are COUPLED, not independent: the agent's
+  // validateInstallFileName rejects the command outright unless the filename's
+  // extension equals '.' + fileType.
+  describe('dispatched fileName/fileType pair', () => {
+    const dispatchWithVersion = async (
+      versionOverrides: Record<string, unknown>,
+      deploymentId: string,
+    ) => {
+      const versionRecord = {
+        id: 'ver-ft',
+        catalogId: 'cat-1',
+        s3Key: null,
+        downloadUrl: 'https://dl/acme.msi',
+        checksum: null,
+        originalFileName: null,
+        silentInstallArgs: null,
+        version: '1.0.0',
+        ...versionOverrides,
+      };
+      const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+      const targetDevices = [
+        { id: 'dev-1', agentId: 'agent-1', siteId: 'site-1', hostname: 'WKS-1', customFields: {} },
+      ];
+
+      selectMock
+        .mockReturnValueOnce(sel([versionRecord]))
+        .mockReturnValueOnce(sel([catalogItem]))
+        .mockReturnValueOnce(sel(targetDevices))
+        .mockReturnValueOnce(selLimit([{ name: 'Acme' }]))
+        .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }]))
+        .mockReturnValueOnce(selJoin([]));
+      insertMock
+        .mockReturnValueOnce(insWithReturning([{ id: deploymentId, orgId: 'org-1' }]))
+        .mockReturnValueOnce(ins());
+
+      await createSoftwareDeployment({
+        orgId: 'org-1',
+        softwareVersionId: 'ver-ft',
+        deploymentType: 'install',
+        deviceIds: ['dev-1'],
+        scheduleType: 'immediate',
+        createdBy: null,
+      });
+
+      return sendCommandMock.mock.calls[0]![1].payload;
+    };
+
+    it('sends package.msi for an MSI version with no original filename', async () => {
+      // Reverting the fix makes this `{fileType:'exe', fileName:'package.exe'}`
+      // — the exact payload that produced ERROR_BAD_EXE_FORMAT on Windows.
+      const payload = await dispatchWithVersion({ fileType: 'msi' }, 'dep-ft-msi');
+      expect(payload.fileType).toBe('msi');
+      expect(payload.fileName).toBe('package.msi');
+    });
+
+    it('keeps the legacy exe fallback for a version with no recorded type', async () => {
+      // Deliberate, not incidental: we never guess a better answer from the URL
+      // at dispatch time, because that would silently override a stored type.
+      const payload = await dispatchWithVersion({ fileType: null }, 'dep-ft-null');
+      expect(payload.fileType).toBe('exe');
+      expect(payload.fileName).toBe('package.exe');
+    });
+
+    it('falls back to exe for a file_type the agent could not install', async () => {
+      // The column is a bare nullable varchar with no CHECK, so anything a
+      // future route or manual UPDATE writes would otherwise reach the device
+      // verbatim and fail only AFTER the download.
+      const payload = await dispatchWithVersion({ fileType: 'rpm' }, 'dep-ft-bogus');
+      expect(payload.fileType).toBe('exe');
+      expect(payload.fileName).toBe('package.exe');
+    });
+
+    it('keeps a stored original filename in step with its type', async () => {
+      const payload = await dispatchWithVersion(
+        { fileType: 'msi', originalFileName: 'AcmeAgent.msi' },
+        'dep-ft-orig',
+      );
+      expect(payload.fileName).toBe('AcmeAgent.msi');
+      // The invariant the agent enforces, stated once here so any future change
+      // to either field has to keep them consistent.
+      expect(payload.fileName.toLowerCase().endsWith(`.${payload.fileType}`)).toBe(true);
+    });
+  });
+
   it('resolves a {{var.<key>}} tenant variable into the download URL (#3409 PR2)', async () => {
     const versionRecord = {
       id: 'ver-var2',

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -1,4 +1,5 @@
 import { and, eq, inArray } from 'drizzle-orm';
+import { isSoftwareFileType } from '@breeze/shared';
 import { db } from '../db';
 import {
   deploymentResults,
@@ -466,6 +467,10 @@ export async function buildAndDispatchSoftwareInstalls(
     // reconciliation keys on it) and the WS command id.
     const retryCount = deviceRetryCounts?.[device.id] ?? 0;
 
+    const resolvedFileType = isSoftwareFileType(versionRecord.fileType)
+      ? versionRecord.fileType
+      : 'exe';
+
     // deploymentId MUST be in the payload: the WS transport tracks it via
     // the sw-install-<deployment>-<device>-<attempt> command id, but the
     // queued fallback's device_commands row only has the payload to key
@@ -479,9 +484,19 @@ export async function buildAndDispatchSoftwareInstalls(
         approvedPrivateOrigins,
       },
       checksum: versionRecord.checksum,
-      fileName:
-        versionRecord.originalFileName ?? `package.${versionRecord.fileType ?? 'exe'}`,
-      fileType: versionRecord.fileType ?? 'exe',
+      // file_type is a plain nullable varchar with no CHECK constraint, so the
+      // column can hold anything a future route, import or manual UPDATE puts
+      // there. Narrow on read: an unrecognized value would otherwise be
+      // dispatched verbatim and only rejected by the agent AFTER the download,
+      // as `unsupported fileType`. 'exe' remains the historical fallback for a
+      // NULL — see deriveSoftwareFileTypeFromUrl on why we never guess better.
+      //
+      // fileName and fileType are a COUPLED pair, not two independent fields:
+      // the agent's validateInstallFileName rejects the command outright when
+      // the filename's extension doesn't equal '.' + fileType. Building the
+      // fallback name from the same resolved type is what keeps them in step.
+      fileName: versionRecord.originalFileName ?? `package.${resolvedFileType}`,
+      fileType: resolvedFileType,
       silentInstallArgs: deviceSilentInstallArgs,
       softwareName: catalogItem.name,
       version: versionRecord.version,

--- a/apps/api/src/services/softwareVersionShared.ts
+++ b/apps/api/src/services/softwareVersionShared.ts
@@ -5,10 +5,16 @@
  * Behavior is identical to the pre-extraction definitions.
  */
 import { and, eq } from 'drizzle-orm';
+import { SOFTWARE_FILE_TYPES } from '@breeze/shared';
 import { db } from '../db';
 import { softwareVersions } from '../db/schema';
 
-export const ALLOWED_EXTENSIONS = new Set(['.msi', '.exe', '.dmg', '.deb', '.pkg']);
+// Derived, not restated: this was a second hand-maintained copy of the installer
+// type list, and a third (the Go agent's isSupportedInstallFileType) is already
+// unavoidable. One TS source of truth is the most we can collapse to.
+export const ALLOWED_EXTENSIONS: ReadonlySet<string> = new Set(
+  SOFTWARE_FILE_TYPES.map((t) => `.${t}`),
+);
 export const MAX_UPLOAD_SIZE = 500 * 1024 * 1024; // 500 MB
 
 export type SoftwareVersionInsert = Omit<typeof softwareVersions.$inferInsert, 'catalogId' | 'isLatest'>;

--- a/apps/web/src/components/software/AddPackageModal.test.tsx
+++ b/apps/web/src/components/software/AddPackageModal.test.tsx
@@ -150,6 +150,52 @@ describe('AddPackageModal', () => {
       expect(screen.getByLabelText('Silent install args')).toHaveValue('');
     });
 
+    it('retracts the msiexec prefill when the URL is corrected to a non-MSI', async () => {
+      routeMock({});
+      render(<AddPackageModal open onClose={() => {}} onCreated={() => {}} />);
+      const urlInput = screen.getByPlaceholderText('https://example.com/package-v1.0.0.msi');
+
+      fireEvent.change(urlInput, { target: { value: 'https://dl.example.com/acme.msi' } });
+      await waitFor(() =>
+        expect(screen.getByLabelText('Silent install args')).toHaveValue(
+          'msiexec /i "{file}" /qn /norestart',
+        ),
+      );
+
+      // Leaving msiexec behind would ship `setup.exe msiexec /i …` to the agent.
+      fireEvent.change(urlInput, { target: { value: 'https://dl.example.com/setup.exe' } });
+      await waitFor(() =>
+        expect(screen.getByLabelText('Silent install args')).toHaveValue(''),
+      );
+    });
+
+    it('keeps a hand-typed command across a URL change', async () => {
+      routeMock({});
+      render(<AddPackageModal open onClose={() => {}} onCreated={() => {}} />);
+      const urlInput = screen.getByPlaceholderText('https://example.com/package-v1.0.0.msi');
+
+      fireEvent.change(screen.getByLabelText('Silent install args'), {
+        target: { value: '/S /norestart' },
+      });
+      fireEvent.change(urlInput, { target: { value: 'https://dl.example.com/acme.msi' } });
+
+      expect(screen.getByLabelText('Silent install args')).toHaveValue('/S /norestart');
+    });
+
+    it('retracts the prefill when the type selector is changed away from MSI', async () => {
+      routeMock({});
+      render(<AddPackageModal open onClose={() => {}} onCreated={() => {}} />);
+      fireEvent.change(screen.getByPlaceholderText('https://example.com/package-v1.0.0.msi'), {
+        target: { value: 'https://dl.example.com/acme.msi' },
+      });
+      await waitFor(() =>
+        expect(screen.getByLabelText('Silent install args')).not.toHaveValue(''),
+      );
+
+      fireEvent.change(screen.getByTestId('package-file-type'), { target: { value: 'exe' } });
+      expect(screen.getByLabelText('Silent install args')).toHaveValue('');
+    });
+
     it('omits fileType when left on auto so the server infers it', async () => {
       const onCreated = vi.fn();
       routeMock({});

--- a/apps/web/src/components/software/AddPackageModal.test.tsx
+++ b/apps/web/src/components/software/AddPackageModal.test.tsx
@@ -115,6 +115,71 @@ describe('AddPackageModal', () => {
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
   });
 
+  // A URL package used to carry no installer type at all, so the agent saved the
+  // MSI as package.exe and exec'd it directly — ERROR_BAD_EXE_FORMAT on Windows,
+  // with the operator's msiexec command silently discarded.
+  describe('installer type (URL source)', () => {
+    const versionBody = () => {
+      const call = fetchMock.mock.calls.find(
+        ([u, o]) => /\/versions$/.test(u as string) && o?.method === 'POST',
+      );
+      return JSON.parse((call?.[1] as RequestInit).body as string);
+    };
+
+    it('prefills the msiexec commands from a .msi URL', async () => {
+      routeMock({});
+      render(<AddPackageModal open onClose={() => {}} onCreated={() => {}} />);
+      fillMinimum();
+
+      await waitFor(() =>
+        expect(screen.getByLabelText('Silent install args')).toHaveValue(
+          'msiexec /i "{file}" /qn /norestart',
+        ),
+      );
+    });
+
+    it('leaves the install command alone for a non-MSI URL', async () => {
+      routeMock({});
+      render(<AddPackageModal open onClose={() => {}} onCreated={() => {}} />);
+      fireEvent.change(screen.getByPlaceholderText('https://example.com/package-v1.0.0.msi'), {
+        target: { value: 'https://dl.example.com/setup.exe' },
+      });
+
+      // An EXE's silent switch is vendor-specific; guessing one would install
+      // interactively (or not at all) on an unattended machine.
+      expect(screen.getByLabelText('Silent install args')).toHaveValue('');
+    });
+
+    it('omits fileType when left on auto so the server infers it', async () => {
+      const onCreated = vi.fn();
+      routeMock({});
+      render(<AddPackageModal open onClose={() => {}} onCreated={onCreated} />);
+      fillMinimum();
+      await submitCreate();
+      await waitFor(() => expect(onCreated).toHaveBeenCalled());
+
+      expect(versionBody()).not.toHaveProperty('fileType');
+      expect(versionBody().downloadUrl).toBe('https://dl.example.com/chrome.msi');
+    });
+
+    it('sends an explicitly chosen fileType for a URL with no usable extension', async () => {
+      const onCreated = vi.fn();
+      routeMock({});
+      render(<AddPackageModal open onClose={() => {}} onCreated={onCreated} />);
+      fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Acme' } });
+      fireEvent.change(screen.getByLabelText('Version'), { target: { value: '1.0.0' } });
+      fireEvent.change(screen.getByPlaceholderText('https://example.com/package-v1.0.0.msi'), {
+        target: { value: 'https://vendor.example.com/download.php?product=acme' },
+      });
+      fireEvent.change(screen.getByTestId('package-file-type'), { target: { value: 'msi' } });
+
+      await submitCreate();
+      await waitFor(() => expect(onCreated).toHaveBeenCalled());
+
+      expect(versionBody().fileType).toBe('msi');
+    });
+  });
+
   it('blocks submit when the URL contains an unknown variable', async () => {
     routeMock({});
     render(<AddPackageModal open onClose={() => {}} onCreated={() => {}} />);

--- a/apps/web/src/components/software/AddPackageModal.tsx
+++ b/apps/web/src/components/software/AddPackageModal.tsx
@@ -9,11 +9,11 @@ import {
 import { asList } from '@/lib/asList';
 import {
   SOFTWARE_FILE_TYPES,
-  defaultSilentArgsForFileType,
   deriveSoftwareFileTypeFromUrl,
   type DetectionRule,
   type SoftwareFileType,
 } from "@breeze/shared";
+import { applySilentArgsPrefill } from "@/lib/installerArgsPrefill";
 import { cn } from "@/lib/utils";
 import { Dialog } from "../shared/Dialog";
 import { showToast } from "../shared/Toast";
@@ -167,41 +167,40 @@ export default function AddPackageModal({
   const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
+    // A filename is a URL's last path segment as far as the derivation cares.
+    const derived = deriveSoftwareFileTypeFromUrl(file.name);
     setForm((prev) => ({
       ...prev,
       file,
       fileName: file.name,
-      silentInstallArgs:
-        ext === "msi" && !prev.silentInstallArgs
-          ? 'msiexec /i "{file}" /qn /norestart'
-          : prev.silentInstallArgs,
-      silentUninstallArgs:
-        ext === "msi" && !prev.silentUninstallArgs
-          ? 'msiexec /x "{file}" /qn /norestart'
-          : prev.silentUninstallArgs,
+      ...applySilentArgsPrefill(prev, derived),
     }));
   };
   /** URL-source counterpart to handleFile: the extension in the URL is the only
    *  signal we have about what the installer actually is, so prefill the same
-   *  MSI defaults from it. Prefill never overwrites something the user typed. */
+   *  MSI defaults from it. The prefill is retractable — see applySilentArgsPrefill
+   *  for why leaving a stale msiexec command behind is actively dangerous. */
   const handleDownloadUrl = (value: string) => {
-    setForm((prev) => {
-      const derived = deriveSoftwareFileTypeFromUrl(value);
-      const defaults = defaultSilentArgsForFileType(derived);
-      return {
-        ...prev,
-        downloadUrl: value,
-        silentInstallArgs:
-          defaults && !prev.silentInstallArgs
-            ? defaults.install
-            : prev.silentInstallArgs,
-        silentUninstallArgs:
-          defaults && !prev.silentUninstallArgs
-            ? defaults.uninstall
-            : prev.silentUninstallArgs,
-      };
-    });
+    setForm((prev) => ({
+      ...prev,
+      downloadUrl: value,
+      ...applySilentArgsPrefill(
+        prev,
+        // An explicit selector choice outranks the URL for prefill purposes too.
+        prev.fileType || deriveSoftwareFileTypeFromUrl(value),
+      ),
+    }));
+  };
+  /** Selector changes retract or install the prefill the same way a URL edit does. */
+  const handleFileTypeChange = (value: "" | SoftwareFileType) => {
+    setForm((prev) => ({
+      ...prev,
+      fileType: value,
+      ...applySilentArgsPrefill(
+        prev,
+        value || deriveSoftwareFileTypeFromUrl(prev.downloadUrl),
+      ),
+    }));
   };
   /** What the server will infer when the user leaves the selector on "auto" —
    *  shown so an unrecognized URL doesn't silently fall back to exe. */
@@ -666,8 +665,7 @@ export default function AddPackageModal({
                       data-testid="package-file-type"
                       value={form.fileType}
                       onChange={(e) =>
-                        update(
-                          "fileType",
+                        handleFileTypeChange(
                           e.target.value as "" | SoftwareFileType,
                         )
                       }
@@ -689,7 +687,9 @@ export default function AddPackageModal({
                         </option>
                       ))}
                     </select>
-                    {!form.fileType && !inferredFileType && (
+                    {form.downloadUrl.trim() !== "" &&
+                      !form.fileType &&
+                      !inferredFileType && (
                       <p className="mt-1 text-xs text-amber-600 dark:text-amber-500">
                         {i18n.t(
                           "policies:software.addPackageModal.installerTypeUndetected",

--- a/apps/web/src/components/software/AddPackageModal.tsx
+++ b/apps/web/src/components/software/AddPackageModal.tsx
@@ -7,7 +7,13 @@ import {
   HardDriveUpload,
 } from "lucide-react";
 import { asList } from '@/lib/asList';
-import type { DetectionRule } from "@breeze/shared";
+import {
+  SOFTWARE_FILE_TYPES,
+  defaultSilentArgsForFileType,
+  deriveSoftwareFileTypeFromUrl,
+  type DetectionRule,
+  type SoftwareFileType,
+} from "@breeze/shared";
 import { cn } from "@/lib/utils";
 import { Dialog } from "../shared/Dialog";
 import { showToast } from "../shared/Toast";
@@ -72,6 +78,9 @@ const blankForm = {
   architecture: "x64" as Architecture,
   source: "url" as Source,
   downloadUrl: "",
+  // "" = infer from the URL's extension server-side. Only meaningful for the URL
+  // source; the file source derives it from the uploaded filename.
+  fileType: "" as "" | SoftwareFileType,
   supportedOs: [] as string[],
   silentInstallArgs: "",
   silentUninstallArgs: "",
@@ -173,6 +182,33 @@ export default function AddPackageModal({
           : prev.silentUninstallArgs,
     }));
   };
+  /** URL-source counterpart to handleFile: the extension in the URL is the only
+   *  signal we have about what the installer actually is, so prefill the same
+   *  MSI defaults from it. Prefill never overwrites something the user typed. */
+  const handleDownloadUrl = (value: string) => {
+    setForm((prev) => {
+      const derived = deriveSoftwareFileTypeFromUrl(value);
+      const defaults = defaultSilentArgsForFileType(derived);
+      return {
+        ...prev,
+        downloadUrl: value,
+        silentInstallArgs:
+          defaults && !prev.silentInstallArgs
+            ? defaults.install
+            : prev.silentInstallArgs,
+        silentUninstallArgs:
+          defaults && !prev.silentUninstallArgs
+            ? defaults.uninstall
+            : prev.silentUninstallArgs,
+      };
+    });
+  };
+  /** What the server will infer when the user leaves the selector on "auto" —
+   *  shown so an unrecognized URL doesn't silently fall back to exe. */
+  const inferredFileType = useMemo(
+    () => deriveSoftwareFileTypeFromUrl(form.downloadUrl),
+    [form.downloadUrl],
+  );
   const knownKeys = useMemo(
     () => new Set(customFields.map((f) => f.fieldKey)),
     [customFields],
@@ -259,6 +295,8 @@ export default function AddPackageModal({
         body: JSON.stringify({
           ...shared,
           downloadUrl: form.downloadUrl.trim() || undefined,
+          // Omitted when left on "auto" so the server infers from the URL.
+          fileType: form.fileType || undefined,
         }),
       });
   };
@@ -598,7 +636,7 @@ export default function AddPackageModal({
                   <VariableInput
                     id="pkg-url"
                     value={form.downloadUrl}
-                    onChange={(v) => update("downloadUrl", v)}
+                    onChange={handleDownloadUrl}
                     placeholder={i18n.t(
                       "policies:software.addPackageModal.httpsExampleComPackageV100",
                     )}
@@ -614,6 +652,51 @@ export default function AddPackageModal({
                       "policies:software.addPackageModal.resolvedPerOrganizationAtDeployTime",
                     )}
                   </p>
+                  {/* The installer type decides whether the agent runs msiexec or
+                      execs the file directly, so an MSI behind a URL with no
+                      recognizable extension has to be stated explicitly. */}
+                  <div className="mt-3">
+                    <label className={labelCls} htmlFor="pkg-file-type">
+                      {i18n.t(
+                        "policies:software.addPackageModal.installerType",
+                      )}
+                    </label>
+                    <select
+                      id="pkg-file-type"
+                      data-testid="package-file-type"
+                      value={form.fileType}
+                      onChange={(e) =>
+                        update(
+                          "fileType",
+                          e.target.value as "" | SoftwareFileType,
+                        )
+                      }
+                      className="mt-1 h-10 w-full rounded-md border bg-background px-3 text-sm"
+                    >
+                      <option value="">
+                        {inferredFileType
+                          ? i18n.t(
+                              "policies:software.addPackageModal.autoDetectedType",
+                              { type: inferredFileType.toUpperCase() },
+                            )
+                          : i18n.t(
+                              "policies:software.addPackageModal.autoDetectFromUrl",
+                            )}
+                      </option>
+                      {SOFTWARE_FILE_TYPES.map((t) => (
+                        <option key={t} value={t}>
+                          {t.toUpperCase()}
+                        </option>
+                      ))}
+                    </select>
+                    {!form.fileType && !inferredFileType && (
+                      <p className="mt-1 text-xs text-amber-600 dark:text-amber-500">
+                        {i18n.t(
+                          "policies:software.addPackageModal.installerTypeUndetected",
+                        )}
+                      </p>
+                    )}
+                  </div>
                 </div>
               ) : (
                 <div className="mt-3 flex items-center gap-3">

--- a/apps/web/src/components/software/SoftwareVersionManager.fileType.test.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.fileType.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * The add-version-to-an-existing-package flow. It POSTs to the same
+ * `/software/catalog/:id/versions` route as AddPackageModal and had none of the
+ * installer-type handling, so a URL-sourced MSI added here reached the agent as
+ * `fileType: 'exe'` and was exec'd directly — the original bug, in the flow an
+ * MSP actually hits most often over a package's life.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SoftwareVersionManager from './SoftwareVersionManager';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../lib/softwarePackageUpload', () => ({ uploadPackageVersion: vi.fn() }));
+vi.mock('./DetectionRulesEditor', () => ({ default: () => null }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const EXISTING_VERSION = {
+  id: 'ver-1',
+  version: '1.0.0',
+  releaseDate: '2026-01-01T00:00:00Z',
+  architecture: 'x64',
+  fileType: 'msi',
+  isLatest: true,
+};
+
+async function renderLoaded() {
+  render(<SoftwareVersionManager catalogId="cat-1" embedded />);
+  await waitFor(() =>
+    expect(screen.queryByText(/loading software versions/i)).not.toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByRole('button', { name: /add version/i }));
+}
+
+const urlInput = () =>
+  screen.getByPlaceholderText('https://example.com/package-v1.0.0.msi');
+
+/** The JSON body of the metadata-only version POST. */
+const versionBody = () => {
+  const call = fetchMock.mock.calls.find(
+    ([u, o]) => /\/versions$/.test(String(u)) && (o as RequestInit)?.method === 'POST',
+  );
+  return JSON.parse((call?.[1] as RequestInit).body as string);
+};
+
+const submitForm = () =>
+  fireEvent.submit(urlInput().closest('form')!);
+
+describe('SoftwareVersionManager installer type (URL source)', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementation((url: string, opts?: RequestInit) => {
+      if (String(url).startsWith('/custom-fields')) {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+      if (/\/versions$/.test(String(url)) && opts?.method === 'POST') {
+        return Promise.resolve(jsonResponse({ data: { ...EXISTING_VERSION, id: 'ver-2' } }));
+      }
+      return Promise.resolve(jsonResponse({ data: [EXISTING_VERSION] }));
+    });
+  });
+
+  it('prefills the msiexec commands from a .msi URL', async () => {
+    await renderLoaded();
+    fireEvent.change(urlInput(), { target: { value: 'https://cdn.example/acme.msi' } });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('version-file-type')).toHaveValue(''),
+    );
+    expect(screen.getByDisplayValue('msiexec /i "{file}" /qn /norestart')).toBeTruthy();
+  });
+
+  it('retracts the prefill when the URL is corrected to a non-MSI', async () => {
+    await renderLoaded();
+    fireEvent.change(urlInput(), { target: { value: 'https://cdn.example/acme.msi' } });
+    await waitFor(() =>
+      expect(screen.queryByDisplayValue('msiexec /i "{file}" /qn /norestart')).toBeTruthy(),
+    );
+
+    fireEvent.change(urlInput(), { target: { value: 'https://cdn.example/setup.exe' } });
+    await waitFor(() =>
+      expect(screen.queryByDisplayValue('msiexec /i "{file}" /qn /norestart')).toBeNull(),
+    );
+  });
+
+  it('sends an explicitly chosen fileType for a URL with no usable extension', async () => {
+    await renderLoaded();
+    fireEvent.change(screen.getByPlaceholderText('e.g. 1.0.0'), {
+      target: { value: '2.0.0' },
+    });
+    fireEvent.change(urlInput(), {
+      target: { value: 'https://vendor.example/download.php?product=acme' },
+    });
+    fireEvent.change(screen.getByTestId('version-file-type'), { target: { value: 'msi' } });
+
+    submitForm();
+
+    await waitFor(() => expect(versionBody().fileType).toBe('msi'));
+  });
+
+  it('omits fileType when left on auto so the server infers it', async () => {
+    await renderLoaded();
+    fireEvent.change(screen.getByPlaceholderText('e.g. 1.0.0'), {
+      target: { value: '2.0.0' },
+    });
+    fireEvent.change(urlInput(), { target: { value: 'https://cdn.example/acme.msi' } });
+
+    submitForm();
+
+    await waitFor(() => expect(versionBody().downloadUrl).toBe('https://cdn.example/acme.msi'));
+    expect(versionBody()).not.toHaveProperty('fileType');
+  });
+
+  it('warns when the URL carries no recognizable installer extension', async () => {
+    await renderLoaded();
+    fireEvent.change(urlInput(), {
+      target: { value: 'https://vendor.example/download.php?product=acme' },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/no recognizable installer extension/i)).toBeTruthy(),
+    );
+  });
+
+  it('does not warn before a URL has been entered', async () => {
+    await renderLoaded();
+    expect(screen.queryByText(/no recognizable installer extension/i)).toBeNull();
+  });
+});

--- a/apps/web/src/components/software/SoftwareVersionManager.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.tsx
@@ -10,7 +10,13 @@ import {
   Upload,
 } from "lucide-react";
 import { asList } from '@/lib/asList';
-import type { DetectionRule } from "@breeze/shared";
+import {
+  SOFTWARE_FILE_TYPES,
+  deriveSoftwareFileTypeFromUrl,
+  type DetectionRule,
+  type SoftwareFileType,
+} from "@breeze/shared";
+import { applySilentArgsPrefill } from "@/lib/installerArgsPrefill";
 import { cn } from "@/lib/utils";
 import { fetchWithAuth } from "../../stores/auth";
 import { findUnknownTokens } from "@/lib/installerVariables";
@@ -122,6 +128,9 @@ export default function SoftwareVersionManager({
     silentInstallArgs: "",
     silentUninstallArgs: "",
     downloadUrl: "",
+    // "" = let the server infer from the URL. Only meaningful for the URL
+    // source; the upload path derives it from the uploaded filename.
+    fileType: "" as "" | SoftwareFileType,
     supportedOs: [] as string[],
     detectionRules: [] as DetectionRule[],
     file: null as File | null,
@@ -249,22 +258,42 @@ export default function SoftwareVersionManager({
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
-    const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
     setFormState((prev) => ({
       ...prev,
       file,
       fileName: file.name,
-      // Auto-populate MSI silent args
-      silentInstallArgs:
-        ext === "msi" && !prev.silentInstallArgs
-          ? 'msiexec /i "{file}" /qn /norestart'
-          : prev.silentInstallArgs,
-      silentUninstallArgs:
-        ext === "msi" && !prev.silentUninstallArgs
-          ? 'msiexec /x "{file}" /qn /norestart'
-          : prev.silentUninstallArgs,
+      // Auto-populate MSI silent args (retractable — see applySilentArgsPrefill).
+      ...applySilentArgsPrefill(prev, deriveSoftwareFileTypeFromUrl(file.name)),
     }));
   };
+  /** The URL source carries no filename, so the installer type has to come from
+   *  the URL's extension or from the operator. Without it the server stores
+   *  file_type NULL, the dispatcher falls back to 'exe', and the agent execs the
+   *  installer directly — which is the bug this whole path exists to prevent. */
+  const handleDownloadUrlChange = (value: string) => {
+    setFormState((prev) => ({
+      ...prev,
+      downloadUrl: value,
+      ...applySilentArgsPrefill(
+        prev,
+        prev.fileType || deriveSoftwareFileTypeFromUrl(value),
+      ),
+    }));
+  };
+  const handleFileTypeChange = (value: "" | SoftwareFileType) => {
+    setFormState((prev) => ({
+      ...prev,
+      fileType: value,
+      ...applySilentArgsPrefill(
+        prev,
+        value || deriveSoftwareFileTypeFromUrl(prev.downloadUrl),
+      ),
+    }));
+  };
+  const inferredFileType = useMemo(
+    () => deriveSoftwareFileTypeFromUrl(formState.downloadUrl),
+    [formState.downloadUrl],
+  );
   const handlePromoteLatest = useCallback(
     async (versionId: string) => {
       if (!catalogId || versionId === latestId) return;
@@ -396,6 +425,8 @@ export default function SoftwareVersionManager({
               silentInstallArgs: formState.silentInstallArgs || undefined,
               silentUninstallArgs: formState.silentUninstallArgs || undefined,
               downloadUrl: formState.downloadUrl || undefined,
+              // Omitted on "auto" so the server infers from the URL.
+              fileType: formState.fileType || undefined,
               supportedOs:
                 formState.supportedOs.length > 0
                   ? formState.supportedOs
@@ -429,6 +460,7 @@ export default function SoftwareVersionManager({
         silentInstallArgs: "",
         silentUninstallArgs: "",
         downloadUrl: "",
+        fileType: "",
         supportedOs: [],
         detectionRules: [],
         file: null,
@@ -589,9 +621,7 @@ export default function SoftwareVersionManager({
             <div className="mt-2">
               <VariableInput
                 value={formState.downloadUrl}
-                onChange={(value) =>
-                  setFormState((prev) => ({ ...prev, downloadUrl: value }))
-                }
+                onChange={handleDownloadUrlChange}
                 placeholder={i18n.t(
                   "policies:software.softwareVersionManager.httpsExampleComPackageV100",
                 )}
@@ -610,6 +640,54 @@ export default function SoftwareVersionManager({
                 "policies:software.softwareVersionManager.resolvePerOrganizationAtDeployTime",
               )}
             </p>
+            {/* Only shown for the URL source: the upload path derives the type
+                from the uploaded filename and needs no operator input. */}
+            {!formState.file && (
+              <div className="mt-3">
+                <label
+                  className="text-xs font-semibold uppercase text-muted-foreground"
+                  htmlFor="version-file-type"
+                >
+                  {i18n.t(
+                    "policies:software.softwareVersionManager.installerType",
+                  )}
+                </label>
+                <select
+                  id="version-file-type"
+                  data-testid="version-file-type"
+                  value={formState.fileType}
+                  onChange={(e) =>
+                    handleFileTypeChange(e.target.value as "" | SoftwareFileType)
+                  }
+                  className="mt-1 h-10 w-full rounded-md border bg-background px-3 text-sm"
+                >
+                  <option value="">
+                    {inferredFileType
+                      ? i18n.t(
+                          "policies:software.softwareVersionManager.autoDetectedType",
+                          { type: inferredFileType.toUpperCase() },
+                        )
+                      : i18n.t(
+                          "policies:software.softwareVersionManager.autoDetectFromUrl",
+                        )}
+                  </option>
+                  {SOFTWARE_FILE_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {t.toUpperCase()}
+                    </option>
+                  ))}
+                </select>
+                {formState.downloadUrl.trim() !== "" &&
+                  !formState.fileType &&
+                  !inferredFileType && (
+                    <p className="mt-1 text-xs text-amber-600 dark:text-amber-500">
+                      {i18n.t(
+                        "policies:software.softwareVersionManager.installerTypeUndetected",
+                      )}
+                    </p>
+                  )}
+              </div>
+            )}
           </div>
 
           <div className="mt-4">

--- a/apps/web/src/lib/__tests__/installerArgsPrefill.test.ts
+++ b/apps/web/src/lib/__tests__/installerArgsPrefill.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { applySilentArgsPrefill } from '../installerArgsPrefill';
+
+const MSI_INSTALL = 'msiexec /i "{file}" /qn /norestart';
+const MSI_UNINSTALL = 'msiexec /x "{file}" /qn /norestart';
+const EMPTY = { silentInstallArgs: '', silentUninstallArgs: '' };
+
+describe('applySilentArgsPrefill', () => {
+  it('fills empty fields with the MSI defaults', () => {
+    expect(applySilentArgsPrefill(EMPTY, 'msi')).toEqual({
+      silentInstallArgs: MSI_INSTALL,
+      silentUninstallArgs: MSI_UNINSTALL,
+    });
+  });
+
+  it('leaves empty fields empty for a type with no default', () => {
+    expect(applySilentArgsPrefill(EMPTY, 'exe')).toEqual(EMPTY);
+    expect(applySilentArgsPrefill(EMPTY, null)).toEqual(EMPTY);
+  });
+
+  it('RETRACTS its own prefill when the type changes away from msi', () => {
+    // The bug this exists to prevent: leaving msiexec behind on an EXE package
+    // makes the agent run `setup.exe msiexec /i <path> /qn /norestart`, and most
+    // NSIS/InstallShield installers ignore unknown switches and open an
+    // interactive UI — an unattended install that hangs instead of failing.
+    const prefilled = { silentInstallArgs: MSI_INSTALL, silentUninstallArgs: MSI_UNINSTALL };
+    expect(applySilentArgsPrefill(prefilled, 'exe')).toEqual(EMPTY);
+    expect(applySilentArgsPrefill(prefilled, null)).toEqual(EMPTY);
+  });
+
+  it('never overwrites a command the user typed', () => {
+    const typed = {
+      silentInstallArgs: '/S /norestart',
+      silentUninstallArgs: '/uninstall /S',
+    };
+    expect(applySilentArgsPrefill(typed, 'msi')).toEqual(typed);
+    expect(applySilentArgsPrefill(typed, 'exe')).toEqual(typed);
+  });
+
+  it('treats a user edit of a prefilled value as user-owned', () => {
+    // Same command plus REBOOT=ReallySuppress — no longer verbatim ours.
+    const edited = {
+      silentInstallArgs: 'msiexec /i "{file}" /qn REBOOT=ReallySuppress',
+      silentUninstallArgs: MSI_UNINSTALL,
+    };
+    const result = applySilentArgsPrefill(edited, 'exe');
+    expect(result.silentInstallArgs).toBe('msiexec /i "{file}" /qn REBOOT=ReallySuppress');
+    // The untouched uninstall field is still ours, so it retracts.
+    expect(result.silentUninstallArgs).toBe('');
+  });
+
+  it('decides ownership per field, not for the pair', () => {
+    const mixed = { silentInstallArgs: '/S', silentUninstallArgs: '' };
+    expect(applySilentArgsPrefill(mixed, 'msi')).toEqual({
+      silentInstallArgs: '/S',
+      silentUninstallArgs: MSI_UNINSTALL,
+    });
+  });
+
+  it('is idempotent for a stable type', () => {
+    const once = applySilentArgsPrefill(EMPTY, 'msi');
+    expect(applySilentArgsPrefill(once, 'msi')).toEqual(once);
+  });
+});

--- a/apps/web/src/lib/installerArgsPrefill.ts
+++ b/apps/web/src/lib/installerArgsPrefill.ts
@@ -1,0 +1,59 @@
+import {
+  SOFTWARE_FILE_TYPES,
+  defaultSilentArgsForFileType,
+  type SilentInstallDefaults,
+  type SoftwareFileType,
+} from "@breeze/shared";
+
+/**
+ * Retractable prefill for the silent install/uninstall command fields.
+ *
+ * A one-directional prefill (fill when empty, never clear) is a silent
+ * misconfiguration generator: type a `.msi` URL and the fields auto-fill with
+ * the msiexec pair, then correct the URL to `.exe` and the msiexec command stays
+ * behind. The version is then stored as `fileType: 'exe'` WITH msiexec args, and
+ * the agent's EXE branch runs `setup.exe msiexec /i <path> /qn /norestart` —
+ * most NSIS/InstallShield installers ignore unknown switches and open an
+ * interactive UI, so an unattended install hangs instead of failing loudly.
+ * Nothing catches it agent-side either: validateMSIInstallArgs only runs when
+ * fileType is 'msi'.
+ *
+ * So the prefill has to be OWNED rather than sticky — replaced or withdrawn when
+ * the installer type changes, but never overwriting something a human typed.
+ * Ownership is decided by value, not by tracking edits: a field still holding a
+ * string this module could have produced is ours to revise. That is also what
+ * makes it correct across a source switch (URL -> file upload and back), where
+ * the previous type isn't otherwise recoverable.
+ */
+
+/** True when `current` is empty or is verbatim a default this module generated. */
+function isPrefillOwned(
+  current: string,
+  pick: (defaults: SilentInstallDefaults) => string,
+): boolean {
+  if (current === "") return true;
+  return SOFTWARE_FILE_TYPES.some((type) => {
+    const defaults = defaultSilentArgsForFileType(type);
+    return defaults !== null && pick(defaults) === current;
+  });
+}
+
+/**
+ * The silent-args fields as they should read for `nextFileType`. Owned fields are
+ * rewritten to the new type's defaults (or cleared when it has none); anything
+ * the user typed is returned unchanged.
+ */
+export function applySilentArgsPrefill(
+  current: { silentInstallArgs: string; silentUninstallArgs: string },
+  nextFileType: SoftwareFileType | null,
+): { silentInstallArgs: string; silentUninstallArgs: string } {
+  const next = defaultSilentArgsForFileType(nextFileType);
+  return {
+    silentInstallArgs: isPrefillOwned(current.silentInstallArgs, (d) => d.install)
+      ? (next?.install ?? "")
+      : current.silentInstallArgs,
+    silentUninstallArgs: isPrefillOwned(current.silentUninstallArgs, (d) => d.uninstall)
+      ? (next?.uninstall ?? "")
+      : current.silentUninstallArgs,
+  };
+}

--- a/apps/web/src/locales/de-DE/policies.json
+++ b/apps/web/src/locales/de-DE/policies.json
@@ -1211,7 +1211,11 @@
       "uploading": "Hochladen…",
       "creating": "Erstellen…",
       "retryAddingVersion": "Versuchen Sie erneut, die Version hinzuzufügen",
-      "createPackage": "Paket erstellen"
+      "createPackage": "Paket erstellen",
+      "installerType": "Installationstyp",
+      "autoDetectFromUrl": "Automatisch aus URL erkennen",
+      "autoDetectedType": "Automatisch erkannt ({{type}})",
+      "installerTypeUndetected": "Diese URL hat keine erkennbare Installationsdatei-Endung. Wählen Sie den Typ explizit aus — andernfalls wird die heruntergeladene Datei direkt ausgeführt, was bei einer MSI fehlschlägt."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Verwaltet integriert",

--- a/apps/web/src/locales/de-DE/policies.json
+++ b/apps/web/src/locales/de-DE/policies.json
@@ -1710,7 +1710,11 @@
       "saving": "Speichern...",
       "uploadSave": "Hochladen und speichern",
       "saveVersion": "Version speichern",
-      "setAsLatest": "Als aktuell festlegen"
+      "setAsLatest": "Als aktuell festlegen",
+      "installerType": "Installationstyp",
+      "autoDetectFromUrl": "Automatisch aus URL erkennen",
+      "autoDetectedType": "Automatisch erkannt ({{type}})",
+      "installerTypeUndetected": "Diese URL hat keine erkennbare Installationsdatei-Endung. Wählen Sie den Typ explizit aus — andernfalls wird die heruntergeladene Datei direkt ausgeführt, was bei einer MSI fehlschlägt."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Fügen Sie eine Bereitstellungszeitvariable ein",

--- a/apps/web/src/locales/en/policies.json
+++ b/apps/web/src/locales/en/policies.json
@@ -1211,7 +1211,11 @@
       "uploading": "Uploading…",
       "creating": "Creating…",
       "retryAddingVersion": "Retry adding version",
-      "createPackage": "Create package"
+      "createPackage": "Create package",
+      "installerType": "Installer type",
+      "autoDetectFromUrl": "Auto-detect from URL",
+      "autoDetectedType": "Auto-detect ({{type}})",
+      "installerTypeUndetected": "This URL has no recognizable installer extension. Pick the type explicitly — otherwise the downloaded file is run directly, which fails for an MSI."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Managed built-in",

--- a/apps/web/src/locales/en/policies.json
+++ b/apps/web/src/locales/en/policies.json
@@ -1710,7 +1710,11 @@
       "saving": "Saving...",
       "uploadSave": "Upload & Save",
       "saveVersion": "Save Version",
-      "setAsLatest": "Set as latest"
+      "setAsLatest": "Set as latest",
+      "installerType": "Installer type",
+      "autoDetectFromUrl": "Auto-detect from URL",
+      "autoDetectedType": "Auto-detect ({{type}})",
+      "installerTypeUndetected": "This URL has no recognizable installer extension. Pick the type explicitly — otherwise the downloaded file is run directly, which fails for an MSI."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Insert a deploy-time variable",

--- a/apps/web/src/locales/es-419/policies.json
+++ b/apps/web/src/locales/es-419/policies.json
@@ -1211,7 +1211,11 @@
       "uploading": "Subiendo…",
       "creating": "Creando…",
       "retryAddingVersion": "Reintentar agregar versión",
-      "createPackage": "Crear paquete"
+      "createPackage": "Crear paquete",
+      "installerType": "Tipo de instalador",
+      "autoDetectFromUrl": "Detectar automáticamente desde la URL",
+      "autoDetectedType": "Detección automática ({{type}})",
+      "installerTypeUndetected": "Esta URL no tiene una extensión de instalador reconocible. Elija el tipo explícitamente; de lo contrario, el archivo descargado se ejecuta directamente, lo que falla con un MSI."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Gestionado integrado",

--- a/apps/web/src/locales/es-419/policies.json
+++ b/apps/web/src/locales/es-419/policies.json
@@ -1710,7 +1710,11 @@
       "saving": "Guardando...",
       "uploadSave": "Cargar y guardar",
       "saveVersion": "Guardar versión",
-      "setAsLatest": "Establecer como más reciente"
+      "setAsLatest": "Establecer como más reciente",
+      "installerType": "Tipo de instalador",
+      "autoDetectFromUrl": "Detectar automáticamente desde la URL",
+      "autoDetectedType": "Detección automática ({{type}})",
+      "installerTypeUndetected": "Esta URL no tiene una extensión de instalador reconocible. Elija el tipo explícitamente; de lo contrario, el archivo descargado se ejecuta directamente, lo que falla con un MSI."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Insertar una variable de tiempo de implementación",

--- a/apps/web/src/locales/fr-CA/policies.json
+++ b/apps/web/src/locales/fr-CA/policies.json
@@ -1211,7 +1211,11 @@
       "uploading": "Téléversement...",
       "creating": "Création…",
       "retryAddingVersion": "Réessayer d’ajouter la version",
-      "createPackage": "Créer un package"
+      "createPackage": "Créer un package",
+      "installerType": "Type d'installateur",
+      "autoDetectFromUrl": "Détecter automatiquement depuis l'URL",
+      "autoDetectedType": "Détection automatique ({{type}})",
+      "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Intégré géré",

--- a/apps/web/src/locales/fr-CA/policies.json
+++ b/apps/web/src/locales/fr-CA/policies.json
@@ -1710,7 +1710,11 @@
       "saving": "Enregistrement...",
       "uploadSave": "Téléverser et enregistrer",
       "saveVersion": "Enregistrer la version",
-      "setAsLatest": "Fixé comme le plus récent"
+      "setAsLatest": "Fixé comme le plus récent",
+      "installerType": "Type d'installateur",
+      "autoDetectFromUrl": "Détecter automatiquement depuis l'URL",
+      "autoDetectedType": "Détection automatique ({{type}})",
+      "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Insérer une variable de temps de déploiement",

--- a/apps/web/src/locales/fr-FR/policies.json
+++ b/apps/web/src/locales/fr-FR/policies.json
@@ -1710,7 +1710,11 @@
       "saving": "Enregistrement...",
       "uploadSave": "Téléverser et enregistrer",
       "saveVersion": "Enregistrer la version",
-      "setAsLatest": "Fixé comme le plus récent"
+      "setAsLatest": "Fixé comme le plus récent",
+      "installerType": "Type d'installateur",
+      "autoDetectFromUrl": "Détecter automatiquement depuis l'URL",
+      "autoDetectedType": "Détection automatique ({{type}})",
+      "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Insérer une variable de temps de déploiement",

--- a/apps/web/src/locales/fr-FR/policies.json
+++ b/apps/web/src/locales/fr-FR/policies.json
@@ -1211,7 +1211,11 @@
       "uploading": "Téléchargement...",
       "creating": "Création…",
       "retryAddingVersion": "Réessayer d’ajouter la version",
-      "createPackage": "Créer un package"
+      "createPackage": "Créer un package",
+      "installerType": "Type d'installateur",
+      "autoDetectFromUrl": "Détecter automatiquement depuis l'URL",
+      "autoDetectedType": "Détection automatique ({{type}})",
+      "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Intégré géré",

--- a/apps/web/src/locales/it-IT/policies.json
+++ b/apps/web/src/locales/it-IT/policies.json
@@ -1710,7 +1710,11 @@
       "saving": "Salvataggio...",
       "uploadSave": "Carica e salva",
       "saveVersion": "Salva versione",
-      "setAsLatest": "Imposta come più recente"
+      "setAsLatest": "Imposta come più recente",
+      "installerType": "Tipo di installer",
+      "autoDetectFromUrl": "Rilevamento automatico dall'URL",
+      "autoDetectedType": "Rilevamento automatico ({{type}})",
+      "installerTypeUndetected": "Questo URL non ha un'estensione di installer riconoscibile. Scegli il tipo esplicitamente, altrimenti il file scaricato viene eseguito direttamente, cosa che fallisce per un MSI."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Inserisci una variabile di distribuzione",

--- a/apps/web/src/locales/it-IT/policies.json
+++ b/apps/web/src/locales/it-IT/policies.json
@@ -1211,7 +1211,11 @@
       "uploading": "Caricamento…",
       "creating": "Creazione…",
       "retryAddingVersion": "Riprova ad aggiungere la versione",
-      "createPackage": "Crea pacchetto"
+      "createPackage": "Crea pacchetto",
+      "installerType": "Tipo di installer",
+      "autoDetectFromUrl": "Rilevamento automatico dall'URL",
+      "autoDetectedType": "Rilevamento automatico ({{type}})",
+      "installerTypeUndetected": "Questo URL non ha un'estensione di installer riconoscibile. Scegli il tipo esplicitamente, altrimenti il file scaricato viene eseguito direttamente, cosa che fallisce per un MSI."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Integrato gestito",

--- a/apps/web/src/locales/pt-BR/policies.json
+++ b/apps/web/src/locales/pt-BR/policies.json
@@ -1710,7 +1710,11 @@
       "saving": "Salvando...",
       "uploadSave": "Enviar e salvar",
       "saveVersion": "Salvar versão",
-      "setAsLatest": "Definir como mais recente"
+      "setAsLatest": "Definir como mais recente",
+      "installerType": "Tipo de instalador",
+      "autoDetectFromUrl": "Detectar automaticamente pela URL",
+      "autoDetectedType": "Detecção automática ({{type}})",
+      "installerTypeUndetected": "Esta URL não tem uma extensão de instalador reconhecível. Escolha o tipo explicitamente — caso contrário, o arquivo baixado é executado diretamente, o que falha para um MSI."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Inserir uma variável de tempo de implantação",

--- a/apps/web/src/locales/pt-BR/policies.json
+++ b/apps/web/src/locales/pt-BR/policies.json
@@ -1211,7 +1211,11 @@
       "uploading": "Enviando…",
       "creating": "Criando…",
       "retryAddingVersion": "Tentar adicionar versão novamente",
-      "createPackage": "Criar pacote"
+      "createPackage": "Criar pacote",
+      "installerType": "Tipo de instalador",
+      "autoDetectFromUrl": "Detectar automaticamente pela URL",
+      "autoDetectedType": "Detecção automática ({{type}})",
+      "installerTypeUndetected": "Esta URL não tem uma extensão de instalador reconhecível. Escolha o tipo explicitamente — caso contrário, o arquivo baixado é executado diretamente, o que falha para um MSI."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Integrado gerenciado",

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -11,6 +11,7 @@ export * from './csvExport';
 export * from './reportSchedule';
 export * from './s3Region';
 export * from './s3Endpoint';
+export * from './softwareFileType';
 // Deliberately NOT `export *`. `compileExcludeMatcher` is a code-point port of
 // the agent's matcher and knowingly diverges from Go on mid-rune byte offsets
 // and Unicode special-casing (see matcherPortLimitations in

--- a/packages/shared/src/utils/softwareFileType.test.ts
+++ b/packages/shared/src/utils/softwareFileType.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SOFTWARE_FILE_TYPES,
+  isSoftwareFileType,
+  deriveSoftwareFileTypeFromUrl,
+  defaultSilentArgsForFileType,
+} from './softwareFileType';
+
+describe('deriveSoftwareFileTypeFromUrl', () => {
+  it('derives every supported type from a plain URL', () => {
+    for (const type of SOFTWARE_FILE_TYPES) {
+      expect(deriveSoftwareFileTypeFromUrl(`https://vendor.example/pkg.${type}`)).toBe(type);
+    }
+  });
+
+  it('ignores the query string and fragment', () => {
+    // The regression: a presigned vendor URL puts a signature after the
+    // extension, and naive `endsWith('.msi')` misses it.
+    expect(
+      deriveSoftwareFileTypeFromUrl('https://cdn.example/agent.msi?X-Amz-Signature=abc123&e=1'),
+    ).toBe('msi');
+    expect(deriveSoftwareFileTypeFromUrl('https://cdn.example/agent.msi#sha256')).toBe('msi');
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(deriveSoftwareFileTypeFromUrl('https://cdn.example/Agent.MSI')).toBe('msi');
+  });
+
+  it('survives unresolved deploy-time tokens that make the URL unparseable', () => {
+    // `new URL()` would percent-encode or reject these; the extension must still
+    // be recoverable because token substitution happens later, on dispatch.
+    expect(
+      deriveSoftwareFileTypeFromUrl('https://cdn.example/{{org.name}}/agent.msi'),
+    ).toBe('msi');
+    expect(
+      deriveSoftwareFileTypeFromUrl('https://cdn.example/agent.msi?key={{var.site_key}}'),
+    ).toBe('msi');
+  });
+
+  it('returns null rather than guessing when there is no usable extension', () => {
+    // Guessing 'exe' here is exactly the bug this module exists to fix.
+    expect(deriveSoftwareFileTypeFromUrl('https://vendor.example/download.php?product=foo')).toBeNull();
+    expect(deriveSoftwareFileTypeFromUrl('https://vendor.example/latest')).toBeNull();
+    expect(deriveSoftwareFileTypeFromUrl('https://vendor.example/pkg.zip')).toBeNull();
+    expect(deriveSoftwareFileTypeFromUrl('https://vendor.example/')).toBeNull();
+  });
+
+  it('does not mistake a dotted host or path segment for an extension', () => {
+    expect(deriveSoftwareFileTypeFromUrl('https://downloads.vendor.example')).toBeNull();
+    expect(deriveSoftwareFileTypeFromUrl('https://vendor.example/v1.2.3/installer')).toBeNull();
+  });
+
+  it('handles empty and non-string input', () => {
+    expect(deriveSoftwareFileTypeFromUrl('')).toBeNull();
+    expect(deriveSoftwareFileTypeFromUrl('   ')).toBeNull();
+    expect(deriveSoftwareFileTypeFromUrl(null)).toBeNull();
+    expect(deriveSoftwareFileTypeFromUrl(undefined)).toBeNull();
+  });
+});
+
+describe('isSoftwareFileType', () => {
+  it('accepts supported types and rejects everything else', () => {
+    expect(isSoftwareFileType('msi')).toBe(true);
+    expect(isSoftwareFileType('zip')).toBe(false);
+    expect(isSoftwareFileType('MSI')).toBe(false); // callers lowercase first
+    expect(isSoftwareFileType(null)).toBe(false);
+  });
+});
+
+describe('defaultSilentArgsForFileType', () => {
+  it('returns the msiexec pair for msi', () => {
+    expect(defaultSilentArgsForFileType('msi')).toEqual({
+      install: 'msiexec /i "{file}" /qn /norestart',
+      uninstall: 'msiexec /x "{file}" /qn /norestart',
+    });
+  });
+
+  it('quotes {file} so a temp path containing spaces stays one argument', () => {
+    // The agent substitutes {file} BEFORE tokenizing on spaces, so an unquoted
+    // token would split a spaced path across several argv entries.
+    expect(defaultSilentArgsForFileType('msi')!.install).toContain('"{file}"');
+  });
+
+  it('has no default for types whose silent switch is vendor-specific', () => {
+    expect(defaultSilentArgsForFileType('exe')).toBeNull();
+    expect(defaultSilentArgsForFileType('deb')).toBeNull();
+    expect(defaultSilentArgsForFileType(null)).toBeNull();
+    expect(defaultSilentArgsForFileType(undefined)).toBeNull();
+  });
+});

--- a/packages/shared/src/utils/softwareFileType.test.ts
+++ b/packages/shared/src/utils/softwareFileType.test.ts
@@ -48,6 +48,18 @@ describe('deriveSoftwareFileTypeFromUrl', () => {
   it('does not mistake a dotted host or path segment for an extension', () => {
     expect(deriveSoftwareFileTypeFromUrl('https://downloads.vendor.example')).toBeNull();
     expect(deriveSoftwareFileTypeFromUrl('https://vendor.example/v1.2.3/installer')).toBeNull();
+    expect(deriveSoftwareFileTypeFromUrl('https://vendor.example/installers/')).toBeNull();
+  });
+
+  it('does not read an extension out of the query string', () => {
+    // Pinned deliberately. A well-meaning "improvement" that scanned the query
+    // string would reintroduce this bug pointed the other way: a download
+    // script whose ?file= names an MSI may still serve an EXE wrapper.
+    expect(deriveSoftwareFileTypeFromUrl('https://host/download?file=agent.msi')).toBeNull();
+  });
+
+  it('does not decode percent-encoded separators', () => {
+    expect(deriveSoftwareFileTypeFromUrl('https://host/agent%2Emsi')).toBeNull();
   });
 
   it('handles empty and non-string input', () => {
@@ -81,10 +93,31 @@ describe('defaultSilentArgsForFileType', () => {
     expect(defaultSilentArgsForFileType('msi')!.install).toContain('"{file}"');
   });
 
-  it('has no default for types whose silent switch is vendor-specific', () => {
+  it('has no default for exe, whose silent switch is vendor-specific', () => {
     expect(defaultSilentArgsForFileType('exe')).toBeNull();
+  });
+
+  it('has no default for deb/pkg/dmg, whose args the agent ignores entirely', () => {
+    // Different reason from exe: the agent hardcodes `dpkg -i`,
+    // `installer -pkg … -target /` and mount-and-install, and never reads
+    // silentInstallArgs for these at all.
     expect(defaultSilentArgsForFileType('deb')).toBeNull();
+    expect(defaultSilentArgsForFileType('pkg')).toBeNull();
+    expect(defaultSilentArgsForFileType('dmg')).toBeNull();
+  });
+
+  it('normalizes case and surrounding space', () => {
+    // A stored 'MSI' must not silently yield no defaults — every other layer
+    // (Go's strings.ToLower, getFileExtension) is case-insensitive.
+    expect(defaultSilentArgsForFileType('MSI')?.install).toBe(
+      'msiexec /i "{file}" /qn /norestart',
+    );
+    expect(defaultSilentArgsForFileType('  msi  ')).not.toBeNull();
+  });
+
+  it('has no default for a missing type', () => {
     expect(defaultSilentArgsForFileType(null)).toBeNull();
     expect(defaultSilentArgsForFileType(undefined)).toBeNull();
+    expect(defaultSilentArgsForFileType('rpm')).toBeNull();
   });
 });

--- a/packages/shared/src/utils/softwareFileType.ts
+++ b/packages/shared/src/utils/softwareFileType.ts
@@ -1,0 +1,83 @@
+/**
+ * Installer file-type helpers shared by the API (routes/software.ts,
+ * services/softwareVersionShared.ts) and the web package form
+ * (components/software/AddPackageModal.tsx).
+ *
+ * Why this is shared rather than API-local: a software version created from a
+ * download URL never had a `file_type`, because only the UPLOAD path derived one
+ * from the uploaded filename. The dispatcher then fell back to
+ * `fileType: 'exe'` / `fileName: 'package.exe'`, so the agent saved an MSI as
+ * `package.exe` and took its EXE branch — which execs the downloaded file
+ * DIRECTLY (`exec.CommandContext(ctx, localPath, ...)`). Windows rejects an MSI
+ * at CreateProcess with ERROR_BAD_EXE_FORMAT ("This version of %1 is not
+ * compatible with the version of Windows you're running"), and the operator's
+ * `msiexec /i "{file}" ...` command was never used at all.
+ *
+ * Deriving the same answer in the browser (to preview and prefill) and on the
+ * server (which is authoritative) from ONE implementation is what keeps the two
+ * from drifting apart again.
+ */
+
+/** File types the agent can install — mirrors isSupportedInstallFileType in
+ *  agent/internal/remote/tools/software_install.go. */
+export const SOFTWARE_FILE_TYPES = ['msi', 'exe', 'dmg', 'deb', 'pkg'] as const;
+
+export type SoftwareFileType = (typeof SOFTWARE_FILE_TYPES)[number];
+
+export function isSoftwareFileType(value: unknown): value is SoftwareFileType {
+  return (
+    typeof value === 'string' &&
+    (SOFTWARE_FILE_TYPES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Best-effort installer type for a download URL, or null when the URL does not
+ * end in a recognized installer extension.
+ *
+ * Deliberately conservative: null means "we don't know", and callers keep the
+ * pre-existing behavior rather than guessing. A vendor URL like
+ * `https://host/download.php?product=foo` yields null, not 'exe' — an
+ * over-confident guess here re-creates the exact bug this file exists to fix,
+ * just pointed the other way.
+ */
+export function deriveSoftwareFileTypeFromUrl(
+  downloadUrl: string | null | undefined,
+): SoftwareFileType | null {
+  if (typeof downloadUrl !== 'string') return null;
+  const trimmed = downloadUrl.trim();
+  if (trimmed === '') return null;
+
+  // Strip query/fragment by hand instead of using `new URL()`: a stored download
+  // URL may still carry unresolved deploy-time tokens (`{{org.name}}`,
+  // `{{var.site_key}}`), which either make the parser throw or get
+  // percent-encoded — both of which would lose the extension we're after.
+  const withoutQuery = trimmed.split(/[?#]/, 1)[0] ?? '';
+  const lastSlash = withoutQuery.lastIndexOf('/');
+  const fileName = lastSlash >= 0 ? withoutQuery.slice(lastSlash + 1) : withoutQuery;
+
+  const dot = fileName.lastIndexOf('.');
+  if (dot < 0) return null;
+  const ext = fileName.slice(dot + 1).toLowerCase();
+
+  return isSoftwareFileType(ext) ? ext : null;
+}
+
+/**
+ * The silent install/uninstall commands to prefill for a file type, or null when
+ * the type has no useful default.
+ *
+ * MSI is the only one with a universally correct pair. An EXE installer's silent
+ * switch is vendor-specific (`/S`, `/silent`, `/quiet`, `-q`), so guessing one
+ * would produce a command that fails or — worse — installs interactively on an
+ * unattended machine.
+ */
+export function defaultSilentArgsForFileType(
+  fileType: string | null | undefined,
+): { install: string; uninstall: string } | null {
+  if (fileType !== 'msi') return null;
+  return {
+    install: 'msiexec /i "{file}" /qn /norestart',
+    uninstall: 'msiexec /x "{file}" /qn /norestart',
+  };
+}

--- a/packages/shared/src/utils/softwareFileType.ts
+++ b/packages/shared/src/utils/softwareFileType.ts
@@ -1,17 +1,27 @@
 /**
  * Installer file-type helpers shared by the API (routes/software.ts,
- * services/softwareVersionShared.ts) and the web package form
- * (components/software/AddPackageModal.tsx).
+ * routes/softwareUploads.ts) and the web package forms
+ * (components/software/AddPackageModal.tsx, SoftwareVersionManager.tsx).
  *
  * Why this is shared rather than API-local: a software version created from a
  * download URL never had a `file_type`, because only the UPLOAD path derived one
  * from the uploaded filename. The dispatcher then fell back to
  * `fileType: 'exe'` / `fileName: 'package.exe'`, so the agent saved an MSI as
- * `package.exe` and took its EXE branch — which execs the downloaded file
- * DIRECTLY (`exec.CommandContext(ctx, localPath, ...)`). Windows rejects an MSI
- * at CreateProcess with ERROR_BAD_EXE_FORMAT ("This version of %1 is not
- * compatible with the version of Windows you're running"), and the operator's
- * `msiexec /i "{file}" ...` command was never used at all.
+ * `package.exe` and took its WINDOWS EXE branch — which execs the downloaded
+ * file DIRECTLY (`exec.CommandContext(ctx, localPath, parts...)`). Windows
+ * rejects an MSI at CreateProcess with ERROR_BAD_EXE_FORMAT ("This version of %1
+ * is not compatible with the version of Windows you're running").
+ *
+ * Note the operator's `msiexec /i "{file}" ...` was NOT discarded — it was
+ * misrouted: the EXE branch substitutes `{file}` and passes the whole string as
+ * argv to the downloaded file, so the real argv was
+ * `[<the MSI>, "msiexec", "/i", <path>, "/qn", "/norestart"]`. CreateProcess
+ * fails before argv matters, which is why the symptom is the exec error rather
+ * than an msiexec complaint.
+ *
+ * On macOS/Linux the same 'exe' fallback failed earlier still, in
+ * executeInstaller's `default:` branch as `unsupported file type "exe" on
+ * <os>` — which is why dmg/deb/pkg packages were broken by this too.
  *
  * Deriving the same answer in the browser (to preview and prefill) and on the
  * server (which is authoritative) from ONE implementation is what keeps the two
@@ -19,7 +29,10 @@
  */
 
 /** File types the agent can install — mirrors isSupportedInstallFileType in
- *  agent/internal/remote/tools/software_install.go. */
+ *  agent/internal/remote/tools/software_install.go. Nothing enforces that
+ *  mirror, and the drift is asymmetric: this list backs a `z.enum` on the
+ *  create-version route, so a type added agent-side without being added here is
+ *  rejected by the API with a 400. */
 export const SOFTWARE_FILE_TYPES = ['msi', 'exe', 'dmg', 'deb', 'pkg'] as const;
 
 export type SoftwareFileType = (typeof SOFTWARE_FILE_TYPES)[number];
@@ -63,19 +76,37 @@ export function deriveSoftwareFileTypeFromUrl(
   return isSoftwareFileType(ext) ? ext : null;
 }
 
+/** A pair of install/uninstall command templates. `{file}` is substituted with
+ *  the downloaded installer's local path by the agent, before the string is
+ *  tokenized on spaces — which is why the token is quoted. */
+export interface SilentInstallDefaults {
+  install: string;
+  uninstall: string;
+}
+
 /**
  * The silent install/uninstall commands to prefill for a file type, or null when
  * the type has no useful default.
  *
- * MSI is the only one with a universally correct pair. An EXE installer's silent
- * switch is vendor-specific (`/S`, `/silent`, `/quiet`, `-q`), so guessing one
- * would produce a command that fails or — worse — installs interactively on an
- * unattended machine.
+ * MSI is the only type whose install command the agent actually BUILDS from
+ * silentInstallArgs. The others have no default for two different reasons:
+ *   - exe  — the args are used (passed as argv to the installer), but the silent
+ *            switch is vendor-specific (`/S`, `/silent`, `/quiet`, `-q`), so a
+ *            guess produces a command that fails or, worse, installs
+ *            interactively on an unattended machine.
+ *   - deb/pkg/dmg — the agent IGNORES silentInstallArgs entirely and hardcodes
+ *            `dpkg -i`, `installer -pkg … -target /`, and mount-and-install
+ *            respectively. A default here would be inert, not wrong.
+ *
+ * Accepts a loose string because callers pass a raw nullable DB column; the
+ * comparison is normalized so a stored 'MSI' behaves like 'msi' rather than
+ * silently yielding no defaults.
  */
 export function defaultSilentArgsForFileType(
   fileType: string | null | undefined,
-): { install: string; uninstall: string } | null {
-  if (fileType !== 'msi') return null;
+): SilentInstallDefaults | null {
+  const normalized = typeof fileType === 'string' ? fileType.trim().toLowerCase() : null;
+  if (normalized !== 'msi') return null;
   return {
     install: 'msiexec /i "{file}" /qn /norestart',
     uninstall: 'msiexec /x "{file}" /qn /norestart',


### PR DESCRIPTION
## The bug

Deploying an MSI by **download URL** could never work. Reported from OliveTech (DO US):

```
fork/exec C:\Windows\SystemTemp\breeze-sw-install-3609918658\package.exe:
This version of %1 is not compatible with the version of Windows you're running.
```

A software version created from a URL never recorded a `file_type`. Only the upload paths derived one (from the uploaded filename) — the JSON create-version route `POST /software/catalog/:id/versions` had no `fileType` field in `createVersionSchema` and never set the column.

`services/softwareDeployment.ts:482-484` then hit its fallbacks at dispatch:

```ts
fileName: versionRecord.originalFileName ?? `package.${versionRecord.fileType ?? 'exe'}`,
fileType: versionRecord.fileType ?? 'exe',
```

The agent received `fileType: "exe"`, saved the MSI as `package.exe`, and took the EXE branch of `executeInstaller` (`agent/internal/remote/tools/software_install.go:557-564`), which execs the downloaded file **directly**:

```go
cmd = exec.CommandContext(ctx, localPath, parts...)
```

Windows rejects an MSI at CreateProcess with `ERROR_BAD_EXE_FORMAT`. The operator's `msiexec /i "{file}" /qn /norestart` was passed as argv **to the MSI** rather than to msiexec — it was never used. Had `fileType` been `msi`, line 554 would have run msiexec correctly.

There was no workaround short of re-adding the package as an upload.

## The fix

| Area | Change |
|---|---|
| `packages/shared` | New `softwareFileType` util: `deriveSoftwareFileTypeFromUrl` + `defaultSilentArgsForFileType`, shared so the browser preview and the authoritative server derivation can't drift |
| `routes/software.ts` | `createVersionSchema` accepts optional `fileType`; handler prefers it, else infers from the URL, and applies the MSI silent-arg defaults the upload path already had |
| `routes/software.ts`, `routes/softwareUploads.ts` | Both upload paths take the msiexec strings from the shared helper instead of duplicating literals |
| `AddPackageModal` | Installer-type selector on the URL source (auto-detect default, shows what was detected), MSI arg prefill on URL entry matching the existing file-source behavior, explicit warning when the URL has no recognizable extension. Strings in all 7 locales |
| Migration | Backfills `file_type` for existing URL-created versions |

### Design notes

**Derivation returns `null` rather than guessing.** A URL like `https://vendor.example/download.php?product=foo` yields null and keeps the historical `'exe'` dispatch — an over-confident guess just re-creates this bug pointed the other way. That is what the explicit selector and the amber warning in the UI are for.

**Query/fragment stripped without `new URL()`.** Presigned vendor URLs put the signature after the extension, and a stored URL may still carry unresolved `{{org.name}}` / `{{var.site_key}}` deploy-time tokens that make the parser throw or percent-encode the braces.

**MSI is the only type with prefilled args.** An EXE's silent switch is vendor-specific (`/S`, `/silent`, `/quiet`, `-q`); guessing one installs interactively on an unattended machine.

**`silent_install_args` is deliberately not rewritten by the migration.** With the type corrected, `buildMSIExecArgs` already defaults empty args to `/i <path> /qn /norestart` and strips a leading `msiexec` token from a supplied one. Editing an operator's stored command is out of scope for a data repair.

## Schema / contracts

No new tables and **no new columns** — `file_type` and `original_file_name` already exist on `software_versions`. No RLS, cascade, or export-policy registration applies.

Migration is dated `2026-08-23` rather than today: existing migrations already run to `2026-08-22`, so today's date would not have sorted last. `check-migration-naming.sh` passes.

## Verification

**Migration applied against live Postgres** inside a rolled-back transaction:

```
WARNING:  backfilled file_type on 3 url-created software_versions row(s)
 version |                   url                   | file_type
---------+-----------------------------------------+-----------
 1       | https://cdn.example/acme.msi            | msi
 2       | https://cdn.example/acme.MSI?sig=x      | msi
 3       | https://vendor.example/download.php?p=1 | NULL     <- unusable ext, untouched
 4       | https://cdn.example/setup.exe           | exe
 5       | https://cdn.example/other.msi           | exe      <- already set, untouched
 6       | (null)                                  | NULL
=== second apply === (no warning — idempotent)
```

**Tests** — new assertions were mutation-tested, not just run:

- `packages/shared` — 1938 passed (12 new cases)
- `apps/api` `software.test.ts` + `softwareUploads.test.ts` — 137 passed (7 new). Reverting the fix fails 5.
- `apps/web` `AddPackageModal.test.tsx` — 19 passed (4 new). Reverting the fix fails 2.
- `apps/web` i18n coverage — 98 passed; `autoMigrate.test.ts` — 60 passed
- eslint clean on all changed sources

## Follow-up (not in this PR)

URL-created versions still send `originalFileName: null`, so the agent saves `package.<type>`. That is correct and always matches `file_type` — deriving a filename from the URL risks an extension/type mismatch that `validateInstallFileName` rejects outright. Worth revisiting only if a vendor installer turns out to care about its own filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)