### PR TITLE
fix(api,web): default a new quote's currency to the partner's, not USD (#3200)

### DIFF
--- a/apps/api/src/__tests__/integration/quoteCurrency.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quoteCurrency.integration.test.ts
@@ -1,0 +1,48 @@
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { quotes } from '../../db/schema/quotes';
+import { partners } from '../../db/schema/orgs';
+import { createPartner, createOrganization } from './db-utils';
+import { createQuote } from '../../services/quoteService';
+
+// Integration-gated (real Postgres): createQuote resolves the partner currency
+// with a live query, so this cannot be exercised by the service-mocked unit
+// suite. Runs in CI's Test API against a real DB.
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function eurPartnerWithOrg() {
+  return withSystemDbAccessContext(async () => {
+    const partner = await createPartner();
+    await db.update(partners).set({ currencyCode: 'EUR' }).where(eq(partners.id, partner.id));
+    const org = await createOrganization({ partnerId: partner.id });
+    return { partnerId: partner.id, orgId: org.id };
+  });
+}
+
+describe('createQuote currency defaulting (#3200)', () => {
+  runDb('defaults a new quote to the partner currency when currencyCode is omitted', async () => {
+    const { partnerId, orgId } = await eurPartnerWithOrg();
+    const actor = { userId: null, partnerId, accessibleOrgIds: [orgId] };
+
+    const created = await withSystemDbAccessContext(() => createQuote({ orgId }, actor));
+    const [q] = await withSystemDbAccessContext(() =>
+      db.select({ currencyCode: quotes.currencyCode }).from(quotes).where(eq(quotes.id, created.id)),
+    );
+    expect(q?.currencyCode).toBe('EUR');
+  });
+
+  runDb('honors an explicit currencyCode over the partner default', async () => {
+    const { partnerId, orgId } = await eurPartnerWithOrg();
+    const actor = { userId: null, partnerId, accessibleOrgIds: [orgId] };
+
+    const created = await withSystemDbAccessContext(() =>
+      createQuote({ orgId, currencyCode: 'GBP' }, actor),
+    );
+    const [q] = await withSystemDbAccessContext(() =>
+      db.select({ currencyCode: quotes.currencyCode }).from(quotes).where(eq(quotes.id, created.id)),
+    );
+    expect(q?.currencyCode).toBe('GBP');
+  });
+});

--- a/apps/api/src/services/aiToolsQuotes.ts
+++ b/apps/api/src/services/aiToolsQuotes.ts
@@ -253,7 +253,7 @@ export function registerQuoteTools(aiTools: Map<string, AiTool>): void {
             type: 'object',
             description:
               'Create-quote payload (create_draft). Required: orgId (UUID). Optional: siteId (UUID), ' +
-              'title, currencyCode (3-letter, default USD), expiryDate (YYYY-MM-DD), introNotes, terms, ' +
+              'title, currencyCode (3-letter; defaults to the partner\'s currency), expiryDate (YYYY-MM-DD), introNotes, terms, ' +
               'termsAndConditions.',
           },
           patch: {

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -250,6 +250,19 @@ export async function createQuote(input: CreateQuoteInput, actor: QuoteActor) {
   assertOrg(actor, input.orgId);
   assertSite(actor, input.siteId ?? null);
   const taxRate = await resolveQuoteTaxRate(input.orgId, partnerId);
+  // A new quote inherits the partner's configured currency unless the caller
+  // names one explicitly. The web and MCP create forms used to hardcode 'USD',
+  // so a non-USD partner's quotes (and their PDFs) were always minted in USD
+  // (#3200). The notNull DB default 'USD' remains the final backstop.
+  let currencyCode = input.currencyCode;
+  if (!currencyCode) {
+    const [partner] = await db
+      .select({ currencyCode: partners.currencyCode })
+      .from(partners)
+      .where(eq(partners.id, partnerId))
+      .limit(1);
+    currencyCode = partner?.currencyCode ?? 'USD';
+  }
   // Number at creation (not at send): techs reference the number while drafting
   // and in the list. A deleted draft leaves a counter gap, which the numbering
   // contract explicitly tolerates (see allocateQuoteCounter). sendQuote keeps
@@ -263,7 +276,7 @@ export async function createQuote(input: CreateQuoteInput, actor: QuoteActor) {
     siteId: input.siteId ?? null,
     quoteNumber,
     title: input.title?.trim() || null,
-    currencyCode: input.currencyCode,
+    currencyCode,
     taxRate,
     expiryDate: input.expiryDate ?? null,
     introNotes: input.introNotes ?? null,

--- a/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.test.tsx
@@ -239,7 +239,9 @@ describe('QuotesPage', () => {
       (c) => String(c[0]) === '/quotes' && (c[1] as RequestInit | undefined)?.method === 'POST',
     );
     expect(createCall).toBeTruthy();
-    expect(JSON.parse((createCall![1] as RequestInit).body as string)).toEqual({ orgId: 'org-1', currencyCode: 'USD' });
+    // No hardcoded currencyCode (#3200): the create omits it so the server
+    // defaults the new quote to the partner's currency, not always 'USD'.
+    expect(JSON.parse((createCall![1] as RequestInit).body as string)).toEqual({ orgId: 'org-1' });
     // No clone endpoint involved in a blank create.
     expect(fetchMock.mock.calls.some((c) => String(c[0]).includes('/clone'))).toBe(false);
   });

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -230,7 +230,7 @@ export function QuotesPage() {
         // nulls the site on retarget, matching updateQuote's reassignment.
         request: () => newSourceId
           ? cloneQuote(newSourceId, { orgId: newOrgId, title: newTitle.trim() || undefined })
-          : createQuote({ orgId: newOrgId, siteId: newSiteId || undefined, title: newTitle.trim() || undefined, currencyCode: 'USD' }),
+          : createQuote({ orgId: newOrgId, siteId: newSiteId || undefined, title: newTitle.trim() || undefined }),
         errorFallback: t('quotes.page.create.error'),
         successMessage: t('quotes.page.create.success'),
         onUnauthorized: UNAUTHORIZED,

--- a/packages/shared/src/validators/quotes.test.ts
+++ b/packages/shared/src/validators/quotes.test.ts
@@ -9,9 +9,11 @@ import {
 } from './quotes';
 
 describe('quote validators', () => {
-  it('accepts a minimal create payload', () => {
+  it('accepts a minimal create payload and leaves currencyCode unset', () => {
+    // currencyCode is optional now (#3200): omitting it lets createQuote inherit
+    // the partner's currency server-side, instead of the schema forcing 'USD'.
     const q = createQuoteSchema.parse({ orgId: '11111111-1111-1111-1111-111111111111' });
-    expect(q.currencyCode).toBe('USD');
+    expect(q.currencyCode).toBeUndefined();
   });
 
   it('parses a recurring catalog line with term', () => {

--- a/packages/shared/src/validators/quotes.ts
+++ b/packages/shared/src/validators/quotes.ts
@@ -143,7 +143,9 @@ export const createQuoteSchema = z.object({
   orgId: z.string().guid(),
   siteId: z.string().guid().optional(),
   title: z.string().max(200).optional(),
-  currencyCode: z.string().length(3).default('USD'),
+  // Omit to inherit the partner's configured currency (resolved server-side in
+  // createQuote); the DB column still defaults to 'USD' as a backstop (#3200).
+  currencyCode: z.string().length(3).optional(),
   expiryDate: isoDate.optional(),
   introNotes: z.string().max(5000).optional(),
   terms: z.string().max(20_000).optional(),


### PR DESCRIPTION
Addresses the create-currency half of #3200.

## Problem

A new quote was **always minted in USD** regardless of the partner's configured currency:
- `QuotesPage` hardcoded `currencyCode: 'USD'` on create, and
- the shared `createQuoteSchema` **defaulted** `currencyCode` to `'USD'`, so even MCP `create_draft` forced USD.

A non-USD partner's quotes (and their PDFs) were mislabelled at the source.

## Fix

- `createQuoteSchema.currencyCode` is now **optional** (was `.default('USD')`).
- `createQuote` resolves the currency when the caller omits it: the **partner's** `currencyCode` (organizations have no currency column; partners do — `orgs.ts:69`), falling back to `'USD'`. The `quotes` column stays `NOT NULL DEFAULT 'USD'` as the final backstop. An explicit `currencyCode` still wins.
- `QuotesPage` drops the hardcoded `'USD'`; MCP `create_draft`'s description now says it defaults to the partner's currency.

## Review

Adversarial Codex review: the only quote-insert consumers of the schema are the `POST /quotes` route and MCP `create_draft`, both routing through `createQuote` (the clone path copies the source's currency), so no path inserts an unresolved/NULL currency; `partnerId` is validated before use and a non-matching partner falls back to USD. Verdict: correct and safe to ship.

## Out of scope (separate concern, NOT touched)

The invoice/quote **PDF** `formatMoney` renders a currency **symbol** only for USD (EUR/GBP fall through to `AMOUNT CUR`, and `₹ ₩ ₪` would fail *silently* under pdfkit's WinAnsi Helvetica). Fixing that needs a WinAnsi-safe fallback or an embedded Unicode font — a distinct, font-encoding-sensitive change left for a follow-up.

## Testing

- shared schema test: a minimal create payload now leaves `currencyCode` **undefined**.
- `QuotesPage` test: the create body is `{ orgId }` only.
- **new CI-gated integration test** (`quoteCurrency.integration.test.ts`, `it.runIf(DATABASE_URL)`): a partner with `currencyCode='EUR'` → a create that omits currency yields an **EUR** quote; an explicit `'GBP'` overrides.

`tsc --noEmit` (apps/api) clean; full web vitest **570 files / 5564 tests**; shared + api quote unit tests pass; eslint clean.

https://claude.ai/code/session_0187oKb4Pw7KTXT2Lsvq7hUr
