### PR TITLE
fix(api): salvage per-VPN so one bad entry can't drop the whole network payload (#3550)

### DIFF
--- a/apps/api/src/routes/agents/inventory.ts
+++ b/apps/api/src/routes/agents/inventory.ts
@@ -1,6 +1,8 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
+import { z } from 'zod';
 import { zValidator } from '../../lib/validation';
+import { vpnPresenceIngestSchema } from '@breeze/shared';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import {
@@ -325,9 +327,33 @@ inventoryRoutes.put('/:id/network', bodyLimit({ maxSize: 5 * 1024 * 1024, onErro
   // a live tunnel to "no VPN". We stamp reportedAt server-side per entry.
   // Semantics of the stored column: null = never successfully reported (old
   // agent or every collection failed); [] = reported with no active VPN.
-  const vpnProvided = data.vpns !== undefined;
+  // #3550: validate VPN entries PER-ENTRY here, not in the request schema, so a
+  // single malformed entry can't 400 the whole payload and discard the valid
+  // adapter inventory in the same request. Bad entries are dropped and counted.
+  const rawVpns = data.vpns;
+  const salvagedVpns: z.infer<typeof vpnPresenceIngestSchema>[] = [];
+  let droppedVpnCount = 0;
+  if (rawVpns !== undefined) {
+    for (const entry of rawVpns) {
+      const parsed = vpnPresenceIngestSchema.safeParse(entry);
+      if (parsed.success) salvagedVpns.push(parsed.data);
+      else droppedVpnCount += 1;
+    }
+  }
+  if (droppedVpnCount > 0) {
+    console.warn(
+      `[agents.network] dropped ${droppedVpnCount} malformed VPN ` +
+        `entr${droppedVpnCount === 1 ? 'y' : 'ies'} for agent ${agentId}; ` +
+        `kept ${salvagedVpns.length}, adapters preserved`,
+    );
+  }
+  // Treat an all-malformed report like a FAILED collection: leave the stored
+  // snapshot untouched rather than overwriting a live tunnel to "no VPN". A
+  // genuinely empty report (agent sent [], nothing dropped) is still honored as
+  // "reported, no active VPN".
+  const vpnProvided = rawVpns !== undefined && !(salvagedVpns.length === 0 && droppedVpnCount > 0);
   const activeVpns = vpnProvided
-    ? data.vpns!.map((vpn) => ({
+    ? salvagedVpns.map((vpn) => ({
         provider: vpn.provider,
         active: vpn.active,
         interfaceName: vpn.interfaceName,
@@ -373,7 +399,11 @@ inventoryRoutes.put('/:id/network', bodyLimit({ maxSize: 5 * 1024 * 1024, onErro
   return c.json({
     success: true,
     count: data.adapters.length,
-    vpnCount: vpnProvided ? activeVpns!.length : null
+    vpnCount: vpnProvided ? activeVpns!.length : null,
+    // Machine-readable partial-ingest signal (#3550): how many VPN entries were
+    // dropped as malformed. 0 on a clean ingest; lets a future agent surface a
+    // persistent serialization regression instead of it hiding behind a 200.
+    droppedVpnCount
   });
 });
 

--- a/apps/api/src/routes/agents/inventoryNetworkVpn.test.ts
+++ b/apps/api/src/routes/agents/inventoryNetworkVpn.test.ts
@@ -4,7 +4,8 @@ import { Hono } from 'hono';
 // Active-VPN-client presence ingest via PUT /:id/network (#2139). Verifies the
 // handler stamps reportedAt server-side and persists the snapshot to
 // devices.activeVpns, that old agents (no `vpns`) store an empty array, and
-// that the payload validator rejects unknown providers.
+// that a malformed VPN entry is SALVAGED per-entry — dropped without rejecting
+// the whole payload (which used to discard the valid adapter inventory, #3550).
 
 vi.mock('../../db', () => ({
   db: {
@@ -43,11 +44,18 @@ function mockDeviceLookup(device: { id: string; orgId: string } | null) {
 // Capture what the handler writes to devices.activeVpns inside the txn.
 // `updateCalled` distinguishes "wrote []" from "never touched the column".
 function mockTransactionCapture() {
-  const captured: { activeVpns?: unknown; updateCalled: boolean } = { updateCalled: false };
+  const captured: { activeVpns?: unknown; inserted?: unknown[]; updateCalled: boolean } = {
+    updateCalled: false,
+  };
   vi.mocked(db.transaction).mockImplementation(async (fn: any) => {
     const tx = {
       delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
-      insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+      insert: vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((rows: unknown[]) => {
+          captured.inserted = rows;
+          return Promise.resolve(undefined);
+        }),
+      }),
       update: vi.fn().mockReturnValue({
         set: vi.fn().mockImplementation((row: { activeVpns?: unknown }) => {
           captured.updateCalled = true;
@@ -191,26 +199,47 @@ describe('agent network inventory — VPN presence ingest (#2139)', () => {
     expect(Number.isNaN(Date.parse(inactive!.reportedAt as string))).toBe(false);
   });
 
-  it('rejects an active VPN entry with an empty interfaceName (validator)', async () => {
-    // zValidator rejects before the handler runs — no db mocks needed, and
-    // queuing a device lookup here would leak into the next test.
+  it('salvages a mixed payload: drops a malformed VPN but keeps the valid VPN and the adapters (#3550)', async () => {
+    mockDeviceLookup({ id: 'device-1', orgId: 'org-1' });
+    const captured = mockTransactionCapture();
+
     const res = await putNetwork(makeApp(), {
-      adapters: [],
-      vpns: [{ provider: 'tailscale', active: true, interfaceName: '', detectionSource: 'interface' }],
+      adapters: [{ interfaceName: 'en0', ipAddress: '10.0.0.5', ipType: 'ipv4', isPrimary: true }],
+      vpns: [
+        { provider: 'tailscale', active: true, interfaceName: 'utun3', ipv4: '100.1.2.3', detectionSource: 'interface' },
+        // Malformed: an active VPN with no interfaceName.
+        { provider: 'tailscale', active: true, interfaceName: '', detectionSource: 'interface' },
+      ],
     });
 
-    expect(res.status).toBe(400);
+    // The whole payload is no longer rejected — the valid adapter is persisted...
+    expect(res.status).toBe(200);
+    expect(captured.inserted).toHaveLength(1);
+    // ...and only the well-formed VPN survives.
+    const stored = captured.activeVpns as Array<Record<string, unknown>>;
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({ provider: 'tailscale', interfaceName: 'utun3' });
+    const body = await res.json();
+    expect(body.vpnCount).toBe(1);
+    // The response reports how many entries were dropped (#3550 observability).
+    expect(body.droppedVpnCount).toBe(1);
   });
 
-  it('rejects an unknown VPN provider (validator)', async () => {
-    // zValidator rejects before the handler runs — no db mocks needed, and
-    // queuing a device lookup here would leak into the next test.
+  it('salvages an unknown-provider VPN: adapters persist and the bad entry is dropped (#3550)', async () => {
+    mockDeviceLookup({ id: 'device-1', orgId: 'org-1' });
+    const captured = mockTransactionCapture();
+
     const res = await putNetwork(makeApp(), {
-      adapters: [],
+      adapters: [{ interfaceName: 'eth0', ipAddress: '192.168.1.20', ipType: 'ipv4', isPrimary: true }],
       vpns: [{ provider: 'nordvpn', active: true, interfaceName: 'utun9', detectionSource: 'interface' }],
     });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    expect(captured.inserted).toHaveLength(1);
+    // Every provided VPN was malformed, so the snapshot is left UNTOUCHED rather
+    // than overwritten to "no VPN" (avoids clobbering a live tunnel). The handler
+    // signals this by not calling update on activeVpns.
+    expect(captured.updateCalled).toBe(false);
   });
 
   it('returns 404 and does not open a txn when the device is unknown', async () => {

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import { isIP } from 'node:net';
-import { vpnPresenceIngestSchema } from '@breeze/shared';
 
 // ============================================
 // Enrollment
@@ -591,8 +590,10 @@ export const updateNetworkSchema = z.object({
     isPrimary: z.boolean().optional()
   })).max(100),
   // Active-VPN-client presence (#2139). Optional so older agents that don't
-  // report VPNs still validate. The API stamps reportedAt per entry on ingest.
-  vpns: z.array(vpnPresenceIngestSchema).max(50).optional()
+  // report VPNs still validate. Entries are validated PER-ENTRY in the handler
+  // (against vpnPresenceIngestSchema), not here, so one malformed VPN can't 400
+  // the whole payload and silently discard the valid adapter inventory (#3550).
+  vpns: z.array(z.unknown()).max(50).optional()
 });
 
 // ============================================


### PR DESCRIPTION
Closes #3550.

## Problem

`PUT /:id/network` validated `vpns` atomically (`z.array(vpnPresenceIngestSchema).max(50)`), so **a single malformed VPN entry** — an unknown provider, an active tunnel with no `interfaceName`, an over-length field — 400'd the **entire request** and silently discarded the valid **`adapters`** inventory reported in the same payload.

## Fix

Validate VPN entries **per-entry in the handler** instead of in the request schema:
- keep the well-formed entries, **drop** the malformed ones, and report the dropped count (`console.warn` + a machine-readable `droppedVpnCount` in the response).
- **adapters** are still strictly validated and are now persisted regardless of a bad VPN entry — the whole point.

An **all-malformed** VPN report is treated like a *failed collection*: the stored `activeVpns` snapshot is left **untouched** rather than overwritten to "no VPN", so a transient serialization glitch can't clobber a live-tunnel snapshot. A genuinely empty report (`[]`, nothing dropped) is still stored as "reported, no active VPN".

`vpnPresenceIngestSchema` is **unchanged and still enforced** — only the failure mode moved from reject-all to drop-bad, so stored VPN quality is identical to before.

| Input | stored `activeVpns` |
|---|---|
| omitted | untouched (collection unavailable) |
| `[]` | `[]` (no active VPN) |
| `[valid]` | the valid list |
| `[valid, bad]` | the valid subset |
| `[bad]` / `[bad, bad]` | untouched (avoids a false empty snapshot) |

## Review

Adversarial Codex review verified the all-dropped-vs-empty predicate (full truth table above), that the schema still rejects non-arrays / arrays >50 / lets old agents omit `vpns`, that no unvalidated field reaches the DB (raw entries are `safeParse`d; only `parsed.data` is stored), and that adapters are preserved. Its one note — partial acceptance being invisible to the agent — is addressed by returning `droppedVpnCount`. Verdict: correct and safe to ship.

## Testing

The two tests that asserted a `400` on a bad VPN are **inverted** to assert salvage: a mixed payload persists the adapter + the valid VPN and drops the bad one (`droppedVpnCount: 1`); an all-malformed payload persists adapters and leaves the snapshot untouched (`updateCalled === false`). Control-verified (removing the per-entry drop reds the mixed test).

`tsc --noEmit` (apps/api) clean; vitest `inventoryNetworkVpn` + `bodyLimit` + `devices/network` + shared validators pass; eslint clean. No schema/migration changes.

https://claude.ai/code/session_0187oKb4Pw7KTXT2Lsvq7hUr
