### PR TITLE
fix(agent,api): AI-generated PowerShell scripts fail with Unicode parse errors

### DIFF
--- a/agent/internal/executor/shell.go
+++ b/agent/internal/executor/shell.go
@@ -99,12 +99,14 @@ func normalizeLineEndings(content, scriptType string) string {
 }
 
 // utf8BOM is prepended to PowerShell scripts on write. Windows PowerShell 5.1
-// decodes a BOM-less .ps1 as the system ANSI codepage, so any non-ASCII
-// character in UTF-8 content (curly quotes, em-dashes, accented letters) turns
-// into mojibake and the parser reports cascading "Unexpected token" /
-// "missing terminator" errors. The BOM forces UTF-8 decoding; pwsh on all
-// platforms handles it too. Bash/python/cmd must NOT get one — bash refuses a
-// BOM before the shebang and cmd feeds it to the first command.
+// decodes a BOM-less .ps1 as the system ANSI codepage, so non-ASCII UTF-8
+// content turns into mojibake: accented letters merely garble output, but
+// mis-decoded curly quotes lose their delimiter role and the parser reports
+// cascading "Unexpected token" / "missing terminator" errors. The BOM forces
+// UTF-8 decoding; pwsh on all platforms handles it too. Only .ps1 gets one:
+// a BOM keeps bash from recognizing the shebang and its bytes run as a
+// garbage first command, cmd likewise feeds it to the first command, and
+// python skips a BOM anyway so there is no reason to add it.
 const utf8BOM = "\xEF\xBB\xBF"
 
 // WriteScriptFile writes script content to a temporary file with the appropriate extension

--- a/agent/internal/executor/shell.go
+++ b/agent/internal/executor/shell.go
@@ -98,9 +98,21 @@ func normalizeLineEndings(content, scriptType string) string {
 	}
 }
 
+// utf8BOM is prepended to PowerShell scripts on write. Windows PowerShell 5.1
+// decodes a BOM-less .ps1 as the system ANSI codepage, so any non-ASCII
+// character in UTF-8 content (curly quotes, em-dashes, accented letters) turns
+// into mojibake and the parser reports cascading "Unexpected token" /
+// "missing terminator" errors. The BOM forces UTF-8 decoding; pwsh on all
+// platforms handles it too. Bash/python/cmd must NOT get one — bash refuses a
+// BOM before the shebang and cmd feeds it to the first command.
+const utf8BOM = "\xEF\xBB\xBF"
+
 // WriteScriptFile writes script content to a temporary file with the appropriate extension
 func WriteScriptFile(content, scriptType string) (string, error) {
 	content = normalizeLineEndings(content, scriptType)
+	if strings.ToLower(scriptType) == ScriptTypePowerShell && !strings.HasPrefix(content, utf8BOM) {
+		content = utf8BOM + content
+	}
 	// Get the temp directory
 	tempDir := os.TempDir()
 	scriptDir := filepath.Join(tempDir, "breeze-scripts")

--- a/agent/internal/executor/shell_bom_test.go
+++ b/agent/internal/executor/shell_bom_test.go
@@ -9,8 +9,8 @@ import (
 // em-dashes) parses fine as UTF-8 but Windows PowerShell 5.1 decodes a
 // BOM-less .ps1 as ANSI, producing cascading "Unexpected token" /
 // "missing terminator" parse errors. WriteScriptFile must stamp a UTF-8 BOM
-// on .ps1 files — and only .ps1 files (bash rejects a BOM before the
-// shebang; cmd feeds it to the first command).
+// on .ps1 files — and only .ps1 files (a BOM hides the shebang from bash and
+// runs as a garbage first command; cmd feeds it to the first command).
 func TestWriteScriptFileUTF8BOM(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -21,6 +21,7 @@ func TestWriteScriptFileUTF8BOM(t *testing.T) {
 		{"powershell gets BOM", ScriptTypePowerShell, "Write-Host \"done (“ok”)\"\r\n", true},
 		{"powershell ascii gets BOM", ScriptTypePowerShell, "Write-Host 'plain'\r\n", true},
 		{"powershell existing BOM not doubled", ScriptTypePowerShell, utf8BOM + "Write-Host 'x'\r\n", true},
+		{"powershell LF content gets BOM", ScriptTypePowerShell, "Write-Host 'lf'\n", true},
 		{"bash no BOM", ScriptTypeBash, "#!/bin/bash\necho hi\n", false},
 		{"python no BOM", ScriptTypePython, "print('hi')\n", false},
 		{"cmd no BOM", ScriptTypeCMD, "@echo off\r\necho hi\r\n", false},

--- a/agent/internal/executor/shell_bom_test.go
+++ b/agent/internal/executor/shell_bom_test.go
@@ -1,0 +1,48 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+)
+
+// AI-generated PowerShell containing typographic Unicode (curly quotes,
+// em-dashes) parses fine as UTF-8 but Windows PowerShell 5.1 decodes a
+// BOM-less .ps1 as ANSI, producing cascading "Unexpected token" /
+// "missing terminator" parse errors. WriteScriptFile must stamp a UTF-8 BOM
+// on .ps1 files — and only .ps1 files (bash rejects a BOM before the
+// shebang; cmd feeds it to the first command).
+func TestWriteScriptFileUTF8BOM(t *testing.T) {
+	tests := []struct {
+		name       string
+		scriptType string
+		content    string
+		wantBOM    bool
+	}{
+		{"powershell gets BOM", ScriptTypePowerShell, "Write-Host \"done (“ok”)\"\r\n", true},
+		{"powershell ascii gets BOM", ScriptTypePowerShell, "Write-Host 'plain'\r\n", true},
+		{"powershell existing BOM not doubled", ScriptTypePowerShell, utf8BOM + "Write-Host 'x'\r\n", true},
+		{"bash no BOM", ScriptTypeBash, "#!/bin/bash\necho hi\n", false},
+		{"python no BOM", ScriptTypePython, "print('hi')\n", false},
+		{"cmd no BOM", ScriptTypeCMD, "@echo off\r\necho hi\r\n", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := WriteScriptFile(tt.content, tt.scriptType)
+			if err != nil {
+				t.Fatalf("WriteScriptFile: %v", err)
+			}
+			defer CleanupScript(path)
+			got := readScript(t, path)
+			if hasBOM := strings.HasPrefix(got, utf8BOM); hasBOM != tt.wantBOM {
+				t.Fatalf("BOM presence = %v, want %v (content %q)", hasBOM, tt.wantBOM, got)
+			}
+			if strings.HasPrefix(got, utf8BOM+utf8BOM) {
+				t.Fatalf("BOM doubled: %q", got)
+			}
+			// Original content must survive intact after the optional BOM.
+			if !strings.HasSuffix(got, strings.TrimPrefix(tt.content, utf8BOM)) {
+				t.Fatalf("content mangled: %q", got)
+			}
+		})
+	}
+}

--- a/apps/api/src/services/scriptBuilderPrompt.ts
+++ b/apps/api/src/services/scriptBuilderPrompt.ts
@@ -27,6 +27,11 @@ When editing an existing script, prefer targeted modifications over full rewrite
 Always consider error handling, logging, and cross-platform compatibility.
 For PowerShell, prefer modern cmdlets. For Bash, ensure POSIX compatibility where possible.
 
+Script code must use plain ASCII punctuation only: straight quotes (' and "), ASCII
+hyphens (-), and regular spaces. Never use typographic characters (curly quotes,
+en/em dashes, ellipsis, non-breaking spaces) in code — they cause parse errors on
+target machines.
+
 IMPORTANT: Always use apply_script_code to deliver code to the editor, not just a code block in the chat. The chat message should explain the code; the tool applies it to the editor.`;
 
   if (!context?.editorSnapshot) {

--- a/apps/api/src/services/scriptBuilderTools.applyNormalize.test.ts
+++ b/apps/api/src/services/scriptBuilderTools.applyNormalize.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeApplyHandler } from './scriptBuilderTools';
+
+/**
+ * Pins the wiring between normalizeScriptCode and the editor delivery path:
+ * makeApplyHandler must hand the NORMALIZED args to onPostToolUse, because
+ * that exact object is what aiAgentSdk.createSessionPostToolUse re-attaches
+ * into the SSE tool_result the editor reads (scriptAiStore). If a refactor
+ * ever passes the raw SDK args instead, typographic Unicode reaches devices
+ * again -- and for bash/python the agent-side BOM layer does not cover it.
+ */
+describe('apply_script_code normalization wiring', () => {
+  it('delivers normalized code to onPostToolUse', async () => {
+    const spy = vi.fn();
+    const handler = makeApplyHandler('apply_script_code', spy);
+
+    const rawCode = 'Write-Host \u201cdone \u2014 ok\u201d';
+    await handler({ code: rawCode, language: 'powershell' });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [, args] = spy.mock.calls[0]!;
+    expect((args as { code: string }).code).toBe('Write-Host "done - ok"');
+  });
+
+  it('reports codeChars for the normalized code', async () => {
+    const spy = vi.fn();
+    const handler = makeApplyHandler('apply_script_code', spy);
+
+    // Ellipsis expands 1 -> 3 chars, so raw and normalized lengths differ.
+    await handler({ code: 'echo hi\u2026', language: 'bash' });
+
+    const [, , output] = spy.mock.calls[0]!;
+    expect(String(output)).toContain('"codeChars":10');
+  });
+
+  it('leaves non-code args untouched', async () => {
+    const spy = vi.fn();
+    const handler = makeApplyHandler('apply_script_metadata', spy);
+
+    await handler({ name: 'Disk cleanup \u2014 weekly' });
+
+    const [, args] = spy.mock.calls[0]!;
+    expect((args as { name: string }).name).toBe('Disk cleanup \u2014 weekly');
+  });
+});

--- a/apps/api/src/services/scriptBuilderTools.ts
+++ b/apps/api/src/services/scriptBuilderTools.ts
@@ -16,6 +16,7 @@ import { compactToolResultForChat } from './aiToolOutput';
 import { captureException } from './sentry';
 import type { PreToolUseCallback, PostToolUseCallback } from './aiAgentSdkTools';
 import { sanitizeThrownToolError } from './aiToolErrors';
+import { normalizeScriptCode } from './scriptCodeNormalize';
 
 const TOOL_EXECUTION_TIMEOUT_MS = 60_000;
 
@@ -142,6 +143,13 @@ function makeApplyHandler(
 ) {
   return async (args: Record<string, unknown>) => {
     const startTime = Date.now();
+    // Scrub typographic Unicode (curly quotes, em-dashes, NBSP) the model
+    // sometimes emits — it breaks script parsing on-device (#PS 5.1 ANSI
+    // decode, bash literal chars). The editor receives `args` via the SSE
+    // tool_result re-attach in aiAgentSdk.createSessionPostToolUse.
+    if (typeof args.code === 'string') {
+      args = { ...args, code: normalizeScriptCode(args.code) };
+    }
     const code = typeof args.code === 'string' ? args.code : undefined;
     const output = compactToolResultForChat(toolName, JSON.stringify({
       applied: true,

--- a/apps/api/src/services/scriptBuilderTools.ts
+++ b/apps/api/src/services/scriptBuilderTools.ts
@@ -137,16 +137,20 @@ function makeExistingHandler(
 // Apply tool handlers (emit SSE events, no DB execution)
 // ============================================
 
-function makeApplyHandler(
+// Exported for scriptBuilderTools.applyNormalize.test.ts, which pins that the
+// normalized (not raw) code is what reaches onPostToolUse — the object the SSE
+// tool_result re-attach delivers to the editor.
+export function makeApplyHandler(
   toolName: string,
   onPostToolUse?: PostToolUseCallback,
 ) {
   return async (args: Record<string, unknown>) => {
     const startTime = Date.now();
     // Scrub typographic Unicode (curly quotes, em-dashes, NBSP) the model
-    // sometimes emits — it breaks script parsing on-device (#PS 5.1 ANSI
-    // decode, bash literal chars). The editor receives `args` via the SSE
-    // tool_result re-attach in aiAgentSdk.createSessionPostToolUse.
+    // sometimes emits — it breaks script parsing on-device (PowerShell 5.1
+    // ANSI mis-decode; literal chars in bash syntax positions). The editor
+    // receives `args` via the SSE tool_result re-attach in
+    // aiAgentSdk.createSessionPostToolUse.
     if (typeof args.code === 'string') {
       args = { ...args, code: normalizeScriptCode(args.code) };
     }

--- a/apps/api/src/services/scriptCodeNormalize.test.ts
+++ b/apps/api/src/services/scriptCodeNormalize.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeScriptCode } from './scriptCodeNormalize';
+
+describe('normalizeScriptCode', () => {
+  it('replaces curly double quotes so PowerShell strings parse', () => {
+    const input = 'Write-Host \u201cDownload completed successfully ($([math]::Round($fileSize, 2)) MB)\u201d';
+    expect(normalizeScriptCode(input)).toBe(
+      'Write-Host "Download completed successfully ($([math]::Round($fileSize, 2)) MB)"'
+    );
+  });
+
+  it('replaces curly single quotes and apostrophes', () => {
+    expect(normalizeScriptCode('echo \u2018hi\u2019 don\u2019t')).toBe("echo 'hi' don't");
+  });
+
+  it('replaces en/em dashes and minus sign with ASCII hyphen', () => {
+    expect(normalizeScriptCode('a \u2013 b \u2014 c \u2212 d \u2010 e')).toBe('a - b - c - d - e');
+  });
+
+  it('replaces ellipsis and non-breaking spaces', () => {
+    expect(normalizeScriptCode('Waiting\u2026 done\u00a0now\u202fok')).toBe('Waiting... done now ok');
+  });
+
+  it('strips zero-width characters and BOMs', () => {
+    expect(normalizeScriptCode('a\u200bb\u200cc\u200dd\ufeffe')).toBe('abcde');
+  });
+
+  it('leaves plain ASCII code untouched', () => {
+    const script = 'try {\n  Invoke-WebRequest -Uri $url -OutFile $tempPath\n} catch {\n  throw "failed: $_"\n}';
+    expect(normalizeScriptCode(script)).toBe(script);
+  });
+
+  it('leaves legitimate non-ASCII content (accents, CJK) untouched', () => {
+    expect(normalizeScriptCode('echo "r\u00e9sum\u00e9 \u65e5\u672c\u8a9e"')).toBe('echo "r\u00e9sum\u00e9 \u65e5\u672c\u8a9e"');
+  });
+});

--- a/apps/api/src/services/scriptCodeNormalize.ts
+++ b/apps/api/src/services/scriptCodeNormalize.ts
@@ -2,17 +2,19 @@
  * Normalize typographic Unicode punctuation in AI-generated script code.
  *
  * LLMs occasionally emit curly quotes, em/en dashes, ellipses, and
- * non-breaking/zero-width spaces inside script code. Interpreters treat these
- * as ordinary characters (bash/python) or, worse, Windows PowerShell 5.1
- * mis-decodes them entirely in a BOM-less ANSI read, producing cascading
- * parse errors ("Unexpected token", "missing string terminator"). The agent
- * now writes .ps1 files with a UTF-8 BOM, but code should be plain ASCII
- * punctuation regardless -- a curly quote is never intentional in a quote
- * position and breaks bash/python even when decoded correctly.
+ * non-breaking/zero-width characters inside script code. In syntax positions
+ * these break bash/python outright, and Windows PowerShell 5.1 mis-decodes
+ * them entirely in a BOM-less ANSI read, producing cascading parse errors
+ * ("Unexpected token", "missing string terminator"). The Go agent stamps a
+ * UTF-8 BOM on .ps1 files (internal/executor/shell.go WriteScriptFile), but
+ * code should be plain ASCII punctuation regardless.
  *
- * Deliberately conservative: only characters that are unambiguous typographic
- * substitutions for ASCII are mapped. Everything else (accented letters,
- * CJK, symbols) passes through untouched.
+ * Replacements apply everywhere, including inside string contents -- an
+ * intentional trade-off: typographic punctuation in script output text is
+ * cosmetic, while in a delimiter position it is always a bug. Otherwise
+ * deliberately conservative: only unambiguous typographic substitutions for
+ * ASCII are mapped; everything else (accented letters, CJK, symbols) passes
+ * through untouched.
  */
 
 const TYPOGRAPHIC_REPLACEMENTS: ReadonlyArray<[RegExp, string]> = [

--- a/apps/api/src/services/scriptCodeNormalize.ts
+++ b/apps/api/src/services/scriptCodeNormalize.ts
@@ -1,0 +1,39 @@
+/**
+ * Normalize typographic Unicode punctuation in AI-generated script code.
+ *
+ * LLMs occasionally emit curly quotes, em/en dashes, ellipses, and
+ * non-breaking/zero-width spaces inside script code. Interpreters treat these
+ * as ordinary characters (bash/python) or, worse, Windows PowerShell 5.1
+ * mis-decodes them entirely in a BOM-less ANSI read, producing cascading
+ * parse errors ("Unexpected token", "missing string terminator"). The agent
+ * now writes .ps1 files with a UTF-8 BOM, but code should be plain ASCII
+ * punctuation regardless -- a curly quote is never intentional in a quote
+ * position and breaks bash/python even when decoded correctly.
+ *
+ * Deliberately conservative: only characters that are unambiguous typographic
+ * substitutions for ASCII are mapped. Everything else (accented letters,
+ * CJK, symbols) passes through untouched.
+ */
+
+const TYPOGRAPHIC_REPLACEMENTS: ReadonlyArray<[RegExp, string]> = [
+  // Curly single quotes / apostrophes and prime
+  [/[\u2018\u2019\u201A\u201B\u2032]/g, "'"],
+  // Curly double quotes and double prime
+  [/[\u201C\u201D\u201E\u201F\u2033]/g, '"'],
+  // Hyphen variants, en/em/horizontal-bar dashes, and the minus sign
+  [/[\u2010-\u2015\u2212]/g, '-'],
+  // Horizontal ellipsis
+  [/\u2026/g, '...'],
+  // Non-breaking and fixed-width spaces: NBSP, figure space, narrow NBSP
+  [/[\u00A0\u2007\u202F]/g, ' '],
+  // Zero-width characters and stray BOMs -- delete outright
+  [/[\u200B\u200C\u200D\uFEFF]/g, ''],
+];
+
+export function normalizeScriptCode(code: string): string {
+  let result = code;
+  for (const [pattern, replacement] of TYPOGRAPHIC_REPLACEMENTS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}


### PR DESCRIPTION
## Problem

Scripts written by the script-builder AI intermittently fail on Windows devices with cascading parse errors:

```
Unexpected token 'MB' in expression or statement.
Missing closing ')' in expression.
The string is missing the terminator: ".
```

The script text is syntactically valid — the failure is an encoding bug. The AI sometimes emits typographic Unicode (curly quotes `“”`, em-dashes, non-breaking spaces). The agent writes `.ps1` files as UTF-8 **without a BOM** and runs them with `powershell.exe -File`; Windows PowerShell 5.1 decodes a BOM-less `.ps1` as the ANSI codepage, so the multi-byte punctuation becomes mojibake, string delimiters are never recognized, and the parser cascades.

## Fix (three layers)

1. **Agent (root cause)** — `WriteScriptFile` now stamps a UTF-8 BOM on `.ps1` files, so any UTF-8 content decodes as authored. `.ps1` only: bash rejects a BOM before the shebang, and cmd feeds it to the first command. Guards against double-BOM.
2. **API** — new `normalizeScriptCode` converts typographic punctuation to ASCII (curly quotes → straight, dash variants → `-`, ellipsis → `...`, NBSP → space, zero-widths stripped) in `apply_script_code` before the code reaches the editor. These characters also break bash/python even when decoded correctly. Conservative: accented letters / CJK / symbols untouched.
3. **Prompt** — the script-builder system prompt now explicitly forbids typographic characters in code.

## Tests

- `agent/internal/executor/shell_bom_test.go` — BOM present on `.ps1` (incl. no double-BOM), absent on `.sh`/`.py`/`.bat`, content intact. `go test -race ./internal/executor/` green.
- `apps/api/src/services/scriptCodeNormalize.test.ts` — includes the exact reported repro line; 40 tests green together with the script-builder guard suite. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)