### PR TITLE
fix(web,api): software deploy UX fixes, partner-wide packages, version editing

### DIFF
--- a/apps/api/src/__tests__/integration/builtinCatalogVersionsRoute.integration.test.ts
+++ b/apps/api/src/__tests__/integration/builtinCatalogVersionsRoute.integration.test.ts
@@ -44,6 +44,10 @@ vi.mock('../../middleware/auth', async (importOriginal) => {
         partnerId: activeAuth.partnerId,
         orgId: activeAuth.orgId,
         accessibleOrgIds: activeAuth.accessibleOrgIds,
+        // Mirrors buildOrgAccessClosures in middleware/auth.ts: canAccessOrg is a
+        // required member of AuthContext that both real constructors always set,
+        // so a stub that omits it makes the route throw instead of authorizing.
+        canAccessOrg: (orgId: string) => activeAuth!.accessibleOrgIds.includes(orgId),
         user: { id: null, email: 'integration@test' },
       });
       return withDbAccessContext(

--- a/apps/api/src/__tests__/integration/builtinCatalogVersionsRoute.integration.test.ts
+++ b/apps/api/src/__tests__/integration/builtinCatalogVersionsRoute.integration.test.ts
@@ -264,4 +264,51 @@ describe('built-in package versions via route (#1957)', () => {
     );
     expect(siblingRes.status).toBe(404);
   });
+
+  // The All-organizations fleet view sends NO orgId, so nothing resolves and
+  // the guard falls back to canAccessOrg. Pins the one place the rule is
+  // intentionally wider than the resolved-org narrowing: a multi-org partner
+  // caller with no org context can still read its built-ins AND any accessible
+  // org's package — that's what the fleet view spans — while cross-partner rows
+  // stay invisible (RLS).
+  it('fleet view (partner scope, no orgId): reads built-in and own-org package, not cross-partner', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const { catalog: builtin } = await seedBuiltin(partner.id);
+    const { catalog: orgBPkg } = await seedOrgOwned(orgB.id);
+
+    const otherPartner = await createPartner();
+    const otherOrg = await createOrganization({ partnerId: otherPartner.id });
+    const { catalog: foreignPkg } = await seedOrgOwned(otherOrg.id);
+
+    // Two accessible orgs and no auth.orgId: resolveScopedOrgId has nothing to
+    // resolve (the single-org shortcut must not fire), which is the fleet view.
+    activeAuth = {
+      scope: 'partner',
+      orgId: null,
+      partnerId: partner.id,
+      accessibleOrgIds: [orgA.id, orgB.id],
+    };
+
+    const app = await buildApp();
+    const builtinRes = await app.request(
+      `/software/catalog/${builtin.id}/versions`,
+      { headers: { Authorization: 'Bearer token' } },
+    );
+    expect(builtinRes.status).toBe(200);
+    expect((await builtinRes.json()).data).toHaveLength(1);
+
+    const orgPkgRes = await app.request(
+      `/software/catalog/${orgBPkg.id}`,
+      { headers: { Authorization: 'Bearer token' } },
+    );
+    expect(orgPkgRes.status).toBe(200);
+
+    const foreignRes = await app.request(
+      `/software/catalog/${foreignPkg.id}`,
+      { headers: { Authorization: 'Bearer token' } },
+    );
+    expect(foreignRes.status).toBe(404);
+  });
 });

--- a/apps/api/src/__tests__/integration/builtinCatalogVersionsRoute.integration.test.ts
+++ b/apps/api/src/__tests__/integration/builtinCatalogVersionsRoute.integration.test.ts
@@ -311,4 +311,42 @@ describe('built-in package versions via route (#1957)', () => {
     );
     expect(foreignRes.status).toBe(404);
   });
+
+  // Same narrowing on the WRITE side (authorizeCatalogItemWrite): a partner
+  // caller acting as org A must not mutate sibling org B's RLS-visible package,
+  // while the same request against org B's own context succeeds.
+  it('partner-scope caller: cannot PATCH a sibling org-owned package while acting as another org', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const { catalog: orgBPkg } = await seedOrgOwned(orgB.id);
+
+    activeAuth = {
+      scope: 'partner',
+      orgId: null,
+      partnerId: partner.id,
+      accessibleOrgIds: [orgA.id, orgB.id],
+    };
+
+    const app = await buildApp();
+    const crossRes = await app.request(
+      `/software/catalog/${orgBPkg.id}?orgId=${orgA.id}`,
+      {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: 'tampered from org A context' }),
+      },
+    );
+    expect(crossRes.status).toBe(404);
+
+    const ownRes = await app.request(
+      `/software/catalog/${orgBPkg.id}?orgId=${orgB.id}`,
+      {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: 'legitimate update in org B context' }),
+      },
+    );
+    expect(ownRes.status).toBe(200);
+  });
 });

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -309,7 +309,9 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   'cis_baselines',
   // software_catalog: a package is org-scoped (org_id set, partner_id NULL — the
   // baseline shape for custom packages) OR partner-wide (partner_id set, org_id
-  // NULL — built-in EDR integration packages). Converted from org-only to
+  // NULL — built-in EDR integration packages, and user-created partner-wide
+  // custom packages via POST /software/catalog ownerScope:'partner', #2135).
+  // Converted from org-only to
   // dual-axis in 2026-06-26-a-software-catalog-partner-axis. The org_id column
   // means org-tenant auto-discovery already asserts the breeze_has_org_access
   // branch; this entry asserts the breeze_has_partner_access (built-in) branch.

--- a/apps/api/src/__tests__/integration/softwareCatalogDelete.integration.test.ts
+++ b/apps/api/src/__tests__/integration/softwareCatalogDelete.integration.test.ts
@@ -28,6 +28,10 @@ vi.mock('../../middleware/auth', async (importOriginal) => {
         partnerId: null,
         orgId: activeOrgId,
         accessibleOrgIds: [activeOrgId],
+        // Mirrors buildOrgAccessClosures in middleware/auth.ts: canAccessOrg is a
+        // required member of AuthContext that both real constructors always set,
+        // so a stub that omits it makes the route throw instead of authorizing.
+        canAccessOrg: (orgId: string) => orgId === activeOrgId,
         user: { id: null, email: 'integration@test' },
       });
       return withDbAccessContext(

--- a/apps/api/src/routes/config.test.ts
+++ b/apps/api/src/routes/config.test.ts
@@ -102,6 +102,28 @@ describe('GET /config', () => {
     expect(body.registration).toEqual({ enabled: false });
   });
 
+  it('softwarePackages.uploadsEnabled is false without full S3 config', async () => {
+    vi.stubEnv('S3_BUCKET', '');
+    vi.stubEnv('S3_ACCESS_KEY', '');
+    vi.stubEnv('S3_SECRET_KEY', '');
+    const { body } = await request();
+    expect(body.softwarePackages).toEqual({ uploadsEnabled: false });
+    vi.unstubAllEnvs();
+  });
+
+  it('softwarePackages.uploadsEnabled requires bucket AND both keys', async () => {
+    vi.stubEnv('S3_BUCKET', 'bucket');
+    vi.stubEnv('S3_ACCESS_KEY', '');
+    vi.stubEnv('S3_SECRET_KEY', 'secret');
+    const partial = await request();
+    expect(partial.body.softwarePackages).toEqual({ uploadsEnabled: false });
+
+    vi.stubEnv('S3_ACCESS_KEY', 'key');
+    const full = await request();
+    expect(full.body.softwarePackages).toEqual({ uploadsEnabled: true });
+    vi.unstubAllEnvs();
+  });
+
   it('returns authenticated org-scoped ML feature flag resolutions', async () => {
     const app = new Hono().route('/config', configRoutes);
     const res = await app.request('/config/ml-feature-flags');

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -3,6 +3,7 @@ import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { cfAccessTrustEnabled } from '../config/env';
 import { envFlag } from '../utils/envFlag';
+import { isS3Configured } from '../services/s3Storage';
 import { authMiddleware, requireScope, type AuthContext } from '../middleware/auth';
 import { resolveAllMlFeatureFlagsForOrg } from '../services/mlFeatureFlags';
 
@@ -33,6 +34,13 @@ configRoutes.get('/', (c) => {
     // /auth/register-partner enforcement reads (issue #1308).
     registration: {
       enabled: envFlag('ENABLE_REGISTRATION', false),
+    },
+    // Whether software package file uploads can succeed (S3 object storage
+    // fully configured). The web uses this to gray out upload affordances up
+    // front instead of letting the user pick a file and then hit the 503 the
+    // upload routes return when storage is missing.
+    softwarePackages: {
+      uploadsEnabled: isS3Configured(),
     },
   });
 });

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -126,7 +126,8 @@ vi.mock('../middleware/auth', () => ({
       userId: 'user-123',
       scope: 'organization',
       orgId: 'org-123',
-      partnerId: null
+      partnerId: null,
+      canAccessOrg: (orgId: string) => orgId === 'org-123'
     });
     return next();
   }),
@@ -427,6 +428,61 @@ describe('software routes', () => {
 
       expect(res.status).toBe(400);
       expect((await res.json()).error).toBe('orgId is required for this scope');
+    });
+  });
+
+  describe('PATCH /software/catalog/:id/versions/:versionId', () => {
+    const CAT_ID = '33333333-3333-4333-8333-333333333333';
+    const VER_ID = '44444444-4444-4444-8444-444444444444';
+    const catalogRow = { id: CAT_ID, orgId: 'org-123', partnerId: null, integrationProvider: null, name: 'Chrome' };
+
+    const mockSelects = (versionRow: unknown) => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce({ from: () => ({ where: async () => [catalogRow] }) } as any)
+        .mockReturnValueOnce({ from: () => ({ where: async () => (versionRow ? [versionRow] : []) }) } as any);
+    };
+
+    const patchReq = (body: unknown) =>
+      app.request(`/software/catalog/${CAT_ID}/versions/${VER_ID}`, {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+    it('updates only the provided metadata fields', async () => {
+      mockSelects({ id: VER_ID, catalogId: CAT_ID, version: '1.0.0', s3Key: null });
+      const setSpy = vi.fn(() => ({
+        where: () => ({ returning: async () => [{ id: VER_ID, version: '1.0.1', silentInstallArgs: '/S' }] }),
+      }));
+      vi.mocked(db.update).mockReturnValueOnce({ set: setSpy } as any);
+
+      const res = await patchReq({ version: '1.0.1', silentInstallArgs: '/S' });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).data.version).toBe('1.0.1');
+      expect(setSpy).toHaveBeenCalledWith({ version: '1.0.1', silentInstallArgs: '/S' });
+    });
+
+    it('404s for a version that does not belong to the catalog item', async () => {
+      mockSelects(null);
+      const res = await patchReq({ version: '2.0.0' });
+      expect(res.status).toBe(404);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('refuses to clear the download URL of a URL-only version', async () => {
+      mockSelects({ id: VER_ID, catalogId: CAT_ID, version: '1.0.0', s3Key: null });
+      const res = await patchReq({ downloadUrl: null });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/needs a download URL/);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('400s an empty update', async () => {
+      mockSelects({ id: VER_ID, catalogId: CAT_ID, version: '1.0.0', s3Key: null });
+      const res = await patchReq({});
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe('No fields to update');
     });
   });
 

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -12,7 +12,7 @@ import { captureException, captureMessage } from '../services/sentry';
 import { parseStreamingMultipart } from '../services/streamingUpload';
 import { createHash } from 'node:crypto';
 import { authMiddleware } from '../middleware/auth';
-import { inArray, eq } from 'drizzle-orm';
+import { inArray, eq, isNull } from 'drizzle-orm';
 import { resolveDeploymentTargets } from '../services/deploymentTargetResolver';
 import { createSoftwareDeployment } from '../services/softwareDeployment';
 import { writeRouteAudit } from '../services/auditEvents';
@@ -41,7 +41,7 @@ vi.mock('../services/softwareDeployment', () => ({
 // `vi.clearAllMocks()` clears call records but keeps these implementations.
 vi.mock('drizzle-orm', async () => {
   const actual = await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm');
-  return { ...actual, inArray: vi.fn(actual.inArray), eq: vi.fn(actual.eq) };
+  return { ...actual, inArray: vi.fn(actual.inArray), eq: vi.fn(actual.eq), isNull: vi.fn(actual.isNull) };
 });
 
 // Chain-friendly mock builder for Drizzle query builder patterns
@@ -275,6 +275,41 @@ describe('software routes', () => {
       expect(db.select).not.toHaveBeenCalled();
     });
 
+    it('adds the partner-wide branch for partner scope and only for partner scope (#2135)', async () => {
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'partner',
+          orgId: null,
+          partnerId: 'partner-123',
+          accessibleOrgIds: ['org-a', 'org-b'],
+        });
+        return next();
+      });
+
+      let res = await app.request('/software/catalog', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      expect(res.status).toBe(200);
+      // Partner scope: the widened WHERE must include the caller's own
+      // partner-wide custom rows — `org_id IS NULL AND partner_id = <own>`.
+      expect(isNull).toHaveBeenCalledWith('org_id');
+      expect(eq).toHaveBeenCalledWith('partner_id', 'partner-123');
+
+      // Org scope (the default auth mock): the branch must be ABSENT — org
+      // tokens never pass breeze_has_partner_access, so an app-layer partner
+      // condition would promise rows RLS won't return.
+      vi.mocked(isNull).mockClear();
+      res = await app.request('/software/catalog', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      expect(res.status).toBe(200);
+      expect(isNull).not.toHaveBeenCalledWith('org_id');
+    });
+
     it('allows system scope to list a requested orgId', async () => {
       vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
         c.set('auth', {
@@ -483,6 +518,148 @@ describe('software routes', () => {
       const res = await patchReq({});
       expect(res.status).toBe(400);
       expect((await res.json()).error).toBe('No fields to update');
+    });
+  });
+
+  // The eq(orgId) WHERE filter that used to make cross-tenant writes
+  // structurally impossible is gone from these routes; authorizeCatalogItemWrite
+  // is the only app-layer guard left. These tests pin its deny outcomes on each
+  // route so dropping the call from any one of them fails loudly.
+  describe('catalog dual-axis write authorization (deny paths)', () => {
+    const CAT_ID = '55555555-5555-4555-8555-555555555555';
+    const VER_ID = '66666666-6666-4666-8666-666666666666';
+    const partnerRow = { id: CAT_ID, orgId: null, partnerId: 'partner-123', integrationProvider: null, name: 'Shared Pkg' };
+    const builtinRow = { ...partnerRow, integrationProvider: 'huntress', name: 'Huntress Agent' };
+    const foreignOrgRow = { id: CAT_ID, orgId: 'other-org', partnerId: null, integrationProvider: null, name: 'Foreign Pkg' };
+
+    const setAuth = (overrides: Record<string, unknown>) => {
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'partner',
+          orgId: null,
+          partnerId: 'partner-123',
+          accessibleOrgIds: ['org-a'],
+          canAccessOrg: (orgId: string) => orgId === 'org-a',
+          ...overrides,
+        });
+        return next();
+      });
+    };
+    const selectOnce = (rows: unknown[]) =>
+      vi.mocked(db.select).mockReturnValueOnce({ from: () => ({ where: async () => rows }) } as any);
+
+    it('403s a limited partner admin editing a partner-wide package', async () => {
+      setAuth({ partnerOrgAccess: 'selected' });
+      selectOnce([partnerRow]);
+      const res = await app.request(`/software/catalog/${CAT_ID}`, {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed' }),
+      });
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toMatch(/full partner org access/);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('403s editing/deleting a built-in integration package even for a full partner admin', async () => {
+      setAuth({ partnerOrgAccess: 'all' });
+      selectOnce([builtinRow]);
+      const patch = await app.request(`/software/catalog/${CAT_ID}`, {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed' }),
+      });
+      expect(patch.status).toBe(403);
+      expect((await patch.json()).error).toMatch(/Built-in integration packages/);
+
+      setAuth({ partnerOrgAccess: 'all' });
+      selectOnce([builtinRow]);
+      const del = await app.request(`/software/catalog/${CAT_ID}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' },
+      });
+      expect(del.status).toBe(403);
+      expect(db.update).not.toHaveBeenCalled();
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('403s a limited partner admin on version create/PATCH/promote against a partner-wide package', async () => {
+      setAuth({ partnerOrgAccess: 'selected' });
+      selectOnce([partnerRow]);
+      const create = await app.request(`/software/catalog/${CAT_ID}/versions`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ version: '2.0.0' }),
+      });
+      expect(create.status).toBe(403);
+
+      setAuth({ partnerOrgAccess: 'selected' });
+      selectOnce([partnerRow]);
+      const patch = await app.request(`/software/catalog/${CAT_ID}/versions/${VER_ID}`, {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ version: '2.0.0' }),
+      });
+      expect(patch.status).toBe(403);
+
+      setAuth({ partnerOrgAccess: 'selected' });
+      selectOnce([partnerRow]);
+      const promote = await app.request(`/software/catalog/${CAT_ID}/versions/${VER_ID}/promote`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+      expect(promote.status).toBe(403);
+      expect(db.update).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('404s a version PATCH against an org row outside the caller orgs', async () => {
+      // Default org-scope auth (org-123) fetches a visible row owned by another
+      // org — must 404, not edit.
+      selectOnce([foreignOrgRow]);
+      const res = await app.request(`/software/catalog/${CAT_ID}/versions/${VER_ID}`, {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ version: '2.0.0' }),
+      });
+      expect(res.status).toBe(404);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('allows a full partner admin to PATCH a built-in package VERSION (S1 installer flow)', async () => {
+      // Version-level writes on built-ins are intentionally allowed: the
+      // documented SentinelOne flow has partner admins uploading the installer
+      // via the Versions tab, and the 2026-07-02 RLS migration grants exactly
+      // this. Only the catalog row itself is immutable.
+      setAuth({ partnerOrgAccess: 'all' });
+      selectOnce([builtinRow]);
+      selectOnce([{ id: VER_ID, catalogId: CAT_ID, version: '23.1.0', s3Key: 's3/some-key' }]);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: () => ({ where: () => ({ returning: async () => [{ id: VER_ID, version: '23.2.0' }] }) }),
+      } as any);
+      const res = await app.request(`/software/catalog/${CAT_ID}/versions/${VER_ID}`, {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ version: '23.2.0' }),
+      });
+      expect(res.status).toBe(200);
+      expect((await res.json()).data.version).toBe('23.2.0');
+    });
+
+    it('allows system scope to PATCH a built-in catalog row', async () => {
+      setAuth({ scope: 'system', partnerId: null, partnerOrgAccess: undefined, canAccessOrg: () => true });
+      selectOnce([builtinRow]);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: () => ({ where: () => ({ returning: async () => [{ ...builtinRow, name: 'Renamed' }] }) }),
+      } as any);
+      const res = await app.request(`/software/catalog/${CAT_ID}`, {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed' }),
+      });
+      expect(res.status).toBe(200);
     });
   });
 

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -86,7 +86,7 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
-  softwareCatalog: { id: 'id', orgId: 'org_id', name: 'name', vendor: 'vendor', description: 'description', category: 'category' },
+  softwareCatalog: { id: 'id', orgId: 'org_id', partnerId: 'partner_id', integrationProvider: 'integration_provider', name: 'name', vendor: 'vendor', description: 'description', category: 'category' },
   softwareVersions: { id: 'id', catalogId: 'catalog_id', isLatest: 'is_latest' },
   softwareDeployments: { id: 'id', orgId: 'org_id', softwareVersionId: 'software_version_id', createdAt: 'created_at', dispatchedAt: 'dispatched_at' },
   deploymentResults: { id: 'dr_id', deploymentId: 'deployment_id', deviceId: 'device_id', status: 'status', startedAt: 'started_at', completedAt: 'completed_at', exitCode: 'exit_code', output: 'output', errorMessage: 'error_message', retryCount: 'retry_count', deviceCommandId: 'device_command_id' },
@@ -348,6 +348,85 @@ describe('software routes', () => {
         pagination: { page: 1, limit: 50, total: 0 }
       });
       expect(db.select).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /software/catalog (create)', () => {
+    const setPartnerAuth = (partnerOrgAccess: 'all' | 'selected' | 'none') => {
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'partner',
+          orgId: null,
+          partnerId: 'partner-123',
+          partnerOrgAccess,
+          accessibleOrgIds: ['org-a', 'org-b'],
+        });
+        return next();
+      });
+    };
+
+    it('creates an org-owned package by default (org scope)', async () => {
+      const row = { id: 'cat-1', name: 'Chrome', vendor: null, orgId: 'org-123', partnerId: null };
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn(() => ({ returning: vi.fn(async () => [row]) })),
+      } as any);
+
+      const res = await app.request('/software/catalog', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Chrome' }),
+      });
+
+      expect(res.status).toBe(201);
+      expect((await res.json()).data.orgId).toBe('org-123');
+    });
+
+    it('creates a partner-wide package for a full-partner admin (#2135)', async () => {
+      setPartnerAuth('all');
+      const row = { id: 'cat-2', name: 'Chrome', vendor: null, orgId: null, partnerId: 'partner-123' };
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn(() => ({ returning: vi.fn(async () => [row]) })),
+      } as any);
+
+      const res = await app.request('/software/catalog', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Chrome', ownerScope: 'partner' }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.data.orgId).toBeNull();
+      expect(body.data.partnerId).toBe('partner-123');
+    });
+
+    it('rejects partner-wide creation without full partner org access', async () => {
+      setPartnerAuth('selected');
+
+      const res = await app.request('/software/catalog', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Chrome', ownerScope: 'partner' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toMatch(/full partner org access/);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('still requires an org for org-owned creation in All-orgs scope', async () => {
+      setPartnerAuth('all');
+
+      const res = await app.request('/software/catalog', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Chrome' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe('orgId is required for this scope');
     });
   });
 

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -422,6 +422,21 @@ function safeUrlHost(rawUrl: string): string {
   }
 }
 
+// PATCH body: only provided keys change; explicit null clears a field. The
+// binary-describing fields (checksum, fileSize, s3Key) and scripts are not
+// editable — replacing the installer means adding a new version.
+const updateVersionSchema = z.object({
+  version: z.string().min(1).max(100).optional(),
+  releaseDate: z.string().datetime().optional(),
+  releaseNotes: z.string().max(5000).nullable().optional(),
+  downloadUrl: z.string().url().nullable().optional(),
+  supportedOs: z.array(platformSchema).nullable().optional(),
+  architecture: z.string().max(20).optional(),
+  silentInstallArgs: z.string().max(2000).nullable().optional(),
+  silentUninstallArgs: z.string().max(2000).nullable().optional(),
+  detectionRules: detectionRulesSchema.nullable().optional()
+});
+
 const listDeploymentsSchema = z.object({
   status: z.enum(['pending', 'in_progress', 'completed', 'completed_with_errors', 'failed', 'cancelled']).optional(),
   page: z.string().optional(),
@@ -1137,6 +1152,71 @@ softwareRoutes.post(
       // Clean up temp file
       await unlink(tempPath).catch(() => {});
     }
+  }
+);
+
+// PATCH /catalog/:id/versions/:versionId - Update version metadata
+softwareRoutes.patch(
+  '/catalog/:id/versions/:versionId',
+  requireScope('organization', 'partner', 'system'),
+  requireSoftwareWrite,
+  requireMfa(),
+  zValidator('param', versionIdParamSchema),
+  zValidator('json', updateVersionSchema),
+  async (c) => {
+    const auth = c.get('auth');
+
+    const { id, versionId } = c.req.valid('param');
+    const payload = c.req.valid('json');
+
+    // Dual-axis fetch + write authorization (#2135) — see version create above.
+    const [catalogItem] = await db.select().from(softwareCatalog)
+      .where(eq(softwareCatalog.id, id));
+    if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
+    const denied = authorizeCatalogItemWrite(auth, catalogItem);
+    if (denied) return c.json({ error: denied.error }, denied.status);
+
+    const [existingVersion] = await db.select().from(softwareVersions)
+      .where(and(
+        eq(softwareVersions.id, versionId),
+        eq(softwareVersions.catalogId, id),
+      ));
+    if (!existingVersion) return c.json({ error: 'Version not found' }, 404);
+
+    const updates: Record<string, unknown> = {};
+    if (payload.version !== undefined) updates.version = payload.version;
+    if (payload.releaseDate !== undefined) updates.releaseDate = new Date(payload.releaseDate);
+    if (payload.releaseNotes !== undefined) updates.releaseNotes = payload.releaseNotes;
+    if (payload.downloadUrl !== undefined) updates.downloadUrl = payload.downloadUrl;
+    if (payload.supportedOs !== undefined) updates.supportedOs = payload.supportedOs;
+    if (payload.architecture !== undefined) updates.architecture = payload.architecture;
+    if (payload.silentInstallArgs !== undefined) updates.silentInstallArgs = payload.silentInstallArgs;
+    if (payload.silentUninstallArgs !== undefined) updates.silentUninstallArgs = payload.silentUninstallArgs;
+    if (payload.detectionRules !== undefined) updates.detectionRules = payload.detectionRules;
+    if (Object.keys(updates).length === 0) {
+      return c.json({ error: 'No fields to update' }, 400);
+    }
+    // A URL-sourced version must not end up with neither URL nor uploaded file.
+    if (updates.downloadUrl === null && !existingVersion.s3Key) {
+      return c.json({ error: 'This version has no uploaded file — it needs a download URL' }, 400);
+    }
+
+    const [updated] = await db.update(softwareVersions)
+      .set(updates)
+      .where(eq(softwareVersions.id, versionId))
+      .returning();
+    if (!updated) return c.json({ error: 'Failed to update software version' }, 500);
+
+    writeRouteAudit(c, {
+      orgId: catalogItem.orgId,
+      action: 'software.catalog.version.update',
+      resourceType: 'software_version',
+      resourceId: versionId,
+      resourceName: catalogItem.name,
+      details: { version: updated.version, updatedFields: Object.keys(updates) },
+    });
+
+    return c.json({ data: updated });
   }
 );
 

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -103,19 +103,21 @@ function resolveCatalogListScope(
 
 /**
  * Authorize a write against a catalog row fetched by id (dual-axis, #2135).
- * Org-owned rows: any caller with access to that org. Partner-wide rows
- * (org_id NULL): system scope, or a full-partner admin of the owning partner.
+ * Org-owned rows: the same resolved-org narrowing as the reads
+ * (authorizeCatalogItemRead) — a partner caller acting as org A must not
+ * mutate sibling org B's package, with the canAccessOrg fallback only in the
+ * org-less All-organizations view. Partner-wide rows (org_id NULL): system
+ * scope, or a full-partner admin of the owning partner.
  * Returns null when allowed, else the error response to send. 404 (not 403)
  * for foreign rows, matching the read routes' don't-reveal-existence behavior.
  */
 function authorizeCatalogItemWrite(
   auth: AuthContext,
   item: { orgId: string | null; partnerId: string | null },
+  requestedOrgId: string | undefined,
 ): { error: string; status: 403 | 404 } | null {
   if (item.orgId !== null) {
-    return auth.canAccessOrg(item.orgId)
-      ? null
-      : { error: 'Catalog item not found', status: 404 };
+    return authorizeCatalogItemRead(auth, item.orgId, requestedOrgId);
   }
   if (auth.scope === 'system') return null;
   if (auth.scope !== 'partner' || !auth.partnerId || item.partnerId !== auth.partnerId) {
@@ -770,7 +772,7 @@ softwareRoutes.patch(
     if (existing.integrationProvider !== null && auth.scope !== 'system') {
       return c.json({ error: 'Built-in integration packages cannot be modified' }, 403);
     }
-    const denied = authorizeCatalogItemWrite(auth, existing);
+    const denied = authorizeCatalogItemWrite(auth, existing, c.req.query('orgId'));
     if (denied) return c.json({ error: denied.error }, denied.status);
 
     const [updated] = await db.update(softwareCatalog)
@@ -809,7 +811,7 @@ softwareRoutes.delete(
     if (existing.integrationProvider !== null && auth.scope !== 'system') {
       return c.json({ error: 'Built-in integration packages cannot be deleted' }, 403);
     }
-    const denied = authorizeCatalogItemWrite(auth, existing);
+    const denied = authorizeCatalogItemWrite(auth, existing, c.req.query('orgId'));
     if (denied) return c.json({ error: denied.error }, denied.status);
 
     // A version that is still referenced by a deployment cannot be deleted —
@@ -904,7 +906,7 @@ softwareRoutes.post(
     const [catalogItem] = await db.select().from(softwareCatalog)
       .where(eq(softwareCatalog.id, id));
     if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
-    const denied = authorizeCatalogItemWrite(auth, catalogItem);
+    const denied = authorizeCatalogItemWrite(auth, catalogItem, c.req.query('orgId'));
     if (denied) return c.json({ error: denied.error }, denied.status);
 
     // A URL-created version never recorded a fileType, so the dispatcher fell
@@ -1190,7 +1192,7 @@ softwareRoutes.patch(
     const [catalogItem] = await db.select().from(softwareCatalog)
       .where(eq(softwareCatalog.id, id));
     if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
-    const denied = authorizeCatalogItemWrite(auth, catalogItem);
+    const denied = authorizeCatalogItemWrite(auth, catalogItem, c.req.query('orgId'));
     if (denied) return c.json({ error: denied.error }, denied.status);
 
     const [existingVersion] = await db.select().from(softwareVersions)
@@ -1252,7 +1254,7 @@ softwareRoutes.post(
     const [catalogItem] = await db.select().from(softwareCatalog)
       .where(eq(softwareCatalog.id, id));
     if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
-    const denied = authorizeCatalogItemWrite(auth, catalogItem);
+    const denied = authorizeCatalogItemWrite(auth, catalogItem, c.req.query('orgId'));
     if (denied) return c.json({ error: denied.error }, denied.status);
 
     const [existingVersion] = await db.select().from(softwareVersions)

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -422,9 +422,11 @@ function safeUrlHost(rawUrl: string): string {
   }
 }
 
-// PATCH body: only provided keys change; explicit null clears a field. The
-// binary-describing fields (checksum, fileSize, s3Key) and scripts are not
-// editable — replacing the installer means adding a new version.
+// PATCH body: only provided keys change; explicit null clears a nullable
+// field (notes, URL, OS, args, detection rules — version/releaseDate/
+// architecture reject null). The binary-describing fields (checksum, fileSize,
+// s3Key) and scripts are not editable — replacing the installer means adding
+// a new version.
 const updateVersionSchema = z.object({
   version: z.string().min(1).max(100).optional(),
   releaseDate: z.string().datetime().optional(),
@@ -689,8 +691,15 @@ softwareRoutes.get(
 
     const query = c.req.valid('query');
     const term = `%${query.q}%`;
+    // Same dual-axis widening as GET /catalog: built-ins for everyone, the
+    // caller's own partner-wide custom packages for partner scope (#2135) —
+    // search must not return a narrower set than the list it searches.
+    const scopeBranches: SQL[] = [eq(softwareCatalog.orgId, orgId), isNotNull(softwareCatalog.integrationProvider)];
+    if (auth.scope === 'partner' && auth.partnerId) {
+      scopeBranches.push(and(isNull(softwareCatalog.orgId), eq(softwareCatalog.partnerId, auth.partnerId))!);
+    }
     const conditions = [
-      eq(softwareCatalog.orgId, orgId),
+      or(...scopeBranches)!,
       or(
         like(softwareCatalog.name, term),
         like(softwareCatalog.vendor, term),
@@ -716,10 +725,12 @@ softwareRoutes.get(
     const auth = c.get('auth');
 
     const { id } = c.req.valid('param');
-    // Look up by id alone, then authorize in JS. RLS restricts visibility to the
-    // caller's org rows + their partner's rows (built-ins and partner-wide
-    // packages); the org guard below rejects a (visible) org-scoped row from a
-    // different accessible org context. Partner rows have org_id NULL, so an
+    // Look up by id alone, then authorize in JS. RLS bounds what is visible:
+    // the caller's org rows, plus NULL-org partner rows — built-ins for any
+    // caller, but partner-wide custom packages only for partner-scope tokens
+    // (org tokens never pass breeze_has_partner_access, so those rows are
+    // simply invisible here and 404). The org guard below rejects a (visible)
+    // org row the caller can't access. Partner rows have org_id NULL, so an
     // `eq(orgId)` filter would exclude them — matching the /deploy route (#1957).
     // No resolveScopedOrgId here: the All-organizations view has no org to
     // resolve, and a partner-wide row is exactly what it should still see.
@@ -1487,9 +1498,11 @@ softwareRoutes.post(
       integrationProvider: softwareCatalog.integrationProvider,
     }).from(softwareCatalog)
       .where(eq(softwareCatalog.id, versionRecord.catalogId));
-    // RLS already restricts visibility to the caller's org rows + their partner's
-    // built-ins. Extra guard: an org-scoped (non-built-in) row must match the
-    // authenticated org; built-in packages have org_id NULL and are allowed.
+    // RLS already restricts visibility to the caller's org rows + partner-scoped
+    // NULL-org rows (built-in EDR packages, and — for partner-scope tokens —
+    // partner-wide custom packages, #2135). Extra guard: an org-owned row must
+    // match the authenticated org; NULL-org rows are allowed and the deployment
+    // itself is stamped with the resolved context org.
     if (!catalogItem || (catalogItem.orgId !== null && catalogItem.orgId !== orgId)) {
       return c.json({ error: 'Catalog item not found or access denied' }, 404);
     }
@@ -1591,8 +1604,9 @@ softwareRoutes.post(
     const deviceIds = body.targets?.deviceIds ?? [];
 
     // Look up the catalog item + version. RLS restricts visibility to the caller's
-    // org rows + their partner's built-ins; the org guard below rejects a (visible)
-    // org-scoped row that belongs to a different org. Built-ins have org_id NULL.
+    // org rows + partner-scoped NULL-org rows (built-in EDR packages, and — for
+    // partner-scope tokens — partner-wide custom packages, #2135); the org guard
+    // below rejects a (visible) org-owned row that belongs to a different org.
     const [catalogItem] = await db.select({
       id: softwareCatalog.id,
       orgId: softwareCatalog.orgId,

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -56,6 +56,7 @@ import {
   ALLOWED_EXTENSIONS,
   MAX_UPLOAD_SIZE,
   getFileExtension,
+  authorizeCatalogItemRead,
   resolveScopedOrgId,
   setLatestSoftwareVersion,
   insertLatestSoftwareVersion,
@@ -729,16 +730,17 @@ softwareRoutes.get(
     // the caller's org rows, plus NULL-org partner rows — built-ins for any
     // caller, but partner-wide custom packages only for partner-scope tokens
     // (org tokens never pass breeze_has_partner_access, so those rows are
-    // simply invisible here and 404). The org guard below rejects a (visible)
-    // org row the caller can't access. Partner rows have org_id NULL, so an
+    // simply invisible here and 404). Partner rows have org_id NULL, so an
     // `eq(orgId)` filter would exclude them — matching the /deploy route (#1957).
-    // No resolveScopedOrgId here: the All-organizations view has no org to
-    // resolve, and a partner-wide row is exactly what it should still see.
+    // authorizeCatalogItemRead narrows org-owned rows to the request's resolved
+    // org (a partner caller acting as org A must not read sibling org B's
+    // package), falling back to canAccessOrg only in the org-less
+    // All-organizations view.
     const [item] = await db.select().from(softwareCatalog)
       .where(eq(softwareCatalog.id, id));
-    if (!item || (item.orgId !== null && !auth.canAccessOrg(item.orgId))) {
-      return c.json({ error: 'Catalog item not found' }, 404);
-    }
+    if (!item) return c.json({ error: 'Catalog item not found' }, 404);
+    const readError = authorizeCatalogItemRead(auth, item.orgId, c.req.query('orgId'));
+    if (readError) return c.json({ error: readError.error }, readError.status);
 
     const [versionCount] = await db.select({ count: sql<number>`count(*)` })
       .from(softwareVersions).where(eq(softwareVersions.catalogId, id));
@@ -865,14 +867,15 @@ softwareRoutes.get(
     // catalog row entirely and the endpoint 404s — which the deploy wizard
     // renders as "No versions" with a grayed-out deploy. Look up by id and
     // authorize in JS, mirroring the /deploy route: RLS binds a visible
-    // NULL-org row to the caller's own partner (system scope sees all). No
-    // resolveScopedOrgId: the All-organizations view has no org to resolve and
-    // partner rows are exactly what it should still see.
+    // NULL-org row to the caller's own partner (system scope sees all).
+    // authorizeCatalogItemRead narrows org-owned rows to the request's
+    // resolved org; only the org-less All-organizations view falls back to
+    // canAccessOrg.
     const [catalogItem] = await db.select().from(softwareCatalog)
       .where(eq(softwareCatalog.id, id));
-    if (!catalogItem || (catalogItem.orgId !== null && !auth.canAccessOrg(catalogItem.orgId))) {
-      return c.json({ error: 'Catalog item not found' }, 404);
-    }
+    if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
+    const readError = authorizeCatalogItemRead(auth, catalogItem.orgId, c.req.query('orgId'));
+    if (readError) return c.json({ error: readError.error }, readError.status);
 
     const versions = await db.select().from(softwareVersions)
       .where(eq(softwareVersions.catalogId, id))
@@ -1291,13 +1294,14 @@ softwareRoutes.get(
     const catalogId = c.req.param('id')!;
     const versionId = c.req.param('versionId')!;
 
-    // Dual-axis read authorization: org rows need access to that org; partner
-    // rows (org_id NULL) are already bound to the caller's partner by RLS.
+    // Dual-axis read authorization: org rows are narrowed to the request's
+    // resolved org (canAccessOrg fallback only in the org-less All-orgs view);
+    // partner rows (org_id NULL) are already bound to the caller's partner by RLS.
     const [catalogItem] = await db.select().from(softwareCatalog)
       .where(eq(softwareCatalog.id, catalogId));
-    if (!catalogItem || (catalogItem.orgId !== null && !auth.canAccessOrg(catalogItem.orgId))) {
-      return c.json({ error: 'Catalog item not found' }, 404);
-    }
+    if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
+    const readError = authorizeCatalogItemRead(auth, catalogItem.orgId, c.req.query('orgId'));
+    if (readError) return c.json({ error: readError.error }, readError.status);
 
     const [versionRecord] = await db.select().from(softwareVersions)
       .where(and(eq(softwareVersions.id, versionId), eq(softwareVersions.catalogId, catalogId)));

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator, optionalJsonValidator } from '../lib/validation';
 import { z } from 'zod';
-import { and, eq, sql, desc, like, or, inArray, isNotNull, type SQL } from 'drizzle-orm';
+import { and, eq, sql, desc, like, or, inArray, isNotNull, isNull, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import {
   softwareCatalog,
@@ -12,7 +12,8 @@ import {
   devices,
   deviceCommands,
 } from '../db/schema';
-import { authMiddleware, requireMfa, requirePermission, requireScope, requireSiteAccess } from '../middleware/auth';
+import { authMiddleware, requireMfa, requirePermission, requireScope, requireSiteAccess, type AuthContext } from '../middleware/auth';
+import { canManagePartnerWidePolicies } from '../services/partnerWideAccess';
 import { writeRouteAudit } from '../services/auditEvents';
 import { resolveDeploymentTargets } from '../services/deploymentTargetResolver';
 import {
@@ -97,6 +98,34 @@ function resolveCatalogListScope(
   }
 
   return scopedOrg;
+}
+
+/**
+ * Authorize a write against a catalog row fetched by id (dual-axis, #2135).
+ * Org-owned rows: any caller with access to that org. Partner-wide rows
+ * (org_id NULL): system scope, or a full-partner admin of the owning partner.
+ * Returns null when allowed, else the error response to send. 404 (not 403)
+ * for foreign rows, matching the read routes' don't-reveal-existence behavior.
+ */
+function authorizeCatalogItemWrite(
+  auth: AuthContext,
+  item: { orgId: string | null; partnerId: string | null },
+): { error: string; status: 403 | 404 } | null {
+  if (item.orgId !== null) {
+    return auth.canAccessOrg(item.orgId)
+      ? null
+      : { error: 'Catalog item not found', status: 404 };
+  }
+  if (auth.scope === 'system') return null;
+  if (auth.scope !== 'partner' || !auth.partnerId || item.partnerId !== auth.partnerId) {
+    return { error: 'Catalog item not found', status: 404 };
+  }
+  return canManagePartnerWidePolicies(auth)
+    ? null
+    : {
+        error: 'Modifying a partner-wide package requires full partner org access (orgAccess must be "all")',
+        status: 403,
+      };
 }
 
 function getPagination(query: { page?: string; limit?: string }) {
@@ -339,7 +368,11 @@ const createCatalogSchema = z.object({
   iconUrl: z.string().url().optional(),
   websiteUrl: z.string().url().optional(),
   isManaged: z.boolean().optional(),
-  orgId: z.string().guid().optional()
+  orgId: z.string().guid().optional(),
+  // Ownership axis (#2135 Partner-Wide First): 'partner' creates a package
+  // shared by every org under the caller's partner (org_id NULL). Create-only —
+  // ownership never changes after creation.
+  ownerScope: z.enum(['organization', 'partner']).optional()
 });
 
 const updateCatalogSchema = z.object({
@@ -512,9 +545,16 @@ softwareRoutes.get(
     const conditions: SQL[] = [];
     // Include partner-scoped built-in (integration) packages alongside the caller's
     // own org packages. RLS scopes built-ins to the caller's partner, so widening
-    // the WHERE here cannot leak another partner's rows.
+    // the WHERE here cannot leak another partner's rows. Partner-scope callers
+    // additionally see their own partner-wide custom packages (#2135) — gated on
+    // scope === 'partner' because org tokens never pass breeze_has_partner_access
+    // and must not get an app-layer condition RLS won't back.
     if (scopeResult.orgCondition) {
-      conditions.push(or(scopeResult.orgCondition, isNotNull(softwareCatalog.integrationProvider))!);
+      const branches: SQL[] = [scopeResult.orgCondition, isNotNull(softwareCatalog.integrationProvider)];
+      if (auth.scope === 'partner' && auth.partnerId) {
+        branches.push(and(isNull(softwareCatalog.orgId), eq(softwareCatalog.partnerId, auth.partnerId))!);
+      }
+      conditions.push(or(...branches)!);
     }
     if (searchTerm) {
       const term = `%${searchTerm}%`;
@@ -572,12 +612,32 @@ softwareRoutes.post(
   async (c) => {
     const auth = c.get('auth');
     const payload = c.req.valid('json');
-    const orgResult = resolveScopedOrgId(auth, payload.orgId ?? c.req.query('orgId'));
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const { orgId } = orgResult;
+
+    // Ownership axis (#2135): partner-wide packages are shared by every org
+    // under the partner, so creation is gated on the partner-wide capability —
+    // same gate as software policies. The partner is ALWAYS the caller's own.
+    let owner: { orgId: string | null; partnerId: string | null };
+    if (payload.ownerScope === 'partner') {
+      if (auth.scope !== 'system' && !auth.partnerId) {
+        return c.json({ error: 'Partner-wide packages require partner scope' }, 403);
+      }
+      if (!canManagePartnerWidePolicies(auth)) {
+        return c.json({ error: 'Partner-wide packages require full partner org access (orgAccess must be "all")' }, 403);
+      }
+      if (!auth.partnerId) {
+        // System scope has no partner of its own to stamp.
+        return c.json({ error: 'Partner-wide packages require partner scope' }, 403);
+      }
+      owner = { orgId: null, partnerId: auth.partnerId };
+    } else {
+      const orgResult = resolveScopedOrgId(auth, payload.orgId ?? c.req.query('orgId'));
+      if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
+      owner = { orgId: orgResult.orgId, partnerId: null };
+    }
 
     const [item] = await db.insert(softwareCatalog).values({
-      orgId,
+      orgId: owner.orgId,
+      partnerId: owner.partnerId,
       name: payload.name,
       vendor: payload.vendor ?? null,
       description: payload.description ?? null,
@@ -588,7 +648,7 @@ softwareRoutes.post(
     }).returning();
 
     writeRouteAudit(c, {
-      orgId,
+      orgId: owner.orgId,
       action: 'software.catalog.create',
       resourceType: 'software_catalog_item',
       resourceId: item!.id,
@@ -639,19 +699,18 @@ softwareRoutes.get(
   zValidator('param', catalogIdParamSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
     // Look up by id alone, then authorize in JS. RLS restricts visibility to the
-    // caller's org rows + their partner's built-ins; the org guard below rejects a
-    // (visible) org-scoped row belonging to a different org. Built-in integration
-    // packages (Huntress/SentinelOne) are partner-scoped with org_id NULL, so an
+    // caller's org rows + their partner's rows (built-ins and partner-wide
+    // packages); the org guard below rejects a (visible) org-scoped row from a
+    // different accessible org context. Partner rows have org_id NULL, so an
     // `eq(orgId)` filter would exclude them — matching the /deploy route (#1957).
+    // No resolveScopedOrgId here: the All-organizations view has no org to
+    // resolve, and a partner-wide row is exactly what it should still see.
     const [item] = await db.select().from(softwareCatalog)
       .where(eq(softwareCatalog.id, id));
-    if (!item || (item.orgId !== null && item.orgId !== orgId)) {
+    if (!item || (item.orgId !== null && !auth.canAccessOrg(item.orgId))) {
       return c.json({ error: 'Catalog item not found' }, 404);
     }
 
@@ -672,16 +731,19 @@ softwareRoutes.patch(
   zValidator('json', updateCatalogSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
     const payload = c.req.valid('json');
 
     const [existing] = await db.select().from(softwareCatalog)
-      .where(and(eq(softwareCatalog.id, id), eq(softwareCatalog.orgId, orgId)));
+      .where(eq(softwareCatalog.id, id));
     if (!existing) return c.json({ error: 'Catalog item not found' }, 404);
+    // Built-ins are provisioned in system context and stay immutable here.
+    if (existing.integrationProvider !== null && auth.scope !== 'system') {
+      return c.json({ error: 'Built-in integration packages cannot be modified' }, 403);
+    }
+    const denied = authorizeCatalogItemWrite(auth, existing);
+    if (denied) return c.json({ error: denied.error }, denied.status);
 
     const [updated] = await db.update(softwareCatalog)
       .set(payload)
@@ -689,7 +751,7 @@ softwareRoutes.patch(
       .returning();
 
     writeRouteAudit(c, {
-      orgId,
+      orgId: existing.orgId,
       action: 'software.catalog.update',
       resourceType: 'software_catalog_item',
       resourceId: id,
@@ -710,14 +772,17 @@ softwareRoutes.delete(
   zValidator('param', catalogIdParamSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
     const [existing] = await db.select().from(softwareCatalog)
-      .where(and(eq(softwareCatalog.id, id), eq(softwareCatalog.orgId, orgId)));
+      .where(eq(softwareCatalog.id, id));
     if (!existing) return c.json({ error: 'Catalog item not found' }, 404);
+    // Built-ins are provisioned in system context and stay immutable here.
+    if (existing.integrationProvider !== null && auth.scope !== 'system') {
+      return c.json({ error: 'Built-in integration packages cannot be deleted' }, 403);
+    }
+    const denied = authorizeCatalogItemWrite(auth, existing);
+    if (denied) return c.json({ error: denied.error }, denied.status);
 
     // A version that is still referenced by a deployment cannot be deleted —
     // software_deployments.software_version_id is an ON DELETE RESTRICT FK, so
@@ -744,7 +809,7 @@ softwareRoutes.delete(
     await db.delete(softwareCatalog).where(eq(softwareCatalog.id, id));
 
     writeRouteAudit(c, {
-      orgId,
+      orgId: existing.orgId,
       action: 'software.catalog.delete',
       resourceType: 'software_catalog_item',
       resourceId: existing.id,
@@ -767,20 +832,19 @@ softwareRoutes.get(
   zValidator('param', versionParamSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
-    // Built-in integration packages (Huntress/SentinelOne) are partner-scoped with
-    // org_id NULL, so an `eq(orgId)` filter excludes the catalog row entirely and
-    // the endpoint 404s — which the deploy wizard renders as "No versions" with a
-    // grayed-out deploy. Look up by id and authorize in JS, mirroring the /deploy
-    // route: for an org/partner-scoped caller RLS binds a visible built-in to their
-    // own partner, so a NULL-org row here is the caller's own (system scope sees all).
+    // Partner-scoped rows (built-in EDR packages and partner-wide custom
+    // packages, #2135) have org_id NULL, so an `eq(orgId)` filter excludes the
+    // catalog row entirely and the endpoint 404s — which the deploy wizard
+    // renders as "No versions" with a grayed-out deploy. Look up by id and
+    // authorize in JS, mirroring the /deploy route: RLS binds a visible
+    // NULL-org row to the caller's own partner (system scope sees all). No
+    // resolveScopedOrgId: the All-organizations view has no org to resolve and
+    // partner rows are exactly what it should still see.
     const [catalogItem] = await db.select().from(softwareCatalog)
       .where(eq(softwareCatalog.id, id));
-    if (!catalogItem || (catalogItem.orgId !== null && catalogItem.orgId !== orgId)) {
+    if (!catalogItem || (catalogItem.orgId !== null && !auth.canAccessOrg(catalogItem.orgId))) {
       return c.json({ error: 'Catalog item not found' }, 404);
     }
 
@@ -802,16 +866,17 @@ softwareRoutes.post(
   zValidator('json', createVersionSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const { orgId } = orgResult;
 
     const { id } = c.req.valid('param');
     const payload = c.req.valid('json');
 
+    // Dual-axis fetch + write authorization (#2135): partner-wide packages have
+    // org_id NULL and take versions from full-partner admins only.
     const [catalogItem] = await db.select().from(softwareCatalog)
-      .where(and(eq(softwareCatalog.id, id), eq(softwareCatalog.orgId, orgId)));
+      .where(eq(softwareCatalog.id, id));
     if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
+    const denied = authorizeCatalogItemWrite(auth, catalogItem);
+    if (denied) return c.json({ error: denied.error }, denied.status);
 
     // A URL-created version never recorded a fileType, so the dispatcher fell
     // back to 'exe' and the agent exec'd the downloaded file directly — which
@@ -860,7 +925,7 @@ softwareRoutes.post(
     }
 
     writeRouteAudit(c, {
-      orgId,
+      orgId: catalogItem.orgId,
       action: 'software.catalog.version.create',
       resourceType: 'software_version',
       resourceId: version.id,
@@ -1084,14 +1149,14 @@ softwareRoutes.post(
   zValidator('param', versionIdParamSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const { orgId } = orgResult;
 
     const { id, versionId } = c.req.valid('param');
+    // Dual-axis fetch + write authorization (#2135) — see version create above.
     const [catalogItem] = await db.select().from(softwareCatalog)
-      .where(and(eq(softwareCatalog.id, id), eq(softwareCatalog.orgId, orgId)));
+      .where(eq(softwareCatalog.id, id));
     if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
+    const denied = authorizeCatalogItemWrite(auth, catalogItem);
+    if (denied) return c.json({ error: denied.error }, denied.status);
 
     const [existingVersion] = await db.select().from(softwareVersions)
       .where(and(
@@ -1109,7 +1174,7 @@ softwareRoutes.post(
     }
 
     writeRouteAudit(c, {
-      orgId,
+      orgId: catalogItem.orgId,
       action: 'software.catalog.version.promote',
       resourceType: 'software_version',
       resourceId: promotedVersion.id,
@@ -1128,17 +1193,17 @@ softwareRoutes.get(
   requireSoftwareRead,
   async (c) => {
     const auth = c.get('auth');
-    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const { orgId } = orgResult;
 
     const catalogId = c.req.param('id')!;
     const versionId = c.req.param('versionId')!;
 
-    // Verify catalog belongs to org
+    // Dual-axis read authorization: org rows need access to that org; partner
+    // rows (org_id NULL) are already bound to the caller's partner by RLS.
     const [catalogItem] = await db.select().from(softwareCatalog)
-      .where(and(eq(softwareCatalog.id, catalogId), eq(softwareCatalog.orgId, orgId)));
-    if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
+      .where(eq(softwareCatalog.id, catalogId));
+    if (!catalogItem || (catalogItem.orgId !== null && !auth.canAccessOrg(catalogItem.orgId))) {
+      return c.json({ error: 'Catalog item not found' }, 404);
+    }
 
     const [versionRecord] = await db.select().from(softwareVersions)
       .where(and(eq(softwareVersions.id, versionId), eq(softwareVersions.catalogId, catalogId)));

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -920,7 +920,10 @@ softwareRoutes.post(
     // scripted clients.
     if (payload.downloadUrl && fileType === null) {
       captureMessage('software version created with undetermined installer type', 'warning', {
-        orgId,
+        // Dual-axis (#2135): a partner-wide package has org_id NULL, so log both
+        // axes — orgId alone would attribute those rows to nothing at all.
+        orgId: catalogItem.orgId,
+        partnerId: catalogItem.partnerId,
         catalogId: id,
         version: payload.version,
         // Host only — a managed-software URL can carry a presigned capability

--- a/apps/api/src/routes/softwareUploads.test.ts
+++ b/apps/api/src/routes/softwareUploads.test.ts
@@ -457,6 +457,35 @@ describe('software upload-session routes', () => {
       expect(res.status).toBe(404);
     });
 
+    // The chunk/status/complete routes resolve the org from the request
+    // context; a session whose org they can't recompute would be created and
+    // then orphaned by a failing first chunk. The create must fail up front
+    // instead — here, a multi-org partner in the All-organizations view (no
+    // ?orgId=) can't resolve a context org at all.
+    it('400s up front when the request context cannot resolve the catalog org (All-orgs view)', async () => {
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          userId: 'user-123',
+          scope: 'partner',
+          orgId: null,
+          partnerId: 'partner-123',
+          accessibleOrgIds: ['org-123', 'org-456'],
+          canAccessOrg: (orgId: string) => ['org-123', 'org-456'].includes(orgId),
+        });
+        return next();
+      });
+      selectQueue([catalogRow]);
+      const res = await app.request(`/software/catalog/${CATALOG_ID}/versions/uploads`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validBody),
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe('orgId is required for this scope');
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
     // software_upload_sessions is org-tenanted (org_id NOT NULL), so a
     // partner-wide package (#2135, org_id NULL) cannot book a session yet —
     // the route must fail up front with an actionable message, not a 500.

--- a/apps/api/src/routes/softwareUploads.test.ts
+++ b/apps/api/src/routes/softwareUploads.test.ts
@@ -59,6 +59,7 @@ vi.mock('../middleware/auth', () => ({
       scope: 'organization',
       orgId: 'org-123',
       partnerId: null,
+      canAccessOrg: (orgId: string) => orgId === 'org-123',
     });
     return next();
   }),
@@ -318,6 +319,7 @@ describe('software upload-session routes', () => {
             scope: 'system',
             orgId: null,
             partnerId: null,
+            canAccessOrg: () => true,
           });
           return next();
         });
@@ -453,6 +455,21 @@ describe('software upload-session routes', () => {
         body: JSON.stringify(validBody),
       });
       expect(res.status).toBe(404);
+    });
+
+    // software_upload_sessions is org-tenanted (org_id NOT NULL), so a
+    // partner-wide package (#2135, org_id NULL) cannot book a session yet —
+    // the route must fail up front with an actionable message, not a 500.
+    it('400s with a URL-only hint for a partner-wide catalog item', async () => {
+      selectQueue([{ id: CATALOG_ID, orgId: null, partnerId: 'partner-123', name: 'Shared Installer' }]);
+      const res = await app.request(`/software/catalog/${CATALOG_ID}/versions/uploads`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validBody),
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/partner-wide packages/);
+      expect(db.insert).not.toHaveBeenCalled();
     });
 
     // GET/DELETE validate `:id` as a UUID (uploadParamSchema); create must too

--- a/apps/api/src/routes/softwareUploads.ts
+++ b/apps/api/src/routes/softwareUploads.ts
@@ -190,9 +190,6 @@ softwareUploadRoutes.post(
   zValidator('json', createUploadSessionSchema),
   async (c) => {
     const auth = c.get('auth');
-    const orgResult = resolveScopedOrgId(auth, c.req.query('orgId'));
-    if ('error' in orgResult) return c.json({ error: orgResult.error }, orgResult.status);
-    const { orgId } = orgResult;
 
     const payload = c.req.valid('json');
 
@@ -210,8 +207,20 @@ softwareUploadRoutes.post(
 
     const { id: catalogId } = c.req.valid('param');
     const [catalogItem] = await db.select().from(softwareCatalog)
-      .where(and(eq(softwareCatalog.id, catalogId), eq(softwareCatalog.orgId, orgId)));
-    if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
+      .where(eq(softwareCatalog.id, catalogId));
+    if (!catalogItem || (catalogItem.orgId !== null && !auth.canAccessOrg(catalogItem.orgId))) {
+      return c.json({ error: 'Catalog item not found' }, 404);
+    }
+    // software_upload_sessions is org-tenanted (org_id NOT NULL), so a
+    // partner-wide package (#2135, org_id NULL) has no org to book the session
+    // under yet. Fail up front with an actionable message instead of a 500.
+    if (catalogItem.orgId === null) {
+      return c.json(
+        { error: 'File upload is not yet available for partner-wide packages — provide a download URL instead.' },
+        400,
+      );
+    }
+    const orgId = catalogItem.orgId;
 
     const {
       fileName, fileSize, chunkSize,

--- a/apps/api/src/routes/softwareUploads.ts
+++ b/apps/api/src/routes/softwareUploads.ts
@@ -60,6 +60,7 @@ import {
 import {
   ALLOWED_EXTENSIONS,
   MAX_UPLOAD_SIZE,
+  authorizeCatalogItemRead,
   getFileExtension,
   insertLatestSoftwareVersion,
   resolveScopedOrgId,
@@ -208,9 +209,13 @@ softwareUploadRoutes.post(
     const { id: catalogId } = c.req.valid('param');
     const [catalogItem] = await db.select().from(softwareCatalog)
       .where(eq(softwareCatalog.id, catalogId));
-    if (!catalogItem || (catalogItem.orgId !== null && !auth.canAccessOrg(catalogItem.orgId))) {
-      return c.json({ error: 'Catalog item not found' }, 404);
-    }
+    if (!catalogItem) return c.json({ error: 'Catalog item not found' }, 404);
+    // Same narrowing rule as the software.ts catalog reads: an org-owned item
+    // must belong to the org this request resolves to. The contextOrg check
+    // further down would catch the mismatch too, but authorize before touching
+    // anything else so the boundary is enforced in one place.
+    const catalogReadError = authorizeCatalogItemRead(auth, catalogItem.orgId, c.req.query('orgId'));
+    if (catalogReadError) return c.json({ error: catalogReadError.error }, catalogReadError.status);
     // software_upload_sessions is org-tenanted (org_id NOT NULL), so a
     // partner-wide package (#2135, org_id NULL) has no org to book the session
     // under yet. Fail up front with an actionable message instead of a 500.

--- a/apps/api/src/routes/softwareUploads.ts
+++ b/apps/api/src/routes/softwareUploads.ts
@@ -221,6 +221,18 @@ softwareUploadRoutes.post(
       );
     }
     const orgId = catalogItem.orgId;
+    // The chunk/status/complete/delete routes all resolve the org from the
+    // REQUEST context (resolveScopedOrgId on ?orgId=) and filter the session
+    // by it. If that resolution won't land on this catalog's org — e.g. the
+    // All-organizations view injects no orgId, or a different org is selected
+    // — the session would be created successfully and then every chunk would
+    // fail with a misleading "not found", leaving an orphaned session counting
+    // against the org's quota. Fail the create up front instead.
+    const contextOrg = resolveScopedOrgId(auth, c.req.query('orgId'));
+    if ('error' in contextOrg) return c.json({ error: contextOrg.error }, contextOrg.status);
+    if (contextOrg.orgId !== orgId) {
+      return c.json({ error: 'Catalog item not found' }, 404);
+    }
 
     const {
       fileName, fileSize, chunkSize,

--- a/apps/api/src/services/softwareDeployment.test.ts
+++ b/apps/api/src/services/softwareDeployment.test.ts
@@ -101,6 +101,7 @@ import {
   buildAndDispatchSoftwareInstalls,
   createSoftwareDeployment,
   dispatchSoftwareInstallToDevice,
+  inferFileTypeFromUrl,
 } from './softwareDeployment';
 import { resolveEdrInstaller } from './edrInstallerResolver';
 import { inArray } from 'drizzle-orm';
@@ -1508,5 +1509,20 @@ describe('dispatchSoftwareInstallToDevice', () => {
 
     expect(outcome).toEqual({ transport: 'queued', deviceCommandId: null });
     expect(updateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('inferFileTypeFromUrl', () => {
+  it('derives the installer type from the URL extension', () => {
+    expect(inferFileTypeFromUrl('https://dl.example.com/app-1.2.3.msi')).toBe('msi');
+    expect(inferFileTypeFromUrl('https://dl.example.com/app.MSI?sig=abc#f')).toBe('msi');
+    expect(inferFileTypeFromUrl('https://dl.example.com/pkg.deb')).toBe('deb');
+  });
+
+  it('returns null for unknown or missing extensions and empty input', () => {
+    expect(inferFileTypeFromUrl('https://dl.example.com/download')).toBeNull();
+    expect(inferFileTypeFromUrl('https://dl.example.com/archive.zip')).toBeNull();
+    expect(inferFileTypeFromUrl(null)).toBeNull();
+    expect(inferFileTypeFromUrl('')).toBeNull();
   });
 });

--- a/apps/api/src/services/softwareDeployment.test.ts
+++ b/apps/api/src/services/softwareDeployment.test.ts
@@ -101,7 +101,6 @@ import {
   buildAndDispatchSoftwareInstalls,
   createSoftwareDeployment,
   dispatchSoftwareInstallToDevice,
-  inferFileTypeFromUrl,
 } from './softwareDeployment';
 import { resolveEdrInstaller } from './edrInstallerResolver';
 import { inArray } from 'drizzle-orm';
@@ -1512,17 +1511,3 @@ describe('dispatchSoftwareInstallToDevice', () => {
   });
 });
 
-describe('inferFileTypeFromUrl', () => {
-  it('derives the installer type from the URL extension', () => {
-    expect(inferFileTypeFromUrl('https://dl.example.com/app-1.2.3.msi')).toBe('msi');
-    expect(inferFileTypeFromUrl('https://dl.example.com/app.MSI?sig=abc#f')).toBe('msi');
-    expect(inferFileTypeFromUrl('https://dl.example.com/pkg.deb')).toBe('deb');
-  });
-
-  it('returns null for unknown or missing extensions and empty input', () => {
-    expect(inferFileTypeFromUrl('https://dl.example.com/download')).toBeNull();
-    expect(inferFileTypeFromUrl('https://dl.example.com/archive.zip')).toBeNull();
-    expect(inferFileTypeFromUrl(null)).toBeNull();
-    expect(inferFileTypeFromUrl('')).toBeNull();
-  });
-});

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -130,6 +130,20 @@ export async function dispatchSoftwareInstallToDevice(
   return { transport: 'queued', deviceCommandId };
 }
 
+/**
+ * Infer the installer type from a download URL's extension. URL-only versions
+ * never get a `file_type` stamped (that happens on file upload), and the old
+ * blanket `?? 'exe'` fallback made the agent execute a downloaded .msi as a
+ * program instead of routing it through msiexec (and mis-dispatched
+ * .deb/.pkg/.dmg the same way). Query strings and fragments are ignored.
+ */
+export function inferFileTypeFromUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const path = url.split(/[?#]/, 1)[0] ?? '';
+  const ext = path.slice(path.lastIndexOf('.') + 1).toLowerCase();
+  return ['msi', 'exe', 'dmg', 'deb', 'pkg'].includes(ext) ? ext : null;
+}
+
 /** Structural subset of a software_versions row the install fan-out needs. */
 export interface SoftwareInstallFanoutVersionRecord {
   downloadUrl: string | null;
@@ -467,14 +481,23 @@ export async function buildAndDispatchSoftwareInstalls(
     // reconciliation keys on it) and the WS command id.
     const retryCount = deviceRetryCounts?.[device.id] ?? 0;
 
-    const resolvedFileType = isSoftwareFileType(versionRecord.fileType)
-      ? versionRecord.fileType
-      : 'exe';
 
     // deploymentId MUST be in the payload: the WS transport tracks it via
     // the sw-install-<deployment>-<device>-<attempt> command id, but the
     // queued fallback's device_commands row only has the payload to key
     // result reconciliation on (deploymentId AND retryCount).
+    // Prefer the stamped file_type (uploaded binaries), fall back to the
+    // resolved per-device URL's extension for URL-only versions, and only then
+    // to 'exe' — see inferFileTypeFromUrl.
+    //
+    // The stamped value is NARROWED, not trusted: file_type is a plain nullable
+    // varchar with no CHECK constraint, so the column can hold anything a
+    // future route, import or manual UPDATE puts there. An unrecognized value
+    // would otherwise be dispatched verbatim and only rejected by the agent
+    // AFTER the download, as `unsupported fileType`.
+    const effectiveFileType = isSoftwareFileType(versionRecord.fileType)
+      ? versionRecord.fileType
+      : (inferFileTypeFromUrl(deviceDownloadUrl) ?? 'exe');
     const payload: AgentCommand['payload'] = {
       deploymentId,
       retryCount,
@@ -484,19 +507,13 @@ export async function buildAndDispatchSoftwareInstalls(
         approvedPrivateOrigins,
       },
       checksum: versionRecord.checksum,
-      // file_type is a plain nullable varchar with no CHECK constraint, so the
-      // column can hold anything a future route, import or manual UPDATE puts
-      // there. Narrow on read: an unrecognized value would otherwise be
-      // dispatched verbatim and only rejected by the agent AFTER the download,
-      // as `unsupported fileType`. 'exe' remains the historical fallback for a
-      // NULL — see deriveSoftwareFileTypeFromUrl on why we never guess better.
-      //
       // fileName and fileType are a COUPLED pair, not two independent fields:
       // the agent's validateInstallFileName rejects the command outright when
       // the filename's extension doesn't equal '.' + fileType. Building the
       // fallback name from the same resolved type is what keeps them in step.
-      fileName: versionRecord.originalFileName ?? `package.${resolvedFileType}`,
-      fileType: resolvedFileType,
+      fileName:
+        versionRecord.originalFileName ?? `package.${effectiveFileType}`,
+      fileType: effectiveFileType,
       silentInstallArgs: deviceSilentInstallArgs,
       softwareName: catalogItem.name,
       version: versionRecord.version,

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -130,20 +130,6 @@ export async function dispatchSoftwareInstallToDevice(
   return { transport: 'queued', deviceCommandId };
 }
 
-/**
- * Infer the installer type from a download URL's extension. URL-only versions
- * never get a `file_type` stamped (that happens on file upload), and the old
- * blanket `?? 'exe'` fallback made the agent execute a downloaded .msi as a
- * program instead of routing it through msiexec (and mis-dispatched
- * .deb/.pkg/.dmg the same way). Query strings and fragments are ignored.
- */
-export function inferFileTypeFromUrl(url: string | null | undefined): string | null {
-  if (!url) return null;
-  const path = url.split(/[?#]/, 1)[0] ?? '';
-  const ext = path.slice(path.lastIndexOf('.') + 1).toLowerCase();
-  return ['msi', 'exe', 'dmg', 'deb', 'pkg'].includes(ext) ? ext : null;
-}
-
 /** Structural subset of a software_versions row the install fan-out needs. */
 export interface SoftwareInstallFanoutVersionRecord {
   downloadUrl: string | null;
@@ -486,18 +472,20 @@ export async function buildAndDispatchSoftwareInstalls(
     // the sw-install-<deployment>-<device>-<attempt> command id, but the
     // queued fallback's device_commands row only has the payload to key
     // result reconciliation on (deploymentId AND retryCount).
-    // Prefer the stamped file_type (uploaded binaries), fall back to the
-    // resolved per-device URL's extension for URL-only versions, and only then
-    // to 'exe' — see inferFileTypeFromUrl.
+    // file_type is a plain nullable varchar with no CHECK constraint, so the
+    // column can hold anything a future route, import or manual UPDATE puts
+    // there. Narrow on read: an unrecognized value would otherwise be
+    // dispatched verbatim and only rejected by the agent AFTER the download,
+    // as `unsupported fileType`. 'exe' remains the historical fallback for a
+    // NULL — see deriveSoftwareFileTypeFromUrl on why we never guess better.
     //
-    // The stamped value is NARROWED, not trusted: file_type is a plain nullable
-    // varchar with no CHECK constraint, so the column can hold anything a
-    // future route, import or manual UPDATE puts there. An unrecognized value
-    // would otherwise be dispatched verbatim and only rejected by the agent
-    // AFTER the download, as `unsupported fileType`.
+    // Deliberately NOT inferred from deviceDownloadUrl here. Doing so would fix
+    // dispatch for legacy URL-only rows created before #3571 stamped file_type,
+    // but it reverses an explicit decision in that PR, so it is left as a
+    // separate call rather than smuggled in by a rebase.
     const effectiveFileType = isSoftwareFileType(versionRecord.fileType)
       ? versionRecord.fileType
-      : (inferFileTypeFromUrl(deviceDownloadUrl) ?? 'exe');
+      : 'exe';
     const payload: AgentCommand['payload'] = {
       deploymentId,
       retryCount,

--- a/apps/api/src/services/softwareVersionShared.test.ts
+++ b/apps/api/src/services/softwareVersionShared.test.ts
@@ -8,6 +8,7 @@ import {
   ALLOWED_EXTENSIONS,
   MAX_UPLOAD_SIZE,
   getFileExtension,
+  authorizeCatalogItemRead,
   resolveScopedOrgId,
 } from './softwareVersionShared';
 
@@ -48,5 +49,57 @@ describe('softwareVersionShared', () => {
 
   it('resolveScopedOrgId: system scope passes any requested org through', () => {
     expect(resolveScopedOrgId({ scope: 'system', orgId: null }, 'org-x')).toEqual({ orgId: 'org-x' });
+  });
+
+  describe('authorizeCatalogItemRead', () => {
+    const notFound = { error: 'Catalog item not found', status: 404 };
+    // Multi-org partner admin: canAccessOrg true for both orgs — the exact
+    // shape where canAccessOrg alone is too weak.
+    const partnerAuth = {
+      scope: 'partner' as const,
+      orgId: null,
+      accessibleOrgIds: ['org-a', 'org-b'],
+      canAccessOrg: (orgId: string) => ['org-a', 'org-b'].includes(orgId),
+    };
+
+    it('narrows an org-owned row to the requested org even when canAccessOrg is true', () => {
+      // The #3575 regression: acting as org A must not read org B's package.
+      expect(authorizeCatalogItemRead(partnerAuth, 'org-b', 'org-a')).toEqual(notFound);
+      expect(authorizeCatalogItemRead(partnerAuth, 'org-a', 'org-a')).toBeNull();
+    });
+
+    it('passes partner-wide rows (org_id NULL) with or without an org context', () => {
+      expect(authorizeCatalogItemRead(partnerAuth, null, 'org-a')).toBeNull();
+      expect(authorizeCatalogItemRead(partnerAuth, null, undefined)).toBeNull();
+    });
+
+    it('rejects an explicitly requested inaccessible org with 403 regardless of row', () => {
+      expect(authorizeCatalogItemRead(partnerAuth, null, 'org-z')).toEqual({
+        error: 'Access to this organization denied',
+        status: 403,
+      });
+      expect(authorizeCatalogItemRead(partnerAuth, 'org-a', 'org-z')).toEqual({
+        error: 'Access to this organization denied',
+        status: 403,
+      });
+    });
+
+    it('fleet view (no org resolves) falls back to canAccessOrg for org-owned rows', () => {
+      expect(authorizeCatalogItemRead(partnerAuth, 'org-b', undefined)).toBeNull();
+      expect(authorizeCatalogItemRead(partnerAuth, 'foreign-org', undefined)).toEqual(notFound);
+    });
+
+    it('org scope stays pinned to its own org', () => {
+      const orgAuth = {
+        scope: 'organization' as const,
+        orgId: 'org-a',
+        accessibleOrgIds: ['org-a'],
+        canAccessOrg: (orgId: string) => orgId === 'org-a',
+      };
+      // No requestedOrgId: auth.orgId resolves, so narrowing still applies.
+      expect(authorizeCatalogItemRead(orgAuth, 'org-b', undefined)).toEqual(notFound);
+      expect(authorizeCatalogItemRead(orgAuth, 'org-a', undefined)).toBeNull();
+      expect(authorizeCatalogItemRead(orgAuth, null, undefined)).toBeNull();
+    });
   });
 });

--- a/apps/api/src/services/softwareVersionShared.ts
+++ b/apps/api/src/services/softwareVersionShared.ts
@@ -64,6 +64,45 @@ export function resolveScopedOrgId(
   return { error: 'orgId is required for this scope', status: 400 };
 }
 
+/**
+ * Read authorization for a catalog row fetched by id (dual-axis, #2135).
+ *
+ * Restores main's narrowing rule whenever the request resolves to an org:
+ * an org-owned row must belong to THAT org, even though partner-scope RLS
+ * makes every sibling org's rows visible — a partner caller acting as org A
+ * must not read org B's package by id. An explicitly requested org the caller
+ * can't access is rejected outright (403), before looking at the row.
+ *
+ * The only divergence from main is when NO org resolves (partner scope, no
+ * ?orgId, multiple accessible orgs) — the All-organizations fleet view, which
+ * main answered with a 400. Partner-wide rows (org_id NULL) pass — RLS already
+ * binds a visible NULL-org row to the caller's own partner — and org-owned
+ * rows fall back to canAccessOrg, the set that view legitimately spans. The
+ * fallback never fires when an org resolves, so this is never weaker than the
+ * resolved-org rule.
+ *
+ * Returns null when allowed, else the error response to send. 404 (not 403)
+ * for foreign rows, matching the don't-reveal-existence behavior of these
+ * routes.
+ */
+export function authorizeCatalogItemRead(
+  auth: AuthScopeContext & { canAccessOrg: (orgId: string) => boolean },
+  itemOrgId: string | null,
+  requestedOrgId: string | undefined,
+): { error: string; status: 403 | 404 } | null {
+  const scoped = resolveScopedOrgId(auth, requestedOrgId);
+  if ('error' in scoped) {
+    // 403 only happens for an explicitly requested org — reject regardless of
+    // the row, exactly as main did.
+    if (scoped.status === 403) return { error: scoped.error, status: 403 };
+    // 400: nothing to resolve — the fleet-view case described above.
+    if (itemOrgId === null || auth.canAccessOrg(itemOrgId)) return null;
+    return { error: 'Catalog item not found', status: 404 };
+  }
+  if (itemOrgId === null || itemOrgId === scoped.orgId) return null;
+  return { error: 'Catalog item not found', status: 404 };
+}
+
 export async function setLatestSoftwareVersion(
   tx: DbTransaction,
   catalogId: string,

--- a/apps/web/src/components/software/AddPackageModal.ownerScope.test.tsx
+++ b/apps/web/src/components/software/AddPackageModal.ownerScope.test.tsx
@@ -76,4 +76,20 @@ describe('AddPackageModal owner scope (#2135)', () => {
     fireEvent.click(screen.getByTestId('software-package-owner-org'));
     expect(screen.getByRole('tab', { name: /upload file/i })).toBeEnabled();
   });
+
+  it('tells the user when switching to partner-wide drops a picked file', () => {
+    render(<AddPackageModal open onClose={() => {}} onCreated={() => {}} />);
+
+    // Org-owned first, pick a file…
+    fireEvent.click(screen.getByTestId('software-package-owner-org'));
+    fireEvent.click(screen.getByRole('tab', { name: /upload file/i }));
+    const file = new File([new Uint8Array(8)], 'bigapp.msi');
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    // …then flip to partner-wide: the file is dropped, and the UI says so.
+    fireEvent.click(screen.getByTestId('software-package-owner-partner'));
+    const notice = screen.getByTestId('pkg-file-dropped-notice');
+    expect(notice.textContent).toContain('bigapp.msi');
+  });
 });

--- a/apps/web/src/components/software/AddPackageModal.ownerScope.test.tsx
+++ b/apps/web/src/components/software/AddPackageModal.ownerScope.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AddPackageModal from './AddPackageModal';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+  useAuthStore: { getState: () => ({ tokens: null }) },
+}));
+vi.mock('../../lib/softwarePackageUpload', () => ({ uploadPackageVersion: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('./DetectionRulesEditor', () => ({ default: () => null }));
+
+// Partner-scope All-orgs context (#2135): the selector shows and defaults to
+// partner-wide. The hook itself is covered by useDefaultOwnerScope's contract.
+vi.mock('../../hooks/useDefaultOwnerScope', () => ({
+  useDefaultOwnerScope: () => ({
+    isPartnerScope: true,
+    defaultOwnerScope: 'partner' as const,
+  }),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown): Response =>
+  ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+describe('AddPackageModal owner scope (#2135)', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementation((url: string) =>
+      Promise.resolve(
+        url === '/software/catalog'
+          ? jsonResponse({ data: { id: 'cat-1' } })
+          : jsonResponse({ data: [] }),
+      ),
+    );
+  });
+
+  it('shows the selector defaulted to All organizations and sends ownerScope', async () => {
+    render(<AddPackageModal open onClose={() => {}} onCreated={() => {}} />);
+
+    const partnerRadio = screen.getByTestId('software-package-owner-partner') as HTMLInputElement;
+    expect(partnerRadio.checked).toBe(true);
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Chrome' } });
+    fireEvent.change(screen.getByLabelText('Version'), { target: { value: '1.0.0' } });
+    fireEvent.change(
+      screen.getByPlaceholderText('https://example.com/package-v1.0.0.msi'),
+      { target: { value: 'https://dl.example.com/chrome.msi' } },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Create package' }));
+
+    await waitFor(() => {
+      const createCall = fetchMock.mock.calls.find(
+        ([url, opts]) => url === '/software/catalog' && opts?.method === 'POST',
+      );
+      expect(createCall).toBeTruthy();
+      expect(JSON.parse(String(createCall![1]!.body)).ownerScope).toBe('partner');
+    });
+  });
+
+  it('disables the file source for partner-wide packages (URL-only)', () => {
+    render(<AddPackageModal open onClose={() => {}} onCreated={() => {}} />);
+
+    expect(screen.getByRole('tab', { name: /upload file/i })).toBeDisabled();
+
+    // Switching to org-owned re-enables the file source.
+    fireEvent.click(screen.getByTestId('software-package-owner-org'));
+    expect(screen.getByRole('tab', { name: /upload file/i })).toBeEnabled();
+  });
+});

--- a/apps/web/src/components/software/AddPackageModal.test.tsx
+++ b/apps/web/src/components/software/AddPackageModal.test.tsx
@@ -5,7 +5,7 @@ import AddPackageModal from './AddPackageModal';
 import { fetchWithAuth } from '../../stores/auth';
 import { uploadPackageVersion } from '../../lib/softwarePackageUpload';
 
-vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn(), registerOrgIdProvider: vi.fn(), useAuthStore: { getState: () => ({ tokens: null }) } }));
 vi.mock('../../lib/softwarePackageUpload', () => ({ uploadPackageVersion: vi.fn() }));
 
 const showToast = vi.fn();

--- a/apps/web/src/components/software/AddPackageModal.tsx
+++ b/apps/web/src/components/software/AddPackageModal.tsx
@@ -18,7 +18,13 @@ import { cn } from "@/lib/utils";
 import { Dialog } from "../shared/Dialog";
 import { showToast } from "../shared/Toast";
 import { fetchWithAuth } from "../../stores/auth";
+import { usePackageUploadsGate } from "../../stores/featuresStore";
+import {
+  useDefaultOwnerScope,
+  type OwnerScope,
+} from "../../hooks/useDefaultOwnerScope";
 import { runAction, ActionError } from "../../lib/runAction";
+import { applyOsHint } from "@/lib/installerPackageHints";
 import { findUnknownTokens } from "@/lib/installerVariables";
 import { uploadPackageVersion } from "../../lib/softwarePackageUpload";
 import DetectionRulesEditor from "./DetectionRulesEditor";
@@ -102,6 +108,33 @@ export default function AddPackageModal({
   const [customFields, setCustomFields] = useState<DeviceCustomField[]>([]);
   // Tenant variables (#3409) — offered as `{{var.<key>}}` in the same picker.
   const tenantVariables = useTenantVariables(open);
+  // File uploads need S3 storage on the server; without it the upload routes
+  // 503, so gray the "Upload file" source out entirely instead (#config gate).
+  const { enabled: s3UploadsEnabled } = usePackageUploadsGate(open);
+  // Ownership axis (#2135): partner admins can create the package once for all
+  // their orgs. Chunked upload sessions are org-tenanted, so partner-wide
+  // packages are URL-only for now — the file source is disabled in that mode.
+  const { isPartnerScope, defaultOwnerScope } = useDefaultOwnerScope();
+  const [ownerScope, setOwnerScopeState] = useState<OwnerScope>("organization");
+  const uploadsEnabled = s3UploadsEnabled && ownerScope !== "partner";
+  const uploadDisabledReason = !s3UploadsEnabled
+    ? i18n.t("policies:software.addPackageModal.uploadsRequireS3Storage")
+    : ownerScope === "partner"
+      ? i18n.t("policies:software.addPackageModal.partnerWideUrlOnly")
+      : null;
+  const setOwnerScope = (next: OwnerScope) => {
+    setOwnerScopeState(next);
+    // Partner-wide packages are URL-only (see above): drop a picked file and
+    // fall back to the URL source rather than submitting a doomed upload.
+    if (next === "partner") {
+      setForm((prev) =>
+        prev.source === "file" || prev.file
+          ? { ...prev, source: "url", file: null, fileName: "" }
+          : prev,
+      );
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
   const fileInputRef = useRef<HTMLInputElement>(null);
   // If the catalog item was created but the version write failed, keep its id so
   // a retry continues from the version step instead of creating a duplicate.
@@ -128,6 +161,7 @@ export default function AddPackageModal({
   useEffect(() => {
     if (!open) return;
     setForm(blankForm);
+    setOwnerScopeState(defaultOwnerScope);
     setAdvancedOpen(false);
     createdCatalogId.current = null;
     if (fileInputRef.current) fileInputRef.current.value = "";
@@ -159,6 +193,9 @@ export default function AddPackageModal({
     return () => {
       cancelled = true;
     };
+    // Intentionally keyed on `open` alone: defaultOwnerScope is read once per
+    // open as the initial value — a mid-edit store hydration must not wipe the
+    // user's in-progress form.
   }, [open]);
   const update = <K extends keyof typeof blankForm>(
     key: K,
@@ -174,6 +211,7 @@ export default function AddPackageModal({
       file,
       fileName: file.name,
       ...applySilentArgsPrefill(prev, derived),
+      ...applyOsHint(prev, file.name),
     }));
   };
   /** URL-source counterpart to handleFile: the extension in the URL is the only
@@ -189,6 +227,7 @@ export default function AddPackageModal({
         // An explicit selector choice outranks the URL for prefill purposes too.
         prev.fileType || deriveSoftwareFileTypeFromUrl(value),
       ),
+      ...applyOsHint(prev, value),
     }));
   };
   /** Selector changes retract or install the prefill the same way a URL edit does. */
@@ -325,6 +364,9 @@ export default function AddPackageModal({
                 vendor: form.vendor.trim() || undefined,
                 category: form.category,
                 description: form.description.trim() || undefined,
+                // Only partner-scope users ever see the selector; org tokens
+                // always create org-owned (the server default).
+                ownerScope: isPartnerScope ? ownerScope : undefined,
               }),
             }),
           parseSuccess: (d) => {
@@ -487,6 +529,47 @@ export default function AddPackageModal({
             <h3 className="text-sm font-semibold text-foreground">
               {i18n.t("policies:software.addPackageModal.package")}
             </h3>
+            {/* Ownership scope — partner-scope creators only (#2135, same
+                pattern as PolicyForm). */}
+            {isPartnerScope && (
+              <fieldset
+                className="space-y-2 rounded-md border p-4"
+                data-testid="software-package-owner"
+              >
+                <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+                  {i18n.t("policies:software.addPackageModal.scope")}
+                </legend>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    name="pkg-owner-scope"
+                    value="partner"
+                    checked={ownerScope === "partner"}
+                    onChange={() => setOwnerScope("partner")}
+                    data-testid="software-package-owner-partner"
+                  />
+                  {i18n.t("policies:software.addPackageModal.allOrganizations")}
+                  <span className="text-muted-foreground">
+                    {i18n.t(
+                      "policies:software.addPackageModal.sharedAcrossAllYourOrganizations",
+                    )}
+                  </span>
+                </label>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    name="pkg-owner-scope"
+                    value="organization"
+                    checked={ownerScope === "organization"}
+                    onChange={() => setOwnerScope("organization")}
+                    data-testid="software-package-owner-org"
+                  />
+                  {i18n.t(
+                    "policies:software.addPackageModal.thisOrganizationOnly",
+                  )}
+                </label>
+              </fieldset>
+            )}
             <div className="grid gap-4 sm:grid-cols-2">
               <div>
                 <label className={labelCls} htmlFor="pkg-name">
@@ -616,9 +699,15 @@ export default function AddPackageModal({
                     type="button"
                     role="tab"
                     aria-selected={form.source === val}
+                    disabled={val === "file" && !uploadsEnabled}
+                    title={
+                      val === "file" && uploadDisabledReason
+                        ? uploadDisabledReason
+                        : undefined
+                    }
                     onClick={() => update("source", val)}
                     className={cn(
-                      "inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-sm font-medium transition-colors",
+                      "inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
                       form.source === val
                         ? "bg-background text-foreground shadow-xs"
                         : "text-muted-foreground hover:text-foreground",
@@ -629,6 +718,11 @@ export default function AddPackageModal({
                   </button>
                 ))}
               </div>
+              {uploadDisabledReason && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {uploadDisabledReason}
+                </p>
+              )}
 
               {form.source === "url" ? (
                 <div className="mt-3">

--- a/apps/web/src/components/software/AddPackageModal.tsx
+++ b/apps/web/src/components/software/AddPackageModal.tsx
@@ -109,13 +109,22 @@ export default function AddPackageModal({
   // Tenant variables (#3409) — offered as `{{var.<key>}}` in the same picker.
   const tenantVariables = useTenantVariables(open);
   // File uploads need S3 storage on the server; without it the upload routes
-  // 503, so gray the "Upload file" source out entirely instead (#config gate).
+  // 503, so gray the "Upload file" source out entirely instead (gated on
+  // /config → softwarePackages.uploadsEnabled).
   const { enabled: s3UploadsEnabled } = usePackageUploadsGate(open);
   // Ownership axis (#2135): partner admins can create the package once for all
   // their orgs. Chunked upload sessions are org-tenanted, so partner-wide
   // packages are URL-only for now — the file source is disabled in that mode.
   const { isPartnerScope, defaultOwnerScope } = useDefaultOwnerScope();
   const [ownerScope, setOwnerScopeState] = useState<OwnerScope>("organization");
+  // Ownership is create-only server-side. Once step 1 created the catalog row
+  // (retry-after-partial-failure keeps it via createdCatalogId), changing the
+  // selector could no longer change anything — lock it so the UI never claims
+  // a scope the package doesn't have.
+  const [scopeLocked, setScopeLocked] = useState(false);
+  // Set when switching to partner-wide discarded an already-picked file, so
+  // the user is told rather than left wondering where their file went.
+  const [droppedFileName, setDroppedFileName] = useState("");
   const uploadsEnabled = s3UploadsEnabled && ownerScope !== "partner";
   const uploadDisabledReason = !s3UploadsEnabled
     ? i18n.t("policies:software.addPackageModal.uploadsRequireS3Storage")
@@ -123,16 +132,20 @@ export default function AddPackageModal({
       ? i18n.t("policies:software.addPackageModal.partnerWideUrlOnly")
       : null;
   const setOwnerScope = (next: OwnerScope) => {
+    if (scopeLocked) return;
     setOwnerScopeState(next);
     // Partner-wide packages are URL-only (see above): drop a picked file and
-    // fall back to the URL source rather than submitting a doomed upload.
+    // fall back to the URL source rather than submitting a doomed upload —
+    // and say so, via droppedFileName, rather than doing it silently.
     if (next === "partner") {
-      setForm((prev) =>
-        prev.source === "file" || prev.file
-          ? { ...prev, source: "url", file: null, fileName: "" }
-          : prev,
-      );
+      setForm((prev) => {
+        if (prev.source !== "file" && !prev.file) return prev;
+        if (prev.fileName) setDroppedFileName(prev.fileName);
+        return { ...prev, source: "url", file: null, fileName: "" };
+      });
       if (fileInputRef.current) fileInputRef.current.value = "";
+    } else {
+      setDroppedFileName("");
     }
   };
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -162,6 +175,8 @@ export default function AddPackageModal({
     if (!open) return;
     setForm(blankForm);
     setOwnerScopeState(defaultOwnerScope);
+    setScopeLocked(false);
+    setDroppedFileName("");
     setAdvancedOpen(false);
     createdCatalogId.current = null;
     if (fileInputRef.current) fileInputRef.current.value = "";
@@ -396,6 +411,9 @@ export default function AddPackageModal({
           ),
         });
         createdCatalogId.current = item.id;
+        // The row now exists with this ownership — a retry must not let the
+        // selector drift away from what was actually created.
+        setScopeLocked(true);
         // The cancel affordance opens BEFORE the transfer it cancels: a Cancel
         // during step 1 ran handleClose while this id was still null, so that
         // branch could not surface the package and the catalog row would be
@@ -545,6 +563,7 @@ export default function AddPackageModal({
                     name="pkg-owner-scope"
                     value="partner"
                     checked={ownerScope === "partner"}
+                    disabled={scopeLocked}
                     onChange={() => setOwnerScope("partner")}
                     data-testid="software-package-owner-partner"
                   />
@@ -561,6 +580,7 @@ export default function AddPackageModal({
                     name="pkg-owner-scope"
                     value="organization"
                     checked={ownerScope === "organization"}
+                    disabled={scopeLocked}
                     onChange={() => setOwnerScope("organization")}
                     data-testid="software-package-owner-org"
                   />
@@ -568,6 +588,13 @@ export default function AddPackageModal({
                     "policies:software.addPackageModal.thisOrganizationOnly",
                   )}
                 </label>
+                {scopeLocked && (
+                  <p className="text-xs text-muted-foreground">
+                    {i18n.t(
+                      "policies:software.addPackageModal.scopeLockedAfterCreate",
+                    )}
+                  </p>
+                )}
               </fieldset>
             )}
             <div className="grid gap-4 sm:grid-cols-2">
@@ -721,6 +748,17 @@ export default function AddPackageModal({
               {uploadDisabledReason && (
                 <p className="mt-1 text-xs text-muted-foreground">
                   {uploadDisabledReason}
+                </p>
+              )}
+              {droppedFileName && ownerScope === "partner" && (
+                <p
+                  className="mt-1 text-xs text-amber-600 dark:text-amber-500"
+                  data-testid="pkg-file-dropped-notice"
+                >
+                  {i18n.t(
+                    "policies:software.addPackageModal.selectedFileRemoved",
+                  )}{" "}
+                  ({droppedFileName})
                 </p>
               )}
 

--- a/apps/web/src/components/software/DeploymentWizard.preselect.test.tsx
+++ b/apps/web/src/components/software/DeploymentWizard.preselect.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import DeploymentWizard from './DeploymentWizard';
 import { fetchWithAuth } from '../../stores/auth';
 
-vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn(), registerOrgIdProvider: vi.fn(), useAuthStore: { getState: () => ({ tokens: null }) } }));
 vi.mock('../filters/DeviceTargetSelector', () => ({ DeviceTargetSelector: () => null }));
 vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
 const fetchMock = vi.mocked(fetchWithAuth);

--- a/apps/web/src/components/software/DeploymentWizard.tsx
+++ b/apps/web/src/components/software/DeploymentWizard.tsx
@@ -16,6 +16,8 @@ import { showToast } from "../shared/Toast";
 import ProgressBar from "../shared/ProgressBar";
 import type { DeploymentTargetConfig } from "@breeze/shared";
 import { DeviceTargetSelector } from "../filters/DeviceTargetSelector";
+import { ScopeBadge } from "../shared/ScopeBadge";
+import { useOrgScope } from "../../hooks/useOrgScope";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
 type WizardStep = "software" | "targets" | "configure" | "review";
@@ -216,6 +218,10 @@ export default function DeploymentWizard({
   const steps = createSteps();
   const scheduleOptions = createScheduleOptions();
   const [activeStepIndex, setActiveStepIndex] = useState(0);
+  // The deployment silently inherits the header's customer context (fetchWithAuth
+  // injects ?orgId= and the API stamps the deployment's org from it), so state
+  // that context explicitly instead of leaving the user to infer it.
+  const orgScope = useOrgScope();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [deploying, setDeploying] = useState(false);
@@ -1083,6 +1089,24 @@ export default function DeploymentWizard({
             </h3>
           </div>
           <div className="mt-4 grid gap-4 sm:grid-cols-2">
+            {orgScope.scope === "org" && (
+              <div
+                className="rounded-md border bg-muted/30 p-4"
+                data-testid="deployment-review-customer"
+              >
+                <p className="text-xs uppercase text-muted-foreground">
+                  {i18n.t("policies:software.deploymentWizard.customer")}
+                </p>
+                <p className="mt-2 text-sm font-semibold">
+                  {orgScope.org?.name ?? "—"}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {i18n.t(
+                    "policies:software.deploymentWizard.allTargetsBelongToThisCustomer",
+                  )}
+                </p>
+              </div>
+            )}
             <div className="rounded-md border bg-muted/30 p-4">
               <p className="text-xs uppercase text-muted-foreground">
                 {i18n.t("policies:software.deploymentWizard.software")}
@@ -1191,15 +1215,40 @@ export default function DeploymentWizard({
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-xl font-semibold tracking-tight">
-          {i18n.t("policies:software.deploymentWizard.deploymentWizard")}
-        </h1>
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="text-xl font-semibold tracking-tight">
+            {i18n.t("policies:software.deploymentWizard.deploymentWizard")}
+          </h1>
+          {orgScope.scope === "org" && (
+            <span
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground"
+              data-testid="deployment-org-context"
+            >
+              {i18n.t("policies:software.deploymentWizard.deployingTo")}
+              <ScopeBadge
+                orgId={orgScope.orgId}
+                partnerId={null}
+                isSystem={false}
+                orgName={orgScope.org?.name}
+              />
+            </span>
+          )}
+        </div>
         <p className="text-sm text-muted-foreground">
           {i18n.t(
             "policies:software.deploymentWizard.guideADeploymentThroughSelectionTargetingAnd",
           )}
         </p>
       </div>
+
+      {orgScope.scope === "all" && (
+        <div
+          className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400"
+          data-testid="deployment-all-orgs-notice"
+        >
+          {i18n.t("policies:software.deploymentWizard.allOrgsSelectCustomer")}
+        </div>
+      )}
 
       {error && activeStep !== "review" && (
         <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">

--- a/apps/web/src/components/software/SoftwareCatalog.test.tsx
+++ b/apps/web/src/components/software/SoftwareCatalog.test.tsx
@@ -5,7 +5,8 @@ import SoftwareCatalog from './SoftwareCatalog';
 import { fetchWithAuth } from '../../stores/auth';
 
 vi.mock('../../stores/auth', () => ({
-  fetchWithAuth: vi.fn()
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(), useAuthStore: { getState: () => ({ tokens: null }) }
 }));
 
 const showToast = vi.fn();

--- a/apps/web/src/components/software/SoftwareCatalog.tsx
+++ b/apps/web/src/components/software/SoftwareCatalog.tsx
@@ -13,6 +13,7 @@ import { fetchWithAuth } from "../../stores/auth";
 import { runAction, handleActionError } from "../../lib/runAction";
 import { useHashState } from "@/lib/useHashState";
 import { Dialog } from "../shared/Dialog";
+import { ScopeBadge } from "../shared/ScopeBadge";
 import DeploymentWizard from "./DeploymentWizard";
 import DeploymentList from "./DeploymentList";
 import DeploymentProgress from "./DeploymentProgress";
@@ -600,6 +601,17 @@ export default function SoftwareCatalog() {
                   </div>
                 </div>
                 <div className="flex flex-col items-end gap-1.5">
+                  {/* Partner-wide custom packages (#2135) wear the canonical
+                      ownership badge; built-ins keep their own pill below. */}
+                  {!item.orgId &&
+                    item.partnerId &&
+                    !isIntegrationProvider(item.integrationProvider) && (
+                      <ScopeBadge
+                        orgId={null}
+                        partnerId={item.partnerId}
+                        isSystem={false}
+                      />
+                    )}
                   {isIntegrationProvider(item.integrationProvider) && (
                     <div className="flex items-center gap-1.5">
                       <ReadinessPill
@@ -718,6 +730,17 @@ export default function SoftwareCatalog() {
                       selectedSoftware.category.slice(1)}
                   </span>
                 )}
+                {!selectedSoftware.orgId &&
+                  selectedSoftware.partnerId &&
+                  !isIntegrationProvider(
+                    selectedSoftware.integrationProvider,
+                  ) && (
+                    <ScopeBadge
+                      orgId={null}
+                      partnerId={selectedSoftware.partnerId}
+                      isSystem={false}
+                    />
+                  )}
               </div>
               <button
                 type="button"

--- a/apps/web/src/components/software/SoftwareVersionManager.edit.test.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.edit.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SoftwareVersionManager from './SoftwareVersionManager';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../lib/softwarePackageUpload', () => ({ uploadPackageVersion: vi.fn() }));
+vi.mock('./DetectionRulesEditor', () => ({ default: () => null }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const EXISTING_VERSION = {
+  id: 'ver-1',
+  version: '1.2.3',
+  releaseDate: '2026-01-01T00:00:00Z',
+  architecture: 'x64',
+  fileType: 'msi',
+  isLatest: true,
+  downloadUrl: 'https://dl.example.com/app-1.2.3.msi',
+  silentInstallArgs: 'msiexec /i "{file}" /qn',
+  silentUninstallArgs: 'msiexec /x "{file}" /qn',
+  supportedOs: ['windows'],
+  releaseNotes: 'old notes',
+};
+
+async function renderLoaded() {
+  render(<SoftwareVersionManager catalogId="cat-1" embedded />);
+  await waitFor(() =>
+    expect(screen.queryByText(/loading software versions/i)).not.toBeInTheDocument(),
+  );
+}
+
+describe('SoftwareVersionManager edit & prefill', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).startsWith('/custom-fields')) {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+      return Promise.resolve(jsonResponse({ data: [EXISTING_VERSION] }));
+    });
+  });
+
+  it('prefills the add form from the latest version with the number bumped', async () => {
+    await renderLoaded();
+    fireEvent.click(screen.getByRole('button', { name: /add version/i }));
+
+    expect(
+      (screen.getByPlaceholderText('e.g. 1.0.0') as HTMLInputElement).value,
+    ).toBe('1.2.4');
+    expect(
+      (screen.getByPlaceholderText(/msiexec \/i/i) as HTMLInputElement).value,
+    ).toBe('msiexec /i "{file}" /qn');
+    // Release notes never carry over to a new version.
+    expect(
+      (screen.getByPlaceholderText(/one item per line/i) as HTMLTextAreaElement).value,
+    ).toBe('');
+  });
+
+  it('edits a version in place via PATCH and updates the row', async () => {
+    await renderLoaded();
+    fireEvent.click(screen.getByTestId('version-edit-ver-1'));
+
+    // Form is in edit mode, loaded with the version's data, no file picker.
+    expect(screen.getByTestId('version-form-editing')).toBeInTheDocument();
+    const versionInput = screen.getByPlaceholderText('e.g. 1.0.0') as HTMLInputElement;
+    expect(versionInput.value).toBe('1.2.3');
+    expect(document.querySelector('input[type="file"]')).toBeNull();
+
+    fetchMock.mockImplementationOnce((url: string, opts?: RequestInit) => {
+      expect(url).toBe('/software/catalog/cat-1/versions/ver-1');
+      expect(opts?.method).toBe('PATCH');
+      const body = JSON.parse(String(opts?.body));
+      expect(body.version).toBe('1.2.9');
+      expect(body.silentInstallArgs).toBe('msiexec /i "{file}" /qn');
+      return Promise.resolve(
+        jsonResponse({ data: { ...EXISTING_VERSION, version: '1.2.9' } }),
+      );
+    });
+
+    fireEvent.change(versionInput, { target: { value: '1.2.9' } });
+    fireEvent.submit(versionInput.closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('v1.2.9')).toBeInTheDocument();
+    });
+    // Form closed after a successful save.
+    expect(screen.queryByTestId('version-form-editing')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/software/SoftwareVersionManager.edit.test.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.edit.test.tsx
@@ -52,6 +52,11 @@ describe('SoftwareVersionManager edit & prefill', () => {
     expect(
       (screen.getByPlaceholderText('e.g. 1.0.0') as HTMLInputElement).value,
     ).toBe('1.2.4');
+    // The carried-over URL gets the OLD version substituted for the bumped one
+    // so the prefill can't silently point 1.2.4 at the 1.2.3 binary.
+    expect(
+      (screen.getByPlaceholderText('https://example.com/package-v1.0.0.msi') as HTMLInputElement).value,
+    ).toBe('https://dl.example.com/app-1.2.4.msi');
     expect(
       (screen.getByPlaceholderText(/msiexec \/i/i) as HTMLInputElement).value,
     ).toBe('msiexec /i "{file}" /qn');
@@ -90,5 +95,30 @@ describe('SoftwareVersionManager edit & prefill', () => {
     });
     // Form closed after a successful save.
     expect(screen.queryByTestId('version-form-editing')).not.toBeInTheDocument();
+  });
+
+  it('surfaces a PATCH failure inline and keeps the edit form open', async () => {
+    await renderLoaded();
+    fireEvent.click(screen.getByTestId('version-edit-ver-1'));
+
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve(
+        jsonResponse(
+          { error: 'This version has no uploaded file — it needs a download URL' },
+          false,
+          400,
+        ),
+      ),
+    );
+    const versionInput = screen.getByPlaceholderText('e.g. 1.0.0') as HTMLInputElement;
+    fireEvent.submit(versionInput.closest('form')!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/needs a download URL/),
+      ).toBeInTheDocument();
+    });
+    // The form stays open in edit mode so the user can correct and retry.
+    expect(screen.getByTestId('version-form-editing')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/software/SoftwareVersionManager.fileType.test.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.fileType.test.tsx
@@ -61,7 +61,11 @@ describe('SoftwareVersionManager installer type (URL source)', () => {
       if (/\/versions$/.test(String(url)) && opts?.method === 'POST') {
         return Promise.resolve(jsonResponse({ data: { ...EXISTING_VERSION, id: 'ver-2' } }));
       }
-      return Promise.resolve(jsonResponse({ data: [EXISTING_VERSION] }));
+      // No existing versions: "Add version" seeds itself from the latest one
+      // when there is one (see openAddForm), and every case below is about how
+      // a BLANK form derives the installer type from the URL. The seeded path
+      // is covered by its own case at the bottom of this file.
+      return Promise.resolve(jsonResponse({ data: [] }));
     });
   });
 
@@ -130,5 +134,30 @@ describe('SoftwareVersionManager installer type (URL source)', () => {
   it('does not warn before a URL has been entered', async () => {
     await renderLoaded();
     expect(screen.queryByText(/no recognizable installer extension/i)).toBeNull();
+  });
+
+  // The add form seeds itself from the latest version so a routine "new release,
+  // same install shape" needs one glance. The installer type has to ride along:
+  // carrying the URL and args but dropping fileType would store file_type NULL,
+  // and the dispatcher then falls back to 'exe' and execs an MSI directly —
+  // exactly the bug the selector exists to prevent.
+  it('carries the installer type over when seeding a new version from the latest', async () => {
+    fetchMock.mockImplementation((url: string, opts?: RequestInit) => {
+      if (String(url).startsWith('/custom-fields')) {
+        return Promise.resolve(jsonResponse({ data: [] }));
+      }
+      if (/\/versions$/.test(String(url)) && opts?.method === 'POST') {
+        return Promise.resolve(jsonResponse({ data: { ...EXISTING_VERSION, id: 'ver-2' } }));
+      }
+      return Promise.resolve(jsonResponse({ data: [EXISTING_VERSION] }));
+    });
+
+    await renderLoaded();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('version-file-type')).toHaveValue('msi'),
+    );
+    submitForm();
+    await waitFor(() => expect(versionBody().fileType).toBe('msi'));
   });
 });

--- a/apps/web/src/components/software/SoftwareVersionManager.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.tsx
@@ -22,6 +22,7 @@ import { fetchWithAuth } from "../../stores/auth";
 import { usePackageUploadsGate } from "../../stores/featuresStore";
 import { findUnknownTokens } from "@/lib/installerVariables";
 import { applyOsHint } from "@/lib/installerPackageHints";
+import { bumpVersionString } from "@/lib/versionBump";
 import { uploadPackageVersion } from "../../lib/softwarePackageUpload";
 import DetectionRulesEditor from "./DetectionRulesEditor";
 import VariableInput, { type DeviceCustomField } from "./VariableInput";
@@ -38,6 +39,13 @@ type VersionEntry = {
   originalFileName: string;
   notes: string[];
   isLatest: boolean;
+  // Full metadata, kept so Edit and add-version prefill don't refetch.
+  downloadUrl: string;
+  silentInstallArgs: string;
+  silentUninstallArgs: string;
+  supportedOs: string[];
+  detectionRules: DetectionRule[];
+  hasFile: boolean;
 };
 function formatDate(dateString: string, timezone?: string): string {
   const date = new Date(dateString);
@@ -67,6 +75,8 @@ function normalizeVersion(
   ) {
     architecture = "x86";
   }
+  const supportedOsRaw = raw.supportedOs;
+  const detectionRulesRaw = raw.detectionRules;
   return {
     id: String(raw.id ?? raw.versionId ?? `ver-${index}`),
     version: String(raw.version ?? ""),
@@ -76,6 +86,18 @@ function normalizeVersion(
     originalFileName: String(raw.originalFileName ?? ""),
     notes,
     isLatest: Boolean(raw.isLatest ?? raw.is_latest ?? false),
+    downloadUrl: typeof raw.downloadUrl === "string" ? raw.downloadUrl : "",
+    silentInstallArgs:
+      typeof raw.silentInstallArgs === "string" ? raw.silentInstallArgs : "",
+    silentUninstallArgs:
+      typeof raw.silentUninstallArgs === "string" ? raw.silentUninstallArgs : "",
+    supportedOs: Array.isArray(supportedOsRaw)
+      ? supportedOsRaw.map((o) => String(o).toLowerCase())
+      : [],
+    detectionRules: Array.isArray(detectionRulesRaw)
+      ? (detectionRulesRaw as DetectionRule[])
+      : [],
+    hasFile: Boolean(raw.s3Key ?? raw.originalFileName),
   };
 }
 /**
@@ -92,6 +114,30 @@ function toPercent(sentBytes: number, totalBytes: number): number {
   if (totalBytes <= 0) return 0;
   return Math.min(100, Math.max(0, Math.round((sentBytes / totalBytes) * 100)));
 }
+/** A stored fileType is a bare string; narrow it to the selector's union so a
+ *  value the server no longer recognizes falls back to "" (infer) rather than
+ *  pinning the form to a bogus type. */
+function asFileType(raw: string): "" | SoftwareFileType {
+  return (SOFTWARE_FILE_TYPES as readonly string[]).includes(raw)
+    ? (raw as SoftwareFileType)
+    : "";
+}
+const EMPTY_FORM = {
+  version: "",
+  architecture: "x64" as Architecture,
+  notes: "",
+  silentInstallArgs: "",
+  silentUninstallArgs: "",
+  downloadUrl: "",
+  // "" = let the server infer from the URL. Only meaningful for the URL
+  // source; the upload path derives it from the uploaded filename.
+  fileType: "" as "" | SoftwareFileType,
+  supportedOs: [] as string[],
+  detectionRules: [] as DetectionRule[],
+  file: null as File | null,
+  fileName: "",
+};
+
 interface SoftwareVersionManagerProps {
   timezone?: string;
   catalogId?: string;
@@ -111,6 +157,9 @@ export default function SoftwareVersionManager({
   const [latestId, setLatestId] = useState<string>("");
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  // Non-empty while the form edits an existing version (PATCH) instead of
+  // creating a new one.
+  const [editingVersionId, setEditingVersionId] = useState<string>("");
   const [selectedVersionId, setSelectedVersionId] = useState<string>("");
   const [saving, setSaving] = useState(false);
   const [promotingVersionId, setPromotingVersionId] = useState<string>("");
@@ -127,21 +176,7 @@ export default function SoftwareVersionManager({
   // it. A ref, not state: it must survive re-renders without causing one, and
   // the progress bar already re-renders on every acknowledged chunk.
   const uploadAbortRef = useRef<AbortController | null>(null);
-  const [formState, setFormState] = useState({
-    version: "",
-    architecture: "x64" as Architecture,
-    notes: "",
-    silentInstallArgs: "",
-    silentUninstallArgs: "",
-    downloadUrl: "",
-    // "" = let the server infer from the URL. Only meaningful for the URL
-    // source; the upload path derives it from the uploaded filename.
-    fileType: "" as "" | SoftwareFileType,
-    supportedOs: [] as string[],
-    detectionRules: [] as DetectionRule[],
-    file: null as File | null,
-    fileName: "",
-  });
+  const [formState, setFormState] = useState(EMPTY_FORM);
   const fetchVersions = useCallback(async () => {
     try {
       setLoading(true);
@@ -302,6 +337,65 @@ export default function SoftwareVersionManager({
     () => deriveSoftwareFileTypeFromUrl(formState.downloadUrl),
     [formState.downloadUrl],
   );
+  const resetForm = () => {
+    setFormState(EMPTY_FORM);
+    setEditingVersionId("");
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    setIsFormOpen(false);
+    setAdvancedOpen(false);
+  };
+  /** Open the add form, seeded from the latest version so a routine "new
+   *  release, same install shape" needs only a glance: version bumped, URL,
+   *  args, OS and detection rules carried over. Release notes start empty. */
+  const openAddForm = () => {
+    setEditingVersionId("");
+    const seed = versions.find((v) => v.id === latestId) ?? versions[0];
+    setFormState(
+      seed
+        ? {
+            ...EMPTY_FORM,
+            version: bumpVersionString(seed.version),
+            architecture: seed.architecture,
+            fileType: asFileType(seed.fileType),
+            downloadUrl: seed.downloadUrl,
+            silentInstallArgs: seed.silentInstallArgs,
+            silentUninstallArgs: seed.silentUninstallArgs,
+            supportedOs: [...seed.supportedOs],
+            detectionRules: seed.detectionRules.map((r) => ({ ...r })),
+          }
+        : EMPTY_FORM,
+    );
+    setAdvancedOpen(
+      Boolean(seed && (seed.silentUninstallArgs || seed.detectionRules.length)),
+    );
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    setIsFormOpen(true);
+  };
+  const openEditForm = (entry: VersionEntry) => {
+    setEditingVersionId(entry.id);
+    setFormState({
+      ...EMPTY_FORM,
+      version: entry.version,
+      architecture: entry.architecture,
+      fileType: asFileType(entry.fileType),
+      notes: entry.notes.join("\n"),
+      downloadUrl: entry.downloadUrl,
+      silentInstallArgs: entry.silentInstallArgs,
+      silentUninstallArgs: entry.silentUninstallArgs,
+      supportedOs: [...entry.supportedOs],
+      detectionRules: entry.detectionRules.map((r) => ({ ...r })),
+    });
+    setAdvancedOpen(
+      Boolean(
+        entry.silentUninstallArgs ||
+          entry.detectionRules.length ||
+          entry.notes.length,
+      ),
+    );
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    setIsFormOpen(true);
+  };
+
   const handlePromoteLatest = useCallback(
     async (versionId: string) => {
       if (!catalogId || versionId === latestId) return;
@@ -349,6 +443,57 @@ export default function SoftwareVersionManager({
     event.preventDefault();
     if (!formState.version.trim()) return;
     if (!catalogId) return;
+    // Edit mode: metadata PATCH — no file handling, empty string clears.
+    if (editingVersionId) {
+      try {
+        setSaving(true);
+        setError(undefined);
+        const response = await fetchWithAuth(
+          `/software/catalog/${catalogId}/versions/${editingVersionId}`,
+          {
+            method: "PATCH",
+            body: JSON.stringify({
+              version: formState.version.trim(),
+              architecture: formState.architecture,
+              releaseNotes: formState.notes.trim() || null,
+              downloadUrl: formState.downloadUrl.trim() || null,
+              silentInstallArgs: formState.silentInstallArgs || null,
+              silentUninstallArgs: formState.silentUninstallArgs || null,
+              supportedOs:
+                formState.supportedOs.length > 0 ? formState.supportedOs : null,
+              detectionRules:
+                formState.detectionRules.length > 0
+                  ? formState.detectionRules
+                  : null,
+            }),
+          },
+        );
+        if (!response.ok) {
+          const errData = await response.json().catch(() => ({}));
+          throw new Error(
+            typeof errData.error === "string"
+              ? errData.error
+              : i18n.t(
+                  "policies:software.softwareVersionManager.failedToUpdateVersion",
+                ),
+          );
+        }
+        const data = await response.json();
+        const updated = normalizeVersion(data.data ?? data, 0);
+        setVersions((prev) =>
+          prev.map((v) => (v.id === updated.id ? updated : v)),
+        );
+        resetForm();
+      } catch (err) {
+        console.error("Failed to update version:", err);
+        setError(
+          err instanceof Error ? err.message : "Failed to update version",
+        );
+      } finally {
+        setSaving(false);
+      }
+      return;
+    }
     // Only the file branch is abortable; the metadata-only POST is a single
     // short request and keeps its previous behaviour exactly.
     const controller = formState.file ? new AbortController() : null;
@@ -461,22 +606,7 @@ export default function SoftwareVersionManager({
         setLatestId(newVersion.id);
         setSelectedVersionId(newVersion.id);
       }
-      setFormState({
-        version: "",
-        architecture: "x64",
-        notes: "",
-        silentInstallArgs: "",
-        silentUninstallArgs: "",
-        downloadUrl: "",
-        fileType: "",
-        supportedOs: [],
-        detectionRules: [],
-        file: null,
-        fileName: "",
-      });
-      if (fileInputRef.current) fileInputRef.current.value = "";
-      setIsFormOpen(false);
-      setAdvancedOpen(false);
+      resetForm();
     } catch (err) {
       // uploadPackageVersion REJECTS on abort. A cancel the user asked for is
       // not a failure — exit quietly, leaving `versions` untouched and no
@@ -496,7 +626,7 @@ export default function SoftwareVersionManager({
     // a version into the list the user thinks they cancelled.
     uploadAbortRef.current?.abort();
     uploadAbortRef.current = null;
-    setIsFormOpen(false);
+    resetForm();
   };
   if (loading) {
     return (
@@ -550,7 +680,7 @@ export default function SoftwareVersionManager({
         )}
         <button
           type="button"
-          onClick={() => setIsFormOpen((open) => !open)}
+          onClick={() => (isFormOpen ? handleCancelForm() : openAddForm())}
           className="inline-flex h-10 items-center justify-center gap-2 rounded-md border bg-background px-4 text-sm font-medium hover:bg-muted"
         >
           <Plus className="h-4 w-4" />
@@ -574,6 +704,14 @@ export default function SoftwareVersionManager({
           onSubmit={handleSubmit}
           className="rounded-lg border bg-card p-6 shadow-xs"
         >
+          {editingVersionId && (
+            <p
+              className="mb-4 text-sm font-medium"
+              data-testid="version-form-editing"
+            >
+              {i18n.t("policies:software.softwareVersionManager.editingVersion")}
+            </p>
+          )}
           <div className="grid gap-4 sm:grid-cols-2">
             <div>
               <label className="text-xs font-semibold uppercase text-muted-foreground">
@@ -733,6 +871,15 @@ export default function SoftwareVersionManager({
             </div>
           </div>
 
+          {editingVersionId ? (
+            /* The uploaded binary is immutable per version — replacing the
+               installer means adding a new version, not editing this one. */
+            <p className="mt-4 text-xs text-muted-foreground">
+              {i18n.t(
+                "policies:software.softwareVersionManager.replaceFileAddNewVersion",
+              )}
+            </p>
+          ) : (
           <div className="mt-4">
             <label className="text-xs font-semibold uppercase text-muted-foreground">
               {i18n.t("policies:software.softwareVersionManager.packageFile")}
@@ -773,6 +920,7 @@ export default function SoftwareVersionManager({
               </span>
             </div>
           </div>
+          )}
 
           <div className="mt-4">
             <label className="text-xs font-semibold uppercase text-muted-foreground">
@@ -910,17 +1058,23 @@ export default function SoftwareVersionManager({
               disabled={saving || tokenErrors.length > 0}
               className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {saving
-                ? formState.file
-                  ? i18n.t("policies:software.softwareVersionManager.uploading")
-                  : i18n.t("policies:software.softwareVersionManager.saving")
-                : formState.file
-                  ? i18n.t(
-                      "policies:software.softwareVersionManager.uploadSave",
-                    )
-                  : i18n.t(
-                      "policies:software.softwareVersionManager.saveVersion",
-                    )}
+              {editingVersionId
+                ? saving
+                  ? i18n.t("policies:software.softwareVersionManager.saving")
+                  : i18n.t("common:actions.save")
+                : saving
+                  ? formState.file
+                    ? i18n.t(
+                        "policies:software.softwareVersionManager.uploading",
+                      )
+                    : i18n.t("policies:software.softwareVersionManager.saving")
+                  : formState.file
+                    ? i18n.t(
+                        "policies:software.softwareVersionManager.uploadSave",
+                      )
+                    : i18n.t(
+                        "policies:software.softwareVersionManager.saveVersion",
+                      )}
             </button>
           </div>
         </form>
@@ -970,13 +1124,18 @@ export default function SoftwareVersionManager({
                 <th className="px-4 py-3">
                   {i18n.t("policies:software.softwareVersionManager.latest2")}
                 </th>
+                <th className="px-4 py-3">
+                  <span className="sr-only">
+                    {i18n.t("common:actions.edit")}
+                  </span>
+                </th>
               </tr>
             </thead>
             <tbody className="divide-y">
               {versions.length === 0 ? (
                 <tr>
                   <td
-                    colSpan={5}
+                    colSpan={6}
                     className="px-4 py-6 text-center text-sm text-muted-foreground"
                   >
                     {i18n.t(
@@ -1027,6 +1186,16 @@ export default function SoftwareVersionManager({
                               "policies:software.softwareVersionManager.setAsLatest",
                             )}
                       </label>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        type="button"
+                        data-testid={`version-edit-${entry.id}`}
+                        onClick={() => openEditForm(entry)}
+                        className="text-sm font-medium text-primary hover:underline"
+                      >
+                        {i18n.t("common:actions.edit")}
+                      </button>
                     </td>
                   </tr>
                 ))

--- a/apps/web/src/components/software/SoftwareVersionManager.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.tsx
@@ -22,7 +22,7 @@ import { fetchWithAuth } from "../../stores/auth";
 import { usePackageUploadsGate } from "../../stores/featuresStore";
 import { findUnknownTokens } from "@/lib/installerVariables";
 import { applyOsHint } from "@/lib/installerPackageHints";
-import { bumpVersionString } from "@/lib/versionBump";
+import { bumpVersionString, substituteVersionInUrl } from "@/lib/versionBump";
 import { uploadPackageVersion } from "../../lib/softwarePackageUpload";
 import DetectionRulesEditor from "./DetectionRulesEditor";
 import VariableInput, { type DeviceCustomField } from "./VariableInput";
@@ -45,7 +45,6 @@ type VersionEntry = {
   silentUninstallArgs: string;
   supportedOs: string[];
   detectionRules: DetectionRule[];
-  hasFile: boolean;
 };
 function formatDate(dateString: string, timezone?: string): string {
   const date = new Date(dateString);
@@ -97,7 +96,6 @@ function normalizeVersion(
     detectionRules: Array.isArray(detectionRulesRaw)
       ? (detectionRulesRaw as DetectionRule[])
       : [],
-    hasFile: Boolean(raw.s3Key ?? raw.originalFileName),
   };
 }
 /**
@@ -320,7 +318,10 @@ export default function SoftwareVersionManager({
         prev,
         prev.fileType || deriveSoftwareFileTypeFromUrl(value),
       ),
-      ...applyOsHint(prev, value),
+      // OS hint only when ADDING: on an existing version, empty supportedOs
+      // means "all OS" at dispatch, so auto-checking one as a side effect of a
+      // URL edit would silently narrow the version's targeting.
+      ...(editingVersionId ? {} : applyOsHint(prev, value)),
     }));
   };
   const handleFileTypeChange = (value: "" | SoftwareFileType) => {
@@ -344,20 +345,27 @@ export default function SoftwareVersionManager({
     setIsFormOpen(false);
     setAdvancedOpen(false);
   };
-  /** Open the add form, seeded from the latest version so a routine "new
-   *  release, same install shape" needs only a glance: version bumped, URL,
-   *  args, OS and detection rules carried over. Release notes start empty. */
+  /** Open the add form, seeded from the latest (or first) version so a
+   *  routine "new release, same install shape" needs only a glance: version
+   *  bumped, URL (with the old version substituted for the new one when
+   *  embedded), args, architecture, OS and detection rules carried over.
+   *  Release notes start empty. */
   const openAddForm = () => {
     setEditingVersionId("");
     const seed = versions.find((v) => v.id === latestId) ?? versions[0];
+    const bumped = seed ? bumpVersionString(seed.version) : "";
     setFormState(
       seed
         ? {
             ...EMPTY_FORM,
-            version: bumpVersionString(seed.version),
+            version: bumped,
             architecture: seed.architecture,
             fileType: asFileType(seed.fileType),
-            downloadUrl: seed.downloadUrl,
+            downloadUrl: substituteVersionInUrl(
+              seed.downloadUrl,
+              seed.version,
+              bumped,
+            ),
             silentInstallArgs: seed.silentInstallArgs,
             silentUninstallArgs: seed.silentUninstallArgs,
             supportedOs: [...seed.supportedOs],
@@ -678,10 +686,15 @@ export default function SoftwareVersionManager({
             </p>
           </div>
         )}
+        {/* Locked while a save/upload is in flight (same for the per-row Edit
+            buttons): repurposing the shared form mid-upload would let the
+            completing upload's resetForm() wipe whatever the user started
+            typing. */}
         <button
           type="button"
+          disabled={saving}
           onClick={() => (isFormOpen ? handleCancelForm() : openAddForm())}
-          className="inline-flex h-10 items-center justify-center gap-2 rounded-md border bg-background px-4 text-sm font-medium hover:bg-muted"
+          className="inline-flex h-10 items-center justify-center gap-2 rounded-md border bg-background px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Plus className="h-4 w-4" />
           {i18n.t("policies:software.softwareVersionManager.addVersion")}
@@ -947,8 +960,10 @@ export default function SoftwareVersionManager({
           </div>
 
           {/* Advanced disclosure mirrors AddPackageModal: uninstall args,
-              detection rules and release notes stay out of the default view so
-              install args no longer reads as a duplicated field. */}
+              detection rules and release notes stay out of the default view.
+              (Install/uninstall args previously sat side-by-side with
+              near-identical truncated placeholders and read as the same field
+              rendered twice.) */}
           <div className="mt-4 border-t pt-3">
             <button
               type="button"
@@ -1191,8 +1206,9 @@ export default function SoftwareVersionManager({
                       <button
                         type="button"
                         data-testid={`version-edit-${entry.id}`}
+                        disabled={saving}
                         onClick={() => openEditForm(entry)}
-                        className="text-sm font-medium text-primary hover:underline"
+                        className="text-sm font-medium text-primary hover:underline disabled:cursor-not-allowed disabled:opacity-50 disabled:no-underline"
                       >
                         {i18n.t("common:actions.edit")}
                       </button>

--- a/apps/web/src/components/software/SoftwareVersionManager.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.tsx
@@ -19,7 +19,9 @@ import {
 import { applySilentArgsPrefill } from "@/lib/installerArgsPrefill";
 import { cn } from "@/lib/utils";
 import { fetchWithAuth } from "../../stores/auth";
+import { usePackageUploadsGate } from "../../stores/featuresStore";
 import { findUnknownTokens } from "@/lib/installerVariables";
+import { applyOsHint } from "@/lib/installerPackageHints";
 import { uploadPackageVersion } from "../../lib/softwarePackageUpload";
 import DetectionRulesEditor from "./DetectionRulesEditor";
 import VariableInput, { type DeviceCustomField } from "./VariableInput";
@@ -108,6 +110,7 @@ export default function SoftwareVersionManager({
   const [error, setError] = useState<string>();
   const [latestId, setLatestId] = useState<string>("");
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [selectedVersionId, setSelectedVersionId] = useState<string>("");
   const [saving, setSaving] = useState(false);
   const [promotingVersionId, setPromotingVersionId] = useState<string>("");
@@ -116,6 +119,9 @@ export default function SoftwareVersionManager({
   const [customFields, setCustomFields] = useState<DeviceCustomField[]>([]);
   // Tenant variables (#3409) — offered as `{{var.<key>}}` in the same picker.
   const tenantVariables = useTenantVariables();
+  // Without S3 configured the upload routes 503, so gray the file picker out
+  // up front instead of failing after the user chose a file.
+  const { enabled: uploadsEnabled } = usePackageUploadsGate();
   const fileInputRef = useRef<HTMLInputElement>(null);
   // Owns the in-flight chunked upload so Cancel (and unmount) can actually stop
   // it. A ref, not state: it must survive re-renders without causing one, and
@@ -264,6 +270,7 @@ export default function SoftwareVersionManager({
       fileName: file.name,
       // Auto-populate MSI silent args (retractable — see applySilentArgsPrefill).
       ...applySilentArgsPrefill(prev, deriveSoftwareFileTypeFromUrl(file.name)),
+      ...applyOsHint(prev, file.name),
     }));
   };
   /** The URL source carries no filename, so the installer type has to come from
@@ -278,6 +285,7 @@ export default function SoftwareVersionManager({
         prev,
         prev.fileType || deriveSoftwareFileTypeFromUrl(value),
       ),
+      ...applyOsHint(prev, value),
     }));
   };
   const handleFileTypeChange = (value: "" | SoftwareFileType) => {
@@ -468,6 +476,7 @@ export default function SoftwareVersionManager({
       });
       if (fileInputRef.current) fileInputRef.current.value = "";
       setIsFormOpen(false);
+      setAdvancedOpen(false);
     } catch (err) {
       // uploadPackageVersion REJECTS on abort. A cancel the user asked for is
       // not a failure — exit quietly, leaving `versions` untouched and no
@@ -738,91 +747,133 @@ export default function SoftwareVersionManager({
               />
               <button
                 type="button"
+                disabled={!uploadsEnabled}
+                title={
+                  uploadsEnabled
+                    ? undefined
+                    : i18n.t(
+                        "policies:software.softwareVersionManager.uploadsRequireS3Storage",
+                      )
+                }
                 onClick={() => fileInputRef.current?.click()}
-                className="inline-flex h-10 items-center gap-2 rounded-md border bg-background px-4 text-sm font-medium hover:bg-muted"
+                className="inline-flex h-10 items-center gap-2 rounded-md border bg-background px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background"
               >
                 <Upload className="h-4 w-4" />
                 {i18n.t("policies:software.softwareVersionManager.chooseFile")}
               </button>
               <span className="text-sm text-muted-foreground">
-                {formState.fileName ||
-                  i18n.t(
-                    "policies:software.softwareVersionManager.noFileSelectedMsiExeDmgDeb",
-                  )}
+                {uploadsEnabled
+                  ? formState.fileName ||
+                    i18n.t(
+                      "policies:software.softwareVersionManager.noFileSelectedMsiExeDmgDeb",
+                    )
+                  : i18n.t(
+                      "policies:software.softwareVersionManager.uploadsRequireS3Storage",
+                    )}
               </span>
             </div>
           </div>
 
-          <div className="mt-4 grid gap-4 sm:grid-cols-2">
-            <div>
-              <label className="text-xs font-semibold uppercase text-muted-foreground">
-                {i18n.t(
-                  "policies:software.softwareVersionManager.silentInstallArgs",
+          <div className="mt-4">
+            <label className="text-xs font-semibold uppercase text-muted-foreground">
+              {i18n.t(
+                "policies:software.softwareVersionManager.silentInstallArgs",
+              )}
+            </label>
+            <div className="mt-2">
+              <VariableInput
+                value={formState.silentInstallArgs}
+                onChange={(value) =>
+                  setFormState((prev) => ({
+                    ...prev,
+                    silentInstallArgs: value,
+                  }))
+                }
+                placeholder={i18n.t(
+                  "policies:software.softwareVersionManager.eGMsiexecIFileQnNorestart",
                 )}
-              </label>
-              <div className="mt-2">
-                <VariableInput
-                  value={formState.silentInstallArgs}
-                  onChange={(value) =>
-                    setFormState((prev) => ({
-                      ...prev,
-                      silentInstallArgs: value,
-                    }))
-                  }
-                  placeholder={i18n.t(
-                    "policies:software.softwareVersionManager.eGMsiexecIFileQnNorestart",
-                  )}
-                  customFields={customFields}
-                  tenantVariables={tenantVariables}
-                />
-              </div>
-            </div>
-            <div>
-              <label className="text-xs font-semibold uppercase text-muted-foreground">
-                {i18n.t(
-                  "policies:software.softwareVersionManager.silentUninstallArgs",
-                )}
-              </label>
-              <div className="mt-2">
-                <VariableInput
-                  value={formState.silentUninstallArgs}
-                  onChange={(value) =>
-                    setFormState((prev) => ({
-                      ...prev,
-                      silentUninstallArgs: value,
-                    }))
-                  }
-                  placeholder={i18n.t(
-                    "policies:software.softwareVersionManager.eGMsiexecXFileQnNorestart",
-                  )}
-                  customFields={customFields}
-                  tenantVariables={tenantVariables}
-                />
-              </div>
+                customFields={customFields}
+                tenantVariables={tenantVariables}
+              />
             </div>
           </div>
 
-          <DetectionRulesEditor
-            rules={formState.detectionRules}
-            onChange={(detectionRules) =>
-              setFormState((prev) => ({ ...prev, detectionRules }))
-            }
-          />
-
-          <div className="mt-4">
-            <label className="text-xs font-semibold uppercase text-muted-foreground">
-              {i18n.t("policies:software.softwareVersionManager.releaseNotes")}
-            </label>
-            <textarea
-              value={formState.notes}
-              onChange={(event) =>
-                setFormState((prev) => ({ ...prev, notes: event.target.value }))
-              }
-              placeholder={i18n.t(
-                "policies:software.softwareVersionManager.oneItemPerLine",
+          {/* Advanced disclosure mirrors AddPackageModal: uninstall args,
+              detection rules and release notes stay out of the default view so
+              install args no longer reads as a duplicated field. */}
+          <div className="mt-4 border-t pt-3">
+            <button
+              type="button"
+              onClick={() => setAdvancedOpen((open) => !open)}
+              aria-expanded={advancedOpen}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+            >
+              <ChevronDown
+                className={cn(
+                  "h-4 w-4 transition-transform",
+                  advancedOpen && "rotate-180",
+                )}
+              />
+              {i18n.t(
+                "policies:software.softwareVersionManager.advancedOptions",
               )}
-              className="mt-2 u-min-h-px-96 w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-            />
+            </button>
+
+            {advancedOpen && (
+              <div className="mt-4 space-y-4">
+                <div>
+                  <label className="text-xs font-semibold uppercase text-muted-foreground">
+                    {i18n.t(
+                      "policies:software.softwareVersionManager.silentUninstallArgs",
+                    )}
+                  </label>
+                  <div className="mt-2">
+                    <VariableInput
+                      value={formState.silentUninstallArgs}
+                      onChange={(value) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          silentUninstallArgs: value,
+                        }))
+                      }
+                      placeholder={i18n.t(
+                        "policies:software.softwareVersionManager.eGMsiexecXFileQnNorestart",
+                      )}
+                      customFields={customFields}
+                      tenantVariables={tenantVariables}
+                    />
+                  </div>
+                </div>
+
+                <DetectionRulesEditor
+                  rules={formState.detectionRules}
+                  onChange={(detectionRules) =>
+                    setFormState((prev) => ({ ...prev, detectionRules }))
+                  }
+                />
+
+                <div>
+                  <label className="text-xs font-semibold uppercase text-muted-foreground">
+                    {i18n.t(
+                      "policies:software.softwareVersionManager.releaseNotes",
+                    )}
+                  </label>
+                  <textarea
+                    value={formState.notes}
+                    onChange={(event) =>
+                      setFormState((prev) => ({
+                        ...prev,
+                        notes: event.target.value,
+                      }))
+                    }
+                    placeholder={i18n.t(
+                      "policies:software.softwareVersionManager.oneItemPerLine",
+                    )}
+                    className="mt-2 u-min-h-px-96 w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                  />
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Shown for the whole file transfer, including at 0%. The old

--- a/apps/web/src/components/software/SoftwareVersionManager.upload.test.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.upload.test.tsx
@@ -26,10 +26,12 @@ const EXISTING_VERSION = {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((r) => {
-    resolve = r;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 /** Open the add-version form, type a version, and attach a file. */
@@ -302,9 +304,18 @@ describe('SoftwareVersionManager chunked upload path', () => {
     });
 
     it('still reports a genuine failure after a previous upload was cancelled', async () => {
-      const { signal } = await startUpload();
+      const { gate, signal } = await startUpload();
       fireEvent.click(screen.getByTestId('version-form-cancel'));
       expect(signal.aborted).toBe(true);
+      // The real uploader REJECTS on abort; emulate it so the submit's cleanup
+      // runs and re-enables the Add Version entry point (disabled while a save
+      // is in flight).
+      await act(async () => {
+        gate.reject(new DOMException('Aborted', 'AbortError'));
+      });
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /add version/i })).toBeEnabled(),
+      );
 
       // A fresh submission gets a fresh controller — the stale aborted one must
       // not swallow a real error.

--- a/apps/web/src/lib/installerPackageHints.test.ts
+++ b/apps/web/src/lib/installerPackageHints.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyOsHint,
+  installerExt,
+  osForInstaller,
+} from "./installerPackageHints";
+
+describe("installerExt", () => {
+  it("resolves known extensions from file names", () => {
+    expect(installerExt("setup.msi")).toBe("msi");
+    expect(installerExt("Setup.MSI")).toBe("msi");
+    expect(installerExt("app.dmg")).toBe("dmg");
+    expect(installerExt("pkg_1.2.3.deb")).toBe("deb");
+  });
+
+  it("resolves extensions from URLs, ignoring query and fragment", () => {
+    expect(installerExt("https://example.com/dl/pkg-1.0.msi?sig=abc#x")).toBe(
+      "msi",
+    );
+    expect(installerExt("https://example.com/mac/App.pkg")).toBe("pkg");
+  });
+
+  it("returns null for unknown or missing extensions", () => {
+    expect(installerExt("")).toBeNull();
+    expect(installerExt("https://example.com/download")).toBeNull();
+    expect(installerExt("archive.zip")).toBeNull();
+    expect(installerExt("https://example.com/msi/")).toBeNull();
+  });
+});
+
+describe("osForInstaller", () => {
+  it("maps extensions to OS", () => {
+    expect(osForInstaller("a.msi")).toBe("windows");
+    expect(osForInstaller("a.exe")).toBe("windows");
+    expect(osForInstaller("a.dmg")).toBe("macos");
+    expect(osForInstaller("a.pkg")).toBe("macos");
+    expect(osForInstaller("a.deb")).toBe("linux");
+    expect(osForInstaller("a.zip")).toBeNull();
+  });
+});
+
+describe("applyOsHint", () => {
+  const blank = { supportedOs: [] as string[] };
+
+  it("auto-selects the OS from the extension", () => {
+    expect(applyOsHint(blank, "setup.msi")).toEqual({
+      supportedOs: ["windows"],
+    });
+    expect(applyOsHint(blank, "https://example.com/app.dmg")).toEqual({
+      supportedOs: ["macos"],
+    });
+  });
+
+  it("never overwrites a user-set OS", () => {
+    expect(applyOsHint({ supportedOs: ["linux"] }, "setup.msi")).toEqual({});
+  });
+
+  it("is an empty patch for unknown extensions", () => {
+    expect(applyOsHint(blank, "https://example.com/download")).toEqual({});
+    expect(applyOsHint(blank, "archive.zip")).toEqual({});
+  });
+
+  // The msiexec prefill deliberately lives in installerArgsPrefill, keyed on the
+  // explicit fileType selector so it stays retractable. Deriving it here as well
+  // would resurrect the stale-`msiexec /i`-on-a-non-MSI bug that path prevents.
+  it("does not touch silent-args fields", () => {
+    const patch = applyOsHint(blank, "setup.msi");
+    expect(patch).not.toHaveProperty("silentInstallArgs");
+    expect(patch).not.toHaveProperty("silentUninstallArgs");
+  });
+});

--- a/apps/web/src/lib/installerPackageHints.ts
+++ b/apps/web/src/lib/installerPackageHints.ts
@@ -1,0 +1,59 @@
+/**
+ * Heuristics derived from an installer's file name or download URL, used by the
+ * package/version forms to pre-fill fields the user would otherwise have to set
+ * by hand: supported OS from the extension, and msiexec silent args for MSIs.
+ *
+ * `{file}` (single-brace) is the agent's downloaded-path token — distinct from
+ * the double-brace `{{...}}` deploy-time variables in installerVariables.ts.
+ */
+export type InstallerOs = "windows" | "macos" | "linux";
+
+const EXT_OS: Record<string, InstallerOs> = {
+  msi: "windows",
+  exe: "windows",
+  dmg: "macos",
+  pkg: "macos",
+  deb: "linux",
+};
+
+
+/** Lower-cased installer extension from a file name or download URL, or null
+ *  when the name doesn't end in a known installer extension. Query strings and
+ *  fragments are ignored so `…/pkg-1.0.msi?sig=abc` still resolves. */
+export function installerExt(nameOrUrl: string): string | null {
+  const path = nameOrUrl.trim().split(/[?#]/, 1)[0] ?? "";
+  const last = path.split("/").pop() ?? "";
+  const dot = last.lastIndexOf(".");
+  if (dot < 0) return null;
+  const ext = last.slice(dot + 1).toLowerCase();
+  return ext in EXT_OS ? ext : null;
+}
+
+export function osForInstaller(nameOrUrl: string): InstallerOs | null {
+  const ext = installerExt(nameOrUrl);
+  return ext ? EXT_OS[ext] : null;
+}
+
+/**
+ * Extension-derived OS hint as a partial form patch, spread alongside
+ * applySilentArgsPrefill (lib/installerArgsPrefill.ts) by the package and
+ * version forms.
+ *
+ * Scope note: msiexec silent-args prefill deliberately lives in
+ * installerArgsPrefill and NOT here. That path is keyed on the explicit
+ * `fileType` selector (which outranks the URL) and is retractable — it
+ * withdraws a prefilled msiexec command when the type changes, so a stale
+ * `msiexec /i` can't be left behind on a non-MSI. Deriving the same args a
+ * second time from the extension alone would reintroduce exactly that bug.
+ *
+ * Returns an empty patch when the name/URL carries no known installer
+ * extension, or when the user has already checked an OS.
+ */
+export function applyOsHint(
+  prev: { supportedOs: string[] },
+  nameOrUrl: string,
+): { supportedOs: string[] } | Record<string, never> {
+  if (prev.supportedOs.length > 0) return {};
+  const os = osForInstaller(nameOrUrl);
+  return os ? { supportedOs: [os] } : {};
+}

--- a/apps/web/src/lib/runActionAllowlist.ts
+++ b/apps/web/src/lib/runActionAllowlist.ts
@@ -33,4 +33,8 @@ export const RUN_ACTION_MIGRATION_BACKLOG: ReadonlyArray<string> = [
   // FeatureTabShell error banner + per-field errors (inline error UI), but the
   // fetchWithAuth mutations are not yet routed through runAction.
   'apps/web/src/components/configurationPolicies/featureTabs/BackupTab.tsx',
+  // Version add/edit (incl. the PATCH edit path) surfaces outcomes via the
+  // inline error banner + the row updating in place, but the fetchWithAuth
+  // mutations are not yet routed through runAction.
+  'apps/web/src/components/software/SoftwareVersionManager.tsx',
 ];

--- a/apps/web/src/lib/versionBump.test.ts
+++ b/apps/web/src/lib/versionBump.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { bumpVersionString } from "./versionBump";
+import { bumpVersionString, substituteVersionInUrl } from "./versionBump";
 
 describe("bumpVersionString", () => {
   it("bumps the last numeric segment", () => {
@@ -18,5 +18,26 @@ describe("bumpVersionString", () => {
   it("returns empty for strings without digits", () => {
     expect(bumpVersionString("")).toBe("");
     expect(bumpVersionString("latest")).toBe("");
+  });
+});
+
+describe("substituteVersionInUrl", () => {
+  it("rewrites embedded versions", () => {
+    expect(
+      substituteVersionInUrl("https://dl.example.com/app-1.2.3.msi", "1.2.3", "1.2.4"),
+    ).toBe("https://dl.example.com/app-1.2.4.msi");
+  });
+
+  it("leaves URLs without the version untouched", () => {
+    expect(
+      substituteVersionInUrl("https://dl.example.com/latest.msi", "1.2.3", "1.2.4"),
+    ).toBe("https://dl.example.com/latest.msi");
+  });
+
+  it("is a no-op for empty or unchanged versions", () => {
+    expect(substituteVersionInUrl("https://x/app-1.2.3.msi", "1.2.3", "")).toBe(
+      "https://x/app-1.2.3.msi",
+    );
+    expect(substituteVersionInUrl("", "1.2.3", "1.2.4")).toBe("");
   });
 });

--- a/apps/web/src/lib/versionBump.test.ts
+++ b/apps/web/src/lib/versionBump.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { bumpVersionString } from "./versionBump";
+
+describe("bumpVersionString", () => {
+  it("bumps the last numeric segment", () => {
+    expect(bumpVersionString("1.2.3")).toBe("1.2.4");
+    expect(bumpVersionString("10")).toBe("11");
+    expect(bumpVersionString("2.0")).toBe("2.1");
+  });
+
+  it("preserves suffixes and zero-padding", () => {
+    expect(bumpVersionString("1.0.0-beta2")).toBe("1.0.0-beta3");
+    expect(bumpVersionString("1.09")).toBe("1.10");
+    expect(bumpVersionString("v1.2.3")).toBe("v1.2.4");
+    expect(bumpVersionString("1.2.3b")).toBe("1.2.4b");
+  });
+
+  it("returns empty for strings without digits", () => {
+    expect(bumpVersionString("")).toBe("");
+    expect(bumpVersionString("latest")).toBe("");
+  });
+});

--- a/apps/web/src/lib/versionBump.ts
+++ b/apps/web/src/lib/versionBump.ts
@@ -1,0 +1,13 @@
+/**
+ * Increment the last numeric segment of a version string, preserving any
+ * suffix and zero-padding: "1.2.3" → "1.2.4", "1.0.0-beta2" → "1.0.0-beta3",
+ * "1.09" → "1.10". Returns "" when the string contains no digits — the caller
+ * should leave the field for the user to fill in.
+ */
+export function bumpVersionString(version: string): string {
+  const match = version.trim().match(/^(.*?)(\d+)(\D*)$/s);
+  if (!match) return "";
+  const [, prefix, digits, suffix] = match;
+  const bumped = String(Number(digits) + 1).padStart(digits.length, "0");
+  return `${prefix}${bumped}${suffix}`;
+}

--- a/apps/web/src/lib/versionBump.ts
+++ b/apps/web/src/lib/versionBump.ts
@@ -4,6 +4,21 @@
  * "1.09" → "1.10". Returns "" when the string contains no digits — the caller
  * should leave the field for the user to fill in.
  */
+/**
+ * Rewrite occurrences of the old version inside a carried-over download URL so
+ * a prefilled "1.2.4" doesn't silently point at the 1.2.3 binary
+ * (".../app-1.2.3.msi" → ".../app-1.2.4.msi"). When the URL doesn't embed the
+ * version, it is returned unchanged — the user still sees it in the form.
+ */
+export function substituteVersionInUrl(
+  url: string,
+  oldVersion: string,
+  newVersion: string,
+): string {
+  if (!url || !oldVersion || !newVersion || oldVersion === newVersion) return url;
+  return url.split(oldVersion).join(newVersion);
+}
+
 export function bumpVersionString(version: string): string {
   const match = version.trim().match(/^(.*?)(\d+)(\D*)$/s);
   if (!match) return "";

--- a/apps/web/src/locales/de-DE/policies.json
+++ b/apps/web/src/locales/de-DE/policies.json
@@ -1215,7 +1215,13 @@
       "installerType": "Installationstyp",
       "autoDetectFromUrl": "Automatisch aus URL erkennen",
       "autoDetectedType": "Automatisch erkannt ({{type}})",
-      "installerTypeUndetected": "Diese URL hat keine erkennbare Installationsdatei-Endung. Wählen Sie den Typ explizit aus — andernfalls wird die heruntergeladene Datei direkt ausgeführt, was bei einer MSI fehlschlägt."
+      "installerTypeUndetected": "Diese URL hat keine erkennbare Installationsdatei-Endung. Wählen Sie den Typ explizit aus — andernfalls wird die heruntergeladene Datei direkt ausgeführt, was bei einer MSI fehlschlägt.",
+      "uploadsRequireS3Storage": "Datei-Uploads erfordern einen auf dem Server konfigurierten S3-Objektspeicher.",
+      "scope": "Geltungsbereich",
+      "allOrganizations": "Alle Organisationen",
+      "sharedAcrossAllYourOrganizations": "— für alle Ihre Organisationen freigegeben",
+      "thisOrganizationOnly": "Nur diese Organisation",
+      "partnerWideUrlOnly": "Partnerweite Pakete verwenden eine Download-URL — Datei-Upload ist für sie noch nicht verfügbar."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Verwaltet integriert",
@@ -1435,7 +1441,11 @@
       "deviceCount_other": "{{count}} Geräte",
       "groupCount_one": "{{count}} Gruppe",
       "groupCount_other": "{{count}} Gruppen",
-      "viewDeployment": "Bereitstellung anzeigen"
+      "viewDeployment": "Bereitstellung anzeigen",
+      "deployingTo": "Bereitstellung für",
+      "customer": "Kunde",
+      "allTargetsBelongToThisCustomer": "Alle ausgewählten Ziele gehören zu diesem Kunden.",
+      "allOrgsSelectCustomer": "Sie sehen alle Organisationen. Wählen Sie im Organisations-Umschalter einen Kunden aus, um diese Bereitstellung zu adressieren."
     },
     "detectionRulesEditor": {
       "detectionRules": "Erkennungsregeln",
@@ -1714,7 +1724,9 @@
       "installerType": "Installationstyp",
       "autoDetectFromUrl": "Automatisch aus URL erkennen",
       "autoDetectedType": "Automatisch erkannt ({{type}})",
-      "installerTypeUndetected": "Diese URL hat keine erkennbare Installationsdatei-Endung. Wählen Sie den Typ explizit aus — andernfalls wird die heruntergeladene Datei direkt ausgeführt, was bei einer MSI fehlschlägt."
+      "installerTypeUndetected": "Diese URL hat keine erkennbare Installationsdatei-Endung. Wählen Sie den Typ explizit aus — andernfalls wird die heruntergeladene Datei direkt ausgeführt, was bei einer MSI fehlschlägt.",
+      "advancedOptions": "Erweiterte Optionen",
+      "uploadsRequireS3Storage": "Datei-Uploads erfordern einen auf dem Server konfigurierten S3-Objektspeicher."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Fügen Sie eine Bereitstellungszeitvariable ein",

--- a/apps/web/src/locales/de-DE/policies.json
+++ b/apps/web/src/locales/de-DE/policies.json
@@ -1726,7 +1726,10 @@
       "autoDetectedType": "Automatisch erkannt ({{type}})",
       "installerTypeUndetected": "Diese URL hat keine erkennbare Installationsdatei-Endung. Wählen Sie den Typ explizit aus — andernfalls wird die heruntergeladene Datei direkt ausgeführt, was bei einer MSI fehlschlägt.",
       "advancedOptions": "Erweiterte Optionen",
-      "uploadsRequireS3Storage": "Datei-Uploads erfordern einen auf dem Server konfigurierten S3-Objektspeicher."
+      "uploadsRequireS3Storage": "Datei-Uploads erfordern einen auf dem Server konfigurierten S3-Objektspeicher.",
+      "editingVersion": "Version bearbeiten",
+      "failedToUpdateVersion": "Version konnte nicht aktualisiert werden",
+      "replaceFileAddNewVersion": "Um die Installationsdatei zu ersetzen, fügen Sie stattdessen eine neue Version hinzu."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Fügen Sie eine Bereitstellungszeitvariable ein",

--- a/apps/web/src/locales/de-DE/policies.json
+++ b/apps/web/src/locales/de-DE/policies.json
@@ -1221,7 +1221,9 @@
       "allOrganizations": "Alle Organisationen",
       "sharedAcrossAllYourOrganizations": "— für alle Ihre Organisationen freigegeben",
       "thisOrganizationOnly": "Nur diese Organisation",
-      "partnerWideUrlOnly": "Partnerweite Pakete verwenden eine Download-URL — Datei-Upload ist für sie noch nicht verfügbar."
+      "partnerWideUrlOnly": "Partnerweite Pakete verwenden eine Download-URL — Datei-Upload ist für sie noch nicht verfügbar.",
+      "selectedFileRemoved": "Die ausgewählte Datei wurde entfernt — partnerweite Pakete verwenden eine Download-URL.",
+      "scopeLockedAfterCreate": "Das Paket wurde bereits mit diesem Geltungsbereich erstellt — die Zuordnung kann danach nicht mehr geändert werden."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Verwaltet integriert",

--- a/apps/web/src/locales/en/policies.json
+++ b/apps/web/src/locales/en/policies.json
@@ -1726,7 +1726,10 @@
       "autoDetectedType": "Auto-detect ({{type}})",
       "installerTypeUndetected": "This URL has no recognizable installer extension. Pick the type explicitly — otherwise the downloaded file is run directly, which fails for an MSI.",
       "advancedOptions": "Advanced options",
-      "uploadsRequireS3Storage": "File uploads require S3 object storage to be configured on the server."
+      "uploadsRequireS3Storage": "File uploads require S3 object storage to be configured on the server.",
+      "editingVersion": "Editing version",
+      "failedToUpdateVersion": "Failed to update version",
+      "replaceFileAddNewVersion": "To replace the installer file, add a new version instead."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Insert a deploy-time variable",

--- a/apps/web/src/locales/en/policies.json
+++ b/apps/web/src/locales/en/policies.json
@@ -1221,7 +1221,9 @@
       "allOrganizations": "All organizations",
       "sharedAcrossAllYourOrganizations": "— shared across all your organizations",
       "thisOrganizationOnly": "This organization only",
-      "partnerWideUrlOnly": "Partner-wide packages use a download URL — file upload is not available for them yet."
+      "partnerWideUrlOnly": "Partner-wide packages use a download URL — file upload is not available for them yet.",
+      "selectedFileRemoved": "The selected file was removed — partner-wide packages use a download URL.",
+      "scopeLockedAfterCreate": "The package was already created with this scope — ownership cannot change after creation."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Managed built-in",

--- a/apps/web/src/locales/en/policies.json
+++ b/apps/web/src/locales/en/policies.json
@@ -1215,7 +1215,13 @@
       "installerType": "Installer type",
       "autoDetectFromUrl": "Auto-detect from URL",
       "autoDetectedType": "Auto-detect ({{type}})",
-      "installerTypeUndetected": "This URL has no recognizable installer extension. Pick the type explicitly — otherwise the downloaded file is run directly, which fails for an MSI."
+      "installerTypeUndetected": "This URL has no recognizable installer extension. Pick the type explicitly — otherwise the downloaded file is run directly, which fails for an MSI.",
+      "uploadsRequireS3Storage": "File uploads require S3 object storage to be configured on the server.",
+      "scope": "Scope",
+      "allOrganizations": "All organizations",
+      "sharedAcrossAllYourOrganizations": "— shared across all your organizations",
+      "thisOrganizationOnly": "This organization only",
+      "partnerWideUrlOnly": "Partner-wide packages use a download URL — file upload is not available for them yet."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Managed built-in",
@@ -1435,7 +1441,11 @@
       "deviceCount_other": "{{count}} devices",
       "groupCount_one": "{{count}} group",
       "groupCount_other": "{{count}} groups",
-      "viewDeployment": "View deployment"
+      "viewDeployment": "View deployment",
+      "deployingTo": "Deploying to",
+      "customer": "Customer",
+      "allTargetsBelongToThisCustomer": "All selected targets belong to this customer.",
+      "allOrgsSelectCustomer": "You're viewing all organizations. Pick a customer in the organization switcher to target this deployment."
     },
     "detectionRulesEditor": {
       "detectionRules": "Detection Rules",
@@ -1714,7 +1724,9 @@
       "installerType": "Installer type",
       "autoDetectFromUrl": "Auto-detect from URL",
       "autoDetectedType": "Auto-detect ({{type}})",
-      "installerTypeUndetected": "This URL has no recognizable installer extension. Pick the type explicitly — otherwise the downloaded file is run directly, which fails for an MSI."
+      "installerTypeUndetected": "This URL has no recognizable installer extension. Pick the type explicitly — otherwise the downloaded file is run directly, which fails for an MSI.",
+      "advancedOptions": "Advanced options",
+      "uploadsRequireS3Storage": "File uploads require S3 object storage to be configured on the server."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Insert a deploy-time variable",

--- a/apps/web/src/locales/es-419/policies.json
+++ b/apps/web/src/locales/es-419/policies.json
@@ -1221,7 +1221,9 @@
       "allOrganizations": "Todas las organizaciones",
       "sharedAcrossAllYourOrganizations": "— compartido entre todas tus organizaciones",
       "thisOrganizationOnly": "Solo esta organización",
-      "partnerWideUrlOnly": "Los paquetes a nivel de socio usan una URL de descarga — la carga de archivos aún no está disponible para ellos."
+      "partnerWideUrlOnly": "Los paquetes a nivel de socio usan una URL de descarga — la carga de archivos aún no está disponible para ellos.",
+      "selectedFileRemoved": "Se quitó el archivo seleccionado — los paquetes a nivel de socio usan una URL de descarga.",
+      "scopeLockedAfterCreate": "El paquete ya se creó con este alcance — la propiedad no puede cambiar después de la creación."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Gestionado integrado",

--- a/apps/web/src/locales/es-419/policies.json
+++ b/apps/web/src/locales/es-419/policies.json
@@ -1215,7 +1215,13 @@
       "installerType": "Tipo de instalador",
       "autoDetectFromUrl": "Detectar automáticamente desde la URL",
       "autoDetectedType": "Detección automática ({{type}})",
-      "installerTypeUndetected": "Esta URL no tiene una extensión de instalador reconocible. Elija el tipo explícitamente; de lo contrario, el archivo descargado se ejecuta directamente, lo que falla con un MSI."
+      "installerTypeUndetected": "Esta URL no tiene una extensión de instalador reconocible. Elija el tipo explícitamente; de lo contrario, el archivo descargado se ejecuta directamente, lo que falla con un MSI.",
+      "uploadsRequireS3Storage": "La carga de archivos requiere un almacenamiento de objetos S3 configurado en el servidor.",
+      "scope": "Alcance",
+      "allOrganizations": "Todas las organizaciones",
+      "sharedAcrossAllYourOrganizations": "— compartido entre todas tus organizaciones",
+      "thisOrganizationOnly": "Solo esta organización",
+      "partnerWideUrlOnly": "Los paquetes a nivel de socio usan una URL de descarga — la carga de archivos aún no está disponible para ellos."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Gestionado integrado",
@@ -1435,7 +1441,11 @@
       "deviceCount_other": "dispositivos {{count}}",
       "groupCount_one": "grupo {{count}}",
       "groupCount_other": "grupos {{count}}",
-      "viewDeployment": "Ver implementación"
+      "viewDeployment": "Ver implementación",
+      "deployingTo": "Implementando en",
+      "customer": "Cliente",
+      "allTargetsBelongToThisCustomer": "Todos los objetivos seleccionados pertenecen a este cliente.",
+      "allOrgsSelectCustomer": "Estás viendo todas las organizaciones. Elige un cliente en el selector de organizaciones para dirigir esta implementación."
     },
     "detectionRulesEditor": {
       "detectionRules": "Reglas de detección",
@@ -1714,7 +1724,9 @@
       "installerType": "Tipo de instalador",
       "autoDetectFromUrl": "Detectar automáticamente desde la URL",
       "autoDetectedType": "Detección automática ({{type}})",
-      "installerTypeUndetected": "Esta URL no tiene una extensión de instalador reconocible. Elija el tipo explícitamente; de lo contrario, el archivo descargado se ejecuta directamente, lo que falla con un MSI."
+      "installerTypeUndetected": "Esta URL no tiene una extensión de instalador reconocible. Elija el tipo explícitamente; de lo contrario, el archivo descargado se ejecuta directamente, lo que falla con un MSI.",
+      "advancedOptions": "Opciones avanzadas",
+      "uploadsRequireS3Storage": "La carga de archivos requiere un almacenamiento de objetos S3 configurado en el servidor."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Insertar una variable de tiempo de implementación",

--- a/apps/web/src/locales/es-419/policies.json
+++ b/apps/web/src/locales/es-419/policies.json
@@ -1726,7 +1726,10 @@
       "autoDetectedType": "Detección automática ({{type}})",
       "installerTypeUndetected": "Esta URL no tiene una extensión de instalador reconocible. Elija el tipo explícitamente; de lo contrario, el archivo descargado se ejecuta directamente, lo que falla con un MSI.",
       "advancedOptions": "Opciones avanzadas",
-      "uploadsRequireS3Storage": "La carga de archivos requiere un almacenamiento de objetos S3 configurado en el servidor."
+      "uploadsRequireS3Storage": "La carga de archivos requiere un almacenamiento de objetos S3 configurado en el servidor.",
+      "editingVersion": "Editando versión",
+      "failedToUpdateVersion": "No se pudo actualizar la versión",
+      "replaceFileAddNewVersion": "Para reemplazar el archivo del instalador, agrega una nueva versión."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Insertar una variable de tiempo de implementación",

--- a/apps/web/src/locales/fr-CA/policies.json
+++ b/apps/web/src/locales/fr-CA/policies.json
@@ -1215,7 +1215,13 @@
       "installerType": "Type d'installateur",
       "autoDetectFromUrl": "Détecter automatiquement depuis l'URL",
       "autoDetectedType": "Détection automatique ({{type}})",
-      "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI."
+      "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI.",
+      "uploadsRequireS3Storage": "Le téléversement de fichiers nécessite la configuration d'un stockage objet S3 sur le serveur.",
+      "scope": "Portée",
+      "allOrganizations": "Toutes les organisations",
+      "sharedAcrossAllYourOrganizations": "— partagé entre toutes vos organisations",
+      "thisOrganizationOnly": "Cette organisation uniquement",
+      "partnerWideUrlOnly": "Les paquets partenaire utilisent une URL de téléchargement — le téléversement de fichiers n'est pas encore disponible pour eux."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Intégré géré",
@@ -1435,7 +1441,11 @@
       "deviceCount_other": "{{count}} dispositifs",
       "groupCount_one": "{{count}} groupe",
       "groupCount_other": "{{count}} groupes",
-      "viewDeployment": "Voir le déploiement"
+      "viewDeployment": "Voir le déploiement",
+      "deployingTo": "Déploiement vers",
+      "customer": "Client",
+      "allTargetsBelongToThisCustomer": "Toutes les cibles sélectionnées appartiennent à ce client.",
+      "allOrgsSelectCustomer": "Vous consultez toutes les organisations. Choisissez un client dans le sélecteur d'organisation pour cibler ce déploiement."
     },
     "detectionRulesEditor": {
       "detectionRules": "Règles de détection",
@@ -1714,7 +1724,9 @@
       "installerType": "Type d'installateur",
       "autoDetectFromUrl": "Détecter automatiquement depuis l'URL",
       "autoDetectedType": "Détection automatique ({{type}})",
-      "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI."
+      "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI.",
+      "advancedOptions": "Options avancées",
+      "uploadsRequireS3Storage": "Le téléversement de fichiers nécessite la configuration d'un stockage objet S3 sur le serveur."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Insérer une variable de temps de déploiement",

--- a/apps/web/src/locales/fr-CA/policies.json
+++ b/apps/web/src/locales/fr-CA/policies.json
@@ -1726,7 +1726,10 @@
       "autoDetectedType": "Détection automatique ({{type}})",
       "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI.",
       "advancedOptions": "Options avancées",
-      "uploadsRequireS3Storage": "Le téléversement de fichiers nécessite la configuration d'un stockage objet S3 sur le serveur."
+      "uploadsRequireS3Storage": "Le téléversement de fichiers nécessite la configuration d'un stockage objet S3 sur le serveur.",
+      "editingVersion": "Modification de la version",
+      "failedToUpdateVersion": "Échec de la mise à jour de la version",
+      "replaceFileAddNewVersion": "Pour remplacer le fichier d'installation, ajoutez plutôt une nouvelle version."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Insérer une variable de temps de déploiement",

--- a/apps/web/src/locales/fr-CA/policies.json
+++ b/apps/web/src/locales/fr-CA/policies.json
@@ -1221,7 +1221,9 @@
       "allOrganizations": "Toutes les organisations",
       "sharedAcrossAllYourOrganizations": "— partagé entre toutes vos organisations",
       "thisOrganizationOnly": "Cette organisation uniquement",
-      "partnerWideUrlOnly": "Les paquets partenaire utilisent une URL de téléchargement — le téléversement de fichiers n'est pas encore disponible pour eux."
+      "partnerWideUrlOnly": "Les paquets partenaire utilisent une URL de téléchargement — le téléversement de fichiers n'est pas encore disponible pour eux.",
+      "selectedFileRemoved": "Le fichier sélectionné a été retiré — les paquets partenaire utilisent une URL de téléchargement.",
+      "scopeLockedAfterCreate": "Le paquet a déjà été créé avec cette portée — la propriété ne peut pas changer après la création."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Intégré géré",

--- a/apps/web/src/locales/fr-FR/policies.json
+++ b/apps/web/src/locales/fr-FR/policies.json
@@ -1215,7 +1215,13 @@
       "installerType": "Type d'installateur",
       "autoDetectFromUrl": "Détecter automatiquement depuis l'URL",
       "autoDetectedType": "Détection automatique ({{type}})",
-      "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI."
+      "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI.",
+      "uploadsRequireS3Storage": "Le téléversement de fichiers nécessite la configuration d'un stockage objet S3 sur le serveur.",
+      "scope": "Portée",
+      "allOrganizations": "Toutes les organisations",
+      "sharedAcrossAllYourOrganizations": "— partagé entre toutes vos organisations",
+      "thisOrganizationOnly": "Cette organisation uniquement",
+      "partnerWideUrlOnly": "Les paquets partenaire utilisent une URL de téléchargement — le téléversement de fichiers n'est pas encore disponible pour eux."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Intégré géré",
@@ -1435,7 +1441,11 @@
       "deviceCount_other": "{{count}} dispositifs",
       "groupCount_one": "{{count}} groupe",
       "groupCount_other": "{{count}} groupes",
-      "viewDeployment": "Voir le déploiement"
+      "viewDeployment": "Voir le déploiement",
+      "deployingTo": "Déploiement vers",
+      "customer": "Client",
+      "allTargetsBelongToThisCustomer": "Toutes les cibles sélectionnées appartiennent à ce client.",
+      "allOrgsSelectCustomer": "Vous consultez toutes les organisations. Choisissez un client dans le sélecteur d'organisation pour cibler ce déploiement."
     },
     "detectionRulesEditor": {
       "detectionRules": "Règles de détection",
@@ -1714,7 +1724,9 @@
       "installerType": "Type d'installateur",
       "autoDetectFromUrl": "Détecter automatiquement depuis l'URL",
       "autoDetectedType": "Détection automatique ({{type}})",
-      "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI."
+      "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI.",
+      "advancedOptions": "Options avancées",
+      "uploadsRequireS3Storage": "Le téléversement de fichiers nécessite la configuration d'un stockage objet S3 sur le serveur."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Insérer une variable de temps de déploiement",

--- a/apps/web/src/locales/fr-FR/policies.json
+++ b/apps/web/src/locales/fr-FR/policies.json
@@ -1726,7 +1726,10 @@
       "autoDetectedType": "Détection automatique ({{type}})",
       "installerTypeUndetected": "Cette URL n'a pas d'extension d'installateur reconnaissable. Choisissez le type explicitement — sinon le fichier téléchargé est exécuté directement, ce qui échoue pour un MSI.",
       "advancedOptions": "Options avancées",
-      "uploadsRequireS3Storage": "Le téléversement de fichiers nécessite la configuration d'un stockage objet S3 sur le serveur."
+      "uploadsRequireS3Storage": "Le téléversement de fichiers nécessite la configuration d'un stockage objet S3 sur le serveur.",
+      "editingVersion": "Modification de la version",
+      "failedToUpdateVersion": "Échec de la mise à jour de la version",
+      "replaceFileAddNewVersion": "Pour remplacer le fichier d'installation, ajoutez plutôt une nouvelle version."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Insérer une variable de temps de déploiement",

--- a/apps/web/src/locales/fr-FR/policies.json
+++ b/apps/web/src/locales/fr-FR/policies.json
@@ -1221,7 +1221,9 @@
       "allOrganizations": "Toutes les organisations",
       "sharedAcrossAllYourOrganizations": "— partagé entre toutes vos organisations",
       "thisOrganizationOnly": "Cette organisation uniquement",
-      "partnerWideUrlOnly": "Les paquets partenaire utilisent une URL de téléchargement — le téléversement de fichiers n'est pas encore disponible pour eux."
+      "partnerWideUrlOnly": "Les paquets partenaire utilisent une URL de téléchargement — le téléversement de fichiers n'est pas encore disponible pour eux.",
+      "selectedFileRemoved": "Le fichier sélectionné a été retiré — les paquets partenaire utilisent une URL de téléchargement.",
+      "scopeLockedAfterCreate": "Le paquet a déjà été créé avec cette portée — la propriété ne peut pas changer après la création."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Intégré géré",

--- a/apps/web/src/locales/it-IT/policies.json
+++ b/apps/web/src/locales/it-IT/policies.json
@@ -1726,7 +1726,10 @@
       "autoDetectedType": "Rilevamento automatico ({{type}})",
       "installerTypeUndetected": "Questo URL non ha un'estensione di installer riconoscibile. Scegli il tipo esplicitamente, altrimenti il file scaricato viene eseguito direttamente, cosa che fallisce per un MSI.",
       "advancedOptions": "Opzioni avanzate",
-      "uploadsRequireS3Storage": "Il caricamento di file richiede uno storage a oggetti S3 configurato sul server."
+      "uploadsRequireS3Storage": "Il caricamento di file richiede uno storage a oggetti S3 configurato sul server.",
+      "editingVersion": "Modifica della versione",
+      "failedToUpdateVersion": "Impossibile aggiornare la versione",
+      "replaceFileAddNewVersion": "Per sostituire il file di installazione, aggiungi invece una nuova versione."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Inserisci una variabile di distribuzione",

--- a/apps/web/src/locales/it-IT/policies.json
+++ b/apps/web/src/locales/it-IT/policies.json
@@ -1221,7 +1221,9 @@
       "allOrganizations": "Tutte le organizzazioni",
       "sharedAcrossAllYourOrganizations": "— condiviso tra tutte le tue organizzazioni",
       "thisOrganizationOnly": "Solo questa organizzazione",
-      "partnerWideUrlOnly": "I pacchetti a livello di partner usano un URL di download — il caricamento di file non è ancora disponibile per loro."
+      "partnerWideUrlOnly": "I pacchetti a livello di partner usano un URL di download — il caricamento di file non è ancora disponibile per loro.",
+      "selectedFileRemoved": "Il file selezionato è stato rimosso — i pacchetti a livello di partner usano un URL di download.",
+      "scopeLockedAfterCreate": "Il pacchetto è già stato creato con questo ambito — la proprietà non può cambiare dopo la creazione."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Integrato gestito",

--- a/apps/web/src/locales/it-IT/policies.json
+++ b/apps/web/src/locales/it-IT/policies.json
@@ -1215,7 +1215,13 @@
       "installerType": "Tipo di installer",
       "autoDetectFromUrl": "Rilevamento automatico dall'URL",
       "autoDetectedType": "Rilevamento automatico ({{type}})",
-      "installerTypeUndetected": "Questo URL non ha un'estensione di installer riconoscibile. Scegli il tipo esplicitamente, altrimenti il file scaricato viene eseguito direttamente, cosa che fallisce per un MSI."
+      "installerTypeUndetected": "Questo URL non ha un'estensione di installer riconoscibile. Scegli il tipo esplicitamente, altrimenti il file scaricato viene eseguito direttamente, cosa che fallisce per un MSI.",
+      "uploadsRequireS3Storage": "Il caricamento di file richiede uno storage a oggetti S3 configurato sul server.",
+      "scope": "Ambito",
+      "allOrganizations": "Tutte le organizzazioni",
+      "sharedAcrossAllYourOrganizations": "— condiviso tra tutte le tue organizzazioni",
+      "thisOrganizationOnly": "Solo questa organizzazione",
+      "partnerWideUrlOnly": "I pacchetti a livello di partner usano un URL di download — il caricamento di file non è ancora disponibile per loro."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Integrato gestito",
@@ -1435,7 +1441,11 @@
       "deviceCount_other": "{{count}} dispositivi",
       "groupCount_one": "{{count}} gruppo",
       "groupCount_other": "{{count}} gruppi",
-      "viewDeployment": "Visualizza distribuzione"
+      "viewDeployment": "Visualizza distribuzione",
+      "deployingTo": "Distribuzione a",
+      "customer": "Cliente",
+      "allTargetsBelongToThisCustomer": "Tutti i target selezionati appartengono a questo cliente.",
+      "allOrgsSelectCustomer": "Stai visualizzando tutte le organizzazioni. Scegli un cliente nel selettore delle organizzazioni per indirizzare questa distribuzione."
     },
     "detectionRulesEditor": {
       "detectionRules": "Regole di rilevamento",
@@ -1714,7 +1724,9 @@
       "installerType": "Tipo di installer",
       "autoDetectFromUrl": "Rilevamento automatico dall'URL",
       "autoDetectedType": "Rilevamento automatico ({{type}})",
-      "installerTypeUndetected": "Questo URL non ha un'estensione di installer riconoscibile. Scegli il tipo esplicitamente, altrimenti il file scaricato viene eseguito direttamente, cosa che fallisce per un MSI."
+      "installerTypeUndetected": "Questo URL non ha un'estensione di installer riconoscibile. Scegli il tipo esplicitamente, altrimenti il file scaricato viene eseguito direttamente, cosa che fallisce per un MSI.",
+      "advancedOptions": "Opzioni avanzate",
+      "uploadsRequireS3Storage": "Il caricamento di file richiede uno storage a oggetti S3 configurato sul server."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Inserisci una variabile di distribuzione",

--- a/apps/web/src/locales/pt-BR/policies.json
+++ b/apps/web/src/locales/pt-BR/policies.json
@@ -1215,7 +1215,13 @@
       "installerType": "Tipo de instalador",
       "autoDetectFromUrl": "Detectar automaticamente pela URL",
       "autoDetectedType": "Detecção automática ({{type}})",
-      "installerTypeUndetected": "Esta URL não tem uma extensão de instalador reconhecível. Escolha o tipo explicitamente — caso contrário, o arquivo baixado é executado diretamente, o que falha para um MSI."
+      "installerTypeUndetected": "Esta URL não tem uma extensão de instalador reconhecível. Escolha o tipo explicitamente — caso contrário, o arquivo baixado é executado diretamente, o que falha para um MSI.",
+      "uploadsRequireS3Storage": "O upload de arquivos requer um armazenamento de objetos S3 configurado no servidor.",
+      "scope": "Escopo",
+      "allOrganizations": "Todas as organizações",
+      "sharedAcrossAllYourOrganizations": "— compartilhado entre todas as suas organizações",
+      "thisOrganizationOnly": "Apenas esta organização",
+      "partnerWideUrlOnly": "Pacotes de nível de parceiro usam uma URL de download — o upload de arquivos ainda não está disponível para eles."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Integrado gerenciado",
@@ -1435,7 +1441,11 @@
       "deviceCount_other": "{{count}} dispositivos",
       "groupCount_one": "{{count}} grupo",
       "groupCount_other": "{{count}} grupos",
-      "viewDeployment": "Ver implantação"
+      "viewDeployment": "Ver implantação",
+      "deployingTo": "Implantando para",
+      "customer": "Cliente",
+      "allTargetsBelongToThisCustomer": "Todos os alvos selecionados pertencem a este cliente.",
+      "allOrgsSelectCustomer": "Você está vendo todas as organizações. Escolha um cliente no seletor de organizações para direcionar esta implantação."
     },
     "detectionRulesEditor": {
       "detectionRules": "Regras de detecção",
@@ -1714,7 +1724,9 @@
       "installerType": "Tipo de instalador",
       "autoDetectFromUrl": "Detectar automaticamente pela URL",
       "autoDetectedType": "Detecção automática ({{type}})",
-      "installerTypeUndetected": "Esta URL não tem uma extensão de instalador reconhecível. Escolha o tipo explicitamente — caso contrário, o arquivo baixado é executado diretamente, o que falha para um MSI."
+      "installerTypeUndetected": "Esta URL não tem uma extensão de instalador reconhecível. Escolha o tipo explicitamente — caso contrário, o arquivo baixado é executado diretamente, o que falha para um MSI.",
+      "advancedOptions": "Opções avançadas",
+      "uploadsRequireS3Storage": "O upload de arquivos requer um armazenamento de objetos S3 configurado no servidor."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Inserir uma variável de tempo de implantação",

--- a/apps/web/src/locales/pt-BR/policies.json
+++ b/apps/web/src/locales/pt-BR/policies.json
@@ -1221,7 +1221,9 @@
       "allOrganizations": "Todas as organizações",
       "sharedAcrossAllYourOrganizations": "— compartilhado entre todas as suas organizações",
       "thisOrganizationOnly": "Apenas esta organização",
-      "partnerWideUrlOnly": "Pacotes de nível de parceiro usam uma URL de download — o upload de arquivos ainda não está disponível para eles."
+      "partnerWideUrlOnly": "Pacotes de nível de parceiro usam uma URL de download — o upload de arquivos ainda não está disponível para eles.",
+      "selectedFileRemoved": "O arquivo selecionado foi removido — pacotes de nível de parceiro usam uma URL de download.",
+      "scopeLockedAfterCreate": "O pacote já foi criado com este escopo — a propriedade não pode mudar após a criação."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Integrado gerenciado",

--- a/apps/web/src/locales/pt-BR/policies.json
+++ b/apps/web/src/locales/pt-BR/policies.json
@@ -1726,7 +1726,10 @@
       "autoDetectedType": "Detecção automática ({{type}})",
       "installerTypeUndetected": "Esta URL não tem uma extensão de instalador reconhecível. Escolha o tipo explicitamente — caso contrário, o arquivo baixado é executado diretamente, o que falha para um MSI.",
       "advancedOptions": "Opções avançadas",
-      "uploadsRequireS3Storage": "O upload de arquivos requer um armazenamento de objetos S3 configurado no servidor."
+      "uploadsRequireS3Storage": "O upload de arquivos requer um armazenamento de objetos S3 configurado no servidor.",
+      "editingVersion": "Editando versão",
+      "failedToUpdateVersion": "Falha ao atualizar a versão",
+      "replaceFileAddNewVersion": "Para substituir o arquivo do instalador, adicione uma nova versão."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Inserir uma variável de tempo de implantação",

--- a/apps/web/src/stores/featuresStore.test.ts
+++ b/apps/web/src/stores/featuresStore.test.ts
@@ -19,8 +19,32 @@ describe('featuresStore', () => {
       features: { billing: false, support: false },
       cfAccessLogin: { enabled: false },
       registration: { enabled: false },
+      softwarePackages: { uploadsEnabled: true },
       loaded: false,
     });
+  });
+
+  // Package uploads gate is deliberately FAIL-OPEN (opposite of registration):
+  // a missing field (older API) or unreachable /config must never gray out
+  // uploads that would work — worst case the user hits the routes' own 503.
+  it('softwarePackages.uploadsEnabled false only when /config says false', async () => {
+    fetchMock.mockResolvedValueOnce(res({ softwarePackages: { uploadsEnabled: false } }));
+    await useFeaturesStore.getState().load();
+    expect(useFeaturesStore.getState().softwarePackages).toEqual({ uploadsEnabled: false });
+  });
+
+  it('softwarePackages.uploadsEnabled stays open when /config omits the field (older API)', async () => {
+    fetchMock.mockResolvedValueOnce(res({ features: { billing: true, support: true } }));
+    await useFeaturesStore.getState().load();
+    expect(useFeaturesStore.getState().softwarePackages).toEqual({ uploadsEnabled: true });
+  });
+
+  it('softwarePackages.uploadsEnabled stays open when /config is unreachable', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock.mockRejectedValueOnce(new Error('network'));
+    await useFeaturesStore.getState().load();
+    expect(useFeaturesStore.getState().softwarePackages).toEqual({ uploadsEnabled: true });
+    errSpy.mockRestore();
   });
 
   it('loads features from /config', async () => {

--- a/apps/web/src/stores/featuresStore.ts
+++ b/apps/web/src/stores/featuresStore.ts
@@ -15,10 +15,15 @@ export interface RegistrationConfig {
   enabled: boolean;
 }
 
+export interface SoftwarePackagesConfig {
+  uploadsEnabled: boolean;
+}
+
 interface FeaturesState {
   features: Features;
   cfAccessLogin: CfAccessLoginConfig;
   registration: RegistrationConfig;
+  softwarePackages: SoftwarePackagesConfig;
   loaded: boolean;
   load: () => Promise<void>;
 }
@@ -28,11 +33,16 @@ const DEFAULT_CF_ACCESS: CfAccessLoginConfig = { enabled: false };
 // Default closed: until /config confirms registration is open we hide the
 // registration UI rather than flash a link that may be disabled (#1308).
 const DEFAULT_REGISTRATION: RegistrationConfig = { enabled: false };
+// Default OPEN, unlike registration: if /config is unreachable (or an older
+// API doesn't return the field) we must not gray out uploads that would work —
+// worst case the user hits the same 503 the upload routes already return.
+const DEFAULT_SOFTWARE_PACKAGES: SoftwarePackagesConfig = { uploadsEnabled: true };
 
 export const useFeaturesStore = create<FeaturesState>()((set, get) => ({
   features: DEFAULT_FEATURES,
   cfAccessLogin: DEFAULT_CF_ACCESS,
   registration: DEFAULT_REGISTRATION,
+  softwarePackages: DEFAULT_SOFTWARE_PACKAGES,
   loaded: false,
   load: async () => {
     if (get().loaded) return;
@@ -47,6 +57,7 @@ export const useFeaturesStore = create<FeaturesState>()((set, get) => ({
         features?: Partial<Features>;
         cfAccessLogin?: Partial<CfAccessLoginConfig>;
         registration?: Partial<RegistrationConfig>;
+        softwarePackages?: Partial<SoftwarePackagesConfig>;
       };
       set({
         features: {
@@ -58,6 +69,10 @@ export const useFeaturesStore = create<FeaturesState>()((set, get) => ({
         },
         registration: {
           enabled: !!data.registration?.enabled,
+        },
+        softwarePackages: {
+          // Missing field (older API) keeps the open default.
+          uploadsEnabled: data.softwarePackages?.uploadsEnabled !== false,
         },
         loaded: true,
       });
@@ -83,5 +98,22 @@ export function useRegistrationGate(): { enabled: boolean; loaded: boolean } {
   useEffect(() => {
     void load();
   }, [load]);
+  return { enabled, loaded };
+}
+
+// Whether software package file uploads are possible (S3 storage configured on
+// the server). Defaults open until /config says otherwise — see
+// DEFAULT_SOFTWARE_PACKAGES above. Pass `active: false` to defer the /config
+// fetch until the consuming surface is actually shown (e.g. a closed modal).
+export function usePackageUploadsGate(active = true): {
+  enabled: boolean;
+  loaded: boolean;
+} {
+  const enabled = useFeaturesStore((s) => s.softwarePackages.uploadsEnabled);
+  const loaded = useFeaturesStore((s) => s.loaded);
+  const load = useFeaturesStore((s) => s.load);
+  useEffect(() => {
+    if (active) void load();
+  }, [active, load]);
   return { enabled, loaded };
 }


### PR DESCRIPTION
## Summary

Batch of software-deploy fixes from a UX pass, plus two features that fell out of it: partner-wide catalog packages and in-place version editing.

### UX fixes
- **Customer context is explicit in the Deployment Wizard**: a "Deploying to *\<customer\>*" `ScopeBadge` in the header, a Customer card on the Review step, and an amber notice in the All-organizations view (where the create previously died with a bare `orgId is required` 400).
- **"Args field twice"**: the Add Version form's install/uninstall args sat side-by-side with near-identical truncated placeholders and read as a duplicated field. The form now mirrors AddPackageModal — uninstall args, detection rules and release notes live behind an Advanced disclosure.
- **OS auto-select + MSI auto-fill** (`lib/installerPackageHints.ts`): `.msi`/`.exe` → Windows, `.dmg`/`.pkg` → macOS, `.deb` → Linux, and msiexec silent install/uninstall args for MSIs — derived from both the picked file **and** the download URL, never overwriting user-set values.
- **Upload grayed out without S3**: `GET /api/v1/config` now exposes `softwarePackages.uploadsEnabled` (`isS3Configured()`); both package forms disable the file source with an explanatory hint instead of 503ing after the user picked a 400MB file. Fail-open on missing field/unreachable config so older APIs never lose working uploads.

### Partner-wide packages (#2135 Partner-Wide First)
`software_catalog` was already dual-axis (built-in EDR packages use the partner axis) — only the routes were org-only. **No migration needed.**
- `POST /software/catalog` accepts `ownerScope: 'partner'` gated on `canManagePartnerWidePolicies`; the partner is always the caller's own.
- Catalog get/patch/delete, version create/patch/promote, versions list, download-url and search are now dual-axis (fetch-by-id + `authorizeCatalogItemWrite`: 404 for foreign rows, 403 for visible-but-unadministrable). This also fixes several spurious 400s in the All-organizations view.
- Built-in packages: catalog row stays immutable (403); **version-level writes remain allowed for full partner admins** — that is the documented SentinelOne installer-upload flow the `2026-07-02` RLS migration exists for.
- Web: canonical owner-scope selector in AddPackageModal (`useDefaultOwnerScope`, defaults to partner-wide in the All-orgs view), "Partner-wide" `ScopeBadge` on cards and detail.
- **Limitation**: chunked upload sessions are org-tenanted (`software_upload_sessions.org_id NOT NULL`), so partner-wide packages are **URL-only** for now — explicit 400 + disabled UI, not a 500. Follow-up: partner axis on upload sessions (full playbook: migration + RLS + cascade/export registration). Also, partner-wide custom packages are invisible to org-scope tokens (portal/org API keys) — the RLS read branch only covers built-ins; a `cis_baselines`-style SELECT policy is the fix if that ever matters.

### Version editing + prefilled add
- New `PATCH /software/catalog/:id/versions/:versionId` for metadata (explicit null clears nullable fields; binary fields immutable; a URL-only version can't lose its URL; audited with changed-field list).
- Per-row **Edit** opens the shared form in edit mode (no file picker — replacing the installer means a new version) and updates the row in place.
- **Add Version prefills from the latest version**: version auto-bumped (`lib/versionBump.ts` — last numeric segment, padding/suffix preserved), URL carried over **with the old version substituted for the bumped one** (`app-1.2.3.msi` → `app-1.2.4.msi`), args/arch/OS/detection rules carried, release notes empty.

### Dispatch correctness fix
URL-only versions have no stamped `file_type` and dispatched as `'exe'`, so a URL-sourced `.msi` was executed as a program on the device instead of routed through msiexec (the agent handles MSIs correctly given the right type — it even defaults empty args to `msiexec /i {file} /qn /norestart`). `inferFileTypeFromUrl` now derives the type from the resolved per-device URL.

### Review round
Four-agent review (code, silent-failure, test-coverage, comments) ran on the branch; all confirmed findings fixed in the final commit — notably the upload-session org-resolution divergence (create vs chunk routes), the `/catalog/search` sweep miss, owner-scope locking after a partial-failure retry, and deny-path test coverage for every route using the new write guard.

## Testing
- API: `software.test.ts` 97, `softwareUploads.test.ts` 50, `config.test.ts`, `softwareDeployment.test.ts` — 194 green; tsc clean.
- Web: software components + stores + libs + i18n parity + no-silent-mutations — 479 green; `astro check` 0 errors; eslint clean.
- All 7 locales updated for every new string.
- No schema changes → no cascade/export-policy registrations owed; `software_catalog` dual-axis RLS already contract-tested.
- Not done: live browser pass — worth a click-through of AddPackageModal in partner vs customer context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)