### PR TITLE
fix(api): rate-limit HP/Lenovo warranty lookups at the request boundary (#3201)

### DIFF
--- a/apps/api/src/services/warrantyProviders/hpProvider.ts
+++ b/apps/api/src/services/warrantyProviders/hpProvider.ts
@@ -1,4 +1,5 @@
 import type { WarrantyProvider, WarrantyLookupResult, WarrantyEntitlement } from './types';
+import { hpRateLimiter } from './throttle';
 
 export const hpProvider: WarrantyProvider = {
   name: 'hp',
@@ -17,8 +18,11 @@ export const hpProvider: WarrantyProvider = {
   async lookup(serialNumbers: string[]): Promise<Map<string, WarrantyLookupResult>> {
     const results = new Map<string, WarrantyLookupResult>();
 
-    // HP unofficial API — single serial lookup, no batching
+    // HP unofficial API — single serial lookup, no batching. Rate-limit at the
+    // request boundary so a whole-fleet sync (one single-serial call per device,
+    // across concurrent workers) doesn't burst the endpoint (#3201).
     for (const sn of serialNumbers) {
+      await hpRateLimiter.acquire();
       try {
         const response = await fetch(
           `https://support.hp.com/hp-pps-api/os/getWarrantyInfo?serialNumber=${encodeURIComponent(sn)}&country=US`,

--- a/apps/api/src/services/warrantyProviders/lenovoProvider.ts
+++ b/apps/api/src/services/warrantyProviders/lenovoProvider.ts
@@ -1,4 +1,5 @@
 import type { WarrantyProvider, WarrantyLookupResult, WarrantyEntitlement } from './types';
+import { lenovoRateLimiter } from './throttle';
 
 export const lenovoProvider: WarrantyProvider = {
   name: 'lenovo',
@@ -28,7 +29,11 @@ export const lenovoProvider: WarrantyProvider = {
       return results;
     }
 
+    // Rate-limit at the request boundary so a whole-fleet sync (one single-serial
+    // call per device, across concurrent workers) doesn't burst Lenovo's API and
+    // get the source IP rate-limited (#3201).
     for (const sn of serialNumbers) {
+      await lenovoRateLimiter.acquire();
       try {
         const response = await fetch(
           `https://pcsupport.lenovo.com/us/en/api/v4/upsell/redport/getIbaseInfo?Serial=${encodeURIComponent(sn)}`,

--- a/apps/api/src/services/warrantyProviders/throttle.ts
+++ b/apps/api/src/services/warrantyProviders/throttle.ts
@@ -1,0 +1,49 @@
+// Per-provider request rate limiter for the third-party warranty lookups (HP's
+// unofficial support endpoint, Lenovo's pcsupport API).
+//
+// Warranty sync makes ONE single-serial `lookup()` call PER DEVICE (see
+// warrantySync.ts), across up to 3 concurrent worker jobs in this process, so
+// spacing serials *within* a lookup() call throttles nothing — every real call
+// has exactly one serial. The limit must be enforced ACROSS calls at the
+// vendor-request boundary. `acquire()` serializes and spaces every fetch to at
+// least `minIntervalMs` apart, coordinating all lookup() calls and concurrent
+// jobs in THIS process (#3201). It is not cross-process (that would need a
+// shared store), but it stops a single API instance from bursting a whole
+// fleet's serials at the vendor and getting the source IP throttled/banned.
+//
+// Neither vendor documents a rate limit, so the default is deliberately
+// conservative (~4 req/s); tune it if a vendor publishes a specific ceiling.
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface WarrantyRateLimiter {
+  acquire(): Promise<void>;
+}
+
+export function createWarrantyRateLimiter(minIntervalMs: number): WarrantyRateLimiter {
+  // A serialized queue: each acquire() chains off the previous one and only
+  // resolves once at least `minIntervalMs` has passed since the last release.
+  let tail: Promise<void> = Promise.resolve();
+  let lastReleaseAt = 0;
+  return {
+    acquire(): Promise<void> {
+      const gated = tail.then(async () => {
+        const wait = lastReleaseAt + minIntervalMs - Date.now();
+        if (wait > 0) await sleep(wait);
+        lastReleaseAt = Date.now();
+      });
+      // Keep the queue alive even if the gate ever rejects (defensive — the body
+      // only awaits a timer, so in practice it can't).
+      tail = gated.catch(() => undefined);
+      return gated;
+    },
+  };
+}
+
+export const WARRANTY_LOOKUP_MIN_INTERVAL_MS = 250;
+
+// One limiter per provider — they hit different vendors, so their rate limits
+// are independent.
+export const hpRateLimiter = createWarrantyRateLimiter(WARRANTY_LOOKUP_MIN_INTERVAL_MS);
+export const lenovoRateLimiter = createWarrantyRateLimiter(WARRANTY_LOOKUP_MIN_INTERVAL_MS);

--- a/apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts
+++ b/apps/api/src/services/warrantyProviders/warrantyProviderThrottle.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Spy on the per-provider limiter INSTANCES so we can prove the providers
+// acquire once per vendor fetch, while keeping the real createWarrantyRateLimiter
+// for the spacing unit test below.
+const { hpAcquire, lenovoAcquire } = vi.hoisted(() => ({
+  hpAcquire: vi.fn().mockResolvedValue(undefined),
+  lenovoAcquire: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./throttle', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./throttle')>();
+  return {
+    ...actual,
+    hpRateLimiter: { acquire: hpAcquire },
+    lenovoRateLimiter: { acquire: lenovoAcquire },
+  };
+});
+
+import { hpProvider } from './hpProvider';
+import { lenovoProvider } from './lenovoProvider';
+import { createWarrantyRateLimiter } from './throttle';
+
+const okJson = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+beforeEach(() => {
+  hpAcquire.mockClear();
+  lenovoAcquire.mockClear();
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okJson({})));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('warranty provider request throttling (#3201)', () => {
+  // The bug this guards: production calls lookup([oneSerial]) once per device, so
+  // the limiter MUST fire per fetch across separate calls — not just within one
+  // multi-serial call.
+  it('HP: acquires the limiter on every request, even across single-serial calls', async () => {
+    await hpProvider.lookup(['a']);
+    await hpProvider.lookup(['b']);
+    await hpProvider.lookup(['c']);
+    expect(hpAcquire).toHaveBeenCalledTimes(3);
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('HP: acquires once per serial within a multi-serial call too', async () => {
+    await hpProvider.lookup(['a', 'b']);
+    expect(hpAcquire).toHaveBeenCalledTimes(2);
+  });
+
+  it('HP: no serials → no acquire', async () => {
+    await hpProvider.lookup([]);
+    expect(hpAcquire).not.toHaveBeenCalled();
+  });
+
+  it('Lenovo: acquires the limiter on every request when configured', async () => {
+    vi.stubEnv('LENOVO_API_KEY', 'test-client-id');
+    await lenovoProvider.lookup(['a']);
+    await lenovoProvider.lookup(['b']);
+    expect(lenovoAcquire).toHaveBeenCalledTimes(2);
+  });
+
+  it('Lenovo: no API key → no vendor calls and no acquire', async () => {
+    vi.stubEnv('LENOVO_API_KEY', '');
+    await lenovoProvider.lookup(['a', 'b', 'c']);
+    expect(lenovoAcquire).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('createWarrantyRateLimiter', () => {
+  it('lets the first acquire through immediately but spaces the next by the interval', async () => {
+    vi.useFakeTimers();
+    // A realistic clock so the initial lastReleaseAt=0 makes the first wait
+    // negative (immediate), as in production.
+    vi.setSystemTime(1_700_000_000_000);
+    try {
+      const limiter = createWarrantyRateLimiter(250);
+
+      let firstDone = false;
+      limiter.acquire().then(() => {
+        firstDone = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(firstDone).toBe(true);
+
+      let secondDone = false;
+      limiter.acquire().then(() => {
+        secondDone = true;
+      });
+      // Not yet — must wait out the interval.
+      await vi.advanceTimersByTimeAsync(100);
+      expect(secondDone).toBe(false);
+      await vi.advanceTimersByTimeAsync(200);
+      expect(secondDone).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Addresses the throttling item of #3201 (its VM-exclusion half is already fixed in #3399/#3417).

## Problem

The HP and Lenovo warranty providers looped `fetch` per serial with **no throttle**, so a whole-fleet warranty sync could burst the vendor endpoints and get the source IP rate-limited/banned.

## Fix

A **per-provider request rate limiter** (`throttle.ts`): a serialized promise-queue whose `acquire()` spaces successive releases **≥ 250ms** apart. `hpProvider` and `lenovoProvider` `await` their provider's limiter before **each** vendor fetch.

**Why at the request boundary, as a process-shared singleton:** warranty sync calls `provider.lookup([oneSerial])` **once per device** (not one multi-serial call), across up to 3 concurrent BullMQ jobs. So throttling *within* a `lookup()` call does nothing — the limit has to live at the fetch boundary and be shared across calls and jobs. (An adversarial Codex pass caught that a first, naive "space serials within a call" cut was completely inert in production; this is the redesign.)

250ms is a deliberately **conservative** default — neither vendor documents a limit — and is centralised for easy tuning.

## Known limitation (documented in `throttle.ts`)

The limiter is **process-local**. The current deployment is a single `breeze-api` container, so it caps this instance's burst. Horizontal API scaling (multiple replicas sharing a vendor-facing source IP) would need a Redis-backed distributed limiter — a larger change, out of scope here.

## Review

Two Codex passes. The first found the naive within-call throttle inert against the real one-serial-per-device topology. The second verified the redesign: sound FIFO serialization, no ever-growing settled promise chain, race-free `lastReleaseAt` (single-threaded event loop), and no conflict with the 300s worker lock (a 50-device batch adds ~12s). Verdict: safe to ship for the single-API-process topology.

## Testing

- The limiter fires **per fetch across separate single-serial calls** (the real sync topology), not just within a multi-serial call — the exact bug the redesign fixes.
- The Lenovo no-API-key path makes no vendor calls and doesn't throttle.
- A fake-timer unit test asserts the first `acquire()` is immediate and the next waits the interval.
- Control-verified (removing the `acquire()` reds the across-calls test).

`tsc --noEmit` (apps/api) clean; vitest `warrantyProviders` + `warrantySync` pass; eslint clean. No new env vars (avoids the env-doc parity guard) and no migration.

https://claude.ai/code/session_0187oKb4Pw7KTXT2Lsvq7hUr
