### PR TITLE
fix(api): mark truncated arrays in-band in MCP tool output (#3521)

### DIFF
--- a/apps/api/src/services/aiToolOutput.test.ts
+++ b/apps/api/src/services/aiToolOutput.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { compactToolResultForChat, redactSensitiveToolInput } from './aiToolOutput';
 
+// #3521: a truncated array carries a trailing in-band sentinel string. When a
+// test cross-checks kept-vs-dropped counts, exclude that synthetic element.
+const SENTINEL_RE = /more items omitted/;
+const realLen = (arr: unknown[]): number =>
+  arr.filter((x) => !(typeof x === 'string' && SENTINEL_RE.test(x))).length;
+
 // SR5-16: tool_input is persisted UNCONDITIONALLY to the transcript (even for
 // denied calls). Sensitive keys must be masked at that chokepoint.
 describe('redactSensitiveToolInput', () => {
@@ -242,7 +248,7 @@ describe('compactToolResultForChat', () => {
     expect(stdout.totalPages).toBe(3);
     expect(Array.isArray(stdout.processes)).toBe(true);
     // 120 in → capped at 50 (or tighter): the compaction must actually fire.
-    expect((stdout.processes as unknown[]).length).toBeLessThanOrEqual(50);
+    expect(realLen(stdout.processes as unknown[])).toBeLessThanOrEqual(50);
     expect((parsed.stdoutTruncation as Record<string, unknown>).itemsDropped).toBeGreaterThanOrEqual(70);
     expect(parsed.stdoutChars).toBeGreaterThan(2_000);
   });
@@ -281,7 +287,7 @@ describe('compactToolResultForChat', () => {
     expect(Array.isArray(stdout.events)).toBe(true);
     expect((stdout.events as unknown[]).length).toBeGreaterThan(0);
     const truncation = parsed.stdoutTruncation as Record<string, unknown>;
-    expect(truncation.itemsDropped).toBe(300 - (stdout.events as unknown[]).length);
+    expect(truncation.itemsDropped).toBe(300 - realLen(stdout.events as unknown[]));
     expect(String(truncation.note)).toContain('event_logs_query');
   });
 
@@ -350,7 +356,7 @@ describe('compactToolResultForChat', () => {
     expect(compacted.length).toBeLessThanOrEqual(8_000);
     const parsed = JSON.parse(compacted) as Record<string, unknown>;
     const stdout = parsed.stdout as Record<string, unknown>;
-    const kept = (stdout.processes as unknown[]).length;
+    const kept = realLen(stdout.processes as unknown[]);
 
     expect(kept).toBeLessThan(45);
     const truncation = parsed.stdoutTruncation as Record<string, unknown>;
@@ -520,5 +526,64 @@ describe('compactToolResultForChat', () => {
     expect(Array.isArray(parsed.runs)).toBe(true);
     expect((parsed.runs as unknown[]).length).toBeLessThanOrEqual(40);
     expect(parsed.runsDropped).toBeGreaterThan(0);
+  });
+});
+
+describe('array truncation in-band sentinel (#3521)', () => {
+  it('appends an in-band sentinel element when a truncated array would otherwise read as complete', () => {
+    // get_quote is not a fleet tool, so its nested `blocks` array flows through
+    // the generic compactValue path — where truncation used to leave no in-band
+    // marker, only a buried `_chat.arrayItemsDropped` stat.
+    const blocks = Array.from({ length: 60 }, (_, i) => ({ id: i, type: 'text', content: 'x'.repeat(200) }));
+    const raw = JSON.stringify({ data: { blocks } });
+
+    const parsed = JSON.parse(compactToolResultForChat('get_quote', raw)) as {
+      data: { blocks: unknown[] };
+    };
+    const outBlocks = parsed.data.blocks;
+
+    expect(outBlocks.length).toBeLessThan(blocks.length);
+    const last = outBlocks[outBlocks.length - 1];
+    expect(typeof last).toBe('string');
+    expect(last as string).toMatch(/truncated: \d+ more items omitted/);
+    // Everything before the sentinel is a real (object) block.
+    expect(typeof outBlocks[0]).toBe('object');
+  });
+
+  it('does not add a sentinel to an array that fits within the cap', () => {
+    const raw = JSON.stringify({ data: { blocks: [{ id: 1, type: 'text' }, { id: 2, type: 'text' }] } });
+    const parsed = JSON.parse(compactToolResultForChat('get_quote', raw)) as {
+      data: { blocks: unknown[] };
+    };
+    expect(parsed.data.blocks).toHaveLength(2);
+    expect(parsed.data.blocks.every((b) => typeof b === 'object')).toBe(true);
+  });
+
+  it('is idempotent: a pre-existing array marker is not counted as a real item when re-truncated', () => {
+    // 45 real items + a marker left by a prior compaction. Re-truncating must
+    // count only the 45 real items, so `keptReal + N === 45` (NOT 46). Without
+    // the idempotence strip, the marker inflates the count by one.
+    const REAL = 45;
+    const PRIOR = 999;
+    const blocks: unknown[] = [
+      ...Array.from({ length: REAL }, (_, i) => ({ id: i, type: 'text', content: 'x'.repeat(150) })),
+      `...[truncated: ${PRIOR} more items omitted. Use pagination or the REST API]`,
+    ];
+    const raw = JSON.stringify({ data: { blocks } });
+
+    const parsed = JSON.parse(compactToolResultForChat('get_quote', raw)) as {
+      data: { blocks: unknown[] };
+    };
+    const out = parsed.data.blocks;
+    const keptReal = out.filter((b) => typeof b === 'object').length;
+    const markers = out.filter((b) => typeof b === 'string' && SENTINEL_RE.test(b));
+
+    expect(markers).toHaveLength(1); // exactly one marker, not stacked
+    expect(keptReal).toBeLessThan(REAL); // truncation happened
+    const n = Number(/truncated: (\d+) more/.exec(markers[0] as string)![1]);
+    // Cumulative: prior omissions + the real items dropped THIS pass. The prior
+    // marker is not counted as one of the real items (that would give PRIOR + 1
+    // too many), and the prior count is carried forward, not reset.
+    expect(n).toBe(PRIOR + (REAL - keptReal));
   });
 });

--- a/apps/api/src/services/aiToolOutput.ts
+++ b/apps/api/src/services/aiToolOutput.ts
@@ -93,6 +93,26 @@ function truncateText(value: string, maxChars: number, stats: CompactStats): str
   return `${base.slice(0, maxChars)}\n...[truncated ${omitted} chars]`;
 }
 
+// #3521: the in-band marker appended to a truncated ARRAY, mirroring the string
+// `[truncated N chars]` marker. The ANCHORED regex matches only our exact
+// canonical marker, so a re-compaction pass recognizes its own marker (staying
+// idempotent) without misclassifying a legitimate trailing string that merely
+// begins similarly.
+const ARRAY_SENTINEL_RE = /^\.\.\.\[truncated: (\d+) more items omitted. Use pagination or the REST API\]$/;
+
+function arrayTruncationSentinel(dropped: number): string {
+  return `...[truncated: ${dropped} more items omitted. Use pagination or the REST API]`;
+}
+
+// Prior omitted count if `value` is exactly our marker, else null. Used to carry
+// the count forward across a tighter re-compaction (mirrors truncateText's
+// priorOmitted), so the marker reports the TOTAL omitted from the original input.
+function priorArrayOmitted(value: unknown): number | null {
+  if (typeof value !== 'string') return null;
+  const match = ARRAY_SENTINEL_RE.exec(value);
+  return match ? Number(match[1]) : null;
+}
+
 export function redactAiToolOutputText(value: string): string {
   return BARE_SECRET_PATTERNS.reduce(
     (current, pattern) => current.replace(pattern, REDACTED),
@@ -155,13 +175,33 @@ function compactValue(
   }
 
   if (Array.isArray(value)) {
-    if (value.length > config.maxArrayItems) {
-      stats.arraysTruncated += 1;
-      stats.arrayItemsDropped += value.length - config.maxArrayItems;
-    }
-    return value
+    // #3521: a truncated array used to be `.slice()`d with only a buried
+    // `_chat.arrayItemsDropped` stat — the array itself reads as a complete,
+    // plausible list, so it silently misrepresents state. Append an in-band
+    // marker element (mirroring the string `...[truncated N chars]` marker) at
+    // the point of loss. It is a JSON string, so the array stays valid JSON.
+    //
+    // Idempotence: if this array already carries our marker (e.g. output that is
+    // ever re-compacted), strip it first so the synthetic element is not counted
+    // as a real item nor re-truncated in place; re-emit or refresh it below.
+    const priorOmitted = value.length > 0 ? priorArrayOmitted(value[value.length - 1]) : null;
+    const items = priorOmitted !== null ? value.slice(0, -1) : value;
+    const compacted = items
       .slice(0, config.maxArrayItems)
       .map((item) => compactValue(item, stats, config, depth + 1));
+    const droppedThisPass = items.length - config.maxArrayItems;
+    if (droppedThisPass > 0) {
+      stats.arraysTruncated += 1;
+      stats.arrayItemsDropped += droppedThisPass;
+      // Marker reports the CUMULATIVE omission from the original input, so a
+      // tighter re-compaction of already-marked output doesn't understate it.
+      compacted.push(arrayTruncationSentinel((priorOmitted ?? 0) + droppedThisPass));
+    } else if (priorOmitted !== null) {
+      // Already-truncated upstream and still fits — preserve the existing count
+      // rather than silently dropping the "more omitted" signal.
+      compacted.push(arrayTruncationSentinel(priorOmitted));
+    }
+    return compacted;
   }
 
   if (isRecord(value)) {


### PR DESCRIPTION
## What

MCP tool-output compaction (`aiToolOutput.ts` `compactValue`) truncated over-long arrays with a bare `.slice()`, recording only a buried `_chat.arrayItemsDropped` stat. An agent reading e.g. `get_quote`'s `blocks` array saw a plausible, complete-looking list and had no reason to inspect the envelope stats, so a truncated array **silently misrepresented state** (the reporter had to fall back to the REST API to see the real quote). String truncation, by contrast, has always left an in-band `...[truncated N chars]` marker.

## Change

When `compactValue` truncates an array, append one in-band sentinel string element at the point of loss:

`...[truncated: N more items omitted. Use pagination or the REST API]`

It is a JSON string, so the array stays valid JSON. This mirrors the existing string-truncation marker, and — like the file's `truncateText` — it is **idempotent**: a re-compaction pass recognizes its own marker (anchored canonical regex), does not count it as a real item, does not stack a second marker, and **carries the prior omitted count forward** so a tighter re-compaction reports the cumulative total, not just the last step.

## Notes for review

- The output is serialized to a string for the model; there is no programmatic consumer of the compacted array (verified callers: `mcpServer.ts`, `aiAgentSdkTools.ts` — both pass raw results and never re-compact). The sentinel does make an object array mixed-type; if you'd prefer an envelope `{ items, omitted }` instead, I'm happy to switch — I went with the sentinel per the issue's proposal.
- Fleet tools pre-prune their top-level arrays to 40 (`compactFleetPayload`) before `compactValue`, so this only adds a marker where an array genuinely exceeds the cap at the generic level (e.g. nested `blocks`).

## Tests

`aiToolOutput.test.ts`: sentinel appended on truncation; none when the array fits; idempotent carry-forward on a pre-marked array (control-verified). The three existing `#3093` stdout tests now count real items (excluding the synthetic marker); `stdoutTruncation.itemsDropped` still equals the real dropped count.

https://claude.ai/code/session_0187oKb4Pw7KTXT2Lsvq7hUr
