### PR TITLE
Script executions output fix + in-editor script test loop (v1)

### DIFF
--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -1053,7 +1053,7 @@ scriptRoutes.get(
       .offset(offset);
 
     return c.json({
-      data: executionList,
+      data: executionList.map(execution => ({ ...execution, scriptName: script.name })),
       pagination: { page, limit, total }
     });
   }

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -125,6 +125,7 @@ export const TOOL_TIERS = {
   get_script_details: 1,
   list_script_templates: 1,
   get_script_execution_history: 1,
+  get_script_execution: 1,
   manage_services: 3,
   security_scan: 3,
   get_security_posture: 1,
@@ -1141,6 +1142,15 @@ export function createBreezeMcpServer(
         parameters: z.record(z.string(), z.unknown()).optional(),
       },
       makeHandler('run_script', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'get_script_execution',
+      'Fetch one script execution by ID with status, exit code, stdout, and stderr. Use to read the result of a run that was still running when run_script returned.',
+      {
+        executionId: uuid,
+      },
+      makeHandler('get_script_execution', getAuth, onPreToolUse, onPostToolUse)
     ),
 
     tool(

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -747,6 +747,7 @@ export const TOOL_PERMISSIONS: Record<string, { resource: string; action: string
   get_script_details: { resource: 'scripts', action: 'read' },
   list_script_templates: { resource: 'scripts', action: 'read' },
   get_script_execution_history: { resource: 'scripts', action: 'read' },
+  get_script_execution: { resource: 'scripts', action: 'read' },
   // Backup & DR tools
   query_backups: { resource: 'devices', action: 'read' },
   get_backup_status: { resource: 'devices', action: 'read' },

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -1253,6 +1253,9 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
     scriptId: uuid,
     limit: z.number().int().min(1).max(50).optional(),
   }),
+  get_script_execution: z.object({
+    executionId: uuid,
+  }),
 
   // Monitoring tools
   query_monitors: z.object({

--- a/apps/api/src/services/aiToolsScripts.getExecution.test.ts
+++ b/apps/api/src/services/aiToolsScripts.getExecution.test.ts
@@ -15,6 +15,7 @@ vi.mock('../db', () => ({
   db: { select: vi.fn() },
 }));
 
+import { eq } from 'drizzle-orm';
 import { db } from '../db';
 import { registerScriptTools } from './aiToolsScripts';
 import type { AiTool } from './aiTools';
@@ -62,18 +63,39 @@ const executionRow = {
   createdAt: '2026-08-15T10:00:00Z',
 };
 
-function mockExecutionRows(rows: unknown[]) {
+function mockExecutionRows(rows: unknown[], capturedWhere?: unknown[]) {
   (db.select as ReturnType<typeof vi.fn>).mockReturnValue({
     from: () => ({
       innerJoin: () => ({
         leftJoin: () => ({
-          where: () => ({
-            limit: () => Promise.resolve(rows),
-          }),
+          where: (cond: unknown) => {
+            capturedWhere?.push(cond);
+            return { limit: () => Promise.resolve(rows) };
+          },
         }),
       }),
     }),
   });
+}
+
+/** Flatten a drizzle SQL condition tree to lowercase text tokens so tests can
+ *  assert on actual clause structure instead of vacuously trusting the mock
+ *  (a token-scan on the built condition, per the where-clause testing rule). */
+function flattenSql(node: unknown, out: string[] = []): string[] {
+  if (node == null) return out;
+  const anyNode = node as Record<string, unknown>;
+  if (Array.isArray(node)) {
+    for (const child of node) flattenSql(child, out);
+  } else if (Array.isArray(anyNode.queryChunks)) {
+    flattenSql(anyNode.queryChunks, out);
+  } else if (Array.isArray(anyNode.value)) {
+    for (const v of anyNode.value) out.push(String(v).toLowerCase());
+  } else if (typeof anyNode.name === 'string') {
+    out.push(String(anyNode.name).toLowerCase());
+  } else if ('value' in anyNode) {
+    out.push(String(anyNode.value).toLowerCase());
+  }
+  return out;
 }
 
 beforeEach(() => {
@@ -116,6 +138,22 @@ describe('get_script_execution', () => {
     const result = JSON.parse(await getTool().handler({ executionId: EXECUTION_ID }, auth));
 
     expect(result.error).toBe('Execution not found');
+  });
+
+  it('org condition admits org-less (partner-wide/system) scripts via IS NULL, not a bare org match', async () => {
+    const captured: unknown[] = [];
+    mockExecutionRows([executionRow], captured);
+    const auth = makeAuth();
+    // Simulate an org-scoped session: orgCondition returns a real condition.
+    (auth as unknown as Record<string, unknown>).orgCondition =
+      (col: unknown) => eq(col as Parameters<typeof eq>[0], 'org-1');
+    await getTool().handler({ executionId: EXECUTION_ID }, auth);
+
+    const tokens = flattenSql(captured[0]).join(' ');
+    // The clause must OR the org match with IS NULL so partner-wide scripts
+    // (org_id NULL — the repo default ownership shape) stay readable.
+    expect(tokens).toContain('is null');
+    expect(tokens).toContain(' or ');
   });
 
   it('tolerates a deleted device (left join) — output still returned', async () => {

--- a/apps/api/src/services/aiToolsScripts.getExecution.test.ts
+++ b/apps/api/src/services/aiToolsScripts.getExecution.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Coverage for the get_script_execution tier-1 tool (script-editor test loop):
+ * single-execution lookup with the script-org condition applied and the site
+ * axis enforced after the row loads. The tool exists so the AI can read a
+ * run's output after the user's editor Test Run (or after a run outlives the
+ * 60s tool window), so the shape of the returned JSON is part of the contract.
+ */
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn() },
+}));
+
+import { db } from '../db';
+import { registerScriptTools } from './aiToolsScripts';
+import type { AiTool } from './aiTools';
+import type { AuthContext } from '../middleware/auth';
+
+const EXECUTION_ID = '11111111-1111-1111-1111-111111111111';
+const SCRIPT_ID = '22222222-2222-2222-2222-222222222222';
+const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+const SITE_ID = '44444444-4444-4444-4444-444444444444';
+
+function getTool(): AiTool {
+  const map = new Map<string, AiTool>();
+  registerScriptTools(map);
+  return map.get('get_script_execution')!;
+}
+
+function makeAuth(overrides: Partial<Record<'canAccessSite', (siteId: string | null) => boolean>> = {}): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    canAccessSite: overrides.canAccessSite ?? (() => true),
+  } as unknown as AuthContext;
+}
+
+const executionRow = {
+  id: EXECUTION_ID,
+  scriptId: SCRIPT_ID,
+  scriptName: 'Disk cleanup',
+  deviceId: DEVICE_ID,
+  deviceHostname: 'dev1',
+  deviceSiteId: SITE_ID,
+  status: 'completed',
+  exitCode: 0,
+  stdout: 'cleaned 12 files',
+  stderr: '',
+  errorMessage: null,
+  startedAt: '2026-08-15T10:00:00Z',
+  completedAt: '2026-08-15T10:00:05Z',
+  createdAt: '2026-08-15T10:00:00Z',
+};
+
+function mockExecutionRows(rows: unknown[]) {
+  (db.select as ReturnType<typeof vi.fn>).mockReturnValue({
+    from: () => ({
+      innerJoin: () => ({
+        leftJoin: () => ({
+          where: () => ({
+            limit: () => Promise.resolve(rows),
+          }),
+        }),
+      }),
+    }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('get_script_execution', () => {
+  it('is registered as tier 1 (read-only, auto-executes)', () => {
+    expect(getTool().tier).toBe(1);
+  });
+
+  it('returns the execution with output fields and without the internal site id', async () => {
+    mockExecutionRows([executionRow]);
+    const result = JSON.parse(await getTool().handler({ executionId: EXECUTION_ID }, makeAuth()));
+
+    expect(result.execution).toMatchObject({
+      id: EXECUTION_ID,
+      scriptId: SCRIPT_ID,
+      scriptName: 'Disk cleanup',
+      status: 'completed',
+      exitCode: 0,
+      stdout: 'cleaned 12 files',
+      stderr: '',
+      deviceHostname: 'dev1',
+    });
+    expect(result.execution).not.toHaveProperty('deviceSiteId');
+  });
+
+  it('returns "Execution not found" when the org-scoped query matches nothing (cross-org lookup)', async () => {
+    mockExecutionRows([]);
+    const result = JSON.parse(await getTool().handler({ executionId: EXECUTION_ID }, makeAuth()));
+
+    expect(result.error).toBe('Execution not found');
+    expect(result.execution).toBeUndefined();
+  });
+
+  it('denies the row when the device is outside the caller site allowlist — same error as not-found', async () => {
+    mockExecutionRows([executionRow]);
+    const auth = makeAuth({ canAccessSite: (siteId) => siteId !== SITE_ID });
+    const result = JSON.parse(await getTool().handler({ executionId: EXECUTION_ID }, auth));
+
+    expect(result.error).toBe('Execution not found');
+  });
+
+  it('tolerates a deleted device (left join) — output still returned', async () => {
+    mockExecutionRows([{ ...executionRow, deviceHostname: null, deviceSiteId: null }]);
+    const result = JSON.parse(await getTool().handler({ executionId: EXECUTION_ID }, makeAuth()));
+
+    expect(result.execution.stdout).toBe('cleaned 12 files');
+    expect(result.execution.deviceHostname).toBeNull();
+  });
+});

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -679,10 +679,13 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
       },
     },
     handler: async (input, auth) => {
-      // Verify the script belongs to the user's org before returning execution data
+      // Verify the script belongs to the user's org before returning execution
+      // data. Partner-wide/system scripts have org_id NULL — same guard as
+      // run_script, or the history of the repo's default ownership shape would
+      // read as "Script not found".
       const scriptConditions: SQL[] = [eq(scripts.id, input.scriptId as string), isNull(scripts.deletedAt)];
       const orgCondition = auth.orgCondition(scripts.orgId);
-      if (orgCondition) scriptConditions.push(orgCondition);
+      if (orgCondition) scriptConditions.push(or(isNull(scripts.orgId), orgCondition)!);
 
       const [script] = await db
         .select({ id: scripts.id })
@@ -731,7 +734,12 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
       },
     },
     handler: async (input, auth) => {
-      const scriptOrgCondition = auth.orgCondition(scripts.orgId);
+      // Partner-wide/system scripts have org_id NULL; the plain orgCondition
+      // would exclude their executions (same trap run_script guards against
+      // above). Org-less scripts pass here; the device-site check below and
+      // RLS still constrain what the session can see.
+      const orgCond = auth.orgCondition(scripts.orgId);
+      const scriptOrgCondition = orgCond ? or(isNull(scripts.orgId), orgCond) : undefined;
 
       const [execution] = await db
         .select({

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -11,6 +11,7 @@
  * - get_script_details (Tier 1): Get script metadata with optional content/versions/stats
  * - list_script_templates (Tier 1): Browse available script templates
  * - get_script_execution_history (Tier 1): Get past execution results for a script
+ * - get_script_execution (Tier 1): Get a single execution by ID (status + output)
  * - search_script_library (Tier 1): Search scripts and templates together
  * - manage_processes (Tier 1): List or kill running processes on a device
  * - manage_scheduled_tasks (Tier 1): List/run/enable/disable/delete scheduled tasks
@@ -709,6 +710,63 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
         .limit(limit);
 
       return JSON.stringify({ executions: results, count: results.length });
+    },
+  });
+
+  // ============================================
+  // get_script_execution - Tier 1 (read-only)
+  // ============================================
+
+  registerTool({
+    tier: 1,
+    definition: {
+      name: 'get_script_execution',
+      description: 'Get a single script execution by ID, including status, exit code, stdout, stderr, and timing. Use this to fetch the result of a run you or the user started (e.g. after a run outlived the tool call, or after the user clicked Test Run in the editor).',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          executionId: { type: 'string', description: 'UUID of the script execution to fetch' },
+        },
+        required: ['executionId'],
+      },
+    },
+    handler: async (input, auth) => {
+      const scriptOrgCondition = auth.orgCondition(scripts.orgId);
+
+      const [execution] = await db
+        .select({
+          id: scriptExecutions.id,
+          scriptId: scriptExecutions.scriptId,
+          scriptName: scripts.name,
+          deviceId: scriptExecutions.deviceId,
+          deviceHostname: devices.hostname,
+          deviceSiteId: devices.siteId,
+          status: scriptExecutions.status,
+          exitCode: scriptExecutions.exitCode,
+          stdout: scriptExecutions.stdout,
+          stderr: scriptExecutions.stderr,
+          errorMessage: scriptExecutions.errorMessage,
+          startedAt: scriptExecutions.startedAt,
+          completedAt: scriptExecutions.completedAt,
+          createdAt: scriptExecutions.createdAt,
+        })
+        .from(scriptExecutions)
+        .innerJoin(scripts, eq(scriptExecutions.scriptId, scripts.id))
+        .leftJoin(devices, eq(scriptExecutions.deviceId, devices.id))
+        .where(and(
+          eq(scriptExecutions.id, input.executionId as string),
+          ...(scriptOrgCondition ? [scriptOrgCondition] : []),
+        ))
+        .limit(1);
+
+      if (!execution) return JSON.stringify({ error: 'Execution not found' });
+      // Site axis: same rule verifyDeviceAccess applies on the write path.
+      if (auth.canAccessSite && !auth.canAccessSite(execution.deviceSiteId)) {
+        return JSON.stringify({ error: 'Execution not found' });
+      }
+
+      const { deviceSiteId: _siteId, ...result } = execution;
+      return JSON.stringify({ execution: result });
     },
   });
 

--- a/apps/api/src/services/scriptBuilderPrompt.test.ts
+++ b/apps/api/src/services/scriptBuilderPrompt.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { buildScriptBuilderSystemPrompt } from './scriptBuilderPrompt';
+
+/**
+ * The editor test-loop relies on the system prompt carrying three context ids
+ * (saved script, pinned test device, last test-run execution) so the model can
+ * run and read results without guessing via list_scripts. These were silently
+ * droppable before (#scriptId existed in the type but was never rendered), so
+ * pin their presence and absence explicitly.
+ */
+
+const SCRIPT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const DEVICE_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const EXECUTION_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+describe('buildScriptBuilderSystemPrompt', () => {
+  it('returns the base prompt when no context is given', () => {
+    const prompt = buildScriptBuilderSystemPrompt();
+    expect(prompt).toContain('script-writing assistant');
+    expect(prompt).not.toContain('Saved script ID');
+    expect(prompt).not.toContain('Pinned test device');
+    expect(prompt).not.toContain('--- Current Editor State ---');
+  });
+
+  it('renders scriptId, targetDeviceId, and lastTestExecutionId when present without a snapshot', () => {
+    const prompt = buildScriptBuilderSystemPrompt({
+      scriptId: SCRIPT_ID,
+      targetDeviceId: DEVICE_ID,
+      lastTestExecutionId: EXECUTION_ID,
+    });
+    expect(prompt).toContain(`Saved script ID: ${SCRIPT_ID}`);
+    expect(prompt).toContain(`Pinned test device ID: ${DEVICE_ID}`);
+    expect(prompt).toContain(`Most recent editor test-run execution ID: ${EXECUTION_ID}`);
+  });
+
+  it('renders the context ids alongside the editor snapshot', () => {
+    const prompt = buildScriptBuilderSystemPrompt({
+      scriptId: SCRIPT_ID,
+      targetDeviceId: DEVICE_ID,
+      editorSnapshot: { name: 'Cleanup', language: 'powershell', content: 'Get-ChildItem' },
+    });
+    expect(prompt).toContain(`Saved script ID: ${SCRIPT_ID}`);
+    expect(prompt).toContain(`Pinned test device ID: ${DEVICE_ID}`);
+    expect(prompt).toContain('--- Current Editor State ---');
+    expect(prompt).toContain('Get-ChildItem');
+  });
+
+  it('omits context lines that are absent', () => {
+    const prompt = buildScriptBuilderSystemPrompt({
+      editorSnapshot: { content: 'echo hi' },
+    });
+    expect(prompt).not.toContain('Saved script ID');
+    expect(prompt).not.toContain('Pinned test device');
+    expect(prompt).not.toContain('Most recent editor test-run execution ID');
+    expect(prompt).toContain('echo hi');
+  });
+});

--- a/apps/api/src/services/scriptBuilderPrompt.ts
+++ b/apps/api/src/services/scriptBuilderPrompt.ts
@@ -15,7 +15,10 @@ You have access to tools that let you:
 - Set script metadata like name, description, OS targets (apply_script_metadata)
 - Look up devices, alerts, and installed software to tailor scripts
 - Search the existing script library for reference
-- Test-run scripts on devices (requires user approval)
+- Test-run saved scripts on devices with execute_script_on_device (requires user approval; returns stdout/stderr and exit code inline)
+- Read any run's result with get_script_execution / get_script_execution_history — including runs the user starts from the editor's Test Run button
+
+To iterate on a script: apply_script_code, ensure the script is saved (ask the user to save if your edits are unsaved — execution always runs the SAVED content), run it on the pinned test device, read the output, and fix. If a run is still running when the tool call returns, poll get_script_execution with the returned executionId.
 
 When the user asks you to write or modify a script:
 1. Ask clarifying questions if the request is ambiguous
@@ -29,12 +32,23 @@ For PowerShell, prefer modern cmdlets. For Bash, ensure POSIX compatibility wher
 
 IMPORTANT: Always use apply_script_code to deliver code to the editor, not just a code block in the chat. The chat message should explain the code; the tool applies it to the editor.`;
 
+  const contextParts: string[] = [];
+  if (context?.scriptId) {
+    contextParts.push(`Saved script ID: ${context.scriptId} — pass this to get_script_details, get_script_execution_history, and execute_script_on_device.`);
+  }
+  if (context?.targetDeviceId) {
+    contextParts.push(`Pinned test device ID: ${context.targetDeviceId} — the user selected this device for test runs; target it with execute_script_on_device unless told otherwise.`);
+  }
+  if (context?.lastTestExecutionId) {
+    contextParts.push(`Most recent editor test-run execution ID: ${context.lastTestExecutionId} — read its output with get_script_execution.`);
+  }
+
   if (!context?.editorSnapshot) {
-    return base;
+    return contextParts.length > 0 ? [base, '', ...contextParts].join('\n') : base;
   }
 
   const snap = context.editorSnapshot;
-  const parts = [base, '\n--- Current Editor State ---'];
+  const parts = [base, ...(contextParts.length > 0 ? ['', ...contextParts] : []), '\n--- Current Editor State ---'];
 
   if (snap.name) parts.push(`Name: ${snap.name}`);
   if (snap.language) parts.push(`Language: ${snap.language}`);

--- a/apps/api/src/services/scriptBuilderTools.ts
+++ b/apps/api/src/services/scriptBuilderTools.ts
@@ -43,6 +43,7 @@ export const SCRIPT_BUILDER_TOOL_TIERS: Record<string, AiToolTier> = {
   get_script_details: 1,
   list_script_templates: 1,
   get_script_execution_history: 1,
+  get_script_execution: 1,
   execute_script_on_device: 3,
 };
 
@@ -283,6 +284,15 @@ export function createScriptBuilderMcpServer(
         limit: z.number().int().min(1).max(50).optional(),
       },
       makeExistingHandler('get_script_execution_history', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'get_script_execution',
+      'Fetch one script execution by ID with status, exit code, stdout, and stderr. Use after a run you or the user started to read its result.',
+      {
+        executionId: uuid.describe('The execution ID to fetch'),
+      },
+      makeExistingHandler('get_script_execution', getAuth, onPreToolUse, onPostToolUse)
     ),
 
     // --- Execution tool (requires approval) ---

--- a/apps/web/src/components/ai-risk/tierConfig.ts
+++ b/apps/web/src/components/ai-risk/tierConfig.ts
@@ -97,6 +97,8 @@ export const TIER_DEFINITIONS: TierDefinition[] = [
       // Scripts & Automation
       { name: 'search_script_library', description: 'Search scripts and templates', category: 'Scripts & Automation' },
       { name: 'get_script_details', description: 'Script content, versions, and stats', category: 'Scripts & Automation' },
+      { name: 'get_script_execution_history', description: 'Past execution results for a script', category: 'Scripts & Automation' },
+      { name: 'get_script_execution', description: 'One script execution with its output', category: 'Scripts & Automation' },
       { name: 'list_playbooks', description: 'List self-healing playbooks', category: 'Scripts & Automation' },
       { name: 'get_playbook_history', description: 'Playbook execution history', category: 'Scripts & Automation' },
       // Configuration Policies

--- a/apps/web/src/components/scripts/ExecutionDetails.tsx
+++ b/apps/web/src/components/scripts/ExecutionDetails.tsx
@@ -56,7 +56,7 @@ function normalizeOutput(raw: string): string {
   return s;
 }
 
-function OutputSection({
+export function OutputSection({
   title,
   content,
   icon: Icon,

--- a/apps/web/src/components/scripts/ExecutionHistory.tsx
+++ b/apps/web/src/components/scripts/ExecutionHistory.tsx
@@ -111,8 +111,8 @@ export default function ExecutionHistory({
     return executions.filter(execution => {
       const matchesQuery = normalizedQuery.length === 0
         ? true
-        : execution.scriptName.toLowerCase().includes(normalizedQuery) ||
-          execution.deviceHostname.toLowerCase().includes(normalizedQuery);
+        : (execution.scriptName ?? '').toLowerCase().includes(normalizedQuery) ||
+          (execution.deviceHostname ?? '').toLowerCase().includes(normalizedQuery);
 
       const matchesStatus = statusFilter === 'all' ? true : execution.status === statusFilter;
 
@@ -149,10 +149,10 @@ export default function ExecutionHistory({
       let cmp = 0;
       switch (sortColumn) {
         case 'scriptName':
-          cmp = a.scriptName.localeCompare(b.scriptName);
+          cmp = (a.scriptName ?? '').localeCompare(b.scriptName ?? '');
           break;
         case 'device':
-          cmp = a.deviceHostname.localeCompare(b.deviceHostname);
+          cmp = (a.deviceHostname ?? '').localeCompare(b.deviceHostname ?? '');
           break;
         case 'status':
           cmp = a.status.localeCompare(b.status);

--- a/apps/web/src/components/scripts/ScriptAiPanel.tsx
+++ b/apps/web/src/components/scripts/ScriptAiPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, Undo2, Redo2 } from 'lucide-react';
-import { useScriptAiStore } from '@/stores/scriptAiStore';
+import { useScriptAiStore, buildEditorContext } from '@/stores/scriptAiStore';
 import ScriptAiMessages from './ScriptAiMessages';
 import ScriptAiInput from './ScriptAiInput';
 import type { ScriptFormBridge } from '@/stores/scriptAiStore';
@@ -36,10 +36,7 @@ export default function ScriptAiPanel({ bridge }: ScriptAiPanelProps) {
   // Create session when panel mounts for the first time
   useEffect(() => {
     if (!sessionId) {
-      const formValues = bridge.getFormValues();
-      createSession({
-        editorSnapshot: formValues,
-      });
+      createSession(buildEditorContext(bridge));
     }
   }, [sessionId, createSession, bridge]);
 

--- a/apps/web/src/components/scripts/ScriptEditPage.tsx
+++ b/apps/web/src/components/scripts/ScriptEditPage.tsx
@@ -87,7 +87,7 @@ export default function ScriptEditPage({ scriptId }: ScriptEditPageProps) {
     fetchScript();
   }, [fetchScript]);
 
-  const handleSubmit = async (values: ScriptSubmitValues) => {
+  const handleSubmit = async (values: ScriptSubmitValues, options?: { navigate?: boolean }) => {
     setSubmitting(true);
     setError(undefined);
 
@@ -141,7 +141,9 @@ export default function ScriptEditPage({ scriptId }: ScriptEditPageProps) {
       }
 
       showToast({ type: 'success', message: isNew ? t('scriptEditPage.toast.created') : t('scriptEditPage.toast.saved') });
-      void navigateTo('/scripts');
+      // Test-run saves stay in the editor (navigate: false); the explicit Save
+      // button keeps its return-to-list behavior.
+      if (options?.navigate !== false) void navigateTo('/scripts');
     } catch (err) {
       setError(err instanceof Error ? err.message : t('scriptEditPage.errors.generic'));
       throw err; // re-throw so ScriptForm knows the save failed
@@ -239,6 +241,7 @@ export default function ScriptEditPage({ scriptId }: ScriptEditPageProps) {
         loading={submitting}
         isNew={isNew}
         isSystemScript={scriptScope?.isSystem ?? false}
+        scriptId={scriptId}
       />
     </div>
   );

--- a/apps/web/src/components/scripts/ScriptEditPage.tsx
+++ b/apps/web/src/components/scripts/ScriptEditPage.tsx
@@ -141,6 +141,13 @@ export default function ScriptEditPage({ scriptId }: ScriptEditPageProps) {
       }
 
       showToast({ type: 'success', message: isNew ? t('scriptEditPage.toast.created') : t('scriptEditPage.toast.saved') });
+      // Keep the local scope in sync after an in-place save that re-scoped the
+      // script — a later save would otherwise compare against the stale scope,
+      // strip the availability fields as "unchanged", and silently leave the
+      // script on the wrong scope.
+      if (!isNew && payload.availability !== undefined) {
+        setScriptScope(prev => prev ? { ...prev, orgId: payload.orgId ?? null } : prev);
+      }
       // Test-run saves stay in the editor (navigate: false); the explicit Save
       // button keeps its return-to-list behavior.
       if (options?.navigate !== false) void navigateTo('/scripts');

--- a/apps/web/src/components/scripts/ScriptExecutionsPage.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionsPage.tsx
@@ -106,7 +106,24 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
   }, [fetchScript, fetchExecutions, fetchDevices, fetchSites]);
 
   const handleViewDetails = (execution: ScriptExecution) => {
+    // Open immediately with the list row, then upgrade with the full record —
+    // the list endpoint omits stdout/stderr to keep its payload small.
     setSelectedExecution(execution);
+    void (async () => {
+      try {
+        const response = await fetchWithAuth(`/scripts/executions/${execution.id}`);
+        if (!response.ok) {
+          if (response.status === 401) void navigateTo('/login', { replace: true });
+          return;
+        }
+        const detail = await response.json();
+        setSelectedExecution(prev =>
+          prev && prev.id === execution.id ? { ...prev, ...detail } : prev
+        );
+      } catch {
+        // Keep the list row; the modal still shows status/metadata.
+      }
+    })();
   };
 
   const handleCloseDetails = () => {

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -318,7 +318,10 @@ describe('ScriptForm unknown-variable notice', () => {
     editorInstances.length = 0;
     getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'o-1' });
     orgStoreMock.mockReturnValue({ organizations: [], partners: [], sites: [] });
-    fetchWithAuthMock.mockResolvedValue(
+    // Fresh Response per call: the form now issues several reads on mount
+    // (tenant variables + the test runner's device list), and a shared
+    // Response body can only be consumed once.
+    fetchWithAuthMock.mockImplementation(async () =>
       new Response(JSON.stringify({ data: [tenantVariable] }), { status: 200 })
     );
   });

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -357,7 +357,10 @@ export default function ScriptForm({
             { ...rest, exitCodeSeverityMapping: rowsToMapping(exitCodeSeverityMapping) },
             { navigate: false }
           );
-          reset(getValues());
+          // Baseline on the SAVED snapshot, keeping the live buffer: edits
+          // typed while the PUT was in flight stay dirty (so the next run
+          // re-saves them and the nav guard still protects them).
+          reset(values, { keepValues: true });
           resolve(true);
         } catch {
           resolve(false);

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -19,6 +19,7 @@ import type { EditorProps } from '@monaco-editor/react';
 import 'monaco-editor/min/vs/editor/editor.main.css';
 
 import ScriptAiPanel from './ScriptAiPanel';
+import ScriptTestRunner from './ScriptTestRunner';
 import CollapsibleSection from './CollapsibleSection';
 import ScriptVariablePicker from './ScriptVariablePicker';
 import { findUnknownVariableKeys, useTenantVariables } from '@/lib/tenantVariableTokens';
@@ -40,7 +41,7 @@ import {
 export type { ScriptFormValues, ScriptParameter, ScriptSubmitValues } from './ScriptFormSchema';
 
 type ScriptFormProps = {
-  onSubmit?: (values: ScriptSubmitValues) => void | Promise<void>;
+  onSubmit?: (values: ScriptSubmitValues, options?: { navigate?: boolean }) => void | Promise<void>;
   onCancel?: () => void;
   defaultValues?: Partial<ScriptFormValues>;
   submitLabel?: string;
@@ -49,6 +50,9 @@ type ScriptFormProps = {
   // System scripts can't be re-scoped through this form (they're read-only for
   // non-system users and stay system-scope-seed-only). Hides the picker on edit.
   isSystemScript?: boolean;
+  // Saved script id — enables the test runner and lets the AI panel know which
+  // script it is editing. Absent for never-saved scripts.
+  scriptId?: string;
 };
 
 export default function ScriptForm({
@@ -59,6 +63,7 @@ export default function ScriptForm({
   loading,
   isNew = false,
   isSystemScript = false,
+  scriptId,
 }: ScriptFormProps) {
   const { t } = useTranslation('scripts');
   // Resolved after mount, never during render. Reading `navigator` inline made
@@ -159,6 +164,7 @@ export default function ScriptForm({
     watch,
     getValues,
     setValue,
+    reset,
     formState: { errors, isSubmitting, isDirty }
   } = useForm<ScriptFormValues>({
     resolver: zodResolver(scriptSchema) as never,
@@ -202,7 +208,15 @@ export default function ScriptForm({
 
   const { panelOpen, togglePanel } = useScriptAiStore();
 
+  // Test-runner state the AI panel context reads through the bridge. Refs (not
+  // state) because the bridge is memoized once and reads lazily.
+  const testDeviceIdRef = useRef<string | null>(null);
+  const lastTestExecutionIdRef = useRef<string | null>(null);
+
   const bridge: ScriptFormBridge = useMemo(() => ({
+    getScriptId: () => scriptId ?? null,
+    getTestDeviceId: () => testDeviceIdRef.current,
+    getLastTestExecutionId: () => lastTestExecutionIdRef.current,
     getFormValues: () => getValues() as ScriptFormValues,
     setFormValues: (partial) => {
       Object.entries(partial).forEach(([key, value]) => {
@@ -221,7 +235,7 @@ export default function ScriptForm({
         });
       }
     },
-  }), [getValues, setValue]);
+  }), [getValues, setValue, scriptId]);
 
   // Warn before leaving with unsaved changes (browser close/refresh + Astro SPA nav)
   const isDirtyRef = useRef(false);
@@ -329,6 +343,29 @@ export default function ScriptForm({
       setValue('osTypes', [...current, os]);
     }
   };
+
+  // Save the form without navigating away — used by the test runner before a
+  // run when the buffer is dirty, so the run always executes what's on screen.
+  // Resolves false on validation or save failure. Marks the form pristine on
+  // success so the unsaved-changes guard doesn't warn about saved work.
+  const saveForTestRun = useCallback(() => new Promise<boolean>((resolve) => {
+    void handleSubmit(
+      async values => {
+        try {
+          const { exitCodeSeverityMapping, ...rest } = values;
+          await onSubmit?.(
+            { ...rest, exitCodeSeverityMapping: rowsToMapping(exitCodeSeverityMapping) },
+            { navigate: false }
+          );
+          reset(getValues());
+          resolve(true);
+        } catch {
+          resolve(false);
+        }
+      },
+      () => resolve(false)
+    )();
+  }), [handleSubmit, onSubmit, reset, getValues]);
 
   const addParameter = () => {
     append({
@@ -609,6 +646,16 @@ export default function ScriptForm({
             </span>
           </p>
         )}
+        <ScriptTestRunner
+          scriptId={scriptId}
+          osTypes={watchOsTypes ?? []}
+          parameters={watchParameters}
+          timeoutSeconds={watch('timeoutSeconds')}
+          isDirty={isDirty}
+          onSaveChanges={saveForTestRun}
+          onTestDeviceChange={(deviceId) => { testDeviceIdRef.current = deviceId; }}
+          onExecutionChange={(executionId) => { lastTestExecutionIdRef.current = executionId; }}
+        />
       </div>
 
       {/* Parameters */}

--- a/apps/web/src/components/scripts/ScriptTestRunner.test.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import ScriptTestRunner from './ScriptTestRunner';
+
+const { fetchWithAuthMock } = vi.hoisted(() => ({ fetchWithAuthMock: vi.fn() }));
+
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../stores/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../stores/auth')>();
+  return { ...actual, fetchWithAuth: fetchWithAuthMock };
+});
+
+const SCRIPT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const DEVICE_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const EXECUTION_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+const onlineDevice = { id: DEVICE_ID, hostname: 'test-box', os: 'windows', status: 'online' };
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe('ScriptTestRunner', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url === '/devices') return jsonResponse({ data: [onlineDevice] });
+      return jsonResponse({}, 404);
+    });
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables test runs and explains why when the script was never saved', async () => {
+    render(
+      <ScriptTestRunner osTypes={['windows']} isDirty={false} onSaveChanges={async () => true} />
+    );
+
+    expect(await screen.findByText(/save the script once/i)).toBeInTheDocument();
+    expect(screen.getByTestId('test-run-button')).toBeDisabled();
+    expect(screen.getByTestId('test-device-select')).toBeDisabled();
+  });
+
+  it('filters the device list to the script OS targets', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url === '/devices') {
+        return jsonResponse({ data: [
+          onlineDevice,
+          { id: 'dddddddd-dddd-dddd-dddd-dddddddddddd', hostname: 'mac-box', os: 'macos', status: 'online' },
+        ] });
+      }
+      return jsonResponse({}, 404);
+    });
+    render(
+      <ScriptTestRunner scriptId={SCRIPT_ID} osTypes={['windows']} isDirty={false} onSaveChanges={async () => true} />
+    );
+
+    await waitFor(() => expect(screen.getByText('test-box')).toBeInTheDocument());
+    expect(screen.queryByText('mac-box')).toBeNull();
+  });
+
+  it('runs on the selected device and renders the execution output when it completes', async () => {
+    let polls = 0;
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/devices') return jsonResponse({ data: [onlineDevice] });
+      if (url === `/scripts/${SCRIPT_ID}/execute` && init?.method === 'POST') {
+        return jsonResponse({ executions: [{ executionId: EXECUTION_ID, deviceId: DEVICE_ID }] }, 201);
+      }
+      if (url === `/scripts/executions/${EXECUTION_ID}`) {
+        polls += 1;
+        return jsonResponse({
+          id: EXECUTION_ID,
+          status: 'completed',
+          exitCode: 0,
+          stdout: 'hello from test-box',
+          stderr: '',
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const onExecutionChange = vi.fn();
+    render(
+      <ScriptTestRunner
+        scriptId={SCRIPT_ID}
+        osTypes={['windows']}
+        isDirty={false}
+        onSaveChanges={async () => true}
+        onExecutionChange={onExecutionChange}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('test-box')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    fireEvent.click(screen.getByTestId('test-run-button'));
+
+    await waitFor(() => expect(onExecutionChange).toHaveBeenCalledWith(EXECUTION_ID));
+    await waitFor(
+      () => expect(screen.getByText('hello from test-box')).toBeInTheDocument(),
+      { timeout: 5000 }
+    );
+    expect(polls).toBeGreaterThan(0);
+
+    const executeCall = fetchWithAuthMock.mock.calls.find(([url]) => url === `/scripts/${SCRIPT_ID}/execute`);
+    expect(JSON.parse((executeCall![1] as RequestInit).body as string)).toMatchObject({
+      deviceIds: [DEVICE_ID],
+      triggerType: 'manual',
+    });
+  }, 10000);
+
+  it('saves first when the form is dirty and aborts the run when the save fails', async () => {
+    const onSaveChanges = vi.fn(async () => false);
+    render(
+      <ScriptTestRunner
+        scriptId={SCRIPT_ID}
+        osTypes={['windows']}
+        isDirty={true}
+        onSaveChanges={onSaveChanges}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('test-box')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    expect(screen.getByTestId('test-run-button')).toHaveTextContent(/save/i);
+    fireEvent.click(screen.getByTestId('test-run-button'));
+
+    await waitFor(() => expect(onSaveChanges).toHaveBeenCalledTimes(1));
+    // The execute endpoint must never be hit after a failed save.
+    expect(fetchWithAuthMock.mock.calls.some(([url]) => String(url).includes('/execute'))).toBe(false);
+    expect(await screen.findByText(/save failed/i)).toBeInTheDocument();
+  });
+
+  it('blocks runs when a required parameter has no default', async () => {
+    render(
+      <ScriptTestRunner
+        scriptId={SCRIPT_ID}
+        osTypes={['windows']}
+        parameters={[{ name: 'target', type: 'string', required: true, defaultValue: '' }]}
+        isDirty={false}
+        onSaveChanges={async () => true}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('test-box')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    expect(screen.getByTestId('test-run-button')).toBeDisabled();
+    expect(screen.getByText(/target/)).toBeInTheDocument();
+  });
+
+  it('remembers the pinned device per script and reports it to the parent', async () => {
+    localStorage.setItem(`breeze:script-test-device:${SCRIPT_ID}`, DEVICE_ID);
+    const onTestDeviceChange = vi.fn();
+    render(
+      <ScriptTestRunner
+        scriptId={SCRIPT_ID}
+        osTypes={['windows']}
+        isDirty={false}
+        onSaveChanges={async () => true}
+        onTestDeviceChange={onTestDeviceChange}
+      />
+    );
+
+    await waitFor(() => expect(onTestDeviceChange).toHaveBeenCalledWith(DEVICE_ID));
+    expect((screen.getByTestId('test-device-select') as HTMLSelectElement).value).toBe(DEVICE_ID);
+  });
+});

--- a/apps/web/src/components/scripts/ScriptTestRunner.test.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.test.tsx
@@ -14,7 +14,9 @@ const SCRIPT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 const DEVICE_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
 const EXECUTION_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
 
-const onlineDevice = { id: DEVICE_ID, hostname: 'test-box', os: 'windows', status: 'online' };
+// Real GET /devices shape: the API emits `osType`, not `os` — the component
+// must normalise (regression: the picker filtered on `os` and matched nothing).
+const onlineDevice = { id: DEVICE_ID, hostname: 'test-box', osType: 'windows', status: 'online' };
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status });
@@ -47,7 +49,7 @@ describe('ScriptTestRunner', () => {
       if (url === '/devices') {
         return jsonResponse({ data: [
           onlineDevice,
-          { id: 'dddddddd-dddd-dddd-dddd-dddddddddddd', hostname: 'mac-box', os: 'macos', status: 'online' },
+          { id: 'dddddddd-dddd-dddd-dddd-dddddddddddd', hostname: 'mac-box', osType: 'macos', status: 'online' },
         ] });
       }
       return jsonResponse({}, 404);
@@ -146,6 +148,66 @@ describe('ScriptTestRunner', () => {
     fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
     expect(screen.getByTestId('test-run-button')).toBeDisabled();
     expect(screen.getByText(/target/)).toBeInTheDocument();
+  });
+
+  it('treats a cancelled execution as terminal and shows its status', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/devices') return jsonResponse({ data: [onlineDevice] });
+      if (url === `/scripts/${SCRIPT_ID}/execute` && init?.method === 'POST') {
+        return jsonResponse({ executions: [{ executionId: EXECUTION_ID, deviceId: DEVICE_ID }] }, 201);
+      }
+      if (url === `/scripts/executions/${EXECUTION_ID}`) {
+        return jsonResponse({ id: EXECUTION_ID, status: 'cancelled', stdout: '', stderr: '' });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    render(
+      <ScriptTestRunner scriptId={SCRIPT_ID} osTypes={['windows']} isDirty={false} onSaveChanges={async () => true} />
+    );
+    await waitFor(() => expect(screen.getByText('test-box')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    fireEvent.click(screen.getByTestId('test-run-button'));
+
+    await waitFor(
+      () => expect(screen.getByText(/cancelled/i)).toBeInTheDocument(),
+      { timeout: 5000 }
+    );
+    // Terminal — the button is usable again, no deadline error.
+    expect(screen.getByTestId('test-run-button')).not.toBeDisabled();
+  }, 10000);
+
+  it('stops polling on a permanent 404 instead of retrying to the deadline', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/devices') return jsonResponse({ data: [onlineDevice] });
+      if (url === `/scripts/${SCRIPT_ID}/execute` && init?.method === 'POST') {
+        return jsonResponse({ executions: [{ executionId: EXECUTION_ID, deviceId: DEVICE_ID }] }, 201);
+      }
+      if (url === `/scripts/executions/${EXECUTION_ID}`) return jsonResponse({ error: 'gone' }, 404);
+      return jsonResponse({}, 404);
+    });
+
+    render(
+      <ScriptTestRunner scriptId={SCRIPT_ID} osTypes={['windows']} isDirty={false} onSaveChanges={async () => true} />
+    );
+    await waitFor(() => expect(screen.getByText('test-box')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    fireEvent.click(screen.getByTestId('test-run-button'));
+
+    await waitFor(
+      () => expect(screen.getByText(/could not read the run result/i)).toBeInTheDocument(),
+      { timeout: 5000 }
+    );
+    const pollCalls = fetchWithAuthMock.mock.calls.filter(([url]) => String(url).includes('/executions/'));
+    expect(pollCalls.length).toBe(1);
+  }, 10000);
+
+  it('does not fetch the device list for a never-saved script', async () => {
+    render(
+      <ScriptTestRunner osTypes={['windows']} isDirty={false} onSaveChanges={async () => true} />
+    );
+    await screen.findByText(/save the script once/i);
+    expect(fetchWithAuthMock.mock.calls.some(([url]) => url === '/devices')).toBe(false);
   });
 
   it('remembers the pinned device per script and reports it to the parent', async () => {

--- a/apps/web/src/components/scripts/ScriptTestRunner.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.tsx
@@ -112,9 +112,8 @@ export default function ScriptTestRunner({
       setSelectedDeviceId(stored);
       onTestDeviceChange?.(stored);
     }
-    // Restore once per script — onTestDeviceChange is a stable-enough callback
-    // and re-running on its identity would fight the user's manual selection.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Restore once per script (deliberately not keyed on onTestDeviceChange's
+    // identity — re-running would fight the user's manual selection).
   }, [scriptId, compatibleDevices.length]);
 
   // Cancel any in-flight poll loop on unmount.

--- a/apps/web/src/components/scripts/ScriptTestRunner.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.tsx
@@ -17,7 +17,7 @@ export type TestDevice = {
   status: 'online' | 'offline' | 'maintenance';
 };
 
-type TestRunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'timeout';
+type TestRunStatus = 'pending' | 'queued' | 'running' | 'completed' | 'failed' | 'timeout' | 'cancelled';
 
 type TestRunExecution = {
   id: string;
@@ -44,7 +44,7 @@ type ScriptTestRunnerProps = {
 };
 
 const POLL_INTERVAL_MS = 2000;
-const TERMINAL_STATUSES: TestRunStatus[] = ['completed', 'failed', 'timeout'];
+const TERMINAL_STATUSES: TestRunStatus[] = ['completed', 'failed', 'timeout', 'cancelled'];
 
 const storageKey = (scriptId: string) => `breeze:script-test-device:${scriptId}`;
 
@@ -67,19 +67,31 @@ export default function ScriptTestRunner({
   const pollTokenRef = useRef(0);
 
   useEffect(() => {
+    // The runner is disabled for never-saved scripts — don't fetch the fleet
+    // list for /scripts/new.
+    if (!scriptId) return;
     let cancelled = false;
     (async () => {
       try {
         const response = await fetchWithAuth('/devices');
         if (!response.ok || cancelled) return;
         const data = await response.json();
-        if (!cancelled) setDevices(asList(data, 'devices'));
+        if (!cancelled) {
+          // GET /devices emits `osType`; normalise so the OS filter below works
+          // (other consumers do the same, see ScriptsPage's device mapping).
+          setDevices(asList<Record<string, unknown>>(data, 'devices').map(d => ({
+            id: String(d.id),
+            hostname: String(d.hostname ?? ''),
+            os: (d.osType ?? d.os ?? '') as TestDevice['os'],
+            status: (d.status ?? 'offline') as TestDevice['status'],
+          })));
+        }
       } catch {
         // Non-fatal: the picker just shows the empty state.
       }
     })();
     return () => { cancelled = true; };
-  }, []);
+  }, [scriptId]);
 
   const compatibleDevices = useMemo(() => {
     const matching = devices.filter(device => osTypes?.includes(device.os));
@@ -136,7 +148,10 @@ export default function ScriptTestRunner({
   const pollExecution = useCallback(async (executionId: string) => {
     const token = ++pollTokenRef.current;
     // Poll to the script's own timeout plus slack for queue + agent pickup.
-    const deadline = Date.now() + ((timeoutSeconds || 300) + 120) * 1000;
+    // Number(): the form registers timeoutSeconds without valueAsNumber, so an
+    // edited field arrives as a string and would string-concatenate here.
+    const timeoutSecs = Number(timeoutSeconds) || 300;
+    const deadline = Date.now() + (timeoutSecs + 120) * 1000;
 
     while (Date.now() < deadline) {
       await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
@@ -148,7 +163,16 @@ export default function ScriptTestRunner({
           void navigateTo('/login', { replace: true });
           return;
         }
-        if (!response.ok) continue; // transient — keep polling until deadline
+        if (!response.ok) {
+          // A 4xx is permanent (execution deleted, access revoked) — stop
+          // instead of hammering the endpoint to the deadline. 5xx retries.
+          if (response.status >= 400 && response.status < 500) {
+            setPhase('idle');
+            setRunError(t('testRunner.errors.pollFailed'));
+            return;
+          }
+          continue;
+        }
         const detail = await response.json() as TestRunExecution;
         if (pollTokenRef.current !== token) return;
         setExecution(detail);
@@ -228,6 +252,7 @@ export default function ScriptTestRunner({
     if (!execution) return null;
     switch (execution.status) {
       case 'pending':
+      case 'queued':
       case 'running':
         return (
           <span className="inline-flex items-center gap-1.5 rounded-full border border-blue-500/40 bg-blue-500/20 px-2.5 py-1 text-xs font-medium text-blue-700">
@@ -254,6 +279,13 @@ export default function ScriptTestRunner({
           <span className="inline-flex items-center gap-1.5 rounded-full border border-warning/30 bg-warning/15 px-2.5 py-1 text-xs font-medium text-warning">
             <AlertTriangle className="h-3 w-3" />
             {t('testRunner.status.timeout')}
+          </span>
+        );
+      case 'cancelled':
+        return (
+          <span className="inline-flex items-center gap-1.5 rounded-full border bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+            <XCircle className="h-3 w-3" />
+            {t('testRunner.status.cancelled')}
           </span>
         );
     }

--- a/apps/web/src/components/scripts/ScriptTestRunner.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.tsx
@@ -1,0 +1,364 @@
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Play, Loader2, CheckCircle, XCircle, AlertTriangle, Clock, Terminal, AlertOctagon, ExternalLink } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '@/lib/runAction';
+import { navigateTo } from '@/lib/navigation';
+import { asList } from '@/lib/asList';
+import { OutputSection } from './ExecutionDetails';
+import type { OSType } from './ScriptList';
+import type { ScriptParameter } from './ScriptFormSchema';
+
+export type TestDevice = {
+  id: string;
+  hostname: string;
+  os: OSType;
+  status: 'online' | 'offline' | 'maintenance';
+};
+
+type TestRunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'timeout';
+
+type TestRunExecution = {
+  id: string;
+  status: TestRunStatus;
+  exitCode?: number | null;
+  stdout?: string | null;
+  stderr?: string | null;
+  errorMessage?: string | null;
+};
+
+type ScriptTestRunnerProps = {
+  /** Undefined while the script has never been saved — test runs are disabled. */
+  scriptId?: string;
+  osTypes: OSType[];
+  parameters?: ScriptParameter[];
+  timeoutSeconds?: number;
+  isDirty: boolean;
+  /** Save the form in place (no navigation). Resolves true when the save succeeded. */
+  onSaveChanges: () => Promise<boolean>;
+  /** Reports the pinned device so the AI panel context can carry it. */
+  onTestDeviceChange?: (deviceId: string | null) => void;
+  /** Reports the most recent test-run execution id for the AI panel context. */
+  onExecutionChange?: (executionId: string | null) => void;
+};
+
+const POLL_INTERVAL_MS = 2000;
+const TERMINAL_STATUSES: TestRunStatus[] = ['completed', 'failed', 'timeout'];
+
+const storageKey = (scriptId: string) => `breeze:script-test-device:${scriptId}`;
+
+export default function ScriptTestRunner({
+  scriptId,
+  osTypes,
+  parameters,
+  timeoutSeconds,
+  isDirty,
+  onSaveChanges,
+  onTestDeviceChange,
+  onExecutionChange,
+}: ScriptTestRunnerProps) {
+  const { t } = useTranslation('scripts');
+  const [devices, setDevices] = useState<TestDevice[]>([]);
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string>('');
+  const [phase, setPhase] = useState<'idle' | 'saving' | 'starting' | 'polling'>('idle');
+  const [execution, setExecution] = useState<TestRunExecution | null>(null);
+  const [runError, setRunError] = useState<string | null>(null);
+  const pollTokenRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetchWithAuth('/devices');
+        if (!response.ok || cancelled) return;
+        const data = await response.json();
+        if (!cancelled) setDevices(asList(data, 'devices'));
+      } catch {
+        // Non-fatal: the picker just shows the empty state.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const compatibleDevices = useMemo(() => {
+    const matching = devices.filter(device => osTypes?.includes(device.os));
+    // Online first, then by hostname, so the sensible pick is on top.
+    return [...matching].sort((a, b) => {
+      if ((a.status === 'online') !== (b.status === 'online')) {
+        return a.status === 'online' ? -1 : 1;
+      }
+      return a.hostname.localeCompare(b.hostname);
+    });
+  }, [devices, osTypes]);
+
+  // Restore the per-script pinned device once devices are known.
+  useEffect(() => {
+    if (!scriptId || compatibleDevices.length === 0) return;
+    const stored = localStorage.getItem(storageKey(scriptId));
+    if (stored && compatibleDevices.some(d => d.id === stored)) {
+      setSelectedDeviceId(stored);
+      onTestDeviceChange?.(stored);
+    }
+    // Restore once per script — onTestDeviceChange is a stable-enough callback
+    // and re-running on its identity would fight the user's manual selection.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scriptId, compatibleDevices.length]);
+
+  // Cancel any in-flight poll loop on unmount.
+  useEffect(() => () => { pollTokenRef.current += 1; }, []);
+
+  const handleDeviceSelect = (deviceId: string) => {
+    setSelectedDeviceId(deviceId);
+    if (scriptId) {
+      if (deviceId) localStorage.setItem(storageKey(scriptId), deviceId);
+      else localStorage.removeItem(storageKey(scriptId));
+    }
+    onTestDeviceChange?.(deviceId || null);
+  };
+
+  const missingRequiredParams = useMemo(
+    () => (parameters ?? []).filter(p => p.required && !p.defaultValue).map(p => p.name),
+    [parameters]
+  );
+
+  const defaultParameters = useMemo(() => {
+    const result: Record<string, string | number | boolean> = {};
+    for (const p of parameters ?? []) {
+      if (p.defaultValue === undefined || p.defaultValue === '') continue;
+      if (p.type === 'number') result[p.name] = Number(p.defaultValue);
+      else if (p.type === 'boolean') result[p.name] = p.defaultValue === 'true';
+      else result[p.name] = p.defaultValue;
+    }
+    return result;
+  }, [parameters]);
+
+  const pollExecution = useCallback(async (executionId: string) => {
+    const token = ++pollTokenRef.current;
+    // Poll to the script's own timeout plus slack for queue + agent pickup.
+    const deadline = Date.now() + ((timeoutSeconds || 300) + 120) * 1000;
+
+    while (Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+      if (pollTokenRef.current !== token) return;
+
+      try {
+        const response = await fetchWithAuth(`/scripts/executions/${executionId}`);
+        if (response.status === 401) {
+          void navigateTo('/login', { replace: true });
+          return;
+        }
+        if (!response.ok) continue; // transient — keep polling until deadline
+        const detail = await response.json() as TestRunExecution;
+        if (pollTokenRef.current !== token) return;
+        setExecution(detail);
+        if (TERMINAL_STATUSES.includes(detail.status)) {
+          setPhase('idle');
+          return;
+        }
+      } catch {
+        // transient network failure — keep polling until deadline
+      }
+    }
+
+    if (pollTokenRef.current === token) {
+      setPhase('idle');
+      setRunError(t('testRunner.errors.pollDeadline'));
+    }
+  }, [timeoutSeconds, t]);
+
+  const handleRun = async () => {
+    if (!scriptId || !selectedDeviceId || phase !== 'idle') return;
+    setRunError(null);
+
+    if (isDirty) {
+      setPhase('saving');
+      const saved = await onSaveChanges();
+      if (!saved) {
+        setPhase('idle');
+        setRunError(t('testRunner.errors.save'));
+        return;
+      }
+    }
+
+    setPhase('starting');
+    setExecution(null);
+    try {
+      const data = await runAction<{ executions?: Array<{ executionId: string }> }>({
+        request: () => fetchWithAuth(`/scripts/${scriptId}/execute`, {
+          method: 'POST',
+          body: JSON.stringify({
+            deviceIds: [selectedDeviceId],
+            parameters: defaultParameters,
+            triggerType: 'manual',
+          }),
+        }),
+        errorFallback: t('testRunner.errors.execute'),
+        onUnauthorized: () => { void navigateTo('/login', { replace: true }); },
+      });
+
+      const executionId = data.executions?.[0]?.executionId;
+      if (!executionId) {
+        // 201 with zero executions (e.g. maintenance-suppressed) — runAction
+        // treats it as success, so surface it here.
+        setPhase('idle');
+        setRunError(t('testRunner.errors.notStarted'));
+        return;
+      }
+
+      setExecution({ id: executionId, status: 'pending' });
+      onExecutionChange?.(executionId);
+      setPhase('polling');
+      void pollExecution(executionId);
+    } catch (err) {
+      setPhase('idle');
+      if (err instanceof ActionError && err.status === 401) return;
+      // runAction already toasted; keep the inline strip in sync too.
+      setRunError(err instanceof Error && !(err instanceof ActionError)
+        ? t('testRunner.errors.execute')
+        : null);
+    }
+  };
+
+  const selectedDevice = compatibleDevices.find(d => d.id === selectedDeviceId);
+  const busy = phase !== 'idle';
+  const running = execution && !TERMINAL_STATUSES.includes(execution.status);
+
+  const statusChip = () => {
+    if (!execution) return null;
+    switch (execution.status) {
+      case 'pending':
+      case 'running':
+        return (
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-blue-500/40 bg-blue-500/20 px-2.5 py-1 text-xs font-medium text-blue-700">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {t(/* i18n-dynamic */ `testRunner.status.${execution.status}`)}
+          </span>
+        );
+      case 'completed':
+        return (
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-success/30 bg-success/15 px-2.5 py-1 text-xs font-medium text-success">
+            <CheckCircle className="h-3 w-3" />
+            {t('testRunner.status.completed')}
+          </span>
+        );
+      case 'failed':
+        return (
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-destructive/30 bg-destructive/15 px-2.5 py-1 text-xs font-medium text-destructive">
+            <XCircle className="h-3 w-3" />
+            {t('testRunner.status.failed')}
+          </span>
+        );
+      case 'timeout':
+        return (
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-warning/30 bg-warning/15 px-2.5 py-1 text-xs font-medium text-warning">
+            <AlertTriangle className="h-3 w-3" />
+            {t('testRunner.status.timeout')}
+          </span>
+        );
+    }
+  };
+
+  return (
+    <div className="rounded-md border" data-testid="script-test-runner">
+      <div className="flex flex-wrap items-center gap-2 bg-muted/20 px-3 py-2">
+        <span className="inline-flex items-center gap-1.5 text-sm font-medium">
+          <Terminal className="h-4 w-4 text-muted-foreground" />
+          {t('testRunner.title')}
+        </span>
+        <select
+          value={selectedDeviceId}
+          onChange={event => handleDeviceSelect(event.target.value)}
+          disabled={!scriptId || busy}
+          data-testid="test-device-select"
+          className="h-9 min-w-48 flex-1 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-60 sm:flex-none"
+        >
+          <option value="">
+            {compatibleDevices.length === 0
+              ? t('testRunner.noDevices')
+              : t('testRunner.devicePlaceholder')}
+          </option>
+          {compatibleDevices.map(device => (
+            <option key={device.id} value={device.id}>
+              {device.hostname}
+              {device.status !== 'online' ? ` (${t(/* i18n-dynamic */ `testRunner.deviceStatus.${device.status}`)})` : ''}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={handleRun}
+          disabled={!scriptId || !selectedDeviceId || busy || missingRequiredParams.length > 0}
+          data-testid="test-run-button"
+          className="inline-flex h-9 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+          {phase === 'saving'
+            ? t('common:states.saving')
+            : isDirty
+              ? t('testRunner.saveAndRun')
+              : t('testRunner.run')}
+        </button>
+        {statusChip()}
+        {execution && typeof execution.exitCode === 'number' && (
+          <span className={cn(
+            'inline-flex items-center rounded px-2 py-0.5 text-xs font-mono',
+            execution.exitCode === 0 ? 'bg-success/15 text-success' : 'bg-destructive/15 text-destructive'
+          )}>
+            {t('testRunner.exitCode', { code: execution.exitCode })}
+          </span>
+        )}
+        {scriptId && (
+          <a
+            href={`/scripts/${scriptId}/executions`}
+            className="ml-auto inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {t('testRunner.viewHistory')}
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        )}
+      </div>
+
+      {!scriptId && (
+        <p className="border-t px-3 py-2 text-xs text-muted-foreground">
+          {t('testRunner.saveFirst')}
+        </p>
+      )}
+      {scriptId && missingRequiredParams.length > 0 && (
+        <p className="border-t px-3 py-2 text-xs text-warning">
+          {t('testRunner.requiredParams', { params: missingRequiredParams.join(', ') })}
+        </p>
+      )}
+      {scriptId && selectedDevice && selectedDevice.status !== 'online' && !busy && (
+        <p className="flex items-center gap-1.5 border-t px-3 py-2 text-xs text-warning">
+          <Clock className="h-3 w-3" />
+          {t('testRunner.offlineWarning')}
+        </p>
+      )}
+      {runError && (
+        <p className="border-t px-3 py-2 text-xs text-destructive">{runError}</p>
+      )}
+
+      {execution && !running && TERMINAL_STATUSES.includes(execution.status) && (
+        <div className="space-y-3 border-t p-3">
+          {execution.errorMessage && (
+            <p className="text-sm text-destructive">{execution.errorMessage}</p>
+          )}
+          <OutputSection
+            title={t('executionDetails.output.stdout')}
+            content={execution.stdout ?? undefined}
+            icon={Terminal}
+            defaultOpen={true}
+          />
+          <OutputSection
+            title={t('executionDetails.output.stderr')}
+            content={execution.stderr ?? undefined}
+            icon={AlertOctagon}
+            defaultOpen={!!execution.stderr}
+            variant="error"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -1237,13 +1237,16 @@
       "running": "Läuft",
       "completed": "Abgeschlossen",
       "failed": "Fehlgeschlagen",
-      "timeout": "Zeitüberschreitung"
+      "timeout": "Zeitüberschreitung",
+      "queued": "In Warteschlange",
+      "cancelled": "Abgebrochen"
     },
     "errors": {
       "execute": "Testlauf konnte nicht gestartet werden",
       "save": "Speichern fehlgeschlagen — beheben Sie die Fehler oben und versuchen Sie es erneut.",
       "notStarted": "Der Lauf wurde nicht gestartet (das Gerät befindet sich möglicherweise in Wartung).",
-      "pollDeadline": "Noch kein Ergebnis — prüfen Sie den Ausführungsverlauf."
+      "pollDeadline": "Noch kein Ergebnis — prüfen Sie den Ausführungsverlauf.",
+      "pollFailed": "Ergebnis konnte nicht gelesen werden — der Lauf wurde möglicherweise gelöscht oder Ihr Zugriff hat sich geändert."
     }
   }
 }

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -1216,5 +1216,34 @@
     "scriptCount": "{{count}} Skripte im Bundle",
     "statusInvalid": "Ungültig",
     "exportLimit": "Sie können bis zu {{max}} Skripte pro Bundle exportieren."
+  },
+  "testRunner": {
+    "title": "Testlauf",
+    "devicePlaceholder": "Testgerät auswählen…",
+    "noDevices": "Keine kompatiblen Geräte",
+    "deviceStatus": {
+      "offline": "nicht verbunden",
+      "maintenance": "Wartung"
+    },
+    "run": "Testlauf starten",
+    "saveAndRun": "Speichern & Testlauf",
+    "saveFirst": "Speichern Sie das Skript einmal, um Testläufe zu aktivieren.",
+    "requiredParams": "Pflichtparameter ohne Standardwerte ({{params}}) — verwenden Sie stattdessen den Dialog „Skript ausführen“.",
+    "offlineWarning": "Das ausgewählte Gerät ist offline — der Lauf wartet, bis es sich wieder verbindet.",
+    "exitCode": "Exit {{code}}",
+    "viewHistory": "Verlauf anzeigen",
+    "status": {
+      "pending": "In Warteschlange",
+      "running": "Läuft",
+      "completed": "Abgeschlossen",
+      "failed": "Fehlgeschlagen",
+      "timeout": "Zeitüberschreitung"
+    },
+    "errors": {
+      "execute": "Testlauf konnte nicht gestartet werden",
+      "save": "Speichern fehlgeschlagen — beheben Sie die Fehler oben und versuchen Sie es erneut.",
+      "notStarted": "Der Lauf wurde nicht gestartet (das Gerät befindet sich möglicherweise in Wartung).",
+      "pollDeadline": "Noch kein Ergebnis — prüfen Sie den Ausführungsverlauf."
+    }
   }
 }

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -1237,13 +1237,16 @@
       "running": "Running",
       "completed": "Completed",
       "failed": "Failed",
-      "timeout": "Timed out"
+      "timeout": "Timed out",
+      "queued": "Queued",
+      "cancelled": "Cancelled"
     },
     "errors": {
       "execute": "Failed to start the test run",
       "save": "Save failed — fix the errors above and try again.",
       "notStarted": "The run was not started (the device may be in maintenance).",
-      "pollDeadline": "Still no result — check the execution history for the outcome."
+      "pollDeadline": "Still no result — check the execution history for the outcome.",
+      "pollFailed": "Could not read the run result — it may have been deleted or your access changed."
     }
   }
 }

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -1216,5 +1216,34 @@
     "scriptCount": "{{count}} scripts in bundle",
     "statusInvalid": "Invalid",
     "exportLimit": "You can export up to {{max}} scripts per bundle."
+  },
+  "testRunner": {
+    "title": "Test run",
+    "devicePlaceholder": "Select a test device…",
+    "noDevices": "No compatible devices",
+    "deviceStatus": {
+      "offline": "offline",
+      "maintenance": "maintenance"
+    },
+    "run": "Test Run",
+    "saveAndRun": "Save & Test Run",
+    "saveFirst": "Save the script once to enable test runs.",
+    "requiredParams": "Required parameters without defaults ({{params}}) — use the Run Script dialog instead.",
+    "offlineWarning": "The selected device is offline — the run will wait until it reconnects.",
+    "exitCode": "exit {{code}}",
+    "viewHistory": "View history",
+    "status": {
+      "pending": "Queued",
+      "running": "Running",
+      "completed": "Completed",
+      "failed": "Failed",
+      "timeout": "Timed out"
+    },
+    "errors": {
+      "execute": "Failed to start the test run",
+      "save": "Save failed — fix the errors above and try again.",
+      "notStarted": "The run was not started (the device may be in maintenance).",
+      "pollDeadline": "Still no result — check the execution history for the outcome."
+    }
   }
 }

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -1216,5 +1216,34 @@
     "scriptCount": "{{count}} scripts en el paquete",
     "statusInvalid": "Inválido",
     "exportLimit": "Puedes exportar hasta {{max}} scripts por paquete."
+  },
+  "testRunner": {
+    "title": "Ejecución de prueba",
+    "devicePlaceholder": "Seleccionar dispositivo de prueba…",
+    "noDevices": "No hay dispositivos compatibles",
+    "deviceStatus": {
+      "offline": "desconectado",
+      "maintenance": "mantenimiento"
+    },
+    "run": "Ejecutar prueba",
+    "saveAndRun": "Guardar y probar",
+    "saveFirst": "Guarda el script una vez para habilitar las ejecuciones de prueba.",
+    "requiredParams": "Parámetros obligatorios sin valores predeterminados ({{params}}) — usa el diálogo Ejecutar script.",
+    "offlineWarning": "El dispositivo seleccionado está desconectado — la ejecución esperará hasta que se reconecte.",
+    "exitCode": "salida {{code}}",
+    "viewHistory": "Ver historial",
+    "status": {
+      "pending": "En cola",
+      "running": "En ejecución",
+      "completed": "Completada",
+      "failed": "Fallida",
+      "timeout": "Tiempo agotado"
+    },
+    "errors": {
+      "execute": "No se pudo iniciar la ejecución de prueba",
+      "save": "Error al guardar — corrige los errores anteriores e inténtalo de nuevo.",
+      "notStarted": "La ejecución no se inició (el dispositivo puede estar en mantenimiento).",
+      "pollDeadline": "Aún sin resultado — revisa el historial de ejecuciones."
+    }
   }
 }

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -1237,13 +1237,16 @@
       "running": "En ejecución",
       "completed": "Completada",
       "failed": "Fallida",
-      "timeout": "Tiempo agotado"
+      "timeout": "Tiempo agotado",
+      "queued": "En cola",
+      "cancelled": "Cancelada"
     },
     "errors": {
       "execute": "No se pudo iniciar la ejecución de prueba",
       "save": "Error al guardar — corrige los errores anteriores e inténtalo de nuevo.",
       "notStarted": "La ejecución no se inició (el dispositivo puede estar en mantenimiento).",
-      "pollDeadline": "Aún sin resultado — revisa el historial de ejecuciones."
+      "pollDeadline": "Aún sin resultado — revisa el historial de ejecuciones.",
+      "pollFailed": "No se pudo leer el resultado — la ejecución pudo haber sido eliminada o tu acceso cambió."
     }
   }
 }

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -1216,5 +1216,34 @@
     "scriptCount": "{{count}} scripts dans le bundle",
     "statusInvalid": "Invalide",
     "exportLimit": "Vous pouvez exporter jusqu’à {{max}} scripts par bundle."
+  },
+  "testRunner": {
+    "title": "Exécution de test",
+    "devicePlaceholder": "Sélectionner un appareil de test…",
+    "noDevices": "Aucun appareil compatible",
+    "deviceStatus": {
+      "offline": "hors ligne",
+      "maintenance": "en maintenance"
+    },
+    "run": "Lancer le test",
+    "saveAndRun": "Enregistrer et tester",
+    "saveFirst": "Enregistrez le script une première fois pour activer les exécutions de test.",
+    "requiredParams": "Paramètres obligatoires sans valeur par défaut ({{params}}) — utilisez plutôt la boîte de dialogue Exécuter le script.",
+    "offlineWarning": "L'appareil sélectionné est hors ligne — l'exécution attendra sa reconnexion.",
+    "exitCode": "sortie {{code}}",
+    "viewHistory": "Voir l'historique",
+    "status": {
+      "pending": "En attente",
+      "running": "En cours",
+      "completed": "Terminée",
+      "failed": "Échouée",
+      "timeout": "Délai expiré"
+    },
+    "errors": {
+      "execute": "Impossible de démarrer l'exécution de test",
+      "save": "Échec de l'enregistrement — corrigez les erreurs ci-dessus et réessayez.",
+      "notStarted": "L'exécution n'a pas démarré (l'appareil est peut-être en maintenance).",
+      "pollDeadline": "Toujours aucun résultat — consultez l'historique des exécutions."
+    }
   }
 }

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -1237,13 +1237,16 @@
       "running": "En cours",
       "completed": "Terminée",
       "failed": "Échouée",
-      "timeout": "Délai expiré"
+      "timeout": "Délai expiré",
+      "queued": "En file",
+      "cancelled": "Annulée"
     },
     "errors": {
       "execute": "Impossible de démarrer l'exécution de test",
       "save": "Échec de l'enregistrement — corrigez les erreurs ci-dessus et réessayez.",
       "notStarted": "L'exécution n'a pas démarré (l'appareil est peut-être en maintenance).",
-      "pollDeadline": "Toujours aucun résultat — consultez l'historique des exécutions."
+      "pollDeadline": "Toujours aucun résultat — consultez l'historique des exécutions.",
+      "pollFailed": "Impossible de lire le résultat — l'exécution a peut-être été supprimée ou votre accès a changé."
     }
   }
 }

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -1216,5 +1216,34 @@
     "scriptCount": "{{count}} scripts dans le bundle",
     "statusInvalid": "Invalide",
     "exportLimit": "Vous pouvez exporter jusqu’à {{max}} scripts par bundle."
+  },
+  "testRunner": {
+    "title": "Exécution de test",
+    "devicePlaceholder": "Sélectionner un appareil de test…",
+    "noDevices": "Aucun appareil compatible",
+    "deviceStatus": {
+      "offline": "hors ligne",
+      "maintenance": "en maintenance"
+    },
+    "run": "Lancer le test",
+    "saveAndRun": "Enregistrer et tester",
+    "saveFirst": "Enregistrez le script une première fois pour activer les exécutions de test.",
+    "requiredParams": "Paramètres obligatoires sans valeur par défaut ({{params}}) — utilisez plutôt la boîte de dialogue Exécuter le script.",
+    "offlineWarning": "L'appareil sélectionné est hors ligne — l'exécution attendra sa reconnexion.",
+    "exitCode": "sortie {{code}}",
+    "viewHistory": "Voir l'historique",
+    "status": {
+      "pending": "En attente",
+      "running": "En cours",
+      "completed": "Terminée",
+      "failed": "Échouée",
+      "timeout": "Délai expiré"
+    },
+    "errors": {
+      "execute": "Impossible de démarrer l'exécution de test",
+      "save": "Échec de l'enregistrement — corrigez les erreurs ci-dessus et réessayez.",
+      "notStarted": "L'exécution n'a pas démarré (l'appareil est peut-être en maintenance).",
+      "pollDeadline": "Toujours aucun résultat — consultez l'historique des exécutions."
+    }
   }
 }

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -1237,13 +1237,16 @@
       "running": "En cours",
       "completed": "Terminée",
       "failed": "Échouée",
-      "timeout": "Délai expiré"
+      "timeout": "Délai expiré",
+      "queued": "En file",
+      "cancelled": "Annulée"
     },
     "errors": {
       "execute": "Impossible de démarrer l'exécution de test",
       "save": "Échec de l'enregistrement — corrigez les erreurs ci-dessus et réessayez.",
       "notStarted": "L'exécution n'a pas démarré (l'appareil est peut-être en maintenance).",
-      "pollDeadline": "Toujours aucun résultat — consultez l'historique des exécutions."
+      "pollDeadline": "Toujours aucun résultat — consultez l'historique des exécutions.",
+      "pollFailed": "Impossible de lire le résultat — l'exécution a peut-être été supprimée ou votre accès a changé."
     }
   }
 }

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -1216,5 +1216,34 @@
     "scriptCount": "{{count}} script nel bundle",
     "statusInvalid": "Non valido",
     "exportLimit": "Puoi esportare fino a {{max}} script per bundle."
+  },
+  "testRunner": {
+    "title": "Esecuzione di prova",
+    "devicePlaceholder": "Seleziona un dispositivo di prova…",
+    "noDevices": "Nessun dispositivo compatibile",
+    "deviceStatus": {
+      "offline": "non in linea",
+      "maintenance": "manutenzione"
+    },
+    "run": "Esegui prova",
+    "saveAndRun": "Salva ed esegui prova",
+    "saveFirst": "Salva lo script una volta per abilitare le esecuzioni di prova.",
+    "requiredParams": "Parametri obbligatori senza valori predefiniti ({{params}}) — usa invece la finestra Esegui script.",
+    "offlineWarning": "Il dispositivo selezionato è offline — l'esecuzione attenderà la riconnessione.",
+    "exitCode": "codice {{code}}",
+    "viewHistory": "Vedi cronologia",
+    "status": {
+      "pending": "In coda",
+      "running": "In esecuzione",
+      "completed": "Completata",
+      "failed": "Non riuscita",
+      "timeout": "Tempo scaduto"
+    },
+    "errors": {
+      "execute": "Impossibile avviare l'esecuzione di prova",
+      "save": "Salvataggio non riuscito — correggi gli errori sopra e riprova.",
+      "notStarted": "L'esecuzione non è stata avviata (il dispositivo potrebbe essere in manutenzione).",
+      "pollDeadline": "Ancora nessun risultato — controlla la cronologia delle esecuzioni."
+    }
   }
 }

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -1237,13 +1237,16 @@
       "running": "In esecuzione",
       "completed": "Completata",
       "failed": "Non riuscita",
-      "timeout": "Tempo scaduto"
+      "timeout": "Tempo scaduto",
+      "queued": "In coda",
+      "cancelled": "Annullata"
     },
     "errors": {
       "execute": "Impossibile avviare l'esecuzione di prova",
       "save": "Salvataggio non riuscito — correggi gli errori sopra e riprova.",
       "notStarted": "L'esecuzione non è stata avviata (il dispositivo potrebbe essere in manutenzione).",
-      "pollDeadline": "Ancora nessun risultato — controlla la cronologia delle esecuzioni."
+      "pollDeadline": "Ancora nessun risultato — controlla la cronologia delle esecuzioni.",
+      "pollFailed": "Impossibile leggere il risultato — l'esecuzione potrebbe essere stata eliminata o il tuo accesso è cambiato."
     }
   }
 }

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -1237,13 +1237,16 @@
       "running": "Em execução",
       "completed": "Concluída",
       "failed": "Falhou",
-      "timeout": "Tempo esgotado"
+      "timeout": "Tempo esgotado",
+      "queued": "Na fila",
+      "cancelled": "Cancelada"
     },
     "errors": {
       "execute": "Falha ao iniciar a execução de teste",
       "save": "Falha ao salvar — corrija os erros acima e tente novamente.",
       "notStarted": "A execução não foi iniciada (o dispositivo pode estar em manutenção).",
-      "pollDeadline": "Ainda sem resultado — verifique o histórico de execuções."
+      "pollDeadline": "Ainda sem resultado — verifique o histórico de execuções.",
+      "pollFailed": "Não foi possível ler o resultado — a execução pode ter sido excluída ou seu acesso mudou."
     }
   }
 }

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -1216,5 +1216,34 @@
     "scriptCount": "{{count}} scripts no pacote",
     "statusInvalid": "Inválido",
     "exportLimit": "Você pode exportar até {{max}} scripts por pacote."
+  },
+  "testRunner": {
+    "title": "Execução de teste",
+    "devicePlaceholder": "Selecionar dispositivo de teste…",
+    "noDevices": "Nenhum dispositivo compatível",
+    "deviceStatus": {
+      "offline": "desconectado",
+      "maintenance": "manutenção"
+    },
+    "run": "Executar teste",
+    "saveAndRun": "Salvar e testar",
+    "saveFirst": "Salve o script uma vez para habilitar execuções de teste.",
+    "requiredParams": "Parâmetros obrigatórios sem valores padrão ({{params}}) — use a caixa de diálogo Executar script.",
+    "offlineWarning": "O dispositivo selecionado está offline — a execução aguardará até que ele reconecte.",
+    "exitCode": "saída {{code}}",
+    "viewHistory": "Ver histórico",
+    "status": {
+      "pending": "Na fila",
+      "running": "Em execução",
+      "completed": "Concluída",
+      "failed": "Falhou",
+      "timeout": "Tempo esgotado"
+    },
+    "errors": {
+      "execute": "Falha ao iniciar a execução de teste",
+      "save": "Falha ao salvar — corrija os erros acima e tente novamente.",
+      "notStarted": "A execução não foi iniciada (o dispositivo pode estar em manutenção).",
+      "pollDeadline": "Ainda sem resultado — verifique o histórico de execuções."
+    }
   }
 }

--- a/apps/web/src/stores/scriptAiStore.ts
+++ b/apps/web/src/stores/scriptAiStore.ts
@@ -74,6 +74,12 @@ export interface ScriptFormBridge {
   takeSnapshot: () => ScriptFormSnapshot;
   /** Restore a previously taken snapshot */
   restoreSnapshot: (snapshot: ScriptFormSnapshot) => void;
+  /** Saved script id, when the editor holds an already-saved script */
+  getScriptId?: () => string | null;
+  /** Device the user pinned in the editor's test runner */
+  getTestDeviceId?: () => string | null;
+  /** Most recent test-run execution started from the editor */
+  getLastTestExecutionId?: () => string | null;
 }
 
 interface PendingApproval {
@@ -138,6 +144,23 @@ function isApplyTool(toolName: string | undefined): boolean {
 
 function baseToolName(toolName: string): string {
   return toolName.includes('__') ? toolName.split('__').pop()! : toolName;
+}
+
+/** Build the session context from the editor bridge: snapshot plus the saved
+ *  script id / pinned test device / last test run, when the form knows them.
+ *  Exported for ScriptAiPanel's mount-time session create. */
+export function buildEditorContext(bridge: ScriptFormBridge | null): ScriptBuilderContext | undefined {
+  if (!bridge) return undefined;
+  const context: ScriptBuilderContext = {
+    editorSnapshot: bridge.getFormValues() as ScriptBuilderContext['editorSnapshot'],
+  };
+  const scriptId = bridge.getScriptId?.();
+  if (scriptId) context.scriptId = scriptId;
+  const targetDeviceId = bridge.getTestDeviceId?.();
+  if (targetDeviceId) context.targetDeviceId = targetDeviceId;
+  const lastTestExecutionId = bridge.getLastTestExecutionId?.();
+  if (lastTestExecutionId) context.lastTestExecutionId = lastTestExecutionId;
+  return context;
 }
 
 // ============================================
@@ -233,10 +256,7 @@ export const useScriptAiStore = create<ScriptAiState>()(
 
       // Create session if needed — use current editor state as context
       if (!sessionId) {
-        const editorContext: ScriptBuilderContext | undefined = _bridge
-          ? { editorSnapshot: _bridge.getFormValues() as ScriptBuilderContext['editorSnapshot'] }
-          : undefined;
-        await get().createSession(editorContext);
+        await get().createSession(buildEditorContext(_bridge));
       }
 
       const currentSessionId = get().sessionId;
@@ -260,10 +280,7 @@ export const useScriptAiStore = create<ScriptAiState>()(
 
       try {
         // Build editor context from bridge for system prompt refresh
-        const bridge = get()._bridge;
-        const editorContext: ScriptBuilderContext | undefined = bridge
-          ? { editorSnapshot: bridge.getFormValues() as ScriptBuilderContext['editorSnapshot'] }
-          : undefined;
+        const editorContext = buildEditorContext(get()._bridge);
 
         const res = await fetchWithAuth(
           `/ai/script-builder/sessions/${currentSessionId}/messages`,

--- a/docs/superpowers/specs/web-ui/2026-08-15-script-editor-test-loop-design.md
+++ b/docs/superpowers/specs/web-ui/2026-08-15-script-editor-test-loop-design.md
@@ -1,0 +1,85 @@
+# Script Editor Test Loop — Design
+
+**Date:** 2026-08-15
+**Status:** Draft v2 — post advisor quorum (Codex xhigh reviewed; both contentious decisions revised). Pending user review.
+**Related fix (shipped alongside, commit `fe1211974`):** script-level executions page never showed stdout/stderr — `GET /scripts/:id/executions` omits the output columns and the page handed the stripped list row to the details modal. Fixed by fetching `GET /scripts/executions/:id` on open and adding `scriptName` to the list response.
+
+## Problem
+
+Iterating on a script today means: edit in `/scripts/:id` → navigate to the scripts list or a device page → run via `ScriptExecutionModal` → navigate to executions/device history → open the result → go back to the editor. The AI sidecar (`script_builder` session) can edit the buffer (`apply_script_code`) and can run *saved* scripts (`execute_script_on_device`, tier 3), but it does not know which script it is editing, cannot run unsaved edits, and every run hits an approval modal — so "AI tests and iterates" doesn't actually work end-to-end.
+
+## What already exists (leverage, don't rebuild)
+
+- `execute_script_on_device` (script-builder MCP, `scriptBuilderTools.ts:289`) → proxies the main `run_script` handler (`aiToolsScripts.ts:170`), which blocks up to 60s via `waitForCommandResult` and returns stdout/stderr/exitCode inline. The synchronous result loop the feature needs is already built.
+- Editor AI sidecar with SSE streaming, approval events, and a form bridge (`ScriptAiPanel`, `scriptAiStore`, `ScriptFormBridge`). Sessions are rows in `ai_sessions` with `type='script_builder'`.
+- Each user message ships the current `editorSnapshot` to the server, and the `apply_script_code` handler knows the content it instructed the client to apply — so the server can maintain an authoritative draft without new sync machinery.
+- `dispatchScriptToDevice` (`scriptDispatch.ts:87`) takes resolved content and records a `script_executions` row; results flow back via agent WS → `handleScriptResult` (`commandResultHandlers.ts:320`).
+- Tier-3 tool calls flow through the durable action-intent approval path (`aiAgentSdk.ts:879`, `aiAgent.ts` `handleApproval` with session-owner enforcement). Any grant mechanism must integrate here, not bolt a checkbox onto the client dialog.
+
+## Phasing (quorum-driven)
+
+**v1 — human-runs, AI-reads (ships the core ask with minimal new attack surface):**
+editor test-device picker, Save & Test Run button + results strip, `scriptId`/`targetDeviceId` in the AI context, `get_script_execution` tier-1 tool. The user runs from the editor; the AI immediately reads the result and iterates on the code. AI-initiated runs still work today via `execute_script_on_device` with per-run approval.
+
+**v2 — AI-runs with scoped auto-approval:**
+`test_script` (server-draft execution) + session tool grants. Needs the server-side draft, execution-content audit, and the grant table below.
+
+## Design
+
+### A. Pinned test device (editor state + AI context) — v1
+
+- **"Test device"** picker in `ScriptForm`'s toolbar (compact combobox; devices filtered to the script's `osTypes`, online first). Persist per-script in `localStorage` (`breeze:script-test-device:<scriptId>`). No schema change.
+- Extend `ScriptFormBridge` with `getTestDeviceId()`; send the already-declared-but-never-populated `ScriptBuilderContext.scriptId` plus new `targetDeviceId` on session create and each message; feed both into `buildScriptBuilderSystemPrompt`.
+- Plumbing note (quorum): `ScriptForm` has no `scriptId` prop today — `ScriptEditPage` owns the id and must pass it down.
+
+### B. Run from the editor (human path) — v1
+
+- **"Save & Test Run" button** in the editor header, enabled when a test device is pinned: save (create draft on first save), then `POST /scripts/:id/execute` with `deviceIds: [testDeviceId]`, `triggerType: 'manual'`. Inherits the route's `requireMfa()`.
+- Refactor required (quorum): the current save handler navigates back to `/scripts` and discards the created id (`ScriptEditPage.tsx:90`). Save must become save-in-place returning the script id, with navigation only on explicit "Save & Close".
+- **Results strip** at the bottom of the editor (collapsible): status chip while pending/running, then exit code + stdout/stderr via the existing `OutputSection`. Poll `GET /scripts/executions/:id` every 2s until terminal status (cap at the script's `timeoutSeconds`, ceiling 1h). No websocket work.
+- After a run completes, the result lands in the AI context two ways: the system prompt names the latest execution id, and the model can call `get_script_execution` — so "user runs, AI fixes" needs no further plumbing.
+
+### C. `get_script_execution` (tier 1, both tool surfaces) — v1
+
+New read-only tool: `{ executionId: uuid }` → status, exitCode, stdout, stderr, errorMessage, timing; same access checks as `GET /scripts/executions/:id`. Closes the "run outlived the 60s tool window and there is no recovery" gap. Register in `aiToolsScripts.ts` (tier 1) and the script-builder allowlist.
+
+### D. `test_script` — AI-initiated run of the working draft — v2
+
+Replaces `execute_script_on_device` in the script-builder allowlist (the global-agent `run_script` is untouched).
+
+- Input: `{ deviceId?: uuid, parameters?, runAs? }` — defaults to the session's pinned test device; structured error if none.
+- **Content source: a server-side session draft, not the message-carried snapshot.** Quorum finding: `apply_script_code` mutates the client form, and the server only receives the new buffer on the *next* user message — "run the latest snapshot" would execute stale code within the same turn. Instead the server keeps an authoritative draft per session (revision counter + content), updated by (a) the `editorSnapshot` on each incoming message and (b) every `apply_script_code` call at the moment the server emits it. `test_script` resolves exactly one revision at invocation and dispatches that content.
+- **Audit:** the resolved content's SHA-256, revision, effective `runAs`, and canonical parameters are stamped into the `ai_tool_executions` record for the call (which already stores tool input), alongside `executionId`. Full content is recoverable from the chat transcript + revision; we do not add a content column to `script_executions` (avoids a new export-policy classification for v1-adjacent work). If ops experience shows hash+transcript is insufficient for reproduction, add an encrypted snapshot store as a follow-up.
+- Requires the script to have been saved at least once (`script_executions.script_id` is NOT NULL). New scripts: the v1 Save & Test Run flow creates the draft.
+- Executes through the same guarded pipeline as `run_script`: `verifyDeviceAccess`, script↔device org/partner equality, dispatch, redaction. Wire via `makeExistingHandler` so `onPreToolUse` runs (never `makeApplyHandler`).
+- **Timeout handling (corrected per quorum):** `waitForCommandResult` *terminalizes* the command at its deadline (marks it failed/timeout, after which the late agent result loses the CAS in `agentWs.ts` and is dropped). `test_script` must instead use a non-mutating poll capped at ~50s (inside the 60s MCP tool timeout) and, if still running, return `{ status: 'running', executionId }` without touching the command row, directing the model to `get_script_execution`.
+- **Default resolution before approval:** the guardrail/approval hook currently sees raw tool arguments; `test_script` must resolve the effective device, `runAs`, and parameters *before* the approval/grant check so the user approves (and the grant matches) what actually executes.
+
+### E. Approval model — scoped session tool grants — v2
+
+`test_script` stays tier 3, flowing through the existing action-intent approval path. To remove per-iteration friction, the approval UI offers **"Auto-approve test runs like this for the rest of this session"**, which creates a server-side grant. Quorum pushback accepted: device-only matching over-scopes an RCE capability, and mutable session JSON (`contextSnapshot` is client-derived and replaced every message) is the wrong storage.
+
+- **New table `ai_session_tool_grants`** (RLS shape 1, direct `org_id`; register in `CORE_ORG_CASCADE_DELETE_ORDER` + `CORE_TENANT_EXPORT_POLICY` in the same PR): `id, org_id, session_id, granted_by_user_id, tool ('test_script'), script_id, device_id, allowed_run_as, timeout_ceiling_secs, granting_execution_id, created_at, expires_at, revoked_at, last_used_at`.
+- **Match key on use:** session + owner (caller must equal `granted_by_user_id` — note `getScriptBuilderSession` is org-scoped, not user-scoped, so this check is explicit) + tool + `script_id` + `device_id` + effective `runAs` ⊆ `allowed_run_as` + not expired/revoked. Content is *intended* to vary (that's the feature) and the consent copy says so explicitly: "any code currently in this editor session". Anything outside the key → normal tier-3 approval.
+- Auto-approved calls are logged tier-2-style (`auto_approved_by_grant: <grantId>`) with the content hash from §D. Grants default-expire after 4h or session end; revocation sets `revoked_at` (rows retained for audit, never deleted outside org erasure). Revocable via a chip in the panel header.
+- Grant creation happens server-side inside the approval decision handler (which already enforces session ownership), never from a bare session lookup.
+- MFA note (corrected per quorum): the script-builder routes — session create, messages, approve — already `requireMfa()`, so there is no human-vs-AI MFA asymmetry on this surface. Grant lifetime (4h) deliberately sits inside typical MFA freshness.
+
+### F. Explicitly out of scope
+
+Websocket/live-tail of output; multi-device test matrices; encrypted per-execution content store (follow-up trigger in §D); `approvalMode` for the global agent sidebar; running never-saved scripts; agent-side changes (none needed).
+
+## Quorum record (2026-08-15, Codex gpt-5.6-sol xhigh, read-only)
+
+Codex DISAGREED with both v1-draft decisions; verdicts accepted in part:
+
+1. *Run-what-you-see from message-carried snapshot* — *accepted*: the same-turn staleness race is real; moved to a server-side revisioned draft with per-run content hash in the audit record. *Rejected as v2-overkill*: full encrypted immutable artifact store with client revision acknowledgement (hash + transcript + revision covers audit; artifact store is the named follow-up).
+2. *Device-only session grant in session JSON* — *accepted*: dedicated RLS'd grant table, grant key widened to owner + script + device + runAs + expiry, integration with the action-intent approval path, retention over deletion. *Rejected*: binding the grant to a language/OS "profile" (the script row already fixes language, and osType is implied by the pinned device).
+
+Codex also surfaced three factual corrections folded in above: `waitForCommandResult` terminalizes on timeout (no naive "return running"); scriptAi routes already require MFA; the editor save path navigates away and must be refactored for save-in-place.
+
+## Implementation order
+
+**v1:** (1) `get_script_execution` tool + allowlists; (2) save-in-place refactor in `ScriptEditPage`/`ScriptForm`; (3) test-device picker + bridge/context/system-prompt plumbing; (4) Save & Test Run + results strip. Tests: tool-handler unit (access checks), web tests for picker/save-in-place/results polling.
+
+**v2:** (5) server-side session draft revisions; (6) `test_script` (non-mutating wait + pre-approval default resolution); (7) `ai_session_tool_grants` migration + RLS + cascade/export registration + grant path in the approval handler; (8) approval-UI checkbox + revocation chip. Tests: draft-revision race (apply→run same turn), grant match/mismatch matrix (device, runAs, expiry, non-owner), integration test proving a granted session auto-executes on the granted device and still blocks on any other device, RLS forge test for the grants table.

--- a/packages/shared/src/types/ai.ts
+++ b/packages/shared/src/types/ai.ts
@@ -240,6 +240,10 @@ export type RunAs = ScriptRunAs;
 
 export interface ScriptBuilderContext {
   scriptId?: string;
+  /** Device the user pinned in the editor for test runs. */
+  targetDeviceId?: string;
+  /** Most recent test-run execution started from the editor. */
+  lastTestExecutionId?: string;
   editorSnapshot?: {
     name?: string;
     content?: string;

--- a/packages/shared/src/validators/ai.ts
+++ b/packages/shared/src/validators/ai.ts
@@ -78,6 +78,8 @@ export const aiSessionQuerySchema = z.object({
 
 export const scriptBuilderContextSchema = z.object({
   scriptId: z.string().guid().optional(),
+  targetDeviceId: z.string().guid().optional(),
+  lastTestExecutionId: z.string().guid().optional(),
   editorSnapshot: z.object({
     name: z.string().max(255).optional(),
     content: z.string().max(500_000).optional(),


### PR DESCRIPTION
## What

**Fix — script executions page showed no output.** `GET /scripts/:id/executions` omits `stdout`/`stderr` from its SELECT (intentionally, to keep the list payload small), but `ScriptExecutionsPage` handed the stripped list row straight to the details modal — so output never rendered, while the device view (whose list endpoint includes the columns) worked. Opening details now fetches the existing `GET /scripts/executions/:id` and merges the full record in. Also fixes two adjacent crashes: the list endpoint didn't return `scriptName`, so typing in the search box threw; and sort/filter now tolerate a null hostname from the left join (deleted devices).

**Feature — in-editor script test loop (v1).** Edit → run → read output without leaving the editor, for both the user and the AI sidecar:

- **ScriptTestRunner** under the editor: pin a test device (per-script, localStorage, filtered to the script's OS targets, online first), **Save & Test Run** (save-in-place — the explicit Save button keeps its return-to-list behavior), and an inline result strip that polls the execution to a terminal state and renders exit code + stdout/stderr.
- **New tier-1 `get_script_execution` AI tool** (single execution by id, with output), registered in all guardrail registries, the script-builder MCP server, and the main Breeze MCP server. Closes the dead end where a run outliving the 60s tool window had no recovery path (`get_script_execution_history` was the only fallback and can't target one run).
- **AI context plumbing:** the script-builder session now carries `scriptId` (declared in the types since day one but never populated), `targetDeviceId`, and `lastTestExecutionId`, rendered into the system prompt — so the model knows which script it's editing, where to test it, and which run to read, instead of guessing via `list_scripts`.

Design spec: `docs/superpowers/specs/web-ui/2026-08-15-script-editor-test-loop-design.md` — reviewed by a Codex xhigh advisor pass; v2 (AI-initiated runs of the working draft + session-scoped auto-approval grants) is specced but deliberately not built here.

## Testing

- New: `aiToolsScripts.getExecution.test.ts` (tier, output shape, org/site denial, deleted device), `scriptBuilderPrompt.test.ts` (context id rendering), `ScriptTestRunner.test.tsx` (6 cases: unsaved gating, OS filtering, run→poll→output, dirty-save abort, required-param gating, pinned-device restore).
- Full API unit suite (22k tests), full web suite (5.5k tests incl. locale parity + translation coverage for the 7-locale strings), shared suite, and `tsc` on api/web/shared — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)