### PR TITLE
fix(api): normalize the status glyphs that actually broke AI PowerShell

### DIFF
--- a/apps/api/src/services/scriptBuilderPrompt.ts
+++ b/apps/api/src/services/scriptBuilderPrompt.ts
@@ -30,10 +30,14 @@ When editing an existing script, prefer targeted modifications over full rewrite
 Always consider error handling, logging, and cross-platform compatibility.
 For PowerShell, prefer modern cmdlets. For Bash, ensure POSIX compatibility where possible.
 
-Script code must use plain ASCII punctuation only: straight quotes (' and "), ASCII
-hyphens (-), and regular spaces. Never use typographic characters (curly quotes,
-en/em dashes, ellipsis, non-breaking spaces) in code — they cause parse errors on
-target machines.
+Script code must be plain ASCII — this includes the text inside strings and comments,
+not just the syntax. Use straight quotes (' and "), ASCII hyphens (-), and regular
+spaces. Never use typographic punctuation (curly quotes, en/em dashes, ellipsis,
+non-breaking spaces) and never use decorative glyphs in output: no check marks,
+crosses, warning signs, arrows, bullets, box-drawing characters, or emoji. Write
+status output as [OK], [X], [!], -> and * instead. On Windows these characters are
+mis-decoded and silently turn into string delimiters, which breaks the script with
+parse errors that point at the wrong line.
 
 IMPORTANT: Always use apply_script_code to deliver code to the editor, not just a code block in the chat. The chat message should explain the code; the tool applies it to the editor.`;
 

--- a/apps/api/src/services/scriptBuilderTools.applyNormalize.test.ts
+++ b/apps/api/src/services/scriptBuilderTools.applyNormalize.test.ts
@@ -22,6 +22,22 @@ describe('apply_script_code normalization wiring', () => {
     expect((args as { code: string }).code).toBe('Write-Host "done - ok"');
   });
 
+  it('delivers the status glyphs from the real failure transliterated', async () => {
+    const spy = vi.fn();
+    const handler = makeApplyHandler('apply_script_code', spy);
+
+    // Verbatim from the payload that produced the reported parse errors.
+    await handler({
+      code: 'Write-Host "✓ Download completed successfully ($fileSizeRounded MB)"',
+      language: 'powershell',
+    });
+
+    const [, args] = spy.mock.calls[0]!;
+    expect((args as { code: string }).code).toBe(
+      'Write-Host "[OK] Download completed successfully ($fileSizeRounded MB)"'
+    );
+  });
+
   it('reports codeChars for the normalized code', async () => {
     const spy = vi.fn();
     const handler = makeApplyHandler('apply_script_code', spy);

--- a/apps/api/src/services/scriptCodeNormalize.test.ts
+++ b/apps/api/src/services/scriptCodeNormalize.test.ts
@@ -33,4 +33,39 @@ describe('normalizeScriptCode', () => {
   it('leaves legitimate non-ASCII content (accents, CJK) untouched', () => {
     expect(normalizeScriptCode('echo "r\u00e9sum\u00e9 \u65e5\u672c\u8a9e"')).toBe('echo "r\u00e9sum\u00e9 \u65e5\u672c\u8a9e"');
   });
+
+  // The check mark -- not a curly quote -- is what actually broke every
+  // reported script. U+2713 is E2 9C 93; PowerShell 5.1 reading a BOM-less
+  // .ps1 as CP1252 turns the trailing 0x93 into U+201C, which it honours as a
+  // closing double quote, so the string ends mid-line.
+  it('transliterates the check mark that terminated PowerShell strings early', () => {
+    const input = 'Write-Host "\u2713 Download completed successfully ($fileSizeRounded MB)" -ForegroundColor Green';
+    expect(normalizeScriptCode(input)).toBe(
+      'Write-Host "[OK] Download completed successfully ($fileSizeRounded MB)" -ForegroundColor Green'
+    );
+  });
+
+  it('transliterates the full status-glyph set the model emits', () => {
+    expect(normalizeScriptCode('\u2713 \u2714 \u2705 \u2611')).toBe('[OK] [OK] [OK] [OK]');
+    expect(normalizeScriptCode('\u2717 \u2718 \u2716 \u274c \u2612')).toBe('[X] [X] [X] [X] [X]');
+    expect(normalizeScriptCode('\u26a0 \u26d4 \u2757')).toBe('[!] [!] [!]');
+    expect(normalizeScriptCode('a \u2192 b \u2190 c')).toBe('a -> b <- c');
+    expect(normalizeScriptCode('\u2022 item')).toBe('* item');
+  });
+
+  it('strips emoji and decorative glyphs, including the variation selector', () => {
+    expect(normalizeScriptCode('Write-Host "\u{1f680}Deploying\u2728"')).toBe('Write-Host "Deploying"');
+    // Warning sign + VS16 is the common emoji-presentation spelling.
+    expect(normalizeScriptCode('\u26a0\ufe0f check')).toBe('[!] check');
+  });
+
+  it('strips the word joiner and soft hyphen alongside zero-widths', () => {
+    // U+2060 appeared in a saved production script next to a narrow NBSP.
+    expect(normalizeScriptCode('Get-\u2060Service\u00ad Name\u202fx')).toBe('Get-Service Name x');
+  });
+
+  it('leaves arrows and glyphs out of otherwise ASCII code untouched', () => {
+    const script = 'if ($x -eq 1) { Write-Host "[OK] done" } else { Write-Host "[X] failed" }';
+    expect(normalizeScriptCode(script)).toBe(script);
+  });
 });

--- a/apps/api/src/services/scriptCodeNormalize.ts
+++ b/apps/api/src/services/scriptCodeNormalize.ts
@@ -1,20 +1,33 @@
 /**
- * Normalize typographic Unicode punctuation in AI-generated script code.
+ * Normalize non-ASCII Unicode in AI-generated script code to ASCII.
  *
- * LLMs occasionally emit curly quotes, em/en dashes, ellipses, and
- * non-breaking/zero-width characters inside script code. In syntax positions
- * these break bash/python outright, and Windows PowerShell 5.1 mis-decodes
- * them entirely in a BOM-less ANSI read, producing cascading parse errors
- * ("Unexpected token", "missing string terminator"). The Go agent stamps a
- * UTF-8 BOM on .ps1 files (internal/executor/shell.go WriteScriptFile), but
- * code should be plain ASCII punctuation regardless.
+ * LLMs emit two families of offender: typographic punctuation (curly quotes,
+ * em/en dashes, ellipses, non-breaking and zero-width spaces) and decorative
+ * status glyphs in progress output (check marks, crosses, warning signs,
+ * arrows, bullets, emoji). In syntax positions the punctuation breaks
+ * bash/python outright. On Windows the failure is broader and worse:
+ * PowerShell 5.1 decodes a BOM-less .ps1 as the system ANSI codepage, and each
+ * byte of a multi-byte sequence then decodes as its own CP1252 char. Bytes
+ * 0x91-0x94 are the curly quotes, which PowerShell honours as genuine string
+ * delimiters, so any character carrying one silently closes the string it sits
+ * in and the parse cascades into "Unexpected token" / "missing string
+ * terminator" errors pointing far from the real position. U+2713 CHECK MARK
+ * (E2 9C 93, the 0x93 landing on U+201C) is the observed real-world case: a
+ * Write-Host progress line with a check mark makes the whole file unparseable.
+ *
+ * The Go agent stamps a UTF-8 BOM on .ps1 files (internal/executor/shell.go
+ * WriteScriptFile), which fixes the decode at the source, but that fix only
+ * reaches a device once its agent updates. This pass is the server-side half:
+ * it takes effect the moment the code is applied to the editor, on every
+ * agent version, so keep it able to stand alone.
  *
  * Replacements apply everywhere, including inside string contents -- an
- * intentional trade-off: typographic punctuation in script output text is
- * cosmetic, while in a delimiter position it is always a bug. Otherwise
- * deliberately conservative: only unambiguous typographic substitutions for
- * ASCII are mapped; everything else (accented letters, CJK, symbols) passes
- * through untouched.
+ * intentional trade-off: a glyph in output text is cosmetic, while the same
+ * glyph in a delimiter position is always a bug. Status glyphs are
+ * transliterated ("[OK]") rather than deleted so log output stays readable;
+ * purely decorative blocks are deleted. Letters, accents and CJK pass through
+ * untouched -- they are legitimate content, and none of them can act as a
+ * delimiter even when mis-decoded.
  */
 
 const TYPOGRAPHIC_REPLACEMENTS: ReadonlyArray<[RegExp, string]> = [
@@ -28,8 +41,35 @@ const TYPOGRAPHIC_REPLACEMENTS: ReadonlyArray<[RegExp, string]> = [
   [/\u2026/g, '...'],
   // Non-breaking and fixed-width spaces: NBSP, figure space, narrow NBSP
   [/[\u00A0\u2007\u202F]/g, ' '],
-  // Zero-width characters and stray BOMs -- delete outright
-  [/[\u200B\u200C\u200D\uFEFF]/g, ''],
+
+  // Status glyphs. These are what the model actually reaches for when writing
+  // progress output ("Write-Host \u2713 Download completed"), and they are the
+  // characters observed in every real parse failure -- U+2713 encodes as
+  // E2 9C 93, whose trailing 0x93 lands on U+201C in CP1252, and PowerShell
+  // honours U+201C as a real double-quote delimiter, so the string terminates
+  // mid-line. Transliterated rather than deleted to keep the output readable.
+  [/[\u2713\u2714\u2705\u2611]/g, '[OK]'],
+  [/[\u2717\u2718\u2716\u274C\u2612]/g, '[X]'],
+  [/[\u26A0\u26D4\u2757\u2755]/g, '[!]'],
+  // Arrows and bullets that carry meaning in progress/log lines
+  [/[\u2192\u27A1\u21D2]/g, '->'],
+  [/[\u2190\u21D0]/g, '<-'],
+  [/[\u2022\u2023\u25CF\u25AA\u25A0]/g, '*'],
+
+  // Remaining arrows, technical marks, shapes, dingbats and pictographs --
+  // decorative only, never meaningful in script syntax, so delete rather than
+  // transliterate. Runs AFTER the specific maps above so those keep their
+  // ASCII spellings. Whole blocks are swept rather than the individual glyphs
+  // seen in the wild because the hazard is byte-level, not glyph-level: ANY
+  // byte of a multi-byte sequence lands on its own CP1252 char, and 0x91-0x94
+  // are the curly quotes PowerShell honours as string delimiters. U+2713
+  // (E2 9C 93) and U+2500 (E2 94 80) both carry one. Letters, accents and CJK
+  // stay -- none of their bytes fall in that range.
+  [/[\u2190-\u21FF\u2300-\u23FF\u2500-\u27BF\u2B00-\u2BFF\uFE0F\u{1F000}-\u{1FAFF}]/gu, ''],
+
+  // Zero-width, word-joiner, invisible-operator and soft-hyphen characters,
+  // plus stray BOMs -- delete outright.
+  [/[\u00AD\u180E\u200B-\u200F\u2060-\u2064\uFEFF]/g, ''],
 ];
 
 export function normalizeScriptCode(code: string): string {


### PR DESCRIPTION
Follow-up to #3574. That PR's diagnosis of the mechanism was right, but the character set it scrubbed was wrong, so the API layer would not have fixed the reported failures.

## What the production data shows

I reviewed the real `script_builder` conversations on US prod. The reported error is preserved verbatim in `ai_messages`:

```
+ ... ost "âœ“ Download completed successfully ($fileSizeRounded MB)" -Fore ...
Unexpected token 'MB' in expression or statement.
```

`âœ“` is the mojibake of **U+2713 CHECK MARK**, not a curly quote. A character census across every `script_builder` message on US prod:

| Char | Count |
|---|---|
| `U+2713` ✓ | 70 |
| `U+2705` ✅ | 29 |
| `U+2717` ✗ | 8 |
| `U+2192` → | 2 |
| 🚀 ❌ ✨ | 1 each |

**Zero** genuine curly quotes, em-dashes or non-breaking spaces in any failing payload.

Replaying all 11 real `apply_script_code` payloads from prod through `normalizeScriptCode` as merged in #3574 returned **11/11 unchanged** — the table scrubbed a class of character that never once appeared. After this PR: **0/11**.

## The mechanism is byte-level, not glyph-level

Under a BOM-less CP1252 read, *every* byte of a multi-byte sequence decodes as its own character, and bytes `0x91`-`0x94` are the curly quotes — which PowerShell honours as genuine string delimiters (`about_Quoting_Rules`). `U+2713` is `E2 9C 93`, so the `0x93` becomes `U+201C` and closes the string mid-line; everything after it parses as bare code, which is the cascade in the report. This also implicates box-drawing (`U+2500` = `E2 94 80`) and arrows (`U+2194`) — neither was covered before.

## Changes

- **normalize**: transliterate status glyphs to ASCII tags that keep output readable (`[OK]`, `[X]`, `[!]`, `->`, `*`), then block-sweep arrows / technical marks / shapes / dingbats / emoji, and complete the invisibles — `U+2060` WORD JOINER is live in a saved prod script and the old rule stopped at `U+200D`/`FEFF`.
- **prompt**: forbid decorative glyphs and emoji explicitly, not just typographic punctuation, and name the ASCII spellings to use instead.
- **tests**: pin the real failing line end-to-end through the apply wiring.

Letters, accents and CJK still pass through — none of their bytes fall in the delimiter range.

## Why this layer has to stand alone

The agent-side UTF-8 BOM stamp from #3574 fixes the decode at the source, but it only reaches a device once that agent updates — and the agent fleet promote is currently blocked on the hosted signed-distribution decision. Until that lands, this server-side pass is the only layer that reaches existing devices.

## Verification

- `scriptCodeNormalize.test.ts` + `scriptBuilderTools.applyNormalize.test.ts`: 16/16 pass
- `tsc --noEmit`: clean
- All 11 real prod payloads: 0/11 still carry non-ASCII

## Known gaps (not addressed here)

- Four saved scripts on US prod still contain glyphs. Normalization only runs at `apply_script_code` time and never re-cleans stored rows, so they stay broken on non-BOM agents until re-saved. Backfilling is a production data change.
- The normalizer has one call site (the AI apply path), so hand-pasted scripts are not normalized. Extending it to the save route would close that, but it silently rewrites user-entered content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)