### PR TITLE
fix(agent): EXE installers hang until the 30-minute install timeout

### DIFF
--- a/agent/internal/remote/tools/software_install.go
+++ b/agent/internal/remote/tools/software_install.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -16,6 +17,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -610,14 +612,33 @@ func executeInstaller(localPath, fileType, silentInstallArgs string) (int, strin
 
 	case fileType == "dmg" && runtime.GOOS == "darwin":
 		// Mount, find .app or .pkg, install, unmount
-		exitCode, output, err := installDMG(ctx, localPath)
-		return exitCode, output, false, err
+		return installDMG(ctx, localPath)
 
 	default:
 		return 1, "", false, fmt.Errorf("unsupported file type %q on %s", fileType, runtime.GOOS)
 	}
 
 	return runInstallerCommand(ctx, cmd, fileType)
+}
+
+// lockedBuffer collects an installer's merged stdout+stderr. CombinedOutput's
+// plain bytes.Buffer is not safe here: with WaitDelay, Wait can return while the
+// copy goroutine of a descendant that still holds the pipe is writing.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]byte(nil), b.buf.Bytes()...)
 }
 
 // runInstallerCommand runs one installer command. Its third return says the
@@ -632,7 +653,25 @@ func runInstallerCommand(ctx context.Context, cmd *exec.Cmd, fileType string) (i
 	// 30-minute timeout. Mirrors scripts/runner.go and executor/executor.go.
 	cmd.WaitDelay = installerWaitDelay
 
-	output, err := cmd.CombinedOutput()
+	tree := newInstallerProcessTree()
+	defer tree.release()
+	tree.prepare(cmd)
+
+	// Start/Wait rather than CombinedOutput: the process must be adopted by the
+	// tree the moment it exists. One writer for both streams so os/exec collapses
+	// them onto a single pipe exactly as CombinedOutput does; the lock is because
+	// WaitDelay lets Wait return while an abandoned descendant's copy goroutine
+	// is still writing.
+	var buf lockedBuffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	if err := cmd.Start(); err != nil {
+		return 1, "", false, err
+	}
+	tree.adopt(cmd)
+	err := cmd.Wait()
+	output := buf.Bytes()
 
 	exitCode := 0
 	descendantsPending := false
@@ -659,6 +698,10 @@ func runInstallerCommand(ctx context.Context, cmd *exec.Cmd, fileType string) (i
 	// of the window is reported as a 30-minute hang.
 	if ctx.Err() == context.DeadlineExceeded &&
 		(cmd.ProcessState == nil || !cmd.ProcessState.Exited() || !installerExitIndicatesSuccess(fileType, exitCode)) {
+		// Only here: the deadline fired on an installer that never finished, so
+		// its descendants are part of a hang, not of a legitimate install still
+		// landing. Every other path leaves the tree alone.
+		tree.kill(cmd)
 		return -1, procoutput.BytesToUTF8(output), false,
 			fmt.Errorf("installer timed out after %s and was terminated", installTimeout)
 	}
@@ -715,35 +758,39 @@ func buildMSIExecArgs(localPath, silentInstallArgs string) []string {
 	return parts
 }
 
-func installDMG(ctx context.Context, dmgPath string) (int, string, error) {
+// dmgCommandContext builds installDMG's child processes. A var (not a direct
+// exec.CommandContext call) solely so tests can drive the DMG path without a
+// real disk image; production behavior is unchanged.
+var dmgCommandContext = exec.CommandContext
+
+func installDMG(ctx context.Context, dmgPath string) (int, string, bool, error) {
 	// Mount
 	mountPoint := filepath.Join(os.TempDir(), "breeze-dmg-mount")
 	os.MkdirAll(mountPoint, 0700)
 
-	mountCmd := exec.CommandContext(ctx, "hdiutil", "attach", dmgPath, "-mountpoint", mountPoint, "-nobrowse", "-quiet")
-	if out, err := mountCmd.CombinedOutput(); err != nil {
-		return 1, procoutput.BytesToUTF8(out), fmt.Errorf("failed to mount DMG: %w", err)
+	// hdiutil and cp go through runInstallerCommand for its WaitDelay and its
+	// timeout labeling — hdiutil's helper daemon can hold the output pipes, and a
+	// wedged mount or a multi-gigabyte copy that hits the deadline must be
+	// reported as a timeout, not as the kill's exit code. Neither is an
+	// *installer*, so both are run with an empty fileType: only 0 means success,
+	// the Windows reboot-pending codes (3010/1641) have no meaning for them.
+	// Their descendantsPending is likewise dropped rather than propagated —
+	// nothing hdiutil or cp leaves behind is an install still landing on disk.
+	mountCmd := dmgCommandContext(ctx, "hdiutil", "attach", dmgPath, "-mountpoint", mountPoint, "-nobrowse", "-quiet")
+	if _, out, _, err := runInstallerCommand(ctx, mountCmd, ""); err != nil {
+		return 1, out, false, fmt.Errorf("failed to mount DMG: %w", err)
 	}
-	defer exec.Command("hdiutil", "detach", mountPoint, "-quiet").Run()
+	defer dmgCommandContext(context.Background(), "hdiutil", "detach", mountPoint, "-quiet").Run()
 
 	// Look for .pkg first, then .app
 	entries, _ := os.ReadDir(mountPoint)
 	for _, entry := range entries {
 		if strings.HasSuffix(entry.Name(), ".pkg") {
 			pkgPath := filepath.Join(mountPoint, entry.Name())
-			cmd := exec.CommandContext(ctx, "installer", "-pkg", pkgPath, "-target", "/")
-			out, err := cmd.CombinedOutput()
-			exitCode := 0
-			if err != nil {
-				if exitErr, ok := err.(*exec.ExitError); ok {
-					exitCode = exitErr.ExitCode()
-				}
-				if exitCode != 0 {
-					return exitCode, procoutput.BytesToUTF8(out), fmt.Errorf("pkg installer exited with code %d", exitCode)
-				}
-				return 1, procoutput.BytesToUTF8(out), err
-			}
-			return 0, procoutput.BytesToUTF8(out), nil
+			// A .pkg postinstall script routinely spawns a lingering child, so
+			// this is the DMG case that needs both the WaitDelay escape and the
+			// descendantsPending signal that makes detection settle.
+			return runInstallerCommand(ctx, dmgCommandContext(ctx, "installer", "-pkg", pkgPath, "-target", "/"), "pkg")
 		}
 	}
 
@@ -752,16 +799,15 @@ func installDMG(ctx context.Context, dmgPath string) (int, string, error) {
 		if strings.HasSuffix(entry.Name(), ".app") {
 			src := filepath.Join(mountPoint, entry.Name())
 			dst := filepath.Join("/Applications", entry.Name())
-			cmd := exec.CommandContext(ctx, "cp", "-R", src, dst)
-			out, err := cmd.CombinedOutput()
+			exitCode, out, _, err := runInstallerCommand(ctx, dmgCommandContext(ctx, "cp", "-R", src, dst), "")
 			if err != nil {
-				return 1, procoutput.BytesToUTF8(out), fmt.Errorf("failed to copy app: %w", err)
+				return exitCode, out, false, fmt.Errorf("failed to copy app: %w", err)
 			}
-			return 0, procoutput.BytesToUTF8(out), nil
+			return exitCode, out, false, nil
 		}
 	}
 
-	return 1, "", fmt.Errorf("no .pkg or .app found in DMG")
+	return 1, "", false, fmt.Errorf("no .pkg or .app found in DMG")
 }
 
 // splitCommandLine splits a command-line string into arguments, respecting double-quoted strings.

--- a/agent/internal/remote/tools/software_install.go
+++ b/agent/internal/remote/tools/software_install.go
@@ -46,6 +46,17 @@ var maxInstallFileSize int64 = 500 * 1024 * 1024 // 500 MB
 // can shrink it; production behavior is a fixed safety net.
 var installerWaitDelay = 10 * time.Second
 
+// detectionSettleWindow/detectionSettleInterval bound the post-install
+// detection re-check used ONLY when the installer's descendants outlived the
+// wrapper (the ErrWaitDelay path): the wrapper is gone but the real setup is
+// still writing to disk, so a single immediate evaluation would fail a healthy
+// install as "detection rule not satisfied". Vars (not consts) solely so tests
+// can shrink them; the ordinary install path never reads them.
+var (
+	detectionSettleWindow   = 60 * time.Second
+	detectionSettleInterval = 2 * time.Second
+)
+
 var checksumHexPattern = regexp.MustCompile(`^[a-fA-F0-9]{64}$`)
 
 // InstallSoftware downloads a package from a presigned URL, verifies its checksum,
@@ -156,7 +167,7 @@ func InstallSoftware(payload map[string]any) (result CommandResult) {
 	}
 
 	// Execute installer
-	exitCode, output, err := executeInstaller(localPath, fileType, silentInstallArgs)
+	exitCode, output, descendantsPending, err := executeInstaller(localPath, fileType, silentInstallArgs)
 	output, outputTruncated := sanitizeInstallerOutput(output)
 	if err != nil {
 		errMsg := err.Error()
@@ -186,7 +197,7 @@ func InstallSoftware(payload map[string]any) (result CommandResult) {
 		successPayload["outputTruncated"] = true
 	}
 
-	return applyPostInstallDetection(successPayload, exitCode, output, detectionRules, time.Since(startTime).Milliseconds())
+	return applyPostInstallDetectionSettling(successPayload, exitCode, output, detectionRules, time.Since(startTime).Milliseconds(), descendantsPending)
 }
 
 // applyPostInstallDetection decides the final install result from the device's
@@ -203,11 +214,30 @@ func InstallSoftware(payload map[string]any) (result CommandResult) {
 // With no rules it is a plain exit-code success. successPayload is mutated with
 // detection metadata for the success/unsupported paths.
 func applyPostInstallDetection(successPayload map[string]any, exitCode int, output string, rules []DetectionRule, durationMs int64) CommandResult {
+	return applyPostInstallDetectionSettling(successPayload, exitCode, output, rules, durationMs, false)
+}
+
+// applyPostInstallDetectionSettling is applyPostInstallDetection plus the
+// descendant case. When descendantsPending is set the wrapper installer exited
+// while the REAL installer was still running (the ErrWaitDelay path), so the
+// software legitimately is not on disk yet and one immediate check would fail a
+// healthy install. Only that case re-checks, bounded by detectionSettleWindow
+// and returning the moment the rule is satisfied; the ordinary path keeps its
+// single-shot evaluation and timing. An unsupported verdict can never change,
+// so it is never waited on.
+func applyPostInstallDetectionSettling(successPayload map[string]any, exitCode int, output string, rules []DetectionRule, durationMs int64, descendantsPending bool) CommandResult {
 	if len(rules) == 0 {
 		return NewSuccessResult(successPayload, durationMs)
 	}
 
 	post := EvaluateDetectionRules(rules)
+	if descendantsPending {
+		deadline := time.Now().Add(detectionSettleWindow)
+		for post.Supported && !post.Detected && time.Now().Before(deadline) {
+			time.Sleep(detectionSettleInterval)
+			post = EvaluateDetectionRules(rules)
+		}
+	}
 	if !post.Supported {
 		successPayload["detectionPerformed"] = false
 		successPayload["detail"] = post.Detail
@@ -550,7 +580,10 @@ func computeSHA256(filePath string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-func executeInstaller(localPath, fileType, silentInstallArgs string) (int, string, error) {
+// executeInstaller runs the installer for fileType. The third return reports
+// that the installer's descendants outlived it (see runInstallerCommand), which
+// post-install detection needs in order to wait for the real install to land.
+func executeInstaller(localPath, fileType, silentInstallArgs string) (int, string, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), installTimeout)
 	defer cancel()
 
@@ -577,16 +610,21 @@ func executeInstaller(localPath, fileType, silentInstallArgs string) (int, strin
 
 	case fileType == "dmg" && runtime.GOOS == "darwin":
 		// Mount, find .app or .pkg, install, unmount
-		return installDMG(ctx, localPath)
+		exitCode, output, err := installDMG(ctx, localPath)
+		return exitCode, output, false, err
 
 	default:
-		return 1, "", fmt.Errorf("unsupported file type %q on %s", fileType, runtime.GOOS)
+		return 1, "", false, fmt.Errorf("unsupported file type %q on %s", fileType, runtime.GOOS)
 	}
 
 	return runInstallerCommand(ctx, cmd, fileType)
 }
 
-func runInstallerCommand(ctx context.Context, cmd *exec.Cmd, fileType string) (int, string, error) {
+// runInstallerCommand runs one installer command. Its third return says the
+// installer's descendants were still holding the output pipes when the wrapper
+// exited — i.e. the real setup is probably still running, which post-install
+// detection must account for before declaring the rule unsatisfied.
+func runInstallerCommand(ctx context.Context, cmd *exec.Cmd, fileType string) (int, string, bool, error) {
 	cmd.Env = procoutput.ApplyEnv(os.Environ())
 	// EXE installers are typically wrappers: they spawn the real setup (which
 	// inherits the output handles) and exit. Without WaitDelay, Wait blocks on
@@ -595,28 +633,41 @@ func runInstallerCommand(ctx context.Context, cmd *exec.Cmd, fileType string) (i
 	cmd.WaitDelay = installerWaitDelay
 
 	output, err := cmd.CombinedOutput()
-	if ctx.Err() == context.DeadlineExceeded {
-		return -1, procoutput.BytesToUTF8(output),
-			fmt.Errorf("installer timed out after %s and was terminated", installTimeout)
-	}
+
 	exitCode := 0
+	descendantsPending := false
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
 		} else if errors.Is(err, exec.ErrWaitDelay) {
 			// The installer itself exited; only its abandoned descendants kept
 			// the output pipes open. Judge the install by the real exit code.
-			exitCode = cmd.ProcessState.ExitCode()
+			descendantsPending = true
+			if cmd.ProcessState != nil {
+				exitCode = cmd.ProcessState.ExitCode()
+			}
 		} else {
-			return 1, procoutput.BytesToUTF8(output), err
+			return 1, procoutput.BytesToUTF8(output), false, err
 		}
 	}
 
-	if installerExitIndicatesSuccess(fileType, exitCode) {
-		return exitCode, procoutput.BytesToUTF8(output), nil
+	// The deadline having passed is NOT on its own a timeout: a wrapper can exit
+	// 0 and then have Wait drain its descendants' pipes past the deadline, in
+	// which case the deadline killed nothing and the install really succeeded.
+	// Only claim a timeout when the process did not finish on its own with a
+	// success code — otherwise a good install inside the last installerWaitDelay
+	// of the window is reported as a 30-minute hang.
+	if ctx.Err() == context.DeadlineExceeded &&
+		(cmd.ProcessState == nil || !cmd.ProcessState.Exited() || !installerExitIndicatesSuccess(fileType, exitCode)) {
+		return -1, procoutput.BytesToUTF8(output), false,
+			fmt.Errorf("installer timed out after %s and was terminated", installTimeout)
 	}
 
-	return exitCode, procoutput.BytesToUTF8(output), fmt.Errorf("installer exited with code %d", exitCode)
+	if installerExitIndicatesSuccess(fileType, exitCode) {
+		return exitCode, procoutput.BytesToUTF8(output), descendantsPending, nil
+	}
+
+	return exitCode, procoutput.BytesToUTF8(output), descendantsPending, fmt.Errorf("installer exited with code %d", exitCode)
 }
 
 // installerExitIndicatesSuccess reports whether an installer exit code means the

--- a/agent/internal/remote/tools/software_install.go
+++ b/agent/internal/remote/tools/software_install.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -39,6 +40,11 @@ const (
 // shrink it — moving the real 500 MiB through a unit test is impractical.
 // Production behavior is unchanged.
 var maxInstallFileSize int64 = 500 * 1024 * 1024 // 500 MB
+
+// installerWaitDelay bounds how long Wait keeps collecting output after the
+// installer process itself has exited. A var (not a const) solely so tests
+// can shrink it; production behavior is a fixed safety net.
+var installerWaitDelay = 10 * time.Second
 
 var checksumHexPattern = regexp.MustCompile(`^[a-fA-F0-9]{64}$`)
 
@@ -577,13 +583,30 @@ func executeInstaller(localPath, fileType, silentInstallArgs string) (int, strin
 		return 1, "", fmt.Errorf("unsupported file type %q on %s", fileType, runtime.GOOS)
 	}
 
+	return runInstallerCommand(ctx, cmd, fileType)
+}
+
+func runInstallerCommand(ctx context.Context, cmd *exec.Cmd, fileType string) (int, string, error) {
 	cmd.Env = procoutput.ApplyEnv(os.Environ())
+	// EXE installers are typically wrappers: they spawn the real setup (which
+	// inherits the output handles) and exit. Without WaitDelay, Wait blocks on
+	// pipe EOF until every descendant exits — real installs stalled into the
+	// 30-minute timeout. Mirrors scripts/runner.go and executor/executor.go.
+	cmd.WaitDelay = installerWaitDelay
 
 	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return -1, procoutput.BytesToUTF8(output),
+			fmt.Errorf("installer timed out after %s and was terminated", installTimeout)
+	}
 	exitCode := 0
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
+		} else if errors.Is(err, exec.ErrWaitDelay) {
+			// The installer itself exited; only its abandoned descendants kept
+			// the output pipes open. Judge the install by the real exit code.
+			exitCode = cmd.ProcessState.ExitCode()
 		} else {
 			return 1, procoutput.BytesToUTF8(output), err
 		}

--- a/agent/internal/remote/tools/software_install.go
+++ b/agent/internal/remote/tools/software_install.go
@@ -780,7 +780,12 @@ func installDMG(ctx context.Context, dmgPath string) (int, string, bool, error) 
 	if _, out, _, err := runInstallerCommand(ctx, mountCmd, ""); err != nil {
 		return 1, out, false, fmt.Errorf("failed to mount DMG: %w", err)
 	}
-	defer dmgCommandContext(context.Background(), "hdiutil", "detach", mountPoint, "-quiet").Run()
+	// Best-effort unmount: the install result is already decided by the time this
+	// runs, and a failed detach leaves a stale mountpoint rather than a bad
+	// install, so there is nothing actionable to report from here.
+	defer func() {
+		_ = dmgCommandContext(context.Background(), "hdiutil", "detach", mountPoint, "-quiet").Run()
+	}()
 
 	// Look for .pkg first, then .app
 	entries, _ := os.ReadDir(mountPoint)

--- a/agent/internal/remote/tools/software_install_dmg_test.go
+++ b/agent/internal/remote/tools/software_install_dmg_test.go
@@ -1,0 +1,144 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeDMGCommands routes installDMG's child processes through sh so the DMG
+// path can be exercised without a real disk image. payload is the entry the
+// fake `hdiutil attach` drops in the mount point ("" for an empty image,
+// mountFails for a mount that refuses); installScript stands in for the real
+// `installer -pkg` / `cp -R` invocation.
+const mountFails = "\x00fail"
+
+func fakeDMGCommands(t *testing.T, payload, installScript string) string {
+	t.Helper()
+	t.Setenv("TMPDIR", t.TempDir())
+	mountPoint := filepath.Join(os.TempDir(), "breeze-dmg-mount")
+
+	attachScript := "mkdir -p " + mountPoint
+	switch payload {
+	case mountFails:
+		attachScript = "exit 1"
+	case "":
+	default:
+		attachScript += " && touch " + filepath.Join(mountPoint, payload)
+	}
+
+	prev := dmgCommandContext
+	dmgCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		switch {
+		case name == "hdiutil" && len(args) > 0 && args[0] == "attach":
+			return exec.CommandContext(ctx, "sh", "-c", attachScript)
+		case name == "hdiutil":
+			return exec.CommandContext(ctx, "sh", "-c", "true")
+		default:
+			return exec.CommandContext(ctx, "sh", "-c", installScript)
+		}
+	}
+	t.Cleanup(func() { dmgCommandContext = prev })
+	return mountPoint
+}
+
+// The DMG path had its own hand-rolled CombinedOutput call, so a .pkg whose
+// postinstall script leaves a descendant behind kept the ORIGINAL bug: Wait
+// blocked on pipe EOF until the 30-minute install timeout.
+func TestInstallDMGDoesNotBlockOnPkgDescendants(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test drives the helpers through sh")
+	}
+	prev := installerWaitDelay
+	installerWaitDelay = 500 * time.Millisecond
+	defer func() { installerWaitDelay = prev }()
+
+	fakeDMGCommands(t, "Acme.pkg", "sleep 8 & echo pkg-installed")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	exitCode, output, descendantsPending, err := installDMG(ctx, "/nonexistent/Acme.dmg")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected success after the pkg installer exited, got err=%v (exitCode=%d)", err, exitCode)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(output, "pkg-installed") {
+		t.Fatalf("expected captured installer output, got %q", output)
+	}
+	if elapsed > 4*time.Second {
+		t.Fatalf("installDMG blocked on a descendant for %v; want prompt return after the pkg installer exits", elapsed)
+	}
+	if !descendantsPending {
+		t.Fatal("expected descendantsPending=true so post-install detection settles instead of failing an in-flight install")
+	}
+}
+
+// A genuine DMG install timeout must be labeled as a timeout, not as the kill's
+// exit code — the same guarantee runInstallerCommand gives every other type.
+func TestInstallDMGLabelsTimeoutAsTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test drives the helpers through sh")
+	}
+	prev := installerWaitDelay
+	installerWaitDelay = 300 * time.Millisecond
+	defer func() { installerWaitDelay = prev }()
+
+	fakeDMGCommands(t, "Acme.pkg", "sleep 30")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	_, _, _, err := installDMG(ctx, "/nonexistent/Acme.dmg")
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected a timeout label, got %v", err)
+	}
+}
+
+// A non-zero pkg installer exit keeps failing the install, and a DMG carrying
+// neither payload keeps its own error.
+func TestInstallDMGReportsFailures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test drives the helpers through sh")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	fakeDMGCommands(t, "Acme.pkg", "exit 7")
+	exitCode, _, _, err := installDMG(ctx, "/nonexistent/Acme.dmg")
+	if exitCode != 7 || err == nil || !strings.Contains(err.Error(), "code 7") {
+		t.Fatalf("want exit code 7 surfaced, got exitCode=%d err=%v", exitCode, err)
+	}
+
+	fakeDMGCommands(t, "", "true")
+	_, _, _, err = installDMG(ctx, "/nonexistent/Acme.dmg")
+	if err == nil || !strings.Contains(err.Error(), "no .pkg or .app found in DMG") {
+		t.Fatalf("want the DMG-specific empty-image error, got %v", err)
+	}
+}
+
+// A mount failure stays a mount failure — the hdiutil step must not be reported
+// as an installer exit code.
+func TestInstallDMGReportsMountFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test drives the helpers through sh")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	fakeDMGCommands(t, mountFails, "true")
+	_, _, _, err := installDMG(ctx, "/nonexistent/Acme.dmg")
+	if err == nil || !strings.Contains(err.Error(), "failed to mount DMG") {
+		t.Fatalf("want a mount-failure error, got %v", err)
+	}
+}

--- a/agent/internal/remote/tools/software_install_exec_test.go
+++ b/agent/internal/remote/tools/software_install_exec_test.go
@@ -2,7 +2,9 @@ package tools
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -30,7 +32,7 @@ func TestRunInstallerCommandReturnsWhenDescendantHoldsPipe(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	exitCode, output, err := runInstallerCommand(ctx, shInstallerCommand(ctx, "sleep 8 & echo wrapper-done"), "exe")
+	exitCode, output, _, err := runInstallerCommand(ctx, shInstallerCommand(ctx, "sleep 8 & echo wrapper-done"), "exe")
 	elapsed := time.Since(start)
 
 	if err != nil {
@@ -57,9 +59,39 @@ func TestRunInstallerCommandLabelsTimeoutAsTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
 
-	_, _, err := runInstallerCommand(ctx, shInstallerCommand(ctx, "sleep 10"), "exe")
+	_, _, _, err := runInstallerCommand(ctx, shInstallerCommand(ctx, "sleep 10"), "exe")
 	if err == nil || !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("expected timeout to be labeled as such, got err=%v", err)
+	}
+}
+
+// A wrapper that exits 0 while a descendant still holds the output pipes can
+// drain past the install deadline: the process is already gone, so the deadline
+// killed nothing. Sampling ctx.Err() alone mislabeled that as a 30-minute
+// timeout — a 10-second-wide window (installerWaitDelay) on exactly the
+// wrapper-style installers this path exists to serve.
+func TestRunInstallerCommandDoesNotMislabelLateSuccessAsTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test drives the helper through sh")
+	}
+	prev := installerWaitDelay
+	installerWaitDelay = 2 * time.Second
+	defer func() { installerWaitDelay = prev }()
+
+	// The deadline expires while Wait is still draining the descendant's pipes,
+	// long after the wrapper itself exited 0.
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	exitCode, output, _, err := runInstallerCommand(ctx, shInstallerCommand(ctx, "sleep 30 & echo wrapper-done"), "exe")
+	if err != nil {
+		t.Fatalf("expected success for a wrapper that exited 0, got err=%v (exitCode=%d)", err, exitCode)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(output, "wrapper-done") {
+		t.Fatalf("expected captured wrapper output, got %q", output)
 	}
 }
 
@@ -72,11 +104,113 @@ func TestRunInstallerCommandReportsRealExitCode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	exitCode, _, err := runInstallerCommand(ctx, shInstallerCommand(ctx, "exit 3"), "exe")
+	exitCode, _, _, err := runInstallerCommand(ctx, shInstallerCommand(ctx, "exit 3"), "exe")
 	if exitCode != 3 {
 		t.Fatalf("expected exit code 3, got %d", exitCode)
 	}
 	if err == nil || !strings.Contains(err.Error(), "installer exited with code 3") {
 		t.Fatalf("expected exit-code error, got %v", err)
+	}
+}
+
+// The ErrWaitDelay path means the wrapper exited while descendants — typically
+// the REAL installer — kept running. Detection has to know, so it can wait for
+// the software to land instead of failing the install as unsatisfied.
+func TestRunInstallerCommandReportsDescendantsOutlivedWrapper(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test drives the helper through sh")
+	}
+	prev := installerWaitDelay
+	installerWaitDelay = 300 * time.Millisecond
+	defer func() { installerWaitDelay = prev }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, _, descendantsPending, err := runInstallerCommand(ctx, shInstallerCommand(ctx, "sleep 10 & echo wrapper-done"), "exe")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if !descendantsPending {
+		t.Fatal("expected descendantsPending=true when a descendant outlived the wrapper")
+	}
+
+	_, _, descendantsPending, err = runInstallerCommand(ctx, shInstallerCommand(ctx, "echo done"), "exe")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if descendantsPending {
+		t.Fatal("expected descendantsPending=false for an installer that left nothing behind")
+	}
+}
+
+// When the wrapper's descendants are still installing, a single immediate
+// detection check reports "installer reported success but detection rule was
+// not satisfied" for an install that is merely still in flight. The settling
+// path must re-check within its bound and pass as soon as the app appears.
+func TestApplyPostInstallDetectionSettlesWhileDescendantsInstall(t *testing.T) {
+	prevWindow := detectionSettleWindow
+	prevInterval := detectionSettleInterval
+	detectionSettleWindow = 5 * time.Second
+	detectionSettleInterval = 50 * time.Millisecond
+	defer func() {
+		detectionSettleWindow = prevWindow
+		detectionSettleInterval = prevInterval
+	}()
+
+	marker := filepath.Join(t.TempDir(), "late.txt")
+	rules := []DetectionRule{{Type: "file_exists", Path: marker}}
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		_ = os.WriteFile(marker, []byte("x"), 0o600)
+	}()
+
+	r := applyPostInstallDetectionSettling(map[string]any{"success": true}, 0, "out", rules, 0, true)
+	if r.Status != "completed" {
+		t.Fatalf("want completed once the descendant install lands, got %q (err=%q)", r.Status, r.Error)
+	}
+}
+
+// The ordinary path must keep today's single-shot behavior and timing: a normal
+// install that leaves nothing behind must not linger for the settle window.
+func TestApplyPostInstallDetectionOrdinaryPathStaysSingleShot(t *testing.T) {
+	prevWindow := detectionSettleWindow
+	detectionSettleWindow = 10 * time.Second
+	defer func() { detectionSettleWindow = prevWindow }()
+
+	rules := []DetectionRule{{Type: "file_exists", Path: filepath.Join(t.TempDir(), "absent.txt")}}
+	start := time.Now()
+	r := applyPostInstallDetectionSettling(map[string]any{"success": true}, 0, "out", rules, 0, false)
+	if r.Status != "failed" {
+		t.Fatalf("want failed, got %q", r.Status)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("ordinary path polled for %v; want a single immediate evaluation", elapsed)
+	}
+}
+
+// Unsupported-on-this-platform still means "detection not performed" — never a
+// silent flip — and must not burn the settle window waiting for a verdict that
+// can never change.
+func TestApplyPostInstallDetectionSettlingKeepsUnsupportedSemantics(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("registry clause is supported on Windows")
+	}
+	prevWindow := detectionSettleWindow
+	detectionSettleWindow = 10 * time.Second
+	defer func() { detectionSettleWindow = prevWindow }()
+
+	payload := map[string]any{"success": true}
+	rules := []DetectionRule{{Type: "registry", Path: `SOFTWARE\Acme\App`}}
+	start := time.Now()
+	r := applyPostInstallDetectionSettling(payload, 0, "out", rules, 0, true)
+	if r.Status != "completed" {
+		t.Fatalf("want completed, got %q", r.Status)
+	}
+	if payload["detectionPerformed"] != false {
+		t.Fatalf("want detectionPerformed=false, got %v", payload["detectionPerformed"])
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("unsupported detection polled for %v; want an immediate verdict", elapsed)
 	}
 }

--- a/agent/internal/remote/tools/software_install_exec_test.go
+++ b/agent/internal/remote/tools/software_install_exec_test.go
@@ -1,0 +1,82 @@
+package tools
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func shInstallerCommand(ctx context.Context, script string) *exec.Cmd {
+	return exec.CommandContext(ctx, "sh", "-c", script)
+}
+
+// Regression for the EXE-installer hang: a wrapper installer that spawns a
+// background child (which inherits stdout/stderr) and then exits must not
+// stall runInstallerCommand until that descendant exits — without WaitDelay,
+// CombinedOutput blocks on pipe EOF until every handle-holding descendant is
+// gone, so real-world EXE wrappers ran into the 30-minute install timeout.
+func TestRunInstallerCommandReturnsWhenDescendantHoldsPipe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test drives the helper through sh")
+	}
+	prev := installerWaitDelay
+	installerWaitDelay = 500 * time.Millisecond
+	defer func() { installerWaitDelay = prev }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	exitCode, output, err := runInstallerCommand(ctx, shInstallerCommand(ctx, "sleep 8 & echo wrapper-done"), "exe")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected success after wrapper exit, got err=%v (exitCode=%d)", err, exitCode)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(output, "wrapper-done") {
+		t.Fatalf("expected captured wrapper output, got %q", output)
+	}
+	if elapsed > 4*time.Second {
+		t.Fatalf("runInstallerCommand blocked on descendant process for %v; want prompt return after wrapper exit", elapsed)
+	}
+}
+
+// A genuine install timeout must be reported as a timeout, not disguised as
+// the kill's exit code ("installer exited with code 1" on Windows, -1 on
+// unix), which is indistinguishable from a real installer failure.
+func TestRunInstallerCommandLabelsTimeoutAsTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test drives the helper through sh")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	_, _, err := runInstallerCommand(ctx, shInstallerCommand(ctx, "sleep 10"), "exe")
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout to be labeled as such, got err=%v", err)
+	}
+}
+
+// A real non-zero installer exit must keep today's shape: the true exit code
+// and the "installer exited with code N" error.
+func TestRunInstallerCommandReportsRealExitCode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test drives the helper through sh")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	exitCode, _, err := runInstallerCommand(ctx, shInstallerCommand(ctx, "exit 3"), "exe")
+	if exitCode != 3 {
+		t.Fatalf("expected exit code 3, got %d", exitCode)
+	}
+	if err == nil || !strings.Contains(err.Error(), "installer exited with code 3") {
+		t.Fatalf("expected exit-code error, got %v", err)
+	}
+}

--- a/agent/internal/remote/tools/software_install_process_tree.go
+++ b/agent/internal/remote/tools/software_install_process_tree.go
@@ -1,0 +1,29 @@
+package tools
+
+import "os/exec"
+
+// installerProcessTree groups an installer with the descendants it spawns so a
+// genuine timeout can terminate the REAL setup process instead of only the
+// wrapper that launched it. The context deadline kills the direct child alone,
+// which on a hung install leaves the service installer / updater / bundled
+// setup running as an orphan, still mutating the device long after the
+// deployment was reported as timed out.
+//
+// The tree is torn down ONLY on the genuine-timeout path. A wrapper exiting
+// successfully while its descendants keep installing is the normal case the
+// WaitDelay handling exists to serve, so release() must relinquish ownership
+// without signalling anything.
+//
+// Every method is best-effort by contract: a platform that cannot contain the
+// tree degrades to today's kill-the-direct-child behavior rather than failing
+// an otherwise healthy install.
+type installerProcessTree interface {
+	// prepare mutates cmd before Start.
+	prepare(cmd *exec.Cmd)
+	// adopt takes ownership of the process immediately after Start.
+	adopt(cmd *exec.Cmd)
+	// kill terminates every process in the tree.
+	kill(cmd *exec.Cmd)
+	// release drops the tree's OS resources WITHOUT terminating anything.
+	release()
+}

--- a/agent/internal/remote/tools/software_install_process_tree_unix.go
+++ b/agent/internal/remote/tools/software_install_process_tree_unix.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package tools
+
+import (
+	"errors"
+	"log/slog"
+	"os/exec"
+	"syscall"
+)
+
+// unixInstallerProcessTree puts the installer in its own process group. A
+// descendant that reparents to init is unreachable by pid, but it stays in the
+// group it was born into, so signalling the group is what actually reaches the
+// real installer on a timeout.
+type unixInstallerProcessTree struct{}
+
+func newInstallerProcessTree() installerProcessTree { return unixInstallerProcessTree{} }
+
+func (unixInstallerProcessTree) prepare(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+func (unixInstallerProcessTree) adopt(*exec.Cmd) {}
+
+func (unixInstallerProcessTree) kill(cmd *exec.Cmd) {
+	if cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return
+	}
+	// Setpgid makes the child its own group leader, so its pid IS the group id.
+	// SIGKILL rather than a graceful term: the deadline has already killed the
+	// leader, and whatever is left has outlived a 30-minute install window.
+	// ESRCH just means the group drained on its own first.
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		slog.Warn("failed to terminate installer process group after timeout",
+			"pid", cmd.Process.Pid, "error", err.Error())
+	}
+}
+
+func (unixInstallerProcessTree) release() {}

--- a/agent/internal/remote/tools/software_install_process_tree_windows.go
+++ b/agent/internal/remote/tools/software_install_process_tree_windows.go
@@ -1,0 +1,112 @@
+//go:build windows
+
+package tools
+
+import (
+	"log/slog"
+	"os/exec"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// windowsInstallerProcessTree owns one Job Object per installer run. Descendants
+// of a job member join the job automatically, so terminating the job on a
+// timeout reaches the real setup process that the wrapper handed the work to.
+//
+// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE is the same kernel-enforced backstop
+// sessionbroker's helper job uses (helper_job_windows.go): it guarantees the
+// tree cannot outlive the agent if the agent dies mid-install. It is cleared
+// again before the handle is closed on every non-timeout path — see release.
+type windowsInstallerProcessTree struct {
+	handle windows.Handle
+}
+
+func newInstallerProcessTree() installerProcessTree {
+	handle, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		slog.Warn("installer job object unavailable; a timeout will terminate the installer only",
+			"error", err.Error())
+		return &windowsInstallerProcessTree{}
+	}
+	if err := setInstallerJobKillOnClose(handle, true); err != nil {
+		_ = windows.CloseHandle(handle)
+		slog.Warn("installer job object could not be configured; a timeout will terminate the installer only",
+			"error", err.Error())
+		return &windowsInstallerProcessTree{}
+	}
+	return &windowsInstallerProcessTree{handle: handle}
+}
+
+func setInstallerJobKillOnClose(handle windows.Handle, kill bool) error {
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+	if kill {
+		info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	}
+	_, err := windows.SetInformationJobObject(
+		handle,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	)
+	return err
+}
+
+func (t *windowsInstallerProcessTree) prepare(*exec.Cmd) {}
+
+func (t *windowsInstallerProcessTree) adopt(cmd *exec.Cmd) {
+	if t.handle == 0 || cmd.Process == nil {
+		return
+	}
+	// os/exec does not expose the child's handle, so it is reopened by pid. The
+	// process is running by the time we get here, so a descendant it spawned in
+	// that window is outside the job; the wrapper itself is always in it, which
+	// is what the timeout path needs.
+	process, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(cmd.Process.Pid))
+	if err != nil {
+		slog.Warn("could not open installer process for job assignment; a timeout will terminate the installer only",
+			"pid", cmd.Process.Pid, "error", err.Error())
+		return
+	}
+	defer func() { _ = windows.CloseHandle(process) }()
+
+	if err := windows.AssignProcessToJobObject(t.handle, process); err != nil {
+		// A process already inside a job that forbids breakaway cannot join a
+		// second one — the constraint sessionbroker's spawner hit on a real RDS
+		// host (#2536). Degrading here costs the tree kill on timeout; failing
+		// here would cost the install itself, on every such host.
+		slog.Warn("installer not assigned to job object; a timeout will terminate the installer only",
+			"pid", cmd.Process.Pid, "error", err.Error())
+	}
+}
+
+func (t *windowsInstallerProcessTree) kill(cmd *exec.Cmd) {
+	if t.handle == 0 {
+		return
+	}
+	if err := windows.TerminateJobObject(t.handle, 1); err != nil {
+		slog.Warn("failed to terminate installer job object after timeout", "error", err.Error())
+	}
+	_ = windows.CloseHandle(t.handle)
+	t.handle = 0
+}
+
+func (t *windowsInstallerProcessTree) release() {
+	if t.handle == 0 {
+		return
+	}
+	// Clearing kill-on-close FIRST is what keeps a healthy wrapper install
+	// alive: closing the handle with the flag still set would kill exactly the
+	// descendants the wrapper legitimately left running, reintroducing the very
+	// failure the WaitDelay work fixed. If the flag cannot be cleared, leak the
+	// handle — one kernel handle on a path that should never occur — rather than
+	// close it and take a good install down with it.
+	if err := setInstallerJobKillOnClose(t.handle, false); err != nil {
+		slog.Warn("installer job object kill-on-close could not be cleared; retaining the handle so in-flight descendants survive",
+			"error", err.Error())
+		t.handle = 0
+		return
+	}
+	_ = windows.CloseHandle(t.handle)
+	t.handle = 0
+}

--- a/agent/internal/remote/tools/software_install_tree_test.go
+++ b/agent/internal/remote/tools/software_install_tree_test.go
@@ -1,0 +1,72 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A genuine install timeout must terminate the whole process tree. Installers
+// are wrappers: killing only the direct child leaves the REAL setup running as
+// an orphan, still mutating the device long after the deployment was reported
+// as timed out.
+func TestRunInstallerCommandKillsProcessTreeOnTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test drives the helper through sh")
+	}
+	prev := installerWaitDelay
+	installerWaitDelay = 500 * time.Millisecond
+	defer func() { installerWaitDelay = prev }()
+
+	marker := filepath.Join(t.TempDir(), "descendant-ran.txt")
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	// The wrapper hangs past the deadline while a descendant keeps working; the
+	// descendant writes its marker only after the wrapper has been killed.
+	script := "( sleep 2; echo alive > " + marker + " ) & sleep 30"
+	_, _, _, err := runInstallerCommand(ctx, shInstallerCommand(ctx, script), "exe")
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+
+	time.Sleep(3 * time.Second)
+	if _, statErr := os.Stat(marker); statErr == nil {
+		t.Fatal("descendant survived the install timeout and kept running; want the whole process tree terminated")
+	}
+}
+
+// The tree kill belongs to the genuine-timeout path ONLY. A wrapper that exits
+// successfully while the real installer keeps running is the normal case the
+// WaitDelay fix exists to serve — killing there would abort every healthy
+// wrapper-style install the moment the wrapper returned.
+func TestRunInstallerCommandLeavesDescendantsAloneOnSuccess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test drives the helper through sh")
+	}
+	prev := installerWaitDelay
+	installerWaitDelay = 300 * time.Millisecond
+	defer func() { installerWaitDelay = prev }()
+
+	marker := filepath.Join(t.TempDir(), "install-landed.txt")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	script := "( sleep 1; echo alive > " + marker + " ) & echo wrapper-done"
+	_, _, descendantsPending, err := runInstallerCommand(ctx, shInstallerCommand(ctx, script), "exe")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if !descendantsPending {
+		t.Fatal("expected descendantsPending=true")
+	}
+
+	time.Sleep(2 * time.Second)
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Fatalf("descendant install was killed after the wrapper exited successfully: %v", statErr)
+	}
+}


### PR DESCRIPTION
## Problem

Every EXE software deployment sat on **Pending** for 30 minutes and then failed with `installer exited with code 1`. MSI deployments worked fine. Found while verifying the hosted DO Spaces upload rollout — a 161 MB installer uploaded, downloaded, and checksummed correctly, then stalled.

Root cause: `executeInstaller` used `cmd.CombinedOutput()` with no `cmd.WaitDelay`. With pipe-backed stdout/stderr, `Wait` returns on pipe EOF, not on child exit — so it blocks until **every process that inherited the handles** exits. EXE installers are typically wrappers: they extract, spawn the real setup, and exit. The grandchild holds the pipe, so the agent waited out the full `installTimeout` and killed the wrapper. The kill was then mislabeled: a killed process reports exit code 1 on Windows, so timeouts were indistinguishable from genuine installer failures.

MSI was never affected — `msiexec /qn` installs through the MSI service and leaves no pipe-holding descendants, exactly matching the field report.

Every other exec site in the repo (`scripts/runner.go`, `executor/executor.go`, `collectors/command_limits.go`) already sets `WaitDelay`. The installer path was the one that missed it.

## Changes

Extracted `runInstallerCommand` as the single path for installer child processes:

- **`cmd.WaitDelay` (10s)** so `Wait` returns once the installer itself exits, even when abandoned descendants hold the output pipes. `exec.ErrWaitDelay` is judged by the real exit code rather than reported as a failure.
- **Honest timeout labeling** — a genuine timeout now reports `installer timed out after 30m0s and was terminated`. Critically, the deadline having passed is *not* on its own a timeout: a wrapper can exit 0 and have `Wait` drain descendants past the deadline, where the deadline killed nothing. Only claim a timeout when the process did not finish on its own with a success code, otherwise a good install inside the last 10s of the window is reported as a 30-minute hang.
- **Detection settling** — with the early return, the wrapper has exited while the real installer may still be running, so a single-shot detection check produced false `detection rule was not satisfied` failures. `descendantsPending` now drives a bounded re-check (60s, 2s interval) that returns as soon as the rule is satisfied. The ordinary path stays single-shot and unchanged in timing; unsupported-on-platform still means "detection not performed" and returns immediately.
- **Process-tree kill on genuine timeout** — Windows via a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` (following the existing `sessionbroker/helper_job_windows.go` pattern), unix via `Setpgid` + signaling the group. Reachable from exactly one branch: deadline fired *and* the process did not finish successfully. `release()` clears kill-on-close before closing the job handle — the reverse would kill the descendants a healthy wrapper legitimately left running, reintroducing the bug this PR fixes.
- **`installDMG` routed through the same runner**, deleting a divergent hand-rolled third copy of the exit-code logic. macOS DMG installs previously kept the original bug in full. `hdiutil`/`cp` route through with an empty `fileType` so they gain WaitDelay and timeout labeling without inheriting the 3010/1641 reboot-code semantics, which are meaningless for a mount and a copy; their `descendantsPending` is dropped, since a lingering `diskimages-helper` is normal mount state rather than an install still landing.

`Start`/`Wait` replaces `CombinedOutput` so the process can be adopted by the tree the instant it exists, with a mutex-guarded buffer for merged output — required because WaitDelay lets `Wait` return while an abandoned descendant's copy goroutine is still writing.

## Testing

Written test-first; every regression test was observed failing for the right reason before the fix:

- `runInstallerCommand blocked on descendant process for 8.02s` — the core hang.
- `expected timeout to be labeled as such, got err=installer exited with code -1` — the mislabel.
- `expected success for a wrapper that exited 0, got err=installer timed out after 30m0s` — the late-success inversion.
- `installDMG blocked on a descendant for 8.11s` / `expected a timeout label, got pkg installer exited with code -1` — the same two bugs surviving in the DMG path.
- `descendant survived the install timeout and kept running` — the missing tree kill.

Guard tests cover the cases that must **not** change: real non-zero exits still report their true exit code, the ordinary detection path stays single-shot, unsupported detection returns immediately, and a healthy wrapper's descendants are left alone on success.

Verification: `go test -race ./...` green across the whole agent; `go vet ./internal/...` clean; `GOOS=windows` vet (including test files) plus windows/linux/darwin builds all pass.

## Known limitations

- **The Windows job-object path was never executed** — this was developed on macOS, and both new test files skip on Windows. It was validated by `GOOS=windows go vet` (which compiles the tests) and by conforming structurally to the in-production `sessionbroker` job pattern. **Worth a real-device check before this reaches the fleet.**
- `os/exec` doesn't expose the child handle, so the process is reopened by pid after `Start`; a descendant spawned inside that microsecond window would be outside the job. Documented in the code.
- Job assignment degrades rather than fails (a process already in a job that forbids breakaway cannot join a second one, per the `#2536` precedent) — the cost is the tree kill, never the install.

## Related

- #3578 — deployments show "Pending" with no feedback for up to 45 minutes. This PR removes the most common *cause* of the long wait, but the missing in-progress reporting is still worth fixing separately.
- The original Printix failure that surfaced this is a separate, device-specific issue (the installer needs `api.printix.net` reachability, which fails on that machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)