### PR TITLE
fix(web,api): script test-run recovery, stale device pin, and AI tool descriptions

### DIFF
--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -1146,7 +1146,7 @@ export function createBreezeMcpServer(
 
     tool(
       'get_script_execution',
-      'Fetch one script execution by ID with status, exit code, stdout, and stderr. Use to read the result of a run that was still running when run_script returned.',
+      'Fetch one script execution by ID with status, exit code, stdout, and stderr. Use for runs started outside the current tool call (the script editor Test Run button, or an execution id from get_script_execution_history) — not to re-check a run_script call that already returned.',
       {
         executionId: uuid,
       },

--- a/apps/api/src/services/aiToolsScripts.getExecution.test.ts
+++ b/apps/api/src/services/aiToolsScripts.getExecution.test.ts
@@ -3,9 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 /**
  * Coverage for the get_script_execution tier-1 tool (script-editor test loop):
  * single-execution lookup with the script-org condition applied and the site
- * axis enforced after the row loads. The tool exists so the AI can read a
- * run's output after the user's editor Test Run (or after a run outlives the
- * 60s tool window), so the shape of the returned JSON is part of the contract.
+ * axis enforced after the row loads. The tool exists so the AI can read the
+ * output of a run started outside the current tool call (the editor's Test Run
+ * button, or an id from get_script_execution_history), so the shape of the
+ * returned JSON is part of the contract. It is NOT a recovery path for a
+ * run_script that hit its 60s wait: that timeout terminalizes the command row,
+ * so the agent's late result loses the CAS in routes/agentWs.ts and never
+ * reaches handleScriptResult — stdout/exitCode stay null forever.
  */
 
 vi.mock('../db', () => ({
@@ -17,6 +21,7 @@ vi.mock('../db', () => ({
 
 import { eq } from 'drizzle-orm';
 import { db } from '../db';
+import { scriptExecutions } from '../db/schema';
 import { registerScriptTools } from './aiToolsScripts';
 import type { AiTool } from './aiTools';
 import type { AuthContext } from '../middleware/auth';
@@ -98,6 +103,22 @@ function flattenSql(node: unknown, out: string[] = []): string[] {
   return out;
 }
 
+/** Token stream of a condition tree, joined with a separator that cannot occur
+ *  inside a column name or a uuid — so `toContain` on it is a contiguous
+ *  subsequence check (column adjacent to its bound param), not a loose
+ *  "the string appears somewhere" check. */
+function sqlTokenText(node: unknown): string {
+  return flattenSql(node).join('|');
+}
+
+/** The bound parameter values drizzle carries in the clause (drizzle `Param`
+ *  nodes surface through flattenSql's `'value' in node` branch). Asserting on
+ *  these is what makes a where-clause test non-vacuous: a predicate that was
+ *  deleted takes its bound value with it. */
+function boundParamValues(node: unknown): string[] {
+  return flattenSql(node).filter((t) => /^[0-9a-f-]{36}$/.test(t));
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -108,8 +129,16 @@ describe('get_script_execution', () => {
   });
 
   it('returns the execution with output fields and without the internal site id', async () => {
-    mockExecutionRows([executionRow]);
+    const captured: unknown[] = [];
+    mockExecutionRows([executionRow], captured);
     const result = JSON.parse(await getTool().handler({ executionId: EXECUTION_ID }, makeAuth()));
+
+    // Without an id predicate the query is `.limit(1)` over an unfiltered join
+    // and would return an ARBITRARY execution — including another org's, since
+    // the org condition is absent on a partner/system session. The clause must
+    // therefore BIND the requested id, not merely mention an `id` column.
+    expect(boundParamValues(captured[0])).toContain(EXECUTION_ID);
+    expect(sqlTokenText(captured[0])).toContain(sqlTokenText(eq(scriptExecutions.id, EXECUTION_ID)));
 
     expect(result.execution).toMatchObject({
       id: EXECUTION_ID,
@@ -124,7 +153,12 @@ describe('get_script_execution', () => {
     expect(result.execution).not.toHaveProperty('deviceSiteId');
   });
 
-  it('returns "Execution not found" when the org-scoped query matches nothing (cross-org lookup)', async () => {
+  // Renamed from "...when the org-scoped query matches nothing (cross-org
+  // lookup)": this test mocks an empty result set, so it exercises the
+  // no-row branch only and says nothing about scoping. The clause itself is
+  // asserted by the happy path (executionId binding) and by the org-condition
+  // test below; duplicating those here would only re-hide what this covers.
+  it('returns "Execution not found" when the query matches no row', async () => {
     mockExecutionRows([]);
     const result = JSON.parse(await getTool().handler({ executionId: EXECUTION_ID }, makeAuth()));
 

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -728,7 +728,7 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
     tier: 1,
     definition: {
       name: 'get_script_execution',
-      description: 'Get a single script execution by ID, including status, exit code, stdout, stderr, and timing. Use this to fetch the result of a run you or the user started (e.g. after a run outlived the tool call, or after the user clicked Test Run in the editor).',
+      description: 'Get a single script execution by ID, including status, exit code, stdout, stderr, and timing. Use this for runs started OUTSIDE the current tool call — e.g. the user clicked Test Run in the script editor, or you have an execution id from get_script_execution_history. It is not a way to recover a run_script call that timed out: run_script already returns that run\'s final recorded outcome.',
       input_schema: {
         type: 'object' as const,
         properties: {

--- a/apps/api/src/services/scriptBuilderPrompt.ts
+++ b/apps/api/src/services/scriptBuilderPrompt.ts
@@ -18,7 +18,7 @@ You have access to tools that let you:
 - Test-run saved scripts on devices with execute_script_on_device (requires user approval; returns stdout/stderr and exit code inline)
 - Read any run's result with get_script_execution / get_script_execution_history — including runs the user starts from the editor's Test Run button
 
-To iterate on a script: apply_script_code, ensure the script is saved (ask the user to save if your edits are unsaved — execution always runs the SAVED content), run it on the pinned test device, read the output, and fix. If a run is still running when the tool call returns, poll get_script_execution with the returned executionId.
+To iterate on a script: apply_script_code, ensure the script is saved (ask the user to save if your edits are unsaved — execution always runs the SAVED content), run it on the pinned test device, read the output, and fix. execute_script_on_device returns that run's final recorded outcome — if it comes back as a timeout, say so and offer to re-run; polling get_script_execution for the same executionId will not turn up a later result.
 
 When the user asks you to write or modify a script:
 1. Ask clarifying questions if the request is ambiguous

--- a/apps/api/src/services/scriptBuilderTools.ts
+++ b/apps/api/src/services/scriptBuilderTools.ts
@@ -298,7 +298,7 @@ export function createScriptBuilderMcpServer(
 
     tool(
       'get_script_execution',
-      'Fetch one script execution by ID with status, exit code, stdout, and stderr. Use after a run you or the user started to read its result.',
+      'Fetch one script execution by ID with status, exit code, stdout, and stderr. Use for runs started outside the current tool call (the editor Test Run button, or an execution id from get_script_execution_history) — not to re-check an execute_script_on_device call that already returned.',
       {
         executionId: uuid.describe('The execution ID to fetch'),
       },

--- a/apps/web/src/components/scripts/ScriptTestRunner.test.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import ScriptTestRunner from './ScriptTestRunner';
 
@@ -32,7 +32,13 @@ describe('ScriptTestRunner', () => {
   });
   afterEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
+
+  // Fake timers let the poll loop (POLL_INTERVAL_MS = 2000) run to its deadline
+  // in milliseconds of wall clock instead of minutes — the deadline path is
+  // untestable with real timers.
+  const flush = (ms = 0) => act(async () => { await vi.advanceTimersByTimeAsync(ms); });
 
   it('disables test runs and explains why when the script was never saved', async () => {
     render(
@@ -225,5 +231,149 @@ describe('ScriptTestRunner', () => {
 
     await waitFor(() => expect(onTestDeviceChange).toHaveBeenCalledWith(DEVICE_ID));
     expect((screen.getByTestId('test-device-select') as HTMLSelectElement).value).toBe(DEVICE_ID);
+  });
+
+  it('terminalises the run on a permanent poll failure and re-polls the same execution on retry', async () => {
+    vi.useFakeTimers();
+    let polls = 0;
+    let pollGone = true;
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/devices') return jsonResponse({ data: [onlineDevice] });
+      if (url === `/scripts/${SCRIPT_ID}/execute` && init?.method === 'POST') {
+        return jsonResponse({ executions: [{ executionId: EXECUTION_ID, deviceId: DEVICE_ID }] }, 201);
+      }
+      if (url === `/scripts/executions/${EXECUTION_ID}`) {
+        polls += 1;
+        if (pollGone) return jsonResponse({ error: 'gone' }, 404);
+        return jsonResponse({ id: EXECUTION_ID, status: 'completed', exitCode: 0, stdout: 'recovered output', stderr: '' });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    render(
+      <ScriptTestRunner scriptId={SCRIPT_ID} osTypes={['windows']} isDirty={false} onSaveChanges={async () => true} />
+    );
+    await flush();
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    fireEvent.click(screen.getByTestId('test-run-button'));
+    await flush(4000);
+
+    expect(polls).toBe(1);
+    expect(screen.getByText(/could not read the run result/i)).toBeInTheDocument();
+    // The run must not still be presented as in flight: no spinning status chip,
+    // and the Run button is only re-enabled because nothing is running.
+    expect(screen.queryByText('Queued')).toBeNull();
+    expect(screen.queryByText('Running')).toBeNull();
+    expect(screen.getByTestId('test-run-button')).not.toBeDisabled();
+
+    // Recovery must re-read the SAME execution, never start a second run.
+    pollGone = false;
+    fireEvent.click(screen.getByTestId('test-poll-retry'));
+    await flush(4000);
+
+    expect(screen.getByText('recovered output')).toBeInTheDocument();
+    expect(polls).toBe(2);
+    expect(fetchWithAuthMock.mock.calls.filter(([url]) => String(url).includes('/execute')).length).toBe(1);
+  });
+
+  it('keeps polling through a 429 — a rate limit is not a permanent failure', async () => {
+    vi.useFakeTimers();
+    let polls = 0;
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/devices') return jsonResponse({ data: [onlineDevice] });
+      if (url === `/scripts/${SCRIPT_ID}/execute` && init?.method === 'POST') {
+        return jsonResponse({ executions: [{ executionId: EXECUTION_ID, deviceId: DEVICE_ID }] }, 201);
+      }
+      if (url === `/scripts/executions/${EXECUTION_ID}`) {
+        polls += 1;
+        if (polls <= 2) return jsonResponse({ error: 'rate limited' }, 429);
+        return jsonResponse({ id: EXECUTION_ID, status: 'completed', exitCode: 0, stdout: 'after the limit', stderr: '' });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    render(
+      <ScriptTestRunner scriptId={SCRIPT_ID} osTypes={['windows']} isDirty={false} onSaveChanges={async () => true} />
+    );
+    await flush();
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    fireEvent.click(screen.getByTestId('test-run-button'));
+    await flush(10000);
+
+    expect(polls).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText('after the limit')).toBeInTheDocument();
+    expect(screen.queryByText(/could not read the run result/i)).toBeNull();
+  });
+
+  it('terminalises the run when the poll deadline expires', async () => {
+    vi.useFakeTimers();
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/devices') return jsonResponse({ data: [onlineDevice] });
+      if (url === `/scripts/${SCRIPT_ID}/execute` && init?.method === 'POST') {
+        return jsonResponse({ executions: [{ executionId: EXECUTION_ID, deviceId: DEVICE_ID }] }, 201);
+      }
+      if (url === `/scripts/executions/${EXECUTION_ID}`) {
+        return jsonResponse({ id: EXECUTION_ID, status: 'running' });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    render(
+      <ScriptTestRunner
+        scriptId={SCRIPT_ID}
+        osTypes={['windows']}
+        timeoutSeconds={1}
+        isDirty={false}
+        onSaveChanges={async () => true}
+      />
+    );
+    await flush();
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    fireEvent.click(screen.getByTestId('test-run-button'));
+    // Deadline is timeoutSeconds + 120s of slack.
+    await flush(130_000);
+
+    expect(screen.getByText(/still no result/i)).toBeInTheDocument();
+    expect(screen.queryByText('Running')).toBeNull();
+    expect(screen.queryByText('Queued')).toBeNull();
+    expect(screen.getByTestId('test-run-button')).not.toBeDisabled();
+    // Recovery is still possible without starting a second run.
+    expect(screen.getByTestId('test-poll-retry')).toBeInTheDocument();
+  });
+
+  it('clears a pinned device that the new OS targets no longer allow', async () => {
+    const onTestDeviceChange = vi.fn();
+    const { rerender } = render(
+      <ScriptTestRunner
+        scriptId={SCRIPT_ID}
+        osTypes={['windows']}
+        isDirty={false}
+        onSaveChanges={async () => true}
+        onTestDeviceChange={onTestDeviceChange}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('test-box')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    expect(screen.getByTestId('test-run-button')).not.toBeDisabled();
+    expect(localStorage.getItem(`breeze:script-test-device:${SCRIPT_ID}`)).toBe(DEVICE_ID);
+
+    rerender(
+      <ScriptTestRunner
+        scriptId={SCRIPT_ID}
+        osTypes={['macos']}
+        isDirty={false}
+        onSaveChanges={async () => true}
+        onTestDeviceChange={onTestDeviceChange}
+      />
+    );
+
+    await waitFor(() =>
+      expect((screen.getByTestId('test-device-select') as HTMLSelectElement).value).toBe('')
+    );
+    // Run must be blocked, not silently targeting the now-hidden device.
+    expect(screen.getByTestId('test-run-button')).toBeDisabled();
+    expect(onTestDeviceChange).toHaveBeenLastCalledWith(null);
+    expect(localStorage.getItem(`breeze:script-test-device:${SCRIPT_ID}`)).toBeNull();
   });
 });

--- a/apps/web/src/components/scripts/ScriptTestRunner.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Play, Loader2, CheckCircle, XCircle, AlertTriangle, Clock, Terminal, AlertOctagon, ExternalLink } from 'lucide-react';
+import { Play, Loader2, CheckCircle, XCircle, AlertTriangle, Clock, Terminal, AlertOctagon, ExternalLink, RefreshCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '@/lib/runAction';
@@ -64,6 +64,9 @@ export default function ScriptTestRunner({
   const [phase, setPhase] = useState<'idle' | 'saving' | 'starting' | 'polling'>('idle');
   const [execution, setExecution] = useState<TestRunExecution | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
+  // Set when polling gave up (permanent poll error / deadline) so the user can
+  // re-read THAT execution instead of starting a second run on a real device.
+  const [retryExecutionId, setRetryExecutionId] = useState<string | null>(null);
   const pollTokenRef = useRef(0);
 
   useEffect(() => {
@@ -116,6 +119,23 @@ export default function ScriptTestRunner({
     // identity — re-running would fight the user's manual selection).
   }, [scriptId, compatibleDevices.length]);
 
+  // Drop a pinned device that the current OS targets no longer allow. Without
+  // this the <select> renders as unselected (no matching <option>) while the Run
+  // button stays enabled and would still POST the hidden device id.
+  useEffect(() => {
+    if (!selectedDeviceId) return;
+    // `devices` empty means the /devices fetch hasn't resolved (or failed), not
+    // that the pin is incompatible — never clear a legitimate selection during
+    // the initial load window, or this would fight the restore effect above.
+    if (devices.length === 0) return;
+    if (compatibleDevices.some(d => d.id === selectedDeviceId)) return;
+    setSelectedDeviceId('');
+    if (scriptId) localStorage.removeItem(storageKey(scriptId));
+    onTestDeviceChange?.(null);
+    // onTestDeviceChange is deliberately not a dep — callers pass an inline
+    // closure, and re-running on its identity would re-check needlessly.
+  }, [devices, compatibleDevices, selectedDeviceId, scriptId]);
+
   // Cancel any in-flight poll loop on unmount.
   useEffect(() => () => { pollTokenRef.current += 1; }, []);
 
@@ -152,6 +172,17 @@ export default function ScriptTestRunner({
     const timeoutSecs = Number(timeoutSeconds) || 300;
     const deadline = Date.now() + (timeoutSecs + 120) * 1000;
 
+    // Give up on reading the result without claiming the run is still in flight:
+    // dropping `execution` stops the animated status chip (which would otherwise
+    // spin forever while the Run button was re-enabled) and offers a re-poll of
+    // the SAME execution so recovery never means a second run on a real device.
+    const abandonPoll = (message: string) => {
+      setPhase('idle');
+      setExecution(null);
+      setRetryExecutionId(executionId);
+      setRunError(message);
+    };
+
     while (Date.now() < deadline) {
       await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
       if (pollTokenRef.current !== token) return;
@@ -163,11 +194,14 @@ export default function ScriptTestRunner({
           return;
         }
         if (!response.ok) {
-          // A 4xx is permanent (execution deleted, access revoked) — stop
-          // instead of hammering the endpoint to the deadline. 5xx retries.
-          if (response.status >= 400 && response.status < 500) {
-            setPhase('idle');
-            setRunError(t('testRunner.errors.pollFailed'));
+          // Most 4xx are permanent (execution deleted, access revoked) — stop
+          // instead of hammering the endpoint to the deadline. 408 and 429 are
+          // NOT permanent: the app-wide globalRateLimit() can trip on a 2s poll
+          // loop, so those fall through and retry alongside 5xx.
+          const permanent = response.status >= 400 && response.status < 500
+            && response.status !== 408 && response.status !== 429;
+          if (permanent) {
+            abandonPoll(t('testRunner.errors.pollFailed'));
             return;
           }
           continue;
@@ -185,14 +219,25 @@ export default function ScriptTestRunner({
     }
 
     if (pollTokenRef.current === token) {
-      setPhase('idle');
-      setRunError(t('testRunner.errors.pollDeadline'));
+      abandonPoll(t('testRunner.errors.pollDeadline'));
     }
   }, [timeoutSeconds, t]);
+
+  // Re-read the SAME execution after a poll failure — never a second run.
+  const handleRetryPoll = () => {
+    if (!retryExecutionId || phase !== 'idle') return;
+    const executionId = retryExecutionId;
+    setRunError(null);
+    setRetryExecutionId(null);
+    setExecution({ id: executionId, status: 'pending' });
+    setPhase('polling');
+    void pollExecution(executionId);
+  };
 
   const handleRun = async () => {
     if (!scriptId || !selectedDeviceId || phase !== 'idle') return;
     setRunError(null);
+    setRetryExecutionId(null);
 
     if (isDirty) {
       setPhase('saving');
@@ -367,7 +412,20 @@ export default function ScriptTestRunner({
         </p>
       )}
       {runError && (
-        <p className="border-t px-3 py-2 text-xs text-destructive">{runError}</p>
+        <p className="flex flex-wrap items-center gap-2 border-t px-3 py-2 text-xs text-destructive">
+          <span>{runError}</span>
+          {retryExecutionId && !busy && (
+            <button
+              type="button"
+              onClick={handleRetryPoll}
+              data-testid="test-poll-retry"
+              className="inline-flex items-center gap-1 rounded border border-destructive/40 px-2 py-0.5 font-medium transition hover:bg-destructive/10"
+            >
+              <RefreshCw className="h-3 w-3" />
+              {t('common:actions.retry')}
+            </button>
+          )}
+        </p>
       )}
 
       {execution && !running && TERMINAL_STATUSES.includes(execution.status) && (


### PR DESCRIPTION
Follow-ups from the post-merge review of #3582. Four findings, ranked by consequence.

## 1. Terminal poll failures left a permanently spinning chip — and the only escape was a second run

Both give-up exits from `pollExecution` (permanent poll error, deadline fall-through) set `phase='idle'` but left `execution.status` at `pending`/`queued`/`running`. The animated `Loader2` chip spun forever, the output block stayed hidden, and the Run button was simultaneously re-enabled — so the only affordance left was **Test Run, which starts a second execution on a real customer device**.

Both exits now clear `execution` and stash the id for a **Retry** control that re-enters `pollExecution` with the *same* execution id. Recovery never means a second run.

## 2. 408/429 were treated as permanent

The "4xx is permanent" branch swallowed 429. `globalRateLimit()` is mounted app-wide and a 2s poll loop can plausibly trip it, which aborted the poll and showed a wrong "deleted or access revoked" message. 408 and 429 now fall through to the retry path alongside 5xx.

## 3. A pinned device survived an OS-target change

`compatibleDevices` recomputed on `osTypes` change but `selectedDeviceId` was never reconciled. Removing an OS target after pinning a device left the `<select>` rendering as unselected (no matching `<option>`) and suppressed the offline warning — while Run stayed enabled and `handleRun` still POSTed the hidden device id. Executing on a machine the operator believes is deselected is the wrong failure direction.

Now reconciled: selection, localStorage pin, and `onTestDeviceChange(null)`. The effect guards on the raw `devices` list being empty (not `compatibleDevices`) so it can't fight the restore-from-localStorage effect during the load window.

## 4. The executionId filter was unguarded — verified by mutation

Deleting `eq(scriptExecutions.id, input.executionId)` from the handler's `.where(and(...))` left **all 6 tests green**, while the tool would return an arbitrary execution row (`.limit(1)` over an unfiltered join).

The existing `flattenSql` helper was the right instinct and already catches a deleted *org* condition — it just wasn't applied to the id predicate. The happy-path test now asserts the execution id appears in the clause's **bound params**, adjacent to an `id` column.

Mutation-verified twice (once by the implementing agent, once independently):
- predicate present → 6 passed
- predicate deleted → `AssertionError: expected [] to include '1111...'`, 1 failed / 5 passed
- restored → 6 passed

Also renamed a test whose name claimed `cross-org lookup` coverage it did not have (it mocks `[]` and only exercises the no-row branch).

## 5. Four AI-facing tool descriptions promised a recovery path that does not exist

`aiToolsScripts.ts`, `aiAgentSdkTools.ts`, `scriptBuilderTools.ts`, and `scriptBuilderPrompt.ts` all told the model to use `get_script_execution` to read a run that was still running when `run_script` returned. **That path does not exist.** Verified chain:

1. `run_script` waits via `waitForCommandResult(commandId, 60000)` (`aiToolsScripts.ts:328`)
2. at its deadline that terminalizes the command row to `status:'failed'` (`commandQueue.ts:588-605`)
3. the agent's real result then fails the `status IN ('pending','sent')` filter at the **lookup** in `agentWs.ts:1598-1610` — earlier than the CAS at `:1739` — and falls into `processOrphanedCommandResult`, which handles only SNMP/discovery/tunnel and returns
4. so `handleScriptResult` (the only writer of stdout/stderr/exitCode onto `script_executions`) never runs
5. `staleCommandReaper` later stamps status but explicitly does not persist output, and attributes it to the misleading #3097 "delivered but never recorded" message

Net: in exactly the scenario those strings named, the tool returns `status:'failed'`, `exitCode:null`, `stdout:null` permanently — instructing the model to attempt an impossible recovery **and to report a successful script as failed**. Since these are prompts the model acts on, this was a functional bug, not a wording nit.

The strings now describe the tool's real use: reading a run started outside the current tool call (the editor's Test Run button, or an id from `get_script_execution_history`).

## Out of scope — needs a separate issue

The underlying defect is untouched here: **a `run_script` call exceeding the 60s wait permanently loses the agent's real output.** Fix directions are either letting the WS path accept a late result for a `timeout`-flagged command, or making `handleScriptResult` reachable from the orphaned/late path. That touches the agent WS result path and deserves its own PR.

## Testing

- `apps/web` scripts components: 82 passed (7 files) — includes 4 new `ScriptTestRunner` cases covering the 404-stop + retry-same-id, 429-continues-polling, deadline, and OS-retarget-clears-selection paths
- `apps/api` script tools: 126 passed (12 files), `scriptBuilderTools.guard.test.ts` 36/36
- New polling tests use `vi.useFakeTimers()`, which is what makes the deadline path testable at all; the pre-existing polling tests were left on real timers (converting them is a cheap follow-up now that the helper exists)
- No new locale keys: the Retry button reuses `common:actions.retry`, already translated in all 7 locales. Seeding English-valued keys would have reddened `translationCoverage.test.ts`, which asserts an exact count of English-identical leaves per locale.

No schema, migration, or tenancy changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)