### PR TITLE
fix(api): enforce the inbound email-to-ticket toggle server-side (#3597)

### DIFF
--- a/apps/api/migrations/2026-08-24-inbound-enabled-backfill.sql
+++ b/apps/api/migrations/2026-08-24-inbound-enabled-backfill.sql
@@ -1,0 +1,58 @@
+-- #3597 — the 'Enable email-to-ticket' switch becomes an ENFORCED gate.
+--
+-- Until now `settings.ticketing.inbound.enabled` was display-only: the settings card
+-- persisted and re-rendered it, but nothing in the ingestion pipeline read it, so mail
+-- was ticketed regardless. Two consequences for existing data:
+--
+--   1. The card read the flag back as `enabled: false` when absent, and it replaces the
+--      whole `ticketing.inbound` sub-object on EVERY save. So any partner who ever
+--      touched an unrelated inbound setting (triage org, autoresponder, unknown-sender
+--      mode) had `enabled: false` written for them — while their mail kept flowing.
+--   2. A stored `false` therefore is NOT evidence that the partner wanted the feature
+--      off. Observed inbound mail IS evidence that they rely on it.
+--
+-- So: repair an explicit `false` to `true` for partners who have actually received
+-- inbound mail. Partners with no `enabled` key are untouched — the runtime default is
+-- permissive (see PartnerInboundPolicy.enabled), which preserves today's behavior.
+-- Partners with an explicit `false` and no observed mail are also untouched: nothing
+-- breaks for them, and if the false was deliberate we honor it.
+--
+-- Anyone who genuinely wants inbound off can now switch it off and have it take effect.
+--
+-- A blanket "set every existing partner to true" was considered and rejected: with the
+-- runtime default already permissive, the only rows that matter are the explicit
+-- `false`s, and a regression requires mail to actually be flowing. The observed-mail
+-- condition therefore covers every partner who can regress while leaving a deliberate
+-- `false` on a partner with no inbound mail alone.
+--
+-- Re-run note: this is a one-shot repair, not a converger. It is safely idempotent
+-- immediately after release (no row matches `= 'false'` once repaired), but it is NOT
+-- safe to replay months later — by then a partner may have deliberately switched the
+-- feature off AND have `ticket_email_inbound` rows, and a replay would re-enable them.
+-- `breeze_migrations` keys on filename and applies each file once, which is the
+-- guarantee being relied on here. Do not copy this file forward under a new name.
+
+DO $$
+DECLARE
+  repaired integer;
+BEGIN
+  WITH updated AS (
+    UPDATE partners p
+       SET settings = jsonb_set(
+             COALESCE(p.settings, '{}'::jsonb),
+             '{ticketing,inbound,enabled}',
+             'true'::jsonb,
+             true
+           )
+     WHERE p.settings -> 'ticketing' -> 'inbound' -> 'enabled' = 'false'::jsonb
+       AND EXISTS (
+             SELECT 1 FROM ticket_email_inbound t WHERE t.partner_id = p.id
+           )
+    RETURNING 1
+  )
+  SELECT count(*) INTO repaired FROM updated;
+
+  IF repaired > 0 THEN
+    RAISE WARNING 'backfilled ticketing.inbound.enabled=true for % partner(s) with observed inbound mail (#3597)', repaired;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/resolveOrg.integration.test.ts
+++ b/apps/api/src/__tests__/integration/resolveOrg.integration.test.ts
@@ -120,7 +120,7 @@ describe('loadPartnerInboundPolicy', () => {
   it('reads routing policy from partners.settings JSONB, defaulting absent to quarantine', async () => {
     const { p } = await seedPartnerOrg();
     const defaults = await withSystemDbAccessContext(() => loadPartnerInboundPolicy(p.id));
-    expect(defaults).toEqual({ unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: false });
+    expect(defaults).toEqual({ enabled: true, unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: false });
 
     const adminDb = getTestDb() as any;
     await adminDb
@@ -129,7 +129,34 @@ describe('loadPartnerInboundPolicy', () => {
       .where(eq(partners.id, p.id));
 
     const set = await withSystemDbAccessContext(() => loadPartnerInboundPolicy(p.id));
-    expect(set).toEqual({ unknownSenderMode: 'drop', defaultTriageOrgId: 'org-triage', dropUnverifiedSenders: true });
+    expect(set).toEqual({ enabled: true, unknownSenderMode: 'drop', defaultTriageOrgId: 'org-triage', dropUnverifiedSenders: true });
+  });
+
+  // #3597. `enabled` is the ONE field here that defaults permissive: the toggle was
+  // display-only until the gate shipped, so ingestion has always been on and a
+  // default of false would silently stop ticketing on upgrade.
+  it('reads enabled, defaulting an absent flag to true and honoring an explicit false', async () => {
+    const { p } = await seedPartnerOrg();
+    const adminDb = getTestDb() as any;
+
+    // A stored inbound object that predates the flag entirely.
+    await adminDb
+      .update(partners)
+      .set({ settings: { ticketing: { inbound: { unknownSenderMode: 'quarantine' } } } })
+      .where(eq(partners.id, p.id));
+    expect((await withSystemDbAccessContext(() => loadPartnerInboundPolicy(p.id))).enabled).toBe(true);
+
+    await adminDb
+      .update(partners)
+      .set({ settings: { ticketing: { inbound: { enabled: false } } } })
+      .where(eq(partners.id, p.id));
+    expect((await withSystemDbAccessContext(() => loadPartnerInboundPolicy(p.id))).enabled).toBe(false);
+
+    await adminDb
+      .update(partners)
+      .set({ settings: { ticketing: { inbound: { enabled: true } } } })
+      .where(eq(partners.id, p.id));
+    expect((await withSystemDbAccessContext(() => loadPartnerInboundPolicy(p.id))).enabled).toBe(true);
   });
 
   it('maps the legacy triageUnknownSenders boolean to unknownSenderMode for back-compat', async () => {
@@ -141,6 +168,6 @@ describe('loadPartnerInboundPolicy', () => {
       .where(eq(partners.id, p.id));
 
     const set = await withSystemDbAccessContext(() => loadPartnerInboundPolicy(p.id));
-    expect(set).toEqual({ unknownSenderMode: 'triage', defaultTriageOrgId: 'org-triage', dropUnverifiedSenders: false });
+    expect(set).toEqual({ enabled: true, unknownSenderMode: 'triage', defaultTriageOrgId: 'org-triage', dropUnverifiedSenders: false });
   });
 });

--- a/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
@@ -266,7 +266,7 @@ beforeEach(() => {
   resolveOrgMock.mockResolvedValue(null);
   findOrCreateContactMock.mockReset();
   loadPolicyMock.mockReset();
-  loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: false });
+  loadPolicyMock.mockResolvedValue({ enabled: true, unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: false });
 });
 
 describe('processInboundEmail', () => {
@@ -912,7 +912,7 @@ describe('processInboundEmail', () => {
     state.selectRows['ticket_email_inbound'] = [];
     state.selectRows['tickets'] = [];
     state.selectRows['portal_users'] = [];
-    loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: true });
+    loadPolicyMock.mockResolvedValue({ enabled: true, unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: true });
 
     await processInboundEmail(email({ senderAuth: { spf: 'fail', dkim: 'fail', dmarc: 'fail', verified: false } }));
 
@@ -967,7 +967,7 @@ describe('processInboundEmail — Phase 5 sender-domain routing', () => {
     loadPolicyMock.mockReset();
     // Safe defaults: no domain match, quarantine unknown senders.
     resolveOrgMock.mockResolvedValue(null);
-    loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: false });
+    loadPolicyMock.mockResolvedValue({ enabled: true, unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: false });
   });
 
   it('routes a mapped domain (autoCreateContact true) -> creates ticket in the org + onboards a contact', async () => {
@@ -1003,7 +1003,7 @@ describe('processInboundEmail — Phase 5 sender-domain routing', () => {
   it('falls back to the triage org when enabled and no domain matches (no contact onboarding)', async () => {
     state.selectRows['organizations'] = [{ id: 'o-triage' }];
     resolveOrgMock.mockResolvedValue(null);
-    loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'triage', defaultTriageOrgId: 'o-triage', dropUnverifiedSenders: false });
+    loadPolicyMock.mockResolvedValue({ enabled: true, unknownSenderMode: 'triage', defaultTriageOrgId: 'o-triage', dropUnverifiedSenders: false });
     createTicketMock.mockResolvedValue({ id: 't-t', internalNumber: 'T-2026-0100' });
 
     await processInboundEmail(email());
@@ -1016,7 +1016,7 @@ describe('processInboundEmail — Phase 5 sender-domain routing', () => {
 
   it('quarantines when nothing matches and mode is quarantine (default)', async () => {
     resolveOrgMock.mockResolvedValue(null);
-    loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: false });
+    loadPolicyMock.mockResolvedValue({ enabled: true, unknownSenderMode: 'quarantine', defaultTriageOrgId: null, dropUnverifiedSenders: false });
 
     await processInboundEmail(email());
 
@@ -1026,7 +1026,7 @@ describe('processInboundEmail — Phase 5 sender-domain routing', () => {
 
   it('triage mode with NO triage org configured falls through to quarantine (never a no-org create)', async () => {
     resolveOrgMock.mockResolvedValue(null);
-    loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'triage', defaultTriageOrgId: null, dropUnverifiedSenders: false });
+    loadPolicyMock.mockResolvedValue({ enabled: true, unknownSenderMode: 'triage', defaultTriageOrgId: null, dropUnverifiedSenders: false });
 
     await processInboundEmail(email());
 
@@ -1036,7 +1036,7 @@ describe('processInboundEmail — Phase 5 sender-domain routing', () => {
 
   it("'drop' mode silently ignores an unknown sender — no ticket, no quarantine (audit row only)", async () => {
     resolveOrgMock.mockResolvedValue(null);
-    loadPolicyMock.mockResolvedValue({ unknownSenderMode: 'drop', defaultTriageOrgId: null, dropUnverifiedSenders: false });
+    loadPolicyMock.mockResolvedValue({ enabled: true, unknownSenderMode: 'drop', defaultTriageOrgId: null, dropUnverifiedSenders: false });
 
     await processInboundEmail(email());
 
@@ -1073,5 +1073,98 @@ describe('processInboundEmail — Phase 5 sender-domain routing', () => {
     const input = createTicketMock.mock.calls[0]![0] as Record<string, unknown>;
     expect(input.orgId).toBe('o-known');
     expect(input.submittedBy).toBe('pu-known');
+  });
+});
+
+// #3597 — the 'Enable email-to-ticket' switch was persisted and rendered but never
+// read by this pipeline, so turning the feature OFF did nothing. These assert the
+// gate is real, that it beats every downstream branch, and that it does not fire on
+// its own default (which must stay permissive so an upgrade can't stop ingestion).
+describe('processInboundEmail — inbound enabled master switch (#3597)', () => {
+  const disabled = {
+    enabled: false,
+    unknownSenderMode: 'quarantine' as const,
+    defaultTriageOrgId: null,
+    dropUnverifiedSenders: false,
+  };
+
+  beforeEach(() => {
+    state.selectRows['ticket_email_inbound'] = [];
+    state.selectRows['tickets'] = [];
+    state.selectRows['portal_users'] = [];
+    resolveMock.mockResolvedValue('p-1');
+    resolveOrgMock.mockResolvedValue(null);
+  });
+
+  it('ignores mail for a partner with inbound disabled — no ticket, no quarantine row', async () => {
+    loadPolicyMock.mockResolvedValue(disabled);
+
+    await processInboundEmail(email());
+
+    expect(createTicketMock).not.toHaveBeenCalled();
+    const rows = inboundOf();
+    expect(rows).toHaveLength(1);
+    // 'ignored', not 'quarantined'/'failed' — those two are REVIEW_STATUSES, and a
+    // partner who switched the feature off must not accumulate a review queue.
+    expect(rows[0]!.parseStatus).toBe('ignored');
+    expect(rows[0]!.partnerId).toBe('p-1');
+    expect(rows[0]!.ticketId).toBeNull();
+    expect(rows[0]!.error).toBe('inbound disabled for partner');
+  });
+
+  it('beats a live thread match — a disabled partner gets no comment append or reopen', async () => {
+    loadPolicyMock.mockResolvedValue(disabled);
+    // A ticket the message would otherwise match (and reopen, since it's resolved).
+    state.selectRows['tickets'] = [{
+      id: 't-live', partnerId: 'p-1', orgId: 'o-1', status: 'resolved',
+      emailThreadKey: 'k', internalNumber: 'T-2026-0001',
+    }];
+
+    await processInboundEmail(email());
+
+    expect(state.updates).toHaveLength(0);
+    expect(inboundOf()[0]!.parseStatus).toBe('ignored');
+  });
+
+  it('suppresses the autoresponder — nothing downstream of the gate runs', async () => {
+    loadPolicyMock.mockResolvedValue(disabled);
+    state.selectRows['organizations'] = [{ id: 'o-9' }];
+    resolveOrgMock.mockResolvedValue({ orgId: 'o-9', autoCreateContact: true });
+
+    await processInboundEmail(email());
+
+    expect(maybeSendAutoresponseMock).not.toHaveBeenCalled();
+    expect(findOrCreateContactMock).not.toHaveBeenCalled();
+    expect(resolveOrgMock).not.toHaveBeenCalled();
+  });
+
+  it('gates the M365 poll path too (the flag is per-partner, not per-transport)', async () => {
+    const mailboxGeneration = {
+      connectionId: '44444444-4444-4444-8444-444444444444',
+      partnerId: '22222222-2222-4222-8222-222222222222',
+      tenantId: '11111111-1111-4111-8111-111111111111',
+      consentAttemptId: '66666666-6666-4666-8666-666666666666',
+    };
+    state.selectRows['ticket_mailbox_connections'] = [{ id: mailboxGeneration.connectionId }];
+    loadPolicyMock.mockResolvedValue(disabled);
+
+    await processInboundEmail(
+      email({ provider: 'm365', resolvedPartnerId: mailboxGeneration.partnerId }),
+      mailboxGeneration,
+    );
+
+    expect(createTicketMock).not.toHaveBeenCalled();
+    expect(inboundOf()).toEqual([expect.objectContaining({
+      partnerId: mailboxGeneration.partnerId,
+      parseStatus: 'ignored',
+    })]);
+  });
+
+  it('does not fire for an enabled partner (the gate is not the whole pipeline)', async () => {
+    loadPolicyMock.mockResolvedValue({ ...disabled, enabled: true });
+
+    await processInboundEmail(email());
+
+    expect(inboundOf()[0]!.parseStatus).toBe('quarantined');
   });
 });

--- a/apps/api/src/services/inboundEmail/inboundEmailService.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.ts
@@ -218,6 +218,40 @@ export async function processInboundEmail(
       .limit(1);
     if (dup[0]) return;
 
+    // (2b) Master switch (#3597). `settings.ticketing.inbound.enabled` used to be
+    // display-only: the card persisted and re-rendered it while nothing in this
+    // pipeline read it, so a partner who turned the feature OFF kept getting tickets
+    // (and autoresponses) with no in-product way to stop it. Gate here — after the
+    // partner is known (the flag is per-partner) and after the dedup SELECT, so a
+    // provider retry short-circuits on the existing row instead of racing the
+    // (partner_id, provider_message_id) unique index and landing a spurious `failed`.
+    //
+    // Terminate as `ignored`, not an error: the webhook already 202'd and a 4xx/5xx
+    // would make the provider retry mail we intend to discard. `ignored` also keeps
+    // the row out of the review queue (REVIEW_STATUSES = quarantined|failed), which
+    // is the point — a disabled partner should see nothing, not a growing queue.
+    // No separate autoresponder gate is needed: autoresponses only fire from
+    // createFromEmail, which is downstream of this return.
+    //
+    // The M365 poll path lands here too (mailboxGeneration carries the partnerId), so
+    // it is covered — but note the semantic: the poller still fetches, marks read, and
+    // advances its delta cursor, so mail that arrives while the switch is OFF is
+    // CONSUMED (with an audit row), not queued for replay when it's switched back on.
+    // 'Off' means discard-with-audit, not pause. Pause-and-replay would need a
+    // cursor-level design in ticketMailboxPollWorker, not a gate here.
+    //
+    // Scope: this governs NEW ingestion only. Rows already in the review queue stay
+    // manually convertible after the switch goes off — the switch is not a retroactive
+    // queue purge.
+    //
+    // The policy is loaded ONCE here and threaded to the unknown-sender decision at
+    // the bottom, replacing what used to be two independent reads of the same row.
+    const policy = await loadPartnerInboundPolicy(partnerId);
+    if (!policy.enabled) {
+      await logInbound(n, partnerId, 'ignored', null, 'inbound disabled for partner');
+      return;
+    }
+
     // (R4) Sender authentication gate. The From header is spoofable and the per-partner
     // ticket token (T-YYYY-NNNN) is enumerable, so a token/thread match or a
     // known-portal-user match must NOT be trusted to append a PUBLIC comment, reopen a
@@ -249,7 +283,6 @@ export async function processInboundEmail(
       // queue, no autoresponse). This gate runs before any sender matching, so
       // the drop applies to ALL unverified senders — known or not (see
       // PartnerInboundPolicy.dropUnverifiedSenders).
-      const policy = await loadPartnerInboundPolicy(partnerId);
       if (policy.dropUnverifiedSenders) {
         await logInbound(n, partnerId, 'ignored', null, `drop: ${reason}`);
       } else {
@@ -316,8 +349,8 @@ export async function processInboundEmail(
     // (7) Unknown sender (no thread, no portal user, no mapped domain). The
     // partner's policy (settings.ticketing.inbound) decides the fate. No contact
     // is onboarded — the customer is unknown. Default-off: absent settings keep
-    // the Phase 4 quarantine behavior.
-    const policy = await loadPartnerInboundPolicy(partnerId);
+    // the Phase 4 quarantine behavior. (`policy` was loaded at the master-switch
+    // gate above.)
 
     // 'drop' — silently ignore: no ticket, no review-queue row, no autoresponse.
     // Distinct from quarantine so unmapped spam doesn't fill the review queue.

--- a/apps/api/src/services/inboundEmail/resolveOrg.ts
+++ b/apps/api/src/services/inboundEmail/resolveOrg.ts
@@ -87,6 +87,20 @@ export type UnknownSenderMode = 'quarantine' | 'triage' | 'drop';
 const UNKNOWN_SENDER_MODES: readonly UnknownSenderMode[] = ['quarantine', 'triage', 'drop'];
 
 export interface PartnerInboundPolicy {
+  /**
+   * The 'Enable email-to-ticket' master switch (settings.ticketing.inbound.enabled).
+   * When false, `processInboundEmail` terminates as 'ignored' before any ticket,
+   * review-queue row, or autoresponse is produced.
+   *
+   * Defaults to TRUE when absent, which is deliberately the opposite of the safe
+   * default used by every other field here: from the feature's introduction until
+   * this gate existed the flag was display-only, so ingestion has ALWAYS been on.
+   * Defaulting to false would silently stop ticketing for every partner that never
+   * touched the toggle. A stored `false` written before this gate shipped is not
+   * evidence of intent either — see the `2026-08-24-inbound-enabled-backfill.sql`
+   * migration, which repairs those rows for partners with observed inbound mail.
+   */
+  enabled: boolean;
   unknownSenderMode: UnknownSenderMode;
   defaultTriageOrgId: string | null;
   /**
@@ -101,7 +115,9 @@ export interface PartnerInboundPolicy {
 /**
  * Read the partner's inbound routing policy from partners.settings JSONB
  * (settings.ticketing.inbound). Absent fields read as the safe default
- * (quarantine; never drop). Back-compat: a partner that only has the legacy
+ * (quarantine; never drop) — with the deliberate exception of `enabled`, which
+ * defaults to true so an upgrade cannot silently stop ingestion (see the field
+ * docs on PartnerInboundPolicy). Back-compat: a partner that only has the legacy
  * `triageUnknownSenders` boolean (set before the 3-way mode existed) maps
  * true -> 'triage', false/absent -> 'quarantine'. The first save from the UI
  * replaces the inbound object wholesale, retiring the legacy key.
@@ -118,6 +134,7 @@ export async function loadPartnerInboundPolicy(
   const inbound =
     (((settings.ticketing as Record<string, unknown> | undefined)?.inbound) as
       | {
+          enabled?: boolean;
           defaultTriageOrgId?: string | null;
           triageUnknownSenders?: boolean;
           unknownSenderMode?: string;
@@ -134,6 +151,7 @@ export async function loadPartnerInboundPolicy(
       : 'quarantine';
 
   return {
+    enabled: inbound.enabled !== false,
     unknownSenderMode: mode,
     defaultTriageOrgId: inbound.defaultTriageOrgId ?? null,
     dropUnverifiedSenders: inbound.dropUnverifiedSenders === true,

--- a/apps/api/src/services/ticketConfigService.test.ts
+++ b/apps/api/src/services/ticketConfigService.test.ts
@@ -250,13 +250,21 @@ describe('getTicketConfig inbound block', () => {
     expect(cfg.inbound.address).toBe('support@tickets.acme.com');
     expect(cfg.inbound.addressOverride).toBe('support@tickets.acme.com');
   });
-  it('defaults enabled=false, autoresponderEnabled=true, addressOverride=null when config absent', async () => {
+  // #3597: `enabled` must read back with the SAME default the ingestion gate uses
+  // (loadPartnerInboundPolicy: absent → true), or the card renders an "off" toggle
+  // for a partner whose mail is still being ingested — the original bug.
+  it('defaults enabled=true, autoresponderEnabled=true, addressOverride=null when config absent', async () => {
     enqueueForInbound({ slug: 'acme', settings: {} });
     const cfg = await getTicketConfig('p-1');
-    expect(cfg.inbound.enabled).toBe(false);
+    expect(cfg.inbound.enabled).toBe(true);
     expect(cfg.inbound.autoresponderEnabled).toBe(true);
     expect(cfg.inbound.defaultTriageOrgId).toBeNull();
     expect(cfg.inbound.addressOverride).toBeNull();
+  });
+  it('surfaces an explicit enabled=false (the gate honors it)', async () => {
+    enqueueForInbound({ slug: 'acme', settings: { ticketing: { inbound: { enabled: false } } } });
+    const cfg = await getTicketConfig('p-1');
+    expect(cfg.inbound.enabled).toBe(false);
   });
   it('surfaces auto-reply subject/body from partner settings, defaulting to null', async () => {
     enqueueForInbound({ slug: 'acme', settings: { ticketing: { inbound: { autoresponseSubject: 'Hi {{ticket_number}}', autoresponseBody: 'Body' } } } });

--- a/apps/api/src/services/ticketConfigService.ts
+++ b/apps/api/src/services/ticketConfigService.ts
@@ -389,7 +389,11 @@ export async function getTicketConfig(partnerId: string) {
         : 'quarantine';
 
   const inbound = {
-    enabled: inboundCfg.enabled ?? false,
+    // Must use the SAME default as loadPartnerInboundPolicy (absent → true), or the
+    // card renders an "off" toggle for a partner whose mail is still being ingested —
+    // which is precisely the display-only bug #3597 fixed. Absent means "never
+    // configured", and ingestion has been on for those partners since day one.
+    enabled: inboundCfg.enabled !== false,
     address: addressOverride ?? derived,
     addressOverride,
     defaultTriageOrgId: inboundCfg.defaultTriageOrgId ?? null,

--- a/apps/docs/src/content/docs/features/ticketing.mdx
+++ b/apps/docs/src/content/docs/features/ticketing.mdx
@@ -137,6 +137,15 @@ Tickets enter the queue from four directions:
 
 Breeze can turn customer emails into tickets automatically, so your help desk works entirely over email like a full PSA. Configure it under **Settings → Ticketing → Inbound email**.
 
+### Turning it on and off
+
+**Enable email-to-ticket** on the Inbound email card is the master switch for the whole feature. With it off, mail addressed to your partner is discarded — no ticket, no review-queue entry, no autoresponse — and each discarded message is still recorded in the inbound log for audit. It applies to both delivery paths: the native inbound address and a connected Microsoft 365 shared mailbox.
+
+Two things to know:
+
+- Existing partners are **on** by default. The switch had no effect before v0.106.0, so ingestion has always been running; leaving it alone keeps today's behavior.
+- Switching it off **discards** mail rather than pausing it. Messages that arrive while it's off are not queued for replay when you switch it back on.
+
 ### Your inbound address
 
 Each partner gets an **inbound address** -- the email address customers send to. Copy it from the Inbound email card and share it with your customers (or forward your existing support mailbox to it). Mail sent to that address is converted into tickets.


### PR DESCRIPTION
Fixes #3597.

## The bug

`settings.ticketing.inbound.enabled` was persisted and rendered but **nothing in the ingestion path read it**. Mail was ticketed whether the toggle was on or off, autoresponders kept firing for partners who thought the feature was disabled, and there was no in-product way to stop ingestion short of tearing down the Mailgun route or disconnecting the mailbox.

## The gate

`PartnerInboundPolicy` gains `enabled`; `processInboundEmail` gates on it and terminates as `ignored` with `error='inbound disabled for partner'`.

Placement is deliberate:

| Relative to | Why |
|---|---|
| **after** the dedup SELECT | a provider retry short-circuits on the existing row instead of racing the `(partner_id, provider_message_id)` unique index and landing a spurious `failed` |
| **before** the sender-auth gate | otherwise disabled *unverified* mail still lands in quarantine |
| `ignored`, not `skipped`/`quarantined` | `skipped` is documented for non-active partners; `quarantined`/`failed` are the two `REVIEW_STATUSES`, and a partner who switched the feature off must not accumulate a review queue |

Autoresponses are suppressed for free — they only fire from `createFromEmail`, downstream of the gate. The M365 poll path lands in the same function (mailboxGeneration carries the partnerId), so it is covered by the same gate. The policy is now loaded **once** and threaded to the unknown-sender decision, replacing two independent reads of the same partner row.

## Back-compat — the part that could have broken every partner

The flag was display-only, so ingestion has *always* been on. Two traps:

1. **Absent `enabled`** now reads as `true` — in both `loadPartnerInboundPolicy` and `getTicketConfig`. Same default on both sides, or the card renders an "off" toggle for a partner whose mail is still being ingested (which is exactly the original bug). Gating naively on `?? false` would have stopped ingestion for every partner on upgrade.
2. **Stored `enabled: false` is not evidence of intent.** The card replaces `ticketing.inbound` wholesale on every save and always sent `enabled: next.enabled`, so any partner who ever changed an unrelated setting (triage org, autoresponder, unknown-sender mode) had `false` written for them while their mail kept flowing.

`2026-08-24-inbound-enabled-backfill.sql` therefore repairs an explicit `false` → `true` **only for partners with rows in `ticket_email_inbound`** (observed mail = evidence of reliance), and `RAISE WARNING`s the count. A `false` on a partner with no inbound mail is left alone — nothing can regress there, and if it was deliberate we honor it. The file carries a do-not-replay note: it is a one-shot repair, not a converger.

## Semantics, documented

- **Off discards, it does not pause.** The M365 poller still fetches, marks read, and advances its delta cursor, so mail arriving while the switch is off is consumed with an audit row and will not replay when switched back on.
- **The switch governs new ingestion only** — rows already in the review queue stay manually convertible.

Both are in the code comments and in a new "Turning it on and off" section in the ticketing docs.

## Verification

- 5 new gate cases in `inboundEmailService.test.ts` (ignored-not-quarantined + reason; beats a live thread match; suppresses the autoresponder; gates the M365 path; does not fire when enabled). All four negative cases **mutation-checked** — replacing the gate with a no-op fails exactly those 4 and nothing else.
- `enabled` coverage added to the `loadPartnerInboundPolicy` integration suite (absent → true, explicit false, explicit true), and the flipped `getTicketConfig` default plus an explicit-false case.
- The migration was replayed against a scratch Postgres over: explicit false + observed mail (repaired, sibling keys preserved), false without mail (untouched), absent flag (untouched), empty settings, `NULL` settings. Replay is a silent no-op.
- `tsc --noEmit` clean; 223 API unit tests green across the inbound/ticket-config surface.

## Release notes

Needs a call-out: the toggle now does something. Existing partners are unaffected (default-on + backfill), but a partner who had *deliberately* switched it off and kept receiving mail will find it now genuinely stops.

## Open question, deliberately not decided here

**Should NEW partners default to inbound off?** Today a new partner is effectively on the moment the platform inbound domain exists — `<slug>@<domain>` accepts mail immediately, which #3597 calls out as "a surprising default-on surface". Codex's read (advisor quorum) was that the clean steady state is: existing partners → explicit `true`, new partners → explicit `false`, loader default `false`. I kept this PR to bug-fix scope — flipping the default for new partners is a product decision, and it would silently discard mail for an operator who sets up a Mailgun route before finding the toggle. Worth a follow-up issue either way.

## Not fixed here

The terminal-status rows written *before* the dedup SELECT (partner-status `skipped`, self-loop `ignored`) have the retry-hits-unique-index → `failed` problem this PR sidesteps by sitting after the dedup. Pre-existing, out of scope, noted so it isn't lost.

## Siblings

#3598 and #3599 are the other two from this batch — both confusion-only, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)