### PR TITLE
docs: default PRs to `Closes #N`, reserve `Refs #N` for partial fixes

### DIFF
--- a/.claude/skills/gh-queue/SKILL.md
+++ b/.claude/skills/gh-queue/SKILL.md
@@ -150,7 +150,18 @@ gh api graphql -f query='mutation($id:ID!,$body:String!){addDiscussionComment(in
   gh api graphql -f query='mutation($id:ID!){closeDiscussion(input:{discussionId:$id,reason:RESOLVED}){discussion{number closed}}}' -f id="$DID"
   ```
   `reason: RESOLVED` for answered/shipped, `OUTDATED` for superseded. Leave open anything with genuine outstanding work even if I wrote "closing as resolved" earlier — verify the work actually shipped (e.g. a discussion whose prerequisite PR merged but whose feature PR never did → stays open).
-- **Issues:** defer to the `github-issues` skill. **NEVER close community issues yourself** — reporter verifies and closes, or owner closes after reporter confirms, or owner closes stale ones with a note. A commit/deploy is not a verification.
+- **Issues:** defer to the `github-issues` skill, which splits the rule by who filed it. **NEVER close community issues yourself** — reporter verifies and closes, or owner closes after reporter confirms, or owner closes stale ones with a note. A commit/deploy is not a verification. **Internally-filed issues are the opposite**: close them once their fix is merged, since no third party is waiting to verify.
+
+**Fixed-but-open sweep.** Because PRs historically used `Refs #N` rather than `Closes #N`, merged fixes do not close their issue. When the open count looks wrong, run the sweep rather than reading titles:
+
+```bash
+gh issue list --state open --limit 400 --json number --jq '.[].number' > /tmp/open.txt
+git log origin/main --since=<date> --pretty=format:'%H%x09%s%x0a%b%x00' > /tmp/log.txt
+# match each open number against every commit subject+body; a subject of the form
+# `fix(scope): summary (#ISSUE) (#PR)` is the repo's fully-fixed signature
+```
+
+Then read the commit **body** before closing, not the subject: several deliberately say "this is half of #N" or "leaving open for the reporter". Close only the ones with no such caveat, and comment with the fixing PR + SHA.
 
 ### 6. After every action
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,17 @@
 
 -
 
+## Linked Issues
+
+<!--
+Use `Closes #1234` when this PR fully resolves the issue — it closes on merge.
+Use `Refs #1234` ONLY if this fixes part of it, or a community reporter still has
+to verify; in that case say below which half shipped and which did not.
+`Closes #1 #2` only closes #1 — repeat the keyword: `Closes #1, closes #2`.
+-->
+
+Closes #
+
 ## Type of Change
 
 <!-- Check the one that applies: -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,7 +310,27 @@ docker compose -f docker-compose.yml -f docker-compose.override.yml.local-build 
 - If there is no issue number, use the same prefix with a concise slug, e.g. `fix/<short-slug>` or `feat/<short-slug>`.
 - Use `pr-####` or `pr-####-review` only when the branch is specifically for inspecting or reviewing an existing PR.
 - Keep branch slugs lowercase, kebab-case, and specific to the work. Avoid agent/tool/vendor prefixes such as `codex/`, `claude/`, or similar.
-- PR titles should follow the existing convention where useful: `fix(scope): summary`, `feat(scope): summary`, `docs(scope): summary`, or `chore(scope): summary`. Include issue references such as `(#1234)`, `refs #1234`, or `closes #1234` when the work is tied to an issue.
+- PR titles should follow the existing convention where useful: `fix(scope): summary`, `feat(scope): summary`, `docs(scope): summary`, or `chore(scope): summary`. Include the issue number as `(#1234)` when the work is tied to an issue.
+
+### Linking Issues from a PR
+
+The PR **body** decides whether the issue survives the merge. Pick deliberately —
+this is not a stylistic choice.
+
+- **`Closes #1234`** — the PR fully resolves the issue. Use this by default. The
+  issue closes automatically on merge and leaves the backlog.
+- **`Refs #1234`** — the PR resolves only part of the issue, or the issue is a
+  community report whose reporter still has to verify on their own hardware. When
+  you use `Refs`, **state in the PR body which half shipped and which did not** —
+  a bare `Refs` with no scope note is how a fixed issue becomes permanent backlog.
+
+`Refs` was the de-facto default for a long time and it does not close anything, so
+~15 fully-fixed issues sat open for weeks (#2728, #2814, #2894, #2895, #2896, #2913,
+#2950, #2974, #2997, #2999, #3000, #3006, #3201 among them). Default to `Closes`;
+reach for `Refs` only when one of the two reasons above actually applies.
+
+Mechanics: `Closes #X #Y` auto-closes **only** `#X`. Repeat the keyword per issue —
+`Closes #X, closes #Y`.
 
 ### Production Deploy
 


### PR DESCRIPTION
## Summary

- The de-facto convention was `Refs #N` on every PR, which closes nothing — so the issue backlog only ever grew (271 open on 2026-08-16, 15 of them fully fixed and merely un-closed).
- Documents the rule in the three places it's actually read: `AGENTS.md`, the PR template, and the `gh-queue` skill.
- `Refs` is right for exactly two cases — a partial fix, and a community report whose reporter still has to verify. It was the default for everything.

## Context

Fully fixed but left open: #2728, #2814, #2894, #2895, #2896, #2913, #2950, #2974, #2997, #2999, #3000, #3006, #3033, #3201, #3521 — now closed. #2895 and #2896 each carried a comment reading "verified on main, leaving this open for you to close", and then sat for six days.

The upstream cause was the user-global `github-issues` skill, whose blanket **"NEVER close issues yourself"** rule is correct for community reports but was being applied to internally-filed issues too. That skill lives outside this repo and has been updated separately to split the rule by who filed the issue.

## Changes

- **`AGENTS.md`** — new "Linking Issues from a PR" section: `Closes #N` by default; `Refs #N` only for a partial fix or a pending community verification, and then the PR body must say which half shipped. Also records that `Closes #X #Y` auto-closes only `#X`.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — a "Linked Issues" section prefilled with `Closes #`, making the closing form the path of least resistance.
- **`.claude/skills/gh-queue/SKILL.md`** — internal vs community closure split, plus the fixed-but-open sweep: match open issue numbers against merged commit subjects, then read the commit *body*, since several deliberately say "this is half of #N".

## Type of Change

- [x] Documentation

## Testing

- [x] Existing tests pass — docs/template only, no code paths touched. `check-migration-naming` pre-commit hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)