### PR TITLE
docs(gh-queue): triage by label view, not by the raw open-issue count

### DIFF
--- a/.claude/skills/gh-queue/SKILL.md
+++ b/.claude/skills/gh-queue/SKILL.md
@@ -62,6 +62,20 @@ gh issue list --repo LanternOps/breeze --state open --limit 50 \
 
 Cross-check against `queue.md`. Add anything new, mark anything closed/merged, flag drift.
 
+**Never quote the bare open-issue count as a backlog number.** As of 2026-08-16 the 248 open issues are ~112 `enhancement` (roadmap you filed for yourself) against ~136 defects; the total moves with how fast you file features, not with how fast you fix bugs. Every open issue now carries a label, so use the views rather than the total:
+
+```bash
+# The defect list — the number that should actually trend down
+gh issue list --repo LanternOps/breeze --state open --limit 200 \
+  --label bug --label tech-debt --label ci-red    # OR-semantics: any of these
+# Roadmap — feature work; triage it, don't count it as debt
+gh issue list --repo LanternOps/breeze --state open --limit 200 --label enhancement
+# Waiting on someone else — sweep for stale ones each round
+gh issue list --repo LanternOps/breeze --state open --label pending-author --label needs-info
+```
+
+An unlabeled issue is invisible to all three, so **label on sight** — that's what let 69 issues escape triage entirely before 2026-08-16.
+
 **The universal staleness trap — "I responded but the queue memory is stale" applies to ALL THREE types.** For every open item, compare the *last-activity author + date* against my last engagement. If someone else spoke after me with a date past my last action, **I'm the blocker** — read the full thread before deciding what's open. This is the single most common failure mode and it is type-agnostic:
 
 - **PRs:** `reviewDecision` resets from `CHANGES_REQUESTED` → `REVIEW_REQUIRED` whenever new commits land, so a PR you bounced that's since been fixed looks identical to one the author hasn't touched. For every "REQUEST CHANGES posted" PR, verify `commits.last.committedDate` vs the bounce date:


### PR DESCRIPTION
## Summary

- The open-issue total was being read as a backlog number. It isn't one: ~112 of 248 open issues are `enhancement` (roadmap filed by the maintainer) against ~136 defects, so the total tracks feature-filing rate rather than fix rate.
- Adds the three views the triage round should use — defects, roadmap, waiting-on-someone-else — plus a label-on-sight rule.

## Context

Follow-up to #3618. Two sweeps this session:

1. **15 fixed-but-open issues closed** — every PR used `Refs #N` instead of `Closes #N`, so nothing auto-closed. #3618 fixed the convention.
2. **10 stale community reports closed** — all had a "this shipped in vX, please confirm" follow-up dated 2026-07-16 with no reply in 31 days, against fixes that landed in v0.82–v0.95 (current is v0.105.1).

Then the remaining count still looked wrong, which is what this PR addresses: **69 open issues carried no label at all**, so they matched none of the triage views and were effectively invisible. All 69 are now classified (38 `bug`, 12 `enhancement`, 15 `tech-debt`, 3 `ci-red`, 1 `documentation`), and open issues are at 100% label coverage.

Note: converting the community feature requests to Discussions was considered and rejected — GitHub exposes no `convertIssueToDiscussion` mutation (UI-only, per-issue), and conversion would drop the issue numbers other issues cross-reference. Labels do the same job without breaking links.

## Type of Change

- [x] Documentation

## Testing

- [x] Existing tests pass — skill doc only, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)