### PR TITLE
fix(i18n): unbreak main — tr-TR parity gaps and a short duplicate baseline

### DIFF
--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -320,7 +320,12 @@ const namespaceDuplicateBaselines = {
     'alerts.json': 25,
     'auth.json': 14,
     'backup.json': 25,
-    'billing.json': 16,
+    // +2: the quote/invoice bulk-result strings ("{{succeeded}} {{verb}}") are
+    // pure interpolation with no prose to translate, so they are necessarily
+    // identical to English. They arrived from #3501 after tr-TR (#3497) forked,
+    // which is why the PR was green on its base and this baseline was short by
+    // two on main.
+    'billing.json': 18,
     'common.json': 48,
     'devices.json': 77,
     'discovery.json': 9,

--- a/apps/web/src/locales/tr-TR/alerts.json
+++ b/apps/web/src/locales/tr-TR/alerts.json
@@ -545,7 +545,12 @@
     },
     "bulkConfirmQuestion": "{{action}} {{count}} uyarısı?",
     "bulkConfirmQuestion_one": "{{action}} {{count}} uyarısı?",
-    "bulkConfirmQuestion_other": "{{action}} {{count}} uyarıları var mı?"
+    "bulkConfirmQuestion_other": "{{action}} {{count}} uyarıları var mı?",
+    "noDevicesTitle": "Henüz rapor veren cihaz yok",
+    "noDevicesInstallAgentToSeeAlerts": "Burada uyarıları görmeye başlamak için ilk cihazınıza aracıyı yükleyin.",
+    "installYourFirstDevice": "İlk cihazınızı yükleyin",
+    "noActiveAlerts": "Etkin uyarı yok",
+    "deviceStatusUnavailable": "Cihaz durumunuz yüklenemedi. Yeniden denemek için sayfayı yenileyin."
   },
   "alertsSummary": {
     "activeAlerts": "Aktif Uyarılar",

--- a/apps/web/src/locales/tr-TR/policies.json
+++ b/apps/web/src/locales/tr-TR/policies.json
@@ -1211,7 +1211,19 @@
       "uploading": "Yükleniyor…",
       "creating": "Oluşturuluyor…",
       "retryAddingVersion": "Sürüm eklemeyi yeniden deneyin",
-      "createPackage": "Paket oluştur"
+      "createPackage": "Paket oluştur",
+      "installerType": "Yükleyici türü",
+      "autoDetectFromUrl": "URL'den otomatik algıla",
+      "autoDetectedType": "Otomatik algıla ({{type}})",
+      "installerTypeUndetected": "Bu URL'de tanınabilir bir yükleyici uzantısı yok. Türü açıkça seçin — aksi takdirde indirilen dosya doğrudan çalıştırılır ve bu bir MSI için başarısız olur.",
+      "uploadsRequireS3Storage": "Dosya yüklemeleri için sunucuda S3 nesne depolamasının yapılandırılmış olması gerekir.",
+      "scope": "Kapsam",
+      "allOrganizations": "Tüm organizasyonlar",
+      "sharedAcrossAllYourOrganizations": "— tüm organizasyonlarınız arasında paylaşılır",
+      "thisOrganizationOnly": "Yalnızca bu organizasyon",
+      "partnerWideUrlOnly": "İş ortağı genelindeki paketler bir indirme URL’si kullanır — bunlar için dosya yükleme henüz kullanılamıyor.",
+      "selectedFileRemoved": "Seçilen dosya kaldırıldı — iş ortağı genelindeki paketler bir indirme URL’si kullanır.",
+      "scopeLockedAfterCreate": "Paket zaten bu kapsamla oluşturuldu — oluşturulduktan sonra sahiplik değiştirilemez."
     },
     "builtinPackageDetail": {
       "managedBuiltIn": "Yönetilen yerleşik",
@@ -1431,7 +1443,11 @@
       "deviceCount_other": "{{count}} cihazlar",
       "groupCount_one": "{{count}} grubu",
       "groupCount_other": "{{count}} grup",
-      "viewDeployment": "Dağıtımı görüntüle"
+      "viewDeployment": "Dağıtımı görüntüle",
+      "deployingTo": "Şuraya dağıtılıyor",
+      "customer": "Müşteri",
+      "allTargetsBelongToThisCustomer": "Seçilen tüm hedefler bu müşteriye aittir.",
+      "allOrgsSelectCustomer": "Tüm organizasyonları görüntülüyorsunuz. Bu dağıtımı hedeflemek için organizasyon değiştiriciden bir müşteri seçin."
     },
     "detectionRulesEditor": {
       "detectionRules": "Algılama Kuralları",
@@ -1706,7 +1722,16 @@
       "saving": "Kaydediliyor...",
       "uploadSave": "Yükle ve Kaydet",
       "saveVersion": "Sürümü Kaydet",
-      "setAsLatest": "En yeni olarak ayarla"
+      "setAsLatest": "En yeni olarak ayarla",
+      "installerType": "Yükleyici türü",
+      "autoDetectFromUrl": "URL'den otomatik algıla",
+      "autoDetectedType": "Otomatik algıla ({{type}})",
+      "installerTypeUndetected": "Bu URL'de tanınabilir bir yükleyici uzantısı yok. Türü açıkça seçin — aksi takdirde indirilen dosya doğrudan çalıştırılır ve bu bir MSI için başarısız olur.",
+      "advancedOptions": "Gelişmiş seçenekler",
+      "uploadsRequireS3Storage": "Dosya yüklemeleri için sunucuda S3 nesne depolamasının yapılandırılmış olması gerekir.",
+      "editingVersion": "Sürüm düzenleniyor",
+      "failedToUpdateVersion": "Sürüm güncellenemedi",
+      "replaceFileAddNewVersion": "Yükleyici dosyasını değiştirmek için bunun yerine yeni bir sürüm ekleyin."
     },
     "variableInput": {
       "insertADeployTimeVariable": "Dağıtım zamanı değişkeni ekleyin",

--- a/apps/web/src/locales/tr-TR/scripts.json
+++ b/apps/web/src/locales/tr-TR/scripts.json
@@ -1241,5 +1241,37 @@
     "scriptCount": "{{count}} komut dosyaları pakette",
     "statusInvalid": "Geçersiz",
     "exportLimit": "Paket başına en fazla {{max}} komut dosyasını dışa aktarabilirsiniz."
+  },
+  "testRunner": {
+    "title": "Test çalıştırması",
+    "devicePlaceholder": "Bir test cihazı seçin…",
+    "noDevices": "Uyumlu cihaz yok",
+    "deviceStatus": {
+      "offline": "çevrimdışı",
+      "maintenance": "bakımda"
+    },
+    "run": "Test Çalıştır",
+    "saveAndRun": "Kaydet ve Test Çalıştır",
+    "saveFirst": "Test çalıştırmalarını etkinleştirmek için betiği bir kez kaydedin.",
+    "requiredParams": "Varsayılanı olmayan zorunlu parametreler ({{params}}) — bunun yerine Betik Çalıştır iletişim kutusunu kullanın.",
+    "offlineWarning": "Seçilen cihaz çevrimdışı — çalıştırma, cihaz yeniden bağlanana kadar bekleyecek.",
+    "exitCode": "çıkış {{code}}",
+    "viewHistory": "Geçmişi görüntüle",
+    "status": {
+      "pending": "Kuyrukta",
+      "running": "Çalışıyor",
+      "completed": "Tamamlandı",
+      "failed": "Başarısız",
+      "timeout": "Zaman aşımına uğradı",
+      "queued": "Kuyrukta",
+      "cancelled": "İptal edildi"
+    },
+    "errors": {
+      "execute": "Test çalıştırması başlatılamadı",
+      "save": "Kaydetme başarısız — yukarıdaki hataları düzeltip yeniden deneyin.",
+      "notStarted": "Çalıştırma başlatılmadı (cihaz bakımda olabilir).",
+      "pollDeadline": "Hâlâ sonuç yok — sonucu görmek için çalıştırma geçmişini kontrol edin.",
+      "pollFailed": "Çalıştırma sonucu okunamadı — silinmiş olabilir veya erişiminiz değişmiş olabilir."
+    }
   }
 }


### PR DESCRIPTION
**Main is red on `Test Web` and has been since #3497 merged.** Two independent stale-base effects, neither of which its own CI could have caught.

**Locale parity — 54 missing tr-TR keys.** Keys landed on `en` after the tr-TR branch forked: the Alerts empty-state cluster (#3536), the script test-runner (#3605), and the software installer-type / scope strings (#3575). `localeParity.test.ts` enumerates the locales directory dynamically, so tr-TR started being checked the moment it existed — against an `en` that had since moved. All 54 translated here, following the conventions already in the catalog (`Dağıtım` for deploy, `Sürüm` for version, `Kapsam` for scope, `Yükleyici` for installer).

**Duplicate baseline — off by two.** `billing.json` carries 18 exact-English duplicates against a recorded baseline of 16. The two extra are `quotes.page.bulk.success` and `invoicesPage.bulk.success`, both `"{{succeeded}} {{verb}}"` — pure interpolation with no prose to translate, so identical to English by necessity rather than by omission. They came from #3501, which merged after tr-TR forked. Baseline raised to 18 with the reasoning inline, matching the file's existing `+N: reason` convention.

**Why the PR was green.** `#3497`'s last commit was 2026-08-15 and it was merged 2026-08-16 against a base that had moved underneath it. This is the documented stale-base trap in CLAUDE.md — a green PR reddening main — and it's worth noting the irony that the parity gap I bounced #3497 for is the same mechanism that bit it again on a different set of keys.

## Verification

`localeParity`, `translationCoverage`, `terminologyQuality`, `extractionQuality` and `keyUsage` all pass locally — 81 tests across 5 files. All 8 locales are at exact key parity with `en`, zero missing and zero extra.

Fixes the `Test Web` failure on main at `7d4f1026`.