### PR TITLE
fix(gh-queue): defect-view query returned zero — repeated --label is AND

### DIFF
--- a/.claude/skills/gh-queue/SKILL.md
+++ b/.claude/skills/gh-queue/SKILL.md
@@ -67,14 +67,16 @@ Cross-check against `queue.md`. Add anything new, mark anything closed/merged, f
 ```bash
 # The defect list — the number that should actually trend down
 gh issue list --repo LanternOps/breeze --state open --limit 200 \
-  --label bug --label tech-debt --label ci-red    # OR-semantics: any of these
+  --search 'label:bug,tech-debt,ci-red'
 # Roadmap — feature work; triage it, don't count it as debt
 gh issue list --repo LanternOps/breeze --state open --limit 200 --label enhancement
 # Waiting on someone else — sweep for stale ones each round
-gh issue list --repo LanternOps/breeze --state open --label pending-author --label needs-info
+gh issue list --repo LanternOps/breeze --state open --search 'label:pending-author,needs-info'
 ```
 
 An unlabeled issue is invisible to all three, so **label on sight** — that's what let 69 issues escape triage entirely before 2026-08-16.
+
+**Repeated `--label` is AND, not OR.** `--label bug --label tech-debt` returns only issues carrying *both*, which for these labels is zero — a silently empty result that reads exactly like "no defects." Use `--search 'label:a,b,c'` (comma = OR) whenever you want any-of semantics, and sanity-check the count against `--state open` before believing a small number.
 
 **The universal staleness trap — "I responded but the queue memory is stale" applies to ALL THREE types.** For every open item, compare the *last-activity author + date* against my last engagement. If someone else spoke after me with a date past my last action, **I'm the blocker** — read the full thread before deciding what's open. This is the single most common failure mode and it is type-agnostic:
 


### PR DESCRIPTION
## Summary

- The defect view added in #3619 used `--label bug --label tech-debt --label ci-red` with a comment claiming OR semantics. Repeated `--label` is **AND** — it matches only issues carrying all three, of which there are none.
- Verified live: flag form returns **0**, `--search 'label:bug,tech-debt,ci-red'` returns **134**.
- Fixes both affected views and records the trap.

## Why this matters

An empty result reads as "no defects to triage" rather than as a broken query, so the doc would have quietly suppressed the entire defect list on every future triage round — the opposite of what #3619 set out to do.

## Type of Change

- [x] Bug fix

## Testing

- [x] Both queries run against the live repo; counts cross-checked against a local set-intersection over `gh issue list --json labels` (134 defects, 112 enhancement, 248 open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)