### PR TITLE
fix(i18n): translate the "/ea" unit in tr-TR and es-419 quote pricing

### DIFF
--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -80,7 +80,9 @@ const namespaceDuplicateBaselines = {
     // +1: order breakdown — "SKU" is a locale-invariant acronym.
     // +1: partnerBillingSettings.defaults.documentPageSizeA4 — "A4" is the
     // ISO 216 paper size code, identical in every catalog.
-    'billing.json': 41,
+    // 41 -> 40: `contracts.contractPax8Drawer.priceEach` is no longer a
+    // duplicate; its "/ea" was genuinely untranslated, not a literal.
+    'billing.json': 40,
     // +1: dashboard.vuln.kevCves_one — "{{count}} CVE" is a locale-invariant
     // acronym.
     // +8: PsaConnectionForm credential placeholders — literal token formats
@@ -320,12 +322,13 @@ const namespaceDuplicateBaselines = {
     'alerts.json': 25,
     'auth.json': 14,
     'backup.json': 25,
-    // +2: the quote/invoice bulk-result strings ("{{succeeded}} {{verb}}") are
+    // +1: the quote/invoice bulk-result strings ("{{succeeded}} {{verb}}") are
     // pure interpolation with no prose to translate, so they are necessarily
     // identical to English. They arrived from #3501 after tr-TR (#3497) forked,
-    // which is why the PR was green on its base and this baseline was short by
-    // two on main.
-    'billing.json': 18,
+    // which is why the PR was green on its base and this baseline was short on
+    // main. 18 -> 17 because `contracts.contractPax8Drawer.priceEach` is no
+    // longer a duplicate: it was genuinely untranslated, not a literal.
+    'billing.json': 17,
     'common.json': 48,
     'devices.json': 77,
     'discovery.json': 9,

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -304,7 +304,7 @@
       "empty": "Aún no se han sincronizado suscripciones a Pax8 para esta organización. Sincronízalos en Integraciones → Pax8.",
       "subscriptionFallback": "Suscripción Pax8",
       "quantity": "cantidad {{quantity}}",
-      "priceEach": "{{currency}} {{price}}/ea",
+      "priceEach": "{{currency}} {{price}}/u.",
       "alreadyLinked": "ya vinculado",
       "relink": "Volver a vincular",
       "link": "Enlace",

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -304,7 +304,7 @@
       "empty": "Bu kuruluş için henüz hiçbir Pax8 aboneliği senkronize edilmedi. Bunları Entegrasyonlar → Pax8 altında senkronize edin.",
       "subscriptionFallback": "Pax8 aboneliği",
       "quantity": "adet {{quantity}}",
-      "priceEach": "{{currency}} {{price}}/ea",
+      "priceEach": "{{currency}} {{price}}/adet",
       "alreadyLinked": "zaten bağlı",
       "relink": "Yeniden bağlantı oluştur",
       "link": "Bağlantı",


### PR DESCRIPTION
`contracts.contractPax8Drawer.priceEach` renders a per-unit price as `{{currency}} {{price}}/ea`. `/ea` is an English abbreviation for "each" — not a symbol, not an interpolation-only token — and two catalogs still ship it verbatim.

The other five locales all localize it, which is what makes this a gap rather than a house style:

| locale | value |
|---|---|
| fr-FR | `{{currency}} {{price}}/unité` |
| fr-CA | `{{currency}} {{price}}/unité` |
| de-DE | `{{currency}} {{price}}/Stück` |
| pt-BR | `{{currency}} {{price}}/un.` |
| it-IT | `{{currency}} {{price}}/cad` |
| **tr-TR** | **`{{currency}} {{price}}/ea`** |
| **es-419** | **`{{currency}} {{price}}/ea`** |

Now `/adet` (tr-TR) and `/u.` (es-419), the latter matching pt-BR's `/un.` abbreviation style.

### Why this also tightens the duplicate guard

Both were being counted as accepted exact-English duplicates, so the baseline was treating a real untranslated string as an approved literal. #3620 raised the tr-TR `billing.json` baseline to 18 on the reading that all 18 were intentional; this one was not. The baselines drop rather than rise:

- tr-TR `billing.json` 18 → 17
- es-419 `billing.json` 41 → 40

I went through all 18 tr-TR duplicates individually before concluding this was the only genuine miss. The rest are symbols (`✓`, `%`, `—`), interpolation-only format strings (`{{qty}} × {{price}}`, `{{succeeded}} {{verb}}`, `v{{number}}`), an example URL, and the cross-locale literals `MSRP`, `SKU`, `A4`, `Letter`, `PN`.

`PN` is the one I deliberately left alone: it is byte-identical in every locale including fr/de/pt/es/it, which reads as a deliberate cross-locale abbreviation rather than an omission. Happy to change it if the glossary says otherwise, but it did not look like the same class of defect as `/ea`.

Interpolation placeholders are untouched, so `localeParity`'s token check is unaffected.

### Verification

Local, node 22.23.2 (CI `.nvmrc`), pnpm 10.34.5:

- `apps/web` `src/lib/i18n/` — **105/105 pass** (localeParity, translationCoverage, terminologyQuality, extractionQuality, keyUsage)

Refs #3620, #3497
