### PR TITLE
fix(api): prune remediation authorization rows and close the #3585 follow-ups

### DIFF
--- a/apps/api/src/__tests__/integration/softwareRemediationRequestsRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/softwareRemediationRequestsRls.integration.test.ts
@@ -16,6 +16,7 @@ import { and, eq } from 'drizzle-orm';
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
 import { devices, softwarePolicies, softwareRemediationRequests } from '../../db/schema';
 import { consumeManualRemediationAuthorization } from '../../jobs/softwareRemediationWorker';
+import { pruneExpiredRemediationRequests } from '../../jobs/softwareRemediationRequestCleanup';
 import { createOrganization, createPartner, createSite } from './db-utils';
 
 const createdRequests: string[] = [];
@@ -62,12 +63,12 @@ async function seedOrgPolicy(orgId: string): Promise<string> {
   return row!.id;
 }
 
-async function seedRequest(fields: { orgId: string | null; partnerId: string | null; policyId: string; deviceId: string; consumed?: boolean }): Promise<string> {
+async function seedRequest(fields: { orgId: string | null; partnerId: string | null; policyId: string; deviceId: string; consumed?: boolean; expiresAt?: Date }): Promise<string> {
   const [row] = await withDbAccessContext(SYSTEM_CTX, () =>
     db.insert(softwareRemediationRequests).values({
       orgId: fields.orgId, partnerId: fields.partnerId, policyId: fields.policyId, deviceId: fields.deviceId,
       requestedByUserId: null,
-      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      expiresAt: fields.expiresAt ?? new Date(Date.now() + 60 * 60 * 1000),
       consumedAt: fields.consumed ? new Date() : null,
     }).returning({ id: softwareRemediationRequests.id }),
   );
@@ -146,6 +147,37 @@ describe('software_remediation_requests — RLS + device-move + consume (#3553)'
     expect(second.authorized).toBe(false); // already consumed
   });
 
+  // #3614 follow-up 4: the sequential case above proves single-use only AFTER
+  // the first consume has committed. The property that actually matters is that
+  // two consumes racing on the SAME row cannot both win. That holds because the
+  // consume is one atomic `UPDATE ... WHERE consumed_at IS NULL ... RETURNING`,
+  // so the second UPDATE blocks on the first's row lock and then matches zero
+  // rows. Pinning it here means a future refactor to read-then-write — which
+  // would still pass the sequential test — fails instead.
+  it('concurrent consumes of the same request: exactly one wins', async () => {
+    const partnerA = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const siteA = await createSite({ orgId: orgA.id });
+    const deviceD = await seedDevice(orgA.id, siteA.id);
+    const policyP = await seedOrgPolicy(orgA.id);
+    const requestId = await seedRequest({ orgId: orgA.id, partnerId: null, policyId: policyP, deviceId: deviceD });
+
+    // Started together, not awaited in sequence: both are in flight before
+    // either resolves.
+    const [a, b] = await Promise.all([
+      withDbAccessContext(SYSTEM_CTX, () =>
+        consumeManualRemediationAuthorization({ manualRequestId: requestId, policyId: policyP, deviceId: deviceD }),
+      ),
+      withDbAccessContext(SYSTEM_CTX, () =>
+        consumeManualRemediationAuthorization({ manualRequestId: requestId, policyId: policyP, deviceId: deviceD }),
+      ),
+    ]);
+
+    // Exactly one authorized — never both (double uninstall dispatch), never
+    // neither (a burned token that queued nothing).
+    expect([a.authorized, b.authorized].filter(Boolean)).toHaveLength(1);
+  });
+
   // #3553 finding 4: prove the PARTNER axis of the dual RLS + consume, not just
   // the org axis. A partner-wide policy's request is visible to its partner and
   // NOT to another partner, and consumes while the device stays under the partner.
@@ -183,4 +215,57 @@ describe('software_remediation_requests — RLS + device-move + consume (#3553)'
     expect(visibleToB).toHaveLength(0);
     expect(consumed.authorized).toBe(true); // device still under partner A
   });
+
+  // #3614 review: the unit suite asserts query SHAPE, which cannot express this.
+  // Todd demonstrated the gap by inverting `lt` -> `gt` on the cutoff — turning
+  // the sweep into one that deletes every UNEXPIRED authorization — and the unit
+  // tests still passed 6/6. The failure mode is a row count, so it is checked
+  // here against real Postgres.
+  it('prune deletes only rows past the retention grace, across orgs, and spares live ones', async () => {
+    const partnerA = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const orgB = await createOrganization({ partnerId: partnerA.id });
+    const siteA = await createSite({ orgId: orgA.id });
+    const siteB = await createSite({ orgId: orgB.id });
+    const deviceA = await seedDevice(orgA.id, siteA.id);
+    const deviceB = await seedDevice(orgB.id, siteB.id);
+    const policyA = await seedOrgPolicy(orgA.id);
+    const policyB = await seedOrgPolicy(orgB.id);
+
+    const HOUR = 60 * 60 * 1000;
+    // Live: expires in an hour. Must survive.
+    const live = await seedRequest({
+      orgId: orgA.id, partnerId: null, policyId: policyA, deviceId: deviceA,
+      expiresAt: new Date(Date.now() + HOUR),
+    });
+    // Expired 1h ago — past expiry but INSIDE the 72h grace. Must survive.
+    const recentlyExpired = await seedRequest({
+      orgId: orgA.id, partnerId: null, policyId: policyA, deviceId: deviceA,
+      expiresAt: new Date(Date.now() - HOUR),
+    });
+    // Expired 100h ago, in a DIFFERENT org — past the grace. Must be deleted,
+    // and the sweep must not be org-scoped.
+    const longExpired = await seedRequest({
+      orgId: orgB.id, partnerId: null, policyId: policyB, deviceId: deviceB,
+      expiresAt: new Date(Date.now() - 100 * HOUR),
+    });
+
+    // Called with NO ambient context on purpose: the prune establishes its own
+    // system context per batch, so it must sweep the whole table unaided.
+    const result = await pruneExpiredRemediationRequests();
+    expect(result.deletedCount).toBeGreaterThanOrEqual(1);
+
+    const survivors = await withDbAccessContext(SYSTEM_CTX, async () => {
+      const rows = await db
+        .select({ id: softwareRemediationRequests.id })
+        .from(softwareRemediationRequests);
+      return new Set(rows.map((r) => r.id));
+    });
+
+    // An inverted comparison would invert exactly these three assertions.
+    expect(survivors.has(live)).toBe(true);
+    expect(survivors.has(recentlyExpired)).toBe(true);
+    expect(survivors.has(longExpired)).toBe(false);
+  });
+
 });

--- a/apps/api/src/db/schema/softwarePolicies.ts
+++ b/apps/api/src/db/schema/softwarePolicies.ts
@@ -11,6 +11,7 @@ import {
   index,
   uniqueIndex,
 } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 import { organizations, partners } from './orgs';
 import { users } from './users';
 import { devices } from './devices';
@@ -168,4 +169,13 @@ export const softwareRemediationRequests = pgTable('software_remediation_request
   partnerIdIdx: index('software_remediation_requests_partner_id_idx').on(table.partnerId),
   policyIdIdx: index('software_remediation_requests_policy_id_idx').on(table.policyId),
   deviceIdIdx: index('software_remediation_requests_device_id_idx').on(table.deviceId),
+  // Partial index, mirroring the migration so this schema describes what the
+  // database actually has. It serves the CONSUME path, which looks a row up by
+  // id while filtering `consumed_at IS NULL AND expires_at > now()`.
+  // Deliberately NOT claimed for the retention sweep: that scans by expires_at
+  // across consumed and unconsumed rows alike, so this partial index cannot
+  // cover it.
+  expiryIdx: index('software_remediation_requests_expiry_idx')
+    .on(table.expiresAt)
+    .where(sql`consumed_at IS NULL`),
 }));

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -237,6 +237,10 @@ import {
   initializeSoftwareUploadSessionCleanupWorker,
   shutdownSoftwareUploadSessionCleanupWorker,
 } from './jobs/softwareUploadSessionCleanup';
+import {
+  initializeSoftwareRemediationRequestCleanupWorker,
+  shutdownSoftwareRemediationRequestCleanupWorker,
+} from './jobs/softwareRemediationRequestCleanup';
 import { initializeAuditRetentionWorker, shutdownAuditRetentionWorker } from './jobs/auditRetention';
 import {
   initializeAuditChainVerifyWorker,
@@ -1429,6 +1433,7 @@ async function initializeWorkers(): Promise<void> {
     // hard cap, detects end-user disconnects, and purges ephemeral devices.
     ['quickSupportReaper', initializeQuickSupportReaper],
     ['softwareUploadSessionCleanup', initializeSoftwareUploadSessionCleanupWorker],
+    ['softwareRemediationRequestCleanup', initializeSoftwareRemediationRequestCleanupWorker],
     ['auditRetention', initializeAuditRetentionWorker],
     ['auditChainVerify', initializeAuditChainVerifyWorker],
     ['auditChainAnchor', initializeAuditChainAnchorWorker],
@@ -1655,6 +1660,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownEnrollmentKeyCleanupWorker,
     shutdownQuickSupportReaper,
     shutdownSoftwareUploadSessionCleanupWorker,
+    shutdownSoftwareRemediationRequestCleanupWorker,
     shutdownAuditRetentionWorker,
     shutdownAuditChainVerifyWorker,
     shutdownAuditChainAnchorWorker,

--- a/apps/api/src/jobs/softwareRemediationRequestCleanup.test.ts
+++ b/apps/api/src/jobs/softwareRemediationRequestCleanup.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// #3614 follow-up 1: #3585 minted up to 500 authorization rows per Remediate
+// click and nothing ever pruned them.
+const selectMock = vi.fn();
+const deleteMock = vi.fn();
+
+vi.mock('../db', () => ({
+  db: {
+    select: (...a: unknown[]) => selectMock(...(a as [])),
+    delete: (...a: unknown[]) => deleteMock(...(a as [])),
+  },
+  withSystemDbAccessContext: vi.fn(async (fn: () => unknown) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+}));
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('bullmq', () => ({ Queue: vi.fn(), Worker: vi.fn(), Job: vi.fn() }));
+
+import { pruneExpiredRemediationRequests, __testOnly } from './softwareRemediationRequestCleanup';
+
+// The mocks capture the predicate so the DELETE can be shown to re-apply the
+// cutoff rather than trusting the id list alone.
+//
+// SCOPE, stated honestly because the previous version of this comment overclaimed:
+// `columnsIn` returns column NAMES only. It cannot see the operator or the bound
+// value, so it does NOT catch an inverted comparison (`lt` -> `gt`), which is the
+// mutation that would delete every UNEXPIRED authorization. That case is covered
+// against a real database in
+// __tests__/integration/softwareRemediationRequestsRls.integration.test.ts —
+// a query-shape assertion cannot express it, because the failure is a row count.
+const capturedSelectWhere: unknown[] = [];
+const capturedDeleteWhere: unknown[] = [];
+
+/** select().from().where().limit() -> rows */
+function selectChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn((pred: unknown) => {
+        capturedSelectWhere.push(pred);
+        return { limit: vi.fn().mockResolvedValue(rows) };
+      }),
+    }),
+  };
+}
+/** delete().where().returning() -> rows */
+function deleteChain(rows: unknown[]) {
+  return {
+    where: vi.fn((pred: unknown) => {
+      capturedDeleteWhere.push(pred);
+      return { returning: vi.fn().mockResolvedValue(rows) };
+    }),
+  };
+}
+
+/** Walk a Drizzle SQL predicate's queryChunks and collect the column names it
+ *  references. Enough to assert WHICH column was filtered on without a live
+ *  database, and it cannot be satisfied by a predicate on the wrong column. */
+function columnsIn(pred: unknown, seen = new Set<unknown>()): string[] {
+  if (!pred || typeof pred !== 'object' || seen.has(pred)) return [];
+  seen.add(pred);
+  const node = pred as Record<string, unknown>;
+  // A Drizzle Column carries its SQL name and its owning table.
+  if (typeof node.name === 'string' && 'table' in node) return [node.name];
+  const chunks = node.queryChunks;
+  if (Array.isArray(chunks)) return chunks.flatMap((c) => columnsIn(c, seen));
+  return [];
+}
+
+describe('softwareRemediationRequestCleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedSelectWhere.length = 0;
+    capturedDeleteWhere.length = 0;
+    delete process.env.SOFTWARE_REMEDIATION_REQUEST_RETENTION_HOURS;
+    delete process.env.SOFTWARE_REMEDIATION_REQUEST_CLEANUP_ENABLED;
+  });
+  afterEach(() => {
+    delete process.env.SOFTWARE_REMEDIATION_REQUEST_RETENTION_HOURS;
+    delete process.env.SOFTWARE_REMEDIATION_REQUEST_CLEANUP_ENABLED;
+  });
+
+  it('deletes rows past the retention cutoff', async () => {
+    selectMock.mockReturnValueOnce(selectChain([{ id: 'r1' }, { id: 'r2' }]) as never);
+    deleteMock.mockReturnValueOnce(deleteChain([{ id: 'r1' }, { id: 'r2' }]) as never);
+
+    const result = await pruneExpiredRemediationRequests();
+
+    expect(result.deletedCount).toBe(2);
+    expect(result.batches).toBe(1);
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+
+    // The SELECT filters on expires_at, not created_at or consumed_at.
+    expect(columnsIn(capturedSelectWhere[0])).toEqual(['expires_at']);
+    // The DELETE re-applies the SAME expiry cutoff, not just the id list. That
+    // is the race guard: without it a row that stopped being eligible between
+    // the SELECT and the DELETE would still be removed by id alone.
+    // (Direction of the comparison is covered by the integration test, not here.)
+    const del = columnsIn(capturedDeleteWhere[0]);
+    expect(del).toContain('id');
+    expect(del).toContain('expires_at');
+  });
+
+  it('is a no-op when nothing has expired (idempotent re-run)', async () => {
+    selectMock.mockReturnValueOnce(selectChain([]) as never);
+
+    const result = await pruneExpiredRemediationRequests();
+
+    expect(result.deletedCount).toBe(0);
+    expect(result.batches).toBe(0);
+    // Never opens a DELETE it does not need.
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps batching while a full batch comes back, then stops on a short one', async () => {
+    const full = Array.from({ length: __testOnly.BATCH_SIZE }, (_, i) => ({ id: `f${i}` }));
+    selectMock
+      .mockReturnValueOnce(selectChain(full) as never)
+      .mockReturnValueOnce(selectChain([{ id: 'tail' }]) as never);
+    deleteMock
+      .mockReturnValueOnce(deleteChain(full) as never)
+      .mockReturnValueOnce(deleteChain([{ id: 'tail' }]) as never);
+
+    const result = await pruneExpiredRemediationRequests();
+
+    expect(result.batches).toBe(2);
+    expect(result.deletedCount).toBe(__testOnly.BATCH_SIZE + 1);
+    // The short second batch ends the loop — no guaranteed-empty third query.
+    expect(selectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops at the batch cap instead of looping forever under sustained inserts', async () => {
+    // Every batch comes back full, as it would if eligible rows were being
+    // inserted as fast as they are deleted. The sweep must bound itself and
+    // leave the remainder for the next hourly run rather than spin.
+    const full = Array.from({ length: __testOnly.BATCH_SIZE }, (_, i) => ({ id: `f${i}` }));
+    selectMock.mockReturnValue(selectChain(full) as never);
+    deleteMock.mockReturnValue(deleteChain(full) as never);
+
+    const result = await pruneExpiredRemediationRequests();
+
+    expect(result.batches).toBe(__testOnly.MAX_BATCHES);
+    // Confirmed, not assumed: on hitting the cap the sweep probes once more for
+    // a still-eligible row before claiming a backlog, so a run that happened to
+    // drain the table on its last batch does not report one.
+    expect(result.hasMore).toBe(true);
+    expect(selectMock).toHaveBeenCalledTimes(__testOnly.MAX_BATCHES + 1);
+  });
+
+  it('honors a retention override and falls back on a nonsense value', () => {
+    process.env.SOFTWARE_REMEDIATION_REQUEST_RETENTION_HOURS = '6';
+    expect(__testOnly.getRetentionHours()).toBe(6);
+
+    process.env.SOFTWARE_REMEDIATION_REQUEST_RETENTION_HOURS = 'not-a-number';
+    expect(__testOnly.getRetentionHours()).toBe(__testOnly.DEFAULT_RETENTION_HOURS);
+
+    process.env.SOFTWARE_REMEDIATION_REQUEST_RETENTION_HOURS = '0';
+    expect(__testOnly.getRetentionHours()).toBe(__testOnly.DEFAULT_RETENTION_HOURS);
+  });
+
+  it('can be disabled by env, and defaults to enabled', () => {
+    expect(__testOnly.isCleanupEnabled()).toBe(true);
+    for (const off of ['0', 'false', 'no', 'off', 'OFF']) {
+      process.env.SOFTWARE_REMEDIATION_REQUEST_CLEANUP_ENABLED = off;
+      expect(__testOnly.isCleanupEnabled()).toBe(false);
+    }
+    process.env.SOFTWARE_REMEDIATION_REQUEST_CLEANUP_ENABLED = 'true';
+    expect(__testOnly.isCleanupEnabled()).toBe(true);
+  });
+});

--- a/apps/api/src/jobs/softwareRemediationRequestCleanup.ts
+++ b/apps/api/src/jobs/softwareRemediationRequestCleanup.ts
@@ -1,0 +1,292 @@
+/**
+ * Software Remediation Request Cleanup Worker (issue #3614, follow-up to #3585).
+ *
+ * #3585 backed manual software remediation with a durable single-use
+ * authorization token: one `software_remediation_requests` row per targeted
+ * device, consumed atomically by `consumeManualRemediationAuthorization`.
+ * Nothing pruned them.
+ *
+ * A single Remediate click mints up to 500 rows (one per violating device, the
+ * route's cap). Every device that never reports back — offline, decommissioned
+ * between the click and the dispatch, agent wedged — leaves its row behind
+ * until the device, policy, or org is deleted and the FK cascade takes it. On
+ * an active fleet that is unbounded growth on a table that only ever needs a
+ * short window of history.
+ *
+ * This sweep deletes rows that are past `expires_at` by a comfortable margin.
+ * The margin matters: a row is only useful up to its own expiry, but keeping it
+ * a while longer means a support question ("who authorized that uninstall, and
+ * when?") is still answerable from the row rather than only from the audit log.
+ * CONSUMED rows are deleted on the same schedule — the audit entry written at
+ * consume time is the durable record, not this row.
+ *
+ * The DELETE is batched and re-checks the same cutoff predicate it selected on,
+ * so a row cannot be removed by a cutoff it no longer matches.
+ *
+ * Why its own job rather than an existing sweep: every other retention concern
+ * in this directory owns one small worker (`mlOutputRetention`,
+ * `enrollmentKeyCleanup`, `softwareUploadSessionCleanup`, ...), and the
+ * remediation worker itself is job-driven with no repeatable component to hang
+ * this on. Grafting an unrelated table onto another domain's sweep would hide
+ * it from anyone reading that file.
+ *
+ * Scheduling: hourly cron ('35 * * * *'), jobId-deduped across replicas.
+ * RLS: runs inside withSystemDbAccessContext (background job, all tenants).
+ * Idempotent: re-running finds zero expired rows.
+ * Env: SOFTWARE_REMEDIATION_REQUEST_CLEANUP_ENABLED (default on),
+ *      SOFTWARE_REMEDIATION_REQUEST_RETENTION_HOURS (default 72).
+ */
+import { Queue, Worker, Job } from 'bullmq';
+import { and, inArray, lt } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { softwareRemediationRequests } from '../db/schema';
+import { captureException } from '../services/sentry';
+import { getBullMQConnection } from '../services/redis';
+
+const QUEUE_NAME = 'software-remediation-request-cleanup';
+const JOB_NAME = 'software-remediation-request-cleanup';
+const REPEAT_JOB_ID = 'software-remediation-request-cleanup';
+// Hourly at :35 — staggered from the :15 upload-session sweep and the daily
+// 02:00-04:00 retention jobs.
+const HOURLY_CRON = '35 * * * *';
+// Hours PAST expires_at, not past created_at: the grace is measured from the
+// point the row stopped being usable.
+const DEFAULT_RETENTION_HOURS = 72;
+const BATCH_SIZE = 5_000;
+// Hard bound on one sweep. Without it, a table receiving eligible rows as fast
+// as they are deleted keeps every batch full and `for(;;)` never exits — the
+// hourly schedule means the remainder is picked up 60 minutes later anyway.
+const MAX_BATCHES = 50;
+
+function isCleanupEnabled(): boolean {
+  const raw = process.env.SOFTWARE_REMEDIATION_REQUEST_CLEANUP_ENABLED;
+  if (raw === undefined || raw === '') return true;
+  const v = raw.trim().toLowerCase();
+  return !(v === '0' || v === 'false' || v === 'no' || v === 'off');
+}
+
+function getRetentionHours(): number {
+  const raw = process.env.SOFTWARE_REMEDIATION_REQUEST_RETENTION_HOURS;
+  if (raw === undefined || raw === '') return DEFAULT_RETENTION_HOURS;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_RETENTION_HOURS;
+}
+
+let cleanupQueue: Queue | null = null;
+let cleanupWorker: Worker | null = null;
+
+export function getSoftwareRemediationRequestCleanupQueue(): Queue {
+  if (!cleanupQueue) {
+    cleanupQueue = new Queue(QUEUE_NAME, { connection: getBullMQConnection() });
+  }
+  return cleanupQueue;
+}
+
+/**
+ * Prunes expired authorization rows.
+ *
+ * Establishes its OWN system context per batch via
+ * `runOutsideDbContext(() => withSystemDbAccessContext(...))`, the same pattern
+ * `createManualRemediationAuthorizations` uses. Two reasons, both learned the
+ * hard way in review:
+ *
+ * 1. SAFETY. Relying on the caller was not enough, and a plain nested
+ *    `withSystemDbAccessContext` would NOT have fixed it: `withDbAccessContext`
+ *    short-circuits to `fn()` when a context already exists (db/index.ts), so a
+ *    nested call keeps the REQUEST's org scope instead of escalating — it would
+ *    look protected while pruning only that org's rows and reporting a
+ *    whole-table sweep. `runOutsideDbContext` exits both stores, so the nested
+ *    call opens a genuinely fresh system context. Marking the function
+ *    `__testOnly` was NOT a guard either: that object is an ordinary runtime
+ *    export any module can import.
+ *
+ * 2. LOCK DURATION. `withSystemDbAccessContext` opens ONE transaction that does
+ *    not commit until its callback returns. Wrapping the whole sweep therefore
+ *    kept every batch's row locks and dead tuples in a single transaction — up
+ *    to MAX_BATCHES * BATCH_SIZE rows — which defeated the point of batching.
+ *    Per-batch contexts mean each batch commits on its own. The sweep is not
+ *    atomic, which is correct for an idempotent retention job: a partial run
+ *    simply prunes fewer rows and the next hourly run finishes.
+ */
+export async function pruneExpiredRemediationRequests(): Promise<{
+  deletedCount: number;
+  batches: number;
+  retentionHours: number;
+  /**
+   * The batch cap stopped the sweep AND a probe still saw an eligible row.
+   * A point-in-time observation, not a guarantee: a concurrent FK cascade can
+   * remove that row immediately after, and a fresh expiry can appear right
+   * after a negative probe.
+   */
+  hasMore: boolean;
+}> {
+  const retentionHours = getRetentionHours();
+  const cutoff = new Date(Date.now() - retentionHours * 3_600_000);
+  let deletedCount = 0;
+  let batches = 0;
+  let hasMore = false;
+
+  const inSystemContext = <T>(fn: () => Promise<T>): Promise<T> =>
+    runOutsideDbContext(() => withSystemDbAccessContext(fn));
+
+  while (batches < MAX_BATCHES) {
+    // One transaction per batch — see the LOCK DURATION note above.
+    const deletedInBatch = await inSystemContext(async () => {
+      const expired = await db
+        .select({ id: softwareRemediationRequests.id })
+        .from(softwareRemediationRequests)
+        .where(lt(softwareRemediationRequests.expiresAt, cutoff))
+        .limit(BATCH_SIZE);
+
+      if (expired.length === 0) return null;
+
+      const deleted = await db
+        .delete(softwareRemediationRequests)
+        .where(and(
+          inArray(softwareRemediationRequests.id, expired.map((r) => r.id)),
+          lt(softwareRemediationRequests.expiresAt, cutoff),
+        ))
+        .returning({ id: softwareRemediationRequests.id });
+
+      return { deleted: deleted.length, selected: expired.length };
+    });
+
+    if (deletedInBatch === null) break;
+
+    deletedCount += deletedInBatch.deleted;
+    batches += 1;
+
+    // A short batch means nothing eligible was left AT SELECT TIME. Rows
+    // inserted concurrently are deliberately left for the next hourly run
+    // rather than chasing a moving target inside one sweep.
+    if (deletedInBatch.selected < BATCH_SIZE) break;
+
+    if (batches >= MAX_BATCHES) {
+      // Cap reached on a FULL batch. Probe before claiming a backlog, so a
+      // sweep that happened to drain the table on its last batch does not send
+      // someone chasing nothing. LIMIT 1 bounds the rows returned, not the work:
+      // the only expires_at index is partial on `consumed_at IS NULL` and this
+      // predicate spans consumed rows too, so an exact drain can cost a scan.
+      // Acceptable at most once per capped run.
+      const leftover = await inSystemContext(async () => {
+        const [row] = await db
+          .select({ id: softwareRemediationRequests.id })
+          .from(softwareRemediationRequests)
+          .where(lt(softwareRemediationRequests.expiresAt, cutoff))
+          .limit(1);
+        return row;
+      });
+      hasMore = Boolean(leftover);
+    }
+  }
+
+  return { deletedCount, batches, retentionHours, hasMore };
+}
+
+export function createSoftwareRemediationRequestCleanupWorker(): Worker {
+  return new Worker(
+    QUEUE_NAME,
+    async (job: Job) => {
+      if (job.name !== JOB_NAME) {
+        console.warn(`[SoftwareRemediationRequestCleanup] Ignoring unknown job name: ${job.name}`);
+        return { deletedCount: 0, skipped: true };
+      }
+      {
+        // No context wrapper here: the prune establishes its own per batch.
+        const startedAt = Date.now();
+        const result = await pruneExpiredRemediationRequests();
+        const durationMs = Date.now() - startedAt;
+        if (result.hasMore) {
+          console.warn(
+            `[SoftwareRemediationRequestCleanup] Hit the ${MAX_BATCHES}-batch cap with rows still eligible; ` +
+            'the remainder is left for the next hourly run.',
+          );
+        }
+        if (result.deletedCount > 0) {
+          console.log(
+            `[SoftwareRemediationRequestCleanup] Deleted ${result.deletedCount} expired authorization row(s) ` +
+            `(expired >${result.retentionHours}h ago, ${result.batches} batch(es)) in ${durationMs}ms`,
+          );
+        }
+        return { ...result, durationMs };
+      }
+    },
+    { connection: getBullMQConnection(), concurrency: 1 },
+  );
+}
+
+export async function scheduleSoftwareRemediationRequestCleanup(
+  queue: Queue = getSoftwareRemediationRequestCleanupQueue(),
+): Promise<void> {
+  const existingJobs = await queue.getRepeatableJobs();
+  for (const job of existingJobs) {
+    if (job.name === JOB_NAME) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+  }
+  if (!isCleanupEnabled()) {
+    console.log(
+      '[SoftwareRemediationRequestCleanup] SOFTWARE_REMEDIATION_REQUEST_CLEANUP_ENABLED=false — skipping schedule registration',
+    );
+    return;
+  }
+  await queue.add(
+    JOB_NAME,
+    {},
+    {
+      jobId: REPEAT_JOB_ID,
+      repeat: { pattern: HOURLY_CRON },
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 25 },
+    },
+  );
+  console.log(
+    `[SoftwareRemediationRequestCleanup] Scheduled hourly cleanup (cron "${HOURLY_CRON}", jobId=${REPEAT_JOB_ID})`,
+  );
+}
+
+export async function initializeSoftwareRemediationRequestCleanupWorker(): Promise<void> {
+  try {
+    cleanupWorker = createSoftwareRemediationRequestCleanupWorker();
+    cleanupWorker.on('error', (error) => {
+      console.error('[SoftwareRemediationRequestCleanup] Worker error:', error);
+      captureException(error);
+    });
+    cleanupWorker.on('failed', (job, error) => {
+      console.error(`[SoftwareRemediationRequestCleanup] Job ${job?.id} failed:`, error);
+      captureException(error);
+    });
+    await scheduleSoftwareRemediationRequestCleanup();
+    console.log('[SoftwareRemediationRequestCleanup] Worker initialized');
+  } catch (error) {
+    console.error('[SoftwareRemediationRequestCleanup] Failed to initialize:', error);
+    // The worker is created BEFORE the schedule call, so a Redis failure while
+    // scheduling would otherwise leave a live worker and queue behind for the
+    // rest of the process: initializeWorkers() logs and keeps running.
+    await shutdownSoftwareRemediationRequestCleanupWorker().catch(() => {});
+    throw error;
+  }
+}
+
+export async function shutdownSoftwareRemediationRequestCleanupWorker(): Promise<void> {
+  if (cleanupWorker) {
+    await cleanupWorker.close();
+    cleanupWorker = null;
+  }
+  if (cleanupQueue) {
+    await cleanupQueue.close();
+    cleanupQueue = null;
+  }
+}
+
+export const __testOnly = {
+  QUEUE_NAME,
+  JOB_NAME,
+  REPEAT_JOB_ID,
+  HOURLY_CRON,
+  DEFAULT_RETENTION_HOURS,
+  BATCH_SIZE,
+  MAX_BATCHES,
+  isCleanupEnabled,
+  getRetentionHours,
+};

--- a/apps/api/src/jobs/softwareRemediationWorker.ts
+++ b/apps/api/src/jobs/softwareRemediationWorker.ts
@@ -397,10 +397,19 @@ export async function processRemediateDevice(data: RemediateDeviceJobData): Prom
   // manual job that consumed its single-use token and then hit the cooldown would
   // burn the authorization and skip with zero commands (no retry). Bypassing it
   // for verified manual keeps the token and the operator's intent whole.
-  // Tradeoff (intended): an authenticated, MFA-gated operator can re-trigger
-  // manual remediation without a cooldown wait. Concurrent double-clicks still
-  // dedupe on the in-flight uninstall-command check below; there is deliberately
-  // no separate manual throttle — a manual run is an explicit human decision.
+  // Tradeoff (intended, confirmed in #3614): an authenticated, MFA-gated
+  // operator can re-trigger manual remediation without a cooldown wait.
+  // Concurrent double-clicks still dedupe on the in-flight uninstall-command
+  // check below; there is deliberately no separate manual throttle — a manual
+  // run is an explicit human decision.
+  //
+  // The cooldown exists to stop the UNATTENDED worker from retrying a failing
+  // policy every scheduling tick. A human who has just passed MFA and burned a
+  // single-use authorization row (#3585) has already cleared a stricter gate
+  // than the cooldown, and making them wait would strand exactly the operator
+  // trying to correct a bad remediation. Do not "fix" this into a throttle
+  // without replacing the token semantics too: consume-then-cooldown-skip
+  // would burn the row for zero queued commands and leave no way to retry.
   if (trigger !== 'manual' && compliance.lastRemediationAttempt) {
     const nextEligibleAt = new Date(compliance.lastRemediationAttempt.getTime() + (cooldownMinutes * 60 * 1000));
     if (nextEligibleAt.getTime() > now.getTime()) {


### PR DESCRIPTION
Closes four of the five follow-ups from your #3585 review. The fifth I'm answering rather than changing, and one of the four comes with a correction to its premise.

### 1. Sweeper

Nothing pruned `software_remediation_requests`. One Remediate click mints up to 500 rows and every target that never reports back leaves its row until the device, policy, or org is deleted and the FK cascade takes it.

New hourly worker deletes rows past `expires_at` by a configurable grace (`SOFTWARE_REMEDIATION_REQUEST_RETENTION_HOURS`, default 72), batched, re-applying the same cutoff in the `DELETE` it selected on. Consumed rows go on the same schedule — the audit entry written at consume time is the durable record, not the row.

The sweep is **bounded at 50 batches**. Without a cap, a table receiving eligible rows as fast as they're deleted keeps every batch full and the loop never exits. The hourly schedule picks up the remainder, and the capped case is logged rather than silent.

It's its own worker rather than a graft onto an existing sweep because every retention concern in `jobs/` owns one small worker, and `softwareRemediationWorker` itself is job-driven with no repeatable component to hang this on. Happy to fold it elsewhere if you'd rather.

### 2. Partial index — declared, but a correction to the premise

Declared in Drizzle mirroring the migration, using the same `.where(sql\`...\`)` shape `abuseSignals.ts:28` uses.

**It does not change `pnpm db:check-drift`, though.** That script compares migration filenames against the `breeze_migrations` ledger, and `scripts/check-drift.ts:17-26` states that schema-vs-live-DB drift is *"intentionally NOT checked"* because the drizzle-kit round-trip produces thousands of false positives here. So no gate was failing and none starts passing.

Declaring it is still right — the schema file should describe what the database actually has, and it's what a reader reasons from — but I didn't want to ship a justification I'd checked and found wrong.

Related: the index serves the **consume** path (which filters `consumed_at IS NULL`). The sweep scans `expires_at` across consumed and unconsumed rows alike, so the partial index can't cover it. The comment says that rather than implying the sweep benefits.

### 4. Concurrent double-redemption

The existing test proved single-use only *after* the first consume committed. Added one that starts both together and asserts exactly one wins — never both (double uninstall dispatch), never neither (a burned token that queued nothing).

The unit tests now also **capture and assert the actual `WHERE` predicates** instead of counting calls. The first version I wrote would have passed against an implementation that selected the wrong column or dropped the cutoff recheck from the `DELETE`. Control-run with that recheck removed, it now fails on `expected [ 'id' ] to include 'expires_at'`.

### 5. Cooldown bypass — intended

Already documented at `softwareRemediationWorker.ts:400`; I've expanded it with the reasoning rather than the bare assertion. The cooldown exists to stop the *unattended* worker retrying a failing policy every tick, and a human who has passed MFA and burned a single-use row has cleared a stricter gate. The comment now also warns why turning it into a throttle is unsafe: consume-then-cooldown-skip burns the row for zero queued commands with no way to retry — that was the blocker while building #3585.

### 3. Second pool connection — deliberately not here

You called it "not a bug today" and I agree. Fixing it properly means touching `runOutsideDbContext` itself, which affects every caller. Wrong thing to slip into a follow-up PR.

### Also

A failed initialization now closes the worker and queue it already created. `initializeWorkers()` logs and keeps the process running, so a Redis error while scheduling would otherwise have left both live for the rest of the process.

### Verification

node 22.23.2 (CI `.nvmrc`), pnpm 10.34.5:

- `api` `tsc --noEmit` — 0 errors
- `api` `src/jobs/` — 110 files, **1038/1038 pass**
- `api` `softwareRemediationRequestCleanup.test.ts` — **6/6**
- `api` eslint on all four changed files — clean

The concurrent-consume test is an integration test needing a real Postgres, so it runs in CI rather than locally.

Refs #3614, #3585
