### PR TITLE
feat(web): edit-in-place for persisted quote table/callout blocks (#3547)

### DIFF
--- a/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
@@ -22,13 +22,12 @@ import {
   type QuoteBlock,
   type QuoteLine,
   type QuoteLineRecurrence,
-  type QuoteTableContent,
-  type QuoteCalloutContent,
   formatMoney,
 } from './quoteTypes';
 import { type LineUpdate, SrSaved, fieldRing, pendingKey, seamless } from './quoteEditorShared';
 import { GhostRow, EditableLineRow, ReadonlyLineRow, type LineRevealRequest } from './QuoteLineRows';
 import { ContractBlockEditor } from './QuoteContractBlockEditor';
+import { TableBlockEditor, CalloutBlockEditor } from './QuoteStructuredBlockEditor';
 
 // ── A single block, with an inline line builder when it is a pricing table ──
 export function BlockCard({
@@ -382,85 +381,13 @@ export function BlockCard({
           <ContractBlockEditor block={block} canWrite={canWrite} onEditBlock={onEditBlock} />
         )}
 
-        {block.blockType === 'table' && (() => {
-          // Structured JSON, never HTML-parsed — column labels and cell values
-          // are sanitized server-side with the inline-only profile on both
-          // write and read (quoteService's read-path sanitizer), same
-          // dangerouslySetInnerHTML precedent as QuoteDocument.tsx's canonical
-          // table rendering, which this mirrors. Read-only for now (no inline
-          // edit affordance yet — remove-and-re-add is the only way to change
-          // a persisted table, same limitation the contract block used to
-          // have before ContractBlockEditor).
-          const content = block.content as Partial<QuoteTableContent> | undefined;
-          if (!content?.columns?.length || !content?.rows?.length) {
-            return (
-              <p className="text-sm text-muted-foreground" data-testid={`quote-block-table-content-${block.id}`}>
-                {t('quotes.editor.block.tableEmpty')}
-              </p>
-            );
-          }
-          return (
-            <div className="overflow-x-auto" data-testid={`quote-block-table-content-${block.id}`}>
-              <table className="w-full border-collapse text-sm">
-                <thead>
-                  <tr className={content.headerStyle === 'plain' ? 'border-b-2' : 'border-b-2 bg-primary/10'}>
-                    {content.columns.map((col, i) => (
-                      <th
-                        key={i}
-                        style={{ textAlign: col.align ?? 'left' }}
-                        className="px-3 py-2 font-semibold text-foreground"
-                        dangerouslySetInnerHTML={{ __html: col.label }}
-                      />
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {content.rows.map((row, ri) => (
-                    <tr key={ri} className={content.zebra && ri % 2 === 1 ? 'bg-muted/30' : undefined}>
-                      {row.cells.map((cell, ci) => (
-                        <td
-                          key={ci}
-                          style={{ textAlign: content.columns?.[ci]?.align ?? 'left' }}
-                          className="px-3 py-2 align-top text-foreground/90"
-                          dangerouslySetInnerHTML={{ __html: cell }}
-                        />
-                      ))}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {content.caption && <p className="mt-1 text-xs text-muted-foreground">{content.caption}</p>}
-            </div>
-          );
-        })()}
+        {block.blockType === 'table' && (
+          <TableBlockEditor block={block} canWrite={canWrite} busy={blockBusy} onEditBlock={onEditBlock} />
+        )}
 
-        {block.blockType === 'callout' && (() => {
-          // Same server-sanitized-HTML precedent as rich_text. Read-only for
-          // now — see the table block's note above.
-          const content = block.content as Partial<QuoteCalloutContent> | undefined;
-          if (!content?.html?.trim()) {
-            return (
-              <p className="text-sm text-muted-foreground" data-testid={`quote-block-callout-content-${block.id}`}>
-                {t('quotes.editor.block.calloutEmpty')}
-              </p>
-            );
-          }
-          const tone =
-            content.variant === 'warn'
-              ? 'border-amber-500/40 bg-amber-500/10'
-              : content.variant === 'accent'
-                ? 'border-primary/40 bg-primary/10'
-                : 'border-border bg-muted/40';
-          return (
-            <div className={`rounded-lg border-l-4 p-4 ${tone}`} data-testid={`quote-block-callout-content-${block.id}`}>
-              {content.title && <p className="mb-1 text-sm font-semibold text-foreground">{content.title}</p>}
-              <div
-                className="quote-rich-text prose prose-sm max-w-prose dark:prose-invert"
-                dangerouslySetInnerHTML={{ __html: content.html }}
-              />
-            </div>
-          );
-        })()}
+        {block.blockType === 'callout' && (
+          <CalloutBlockEditor block={block} canWrite={canWrite} busy={blockBusy} onEditBlock={onEditBlock} />
+        )}
 
         {isTable && (
           <div className="space-y-3">

--- a/apps/web/src/components/billing/quotes/QuoteBlockContentForms.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBlockContentForms.tsx
@@ -1,0 +1,325 @@
+// The authoring fields for the structured `table` and `callout` blocks, shared
+// by BOTH the add-block form (QuoteEditor) and the edit-in-place affordance on
+// a persisted block (QuoteBlockCard) — issue #3547. Extracted rather than
+// duplicated so the two surfaces can never drift: one grid invariant, one set
+// of caps, one set of test ids.
+//
+// Each surface owns a single form-state object and passes it down; the mutators
+// are pure functions over that state, so the "every row has exactly
+// columns.length cells" invariant quoteTableContentSchema enforces server-side
+// is maintained at every mutation, on both surfaces.
+import { useTranslation } from 'react-i18next';
+import '../../../lib/i18n';
+import type { QuoteTableColumn, QuoteTableContent, QuoteCalloutContent } from '@breeze/shared';
+import RichTextEditor from '../../common/RichTextEditor';
+import InlineRichTextEditor from '../../common/InlineRichTextEditor';
+
+// Caps mirrored from quoteTableContentSchema (8 cols x 100 rows x 2000 chars).
+export const MAX_TABLE_COLUMNS = 8;
+export const MAX_TABLE_ROWS = 100;
+
+// ── table ───────────────────────────────────────────────────────────────────
+
+export type TableFormState = {
+  columns: QuoteTableColumn[];
+  rows: { cells: string[] }[];
+  caption: string;
+  zebra: boolean;
+  headerStyle: 'accent' | 'plain';
+};
+
+export function freshTableForm(): TableFormState {
+  return {
+    columns: [{ label: '' }, { label: '' }],
+    rows: [{ cells: ['', ''] }, { cells: ['', ''] }],
+    caption: '',
+    zebra: false,
+    headerStyle: 'plain',
+  };
+}
+
+/** Seed the form from a persisted block's content. Defensive about shape: a
+ *  legacy or hand-written row that disagrees with columns.length is padded or
+ *  trimmed HERE (once, visibly, before the user edits) rather than being sent
+ *  back to the API where the schema's exact-shape refinement would reject it. */
+export function tableFormFromContent(content: unknown): TableFormState {
+  const c = (content ?? {}) as Partial<QuoteTableContent>;
+  const columns = Array.isArray(c.columns) && c.columns.length > 0
+    ? c.columns.slice(0, MAX_TABLE_COLUMNS).map((col) => ({ ...col }))
+    : [{ label: '' }];
+  const rawRows = Array.isArray(c.rows) && c.rows.length > 0 ? c.rows.slice(0, MAX_TABLE_ROWS) : [{ cells: [] }];
+  const rows = rawRows.map((r) => {
+    const cells = Array.isArray(r?.cells) ? r.cells.slice(0, columns.length) : [];
+    while (cells.length < columns.length) cells.push('');
+    return { cells };
+  });
+  return {
+    columns,
+    rows,
+    caption: c.caption ?? '',
+    zebra: c.zebra ?? false,
+    headerStyle: c.headerStyle ?? 'plain',
+  };
+}
+
+/** The PATCH/POST body content for a table block. Mirrors the add-block
+ *  builder exactly: an empty caption is omitted rather than sent as ''. */
+export function tableFormToContent(form: TableFormState): Record<string, unknown> {
+  return {
+    columns: form.columns,
+    rows: form.rows.map((r) => ({ cells: r.cells })),
+    ...(form.caption.trim() ? { caption: form.caption.trim() } : {}),
+    zebra: form.zebra,
+    headerStyle: form.headerStyle,
+  };
+}
+
+export const tableForm = {
+  addColumn: (f: TableFormState): TableFormState =>
+    f.columns.length >= MAX_TABLE_COLUMNS
+      ? f
+      : { ...f, columns: [...f.columns, { label: '' }], rows: f.rows.map((r) => ({ cells: [...r.cells, ''] })) },
+  removeColumn: (f: TableFormState, idx: number): TableFormState =>
+    f.columns.length <= 1
+      ? f
+      : {
+          ...f,
+          columns: f.columns.filter((_, i) => i !== idx),
+          rows: f.rows.map((r) => ({ cells: r.cells.filter((_, i) => i !== idx) })),
+        },
+  addRow: (f: TableFormState): TableFormState =>
+    f.rows.length >= MAX_TABLE_ROWS ? f : { ...f, rows: [...f.rows, { cells: Array(f.columns.length).fill('') }] },
+  removeRow: (f: TableFormState, idx: number): TableFormState =>
+    f.rows.length <= 1 ? f : { ...f, rows: f.rows.filter((_, i) => i !== idx) },
+  setColumnLabel: (f: TableFormState, idx: number, label: string): TableFormState =>
+    ({ ...f, columns: f.columns.map((c, i) => (i === idx ? { ...c, label } : c)) }),
+  setColumnAlign: (f: TableFormState, idx: number, align: QuoteTableColumn['align']): TableFormState =>
+    ({ ...f, columns: f.columns.map((c, i) => (i === idx ? { ...c, align } : c)) }),
+  setCell: (f: TableFormState, rowIdx: number, colIdx: number, html: string): TableFormState =>
+    ({ ...f, rows: f.rows.map((r, i) => (i === rowIdx ? { cells: r.cells.map((c, j) => (j === colIdx ? html : c)) } : r)) }),
+};
+
+export function TableBlockFields({
+  value, onChange, idPrefix = 'quote-block-table', disabled = false,
+}: {
+  value: TableFormState;
+  onChange: (next: TableFormState) => void;
+  /** Test-id / DOM-id namespace. Defaults to the add-form's ids; the
+   *  edit-in-place surface passes a per-block prefix so several forms can be
+   *  mounted at once without colliding. */
+  idPrefix?: string;
+  disabled?: boolean;
+}) {
+  const { t } = useTranslation('billing');
+  return (
+    <div className="mb-3 space-y-3" data-testid={idPrefix}>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[32rem] border-separate border-spacing-1 text-xs">
+          <thead>
+            <tr>
+              {value.columns.map((col, colIdx) => (
+                <th key={colIdx} className="text-left font-normal">
+                  <div className="flex items-center gap-1">
+                    <input
+                      type="text"
+                      value={col.label}
+                      maxLength={200}
+                      disabled={disabled}
+                      onChange={(e) => onChange(tableForm.setColumnLabel(value, colIdx, e.target.value))}
+                      placeholder={t('quotes.editor.table.columnLabelPlaceholder')}
+                      data-testid={`${idPrefix}-column-label-${colIdx}`}
+                      className="h-8 w-full rounded-md border bg-background px-2 text-xs focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+                    />
+                    <select
+                      value={col.align ?? 'left'}
+                      disabled={disabled}
+                      onChange={(e) => onChange(tableForm.setColumnAlign(value, colIdx, e.target.value as QuoteTableColumn['align']))}
+                      aria-label={t('quotes.editor.table.columnAlignAria')}
+                      data-testid={`${idPrefix}-column-align-${colIdx}`}
+                      className="h-8 rounded-md border bg-background px-1 text-xs focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+                    >
+                      <option value="left">{t('quotes.editor.table.alignLeft')}</option>
+                      <option value="center">{t('quotes.editor.table.alignCenter')}</option>
+                      <option value="right">{t('quotes.editor.table.alignRight')}</option>
+                    </select>
+                    <button
+                      type="button"
+                      onClick={() => onChange(tableForm.removeColumn(value, colIdx))}
+                      disabled={disabled || value.columns.length <= 1}
+                      aria-label={t('quotes.editor.table.removeColumn')}
+                      title={t('quotes.editor.table.removeColumn')}
+                      data-testid={`${idPrefix}-remove-column-${colIdx}`}
+                      className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted disabled:opacity-40"
+                    >
+                      &times;
+                    </button>
+                  </div>
+                </th>
+              ))}
+              <th className="w-8">
+                <button
+                  type="button"
+                  onClick={() => onChange(tableForm.addColumn(value))}
+                  disabled={disabled || value.columns.length >= MAX_TABLE_COLUMNS}
+                  aria-label={t('quotes.editor.table.addColumn')}
+                  title={t('quotes.editor.table.addColumn')}
+                  data-testid={`${idPrefix}-add-column`}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md border text-muted-foreground hover:bg-muted disabled:opacity-40"
+                >
+                  +
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {value.rows.map((row, rowIdx) => (
+              <tr key={rowIdx}>
+                {row.cells.map((cell, colIdx) => (
+                  <td key={colIdx} className="align-top">
+                    <InlineRichTextEditor
+                      value={cell}
+                      onChange={(html) => onChange(tableForm.setCell(value, rowIdx, colIdx, html))}
+                      ariaLabel={t('quotes.editor.table.cellAria', { row: rowIdx + 1, column: colIdx + 1 })}
+                      testId={`${idPrefix}-cell-${rowIdx}-${colIdx}`}
+                      maxLength={2000}
+                    />
+                  </td>
+                ))}
+                <td className="align-top">
+                  <button
+                    type="button"
+                    onClick={() => onChange(tableForm.removeRow(value, rowIdx))}
+                    disabled={disabled || value.rows.length <= 1}
+                    aria-label={t('quotes.editor.table.removeRow')}
+                    title={t('quotes.editor.table.removeRow')}
+                    data-testid={`${idPrefix}-remove-row-${rowIdx}`}
+                    className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted disabled:opacity-40"
+                  >
+                    &times;
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <button
+        type="button"
+        onClick={() => onChange(tableForm.addRow(value))}
+        disabled={disabled || value.rows.length >= MAX_TABLE_ROWS}
+        data-testid={`${idPrefix}-add-row`}
+        className="inline-flex h-8 items-center justify-center rounded-md border px-3 text-xs font-medium text-muted-foreground hover:bg-muted disabled:opacity-40"
+      >
+        {t('quotes.editor.table.addRow')}
+      </button>
+      <input
+        type="text"
+        value={value.caption}
+        maxLength={300}
+        disabled={disabled}
+        onChange={(e) => onChange({ ...value, caption: e.target.value })}
+        placeholder={t('quotes.editor.table.captionPlaceholder')}
+        data-testid={`${idPrefix}-caption`}
+        className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+      />
+      <div className="flex flex-wrap items-center gap-4">
+        <label className="inline-flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={value.zebra}
+            disabled={disabled}
+            onChange={(e) => onChange({ ...value, zebra: e.target.checked })}
+            data-testid={`${idPrefix}-zebra`}
+          />
+          {t('quotes.editor.table.zebra')}
+        </label>
+        <label className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+          {t('quotes.editor.table.headerStyle')}
+          <select
+            value={value.headerStyle}
+            disabled={disabled}
+            onChange={(e) => onChange({ ...value, headerStyle: e.target.value as 'accent' | 'plain' })}
+            data-testid={`${idPrefix}-header-style`}
+            className="h-8 rounded-md border bg-background px-2 text-xs focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+          >
+            <option value="plain">{t('quotes.editor.table.headerStylePlain')}</option>
+            <option value="accent">{t('quotes.editor.table.headerStyleAccent')}</option>
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+}
+
+// ── callout ─────────────────────────────────────────────────────────────────
+
+export type CalloutFormState = {
+  variant: QuoteCalloutContent['variant'];
+  title: string;
+  html: string;
+};
+
+export function freshCalloutForm(): CalloutFormState {
+  return { variant: 'info', title: '', html: '' };
+}
+
+export function calloutFormFromContent(content: unknown): CalloutFormState {
+  const c = (content ?? {}) as Partial<QuoteCalloutContent>;
+  return { variant: c.variant ?? 'info', title: c.title ?? '', html: c.html ?? '' };
+}
+
+export function calloutFormToContent(form: CalloutFormState): Record<string, unknown> {
+  return {
+    variant: form.variant,
+    ...(form.title.trim() ? { title: form.title.trim() } : {}),
+    html: form.html,
+  };
+}
+
+export function CalloutBlockFields({
+  value, onChange, idPrefix = 'quote-block-callout', disabled = false,
+}: {
+  value: CalloutFormState;
+  onChange: (next: CalloutFormState) => void;
+  idPrefix?: string;
+  disabled?: boolean;
+}) {
+  const { t } = useTranslation('billing');
+  return (
+    <div className="mb-3 space-y-3" data-testid={idPrefix}>
+      <div>
+        <label htmlFor={`${idPrefix}-variant`} className="mb-1 block text-xs text-muted-foreground">
+          {t('quotes.editor.callout.variantLabel')}
+        </label>
+        <select
+          id={`${idPrefix}-variant`}
+          value={value.variant}
+          disabled={disabled}
+          onChange={(e) => onChange({ ...value, variant: e.target.value as QuoteCalloutContent['variant'] })}
+          data-testid={`${idPrefix}-variant`}
+          className="h-9 w-full rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+        >
+          <option value="info">{t('quotes.editor.callout.variantInfo')}</option>
+          <option value="accent">{t('quotes.editor.callout.variantAccent')}</option>
+          <option value="warn">{t('quotes.editor.callout.variantWarn')}</option>
+        </select>
+      </div>
+      <input
+        type="text"
+        value={value.title}
+        maxLength={200}
+        disabled={disabled}
+        onChange={(e) => onChange({ ...value, title: e.target.value })}
+        placeholder={t('quotes.editor.callout.titlePlaceholder')}
+        data-testid={`${idPrefix}-title`}
+        className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+      />
+      <RichTextEditor
+        value={value.html}
+        onChange={(html) => onChange({ ...value, html })}
+        ariaLabel={t('quotes.editor.callout.bodyAria')}
+        testId={`${idPrefix}-body`}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/billing/quotes/QuoteBlockContentForms.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBlockContentForms.tsx
@@ -39,26 +39,39 @@ export function freshTableForm(): TableFormState {
 }
 
 /** Seed the form from a persisted block's content. Defensive about shape: a
- *  legacy or hand-written row that disagrees with columns.length is padded or
- *  trimmed HERE (once, visibly, before the user edits) rather than being sent
- *  back to the API where the schema's exact-shape refinement would reject it. */
-export function tableFormFromContent(content: unknown): TableFormState {
+ *  legacy or hand-written table that exceeds the caps, or a row that disagrees
+ *  with columns.length, is reshaped HERE rather than being sent back to the API
+ *  where the schema's exact-shape refinement would reject it with nothing the
+ *  user can act on.
+ *
+ *  Reshaping DISCARDS content (dropped columns/rows/cells), so it reports
+ *  `adjusted` — the caller must tell the user before their Save overwrites the
+ *  stored block with the reshaped version. Today the API's read-path sanitizer
+ *  means in-app content never reaches here out of shape; `adjusted` exists for
+ *  imported/migrated content and for a future cap reduction, which is exactly
+ *  when silently dropping rows would be worst. */
+export function tableFormFromContent(content: unknown): { form: TableFormState; adjusted: boolean } {
   const c = (content ?? {}) as Partial<QuoteTableContent>;
-  const columns = Array.isArray(c.columns) && c.columns.length > 0
-    ? c.columns.slice(0, MAX_TABLE_COLUMNS).map((col) => ({ ...col }))
-    : [{ label: '' }];
-  const rawRows = Array.isArray(c.rows) && c.rows.length > 0 ? c.rows.slice(0, MAX_TABLE_ROWS) : [{ cells: [] }];
-  const rows = rawRows.map((r) => {
-    const cells = Array.isArray(r?.cells) ? r.cells.slice(0, columns.length) : [];
+  const rawColumns = Array.isArray(c.columns) && c.columns.length > 0 ? c.columns : [{ label: '' }];
+  const columns = rawColumns.slice(0, MAX_TABLE_COLUMNS).map((col) => ({ ...col }));
+  const rawRows = Array.isArray(c.rows) && c.rows.length > 0 ? c.rows : [{ cells: [] }];
+  let adjusted = columns.length !== rawColumns.length || rawRows.length > MAX_TABLE_ROWS;
+  const rows = rawRows.slice(0, MAX_TABLE_ROWS).map((r) => {
+    const source = Array.isArray(r?.cells) ? r.cells : [];
+    if (source.length !== columns.length) adjusted = true;
+    const cells = source.slice(0, columns.length);
     while (cells.length < columns.length) cells.push('');
     return { cells };
   });
   return {
-    columns,
-    rows,
-    caption: c.caption ?? '',
-    zebra: c.zebra ?? false,
-    headerStyle: c.headerStyle ?? 'plain',
+    form: {
+      columns,
+      rows,
+      caption: c.caption ?? '',
+      zebra: c.zebra ?? false,
+      headerStyle: c.headerStyle ?? 'plain',
+    },
+    adjusted,
   };
 }
 

--- a/apps/web/src/components/billing/quotes/QuoteEditor.calloutblock.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.calloutblock.test.tsx
@@ -3,7 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuoteEditor from './QuoteEditor';
 import type { QuoteDetail as QuoteDetailData, QuoteBlock } from './quoteTypes';
-import { addBlock } from '../../../lib/api/quotes';
+import { addBlock, updateBlock } from '../../../lib/api/quotes';
+
+// Mutable grant set so the edit-affordance gating (writer vs read-only) can be
+// exercised in this file; defaults to the wildcard the create tests assume.
+const auth = vi.hoisted(() => ({ permissions: [{ resource: '*', action: '*' }] as { resource: string; action: string }[] }));
 
 // Same house pattern as TemplateEditor.test.tsx: swap the tiptap-backed
 // RichTextEditor for a plain textarea so this test targets the callout form
@@ -21,7 +25,7 @@ vi.mock('../../../stores/auth', () => ({
   ),
   useAuthStore: Object.assign(
     (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
-      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+      selector({ user: { permissions: auth.permissions } }),
     { getState: () => ({ tokens: null }) },
   ),
 }));
@@ -72,6 +76,7 @@ const detail: QuoteDetailData = {
 };
 
 const addBlockMock = vi.mocked(addBlock);
+const updateBlockMock = vi.mocked(updateBlock);
 
 async function openCalloutForm() {
   render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
@@ -167,5 +172,104 @@ describe('QuoteEditor — persisted callout block', () => {
     const content = screen.getByTestId('quote-block-callout-content-blk-c');
     expect(content).toHaveTextContent('Heads up');
     expect(content).toHaveTextContent('Read carefully');
+  });
+});
+
+// #3547: same edit-in-place contract as the table block — the create-form
+// fields, prefilled from block.content, saved through updateBlock.
+describe('QuoteEditor — edit persisted callout block', () => {
+  const calloutBlock: QuoteBlock = {
+    id: 'blk-c', quoteId: 'q-1', orgId: 'org-1', blockType: 'callout',
+    content: { variant: 'warn', title: 'Heads up', html: '<p>Read carefully</p>' },
+    sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auth.permissions = [{ resource: '*', action: '*' }];
+  });
+
+  async function openEditor() {
+    render(<QuoteEditor detail={{ ...detail, blocks: [calloutBlock] }} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+  }
+
+  it('hides the edit affordance from a read-only viewer but still renders the callout', async () => {
+    auth.permissions = [{ resource: 'quotes', action: 'read' }];
+    await openEditor();
+    expect(screen.getByTestId('quote-block-callout-content-blk-c')).toBeInTheDocument();
+    expect(screen.queryByTestId('quote-block-callout-blk-c-edit')).not.toBeInTheDocument();
+  });
+
+  it('prefills variant, title and body when edit is opened', async () => {
+    await openEditor();
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit'));
+
+    expect(screen.getByTestId('quote-block-callout-blk-c-edit-form-variant')).toHaveValue('warn');
+    expect(screen.getByTestId('quote-block-callout-blk-c-edit-form-title')).toHaveValue('Heads up');
+    expect(screen.getByTestId('quote-block-callout-blk-c-edit-form-body')).toHaveValue('<p>Read carefully</p>');
+    expect(screen.queryByTestId('quote-block-callout-content-blk-c')).not.toBeInTheDocument();
+  });
+
+  it('saving PATCHes the edited content through updateBlock and closes the form', async () => {
+    updateBlockMock.mockResolvedValue(okRes({ id: 'blk-c' }));
+    await openEditor();
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit'));
+
+    fireEvent.change(screen.getByTestId('quote-block-callout-blk-c-edit-form-variant'), { target: { value: 'accent' } });
+    fireEvent.change(screen.getByTestId('quote-block-callout-blk-c-edit-form-body'), { target: { value: '<p>Revised</p>' } });
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit-save'));
+
+    await waitFor(() => expect(updateBlockMock).toHaveBeenCalledWith('q-1', 'blk-c', {
+      blockType: 'callout',
+      content: { variant: 'accent', title: 'Heads up', html: '<p>Revised</p>' },
+    }));
+    await waitFor(() => expect(screen.queryByTestId('quote-block-callout-blk-c-edit-form')).not.toBeInTheDocument());
+  });
+
+  it('clearing the title drops it from the PATCHed content (never sent as an empty string)', async () => {
+    updateBlockMock.mockResolvedValue(okRes({ id: 'blk-c' }));
+    await openEditor();
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit'));
+    fireEvent.change(screen.getByTestId('quote-block-callout-blk-c-edit-form-title'), { target: { value: '  ' } });
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit-save'));
+
+    await waitFor(() => expect(updateBlockMock).toHaveBeenCalledWith('q-1', 'blk-c', {
+      blockType: 'callout',
+      content: { variant: 'warn', html: '<p>Read carefully</p>' },
+    }));
+  });
+
+  it('an emptied body disables save (an empty callout renders as nothing)', async () => {
+    await openEditor();
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit'));
+    fireEvent.change(screen.getByTestId('quote-block-callout-blk-c-edit-form-body'), { target: { value: '' } });
+
+    expect(screen.getByTestId('quote-block-callout-blk-c-edit-save')).toBeDisabled();
+    expect(updateBlockMock).not.toHaveBeenCalled();
+  });
+
+  it('cancel discards the draft without PATCHing', async () => {
+    await openEditor();
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit'));
+    fireEvent.change(screen.getByTestId('quote-block-callout-blk-c-edit-form-body'), { target: { value: '<p>Discarded</p>' } });
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit-cancel'));
+
+    expect(updateBlockMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId('quote-block-callout-content-blk-c')).toHaveTextContent('Read carefully');
+
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit'));
+    expect(screen.getByTestId('quote-block-callout-blk-c-edit-form-body')).toHaveValue('<p>Read carefully</p>');
+  });
+
+  it('a failed save surfaces the error and leaves the form open with the draft intact', async () => {
+    updateBlockMock.mockResolvedValue(errRes());
+    await openEditor();
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit'));
+    fireEvent.change(screen.getByTestId('quote-block-callout-blk-c-edit-form-body'), { target: { value: '<p>Revised</p>' } });
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit-save'));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    expect(screen.getByTestId('quote-block-callout-blk-c-edit-form-body')).toHaveValue('<p>Revised</p>');
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tableblock.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tableblock.test.tsx
@@ -332,3 +332,68 @@ describe('QuoteEditor — edit persisted table block', () => {
     expect(screen.getByTestId('quote-block-table-blk-t-edit-form-cell-0-0')).toHaveValue('Switch');
   });
 });
+
+// Review follow-up (#3631): the defensive reshape in tableFormFromContent
+// DISCARDS content, so it must not be silent — and the paths it exists for
+// (out-of-cap / ragged legacy content) need real coverage.
+describe('QuoteEditor — persisted table needing reshape on edit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auth.permissions = [{ resource: '*', action: '*' }];
+  });
+
+  function renderWith(content: Record<string, unknown>) {
+    const block: QuoteBlock = {
+      id: 'blk-t', quoteId: 'q-1', orgId: 'org-1', blockType: 'table',
+      content, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+    };
+    render(<QuoteEditor detail={{ ...detail, blocks: [block] }} onChanged={vi.fn()} />);
+    return waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+  }
+
+  it('pads a ragged row to columns.length and warns that saving replaces the stored table', async () => {
+    updateBlockMock.mockResolvedValue(okRes({ id: 'blk-t' }));
+    // Row has ONE cell for TWO columns — the shape the server schema rejects.
+    await renderWith({ columns: [{ label: 'Item' }, { label: 'Notes' }], rows: [{ cells: ['Router'] }] });
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit'));
+
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-reshaped')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-form-cell-0-1')).toHaveValue('');
+
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit-save'));
+    await waitFor(() => expect(updateBlockMock).toHaveBeenCalledWith('q-1', 'blk-t', expect.objectContaining({
+      content: expect.objectContaining({ rows: [{ cells: ['Router', ''] }] }),
+    })));
+  });
+
+  it('does not warn when the stored content already fits', async () => {
+    await renderWith({ columns: [{ label: 'Item' }], rows: [{ cells: ['Router'] }] });
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit'));
+    expect(screen.queryByTestId('quote-block-table-blk-t-edit-reshaped')).not.toBeInTheDocument();
+  });
+
+  it('truncates a table past the 8-column cap, warns, and disables add-column at the cap', async () => {
+    const columns = Array.from({ length: 10 }, (_, i) => ({ label: `C${i}` }));
+    await renderWith({ columns, rows: [{ cells: columns.map((_, i) => `v${i}`) }] });
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit'));
+
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-reshaped')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-form-column-label-7')).toBeInTheDocument();
+    expect(screen.queryByTestId('quote-block-table-blk-t-edit-form-column-label-8')).not.toBeInTheDocument();
+    // Already at the cap, so the grid cannot grow further.
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-form-add-column')).toBeDisabled();
+  });
+
+  it('flashes the saved cue after a successful edit', async () => {
+    updateBlockMock.mockResolvedValue(okRes({ id: 'blk-t' }));
+    await renderWith({ columns: [{ label: 'Item' }], rows: [{ cells: ['Router'] }] });
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit'));
+    fireEvent.change(screen.getByTestId('quote-block-table-blk-t-edit-form-cell-0-0'), { target: { value: 'Switch' } });
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit-save'));
+
+    // The live region is always mounted — only its TEXT changes — so assert the
+    // announcement, not the element's presence (which would pass regardless).
+    expect(screen.getByTestId('quote-block-table-blk-t-saved')).toHaveTextContent('');
+    await waitFor(() => expect(screen.getByTestId('quote-block-table-blk-t-saved')).toHaveTextContent('Saved'));
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tableblock.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tableblock.test.tsx
@@ -3,7 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuoteEditor from './QuoteEditor';
 import type { QuoteDetail as QuoteDetailData, QuoteBlock } from './quoteTypes';
-import { addBlock } from '../../../lib/api/quotes';
+import { addBlock, updateBlock } from '../../../lib/api/quotes';
+
+// Mutable grant set so the edit-affordance gating (writer vs read-only) can be
+// exercised in this file; defaults to the wildcard the create tests assume.
+const auth = vi.hoisted(() => ({ permissions: [{ resource: '*', action: '*' }] as { resource: string; action: string }[] }));
 
 // This test targets the table-grid authoring UI (add/remove row+column, align,
 // zebra/headerStyle, submit wiring) — not TipTap internals, which
@@ -24,7 +28,7 @@ vi.mock('../../../stores/auth', () => ({
   ),
   useAuthStore: Object.assign(
     (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
-      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+      selector({ user: { permissions: auth.permissions } }),
     { getState: () => ({ tokens: null }) },
   ),
 }));
@@ -75,6 +79,7 @@ const detail: QuoteDetailData = {
 };
 
 const addBlockMock = vi.mocked(addBlock);
+const updateBlockMock = vi.mocked(updateBlock);
 
 async function openTableForm() {
   render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
@@ -218,5 +223,112 @@ describe('QuoteEditor — persisted table block', () => {
     expect(content).toHaveTextContent('Item');
     expect(content).toHaveTextContent('Router');
     expect(content).toHaveTextContent('Hardware');
+  });
+});
+
+// #3547: editing a persisted table used to mean delete-and-recreate. The edit
+// affordance reuses the create-form fields, prefilled from block.content, and
+// saves through the same updateBlock path the contract block established.
+describe('QuoteEditor — edit persisted table block', () => {
+  const tableBlock: QuoteBlock = {
+    id: 'blk-t', quoteId: 'q-1', orgId: 'org-1', blockType: 'table',
+    content: {
+      columns: [{ label: 'Item' }, { label: 'Notes', align: 'right' }],
+      rows: [{ cells: ['Router', 'Optional'] }],
+      caption: 'Hardware',
+    },
+    sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auth.permissions = [{ resource: '*', action: '*' }];
+  });
+
+  async function openEditor() {
+    render(<QuoteEditor detail={{ ...detail, blocks: [tableBlock] }} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+  }
+
+  it('hides the edit affordance from a read-only viewer but still renders the table', async () => {
+    auth.permissions = [{ resource: 'quotes', action: 'read' }];
+    await openEditor();
+    expect(screen.getByTestId('quote-block-table-content-blk-t')).toBeInTheDocument();
+    expect(screen.queryByTestId('quote-block-table-blk-t-edit')).not.toBeInTheDocument();
+  });
+
+  it('prefills the grid from the persisted content when edit is opened', async () => {
+    await openEditor();
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit'));
+
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-form-column-label-0')).toHaveValue('Item');
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-form-column-label-1')).toHaveValue('Notes');
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-form-column-align-1')).toHaveValue('right');
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-form-cell-0-0')).toHaveValue('Router');
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-form-cell-0-1')).toHaveValue('Optional');
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-form-caption')).toHaveValue('Hardware');
+    // The read-only render is replaced by the form while editing.
+    expect(screen.queryByTestId('quote-block-table-content-blk-t')).not.toBeInTheDocument();
+  });
+
+  it('saving PATCHes the edited grid through updateBlock and closes the form', async () => {
+    updateBlockMock.mockResolvedValue(okRes({ id: 'blk-t' }));
+    await openEditor();
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit'));
+
+    fireEvent.change(screen.getByTestId('quote-block-table-blk-t-edit-form-cell-0-0'), { target: { value: 'Switch' } });
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit-save'));
+
+    await waitFor(() => expect(updateBlockMock).toHaveBeenCalledWith('q-1', 'blk-t', {
+      blockType: 'table',
+      content: {
+        columns: [{ label: 'Item' }, { label: 'Notes', align: 'right' }],
+        rows: [{ cells: ['Switch', 'Optional'] }],
+        caption: 'Hardware',
+        zebra: false,
+        headerStyle: 'plain',
+      },
+    }));
+    // Form closes on success, returning the canvas to the rendered table.
+    await waitFor(() => expect(screen.queryByTestId('quote-block-table-blk-t-edit-form')).not.toBeInTheDocument());
+  });
+
+  it('keeps grid mutations shape-valid: adding a column pads the persisted row', async () => {
+    updateBlockMock.mockResolvedValue(okRes({ id: 'blk-t' }));
+    await openEditor();
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit'));
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit-form-add-column'));
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit-save'));
+
+    await waitFor(() => expect(updateBlockMock).toHaveBeenCalledWith('q-1', 'blk-t', expect.objectContaining({
+      content: expect.objectContaining({
+        columns: [{ label: 'Item' }, { label: 'Notes', align: 'right' }, { label: '' }],
+        rows: [{ cells: ['Router', 'Optional', ''] }],
+      }),
+    })));
+  });
+
+  it('cancel discards the draft without PATCHing, and reopening shows the persisted content again', async () => {
+    await openEditor();
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit'));
+    fireEvent.change(screen.getByTestId('quote-block-table-blk-t-edit-form-cell-0-0'), { target: { value: 'Discarded' } });
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit-cancel'));
+
+    expect(updateBlockMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId('quote-block-table-content-blk-t')).toHaveTextContent('Router');
+
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit'));
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-form-cell-0-0')).toHaveValue('Router');
+  });
+
+  it('a failed save surfaces the error and leaves the form open with the draft intact', async () => {
+    updateBlockMock.mockResolvedValue(errRes());
+    await openEditor();
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit'));
+    fireEvent.change(screen.getByTestId('quote-block-table-blk-t-edit-form-cell-0-0'), { target: { value: 'Switch' } });
+    fireEvent.click(screen.getByTestId('quote-block-table-blk-t-edit-save'));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    expect(screen.getByTestId('quote-block-table-blk-t-edit-form-cell-0-0')).toHaveValue('Switch');
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -28,16 +28,25 @@ import {
   type ContractTemplateDetail,
   type TemplateVersionSummary,
 } from '../../../lib/api/contractTemplates';
-import type { QuoteBlockInput, CoverPage, QuoteTableColumn, QuoteCalloutContent } from '@breeze/shared';
+import type { QuoteBlockInput, CoverPage } from '@breeze/shared';
 import { computeQuoteTotals, computeQuoteProfit, priceFromMarkup, toQuoteDepositConfig, type QuoteLineForMath, type QuoteProfit, type QuoteTotals, type QuoteDepositType, type QuoteDepositConfig } from '@breeze/shared';
 import { listCatalog, createCatalogItem, type CatalogItem } from '../../../lib/api/catalog';
 import { ecExpressStatus, ecExpressImport, type EcProduct, type EcStatus, pax8Status, pax8Import, type Pax8Product, type Pax8PriceOption } from '../../../lib/api/distributors';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import { showToast } from '../../shared/Toast';
 import RichTextEditor from '../../common/RichTextEditor';
-import InlineRichTextEditor from '../../common/InlineRichTextEditor';
 import PolishButton from '../../catalog/PolishButton';
 import { BlockCard, QuoteImagePreview } from './QuoteBlockCard';
+import {
+  TableBlockFields,
+  CalloutBlockFields,
+  freshTableForm,
+  freshCalloutForm,
+  tableFormToContent,
+  calloutFormToContent,
+  type TableFormState,
+  type CalloutFormState,
+} from './QuoteBlockContentForms';
 import { QuoteBulkBar } from './QuoteBulkBar';
 import { UnassignedLines } from './QuoteUnassignedLines';
 import { UNAUTHORIZED, type LineUpdate, SrSaved, fieldRing, pendingKey, useSavedFlash, useShowInternalMargin } from './quoteEditorShared';
@@ -71,16 +80,6 @@ const ADD_BLOCK_OPTIONS: { value: AddableBlockType; labelKey: string }[] = [
   { value: 'table', labelKey: 'quotes.editor.blockTypes.table' },
   { value: 'callout', labelKey: 'quotes.editor.blockTypes.callout' },
 ];
-
-/** Fresh 2x2 grid the table form starts from (and resets to after a submit) —
- *  small enough to see the whole shape at a glance, with both add row/column
- *  actions immediately meaningful (removing either lands at the 1x1 floor). */
-function freshTableColumns(): QuoteTableColumn[] {
-  return [{ label: '' }, { label: '' }];
-}
-function freshTableRows(columnCount: number): { cells: string[] }[] {
-  return [{ cells: Array(columnCount).fill('') }, { cells: Array(columnCount).fill('') }];
-}
 
 
 // Grace window for undo-able line/section deletion: the item leaves the UI
@@ -361,57 +360,16 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   const [imageUrl, setImageUrl] = useState('');
 
   // ---- add table block ------------------------------------------------------
-  // `tableRows[i].cells.length` is kept equal to `tableColumns.length` at every
-  // mutation (add/remove column pads/trims every row in the same setState) —
-  // the same exact-shape invariant quoteTableContentSchema enforces server-side,
-  // so the POST body can never trip its row-length refinement.
-  const [tableColumns, setTableColumns] = useState<QuoteTableColumn[]>(freshTableColumns);
-  const [tableRows, setTableRows] = useState<{ cells: string[] }[]>(() => freshTableRows(2));
-  const [tableCaption, setTableCaption] = useState('');
-  const [tableZebra, setTableZebra] = useState(false);
-  const [tableHeaderStyle, setTableHeaderStyle] = useState<'accent' | 'plain'>('plain');
-
-  const resetTableForm = useCallback(() => {
-    setTableColumns(freshTableColumns());
-    setTableRows(freshTableRows(2));
-    setTableCaption('');
-    setTableZebra(false);
-    setTableHeaderStyle('plain');
-  }, []);
-
-  const addTableColumn = useCallback(() => {
-    setTableColumns((cols) => (cols.length >= 8 ? cols : [...cols, { label: '' }]));
-    setTableRows((rows) => (rows.length > 0 && rows[0].cells.length >= 8 ? rows : rows.map((r) => ({ cells: [...r.cells, ''] }))));
-  }, []);
-  const removeTableColumn = useCallback((idx: number) => {
-    setTableColumns((cols) => (cols.length <= 1 ? cols : cols.filter((_, i) => i !== idx)));
-    setTableRows((rows) => (rows.length > 0 && rows[0].cells.length <= 1 ? rows : rows.map((r) => ({ cells: r.cells.filter((_, i) => i !== idx) }))));
-  }, []);
-  const addTableRow = useCallback(() => {
-    setTableRows((rows) => (rows.length >= 100 ? rows : [...rows, { cells: Array(tableColumns.length).fill('') }]));
-  }, [tableColumns.length]);
-  const removeTableRow = useCallback((idx: number) => {
-    setTableRows((rows) => (rows.length <= 1 ? rows : rows.filter((_, i) => i !== idx)));
-  }, []);
-  const setTableColumnLabel = useCallback((idx: number, label: string) => {
-    setTableColumns((cols) => cols.map((c, i) => (i === idx ? { ...c, label } : c)));
-  }, []);
-  const setTableColumnAlign = useCallback((idx: number, align: QuoteTableColumn['align']) => {
-    setTableColumns((cols) => cols.map((c, i) => (i === idx ? { ...c, align } : c)));
-  }, []);
-  const setTableCell = useCallback((rowIdx: number, colIdx: number, html: string) => {
-    setTableRows((rows) => rows.map((r, i) => (i === rowIdx ? { cells: r.cells.map((c, j) => (j === colIdx ? html : c)) } : r)));
-  }, []);
+  // The grid fields (and the "every row has exactly columns.length cells"
+  // invariant quoteTableContentSchema enforces server-side) live in
+  // QuoteBlockContentForms, shared with the edit-in-place affordance on a
+  // persisted block — so the two surfaces can never drift.
+  const [tableFormState, setTableFormState] = useState<TableFormState>(freshTableForm);
+  const resetTableForm = useCallback(() => setTableFormState(freshTableForm()), []);
 
   // ---- add callout block -----------------------------------------------------
-  const [calloutVariant, setCalloutVariant] = useState<QuoteCalloutContent['variant']>('info');
-  const [calloutTitle, setCalloutTitle] = useState('');
-  const [calloutHtml, setCalloutHtml] = useState('');
-  const resetCalloutForm = useCallback(() => {
-    setCalloutVariant('info');
-    setCalloutTitle('');
-    setCalloutHtml('');
-  }, []);
+  const [calloutFormState, setCalloutFormState] = useState<CalloutFormState>(freshCalloutForm);
+  const resetCalloutForm = useCallback(() => setCalloutFormState(freshCalloutForm()), []);
 
   // ---- add contract block --------------------------------------------------
   // The template library for the picker, loaded lazily the first time the
@@ -1306,13 +1264,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
         const created = await runAction<{ id?: string }>({
           request: () => addBlock(quote.id, {
             blockType: 'table' as const,
-            content: {
-              columns: tableColumns,
-              rows: tableRows.map((r) => ({ cells: r.cells })),
-              ...(tableCaption.trim() ? { caption: tableCaption.trim() } : {}),
-              zebra: tableZebra,
-              headerStyle: tableHeaderStyle,
-            },
+            content: tableFormToContent(tableFormState),
           } as QuoteBlockInput),
           errorFallback: t('quotes.editor.errors.addSection'),
           // No success toast — the new table visibly appears in the block list.
@@ -1328,16 +1280,12 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
     }
 
     if (addType === 'callout') {
-      if (!calloutHtml.trim()) return;
+      if (!calloutFormState.html.trim()) return;
       await runScoped('add-block', async () => {
         const created = await runAction<{ id?: string }>({
           request: () => addBlock(quote.id, {
             blockType: 'callout' as const,
-            content: {
-              variant: calloutVariant,
-              ...(calloutTitle.trim() ? { title: calloutTitle.trim() } : {}),
-              html: calloutHtml,
-            },
+            content: calloutFormToContent(calloutFormState),
           } as QuoteBlockInput),
           errorFallback: t('quotes.editor.errors.addSection'),
           // No success toast — the new callout visibly appears in the block list.
@@ -1378,7 +1326,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
       setInsertAt(null);
       refresh();
     }, t('quotes.editor.errors.addSection'));
-  }, [addType, headingText, richText, tableLabel, imageFile, imageCaption, imageSource, imageUrl, contractTemplateId, contractVersion, contractVarValues, contractLabel, resetContractForm, tableColumns, tableRows, tableCaption, tableZebra, tableHeaderStyle, resetTableForm, calloutVariant, calloutTitle, calloutHtml, resetCalloutForm, positionNewBlock, quote.id, refresh, runScoped, t]);
+  }, [addType, headingText, richText, tableLabel, imageFile, imageCaption, imageSource, imageUrl, contractTemplateId, contractVersion, contractVarValues, contractLabel, resetContractForm, tableFormState, resetTableForm, calloutFormState, resetCalloutForm, positionNewBlock, quote.id, refresh, runScoped, t]);
 
 
   // Removing a line_items block cascades to every line under it (server-side), so
@@ -2280,173 +2228,11 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
             )}
 
             {addType === 'table' && (
-              <div className="mb-3 space-y-3" data-testid="quote-block-table">
-                <div className="overflow-x-auto">
-                  <table className="w-full min-w-[32rem] border-separate border-spacing-1 text-xs">
-                    <thead>
-                      <tr>
-                        {tableColumns.map((col, colIdx) => (
-                          <th key={colIdx} className="text-left font-normal">
-                            <div className="flex items-center gap-1">
-                              <input
-                                type="text"
-                                value={col.label}
-                                maxLength={200}
-                                onChange={(e) => setTableColumnLabel(colIdx, e.target.value)}
-                                placeholder={t('quotes.editor.table.columnLabelPlaceholder')}
-                                data-testid={`quote-block-table-column-label-${colIdx}`}
-                                className="h-8 w-full rounded-md border bg-background px-2 text-xs focus:outline-hidden focus:ring-2 focus:ring-ring"
-                              />
-                              <select
-                                value={col.align ?? 'left'}
-                                onChange={(e) => setTableColumnAlign(colIdx, e.target.value as QuoteTableColumn['align'])}
-                                aria-label={t('quotes.editor.table.columnAlignAria')}
-                                data-testid={`quote-block-table-column-align-${colIdx}`}
-                                className="h-8 rounded-md border bg-background px-1 text-xs focus:outline-hidden focus:ring-2 focus:ring-ring"
-                              >
-                                <option value="left">{t('quotes.editor.table.alignLeft')}</option>
-                                <option value="center">{t('quotes.editor.table.alignCenter')}</option>
-                                <option value="right">{t('quotes.editor.table.alignRight')}</option>
-                              </select>
-                              <button
-                                type="button"
-                                onClick={() => removeTableColumn(colIdx)}
-                                disabled={tableColumns.length <= 1}
-                                aria-label={t('quotes.editor.table.removeColumn')}
-                                title={t('quotes.editor.table.removeColumn')}
-                                data-testid={`quote-block-table-remove-column-${colIdx}`}
-                                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted disabled:opacity-40"
-                              >
-                                &times;
-                              </button>
-                            </div>
-                          </th>
-                        ))}
-                        <th className="w-8">
-                          <button
-                            type="button"
-                            onClick={addTableColumn}
-                            disabled={tableColumns.length >= 8}
-                            aria-label={t('quotes.editor.table.addColumn')}
-                            title={t('quotes.editor.table.addColumn')}
-                            data-testid="quote-block-table-add-column"
-                            className="inline-flex h-8 w-8 items-center justify-center rounded-md border text-muted-foreground hover:bg-muted disabled:opacity-40"
-                          >
-                            +
-                          </button>
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {tableRows.map((row, rowIdx) => (
-                        <tr key={rowIdx}>
-                          {row.cells.map((cell, colIdx) => (
-                            <td key={colIdx} className="align-top">
-                              <InlineRichTextEditor
-                                value={cell}
-                                onChange={(html) => setTableCell(rowIdx, colIdx, html)}
-                                ariaLabel={t('quotes.editor.table.cellAria', { row: rowIdx + 1, column: colIdx + 1 })}
-                                testId={`quote-block-table-cell-${rowIdx}-${colIdx}`}
-                                maxLength={2000}
-                              />
-                            </td>
-                          ))}
-                          <td className="align-top">
-                            <button
-                              type="button"
-                              onClick={() => removeTableRow(rowIdx)}
-                              disabled={tableRows.length <= 1}
-                              aria-label={t('quotes.editor.table.removeRow')}
-                              title={t('quotes.editor.table.removeRow')}
-                              data-testid={`quote-block-table-remove-row-${rowIdx}`}
-                              className="inline-flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted disabled:opacity-40"
-                            >
-                              &times;
-                            </button>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-                <button
-                  type="button"
-                  onClick={addTableRow}
-                  disabled={tableRows.length >= 100}
-                  data-testid="quote-block-table-add-row"
-                  className="inline-flex h-8 items-center justify-center rounded-md border px-3 text-xs font-medium text-muted-foreground hover:bg-muted disabled:opacity-40"
-                >
-                  {t('quotes.editor.table.addRow')}
-                </button>
-                <input
-                  type="text"
-                  value={tableCaption}
-                  maxLength={300}
-                  onChange={(e) => setTableCaption(e.target.value)}
-                  placeholder={t('quotes.editor.table.captionPlaceholder')}
-                  data-testid="quote-block-table-caption"
-                  className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                />
-                <div className="flex flex-wrap items-center gap-4">
-                  <label className="inline-flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
-                    <input
-                      type="checkbox"
-                      checked={tableZebra}
-                      onChange={(e) => setTableZebra(e.target.checked)}
-                      data-testid="quote-block-table-zebra"
-                    />
-                    {t('quotes.editor.table.zebra')}
-                  </label>
-                  <label className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-                    {t('quotes.editor.table.headerStyle')}
-                    <select
-                      value={tableHeaderStyle}
-                      onChange={(e) => setTableHeaderStyle(e.target.value as 'accent' | 'plain')}
-                      data-testid="quote-block-table-header-style"
-                      className="h-8 rounded-md border bg-background px-2 text-xs focus:outline-hidden focus:ring-2 focus:ring-ring"
-                    >
-                      <option value="plain">{t('quotes.editor.table.headerStylePlain')}</option>
-                      <option value="accent">{t('quotes.editor.table.headerStyleAccent')}</option>
-                    </select>
-                  </label>
-                </div>
-              </div>
+              <TableBlockFields value={tableFormState} onChange={setTableFormState} />
             )}
 
             {addType === 'callout' && (
-              <div className="mb-3 space-y-3" data-testid="quote-block-callout">
-                <div>
-                  <label htmlFor="quote-block-callout-variant" className="mb-1 block text-xs text-muted-foreground">
-                    {t('quotes.editor.callout.variantLabel')}
-                  </label>
-                  <select
-                    id="quote-block-callout-variant"
-                    value={calloutVariant}
-                    onChange={(e) => setCalloutVariant(e.target.value as QuoteCalloutContent['variant'])}
-                    data-testid="quote-block-callout-variant"
-                    className="h-9 w-full rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                  >
-                    <option value="info">{t('quotes.editor.callout.variantInfo')}</option>
-                    <option value="accent">{t('quotes.editor.callout.variantAccent')}</option>
-                    <option value="warn">{t('quotes.editor.callout.variantWarn')}</option>
-                  </select>
-                </div>
-                <input
-                  type="text"
-                  value={calloutTitle}
-                  maxLength={200}
-                  onChange={(e) => setCalloutTitle(e.target.value)}
-                  placeholder={t('quotes.editor.callout.titlePlaceholder')}
-                  data-testid="quote-block-callout-title"
-                  className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                />
-                <RichTextEditor
-                  value={calloutHtml}
-                  onChange={setCalloutHtml}
-                  ariaLabel={t('quotes.editor.callout.bodyAria')}
-                  testId="quote-block-callout-body"
-                />
-              </div>
+              <CalloutBlockFields value={calloutFormState} onChange={setCalloutFormState} />
             )}
 
             <div className="flex justify-end">
@@ -2460,7 +2246,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
                   (addType === 'image' && imageSource === 'file' && !imageFile) ||
                   (addType === 'image' && imageSource === 'url' && !imageUrl.trim()) ||
                   (addType === 'contract' && !contractVersion) ||
-                  (addType === 'callout' && !calloutHtml.trim())
+                  (addType === 'callout' && !calloutFormState.html.trim())
                 }
                 data-testid="quote-add-block-submit"
                 className="inline-flex h-9 items-center justify-center rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:opacity-50"

--- a/apps/web/src/components/billing/quotes/QuoteStructuredBlockEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteStructuredBlockEditor.tsx
@@ -1,0 +1,259 @@
+// Edit-in-place for the persisted structured blocks (`table` / `callout`) —
+// issue #3547. Before this, changing a shipped table meant delete-and-recreate,
+// which is a real papercut on a large grid.
+//
+// Shape follows the contract block's precedent (QuoteContractBlockEditor):
+// the block owns its own draft, saves through the parent's `onEditBlock`
+// (→ updateBlock → PATCH /quotes/:id/blocks/:blockId), and flashes SrSaved on
+// success. It differs in one deliberate way: contract blocks render their form
+// unconditionally, but a table/callout's *rendered* form IS its content on the
+// canvas (a table should look like a table), so editing is behind an explicit
+// affordance and the read-only render stays the resting state.
+//
+// The fields themselves are the create-form's, imported from
+// QuoteBlockContentForms and prefilled from the block's current content.
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import '../../../lib/i18n';
+import { type QuoteBlock, type QuoteTableContent, type QuoteCalloutContent } from './quoteTypes';
+import { SrSaved } from './quoteEditorShared';
+import {
+  TableBlockFields,
+  CalloutBlockFields,
+  tableFormFromContent,
+  tableFormToContent,
+  calloutFormFromContent,
+  calloutFormToContent,
+  type TableFormState,
+  type CalloutFormState,
+} from './QuoteBlockContentForms';
+
+/** Quiet "Saved" flash, cleared on unmount so a late timer can't setState a
+ *  block that has since been removed (same guard BlockCard uses). */
+function useSavedFlash(): [boolean, () => void] {
+  const [saved, setSaved] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+  const flash = useCallback(() => {
+    setSaved(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setSaved(false), 1500);
+  }, []);
+  return [saved, flash];
+}
+
+function EditToolbar({
+  editing, busy, canSave, onEdit, onCancel, onSave, idBase, saved,
+}: {
+  editing: boolean;
+  busy: boolean;
+  canSave: boolean;
+  onEdit: () => void;
+  onCancel: () => void;
+  onSave: () => void;
+  idBase: string;
+  saved: boolean;
+}) {
+  const { t } = useTranslation('billing');
+  return (
+    <div className="mb-1 flex items-center gap-2">
+      <SrSaved show={saved} testId={`${idBase}-saved`} />
+      {editing ? (
+        <>
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={busy || !canSave}
+            data-testid={`${idBase}-edit-save`}
+            className="ml-auto inline-flex h-8 items-center justify-center rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {t('quotes.editor.block.saveEdit')}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            data-testid={`${idBase}-edit-cancel`}
+            className="inline-flex h-8 items-center justify-center rounded-md border px-3 text-xs font-medium hover:bg-muted disabled:opacity-50"
+          >
+            {t('quotes.editor.actions.cancel')}
+          </button>
+        </>
+      ) : (
+        <button
+          type="button"
+          onClick={onEdit}
+          disabled={busy}
+          data-testid={`${idBase}-edit`}
+          className="ml-auto inline-flex h-8 items-center justify-center rounded-md border px-3 text-xs font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+        >
+          {t('quotes.editor.block.edit')}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function TableBlockEditor({
+  block, canWrite, busy, onEditBlock,
+}: {
+  block: QuoteBlock;
+  canWrite: boolean;
+  busy: boolean;
+  onEditBlock: (block: QuoteBlock, content: Record<string, unknown>) => Promise<boolean>;
+}) {
+  const { t } = useTranslation('billing');
+  // `null` = not editing. Seeded from the block's content on open, so a
+  // background refresh while the form is closed is always picked up, and one
+  // mid-edit can never clobber the user's draft.
+  const [form, setForm] = useState<TableFormState | null>(null);
+  const [saved, flash] = useSavedFlash();
+  const content = block.content as Partial<QuoteTableContent> | undefined;
+  const idBase = `quote-block-table-${block.id}`;
+
+  const save = useCallback(async () => {
+    if (!form) return;
+    if (await onEditBlock(block, tableFormToContent(form))) {
+      setForm(null);
+      flash();
+    }
+  }, [form, block, onEditBlock, flash]);
+
+  const body = form ? (
+    <TableBlockFields
+      value={form}
+      onChange={setForm}
+      idPrefix={`${idBase}-edit-form`}
+      disabled={busy}
+    />
+  ) : !content?.columns?.length || !content?.rows?.length ? (
+    <p className="text-sm text-muted-foreground" data-testid={`quote-block-table-content-${block.id}`}>
+      {t('quotes.editor.block.tableEmpty')}
+    </p>
+  ) : (
+    // Structured JSON, never HTML-parsed — column labels and cell values are
+    // sanitized server-side with the inline-only profile on both write and read
+    // (quoteService's read-path sanitizer), same dangerouslySetInnerHTML
+    // precedent as QuoteDocument.tsx's canonical table rendering, which this
+    // mirrors.
+    <div className="overflow-x-auto" data-testid={`quote-block-table-content-${block.id}`}>
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className={content.headerStyle === 'plain' ? 'border-b-2' : 'border-b-2 bg-primary/10'}>
+            {content.columns.map((col, i) => (
+              <th
+                key={i}
+                style={{ textAlign: col.align ?? 'left' }}
+                className="px-3 py-2 font-semibold text-foreground"
+                dangerouslySetInnerHTML={{ __html: col.label }}
+              />
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {content.rows.map((row, ri) => (
+            <tr key={ri} className={content.zebra && ri % 2 === 1 ? 'bg-muted/30' : undefined}>
+              {row.cells.map((cell, ci) => (
+                <td
+                  key={ci}
+                  style={{ textAlign: content.columns?.[ci]?.align ?? 'left' }}
+                  className="px-3 py-2 align-top text-foreground/90"
+                  dangerouslySetInnerHTML={{ __html: cell }}
+                />
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {content.caption && <p className="mt-1 text-xs text-muted-foreground">{content.caption}</p>}
+    </div>
+  );
+
+  if (!canWrite) return body;
+  return (
+    <div>
+      <EditToolbar
+        editing={form !== null}
+        busy={busy}
+        canSave
+        onEdit={() => setForm(tableFormFromContent(block.content))}
+        onCancel={() => setForm(null)}
+        onSave={() => void save()}
+        idBase={idBase}
+        saved={saved}
+      />
+      {body}
+    </div>
+  );
+}
+
+export function CalloutBlockEditor({
+  block, canWrite, busy, onEditBlock,
+}: {
+  block: QuoteBlock;
+  canWrite: boolean;
+  busy: boolean;
+  onEditBlock: (block: QuoteBlock, content: Record<string, unknown>) => Promise<boolean>;
+}) {
+  const { t } = useTranslation('billing');
+  const [form, setForm] = useState<CalloutFormState | null>(null);
+  const [saved, flash] = useSavedFlash();
+  const content = block.content as Partial<QuoteCalloutContent> | undefined;
+  const idBase = `quote-block-callout-${block.id}`;
+
+  const save = useCallback(async () => {
+    if (!form || !form.html.trim()) return;
+    if (await onEditBlock(block, calloutFormToContent(form))) {
+      setForm(null);
+      flash();
+    }
+  }, [form, block, onEditBlock, flash]);
+
+  const tone =
+    content?.variant === 'warn'
+      ? 'border-amber-500/40 bg-amber-500/10'
+      : content?.variant === 'accent'
+        ? 'border-primary/40 bg-primary/10'
+        : 'border-border bg-muted/40';
+
+  const body = form ? (
+    <CalloutBlockFields
+      value={form}
+      onChange={setForm}
+      idPrefix={`${idBase}-edit-form`}
+      disabled={busy}
+    />
+  ) : !content?.html?.trim() ? (
+    <p className="text-sm text-muted-foreground" data-testid={`quote-block-callout-content-${block.id}`}>
+      {t('quotes.editor.block.calloutEmpty')}
+    </p>
+  ) : (
+    // Same server-sanitized-HTML precedent as rich_text.
+    <div className={`rounded-lg border-l-4 p-4 ${tone}`} data-testid={`quote-block-callout-content-${block.id}`}>
+      {content.title && <p className="mb-1 text-sm font-semibold text-foreground">{content.title}</p>}
+      <div
+        className="quote-rich-text prose prose-sm max-w-prose dark:prose-invert"
+        dangerouslySetInnerHTML={{ __html: content.html }}
+      />
+    </div>
+  );
+
+  if (!canWrite) return body;
+  return (
+    <div>
+      <EditToolbar
+        editing={form !== null}
+        busy={busy}
+        // An empty body is not a valid callout (quoteCalloutContentSchema aside,
+        // it renders as nothing) — same gate the add form applies to submit.
+        canSave={form !== null && form.html.trim() !== ''}
+        onEdit={() => setForm(calloutFormFromContent(block.content))}
+        onCancel={() => setForm(null)}
+        onSave={() => void save()}
+        idBase={idBase}
+        saved={saved}
+      />
+      {body}
+    </div>
+  );
+}

--- a/apps/web/src/components/billing/quotes/QuoteStructuredBlockEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteStructuredBlockEditor.tsx
@@ -12,42 +12,31 @@
 //
 // The fields themselves are the create-form's, imported from
 // QuoteBlockContentForms and prefilled from the block's current content.
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../../../lib/i18n';
 import { type QuoteBlock, type QuoteTableContent, type QuoteCalloutContent } from './quoteTypes';
-import { SrSaved } from './quoteEditorShared';
+import { SrSaved, useSavedFlash } from './quoteEditorShared';
 import {
   TableBlockFields,
   CalloutBlockFields,
   tableFormFromContent,
   tableFormToContent,
+  MAX_TABLE_COLUMNS,
+  MAX_TABLE_ROWS,
   calloutFormFromContent,
   calloutFormToContent,
   type TableFormState,
   type CalloutFormState,
 } from './QuoteBlockContentForms';
 
-/** Quiet "Saved" flash, cleared on unmount so a late timer can't setState a
- *  block that has since been removed (same guard BlockCard uses). */
-function useSavedFlash(): [boolean, () => void] {
-  const [saved, setSaved] = useState(false);
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
-  const flash = useCallback(() => {
-    setSaved(true);
-    if (timer.current) clearTimeout(timer.current);
-    timer.current = setTimeout(() => setSaved(false), 1500);
-  }, []);
-  return [saved, flash];
-}
-
 function EditToolbar({
-  editing, busy, canSave, onEdit, onCancel, onSave, idBase, saved,
+  editing, busy, canSave = true, onEdit, onCancel, onSave, idBase, saved,
 }: {
   editing: boolean;
   busy: boolean;
-  canSave: boolean;
+  /** Omitted where there is nothing to gate on (see TableBlockEditor). */
+  canSave?: boolean;
   onEdit: () => void;
   onCancel: () => void;
   onSave: () => void;
@@ -107,25 +96,46 @@ export function TableBlockEditor({
   // background refresh while the form is closed is always picked up, and one
   // mid-edit can never clobber the user's draft.
   const [form, setForm] = useState<TableFormState | null>(null);
+  // Set when seeding had to reshape the stored content to fit the caps / the
+  // exact-cells contract. Saving would then overwrite the block with the
+  // reshaped version, so the user is told before they can do that.
+  const [reshaped, setReshaped] = useState(false);
   const [saved, flash] = useSavedFlash();
   const content = block.content as Partial<QuoteTableContent> | undefined;
   const idBase = `quote-block-table-${block.id}`;
 
+  const openEdit = useCallback(() => {
+    const seed = tableFormFromContent(block.content);
+    setForm(seed.form);
+    setReshaped(seed.adjusted);
+  }, [block.content]);
+  const closeEdit = useCallback(() => { setForm(null); setReshaped(false); }, []);
+
   const save = useCallback(async () => {
     if (!form) return;
     if (await onEditBlock(block, tableFormToContent(form))) {
-      setForm(null);
+      closeEdit();
       flash();
     }
-  }, [form, block, onEditBlock, flash]);
+  }, [form, block, onEditBlock, flash, closeEdit]);
 
   const body = form ? (
-    <TableBlockFields
-      value={form}
-      onChange={setForm}
-      idPrefix={`${idBase}-edit-form`}
-      disabled={busy}
-    />
+    <>
+      {reshaped && (
+        <p
+          className="mb-2 rounded-md border border-warning/40 bg-warning/10 px-2 py-1 text-xs text-warning-foreground dark:text-warning"
+          data-testid={`${idBase}-edit-reshaped`}
+        >
+          {t('quotes.editor.table.reshapedWarning', { columns: MAX_TABLE_COLUMNS, rows: MAX_TABLE_ROWS })}
+        </p>
+      )}
+      <TableBlockFields
+        value={form}
+        onChange={setForm}
+        idPrefix={`${idBase}-edit-form`}
+        disabled={busy}
+      />
+    </>
   ) : !content?.columns?.length || !content?.rows?.length ? (
     <p className="text-sm text-muted-foreground" data-testid={`quote-block-table-content-${block.id}`}>
       {t('quotes.editor.block.tableEmpty')}
@@ -175,9 +185,11 @@ export function TableBlockEditor({
       <EditToolbar
         editing={form !== null}
         busy={busy}
-        canSave
-        onEdit={() => setForm(tableFormFromContent(block.content))}
-        onCancel={() => setForm(null)}
+        // No validity gate, deliberately: the grid mutators keep the shape
+        // schema-valid at all times and empty labels/cells are legal (the add
+        // form submits a blank grid too), so there is nothing to gate on.
+        onEdit={openEdit}
+        onCancel={closeEdit}
         onSave={() => void save()}
         idBase={idBase}
         saved={saved}

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -512,7 +512,9 @@
         "imageSectionPdf": "Bildausschnitt (gerendert im PDF).",
         "richTextContentAria": "Rich-Text-Inhalt",
         "tableEmpty": "Leere Tabelle.",
-        "calloutEmpty": "Leere Hinweisbox."
+        "calloutEmpty": "Leere Hinweisbox.",
+        "edit": "Bearbeiten",
+        "saveEdit": "Speichern"
       },
       "blockTypes": {
         "heading": "Überschrift",

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -749,7 +749,8 @@
         "zebra": "Zebrastreifen",
         "headerStyle": "Kopfzeilenstil",
         "headerStylePlain": "Einfach",
-        "headerStyleAccent": "Akzent"
+        "headerStyleAccent": "Akzent",
+        "reshapedWarning": "Diese Tabelle überschritt das Limit von {{columns}} Spalten x {{rows}} Zeilen und wurde angepasst. Beim Speichern wird die gespeicherte Tabelle durch die hier angezeigte ersetzt."
       },
       "terms": {
         "placeholder": "Zahlungsbedingungen, Garantieklauseln usw.",

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -512,7 +512,9 @@
         "imageSectionPdf": "Image section (rendered in the PDF).",
         "richTextContentAria": "Rich text content",
         "tableEmpty": "Empty table.",
-        "calloutEmpty": "Empty callout."
+        "calloutEmpty": "Empty callout.",
+        "edit": "Edit",
+        "saveEdit": "Save"
       },
       "blockTypes": {
         "heading": "Heading",

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -749,7 +749,8 @@
         "zebra": "Zebra stripes",
         "headerStyle": "Header style",
         "headerStylePlain": "Plain",
-        "headerStyleAccent": "Accent"
+        "headerStyleAccent": "Accent",
+        "reshapedWarning": "This table didn't fit the {{columns}}-column x {{rows}}-row limit, so it was reshaped to fit. Saving replaces the stored table with what you see here."
       },
       "terms": {
         "placeholder": "Payment terms, warranty clauses, etc.",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -749,7 +749,8 @@
         "zebra": "Filas alternadas",
         "headerStyle": "Estilo de encabezado",
         "headerStylePlain": "Simple",
-        "headerStyleAccent": "Acento"
+        "headerStyleAccent": "Acento",
+        "reshapedWarning": "Esta tabla no cabía en el límite de {{columns}} columnas x {{rows}} filas, así que se ajustó. Al guardar, se reemplaza la tabla almacenada por la que ves aquí."
       },
       "terms": {
         "placeholder": "Condiciones de pago, cláusulas de garantía, etc.",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -512,7 +512,9 @@
         "imageSectionPdf": "Sección de imagen (representada en PDF).",
         "richTextContentAria": "Contenido de texto enriquecido",
         "tableEmpty": "Tabla vacía.",
-        "calloutEmpty": "Recuadro vacío."
+        "calloutEmpty": "Recuadro vacío.",
+        "edit": "Editar",
+        "saveEdit": "Guardar"
       },
       "blockTypes": {
         "heading": "Título",

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -720,7 +720,8 @@
         "zebra": "Lignes zébrées",
         "headerStyle": "Style d'en-tête",
         "headerStylePlain": "Simple",
-        "headerStyleAccent": "Accentué"
+        "headerStyleAccent": "Accentué",
+        "reshapedWarning": "Ce tableau dépassait la limite de {{columns}} colonnes x {{rows}} lignes et a été ajusté. L'enregistrement remplace le tableau stocké par celui affiché ici."
       },
       "terms": {
         "placeholder": "Conditions de paiement, clauses de garantie, etc.",

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -512,7 +512,9 @@
         "imageSectionPdf": "Section image (rendue dans le PDF).",
         "richTextContentAria": "Contenu en texte enrichi",
         "tableEmpty": "Tableau vide.",
-        "calloutEmpty": "Encadré vide."
+        "calloutEmpty": "Encadré vide.",
+        "edit": "Modifier",
+        "saveEdit": "Enregistrer"
       },
       "blockTypes": {
         "heading": "Titre",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -512,7 +512,9 @@
         "imageSectionPdf": "Section image (rendue dans le PDF).",
         "richTextContentAria": "Contenu en texte enrichi",
         "tableEmpty": "Tableau vide.",
-        "calloutEmpty": "Encadré vide."
+        "calloutEmpty": "Encadré vide.",
+        "edit": "Modifier",
+        "saveEdit": "Enregistrer"
       },
       "blockTypes": {
         "heading": "Titre",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -749,7 +749,8 @@
         "zebra": "Lignes zébrées",
         "headerStyle": "Style d'en-tête",
         "headerStylePlain": "Simple",
-        "headerStyleAccent": "Accentué"
+        "headerStyleAccent": "Accentué",
+        "reshapedWarning": "Ce tableau dépassait la limite de {{columns}} colonnes x {{rows}} lignes et a été ajusté. L'enregistrement remplace le tableau stocké par celui affiché ici."
       },
       "terms": {
         "placeholder": "Conditions de paiement, clauses de garantie, etc.",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -512,7 +512,9 @@
         "imageSectionPdf": "Sezione immagine (renderizzata nel PDF).",
         "richTextContentAria": "Contenuto di testo formattato",
         "tableEmpty": "Tabella vuota.",
-        "calloutEmpty": "Riquadro vuoto."
+        "calloutEmpty": "Riquadro vuoto.",
+        "edit": "Modifica",
+        "saveEdit": "Salva"
       },
       "blockTypes": {
         "heading": "Intestazione",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -720,7 +720,8 @@
         "zebra": "Righe alternate",
         "headerStyle": "Stile intestazione",
         "headerStylePlain": "Semplice",
-        "headerStyleAccent": "Accento"
+        "headerStyleAccent": "Accento",
+        "reshapedWarning": "Questa tabella superava il limite di {{columns}} colonne x {{rows}} righe ed è stata adattata. Il salvataggio sostituisce la tabella memorizzata con quella mostrata qui."
       },
       "terms": {
         "placeholder": "Termini di pagamento, clausole di garanzia, ecc.",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -512,7 +512,9 @@
         "imageSectionPdf": "Seção de imagem (renderizada no PDF).",
         "richTextContentAria": "Conteúdo de rich text",
         "tableEmpty": "Tabela vazia.",
-        "calloutEmpty": "Destaque vazio."
+        "calloutEmpty": "Destaque vazio.",
+        "edit": "Editar",
+        "saveEdit": "Salvar"
       },
       "blockTypes": {
         "heading": "Título",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -749,7 +749,8 @@
         "zebra": "Linhas alternadas",
         "headerStyle": "Estilo do cabeçalho",
         "headerStylePlain": "Simples",
-        "headerStyleAccent": "Destaque"
+        "headerStyleAccent": "Destaque",
+        "reshapedWarning": "Esta tabela excedia o limite de {{columns}} colunas x {{rows}} linhas e foi ajustada. Salvar substitui a tabela armazenada pela exibida aqui."
       },
       "terms": {
         "placeholder": "Termos de pagamento, cláusulas de garantia, etc.",

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -757,7 +757,8 @@
         "zebra": "Zebra şeritleri",
         "headerStyle": "Başlık stili",
         "headerStylePlain": "Düz",
-        "headerStyleAccent": "Vurgulu"
+        "headerStyleAccent": "Vurgulu",
+        "reshapedWarning": "Bu tablo {{columns}} sütun x {{rows}} satır sınırına sığmadığı için yeniden düzenlendi. Kaydetmek, kayıtlı tabloyu burada gördüğünüzle değiştirir."
       },
       "terms": {
         "placeholder": "Ödeme koşulları, garanti hükümleri vb.",

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -512,7 +512,9 @@
         "imageSectionPdf": "Resim bölümü (PDF'de oluşturulmuştur).",
         "richTextContentAria": "Zengin metin içeriği",
         "tableEmpty": "Boş tablo.",
-        "calloutEmpty": "Boş çağrı kutusu."
+        "calloutEmpty": "Boş çağrı kutusu.",
+        "edit": "Düzenle",
+        "saveEdit": "Kaydet"
       },
       "blockTypes": {
         "heading": "Başlık",


### PR DESCRIPTION
## What

Persisted `table` and `callout` blocks in the quote editor were create-and-display only — fixing a typo in a large table meant deleting the block and rebuilding it. Both now have an inline **Edit** affordance on the canvas that reuses the existing create-form fields, prefilled from the block's current content, saving through the existing `updateBlock` path. The contract block's editor is the precedent followed.

## How

- **`QuoteBlockContentForms.tsx` (new)** — the table grid and callout authoring fields, lifted out of `QuoteEditor.tsx` and parameterised by an id/test-id prefix so the add form and a per-block edit form can be mounted at the same time. Sharing one implementation is the point: the "every row has exactly `columns.length` cells" invariant that `quoteTableContentSchema`'s exact-shape refinement enforces server-side now cannot drift between create and edit. Also exports `*FromContent` / `*ToContent` so both surfaces build identical request bodies.
- **`QuoteStructuredBlockEditor.tsx` (new)** — `TableBlockEditor` / `CalloutBlockEditor`. Read-only render at rest with an Edit button for writers; the form replaces it while editing, with Save / Cancel and the shared `SrSaved` flash. Deliberately different from `ContractBlockEditor`, which renders its form unconditionally: on the canvas a table should look like a table, so the grid is behind a toggle.
- **Prefill is defensive** — a legacy/hand-written row that disagrees with `columns.length` is padded or trimmed once, visibly, on open, rather than being PATCHed into a schema rejection the user can't act on.
- **Failure handling** — save goes through the parent's `editBlock` → `runAction`, so a rejected PATCH toasts and leaves the form open with the draft intact (no silent no-op).
- Read-only viewers keep the rendered block and get no edit affordance.

No API change: `PATCH /quotes/:id/blocks/:blockId` already validates `table` / `callout` content through `quoteBlockInputSchema`.

## Testing

- `QuoteEditor.tableblock.test.tsx` +6: read-only gating, prefill from persisted content, save PATCH body, add-column padding the persisted row (shape invariant), cancel discarding the draft, failed save keeping the draft.
- `QuoteEditor.calloutblock.test.tsx` +7: same plus emptied-body disabling save and a cleared title being omitted rather than sent as `''`.
- All 50 quote component suites green (420 tests), i18n locale parity green (8 locales), `tsc --noEmit` clean.

Closes #3547

🤖 Generated with [Claude Code](https://claude.com/claude-code)