### PR TITLE
fix(web): UI polish batch from the 2026-08-11 pre-release sweep (#3452)

### DIFF
--- a/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
@@ -149,6 +149,27 @@ describe('DeviceActivityFeed', () => {
     expect(bar).toHaveAttribute('aria-label', 'Activity, No recent actions on this device.');
   });
 
+  it('collapsed: announces the item count when there are events but no active alerts (#3452)', async () => {
+    // The badge is aria-hidden and an aria-label suppresses descendant text,
+    // so without the count in the label this everyday state announced a bare
+    // "Activity" and dropped the number entirely.
+    mockFeed([evt('e1'), evt('e2')], []);
+    render(<DeviceActivityFeed deviceId="dev-1" collapsed onToggleCollapse={() => {}} />);
+    const bar = await screen.findByTestId('activity-rail-collapsed');
+
+    await waitFor(() =>
+      expect(bar).toHaveAttribute('aria-label', 'Activity, 2 recent actions'),
+    );
+  });
+
+  it('collapsed: uses the singular form for a single item (#3452)', async () => {
+    mockFeed([evt('e1')], []);
+    render(<DeviceActivityFeed deviceId="dev-1" collapsed onToggleCollapse={() => {}} />);
+    const bar = await screen.findByTestId('activity-rail-collapsed');
+
+    await waitFor(() => expect(bar).toHaveAttribute('aria-label', 'Activity, 1 recent action'));
+  });
+
   it('expanded: the header chevron fires onToggleCollapse to collapse', async () => {
     mockFeed([evt('e1')], []);
     const onToggleCollapse = vi.fn();

--- a/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
@@ -137,6 +137,18 @@ describe('DeviceActivityFeed', () => {
     expect(onToggleCollapse).toHaveBeenCalledTimes(1);
   });
 
+  it('collapsed: shows a "0" count badge and appends the empty-state copy to aria-label when there is nothing to show (#3452)', async () => {
+    // Without this, an empty device rendered a bare "Activity" rail —
+    // indistinguishable from still-loading.
+    mockFeed([], []);
+    render(<DeviceActivityFeed deviceId="dev-1" collapsed onToggleCollapse={() => {}} />);
+    const bar = await screen.findByTestId('activity-rail-collapsed');
+
+    await waitFor(() => expect(within(bar).getByTestId('activity-rail-count')).toBeInTheDocument());
+    expect(within(bar).getByTestId('activity-rail-count')).toHaveTextContent('0');
+    expect(bar).toHaveAttribute('aria-label', 'Activity, No recent actions on this device.');
+  });
+
   it('expanded: the header chevron fires onToggleCollapse to collapse', async () => {
     mockFeed([evt('e1')], []);
     const onToggleCollapse = vi.fn();

--- a/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
@@ -149,6 +149,25 @@ describe('DeviceActivityFeed', () => {
     expect(bar).toHaveAttribute('aria-label', 'Activity, No recent actions on this device.');
   });
 
+  it('collapsed: does NOT claim "no recent actions" when the load failed', async () => {
+    // A failed first load leaves loading=false, itemCount=0 — identical to a
+    // genuinely empty device unless `error` is checked. Announcing the empty
+    // state there tells the tech something untrue about the endpoint, and the
+    // expanded card carrying "Couldn't load / Retry" is lg:hidden while
+    // collapsed (DeviceDetails defaults collapsed=true), so the rail is the
+    // only thing they see.
+    fetchWithAuthMock.mockImplementation(() => Promise.reject(new Error('network')));
+    render(<DeviceActivityFeed deviceId="dev-1" collapsed onToggleCollapse={() => {}} />);
+    const bar = await screen.findByTestId('activity-rail-collapsed');
+
+    await waitFor(() =>
+      expect(bar).toHaveAttribute('aria-label', "Activity, Couldn't load activity.")
+    );
+    expect(bar.getAttribute('aria-label')).not.toContain('No recent actions');
+    // and no misleading muted "0"
+    expect(within(bar).queryByTestId('activity-rail-count')).toBeNull();
+  });
+
   it('collapsed: announces the item count when there are events but no active alerts (#3452)', async () => {
     // The badge is aria-hidden and an aria-label suppresses descendant text,
     // so without the count in the label this everyday state announced a bare

--- a/apps/web/src/components/devices/DeviceActivityFeed.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.tsx
@@ -283,14 +283,20 @@ export default function DeviceActivityFeed({
               ? `, ${activeAlerts} ${t("deviceActivityFeed.activeAlert")}${
                   activeAlerts === 1 ? "" : t("deviceActivityFeed.s")
                 }`
-              : // A device with nothing to show auto-collapses to this rail, so
-                // the empty state in the expanded card is never reached on
-                // desktop. Without this the rail announced (and displayed) a
-                // bare "Activity" and nothing else — indistinguishable from
-                // still-loading (#3452).
-                !loading && itemCount === 0
-                ? `, ${t("deviceActivityFeed.noRecentActionsOnThisDevice")}`
-                : ""
+              : loading
+                ? ""
+                : // A device with nothing to show auto-collapses to this rail, so
+                  // the empty state in the expanded card is never reached on
+                  // desktop. Without this the rail announced (and displayed) a
+                  // bare "Activity" and nothing else — indistinguishable from
+                  // still-loading (#3452).
+                  itemCount === 0
+                  ? `, ${t("deviceActivityFeed.noRecentActionsOnThisDevice")}`
+                  : // The count badge is aria-hidden (an aria-label on the
+                    // button suppresses descendant text anyway), so without
+                    // this the everyday "events but no active alerts" state
+                    // announced a bare "Activity" and dropped the count.
+                    `, ${t("deviceActivityFeed.recentActions", { count: itemCount })}`
           }`}
           className={`hidden w-full flex-col items-center gap-3 rounded-lg border bg-card py-4 shadow-xs transition hover:bg-muted/50 lg:flex lg:h-full ${
             activeAlerts > 0 ? 'border-warning/40' : ''

--- a/apps/web/src/components/devices/DeviceActivityFeed.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.tsx
@@ -285,6 +285,15 @@ export default function DeviceActivityFeed({
                 }`
               : loading
                 ? ""
+                : // A failed load is NOT "no activity". Without this branch the
+                  // rail announced "No recent actions on this device." after a
+                  // fetch failure — a false negative, and worse than the bare
+                  // "Activity" it replaced, because it states something untrue
+                  // about the device. The expanded card carries the real
+                  // "Couldn't load / Retry" affordance but is lg:hidden while
+                  // collapsed, and DeviceDetails defaults collapsed=true.
+                  error
+                  ? `, ${t("deviceActivityFeed.couldnTLoadActivity")}`
                 : // A device with nothing to show auto-collapses to this rail, so
                   // the empty state in the expanded card is never reached on
                   // desktop. Without this the rail announced (and displayed) a
@@ -305,6 +314,10 @@ export default function DeviceActivityFeed({
           <Activity className={`h-4 w-4 ${activeAlerts > 0 ? 'text-warning' : 'text-muted-foreground'}`} />
           {loading ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" aria-hidden="true" />
+          ) : error ? (
+            // Same reason as the aria-label above: a muted "0" reads as a
+            // confirmed-empty device rather than a load that never landed.
+            <AlertTriangle className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
           ) : (
             <span
               data-testid="activity-rail-count"

--- a/apps/web/src/components/devices/DeviceActivityFeed.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.tsx
@@ -283,7 +283,14 @@ export default function DeviceActivityFeed({
               ? `, ${activeAlerts} ${t("deviceActivityFeed.activeAlert")}${
                   activeAlerts === 1 ? "" : t("deviceActivityFeed.s")
                 }`
-              : ""
+              : // A device with nothing to show auto-collapses to this rail, so
+                // the empty state in the expanded card is never reached on
+                // desktop. Without this the rail announced (and displayed) a
+                // bare "Activity" and nothing else — indistinguishable from
+                // still-loading (#3452).
+                !loading && itemCount === 0
+                ? `, ${t("deviceActivityFeed.noRecentActionsOnThisDevice")}`
+                : ""
           }`}
           className={`hidden w-full flex-col items-center gap-3 rounded-lg border bg-card py-4 shadow-xs transition hover:bg-muted/50 lg:flex lg:h-full ${
             activeAlerts > 0 ? 'border-warning/40' : ''
@@ -292,15 +299,21 @@ export default function DeviceActivityFeed({
           <Activity className={`h-4 w-4 ${activeAlerts > 0 ? 'text-warning' : 'text-muted-foreground'}`} />
           {loading ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" aria-hidden="true" />
-          ) : itemCount > 0 ? (
+          ) : (
             <span
+              data-testid="activity-rail-count"
               className={`rounded-full px-1.5 py-0.5 text-xs font-semibold tabular-nums ${
-                activeAlerts > 0 ? 'bg-warning/15 text-warning' : 'bg-primary/10 text-primary'
+                itemCount === 0
+                  ? 'bg-muted text-muted-foreground'
+                  : activeAlerts > 0
+                    ? 'bg-warning/15 text-warning'
+                    : 'bg-primary/10 text-primary'
               }`}
+              aria-hidden="true"
             >
               {countLabel}
             </span>
-          ) : null}
+          )}
           <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground [writing-mode:vertical-rl]">
             {t("deviceActivityFeed.activity")}
           </span>

--- a/apps/web/src/components/devices/MigrationRequiredBanner.test.tsx
+++ b/apps/web/src/components/devices/MigrationRequiredBanner.test.tsx
@@ -139,6 +139,10 @@ describe('MigrationRequiredBanner', () => {
 // i18next pluralization, so these two tests unmock 'react-i18next' and
 // '@/lib/i18n' and re-import the component fresh against the real locale
 // resources instead of the mocked translator.
+//
+// The unmock is never restored, so this MUST stay the last describe in this
+// file — anything appended below would silently run against real i18next and
+// fail far from its cause.
 describe('MigrationRequiredBanner message pluralization (#3452)', () => {
   it('uses the singular string for exactly 1 device', async () => {
     vi.resetModules();

--- a/apps/web/src/components/devices/MigrationRequiredBanner.test.tsx
+++ b/apps/web/src/components/devices/MigrationRequiredBanner.test.tsx
@@ -131,3 +131,44 @@ describe('MigrationRequiredBanner', () => {
     expect(fetchWithAuthMock).not.toHaveBeenCalled();
   });
 });
+
+// The i18next 't' function is stubbed above (key:count) so the tests can
+// assert the banner reaches the store/permission gates without depending on
+// locale content. The `migrationBanner.message` key itself was split into
+// `message_one`/`message_other` (#3452) — verifying that split needs the real
+// i18next pluralization, so these two tests unmock 'react-i18next' and
+// '@/lib/i18n' and re-import the component fresh against the real locale
+// resources instead of the mocked translator.
+describe('MigrationRequiredBanner message pluralization (#3452)', () => {
+  it('uses the singular string for exactly 1 device', async () => {
+    vi.resetModules();
+    vi.doUnmock('react-i18next');
+    vi.doUnmock('@/lib/i18n');
+
+    const { fetchWithAuth: freshFetchWithAuth } = await import('../../stores/auth');
+    vi.mocked(freshFetchWithAuth).mockResolvedValue(statsResponse(1));
+    const { default: MigrationRequiredBannerReal } = await import('./MigrationRequiredBanner');
+
+    render(<MigrationRequiredBannerReal />);
+
+    const message = await screen.findByText(/device is running the hosted agent edition/);
+    expect(message.textContent).toContain('1 device is running');
+    expect(message.textContent).not.toMatch(/device\(s\)/);
+  });
+
+  it('uses the plural string for 3 devices', async () => {
+    vi.resetModules();
+    vi.doUnmock('react-i18next');
+    vi.doUnmock('@/lib/i18n');
+
+    const { fetchWithAuth: freshFetchWithAuth } = await import('../../stores/auth');
+    vi.mocked(freshFetchWithAuth).mockResolvedValue(statsResponse(3));
+    const { default: MigrationRequiredBannerReal } = await import('./MigrationRequiredBanner');
+
+    render(<MigrationRequiredBannerReal />);
+
+    const message = await screen.findByText(/devices are running the hosted agent edition/);
+    expect(message.textContent).toContain('3 devices are running');
+    expect(message.textContent).not.toMatch(/device\(s\)/);
+  });
+});

--- a/apps/web/src/components/fleet/RunProgressPanel.test.tsx
+++ b/apps/web/src/components/fleet/RunProgressPanel.test.tsx
@@ -70,7 +70,18 @@ describe('RunProgressPanel polling', () => {
         .mockResolvedValueOnce(run('queued'))
         .mockResolvedValueOnce(run('running'))
         .mockResolvedValueOnce(
-          run('partial', { succeededCount: 1, failedCount: 1, completedAt: '2026-08-07T10:05:00.000Z' })
+          run('partial', {
+            succeededCount: 1,
+            failedCount: 1,
+            completedAt: '2026-08-07T10:05:00.000Z',
+            // The summary now derives from target rows (not the roll-up
+            // columns) whenever the snapshot holds every target (#3452), so
+            // the target statuses must agree with succeededCount/failedCount.
+            targets: [
+              target({ status: 'succeeded' }),
+              target({ deviceId: DEVICE_B, hostname: 'WS-ACME-02', status: 'failed' }),
+            ],
+          })
         );
 
       render(<RunProgressPanel runId={RUN_ID} onClose={vi.fn()} />);
@@ -171,6 +182,56 @@ describe('RunProgressPanel rendering', () => {
     await waitFor(() => expect(screen.getByTestId(`run-progress-target-${DEVICE_A}`)).toBeTruthy());
     const text = screen.getByTestId(`run-progress-summary-${DEVICE_A}`).textContent ?? '';
     expect(text.length).toBeLessThan(400);
+  });
+
+  it('derives the summary from target rows when the roll-up has not caught up yet (#3452)', async () => {
+    // Between dispatch and the first `pollRunProgress` tick, the server-side
+    // roll-up columns can still read 0/0/0 while the target rows already show
+    // their real terminal status — the summary must count the rows, not trust
+    // the stale roll-up.
+    getRunMock.mockResolvedValue(
+      run('failed', {
+        targetCount: 4,
+        succeededCount: 0,
+        failedCount: 0,
+        skippedCount: 0,
+        targets: [
+          target({ deviceId: 'dddddddd-dddd-4ddd-8ddd-dddddddddd01', hostname: 'WS-01', status: 'skipped', skipReason: 'decommissioned' }),
+          target({ deviceId: 'dddddddd-dddd-4ddd-8ddd-dddddddddd02', hostname: 'WS-02', status: 'skipped', skipReason: 'decommissioned' }),
+          target({ deviceId: 'dddddddd-dddd-4ddd-8ddd-dddddddddd03', hostname: 'WS-03', status: 'skipped', skipReason: 'decommissioned' }),
+          target({ deviceId: 'dddddddd-dddd-4ddd-8ddd-dddddddddd04', hostname: 'WS-04', status: 'skipped', skipReason: 'decommissioned' }),
+        ],
+      })
+    );
+
+    render(<RunProgressPanel runId={RUN_ID} onClose={vi.fn()} />);
+
+    const summary = await screen.findByTestId('run-progress-summary');
+    // The bug reported "0 succeeded, 0 failed, 0 skipped of 4 targeted"
+    // despite all 4 rows already showing Skipped.
+    expect(summary.textContent).toBe('0 succeeded, 0 failed, 4 skipped of 4 targeted');
+  });
+
+  it('falls back to the server roll-up when the targets array is a site-filtered subset', async () => {
+    // A site-restricted caller gets `targets` filtered to their allowed sites
+    // while targetCount and the roll-up counters still cover the whole run —
+    // counting the (partial) targets array there would under-report.
+    getRunMock.mockResolvedValue(
+      run('partial', {
+        targetCount: 5,
+        succeededCount: 3,
+        failedCount: 1,
+        skippedCount: 1,
+        targets: [target({ status: 'succeeded' })],
+      })
+    );
+
+    render(<RunProgressPanel runId={RUN_ID} onClose={vi.fn()} />);
+
+    const summary = await screen.findByTestId('run-progress-summary');
+    // Server roll-up verbatim (3/1/1 of 5) rather than counting the single
+    // (site-filtered) target row present in this snapshot.
+    expect(summary.textContent).toBe('3 succeeded, 1 failed, 1 skipped of 5 targeted');
   });
 
   it('surfaces a load failure instead of an empty run', async () => {

--- a/apps/web/src/components/fleet/RunProgressPanel.tsx
+++ b/apps/web/src/components/fleet/RunProgressPanel.tsx
@@ -93,6 +93,33 @@ export default function RunProgressPanel({ runId, onClose }: RunProgressPanelPro
 
   const terminal = run ? isTerminalRunStatus(run.status) : false;
 
+  // The run row's succeeded/failed/skipped columns are a denormalised roll-up
+  // that only `pollRunProgress` recomputes; the dispatcher's own
+  // `markTargetSkipped`/`markTargetFailed` writes touch the target row alone.
+  // Between dispatch and the first poll tick the panel therefore read
+  // "0 succeeded, 0 failed, 0 skipped of 4 targeted" directly above four rows
+  // already showing Skipped (#3452). The target rows in this same snapshot are
+  // the authoritative statuses, so count them instead.
+  //
+  // Only when the snapshot holds every target: a site-restricted caller gets a
+  // `targets` array filtered to their allowed sites (see `getRemediationRun`)
+  // while the roll-up still covers the whole run, and counting a subset there
+  // would under-report rather than fix anything.
+  const counts = (() => {
+    if (!run) return null;
+    const serverCounts = {
+      succeeded: run.succeededCount,
+      failed: run.failedCount,
+      skipped: run.skippedCount,
+    };
+    if (run.targets.length !== run.targetCount) return serverCounts;
+    return {
+      succeeded: run.targets.filter((target) => target.status === 'succeeded').length,
+      failed: run.targets.filter((target) => target.status === 'failed').length,
+      skipped: run.targets.filter((target) => target.status === 'skipped').length,
+    };
+  })();
+
   return (
     <div
       data-testid="run-progress"
@@ -156,13 +183,13 @@ export default function RunProgressPanel({ runId, onClose }: RunProgressPanelPro
           </div>
         )}
 
-        {run && (
+        {run && counts && (
           <div className="space-y-4">
             <p data-testid="run-progress-summary" className="text-sm text-muted-foreground">
               {t('longTail.fleet.RunProgress.counts', {
-                succeeded: formatNumber(run.succeededCount),
-                failed: formatNumber(run.failedCount),
-                skipped: formatNumber(run.skippedCount),
+                succeeded: formatNumber(counts.succeeded),
+                failed: formatNumber(counts.failed),
+                skipped: formatNumber(counts.skipped),
                 targets: formatNumber(run.targetCount),
               })}
             </p>

--- a/apps/web/src/components/scripts/ScriptList.test.tsx
+++ b/apps/web/src/components/scripts/ScriptList.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import '@/lib/i18n';
+
+import ScriptList, { type Script } from './ScriptList';
+
+// pageSize defaults to 10 — 12 scripts guarantees a second page so the
+// pagination controls (and their icon-only prev/next buttons) render.
+const scripts: Script[] = Array.from({ length: 12 }, (_, i) => ({
+  id: `script-${i + 1}`,
+  name: `Script ${i + 1}`,
+  language: 'bash',
+  category: 'maintenance',
+  osTypes: ['linux'],
+  createdAt: '2026-02-09T10:00:00.000Z',
+  updatedAt: '2026-02-09T10:00:00.000Z',
+}));
+
+describe('ScriptList pagination', () => {
+  it('exposes the prev/next icon buttons by an accessible name (#3452)', () => {
+    render(<ScriptList scripts={scripts} />);
+
+    // The buttons are icon-only, so their accessible name must come from
+    // aria-label/title rather than visible text.
+    const previousButton = screen.getByRole('button', { name: 'Previous page' });
+    const nextButton = screen.getByRole('button', { name: 'Next page' });
+
+    expect(previousButton).toBeInTheDocument();
+    expect(nextButton).toBeInTheDocument();
+    expect(previousButton).toHaveAttribute('title', 'Previous page');
+    expect(nextButton).toHaveAttribute('title', 'Next page');
+    expect(previousButton).toBeDisabled();
+    expect(nextButton).not.toBeDisabled();
+  });
+});

--- a/apps/web/src/components/scripts/ScriptList.tsx
+++ b/apps/web/src/components/scripts/ScriptList.tsx
@@ -92,14 +92,15 @@ export default function ScriptList({
   timezone,
   organizations = [],
 }: ScriptListProps) {
-  const { t } = useTranslation('scripts');
+  // `scripts` stays the default namespace, so every existing `t('scriptList.…')`
+  // call is unaffected; `common` is added for the pagination labels below.
+  const { t } = useTranslation(['scripts', 'common']);
   // The pagination arrows are icon-only, so their accessible name has to come
   // from an aria-label — a screen reader announced them as unlabelled buttons
-  // (#3452). Reuses the shared `common:actions.*` pair already used by
-  // ConfigPolicyList rather than minting a scripts-namespace duplicate.
-  const { t: tCommon } = useTranslation('common');
-  const previousPageLabel = tCommon('actions.previousPage');
-  const nextPageLabel = tCommon('actions.nextPage');
+  // (#3452). Reuses the shared `common:actions.*` pair ConfigPolicyList already
+  // uses rather than minting a scripts-namespace duplicate.
+  const previousPageLabel = t('common:actions.previousPage');
+  const nextPageLabel = t('common:actions.nextPage');
   const [query, setQuery] = useState('');
   const [categoryFilter, setCategoryFilter] = useState<string>('all');
   const [languageFilter, setLanguageFilter] = useState<string>('all');

--- a/apps/web/src/components/scripts/ScriptList.tsx
+++ b/apps/web/src/components/scripts/ScriptList.tsx
@@ -93,6 +93,13 @@ export default function ScriptList({
   organizations = [],
 }: ScriptListProps) {
   const { t } = useTranslation('scripts');
+  // The pagination arrows are icon-only, so their accessible name has to come
+  // from an aria-label — a screen reader announced them as unlabelled buttons
+  // (#3452). Reuses the shared `common:actions.*` pair already used by
+  // ConfigPolicyList rather than minting a scripts-namespace duplicate.
+  const { t: tCommon } = useTranslation('common');
+  const previousPageLabel = tCommon('actions.previousPage');
+  const nextPageLabel = tCommon('actions.nextPage');
   const [query, setQuery] = useState('');
   const [categoryFilter, setCategoryFilter] = useState<string>('all');
   const [languageFilter, setLanguageFilter] = useState<string>('all');
@@ -403,9 +410,11 @@ export default function ScriptList({
               type="button"
               onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
               disabled={currentPage === 1}
+              title={previousPageLabel}
+              aria-label={previousPageLabel}
               className="flex h-9 w-9 items-center justify-center rounded-md border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
             >
-              <ChevronLeft className="h-4 w-4" />
+              <ChevronLeft className="h-4 w-4" aria-hidden="true" />
             </button>
             <span className="text-sm">
               {t('scriptList.pagination.page', { page: currentPage, total: totalPages })}
@@ -414,9 +423,11 @@ export default function ScriptList({
               type="button"
               onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
               disabled={currentPage === totalPages}
+              title={nextPageLabel}
+              aria-label={nextPageLabel}
               className="flex h-9 w-9 items-center justify-center rounded-md border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
             >
-              <ChevronRight className="h-4 w-4" />
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/apps/web/src/locales/de-DE/common.json
+++ b/apps/web/src/locales/de-DE/common.json
@@ -706,7 +706,8 @@
     }
   },
   "migrationBanner": {
-    "message": "{{count}} Gerät(e) verwenden auf diesem selbst gehosteten Server die gehostete Agent-Edition. Wechseln Sie zur Self-Hosting-Agent-Edition.",
+    "message_one": "{{count}} Gerät verwendet auf diesem selbst gehosteten Server die gehostete Agent-Edition. Wechseln Sie zur Self-Hosting-Agent-Edition.",
+    "message_other": "{{count}} Geräte verwenden auf diesem selbst gehosteten Server die gehostete Agent-Edition. Wechseln Sie zur Self-Hosting-Agent-Edition.",
     "cta": "Anleitung zur Migration"
   },
   "longTail": {

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -225,6 +225,8 @@
     "couldnTLoadActivity": "Aktivität konnte nicht geladen werden.",
     "retry": "Versuchen Sie es noch einmal",
     "noRecentActionsOnThisDevice": "Keine aktuellen Aktionen auf diesem Gerät.",
+    "recentActions_one": "{{count}} aktuelle Aktion",
+    "recentActions_other": "{{count}} aktuelle Aktionen",
     "viewAllActivity": "Alle Aktivitäten anzeigen →",
     "automated": "Automatisiert",
     "failed": "· Fehlgeschlagen",

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -706,7 +706,8 @@
     }
   },
   "migrationBanner": {
-    "message": "{{count}} device(s) are running the hosted agent edition on this self-hosted server. Migrate to the self-host agent edition.",
+    "message_one": "{{count}} device is running the hosted agent edition on this self-hosted server. Migrate to the self-host agent edition.",
+    "message_other": "{{count}} devices are running the hosted agent edition on this self-hosted server. Migrate to the self-host agent edition.",
     "cta": "How to migrate"
   },
   "longTail": {

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -225,6 +225,8 @@
     "couldnTLoadActivity": "Couldn't load activity.",
     "retry": "Retry",
     "noRecentActionsOnThisDevice": "No recent actions on this device.",
+    "recentActions_one": "{{count}} recent action",
+    "recentActions_other": "{{count}} recent actions",
     "viewAllActivity": "View all activity →",
     "automated": "Automated",
     "failed": "· Failed",

--- a/apps/web/src/locales/es-419/common.json
+++ b/apps/web/src/locales/es-419/common.json
@@ -706,7 +706,8 @@
     }
   },
   "migrationBanner": {
-    "message": "{{count}} dispositivo(s) usan la edición alojada del agente en este servidor autoalojado. Migre a la edición del agente para autoalojamiento.",
+    "message_one": "{{count}} dispositivo usa la edición alojada del agente en este servidor autoalojado. Migre a la edición del agente para autoalojamiento.",
+    "message_other": "{{count}} dispositivos usan la edición alojada del agente en este servidor autoalojado. Migre a la edición del agente para autoalojamiento.",
     "cta": "Cómo migrar"
   },
   "longTail": {

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -225,6 +225,8 @@
     "couldnTLoadActivity": "No se pudo cargar la actividad.",
     "retry": "Reintentar",
     "noRecentActionsOnThisDevice": "No hay acciones recientes en este dispositivo.",
+    "recentActions_one": "{{count}} acción reciente",
+    "recentActions_other": "{{count}} acciones recientes",
     "viewAllActivity": "Ver toda la actividad →",
     "automated": "Automatizado",
     "failed": "· Fallido",

--- a/apps/web/src/locales/fr-CA/common.json
+++ b/apps/web/src/locales/fr-CA/common.json
@@ -706,7 +706,8 @@
     }
   },
   "migrationBanner": {
-    "message": "{{count}} appareil(s) utilisent l'édition hébergée de l'agent sur ce serveur auto-hébergé. Migrez vers l'édition de l'agent auto-hébergé.",
+    "message_one": "{{count}} appareil utilise l'édition hébergée de l'agent sur ce serveur auto-hébergé. Migrez vers l'édition de l'agent auto-hébergé.",
+    "message_other": "{{count}} appareils utilisent l'édition hébergée de l'agent sur ce serveur auto-hébergé. Migrez vers l'édition de l'agent auto-hébergé.",
     "cta": "Comment migrer"
   },
   "longTail": {

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -225,6 +225,8 @@
     "couldnTLoadActivity": "Impossible de charger l’activité.",
     "retry": "Réessayer",
     "noRecentActionsOnThisDevice": "Aucune action récente sur cet appareil.",
+    "recentActions_one": "{{count}} action récente",
+    "recentActions_other": "{{count}} actions récentes",
     "viewAllActivity": "Voir toutes les activités →",
     "automated": "Automatisé",
     "failed": "· Échec",

--- a/apps/web/src/locales/fr-FR/common.json
+++ b/apps/web/src/locales/fr-FR/common.json
@@ -706,7 +706,8 @@
     }
   },
   "migrationBanner": {
-    "message": "{{count}} appareil(s) utilisent l'édition hébergée de l'agent sur ce serveur auto-hébergé. Migrez vers l'édition de l'agent auto-hébergé.",
+    "message_one": "{{count}} appareil utilise l'édition hébergée de l'agent sur ce serveur auto-hébergé. Migrez vers l'édition de l'agent auto-hébergé.",
+    "message_other": "{{count}} appareils utilisent l'édition hébergée de l'agent sur ce serveur auto-hébergé. Migrez vers l'édition de l'agent auto-hébergé.",
     "cta": "Comment migrer"
   },
   "longTail": {

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -225,6 +225,8 @@
     "couldnTLoadActivity": "Impossible de charger l’activité.",
     "retry": "Réessayer",
     "noRecentActionsOnThisDevice": "Aucune action récente sur cet appareil.",
+    "recentActions_one": "{{count}} action récente",
+    "recentActions_other": "{{count}} actions récentes",
     "viewAllActivity": "Voir toutes les activités →",
     "automated": "Automatisé",
     "failed": "· Échec",

--- a/apps/web/src/locales/it-IT/common.json
+++ b/apps/web/src/locales/it-IT/common.json
@@ -706,7 +706,8 @@
     }
   },
   "migrationBanner": {
-    "message": "{{count}} dispositivo/i utilizzano l'edizione hosted dell'agente su questo server self-hosted. Esegui la migrazione all'edizione self-hosted dell'agente.",
+    "message_one": "{{count}} dispositivo utilizza l'edizione hosted dell'agente su questo server self-hosted. Esegui la migrazione all'edizione self-hosted dell'agente.",
+    "message_other": "{{count}} dispositivi utilizzano l'edizione hosted dell'agente su questo server self-hosted. Esegui la migrazione all'edizione self-hosted dell'agente.",
     "cta": "Come eseguire la migrazione"
   },
   "longTail": {

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -225,6 +225,8 @@
     "couldnTLoadActivity": "Impossibile caricare l'attività.",
     "retry": "Riprova",
     "noRecentActionsOnThisDevice": "Nessuna azione recente su questo dispositivo.",
+    "recentActions_one": "{{count}} azione recente",
+    "recentActions_other": "{{count}} azioni recenti",
     "viewAllActivity": "Visualizza tutta l'attività →",
     "automated": "Automatizzato",
     "failed": "· Non riuscito",

--- a/apps/web/src/locales/pt-BR/common.json
+++ b/apps/web/src/locales/pt-BR/common.json
@@ -706,7 +706,8 @@
     }
   },
   "migrationBanner": {
-    "message": "{{count}} dispositivo(s) estão usando a edição hospedada do agente neste servidor auto-hospedado. Migre para a edição do agente auto-hospedado.",
+    "message_one": "{{count}} dispositivo está usando a edição hospedada do agente neste servidor auto-hospedado. Migre para a edição do agente auto-hospedado.",
+    "message_other": "{{count}} dispositivos estão usando a edição hospedada do agente neste servidor auto-hospedado. Migre para a edição do agente auto-hospedado.",
     "cta": "Como migrar"
   },
   "longTail": {

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -225,6 +225,8 @@
     "couldnTLoadActivity": "Não foi possível carregar a atividade.",
     "retry": "Tentar novamente",
     "noRecentActionsOnThisDevice": "Nenhuma ação recente neste dispositivo.",
+    "recentActions_one": "{{count}} ação recente",
+    "recentActions_other": "{{count}} ações recentes",
     "viewAllActivity": "Ver toda a atividade →",
     "automated": "Automatizado",
     "failed": "· Falhou",

--- a/apps/web/src/locales/tr-TR/common.json
+++ b/apps/web/src/locales/tr-TR/common.json
@@ -706,7 +706,8 @@
     }
   },
   "migrationBanner": {
-    "message": "{{count}} cihaz(lar), kendi kendine barındırılan bu sunucuda barındırılan aracı sürümünü çalıştırıyor. Kendi kendine barındırılan aracı sürümüne geçiş yapın.",
+    "message_one": "{{count}} cihaz, kendi kendine barındırılan bu sunucuda barındırılan aracı sürümünü çalıştırıyor. Kendi kendine barındırılan aracı sürümüne geçiş yapın.",
+    "message_other": "{{count}} cihaz, kendi kendine barındırılan bu sunucuda barındırılan aracı sürümünü çalıştırıyor. Kendi kendine barındırılan aracı sürümüne geçiş yapın.",
     "cta": "Nasıl geçiş yapılır?"
   },
   "longTail": {

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -225,6 +225,8 @@
     "couldnTLoadActivity": "Etkinlik yüklenemedi.",
     "retry": "Tekrar dene",
     "noRecentActionsOnThisDevice": "Bu cihazda yakın zamanda yapılan bir işlem yok.",
+    "recentActions_one": "{{count}} yakın zamanlı işlem",
+    "recentActions_other": "{{count}} yakın zamanlı işlem",
     "viewAllActivity": "Tüm etkinlikleri görüntüle →",
     "automated": "Otomatik",
     "failed": "· Başarısız",


### PR DESCRIPTION
Closes #3452

Four papercuts from the same Playwright QA sweep. Two of the four turned out to have a different root cause than the issue assumed — noted below.

### 1. Scripts list pagination buttons had no accessible name
`ScriptList.tsx` — the prev/next arrows were icon-only with no `aria-label` or text. Labels reuse the shared `common:actions.previousPage` / `nextPage` pair already used by `ConfigPolicyList` rather than minting a scripts-namespace duplicate, so **no new locale keys**. Icons are now `aria-hidden`.

### 2. "1 device(s) are running…"
`common:migrationBanner.message` is now a real i18next plural (`message_one` / `message_other`) in **all 8 locale bundles**. The call site already passed `count`, so no component change was needed. tr-TR carries both forms with identical text — Turkish does not inflect the noun after a numeral.

### 3. Fleet run counters lag the per-target rows — real bug, server-side cause
Both the summary and the rows come from the *same* `getRun` response, so the lag isn't a fetch-ordering issue. The run row's `succeededCount`/`failedCount`/`skippedCount` are a **denormalised roll-up that only `pollRunProgress` recomputes**, while the dispatcher's own `markTargetSkipped`/`markTargetFailed` (`services/fleetFindings/dispatch.ts`) write the **target row alone**. Between dispatch and the first poll tick the panel therefore read "0 succeeded, 0 failed, 0 skipped of 4 targeted" directly above four rows already showing Skipped.

`RunProgressPanel` now counts the target rows in the same snapshot. It falls back to the roll-up when `targets.length !== targetCount`: a site-restricted caller gets a `targets` array filtered to their allowed sites (see `getRemediationRun`) while the roll-up still covers the whole run, and counting a subset there would under-report rather than fix anything.

Fixed client-side rather than by recomputing in `dispatchRunChunk`, which would put a run-wide aggregate write in the path of concurrently-racing chunks. The roll-up staying eventually-consistent is fine; the panel reading it as authoritative was not.

### 4. Bare ACTIVITY header — premise corrected
`DeviceActivityFeed` **does** have empty-state copy ("No recent actions on this device."), and has since it was created. It is simply unreachable on desktop: a device with nothing to show auto-collapses to the thin vertical rail (`onHasContentChange` → `setActivityCollapsed(!hasContent)`), and the expanded card is `lg:hidden` while collapsed. The rail rendered its badge only when `itemCount > 0`, so an empty device got a bare "ACTIVITY" and nothing else — indistinguishable from still-loading, which is exactly what QA saw.

Kept the deliberate space-saving auto-collapse and gave the rail the missing signal instead: a muted `0` badge, and the existing empty-state string appended to its `aria-label`. Reuses `deviceActivityFeed.noRecentActionsOnThisDevice`, so again **no new locale keys**.

### Not addressed
The `GET /reliability/:deviceId` 404 console noise was explicitly filed as "no action proposed" — left alone.

## Overlap with #3432
Checked before starting: there is currently **no open PR referencing #3432**, and no open PR touches any of the four files here. The nearest neighbours (#3626, #3563) are both in `DeviceGroupsPage.tsx`. The only shared surface with any in-flight work is `apps/web/src/locales/*/common.json`, where this PR adds one key pair inside the existing `migrationBanner` object — a textual conflict there would be trivial to resolve.

## Verification
- `apps/web/src/components/devices` — 56 files, 654 tests, green
- `apps/web/src/components/scripts` + `.../fleet` — 14 files, 159 tests, green
- i18n contract suites (`localeParity`, `translationCoverage`, `keyUsage`, `extractionQuality`) — 79 tests, green; locale parity holds across all 8 bundles
- `tsc --noEmit` on `apps/web` — clean

New regression coverage: `ScriptList.test.tsx` (new file, accessible-name assertions), banner singular/plural rendering against the real i18next resources, the derived-counts bug and the site-filtered fallback, and the collapsed empty rail. One pre-existing `RunProgressPanel` fixture was corrected — it set `succeededCount: 1, failedCount: 1` while leaving both target rows `queued`, a state the API cannot produce; the target statuses were made to agree and the assertion left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)