### PR TITLE
fix(installer): always write an MSI log so Windows install failures are diagnosable

### DIFF
--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -145,6 +145,27 @@
     <Property Id="ENROLLMENT_SECRET" Secure="yes" Hidden="yes" />
     <?endif?>
     <Property Id="BOOTSTRAP_TOKEN" Secure="yes" Hidden="yes" />
+    <!-- Always write a verbose MSI log to %TEMP%\MSI*.LOG and print its path in
+         the failure dialog. Without this, a rolled-back install shows only
+         "Breeze Agent Setup Wizard ended prematurely" with no cause and no log
+         to ask the reporter for — every enroll failure (the agent distinguishes
+         seven categories as exit codes 10-17, see internal/agentapp/enroll_error.go)
+         collapses into an indistinguishable 1603, and support has to talk the
+         user through re-running under `msiexec /i ... /l*v`. That re-run is
+         itself unreliable: the failure is often environmental (expired token,
+         captive portal) and no longer reproduces by the time we ask.
+
+         Secret safety: the `p` flag logs property VALUES, so every property
+         carrying a credential must be Hidden="yes" (WiX emits those into
+         MsiHiddenProperties, and the log prints them as `**********`).
+         ENROLLMENT_KEY, ENROLLMENT_SECRET and BOOTSTRAP_TOKEN are all marked
+         above — KEEP IT THAT WAY when adding any new credential-bearing
+         property, or it lands in a world-readable file under %TEMP%.
+         The bootstrap token also appears inside the filename-bootstrap
+         package path (OriginalDatabase, "Breeze Agent (TOKEN@HOST).msi"),
+         which MSI logs in its header regardless of flags; that is accepted
+         because the same token is already on disk in the file's own name. -->
+    <Property Id="MsiLogging" Value="voicewarmupx" />
     <Property Id="ARPNOREPAIR" Value="1" />
     <Property Id="POWERSHELL_EXE" Secure="yes" />
     <Property Id="BREEZE_KILL_CMD" Secure="yes" />


### PR DESCRIPTION
## What

Adds `<Property Id="MsiLogging" Value="voicewarmupx"/>` to `agent/installer/breeze.wxs`.

## Why

`breeze.wxs` set no `MsiLogging` property, so a rolled-back Windows install wrote **no log at all**. The user sees "Breeze Agent Setup Wizard ended prematurely" and we have no artifact to ask for.

This matters more than it looks. The agent already classifies seven distinct enrollment failures as exit codes 10–17 (`agent/internal/agentapp/enroll_error.go:20-36`) — network/DNS, TLS, 401/403 bad-or-expired key, 404 wrong server URL, 429, 5xx, identity conflict. But `EnrollAgent` (`breeze.wxs:482-489`) and `BootstrapEnroll` (`:523-531`) are `Return="check"` and pass `--quiet`, so all seven collapse into an indistinguishable MSI 1603 + rollback and the explanatory stderr goes nowhere.

The current workaround — talk the reporter through re-running under `msiexec /i … /l*v` — is unreliable, because these failures are typically environmental (expired token, captive portal, TLS distrust) and frequently don't reproduce on the second run.

With this set, Windows Installer writes `%TEMP%\MSI*.LOG` on every install and prints its path in the failure dialog.

## Secret safety

The `p` flag logs property **values**, so any credential-bearing property must be `Hidden="yes"` — WiX emits those into `MsiHiddenProperties` and the log renders them as `**********`. `ENROLLMENT_KEY`, `ENROLLMENT_SECRET` and `BOOTSTRAP_TOKEN` are all already marked (`breeze.wxs:137-147`); I verified this rather than assumed it, and added a comment recording the invariant so a future credential-bearing property doesn't quietly land in a world-readable `%TEMP%` file.

One accepted exposure: on the filename-bootstrap path the token is part of the package path (`Breeze Agent (TOKEN@HOST).msi`), which MSI writes into the log header regardless of flags. That token is already sitting on the same disk in the file's own name, so the log adds no new exposure.

## Scope

Deliberately narrow. This makes failures **diagnosable**; it does not make them **self-explanatory**. Still open in #3624:
- mapping exit codes 10–17 to MSI `<Error>` rows so the user reads "enrollment key expired" instead of 1603
- the `bootstrap.go:191-196` silent-success path (exits 0 with no enrollment)
- the console-window flash on upgrade — **note: the fix proposed in #3624 for this is wrong; see my correction on the issue**

## Testing

XML validity verified by parse. The MSI itself **cannot be built or exercised here** — no `wix` CLI and no Windows host — so this needs a real MSI build plus one deliberate failed install (e.g. expired token) to confirm the log is written and the dialog surfaces its path. Flagging that explicitly rather than claiming verification I didn't do.

Refs #3624

🤖 Generated with [Claude Code](https://claude.com/claude-code)