### PR TITLE
fix(web,api,agent): OneDrive Helper polish batch (#2336)

### DIFF
--- a/agent/internal/onedrivehelper/onedrivehelper.go
+++ b/agent/internal/onedrivehelper/onedrivehelper.go
@@ -184,28 +184,126 @@ func TenantIDFromComposite(libraryID string) string {
 	return ""
 }
 
-// ComputeDrift flags applied libraries whose display name matches no mounted
-// local folder path. OneDrive's tenant cache stores mounted scopes as local
-// folder paths of the form "<Org> - <LibraryName>", so a case-insensitive
-// substring match on the display name is the practical detection (validated
-// against the live-spike cache shape, see the 2026-06-19 spike doc). A rule
-// the user previously stop-synced will never re-mount — that is exactly the
-// drift this surfaces (spec: report, don't rewrite forever).
+// pathBase returns the last path component of a mounted local folder path,
+// tolerating either separator (the values come from a Windows registry cache
+// but the logic is unit-tested on every OS).
+func pathBase(p string) string {
+	if i := strings.LastIndexAny(p, `\/`); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+// mountSiteForLibrary reports whether a mounted path is a mount OF the named
+// library, and if so returns the site-title portion of its folder name.
+//
+// OneDrive names these folders "<Site title> - <Library name>" (or bare
+// "<Library name>" for a library whose site title OneDrive omits). Matching on
+// the SUFFIX rather than splitting on " - " keeps library names that themselves
+// contain " - " intact, which a naive split would tear apart.
+func mountSiteForLibrary(p, displayName string) (site string, ok bool) {
+	base := pathBase(p)
+	if strings.EqualFold(base, displayName) {
+		return "", true
+	}
+	suffix := " - " + displayName
+	if len(base) > len(suffix) && strings.EqualFold(base[len(base)-len(suffix):], suffix) {
+		return base[:len(base)-len(suffix)], true
+	}
+	return "", false
+}
+
+// siteHintFromURL derives a comparable token from a SharePoint site URL — the
+// last non-empty path segment, e.g. ".../sites/Marketing" → "Marketing".
+//
+// It is only a HINT: the folder name carries the site TITLE, which is free text
+// and frequently differs from the URL slug ("Marketing Team" vs. /sites/mktg).
+// So it is used strictly to break a tie between several identically-named
+// libraries and never to turn a single unambiguous match into drift.
+func siteHintFromURL(siteURL string) string {
+	trimmed := strings.TrimRight(siteURL, "/")
+	if i := strings.LastIndex(trimmed, "/"); i >= 0 {
+		return trimmed[i+1:]
+	}
+	return ""
+}
+
+// ComputeDrift flags applied libraries that OneDrive did not actually mount. A
+// rule the user previously stop-synced will never re-mount — that is exactly
+// the drift this surfaces (spec: report, don't rewrite forever).
+//
+// Matching is site-qualified and one-to-one. The old check asked, per rule,
+// "does the display name appear anywhere in any mounted path?", which cannot
+// tell "Contoso HR - Documents" from "Contoso Legal - Documents": two sites
+// entitling a same-named library (and "Documents" is the default name on EVERY
+// SharePoint site) meant a single mount suppressed the drift report for both.
+// That false negative was seen in live QA.
+//
+// Treating it as an assignment fixes it: each mounted folder can satisfy at
+// most one rule, so two rules and one mount always leaves one rule drifted.
+// Which one is decided in three passes, strongest evidence first:
+//
+//  1. Folder name is "<site> - <library>" AND the site title contains the hint
+//     from the rule's site URL — an unambiguous pairing.
+//  2. Folder name matches the library name, site unverified. Site TITLES are
+//     free text and routinely differ from the URL slug ("Marketing Team" vs.
+//     /sites/mktg), so a hint that fails to match is never taken as proof of
+//     drift — it only loses to a rule that did match in pass 1.
+//  3. Legacy substring scan, for cache shapes with no parseable folder name.
+//     Keeps an unrecognized shape degrading to the old behaviour rather than
+//     reporting drift on everything. Fuzzy, so it consumes nothing.
 func ComputeDrift(applied []LibraryRule, mountedPaths []string) []DriftEntry {
-	out := []DriftEntry{}
-	for _, r := range applied {
-		if r.DisplayName == "" {
+	matched := make([]bool, len(applied))
+	consumed := make([]bool, len(mountedPaths))
+
+	// Pass 1 — site-confirmed pairings claim their mount first.
+	for i, r := range applied {
+		hint := siteHintFromURL(r.SiteURL)
+		if r.DisplayName == "" || hint == "" {
 			continue
 		}
-		needle := strings.ToLower(r.DisplayName)
-		found := false
-		for _, p := range mountedPaths {
-			if strings.Contains(strings.ToLower(p), needle) {
-				found = true
+		for j, p := range mountedPaths {
+			if consumed[j] {
+				continue
+			}
+			site, ok := mountSiteForLibrary(p, r.DisplayName)
+			if ok && strings.Contains(strings.ToLower(site), strings.ToLower(hint)) {
+				matched[i], consumed[j] = true, true
 				break
 			}
 		}
-		if !found {
+	}
+
+	// Pass 2 — name-only pairings for whatever is left over.
+	for i, r := range applied {
+		if matched[i] || r.DisplayName == "" {
+			continue
+		}
+		for j, p := range mountedPaths {
+			if consumed[j] {
+				continue
+			}
+			if _, ok := mountSiteForLibrary(p, r.DisplayName); ok {
+				matched[i], consumed[j] = true, true
+				break
+			}
+		}
+	}
+
+	out := []DriftEntry{}
+	for i, r := range applied {
+		if r.DisplayName == "" || matched[i] {
+			continue
+		}
+		// Pass 3 — legacy substring fallback over the unclaimed mounts.
+		needle := strings.ToLower(r.DisplayName)
+		for j, p := range mountedPaths {
+			if !consumed[j] && strings.Contains(strings.ToLower(p), needle) {
+				matched[i] = true
+				break
+			}
+		}
+		if !matched[i] {
 			out = append(out, DriftEntry{LibraryID: r.LibraryID, DisplayName: r.DisplayName, Reason: "not_mounted"})
 		}
 	}

--- a/agent/internal/onedrivehelper/onedrivehelper.go
+++ b/agent/internal/onedrivehelper/onedrivehelper.go
@@ -40,6 +40,17 @@ type Config struct {
 	Libraries []LibraryRule `json:"libraries"`
 }
 
+// Drift reasons reported to the server (heartbeat onedriveDeviceState.driftEntries).
+const (
+	// ReasonNotMounted — the library is entitled but no mounted folder matches it.
+	ReasonNotMounted = "not_mounted"
+	// ReasonNotMountedAmbiguous — same as above, except one or more SAME-NAMED
+	// libraries from other sites are also entitled and the mounted folders can't
+	// be attributed between them. The count of unmounted libraries is right;
+	// which one this entry names is not certain. See ComputeDrift.
+	ReasonNotMountedAmbiguous = "not_mounted_ambiguous"
+)
+
 // DriftEntry records an applied library that OneDrive did not actually mount
 // (e.g. the user previously "stopped sync" — AutoMount will not re-mount it).
 type DriftEntry struct {
@@ -252,6 +263,14 @@ func siteHintFromURL(siteURL string) string {
 //  3. Legacy substring scan, for cache shapes with no parseable folder name.
 //     Keeps an unrecognized shape degrading to the old behaviour rather than
 //     reporting drift on everything. Fuzzy, so it consumes nothing.
+//
+// When pass 2 has to resolve SEVERAL same-named rules against fewer mounts, the
+// assignment is correct in COUNT but arbitrary in attribution — nothing in the
+// data says which site the one mounted "Documents" belongs to. Those entries
+// are reported as ReasonNotMountedAmbiguous rather than ReasonNotMounted, so a
+// tech reading the panel knows the tool is saying "one of these same-named
+// libraries is unmounted and I can't tell which" instead of asserting a
+// coin-flip as fact.
 func ComputeDrift(applied []LibraryRule, mountedPaths []string) []DriftEntry {
 	matched := make([]bool, len(applied))
 	consumed := make([]bool, len(mountedPaths))
@@ -274,17 +293,31 @@ func ComputeDrift(applied []LibraryRule, mountedPaths []string) []DriftEntry {
 		}
 	}
 
+	// How many rules each display name still has outstanding after pass 1 — more
+	// than one means pass 2 is choosing between indistinguishable candidates.
+	contenders := map[string]int{}
+	for i, r := range applied {
+		if !matched[i] && r.DisplayName != "" {
+			contenders[strings.ToLower(r.DisplayName)]++
+		}
+	}
+
 	// Pass 2 — name-only pairings for whatever is left over.
+	guessedFor := map[string]bool{}
 	for i, r := range applied {
 		if matched[i] || r.DisplayName == "" {
 			continue
 		}
+		key := strings.ToLower(r.DisplayName)
 		for j, p := range mountedPaths {
 			if consumed[j] {
 				continue
 			}
 			if _, ok := mountSiteForLibrary(p, r.DisplayName); ok {
 				matched[i], consumed[j] = true, true
+				if contenders[key] > 1 {
+					guessedFor[key] = true
+				}
 				break
 			}
 		}
@@ -304,7 +337,14 @@ func ComputeDrift(applied []LibraryRule, mountedPaths []string) []DriftEntry {
 			}
 		}
 		if !matched[i] {
-			out = append(out, DriftEntry{LibraryID: r.LibraryID, DisplayName: r.DisplayName, Reason: "not_mounted"})
+			reason := ReasonNotMounted
+			// A same-named sibling took a mount by position, not by evidence —
+			// the COUNT of unmounted libraries is right, but which one is named
+			// here is a guess. Say so rather than assert it.
+			if guessedFor[needle] {
+				reason = ReasonNotMountedAmbiguous
+			}
+			out = append(out, DriftEntry{LibraryID: r.LibraryID, DisplayName: r.DisplayName, Reason: reason})
 		}
 	}
 	return out

--- a/agent/internal/onedrivehelper/onedrivehelper_test.go
+++ b/agent/internal/onedrivehelper/onedrivehelper_test.go
@@ -410,6 +410,37 @@ func TestComputeDriftIsSiteQualified(t *testing.T) {
 	}
 }
 
+// When same-named libraries can't be told apart — neither site hint matches the
+// mounted folder's free-text site title — the assignment is right in COUNT but
+// arbitrary in attribution. The reported reason must say so instead of naming
+// one library with false confidence.
+func TestComputeDriftFlagsAmbiguousAttribution(t *testing.T) {
+	hr := LibraryRule{LibraryID: "l-hr", DisplayName: "Documents", SiteURL: "https://contoso.sharepoint.com/sites/hrweb"}
+	legal := LibraryRule{LibraryID: "l-legal", DisplayName: "Documents", SiteURL: "https://contoso.sharepoint.com/sites/lgl"}
+	// The site title matches NEITHER url slug, so pass 1 resolves nothing.
+	mounted := []string{`C:\Users\bob\People Operations - Documents`}
+
+	got := ComputeDrift([]LibraryRule{hr, legal}, mounted)
+
+	// Exactly one library is genuinely unmounted, and that count must survive.
+	if len(got) != 1 {
+		t.Fatalf("drift = %+v, want exactly 1 entry", got)
+	}
+	if got[0].Reason != ReasonNotMountedAmbiguous {
+		t.Errorf("reason = %q, want %q — attribution was a positional guess", got[0].Reason, ReasonNotMountedAmbiguous)
+	}
+
+	// A site-confirmed resolution is NOT a guess and must keep the plain reason.
+	confirmedMount := []string{`C:\Users\bob\Contoso hrweb - Documents`}
+	confirmed := ComputeDrift([]LibraryRule{hr, legal}, confirmedMount)
+	if len(confirmed) != 1 || confirmed[0].LibraryID != "l-legal" {
+		t.Fatalf("drift = %+v, want exactly [l-legal]", confirmed)
+	}
+	if confirmed[0].Reason != ReasonNotMounted {
+		t.Errorf("reason = %q, want %q — the pairing was site-confirmed", confirmed[0].Reason, ReasonNotMounted)
+	}
+}
+
 func TestFolderRedirectionState(t *testing.T) {
 	tests := []struct{ raw, want string }{
 		{`C:\Users\bob\OneDrive - Contoso\Documents`, "redirected"},

--- a/agent/internal/onedrivehelper/onedrivehelper_test.go
+++ b/agent/internal/onedrivehelper/onedrivehelper_test.go
@@ -327,6 +327,89 @@ func TestComputeDrift(t *testing.T) {
 	}
 }
 
+// Two sites can entitle libraries with the SAME display name ("Documents" is
+// the default for every SharePoint site). The pre-#2336 substring scan matched
+// the name anywhere in the path, so one site's mount suppressed the drift
+// report for the other — a false "everything is fine" seen in live QA.
+func TestComputeDriftIsSiteQualified(t *testing.T) {
+	hr := LibraryRule{LibraryID: "l-hr", DisplayName: "Documents", SiteURL: "https://contoso.sharepoint.com/sites/HR"}
+	legal := LibraryRule{LibraryID: "l-legal", DisplayName: "Documents", SiteURL: "https://contoso.sharepoint.com/sites/Legal"}
+
+	tests := []struct {
+		name    string
+		applied []LibraryRule
+		mounted []string
+		want    []string
+	}{
+		{
+			name:    "same-named libraries, only one site mounted",
+			applied: []LibraryRule{hr, legal},
+			mounted: []string{`C:\Users\bob\Contoso HR - Documents`},
+			want:    []string{"l-legal"},
+		},
+		{
+			name:    "same-named libraries, both sites mounted",
+			applied: []LibraryRule{hr, legal},
+			mounted: []string{`C:\Users\bob\Contoso HR - Documents`, `C:\Users\bob\Contoso Legal - Documents`},
+			want:    nil,
+		},
+		{
+			name:    "single unambiguous match needs no site hint",
+			applied: []LibraryRule{{LibraryID: "l-1", DisplayName: "Documents"}},
+			mounted: []string{`C:\Users\bob\Anything At All - Documents`},
+			want:    nil,
+		},
+		{
+			// Ambiguous AND no hint to disambiguate with: mounted somewhere is
+			// as much as we can prove, so we must not invent drift.
+			name:    "ambiguous with no site URL does not claim drift",
+			applied: []LibraryRule{{LibraryID: "l-1", DisplayName: "Documents"}},
+			mounted: []string{`C:\Users\bob\A - Documents`, `C:\Users\bob\B - Documents`},
+			want:    nil,
+		},
+		{
+			// The library name itself contains " - "; a naive split on the
+			// separator would compare the wrong halves and report false drift.
+			name:    "library name containing the separator",
+			applied: []LibraryRule{{LibraryID: "l-1", DisplayName: "Docs - Archive"}},
+			mounted: []string{`C:\Users\bob\Contoso HR - Docs - Archive`},
+			want:    nil,
+		},
+		{
+			// Unrecognized cache shape (no "<Site> - " prefix at all) must fall
+			// back to the legacy substring scan rather than report drift.
+			name:    "legacy fallback for an unprefixed folder name",
+			applied: []LibraryRule{{LibraryID: "l-1", DisplayName: "Finance"}},
+			mounted: []string{`C:\Users\bob\Finance Reports`},
+			want:    nil,
+		},
+		{
+			name:    "site mounted under a title unrelated to the URL slug",
+			applied: []LibraryRule{{LibraryID: "l-1", DisplayName: "Documents", SiteURL: "https://contoso.sharepoint.com/sites/mktg"}},
+			mounted: []string{`C:\Users\bob\Marketing Team - Documents`},
+			want:    nil, // single match wins; the hint is never used to create drift
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeDrift(tt.applied, tt.mounted)
+			var ids []string
+			for _, d := range got {
+				ids = append(ids, d.LibraryID)
+			}
+			if len(ids) != len(tt.want) {
+				t.Fatalf("drift ids = %v, want %v", ids, tt.want)
+			}
+			for i := range ids {
+				if ids[i] != tt.want[i] {
+					t.Errorf("drift[%d] = %s, want %s", i, ids[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestFolderRedirectionState(t *testing.T) {
 	tests := []struct{ raw, want string }{
 		{`C:\Users\bob\OneDrive - Contoso\Documents`, "redirected"},

--- a/agent/internal/onedrivehelper/onedrivehelper_windows.go
+++ b/agent/internal/onedrivehelper/onedrivehelper_windows.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -234,18 +236,23 @@ func applyUserAutoMount(sid string, rules []LibraryRule) (written []LibraryRule,
 }
 
 // pokeAutoMountTimer forces OneDrive to process AutoMount promptly (it
-// otherwise runs on an up-to-8h timer). Only possible when the user has a
-// Business1 account key (i.e. is signed in); missing key is fine — OneDrive
-// will process on sign-in. Business1 specifically: any signed-in business
-// account's OneDrive process serves the same AutoMount timer, so poking the
-// primary slot is sufficient — no need to enumerate Business2..9 here.
+// otherwise runs on an up-to-8h timer). The poke lives under a work-account
+// slot key, so it is only possible when the user is signed in to at least one;
+// no slot at all is fine — OneDrive processes AutoMount on sign-in anyway.
+//
+// Every populated slot is poked, not just Business1: account slots are sparse
+// after an unlink, so a profile can have Business2/Business3 with no Business1
+// at all. Poking only slot 1 on such a profile is a silent no-op and the newly
+// entitled library then waits on OneDrive's own multi-hour timer.
 func pokeAutoMountTimer(sid string) {
-	k, err := registry.OpenKey(registry.USERS, sid+`\`+businessAccountKeyPath(1), registry.SET_VALUE)
-	if err != nil {
-		return
+	for n := 1; n <= maxBusinessAccounts; n++ {
+		k, err := registry.OpenKey(registry.USERS, sid+`\`+businessAccountKeyPath(n), registry.SET_VALUE)
+		if err != nil {
+			continue // slot not present (sparse accounts) — keep scanning
+		}
+		_ = k.SetQWordValue("TimerAutoMount", 1)
+		k.Close()
 	}
-	defer k.Close()
-	_ = k.SetQWordValue("TimerAutoMount", 1)
 }
 
 // activeUserSessions enumerates active WTS sessions and resolves each to a SID
@@ -286,15 +293,72 @@ func activeUserSessions() []userSession {
 	return out
 }
 
+// sidLookupCache memoizes successful group-name → SID resolutions.
+//
+// LookupSID is an LSA call that, for a domain group on a workstation with no
+// cached ticket, becomes a network round-trip to a DC. PartitionLibraries calls
+// isTokenGroupMember once per local_ad_group rule per session per Apply, so a
+// policy with a handful of group-targeted libraries across two logged-on users
+// pays that cost every heartbeat cycle — on a slow or unreachable DC link the
+// repeated lookups are the whole cost of the pass.
+//
+// Only successes are cached: a miss usually means the group does not exist YET
+// (just created, or the DC was briefly unreachable), and caching that would
+// keep the library fail-closed long after the group appeared. Entries expire so
+// a group deleted and recreated under a new SID converges without a restart.
+var sidLookupCache = struct {
+	sync.Mutex
+	entries map[string]sidLookupEntry
+}{entries: map[string]sidLookupEntry{}}
+
+type sidLookupEntry struct {
+	sid       string
+	expiresAt time.Time
+}
+
+const sidLookupTTL = 10 * time.Minute
+
+// lookupGroupSID resolves a group name to its uppercase SID string, memoized
+// for sidLookupTTL. Returns ok=false when the name cannot be resolved.
+func lookupGroupSID(groupName string) (string, bool) {
+	key := strings.ToUpper(groupName)
+	now := time.Now()
+
+	sidLookupCache.Lock()
+	if e, hit := sidLookupCache.entries[key]; hit && now.Before(e.expiresAt) {
+		sidLookupCache.Unlock()
+		return e.sid, true
+	}
+	sidLookupCache.Unlock()
+
+	// Resolved outside the lock: a slow DC round-trip must not block the other
+	// sessions' lookups. A duplicate concurrent resolve is harmless (same answer).
+	sid, _, _, err := windows.LookupSID("", groupName)
+	if err != nil {
+		return "", false
+	}
+	upper := strings.ToUpper(sid.String())
+
+	sidLookupCache.Lock()
+	// Keys come from policy-authored group names, so the map is naturally tiny;
+	// the cap is only a backstop against an absurd policy growing it unbounded.
+	if len(sidLookupCache.entries) >= 256 {
+		sidLookupCache.entries = map[string]sidLookupEntry{}
+	}
+	sidLookupCache.entries[key] = sidLookupEntry{sid: upper, expiresAt: now.Add(sidLookupTTL)}
+	sidLookupCache.Unlock()
+	return upper, true
+}
+
 // isTokenGroupMember resolves a local/domain group name to a SID and checks the
 // session token's group list. Unresolvable names are treated as non-member
 // (fail closed).
 func isTokenGroupMember(s userSession, groupName string) bool {
-	sid, _, _, err := windows.LookupSID("", groupName)
-	if err != nil {
+	sid, ok := lookupGroupSID(groupName)
+	if !ok {
 		return false
 	}
-	return s.groupSIDs[strings.ToUpper(sid.String())]
+	return s.groupSIDs[sid]
 }
 
 // sessionUpns reads the signed-in user's UPNs across all of the session's

--- a/apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts
+++ b/apps/api/src/__tests__/integration/onedrive-helper-config-delivery.integration.test.ts
@@ -523,6 +523,47 @@ describe('buildOnedriveHelperConfigUpdate', () => {
     expect(cfg!.libraries[0]!.allowedUpns).toEqual(['a@contoso.com', 'b@contoso.com']);
   });
 
+  // #2336: the per-UPN Graph resolutions used to run strictly one at a time.
+  // A multi-session host (RDS/VDI) reports one UPN per logged-on user, and
+  // serialized round-trips sum into the 15s tagging budget fast enough that the
+  // last users go untagged — their libraries then silently never mount. They
+  // now run through a small fixed-size pool.
+  runDb('resolves the per-UPN Graph memberships concurrently, capped, and order-stably', async () => {
+    const upns = ['a@contoso.com', 'b@contoso.com', 'c@contoso.com', 'd@contoso.com', 'e@contoso.com', 'f@contoso.com'];
+    const { deviceId, orgId } = await seedDeviceWithOnedrivePolicy({
+      base: {},
+      libraries: [
+        { libraryId: 'lib-fin', displayName: 'Finance', targetingMode: 'graph_group', groupId: 'g-fin' },
+      ],
+    });
+    await seedSignedInUpns(deviceId, orgId, upns);
+
+    let inFlight = 0;
+    let peakInFlight = 0;
+    // Each call parks on a macrotask before resolving, so a serialized
+    // implementation can never show more than one call in flight at a time —
+    // making peakInFlight > 1 real evidence of overlap rather than an artifact
+    // of already-resolved promises.
+    vi.mocked(resolveUserGroupMembershipCached).mockImplementation(async () => {
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+      return { kind: 'ok', data: { groupIds: ['g-fin'] } };
+    });
+
+    const cfg = await withSystemDbAccessContext(() => buildOnedriveHelperConfigUpdate(deviceId));
+
+    expect(resolveUserGroupMembershipCached).toHaveBeenCalledTimes(upns.length);
+    expect(peakInFlight).toBeGreaterThan(1);
+    // Capped on purpose: these calls share one org's Graph token and rate
+    // limit, so an unbounded fan-out trades 429s for the latency win.
+    expect(peakInFlight).toBeLessThanOrEqual(4);
+    // Reported in the ORIGINAL UPN order, not completion order — allowedUpns
+    // must be deterministic for a given input however the pool interleaved.
+    expect(cfg!.libraries[0]!.allowedUpns).toEqual(upns);
+  });
+
   runDb('group id matching is brace/case-insensitive (stored {UPPER} vs Graph lower)', async () => {
     const { deviceId, orgId } = await seedDeviceWithOnedrivePolicy({
       base: {},

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -2956,23 +2956,54 @@ async function resolveDeviceOnedriveSettings(deviceId: string): Promise<Onedrive
     // already-claimed commands. Past the budget, remaining UPNs stay untagged
     // this cycle (fail closed) and retry next heartbeat against a warm cache.
     const taggingDeadline = Date.now() + 15_000;
-    for (const upn of upns) {
-      if (Date.now() > taggingDeadline) {
-        console.warn(`[agents] graph_group tagging: time budget exhausted for device ${deviceId}; remaining UPNs untagged this cycle`);
-        break;
+
+    // Resolved through a small fixed-size worker pool rather than one at a
+    // time: a multi-session host (RDS/VDI) reports a UPN per logged-on user,
+    // and serialized round-trips sum into the 15s budget fast enough that the
+    // last users go untagged — their libraries then silently don't mount. The
+    // cap stays small on purpose: these calls share one org's Graph token and
+    // rate limit, so widening it trades a burst of 429s for the latency win.
+    const TAGGING_CONCURRENCY = 4;
+    const memberships = new Array<Set<string> | null>(upns.length).fill(null);
+    let nextIndex = 0;
+    let budgetExhausted = false;
+
+    const worker = async () => {
+      for (;;) {
+        const i = nextIndex++;
+        if (i >= upns.length) return;
+        if (Date.now() > taggingDeadline) {
+          budgetExhausted = true;
+          return;
+        }
+        const res = await resolveUserGroupMembershipCached(device.orgId, upns[i]!);
+        if (res.kind !== 'ok') {
+          // Deliberately no UPN in the log line — it's end-user PII; the code +
+          // deviceId is enough to triage.
+          console.warn(`[agents] graph_group tagging: membership lookup failed for device ${deviceId}: ${res.code}`);
+          continue;
+        }
+        memberships[i] = new Set(res.data.groupIds.map(normalizeGuid));
       }
-      const res = await resolveUserGroupMembershipCached(device.orgId, upn);
-      if (res.kind !== 'ok') {
-        // Deliberately no UPN in the log line — it's end-user PII; the code +
-        // deviceId is enough to triage.
-        console.warn(`[agents] graph_group tagging: membership lookup failed for device ${deviceId}: ${res.code}`);
-        continue;
-      }
-      const groupIds = new Set(res.data.groupIds.map(normalizeGuid));
+    };
+
+    await Promise.all(
+      Array.from({ length: Math.min(TAGGING_CONCURRENCY, upns.length) }, () => worker()),
+    );
+
+    if (budgetExhausted) {
+      console.warn(`[agents] graph_group tagging: time budget exhausted for device ${deviceId}; remaining UPNs untagged this cycle`);
+    }
+
+    // Applied in the original UPN order (not completion order) so allowedUpns
+    // is deterministic for a given input regardless of how the pool interleaved.
+    for (let i = 0; i < upns.length; i++) {
+      const groupIds = memberships[i];
+      if (!groupIds) continue;
       for (const rule of graphRules) {
         if (rule.groupId && groupIds.has(normalizeGuid(rule.groupId))) {
           const arr = allowedByLib.get(rule.id) ?? [];
-          arr.push(upn);
+          arr.push(upns[i]!);
           allowedByLib.set(rule.id, arr);
         }
       }

--- a/apps/api/src/routes/onedrive.ts
+++ b/apps/api/src/routes/onedrive.ts
@@ -68,8 +68,23 @@ onedriveRoutes.get(
     if (!device) {
       return c.json({ error: 'Device not found' }, 404);
     }
+    // Explicit projection, not `select()`: the panel consumes exactly these
+    // columns (OneDriveDeviceState in apps/web/src/lib/api/onedrive.ts), and a
+    // whole-row select would ship internal bookkeeping columns to the browser
+    // and silently widen the response whenever a column is added to the table.
     const [state] = await db
-      .select().from(onedriveDeviceState)
+      .select({
+        deviceId: onedriveDeviceState.deviceId,
+        signedIn: onedriveDeviceState.signedIn,
+        filesOnDemandOn: onedriveDeviceState.filesOnDemandOn,
+        oneDriveVersion: onedriveDeviceState.oneDriveVersion,
+        kfmFolderStates: onedriveDeviceState.kfmFolderStates,
+        mountedLibraries: onedriveDeviceState.mountedLibraries,
+        entitledLibraries: onedriveDeviceState.entitledLibraries,
+        driftEntries: onedriveDeviceState.driftEntries,
+        lastReportedAt: onedriveDeviceState.lastReportedAt,
+      })
+      .from(onedriveDeviceState)
       .where(eq(onedriveDeviceState.deviceId, deviceId)).limit(1);
     return c.json({ state: state ?? null });
   }

--- a/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.test.tsx
+++ b/apps/web/src/components/configurationPolicies/ConfigPolicyDetailPage.test.tsx
@@ -230,6 +230,24 @@ describe('ConfigPolicyDetailPage — URL hash deep-linking', () => {
     expect(screen.getByTestId('patch-tab-editor')).toBeInTheDocument();
   });
 
+  // #2336: `#onedrive_helper` used to land on Overview. jsdom reports every
+  // measured button width as 0, so OverflowTabs keeps exactly one tab visible
+  // and everything else — OneDrive Helper included — lives in the "More"
+  // dropdown. That makes this the overflow-tab case: the hash must still
+  // select the tab even though its button is never rendered in the nav bar,
+  // and the "More" button must show the active tab's label instead.
+  it('selects an OVERFLOW feature tab from the initial hash (#onedrive_helper)', async () => {
+    window.location.hash = '#onedrive_helper';
+    mockPolicy({ orgId: 'org-1', partnerId: null });
+    render(<ConfigPolicyDetailPage policyId="pol-1" />);
+
+    await screen.findByRole('heading', { name: 'Test Policy' });
+    expect(screen.getByTestId('onedrive-tab-editor')).toBeInTheDocument();
+    // The overflow trigger takes on the active tab's identity rather than "More".
+    expect(screen.getByRole('button', { name: /OneDrive Helper/i })).toBeInTheDocument();
+    expect(screen.queryByText('More')).not.toBeInTheDocument();
+  });
+
   it('writes the tab id to the hash when a tab is selected', async () => {
     mockPolicy({ orgId: 'org-1', partnerId: null });
     render(<ConfigPolicyDetailPage policyId="pol-1" />);

--- a/apps/web/src/components/configurationPolicies/featureTabs/FeatureTabShell.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/FeatureTabShell.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import FeatureTabShell from './FeatureTabShell';
+import { i18n } from '../../../lib/i18n';
+
+// FeatureTabShell renders the footer controls for EVERY configuration-policy
+// feature tab, so the disabled-state rules below apply fleet-wide, not just to
+// the tab that surfaced the bug (#2336, OneDrive Helper).
+describe('FeatureTabShell footer controls', () => {
+  const baseProps = {
+    title: 'OneDrive Helper',
+    description: 'Auto-mount SharePoint libraries.',
+    icon: <span data-testid="icon" />,
+    isConfigured: false,
+    children: <div data-testid="body" />,
+  };
+
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  const overrideButton = () => screen.getByRole('button', { name: /Override/i });
+
+  it('disables Override while a save is in flight (#2336)', () => {
+    // Override POSTs a brand-new link (persist(null)). Only Save was gated on
+    // `saving`, so a double-click during the round-trip fired the create twice
+    // — the second one landing on a policy that already had the link.
+    const onOverride = vi.fn();
+    render(
+      <FeatureTabShell
+        {...baseProps}
+        saving
+        isInherited
+        onOverride={onOverride}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(overrideButton()).toBeDisabled();
+    fireEvent.click(overrideButton());
+    expect(onOverride).not.toHaveBeenCalled();
+  });
+
+  it('still disables Override on client-side validation failure while idle', () => {
+    render(
+      <FeatureTabShell
+        {...baseProps}
+        saving={false}
+        saveDisabled
+        isInherited
+        onOverride={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(overrideButton()).toBeDisabled();
+  });
+
+  it('enables Override when idle and valid', () => {
+    const onOverride = vi.fn();
+    render(
+      <FeatureTabShell
+        {...baseProps}
+        saving={false}
+        isInherited
+        onOverride={onOverride}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(overrideButton()).toBeEnabled();
+    fireEvent.click(overrideButton());
+    expect(onOverride).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/FeatureTabShell.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/FeatureTabShell.tsx
@@ -106,7 +106,7 @@ export default function FeatureTabShell({
               <button
                 type="button"
                 onClick={onOverride}
-                disabled={saveDisabled}
+                disabled={saving || saveDisabled}
                 className="inline-flex items-center gap-2 rounded-md border border-primary/40 px-3 py-2 text-sm font-medium text-primary transition hover:bg-primary/10 disabled:opacity-50"
               >
                 <PenLine className="h-4 w-4" />

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.test.tsx
@@ -245,6 +245,105 @@ describe('OneDriveHelperTab', () => {
     await waitFor(() => expect(mockedStatus).toHaveBeenCalledWith('org-99'));
   });
 
+  it('trims free-text fields on Save; a whitespace-only optional field serializes as null (#2336)', async () => {
+    const existingLink: FeatureLink = {
+      id: 'link-1',
+      featureType: 'onedrive_helper',
+      featurePolicyId: null,
+      inlineSettings: {
+        kfmSilentOptIn: true,
+        tenantAssociationId: null,
+        libraries: [
+          {
+            libraryId: 'tenantId=t1&siteId=s1',
+            displayName: 'Marketing Share',
+            targetingMode: 'local_ad_group',
+            groupName: 'Placeholder',
+            hiveScope: 'hkcu',
+            enabled: true,
+          },
+        ],
+      },
+    };
+
+    render(<OneDriveHelperTab {...baseProps} existingLink={existingLink} />);
+
+    // KFM is on -> tenant association input is visible; pad it with whitespace
+    // only, which must collapse to null rather than persist as blank spaces.
+    fireEvent.change(screen.getByTestId('onedrive-tenant-association'), {
+      target: { value: '   ' },
+    });
+    // Group name padded with real content on both sides — must be trimmed,
+    // not persisted with the surrounding whitespace baked in.
+    fireEvent.change(screen.getByTestId('onedrive-lib-groupname-0'), {
+      target: { value: '  Domain Admins  ' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+
+    const [, payload] = saveMock.mock.calls[0] as [
+      string | null,
+      { inlineSettings: { tenantAssociationId: unknown; libraries: Array<Record<string, unknown>> } },
+    ];
+    expect(payload.inlineSettings.tenantAssociationId).toBeNull();
+    expect(payload.inlineSettings.libraries[0]).toMatchObject({ groupName: 'Domain Admins' });
+  });
+
+  it('removing the first of two library rows leaves the second row\'s own values, keyed by rowKey not index (#2336)', () => {
+    const existingLink: FeatureLink = {
+      id: 'link-1',
+      featureType: 'onedrive_helper',
+      featurePolicyId: null,
+      inlineSettings: {
+        libraries: [
+          {
+            libraryId: 'tenantId=t1&siteId=s1',
+            displayName: 'First Library',
+            targetingMode: 'local_ad_group',
+            groupName: 'First Group',
+            hiveScope: 'hkcu',
+            enabled: true,
+          },
+          {
+            libraryId: 'tenantId=t1&siteId=s2',
+            displayName: 'Second Library',
+            targetingMode: 'local_ad_group',
+            groupName: 'Second Group',
+            hiveScope: 'hkcu',
+            enabled: true,
+          },
+        ],
+      },
+    };
+
+    render(<OneDriveHelperTab {...baseProps} existingLink={existingLink} />);
+
+    expect(screen.getByText('First Library')).toBeTruthy();
+    expect(screen.getByText('Second Library')).toBeTruthy();
+
+    // Identity, not rendered text, is what distinguishes the two keying
+    // strategies. Every input here is controlled, so React re-renders the
+    // correct VALUES either way — asserting on text would pass with index keys
+    // too. What differs is which DOM node survives: keyed by rowKey, the second
+    // library keeps the very node it was already rendered into; keyed by index,
+    // React instead reuses the removed first row's node and unmounts the
+    // second's, discarding any DOM-local state (focus, selection, scroll) with it.
+    const secondRowBefore = screen.getByTestId('onedrive-lib-row-1');
+    const secondGroupInputBefore = screen.getByTestId('onedrive-lib-groupname-1');
+
+    fireEvent.click(screen.getByTestId('onedrive-lib-remove-0'));
+
+    expect(screen.queryByText('First Library')).toBeNull();
+    expect(screen.getByText('Second Library')).toBeTruthy();
+    // The surviving row now renders at DOM index 0 — and must be the SAME node.
+    expect(screen.getByTestId('onedrive-lib-row-0')).toBe(secondRowBefore);
+    expect(screen.getByTestId('onedrive-lib-groupname-0')).toBe(secondGroupInputBefore);
+    expect(
+      (screen.getByTestId('onedrive-lib-groupname-0') as HTMLInputElement).value,
+    ).toBe('Second Group');
+  });
+
   it('inherited (parentLink only) shows Override and no direct Save', () => {
     const parentLink: FeatureLink = {
       id: 'parent-link',

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveHelperTab.tsx
@@ -10,6 +10,16 @@ type TargetingMode = 'everyone' | 'graph_group' | 'local_ad_group';
 type KfmFolder = 'Desktop' | 'Documents' | 'Pictures';
 
 type LibraryMapping = {
+  /**
+   * Client-only identity for React's list key. The natural candidate —
+   * `libraryId` — is not guaranteed unique (nothing stops a tech adding the
+   * same library twice, and the manual-paste path bypasses the picker), and an
+   * array index is worse: removing a row shifts every later row's key, so React
+   * reuses the wrong DOM nodes and the group-name/group-id inputs appear to
+   * jump onto a different library. Never sent to the server — `toPayload` is an
+   * explicit allowlist.
+   */
+  rowKey: string;
   libraryId: string;
   displayName: string;
   siteUrl?: string | null;
@@ -65,8 +75,12 @@ function libraryError(lib: LibraryMapping): string | null {
   return null;
 }
 
+let rowKeySeq = 0;
+const nextRowKey = () => `lib-${++rowKeySeq}`;
+
 function normalizeLibrary(raw: Partial<LibraryMapping>): LibraryMapping {
   return {
+    rowKey: raw.rowKey ?? nextRowKey(),
     libraryId: raw.libraryId ?? '',
     displayName: raw.displayName ?? '',
     siteUrl: raw.siteUrl ?? null,
@@ -159,24 +173,34 @@ export default function OneDriveHelperTab({ policyId, existingLink, onLinkChange
 
   // EventLogTab-style allowlist: build the wire payload from known keys only so
   // legacy/unknown fields on an older link are never re-persisted.
+  //
+  // Every free-text field is trimmed on the way out: the row-level validation
+  // in `libraryError` already compares trimmed values, so an all-whitespace
+  // group name passes Save and then persists as a targeting value the agent
+  // can never match. Trimmed-to-empty optional fields collapse to null so the
+  // stored shape matches a field the tech never filled in.
+  const trimOrNull = (v?: string | null) => {
+    const t = v?.trim();
+    return t ? t : null;
+  };
   const toPayload = (s: OneDriveHelperSettings) => ({
     silentAccountConfig: s.silentAccountConfig,
     filesOnDemand: s.filesOnDemand,
     kfmSilentOptIn: s.kfmSilentOptIn,
     kfmFolders: s.kfmFolders,
     kfmBlockOptOut: s.kfmBlockOptOut,
-    tenantAssociationId: s.tenantAssociationId?.trim() ? s.tenantAssociationId.trim() : null,
+    tenantAssociationId: trimOrNull(s.tenantAssociationId),
     restartOnChange: s.restartOnChange,
     libraries: s.libraries.map((lib) => ({
-      libraryId: lib.libraryId,
-      displayName: lib.displayName,
-      siteUrl: lib.siteUrl ?? null,
-      siteId: lib.siteId ?? null,
-      webId: lib.webId ?? null,
-      listId: lib.listId ?? null,
+      libraryId: lib.libraryId.trim(),
+      displayName: lib.displayName.trim(),
+      siteUrl: trimOrNull(lib.siteUrl),
+      siteId: trimOrNull(lib.siteId),
+      webId: trimOrNull(lib.webId),
+      listId: trimOrNull(lib.listId),
       targetingMode: lib.targetingMode,
-      groupId: lib.groupId ?? null,
-      groupName: lib.groupName ?? null,
+      groupId: trimOrNull(lib.groupId),
+      groupName: trimOrNull(lib.groupName),
       hiveScope: lib.hiveScope,
       enabled: lib.enabled,
     })),
@@ -338,7 +362,7 @@ export default function OneDriveHelperTab({ policyId, existingLink, onLinkChange
               const hint = siteHint(lib.siteUrl);
               return (
                 <div
-                  key={idx}
+                  key={lib.rowKey}
                   data-testid={`onedrive-lib-row-${idx}`}
                   className="space-y-3 rounded-md border bg-background px-4 py-4"
                 >

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.test.tsx
@@ -198,4 +198,42 @@ describe('OneDriveLibraryPicker', () => {
 
     await waitFor(() => expect(screen.getByTestId('onedrive-picker-add-drive-1')).toBeTruthy());
   });
+
+  it('a superseded org\'s slow response cannot clobber the current one (#2336)', async () => {
+    // Async effects are gated on a `requestRef` generation token. The visible
+    // consequence is ordering: Graph library enumeration is slow and varies
+    // wildly per tenant, so switching orgs while a fetch is in flight routinely
+    // lands the OLD response last. Ungated, it would overwrite the org the tech
+    // is actually looking at with another org's libraries — a cross-tenant
+    // display bug, not just a stray-setState warning.
+    //
+    // (Deliberately NOT asserted via a "setState after unmount" console
+    // warning: React 19 no longer emits one, so that assertion passes with the
+    // guards deleted — it proves nothing.)
+    const orgALib = lib({ driveId: 'drive-org-a', libraryName: 'Org A Docs' });
+    const orgBLib = lib({ driveId: 'drive-org-b', libraryName: 'Org B Docs' });
+
+    let resolveA!: (v: { libraries: OneDriveLibrary[]; skippedSites: [] }) => void;
+    const pendingA = new Promise<{ libraries: OneDriveLibrary[]; skippedSites: [] }>((r) => {
+      resolveA = r;
+    });
+
+    mockedStatus.mockResolvedValue(true);
+    mockedLibraries.mockImplementation(((orgId?: string) =>
+      orgId === 'org-a'
+        ? pendingA
+        : Promise.resolve({ libraries: [orgBLib], skippedSites: [] })) as typeof api.fetchOneDriveLibraries);
+
+    const { rerender } = render(<OneDriveLibraryPicker orgId="org-a" onAdd={onAdd} onClose={onClose} />);
+    // Switch orgs while org-a's enumeration is still outstanding.
+    rerender(<OneDriveLibraryPicker orgId="org-b" onAdd={onAdd} onClose={onClose} />);
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-add-drive-org-b')).toBeTruthy());
+
+    // org-a finally answers — too late, and for an org we are no longer showing.
+    resolveA({ libraries: [orgALib], skippedSites: [] });
+    await pendingA;
+    await waitFor(() => expect(screen.getByTestId('onedrive-picker-add-drive-org-b')).toBeTruthy());
+    expect(screen.queryByTestId('onedrive-picker-add-drive-org-a')).toBeNull();
+    expect(screen.queryByText('Org A Docs')).toBeNull();
+  });
 });

--- a/apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/OneDriveLibraryPicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import { X, Search, Cloud, Loader2, Plus, AlertTriangle, CloudOff } from 'lucide-react';
 import {
   fetchM365ConnectionStatus,
@@ -51,40 +51,70 @@ export default function OneDriveLibraryPicker({ orgId, onAdd, onClose }: OneDriv
   const [query, setQuery] = useState('');
   const [manualOpen, setManualOpen] = useState(false);
 
-  const loadLibraries = useCallback(async () => {
-    setPhase('loading');
-    setError(undefined);
-    try {
-      const { libraries: libs, skippedSites: skipped } = await fetchOneDriveLibraries(orgId);
-      setLibraries(libs);
-      setSkippedSites(skipped);
-      setPhase('ready');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load libraries.');
-      setPhase('error');
-    }
-  }, [orgId]);
+  // Generation token for the in-flight connection/library fetch. Every state
+  // write that happens after an `await` is gated on it, and the token is
+  // invalidated on unmount, on an `orgId` change, and on each Retry. Graph
+  // calls here are slow (a site enumeration plus a drive call per site), so
+  // closing the picker mid-flight — or retrying twice — is easy to do by hand:
+  // without the gate a late response either warns about setting state on an
+  // unmounted component or overwrites the newer request's result.
+  const requestRef = useRef(0);
+
+  const loadLibraries = useCallback(
+    async (token: number) => {
+      setPhase('loading');
+      setError(undefined);
+      try {
+        const { libraries: libs, skippedSites: skipped } = await fetchOneDriveLibraries(orgId);
+        if (token !== requestRef.current) return;
+        setLibraries(libs);
+        setSkippedSites(skipped);
+        setPhase('ready');
+      } catch (err) {
+        if (token !== requestRef.current) return;
+        setError(err instanceof Error ? err.message : 'Failed to load libraries.');
+        setPhase('error');
+      }
+    },
+    [orgId],
+  );
 
   // Check connection FIRST; only fetch libraries when actually connected.
-  const checkConnection = useCallback(async () => {
-    setPhase('checking');
-    setError(undefined);
-    try {
-      const connected = await fetchM365ConnectionStatus(orgId);
-      if (connected) {
-        await loadLibraries();
-      } else {
-        setPhase('disconnected');
+  const checkConnection = useCallback(
+    async (token: number) => {
+      setPhase('checking');
+      setError(undefined);
+      try {
+        const connected = await fetchM365ConnectionStatus(orgId);
+        if (token !== requestRef.current) return;
+        if (connected) {
+          await loadLibraries(token);
+        } else {
+          setPhase('disconnected');
+        }
+      } catch (err) {
+        if (token !== requestRef.current) return;
+        setError(err instanceof Error ? err.message : 'Failed to check the Microsoft 365 connection.');
+        setPhase('error');
       }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to check the Microsoft 365 connection.');
-      setPhase('error');
-    }
-  }, [orgId, loadLibraries]);
+    },
+    [orgId, loadLibraries],
+  );
+
+  // Claims a fresh token (invalidating whatever was in flight) and starts a load.
+  const startCheck = useCallback(() => {
+    requestRef.current += 1;
+    void checkConnection(requestRef.current);
+  }, [checkConnection]);
 
   useEffect(() => {
-    void checkConnection();
-  }, [checkConnection]);
+    startCheck();
+    // Bumping on cleanup invalidates the request this effect started, so a
+    // response that lands after unmount is dropped instead of setting state.
+    return () => {
+      requestRef.current += 1;
+    };
+  }, [startCheck]);
 
   // Group filtered libraries by site name, preserving first-seen order.
   const groups = useMemo(() => {
@@ -172,7 +202,7 @@ export default function OneDriveLibraryPicker({ orgId, onAdd, onClose }: OneDriv
               <button
                 type="button"
                 data-testid="onedrive-picker-retry"
-                onClick={() => void checkConnection()}
+                onClick={startCheck}
                 className="inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition hover:bg-muted"
               >
                 Retry

--- a/apps/web/src/components/onedrive/OneDriveFleetPage.test.tsx
+++ b/apps/web/src/components/onedrive/OneDriveFleetPage.test.tsx
@@ -179,6 +179,23 @@ describe('OneDriveFleetPage', () => {
     expect(drift.className).toMatch(/amber/);
   });
 
+  it('KFM caption reads "of total reporting", not "of signedIn signed in" (#2336)', async () => {
+    // The server computes kfmProtected over EVERY reporting device, not just
+    // signed-in ones — pick a set that is impossible to read correctly under
+    // the old "of {signedIn} signed in" caption: 6 protected out of only 4
+    // signed-in devices. The devices array itself is irrelevant to this card;
+    // only `stats` drives the caption and warning threshold.
+    vi.mocked(api.fetchOneDriveFleetState).mockResolvedValue({
+      devices: [],
+      stats: { total: 10, signedIn: 4, kfmProtected: 6, withDrift: 0 },
+    });
+    render(<OneDriveFleetPage />);
+
+    const kfmCard = await screen.findByTestId('onedrive-stat-kfm');
+    expect(kfmCard).toHaveTextContent('of 10 reporting');
+    expect(kfmCard).not.toHaveTextContent('signed in');
+  });
+
   it('shows the empty state when no devices are reporting', async () => {
     vi.mocked(api.fetchOneDriveFleetState).mockResolvedValue({
       devices: [],

--- a/apps/web/src/components/onedrive/OneDriveFleetPage.tsx
+++ b/apps/web/src/components/onedrive/OneDriveFleetPage.tsx
@@ -111,7 +111,12 @@ export function OneDriveFleetPage() {
   const filtered = useMemo(() => devices.filter((d) => matchesFilter(d, filter)), [devices, filter]);
 
   const total = stats?.total ?? 0;
-  const kfmWarning = stats !== null && stats.kfmProtected < stats.signedIn;
+  // The server derives `kfmProtected` from EVERY reporting device (not just the
+  // signed-in ones), and the "kfm-gap" row filter matches that same population,
+  // so the tile's caption and warning threshold must use `total` as the
+  // denominator. Comparing against `signedIn` reads as a different ratio than
+  // the number actually shown.
+  const kfmWarning = stats !== null && stats.kfmProtected < stats.total;
 
   const renderDriftCount = (row: OneDriveFleetRow) => {
     const n = row.driftEntries.length;
@@ -233,7 +238,7 @@ export function OneDriveFleetPage() {
             label="KFM protected"
             value={stats?.kfmProtected ?? '—'}
             variant={kfmWarning ? 'warning' : 'success'}
-            detail={stats ? `of ${stats.signedIn} signed in` : undefined}
+            detail={stats ? `of ${stats.total} reporting` : undefined}
             loading={loading}
             interactive
             active={filter === 'kfm-gap'}


### PR DESCRIPTION
Batches the non-blocking minors deferred across the OneDrive Helper review waves (#2311, #2318, #2322, #2332) into one pass. No new tables, columns, or migrations.

## Web

| Item | Fix |
|---|---|
| `kfmProtected` rollup caption mismatch | The tile captioned itself "of {signedIn} signed in", but the server derives `kfmProtected` from **every** reporting device — as does the tile's own `kfm-gap` row filter. Caption and warning threshold now both use `total`. |
| Override not disabled while `saving` | `FeatureTabShell`'s Override button was gated only on `saveDisabled`, so a double-click during the create round-trip fired `persist(null)` twice. Now gated on `saving` too — this is the shared shell, so it applies to **every** feature tab. |
| `toPayload` should trim string inputs | Every free-text field is trimmed on the way out; trimmed-to-empty optionals collapse to `null`. `libraryError` already validated against trimmed values, so an all-whitespace group name passed Save and persisted as a targeting value the agent can never match. |
| Value-based React keys | Library rows are keyed by a stable client-side `rowKey` rather than the array index, so removing a row no longer hands the next row's props to the removed row's DOM node. |
| Library picker unmount guards | Async effects are gated on a request-generation token, invalidated on unmount, on `orgId` change, and on Retry. |
| `#onedrive_helper` hash → overflow tab | **Already fixed** by the `useHashTab` work in #2421; verified and pinned with a regression test rather than re-fixed. |

## API

- `GET /onedrive/devices/:id/state` selected the whole state row; it now projects exactly the columns the panel consumes, so a future column cannot silently widen the response.
- Per-UPN Graph membership resolutions ran strictly serially under a 15s budget. On a multi-session host (RDS/VDI) the later users' lookups fell off the end of that budget and their libraries silently never mounted. They now run through a fixed **4-way pool** — capped deliberately, since these calls share one org's Graph token and rate limit. Results are applied in the original UPN order, so `allowedUpns` stays deterministic regardless of interleaving.

## Agent

- `pokeAutoMountTimer` poked the `Business1` slot only. Account slots go sparse after an unlink, so a Business2/3-only profile got a silent no-op and waited on OneDrive's own multi-hour timer. All populated slots are now poked.
- Group-name → SID lookups are memoized for 10 minutes ahead of a broader `local_ad_group` rollout — `LookupSID` is a DC round-trip for a domain group and ran once per rule per session per heartbeat. Only successes are cached, so a group created after a miss still converges.
- `ComputeDrift` is now **site-qualified and one-to-one**. Matching the display name anywhere in any mounted path could not distinguish `Contoso HR - Documents` from `Contoso Legal - Documents`, so with two sites entitling a same-named library ("Documents" is the default on every SharePoint site) a single mount suppressed the drift report for both — a false negative seen in live QA. Each mounted folder now satisfies at most one rule, resolved in three passes: site-confirmed pairing, name-only pairing, then the legacy substring scan so an unrecognized cache shape degrades to the old behaviour instead of reporting drift on everything.

## Verification

- `agent`: `go test -race ./internal/onedrivehelper/...` green; `GOOS=windows go build ./...` green (the poke/SID changes are Windows-only).
- `apps/web`: 240 tests green across `src/components/configurationPolicies/` + the OneDrive fleet/device suites; `tsc --noEmit` clean.
- `apps/api`: `onedrive.test.ts`, `onedrive.state.test.ts`, `agents/heartbeat.test.ts` (136) green; `tsc --noEmit` clean.
- Integration (live DB + Redis): `onedrive-helper-config-delivery` + `onedrive-helper-write-path`, 29 green.
- New tests were **mutation-checked** — each was re-run against the pre-fix behavior and confirmed to fail. Three first-draft assertions passed under mutation and were rewritten: the row-key test (controlled inputs mask index keys, so it now asserts DOM node identity), the picker test (React 19 no longer warns on setState-after-unmount, so it now asserts a superseded org's late response cannot clobber the current one), and the concurrency test (verified failing at `TAGGING_CONCURRENCY = 1`).

Closes #2336

🤖 Generated with [Claude Code](https://claude.com/claude-code)