### PR TITLE
fix(web,api): billing punch-list a11y, toast anchor, and PDF wordmark (#2151)

### DIFF
--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -394,7 +394,9 @@ async function loadInvoiceForRender(invoiceId: string): Promise<{ invoice: Invoi
       // snapshot above still carries the company name — printing the word
       // "Invoice" in the wordmark slot (beside the header's own INVOICE
       // eyebrow) threw that away.
-      partnerName: partner?.name ?? (invoice.sellerSnapshot as SellerSnapshot | null)?.name ?? 'Invoice',
+      // `||`, not `??`: neither name column is constrained non-empty, and a
+      // blank wordmark is a worse document than the generic word.
+      partnerName: partner?.name || (invoice.sellerSnapshot as SellerSnapshot | null)?.name || 'Invoice',
       logoUrl: branding?.logoUrl ?? null,
       primaryColor: branding?.primaryColor ?? null,
       footerText: invoice.terms ?? partner?.invoiceFooter ?? branding?.footerText ?? null,

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -386,7 +386,15 @@ async function loadInvoiceForRender(invoiceId: string): Promise<{ invoice: Invoi
     invoice,
     lines,
     branding: {
-      partnerName: partner?.name ?? 'Invoice',
+      // Seller-snapshot fallback before the document-type literal (#2151), so
+      // the invoice PDF degrades the same way the quote side does
+      // (resolveQuoteBranding) and the same way both web previews already do
+      // (`branding.partnerName || seller.name`). A partner row that reads back
+      // empty is an RLS/scope artifact, not a nameless partner, and the frozen
+      // snapshot above still carries the company name — printing the word
+      // "Invoice" in the wordmark slot (beside the header's own INVOICE
+      // eyebrow) threw that away.
+      partnerName: partner?.name ?? (invoice.sellerSnapshot as SellerSnapshot | null)?.name ?? 'Invoice',
       logoUrl: branding?.logoUrl ?? null,
       primaryColor: branding?.primaryColor ?? null,
       footerText: invoice.terms ?? partner?.invoiceFooter ?? branding?.footerText ?? null,

--- a/apps/api/src/services/quoteBranding.test.ts
+++ b/apps/api/src/services/quoteBranding.test.ts
@@ -96,6 +96,18 @@ describe('resolveQuoteBranding', () => {
     expect(b.partnerName).toBe('Proposal');
   });
 
+  it('blank names are skipped, not printed — a wordmark is never empty', async () => {
+    // Neither partners.name nor the snapshot's name is constrained non-empty,
+    // and `??` would happily hand an empty string to the renderer.
+    queue({ ...basePartner, name: '' }, baseBrand);
+    const frozen = { name: '', address: null, phone: null, email: null, website: null };
+    expect((await resolveQuoteBranding(source({ sellerSnapshot: frozen }))).partnerName).toBe('Proposal');
+
+    queue({ ...basePartner, name: '' }, baseBrand);
+    const named = { name: 'Frozen Co', address: null, phone: null, email: null, website: null };
+    expect((await resolveQuoteBranding(source({ sellerSnapshot: named }))).partnerName).toBe('Frozen Co');
+  });
+
   it('frozen sellerSnapshot wins; buildSellerSnapshot is not synthesized', async () => {
     queue(basePartner, baseBrand);
     const frozen = { name: 'Frozen Co', address: null, phone: null, email: null, website: null };

--- a/apps/api/src/services/quoteBranding.test.ts
+++ b/apps/api/src/services/quoteBranding.test.ts
@@ -61,7 +61,7 @@ describe('resolveQuoteBranding', () => {
     expect((await resolveQuoteBranding(source({ currencyCode: null }))).currencyCode).toBe('USD');
   });
 
-  it('partner absent → partnerName falls back to "Proposal", logo/color/seller null', async () => {
+  it('partner absent AND no frozen seller → partnerName falls back to "Proposal", logo/color/seller null', async () => {
     queue(null, baseBrand);
     const b = await resolveQuoteBranding(source());
     expect(b.partnerName).toBe('Proposal');
@@ -69,6 +69,31 @@ describe('resolveQuoteBranding', () => {
     // brand still resolves logo/color from the portal_branding read.
     expect(b.logoUrl).toBe('logo.png');
     expect(b.primaryColor).toBe('#1c8a9e');
+  });
+
+  it('partner absent but seller frozen → wordmark uses the frozen company name, not "Proposal" (#2151)', async () => {
+    // The realistic empty-partner case is the org-scoped RLS zero-row read the
+    // module header warns about, not a nameless partner — and a sent document
+    // still carries the seller name. Printing the document-type word in the
+    // wordmark slot threw away a name we already had.
+    queue(null, baseBrand);
+    const frozen = { name: 'Lantern IT Services', address: null, phone: null, email: null, website: null };
+    const b = await resolveQuoteBranding(source({ sellerSnapshot: frozen }));
+    expect(b.partnerName).toBe('Lantern IT Services');
+  });
+
+  it('a live partner still outranks the frozen seller name', async () => {
+    queue(basePartner, baseBrand);
+    const frozen = { name: 'Stale Co', address: null, phone: null, email: null, website: null };
+    const b = await resolveQuoteBranding(source({ sellerSnapshot: frozen }));
+    expect(b.partnerName).toBe('Lantern IT');
+  });
+
+  it('a frozen seller with a null name still degrades to "Proposal"', async () => {
+    queue(null, baseBrand);
+    const frozen = { name: null, address: null, phone: null, email: null, website: null };
+    const b = await resolveQuoteBranding(source({ sellerSnapshot: frozen }));
+    expect(b.partnerName).toBe('Proposal');
   });
 
   it('frozen sellerSnapshot wins; buildSellerSnapshot is not synthesized', async () => {

--- a/apps/api/src/services/quoteBranding.ts
+++ b/apps/api/src/services/quoteBranding.ts
@@ -18,7 +18,8 @@ import { buildSellerSnapshot, type SellerSnapshot } from './sellerSnapshot';
 import { resolveThemeId, resolvePageSize, type DocumentThemeId, type DocumentPageSize } from './documentThemes';
 
 export interface QuoteBranding {
-  /** Partner display name; falls back to "Proposal" when the partner is absent. */
+  /** Partner display name. Falls back to the document's frozen seller name when
+   *  the partner row is unreadable, and only then to "Proposal". */
   partnerName: string;
   /** Portal logo URL (data: or hosted) rendered directly in an <img>, or null. */
   logoUrl: string | null;
@@ -73,13 +74,24 @@ export async function resolveQuoteBranding(quote: QuoteBrandingSource): Promise<
 
   const snap = quote.presentationSnapshot as { theme?: string; pageSize?: string } | null;
 
+  const seller = (quote.sellerSnapshot as SellerSnapshot | null) ?? (partner ? buildSellerSnapshot(partner) : null);
+
   return {
-    partnerName: partner?.name ?? 'Proposal',
+    // Seller-snapshot fallback before the document-type literal (#2151). The
+    // realistic way `partner` comes back empty is the RLS zero-row read in the
+    // header note, not a genuinely nameless partner — and in exactly that case
+    // the document still carries the seller name frozen onto it at send time.
+    // Falling straight through to "Proposal" printed a document-type word where
+    // a company name belongs, next to the header's own PROPOSAL eyebrow. This
+    // also matches what the web preview already does (InvoiceDocument /
+    // QuoteDocument: `branding.partnerName || seller.name`), so PDF and preview
+    // now degrade identically instead of diverging on the same missing row.
+    partnerName: partner?.name ?? seller?.name ?? 'Proposal',
     logoUrl: brand?.logoUrl ?? null,
     primaryColor: brand?.primaryColor ?? null,
     footer: quote.terms ?? partner?.invoiceFooter ?? brand?.footerText ?? null,
     currencyCode: quote.currencyCode ?? partner?.currencyCode ?? 'USD',
-    seller: (quote.sellerSnapshot as SellerSnapshot | null) ?? (partner ? buildSellerSnapshot(partner) : null),
+    seller,
     theme: resolveThemeId(snap?.theme ?? partner?.documentTheme),
     pageSize: resolvePageSize(snap?.pageSize ?? partner?.documentPageSize),
   };

--- a/apps/api/src/services/quoteBranding.ts
+++ b/apps/api/src/services/quoteBranding.ts
@@ -86,7 +86,9 @@ export async function resolveQuoteBranding(quote: QuoteBrandingSource): Promise<
     // also matches what the web preview already does (InvoiceDocument /
     // QuoteDocument: `branding.partnerName || seller.name`), so PDF and preview
     // now degrade identically instead of diverging on the same missing row.
-    partnerName: partner?.name ?? seller?.name ?? 'Proposal',
+    // `||`, not `??`: neither column is constrained non-empty, and a blank
+    // wordmark is a worse document than the generic word.
+    partnerName: partner?.name || seller?.name || 'Proposal',
     logoUrl: brand?.logoUrl ?? null,
     primaryColor: brand?.primaryColor ?? null,
     footer: quote.terms ?? partner?.invoiceFooter ?? brand?.footerText ?? null,

--- a/apps/web/src/components/billing/InvoiceEditor.a11y.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.a11y.test.tsx
@@ -1,0 +1,93 @@
+// #2151 — every qty/price control in the invoice editor answered to the same
+// accessible name ("Quantity" / "Unit price"): the manual add-line row, the
+// catalog-pick row, and every persisted line row. A screen reader's
+// form-controls list was therefore a run of indistinguishable entries with
+// nothing to say which line each one belonged to.
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoiceEditor from './InvoiceEditor';
+import type { InvoiceDetail } from './invoiceTypes';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const namedLine: InvoiceDetail['lines'][number] = {
+  id: 'line-1', invoiceId: 'inv-1', sourceType: 'manual', parentLineId: null, catalogItemId: null,
+  name: 'Firewall install', description: 'Setup', quantity: '2.00', unitPrice: '50.00',
+  costBasis: null, revenueAllocation: null, taxable: false, customerVisible: true,
+  lineTotal: '100.00', isUnapprovedTime: false, sortOrder: 1,
+};
+
+const detailWith = (lines: InvoiceDetail['lines']): InvoiceDetail => ({
+  invoice: {
+    id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '100.00', taxRate: null,
+    taxTotal: '0.00', total: '100.00', amountPaid: '0.00', balance: '100.00', billToName: 'Acme',
+    notes: '', termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z',
+  },
+  lines,
+});
+
+describe('InvoiceEditor — line-field accessible names (#2151)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      return json({ data: {} });
+    });
+  });
+
+  it('names a persisted line’s qty and price inputs after its item', async () => {
+    render(<InvoiceEditor detail={detailWith([namedLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    expect(screen.getByTestId('invoice-line-qty-line-1')).toHaveAttribute('aria-label', 'Quantity for Firewall install');
+    expect(screen.getByTestId('invoice-line-price-line-1')).toHaveAttribute('aria-label', 'Unit price for Firewall install');
+  });
+
+  it('falls back to the description, then to "this line", for a line with no name', async () => {
+    const described = { ...namedLine, name: null };
+    const bare = { ...namedLine, id: 'line-2', name: null, description: null, sortOrder: 2 };
+    render(<InvoiceEditor detail={detailWith([described, bare])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    expect(screen.getByTestId('invoice-line-qty-line-1')).toHaveAttribute('aria-label', 'Quantity for Setup');
+    expect(screen.getByTestId('invoice-line-qty-line-2')).toHaveAttribute('aria-label', 'Quantity for this line');
+  });
+
+  it('gives two lines distinct qty/price names rather than N identical "Quantity" controls', async () => {
+    const second = { ...namedLine, id: 'line-2', name: 'Switch install', sortOrder: 2 };
+    render(<InvoiceEditor detail={detailWith([namedLine, second])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const names = ['invoice-line-qty-line-1', 'invoice-line-qty-line-2', 'invoice-line-price-line-1', 'invoice-line-price-line-2']
+      .map((id) => screen.getByTestId(id).getAttribute('aria-label'));
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('names the manual add-line row’s qty/price as the new line, not a duplicate of the rows below', async () => {
+    render(<InvoiceEditor detail={detailWith([namedLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-add-mode-manual'));
+
+    expect(screen.getByTestId('invoice-manual-qty')).toHaveAttribute('aria-label', 'New line quantity');
+    expect(screen.getByTestId('invoice-manual-price')).toHaveAttribute('aria-label', 'New line unit price');
+    expect(screen.getByTestId('invoice-manual-qty').getAttribute('aria-label'))
+      .not.toBe(screen.getByTestId('invoice-line-qty-line-1').getAttribute('aria-label'));
+  });
+});

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -681,13 +681,13 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
                   className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                 />
                 <input
-                  type="number" min="0" step="0.01" placeholder={t('invoiceEditor.table.qty')} aria-label={t('invoiceEditor.fields.quantity')} value={manualQty}
+                  type="number" min="0" step="0.01" placeholder={t('invoiceEditor.table.qty')} aria-label={t('invoiceEditor.fields.quantityNewLine')} value={manualQty}
                   onChange={(e) => setManualQty(e.target.value)}
                   data-testid="invoice-manual-qty"
                   className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                 />
                 <input
-                  type="number" min="0" step="0.01" placeholder={t('invoiceEditor.table.price')} aria-label={t('invoiceEditor.fields.unitPrice')} value={manualPrice}
+                  type="number" min="0" step="0.01" placeholder={t('invoiceEditor.table.price')} aria-label={t('invoiceEditor.fields.unitPriceNewLine')} value={manualPrice}
                   onChange={(e) => setManualPrice(e.target.value)}
                   data-testid="invoice-manual-price"
                   className="h-9 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
@@ -716,7 +716,7 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
                 </span>
                 <input
                   type="number" min="0" step="0.01" value={pickQty}
-                  onChange={(e) => setPickQty(e.target.value)} aria-label={t('invoiceEditor.fields.quantity')}
+                  onChange={(e) => setPickQty(e.target.value)} aria-label={t('invoiceEditor.fields.quantityFor', { item: picked.name })}
                   data-testid="invoice-pick-qty"
                   className="h-9 w-20 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                 />
@@ -890,6 +890,13 @@ function LineRow({
   const taxableKey = `taxable-${line.id}`;
   const visibleKey = `visible-${line.id}`;
   const removeKey = `remove-${line.id}`;
+  // Accessible names for this row's numeric fields. Every row (and the two
+  // add-line rows) previously labelled its qty/price inputs "Quantity"/"Unit
+  // price", so a screen reader's form-controls list was N indistinguishable
+  // pairs (#2151). Scoping the name to the line's item makes each addressable.
+  // Deliberately the PERSISTED name, not the live draft — an accessible name
+  // that changes on every keystroke is itself SR churn.
+  const rowLabelItem = (line.name ?? '').trim() || (line.description ?? '').trim() || t('invoiceEditor.fields.untitledLine');
   const [name, setName] = useState(line.name ?? '');
   const [desc, setDesc] = useState(line.description ?? '');
   const [qty, setQty] = useState(line.quantity);
@@ -1025,7 +1032,7 @@ function LineRow({
         <td className="px-3 py-2 text-right">
           <input
             type="number" min="0" step="0.01" value={qty} disabled={!canWrite || isPending(qtyKey)}
-            aria-label={t('invoiceEditor.fields.quantity')}
+            aria-label={t('invoiceEditor.fields.quantityFor', { item: rowLabelItem })}
             aria-describedby={qtyDirty ? unsavedHintId('invoice-line', line.id, 'qty') : undefined}
             onChange={(e) => { setQty(e.target.value); qtyEdited.current = true; }}
             onBlur={commitQty}
@@ -1037,7 +1044,7 @@ function LineRow({
         <td className="px-3 py-2 text-right">
           <input
             type="number" min="0" step="0.01" value={price} disabled={!canWrite || isPending(priceKey)}
-            aria-label={t('invoiceEditor.fields.unitPrice')}
+            aria-label={t('invoiceEditor.fields.unitPriceFor', { item: rowLabelItem })}
             aria-describedby={priceDirty ? unsavedHintId('invoice-line', line.id, 'price') : undefined}
             onChange={(e) => { setPrice(e.target.value); priceEdited.current = true; }}
             onBlur={commitPrice}

--- a/apps/web/src/components/billing/quotes/QuoteEditor.a11y.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.a11y.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+
+// #2151: every qty/price input in the editor answered to the same accessible
+// name ("Quantity" / "Unit price"), so a screen reader's form-controls list was
+// a run of indistinguishable entries with no way to tell which line each one
+// belonged to. The sibling announce-on-mount fix lives in
+// QuoteEditor.srtotals.test.tsx (it needs a different i18n mock).
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  updateBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  reorderBlocks: vi.fn(),
+  reorderLines: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  addQuoteImageFromUrl: vi.fn(),
+  updateQuote: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const block: QuoteDetailData['blocks'][number] = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Services' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseLine: QuoteDetailData['lines'][number] = {
+  id: 'line-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+  name: 'Firewall install', description: 'Setup', quantity: '1.00',
+  unitPrice: '500.00', taxable: true, customerVisible: true, lineTotal: '500.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseQuote: QuoteDetailData['quote'] = {
+  id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+  currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '500.00', taxRate: '0',
+  taxTotal: '0.00', total: '500.00', oneTimeTotal: '500.00', monthlyRecurringTotal: '0.00',
+  annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '500.00', billToName: null, introNotes: null,
+  terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+  convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+  createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const detailWith = (lines: QuoteDetailData['lines']): QuoteDetailData => ({
+  quote: baseQuote, blocks: [block], lines,
+});
+
+describe('QuoteEditor — line-field accessible names (#2151)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('names each persisted line’s qty and price inputs after its item', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    expect(screen.getByTestId('quote-line-qty-line-1')).toHaveAttribute('aria-label', 'Quantity for Firewall install');
+    expect(screen.getByTestId('quote-line-price-line-1')).toHaveAttribute('aria-label', 'Unit price for Firewall install');
+  });
+
+  it('gives two lines distinct qty/price names rather than N identical "Quantity" controls', async () => {
+    const second: QuoteDetailData['lines'][number] = {
+      ...baseLine, id: 'line-2', name: 'Switch install', sortOrder: 1,
+    };
+    render(<QuoteEditor detail={detailWith([baseLine, second])} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    const names = ['quote-line-qty-line-1', 'quote-line-qty-line-2', 'quote-line-price-line-1', 'quote-line-price-line-2']
+      .map((id) => screen.getByTestId(id).getAttribute('aria-label'));
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('falls back to the shared "this line" phrase for an untitled line instead of an empty name', async () => {
+    const untitled: QuoteDetailData['lines'][number] = { ...baseLine, name: null, description: null };
+    render(<QuoteEditor detail={detailWith([untitled])} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    expect(screen.getByTestId('quote-line-qty-line-1')).toHaveAttribute('aria-label', 'Quantity for this line');
+  });
+
+  it('names the new-line row’s qty/price distinctly from the persisted rows', async () => {
+    render(<QuoteEditor detail={detailWith([baseLine])} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    expect(screen.getByTestId('quote-ghost-qty-blk-1')).toHaveAttribute('aria-label', 'New line quantity');
+    expect(screen.getByTestId('quote-ghost-price-blk-1')).toHaveAttribute('aria-label', 'New line unit price');
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.srtotals.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.srtotals.test.tsx
@@ -1,0 +1,177 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+
+// #2151 — the rail's live-totals status node announced ~800ms after load on a
+// quote nobody had touched.
+//
+// The old guard skipped only the FIRST run of the debounce effect, whose dep was
+// the announcement SENTENCE. That is not the same thing as "the totals changed":
+// any later render that produces different sentence TEXT while the figures sit
+// still fires the effect a second time, past the guard, and announces totals the
+// user never touched. i18n resources arriving after the first paint do exactly
+// that — the sentence goes from raw key to real copy on an untouched quote. The
+// fix keys the effect on the figures themselves.
+//
+// The `useTranslation` mock below is what makes these tests non-vacuous: it
+// reproduces that settle (raw keys until `i18n.ready` is flipped, real copy
+// after). Without it nothing changes the sentence text and the buggy version
+// passes too — verified by reverting the fix and watching these go red.
+const i18n = vi.hoisted(() => ({ ready: true }));
+
+vi.mock('react-i18next', async () => {
+  const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next');
+  return {
+    ...actual,
+    useTranslation: ((...args: Parameters<typeof actual.useTranslation>) => {
+      const real = actual.useTranslation(...args);
+      const t = ((key: string, ...rest: unknown[]) =>
+        (i18n.ready
+          ? (real.t as unknown as (...a: unknown[]) => unknown)(key, ...rest)
+          : key)) as unknown as typeof real.t;
+      return Object.assign(Object.create(Object.getPrototypeOf(real) as object), real, { t });
+    }) as typeof actual.useTranslation,
+  };
+});
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  updateBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  reorderBlocks: vi.fn(),
+  reorderLines: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  addQuoteImageFromUrl: vi.fn(),
+  updateQuote: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const block: QuoteDetailData['blocks'][number] = {
+  id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+  content: { label: 'Services' }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseLine: QuoteDetailData['lines'][number] = {
+  id: 'line-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+  catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+  name: 'Firewall install', description: 'Setup', quantity: '1.00',
+  unitPrice: '500.00', taxable: true, customerVisible: true, lineTotal: '500.00',
+  recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const baseQuote: QuoteDetailData['quote'] = {
+  id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+  currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '500.00', taxRate: '0',
+  taxTotal: '0.00', total: '500.00', oneTimeTotal: '500.00', monthlyRecurringTotal: '0.00',
+  annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '500.00', billToName: null, introNotes: null,
+  terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+  convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+  createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const detail = (): QuoteDetailData => ({ quote: baseQuote, blocks: [block], lines: [baseLine] });
+
+describe('QuoteEditor — live-totals SR announcement (#2151)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    i18n.ready = true;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    i18n.ready = true;
+    vi.useRealTimers();
+  });
+
+  const advance = async (ms: number) => {
+    await act(async () => {
+      vi.advanceTimersByTime(ms);
+    });
+  };
+
+  it('stays silent on a freshly-loaded quote nobody has edited', async () => {
+    render(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    await advance(2000);
+
+    expect(screen.getByTestId('quote-totals-sr')).toBeEmptyDOMElement();
+  });
+
+  it('stays silent when late-arriving translations change the sentence but not the figures', async () => {
+    i18n.ready = false;
+    const { rerender } = render(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    // Resources land: the sentence goes from raw key to real copy on a quote
+    // nobody has touched. This is the render that defeated the old
+    // skip-the-first-run guard and announced the untouched totals.
+    i18n.ready = true;
+    rerender(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
+    await advance(2000);
+
+    expect(screen.getByTestId('quote-totals-sr')).toBeEmptyDOMElement();
+  });
+
+  it('announces the settled totals once the figures actually change', async () => {
+    render(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    fireEvent.change(screen.getByTestId('quote-line-qty-line-1'), { target: { value: '3' } });
+    await advance(2000);
+
+    expect(screen.getByTestId('quote-totals-sr')).toHaveTextContent('$1,500.00');
+  });
+
+  it('holds the announcement until the settle window elapses (still debounced)', async () => {
+    render(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    fireEvent.change(screen.getByTestId('quote-line-qty-line-1'), { target: { value: '3' } });
+    await advance(400);
+
+    expect(screen.getByTestId('quote-totals-sr')).toBeEmptyDOMElement();
+  });
+
+  it('announces only the final figure when edits arrive inside one settle window', async () => {
+    render(<QuoteEditor detail={detail()} onChanged={vi.fn()} />);
+    await screen.findByTestId('quote-editor');
+
+    const qty = screen.getByTestId('quote-line-qty-line-1');
+    fireEvent.change(qty, { target: { value: '2' } });
+    await advance(300);
+    fireEvent.change(qty, { target: { value: '4' } });
+    await advance(2000);
+
+    const sr = screen.getByTestId('quote-totals-sr');
+    expect(sr).toHaveTextContent('$2,000.00');
+    expect(sr).not.toHaveTextContent('$1,000.00');
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -34,6 +34,7 @@ import { listCatalog, createCatalogItem, type CatalogItem } from '../../../lib/a
 import { ecExpressStatus, ecExpressImport, type EcProduct, type EcStatus, pax8Status, pax8Import, type Pax8Product, type Pax8PriceOption } from '../../../lib/api/distributors';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import { showToast } from '../../shared/Toast';
+import { useToastRailOffset } from '../../shared/toastRailOffset';
 import RichTextEditor from '../../common/RichTextEditor';
 import InlineRichTextEditor from '../../common/InlineRichTextEditor';
 import PolishButton from '../../catalog/PolishButton';
@@ -150,6 +151,9 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
   const canWrite = can('quotes', 'write');
+  // This editor is the page with the sticky bottom-anchored right rail (Live
+  // totals + Terms), so it — not the shared container — owns the toast lift.
+  useToastRailOffset();
   // Cost/margin is a read affordance, not a write one: read-only users already see
   // the per-line internal cost bands (ReadonlyLineRow) + the toggle, so the rail
   // Margin summary is gated the same way QuoteDetail gates it — on quotes:read —
@@ -818,16 +822,34 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   const SR_SETTLE_MS = 800;
   const [srAnnouncement, setSrAnnouncement] = useState('');
   const srTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Skip the very first sentence: without this the debounce fires ~800ms after
-  // mount and announces the initial totals to an SR user who hasn't edited
-  // anything yet. Only CHANGES announce.
-  const srMounted = useRef(false);
+  // What the announcement is ABOUT: the figures themselves, independent of the
+  // sentence that wraps them. Gating on this rather than on `srSentence` is the
+  // #2151 fix — the sentence also changes when nothing about the quote does.
+  // i18next hydrates its resources asynchronously, so `t` (and therefore
+  // `srSentence`) changes identity shortly after mount even on a quote nobody
+  // has touched. A skip-the-first-render guard can't see that: the re-render is
+  // the SECOND one, so it sailed through and announced the untouched totals
+  // ~800ms after load. Comparing figures instead makes the i18n settle a no-op.
+  const srTotalsKey = useMemo(
+    () => [railOneTime, railMonthly, railAnnual, railTax, railDue, currency].join('|'),
+    [railOneTime, railMonthly, railAnnual, railTax, railDue, currency],
+  );
+  // The sentence is read at FIRE time, not scheduled with the timer, so a burst
+  // that settles after the i18n resources land still announces real copy.
+  const srSentenceRef = useRef(srSentence);
+  useEffect(() => { srSentenceRef.current = srSentence; }, [srSentence]);
+  // null until the first post-mount figures are recorded as the baseline — the
+  // starting totals are what the visible rail already shows, so they are never
+  // announced. Only a CHANGE from them (an edit) announces.
+  const srFirstKey = useRef(true);
   useEffect(() => {
-    if (!srMounted.current) { srMounted.current = true; return; }
-    if (srTimer.current) clearTimeout(srTimer.current);
-    srTimer.current = setTimeout(() => setSrAnnouncement(srSentence), SR_SETTLE_MS);
+    if (srFirstKey.current) { srFirstKey.current = false; return; }
+    srTimer.current = setTimeout(() => setSrAnnouncement(srSentenceRef.current), SR_SETTLE_MS);
+    // Cleanup runs on unmount AND before the next key change, which is exactly
+    // the debounce reset: a second edit inside the settle window replaces the
+    // pending announcement rather than queuing another one.
     return () => { if (srTimer.current) clearTimeout(srTimer.current); };
-  }, [srSentence]);
+  }, [srTotalsKey]);
 
   // Internal net-profit summary for the rail's "Margin (internal)" block. Built
   // over the SAME merged line set as the totals: draft-or-persisted values plus

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -825,11 +825,11 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   // What the announcement is ABOUT: the figures themselves, independent of the
   // sentence that wraps them. Gating on this rather than on `srSentence` is the
   // #2151 fix — the sentence also changes when nothing about the quote does.
-  // i18next hydrates its resources asynchronously, so `t` (and therefore
-  // `srSentence`) changes identity shortly after mount even on a quote nobody
-  // has touched. A skip-the-first-render guard can't see that: the re-render is
-  // the SECOND one, so it sailed through and announced the untouched totals
-  // ~800ms after load. Comparing figures instead makes the i18n settle a no-op.
+  // i18n resources arriving after the first paint rewrite the sentence TEXT
+  // (raw key → real copy) on a quote nobody has touched, which refires an effect
+  // keyed on the sentence. A skip-the-first-render guard can't help: that is the
+  // SECOND run, so it sailed through and announced the untouched totals ~800ms
+  // after load. Keying on the figures makes any copy-only change a no-op.
   const srTotalsKey = useMemo(
     () => [railOneTime, railMonthly, railAnnual, railTax, railDue, currency].join('|'),
     [railOneTime, railMonthly, railAnnual, railTax, railDue, currency],
@@ -838,9 +838,9 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   // that settles after the i18n resources land still announces real copy.
   const srSentenceRef = useRef(srSentence);
   useEffect(() => { srSentenceRef.current = srSentence; }, [srSentence]);
-  // null until the first post-mount figures are recorded as the baseline — the
-  // starting totals are what the visible rail already shows, so they are never
-  // announced. Only a CHANGE from them (an edit) announces.
+  // The first run only records the mount-time figures as the baseline: they are
+  // what the visible rail already shows, so they are never announced. Only a
+  // CHANGE from them (an edit) reaches the debounce below.
   const srFirstKey = useRef(true);
   useEffect(() => {
     if (srFirstKey.current) { srFirstKey.current = false; return; }

--- a/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
@@ -356,7 +356,11 @@ export function GhostRow({ blockId, busy, currency, onAdd, colSpan }: {
             onChange={(e) => { setQty(e.target.value); setError(null); }}
             onKeyDown={onKeyDown}
             disabled={busy}
-            aria-label={t('quotes.editor.line.quantityAria')}
+            // The new-line row and every persisted row used to share the bare
+            // "Quantity" label, so a screen reader's form-controls list read as
+            // N identical entries with nothing to tell them apart (#2151). The
+            // ghost row names itself; persisted rows name their item below.
+            aria-label={t('quotes.editor.ghost.quantityAria')}
             data-testid={`quote-ghost-qty-${blockId}`}
             className={`${ghostField} w-14 px-2 text-right text-sm tabular-nums ${active ? '' : 'hidden'}`}
           />
@@ -371,7 +375,7 @@ export function GhostRow({ blockId, busy, currency, onAdd, colSpan }: {
             onKeyDown={onKeyDown}
             disabled={busy}
             placeholder="0.00"
-            aria-label={t('quotes.editor.table.unitPrice')}
+            aria-label={t('quotes.editor.ghost.unitPriceAria')}
             data-testid={`quote-ghost-price-${blockId}`}
             style={{ width: growWidth(ghostPriceDisplay, 6, 18, MONEY_INPUT_PAD_X) }}
             className={`${ghostField} px-2 text-right text-sm tabular-nums ${active ? '' : 'hidden'}`}
@@ -578,6 +582,14 @@ export function EditableLineRow({
   // removal flow runs under `line:<id>` and should hold the row's actions.
   const fieldBusy = (field: string) => isPending(pendingKey.lineField(line.id, field));
   const removeBusy = isPending(pendingKey.line(line.id));
+  // Accessible names for this row's numeric fields. Every row previously
+  // labelled its qty/price inputs "Quantity"/"Unit price", so a screen reader's
+  // form-controls list was N indistinguishable pairs (#2151). Scoping the name
+  // to the line's item makes each one addressable. Deliberately the PERSISTED
+  // title, not the live `name` draft — an accessible name that changes on every
+  // keystroke is itself SR churn — and it falls back to the same "this line"
+  // phrase the bulk-select checkbox already uses for an untitled row.
+  const rowLabelItem = lineTitle(line) || t('quotes.editor.confirm.thisLine');
   const [name, setName] = useState(line.name ?? '');
   const [desc, setDesc] = useState(line.description ?? '');
   // Rest-state density: an EMPTY description renders no textarea — a compact
@@ -1056,7 +1068,7 @@ export function EditableLineRow({
         <input
           type="number" min="1" step="1"
           value={qty}
-          aria-label={t('quotes.editor.line.quantityAria')}
+          aria-label={t('quotes.editor.line.quantityForAria', { item: rowLabelItem })}
           onChange={(e) => { setQty(e.target.value); qtyEdited.current = true; setFieldError('qty', null); }}
           onBlur={commitQty}
           disabled={fieldBusy('qty')}
@@ -1071,7 +1083,7 @@ export function EditableLineRow({
         <input
           type="text" inputMode="decimal"
           value={priceDisplay}
-          aria-label={t('quotes.editor.table.unitPrice')}
+          aria-label={t('quotes.editor.line.unitPriceForAria', { item: rowLabelItem })}
           onFocus={() => setPriceFocused(true)}
           onChange={(e) => { setPrice(filterMoneyChars(e.target.value)); priceEdited.current = true; setFieldError('price', null); }}
           onBlur={() => { setPriceFocused(false); commitPrice(); }}

--- a/apps/web/src/components/shared/Toast.test.tsx
+++ b/apps/web/src/components/shared/Toast.test.tsx
@@ -333,3 +333,27 @@ describe('ToastContainer', () => {
     });
   });
 });
+
+describe('ToastContainer bottom anchor (#2151)', () => {
+  beforeEach(() => _resetToastQueueForTests());
+  afterEach(() => {
+    _resetToastQueueForTests();
+    document.documentElement.removeAttribute('data-toast-rail');
+  });
+
+  it('anchors off the --breeze-toast-bottom variable instead of hardcoding one page’s rail clearance', () => {
+    render(<ToastContainer />);
+    act(() => {
+      showToast({ type: 'success', message: 'anchored' });
+    });
+
+    const container = screen.getByTestId('toast-container');
+    // The lift belongs to the page that has the rail (useToastRailOffset), not
+    // to this shared container: a baked-in class moved EVERY page's toasts.
+    expect(container.className).not.toMatch(/bottom-24/);
+    expect(container.style.bottom).toBe('var(--breeze-toast-bottom, 1.5rem)');
+    // Still bottom-right — only the offset became a variable.
+    expect(container.className).toContain('fixed');
+    expect(container.className).toContain('right-6');
+  });
+});

--- a/apps/web/src/components/shared/Toast.tsx
+++ b/apps/web/src/components/shared/Toast.tsx
@@ -118,13 +118,14 @@ export default function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    // Bottom-right, but lifted on lg+ so the toast clears the quote editor's
-    // sticky right-rail (Live totals + Terms panel) whose lower controls the
-    // stock bottom-6 anchor visually overlapped on shorter viewports. z-index was
-    // never the issue — the toast sat on top of the rail's interactive controls;
-    // raising the anchor keeps bottom-right while leaving the rail usable. The
-    // extra lift on wide screens is harmless on pages without a right rail.
-    <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-2 lg:bottom-24" data-testid="toast-container">
+    // Bottom-right. The offset is a variable so a page with a sticky right rail
+    // (the quote editor's Live totals + Terms panel, whose lower controls the
+    // stock anchor visually overlapped) can lift the toast for itself via
+    // useToastRailOffset (./toastRailOffset.ts) — see that module's note and the
+    // matching rule in styles/globals.css.
+    // z-index was never the issue: the toast sat on top of the rail's
+    // interactive controls, so the anchor is what has to move.
+    <div className="fixed right-6 z-50 flex flex-col gap-2" style={{ bottom: 'var(--breeze-toast-bottom, 1.5rem)' }} data-testid="toast-container">
       {toasts.map(toast => {
         const isError = toast.type === 'error';
         const isWarning = toast.type === 'warning';

--- a/apps/web/src/components/shared/toastRailOffset.test.tsx
+++ b/apps/web/src/components/shared/toastRailOffset.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useToastRailOffset } from './toastRailOffset';
+
+// #2151 — the toast lift used to be a flat `lg:bottom-24` baked into the shared
+// ToastContainer, so one page's right rail moved every page's toasts. It is now
+// opt-in: the page with the rail stamps `data-toast-rail` on <html> for as long
+// as it is mounted, and globals.css raises --breeze-toast-bottom off that.
+
+function Rail() {
+  useToastRailOffset();
+  return <div data-testid="rail" />;
+}
+
+const railOffsetSet = () => document.documentElement.hasAttribute('data-toast-rail');
+
+describe('useToastRailOffset', () => {
+  afterEach(() => document.documentElement.removeAttribute('data-toast-rail'));
+
+  it('does not lift the anchor for a page that never opts in', () => {
+    render(<div data-testid="plain" />);
+    expect(railOffsetSet()).toBe(false);
+  });
+
+  it('lifts the anchor while mounted and drops it on unmount', () => {
+    const { unmount } = render(<Rail />);
+    expect(railOffsetSet()).toBe(true);
+
+    unmount();
+    expect(railOffsetSet()).toBe(false);
+  });
+
+  it('keeps the lift while a second holder is still mounted (refcounted)', () => {
+    // Two rail-bearing trees can overlap — e.g. a remount whose old tree has not
+    // finished tearing down. A naive set/remove would drop the offset out from
+    // under the survivor the moment the first one unmounted.
+    const first = render(<Rail />);
+    const second = render(<Rail />);
+    expect(railOffsetSet()).toBe(true);
+
+    first.unmount();
+    expect(railOffsetSet()).toBe(true);
+
+    second.unmount();
+    expect(railOffsetSet()).toBe(false);
+  });
+});

--- a/apps/web/src/components/shared/toastRailOffset.ts
+++ b/apps/web/src/components/shared/toastRailOffset.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+// Opt-in lift for the global toast anchor (#2151).
+//
+// ToastContainer sits bottom-right and reads its offset from the
+// `--breeze-toast-bottom` CSS variable (see the rule in styles/globals.css).
+// A page whose sticky right rail is bottom-anchored — today only the quote
+// editor's Live totals + Terms panel — would otherwise have the toast land on
+// top of the rail's interactive controls on shorter viewports. z-index was
+// never the fix: the toast is *supposed* to be on top, so the anchor is what
+// has to move.
+//
+// This used to be a flat `lg:bottom-24` on the shared container, which meant one
+// page's layout moved every page's toasts, and the next page to grow a right
+// rail would have re-litigated that single number. Owning the lift here keeps
+// the container generic: the page that has the rail declares it, for as long as
+// it is mounted.
+//
+// Deliberately a separate module from Toast.tsx: the toast bus module is mocked
+// wholesale (`vi.mock('../../shared/Toast')`) by a large number of suites, and a
+// layout hook exported from there would break every one of them.
+
+const RAIL_OFFSET_ATTR = 'data-toast-rail';
+
+// Refcounted: two rail-bearing islands can be mounted at once (e.g. an editor
+// remounting while the old tree is still tearing down), and the first unmount
+// must not drop the offset out from under the other.
+let holders = 0;
+
+/** Lift the global toast anchor while the calling component is mounted. Call
+ *  from any page that renders a sticky bottom-anchored right rail. */
+export function useToastRailOffset(): void {
+  useEffect(() => {
+    holders += 1;
+    document.documentElement.setAttribute(RAIL_OFFSET_ATTR, '');
+    return () => {
+      holders -= 1;
+      if (holders <= 0) {
+        holders = 0;
+        document.documentElement.removeAttribute(RAIL_OFFSET_ATTR);
+      }
+    };
+  }, []);
+}

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -658,6 +658,8 @@
         "partNumberOptional": "Teilenummer (optional)",
         "profit": "Gewinn",
         "quantityAria": "Menge",
+        "quantityForAria": "Menge für {{item}}",
+        "unitPriceForAria": "Stückpreis für {{item}}",
         "saveToCatalog": "Im Katalog speichern",
         "showLess": "Weniger anzeigen",
         "showMore": "Mehr anzeigen",
@@ -805,7 +807,9 @@
       "ghost": {
         "add": "Hinzufügen",
         "nameAria": "Name der neuen Zeile",
-        "placeholder": "Artikelnamen eingeben…"
+        "placeholder": "Artikelnamen eingeben…",
+        "quantityAria": "Menge der neuen Zeile",
+        "unitPriceAria": "Stückpreis der neuen Zeile"
       },
       "unassigned": {
         "explainer": "Diese Positionen gehören zu keinem Preisabschnitt, erscheinen aber trotzdem im Angebot des Kunden und zählen zu dessen Summen. Verschieben Sie jede Position in einen Preisabschnitt, um zu bestimmen, wo sie erscheint.",
@@ -1318,7 +1322,12 @@
       "lineName": "Positionsname",
       "name": "Name",
       "quantity": "Menge",
+      "quantityFor": "Menge für {{item}}",
+      "quantityNewLine": "Menge der neuen Zeile",
+      "unitPriceFor": "Stückpreis für {{item}}",
+      "unitPriceNewLine": "Stückpreis der neuen Zeile",
       "taxable": "Steuerpflichtig",
+      "untitledLine": "diese Position",
       "unitPrice": "Stückpreis"
     },
     "hiddenSuffix": "(versteckt)",

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -658,6 +658,7 @@
         "partNumberOptional": "Part # (optional)",
         "profit": "Profit",
         "quantityAria": "Quantity",
+        "quantityForAria": "Quantity for {{item}}",
         "saveToCatalog": "Save to catalog",
         "showLess": "Show less",
         "showMore": "Show more",
@@ -665,7 +666,8 @@
         "skuHelp": "Your catalog or distributor stock number for this item.",
         "skuOptional": "SKU (optional)",
         "tidyWithAi": "Tidy with AI",
-        "unitCost": "Unit cost"
+        "unitCost": "Unit cost",
+        "unitPriceForAria": "Unit price for {{item}}"
       },
       "liveTotals": {
         "annualRecurring": "Annual recurring",
@@ -805,7 +807,9 @@
       "ghost": {
         "add": "Add",
         "nameAria": "New line name",
-        "placeholder": "Type an item name…"
+        "placeholder": "Type an item name…",
+        "quantityAria": "New line quantity",
+        "unitPriceAria": "New line unit price"
       },
       "unassigned": {
         "explainer": "These lines aren’t in any pricing section, but they still appear on the customer’s quote and count toward its totals. Move each one into a pricing section to control where it appears.",
@@ -1318,8 +1322,13 @@
       "lineName": "Line name",
       "name": "Name",
       "quantity": "Quantity",
+      "quantityFor": "Quantity for {{item}}",
+      "quantityNewLine": "New line quantity",
       "taxable": "Taxable",
-      "unitPrice": "Unit price"
+      "unitPrice": "Unit price",
+      "unitPriceFor": "Unit price for {{item}}",
+      "unitPriceNewLine": "New line unit price",
+      "untitledLine": "this line"
     },
     "hiddenSuffix": " (hidden)",
     "notes": {

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -658,6 +658,8 @@
         "partNumberOptional": "Número de pieza (opcional)",
         "profit": "Ganancia",
         "quantityAria": "Cantidad",
+        "quantityForAria": "Cantidad de {{item}}",
+        "unitPriceForAria": "Precio unitario de {{item}}",
         "saveToCatalog": "Guardar en catálogo",
         "showLess": "Mostrar menos",
         "showMore": "Mostrar más",
@@ -805,7 +807,9 @@
       "ghost": {
         "add": "Agregar",
         "nameAria": "Nombre de la nueva línea",
-        "placeholder": "Escribe el nombre del ítem…"
+        "placeholder": "Escribe el nombre del ítem…",
+        "quantityAria": "Cantidad de la nueva línea",
+        "unitPriceAria": "Precio unitario de la nueva línea"
       },
       "unassigned": {
         "explainer": "Estas líneas no están en ninguna sección de precios, pero aun así aparecen en la cotización del cliente y se suman a sus totales. Mueve cada una a una sección de precios para controlar dónde aparece.",
@@ -1318,7 +1322,12 @@
       "lineName": "Nombre de línea",
       "name": "Nombre",
       "quantity": "Cantidad",
+      "quantityFor": "Cantidad de {{item}}",
+      "quantityNewLine": "Cantidad de la nueva línea",
+      "unitPriceFor": "Precio unitario de {{item}}",
+      "unitPriceNewLine": "Precio unitario de la nueva línea",
       "taxable": "Imponible",
+      "untitledLine": "esta linea",
       "unitPrice": "Precio unitario"
     },
     "hiddenSuffix": "(oculto)",

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -630,6 +630,8 @@
         "partNumberOptional": "Part # (facultatif)",
         "profit": "Profit",
         "quantityAria": "Quantité",
+        "quantityForAria": "Quantité pour {{item}}",
+        "unitPriceForAria": "Prix unitaire pour {{item}}",
         "saveToCatalog": "Enregistrer dans le catalogue",
         "sku": "SKU",
         "skuOptional": "SKU (facultatif)",
@@ -768,7 +770,9 @@
       "ghost": {
         "add": "Ajouter",
         "nameAria": "Nom de la nouvelle ligne",
-        "placeholder": "Saisissez le nom de l'article…"
+        "placeholder": "Saisissez le nom de l'article…",
+        "quantityAria": "Quantité de la nouvelle ligne",
+        "unitPriceAria": "Prix unitaire de la nouvelle ligne"
       },
       "bulk": {
         "applied_one": "{{count}} ligne mise à jour.",
@@ -1318,7 +1322,12 @@
       "lineName": "Nom de la ligne",
       "name": "Nom",
       "quantity": "Quantité",
+      "quantityFor": "Quantité pour {{item}}",
+      "quantityNewLine": "Quantité de la nouvelle ligne",
+      "unitPriceFor": "Prix unitaire pour {{item}}",
+      "unitPriceNewLine": "Prix unitaire de la nouvelle ligne",
       "taxable": "Taxable",
+      "untitledLine": "cette ligne",
       "unitPrice": "Prix unitaire"
     },
     "hiddenSuffix": " (masqué)",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -658,6 +658,8 @@
         "partNumberOptional": "Part # (facultatif)",
         "profit": "Profit",
         "quantityAria": "Quantité",
+        "quantityForAria": "Quantité pour {{item}}",
+        "unitPriceForAria": "Prix unitaire pour {{item}}",
         "saveToCatalog": "Enregistrer dans le catalogue",
         "showLess": "Afficher moins",
         "showMore": "Afficher plus",
@@ -805,7 +807,9 @@
       "ghost": {
         "add": "Ajouter",
         "nameAria": "Nom de la nouvelle ligne",
-        "placeholder": "Saisissez le nom de l'article…"
+        "placeholder": "Saisissez le nom de l'article…",
+        "quantityAria": "Quantité de la nouvelle ligne",
+        "unitPriceAria": "Prix unitaire de la nouvelle ligne"
       },
       "unassigned": {
         "explainer": "Ces lignes ne figurent dans aucune section tarifaire, mais elles apparaissent malgré tout sur le devis du client et sont comptées dans ses totaux. Déplacez chacune d'elles dans une section tarifaire pour maîtriser l'endroit où elle apparaît.",
@@ -1318,7 +1322,12 @@
       "lineName": "Nom de la ligne",
       "name": "Nom",
       "quantity": "Quantité",
+      "quantityFor": "Quantité pour {{item}}",
+      "quantityNewLine": "Quantité de la nouvelle ligne",
+      "unitPriceFor": "Prix unitaire pour {{item}}",
+      "unitPriceNewLine": "Prix unitaire de la nouvelle ligne",
       "taxable": "Taxable",
+      "untitledLine": "cette ligne",
       "unitPrice": "Prix unitaire"
     },
     "hiddenSuffix": " (masqué)",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -630,6 +630,8 @@
         "partNumberOptional": "Cod. parte (facoltativo)",
         "profit": "Profitto",
         "quantityAria": "Quantità",
+        "quantityForAria": "Quantità per {{item}}",
+        "unitPriceForAria": "Prezzo unitario per {{item}}",
         "saveToCatalog": "Salva nel catalogo",
         "sku": "SKU",
         "skuOptional": "SKU (facoltativo)",
@@ -768,7 +770,9 @@
       "ghost": {
         "add": "Aggiungi",
         "nameAria": "Nome nuova riga",
-        "placeholder": "Digita il nome di un elemento…"
+        "placeholder": "Digita il nome di un elemento…",
+        "quantityAria": "Quantità nuova riga",
+        "unitPriceAria": "Prezzo unitario nuova riga"
       },
       "bulk": {
         "applied_one": "Aggiornata {{count}} riga.",
@@ -1318,7 +1322,12 @@
       "lineName": "Nome riga",
       "name": "Nome",
       "quantity": "Quantità",
+      "quantityFor": "Quantità per {{item}}",
+      "quantityNewLine": "Quantità nuova riga",
+      "unitPriceFor": "Prezzo unitario per {{item}}",
+      "unitPriceNewLine": "Prezzo unitario nuova riga",
       "taxable": "Imponibile",
+      "untitledLine": "questa riga",
       "unitPrice": "Prezzo unitario"
     },
     "hiddenSuffix": " (nascosta)",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -658,6 +658,8 @@
         "partNumberOptional": "Nº da peça (opcional)",
         "profit": "Lucro",
         "quantityAria": "Quantidade",
+        "quantityForAria": "Quantidade de {{item}}",
+        "unitPriceForAria": "Preço unitário de {{item}}",
         "saveToCatalog": "Salvar no catálogo",
         "showLess": "Mostrar menos",
         "showMore": "Mostrar mais",
@@ -805,7 +807,9 @@
       "ghost": {
         "add": "Adicionar",
         "nameAria": "Nome da nova linha",
-        "placeholder": "Digite o nome do item…"
+        "placeholder": "Digite o nome do item…",
+        "quantityAria": "Quantidade da nova linha",
+        "unitPriceAria": "Preço unitário da nova linha"
       },
       "unassigned": {
         "explainer": "Estas linhas não estão em nenhuma seção de preços, mas mesmo assim aparecem na cotação do cliente e entram nos totais dela. Mova cada uma para uma seção de preços para controlar onde ela aparece.",
@@ -1318,7 +1322,12 @@
       "lineName": "Nome da linha",
       "name": "Nome",
       "quantity": "Quantidade",
+      "quantityFor": "Quantidade de {{item}}",
+      "quantityNewLine": "Quantidade da nova linha",
+      "unitPriceFor": "Preço unitário de {{item}}",
+      "unitPriceNewLine": "Preço unitário da nova linha",
       "taxable": "Tributável",
+      "untitledLine": "esta linha",
       "unitPrice": "Preço unitário"
     },
     "hiddenSuffix": " (oculta)",

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -666,6 +666,8 @@
         "partNumberOptional": "Parça No (isteğe bağlı)",
         "profit": "Kâr",
         "quantityAria": "Adet",
+        "quantityForAria": "{{item}} adedi",
+        "unitPriceForAria": "{{item}} birim fiyatı",
         "saveToCatalog": "Kataloğa kaydet",
         "showLess": "Daha az göster",
         "showMore": "Daha fazlasını göster",
@@ -813,7 +815,9 @@
       "ghost": {
         "add": "Ekle",
         "nameAria": "Yeni satır adı",
-        "placeholder": "Bir öğe adı yazın…"
+        "placeholder": "Bir öğe adı yazın…",
+        "quantityAria": "Yeni satır adedi",
+        "unitPriceAria": "Yeni satır birim fiyatı"
       },
       "unassigned": {
         "explainer": "Bu satırlar herhangi bir fiyatlandırma bölümünde yer almaz ancak yine de müşterinin teklifinde görünür ve toplamlara dahil edilir. Nerede görüneceğini kontrol etmek için her birini bir fiyatlandırma bölümüne taşıyın.",
@@ -1318,7 +1322,12 @@
       "lineName": "Satır adı",
       "name": "Ad",
       "quantity": "Adet",
+      "quantityFor": "{{item}} adedi",
+      "quantityNewLine": "Yeni satır adedi",
+      "unitPriceFor": "{{item}} birim fiyatı",
+      "unitPriceNewLine": "Yeni satır birim fiyatı",
       "taxable": "Vergiye tabi",
+      "untitledLine": "bu satır",
       "unitPrice": "Birim fiyatı"
     },
     "hiddenSuffix": "(gizli)",

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -34647,3 +34647,18 @@
   font-family: 'Barlow Condensed', 'DM Sans', sans-serif;
   letter-spacing: 0.01em;
 }
+
+/* Toast bottom anchor (#2151). ToastContainer reads --breeze-toast-bottom; a
+   page that renders a sticky bottom-anchored right rail opts into the lift by
+   calling useToastRailOffset(), which stamps data-toast-rail on <html>. This
+   replaced a flat lg:bottom-24 on the shared container, which pushed EVERY
+   page's toasts up for one page's layout. lg-only because that is where the
+   rail stops stacking under the content and starts competing for the corner. */
+:root {
+  --breeze-toast-bottom: 1.5rem;
+}
+@media (min-width: 1024px) {
+  html[data-toast-rail] {
+    --breeze-toast-bottom: 6rem;
+  }
+}


### PR DESCRIPTION
Refs #2151 (line-grid column-priority item still open — see "Left out" below).

Four of the five items left on the #2151 punch list after the partial fix in #2177. The fifth is deliberately left out — see the bottom.

## 1. Duplicate `aria-label="Quantity"` (a11y pass)

Every qty and unit-price input in both editors answered to the same accessible name, so a screen reader's form-controls list was a run of indistinguishable entries with nothing to say which line each belonged to. Five collisions: quote ghost row + persisted row, invoice manual-add + catalog-pick + persisted row.

- Persisted rows: `Quantity for <item>` / `Unit price for <item>`. Deliberately the **persisted** title, not the live draft — an accessible name that changes on every keystroke is itself SR churn. Untitled quote lines reuse the existing `this line` phrase the bulk-select checkbox already uses; invoice lines fall back name → description → `this line`.
- New-line and catalog-pick rows name themselves (`New line quantity`, and the pick row is scoped to the picked item).
- New keys added across all 8 locale catalogs (parity suite green).

## 2. Quote live-totals SR announcement fired on mount

The rail's `role="status"` node announced ~800ms after load on a quote nobody had touched, despite an existing skip-the-first-render guard.

Root cause: the guard skipped only the **first run** of a debounce effect whose dep was the announcement **sentence**. That is not the same thing as "the totals changed" — any later render producing different sentence *text* while the figures sit still fires the effect a second time, past the guard. i18n resources arriving after first paint do exactly that (raw key → real copy on an untouched quote).

The effect now keys on a `srTotalsKey` built from the figures, so a copy-only change is a no-op while a real edit still announces (debounced, last-write-wins). The sentence is read at fire time via a ref so a burst that settles after the i18n swap still announces real copy.

`QuoteEditor.srtotals.test.tsx` is mutation-verified: reverting the fix turns the late-translation case red. Its `useTranslation` mock exists precisely to make that non-vacuous — without it, nothing changes the sentence text and the buggy version passes too.

## 3. Toast container `lg:bottom-24`

The issue flagged this as a shared-container smell, and it was: one page's sticky right rail set a global lift, so every page's toasts moved, and the next page to grow a rail would have re-litigated the single number.

The offset is now `--breeze-toast-bottom` (default `1.5rem`, rule in `globals.css`), and the page that has the rail opts in with `useToastRailOffset()` — refcounted, `lg`-only, cleaned up on unmount. Only `QuoteEditor` opts in today. Deliberately a separate module from `Toast.tsx`: that module is `vi.mock`ed wholesale by a large number of suites, and a layout hook exported from there would break every one of them.

## 4. PDF fallback wordmark

`invoicePdf` printed `Invoice` and the shared quote resolver `Proposal` in the wordmark slot when the partner row read back empty — a document-type word where a company name belongs, next to the header's own INVOICE/PROPOSAL eyebrow.

The realistic empty-partner case is the org-scoped RLS zero-row read `quoteBranding.ts`'s own header warns about, not a nameless partner — and the document still carries the seller name frozen onto it at send. Both sides now fall through `seller.name` before the literal, which is exactly what the two web previews (`InvoiceDocument` / `QuoteDocument`) already do, so PDF and preview degrade identically instead of diverging on the same missing row.

Unit-covered on the quote side (`quoteBranding.test.ts`, incl. live-partner-wins and null-seller-name cases). The invoice side is the same one-line change inside the unexported `loadInvoiceForRender`, reachable only through the DB path, so it is covered by the existing integration suite rather than a new unit test.

## Left out: quote-editor line-grid horizontal scroll

The punch list itself says this "needs column-priority restructuring", and that holds up. The grid already sizes Item flexibly and Qty/Price/Total to content, and at 1280px with the 300px rail open the content column is comfortably wider than the table's `min-w-[36rem]` floor — so the overflow is driven by *content* width (long item names plus the internal cost band), not by container arithmetic. Fixing it properly means deciding which columns yield first (truncation/stacking priority), which is a design change rather than a punch-list tidy. Left for a follow-up so this batch stays mechanical.

## Overlap with #3631

#3631 (block edit-in-place) also touches `QuoteEditor.tsx` and the locale `billing.json` files. Overlap here is small and in different regions: this PR adds an import + a one-line hook call near the top of `QuoteEditor` and rewrites the SR-debounce effect; locale changes are new keys in `quotes.editor.line` / `quotes.editor.ghost` / `invoiceEditor.fields`. No shared blocks, but whichever lands second should expect a trivial rebase on the locale files. `QuoteBlockCard.tsx` and `QuoteBlockContentForms.tsx` are untouched here.

## Verification

- `apps/web`: 99 files / 811 tests green (`src/components/billing`, `src/lib/i18n`, `src/components/shared`), including the 4 new suites.
- `apps/api`: `quoteBranding.test.ts` + `invoicePdf.test.ts`, 28 tests green.
- `astro check` clean (0 errors); `tsc --noEmit` clean in `apps/api`.
- No schema, migration, or tenancy surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)