### PR TITLE
fix(api): close cross-tenant CIS scan fan-out and cross-org ticket email injection

### DIFF
--- a/apps/api/src/jobs/cisJobs.ts
+++ b/apps/api/src/jobs/cisJobs.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { Job, Queue, Worker } from 'bullmq';
 import { and, eq, inArray, ne, sql } from 'drizzle-orm';
 import * as dbModule from '../db';
@@ -505,12 +506,21 @@ export async function scheduleCisScan(
     ? Array.from(new Set(options.deviceIds.filter((id) => typeof id === 'string' && id.length > 0))).sort()
     : undefined;
   const slot = Math.floor(Date.now() / ON_DEMAND_CIS_SCAN_DEDUPE_WINDOW_MS).toString(36);
+  // Keep the device component bounded now that authorized route fan-outs can
+  // contain thousands of explicit ids. The 'all' label remains reserved for a
+  // genuinely unscoped whole-baseline scan; explicit sets retain deterministic
+  // deduplication without producing unusably long Redis keys.
+  const deviceLabel = !normalizedDeviceIds || normalizedDeviceIds.length === 0
+    ? 'all'
+    : normalizedDeviceIds.length <= 4
+      ? normalizedDeviceIds.join(',')
+      : `n${normalizedDeviceIds.length}.${createHash('sha256').update(normalizedDeviceIds.join(',')).digest('hex').slice(0, 16)}`;
   // '-' separator (not ':') — BullMQ rejects custom jobIds whose colon-split
   // length !== 3, and this 4-part id would throw. See #1101.
   const jobId = [
     'cis-manual-scan',
     baselineId,
-    normalizedDeviceIds ? normalizedDeviceIds.join(',') : 'all',
+    deviceLabel,
     slot,
   ].join('-');
   const existing = await queue.getJob(jobId);

--- a/apps/api/src/routes/cisHardening.ts
+++ b/apps/api/src/routes/cisHardening.ts
@@ -1,6 +1,6 @@
 import { Hono, type Context } from 'hono';
 import { zValidator } from '../lib/validation';
-import { and, desc, eq, gte, inArray, isNull, lte, or, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, isNull, lte, ne, or, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { optionalQueryBoolean } from '@breeze/shared';
 
@@ -124,6 +124,87 @@ function baselineVisibilityCondition(auth: AuthContext): SQL | undefined {
   // org-owned baseline from system callers.
   if (!orgCondition) return undefined;
   return partnerWide ? or(orgCondition, partnerWide) : orgCondition;
+}
+
+async function resolveAuthorizedCisScanDeviceIds(
+  auth: AuthContext,
+  permissions: UserPermissions | undefined,
+  baseline: typeof cisBaselines.$inferSelect,
+  requestedDeviceIds: string[] | undefined,
+): Promise<
+  | { deviceIds: string[] }
+  | { error: string; status: 400 | 403; deniedDeviceIds?: string[] }
+> {
+  const hasExplicitDeviceIds = Array.isArray(requestedDeviceIds) && requestedDeviceIds.length > 0;
+
+  // Device eligibility follows the baseline's OWNER. `eq(devices.orgId,
+  // baseline.orgId)` silently matches nothing when org_id is NULL, so a
+  // partner-wide baseline resolves its devices through the org's partner
+  // instead. Never widen past the caller's own org access, including when the
+  // caller omits deviceIds and asks the server to resolve the full scope.
+  const deviceOwnerCondition = baseline.partnerId
+    ? inArray(
+        devices.orgId,
+        db.select({ id: organizations.id })
+          .from(organizations)
+          .where(eq(organizations.partnerId, baseline.partnerId))
+      )
+    : eq(devices.orgId, baseline.orgId!);
+  const deviceOrgAccess = auth.orgCondition(devices.orgId);
+  const conditions: SQL[] = [
+    deviceOwnerCondition,
+    ...(deviceOrgAccess ? [deviceOrgAccess] : []),
+    eq(devices.osType, baseline.osType),
+  ];
+
+  if (hasExplicitDeviceIds) {
+    conditions.push(inArray(devices.id, requestedDeviceIds));
+  } else {
+    // Mirror selectCisScanTargetDevices: server-resolved fan-out must never
+    // include Quick Support machines or devices that have been decommissioned.
+    conditions.push(eq(devices.isEphemeral, false), ne(devices.status, 'decommissioned'));
+  }
+
+  const rows = await db
+    .select({ id: devices.id, siteId: devices.siteId })
+    .from(devices)
+    .where(and(...conditions));
+
+  if (hasExplicitDeviceIds && rows.length !== requestedDeviceIds.length) {
+    return {
+      error: 'One or more deviceIds do not belong to the baseline org/os scope',
+      status: 400,
+    };
+  }
+
+  // Site is an app-layer axis only: RLS cannot prevent a site-restricted user
+  // from dispatching to another site within an otherwise authorized org.
+  if (permissions?.allowedSiteIds) {
+    const deniedDeviceIds = rows
+      .filter((device) =>
+        typeof device.siteId !== 'string' || !canAccessSite(permissions, device.siteId)
+      )
+      .map((device) => device.id);
+
+    if (hasExplicitDeviceIds && deniedDeviceIds.length > 0) {
+      return {
+        error: 'Access to one or more device sites denied',
+        status: 403,
+        deniedDeviceIds,
+      };
+    }
+
+    if (!hasExplicitDeviceIds && deniedDeviceIds.length > 0) {
+      const deniedDeviceIdSet = new Set(deniedDeviceIds);
+      return {
+        deviceIds: rows
+          .filter((device) => !deniedDeviceIdSet.has(device.id))
+          .map((device) => device.id),
+      };
+    }
+  }
+
+  return { deviceIds: rows.map((device) => device.id) };
 }
 
 function mapBaselineRow(row: typeof cisBaselines.$inferSelect) {
@@ -428,55 +509,27 @@ cisHardeningRoutes.post(
       return c.json({ error: 'Baseline is inactive' }, 400);
     }
 
-    if (Array.isArray(body.deviceIds) && body.deviceIds.length > 0) {
-      // Device eligibility follows the baseline's OWNER. `eq(devices.orgId,
-      // baseline.orgId)` silently matches nothing when org_id is NULL, so a
-      // partner-wide baseline resolves its devices through the org's partner
-      // instead. Never widen past the caller's own org access.
-      const deviceOwnerCondition = baseline.partnerId
-        ? inArray(
-            devices.orgId,
-            db.select({ id: organizations.id })
-              .from(organizations)
-              .where(eq(organizations.partnerId, baseline.partnerId))
-          )
-        : eq(devices.orgId, baseline.orgId!);
-      const deviceOrgAccess = auth.orgCondition(devices.orgId);
-
-      const scopedDevices = await db
-        .select({ id: devices.id, siteId: devices.siteId })
-        .from(devices)
-        .where(and(
-          inArray(devices.id, body.deviceIds),
-          deviceOwnerCondition,
-          ...(deviceOrgAccess ? [deviceOrgAccess] : []),
-          eq(devices.osType, baseline.osType),
-        ));
-
-      if (scopedDevices.length !== body.deviceIds.length) {
-        return c.json({ error: 'One or more deviceIds do not belong to the baseline org/os scope' }, 400);
-      }
-
-      // Site-scope check: partner-scope users restricted to a subset of sites
-      // must not be able to schedule a CIS scan against devices in other sites
-      // within the same org. RLS does not defend the site axis.
-      const permissions = c.get('permissions') as UserPermissions | undefined;
-      if (permissions?.allowedSiteIds) {
-        const deniedDeviceIds = scopedDevices
-          .filter((device) =>
-            typeof device.siteId !== 'string' || !canAccessSite(permissions, device.siteId)
-          )
-          .map((device) => device.id);
-        if (deniedDeviceIds.length > 0) {
-          return c.json({ error: 'Access to one or more device sites denied', deniedDeviceIds }, 403);
-        }
-      }
+    const permissions = c.get('permissions') as UserPermissions | undefined;
+    const resolved = await resolveAuthorizedCisScanDeviceIds(
+      auth,
+      permissions,
+      baseline,
+      body.deviceIds,
+    );
+    if ('error' in resolved) {
+      return c.json({
+        error: resolved.error,
+        ...(resolved.deniedDeviceIds ? { deniedDeviceIds: resolved.deniedDeviceIds } : {}),
+      }, resolved.status);
     }
 
-    const jobId = await scheduleCisScan(baseline.id, {
-      requestedBy: auth.user.id,
-      deviceIds: body.deviceIds,
-    });
+    const resolvedDeviceIds = resolved.deviceIds;
+    const jobId = resolvedDeviceIds.length > 0
+      ? await scheduleCisScan(baseline.id, {
+          requestedBy: auth.user.id,
+          deviceIds: resolvedDeviceIds,
+        })
+      : null;
 
     writeRouteAudit(c, {
       orgId: baseline.orgId,
@@ -485,9 +538,19 @@ cisHardeningRoutes.post(
       resourceId: baseline.id,
       details: {
         jobId,
-        deviceCount: body.deviceIds?.length ?? null,
+        deviceCount: resolvedDeviceIds.length,
+        requestedDeviceCount: body.deviceIds?.length ?? null,
       },
     });
+
+    if (jobId === null) {
+      return c.json({
+        message: 'CIS scan queued',
+        jobId: null,
+        baselineId: baseline.id,
+        deviceCount: 0,
+      }, 202);
+    }
 
     return c.json({
       message: 'CIS scan queued',

--- a/apps/api/src/routes/cisHardening_scan_authz.test.ts
+++ b/apps/api/src/routes/cisHardening_scan_authz.test.ts
@@ -1,0 +1,417 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+/**
+ * Regression suite for the CROSS-TENANT CIS SCAN FAN-OUT (security review 2026-08-16 §1.2).
+ *
+ * Before the fix, every device authorization predicate on `POST /cis/scan` lived
+ * inside `if (Array.isArray(body.deviceIds) && body.deviceIds.length > 0)`. Omitting
+ * `deviceIds` skipped ALL of them and handed `deviceIds: undefined` to
+ * `scheduleCisScan`, which labels the job `'all'` and lets the worker resolve devices
+ * through the baseline's PARTNER — so an organization-scope caller could fan a scan
+ * across every customer org under the MSP.
+ *
+ * These tests are deliberately BEHAVIOURAL rather than "was some where() built":
+ * the db mock below actually EVALUATES the drizzle condition tree against a fixture
+ * device table (the schema mock makes every column a plain string, so drizzle keeps
+ * both sides of each comparison as raw query chunks — see `evalCondition`). If the
+ * route stops applying `auth.orgCondition`, or stops resolving the set server-side,
+ * the fixture rows that come back change and the assertions fail.
+ */
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const PARTNER_ID = 'partner-1';
+const BASELINE_ID = '11111111-1111-1111-1111-111111111111';
+
+type OrgRow = { id: string; partnerId: string };
+type DeviceRow = {
+  id: string;
+  orgId: string;
+  osType: string;
+  isEphemeral: boolean;
+  status: string;
+  siteId: string | null;
+};
+
+const ORGS: OrgRow[] = [
+  { id: 'org-a', partnerId: PARTNER_ID },
+  { id: 'org-b', partnerId: PARTNER_ID },
+  { id: 'org-c', partnerId: 'partner-2' },
+];
+
+const DEVICES: DeviceRow[] = [
+  // org-a — the caller's own org
+  { id: 'dev-a1', orgId: 'org-a', osType: 'windows', isEphemeral: false, status: 'online', siteId: 'site-a' },
+  { id: 'dev-a2', orgId: 'org-a', osType: 'linux', isEphemeral: false, status: 'online', siteId: 'site-a' },
+  { id: 'dev-a3', orgId: 'org-a', osType: 'windows', isEphemeral: true, status: 'online', siteId: 'site-a' },
+  { id: 'dev-a4', orgId: 'org-a', osType: 'windows', isEphemeral: false, status: 'decommissioned', siteId: 'site-a' },
+  // org-b — a DIFFERENT customer under the SAME partner. This is the blast radius.
+  { id: 'dev-b1', orgId: 'org-b', osType: 'windows', isEphemeral: false, status: 'online', siteId: 'site-b' },
+  // org-c — a different partner entirely
+  { id: 'dev-c1', orgId: 'org-c', osType: 'windows', isEphemeral: false, status: 'online', siteId: 'site-c' },
+];
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    orgs: [] as Array<Record<string, unknown>>,
+    devices: [] as Array<Record<string, unknown>>,
+    baselines: [] as Array<Record<string, unknown>>,
+    auth: {} as Record<string, unknown>,
+    permissions: undefined as unknown,
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// db mock: a tiny evaluator over drizzle's queryChunks.
+//
+// With the schema mocked to plain strings, `eq(devices.orgId, 'org-a')` serializes
+// to the chunk sequence [StringChunk(''), 'devices.orgId', StringChunk(' = '),
+// 'org-a', StringChunk('')] — both operands survive as raw chunks. That lets the
+// mock behave like a real filter instead of rubber-stamping whatever SQL it is
+// handed, so an assertion here cannot pass with the guard removed.
+// ---------------------------------------------------------------------------
+vi.mock('../db', () => {
+  function isSql(node: unknown): node is { queryChunks: unknown[] } {
+    return !!node && Array.isArray((node as { queryChunks?: unknown[] }).queryChunks);
+  }
+  function stringChunk(node: unknown): string | null {
+    const value = (node as { value?: unknown })?.value;
+    return Array.isArray(value) && value.every((v) => typeof v === 'string') ? value.join('') : null;
+  }
+
+  type SubqueryChain = { __table: string; __where: unknown };
+  function isSubquery(node: unknown): node is SubqueryChain {
+    return !!node && typeof (node as SubqueryChain).__table === 'string';
+  }
+
+  function subqueryIds(chain: SubqueryChain): unknown[] {
+    if (chain.__table !== 'organizations') throw new Error(`unexpected subquery on ${chain.__table}`);
+    return state.orgs.filter((row) => evalCondition(chain.__where, row)).map((row) => row.id);
+  }
+
+  function evalCondition(cond: unknown, row: Record<string, unknown>): boolean {
+    if (cond === undefined || cond === null) return true;
+    if (!isSql(cond)) throw new Error('condition is not a drizzle SQL node');
+
+    const raws: unknown[] = [];
+    const nested: unknown[] = [];
+    const strings: string[] = [];
+    for (const chunk of cond.queryChunks) {
+      if (isSql(chunk)) {
+        nested.push(chunk);
+        continue;
+      }
+      const s = stringChunk(chunk);
+      if (s !== null) strings.push(s);
+      else raws.push(chunk);
+    }
+
+    // Composite / wrapper node (and(), or(), and the paren wrapper they emit).
+    if (raws.length === 0) {
+      if (nested.length === 0) throw new Error('empty condition node');
+      const results = nested.map((n) => evalCondition(n, row));
+      return strings.includes(' or ') ? results.some(Boolean) : results.every(Boolean);
+    }
+
+    // Leaf comparison: raws[0] is the column, the rest are operands.
+    const column = String(raws[0]);
+    // `inArray(col, [a, b])` binds the whole array as ONE chunk, so flatten it.
+    const operands = raws.slice(1).flatMap((v) => (Array.isArray(v) ? v : [v]));
+    const op = (strings.find((s) => s.trim().length > 0) ?? '=').trim();
+    const cell = row[column.includes('.') ? column.slice(column.indexOf('.') + 1) : column];
+
+    if (op === '=') return cell === operands[0];
+    if (op === '<>') return cell !== operands[0];
+    if (op === 'in') {
+      if (operands.length === 1 && isSubquery(operands[0])) {
+        return subqueryIds(operands[0] as SubqueryChain).includes(cell);
+      }
+      return operands.includes(cell);
+    }
+    throw new Error(`unsupported operator '${op}'`);
+  }
+
+  function makeSelect(columns?: Record<string, unknown>) {
+    const chain: Record<string, unknown> = {
+      __table: 'unknown',
+      __where: undefined,
+      __columns: columns,
+      from(table: unknown) {
+        chain.__table = (table as { __t?: string })?.__t ?? 'unknown';
+        return chain;
+      },
+      where(w: unknown) {
+        chain.__where = w;
+        return chain;
+      },
+      limit(_n: number) {
+        return Promise.resolve(rows());
+      },
+      then(onOk: (v: unknown) => unknown, onErr?: (e: unknown) => unknown) {
+        return Promise.resolve(rows()).then(onOk, onErr);
+      },
+    };
+    function rows(): unknown[] {
+      if (chain.__table === 'cis_baselines') return state.baselines;
+      if (chain.__table === 'organizations') {
+        return state.orgs.filter((r) => evalCondition(chain.__where, r));
+      }
+      if (chain.__table === 'devices') {
+        return state.devices
+          .filter((r) => evalCondition(chain.__where, r))
+          .map((r) => ({ id: r.id, siteId: r.siteId }));
+      }
+      return [];
+    }
+    return chain;
+  }
+
+  return {
+    runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+    withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    db: {
+      select: vi.fn((columns?: Record<string, unknown>) => makeSelect(columns)),
+      insert: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../db/schema', () => ({
+  cisBaselines: {
+    __t: 'cis_baselines',
+    id: 'cisBaselines.id',
+    orgId: 'cisBaselines.orgId',
+    partnerId: 'cisBaselines.partnerId',
+    osType: 'cisBaselines.osType',
+    isActive: 'cisBaselines.isActive',
+    updatedAt: 'cisBaselines.updatedAt',
+  },
+  cisBaselineResults: { __t: 'cis_baseline_results', id: 'cisBaselineResults.id', orgId: 'cisBaselineResults.orgId' },
+  cisRemediationActions: { __t: 'cis_remediation_actions', id: 'cisRemediationActions.id' },
+  devices: {
+    __t: 'devices',
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    osType: 'devices.osType',
+    siteId: 'devices.siteId',
+    isEphemeral: 'devices.isEphemeral',
+    status: 'devices.status',
+    hostname: 'devices.hostname',
+  },
+  organizations: {
+    __t: 'organizations',
+    id: 'organizations.id',
+    partnerId: 'organizations.partnerId',
+  },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', state.auth);
+    c.set('permissions', state.permissions);
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    c.set('permissions', state.permissions);
+    return next();
+  }),
+}));
+
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/cisHardening', () => ({
+  extractFailedCheckIds: vi.fn(),
+  normalizeCisSchedule: vi.fn((s: any) => s ?? null),
+}));
+vi.mock('../jobs/cisJobs', () => ({
+  scheduleCisScan: vi.fn(),
+  scheduleCisRemediation: vi.fn(),
+  scheduleCisRemediationWithResult: vi.fn(),
+}));
+vi.mock('./networkShared', () => ({
+  resolveOrgId: vi.fn((auth: any, requestedOrgId?: string) => {
+    if (auth.scope === 'organization') return { orgId: auth.orgId };
+    if (requestedOrgId) return { orgId: requestedOrgId };
+    return { error: 'orgId is required', status: 400 };
+  }),
+}));
+
+import { eq, inArray } from 'drizzle-orm';
+import { cisHardeningRoutes } from './cisHardening';
+import { devices } from '../db/schema';
+import { scheduleCisScan } from '../jobs/cisJobs';
+
+function makeAuth(scope: 'organization' | 'partner' | 'system', accessibleOrgIds: string[] | null) {
+  return {
+    user: { id: 'user-1', email: 'tech@msp.example', name: 'Tech' },
+    scope,
+    partnerId: PARTNER_ID,
+    orgId: accessibleOrgIds?.[0] ?? null,
+    accessibleOrgIds,
+    // Mirrors buildOrgAccessClosures (middleware/auth.ts): null = unrestricted.
+    orgCondition: (column: any) => {
+      if (accessibleOrgIds === null) return undefined;
+      if (accessibleOrgIds.length === 1) return eq(column, accessibleOrgIds[0]);
+      return inArray(column, accessibleOrgIds);
+    },
+    canAccessOrg: (orgId: string) => accessibleOrgIds === null || accessibleOrgIds.includes(orgId),
+  };
+}
+
+function partnerWideBaseline(overrides: Record<string, unknown> = {}) {
+  return {
+    id: BASELINE_ID,
+    orgId: null,
+    partnerId: PARTNER_ID,
+    name: 'Windows L1 (all orgs)',
+    osType: 'windows',
+    benchmarkVersion: '3.0.0',
+    level: 'l1',
+    customExclusions: [],
+    scanSchedule: null,
+    isActive: true,
+    createdBy: 'user-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function scan(app: Hono, body: Record<string, unknown>) {
+  return app.request('/cis/scan', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+    body: JSON.stringify(body),
+  });
+}
+
+function scheduledDeviceIds(): string[] | undefined {
+  expect(scheduleCisScan).toHaveBeenCalledTimes(1);
+  const [, options] = vi.mocked(scheduleCisScan).mock.calls[0]! as [string, { deviceIds?: string[] }];
+  return options.deviceIds;
+}
+
+describe('POST /cis/scan — target-set authorization (security review §1.2)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.orgs = ORGS.map((o) => ({ ...o }));
+    state.devices = DEVICES.map((d) => ({ ...d }));
+    state.baselines = [partnerWideBaseline()];
+    state.permissions = undefined;
+    state.auth = makeAuth('organization', ['org-a']);
+    vi.mocked(scheduleCisScan).mockResolvedValue('job-1');
+    app = new Hono();
+    app.route('/cis', cisHardeningRoutes);
+  });
+
+  it('an ORG-scope caller omitting deviceIds on a PARTNER-WIDE baseline targets ONLY their own org', async () => {
+    const res = await scan(app, { baselineId: BASELINE_ID });
+    expect(res.status).toBe(202);
+
+    const targeted = scheduledDeviceIds();
+    // The whole point: an explicit, server-authorized list — never `undefined`,
+    // which is what made the worker fan out through the partner.
+    expect(Array.isArray(targeted)).toBe(true);
+    expect(targeted).toEqual(['dev-a1']);
+    // The other customer under the SAME partner must not be touched.
+    expect(targeted).not.toContain('dev-b1');
+    // Nor another partner's fleet, nor OS mismatches / ephemeral / decommissioned.
+    expect(targeted).not.toContain('dev-c1');
+    expect(targeted).not.toContain('dev-a2');
+    expect(targeted).not.toContain('dev-a3');
+    expect(targeted).not.toContain('dev-a4');
+  });
+
+  it('builds the target set with auth.orgCondition on devices.orgId', async () => {
+    const orgConditionSpy = vi.fn((column: any) => eq(column, 'org-a'));
+    state.auth = { ...makeAuth('organization', ['org-a']), orgCondition: orgConditionSpy };
+
+    const res = await scan(app, { baselineId: BASELINE_ID });
+
+    expect(res.status).toBe(202);
+    expect(orgConditionSpy).toHaveBeenCalledWith(devices.orgId);
+  });
+
+  it('a PARTNER-scope caller omitting deviceIds fans out across the orgs they can access', async () => {
+    state.auth = makeAuth('partner', ['org-a', 'org-b']);
+
+    const res = await scan(app, { baselineId: BASELINE_ID });
+
+    expect(res.status).toBe(202);
+    expect(scheduledDeviceIds()!.sort()).toEqual(['dev-a1', 'dev-b1']);
+  });
+
+  it('a SYSTEM-scope caller (no org filter) still stops at the baseline owner partner', async () => {
+    state.auth = makeAuth('system', null);
+
+    const res = await scan(app, { baselineId: BASELINE_ID });
+
+    expect(res.status).toBe(202);
+    const targeted = scheduledDeviceIds()!.sort();
+    expect(targeted).toEqual(['dev-a1', 'dev-b1']);
+    expect(targeted).not.toContain('dev-c1');
+  });
+
+  it('drops site-restricted devices from a server-resolved set instead of 403-ing the whole scan', async () => {
+    state.auth = makeAuth('partner', ['org-a', 'org-b']);
+    state.permissions = { allowedSiteIds: ['site-a'] };
+
+    const res = await scan(app, { baselineId: BASELINE_ID });
+
+    expect(res.status).toBe(202);
+    expect(scheduledDeviceIds()).toEqual(['dev-a1']);
+  });
+
+  it('queues nothing when the authorized target set is empty', async () => {
+    state.auth = makeAuth('organization', ['org-c']); // org-c is under a different partner
+
+    const res = await scan(app, { baselineId: BASELINE_ID });
+
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.jobId).toBeNull();
+    expect(body.deviceCount).toBe(0);
+    expect(scheduleCisScan).not.toHaveBeenCalled();
+  });
+
+  // The route schema requires GUIDs, so the explicit-list cases use GUID fixtures.
+  const GUID_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const GUID_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+  it('still 400s an EXPLICIT deviceIds list that reaches into another org', async () => {
+    // The caller is org-a scoped; GUID_B lives in org-b, so it never resolves.
+    state.devices = [
+      { id: GUID_A, orgId: 'org-a', osType: 'windows', isEphemeral: false, status: 'online', siteId: 'site-a' },
+      { id: GUID_B, orgId: 'org-b', osType: 'windows', isEphemeral: false, status: 'online', siteId: 'site-b' },
+    ];
+
+    const res = await scan(app, { baselineId: BASELINE_ID, deviceIds: [GUID_A, GUID_B] });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain('do not belong');
+    expect(scheduleCisScan).not.toHaveBeenCalled();
+  });
+
+  it('still 403s an EXPLICIT deviceIds list that reaches outside the caller allowed sites', async () => {
+    state.auth = makeAuth('partner', ['org-a', 'org-b']);
+    state.permissions = { allowedSiteIds: ['site-a'] };
+    state.devices = [
+      { id: GUID_A, orgId: 'org-a', osType: 'windows', isEphemeral: false, status: 'online', siteId: 'site-a' },
+      { id: GUID_B, orgId: 'org-b', osType: 'windows', isEphemeral: false, status: 'online', siteId: 'site-b' },
+    ];
+
+    const res = await scan(app, { baselineId: BASELINE_ID, deviceIds: [GUID_A, GUID_B] });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.deniedDeviceIds).toEqual([GUID_B]);
+    expect(scheduleCisScan).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/cisHardening_scan_report.test.ts
+++ b/apps/api/src/routes/cisHardening_scan_report.test.ts
@@ -145,13 +145,22 @@ describe('CIS hardening routes', () => {
   // ============================================
   describe('POST /cis/scan', () => {
     it('triggers a scan for a baseline', async () => {
-      vi.mocked(db.select).mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([makeBaseline()]),
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([makeBaseline()]),
+            }),
           }),
-        }),
-      } as any);
+        } as any)
+        // Omitting deviceIds no longer skips authorization: the route now resolves
+        // the target set server-side with the SAME predicates the explicit-list
+        // branch uses (security review §1.2). See cisHardening_scan_authz.test.ts.
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ id: DEVICE_ID, siteId: 'site-1' }]),
+          }),
+        } as any);
       vi.mocked(scheduleCisScan).mockResolvedValueOnce('job-123');
 
       const res = await app.request('/cis/scan', {
@@ -165,6 +174,10 @@ describe('CIS hardening routes', () => {
       expect(body.message).toContain('CIS scan queued');
       expect(body.jobId).toBe('job-123');
       expect(scheduleCisScan).toHaveBeenCalledTimes(1);
+      // Never `undefined` — that is what let the worker fan out through the partner.
+      expect(vi.mocked(scheduleCisScan).mock.calls[0]![1]).toMatchObject({
+        deviceIds: [DEVICE_ID],
+      });
     });
 
     it('returns 404 for nonexistent baseline', async () => {

--- a/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
@@ -162,7 +162,7 @@ vi.mock('../../db/schema', () => ({
     id: 'id', partnerId: 'partnerId', orgId: 'orgId', status: 'status', subject: 'subject',
     emailThreadKey: 'emailThreadKey', emailMessageId: 'emailMessageId',
     internalNumber: 'internalNumber', resolvedAt: 'resolvedAt', updatedAt: 'updatedAt',
-    deletedAt: 'deletedAt'
+    deletedAt: 'deletedAt', submittedBy: 'submittedBy', submitterEmail: 'submitterEmail'
   },
   ticketComments: { __t: 'ticket_comments', ticketId: 'ticketId' },
   portalUsers: { __t: 'portal_users', id: 'id', orgId: 'orgId', email: 'email' },
@@ -1166,5 +1166,155 @@ describe('processInboundEmail — inbound enabled master switch (#3597)', () => 
     await processInboundEmail(email());
 
     expect(inboundOf()[0]!.parseStatus).toBe('quarantined');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security review 2026-08-16 §1.3 — cross-org ticket comment injection via the
+// enumerable subject token.
+//
+// The subject-token path used to key on partnerId + status + internalNumber ONLY.
+// Ticket numbers are sequential, so anyone whose mail passes SPF/DKIM/DMARC (which
+// only proves they own THEIR OWN domain) could email the MSP's support address with
+// `Re: [T-2026-0123]` and get a PUBLIC comment appended to another customer org's
+// ticket — reopening it if it was resolved. The thread-key path is unguessable and
+// is deliberately left unbound.
+// ---------------------------------------------------------------------------
+describe('subject-token matches are bound to the sender (§1.3)', () => {
+  const VICTIM_TOKEN = 'T-2026-0123';
+
+  function victimTicket(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 't-victim',
+      partnerId: 'p-1',
+      orgId: 'org-b',
+      status: 'resolved',
+      emailThreadKey: '<anchor-b@tickets.example.com>',
+      internalNumber: VICTIM_TOKEN,
+      submittedBy: 'pu-victim',
+      submitterEmail: 'victim@customer-b.example',
+      ...overrides,
+    };
+  }
+
+  function comments() {
+    return state.inserts.filter((i) => i.table === 'ticket_comments').map((i) => i.values);
+  }
+
+  function reopened() {
+    return state.updates.filter((u) => u.table === 'tickets' && u.set.status === 'open');
+  }
+
+  beforeEach(() => {
+    resolveMock.mockResolvedValue('p-1');
+    state.selectRows['ticket_email_inbound'] = []; // no duplicate suppression
+    state.selectRows['tickets'] = [victimTicket()];
+    state.selectRows['portal_users'] = [];
+    state.selectRows['organizations'] = [{ id: 'org-a' }, { id: 'org-b' }];
+  });
+
+  it('EXPLOIT: an unaffiliated sender guessing the token gets NO comment and NO reopen', async () => {
+    // Attacker owns evil.example, so SPF/DKIM/DMARC pass. They know only the number.
+    await processInboundEmail(email({
+      from: 'attacker@evil.example',
+      fromName: 'Totally Legit',
+      subject: `Re: [${VICTIM_TOKEN}] please wire the funds`,
+    }));
+
+    expect(comments()).toHaveLength(0);
+    expect(reopened()).toHaveLength(0);
+    expect(emitMock).not.toHaveBeenCalled();
+    // No new ticket carrying the victim's org either.
+    expect(createTicketMock).not.toHaveBeenCalled();
+
+    // The fallthrough is indistinguishable from a message that carried no token:
+    // quarantined, with no ticket id that would confirm T-2026-0123 exists.
+    const log = inboundOf();
+    expect(log).toHaveLength(1);
+    expect(log[0]!.parseStatus).toBe('quarantined');
+    expect(log[0]!.ticketId ?? null).toBeNull();
+  });
+
+  it('EXPLOIT: a portal user of a DIFFERENT org under the same partner cannot reach the ticket', async () => {
+    // The sharpest case: a genuine customer of the same MSP, just not of org-b.
+    state.selectRows['portal_users'] = [{ id: 'pu-a', orgId: 'org-a' }];
+    createTicketMock.mockResolvedValue({ id: 't-own-org', internalNumber: 'T-2026-0500' });
+
+    await processInboundEmail(email({
+      from: 'neighbour@customer-a.example',
+      subject: `Re: [${VICTIM_TOKEN}] status?`,
+    }));
+
+    expect(comments()).toHaveLength(0);
+    expect(reopened()).toHaveLength(0);
+    // Falls through to the normal known-sender path: a fresh ticket in THEIR OWN org.
+    expect(createTicketMock).toHaveBeenCalledTimes(1);
+    expect((createTicketMock.mock.calls[0]![0] as Record<string, unknown>).orgId).toBe('org-a');
+    expect(inboundOf()[0]!.ticketId).toBe('t-own-org');
+  });
+
+  it('EXPLOIT: the CLOSED-ticket token path is bound too (no linked ticket in the victim org)', async () => {
+    state.selectRows['tickets'] = [victimTicket({ id: 't-closed-victim', status: 'closed' })];
+
+    await processInboundEmail(email({
+      from: 'attacker@evil.example',
+      subject: `Re: [${VICTIM_TOKEN}] reopening this`,
+    }));
+
+    expect(createTicketMock).not.toHaveBeenCalled();
+    expect(comments()).toHaveLength(0);
+    expect(inboundOf()[0]!.parseStatus).toBe('quarantined');
+  });
+
+  it('ALLOWED: the ticket requester replying by token still matches (comment + reopen)', async () => {
+    await processInboundEmail(email({
+      from: 'Victim@Customer-B.example', // case-insensitive match on submitter_email
+      subject: `Re: [${VICTIM_TOKEN}] any update?`,
+    }));
+
+    expect(comments()).toHaveLength(1);
+    expect(comments()[0]!.isPublic).toBe(true);
+    expect(reopened()).toHaveLength(1);
+    expect(inboundOf()[0]!.parseStatus).toBe('matched');
+    expect(inboundOf()[0]!.ticketId).toBe('t-victim');
+  });
+
+  it('ALLOWED: a portal user / email contact in the ticket org matches by token', async () => {
+    state.selectRows['tickets'] = [victimTicket({ submitterEmail: null, submittedBy: null })];
+    state.selectRows['portal_users'] = [{ id: 'pu-b2', orgId: 'org-b' }];
+
+    await processInboundEmail(email({
+      from: 'colleague@customer-b.example',
+      subject: `Re: [${VICTIM_TOKEN}] adding myself`,
+    }));
+
+    expect(comments()).toHaveLength(1);
+    expect(comments()[0]!.portalUserId).toBe('pu-b2');
+    expect(inboundOf()[0]!.parseStatus).toBe('matched');
+  });
+
+  it('ALLOWED: a sender whose domain is mapped to the ticket org matches by token', async () => {
+    state.selectRows['tickets'] = [victimTicket({ submitterEmail: null, submittedBy: null })];
+    resolveOrgMock.mockResolvedValue({ orgId: 'org-b', autoCreateContact: false });
+
+    await processInboundEmail(email({
+      from: 'newperson@customer-b.example',
+      subject: `Re: [${VICTIM_TOKEN}] hello`,
+    }));
+
+    expect(comments()).toHaveLength(1);
+    expect(inboundOf()[0]!.parseStatus).toBe('matched');
+  });
+
+  it('UNCHANGED: the unguessable thread-key path still matches without any sender binding', async () => {
+    await processInboundEmail(email({
+      from: 'stranger@somewhere.example',
+      subject: 'no token here at all',
+      inReplyTo: '<anchor-b@tickets.example.com>',
+    }));
+
+    expect(comments()).toHaveLength(1);
+    expect(inboundOf()[0]!.parseStatus).toBe('matched');
+    expect(inboundOf()[0]!.ticketId).toBe('t-victim');
   });
 });

--- a/apps/api/src/services/inboundEmail/inboundEmailService.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.ts
@@ -291,7 +291,10 @@ export async function processInboundEmail(
       return;
     }
 
-    const matched = await findTicketInPartner(n, partnerId);
+    // Resolve sender identity lazily so token binding and unmatched fallthrough
+    // reuse the same partner-scoped lookups.
+    const senderResolver = createSenderResolver(n.from, partnerId);
+    const matched = await findTicketInPartner(n, partnerId, senderResolver);
     if (matched) {
       // GUARD (spec §6 layer 2): never act across partners. A partner-scoped match query
       // should already make this impossible, but re-assert before ANY write and throw
@@ -302,7 +305,7 @@ export async function processInboundEmail(
       }
 
       // Append a public inbound comment, then reopen if resolved.
-      await appendInboundComment(matched.id, n, partnerId);
+      await appendInboundComment(matched.id, n, partnerId, senderResolver);
       if (matched.status === 'resolved') {
         await reopenResolvedTicket(matched.id, partnerId);
       }
@@ -315,7 +318,7 @@ export async function processInboundEmail(
     // SEPARATE from findTicketInPartner (which excludes closed) so the live-continuation
     // it spawns is what future replies match — the closed original is never re-matched,
     // which is what prevents a thread from forking into N tickets (FIX 2).
-    const closedOriginal = await findClosedTicketInPartner(n, partnerId);
+    const closedOriginal = await findClosedTicketInPartner(n, partnerId, senderResolver);
     if (closedOriginal) {
       const t = await createFromEmail(n, partnerId, closedOriginal.orgId, closedOriginal.emailThreadKey, closedOriginal.internalNumber);
       await logInbound(n, partnerId, 'created', t.id);
@@ -325,7 +328,7 @@ export async function processInboundEmail(
     // (5) Known portal-user sender -> their home org. Most specific; wins over
     // domain rules (a user who belongs to a sub-org isn't overridden by a
     // broader domain mapping).
-    const sender = await findPortalUserInPartner(n.from, partnerId);
+    const sender = await senderResolver.portalUser();
     if (sender) {
       const t = await createFromEmail(n, partnerId, sender.orgId, null, null, sender.id);
       await logInbound(n, partnerId, 'created', t.id);
@@ -336,7 +339,7 @@ export async function processInboundEmail(
     // ticket; optionally onboard a password-less contact so future replies
     // thread + attribute. This sits behind the senderAuth.verified (DMARC) gate
     // above, so a forged From: @customer.com can't file into the customer's org.
-    const domainMatch = await resolveOrgBySenderDomain(n.from, partnerId);
+    const domainMatch = await senderResolver.domainOrg();
     if (domainMatch) {
       const submittedBy = domainMatch.autoCreateContact
         ? await findOrCreateEmailContact(domainMatch.orgId, n.from, n.fromName ?? null)
@@ -390,6 +393,8 @@ interface MatchedTicket {
   status: string;
   emailThreadKey: string | null;
   internalNumber: string | null;
+  submittedBy: string | null;
+  submitterEmail: string | null;
 }
 
 const MATCH_COLS = {
@@ -398,8 +403,59 @@ const MATCH_COLS = {
   orgId: tickets.orgId,
   status: tickets.status,
   emailThreadKey: tickets.emailThreadKey,
-  internalNumber: tickets.internalNumber
+  internalNumber: tickets.internalNumber,
+  submittedBy: tickets.submittedBy,
+  submitterEmail: tickets.submitterEmail
 };
+
+interface SenderIdentity {
+  portalUser: { id: string; orgId: string; name: string | null } | null;
+  domainOrg: { orgId: string; autoCreateContact: boolean } | null;
+}
+
+interface SenderResolver {
+  portalUser(): Promise<SenderIdentity['portalUser']>;
+  domainOrg(): Promise<SenderIdentity['domainOrg']>;
+}
+
+function createSenderResolver(from: string, partnerId: string): SenderResolver {
+  let portalUserPromise: Promise<SenderIdentity['portalUser']> | undefined;
+  let domainOrgPromise: Promise<SenderIdentity['domainOrg']> | undefined;
+
+  return {
+    portalUser() {
+      portalUserPromise ??= findPortalUserInPartner(from, partnerId);
+      return portalUserPromise;
+    },
+    domainOrg() {
+      domainOrgPromise ??= resolveOrgBySenderDomain(from, partnerId);
+      return domainOrgPromise;
+    }
+  };
+}
+
+/**
+ * Bind a subject-token (ticket-number) match to the sender. Ticket numbers are
+ * sequential and enumerable and the token path carries no org predicate, so
+ * without this ANY authenticated-domain sender could append a public comment to
+ * another customer org's ticket (and reopen it). The thread-key path is
+ * unguessable and needs no binding.
+ */
+async function senderIsBoundToTicket(
+  from: string,
+  ticket: MatchedTicket,
+  sender: SenderResolver
+): Promise<boolean> {
+  if (ticket.submitterEmail && ticket.submitterEmail.trim().toLowerCase() === from.trim().toLowerCase()) {
+    return true;
+  }
+
+  const pu = await sender.portalUser();
+  if (pu && (pu.orgId === ticket.orgId || pu.id === ticket.submittedBy)) return true;
+
+  const dom = await sender.domainOrg();
+  return !!dom && dom.orgId === ticket.orgId;
+}
 
 // Candidate threading keys: In-Reply-To + every References entry (a reply's parent
 // can be anywhere in the References chain), deduped.
@@ -417,7 +473,11 @@ function candidateThreadKeys(n: NormalizedInboundEmail): string[] {
 // and fork the thread into N tickets. Excluding closed here makes a reply to a closed
 // ticket fall through to the dedicated closed lookup (-> ONE new linked ticket), while
 // subsequent replies match the LIVE continuation. Resolved tickets still match (reopen).
-async function findTicketInPartner(n: NormalizedInboundEmail, partnerId: string): Promise<MatchedTicket | null> {
+async function findTicketInPartner(
+  n: NormalizedInboundEmail,
+  partnerId: string,
+  sender: SenderResolver
+): Promise<MatchedTicket | null> {
   // 1) thread headers -> email_thread_key OR email_message_id (scoped to partner,
   // live tickets only). Candidate keys (In-Reply-To ∪ References) are matched
   // against EITHER column: email_thread_key carries the generated anchor (so a
@@ -457,7 +517,12 @@ async function findTicketInPartner(n: NormalizedInboundEmail, partnerId: string)
         eq(tickets.internalNumber, m[0])
       ))
       .limit(1);
-    if (rows[0]) return rows[0] as MatchedTicket;
+    const row = rows[0] as MatchedTicket | undefined;
+    if (row) {
+      // The token is enumerable, so require proof that this sender belongs to the ticket.
+      if (!(await senderIsBoundToTicket(n.from, row, sender))) return null;
+      return row;
+    }
   }
 
   return null;
@@ -468,7 +533,11 @@ async function findTicketInPartner(n: NormalizedInboundEmail, partnerId: string)
 // single new linked ticket when a customer replies to a closed thread. Kept separate from
 // findTicketInPartner (which returns live tickets only) so the closed original is never
 // re-matched for an append. Still partner-scoped (spec §6 layer 1).
-async function findClosedTicketInPartner(n: NormalizedInboundEmail, partnerId: string): Promise<MatchedTicket | null> {
+async function findClosedTicketInPartner(
+  n: NormalizedInboundEmail,
+  partnerId: string,
+  sender: SenderResolver
+): Promise<MatchedTicket | null> {
   const candidateKeys = candidateThreadKeys(n);
   if (candidateKeys.length > 0) {
     const rows = await db
@@ -496,7 +565,12 @@ async function findClosedTicketInPartner(n: NormalizedInboundEmail, partnerId: s
         eq(tickets.internalNumber, m[0])
       ))
       .limit(1);
-    if (rows[0]) return rows[0] as MatchedTicket;
+    const row = rows[0] as MatchedTicket | undefined;
+    if (row) {
+      // The token is enumerable, so require proof that this sender belongs to the ticket.
+      if (!(await senderIsBoundToTicket(n.from, row, sender))) return null;
+      return row;
+    }
   }
 
   return null;
@@ -625,11 +699,16 @@ async function createFromEmail(
   return ticket;
 }
 
-async function appendInboundComment(ticketId: string, n: NormalizedInboundEmail, partnerId: string): Promise<void> {
+async function appendInboundComment(
+  ticketId: string,
+  n: NormalizedInboundEmail,
+  partnerId: string,
+  senderResolver: SenderResolver
+): Promise<void> {
   // Inserted directly (NOT via addTicketComment, which forces authorType:'internal' /
   // user_id=actor). Under system scope the ticket_comments INSERT policy permits user_id IS
   // NULL. Email-sourced comments are ALWAYS public (spec §4: email can never create an internal note).
-  const sender = await findPortalUserInPartner(n.from, partnerId);
+  const sender = await senderResolver.portalUser();
   // appendInboundComment is only reached on the verified-sender match path (R4 gate
   // upstream), so a matched portal user is an authenticated identity: prefer their
   // STORED name over the spoofable From display name. Fall back to the header only


### PR DESCRIPTION
Two verified **CRITICAL** cross-tenant findings from the 2026-08-16 security review (`internal/2026-08-16-security-review-findings.md` §1.2 and §1.3). Both are authorization-shape bugs, not missing gates.

---

## 1. Org user could fan a CIS scan across every customer under the partner

**Where:** `apps/api/src/routes/cisHardening.ts:431-495` (pre-fix), `apps/api/src/jobs/cisJobs.ts:496-515`

**Exploit.** Every device authorization predicate on `POST /cis/scan` — owner condition, `auth.orgCondition(devices.orgId)`, OS match, and the explicit `allowedSiteIds` check that even carries the comment *"RLS does not defend the site axis"* — lived inside `if (Array.isArray(body.deviceIds) && body.deviceIds.length > 0)`. Omitting `deviceIds` skipped all of them and fell through to `scheduleCisScan(baseline.id, { deviceIds: undefined })`, which labels the job `'all'` and lets the worker resolve devices through the baseline's **partner**; for a partner-wide baseline (`partner_id` set, `org_id` NULL) an organization-scope caller with `devices:write` therefore dispatched a CIS scan against every org under the MSP. Partner-owned baseline *reads* are deliberately widened to org tokens (see follow-up below), so discovering the `baselineId` is trivial.

**Fix.**
- New file-local `resolveAuthorizedCisScanDeviceIds()` (`apps/api/src/routes/cisHardening.ts:129-208`) builds **one** predicate set — owner condition, `auth.orgCondition(devices.orgId)`, OS match, `allowedSiteIds` — and is used by **both** branches, so the explicit and server-resolved paths cannot drift again.
- The `/scan` handler now calls it **unconditionally** (`cisHardening.ts:512-519`) and always passes an explicit, authorized id list to `scheduleCisScan` — never `undefined`. An empty authorized set returns `202` with `jobId: null` rather than enqueuing anything.
- When the caller omits `deviceIds`, the server-resolved set additionally mirrors what the worker already filters (`isEphemeral = false`, `status <> 'decommissioned'`) so a Quick Support machine or a decommissioned endpoint is never swept in. Site-restricted devices are **filtered out** of a server-resolved set rather than 403-ing the whole scan; the explicit-list branch keeps its existing 400/403 semantics verbatim.
- The audit row now records both `deviceCount` (resolved) and `requestedDeviceCount` (what the client asked for).
- **`'all'` job-label semantics changed, deliberately:** because the route now always supplies ids, `scheduleCisScan` would have joined thousands of UUIDs into the BullMQ `jobId`. The device component is now bounded — `<= 4` ids keep the existing `join(',')` form, longer sets become `n<count>.<sha256-16>` (deterministic over the sorted, deduped list, so in-window dedupe still collapses identical requests and distinct sets never collide). The literal `'all'` label now means only a genuinely unscoped scheduled/recurring scan (`apps/api/src/jobs/cisJobs.ts:509-517`).

**Worker side confirmed correct, unchanged.** `selectCisScanTargetDevices` (`cisJobs.ts:157-185`) already fans a partner-wide baseline out by the device org's partner, and `processRunBaselineScan` (`cisJobs.ts:227-232`) already stamps the queued command with `orgId: row.orgId` — the DEVICE's org, never the baseline's. That matches the partner-wide fan-out contract in CLAUDE.md, so nothing was touched there.

**Test:** `apps/api/src/routes/cisHardening_scan_authz.test.ts` (new, 8 cases). The db mock **evaluates the real drizzle condition tree** against a fixture device table rather than rubber-stamping whatever SQL it's handed, so the assertions are on the actually-resolved device set. The headline case — org-scope caller, partner-wide baseline, `deviceIds` omitted — asserts the scheduled set is exactly `['dev-a1']` and explicitly not `dev-b1` (a different customer under the same partner) or `dev-c1` (another partner). Partner-scope and system-scope fan-out, site filtering, the empty-set no-op, and the unchanged explicit-list 400/403 paths are covered too.

---

## 2. Cross-org ticket comment injection via the email subject token

**Where:** `apps/api/src/services/inboundEmail/inboundEmailService.ts:294` → `findTicketInPartner()` at `:447-461` (pre-fix)

**Exploit.** Match path 2 keyed the subject token `[T-YYYY-NNNN]` on **only** `partner_id` + `status <> 'closed'` + not deleted + `internal_number` — no org predicate and no sender-to-ticket binding. Ticket numbers are sequential and enumerable, so anyone who emails the MSP's support address with subject `Re: [T-2026-0123]` got a **public comment appended** to that ticket and a resolved ticket **reopened**, for a different customer org — and the tech sees it in-thread as a genuine customer reply. SPF/DKIM/DMARC do not help: they only prove the attacker owns their own domain. The cross-*partner* guard at `:298` is correct; the gap was cross-*org within* one partner, and sender identification (`findPortalUserInPartner`) only ran at step 5, after matching at step 2.

**Fix.**
- Sender identity is resolved by a lazily-memoized `createSenderResolver()` (`inboundEmailService.ts:409-424`) built once per message, wrapping the **existing** `findPortalUserInPartner` and `resolveOrgBySenderDomain` lookups. It is threaded into matching and reused at steps 5/6 and in `appendInboundComment`, so no query runs twice.
- `senderIsBoundToTicket()` (`inboundEmailService.ts:426-450`) accepts a number match only when the sender is genuinely associated with the ticket's org: they are the ticket's requester (`submitter_email`, case-insensitive), a portal user / auto-created email contact in the ticket's org (or the ticket's `submitted_by`), or their domain is mapped to the ticket's org. `submittedBy` / `submitterEmail` were added to `MATCH_COLS`.
- The guard is applied to the number path of **both** `findTicketInPartner` (`:520-525`) and `findClosedTicketInPartner` (`:568-573`) — the closed-ticket token path had the same gap and would have spawned a linked ticket inside the victim org.
- An unbound sender simply **does not match**: control falls through to the ordinary unmatched-sender path (portal-user create → domain create → triage → quarantine) with no distinct log reason, status, or response, so the fallthrough is indistinguishable from a message that carried no token at all and never confirms the referenced ticket exists.
- The **thread-key path is untouched** — `In-Reply-To` / `References` against `email_thread_key` / `email_message_id` is already unguessable, so binding it would only break legitimate threading.

**Test:** 7 new cases in `apps/api/src/services/inboundEmail/inboundEmailService.test.ts` (`describe('subject-token matches are bound to the sender (§1.3)')`), using the file's existing behavioural db harness. The headline case — token for a ticket in org B, sender unaffiliated with org B — asserts **zero** `ticket_comments` inserts, **zero** reopen updates, no `emitTicketEvent`, no ticket created, and an inbound log of `quarantined` with a null `ticketId`. Also covered: a portal user of a *different* org under the same partner (falls through to a fresh ticket in their own org), the closed-ticket token path, the three legitimate binding routes, and the unchanged thread-key path.

---

## Verification

- `pnpm --filter @breeze/api test` on the touched suites: **164 passed / 15 files** (`cisHardening_*`, `cisJobs`, all of `services/inboundEmail/`).
- **Revert-the-fix check, actually run.** Restoring the `if (Array.isArray(body.deviceIds) …)` guard shape reds 6 of the 8 new CIS cases, including the headline one. Deleting the two `senderIsBoundToTicket` calls reds all 3 `EXPLOIT:` email cases and leaves the 4 `ALLOWED:`/`UNCHANGED:` cases green — so the suite fails for the right reason, not because a mock stopped resolving.
- `pnpm --filter @breeze/api exec tsc --noEmit`: clean.
- One pre-existing test needed updating: `cisHardening_scan_report.test.ts`'s "triggers a scan for a baseline" now mocks the second device-resolution `db.select` (omitting `deviceIds` no longer skips authorization) and asserts `scheduleCisScan` receives an explicit id array.

## Follow-up (not fixed here)

`apps/api/migrations/2026-08-10-cis-baselines-partner-ownership.sql:107` deliberately widens partner-owned CIS baseline **reads** to org tokens — that is how an org user legitimately sees a partner-wide baseline, and it is how the attacker discovered the `baselineId` in finding 1. The widening is intentional but load-bearing for that exploit chain and should be revisited separately now that the dispatch side is closed.

Minor: the web caller (`apps/web/src/components/cisHardening/CisBaselinesTab.tsx:97`) ignores `jobId`, so the new empty-set `202 { jobId: null }` toasts "scan queued" even when zero devices were authorized. Harmless, but worth a nicer message later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
