### PR TITLE
docs(security): enforce advisory publication + self-hoster disclosure guidance

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -315,10 +315,51 @@ Caveats:
 
 Rolling the fleet is a user-facing change — get Todd's go-ahead before promoting, and don't promote until both regions are deployed and healthy.
 
-**Security releases:** publish the GHSA advisory **after** rollout completes, never before (fix → quiet release → roll out → then publish). Internal cadence docs: `internal/security-hardening-tracker.md`, `internal/pending-release-notes-security.md`.
+**Security releases:** publish the GHSA advisory **after** rollout completes, never before (fix → quiet release → roll out → then publish). Internal cadence docs: `internal/security-disclosure-policy.md` (the decision doc), `internal/security-advisory-queue.md` (what's owed), `internal/security-hardening-tracker.md`.
+
+### Advisory-debt pre-flight — run this FIRST, every release, no exceptions
+
+Not a "security release only" step. Run it before writing the release body, because a pending
+advisory changes how *this* release's notes are worded.
+
+```bash
+gh api repos/lanternops/breeze/security-advisories \
+  --jq '.[] | select(.state=="draft") | "DRAFT \(.ghsa_id) patched=\(.vulnerabilities[0].patched_versions // "?") — \(.summary)"'
+```
+
+**GATE — this release does not proceed if a draft advisory's `patched_versions` has already rolled
+out.** Publish it first (`internal/security-advisory-queue.md` has the exact commands). Once a fix
+ships, it is visible in the diff and the release notes; the advisory is the only thing that turns it
+into a *notification*. Holding it protects nobody and leaves self-hosters unaware they're exposed.
+
+This gate exists because the old trailing checkbox ("GHSA published after rollout") **never once
+fired**: it sat last, after manual go-ahead-gated steps, so the release session always ended before
+rollout finished — and nothing persisted the debt afterward. Two High advisories from v0.69.0 sat
+unpublished for 2.5 months and 36 releases. Binding the check to the *next* release works because
+releases reliably recur; "after rollout" is a moment nobody revisits.
+
+### Release-notes security sections
+
+Split by urgency — one bullet in the first section carries more signal than a paragraph buried in
+forty:
+
+```markdown
+### Security — action required
+Self-hosted operators on <affected range> should upgrade immediately. <what an attacker could DO>.
+(GHSA-xxxx, #NNNN)
+
+### Security — hardening
+<routine defense-in-depth, batched, no urgency language>
+```
+
+Say what an attacker could **do**, not what the code now does — "could execute arbitrary code as
+root on macOS agents with auto-update enabled", not "now verifies the .pkg against the manifest".
+Name the affected version range; self-hosters do not know whether they're affected. Full taxonomy
+and per-severity clocks: `internal/security-disclosure-policy.md`.
 
 ## Quick checklist
 
+- [ ] **Advisory-debt pre-flight run** (`gh api ... select(.state=="draft")`) — any draft whose patched version already rolled out is **published before this release proceeds**
 - [ ] `docs/release-notes/next-release-draft.md` read and folded into the body — then cleared
 - [ ] `git diff $PREV..HEAD --stat` + migrations reviewed — blast radius understood
 - [ ] Tag pushed (off main for full release / off $PREV for surgical hotfix)
@@ -332,7 +373,7 @@ Rolling the fleet is a user-facing change — get Todd's go-ahead before promoti
 - [ ] Droplets deployed — **night region first** (back up → deploy → verify), then the other + `/health` green
 - [ ] Agent fleet promoted via slot-aware DB row change (both DBs) — only with Todd's go-ahead
 - [ ] Firewall exception removed (if the doctl fallback was used)
-- [ ] GHSA published *after* rollout (security releases only)
+- [ ] GHSA published *after* rollout (security releases only) — **and its row in `internal/security-advisory-queue.md` moved to Published.** If rollout finishes after this session ends, the queue row is what carries the debt forward; the next release's pre-flight gate will block on it.
 
 ## Notes & gotchas
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,43 @@
 
 ## Supported Versions
 
+Security fixes ship in the latest release only. Breeze does not backport patches to older
+versions — if you self-host, **staying current is the patch strategy**.
+
 | Version | Supported          |
 |---------|--------------------|
 | latest  | :white_check_mark: |
+| older   | :x:                |
+
+## How we disclose (for self-hosters)
+
+If you self-host, this is the section that matters to you. Hosted (`eu.2breeze.app` /
+`us.2breeze.app`) customers are patched by us on deploy; **self-hosted installs stay vulnerable
+until you upgrade.**
+
+**Watch these two places:**
+
+1. **[GitHub Security Advisories](https://github.com/LanternOps/breeze/security/advisories)** — the
+   authoritative record. Every Critical and High vulnerability gets an advisory with affected and
+   patched version ranges, impact, and workarounds. Use *Watch → Custom → Security alerts* on this
+   repo to be notified.
+2. **Release notes** — each release separates security content into two sections:
+   - `### Security — action required` — **upgrade promptly**; states the affected version range and
+     what an attacker could actually do.
+   - `### Security — hardening` — routine defense-in-depth, no urgency.
+
+**Timing.** We publish advisories only *after* a fix has shipped and rolled out, so the details are
+never public while users are unpatched. After that we aim to publish within **72 hours** (Critical)
+or **7 days** (High) of rollout.
+
+**CVEs.** Critical and High advisories get a CVE. Note that because Breeze is distributed as
+container images and binaries rather than through a package ecosystem, automated scanners and
+Dependabot generally will **not** alert you — please watch the advisories directly rather than
+relying on tooling to tell you.
+
+**Running an old version?** Check the advisories page against your deployed version
+(`GET /health` reports it). Anything published with a patched version newer than yours applies to
+you.
 
 ## Reporting a Vulnerability
 

--- a/apps/docs/src/content/docs/security/overview.mdx
+++ b/apps/docs/src/content/docs/security/overview.mdx
@@ -474,10 +474,48 @@ Breeze's security controls align with SOC 2 Trust Service Criteria.
 
 ## Vulnerability Disclosure
 
+### Reporting a vulnerability to us
+
 We follow coordinated disclosure:
 
 - **Response timelines**: 48-hour acknowledgment, severity-based fix targets
 - **Email**: [security@lanternops.io](mailto:security@lanternops.io)
+
+### Staying informed (self-hosted operators)
+
+<Aside type="caution" title="Self-hosted installs are not patched automatically">
+Breeze Cloud is patched by us on deploy. **A self-hosted install stays vulnerable until you
+upgrade it.** Security fixes ship in the latest release only — there are no backports, so staying
+current *is* the patch strategy. Set up one of the notifications below during initial deployment;
+Breeze does not phone home, so we have no way to contact you otherwise.
+</Aside>
+
+**1. Watch security advisories (recommended).** Published advisories are the authoritative record
+of what was fixed, which versions are affected, and any workarounds:
+
+- Go to [github.com/LanternOps/breeze](https://github.com/LanternOps/breeze) → **Watch** →
+  **Custom** → tick **Security alerts**.
+- Browse existing advisories at
+  [/security/advisories](https://github.com/LanternOps/breeze/security/advisories).
+
+**2. Read the security sections of each release.** Release notes split security content by urgency:
+
+| Section | Meaning |
+|---|---|
+| `Security — action required` | Upgrade promptly. States the affected version range and what an attacker could do. |
+| `Security — hardening` | Routine defense-in-depth. No action needed beyond upgrading normally. |
+
+**3. Check your deployed version against the advisories.** `GET /health` reports the running
+version. Any advisory whose patched version is newer than yours applies to your deployment.
+
+<Aside type="note" title="Automated scanners will not warn you">
+Breeze is distributed as container images and signed binaries rather than through a package
+ecosystem (npm, PyPI, and similar). Dependabot and most SCA scanners therefore do **not** raise
+alerts for Breeze advisories. Watch the advisories directly — do not assume tooling will tell you.
+</Aside>
+
+Critical and High vulnerabilities receive a CVE and a GitHub Security Advisory, published **after**
+a fix has shipped and rolled out, so details are never public while operators are unpatched.
 
 ---
 


### PR DESCRIPTION
## Why

Two High-severity advisories from **v0.69.0 (2026-06-02)** sat unpublished for **2.5 months and 36 releases**:

- [GHSA-7m9m-6m4w-244h](https://github.com/LanternOps/breeze/security/advisories/GHSA-7m9m-6m4w-244h) — macOS agent auto-update ran an unverified `.pkg` as root (root RCE via MITM/poisoned asset)
- [GHSA-276w-8c3g-5pv9](https://github.com/LanternOps/breeze/security/advisories/GHSA-276w-8c3g-5pv9) — quarantined device could clear its own containment by re-enrolling

Both are **now published** (2026-08-17), CWEs assigned, CVEs requested, and the v0.69.0 release notes retroactively lead with a `Security — action required` callout.

The four-step cadence in the hardening tracker was correct and was followed through step 3. **Step 4 has never once executed.**

## Root cause — structural, not negligence

The checklist item read *"GHSA published after rollout (security releases only)"* and:

1. **Sat last**, after manual go-ahead-gated deploy/promote steps — so the release session always ended *before* rollout completed. The box was unresolvable when read.
2. **Was conditional**, requiring the releaser to already know advisories were pending. Nothing surfaced them.
3. **Had no persistence.** Once the session ended, the unchecked box was gone.

Three independent artifacts show the same failure: the two draft GHSAs, `internal/pending-release-notes-security.md`, and a staged `v0.69.0-changelog-postrollout.patch` — which additionally targeted `CHANGELOG.md` (abandoned at 0.67.1), so it was unexecutable from the moment it was written.

## The fix

**Bind advisory debt to the NEXT release, not to "after rollout."** Releases reliably recur; post-rollout moments never get revisited.

### `.claude/skills/release/SKILL.md`
- Unconditional **advisory-debt pre-flight**, run *first*, listing draft advisories.
- **GATE:** the release does not proceed if a draft's patched version has already rolled out. Once a fix ships it is public in the diff and the notes — the advisory is the only thing that turns it into a *notification*, so holding it protects nobody.
- Two-section release-notes taxonomy (`action required` vs `hardening`) and the "say what an attacker could **do**, not what the code now does" rule.

### `SECURITY.md`
- New **How we disclose** section: what to watch, what the two release-note sections mean, publication timing, how to check a deployed version.
- Corrected **Supported Versions** — no backports, so staying current *is* the patch strategy. `latest ✅` alone did not convey that.

### `apps/docs` → `security/overview.mdx`
- Splits disclosure into inbound reporting vs **staying informed**.
- Subscription guidance placed at install-time attention — the cheapest way to grow the advisory subscriber list.
- States plainly that **Dependabot/SCA will not alert** (container images, not a package ecosystem), so operators don't assume tooling covers them.

## Known gap this does *not* close

We have **no way to reach existing self-hosters**: no phone-home, no registration, no telemetry, no mailing list. GHSA watcher emails do work — the constraint is our near-empty subscriber list, not the channel. The operator who deployed months ago, isn't in Discord, and doesn't watch the repo remains unreachable.

Scoped separately: an in-product advisory banner that resolves content **at runtime** (a build-time constant can never warn about a vulnerability disclosed after that build was cut — you cannot ship the warning inside the vulnerable build).

## Review notes

- Docs-only + skill-only. No runtime code, no migrations.
- Other worktrees carry their own copies of `release/SKILL.md`; they'll rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)