### PR TITLE
fix(api): enforce partner-wide capability + delegation ceiling on credential issuance

### DIFF
--- a/apps/api/src/__tests__/integration/client-ai-template-routes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/client-ai-template-routes.integration.test.ts
@@ -17,6 +17,12 @@ let activeAuthContext: {
   scope: 'partner';
   partnerId: string;
   accessibleOrgIds: string[];
+  /**
+   * Mirrors the real authMiddleware field (auth.ts:266) that
+   * canManagePartnerWidePolicies() gates on. Partner-wide (org_id NULL) writes
+   * require a full-partner admin ('all'); org-scoped writes must NOT.
+   */
+  partnerOrgAccess?: 'all' | 'selected' | 'none' | null;
 } | null = null;
 
 vi.mock('../../middleware/auth', async () => {
@@ -27,6 +33,7 @@ vi.mock('../../middleware/auth', async () => {
       c.set('auth', {
         scope: activeAuthContext.scope,
         partnerId: activeAuthContext.partnerId,
+        partnerOrgAccess: activeAuthContext.partnerOrgAccess ?? null,
         orgId: null,
         accessibleOrgIds: activeAuthContext.accessibleOrgIds,
         user: { id: null, email: 'integration@test' },
@@ -95,7 +102,7 @@ const JSON_HEADERS = { Authorization: 'Bearer x', 'Content-Type': 'application/j
 describe('adminTemplates routes against real RLS (breeze_app)', () => {
   it('POST creates a partner-wide template (org_id NULL) — the §10 write path', async () => {
     const partner = await createPartner();
-    activeAuthContext = { scope: 'partner', partnerId: partner.id, accessibleOrgIds: [] };
+    activeAuthContext = { scope: 'partner', partnerId: partner.id, accessibleOrgIds: [], partnerOrgAccess: 'all' };
 
     const app = await buildApp();
     const res = await app.request('/client-ai/admin/templates', {
@@ -124,7 +131,7 @@ describe('adminTemplates routes against real RLS (breeze_app)', () => {
     const partnerA = await createPartner();
     const partnerB = await createPartner();
 
-    activeAuthContext = { scope: 'partner', partnerId: partnerA.id, accessibleOrgIds: [] };
+    activeAuthContext = { scope: 'partner', partnerId: partnerA.id, accessibleOrgIds: [], partnerOrgAccess: 'all' };
     let app = await buildApp();
     const createRes = await app.request('/client-ai/admin/templates', {
       method: 'POST',
@@ -134,7 +141,7 @@ describe('adminTemplates routes against real RLS (breeze_app)', () => {
     const { template } = await createRes.json();
     created.push(template.id);
 
-    activeAuthContext = { scope: 'partner', partnerId: partnerB.id, accessibleOrgIds: [] };
+    activeAuthContext = { scope: 'partner', partnerId: partnerB.id, accessibleOrgIds: [], partnerOrgAccess: 'all' };
     app = await buildApp();
     const list = await app.request('/client-ai/admin/templates', { headers: JSON_HEADERS });
     const listBody = await list.json();

--- a/apps/api/src/__tests__/partner-wide-write-coverage.test.ts
+++ b/apps/api/src/__tests__/partner-wide-write-coverage.test.ts
@@ -1,0 +1,220 @@
+/**
+ * CONTRACT TEST — every caller-facing write to partner-wide state must consult
+ * `canManagePartnerWidePolicies` (epic #2135).
+ *
+ * Why this file exists: the security review of 2026-08-16 (§1.1) found SIX
+ * independent write sites that gated on `scope` and never on the CAPABILITY —
+ * custom fields, the approval-assurance floor, update rings (route + AI tool),
+ * AI prompt templates, alert templates, and partner service principals (which
+ * mint partner-wide MACHINE CREDENTIALS). Human code review had caught 0 of
+ * them across six separate PRs. That is exactly the failure profile the cascade
+ * lists and RLS coverage already answer mechanically, so this answers it the
+ * same way.
+ *
+ * The rule, and it is deliberately blunt:
+ *
+ *   A file under `src/routes/**` or `src/services/aiTools*.ts` that mutates a
+ *   PARTNER-AXIS table must mention `canManagePartnerWidePolicies`.
+ *
+ * "Partner-axis table" is derived from the live Drizzle schema, never
+ * hand-listed: any table with a `partner_id` column whose `org_id` is absent or
+ * NULLABLE can hold a row that belongs to the partner rather than to one org —
+ * i.e. a row that pushes state into every org under the MSP, including orgs
+ * created later. `org_id NOT NULL` tables cannot express that and are skipped.
+ *
+ * Scope is limited to routes + AI tools on purpose: those are the surfaces a
+ * human or an agent can reach with a token. Workers, jobs, seeds and background
+ * services run in a system context with no caller to gate, and enumerating them
+ * would drown the signal.
+ *
+ * The check is textual (does the file mention the helper?), not semantic — it
+ * cannot prove the gate is placed correctly, only that the author was made to
+ * think about it. Per-route tests assert the 403 actually fires. A grep-level
+ * guard that fires 6/6 is worth far more than a clever one that ships.
+ *
+ * Adding a file here: FIRST convince yourself the write genuinely cannot create
+ * or modify a partner-owned row from a caller's request. Then add it to
+ * ALLOWED_WITHOUT_CAPABILITY_CHECK with a reason. An entry with no reason is a
+ * bug you have not found yet.
+ *
+ * Plain unit test — reads the Drizzle schema objects and the source tree. No
+ * database, so it runs in the `test-api` job where a stale base still fails.
+ */
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, resolve } from 'path';
+import { getTableColumns, is } from 'drizzle-orm';
+import { PgTable } from 'drizzle-orm/pg-core';
+import * as schema from '../db/schema';
+
+const CAPABILITY_FN = 'canManagePartnerWidePolicies';
+const API_SRC = resolve(__dirname, '..');
+
+/**
+ * Files that mutate a partner-axis table but legitimately do not need the
+ * partner-wide capability gate. Every entry carries the reason it is exempt.
+ */
+const ALLOWED_WITHOUT_CAPABILITY_CHECK: Record<string, string> = {
+  // --- `users` is dual-axis (shape 4) but these are AUTHENTICATION flows -----
+  // They mutate the acting user's own credential/session columns (password
+  // hash, MFA secret, passkeys, phone, email verification, last-login), never
+  // partner-wide configuration. Authority here is "is this you", not "may you
+  // administer the partner".
+  'routes/auth/cfAccessRedirectLogin.ts': 'writes the authenticating user\'s own session/login columns',
+  'routes/auth/invite.ts': 'user invitation lifecycle; org/partner membership is gated by USERS_INVITE',
+  'routes/auth/login.ts': 'writes last-login/lockout columns for the authenticating user',
+  'routes/auth/mfa.ts': 'writes the acting user\'s own MFA enrolment',
+  'routes/auth/passkeys.ts': 'writes the acting user\'s own passkey credentials',
+  'routes/auth/password.ts': 'writes the acting user\'s own password hash',
+  'routes/auth/phone.ts': 'writes the acting user\'s own phone factor',
+  'routes/auth/verifyEmail.ts': 'writes the acting user\'s own email-verification state',
+  'routes/system.ts': 'platform-admin/system bootstrap surface, gated on isPlatformAdmin',
+  'routes/admin/abuse.ts': 'platform-admin abuse containment (suspend/flag), gated on isPlatformAdmin',
+
+  // --- org provisioning: gated on the ORG axis, not the partner axis --------
+  // Creating an organization under the partner is `organizations:write` plus
+  // orgAccess handling tracked separately (security review §1.1 "adjacent
+  // orgAccess gaps": orgs.ts:1345/1459, provisioning). It does not write a
+  // partner-owned CONFIG row.
+  'routes/agents/mtls.ts': 'agent enrolment touches organizations for cert/tenant bookkeeping, not partner config',
+  'routes/partnerApi/provisioning.ts': 'service-principal org provisioning; authority comes from the principal\'s scopes',
+  'services/aiToolsOrgs.ts': 'org CRUD tool; org-axis authority, no partner-owned row written',
+
+  // --- integrations / connections owned by the partner but gated elsewhere ---
+  'routes/accounting/index.ts': 'QBO/Xero connection lifecycle is gated by its own admin permission set',
+  'routes/oauthInteraction.ts': 'records the end-user\'s own OAuth consent grant, not partner configuration',
+
+  // --- known gaps, tracked; listed so the count cannot silently grow ---------
+  'routes/alertTemplates/rules.ts': 'alert RULES are org-owned in practice; partner-wide rule ownership is not exposed by this route',
+  'routes/softwareInstallMethods.ts': 'software_catalog rows here are catalog metadata, gated by the software permission set',
+  'routes/softwareInventory.ts': 'read-oriented inventory surface; its policy writes delegate to softwarePolicies routes',
+};
+
+/** Table export names whose rows can be partner-owned (org_id absent or nullable). */
+function partnerAxisTableNames(): string[] {
+  const names: string[] = [];
+  for (const [exportName, value] of Object.entries(schema)) {
+    if (!value || typeof value !== 'object') continue;
+    if (!is(value as never, PgTable)) continue;
+    let columns: Record<string, { notNull: boolean }>;
+    try {
+      columns = getTableColumns(value as never) as unknown as Record<string, { notNull: boolean }>;
+    } catch {
+      continue;
+    }
+    const orgId = columns.orgId;
+    const partnerId = columns.partnerId;
+    if (partnerId && (!orgId || !orgId.notNull)) names.push(exportName);
+  }
+  return names.sort();
+}
+
+function collectSourceFiles(): string[] {
+  const files: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!full.endsWith('.ts')) continue;
+      if (full.endsWith('.test.ts') || full.endsWith('.d.ts')) continue;
+      files.push(full);
+    }
+  };
+  walk(join(API_SRC, 'routes'));
+  for (const entry of readdirSync(join(API_SRC, 'services'))) {
+    if (/^aiTools.*\.ts$/.test(entry) && !entry.endsWith('.test.ts')) {
+      files.push(join(API_SRC, 'services', entry));
+    }
+  }
+  return files.sort();
+}
+
+/** Tables this file passes to `.insert()` / `.update()` / `.delete()`. */
+function mutatedTables(source: string, tableNames: string[]): string[] {
+  return tableNames.filter((table) =>
+    new RegExp(`\\.(insert|update|delete)\\(\\s*${table}\\s*[,)]`).test(source)
+  );
+}
+
+describe('partner-wide write coverage (security review 2026-08-16 §1.1)', () => {
+  const tableNames = partnerAxisTableNames();
+
+  it('derives a non-trivial partner-axis table set from the live schema', () => {
+    // Guards the guard: if the derivation silently returns [] (a schema import
+    // shape change, a Drizzle upgrade), every assertion below passes vacuously.
+    expect(tableNames.length).toBeGreaterThan(30);
+    expect(tableNames).toContain('customFieldDefinitions');
+    expect(tableNames).toContain('partnerServicePrincipals');
+    expect(tableNames).toContain('patchPolicies');
+    expect(tableNames).toContain('authenticatorPolicies');
+    expect(tableNames).toContain('alertTemplates');
+    expect(tableNames).toContain('clientAiPromptTemplates');
+  });
+
+  it('every caller-facing partner-axis write site consults the capability helper', () => {
+    const violations: string[] = [];
+
+    for (const file of collectSourceFiles()) {
+      const source = readFileSync(file, 'utf8');
+      const tables = mutatedTables(source, tableNames);
+      if (tables.length === 0) continue;
+
+      const rel = relative(API_SRC, file);
+      if (rel in ALLOWED_WITHOUT_CAPABILITY_CHECK) continue;
+      if (source.includes(CAPABILITY_FN)) continue;
+
+      violations.push(`${rel} mutates ${tables.join(', ')} without calling ${CAPABILITY_FN}()`);
+    }
+
+    expect(
+      violations,
+      `Partner-wide write sites missing the ${CAPABILITY_FN}() gate.\n` +
+        'Add the gate (403 + PARTNER_WIDE_WRITE_DENIED_MESSAGE), or, if the write genuinely ' +
+        'cannot touch a partner-owned row, add the file to ALLOWED_WITHOUT_CAPABILITY_CHECK ' +
+        'with a reason.\n' +
+        violations.join('\n')
+    ).toEqual([]);
+  });
+
+  it('the allowlist has no stale entries', () => {
+    // A file that stopped mutating partner-axis tables (or moved) must leave the
+    // allowlist, or the exemption silently outlives the code it excused.
+    const stillMutating = new Set(
+      collectSourceFiles()
+        .filter((file) => mutatedTables(readFileSync(file, 'utf8'), tableNames).length > 0)
+        .map((file) => relative(API_SRC, file))
+    );
+
+    const stale = Object.keys(ALLOWED_WITHOUT_CAPABILITY_CHECK).filter((rel) => !stillMutating.has(rel));
+    expect(stale, `Remove these from ALLOWED_WITHOUT_CAPABILITY_CHECK: ${stale.join(', ')}`).toEqual([]);
+  });
+
+  it('every allowlist entry documents why it is exempt', () => {
+    const undocumented = Object.entries(ALLOWED_WITHOUT_CAPABILITY_CHECK)
+      .filter(([, reason]) => reason.trim().length < 20)
+      .map(([rel]) => rel);
+    expect(undocumented).toEqual([]);
+  });
+
+  it('the six sites from the 2026-08-16 review carry the gate', () => {
+    // Named explicitly so a regression on any ONE of them is a clearly-labelled
+    // failure rather than an anonymous line in the sweep above.
+    const fixed = [
+      'routes/customFields.ts',
+      'routes/authenticator.ts',
+      'routes/updateRings.ts',
+      'services/aiToolsPolicyPrereqs.ts',
+      'routes/clientAi/adminTemplates.ts',
+      'routes/alertTemplates/templates.ts',
+      'routes/partnerServicePrincipals.ts',
+    ];
+
+    for (const rel of fixed) {
+      const source = readFileSync(join(API_SRC, rel), 'utf8');
+      expect(source.includes(CAPABILITY_FN), `${rel} lost its ${CAPABILITY_FN}() gate`).toBe(true);
+    }
+  });
+});

--- a/apps/api/src/routes/alertTemplates.partnerWide.test.ts
+++ b/apps/api/src/routes/alertTemplates.partnerWide.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const { authRef, selectResult, dbInsertMock, dbUpdateMock, dbDeleteMock } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'partner' as const,
+      partnerId: 'p-1' as string | null,
+      partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null | undefined,
+      orgId: null as string | null,
+      accessibleOrgIds: [] as string[],
+      canAccessOrg: (_orgId: string) => false,
+      user: { id: 'u-1', email: 'admin@example.com' },
+    },
+  },
+  selectResult: vi.fn(),
+  dbInsertMock: vi.fn(),
+  dbUpdateMock: vi.fn(),
+  dbDeleteMock: vi.fn(),
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    c.set('auth', authRef.current);
+    await next();
+  },
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn(() => selectResult()) })),
+      })),
+    })),
+    insert: dbInsertMock,
+    update: dbUpdateMock,
+    delete: dbDeleteMock,
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  alertTemplates: {
+    id: 'id', orgId: 'orgId', partnerId: 'partnerId', name: 'name', description: 'description',
+    category: 'category', conditions: 'conditions', severity: 'severity', targets: 'targets',
+    cooldownMinutes: 'cooldownMinutes', isBuiltIn: 'isBuiltIn', titleTemplate: 'titleTemplate',
+    messageTemplate: 'messageTemplate', createdAt: 'createdAt', updatedAt: 'updatedAt',
+  },
+}));
+
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../services/alertConditions', () => ({ retiredConditionTypeError: vi.fn(() => null) }));
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: { ALERTS_WRITE: { resource: 'alerts', action: 'write' } },
+}));
+vi.mock('../utils/pagination', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
+}));
+
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
+import { templateRoutes } from './alertTemplates/templates';
+
+const TEMPLATE_ID = '55555555-5555-4555-8555-555555555555';
+
+const PARTNER_ROW = {
+  id: TEMPLATE_ID,
+  orgId: null,
+  partnerId: 'p-1',
+  name: 'Offline devices',
+  description: null,
+  category: 'Availability',
+  conditions: {},
+  severity: 'high',
+  targets: { scope: 'organization' },
+  cooldownMinutes: 15,
+  isBuiltIn: false,
+};
+
+function setPartnerOrgAccess(partnerOrgAccess: 'all' | 'selected') {
+  authRef.current = {
+    scope: 'partner',
+    partnerId: 'p-1',
+    partnerOrgAccess,
+    orgId: null,
+    accessibleOrgIds: [],
+    canAccessOrg: () => false,
+    user: { id: 'u-1', email: 'admin@example.com' },
+  };
+}
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alert-templates', templateRoutes);
+  return app;
+}
+
+function createRequest(app: Hono) {
+  return app.request('/alert-templates/templates', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Offline devices', severity: 'high', availability: 'partner' }),
+  });
+}
+
+function patchRequest(app: Hono) {
+  return app.request(`/alert-templates/templates/${TEMPLATE_ID}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Long-offline devices' }),
+  });
+}
+
+function deleteRequest(app: Hono) {
+  return app.request(`/alert-templates/templates/${TEMPLATE_ID}`, { method: 'DELETE' });
+}
+
+describe('alert template partner-wide capability gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPartnerOrgAccess('all');
+    selectResult.mockResolvedValue([PARTNER_ROW]);
+    dbInsertMock.mockImplementation(() => ({
+      values: vi.fn((values: Record<string, unknown>) => ({
+        returning: vi.fn(async () => [{ ...PARTNER_ROW, ...values }]),
+      })),
+    }));
+    dbUpdateMock.mockImplementation(() => ({
+      set: vi.fn((values: Record<string, unknown>) => ({
+        where: vi.fn(() => ({ returning: vi.fn(async () => [{ ...PARTNER_ROW, ...values }]) })),
+      })),
+    }));
+    dbDeleteMock.mockImplementation(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+  });
+
+  it('POST /templates with partner availability returns 403 for selected access', async () => {
+    setPartnerOrgAccess('selected');
+
+    const res = await createRequest(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    expect(dbInsertMock).not.toHaveBeenCalled();
+  });
+
+  it('POST /templates with partner availability succeeds for all access', async () => {
+    const res = await createRequest(makeApp());
+
+    expect(res.status).toBe(201);
+    expect((await res.json()).data).toMatchObject({ orgId: null, partnerId: 'p-1' });
+    expect(dbInsertMock).toHaveBeenCalledOnce();
+  });
+
+  it('PATCH /templates/:id returns 403 for selected access on a partner-wide row', async () => {
+    setPartnerOrgAccess('selected');
+
+    const res = await patchRequest(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    expect(dbUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /templates/:id succeeds for all access on the same partner-wide row', async () => {
+    const res = await patchRequest(makeApp());
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.name).toBe('Long-offline devices');
+    expect(dbUpdateMock).toHaveBeenCalledOnce();
+  });
+
+  it('DELETE /templates/:id returns 403 for selected access on a partner-wide row', async () => {
+    setPartnerOrgAccess('selected');
+
+    const res = await deleteRequest(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    expect(dbDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /templates/:id succeeds for all access on the same partner-wide row', async () => {
+    const res = await deleteRequest(makeApp());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: { id: TEMPLATE_ID, deleted: true } });
+    expect(dbDeleteMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/routes/alertTemplates/templates.guard.test.ts
+++ b/apps/api/src/routes/alertTemplates/templates.guard.test.ts
@@ -11,8 +11,12 @@ const partnerWide: Row = { orgId: null, partnerId: 'p-1', isBuiltIn: false };
 const builtIn: Row = { orgId: null, partnerId: null, isBuiltIn: true };
 
 const orgUser = { scope: 'organization' as const, partnerId: 'p-1', canAccessOrg: (id: string) => id === 'org-1' };
-const partnerUser = { scope: 'partner' as const, partnerId: 'p-1', canAccessOrg: (id: string) => id === 'org-1' };
-const otherPartnerUser = { scope: 'partner' as const, partnerId: 'p-2', canAccessOrg: () => false };
+// Full partner admin: org_access = 'all' is the capability to administer
+// partner-wide state (epic #2135). `restrictedPartnerUser` is the same partner
+// with a narrowed selection — visible to it, but not administrable.
+const partnerUser = { scope: 'partner' as const, partnerId: 'p-1', partnerOrgAccess: 'all' as const, canAccessOrg: (id: string) => id === 'org-1' };
+const restrictedPartnerUser = { scope: 'partner' as const, partnerId: 'p-1', partnerOrgAccess: 'selected' as const, canAccessOrg: (id: string) => id === 'org-1' };
+const otherPartnerUser = { scope: 'partner' as const, partnerId: 'p-2', partnerOrgAccess: 'all' as const, canAccessOrg: () => false };
 const systemUser = { scope: 'system' as const, partnerId: null, canAccessOrg: () => true };
 
 describe('canWriteTemplate', () => {
@@ -35,6 +39,16 @@ describe('canWriteTemplate', () => {
 
   it('lets the owning partner edit a partner-wide template', () => {
     expect(canWriteTemplate(partnerUser, partnerWide)).toEqual({ ok: true });
+  });
+
+  it('denies a RESTRICTED partner user (orgAccess selected) the partner-wide write (§1.1 #5)', () => {
+    // Scope proves WHICH partner, not the capability to administer its shared
+    // state. The row is visible to this user; it must not be writable.
+    expect(canWriteTemplate(restrictedPartnerUser, partnerWide)).toMatchObject({ ok: false, status: 403 });
+  });
+
+  it('still lets a restricted partner user edit an ORG-owned template they can reach', () => {
+    expect(canWriteTemplate(restrictedPartnerUser, orgRow)).toEqual({ ok: true });
   });
 
   it('hides another partner’s partner-wide template (404)', () => {

--- a/apps/api/src/routes/alertTemplates/templates.ts
+++ b/apps/api/src/routes/alertTemplates/templates.ts
@@ -10,6 +10,10 @@ import { parseBoolean } from './helpers';
 import { getPagination } from '../../utils/pagination';
 import { PERMISSIONS } from '../../services/permissions';
 import { retiredConditionTypeError } from '../../services/alertConditions';
+import {
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+  canManagePartnerWidePolicies,
+} from '../../services/partnerWideAccess';
 
 export const templateRoutes = new Hono();
 
@@ -75,7 +79,7 @@ export function templateScopeCondition(auth: AuthContext): ReturnType<typeof or>
 // rows belong to the MSP and are read-only for org scope; built-in rows are
 // read-only for everyone (only seeding creates them). Caller is the AuthContext.
 export function canWriteTemplate(
-  auth: Pick<AuthContext, 'scope' | 'partnerId' | 'canAccessOrg'>,
+  auth: Pick<AuthContext, 'scope' | 'partnerId' | 'canAccessOrg' | 'partnerOrgAccess'>,
   row: { orgId: string | null; partnerId: string | null; isBuiltIn: boolean },
 ): { ok: true } | { ok: false; status: 403 | 404; error: string } {
   if (row.isBuiltIn) return { ok: false, status: 403, error: 'Built-in templates cannot be modified' };
@@ -85,8 +89,14 @@ export function canWriteTemplate(
     if (auth.scope === 'organization') {
       return { ok: false, status: 403, error: 'This template is shared across your organization and is read-only here' };
     }
-    if (row.partnerId === auth.partnerId) return { ok: true };
-    return { ok: false, status: 404, error: 'Template not found' };
+    if (row.partnerId !== auth.partnerId) return { ok: false, status: 404, error: 'Template not found' };
+    // Partner scope proves WHICH partner, not the capability to administer
+    // that partner's shared state (epic #2135; security review 2026-08-16
+    // §1.1 #5).
+    if (!canManagePartnerWidePolicies(auth)) {
+      return { ok: false, status: 403, error: PARTNER_WIDE_WRITE_DENIED_MESSAGE };
+    }
+    return { ok: true };
   }
   // Org-specific record: caller must be able to access that org.
   if (row.orgId !== null && auth.canAccessOrg(row.orgId)) return { ok: true };
@@ -237,6 +247,10 @@ templateRoutes.post(
           orgId = null;
           partnerId = auth.partnerId ?? null;
           if (!partnerId) return c.json({ error: 'Partner context required' }, 403);
+          // Partner-wide row: capability gate, not just scope (§1.1 #5).
+          if (!canManagePartnerWidePolicies(auth)) {
+            return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+          }
         } else {
           if (!orgId) {
             const single = auth.accessibleOrgIds?.[0];

--- a/apps/api/src/routes/apiKeys.rotateCeiling.test.ts
+++ b/apps/api/src/routes/apiKeys.rotateCeiling.test.ts
@@ -1,0 +1,235 @@
+/**
+ * §1.4 — API-key rotation must not hand a broader key's plaintext to a lesser
+ * admin. Rotation regenerates the secret but leaves scopes and the delegating
+ * `created_by` untouched, so the rotator walks away with the key's authority.
+ * `ensureOrgAccess` only proves org membership; these tests assert the three
+ * delegation-ceiling axes actually deny, and — the important half — that a
+ * legitimately-superior caller still succeeds.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const KEY_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ORG_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+const { authRef, permissionsRef, existingKeyRef, creatorAuthzRef } = vi.hoisted(() => ({
+  authRef: { current: null as any },
+  permissionsRef: { current: null as any },
+  existingKeyRef: { current: null as any },
+  creatorAuthzRef: { current: null as any },
+}));
+
+vi.mock('../services', () => ({}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([existingKeyRef.current])),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() =>
+            Promise.resolve([
+              {
+                id: KEY_ID,
+                orgId: ORG_ID,
+                name: 'Victim Key',
+                keyPrefix: 'brz_rotated',
+                scopes: existingKeyRef.current?.scopes ?? [],
+                status: 'active',
+              },
+            ])
+          ),
+        })),
+      })),
+    })),
+  },
+  runOutsideDbContext: vi.fn((fn: () => any) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({ apiKeys: {}, organizations: {} }));
+
+vi.mock('../services/auditService', () => ({ createAuditLogAsync: vi.fn() }));
+
+vi.mock('../services/apiKeyAuthorization', () => ({
+  authorizeHumanApiKeyCreator: vi.fn(async () => creatorAuthzRef.current),
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', authRef.current);
+    c.set('permissions', permissionsRef.current);
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+import { apiKeyRoutes } from './apiKeys';
+
+/** Caller: org scope, holds everything, no site restriction. */
+function superiorCaller() {
+  authRef.current = {
+    scope: 'organization',
+    partnerId: null,
+    orgId: ORG_ID,
+    allowedSiteIds: undefined,
+    user: { id: 'boss', email: 'boss@example.com' },
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+  };
+  permissionsRef.current = {
+    permissions: [{ resource: '*', action: '*' }],
+    partnerId: null,
+    orgId: ORG_ID,
+    roleId: 'role-admin',
+    scope: 'organization',
+  };
+}
+
+function rotate(app: Hono) {
+  return app.request(`/api-keys/${KEY_ID}/rotate`, {
+    method: 'POST',
+    headers: { Authorization: 'Bearer token' },
+  });
+}
+
+describe('POST /api-keys/:id/rotate — delegation ceiling (§1.4)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    superiorCaller();
+    existingKeyRef.current = {
+      id: KEY_ID,
+      orgId: ORG_ID,
+      status: 'active',
+      createdBy: 'victim',
+      scopes: ['devices:read'],
+      principalType: 'human',
+      principalId: null,
+    };
+    creatorAuthzRef.current = {
+      ok: true,
+      permissions: {
+        permissions: [{ resource: 'devices', action: 'read' }],
+        partnerId: null,
+        orgId: ORG_ID,
+        roleId: 'role-victim',
+        scope: 'organization',
+      },
+      allowedSiteIds: undefined,
+      clampedScopes: ['devices:read'],
+    };
+    app = new Hono();
+    app.route('/api-keys', apiKeyRoutes);
+  });
+
+  it('POSITIVE CONTROL: a caller whose authority covers the key rotates it and gets plaintext', async () => {
+    const res = await rotate(app);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.key).toMatch(/^brz_/);
+  });
+
+  it('denies on the PERMISSION axis when the key carries a scope the rotator lacks', async () => {
+    // The core §1.4 escalation: caller has organizations:write (enough to reach
+    // the route) but not scripts:execute, which the victim's key confers.
+    permissionsRef.current = {
+      permissions: [{ resource: 'organizations', action: 'write' }],
+      partnerId: null,
+      orgId: ORG_ID,
+      roleId: 'role-lesser',
+      scope: 'organization',
+    };
+    existingKeyRef.current.scopes = ['scripts:execute'];
+
+    const res = await rotate(app);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.details.violation).toBe('permission');
+    expect(body.details.missingPermission).toBe('scripts:execute');
+  });
+
+  it('denies on the SCOPE axis when an org caller rotates a partner-scope credential', async () => {
+    creatorAuthzRef.current.permissions.scope = 'partner';
+
+    const res = await rotate(app);
+    expect(res.status).toBe(403);
+    expect((await res.json()).details.violation).toBe('scope');
+  });
+
+  it('denies on the SITE axis when a site-restricted caller rotates an unrestricted key', async () => {
+    authRef.current.allowedSiteIds = ['site-1'];
+    creatorAuthzRef.current.allowedSiteIds = undefined;
+
+    const res = await rotate(app);
+    expect(res.status).toBe(403);
+    expect((await res.json()).details.violation).toBe('site');
+  });
+
+  it('allows a site-restricted caller to rotate a key confined to their own sites', async () => {
+    authRef.current.allowedSiteIds = ['site-1', 'site-2'];
+    creatorAuthzRef.current.allowedSiteIds = ['site-1'];
+
+    const res = await rotate(app);
+    expect(res.status).toBe(200);
+  });
+
+  it('denies when the key\'s delegating creator can no longer be authorized', async () => {
+    creatorAuthzRef.current = { ok: false, reason: 'no_membership' };
+
+    const res = await rotate(app);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/revoke it instead of rotating it/);
+  });
+
+  it('denies when the request carries no resolved permissions at all (fail closed)', async () => {
+    permissionsRef.current = undefined;
+
+    const res = await rotate(app);
+    expect(res.status).toBe(403);
+  });
+
+  it('runs the ceiling BEFORE any write — a denied rotation must not touch the row', async () => {
+    const { db } = await import('../db');
+    permissionsRef.current = {
+      permissions: [{ resource: 'organizations', action: 'write' }],
+      partnerId: null,
+      orgId: ORG_ID,
+      roleId: 'role-lesser',
+      scope: 'organization',
+    };
+    existingKeyRef.current.scopes = ['scripts:execute'];
+
+    const res = await rotate(app);
+    expect(res.status).toBe(403);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('service-principal keys skip creator resolution but still face the ceiling', async () => {
+    existingKeyRef.current.principalType = 'service';
+    existingKeyRef.current.principalId = 'sp-1';
+    existingKeyRef.current.scopes = ['scripts:execute'];
+    permissionsRef.current = {
+      permissions: [{ resource: 'organizations', action: 'write' }],
+      partnerId: null,
+      orgId: ORG_ID,
+      roleId: 'role-lesser',
+      scope: 'organization',
+    };
+
+    const { authorizeHumanApiKeyCreator } = await import('../services/apiKeyAuthorization');
+    const res = await rotate(app);
+
+    expect(res.status).toBe(403);
+    expect(authorizeHumanApiKeyCreator).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/apiKeys.test.ts
+++ b/apps/api/src/routes/apiKeys.test.ts
@@ -39,6 +39,25 @@ vi.mock('../db/schema', () => ({
   organizations: {}
 }));
 
+// The §1.4 rotation delegation ceiling resolves the key's delegating creator
+// through this service. Default it to "creator is an ordinary org user with no
+// site restriction" so the happy-path rotate test still exercises the handler;
+// the ceiling's own denials are covered in apiKeys.rotateCeiling.test.ts.
+vi.mock('../services/apiKeyAuthorization', () => ({
+  authorizeHumanApiKeyCreator: vi.fn(async () => ({
+    ok: true,
+    permissions: {
+      permissions: [{ resource: '*', action: '*' }],
+      partnerId: null,
+      orgId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      roleId: 'role-1',
+      scope: 'organization'
+    },
+    allowedSiteIds: undefined,
+    clampedScopes: []
+  }))
+}));
+
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
     c.set('auth', {

--- a/apps/api/src/routes/apiKeys.ts
+++ b/apps/api/src/routes/apiKeys.ts
@@ -8,8 +8,16 @@ import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthC
 import { createHash, randomBytes } from 'crypto';
 import { createAuditLogAsync } from '../services/auditService';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
-import { PERMISSIONS, type UserPermissions } from '../services/permissions';
-import { validateApiKeyScopeDelegation } from '../services/apiKeyScopes';
+import { PERMISSIONS, hasPermission, type UserPermissions } from '../services/permissions';
+import {
+  requiredPermissionsForApiKeyScopes,
+  validateApiKeyScopeDelegation,
+} from '../services/apiKeyScopes';
+import { authorizeHumanApiKeyCreator } from '../services/apiKeyAuthorization';
+import {
+  DELEGATION_CEILING_DENIED_MESSAGE,
+  checkDelegationCeiling,
+} from '../services/delegationCeiling';
 
 export const apiKeyRoutes = new Hono();
 
@@ -77,6 +85,98 @@ function writeApiKeyAudit(
     userAgent: c.req.header('user-agent'),
     result: 'success'
   });
+}
+
+/**
+ * Delegation ceiling for ROTATION (security review 2026-08-16 §1.4).
+ *
+ * Rotation regenerates the secret but changes nothing about what the key can
+ * do: its `scopes`, and the `created_by` user whose live permissions the key
+ * actually delegates from (see `buildAuthFromApiKey` / SR2-15), survive
+ * untouched. Handing the new plaintext to the rotator therefore hands them the
+ * key's whole authority. `ensureOrgAccess` only proves they may act in the
+ * key's ORG — that is not the same as being allowed to wield the key.
+ *
+ * So before returning plaintext, assert the rotator's own authority is a
+ * superset of the key's on all three axes (scope / permission / site). Creation
+ * already does the permission axis via `validateRequestedScopes`; rotation had
+ * no equivalent at all.
+ *
+ * Fails CLOSED: if the key's delegating creator can no longer be authorized
+ * (off-boarded, role reduced, DB error), the key's true authority is unknown
+ * and rotation is denied. Such a key is already dead on the request path — it
+ * should be revoked, not rotated.
+ */
+async function enforceRotationDelegationCeiling(
+  c: any,
+  auth: Pick<AuthContext, 'scope' | 'partnerId' | 'allowedSiteIds'>,
+  existingKey: {
+    orgId: string;
+    scopes: string[] | null;
+    createdBy: string;
+    principalType?: string | null;
+    principalId?: string | null;
+  },
+): Promise<{ response: Response } | null> {
+  const callerPermissions = c.get('permissions') as UserPermissions | undefined;
+  if (!callerPermissions) {
+    return { response: c.json({ error: DELEGATION_CEILING_DENIED_MESSAGE }, 403) };
+  }
+
+  const keyScopes = existingKey.scopes ?? [];
+  const isServicePrincipalKey =
+    existingKey.principalType === 'service' && !!existingKey.principalId;
+
+  // Service-principal keys delegate from the principal row, not a human, and
+  // are never site-restricted (authorizeServicePrincipalKey). Human keys
+  // delegate from their creator's LIVE permissions — resolve those so the
+  // credential's real scope/site reach is compared, not a mint-time guess.
+  let credentialScope: 'system' | 'partner' | 'organization' = 'organization';
+  let credentialSiteIds: string[] | undefined;
+
+  if (!isServicePrincipalKey) {
+    const creator = await authorizeHumanApiKeyCreator({
+      createdBy: existingKey.createdBy,
+      orgId: existingKey.orgId,
+      partnerId: auth.partnerId ?? null,
+      scopes: keyScopes,
+    });
+    if (!creator.ok) {
+      return {
+        response: c.json(
+          {
+            error: 'This key\'s owner can no longer be authorized; revoke it instead of rotating it',
+            details: { reason: creator.reason },
+          },
+          403,
+        ),
+      };
+    }
+    credentialScope = creator.permissions?.scope ?? 'organization';
+    credentialSiteIds = creator.allowedSiteIds;
+  }
+
+  const ceiling = checkDelegationCeiling({
+    caller: { scope: auth.scope, allowedSiteIds: auth.allowedSiteIds },
+    credential: {
+      scope: credentialScope,
+      permissions: requiredPermissionsForApiKeyScopes(keyScopes),
+      allowedSiteIds: credentialSiteIds,
+    },
+    holdsPermission: (permission) =>
+      hasPermission(callerPermissions, permission.resource, permission.action),
+  });
+
+  if (!ceiling.ok) {
+    return {
+      response: c.json(
+        { error: ceiling.error, details: { violation: ceiling.violation, ...(ceiling.details ?? {}) } },
+        403,
+      ),
+    };
+  }
+
+  return null;
 }
 
 function validateRequestedScopes(c: any, scopes: string[]) {
@@ -547,6 +647,11 @@ apiKeyRoutes.post(
     if (existingKey.status !== 'active') {
       return c.json({ error: `Cannot rotate ${existingKey.status} API key` }, 400);
     }
+
+    // §1.4 delegation ceiling: org access is not key access. Runs BEFORE any
+    // secret is generated or written.
+    const ceilingDenial = await enforceRotationDelegationCeiling(c, auth, existingKey);
+    if (ceilingDenial) return ceilingDenial.response;
 
     // Generate new key
     const { fullKey, keyPrefix, keyHash } = generateApiKey();

--- a/apps/api/src/routes/authenticator.test.ts
+++ b/apps/api/src/routes/authenticator.test.ts
@@ -168,8 +168,10 @@ vi.mock('../middleware/auth', () => ({
     }
     c.set('auth', {
       user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+      scope: 'partner',
       orgId: 'org-123',
       partnerId: 'partner-123',
+      partnerOrgAccess: 'all',
       token: { mfa: true, sid: 'sid-123' },
     });
     return next();

--- a/apps/api/src/routes/authenticator.ts
+++ b/apps/api/src/routes/authenticator.ts
@@ -11,6 +11,10 @@ import {
   verifyApproverRegistration,
 } from '../services/approverWebAuthn';
 import { loadPartnerPolicy, validateRaiseOnly } from '../services/authenticatorPolicy';
+import {
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+  canManagePartnerWidePolicies,
+} from '../services/partnerWideAccess';
 import { readMobileDeviceId } from '../services/mobileDeviceBinding';
 import {
   requireCurrentPasswordStepUp,
@@ -500,6 +504,14 @@ authenticatorRoutes.put(
     const auth = c.get('auth');
     if (!auth.partnerId) {
       return c.json({ error: 'Approval-security policy is partner-scoped' }, 400);
+    }
+    // The approval-assurance floor applies to EVERY org under the partner, so
+    // it is partner-wide state: capability gate, not just a partner context
+    // (epic #2135; security review 2026-08-16 §1.1 #2). Without this an
+    // `orgAccess: selected` user with users:write could rewrite the whole
+    // MSP's step-up enforcement.
+    if (!canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
     const input = c.req.valid('json');
     // floorOverrides already infers as AssuranceFloorOverrides (literal levels in

--- a/apps/api/src/routes/clientAi/adminTemplates.partnerWide.test.ts
+++ b/apps/api/src/routes/clientAi/adminTemplates.partnerWide.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  authRef,
+  selectResult,
+  dbInsertMock,
+  dbUpdateMock,
+  dbDeleteMock,
+} = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'partner' as 'partner' | 'organization' | 'system',
+      partnerId: 'p-1' as string | null,
+      partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null | undefined,
+      orgId: null as string | null,
+      accessibleOrgIds: [] as string[],
+      canAccessOrg: (_orgId: string) => false,
+      user: { id: 'u-1', email: 'admin@example.com' },
+    },
+  },
+  selectResult: vi.fn(),
+  dbInsertMock: vi.fn(),
+  dbUpdateMock: vi.fn(),
+  dbDeleteMock: vi.fn(),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (c: any, next: any) => {
+    c.set('auth', authRef.current);
+    await next();
+  }),
+  requirePermission: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(() => {
+      const chain: Record<string, any> = {};
+      for (const method of ['from', 'leftJoin', 'where', 'limit', 'orderBy']) {
+        chain[method] = vi.fn(() => chain);
+      }
+      chain.then = (resolve: (value: unknown[]) => unknown, reject?: (error: unknown) => unknown) =>
+        Promise.resolve(selectResult()).then(resolve, reject);
+      return chain;
+    }),
+    insert: dbInsertMock,
+    update: dbUpdateMock,
+    delete: dbDeleteMock,
+  },
+}));
+
+vi.mock('../../db/schema/clientAi', () => ({
+  clientAiPromptTemplates: {
+    id: 'id', orgId: 'orgId', partnerId: 'partnerId', name: 'name', description: 'description',
+    promptBody: 'promptBody', category: 'category', hosts: 'hosts', createdAt: 'createdAt',
+    updatedAt: 'updatedAt', createdBy: 'createdBy',
+  },
+}));
+vi.mock('../../db/schema/orgs', () => ({ organizations: { id: 'id', name: 'name' } }));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../../services/permissions', () => ({
+  PERMISSIONS: {
+    ORGS_READ: { resource: 'organizations', action: 'read' },
+    ORGS_WRITE: { resource: 'organizations', action: 'write' },
+  },
+}));
+
+import { authMiddleware } from '../../middleware/auth';
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
+import { clientAiAdminTemplateRoutes } from './adminTemplates';
+
+const TEMPLATE_ID = '77777777-7777-4777-8777-777777777777';
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+
+const PARTNER_ROW = {
+  id: TEMPLATE_ID,
+  orgId: null,
+  partnerId: 'p-1',
+  orgName: null,
+  name: 'Quarterly summary',
+  description: null,
+  promptBody: 'Summarize the quarter.',
+  category: 'finance',
+  hosts: null,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+};
+
+function setPartnerAuth(partnerOrgAccess: 'all' | 'selected') {
+  authRef.current = {
+    scope: 'partner',
+    partnerId: 'p-1',
+    partnerOrgAccess,
+    orgId: null,
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    user: { id: 'u-1', email: 'admin@example.com' },
+  };
+}
+
+function setOrgAuth() {
+  authRef.current = {
+    scope: 'organization',
+    partnerId: null,
+    partnerOrgAccess: undefined,
+    orgId: ORG_ID,
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    user: { id: 'u-2', email: 'org-admin@example.com' },
+  };
+}
+
+function makeApp() {
+  const app = new Hono();
+  app.use('*', authMiddleware as never);
+  app.route('/client-ai/admin', clientAiAdminTemplateRoutes);
+  return app;
+}
+
+const HEADERS = { 'Content-Type': 'application/json' };
+
+function createRequest(app: Hono) {
+  return app.request('/client-ai/admin/templates', {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify({ name: 'Quarterly summary', promptBody: 'Summarize the quarter.' }),
+  });
+}
+
+function updateRequest(app: Hono) {
+  return app.request(`/client-ai/admin/templates/${TEMPLATE_ID}`, {
+    method: 'PUT',
+    headers: HEADERS,
+    body: JSON.stringify({ name: 'Updated summary' }),
+  });
+}
+
+function deleteRequest(app: Hono) {
+  return app.request(`/client-ai/admin/templates/${TEMPLATE_ID}`, { method: 'DELETE' });
+}
+
+describe('client AI admin template partner-wide capability gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPartnerAuth('all');
+    selectResult.mockResolvedValue([PARTNER_ROW]);
+    dbInsertMock.mockImplementation(() => ({
+      values: vi.fn((values: Record<string, unknown>) => ({
+        returning: vi.fn(async () => [{ ...PARTNER_ROW, ...values }]),
+      })),
+    }));
+    dbUpdateMock.mockImplementation(() => ({
+      set: vi.fn((values: Record<string, unknown>) => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(async () => [{ ...PARTNER_ROW, ...values }]),
+        })),
+      })),
+    }));
+    dbDeleteMock.mockImplementation(() => ({
+      where: vi.fn(() => ({ returning: vi.fn(async () => [PARTNER_ROW]) })),
+    }));
+  });
+
+  it('POST /templates without orgId returns 403 for selected access', async () => {
+    setPartnerAuth('selected');
+
+    const res = await createRequest(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    expect(dbInsertMock).not.toHaveBeenCalled();
+  });
+
+  it('POST /templates without orgId succeeds for all access', async () => {
+    const res = await createRequest(makeApp());
+
+    expect(res.status).toBe(201);
+    expect((await res.json()).template).toMatchObject({ orgId: null, partnerId: 'p-1' });
+    expect(dbInsertMock).toHaveBeenCalledOnce();
+  });
+
+  it('PUT /templates/:id returns 403 for selected access on a partner-wide row', async () => {
+    setPartnerAuth('selected');
+
+    const res = await updateRequest(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    expect(dbUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('PUT /templates/:id succeeds for all access on the same partner-wide row', async () => {
+    const res = await updateRequest(makeApp());
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).template.name).toBe('Updated summary');
+    expect(dbUpdateMock).toHaveBeenCalledOnce();
+  });
+
+  it('DELETE /templates/:id returns 403 for selected access on a partner-wide row', async () => {
+    setPartnerAuth('selected');
+
+    const res = await deleteRequest(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    expect(dbDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /templates/:id succeeds for all access on the same partner-wide row', async () => {
+    const res = await deleteRequest(makeApp());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(dbDeleteMock).toHaveBeenCalledOnce();
+  });
+
+  it('keeps an org-owned row writable by its organization caller', async () => {
+    const orgRow = { ...PARTNER_ROW, orgId: ORG_ID, partnerId: null };
+    setOrgAuth();
+    selectResult.mockResolvedValue([orgRow]);
+    dbUpdateMock.mockImplementation(() => ({
+      set: vi.fn((values: Record<string, unknown>) => ({
+        where: vi.fn(() => ({ returning: vi.fn(async () => [{ ...orgRow, ...values }]) })),
+      })),
+    }));
+    dbDeleteMock.mockImplementation(() => ({
+      where: vi.fn(() => ({ returning: vi.fn(async () => [orgRow]) })),
+    }));
+
+    const putRes = await updateRequest(makeApp());
+    const deleteRes = await deleteRequest(makeApp());
+
+    expect(putRes.status).toBe(200);
+    expect(deleteRes.status).toBe(200);
+    expect(dbUpdateMock).toHaveBeenCalledOnce();
+    expect(dbDeleteMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/routes/clientAi/adminTemplates.partnerWide.test.ts
+++ b/apps/api/src/routes/clientAi/adminTemplates.partnerWide.test.ts
@@ -15,7 +15,7 @@ const {
       partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null | undefined,
       orgId: null as string | null,
       accessibleOrgIds: [] as string[],
-      canAccessOrg: (_orgId: string) => false,
+      canAccessOrg: (_orgId: string): boolean => false,
       user: { id: 'u-1', email: 'admin@example.com' },
     },
   },

--- a/apps/api/src/routes/clientAi/adminTemplates.test.ts
+++ b/apps/api/src/routes/clientAi/adminTemplates.test.ts
@@ -20,6 +20,7 @@ vi.mock('../../middleware/auth', () => ({
     c.set('auth', {
       scope: authState.scope,
       partnerId: authState.partnerId,
+      partnerOrgAccess: authState.scope === 'partner' ? 'all' : null,
       orgId: authState.scope === 'organization' ? '0c0c0c0c-1111-4222-8333-444455556666' : null,
       accessibleOrgIds: ['0c0c0c0c-1111-4222-8333-444455556666'],
       user: { id: 'ce11ce11-1111-4222-8333-444455556666', email: 'msp@example.com' },

--- a/apps/api/src/routes/clientAi/adminTemplates.ts
+++ b/apps/api/src/routes/clientAi/adminTemplates.ts
@@ -8,6 +8,10 @@ import { requirePermission } from '../../middleware/auth';
 import { normalizeTemplateHosts } from '../../services/clientAiHosts';
 import { PERMISSIONS } from '../../services/permissions';
 import { writeRouteAudit } from '../../services/auditEvents';
+import {
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+  canManagePartnerWidePolicies,
+} from '../../services/partnerWideAccess';
 import { resolveScopedOrgId } from '../c2c/helpers';
 import { templateBodySchema, templateUpdateSchema, templateListQuerySchema } from './schemas';
 
@@ -40,6 +44,7 @@ const requireOrgsWrite = requirePermission(
 type TemplateAuth = {
   scope: 'system' | 'partner' | 'organization';
   partnerId: string | null;
+  partnerOrgAccess?: 'all' | 'selected' | 'none' | null;
   user?: { id: string };
 };
 
@@ -116,6 +121,13 @@ clientAiAdminTemplateRoutes.post(
       if (auth.scope === 'organization' || !auth.partnerId) {
         return c.json({ error: 'partner_scope_required' }, 403);
       }
+      // Scope alone is not the capability (epic #2135; security review
+      // 2026-08-16 §1.1 #4): a `selected` partner user must not author a
+      // template that lands in every org under the partner, including orgs
+      // created later.
+      if (!canManagePartnerWidePolicies(auth)) {
+        return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+      }
       values = {
         orgId: null,
         partnerId: auth.partnerId,
@@ -150,6 +162,7 @@ clientAiAdminTemplateRoutes.put(
   requireOrgsWrite,
   zValidator('json', templateUpdateSchema),
   async (c) => {
+    const auth = c.get('auth') as TemplateAuth;
     const id = c.req.param('id')!;
     const body = c.req.valid('json');
 
@@ -161,6 +174,11 @@ clientAiAdminTemplateRoutes.put(
       .where(eq(clientAiPromptTemplates.id, id))
       .limit(1);
     if (!existing) return c.json({ error: 'Template not found' }, 404);
+
+    // Partner-wide row (org_id NULL): same capability gate as create.
+    if (existing.orgId === null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
 
     const set: Partial<typeof clientAiPromptTemplates.$inferInsert> = { updatedAt: new Date() };
     if (body.name !== undefined) set.name = body.name;
@@ -191,7 +209,20 @@ clientAiAdminTemplateRoutes.put(
 
 // ── DELETE /templates/:id ─────────────────────────────────────────────────────
 clientAiAdminTemplateRoutes.delete('/templates/:id', requireOrgsWrite, async (c) => {
+  const auth = c.get('auth') as TemplateAuth;
   const id = c.req.param('id')!;
+
+  // Read before deleting so the partner-wide capability gate can see the row's
+  // ownership axis (RLS already bounds visibility to the caller's tenancy).
+  const [target] = await db
+    .select({ orgId: clientAiPromptTemplates.orgId })
+    .from(clientAiPromptTemplates)
+    .where(eq(clientAiPromptTemplates.id, id))
+    .limit(1);
+  if (!target) return c.json({ error: 'Template not found' }, 404);
+  if (target.orgId === null && !canManagePartnerWidePolicies(auth)) {
+    return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+  }
 
   const [row] = await db
     .delete(clientAiPromptTemplates)

--- a/apps/api/src/routes/customFields.partnerWide.test.ts
+++ b/apps/api/src/routes/customFields.partnerWide.test.ts
@@ -10,7 +10,7 @@ const { authRef, selectResult, insertResult, updateResult, dbInsertMock, dbUpdat
         partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null | undefined,
         orgId: null as string | null,
         accessibleOrgIds: [] as string[] | null,
-        canAccessOrg: (_orgId: string) => false,
+        canAccessOrg: (_orgId: string): boolean => false,
         user: { id: 'u-1', email: 'admin@example.com' },
       },
     },

--- a/apps/api/src/routes/customFields.partnerWide.test.ts
+++ b/apps/api/src/routes/customFields.partnerWide.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const { authRef, selectResult, insertResult, updateResult, dbInsertMock, dbUpdateMock, dbDeleteMock } =
+  vi.hoisted(() => ({
+    authRef: {
+      current: {
+        scope: 'partner' as 'partner' | 'organization' | 'system',
+        partnerId: 'p-1' as string | null,
+        partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null | undefined,
+        orgId: null as string | null,
+        accessibleOrgIds: [] as string[] | null,
+        canAccessOrg: (_orgId: string) => false,
+        user: { id: 'u-1', email: 'admin@example.com' },
+      },
+    },
+    selectResult: vi.fn(),
+    insertResult: vi.fn(),
+    updateResult: vi.fn(),
+    dbInsertMock: vi.fn(),
+    dbUpdateMock: vi.fn(),
+    dbDeleteMock: vi.fn(),
+  }));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (c: any, next: any) => {
+    c.set('auth', authRef.current);
+    await next();
+  }),
+  requireScope: () => async (_c: any, next: any) => next(),
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn(() => selectResult()) })),
+      })),
+    })),
+    insert: dbInsertMock,
+    update: dbUpdateMock,
+    delete: dbDeleteMock,
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  customFieldDefinitions: {
+    id: 'id', orgId: 'orgId', partnerId: 'partnerId', name: 'name', fieldKey: 'fieldKey',
+    type: 'type', options: 'options', required: 'required', defaultValue: 'defaultValue',
+    deviceTypes: 'deviceTypes', createdAt: 'createdAt', updatedAt: 'updatedAt',
+  },
+}));
+
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: {
+    DEVICES_READ: { resource: 'devices', action: 'read' },
+    DEVICES_WRITE: { resource: 'devices', action: 'write' },
+  },
+}));
+
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
+import { customFieldRoutes } from './customFields';
+
+const FIELD_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+
+function makeField(overrides: Record<string, unknown> = {}) {
+  return {
+    id: FIELD_ID,
+    orgId: null,
+    partnerId: 'p-1',
+    name: 'Serial Number',
+    fieldKey: 'serial_number',
+    type: 'text',
+    options: null,
+    required: false,
+    defaultValue: null,
+    deviceTypes: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    ...overrides,
+  };
+}
+
+function setPartnerAuth(partnerOrgAccess: 'all' | 'selected') {
+  authRef.current = {
+    scope: 'partner',
+    partnerId: 'p-1',
+    partnerOrgAccess,
+    orgId: null,
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    user: { id: 'u-1', email: 'admin@example.com' },
+  };
+}
+
+function setOrgAuth() {
+  authRef.current = {
+    scope: 'organization',
+    partnerId: null,
+    partnerOrgAccess: undefined,
+    orgId: ORG_ID,
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+    user: { id: 'u-2', email: 'org-admin@example.com' },
+  };
+}
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/custom-fields', customFieldRoutes);
+  return app;
+}
+
+function createRequest(app: Hono) {
+  return app.request('/custom-fields', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Serial Number', fieldKey: 'serial_number', type: 'text' }),
+  });
+}
+
+function patchRequest(app: Hono) {
+  return app.request(`/custom-fields/${FIELD_ID}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Asset Serial' }),
+  });
+}
+
+function deleteRequest(app: Hono) {
+  return app.request(`/custom-fields/${FIELD_ID}`, { method: 'DELETE' });
+}
+
+describe('custom fields partner-wide capability gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPartnerAuth('all');
+    selectResult.mockResolvedValue([makeField()]);
+    insertResult.mockResolvedValue([makeField()]);
+    updateResult.mockResolvedValue([makeField({ name: 'Asset Serial' })]);
+    dbInsertMock.mockImplementation(() => ({
+      values: vi.fn(() => ({ returning: vi.fn(() => insertResult()) })),
+    }));
+    dbUpdateMock.mockImplementation(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({ returning: vi.fn(() => updateResult()) })),
+      })),
+    }));
+    dbDeleteMock.mockImplementation(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+  });
+
+  it('POST / without orgId returns 403 for selected partner access', async () => {
+    setPartnerAuth('selected');
+
+    const res = await createRequest(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    expect(dbInsertMock).not.toHaveBeenCalled();
+  });
+
+  it('POST / without orgId succeeds for all partner access', async () => {
+    const res = await createRequest(makeApp());
+
+    expect(res.status).toBe(201);
+    expect((await res.json()).data).toMatchObject({ orgId: null, partnerId: 'p-1' });
+    expect(dbInsertMock).toHaveBeenCalledOnce();
+  });
+
+  it('PATCH /:id returns 403 for selected access on a partner-wide row', async () => {
+    setPartnerAuth('selected');
+
+    const res = await patchRequest(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(dbUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /:id succeeds for all access on the same partner-wide row', async () => {
+    const res = await patchRequest(makeApp());
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.name).toBe('Asset Serial');
+    expect(dbUpdateMock).toHaveBeenCalledOnce();
+  });
+
+  it('DELETE /:id returns 403 for selected access on a partner-wide row', async () => {
+    setPartnerAuth('selected');
+
+    const res = await deleteRequest(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(dbDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /:id succeeds for all access on the same partner-wide row', async () => {
+    const res = await deleteRequest(makeApp());
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.id).toBe(FIELD_ID);
+    expect(dbDeleteMock).toHaveBeenCalledOnce();
+  });
+
+  it('keeps an org-owned row editable by its organization caller', async () => {
+    setOrgAuth();
+    selectResult.mockResolvedValue([makeField({ orgId: ORG_ID, partnerId: null })]);
+    updateResult.mockResolvedValue([makeField({ orgId: ORG_ID, partnerId: null, name: 'Asset Serial' })]);
+
+    const res = await patchRequest(makeApp());
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).data).toMatchObject({ orgId: ORG_ID, name: 'Asset Serial' });
+    expect(dbUpdateMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/routes/customFields.ts
+++ b/apps/api/src/routes/customFields.ts
@@ -54,6 +54,10 @@ import { customFieldDefinitions } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS } from '../services/permissions';
+import {
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+  canManagePartnerWidePolicies,
+} from '../services/partnerWideAccess';
 
 export const customFieldRoutes = new Hono();
 const requireCustomFieldRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
@@ -117,7 +121,7 @@ async function getOrgIdsForAuth(
 
 function canEditField(
   field: typeof customFieldDefinitions.$inferSelect,
-  auth: { scope: string; partnerId: string | null; orgId: string | null }
+  auth: Pick<AuthContext, 'scope' | 'partnerId' | 'orgId' | 'partnerOrgAccess'>
 ) {
   if (auth.scope === 'system') {
     return true;
@@ -132,7 +136,10 @@ function canEditField(
   }
 
   if (field.partnerId) {
-    return auth.scope === 'partner' && auth.partnerId === field.partnerId;
+    // Partner-wide row (org_id NULL): epic #2135 capability gate, not just
+    // scope. A `selected` partner user whose selection happens to cover every
+    // current org still must not administer partner-wide state.
+    return auth.partnerId === field.partnerId && canManagePartnerWidePolicies(auth);
   }
 
   return false;
@@ -306,6 +313,11 @@ customFieldRoutes.post(
         }
         partnerId = null;
       } else {
+        // Partner-wide definition (org_id NULL) — capability gate, not just
+        // scope (epic #2135; security review 2026-08-16 §1.1 #1).
+        if (!canManagePartnerWidePolicies(auth)) {
+          return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+        }
         partnerId = auth.partnerId;
       }
     } else if (!orgId && !partnerId) {

--- a/apps/api/src/routes/customFields_multitenant.test.ts
+++ b/apps/api/src/routes/customFields_multitenant.test.ts
@@ -115,6 +115,7 @@ describe('customFields routes', () => {
           scope: 'partner',
           orgId: null,
           partnerId: PARTNER_ID,
+          partnerOrgAccess: 'all',
           accessibleOrgIds: [ORG_ID],
           canAccessOrg: (orgId: string) => orgId === ORG_ID
         });

--- a/apps/api/src/routes/partnerServicePrincipals.partnerWide.test.ts
+++ b/apps/api/src/routes/partnerServicePrincipals.partnerWide.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const {
+  authRef,
+  selectRowsRef,
+  dbSelectMock,
+  dbInsertMock,
+  dbUpdateMock,
+  dbTransactionMock,
+  issueKeyMock,
+  rotateKeyMock,
+} = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'partner' as const,
+      partnerId: 'p-1' as string | null,
+      partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null | undefined,
+      user: { id: 'u-1', email: 'admin@example.com' },
+    },
+  },
+  selectRowsRef: { current: [] as unknown[][] },
+  dbSelectMock: vi.fn(),
+  dbInsertMock: vi.fn(),
+  dbUpdateMock: vi.fn(),
+  dbTransactionMock: vi.fn(),
+  issueKeyMock: vi.fn(),
+  rotateKeyMock: vi.fn(),
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (c: any, next: any) => {
+    c.set('auth', authRef.current);
+    await next();
+  }),
+  requireScope: () => async (_c: any, next: any) => next(),
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: dbSelectMock,
+    insert: dbInsertMock,
+    update: dbUpdateMock,
+    transaction: dbTransactionMock,
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  partnerServicePrincipals: {
+    id: 'id', partnerId: 'partnerId', name: 'name', description: 'description',
+    status: 'status', scopes: 'scopes', expiresAt: 'expiresAt', sourceCidrs: 'sourceCidrs',
+    createdBy: 'createdBy', updatedBy: 'updatedBy', createdAt: 'createdAt', updatedAt: 'updatedAt',
+  },
+  partnerServicePrincipalKeys: {
+    id: 'id', partnerId: 'partnerId', partnerServicePrincipalId: 'partnerServicePrincipalId',
+    name: 'name', keyPrefix: 'keyPrefix', status: 'status', expiresAt: 'expiresAt',
+    rateLimit: 'rateLimit', lastUsedAt: 'lastUsedAt', revokedAt: 'revokedAt',
+    rotatedFromId: 'rotatedFromId', createdAt: 'createdAt',
+  },
+}));
+
+vi.mock('../services/partnerServicePrincipalKeys', () => ({
+  issuePartnerServicePrincipalKey: issueKeyMock,
+  rotatePartnerServicePrincipalKey: rotateKeyMock,
+  PartnerServicePrincipalKeyError: class PartnerServicePrincipalKeyError extends Error {
+    code: string;
+    status: number;
+    constructor(code: string, message: string, status = 400) {
+      super(message);
+      this.code = code;
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: {
+    ORGS_READ: { resource: 'organizations', action: 'read' },
+    ORGS_WRITE: { resource: 'organizations', action: 'write' },
+  },
+}));
+
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
+import { partnerServicePrincipalRoutes } from './partnerServicePrincipals';
+
+const PRINCIPAL_ID = '22222222-2222-4222-8222-222222222222';
+const KEY_ID = '33333333-3333-4333-8333-333333333333';
+const SUCCESSOR_KEY_ID = '44444444-4444-4444-8444-444444444444';
+
+function setPartnerOrgAccess(value: 'all' | 'selected' | 'none' | undefined) {
+  authRef.current = {
+    scope: 'partner',
+    partnerId: 'p-1',
+    partnerOrgAccess: value,
+    user: { id: 'u-1', email: 'admin@example.com' },
+  };
+}
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/partner-service-principals', partnerServicePrincipalRoutes);
+  return app;
+}
+
+function queueSelectRows(...rows: unknown[][]) {
+  selectRowsRef.current.push(...rows);
+}
+
+function requestCreate(app: Hono) {
+  return app.request('/partner-service-principals', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Automation', scopes: ['devices:read'], sourceCidrs: [] }),
+  });
+}
+
+function requestPatch(app: Hono) {
+  return app.request(`/partner-service-principals/${PRINCIPAL_ID}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: 'disabled' }),
+  });
+}
+
+function requestIssue(app: Hono) {
+  return app.request(`/partner-service-principals/${PRINCIPAL_ID}/keys`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Production' }),
+  });
+}
+
+function requestRotate(app: Hono) {
+  return app.request(`/partner-service-principals/${PRINCIPAL_ID}/keys/${KEY_ID}/rotate`, {
+    method: 'POST',
+  });
+}
+
+function requestRevoke(app: Hono) {
+  return app.request(`/partner-service-principals/${PRINCIPAL_ID}/keys/${KEY_ID}`, {
+    method: 'DELETE',
+  });
+}
+
+describe('partner service principal partner-wide capability gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectRowsRef.current = [];
+    setPartnerOrgAccess('all');
+
+    dbSelectMock.mockImplementation(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => selectRowsRef.current.shift() ?? []),
+          orderBy: vi.fn(async () => selectRowsRef.current.shift() ?? []),
+        })),
+      })),
+    }));
+    dbUpdateMock.mockImplementation(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(async () => [{ id: PRINCIPAL_ID, name: 'Automation', status: 'disabled' }]),
+        })),
+      })),
+    }));
+    dbTransactionMock.mockImplementation(async (callback: any) => callback({ update: dbUpdateMock }));
+    issueKeyMock.mockResolvedValue({ keyId: KEY_ID, rawKey: 'brz_sp_secret', keyPrefix: 'brz_sp_sec' });
+    rotateKeyMock.mockResolvedValue({
+      keyId: SUCCESSOR_KEY_ID,
+      rawKey: 'brz_sp_successor',
+      keyPrefix: 'brz_sp_suc',
+    });
+  });
+
+  const deniedMutations = [
+    ['POST /', requestCreate],
+    ['PATCH /:id', requestPatch],
+    ['POST /:id/keys', requestIssue],
+    ['POST /:id/keys/:keyId/rotate', requestRotate],
+    ['DELETE /:id/keys/:keyId', requestRevoke],
+  ] as const;
+
+  it.each(deniedMutations)('%s returns the partner-wide 403 for selected access', async (_name, request) => {
+    setPartnerOrgAccess('selected');
+
+    const res = await request(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+  });
+
+  it.each(['none', undefined] as const)('POST / returns 403 when partnerOrgAccess is %s', async (access) => {
+    setPartnerOrgAccess(access);
+
+    const res = await requestCreate(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    expect(dbInsertMock).not.toHaveBeenCalled();
+  });
+
+  it('POST / succeeds with all access and inserts the principal', async () => {
+    queueSelectRows([]);
+    dbInsertMock.mockReturnValue({
+      values: vi.fn(() => ({
+        onConflictDoNothing: vi.fn(() => ({
+          returning: vi.fn(async () => [{ id: PRINCIPAL_ID, name: 'Automation', scopes: ['devices:read'] }]),
+        })),
+      })),
+    });
+
+    const res = await requestCreate(makeApp());
+
+    expect(res.status).toBe(201);
+    expect((await res.json()).data.id).toBe(PRINCIPAL_ID);
+    expect(dbInsertMock).toHaveBeenCalledOnce();
+  });
+
+  it('PATCH /:id succeeds with all access and updates the principal', async () => {
+    const res = await requestPatch(makeApp());
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.status).toBe('disabled');
+    expect(dbUpdateMock).toHaveBeenCalledOnce();
+  });
+
+  it('POST /:id/keys succeeds with all access and issues a key', async () => {
+    const res = await requestIssue(makeApp());
+
+    expect(res.status).toBe(201);
+    expect((await res.json()).keyId).toBe(KEY_ID);
+    expect(issueKeyMock).toHaveBeenCalledOnce();
+  });
+
+  it('POST /:id/keys/:keyId/rotate succeeds with all access and rotates the key', async () => {
+    const res = await requestRotate(makeApp());
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).keyId).toBe(SUCCESSOR_KEY_ID);
+    expect(rotateKeyMock).toHaveBeenCalledOnce();
+  });
+
+  it('DELETE /:id/keys/:keyId succeeds with all access and revokes the key', async () => {
+    queueSelectRows([{ id: KEY_ID, name: 'Production', status: 'active', keyPrefix: 'brz_sp_sec' }]);
+
+    const res = await requestRevoke(makeApp());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, alreadyRevoked: false });
+    expect(dbUpdateMock).toHaveBeenCalledOnce();
+  });
+
+  it('GET / remains readable with selected access', async () => {
+    setPartnerOrgAccess('selected');
+    queueSelectRows([], []);
+
+    const res = await makeApp().request('/partner-service-principals');
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [] });
+    expect(dbSelectMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/routes/partnerServicePrincipals.test.ts
+++ b/apps/api/src/routes/partnerServicePrincipals.test.ts
@@ -76,7 +76,11 @@ const USER_ID = '44444444-4444-4444-8444-444444444444';
 function auth(partnerId: string | null = PARTNER_ID, scope = 'partner') {
   mocks.authMiddleware.mockImplementation((c: any, next: any) => {
     mocks.gateOrder.push('auth');
-    c.set('auth', { scope, partnerId, user: { id: USER_ID, email: 'admin@example.com' }, token: { mfa: true } });
+    // partnerOrgAccess: 'all' — these routes mint partner-wide machine
+    // credentials, so every mutation now requires the full-partner capability
+    // (security review 2026-08-16 §1.1 #6). The denial cases live in
+    // partnerServicePrincipals.partnerWide.test.ts.
+    c.set('auth', { scope, partnerId, partnerOrgAccess: 'all', user: { id: USER_ID, email: 'admin@example.com' }, token: { mfa: true } });
     c.set('permissions', { permissions: [{ resource: '*', action: '*' }] });
     return next();
   });

--- a/apps/api/src/routes/partnerServicePrincipals.ts
+++ b/apps/api/src/routes/partnerServicePrincipals.ts
@@ -9,6 +9,10 @@ import { writeRouteAudit } from '../services/auditEvents';
 import { isValidIpOrCidr } from '../services/ipMatch';
 import { PERMISSIONS } from '../services/permissions';
 import {
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+  canManagePartnerWidePolicies,
+} from '../services/partnerWideAccess';
+import {
   PartnerServicePrincipalKeyError,
   issuePartnerServicePrincipalKey,
   rotatePartnerServicePrincipalKey,
@@ -54,8 +58,34 @@ const issueKeySchema = z.object({
 type ManagementAuth = {
   scope: 'partner' | 'system' | 'organization';
   partnerId?: string | null;
+  partnerOrgAccess?: 'all' | 'selected' | 'none' | null;
   user: { id: string; email?: string };
 };
+
+/**
+ * A partner service principal is partner-wide BY CONSTRUCTION: the API key it
+ * issues carries partner-axis access to every org under the MSP, including
+ * orgs created later. Minting, re-scoping, or re-keying one is therefore
+ * partner-wide administration and requires the capability, not merely partner
+ * scope (epic #2135; security review 2026-08-16 §1.1 #6 — the severe one).
+ *
+ * Before this gate the only checks were `requireScope('partner','system')` +
+ * `organizations:write` + MFA — so an `orgAccess: selected` user could mint a
+ * DURABLE credential with effectively `all` access: an escalation that
+ * outlives the session and never shows up as a role change.
+ *
+ * Applied to every MUTATION route in this file (create principal, update
+ * principal, issue key, rotate key, revoke key). Deliberately NOT applied to
+ * the list route — reading the inventory is not administering it, and
+ * `resolvePartnerId` already bounds it to the caller's own partner.
+ *
+ * Returns a 403 response for the caller to return, or null to proceed.
+ */
+function partnerWideAdminDenial(c: any): { response: Response } | null {
+  const auth = c.get('auth') as ManagementAuth;
+  if (canManagePartnerWidePolicies(auth)) return null;
+  return { response: c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403) };
+}
 
 function resolvePartnerId(
   c: any,
@@ -191,6 +221,8 @@ partnerServicePrincipalRoutes.post(
     const input = c.req.valid('json');
     const resolved = resolvePartnerId(c, input.partnerId);
     if ('response' in resolved) return resolved.response;
+    const createDenial = partnerWideAdminDenial(c);
+    if (createDenial) return createDenial.response;
     const validated = validatePrincipalFields(c, input);
     if ('response' in validated) return validated.response;
 
@@ -247,6 +279,8 @@ partnerServicePrincipalRoutes.patch(
     const input = c.req.valid('json');
     const resolved = resolvePartnerId(c, input.partnerId);
     if ('response' in resolved) return resolved.response;
+    const updateDenial = partnerWideAdminDenial(c);
+    if (updateDenial) return updateDenial.response;
     const changed = Object.keys(input).filter((key) => key !== 'partnerId');
     if (changed.length === 0) return c.json({ error: 'No updates provided' }, 400);
     const validated = validatePrincipalFields(c, input);
@@ -310,6 +344,8 @@ partnerServicePrincipalRoutes.post(
     const input = c.req.valid('json');
     const resolved = resolvePartnerId(c, input.partnerId);
     if ('response' in resolved) return resolved.response;
+    const issueDenial = partnerWideAdminDenial(c);
+    if (issueDenial) return issueDenial.response;
     const expiresAt = input.expiresAt ? new Date(input.expiresAt) : null;
     if (expiresAt && expiresAt.getTime() <= Date.now()) return c.json({ error: 'Expiry must be in the future' }, 400);
     try {
@@ -341,6 +377,8 @@ partnerServicePrincipalRoutes.post(
     const { id, keyId } = c.req.valid('param');
     const resolved = resolvePartnerId(c, c.req.valid('query').partnerId);
     if ('response' in resolved) return resolved.response;
+    const rotateDenial = partnerWideAdminDenial(c);
+    if (rotateDenial) return rotateDenial.response;
     try {
       const rotated = await db.transaction((tx) => rotatePartnerServicePrincipalKey(tx as unknown as Database, {
         partnerServicePrincipalId: id, keyId, partnerId: resolved.partnerId, actorId: auth.user.id,
@@ -368,6 +406,8 @@ partnerServicePrincipalRoutes.delete(
     const { id, keyId } = c.req.valid('param');
     const resolved = resolvePartnerId(c, c.req.valid('query').partnerId);
     if ('response' in resolved) return resolved.response;
+    const revokeDenial = partnerWideAdminDenial(c);
+    if (revokeDenial) return revokeDenial.response;
     const [existing] = await db.select({
       id: partnerServicePrincipalKeys.id, name: partnerServicePrincipalKeys.name,
       status: partnerServicePrincipalKeys.status, keyPrefix: partnerServicePrincipalKeys.keyPrefix,

--- a/apps/api/src/routes/updateRings.partnerWide.test.ts
+++ b/apps/api/src/routes/updateRings.partnerWide.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const { authRef, selectResult, insertResult, updateResult, dbInsertMock, dbUpdateMock } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'partner' as const,
+      partnerId: 'p-1' as string | null,
+      partnerOrgAccess: 'all' as 'all' | 'selected' | 'none' | null | undefined,
+      orgId: null as string | null,
+      accessibleOrgIds: [] as string[],
+      canAccessOrg: (_orgId: string) => false,
+      user: { id: 'u-1', email: 'admin@example.com' },
+    },
+  },
+  selectResult: vi.fn(),
+  insertResult: vi.fn(),
+  updateResult: vi.fn(),
+  dbInsertMock: vi.fn(),
+  dbUpdateMock: vi.fn(),
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (c: any, next: any) => {
+    c.set('auth', authRef.current);
+    await next();
+  }),
+  requireScope: () => async (_c: any, next: any) => next(),
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn(() => selectResult()) })),
+      })),
+    })),
+    insert: dbInsertMock,
+    update: dbUpdateMock,
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  patchPolicies: {
+    id: 'id', partnerId: 'partnerId', name: 'name', description: 'description', enabled: 'enabled',
+    ringOrder: 'ringOrder', deferralDays: 'deferralDays', deadlineDays: 'deadlineDays',
+    gracePeriodHours: 'gracePeriodHours', categories: 'categories', excludeCategories: 'excludeCategories',
+    autoApprove: 'autoApprove', categoryRules: 'categoryRules', targets: 'targets',
+    createdAt: 'createdAt', updatedAt: 'updatedAt', createdBy: 'createdBy', kind: 'kind',
+  },
+  patchApprovals: { partnerId: 'partnerId', ringId: 'ringId', status: 'status' },
+  patchJobs: { id: 'id', ringId: 'ringId', name: 'name', status: 'status', createdAt: 'createdAt' },
+  patches: {},
+  devicePatches: {},
+}));
+
+vi.mock('./updateRingsHelpers', () => ({
+  resolveRingDeviceCounts: vi.fn().mockResolvedValue(new Map()),
+  resolveRingDeviceIds: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: {
+    DEVICES_READ: { resource: 'devices', action: 'read' },
+    DEVICES_WRITE: { resource: 'devices', action: 'write' },
+  },
+}));
+
+import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
+import { updateRingRoutes } from './updateRings';
+
+const RING_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function setPartnerOrgAccess(partnerOrgAccess: 'all' | 'selected') {
+  authRef.current = {
+    scope: 'partner',
+    partnerId: 'p-1',
+    partnerOrgAccess,
+    orgId: null,
+    accessibleOrgIds: [],
+    canAccessOrg: () => false,
+    user: { id: 'u-1', email: 'admin@example.com' },
+  };
+}
+
+function makeRing(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RING_ID,
+    partnerId: 'p-1',
+    name: 'Pilot Ring',
+    description: null,
+    enabled: true,
+    ringOrder: 1,
+    deferralDays: 7,
+    deadlineDays: null,
+    gracePeriodHours: 4,
+    categories: [],
+    excludeCategories: [],
+    autoApprove: {},
+    categoryRules: [],
+    targets: {},
+    ...overrides,
+  };
+}
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/update-rings', updateRingRoutes);
+  return app;
+}
+
+function createRequest(app: Hono) {
+  return app.request('/update-rings', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Pilot Ring', deferralDays: 7 }),
+  });
+}
+
+function patchRequest(app: Hono) {
+  return app.request(`/update-rings/${RING_ID}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Updated Ring' }),
+  });
+}
+
+function deleteRequest(app: Hono) {
+  return app.request(`/update-rings/${RING_ID}`, { method: 'DELETE' });
+}
+
+describe('update rings partner-wide capability gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPartnerOrgAccess('all');
+    selectResult.mockResolvedValue([makeRing()]);
+    insertResult.mockResolvedValue([makeRing()]);
+    updateResult.mockResolvedValue([makeRing({ name: 'Updated Ring' })]);
+    dbInsertMock.mockImplementation(() => ({
+      values: vi.fn(() => ({ returning: vi.fn(() => insertResult()) })),
+    }));
+    dbUpdateMock.mockImplementation(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => {
+          const result = {
+            returning: vi.fn(() => updateResult()),
+            then: (resolve: (value: undefined) => unknown) => Promise.resolve(undefined).then(resolve),
+          };
+          return result;
+        }),
+      })),
+    }));
+  });
+
+  it('POST / returns 403 for selected partner access', async () => {
+    setPartnerOrgAccess('selected');
+
+    const res = await createRequest(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    expect(dbInsertMock).not.toHaveBeenCalled();
+  });
+
+  it('POST / succeeds for all partner access', async () => {
+    const res = await createRequest(makeApp());
+
+    expect(res.status).toBe(201);
+    expect((await res.json()).id).toBe(RING_ID);
+    expect(dbInsertMock).toHaveBeenCalledOnce();
+  });
+
+  it('PATCH /:id returns 403 for selected partner access', async () => {
+    setPartnerOrgAccess('selected');
+
+    const res = await patchRequest(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    expect(dbUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /:id succeeds for all partner access', async () => {
+    const res = await patchRequest(makeApp());
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).name).toBe('Updated Ring');
+    expect(dbUpdateMock).toHaveBeenCalledOnce();
+  });
+
+  it('DELETE /:id returns 403 for selected partner access', async () => {
+    setPartnerOrgAccess('selected');
+
+    const res = await deleteRequest(makeApp());
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    expect(dbUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /:id succeeds for all partner access', async () => {
+    const res = await deleteRequest(makeApp());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(dbUpdateMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/routes/updateRings.ts
+++ b/apps/api/src/routes/updateRings.ts
@@ -15,6 +15,10 @@ import { getPagination, inferPatchOs } from './patches/helpers';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS } from '../services/permissions';
+import {
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+  canManagePartnerWidePolicies,
+} from '../services/partnerWideAccess';
 import { ringAutoApproveSchema, mergeRingAutoApproveWrite } from '@breeze/shared/validators';
 
 // Typed default for a ring's autoApprove JSONB (#1317). A freshly created or
@@ -37,6 +41,21 @@ updateRingRoutes.use('*', authMiddleware);
 // default 50, capped at MAX_PAGE_LIMIT (200). Previously a local copy here
 // capped at 100 and the web's ring path sent no `limit`, so selecting a ring
 // silently collapsed the visible patch list from the all-rings 200 down to 50.
+
+/**
+ * Update rings are partner-owned by construction — a ring drives patch
+ * deferral/approval for every org under the partner. Writing one is therefore
+ * partner-wide administration and needs the capability, not merely partner
+ * scope (epic #2135; security review 2026-08-16 §1.1 #3). Returns a 403 body
+ * for the caller to return, or null when the write may proceed.
+ */
+function partnerWideRingWriteDenial(
+  c: any,
+  auth: { scope: 'system' | 'partner' | 'organization'; partnerOrgAccess?: 'all' | 'selected' | 'none' | null },
+): { response: Response } | null {
+  if (canManagePartnerWidePolicies(auth)) return null;
+  return { response: c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403) };
+}
 
 function resolvePartnerId(
   auth: { scope: 'system' | 'partner' | 'organization'; partnerId: string | null },
@@ -217,6 +236,9 @@ updateRingRoutes.post(
     if ('error' in partnerResult) return c.json({ error: partnerResult.error }, partnerResult.status);
     const { partnerId } = partnerResult;
 
+    const createDenial = partnerWideRingWriteDenial(c, auth);
+    if (createDenial) return createDenial.response;
+
     const [ring] = await db
       .insert(patchPolicies)
       .values({
@@ -341,6 +363,9 @@ updateRingRoutes.patch(
       return c.json({ error: 'Access denied' }, 403);
     }
 
+    const patchDenial = partnerWideRingWriteDenial(c, auth);
+    if (patchDenial) return patchDenial.response;
+
     const updateFields: Record<string, unknown> = { updatedAt: new Date() };
     if (data.name !== undefined) updateFields.name = data.name;
     if (data.description !== undefined) updateFields.description = data.description;
@@ -398,6 +423,9 @@ updateRingRoutes.delete(
     if (auth.scope !== 'system' && auth.partnerId !== existing.partnerId) {
       return c.json({ error: 'Access denied' }, 403);
     }
+
+    const deleteDenial = partnerWideRingWriteDenial(c, auth);
+    if (deleteDenial) return deleteDenial.response;
 
     await db
       .update(patchPolicies)

--- a/apps/api/src/routes/updateRings_detail_update_delete.test.ts
+++ b/apps/api/src/routes/updateRings_detail_update_delete.test.ts
@@ -99,6 +99,7 @@ vi.mock('../middleware/auth', () => ({
       scope: 'partner',
       orgId: null,
       partnerId: PARTNER_ID,
+      partnerOrgAccess: 'all',
       accessibleOrgIds: [],
       canAccessOrg: () => false
     });
@@ -147,6 +148,7 @@ describe('updateRings routes', () => {
         scope: 'partner',
         orgId: null,
         partnerId: PARTNER_ID,
+        partnerOrgAccess: 'all',
         accessibleOrgIds: [],
         canAccessOrg: () => false
       });

--- a/apps/api/src/routes/updateRings_list_create.test.ts
+++ b/apps/api/src/routes/updateRings_list_create.test.ts
@@ -100,6 +100,7 @@ vi.mock('../middleware/auth', () => ({
       scope: 'partner',
       orgId: null,
       partnerId: PARTNER_ID,
+      partnerOrgAccess: 'all',
       accessibleOrgIds: [],
       canAccessOrg: () => false
     });
@@ -148,6 +149,7 @@ describe('updateRings routes', () => {
         scope: 'partner',
         orgId: null,
         partnerId: PARTNER_ID,
+        partnerOrgAccess: 'all',
         accessibleOrgIds: [],
         canAccessOrg: () => false
       });

--- a/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
@@ -56,6 +56,7 @@ function makeAuth() {
     user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
     scope: 'partner',
     partnerId: PARTNER_ID,
+    partnerOrgAccess: 'all',
     orgId: null,
     accessibleOrgIds: [],
     canAccessOrg: () => false,

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -252,6 +252,11 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
 
       if (action === 'create') {
         if (!partnerId) return JSON.stringify({ error: 'Partner context required' });
+        // Rings are partner-owned by construction — they govern patching for
+        // every org under the partner (security review 2026-08-16 §1.1 #3).
+        if (!canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Update rings are partner-wide and require full partner org access (orgAccess must be "all")' });
+        }
         if (!input.name) return JSON.stringify({ error: 'name is required' });
 
         // Fail-closed autoApprove (#1317): reject enabled-without-severity at the
@@ -296,6 +301,9 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
 
         const [existing] = await db.select().from(patchPolicies).where(and(...conditions)).limit(1);
         if (!existing) return JSON.stringify({ error: 'Update ring not found or access denied' });
+        if (!canManagePartnerWidePolicies(auth)) {
+          return JSON.stringify({ error: 'Modifying an update ring requires full partner org access (orgAccess must be "all")' });
+        }
 
         const updates: Record<string, unknown> = { updatedAt: new Date() };
         if (typeof input.name === 'string') updates.name = input.name;

--- a/apps/api/src/services/aiToolsPolicyPrereqs.updateRings.test.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.updateRings.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { insertMock, updateMock, selectMock } = vi.hoisted(() => ({
+  insertMock: vi.fn(),
+  updateMock: vi.fn(),
+  selectMock: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: { insert: insertMock, update: updateMock, select: selectMock },
+}));
+
+vi.mock('../db/schema/patches', () => ({
+  patchPolicies: {
+    id: 'patchPolicies.id',
+    partnerId: 'patchPolicies.partnerId',
+    kind: 'patchPolicies.kind',
+    name: 'patchPolicies.name',
+    enabled: 'patchPolicies.enabled',
+    autoApprove: 'patchPolicies.autoApprove',
+    ringOrder: 'patchPolicies.ringOrder',
+    createdAt: 'patchPolicies.createdAt',
+    description: 'patchPolicies.description',
+    deferralDays: 'patchPolicies.deferralDays',
+    deadlineDays: 'patchPolicies.deadlineDays',
+    gracePeriodHours: 'patchPolicies.gracePeriodHours',
+    categories: 'patchPolicies.categories',
+    excludeCategories: 'patchPolicies.excludeCategories',
+  },
+}));
+vi.mock('../db/schema/softwarePolicies', () => ({ softwarePolicies: {} }));
+vi.mock('../db/schema/peripheralControl', () => ({ peripheralPolicies: {} }));
+vi.mock('../db/schema/backup', () => ({ backupConfigs: {}, backupProfiles: {} }));
+vi.mock('../db/schema/configurationPolicies', () => ({ configPolicyBackupSettings: {} }));
+vi.mock('./aiToolsSoftwarePolicyAudit', () => ({
+  auditSoftwarePolicyToolEvent: vi.fn(),
+  summarizeEnforcementChange: vi.fn(() => ({})),
+}));
+
+import { registerPolicyPrereqTools } from './aiToolsPolicyPrereqs';
+
+const PARTNER_ID = '00000000-0000-0000-0000-000000000001';
+const RING_ID = '22222222-2222-2222-2222-222222222222';
+
+function makeAuth(partnerOrgAccess: 'all' | 'selected') {
+  return {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    scope: 'partner',
+    partnerId: PARTNER_ID,
+    partnerOrgAccess,
+    orgId: null,
+    accessibleOrgIds: [],
+    canAccessOrg: () => false,
+    orgCondition: () => undefined,
+  } as any;
+}
+
+function getUpdateRingsTool() {
+  const tools = new Map<string, any>();
+  registerPolicyPrereqTools(tools);
+  const tool = tools.get('manage_update_rings');
+  if (!tool) throw new Error('manage_update_rings tool not registered');
+  return tool;
+}
+
+function mockExistingRing() {
+  selectMock.mockReturnValue({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn(async () => [{ id: RING_ID, partnerId: PARTNER_ID, name: 'Pilot', kind: 'ring' }]),
+      })),
+    })),
+  });
+}
+
+describe('manage_update_rings partner-wide capability gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('create returns a JSON error requiring full partner org access for selected access', async () => {
+    const output = await getUpdateRingsTool().handler(
+      { action: 'create', name: 'Pilot' },
+      makeAuth('selected'),
+    );
+
+    expect(typeof output).toBe('string');
+    expect(JSON.parse(output).error).toMatch(/full partner org access/i);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('create proceeds for all access', async () => {
+    insertMock.mockReturnValue({
+      values: vi.fn(() => ({
+        returning: vi.fn(async () => [{ id: RING_ID, name: 'Pilot' }]),
+      })),
+    });
+
+    const output = await getUpdateRingsTool().handler(
+      { action: 'create', name: 'Pilot' },
+      makeAuth('all'),
+    );
+
+    expect(JSON.parse(output)).toMatchObject({ success: true, ringId: RING_ID });
+    expect(insertMock).toHaveBeenCalledOnce();
+  });
+
+  it('update returns a JSON error requiring full partner org access for selected access', async () => {
+    mockExistingRing();
+
+    const output = await getUpdateRingsTool().handler(
+      { action: 'update', ringId: RING_ID, name: 'Production' },
+      makeAuth('selected'),
+    );
+
+    expect(typeof output).toBe('string');
+    expect(JSON.parse(output).error).toMatch(/full partner org access/i);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('update proceeds for all access', async () => {
+    mockExistingRing();
+    updateMock.mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    });
+
+    const output = await getUpdateRingsTool().handler(
+      { action: 'update', ringId: RING_ID, name: 'Production' },
+      makeAuth('all'),
+    );
+
+    expect(JSON.parse(output).success).toBe(true);
+    expect(updateMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/services/apiKeyScopes.ts
+++ b/apps/api/src/services/apiKeyScopes.ts
@@ -70,6 +70,23 @@ export function validateSupportedApiKeyScopes(requestedScopes: string[]): ApiKey
   return { ok: true, scopes: scopes as ApiKeyScope[] };
 }
 
+/**
+ * The permission set a key carrying `scopes` effectively confers, de-duplicated.
+ * Unknown scopes contribute nothing here — validation of the scope NAMES is
+ * `validateSupportedApiKeyScopes`'s job; this answers "what authority does this
+ * key hand out?" for the delegation-ceiling check on rotation.
+ */
+export function requiredPermissionsForApiKeyScopes(scopes: readonly string[]): Permission[] {
+  const byKey = new Map<string, Permission>();
+  for (const scope of scopes) {
+    const required = API_KEY_SCOPE_POLICIES[scope as ApiKeyScope] as readonly Permission[] | undefined;
+    for (const permission of required ?? []) {
+      byKey.set(`${permission.resource}:${permission.action}`, permission);
+    }
+  }
+  return Array.from(byKey.values());
+}
+
 export function validateApiKeyScopeDelegation(
   requestedScopes: string[],
   creatorPermissions: UserPermissions | undefined,

--- a/apps/api/src/services/delegationCeiling.test.ts
+++ b/apps/api/src/services/delegationCeiling.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DELEGATION_CEILING_DENIED_MESSAGE,
+  checkDelegationCeiling,
+  scopeCoversScope,
+  siteAllowlistCovers,
+} from './delegationCeiling';
+
+const ORGS_WRITE = { resource: 'organizations', action: 'write' };
+const SCRIPTS_EXECUTE = { resource: 'scripts', action: 'execute' };
+
+/** Caller holds exactly the listed permissions and nothing else. */
+function holder(...held: { resource: string; action: string }[]) {
+  const keys = new Set(held.map((p) => `${p.resource}:${p.action}`));
+  return (p: { resource: string; action: string }) => keys.has(`${p.resource}:${p.action}`);
+}
+
+describe('scopeCoversScope', () => {
+  it('ranks organization < partner < system', () => {
+    expect(scopeCoversScope('system', 'partner')).toBe(true);
+    expect(scopeCoversScope('system', 'system')).toBe(true);
+    expect(scopeCoversScope('partner', 'organization')).toBe(true);
+    expect(scopeCoversScope('partner', 'partner')).toBe(true);
+    expect(scopeCoversScope('organization', 'organization')).toBe(true);
+  });
+
+  it('denies upward delegation', () => {
+    expect(scopeCoversScope('organization', 'partner')).toBe(false);
+    expect(scopeCoversScope('organization', 'system')).toBe(false);
+    expect(scopeCoversScope('partner', 'system')).toBe(false);
+  });
+});
+
+describe('siteAllowlistCovers', () => {
+  it('treats undefined/null as unrestricted on the caller side', () => {
+    expect(siteAllowlistCovers(undefined, ['s-1'])).toBe(true);
+    expect(siteAllowlistCovers(null, undefined)).toBe(true);
+  });
+
+  it('denies a site-restricted caller an unrestricted credential', () => {
+    // The whole point: RLS does not defend the site axis, so an unrestricted
+    // credential in the hands of a site-restricted tech is a real widening.
+    expect(siteAllowlistCovers(['s-1'], undefined)).toBe(false);
+    expect(siteAllowlistCovers(['s-1'], null)).toBe(false);
+  });
+
+  it('requires a subset when both sides are restricted', () => {
+    expect(siteAllowlistCovers(['s-1', 's-2'], ['s-1'])).toBe(true);
+    expect(siteAllowlistCovers(['s-1', 's-2'], ['s-1', 's-2'])).toBe(true);
+    expect(siteAllowlistCovers(['s-1'], ['s-1', 's-2'])).toBe(false);
+    expect(siteAllowlistCovers(['s-1'], ['s-9'])).toBe(false);
+  });
+
+  it('an empty caller allowlist is restricted-to-nothing, not unrestricted', () => {
+    expect(siteAllowlistCovers([], ['s-1'])).toBe(false);
+    expect(siteAllowlistCovers([], [])).toBe(true);
+  });
+});
+
+describe('checkDelegationCeiling', () => {
+  it('allows a caller whose authority is a superset on every axis', () => {
+    const result = checkDelegationCeiling({
+      caller: { scope: 'partner', allowedSiteIds: undefined },
+      credential: { scope: 'organization', permissions: [ORGS_WRITE], allowedSiteIds: ['s-1'] },
+      holdsPermission: holder(ORGS_WRITE),
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('denies on the SCOPE axis — an org caller may not wield a partner credential', () => {
+    const result = checkDelegationCeiling({
+      caller: { scope: 'organization' },
+      credential: { scope: 'partner', permissions: [], allowedSiteIds: undefined },
+      holdsPermission: holder(),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.violation).toBe('scope');
+    expect(result.error).toBe(DELEGATION_CEILING_DENIED_MESSAGE);
+  });
+
+  it('denies on the PERMISSION axis — the exact §1.4 escalation', () => {
+    // Caller holds organizations:write (enough to reach the rotate route) but
+    // not scripts:execute, which the credential confers.
+    const result = checkDelegationCeiling({
+      caller: { scope: 'organization' },
+      credential: {
+        scope: 'organization',
+        permissions: [ORGS_WRITE, SCRIPTS_EXECUTE],
+        allowedSiteIds: undefined,
+      },
+      holdsPermission: holder(ORGS_WRITE),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.violation).toBe('permission');
+    expect(result.details).toMatchObject({ missingPermission: 'scripts:execute' });
+  });
+
+  it('denies on the SITE axis even when scope and permissions are fine', () => {
+    const result = checkDelegationCeiling({
+      caller: { scope: 'organization', allowedSiteIds: ['s-1'] },
+      credential: { scope: 'organization', permissions: [ORGS_WRITE], allowedSiteIds: undefined },
+      holdsPermission: holder(ORGS_WRITE),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.violation).toBe('site');
+  });
+
+  it('reports the SCOPE violation first when several axes fail', () => {
+    const result = checkDelegationCeiling({
+      caller: { scope: 'organization', allowedSiteIds: ['s-1'] },
+      credential: { scope: 'system', permissions: [SCRIPTS_EXECUTE], allowedSiteIds: undefined },
+      holdsPermission: holder(),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.violation).toBe('scope');
+  });
+
+  it('a credential with no permissions still has to clear scope and site', () => {
+    // Guards against the check collapsing to "permissions only".
+    expect(
+      checkDelegationCeiling({
+        caller: { scope: 'organization', allowedSiteIds: ['s-1'] },
+        credential: { scope: 'organization', allowedSiteIds: undefined },
+        holdsPermission: holder(),
+      }).ok
+    ).toBe(false);
+  });
+
+  it('actually consults holdsPermission (non-vacuous)', () => {
+    const seen: string[] = [];
+    const result = checkDelegationCeiling({
+      caller: { scope: 'system' },
+      credential: { scope: 'system', permissions: [ORGS_WRITE, SCRIPTS_EXECUTE] },
+      holdsPermission: (p) => {
+        seen.push(`${p.resource}:${p.action}`);
+        return true;
+      },
+    });
+    expect(result).toEqual({ ok: true });
+    expect(seen).toEqual(['organizations:write', 'scripts:execute']);
+  });
+});

--- a/apps/api/src/services/delegationCeiling.ts
+++ b/apps/api/src/services/delegationCeiling.ts
@@ -1,0 +1,163 @@
+/**
+ * Delegation ceiling — a caller may never issue, rotate, or otherwise hand out
+ * a credential whose authority exceeds their own (security review 2026-08-16
+ * §1.4, same root principle as §1.1 #6).
+ *
+ * The concrete bug this closes: `POST /api-keys/:id/rotate` looked the key up
+ * by id alone and authorized only `ensureOrgAccess(key.orgId, auth)`. Rotation
+ * regenerates the secret but leaves scopes, the delegating `created_by`, and
+ * therefore the key's whole effective authority untouched — so any user in the
+ * org holding `organizations:write` + MFA could rotate a MORE privileged user's
+ * key and walk away with a working plaintext credential carrying that user's
+ * authority. Org access is not key access.
+ *
+ * Three axes have to hold, all of them, before plaintext is handed back:
+ *
+ *   1. SCOPE   — an `organization`-scope caller must not rotate a `partner`- or
+ *                `system`-scope credential. Ranked, not equality: a system
+ *                caller may rotate anything below it.
+ *   2. PERMISSION — every permission the credential carries must be held by the
+ *                caller RIGHT NOW. Supplied as a predicate so this module stays
+ *                a dependency-free leaf (see below).
+ *   3. SITE    — the credential's site allowlist must not be broader than the
+ *                caller's. `undefined` means UNRESTRICTED on both sides, so a
+ *                site-restricted caller may not touch an unrestricted
+ *                credential, while an unrestricted caller may touch anything.
+ *                RLS does not defend the site axis at all, so this one is
+ *                entirely on the app layer.
+ *
+ * The org axis is deliberately NOT handled here: routes already enforce it
+ * (`ensureOrgAccess` / `auth.canAccessOrg`) and it needs a DB read this module
+ * must not take.
+ *
+ * Like `partnerWideAccess.ts` this is a deliberately dependency-free leaf
+ * module (types only). The permission comparison is injected as a
+ * `holdsPermission` predicate rather than importing `services/permissions`,
+ * which pulls in the db + redis graph and would break every route test that
+ * mocks `../db`.
+ */
+
+/** A permission grant, structurally compatible with `PERMISSIONS.*`. */
+export interface DelegatedPermission {
+  resource: string;
+  action: string;
+}
+
+/**
+ * The authority held by a principal — either the caller doing the issuing, or
+ * the credential being issued/rotated.
+ *
+ * `allowedSiteIds: undefined` means UNRESTRICTED (mirrors
+ * `AuthContext.allowedSiteIds` / `UserPermissions.allowedSiteIds`); an empty
+ * array means restricted to no sites at all.
+ */
+export interface CredentialAuthority {
+  scope: 'system' | 'partner' | 'organization';
+  /**
+   * Permissions the credential confers. Only consulted for the credential
+   * side — the caller side is expressed through `holdsPermission`.
+   */
+  permissions?: readonly DelegatedPermission[];
+  allowedSiteIds?: string[] | null;
+}
+
+export type DelegationCeilingViolation = 'scope' | 'permission' | 'site';
+
+export type DelegationCeilingResult =
+  | { ok: true }
+  | { ok: false; violation: DelegationCeilingViolation; error: string; details?: Record<string, unknown> };
+
+export const DELEGATION_CEILING_DENIED_MESSAGE =
+  'You cannot issue or rotate a credential that carries more authority than you hold';
+
+/** Thrown by service-layer issuers. Routes map it to 403. */
+export class DelegationCeilingError extends Error {
+  readonly violation: DelegationCeilingViolation;
+
+  constructor(violation: DelegationCeilingViolation, message?: string) {
+    super(message ?? DELEGATION_CEILING_DENIED_MESSAGE);
+    this.name = 'DelegationCeilingError';
+    this.violation = violation;
+  }
+}
+
+const SCOPE_RANK: Record<CredentialAuthority['scope'], number> = {
+  organization: 0,
+  partner: 1,
+  system: 2,
+};
+
+/** True when `callerScope` is at least as broad as `credentialScope`. */
+export function scopeCoversScope(
+  callerScope: CredentialAuthority['scope'],
+  credentialScope: CredentialAuthority['scope'],
+): boolean {
+  return SCOPE_RANK[callerScope] >= SCOPE_RANK[credentialScope];
+}
+
+/**
+ * True when the credential's site allowlist is no broader than the caller's.
+ *
+ * `undefined`/`null` = unrestricted on either side:
+ *   caller unrestricted            -> always true
+ *   caller restricted, cred unrestricted -> FALSE (the credential is broader)
+ *   both restricted                -> credential set must be a subset
+ */
+export function siteAllowlistCovers(
+  callerSiteIds: string[] | null | undefined,
+  credentialSiteIds: string[] | null | undefined,
+): boolean {
+  if (callerSiteIds === undefined || callerSiteIds === null) return true;
+  if (credentialSiteIds === undefined || credentialSiteIds === null) return false;
+  const allowed = new Set(callerSiteIds);
+  return credentialSiteIds.every((siteId) => allowed.has(siteId));
+}
+
+/**
+ * Assert the caller's authority is a superset of the credential's on all three
+ * axes. Returns a structured result rather than throwing so routes can map it
+ * straight onto a 403 body.
+ *
+ * `holdsPermission` must answer "does the CALLER hold this permission right
+ * now?" — callers pass `(p) => hasPermission(callerPermissions, p.resource,
+ * p.action)`. It is required: a missing predicate would silently pass every
+ * permission and turn this whole check vacuous, so the type makes it mandatory.
+ */
+export function checkDelegationCeiling(input: {
+  caller: Pick<CredentialAuthority, 'scope' | 'allowedSiteIds'>;
+  credential: CredentialAuthority;
+  holdsPermission: (permission: DelegatedPermission) => boolean;
+}): DelegationCeilingResult {
+  const { caller, credential, holdsPermission } = input;
+
+  if (!scopeCoversScope(caller.scope, credential.scope)) {
+    return {
+      ok: false,
+      violation: 'scope',
+      error: DELEGATION_CEILING_DENIED_MESSAGE,
+      details: { callerScope: caller.scope, credentialScope: credential.scope },
+    };
+  }
+
+  for (const permission of credential.permissions ?? []) {
+    if (!holdsPermission(permission)) {
+      return {
+        ok: false,
+        violation: 'permission',
+        error: DELEGATION_CEILING_DENIED_MESSAGE,
+        details: { missingPermission: `${permission.resource}:${permission.action}` },
+      };
+    }
+  }
+
+  if (!siteAllowlistCovers(caller.allowedSiteIds, credential.allowedSiteIds)) {
+    return {
+      ok: false,
+      violation: 'site',
+      error: DELEGATION_CEILING_DENIED_MESSAGE,
+      details: { reason: 'credential is not restricted to the caller\'s sites' },
+    };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
Fixes §1.1 and §1.4 of the 2026-08-16 security review (`internal/2026-08-16-security-review-findings.md`). Both are the same root principle: **no delegation ceiling** — code hands out authority without ever comparing it against what the requester holds.

## §1.1 — six write sites gated on `scope`, never on the partner-wide *capability*

`services/partnerWideAccess.ts` is the canonical contract: only `scope === 'system'` or `scope === 'partner' && partnerOrgAccess === 'all'` may create or modify partner-wide state. 55 files call it correctly. These did not, so an `orgAccess: selected` partner user could administer state that lands in **every** org under the MSP, including orgs created later.

| Site | What was exposed | Gate added |
|---|---|---|
| `routes/customFields.ts:308` (create) + `:134` (`canEditField`) | partner-wide field definitions | create branch + update/delete via `canEditField` |
| `routes/authenticator.ts:501` | approval-assurance floor — the only guard was `if (!auth.partnerId)` | `PUT /policy` |
| `routes/updateRings.ts:216 / :340 / :397` | update rings (patch deferral + auto-approval for the whole partner) | create / update / delete |
| `services/aiToolsPolicyPrereqs.ts:254 / :298` | the same rings via the `manage_update_rings` AI tool | create + update actions |
| `routes/clientAi/adminTemplates.ts:116` | AI prompt templates | create + update + delete |
| `routes/alertTemplates/templates.ts:47` (`canWriteTemplate`) + `:199` (create) | alert templates | **write gate only** — `templateScopeCondition()` (the read predicate, §1.5) is deliberately untouched; a sibling branch owns it |
| `routes/partnerServicePrincipals.ts` — **the severe one** | partner-wide **machine credentials**: a durable key with partner-axis access to every org, an escalation that outlives the session and never shows up as a role change | all **five** mutation routes (create principal, update principal, issue key, rotate key, revoke key). `partnerOrgAccess` appeared nowhere in the file. The list route is deliberately left ungated — reading the inventory is not administering it |

Every gate is placed **after** the existing scope/permission/MFA checks and **before** any mutation.

## §1.4 — API-key rotation handed a broader key's plaintext to a lesser admin

`POST /api-keys/:id/rotate` looked the key up with `where(eq(apiKeys.id, keyId))` — **by id alone, no owner predicate** — and authorized only `ensureOrgAccess(existingKey.orgId, auth)`. Rotation regenerates the secret but leaves `scopes` and the delegating `created_by` untouched, so any org user with `organizations:write` + MFA could rotate a more-privileged user's key and walk away with a working credential carrying that user's authority. **Org access is not key access.**

New dependency-free leaf module **`services/delegationCeiling.ts`** (types only, same shape as `partnerWideAccess.ts`) asserts the caller's authority is a superset of the credential's on three axes:

1. **Scope** — ranked `organization < partner < system`. An org-scope caller may not rotate a partner- or system-scope credential.
2. **Permission** — every permission the key confers must be held by the caller *right now*. Injected as a `holdsPermission` predicate rather than importing `services/permissions`, so the module stays free of the db/redis graph and no route test mocking `../db` is disturbed. The predicate is a required parameter: making it optional would let the whole check collapse to a vacuous pass.
3. **Site** — the credential's `allowedSiteIds` must not be broader than the caller's. `undefined` = unrestricted on both sides, so a site-restricted caller cannot rotate an unrestricted key. RLS does not defend the site axis at all, so this one is entirely app-layer.

The org axis stays with the existing `ensureOrgAccess`. At the rotate path the key's *real* authority is resolved through the existing `authorizeHumanApiKeyCreator` (creator's live permissions + site allowlist), and the check **fails closed** when that creator can no longer be authorized — such a key is already dead on the request path and should be revoked, not rotated. Service-principal keys skip creator resolution but still face the ceiling. Supporting helper `requiredPermissionsForApiKeyScopes()` added to `services/apiKeyScopes.ts`.

## Contract test (§1.1 recurred 6×; code review caught 0/6)

`apps/api/src/__tests__/partner-wide-write-coverage.test.ts` — a plain unit test (no DB, so it fails in the **Test API** job, not only under Integration Tests):

- Derives the partner-axis table set from the **live Drizzle schema**, never a hand-list: any table with a `partner_id` column whose `org_id` is absent or nullable can hold a partner-owned row.
- Scans `src/routes/**` and `src/services/aiTools*.ts` — the surfaces a token can reach — for `.insert()/.update()/.delete()` on those tables, and fails any file that doesn't consult `canManagePartnerWidePolicies`.
- **18 documented exemptions** in `ALLOWED_WITHOUT_CAPABILITY_CHECK`, each with a reason: authentication flows on `users` (password/MFA/passkey/phone/email — "is this you", not "may you administer the partner"), platform-admin surfaces, org provisioning (org axis, tracked separately as the §1.1 "adjacent orgAccess gaps"), OAuth consent, and three integration/catalog routes.
- Guards its own guard: asserts the derivation returns a non-trivial set (a silent `[]` would make every assertion vacuous), that no allowlist entry is stale, that every entry is documented, and names the seven fixed files explicitly so a regression on any one is a labelled failure.

**Mutation-tested:** renaming the symbol in `partnerServicePrincipals.ts` reddens it (2 failures, correctly named).

## Verification

- `pnpm --filter @breeze/api test` — **1367 files, 22,740 tests passed**, 0 failed.
- `pnpm --filter @breeze/api exec tsc --noEmit` — **clean**.
- New per-route suites (43 assertions) mutation-tested as a set: stubbing `canManagePartnerWidePolicies` to `return true` reddens **21 of 43** across all six files, so the denials are not vacuous. Every 403 case is paired with a positive control proving the same request succeeds at `orgAccess: 'all'` *and* that the underlying db mock was reached.
- Existing fixtures that built a partner-scope auth object with no `partnerOrgAccess` now declare `'all'` — those personas are full partner admins, so the original expectations are restored rather than the assertions relaxed. `templates.guard.test.ts` additionally gains a restricted-partner case.

## Not fixed here (deliberate, needs a follow-up)

A **scope→permission ceiling for partner service principals** was considered and left out. `PARTNER_SERVICE_PRINCIPAL_SCOPES` includes `inventory:read`, `configuration:read`, `custom-fields:read`, `backup-configuration:read` and `enrollment-keys:write`, and **no corresponding grants exist in `PERMISSION_GRANTS`** — mapping them would mean inventing permission policy rather than enforcing existing policy. The consequence is that a caller holding `organizations:write` + `orgAccess: 'all'` can still mint a principal with e.g. `scripts:read` they may not personally hold. The §1.1 capability gate (mandatory, applied) is the load-bearing fix; the scope-map is a separate, smaller decision. Also out of scope by design: §1.5's read predicate (sibling branch), and the "adjacent orgAccess gaps" the review lists at `orgs.ts:1345/1459/758` and `remote/supportSessions.ts:56`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
