### PR TITLE
fix(web): What's New splash never auto-shows on the upgrade that introduces an entry (#3646)

### DIFF
--- a/apps/web/src/components/whatsNew/WhatsNewSplash.test.tsx
+++ b/apps/web/src/components/whatsNew/WhatsNewSplash.test.tsx
@@ -50,10 +50,20 @@ describe('WhatsNewSplash', () => {
     });
   });
 
-  it('renders nothing when there is no applicable entry', async () => {
-    window.localStorage.clear(); // first-ever load => baseline only, no show
+  // #3646: with no stored floor (existing user upgrading from a pre-feature
+  // build) the newest shipped entry must still auto-show rather than be
+  // silently baselined away.
+  it('shows the newest entry when no floor is stored', async () => {
+    window.localStorage.clear();
+    render(<WhatsNewSplash />);
+    expect(await screen.findByText(/whatsNew\.title:/)).toBeInTheDocument();
+    // Nothing is written until the user acknowledges it.
+    expect(window.localStorage.getItem(LAST_SEEN_KEY)).toBeNull();
+  });
+
+  it('renders nothing once the newest entry has been acknowledged', async () => {
+    window.localStorage.setItem(LAST_SEEN_KEY, '99.0.0');
     const { container } = render(<WhatsNewSplash />);
-    // Give the mount effect a tick to run (it will write the baseline and stay closed).
     await waitFor(() => {
       expect(container).toBeEmptyDOMElement();
     });

--- a/apps/web/src/components/whatsNew/WhatsNewSplash.test.tsx
+++ b/apps/web/src/components/whatsNew/WhatsNewSplash.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import WhatsNewSplash from './WhatsNewSplash';
+import WhatsNewSplash, { REOPEN_EVENT } from './WhatsNewSplash';
 import { LAST_SEEN_KEY } from '../../lib/whatsNewState';
 
 // t returns key + interpolated version so assertions are stable without real i18n.
@@ -68,5 +68,16 @@ describe('WhatsNewSplash', () => {
       expect(container).toBeEmptyDOMElement();
     });
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  // The sidebar link reopens via a window event and ignores the dismissal floor.
+  it('reopens on the sidebar event even when the floor suppresses the splash', async () => {
+    window.localStorage.setItem(LAST_SEEN_KEY, '99.0.0');
+    render(<WhatsNewSplash />);
+    await waitFor(() => {
+      expect(screen.queryByText('whatsNew.gotIt')).not.toBeInTheDocument();
+    });
+    fireEvent(window, new Event(REOPEN_EVENT));
+    expect(await screen.findByText(/whatsNew\.title:/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/lib/whatsNewState.test.ts
+++ b/apps/web/src/lib/whatsNewState.test.ts
@@ -56,6 +56,29 @@ describe('decideWhatsNew', () => {
     expect(decideWhatsNew(s, '0.105.0', ENTRIES).entry?.version).toBe('0.105.0');
   });
 
+  // An unparseable floor makes every semverCompare null, which would otherwise
+  // suppress the splash forever with nothing left to rewrite the key.
+  it('treats an unparseable stored floor as absent', () => {
+    const s = fakeStorage({ [LAST_SEEN_KEY]: 'not-a-version' });
+    expect(decideWhatsNew(s, '0.105.0', ENTRIES).entry?.version).toBe('0.105.0');
+  });
+
+  it('rewrites the baseline over an unparseable floor when nothing applies', () => {
+    const s = fakeStorage({ [LAST_SEEN_KEY]: 'garbage' });
+    expect(decideWhatsNew(s, '0.103.0', ENTRIES)).toEqual({
+      entry: null,
+      baselineToSet: '0.103.0',
+    });
+  });
+
+  it('shows nothing when the entry list is empty', () => {
+    const s = fakeStorage();
+    expect(decideWhatsNew(s, '0.105.0', [])).toEqual({
+      entry: null,
+      baselineToSet: '0.105.0',
+    });
+  });
+
   it('does not re-show after the no-floor entry is acknowledged', () => {
     const s = fakeStorage();
     const first = decideWhatsNew(s, '0.105.0', ENTRIES);

--- a/apps/web/src/lib/whatsNewState.test.ts
+++ b/apps/web/src/lib/whatsNewState.test.ts
@@ -23,9 +23,44 @@ describe('decideWhatsNew', () => {
     expect(s._map.has(LAST_SEEN_KEY)).toBe(false);
   });
 
-  it('first-ever load sets baseline without showing', () => {
+  // #3646: an existing user upgrading from a build that predates the feature has
+  // no floor either, so "no floor" must not baseline the current entry away.
+  it('shows the newest shipped entry when there is no floor', () => {
     const s = fakeStorage();
-    expect(decideWhatsNew(s, '0.105.0', ENTRIES)).toEqual({ entry: null, baselineToSet: '0.105.0' });
+    const d = decideWhatsNew(s, '0.105.0', ENTRIES);
+    expect(d.entry?.version).toBe('0.105.0');
+    expect(d.baselineToSet).toBeNull();
+    expect(s._map.has(LAST_SEEN_KEY)).toBe(false);
+  });
+
+  it('shows at most one entry with no floor, even with a backlog', () => {
+    const s = fakeStorage();
+    expect(decideWhatsNew(s, '0.105.0', ENTRIES).entry?.version).toBe('0.105.0');
+  });
+
+  it('no floor still respects the running web version', () => {
+    const s = fakeStorage();
+    expect(decideWhatsNew(s, '0.104.0', ENTRIES).entry?.version).toBe('0.104.0');
+  });
+
+  it('no floor and nothing applicable sets the baseline instead', () => {
+    const s = fakeStorage();
+    expect(decideWhatsNew(s, '0.103.0', ENTRIES)).toEqual({
+      entry: null,
+      baselineToSet: '0.103.0',
+    });
+  });
+
+  it('treats an empty stored floor as absent', () => {
+    const s = fakeStorage({ [LAST_SEEN_KEY]: '' });
+    expect(decideWhatsNew(s, '0.105.0', ENTRIES).entry?.version).toBe('0.105.0');
+  });
+
+  it('does not re-show after the no-floor entry is acknowledged', () => {
+    const s = fakeStorage();
+    const first = decideWhatsNew(s, '0.105.0', ENTRIES);
+    markSeen(s, first.entry!.version);
+    expect(decideWhatsNew(s, '0.105.0', ENTRIES).entry).toBeNull();
   });
 
   it('shows the newest entry above the floor and at/below web version', () => {

--- a/apps/web/src/lib/whatsNewState.ts
+++ b/apps/web/src/lib/whatsNewState.ts
@@ -7,7 +7,11 @@ export const LAST_SEEN_KEY = 'breeze.whatsNew.lastSeenVersion';
 export interface WhatsNewDecision {
   /** The entry to show, or null. */
   entry: WhatsNewEntry | null;
-  /** First-ever load only: caller writes this baseline and shows nothing. */
+  /**
+   * Set only when there is no stored floor AND nothing to show: the caller
+   * writes this baseline so the *next* release still surfaces. When there is an
+   * entry to show, this is null and the floor is written by "Got it" instead.
+   */
   baselineToSet: string | null;
 }
 
@@ -27,15 +31,29 @@ export function decideWhatsNew(
 ): WhatsNewDecision {
   if (webVersion === 'dev') return { entry: null, baselineToSet: null };
 
-  const floor = storage.getItem(LAST_SEEN_KEY);
-  if (!floor) return { entry: null, baselineToSet: webVersion };
+  // Treat an empty value as absent — a blank floor is not a version.
+  const floor = storage.getItem(LAST_SEEN_KEY) || null;
 
   const applicable = entries.filter((e) => {
-    const aboveFloor = semverCompare(e.version, floor);
     const atMostWeb = semverCompare(e.version, webVersion);
-    return aboveFloor !== null && aboveFloor > 0 && atMostWeb !== null && atMostWeb <= 0;
+    if (atMostWeb === null || atMostWeb > 0) return false;
+    // No floor yet: every entry the running build shipped is a candidate, so
+    // `highest` picks the release the user just landed on.
+    if (floor === null) return true;
+    const aboveFloor = semverCompare(e.version, floor);
+    return aboveFloor !== null && aboveFloor > 0;
   });
-  return { entry: highest(applicable), baselineToSet: null };
+  const entry = highest(applicable);
+
+  // A missing floor means either a brand-new user or an existing user upgrading
+  // from a build that predates this feature. The two are indistinguishable, and
+  // baselining both away meant the entry that shipped the feature could never
+  // auto-show (#3646). Both populations now see the newest shipped entry once.
+  // Only when there is nothing to show do we write a baseline, so the next
+  // release still surfaces.
+  if (floor === null && !entry) return { entry: null, baselineToSet: webVersion };
+
+  return { entry, baselineToSet: null };
 }
 
 export function markSeen(storage: Pick<Storage, 'setItem'>, version: string): void {

--- a/apps/web/src/lib/whatsNewState.ts
+++ b/apps/web/src/lib/whatsNewState.ts
@@ -31,8 +31,12 @@ export function decideWhatsNew(
 ): WhatsNewDecision {
   if (webVersion === 'dev') return { entry: null, baselineToSet: null };
 
-  // Treat an empty value as absent — a blank floor is not a version.
-  const floor = storage.getItem(LAST_SEEN_KEY) || null;
+  // Treat an empty or unparseable value as absent. A floor semverCompare cannot
+  // read makes every comparison null, which would suppress the splash forever
+  // with nothing left to rewrite the key — the same silent-disappearance shape
+  // as the bug above.
+  const stored = storage.getItem(LAST_SEEN_KEY);
+  const floor = stored && semverCompare(stored, stored) !== null ? stored : null;
 
   const applicable = entries.filter((e) => {
     const atMostWeb = semverCompare(e.version, webVersion);


### PR DESCRIPTION
## Problem

`decideWhatsNew` treated a missing `breeze.whatsNew.lastSeenVersion` key as "brand-new user": it wrote the running version as the baseline and rendered nothing. An **existing** user upgrading from a build that predates the splash has no key either, so they hit the same branch — the entry that shipped *with* the upgrade was silently baselined away and could never auto-show. The earliest anything could auto-appear was the release *after* a user's first post-upgrade visit, which defeats the point of the splash.

The two populations are indistinguishable by "has no key" but wanted opposite behaviour.

## Fix

Option 1 from the issue (smallest change that fixes the symptom): with no stored floor, don't baseline — show the newest entry the running build shipped, once.

- No floor → every entry at or below `webVersion` is a candidate, and `highest` picks one. A backlog still produces a **single** splash, and entries newer than the running build are still suppressed.
- `baselineToSet` is now written only when there is no floor **and** nothing applicable to show, so the next release still surfaces.
- An empty stored value is treated as absent rather than as a version.
- New users see at most one entry (the release they signed up on) — accepted trade-off, as noted in the issue.

## Not in scope

The secondary `localStorage` per-browser point (option 2, server-side last-seen) is a schema field + endpoint and is deliberately left out. After this fix, a second browser/profile shows at most one entry rather than none.

## Tests

- `apps/web/src/lib/whatsNewState.test.ts` — no-floor shows newest entry; respects the running web version; single entry despite a backlog; no-floor-with-nothing-applicable writes the baseline; empty floor treated as absent; no re-show after acknowledgement.
- `apps/web/src/components/whatsNew/WhatsNewSplash.test.tsx` — splash renders with cleared `localStorage` and writes nothing until "Got it"; renders nothing once acknowledged.

Verified the new tests are not vacuous: with the `whatsNewState.ts` change stashed, 6 of them fail.

Closes #3646

🤖 Generated with [Claude Code](https://claude.com/claude-code)