### PR TITLE
fix(web): gate dashboard "all clear" claims on a non-zero device count (#3613)

### DIFF
--- a/apps/web/src/components/dashboard/AlertsFeed.tsx
+++ b/apps/web/src/components/dashboard/AlertsFeed.tsx
@@ -1,10 +1,11 @@
-import { AlertTriangle, AlertCircle, Info, XCircle, CheckCircle2, ChevronRight } from 'lucide-react';
+import { AlertTriangle, AlertCircle, Info, XCircle, CheckCircle2, ChevronRight, HardDriveDownload } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getErrorMessage, getErrorTitle } from '@/lib/errorMessages';
 import { formatTimeAgo } from '@/lib/formatTime';
 import { useTranslation } from 'react-i18next';
+import { fleetPresence } from './fleetPresence';
 import type { DashboardQueryState } from '../../hooks/useDashboardQuery';
-import type { AlertRow, AlertsSummary } from './types';
+import type { AlertRow, AlertsSummary, DeviceStats } from './types';
 
 const severityConfig: Record<string, { icon: typeof Info; chipClass: string; iconClass: string }> = {
   critical: { icon: XCircle, chipClass: 'bg-destructive/10', iconClass: 'text-destructive' },
@@ -19,15 +20,20 @@ const severityConfig: Record<string, { icon: typeof Info; chipClass: string; ico
  * filters server-side); rows with a device deep-link to it. Hidden when the
  * caller can't read alerts — an empty success state on a 403 would be a
  * false health claim.
+ *
+ * An empty feed is only "all clear" once the fleet denominator is known to be
+ * non-zero — see `fleetPresence` (#3613).
  */
 export default function AlertsFeed({
   alerts,
   summary,
+  devices,
   showOrg,
   onRetry,
 }: {
   alerts: DashboardQueryState<AlertRow[]>;
   summary: DashboardQueryState<AlertsSummary>;
+  devices: DashboardQueryState<DeviceStats>;
   showOrg: boolean;
   onRetry: () => void;
 }) {
@@ -108,18 +114,70 @@ export default function AlertsFeed({
   }
 
   const rows = alerts.data ?? [];
+  const presence = fleetPresence(devices);
+
+  // An empty feed says nothing about fleet health until the device count is
+  // known. Only `present` earns the green all-clear; the other three states
+  // report what we actually know instead of asserting health.
+  const renderEmpty = () => {
+    if (presence === 'loading') {
+      return (
+        <div
+          className="flex h-40 flex-col items-center justify-center gap-2"
+          data-testid="dashboard-alerts-empty-pending"
+        >
+          <div className="skeleton h-10 w-10 rounded-full" />
+          <div className="skeleton h-3.5 w-40 rounded" />
+        </div>
+      );
+    }
+
+    if (presence === 'none') {
+      return (
+        <div
+          className="flex h-40 flex-col items-center justify-center gap-2 text-center"
+          data-testid="dashboard-alerts-empty-no-devices"
+        >
+          <div className="rounded-full bg-muted p-2.5">
+            <HardDriveDownload className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          </div>
+          <p className="text-sm font-medium text-foreground/80">{t('dashboard.alerts.noDevicesTitle')}</p>
+          <p className="text-xs text-muted-foreground">{t('dashboard.alerts.noDevicesHint')}</p>
+        </div>
+      );
+    }
+
+    if (presence === 'unknown') {
+      return (
+        <div
+          className="flex h-40 flex-col items-center justify-center gap-2 text-center"
+          data-testid="dashboard-alerts-empty-coverage-unknown"
+        >
+          <div className="rounded-full bg-muted p-2.5">
+            <Info className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          </div>
+          <p className="text-sm font-medium text-foreground/80">{t('dashboard.alerts.noActiveAlerts')}</p>
+          <p className="text-xs text-muted-foreground">{t('dashboard.alerts.deviceStatusUnavailable')}</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex h-40 flex-col items-center justify-center gap-2 text-center" data-testid="dashboard-alerts-all-clear">
+        <div className="rounded-full bg-success/10 p-2.5">
+          <CheckCircle2 className="h-5 w-5 text-success" />
+        </div>
+        <p className="text-sm font-medium text-foreground/80">{t('dashboard.alerts.allClear')}</p>
+        <p className="text-xs text-muted-foreground">{t('dashboard.alerts.empty')}</p>
+      </div>
+    );
+  };
 
   return (
     <div className="rounded-lg border bg-card p-5 shadow-xs">
       {header}
       {rows.length === 0 ? (
-        <div className="flex h-40 flex-col items-center justify-center gap-2 text-center">
-          <div className="rounded-full bg-success/10 p-2.5">
-            <CheckCircle2 className="h-5 w-5 text-success" />
-          </div>
-          <p className="text-sm font-medium text-foreground/80">{t('dashboard.alerts.allClear')}</p>
-          <p className="text-xs text-muted-foreground">{t('dashboard.alerts.empty')}</p>
-        </div>
+        renderEmpty()
       ) : (
         <div className="-mx-2 divide-y divide-border/60">
           {rows.map((alert) => {

--- a/apps/web/src/components/dashboard/DashboardPage.tsx
+++ b/apps/web/src/components/dashboard/DashboardPage.tsx
@@ -165,7 +165,13 @@ export default function DashboardPage() {
 
       <div className="grid items-start gap-6 lg:grid-cols-3">
         <div className="lg:col-span-2">
-          <AlertsFeed alerts={alerts} summary={alertsSummary} showOrg={currentOrgId === null} onRetry={refresh} />
+          <AlertsFeed
+            alerts={alerts}
+            summary={alertsSummary}
+            devices={devices}
+            showOrg={currentOrgId === null}
+            onRetry={refresh}
+          />
         </div>
         <FleetStatusCard devices={devices} offline={offline} />
       </div>
@@ -174,7 +180,7 @@ export default function DashboardPage() {
         <div className="grid items-start gap-6 md:grid-cols-2 xl:grid-cols-3">
           <SecurityPostureCard security={security} />
           <PatchComplianceCard patch={patch} />
-          <VulnerabilitiesCard vulns={vulns} />
+          <VulnerabilitiesCard vulns={vulns} devices={devices} />
         </div>
       )}
 

--- a/apps/web/src/components/dashboard/FleetStatusCard.tsx
+++ b/apps/web/src/components/dashboard/FleetStatusCard.tsx
@@ -33,6 +33,19 @@ export default function FleetStatusCard({
   }
 
   const stats = devices.data;
+  // A failed /devices/stats must not vanish the card: an absent card reads as
+  // "nothing to report", which is the same false-negative #3613 is about. The
+  // 403/404 permission-hide is the one case where disappearing is deliberate.
+  if (!stats && devices.error && !devices.unavailable) {
+    return (
+      <div className="rounded-lg border bg-card p-5 shadow-xs" data-testid="dashboard-fleet-status">
+        <a href="/devices" className="text-sm font-semibold transition-colors hover:text-primary">
+          {t('dashboard.fleetStatus.title')}
+        </a>
+        <p className="mt-3 text-xs text-muted-foreground">{t('dashboard.stats.loadFailed')}</p>
+      </div>
+    );
+  }
   if (!stats || stats.total === 0) return null;
 
   const other = Math.max(stats.total - stats.online - (stats.byStatus.offline ?? 0), 0);

--- a/apps/web/src/components/dashboard/KpiStrip.test.tsx
+++ b/apps/web/src/components/dashboard/KpiStrip.test.tsx
@@ -9,15 +9,15 @@ import type { DashboardQueryState } from '../../hooks/useDashboardQuery';
 import type { AlertsSummary, DeviceStats, PatchCompliance, TicketStats } from './types';
 
 function loaded<T>(data: T): DashboardQueryState<T> {
-  return { data, error: null, isLoading: false, isFetching: false, unavailable: false };
+  return { data, error: null, isLoading: false, isFetching: false, unavailable: false, staleScope: false };
 }
 
 function unavailable<T>(): DashboardQueryState<T> {
-  return { data: null, error: null, isLoading: false, isFetching: false, unavailable: true };
+  return { data: null, error: null, isLoading: false, isFetching: false, unavailable: true, staleScope: false };
 }
 
 function failed<T>(): DashboardQueryState<T> {
-  return { data: null, error: new Error('boom'), isLoading: false, isFetching: false, unavailable: false };
+  return { data: null, error: new Error('boom'), isLoading: false, isFetching: false, unavailable: false, staleScope: false };
 }
 
 const deviceStats: DeviceStats = {

--- a/apps/web/src/components/dashboard/VulnerabilitiesCard.tsx
+++ b/apps/web/src/components/dashboard/VulnerabilitiesCard.tsx
@@ -1,20 +1,27 @@
-import { ShieldCheck } from 'lucide-react';
+import { ShieldCheck, HardDriveDownload, Info } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getErrorMessage } from '@/lib/errorMessages';
 import { useTranslation } from 'react-i18next';
 import { formatNumber } from '@/lib/i18n/format';
+import { fleetPresence } from './fleetPresence';
 import type { DashboardQueryState } from '../../hooks/useDashboardQuery';
-import type { VulnerabilityStats } from './types';
+import type { DeviceStats, VulnerabilityStats } from './types';
 
 /**
  * Open vulnerability exposure: critical findings, known-exploited (KEV)
  * reach, and how many findings already have a patch waiting. Hidden when
  * the caller can't read /vulnerabilities/stats.
+ *
+ * Zero findings only means "no open vulnerabilities" once the fleet
+ * denominator is known to be non-zero — "we scanned and found nothing" and
+ * "we never looked" are opposite facts (#3613).
  */
 export default function VulnerabilitiesCard({
   vulns,
+  devices,
 }: {
   vulns: DashboardQueryState<VulnerabilityStats>;
+  devices: DashboardQueryState<DeviceStats>;
 }) {
   const { t } = useTranslation('common');
 
@@ -48,7 +55,52 @@ export default function VulnerabilitiesCard({
   const data = vulns.data;
   if (!data) return null;
 
-  const allClear = data.totalFindings === 0;
+  const presence = fleetPresence(devices);
+  const noFindings = data.totalFindings === 0;
+
+  const renderNoFindings = () => {
+    if (presence === 'loading') {
+      return (
+        <div className="flex flex-col items-center gap-2.5 py-5" data-testid="dashboard-vuln-pending">
+          <div className="skeleton h-10 w-10 rounded-full" />
+          <div className="skeleton h-3.5 w-40 rounded" />
+        </div>
+      );
+    }
+
+    if (presence === 'none') {
+      return (
+        <div className="flex flex-col items-center py-5 text-center" data-testid="dashboard-vuln-no-devices">
+          <div className="mb-2.5 rounded-full bg-muted p-2.5">
+            <HardDriveDownload className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          </div>
+          <p className="text-sm font-medium text-foreground">{t('dashboard.vuln.noDevicesTitle')}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">{t('dashboard.vuln.noDevicesHint')}</p>
+        </div>
+      );
+    }
+
+    if (presence === 'unknown') {
+      return (
+        <div className="flex flex-col items-center py-5 text-center" data-testid="dashboard-vuln-coverage-unknown">
+          <div className="mb-2.5 rounded-full bg-muted p-2.5">
+            <Info className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          </div>
+          <p className="text-sm font-medium text-foreground">{t('dashboard.vuln.noneReported')}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">{t('dashboard.vuln.coverageUnknown')}</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex flex-col items-center py-5 text-center" data-testid="dashboard-vuln-all-clear">
+        <div className="mb-2.5 rounded-full bg-success/10 p-2.5">
+          <ShieldCheck className="h-5 w-5 text-success" />
+        </div>
+        <p className="text-sm font-medium text-foreground">{t('dashboard.vuln.allClear')}</p>
+      </div>
+    );
+  };
 
   return (
     <div className="rounded-lg border bg-card p-5 shadow-xs" data-testid="dashboard-vulnerabilities-card">
@@ -56,20 +108,15 @@ export default function VulnerabilitiesCard({
         <a href="/vulnerabilities" className="text-sm font-semibold transition-colors hover:text-primary">
           {t('dashboard.vuln.title')}
         </a>
-        {!allClear && (
+        {!noFindings && (
           <span className="text-xs tabular-nums text-muted-foreground">
             {t('dashboard.vuln.totalOpen', { count: data.totalFindings })}
           </span>
         )}
       </div>
 
-      {allClear ? (
-        <div className="flex flex-col items-center py-5 text-center">
-          <div className="mb-2.5 rounded-full bg-success/10 p-2.5">
-            <ShieldCheck className="h-5 w-5 text-success" />
-          </div>
-          <p className="text-sm font-medium text-foreground">{t('dashboard.vuln.allClear')}</p>
-        </div>
+      {noFindings ? (
+        renderNoFindings()
       ) : (
         <dl className="space-y-2.5">
           <div className="flex items-center justify-between gap-3">

--- a/apps/web/src/components/dashboard/fleetPresence.ts
+++ b/apps/web/src/components/dashboard/fleetPresence.ts
@@ -1,0 +1,30 @@
+import type { DashboardQueryState } from '../../hooks/useDashboardQuery';
+import type { DeviceStats } from './types';
+
+/**
+ * Whether the fleet denominator behind a rollup card is known and non-zero.
+ *
+ * - `present` — at least one device is enrolled, so an aggregate of zero is a
+ *   real finding ("we looked and found nothing").
+ * - `none`    — zero devices enrolled. An aggregate of zero means nothing.
+ * - `loading` — device count not settled yet; render neutral rather than
+ *   flashing an all-clear that may be retracted a tick later.
+ * - `unknown` — /devices/stats failed or is permission-hidden, so coverage
+ *   can't be proven either way.
+ */
+export type FleetPresence = 'present' | 'none' | 'loading' | 'unknown';
+
+/**
+ * Rollup cards must not render an affirmative "all clear" unless this returns
+ * `present`: with zero (or an unknown number of) devices reporting, "nothing
+ * found" and "we never looked" are opposite facts that otherwise render
+ * identically. See #3613 (and #3536 for the same fix on the Alerts page).
+ */
+export function fleetPresence(devices: DashboardQueryState<DeviceStats>): FleetPresence {
+  // Data wins over the in-flight flags: a background poll keeps the last
+  // known count, and that count is still the best answer we have.
+  if (devices.data) return devices.data.total > 0 ? 'present' : 'none';
+  if (devices.isLoading) return 'loading';
+  // Error with nothing cached, or a 403/404 permission-hide.
+  return 'unknown';
+}

--- a/apps/web/src/components/dashboard/fleetPresence.ts
+++ b/apps/web/src/components/dashboard/fleetPresence.ts
@@ -21,8 +21,14 @@ export type FleetPresence = 'present' | 'none' | 'loading' | 'unknown';
  * identically. See #3613 (and #3536 for the same fix on the Alerts page).
  */
 export function fleetPresence(devices: DashboardQueryState<DeviceStats>): FleetPresence {
-  // Data wins over the in-flight flags: a background poll keeps the last
-  // known count, and that count is still the best answer we have.
+  // A count belonging to a previously-selected org is worse than no count:
+  // switching from a populated org to an empty one would otherwise paint the
+  // old denominator over the new org's zeros and re-assert the all-clear this
+  // whole module exists to prevent, for as long as /devices/stats lags the
+  // card's own (already-resolved) query.
+  if (devices.staleScope) return 'loading';
+  // Otherwise data wins over the in-flight flags: a routine background poll
+  // keeps the last known count, and that count is still the best answer.
   if (devices.data) return devices.data.total > 0 ? 'present' : 'none';
   if (devices.isLoading) return 'loading';
   // Error with nothing cached, or a 403/404 permission-hide.

--- a/apps/web/src/components/dashboard/zeroDeviceClaims.test.tsx
+++ b/apps/web/src/components/dashboard/zeroDeviceClaims.test.tsx
@@ -9,22 +9,23 @@ vi.mock('@/lib/i18n/format', async (importOriginal) => ({
 }));
 
 import AlertsFeed from './AlertsFeed';
+import FleetStatusCard from './FleetStatusCard';
 import VulnerabilitiesCard from './VulnerabilitiesCard';
 import { fleetPresence } from './fleetPresence';
 import type { DashboardQueryState } from '../../hooks/useDashboardQuery';
-import type { AlertRow, AlertsSummary, DeviceStats, VulnerabilityStats } from './types';
+import type { AlertRow, AlertsSummary, DeviceStats, OfflineDevice, VulnerabilityStats } from './types';
 
 function loaded<T>(data: T): DashboardQueryState<T> {
-  return { data, error: null, isLoading: false, isFetching: false, unavailable: false };
+  return { data, error: null, isLoading: false, isFetching: false, unavailable: false, staleScope: false };
 }
 function loading<T>(): DashboardQueryState<T> {
-  return { data: null, error: null, isLoading: true, isFetching: true, unavailable: false };
+  return { data: null, error: null, isLoading: true, isFetching: true, unavailable: false, staleScope: false };
 }
 function failed<T>(): DashboardQueryState<T> {
-  return { data: null, error: new Error('boom'), isLoading: false, isFetching: false, unavailable: false };
+  return { data: null, error: new Error('boom'), isLoading: false, isFetching: false, unavailable: false, staleScope: false };
 }
 function unavailable<T>(): DashboardQueryState<T> {
-  return { data: null, error: null, isLoading: false, isFetching: false, unavailable: true };
+  return { data: null, error: null, isLoading: false, isFetching: false, unavailable: true, staleScope: false };
 }
 
 function stats(total: number): DeviceStats {
@@ -58,13 +59,41 @@ describe('fleetPresence', () => {
 
   it('prefers a cached count over an in-flight background poll', () => {
     expect(
-      fleetPresence({ data: stats(5), error: null, isLoading: false, isFetching: true, unavailable: false })
+      fleetPresence({ data: stats(5), error: null, isLoading: false, isFetching: true, unavailable: false, staleScope: false })
     ).toBe('present');
     // A failed background poll keeps the last known count rather than
     // degrading to "unknown".
     expect(
-      fleetPresence({ data: stats(5), error: new Error('boom'), isLoading: false, isFetching: false, unavailable: false })
+      fleetPresence({ data: stats(5), error: new Error('boom'), isLoading: false, isFetching: false, unavailable: false, staleScope: false })
     ).toBe('present');
+  });
+
+  it('suspends the count while it belongs to a previously-selected org scope', () => {
+    // Org switch: /devices/stats still holds the OLD org's non-zero count
+    // while the card's own query has already resolved for the new org.
+    // Reading 'present' here would re-assert the exact false all-clear #3613
+    // is about, so the stale count must not be trusted.
+    expect(
+      fleetPresence({
+        data: stats(42),
+        error: null,
+        isLoading: false,
+        isFetching: true,
+        unavailable: false,
+        staleScope: true,
+      })
+    ).toBe('loading');
+    // Even a failed refetch must not promote old-scope data back to trusted.
+    expect(
+      fleetPresence({
+        data: stats(42),
+        error: new Error('boom'),
+        isLoading: false,
+        isFetching: false,
+        unavailable: false,
+        staleScope: true,
+      })
+    ).toBe('loading');
   });
 });
 
@@ -177,5 +206,26 @@ describe('VulnerabilitiesCard zero-findings state (#3613)', () => {
     );
     expect(screen.getByText('dashboard.vuln.criticalOpen')).toBeInTheDocument();
     expect(screen.queryByTestId('dashboard-vuln-coverage-unknown')).toBeNull();
+  });
+});
+
+describe('FleetStatusCard failure visibility', () => {
+  function renderFleet(devices: DashboardQueryState<DeviceStats>) {
+    return render(<FleetStatusCard devices={devices} offline={loaded<OfflineDevice[]>([])} />);
+  }
+
+  it('stays visible with an explicit failure note when the device query fails', () => {
+    const { container } = renderFleet(failed<DeviceStats>());
+    // Vanishing would read as "nothing to report" — the same false negative.
+    expect(container).not.toBeEmptyDOMElement();
+    expect(screen.getByTestId('dashboard-fleet-status')).toBeInTheDocument();
+    expect(screen.getByText('dashboard.stats.loadFailed')).toBeInTheDocument();
+  });
+
+  it('still hides entirely on a deliberate permission-hide or an empty fleet', () => {
+    const { container: hidden } = renderFleet(unavailable<DeviceStats>());
+    expect(hidden).toBeEmptyDOMElement();
+    const { container: empty } = renderFleet(loaded(stats(0)));
+    expect(empty).toBeEmptyDOMElement();
   });
 });

--- a/apps/web/src/components/dashboard/zeroDeviceClaims.test.tsx
+++ b/apps/web/src/components/dashboard/zeroDeviceClaims.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@/lib/i18n/format', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/i18n/format')>()),
+  formatNumber: (n: number) => String(n),
+}));
+
+import AlertsFeed from './AlertsFeed';
+import VulnerabilitiesCard from './VulnerabilitiesCard';
+import { fleetPresence } from './fleetPresence';
+import type { DashboardQueryState } from '../../hooks/useDashboardQuery';
+import type { AlertRow, AlertsSummary, DeviceStats, VulnerabilityStats } from './types';
+
+function loaded<T>(data: T): DashboardQueryState<T> {
+  return { data, error: null, isLoading: false, isFetching: false, unavailable: false };
+}
+function loading<T>(): DashboardQueryState<T> {
+  return { data: null, error: null, isLoading: true, isFetching: true, unavailable: false };
+}
+function failed<T>(): DashboardQueryState<T> {
+  return { data: null, error: new Error('boom'), isLoading: false, isFetching: false, unavailable: false };
+}
+function unavailable<T>(): DashboardQueryState<T> {
+  return { data: null, error: null, isLoading: false, isFetching: false, unavailable: true };
+}
+
+function stats(total: number): DeviceStats {
+  return { total, online: total, offline: 0, byStatus: { online: total }, migrationRequiredCount: 0 };
+}
+
+const alertsSummary: AlertsSummary = {
+  bySeverity: { critical: 0, high: 0, medium: 0, low: 0, info: 0 },
+  byStatus: { active: 0, acknowledged: 0, resolved: 0, suppressed: 0, dismissed: 0 },
+  total: 0,
+};
+
+const noVulns: VulnerabilityStats = {
+  criticalOpen: 0,
+  kevCveCount: 0,
+  kevDeviceCount: 0,
+  patchReadyFindingCount: 0,
+  acceptedExpiringSoon: 0,
+  totalFindings: 0,
+  lastDetectedAt: null,
+};
+
+describe('fleetPresence', () => {
+  it('classifies each device-count state', () => {
+    expect(fleetPresence(loaded(stats(3)))).toBe('present');
+    expect(fleetPresence(loaded(stats(0)))).toBe('none');
+    expect(fleetPresence(loading<DeviceStats>())).toBe('loading');
+    expect(fleetPresence(failed<DeviceStats>())).toBe('unknown');
+    expect(fleetPresence(unavailable<DeviceStats>())).toBe('unknown');
+  });
+
+  it('prefers a cached count over an in-flight background poll', () => {
+    expect(
+      fleetPresence({ data: stats(5), error: null, isLoading: false, isFetching: true, unavailable: false })
+    ).toBe('present');
+    // A failed background poll keeps the last known count rather than
+    // degrading to "unknown".
+    expect(
+      fleetPresence({ data: stats(5), error: new Error('boom'), isLoading: false, isFetching: false, unavailable: false })
+    ).toBe('present');
+  });
+});
+
+function renderFeed(devices: DashboardQueryState<DeviceStats>) {
+  return render(
+    <AlertsFeed
+      alerts={loaded<AlertRow[]>([])}
+      summary={loaded(alertsSummary)}
+      devices={devices}
+      showOrg={false}
+      onRetry={() => {}}
+    />
+  );
+}
+
+describe('AlertsFeed empty state (#3613)', () => {
+  it('does not claim "all clear" when zero devices are reporting', () => {
+    renderFeed(loaded(stats(0)));
+    expect(screen.queryByTestId('dashboard-alerts-all-clear')).toBeNull();
+    expect(screen.queryByText('dashboard.alerts.allClear')).toBeNull();
+    expect(screen.getByTestId('dashboard-alerts-empty-no-devices')).toBeInTheDocument();
+    expect(screen.getByText('dashboard.alerts.noDevicesTitle')).toBeInTheDocument();
+  });
+
+  it('does not claim "all clear" while the device count is still loading', () => {
+    renderFeed(loading<DeviceStats>());
+    expect(screen.queryByText('dashboard.alerts.allClear')).toBeNull();
+    expect(screen.getByTestId('dashboard-alerts-empty-pending')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['a failed device request', failed<DeviceStats>()],
+    ['a permission-hidden device request', unavailable<DeviceStats>()],
+  ])('states only the known fact on %s', (_label, devices) => {
+    renderFeed(devices);
+    expect(screen.queryByText('dashboard.alerts.allClear')).toBeNull();
+    expect(screen.getByTestId('dashboard-alerts-empty-coverage-unknown')).toBeInTheDocument();
+    expect(screen.getByText('dashboard.alerts.deviceStatusUnavailable')).toBeInTheDocument();
+  });
+
+  it('still claims "all clear" when devices are reporting and no alerts are open', () => {
+    renderFeed(loaded(stats(12)));
+    expect(screen.getByTestId('dashboard-alerts-all-clear')).toBeInTheDocument();
+    expect(screen.getByText('dashboard.alerts.allClear')).toBeInTheDocument();
+  });
+
+  it('renders alert rows regardless of the device count', () => {
+    render(
+      <AlertsFeed
+        alerts={loaded<AlertRow[]>([
+          {
+            id: 'a1',
+            title: 'Disk almost full',
+            severity: 'critical',
+            status: 'active',
+            deviceId: 'd1',
+            deviceHostname: 'host-1',
+            createdAt: '2026-08-17T00:00:00.000Z',
+          },
+        ])}
+        summary={loaded(alertsSummary)}
+        devices={failed<DeviceStats>()}
+        showOrg={false}
+        onRetry={() => {}}
+      />
+    );
+    expect(screen.getByText('Disk almost full')).toBeInTheDocument();
+    expect(screen.queryByTestId('dashboard-alerts-empty-coverage-unknown')).toBeNull();
+  });
+});
+
+function renderVulns(devices: DashboardQueryState<DeviceStats>, vulns = loaded(noVulns)) {
+  return render(<VulnerabilitiesCard vulns={vulns} devices={devices} />);
+}
+
+describe('VulnerabilitiesCard zero-findings state (#3613)', () => {
+  it('does not claim "no open vulnerabilities" when zero devices are reporting', () => {
+    renderVulns(loaded(stats(0)));
+    expect(screen.queryByText('dashboard.vuln.allClear')).toBeNull();
+    expect(screen.getByTestId('dashboard-vuln-no-devices')).toBeInTheDocument();
+    expect(screen.getByText('dashboard.vuln.noDevicesHint')).toBeInTheDocument();
+  });
+
+  it('does not claim "no open vulnerabilities" while the device count is loading', () => {
+    renderVulns(loading<DeviceStats>());
+    expect(screen.queryByText('dashboard.vuln.allClear')).toBeNull();
+    expect(screen.getByTestId('dashboard-vuln-pending')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['a failed device request', failed<DeviceStats>()],
+    ['a permission-hidden device request', unavailable<DeviceStats>()],
+  ])('reports coverage as unconfirmed on %s', (_label, devices) => {
+    renderVulns(devices);
+    expect(screen.queryByText('dashboard.vuln.allClear')).toBeNull();
+    expect(screen.getByTestId('dashboard-vuln-coverage-unknown')).toBeInTheDocument();
+    expect(screen.getByText('dashboard.vuln.coverageUnknown')).toBeInTheDocument();
+  });
+
+  it('still claims "no open vulnerabilities" when devices are reporting', () => {
+    renderVulns(loaded(stats(9)));
+    expect(screen.getByTestId('dashboard-vuln-all-clear')).toBeInTheDocument();
+    expect(screen.getByText('dashboard.vuln.allClear')).toBeInTheDocument();
+  });
+
+  it('renders the findings breakdown regardless of the device count', () => {
+    renderVulns(
+      failed<DeviceStats>(),
+      loaded({ ...noVulns, totalFindings: 4, criticalOpen: 2, kevCveCount: 1, kevDeviceCount: 1 })
+    );
+    expect(screen.getByText('dashboard.vuln.criticalOpen')).toBeInTheDocument();
+    expect(screen.queryByTestId('dashboard-vuln-coverage-unknown')).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/useDashboardQuery.test.tsx
+++ b/apps/web/src/hooks/useDashboardQuery.test.tsx
@@ -1,129 +1,122 @@
-import { act, render, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useDashboardQuery, type DashboardQueryState } from './useDashboardQuery';
-import { fetchWithAuth } from '../stores/auth';
+let currentOrgId: string | null = 'org-a';
+const fetchWithAuth = vi.fn();
 
-// The global Current/All-orgs pill is modeled by currentOrgId: a concrete id
-// means "this org", and null means the explicit All-orgs scope (see orgStore).
-let mockOrgState: { currentOrgId: string | null };
-
-vi.mock('../stores/auth', () => ({
-  fetchWithAuth: vi.fn(),
-}));
-
+vi.mock('../stores/auth', () => ({ fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args) }));
 vi.mock('../stores/orgStore', () => ({
-  useOrgStore: Object.assign(
-    (selector?: (s: typeof mockOrgState) => unknown) =>
-      selector ? selector(mockOrgState) : mockOrgState,
-    { getState: () => mockOrgState },
-  ),
+  useOrgStore: (selector: (s: { currentOrgId: string | null }) => unknown) => selector({ currentOrgId }),
 }));
 
-const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+import { useDashboardQuery } from './useDashboardQuery';
 
-const jsonResponse = (body: unknown, status = 200): Response =>
-  ({
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => body,
-  }) as unknown as Response;
-
-let lastState: DashboardQueryState<number> | null = null;
-
-function Probe({ token }: { token: number }) {
-  lastState = useDashboardQuery<number>('/devices/stats', token, (j: any) => j.data.total);
-  return null;
+function jsonResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
 }
 
-beforeEach(() => {
-  mockOrgState = { currentOrgId: 'org-1' };
-  lastState = null;
-  fetchWithAuthMock.mockReset();
-  fetchWithAuthMock.mockResolvedValue(jsonResponse({ data: { total: 7 } }));
-});
+/** A response whose body resolves only when the returned `settle` is called. */
+function deferredResponse(body: unknown) {
+  let settle!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+  const response = {
+    ok: true,
+    status: 200,
+    json: async () => {
+      await gate;
+      return body;
+    },
+  } as unknown as Response;
+  return { response, settle };
+}
 
-afterEach(() => {
-  vi.clearAllMocks();
-});
-
-describe('useDashboardQuery', () => {
-  it('fetches once and exposes the selected data', async () => {
-    render(<Probe token={0} />);
-
-    await waitFor(() => expect(lastState?.data).toBe(7));
-    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
-    expect(fetchWithAuthMock).toHaveBeenLastCalledWith('/devices/stats');
-    expect(lastState?.isLoading).toBe(false);
-    expect(lastState?.unavailable).toBe(false);
+describe('useDashboardQuery staleScope', () => {
+  beforeEach(() => {
+    currentOrgId = 'org-a';
+    fetchWithAuth.mockReset();
   });
 
-  it('refetches when the org scope flips Current -> All orgs', async () => {
-    const { rerender } = render(<Probe token={0} />);
-    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+  it('is false for a settled load and for a plain refresh-token poll', async () => {
+    fetchWithAuth.mockResolvedValue(jsonResponse({ total: 5 }));
 
-    mockOrgState.currentOrgId = null;
-    rerender(<Probe token={0} />);
+    const { result, rerender } = renderHook(
+      ({ tick }: { tick: number }) => useDashboardQuery<{ total: number }>('/devices/stats', tick, (j: any) => j),
+      { initialProps: { tick: 0 } }
+    );
 
-    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.data).toEqual({ total: 5 }));
+    expect(result.current.staleScope).toBe(false);
+
+    rerender({ tick: 1 });
+    // A same-scope poll keeps the cached value trusted throughout.
+    expect(result.current.staleScope).toBe(false);
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(result.current.staleScope).toBe(false);
   });
 
-  it('refetches when the refresh token bumps, not on unrelated re-renders', async () => {
-    const { rerender } = render(<Probe token={0} />);
-    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+  it('flags the cached value while an org switch is in flight, and clears it on arrival', async () => {
+    fetchWithAuth.mockResolvedValueOnce(jsonResponse({ total: 42 }));
 
-    rerender(<Probe token={0} />);
-    await new Promise((r) => setTimeout(r, 0));
-    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+    const { result, rerender } = renderHook(
+      ({ tick }: { tick: number }) => useDashboardQuery<{ total: number }>('/devices/stats', tick, (j: any) => j),
+      { initialProps: { tick: 0 } }
+    );
+    await waitFor(() => expect(result.current.data).toEqual({ total: 42 }));
 
-    rerender(<Probe token={1} />);
-    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
-  });
+    // Switch to an org whose response hasn't landed yet. The old count is
+    // still in `data` — it must be marked as belonging to the old scope.
+    const { response, settle } = deferredResponse({ total: 0 });
+    fetchWithAuth.mockResolvedValueOnce(response);
+    currentOrgId = 'org-b';
+    rerender({ tick: 0 });
 
-  it('marks 403 responses unavailable instead of erroring', async () => {
-    fetchWithAuthMock.mockResolvedValue(jsonResponse({ error: 'forbidden' }, 403));
-    render(<Probe token={0} />);
-
-    await waitFor(() => expect(lastState?.unavailable).toBe(true));
-    expect(lastState?.error).toBeNull();
-    expect(lastState?.data).toBeNull();
-    expect(lastState?.isLoading).toBe(false);
-  });
-
-  it('discards a slow stale-scope response that resolves after a newer one', async () => {
-    // org-1's response is deliberately slow; org-2's is instant. If the
-    // sequence guard is removed, org-1's data (7) overwrites org-2's (99)
-    // after the scope change — the cross-org data flash this test pins.
-    let resolveSlow!: (r: Response) => void;
-    const slow = new Promise<Response>((r) => (resolveSlow = r));
-    fetchWithAuthMock.mockReturnValueOnce(slow as any);
-    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ data: { total: 99 } }));
-
-    const { rerender } = render(<Probe token={0} />);
-    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
-
-    mockOrgState.currentOrgId = 'org-2';
-    rerender(<Probe token={0} />);
-    await waitFor(() => expect(lastState?.data).toBe(99));
+    expect(result.current.data).toEqual({ total: 42 });
+    expect(result.current.staleScope).toBe(true);
 
     await act(async () => {
-      resolveSlow(jsonResponse({ data: { total: 7 } }));
-      await Promise.resolve();
+      settle();
     });
-
-    expect(lastState?.data).toBe(99);
+    await waitFor(() => expect(result.current.data).toEqual({ total: 0 }));
+    expect(result.current.staleScope).toBe(false);
   });
 
-  it('keeps stale data visible when a background poll fails', async () => {
-    const { rerender } = render(<Probe token={0} />);
-    await waitFor(() => expect(lastState?.data).toBe(7));
+  it('keeps the flag set when the post-switch refetch fails', async () => {
+    fetchWithAuth.mockResolvedValueOnce(jsonResponse({ total: 42 }));
 
-    fetchWithAuthMock.mockResolvedValue(jsonResponse({ error: 'boom' }, 500));
-    await act(async () => {
-      rerender(<Probe token={1} />);
-    });
+    const { result, rerender } = renderHook(
+      ({ tick }: { tick: number }) => useDashboardQuery<{ total: number }>('/devices/stats', tick, (j: any) => j),
+      { initialProps: { tick: 0 } }
+    );
+    await waitFor(() => expect(result.current.data).toEqual({ total: 42 }));
 
-    await waitFor(() => expect(lastState?.error).not.toBeNull());
-    expect(lastState?.data).toBe(7);
+    fetchWithAuth.mockRejectedValueOnce(new Error('network down'));
+    currentOrgId = 'org-b';
+    rerender({ tick: 0 });
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    // Stale data survives the failure (deliberate) but stays untrusted.
+    expect(result.current.data).toEqual({ total: 42 });
+    expect(result.current.staleScope).toBe(true);
+  });
+
+  it('clears the flag when the post-switch request is permission-hidden', async () => {
+    fetchWithAuth.mockResolvedValueOnce(jsonResponse({ total: 42 }));
+
+    const { result, rerender } = renderHook(
+      ({ tick }: { tick: number }) => useDashboardQuery<{ total: number }>('/devices/stats', tick, (j: any) => j),
+      { initialProps: { tick: 0 } }
+    );
+    await waitFor(() => expect(result.current.data).toEqual({ total: 42 }));
+
+    fetchWithAuth.mockResolvedValueOnce({ ok: false, status: 403 } as unknown as Response);
+    currentOrgId = 'org-b';
+    rerender({ tick: 0 });
+
+    await waitFor(() => expect(result.current.unavailable).toBe(true));
+    // A 403 clears `data` outright, so there is no stale value left to flag.
+    expect(result.current.data).toBeNull();
+    expect(result.current.staleScope).toBe(false);
   });
 });

--- a/apps/web/src/hooks/useDashboardQuery.test.tsx
+++ b/apps/web/src/hooks/useDashboardQuery.test.tsx
@@ -1,122 +1,202 @@
-import { renderHook, waitFor, act } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-let currentOrgId: string | null = 'org-a';
-const fetchWithAuth = vi.fn();
+import { useDashboardQuery, type DashboardQueryState } from './useDashboardQuery';
+import { fetchWithAuth } from '../stores/auth';
 
-vi.mock('../stores/auth', () => ({ fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args) }));
-vi.mock('../stores/orgStore', () => ({
-  useOrgStore: (selector: (s: { currentOrgId: string | null }) => unknown) => selector({ currentOrgId }),
+// The global Current/All-orgs pill is modeled by currentOrgId: a concrete id
+// means "this org", and null means the explicit All-orgs scope (see orgStore).
+let mockOrgState: { currentOrgId: string | null };
+
+vi.mock('../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
 }));
 
-import { useDashboardQuery } from './useDashboardQuery';
+vi.mock('../stores/orgStore', () => ({
+  useOrgStore: Object.assign(
+    (selector?: (s: typeof mockOrgState) => unknown) =>
+      selector ? selector(mockOrgState) : mockOrgState,
+    { getState: () => mockOrgState },
+  ),
+}));
 
-function jsonResponse(body: unknown) {
-  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  }) as unknown as Response;
+
+let lastState: DashboardQueryState<number> | null = null;
+
+function Probe({ token }: { token: number }) {
+  lastState = useDashboardQuery<number>('/devices/stats', token, (j: any) => j.data.total);
+  return null;
 }
 
-/** A response whose body resolves only when the returned `settle` is called. */
-function deferredResponse(body: unknown) {
-  let settle!: () => void;
-  const gate = new Promise<void>((resolve) => {
-    settle = resolve;
+beforeEach(() => {
+  mockOrgState = { currentOrgId: 'org-1' };
+  lastState = null;
+  fetchWithAuthMock.mockReset();
+  fetchWithAuthMock.mockResolvedValue(jsonResponse({ data: { total: 7 } }));
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useDashboardQuery', () => {
+  it('fetches once and exposes the selected data', async () => {
+    render(<Probe token={0} />);
+
+    await waitFor(() => expect(lastState?.data).toBe(7));
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+    expect(fetchWithAuthMock).toHaveBeenLastCalledWith('/devices/stats');
+    expect(lastState?.isLoading).toBe(false);
+    expect(lastState?.unavailable).toBe(false);
   });
-  const response = {
-    ok: true,
-    status: 200,
-    json: async () => {
-      await gate;
-      return body;
-    },
-  } as unknown as Response;
-  return { response, settle };
-}
 
+  it('refetches when the org scope flips Current -> All orgs', async () => {
+    const { rerender } = render(<Probe token={0} />);
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+
+    mockOrgState.currentOrgId = null;
+    rerender(<Probe token={0} />);
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('refetches when the refresh token bumps, not on unrelated re-renders', async () => {
+    const { rerender } = render(<Probe token={0} />);
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+
+    rerender(<Probe token={0} />);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+
+    rerender(<Probe token={1} />);
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('marks 403 responses unavailable instead of erroring', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse({ error: 'forbidden' }, 403));
+    render(<Probe token={0} />);
+
+    await waitFor(() => expect(lastState?.unavailable).toBe(true));
+    expect(lastState?.error).toBeNull();
+    expect(lastState?.data).toBeNull();
+    expect(lastState?.isLoading).toBe(false);
+  });
+
+  it('discards a slow stale-scope response that resolves after a newer one', async () => {
+    // org-1's response is deliberately slow; org-2's is instant. If the
+    // sequence guard is removed, org-1's data (7) overwrites org-2's (99)
+    // after the scope change — the cross-org data flash this test pins.
+    let resolveSlow!: (r: Response) => void;
+    const slow = new Promise<Response>((r) => (resolveSlow = r));
+    fetchWithAuthMock.mockReturnValueOnce(slow as any);
+    fetchWithAuthMock.mockResolvedValueOnce(jsonResponse({ data: { total: 99 } }));
+
+    const { rerender } = render(<Probe token={0} />);
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+
+    mockOrgState.currentOrgId = 'org-2';
+    rerender(<Probe token={0} />);
+    await waitFor(() => expect(lastState?.data).toBe(99));
+
+    await act(async () => {
+      resolveSlow(jsonResponse({ data: { total: 7 } }));
+      await Promise.resolve();
+    });
+
+    expect(lastState?.data).toBe(99);
+  });
+
+  it('keeps stale data visible when a background poll fails', async () => {
+    const { rerender } = render(<Probe token={0} />);
+    await waitFor(() => expect(lastState?.data).toBe(7));
+
+    fetchWithAuthMock.mockResolvedValue(jsonResponse({ error: 'boom' }, 500));
+    await act(async () => {
+      rerender(<Probe token={1} />);
+    });
+
+    await waitFor(() => expect(lastState?.error).not.toBeNull());
+    expect(lastState?.data).toBe(7);
+  });
+});
+
+// `staleScope` exists so a widget that draws a conclusion from ANOTHER
+// widget's data (fleetPresence, #3613) can tell "the count I'm holding
+// belongs to the org you just switched away from" apart from "the count is
+// current". Widgets rendering their own numbers keep ignoring it.
 describe('useDashboardQuery staleScope', () => {
-  beforeEach(() => {
-    currentOrgId = 'org-a';
-    fetchWithAuth.mockReset();
-  });
+  it('stays false through a settled load and a same-scope refresh poll', async () => {
+    const { rerender } = render(<Probe token={0} />);
+    await waitFor(() => expect(lastState?.data).toBe(7));
+    expect(lastState?.staleScope).toBe(false);
 
-  it('is false for a settled load and for a plain refresh-token poll', async () => {
-    fetchWithAuth.mockResolvedValue(jsonResponse({ total: 5 }));
-
-    const { result, rerender } = renderHook(
-      ({ tick }: { tick: number }) => useDashboardQuery<{ total: number }>('/devices/stats', tick, (j: any) => j),
-      { initialProps: { tick: 0 } }
-    );
-
-    await waitFor(() => expect(result.current.data).toEqual({ total: 5 }));
-    expect(result.current.staleScope).toBe(false);
-
-    rerender({ tick: 1 });
-    // A same-scope poll keeps the cached value trusted throughout.
-    expect(result.current.staleScope).toBe(false);
-    await waitFor(() => expect(result.current.isFetching).toBe(false));
-    expect(result.current.staleScope).toBe(false);
+    rerender(<Probe token={1} />);
+    expect(lastState?.staleScope).toBe(false);
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
+    expect(lastState?.staleScope).toBe(false);
   });
 
   it('flags the cached value while an org switch is in flight, and clears it on arrival', async () => {
-    fetchWithAuth.mockResolvedValueOnce(jsonResponse({ total: 42 }));
+    const { rerender } = render(<Probe token={0} />);
+    await waitFor(() => expect(lastState?.data).toBe(7));
 
-    const { result, rerender } = renderHook(
-      ({ tick }: { tick: number }) => useDashboardQuery<{ total: number }>('/devices/stats', tick, (j: any) => j),
-      { initialProps: { tick: 0 } }
+    // org-2's response is held open: the old org's count is still on screen.
+    let resolvePending!: (r: Response) => void;
+    fetchWithAuthMock.mockReturnValueOnce(
+      new Promise<Response>((r) => (resolvePending = r)) as any
     );
-    await waitFor(() => expect(result.current.data).toEqual({ total: 42 }));
+    mockOrgState.currentOrgId = 'org-2';
+    rerender(<Probe token={0} />);
 
-    // Switch to an org whose response hasn't landed yet. The old count is
-    // still in `data` — it must be marked as belonging to the old scope.
-    const { response, settle } = deferredResponse({ total: 0 });
-    fetchWithAuth.mockResolvedValueOnce(response);
-    currentOrgId = 'org-b';
-    rerender({ tick: 0 });
-
-    expect(result.current.data).toEqual({ total: 42 });
-    expect(result.current.staleScope).toBe(true);
+    expect(lastState?.data).toBe(7);
+    expect(lastState?.staleScope).toBe(true);
 
     await act(async () => {
-      settle();
+      resolvePending(jsonResponse({ data: { total: 0 } }));
+      await Promise.resolve();
     });
-    await waitFor(() => expect(result.current.data).toEqual({ total: 0 }));
-    expect(result.current.staleScope).toBe(false);
+    await waitFor(() => expect(lastState?.data).toBe(0));
+    expect(lastState?.staleScope).toBe(false);
   });
 
   it('keeps the flag set when the post-switch refetch fails', async () => {
-    fetchWithAuth.mockResolvedValueOnce(jsonResponse({ total: 42 }));
+    const { rerender } = render(<Probe token={0} />);
+    await waitFor(() => expect(lastState?.data).toBe(7));
 
-    const { result, rerender } = renderHook(
-      ({ tick }: { tick: number }) => useDashboardQuery<{ total: number }>('/devices/stats', tick, (j: any) => j),
-      { initialProps: { tick: 0 } }
-    );
-    await waitFor(() => expect(result.current.data).toEqual({ total: 42 }));
+    fetchWithAuthMock.mockResolvedValue(jsonResponse({ error: 'boom' }, 500));
+    mockOrgState.currentOrgId = 'org-2';
+    await act(async () => {
+      rerender(<Probe token={0} />);
+    });
 
-    fetchWithAuth.mockRejectedValueOnce(new Error('network down'));
-    currentOrgId = 'org-b';
-    rerender({ tick: 0 });
-
-    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
-    // Stale data survives the failure (deliberate) but stays untrusted.
-    expect(result.current.data).toEqual({ total: 42 });
-    expect(result.current.staleScope).toBe(true);
+    await waitFor(() => expect(lastState?.error).not.toBeNull());
+    // Stale data survives the failure (deliberate) but must stay untrusted —
+    // a failed refetch does not make old-scope data current.
+    expect(lastState?.data).toBe(7);
+    expect(lastState?.staleScope).toBe(true);
   });
 
   it('clears the flag when the post-switch request is permission-hidden', async () => {
-    fetchWithAuth.mockResolvedValueOnce(jsonResponse({ total: 42 }));
+    const { rerender } = render(<Probe token={0} />);
+    await waitFor(() => expect(lastState?.data).toBe(7));
 
-    const { result, rerender } = renderHook(
-      ({ tick }: { tick: number }) => useDashboardQuery<{ total: number }>('/devices/stats', tick, (j: any) => j),
-      { initialProps: { tick: 0 } }
-    );
-    await waitFor(() => expect(result.current.data).toEqual({ total: 42 }));
+    fetchWithAuthMock.mockResolvedValue(jsonResponse({ error: 'forbidden' }, 403));
+    mockOrgState.currentOrgId = 'org-2';
+    await act(async () => {
+      rerender(<Probe token={0} />);
+    });
 
-    fetchWithAuth.mockResolvedValueOnce({ ok: false, status: 403 } as unknown as Response);
-    currentOrgId = 'org-b';
-    rerender({ tick: 0 });
-
-    await waitFor(() => expect(result.current.unavailable).toBe(true));
-    // A 403 clears `data` outright, so there is no stale value left to flag.
-    expect(result.current.data).toBeNull();
-    expect(result.current.staleScope).toBe(false);
+    await waitFor(() => expect(lastState?.unavailable).toBe(true));
+    // A 403 clears `data` outright, so no stale value is left to flag.
+    expect(lastState?.data).toBeNull();
+    expect(lastState?.staleScope).toBe(false);
   });
 });

--- a/apps/web/src/hooks/useDashboardQuery.ts
+++ b/apps/web/src/hooks/useDashboardQuery.ts
@@ -17,6 +17,16 @@ export interface DashboardQueryState<T> {
    * applies to transient failures.
    */
   unavailable: boolean;
+  /**
+   * True while the cached `data` was fetched under a *previous* org scope and
+   * the refetch for the current scope hasn't landed yet. Widgets that merely
+   * display their own numbers can ignore this (a stale number for one paint is
+   * better than a skeleton flash), but any widget that draws a *conclusion*
+   * from another widget's data must treat it as "not known yet" — otherwise
+   * switching from a populated org to an empty one paints the previous org's
+   * denominator over the new org's zeros. See `fleetPresence` (#3613).
+   */
+  staleScope: boolean;
 }
 
 /**
@@ -38,8 +48,13 @@ export function useDashboardQuery<T>(
     isLoading: true,
     isFetching: true,
     unavailable: false,
+    staleScope: false,
   });
   const currentOrgId = useOrgStore((s) => s.currentOrgId);
+
+  // The org scope the currently-held `data` was fetched under. `undefined`
+  // until the first response lands.
+  const dataOrgId = useRef<string | null | undefined>(undefined);
 
   // Keep the latest selector without making it an effect dependency —
   // callers pass inline arrows.
@@ -52,7 +67,11 @@ export function useDashboardQuery<T>(
 
   useEffect(() => {
     const seq = ++requestSeq.current;
-    setState((prev) => ({ ...prev, isFetching: true }));
+    setState((prev) => ({
+      ...prev,
+      isFetching: true,
+      staleScope: prev.data != null && dataOrgId.current !== currentOrgId,
+    }));
 
     const run = async () => {
       try {
@@ -60,19 +79,29 @@ export function useDashboardQuery<T>(
         if (seq !== requestSeq.current) return;
 
         if (response.status === 403 || response.status === 404) {
-          setState({ data: null, error: null, isLoading: false, isFetching: false, unavailable: true });
+          dataOrgId.current = currentOrgId;
+          setState({
+            data: null,
+            error: null,
+            isLoading: false,
+            isFetching: false,
+            unavailable: true,
+            staleScope: false,
+          });
           return;
         }
         if (!response.ok) throw response;
 
         const json = await response.json();
         if (seq !== requestSeq.current) return;
+        dataOrgId.current = currentOrgId;
         setState({
           data: selectRef.current(json),
           error: null,
           isLoading: false,
           isFetching: false,
           unavailable: false,
+          staleScope: false,
         });
       } catch (err) {
         if (seq !== requestSeq.current) return;
@@ -90,6 +119,9 @@ export function useDashboardQuery<T>(
           isLoading: false,
           isFetching: false,
           unavailable: false,
+          // A failed refetch does NOT make old-scope data current — keep it
+          // flagged so conclusions drawn from it stay suspended.
+          staleScope: prev.data != null && dataOrgId.current !== currentOrgId,
         }));
       }
     };

--- a/apps/web/src/locales/de-DE/common.json
+++ b/apps/web/src/locales/de-DE/common.json
@@ -252,7 +252,11 @@
       "viewAll": "Alle anzeigen",
       "allClear": "Alles in Ordnung",
       "empty": "Keine aktiven Warnmeldungen im Gerätebestand",
-      "fallbackTitle": "Warnmeldung"
+      "fallbackTitle": "Warnmeldung",
+      "noDevicesTitle": "Noch keine Geräte melden Daten",
+      "noDevicesHint": "Warnungen erscheinen, sobald ein Gerät registriert ist.",
+      "noActiveAlerts": "Keine aktiven Warnungen",
+      "deviceStatusUnavailable": "Gerätestatus nicht verfügbar — Flottenabdeckung kann nicht bestätigt werden."
     },
     "customizer": {
       "title": "Dashboard-Anpassung",
@@ -353,7 +357,11 @@
       "kevCves_other": "{{count}} CVEs",
       "kevDevices": "{{count}} Geräte",
       "kevDevices_one": "{{count}} Gerät",
-      "kevDevices_other": "{{count}} Geräte"
+      "kevDevices_other": "{{count}} Geräte",
+      "noDevicesTitle": "Noch keine Geräte melden Daten",
+      "noDevicesHint": "Registrieren Sie ein Gerät, um mit der Suche nach Schwachstellen zu beginnen.",
+      "noneReported": "Keine offenen Funde gemeldet",
+      "coverageUnknown": "Gerätestatus nicht verfügbar — Scan-Abdeckung kann nicht bestätigt werden."
     },
     "refreshFailed": "Aktualisierung fehlgeschlagen — ältere Daten werden angezeigt"
   },

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -252,7 +252,11 @@
       "viewAll": "View all",
       "allClear": "All clear",
       "empty": "No active alerts across your fleet",
-      "fallbackTitle": "Alert"
+      "fallbackTitle": "Alert",
+      "noDevicesTitle": "No devices reporting yet",
+      "noDevicesHint": "Alerts will appear once a device is enrolled.",
+      "noActiveAlerts": "No active alerts",
+      "deviceStatusUnavailable": "Device status unavailable — fleet coverage can't be confirmed."
     },
     "customizer": {
       "title": "Dashboard Customizer",
@@ -353,7 +357,11 @@
       "kevCves_other": "{{count}} CVEs",
       "kevDevices": "{{count}} devices",
       "kevDevices_one": "{{count}} device",
-      "kevDevices_other": "{{count}} devices"
+      "kevDevices_other": "{{count}} devices",
+      "noDevicesTitle": "No devices reporting yet",
+      "noDevicesHint": "Enroll a device to start scanning for vulnerabilities.",
+      "noneReported": "No open findings reported",
+      "coverageUnknown": "Device status unavailable — scan coverage can't be confirmed."
     },
     "refreshFailed": "Couldn't refresh — showing older data"
   },

--- a/apps/web/src/locales/es-419/common.json
+++ b/apps/web/src/locales/es-419/common.json
@@ -252,7 +252,11 @@
       "viewAll": "Ver todo",
       "allClear": "Todo claro",
       "empty": "No hay alertas activas en toda su flota",
-      "fallbackTitle": "Alerta"
+      "fallbackTitle": "Alerta",
+      "noDevicesTitle": "Aún no hay dispositivos reportando",
+      "noDevicesHint": "Las alertas aparecerán cuando se inscriba un dispositivo.",
+      "noActiveAlerts": "Sin alertas activas",
+      "deviceStatusUnavailable": "Estado de dispositivos no disponible: no se puede confirmar la cobertura de la flota."
     },
     "customizer": {
       "title": "Personalizador de panel",
@@ -353,7 +357,11 @@
       "kevCves_other": "{{count}} CVE",
       "kevDevices": "{{count}} dispositivos",
       "kevDevices_one": "{{count}} dispositivo",
-      "kevDevices_other": "{{count}} dispositivos"
+      "kevDevices_other": "{{count}} dispositivos",
+      "noDevicesTitle": "Aún no hay dispositivos reportando",
+      "noDevicesHint": "Inscribe un dispositivo para comenzar a buscar vulnerabilidades.",
+      "noneReported": "No se reportaron hallazgos abiertos",
+      "coverageUnknown": "Estado de dispositivos no disponible: no se puede confirmar la cobertura del análisis."
     },
     "refreshFailed": "No se pudo actualizar — mostrando datos anteriores"
   },

--- a/apps/web/src/locales/fr-CA/common.json
+++ b/apps/web/src/locales/fr-CA/common.json
@@ -252,7 +252,11 @@
       "viewAll": "Voir tout",
       "allClear": "Tout est clair",
       "empty": "Aucune alerte active dans votre flotte",
-      "fallbackTitle": "Alerte"
+      "fallbackTitle": "Alerte",
+      "noDevicesTitle": "Aucun appareil ne transmet encore de données",
+      "noDevicesHint": "Les alertes s'afficheront dès qu'un appareil sera inscrit.",
+      "noActiveAlerts": "Aucune alerte active",
+      "deviceStatusUnavailable": "État des appareils indisponible : impossible de confirmer la couverture du parc."
     },
     "customizer": {
       "title": "Customizer de tableau de bord",
@@ -353,7 +357,11 @@
       "kevCves_other": "{{count}} CVE",
       "kevDevices": "{{count}} appareils",
       "kevDevices_one": "{{count}} appareil",
-      "kevDevices_other": "{{count}} appareils"
+      "kevDevices_other": "{{count}} appareils",
+      "noDevicesTitle": "Aucun appareil ne transmet encore de données",
+      "noDevicesHint": "Inscrivez un appareil pour lancer la recherche de vulnérabilités.",
+      "noneReported": "Aucune vulnérabilité ouverte signalée",
+      "coverageUnknown": "État des appareils indisponible : impossible de confirmer la couverture de l'analyse."
     },
     "refreshFailed": "Impossible d'actualiser — affichage de données plus anciennes"
   },

--- a/apps/web/src/locales/fr-FR/common.json
+++ b/apps/web/src/locales/fr-FR/common.json
@@ -252,7 +252,11 @@
       "viewAll": "Voir tout",
       "allClear": "Tout est clair",
       "empty": "Aucune alerte active dans votre flotte",
-      "fallbackTitle": "Alerte"
+      "fallbackTitle": "Alerte",
+      "noDevicesTitle": "Aucun appareil ne remonte encore de données",
+      "noDevicesHint": "Les alertes apparaîtront une fois qu'un appareil aura été inscrit.",
+      "noActiveAlerts": "Aucune alerte active",
+      "deviceStatusUnavailable": "État des appareils indisponible : la couverture du parc ne peut pas être confirmée."
     },
     "customizer": {
       "title": "Customizer de tableau de bord",
@@ -353,7 +357,11 @@
       "kevCves_other": "{{count}} CVE",
       "kevDevices": "{{count}} appareils",
       "kevDevices_one": "{{count}} appareil",
-      "kevDevices_other": "{{count}} appareils"
+      "kevDevices_other": "{{count}} appareils",
+      "noDevicesTitle": "Aucun appareil ne remonte encore de données",
+      "noDevicesHint": "Inscrivez un appareil pour démarrer la recherche de vulnérabilités.",
+      "noneReported": "Aucune vulnérabilité ouverte signalée",
+      "coverageUnknown": "État des appareils indisponible : la couverture de l'analyse ne peut pas être confirmée."
     },
     "refreshFailed": "Actualisation impossible — données plus anciennes affichées"
   },

--- a/apps/web/src/locales/it-IT/common.json
+++ b/apps/web/src/locales/it-IT/common.json
@@ -252,7 +252,11 @@
       "viewAll": "Visualizza tutto",
       "allClear": "Tutto chiaro",
       "empty": "Nessun avviso attivo nella tua flotta",
-      "fallbackTitle": "Avviso"
+      "fallbackTitle": "Avviso",
+      "noDevicesTitle": "Nessun dispositivo sta ancora inviando dati",
+      "noDevicesHint": "Gli avvisi compariranno una volta registrato un dispositivo.",
+      "noActiveAlerts": "Nessun avviso attivo",
+      "deviceStatusUnavailable": "Stato dei dispositivi non disponibile: impossibile confermare la copertura della flotta."
     },
     "customizer": {
       "title": "Personalizzazione del dashboard",
@@ -353,7 +357,11 @@
       "kevCves_other": "{{count}} CVE",
       "kevDevices": "{{count}} dispositivi",
       "kevDevices_one": "{{count}} dispositivo",
-      "kevDevices_other": "{{count}} dispositivi"
+      "kevDevices_other": "{{count}} dispositivi",
+      "noDevicesTitle": "Nessun dispositivo sta ancora inviando dati",
+      "noDevicesHint": "Registra un dispositivo per avviare la scansione delle vulnerabilità.",
+      "noneReported": "Nessun rilevamento aperto segnalato",
+      "coverageUnknown": "Stato dei dispositivi non disponibile: impossibile confermare la copertura della scansione."
     },
     "refreshFailed": "Aggiornamento non riuscito — vengono mostrati dati meno recenti"
   },

--- a/apps/web/src/locales/pt-BR/common.json
+++ b/apps/web/src/locales/pt-BR/common.json
@@ -252,7 +252,11 @@
       "viewAll": "Ver todos",
       "allClear": "Tudo certo",
       "empty": "Nenhum alerta ativo em sua frota",
-      "fallbackTitle": "Alerta"
+      "fallbackTitle": "Alerta",
+      "noDevicesTitle": "Nenhum dispositivo reportando ainda",
+      "noDevicesHint": "Os alertas aparecerão assim que um dispositivo for registrado.",
+      "noActiveAlerts": "Nenhum alerta ativo",
+      "deviceStatusUnavailable": "Status dos dispositivos indisponível: não é possível confirmar a cobertura da frota."
     },
     "customizer": {
       "title": "Personalizador do painel",
@@ -353,7 +357,11 @@
       "kevCves_other": "{{count}} CVEs",
       "kevDevices": "{{count}} dispositivos",
       "kevDevices_one": "{{count}} dispositivo",
-      "kevDevices_other": "{{count}} dispositivos"
+      "kevDevices_other": "{{count}} dispositivos",
+      "noDevicesTitle": "Nenhum dispositivo reportando ainda",
+      "noDevicesHint": "Registre um dispositivo para começar a verificar vulnerabilidades.",
+      "noneReported": "Nenhuma ocorrência aberta reportada",
+      "coverageUnknown": "Status dos dispositivos indisponível: não é possível confirmar a cobertura da varredura."
     },
     "refreshFailed": "Falha ao atualizar — exibindo dados mais antigos"
   },

--- a/apps/web/src/locales/tr-TR/common.json
+++ b/apps/web/src/locales/tr-TR/common.json
@@ -252,7 +252,11 @@
       "viewAll": "Tümünü görüntüle",
       "allClear": "Her şey temiz",
       "empty": "Filonuzda aktif uyarı yok",
-      "fallbackTitle": "Uyarı"
+      "fallbackTitle": "Uyarı",
+      "noDevicesTitle": "Henüz veri gönderen cihaz yok",
+      "noDevicesHint": "Bir cihaz kaydedildiğinde uyarılar burada görünecek.",
+      "noActiveAlerts": "Etkin uyarı yok",
+      "deviceStatusUnavailable": "Cihaz durumu kullanılamıyor: filo kapsamı doğrulanamıyor."
     },
     "customizer": {
       "title": "Kontrol Paneli Özelleştirici",
@@ -353,7 +357,11 @@
       "kevCves_other": "{{count}} CVE'ler",
       "kevDevices": "{{count}} cihazlar",
       "kevDevices_one": "{{count}} cihaz",
-      "kevDevices_other": "{{count}} cihazlar"
+      "kevDevices_other": "{{count}} cihazlar",
+      "noDevicesTitle": "Henüz veri gönderen cihaz yok",
+      "noDevicesHint": "Güvenlik açığı taramasını başlatmak için bir cihaz kaydedin.",
+      "noneReported": "Açık bulgu bildirilmedi",
+      "coverageUnknown": "Cihaz durumu kullanılamıyor: tarama kapsamı doğrulanamıyor."
     },
     "refreshFailed": "Yenilenemedi — eski veriler gösteriliyor"
   },


### PR DESCRIPTION
## Problem

Two dashboard cards rendered an affirmative health claim straight out of an empty result set, with no device gate:

- `AlertsFeed.tsx` — `rows.length === 0` → **"All clear / No active alerts across your fleet"**
- `VulnerabilitiesCard.tsx` — `totalFindings === 0` → **"No open vulnerabilities"**

With zero devices enrolled — what a brand-new partner sees immediately after login — those read identically to a scanned-and-clean fleet. "We looked and found nothing" and "we never looked" are opposite facts. The vulnerabilities one is the more dangerous of the two.

#3536 fixed the same class of bug on the Alerts page; `SecurityPostureCard.tsx:65` already gates on `totalDevices === 0`. This applies that shape to the two cards that still lacked it.

## Change

**`fleetPresence.ts` (new)** — one shared classifier over the existing `/devices/stats` dashboard query, so every rollup card resolves the denominator the same way rather than each re-deriving it:

| state | meaning |
|---|---|
| `present` | ≥1 device enrolled — an aggregate of zero is a real finding |
| `none` | zero devices — the aggregate means nothing |
| `loading` | count not settled; render neutral rather than flash a claim that may be retracted |
| `unknown` | `/devices/stats` failed or is 403/404-hidden; coverage unprovable |

A cached count wins over an in-flight *or* failed background poll — a transient poll failure shouldn't downgrade a known-good denominator to "unknown".

**`AlertsFeed`** and **`VulnerabilitiesCard`** now take the devices query and only render the green all-clear on `present`. The other three states render honestly: an enrollment-oriented empty state on `none`, a neutral skeleton on `loading`, and — on `unknown` — the one fact we actually have ("no active alerts" / "no open findings reported") next to an explicit note that coverage can't be confirmed. Non-empty rendering paths are untouched.

**Sweep** (the issue asked for one rather than two one-liners): the other rollup cards were checked and are already correct — `SecurityPostureCard` gates on `totalDevices`, `PatchComplianceCard` on `hasAnyPatchData`, `FleetStatusCard` returns null at `total === 0`, and `KpiStrip` already swaps in an enroll-your-first-device CTA. `RecentActivity`'s "No activity yet" is not a health claim. No other affirmative copy needs gating.

## Tests

`apps/web/src/components/dashboard/zeroDeviceClaims.test.tsx` — 14 cases: the classifier's five inputs plus the cached-count precedence rule, and for **each** card all four presence states, asserting the all-clear copy is *absent* in three of them and still present in the fourth. Plus a case per card proving the populated path is unaffected.

- `vitest run src/components/dashboard/` → 19 passed (2 files)
- i18n contract suites (localeParity, keyUsage, translationCoverage, extractionQuality, terminologyQuality) → 81 passed
- `tsc --noEmit` → clean

New keys are translated (not English placeholders) across all eight locales.

Closes #3613

🤖 Generated with [Claude Code](https://claude.com/claude-code)