### PR TITLE
fix(web,api): don't report inbound email as unconfigured on the M365-only path (#3598)

### DIFF
--- a/apps/api/src/services/ticketConfigService.test.ts
+++ b/apps/api/src/services/ticketConfigService.test.ts
@@ -153,6 +153,12 @@ vi.mock('../db/schema/portal', () => ({
 const { configRef } = vi.hoisted(() => ({ configRef: { current: { TICKETS_INBOUND_DOMAIN: 'tickets.example.com' as string | undefined } } }));
 vi.mock('../config/validate', () => ({ getConfig: () => configRef.current }));
 
+// The M365 mailbox count is a separate partner-scoped query (#3598); mock it so
+// the inbound tests stay on ticketConfigService's own FIFO of select results.
+// countConnectedMailboxes' own filtering is covered in connectionService.test.ts.
+const { countConnectedMailboxesMock } = vi.hoisted(() => ({ countConnectedMailboxesMock: vi.fn(async () => 0) }));
+vi.mock('./ticketMailbox/connectionService', () => ({ countConnectedMailboxes: countConnectedMailboxesMock }));
+
 // createTicket lives in ./ticketService — mock it so convert doesn't hit the
 // real ticket-creation service (DB inserts, event emission, SLA resolution).
 const { createTicketMock } = vi.hoisted(() => ({ createTicketMock: vi.fn() }));
@@ -182,6 +188,8 @@ beforeEach(() => {
   dbMocks.insertErrors.length = 0;
   dbMocks.insertResult = [];
   dbMocks.updateResult = [];
+  countConnectedMailboxesMock.mockClear();
+  countConnectedMailboxesMock.mockResolvedValue(0);
 });
 
 // Recursively flatten a predicate sentinel (eq/inArray/and) into its leaf clauses.
@@ -303,6 +311,22 @@ describe('getTicketConfig inbound block', () => {
       if (prev === undefined) delete process.env.IS_HOSTED;
       else process.env.IS_HOSTED = prev;
     }
+  });
+  // #3598: an M365-only partner has no inbound domain by design. The card needs
+  // the mailbox count to tell that apart from "nothing is configured".
+  it('reports connectedMailboxCount for the partner alongside domainConfigured=false', async () => {
+    configRef.current.TICKETS_INBOUND_DOMAIN = undefined;
+    countConnectedMailboxesMock.mockResolvedValue(2);
+    enqueueForInbound({ slug: 'acme', settings: {} });
+    const cfg = await getTicketConfig(PARTNER);
+    expect(cfg.inbound.domainConfigured).toBe(false);
+    expect(cfg.inbound.connectedMailboxCount).toBe(2);
+    expect(countConnectedMailboxesMock).toHaveBeenCalledWith(PARTNER);
+  });
+  it('reports connectedMailboxCount=0 when no mailbox is connected', async () => {
+    enqueueForInbound({ slug: 'acme', settings: {} });
+    const cfg = await getTicketConfig(PARTNER);
+    expect(cfg.inbound.connectedMailboxCount).toBe(0);
   });
   it('defaults unknownSenderMode=quarantine and dropUnverifiedSenders=false when absent', async () => {
     enqueueForInbound({ slug: 'acme', settings: {} });

--- a/apps/api/src/services/ticketConfigService.ts
+++ b/apps/api/src/services/ticketConfigService.ts
@@ -8,6 +8,7 @@ import { isHosted } from '../config/env';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { createTicket, type TicketActor } from './ticketService';
 import { isPgUniqueViolation } from '../utils/pgErrors';
+import { countConnectedMailboxes } from './ticketMailbox/connectionService';
 import type {
   CreateTicketStatusInput, UpdateTicketStatusInput, PrioritySettingsInput,
   OrgTicketSettingsInput, TicketPriorityValue,
@@ -337,7 +338,8 @@ async function readPriorities(partnerId: string): Promise<Record<TicketPriorityV
  * Full partner ticketing configuration: every custom + system status (ordered),
  * the merged per-priority SLA settings (nulls where unset), and the inbound-email
  * block (resolved address + override, enabled/autoresponder flags, defaultTriageOrgId,
- * slug, and whether TICKETS_INBOUND_DOMAIN is configured).
+ * slug, whether TICKETS_INBOUND_DOMAIN is configured, and how many M365
+ * mailboxes are connected — the second, domain-free inbound path).
  */
 export async function getTicketConfig(partnerId: string) {
   const statuses = await db
@@ -378,6 +380,14 @@ export async function getTicketConfig(partnerId: string) {
   const derived = domainConfigured && effectiveLocalPart ? `${effectiveLocalPart}@${domain}` : '';
   const addressOverride = (inboundCfg.address && inboundCfg.address.length > 0) ? inboundCfg.address : null;
 
+  // The M365 shared-mailbox path needs no inbound domain, no MX records and no
+  // Mailgun account, so `domainConfigured` alone can't answer "can this partner
+  // receive email as tickets at all?" — a partner running only M365 was being
+  // told their setup was broken (issue #3598). Count the mailboxes that are
+  // actually polling so the card can distinguish "no native address" from
+  // "no inbound path at all".
+  const connectedMailboxCount = await countConnectedMailboxes(partnerId);
+
   // Resolve the 3-way unknown-sender mode with the same back-compat rule as
   // loadPartnerInboundPolicy: explicit mode wins, else the legacy boolean maps
   // true→'triage', else 'quarantine'. `triageUnknownSenders` is still emitted
@@ -407,6 +417,7 @@ export async function getTicketConfig(partnerId: string) {
     slug,
     inboundLocalPart,
     domainConfigured,
+    connectedMailboxCount,
     // Lets the Inbound email card branch its "no domain configured" copy: on
     // hosted the reader can only escalate to us, but on self-host the reader IS
     // the operator and needs the variable name (issue #3599). Read at call time

--- a/apps/api/src/services/ticketMailbox/connectionService.test.ts
+++ b/apps/api/src/services/ticketMailbox/connectionService.test.ts
@@ -122,6 +122,7 @@ vi.stubGlobal('fetch', fetchMock);
 import { ticketMailboxConnections, ticketMailboxTenantOwnerships } from '../../db/schema/ticketMailbox';
 import {
   bindVerifiedTenant,
+  countConnectedMailboxes,
   createPendingConnection,
   disableConnection,
   isConnectedMailboxSnapshotCurrent,
@@ -423,6 +424,28 @@ describe('ticket mailbox connection service', () => {
     expect(Object.keys(dbMocks.selectedFields[0] ?? {})).toEqual([
       'id', 'mailboxAddress', 'displayName', 'status', 'lastPolledAt', 'lastMessageAt',
     ]);
+  });
+
+  // #3598: the inbound-email card uses this count to tell "no native address"
+  // apart from "no inbound path at all". A count that ignored `status` would
+  // report a pending/errored mailbox as a working path.
+  it('counts only connected mailboxes, filtered by partner AND status', async () => {
+    dbMocks.selectResults.push([{ id: CONNECTION_ID }, { id: OTHER_PARTNER_ID }]);
+
+    await expect(countConnectedMailboxes(PARTNER_ID)).resolves.toBe(2);
+
+    expect(dbMocks.selectWheres.at(-1)).toEqual({
+      op: 'and',
+      conditions: [
+        { op: 'eq', column: ticketMailboxConnections.partnerId, value: PARTNER_ID },
+        { op: 'eq', column: ticketMailboxConnections.status, value: 'connected' },
+      ],
+    });
+  });
+
+  it('returns 0 when the partner has no connected mailboxes', async () => {
+    dbMocks.selectResults.push([]);
+    await expect(countConnectedMailboxes(PARTNER_ID)).resolves.toBe(0);
   });
 
   it('only lists active mailboxes whose tenant ownership matches both tenant and partner', async () => {

--- a/apps/api/src/services/ticketMailbox/connectionService.ts
+++ b/apps/api/src/services/ticketMailbox/connectionService.ts
@@ -77,9 +77,12 @@ export async function listMailboxConnections(partnerId: string): Promise<Mailbox
  * How many M365 mailboxes this partner actually receives mail through.
  * `connected` is the only status that polls (see listConnectedMailboxes) — a
  * pending/error/disabled row is NOT a working inbound path, so it must not
- * count as one. Runs in the caller's request DB context: an org-scoped reader
- * sees no partner rows and gets 0, which degrades to the "not configured"
- * copy rather than a false "you're all set".
+ * count as one. Runs in the caller's request DB context (like
+ * listMailboxConnections) and leans on the table's breeze_has_partner_access
+ * policy, so only a partner- or system-scoped caller sees rows. Its one caller,
+ * getTicketConfig, is reachable only behind requireScope('partner','system') —
+ * do NOT call it from an org-scoped path, where RLS returns 0 and would
+ * silently understate a working inbound setup.
  */
 export async function countConnectedMailboxes(partnerId: string): Promise<number> {
   const rows = await db.select({ id: ticketMailboxConnections.id })

--- a/apps/api/src/services/ticketMailbox/connectionService.ts
+++ b/apps/api/src/services/ticketMailbox/connectionService.ts
@@ -73,6 +73,24 @@ export async function listMailboxConnections(partnerId: string): Promise<Mailbox
   }));
 }
 
+/**
+ * How many M365 mailboxes this partner actually receives mail through.
+ * `connected` is the only status that polls (see listConnectedMailboxes) — a
+ * pending/error/disabled row is NOT a working inbound path, so it must not
+ * count as one. Runs in the caller's request DB context: an org-scoped reader
+ * sees no partner rows and gets 0, which degrades to the "not configured"
+ * copy rather than a false "you're all set".
+ */
+export async function countConnectedMailboxes(partnerId: string): Promise<number> {
+  const rows = await db.select({ id: ticketMailboxConnections.id })
+    .from(ticketMailboxConnections)
+    .where(and(
+      eq(ticketMailboxConnections.partnerId, partnerId),
+      eq(ticketMailboxConnections.status, 'connected'),
+    ));
+  return rows.length;
+}
+
 /** System-context read across all partners — used by the poll worker (Plan 2). */
 export async function listConnectedMailboxes(): Promise<ConnectedMailbox[]> {
   return runOutsideDbContext(() => withSystemDbAccessContext(async () => {

--- a/apps/web/src/components/settings/InboundEmailCard.test.tsx
+++ b/apps/web/src/components/settings/InboundEmailCard.test.tsx
@@ -36,6 +36,7 @@ interface CfgShape {
   autoresponseBody: string | null;
   slug: string;
   domainConfigured: boolean;
+  connectedMailboxCount?: number;
   isHosted?: boolean;
 }
 
@@ -210,6 +211,38 @@ describe('InboundEmailCard', () => {
       'https://docs.breezermm.com/deploy/environment/#inbound-email-to-ticket-mailgun',
     );
     expect(link.getAttribute('rel')).toContain('noopener');
+  });
+
+  // #3598: an operator running ONLY the M365 mailbox path needs no inbound
+  // domain — the amber "isn't configured" error told them their working setup
+  // was broken. Only the native address is missing; say that instead.
+  it.each([undefined, false] as const)(
+    'suppresses the unconfigured error when a mailbox is connected (isHosted=%s)',
+    async (isHosted) => {
+      routeFetch({ ...CFG, address: '', domainConfigured: false, connectedMailboxCount: 1, isHosted });
+      render(<InboundEmailCard />);
+      const hint = await screen.findByTestId('inbound-address-via-mailbox');
+      expect(hint.textContent).toContain('Microsoft 365');
+      expect(screen.queryByTestId('inbound-address-unconfigured')).toBeNull();
+      expect(screen.queryByTestId('inbound-address-unconfigured-docs')).toBeNull();
+    },
+  );
+
+  it('still shows the unconfigured error when no mailbox is connected', async () => {
+    routeFetch({ ...CFG, address: '', domainConfigured: false, connectedMailboxCount: 0 });
+    render(<InboundEmailCard />);
+    expect(await screen.findByTestId('inbound-address-unconfigured')).toBeTruthy();
+    expect(screen.queryByTestId('inbound-address-via-mailbox')).toBeNull();
+  });
+
+  // A connected mailbox must not hide the native address editor — both paths
+  // can run at once, and the local part is still editable.
+  it('keeps the native address editor when the domain IS configured and a mailbox is connected', async () => {
+    routeFetch({ ...CFG, connectedMailboxCount: 1 });
+    render(<InboundEmailCard />);
+    expect(await screen.findByTestId('inbound-localpart')).toBeTruthy();
+    expect(screen.queryByTestId('inbound-address-via-mailbox')).toBeNull();
+    expect(screen.queryByTestId('inbound-address-unconfigured')).toBeNull();
   });
 
   it.each([true, undefined])(

--- a/apps/web/src/components/settings/InboundEmailCard.tsx
+++ b/apps/web/src/components/settings/InboundEmailCard.tsx
@@ -38,6 +38,9 @@ interface InboundConfig {
   autoresponseBody: string | null;
   slug: string;
   domainConfigured: boolean;
+  // Connected M365 shared mailboxes (status 'connected'). Absent on an older
+  // API → 0 → the card behaves exactly as it did before this field existed.
+  connectedMailboxCount?: number;
   // Mirrors the API's IS_HOSTED. Absent (older API) is treated as hosted so we
   // don't show a self-host-only variable name to a hosted partner.
   isHosted?: boolean;
@@ -282,6 +285,14 @@ export default function InboundEmailCard() {
                 {t('common:actions.copy')}
               </button>
             </div>
+          ) : (cfg.connectedMailboxCount ?? 0) > 0 ? (
+            // Only the NATIVE address is missing — mail is still arriving via the
+            // connected M365 mailbox(es) listed in the card below, which need no
+            // inbound domain. Rendering the amber "not configured" error here told
+            // M365-only operators their working setup was broken (#3598).
+            <p className="mt-0.5 text-xs text-muted-foreground" data-testid="inbound-address-via-mailbox">
+              {t('inboundEmail.addressViaMailbox')}
+            </p>
           ) : (
             <p className="mt-0.5 text-xs text-amber-600" data-testid="inbound-address-unconfigured">
               {cfg.isHosted === false ? (

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -597,6 +597,7 @@
     "localPart": "Lokaler Teil der eingehenden Adresse",
     "domainNotConfigured": "Die Plattform-Eingangsdomäne ist noch nicht konfiguriert. Kontaktieren Sie Ihren Administrator.",
     "domainNotConfiguredSelfHosted": "Es ist keine Plattform-Eingangsdomäne konfiguriert, daher kann keine Eingangsadresse erzeugt werden. Setzen Sie <var>TICKETS_INBOUND_DOMAIN</var> auf Ihrem Breeze-Server und starten Sie die API neu — siehe <docs>Einrichtung von E-Mail-zu-Ticket</docs>. Alternativ können Sie ein freigegebenes Microsoft 365-Postfach verbinden — dieser Weg benötigt keine Eingangsdomäne.",
+    "addressViaMailbox": "Es ist keine native Eingangsadresse konfiguriert, E-Mails treffen aber weiterhin über Ihr unten verbundenes Microsoft 365-Postfach ein – dieser Weg benötigt keine Eingangsdomäne.",
     "triageOrganization": "Standard-Triage-Organisation",
     "unknownSenders": "Unbekannte Absender",
     "unknownDescription": "Was tun mit E-Mails, deren Absender kein Portalbenutzer, keine zugeordnete Kundendomäne oder eine Antwort auf ein vorhandenes Ticket ist?",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -597,6 +597,7 @@
     "localPart": "Inbound address local part",
     "domainNotConfigured": "The platform inbound domain isn't configured yet. Contact your administrator.",
     "domainNotConfiguredSelfHosted": "No platform inbound domain is configured, so an inbound address can't be generated. Set <var>TICKETS_INBOUND_DOMAIN</var> on your Breeze server and restart the API — see <docs>Inbound email-to-ticket setup</docs>. Alternatively, connect a Microsoft 365 shared mailbox — that path needs no inbound domain.",
+    "addressViaMailbox": "No native inbound address is configured, but email is still arriving through your connected Microsoft 365 mailbox below — that path needs no inbound domain.",
     "triageOrganization": "Default triage organization",
     "unknownSenders": "Unknown senders",
     "unknownDescription": "What to do with mail whose sender isn't a portal user, a mapped customer domain, or a reply to an existing ticket.",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -597,6 +597,7 @@
     "localPart": "Parte local de dirección entrante",
     "domainNotConfigured": "El dominio entrante de la plataforma aún no está configurado. Póngase en contacto con su administrador.",
     "domainNotConfiguredSelfHosted": "No hay ningún dominio entrante de la plataforma configurado, por lo que no se puede generar una dirección entrante. Configure <var>TICKETS_INBOUND_DOMAIN</var> en su servidor Breeze y reinicie la API — consulte <docs>Configuración de correo electrónico a ticket</docs>. Como alternativa, conecte un buzón compartido de Microsoft 365 — esa vía no necesita dominio entrante.",
+    "addressViaMailbox": "No hay una dirección de entrada nativa configurada, pero el correo sigue llegando a través del buzón de Microsoft 365 conectado que aparece abajo: esa vía no necesita un dominio entrante.",
     "triageOrganization": "Organización de clasificación predeterminada",
     "unknownSenders": "Remitentes desconocidos",
     "unknownDescription": "Qué hacer con el correo cuyo remitente no es un usuario del portal, un dominio de cliente asignado o una respuesta a un ticket existente.",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -597,6 +597,7 @@
     "localPart": "Adresse entrante : partie locale",
     "domainNotConfigured": "Le domaine entrant de la plateforme n’est pas encore configuré. Contactez votre administrateur.",
     "domainNotConfiguredSelfHosted": "Aucun domaine entrant de la plateforme n’est configuré, donc aucune adresse entrante ne peut être générée. Définissez <var>TICKETS_INBOUND_DOMAIN</var> sur votre serveur Breeze et redémarrez l’API — voir <docs>Configuration du courriel vers ticket</docs>. Vous pouvez aussi connecter une boîte aux lettres partagée Microsoft 365 — cette voie ne nécessite aucun domaine entrant.",
+    "addressViaMailbox": "Aucune adresse entrante native n’est configurée, mais les courriels arrivent toujours par la boîte aux lettres Microsoft 365 connectée ci-dessous — cette voie n’a besoin d’aucun domaine entrant.",
     "triageOrganization": "Organisation par défaut du triage",
     "unknownSenders": "Expéditeurs inconnus",
     "unknownDescription": "Que faire avec un courrier dont l’expéditeur n’est pas un utilisateur du portail, un domaine client mappé, ou une réponse à un billet existant ?",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -597,6 +597,7 @@
     "localPart": "Adresse entrante : partie locale",
     "domainNotConfigured": "Le domaine entrant de la plateforme n’est pas encore configuré. Contactez votre administrateur.",
     "domainNotConfiguredSelfHosted": "Aucun domaine entrant de la plateforme n’est configuré, donc aucune adresse entrante ne peut être générée. Définissez <var>TICKETS_INBOUND_DOMAIN</var> sur votre serveur Breeze et redémarrez l’API — voir <docs>Configuration de l’e-mail vers ticket</docs>. Vous pouvez aussi connecter une boîte aux lettres partagée Microsoft 365 — cette voie ne nécessite aucun domaine entrant.",
+    "addressViaMailbox": "Aucune adresse entrante native n’est configurée, mais les e-mails arrivent toujours par la boîte aux lettres Microsoft 365 connectée ci-dessous — cette voie ne nécessite aucun domaine entrant.",
     "triageOrganization": "Organisation par défaut du triage",
     "unknownSenders": "Expéditeurs inconnus",
     "unknownDescription": "Que faire avec un courrier dont l’expéditeur n’est pas un utilisateur du portail, un domaine client mappé, ou une réponse à un ticket existant ?",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -597,6 +597,7 @@
     "localPart": "Parte locale dell'indirizzo in ingresso",
     "domainNotConfigured": "Il dominio in ingresso della piattaforma non è ancora configurato. Contatta l'amministratore.",
     "domainNotConfiguredSelfHosted": "Non è configurato alcun dominio in ingresso della piattaforma, quindi non è possibile generare un indirizzo in ingresso. Imposta <var>TICKETS_INBOUND_DOMAIN</var> sul tuo server Breeze e riavvia l'API — vedi <docs>Configurazione da e-mail a ticket</docs>. In alternativa, collega una cassetta postale condivisa Microsoft 365 — questo percorso non richiede alcun dominio in ingresso.",
+    "addressViaMailbox": "Nessun indirizzo in ingresso nativo è configurato, ma le email continuano ad arrivare tramite la casella di posta Microsoft 365 collegata qui sotto: quel percorso non richiede un dominio in ingresso.",
     "triageOrganization": "Organizzazione di triage predefinita",
     "unknownSenders": "Mittenti sconosciuti",
     "unknownDescription": "Cosa fare con email il cui mittente non è un utente del portale, un dominio cliente mappato o una risposta a un ticket esistente.",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -597,6 +597,7 @@
     "localPart": "Parte local do endereço de entrada",
     "domainNotConfigured": "O domínio de entrada da plataforma ainda não está configurado. Entre em contato com o administrador.",
     "domainNotConfiguredSelfHosted": "Nenhum domínio de entrada da plataforma está configurado, portanto não é possível gerar um endereço de entrada. Defina <var>TICKETS_INBOUND_DOMAIN</var> no seu servidor Breeze e reinicie a API — consulte <docs>Configuração de e-mail para ticket</docs>. Como alternativa, conecte uma caixa de correio compartilhada do Microsoft 365 — esse caminho não precisa de domínio de entrada.",
+    "addressViaMailbox": "Nenhum endereço de entrada nativo está configurado, mas os e-mails continuam chegando pela caixa de correio do Microsoft 365 conectada abaixo — esse caminho não precisa de um domínio de entrada.",
     "triageOrganization": "Organização de triagem padrão",
     "unknownSenders": "Remetentes desconhecidos",
     "unknownDescription": "O que fazer com mensagens cujo remetente não é usuário do portal, domínio de cliente mapeado nem resposta a um chamado existente.",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -597,6 +597,7 @@
     "localPart": "Gelen adresin yerel kısmı",
     "domainNotConfigured": "Platform gelen etki alanı henüz yapılandırılmadı. Yöneticinizle iletişime geçin.",
     "domainNotConfiguredSelfHosted": "Platform gelen etki alanı yapılandırılmadığı için gelen adres oluşturulamıyor. Breeze sunucunuzda <var>TICKETS_INBOUND_DOMAIN</var> değerini ayarlayın ve API'yi yeniden başlatın — bkz. <docs>E-postadan talebe kurulumu</docs>. Alternatif olarak, bir Microsoft 365 paylaşılan posta kutusu bağlayabilirsiniz — bu yol gelen etki alanı gerektirmez.",
+    "addressViaMailbox": "Yerel bir gelen adres yapılandırılmadı, ancak e-postalar aşağıdaki bağlı Microsoft 365 posta kutusu üzerinden gelmeye devam ediyor — bu yol için gelen etki alanı gerekmez.",
     "triageOrganization": "Varsayılan triyaj organizasyonu",
     "unknownSenders": "Bilinmeyen gönderenler",
     "unknownDescription": "Göndereni portal kullanıcısı olmayan, eşlenen müşteri alanı olmayan veya mevcut bir destek bildirimine yanıt olmayan postalarla ne yapılmalı?",


### PR DESCRIPTION
## Problem

`domainConfigured` is derived purely from `TICKETS_INBOUND_DOMAIN`, so the Inbound email card told every partner running **only** the Microsoft 365 shared-mailbox path that "the platform inbound domain isn't configured" — on a setup that is complete and actively ingesting mail. That path needs no inbound domain, no MX records and no Mailgun account. It's how the original Discord reporter concluded email-to-ticket was M365-only and still broken.

## Fix

The card was answering two questions with one boolean. Split them:

- **API** — `getTicketConfig` now also returns `connectedMailboxCount`, backed by a new partner-scoped `countConnectedMailboxes()` in `ticketMailbox/connectionService.ts`. It counts only `status = 'connected'` rows: a `pending_consent`/`error`/`reauth_required`/`disabled` mailbox is *not* a working inbound path and must not read as one. `domainConfigured` keeps its exact meaning (is there a native Mailgun address) — no behaviour change for the Mailgun path.
- **Web** — the "no native address" slot now renders a neutral note pointing at the connected-mailbox card directly below when `connectedMailboxCount > 0`, and keeps the existing amber error (both the hosted and the self-hosted #3599 variants) only when neither path is configured. Both paths can run at once: when the domain *is* configured the native address editor renders unchanged regardless of mailboxes.

Back-compat: the field is optional on the web side, so an older API that omits it reads as 0 and the card behaves exactly as before.

New i18n key `settings:inboundEmail.addressViaMailbox` added to all 8 locales.

## Tests

- `apps/api/src/services/ticketMailbox/connectionService.test.ts` — count filters on partner **and** `status='connected'` (asserts the actual where-predicate, not just the row count), and 0 when none.
- `apps/api/src/services/ticketConfigService.test.ts` — `connectedMailboxCount` surfaces in the inbound block alongside `domainConfigured=false`, and is 0 when no mailbox is connected.
- `apps/web/src/components/settings/InboundEmailCard.test.tsx` — error suppressed with a connected mailbox (hosted + self-hosted), error still shown with none, native editor untouched when the domain is configured.

Green: `vitest run` on the three API suites (131 passed) and the card suite (18 passed); `src/lib/i18n` locale parity/coverage suites 105 passed; `tsc --noEmit` clean in `apps/api` and `apps/web`.

## Not in scope

The wording of the genuinely-unconfigured message is #3599 (already merged); this PR only decides *when* that message is shown.

Closes #3598

🤖 Generated with [Claude Code](https://claude.com/claude-code)