### PR TITLE
fix(api): read patch version through device_patches.available_version (#3648)

### DIFF
--- a/apps/api/src/routes/devices/software.ts
+++ b/apps/api/src/routes/devices/software.ts
@@ -76,7 +76,13 @@ softwareRoutes.get(
           .select({
             title: patches.title,
             packageId: patches.packageId,
-            version: patches.version,
+            // THIS device's agent-observed version, falling back to the global
+            // catalog. #3645 moved agent scan writes off the shared `patches`
+            // row (any tenant's agent could shift it), so `patches.version` now
+            // goes stale between vendor catalog refreshes. Same COALESCE the
+            // approval evaluator uses (patchApprovalEvaluator.ts) so the Update
+            // button and the enforcement path agree on one version.
+            version: sql<string | null>`COALESCE(${devicePatches.availableVersion}, ${patches.version})`,
             source: patches.source,
           })
           .from(devicePatches)

--- a/apps/api/src/services/vulnerabilityRemediation.ts
+++ b/apps/api/src/services/vulnerabilityRemediation.ts
@@ -137,7 +137,10 @@ async function thirdPartyCandidatesByProduct(
       patchId: patches.id,
       title: patches.title,
       packageId: patches.packageId,
-      version: patches.version,
+      // Device-observed version first (see #3645/#3648): the global catalog row
+      // is no longer refreshed by agent scans, so reading `patches.version`
+      // alone reports progressively staler versions for the matched update.
+      version: sql<string | null>`COALESCE(${devicePatches.availableVersion}, ${patches.version})`,
     })
     .from(patches)
     .innerJoin(devicePatches, and(


### PR DESCRIPTION
Closes #3648. Unblocked now that #3645 merged — you'd stopped on exactly that dependency guard, and it cleared about twenty minutes ago.

Both device-scoped readers now match `patchApprovalEvaluator`:

| file | surface |
|---|---|
| `routes/devices/software.ts` | third-party update annotation |
| `services/vulnerabilityRemediation.ts` | third-party candidate match |

Projection only — both files already import `sql` and already join `devicePatches`. No new joins, no `WHERE` change, no migration.

### Two precisions, because the shorthand in the issue implies more than it should

**"The two remaining readers" means the two *device-scoped* ones.** Two other production reads of bare `patches.version` exist and I left them alone deliberately: `jobs/cveEnrichmentWorker.ts:66` and `routes/patches/list.ts:117`. Neither has a device identity to prefer a per-device value from — the patch list is global, and CVE enrichment stores shared `cveIds`/severity for one patch row that different devices may observe at different versions. Converting those needs an aggregation decision, not a COALESCE.

**This aligns the version *source*, not the selected patch row.** For a given `(device_id, patch_id)` all three queries now compute the same expression. But the software index keeps the first row for a duplicate normalized title+packageId with no `ORDER BY`, remediation orders by `releaseDate DESC`, and the evaluator judges each pending patch independently — so two rows sharing a package ID can still surface differently across the three. Worth knowing before anyone reads this as "one agreed version everywhere."

No null regression: `patches.version` was **already** nullable, as is `available_version`, so the inferred and declared types are both `string | null`, and `buildUpdateIndex` / `annotateSoftwareRow` / the vulnerable-range filter already guard it.

On the backfill question — agreed, next scan cycle is fine. The fallback means a device with no `available_version` yet still reports the catalog value, so it degrades to today's behaviour rather than to null.

### Test coverage — the honest position

**There is no regression test, and I don't want that buried in a green checkmark.** All 493 passing tests in the touched suites would still pass after reverting both expressions. `tsc` proves the columns and types exist; it does not prove the emitted SQL contains both tables, that `available_version` wins when the two differ, or that the fallback works when it's null. That gap matters more than usual here, because the entire point of the change is to distinguish two conflicting non-null values.

Why I didn't just add one:

- `routes/devices/software.ts` has no route-level harness, and no integration test currently mounts that route — building one is real work, not a few lines.
- `thirdPartyCandidatesByProduct` is module-private, reachable only through `remediateVulnerabilities` after several intermediate queries. I tried asserting the projection through the existing hoisted `db` stub; reaching that branch means encoding the internal call order into the stub's per-table queue, which produces a test that can pass for the wrong reason. I deleted it rather than leave it in.

After the `lt`/`gt` lesson on #3630 I'd rather ship two verified lines with the gap named than something that looks like coverage. **Say the word and I'll build the real-Postgres case** — seed a `third_party` patch whose `available_version` differs from `patches.version`, assert the device value comes back — before this merges.

### Verification

node 22.23.2, pnpm 10.34.5:

- `tsc --noEmit` — 0 errors
- `routes/devices/` + `vulnerabilityRemediation` — **493/493**
- eslint on both changed files — clean
