### PR TITLE
fix(scripts): treat partner-wide name matches as bundle-import conflicts (#3450)

### DIFF
--- a/apps/api/src/services/scriptBundle/index.test.ts
+++ b/apps/api/src/services/scriptBundle/index.test.ts
@@ -485,6 +485,32 @@ describe('importBundle', () => {
     expect(h.state.updates).toHaveLength(0);
   });
 
+  it('isolates the partner-wide new-version refusal to its own entry — the rest of the bundle still imports', async () => {
+    const bundle = validBundle([baseEntry, { ...baseEntry, name: 'Unrelated script' }]);
+    h.state.selectQueue.push(
+      [], // entry 1: no org-owned match
+      [{ id: SCRIPT_ID, name: baseEntry.name, version: 4, content: 'DIFFERENT content' }],
+      [], // entry 2: no org-owned match
+      [] // entry 2: no partner-wide match either → imports normally
+    );
+    const result = await importBundle(makeAuth(), bundle, {
+      mode: 'new-version',
+      availability: 'org'
+    });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) {
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]!.index).toBe(0);
+      // The refusal must `continue`, not abort the loop.
+      expect(result.imported).toBe(1);
+      expect(result.scripts).toHaveLength(1);
+      expect(result.scripts[0]).toMatchObject({ index: 1, name: 'Unrelated script', action: 'imported' });
+    }
+    const scriptInserts = h.state.inserts.filter((i) => i.table === scripts);
+    expect(scriptInserts).toHaveLength(1);
+    expect((scriptInserts[0]!.values as Record<string, unknown>).name).toBe('Unrelated script');
+  });
+
   it('new-version mode treats an identical-content partner-wide match as a no-op skip', async () => {
     h.state.selectQueue.push(
       [],

--- a/apps/api/src/services/scriptBundle/index.test.ts
+++ b/apps/api/src/services/scriptBundle/index.test.ts
@@ -392,7 +392,8 @@ describe('importBundle', () => {
   it('resolves tags by name in the target scope: reuses existing, creates missing, links both', async () => {
     const bundle = validBundle([{ ...baseEntry, tags: ['printing', 'windows'] }]);
     h.state.selectQueue.push(
-      [], // findExistingByName → none
+      [], // findConflictByName → no org-owned match
+      [], // findConflictByName → no partner-wide match (#3450)
       [{ id: TAG_ID, name: 'printing' }] // ensureTagIds → 'printing' exists, 'windows' missing
     );
     const result = await importBundle(makeAuth(), bundle, { mode: 'skip', availability: 'org' });
@@ -438,10 +439,98 @@ describe('importBundle', () => {
     expect(h.state.updates).toHaveLength(0);
   });
 
+  // -------------------------------------------------------------------------
+  // #3450: partner-wide collisions on an org-target import.
+  // -------------------------------------------------------------------------
+  it('skip mode skips a partner-wide name match instead of creating a duplicate (#3450)', async () => {
+    h.state.selectQueue.push(
+      [], // no org-owned row
+      [{ id: SCRIPT_ID, name: baseEntry.name, version: 1, content: 'something else' }]
+    );
+    const result = await importBundle(makeAuth(), validBundle([baseEntry]), {
+      mode: 'skip',
+      availability: 'org'
+    });
+    expect('error' in result).toBe(false);
+    if ('skipped' in result) {
+      expect(result.skipped).toBe(1);
+      expect(result.imported).toBe(0);
+      expect(result.scripts[0]).toMatchObject({ action: 'skipped', scriptId: SCRIPT_ID });
+    }
+    // The whole point: no new scripts row.
+    expect(h.state.inserts.filter((i) => i.table === scripts)).toHaveLength(0);
+  });
+
+  it('new-version mode refuses to version a read-only partner-wide row, and does not duplicate it', async () => {
+    h.state.selectQueue.push(
+      [],
+      [{ id: SCRIPT_ID, name: baseEntry.name, version: 4, content: 'DIFFERENT content' }]
+    );
+    const result = await importBundle(makeAuth(), validBundle([baseEntry]), {
+      mode: 'new-version',
+      availability: 'org'
+    });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) {
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]!.name).toBe(baseEntry.name);
+      expect(result.errors[0]!.error).toContain('partner-wide');
+      expect(result.errors[0]!.error).toContain('read-only');
+      expect(result.imported).toBe(0);
+      expect(result.versioned).toBe(0);
+    }
+    // Neither a duplicate org row nor any mutation of the partner-wide row.
+    expect(h.state.inserts.filter((i) => i.table === scripts)).toHaveLength(0);
+    expect(h.state.inserts.filter((i) => i.table === scriptVersions)).toHaveLength(0);
+    expect(h.state.updates).toHaveLength(0);
+  });
+
+  it('new-version mode treats an identical-content partner-wide match as a no-op skip', async () => {
+    h.state.selectQueue.push(
+      [],
+      [{ id: SCRIPT_ID, name: baseEntry.name, version: 4, content: baseEntry.content }]
+    );
+    const result = await importBundle(makeAuth(), validBundle([baseEntry]), {
+      mode: 'new-version',
+      availability: 'org'
+    });
+    if ('skipped' in result) {
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toHaveLength(0);
+    }
+    expect(h.state.inserts.filter((i) => i.table === scripts)).toHaveLength(0);
+    expect(h.state.updates).toHaveLength(0);
+  });
+
+  it('rename mode picks a name free of BOTH the org and partner-wide namespaces', async () => {
+    h.state.selectQueue.push(
+      [], // no org-owned row
+      [{ id: SCRIPT_ID, name: baseEntry.name, version: 1, content: 'x' }], // partner-wide match
+      [{ name: `${baseEntry.name} (2)` }] // findFreeName: "(2)" already taken
+    );
+    const result = await importBundle(makeAuth(), validBundle([baseEntry]), {
+      mode: 'rename',
+      availability: 'org'
+    });
+    expect('error' in result).toBe(false);
+    if ('renamed' in result) {
+      expect(result.renamed).toBe(1);
+      expect(result.scripts[0]).toMatchObject({ action: 'renamed', finalName: `${baseEntry.name} (3)` });
+    }
+
+    // The free-name query must span both namespaces. For an ORG target,
+    // scopeCondition alone never mentions partner_id — so its presence here
+    // proves the partner-wide branch was OR'd in rather than the assertion
+    // passing on the org condition by accident.
+    const freeNameWhere = h.state.selectWheres[2];
+    expect(conditionMentionsColumn(freeNameWhere, 'partner_id')).toBe(true);
+    expect(conditionMentionsColumn(freeNameWhere, 'org_id')).toBe(true);
+  });
+
   it('conflict lookups exclude system-library rows, so a bundle can never update an is_system script', async () => {
     h.state.selectQueue.push([]);
     await importBundle(makeAuth(), validBundle([baseEntry]), { mode: 'new-version', availability: 'org' });
-    // The first SELECT is findExistingByName; its WHERE must filter on
+    // The first SELECT is findConflictByName; its WHERE must filter on
     // is_system (= false) so a system script sharing the name is never
     // matched — and therefore never rewritten by new-version mode.
     expect(h.state.selectWheres.length).toBeGreaterThan(0);
@@ -555,6 +644,75 @@ describe('previewBundle', () => {
     const auth = makeAuth({ scope: 'partner', orgId: null, partnerOrgAccess: 'selected' });
     const result = await previewBundle(auth, validBundle([baseEntry]), { availability: 'partner' });
     expect(result).toEqual({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE, status: 403 });
+  });
+
+  // -------------------------------------------------------------------------
+  // #3450: an org-target import collides with the caller's PARTNER-WIDE rows
+  // too. They are not writable here, but they render in the same library list,
+  // so annotating them 'new' is what produced visible same-name duplicates.
+  // -------------------------------------------------------------------------
+  it('flags a partner-wide name match as a conflict, not "new" (#3450)', async () => {
+    h.state.selectQueue.push(
+      [], // no org-owned row with this name
+      [{ id: SCRIPT_ID, name: baseEntry.name, version: 3 }] // ...but a partner-wide one exists
+    );
+    const result = await previewBundle(makeAuth(), validBundle([baseEntry]), { availability: 'org' });
+    expect('error' in result).toBe(false);
+    if ('entries' in result) {
+      expect(result.entries[0]).toMatchObject({
+        status: 'name-conflict',
+        conflictKind: 'partner-wide',
+        existingScriptId: SCRIPT_ID,
+        existingVersion: 3
+      });
+    }
+    expect(h.state.inserts).toHaveLength(0);
+    expect(h.state.updates).toHaveLength(0);
+  });
+
+  it('prefers the org-owned match over a partner-wide one and never queries for the latter', async () => {
+    h.state.selectQueue.push([{ id: SCRIPT_ID, name: baseEntry.name, version: 2 }]);
+    const result = await previewBundle(makeAuth(), validBundle([baseEntry]), { availability: 'org' });
+    if ('entries' in result) {
+      expect(result.entries[0]).toMatchObject({
+        status: 'name-conflict',
+        conflictKind: 'target-scope',
+        existingScriptId: SCRIPT_ID
+      });
+    }
+    // Only the owned lookup ran — the partner-wide lookup short-circuits, so a
+    // writable row is never shadowed by a read-only one.
+    expect(h.state.selectWheres).toHaveLength(1);
+  });
+
+  it('omits conflictKind entirely when the entry is new', async () => {
+    h.state.selectQueue.push([], []);
+    const result = await previewBundle(makeAuth(), validBundle([baseEntry]), { availability: 'org' });
+    if ('entries' in result) {
+      expect(result.entries[0]!.status).toBe('new');
+      expect(result.entries[0]).not.toHaveProperty('conflictKind');
+    }
+  });
+
+  it('does NOT run a partner-wide lookup when the target IS partner-wide (already in scope)', async () => {
+    const auth = makeAuth({ scope: 'partner', orgId: null, partnerOrgAccess: 'all' });
+    h.state.selectQueue.push([]);
+    const result = await previewBundle(auth, validBundle([baseEntry]), { availability: 'partner' });
+    expect('entries' in result).toBe(true);
+    // scopeCondition already targets (org_id IS NULL, partner_id = P); a second
+    // identical query would be pure waste.
+    expect(h.state.selectWheres).toHaveLength(1);
+  });
+
+  it('does NOT run a partner-wide lookup for a system-scope import (no partner context)', async () => {
+    const auth = makeAuth({ scope: 'system', orgId: null, partnerId: null, accessibleOrgIds: null });
+    h.state.selectQueue.push([]);
+    const result = await previewBundle(auth, validBundle([baseEntry]), {
+      availability: 'org',
+      orgId: ORG_ID
+    });
+    expect('entries' in result).toBe(true);
+    expect(h.state.selectWheres).toHaveLength(1);
   });
 });
 

--- a/apps/api/src/services/scriptBundle/index.ts
+++ b/apps/api/src/services/scriptBundle/index.ts
@@ -21,7 +21,7 @@
  *   the fact — which is why the route audits every imported script with the
  *   bundle's identity.
  */
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
 import { findVariableTokens } from '@breeze/shared';
 import { db } from '../../db';
 import { scripts, scriptTags, scriptToTags, scriptVersions, tenantVariables } from '../../db/schema';
@@ -216,21 +216,75 @@ function scopeCondition(scope: ScriptCreateScope) {
   );
 }
 
-function sameNameCondition(scope: ScriptCreateScope, name: string) {
-  return and(eq(scripts.name, name), scopeCondition(scope));
+/**
+ * Condition matching the caller's PARTNER-WIDE scripts when the import targets
+ * an ORG (#3450). These rows are not writable by an org-target import, but the
+ * scripts list renders partner-wide and org rows in one library, so a name that
+ * already exists partner-wide is a real collision from the operator's point of
+ * view — annotating it `new` and importing it anyway produces a visible
+ * same-name duplicate.
+ *
+ * Returns null when the target IS partner-wide (`scope.orgId` null — then
+ * {@link scopeCondition} already covers these rows) or when there is no partner
+ * context at all (system-scope import into a specific org).
+ *
+ * Gating is on the RESOLVED SCOPE, not `auth.scope`: organization-scope users
+ * legitimately SEE their MSP's partner-wide scripts — `resolveScriptCreateScope`
+ * carries `auth.partnerId` through for them, the list route unions on
+ * `partner_id`, and RLS grants the read via the own-partner SELECT branch
+ * (`2026-06-13-catalog-partner-read-branch.sql`). They just cannot WRITE them,
+ * which is exactly why this is a separate, read-only conflict class.
+ */
+function partnerWideConflictCondition(scope: ScriptCreateScope) {
+  if (!scope.orgId || !scope.partnerId) return null;
+  return and(
+    isNull(scripts.orgId),
+    eq(scripts.partnerId, scope.partnerId),
+    eq(scripts.isSystem, false),
+    isNull(scripts.deletedAt)
+  );
 }
 
-async function findExistingByName(scope: ScriptCreateScope, name: string) {
+/**
+ * How a bundle entry's name collided:
+ * - `target-scope` — a row the import OWNS and may rewrite (skip/rename/version).
+ * - `partner-wide` — a partner-wide row visible to the caller but READ-ONLY for
+ *   an org-target import (#3262). Never versioned, never rewritten.
+ */
+export type BundleConflictKind = 'target-scope' | 'partner-wide';
+
+export type BundleConflict = { row: ScriptRow; kind: BundleConflictKind };
+
+/**
+ * Resolve a name to the conflicting row, if any. A `target-scope` match always
+ * wins over a `partner-wide` one: when both exist the owned row is the thing
+ * the operator's chosen mode should act on, and versioning it is safe.
+ */
+async function findConflictByName(
+  scope: ScriptCreateScope,
+  name: string
+): Promise<BundleConflict | undefined> {
   // Duplicate names are not prevented by any unique index; order by creation
   // so a conflict deterministically resolves to the OLDEST matching row
   // instead of whichever row the query plan happens to return first.
-  const [existing] = await db
+  const [owned] = await db
     .select()
     .from(scripts)
-    .where(sameNameCondition(scope, name))
+    .where(and(eq(scripts.name, name), scopeCondition(scope)))
     .orderBy(scripts.createdAt)
     .limit(1);
-  return existing;
+  if (owned) return { row: owned, kind: 'target-scope' };
+
+  const partnerWide = partnerWideConflictCondition(scope);
+  if (!partnerWide) return undefined;
+
+  const [shared] = await db
+    .select()
+    .from(scripts)
+    .where(and(eq(scripts.name, name), partnerWide))
+    .orderBy(scripts.createdAt)
+    .limit(1);
+  return shared ? { row: shared, kind: 'partner-wide' } : undefined;
 }
 
 /**
@@ -250,6 +304,13 @@ export type BundlePreviewEntry = {
   index: number;
   name: string;
   status: 'new' | 'name-conflict' | 'invalid';
+  /**
+   * Present exactly when `status === 'name-conflict'` (#3450). Deliberately a
+   * refinement of the existing status rather than a new status value: a client
+   * older than this change still renders a generic conflict badge instead of
+   * falling through to "Invalid" on an unrecognised enum member.
+   */
+  conflictKind?: BundleConflictKind;
   error?: string;
   existingScriptId?: string;
   existingVersion?: number;
@@ -299,12 +360,18 @@ export async function previewBundle(
       entries.push({ index, name: parsed.name, status: 'invalid', error: parsed.error });
       continue;
     }
-    const existing = await findExistingByName(scope, parsed.entry.name);
+    const conflict = await findConflictByName(scope, parsed.entry.name);
     entries.push({
       index,
       name: parsed.entry.name,
-      status: existing ? 'name-conflict' : 'new',
-      ...(existing ? { existingScriptId: existing.id, existingVersion: existing.version } : {})
+      status: conflict ? 'name-conflict' : 'new',
+      ...(conflict
+        ? {
+            conflictKind: conflict.kind,
+            existingScriptId: conflict.row.id,
+            existingVersion: conflict.row.version
+          }
+        : {})
     });
   }
 
@@ -366,10 +433,14 @@ async function findFreeName(scope: ScriptCreateScope, base: string): Promise<str
     const suffix = ` (${i})`;
     candidates.push(base.slice(0, 255 - suffix.length) + suffix);
   }
+  // Both namespaces are off-limits: a rename that dodges the org rows but lands
+  // on a partner-wide name reproduces the very duplicate #3450 is about.
+  const partnerWide = partnerWideConflictCondition(scope);
+  const visible = partnerWide ? or(scopeCondition(scope), partnerWide) : scopeCondition(scope);
   const taken = await db
     .select({ name: scripts.name })
     .from(scripts)
-    .where(and(inArray(scripts.name, candidates), scopeCondition(scope)));
+    .where(and(inArray(scripts.name, candidates), visible));
   const takenNames = new Set(taken.map((t) => t.name));
   return candidates.find((c) => !takenNames.has(c)) ?? null;
 }
@@ -436,9 +507,13 @@ export async function importBundle(
         continue;
       }
 
-      const existing = await findExistingByName(scope, entry.name);
+      const conflict = await findConflictByName(scope, entry.name);
+      const existing = conflict?.row;
 
       if (existing && options.mode === 'skip') {
+        // Skips on a partner-wide match too (#3450) — the operator asked not to
+        // add a name that already exists in the library they are looking at,
+        // and partner-wide rows are in that same list.
         result.skipped++;
         result.scripts.push({ index, name: entry.name, action: 'skipped', scriptId: existing.id });
         continue;
@@ -447,9 +522,28 @@ export async function importBundle(
       if (existing && options.mode === 'new-version' && existing.content === entry.content) {
         // Idempotent re-import: identical content must not pad version
         // history — re-running the same bundle N times would otherwise
-        // produce N no-op versions and N identical snapshots.
+        // produce N no-op versions and N identical snapshots. Applies to a
+        // partner-wide match as well: the content is already live for this org
+        // under that name, so an org-owned copy would add nothing but a
+        // duplicate.
         result.skipped++;
         result.scripts.push({ index, name: entry.name, action: 'skipped', scriptId: existing.id });
+        continue;
+      }
+
+      if (conflict?.kind === 'partner-wide' && options.mode === 'new-version') {
+        // An org-target import may never version a partner-wide row (#3262),
+        // and silently creating an org-owned row of the same name is the
+        // duplicate #3450 reports. Fail this entry loudly with the two modes
+        // that CAN proceed; the rest of the bundle still imports.
+        result.errors.push({
+          index,
+          name: entry.name,
+          error:
+            `A partner-wide script named "${entry.name}" already exists and is read-only for an ` +
+            'organization import. Re-run with the "Skip it" or "Rename" collision mode, or import ' +
+            'the bundle as partner-wide to version it.'
+        });
         continue;
       }
 

--- a/apps/web/src/components/scripts/ScriptBundleImport.tsx
+++ b/apps/web/src/components/scripts/ScriptBundleImport.tsx
@@ -25,6 +25,13 @@ type PreviewEntry = {
   index: number;
   name: string;
   status: 'new' | 'name-conflict' | 'invalid';
+  /**
+   * Only set on a 'name-conflict' (#3450). 'partner-wide' means the colliding
+   * script is one of the MSP's shared scripts — visible in this same library
+   * list but read-only for an organization-targeted import, so "New version"
+   * cannot apply to it. Optional: an older API omits it.
+   */
+  conflictKind?: 'target-scope' | 'partner-wide';
   error?: string;
   existingVersion?: number;
 };
@@ -466,12 +473,20 @@ export function ScriptBundleImportModal({
                             {entry.status === 'new'
                               ? t('bundle.statusNew')
                               : entry.status === 'name-conflict'
-                                ? t('bundle.statusConflict')
+                                ? entry.conflictKind === 'partner-wide'
+                                  ? t('bundle.statusConflictPartnerWide')
+                                  : t('bundle.statusConflict')
                                 : t('bundle.statusInvalid')}
                           </span>
                           {entry.status === 'invalid' && entry.error && (
                             <p className="mt-1 text-xs text-destructive">{entry.error}</p>
                           )}
+                          {entry.status === 'name-conflict' &&
+                            entry.conflictKind === 'partner-wide' && (
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {t('bundle.partnerWideConflictHint')}
+                              </p>
+                            )}
                         </td>
                       </tr>
                     ))}

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -1231,6 +1231,8 @@
     "previewTitle": "Zustand",
     "statusNew": "Neu",
     "statusConflict": "Namenskonflikt",
+    "statusConflictPartnerWide": "Partnerweit vorhanden",
+    "partnerWideConflictHint": "Ein partnerweit freigegebenes Skript verwendet diesen Namen bereits. Es ist hier schreibgeschützt — überspringen oder umbenennen.",
     "modeLabel": "Wenn ein Skript mit demselben Namen bereits existiert",
     "modeSkip": "Überspringen",
     "modeRename": "Mit neuem Namen importieren",

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -1231,6 +1231,8 @@
     "previewTitle": "Status",
     "statusNew": "New",
     "statusConflict": "Name conflict",
+    "statusConflictPartnerWide": "Exists partner-wide",
+    "partnerWideConflictHint": "A shared partner-wide script already uses this name. It is read-only here — Skip it or Rename.",
     "modeLabel": "When a script with the same name already exists",
     "modeSkip": "Skip it",
     "modeRename": "Import with a new name",

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -1231,6 +1231,8 @@
     "previewTitle": "Estado",
     "statusNew": "Nuevo",
     "statusConflict": "Conflicto de nombre",
+    "statusConflictPartnerWide": "Existe a nivel de partner",
+    "partnerWideConflictHint": "Un script compartido a nivel de partner ya usa este nombre. Aquí es de solo lectura: omítelo o renómbralo.",
     "modeLabel": "Cuando ya existe un script con el mismo nombre",
     "modeSkip": "Omitirlo",
     "modeRename": "Importar con un nombre nuevo",

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -1231,6 +1231,8 @@
     "previewTitle": "Statut",
     "statusNew": "Nouveau",
     "statusConflict": "Conflit de nom",
+    "statusConflictPartnerWide": "Existe au niveau du partenaire",
+    "partnerWideConflictHint": "Un script partagé au niveau du partenaire porte déjà ce nom. Il est en lecture seule ici — ignorez-le ou renommez-le.",
     "modeLabel": "Quand un script portant le même nom existe déjà",
     "modeSkip": "L'ignorer",
     "modeRename": "Importer sous un nouveau nom",

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -1231,6 +1231,8 @@
     "previewTitle": "Statut",
     "statusNew": "Nouveau",
     "statusConflict": "Conflit de nom",
+    "statusConflictPartnerWide": "Existe au niveau du partenaire",
+    "partnerWideConflictHint": "Un script partagé au niveau du partenaire porte déjà ce nom. Il est en lecture seule ici — ignorez-le ou renommez-le.",
     "modeLabel": "Quand un script portant le même nom existe déjà",
     "modeSkip": "L'ignorer",
     "modeRename": "Importer sous un nouveau nom",

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -1231,6 +1231,8 @@
     "previewTitle": "Stato",
     "statusNew": "Nuovo",
     "statusConflict": "Conflitto di nome",
+    "statusConflictPartnerWide": "Esiste a livello partner",
+    "partnerWideConflictHint": "Uno script condiviso a livello partner usa già questo nome. Qui è di sola lettura: ignoralo o rinominalo.",
     "modeLabel": "Quando esiste già uno script con lo stesso nome",
     "modeSkip": "Salta",
     "modeRename": "Importa con un nuovo nome",

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -1231,6 +1231,8 @@
     "previewTitle": "Situação",
     "statusNew": "Novo",
     "statusConflict": "Conflito de nome",
+    "statusConflictPartnerWide": "Existe no nível do parceiro",
+    "partnerWideConflictHint": "Um script compartilhado no nível do parceiro já usa esse nome. Ele é somente leitura aqui — ignore-o ou renomeie-o.",
     "modeLabel": "Quando já existe um script com o mesmo nome",
     "modeSkip": "Ignorar",
     "modeRename": "Importar com um novo nome",

--- a/apps/web/src/locales/tr-TR/scripts.json
+++ b/apps/web/src/locales/tr-TR/scripts.json
@@ -1231,6 +1231,8 @@
     "previewTitle": "Durum",
     "statusNew": "Yeni",
     "statusConflict": "Ad çakışması",
+    "statusConflictPartnerWide": "İş ortağı genelinde mevcut",
+    "partnerWideConflictHint": "İş ortağı genelinde paylaşılan bir komut dosyası bu adı zaten kullanıyor. Burada salt okunurdur — atlayın veya yeniden adlandırın.",
     "modeLabel": "Aynı adda bir komut dosyası zaten mevcut olduğunda",
     "modeSkip": "Atla",
     "modeRename": "Yeni bir adla içe aktarın",


### PR DESCRIPTION
Closes #3450

## Problem

Script-bundle import collision detection (`scopeCondition`) only matched rows in the resolved **target** scope. With the import modal's default availability (`org`), importing a bundle whose script names match existing **partner-wide** scripts annotated every entry as **New**, and the "Skip it" collision mode imported them anyway — producing same-name duplicates in the one library list the operator sees, since partner-wide and org rows render together.

## Approach

The org-vs-partner-wide **write** split is deliberate (#3262) and is unchanged: an org-target import still never mutates or versions a partner-wide row. What changes is that a *visible but read-only* partner-wide row is now recognised as a collision rather than invisible.

- `findConflictByName` replaces `findExistingByName` and returns `{ row, kind }`. A `target-scope` (owned, writable) match always wins over a read-only `partner-wide` one, and the partner-wide query only runs when the owned lookup misses.
- The partner-wide lookup is gated on the **resolved scope** carrying both an `orgId` and a `partnerId` — deliberately **not** on `auth.scope === 'partner'`. Organization-scope users legitimately *see* their MSP's partner-wide scripts: the list route unions on `partner_id`, and RLS grants the read through the own-partner SELECT branch added in `2026-06-13-catalog-partner-read-branch.sql`. They just cannot write them, which is precisely why this is a separate read-only conflict class. Gating on `auth.scope` would have left org users — the majority of the affected callers — still seeing "New".
- Preview keeps `status: 'name-conflict'` and adds a `conflictKind` refinement rather than introducing a new status value, so a client older than this change renders a generic conflict badge instead of falling through to "Invalid" on an unrecognised enum member.

### Collision-mode semantics against a partner-wide match

| Mode | Before | After |
|---|---|---|
| Skip it | imported a duplicate | **skipped** |
| Rename | renamed only around org names (could land on a partner-wide name) | free name excludes **both** namespaces |
| New version | silently created a duplicate org row | **per-entry error** naming the modes that can proceed — except identical content, which stays a no-op skip, matching the existing idempotent-re-import behaviour |

A per-entry error (rather than silently creating an org-owned override) is the honest outcome: the operator asked to version an existing script, and that specific row cannot be versioned from this scope. The rest of the bundle still imports, consistent with every other per-entry failure mode in the importer.

## UI

The modal badges these entries **"Exists partner-wide"** in amber with a hint line explaining it is read-only here and to Skip or Rename. New keys `bundle.statusConflictPartnerWide` / `bundle.partnerWideConflictHint` added across all eight locales.

## Tests

Five new service tests (preview annotation, owned-wins-over-partner-wide with no second query, skip-mode skip, new-version refusal, new-version identical-content skip, rename across both namespaces), plus negative cases proving the extra lookup does **not** fire for a partner-wide target or a system-scope import. Mutation-checked: stubbing `partnerWideConflictCondition` to return `null` reddens all of them.

- `apps/api/src/services/scriptBundle/index.test.ts` — 38 passed
- `apps/api/src/routes/scriptBundle.test.ts`, `scripts.test.ts`, `scripts.execute-schema.test.ts` — 91 passed / 2 skipped
- `apps/web/src/lib/i18n/localeParity.test.ts`, `apps/web/src/lib/scriptBundle.test.ts` — 63 passed
- `tsc --noEmit` clean in both `apps/api` and `apps/web`

## Not addressed

The mirror case — a **partner-wide** import colliding with an org-owned name in some org under the partner — is out of scope here and not sanely fixable at import time (there is no single org to check against, and the conflict would be per-org). No migration; no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)