### PR TITLE
fix(api): give the global body-limit gate server-side telemetry (#3517)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,11 +11,10 @@ import { cors } from 'hono/cors';
 import { HTTPException } from 'hono/http-exception';
 import { prettyJSON } from 'hono/pretty-json';
 import { secureHeaders } from 'hono/secure-headers';
-import { bodyLimit } from 'hono/body-limit';
 
 import { securityMiddleware } from './middleware/security';
 import { requestPathLogger } from './middleware/requestPathLogger';
-import { bodyLimitForPath } from './middleware/bodyLimit';
+import { createGlobalBodyLimitMiddleware } from './middleware/bodyLimitGate';
 import { globalRateLimit } from './middleware/globalRateLimit';
 import { authRoutes } from './routes/auth';
 import { accountDeletionAdminRoutes } from './routes/auth/accountDeletion';
@@ -492,14 +491,12 @@ app.use(
   })
 );
 app.use('*', securityMiddleware());
-app.use('*', async (c, next) => {
-  // oidc-provider reads the raw Node IncomingMessage stream itself.
-  if (c.req.path === '/oauth' || c.req.path.startsWith('/oauth/')) {
-    return next();
-  }
-  const { maxSize, error } = bodyLimitForPath(c.req.path);
-  return bodyLimit({ maxSize, onError: (ctx) => ctx.json({ error }, 413) })(c, next);
-});
+app.use(
+  '*',
+  createGlobalBodyLimitMiddleware({
+    capture: (message, tags) => captureMessage(message, 'warning', undefined, tags),
+  })
+);
 app.use('*', globalRateLimit());
 app.use('*', prettyJSON());
 app.use(

--- a/apps/api/src/middleware/bodyLimit.test.ts
+++ b/apps/api/src/middleware/bodyLimit.test.ts
@@ -9,10 +9,12 @@ const KB = 1024;
 describe('bodyLimitForPath', () => {
   it('applies the tight 1MB default to ordinary routes', () => {
     expect(bodyLimitForPath('/api/v1/devices')).toEqual({
+      rule: 'default',
       maxSize: 1 * MB,
       error: 'Request body too large',
     });
     expect(bodyLimitForPath('/api/v1/software/catalog')).toEqual({
+      rule: 'default',
       maxSize: 1 * MB,
       error: 'Request body too large',
     });
@@ -20,10 +22,12 @@ describe('bodyLimitForPath', () => {
 
   it('carves out dev-push binary uploads at 150MB', () => {
     expect(bodyLimitForPath('/api/v1/dev/push')).toEqual({
+      rule: 'dev-push',
       maxSize: 150 * MB,
       error: 'Binary too large (max 150MB)',
     });
     expect(bodyLimitForPath('/api/v1/dev/push/anything')).toEqual({
+      rule: 'dev-push',
       maxSize: 150 * MB,
       error: 'Binary too large (max 150MB)',
     });
@@ -37,6 +41,7 @@ describe('bodyLimitForPath', () => {
     expect(
       bodyLimitForPath('/api/v1/agents/agent-1/commands/11111111-1111-4111-8111-111111111111/result'),
     ).toEqual({
+      rule: 'agent-command-result',
       maxSize: 12 * MB,
       error: 'Command result too large (max 12MB)',
     });
@@ -51,6 +56,7 @@ describe('bodyLimitForPath', () => {
   // the agent's WS read limit is derived from the same cap (issue #2399).
   it('carves out file-browser uploads at 8MB', () => {
     expect(bodyLimitForPath('/api/v1/system-tools/devices/dev-1/files/upload')).toEqual({
+      rule: 'file-upload',
       maxSize: 8 * MB,
       error: 'File too large (max 4MB)',
     });
@@ -106,10 +112,12 @@ describe('bodyLimitForPath', () => {
   // effective total-bundle cap.
   it('carves out script bundle import/preview at 20MB', () => {
     expect(bodyLimitForPath('/api/v1/scripts/bundle/import')).toEqual({
+      rule: 'script-bundle',
       maxSize: 20 * MB,
       error: 'Bundle too large (max 20MB)',
     });
     expect(bodyLimitForPath('/api/v1/scripts/bundle/preview')).toEqual({
+      rule: 'script-bundle',
       maxSize: 20 * MB,
       error: 'Bundle too large (max 20MB)',
     });
@@ -127,6 +135,7 @@ describe('bodyLimitForPath', () => {
         '/api/v1/software/catalog/11111111-1111-4111-8111-111111111111/versions/uploads/22222222-2222-4222-8222-222222222222/chunks',
       ),
     ).toEqual({
+      rule: 'software-chunk',
       maxSize: 9 * MB,
       error: 'Chunk too large (max 8MB)',
     });
@@ -144,6 +153,7 @@ describe('bodyLimitForPath', () => {
   // the generic "Request body too large".
   it('carves out quote image uploads at the route 5MB cap (#3482)', () => {
     expect(bodyLimitForPath('/api/v1/quotes/11111111-1111-4111-8111-111111111111/images')).toEqual({
+      rule: 'image-upload',
       maxSize: 5 * MB + 64 * KB,
       error: 'Image too large (max 5 MB)',
     });
@@ -157,12 +167,14 @@ describe('bodyLimitForPath', () => {
   // Same shadowing bug, same 5MB advertised cap, found alongside #3482.
   it('carves out catalog item image and user avatar uploads at 5MB', () => {
     expect(bodyLimitForPath('/api/v1/catalog/item-1/image')).toEqual({
+      rule: 'image-upload',
       maxSize: 5 * MB + 64 * KB,
       error: 'Image too large (max 5 MB)',
     });
     // Avatar keeps its own wording: at equal thresholds this gate answers
     // before the route's middleware, so the message here is what callers see.
     expect(bodyLimitForPath('/api/v1/users/me/avatar')).toEqual({
+      rule: 'avatar',
       maxSize: 5 * MB + 64 * KB,
       error: 'Avatar file too large (max 5 MB)',
     });
@@ -174,10 +186,40 @@ describe('bodyLimitForPath', () => {
     expect(
       bodyLimitForPath('/api/v1/contracts/contract-templates/tpl-1/versions/upload'),
     ).toEqual({
+      rule: 'contract-template',
       maxSize: 10 * MB + 64 * KB,
       error: 'File exceeds the 10MB upload limit',
     });
     expect(bodyLimitForPath('/api/v1/contracts/contract-templates/tpl-1/versions').maxSize).toBe(1 * MB);
+  });
+
+  // #3517: the rule label is what body-limit telemetry groups on, so it has to
+  // stay a closed set AND actually discriminate. A carve-out that reuses another
+  // branch's label (or forgets to change 'default') would silently file its 413s
+  // under the wrong bucket — exactly the blindness this telemetry exists to fix.
+  it('gives every carve-out branch a distinct, non-default rule label (#3517)', () => {
+    const sampled: Record<string, string> = {
+      'dev-push': '/api/v1/dev/push',
+      'file-upload': '/api/v1/system-tools/devices/dev-1/files/upload',
+      'software-chunk':
+        '/api/v1/software/catalog/cat-1/versions/uploads/up-1/chunks',
+      'software-package': '/api/v1/software/catalog/cat-1/versions/upload',
+      'agent-command-result': '/api/v1/agents/agent-1/commands/cmd-1/result',
+      'script-bundle': '/api/v1/scripts/bundle/import',
+      'image-upload': '/api/v1/catalog/item-1/image',
+      avatar: '/api/v1/users/me/avatar',
+      'contract-template': '/api/v1/contracts/contract-templates/tpl-1/versions/upload',
+      'agent-ingest': '/api/v1/agents/agent-1/software',
+    };
+    for (const [rule, path] of Object.entries(sampled)) {
+      expect({ path, rule: bodyLimitForPath(path).rule }).toEqual({ path, rule });
+    }
+    expect(bodyLimitForPath('/api/v1/devices').rule).toBe('default');
+    // Labels are Sentry tag values: bounded, and free of the characters
+    // `sentry.ts` rejects (`/?#`, CR/LF) so they can never smuggle a path.
+    for (const rule of [...Object.keys(sampled), 'default']) {
+      expect(rule).toMatch(/^[a-z][a-z0-9-]{0,31}$/);
+    }
   });
 });
 
@@ -279,7 +321,13 @@ const ROUTE_LEVEL_BODY_LIMITS: Record<
 // surfaces live under src/ generally (routes/, but also modules/, extensions/),
 // so the scan roots at src/ rather than src/routes to catch registrations
 // mounted from outside the routes tree.
-const SCAN_EXEMPT = new Set(['index.ts', 'middleware/bodyLimit.ts']);
+// index.ts mounts the global gate; bodyLimitGate.ts IS the gate (it owns the
+// only `bodyLimit(` call that is not route-level); bodyLimit.ts is this module.
+const SCAN_EXEMPT = new Set([
+  'index.ts',
+  'middleware/bodyLimit.ts',
+  'middleware/bodyLimitGate.ts',
+]);
 
 function filesRegisteringBodyLimit(dir: string, root: string): string[] {
   const found: string[] = [];

--- a/apps/api/src/middleware/bodyLimit.test.ts
+++ b/apps/api/src/middleware/bodyLimit.test.ts
@@ -215,9 +215,18 @@ describe('bodyLimitForPath', () => {
       expect({ path, rule: bodyLimitForPath(path).rule }).toEqual({ path, rule });
     }
     expect(bodyLimitForPath('/api/v1/devices').rule).toBe('default');
+    // agent-logs / agent-process-sample are route-level rules: their limits are
+    // TIGHTER than the global default, so the gate must NOT claim them.
+    expect(bodyLimitForPath('/api/v1/agents/agent-1/logs').rule).toBe('default');
+    expect(bodyLimitForPath('/api/v1/agents/agent-1/process-sample').rule).toBe('default');
     // Labels are Sentry tag values: bounded, and free of the characters
     // `sentry.ts` rejects (`/?#`, CR/LF) so they can never smuggle a path.
-    for (const rule of [...Object.keys(sampled), 'default']) {
+    for (const rule of [
+      ...Object.keys(sampled),
+      'default',
+      'agent-logs',
+      'agent-process-sample',
+    ]) {
       expect(rule).toMatch(/^[a-z][a-z0-9-]{0,31}$/);
     }
   });

--- a/apps/api/src/middleware/bodyLimit.ts
+++ b/apps/api/src/middleware/bodyLimit.ts
@@ -32,7 +32,12 @@ export type BodyLimitRule =
   | 'image-upload'
   | 'avatar'
   | 'contract-template'
-  | 'agent-ingest';
+  | 'agent-ingest'
+  // Route-level limits TIGHTER than the global default, so `bodyLimitForPath`
+  // never returns them — the route's own gate is the one that answers. They
+  // share this namespace so all body-limit 413s group on one tag.
+  | 'agent-logs'
+  | 'agent-process-sample';
 
 export interface BodyLimitPolicy {
   rule: BodyLimitRule;

--- a/apps/api/src/middleware/bodyLimit.ts
+++ b/apps/api/src/middleware/bodyLimit.ts
@@ -10,29 +10,63 @@
  * Kept as a pure function (no Hono/server imports) so it can be unit-tested
  * without booting the API.
  */
-export function bodyLimitForPath(path: string): { maxSize: number; error: string } {
+/**
+ * Stable, closed-set identity for the carve-out branch that matched.
+ *
+ * #3517: the global gate's 413s were invisible server-side, and the obvious fix
+ * (log the path) is exactly what `middleware/requestPathLogger.ts` forbids — the
+ * gate runs at `app.use('*')` BEFORE routing, so no bounded matched-route label
+ * exists yet. The rule label is bounded by construction, needs no redaction, and
+ * is the dimension operators actually want to group on ("which limit is firing,
+ * and how often"). Keep it a union type: adding a carve-out below without a
+ * label here is a type error, which is the point.
+ */
+export type BodyLimitRule =
+  | 'default'
+  | 'dev-push'
+  | 'file-upload'
+  | 'software-chunk'
+  | 'software-package'
+  | 'agent-command-result'
+  | 'script-bundle'
+  | 'image-upload'
+  | 'avatar'
+  | 'contract-template'
+  | 'agent-ingest';
+
+export interface BodyLimitPolicy {
+  rule: BodyLimitRule;
+  maxSize: number;
+  error: string;
+}
+
+export function bodyLimitForPath(path: string): BodyLimitPolicy {
   // Dev-push uploads agent binaries (~20MB); skip the default 1MB limit.
   if (path.startsWith('/api/v1/dev/push')) {
-    return { maxSize: 150 * 1024 * 1024, error: 'Binary too large (max 150MB)' };
+    return { rule: 'dev-push', maxSize: 150 * 1024 * 1024, error: 'Binary too large (max 150MB)' };
   }
   // File browser uploads send base64-encoded content in JSON body (~33%
   // overhead). The agent caps file_write at 4MB decoded (~5.6MB base64, see
   // fileUploadBodySchema); 8MB covers that plus JSON envelope/escaping.
   if (path.match(/^\/api\/v1\/system-tools\/devices\/[^/]+\/files\/upload$/)) {
-    return { maxSize: 8 * 1024 * 1024, error: 'File too large (max 4MB)' };
+    return { rule: 'file-upload', maxSize: 8 * 1024 * 1024, error: 'File too large (max 4MB)' };
   }
   // Chunked software package uploads (#2951): each chunk is a raw
   // application/octet-stream body of at most 8MB (client UPLOAD_CHUNK_SIZE,
   // server-validated chunk_size cap). 9MB headroom lets the route's own
   // per-chunk limit answer with its specific message instead of this one.
   if (path.match(/^\/api\/v1\/software\/catalog\/[^/]+\/versions\/uploads\/[^/]+\/chunks$/)) {
-    return { maxSize: 9 * 1024 * 1024, error: 'Chunk too large (max 8MB)' };
+    return { rule: 'software-chunk', maxSize: 9 * 1024 * 1024, error: 'Chunk too large (max 8MB)' };
   }
   // Software package (installer) uploads are multipart and capped at 500MB by the
   // route's own MAX_UPLOAD_SIZE check; give the body limit headroom over that so the
   // route returns its specific "File too large" message instead of this generic one.
   if (path.match(/^\/api\/v1\/software\/catalog\/[^/]+\/versions\/upload$/)) {
-    return { maxSize: 512 * 1024 * 1024, error: 'Package too large (max 500MB)' };
+    return {
+      rule: 'software-package',
+      maxSize: 512 * 1024 * 1024,
+      error: 'Package too large (max 500MB)',
+    };
   }
   // Agent command results submitted via the heartbeat/REST fallback leg (used
   // when the WS path is unavailable). commandResultSchema already caps stdout
@@ -42,14 +76,18 @@ export function bodyLimitForPath(path: string): { maxSize: number; error: string
   // caller sees a misleading generic timeout (#2401). 12MB covers both capped
   // fields plus JSON escaping/envelope. Agent-authenticated route.
   if (path.match(/^\/api\/v1\/agents\/[^/]+\/commands\/[^/]+\/result$/)) {
-    return { maxSize: 12 * 1024 * 1024, error: 'Command result too large (max 12MB)' };
+    return {
+      rule: 'agent-command-result',
+      maxSize: 12 * 1024 * 1024,
+      error: 'Command result too large (max 12MB)',
+    };
   }
   // Script bundle import/preview (#3245): a bundle carries whole script
   // libraries (up to 200 scripts x 256KB content, both capped by the bundle
   // schema). 20MB is the effective total-bundle cap; the schema's per-field
   // caps answer with specific messages below it.
   if (path === '/api/v1/scripts/bundle/import' || path === '/api/v1/scripts/bundle/preview') {
-    return { maxSize: 20 * 1024 * 1024, error: 'Bundle too large (max 20MB)' };
+    return { rule: 'script-bundle', maxSize: 20 * 1024 * 1024, error: 'Bundle too large (max 20MB)' };
   }
   // Multipart image/document uploads that the UI advertises at 5 MB (10 MB for
   // contract templates). Each of these routes already registers its OWN
@@ -66,13 +104,25 @@ export function bodyLimitForPath(path: string): { maxSize: number; error: string
     path.match(/^\/api\/v1\/quotes\/[^/]+\/images$/) ||
     path.match(/^\/api\/v1\/catalog\/[^/]+\/image$/)
   ) {
-    return { maxSize: 5 * 1024 * 1024 + 64 * 1024, error: 'Image too large (max 5 MB)' };
+    return {
+      rule: 'image-upload',
+      maxSize: 5 * 1024 * 1024 + 64 * 1024,
+      error: 'Image too large (max 5 MB)',
+    };
   }
   if (path === '/api/v1/users/me/avatar') {
-    return { maxSize: 5 * 1024 * 1024 + 64 * 1024, error: 'Avatar file too large (max 5 MB)' };
+    return {
+      rule: 'avatar',
+      maxSize: 5 * 1024 * 1024 + 64 * 1024,
+      error: 'Avatar file too large (max 5 MB)',
+    };
   }
   if (path.match(/^\/api\/v1\/contracts\/contract-templates\/[^/]+\/versions\/upload$/)) {
-    return { maxSize: 10 * 1024 * 1024 + 64 * 1024, error: 'File exceeds the 10MB upload limit' };
+    return {
+      rule: 'contract-template',
+      maxSize: 10 * 1024 * 1024 + 64 * 1024,
+      error: 'File exceeds the 10MB upload limit',
+    };
   }
   // Agent inventory/heartbeat ingest (#3516). Every one of these routes already
   // registers its OWN `bodyLimit({ maxSize: 5MB })` — hardware/software/disks/
@@ -92,7 +142,7 @@ export function bodyLimitForPath(path: string): { maxSize: number; error: string
   // `/monitoring-results` (deliberately 1MB in heartbeat.ts) or the already
   // carved-out `/commands/:id/result` above.
   if (path.match(/^\/api\/v1\/agents\/[^/]+\/(hardware|software|disks|network|connections|heartbeat)$/)) {
-    return { maxSize: 5 * 1024 * 1024, error: 'Request body too large' };
+    return { rule: 'agent-ingest', maxSize: 5 * 1024 * 1024, error: 'Request body too large' };
   }
-  return { maxSize: 1024 * 1024, error: 'Request body too large' };
+  return { rule: 'default', maxSize: 1024 * 1024, error: 'Request body too large' };
 }

--- a/apps/api/src/middleware/bodyLimitGate.test.ts
+++ b/apps/api/src/middleware/bodyLimitGate.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { Hono } from 'hono';
-import { createGlobalBodyLimitMiddleware } from './bodyLimitGate';
+import { bodyLimit } from 'hono/body-limit';
+import {
+  bodyLimitOnError,
+  createGlobalBodyLimitMiddleware,
+  resetBodyLimitTelemetry,
+  safeContentLength,
+} from './bodyLimitGate';
 import { requestPathLogger } from './requestPathLogger';
 
 const MB = 1024 * 1024;
@@ -30,6 +36,10 @@ function buildApp() {
 
 const REQUEST_ID = '123e4567-e89b-42d3-a456-426614174000';
 
+// The Sentry throttle is module state shared by the gate and the route-level
+// limits, so it must not leak between cases.
+beforeEach(() => resetBodyLimitTelemetry());
+
 describe('createGlobalBodyLimitMiddleware', () => {
   it('logs a bounded rule/size/correlation record on 413 and never the raw path', async () => {
     const { app, warnings, captures } = buildApp();
@@ -49,7 +59,7 @@ describe('createGlobalBodyLimitMiddleware', () => {
     ]);
     expect(captures).toEqual([
       {
-        message: 'Global request body limit rejected a request',
+        message: 'Request body limit rejected a request',
         tags: {
           method: 'POST',
           body_limit_rule: 'default',
@@ -145,6 +155,57 @@ describe('createGlobalBodyLimitMiddleware', () => {
     ]);
   });
 
+  // `Content-Length` is the one caller-controlled value that reaches the log
+  // line and (indirectly) an operator's eye, so it gets the same re-validation
+  // treatment as `X-Request-Id`. Exercised directly: Hono's gate short-circuits
+  // on an unparseable header, so these never reach `onError` over HTTP.
+  it('only echoes a Content-Length that is a plain, round-tripping decimal', () => {
+    expect(safeContentLength('1048577')).toBe('1048577');
+    expect(safeContentLength('0')).toBe('0');
+
+    for (const forged of [
+      undefined,
+      '',
+      '1e9', // exponent notation — parseInt() would read this as 1
+      ' 1048577',
+      '1048577 ',
+      '+1048577',
+      '-1',
+      '1048577, 5', // duplicate headers joined by the fetch layer
+      '1048577\n injected=1',
+      '0x100000',
+      '1'.repeat(17), // over the 16-digit ceiling
+      '9'.repeat(16), // 16 digits but past Number.MAX_SAFE_INTEGER
+    ]) {
+      expect({ forged, reported: safeContentLength(forged) }).toEqual({
+        forged,
+        reported: 'unknown',
+      });
+    }
+  });
+
+  it('throttles Sentry per rule, so a second rule is not muted by the first', async () => {
+    const { app, warnings, captures } = buildApp();
+    const overDefault = MB + 1;
+    const overImage = 5 * MB + 64 * 1024 + 1;
+
+    await app.request('/api/v1/devices', {
+      method: 'POST',
+      headers: { 'Content-Length': String(overDefault) },
+      body: 'x'.repeat(overDefault),
+    });
+    // A different rule inside the same throttle window must still report — a
+    // globally-keyed throttle would swallow this one.
+    await app.request('/api/v1/quotes/tok-1/images', {
+      method: 'POST',
+      headers: { 'Content-Length': String(overImage) },
+      body: 'x'.repeat(overImage),
+    });
+
+    expect(warnings).toHaveLength(2);
+    expect(captures.map((c) => c.tags.body_limit_rule)).toEqual(['default', 'image-upload']);
+  });
+
   it('still lets the oidc-provider paths through untouched', async () => {
     const { app, warnings, captures } = buildApp();
 
@@ -170,5 +231,80 @@ describe('createGlobalBodyLimitMiddleware', () => {
     expect(response.status).toBe(200);
     expect(warnings).toEqual([]);
     expect(captures).toEqual([]);
+  });
+});
+
+describe('bodyLimitOnError (route-level limits tighter than the global gate)', () => {
+  // #3517 regression: agent log shipping and process samples declare 256KB,
+  // which is TIGHTER than the global 1MB default, so the instrumented global
+  // gate never answers for them. Before this, their 413s were fully silent on
+  // an agent-authenticated path where nobody is watching.
+  it('reports the route rule and returns the route message', async () => {
+    const warnings: string[] = [];
+    const captures: Capture[] = [];
+    const maxSize = 256 * 1024;
+    const app = new Hono();
+    app.use('*', requestPathLogger(() => undefined));
+    // The global gate runs first in production and is a no-op here (256KB is
+    // well under its 1MB default), exactly as it is for these routes.
+    app.use('*', createGlobalBodyLimitMiddleware({ warn: () => {}, capture: () => {} }));
+    app.post(
+      '/api/v1/agents/:id/logs',
+      bodyLimit({
+        maxSize,
+        onError: bodyLimitOnError('agent-logs', maxSize, 'Log batch too large (max 256KB gzipped)', {
+          warn: (m) => warnings.push(m),
+          capture: (message, tags) => captures.push({ message, tags }),
+        }),
+      }),
+      (c) => c.json({ reached: true })
+    );
+
+    const contentLength = maxSize + 1;
+    const response = await app.request('/api/v1/agents/agent-1/logs', {
+      method: 'POST',
+      headers: { 'Content-Length': String(contentLength), 'X-Request-Id': REQUEST_ID },
+      body: 'x'.repeat(contentLength),
+    });
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({ error: 'Log batch too large (max 256KB gzipped)' });
+    expect(warnings).toEqual([
+      `[body-limit] rejected method=POST rule=agent-logs max_size=${maxSize} ` +
+        `content_length=${contentLength} request_id=${REQUEST_ID}`,
+    ]);
+    expect(captures[0]?.tags.body_limit_rule).toBe('agent-logs');
+    expect(JSON.stringify({ warnings, captures })).not.toContain('/api/v1/agents/agent-1/logs');
+  });
+
+  it('still answers 413 when the telemetry sinks throw', async () => {
+    const maxSize = 256 * 1024;
+    const app = new Hono();
+    app.post(
+      '/api/v1/agents/:id/logs',
+      bodyLimit({
+        maxSize,
+        onError: bodyLimitOnError('agent-logs', maxSize, 'Log batch too large (max 256KB gzipped)', {
+          warn: () => {
+            throw new Error('log sink down');
+          },
+          capture: () => {
+            throw new Error('sentry down');
+          },
+        }),
+      }),
+      (c) => c.json({ reached: true })
+    );
+
+    const contentLength = maxSize + 1;
+    const response = await app.request('/api/v1/agents/agent-1/logs', {
+      method: 'POST',
+      headers: { 'Content-Length': String(contentLength) },
+      body: 'x'.repeat(contentLength),
+    });
+
+    // A faulting telemetry sink must not escalate a precise 413 into a 500.
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({ error: 'Log batch too large (max 256KB gzipped)' });
   });
 });

--- a/apps/api/src/middleware/bodyLimitGate.test.ts
+++ b/apps/api/src/middleware/bodyLimitGate.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { createGlobalBodyLimitMiddleware } from './bodyLimitGate';
+import { requestPathLogger } from './requestPathLogger';
+
+const MB = 1024 * 1024;
+
+interface Capture {
+  message: string;
+  tags: Record<string, string>;
+}
+
+function buildApp() {
+  const warnings: string[] = [];
+  const captures: Capture[] = [];
+  const app = new Hono();
+  app.use('*', requestPathLogger(() => undefined));
+  app.use(
+    '*',
+    createGlobalBodyLimitMiddleware({
+      warn: (message) => warnings.push(message),
+      capture: (message, tags) => captures.push({ message, tags }),
+    })
+  );
+  app.post('/api/v1/quotes/:token/images', (c) => c.json({ reached: true }));
+  app.post('/api/v1/devices', (c) => c.json({ reached: true }));
+  app.post('/oauth/token', (c) => c.json({ reached: true }));
+  return { app, warnings, captures };
+}
+
+const REQUEST_ID = '123e4567-e89b-42d3-a456-426614174000';
+
+describe('createGlobalBodyLimitMiddleware', () => {
+  it('logs a bounded rule/size/correlation record on 413 and never the raw path', async () => {
+    const { app, warnings, captures } = buildApp();
+    const contentLength = MB + 1;
+
+    const response = await app.request('/api/v1/devices?token=secret-capability', {
+      method: 'POST',
+      headers: { 'Content-Length': String(contentLength), 'X-Request-Id': REQUEST_ID },
+      body: 'x'.repeat(contentLength),
+    });
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({ error: 'Request body too large' });
+    expect(warnings).toEqual([
+      `[body-limit] rejected method=POST rule=default max_size=${MB} ` +
+        `content_length=${contentLength} request_id=${REQUEST_ID}`,
+    ]);
+    expect(captures).toEqual([
+      {
+        message: 'Global request body limit rejected a request',
+        tags: {
+          method: 'POST',
+          body_limit_rule: 'default',
+          body_limit_max_size: String(MB),
+        },
+      },
+    ]);
+    const emitted = JSON.stringify({ warnings, captures });
+    expect(emitted).not.toContain('/api/v1/devices');
+    expect(emitted).not.toContain('secret-capability');
+  });
+
+  it('reports the carve-out rule that matched, not just the default', async () => {
+    const { app, warnings, captures } = buildApp();
+    const oversized = 5 * MB + 64 * 1024 + 1;
+
+    const response = await app.request('/api/v1/quotes/tok-1/images', {
+      method: 'POST',
+      headers: { 'Content-Length': String(oversized) },
+      body: 'x'.repeat(oversized),
+    });
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({ error: 'Image too large (max 5 MB)' });
+    expect(warnings[0]).toContain('rule=image-upload');
+    expect(warnings[0]).toContain(`max_size=${5 * MB + 64 * 1024}`);
+    expect(captures[0]?.tags.body_limit_rule).toBe('image-upload');
+  });
+
+  it('throttles Sentry per rule while console telemetry stays complete', async () => {
+    const { app, warnings, captures } = buildApp();
+    const contentLength = MB + 1;
+
+    for (let i = 0; i < 3; i += 1) {
+      const response = await app.request('/api/v1/devices', {
+        method: 'POST',
+        headers: { 'Content-Length': String(contentLength) },
+        body: 'x'.repeat(contentLength),
+      });
+      expect(response.status).toBe(413);
+    }
+
+    // Self-hosted operators read the console, so every rejection is recorded
+    // there; Sentry only needs to learn the condition exists.
+    expect(warnings).toHaveLength(3);
+    expect(captures).toHaveLength(1);
+  });
+
+  it('reports request_id=unknown rather than echoing a forged X-Request-Id', async () => {
+    const warnings: string[] = [];
+    const app = new Hono();
+    // No requestPathLogger mounted, so nothing set the correlation ID. The gate
+    // must not fall back to the caller-supplied header.
+    app.use('*', createGlobalBodyLimitMiddleware({ warn: (m) => warnings.push(m) }));
+    app.post('/api/v1/devices', (c) => c.json({ reached: true }));
+
+    const contentLength = MB + 1;
+    const response = await app.request('/api/v1/devices', {
+      method: 'POST',
+      headers: { 'Content-Length': String(contentLength), 'X-Request-Id': 'not-a-uuid' },
+      body: 'x'.repeat(contentLength),
+    });
+
+    expect(response.status).toBe(413);
+    expect(warnings).toEqual([
+      `[body-limit] rejected method=POST rule=default max_size=${MB} ` +
+        `content_length=${contentLength} request_id=unknown`,
+    ]);
+    expect(warnings[0]).not.toContain('not-a-uuid');
+  });
+
+  it('reports content_length=unknown for a streamed body with no Content-Length', async () => {
+    const { app, warnings } = buildApp();
+    const chunk = new Uint8Array(MB + 1);
+
+    const response = await app.request('/api/v1/devices', {
+      method: 'POST',
+      headers: { 'X-Request-Id': REQUEST_ID },
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(chunk);
+          controller.close();
+        },
+      }),
+      // Required by undici for a streaming request body.
+      duplex: 'half',
+    } as RequestInit);
+
+    expect(response.status).toBe(413);
+    expect(warnings).toEqual([
+      `[body-limit] rejected method=POST rule=default max_size=${MB} ` +
+        `content_length=unknown request_id=${REQUEST_ID}`,
+    ]);
+  });
+
+  it('still lets the oidc-provider paths through untouched', async () => {
+    const { app, warnings, captures } = buildApp();
+
+    const response = await app.request('/oauth/token', {
+      method: 'POST',
+      body: 'x'.repeat(MB + 1),
+    });
+
+    expect(response.status).toBe(200);
+    expect(warnings).toEqual([]);
+    expect(captures).toEqual([]);
+  });
+
+  it('does not log anything for a request under the limit', async () => {
+    const { app, warnings, captures } = buildApp();
+
+    const response = await app.request('/api/v1/devices', {
+      method: 'POST',
+      headers: { 'X-Request-Id': REQUEST_ID },
+      body: 'small',
+    });
+
+    expect(response.status).toBe(200);
+    expect(warnings).toEqual([]);
+    expect(captures).toEqual([]);
+  });
+});

--- a/apps/api/src/middleware/bodyLimitGate.ts
+++ b/apps/api/src/middleware/bodyLimitGate.ts
@@ -1,56 +1,135 @@
 import { bodyLimit } from 'hono/body-limit';
-import type { MiddlewareHandler } from 'hono';
+import type { Context, MiddlewareHandler } from 'hono';
 import { requestCorrelationId } from '../services/safeRequestLabel';
+import { captureMessage } from '../services/sentry';
 import { createReportThrottle } from '../utils/reportThrottle';
-import { bodyLimitForPath } from './bodyLimit';
+import { bodyLimitForPath, type BodyLimitRule } from './bodyLimit';
 
 /**
- * The global request body-size gate, registered once as `app.use('*')`.
+ * Telemetry for every 413 the API raises on a body-size limit.
  *
- * #3517: this gate used to answer 413 straight out of `onError` with no log, no
- * error ID and no Sentry event, so every rejection it has ever produced was
- * invisible server-side. That is why #1377, #2401, #3482 and #3516 were all
+ * #3517: the global gate used to answer 413 straight out of `onError` with no
+ * log, no error ID and no Sentry event, so every rejection it has ever produced
+ * was invisible server-side. That is why #1377, #2401, #3482 and #3516 were all
  * found by a customer hitting a wall — a route silently capped at 1MB looks
  * perfectly healthy from the operator side.
  *
  * The obvious fix (log `c.req.path`) is forbidden: `requestPathLogger` never
- * emits a raw path, and this gate runs BEFORE routing so `safeMatchedRouteLabel`
- * has nothing to work with yet. Instead we emit the carve-out RULE label — a
- * closed set defined in `bodyLimit.ts`, bounded by construction, and the
- * dimension operators actually want to group on. Method, configured maximum,
- * declared content length and the request correlation ID come along; the path,
- * the query and every caller-controlled string do not.
+ * emits a raw path, and the global gate runs BEFORE routing so
+ * `safeMatchedRouteLabel` has nothing to work with yet. Instead we emit the
+ * RULE label — a closed set, bounded by construction, and the dimension
+ * operators actually want to group on. Method, configured maximum, declared
+ * content length and the request correlation ID come along; the path, the query
+ * and every caller-controlled string do not.
  */
 
 /** One Sentry event per rule per window; console logging stays complete. */
 const SENTRY_THROTTLE_MS = 5 * 60 * 1000;
 
-interface BodyLimitTelemetry {
+/**
+ * Shared across the global gate AND the route-level limits, so a rule that
+ * fires on both legs is throttled once rather than twice.
+ */
+const sentryThrottle = createReportThrottle(SENTRY_THROTTLE_MS);
+
+export interface BodyLimitTelemetry {
   /** Structured console sink. Defaults to `console.warn`. */
   warn?: (message: string) => void;
-  /** Hosted-only aggregate sink (Sentry). Omitted = console only. */
+  /** Aggregate sink. Defaults to Sentry; inert when Sentry is not initialised. */
   capture?: (message: string, tags: Record<string, string>) => void;
+}
+
+/** Test seam — the throttle is module state, so suites must not inherit it. */
+export function resetBodyLimitTelemetry(): void {
+  sentryThrottle.reset();
 }
 
 /**
  * `Content-Length` is caller-controlled, so it is only ever reported when it is
  * a plain decimal integer that survives round-tripping. Anything else (absent,
- * multiple values, `1e9`, padding, a chunked request with no length at all) is
- * reported as the sentinel rather than echoed.
+ * multiple values joined by the fetch layer, `1e9`, padding, a chunked request
+ * with no length at all) is reported as the sentinel rather than echoed.
+ *
+ * Exported for direct unit testing: Hono's own gate short-circuits on an
+ * unparseable `Content-Length` (`parseInt('1e9', 10) === 1`), so a malformed
+ * header never reaches `onError` through the HTTP path and these guards cannot
+ * be exercised end-to-end.
  */
-function safeContentLength(value: string | undefined): string {
+export function safeContentLength(value: string | undefined): string {
   if (!value || !/^\d{1,16}$/.test(value)) return 'unknown';
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) ? String(parsed) : 'unknown';
 }
 
+/**
+ * Record one body-limit rejection. Never throws: this runs on the error path of
+ * a request that is already being refused, and a faulting telemetry sink must
+ * not turn a precise 413 into an opaque 500.
+ */
+export function reportBodyLimitRejection(
+  c: Context,
+  rule: BodyLimitRule,
+  maxSize: number,
+  telemetry: BodyLimitTelemetry = {}
+): void {
+  const warn = telemetry.warn ?? ((message: string) => console.warn(message));
+  const capture = telemetry.capture ?? defaultCapture;
+
+  const method = c.req.method;
+  try {
+    warn(
+      `[body-limit] rejected method=${method} rule=${rule} ` +
+        `max_size=${maxSize} content_length=${safeContentLength(c.req.header('Content-Length'))} ` +
+        `request_id=${requestCorrelationId(c)}`
+    );
+  } catch {
+    // A broken log sink must not escalate the caller's 413 into a 500.
+  }
+
+  try {
+    // Throttled per rule: a misconfigured limit fires on every request from
+    // every affected client, and its presence — not its count — is what drives
+    // the fix. The console line above is never throttled, so self-hosted
+    // operators keep the complete record.
+    if (sentryThrottle.shouldReport(rule)) {
+      capture('Request body limit rejected a request', {
+        method,
+        body_limit_rule: rule,
+        body_limit_max_size: String(maxSize),
+      });
+    }
+  } catch {
+    // Same reasoning: Sentry faulting is not the caller's problem.
+  }
+}
+
+function defaultCapture(message: string, tags: Record<string, string>): void {
+  captureMessage(message, 'warning', undefined, tags);
+}
+
+/**
+ * `onError` for a route-level `bodyLimit`, which the global gate cannot cover:
+ * a route limit TIGHTER than the global default (agent log shipping and process
+ * samples, both 256KB) is the one that actually answers, so without this its
+ * 413s stay invisible — the exact blindness #3517 exists to remove, on the two
+ * agent-authenticated paths where nobody is watching.
+ */
+export function bodyLimitOnError(
+  rule: BodyLimitRule,
+  maxSize: number,
+  error: string,
+  telemetry: BodyLimitTelemetry = {}
+) {
+  return (c: Context) => {
+    reportBodyLimitRejection(c, rule, maxSize, telemetry);
+    return c.json({ error }, 413);
+  };
+}
+
+/** The global request body-size gate, registered once as `app.use('*')`. */
 export function createGlobalBodyLimitMiddleware(
   telemetry: BodyLimitTelemetry = {}
 ): MiddlewareHandler {
-  const warn = telemetry.warn ?? ((message: string) => console.warn(message));
-  const capture = telemetry.capture;
-  const sentryThrottle = createReportThrottle(SENTRY_THROTTLE_MS);
-
   return async (c, next) => {
     // oidc-provider reads the raw Node IncomingMessage stream itself.
     if (c.req.path === '/oauth' || c.req.path.startsWith('/oauth/')) {
@@ -61,27 +140,7 @@ export function createGlobalBodyLimitMiddleware(
     return bodyLimit({
       maxSize: policy.maxSize,
       onError: (ctx) => {
-        const method = ctx.req.method;
-        const contentLength = safeContentLength(ctx.req.header('Content-Length'));
-
-        warn(
-          `[body-limit] rejected method=${method} rule=${policy.rule} ` +
-            `max_size=${policy.maxSize} content_length=${contentLength} ` +
-            `request_id=${requestCorrelationId(ctx)}`
-        );
-
-        // Throttled per rule: a misconfigured limit fires on every request from
-        // every affected client, and its presence — not its count — is what
-        // drives the fix. The console line above is never throttled, so
-        // self-hosted operators keep the complete record.
-        if (capture && sentryThrottle.shouldReport(policy.rule)) {
-          capture('Global request body limit rejected a request', {
-            method,
-            body_limit_rule: policy.rule,
-            body_limit_max_size: String(policy.maxSize),
-          });
-        }
-
+        reportBodyLimitRejection(ctx, policy.rule, policy.maxSize, telemetry);
         return ctx.json({ error: policy.error }, 413);
       },
     })(c, next);

--- a/apps/api/src/middleware/bodyLimitGate.ts
+++ b/apps/api/src/middleware/bodyLimitGate.ts
@@ -1,0 +1,89 @@
+import { bodyLimit } from 'hono/body-limit';
+import type { MiddlewareHandler } from 'hono';
+import { requestCorrelationId } from '../services/safeRequestLabel';
+import { createReportThrottle } from '../utils/reportThrottle';
+import { bodyLimitForPath } from './bodyLimit';
+
+/**
+ * The global request body-size gate, registered once as `app.use('*')`.
+ *
+ * #3517: this gate used to answer 413 straight out of `onError` with no log, no
+ * error ID and no Sentry event, so every rejection it has ever produced was
+ * invisible server-side. That is why #1377, #2401, #3482 and #3516 were all
+ * found by a customer hitting a wall — a route silently capped at 1MB looks
+ * perfectly healthy from the operator side.
+ *
+ * The obvious fix (log `c.req.path`) is forbidden: `requestPathLogger` never
+ * emits a raw path, and this gate runs BEFORE routing so `safeMatchedRouteLabel`
+ * has nothing to work with yet. Instead we emit the carve-out RULE label — a
+ * closed set defined in `bodyLimit.ts`, bounded by construction, and the
+ * dimension operators actually want to group on. Method, configured maximum,
+ * declared content length and the request correlation ID come along; the path,
+ * the query and every caller-controlled string do not.
+ */
+
+/** One Sentry event per rule per window; console logging stays complete. */
+const SENTRY_THROTTLE_MS = 5 * 60 * 1000;
+
+interface BodyLimitTelemetry {
+  /** Structured console sink. Defaults to `console.warn`. */
+  warn?: (message: string) => void;
+  /** Hosted-only aggregate sink (Sentry). Omitted = console only. */
+  capture?: (message: string, tags: Record<string, string>) => void;
+}
+
+/**
+ * `Content-Length` is caller-controlled, so it is only ever reported when it is
+ * a plain decimal integer that survives round-tripping. Anything else (absent,
+ * multiple values, `1e9`, padding, a chunked request with no length at all) is
+ * reported as the sentinel rather than echoed.
+ */
+function safeContentLength(value: string | undefined): string {
+  if (!value || !/^\d{1,16}$/.test(value)) return 'unknown';
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? String(parsed) : 'unknown';
+}
+
+export function createGlobalBodyLimitMiddleware(
+  telemetry: BodyLimitTelemetry = {}
+): MiddlewareHandler {
+  const warn = telemetry.warn ?? ((message: string) => console.warn(message));
+  const capture = telemetry.capture;
+  const sentryThrottle = createReportThrottle(SENTRY_THROTTLE_MS);
+
+  return async (c, next) => {
+    // oidc-provider reads the raw Node IncomingMessage stream itself.
+    if (c.req.path === '/oauth' || c.req.path.startsWith('/oauth/')) {
+      return next();
+    }
+
+    const policy = bodyLimitForPath(c.req.path);
+    return bodyLimit({
+      maxSize: policy.maxSize,
+      onError: (ctx) => {
+        const method = ctx.req.method;
+        const contentLength = safeContentLength(ctx.req.header('Content-Length'));
+
+        warn(
+          `[body-limit] rejected method=${method} rule=${policy.rule} ` +
+            `max_size=${policy.maxSize} content_length=${contentLength} ` +
+            `request_id=${requestCorrelationId(ctx)}`
+        );
+
+        // Throttled per rule: a misconfigured limit fires on every request from
+        // every affected client, and its presence — not its count — is what
+        // drives the fix. The console line above is never throttled, so
+        // self-hosted operators keep the complete record.
+        if (capture && sentryThrottle.shouldReport(policy.rule)) {
+          capture('Global request body limit rejected a request', {
+            method,
+            body_limit_rule: policy.rule,
+            body_limit_max_size: String(policy.maxSize),
+          });
+        }
+
+        return ctx.json({ error: policy.error }, 413);
+      },
+    })(c, next);
+  };
+}

--- a/apps/api/src/middleware/requestPathLogger.ts
+++ b/apps/api/src/middleware/requestPathLogger.ts
@@ -17,6 +17,9 @@ export function requestPathLogger(
     const method = c.req.method;
     const requestId = newRequestCorrelationId(c.req.header('X-Request-Id'));
     const startedAt = Date.now();
+    // Published on the context so later middleware (e.g. the global body-limit
+    // gate, #3517) can correlate its own logs without re-deriving an ID.
+    c.set('requestCorrelationId', requestId);
     c.header('X-Request-Id', requestId);
     print(`<-- ${method} request_id=${requestId}`);
 

--- a/apps/api/src/routes/agents/logs.ts
+++ b/apps/api/src/routes/agents/logs.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
+import { bodyLimitOnError, reportBodyLimitRejection } from '../../middleware/bodyLimitGate';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
 import { gunzipSync } from 'node:zlib';
@@ -21,6 +22,9 @@ export const logsRoutes = new Hono();
 //   - max(logs)=200: cap rows per request. Combined with the agent's ~60s
 //     ship interval and a 1-2s typical processing budget, this still scales
 //     to ~200 logs/min/agent, which is 5-10x the realistic steady-state rate.
+const LOG_BATCH_MAX_BODY_BYTES = 256 * 1024;
+const LOG_BATCH_TOO_LARGE = 'Log batch too large (max 256KB gzipped)';
+
 const agentLogEntrySchema = z.object({
   timestamp: z.string().datetime({ offset: true }),
   level: z.enum(['debug', 'info', 'warn', 'error']),
@@ -40,8 +44,10 @@ const agentLogIngestSchema = z.object({
 logsRoutes.post(
   '/:id/logs',
   bodyLimit({
-    maxSize: 256 * 1024,
-    onError: (c) => c.json({ error: 'Log batch too large (max 256KB gzipped)' }, 413),
+    maxSize: LOG_BATCH_MAX_BODY_BYTES,
+    // #3517: report the rejection — this limit is tighter than the global gate,
+    // so the instrumented gate never sees it.
+    onError: bodyLimitOnError('agent-logs', LOG_BATCH_MAX_BODY_BYTES, LOG_BATCH_TOO_LARGE),
   }),
   async (c) => {
   const agentId = c.req.param('id');
@@ -60,7 +66,11 @@ logsRoutes.post(
     // body exceeds the configured maxSize (no Content-Length header) — surface
     // it as 413 instead of the generic 400.
     if (err instanceof Error && err.name === 'BodyLimitError') {
-      return c.json({ error: 'Log batch too large (max 256KB gzipped)' }, 413);
+      // Chunked upload with no Content-Length: Hono's gate streams and throws
+      // here instead of calling onError, so this leg needs its own report or
+      // the rejection is still invisible (#3517).
+      reportBodyLimitRejection(c, 'agent-logs', LOG_BATCH_MAX_BODY_BYTES);
+      return c.json({ error: LOG_BATCH_TOO_LARGE }, 413);
     }
     console.error(`[AgentLogs] Failed to decode request body for agent ${agentId}:`, message);
     return c.json({ error: 'Failed to decode request body', detail: message }, 400);

--- a/apps/api/src/routes/agents/logs.ts
+++ b/apps/api/src/routes/agents/logs.ts
@@ -62,13 +62,14 @@ logsRoutes.post(
     body = JSON.parse(decoded.toString('utf-8'));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    // Hono's bodyLimit middleware throws a BodyLimitError when the request
-    // body exceeds the configured maxSize (no Content-Length header) — surface
-    // it as 413 instead of the generic 400.
+    // Vestigial/defensive: kept so an oversize body can never be reported as a
+    // generic 400. Under the pinned hono, `bodyLimit()` returns `onError(c)`
+    // directly on BOTH the Content-Length and the streaming leg and never
+    // throws, so this branch is unreachable today and `BodyLimitError` is
+    // defined nowhere in the tree. It only fires if a future hono reinstates a
+    // throwing path — hence the report, which keeps the 413 visible (#3517)
+    // rather than silently regressing to the pre-#3517 behaviour.
     if (err instanceof Error && err.name === 'BodyLimitError') {
-      // Chunked upload with no Content-Length: Hono's gate streams and throws
-      // here instead of calling onError, so this leg needs its own report or
-      // the rejection is still invisible (#3517).
       reportBodyLimitRejection(c, 'agent-logs', LOG_BATCH_MAX_BODY_BYTES);
       return c.json({ error: LOG_BATCH_TOO_LARGE }, 413);
     }

--- a/apps/api/src/routes/agents/processSample.ts
+++ b/apps/api/src/routes/agents/processSample.ts
@@ -1,11 +1,14 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { bodyLimit } from 'hono/body-limit';
+import { bodyLimitOnError } from '../../middleware/bodyLimitGate';
 import { db } from '../../db';
 import { deviceProcessSamples } from '../../db/schema';
 import { type AgentAuthContext } from '../../middleware/agentAuth';
 import { requireAgentRole } from '../../middleware/requireAgentRole';
 import { processSampleSchema } from './schemas';
+
+const PROCESS_SAMPLE_MAX_BODY_BYTES = 256 * 1024;
 
 export const processSampleRoutes = new Hono();
 // Process-sample ingest is the main agent's job; reject watchdog-role tokens so
@@ -14,7 +17,16 @@ processSampleRoutes.use('*', requireAgentRole);
 
 processSampleRoutes.post(
   '/:id/process-sample',
-  bodyLimit({ maxSize: 256 * 1024, onError: (c) => c.json({ error: 'Request body too large' }, 413) }),
+  bodyLimit({
+    maxSize: PROCESS_SAMPLE_MAX_BODY_BYTES,
+    // #3517: report the rejection — this limit is tighter than the global gate,
+    // so the instrumented gate never sees it.
+    onError: bodyLimitOnError(
+      'agent-process-sample',
+      PROCESS_SAMPLE_MAX_BODY_BYTES,
+      'Request body too large'
+    ),
+  }),
   zValidator('json', processSampleSchema),
   async (c) => {
     const agentId = c.req.param('id');

--- a/apps/api/src/services/safeRequestLabel.ts
+++ b/apps/api/src/services/safeRequestLabel.ts
@@ -1,6 +1,13 @@
 import { randomUUID } from 'node:crypto';
 import type { Context } from 'hono';
 
+declare module 'hono' {
+  interface ContextVariableMap {
+    /** Set by `requestPathLogger`; read back via `requestCorrelationId`. */
+    requestCorrelationId: string;
+  }
+}
+
 export const UNMATCHED_ROUTE_LABEL = 'unmatched';
 
 const CANONICAL_UUID =
@@ -33,4 +40,16 @@ export function safeMatchedRouteLabel(c: Context): string {
 
 export function newRequestCorrelationId(inbound: string | undefined): string {
   return inbound && CANONICAL_UUID.test(inbound) ? inbound : randomUUID();
+}
+
+/**
+ * The correlation ID `requestPathLogger` stamped on this request, or
+ * `'unknown'` if it is missing or not a canonical UUID (e.g. a middleware that
+ * runs before the logger, or a unit test that mounts the gate standalone).
+ * Re-validating keeps a caller-supplied `X-Request-Id` from reaching a log line
+ * or a Sentry tag unchecked, even if the logger's own validation ever moves.
+ */
+export function requestCorrelationId(c: Context): string {
+  const requestId = c.get('requestCorrelationId');
+  return typeof requestId === 'string' && CANONICAL_UUID.test(requestId) ? requestId : 'unknown';
 }

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -95,6 +95,10 @@ describe('sentry service', () => {
     captureMessage('database warning', 'warning', undefined, {
       pg_code: '42501',
       org_id: '00000000-0000-4000-8000-000000000001',
+      // #3517: without these the body-limit 413 event arrives contentless —
+      // scrubEvent strips message/logentry/extra, so the rule label IS the event.
+      body_limit_rule: 'image-upload',
+      body_limit_max_size: '5308416',
       path: '/quotes/raw-capability',
       route_template: '/quotes/:token',
       partner_id: 'x'.repeat(129),
@@ -105,6 +109,8 @@ describe('sentry service', () => {
       'org_id',
       '00000000-0000-4000-8000-000000000001',
     );
+    expect(setTagMock).toHaveBeenCalledWith('body_limit_rule', 'image-upload');
+    expect(setTagMock).toHaveBeenCalledWith('body_limit_max_size', '5308416');
     expect(setTagMock).not.toHaveBeenCalledWith('path', expect.anything());
     expect(setTagMock).not.toHaveBeenCalledWith('route_template', expect.anything());
     expect(setTagMock).not.toHaveBeenCalledWith('partner_id', expect.anything());

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -82,6 +82,16 @@ const ALLOWED_TAG_NAMES = new Set([
   // (DB_POOL_HEALTH_VERDICTS plus the `check-failed` self-report); carries no
   // tenant, device, or host identifier.
   'db_pool_health_verdict',
+  // #3517: the global body-limit gate's 413s carry the carve-out RULE that
+  // matched and its configured byte ceiling. `body_limit_rule` is the closed
+  // `BodyLimitRule` union (middleware/bodyLimit.ts) and `body_limit_max_size` is
+  // a hardcoded constant from that same table — neither is caller-controlled,
+  // and neither contains a raw request path, tenant, device or host identifier.
+  // Without them the event arrives contentless: `scrubEvent` deletes `message`,
+  // `logentry` and `extra`, so the rule label is the only thing that makes the
+  // cluster groupable and actionable.
+  'body_limit_rule',
+  'body_limit_max_size',
 ]);
 const UNSAFE_TAG_CHARACTERS = /[/?#\r\n]/;
 const SAFE_STRUCTURAL_NAME = /^[A-Za-z_$<][A-Za-z0-9_.$<>:[\] ]{0,127}$/;


### PR DESCRIPTION
Closes #3517

## Problem

`apps/api/src/index.ts` mounted the global body-size gate as a bare
`bodyLimit({ maxSize, onError: (ctx) => ctx.json({ error }, 413) })`. `onError`
returned JSON and logged nothing — no structured log, no error ID, no Sentry
event. **Every 413 this middleware has ever produced was invisible
server-side.**

That is why this class of bug keeps reaching customers first: #1377, #2401 and
#3482 were all found by a user hitting a wall, because a route whose limit was
silently shadowed at 1MB looked perfectly healthy from the operator side.
#3516 is the same shape on the agent ingest path, where nobody is watching at
all.

## Approach — option 1 from the issue (carve-out identity, not the path)

Logging `c.req.path` is off the table: `middleware/requestPathLogger.ts` never
emits a raw request path, and this gate runs at `app.use('*')` **before**
routing, so `safeMatchedRouteLabel` has nothing to work with yet.

Instead every branch of `bodyLimitForPath` now returns a stable `rule` label
from a closed `BodyLimitRule` union. It is bounded by construction, needs no
new redaction machinery, and is the dimension operators actually want to group
on — *which limit is firing, and how often*. Adding a carve-out without a label
is a type error.

## What changed

- **`middleware/bodyLimit.ts`** — `bodyLimitForPath` returns `BodyLimitPolicy
  { rule, maxSize, error }`; each of the 10 carve-outs gets a distinct label.
- **`middleware/bodyLimitGate.ts`** (new) — the gate lifted out of `index.ts`,
  now emitting on rejection: `rule`, `method`, configured `max_size`, validated
  `content_length`, and the request correlation ID. `Content-Length` is
  caller-controlled, so it is only echoed when it is a plain decimal integer
  that round-trips; otherwise `unknown`.
- **`requestPathLogger` / `safeRequestLabel`** — the logger publishes its
  correlation ID on the context; `requestCorrelationId(c)` re-validates it as a
  canonical UUID or returns `unknown`, so a forged `X-Request-Id` can never
  reach a log line or a Sentry tag.
- **Sentry** — one event per rule per 5 minutes (a misconfigured limit fires on
  every request from every affected client; its *presence*, not its count,
  drives the fix). The console line is **never** throttled, so self-hosted
  operators keep the complete record. `body_limit_rule` / `body_limit_max_size`
  are allowlisted in `sentry.ts` — `scrubEvent` deletes `message`, `logentry`
  and `extra`, so without them the event would arrive contentless and
  ungroupable.
- **Drift guard (#3511)** — `bodyLimitGate.ts` added to `SCAN_EXEMPT`; it *is*
  the global gate, not a shadowed route-level limit.

## Behavior preserved

Status codes, error message bodies, every `maxSize`, and the `/oauth` bypass
(oidc-provider reads the raw Node stream itself) are unchanged. This PR adds
telemetry only.

## Tests

- `middleware/bodyLimitGate.test.ts` (new, 7 cases): asserts the emitted record
  never contains the raw path or the query string, that the matched carve-out
  rule is reported (not just `default`), Sentry throttling vs. complete console
  logging, `request_id=unknown` for a forged `X-Request-Id`, `content_length=unknown`
  for a streamed body, `/oauth` passthrough, and silence under the limit.
- `middleware/bodyLimit.test.ts`: existing assertions extended with `rule`, plus
  a new case proving every carve-out has a **distinct, non-`default`** label
  that is safe as a Sentry tag value.
- `services/sentry.test.ts`: the two new tags survive the allowlist.

`vitest run` (serial) on bodyLimit / bodyLimitGate / sentry / requestPathLogger:
**55 passed**. `tsc --noEmit` on `apps/api`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)