### PR TITLE
fix(api,agent): fail loudly when a release is registered without a signed manifest (#3544)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -536,6 +536,13 @@ type Heartbeat struct {
 	// Tracks whether the read-only FS error has been logged (prevents log spam)
 	updateReadOnlyLogged bool
 
+	// Cooldown state for an upgrade target the server refused as untrusted
+	// (updater.ErrUntrustedRelease / HTTP 409). Guarded by untrustedReleaseMu
+	// because doUpgrade runs on a goroutine per heartbeat. Issue #3544.
+	untrustedReleaseMu  sync.Mutex
+	untrustedReleaseVer string
+	untrustedReleaseAt  time.Time
+
 	// Path to the agent state file, set by main after startup.
 	statePath string
 
@@ -6578,8 +6585,48 @@ func (h *Heartbeat) reconcileUserHelperFromExecutable() {
 	h.reconcileUserHelper(binaryPath)
 }
 
+// untrustedReleaseRetryCooldown bounds how often an upgrade target the server
+// has already refused to serve (HTTP 409, updater.ErrUntrustedRelease) is
+// retried. The condition is terminal for that version — no amount of retrying
+// on the device can produce a signed manifest — but it is not permanent: an
+// operator re-registering the version with a signed manifest must recover
+// automatically, so this is a cooldown rather than a hard disable (unlike
+// ErrReadOnlyFS, which calls setAutoUpdate(false)). Mirrors
+// watchdogUpgradeRetryCooldown. Issue #3544, where every device in a fleet
+// re-attempted the same doomed upgrade every ~60s indefinitely.
+const untrustedReleaseRetryCooldown = 30 * time.Minute
+
+// untrustedReleaseBackoffActive reports whether targetVersion was already
+// refused as untrusted within the cooldown window. Tracked per version so a
+// NEW upgrade target is always attempted immediately.
+func (h *Heartbeat) untrustedReleaseBackoffActive(targetVersion string) bool {
+	h.untrustedReleaseMu.Lock()
+	defer h.untrustedReleaseMu.Unlock()
+	return h.untrustedReleaseVer == targetVersion &&
+		time.Since(h.untrustedReleaseAt) < untrustedReleaseRetryCooldown
+}
+
+// noteUntrustedRelease starts (or restarts) the cooldown for targetVersion.
+func (h *Heartbeat) noteUntrustedRelease(targetVersion string) {
+	h.untrustedReleaseMu.Lock()
+	defer h.untrustedReleaseMu.Unlock()
+	h.untrustedReleaseVer = targetVersion
+	h.untrustedReleaseAt = time.Now()
+}
+
 // doUpgrade contains the actual upgrade logic, called by handleUpgrade.
 func (h *Heartbeat) doUpgrade(targetVersion string) {
+	// Checked before sendUpdateStatus and before any download work: the server
+	// re-sends the same upgradeTo on every heartbeat, so without this the
+	// device would keep announcing "Updating" and re-running the whole
+	// prefetch + download path for a version the server is guaranteed to
+	// refuse again.
+	if h.untrustedReleaseBackoffActive(targetVersion) {
+		log.Debug("upgrade skipped: server recently refused this version as untrusted; backing off",
+			"targetVersion", targetVersion)
+		return
+	}
+
 	log.Info("upgrade requested", "targetVersion", targetVersion)
 
 	h.sendUpdateStatus(targetVersion)
@@ -6679,6 +6726,21 @@ func (h *Heartbeat) doUpgrade(targetVersion string) {
 		// Binary is currently executing (ETXTBSY) — transient, retry next heartbeat.
 		if errors.Is(err, updater.ErrTextBusy) {
 			log.Warn("update deferred: binary is executing, will retry", "targetVersion", targetVersion, "error", err.Error())
+			return
+		}
+		// The server refused to serve this version (409): its registered
+		// release manifest is missing or does not verify. Terminal for this
+		// target until an operator fixes the registration, so back off instead
+		// of retrying every heartbeat. err.Error() is safe to log here — it is
+		// a plain error built from the sentinel plus a sanitized snake_case
+		// reason (see updater.downloadInfoRejectionReason), never a *url.Error
+		// carrying the request URL. Issue #3544.
+		if errors.Is(err, updater.ErrUntrustedRelease) {
+			h.noteUntrustedRelease(targetVersion)
+			log.Error("auto-update blocked: the server has this version registered without a valid signed release manifest — re-register it with a signed manifest, or promote a different version",
+				"targetVersion", targetVersion,
+				"error", err.Error(),
+				"retryAfter", untrustedReleaseRetryCooldown.String())
 			return
 		}
 		// A download failure here may carry a *netpolicy.PolicyError, or be a

--- a/agent/internal/heartbeat/untrusted_release_backoff_test.go
+++ b/agent/internal/heartbeat/untrusted_release_backoff_test.go
@@ -1,0 +1,92 @@
+package heartbeat
+
+import (
+	"testing"
+	"time"
+)
+
+// Issue #3544: when the control plane refuses an upgrade target as untrusted
+// (HTTP 409 -> updater.ErrUntrustedRelease), the condition is terminal for
+// that version — retrying cannot produce a signed manifest — but it is NOT
+// permanent, because an operator re-registering the version must recover the
+// fleet automatically. So doUpgrade backs off per target version instead of
+// disabling auto-update. These tests pin that policy on the decision helpers
+// doUpgrade delegates to.
+
+func TestUntrustedReleaseBackoff_InactiveBeforeAnyRejection(t *testing.T) {
+	h := &Heartbeat{}
+	if h.untrustedReleaseBackoffActive("0.105.1") {
+		t.Fatal("a target that was never rejected must not be backed off")
+	}
+}
+
+func TestUntrustedReleaseBackoff_ActiveAfterRejection(t *testing.T) {
+	h := &Heartbeat{}
+	h.noteUntrustedRelease("0.105.1")
+	if !h.untrustedReleaseBackoffActive("0.105.1") {
+		t.Fatal("a just-rejected target must be backed off, not retried next heartbeat")
+	}
+}
+
+// The whole point of the cooldown: the server re-sends the same upgradeTo on
+// every heartbeat (~60s), so without keying on it the device re-runs the full
+// prefetch + download path forever. This is the exact reported symptom.
+func TestUntrustedReleaseBackoff_SuppressesRepeatedHeartbeats(t *testing.T) {
+	h := &Heartbeat{}
+	attempts := 0
+	for i := 0; i < 60; i++ { // an hour of heartbeats at ~60s
+		if h.untrustedReleaseBackoffActive("0.105.1") {
+			continue
+		}
+		attempts++
+		h.noteUntrustedRelease("0.105.1")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 attempt across 60 heartbeats, got %d", attempts)
+	}
+}
+
+// Keyed on the target version: promoting a DIFFERENT version is the operator's
+// fix for this condition, so it must take effect on the very next heartbeat
+// rather than waiting out a cooldown earned by the broken version.
+func TestUntrustedReleaseBackoff_NewTargetIsNotThrottled(t *testing.T) {
+	h := &Heartbeat{}
+	h.noteUntrustedRelease("0.105.1")
+	if h.untrustedReleaseBackoffActive("0.105.2") {
+		t.Fatal("a different target version must not inherit the cooldown")
+	}
+}
+
+// Not permanent: re-registering the SAME version with a signed manifest must
+// recover without restarting the agent.
+func TestUntrustedReleaseBackoff_ExpiresAfterCooldown(t *testing.T) {
+	h := &Heartbeat{}
+	h.noteUntrustedRelease("0.105.1")
+
+	h.untrustedReleaseMu.Lock()
+	h.untrustedReleaseAt = time.Now().Add(-2 * untrustedReleaseRetryCooldown)
+	h.untrustedReleaseMu.Unlock()
+
+	if h.untrustedReleaseBackoffActive("0.105.1") {
+		t.Fatal("the cooldown must expire so a fixed registration recovers on its own")
+	}
+}
+
+// doUpgrade runs on a goroutine per heartbeat, so the state must be safe
+// under concurrent access (-race makes this meaningful).
+func TestUntrustedReleaseBackoff_ConcurrentAccess(t *testing.T) {
+	h := &Heartbeat{}
+	done := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for j := 0; j < 200; j++ {
+				h.noteUntrustedRelease("0.105.1")
+				_ = h.untrustedReleaseBackoffActive("0.105.1")
+			}
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		<-done
+	}
+}

--- a/agent/internal/updater/untrusted_release_test.go
+++ b/agent/internal/updater/untrusted_release_test.go
@@ -159,9 +159,16 @@ func TestDownloadInfoRejectionReasonBoundsBodySize(t *testing.T) {
 	// agent just to produce a log line. The truncated read yields invalid
 	// JSON, so the reason is dropped.
 	huge := `{"reason":"` + strings.Repeat("a", maxDownloadInfoErrorBodyBytes*2) + `"}`
-	got, _ := downloadInfoRejectionReason(strings.NewReader(huge))
+	got, malformed := downloadInfoRejectionReason(strings.NewReader(huge))
 	if got != "" {
 		t.Fatalf("expected oversized body to yield no reason, got %q", got)
+	}
+	// A truncated body is inconclusive, NOT absent: a reason may have been
+	// present and simply cut off mid-string. Reporting it as "server gave no
+	// reason" would be the same silent collapse the malformed flag exists to
+	// prevent, reached through size rather than charset.
+	if !malformed {
+		t.Fatal("a truncated body must be reported as malformed, not as an absent reason")
 	}
 }
 

--- a/agent/internal/updater/untrusted_release_test.go
+++ b/agent/internal/updater/untrusted_release_test.go
@@ -1,0 +1,145 @@
+package updater
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/secmem"
+)
+
+// Issue #3544: the control plane answers download-info with 409 + a
+// machine-readable `reason` when a registered version has no valid signed
+// release manifest. The agent used to discard the body entirely and report
+// only "download info request failed with status 409", then retry every
+// heartbeat forever. These tests pin both halves of the fix: the reason is
+// surfaced, and the failure is classified as terminal via ErrUntrustedRelease.
+
+func newDownloadInfo409Server(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/download") {
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		if body != "" {
+			_, _ = w.Write([]byte(body))
+		}
+	}))
+}
+
+func downloadBinaryAgainst(t *testing.T, server *httptest.Server) error {
+	t.Helper()
+	u := New(&Config{
+		ServerURL: staticServerURL(server.URL),
+		AuthToken: secmem.NewSecureString("test-token"),
+	})
+	u.client = server.Client()
+	_, _, _, err := u.downloadBinary("1.0.0")
+	if err == nil {
+		t.Fatal("expected download to fail on 409")
+	}
+	return err
+}
+
+func TestDownloadBinary409SurfacesReasonAndIsTerminal(t *testing.T) {
+	server := newDownloadInfo409Server(t, `{"error":"Release manifest is not trusted","reason":"signed_release_manifest_required"}`)
+	defer server.Close()
+
+	err := downloadBinaryAgainst(t, server)
+
+	if !errors.Is(err, ErrUntrustedRelease) {
+		t.Fatalf("expected ErrUntrustedRelease, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "signed_release_manifest_required") {
+		t.Fatalf("expected the server's reason in the error, got %q", err.Error())
+	}
+	// The old opaque message must be gone — it is what made #3544 take hours
+	// to diagnose.
+	if strings.Contains(err.Error(), "failed with status 409") {
+		t.Fatalf("409 still reported as an opaque status: %q", err.Error())
+	}
+}
+
+func TestDownloadBinary409WithoutReasonStillTerminal(t *testing.T) {
+	// A control plane that predates the `reason` field, or an intermediary
+	// that replaced the body, must still be classified as terminal — the
+	// backoff must not depend on parsing succeeding.
+	for name, body := range map[string]string{
+		"empty body":     "",
+		"not json":       "gateway timeout",
+		"json no reason": `{"error":"nope"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			server := newDownloadInfo409Server(t, body)
+			defer server.Close()
+
+			err := downloadBinaryAgainst(t, server)
+			if !errors.Is(err, ErrUntrustedRelease) {
+				t.Fatalf("expected ErrUntrustedRelease, got %v", err)
+			}
+		})
+	}
+}
+
+func TestDownloadInfoRejectionReasonSanitizesServerText(t *testing.T) {
+	// The reason lands in agent logs, so only the closed set of lowercase
+	// snake_case identifiers is accepted. Anything else is dropped rather
+	// than echoed — consistent with how the redirect branch of
+	// parseDownloadInfo and SafeDownloadErrorFields treat server-supplied
+	// text.
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"valid reason", `{"reason":"invalid_release_manifest_signature"}`, "invalid_release_manifest_signature"},
+		{"uppercase rejected", `{"reason":"Signed_Manifest"}`, ""},
+		{"url rejected", `{"reason":"https://evil.example/?token=abc"}`, ""},
+		{"spaces rejected", `{"reason":"some prose with detail"}`, ""},
+		{"newline injection rejected", `{"reason":"ok\nfake=log line"}`, ""},
+		{"digits rejected", `{"reason":"reason123"}`, ""},
+		{"empty rejected", `{"reason":""}`, ""},
+		{"overlong rejected", `{"reason":"` + strings.Repeat("a", 65) + `"}`, ""},
+		{"max length accepted", `{"reason":"` + strings.Repeat("a", 64) + `"}`, strings.Repeat("a", 64)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := downloadInfoRejectionReason(strings.NewReader(tc.body)); got != tc.want {
+				t.Fatalf("reason = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDownloadInfoRejectionReasonBoundsBodySize(t *testing.T) {
+	// A hostile endpoint must not be able to stream unbounded data into the
+	// agent just to produce a log line. The truncated read yields invalid
+	// JSON, so the reason is dropped.
+	huge := `{"reason":"` + strings.Repeat("a", maxDownloadInfoErrorBodyBytes*2) + `"}`
+	if got := downloadInfoRejectionReason(strings.NewReader(huge)); got != "" {
+		t.Fatalf("expected oversized body to yield no reason, got %q", got)
+	}
+}
+
+func TestNon409StatusStillReportsOpaqueStatus(t *testing.T) {
+	// Only 409 is terminal. Other failures (e.g. a 503 from a restarting
+	// control plane) must keep retrying on the normal heartbeat cadence.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	err := downloadBinaryAgainst(t, server)
+	if errors.Is(err, ErrUntrustedRelease) {
+		t.Fatalf("503 must not be classified as terminal: %v", err)
+	}
+	if !strings.Contains(err.Error(), "503") {
+		t.Fatalf("expected status in error, got %q", err.Error())
+	}
+}

--- a/agent/internal/updater/untrusted_release_test.go
+++ b/agent/internal/updater/untrusted_release_test.go
@@ -93,27 +93,64 @@ func TestDownloadInfoRejectionReasonSanitizesServerText(t *testing.T) {
 	// than echoed — consistent with how the redirect branch of
 	// parseDownloadInfo and SafeDownloadErrorFields treat server-supplied
 	// text.
+	//
+	// `malformed` distinguishes "the server sent a reason we refused" from
+	// "the server sent no reason". Collapsing those would hide a future
+	// server/agent vocabulary drift forever — the exact silent failure this
+	// change exists to remove.
 	tests := []struct {
-		name string
-		body string
-		want string
+		name          string
+		body          string
+		want          string
+		wantMalformed bool
 	}{
-		{"valid reason", `{"reason":"invalid_release_manifest_signature"}`, "invalid_release_manifest_signature"},
-		{"uppercase rejected", `{"reason":"Signed_Manifest"}`, ""},
-		{"url rejected", `{"reason":"https://evil.example/?token=abc"}`, ""},
-		{"spaces rejected", `{"reason":"some prose with detail"}`, ""},
-		{"newline injection rejected", `{"reason":"ok\nfake=log line"}`, ""},
-		{"digits rejected", `{"reason":"reason123"}`, ""},
-		{"empty rejected", `{"reason":""}`, ""},
-		{"overlong rejected", `{"reason":"` + strings.Repeat("a", 65) + `"}`, ""},
-		{"max length accepted", `{"reason":"` + strings.Repeat("a", 64) + `"}`, strings.Repeat("a", 64)},
+		{"valid reason", `{"reason":"invalid_release_manifest_signature"}`, "invalid_release_manifest_signature", false},
+		{"max length accepted", `{"reason":"` + strings.Repeat("a", 64) + `"}`, strings.Repeat("a", 64), false},
+
+		// Refused, but the caller must still learn a reason WAS present.
+		{"uppercase refused", `{"reason":"Signed_Manifest"}`, "", true},
+		{"url refused", `{"reason":"https://evil.example/?token=abc"}`, "", true},
+		{"spaces refused", `{"reason":"some prose with detail"}`, "", true},
+		{"newline injection refused", `{"reason":"ok\nfake=log line"}`, "", true},
+		{"digits refused", `{"reason":"reason123"}`, "", true},
+		{"overlong refused", `{"reason":"` + strings.Repeat("a", 65) + `"}`, "", true},
+
+		// Genuinely absent — not malformed, nothing was refused.
+		{"empty reason field", `{"reason":""}`, "", false},
+		{"no reason field", `{"error":"nope"}`, "", false},
+		{"not json", `<html>gateway timeout</html>`, "", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := downloadInfoRejectionReason(strings.NewReader(tc.body)); got != tc.want {
+			got, malformed := downloadInfoRejectionReason(strings.NewReader(tc.body))
+			if got != tc.want {
 				t.Fatalf("reason = %q, want %q", got, tc.want)
 			}
+			if malformed != tc.wantMalformed {
+				t.Fatalf("malformed = %v, want %v", malformed, tc.wantMalformed)
+			}
 		})
+	}
+}
+
+// A refused reason must produce a DIFFERENT operator-visible message than an
+// absent one, and must never echo the raw server text.
+func TestDownloadBinary409RefusedReasonIsDistinguishable(t *testing.T) {
+	server := newDownloadInfo409Server(t, `{"reason":"https://evil.example/?token=SECRET"}`)
+	defer server.Close()
+
+	err := downloadBinaryAgainst(t, server)
+	if !errors.Is(err, ErrUntrustedRelease) {
+		t.Fatalf("expected ErrUntrustedRelease, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "unrecognized reason code") {
+		t.Fatalf("a refused reason must be reported as such, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "gave no reason") {
+		t.Fatalf("a refused reason must not be reported as an absent one: %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "evil.example") || strings.Contains(err.Error(), "SECRET") {
+		t.Fatalf("raw server text leaked into the error: %q", err.Error())
 	}
 }
 
@@ -122,7 +159,8 @@ func TestDownloadInfoRejectionReasonBoundsBodySize(t *testing.T) {
 	// agent just to produce a log line. The truncated read yields invalid
 	// JSON, so the reason is dropped.
 	huge := `{"reason":"` + strings.Repeat("a", maxDownloadInfoErrorBodyBytes*2) + `"}`
-	if got := downloadInfoRejectionReason(strings.NewReader(huge)); got != "" {
+	got, _ := downloadInfoRejectionReason(strings.NewReader(huge))
+	if got != "" {
 		t.Fatalf("expected oversized body to yield no reason, got %q", got)
 	}
 }

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -302,31 +302,46 @@ type downloadInfoError struct {
 const maxDownloadInfoErrorBodyBytes = 4 << 10
 
 // downloadInfoRejectionReason extracts the machine-readable `reason` from a
-// refused download-info response, or "" when the body carries none.
+// refused download-info response.
 //
 // The value is deliberately sanitized rather than echoed verbatim: it lands in
 // agent logs, and the surrounding code is careful never to let server-supplied
 // text reach them unfiltered (see SafeDownloadErrorFields and the redirect
 // branch of parseDownloadInfo). Reasons are a closed set of lowercase
-// snake_case identifiers, so anything else is dropped rather than logged.
-func downloadInfoRejectionReason(body io.Reader) string {
+// snake_case identifiers, so anything else is refused.
+//
+// The two failure modes are reported separately (`malformed`), because
+// collapsing them is itself a silent failure — the exact class of bug this
+// whole change exists to remove. If the API's reason vocabulary ever drifts
+// outside the charset the agent accepts (a digit, a capital, over-length),
+// returning a bare "" would make a REFUSED reason indistinguishable from a
+// server that sent none, and the drift would be invisible in agent logs
+// forever. The raw value is still never returned: naming the shape of the
+// problem is enough to diagnose it without letting server text into logs.
+func downloadInfoRejectionReason(body io.Reader) (reason string, malformed bool) {
 	raw, err := io.ReadAll(io.LimitReader(body, maxDownloadInfoErrorBodyBytes))
 	if err != nil {
-		return ""
+		return "", false
 	}
 	var parsed downloadInfoError
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		return ""
+		// Body is not the JSON error envelope at all (an empty body, or an
+		// intermediary's HTML error page). Nothing was refused — there was
+		// nothing to refuse.
+		return "", false
 	}
-	if parsed.Reason == "" || len(parsed.Reason) > 64 {
-		return ""
+	if parsed.Reason == "" {
+		return "", false
+	}
+	if len(parsed.Reason) > 64 {
+		return "", true
 	}
 	for _, r := range parsed.Reason {
 		if (r < 'a' || r > 'z') && r != '_' {
-			return ""
+			return "", true
 		}
 	}
-	return parsed.Reason
+	return parsed.Reason, false
 }
 
 // maxUpdateBinaryBytes bounds both the netpolicy transport (Policy.
@@ -1074,10 +1089,18 @@ func (u *Updater) parseDownloadInfo(resp *http.Response) (downloadInfo, error) {
 		// forever while the body's specific, actionable `reason` was thrown
 		// away. Surface the reason and mark the failure terminal so callers
 		// can back off.
-		if reason := downloadInfoRejectionReason(resp.Body); reason != "" {
+		reason, malformed := downloadInfoRejectionReason(resp.Body)
+		switch {
+		case reason != "":
 			return downloadInfo{}, fmt.Errorf("%w: %s", ErrUntrustedRelease, reason)
+		case malformed:
+			// The server DID send a reason, but not one this agent will put in
+			// a log. Say so explicitly: silently reporting "no reason" would
+			// hide a server/agent vocabulary drift indefinitely.
+			return downloadInfo{}, fmt.Errorf("%w: server sent an unrecognized reason code (refused as unsafe to log)", ErrUntrustedRelease)
+		default:
+			return downloadInfo{}, fmt.Errorf("%w: server gave no reason", ErrUntrustedRelease)
 		}
-		return downloadInfo{}, fmt.Errorf("%w: server gave no reason", ErrUntrustedRelease)
 
 	default:
 		return downloadInfo{}, fmt.Errorf("download info request failed with status %d", resp.StatusCode)

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -278,6 +278,57 @@ var ErrReadOnlyFS = fmt.Errorf("binary path is on a read-only filesystem")
 // but this sentinel prevents misclassification as ErrReadOnlyFS.
 var ErrTextBusy = fmt.Errorf("binary is currently executing")
 
+// ErrUntrustedRelease is returned when the control plane refuses to serve
+// download info for the requested version because the registered release is
+// not trusted (HTTP 409). This is TERMINAL for the current target version:
+// nothing on the device can fix it, and it stays broken until an operator
+// re-registers the version with a signed manifest. Callers must back off
+// rather than retry every heartbeat (issue #3544).
+var ErrUntrustedRelease = fmt.Errorf("release is not trusted by the server")
+
+// downloadInfoError is the control plane's error body for a refused
+// download-info request. `reason` is a machine-readable enum produced by
+// validateReleaseManifest in apps/api/src/routes/agentVersions.ts (e.g.
+// "signed_release_manifest_required", "invalid_release_manifest_signature").
+// Only `reason` is consumed — `error` is human prose that may change freely.
+type downloadInfoError struct {
+	Reason string `json:"reason"`
+}
+
+// maxDownloadInfoErrorBodyBytes bounds how much of a non-2xx body we read
+// before giving up on finding a reason. The real bodies are well under 200
+// bytes; the cap keeps a hostile or misconfigured endpoint from streaming
+// unbounded data into the agent just to produce a log line.
+const maxDownloadInfoErrorBodyBytes = 4 << 10
+
+// downloadInfoRejectionReason extracts the machine-readable `reason` from a
+// refused download-info response, or "" when the body carries none.
+//
+// The value is deliberately sanitized rather than echoed verbatim: it lands in
+// agent logs, and the surrounding code is careful never to let server-supplied
+// text reach them unfiltered (see SafeDownloadErrorFields and the redirect
+// branch of parseDownloadInfo). Reasons are a closed set of lowercase
+// snake_case identifiers, so anything else is dropped rather than logged.
+func downloadInfoRejectionReason(body io.Reader) string {
+	raw, err := io.ReadAll(io.LimitReader(body, maxDownloadInfoErrorBodyBytes))
+	if err != nil {
+		return ""
+	}
+	var parsed downloadInfoError
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return ""
+	}
+	if parsed.Reason == "" || len(parsed.Reason) > 64 {
+		return ""
+	}
+	for _, r := range parsed.Reason {
+		if (r < 'a' || r > 'z') && r != '_' {
+			return ""
+		}
+	}
+	return parsed.Reason
+}
+
 // maxUpdateBinaryBytes bounds both the netpolicy transport (Policy.
 // MaxResponseBytes) and the explicit CopyBounded call in downloadFromURL. A
 // var (not const), matching the trustedUpdateManifestPublicKeys pattern in
@@ -1014,6 +1065,19 @@ func (u *Updater) parseDownloadInfo(resp *http.Response) (downloadInfo, error) {
 		// SafeDownloadErrorFields's stripping does not apply to it), and the
 		// target may carry a capability query string.
 		return downloadInfo{}, fmt.Errorf("download redirects are not trusted without a signed release manifest")
+
+	case http.StatusConflict:
+		// The server registered this version but refuses to serve it: the
+		// release manifest is missing or does not verify. Before #3544 this
+		// fell through to the bare status-code message below, so the agent
+		// logged "download info request failed with status 409" every ~60s
+		// forever while the body's specific, actionable `reason` was thrown
+		// away. Surface the reason and mark the failure terminal so callers
+		// can back off.
+		if reason := downloadInfoRejectionReason(resp.Body); reason != "" {
+			return downloadInfo{}, fmt.Errorf("%w: %s", ErrUntrustedRelease, reason)
+		}
+		return downloadInfo{}, fmt.Errorf("%w: server gave no reason", ErrUntrustedRelease)
 
 	default:
 		return downloadInfo{}, fmt.Errorf("download info request failed with status %d", resp.StatusCode)

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -323,12 +323,19 @@ func downloadInfoRejectionReason(body io.Reader) (reason string, malformed bool)
 	if err != nil {
 		return "", false
 	}
+	// Reading exactly the cap means the body was cut off, so anything we
+	// failed to parse below is inconclusive rather than absent — a reason may
+	// well have been present and simply truncated mid-string. Folding that
+	// into "server gave no reason" would be the same collapse this function
+	// exists to avoid, reached through size instead of charset.
+	truncated := len(raw) == maxDownloadInfoErrorBodyBytes
+
 	var parsed downloadInfoError
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		// Body is not the JSON error envelope at all (an empty body, or an
-		// intermediary's HTML error page). Nothing was refused — there was
-		// nothing to refuse.
-		return "", false
+		// Otherwise the body is not the JSON error envelope at all (an empty
+		// body, or an intermediary's HTML error page). Nothing was refused —
+		// there was nothing to refuse.
+		return "", truncated
 	}
 	if parsed.Reason == "" {
 		return "", false

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -149,6 +149,59 @@ function makeSignedReleaseArtifactManifest(args: {
   };
 }
 
+// POST /agent-versions now requires a signed release manifest (issue #3544).
+// With no trust roots configured (the default in this suite — no env keys,
+// getActivePublicKeys mocked to []), verifyEd25519ManifestSignature soft-
+// passes any signature string, so tests only need the manifest's metadata
+// fields to exactly match the submitted payload. Reuses the exact-match
+// contract from validateReleaseManifest's non-schemaVersion-1 branch.
+function withValidManifest(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  const manifest = JSON.stringify({
+    version: payload.version,
+    component: payload.component ?? "agent",
+    platform: payload.platform,
+    arch: payload.architecture,
+    url: payload.downloadUrl,
+    checksum: payload.checksum,
+  });
+  return {
+    ...payload,
+    releaseManifest: manifest,
+    manifestSignature: "test-signature",
+  };
+}
+
+// Same idea for POST /agent-versions/promote's target-row select mock: the
+// row shape validateReleaseManifest needs (downloadUrl/checksum/manifest/
+// signature) plus a manifest whose fields match the row exactly.
+function makeValidatedTargetRow(row: {
+  component: string;
+  platform: string;
+  architecture: string;
+  version: string;
+}) {
+  const downloadUrl = `https://s3.example.com/${row.component}-${row.version}`;
+  const checksum = "f".repeat(64);
+  const manifest = JSON.stringify({
+    version: row.version,
+    component: row.component,
+    platform: row.platform,
+    arch: row.architecture,
+    url: downloadUrl,
+    checksum,
+  });
+  return {
+    ...row,
+    downloadUrl,
+    checksum,
+    fileSize: null,
+    releaseManifest: manifest,
+    manifestSignature: "test-signature",
+  };
+}
+
 describe("agentVersions routes", () => {
   let app: Hono;
 
@@ -313,8 +366,8 @@ describe("agentVersions routes", () => {
       // The pre-tx target-rows lookup: two components on the same platform/arch.
       vi.mocked(db.select).mockReturnValue(
         selectResolving([
-          { component: "agent", platform: "linux", architecture: "amd64" },
-          { component: "watchdog", platform: "linux", architecture: "amd64" },
+          makeValidatedTargetRow({ component: "agent", platform: "linux", architecture: "amd64", version: "0.71.0" }),
+          makeValidatedTargetRow({ component: "watchdog", platform: "linux", architecture: "amd64", version: "0.71.0" }),
         ]) as any,
       );
 
@@ -377,7 +430,7 @@ describe("agentVersions routes", () => {
     it("promotes only the requested single component", async () => {
       vi.mocked(db.select).mockReturnValue(
         selectResolving([
-          { component: "agent", platform: "linux", architecture: "amd64" },
+          makeValidatedTargetRow({ component: "agent", platform: "linux", architecture: "amd64", version: "0.71.0" }),
         ]) as any,
       );
 
@@ -416,7 +469,7 @@ describe("agentVersions routes", () => {
       process.env.BINARY_EDITION = "hosted";
 
       const targetRowsWhere = vi.fn().mockResolvedValue([
-        { component: "agent", platform: "linux", architecture: "amd64" },
+        makeValidatedTargetRow({ component: "agent", platform: "linux", architecture: "amd64", version: "0.71.0" }),
       ]);
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({ where: targetRowsWhere }),
@@ -461,9 +514,9 @@ describe("agentVersions routes", () => {
     it("promoting with component omitted includes backup rows alongside agent/watchdog", async () => {
       vi.mocked(db.select).mockReturnValue(
         selectResolving([
-          { component: "agent", platform: "linux", architecture: "amd64" },
-          { component: "watchdog", platform: "linux", architecture: "amd64" },
-          { component: "backup", platform: "linux", architecture: "amd64" },
+          makeValidatedTargetRow({ component: "agent", platform: "linux", architecture: "amd64", version: "0.71.0" }),
+          makeValidatedTargetRow({ component: "watchdog", platform: "linux", architecture: "amd64", version: "0.71.0" }),
+          makeValidatedTargetRow({ component: "backup", platform: "linux", architecture: "amd64", version: "0.71.0" }),
         ]) as any,
       );
 
@@ -492,6 +545,115 @@ describe("agentVersions routes", () => {
             components: expect.arrayContaining(["backup"]),
           }),
         }),
+      );
+    });
+
+    // Regression coverage for issue #3544: promote must refuse a target row
+    // that GET /:version/download would itself reject, BEFORE the demotion
+    // transaction runs — otherwise the fleet's currently-working upgrade
+    // target gets stripped on behalf of a promotion that's about to fail.
+    it("409s with signed_release_manifest_required when a target row has a NULL release manifest, and never runs the demotion transaction", async () => {
+      vi.mocked(db.select).mockReturnValue(
+        selectResolving([
+          {
+            component: "agent",
+            platform: "linux",
+            architecture: "amd64",
+            version: "0.71.0",
+            downloadUrl: "https://s3.example.com/agent-0.71.0",
+            checksum: "f".repeat(64),
+            fileSize: null,
+            releaseManifest: null,
+            manifestSignature: null,
+          },
+        ]) as any,
+      );
+
+      const res = await app.request("/agent-versions/promote", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ version: "0.71.0", component: "agent" }),
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toBe("Release manifest is not trusted");
+      expect(body.reason).toBe("signed_release_manifest_required");
+      expect(body.invalidTargets).toEqual([
+        {
+          component: "agent",
+          platform: "linux",
+          architecture: "amd64",
+          reason: "signed_release_manifest_required",
+        },
+      ]);
+      // The demotion/promotion transaction never ran — the previously
+      // promoted row for this slot is untouched.
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it("409s when only SOME target rows fail validation — any failure rejects the whole promotion, never a partial one", async () => {
+      vi.mocked(db.select).mockReturnValue(
+        selectResolving([
+          makeValidatedTargetRow({ component: "agent", platform: "linux", architecture: "amd64", version: "0.71.0" }),
+          {
+            component: "watchdog",
+            platform: "linux",
+            architecture: "amd64",
+            version: "0.71.0",
+            downloadUrl: "https://s3.example.com/watchdog-0.71.0",
+            checksum: "f".repeat(64),
+            fileSize: null,
+            releaseManifest: null,
+            manifestSignature: null,
+          },
+        ]) as any,
+      );
+
+      const res = await app.request("/agent-versions/promote", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ version: "0.71.0" }),
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.reason).toBe("signed_release_manifest_required");
+      expect(body.invalidTargets).toEqual([
+        expect.objectContaining({ component: "watchdog", reason: "signed_release_manifest_required" }),
+      ]);
+      // Even the valid "agent" slot must not be promoted — the whole
+      // operation is atomic across its target rows.
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it("still succeeds when every target row carries a valid signed manifest (happy-path regression guard)", async () => {
+      vi.mocked(db.select).mockReturnValue(
+        selectResolving([
+          makeValidatedTargetRow({ component: "agent", platform: "linux", architecture: "amd64", version: "0.71.0" }),
+          makeValidatedTargetRow({ component: "watchdog", platform: "linux", architecture: "amd64", version: "0.71.0" }),
+        ]) as any,
+      );
+
+      const { tx } = makeTx({ version: "0.70.0" });
+      vi.mocked(db.transaction).mockImplementation(
+        async (fn: any) => fn(tx) as any,
+      );
+
+      const res = await app.request("/agent-versions/promote", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ version: "0.71.0" }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.transaction).toHaveBeenCalled();
+      const body = await res.json();
+      expect(body.promoted).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ component: "agent", version: "0.71.0" }),
+          expect.objectContaining({ component: "watchdog", version: "0.71.0" }),
+        ]),
       );
     });
   });
@@ -1599,13 +1761,15 @@ describe("agentVersions routes", () => {
       const res = await app.request("/agent-versions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          version: "1.0.0",
-          platform: "linux",
-          architecture: "amd64",
-          downloadUrl: "https://s3.example.com/agent-1.0.0",
-          checksum: "c".repeat(64),
-        }),
+        body: JSON.stringify(
+          withValidManifest({
+            version: "1.0.0",
+            platform: "linux",
+            architecture: "amd64",
+            downloadUrl: "https://s3.example.com/agent-1.0.0",
+            checksum: "c".repeat(64),
+          }),
+        ),
       });
 
       expect(res.status).toBe(201);
@@ -1626,13 +1790,15 @@ describe("agentVersions routes", () => {
       const res = await app.request("/agent-versions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          version: "1.0.0",
-          platform: "linux",
-          architecture: "amd64",
-          downloadUrl: "https://s3.example.com/agent-1.0.0",
-          checksum: "c".repeat(64),
-        }),
+        body: JSON.stringify(
+          withValidManifest({
+            version: "1.0.0",
+            platform: "linux",
+            architecture: "amd64",
+            downloadUrl: "https://s3.example.com/agent-1.0.0",
+            checksum: "c".repeat(64),
+          }),
+        ),
       });
 
       expect(res.status).toBe(201);
@@ -1654,14 +1820,16 @@ describe("agentVersions routes", () => {
       const res = await app.request("/agent-versions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          version: "1.0.0",
-          platform: "linux",
-          architecture: "amd64",
-          downloadUrl: "https://s3.example.com/agent-1.0.0",
-          checksum: "c".repeat(64),
-          edition: "hosted",
-        }),
+        body: JSON.stringify(
+          withValidManifest({
+            version: "1.0.0",
+            platform: "linux",
+            architecture: "amd64",
+            downloadUrl: "https://s3.example.com/agent-1.0.0",
+            checksum: "c".repeat(64),
+            edition: "hosted",
+          }),
+        ),
       });
 
       expect(res.status).toBe(201);
@@ -1705,15 +1873,17 @@ describe("agentVersions routes", () => {
       const res = await app.request("/agent-versions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          version: "3.0.0",
-          platform: "linux",
-          architecture: "amd64",
-          downloadUrl: "https://s3.example.com/agent-3.0.0",
-          checksum: "e".repeat(64),
-          isLatest: true,
-          edition: "hosted",
-        }),
+        body: JSON.stringify(
+          withValidManifest({
+            version: "3.0.0",
+            platform: "linux",
+            architecture: "amd64",
+            downloadUrl: "https://s3.example.com/agent-3.0.0",
+            checksum: "e".repeat(64),
+            isLatest: true,
+            edition: "hosted",
+          }),
+        ),
       });
 
       expect(res.status).toBe(201);
@@ -1753,14 +1923,16 @@ describe("agentVersions routes", () => {
       const res = await app.request("/agent-versions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          version: "2.0.0",
-          platform: "linux",
-          architecture: "amd64",
-          downloadUrl: "https://s3.example.com/agent-2.0.0",
-          checksum: "d".repeat(64),
-          isLatest: true,
-        }),
+        body: JSON.stringify(
+          withValidManifest({
+            version: "2.0.0",
+            platform: "linux",
+            architecture: "amd64",
+            downloadUrl: "https://s3.example.com/agent-2.0.0",
+            checksum: "d".repeat(64),
+            isLatest: true,
+          }),
+        ),
       });
 
       expect(res.status).toBe(201);
@@ -1798,6 +1970,77 @@ describe("agentVersions routes", () => {
       });
 
       expect(res.status).toBe(400);
+    });
+
+    // Regression coverage for issue #3544: a manifest-less row used to be
+    // accepted silently at write time and only ever surfaced later as an
+    // opaque 409 on every agent heartbeat trying to download it.
+    it("422s with signed_release_manifest_required when releaseManifest/manifestSignature are omitted", async () => {
+      const res = await app.request("/agent-versions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          version: "1.0.0",
+          platform: "linux",
+          architecture: "amd64",
+          downloadUrl: "https://s3.example.com/agent-1.0.0",
+          checksum: "c".repeat(64),
+        }),
+      });
+
+      expect(res.status).toBe(422);
+      const body = await res.json();
+      expect(body.error).toBe("Release manifest is not trusted");
+      expect(body.reason).toBe("signed_release_manifest_required");
+      // Rejected before any write.
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it("422s with invalid_release_manifest_json when the manifest is present but not valid JSON", async () => {
+      const res = await app.request("/agent-versions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          version: "1.0.0",
+          platform: "linux",
+          architecture: "amd64",
+          downloadUrl: "https://s3.example.com/agent-1.0.0",
+          checksum: "c".repeat(64),
+          releaseManifest: "this is not json",
+          manifestSignature: "test-signature",
+        }),
+      });
+
+      expect(res.status).toBe(422);
+      const body = await res.json();
+      expect(body.error).toBe("Release manifest is not trusted");
+      expect(body.reason).toBe("invalid_release_manifest_json");
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    // Critical ordering property: a rejected isLatest:true row must NOT strip
+    // the currently-working upgrade target off the fleet on its way to being
+    // refused. The manifest check must run BEFORE the isLatest demotion.
+    it("rejects isLatest:true with no manifest WITHOUT demoting the currently-promoted row (outage-prevention ordering, #3544)", async () => {
+      const res = await app.request("/agent-versions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          version: "1.0.0",
+          platform: "linux",
+          architecture: "amd64",
+          downloadUrl: "https://s3.example.com/agent-1.0.0",
+          checksum: "c".repeat(64),
+          isLatest: true,
+        }),
+      });
+
+      expect(res.status).toBe(422);
+      const body = await res.json();
+      expect(body.reason).toBe("signed_release_manifest_required");
+      // The isLatest demotion UPDATE never ran, and neither did the insert.
+      expect(db.update).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -602,6 +602,41 @@ agentVersionRoutes.post(
     const data = c.req.valid("json");
     const edition = data.edition ?? getBinaryEdition();
 
+    // Reject a row that GET /:version/download would refuse to serve, BEFORE
+    // any write. `validateReleaseManifest` is mandatory on the serving path
+    // (line ~526), and there is no route that can complete a half-registered
+    // row afterwards — so a row failing it here is dead on arrival: every
+    // agent pointed at it 409s on every heartbeat, forever, with no terminal
+    // state. Issue #3544 is exactly that: manifest-less rows were accepted
+    // silently at write time and only surfaced as thousands of opaque 409s.
+    // The columns being nullable in the schema while the serving path treats
+    // them as mandatory is the inconsistency; this closes it at the door.
+    //
+    // Ordering matters: this runs before the isLatest demotion below.
+    // Demoting first and validating later would strip the last WORKING
+    // upgrade target off the fleet on behalf of a row we are about to
+    // refuse — turning a rejected request into an outage.
+    const createManifestCheck = await validateReleaseManifest({
+      manifest: data.releaseManifest,
+      signature: data.manifestSignature,
+      version: data.version,
+      platform: data.platform,
+      arch: data.architecture,
+      component: data.component,
+      downloadUrl: data.downloadUrl,
+      checksum: data.checksum,
+      fileSize: data.fileSize,
+    });
+    if (!createManifestCheck.ok) {
+      return c.json(
+        {
+          error: "Release manifest is not trusted",
+          reason: createManifestCheck.reason,
+        },
+        422,
+      );
+    }
+
     // If this version is marked as latest, unset isLatest for other versions
     // with the same platform/architecture/component/edition. Scoped by
     // edition too — otherwise promoting a "self-host" row could demote a
@@ -850,6 +885,12 @@ agentVersionRoutes.post(
         component: agentVersions.component,
         platform: agentVersions.platform,
         architecture: agentVersions.architecture,
+        version: agentVersions.version,
+        downloadUrl: agentVersions.downloadUrl,
+        checksum: agentVersions.checksum,
+        fileSize: agentVersions.fileSize,
+        releaseManifest: agentVersions.releaseManifest,
+        manifestSignature: agentVersions.manifestSignature,
       })
       .from(agentVersions)
       .where(
@@ -873,6 +914,57 @@ agentVersionRoutes.post(
             : `No registered rows for version ${version}`,
         },
         404,
+      );
+    }
+
+    // Refuse to promote a version any of whose rows GET /:version/download
+    // would reject. Promotion is what actually points the fleet at a version,
+    // so an untrusted row here is the difference between a harmless
+    // unreachable DB row and every device in the fleet retrying a 409 every
+    // ~60s indefinitely (issue #3544).
+    //
+    // Rejected if ANY target row fails, not merely if all do: promotion is
+    // atomic across its slots by design, and a partial promotion would split
+    // the fleet — some platforms or components moved to the new version while
+    // the rest stayed behind — which is the very all-or-nothing-vs-partial
+    // confusion that made #3544 hard to diagnose. This also runs BEFORE the
+    // demotion transaction below, so a refused promotion never strips the
+    // currently-working target.
+    const invalidTargets: Array<{
+      component: string;
+      platform: string;
+      architecture: string;
+      reason: string;
+    }> = [];
+    for (const row of targetRows) {
+      const check = await validateReleaseManifest({
+        manifest: row.releaseManifest,
+        signature: row.manifestSignature,
+        version: row.version,
+        platform: row.platform,
+        arch: row.architecture,
+        component: row.component,
+        downloadUrl: row.downloadUrl,
+        checksum: row.checksum,
+        fileSize: row.fileSize,
+      });
+      if (!check.ok) {
+        invalidTargets.push({
+          component: row.component,
+          platform: row.platform,
+          architecture: row.architecture,
+          reason: check.reason,
+        });
+      }
+    }
+    if (invalidTargets.length > 0) {
+      return c.json(
+        {
+          error: "Release manifest is not trusted",
+          reason: invalidTargets[0]!.reason,
+          invalidTargets,
+        },
+        409,
       );
     }
 


### PR DESCRIPTION
## What

Issue #3544's titled bug — one rejected asset aborting the whole binary sync — was fixed in #3538. The issue stayed open for the **two remaining halves** the maintainer identified in [this comment](https://github.com/LanternOps/breeze/issues/3544#issuecomment-5309260366): the failure is *silent and unbounded* on the agent side, and *nothing warns at write time*. This PR closes both.

## Root cause

`validateReleaseManifest` is mandatory on the **serving** path — `GET /agent-versions/:version/download` returns `409 {error, reason}` whenever a row's `release_manifest` / `manifest_signature` is missing or unverifiable (`agentVersions.ts:526`). But **no write path ever ran it**. The columns are nullable in the schema while the serving path treats them as required, so a row registers cleanly and then 409s on every single read, forever.

Reported symptom: every device in the fleet retrying every ~60s indefinitely, with `download info request failed with status 409` as the only signal — while the server was already returning a specific, actionable `reason` in the body that the agent threw away.

## API — reject at the door, not thousands of 409s later

- **`POST /agent-versions`** validates the submitted payload and returns **422** `{error, reason}` on failure. This runs **before** the `isLatest` demotion. Ordering is the point: demoting first and validating later strips the last *working* upgrade target off the fleet on behalf of a row we're about to refuse — turning a rejected request into an outage.
- **`POST /agent-versions/promote`** validates **every** target row before the demotion transaction, returning **409** `{error, reason, invalidTargets}` if **any** row fails. Promotion is the write that actually points the fleet at a version, so it's the one that causes the outage. Rejecting on *any* failure rather than *all* keeps promotion atomic — a partial promotion would split the fleet across platforms/components.

`binarySync` is unaffected: all four of its write sites derive the manifest from upstream signature verification, so normal registration and promotion still pass (its 50 tests stay green).

## Agent — surface the reason, stop retrying a doomed target

- `parseDownloadInfo` handles 409 explicitly, decoding the control plane's machine-readable `reason` and wrapping it in a new `ErrUntrustedRelease` sentinel. The reason is **sanitized** (lowercase snake_case only, length-bounded, body size-capped) rather than echoed verbatim — consistent with how the redirect branch and `SafeDownloadErrorFields` already treat server-supplied text that reaches agent logs.
- `doUpgrade` treats `ErrUntrustedRelease` as terminal for that target version and applies a **30-minute per-version cooldown**, mirroring the existing `watchdogUpgradeRetryCooldown`. Deliberately a cooldown rather than `setAutoUpdate(false)` (what `ErrReadOnlyFS` does): re-registering the version with a signed manifest must recover the fleet on its own. Promoting a *different* version bypasses the cooldown immediately, so the operator's fix takes effect on the next heartbeat. The check runs before `sendUpdateStatus` and before any download work, so a backed-off device also stops announcing "Updating".

The new log line names the actual problem and the fix, instead of a bare status code.

## Design note

The reject-vs-warn choice and the ordering hazards were put to an advisor quorum (independent Codex review) before implementing; it independently reached hard-reject on both endpoints, any-failure semantics for promote, and validate-before-demote — matching the implementation here.

## Testing

| Suite | Result |
|---|---|
| `apps/api` `agentVersions.test.ts` | **58 passed** (52 existing + 6 new) |
| `apps/api` binarySync / selftest / releaseTrustChain | **50 passed** (no regressions) |
| `agent` `go test -race ./internal/updater/...` | **ok** |
| `agent` `go test -race ./internal/heartbeat/...` | **ok** |
| `tsc --noEmit` (apps/api) | **clean** |
| `go build ./...` + `go vet` | **clean** |

New API tests cover: 422 on missing manifest, 422 on unparseable manifest, **a refused `isLatest:true` create never demoting the currently-promoted row**, promote rejecting a NULL-manifest target without running the transaction, a **mixed** valid/invalid promote being rejected whole, and the happy path still succeeding.

New Go tests cover: reason extraction, sanitization (uppercase / URLs / spaces / newline-injection / digits / overlong all dropped), body-size bounds, 409-without-reason still terminal, **non-409 statuses staying retryable**, and the cooldown's version-keying, expiry, and concurrency safety under `-race`.

9 existing API tests were updated to supply valid manifests — the guards were **not** weakened to accommodate them. Verified non-vacuous by mutation: neutering both guards fails 5 tests.

Closes #3544

🤖 Generated with [Claude Code](https://claude.com/claude-code)