### PR TITLE
fix(agent): Defender no longer claims a third-party AV's real-time protection (#3593)

### DIFF
--- a/agent/internal/security/status.go
+++ b/agent/internal/security/status.go
@@ -130,6 +130,47 @@ func providerFromName(name string) string {
 	}
 }
 
+// resolveWSCPrimary picks the Windows Security Center product that owns the
+// device's provider label: the first product reporting real-time protection,
+// falling back to the first registered product. The second return value is
+// whether that product is a genuine attribution — a registered product resolves
+// the provider even when its display name maps to "other" (see
+// defenderOwnsProvider).
+func resolveWSCPrimary(products []AVProduct) (AVProduct, bool) {
+	if len(products) == 0 {
+		return AVProduct{}, false
+	}
+
+	primary := products[0]
+	for _, candidate := range products {
+		if candidate.RealTimeProtection {
+			primary = candidate
+			break
+		}
+	}
+
+	return primary, primary.Registered
+}
+
+// defenderOwnsProvider reports whether the Microsoft Defender fallback may claim
+// the `provider` label for this row.
+//
+// It may when no other AV source identified a provider, or when Defender is the
+// only source reporting active real-time protection. It must NOT when another
+// registered product already supplied both the provider and the
+// real-time-protection value: provider "other" is a real attribution for a
+// registered product whose display name we don't map (CylancePROTECT, for
+// example), not a "nothing found" sentinel. Treating it as one relabelled a
+// third-party product's real-time protection as Defender's, reporting
+// real_time_protection=true on a windows_defender row for a device where
+// Defender was fully disabled (#3593).
+func defenderOwnsProvider(providerIdentified, currentRealTime, defenderRealTime bool) bool {
+	if !providerIdentified {
+		return true
+	}
+	return defenderRealTime && !currentRealTime
+}
+
 func latestScanTime(defenderStatus DefenderStatus) string {
 	if defenderStatus.LastFullScan != "" {
 		return defenderStatus.LastFullScan
@@ -989,6 +1030,10 @@ func CollectStatus(cfg *config.Config) (SecurityStatus, error) {
 	status.Provider = "other"
 	status.EncryptionStatus = "unknown"
 
+	// "other" is both the default and a legitimate provider value, so track
+	// separately whether an AV source actually resolved the provider (#3593).
+	providerIdentified := false
+
 	// Windows Security Center AV products (workstations) first.
 	if runtime.GOOS == "windows" {
 		products, wscErr := GetWindowsSecurityCenterProducts()
@@ -999,17 +1044,11 @@ func CollectStatus(cfg *config.Config) (SecurityStatus, error) {
 		} else {
 			status.WindowsSecurityCenterAvailable = true
 			status.AVProducts = products
-			if len(products) > 0 {
-				primary := products[0]
-				for _, candidate := range products {
-					if candidate.RealTimeProtection {
-						primary = candidate
-						break
-					}
-				}
+			if primary, identified := resolveWSCPrimary(products); primary.Provider != "" {
 				status.Provider = primary.Provider
 				status.RealTimeProtection = primary.RealTimeProtection
 				status.DefinitionsUpdatedAt = primary.Timestamp
+				providerIdentified = identified
 			}
 		}
 	}
@@ -1022,8 +1061,9 @@ func CollectStatus(cfg *config.Config) (SecurityStatus, error) {
 				errs = append(errs, macDefenderErr)
 			}
 		} else {
-			if status.Provider == "other" && macDefenderStatus.Enabled {
+			if !providerIdentified && macDefenderStatus.Enabled {
 				status.Provider = "windows_defender"
+				providerIdentified = true
 			}
 			if macDefenderProduct != nil {
 				status.AVProducts = append(status.AVProducts, *macDefenderProduct)
@@ -1061,8 +1101,9 @@ func CollectStatus(cfg *config.Config) (SecurityStatus, error) {
 			}
 		} else if elasticProduct != nil {
 			status.AVProducts = append(status.AVProducts, *elasticProduct)
-			if status.Provider == "other" {
+			if !providerIdentified {
 				status.Provider = elasticProduct.Provider
+				providerIdentified = true
 			}
 			if status.ProviderVersion == "" {
 				status.ProviderVersion = elasticVersion
@@ -1080,7 +1121,7 @@ func CollectStatus(cfg *config.Config) (SecurityStatus, error) {
 			errs = append(errs, defErr)
 		}
 	} else {
-		if status.Provider == "other" {
+		if defenderOwnsProvider(providerIdentified, status.RealTimeProtection, defenderStatus.RealTimeProtection) {
 			status.Provider = "windows_defender"
 		}
 		if status.ProviderVersion == "" {

--- a/agent/internal/security/status_attribution_test.go
+++ b/agent/internal/security/status_attribution_test.go
@@ -1,0 +1,137 @@
+package security
+
+import "testing"
+
+func TestResolveWSCPrimary(t *testing.T) {
+	defender := AVProduct{
+		DisplayName:        "Windows Defender",
+		Provider:           "windows_defender",
+		Registered:         true,
+		RealTimeProtection: false,
+	}
+	cylance := AVProduct{
+		DisplayName:        "CylancePROTECT",
+		Provider:           "other",
+		Registered:         true,
+		RealTimeProtection: true,
+	}
+	sophos := AVProduct{
+		DisplayName:        "Sophos Intercept X",
+		Provider:           "sophos",
+		Registered:         true,
+		RealTimeProtection: true,
+	}
+	unnamed := AVProduct{Provider: "other", Registered: false}
+
+	cases := []struct {
+		name           string
+		products       []AVProduct
+		wantProvider   string
+		wantRealTime   bool
+		wantIdentified bool
+	}{
+		{"no products", nil, "", false, false},
+		{"single disabled defender", []AVProduct{defender}, "windows_defender", false, true},
+		{
+			// #3593: Defender is listed first but disabled; the active third-party
+			// product wins the provider label even though its name maps to "other".
+			name:           "third-party with rtp beats disabled defender",
+			products:       []AVProduct{defender, cylance},
+			wantProvider:   "other",
+			wantRealTime:   true,
+			wantIdentified: true,
+		},
+		{
+			name:           "first product reporting rtp wins",
+			products:       []AVProduct{defender, sophos, cylance},
+			wantProvider:   "sophos",
+			wantRealTime:   true,
+			wantIdentified: true,
+		},
+		{
+			// Nothing reports real-time protection: fall back to the first product.
+			name:           "falls back to first product",
+			products:       []AVProduct{defender, {DisplayName: "Acme Shield", Provider: "other", Registered: true}},
+			wantProvider:   "windows_defender",
+			wantRealTime:   false,
+			wantIdentified: true,
+		},
+		{
+			// An unregistered (nameless) entry is not a real attribution, so the
+			// Defender fallback is still allowed to claim the provider label.
+			name:           "unregistered product does not identify a provider",
+			products:       []AVProduct{unnamed},
+			wantProvider:   "other",
+			wantRealTime:   false,
+			wantIdentified: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			primary, identified := resolveWSCPrimary(tc.products)
+			if primary.Provider != tc.wantProvider {
+				t.Errorf("provider = %q, want %q", primary.Provider, tc.wantProvider)
+			}
+			if primary.RealTimeProtection != tc.wantRealTime {
+				t.Errorf("realTimeProtection = %v, want %v", primary.RealTimeProtection, tc.wantRealTime)
+			}
+			if identified != tc.wantIdentified {
+				t.Errorf("identified = %v, want %v", identified, tc.wantIdentified)
+			}
+		})
+	}
+}
+
+func TestDefenderOwnsProvider(t *testing.T) {
+	cases := []struct {
+		name               string
+		providerIdentified bool
+		currentRealTime    bool
+		defenderRealTime   bool
+		want               bool
+	}{
+		{
+			// Windows Server / no Security Center data: Defender is all we have.
+			name: "no provider identified", providerIdentified: false,
+			currentRealTime: false, defenderRealTime: false, want: true,
+		},
+		{
+			name: "no provider identified and defender active", providerIdentified: false,
+			currentRealTime: false, defenderRealTime: true, want: true,
+		},
+		{
+			// The #3593 regression: a registered third-party product (provider
+			// "other") supplied realTimeProtection=true and Defender is disabled.
+			// Defender must NOT relabel that row as windows_defender.
+			name: "third-party owns an active row", providerIdentified: true,
+			currentRealTime: true, defenderRealTime: false, want: false,
+		},
+		{
+			// Same shape, but neither is protecting: still not Defender's row.
+			name: "third-party owns an inactive row", providerIdentified: true,
+			currentRealTime: false, defenderRealTime: false, want: false,
+		},
+		{
+			// Defender is the only source reporting active protection, so it is
+			// what is actually protecting the device and owns the label.
+			name: "defender is the only active source", providerIdentified: true,
+			currentRealTime: false, defenderRealTime: true, want: true,
+		},
+		{
+			// Both active: the already-identified product keeps the label.
+			name: "both active", providerIdentified: true,
+			currentRealTime: true, defenderRealTime: true, want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := defenderOwnsProvider(tc.providerIdentified, tc.currentRealTime, tc.defenderRealTime)
+			if got != tc.want {
+				t.Fatalf("defenderOwnsProvider(%v, %v, %v) = %v, want %v",
+					tc.providerIdentified, tc.currentRealTime, tc.defenderRealTime, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`security_status.real_time_protection` was stored as `true` on a `windows_defender` row for a device where Defender is genuinely, completely disabled (third-party AV active). Both on-device sources agreed Defender was off (`Get-MpComputerStatus` → `RealTimeProtectionEnabled: False`, `AMRunningMode: "Not running"`; SecurityCenter2 `productState` real-time byte `0x00`), so neither decoder was at fault — and prior investigation on the issue ruled out the API merge path, a stale row, and the WSC bitmask parser.

## Root cause

`CollectStatus` (`agent/internal/security/status.go`) used `status.Provider == "other"` as a *"no AV source has identified a provider yet"* sentinel. But `"other"` is also a **legitimate resolved provider**: `providerFromName` returns it for any registered Security Center product whose display name isn't in the mapping table — CylancePROTECT, in this report.

So on this device:

1. The Windows Security Center block correctly picks the active third-party product as primary (first product reporting real-time protection wins) and copies **its** `realTimeProtection: true` and provider `"other"` onto the status.
2. The Defender fallback then runs, sees `Provider == "other"`, reads it as "nothing found", and overwrites the label with `windows_defender` — leaving the third-party product's `true` untouched.

Result: a row that attributes another product's active protection to a disabled Microsoft Defender. That also explains the two other oddities in the report — `provider_version` is empty because the Windows `DefenderStatus` never populates it at all, and `definitions_date` is populated because it came from the WSC primary's timestamp, not from Defender.

## Fix

Track provider resolution in a dedicated `providerIdentified` flag instead of sentinel-comparing the value, and extract the two decisions into pure, table-tested helpers:

- `resolveWSCPrimary(products)` — picks the product that owns the provider label (first reporting real-time protection, else the first) and reports whether it is a genuine attribution (i.e. a registered product).
- `defenderOwnsProvider(providerIdentified, currentRealTime, defenderRealTime)` — Defender may claim the label only when **no** other source identified a provider, or when Defender is the **only** source reporting active real-time protection (in which case it really is what's protecting the device).

The macOS Defender and Linux Elastic Defend branches move to the same flag. On those platforms the sentinel was equivalent (the Security Center block never runs), so their behaviour is unchanged.

On the reporter's device the row will now read `provider: other`, `real_time_protection: true` — accurate, since an unmapped third-party product genuinely is providing real-time protection — instead of falsely crediting Defender.

## Tests

New table-driven `agent/internal/security/status_attribution_test.go`: 6 cases for `resolveWSCPrimary` (including the exact disabled-Defender + active-third-party ordering from this issue) and 6 for `defenderOwnsProvider` covering both directions of the ownership rule.

```
go test -race ./internal/security/...   ok
go vet ./internal/security/...          clean (GOOS=darwin, windows, linux)
GOOS=windows go build ./...             clean
```

## Out of scope

- Persisting `avProducts[]` so this class of report is diagnosable from the stored row — tracked separately as #3641.
- Adding a `cylance` provider value: the provider column is a Postgres enum (`security_provider`), so a new vendor needs a migration + shared/web mapping. Filed as a follow-up thought rather than smuggled into a bug fix.

Closes #3593

🤖 Generated with [Claude Code](https://claude.com/claude-code)