### PR TITLE
fix(api): Breeze Agent inventory version tracks the running agent, not the MSI (#3591)

### DIFF
--- a/apps/api/src/routes/agents/agentSelfInventory.test.ts
+++ b/apps/api/src/routes/agents/agentSelfInventory.test.ts
@@ -41,6 +41,21 @@ describe('resolveInventoryVersion (#3591)', () => {
     expect(resolveInventoryVersion('Breeze Agent', '0.100.0', '   ')).toBe('0.100.0');
   });
 
+  it('ignores the provisioning sentinel agent version', () => {
+    // devices.agent_version is NOT NULL and provisioning seeds '0.0.0' until
+    // the first heartbeat. The agent's software report is dispatched in a
+    // goroutine that is not ordered against that heartbeat, so a report can
+    // arrive while the sentinel is still stored. Copying it in would stamp the
+    // agent's row with a version that sorts below every real one — failing
+    // every min-version policy check, and worse than the bug being fixed.
+    expect(resolveInventoryVersion('Breeze Agent', '0.100.0', '0.0.0')).toBe('0.100.0');
+    expect(resolveInventoryVersion('Breeze Agent (Self-Hosted)', '0.101.0', '0.0.0')).toBe('0.101.0');
+    // ...and it must not leak in when there is nothing to fall back to either.
+    expect(resolveInventoryVersion('Breeze Agent', undefined, '0.0.0')).toBeNull();
+    // A real version that merely starts with a zero is untouched.
+    expect(resolveInventoryVersion('Breeze Agent', '0.100.0', '0.0.1')).toBe('0.0.1');
+  });
+
   it('normalizes empty/whitespace reported versions to null', () => {
     expect(resolveInventoryVersion('Google Chrome', '', '0.105.1')).toBeNull();
     expect(resolveInventoryVersion('Google Chrome', '  ', '0.105.1')).toBeNull();

--- a/apps/api/src/routes/agents/agentSelfInventory.test.ts
+++ b/apps/api/src/routes/agents/agentSelfInventory.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { isBreezeAgentProductName, resolveInventoryVersion } from './agentSelfInventory';
+
+describe('isBreezeAgentProductName', () => {
+  it('matches both MSI product names, case- and whitespace-insensitively', () => {
+    expect(isBreezeAgentProductName('Breeze Agent')).toBe(true);
+    expect(isBreezeAgentProductName('  breeze agent  ')).toBe(true);
+    expect(isBreezeAgentProductName('Breeze Agent (Self-Hosted)')).toBe(true);
+    expect(isBreezeAgentProductName('BREEZE AGENT (SELF-HOSTED)')).toBe(true);
+  });
+
+  it('does not match on substrings or neighbouring Breeze products', () => {
+    // A substring match would relabel these with the agent's version.
+    expect(isBreezeAgentProductName('Breeze Agent Helper')).toBe(false);
+    expect(isBreezeAgentProductName('Breeze RMM Watchdog')).toBe(false);
+    expect(isBreezeAgentProductName('Breeze Installer')).toBe(false);
+    expect(isBreezeAgentProductName('Breeze Backup')).toBe(false);
+    expect(isBreezeAgentProductName('Google Chrome')).toBe(false);
+  });
+});
+
+describe('resolveInventoryVersion (#3591)', () => {
+  it('replaces the frozen MSI version of the agent entry with the live agent version', () => {
+    // The registry DisplayVersion is whatever the MSI installed originally;
+    // self-updates replace the binary without touching it.
+    expect(resolveInventoryVersion('Breeze Agent', '0.100.0', '0.105.1')).toBe('0.105.1');
+    expect(resolveInventoryVersion('Breeze Agent (Self-Hosted)', '0.101.0', '0.105.1')).toBe('0.105.1');
+  });
+
+  it('leaves every other product untouched', () => {
+    expect(resolveInventoryVersion('Google Chrome', '127.0', '0.105.1')).toBe('127.0');
+    // Not even the version-shaped coincidence of matching the agent version.
+    expect(resolveInventoryVersion('7-Zip', '24.06', '0.105.1')).toBe('24.06');
+  });
+
+  it('falls back to the reported version when the device has no agent version yet', () => {
+    // A device mid-enrollment can report software before its first heartbeat —
+    // normalizing must never blank out a version we do have.
+    expect(resolveInventoryVersion('Breeze Agent', '0.100.0', null)).toBe('0.100.0');
+    expect(resolveInventoryVersion('Breeze Agent', '0.100.0', undefined)).toBe('0.100.0');
+    expect(resolveInventoryVersion('Breeze Agent', '0.100.0', '   ')).toBe('0.100.0');
+  });
+
+  it('normalizes empty/whitespace reported versions to null', () => {
+    expect(resolveInventoryVersion('Google Chrome', '', '0.105.1')).toBeNull();
+    expect(resolveInventoryVersion('Google Chrome', '  ', '0.105.1')).toBeNull();
+    expect(resolveInventoryVersion('Google Chrome', undefined, '0.105.1')).toBeNull();
+    expect(resolveInventoryVersion('Breeze Agent', undefined, null)).toBeNull();
+  });
+
+  it('still fills the agent entry when the collector reported no version at all', () => {
+    expect(resolveInventoryVersion('Breeze Agent', undefined, '0.105.1')).toBe('0.105.1');
+  });
+});

--- a/apps/api/src/routes/agents/agentSelfInventory.ts
+++ b/apps/api/src/routes/agents/agentSelfInventory.ts
@@ -1,0 +1,59 @@
+/**
+ * Normalization for the agent's own row in a device software inventory report.
+ *
+ * The Windows MSI registers an Uninstall key whose `DisplayVersion` is the
+ * version that was installed originally. The agent self-updates by replacing
+ * its binary in place — it never reinstalls the MSI — so that registry value
+ * is frozen forever while the agent actually running is many versions newer.
+ * The software collector reads the registry, so `software_inventory.version`
+ * for "Breeze Agent" drifts away from `devices.agent_version` (which the
+ * heartbeat reports from the running binary and is authoritative).
+ *
+ * Practical damage: Software Policy allowlist/blocklist evaluation reads
+ * `software_inventory.version`, so the agent itself shows up as a fleet-wide
+ * outdated-software violation on devices that are fully current (issue #3591).
+ *
+ * The fix normalizes at ingest rather than in the collector: the API already
+ * holds the authoritative `devices.agent_version`, and the correction then
+ * applies to every agent already in the field instead of waiting for a fleet
+ * promote. Inventory rows are wiped and reinserted on every report, so no
+ * backfill is needed — the next scan corrects each device.
+ */
+
+/**
+ * Display names the Breeze agent installer registers, lowercased.
+ *
+ * These are the MSI `ProductName` literals (see `agent/installer/build-msi.ps1`:
+ * `$hostedProductName` / `$selfHostProductName`). Matching is exact on the
+ * normalized name — a substring match would also capture unrelated products
+ * that merely mention Breeze, and mislabel their versions with ours.
+ */
+const BREEZE_AGENT_PRODUCT_NAMES = new Set([
+  'breeze agent',
+  'breeze agent (self-hosted)',
+]);
+
+/** True when a reported software name is the Breeze agent's own installer entry. */
+export function isBreezeAgentProductName(name: string): boolean {
+  return BREEZE_AGENT_PRODUCT_NAMES.has(name.trim().toLowerCase());
+}
+
+/**
+ * Version to store for one reported software item.
+ *
+ * For the agent's own entry, prefers the live heartbeat-reported agent version
+ * over the installer-registered one. Falls back to whatever the collector
+ * reported when `agentVersion` is missing (a device that has not completed its
+ * first heartbeat) so a normalization can never blank a version out.
+ */
+export function resolveInventoryVersion(
+  name: string,
+  reportedVersion: string | null | undefined,
+  agentVersion: string | null | undefined
+): string | null {
+  const reported = reportedVersion?.trim() || null;
+  if (!isBreezeAgentProductName(name)) return reported;
+
+  const live = agentVersion?.trim() || null;
+  return live ?? reported;
+}

--- a/apps/api/src/routes/agents/agentSelfInventory.ts
+++ b/apps/api/src/routes/agents/agentSelfInventory.ts
@@ -39,12 +39,27 @@ export function isBreezeAgentProductName(name: string): boolean {
 }
 
 /**
+ * Placeholder `devices.agent_version` written at provisioning, before the
+ * device's first heartbeat reports a real one (see `routes/devices/provision.ts`
+ * — the column is NOT NULL, so provisioning must write *something*).
+ *
+ * It is deliberately chosen to order BELOW every real version so compliance
+ * checks fail rather than silently pass. That makes it the worst possible value
+ * to copy into the inventory row: a device is issued agent credentials at the
+ * same insert, and the agent fires its software report in a goroutine that is
+ * not ordered against the heartbeat, so a report can legitimately arrive while
+ * the sentinel is still in place. Treat it as "no live version yet".
+ */
+const PROVISIONING_SENTINEL_VERSION = '0.0.0';
+
+/**
  * Version to store for one reported software item.
  *
  * For the agent's own entry, prefers the live heartbeat-reported agent version
  * over the installer-registered one. Falls back to whatever the collector
- * reported when `agentVersion` is missing (a device that has not completed its
- * first heartbeat) so a normalization can never blank a version out.
+ * reported while the device has no real agent version yet (missing, blank, or
+ * the provisioning sentinel) so a normalization can only ever improve the
+ * stored version, never degrade or blank one.
  */
 export function resolveInventoryVersion(
   name: string,
@@ -55,5 +70,6 @@ export function resolveInventoryVersion(
   if (!isBreezeAgentProductName(name)) return reported;
 
   const live = agentVersion?.trim() || null;
-  return live ?? reported;
+  if (!live || live === PROVISIONING_SENTINEL_VERSION) return reported;
+  return live;
 }

--- a/apps/api/src/routes/agents/inventory.test.ts
+++ b/apps/api/src/routes/agents/inventory.test.ts
@@ -33,7 +33,7 @@ import * as schema from '../../db/schema';
 import { queueWarrantySyncForDevice } from '../../services/warrantyWorker';
 import { inventoryRoutes } from './inventory';
 
-function mockDeviceLookup(device: { id: string; orgId: string } | null) {
+function mockDeviceLookup(device: { id: string; orgId: string; agentVersion?: string | null } | null) {
   vi.mocked(db.select).mockReturnValueOnce({
     from: vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({
@@ -445,5 +445,54 @@ describe('agent software inventory — vuln finding re-link (BREEZE-3)', () => {
 
     expect(res.status).toBe(404);
     expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  // The agent's own inventory entry is sourced from the MSI's Uninstall
+  // registry key, which a binary self-update never rewrites. Stored verbatim it
+  // freezes at the originally-installed version while devices.agent_version
+  // moves on, and Software Policy evaluation then flags every current device as
+  // running outdated software (#3591).
+  describe('Breeze Agent self-version normalization (#3591)', () => {
+    function insertedRows(insertValues: ReturnType<typeof vi.fn>) {
+      return insertValues.mock.calls[0]?.[0] as Array<{ name: string; version: string | null }>;
+    }
+
+    it('stores the live agent version for the agent entry, not the frozen MSI version', async () => {
+      mockDeviceLookup({ id: 'device-1', orgId: 'org-1', agentVersion: '0.105.1' });
+      const { insertValues } = mockSoftwareTx({ linkedFindings: [], replacementRows: [] });
+
+      const res = await putSoftware(makeApp(), [
+        { name: 'Breeze Agent', version: '0.100.0', vendor: 'LanternOps' },
+        { name: 'Google Chrome', version: '127.0', vendor: 'Google LLC' },
+      ]);
+
+      expect(res.status).toBe(200);
+      const rows = insertedRows(insertValues);
+      expect(rows.find((r) => r.name === 'Breeze Agent')?.version).toBe('0.105.1');
+      // Everything else is stored exactly as reported.
+      expect(rows.find((r) => r.name === 'Google Chrome')?.version).toBe('127.0');
+    });
+
+    it('normalizes the self-hosted edition entry too', async () => {
+      mockDeviceLookup({ id: 'device-1', orgId: 'org-1', agentVersion: '0.105.1' });
+      const { insertValues } = mockSoftwareTx({ linkedFindings: [], replacementRows: [] });
+
+      const res = await putSoftware(makeApp(), [
+        { name: 'Breeze Agent (Self-Hosted)', version: '0.101.0' },
+      ]);
+
+      expect(res.status).toBe(200);
+      expect(insertedRows(insertValues)[0]?.version).toBe('0.105.1');
+    });
+
+    it('keeps the reported version when the device has no agent version yet', async () => {
+      mockDeviceLookup({ id: 'device-1', orgId: 'org-1', agentVersion: null });
+      const { insertValues } = mockSoftwareTx({ linkedFindings: [], replacementRows: [] });
+
+      const res = await putSoftware(makeApp(), [{ name: 'Breeze Agent', version: '0.100.0' }]);
+
+      expect(res.status).toBe(200);
+      expect(insertedRows(insertValues)[0]?.version).toBe('0.100.0');
+    });
   });
 });

--- a/apps/api/src/routes/agents/inventory.test.ts
+++ b/apps/api/src/routes/agents/inventory.test.ts
@@ -485,8 +485,12 @@ describe('agent software inventory — vuln finding re-link (BREEZE-3)', () => {
       expect(insertedRows(insertValues)[0]?.version).toBe('0.105.1');
     });
 
-    it('keeps the reported version when the device has no agent version yet', async () => {
-      mockDeviceLookup({ id: 'device-1', orgId: 'org-1', agentVersion: null });
+    it('keeps the reported version while the device still holds the provisioning sentinel', async () => {
+      // devices.agent_version is NOT NULL; provisioning seeds '0.0.0' until the
+      // first heartbeat lands, and the agent's software report is not ordered
+      // against that heartbeat. Storing the sentinel would sort the agent below
+      // every real version and fail every min-version policy check.
+      mockDeviceLookup({ id: 'device-1', orgId: 'org-1', agentVersion: '0.0.0' });
       const { insertValues } = mockSoftwareTx({ linkedFindings: [], replacementRows: [] });
 
       const res = await putSoftware(makeApp(), [{ name: 'Breeze Agent', version: '0.100.0' }]);

--- a/apps/api/src/routes/agents/inventory.ts
+++ b/apps/api/src/routes/agents/inventory.ts
@@ -21,6 +21,7 @@ import {
   updateNetworkSchema,
 } from './schemas';
 import { sanitizeDate } from './helpers';
+import { resolveInventoryVersion } from './agentSelfInventory';
 import { retryOnTransientLockError } from '../../utils/pgErrors';
 import { upsertAgentWarranty } from '../../services/warrantySync';
 import { queueWarrantySyncForDevice } from '../../services/warrantyWorker';
@@ -170,7 +171,10 @@ inventoryRoutes.put('/:id/software', bodyLimit({ maxSize: 5 * 1024 * 1024, onErr
         deviceId: device.id,
         orgId: device.orgId,
         name: item.name,
-        version: item.version || null,
+        // The agent's own entry comes from the MSI's Uninstall registry key,
+        // which self-updates never rewrite — take the live heartbeat version
+        // instead so the agent stops reading as outdated software (#3591).
+        version: resolveInventoryVersion(item.name, item.version, device.agentVersion),
         vendor: item.vendor || null,
         installDate: sanitizeDate(item.installDate),
         installLocation: item.installLocation || null,


### PR DESCRIPTION
Closes #3591

## Problem

Software Policies > Software > Inventory listed **Breeze Agent** with the version the Windows MSI wrote into its Uninstall registry key at original install. The agent self-updates by replacing its binary in place — it never reinstalls the MSI — so `DisplayVersion` is frozen forever, while `devices.agent_version` (heartbeat-reported from the running binary, authoritative) moves on. `software_inventory.last_seen` stayed current the whole time: the scan runs fine, it just faithfully re-reports a stale registry value.

Practical damage: Software Policy allowlist/blocklist evaluation reads `software_inventory.version`, so the agent itself read as a fleet-wide outdated-software violation on devices that were fully current.

## Fix

Normalize at ingest, in `PUT /agents/:id/software` (`apps/api/src/routes/agents/inventory.ts`): rows whose name is one of the agent's own MSI product names get `devices.agent_version` instead of the reported registry version. New helper `apps/api/src/routes/agents/agentSelfInventory.ts` holds the name set and the resolution rule.

**Why API-side and not in the Go collector** (both options considered, second opinion sought):

- The API already holds the authoritative `devices.agent_version` at that point in the handler.
- The correction applies to every agent **already in the field**. An agent-side fix only reaches devices after a fleet promote, which is currently gated on an unrelated decision.
- One rule in one place; an agent-side copy of the product-name list would be a second rule free to drift.

Details:

- Matching is **exact** on the two `ProductName` literals from `agent/installer/build-msi.ps1` (`Breeze Agent`, `Breeze Agent (Self-Hosted)`), normalized for case/whitespace. A substring match would relabel neighbouring products — Breeze Installer, the watchdog — with the agent's version.
- When a device has no `agent_version` yet (mid-enrollment, before the first heartbeat) the reported version is kept. Normalization can never blank a version out.
- **No migration/backfill.** The software report wipes and reinserts every row for the device, so each device self-corrects on its next scan.

## Not in scope

Sibling issue #3592 (stale inventory entries generally) is deliberately left alone. Worth recording from this pass: this ingest path is a full wipe-and-reinsert per device inside one transaction, and it is the only writer of `software_inventory` from agents — so a stale row surviving a fresh scan cannot come from a missed upsert here. That points #3592 at the report itself (truncated or partial collection agent-side) or at a report that never reached this route, not at the ingest merge logic.

## Tests

- `apps/api/src/routes/agents/agentSelfInventory.test.ts` (new) — name matching incl. near-miss products, the override, the no-agent-version fallback, empty-version normalization.
- `apps/api/src/routes/agents/inventory.test.ts` — new route-level block asserting the rows actually handed to the INSERT. Mutation-checked: reverting the one-line change reds 2 of them.
- `vitest run src/routes/agents/agentSelfInventory.test.ts src/routes/agents/inventory.test.ts --no-file-parallelism` → 29 passed.
- `tsc --noEmit` on `apps/api` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)