### PR TITLE
fix(api): append a unique tiebreaker to every offset-paginated ORDER BY (#3462)

### DIFF
--- a/apps/api/src/db/offsetPaginationOrdering.test.ts
+++ b/apps/api/src/db/offsetPaginationOrdering.test.ts
@@ -34,6 +34,16 @@ const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
  * `orderBy(...)` of any statement that also calls `.offset(...)`. Anything else
  * — a composite key, an aliased subquery column, an ordering built by a shared
  * helper — must be justified by name in ALLOWED_WITHOUT_LITERAL_ID below.
+ *
+ * What it does NOT catch (know this before trusting a green run): the check is
+ * textual, so it cannot tell the BASE table's `id` from some JOINED table's
+ * `id`. `.from(alerts).innerJoin(devices, …).orderBy(devices.hostname,
+ * devices.id)` satisfies the regex while still being non-deterministic, because
+ * many alerts share one device. Proving otherwise needs the join cardinality,
+ * which is in the schema, not in the call site. So: when you review a new
+ * offset-paginated query, confirm by eye that the tiebreaker is the `.from()`
+ * table's own key. The guard catches the common case — no tiebreaker at all —
+ * not every possible wrong one.
  */
 
 /** Files whose `.offset()` statements order deterministically without a literal
@@ -151,7 +161,20 @@ describe('offset pagination ordering (#3462)', () => {
             (entry) => entry.file === rel && haystack.includes(entry.orderByContains)
           );
 
-        const orderByAt = statement.indexOf('.orderBy(');
+        // Pair the `.offset(` with the TEXTUALLY NEAREST `.orderBy(`, not the
+        // first one in the chunk. A chunk can hold a subquery's `.orderBy()`
+        // ahead of the outer paginated one, and taking the first would check
+        // the wrong clause — possibly masking a real violation by finding an
+        // unrelated `.id`. Nearest rather than nearest-preceding because both
+        // chain orders occur in this codebase (`routes/orgs.ts` writes
+        // `.limit().offset().orderBy()`).
+        const offsetAt = statement.indexOf('.offset(');
+        let orderByAt = -1;
+        for (let at = statement.indexOf('.orderBy('); at !== -1; at = statement.indexOf('.orderBy(', at + 1)) {
+          if (orderByAt === -1 || Math.abs(at - offsetAt) < Math.abs(orderByAt - offsetAt)) {
+            orderByAt = at;
+          }
+        }
         if (orderByAt === -1) {
           // Either genuinely unordered, or the `.offset()` was chained in a
           // later statement than the `.orderBy()` (allowlisted by name).

--- a/apps/api/src/db/offsetPaginationOrdering.test.ts
+++ b/apps/api/src/db/offsetPaginationOrdering.test.ts
@@ -1,0 +1,194 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// apps/api/src/db -> apps/api/src is 1 level up.
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Why this test exists
+ * --------------------
+ * `LIMIT/OFFSET` over an `ORDER BY` whose sort key is not unique is
+ * non-deterministic. PostgreSQL guarantees nothing about the relative order of
+ * rows with equal sort keys, and it makes that guarantee *per query* — two
+ * requests for consecutive pages are two independent queries and can even pick
+ * different plans. So a client walking pages over a tied sort key silently
+ * receives some rows twice and never sees others.
+ *
+ * This is not theoretical here. `created_at`/`updated_at` default to `now()`,
+ * which is the **transaction** timestamp, so every row written in one
+ * transaction — a seed, a bulk import, a patch-scan ingest, a provider sync —
+ * shares a byte-identical value. `main` ships several page-walking clients
+ * (`apps/web/src/lib/fetchAllOrganizations.ts`, `scriptsFetch.ts`,
+ * `devicesFetch.ts`) whose whole contract is "accumulate every accessible row",
+ * so the corruption lands in a list the user believes is complete.
+ *
+ * History: #3157 (patch catalog), then #3462 (repo-wide sweep). The fix is
+ * always one line — append the base table's primary key to the `ORDER BY`,
+ * matching the direction of the leading column — which is exactly why it keeps
+ * getting forgotten on the next endpoint. This guard lives in the required
+ * `test-api` job so the next offset-paginated query cannot ship without one.
+ *
+ * The guard is deliberately strict: it wants to see a literal `.id` inside the
+ * `orderBy(...)` of any statement that also calls `.offset(...)`. Anything else
+ * — a composite key, an aliased subquery column, an ordering built by a shared
+ * helper — must be justified by name in ALLOWED_WITHOUT_LITERAL_ID below.
+ */
+
+/** Files whose `.offset()` statements order deterministically without a literal
+ *  `.id` token. Each entry needs a reason; do not add one to silence a failure
+ *  you have not actually reasoned about. */
+const ALLOWED_WITHOUT_LITERAL_ID: ReadonlyArray<{
+  /** Path relative to apps/api/src. */
+  file: string;
+  /** Substring that must appear in the offending `orderBy(...)` arguments —
+   *  scoped so the exemption cannot silently cover a second query in the
+   *  same file. */
+  orderByContains: string;
+  reason: string;
+}> = [
+  {
+    file: 'routes/patches/list.ts',
+    orderByContains: 'orderByClause',
+    reason: 'orderByClause always ends in asc/desc(patches.id) — see the #3157 comment there',
+  },
+  {
+    file: 'routes/devices/core.ts',
+    orderByContains: '...orderBy',
+    reason:
+      'orderBy comes from buildOrderBy() (routes/devices/cursor.ts), which appends devices.id in the matching direction on every branch — it backs the keyset cursor too',
+  },
+  {
+    file: 'routes/tickets/tickets.ts',
+    orderByContains: '...orderBy',
+    reason: 'every branch of the sort switch already ends in asc/desc(tickets.id)',
+  },
+  {
+    file: 'services/logSearch.ts',
+    orderByContains: 'rowsQuery.offset',
+    reason:
+      'the offset is applied in a separate statement (`cursorMode ? rowsQuery : rowsQuery.offset(offset)`); the ordering is resolveSearchOrder(), which ends every branch in asc/desc(deviceEventLogs.id)',
+  },
+  {
+    file: 'services/reliabilityScoring.ts',
+    orderByContains: 'deviceReliability.deviceId',
+    reason: 'device_reliability has no id column; device_id is its primary key',
+  },
+  {
+    file: 'services/fleetFindings/dispatch.ts',
+    orderByContains: 'targetDeviceUuid',
+    reason:
+      'fleet_remediation_run_targets has no id column; PK is (run_id, target_device_uuid) and runId is pinned in the WHERE, so targetDeviceUuid is unique within the paged set',
+  },
+  {
+    file: 'routes/incidents.helpers.ts',
+    orderByContains: 'sub.sourceId',
+    reason:
+      'UNION ALL over three sources, so no single base-table PK; source is constant per leg and sourceId unique within it, so (source, sourceId) is a complete key',
+  },
+  {
+    file: 'routes/cisHardening.ts',
+    orderByContains: 'rankedResults.resultId',
+    reason: 'cis_baseline_results.id, aliased to resultId inside the window-function subquery',
+  },
+];
+
+function collectTsFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '__tests__') continue;
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      collectTsFiles(full, acc);
+      continue;
+    }
+    if (!entry.endsWith('.ts') || entry.includes('.test.')) continue;
+    acc.push(full);
+  }
+  return acc;
+}
+
+/** Return the argument text of the `orderBy(` starting at `open` (the index of
+ *  its `(`), via paren matching. */
+function argsOf(source: string, open: number): string {
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '(') depth++;
+    else if (source[i] === ')') {
+      depth--;
+      if (depth === 0) return source.slice(open + 1, i);
+    }
+  }
+  return source.slice(open + 1);
+}
+
+describe('offset pagination ordering (#3462)', () => {
+  const files = collectTsFiles(SRC_ROOT);
+
+  it('finds source files to scan', () => {
+    // Guards against the scan silently becoming vacuous (a moved directory, a
+    // renamed extension) and reporting zero violations because it read nothing.
+    expect(files.length).toBeGreaterThan(200);
+  });
+
+  it('every .offset() query orders by a unique key', () => {
+    const violations: string[] = [];
+    let checked = 0;
+
+    for (const file of files) {
+      const rel = path.relative(SRC_ROOT, file);
+      const source = readFileSync(file, 'utf8');
+      if (!source.includes('.offset(')) continue;
+
+      // Drizzle query chains are single statements, so splitting on `;` keeps
+      // each `.orderBy(...)` with the `.offset(...)` it belongs to.
+      for (const statement of source.split(';')) {
+        if (!statement.includes('.offset(')) continue;
+        checked++;
+
+        const exempt = (haystack: string) =>
+          ALLOWED_WITHOUT_LITERAL_ID.some(
+            (entry) => entry.file === rel && haystack.includes(entry.orderByContains)
+          );
+
+        const orderByAt = statement.indexOf('.orderBy(');
+        if (orderByAt === -1) {
+          // Either genuinely unordered, or the `.offset()` was chained in a
+          // later statement than the `.orderBy()` (allowlisted by name).
+          if (!exempt(statement)) {
+            violations.push(`${rel}: an .offset() query has no .orderBy() at all`);
+          }
+          continue;
+        }
+        const orderArgs = argsOf(statement, orderByAt + '.orderBy'.length);
+        if (/\.id\b/.test(orderArgs)) continue;
+        if (exempt(orderArgs)) continue;
+
+        violations.push(
+          `${rel}: .offset() query orders by \`${orderArgs.replace(/\s+/g, ' ').trim().slice(0, 120)}\`` +
+            ' — no unique tiebreaker. Append the base table\'s `.id` in the same' +
+            ' direction as the leading column, or justify an exception in' +
+            ' ALLOWED_WITHOUT_LITERAL_ID.'
+        );
+      }
+    }
+
+    expect(checked).toBeGreaterThan(50);
+    expect(violations).toEqual([]);
+  });
+
+  it('has no stale entries in ALLOWED_WITHOUT_LITERAL_ID', () => {
+    // An allowlist entry for a file that no longer paginates by offset is dead
+    // weight that hides the next real violation in that file.
+    const stale = ALLOWED_WITHOUT_LITERAL_ID.filter((entry) => {
+      const full = path.join(SRC_ROOT, entry.file);
+      try {
+        const source = readFileSync(full, 'utf8');
+        return !source.includes('.offset(') || !source.includes(entry.orderByContains);
+      } catch {
+        return true;
+      }
+    }).map((entry) => `${entry.file} (${entry.orderByContains})`);
+    expect(stale).toEqual([]);
+  });
+});

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -627,7 +627,7 @@ abuseRoutes.get(
         .select()
         .from(partnerAbuseSignals)
         .where(conds.length > 0 ? and(...conds) : undefined)
-        .orderBy(desc(partnerAbuseSignals.computedAt))
+        .orderBy(desc(partnerAbuseSignals.computedAt), desc(partnerAbuseSignals.id))
         .limit(limit)
         .offset(offset),
     );

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -260,7 +260,7 @@ alertsRoutes.get(
       .leftJoin(alertRules, eq(alerts.ruleId, alertRules.id))
       .leftJoin(organizations, eq(alerts.orgId, organizations.id))
       .where(whereCondition)
-      .orderBy(desc(alerts.triggeredAt))
+      .orderBy(desc(alerts.triggeredAt), desc(alerts.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/alerts/channels.ts
+++ b/apps/api/src/routes/alerts/channels.ts
@@ -144,7 +144,7 @@ channelsRoutes.get(
       .select()
       .from(notificationChannels)
       .where(whereCondition)
-      .orderBy(desc(notificationChannels.updatedAt))
+      .orderBy(desc(notificationChannels.updatedAt), desc(notificationChannels.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/alerts/policies.ts
+++ b/apps/api/src/routes/alerts/policies.ts
@@ -82,7 +82,7 @@ policiesRoutes.get(
       .select()
       .from(escalationPolicies)
       .where(whereCondition)
-      .orderBy(desc(escalationPolicies.updatedAt))
+      .orderBy(desc(escalationPolicies.updatedAt), desc(escalationPolicies.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/alerts/rules.ts
+++ b/apps/api/src/routes/alerts/rules.ts
@@ -191,7 +191,7 @@ rulesRoutes.get(
         .from(alertRules)
         .leftJoin(alertTemplates, eq(alertRules.templateId, alertTemplates.id))
         .where(whereCondition)
-        .orderBy(desc(alertRules.createdAt));
+        .orderBy(desc(alertRules.createdAt), desc(alertRules.id));
 
       const accessibleRules = [];
       for (const row of candidateRules) {
@@ -225,7 +225,7 @@ rulesRoutes.get(
       .from(alertRules)
       .leftJoin(alertTemplates, eq(alertRules.templateId, alertTemplates.id))
       .where(whereCondition)
-      .orderBy(desc(alertRules.createdAt))
+      .orderBy(desc(alertRules.createdAt), desc(alertRules.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -570,7 +570,7 @@ analyticsRoutes.get(
       .select()
       .from(analyticsDashboards)
       .where(whereCondition)
-      .orderBy(desc(analyticsDashboards.updatedAt))
+      .orderBy(desc(analyticsDashboards.updatedAt), desc(analyticsDashboards.id))
       .limit(limit)
       .offset(offset);
 
@@ -1585,7 +1585,7 @@ analyticsRoutes.get(
       .select()
       .from(slaDefinitionsTable)
       .where(whereCondition)
-      .orderBy(desc(slaDefinitionsTable.updatedAt))
+      .orderBy(desc(slaDefinitionsTable.updatedAt), desc(slaDefinitionsTable.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/apiKeys.ts
+++ b/apps/api/src/routes/apiKeys.ts
@@ -309,7 +309,7 @@ apiKeyRoutes.get(
       })
       .from(apiKeys)
       .where(whereCondition)
-      .orderBy(desc(apiKeys.createdAt))
+      .orderBy(desc(apiKeys.createdAt), desc(apiKeys.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/auditLogs.ts
+++ b/apps/api/src/routes/auditLogs.ts
@@ -341,7 +341,7 @@ async function queryRows(where: SQL | undefined, limit: number, offset: number):
       sql`${devices.agentId} = ${auditLogsTable.details}->>'rawActorId' AND ${auditLogsTable.actorType} = 'agent'`
     )
     .where(where)
-    .orderBy(desc(auditLogsTable.timestamp))
+    .orderBy(desc(auditLogsTable.timestamp), desc(auditLogsTable.id))
     .limit(limit)
     .offset(offset);
 }

--- a/apps/api/src/routes/auth/accountDeletion.ts
+++ b/apps/api/src/routes/auth/accountDeletion.ts
@@ -548,7 +548,7 @@ accountDeletionAdminRoutes.get(
         .from(accountDeletionRequests)
         .leftJoin(users, eq(users.id, accountDeletionRequests.userId))
         .where(eq(accountDeletionRequests.status, status))
-        .orderBy(desc(accountDeletionRequests.requestedAt))
+        .orderBy(desc(accountDeletionRequests.requestedAt), desc(accountDeletionRequests.id))
         .limit(limit)
         .offset(offset);
       return query;

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -653,7 +653,7 @@ automationRoutes.get(
       .select()
       .from(automations)
       .where(whereCondition)
-      .orderBy(desc(automations.updatedAt))
+      .orderBy(desc(automations.updatedAt), desc(automations.id))
       .limit(limit)
       .offset(offset);
 
@@ -820,7 +820,7 @@ automationRoutes.get(
       .select()
       .from(automationRuns)
       .where(whereCondition)
-      .orderBy(desc(automationRuns.startedAt))
+      .orderBy(desc(automationRuns.startedAt), desc(automationRuns.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/backup/bmr.ts
+++ b/apps/api/src/routes/backup/bmr.ts
@@ -429,7 +429,7 @@ bmrRoutes.get(
           allowedSnapshotIds ? inArray(recoveryTokens.snapshotId, allowedSnapshotIds) : undefined
         )
       )
-      .orderBy(desc(recoveryTokens.createdAt))
+      .orderBy(desc(recoveryTokens.createdAt), desc(recoveryTokens.id))
       .limit(query.limit)
       .offset(query.offset);
 

--- a/apps/api/src/routes/c2c/items.ts
+++ b/apps/api/src/routes/c2c/items.ts
@@ -45,7 +45,7 @@ c2cItemsRoutes.get(
       .select()
       .from(c2cBackupItems)
       .where(and(...conditions))
-      .orderBy(desc(c2cBackupItems.createdAt))
+      .orderBy(desc(c2cBackupItems.createdAt), desc(c2cBackupItems.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/cisHardening.ts
+++ b/apps/api/src/routes/cisHardening.ts
@@ -323,7 +323,7 @@ cisHardeningRoutes.get(
       .select()
       .from(cisBaselines)
       .where(where)
-      .orderBy(desc(cisBaselines.updatedAt))
+      .orderBy(desc(cisBaselines.updatedAt), desc(cisBaselines.id))
       .limit(limit)
       .offset(offset);
 
@@ -688,7 +688,7 @@ cisHardeningRoutes.get(
       })
       .from(rankedResults)
       .where(and(...latestConditions))
-      .orderBy(desc(rankedResults.checkedAt))
+      .orderBy(desc(rankedResults.checkedAt), desc(rankedResults.resultId))
       .limit(limit)
       .offset(offset);
 
@@ -1241,7 +1241,7 @@ cisHardeningRoutes.get(
       .innerJoin(devices, eq(cisRemediationActions.deviceId, devices.id))
       .leftJoin(cisBaselines, eq(cisRemediationActions.baselineId, cisBaselines.id))
       .where(where)
-      .orderBy(desc(cisRemediationActions.createdAt))
+      .orderBy(desc(cisRemediationActions.createdAt), desc(cisRemediationActions.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/clientAi/adminSessions.ts
+++ b/apps/api/src/routes/clientAi/adminSessions.ts
@@ -110,7 +110,7 @@ clientAiAdminSessionRoutes.get(
       .leftJoin(organizations, eq(aiSessions.orgId, organizations.id))
       .leftJoin(portalUsers, eq(aiSessions.clientUserId, portalUsers.id))
       .where(where)
-      .orderBy(desc(aiSessions.createdAt))
+      .orderBy(desc(aiSessions.createdAt), desc(aiSessions.id))
       .limit(q.limit)
       .offset(q.offset);
 

--- a/apps/api/src/routes/deployments.ts
+++ b/apps/api/src/routes/deployments.ts
@@ -259,7 +259,7 @@ deploymentRoutes.get(
       .select()
       .from(deployments)
       .where(whereCondition)
-      .orderBy(desc(deployments.createdAt))
+      .orderBy(desc(deployments.createdAt), desc(deployments.id))
       .limit(query.limit)
       .offset(query.offset);
 
@@ -800,7 +800,7 @@ deploymentRoutes.get(
       .from(deploymentDevices)
       .leftJoin(devices, eq(deploymentDevices.deviceId, devices.id))
       .where(whereCondition)
-      .orderBy(deploymentDevices.batchNumber, deploymentDevices.status)
+      .orderBy(deploymentDevices.batchNumber, deploymentDevices.status, deploymentDevices.id)
       .limit(query.limit)
       .offset(query.offset);
 

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -505,7 +505,7 @@ commandsRoutes.get(
       .select()
       .from(deviceCommands)
       .where(eq(deviceCommands.deviceId, deviceId))
-      .orderBy(desc(deviceCommands.createdAt))
+      .orderBy(desc(deviceCommands.createdAt), desc(deviceCommands.id))
       .limit(pagination.limit)
       .offset(pagination.offset);
 

--- a/apps/api/src/routes/devices/diagnosticLogs.ts
+++ b/apps/api/src/routes/devices/diagnosticLogs.ts
@@ -87,7 +87,7 @@ diagnosticLogsRoutes.get(
           .select()
           .from(agentLogs)
           .where(and(...conditions))
-          .orderBy(desc(agentLogs.timestamp))
+          .orderBy(desc(agentLogs.timestamp), desc(agentLogs.id))
           .limit(limit)
           .offset(offset),
         db

--- a/apps/api/src/routes/devices/eventlogs.ts
+++ b/apps/api/src/routes/devices/eventlogs.ts
@@ -74,7 +74,7 @@ eventLogsRoutes.get(
       .select()
       .from(deviceEventLogs)
       .where(whereCondition)
-      .orderBy(desc(deviceEventLogs.timestamp))
+      .orderBy(desc(deviceEventLogs.timestamp), desc(deviceEventLogs.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -253,7 +253,7 @@ eventsRoutes.get(
         .from(auditLogs)
         .leftJoin(users, eq(auditLogs.actorId, users.id))
         .where(whereClause)
-        .orderBy(desc(auditLogs.timestamp))
+        .orderBy(desc(auditLogs.timestamp), desc(auditLogs.id))
         .limit(limit)
         .offset(offset),
     ]);

--- a/apps/api/src/routes/devices/groups.ts
+++ b/apps/api/src/routes/devices/groups.ts
@@ -80,7 +80,7 @@ groupsRoutes.get(
       .select()
       .from(deviceGroups)
       .where(whereCondition)
-      .orderBy(asc(deviceGroups.name))
+      .orderBy(asc(deviceGroups.name), asc(deviceGroups.id))
       .limit(pagination.limit)
       .offset(pagination.offset);
 

--- a/apps/api/src/routes/devices/hardware.ts
+++ b/apps/api/src/routes/devices/hardware.ts
@@ -113,7 +113,7 @@ hardwareRoutes.get(
         .select()
         .from(deviceIpHistory)
         .where(and(...conditions))
-        .orderBy(desc(deviceIpHistory.firstSeen))
+        .orderBy(desc(deviceIpHistory.firstSeen), desc(deviceIpHistory.id))
         .limit(limit)
         .offset(offset);
 

--- a/apps/api/src/routes/devices/network.test.ts
+++ b/apps/api/src/routes/devices/network.test.ts
@@ -239,6 +239,43 @@ describe('GET /devices/network — unified-list network arm (#1322)', () => {
     expect(withoutTotalBody.pagination.total).toBeUndefined();
   });
 
+  // #3462: apps/web/src/lib/devicesFetch.ts's fetchAllNetworkDevices pages
+  // through this endpoint with LIMIT/OFFSET. A discovery sweep writes every
+  // asset it found in one transaction, so `last_seen_at` ties in bulk —
+  // ordering on that tied key alone leaves row order undefined between two
+  // page fetches, and the walk would silently drop an asset and duplicate
+  // another. The unique `id` tiebreaker is what makes the walk a true
+  // enumeration.
+  it('appends a unique id tiebreaker to the sort so paging is stable', async () => {
+    let capturedOrderBy: unknown[] = [];
+    const offset = vi.fn().mockResolvedValue([]);
+    const limit = vi.fn().mockReturnValue({ offset });
+    const orderBy = vi.fn().mockImplementation((...args: unknown[]) => {
+      capturedOrderBy = args;
+      return { limit };
+    });
+    vi.mocked(db.select).mockImplementation(((arg: any) => {
+      const isCount = arg && typeof arg === 'object' && 'count' in arg && Object.keys(arg).length === 1;
+      const where = isCount
+        ? vi.fn().mockResolvedValue([{ count: 0 }])
+        : vi.fn().mockReturnValue({ orderBy });
+      const from = vi.fn().mockReturnValue({ where });
+      return { from } as never;
+    }) as never);
+
+    const res = await app.request('/devices/network', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedOrderBy).toHaveLength(2);
+    const dialect = new PgDialect();
+    const [first, second] = capturedOrderBy as [never, never];
+    expect(dialect.sqlToQuery(first).sql).toMatch(/"last_seen_at" desc/);
+    expect(dialect.sqlToQuery(second).sql).toMatch(/"id" desc/);
+  });
+
   it('rejects a single-org filter the caller cannot access with 403', async () => {
     rigNetworkRows([]);
     const res = await app.request('/devices/network?orgId=00000000-0000-4000-8000-000000000000', {

--- a/apps/api/src/routes/devices/network.ts
+++ b/apps/api/src/routes/devices/network.ts
@@ -180,7 +180,13 @@ networkRoutes.get(
       })
       .from(discoveredAssets)
       .where(whereCondition)
-      .orderBy(desc(discoveredAssets.lastSeenAt))
+      // `id` is a mandatory tiebreaker, not a cosmetic nicety (#3462).
+      // A discovery sweep writes every asset it found in one transaction, so
+      // `last_seen_at` ties in bulk. Ordering on a tied key alone leaves row
+      // order undefined between two LIMIT/OFFSET queries, so the page walk in
+      // `apps/web/src/lib/devicesFetch.ts` (`fetchAllNetworkDevices`) would
+      // silently drop an asset and duplicate another.
+      .orderBy(desc(discoveredAssets.lastSeenAt), desc(discoveredAssets.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/devices/patches.ts
+++ b/apps/api/src/routes/devices/patches.ts
@@ -267,7 +267,7 @@ patchesRoutes.get(
       .from(deviceCommands)
       .leftJoin(users, eq(deviceCommands.createdBy, users.id))
       .where(whereClause)
-      .orderBy(desc(deviceCommands.createdAt))
+      .orderBy(desc(deviceCommands.createdAt), desc(deviceCommands.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/devices/software.ts
+++ b/apps/api/src/routes/devices/software.ts
@@ -57,7 +57,7 @@ softwareRoutes.get(
       .select()
       .from(softwareInventory)
       .where(whereCondition)
-      .orderBy(asc(softwareInventory.name))
+      .orderBy(asc(softwareInventory.name), asc(softwareInventory.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/devices/watchdogLogs.ts
+++ b/apps/api/src/routes/devices/watchdogLogs.ts
@@ -93,7 +93,7 @@ watchdogLogsRoutes.get(
           .select()
           .from(agentLogs)
           .where(and(...conditions))
-          .orderBy(desc(agentLogs.timestamp))
+          .orderBy(desc(agentLogs.timestamp), desc(agentLogs.id))
           .limit(limit)
           .offset(offset),
         db

--- a/apps/api/src/routes/dnsSecurity.ts
+++ b/apps/api/src/routes/dnsSecurity.ts
@@ -562,7 +562,7 @@ dnsSecurityRoutes.get(
         .from(dnsSecurityEvents)
         .leftJoin(devices, eq(dnsSecurityEvents.deviceId, devices.id))
         .where(where)
-        .orderBy(desc(dnsSecurityEvents.timestamp))
+        .orderBy(desc(dnsSecurityEvents.timestamp), desc(dnsSecurityEvents.id))
         .limit(limit)
         .offset(offset),
       db

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -931,7 +931,7 @@ enrollmentKeyRoutes.get(
       .select()
       .from(enrollmentKeys)
       .where(whereCondition)
-      .orderBy(desc(enrollmentKeys.createdAt))
+      .orderBy(desc(enrollmentKeys.createdAt), desc(enrollmentKeys.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -1305,7 +1305,7 @@ groupRoutes.get(
           .from(groupMembershipLog)
           .innerJoin(devices, eq(groupMembershipLog.deviceId, devices.id))
           .where(and(...conditions, inArray(devices.siteId, perms.allowedSiteIds)))
-          .orderBy(desc(groupMembershipLog.createdAt))
+          .orderBy(desc(groupMembershipLog.createdAt), desc(groupMembershipLog.id))
           .limit(query.limit)
           .offset(query.offset)
       : await db
@@ -1322,7 +1322,7 @@ groupRoutes.get(
           .from(groupMembershipLog)
           .leftJoin(devices, eq(groupMembershipLog.deviceId, devices.id))
           .where(and(...conditions))
-          .orderBy(desc(groupMembershipLog.createdAt))
+          .orderBy(desc(groupMembershipLog.createdAt), desc(groupMembershipLog.id))
           .limit(query.limit)
           .offset(query.offset);
 

--- a/apps/api/src/routes/huntress.ts
+++ b/apps/api/src/routes/huntress.ts
@@ -979,7 +979,7 @@ huntressRoutes.get(
           .from(huntressIncidents)
           .leftJoin(devices, eq(huntressIncidents.deviceId, devices.id))
           .where(where)
-          .orderBy(desc(huntressIncidents.reportedAt), desc(huntressIncidents.createdAt))
+          .orderBy(desc(huntressIncidents.reportedAt), desc(huntressIncidents.createdAt), desc(huntressIncidents.id))
           .limit(limit)
           .offset(offset),
         db

--- a/apps/api/src/routes/incidents.helpers.ts
+++ b/apps/api/src/routes/incidents.helpers.ts
@@ -362,8 +362,20 @@ export function buildIncidentFeedQueries(
     // two alone leaves row order undefined between two LIMIT/OFFSET queries and
     // a client paging the feed would see some rows twice and miss others. There
     // is no single base-table PK here — the feed is a UNION ALL over three
-    // sources — but `source` is a constant per leg and `sourceId` is unique
-    // within its leg, so the pair is a complete key across the union.
+    // sources — so we key on `(source, sourceId)`: `source` is a constant per
+    // leg, and `sourceId` separates rows within a leg.
+    //
+    // Honest caveat: that pair is a COMPLETE key only for the tracked leg
+    // (`incidents.id`). The EDR legs carry the vendor's own id, and its unique
+    // index is per INTEGRATION (`huntress_incidents_external_idx` on
+    // `(integration_id, huntress_incident_id)`; likewise for S1), while these
+    // legs are scoped by `org_id` alone. An org with two integrations from the
+    // same vendor could therefore still tie — which needs identical rank AND
+    // identical detectedAt AND a colliding vendor incident id, so it is a
+    // remote corner rather than the everyday transaction-timestamp tie this
+    // fixes. Making it airtight means adding `integration_id` as a fourth
+    // aliased column to all three legs; not worth the surface today, but that
+    // is the fix if it ever bites.
     .orderBy(asc(sub.rank), desc(sub.detectedAt), asc(sub.source), asc(sub.sourceId))
     .limit(params.limit)
     .offset(params.offset);

--- a/apps/api/src/routes/incidents.helpers.ts
+++ b/apps/api/src/routes/incidents.helpers.ts
@@ -356,7 +356,15 @@ export function buildIncidentFeedQueries(
     // first), `detectedAt` descending. Referencing `sub.rank`/`sub.detectedAt`
     // emits correctly-quoted identifiers — raw unquoted `detected_at` would
     // fold to lowercase and fail (`column "detected_at" does not exist`).
-    .orderBy(asc(sub.rank), desc(sub.detectedAt))
+    // `(source, sourceId)` is the mandatory tiebreaker (#3462). `rank` is a
+    // small integer and `detectedAt` ties in bulk (one provider sync writes
+    // every finding it pulled in a single transaction), so ordering on those
+    // two alone leaves row order undefined between two LIMIT/OFFSET queries and
+    // a client paging the feed would see some rows twice and miss others. There
+    // is no single base-table PK here — the feed is a UNION ALL over three
+    // sources — but `source` is a constant per leg and `sourceId` is unique
+    // within its leg, so the pair is a complete key across the union.
+    .orderBy(asc(sub.rank), desc(sub.detectedAt), asc(sub.source), asc(sub.sourceId))
     .limit(params.limit)
     .offset(params.offset);
 

--- a/apps/api/src/routes/incidents.ts
+++ b/apps/api/src/routes/incidents.ts
@@ -220,7 +220,7 @@ incidentRoutes.get(
         .select()
         .from(incidents)
         .where(whereCondition)
-        .orderBy(desc(incidents.detectedAt), desc(incidents.createdAt))
+        .orderBy(desc(incidents.detectedAt), desc(incidents.createdAt), desc(incidents.id))
         .limit(limit)
         .offset(offset),
     ]);

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -437,7 +437,7 @@ logsRoutes.get(
         .from(logCorrelations)
         .leftJoin(logCorrelationRules, eq(logCorrelations.ruleId, logCorrelationRules.id))
         .where(whereCondition)
-        .orderBy(desc(logCorrelations.lastSeen))
+        .orderBy(desc(logCorrelations.lastSeen), desc(logCorrelations.id))
         .limit(limit)
         .offset(offset),
       db

--- a/apps/api/src/routes/networkBaselines.ts
+++ b/apps/api/src/routes/networkBaselines.ts
@@ -205,7 +205,7 @@ networkBaselineRoutes.get(
       .select()
       .from(networkBaselines)
       .where(where)
-      .orderBy(desc(networkBaselines.createdAt))
+      .orderBy(desc(networkBaselines.createdAt), desc(networkBaselines.id))
       .limit(limit)
       .offset(offset);
 
@@ -489,7 +489,7 @@ networkBaselineRoutes.get(
       .select()
       .from(networkChangeEvents)
       .where(where)
-      .orderBy(desc(networkChangeEvents.detectedAt))
+      .orderBy(desc(networkChangeEvents.detectedAt), desc(networkChangeEvents.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/networkChanges.ts
+++ b/apps/api/src/routes/networkChanges.ts
@@ -193,7 +193,7 @@ networkChangeRoutes.get(
       .from(networkChangeEvents)
       .leftJoin(networkBaselines, eq(networkChangeEvents.baselineId, networkBaselines.id))
       .where(where)
-      .orderBy(desc(networkChangeEvents.detectedAt))
+      .orderBy(desc(networkChangeEvents.detectedAt), desc(networkChangeEvents.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -48,7 +48,7 @@ notificationRoutes.get(
         .select()
         .from(userNotifications)
         .where(and(...conditions))
-        .orderBy(desc(userNotifications.createdAt))
+        .orderBy(desc(userNotifications.createdAt), desc(userNotifications.id))
         .limit(query.limit)
         .offset(query.offset),
       db

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -159,7 +159,8 @@ vi.mock('../db/schema', () => ({
     id: { __column: 'organizations.id' },
     partnerId: { __column: 'organizations.partnerId' },
     status: { __column: 'organizations.status' },
-    deletedAt: { __column: 'organizations.deletedAt' }
+    deletedAt: { __column: 'organizations.deletedAt' },
+    createdAt: { __column: 'organizations.createdAt' }
   },
   // #2879 — the suspended-org lifecycle override re-reads the caller's raw
   // partner_users.org_ids selection under a system context.
@@ -1602,6 +1603,45 @@ describe('org routes', () => {
       const body = await res.json();
       expect(body.data).toHaveLength(1);
       expect(body.pagination.total).toBe(1);
+    });
+
+    // #3462: apps/web/src/lib/fetchAllOrganizations.ts pages through this
+    // general (partner/system-scope) branch with LIMIT/OFFSET. `created_at`
+    // is `defaultNow()` and Postgres `now()` is the TRANSACTION timestamp, so
+    // every org written in one transaction (seed, bulk import, migration)
+    // shares a byte-identical value — ordering on that tied key alone leaves
+    // row order undefined between two page fetches, and the walk would
+    // silently see some orgs twice and miss others. This exercises the
+    // general paginated branch (partner scope), NOT the own-org early-return
+    // branch covered by the projection test below.
+    it('appends a unique id tiebreaker to the sort so paging is stable', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      let capturedOrderBy: unknown[] = [];
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 0 }])
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  orderBy: vi.fn().mockImplementation((...args: unknown[]) => {
+                    capturedOrderBy = args;
+                    return Promise.resolve([]);
+                  })
+                })
+              })
+            })
+          })
+        } as any);
+
+      const res = await app.request('/orgs/organizations');
+
+      expect(res.status).toBe(200);
+      expect(capturedOrderBy).toEqual([organizations.createdAt, organizations.id]);
     });
 
     // A partner with >50 orgs can't reach org #51+ via page/limit alone (#2280

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -389,7 +389,7 @@ orgRoutes.get('/partners', requireScope('system'), requireOrgRead, zValidator('q
     .where(conditions)
     .limit(limit)
     .offset(offset)
-    .orderBy(partners.createdAt);
+    .orderBy(partners.createdAt, partners.id);
 
   return c.json({
     data,
@@ -1177,7 +1177,7 @@ orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'
       .where(ownOrgCondition)
       .limit(limit)
       .offset(offset)
-      .orderBy(organizations.createdAt);
+      .orderBy(organizations.createdAt, organizations.id);
     return c.json({
       data,
       pagination: { page, limit, total: Number(countResult[0]?.count ?? 0) }
@@ -1216,7 +1216,14 @@ orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'
     .where(conditions)
     .limit(limit)
     .offset(offset)
-    .orderBy(organizations.createdAt);
+    // `id` is a mandatory tiebreaker, not a cosmetic nicety (#3462).
+    // `created_at` is `defaultNow()` and Postgres `now()` is the TRANSACTION
+    // timestamp, so every org written in one transaction (seed, bulk import,
+    // migration) shares a byte-identical value. Ordering on a tied key alone
+    // leaves row order undefined between two LIMIT/OFFSET queries, so the page
+    // walk in `apps/web/src/lib/fetchAllOrganizations.ts` would silently see
+    // some orgs twice and miss others.
+    .orderBy(organizations.createdAt, organizations.id);
 
   // Apply the partner's preferred organization order, when one is set.
   // - partner scope: load own partner settings.
@@ -1947,7 +1954,7 @@ orgRoutes.get('/sites', requireScope('organization', 'partner', 'system'), requi
     .where(whereCondition)
     .limit(limit)
     .offset(offset)
-    .orderBy(sites.createdAt);
+    .orderBy(sites.createdAt, sites.id);
 
   // Enrich each site with its device count. The `sites` row carries no count
   // column, so without this the API omits `deviceCount` entirely and the web

--- a/apps/api/src/routes/pam.ts
+++ b/apps/api/src/routes/pam.ts
@@ -210,7 +210,7 @@ pamRoutes.get('/elevation-requests', requirePamRead, zValidator('query', listQue
       .leftJoin(revokedByUser, eq(elevationRequests.revokedByUserId, revokedByUser.id))
       .leftJoin(softwarePolicies, eq(elevationRequests.softwarePolicyMatchId, softwarePolicies.id))
       .where(where)
-      .orderBy(desc(elevationRequests.requestedAt))
+      .orderBy(desc(elevationRequests.requestedAt), desc(elevationRequests.id))
       .limit(limit)
       .offset(offset),
     db

--- a/apps/api/src/routes/patchPolicies.ts
+++ b/apps/api/src/routes/patchPolicies.ts
@@ -109,7 +109,7 @@ patchPolicyRoutes.get(
       .select()
       .from(patchPolicies)
       .where(whereCondition)
-      .orderBy(desc(patchPolicies.updatedAt))
+      .orderBy(desc(patchPolicies.updatedAt), desc(patchPolicies.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/patches/approvals.ts
+++ b/apps/api/src/routes/patches/approvals.ts
@@ -63,7 +63,7 @@ approvalsRoutes.get(
       .select()
       .from(patchApprovals)
       .where(whereClause)
-      .orderBy(desc(patchApprovals.createdAt))
+      .orderBy(desc(patchApprovals.createdAt), desc(patchApprovals.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/patches/operations.ts
+++ b/apps/api/src/routes/patches/operations.ts
@@ -148,7 +148,7 @@ operationsRoutes.get(
       .select()
       .from(patchJobs)
       .where(whereClause)
-      .orderBy(desc(patchJobs.createdAt))
+      .orderBy(desc(patchJobs.createdAt), desc(patchJobs.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/peripheralControl.ts
+++ b/apps/api/src/routes/peripheralControl.ts
@@ -403,7 +403,7 @@ peripheralControlRoutes.get(
       .select()
       .from(peripheralEvents)
       .where(where)
-      .orderBy(desc(peripheralEvents.occurredAt), desc(peripheralEvents.createdAt))
+      .orderBy(desc(peripheralEvents.occurredAt), desc(peripheralEvents.createdAt), desc(peripheralEvents.id))
       .limit(limit)
       .offset(offset);
 
@@ -458,7 +458,7 @@ peripheralControlRoutes.get(
       .select()
       .from(peripheralPolicies)
       .where(where)
-      .orderBy(desc(peripheralPolicies.updatedAt))
+      .orderBy(desc(peripheralPolicies.updatedAt), desc(peripheralPolicies.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/plugins.ts
+++ b/apps/api/src/routes/plugins.ts
@@ -155,7 +155,7 @@ pluginRoutes.get(
         })
         .from(pluginCatalog)
         .where(whereClause)
-        .orderBy(desc(pluginCatalog.isFeatured), desc(pluginCatalog.installCount))
+        .orderBy(desc(pluginCatalog.isFeatured), desc(pluginCatalog.installCount), desc(pluginCatalog.id))
         .limit(query.limit)
         .offset(offset),
       db
@@ -254,7 +254,7 @@ pluginRoutes.get(
         .from(pluginInstallations)
         .innerJoin(pluginCatalog, eq(pluginInstallations.catalogId, pluginCatalog.id))
         .where(whereClause)
-        .orderBy(desc(pluginInstallations.createdAt))
+        .orderBy(desc(pluginInstallations.createdAt), desc(pluginInstallations.id))
         .limit(query.limit)
         .offset(offset),
       db
@@ -742,7 +742,7 @@ pluginRoutes.get(
         .select()
         .from(pluginLogs)
         .where(whereClause)
-        .orderBy(desc(pluginLogs.timestamp))
+        .orderBy(desc(pluginLogs.timestamp), desc(pluginLogs.id))
         .limit(query.limit)
         .offset(offset),
       db

--- a/apps/api/src/routes/policyManagement/compliance.ts
+++ b/apps/api/src/routes/policyManagement/compliance.ts
@@ -672,7 +672,7 @@ complianceRoutes.get(
         .from(automationPolicyCompliance)
         .leftJoin(devices, eq(automationPolicyCompliance.deviceId, devices.id))
         .where(whereCondition)
-        .orderBy(desc(automationPolicyCompliance.updatedAt))
+        .orderBy(desc(automationPolicyCompliance.updatedAt), desc(automationPolicyCompliance.id))
         .limit(limit)
         .offset(offset);
 
@@ -872,7 +872,7 @@ complianceRoutes.get(
       .from(automationPolicyCompliance)
       .leftJoin(devices, eq(automationPolicyCompliance.deviceId, devices.id))
       .where(configWhereCondition)
-      .orderBy(desc(automationPolicyCompliance.updatedAt))
+      .orderBy(desc(automationPolicyCompliance.updatedAt), desc(automationPolicyCompliance.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/policyManagement/crud.ts
+++ b/apps/api/src/routes/policyManagement/crud.ts
@@ -80,7 +80,7 @@ crudRoutes.get(
       .select()
       .from(automationPolicies)
       .where(whereCondition)
-      .orderBy(desc(automationPolicies.updatedAt))
+      .orderBy(desc(automationPolicies.updatedAt), desc(automationPolicies.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/portal/assets.ts
+++ b/apps/api/src/routes/portal/assets.ts
@@ -66,7 +66,7 @@ assetRoutes.get('/assets', zValidator('query', listSchema), async (c) => {
       )
     )
     .where(availableWhere)
-    .orderBy(desc(devices.updatedAt))
+    .orderBy(desc(devices.updatedAt), desc(devices.id))
     .limit(limit)
     .offset(offset);
 

--- a/apps/api/src/routes/portal/devices.ts
+++ b/apps/api/src/routes/portal/devices.ts
@@ -39,7 +39,7 @@ deviceRoutes.get('/devices', zValidator('query', listSchema), async (c) => {
     })
     .from(devices)
     .where(and(eq(devices.orgId, auth.user.orgId), eq(devices.isEphemeral, false)))
-    .orderBy(desc(devices.lastSeenAt))
+    .orderBy(desc(devices.lastSeenAt), desc(devices.id))
     .limit(limit)
     .offset(offset);
 

--- a/apps/api/src/routes/portal/invoices.ts
+++ b/apps/api/src/routes/portal/invoices.ts
@@ -58,7 +58,7 @@ invoiceRoutes.get('/invoices', zValidator('query', listSchema), async (c) => {
     })
     .from(invoices)
     .where(conditions)
-    .orderBy(desc(invoices.issueDate), desc(invoices.createdAt))
+    .orderBy(desc(invoices.issueDate), desc(invoices.createdAt), desc(invoices.id))
     .limit(limit)
     .offset(offset);
 

--- a/apps/api/src/routes/portal/tickets.ts
+++ b/apps/api/src/routes/portal/tickets.ts
@@ -141,7 +141,7 @@ ticketRoutes.get('/tickets', zValidator('query', listSchema), async (c) => {
     .from(tickets)
     .leftJoin(ticketStatuses, eq(tickets.statusId, ticketStatuses.id))
     .where(conditions)
-    .orderBy(desc(tickets.createdAt))
+    .orderBy(desc(tickets.createdAt), desc(tickets.id))
     .limit(limit)
     .offset(offset);
 

--- a/apps/api/src/routes/psa.ts
+++ b/apps/api/src/routes/psa.ts
@@ -476,7 +476,7 @@ psaRoutes.get(
       })
       .from(psaConnectionsTable)
       .where(whereClause)
-      .orderBy(desc(psaConnectionsTable.updatedAt))
+      .orderBy(desc(psaConnectionsTable.updatedAt), desc(psaConnectionsTable.id))
       .limit(limit)
       .offset(offset);
 
@@ -1032,7 +1032,7 @@ psaRoutes.get(
     const rows = await (perms?.allowedSiteIds
       ? rowsQuery.leftJoin(devices, eq(psaTicketMappings.deviceId, devices.id)).where(whereClause)
       : rowsQuery.where(whereClause))
-      .orderBy(desc(psaTicketMappings.updatedAt))
+      .orderBy(desc(psaTicketMappings.updatedAt), desc(psaTicketMappings.id))
       .limit(limit)
       .offset(offset);
 
@@ -1105,7 +1105,7 @@ psaRoutes.get(
     const rows = await (perms?.allowedSiteIds
       ? rowsQuery.leftJoin(devices, eq(psaTicketMappings.deviceId, devices.id)).where(whereClause)
       : rowsQuery.where(whereClause))
-      .orderBy(desc(psaTicketMappings.updatedAt))
+      .orderBy(desc(psaTicketMappings.updatedAt), desc(psaTicketMappings.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/remote/sessions.ts
+++ b/apps/api/src/routes/remote/sessions.ts
@@ -401,7 +401,7 @@ sessionRoutes.get(
       .innerJoin(devices, eq(remoteSessions.deviceId, devices.id))
       .leftJoin(users, eq(remoteSessions.userId, users.id))
       .where(whereCondition)
-      .orderBy(desc(remoteSessions.createdAt))
+      .orderBy(desc(remoteSessions.createdAt), desc(remoteSessions.id))
       .limit(limit)
       .offset(offset);
 
@@ -556,7 +556,7 @@ sessionRoutes.get(
       .innerJoin(devices, eq(remoteSessions.deviceId, devices.id))
       .leftJoin(users, eq(remoteSessions.userId, users.id))
       .where(whereCondition)
-      .orderBy(desc(remoteSessions.createdAt))
+      .orderBy(desc(remoteSessions.createdAt), desc(remoteSessions.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/reports/core.ts
+++ b/apps/api/src/routes/reports/core.ts
@@ -230,7 +230,7 @@ coreRoutes.get(
       .select()
       .from(reports)
       .where(whereCondition)
-      .orderBy(desc(reports.updatedAt))
+      .orderBy(desc(reports.updatedAt), desc(reports.id))
       .limit(limit)
       .offset(offset);
 
@@ -277,7 +277,7 @@ coreRoutes.get(
       .select()
       .from(reports)
       .where(whereCondition)
-      .orderBy(desc(reports.updatedAt))
+      .orderBy(desc(reports.updatedAt), desc(reports.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/reports/data.ts
+++ b/apps/api/src/routes/reports/data.ts
@@ -164,7 +164,7 @@ dataRoutes.get(
       .from(devices)
       .leftJoin(deviceHardware, eq(devices.id, deviceHardware.deviceId))
       .where(whereCondition)
-      .orderBy(desc(devices.lastSeenAt))
+      .orderBy(desc(devices.lastSeenAt), desc(devices.id))
       .limit(limit)
       .offset(offset);
 
@@ -242,7 +242,7 @@ dataRoutes.get(
       .from(deviceSoftware)
       .innerJoin(devices, eq(deviceSoftware.deviceId, devices.id))
       .where(whereCondition)
-      .orderBy(deviceSoftware.name)
+      .orderBy(deviceSoftware.name, deviceSoftware.id)
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/reports/runs.ts
+++ b/apps/api/src/routes/reports/runs.ts
@@ -276,7 +276,7 @@ runsRoutes.get(
       .from(reportRuns)
       .innerJoin(reports, eq(reportRuns.reportId, reports.id))
       .where(whereCondition)
-      .orderBy(desc(reportRuns.createdAt))
+      .orderBy(desc(reportRuns.createdAt), desc(reportRuns.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -57,7 +57,7 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
-  scripts: {},
+  scripts: { id: 'scripts.id', updatedAt: 'scripts.updatedAt' },
   scriptExecutions: {},
   scriptExecutionBatches: {},
   devices: {},
@@ -88,6 +88,14 @@ vi.mock('../db/schema', () => ({
   },
   discoveredAssetTypeEnum: { enumValues: ['workstation', 'server', 'printer', 'unknown'] }
 }));
+
+// Spy on `desc` while keeping the real implementation, so the pagination
+// tiebreaker test can assert exactly which columns were passed to it without
+// changing behavior for the rest of the file's tests.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return { ...actual, desc: vi.fn(actual.desc) };
+});
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
@@ -128,7 +136,9 @@ vi.mock('../middleware/auth', () => ({
   requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
 }));
 
+import { desc } from 'drizzle-orm';
 import { db } from '../db';
+import { scripts } from '../db/schema';
 import { writeRouteAudit } from '../services/auditEvents';
 
 describe('scripts routes', () => {
@@ -171,6 +181,41 @@ describe('scripts routes', () => {
     const body = await res.json();
     expect(body.data).toHaveLength(2);
     expect(body.pagination.total).toBe(2);
+  });
+
+  // #3462: apps/web/src/lib/scriptsFetch.ts pages through GET /scripts with
+  // LIMIT/OFFSET. `updated_at` defaults to the TRANSACTION timestamp, so a
+  // bundle import writes many scripts with a byte-identical value — ordering
+  // on that alone leaves row order undefined between two page fetches, and
+  // the walk would silently drop a script and duplicate another. The unique
+  // `id` tiebreaker is what makes the walk a true enumeration.
+  it('appends a unique id tiebreaker to the sort so paging is stable', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: 0 }])
+        })
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockResolvedValue([])
+              })
+            })
+          })
+        })
+      } as any);
+
+    const res = await app.request('/scripts?limit=10&page=1', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(200);
+    expect(desc).toHaveBeenNthCalledWith(1, scripts.updatedAt);
+    expect(desc).toHaveBeenNthCalledWith(2, scripts.id);
   });
 
   it('should get a script by id', async () => {

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -422,7 +422,13 @@ scriptRoutes.get(
       .select()
       .from(scripts)
       .where(whereCondition)
-      .orderBy(desc(scripts.updatedAt))
+      // `id` is a mandatory tiebreaker, not a cosmetic nicety (#3462).
+      // `updated_at` defaults to the TRANSACTION timestamp, so a bundle import
+      // writes many scripts with a byte-identical value. Ordering on a tied key
+      // alone leaves row order undefined between two LIMIT/OFFSET queries, so
+      // the page walk in `apps/web/src/lib/scriptsFetch.ts` would silently drop
+      // a script and duplicate another.
+      .orderBy(desc(scripts.updatedAt), desc(scripts.id))
       .limit(limit)
       .offset(offset);
 
@@ -1095,7 +1101,7 @@ scriptRoutes.get(
       .from(scriptExecutions)
       .leftJoin(devices, eq(scriptExecutions.deviceId, devices.id))
       .where(siteRestrictedWhereCondition)
-      .orderBy(desc(scriptExecutions.createdAt))
+      .orderBy(desc(scriptExecutions.createdAt), desc(scriptExecutions.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/sensitiveData.ts
+++ b/apps/api/src/routes/sensitiveData.ts
@@ -609,7 +609,7 @@ sensitiveDataRoutes.get(
       .from(sensitiveDataFindings)
       .innerJoin(devices, eq(devices.id, sensitiveDataFindings.deviceId))
       .where(whereClause)
-      .orderBy(desc(sensitiveDataFindings.lastSeenAt))
+      .orderBy(desc(sensitiveDataFindings.lastSeenAt), desc(sensitiveDataFindings.id))
       .limit(pagination.limit)
       .offset(pagination.offset);
 

--- a/apps/api/src/routes/sentinelOne.ts
+++ b/apps/api/src/routes/sentinelOne.ts
@@ -726,7 +726,7 @@ sentinelOneRoutes.get(
         .from(s1Threats)
         .leftJoin(devices, eq(s1Threats.deviceId, devices.id))
         .where(where)
-        .orderBy(desc(s1Threats.detectedAt), desc(s1Threats.updatedAt))
+        .orderBy(desc(s1Threats.detectedAt), desc(s1Threats.updatedAt), desc(s1Threats.id))
         .limit(limit)
         .offset(offset),
       db

--- a/apps/api/src/routes/servicePrincipals.ts
+++ b/apps/api/src/routes/servicePrincipals.ts
@@ -142,7 +142,7 @@ servicePrincipalRoutes.get(
       .select()
       .from(servicePrincipals)
       .where(whereCondition)
-      .orderBy(desc(servicePrincipals.createdAt))
+      .orderBy(desc(servicePrincipals.createdAt), desc(servicePrincipals.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -661,7 +661,7 @@ softwareRoutes.get(
         methodKinds: sql<string[]>`(SELECT coalesce(array_agg(DISTINCT software_install_methods.kind), ARRAY[]::varchar[]) FROM software_install_methods WHERE software_install_methods.catalog_id = ${softwareCatalog}.id AND software_install_methods.enabled)`,
       }).from(softwareCatalog)
         .where(whereClause)
-        .orderBy(softwareCatalog.name)
+        .orderBy(softwareCatalog.name, softwareCatalog.id)
         .limit(limit)
         .offset(offset),
       db.select({ count: sql<number>`count(*)` }).from(softwareCatalog)
@@ -1406,7 +1406,7 @@ softwareRoutes.get(
     const [items, countRows] = await Promise.all([
       db.select().from(softwareDeployments)
         .where(orgCondition)
-        .orderBy(desc(softwareDeployments.createdAt))
+        .orderBy(desc(softwareDeployments.createdAt), desc(softwareDeployments.id))
         .limit(limit)
         .offset(offset),
       db.select({ count: sql<number>`count(*)::int` })
@@ -2423,7 +2423,7 @@ softwareRoutes.get(
         .leftJoin(devices, eq(deploymentResults.deviceId, devices.id))
         .leftJoin(deviceCommands, eq(deploymentResults.deviceCommandId, deviceCommands.id))
         .where(whereClause)
-        .orderBy(devices.hostname, deploymentResults.deviceId)
+        .orderBy(devices.hostname, deploymentResults.deviceId, deploymentResults.id)
         .limit(limit)
         .offset(offset),
       db.select({ count: sql<number>`count(*)::int` })

--- a/apps/api/src/routes/softwareInventory.ts
+++ b/apps/api/src/routes/softwareInventory.ts
@@ -754,7 +754,7 @@ softwareInventoryRoutes.get('/:name/devices', requireSoftwareInventoryRead, zVal
     .from(softwareInventory)
     .innerJoin(devices, eq(softwareInventory.deviceId, devices.id))
     .where(whereClause)
-    .orderBy(desc(softwareInventory.lastSeen))
+    .orderBy(desc(softwareInventory.lastSeen), desc(softwareInventory.id))
     .limit(limit)
     .offset(offset);
 

--- a/apps/api/src/routes/softwarePolicies.ts
+++ b/apps/api/src/routes/softwarePolicies.ts
@@ -237,7 +237,7 @@ softwarePoliciesRoutes.get(
       .select()
       .from(softwarePolicies)
       .where(where)
-      .orderBy(desc(softwarePolicies.updatedAt))
+      .orderBy(desc(softwarePolicies.updatedAt), desc(softwarePolicies.id))
       .limit(limit)
       .offset(offset);
 

--- a/apps/api/src/routes/thirdPartyCatalog/list.ts
+++ b/apps/api/src/routes/thirdPartyCatalog/list.ts
@@ -32,7 +32,7 @@ listRoutes.get('/', zValidator('query', listCatalogQuerySchema), async (c) => {
   const [rows, totalRows] = await Promise.all([
     db.select().from(thirdPartyPackageCatalog)
       .where(where)
-      .orderBy(thirdPartyPackageCatalog.vendor, thirdPartyPackageCatalog.friendlyName)
+      .orderBy(thirdPartyPackageCatalog.vendor, thirdPartyPackageCatalog.friendlyName, thirdPartyPackageCatalog.id)
       .limit(q.limit)
       .offset(q.offset),
     db.select({ count: sql<number>`count(*)::int` }).from(thirdPartyPackageCatalog).where(where),

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -348,7 +348,7 @@ webhookRoutes.get(
         .select()
         .from(webhooksTable)
         .where(whereCondition)
-        .orderBy(desc(webhooksTable.createdAt))
+        .orderBy(desc(webhooksTable.createdAt), desc(webhooksTable.id))
         .limit(limit)
         .offset(offset)
     ]);
@@ -613,7 +613,7 @@ webhookRoutes.get(
         .select()
         .from(webhookDeliveries)
         .where(whereCondition)
-        .orderBy(desc(webhookDeliveries.createdAt))
+        .orderBy(desc(webhookDeliveries.createdAt), desc(webhookDeliveries.id))
         .limit(limit)
         .offset(offset)
     ]);

--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -219,7 +219,7 @@ export async function listSessions(auth: AuthContext, options: { status?: string
     })
     .from(aiSessions)
     .where(and(...conditions))
-    .orderBy(desc(aiSessions.lastActivityAt))
+    .orderBy(desc(aiSessions.lastActivityAt), desc(aiSessions.id))
     .limit(limit)
     .offset(offset);
 

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -809,7 +809,7 @@ export async function getSessionHistory(orgId: string, options: { limit?: number
     })
     .from(aiSessions)
     .where(and(...conditions))
-    .orderBy(desc(aiSessions.createdAt))
+    .orderBy(desc(aiSessions.createdAt), desc(aiSessions.id))
     .limit(limit)
     .offset(offset);
 }

--- a/apps/api/src/services/aiToolsC2C.ts
+++ b/apps/api/src/services/aiToolsC2C.ts
@@ -261,7 +261,7 @@ export function registerC2CTools(aiTools: Map<string, AiTool>): void {
           .from(c2cBackupItems)
           .leftJoin(c2cBackupConfigs, eq(c2cBackupItems.configId, c2cBackupConfigs.id))
           .where(whereClause)
-          .orderBy(desc(c2cBackupItems.createdAt))
+          .orderBy(desc(c2cBackupItems.createdAt), desc(c2cBackupItems.id))
           .limit(limit)
           .offset(offset),
         db

--- a/apps/api/src/services/aiToolsHuntress.ts
+++ b/apps/api/src/services/aiToolsHuntress.ts
@@ -333,7 +333,7 @@ export function registerHuntressTools(aiTools: Map<string, AiTool>): void {
           .from(huntressIncidents)
           .leftJoin(devices, eq(huntressIncidents.deviceId, devices.id))
           .where(where)
-          .orderBy(desc(huntressIncidents.reportedAt), desc(huntressIncidents.createdAt))
+          .orderBy(desc(huntressIncidents.reportedAt), desc(huntressIncidents.createdAt), desc(huntressIncidents.id))
           .limit(limit)
           .offset(offset),
         db

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -309,7 +309,7 @@ export async function listConfigPolicies(
     .from(configurationPolicies)
     .leftJoin(organizations, eq(configurationPolicies.orgId, organizations.id))
     .where(whereCondition)
-    .orderBy(desc(configurationPolicies.updatedAt))
+    .orderBy(desc(configurationPolicies.updatedAt), desc(configurationPolicies.id))
     .limit(pagination.limit)
     .offset(offset);
 

--- a/apps/api/src/services/recoveryBootMediaService.ts
+++ b/apps/api/src/services/recoveryBootMediaService.ts
@@ -288,7 +288,7 @@ export async function listRecoveryBootMediaArtifacts(orgId: string, filters: {
         filters.status ? eq(recoveryBootMediaArtifacts.status, filters.status as never) : undefined
       )
     )
-    .orderBy(desc(recoveryBootMediaArtifacts.createdAt))
+    .orderBy(desc(recoveryBootMediaArtifacts.createdAt), desc(recoveryBootMediaArtifacts.id))
     .limit(filters.limit)
     .offset(filters.offset);
 }

--- a/apps/api/src/services/recoveryMediaService.ts
+++ b/apps/api/src/services/recoveryMediaService.ts
@@ -669,7 +669,7 @@ export async function listRecoveryMediaArtifacts(orgId: string, filters: {
         filters.status ? eq(recoveryMediaArtifacts.status, filters.status as never) : undefined
       )
     )
-    .orderBy(desc(recoveryMediaArtifacts.createdAt))
+    .orderBy(desc(recoveryMediaArtifacts.createdAt), desc(recoveryMediaArtifacts.id))
     .limit(filters.limit)
     .offset(filters.offset);
 

--- a/apps/api/src/services/reliabilityScoring.ts
+++ b/apps/api/src/services/reliabilityScoring.ts
@@ -1710,7 +1710,16 @@ export async function listReliabilityDevices(filter: ReliabilityListFilter): Pro
       .from(deviceReliability)
       .innerJoin(devices, eq(deviceReliability.deviceId, devices.id))
       .where(where)
-      .orderBy(asc(deviceReliability.reliabilityScore), desc(deviceReliability.computedAt))
+      // `device_reliability`'s primary key is `device_id` (there is no `id`
+      // column), so that is the unique tiebreaker here (#3462). Without it,
+      // `reliability_score` is a 0-100 integer over a whole fleet — ties are
+      // the norm, not the exception — and consecutive LIMIT/OFFSET pages could
+      // repeat and skip devices.
+      .orderBy(
+        asc(deviceReliability.reliabilityScore),
+        desc(deviceReliability.computedAt),
+        asc(deviceReliability.deviceId)
+      )
       .limit(limit)
       .offset(offset),
   ]);

--- a/apps/api/src/services/ticketConfigService.ts
+++ b/apps/api/src/services/ticketConfigService.ts
@@ -693,7 +693,7 @@ export async function listEmailInboundQueue(
     })
     .from(ticketEmailInbound)
     .where(where)
-    .orderBy(desc(ticketEmailInbound.createdAt))
+    .orderBy(desc(ticketEmailInbound.createdAt), desc(ticketEmailInbound.id))
     .limit(limit)
     .offset(offset);
 

--- a/apps/api/src/services/timeEntryService.ts
+++ b/apps/api/src/services/timeEntryService.ts
@@ -753,7 +753,7 @@ export async function listTimeEntries(filters: ListTimeEntriesFilters) {
     .leftJoin(tickets, eq(timeEntries.ticketId, tickets.id))
     .leftJoin(users, eq(timeEntries.userId, users.id))
     .where(conditions.length ? and(...conditions) : undefined)
-    .orderBy(desc(timeEntries.startedAt))
+    .orderBy(desc(timeEntries.startedAt), desc(timeEntries.id))
     .limit(filters.limit)
     .offset(filters.offset);
 

--- a/apps/api/src/services/userRiskScoring.ts
+++ b/apps/api/src/services/userRiskScoring.ts
@@ -1027,7 +1027,7 @@ export async function listUserRiskScores(filter: UserRiskScoreListFilter): Promi
         )
       )
       .where(whereClause)
-      .orderBy(desc(userRiskScores.score), desc(userRiskScores.calculatedAt))
+      .orderBy(desc(userRiskScores.score), desc(userRiskScores.calculatedAt), desc(userRiskScores.id))
       .limit(limit)
       .offset(offset)
   ]);
@@ -1227,7 +1227,7 @@ export async function listUserRiskEvents(filter: UserRiskEventFilter): Promise<{
       .from(userRiskEvents)
       .innerJoin(users, eq(userRiskEvents.userId, users.id))
       .where(whereClause)
-      .orderBy(desc(userRiskEvents.occurredAt))
+      .orderBy(desc(userRiskEvents.occurredAt), desc(userRiskEvents.id))
       .limit(limit)
       .offset(offset)
   ]);


### PR DESCRIPTION
## What

`LIMIT/OFFSET` over an `ORDER BY` whose sort key is not unique is non-deterministic. PostgreSQL guarantees nothing about the relative order of rows with equal sort keys, and it makes that guarantee **per query** — two requests for consecutive pages are two independent queries and can even pick different plans. A client walking pages therefore receives some rows twice and never sees others, with no error and no visible symptom.

This is reachable, not theoretical: `created_at`/`updated_at` default to `now()`, which is the **transaction** timestamp, so every row written in one transaction — a seed, a bulk import, a script-bundle import, a discovery sweep, a provider sync — shares a byte-identical value.

`main` ships page-walking clients whose whole contract is "accumulate every accessible row": `apps/web/src/lib/fetchAllOrganizations.ts`, `scriptsFetch.ts`, and `fetchAllNetworkDevices` in `devicesFetch.ts`. All three walked endpoints with no tiebreaker, so the "complete" list they assembled could silently be wrong.

## The fix

Append the base table's primary key to the `ORDER BY` of every offset-paginated query, matching the direction of the leading column — the pattern `routes/patches/list.ts` (#3157) and `routes/tickets/tickets.ts` already use. **92 query sites across 71 files.** No change to the intended sort.

The three walker-backed endpoints called out in the issue carry an explanatory comment; the rest are a one-expression mechanical change.

## Cases that were not mechanical

| Site | Why | Tiebreaker used |
|---|---|---|
| `routes/incidents.helpers.ts` | `UNION ALL` over three sources — no single base-table PK | `(source, sourceId)`: `source` is constant per leg, `sourceId` unique within it |
| `services/reliabilityScoring.ts` | `device_reliability` has no `id` column | `device_id`, its primary key |
| `routes/cisHardening.ts` | base id is aliased inside a window-function subquery | `rankedResults.resultId` |
| `routes/software.ts` (deployment results) | ordered by joined `devices.hostname` then `deploymentResults.deviceId`, which is not schema-unique | `deploymentResults.id` |
| `routes/alerts/rules.ts` | the site-scoped branch never calls `.offset()` — it fetches the whole candidate set and slices it in JS, re-running the same unordered query per page request | same bug, fixed alongside |

Already correct and left alone: `routes/patches/list.ts`, `routes/tickets/tickets.ts`, `routes/devices/core.ts` (via `buildOrderBy`), `services/logSearch.ts` (via `resolveSearchOrder`), `routes/mobile.ts`, `routes/updateRings.ts`, `services/fleetFindings/dispatch.ts` (composite PK, `runId` pinned in the WHERE).

The issue asked for a maintainer call on whether `devices/core.ts` and `software.ts` could fan out more than one row per base id. They cannot: `deviceHardware` and `deviceReliability` are schema-enforced 1:1 with `devices` (`device_id` is their PK), and every other join in the sweep is many-to-one on an FK.

## The guard

`apps/api/src/db/offsetPaginationOrdering.test.ts` is a source-level contract test in the required **Test API** job: every statement that calls `.offset()` must order by something unique. Exceptions live in a named allowlist with a stated reason and a scoping substring, so an exemption cannot silently cover a second query in the same file; a companion assertion fails when an allowlist entry goes stale.

It earned its keep immediately — it found `services/reliabilityScoring.ts`, which **both the issue's repo-wide sweep and mine missed**, because that file contains a literal NUL byte (`const KEY_SEP = '\0'`) so `grep` classifies it as binary and skips it without `-a`. That site orders a whole fleet by a 0-100 integer score, where ties are the norm rather than the exception.

The guard was mutation-tested: reverting one fixed site turns it red with a pointed message.

## Verification

- `apps/api` typecheck (`tsc --noEmit`) — clean.
- 190 affected test files single-fork — **3,932 passed, 11 skipped, 0 failed** (every test file co-located with a changed source file, plus `routes/devices/`, `routes/alerts/`, `routes/portal/`).
- New guard test green; verified non-vacuous by reverting a fix.

## Notes for the reviewer

- No schema, migration, or tenancy change — this is `ORDER BY` only.
- Adding a PK to the sort key can change index selection on hot tables. Every affected query already carried a `LIMIT`, and the id column is indexed as a primary key, so the tiebreaker is a suffix on an existing sort rather than a new access path.
- `const KEY_SEP = '\0'` in `reliabilityScoring.ts` is left as-is (it looks deliberate), but it makes that file invisible to plain `grep` — worth knowing for any future repo-wide sweep.

Closes #3462

🤖 Generated with [Claude Code](https://claude.com/claude-code)