### PR TITLE
fix(api,web): report rich-text markup the sanitizer strips instead of a silent 200 (#3520)

### DIFF
--- a/apps/api/src/routes/contracts/templates.test.ts
+++ b/apps/api/src/routes/contracts/templates.test.ts
@@ -213,6 +213,32 @@ describe('contract template routes', () => {
     expect(svc.createDraftVersion).toHaveBeenCalledWith(expect.anything(), TEMPLATE_ID, { bodyHtml: '<p>New draft</p>' });
   });
 
+  // Issue #3520: the response envelope carries `warnings` beside `data` so a
+  // lossy save can't read as a clean success. Warnings never ride inside `data`.
+  it('POST /:id/versions surfaces stripped markup as top-level warnings, outside data', async () => {
+    const warnings = [{ code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'bodyHtml', removedTags: ['table'] }];
+    (svc.createDraftVersion as any).mockResolvedValue({
+      id: VERSION_ID,
+      versionNumber: 2,
+      sourceType: 'authored',
+      bodyHtml: '<p>New draft</p>',
+      status: 'draft',
+      orgId: ORG_ID,
+      partnerId: null,
+      warnings,
+    });
+    const res = await app().request(`${BASE}/${TEMPLATE_ID}/versions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ bodyHtml: '<p>New draft</p><table><tr><td>x</td></tr></table>' }),
+    });
+    expect(res.status).toBe(200); // still a success — the version saved
+    const body = await res.json();
+    expect(body.warnings).toEqual(warnings);
+    expect(body.data.warnings).toBeUndefined();
+    expect(body.data.versionNumber).toBe(2);
+  });
+
   it('POST /:id/versions rejects an empty bodyHtml (400, no service call)', async () => {
     const res = await app().request(`${BASE}/${TEMPLATE_ID}/versions`, {
       method: 'POST',

--- a/apps/api/src/routes/contracts/templates.ts
+++ b/apps/api/src/routes/contracts/templates.ts
@@ -140,8 +140,10 @@ contractTemplateRoutes.post(
   async (c) => {
     try {
       const { id } = c.req.valid('param');
-      const version = await createDraftVersion(authFrom(c), id, c.req.valid('json'));
-      return c.json({ data: serializeVersion(version) });
+      // `warnings` names any markup the rich-text subset discarded from the
+      // submitted body — always present, usually empty (issue #3520).
+      const { warnings, ...version } = await createDraftVersion(authFrom(c), id, c.req.valid('json'));
+      return c.json({ data: serializeVersion(version), warnings });
     } catch (err) {
       return handleTemplateError(c, err);
     }

--- a/apps/api/src/routes/quotes/quotes.test.ts
+++ b/apps/api/src/routes/quotes/quotes.test.ts
@@ -395,6 +395,37 @@ describe('quote crud + lines routes', () => {
     );
   });
 
+  // Issue #3520: the sanitizer silently discarded out-of-subset markup and the
+  // route answered a clean 200. The service's `warnings` now ride the envelope
+  // beside `data` — never folded into the block itself.
+  it('PATCH /:id/blocks/:blockId surfaces stripped markup as top-level warnings, outside data', async () => {
+    const warnings = [{ code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.html', removedTags: ['blockquote', 'table'] }];
+    (svc.updateBlock as any).mockResolvedValue({ id: BLOCK_ID, blockType: 'rich_text', content: { html: '<p>kept</p>' }, warnings });
+    const res = await app().request(`/${QUOTE_ID}/blocks/${BLOCK_ID}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ blockType: 'rich_text', content: { html: '<p>kept</p><table><tr><td>gone</td></tr></table>' } }),
+    });
+    expect(res.status).toBe(200); // still a success — the block saved
+    const body = await res.json();
+    expect(body.warnings).toEqual(warnings);
+    expect(body.data.warnings).toBeUndefined();
+    expect(body.data.id).toBe(BLOCK_ID);
+  });
+
+  it('POST /:id/blocks answers an empty warnings array when nothing was stripped', async () => {
+    (svc.addBlock as any).mockResolvedValue({ id: BLOCK_ID, blockType: 'rich_text', content: { html: '<p>ok</p>' }, warnings: [] });
+    const res = await app().request(`/${QUOTE_ID}/blocks`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ blockType: 'rich_text', content: { html: '<p>ok</p>' } }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.warnings).toEqual([]);
+    expect(body.data.id).toBe(BLOCK_ID);
+  });
+
   it('PATCH /:id/blocks/:blockId rejects an invalid content shape (400)', async () => {
     const res = await app().request(`/${QUOTE_ID}/blocks/${BLOCK_ID}`, {
       method: 'PATCH',

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -145,8 +145,14 @@ quoteCrudRoutes.delete('/:id', scopes, writePerm, zValidator('param', idParam), 
   try { await deleteDraftQuote(c.req.valid('param').id, quoteActorFrom(c)); return c.json({ data: { ok: true } }); }
   catch (err) { return handleServiceError(c, err); }
 });
+// Block writes answer `{ data, warnings }`. `warnings` is always present (often
+// empty) and names any markup the rich-text sanitizer had to discard, so an
+// author is never told "saved" about content that silently went away (#3520).
 quoteCrudRoutes.post('/:id/blocks', scopes, writePerm, zValidator('param', idParam), zValidator('json', quoteBlockInputSchema), async (c) => {
-  try { return c.json({ data: await addBlock(c.req.valid('param').id, c.req.valid('json'), quoteActorFrom(c)) }); }
+  try {
+    const { warnings, ...data } = await addBlock(c.req.valid('param').id, c.req.valid('json'), quoteActorFrom(c));
+    return c.json({ data, warnings });
+  }
   catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.patch('/:id/blocks/reorder', scopes, writePerm, zValidator('param', idParam), zValidator('json', reorderBlocksSchema), async (c) => {
@@ -154,7 +160,11 @@ quoteCrudRoutes.patch('/:id/blocks/reorder', scopes, writePerm, zValidator('para
   catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.patch('/:id/blocks/:blockId', scopes, writePerm, zValidator('param', blockParam), zValidator('json', quoteBlockInputSchema), async (c) => {
-  try { const p = c.req.valid('param'); return c.json({ data: await updateBlock(p.id, p.blockId, c.req.valid('json'), quoteActorFrom(c)) }); }
+  try {
+    const p = c.req.valid('param');
+    const { warnings, ...data } = await updateBlock(p.id, p.blockId, c.req.valid('json'), quoteActorFrom(c));
+    return c.json({ data, warnings });
+  }
   catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.patch('/:id/blocks/:blockId/lines/reorder', scopes, writePerm, zValidator('param', blockParam), zValidator('json', reorderLinesSchema), async (c) => {

--- a/apps/api/src/services/contractTemplateService.test.ts
+++ b/apps/api/src/services/contractTemplateService.test.ts
@@ -262,6 +262,31 @@ describe('createDraftVersion', () => {
     expect(persisted.bodyHtml).toContain('Hi');
   });
 
+  // Issue #3520: sanitizing away a pasted <table>/<blockquote> used to be
+  // invisible — the version saved and the author found out later.
+  it('reports the tags it stripped from bodyHtml instead of saving silently', async () => {
+    const auth = makeAuth({ scope: 'organization', canAccessOrg: () => true });
+    queueResult([ORG_TEMPLATE]);
+    queueResult([{ maxVersion: null }]);
+    queueResult([{ id: 'v1', versionNumber: 1 }]);
+    const row = await svc.createDraftVersion(auth, ORG_TEMPLATE.id, {
+      bodyHtml: '<p>Terms</p><blockquote>note</blockquote><table><tr><td>c</td></tr></table>',
+    });
+    expect(row.id).toBe('v1'); // still saves — warning, not rejection
+    expect(row.warnings).toEqual([
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'bodyHtml', removedTags: ['blockquote', 'table', 'td', 'tr'] },
+    ]);
+  });
+
+  it('reports an empty warnings array when bodyHtml is already inside the subset', async () => {
+    const auth = makeAuth({ scope: 'organization', canAccessOrg: () => true });
+    queueResult([ORG_TEMPLATE]);
+    queueResult([{ maxVersion: null }]);
+    queueResult([{ id: 'v1', versionNumber: 1 }]);
+    const row = await svc.createDraftVersion(auth, ORG_TEMPLATE.id, { bodyHtml: '<p>Terms <strong>apply</strong></p>' });
+    expect(row.warnings).toEqual([]);
+  });
+
   it('rejects adding a draft version to an archived template', async () => {
     const auth = makeAuth({ scope: 'organization', canAccessOrg: () => true });
     queueResult([ARCHIVED_ORG_TEMPLATE]);

--- a/apps/api/src/services/contractTemplateService.ts
+++ b/apps/api/src/services/contractTemplateService.ts
@@ -11,7 +11,11 @@ import { AUTO_CONTRACT_VARIABLES } from '@breeze/shared';
 import { db } from '../db';
 import { contractTemplates, contractTemplateVersions } from '../db/schema';
 import type { AuthContext } from '../middleware/auth';
-import { sanitizeRichTextHtml } from './richTextSanitize';
+import {
+  sanitizeRichTextHtmlWithReport,
+  richTextStripWarning,
+  type RichTextStripWarning,
+} from './richTextSanitize';
 import {
   canManagePartnerWidePolicies,
   PARTNER_WIDE_WRITE_DENIED_MESSAGE,
@@ -368,7 +372,7 @@ export async function createDraftVersion(
   auth: AuthContext,
   templateId: string,
   input: { bodyHtml: string }
-): Promise<VersionRow> {
+): Promise<VersionRow & { warnings: RichTextStripWarning[] }> {
   const template = await getTemplateOr404(templateId);
   assertTemplateWriteAccess(auth, template);
   if (template.status === 'archived') {
@@ -377,8 +381,13 @@ export async function createDraftVersion(
 
   const versionNumber = await nextVersionNumber(templateId);
   // Authored version bodies must pass through the shared rich-text sanitizer
-  // before persisting — same subset enforced on quote rich_text blocks.
-  const bodyHtml = sanitizeRichTextHtml(input.bodyHtml);
+  // before persisting — same subset enforced on quote rich_text blocks. The
+  // reporting variant additionally names anything the subset discarded, so the
+  // author is told rather than left to discover the loss later (issue #3520).
+  const report = sanitizeRichTextHtmlWithReport(input.bodyHtml);
+  const bodyHtml = report.html;
+  const warning = richTextStripWarning('bodyHtml', report);
+  const warnings = warning ? [warning] : [];
 
   const [row] = await db
     .insert(contractTemplateVersions)
@@ -395,7 +404,14 @@ export async function createDraftVersion(
     })
     .returning();
   if (!row) throw new ContractTemplateServiceError('Failed to create draft version', 500, 'VERSION_CREATE_FAILED');
-  return row;
+  if (warnings.length > 0) {
+    console.warn('[contractTemplateService] createDraftVersion removed unsupported markup', {
+      templateId,
+      versionId: row.id,
+      removedTags: report.removedTags,
+    });
+  }
+  return { ...row, warnings };
 }
 
 export async function createUploadedVersion(

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -531,6 +531,41 @@ describe('quoteService deposits', () => {
     expect(inserted.content.html).not.toContain('script');
   });
 
+  it('addBlock hands back the tags it stripped instead of a silent 200 (#3520)', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft' }]); // loadDraft
+    queueResult([{ max: -1 }]); // nextBlockSortOrder
+    queueResult([{ id: 'blk1', blockType: 'rich_text', content: { html: '<p>Hello</p>' } }]); // insert returning
+
+    const row = await svc.addBlock('q1', { blockType: 'rich_text', content: { html: '<p>Hello</p><blockquote>gone</blockquote>' } }, actor);
+
+    expect(row.id).toBe('blk1'); // the block still saves — warning, not rejection
+    expect(row.warnings).toEqual([
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.html', removedTags: ['blockquote'] },
+    ]);
+  });
+
+  it('addBlock returns an empty warnings array when nothing was stripped (#3520)', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft' }]); // loadDraft
+    queueResult([{ max: -1 }]); // nextBlockSortOrder
+    queueResult([{ id: 'blk1', blockType: 'rich_text', content: { html: '<p>Hello</p>' } }]); // insert returning
+
+    const row = await svc.addBlock('q1', { blockType: 'rich_text', content: { html: '<p>Hello</p>' } }, actor);
+
+    expect(row.warnings).toEqual([]);
+  });
+
+  it('updateBlock hands back the tags it stripped (#3520)', async () => {
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft' }]); // loadDraft
+    queueResult([{ blockType: 'rich_text' }]); // existing block type check
+    queueResult([{ id: 'blk1', blockType: 'rich_text', content: { html: '<p>Updated</p>' } }]); // update returning
+
+    const row = await svc.updateBlock('q1', 'blk1', { blockType: 'rich_text', content: { html: '<p>Updated</p><table><tr><td>x</td></tr></table>' } }, actor);
+
+    expect(row.warnings).toEqual([
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.html', removedTags: ['table', 'td', 'tr'] },
+    ]);
+  });
+
   it('addBlock leaves non-rich_text block content untouched', async () => {
     queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'draft' }]); // loadDraft
     queueResult([{ max: -1 }]); // nextBlockSortOrder
@@ -741,7 +776,8 @@ describe('attachCustomerLineImages', () => {
 
 describe('structured block sanitization', () => {
   it('sanitizes every table cell and label on write', () => {
-    const out = svc.sanitizeBlockContentForWrite({ blockType: 'table', content: { columns: [{ label: '<p>Item</p>' }], rows: [{ cells: ['<script>x</script><strong>ok</strong>'] }] } } as never) as never as { columns: { label: string }[]; rows: { cells: string[] }[] };
+    const { content } = svc.sanitizeBlockContentForWrite({ blockType: 'table', content: { columns: [{ label: '<p>Item</p>' }], rows: [{ cells: ['<script>x</script><strong>ok</strong>'] }] } } as never);
+    const out = content as never as { columns: { label: string }[]; rows: { cells: string[] }[] };
     expect(out.columns[0]!.label).toBe('Item');
     expect(out.rows[0]!.cells[0]).toBe('<strong>ok</strong>');
   });
@@ -750,5 +786,71 @@ describe('structured block sanitization', () => {
       { blockType: 'table', content: { rows: 'garbage' } } as { blockType: string; content: unknown },
     ]);
     expect(rows[0]!.content).toEqual({ columns: [], rows: [] }); // canonical empty, never raw garbage
+  });
+});
+
+// Issue #3520: a lossy write used to answer a clean 200. sanitizeBlockContentForWrite
+// now reports what it removed so the route can hand the author a `warnings` array.
+describe('sanitizeBlockContentForWrite loss reporting (#3520)', () => {
+  it('reports the disallowed tags a rich_text write dropped', () => {
+    const { content, warnings } = svc.sanitizeBlockContentForWrite({
+      blockType: 'rich_text',
+      content: { html: '<p>Keep</p><blockquote>Quote</blockquote><table><tr><td>Cell</td></tr></table>' },
+    } as never);
+    expect((content as { html: string }).html).not.toContain('<table');
+    expect(warnings).toEqual([
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.html', removedTags: ['blockquote', 'table', 'td', 'tr'] },
+    ]);
+  });
+
+  it('reports nothing when the submitted html is already inside the subset', () => {
+    const { warnings } = svc.sanitizeBlockContentForWrite({
+      blockType: 'rich_text',
+      content: { html: '<p>Plain <strong>bold</strong> and a <a href="https://a.b">link</a></p>' },
+    } as never);
+    expect(warnings).toEqual([]);
+  });
+
+  it('does NOT warn about stripped attributes or a rejected href scheme — only removed tags', () => {
+    const { warnings } = svc.sanitizeBlockContentForWrite({
+      blockType: 'rich_text',
+      content: { html: '<p style="color:red" class="x">hi</p><a href="javascript:alert(1)">x</a>' },
+    } as never);
+    expect(warnings).toEqual([]);
+  });
+
+  it('collapses a table block\'s per-cell losses into one warning per field family', () => {
+    const { warnings } = svc.sanitizeBlockContentForWrite({
+      blockType: 'table',
+      content: {
+        columns: [{ label: '<h3>A</h3>' }, { label: '<h3>B</h3>' }],
+        rows: [{ cells: ['<p>one</p>', '<ul><li>two</li></ul>'] }, { cells: ['<p>three</p>', 'four'] }],
+        caption: '<strong>Cap</strong>',
+      },
+    } as never);
+    expect(warnings).toEqual([
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.columns[].label', removedTags: ['h3'] },
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.rows[].cells[]', removedTags: ['li', 'p', 'ul'] },
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.caption', removedTags: ['strong'] },
+    ]);
+  });
+
+  it('reports callout html and title losses on their own fields', () => {
+    const { warnings } = svc.sanitizeBlockContentForWrite({
+      blockType: 'callout',
+      content: { variant: 'info', html: '<h1>Big</h1>', title: '<em>T</em>' },
+    } as never);
+    expect(warnings).toEqual([
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.html', removedTags: ['h1'] },
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.title', removedTags: ['em'] },
+    ]);
+  });
+
+  it('reports nothing for a block type that carries no rich text', () => {
+    const { warnings } = svc.sanitizeBlockContentForWrite({
+      blockType: 'heading',
+      content: { text: 'Intro', level: 2 },
+    } as never);
+    expect(warnings).toEqual([]);
   });
 });

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -14,7 +14,15 @@ import { buildBillToAddress, type BillToAddress } from './sellerSnapshot';
 import { computeQuoteTotals, validateQuoteDeposit, toQuoteDepositConfig, type QuoteLineForMath } from './quoteMath';
 import { QuoteServiceError, assertOrg, assertSite, assertQuoteAccess, type QuoteActor } from './quoteTypes';
 import { allocateQuoteCounter, formatQuoteNumber } from './quoteNumbers';
-import { sanitizeRichTextHtml, sanitizeInlineRichText, sanitizePlainText } from './richTextSanitize';
+import {
+  sanitizeRichTextHtml,
+  sanitizeRichTextHtmlWithReport,
+  sanitizeInlineRichTextWithReport,
+  sanitizePlainTextWithReport,
+  richTextStripWarning,
+  type RichTextSanitizeReport,
+  type RichTextStripWarning,
+} from './richTextSanitize';
 import { quoteTableContentSchema, quoteCalloutContentSchema } from '@breeze/shared';
 import type {
   CreateQuoteInput, CloneQuoteInput, UpdateQuoteInput, QuoteLineInput, QuoteBlockInput, ListQuotesQuery,
@@ -79,22 +87,61 @@ export function attachCustomerLineImages<T extends { id: string; imageId: string
  * API — the internal editor (getQuote, below), the portal, and the public accept
  * link — must route through this so no unsanitized author HTML is ever served.
  */
+/**
+ * Merge per-field reports for a repeated field (every table cell, every column
+ * label) into ONE warning naming the field family — an author who pasted a
+ * table into a 6x8 grid wants "tables aren't supported in cells", not 48
+ * identical warnings (issue #3520).
+ */
+function mergeWarnings(field: string, reports: RichTextSanitizeReport[]): RichTextStripWarning[] {
+  const removedTags = [...new Set(reports.flatMap((r) => r.removedTags))].sort();
+  const warning = richTextStripWarning(field, { html: '', removedTags });
+  return warning ? [warning] : [];
+}
+
+/** A block's sanitization result: the value to persist/serve, and what the
+ * sanitizer removed on the way (empty array = nothing lost). */
+interface SanitizedContent<T> {
+  content: T;
+  warnings: RichTextStripWarning[];
+}
+
 /** Per-field sanitization shared by write (sanitizeBlockContentForWrite) and
  * read (sanitizeQuoteBlocksForRead) for the 'table' block: every cell/label is
- * inline-only HTML (richTextSanitize's inline profile), caption is plain text. */
-function sanitizeTableContent(c: QuoteTableContent): QuoteTableContent {
+ * inline-only HTML (richTextSanitize's inline profile), caption is plain text.
+ * Both paths go through this one function so the field map can't drift; only
+ * the WRITE path consumes `warnings` (issue #3520). */
+function sanitizeTableContent(c: QuoteTableContent): SanitizedContent<QuoteTableContent> {
+  const labels = c.columns.map((col) => sanitizeInlineRichTextWithReport(col.label));
+  const cells = c.rows.map((r) => r.cells.map(sanitizeInlineRichTextWithReport));
+  const caption = c.caption ? sanitizePlainTextWithReport(c.caption) : null;
   return {
-    ...c,
-    columns: c.columns.map((col) => ({ ...col, label: sanitizeInlineRichText(col.label) })),
-    rows: c.rows.map((r) => ({ cells: r.cells.map(sanitizeInlineRichText) })),
-    caption: c.caption ? sanitizePlainText(c.caption) : c.caption,
+    content: {
+      ...c,
+      columns: c.columns.map((col, i) => ({ ...col, label: labels[i]!.html })),
+      rows: cells.map((row) => ({ cells: row.map((cell) => cell.html) })),
+      caption: caption ? caption.html : c.caption,
+    },
+    warnings: [
+      ...mergeWarnings('content.columns[].label', labels),
+      ...mergeWarnings('content.rows[].cells[]', cells.flat()),
+      ...(caption ? mergeWarnings('content.caption', [caption]) : []),
+    ],
   };
 }
 
 /** Per-field sanitization shared by write and read for the 'callout' block:
  * html uses the same 11-tag block profile as rich_text, title is plain text. */
-function sanitizeCalloutContent(c: QuoteCalloutContent): QuoteCalloutContent {
-  return { ...c, html: sanitizeRichTextHtml(c.html), title: c.title ? sanitizePlainText(c.title) : c.title };
+function sanitizeCalloutContent(c: QuoteCalloutContent): SanitizedContent<QuoteCalloutContent> {
+  const html = sanitizeRichTextHtmlWithReport(c.html);
+  const title = c.title ? sanitizePlainTextWithReport(c.title) : null;
+  return {
+    content: { ...c, html: html.html, title: title ? title.html : c.title },
+    warnings: [
+      ...mergeWarnings('content.html', [html]),
+      ...(title ? mergeWarnings('content.title', [title]) : []),
+    ],
+  };
 }
 
 // Canonical empty content substituted on read when a stored block's JSONB
@@ -115,11 +162,11 @@ export function sanitizeQuoteBlocksForRead<T extends { blockType: string; conten
     }
     if (block.blockType === 'table') {
       const parsed = quoteTableContentSchema.safeParse(block.content);
-      return { ...block, content: parsed.success ? sanitizeTableContent(parsed.data) : EMPTY_TABLE_CONTENT };
+      return { ...block, content: parsed.success ? sanitizeTableContent(parsed.data).content : EMPTY_TABLE_CONTENT };
     }
     if (block.blockType === 'callout') {
       const parsed = quoteCalloutContentSchema.safeParse(block.content);
-      return { ...block, content: parsed.success ? sanitizeCalloutContent(parsed.data) : EMPTY_CALLOUT_CONTENT };
+      return { ...block, content: parsed.success ? sanitizeCalloutContent(parsed.data).content : EMPTY_CALLOUT_CONTENT };
     }
     return block;
   });
@@ -127,18 +174,36 @@ export function sanitizeQuoteBlocksForRead<T extends { blockType: string; conten
 
 /** Sanitize a block's content at WRITE time (addBlock/updateBlock) — the
  * primary defense; sanitizeQuoteBlocksForRead above is the secondary one.
- * Other block types pass through unchanged. Exported for direct unit testing. */
-export function sanitizeBlockContentForWrite(input: QuoteBlockInput): QuoteBlockInput['content'] {
+ * Other block types pass through unchanged. Exported for direct unit testing.
+ *
+ * Returns the removed tags alongside the content so addBlock/updateBlock can
+ * hand them to the caller instead of 200-ing over the loss (issue #3520). The
+ * READ path deliberately stays silent — a legacy row must render, not warn. */
+export function sanitizeBlockContentForWrite(input: QuoteBlockInput): SanitizedContent<QuoteBlockInput['content']> {
   if (input.blockType === 'rich_text') {
-    return { ...input.content, html: sanitizeRichTextHtml(input.content.html) };
+    const report = sanitizeRichTextHtmlWithReport(input.content.html);
+    return {
+      content: { ...input.content, html: report.html },
+      warnings: mergeWarnings('content.html', [report]),
+    };
   }
-  if (input.blockType === 'table') {
-    return sanitizeTableContent(input.content);
-  }
-  if (input.blockType === 'callout') {
-    return sanitizeCalloutContent(input.content);
-  }
-  return input.content;
+  if (input.blockType === 'table') return sanitizeTableContent(input.content);
+  if (input.blockType === 'callout') return sanitizeCalloutContent(input.content);
+  return { content: input.content, warnings: [] };
+}
+
+/**
+ * Record a lossy block write server-side. Logged at the WRITE boundary (with
+ * ids, never the raw HTML) rather than inside the sanitizer, where the read and
+ * PDF-render paths would emit the same line on every page view (issue #3520).
+ */
+function logStrippedMarkup(op: string, quoteId: string, blockId: string, warnings: RichTextStripWarning[]): void {
+  if (warnings.length === 0) return;
+  console.warn(`[quoteService] ${op} removed unsupported markup`, {
+    quoteId,
+    blockId,
+    warnings: warnings.map((w) => ({ field: w.field, removedTags: w.removedTags })),
+  });
 }
 
 function resolvePartner(actor: QuoteActor): string {
@@ -869,14 +934,16 @@ export async function addBlock(quoteId: string, input: QuoteBlockInput, actor: Q
     await assertContractBlockValid(input.content, q);
   }
   const sortOrder = await nextBlockSortOrder(quoteId);
+  const { content, warnings } = sanitizeBlockContentForWrite(input);
   const [row] = await db.insert(quoteBlocks).values({
     quoteId,
     orgId: q.orgId,
     blockType: input.blockType,
-    content: sanitizeBlockContentForWrite(input),
+    content,
     sortOrder,
   }).returning();
-  return row!;
+  logStrippedMarkup('addBlock', quoteId, row!.id, warnings);
+  return { ...row!, warnings };
 }
 
 /**
@@ -899,11 +966,13 @@ export async function updateBlock(quoteId: string, blockId: string, input: Quote
   if (input.blockType === 'contract') {
     await assertContractBlockValid(input.content, q);
   }
+  const { content, warnings } = sanitizeBlockContentForWrite(input);
   const [row] = await db.update(quoteBlocks)
-    .set({ content: sanitizeBlockContentForWrite(input) })
+    .set({ content })
     .where(and(eq(quoteBlocks.id, blockId), eq(quoteBlocks.quoteId, quoteId)))
     .returning();
-  return row!;
+  logStrippedMarkup('updateBlock', quoteId, blockId, warnings);
+  return { ...row!, warnings };
 }
 
 /**

--- a/apps/api/src/services/richTextSanitize.test.ts
+++ b/apps/api/src/services/richTextSanitize.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { sanitizeRichTextHtml, sanitizeInlineRichText } from './richTextSanitize';
+import {
+  sanitizeRichTextHtml,
+  sanitizeInlineRichText,
+  sanitizePlainText,
+  sanitizeRichTextHtmlWithReport,
+  sanitizeInlineRichTextWithReport,
+  sanitizePlainTextWithReport,
+  richTextStripWarning,
+} from './richTextSanitize';
 
 describe('sanitizeRichTextHtml', () => {
   it('preserves the allowed subset', () => {
@@ -37,5 +45,79 @@ describe('sanitizeInlineRichText', () => {
   it('applies the hardened link rules', () => {
     expect(sanitizeInlineRichText('<a href="javascript:alert(1)">x</a>')).not.toContain('javascript');
     expect(sanitizeInlineRichText('<a href="https://a.b">x</a>')).toContain('rel="noopener noreferrer"');
+  });
+});
+
+// Issue #3520: the sanitizer used to discard out-of-subset tags without telling
+// anyone, so a write returned 200 with the author's content gone. The reporting
+// variants name what was dropped without changing what is produced.
+describe('loss reporting (#3520)', () => {
+  it('sanitizeRichTextHtmlWithReport names every disallowed tag it removed', () => {
+    const r = sanitizeRichTextHtmlWithReport('<p>keep</p><blockquote><h1>x</h1></blockquote><table><tr><td>c</td></tr></table>');
+    expect(r.removedTags).toEqual(['blockquote', 'h1', 'table', 'td', 'tr']);
+  });
+
+  it('reports the same tag once and in sorted order however often it appears', () => {
+    expect(sanitizeRichTextHtmlWithReport('<div>a</div><div>b</div><span>c</span>').removedTags)
+      .toEqual(['div', 'span']);
+  });
+
+  it('lowercases tag names so <TABLE> and <table> report identically', () => {
+    expect(sanitizeRichTextHtmlWithReport('<TABLE><TR><TD>x</TD></TR></TABLE>').removedTags)
+      .toEqual(['table', 'td', 'tr']);
+  });
+
+  it('produces html byte-identical to the silent variant', () => {
+    const inputs = [
+      '<p>hi</p><script>evil()</script><div>d</div>',
+      '<a href="javascript:alert(1)">x</a>',
+      '<p style="color:red" class="x">hi</p>',
+      '<h1>big</h1><table><tr><td>c</td></tr></table>',
+      '',
+    ];
+    for (const input of inputs) {
+      expect(sanitizeRichTextHtmlWithReport(input).html).toBe(sanitizeRichTextHtml(input));
+      expect(sanitizeInlineRichTextWithReport(input).html).toBe(sanitizeInlineRichText(input));
+      expect(sanitizePlainTextWithReport(input).html).toBe(sanitizePlainText(input));
+    }
+  });
+
+  it('reports tag removal only — NOT stripped attributes or a rejected href scheme', () => {
+    // style/class are dropped and `javascript:` is neutered, but no content is
+    // lost, so flagging them would make every Word paste look alarming.
+    expect(sanitizeRichTextHtmlWithReport('<p style="color:red" class="x">hi</p>').removedTags).toEqual([]);
+    expect(sanitizeRichTextHtmlWithReport('<a href="javascript:alert(1)">x</a>').removedTags).toEqual([]);
+    expect(sanitizeRichTextHtmlWithReport('<a href="//evil.example">x</a>').removedTags).toEqual([]);
+  });
+
+  it('reports nothing for html already inside the subset, and nothing for empty input', () => {
+    expect(sanitizeRichTextHtmlWithReport('<p>a <strong>b</strong> <a href="https://a.b">c</a></p>').removedTags).toEqual([]);
+    expect(sanitizeRichTextHtmlWithReport('').removedTags).toEqual([]);
+    expect(sanitizeRichTextHtmlWithReport('plain text, no markup').removedTags).toEqual([]);
+  });
+
+  it('uses the inline profile for the inline reporter — block tags count as removed there', () => {
+    const r = sanitizeInlineRichTextWithReport('<p>x</p><ul><li>y</li></ul><strong>ok</strong>');
+    expect(r.removedTags).toEqual(['li', 'p', 'ul']);
+    expect(r.html).toBe('xy<strong>ok</strong>');
+  });
+
+  it('treats every tag as removed in the plain-text profile', () => {
+    expect(sanitizePlainTextWithReport('<strong>a</strong>b').removedTags).toEqual(['strong']);
+    expect(sanitizePlainTextWithReport('just words').removedTags).toEqual([]);
+  });
+
+  it('collector state does not leak between calls', () => {
+    expect(sanitizeRichTextHtmlWithReport('<table>x</table>').removedTags).toEqual(['table']);
+    expect(sanitizeRichTextHtmlWithReport('<p>clean</p>').removedTags).toEqual([]);
+  });
+
+  it('richTextStripWarning returns null when nothing was removed and a warning when something was', () => {
+    expect(richTextStripWarning('content.html', { html: '', removedTags: [] })).toBeNull();
+    expect(richTextStripWarning('content.html', { html: '', removedTags: ['table'] })).toEqual({
+      code: 'UNSUPPORTED_HTML_TAGS_REMOVED',
+      field: 'content.html',
+      removedTags: ['table'],
+    });
   });
 });

--- a/apps/api/src/services/richTextSanitize.ts
+++ b/apps/api/src/services/richTextSanitize.ts
@@ -57,11 +57,90 @@ const INLINE_OPTIONS: sanitizeHtml.IOptions = {
   ...LINK_OPTIONS,
 };
 
+const PLAIN_TEXT_OPTIONS: sanitizeHtml.IOptions = { allowedTags: [], allowedAttributes: {} };
+
+// ---------------------------------------------------------------------------
+// Loss reporting (issue #3520)
+//
+// sanitize-html discards out-of-subset tags by design and says nothing about
+// it, so a write that submits <table>/<blockquote>/<h1> used to 200 with the
+// content quietly gone. The *-WithReport variants below run the SAME single
+// sanitize pass and additionally report which tag names the parser saw but the
+// profile does not allow, so a write path can tell the author what it dropped.
+//
+// Detection uses sanitize-html's public `onOpenTag` observer, which fires on
+// the source tag before transformTags and before the allowedTags filter — so
+// it sees discarded tags too. It is deliberately NOT a wildcard `transformTags`
+// entry: that would couple production sanitisation to transform ordering.
+// The collector Set is created per call; never hoist it into module-level
+// options, which are shared by the read/render paths.
+// ---------------------------------------------------------------------------
+
+/** A rich-text field's sanitized value plus what sanitisation removed. */
+export interface RichTextSanitizeReport {
+  /** The sanitized HTML — byte-identical to the non-reporting variant. */
+  html: string;
+  /**
+   * Lowercased, de-duplicated, sorted tag names that were present in the input
+   * and discarded because the profile does not allow them.
+   *
+   * TAG removal only. Attribute stripping (`style`, `class`, `id`) and rejected
+   * `href` schemes (`javascript:`, protocol-relative) are NOT reported here —
+   * those are hostile/no-content-loss cases, and naming them would turn every
+   * pasted-from-Word save into a scary warning.
+   */
+  removedTags: string[];
+}
+
+/** Warning payload returned to API clients when a write lost markup. */
+export const RICH_TEXT_STRIP_WARNING_CODE = 'UNSUPPORTED_HTML_TAGS_REMOVED';
+
+export interface RichTextStripWarning {
+  code: typeof RICH_TEXT_STRIP_WARNING_CODE;
+  /** Dotted path of the field within the written payload, e.g. `content.html`. */
+  field: string;
+  removedTags: string[];
+}
+
+/**
+ * Build a warning for a field, or `null` when nothing was removed. Callers
+ * collect these into the `warnings` array they hand back to the client.
+ */
+export function richTextStripWarning(field: string, report: RichTextSanitizeReport): RichTextStripWarning | null {
+  return report.removedTags.length === 0
+    ? null
+    : { code: RICH_TEXT_STRIP_WARNING_CODE, field, removedTags: report.removedTags };
+}
+
+function sanitizeWithReport(
+  input: string,
+  options: sanitizeHtml.IOptions,
+  allowedTags: readonly string[],
+): RichTextSanitizeReport {
+  const allowed = new Set<string>(allowedTags);
+  const removed = new Set<string>();
+  const html = sanitizeHtml(input ?? '', {
+    ...options,
+    // htmlparser2 lowercases tag names, so `<TABLE>` arrives as `table`.
+    onOpenTag: (name) => {
+      if (!allowed.has(name)) removed.add(name);
+    },
+  });
+  return { html, removedTags: [...removed].sort() };
+}
+
 /** Sanitize author/tenant HTML down to the proposal rich-text subset.
  * Applied at WRITE (store only clean content) and again at READ serialization
  * (defense in depth + covers rows written before this module existed). */
 export function sanitizeRichTextHtml(html: string): string {
   return sanitizeHtml(html ?? '', OPTIONS);
+}
+
+/** `sanitizeRichTextHtml` + a report of the tags it discarded. Use on WRITE
+ * paths so the author is told what was dropped; the read/render paths keep
+ * using the silent variant (a legacy row must still render, not warn). */
+export function sanitizeRichTextHtmlWithReport(html: string): RichTextSanitizeReport {
+  return sanitizeWithReport(html, OPTIONS, RICH_TEXT_ALLOWED_TAGS);
 }
 
 /** Sanitize author/tenant HTML down to inline marks only (no block structure) —
@@ -72,8 +151,19 @@ export function sanitizeInlineRichText(html: string): string {
   return sanitizeHtml(html ?? '', INLINE_OPTIONS);
 }
 
+/** `sanitizeInlineRichText` + a report of the tags it discarded (WRITE paths). */
+export function sanitizeInlineRichTextWithReport(html: string): RichTextSanitizeReport {
+  return sanitizeWithReport(html, INLINE_OPTIONS, INLINE_RICH_TEXT_ALLOWED_TAGS);
+}
+
 /** Strip ALL markup — used for plain-text-only fields (table captions, callout
  * titles) where no HTML at all is allowed. */
 export function sanitizePlainText(text: string): string {
-  return sanitizeHtml(text ?? '', { allowedTags: [], allowedAttributes: {} });
+  return sanitizeHtml(text ?? '', PLAIN_TEXT_OPTIONS);
+}
+
+/** `sanitizePlainText` + a report of the tags it discarded (WRITE paths).
+ * Every tag is disallowed in this profile, so any markup at all is reported. */
+export function sanitizePlainTextWithReport(text: string): RichTextSanitizeReport {
+  return sanitizeWithReport(text, PLAIN_TEXT_OPTIONS, []);
 }

--- a/apps/web/src/components/billing/quotes/QuoteEditor.strippedmarkup.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.strippedmarkup.test.tsx
@@ -1,0 +1,161 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData, QuoteBlock } from './quoteTypes';
+import { addBlock, updateBlock } from '../../../lib/api/quotes';
+
+// Same house pattern as the sibling callout/table tests: swap the tiptap-backed
+// RichTextEditor for a plain textarea so this test targets the add-block form
+// wiring (notifyStrippedMarkup), not rich-text editing internals.
+vi.mock('../../common/RichTextEditor', () => ({
+  default: ({ value, onChange, testId }: { value: string; onChange: (v: string) => void; testId: string }) => (
+    <textarea data-testid={testId} value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+  polishTextRequest: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  updateBlock: vi.fn(),
+  updateQuote: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  addQuoteImageFromUrl: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+// okRes mirrors what a real block write now returns per issue #3520: a
+// top-level `warnings` array alongside `data`, not just `{ data }`.
+const okRes = (data: unknown, warnings?: unknown[]) =>
+  ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: vi.fn().mockResolvedValue(warnings === undefined ? { data } : { data, warnings }),
+  } as unknown as Response);
+
+const detail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+    taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+    createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [],
+  lines: [],
+};
+
+const addBlockMock = vi.mocked(addBlock);
+const updateBlockMock = vi.mocked(updateBlock);
+
+const removedTagsWarning = (removedTags: string[]) => [{
+  code: 'UNSUPPORTED_HTML_TAGS_REMOVED',
+  field: 'content.html',
+  removedTags,
+}];
+
+async function openRichTextForm() {
+  render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+  await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+  fireEvent.click(screen.getByTestId('quote-add-block-type-rich_text'));
+  await waitFor(() => expect(screen.getByTestId('quote-block-rich-text-editor')).toBeInTheDocument());
+}
+
+describe('QuoteEditor — stripped-markup warning toast (#3520)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('adding a rich_text block whose response carries warnings fires a warning toast naming the removed tags', async () => {
+    addBlockMock.mockResolvedValue(okRes({ id: 'blk-rt' }, removedTagsWarning(['blockquote', 'table'])));
+    await openRichTextForm();
+
+    fireEvent.change(screen.getByTestId('quote-block-rich-text-editor'), { target: { value: '<table><tr><td>x</td></tr></table>' } });
+    fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+
+    await waitFor(() => expect(addBlockMock).toHaveBeenCalled());
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'warning',
+      message: expect.stringContaining('table'),
+    })));
+    const warningCall = showToast.mock.calls.find((c) => (c[0] as { type: string }).type === 'warning');
+    expect(warningCall?.[0]).toEqual(expect.objectContaining({ message: expect.stringContaining('blockquote') }));
+  });
+
+  it('adding a rich_text block whose response has an empty warnings array fires no warning toast', async () => {
+    addBlockMock.mockResolvedValue(okRes({ id: 'blk-rt2' }, []));
+    await openRichTextForm();
+
+    fireEvent.change(screen.getByTestId('quote-block-rich-text-editor'), { target: { value: '<p>Clean text</p>' } });
+    fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+
+    await waitFor(() => expect(addBlockMock).toHaveBeenCalled());
+    // Give any (incorrect) async toast a chance to fire before asserting absence:
+    // a successful add clears the draft textarea back to empty.
+    await waitFor(() => expect(screen.getByTestId('quote-block-rich-text-editor')).toHaveValue(''));
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
+  });
+});
+
+// Case 3 (editing an existing block through updateBlock) is covered via the
+// callout block's inline-edit form rather than rich_text: rich_text blocks in
+// this editor have no inline "edit in place" affordance (only heading/table/
+// callout/contract do — see the persisted-block branches in QuoteEditor.tsx),
+// so wiring an inline rich_text edit here would require adding UI surface the
+// component doesn't have. notifyStrippedMarkup wraps every parseSuccess
+// (add AND update, across all block types) identically, so exercising it
+// through updateBlock on a callout block proves the same wiring.
+describe('QuoteEditor — stripped-markup warning toast on updateBlock (#3520)', () => {
+  const calloutBlock: QuoteBlock = {
+    id: 'blk-c', quoteId: 'q-1', orgId: 'org-1', blockType: 'callout',
+    content: { variant: 'warn', title: 'Heads up', html: '<p>Read carefully</p>' },
+    sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('editing a persisted block through updateBlock with a warnings-carrying response fires the warning toast', async () => {
+    updateBlockMock.mockResolvedValue(okRes({ id: 'blk-c' }, removedTagsWarning(['h1'])));
+    render(<QuoteEditor detail={{ ...detail, blocks: [calloutBlock] }} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit'));
+    fireEvent.change(screen.getByTestId('quote-block-callout-blk-c-edit-form-body'), { target: { value: '<h1>Revised</h1>' } });
+    fireEvent.click(screen.getByTestId('quote-block-callout-blk-c-edit-save'));
+
+    await waitFor(() => expect(updateBlockMock).toHaveBeenCalled());
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'warning',
+      message: expect.stringContaining('h1'),
+    })));
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -4,6 +4,7 @@ import { Eye, EyeOff, GripVertical, MoreHorizontal } from 'lucide-react';
 import '../../../lib/i18n';
 import { fetchWithAuth } from '../../../stores/auth';
 import { runAction, handleActionError, ActionError } from '../../../lib/runAction';
+import { strippedTagsFrom } from '../../../lib/richTextWarnings';
 import { formatTime } from '../../../lib/dateTimeFormat';
 import { usePermissions } from '../../../lib/permissions';
 import {
@@ -150,6 +151,18 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
   const canWrite = can('quotes', 'write');
+  // Block writes answer with a `warnings` array when the rich-text subset had to
+  // discard markup (a pasted <table>, <blockquote>, <h1>, …). Without this the
+  // save reads as a clean success and the author only finds the loss later —
+  // issue #3520. Warning-level, non-blocking: the block itself DID save.
+  const notifyStrippedMarkup = useCallback((body: unknown) => {
+    const tags = strippedTagsFrom(body);
+    if (tags.length === 0) return;
+    showToast({
+      type: 'warning',
+      message: t('quotes.editor.warnings.markupRemoved', { tags: tags.join(', ') }),
+    });
+  }, [t]);
   // This editor is the page with the sticky bottom-anchored right rail (Live
   // totals + Terms), so it — not the shared container — owns the toast lift.
   useToastRailOffset();
@@ -1217,7 +1230,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
           errorFallback: t('quotes.editor.errors.imageAddedSectionFailed'),
           // No success toast — the image block visibly appears.
           onUnauthorized: UNAUTHORIZED,
-          parseSuccess: (d) => (d as { data: { id?: string } }).data,
+          parseSuccess: (d) => { notifyStrippedMarkup(d); return (d as { data: { id?: string } }).data; },
         });
         await positionNewBlock(createdImg);
         setImageFile(null); setImageCaption(''); setImageUrl('');
@@ -1258,7 +1271,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
             errorFallback: t('quotes.editor.errors.addContractSection'),
             // No success toast — the contract block visibly appears.
             onUnauthorized: UNAUTHORIZED,
-            parseSuccess: (d) => (d as { data: { id?: string } }).data,
+            parseSuccess: (d) => { notifyStrippedMarkup(d); return (d as { data: { id?: string } }).data; },
           });
         } catch (err) {
           // The attach route itself only rejects with INVALID_CONTRACT_TEMPLATE —
@@ -1291,7 +1304,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
           errorFallback: t('quotes.editor.errors.addSection'),
           // No success toast — the new table visibly appears in the block list.
           onUnauthorized: UNAUTHORIZED,
-          parseSuccess: (d) => (d as { data: { id?: string } }).data,
+          parseSuccess: (d) => { notifyStrippedMarkup(d); return (d as { data: { id?: string } }).data; },
         });
         await positionNewBlock(created);
         resetTableForm();
@@ -1312,7 +1325,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
           errorFallback: t('quotes.editor.errors.addSection'),
           // No success toast — the new callout visibly appears in the block list.
           onUnauthorized: UNAUTHORIZED,
-          parseSuccess: (d) => (d as { data: { id?: string } }).data,
+          parseSuccess: (d) => { notifyStrippedMarkup(d); return (d as { data: { id?: string } }).data; },
         });
         await positionNewBlock(created);
         resetCalloutForm();
@@ -1341,7 +1354,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
         errorFallback: t('quotes.editor.errors.addSection'),
         // No success toast — the new section visibly appears in the block list.
         onUnauthorized: UNAUTHORIZED,
-        parseSuccess: (d) => (d as { data: { id?: string } }).data,
+        parseSuccess: (d) => { notifyStrippedMarkup(d); return (d as { data: { id?: string } }).data; },
       });
       await positionNewBlock(created);
       setHeadingText(''); setRichText(''); setTableLabel('');
@@ -1819,10 +1832,11 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
         request: () => updateBlock(quote.id, block.id, { blockType: block.blockType, content } as QuoteBlockInput),
         errorFallback: t('quotes.editor.errors.updateSection'),
         onUnauthorized: UNAUTHORIZED,
+        parseSuccess: (d) => { notifyStrippedMarkup(d); return d; },
       });
       refresh();
     }, t('quotes.editor.errors.updateBlock')),
-  [quote.id, refresh, runScoped, t]);
+  [notifyStrippedMarkup, quote.id, refresh, runScoped, t]);
 
   // Reorder a block one slot up/down. The optimistic order updates instantly on
   // every click (clicks accumulate — none are dropped while a PATCH is pending),

--- a/apps/web/src/components/contracts/TemplateEditor.strippedmarkup.test.tsx
+++ b/apps/web/src/components/contracts/TemplateEditor.strippedmarkup.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+// Same house pattern as TemplateEditor.test.tsx: swap the tiptap-backed
+// RichTextEditor for a plain textarea so this test targets saveDraft's
+// warning-toast wiring, not rich-text editing internals.
+vi.mock('../common/RichTextEditor', () => ({
+  default: ({ value, onChange, testId }: { value: string; onChange: (v: string) => void; testId: string }) => (
+    <textarea data-testid={testId} value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+const api = vi.hoisted(() => ({
+  getContractTemplate: vi.fn(),
+  createTemplateVersion: vi.fn(),
+  uploadTemplateVersion: vi.fn(),
+  publishTemplateVersion: vi.fn(),
+  getTemplateVersion: vi.fn(),
+}));
+vi.mock('../../lib/api/contractTemplates', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../lib/api/contractTemplates')>();
+  return { ...orig, ...api };
+});
+
+import TemplateEditor from './TemplateEditor';
+
+const resp = (payload: unknown, status = 200) =>
+  ({ ok: status < 400, status, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+// okRes mirrors what a real version write now returns per issue #3520: a
+// top-level `warnings` array alongside `data`, not just `{ data }`.
+const okRes = (data: unknown, warnings?: unknown[]) =>
+  resp(warnings === undefined ? { data } : { data, warnings });
+
+const removedTagsWarning = (removedTags: string[]) => [{
+  code: 'UNSUPPORTED_HTML_TAGS_REMOVED',
+  field: 'bodyHtml',
+  removedTags,
+}];
+
+const draftVersion = {
+  id: 'ver-draft',
+  templateId: 'tpl-1',
+  ownerScope: 'organization',
+  orgId: 'org-1',
+  partnerId: null,
+  versionNumber: 1,
+  status: 'draft',
+  sourceType: 'authored',
+  bodyHtml: '<p>Hello {{client.name}}</p>',
+  mime: null,
+  byteSize: null,
+  sha256: null,
+  declaredVariables: [],
+  publishedAt: null,
+  createdBy: 'u1',
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+function activeTemplate(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'tpl-1',
+    ownerScope: 'organization',
+    orgId: 'org-1',
+    partnerId: null,
+    name: 'Acme SOW',
+    description: null,
+    status: 'active',
+    createdBy: 'u1',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    versions: [draftVersion],
+    ...overrides,
+  };
+}
+
+describe('TemplateEditor — stripped-markup warning toast (#3520)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getContractTemplate.mockResolvedValue(okRes(activeTemplate()));
+  });
+
+  it('saving a draft whose response carries warnings fires the warning toast naming the removed tags, not the success toast', async () => {
+    api.createTemplateVersion.mockResolvedValue(
+      okRes({ ...draftVersion, id: 'ver-2', versionNumber: 2 }, removedTagsWarning(['blockquote', 'table'])),
+    );
+
+    render(<TemplateEditor templateId="tpl-1" />);
+    await screen.findByTestId('contract-template-editor');
+
+    const editor = screen.getByTestId('template-body-editor') as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: '<table><tr><td>x</td></tr></table>' } });
+    fireEvent.click(screen.getByTestId('template-save-draft-btn'));
+
+    await waitFor(() => expect(api.createTemplateVersion).toHaveBeenCalled());
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'warning',
+      message: expect.stringContaining('table'),
+    })));
+    const warningCall = showToast.mock.calls.find((c) => (c[0] as { type: string }).type === 'warning');
+    expect(warningCall?.[0]).toEqual(expect.objectContaining({ message: expect.stringContaining('blockquote') }));
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('saving a draft whose response has an empty warnings array fires the success toast and no warning toast', async () => {
+    api.createTemplateVersion.mockResolvedValue(
+      okRes({ ...draftVersion, id: 'ver-3', versionNumber: 2 }, []),
+    );
+
+    render(<TemplateEditor templateId="tpl-1" />);
+    await screen.findByTestId('contract-template-editor');
+
+    const editor = screen.getByTestId('template-body-editor') as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: '<p>Clean text</p>' } });
+    fireEvent.click(screen.getByTestId('template-save-draft-btn'));
+
+    await waitFor(() => expect(api.createTemplateVersion).toHaveBeenCalled());
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' })));
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
+  });
+});

--- a/apps/web/src/components/contracts/TemplateEditor.tsx
+++ b/apps/web/src/components/contracts/TemplateEditor.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Upload } from 'lucide-react';
 import '@/lib/i18n';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
+import { strippedTagsFrom } from '../../lib/richTextWarnings';
 import { showToast } from '../shared/Toast';
 import { StatusPill } from '../billing/shared/StatusPill';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
@@ -132,8 +133,18 @@ export default function TemplateEditor({ templateId, onClose }: Props) {
       await runAction({
         request: () => createTemplateVersion(templateId, { bodyHtml: body }),
         errorFallback: t('contracts.templateEditor.saveError'),
-        successMessage: t('contracts.templateEditor.saveSuccess'),
         onUnauthorized: UNAUTHORIZED,
+        // The version saves either way, but a plain "Saved" over content the
+        // rich-text subset had to discard is exactly the silent loss #3520 is
+        // about — and this body becomes an executed legal document. Warn
+        // INSTEAD of the success toast so the removal can't be read as clean.
+        parseSuccess: (d) => {
+          const tags = strippedTagsFrom(d);
+          showToast(tags.length > 0
+            ? { type: 'warning', message: t('contracts.templateEditor.warnings.markupRemoved', { tags: tags.join(', ') }) }
+            : { type: 'success', message: t('contracts.templateEditor.saveSuccess') });
+          return d;
+        },
       });
       // Force-reseed from the server-normalized body just saved so `dirty` clears
       // even when the sanitizer canonicalized the body (entities/whitespace/attrs)

--- a/apps/web/src/lib/__tests__/richTextWarnings.test.ts
+++ b/apps/web/src/lib/__tests__/richTextWarnings.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { strippedTagsFrom } from '../richTextWarnings';
+
+// Issue #3520: block/version writes answer `{ data, warnings }` when the API's
+// rich-text subset had to discard markup. This helper is what turns that
+// envelope into the tag list the editor toasts.
+describe('strippedTagsFrom', () => {
+  const warning = (removedTags: string[], field = 'content.html') => ({
+    code: 'UNSUPPORTED_HTML_TAGS_REMOVED',
+    field,
+    removedTags,
+  });
+
+  it('returns the removed tags from a single warning', () => {
+    expect(strippedTagsFrom({ data: {}, warnings: [warning(['table', 'tr'])] })).toEqual(['table', 'tr']);
+  });
+
+  it('merges, de-duplicates and sorts tags across several fields', () => {
+    const body = {
+      data: {},
+      warnings: [
+        warning(['p', 'ul'], 'content.rows[].cells[]'),
+        warning(['h3', 'p'], 'content.columns[].label'),
+      ],
+    };
+    expect(strippedTagsFrom(body)).toEqual(['h3', 'p', 'ul']);
+  });
+
+  it('returns nothing for a clean write', () => {
+    expect(strippedTagsFrom({ data: { id: 'blk-1' }, warnings: [] })).toEqual([]);
+  });
+
+  // An older API build (or any endpoint that never opted in) answers without a
+  // `warnings` key. Callers wire this in unconditionally, so it must not throw
+  // or invent a warning.
+  it('returns nothing when the response has no warnings key at all', () => {
+    expect(strippedTagsFrom({ data: { id: 'blk-1' } })).toEqual([]);
+  });
+
+  it('returns nothing for null, non-object and malformed bodies', () => {
+    expect(strippedTagsFrom(null)).toEqual([]);
+    expect(strippedTagsFrom(undefined)).toEqual([]);
+    expect(strippedTagsFrom('nope')).toEqual([]);
+    expect(strippedTagsFrom({ warnings: 'nope' })).toEqual([]);
+    expect(strippedTagsFrom({ warnings: [null, 42, { code: 'OTHER_CODE', removedTags: ['x'] }] })).toEqual([]);
+  });
+
+  it('ignores a warning of a different code, and non-string or empty tag entries', () => {
+    const body = {
+      warnings: [
+        { code: 'SOMETHING_ELSE', field: 'x', removedTags: ['ignored'] },
+        { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.html', removedTags: ['table', '', 7, null] },
+      ],
+    };
+    expect(strippedTagsFrom(body)).toEqual(['table']);
+  });
+});

--- a/apps/web/src/lib/richTextWarnings.ts
+++ b/apps/web/src/lib/richTextWarnings.ts
@@ -1,0 +1,50 @@
+/**
+ * Client side of the rich-text loss report (issue #3520).
+ *
+ * The API's rich-text subset is narrow (11 block tags, 5 inline marks), and
+ * sanitize-html discards anything outside it. Block/version writes used to 200
+ * with the extra markup quietly gone, so an author who pasted a `<table>` or a
+ * `<blockquote>` only found out by noticing their content missing later.
+ *
+ * Those write responses now carry a top-level `warnings` array naming what was
+ * removed. This module turns that array into the tag list a toast can show;
+ * the caller owns the copy and the toast so the wording stays localized.
+ *
+ * Wire format (apps/api/src/services/richTextSanitize.ts):
+ *   { data: <resource>, warnings: [{ code, field, removedTags }] }
+ */
+
+export const RICH_TEXT_STRIP_WARNING_CODE = 'UNSUPPORTED_HTML_TAGS_REMOVED';
+
+export interface RichTextStripWarning {
+  code: string;
+  /** Dotted path of the field the tags were removed from, e.g. `content.html`. */
+  field: string;
+  removedTags: string[];
+}
+
+function isStripWarning(value: unknown): value is RichTextStripWarning {
+  if (!value || typeof value !== 'object') return false;
+  const w = value as Record<string, unknown>;
+  return w.code === RICH_TEXT_STRIP_WARNING_CODE && Array.isArray(w.removedTags);
+}
+
+/**
+ * Every distinct tag the server removed from a write, across all fields of the
+ * response, de-duplicated and sorted. Empty when nothing was lost — including
+ * for older API builds that answer without a `warnings` key at all, so a
+ * caller can wire this in unconditionally.
+ */
+export function strippedTagsFrom(body: unknown): string[] {
+  if (!body || typeof body !== 'object') return [];
+  const warnings = (body as Record<string, unknown>).warnings;
+  if (!Array.isArray(warnings)) return [];
+  const tags = new Set<string>();
+  for (const warning of warnings) {
+    if (!isStripWarning(warning)) continue;
+    for (const tag of warning.removedTags) {
+      if (typeof tag === 'string' && tag.length > 0) tags.add(tag);
+    }
+  }
+  return [...tags].sort();
+}

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -832,6 +832,9 @@
         "variantWarn": "Warnung",
         "titlePlaceholder": "Titel (optional)",
         "bodyAria": "Hinweistext"
+      },
+      "warnings": {
+        "markupRemoved": "Gespeichert, aber nicht unterstützte Formatierung wurde entfernt: {{tags}}. Rich-Text unterstützt Überschriften, Fett, Kursiv, Unterstrichen, Listen und Links."
       }
     },
     "actions": {

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -436,7 +436,10 @@
       "uploadError": "PDF konnte nicht hochgeladen werden",
       "uploadSuccess": "PDF-Version hochgeladen",
       "publishError": "Version konnte nicht veröffentlicht werden",
-      "publishSuccess": "Version veröffentlicht"
+      "publishSuccess": "Version veröffentlicht",
+      "warnings": {
+        "markupRemoved": "Gespeichert, aber nicht unterstützte Formatierung wurde entfernt: {{tags}}. Vertragstexte unterstützen Überschriften, Fett, Kursiv, Unterstrichen, Listen und Links."
+      }
     }
   },
   "quotes": {

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -436,7 +436,10 @@
       "uploadError": "Failed to upload the PDF",
       "uploadSuccess": "PDF version uploaded",
       "publishError": "Failed to publish the version",
-      "publishSuccess": "Version published"
+      "publishSuccess": "Version published",
+      "warnings": {
+        "markupRemoved": "Saved, but some unsupported formatting was removed: {{tags}}. Contract bodies support headings, bold, italic, underline, lists and links."
+      }
     }
   },
   "quotes": {

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -832,6 +832,9 @@
         "variantWarn": "Warning",
         "titlePlaceholder": "Title (optional)",
         "bodyAria": "Callout text"
+      },
+      "warnings": {
+        "markupRemoved": "Saved, but some unsupported formatting was removed: {{tags}}. Rich text supports headings, bold, italic, underline, lists and links."
       }
     },
     "actions": {

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -436,7 +436,10 @@
       "uploadError": "No se pudo subir el PDF",
       "uploadSuccess": "Versión PDF subida",
       "publishError": "No se pudo publicar la versión",
-      "publishSuccess": "Versión publicada"
+      "publishSuccess": "Versión publicada",
+      "warnings": {
+        "markupRemoved": "Se guardó, pero se eliminó formato no admitido: {{tags}}. Los cuerpos de contrato admiten títulos, negrita, cursiva, subrayado, listas y enlaces."
+      }
     }
   },
   "quotes": {

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -832,6 +832,9 @@
         "variantWarn": "Advertencia",
         "titlePlaceholder": "Título (opcional)",
         "bodyAria": "Texto del recuadro"
+      },
+      "warnings": {
+        "markupRemoved": "Se guardó, pero se eliminó formato no admitido: {{tags}}. El texto enriquecido admite títulos, negrita, cursiva, subrayado, listas y enlaces."
       }
     },
     "actions": {

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -436,7 +436,10 @@
       "uploadError": "Échec de l’import du PDF",
       "uploadSuccess": "Version PDF importée",
       "publishError": "Échec de la publication de la version",
-      "publishSuccess": "Version publiée"
+      "publishSuccess": "Version publiée",
+      "warnings": {
+        "markupRemoved": "Enregistré, mais une mise en forme non prise en charge a été supprimée : {{tags}}. Le corps des contrats prend en charge les titres, le gras, l'italique, le soulignement, les listes et les liens."
+      }
     }
   },
   "quotes": {

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -832,6 +832,9 @@
         "variantWarn": "Avertissement",
         "titlePlaceholder": "Titre (facultatif)",
         "bodyAria": "Texte de l'encadré"
+      },
+      "warnings": {
+        "markupRemoved": "Enregistré, mais une mise en forme non prise en charge a été supprimée : {{tags}}. Le texte enrichi prend en charge les titres, le gras, l'italique, le soulignement, les listes et les liens."
       }
     },
     "actions": {

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -436,7 +436,10 @@
       "uploadError": "Échec de l’import du PDF",
       "uploadSuccess": "Version PDF importée",
       "publishError": "Échec de la publication de la version",
-      "publishSuccess": "Version publiée"
+      "publishSuccess": "Version publiée",
+      "warnings": {
+        "markupRemoved": "Enregistré, mais une mise en forme non prise en charge a été supprimée : {{tags}}. Le corps des contrats prend en charge les titres, le gras, l'italique, le soulignement, les listes et les liens."
+      }
     }
   },
   "quotes": {

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -832,6 +832,9 @@
         "variantWarn": "Avertissement",
         "titlePlaceholder": "Titre (facultatif)",
         "bodyAria": "Texte de l'encadré"
+      },
+      "warnings": {
+        "markupRemoved": "Enregistré, mais une mise en forme non prise en charge a été supprimée : {{tags}}. Le texte enrichi prend en charge les titres, le gras, l'italique, le soulignement, les listes et les liens."
       }
     },
     "actions": {

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -436,7 +436,10 @@
       "uploadError": "Impossibile caricare il PDF",
       "uploadSuccess": "Versione PDF caricata",
       "publishError": "Impossibile pubblicare la versione",
-      "publishSuccess": "Versione pubblicata"
+      "publishSuccess": "Versione pubblicata",
+      "warnings": {
+        "markupRemoved": "Salvato, ma è stata rimossa una formattazione non supportata: {{tags}}. Il corpo dei contratti supporta titoli, grassetto, corsivo, sottolineato, elenchi e collegamenti."
+      }
     }
   },
   "quotes": {

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -832,6 +832,9 @@
         "variantWarn": "Avviso",
         "titlePlaceholder": "Titolo (facoltativo)",
         "bodyAria": "Testo del riquadro"
+      },
+      "warnings": {
+        "markupRemoved": "Salvato, ma è stata rimossa una formattazione non supportata: {{tags}}. Il testo formattato supporta titoli, grassetto, corsivo, sottolineato, elenchi e collegamenti."
       }
     },
     "actions": {

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -832,6 +832,9 @@
         "variantWarn": "Aviso",
         "titlePlaceholder": "Título (opcional)",
         "bodyAria": "Texto do destaque"
+      },
+      "warnings": {
+        "markupRemoved": "Salvo, mas foi removida formatação não suportada: {{tags}}. O texto formatado oferece suporte a títulos, negrito, itálico, sublinhado, listas e links."
       }
     },
     "actions": {

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -436,7 +436,10 @@
       "uploadError": "Falha ao enviar o PDF",
       "uploadSuccess": "Versão PDF enviada",
       "publishError": "Falha ao publicar a versão",
-      "publishSuccess": "Versão publicada"
+      "publishSuccess": "Versão publicada",
+      "warnings": {
+        "markupRemoved": "Salvo, mas foi removida formatação não suportada: {{tags}}. O corpo dos contratos oferece suporte a títulos, negrito, itálico, sublinhado, listas e links."
+      }
     }
   },
   "quotes": {

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -832,6 +832,9 @@
       },
       "unsavedField": {
         "lines": "Satır öğeleri"
+      },
+      "warnings": {
+        "markupRemoved": "Kaydedildi, ancak desteklenmeyen biçimlendirme kaldırıldı: {{tags}}. Zengin metin başlıkları, kalın, italik, altı çizili, listeleri ve bağlantıları destekler."
       }
     },
     "actions": {

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -436,7 +436,10 @@
       "uploadError": "PDF yüklenemedi",
       "uploadSuccess": "PDF sürümü yüklendi",
       "publishError": "Sürüm yayınlanamadı",
-      "publishSuccess": "Sürüm yayınlandı"
+      "publishSuccess": "Sürüm yayınlandı",
+      "warnings": {
+        "markupRemoved": "Kaydedildi, ancak desteklenmeyen biçimlendirme kaldırıldı: {{tags}}. Sözleşme gövdeleri başlıkları, kalın, italik, altı çizili, listeleri ve bağlantıları destekler."
+      }
     }
   },
   "quotes": {


### PR DESCRIPTION
Closes #3520

## The bug

The proposal rich-text subset allows 11 block tags (`p br strong em u h3 h4 ul ol li a`), and 5 inline marks in table cells. `sanitize-html` discards everything else by design. The write path accepted the input, sanitized it, persisted the reduced HTML, and answered a clean **200**.

So an author who pasted a `<table>`, `<blockquote>` or `<h1>` was told "saved" and only discovered the loss later by noticing their content was missing. For a `<table>`, the entire tabular structure vanished.

## The fix — fix the silence, not the subset

Writes now report what they removed.

**`richTextSanitize.ts`** gains reporting variants — `sanitizeRichTextHtmlWithReport`, `sanitizeInlineRichTextWithReport`, `sanitizePlainTextWithReport` — that produce **byte-identical HTML** plus the set of tags the profile discarded (a test asserts the byte-identity across both variants).

Detection uses `sanitize-html`'s public **`onOpenTag`** observer, which fires on the *source* tag before `transformTags` and before the `allowedTags` filter — so it sees discarded tags. The collector `Set` is created per call; module-level options (shared with the read/render paths) are never mutated. No wildcard `transformTags` (that would couple production sanitisation to transform ordering) and no second parse.

**Wire format.** Quote block writes (`rich_text` / `table` / `callout`) and authored contract template versions now answer:

```jsonc
{
  "data": { "id": "blk-1", "...": "..." },
  "warnings": [
    { "code": "UNSUPPORTED_HTML_TAGS_REMOVED", "field": "content.html", "removedTags": ["blockquote", "table", "td", "tr"] }
  ]
}
```

`warnings` is **always present** (usually empty) and lives beside `data`, never inside it. A table block's 48 lossy cells collapse into **one** warning per field family (`content.rows[].cells[]`) rather than 48 copies.

**Web.** `QuoteEditor` toasts a non-blocking warning naming the dropped tags on every block add/update. New `apps/web/src/lib/richTextWarnings.ts` (`strippedTagsFrom`) parses the envelope defensively — an API build with no `warnings` key returns `[]` rather than throwing, so it can be wired in unconditionally. i18n key added to all 8 locales.

**Observability.** A write-boundary `console.warn` carries the quote/block/version ids and the tag names — never raw HTML, and not inside the sanitizer, where the read and PDF-render paths would emit the same line on every page view.

## Design notes — what was deliberately NOT done

**No 422.** The issue floated rejecting as the safer default; a quorum (me + an independent Codex read) landed on warn-and-accept instead:

1. The **same sanitizer runs on the READ path and the template-render path** as defense in depth, so rejection could only ever cover a subset of call sites.
2. Real-world paste (Word, Google Docs, external proposals) is full of benign `div`/`span`/`font`/`meta`/`o:p` noise where dropping the tag costs **no author content**. A blanket 422 would make paste unusable and would be a hard behavioural regression for existing API clients and bulk template imports.
3. A "reject only on content-bearing structural tags, warn on the rest" hybrid was considered and rejected as an unprincipled allowlist — `h1` keeps its text, `table` loses structure, `img` loses media, `pre` loses whitespace semantics; the line isn't drawable.
4. The defect in the title is the **silence**, not the strip.

**Only TAG removal is reported.** Stripped attributes (`style`, `class`) and rejected `href` schemes (`javascript:`, protocol-relative) are not — nothing is lost in those cases, and flagging them would make every Word paste look alarming. Covered by an explicit test.

**The READ path stays silent.** A legacy row must render, not warn.

## Out of scope

Sibling issue #3484 (widen the allowlist so `<table>` actually survives) is deliberately **not** in this PR — that needs editor, browser-render *and* PDF-render support landing together. What this PR gives it: `#3484`'s users now at least get told the table was dropped, and `RICH_TEXT_ALLOWED_TAGS` remains the single place the three renderers agree on.

## Verification

- `apps/api`: 283 passed across `richTextSanitize`, `quoteService`, `contractTemplateService`, `aiToolsQuotes`, `routes/quotes/`, `routes/contracts/` (single-fork).
- `apps/web`: 447 passed across `components/billing/quotes/` + the new `richTextWarnings` unit test; i18n `localeParity` / `translationCoverage` / `terminologyQuality` / `extractionQuality` + `no-silent-mutations` green (182 passed).
- `tsc --noEmit` clean in both `apps/api` and `apps/web`.
- The new `QuoteEditor.strippedmarkup.test.tsx` was mutation-checked: commenting out the `notifyStrippedMarkup` calls turns it red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)