### PR TITLE
fix(api): retire inert maintenance-window notify fields (#3256)

### DIFF
--- a/apps/api/src/db/schema/maintenance.ts
+++ b/apps/api/src/db/schema/maintenance.ts
@@ -56,6 +56,16 @@ export const maintenanceWindows = pgTable('maintenance_windows', {
   allowedAlertSeverities: alertSeverityEnum('allowed_alert_severities').array(),
   allowedActions: jsonb('allowed_actions'),
   status: maintenanceWindowStatusEnum('status').notNull().default('scheduled'),
+  // DEPRECATED — inert (#3256). Nothing has ever read these four columns: no
+  // worker, scheduler, or agent command consumes them, so a window that claimed
+  // to "notify before 30 minutes" notified nobody. As of #3256 the API no longer
+  // accepts or writes them; the columns are RETAINED on purpose rather than
+  // dropped, because `maintenance_windows` is hand-enumerated column-by-column in
+  // CORE_TENANT_EXPORT_POLICY (services/tenantExportPolicyRegistry.ts) and
+  // dropping them would shift existing partner canonical-export watermarks — the
+  // same reasoning that kept the config-policy twins in #3197.
+  // Do not read these for new behavior. A real notification consumer (#3207)
+  // should introduce its own validated fields rather than resurrect these.
   notifyBefore: integer('notify_before'),
   notifyOnStart: boolean('notify_on_start').notNull().default(false),
   notifyOnEnd: boolean('notify_on_end').notNull().default(false),

--- a/apps/api/src/routes/maintenance.test.ts
+++ b/apps/api/src/routes/maintenance.test.ts
@@ -228,6 +228,96 @@ describe('maintenance routes', () => {
     expect(body.name).toBe('New Name');
   });
 
+  // Regression guard for #3256: `notifyBefore` / `notifyOnStart` / `notifyOnEnd`
+  // were accepted and persisted but never read by anything, so a window promised
+  // notifications it never sent. They are off the write surface now. These tests
+  // fail if the fields are wired back into the request schemas without a real
+  // consumer landing first.
+  describe('retired notification fields (#3256)', () => {
+    it('should not persist notifyBefore/notifyOnStart/notifyOnEnd on create', async () => {
+      const occurrencesValues = vi.fn().mockResolvedValue(undefined);
+      const windowValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'win-1', orgId: 'org-123', name: 'W', status: 'scheduled' }])
+      });
+      vi.mocked(db.insert)
+        .mockReturnValueOnce({ values: windowValues } as any)
+        .mockReturnValueOnce({ values: occurrencesValues } as any);
+
+      const res = await app.request('/maintenance/windows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({
+          name: 'W',
+          startTime: '2024-01-01T10:00:00.000Z',
+          endTime: '2024-01-01T12:00:00.000Z',
+          timezone: 'UTC',
+          recurrence: 'once',
+          targetType: 'all',
+          notifyBefore: 30,
+          notifyOnStart: true,
+          notifyOnEnd: true
+        })
+      });
+
+      // Still a 201: the keys are stripped, not rejected, so existing clients
+      // that send them keep working.
+      expect(res.status).toBe(201);
+
+      const insertCall = windowValues.mock.calls[0];
+      if (!insertCall) throw new Error('Expected window insert call');
+      const inserted = insertCall[0] as Record<string, unknown>;
+      expect(inserted).not.toHaveProperty('notifyBefore');
+      expect(inserted).not.toHaveProperty('notifyOnStart');
+      expect(inserted).not.toHaveProperty('notifyOnEnd');
+      // The rest of the payload is untouched.
+      expect(inserted).toMatchObject({ orgId: 'org-123', name: 'W' });
+    });
+
+    it('should not write notifyBefore/notifyOnStart/notifyOnEnd on update', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: 'win-1', orgId: 'org-123', name: 'Old Name' }])
+          })
+        })
+      } as any);
+      const setSpy = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: 'win-1', name: 'New Name' }])
+        })
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setSpy } as any);
+
+      const res = await app.request('/maintenance/windows/win-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ name: 'New Name', notifyBefore: 30, notifyOnStart: true, notifyOnEnd: true })
+      });
+
+      expect(res.status).toBe(200);
+      const setCall = setSpy.mock.calls[0];
+      if (!setCall) throw new Error('Expected update set call');
+      const updated = setCall[0] as Record<string, unknown>;
+      expect(updated).not.toHaveProperty('notifyBefore');
+      expect(updated).not.toHaveProperty('notifyOnStart');
+      expect(updated).not.toHaveProperty('notifyOnEnd');
+      expect(updated).toMatchObject({ name: 'New Name' });
+    });
+
+    it('should reject an update that carries only retired notification fields', async () => {
+      const res = await app.request('/maintenance/windows/win-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ notifyBefore: 30, notifyOnStart: true })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('No updates provided');
+      expect(db.update).not.toHaveBeenCalled();
+    });
+  });
+
   it('should delete a maintenance window and future occurrences', async () => {
     vi.mocked(db.select).mockReturnValue({
       from: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/maintenance.ts
+++ b/apps/api/src/routes/maintenance.ts
@@ -123,10 +123,14 @@ const createWindowSchema = z.object({
   deviceIds: z.array(z.string().guid()).optional(),
   suppressAlerts: z.boolean().default(true),
   suppressPatches: z.boolean().default(true),
-  suppressAutomations: z.boolean().default(false),
-  notifyBefore: z.number().int().positive().optional(),
-  notifyOnStart: z.boolean().default(false),
-  notifyOnEnd: z.boolean().default(false)
+  suppressAutomations: z.boolean().default(false)
+  // RETIRED (#3256): `notifyBefore` / `notifyOnStart` / `notifyOnEnd` were
+  // accepted and persisted here but no worker, scheduler, or agent command ever
+  // read them — an admin setting "notify before: 30 minutes" got nothing, with
+  // no indication the setting was inert. They stay off the write surface until a
+  // real maintenance-window notification consumer exists (#3207). This object is
+  // non-strict, so clients still sending the keys get them stripped (200, not
+  // 400) rather than a hard break.
 }).refine((data) => {
   const start = new Date(data.startTime);
   const end = new Date(data.endTime);
@@ -147,10 +151,11 @@ const updateWindowSchema = z.object({
   deviceIds: z.array(z.string().guid()).optional(),
   suppressAlerts: z.boolean().optional(),
   suppressPatches: z.boolean().optional(),
-  suppressAutomations: z.boolean().optional(),
-  notifyBefore: z.number().int().positive().optional(),
-  notifyOnStart: z.boolean().optional(),
-  notifyOnEnd: z.boolean().optional()
+  suppressAutomations: z.boolean().optional()
+  // RETIRED (#3256) — see createWindowSchema. A PATCH carrying only the retired
+  // notification keys now strips to an empty update and returns the existing
+  // "No updates provided" 400, which is the honest answer: there is nothing
+  // those keys can change.
 });
 
 const listWindowsSchema = z.object({
@@ -409,9 +414,9 @@ maintenanceRoutes.post(
         suppressAlerts: body.suppressAlerts,
         suppressPatching: body.suppressPatches,
         suppressAutomations: body.suppressAutomations,
-        notifyBefore: body.notifyBefore,
-        notifyOnStart: body.notifyOnStart,
-        notifyOnEnd: body.notifyOnEnd,
+        // notifyBefore / notifyOnStart / notifyOnEnd deliberately not written
+        // (#3256) — the columns keep their DB defaults (NULL / false / false),
+        // which is what the old code stored anyway.
         createdBy: auth.user.id
       })
       .returning();
@@ -540,9 +545,7 @@ maintenanceRoutes.patch(
     if (updates.suppressAlerts !== undefined) updateData.suppressAlerts = updates.suppressAlerts;
     if (updates.suppressPatches !== undefined) updateData.suppressPatching = updates.suppressPatches;
     if (updates.suppressAutomations !== undefined) updateData.suppressAutomations = updates.suppressAutomations;
-    if (updates.notifyBefore !== undefined) updateData.notifyBefore = updates.notifyBefore;
-    if (updates.notifyOnStart !== undefined) updateData.notifyOnStart = updates.notifyOnStart;
-    if (updates.notifyOnEnd !== undefined) updateData.notifyOnEnd = updates.notifyOnEnd;
+    // notifyBefore / notifyOnStart / notifyOnEnd retired from the write surface (#3256).
 
     const [updated] = await db
       .update(maintenanceWindows)

--- a/apps/docs/src/content/docs/features/maintenance-windows.mdx
+++ b/apps/docs/src/content/docs/features/maintenance-windows.mdx
@@ -102,9 +102,7 @@ The standalone maintenance window routes (`POST /maintenance/windows`, `PATCH /m
 
 3. **Configure suppression.** Set `suppressAlerts`, `suppressPatches`, and `suppressAutomations` to control which actions are paused.
 
-4. **Set notifications.** Optionally set `notifyBefore` (minutes before start), `notifyOnStart`, and `notifyOnEnd`.
-
-5. **Submit the request.** POST to `/maintenance/windows`. The system creates the window and auto-generates up to 10 upcoming occurrences based on the recurrence rule.
+4. **Submit the request.** POST to `/maintenance/windows`. The system creates the window and auto-generates up to 10 upcoming occurrences based on the recurrence rule.
 </Steps>
 
 ```bash
@@ -125,14 +123,15 @@ POST /maintenance/windows
   "siteIds": ["site-uuid-1", "site-uuid-2"],
   "suppressAlerts": true,
   "suppressPatches": true,
-  "suppressAutomations": false,
-  "notifyBefore": 30,
-  "notifyOnStart": true,
-  "notifyOnEnd": true
+  "suppressAutomations": false
 }
 ```
 
 The response returns the created window object with a `201` status code.
+
+<Aside type="note">
+The standalone routes previously accepted `notifyBefore`, `notifyOnStart`, and `notifyOnEnd`. Nothing ever consumed them -- no notification was sent -- so they were removed from the request schema. Sending them is harmless (they are ignored), but they no longer appear in the documented surface. End-user notification for maintenance windows is tracked separately.
+</Aside>
 
 ### Partner-wide Windows (All organizations)
 


### PR DESCRIPTION
Closes #3256

## Problem

`maintenance_windows.notify_before` / `notify_on_start` / `notify_on_end` were validated, accepted, and persisted by `POST`/`PATCH /maintenance/windows` — and read by nothing. No worker, scheduler, or agent command consumed them. An admin who set "notify before: 30 minutes" got no notification and no indication the setting was inert.

Confirmed by a repo-wide sweep: the only read anywhere is `apps/api/src/scripts/migrateToConfigPolicies.ts`, a one-time backfill script that copies legacy values into the config-policy table. `maintenanceService.ts` never touches them.

## Which path, and why

The issue offered two: **wire them up** or **retire them**. Wiring them up means building a maintenance-window notification consumer — that is #3207's scope, and per the issue it needs a validator to land first. This PR takes the **conservative** path: retire them from the API surface so they stop reading as implemented, leaving #3207 free to introduce its own validated fields.

## Changes

- **`apps/api/src/routes/maintenance.ts`** — the three fields are removed from `createWindowSchema` / `updateWindowSchema` and from the insert/update payload builders.
- **`apps/api/src/db/schema/maintenance.ts`** — deprecation comment on the columns.
- **`apps/docs/.../maintenance-windows.mdx`** — removed from the legacy standalone-API example + a note explaining they are ignored. (The `config_policy_maintenance_settings` table earlier on the same page is untouched — different table, #3197.)
- **`apps/api/src/routes/maintenance.test.ts`** — regression guards.

## Why this is not a breaking change

- The zod objects are non-strict, so a client still sending the keys gets them **stripped — 200, not 400**. Existing tests in this file that send `notifyOnStart` still pass unchanged, which is the evidence.
- **Stored values are unchanged.** The create path previously wrote exactly what the column defaults produce (`NULL` / `false` / `false`).
- **Read shape is unchanged.** Responses are raw row selects; legacy rows keep whatever they stored. Only the write surface moved.
- One intentional behavior change: a `PATCH` carrying *only* retired keys now strips to an empty update and hits the existing `"No updates provided"` 400. That is the honest answer — there is nothing those keys can change.

## Columns retained on purpose

Not dropped, and no migration. `maintenance_windows` is hand-enumerated column-by-column in `CORE_TENANT_EXPORT_POLICY` (`services/tenantExportPolicyRegistry.ts:200`), so dropping them would shift existing partner canonical-export watermarks — the same reasoning that kept the config-policy twins in #3197. No schema change means no export-policy, cascade, or RLS registration churn.

## Verification

- `vitest run src/routes/maintenance.test.ts` (single worker): **16 passed, 1 skipped** (the skip is pre-existing).
- **Mutation-tested**: re-adding `notifyBefore` to the insert values and `notifyOnStart` to `updateData` reddens exactly the two new guards (2 failed / 14 passed). They are not vacuous.
- `tsc --noEmit` on `apps/api`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)