### PR TITLE
fix(agent): uninstall reported success without removing anything (#3592)

### DIFF
--- a/agent/internal/collectors/software_windows.go
+++ b/agent/internal/collectors/software_windows.go
@@ -28,11 +28,18 @@ var softwareRegistryPaths = []struct {
 func (c *SoftwareCollector) Collect() ([]SoftwareItem, error) {
 	var software []SoftwareItem
 	seen := make(map[string]bool)
+	var pathErrs []string
 
 	for _, regPath := range softwareRegistryPaths {
 		items, err := collectFromRegistry(regPath.root, regPath.path)
 		if err != nil {
-			// Continue on error - some paths may not exist or be accessible
+			// Continue on error - some paths may not exist or be accessible.
+			// A single unreadable hive is normal (WOW6432Node is absent on
+			// 32-bit Windows; HKCU under the SYSTEM service is the SYSTEM
+			// profile), so it must not fail the whole collection — but record
+			// it so a total failure below can be distinguished from a genuinely
+			// empty machine.
+			pathErrs = append(pathErrs, fmt.Sprintf("%s: %v", regPath.path, err))
 			continue
 		}
 
@@ -44,6 +51,15 @@ func (c *SoftwareCollector) Collect() ([]SoftwareItem, error) {
 				software = append(software, item)
 			}
 		}
+	}
+
+	// Every registry path failed: this is "we could not look", not "nothing is
+	// installed". Returning (nil, nil) here would let callers that treat an
+	// empty list as ground truth — notably the uninstall post-condition check in
+	// remote/tools — conclude that software is absent without ever having read
+	// the registry (#3592).
+	if len(pathErrs) == len(softwareRegistryPaths) {
+		return nil, fmt.Errorf("no installed-software registry path could be read: %s", strings.Join(pathErrs, "; "))
 	}
 
 	return software, nil

--- a/agent/internal/collectors/software_windows.go
+++ b/agent/internal/collectors/software_windows.go
@@ -70,6 +70,13 @@ func collectFromRegistry(rootKey registry.Key, path string) ([]SoftwareItem, err
 		}
 
 		item := readSoftwareFromKey(subkey)
+		// Both reads must happen BEFORE the handle is closed. isSystemComponent
+		// used to be called on the already-closed `subkey`, where every registry
+		// read fails and the function therefore always answered false — so the
+		// SystemComponent=1 / "Update for …" filter below has never actually
+		// filtered anything, and Windows Update and system-component entries have
+		// been reported as ordinary installed software all along (#3592).
+		systemComponent := isSystemComponent(subkey, item.Name)
 		subkey.Close()
 
 		// Skip items without a display name or system components
@@ -78,7 +85,7 @@ func collectFromRegistry(rootKey registry.Key, path string) ([]SoftwareItem, err
 		}
 
 		// Skip Windows updates and system components
-		if isSystemComponent(subkey) {
+		if systemComponent {
 			continue
 		}
 
@@ -160,7 +167,11 @@ func parseInstallDate(dateStr string) string {
 	return ""
 }
 
-func isSystemComponent(key registry.Key) bool {
+// isSystemComponent reports whether an Uninstall subkey describes a system
+// component or a Windows Update rather than user-facing installed software.
+// `key` must still be open; `displayName` is passed in because the caller has
+// already read it.
+func isSystemComponent(key registry.Key, displayName string) bool {
 	// Check SystemComponent flag
 	val, _, err := key.GetIntegerValue("SystemComponent")
 	if err == nil && val == 1 {
@@ -168,7 +179,7 @@ func isSystemComponent(key registry.Key) bool {
 	}
 
 	// Check for Windows Update entries
-	name, _ := readStringValue(key, "DisplayName")
+	name := displayName
 	if strings.HasPrefix(name, "Update for") ||
 		strings.HasPrefix(name, "Security Update for") ||
 		strings.HasPrefix(name, "Hotfix for") {

--- a/agent/internal/heartbeat/handlers.go
+++ b/agent/internal/heartbeat/handlers.go
@@ -329,6 +329,11 @@ func handleCollectSoftware(_ *Heartbeat, cmd Command) tools.CommandResult {
 	return tools.NewSuccessResult(software, time.Since(start).Milliseconds())
 }
 
+// uninstallSoftware is indirected so the re-report gating in
+// handleSoftwareUninstall can be tested on both a successful and a failed
+// uninstall without running a real package manager.
+var uninstallSoftware = tools.UninstallSoftware
+
 // handleSoftwareUninstall removes software and, on success, immediately
 // re-reports software inventory.
 //
@@ -343,7 +348,7 @@ func handleCollectSoftware(_ *Heartbeat, cmd Command) tools.CommandResult {
 // re-report is idempotent anyway — the API replaces the device's whole software
 // list per report — so the worst case is a redundant PUT.
 func handleSoftwareUninstall(h *Heartbeat, cmd Command) tools.CommandResult {
-	result := tools.UninstallSoftware(cmd.Payload)
+	result := uninstallSoftware(cmd.Payload)
 	if result.Status == "completed" && h != nil {
 		if h.sendSoftwareInventoryFn != nil {
 			h.sendSoftwareInventoryFn()

--- a/agent/internal/heartbeat/handlers.go
+++ b/agent/internal/heartbeat/handlers.go
@@ -329,8 +329,21 @@ func handleCollectSoftware(_ *Heartbeat, cmd Command) tools.CommandResult {
 	return tools.NewSuccessResult(software, time.Since(start).Milliseconds())
 }
 
-func handleSoftwareUninstall(_ *Heartbeat, cmd Command) tools.CommandResult {
-	return tools.UninstallSoftware(cmd.Payload)
+// handleSoftwareUninstall removes software and, on success, immediately
+// re-reports software inventory.
+//
+// Without the re-report the dashboard keeps showing the uninstalled program for
+// up to 15 minutes (the sendInventory cadence), which is indistinguishable from
+// the genuine "uninstall silently did nothing" bug also fixed in #3592. The
+// re-report is safe to fire straight away because tools.UninstallSoftware now
+// verifies the software is actually gone from the collector before returning
+// success, so this cannot race an uninstaller that is still running.
+func handleSoftwareUninstall(h *Heartbeat, cmd Command) tools.CommandResult {
+	result := tools.UninstallSoftware(cmd.Payload)
+	if result.Status == "completed" && h != nil {
+		go h.sendSoftwareInventory()
+	}
+	return result
 }
 
 func handleSoftwareUpdate(_ *Heartbeat, cmd Command) tools.CommandResult {

--- a/agent/internal/heartbeat/handlers.go
+++ b/agent/internal/heartbeat/handlers.go
@@ -333,15 +333,23 @@ func handleCollectSoftware(_ *Heartbeat, cmd Command) tools.CommandResult {
 // re-reports software inventory.
 //
 // Without the re-report the dashboard keeps showing the uninstalled program for
-// up to 15 minutes (the sendInventory cadence), which is indistinguishable from
-// the genuine "uninstall silently did nothing" bug also fixed in #3592. The
-// re-report is safe to fire straight away because tools.UninstallSoftware now
-// verifies the software is actually gone from the collector before returning
-// success, so this cannot race an uninstaller that is still running.
+// up to 15 minutes (the sendInventory cadence), which is operationally
+// indistinguishable from the "uninstall silently did nothing" bug also fixed in
+// #3592.
+//
+// Firing immediately does not race a still-running uninstaller: every path in
+// tools.UninstallSoftware is synchronous, and the provider paths additionally
+// confirm the software is gone from the collector before reporting success. A
+// re-report is idempotent anyway — the API replaces the device's whole software
+// list per report — so the worst case is a redundant PUT.
 func handleSoftwareUninstall(h *Heartbeat, cmd Command) tools.CommandResult {
 	result := tools.UninstallSoftware(cmd.Payload)
 	if result.Status == "completed" && h != nil {
-		go h.sendSoftwareInventory()
+		if h.sendSoftwareInventoryFn != nil {
+			h.sendSoftwareInventoryFn()
+		} else {
+			go h.sendSoftwareInventory()
+		}
 	}
 	return result
 }

--- a/agent/internal/heartbeat/handlers_software_uninstall_test.go
+++ b/agent/internal/heartbeat/handlers_software_uninstall_test.go
@@ -1,41 +1,45 @@
 package heartbeat
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+)
 
 // The post-uninstall re-report exists so the dashboard stops showing software
-// that is genuinely gone (#3592). It must fire only when the uninstall actually
-// succeeded — re-reporting after a FAILED uninstall would be harmless but
-// pointless, and firing unconditionally would mask the gating logic entirely.
+// that is genuinely gone (#3592). It must fire on a completed uninstall and NOT
+// on a failed one — a failed uninstall means the software is still there, and
+// re-reporting would just re-assert it.
 func TestHandleSoftwareUninstallReReportsOnlyOnSuccess(t *testing.T) {
 	cases := []struct {
 		name      string
-		payload   map[string]any
+		result    tools.CommandResult
 		wantFired bool
 	}{
 		{
-			// An invalid name fails validation before any provider runs, so the
-			// result is "failed" without touching the endpoint.
-			name:      "failed uninstall does not re-report",
-			payload:   map[string]any{"name": ""},
-			wantFired: false,
+			name:      "completed uninstall re-reports",
+			result:    tools.NewSuccessResult(map[string]any{"action": "uninstall"}, 1),
+			wantFired: true,
 		},
 		{
-			name:      "rejected unsafe name does not re-report",
-			payload:   map[string]any{"name": "../../etc/passwd"},
+			name:      "failed uninstall does not re-report",
+			result:    tools.NewErrorResult(fmt.Errorf("still present in inventory"), 1),
 			wantFired: false,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			orig := uninstallSoftware
+			t.Cleanup(func() { uninstallSoftware = orig })
+			uninstallSoftware = func(map[string]any) tools.CommandResult { return tc.result }
+
 			fired := false
 			h := &Heartbeat{sendSoftwareInventoryFn: func() { fired = true }}
 
-			result := handleSoftwareUninstall(h, Command{Payload: tc.payload})
+			handleSoftwareUninstall(h, Command{Payload: map[string]any{"name": "Some App"}})
 
-			if result.Status == "completed" {
-				t.Fatalf("expected this payload to fail validation, got status %q", result.Status)
-			}
 			if fired != tc.wantFired {
 				t.Errorf("re-report fired = %v, want %v", fired, tc.wantFired)
 			}
@@ -46,8 +50,14 @@ func TestHandleSoftwareUninstallReReportsOnlyOnSuccess(t *testing.T) {
 // A nil Heartbeat must not panic — handlers are invoked from the command
 // dispatch path and this one now dereferences h.
 func TestHandleSoftwareUninstallNilHeartbeatDoesNotPanic(t *testing.T) {
-	result := handleSoftwareUninstall(nil, Command{Payload: map[string]any{"name": ""}})
-	if result.Status != "failed" {
-		t.Errorf("Status = %q, want failed", result.Status)
+	orig := uninstallSoftware
+	t.Cleanup(func() { uninstallSoftware = orig })
+	uninstallSoftware = func(map[string]any) tools.CommandResult {
+		return tools.NewSuccessResult(map[string]any{"action": "uninstall"}, 1)
+	}
+
+	result := handleSoftwareUninstall(nil, Command{Payload: map[string]any{"name": "Some App"}})
+	if result.Status != "completed" {
+		t.Errorf("Status = %q, want completed", result.Status)
 	}
 }

--- a/agent/internal/heartbeat/handlers_software_uninstall_test.go
+++ b/agent/internal/heartbeat/handlers_software_uninstall_test.go
@@ -1,0 +1,53 @@
+package heartbeat
+
+import "testing"
+
+// The post-uninstall re-report exists so the dashboard stops showing software
+// that is genuinely gone (#3592). It must fire only when the uninstall actually
+// succeeded — re-reporting after a FAILED uninstall would be harmless but
+// pointless, and firing unconditionally would mask the gating logic entirely.
+func TestHandleSoftwareUninstallReReportsOnlyOnSuccess(t *testing.T) {
+	cases := []struct {
+		name      string
+		payload   map[string]any
+		wantFired bool
+	}{
+		{
+			// An invalid name fails validation before any provider runs, so the
+			// result is "failed" without touching the endpoint.
+			name:      "failed uninstall does not re-report",
+			payload:   map[string]any{"name": ""},
+			wantFired: false,
+		},
+		{
+			name:      "rejected unsafe name does not re-report",
+			payload:   map[string]any{"name": "../../etc/passwd"},
+			wantFired: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fired := false
+			h := &Heartbeat{sendSoftwareInventoryFn: func() { fired = true }}
+
+			result := handleSoftwareUninstall(h, Command{Payload: tc.payload})
+
+			if result.Status == "completed" {
+				t.Fatalf("expected this payload to fail validation, got status %q", result.Status)
+			}
+			if fired != tc.wantFired {
+				t.Errorf("re-report fired = %v, want %v", fired, tc.wantFired)
+			}
+		})
+	}
+}
+
+// A nil Heartbeat must not panic — handlers are invoked from the command
+// dispatch path and this one now dereferences h.
+func TestHandleSoftwareUninstallNilHeartbeatDoesNotPanic(t *testing.T) {
+	result := handleSoftwareUninstall(nil, Command{Payload: map[string]any{"name": ""}})
+	if result.Status != "failed" {
+		t.Errorf("Status = %q, want failed", result.Status)
+	}
+}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -556,6 +556,12 @@ type Heartbeat struct {
 	// production — the real sendInventory method is invoked.
 	sendInventoryFn func()
 
+	// sendSoftwareInventoryFn is an optional override used by tests to replace
+	// the post-uninstall software re-report inside handleSoftwareUninstall. nil
+	// in production — the real sendSoftwareInventory method runs in its own
+	// goroutine.
+	sendSoftwareInventoryFn func()
+
 	// userHelperDownloader is an optional test seam: when non-nil,
 	// prefetchUserHelper calls this instead of constructing a real
 	// updater.Updater and invoking DownloadBinary. nil in production.

--- a/agent/internal/remote/tools/software.go
+++ b/agent/internal/remote/tools/software.go
@@ -308,6 +308,9 @@ var providerNotFoundMarkers = []string{
 	"no installed package",
 	"unknown package",
 	"not found",
+	// wmic's no-match message. It is emitted with EXIT CODE 0, which is why the
+	// marker check runs on the success path too.
+	"no instance(s) available",
 }
 
 func providerReportedNotFound(lowerOutput string) bool {
@@ -370,7 +373,13 @@ func runUninstallAttempts(softwareName string, attempts []uninstallAttempt) erro
 		sanitizedOutput, outputTruncated := sanitizeUninstallOutput(string(output))
 		lowerOutput := strings.ToLower(sanitizedOutput)
 
-		if err == nil {
+		// A zero exit code is not automatically a removal claim.
+		// `wmic product where name='X' call uninstall` exits 0 and prints
+		// "No Instance(s) Available." when the WHERE clause matches nothing, so
+		// the no-match markers are checked here as well as on the failure path.
+		// Otherwise that lie becomes the one signal still trusted when the
+		// post-condition check is unavailable.
+		if err == nil && !providerReportedNotFound(lowerOutput) {
 			providerClaimedRemoval = true
 			break
 		}
@@ -396,15 +405,30 @@ func runUninstallAttempts(softwareName string, attempts []uninstallAttempt) erro
 		joined += " [error summary truncated]"
 	}
 
+	// Verification may only DOWNGRADE an unproven success to a failure. It must
+	// never upgrade a hard provider error into a success, because "absent from
+	// the inventory collector" is not always "absent from the device": the name
+	// handed to an uninstall command does not always appear verbatim in the
+	// collector's output (a brew cask token is "google-chrome" while
+	// system_profiler reports "Google Chrome"). Letting a name the collector
+	// simply cannot see convert a real apt/brew/msiexec failure into `nil` would
+	// re-create the exact silent success this change exists to remove.
+	if len(errors) > 0 && !providerClaimedRemoval {
+		return fmt.Errorf("failed to uninstall %q after %d attempt(s): %s", softwareName, attempted, joined)
+	}
+
 	stillPresent, verifyErr := uninstallVerifyStillPresent(softwareName)
 	if verifyErr != nil {
-		// Cannot verify. Do not invent a verdict — fall back to the provider
-		// signals, which is the pre-#3592 behavior, minus the wmic exit-0 hole
-		// (a provider exiting 0 is at least evidence it ran).
-		if providerClaimedRemoval || providerNotFoundCount > 0 {
+		// We could not look. A provider that actually exited 0 is still real
+		// evidence something ran, so honour it. "No provider could even see the
+		// package" is NOT evidence — accepting it here would restore the #3592
+		// silent success behind a transient collector failure, which on macOS is
+		// entirely reachable (a system_profiler hiccup during an uninstall of
+		// software Homebrew does not manage).
+		if providerClaimedRemoval {
 			return nil
 		}
-		return fmt.Errorf("failed to uninstall %q after %d attempt(s): %s", softwareName, attempted, joined)
+		return fmt.Errorf("could not confirm %q was removed: no provider reported removing it (%d of %d attempted providers reported it as unknown) and this device's software inventory could not be read: %v", softwareName, providerNotFoundCount, attempted, verifyErr)
 	}
 
 	if !stillPresent {
@@ -413,12 +437,8 @@ func runUninstallAttempts(softwareName string, attempts []uninstallAttempt) erro
 
 	// Verified still installed — every "success" below this line would have been
 	// a lie.
-	switch {
-	case len(errors) > 0:
-		return fmt.Errorf("failed to uninstall %q after %d attempt(s); it is still present in this device's software inventory: %s", softwareName, attempted, joined)
-	case providerClaimedRemoval:
+	if providerClaimedRemoval {
 		return fmt.Errorf("uninstall command for %q reported success but it is still present in this device's software inventory (the uninstaller may have been silently blocked, or may require a reboot to finish)", softwareName)
-	default:
-		return fmt.Errorf("no uninstall provider on this endpoint could locate %q (%d of %d attempted providers reported it as unknown), and it is still present in this device's software inventory", softwareName, providerNotFoundCount, attempted)
 	}
+	return fmt.Errorf("no uninstall provider on this endpoint could locate %q (%d of %d attempted providers reported it as unknown), and it is still present in this device's software inventory", softwareName, providerNotFoundCount, attempted)
 }

--- a/agent/internal/remote/tools/software.go
+++ b/agent/internal/remote/tools/software.go
@@ -295,34 +295,89 @@ func uninstallSoftwareLinux(name string) error {
 	return runUninstallAttempts(name, attempts)
 }
 
+// providerNotFoundMarkers are the phrases an uninstall provider emits when it
+// has no record of the requested package. They mean "*this tool* cannot see it"
+// — NOT "the package is absent from the device". winget in particular indexes
+// only a subset of Add/Remove Programs, and under the SYSTEM service account it
+// cannot see per-user installs at all, so it answers
+// "No installed package found matching input criteria." for plenty of software
+// that is very much installed (#3592).
+var providerNotFoundMarkers = []string{
+	"not installed",
+	"no package",
+	"no installed package",
+	"unknown package",
+	"not found",
+}
+
+func providerReportedNotFound(lowerOutput string) bool {
+	for _, marker := range providerNotFoundMarkers {
+		if strings.Contains(lowerOutput, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// Seams for tests. uninstallVerifyStillPresent is the post-condition check; see
+// software_uninstall_verify.go.
+var (
+	uninstallLookPath   = exec.LookPath
+	runUninstallCommand = func(attempt uninstallAttempt) ([]byte, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+		return exec.CommandContext(ctx, attempt.command, attempt.args...).CombinedOutput()
+	}
+	uninstallVerifyStillPresent = softwareStillInstalled
+)
+
+// runUninstallAttempts walks the platform's uninstall providers in order and
+// then VERIFIES the post-condition before reporting success.
+//
+// The verification is the point of this function, not a belt-and-braces extra.
+// Before #3592 two separate paths returned nil without any evidence of removal:
+//
+//  1. `err == nil` from the provider. `wmic product where name='X' call
+//     uninstall` exits 0 even when the WHERE clause matches nothing, so the
+//     fallback attempt reported success unconditionally.
+//  2. A provider "not found" message short-circuited the whole operation as
+//     "already absent". Because winget is the FIRST attempt on Windows, any
+//     software winget does not index made Breeze answer
+//     `{"action":"uninstall","success":true}` with exit code 0 while never
+//     running the wmic fallback and never touching the machine.
+//
+// Both produced a device_commands row that says the uninstall succeeded, after
+// which the next genuinely-fresh inventory scan legitimately re-reports the
+// software — the "stale entry survives a fresh scan" symptom in #3592.
+//
+// A provider that cannot see the package no longer ends the operation; it falls
+// through to the next provider, and the inventory re-check below decides the
+// outcome. Verification failing (collector error) is not treated as proof of
+// either state — we fall back to the provider signals in that case.
 func runUninstallAttempts(softwareName string, attempts []uninstallAttempt) error {
 	errors := make([]string, 0, len(attempts))
 	attempted := 0
+	providerClaimedRemoval := false
+	providerNotFoundCount := 0
 
 	for _, attempt := range attempts {
-		if _, err := exec.LookPath(attempt.command); err != nil {
+		if _, err := uninstallLookPath(attempt.command); err != nil {
 			continue
 		}
 
 		attempted++
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-		cmd := exec.CommandContext(ctx, attempt.command, attempt.args...)
-		output, err := cmd.CombinedOutput()
-		cancel()
+		output, err := runUninstallCommand(attempt)
 		sanitizedOutput, outputTruncated := sanitizeUninstallOutput(string(output))
 		lowerOutput := strings.ToLower(sanitizedOutput)
 
 		if err == nil {
-			return nil
+			providerClaimedRemoval = true
+			break
 		}
 
-		// If package is already absent, treat as successful remediation.
-		if strings.Contains(lowerOutput, "not installed") ||
-			strings.Contains(lowerOutput, "no package") ||
-			strings.Contains(lowerOutput, "no installed package") ||
-			strings.Contains(lowerOutput, "unknown package") ||
-			strings.Contains(lowerOutput, "not found") {
-			return nil
+		if providerReportedNotFound(lowerOutput) {
+			providerNotFoundCount++
+			continue
 		}
 
 		errLine := fmt.Sprintf("%s %v: %v (%s)", attempt.command, attempt.args, err, strings.TrimSpace(sanitizedOutput))
@@ -340,5 +395,30 @@ func runUninstallAttempts(softwareName string, attempts []uninstallAttempt) erro
 	if truncated {
 		joined += " [error summary truncated]"
 	}
-	return fmt.Errorf("failed to uninstall %q after %d attempt(s): %s", softwareName, attempted, joined)
+
+	stillPresent, verifyErr := uninstallVerifyStillPresent(softwareName)
+	if verifyErr != nil {
+		// Cannot verify. Do not invent a verdict — fall back to the provider
+		// signals, which is the pre-#3592 behavior, minus the wmic exit-0 hole
+		// (a provider exiting 0 is at least evidence it ran).
+		if providerClaimedRemoval || providerNotFoundCount > 0 {
+			return nil
+		}
+		return fmt.Errorf("failed to uninstall %q after %d attempt(s): %s", softwareName, attempted, joined)
+	}
+
+	if !stillPresent {
+		return nil
+	}
+
+	// Verified still installed — every "success" below this line would have been
+	// a lie.
+	switch {
+	case len(errors) > 0:
+		return fmt.Errorf("failed to uninstall %q after %d attempt(s); it is still present in this device's software inventory: %s", softwareName, attempted, joined)
+	case providerClaimedRemoval:
+		return fmt.Errorf("uninstall command for %q reported success but it is still present in this device's software inventory (the uninstaller may have been silently blocked, or may require a reboot to finish)", softwareName)
+	default:
+		return fmt.Errorf("no uninstall provider on this endpoint could locate %q (%d of %d attempted providers reported it as unknown), and it is still present in this device's software inventory", softwareName, providerNotFoundCount, attempted)
+	}
 }

--- a/agent/internal/remote/tools/software_uninstall_verify.go
+++ b/agent/internal/remote/tools/software_uninstall_verify.go
@@ -1,0 +1,54 @@
+package tools
+
+import (
+	"strings"
+
+	"github.com/breeze-rmm/agent/internal/collectors"
+)
+
+// softwareInventoryFn is the enumeration used to verify an uninstall's
+// post-condition. It is the SAME collector the agent reports to
+// /api/v1/agents/{id}/software from, which is what makes the check meaningful:
+// "still installed" here means "the next inventory report will still list it".
+// Indirected for tests.
+var softwareInventoryFn = func() ([]collectors.SoftwareItem, error) {
+	return collectors.Guard("software", collectors.NewSoftwareCollector().Collect)
+}
+
+// normalizeSoftwareNameForMatch makes the uninstall payload's name comparable to
+// an inventory entry's DisplayName. macOS uninstall targets arrive as either
+// "Foo" or "Foo.app" while system_profiler reports "Foo", so the .app suffix is
+// stripped from both sides.
+func normalizeSoftwareNameForMatch(name string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(name))
+	return strings.TrimSuffix(trimmed, ".app")
+}
+
+// softwareStillInstalled reports whether software named `name` is still visible
+// in this device's software inventory.
+//
+// Matching is exact (case-insensitive, trimmed) rather than substring: the name
+// handed to an uninstall command originates from a software_inventory row, so an
+// exact match is available, and substring matching would report "Teams" as still
+// installed because "Microsoft Teams Meeting Add-in" remains.
+//
+// A collector error is returned to the caller rather than being flattened to
+// false — "we could not look" must not be mistaken for "it is gone".
+func softwareStillInstalled(name string) (bool, error) {
+	target := normalizeSoftwareNameForMatch(name)
+	if target == "" {
+		return false, nil
+	}
+
+	installed, err := softwareInventoryFn()
+	if err != nil {
+		return false, err
+	}
+
+	for _, item := range installed {
+		if normalizeSoftwareNameForMatch(item.Name) == target {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/agent/internal/remote/tools/software_uninstall_verify.go
+++ b/agent/internal/remote/tools/software_uninstall_verify.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/breeze-rmm/agent/internal/collectors"
@@ -43,6 +44,15 @@ func softwareStillInstalled(name string) (bool, error) {
 	installed, err := softwareInventoryFn()
 	if err != nil {
 		return false, err
+	}
+
+	// An endpoint with zero installed software is not a real state — it means
+	// the enumeration did not work. The Linux collector in particular returns an
+	// empty list with a nil error when neither dpkg-query nor rpm is usable
+	// (software_linux.go), and treating that as "verified absent" would let the
+	// uninstall post-condition pass without ever having looked.
+	if len(installed) == 0 {
+		return false, fmt.Errorf("software inventory came back empty; cannot verify removal")
 	}
 
 	for _, item := range installed {

--- a/agent/internal/remote/tools/software_uninstall_verify_test.go
+++ b/agent/internal/remote/tools/software_uninstall_verify_test.go
@@ -62,7 +62,7 @@ func TestRunUninstallAttemptsWingetNotFoundDoesNotShortCircuitSuccess(t *testing
 			err    error
 		}{
 			"winget": {output: "No installed package found matching input criteria.", err: fmt.Errorf("exit status 1")},
-			"wmic":   {output: "No Instance(s) Available.", err: fmt.Errorf("exit status 1")},
+			"wmic":   {output: "No Instance(s) Available.", err: nil}, // wmic exits 0 on no match — bug #2
 		},
 	}
 	env.install(t, true, nil)
@@ -94,7 +94,7 @@ func TestRunUninstallAttemptsNotFoundSucceedsWhenVerifiedAbsent(t *testing.T) {
 			err    error
 		}{
 			"winget": {output: "No installed package found matching input criteria.", err: fmt.Errorf("exit status 1")},
-			"wmic":   {output: "No Instance(s) Available.", err: fmt.Errorf("exit status 1")},
+			"wmic":   {output: "No Instance(s) Available.", err: nil}, // wmic exits 0 on no match — bug #2
 		},
 	}
 	env.install(t, false, nil)
@@ -125,8 +125,52 @@ func TestRunUninstallAttemptsExitZeroStillFailsWhenSoftwareRemains(t *testing.T)
 	if err == nil {
 		t.Fatal("exit code 0 from wmic must not be accepted as proof of removal")
 	}
+	// Exit 0 + a no-match message is classified as "this provider cannot see
+	// it", not as a removal claim.
+	if !strings.Contains(err.Error(), "could locate") {
+		t.Fatalf("wmic's exit-0 no-match must not read as a removal claim, got: %v", err)
+	}
+}
+
+// The counterpart: a genuine exit-0 removal that verification contradicts.
+func TestRunUninstallAttemptsClaimedRemovalStillFailsWhenSoftwareRemains(t *testing.T) {
+	env := &fakeUninstallEnv{
+		available: map[string]bool{"winget": true},
+		responses: map[string]struct {
+			output string
+			err    error
+		}{
+			"winget": {output: "Successfully uninstalled", err: nil},
+		},
+	}
+	env.install(t, true, nil)
+
+	err := runUninstallAttempts("Some App", []uninstallAttempt{{command: "winget"}})
+	if err == nil {
+		t.Fatal("a provider claiming success must not override a verified-still-present result")
+	}
 	if !strings.Contains(err.Error(), "reported success") {
 		t.Fatalf("error should distinguish the lying-provider case, got: %v", err)
+	}
+}
+
+// wmic's exit-0 no-match must not be the one signal still trusted when
+// verification is unavailable — that was the remaining route back to a silent
+// success.
+func TestRunUninstallAttemptsWmicExitZeroPlusUnverifiableIsAFailure(t *testing.T) {
+	env := &fakeUninstallEnv{
+		available: map[string]bool{"wmic": true},
+		responses: map[string]struct {
+			output string
+			err    error
+		}{
+			"wmic": {output: "No Instance(s) Available.", err: nil},
+		},
+	}
+	env.install(t, false, fmt.Errorf("registry unreadable"))
+
+	if err := runUninstallAttempts("Some App", []uninstallAttempt{{command: "wmic"}}); err == nil {
+		t.Fatal("wmic exit-0 no-match with verification unavailable must not report success")
 	}
 }
 
@@ -191,6 +235,57 @@ func TestRunUninstallAttemptsFallsBackToErrorWhenVerificationUnavailable(t *test
 	}
 }
 
+// Verification must not upgrade a hard provider failure into a success. The
+// uninstall name does not always appear verbatim in the collector's output (a
+// brew cask token is "google-chrome" while system_profiler reports
+// "Google Chrome"), so "absent" can mean "the collector cannot see this name" —
+// which would otherwise swallow a genuine apt/brew/msiexec error.
+func TestRunUninstallAttemptsHardErrorSurvivesVerifiedAbsent(t *testing.T) {
+	env := &fakeUninstallEnv{
+		available: map[string]bool{"brew": true},
+		responses: map[string]struct {
+			output string
+			err    error
+		}{
+			"brew": {output: "Error: Permission denied @ rb_sysopen", err: fmt.Errorf("exit status 1")},
+		},
+	}
+	env.install(t, false, nil)
+
+	err := runUninstallAttempts("google-chrome", []uninstallAttempt{{command: "brew"}})
+	if err == nil {
+		t.Fatal("a hard provider error must remain a failure even when verification cannot see the name")
+	}
+	if !strings.Contains(err.Error(), "Permission denied") {
+		t.Fatalf("error should carry the provider's failure detail, got: %v", err)
+	}
+}
+
+// "Every provider says it does not know this package" is not evidence of
+// removal. If verification is also unavailable, there is nothing left to stand
+// on and the operation must fail loudly rather than resurrect the #3592 silent
+// success behind a transient collector failure.
+func TestRunUninstallAttemptsNotFoundPlusUnverifiableIsAFailure(t *testing.T) {
+	env := &fakeUninstallEnv{
+		available: map[string]bool{"brew": true},
+		responses: map[string]struct {
+			output string
+			err    error
+		}{
+			"brew": {output: "Error: Cask 'foo' is not installed.", err: fmt.Errorf("exit status 1")},
+		},
+	}
+	env.install(t, false, fmt.Errorf("system_profiler timed out"))
+
+	err := runUninstallAttempts("foo", []uninstallAttempt{{command: "brew"}})
+	if err == nil {
+		t.Fatal("not-found-only with verification unavailable must not report success")
+	}
+	if !strings.Contains(err.Error(), "could not confirm") {
+		t.Fatalf("error should name the unverifiable post-condition, got: %v", err)
+	}
+}
+
 func TestRunUninstallAttemptsNoProviderAvailable(t *testing.T) {
 	env := &fakeUninstallEnv{available: map[string]bool{}}
 	env.install(t, false, nil)
@@ -252,6 +347,21 @@ func TestSoftwareStillInstalledNormalizesDotApp(t *testing.T) {
 	}
 	if !got {
 		t.Error(`softwareStillInstalled("Slack.app") = false, want true`)
+	}
+}
+
+// An empty inventory means the enumeration did not work, not that the endpoint
+// has no software. It must read as "cannot verify", not "verified absent".
+func TestSoftwareStillInstalledTreatsEmptyInventoryAsUnverifiable(t *testing.T) {
+	orig := softwareInventoryFn
+	t.Cleanup(func() { softwareInventoryFn = orig })
+
+	softwareInventoryFn = func() ([]collectors.SoftwareItem, error) {
+		return []collectors.SoftwareItem{}, nil
+	}
+
+	if _, err := softwareStillInstalled("Anything"); err == nil {
+		t.Fatal("an empty inventory must not be reported as verified-absent")
 	}
 }
 

--- a/agent/internal/remote/tools/software_uninstall_verify_test.go
+++ b/agent/internal/remote/tools/software_uninstall_verify_test.go
@@ -1,0 +1,272 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/collectors"
+)
+
+// fakeUninstallEnv swaps every seam runUninstallAttempts uses and restores them
+// on cleanup. `available` is the set of commands exec.LookPath should find;
+// `responses` maps a command name to the output/error one run produces.
+type fakeUninstallEnv struct {
+	available map[string]bool
+	responses map[string]struct {
+		output string
+		err    error
+	}
+	ran []string
+}
+
+func (f *fakeUninstallEnv) install(t *testing.T, stillPresent bool, verifyErr error) {
+	t.Helper()
+
+	origLookPath := uninstallLookPath
+	origRun := runUninstallCommand
+	origVerify := uninstallVerifyStillPresent
+	t.Cleanup(func() {
+		uninstallLookPath = origLookPath
+		runUninstallCommand = origRun
+		uninstallVerifyStillPresent = origVerify
+	})
+
+	uninstallLookPath = func(cmd string) (string, error) {
+		if f.available[cmd] {
+			return "/usr/bin/" + cmd, nil
+		}
+		return "", fmt.Errorf("not found")
+	}
+	runUninstallCommand = func(attempt uninstallAttempt) ([]byte, error) {
+		f.ran = append(f.ran, attempt.command)
+		resp := f.responses[attempt.command]
+		return []byte(resp.output), resp.err
+	}
+	uninstallVerifyStillPresent = func(string) (bool, error) {
+		return stillPresent, verifyErr
+	}
+}
+
+// The #3592 regression. winget is the first Windows attempt and answers
+// "No installed package found matching input criteria." for anything it does not
+// index — which under the SYSTEM service account is a great deal of real
+// software. Before the fix that message short-circuited the whole operation as
+// success, so Breeze reported {"action":"uninstall","success":true} exit 0
+// without ever running the wmic fallback and without touching the machine.
+func TestRunUninstallAttemptsWingetNotFoundDoesNotShortCircuitSuccess(t *testing.T) {
+	env := &fakeUninstallEnv{
+		available: map[string]bool{"winget": true, "wmic": true},
+		responses: map[string]struct {
+			output string
+			err    error
+		}{
+			"winget": {output: "No installed package found matching input criteria.", err: fmt.Errorf("exit status 1")},
+			"wmic":   {output: "No Instance(s) Available.", err: fmt.Errorf("exit status 1")},
+		},
+	}
+	env.install(t, true, nil)
+
+	err := runUninstallAttempts("Microsoft Teams Meeting Add-in for Microsoft Office", []uninstallAttempt{
+		{command: "winget"},
+		{command: "wmic"},
+	})
+
+	if err == nil {
+		t.Fatal("expected an error: the software is still installed, but the uninstall reported success")
+	}
+	if !strings.Contains(err.Error(), "still present") {
+		t.Fatalf("error should name the failed post-condition, got: %v", err)
+	}
+	// A provider that cannot see the package must fall through, not end the run.
+	if len(env.ran) != 2 {
+		t.Fatalf("expected both providers to be attempted, got %v", env.ran)
+	}
+}
+
+// A provider that "not found"s while the software really is gone is the
+// legitimate idempotent re-run, and must still succeed.
+func TestRunUninstallAttemptsNotFoundSucceedsWhenVerifiedAbsent(t *testing.T) {
+	env := &fakeUninstallEnv{
+		available: map[string]bool{"winget": true, "wmic": true},
+		responses: map[string]struct {
+			output string
+			err    error
+		}{
+			"winget": {output: "No installed package found matching input criteria.", err: fmt.Errorf("exit status 1")},
+			"wmic":   {output: "No Instance(s) Available.", err: fmt.Errorf("exit status 1")},
+		},
+	}
+	env.install(t, false, nil)
+
+	if err := runUninstallAttempts("Already Gone", []uninstallAttempt{
+		{command: "winget"},
+		{command: "wmic"},
+	}); err != nil {
+		t.Fatalf("expected success when the software is verified absent, got: %v", err)
+	}
+}
+
+// `wmic product where name='X' call uninstall` exits 0 even when the WHERE
+// clause matches nothing, so an exit-0 provider is not evidence of removal.
+func TestRunUninstallAttemptsExitZeroStillFailsWhenSoftwareRemains(t *testing.T) {
+	env := &fakeUninstallEnv{
+		available: map[string]bool{"wmic": true},
+		responses: map[string]struct {
+			output string
+			err    error
+		}{
+			"wmic": {output: "No Instance(s) Available.", err: nil},
+		},
+	}
+	env.install(t, true, nil)
+
+	err := runUninstallAttempts("Some App", []uninstallAttempt{{command: "wmic"}})
+	if err == nil {
+		t.Fatal("exit code 0 from wmic must not be accepted as proof of removal")
+	}
+	if !strings.Contains(err.Error(), "reported success") {
+		t.Fatalf("error should distinguish the lying-provider case, got: %v", err)
+	}
+}
+
+func TestRunUninstallAttemptsExitZeroSucceedsWhenVerifiedAbsent(t *testing.T) {
+	env := &fakeUninstallEnv{
+		available: map[string]bool{"winget": true, "wmic": true},
+		responses: map[string]struct {
+			output string
+			err    error
+		}{
+			"winget": {output: "Successfully uninstalled", err: nil},
+		},
+	}
+	env.install(t, false, nil)
+
+	if err := runUninstallAttempts("Some App", []uninstallAttempt{
+		{command: "winget"},
+		{command: "wmic"},
+	}); err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	// A provider that genuinely removed the software ends the run — no point
+	// asking the next one to uninstall something that is already gone.
+	if len(env.ran) != 1 {
+		t.Fatalf("expected the run to stop after the successful provider, got %v", env.ran)
+	}
+}
+
+// "Cannot verify" is not "verified gone" and is not "verified present" — it
+// falls back to the provider signals rather than inventing a verdict.
+func TestRunUninstallAttemptsFallsBackWhenVerificationUnavailable(t *testing.T) {
+	env := &fakeUninstallEnv{
+		available: map[string]bool{"winget": true},
+		responses: map[string]struct {
+			output string
+			err    error
+		}{
+			"winget": {output: "Successfully uninstalled", err: nil},
+		},
+	}
+	env.install(t, false, fmt.Errorf("collector unavailable"))
+
+	if err := runUninstallAttempts("Some App", []uninstallAttempt{{command: "winget"}}); err != nil {
+		t.Fatalf("a provider success with verification unavailable should still succeed, got: %v", err)
+	}
+}
+
+func TestRunUninstallAttemptsFallsBackToErrorWhenVerificationUnavailable(t *testing.T) {
+	env := &fakeUninstallEnv{
+		available: map[string]bool{"winget": true},
+		responses: map[string]struct {
+			output string
+			err    error
+		}{
+			"winget": {output: "access is denied", err: fmt.Errorf("exit status 5")},
+		},
+	}
+	env.install(t, false, fmt.Errorf("collector unavailable"))
+
+	if err := runUninstallAttempts("Some App", []uninstallAttempt{{command: "winget"}}); err == nil {
+		t.Fatal("a hard provider failure with verification unavailable must remain a failure")
+	}
+}
+
+func TestRunUninstallAttemptsNoProviderAvailable(t *testing.T) {
+	env := &fakeUninstallEnv{available: map[string]bool{}}
+	env.install(t, false, nil)
+
+	err := runUninstallAttempts("Some App", []uninstallAttempt{{command: "winget"}})
+	if err == nil || !strings.Contains(err.Error(), "no supported uninstall command") {
+		t.Fatalf("expected the no-provider error, got: %v", err)
+	}
+}
+
+func TestSoftwareStillInstalledMatchesExactNameOnly(t *testing.T) {
+	orig := softwareInventoryFn
+	t.Cleanup(func() { softwareInventoryFn = orig })
+
+	softwareInventoryFn = func() ([]collectors.SoftwareItem, error) {
+		return []collectors.SoftwareItem{
+			{Name: "Microsoft Teams Meeting Add-in for Microsoft Office"},
+			{Name: "Google Chrome"},
+		}, nil
+	}
+
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"Microsoft Teams Meeting Add-in for Microsoft Office", true},
+		{"  microsoft teams meeting add-in for microsoft office  ", true},
+		// Substring matching would wrongly report Teams as still installed
+		// because the add-in remains.
+		{"Microsoft Teams", false},
+		{"Chrome", false},
+		{"Google Chrome", true},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got, err := softwareStillInstalled(tc.name)
+		if err != nil {
+			t.Fatalf("%q: unexpected error %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("softwareStillInstalled(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// macOS uninstall targets arrive with or without the .app suffix while
+// system_profiler reports the bare name.
+func TestSoftwareStillInstalledNormalizesDotApp(t *testing.T) {
+	orig := softwareInventoryFn
+	t.Cleanup(func() { softwareInventoryFn = orig })
+
+	softwareInventoryFn = func() ([]collectors.SoftwareItem, error) {
+		return []collectors.SoftwareItem{{Name: "Slack"}}, nil
+	}
+
+	got, err := softwareStillInstalled("Slack.app")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got {
+		t.Error(`softwareStillInstalled("Slack.app") = false, want true`)
+	}
+}
+
+// A collector failure must surface as an error, never be flattened to
+// "not installed" — that would resurrect the silent-success bug through the
+// verification path itself.
+func TestSoftwareStillInstalledPropagatesCollectorError(t *testing.T) {
+	orig := softwareInventoryFn
+	t.Cleanup(func() { softwareInventoryFn = orig })
+
+	softwareInventoryFn = func() ([]collectors.SoftwareItem, error) {
+		return nil, fmt.Errorf("registry unavailable")
+	}
+
+	if _, err := softwareStillInstalled("Anything"); err == nil {
+		t.Fatal("expected the collector error to propagate")
+	}
+}


### PR DESCRIPTION
## Problem

`software_inventory` kept listing a program that Breeze had "successfully" uninstalled, **even across a genuinely fresh scan** — the reporter confirmed a `device_commands` row with `{"action":"uninstall","success":true}`, `exitCode: 0`, and an inventory `last_seen` ~20 minutes *later*.

The API side was ruled out by the #3591 / #3663 investigation: `apps/api/src/routes/agents/inventory.ts` is the only `insert(softwareInventory)` site, and it wipes-and-reinserts the entire device list in one transaction with `lastSeen: now`. So a stale row carrying a fresh `last_seen` is not a merge bug — it means **the agent really did re-report the program**. It did, because the program was still installed, and the uninstall that claimed success never touched it.

## Root cause

`runUninstallAttempts` (`agent/internal/remote/tools/software.go`) had **two** paths that returned `nil` with no evidence of removal:

1. **A provider "not found" message ended the whole operation as "already absent."** winget is the *first* Windows attempt and answers `No installed package found matching input criteria.` for anything it does not index — under the SYSTEM service account that includes per-user installs and plenty of ordinary Add/Remove Programs entries. Breeze therefore returned success, **never ran the `wmic` fallback**, and never touched the machine.
2. **`err == nil` from the provider.** `wmic product where name='X' call uninstall` exits 0 even when the `WHERE` clause matches nothing, so the fallback attempt reported success unconditionally.

Both reproduce the reported evidence exactly.

## Fix

- A provider that cannot see the package **falls through to the next provider** instead of ending the run.
- The outcome is decided by a **post-condition check** against the same collector the agent reports inventory from (`softwareStillInstalled`, new `software_uninstall_verify.go`). "Still present" after the attempts is a failure, with a message that distinguishes the lying-provider case from the no-provider-could-find-it case.
- A collector error is **not** treated as proof of either state — it falls back to the provider signals rather than inventing a verdict.
- Matching is exact (case-insensitive, `.app`-normalized), not substring, so `"Microsoft Teams"` is not reported as still installed merely because `"Microsoft Teams Meeting Add-in"` remains.

### Two supporting fixes in the same path

- **`collectors/software_windows.go` called `isSystemComponent(subkey)` *after* `subkey.Close()`.** Every registry read on a closed handle fails, so the function always answered `false` — the `SystemComponent=1` / `"Update for …"` filter **has never filtered anything**, and Windows Update / system-component entries have been reported as ordinary installed software all along. That is the "incorrect entries" half of the title. The check now runs before the handle is closed and reuses the already-read `DisplayName`.
- **`handleSoftwareUninstall` now re-reports software inventory on success**, instead of leaving the dashboard stale for up to 15 minutes (the `sendInventory` cadence) — which was operationally indistinguishable from the silent-no-op bug above. Safe to fire immediately, because success now means *verified removed*.

## Tests

10 new tests in `agent/internal/remote/tools/software_uninstall_verify_test.go`, including the exact #3592 scenario (winget not-found + wmic exit-0 with the software still present must fail, and must attempt both providers). Idempotent re-runs still succeed when the software is verified absent.

```
go test -race ./internal/remote/tools/ ./internal/collectors/ ./internal/heartbeat/   → all ok
go vet (native + GOOS=windows)                                                        → clean
GOOS=windows/linux/darwin go build ./...                                              → clean
```

## Follow-ups (deliberately not in this PR)

- The Windows collector reads `registry.CURRENT_USER`, which under the SYSTEM service is the **SYSTEM profile's** hive — real users' per-user installs are invisible to inventory. Fixing needs `HKEY_USERS\<SID>` enumeration and would materially change inventory volume.
- `sendSoftwareInventory` drops the whole report when collection errors, leaving the server's previous list in place. Arguably correct (don't wipe inventory on a failed scan) but worth an explicit staleness signal.

Closes #3592

🤖 Generated with [Claude Code](https://claude.com/claude-code)