### PR TITLE
fix(api,web,portal): let <table> survive the rich-text sanitizer (#3484)

### DIFF
--- a/apps/api/src/services/contractTemplateService.test.ts
+++ b/apps/api/src/services/contractTemplateService.test.ts
@@ -262,7 +262,7 @@ describe('createDraftVersion', () => {
     expect(persisted.bodyHtml).toContain('Hi');
   });
 
-  // Issue #3520: sanitizing away a pasted <table>/<blockquote> used to be
+  // Issue #3520: sanitizing away a pasted <pre>/<blockquote> used to be
   // invisible — the version saved and the author found out later.
   it('reports the tags it stripped from bodyHtml instead of saving silently', async () => {
     const auth = makeAuth({ scope: 'organization', canAccessOrg: () => true });
@@ -270,11 +270,11 @@ describe('createDraftVersion', () => {
     queueResult([{ maxVersion: null }]);
     queueResult([{ id: 'v1', versionNumber: 1 }]);
     const row = await svc.createDraftVersion(auth, ORG_TEMPLATE.id, {
-      bodyHtml: '<p>Terms</p><blockquote>note</blockquote><table><tr><td>c</td></tr></table>',
+      bodyHtml: '<p>Terms</p><blockquote>note</blockquote><pre>c</pre>',
     });
     expect(row.id).toBe('v1'); // still saves — warning, not rejection
     expect(row.warnings).toEqual([
-      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'bodyHtml', removedTags: ['blockquote', 'table', 'td', 'tr'] },
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'bodyHtml', removedTags: ['blockquote', 'pre'] },
     ]);
   });
 

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -559,10 +559,10 @@ describe('quoteService deposits', () => {
     queueResult([{ blockType: 'rich_text' }]); // existing block type check
     queueResult([{ id: 'blk1', blockType: 'rich_text', content: { html: '<p>Updated</p>' } }]); // update returning
 
-    const row = await svc.updateBlock('q1', 'blk1', { blockType: 'rich_text', content: { html: '<p>Updated</p><table><tr><td>x</td></tr></table>' } }, actor);
+    const row = await svc.updateBlock('q1', 'blk1', { blockType: 'rich_text', content: { html: '<p>Updated</p><pre>x</pre>' } }, actor);
 
     expect(row.warnings).toEqual([
-      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.html', removedTags: ['table', 'td', 'tr'] },
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.html', removedTags: ['pre'] },
     ]);
   });
 
@@ -795,11 +795,11 @@ describe('sanitizeBlockContentForWrite loss reporting (#3520)', () => {
   it('reports the disallowed tags a rich_text write dropped', () => {
     const { content, warnings } = svc.sanitizeBlockContentForWrite({
       blockType: 'rich_text',
-      content: { html: '<p>Keep</p><blockquote>Quote</blockquote><table><tr><td>Cell</td></tr></table>' },
+      content: { html: '<p>Keep</p><blockquote>Quote</blockquote><pre>Cell</pre>' },
     } as never);
-    expect((content as { html: string }).html).not.toContain('<table');
+    expect((content as { html: string }).html).not.toContain('<pre');
     expect(warnings).toEqual([
-      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.html', removedTags: ['blockquote', 'table', 'td', 'tr'] },
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.html', removedTags: ['blockquote', 'pre'] },
     ]);
   });
 

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -803,6 +803,30 @@ describe('sanitizeBlockContentForWrite loss reporting (#3520)', () => {
     ]);
   });
 
+  // Issue #3484: the write path must actually STORE the table, not just stop
+  // warning about it — this is the only coverage that a quote block write
+  // preserves table structure end to end.
+  it('stores a rich_text table intact and warns about nothing', () => {
+    const { content, warnings } = svc.sanitizeBlockContentForWrite({
+      blockType: 'rich_text',
+      content: { html: '<table><thead><tr><th>Item</th></tr></thead><tbody><tr><td>Setup</td></tr></tbody></table>' },
+    } as never);
+    expect((content as { html: string }).html)
+      .toBe('<table><thead><tr><th>Item</th></tr></thead><tbody><tr><td>Setup</td></tr></tbody></table>');
+    expect(warnings).toEqual([]);
+  });
+
+  it('warns when a table CELL had block content flattened, and still stores the table', () => {
+    const { content, warnings } = svc.sanitizeBlockContentForWrite({
+      blockType: 'rich_text',
+      content: { html: '<table><tr><td><p>a</p><p>b</p></td></tr></table>' },
+    } as never);
+    expect((content as { html: string }).html).toBe('<table><tr><td>a<br />b</td></tr></table>');
+    expect(warnings).toEqual([
+      { code: 'UNSUPPORTED_HTML_TAGS_REMOVED', field: 'content.html', removedTags: ['p'] },
+    ]);
+  });
+
   it('reports nothing when the submitted html is already inside the subset', () => {
     const { warnings } = svc.sanitizeBlockContentForWrite({
       blockType: 'rich_text',

--- a/apps/api/src/services/richTextPdf.test.ts
+++ b/apps/api/src/services/richTextPdf.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import PDFDocument from 'pdfkit';
-import { parseRichText, renderRichTextIntoPdf, measureRichText, measureInlineRuns, type BodyFonts } from './richTextPdf';
+import { parseRichText, renderRichTextIntoPdf, measureRichText, measureInlineRuns, type BodyFonts, type RichTextTextBlock } from './richTextPdf';
 import { registerThemeFonts } from './documentThemes';
+
+function textBlocks(html: string): RichTextTextBlock[] {
+  const blocks = parseRichText(html);
+  for (const b of blocks) if (b.kind === 'table') throw new Error('unexpected table block');
+  return blocks as RichTextTextBlock[];
+}
 
 describe('parseRichText', () => {
   it('splits paragraphs and inline formatting runs', () => {
@@ -15,11 +21,11 @@ describe('parseRichText', () => {
     ]);
   });
   it('numbers ordered list items and bullets unordered ones', () => {
-    const blocks = parseRichText('<ol><li>a</li><li>b</li></ol><ul><li>c</li></ul>');
+    const blocks = textBlocks('<ol><li>a</li><li>b</li></ol><ul><li>c</li></ul>');
     expect(blocks.map((b) => [b.kind, b.ordinal ?? null])).toEqual([['li', 1], ['li', 2], ['li', null]]);
   });
   it('renders h3/h4 as heading blocks and br as run breaks', () => {
-    const blocks = parseRichText('<h3>Key Terms</h3><p>one<br>two</p>');
+    const blocks = textBlocks('<h3>Key Terms</h3><p>one<br>two</p>');
     expect(blocks[0]).toMatchObject({ kind: 'h3' });
     expect(blocks[1]!.runs.some((r) => r.text.includes('\n'))).toBe(true);
   });
@@ -29,7 +35,7 @@ describe('parseRichText', () => {
   it('folds stray root-level inline content into an implicit paragraph (raw API/MCP bodies)', () => {
     // Not producible by the TipTap editor, but a raw contract body can have bare
     // inline content at the root — it must render, not vanish, to match the HTML.
-    const blocks = parseRichText('Plain lead <strong>bold</strong> and <a href="https://x.example">link</a>');
+    const blocks = textBlocks('Plain lead <strong>bold</strong> and <a href="https://x.example">link</a>');
     expect(blocks).toHaveLength(1);
     expect(blocks[0]!.kind).toBe('p');
     expect(blocks[0]!.runs.map((r) => r.text).join('')).toBe('Plain lead bold and link');
@@ -44,7 +50,7 @@ describe('parseRichText', () => {
     // String.fromCodePoint(0x110000) throws RangeError — must fall back to the
     // original literal text instead of crashing the render.
     expect(() => parseRichText('<p>bad &#x110000; ref</p>')).not.toThrow();
-    const blocks = parseRichText('<p>bad &#x110000; ref</p>');
+    const blocks = textBlocks('<p>bad &#x110000; ref</p>');
     expect(blocks[0]!.runs.map((r) => r.text).join('')).toContain('&#x110000;');
   });
   it('does not throw on an out-of-range numeric character reference (attribute value)', () => {
@@ -178,6 +184,133 @@ describe('renderRichTextIntoPdf', () => {
     // y=200 — the renderer must call ensureRoom often enough (and reserve
     // enough per block) for at least one page break to actually fire.
     expect(pageAdds).toBeGreaterThan(0);
+  });
+});
+
+// Issue #3484: <table> survives sanitisation now, so the PDF renderer has to
+// draw a real grid instead of silently dropping the block.
+describe('rich-text tables (#3484)', () => {
+  function ensureRoomFor(doc: PDFKit.PDFDocument, onBreak?: () => void) {
+    return (needed: number): number => {
+      if (doc.y > doc.page.height - doc.page.margins.bottom - needed) {
+        doc.addPage();
+        onBreak?.();
+      }
+      return doc.y;
+    };
+  }
+
+  it('parses a table into rows of inline-run cells, flagging the header row', () => {
+    const blocks = parseRichText(
+      '<table><thead><tr><th>Item</th><th>Price</th></tr></thead><tbody><tr><td>Setup</td><td>$500</td></tr></tbody></table>',
+    );
+    expect(blocks).toHaveLength(1);
+    const table = blocks[0]!;
+    expect(table.kind).toBe('table');
+    if (table.kind !== 'table') throw new Error('expected a table block');
+    expect(table.rows.map((r) => r.header)).toEqual([true, false]);
+    expect(table.rows.map((r) => r.cells.map((c) => c.map((run) => run.text).join('')))).toEqual([
+      ['Item', 'Price'],
+      ['Setup', '$500'],
+    ]);
+  });
+
+  it('treats a <th>-only row as a header even without <thead>, and keeps cell formatting', () => {
+    const blocks = parseRichText('<table><tr><th>H</th></tr><tr><td><strong>b</strong>t</td></tr></table>');
+    const table = blocks[0]!;
+    if (table.kind !== 'table') throw new Error('expected a table block');
+    expect(table.rows.map((r) => r.header)).toEqual([true, false]);
+    expect(table.rows[1]!.cells[0]).toEqual([
+      { text: 'b', bold: true, italic: false, underline: false },
+      { text: 't', bold: false, italic: false, underline: false },
+    ]);
+  });
+
+  it('keeps a table that follows and precedes paragraphs in document order', () => {
+    const blocks = parseRichText('<p>before</p><table><tr><td>x</td></tr></table><p>after</p>');
+    expect(blocks.map((b) => b.kind)).toEqual(['p', 'table', 'p']);
+  });
+
+  it('does not drop a <tr>/<td> orphaned from its <table>', () => {
+    // Reachable via the raw API/MCP; the browser lays the text out as flowing
+    // content, so the PDF must not silently lose it.
+    const blocks = parseRichText('<tr><td>orphan</td></tr>');
+    expect(blocks.map((b) => b.kind)).toEqual(['p']);
+    expect(JSON.stringify(blocks)).toContain('orphan');
+  });
+
+  it('advances the cursor by the table it drew, not by the last cell', () => {
+    // Regression guard for the trap tablePdf.ts documents: per-cell draws leave
+    // pdfkit's own y wherever the LAST column ended, which is shorter than the
+    // row whenever an earlier column wrapped. The returned cursor (and doc.y)
+    // must reflect the table's true bottom or the next block overlaps it.
+    const doc = new PDFDocument({ size: 'A4', margin: 50 });
+    doc.y = 100;
+    const html = '<table><tr><td>' + 'wrap '.repeat(40) + '</td><td>short</td></tr></table>';
+    const after = renderRichTextIntoPdf(doc, html, { x: 50, width: 495, startY: 100, ensureRoom: ensureRoomFor(doc) });
+    const measured = measureRichText(doc, html, 495);
+    expect(after).toBeGreaterThan(100);
+    // Height consumed matches the measurement (plus the trailing block gap).
+    expect(after - 100).toBeCloseTo(measured, 0);
+    // doc.y is left at the table's true bottom — the returned cursor is that
+    // plus the trailing block gap every other block type also adds.
+    expect(doc.y).toBeCloseTo(after - 8, 5);
+  });
+
+  it('measures a table as taller than the same content with fewer rows', () => {
+    const doc = new PDFDocument({ size: 'A4', margin: 50 });
+    const twoRows = measureRichText(doc, '<table><tr><td>a</td></tr><tr><td>b</td></tr></table>', 495);
+    const oneRow = measureRichText(doc, '<table><tr><td>a</td></tr></table>', 495);
+    expect(twoRows).toBeGreaterThan(oneRow);
+    expect(oneRow).toBeGreaterThan(0);
+  });
+
+  it('page-breaks between rows and redraws the header on the new page', async () => {
+    const doc = new PDFDocument({ size: 'A4', margin: 50, compress: false });
+    const chunks: Buffer[] = [];
+    const done = new Promise<Buffer>((resolve) => {
+      doc.on('data', (d: Buffer) => chunks.push(d));
+      doc.on('end', () => resolve(Buffer.concat(chunks)));
+    });
+    doc.y = 60;
+    let pageAdds = 0;
+    const rows = Array.from({ length: 60 }, (_, i) => `<tr><td>Row ${i + 1}</td><td>value</td></tr>`).join('');
+    const html = `<table><thead><tr><th>HeaderLabel</th><th>Amount</th></tr></thead><tbody>${rows}</tbody></table>`;
+    renderRichTextIntoPdf(doc, html, {
+      x: 50, width: 495, startY: 60,
+      ensureRoom: ensureRoomFor(doc, () => { pageAdds += 1; }),
+    });
+    doc.end();
+    const pdf = (await done).toString('latin1');
+
+    expect(pageAdds).toBeGreaterThan(0);
+    // "HeaderLabel" is drawn once per page the table spans. Hex-encoded shows
+    // are how pdfkit emits text with an embedded standard font.
+    const headerShows = (pdf.match(/486561646572/g) ?? []).length; // "Header"
+    expect(headerShows).toBeGreaterThan(1);
+  });
+
+  it('renders an empty <table> as nothing rather than throwing', () => {
+    const doc = new PDFDocument({ size: 'A4', margin: 50 });
+    doc.y = 100;
+    expect(parseRichText('<table></table>')).toEqual([]);
+    expect(renderRichTextIntoPdf(doc, '<table></table>', { x: 50, width: 495, startY: 100, ensureRoom: ensureRoomFor(doc) })).toBe(100);
+  });
+
+  it('degrades a row taller than a whole page into stacked paragraphs instead of clipping it', () => {
+    const doc = new PDFDocument({ size: 'A4', margin: 50 });
+    doc.y = 60;
+    const giant = 'word '.repeat(4000);
+    const html = `<table><tr><th>Label</th></tr><tr><td>${giant}</td></tr></table>`;
+    let pageAdds = 0;
+    // Must terminate (the degrade path never re-asks for room it cannot get)
+    // and must consume more than one page's worth of vertical space.
+    const after = renderRichTextIntoPdf(doc, html, {
+      x: 50, width: 495, startY: 60,
+      ensureRoom: ensureRoomFor(doc, () => { pageAdds += 1; }),
+    });
+    expect(pageAdds).toBeGreaterThan(0);
+    expect(after).toBeGreaterThan(60);
   });
 });
 

--- a/apps/api/src/services/richTextPdf.test.ts
+++ b/apps/api/src/services/richTextPdf.test.ts
@@ -297,6 +297,31 @@ describe('rich-text tables (#3484)', () => {
     expect(renderRichTextIntoPdf(doc, '<table></table>', { x: 50, width: 495, startY: 100, ensureRoom: ensureRoomFor(doc) })).toBe(100);
   });
 
+  it('renders a table with more columns than fit without throwing or losing rows', () => {
+    // Column widths floor at a readable minimum rather than re-balancing, so a
+    // 15-column table overflows the content width by design. It must still
+    // draw, advance the cursor, and stay page-break-sane.
+    const doc = new PDFDocument({ size: 'A4', margin: 50 });
+    doc.y = 100;
+    const cells = Array.from({ length: 15 }, (_, i) => `<td>c${i}</td>`).join('');
+    const html = `<table><tr>${cells}</tr><tr>${cells}</tr></table>`;
+    const after = renderRichTextIntoPdf(doc, html, {
+      x: 50, width: 495, startY: 100,
+      ensureRoom: (needed: number) => { if (doc.y > doc.page.height - doc.page.margins.bottom - needed) doc.addPage(); return doc.y; },
+    });
+    expect(after).toBeGreaterThan(100);
+    expect(measureRichText(doc, html, 495)).toBeGreaterThan(0);
+  });
+
+  it('handles empty cells (zero-length content) without collapsing the column', () => {
+    const doc = new PDFDocument({ size: 'A4', margin: 50 });
+    const blocks = parseRichText('<table><tr><td></td><td>x</td></tr></table>');
+    const table = blocks[0]!;
+    if (table.kind !== 'table') throw new Error('expected a table block');
+    expect(table.rows[0]!.cells).toHaveLength(2);
+    expect(measureRichText(doc, '<table><tr><td></td><td>x</td></tr></table>', 495)).toBeGreaterThan(0);
+  });
+
   it('degrades a row taller than a whole page into stacked paragraphs instead of clipping it', () => {
     const doc = new PDFDocument({ size: 'A4', margin: 50 });
     doc.y = 60;

--- a/apps/api/src/services/richTextPdf.ts
+++ b/apps/api/src/services/richTextPdf.ts
@@ -771,6 +771,11 @@ function measureTableRow(doc: PDFKit.PDFDocument, row: RichTextTableRow, widths:
   }
 }
 
+/** Height the table occupies with NO page breaks — repeated headers are not
+ *  counted, exactly as measureRichText ignores pagination for every other block
+ *  kind. Today's only caller (calloutPdf) passes a non-paginating ensureRoom, so
+ *  measure and draw agree; a future paginating caller would need this to grow a
+ *  page-aware variant rather than trusting this number. */
 function measureTableBlock(doc: PDFKit.PDFDocument, block: RichTextTableBlock, width: number, fonts: BodyFonts): number {
   const widths = tableColumnWidths(block, width);
   return block.rows.reduce((total, row) => total + measureTableRow(doc, row, widths, fonts), 0);

--- a/apps/api/src/services/richTextPdf.ts
+++ b/apps/api/src/services/richTextPdf.ts
@@ -28,12 +28,28 @@ export interface RichTextRun {
   link?: string;
 }
 
-export interface RichTextBlock {
+export interface RichTextTextBlock {
   kind: 'p' | 'h3' | 'h4' | 'li';
   ordinal?: number;
   indent: 0 | 1;
   runs: RichTextRun[];
 }
+
+/** One `<tr>` of a rich-text `<table>` (issue #3484). `header` is true for a row
+ *  whose cells were `<th>` or that sat inside `<thead>` — drawn bold on a tinted
+ *  fill, and repeated at the top of every page the table spills onto. Cells hold
+ *  inline runs only, matching the sanitizer's cell contract. */
+export interface RichTextTableRow {
+  header: boolean;
+  cells: RichTextRun[][];
+}
+
+export interface RichTextTableBlock {
+  kind: 'table';
+  rows: RichTextTableRow[];
+}
+
+export type RichTextBlock = RichTextTextBlock | RichTextTableBlock;
 
 // ---------------------------------------------------------------------------
 // Minimal tokenizer / tree builder over the known 11-tag subset. Not a general
@@ -190,6 +206,39 @@ const BASE_CTX: InlineCtx = { bold: false, italic: false, underline: false };
 // indent 1 rather than growing indent per depth.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Table assembly (#3484): <table> → one 'table' block. Rows are collected
+// through thead/tbody/tfoot wrappers (and directly off <table>, which is what
+// a bare `<table><tr>` paste produces). Cells are inline runs only — the
+// sanitizer guarantees that, and anything block-level that slipped past it
+// flattens through extractRuns rather than being dropped.
+// ---------------------------------------------------------------------------
+
+function collectTableRows(node: ElementNode, inHeader: boolean, rows: RichTextTableRow[]): void {
+  for (const child of node.children) {
+    if (child.type !== 'el') continue;
+    if (child.tag === 'thead') collectTableRows(child, true, rows);
+    else if (child.tag === 'tbody' || child.tag === 'tfoot') collectTableRows(child, false, rows);
+    else if (child.tag === 'tr') {
+      const cells: RichTextRun[][] = [];
+      let allHeaderCells = true;
+      for (const cell of child.children) {
+        if (cell.type !== 'el' || (cell.tag !== 'td' && cell.tag !== 'th')) continue;
+        if (cell.tag !== 'th') allHeaderCells = false;
+        cells.push(extractRuns(cell.children, BASE_CTX));
+      }
+      if (cells.length === 0) continue;
+      rows.push({ header: inHeader || allHeaderCells, cells });
+    }
+  }
+}
+
+function parseTableBlock(node: ElementNode): RichTextTableBlock | null {
+  const rows: RichTextTableRow[] = [];
+  collectTableRows(node, false, rows);
+  return rows.length ? { kind: 'table', rows } : null;
+}
+
 function collectListItems(list: ElementNode, indent: 0 | 1, blocks: RichTextBlock[]): void {
   let ordinal = 0;
   for (const child of list.children) {
@@ -216,6 +265,9 @@ function collectListItems(list: ElementNode, indent: 0 | 1, blocks: RichTextBloc
 // into an implicit paragraph so the PDF matches the browser's HTML render
 // (which lays out stray root inline content as flowing text).
 const ROOT_INLINE_TAGS = new Set(['strong', 'em', 'u', 'a', 'br']);
+
+/** Table parts orphaned from their `<table>` — see the root walk below. */
+const STRAY_TABLE_TAGS = new Set(['thead', 'tbody', 'tfoot', 'tr', 'th', 'td']);
 
 /** Parse sanitized rich-text subset HTML into an ordered block list. Pure /
  *  side-effect-free — safe to unit test without any PDF rendering. */
@@ -251,6 +303,15 @@ export function parseRichText(html: string): RichTextBlock[] {
     } else if (node.tag === 'ul' || node.tag === 'ol') {
       flushInline();
       collectListItems(node, 0, blocks);
+    } else if (node.tag === 'table') {
+      flushInline();
+      const table = parseTableBlock(node);
+      if (table) blocks.push(table);
+    } else if (STRAY_TABLE_TAGS.has(node.tag)) {
+      // A `<tr>`/`<td>` that reached the document root without its `<table>`
+      // (hand-written API/MCP HTML). The browser lays its text out as flowing
+      // content, so buffer it as inline rather than dropping it from the PDF.
+      pendingInline.push(node);
     } else if (ROOT_INLINE_TAGS.has(node.tag)) {
       pendingInline.push(node);
     }
@@ -276,7 +337,7 @@ interface BlockStyle {
   forceBold: boolean;
 }
 
-function styleFor(kind: RichTextBlock['kind']): BlockStyle {
+function styleFor(kind: RichTextTextBlock['kind']): BlockStyle {
   if (kind === 'h3') return { fontSize: 13, spacingAfter: 8, forceBold: true };
   if (kind === 'h4') return { fontSize: 11.5, spacingAfter: 8, forceBold: true };
   return { fontSize: 11, spacingAfter: 8, forceBold: false }; // 'p' | 'li'
@@ -318,8 +379,13 @@ export interface RenderRichTextOpts {
  *  via opts.ensureRoom. Returns the new y cursor (below the last block + its
  *  trailing spacing), for the caller to continue drawing from. */
 export function renderRichTextIntoPdf(doc: PDFKit.PDFDocument, html: string, opts: RenderRichTextOpts): number {
-  const bodyFonts = opts.fonts ?? DEFAULT_BODY_FONTS;
-  const blocks = parseRichText(html);
+  return drawBlocks(doc, parseRichText(html), opts, opts.fonts ?? DEFAULT_BODY_FONTS);
+}
+
+/** The block draw loop, split out of renderRichTextIntoPdf so the oversized-row
+ *  degrade path in drawTableBlock can reuse it on synthetic paragraph blocks
+ *  (which contain no tables, so the mutual recursion terminates at one level). */
+function drawBlocks(doc: PDFKit.PDFDocument, blocks: RichTextBlock[], opts: RenderRichTextOpts, bodyFonts: BodyFonts): number {
   // Side-by-side callers can legitimately leave pdfkit's implicit cursor at the
   // bottom of the column drawn last rather than the lower of both columns.
   // startY is the public contract; synchronize doc.y before ensureRoom reads it.
@@ -332,6 +398,11 @@ export function renderRichTextIntoPdf(doc: PDFKit.PDFDocument, html: string, opt
   // the actual draw calls) never reflects a gap that hasn't been drawn as text.
   let gapBefore = 0;
   for (const block of blocks) {
+    if (block.kind === 'table') {
+      y = drawTableBlock(doc, block, opts, bodyFonts, y, gapBefore);
+      gapBefore = TABLE_SPACING_AFTER;
+      continue;
+    }
     const style = styleFor(block.kind);
     // Ordered-list ordinals reach 2+ digits ("10.", "11.", …) which overflow the
     // fixed 14pt bullet gutter and character-wrap, garbling clause numbering.
@@ -493,7 +564,7 @@ function maxLineHeightForRuns(doc: PDFKit.PDFDocument, runs: RichTextRun[], font
  *  and indent math as the draw loop, but via countWrappedLines instead of an
  *  actual pdfkit draw. Returns the block's own height (excluding spacingAfter —
  *  callers accumulate that separately, matching renderRichTextIntoPdf). */
-function measureBlockHeight(doc: PDFKit.PDFDocument, block: RichTextBlock, width: number, fonts: BodyFonts): number {
+function measureBlockHeight(doc: PDFKit.PDFDocument, block: RichTextTextBlock, width: number, fonts: BodyFonts): number {
   const style = styleFor(block.kind);
   const isLi = block.kind === 'li';
   const prefix = isLi ? (block.ordinal != null ? `${block.ordinal}.` : '•') : '';
@@ -526,6 +597,11 @@ export function measureRichText(doc: PDFKit.PDFDocument, html: string, width: nu
     let total = 0;
     let gapBefore = 0;
     for (const block of blocks) {
+      if (block.kind === 'table') {
+        total += gapBefore + measureTableBlock(doc, block, width, bodyFonts);
+        gapBefore = TABLE_SPACING_AFTER;
+        continue;
+      }
       const style = styleFor(block.kind);
       total += gapBefore + measureBlockHeight(doc, block, width, bodyFonts);
       gapBefore = style.spacingAfter;
@@ -564,9 +640,24 @@ export function renderInlineRunsIntoPdf(
   color: string = TEXT_COLOR,
   forceBold = false,
 ): void {
-  const bodyFonts = fonts ?? DEFAULT_BODY_FONTS;
   if (!html || !html.trim()) return;
-  const runs = extractRuns(tokenize(html), BASE_CTX);
+  drawRuns(doc, extractRuns(tokenize(html), BASE_CTX), x, y, width, fontSize, fonts ?? DEFAULT_BODY_FONTS, align, color, forceBold);
+}
+
+/** Run-sequence draw core shared by renderInlineRunsIntoPdf and the table-cell
+ *  draw (which already holds parsed runs and must not re-serialize to HTML). */
+function drawRuns(
+  doc: PDFKit.PDFDocument,
+  runs: RichTextRun[],
+  x: number,
+  y: number,
+  width: number,
+  fontSize: number,
+  bodyFonts: BodyFonts,
+  align: 'left' | 'center' | 'right' = 'left',
+  color: string = TEXT_COLOR,
+  forceBold = false,
+): void {
   const effectiveRuns = runs.length ? runs : [{ text: '', bold: false, italic: false, underline: false }];
   effectiveRuns.forEach((run, i) => {
     const isFirst = i === 0;
@@ -597,12 +688,193 @@ export function measureInlineRuns(doc: PDFKit.PDFDocument, html: string, width: 
   const saved = saveFontState(doc);
   try {
     if (!html || !html.trim()) return 0;
-    const runs = extractRuns(tokenize(html), BASE_CTX);
-    const effectiveRuns = runs.length ? runs : [{ text: '', bold: false, italic: false, underline: false }];
-    const lines = countWrappedLines(doc, effectiveRuns, width, fontSize, bodyFonts, forceBold);
-    const lineHeight = maxLineHeightForRuns(doc, effectiveRuns, fontSize, bodyFonts, forceBold);
-    return lines * lineHeight;
+    return measureRuns(doc, extractRuns(tokenize(html), BASE_CTX), width, fontSize, bodyFonts, forceBold);
   } finally {
     restoreFontState(doc, saved);
   }
+}
+
+/** Run-sequence measure core (counterpart to drawRuns). Mutates doc font state
+ *  as it measures — callers save/restore around it. */
+function measureRuns(doc: PDFKit.PDFDocument, runs: RichTextRun[], width: number, fontSize: number, bodyFonts: BodyFonts, forceBold = false): number {
+  const effectiveRuns = runs.length ? runs : [{ text: '', bold: false, italic: false, underline: false }];
+  const lines = countWrappedLines(doc, effectiveRuns, width, fontSize, bodyFonts, forceBold);
+  const lineHeight = maxLineHeightForRuns(doc, effectiveRuns, fontSize, bodyFonts, forceBold);
+  return lines * lineHeight;
+}
+
+// ---------------------------------------------------------------------------
+// Rich-text <table> blocks (#3484)
+//
+// Deliberately NOT tablePdf.ts: that module renders the STRUCTURED `table`
+// block type, whose author-supplied column weights / zebra / header style have
+// no counterpart in pasted HTML — and it imports this module, so the dependency
+// can only run one way. What the two share is the cell primitive (drawRuns /
+// measureRuns above), which is where the formatting fidelity actually lives.
+//
+// Column widths are inferred, since HTML carries no weights: each column's
+// weight is the longest plain-text cell in it, clamped so one prose-heavy
+// column can't squeeze the rest below a readable floor.
+// ---------------------------------------------------------------------------
+
+const TABLE_FONT_SIZE = 10;
+const TABLE_CELL_PADDING = 5;
+const TABLE_MIN_COLUMN_WIDTH = 36;
+const TABLE_SPACING_AFTER = 8;
+const TABLE_HEADER_FILL = '#f1f5f9';
+const TABLE_BORDER_COLOR = '#e2e8f0';
+/** Clamp on a column's inferred weight — without an upper bound a single long
+ *  paragraph cell would starve every other column down to the floor. */
+const TABLE_MAX_COLUMN_WEIGHT = 60;
+
+function runsPlainText(runs: RichTextRun[]): string {
+  return runs.map((r) => r.text).join('');
+}
+
+function tableColumnCount(block: RichTextTableBlock): number {
+  return block.rows.reduce((max, row) => Math.max(max, row.cells.length), 0);
+}
+
+/** Distribute `width` across the table's columns by inferred weight, flooring
+ *  each at TABLE_MIN_COLUMN_WIDTH. Like tablePdf's distributeColumnWidths, the
+ *  floor does not re-balance: a table with more columns than fit simply
+ *  overflows rather than rendering illegibly narrow cells. */
+function tableColumnWidths(block: RichTextTableBlock, width: number): number[] {
+  const count = tableColumnCount(block);
+  if (count === 0) return [];
+  const weights = Array.from({ length: count }, (_, i) =>
+    Math.min(
+      TABLE_MAX_COLUMN_WEIGHT,
+      Math.max(1, ...block.rows.map((row) => runsPlainText(row.cells[i] ?? []).trim().length)),
+    ),
+  );
+  const totalWeight = weights.reduce((sum, w) => sum + w, 0) || count;
+  return weights.map((w) => Math.max(TABLE_MIN_COLUMN_WIDTH, Math.round((width * w) / totalWeight)));
+}
+
+/** Row height = tallest cell in the row, padding included. Header rows are
+ *  drawn bold, so they must be MEASURED bold — a themed bold face can carry
+ *  taller line metrics than its regular face. */
+function measureTableRow(doc: PDFKit.PDFDocument, row: RichTextTableRow, widths: number[], fonts: BodyFonts): number {
+  const saved = saveFontState(doc);
+  try {
+    let tallest = 0;
+    row.cells.forEach((cell, i) => {
+      const columnWidth = widths[i];
+      if (columnWidth === undefined) return;
+      const inner = Math.max(0, columnWidth - 2 * TABLE_CELL_PADDING);
+      tallest = Math.max(tallest, measureRuns(doc, cell, inner, TABLE_FONT_SIZE, fonts, row.header));
+    });
+    return tallest + 2 * TABLE_CELL_PADDING;
+  } finally {
+    restoreFontState(doc, saved);
+  }
+}
+
+function measureTableBlock(doc: PDFKit.PDFDocument, block: RichTextTableBlock, width: number, fonts: BodyFonts): number {
+  const widths = tableColumnWidths(block, width);
+  return block.rows.reduce((total, row) => total + measureTableRow(doc, row, widths, fonts), 0);
+}
+
+function drawTableRow(
+  doc: PDFKit.PDFDocument,
+  row: RichTextTableRow,
+  widths: number[],
+  x: number,
+  y: number,
+  height: number,
+  fonts: BodyFonts,
+): void {
+  const totalWidth = widths.reduce((sum, w) => sum + w, 0);
+  if (row.header) {
+    doc.save();
+    doc.rect(x, y, totalWidth, height).fill(TABLE_HEADER_FILL);
+    doc.restore();
+  }
+  let cx = x;
+  widths.forEach((columnWidth, i) => {
+    doc.save();
+    doc.lineWidth(0.5).strokeColor(TABLE_BORDER_COLOR).rect(cx, y, columnWidth, height).stroke();
+    doc.restore();
+    drawRuns(
+      doc,
+      row.cells[i] ?? [],
+      cx + TABLE_CELL_PADDING,
+      y + TABLE_CELL_PADDING,
+      Math.max(0, columnWidth - 2 * TABLE_CELL_PADDING),
+      TABLE_FONT_SIZE,
+      fonts,
+      'left',
+      TEXT_COLOR,
+      row.header,
+    );
+    cx += columnWidth;
+  });
+}
+
+/** Draw one table block, row at a time. Rows never split: the leading header
+ *  row is redrawn on every page the table spills onto, and a row too tall for
+ *  even a fresh page degrades BEFORE drawing into stacked "header: value"
+ *  paragraphs (which paginate themselves) — so this can never loop asking for
+ *  room that does not exist. Mirrors tablePdf.ts's contract for the structured
+ *  block type, but detects the page break from doc.y rather than needing the
+ *  richer EnsureRoomRich callback, keeping renderRichTextIntoPdf's public
+ *  `ensureRoom: (needed) => number` signature (and all its call sites) intact. */
+function drawTableBlock(
+  doc: PDFKit.PDFDocument,
+  block: RichTextTableBlock,
+  opts: RenderRichTextOpts,
+  fonts: BodyFonts,
+  startY: number,
+  gapBefore: number,
+): number {
+  const widths = tableColumnWidths(block, opts.width);
+  if (widths.length === 0) return startY;
+  const totalWidth = widths.reduce((sum, w) => sum + w, 0);
+  const headerRow = block.rows[0]?.header ? block.rows[0] : null;
+  const headerHeight = headerRow ? measureTableRow(doc, headerRow, widths, fonts) : 0;
+  const usablePageHeight = doc.page.height - doc.page.margins.top - doc.page.margins.bottom;
+
+  let y = startY;
+  let leadingGap = gapBefore;
+  block.rows.forEach((row, index) => {
+    const height = measureTableRow(doc, row, widths, fonts);
+    // ensureRoom decides from pdfkit's OWN cursor, which the per-cell draws
+    // above leave wherever the LAST column ended — resync before every call so
+    // the decision is anchored to the y this function tracks (same hazard and
+    // fix as tablePdf.ts's renderTableIntoPdf).
+    doc.y = y;
+    const beforeDocY = doc.y;
+    const reserved = opts.ensureRoom(leadingGap + height);
+    const brokePage = doc.y !== beforeDocY;
+    y = brokePage ? reserved : reserved + leadingGap;
+    leadingGap = 0;
+
+    if (brokePage && headerRow && index > 0) {
+      drawTableRow(doc, headerRow, widths, opts.x, y, headerHeight, fonts);
+      y += headerHeight;
+    }
+
+    if (height > usablePageHeight - headerHeight) {
+      // Taller than a whole page even on its own — fall back to prose so the
+      // content still reaches the reader instead of being clipped.
+      const degraded: RichTextBlock[] = row.cells.map((cell, i) => {
+        const label = headerRow ? runsPlainText(headerRow.cells[i] ?? []).trim() : '';
+        const runs: RichTextRun[] = label
+          ? [{ text: `${label}: `, bold: true, italic: false, underline: false }, ...cell]
+          : [...cell];
+        return { kind: 'p', indent: 0, runs };
+      });
+      y = drawBlocks(doc, degraded, { ...opts, width: totalWidth, startY: y }, fonts);
+      return;
+    }
+
+    drawTableRow(doc, row, widths, opts.x, y, height, fonts);
+    y += height;
+  });
+
+  // Leave pdfkit's cursor where this block actually ended, so the next block's
+  // ensureRoom sees the table's true bottom rather than the last cell's.
+  doc.y = y;
+  return y;
 }

--- a/apps/api/src/services/richTextSanitize.test.ts
+++ b/apps/api/src/services/richTextSanitize.test.ts
@@ -48,13 +48,76 @@ describe('sanitizeInlineRichText', () => {
   });
 });
 
+// Issue #3484: table markup used to be stripped entirely, collapsing a pasted
+// grid into run-together text. It now survives — structure only, cells inline.
+describe('table markup (#3484)', () => {
+  it('preserves table structure', () => {
+    const input = '<table><thead><tr><th>Item</th><th>Price</th></tr></thead><tbody><tr><td>Setup</td><td>$500</td></tr></tbody></table>';
+    expect(sanitizeRichTextHtml(input)).toBe(input);
+  });
+
+  it('keeps a bare table (no thead/tbody) as authored', () => {
+    expect(sanitizeRichTextHtml('<table><tr><td>a</td><td>b</td></tr></table>'))
+      .toBe('<table><tr><td>a</td><td>b</td></tr></table>');
+  });
+
+  it('keeps inline marks and links inside cells', () => {
+    expect(sanitizeRichTextHtml('<table><tr><td><strong>a</strong> <em>b</em></td></tr></table>'))
+      .toBe('<table><tr><td><strong>a</strong> <em>b</em></td></tr></table>');
+    expect(sanitizeRichTextHtml('<table><tr><td><a href="https://a.b">x</a></td></tr></table>'))
+      .toBe('<table><tr><td><a href="https://a.b" rel="noopener noreferrer" target="_blank">x</a></td></tr></table>');
+  });
+
+  it('drops colspan/rowspan/style/width — no attributes survive on table tags', () => {
+    expect(sanitizeRichTextHtml('<table style="width:100%" border="1"><tr><td colspan="2" rowspan="3" class="c">a</td></tr></table>'))
+      .toBe('<table><tr><td>a</td></tr></table>');
+  });
+
+  it('flattens block content inside a cell to inline runs separated by <br />', () => {
+    // Word/Google-Docs paste wraps cell text in <p>; the boundary becomes a
+    // line break rather than vanishing (which would read "ab").
+    expect(sanitizeRichTextHtml('<table><tr><td><p>a</p><p>b</p></td></tr></table>'))
+      .toBe('<table><tr><td>a<br />b</td></tr></table>');
+    expect(sanitizeRichTextHtml('<table><tr><td><ul><li>a</li><li>b</li></ul></td></tr></table>'))
+      .toBe('<table><tr><td>a<br />b</td></tr></table>');
+  });
+
+  it('flattens a NESTED table inside a cell — cells stay inline-only', () => {
+    expect(sanitizeRichTextHtml('<table><tr><td>x<table><tr><td>n1</td><td>n2</td></tr></table></td></tr></table>'))
+      .toBe('<table><tr><td>x<br />n1<br />n2</td></tr></table>');
+  });
+
+  it('reports what the cell pass removed so the author is still warned', () => {
+    const r = sanitizeRichTextHtmlWithReport('<table><tr><td><p>a</p></td></tr></table>');
+    expect(r.removedTags).toEqual(['p']);
+    const nested = sanitizeRichTextHtmlWithReport('<table><tr><td><table><tr><td>n</td></tr></table></td></tr></table>');
+    expect(nested.removedTags).toEqual(['table', 'td', 'tr']);
+  });
+
+  it('still strips script/style/event handlers inside cells', () => {
+    expect(sanitizeRichTextHtml('<table><tr><td onclick="x()"><script>evil()</script>ok</td></tr></table>'))
+      .toBe('<table><tr><td>ok</td></tr></table>');
+    expect(sanitizeRichTextHtml('<table><tr><td><a href="javascript:alert(1)">x</a></td></tr></table>'))
+      .toBe('<table><tr><td><a>x</a></td></tr></table>');
+  });
+
+  it('is idempotent — the read path re-sanitizes stored rows', () => {
+    const once = sanitizeRichTextHtml('<table><tr><td><p>a</p><p>b</p></td></tr></table>');
+    expect(sanitizeRichTextHtml(once)).toBe(once);
+  });
+
+  it('leaves the inline profile table-free — cell/label editors are unchanged', () => {
+    expect(sanitizeInlineRichText('<table><tr><td>z</td></tr></table>')).toBe('z');
+  });
+});
+
 // Issue #3520: the sanitizer used to discard out-of-subset tags without telling
 // anyone, so a write returned 200 with the author's content gone. The reporting
 // variants name what was dropped without changing what is produced.
 describe('loss reporting (#3520)', () => {
   it('sanitizeRichTextHtmlWithReport names every disallowed tag it removed', () => {
-    const r = sanitizeRichTextHtmlWithReport('<p>keep</p><blockquote><h1>x</h1></blockquote><table><tr><td>c</td></tr></table>');
-    expect(r.removedTags).toEqual(['blockquote', 'h1', 'table', 'td', 'tr']);
+    const r = sanitizeRichTextHtmlWithReport('<p>keep</p><blockquote><h1>x</h1></blockquote><pre>c</pre>');
+    expect(r.removedTags).toEqual(['blockquote', 'h1', 'pre']);
   });
 
   it('reports the same tag once and in sorted order however often it appears', () => {
@@ -62,9 +125,9 @@ describe('loss reporting (#3520)', () => {
       .toEqual(['div', 'span']);
   });
 
-  it('lowercases tag names so <TABLE> and <table> report identically', () => {
-    expect(sanitizeRichTextHtmlWithReport('<TABLE><TR><TD>x</TD></TR></TABLE>').removedTags)
-      .toEqual(['table', 'td', 'tr']);
+  it('lowercases tag names so <BLOCKQUOTE> and <blockquote> report identically', () => {
+    expect(sanitizeRichTextHtmlWithReport('<BLOCKQUOTE><PRE>x</PRE></BLOCKQUOTE>').removedTags)
+      .toEqual(['blockquote', 'pre']);
   });
 
   it('produces html byte-identical to the silent variant', () => {
@@ -73,6 +136,7 @@ describe('loss reporting (#3520)', () => {
       '<a href="javascript:alert(1)">x</a>',
       '<p style="color:red" class="x">hi</p>',
       '<h1>big</h1><table><tr><td>c</td></tr></table>',
+      '<table><tbody><tr><td><p>a</p><p>b</p></td><td><table><tr><td>n</td></tr></table></td></tr></tbody></table>',
       '',
     ];
     for (const input of inputs) {
@@ -108,7 +172,7 @@ describe('loss reporting (#3520)', () => {
   });
 
   it('collector state does not leak between calls', () => {
-    expect(sanitizeRichTextHtmlWithReport('<table>x</table>').removedTags).toEqual(['table']);
+    expect(sanitizeRichTextHtmlWithReport('<blockquote>x</blockquote>').removedTags).toEqual(['blockquote']);
     expect(sanitizeRichTextHtmlWithReport('<p>clean</p>').removedTags).toEqual([]);
   });
 

--- a/apps/api/src/services/richTextSanitize.test.ts
+++ b/apps/api/src/services/richTextSanitize.test.ts
@@ -106,6 +106,21 @@ describe('table markup (#3484)', () => {
     expect(sanitizeRichTextHtml(once)).toBe(once);
   });
 
+  it('keeps empty cells rather than collapsing the row', () => {
+    expect(sanitizeRichTextHtml('<table><tr><td></td><td>x</td></tr></table>'))
+      .toBe('<table><tr><td></td><td>x</td></tr></table>');
+  });
+
+  it('survives cell tags that arrive unbalanced without dropping content', () => {
+    // The cell scan runs on sanitize-html output, which is balanced — but the
+    // stray-close and unclosed-cell branches must still be safe if that ever
+    // stops holding, and must never swallow the author's text.
+    expect(sanitizeRichTextHtml('</td>after')).toContain('after');
+    expect(sanitizeRichTextHtml('<table><tr><td>only')).toContain('only');
+    expect(sanitizeRichTextHtml('<table><tr><td>a<td>b</td></tr></table>')).toContain('a');
+    expect(sanitizeRichTextHtml('<table><tr><td>a<td>b</td></tr></table>')).toContain('b');
+  });
+
   it('leaves the inline profile table-free — cell/label editors are unchanged', () => {
     expect(sanitizeInlineRichText('<table><tr><td>z</td></tr></table>')).toBe('z');
   });

--- a/apps/api/src/services/richTextSanitize.ts
+++ b/apps/api/src/services/richTextSanitize.ts
@@ -1,9 +1,26 @@
 // Single source of truth for the proposal/contract rich-text subset. The same
 // list constrains the TipTap editor (apps/web RichTextEditor) and the PDF
 // renderer (richTextPdf.ts) — change all three together or not at all.
+// Browser rendering of the subset lives in apps/web (Tailwind `prose`) and
+// apps/portal (`.quote-rich-text` rules in its globals.css); both need styling
+// for any structural tag added here.
 import sanitizeHtml from 'sanitize-html';
 
-export const RICH_TEXT_ALLOWED_TAGS = ['p', 'br', 'strong', 'em', 'u', 'h3', 'h4', 'ul', 'ol', 'li', 'a'] as const;
+const RICH_TEXT_FLOW_TAGS = ['p', 'br', 'strong', 'em', 'u', 'h3', 'h4', 'ul', 'ol', 'li', 'a'] as const;
+
+/** Table structure permitted inside a `rich_text` body (issue #3484). Authors
+ *  paste real tables out of Word/Google Docs/external proposals, and before
+ *  this the whole grid collapsed into run-together text.
+ *
+ *  NO attributes are allowed on any of these — in particular `colspan` and
+ *  `rowspan` are dropped, so a merged Word cell lands in a single column
+ *  rather than spanning. Every cell's text still survives; only the merge is
+ *  lost. Spanning would have to be honoured by all three renderers (browser,
+ *  PDF grid, TipTap) to be worth allowing, and `rowspan` in particular has no
+ *  sane representation in the PDF row-at-a-time renderer. */
+export const RICH_TEXT_TABLE_TAGS = ['table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td'] as const;
+
+export const RICH_TEXT_ALLOWED_TAGS: readonly string[] = [...RICH_TEXT_FLOW_TAGS, ...RICH_TEXT_TABLE_TAGS];
 
 /** Inline-only marks for table cells / column labels: no block-level structure
  *  by design (Spec A decision #4). Shares the hardened link rules below. */
@@ -58,6 +75,94 @@ const INLINE_OPTIONS: sanitizeHtml.IOptions = {
 };
 
 const PLAIN_TEXT_OPTIONS: sanitizeHtml.IOptions = { allowedTags: [], allowedAttributes: {} };
+
+// ---------------------------------------------------------------------------
+// Table cells are inline-only (issue #3484)
+//
+// sanitize-html's allowedTags is FLAT — it has no notion of "allowed, but not
+// inside a <td>". Left at that, a `rich_text` body could carry a <p>/<ul>/
+// nested <table> inside a cell, which the browser renders natively but the PDF
+// grid (fixed-height, single wrapped run sequence per cell) cannot. Rather
+// than let the three renderers drift, cell CONTENT keeps the same inline-only
+// contract the structured `table` block already has (Spec A decision #4): the
+// pass below re-sanitizes every <td>/<th> body through the inline profile.
+//
+// Block boundaries inside a cell become <br /> instead of vanishing, so
+// Word's `<td><p>a</p><p>b</p></td>` reads "a / b" rather than "ab", and a
+// nested table's cells flatten to one line each. The tags it removes are
+// merged into the *WithReport payload (#3520), so the author is still told.
+//
+// The scan runs on sanitize-html OUTPUT, which is balanced and attribute-free
+// on these tags, and everything it re-emits is either a literal <td>/<th>
+// delimiter copied from that output or the result of another sanitize-html
+// pass — so it cannot reintroduce markup the sanitizer just removed.
+// ---------------------------------------------------------------------------
+
+/** Block-level tag boundaries inside a cell — each becomes a line break before
+ *  the inline profile discards the tag itself. Both edges are matched (not just
+ *  the closing one) so text sitting BEFORE a nested block still separates from
+ *  it; collapseBreaks then folds the runs of `<br />` this produces. */
+const CELL_BLOCK_BOUNDARY_RE = /<(\/?)(p|div|h[1-6]|li|ul|ol|tr|thead|tbody|tfoot|table|td|th)(?:\s[^>]*)?\/?>/gi;
+
+/** Matches a `<td>`/`<th>` open or close tag in sanitize-html's own output. */
+const CELL_TAG_RE = /<(\/?)(?:td|th)(?:\s[^>]*)?>/gi;
+
+function collapseBreaks(html: string): string {
+  return html
+    .replace(/(?:<br\s*\/?>\s*){2,}/gi, '<br />')
+    .replace(/^(?:\s*<br\s*\/?>\s*)+/i, '')
+    .replace(/(?:\s*<br\s*\/?>\s*)+$/i, '');
+}
+
+function normalizeCellBody(inner: string, removed?: Set<string>): string {
+  // The rewrite consumes these tags before sanitize-html can observe them, so
+  // record them here — otherwise the cell pass would strip block structure
+  // silently, which is exactly the defect #3520 fixed.
+  const withBreaks = inner.replace(CELL_BLOCK_BOUNDARY_RE, (_whole, closing: string, tag: string) => {
+    if (removed && !closing) removed.add(tag.toLowerCase());
+    return '<br />';
+  });
+  if (!removed) return collapseBreaks(sanitizeInlineRichText(withBreaks));
+  const report = sanitizeInlineRichTextWithReport(withBreaks);
+  for (const tag of report.removedTags) removed.add(tag);
+  return collapseBreaks(report.html);
+}
+
+/**
+ * Re-sanitize each outermost `<td>`/`<th>` body down to the inline profile.
+ * Idempotent (the read path re-runs it on already-normalized rows) and a no-op
+ * on HTML with no cells at all.
+ */
+function normalizeTableCells(html: string, removed?: Set<string>): string {
+  if (!html.includes('<td') && !html.includes('<th')) return html;
+  let out = '';
+  let copiedTo = 0;
+  let innerStart = 0;
+  let depth = 0;
+  CELL_TAG_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = CELL_TAG_RE.exec(html))) {
+    if (match[1] !== '/') {
+      // Only the OUTERMOST cell is rewritten; cells of a nested table are part
+      // of that body and get flattened by the inline pass along with it.
+      if (depth === 0) {
+        out += html.slice(copiedTo, CELL_TAG_RE.lastIndex);
+        innerStart = CELL_TAG_RE.lastIndex;
+      }
+      depth += 1;
+      continue;
+    }
+    if (depth === 0) continue; // stray `</td>` with no open tag — copy verbatim
+    depth -= 1;
+    if (depth === 0) {
+      out += normalizeCellBody(html.slice(innerStart, match.index), removed);
+      copiedTo = match.index; // resume at the closing tag, keeping it as-is
+    }
+  }
+  // An unclosed final cell leaves copiedTo before its body, so the tail below
+  // still copies the original bytes rather than dropping them.
+  return out + html.slice(copiedTo);
+}
 
 // ---------------------------------------------------------------------------
 // Loss reporting (issue #3520)
@@ -116,6 +221,7 @@ function sanitizeWithReport(
   input: string,
   options: sanitizeHtml.IOptions,
   allowedTags: readonly string[],
+  normalizeCells = false,
 ): RichTextSanitizeReport {
   const allowed = new Set<string>(allowedTags);
   const removed = new Set<string>();
@@ -126,21 +232,25 @@ function sanitizeWithReport(
       if (!allowed.has(name)) removed.add(name);
     },
   });
-  return { html, removedTags: [...removed].sort() };
+  // The cell pass removes tags the OUTER profile allows (a <p> or a nested
+  // <table> is fine in the body, not in a cell), so its own removals are
+  // merged in here — otherwise those strips would be silent again.
+  const normalized = normalizeCells ? normalizeTableCells(html, removed) : html;
+  return { html: normalized, removedTags: [...removed].sort() };
 }
 
 /** Sanitize author/tenant HTML down to the proposal rich-text subset.
  * Applied at WRITE (store only clean content) and again at READ serialization
  * (defense in depth + covers rows written before this module existed). */
 export function sanitizeRichTextHtml(html: string): string {
-  return sanitizeHtml(html ?? '', OPTIONS);
+  return normalizeTableCells(sanitizeHtml(html ?? '', OPTIONS));
 }
 
 /** `sanitizeRichTextHtml` + a report of the tags it discarded. Use on WRITE
  * paths so the author is told what was dropped; the read/render paths keep
  * using the silent variant (a legacy row must still render, not warn). */
 export function sanitizeRichTextHtmlWithReport(html: string): RichTextSanitizeReport {
-  return sanitizeWithReport(html, OPTIONS, RICH_TEXT_ALLOWED_TAGS);
+  return sanitizeWithReport(html, OPTIONS, RICH_TEXT_ALLOWED_TAGS, true);
 }
 
 /** Sanitize author/tenant HTML down to inline marks only (no block structure) —

--- a/apps/api/src/services/richTextSanitize.ts
+++ b/apps/api/src/services/richTextSanitize.ts
@@ -107,11 +107,21 @@ const CELL_BLOCK_BOUNDARY_RE = /<(\/?)(p|div|h[1-6]|li|ul|ol|tr|thead|tbody|tfoo
 /** Matches a `<td>`/`<th>` open or close tag in sanitize-html's own output. */
 const CELL_TAG_RE = /<(\/?)(?:td|th)(?:\s[^>]*)?>/gi;
 
+/** Line-break token as sanitize-html emits it. */
+const BREAK = '<br />';
+/** Single break tag — deliberately NOT a repeated group. A `(?:<br…>\s*){2,}`
+ *  form reads more directly but trips CodeQL's ReDoS rule (js/redos), so the
+ *  runs are collapsed by splitting on ONE break and rejoining, which is linear
+ *  in the input by construction. */
+const SINGLE_BREAK_RE = /<br\s*\/?>/i;
+
+/** Drop the empty segments that a run of `<br />` (or a leading/trailing one)
+ *  produces, so `<p>a</p><p>b</p>` reads "a / b" and not "/ a // b /". */
 function collapseBreaks(html: string): string {
   return html
-    .replace(/(?:<br\s*\/?>\s*){2,}/gi, '<br />')
-    .replace(/^(?:\s*<br\s*\/?>\s*)+/i, '')
-    .replace(/(?:\s*<br\s*\/?>\s*)+$/i, '');
+    .split(SINGLE_BREAK_RE)
+    .filter((segment) => segment.trim().length > 0)
+    .join(BREAK);
 }
 
 function normalizeCellBody(inner: string, removed?: Set<string>): string {
@@ -120,7 +130,7 @@ function normalizeCellBody(inner: string, removed?: Set<string>): string {
   // silently, which is exactly the defect #3520 fixed.
   const withBreaks = inner.replace(CELL_BLOCK_BOUNDARY_RE, (_whole, closing: string, tag: string) => {
     if (removed && !closing) removed.add(tag.toLowerCase());
-    return '<br />';
+    return BREAK;
   });
   if (!removed) return collapseBreaks(sanitizeInlineRichText(withBreaks));
   const report = sanitizeInlineRichTextWithReport(withBreaks);

--- a/apps/portal/src/styles/globals.css
+++ b/apps/portal/src/styles/globals.css
@@ -149,7 +149,8 @@
   /*
    * rich_text quote blocks (quoteBlocks.tsx) render sanitized author HTML via
    * dangerouslySetInnerHTML — the API guarantees only richTextSanitize.ts's fixed
-   * subset (p/br/strong/em/u/h3/h4/ul/ol/li/a) ever reaches this class. Tailwind's
+   * subset (p/br/strong/em/u/h3/h4/ul/ol/li/a + table/thead/tbody/tfoot/tr/th/td)
+   * ever reaches this class. Tailwind's
    * base reset strips list markers and heading weight, so restore the minimal
    * styling that subset needs.
    */
@@ -184,6 +185,22 @@
   }
   .quote-rich-text a {
     @apply text-primary underline underline-offset-2;
+  }
+  /* Tables inside rich_text (issue #3484). The portal deliberately does not
+   * pull in Tailwind's typography plugin (apps/web gets table styling from
+   * `prose` for free), so the grid has to be drawn by hand here — without it a
+   * customer-facing proposal shows a borderless run of cells. Kept visually in
+   * step with the PDF renderer's table (richTextPdf.ts): tinted header row,
+   * hairline borders, no zebra. */
+  .quote-rich-text table {
+    @apply mb-3 w-full table-auto border-collapse text-left text-sm last:mb-0;
+  }
+  .quote-rich-text th,
+  .quote-rich-text td {
+    @apply border border-border px-2 py-1 align-top;
+  }
+  .quote-rich-text th {
+    @apply bg-muted font-semibold text-foreground;
   }
 }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "@tanstack/react-query": "^5.101.4",
     "@tiptap/core": "^3.28.0",
     "@tiptap/extension-link": "^3.28.0",
+    "@tiptap/extension-table": "^3.30.1",
     "@tiptap/extension-underline": "^3.29.1",
     "@tiptap/pm": "^3.28.0",
     "@tiptap/react": "^3.29.1",

--- a/apps/web/src/components/billing/quotes/QuoteEditor.strippedmarkup.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.strippedmarkup.test.tsx
@@ -96,16 +96,16 @@ describe('QuoteEditor — stripped-markup warning toast (#3520)', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('adding a rich_text block whose response carries warnings fires a warning toast naming the removed tags', async () => {
-    addBlockMock.mockResolvedValue(okRes({ id: 'blk-rt' }, removedTagsWarning(['blockquote', 'table'])));
+    addBlockMock.mockResolvedValue(okRes({ id: 'blk-rt' }, removedTagsWarning(['blockquote', 'pre'])));
     await openRichTextForm();
 
-    fireEvent.change(screen.getByTestId('quote-block-rich-text-editor'), { target: { value: '<table><tr><td>x</td></tr></table>' } });
+    fireEvent.change(screen.getByTestId('quote-block-rich-text-editor'), { target: { value: '<blockquote>q</blockquote><pre>code</pre>' } });
     fireEvent.click(screen.getByTestId('quote-add-block-submit'));
 
     await waitFor(() => expect(addBlockMock).toHaveBeenCalled());
     await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
       type: 'warning',
-      message: expect.stringContaining('table'),
+      message: expect.stringContaining('pre'),
     })));
     const warningCall = showToast.mock.calls.find((c) => (c[0] as { type: string }).type === 'warning');
     expect(warningCall?.[0]).toEqual(expect.objectContaining({ message: expect.stringContaining('blockquote') }));

--- a/apps/web/src/components/common/RichTextEditor.test.tsx
+++ b/apps/web/src/components/common/RichTextEditor.test.tsx
@@ -54,6 +54,7 @@ const TOOLBAR_TESTIDS = [
   'rte-bullet-list',
   'rte-ordered-list',
   'rte-link',
+  'rte-insert-table',
 ];
 
 describe('RichTextEditor', () => {
@@ -180,5 +181,60 @@ describe('RichTextEditor', () => {
     expect(editable.querySelector('pre')).toBeNull();
     expect(editable.querySelector('code')).toBeNull();
     expect(editable.textContent).toContain('Body');
+  });
+
+  // Issue #3484: tables are part of the subset now. What matters here is that
+  // the editor emits EXACTLY the shape the API sanitizer keeps — anything else
+  // (an inline width style, a <colgroup>, default colspan/rowspan attributes, a
+  // <p> wrapper inside a cell) is rewritten server-side, which leaves the block
+  // permanently dirty and toasts a bogus "markup removed" warning on every blur.
+  describe('tables (#3484)', () => {
+    it('emits attribute-free <table><tbody><tr><th|td> with no colgroup or width style', async () => {
+      const onChange = vi.fn();
+      render(
+        <RichTextEditor value="<p>Hello</p>" onChange={onChange} ariaLabel="Proposal text" testId="rte-test" />,
+      );
+
+      fireEvent.click(screen.getByTestId('rte-insert-table'));
+      await waitFor(() => expect(onChange).toHaveBeenCalled());
+      const emitted = onChange.mock.calls.at(-1)?.[0] as string;
+
+      expect(emitted).toContain('<table><tbody><tr><th></th>');
+      expect(emitted).not.toMatch(/<colgroup|<col\b/);
+      expect(emitted).not.toMatch(/<table[^>]+>/); // no attributes on <table>
+      expect(emitted).not.toMatch(/<(?:td|th)[^>]+>/); // no colspan/rowspan/colwidth
+      // Cells are inline-only: no paragraph wrapper for the sanitizer to flatten.
+      expect(emitted).not.toMatch(/<(?:td|th)><p>/);
+    });
+
+    it('reveals row/column controls only while the caret is inside a table', async () => {
+      render(
+        <RichTextEditor value="<p>Hello</p>" onChange={() => {}} ariaLabel="Proposal text" testId="rte-test" />,
+      );
+      expect(screen.queryByTestId('rte-table-add-row')).toBeNull();
+
+      fireEvent.click(screen.getByTestId('rte-insert-table'));
+
+      await waitFor(() => expect(screen.getByTestId('rte-table-add-row')).toBeInTheDocument());
+      for (const testId of ['rte-table-delete-row', 'rte-table-add-column', 'rte-table-delete-column', 'rte-table-delete']) {
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+      }
+    });
+
+    it('renders a stored table value instead of collapsing it to text', () => {
+      render(
+        <RichTextEditor
+          value="<table><thead><tr><th>Item</th><th>Price</th></tr></thead><tbody><tr><td>Setup</td><td>$500</td></tr></tbody></table>"
+          onChange={() => {}}
+          ariaLabel="Proposal text"
+          testId="rte-test"
+        />,
+      );
+      const editable = screen.getByTestId('rte-test');
+      expect(editable.querySelector('table')).not.toBeNull();
+      expect(editable.querySelectorAll('tr')).toHaveLength(2);
+      expect(editable.querySelector('th')?.textContent).toBe('Item');
+      expect(editable.textContent).toContain('$500');
+    });
   });
 });

--- a/apps/web/src/components/common/RichTextEditor.test.tsx
+++ b/apps/web/src/components/common/RichTextEditor.test.tsx
@@ -221,6 +221,29 @@ describe('RichTextEditor', () => {
       }
     });
 
+    it('splits a merged (colspan) cell instead of desyncing the model from the DOM', () => {
+      // A Word/Google-Docs table routinely carries colspan. TipTap parses it
+      // into a real span on the node, so suppressing the attribute at render
+      // time alone would draw fewer <td>s than the model spans — misaligning
+      // the table in the editor and desyncing cell hit-testing. Clamping on
+      // parse makes prosemirror-tables pad the row into a proper grid instead.
+      const onChange = vi.fn();
+      render(
+        <RichTextEditor
+          value="<table><tbody><tr><td colspan='2'>merged</td></tr><tr><td>b</td><td>c</td></tr></tbody></table>"
+          onChange={onChange}
+          ariaLabel="Proposal text"
+          testId="rte-test"
+        />,
+      );
+      const rows = screen.getByTestId('rte-test').querySelectorAll('tr');
+      expect(rows).toHaveLength(2);
+      // Every row is rendered with the same physical cell count.
+      expect(rows[0]!.querySelectorAll('td')).toHaveLength(rows[1]!.querySelectorAll('td').length);
+      expect(rows[0]!.querySelector('td')?.getAttribute('colspan')).toBeNull();
+      expect(screen.getByTestId('rte-test').textContent).toContain('merged');
+    });
+
     it('renders a stored table value instead of collapsing it to text', () => {
       render(
         <RichTextEditor

--- a/apps/web/src/components/common/RichTextEditor.tsx
+++ b/apps/web/src/components/common/RichTextEditor.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { EditorContent, useEditor, type Editor } from '@tiptap/react';
+import { EditorContent, useEditor, useEditorState, type Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Link from '@tiptap/extension-link';
+import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table';
 
 export interface RichTextEditorProps {
   /** Current HTML value (already constrained to the sanitizer subset). */
@@ -33,15 +34,65 @@ function isHttpOrHttpsUri(uri: string): boolean {
   return scheme === 'http' || scheme === 'https';
 }
 
+// The editor's table nodes are trimmed to exactly what the sanitizer keeps
+// (issue #3484): bare `<table><tbody><tr><td>`, no attributes, cells inline-only.
+//
+// Every deviation below exists because the sanitizer would rewrite TipTap's
+// default output, and `getHTML()` that doesn't round-trip byte-for-byte leaves
+// the block permanently "unsaved" — it re-PATCHes on every blur, and (since
+// #3520) toasts a spurious "markup removed" warning each time. Specifically:
+// TipTap renders `<table style="min-width:…">` with a `<colgroup>`, and cells
+// carry `colspan`/`rowspan`/`colwidth` attributes even at their defaults.
+//
+// The attributes stay in the SCHEMA (prosemirror-tables' TableMap needs
+// colspan/rowspan to exist) and are suppressed only at render time.
+const suppressAttribute = { renderHTML: () => ({}) };
+
+function inlineOnlyCell<T extends typeof TableCell | typeof TableHeader>(node: T) {
+  return node.extend({
+    // Cells hold inline marks only, matching the sanitizer's cell contract and
+    // the structured table block's Spec A decision #4. Default is 'block+',
+    // which would emit `<td><p>x</p></td>` for the sanitizer to flatten.
+    content: 'inline*',
+    addAttributes() {
+      const inherited: Record<string, unknown> = this.parent?.() ?? {};
+      const suppressed = Object.fromEntries(
+        ['colspan', 'rowspan', 'colwidth']
+          .filter((name) => name in inherited)
+          .map((name) => [name, { ...(inherited[name] as object), ...suppressAttribute }]),
+      );
+      return { ...inherited, ...suppressed };
+    },
+  });
+}
+
+const PlainTable = Table.extend({
+  // Drop the inline width style and the <colgroup>; emit the plain
+  // `<table><tbody>…` shape the sanitizer allows.
+  renderHTML() {
+    return ['table', ['tbody', 0]];
+  },
+});
+
 // The editor is deliberately constrained to the rich-text subset the API
-// sanitizer accepts: p, br, strong, em, u, h3, h4, ul, ol, li, a[href]. Anything
-// StarterKit would otherwise add (code, code blocks, blockquotes, strike,
-// horizontal rules) is disabled so the editor can never emit markup the server
-// would strip. Link + Underline are added standalone (StarterKit's own copies
-// are disabled below to avoid duplicate-extension registration) so we can pin
-// safe protocols and non-navigating links.
+// sanitizer accepts: p, br, strong, em, u, h3, h4, ul, ol, li, a[href], plus
+// table/tbody/tr/th/td. Anything StarterKit would otherwise add (code, code
+// blocks, blockquotes, strike, horizontal rules) is disabled so the editor can
+// never emit markup the server would strip. Link + Underline are added
+// standalone (StarterKit's own copies are disabled below to avoid
+// duplicate-extension registration) so we can pin safe protocols and
+// non-navigating links.
 function buildExtensions() {
   return [
+    PlainTable.configure({
+      // No column resizing: a resized column stores `colwidth`, which the
+      // sanitizer drops — and there is no width to honour in the PDF renderer,
+      // which infers column widths from content.
+      resizable: false,
+    }),
+    TableRow,
+    inlineOnlyCell(TableHeader),
+    inlineOnlyCell(TableCell),
     StarterKit.configure({
       heading: { levels: [3, 4] },
       code: false,
@@ -103,6 +154,25 @@ function ToolbarButton({ testId, label, isActive, onClick }: ToolbarButtonProps)
 
 function Toolbar({ editor }: { editor: Editor }) {
   const { t } = useTranslation('common');
+  // `useEditor` does not re-render on every transaction in TipTap 3, so reading
+  // `editor.isActive(...)` straight in the render body leaves the toolbar
+  // showing the state as of the last React render — which for the table
+  // controls means they never appear. `useEditorState` subscribes properly.
+  const active = useEditorState({
+    editor,
+    selector: ({ editor: e }) => ({
+      bold: e.isActive('bold'),
+      italic: e.isActive('italic'),
+      underline: e.isActive('underline'),
+      heading3: e.isActive('heading', { level: 3 }),
+      heading4: e.isActive('heading', { level: 4 }),
+      bulletList: e.isActive('bulletList'),
+      orderedList: e.isActive('orderedList'),
+      link: e.isActive('link'),
+      table: e.isActive('table'),
+    }),
+  });
+  const inTable = active.table;
   const setLink = () => {
     const previous = editor.getAttributes('link').href as string | undefined;
     const input = window.prompt(t('richTextEditor.linkPrompt'), previous ?? 'https://');
@@ -130,54 +200,99 @@ function Toolbar({ editor }: { editor: Editor }) {
       <ToolbarButton
         testId="rte-bold"
         label={t('richTextEditor.bold')}
-        isActive={editor.isActive('bold')}
+        isActive={active.bold}
         onClick={() => editor.chain().focus().toggleBold().run()}
       />
       <ToolbarButton
         testId="rte-italic"
         label={t('richTextEditor.italic')}
-        isActive={editor.isActive('italic')}
+        isActive={active.italic}
         onClick={() => editor.chain().focus().toggleItalic().run()}
       />
       <ToolbarButton
         testId="rte-underline"
         label={t('richTextEditor.underline')}
-        isActive={editor.isActive('underline')}
+        isActive={active.underline}
         onClick={() => editor.chain().focus().toggleUnderline().run()}
       />
       <span className="mx-1 h-4 w-px bg-border" aria-hidden="true" />
       <ToolbarButton
         testId="rte-h3"
         label={t('richTextEditor.heading3')}
-        isActive={editor.isActive('heading', { level: 3 })}
+        isActive={active.heading3}
         onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
       />
       <ToolbarButton
         testId="rte-h4"
         label={t('richTextEditor.heading4')}
-        isActive={editor.isActive('heading', { level: 4 })}
+        isActive={active.heading4}
         onClick={() => editor.chain().focus().toggleHeading({ level: 4 }).run()}
       />
       <span className="mx-1 h-4 w-px bg-border" aria-hidden="true" />
       <ToolbarButton
         testId="rte-bullet-list"
         label={t('richTextEditor.bulletList')}
-        isActive={editor.isActive('bulletList')}
+        isActive={active.bulletList}
         onClick={() => editor.chain().focus().toggleBulletList().run()}
       />
       <ToolbarButton
         testId="rte-ordered-list"
         label={t('richTextEditor.orderedList')}
-        isActive={editor.isActive('orderedList')}
+        isActive={active.orderedList}
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
       />
       <span className="mx-1 h-4 w-px bg-border" aria-hidden="true" />
       <ToolbarButton
         testId="rte-link"
         label={t('richTextEditor.link')}
-        isActive={editor.isActive('link')}
+        isActive={active.link}
         onClick={setLink}
       />
+      <span className="mx-1 h-4 w-px bg-border" aria-hidden="true" />
+      <ToolbarButton
+        testId="rte-insert-table"
+        label={t('richTextEditor.insertTable')}
+        isActive={inTable}
+        onClick={() =>
+          editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run()
+        }
+      />
+      {/* Row/column controls only mean anything with the caret inside a table,
+          and the toolbar is already dense — keep them out of the way until then. */}
+      {inTable && (
+        <>
+          <ToolbarButton
+            testId="rte-table-add-row"
+            label={t('richTextEditor.addRow')}
+            isActive={false}
+            onClick={() => editor.chain().focus().addRowAfter().run()}
+          />
+          <ToolbarButton
+            testId="rte-table-delete-row"
+            label={t('richTextEditor.deleteRow')}
+            isActive={false}
+            onClick={() => editor.chain().focus().deleteRow().run()}
+          />
+          <ToolbarButton
+            testId="rte-table-add-column"
+            label={t('richTextEditor.addColumn')}
+            isActive={false}
+            onClick={() => editor.chain().focus().addColumnAfter().run()}
+          />
+          <ToolbarButton
+            testId="rte-table-delete-column"
+            label={t('richTextEditor.deleteColumn')}
+            isActive={false}
+            onClick={() => editor.chain().focus().deleteColumn().run()}
+          />
+          <ToolbarButton
+            testId="rte-table-delete"
+            label={t('richTextEditor.deleteTable')}
+            isActive={false}
+            onClick={() => editor.chain().focus().deleteTable().run()}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/common/RichTextEditor.tsx
+++ b/apps/web/src/components/common/RichTextEditor.tsx
@@ -45,8 +45,26 @@ function isHttpOrHttpsUri(uri: string): boolean {
 // carry `colspan`/`rowspan`/`colwidth` attributes even at their defaults.
 //
 // The attributes stay in the SCHEMA (prosemirror-tables' TableMap needs
-// colspan/rowspan to exist) and are suppressed only at render time.
-const suppressAttribute = { renderHTML: () => ({}) };
+// colspan/rowspan to exist) but are pinned to their unmerged defaults on PARSE
+// and emitted by nobody on render.
+//
+// Pinning on parse is not belt-and-braces: TipTap's TableCell gives colspan and
+// rowspan no parseHTML override, so a pasted `<td colspan="2">` — routine in a
+// Word/Google-Docs table, the case this whole feature exists for — sets a real
+// span on the ProseMirror node. Suppressing it at render only would then leave
+// the row drawing FEWER <td> elements than the model believes it spans: the
+// table visibly misaligns inside the editor, and tableEditing's DOM-based cell
+// hit-testing (drag-select, Tab) desyncs from the TableMap. Clamping on parse
+// makes the merge split into ordinary cells instead, which prosemirror-tables
+// then pads out to a rectangular grid — the honest outcome, since merges are
+// unsupported end to end (see RICH_TEXT_TABLE_TAGS in richTextSanitize.ts).
+const unmergedSpan = { parseHTML: () => 1, renderHTML: () => ({}) };
+const noColumnWidth = { parseHTML: () => null, renderHTML: () => ({}) };
+const CELL_ATTRIBUTE_OVERRIDES: Record<string, object> = {
+  colspan: unmergedSpan,
+  rowspan: unmergedSpan,
+  colwidth: noColumnWidth,
+};
 
 function inlineOnlyCell<T extends typeof TableCell | typeof TableHeader>(node: T) {
   return node.extend({
@@ -56,12 +74,12 @@ function inlineOnlyCell<T extends typeof TableCell | typeof TableHeader>(node: T
     content: 'inline*',
     addAttributes() {
       const inherited: Record<string, unknown> = this.parent?.() ?? {};
-      const suppressed = Object.fromEntries(
-        ['colspan', 'rowspan', 'colwidth']
-          .filter((name) => name in inherited)
-          .map((name) => [name, { ...(inherited[name] as object), ...suppressAttribute }]),
+      const overridden = Object.fromEntries(
+        Object.entries(CELL_ATTRIBUTE_OVERRIDES)
+          .filter(([name]) => name in inherited)
+          .map(([name, override]) => [name, { ...(inherited[name] as object), ...override }]),
       );
-      return { ...inherited, ...suppressed };
+      return { ...inherited, ...overridden };
     },
   });
 }

--- a/apps/web/src/components/contracts/TemplateEditor.strippedmarkup.test.tsx
+++ b/apps/web/src/components/contracts/TemplateEditor.strippedmarkup.test.tsx
@@ -86,20 +86,20 @@ describe('TemplateEditor — stripped-markup warning toast (#3520)', () => {
 
   it('saving a draft whose response carries warnings fires the warning toast naming the removed tags, not the success toast', async () => {
     api.createTemplateVersion.mockResolvedValue(
-      okRes({ ...draftVersion, id: 'ver-2', versionNumber: 2 }, removedTagsWarning(['blockquote', 'table'])),
+      okRes({ ...draftVersion, id: 'ver-2', versionNumber: 2 }, removedTagsWarning(['blockquote', 'pre'])),
     );
 
     render(<TemplateEditor templateId="tpl-1" />);
     await screen.findByTestId('contract-template-editor');
 
     const editor = screen.getByTestId('template-body-editor') as HTMLTextAreaElement;
-    fireEvent.change(editor, { target: { value: '<table><tr><td>x</td></tr></table>' } });
+    fireEvent.change(editor, { target: { value: '<blockquote>q</blockquote><pre>code</pre>' } });
     fireEvent.click(screen.getByTestId('template-save-draft-btn'));
 
     await waitFor(() => expect(api.createTemplateVersion).toHaveBeenCalled());
     await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
       type: 'warning',
-      message: expect.stringContaining('table'),
+      message: expect.stringContaining('pre'),
     })));
     const warningCall = showToast.mock.calls.find((c) => (c[0] as { type: string }).type === 'warning');
     expect(warningCall?.[0]).toEqual(expect.objectContaining({ message: expect.stringContaining('blockquote') }));

--- a/apps/web/src/lib/richTextWarnings.ts
+++ b/apps/web/src/lib/richTextWarnings.ts
@@ -1,10 +1,13 @@
 /**
  * Client side of the rich-text loss report (issue #3520).
  *
- * The API's rich-text subset is narrow (11 block tags, 5 inline marks), and
- * sanitize-html discards anything outside it. Block/version writes used to 200
- * with the extra markup quietly gone, so an author who pasted a `<table>` or a
- * `<blockquote>` only found out by noticing their content missing later.
+ * The API's rich-text subset is narrow (a fixed list of block, table and inline
+ * tags — see richTextSanitize.ts), and sanitize-html discards anything outside
+ * it. Block/version writes used to 200 with the extra markup quietly gone, so
+ * an author who pasted a `<blockquote>` or an `<img>` only found out by
+ * noticing their content missing later. (Tables themselves now survive —
+ * issue #3484 — but block content inside a CELL is still flattened, and that
+ * flattening is reported through this same channel.)
  *
  * Those write responses now carry a top-level `warnings` array naming what was
  * removed. This module turns that array into the tag list a toast can show;

--- a/apps/web/src/locales/de-DE/common.json
+++ b/apps/web/src/locales/de-DE/common.json
@@ -82,7 +82,13 @@
     "orderedList": "Nummerierte Liste",
     "link": "Link",
     "linkPrompt": "Geben Sie eine URL ein (http:// oder https://)",
-    "linkInvalid": "Nur http://- und https://-Links sind zulässig"
+    "linkInvalid": "Nur http://- und https://-Links sind zulässig",
+    "insertTable": "Tabelle",
+    "addRow": "Zeile hinzufügen",
+    "deleteRow": "Zeile löschen",
+    "addColumn": "Spalte hinzufügen",
+    "deleteColumn": "Spalte löschen",
+    "deleteTable": "Tabelle löschen"
   },
   "actions": {
     "save": "Speichern",

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -82,7 +82,13 @@
     "orderedList": "Numbered list",
     "link": "Link",
     "linkPrompt": "Enter a URL (http:// or https://)",
-    "linkInvalid": "Only http:// and https:// links are allowed"
+    "linkInvalid": "Only http:// and https:// links are allowed",
+    "insertTable": "Table",
+    "addRow": "Add row",
+    "deleteRow": "Delete row",
+    "addColumn": "Add column",
+    "deleteColumn": "Delete column",
+    "deleteTable": "Delete table"
   },
   "actions": {
     "save": "Save",

--- a/apps/web/src/locales/es-419/common.json
+++ b/apps/web/src/locales/es-419/common.json
@@ -82,7 +82,13 @@
     "orderedList": "Lista numerada",
     "link": "Enlace",
     "linkPrompt": "Introduce una URL (http:// o https://)",
-    "linkInvalid": "Solo se permiten enlaces http:// y https://"
+    "linkInvalid": "Solo se permiten enlaces http:// y https://",
+    "insertTable": "Tabla",
+    "addRow": "Agregar fila",
+    "deleteRow": "Eliminar fila",
+    "addColumn": "Agregar columna",
+    "deleteColumn": "Eliminar columna",
+    "deleteTable": "Eliminar tabla"
   },
   "actions": {
     "save": "Guardar",

--- a/apps/web/src/locales/fr-CA/common.json
+++ b/apps/web/src/locales/fr-CA/common.json
@@ -82,7 +82,13 @@
     "orderedList": "Liste numérotée",
     "link": "Lien",
     "linkPrompt": "Saisissez une URL (http:// ou https://)",
-    "linkInvalid": "Seuls les liens http:// et https:// sont autorisés"
+    "linkInvalid": "Seuls les liens http:// et https:// sont autorisés",
+    "insertTable": "Tableau",
+    "addRow": "Ajouter une ligne",
+    "deleteRow": "Supprimer la ligne",
+    "addColumn": "Ajouter une colonne",
+    "deleteColumn": "Supprimer la colonne",
+    "deleteTable": "Supprimer le tableau"
   },
   "actions": {
     "save": "Enregistrer",

--- a/apps/web/src/locales/fr-FR/common.json
+++ b/apps/web/src/locales/fr-FR/common.json
@@ -82,7 +82,13 @@
     "orderedList": "Liste numérotée",
     "link": "Lien",
     "linkPrompt": "Saisissez une URL (http:// ou https://)",
-    "linkInvalid": "Seuls les liens http:// et https:// sont autorisés"
+    "linkInvalid": "Seuls les liens http:// et https:// sont autorisés",
+    "insertTable": "Tableau",
+    "addRow": "Ajouter une ligne",
+    "deleteRow": "Supprimer la ligne",
+    "addColumn": "Ajouter une colonne",
+    "deleteColumn": "Supprimer la colonne",
+    "deleteTable": "Supprimer le tableau"
   },
   "actions": {
     "save": "Enregistrer",

--- a/apps/web/src/locales/it-IT/common.json
+++ b/apps/web/src/locales/it-IT/common.json
@@ -82,7 +82,13 @@
     "orderedList": "Elenco numerato",
     "link": "Collegamento",
     "linkPrompt": "Inserisci un URL (http:// o https://)",
-    "linkInvalid": "Sono consentiti solo i collegamenti http:// e https://"
+    "linkInvalid": "Sono consentiti solo i collegamenti http:// e https://",
+    "insertTable": "Tabella",
+    "addRow": "Aggiungi riga",
+    "deleteRow": "Elimina riga",
+    "addColumn": "Aggiungi colonna",
+    "deleteColumn": "Elimina colonna",
+    "deleteTable": "Elimina tabella"
   },
   "actions": {
     "save": "Salva",

--- a/apps/web/src/locales/pt-BR/common.json
+++ b/apps/web/src/locales/pt-BR/common.json
@@ -82,7 +82,13 @@
     "orderedList": "Lista numerada",
     "link": "Link",
     "linkPrompt": "Insira uma URL (http:// ou https://)",
-    "linkInvalid": "Somente links http:// e https:// são permitidos"
+    "linkInvalid": "Somente links http:// e https:// são permitidos",
+    "insertTable": "Tabela",
+    "addRow": "Adicionar linha",
+    "deleteRow": "Excluir linha",
+    "addColumn": "Adicionar coluna",
+    "deleteColumn": "Excluir coluna",
+    "deleteTable": "Excluir tabela"
   },
   "actions": {
     "save": "Salvar",

--- a/apps/web/src/locales/tr-TR/common.json
+++ b/apps/web/src/locales/tr-TR/common.json
@@ -82,7 +82,13 @@
     "orderedList": "Numaralı liste",
     "link": "Bağlantı",
     "linkPrompt": "Bir URL girin (http:// veya https://)",
-    "linkInvalid": "Yalnızca http:// ve https:// bağlantılarına izin verilir"
+    "linkInvalid": "Yalnızca http:// ve https:// bağlantılarına izin verilir",
+    "insertTable": "Tablo",
+    "addRow": "Satır ekle",
+    "deleteRow": "Satırı sil",
+    "addColumn": "Sütun ekle",
+    "deleteColumn": "Sütunu sil",
+    "deleteTable": "Tabloyu sil"
   },
   "actions": {
     "save": "Kaydet",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -984,6 +984,9 @@ importers:
       '@tiptap/extension-link':
         specifier: ^3.28.0
         version: 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+      '@tiptap/extension-table':
+        specifier: ^3.30.1
+        version: 3.30.1(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
       '@tiptap/extension-underline':
         specifier: ^3.29.1
         version: 3.29.1(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
@@ -5278,6 +5281,12 @@ packages:
     resolution: {integrity: sha512-VVj2ZZU9QYqiHLcjqMqRYvuHSsokj/AgUl+6TzLrKjlWwyZ18D4H2vkyI0g70iVTKnUpZ3sEy8WA/rqjgBjqBg==}
     peerDependencies:
       '@tiptap/core': 3.28.0
+
+  '@tiptap/extension-table@3.30.1':
+    resolution: {integrity: sha512-frZvuNbgi4ohLGeweHMfKWoCVAlCUB/BULgzjLMaFSaSpVGk2KVeoYtCJf9wR240IAj3t7tti3A7E4Ymz98qOQ==}
+    peerDependencies:
+      '@tiptap/core': 3.30.1
+      '@tiptap/pm': 3.30.1
 
   '@tiptap/extension-text@3.28.0':
     resolution: {integrity: sha512-Jqp1LgfY1mnp4TQHoy+vnHyfn6qnnAM6nHgGwbY5zA8b/Xf1Etll6pziTx9p1J1qcfAgSrnjOyAmA++H7VQqww==}
@@ -15439,7 +15448,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.2': {}
 
@@ -16389,6 +16400,11 @@ snapshots:
   '@tiptap/extension-strike@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
     dependencies:
       '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-table@3.30.1(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@tiptap/pm': 3.28.0
 
   '@tiptap/extension-text@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
     dependencies:


### PR DESCRIPTION
Closes #3484

## The bug

`RICH_TEXT_ALLOWED_TAGS` had no table entries, so pasting a real table into a quote/contract `rich_text` block dropped every structural tag and left the cell text concatenated. #3520 / #3667 made that loss *visible* (write responses now carry a `warnings` array, the editor toasts it) and explicitly deferred the other half — actually letting tables through — to this issue.

## What changed

**`richTextSanitize.ts` — the one list the editor, the browser render and the PDF renderer all agree on**

- `table thead tbody tfoot tr th td` are allowed, with **no attributes**.
- **`colspan`/`rowspan` are deliberately not allowed.** A span only pays off if all three renderers honour it, and `rowspan` has no representation in a row-at-a-time PDF renderer. A merged Word cell lands in one column instead of spanning; every cell's *text* still survives.
- **Cells stay inline-only**, keeping the contract the structured `table` block already has (Spec A decision #4) — the question the sibling PR flagged. Enforcement is a post-sanitize pass that re-runs each `<td>`/`<th>` body through the inline profile. `sanitize-html`'s `allowedTags` is flat, so without this a cell could hold a `<p>`/`<ul>`/nested `<table>` that the browser renders natively and the fixed-height PDF cell cannot — exactly the three-renderer drift this module exists to prevent.
- Block boundaries inside a cell become `<br />` rather than vanishing, so Word's `<td><p>a</p><p>b</p></td>` reads "a / b" instead of "ab", and a nested table's cells flatten one per line.
- Everything the cell pass removes is **merged into the `*WithReport` payload**, so #3520's toast still fires — the flattening is not a new silent strip. The scan runs on `sanitize-html` output (balanced, attribute-free) and re-emits only literal `<td>`/`<th>` delimiters copied from it or the output of another `sanitize-html` pass, so it cannot reintroduce markup.

**`richTextPdf.ts` — tables get drawn**

- `RichTextBlock` becomes a union; `parseRichText` emits a `table` block of rows of inline-run cells, collected through `thead`/`tbody`/`tfoot` (and straight off `<table>`, which is what a bare `<table><tr>` paste produces). A `<tr>`/`<td>` orphaned from its `<table>` folds into an implicit paragraph rather than disappearing from the PDF while still rendering in HTML.
- The grid draws with content-inferred column widths (HTML carries no weights; the weight is the longest plain-text cell, clamped so one prose-heavy column can't starve the rest), a tinted repeated header row, hairline borders, rows that never split, and an oversized-row degrade to stacked "header: value" paragraphs.
- Page breaks are detected from `doc.y` — the trick the block loop already used — so `renderRichTextIntoPdf`'s public `ensureRoom: (needed) => number` signature and all four call sites are unchanged.
- **Not `tablePdf.ts`.** That module renders the *structured* `table` block type, whose author-supplied weights/zebra/header-style have no counterpart in pasted HTML, and it imports this module — the dependency can only run one way. What the two share is the cell primitive (`drawRuns`/`measureRuns`, factored out of the existing inline exports).

**`RichTextEditor.tsx` — TipTap emits exactly what the sanitizer keeps**

TipTap's defaults would not round-trip: `<table style="min-width:…">` with a `<colgroup>`, cells carrying `colspan`/`rowspan`/`colwidth` even at defaults, and `<p>` inside every cell. A `getHTML()` that the sanitizer rewrites leaves the block permanently "unsaved" — it re-PATCHes on every blur and (since #3520) toasts a bogus "markup removed" warning each time, the same trap the `rel="nofollow"` override already documents. So: `renderHTML` overridden to a plain `<table><tbody>`, resizing off, cell attributes suppressed **at render time only** (they stay in the schema — prosemirror-tables' `TableMap` needs them), and cell content `inline*`.

Toolbar gains an insert-table button plus row/column/delete controls that appear only with the caret inside a table. The active-state reads move to `useEditorState`: TipTap 3's `useEditor` does not re-render on every transaction, so reading `editor.isActive(...)` in the render body left the table controls never appearing (and, latently, the existing `aria-pressed` states stale).

**Portal CSS** — `apps/portal` deliberately doesn't pull in Tailwind's typography plugin (web gets table styling free from `prose`), so `.quote-rich-text table/th/td` rules are hand-written to match the PDF's look. Without them a customer-facing proposal renders a borderless run of cells.

## Out of scope

Merged cells (`colspan`/`rowspan`), nested tables, per-column widths, and cell alignment. The structured `table` block remains the way to author a table with layout control; this is about a pasted table surviving intact.

## Verification

- `apps/api`: 345 passed across `richTextSanitize`, `richTextPdf`, `tablePdf`, `calloutPdf`, `quotePdf` (+ classic regression), `quoteService`, `contractTemplateService`, `contractDocumentService`, `contractTemplateRender`, `aiToolsQuotes`, `routes/quotes/`, `routes/contracts/` — single-fork.
- `apps/web`: 795 passed across `components/billing/quotes/`, `components/contracts/`, `components/common/`, `lib/i18n` (localeParity / translationCoverage / terminologyQuality / extractionQuality), `richTextWarnings`, `no-silent-mutations`.
- `tsc --noEmit` clean in `apps/api` and `apps/web`; `apps/portal` `astro build` clean (validates the new `@apply` rules).
- The three tests that used `<table>` as their canonical *stripped-tag* fixture now use `<pre>`/`<blockquote>`, which are still outside the subset — the assertions were re-pointed, not weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
