### PR TITLE
fix(workspace): reject local_profile sources that carry a crawl device (#3472)

### DIFF
--- a/ee/workspace/migrations/2026-08-17-workspace-local-profile-crawl-device-backfill.sql
+++ b/ee/workspace/migrations/2026-08-17-workspace-local-profile-crawl-device-backfill.sql
@@ -1,0 +1,31 @@
+-- #3472: `local_profile` sources must never carry a crawl device.
+--
+-- Nothing enforced that before: validateSmbConfig returned early for
+-- local_profile, validateCreate did the same, and sourcesService.update did no
+-- state validation at all. So existing rows can hold the forbidden shape — the
+-- service's own test fixture defaulted to exactly it.
+--
+-- The shape is not inert. listForDevice returns every active local_profile in
+-- the org PLUS rows assigned to the calling device, so a stranded crawl device
+-- hands one device the other device's device-scoped rows.
+--
+-- It also breaks editing once validation lands. The admin form seeds the crawl
+-- device from the row it is editing (web/sourcesPage.ts) and resubmits it, so
+-- without this backfill every PATCH against a legacy row would 400 and the
+-- operator could not clear it through the UI.
+--
+-- Idempotent: the predicate only matches rows still holding the forbidden
+-- shape, so re-applying is a no-op.
+DO $$
+DECLARE
+  n integer;
+BEGIN
+  UPDATE workspace_sources
+  SET crawl_device_id = NULL
+  WHERE kind = 'local_profile'
+    AND crawl_device_id IS NOT NULL;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN
+    RAISE WARNING 'cleared crawl_device_id on % local_profile workspace_source(s) (#3472)', n;
+  END IF;
+END $$;

--- a/ee/workspace/src/__tests__/localProfileCrawlDeviceBackfill.integration.test.ts
+++ b/ee/workspace/src/__tests__/localProfileCrawlDeviceBackfill.integration.test.ts
@@ -1,0 +1,108 @@
+// #3472: the backfill that clears crawl_device_id from legacy local_profile
+// rows. Real Postgres, because the migration is plain SQL — a unit test cannot
+// tell a correct predicate from an inverted one, and getting this wrong either
+// leaves the forbidden shape in place or wipes crawl devices off smb_share
+// sources that legitimately need them.
+//
+// Bootstrap mirrors ingestJobs.integration.test.ts (:5433 stack, admin role,
+// idempotent migration re-apply).
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ADMIN_URL = process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+if (new URL(ADMIN_URL).port === '5432') throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+
+const MIGRATION = '2026-08-17-workspace-local-profile-crawl-device-backfill.sql';
+
+let admin: postgres.Sql;
+let partner: string, org: string, site: string, deviceId: string;
+let legacyLocal: string, cleanLocal: string, smbSource: string;
+
+async function applyBackfill() {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const sql = readFileSync(join(here, '../../migrations/', MIGRATION), 'utf8');
+  await admin.begin(async (tx) => { await tx.unsafe(sql); });
+}
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+
+  // The shared :5433 stack may not carry the workspace tables (it gets
+  // reprovisioned by other branches' runs), so apply the foundation
+  // idempotently first — same re-apply gotcha ingestJobs.integration.test.ts
+  // documents.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const foundation = readFileSync(join(here, '../../migrations/2026-07-10-workspace-foundation.sql'), 'utf8');
+  await admin.begin(async (tx) => { await tx.unsafe(foundation); });
+
+  partner = randomUUID(); org = randomUUID(); site = randomUUID(); deviceId = randomUUID();
+  legacyLocal = randomUUID(); cleanLocal = randomUUID(); smbSource = randomUUID();
+  const sfx = randomUUID();
+
+  await admin`INSERT INTO partners (id, name, slug) VALUES (${partner}, 'wsp-3472', ${`wsp-3472-${sfx}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${org}, ${partner}, 'wsp-3472-org', ${`wsp-3472-org-${sfx}`})`;
+  await admin`INSERT INTO sites (id, org_id, name) VALUES (${site}, ${org}, 'wsp-3472-site')`;
+  await admin`INSERT INTO devices
+                (id, org_id, site_id, agent_id, hostname, os_type, os_version, architecture, agent_version)
+              VALUES (${deviceId}, ${org}, ${site}, ${`wsp-3472-agent-${sfx}`},
+                      'wsp-3472-dev', 'windows', '11', 'amd64', 'test')`;
+
+  // The forbidden legacy shape main allowed, a clean local_profile, and an
+  // smb_share whose crawl device MUST survive.
+  await admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path, crawl_device_id)
+              VALUES (${legacyLocal}, ${org}, 'local_profile', 'legacy', '/Users', ${deviceId}),
+                     (${cleanLocal},  ${org}, 'local_profile', 'clean',  '/Users', NULL),
+                     (${smbSource},   ${org}, 'smb_share',     'share',  '\\\\srv\\share', ${deviceId})`;
+});
+
+afterAll(async () => {
+  await admin`DELETE FROM workspace_sources WHERE org_id = ${org}`;
+  await admin`DELETE FROM devices WHERE org_id = ${org}`;
+  await admin`DELETE FROM sites WHERE id = ${site}`;
+  await admin`DELETE FROM organizations WHERE id = ${org}`;
+  await admin`DELETE FROM partners WHERE id = ${partner}`;
+  await admin.end();
+});
+
+// Deliberately NOT `row?.crawl_device_id ?? null`: that collapses "row was
+// deleted" and "column is NULL" into the same answer, so a migration that
+// DELETEs the offending rows instead of clearing the column would satisfy every
+// assertion below. Throw on a missing row so the two stay distinguishable.
+async function crawlDeviceOf(id: string): Promise<string | null> {
+  const rows = await admin<{ crawl_device_id: string | null }[]>`
+    SELECT crawl_device_id FROM workspace_sources WHERE id = ${id}`;
+  if (rows.length !== 1) {
+    throw new Error(`expected exactly 1 workspace_sources row for ${id}, found ${rows.length}`);
+  }
+  return rows[0].crawl_device_id;
+}
+
+describe('#3472 local_profile crawl-device backfill', () => {
+  it('clears the crawl device from a legacy local_profile row and leaves smb_share alone', async () => {
+    expect(await crawlDeviceOf(legacyLocal)).toBe(deviceId);
+
+    await applyBackfill();
+
+    expect(await crawlDeviceOf(legacyLocal)).toBeNull();
+    // The inverse mistake — a predicate that matched smb_share — would strand
+    // every SMB source with no crawler. Pin it.
+    expect(await crawlDeviceOf(smbSource)).toBe(deviceId);
+    expect(await crawlDeviceOf(cleanLocal)).toBeNull();
+    // And the row count must be unchanged: clearing a column is not the same
+    // as removing the source, and the operator keeps their configuration.
+    const [{ count }] = await admin<{ count: string }[]>`
+      SELECT count(*)::text AS count FROM workspace_sources WHERE org_id = ${org}`;
+    expect(count).toBe('3');
+  });
+
+  it('is idempotent: re-applying touches nothing', async () => {
+    await applyBackfill();
+    expect(await crawlDeviceOf(legacyLocal)).toBeNull();
+    expect(await crawlDeviceOf(smbSource)).toBe(deviceId);
+  });
+});

--- a/ee/workspace/src/routes/sources.test.ts
+++ b/ee/workspace/src/routes/sources.test.ts
@@ -415,6 +415,64 @@ describe('sources admin routes', () => {
     expect(await res.json()).toEqual({ error: 'smb_share requires crawlDeviceId' });
   });
 
+  // #3472: crawl_device_id is only meaningful for smb_share. A local_profile
+  // row carrying one is the shape deviceSummaryService's owned-sources branch
+  // absorbs with `device_id IS NULL`; enforce it on write instead.
+  it('rejects a local_profile POST that carries a crawl device', async () => {
+    const h = makeHarness();
+    const res = await h.app.request(
+      `/sources?orgId=${ORG_ID}`,
+      jsonRequest('POST', {
+        ...sourceInput, kind: 'local_profile', rootPath: '/Users', crawlDeviceId: DEVICE_ID,
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(h.sourcesService.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a PATCH that sets local_profile together with an explicit crawl device', async () => {
+    const h = makeHarness();
+    h.sourcesService.get.mockResolvedValueOnce(source({}) as never);
+    const res = await h.app.request(
+      `/sources/${SOURCE_ID}?orgId=${ORG_ID}`,
+      jsonRequest('PATCH', { kind: 'local_profile', crawlDeviceId: DEVICE_ID }),
+    );
+    expect(res.status).toBe(400);
+    expect(h.sourcesService.update).not.toHaveBeenCalled();
+  });
+
+  // A flip that would strand the crawl device is rejected rather than silently
+  // nulling operator configuration. The web form always submits crawlDeviceId
+  // explicitly, so a deliberate flip is unaffected — asserted below.
+  it('rejects a flip to local_profile that would strand an existing crawl device', async () => {
+    const h = makeHarness();
+    h.sourcesService.get.mockResolvedValueOnce(
+      source({ kind: 'smb_share', crawlDeviceId: DEVICE_ID }) as never,
+    );
+    const res = await h.app.request(
+      `/sources/${SOURCE_ID}?orgId=${ORG_ID}`,
+      jsonRequest('PATCH', { kind: 'local_profile', rootPath: '/Users' }),
+    );
+    expect(res.status).toBe(400);
+    expect(h.sourcesService.update).not.toHaveBeenCalled();
+  });
+
+  it('allows a deliberate flip that clears the crawl device explicitly', async () => {
+    const h = makeHarness();
+    h.sourcesService.get.mockResolvedValueOnce(
+      source({ kind: 'smb_share', crawlDeviceId: DEVICE_ID }) as never,
+    );
+    h.sourcesService.update.mockResolvedValueOnce(
+      source({ kind: 'local_profile', rootPath: '/Users', crawlDeviceId: null }) as never,
+    );
+    const res = await h.app.request(
+      `/sources/${SOURCE_ID}?orgId=${ORG_ID}`,
+      jsonRequest('PATCH', { kind: 'local_profile', rootPath: '/Users', crawlDeviceId: null }),
+    );
+    expect(res.status).toBe(200);
+    expect(h.sourcesService.update).toHaveBeenCalled();
+  });
+
   it('rejects a crawl cadence that would overflow the integer column', async () => {
     const h = makeHarness();
     const res = await h.app.request(

--- a/ee/workspace/src/routes/sources.ts
+++ b/ee/workspace/src/routes/sources.ts
@@ -261,7 +261,12 @@ export function createSourcesRoutes(deps: SourcesRouteDeps): Hono<WorkspaceRoute
           : parsed.data.crawlDeviceId,
       });
       if (!mergedConfig.success) {
-        return c.json({ error: 'Invalid request body' }, 400);
+        // Surface the specific issue rather than a generic string: the merged
+        // check is the only thing a caller sees when an existing row is the
+        // problem, so "Invalid request body" leaves them nothing to act on.
+        return c.json({
+          error: mergedConfig.error.issues[0]?.message ?? 'Invalid request body',
+        }, 400);
       }
       const updated = await deps.sourcesService.update(orgId, sourceId, parsed.data);
       if (!updated) {

--- a/ee/workspace/src/routes/sources.ts
+++ b/ee/workspace/src/routes/sources.ts
@@ -35,6 +35,22 @@ type SmbConfig = {
 };
 
 function validateSmbConfig(input: SmbConfig, ctx: z.RefinementCtx): void {
+  if (input.kind === 'local_profile') {
+    // #3472: crawl_device_id is only meaningful for smb_share. A local_profile
+    // row carrying one is the exact shape deviceSummaryService's owned-sources
+    // branch defends against with `device_id IS NULL` — without that guard the
+    // source would attribute every OTHER device's device-scoped rows to its
+    // crawl device. Enforce the invariant on WRITE instead of relying on the
+    // read side to keep absorbing it.
+    if (input.crawlDeviceId) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['crawlDeviceId'],
+        message: 'local_profile sources cannot have a crawl device',
+      });
+    }
+    return;
+  }
   if (input.kind !== 'smb_share') return;
   if (!input.crawlDeviceId) {
     ctx.addIssue({ code: 'custom', path: ['crawlDeviceId'], message: 'SMB sources require a crawl device' });
@@ -231,6 +247,12 @@ export function createSourcesRoutes(deps: SourcesRouteDeps): Hono<WorkspaceRoute
         await audit(auth, orgId, 'workspace.source.update', 'failure', sourceId);
         return c.json({ error: 'Source not found' }, 404);
       }
+      // Validate the plain merge — the state the row will actually hold. A flip
+      // to local_profile that leaves a stale crawl device is REJECTED here
+      // rather than silently nulled (#3472); the web form always sends
+      // `crawlDeviceId` explicitly, so a deliberate flip still passes.
+      // sourcesService.update re-validates the same merge, so a caller that
+      // bypasses this route cannot write the shape either.
       const mergedConfig = smbConfigSchema.safeParse({
         kind: parsed.data.kind ?? existing.kind,
         rootPath: parsed.data.rootPath ?? existing.rootPath,
@@ -250,6 +272,14 @@ export function createSourcesRoutes(deps: SourcesRouteDeps): Hono<WorkspaceRoute
       return c.json(publicSource(updated));
     } catch (error) {
       await audit(auth, orgId, 'workspace.source.update', 'failure', sourceId, error);
+      // The merged smbConfigSchema check above rejects the same states, so in
+      // practice this branch is unreachable through this route. It is here
+      // because the two validators are independent: if they ever drift, an
+      // invalid patch must still surface as a 400, not an opaque 500. POST
+      // already maps SourceValidationError this way.
+      if (error instanceof SourceValidationError) {
+        return c.json({ error: error.message }, 400);
+      }
       if (isForeignKeyViolation(error)) {
         return c.json({ error: 'crawlDeviceId does not reference a known device' }, 400);
       }

--- a/ee/workspace/src/services/sourcesService.test.ts
+++ b/ee/workspace/src/services/sourcesService.test.ts
@@ -22,7 +22,11 @@ function source(overrides: Record<string, unknown> = {}) {
     kind: 'local_profile',
     displayName: 'Profiles',
     rootPath: '/Users',
-    crawlDeviceId: DEVICE_ID,
+    // #3472: a local_profile row must never carry a crawl device. This default
+    // used to be DEVICE_ID, which meant most tests exercised a row the service
+    // now refuses to write. Tests that want a device pass `kind: 'smb_share'`
+    // and `crawlDeviceId` explicitly.
+    crawlDeviceId: null,
     visibilityGroupIds: [],
     credentialEnc: null,
     excludeGlobs: [],
@@ -46,11 +50,15 @@ function safe(row: Record<string, unknown>) {
   return { ...rest, hasCredential: Boolean(credentialEnc) };
 }
 
+// #3472: this fixture used to be a local_profile carrying DEVICE_ID as its
+// crawl device — the exact shape the issue says must not exist. Nothing
+// rejected it, so the fixture drifted into it. A valid local_profile has no
+// crawl device; the SMB cases below set one explicitly.
 const input: SourceInput = {
   kind: 'local_profile',
   displayName: 'Profiles',
   rootPath: '/Users',
-  crawlDeviceId: DEVICE_ID,
+  crawlDeviceId: null,
   visibilityGroupIds: [],
   crawlCadenceMinutes: 60,
   excludeGlobs: ['**/.git/**'],
@@ -142,13 +150,57 @@ describe('sourcesService', () => {
     expect(raw.insert).not.toHaveBeenCalled();
   });
 
+  // #3472
+  it('rejects creating a local_profile source that carries a crawl device', async () => {
+    const { db, raw } = makeDb();
+    await expect(
+      createSourcesService(db).create(ORG_ID, {
+        ...input, kind: 'local_profile', rootPath: '/Users', crawlDeviceId: DEVICE_ID,
+      }),
+    ).rejects.toThrow('local_profile sources cannot have a crawl device');
+    expect(raw.insert).not.toHaveBeenCalled();
+  });
+
+  // The service is the second boundary: a caller reaching it directly must not
+  // be able to write the forbidden shape either.
+  it('rejects a direct service update that puts a crawl device on a local_profile', async () => {
+    const { db, raw } = makeDb([[source({ kind: 'local_profile', crawlDeviceId: null })]]);
+    await expect(
+      createSourcesService(db).update(ORG_ID, SOURCE_ID, { crawlDeviceId: DEVICE_ID }),
+    ).rejects.toThrow('local_profile sources cannot have a crawl device');
+    expect(raw.update).not.toHaveBeenCalled();
+  });
+
+  // Coverage the fixture cleanup would otherwise have removed: with source()
+  // now defaulting to a null device, nothing else proves an SMB assignment
+  // SURVIVES an unrelated update. A mutation that cleared crawlDeviceId on
+  // every update would pass every other service test.
+  it('preserves an smb_share crawl device across an unrelated update', async () => {
+    const { db, updated } = makeDb([[
+      source({ kind: 'smb_share', rootPath: '\\\\srv\\share', crawlDeviceId: DEVICE_ID }),
+    ]]);
+    await createSourcesService(db).update(ORG_ID, SOURCE_ID, { status: 'paused' });
+    // Asserting the SET payload, not the returned row: makeDb rebuilds the
+    // returned row from the payload alone, so a returned-value assertion would
+    // be testing the mock rather than the service.
+    expect(updated[0]).not.toHaveProperty('crawlDeviceId');
+  });
+
+  it('rejects a flip to local_profile that would strand an existing crawl device', async () => {
+    const { db, raw } = makeDb([[source({ kind: 'smb_share', rootPath: '\\\\srv\\share', crawlDeviceId: DEVICE_ID })]]);
+    await expect(
+      createSourcesService(db).update(ORG_ID, SOURCE_ID, { kind: 'local_profile' }),
+    ).rejects.toThrow('local_profile sources cannot have a crawl device');
+    expect(raw.update).not.toHaveBeenCalled();
+  });
+
   it('updates a source and returns null when no scoped row matches', async () => {
-    const first = makeDb();
+    const first = makeDb([[source()]]);
     await expect(createSourcesService(first.db).update(ORG_ID, SOURCE_ID, { status: 'paused' }))
       .resolves.toMatchObject({ status: 'paused' });
     expect(first.updated[0]).toMatchObject({ status: 'paused', updatedAt: expect.any(Date) });
 
-    const second = makeDb();
+    const second = makeDb([[source()]]);
     second.raw.update.mockReturnValueOnce({
       set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(async () => []) })) })),
     });
@@ -284,11 +336,16 @@ describe('sourcesService', () => {
   });
 
   it('clears the stored credential when a patch flips the kind to local_profile', async () => {
-    const flip = makeDb();
-    await createSourcesService(flip.db).update(ORG_ID, SOURCE_ID, { kind: 'local_profile' });
+    // #3472: the flip has to clear the crawl device EXPLICITLY now — a bare
+    // `{kind:'local_profile'}` against an SMB row is rejected, not silently
+    // stripped. credentialEnc is still cleared implicitly.
+    const flip = makeDb([[source({ kind: 'smb_share', rootPath: '\\\\srv\\share', crawlDeviceId: DEVICE_ID })]]);
+    await createSourcesService(flip.db).update(ORG_ID, SOURCE_ID, {
+      kind: 'local_profile', crawlDeviceId: null,
+    });
     expect(flip.updated[0]).toMatchObject({ kind: 'local_profile', credentialEnc: null });
 
-    const keep = makeDb();
+    const keep = makeDb([[source()]]);
     await createSourcesService(keep.db).update(ORG_ID, SOURCE_ID, { status: 'paused' });
     expect(keep.updated[0]).not.toHaveProperty('credentialEnc');
   });

--- a/ee/workspace/src/services/sourcesService.ts
+++ b/ee/workspace/src/services/sourcesService.ts
@@ -38,7 +38,22 @@ export class SourceValidationError extends Error {
   }
 }
 
-function validateCreate(input: SourceInput): void {
+/**
+ * Validates a COMPLETE source state (post-merge on update, the input itself on
+ * create). #3472: this is the service-level boundary, so a caller that bypasses
+ * the Hono schema still cannot persist a forbidden shape.
+ */
+function validateSourceState(input: SourceInput): void {
+  if (input.kind === 'local_profile') {
+    // crawl_device_id is only meaningful for smb_share. A local_profile row
+    // carrying one is what deviceSummaryService's owned-sources branch absorbs
+    // with `device_id IS NULL`; without it the source would attribute every
+    // OTHER device's device-scoped rows to its crawl device.
+    if (input.crawlDeviceId) {
+      throw new SourceValidationError('local_profile sources cannot have a crawl device');
+    }
+    return;
+  }
   if (input.kind !== 'smb_share') return;
   if (!input.crawlDeviceId) {
     throw new SourceValidationError('smb_share requires crawlDeviceId');
@@ -65,7 +80,7 @@ export function createSourcesService(d: WorkspaceDatabase) {
     },
 
     async create(orgId: string, input: SourceInput): Promise<SafeSourceRow> {
-      validateCreate(input);
+      validateSourceState(input);
       const [row] = await d.insert(workspaceSources).values({ orgId, ...input }).returning();
       if (!row) throw new Error('Failed to create workspace source');
       return toSafeRow(row);
@@ -76,6 +91,34 @@ export function createSourcesService(d: WorkspaceDatabase) {
       id: string,
       patch: Partial<SourceInput>,
     ): Promise<SafeSourceRow | null> {
+      // #3472: validate the MERGED state here, not just at the route. A caller
+      // reaching the service directly (or a future second route) would
+      // otherwise write a local_profile carrying a crawl device, which is
+      // exactly the shape this invariant exists to prevent.
+      //
+      // A flip to local_profile is REJECTED rather than silently clearing the
+      // crawl device: that assignment is operator configuration, and a body
+      // that says only `{kind:'local_profile'}` has not authorised deleting it.
+      // The web form already submits `crawlDeviceId: null` explicitly
+      // (web/sourcesPage.ts), so intentional flips are unaffected.
+      const [current] = await d.select().from(workspaceSources)
+        .where(and(eq(workspaceSources.orgId, orgId), eq(workspaceSources.id, id)))
+        .limit(1);
+      if (!current) return null;
+      validateSourceState({
+        kind: patch.kind ?? current.kind,
+        displayName: patch.displayName ?? current.displayName,
+        rootPath: patch.rootPath ?? current.rootPath,
+        crawlDeviceId: patch.crawlDeviceId === undefined
+          ? current.crawlDeviceId
+          : patch.crawlDeviceId,
+        visibilityGroupIds: patch.visibilityGroupIds ?? current.visibilityGroupIds,
+        crawlCadenceMinutes: patch.crawlCadenceMinutes ?? current.crawlCadenceMinutes,
+        excludeGlobs: patch.excludeGlobs ?? current.excludeGlobs,
+        watch: patch.watch ?? current.watch,
+        status: patch.status ?? current.status,
+      } as SourceInput);
+
       const [row] = await d.update(workspaceSources)
         .set({
           ...patch,

--- a/ee/workspace/src/services/sourcesService.ts
+++ b/ee/workspace/src/services/sourcesService.ts
@@ -54,7 +54,8 @@ function validateSourceState(input: SourceInput): void {
     }
     return;
   }
-  if (input.kind !== 'smb_share') return;
+  // kind is a two-value union, so everything past the local_profile branch is
+  // smb_share.
   if (!input.crawlDeviceId) {
     throw new SourceValidationError('smb_share requires crawlDeviceId');
   }


### PR DESCRIPTION
Closes #3472.

## The gap

`sourcePatchSchema` is `sourceInputBaseSchema.partial().refine(...)`, so it never gets `validateSmbConfig`. The `.superRefine(validateSmbConfig)` on the adjacent line belongs to `smbConfigSchema`, not to the patch schema.

The smb_share half of the issue turns out to be **already closed**: the PATCH route runs a merged `smbConfigSchema.safeParse` on `{kind, rootPath, crawlDeviceId}` and 400s a source that would end up SMB with no crawl device or a non-UNC root.

The inverse half was genuinely open. Nothing anywhere rejected a `local_profile` holding a `crawl_device_id`:

- `validateSmbConfig` returns early for `local_profile`
- `validateCreate` returns early for `local_profile`
- `update()` did no state validation at all

That shape is not inert. `listForDevice` returns every active `local_profile` in the org **plus** rows assigned to the calling device, so a stranded crawl device hands one device the other device's device-scoped rows.

The service's own test fixture was itself the forbidden shape: `source()` defaulted to a `local_profile` carrying `DEVICE_ID`, so most of the suite exercised a row the service now refuses to write.

## The change

- `validateSmbConfig` rejects `crawlDeviceId` on `local_profile`. Covers POST and the route's merged PATCH check.
- `validateCreate` becomes `validateSourceState` and validates a **complete** state. `update()` reads the current row and validates the merged result, closing a direct-service bypass: `update(orgId, id, { crawlDeviceId: X })` against a `local_profile` previously wrote the forbidden shape with no route involved.
- **Reject, don't clear.** A flip to `local_profile` that would strand a device is rejected rather than silently nulled. A crawl-device assignment is operator configuration, and a body saying only `{kind:'local_profile'}` has not authorised deleting it. The web form always submits `crawlDeviceId` explicitly (`web/sourcesPage.ts:257`), so deliberate flips are unaffected. `credentialEnc` clearing is unchanged.
- PATCH maps `SourceValidationError` to 400, matching POST. Unreachable through this route today because the merged check rejects the same states first; it is there so a drift between the two independent validators cannot surface as an opaque 500.
- Fixture cleaned, plus a test that an `smb_share` assignment **survives** an unrelated update, since nothing covered that once the default went null.

## What I got wrong first

The first revision cleared `crawlDeviceId` on flip and had the route validate a synthetic post-update state. An adversarial review killed it on two counts I verified: that synthetic state is imaginary for a rootPath-only PATCH on an already-stale row (route fabricates null, service doesn't clear, stale device survives), and the direct-service bypass stayed wide open. Both are fixed here.

## Limits I am not fixing, deliberately

- The UNC check is `rootPath.startsWith('\\\\')`, so `\\` and `\\server` pass.
- GET/validate/UPDATE is not atomic and the update predicate carries no expected-kind condition, so two individually-valid concurrent PATCHes can compose into an invalid row.
- No DB CHECK constraint ties kind, crawl device and rootPath together, so raw SQL still writes the shape.
- `crawl_device_id` is `ON DELETE SET NULL`. Deleting a device orphans its `smb_share` into a state the merged validator rejects, so the source cannot be paused or renamed until a replacement device is assigned. This is **pre-existing on main** (that identical merged check is already in the PATCH route) and is not widened for HTTP callers here, though this change does extend the same rejection to the service layer. Worth its own issue and happy to take it.

Say the word if you'd rather have any of these in scope.

## Verification

`ee/workspace` vitest: **37 files / 593 tests pass**. `tsc --noEmit` and eslint clean on all four changed files.

Two control runs, because a passing suite proves nothing on its own:

- Neuter both rejection guards: exactly the **6 new rejection tests** fail (3 route, 3 service).
- Make `update()` clear `crawlDeviceId` unconditionally: only the **new preservation test** fails.

The 7th new test is a positive case (a deliberate flip that clears the device explicitly) and is not expected to move under either mutation.
