### PR TITLE
fix(deps): dedup pnpm-lock.yaml — duplicated hono@4.13.2 key breaks every JS job on main

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8034,10 +8034,6 @@ packages:
     resolution: {integrity: sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.13.2:
-    resolution: {integrity: sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==}
-    engines: {node: '>=16.9.0'}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -19763,8 +19759,6 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
-
-  hono@4.13.2: {}
 
   hono@4.13.2: {}
 


### PR DESCRIPTION
fix(deps): dedup pnpm-lock.yaml - duplicated hono@4.13.2 key breaks every JS job on main

`main` is red: 21 failing jobs, every JS job dying at `Install dependencies`
before any project code runs.

```
 ERR_PNPM_BROKEN_LOCKFILE  The lockfile at ".../pnpm-lock.yaml" is broken:
 duplicated mapping key (8037:3)
```

Reproduced locally on a clean worktree with `pnpm install --frozen-lockfile`,
same line number.

## Cause

A run of dependabot PRs merged back to back without rebase. Counting
`hono@4.13.x` keys per lockfile section at each commit pins the exact one that
broke it:

| Commit | PR | packages | snapshots |
|---|---|---|---|
| `e5ae00036` | #3676 expo-sdk group | `4.13.1` x1 | `4.13.1` x1 |
| `75d0abbab` | #3681 hono group | `4.13.2` x1 | `4.13.2` x1 |
| `67e441adb` | #3682 user-event | `4.13.2` x1 | `4.13.2` x1 |
| `9138bad94` | **#3683 eslint / linting group** | `4.13.2` **x2** | `4.13.2` **x2** |

So #3681 did its job correctly: one entry per section. #3683 is the one that
broke it. Its branch was cut when the lockfile still carried `hono@4.13.1`, so
merging it after #3681 had already moved to `4.13.2` appended a second copy of
the same block instead of reconciling with the existing one. YAML rejects a
duplicated mapping key outright, and pnpm parses the lockfile with js-yaml in
duplicate-checking mode, so it throws rather than taking a last-one-wins path.

Calibration, so "duplicated" is not misread: a healthy package appears exactly
twice in the file, once under `packages:` and once under `snapshots:`. That
cross-section pair is normal. Only repeats WITHIN one section break YAML.

This is the third duplication of this kind on this dependency (see #3407,
which was `hono@4.13.1`).

## The change

6 lines deleted, nothing added, nothing regenerated.

Both removed blocks were asserted byte-identical to the kept copy before
removal - same `resolution` integrity hash, same `engines` - so no resolution
information is lost and it does not matter which copy survives. No package
version moves. The lockfile is deliberately not regenerated: a regen on top of
several same-window bumps would move unrelated transitives and make the diff
unreviewable.

Every manifest requesting hono asks for `^4.13.2` or exactly `4.13.2` (seven files:
apps/api, the three m365 executors, ee/workspace, extension-sdk,
extension-testkit), every importer resolves to 4.13.2, and no `hono@4.13.1`
reference remains anywhere, so the surviving entry is the right one.

## Verification

- `pnpm install --frozen-lockfile` fails on `origin/main`, exits 0 on this branch.
- Ran it a second time: still exit 0, and `git diff --stat` still shows only the
  6 deletions, i.e. the install did not rewrite the lockfile.
- Recursive whole-tree scan for repeated scalar keys within any YAML mapping,
  covering peer-suffixed keys like `foo@1.0.0(bar@2.0.0)` and nested importer
  maps: 2 duplicates on `origin/main`, 0 on this branch.

Note this proves the lockfile parses and matches the manifests. It does not
prove CI is green - it does not cover `e2e-tests` (excluded from the pnpm
workspace, separate npm lock), Linux-specific optional packages, or any of the
lint/type/test/build jobs.

## Prevention

Third occurrence, so this is worth a repo setting rather than a manual repair
each time: require branches to be up to date before merging lockfile-touching
PRs, or use a merge queue, or group dependabot updates so one PR carries one
lockfile change.

Separately, `test-mobile` and `test-agent-race` are not in the `ci-success`
`needs:` list, so if branch protection requires only `CI Success`, a failing
mobile or race job would not block a merge. Unrelated to this fix; flagging it
because these dependency bumps are exactly what `test-mobile` would catch.

