### PR TITLE
fix(web): consume the SSO #ssoCode fragment so SSO login can complete

### DIFF
--- a/apps/web/src/components/auth/AuthOverlay.test.tsx
+++ b/apps/web/src/components/auth/AuthOverlay.test.tsx
@@ -156,3 +156,118 @@ describe('AuthOverlay session-expiry mask', () => {
     expect(navigateTo).not.toHaveBeenCalled();
   });
 });
+
+describe('AuthOverlay #ssoCode exchange bootstrap (#3700)', () => {
+  const UNAUTHENTICATED = {
+    isAuthenticated: false,
+    isLoading: false,
+    tokens: null,
+    user: null,
+    sessionExpiredReason: null,
+  } as const;
+
+  const originalFetch = global.fetch;
+  let fetchCalls: Array<{ url: string; init?: RequestInit }>;
+
+  function stubFetch(routes: Record<string, () => Response>) {
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      fetchCalls.push({ url, init });
+      for (const [needle, respond] of Object.entries(routes)) {
+        if (url.includes(needle)) return respond();
+      }
+      throw new Error(`unexpected fetch in test: ${url}`);
+    }) as typeof fetch;
+  }
+
+  const json = (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    fetchCalls = [];
+    useAuthStore.setState({ ...UNAUTHENTICATED });
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(async () => {
+    const { navigateTo } = await import('../../lib/navigation');
+    vi.mocked(navigateTo).mockClear();
+    global.fetch = originalFetch;
+    vi.useRealTimers();
+    useAuthStore.setState({ ...UNAUTHENTICATED });
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('trades the fragment grant for a session and strips it from the URL', async () => {
+    stubFetch({
+      '/sso/exchange': () => json(200, { accessToken: 'sso-access', expiresInSeconds: 900 }),
+      '/users/me': () => json(200, { id: 'u-1', email: 'jhill@example.com', name: 'J Hill', mfaEnabled: false }),
+    });
+    window.history.replaceState({}, '', '/#ssoCode=grant-123');
+
+    render(<AuthOverlay />);
+    // The fragment must be stripped synchronously on consumption — before the
+    // async exchange settles — so a reload can't replay the single-use grant.
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+    expect(window.location.hash).toBe('');
+
+    await waitFor(() => {
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    });
+    expect(useAuthStore.getState().tokens?.accessToken).toBe('sso-access');
+
+    const exchange = fetchCalls.find((c) => c.url.includes('/sso/exchange'));
+    expect(exchange).toBeDefined();
+    expect(JSON.parse(String(exchange!.init?.body))).toEqual({ code: 'grant-123' });
+
+    const { navigateTo } = await import('../../lib/navigation');
+    expect(navigateTo).not.toHaveBeenCalledWith(expect.stringContaining('/login'), expect.anything());
+  });
+
+  it('bounces to /login with an error notice when the exchange is rejected', async () => {
+    stubFetch({
+      '/sso/exchange': () => json(400, { error: 'Invalid or expired token exchange code' }),
+    });
+    window.history.replaceState({}, '', '/#ssoCode=stale-grant');
+    const { navigateTo } = await import('../../lib/navigation');
+    vi.mocked(navigateTo).mockClear();
+
+    render(<AuthOverlay />);
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+
+    await waitFor(() => {
+      expect(navigateTo).toHaveBeenCalledWith('/login?error=sso_exchange_failed', { replace: true });
+    });
+    expect(window.location.hash).toBe('');
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    // The error-carrying redirect must be the ONLY navigation — the generic
+    // bare-/login branch would strip the notice if it raced and won.
+    expect(vi.mocked(navigateTo)).toHaveBeenCalledTimes(1);
+  });
+
+  it('strips a leftover grant without exchanging when a live session already exists', async () => {
+    stubFetch({});
+    useAuthStore.setState({
+      isAuthenticated: true,
+      isLoading: false,
+      tokens: { accessToken: 'live-token', expiresInSeconds: 900 },
+      sessionExpiredReason: null,
+    });
+    window.history.replaceState({}, '', '/#ssoCode=old-grant');
+
+    render(<AuthOverlay />);
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+      await Promise.resolve();
+    });
+
+    expect(window.location.hash).toBe('');
+    expect(fetchCalls).toHaveLength(0);
+    expect(useAuthStore.getState().tokens?.accessToken).toBe('live-token');
+  });
+});

--- a/apps/web/src/components/auth/AuthOverlay.test.tsx
+++ b/apps/web/src/components/auth/AuthOverlay.test.tsx
@@ -271,3 +271,170 @@ describe('AuthOverlay #ssoCode exchange bootstrap (#3700)', () => {
     expect(useAuthStore.getState().tokens?.accessToken).toBe('live-token');
   });
 });
+
+describe('AuthOverlay #ssoCode failure and race hardening (#3700 review round)', () => {
+  const UNAUTHENTICATED = {
+    isAuthenticated: false,
+    isLoading: false,
+    tokens: null,
+    user: null,
+    sessionExpiredReason: null,
+  } as const;
+
+  const originalFetch = global.fetch;
+  let fetchCalls: Array<{ url: string; init?: RequestInit }>;
+
+  function stubFetch(routes: Record<string, () => Response | Promise<Response>>) {
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      fetchCalls.push({ url, init });
+      for (const [needle, respond] of Object.entries(routes)) {
+        if (url.includes(needle)) return respond();
+      }
+      throw new Error(`unexpected fetch in test: ${url}`);
+    }) as typeof fetch;
+  }
+
+  const json = (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+  async function expectErrorBounce() {
+    const { navigateTo } = await import('../../lib/navigation');
+    await waitFor(() => {
+      expect(navigateTo).toHaveBeenCalledWith('/login?error=sso_exchange_failed', { replace: true });
+    });
+    expect(window.location.hash).toBe('');
+    expect(vi.mocked(navigateTo)).toHaveBeenCalledTimes(1);
+  }
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    fetchCalls = [];
+    useAuthStore.setState({ ...UNAUTHENTICATED });
+    window.history.replaceState({}, '', '/');
+    const { navigateTo } = await import('../../lib/navigation');
+    vi.mocked(navigateTo).mockClear();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+    vi.useRealTimers();
+    useAuthStore.setState({ ...UNAUTHENTICATED });
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('bounces a malformed grant to /login with the error notice, without attempting an exchange', async () => {
+    stubFetch({});
+    window.history.replaceState({}, '', '/#ssoCode=%E0%A4%A');
+
+    render(<AuthOverlay />);
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+
+    await expectErrorBounce();
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it('bounces an empty grant to /login with the error notice', async () => {
+    stubFetch({});
+    window.history.replaceState({}, '', '/#ssoCode=');
+
+    render(<AuthOverlay />);
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+
+    await expectErrorBounce();
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it('bounces to /login with the error notice when /users/me fails after a successful exchange', async () => {
+    stubFetch({
+      '/sso/exchange': () => json(200, { accessToken: 'sso-access', expiresInSeconds: 900 }),
+      '/users/me': () => json(500, { error: 'boom' }),
+    });
+    window.history.replaceState({}, '', '/#ssoCode=grant-1');
+
+    render(<AuthOverlay />);
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+
+    await expectErrorBounce();
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+  });
+
+  it('bounces cleanly when /users/me returns 200 with a non-JSON body (no unhandled rejection)', async () => {
+    stubFetch({
+      '/sso/exchange': () => json(200, { accessToken: 'sso-access', expiresInSeconds: 900 }),
+      '/users/me': () =>
+        new Response('<html>gateway interstitial</html>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        }),
+    });
+    window.history.replaceState({}, '', '/#ssoCode=grant-2');
+
+    render(<AuthOverlay />);
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+
+    await expectErrorBounce();
+  });
+
+  it('bounces with the error notice when the exchange request itself throws (offline)', async () => {
+    stubFetch({
+      '/sso/exchange': () => Promise.reject(new TypeError('Failed to fetch')),
+    });
+    window.history.replaceState({}, '', '/#ssoCode=grant-3');
+
+    render(<AuthOverlay />);
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+
+    await expectErrorBounce();
+  });
+
+  it('completes the exchange for a stale persisted session with a dead refresh cookie, without an eviction race', async () => {
+    // The enforce-SSO lockout arrival state: localStorage still says
+    // isAuthenticated (tokens are memory-only), the refresh cookie is dead,
+    // and a fresh grant is in the fragment. The dead-cookie refresh must not
+    // fire from the slow path and evict mid-exchange.
+    let exchangeSettled = false;
+    stubFetch({
+      '/auth/refresh': () => {
+        if (!exchangeSettled) throw new Error('refresh raced the SSO exchange');
+        return json(401, { error: 'invalid refresh token' });
+      },
+      '/sso/exchange': async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        exchangeSettled = true;
+        return json(200, { accessToken: 'sso-access', expiresInSeconds: 900 });
+      },
+      '/users/me': () => json(200, { id: 'u-9', email: 'locked@example.com', name: 'Locked Out', mfaEnabled: false }),
+    });
+    useAuthStore.setState({
+      ...UNAUTHENTICATED,
+      isAuthenticated: true,
+      user: { id: 'u-9', email: 'locked@example.com', name: 'Locked Out', mfaEnabled: false },
+    });
+    window.history.replaceState({}, '', '/#ssoCode=grant-4');
+
+    render(<AuthOverlay />);
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => {
+      expect(useAuthStore.getState().tokens?.accessToken).toBe('sso-access');
+    });
+    const { navigateTo } = await import('../../lib/navigation');
+    expect(navigateTo).not.toHaveBeenCalled();
+    expect(fetchCalls.some((c) => c.url.includes('/auth/refresh') && !exchangeSettled)).toBe(false);
+  });
+});

--- a/apps/web/src/components/auth/AuthOverlay.tsx
+++ b/apps/web/src/components/auth/AuthOverlay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { bootstrapFromCfAccessRedirect, restoreAccessTokenFromCookie, useAuthStore } from '../../stores/auth';
+import { bootstrapFromCfAccessRedirect, bootstrapFromSsoCode, restoreAccessTokenFromCookie, useAuthStore } from '../../stores/auth';
 import { Loader2 } from 'lucide-react';
 import { navigateTo } from '../../lib/navigation';
 // Initializes the shared i18next singleton. Islands hydrate independently, so
@@ -9,6 +9,26 @@ import { navigateTo } from '../../lib/navigation';
 import '../../lib/i18n';
 
 const CF_ACCESS_LOGIN_PARAM = 'cf-access-login';
+const SSO_CODE_FRAGMENT_PREFIX = 'ssoCode=';
+
+// SSO callback token handoff (#3700): after a successful IdP login the API
+// redirects here with a one-time token-exchange grant in the URL FRAGMENT
+// (`/#ssoCode=<grant>`) — fragments never reach the server, so the grant can't
+// land in access logs or Referer headers. Consuming it strips the fragment
+// from the address bar immediately (before the async exchange settles) so the
+// single-use grant can't be re-triggered by a reload or copied out of the URL.
+function consumeSsoCodeFragment(): string | null {
+  if (typeof window === 'undefined') return null;
+  const hash = window.location.hash.replace(/^#/, '');
+  if (!hash.startsWith(SSO_CODE_FRAGMENT_PREFIX)) return null;
+  const raw = hash.slice(SSO_CODE_FRAGMENT_PREFIX.length).split('&')[0] ?? '';
+  window.history.replaceState({}, '', window.location.pathname + window.location.search);
+  try {
+    return decodeURIComponent(raw) || null;
+  } catch {
+    return null;
+  }
+}
 
 function consumeCfAccessLoginParam(): boolean {
   if (typeof window === 'undefined') return false;
@@ -31,6 +51,7 @@ export default function AuthOverlay() {
   const [isRecovering, setIsRecovering] = useState(false);
   const [recoverAttempted, setRecoverAttempted] = useState(false);
   const [cfBootstrapAttempted, setCfBootstrapAttempted] = useState(false);
+  const [ssoBootstrapAttempted, setSsoBootstrapAttempted] = useState(false);
   const [fadeState, setFadeState] = useState<'visible' | 'fading' | 'hidden'>('visible');
 
   useEffect(() => {
@@ -64,9 +85,43 @@ export default function AuthOverlay() {
 
     if (isChecking || isLoading) return;
 
-    // Fast path: tokens were rehydrated from localStorage — no network needed
+    // Fast path: tokens were rehydrated from localStorage — no network needed.
+    // A leftover `#ssoCode=` fragment (e.g. a re-visited SSO redirect while
+    // already signed in) is stripped without an exchange: the live session wins
+    // and the stale single-use grant must not linger in the address bar.
     if (isAuthenticated && tokens?.accessToken) {
+      consumeSsoCodeFragment();
       return;
+    }
+
+    // SSO redirect bootstrap (#3700): the SSO callback completed the IdP login
+    // and handed us a one-time exchange grant in the fragment. Trade it for
+    // tokens before any other recovery path — it represents a FRESH login, so
+    // it outranks both the CF Access param and a possibly-dead refresh cookie
+    // from a previous session (which is exactly the state a user locked out by
+    // enforce-SSO arrives in). Runs once per overlay mount.
+    if (!ssoBootstrapAttempted) {
+      const ssoCode = consumeSsoCodeFragment();
+      if (ssoCode) {
+        setSsoBootstrapAttempted(true);
+        setIsRecovering(true);
+        void bootstrapFromSsoCode(ssoCode).then((ok) => {
+          if (!ok) {
+            // NOT gated on `cancelled`: the setSsoBootstrapAttempted /
+            // setIsRecovering calls above re-run this effect immediately,
+            // which flips `cancelled` on the old closure long before the
+            // exchange settles — gating here would silently swallow the
+            // failure redirect. isRecovering also deliberately stays true:
+            // dropping it re-arms the final !isAuthenticated branch, whose
+            // bare `/login` redirect races this one and strips the error
+            // param. The navigation below unmounts the overlay anyway.
+            void navigateTo('/login?error=sso_exchange_failed', { replace: true });
+            return;
+          }
+          if (!cancelled) setIsRecovering(false);
+        });
+        return () => { cancelled = true; };
+      }
     }
 
     // CF Access redirect bootstrap: the server's GET /api/v1/auth/cf-access-login
@@ -124,7 +179,7 @@ export default function AuthOverlay() {
     }
 
     return () => { cancelled = true; };
-  }, [isAuthenticated, isLoading, isChecking, tokens, recoverAttempted, isRecovering, cfBootstrapAttempted, sessionExpiredReason]);
+  }, [isAuthenticated, isLoading, isChecking, tokens, recoverAttempted, isRecovering, cfBootstrapAttempted, ssoBootstrapAttempted, sessionExpiredReason]);
 
   // Authenticated with token — fade out then unmount
   const shouldHide = !isChecking && !isLoading && isAuthenticated && !!tokens?.accessToken;

--- a/apps/web/src/components/auth/AuthOverlay.tsx
+++ b/apps/web/src/components/auth/AuthOverlay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { bootstrapFromCfAccessRedirect, bootstrapFromSsoCode, restoreAccessTokenFromCookie, useAuthStore } from '../../stores/auth';
+import { bootstrapFromCfAccessRedirect, bootstrapFromSsoCode, restoreAccessTokenFromCookie, settleSsoLoginGate, useAuthStore } from '../../stores/auth';
 import { Loader2 } from 'lucide-react';
 import { navigateTo } from '../../lib/navigation';
 // Initializes the shared i18next singleton. Islands hydrate independently, so
@@ -17,17 +17,28 @@ const SSO_CODE_FRAGMENT_PREFIX = 'ssoCode=';
 // land in access logs or Referer headers. Consuming it strips the fragment
 // from the address bar immediately (before the async exchange settles) so the
 // single-use grant can't be re-triggered by a reload or copied out of the URL.
-function consumeSsoCodeFragment(): string | null {
-  if (typeof window === 'undefined') return null;
+//
+// `present` is reported separately from `code` because the caller must be able
+// to tell "no SSO handoff happened" apart from "there WAS a handoff and the
+// grant was unusable" (truncated by a chat/mail client, bad percent-encoding).
+// The latter still deserves the sso_exchange_failed notice — collapsing both
+// to null would bounce a real-but-corrupt handoff to a bare, unexplained
+// /login, which is the support dead-end this feature exists to remove.
+type SsoCodeFragment = { present: false } | { present: true; code: string | null };
+
+function consumeSsoCodeFragment(): SsoCodeFragment {
+  if (typeof window === 'undefined') return { present: false };
   const hash = window.location.hash.replace(/^#/, '');
-  if (!hash.startsWith(SSO_CODE_FRAGMENT_PREFIX)) return null;
+  if (!hash.startsWith(SSO_CODE_FRAGMENT_PREFIX)) return { present: false };
   const raw = hash.slice(SSO_CODE_FRAGMENT_PREFIX.length).split('&')[0] ?? '';
   window.history.replaceState({}, '', window.location.pathname + window.location.search);
+  let code: string | null;
   try {
-    return decodeURIComponent(raw) || null;
+    code = decodeURIComponent(raw) || null;
   } catch {
-    return null;
+    code = null;
   }
+  return { present: true, code };
 }
 
 function consumeCfAccessLoginParam(): boolean {
@@ -90,7 +101,7 @@ export default function AuthOverlay() {
     // already signed in) is stripped without an exchange: the live session wins
     // and the stale single-use grant must not linger in the address bar.
     if (isAuthenticated && tokens?.accessToken) {
-      consumeSsoCodeFragment();
+      if (consumeSsoCodeFragment().present) settleSsoLoginGate();
       return;
     }
 
@@ -99,27 +110,61 @@ export default function AuthOverlay() {
     // tokens before any other recovery path — it represents a FRESH login, so
     // it outranks both the CF Access param and a possibly-dead refresh cookie
     // from a previous session (which is exactly the state a user locked out by
-    // enforce-SSO arrives in). Runs once per overlay mount.
+    // enforce-SSO arrives in). Runs once per overlay mount. Every outcome must
+    // settleSsoLoginGate(), or refreshes queued behind the gate hang until its
+    // timeout.
     if (!ssoBootstrapAttempted) {
-      const ssoCode = consumeSsoCodeFragment();
-      if (ssoCode) {
+      const fragment = consumeSsoCodeFragment();
+      if (fragment.present && !fragment.code) {
+        // A handoff arrived but the grant is unusable (empty or malformed
+        // percent-encoding — typically a truncated link). Surface the same
+        // notice as a failed exchange instead of falling through to the bare
+        // /login redirect below, which would be undiagnosable from a support
+        // ticket: the evidence was just stripped from the address bar.
+        setSsoBootstrapAttempted(true);
+        // Same reasoning as the failed-exchange path below: isRecovering stays
+        // true so the effect re-run's bare `/login` branch can't race this
+        // redirect and strip the error param.
+        setIsRecovering(true);
+        console.warn('[AuthOverlay] malformed ssoCode fragment; bouncing to login');
+        void navigateTo('/login?error=sso_exchange_failed', { replace: true });
+        settleSsoLoginGate();
+        return () => { cancelled = true; };
+      }
+      if (fragment.present && fragment.code) {
         setSsoBootstrapAttempted(true);
         setIsRecovering(true);
-        void bootstrapFromSsoCode(ssoCode).then((ok) => {
-          if (!ok) {
-            // NOT gated on `cancelled`: the setSsoBootstrapAttempted /
-            // setIsRecovering calls above re-run this effect immediately,
-            // which flips `cancelled` on the old closure long before the
-            // exchange settles — gating here would silently swallow the
-            // failure redirect. isRecovering also deliberately stays true:
-            // dropping it re-arms the final !isAuthenticated branch, whose
-            // bare `/login` redirect races this one and strips the error
-            // param. The navigation below unmounts the overlay anyway.
-            void navigateTo('/login?error=sso_exchange_failed', { replace: true });
-            return;
-          }
-          if (!cancelled) setIsRecovering(false);
-        });
+        void bootstrapFromSsoCode(fragment.code)
+          .catch((err) => {
+            // bootstrapFromSsoCode resolves false on every expected failure;
+            // a rejection is a genuine bug, but it must still surface the
+            // error redirect rather than stranding the user on the spinner.
+            console.warn('[AuthOverlay] unexpected SSO bootstrap rejection', err);
+            return false;
+          })
+          .then((ok) => {
+            if (!ok) {
+              // NOT gated on `cancelled`: the setSsoBootstrapAttempted /
+              // setIsRecovering calls above re-run this effect immediately,
+              // which flips `cancelled` on the old closure long before the
+              // exchange settles — gating here would silently swallow the
+              // failure redirect. isRecovering also deliberately stays true:
+              // dropping it re-arms the final !isAuthenticated branch, whose
+              // bare `/login` redirect races this one and strips the error
+              // param. The navigation below unmounts the overlay anyway.
+              // Gate settles AFTER the navigation is issued so a queued
+              // refresh's own eviction redirect can't beat this one.
+              void navigateTo('/login?error=sso_exchange_failed', { replace: true });
+              settleSsoLoginGate();
+              return;
+            }
+            settleSsoLoginGate();
+            // Ungated on purpose (`cancelled` is always true by now, see
+            // above): the overlay still hides via shouldHide regardless, but
+            // isRecovering must drop so the slow-path branch isn't suppressed
+            // for the rest of the session.
+            setIsRecovering(false);
+          });
         return () => { cancelled = true; };
       }
     }
@@ -145,8 +190,12 @@ export default function AuthOverlay() {
       }
     }
 
-    // Slow path: authenticated but no token (e.g. first load after login on another tab)
-    if (isAuthenticated && !tokens?.accessToken && !recoverAttempted) {
+    // Slow path: authenticated but no token (e.g. first load after login on
+    // another tab). `!isRecovering` keeps it out of the stale-persisted-auth +
+    // fresh-#ssoCode state: while the SSO exchange is in flight this branch
+    // would otherwise race it with a dead-cookie refresh whose failure
+    // redirects to a bare /login mid-exchange.
+    if (isAuthenticated && !tokens?.accessToken && !recoverAttempted && !isRecovering) {
       setRecoverAttempted(true);
       setIsRecovering(true);
 

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -75,9 +75,12 @@ function getSsoLoginNotice(t: ReturnType<typeof useTranslation<'auth'>>['t']): s
     identity_in_use: t('login.ssoErrors.identityInUse', {
       defaultValue: 'That sign-in identity is already linked to a different account. Contact your administrator.',
     }),
-  // #3700: AuthOverlay's `#ssoCode` → POST /sso/exchange handoff failed (the
-  // single-use grant expired or was already consumed, or the exchange request
-  // itself failed). The IdP login succeeded — the user just re-initiates.
+    // #3700: AuthOverlay's `#ssoCode` → POST /sso/exchange handoff failed (the
+    // single-use grant expired/was consumed, the grant fragment was malformed,
+    // the exchange request failed, or a step AFTER a successful exchange
+    // failed — in that last case the refresh cookie is already set and the
+    // cookie-restore path on this page may sign the user in without any
+    // re-initiation). The IdP login itself succeeded in every case.
     sso_exchange_failed: t('login.ssoErrors.ssoExchangeFailed', {
       defaultValue: 'Single sign-on almost completed, but the final sign-in step failed. Please start the sign-in again.',
     }),

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -75,6 +75,12 @@ function getSsoLoginNotice(t: ReturnType<typeof useTranslation<'auth'>>['t']): s
     identity_in_use: t('login.ssoErrors.identityInUse', {
       defaultValue: 'That sign-in identity is already linked to a different account. Contact your administrator.',
     }),
+  // #3700: AuthOverlay's `#ssoCode` → POST /sso/exchange handoff failed (the
+  // single-use grant expired or was already consumed, or the exchange request
+  // itself failed). The IdP login succeeded — the user just re-initiates.
+    sso_exchange_failed: t('login.ssoErrors.ssoExchangeFailed', {
+      defaultValue: 'Single sign-on almost completed, but the final sign-in step failed. Please start the sign-in again.',
+    }),
   };
   return error ? ssoLoginErrorCopy[error] : undefined;
 }

--- a/apps/web/src/locales/de-DE/auth.json
+++ b/apps/web/src/locales/de-DE/auth.json
@@ -142,6 +142,7 @@
       "identityInUse": "Diese Anmeldeidentität ist bereits mit einem anderen Konto verknüpft. Wenden Sie sich an Ihre Administration.",
       "inviteRequired": "Die Anmeldung war erfolgreich, dieser Identität ist hier jedoch noch kein Konto zugeordnet. Fordern Sie bei Ihrer Administration eine Einladung an und versuchen Sie es erneut.",
       "noPartnerAccess": "Dieses Konto hat keinen Zugriff auf diesen Workspace. Wenden Sie sich an Ihre Administration.",
+      "ssoExchangeFailed": "Single Sign-On war fast abgeschlossen, aber der letzte Anmeldeschritt ist fehlgeschlagen. Bitte starten Sie die Anmeldung erneut.",
       "ssoLinkRequired": "Für dieses Konto ist bereits ein Passwort eingerichtet. Melden Sie sich mit Ihrem Passwort an und verknüpfen Sie anschließend SSO unter Profil → Sicherheit."
     },
     "title": "Bei Breeze anmelden"

--- a/apps/web/src/locales/en/auth.json
+++ b/apps/web/src/locales/en/auth.json
@@ -142,6 +142,7 @@
       "identityInUse": "That sign-in identity is already linked to a different account. Contact your administrator.",
       "inviteRequired": "Your sign-in succeeded, but no account here is linked to that identity yet. Ask your administrator for an invite, then try again.",
       "noPartnerAccess": "That account does not have access to this workspace. Contact your administrator.",
+      "ssoExchangeFailed": "Single sign-on almost completed, but the final sign-in step failed. Please start the sign-in again.",
       "ssoLinkRequired": "This account already has a password. Sign in with your password, then connect SSO under Profile → Security."
     },
     "title": "Sign in to Breeze"

--- a/apps/web/src/locales/es-419/auth.json
+++ b/apps/web/src/locales/es-419/auth.json
@@ -142,6 +142,7 @@
       "identityInUse": "Esa identidad de inicio de sesión ya está vinculada a una cuenta diferente. Póngase en contacto con su administrador.",
       "inviteRequired": "Su inicio de sesión fue exitoso, pero ninguna cuenta aquí está vinculada a esa identidad todavía. Solicite una invitación a su administrador y vuelva a intentarlo.",
       "noPartnerAccess": "Esa cuenta no tiene acceso a este espacio de trabajo. Póngase en contacto con su administrador.",
+      "ssoExchangeFailed": "El inicio de sesión único casi se completó, pero el último paso falló. Vuelva a iniciar sesión.",
       "ssoLinkRequired": "Esta cuenta ya tiene una contraseña. Inicie sesión con su contraseña, luego conéctese SSO en Perfil → Seguridad."
     },
     "title": "Iniciar sesión en Breeze"

--- a/apps/web/src/locales/fr-CA/auth.json
+++ b/apps/web/src/locales/fr-CA/auth.json
@@ -142,6 +142,7 @@
       "identityInUse": "Cette identité d’ouverture de session est déjà liée à un autre compte. Communiquez avec votre administrateur.",
       "inviteRequired": "Votre ouverture de session a réussi, mais aucun compte ici n’est encore lié à cette identité. Demandez une invitation à votre administrateur, puis réessayez.",
       "noPartnerAccess": "Ce compte n’a pas accès à cet espace de travail. Contactez votre administrateur.",
+      "ssoExchangeFailed": "L’authentification unique était presque terminée, mais la dernière étape a échoué. Veuillez recommencer l’ouverture de session.",
       "ssoLinkRequired": "Ce compte possède déjà un mot de passe. Ouvrez une session avec celui-ci, puis associez l’authentification unique dans Profil → Sécurité."
     },
     "title": "Ouvrir une session dans Breeze"

--- a/apps/web/src/locales/fr-FR/auth.json
+++ b/apps/web/src/locales/fr-FR/auth.json
@@ -142,6 +142,7 @@
       "identityInUse": "Cette identité de connexion est déjà liée à un autre compte. Contactez votre administrateur.",
       "inviteRequired": "Votre connexion a réussi, mais aucun compte ici n’est encore lié à cette identité. Demandez une invitation à votre administrateur, puis réessayez.",
       "noPartnerAccess": "Ce compte n’a pas accès à cet espace de travail. Contactez votre administrateur.",
+      "ssoExchangeFailed": "L'authentification unique était presque terminée, mais la dernière étape de connexion a échoué. Veuillez recommencer la connexion.",
       "ssoLinkRequired": "Ce compte a déjà un mot de passe. Connectez-vous avec votre mot de passe, puis connectez-vous SSO sous Profil → Sécurité."
     },
     "title": "Connectez-vous à Breeze"

--- a/apps/web/src/locales/it-IT/auth.json
+++ b/apps/web/src/locales/it-IT/auth.json
@@ -142,6 +142,7 @@
       "identityInUse": "Questa identità di accesso è già collegata a un altro account. Contatta il tuo amministratore.",
       "inviteRequired": "L'accesso è riuscito, ma qui non c'è ancora alcun account collegato a questa identità. Chiedi un invito al tuo amministratore, poi riprova.",
       "noPartnerAccess": "Questo account non ha accesso a questo spazio di lavoro. Contatta il tuo amministratore.",
+      "ssoExchangeFailed": "L'accesso Single Sign-On era quasi completato, ma l'ultimo passaggio non è riuscito. Riavvia l'accesso.",
       "ssoLinkRequired": "Questo account ha già una password. Accedi con la tua password, quindi collega SSO da Profilo → Sicurezza."
     },
     "title": "Accedi a Breeze"

--- a/apps/web/src/locales/pt-BR/auth.json
+++ b/apps/web/src/locales/pt-BR/auth.json
@@ -142,6 +142,7 @@
       "identityInUse": "Essa identidade de login já está vinculada a outra conta. Entre em contato com o administrador.",
       "inviteRequired": "O login foi bem-sucedido, mas nenhuma conta aqui está vinculada a essa identidade. Peça um convite ao administrador e tente novamente.",
       "noPartnerAccess": "Essa conta não tem acesso a este workspace. Entre em contato com o administrador.",
+      "ssoExchangeFailed": "O logon único quase foi concluído, mas a etapa final de login falhou. Inicie o login novamente.",
       "ssoLinkRequired": "Esta conta já tem uma senha. Entre com sua senha e depois conecte o SSO em Perfil → Segurança."
     },
     "title": "Entrar no Breeze"

--- a/apps/web/src/locales/tr-TR/auth.json
+++ b/apps/web/src/locales/tr-TR/auth.json
@@ -142,6 +142,7 @@
       "identityInUse": "Bu oturum açma kimliği zaten farklı bir hesaba bağlı. Yöneticinizle iletişime geçin.",
       "inviteRequired": "Oturum açma işleminiz başarılı oldu ancak henüz bu kimliğe bağlı bir hesap yok. Yöneticinizden bir davet isteyin ve tekrar deneyin.",
       "noPartnerAccess": "Bu hesabın bu çalışma alanına erişimi yok. Yöneticinizle iletişime geçin.",
+      "ssoExchangeFailed": "Çoklu oturum açma neredeyse tamamlandı, ancak son oturum açma adımı başarısız oldu. Lütfen oturum açmayı yeniden başlatın.",
       "ssoLinkRequired": "Bu hesabın zaten bir şifresi var. Parolanızla oturum açın, ardından Profil → Güvenlik altında SSO'ya bağlanın."
     },
     "title": "Breeze'da oturum açın"

--- a/apps/web/src/stores/auth.ssoLoginGate.test.ts
+++ b/apps/web/src/stores/auth.ssoLoginGate.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  armSsoLoginGate,
+  fetchWithAuth,
+  settleSsoLoginGate,
+  useAuthStore,
+} from './auth';
+
+// #3700 SSO login gate: while a `#ssoCode` exchange is (about to be) in
+// flight, every refresh attempt must wait for it to settle. Without the gate,
+// a sibling island's fetchWithAuth bootstrap fires /auth/refresh against the
+// dead cookie of an enforce-SSO-locked-out user and hard-evicts to /login,
+// abandoning the single-use grant mid-exchange.
+describe('SSO login gate holds token refreshes (#3700)', () => {
+  const originalFetch = global.fetch;
+  let fetchCalls: string[];
+
+  beforeEach(() => {
+    fetchCalls = [];
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      fetchCalls.push(url);
+      if (url.includes('/auth/refresh')) {
+        return new Response(
+          JSON.stringify({ tokens: { accessToken: 'refreshed', expiresInSeconds: 900 } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+    useAuthStore.setState({
+      isAuthenticated: true,
+      isLoading: false,
+      tokens: null,
+      user: { id: 'u-1', email: 'a@b.c', name: 'A', mfaEnabled: false },
+      sessionExpiredReason: null,
+    });
+  });
+
+  afterEach(() => {
+    settleSsoLoginGate();
+    global.fetch = originalFetch;
+    useAuthStore.setState({ isAuthenticated: false, tokens: null, user: null });
+    vi.restoreAllMocks();
+  });
+
+  it('defers the bootstrap refresh until the gate settles, then proceeds', async () => {
+    armSsoLoginGate();
+
+    const pending = fetchWithAuth('/config');
+
+    // Give the held refresh every chance to fire while the gate is armed.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fetchCalls.filter((u) => u.includes('/auth/refresh'))).toHaveLength(0);
+
+    settleSsoLoginGate();
+    const response = await pending;
+
+    expect(response.status).toBe(200);
+    expect(fetchCalls.some((u) => u.includes('/auth/refresh'))).toBe(true);
+    expect(useAuthStore.getState().tokens?.accessToken).toBe('refreshed');
+  });
+
+  it('settleSsoLoginGate is a safe no-op when no gate is armed', () => {
+    expect(() => settleSsoLoginGate()).not.toThrow();
+  });
+});

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -533,8 +533,56 @@ export async function restoreAccessTokenFromCookie(): Promise<boolean> {
 export async function bootstrapFromCfAccessRedirect(): Promise<boolean> {
   const outcome = await requestTokenRefreshShared();
   if (outcome.kind !== 'restored' || !outcome.tokens.accessToken) return false;
-  const tokens = outcome.tokens;
+  return completeBootstrapLogin(outcome.tokens);
+}
 
+/**
+ * Bootstraps the auth store after an SSO (OIDC/SAML) redirect login (#3700).
+ *
+ * The SSO callback mints a one-time token-exchange grant and redirects to the
+ * app with `#ssoCode=<grant>` in the fragment (never a query param, so the
+ * grant is not sent to the server or logged in access logs). AuthOverlay
+ * consumes the fragment and calls this helper, which:
+ *
+ *   1. Trades the grant for an access token via POST `/sso/exchange` (which
+ *      also sets the HttpOnly refresh cookie server-side)
+ *   2. Fetches the user record (`/users/me`) with that token
+ *   3. Populates the store via `login(user, tokens)`
+ *
+ * Returns true if the store was populated; false if any step failed (the
+ * caller should bounce to /login with an error notice). The grant is
+ * single-use and short-lived, so a failed exchange is not retryable — the
+ * user re-initiates SSO login instead.
+ */
+export async function bootstrapFromSsoCode(code: string): Promise<boolean> {
+  let exchangeResponse: Response;
+  try {
+    exchangeResponse = await fetch(buildApiUrl('/sso/exchange'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ code }),
+    });
+  } catch {
+    return false;
+  }
+
+  if (!exchangeResponse.ok) return false;
+
+  const data = (await exchangeResponse.json().catch(() => null)) as
+    | { accessToken?: string; expiresInSeconds?: number }
+    | null;
+  if (!data?.accessToken) return false;
+
+  return completeBootstrapLogin({
+    accessToken: data.accessToken,
+    expiresInSeconds: data.expiresInSeconds ?? 900,
+  });
+}
+
+// Shared tail of the redirect-login bootstraps (CF Access, SSO): fetch the
+// user record with the freshly-minted access token and populate the store.
+async function completeBootstrapLogin(tokens: Tokens): Promise<boolean> {
   let meResponse: Response;
   try {
     meResponse = await fetch(buildApiUrl('/users/me'), {

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -444,7 +444,65 @@ async function requestTokenRefresh(): Promise<RefreshOutcome> {
 
 let tokenRefreshInFlight: Promise<RefreshOutcome> | null = null;
 
+// ---- SSO login gate (#3700) -------------------------------------------------
+//
+// When the page loads with `#ssoCode=` in the fragment, an SSO token exchange
+// is about to run — but it only starts once AuthOverlay mounts and its 50ms
+// rehydrate timer fires. Sibling islands (Header, AuthGuard, DashboardWrapper)
+// race ahead of that: with a stale persisted `isAuthenticated: true` and a
+// DEAD refresh cookie (exactly the state an enforce-SSO-locked-out user is
+// in), their first fetchWithAuth/restore call fails the cookie refresh and
+// hard-evicts to /login, abandoning the single-use grant mid-exchange.
+//
+// The gate is armed SYNCHRONOUSLY at module load (before any island effect can
+// run) and makes every refresh attempt wait until the exchange settles. After
+// a successful exchange the refresh cookie is fresh, so the queued refreshes
+// succeed; after a failed one they proceed to their normal eviction path. The
+// timeout is a deadlock backstop for the pathological case where nothing ever
+// consumes the fragment (e.g. the landing page renders no AuthOverlay).
+const SSO_LOGIN_GATE_TIMEOUT_MS = 15_000;
+let ssoLoginGate: Promise<void> | null = null;
+let ssoLoginGateSettle: (() => void) | null = null;
+let ssoLoginGateTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function armSsoLoginGate(): void {
+  if (ssoLoginGate) return;
+  ssoLoginGate = new Promise<void>((resolve) => {
+    ssoLoginGateSettle = resolve;
+  });
+  ssoLoginGateTimer = setTimeout(() => {
+    console.warn('[ssoLoginGate] timed out waiting for the SSO exchange to settle');
+    settleSsoLoginGate();
+  }, SSO_LOGIN_GATE_TIMEOUT_MS);
+}
+
+/** Release refreshes held by the gate. Safe to call when no gate is armed. */
+export function settleSsoLoginGate(): void {
+  if (ssoLoginGateTimer) {
+    clearTimeout(ssoLoginGateTimer);
+    ssoLoginGateTimer = null;
+  }
+  ssoLoginGateSettle?.();
+  ssoLoginGateSettle = null;
+  ssoLoginGate = null;
+}
+
+// Optional chaining: tests (and some embedders) stub `window.location` with a
+// partial object, and this runs at module load where a throw breaks every
+// importer of the store.
+if (typeof window !== 'undefined' && window.location?.hash?.startsWith('#ssoCode=')) {
+  armSsoLoginGate();
+}
+// ----------------------------------------------------------------------------
+
 async function requestTokenRefreshShared(): Promise<RefreshOutcome> {
+  // Hold every refresh while an SSO exchange is (about to be) in flight — a
+  // dead-cookie verdict reached mid-exchange evicts the session and abandons
+  // the grant. See the SSO login gate block above.
+  if (ssoLoginGate) {
+    await ssoLoginGate;
+  }
+
   if (tokenRefreshInFlight) {
     return tokenRefreshInFlight;
   }
@@ -552,7 +610,10 @@ export async function bootstrapFromCfAccessRedirect(): Promise<boolean> {
  * Returns true if the store was populated; false if any step failed (the
  * caller should bounce to /login with an error notice). The grant is
  * single-use and short-lived, so a failed exchange is not retryable — the
- * user re-initiates SSO login instead.
+ * user re-initiates SSO login instead. One partial-success shape to know
+ * about: if the exchange succeeded but the /users/me step failed, the
+ * HttpOnly refresh cookie IS already set, so the /login page's cookie-restore
+ * path may sign the user in without any re-initiation.
  */
 export async function bootstrapFromSsoCode(code: string): Promise<boolean> {
   let exchangeResponse: Response;
@@ -562,17 +623,27 @@ export async function bootstrapFromSsoCode(code: string): Promise<boolean> {
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ code }),
+      // Bounded so a black-holed request settles before AuthOverlay's 10s
+      // safety net fires its bare (error-less) /login redirect.
+      signal: AbortSignal.timeout(8000),
     });
-  } catch {
+  } catch (err) {
+    console.warn('[bootstrapFromSsoCode] /sso/exchange request failed', err);
     return false;
   }
 
-  if (!exchangeResponse.ok) return false;
+  if (!exchangeResponse.ok) {
+    console.warn('[bootstrapFromSsoCode] /sso/exchange rejected', exchangeResponse.status);
+    return false;
+  }
 
   const data = (await exchangeResponse.json().catch(() => null)) as
     | { accessToken?: string; expiresInSeconds?: number }
     | null;
-  if (!data?.accessToken) return false;
+  if (!data?.accessToken) {
+    console.warn('[bootstrapFromSsoCode] /sso/exchange returned no access token');
+    return false;
+  }
 
   return completeBootstrapLogin({
     accessToken: data.accessToken,
@@ -592,14 +663,23 @@ async function completeBootstrapLogin(tokens: Tokens): Promise<boolean> {
         'Content-Type': 'application/json',
       },
       credentials: 'include',
+      signal: AbortSignal.timeout(8000),
     });
-  } catch {
+  } catch (err) {
+    console.warn('[completeBootstrapLogin] /users/me request failed', err);
     return false;
   }
 
-  if (!meResponse.ok) return false;
+  if (!meResponse.ok) {
+    console.warn('[completeBootstrapLogin] /users/me rejected', meResponse.status);
+    return false;
+  }
 
-  const user = (await meResponse.json()) as User | null;
+  // .catch: a 200 with a non-JSON body (proxy/CDN interstitial) must resolve
+  // to a clean `false` — an uncaught rejection here escapes both bootstrap
+  // callers' .then chains, and the user hangs on the overlay spinner until
+  // the 10s safety net drops them on a bare /login with no error notice.
+  const user = (await meResponse.json().catch(() => null)) as User | null;
   if (!user || !user.id) return false;
 
   useAuthStore.getState().login(user, tokens);


### PR DESCRIPTION
## Summary

Closes #3700.

The API's SSO callback mints a one-time token-exchange grant and redirects to the app with `#ssoCode=<grant>`, but the web app never implemented the client half — nothing consumed the fragment or called `POST /sso/exchange`, so every SSO login bounced back to `/login`. With **Enforce SSO** enabled that was a guaranteed full-tenant lockout (field incident, US hosted partner, 2026-08-17 — remediated live by flipping `enforce_sso=false`).

## What this adds

**Commit 1 — the missing client half**
- `stores/auth.ts`: `bootstrapFromSsoCode()` — `POST /sso/exchange` (also sets the HttpOnly refresh cookie server-side) → `GET /users/me` → `login(user, tokens)`. Shared `completeBootstrapLogin()` tail extracted from the CF Access bootstrap.
- `AuthOverlay`: consumes the fragment before any other recovery path, stripping it from the URL synchronously so the single-use grant can't be replayed or copied. Failure → `/login?error=sso_exchange_failed`. A live session strips a stale grant without exchanging.
- `LoginPage` + all 8 locales: copy for the new error code.

**Commit 2 — multi-agent review round (4 agents + verify pass)**
- **SSO login gate** (Critical): the enforce-SSO lockout arrival state is stale persisted `isAuthenticated:true` + dead refresh cookie. Sibling islands (`Header`, `AuthGuard`, `DashboardWrapper`) fire `fetchWithAuth`/restore before the exchange starts, fail the cookie refresh, and hard-evict to `/login` mid-exchange. A gate armed synchronously at auth-store module load (fragment sniff) holds every `requestTokenRefreshShared` caller until the exchange settles (15s deadlock backstop); AuthOverlay's slow path additionally gated on `!isRecovering`.
- **Rejection-proof bootstrap** (Critical): un-caught `meResponse.json()` on a 200-with-non-JSON body (proxy/CDN interstitial) stranded the user on the spinner until the 10s safety net → bare `/login` with no notice. Now caught, with a defensive `.catch` on the overlay chain.
- Malformed/empty `#ssoCode` fragments surface the error notice + `console.warn` instead of an unexplained bare `/login`; 8s timeouts on both bootstrap fetches; diagnostics at every early return.

## Testing

- 9 new AuthOverlay specs: success handoff + synchronous fragment strip, rejected exchange, live-session-wins, malformed/empty fragments, `/users/me` 500 and non-JSON, exchange network throw, stale-auth race (dead-cookie refresh must not evict mid-exchange).
- New `auth.ssoLoginGate.test.ts`: gate holds the bootstrap refresh until settled, then it proceeds; settle is a safe no-op unarmed.
- Full `src/components/auth` + `src/stores` + locale-parity suites green (306 tests); web typecheck clean.

## Notes for reviewers

- The `#ssoCode` fragment (not query) delivery is unchanged API behavior — fragments never reach server logs or Referer.
- The exchange's in-memory grant map on the API side is single-instance only; fine for current droplet topology, pre-existing, untouched here.
- Issue #3700's "gate enforcement behind a verified round-trip login" guardrail is now largely moot (login works) — deliberately not included to keep this focused; can follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)