### PR TITLE
fix(web): confirm-gate single-device reboot from the devices list (#3698)

### DIFF
--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -1158,9 +1158,32 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
       render(<DevicesPage />);
       fireEvent.click(await screen.findByTestId(`row-reboot-${DEV_1}`));
 
+      // #3698: the row action is confirm-gated now, matching the device detail
+      // page. Nothing may reach the API until the operator confirms.
+      expect(vi.mocked(sendDeviceCommand)).not.toHaveBeenCalled();
+      fireEvent.click(await screen.findByTestId('confirm-device-action'));
+
       await waitFor(() => expect(vi.mocked(sendDeviceCommand)).toHaveBeenCalledTimes(1));
       return vi.mocked(showToast).mock.calls.map(c => c[0]);
     }
+
+    // #3698: the reason this issue existed — the list fired immediately while
+    // the detail page confirmed. Pin both halves of the gate.
+    it('does not queue anything until the confirm is accepted', async () => {
+      const { sendDeviceCommand } = await import('../../services/deviceActions');
+      vi.mocked(sendDeviceCommand).mockResolvedValue({ command: {} } as never);
+      vi.mocked(fetchAllDevices).mockResolvedValue({
+        data: [{ ...rawDevice(DEV_1, 'host-alpha'), status: 'online' }],
+      } as never);
+
+      render(<DevicesPage />);
+      fireEvent.click(await screen.findByTestId(`row-reboot-${DEV_1}`));
+
+      // The dialog names the machine, so a mis-click on a dense list is
+      // recoverable rather than merely delayed.
+      expect(await screen.findByText(/host-alpha/)).toBeTruthy();
+      expect(vi.mocked(sendDeviceCommand)).not.toHaveBeenCalled();
+    });
 
     it('online device: reports the command as sent, naming the device', async () => {
       const toasts = await rebootDeviceWithStatus('online');

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -125,6 +125,12 @@ export default function DevicesPage() {
   // silently discarded.
   type PendingDecommissionedSkip = { action: string; devices: Device[]; skippedCount: number; totalCount: number };
   const [pendingDecommissionedSkip, setPendingDecommissionedSkip] = useState<PendingDecommissionedSkip | null>(null);
+  // #3698: single-device destructive actions from the row kebab. The device
+  // DETAIL page has always confirmed these (DeviceActions.tsx); the list did
+  // not, so whether rebooting a production box asked "are you sure?" depended
+  // on which screen you were on — and the list is the dense, easy-to-mis-click
+  // one, with Reboot sitting next to Run Script and Wake.
+  const [pendingDeviceAction, setPendingDeviceAction] = useState<{ action: string; device: Device } | null>(null);
   const [settingsDevice, setSettingsDevice] = useState<Device | null>(null);
   // v2 chip bar seeds its filter from the URL hash so a filtered view is
   // shareable; the legacy DeviceFilterBar owns its own state and ignores it.
@@ -654,7 +660,25 @@ export default function DevicesPage() {
     }
   };
 
+  // Destructive single-device actions. `lock` is deliberately NOT here: it is
+  // reversible and does not disconnect the machine, matching the detail page,
+  // which only confirms these three.
+  const CONFIRM_REQUIRED_ACTIONS = new Set(['reboot', 'reboot_safe_mode', 'shutdown']);
+
+  // The command name is snake_case; the locale keys are camelCase.
+  const confirmKeyFor = (action: string): string =>
+    action === 'reboot_safe_mode' ? 'rebootSafeMode' : action;
+
   const handleDeviceAction = async (action: string, device: Device) => {
+    if (actionInProgress) return;
+    if (CONFIRM_REQUIRED_ACTIONS.has(action)) {
+      setPendingDeviceAction({ action, device });
+      return;
+    }
+    await runDeviceAction(action, device);
+  };
+
+  const runDeviceAction = async (action: string, device: Device) => {
     if (actionInProgress) return;
 
     try {
@@ -1417,6 +1441,30 @@ export default function DevicesPage() {
             total: pendingDecommissionedSkip.totalCount,
             eligible: pendingDecommissionedSkip.devices.length,
           })}
+        />
+      )}
+
+      {/* #3698: mirror of the device-detail confirm gate, reusing the SAME
+          deviceActions.confirm.* copy so the two screens read identically and
+          no new locale keys are needed. Confirming UNMOUNTS the dialog, which
+          is what makes a double-click safe — see the decommissioned-skip
+          dialog above for why isLoading is deliberately absent. */}
+      {pendingDeviceAction && (
+        <ConfirmDialog
+          open={true}
+          onClose={() => setPendingDeviceAction(null)}
+          onConfirm={() => {
+            const p = pendingDeviceAction;
+            setPendingDeviceAction(null);
+            void runDeviceAction(p.action, p.device);
+          }}
+          title={t(/* i18n-dynamic */ `deviceActions.confirm.${confirmKeyFor(pendingDeviceAction.action)}.title`)}
+          message={t(/* i18n-dynamic */ `deviceActions.confirm.${confirmKeyFor(pendingDeviceAction.action)}.message`, {
+            hostname: pendingDeviceAction.device.hostname,
+          })}
+          confirmLabel={t(/* i18n-dynamic */ `deviceActions.confirm.${confirmKeyFor(pendingDeviceAction.action)}.confirm`)}
+          variant={pendingDeviceAction.action === 'shutdown' ? 'destructive' : 'warning'}
+          confirmTestId="confirm-device-action"
         />
       )}
 


### PR DESCRIPTION
Closes #3698.

The row kebab on `/devices` fired a reboot on one click while the identical action on the device **detail** page has always been confirm-gated. Whether rebooting a production box asked "are you sure?" depended purely on which screen the tech was on — and the list is the wrong one to leave open, with dense adjacent rows and Reboot sitting beside Run Script and Wake.

It is worse offline: the command sits `pending` and fires whenever the machine next reconnects, so a stray click can land hours later on a box nobody is thinking about.

## Change

`handleDeviceAction` routes `reboot`, `reboot_safe_mode` and `shutdown` through a `ConfirmDialog` into a new `runDeviceAction`, which holds the original body unchanged.

Of those, **only `reboot` is currently emitted by the list kebab** — it emits `decommission, reboot, restore, run-script, settings, terminal, wake`. The other two are gated at the shared handler so a later menu addition inherits the guard instead of reintroducing this bug.

`lock` is deliberately not gated: reversible, does not disconnect the machine, and the detail page draws the same line.

The dialog reuses the existing `deviceActions.confirm.*` copy the detail page already uses, so the two screens read identically and **no new keys are needed in any of the eight locales**. It names the hostname, so a mis-click is recoverable rather than merely delayed. `shutdown` keeps `destructive`; the reboots stay `warning`, matching the detail page.

Confirming unmounts the dialog — that is what makes a double-click safe, for the reason the decommissioned-skip dialog documents a few lines above: kept mounted, both `ConfirmDialog`'s `disabled` and `actionInProgress` read a closure captured at render and are still false on the second click.

## Two things I want your call on

**1. `decommission` — knowingly left alone.** It is on the same kebab, it is the most destructive item there, and the detail page confirms it. But the list already guards it differently: a 5-second undo toast that defers the call. That reads as a deliberate product choice, not an oversight, and swapping an undo affordance for a modal is a UX decision I did not want to make inside a reboot fix. If you want true parity I will add it; if the undo pattern is intentional, this PR's "the list and the detail should agree" framing should probably say "except decommission, which agrees differently".

**2. A residual double-click concern I did not act on.** An adversarial review argued that unmount-on-confirm stops the *same* detached button firing twice but can let a genuine second physical click hit-test through to whatever sits underneath once the portal is removed, and that the safer shape is keeping the backdrop mounted with `isLoading` plus a synchronous ref guard. I did not change it, because the unmount behaviour here is the established pattern in this file with a written rationale, and the falsifier is a coordinate-level browser test rather than anything the unit suite can show. Worth its own issue if you think the concern is real.

## Tests

Six existing #2630 toast tests drove the row action directly and now click through the gate. I updated them rather than working around them, since they encoded exactly the unguarded behaviour this issue is about — they still distinguish sent-vs-queued after confirmation. Added a test that nothing reaches the API until the operator confirms and that the dialog names the machine.

Control run: with the gate removed, the new test fails and the six updated ones fail with it.

## Verification

Full `@breeze/web` suite **599 files / 5921 tests pass**. `astro check`: 0 errors, 0 warnings. eslint clean on both changed files. The 7 i18n suites (118 tests) pass, including locale parity and key usage — the dynamic key carries the `/* i18n-dynamic */` marker the key-usage gate expects.
