### PR TITLE
refactor(web): hoist the #3698 confirm constants and cover the grid-card path

### DIFF
--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -117,10 +117,23 @@ vi.mock('../filters/DeviceFilterBar', () => ({ DeviceFilterBar: () => null }));
 vi.mock('./DeviceFilterToolbar', () => ({ DeviceFilterToolbar: () => null }));
 vi.mock('../shared/ProgressBar', () => ({ default: () => null }));
 
-// DeviceCard stub renders the hostname so the grid contents are assertable.
+// DeviceCard stub renders the hostname so the grid contents are assertable, and
+// re-emits reboot so the GRID path through handleDeviceAction is covered too —
+// the real DeviceCard emits it from its own kebab (DeviceCard.tsx), and #3698's
+// gate lives on the shared handler, so both surfaces inherit it.
 vi.mock('./DeviceCard', () => ({
-  default: ({ device }: { device: { id: string; hostname: string } }) => (
-    <div data-testid={`device-card-${device.id}`}>{device.hostname}</div>
+  default: ({ device, onAction }: { device: { id: string; hostname: string }; onAction?: (action: string, device: unknown) => void }) => (
+    <div data-testid={`device-card-${device.id}`}>
+      {device.hostname}
+      {/* No text content on purpose: sibling tests assert the card's exact
+          textContent equals the hostname. */}
+      <button
+        type="button"
+        aria-label="card reboot"
+        data-testid={`card-reboot-${device.id}`}
+        onClick={() => onAction?.('reboot', device)}
+      />
+    </div>
   ),
 }));
 
@@ -1183,6 +1196,25 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
       // recoverable rather than merely delayed.
       expect(await screen.findByText(/host-alpha/)).toBeTruthy();
       expect(vi.mocked(sendDeviceCommand)).not.toHaveBeenCalled();
+    });
+
+    // #3698 follow-up: the gate lives on the shared handler, so the GRID card
+    // inherits it. Todd flagged this path as gated-but-untested on review.
+    it('grid card reboot is confirm-gated on the same terms as the list row', async () => {
+      const { sendDeviceCommand } = await import('../../services/deviceActions');
+      vi.mocked(sendDeviceCommand).mockResolvedValue({ command: {} } as never);
+      vi.mocked(fetchAllDevices).mockResolvedValue({
+        data: [{ ...rawDevice(DEV_1, 'host-alpha'), status: 'online' }],
+      } as never);
+
+      render(<DevicesPage />);
+      fireEvent.click(await screen.findByLabelText('Grid view'));
+      fireEvent.click(await screen.findByTestId(`card-reboot-${DEV_1}`));
+
+      expect(vi.mocked(sendDeviceCommand)).not.toHaveBeenCalled();
+      fireEvent.click(await screen.findByTestId('confirm-device-action'));
+      await waitFor(() => expect(vi.mocked(sendDeviceCommand)).toHaveBeenCalledTimes(1));
+      expect(vi.mocked(sendDeviceCommand)).toHaveBeenCalledWith(DEV_1, 'reboot');
     });
 
     it('online device: reports the command as sent, naming the device', async () => {

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -90,6 +90,17 @@ function summarizeFailedDevices(names: string[]): string {
   return rest > 0 ? `${shown.join(', ')} and ${rest} more` : shown.join(', ');
 }
 
+// #3698: destructive single-device actions, confirm-gated to match the device
+// detail page. `lock` is deliberately NOT here: it is reversible and does not
+// disconnect the machine, which is where DeviceActions.tsx draws the same line.
+// Module scope — these are constant, so there is no reason to rebuild them on
+// every render.
+const CONFIRM_REQUIRED_ACTIONS = new Set(['reboot', 'reboot_safe_mode', 'shutdown']);
+
+// The command name is snake_case; the locale keys are camelCase.
+const confirmKeyFor = (action: string): string =>
+  action === 'reboot_safe_mode' ? 'rebootSafeMode' : action;
+
 export default function DevicesPage() {
   const { t } = useTranslation('devices');
   // Org scope is shown by the always-visible top-bar switcher (scope pill +
@@ -659,15 +670,6 @@ export default function DevicesPage() {
       setActionInProgress(false);
     }
   };
-
-  // Destructive single-device actions. `lock` is deliberately NOT here: it is
-  // reversible and does not disconnect the machine, matching the detail page,
-  // which only confirms these three.
-  const CONFIRM_REQUIRED_ACTIONS = new Set(['reboot', 'reboot_safe_mode', 'shutdown']);
-
-  // The command name is snake_case; the locale keys are camelCase.
-  const confirmKeyFor = (action: string): string =>
-    action === 'reboot_safe_mode' ? 'rebootSafeMode' : action;
 
   const handleDeviceAction = async (action: string, device: Device) => {
     if (actionInProgress) return;


### PR DESCRIPTION
Both nits from your #3703 review. Small enough that I'd have folded them in had the PR still been open.

**Hoisted the constants.** `CONFIRM_REQUIRED_ACTIONS` and `confirmKeyFor` were declared inside the component and rebuilt on every render. They're constant; module scope now.

**Covered the grid-card path.** You were right that it was gated-but-untested and undersold. The guard lives on the shared `handleDeviceAction`, and `DeviceCard` routes through it exactly like the list row (`DeviceCard.tsx:278` → `onAction={handleDeviceAction}`), so the grid inherited it for free. The `DeviceCard` stub now re-emits `reboot` and a test drives that path end to end: nothing reaches the API before the confirm, and the confirmed call is `sendDeviceCommand(id, 'reboot')`.

Worth noting the stub's button carries an `aria-label` and no text on purpose — sibling tests assert a card's exact `textContent` equals the hostname, and giving it visible text broke two of them on the first attempt.

Also filed #3705 for the double-click hit-through, scoped as you asked: framed against all three `ConfirmDialog` call sites in the file rather than the one this PR added, with the point that a jsdom test structurally cannot settle it and a Playwright `dblclick()` in both layouts is what would. I was explicit there that I have not reproduced the click-through — the mechanism is legible from the portal teardown, but the observation is missing, so it may well close as not-exploitable.

**Verification:** full `@breeze/web` suite **600 files / 5933 tests pass**, `astro check` 0 errors 0 warnings, eslint clean on both files. Control run: with the gate removed the new grid test fails.
