### PR TITLE
fix(web): batch bulk vulnerability actions to the server's 200-id cap (#3694)

### DIFF
--- a/apps/web/src/lib/api/vulnerabilities.chunking.test.ts
+++ b/apps/web/src/lib/api/vulnerabilities.chunking.test.ts
@@ -1,0 +1,150 @@
+// #3694: the API caps deviceVulnerabilityIds at 200 and the web layer used to
+// POST the whole selection, so any selection over 200 failed with
+// `Too big: expected array to have <=200 items` — reported against a real
+// 576-finding remediation.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+
+const showToast = vi.fn();
+vi.mock('../../components/shared/Toast', () => ({ showToast: (...a: unknown[]) => showToast(...a) }));
+
+import { remediateVuln, bulkAcceptVulnRisk, bulkMitigateVulns, createVulnTicket } from './vulnerabilities';
+
+const ids = (n: number) => Array.from({ length: n }, (_, i) => `id-${i}`);
+const sentBatches = () =>
+  fetchWithAuth.mock.calls.map((c) => JSON.parse((c[1] as { body: string }).body).deviceVulnerabilityIds as string[]);
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+  showToast.mockReset();
+  // A Response body is single-use: mockResolvedValue would hand the SAME object
+  // to every batch and the second .json() would throw. Build a fresh one per call.
+  // Respond with the ACTUAL batch size: a fixed 200 let the 176-id final batch
+  // report 200 and the suite blessed an impossible total of 600.
+  fetchWithAuth.mockImplementation((_url: string, opts: { body: string }) => {
+    const n = (JSON.parse(opts.body).deviceVulnerabilityIds as string[]).length;
+    return Promise.resolve(new Response(JSON.stringify({ scheduled: n, skipped: [], success: true, succeeded: n })));
+  });
+});
+
+describe('#3694 bulk id chunking', () => {
+  it('sends 576 findings as three batches of 200/200/176, none over the cap', async () => {
+    await remediateVuln(ids(576));
+    const batches = sentBatches();
+    expect(batches.map((b) => b.length)).toEqual([200, 200, 176]);
+    expect(batches.flat()).toEqual(ids(576));            // every id sent exactly once, in order
+    expect(Math.max(...batches.map((b) => b.length))).toBeLessThanOrEqual(200);
+  });
+
+  it('at or under the cap it stays a SINGLE request — the unchanged path', async () => {
+    await remediateVuln(ids(200));
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+    expect(sentBatches()[0]).toHaveLength(200);
+  });
+
+  it('emits ONE aggregate success toast for a multi-batch run, not one per batch', async () => {
+    await remediateVuln(ids(576));
+    const successes = showToast.mock.calls.filter((c) => (c[0] as { type: string }).type === 'success');
+    expect(successes).toHaveLength(1);
+    expect((successes[0][0] as { message: string }).message).toContain('576'); // 200+200+176, the real total
+  });
+
+  it('reports partial progress when a later batch fails, instead of failing silently', async () => {
+    fetchWithAuth
+      .mockImplementationOnce(() => Promise.resolve(new Response(JSON.stringify({ scheduled: 200, skipped: [] }))))
+      .mockImplementationOnce(() => Promise.resolve(new Response(JSON.stringify({ error: 'boom' }), { status: 500 })));
+
+    await expect(remediateVuln(ids(576))).rejects.toThrow();
+
+    const errs = showToast.mock.calls
+      .filter((c) => (c[0] as { type: string }).type === 'error')
+      .map((c) => (c[0] as { message: string }).message);
+    // The operator must learn that 200 DID schedule and 376 did not.
+    expect(errs.some((m) => m.includes('200') && m.includes('576'))).toBe(true);
+  });
+
+  it('bulk accept-risk and mitigate chunk the same way and keep their payload', async () => {
+    await bulkAcceptVulnRisk(ids(450), { reason: 'r', acceptedUntil: '2026-12-01' });
+    expect(sentBatches().map((b) => b.length)).toEqual([200, 200, 50]);
+    expect(JSON.parse((fetchWithAuth.mock.calls[0][1] as { body: string }).body).reason).toBe('r');
+
+    fetchWithAuth.mockClear();
+    await bulkMitigateVulns(ids(201), { note: 'n' });
+    expect(sentBatches().map((b) => b.length)).toEqual([200, 1]);
+    expect(JSON.parse((fetchWithAuth.mock.calls[0][1] as { body: string }).body).note).toBe('n');
+  });
+
+
+  // Codex caught these three as unproven: each mutation below passed the
+  // original suite.
+
+  it('the single-batch path STILL emits its success toast (not silently muted)', async () => {
+    await remediateVuln(ids(10));
+    const successes = showToast.mock.calls.filter((c) => (c[0] as { type: string }).type === 'success');
+    expect(successes).toHaveLength(1);
+    // Flipping the at-cap branch to send(ids, false) would drop this toast and
+    // was previously invisible to the suite.
+    expect((successes[0][0] as { message: string }).message).toContain('10');
+  });
+
+  it('batches run SEQUENTIALLY — request 2 does not start until request 1 settles', async () => {
+    const started: number[] = [];
+    let releaseFirst: (() => void) | undefined;
+    fetchWithAuth.mockImplementation((_u: string, opts: { body: string }) => {
+      const n = (JSON.parse(opts.body).deviceVulnerabilityIds as string[]).length;
+      started.push(n);
+      const res = new Response(JSON.stringify({ scheduled: n, skipped: [] }));
+      if (started.length === 1) return new Promise((r) => { releaseFirst = () => r(res); });
+      return Promise.resolve(res);
+    });
+
+    const p = remediateVuln(ids(576));
+    await Promise.resolve();
+    // A concurrent implementation that merely awaits in order would have fired
+    // all three by now.
+    expect(started).toHaveLength(1);
+    releaseFirst!();
+    await p;
+    expect(started).toEqual([200, 200, 176]);
+  });
+
+  it('stops dead on a failed batch — no further requests are sent', async () => {
+    fetchWithAuth
+      .mockImplementationOnce(() => Promise.resolve(new Response(JSON.stringify({ scheduled: 200, skipped: [] }))))
+      .mockImplementationOnce(() => Promise.resolve(new Response(JSON.stringify({ error: 'boom' }), { status: 500 })));
+    await expect(remediateVuln(ids(576))).rejects.toThrow();
+    expect(fetchWithAuth).toHaveBeenCalledTimes(2);   // the third batch must never fire
+  });
+
+  it('the partial message warns about duplicate installs rather than inviting a blind retry', async () => {
+    fetchWithAuth
+      .mockImplementationOnce(() => Promise.resolve(new Response(JSON.stringify({ scheduled: 200, skipped: [] }))))
+      .mockImplementationOnce(() => Promise.resolve(new Response(JSON.stringify({ error: 'boom' }), { status: 500 })));
+    await expect(remediateVuln(ids(576))).rejects.toThrow();
+    const errs = showToast.mock.calls
+      .filter((c) => (c[0] as { type: string }).type === 'error')
+      .map((c) => (c[0] as { message: string }).message);
+    // "At least N" not "exactly N": the failed batch may also have applied work.
+    expect(errs.some((m) => m.includes('At least 200') && /duplicate/i.test(m))).toBe(true);
+  });
+
+  // Tickets are the exception: the server creates ONE ticket per org, so three
+  // batches would create three tickets per org rather than one.
+  it('does NOT chunk ticket creation — it refuses with actionable copy', async () => {
+    await expect(
+      createVulnTicket(ids(576), { title: 't', priority: 'high' }),
+    ).rejects.toThrow(/at most 200/);
+    expect(fetchWithAuth).not.toHaveBeenCalled();
+    const msg = (showToast.mock.calls[0][0] as { message: string }).message;
+    expect(msg).toContain('duplicates');
+  });
+
+  it('still creates a ticket normally at or under the cap', async () => {
+    fetchWithAuth.mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify({ success: true, tickets: [{ ticketId: 't1', orgId: 'o1', findingCount: 5 }], skipped: [] }))));
+    await createVulnTicket(ids(200), { title: 't', priority: 'high' });
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/api/vulnerabilities.ts
+++ b/apps/web/src/lib/api/vulnerabilities.ts
@@ -19,7 +19,8 @@ import {
 } from '@breeze/shared';
 
 import { fetchWithAuth } from '../../stores/auth';
-import { runAction } from '../runAction';
+import { runAction, ActionError } from '../runAction';
+import { showToast } from '../../components/shared/Toast';
 
 // Re-export the shared fleet-triage domain types so existing web call sites that
 // import them from this module keep working (single source of truth is
@@ -235,22 +236,112 @@ export async function fetchCveDevices(cveId: string): Promise<CveDevicesPayload>
   return res.json() as Promise<CveDevicesPayload>;
 }
 
+// ---- Bulk chunking (#3694) ----
+
+/**
+ * Mirrors the server's `deviceVulnerabilityIds` cap (`routes/vulnerabilities.ts`,
+ * `.max(200)` on remediate / bulk accept-risk / bulk mitigate / tickets).
+ *
+ * The cap is a request-size bound, not a product limit: `remediateVulnerabilities`
+ * loops per finding doing ~5 queries plus a command enqueue inside ONE synchronous
+ * request. Raising it server-side would just move the timeout. So the client
+ * batches instead — a 576-finding selection becomes three sequential requests
+ * rather than one guaranteed `Too big: expected array to have <=200 items`.
+ */
+const BULK_ID_LIMIT = 200;
+
+function chunkIds(ids: string[]): string[][] {
+  const out: string[][] = [];
+  for (let i = 0; i < ids.length; i += BULK_ID_LIMIT) out.push(ids.slice(i, i + BULK_ID_LIMIT));
+  return out;
+}
+
+interface ChunkedSpec<T> {
+  /** Sends ONE batch. `toast` is false for multi-batch runs so runAction stays
+   *  silent and this helper emits a single aggregate toast instead. */
+  send: (batch: string[], toast: boolean) => Promise<T>;
+  empty: T;
+  merge: (acc: T, next: T) => T;
+  /** Aggregate success copy, used only on the multi-batch path. */
+  summary: (merged: T) => string;
+  /** Partial-progress copy when a later batch fails mid-run. Must describe the
+   *  merged total as a CONFIRMED LOWER BOUND, never as an exact applied count —
+   *  see runChunked. */
+  partial: (merged: T, done: number, total: number) => string;
+}
+
+/**
+ * Runs an id-capped bulk action, batching only when it has to.
+ *
+ * At or under the cap this is a single request and the behaviour is unchanged —
+ * runAction owns the toast exactly as before. Above the cap the batches run
+ * SEQUENTIALLY (parallel would multiply the per-finding server work the cap
+ * exists to bound) and a single merged toast replaces N per-batch ones.
+ *
+ * If a later batch fails, the batches that already landed are real work the
+ * operator must know about: runAction has toasted the server's reason, and this
+ * adds the scope — which is distinct information, not a duplicate.
+ *
+ * Two things that message must NOT overclaim:
+ *
+ * 1. The merged total is a CONFIRMED LOWER BOUND, not the applied total. The
+ *    failing batch can still have done work before it failed —
+ *    `remediateVulnerabilities` queues each command before the awaited event
+ *    publication, so a throw there leaves commands queued that no response ever
+ *    reported. A lost HTTP response is ambiguous the same way.
+ * 2. Retrying the same selection is NOT safe for remediation. Every call creates
+ *    a fresh `install_patches` command via `queueCommandForExecution` with no
+ *    finding/action idempotency key, so re-sending ids that already succeeded
+ *    queues a SECOND install on those devices. Accept/mitigate are state-writes
+ *    and tolerate a retry; remediation does not. The copy therefore tells the
+ *    operator to reload first rather than inviting a blind retry.
+ */
+async function runChunked<T>(ids: string[], spec: ChunkedSpec<T>): Promise<T> {
+  const batches = chunkIds(ids);
+  if (batches.length <= 1) return spec.send(ids, true);
+
+  let merged = spec.empty;
+  for (let i = 0; i < batches.length; i++) {
+    try {
+      merged = spec.merge(merged, await spec.send(batches[i]!, false));
+    } catch (err) {
+      const done = batches.slice(0, i).reduce((n, b) => n + b.length, 0);
+      showToast({ message: spec.partial(merged, done, ids.length), type: 'error' });
+      throw err;
+    }
+  }
+  showToast({ message: spec.summary(merged), type: 'success' });
+  return merged;
+}
+
 // ---- Mutations (all wrapped in runAction so every outcome surfaces a toast) ----
 
+const remediateSummary = (d: RemediateResult): string =>
+  bulkSummary(`remediation${d.scheduled === 1 ? '' : 's'} scheduled`, d.scheduled, d.skipped);
+
 export async function remediateVuln(deviceVulnerabilityIds: string[]): Promise<RemediateResult> {
-  return runAction<RemediateResult>({
-    request: () =>
-      fetchWithAuth('/vulnerabilities/remediate', {
-        method: 'POST',
-        headers: JSON_HEADERS,
-        body: JSON.stringify({ deviceVulnerabilityIds }),
+  return runChunked<RemediateResult>(deviceVulnerabilityIds, {
+    send: (batch, toast) =>
+      runAction<RemediateResult>({
+        request: () =>
+          fetchWithAuth('/vulnerabilities/remediate', {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ deviceVulnerabilityIds: batch }),
+          }),
+        errorFallback: 'Failed to schedule remediation',
+        ...(toast ? { successMessage: remediateSummary } : {}),
+        parseSuccess: (data) => {
+          const d = data as { scheduled?: number; skipped?: SkippedItem[] };
+          return { scheduled: d.scheduled ?? 0, skipped: d.skipped ?? [] };
+        },
       }),
-    errorFallback: 'Failed to schedule remediation',
-    successMessage: (d) => bulkSummary(`remediation${d.scheduled === 1 ? '' : 's'} scheduled`, d.scheduled, d.skipped),
-    parseSuccess: (data) => {
-      const d = data as { scheduled?: number; skipped?: SkippedItem[] };
-      return { scheduled: d.scheduled ?? 0, skipped: d.skipped ?? [] };
-    },
+    empty: { scheduled: 0, skipped: [] },
+    merge: (a, b) => ({ scheduled: a.scheduled + b.scheduled, skipped: [...a.skipped, ...b.skipped] }),
+    summary: remediateSummary,
+    partial: (d, done, total) =>
+      `Stopped after ${done} of ${total} findings. At least ${d.scheduled} scheduled — some in the failed batch may also have `
+      + `been scheduled. Reload before retrying: re-sending findings that already succeeded queues duplicate installs.`,
   });
 }
 
@@ -296,6 +387,11 @@ export async function reopenVuln(id: string): Promise<void> {
 
 // ---- Mutations: bulk fleet actions ----
 
+/** `success` is AND-ed: one failed batch must not be masked by later successes. */
+function mergeBulk(a: BulkActionResult, b: BulkActionResult): BulkActionResult {
+  return { success: a.success && b.success, succeeded: a.succeeded + b.succeeded, skipped: [...a.skipped, ...b.skipped] };
+}
+
 function parseBulk(data: unknown): BulkActionResult {
   const d = data as Partial<BulkActionResult>;
   return { success: d.success ?? false, succeeded: d.succeeded ?? 0, skipped: d.skipped ?? [] };
@@ -310,16 +406,25 @@ export async function bulkAcceptVulnRisk(
   deviceVulnerabilityIds: string[],
   payload: { reason: string; acceptedUntil: string },
 ): Promise<BulkActionResult> {
-  return runAction<BulkActionResult>({
-    request: () =>
-      fetchWithAuth('/vulnerabilities/bulk/accept-risk', {
-        method: 'POST',
-        headers: JSON_HEADERS,
-        body: JSON.stringify({ deviceVulnerabilityIds, ...payload }),
+  return runChunked<BulkActionResult>(deviceVulnerabilityIds, {
+    send: (batch, toast) =>
+      runAction<BulkActionResult>({
+        request: () =>
+          fetchWithAuth('/vulnerabilities/bulk/accept-risk', {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ deviceVulnerabilityIds: batch, ...payload }),
+          }),
+        errorFallback: 'Failed to accept risk',
+        ...(toast ? { successMessage: (d: BulkActionResult) => bulkSummary('accepted', d.succeeded, d.skipped) } : {}),
+        parseSuccess: parseBulk,
       }),
-    errorFallback: 'Failed to accept risk',
-    successMessage: (d) => bulkSummary('accepted', d.succeeded, d.skipped),
-    parseSuccess: parseBulk,
+    empty: { success: true, succeeded: 0, skipped: [] },
+    merge: mergeBulk,
+    summary: (d) => bulkSummary('accepted', d.succeeded, d.skipped),
+    partial: (d, done, total) =>
+      `Stopped after ${done} of ${total} findings. At least ${d.succeeded} accepted; the rest were not attempted. `
+      + `Reload to see the current state before retrying.`,
   });
 }
 
@@ -327,16 +432,25 @@ export async function bulkMitigateVulns(
   deviceVulnerabilityIds: string[],
   payload: { note: string },
 ): Promise<BulkActionResult> {
-  return runAction<BulkActionResult>({
-    request: () =>
-      fetchWithAuth('/vulnerabilities/bulk/mitigate', {
-        method: 'POST',
-        headers: JSON_HEADERS,
-        body: JSON.stringify({ deviceVulnerabilityIds, ...payload }),
+  return runChunked<BulkActionResult>(deviceVulnerabilityIds, {
+    send: (batch, toast) =>
+      runAction<BulkActionResult>({
+        request: () =>
+          fetchWithAuth('/vulnerabilities/bulk/mitigate', {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ deviceVulnerabilityIds: batch, ...payload }),
+          }),
+        errorFallback: 'Failed to mitigate',
+        ...(toast ? { successMessage: (d: BulkActionResult) => bulkSummary('mitigated', d.succeeded, d.skipped) } : {}),
+        parseSuccess: parseBulk,
       }),
-    errorFallback: 'Failed to mitigate',
-    successMessage: (d) => bulkSummary('mitigated', d.succeeded, d.skipped),
-    parseSuccess: parseBulk,
+    empty: { success: true, succeeded: 0, skipped: [] },
+    merge: mergeBulk,
+    summary: (d) => bulkSummary('mitigated', d.succeeded, d.skipped),
+    partial: (d, done, total) =>
+      `Stopped after ${done} of ${total} findings. At least ${d.succeeded} mitigated; the rest were not attempted. `
+      + `Reload to see the current state before retrying.`,
   });
 }
 
@@ -344,6 +458,21 @@ export async function createVulnTicket(
   deviceVulnerabilityIds: string[],
   payload: { title: string; priority: VulnTicketPriority; note?: string },
 ): Promise<VulnTicketResult> {
+  // DELIBERATELY NOT CHUNKED (#3694). The server groups the findings by org and
+  // creates ONE ticket per org. Splitting a 576-finding selection into three
+  // requests would create THREE tickets per org, which is a different outcome
+  // from what the operator asked for, not a transparent fix — so batching here
+  // would trade a loud error for silently wrong data. Fail fast with copy that
+  // says what to do instead of the raw `Too big: expected array to have <=200
+  // items`. Raising the server cap for this one route, or having it accept a
+  // batch token and append to an existing ticket, is a maintainer call.
+  if (deviceVulnerabilityIds.length > BULK_ID_LIMIT) {
+    const msg = `Select at most ${BULK_ID_LIMIT} findings per ticket (${deviceVulnerabilityIds.length} selected). `
+      + `A ticket is created per organization, so splitting the request would create duplicates.`;
+    showToast({ message: msg, type: 'error' });
+    throw new ActionError(msg, 0);
+  }
+
   return runAction<VulnTicketResult>({
     request: () =>
       fetchWithAuth('/vulnerabilities/tickets', {


### PR DESCRIPTION
Closes #3694. Fixes the 576-finding failure @tim104979 hit in #2598.

## Change

`runChunked` batches `deviceVulnerabilityIds` to the server's 200 cap, **sequentially** — parallel batches would multiply exactly the per-finding work (~5 queries + a command enqueue each) that the cap exists to bound.

At or under the cap it is a single request, byte-identical to before, with `runAction` still owning the toast. Above the cap `runAction` is called without `successMessage` so it stays quiet and one merged toast replaces N.

Applied to `remediateVuln`, `bulkAcceptVulnRisk`, `bulkMitigateVulns`.

## Two things I want your ruling on

**1. Remediation retries are not idempotent — this PR does not fix that.**

An adversarial review flagged it and I confirmed it: `remediateVulnerabilities` queues a fresh `install_patches` through `queueCommandForExecution` with no finding/action idempotency key. So if batch 2 of 3 fails and the operator retries the same selection, the 200 findings that already succeeded queue a **second install** on those devices. The drawers keep the original selection and re-enable submit on failure, so a blind retry is the natural next click.

Before this PR that hazard could not occur, because >200 failed atomically every time. It also meant the feature was unusable for the reported case. So this trades "always fails" for "works, with a partial-failure retry hazard", and I did not want to make that call for you.

What I did do client-side: the partial-failure copy names the confirmed lower bound and tells the operator to reload before retrying, rather than inviting the blind retry. Accept/mitigate are state-writes and tolerate retries; remediation is the one that doesn't.

A real fix is server-side — an idempotency key on `(deviceVulnerabilityId, action)`, or having the route skip findings with an active `install_patches`. Happy to take that as a follow-up if you want it before this lands.

**2. Ticket creation is deliberately NOT chunked**, which departs from the issue's "all four capped endpoints".

The route builds a per-request `byOrg` map and calls `createTicket` once per represented org, with no cross-request correlation or dedup. Three batches can therefore create up to three tickets for an org appearing in all three — trading a loud error for silently wrong data. It now fails fast with copy explaining the limit instead of the raw zod message. Raising the cap for that one route, or letting it append to an existing ticket, is your call.

## On the partial-failure message

The first version of this said "the remaining N were not scheduled". That was an overclaim and I've corrected it: `remediateVulnerabilities` queues each command **before** the awaited event publication, so a throw there leaves work queued that no response reported, and a lost HTTP response is ambiguous the same way. The merged total is now stated as a confirmed lower bound — "At least N scheduled" — never an exact applied count.

## Tests

11 cases, control-verified against three separate mutations, each of which fails the suite:

- disable chunking → 4 fail (including the 576 → 200/200/176 split)
- mute the single-batch toast → the parity test fails
- make the batches concurrent → the sequencing and stop-on-failure tests fail

That second and third mutation both passed my original suite; the review caught them and they're now covered. The success mock also echoes the real batch size — a fixed 200 previously let the 176-id final batch report 200, and the suite blessed an impossible total of 600.

## Verification

Full `@breeze/web` suite **601 files / 5943 tests pass**. `astro check`: 0 errors, 0 warnings. eslint clean on both changed files.
