### PR TITLE
feat(mobile): Tickets tab — queue, detail, comment and status change (#3206)

### DIFF
--- a/apps/mobile/src/components/TabIcons.tsx
+++ b/apps/mobile/src/components/TabIcons.tsx
@@ -39,6 +39,23 @@ export function SystemsIcon({ color, size }: Props) {
   );
 }
 
+// Ticket stub: a rounded rectangle with a perforation notch on each side.
+// Distinct from the Systems trace and the Home bubble at tab-bar size.
+export function TicketsIcon({ color, size }: Props) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24">
+      <Path
+        d="M3 7 a1 1 0 0 1 1 -1 h16 a1 1 0 0 1 1 1 v3 a2 2 0 0 0 0 4 v3 a1 1 0 0 1 -1 1 h-16 a1 1 0 0 1 -1 -1 v-3 a2 2 0 0 0 0 -4 z"
+        stroke={color}
+        strokeWidth={1.75}
+        strokeLinejoin="round"
+        fill="none"
+      />
+      <Path d="M14 8 L14 16" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeDasharray="2 2.5" />
+    </Svg>
+  );
+}
+
 // Reserved for future use (e.g. when Settings becomes a tab again, or for
 // an Alerts-only view). Not currently mounted but kept here so the icon
 // vocabulary lives in one file.

--- a/apps/mobile/src/navigation/MainNavigator.tsx
+++ b/apps/mobile/src/navigation/MainNavigator.tsx
@@ -5,7 +5,9 @@ import { AlertDetailScreen } from '../screens/alerts/AlertDetailScreen';
 import { DeviceDetailScreen } from '../screens/devices/DeviceDetailScreen';
 import { HomeScreen } from '../screens/chat/HomeScreen';
 import { SystemsScreen } from '../screens/systems/SystemsScreen';
-import { HomeIcon, SystemsIcon } from '../components/TabIcons';
+import { TicketsScreen } from '../screens/tickets/TicketsScreen';
+import { TicketDetailScreen } from '../screens/tickets/TicketDetailScreen';
+import { HomeIcon, SystemsIcon, TicketsIcon } from '../components/TabIcons';
 import { palette, fontFamily } from '../theme';
 import type { Alert, Device } from '../services/api';
 
@@ -15,13 +17,49 @@ export type SystemsStackParamList = {
   SystemsDeviceDetail: { device: Device };
 };
 
+export type TicketsStackParamList = {
+  Tickets: undefined;
+  TicketDetail: { ticketId: string };
+};
+
 export type MainTabParamList = {
   HomeTab: undefined;
   SystemsTab: undefined;
+  TicketsTab: undefined;
 };
 
 const Tab = createBottomTabNavigator<MainTabParamList>();
 const SystemsStack = createNativeStackNavigator<SystemsStackParamList>();
+const TicketsStack = createNativeStackNavigator<TicketsStackParamList>();
+
+const stackScreenOptions = {
+  headerStyle: { backgroundColor: palette.dark.bg0 },
+  headerShadowVisible: false,
+  headerTintColor: palette.dark.textHi,
+  headerTitleStyle: {
+    fontFamily: fontFamily.sansSemiBold,
+    fontSize: 17,
+    color: palette.dark.textHi,
+  },
+  contentStyle: { backgroundColor: palette.dark.bg0 },
+} as const;
+
+function TicketsStackNavigator() {
+  return (
+    <TicketsStack.Navigator screenOptions={stackScreenOptions}>
+      <TicketsStack.Screen
+        name="Tickets"
+        component={TicketsScreen}
+        options={{ headerShown: false }}
+      />
+      <TicketsStack.Screen
+        name="TicketDetail"
+        component={TicketDetailScreen}
+        options={{ title: 'Ticket' }}
+      />
+    </TicketsStack.Navigator>
+  );
+}
 
 function SystemsStackNavigator() {
   return (
@@ -92,6 +130,16 @@ export function MainNavigator() {
           tabBarLabel: 'Systems',
           tabBarIcon: ({ color, size }: { color: string; size: number }) => (
             <SystemsIcon color={color} size={size} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="TicketsTab"
+        component={TicketsStackNavigator}
+        options={{
+          tabBarLabel: 'Tickets',
+          tabBarIcon: ({ color, size }: { color: string; size: number }) => (
+            <TicketsIcon color={color} size={size} />
           ),
         }}
       />

--- a/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
@@ -1,0 +1,457 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import type { RouteProp } from '@react-navigation/native';
+import { useRoute } from '@react-navigation/native';
+
+import { palette, radii, spacing, type } from '../../theme';
+import { useAppDispatch } from '../../store';
+import { applyStatusChange, syncTicketFromDetail } from '../../store/ticketsSlice';
+import {
+  addTicketComment,
+  allowedQuickStatuses,
+  changeTicketStatus,
+  getTicket,
+  statusRequiresResolutionNote,
+  SYSTEM_COMMENT_TYPES,
+  type TicketDetail,
+  type TicketStatus,
+} from '../../services/tickets';
+import type { TicketsStackParamList } from '../../navigation/MainNavigator';
+import { Toast } from '../../components/Toast';
+import { relativeTime } from '../../lib/relativeTime';
+import { reportInternalError } from '../../lib/errorReporting';
+
+import { priorityColor, priorityLabel, statusLabel, ticketRef } from './ticketCopy';
+
+type DetailRoute = RouteProp<TicketsStackParamList, 'TicketDetail'>;
+
+/**
+ * Candidate quick actions for the phone — deliberately not the full status set.
+ * Filtered per ticket through `allowedQuickStatuses`, because the API 409s on
+ * an illegal transition (a closed ticket can only reopen to `open`, and a
+ * resolved one cannot go back to `pending`).
+ */
+const QUICK_STATUS_CANDIDATES: readonly TicketStatus[] = ['open', 'pending', 'resolved'];
+
+export function TicketDetailScreen() {
+  const route = useRoute<DetailRoute>();
+  const { ticketId } = route.params;
+  const dispatch = useAppDispatch();
+
+  const [ticket, setTicket] = useState<TicketDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [comment, setComment] = useState('');
+  const [resolutionNote, setResolutionNote] = useState('');
+  const [pendingStatus, setPendingStatus] = useState<TicketStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [toast, setToast] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+
+  // `busy` is render-captured, so two taps before React commits can both see
+  // false and fire duplicate requests. This ref is the synchronous lock.
+  const inFlight = useRef(false);
+  // Only the newest load() may publish; an earlier GET finishing later must not
+  // replace a fresher ticket. Also gates writes after unmount.
+  const loadGeneration = useRef(0);
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  /**
+   * Returns true when the ticket was refreshed. Callers that just mutated
+   * something use the result to decide whether they can honestly report
+   * success: a POST that succeeded followed by a GET that failed leaves the
+   * screen showing stale data, and silently toasting "done" hides that.
+   */
+  const load = useCallback(async (): Promise<boolean> => {
+    const generation = ++loadGeneration.current;
+    const isCurrent = () => mounted.current && loadGeneration.current === generation;
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const fetched = await getTicket(ticketId);
+      // A superseded or unmounted load reports failure rather than writing:
+      // callers use the boolean to decide whether they may claim success, and
+      // this one's data is no longer the freshest.
+      if (!isCurrent()) return false;
+      setTicket(fetched);
+      // Keep the queue in step with what this screen now displays, so Redux and
+      // the detail view cannot hold two different authoritative statuses. This
+      // is the PASSIVE path: update in place, never drop the row.
+      dispatch(
+        syncTicketFromDetail({
+          id: ticketId,
+          status: fetched.status,
+          statusName: fetched.statusName,
+          statusColor: fetched.statusColor,
+        })
+      );
+      return true;
+    } catch (err: unknown) {
+      if (!isCurrent()) return false;
+      const apiError = err as { message?: string };
+      setLoadError(apiError.message || 'Could not load this ticket.');
+      return false;
+    } finally {
+      if (isCurrent()) setLoading(false);
+    }
+  }, [ticketId, dispatch]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const submitComment = useCallback(async () => {
+    const trimmed = comment.trim();
+    if (!trimmed || inFlight.current) return;
+    inFlight.current = true;
+    setBusy(true);
+    try {
+      const created = await addTicketComment(ticketId, trimmed, true);
+      setComment('');
+      const refreshed = await load();
+      if (!refreshed) {
+        // The POST succeeded but the re-read did not. Append the comment the
+        // server returned so the user sees their own text, and say plainly
+        // that the rest of the view may be stale.
+        setTicket((prev) => (prev ? { ...prev, comments: [...prev.comments, created] } : prev));
+        setToast({ kind: 'error', text: 'Comment added, but the ticket could not be refreshed.' });
+      } else {
+        setToast({ kind: 'success', text: 'Comment added' });
+      }
+    } catch (err: unknown) {
+      const apiError = err as { message?: string };
+      reportInternalError(err, 'ticket-comment');
+      if (mounted.current) {
+        setToast({ kind: 'error', text: apiError.message || 'Could not add comment.' });
+      }
+    } finally {
+      inFlight.current = false;
+      if (mounted.current) setBusy(false);
+    }
+  }, [comment, ticketId, load]);
+
+  const submitStatus = useCallback(
+    async (status: TicketStatus) => {
+      if (inFlight.current) return;
+      // Resolving without a note is rejected by the API, so collect it first
+      // rather than firing a request that always 400s.
+      if (statusRequiresResolutionNote(status) && !resolutionNote.trim()) {
+        setPendingStatus(status);
+        setToast({ kind: 'error', text: 'A resolution note is required to resolve.' });
+        return;
+      }
+      inFlight.current = true;
+      setBusy(true);
+      try {
+        const updated = await changeTicketStatus(
+          ticketId,
+          status,
+          resolutionNote.trim() || undefined
+        );
+        setPendingStatus(null);
+        setResolutionNote('');
+        // Trust the server's status, not the one we asked for.
+        const applied = updated?.status ?? status;
+        dispatch(
+          applyStatusChange({
+            id: ticketId,
+            status: applied,
+            // The endpoint returns the custom label too; omitting it here would
+            // blank the queue row's label until the next list fetch.
+            statusName: updated?.statusName ?? null,
+            statusColor: updated?.statusColor ?? null,
+          })
+        );
+        const refreshed = await load();
+        if (!mounted.current) return;
+        const label = statusLabel({ status: applied, statusName: updated?.statusName ?? null });
+        if (!refreshed) {
+          setTicket((prev) => (prev ? { ...prev, ...updated } : prev));
+          setToast({ kind: 'error', text: `Marked ${label}, but the ticket could not be refreshed.` });
+        } else {
+          setToast({ kind: 'success', text: `Marked ${label}` });
+        }
+      } catch (err: unknown) {
+        const apiError = err as { message?: string };
+        reportInternalError(err, 'ticket-status');
+        if (mounted.current) {
+          setToast({ kind: 'error', text: apiError.message || 'Could not change status.' });
+        }
+      } finally {
+        inFlight.current = false;
+        if (mounted.current) setBusy(false);
+      }
+    },
+    [resolutionNote, ticketId, dispatch, load]
+  );
+
+  if (loading && !ticket) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator color={palette.brand.soft} />
+      </View>
+    );
+  }
+
+  if (loadError && !ticket) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.error}>{loadError}</Text>
+        <Pressable onPress={() => void load()} accessibilityRole="button" style={styles.retry}>
+          <Text style={styles.retryText}>Try again</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (!ticket) return null;
+
+  // Only while a resolve is pending. A ticket that is ALREADY resolved offers
+  // no Resolve action (transitions allow only open/closed from there) and
+  // `changeTicketStatus` discards the note on non-resolving moves, so rendering
+  // the input then produces a field whose contents can never be submitted.
+  const showResolutionInput = pendingStatus === 'resolved';
+  const quickStatuses = allowedQuickStatuses(ticket.status, QUICK_STATUS_CANDIDATES);
+  // Only person-authored entries are "comments"; the rest of the array is
+  // activity (status changes, assignments, time entries).
+  const commentCount = ticket.comments.filter(
+    (c) => !c.commentType || !SYSTEM_COMMENT_TYPES.has(c.commentType)
+  ).length;
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.screen}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+        <View style={styles.header}>
+          <Text style={styles.ref}>{ticketRef(ticket)}</Text>
+          <View style={[styles.priorityDot, { backgroundColor: priorityColor(ticket.priority) }]} />
+          <Text style={styles.priority}>{priorityLabel(ticket.priority)}</Text>
+        </View>
+        <Text style={styles.subject}>{ticket.subject}</Text>
+        <Text style={styles.meta}>
+          {statusLabel(ticket)}
+          {ticket.orgName ? ` · ${ticket.orgName}` : ''}
+          {ticket.deviceHostname ? ` · ${ticket.deviceHostname}` : ''}
+        </Text>
+        {ticket.assigneeName ? (
+          <Text style={styles.metaDim}>Assigned to {ticket.assigneeName}</Text>
+        ) : (
+          <Text style={styles.metaDim}>Unassigned</Text>
+        )}
+
+        {ticket.description ? (
+          <View style={styles.card}>
+            <Text style={styles.body}>{ticket.description}</Text>
+          </View>
+        ) : null}
+
+        <Text style={styles.sectionHeader}>STATUS</Text>
+        {quickStatuses.length === 0 ? (
+          <Text style={styles.metaDim}>No status changes available from here.</Text>
+        ) : (
+          <View style={styles.statusRow}>
+            {quickStatuses.map((status) => (
+              <Pressable
+                key={status}
+                onPress={() => void submitStatus(status)}
+                disabled={busy}
+                accessibilityRole="button"
+                accessibilityState={{ disabled: busy }}
+                style={styles.statusChip}
+              >
+                <Text style={styles.statusChipText}>
+                  {statusLabel({ status, statusName: null })}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        )}
+
+        {showResolutionInput ? (
+          <TextInput
+            value={resolutionNote}
+            onChangeText={setResolutionNote}
+            placeholder="Resolution note (required to resolve)"
+            placeholderTextColor={palette.dark.textLo}
+            multiline
+            style={styles.input}
+            accessibilityLabel="Resolution note"
+          />
+        ) : null}
+
+        <Text style={styles.sectionHeader}>
+          ACTIVITY{commentCount ? ` (${commentCount})` : ''}
+        </Text>
+        {ticket.comments.length === 0 ? (
+          <Text style={styles.metaDim}>No comments yet.</Text>
+        ) : (
+          ticket.comments.map((c) => {
+            const isSystem = Boolean(c.commentType && SYSTEM_COMMENT_TYPES.has(c.commentType));
+            if (isSystem) {
+              // Activity entries are not comments: no author chip, no INTERNAL
+              // badge (they are non-public by nature), and dimmed.
+              return (
+                <View key={c.id} style={styles.activityRow}>
+                  <Text style={styles.activityText}>{c.content}</Text>
+                  <Text style={styles.metaDim}>{relativeTime(c.createdAt)}</Text>
+                </View>
+              );
+            }
+            return (
+            <View key={c.id} style={styles.card}>
+              <View style={styles.commentHeader}>
+                <Text style={styles.commentAuthor}>{c.authorName || 'Unknown'}</Text>
+                <Text style={styles.metaDim}>{relativeTime(c.createdAt)}</Text>
+              </View>
+              {c.deleted ? (
+                // The API blanks `content` for soft-deleted comments and flags
+                // them instead of omitting the row. Without this branch the
+                // card renders as an empty bubble, which reads as a bug.
+                <Text style={styles.deletedComment}>Comment deleted</Text>
+              ) : (
+                <>
+                  {!c.isPublic ? <Text style={styles.internal}>INTERNAL</Text> : null}
+                  <Text style={styles.body}>{c.content}</Text>
+                </>
+              )}
+            </View>
+            );
+          })
+        )}
+
+        <TextInput
+          value={comment}
+          onChangeText={setComment}
+          placeholder="Add a comment"
+          placeholderTextColor={palette.dark.textLo}
+          multiline
+          style={styles.input}
+          accessibilityLabel="Add a comment"
+        />
+        <Pressable
+          onPress={() => void submitComment()}
+          disabled={busy || !comment.trim()}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: busy || !comment.trim() }}
+          style={[styles.submit, (busy || !comment.trim()) && styles.submitDisabled]}
+        >
+          <Text style={styles.submitText}>{busy ? 'Working…' : 'Post comment'}</Text>
+        </Pressable>
+      </ScrollView>
+
+      <Toast
+        visible={toast !== null}
+        text={toast?.text ?? ''}
+        kind={toast?.kind ?? 'success'}
+        onHidden={() => setToast(null)}
+      />
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: palette.dark.bg0 },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: palette.dark.bg0,
+    padding: spacing['6'],
+  },
+  content: { padding: spacing['4'], paddingBottom: spacing['8'] },
+  header: { flexDirection: 'row', alignItems: 'center', gap: spacing['2'] },
+  ref: { ...type.monoMd, color: palette.dark.textMd },
+  priorityDot: { width: 8, height: 8, borderRadius: radii.full },
+  priority: { ...type.meta, color: palette.dark.textMd },
+  subject: { ...type.title, color: palette.dark.textHi, marginTop: spacing['2'] },
+  meta: { ...type.meta, color: palette.dark.textMd, marginTop: spacing['2'] },
+  metaDim: { ...type.meta, color: palette.dark.textLo, marginTop: spacing['1'] },
+  sectionHeader: {
+    ...type.metaCaps,
+    color: palette.dark.textLo,
+    marginTop: spacing['6'],
+    marginBottom: spacing['2'],
+  },
+  card: {
+    backgroundColor: palette.dark.bg1,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    padding: spacing['3'],
+    marginTop: spacing['2'],
+  },
+  body: { ...type.body, color: palette.dark.textHi },
+  commentHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  commentAuthor: { ...type.meta, color: palette.dark.textMd },
+  internal: { ...type.metaCaps, color: palette.warning.base, marginTop: spacing['1'] },
+  deletedComment: { ...type.body, color: palette.dark.textLo, fontStyle: 'italic' },
+  activityRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: spacing['2'],
+    paddingVertical: spacing['2'],
+    paddingHorizontal: spacing['1'],
+  },
+  activityText: { ...type.meta, color: palette.dark.textLo, flexShrink: 1 },
+  statusRow: { flexDirection: 'row', gap: spacing['2'], flexWrap: 'wrap' },
+  statusChip: {
+    paddingHorizontal: spacing['3'],
+    paddingVertical: spacing['2'],
+    borderRadius: radii.full,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    backgroundColor: palette.dark.bg1,
+  },
+  statusChipActive: { backgroundColor: palette.brand.deep, borderColor: palette.brand.base },
+  statusChipText: { ...type.meta, color: palette.dark.textMd },
+  statusChipTextActive: { color: palette.dark.textHi },
+  input: {
+    ...type.body,
+    color: palette.dark.textHi,
+    backgroundColor: palette.dark.bg1,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    padding: spacing['3'],
+    marginTop: spacing['2'],
+    minHeight: 88,
+    textAlignVertical: 'top',
+  },
+  submit: {
+    marginTop: spacing['3'],
+    paddingVertical: spacing['3'],
+    borderRadius: radii.md,
+    backgroundColor: palette.brand.base,
+    alignItems: 'center',
+  },
+  submitDisabled: { opacity: 0.5 },
+  submitText: { ...type.bodyMd, color: palette.dark.textHi },
+  error: { ...type.body, color: palette.deny.base, textAlign: 'center' },
+  retry: {
+    marginTop: spacing['4'],
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['2'],
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+  },
+  retryText: { ...type.meta, color: palette.dark.textHi },
+});

--- a/apps/mobile/src/screens/tickets/TicketsScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketsScreen.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useState } from 'react';
+import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import { palette, radii, spacing, type } from '../../theme';
+import { useAppDispatch, useAppSelector } from '../../store';
+import {
+  fetchTickets,
+  selectTicketAssignee,
+  selectTicketQueue,
+  selectTickets,
+  selectTicketsError,
+  selectTicketsLoading,
+  setAssignee,
+  setQueue,
+} from '../../store/ticketsSlice';
+import type { TicketSummary } from '../../services/tickets';
+import type { TicketsStackParamList } from '../../navigation/MainNavigator';
+import { relativeTime } from '../../lib/relativeTime';
+
+import {
+  emptyStateCopy,
+  isBreached,
+  priorityColor,
+  priorityLabel,
+  statusLabel,
+  ticketRef,
+} from './ticketCopy';
+
+type Nav = NativeStackNavigationProp<TicketsStackParamList, 'Tickets'>;
+
+function Chip({
+  label,
+  active,
+  onPress,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+      style={[styles.chip, active && styles.chipActive]}
+    >
+      <Text style={[styles.chipText, active && styles.chipTextActive]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function TicketRow({ ticket, onPress }: { ticket: TicketSummary; onPress: () => void }) {
+  const breached = isBreached(ticket);
+  return (
+    <Pressable onPress={onPress} accessibilityRole="button" style={styles.row}>
+      <View style={styles.rowHeader}>
+        <Text style={styles.ref}>{ticketRef(ticket)}</Text>
+        <View style={[styles.priorityDot, { backgroundColor: priorityColor(ticket.priority) }]} />
+        <Text style={styles.priority}>{priorityLabel(ticket.priority)}</Text>
+        {breached ? <Text style={styles.breach}>SLA</Text> : null}
+      </View>
+      <Text style={styles.subject} numberOfLines={2}>
+        {ticket.subject}
+      </Text>
+      <View style={styles.rowMeta}>
+        <Text style={styles.meta} numberOfLines={1}>
+          {statusLabel(ticket)}
+          {ticket.orgName ? ` · ${ticket.orgName}` : ''}
+        </Text>
+        <Text style={styles.metaDim}>{relativeTime(ticket.updatedAt)}</Text>
+      </View>
+    </Pressable>
+  );
+}
+
+export function TicketsScreen() {
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation<Nav>();
+  const dispatch = useAppDispatch();
+
+  const tickets = useAppSelector(selectTickets);
+  const loading = useAppSelector(selectTicketsLoading);
+  const error = useAppSelector(selectTicketsError);
+  const queue = useAppSelector(selectTicketQueue);
+  const assignee = useAppSelector(selectTicketAssignee);
+
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(() => {
+    return dispatch(fetchTickets({ statusGroup: queue, assignee }));
+  }, [dispatch, queue, assignee]);
+
+  useFocusEffect(
+    useCallback(() => {
+      void load();
+    }, [load])
+  );
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await load();
+    } finally {
+      setRefreshing(false);
+    }
+  }, [load]);
+
+  const empty = emptyStateCopy(queue, assignee);
+
+  return (
+    <View style={[styles.screen, { paddingTop: insets.top + spacing['3'] }]}>
+      <Text style={styles.title}>Tickets</Text>
+
+      <View style={styles.filters}>
+        <Chip label="Open" active={queue === 'open'} onPress={() => dispatch(setQueue('open'))} />
+        <Chip
+          label="Closed"
+          active={queue === 'closed'}
+          onPress={() => dispatch(setQueue('closed'))}
+        />
+        <View style={styles.filterSpacer} />
+        <Chip label="Mine" active={assignee === 'me'} onPress={() => dispatch(setAssignee('me'))} />
+        <Chip label="All" active={assignee === 'all'} onPress={() => dispatch(setAssignee('all'))} />
+      </View>
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      <FlatList
+        data={tickets}
+        keyExtractor={(t) => t.id}
+        renderItem={({ item }) => (
+          <TicketRow
+            ticket={item}
+            onPress={() => navigation.navigate('TicketDetail', { ticketId: item.id })}
+          />
+        )}
+        contentContainerStyle={[
+          styles.listContent,
+          tickets.length === 0 && styles.listContentEmpty,
+        ]}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={palette.dark.textLo}
+          />
+        }
+        ListEmptyComponent={
+          loading ? undefined : (
+            <View style={styles.empty}>
+              <Text style={styles.emptyTitle}>{empty.title}</Text>
+              <Text style={styles.emptyBody}>{empty.body}</Text>
+            </View>
+          )
+        }
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: palette.dark.bg0 },
+  title: { ...type.title, color: palette.dark.textHi, paddingHorizontal: spacing['4'] },
+  filters: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing['2'],
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['3'],
+  },
+  filterSpacer: { flex: 1 },
+  chip: {
+    paddingHorizontal: spacing['3'],
+    paddingVertical: spacing['1'],
+    borderRadius: radii.full,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    backgroundColor: palette.dark.bg1,
+  },
+  chipActive: { backgroundColor: palette.brand.deep, borderColor: palette.brand.base },
+  chipText: { ...type.meta, color: palette.dark.textMd },
+  chipTextActive: { color: palette.dark.textHi },
+  listContent: { paddingHorizontal: spacing['4'], paddingBottom: spacing['8'] },
+  listContentEmpty: { flexGrow: 1, justifyContent: 'center' },
+  row: {
+    backgroundColor: palette.dark.bg1,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    padding: spacing['3'],
+    marginBottom: spacing['2'],
+  },
+  rowHeader: { flexDirection: 'row', alignItems: 'center', gap: spacing['2'] },
+  ref: { ...type.monoMd, color: palette.dark.textMd },
+  priorityDot: { width: 8, height: 8, borderRadius: radii.full },
+  priority: { ...type.meta, color: palette.dark.textMd },
+  breach: { ...type.metaCaps, color: palette.deny.base },
+  subject: { ...type.bodyMd, color: palette.dark.textHi, marginTop: spacing['2'] },
+  rowMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: spacing['2'],
+    gap: spacing['2'],
+  },
+  meta: { ...type.meta, color: palette.dark.textMd, flexShrink: 1 },
+  metaDim: { ...type.meta, color: palette.dark.textLo },
+  error: {
+    ...type.meta,
+    color: palette.deny.base,
+    paddingHorizontal: spacing['4'],
+    paddingBottom: spacing['2'],
+  },
+  empty: { alignItems: 'center', paddingHorizontal: spacing['6'] },
+  emptyTitle: { ...type.bodyMd, color: palette.dark.textHi },
+  emptyBody: { ...type.meta, color: palette.dark.textLo, marginTop: spacing['1'], textAlign: 'center' },
+});

--- a/apps/mobile/src/screens/tickets/ticketCopy.test.ts
+++ b/apps/mobile/src/screens/tickets/ticketCopy.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+
+import { emptyStateCopy, isBreached, priorityLabel, statusLabel, ticketRef } from './ticketCopy';
+
+describe('statusLabel', () => {
+  it('prefers the tenant custom status name', () => {
+    expect(statusLabel({ status: 'open', statusName: 'Awaiting parts' })).toBe('Awaiting parts');
+  });
+
+  it('falls back to a readable label when the custom name is blank', () => {
+    expect(statusLabel({ status: 'on_hold', statusName: '   ' })).toBe('On hold');
+    expect(statusLabel({ status: 'on_hold', statusName: null })).toBe('On hold');
+  });
+});
+
+describe('ticketRef', () => {
+  it('uses the internal number when present', () => {
+    expect(ticketRef({ internalNumber: '1041', id: 'abcdef01-1111' })).toBe('#1041');
+  });
+
+  it('does not double-prefix a number that already carries a #', () => {
+    expect(ticketRef({ internalNumber: '#1041', id: 'abcdef01-1111' })).toBe('#1041');
+  });
+
+  it('preserves a non-numeric internal reference verbatim', () => {
+    expect(ticketRef({ internalNumber: 'TKT-1041', id: 'abcdef01' })).toBe('#TKT-1041');
+  });
+
+  it('falls back to a short id when the tenant has no internal number', () => {
+    expect(ticketRef({ internalNumber: null, id: 'abcdef0123456789' })).toBe('#abcdef01');
+    expect(ticketRef({ internalNumber: '   ', id: 'abcdef0123456789' })).toBe('#abcdef01');
+  });
+});
+
+describe('isBreached', () => {
+  it('is true only when a breach timestamp exists', () => {
+    expect(isBreached({ slaBreachedAt: '2026-08-18T00:00:00Z' })).toBe(true);
+    expect(isBreached({ slaBreachedAt: null })).toBe(false);
+  });
+});
+
+describe('priorityLabel', () => {
+  it('capitalises for display', () => {
+    expect(priorityLabel('urgent')).toBe('Urgent');
+    expect(priorityLabel('low')).toBe('Low');
+  });
+});
+
+describe('emptyStateCopy', () => {
+  it('distinguishes "none assigned to you" from "queue is empty"', () => {
+    expect(emptyStateCopy('open', 'me').title).toBe('Nothing assigned to you');
+    expect(emptyStateCopy('open', 'all').title).toBe('No open tickets');
+  });
+
+  it('varies by queue as well as assignee', () => {
+    expect(emptyStateCopy('closed', 'me').title).toBe('Nothing closed by you');
+    expect(emptyStateCopy('closed', 'all').title).toBe('No closed tickets');
+  });
+});

--- a/apps/mobile/src/screens/tickets/ticketCopy.ts
+++ b/apps/mobile/src/screens/tickets/ticketCopy.ts
@@ -1,0 +1,78 @@
+import type { TicketPriority, TicketStatus, TicketSummary } from '../../services/tickets';
+// Import the pure token module rather than the `../../theme` barrel: the barrel
+// re-exports `useApprovalTheme`, which imports `useColorScheme` from react-native
+// and drags the RN runtime into this otherwise node-testable copy module.
+import { palette } from '../../theme/tokens';
+
+/** Human label for a status, preferring the tenant's custom status name. */
+export function statusLabel(ticket: Pick<TicketSummary, 'status' | 'statusName'>): string {
+  if (ticket.statusName && ticket.statusName.trim()) return ticket.statusName.trim();
+  switch (ticket.status) {
+    case 'on_hold':
+      return 'On hold';
+    case 'new':
+      return 'New';
+    case 'open':
+      return 'Open';
+    case 'pending':
+      return 'Pending';
+    case 'resolved':
+      return 'Resolved';
+    case 'closed':
+      return 'Closed';
+    default:
+      return ticket.status;
+  }
+}
+
+export function priorityLabel(priority: TicketPriority): string {
+  return priority.charAt(0).toUpperCase() + priority.slice(1);
+}
+
+export function priorityColor(priority: TicketPriority): string {
+  switch (priority) {
+    case 'urgent':
+      return palette.deny.base;
+    case 'high':
+      return palette.warning.base;
+    case 'normal':
+      return palette.brand.soft;
+    case 'low':
+    default:
+      return palette.dark.textLo;
+  }
+}
+
+/**
+ * `#1041` when the tenant has internal numbers, else a short id fallback.
+ * `internalNumber` (not `ticketNumber`) is the display reference — it is what
+ * the web queue renders, and it is a nullable varchar rather than an integer.
+ */
+export function ticketRef(ticket: Pick<TicketSummary, 'internalNumber' | 'id'>): string {
+  const n = ticket.internalNumber?.trim();
+  if (n) return n.startsWith('#') ? n : `#${n}`;
+  return `#${ticket.id.slice(0, 8)}`;
+}
+
+export function isBreached(ticket: Pick<TicketSummary, 'slaBreachedAt'>): boolean {
+  return Boolean(ticket.slaBreachedAt);
+}
+
+/**
+ * Empty-state copy depends on both filters — "no tickets at all" and "none
+ * assigned to you" are different situations and a single string reads as a bug
+ * when the tech knows the queue is not empty.
+ */
+export function emptyStateCopy(
+  queue: 'open' | 'closed',
+  assignee: 'me' | 'all'
+): { title: string; body: string } {
+  if (assignee === 'me') {
+    return queue === 'open'
+      ? { title: 'Nothing assigned to you', body: 'Switch to All to see the rest of the queue.' }
+      : { title: 'Nothing closed by you', body: 'Switch to All to see closed tickets.' };
+  }
+  return queue === 'open'
+    ? { title: 'No open tickets', body: 'The open queue is clear.' }
+    : { title: 'No closed tickets', body: 'Closed tickets will appear here.' };
+}

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -278,6 +278,20 @@ async function request<T>(
   return requestWithPrefix<T>(endpoint, API_PREFIX, options);
 }
 
+/**
+ * Issue a request against the core `/api/v1` surface from a sibling service
+ * module. Exported so feature services (tickets, …) reuse this hardened path
+ * — auth header, CSRF header, per-install device id, and the `device_blocked`
+ * notification — instead of re-implementing `fetch` and silently dropping all
+ * four (see `services/search.ts` for the copy this exists to prevent spreading).
+ */
+export async function coreRequest<T>(
+  endpoint: string,
+  options: RequestInit = {}
+): Promise<T> {
+  return requestWithPrefix<T>(endpoint, API_CORE_PREFIX, options);
+}
+
 export type DeviceAction = 'reboot' | 'shutdown' | 'wake' | 'update';
 
 function mapAlert(alert: MobileAlertRecord): Alert {

--- a/apps/mobile/src/services/tickets.test.ts
+++ b/apps/mobile/src/services/tickets.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const coreRequest = vi.fn();
+vi.mock('./api', () => ({ coreRequest: (...args: unknown[]) => coreRequest(...args) }));
+
+import {
+  addTicketComment,
+  allowedQuickStatuses,
+  buildTicketListQuery,
+  canTransition,
+  changeTicketStatus,
+  getTicket,
+  getTickets,
+  statusRequiresResolutionNote,
+  SYSTEM_COMMENT_TYPES,
+  TICKET_STATUS_TRANSITIONS,
+} from './tickets';
+
+beforeEach(() => {
+  coreRequest.mockReset();
+});
+
+describe('buildTicketListQuery', () => {
+  it('defaults to page 1 and does not send an assignee for "all"', () => {
+    const q = new URLSearchParams(buildTicketListQuery({ assignee: 'all' }));
+    expect(q.get('page')).toBe('1');
+    expect(q.get('limit')).toBe('50');
+    // The API treats any non-me/non-unassigned value as a user id, so sending
+    // the literal "all" would filter to a nonexistent assignee and return [].
+    expect(q.has('assignee')).toBe(false);
+  });
+
+  it('sends assignee=me only for the mine filter', () => {
+    const q = new URLSearchParams(buildTicketListQuery({ assignee: 'me' }));
+    expect(q.get('assignee')).toBe('me');
+  });
+
+  it('passes statusGroup through when present and omits it otherwise', () => {
+    expect(new URLSearchParams(buildTicketListQuery({ statusGroup: 'closed' })).get('statusGroup'))
+      .toBe('closed');
+    expect(new URLSearchParams(buildTicketListQuery({})).has('statusGroup')).toBe(false);
+  });
+});
+
+describe('getTickets', () => {
+  it('returns pagination totals from the envelope', async () => {
+    coreRequest.mockResolvedValue({
+      data: [{ id: 't1' }],
+      pagination: { page: 2, limit: 25, total: 87 },
+    });
+    const page = await getTickets({ page: 2, limit: 25 });
+    expect(page.tickets).toHaveLength(1);
+    expect(page.total).toBe(87);
+    expect(page.page).toBe(2);
+    expect(page.limit).toBe(25);
+  });
+
+  it('tolerates a missing pagination block and a non-array data field', async () => {
+    coreRequest.mockResolvedValue({ data: undefined });
+    const page = await getTickets({});
+    expect(page.tickets).toEqual([]);
+    expect(page.total).toBe(0);
+  });
+});
+
+describe('getTicket', () => {
+  it('always yields an array for comments even when the field is absent', async () => {
+    coreRequest.mockResolvedValue({ data: { id: 't1', subject: 'x' } });
+    const ticket = await getTicket('t1');
+    expect(ticket.comments).toEqual([]);
+  });
+});
+
+describe('addTicketComment', () => {
+  it('posts content and isPublic to the comments endpoint', async () => {
+    coreRequest.mockResolvedValue({ data: { id: 'c1' } });
+    await addTicketComment('t1', 'hello', false);
+    const [path, options] = coreRequest.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe('/tickets/t1/comments');
+    expect(options.method).toBe('POST');
+    expect(JSON.parse(String(options.body))).toEqual({ content: 'hello', isPublic: false });
+  });
+});
+
+describe('changeTicketStatus', () => {
+  it('returns the ticket the server responds with, not the requested status', async () => {
+    // Custom-status mapping can make the applied status differ from the ask,
+    // so callers must use the returned row rather than echoing their request.
+    coreRequest.mockResolvedValue({ data: { id: 't1', status: 'closed' } });
+    const updated = await changeTicketStatus('t1', 'resolved', 'note');
+    expect(updated.status).toBe('closed');
+  });
+
+  it('includes resolutionNote when resolving', async () => {
+    coreRequest.mockResolvedValue({ data: {} });
+    await changeTicketStatus('t1', 'resolved', 'fixed the thing');
+    const [path, options] = coreRequest.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe('/tickets/t1/status');
+    expect(JSON.parse(String(options.body))).toEqual({
+      status: 'resolved',
+      resolutionNote: 'fixed the thing',
+    });
+  });
+
+  it('omits resolutionNote on non-resolving transitions', async () => {
+    coreRequest.mockResolvedValue({ data: {} });
+    await changeTicketStatus('t1', 'pending', 'ignored');
+    const [, options] = coreRequest.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(options.body))).toEqual({ status: 'pending' });
+  });
+});
+
+describe('statusRequiresResolutionNote', () => {
+  it('is true only for resolved — the one transition the API rejects without a note', () => {
+    expect(statusRequiresResolutionNote('resolved')).toBe(true);
+    for (const s of ['new', 'open', 'pending', 'on_hold', 'closed'] as const) {
+      expect(statusRequiresResolutionNote(s)).toBe(false);
+    }
+  });
+});
+
+describe('TICKET_STATUS_TRANSITIONS / allowedQuickStatuses', () => {
+  it('matches the server table exactly (ticketService.ts TICKET_STATUS_TRANSITIONS)', () => {
+    expect(TICKET_STATUS_TRANSITIONS).toEqual({
+      new: ['open', 'pending', 'on_hold', 'resolved', 'closed'],
+      open: ['pending', 'on_hold', 'resolved', 'closed'],
+      pending: ['open', 'on_hold', 'resolved', 'closed'],
+      on_hold: ['open', 'pending', 'resolved', 'closed'],
+      resolved: ['open', 'closed'],
+      closed: ['open'],
+    });
+  });
+
+  it('never offers a transition the API would reject with 409', () => {
+    const candidates = ['open', 'pending', 'resolved'] as const;
+    // A resolved ticket may reopen to open or go to closed — never to pending.
+    expect(allowedQuickStatuses('resolved', candidates)).toEqual(['open']);
+    // A closed ticket may only reopen.
+    expect(allowedQuickStatuses('closed', candidates)).toEqual(['open']);
+  });
+
+  it('excludes the ticket current status so a no-op chip is never rendered', () => {
+    expect(allowedQuickStatuses('open', ['open', 'pending', 'resolved'])).toEqual([
+      'pending',
+      'resolved',
+    ]);
+  });
+
+  it('canTransition agrees with the table in both directions', () => {
+    expect(canTransition('closed', 'open')).toBe(true);
+    expect(canTransition('closed', 'resolved')).toBe(false);
+    expect(canTransition('resolved', 'pending')).toBe(false);
+    expect(canTransition('new', 'closed')).toBe(true);
+  });
+});
+
+describe('SYSTEM_COMMENT_TYPES', () => {
+  it('covers exactly the activity kinds the web feed treats as system entries', () => {
+    expect([...SYSTEM_COMMENT_TYPES].sort()).toEqual(
+      ['assignment', 'status_change', 'system', 'time_entry'].sort()
+    );
+    expect(SYSTEM_COMMENT_TYPES.has('comment')).toBe(false);
+    expect(SYSTEM_COMMENT_TYPES.has('internal')).toBe(false);
+  });
+});

--- a/apps/mobile/src/services/tickets.ts
+++ b/apps/mobile/src/services/tickets.ts
@@ -1,0 +1,214 @@
+import { coreRequest } from './api';
+
+/**
+ * Ticket surface for mobile. `/api/v1/mobile/*` has no ticket routes, so the
+ * phone calls the core endpoints (`apps/api/src/routes/tickets/tickets.ts`)
+ * with the token it already holds.
+ *
+ * These interfaces describe the SUBSET of each response the app consumes, not
+ * the full server payload — the list route also returns `source`, `categoryId`,
+ * the SLA-pause fields and `deletedAt`, and the detail route returns whole
+ * `ticket_comments` rows. Extra fields are ignored at runtime; add one here
+ * when a screen starts using it.
+ */
+
+export type TicketStatus = 'new' | 'open' | 'pending' | 'on_hold' | 'resolved' | 'closed';
+export type TicketPriority = 'low' | 'normal' | 'high' | 'urgent';
+
+/** Statuses the API groups as open. Mirrors OPEN_STATUSES in tickets.ts. */
+export const OPEN_TICKET_STATUSES: readonly TicketStatus[] = [
+  'new',
+  'open',
+  'pending',
+  'on_hold',
+];
+
+export interface TicketSummary {
+  id: string;
+  /** Display reference shown in the web queue (nullable varchar, not numeric). */
+  internalNumber: string | null;
+  subject: string;
+  status: TicketStatus;
+  priority: TicketPriority;
+  /** `tickets.org_id` is NOT NULL in the schema, so this is never absent. */
+  orgId: string;
+  orgName: string | null;
+  deviceId: string | null;
+  deviceHostname: string | null;
+  assignedTo: string | null;
+  assigneeName: string | null;
+  dueDate: string | null;
+  slaBreachedAt: string | null;
+  firstResponseAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  statusName: string | null;
+  statusColor: string | null;
+}
+
+export type TicketCommentType =
+  | 'comment'
+  | 'internal'
+  | 'status_change'
+  | 'assignment'
+  | 'time_entry'
+  | 'system';
+
+/** Entry kinds the API emits as activity rather than a person's comment. */
+export const SYSTEM_COMMENT_TYPES: ReadonlySet<TicketCommentType> = new Set([
+  'status_change',
+  'assignment',
+  'time_entry',
+  'system',
+]);
+
+export interface TicketComment {
+  id: string;
+  content: string;
+  isPublic: boolean;
+  authorName: string | null;
+  createdAt: string;
+  /**
+   * `ticket_comments` is an ACTIVITY STREAM, not just user comments — the
+   * detail route returns status changes, assignments and time entries through
+   * the same array (web's TicketFeed branches on this). NOT NULL in the schema
+   * with a `comment` default; optional here only because older cached payloads
+   * may predate the field.
+   */
+  commentType?: TicketCommentType;
+  /**
+   * The detail route blanks `content` for soft-deleted comments and sets this
+   * flag instead of omitting the row, so a deleted comment arrives as an empty
+   * string. Render the placeholder off this rather than off `content`.
+   */
+  deleted?: boolean;
+}
+
+export interface TicketDetail extends TicketSummary {
+  description: string | null;
+  comments: TicketComment[];
+}
+
+export interface TicketPage {
+  tickets: TicketSummary[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+interface ListResponse {
+  data: TicketSummary[];
+  pagination?: { page: number; limit: number; total: number };
+}
+
+export type TicketAssigneeFilter = 'me' | 'all';
+
+export interface ListTicketsParams {
+  /** Server-side grouping; omit to list every status. */
+  statusGroup?: 'open' | 'closed';
+  assignee?: TicketAssigneeFilter;
+  page?: number;
+  limit?: number;
+}
+
+const DEFAULT_LIMIT = 50;
+
+/**
+ * `assignee=all` is a client-side concept — the API treats any non-`me`,
+ * non-`unassigned` value as a user id to filter by, so "all" must be sent as
+ * no parameter at all rather than as the literal string.
+ */
+export function buildTicketListQuery(params: ListTicketsParams): string {
+  const page = params.page ?? 1;
+  const limit = params.limit ?? DEFAULT_LIMIT;
+  const search = new URLSearchParams({ page: String(page), limit: String(limit) });
+  if (params.statusGroup) search.set('statusGroup', params.statusGroup);
+  if (params.assignee === 'me') search.set('assignee', 'me');
+  return search.toString();
+}
+
+export async function getTickets(params: ListTicketsParams = {}): Promise<TicketPage> {
+  const response = await coreRequest<ListResponse>(
+    `/tickets?${buildTicketListQuery(params)}`
+  );
+  const tickets = Array.isArray(response.data) ? response.data : [];
+  return {
+    tickets,
+    total: response.pagination?.total ?? tickets.length,
+    page: response.pagination?.page ?? params.page ?? 1,
+    limit: response.pagination?.limit ?? params.limit ?? DEFAULT_LIMIT,
+  };
+}
+
+export async function getTicket(id: string): Promise<TicketDetail> {
+  const response = await coreRequest<{ data: TicketDetail }>(`/tickets/${id}`);
+  const ticket = response.data;
+  return { ...ticket, comments: Array.isArray(ticket.comments) ? ticket.comments : [] };
+}
+
+export async function addTicketComment(
+  id: string,
+  content: string,
+  isPublic: boolean
+): Promise<TicketComment> {
+  const response = await coreRequest<{ data: TicketComment }>(`/tickets/${id}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ content, isPublic }),
+  });
+  return response.data;
+}
+
+/**
+ * The API rejects `status: 'resolved'` without a non-empty `resolutionNote`
+ * (`changeTicketStatusSchema.superRefine`), so callers must collect one first.
+ * Sending the field on other transitions is harmless but pointless, so it is
+ * only included when resolving.
+ *
+ * Returns the updated ticket the endpoint responds with, so callers apply the
+ * server's authoritative status (custom-status mapping can make it differ from
+ * the requested one) rather than echoing their own request back into state.
+ */
+export async function changeTicketStatus(
+  id: string,
+  status: TicketStatus,
+  resolutionNote?: string
+): Promise<TicketSummary> {
+  const body: { status: TicketStatus; resolutionNote?: string } = { status };
+  if (status === 'resolved' && resolutionNote) body.resolutionNote = resolutionNote;
+  const response = await coreRequest<{ data: TicketSummary }>(`/tickets/${id}/status`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return response.data;
+}
+
+export function statusRequiresResolutionNote(status: TicketStatus): boolean {
+  return status === 'resolved';
+}
+
+/**
+ * Mirrors TICKET_STATUS_TRANSITIONS in `apps/api/src/services/ticketService.ts`.
+ * The API throws 409 INVALID_TRANSITION for anything not listed, so offering an
+ * unreachable target in the UI produces a guaranteed error rather than a
+ * refused action. Resolved reopens only to open/closed; closed only to open.
+ */
+export const TICKET_STATUS_TRANSITIONS: Record<TicketStatus, readonly TicketStatus[]> = {
+  new: ['open', 'pending', 'on_hold', 'resolved', 'closed'],
+  open: ['pending', 'on_hold', 'resolved', 'closed'],
+  pending: ['open', 'on_hold', 'resolved', 'closed'],
+  on_hold: ['open', 'pending', 'resolved', 'closed'],
+  resolved: ['open', 'closed'],
+  closed: ['open'],
+};
+
+export function canTransition(from: TicketStatus, to: TicketStatus): boolean {
+  return TICKET_STATUS_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+/** The quick-action targets to show for a ticket, filtered to legal moves. */
+export function allowedQuickStatuses(
+  from: TicketStatus,
+  candidates: readonly TicketStatus[]
+): TicketStatus[] {
+  return candidates.filter((s) => s !== from && canTransition(from, s));
+}

--- a/apps/mobile/src/store/index.ts
+++ b/apps/mobile/src/store/index.ts
@@ -5,6 +5,7 @@ import authReducer from './authSlice';
 import alertsReducer from './alertsSlice';
 import approvalsReducer from './approvalsSlice';
 import aiChatReducer from './aiChatSlice';
+import ticketsReducer from './ticketsSlice';
 import lifecycleReducer from './lifecycleSlice';
 import { withLogoutReset } from './resettable';
 
@@ -13,6 +14,7 @@ const appReducer = combineReducers({
   alerts: alertsReducer,
   approvals: approvalsReducer,
   aiChat: aiChatReducer,
+  tickets: ticketsReducer,
   lifecycle: lifecycleReducer,
 });
 
@@ -67,3 +69,18 @@ export {
   selectUnacknowledgedAlertsCount,
   selectCriticalAlertsCount,
 } from './alertsSlice';
+
+export {
+  fetchTickets,
+  setQueue,
+  setAssignee,
+  applyStatusChange,
+  syncTicketFromDetail,
+  clearError as clearTicketsError,
+  selectTickets,
+  selectTicketsLoading,
+  selectTicketsError,
+  selectTicketQueue,
+  selectTicketAssignee,
+  selectTicketTotal,
+} from './ticketsSlice';

--- a/apps/mobile/src/store/ticketsSlice.test.ts
+++ b/apps/mobile/src/store/ticketsSlice.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ticketsSlice -> services/tickets -> services/api, whose RN-specific leaves are
+// expo-secure-store and @sentry/react-native. Mock them so the reducer can be
+// exercised in the node-only vitest environment (same approach as
+// logoutResetContract.test.ts).
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn(),
+  setItemAsync: vi.fn(),
+  deleteItemAsync: vi.fn(),
+}));
+vi.mock('@sentry/react-native', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+import reducer, {
+  applyStatusChange,
+  setAssignee,
+  setQueue,
+  clearError,
+} from './ticketsSlice';
+import type { TicketSummary } from '../services/tickets';
+
+function ticket(over: Partial<TicketSummary> = {}): TicketSummary {
+  return {
+    id: 't1',
+    internalNumber: 'TKT-1041',
+    subject: 'Printer offline',
+    status: 'open',
+    priority: 'normal',
+    orgId: 'o1',
+    orgName: 'Example Org',
+    deviceId: null,
+    deviceHostname: null,
+    assignedTo: null,
+    assigneeName: null,
+    dueDate: null,
+    slaBreachedAt: null,
+    firstResponseAt: null,
+    createdAt: '2026-08-18T00:00:00Z',
+    updatedAt: '2026-08-18T00:00:00Z',
+    statusName: null,
+    statusColor: null,
+    ...over,
+  };
+}
+
+const seeded = (over: Partial<ReturnType<typeof reducer>> = {}) => ({
+  ...reducer(undefined, { type: '@@INIT' }),
+  tickets: [ticket()],
+  total: 1,
+  ...over,
+});
+
+describe('ticketsSlice filters', () => {
+  it('sets queue and assignee independently', () => {
+    let state = reducer(undefined, setQueue('closed'));
+    expect(state.queue).toBe('closed');
+    expect(state.assignee).toBe('me');
+    state = reducer(state, setAssignee('all'));
+    expect(state.queue).toBe('closed');
+    expect(state.assignee).toBe('all');
+  });
+
+  it('clears the error without touching the list', () => {
+    const state = reducer({ ...seeded(), error: 'boom' }, clearError());
+    expect(state.error).toBeNull();
+    expect(state.tickets).toHaveLength(1);
+  });
+});
+
+describe('applyStatusChange', () => {
+  it('updates in place when the ticket still belongs in the open queue', () => {
+    const state = reducer(seeded({ queue: 'open' }), applyStatusChange({ id: 't1', status: 'pending' }));
+    expect(state.tickets).toHaveLength(1);
+    expect(state.tickets[0].status).toBe('pending');
+    expect(state.total).toBe(1);
+  });
+
+  it('drops a resolved ticket out of the open queue and decrements the total', () => {
+    const state = reducer(seeded({ queue: 'open' }), applyStatusChange({ id: 't1', status: 'resolved' }));
+    expect(state.tickets).toHaveLength(0);
+    expect(state.total).toBe(0);
+  });
+
+  it('keeps a resolved ticket when viewing the closed queue', () => {
+    const state = reducer(
+      seeded({ queue: 'closed', tickets: [ticket({ status: 'closed' })] }),
+      applyStatusChange({ id: 't1', status: 'resolved' })
+    );
+    expect(state.tickets).toHaveLength(1);
+    expect(state.tickets[0].status).toBe('resolved');
+  });
+
+  it('drops a reopened ticket out of the closed queue', () => {
+    const state = reducer(
+      seeded({ queue: 'closed', tickets: [ticket({ status: 'closed' })] }),
+      applyStatusChange({ id: 't1', status: 'open' })
+    );
+    expect(state.tickets).toHaveLength(0);
+  });
+
+  it('is a no-op for an id that is not in the cached list', () => {
+    const state = reducer(seeded(), applyStatusChange({ id: 'other', status: 'resolved' }));
+    expect(state.tickets).toHaveLength(1);
+    expect(state.total).toBe(1);
+  });
+
+  it('never drives the total negative', () => {
+    const state = reducer(
+      seeded({ queue: 'open', total: 0 }),
+      applyStatusChange({ id: 't1', status: 'closed' })
+    );
+    expect(state.total).toBe(0);
+  });
+});
+
+describe('fetchTickets filter guard', () => {
+  // A fulfilled action only counts when it belongs to the newest started
+  // request, so each case starts one first.
+  const startedState = (over: Partial<ReturnType<typeof reducer>>) =>
+    reducer({ ...seeded({ tickets: [], total: 0 }), ...over }, {
+      type: 'tickets/fetchTickets/pending',
+      meta: { requestId: 'R1' },
+    });
+  const fulfilled = (page: unknown, params: unknown) => ({
+    type: 'tickets/fetchTickets/fulfilled',
+    payload: { page, params },
+    meta: { requestId: 'R1' },
+  });
+
+  it('applies a response whose filters match the current selection', () => {
+    const state = reducer(
+      startedState({ queue: 'open', assignee: 'me' }),
+      fulfilled({ tickets: [ticket()], total: 1 }, { statusGroup: 'open', assignee: 'me' })
+    );
+    expect(state.tickets).toHaveLength(1);
+    expect(state.total).toBe(1);
+  });
+
+  it('discards a slow response for filters the user has already moved off', () => {
+    // User was on open/me, switched to closed/me; the in-flight open response
+    // lands last and must not clobber the newer list.
+    const state = reducer(
+      startedState({ queue: 'closed', assignee: 'me' }),
+      fulfilled({ tickets: [ticket(), ticket()], total: 2 }, { statusGroup: 'open', assignee: 'me' })
+    );
+    expect(state.tickets).toHaveLength(0);
+    expect(state.total).toBe(0);
+  });
+
+  it('discards a stale response when only the assignee changed', () => {
+    const state = reducer(
+      startedState({ queue: 'open', assignee: 'all' }),
+      fulfilled({ tickets: [ticket()], total: 1 }, { statusGroup: 'open', assignee: 'me' })
+    );
+    expect(state.tickets).toHaveLength(0);
+  });
+});
+
+describe('fetchTickets request-id ordering', () => {
+  const pending = (requestId: string) => ({
+    type: 'tickets/fetchTickets/pending',
+    meta: { requestId },
+  });
+  const fulfilledWith = (requestId: string, page: unknown, params: unknown) => ({
+    type: 'tickets/fetchTickets/fulfilled',
+    payload: { page, params },
+    meta: { requestId },
+  });
+  const rejectedWith = (requestId: string, message: string) => ({
+    type: 'tickets/fetchTickets/rejected',
+    payload: message,
+    meta: { requestId },
+  });
+  const sameFilters = { statusGroup: 'open', assignee: 'me' };
+
+  it('ignores an older same-filter response that lands after a newer one', () => {
+    let state = reducer(seeded({ tickets: [], total: 0 }), pending('A'));
+    state = reducer(state, pending('B'));
+    // B is newest; it wins.
+    state = reducer(state, fulfilledWith('B', { tickets: [ticket()], total: 1 }, sameFilters));
+    expect(state.total).toBe(1);
+    // A finishes last with two rows and must be discarded.
+    state = reducer(
+      state,
+      fulfilledWith('A', { tickets: [ticket(), ticket()], total: 2 }, sameFilters)
+    );
+    expect(state.total).toBe(1);
+    expect(state.tickets).toHaveLength(1);
+  });
+
+  it('ignores a rejection from an abandoned request', () => {
+    let state = reducer(seeded(), pending('A'));
+    state = reducer(state, pending('B'));
+    state = reducer(state, rejectedWith('A', 'stale failure'));
+    expect(state.error).toBeNull();
+    // ...and it must not clear the spinner while B is still running.
+    expect(state.isLoading).toBe(true);
+  });
+
+  it('surfaces a rejection from the current request', () => {
+    let state = reducer(seeded(), pending('B'));
+    state = reducer(state, rejectedWith('B', 'real failure'));
+    expect(state.error).toBe('real failure');
+    expect(state.isLoading).toBe(false);
+  });
+});
+
+describe('applyStatusChange custom labels', () => {
+  it('clears a stale custom status label when the status moves', () => {
+    const state = reducer(
+      seeded({ queue: 'open', tickets: [ticket({ statusName: 'Investigating' })] }),
+      applyStatusChange({ id: 't1', status: 'pending' })
+    );
+    // statusLabel() prefers statusName, so keeping it would show
+    // "Investigating" on a pending ticket.
+    expect(state.tickets[0].statusName).toBeNull();
+    expect(state.tickets[0].status).toBe('pending');
+  });
+
+  it('adopts a new custom label when one is supplied', () => {
+    const state = reducer(
+      seeded({ queue: 'open', tickets: [ticket({ statusName: 'Investigating' })] }),
+      applyStatusChange({ id: 't1', status: 'pending', statusName: 'Awaiting parts' })
+    );
+    expect(state.tickets[0].statusName).toBe('Awaiting parts');
+  });
+});
+
+describe('spinner ownership', () => {
+  const pending = (requestId: string) => ({
+    type: 'tickets/fetchTickets/pending',
+    meta: { requestId },
+  });
+  const fulfilledWith = (requestId: string, params: unknown) => ({
+    type: 'tickets/fetchTickets/fulfilled',
+    payload: { page: { tickets: [ticket()], total: 1 }, params },
+    meta: { requestId },
+  });
+
+  it('clears isLoading when the CURRENT request lands with filters the user moved off', () => {
+    // The request is still the newest, so nobody else will clear the spinner.
+    // Discard its data, but do not strand isLoading=true.
+    let state = reducer(seeded({ queue: 'open', tickets: [], total: 0 }), pending('A'));
+    state = reducer(state, setQueue('closed'));
+    state = reducer(state, fulfilledWith('A', { statusGroup: 'open', assignee: 'me' }));
+    expect(state.isLoading).toBe(false);
+    expect(state.tickets).toHaveLength(0);
+  });
+
+  it('leaves isLoading true when an OLDER request lands and a newer one is running', () => {
+    let state = reducer(seeded({ tickets: [], total: 0 }), pending('A'));
+    state = reducer(state, pending('B'));
+    state = reducer(state, fulfilledWith('A', { statusGroup: 'open', assignee: 'me' }));
+    expect(state.isLoading).toBe(true);
+  });
+});

--- a/apps/mobile/src/store/ticketsSlice.ts
+++ b/apps/mobile/src/store/ticketsSlice.ts
@@ -1,0 +1,181 @@
+import { createSlice, createAsyncThunk, type PayloadAction } from '@reduxjs/toolkit';
+
+import {
+  getTickets,
+  type ListTicketsParams,
+  type TicketAssigneeFilter,
+  type TicketSummary,
+} from '../services/tickets';
+
+export type TicketQueueFilter = 'open' | 'closed';
+
+interface TicketsState {
+  tickets: TicketSummary[];
+  total: number;
+  isLoading: boolean;
+  error: string | null;
+  queue: TicketQueueFilter;
+  assignee: TicketAssigneeFilter;
+  lastFetched: string | null;
+  /**
+   * requestId of the most recently STARTED fetch. Only that request may write
+   * results or errors: two fetches with identical filters can still land out of
+   * order, and a filter check alone cannot tell them apart.
+   */
+  currentRequestId: string | null;
+}
+
+const initialState: TicketsState = {
+  tickets: [],
+  total: 0,
+  isLoading: false,
+  error: null,
+  queue: 'open',
+  assignee: 'me',
+  lastFetched: null,
+  currentRequestId: null,
+};
+
+export const fetchTickets = createAsyncThunk(
+  'tickets/fetchTickets',
+  async (params: ListTicketsParams, { rejectWithValue }) => {
+    try {
+      const page = await getTickets(params);
+      // Echo the filters back so the reducer can drop a response that lost the
+      // race: switching queue/assignee fires a new request while the previous
+      // one is in flight, and the slower one must not overwrite the newer.
+      return { page, params };
+    } catch (error: unknown) {
+      const apiError = error as { message?: string };
+      return rejectWithValue(apiError.message || 'Failed to load tickets');
+    }
+  }
+);
+
+/** True when a response was produced by the filters currently selected. */
+function matchesCurrentFilters(state: TicketsState, params: ListTicketsParams): boolean {
+  const forQueue = params.statusGroup ?? state.queue;
+  const forAssignee = params.assignee ?? state.assignee;
+  return forQueue === state.queue && forAssignee === state.assignee;
+}
+
+/** True when this action belongs to the newest in-flight fetch. */
+function isCurrentRequest(state: TicketsState, requestId: string | undefined): boolean {
+  return state.currentRequestId === requestId;
+}
+
+const ticketsSlice = createSlice({
+  name: 'tickets',
+  initialState,
+  reducers: {
+    setQueue: (state, action: PayloadAction<TicketQueueFilter>) => {
+      state.queue = action.payload;
+    },
+    setAssignee: (state, action: PayloadAction<TicketAssigneeFilter>) => {
+      state.assignee = action.payload;
+    },
+    clearError: (state) => {
+      state.error = null;
+    },
+    /**
+     * Reconcile the cached row with what the detail screen just READ. Updates in
+     * place only: a passive refresh must never delete a row or move the total,
+     * because merely opening a ticket somebody else resolved would then make it
+     * vanish from the queue behind the user with no explanation.
+     */
+    syncTicketFromDetail: (
+      state,
+      action: PayloadAction<{
+        id: string;
+        status: TicketSummary['status'];
+        statusName?: string | null;
+        statusColor?: string | null;
+      }>
+    ) => {
+      const index = state.tickets.findIndex((t) => t.id === action.payload.id);
+      if (index === -1) return;
+      state.tickets[index].status = action.payload.status;
+      state.tickets[index].statusName = action.payload.statusName ?? null;
+      state.tickets[index].statusColor = action.payload.statusColor ?? null;
+    },
+    /**
+     * Fold a status change the USER just made back into the cached list. A
+     * ticket that no longer belongs in the visible queue is dropped, which is
+     * why this is reserved for deliberate actions — see `syncTicketFromDetail`
+     * for the passive read path, which must not delete rows.
+     */
+    applyStatusChange: (
+      state,
+      action: PayloadAction<{
+        id: string;
+        status: TicketSummary['status'];
+        statusName?: string | null;
+        statusColor?: string | null;
+      }>
+    ) => {
+      const index = state.tickets.findIndex((t) => t.id === action.payload.id);
+      if (index === -1) return;
+      const isClosed = action.payload.status === 'resolved' || action.payload.status === 'closed';
+      const belongsInQueue = state.queue === 'closed' ? isClosed : !isClosed;
+      if (belongsInQueue) {
+        state.tickets[index].status = action.payload.status;
+        // Drop the tenant's custom label: `statusLabel` prefers `statusName`,
+        // so keeping the old one shows e.g. "Investigating" on a ticket that
+        // has moved to pending. Null falls back to the canonical label until
+        // the next list fetch supplies the new custom name.
+        state.tickets[index].statusName = action.payload.statusName ?? null;
+        state.tickets[index].statusColor = action.payload.statusColor ?? null;
+      } else {
+        state.tickets.splice(index, 1);
+        state.total = Math.max(0, state.total - 1);
+      }
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchTickets.pending, (state, action) => {
+        state.currentRequestId = action.meta.requestId;
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(fetchTickets.fulfilled, (state, action) => {
+        // An older request must not touch anything.
+        if (!isCurrentRequest(state, action.meta.requestId)) return;
+        // The newest request has finished, so the spinner is owned by nobody
+        // else — clear it even when the payload is discarded below. Gating this
+        // on the filter check too would strand isLoading=true whenever filters
+        // changed before the in-flight response landed and no replacement
+        // request had started yet.
+        state.isLoading = false;
+        if (!matchesCurrentFilters(state, action.payload.params)) {
+          // Right request, filters the user has since moved off: drop the data
+          // rather than rendering the previous queue.
+          return;
+        }
+        state.tickets = action.payload.page.tickets;
+        state.total = action.payload.page.total;
+        state.lastFetched = new Date().toISOString();
+        state.error = null;
+      })
+      .addCase(fetchTickets.rejected, (state, action) => {
+        // An abandoned request must not surface an error over a newer view, nor
+        // clear the spinner while the current request is still running.
+        if (!isCurrentRequest(state, action.meta.requestId)) return;
+        state.isLoading = false;
+        state.error = action.payload as string;
+      });
+  },
+});
+
+export const { setQueue, setAssignee, clearError, applyStatusChange, syncTicketFromDetail } =
+  ticketsSlice.actions;
+
+export default ticketsSlice.reducer;
+
+// Selectors
+export const selectTickets = (state: { tickets: TicketsState }) => state.tickets.tickets;
+export const selectTicketsLoading = (state: { tickets: TicketsState }) => state.tickets.isLoading;
+export const selectTicketsError = (state: { tickets: TicketsState }) => state.tickets.error;
+export const selectTicketQueue = (state: { tickets: TicketsState }) => state.tickets.queue;
+export const selectTicketAssignee = (state: { tickets: TicketsState }) => state.tickets.assignee;
+export const selectTicketTotal = (state: { tickets: TicketsState }) => state.tickets.total;


### PR DESCRIPTION
Closes part of #3206 — the Tickets screens that issue lists as gap 1.

The ticketing and time-entry backends are already complete, so this is **client-side only**: no API, schema, or migration changes. Time entry and the offline queue are deliberately left for a follow-up; this PR is the browse/act surface.

## What's here

- **`services/tickets.ts`** — typed client for the core `/api/v1/tickets` surface. `/api/v1/mobile/*` has no ticket routes, so the phone calls the core endpoints with the token it already holds.
- **`store/ticketsSlice.ts`** — queue (open/closed) and assignee (mine/all) filters.
- **`screens/tickets/`** — queue list, and detail with comment posting and quick status changes.
- Tickets tab mounted in `MainNavigator` with its own stack.

## Contract details taken from the API rather than assumed

Several of these were wrong in my first pass and only found by reading the routes:

- **Status transitions are gated.** `ticketService.ts` defines `TICKET_STATUS_TRANSITIONS` and throws 409 `INVALID_TRANSITION` outside it — a resolved ticket cannot go to `pending`, and a closed one only reopens to `open`. The quick-action chips filter through a mirrored table, so the UI never offers a move that is guaranteed to fail. A test asserts the mirror equals the server's, so the two can't drift silently.
- **`ticket_comments` is an activity stream, not just comments.** The detail route returns status changes, assignments and time entries in the same array, keyed by `commentType`. Those now render as dimmed activity rows, are excluded from the comment count, and get no INTERNAL badge (they are non-public by nature). Mirrors web's `TicketFeed`.
- Soft-deleted comments arrive with `content` blanked and `deleted: true` rather than omitted, so they render a placeholder instead of an empty bubble.
- The display reference is **`internalNumber`** (nullable varchar), not `ticketNumber` (a notNull internal key) — matching what the web queue renders.
- `changeTicketStatusSchema` rejects `resolved` without a `resolutionNote`, so the screen collects one first. The note input shows **only while a resolve is pending**: an already-resolved ticket has no Resolve action and the note is discarded on other transitions, so showing it there would orphan the field.
- `tickets.org_id` is NOT NULL, so `orgId` is typed non-nullable.

## Ordering and lifecycle

- `fetchTickets` records the newest request id; only that request may write results or publish errors. Filters alone can't separate two in-flight requests that share them. The spinner is cleared by the current request even when its payload is discarded, so a filter change mid-flight can't strand `isLoading`.
- `applyStatusChange` carries the server's `statusName`/`statusColor` through — `statusLabel()` prefers the custom name, so a stale one showed e.g. "Investigating" on a ticket that had moved to pending.
- A **passive** `syncTicketFromDetail` updates the cached row in place and never deletes it. Merely opening a ticket someone else resolved must not make the row vanish from your queue; only a deliberate action removes rows.
- Detail `load()` is generation-guarded: a superseded or post-unmount GET neither writes state nor reports success.
- Mutations use the server's own response. `POST /:id/status` returns the updated ticket, so the applied status (custom-status mapping can make it differ from the request) is what reaches Redux. A POST that succeeds followed by a failed GET reports "…but the ticket could not be refreshed" and folds the returned record in, rather than toasting success over stale data.
- A ref lock replaces the render-captured `busy` flag for submit guarding: two taps before React commits could both observe `false` and double-submit.

## One shared-code change

`services/api.ts` gains an exported `coreRequest` wrapper. `services/search.ts` previously re-implemented `fetch` for the core prefix and silently dropped the auth header, CSRF header, per-install device id, and the `device_blocked` notification. Exporting the hardened path keeps that copy from spreading. `search.ts` itself is untouched here.

## Verification

Node 22.23.2 (matching `.nvmrc`), the same two commands the `test-mobile` job runs:

```
pnpm test --filter=breeze-mobile   34 files, 366 passed | 3 skipped
pnpm exec tsc --noEmit             exit 0
```

Both gates were control-tested rather than trusted:

- an injected type error makes `tsc` exit 2, so the typecheck isn't vacuously passing
- removing the request-id guard fails exactly the two tests covering it; restoring it passes
- reinstating the combined filter+id guard fails the stuck-spinner test

## Known limitation, not introduced here

`fetchWithTimeout` bounds response *headers* only. If a server sends headers and never finishes the body, the awaited `.json()` never settles and the in-flight lock stays held, leaving the buttons disabled. That affects the previous state-based `busy` guard identically and is a property of the shared fetch helper, so I've left it alone rather than widen this PR's blast radius. Happy to file it separately if you'd like it bounded.

## Not included

Time entry, the offline queue, push categories for assignment and SLA breach, and attachment upload — the rest of #3206. The offline queue is the piece that issue calls out as materially breaking the field-tech use case, and it deserves its own PR.
