### PR TITLE
fix(selfhost): unbreak first-boot — stale image pin, TURN_SECRET gate, placeholder key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -437,6 +437,10 @@ CORS_ALLOWED_ORIGINS=https://app.yourdomain.com
 # If Breeze runs behind Cloudflare Tunnel, deploy TURN on a separate VPS
 # and point TURN_HOST to that VPS's public IP. See docs: /deploy/turn-server/
 # Use: openssl rand -hex 32 to generate TURN_SECRET
+#
+# Leave these blank if you are not using remote desktop — the stack starts fine
+# without them. Only the opt-in `turn` profile needs TURN_SECRET, and coturn
+# refuses to start on an empty one rather than running as an open relay.
 TURN_HOST=
 TURN_PORT=3478
 TURN_SECRET=
@@ -869,15 +873,22 @@ MANAGED_SOFTWARE_POLICY_MODE=compat
 # the same Postgres/Redis/API data after reboots, reruns, or directory moves.
 COMPOSE_PROJECT_NAME=breeze
 
-# BREEZE_VERSION pins the Breeze API/web/binaries images. Update this when
-# upgrading — see https://github.com/lanternops/breeze/releases for current.
-BREEZE_VERSION=0.81.0
+# BREEZE_VERSION pins the Breeze API/web/portal/binaries images. Update this
+# when upgrading — see https://github.com/lanternops/breeze/releases for current.
+#
+# This must name a version whose images are actually PUBLISHED to GHCR, which is
+# not the same as the newest git tag: a release can be tagged and then fail to
+# publish (v0.105.2 and v0.106.0 are both tagged with no images). All four
+# repositories below must carry the tag — `portal` is the one that catches this,
+# since it was added after 0.81.0 and so 404s on every earlier pin.
+# scripts/security/check-env-example-version-pin.sh verifies the pin against GHCR.
+BREEZE_VERSION=0.105.1
 
 # Breeze application images. By default these resolve to the tag matching
 # BREEZE_VERSION above. For higher supply-chain assurance, replace the tag
 # (`:${BREEZE_VERSION}`) with a `@sha256:<digest>` ref from the GHCR package
 # page (https://github.com/orgs/lanternops/packages?repo_name=breeze) or via
-# `docker buildx imagetools inspect ghcr.io/lanternops/breeze/api:0.81.0`.
+# `docker buildx imagetools inspect ghcr.io/lanternops/breeze/api:0.105.1`.
 # The strict digest-pinned production deploy path lives in deploy/.env.example
 # and is enforced by scripts/security/check-supply-chain-hardening.sh.
 BREEZE_API_IMAGE_REF=ghcr.io/lanternops/breeze/api:${BREEZE_VERSION}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,15 @@ jobs:
           bash scripts/check-guided-setup-default-project.sh
           bash scripts/check-guided-setup-db-urls.sh
           bash scripts/check-guided-setup-env-roundtrip.sh
+          bash scripts/check-guided-setup-placeholders.sh
+
+      # The quickstart tells self-hosters to `cp .env.example .env` and bring the
+      # stack up, so a BREEZE_VERSION whose images were never published breaks
+      # every new install. The pin sat at 0.81.0 for ~25 releases (portal images
+      # start at 0.82.0) precisely because nothing checked it. Degrades to a
+      # warning if GHCR is unreachable, so a registry outage cannot redden CI.
+      - name: Guard .env.example version pin is published
+        run: bash scripts/security/check-env-example-version-pin.sh
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10

--- a/apps/docs/src/content/docs/deploy/production.mdx
+++ b/apps/docs/src/content/docs/deploy/production.mdx
@@ -62,6 +62,20 @@ The customer portal is served under the `/portal` path on your main domain (for 
    cp .env.example .env
    ```
 
+   <Aside type="note">
+     `git clone` fails with `destination path 'breeze' already exists and is not
+     an empty directory` if you previously ran the
+     [Quickstart](/getting-started/quickstart/) here, which creates its own
+     `breeze/` directory. Stop and remove the old stack first — renaming the
+     directory is **not** enough, because both installs share the container names
+     and the `COMPOSE_PROJECT_NAME=breeze` Docker volumes:
+
+     ```bash
+     cd breeze && docker compose down     # add -v to also discard the test database
+     cd .. && rm -rf breeze               # or move it somewhere outside your working dir
+     ```
+   </Aside>
+
 3. **Set your domain and secrets**
 
    Edit `.env` and set these required values:
@@ -71,21 +85,38 @@ The customer portal is served under the `/portal` path on your main domain (for 
    ACME_EMAIL=admin@yourdomain.com
    ```
 
-   Generate all secrets at once:
+   Generate all secrets at once. These commands rewrite the placeholder values
+   `.env.example` ships **in place** — do not append a second copy of a key to
+   the end of the file:
 
    ```bash
    for key in JWT_SECRET APP_ENCRYPTION_KEY MFA_ENCRYPTION_KEY \
      ENROLLMENT_KEY_PEPPER MFA_RECOVERY_CODE_PEPPER \
-     METRICS_SCRAPE_TOKEN SESSION_SECRET TURN_SECRET; do
-     echo "${key}=$(openssl rand -hex 32)"
+     METRICS_SCRAPE_TOKEN SESSION_SECRET AGENT_ENROLLMENT_SECRET; do
+     sed -i "s|^${key}=.*|${key}=$(openssl rand -hex 32)|" .env
    done
 
-   echo "AGENT_ENROLLMENT_SECRET=$(openssl rand -hex 32)"
-   echo "POSTGRES_PASSWORD=$(openssl rand -base64 24 | tr -d '/+=')"
-   echo "REDIS_PASSWORD=$(openssl rand -hex 32)"
+   # Canonical base64 decoding to >= 32 bytes; must not reuse JWT_SECRET.
+   # The API refuses to boot in production without this one.
+   sed -i "s|^PARTNER_API_CURSOR_SIGNING_KEY=.*|PARTNER_API_CURSOR_SIGNING_KEY=$(openssl rand -base64 32)|" .env
+
+   POSTGRES_PASSWORD="$(openssl rand -base64 24 | tr -d '/+=')"
+   REDIS_PASSWORD="$(openssl rand -hex 32)"
+   sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=${POSTGRES_PASSWORD}|" .env
+   sed -i "s|^REDIS_PASSWORD=.*|REDIS_PASSWORD=${REDIS_PASSWORD}|" .env
+   sed -i "s|^REDIS_URL=.*|REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379|" .env
    ```
 
-   Paste the output into `.env`.
+   On macOS, use `sed -i ''` instead of `sed -i`.
+
+   Confirm nothing was left at its placeholder:
+
+   ```bash
+   grep -nE 'replace-with|generate-a-random|change-in-production|your-super-secret|changeme' .env
+   ```
+
+   That should print nothing. `TURN_SECRET` is only needed if you enable the TURN
+   profile in step 4.
 
    Then set these required deployment-mode flags. Without them the API refuses to boot in production:
 
@@ -113,6 +144,12 @@ The customer portal is served under the `/portal` path on your main domain (for 
    TURN_REALM=breeze.local
    ```
 
+   Generate the shared secret coturn uses to mint credentials:
+
+   ```bash
+   sed -i "s|^TURN_SECRET=.*|TURN_SECRET=$(openssl rand -hex 32)|" .env
+   ```
+
    Coturn is behind a Docker Compose profile and does not start by default. To enable it:
 
    ```bash
@@ -120,6 +157,13 @@ The customer portal is served under the `/portal` path on your main domain (for 
    ```
 
    Or add `COMPOSE_PROFILES=turn` to your `.env` file for persistent activation.
+
+   <Aside type="note">
+     Skipping remote desktop? Leave `TURN_HOST` and `TURN_SECRET` blank — the rest
+     of the stack starts without them. If you *do* enable the profile, coturn
+     refuses to start on an empty `TURN_SECRET` rather than running as an open
+     relay, since an empty shared secret makes TURN credentials forgeable.
+   </Aside>
 
 
    <Aside type="tip">

--- a/apps/docs/src/content/docs/deploy/production.mdx
+++ b/apps/docs/src/content/docs/deploy/production.mdx
@@ -109,14 +109,16 @@ The customer portal is served under the `/portal` path on your main domain (for 
 
    On macOS, use `sed -i ''` instead of `sed -i`.
 
-   Confirm nothing was left at its placeholder:
+   Confirm no required secret was left at its placeholder:
 
    ```bash
-   grep -nE 'replace-with|generate-a-random|change-in-production|your-super-secret|changeme' .env
+   grep -nE 'replace-with|generate-a-random|change-in-production|your-super-secret|changeme' .env \
+     | grep -v '^[0-9]*:GRAFANA_ADMIN_PASSWORD='
    ```
 
-   That should print nothing. `TURN_SECRET` is only needed if you enable the TURN
-   profile in step 4.
+   That should print nothing. `GRAFANA_ADMIN_PASSWORD` is filtered out because it
+   belongs to the optional monitoring stack and is generated in that section
+   below; `TURN_SECRET` is only needed if you enable the TURN profile in step 4.
 
    Then set these required deployment-mode flags. Without them the API refuses to boot in production:
 

--- a/apps/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/apps/docs/src/content/docs/getting-started/quickstart.mdx
@@ -10,6 +10,29 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 Get a working Breeze instance running with a single `docker compose up`.
 
+## Guided setup (recommended)
+
+The guided installer downloads the templates, generates **every** required
+secret in the right format, checks that the version you pick has published
+container images, and starts the stack:
+
+```bash
+mkdir breeze && cd breeze
+curl -fsSLO https://raw.githubusercontent.com/lanternops/breeze/main/scripts/guided-setup.sh
+bash guided-setup.sh
+```
+
+Prefer to configure `.env` yourself? The manual path is below.
+
+<Aside type="tip">
+  Installing on a **headless server**? Read
+  [Reaching the dashboard from another machine](#reaching-the-dashboard-from-another-machine)
+  before you start — `BREEZE_DOMAIN=localhost` only serves requests made from the
+  Docker host itself.
+</Aside>
+
+## Manual setup
+
 <Steps>
 
 1. **Download the compose file and environment template**
@@ -30,33 +53,75 @@ Get a working Breeze instance running with a single `docker compose up`.
      **directory** and Caddy fails to start.
    </Aside>
 
-2. **Edit `.env` and set the required values**
-
-   At minimum, set these:
+2. **Set your domain**
 
    ```bash
-   # Domain (use "localhost" for local testing)
+   # Domain (use "localhost" for local testing — see the headless note below)
    BREEZE_DOMAIN=localhost
    ACME_EMAIL=you@example.com
-
-   # Generate secrets (run each command, paste the output)
-   openssl rand -base64 64   # → JWT_SECRET
-   openssl rand -hex 32      # → AGENT_ENROLLMENT_SECRET
-   openssl rand -hex 32      # → APP_ENCRYPTION_KEY
-   openssl rand -hex 32      # → MFA_ENCRYPTION_KEY
-   openssl rand -hex 32      # → ENROLLMENT_KEY_PEPPER
-   openssl rand -hex 32      # → MFA_RECOVERY_CODE_PEPPER
-   openssl rand -hex 32      # → SESSION_SECRET
-
-   # Database
-   POSTGRES_PASSWORD=changeme
    ```
+
+3. **Generate the secrets**
+
+   `.env.example` ships placeholder values for every secret. Replace them
+   **in place** — edit the existing line for each key rather than appending a
+   second copy at the end of the file.
+
+   This one-liner rewrites each placeholder with a fresh value:
+
+   ```bash
+   for key in JWT_SECRET SESSION_SECRET AGENT_ENROLLMENT_SECRET \
+     APP_ENCRYPTION_KEY MFA_ENCRYPTION_KEY ENROLLMENT_KEY_PEPPER \
+     MFA_RECOVERY_CODE_PEPPER METRICS_SCRAPE_TOKEN; do
+     sed -i "s|^${key}=.*|${key}=$(openssl rand -hex 32)|" .env
+   done
+
+   # Must be canonical base64 decoding to >= 32 bytes, and must not reuse JWT_SECRET
+   sed -i "s|^PARTNER_API_CURSOR_SIGNING_KEY=.*|PARTNER_API_CURSOR_SIGNING_KEY=$(openssl rand -base64 32)|" .env
+
+   # Database and Redis. Redis auth is REQUIRED — the API refuses to start without it.
+   POSTGRES_PASSWORD="$(openssl rand -base64 24 | tr -d '/+=')"
+   REDIS_PASSWORD="$(openssl rand -hex 32)"
+   sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=${POSTGRES_PASSWORD}|" .env
+   sed -i "s|^REDIS_PASSWORD=.*|REDIS_PASSWORD=${REDIS_PASSWORD}|" .env
+   sed -i "s|^REDIS_URL=.*|REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379|" .env
+   ```
+
+   On macOS, use `sed -i ''` instead of `sed -i`.
+
+   <Aside type="note">
+     `APP_ENCRYPTION_KEY` and `MFA_ENCRYPTION_KEY` must differ from each other,
+     and `PARTNER_API_CURSOR_SIGNING_KEY` must not reuse `JWT_SECRET`. The loop
+     above satisfies both. The authoritative list of every variable, its format,
+     and whether it is required lives in
+     [Environment Variables](/deploy/environment/).
+   </Aside>
 
    <Aside type="danger">
      Never commit `.env` to version control. It contains secrets.
    </Aside>
 
-3. **Start Breeze**
+4. **Check the version pin**
+
+   `.env.example` pins `BREEZE_VERSION` to a specific release. Confirm it is the
+   one you want before starting:
+
+   ```bash
+   grep '^BREEZE_VERSION=' .env
+   ```
+
+   To upgrade later, set it to a newer release from
+   [the releases page](https://github.com/lanternops/breeze/releases) and re-run
+   `docker compose up -d`.
+
+   <Aside type="caution">
+     Pick a version that has **published container images**, which is not always
+     the newest git tag — a release can be tagged before its images finish
+     building. If you pin one that was never published, `docker compose up` fails
+     with `not found`. The guided installer checks this for you.
+   </Aside>
+
+5. **Start Breeze**
 
    ```bash
    docker compose up -d
@@ -67,7 +132,7 @@ Get a working Breeze instance running with a single `docker compose up`.
    - Seeds the default admin user
    - Starts the background job workers
 
-4. **Verify**
+6. **Verify**
 
    ```bash
    # Wait for API to be healthy (~30s on first boot)
@@ -81,6 +146,41 @@ Get a working Breeze instance running with a single `docker compose up`.
 
 </Steps>
 
+## Reaching the dashboard from another machine
+
+`BREEZE_DOMAIN` becomes Caddy's site address, and Caddy only answers requests
+whose `Host` header matches it. With `BREEZE_DOMAIN=localhost` the ports are
+published on all interfaces, but a browser on your laptop sends
+`Host: 192.168.1.50`, which matches nothing — so a minimal/headless server
+install has no reachable UI even though `curl -k https://localhost/health`
+returns `OK` on the box itself.
+
+Pick whichever fits:
+
+- **SSH tunnel** — leave `BREEZE_DOMAIN=localhost` and forward the port:
+
+  ```bash
+  ssh -L 8443:127.0.0.1:443 user@your-server
+  # then browse to https://localhost:8443
+  ```
+
+- **LAN address** — serve the machine's IP or hostname directly:
+
+  ```bash
+  BREEZE_DOMAIN=192.168.1.50
+  PUBLIC_APP_URL=https://192.168.1.50
+  DASHBOARD_URL=https://192.168.1.50
+  ```
+
+  Caddy cannot get a public certificate for a private address, so it serves its
+  internal self-signed cert — accept the browser warning.
+
+- **Real domain** — the production path. See
+  [Production Deploy](/deploy/production/).
+
+Whichever you choose, `PUBLIC_APP_URL` must be the URL users actually visit:
+it is what agent installers and portal links are built from.
+
 ## What's Running
 
 | Container | Port | Purpose |
@@ -88,19 +188,22 @@ Get a working Breeze instance running with a single `docker compose up`.
 | `breeze-caddy` | 80, 443 | Reverse proxy + auto-TLS |
 | `breeze-api` | 3001 (internal) | Hono API server |
 | `breeze-web` | 4321 (internal) | Astro SSR dashboard |
+| `breeze-portal` | 4322 (internal) | Customer portal, served under `/portal` |
 | `breeze-postgres` | 5432 (internal) | PostgreSQL 16 database |
 | `breeze-redis` | 6379 (internal) | Redis 7 (BullMQ + caching) |
 | `breeze-coturn` | 3478 (host) | TURN relay for WebRTC remote desktop (only with `--profile turn`) |
 
 ## Next: Enroll Your First Agent
 
-Download and install the Breeze agent on a device:
+Download and install the Breeze agent on a device. `BREEZE_SERVER` must be the
+URL of your Breeze server **as the target device can reach it** — not
+`localhost`, which on the target device means the target device itself:
 
 ```bash
 # On the target device:
 # The enrollment token is REQUIRED — grab it from the Add Device dialog.
-curl -fsSL https://localhost/api/v1/agents/install.sh | \
-  BREEZE_SERVER=https://localhost \
+curl -fsSL https://breeze.example.com/api/v1/agents/install.sh | \
+  BREEZE_SERVER=https://breeze.example.com \
   BREEZE_ENROLL_TOKEN=<your-enrollment-token> \
   bash
 ```
@@ -109,12 +212,18 @@ If your server is configured with an org enrollment secret, pass it as an
 **optional** extra gate alongside the token (never instead of it):
 
 ```bash
-curl -fsSL https://localhost/api/v1/agents/install.sh | \
-  BREEZE_SERVER=https://localhost \
+curl -fsSL https://breeze.example.com/api/v1/agents/install.sh | \
+  BREEZE_SERVER=https://breeze.example.com \
   BREEZE_ENROLL_TOKEN=<your-enrollment-token> \
   BREEZE_ENROLLMENT_SECRET=<your-enrollment-secret> \
   bash
 ```
+
+<Aside type="caution">
+  Agents cannot enrol against a `localhost`-only install. Give the server a LAN
+  address or a real domain first (see above) — the agent needs to reach it from
+  wherever it runs.
+</Aside>
 
 See [Agent Installation](/agents/installation/) for detailed instructions per platform.
 

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -455,6 +455,16 @@ services:
       - breeze
 
   # TURN relay for WebRTC remote desktop. Opt-in via: docker compose --profile turn up -d
+  # SR-009: coturn must fail closed when TURN_SECRET is unset or empty — an empty
+  # REST shared secret makes TURN credentials trivially forgeable (open relay).
+  #
+  # That check MUST NOT be `--static-auth-secret=${TURN_SECRET:?...}`. Compose
+  # interpolates the whole file BEFORE it filters by profile, so a `:?` inside a
+  # profiled service aborts `docker compose up` for every deployment, including
+  # the ones that never enable TURN. The secret is therefore delivered as a
+  # file-backed Compose secret and validated at container start — which also
+  # keeps it out of argv, where any process in the container could read it from
+  # /proc/<pid>/cmdline. Only the secret moved; every other flag is unchanged.
   coturn:
     image: ${COTURN_IMAGE_REF:?Set COTURN_IMAGE_REF to a digest-pinned coturn image}
     container_name: breeze-coturn
@@ -462,40 +472,54 @@ services:
     profiles:
       - turn
     network_mode: host
-    command: >
-      turnserver
-      --listening-port=3478
-      --tls-listening-port=5349
-      --fingerprint
-      --use-auth-secret
-      --relay-threads=4
-      --user-quota=4
-      --total-quota=1000
-      --max-bps=${TURN_MAX_BPS:-5000000}
-      --no-multicast-peers
-      --denied-peer-ip=0.0.0.0-0.255.255.255
-      --denied-peer-ip=10.0.0.0-10.255.255.255
-      --denied-peer-ip=100.64.0.0-100.127.255.255
-      --denied-peer-ip=127.0.0.0-127.255.255.255
-      --denied-peer-ip=169.254.0.0-169.254.255.255
-      --denied-peer-ip=172.16.0.0-172.31.255.255
-      --denied-peer-ip=192.0.0.0-192.0.0.255
-      --denied-peer-ip=192.168.0.0-192.168.255.255
-      --denied-peer-ip=198.18.0.0-198.19.255.255
-      --denied-peer-ip=224.0.0.0-239.255.255.255
-      --denied-peer-ip=240.0.0.0-255.255.255.255
-      --denied-peer-ip=::1
-      --denied-peer-ip=fc00::-fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
-      --denied-peer-ip=fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
-      --denied-peer-ip=ff00::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
-      --log-file=stdout
-      --verbose
-      --min-port=49152
-      --max-port=65535
-      --no-cli
-      --static-auth-secret=${TURN_SECRET:?TURN_SECRET must be set (openssl rand -hex 32) when the turn profile is enabled}
-      --realm=${TURN_REALM:-breeze.local}
-      --external-ip=${TURN_HOST:-}
+    secrets:
+      - turn_secret
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=1m
+    entrypoint: ['/bin/sh', '-ec']
+    command:
+      - |
+        if [ ! -s /run/secrets/turn_secret ]; then
+          echo 'coturn: refusing to start — TURN_SECRET is unset or empty.' >&2
+          echo 'An empty REST shared secret makes TURN credentials forgeable (open relay).' >&2
+          echo 'Generate one with: openssl rand -hex 32, set TURN_SECRET in .env, and retry.' >&2
+          exit 1
+        fi
+        umask 077
+        printf 'static-auth-secret=%s\n' "$$(cat /run/secrets/turn_secret)" > /tmp/turn-secret.conf
+        exec turnserver -c /tmp/turn-secret.conf "$$@"
+      - turnserver
+      - --listening-port=3478
+      - --tls-listening-port=5349
+      - --fingerprint
+      - --use-auth-secret
+      - --relay-threads=4
+      - --user-quota=4
+      - --total-quota=1000
+      - --max-bps=${TURN_MAX_BPS:-5000000}
+      - --no-multicast-peers
+      - --denied-peer-ip=0.0.0.0-0.255.255.255
+      - --denied-peer-ip=10.0.0.0-10.255.255.255
+      - --denied-peer-ip=100.64.0.0-100.127.255.255
+      - --denied-peer-ip=127.0.0.0-127.255.255.255
+      - --denied-peer-ip=169.254.0.0-169.254.255.255
+      - --denied-peer-ip=172.16.0.0-172.31.255.255
+      - --denied-peer-ip=192.0.0.0-192.0.0.255
+      - --denied-peer-ip=192.168.0.0-192.168.255.255
+      - --denied-peer-ip=198.18.0.0-198.19.255.255
+      - --denied-peer-ip=224.0.0.0-239.255.255.255
+      - --denied-peer-ip=240.0.0.0-255.255.255.255
+      - --denied-peer-ip=::1
+      - --denied-peer-ip=fc00::-fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+      - --denied-peer-ip=fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+      - --denied-peer-ip=ff00::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+      - --log-file=stdout
+      - --verbose
+      - --min-port=49152
+      - --max-port=65535
+      - --no-cli
+      - --realm=${TURN_REALM:-breeze.local}
+      - --external-ip=${TURN_HOST:-}
 
 networks:
   breeze:
@@ -514,6 +538,11 @@ volumes:
 secrets:
   redis_password:
     environment: REDIS_PASSWORD
+  # `environment:` (not `:?`) so an unset TURN_SECRET does not abort interpolation
+  # for deployments that never enable the `turn` profile. coturn itself refuses to
+  # start on an empty secret — see the SR-009 note on that service.
+  turn_secret:
+    environment: TURN_SECRET
   # Standalone Compose bind-mounts file-backed secrets and ignores uid/gid/mode
   # target attributes. /dev/null keeps dark deployments optional; when enabled,
   # the source JWK must already have numeric owner 1001:1001 and mode 0400.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -560,6 +560,24 @@ services:
   # TURN relay for WebRTC remote desktop. Opt-in via: docker compose --profile turn up -d
   # Or set COMPOSE_PROFILES=turn in .env. Requires TURN_HOST and TURN_SECRET.
   # Open UDP 49152-65535 in your firewall for relay traffic.
+  #
+  # SR-009: coturn must fail closed when TURN_SECRET is unset or empty — an empty
+  # REST shared secret makes TURN credentials trivially forgeable (open relay).
+  #
+  # That check MUST NOT be `--static-auth-secret=${TURN_SECRET:?...}`. Compose
+  # interpolates the whole file BEFORE it filters by profile, so a `:?` inside a
+  # profiled service aborts `docker compose up` for everyone — including the
+  # majority who never enable TURN. That broke first boot for every self-hoster:
+  #
+  #   error while interpolating services.coturn.command:
+  #   required variable TURN_SECRET is missing a value
+  #
+  # So the secret is delivered as a Compose secret (file-backed, like
+  # redis_password below) and validated at container start instead. This is
+  # strictly stronger than the old form: the secret now reaches coturn through a
+  # 0600 config file rather than argv, where any process in the container could
+  # read it from /proc/<pid>/cmdline. Every other flag stays on the command line
+  # — only the secret moves — so the peer-deny list stays byte-for-byte reviewable.
   coturn:
     image: ${COTURN_IMAGE_REF:?Set COTURN_IMAGE_REF to a digest-pinned coturn image ref}
     container_name: breeze-coturn
@@ -567,40 +585,58 @@ services:
     profiles:
       - turn
     network_mode: host
-    command: >
-      turnserver
-      --listening-port=3478
-      --tls-listening-port=5349
-      --fingerprint
-      --use-auth-secret
-      --relay-threads=4
-      --user-quota=4
-      --total-quota=1000
-      --max-bps=${TURN_MAX_BPS:-5000000}
-      --no-multicast-peers
-      --denied-peer-ip=0.0.0.0-0.255.255.255
-      --denied-peer-ip=10.0.0.0-10.255.255.255
-      --denied-peer-ip=100.64.0.0-100.127.255.255
-      --denied-peer-ip=127.0.0.0-127.255.255.255
-      --denied-peer-ip=169.254.0.0-169.254.255.255
-      --denied-peer-ip=172.16.0.0-172.31.255.255
-      --denied-peer-ip=192.0.0.0-192.0.0.255
-      --denied-peer-ip=192.168.0.0-192.168.255.255
-      --denied-peer-ip=198.18.0.0-198.19.255.255
-      --denied-peer-ip=224.0.0.0-239.255.255.255
-      --denied-peer-ip=240.0.0.0-255.255.255.255
-      --denied-peer-ip=::1
-      --denied-peer-ip=fc00::-fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
-      --denied-peer-ip=fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
-      --denied-peer-ip=ff00::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
-      --log-file=stdout
-      --verbose
-      --min-port=49152
-      --max-port=65535
-      --no-cli
-      --static-auth-secret=${TURN_SECRET:?TURN_SECRET must be set (openssl rand -hex 32) when the turn profile is enabled}
-      --realm=${TURN_REALM:-breeze.local}
-      --external-ip=${TURN_HOST:-}
+    secrets:
+      - turn_secret
+    tmpfs:
+      # Writable home for the generated 0600 secret config. noexec/nosuid, tiny,
+      # and gone when the container stops.
+      - /tmp:rw,noexec,nosuid,size=1m
+    # `$$` escapes Compose interpolation so these expand in the container's shell
+    # at runtime, not at `docker compose config` time.
+    entrypoint: ['/bin/sh', '-ec']
+    command:
+      - |
+        if [ ! -s /run/secrets/turn_secret ]; then
+          echo 'coturn: refusing to start — TURN_SECRET is unset or empty.' >&2
+          echo 'An empty REST shared secret makes TURN credentials forgeable (open relay).' >&2
+          echo 'Generate one with: openssl rand -hex 32, set TURN_SECRET in .env, and retry.' >&2
+          exit 1
+        fi
+        umask 077
+        printf 'static-auth-secret=%s\n' "$$(cat /run/secrets/turn_secret)" > /tmp/turn-secret.conf
+        exec turnserver -c /tmp/turn-secret.conf "$$@"
+      - turnserver
+      - --listening-port=3478
+      - --tls-listening-port=5349
+      - --fingerprint
+      - --use-auth-secret
+      - --relay-threads=4
+      - --user-quota=4
+      - --total-quota=1000
+      - --max-bps=${TURN_MAX_BPS:-5000000}
+      - --no-multicast-peers
+      - --denied-peer-ip=0.0.0.0-0.255.255.255
+      - --denied-peer-ip=10.0.0.0-10.255.255.255
+      - --denied-peer-ip=100.64.0.0-100.127.255.255
+      - --denied-peer-ip=127.0.0.0-127.255.255.255
+      - --denied-peer-ip=169.254.0.0-169.254.255.255
+      - --denied-peer-ip=172.16.0.0-172.31.255.255
+      - --denied-peer-ip=192.0.0.0-192.0.0.255
+      - --denied-peer-ip=192.168.0.0-192.168.255.255
+      - --denied-peer-ip=198.18.0.0-198.19.255.255
+      - --denied-peer-ip=224.0.0.0-239.255.255.255
+      - --denied-peer-ip=240.0.0.0-255.255.255.255
+      - --denied-peer-ip=::1
+      - --denied-peer-ip=fc00::-fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+      - --denied-peer-ip=fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+      - --denied-peer-ip=ff00::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+      - --log-file=stdout
+      - --verbose
+      - --min-port=49152
+      - --max-port=65535
+      - --no-cli
+      - --realm=${TURN_REALM:-breeze.local}
+      - --external-ip=${TURN_HOST:-}
 
 networks:
   # Fixed subnet so Caddy gets a stable, known peer address (see caddy service
@@ -627,6 +663,12 @@ volumes:
 secrets:
   redis_password:
     environment: REDIS_PASSWORD
+  # `environment:` (not `:?`) so an unset TURN_SECRET does not abort interpolation
+  # for the majority of deployments that never enable the `turn` profile. coturn
+  # itself refuses to start on an empty secret — see the SR-009 note on that
+  # service, and check-relay-edge-hardening.sh which enforces the guard.
+  turn_secret:
+    environment: TURN_SECRET
   # Standalone Compose bind-mounts file-backed secrets and ignores uid/gid/mode
   # target attributes. /dev/null keeps dark deployments optional; when enabled,
   # the source JWK must already have numeric owner 1001:1001 and mode 0400.

--- a/scripts/check-guided-setup-placeholders.sh
+++ b/scripts/check-guided-setup-placeholders.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+# Behavioral guard: every placeholder secret shipped in .env.example must be
+# recognised by the guided installer's looks_like_placeholder().
+#
+# Why this guard exists
+# ---------------------
+# prompt_secret() keeps whatever value is already in .env unless
+# looks_like_placeholder() says it is a placeholder, in which case it generates a
+# real secret. That predicate is a substring allowlist of the exact wordings used
+# in .env.example — so it is only correct as long as nobody introduces a new
+# wording, and it fails SILENTLY when someone does: `--yes`/auto mode copies the
+# placeholder text straight into .env and the API then refuses to boot.
+#
+# PARTNER_API_CURSOR_SIGNING_KEY shipped exactly that way. Every other secret in
+# .env.example used `generate-a-random-...` or `...-change-in-production`, both
+# matched; it alone used `replace-with-base64-encoded-32-byte-random-key`, which
+# was not. Self-hosters running the guided installer got a .env whose cursor
+# signing key was the literal placeholder string, and the API refused to start
+# (validate.ts requires canonical base64 decoding to >= 32 bytes in production).
+#
+# So: derive the expectation from .env.example rather than from a hand-kept list.
+# Any secret-shaped placeholder added there in a new wording fails here, in the
+# required Lint job, instead of in someone's install.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ENV_EXAMPLE="${REPO_ROOT}/.env.example"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+[[ -f "${ENV_EXAMPLE}" ]] || {
+  echo "FAIL: ${ENV_EXAMPLE} not found" >&2
+  exit 1
+}
+
+FUNCTIONS_FILE="${TMP_DIR}/guided-setup-functions.sh"
+CANDIDATES_FILE="${TMP_DIR}/candidates.txt"
+
+sed '/^main "\$@"$/d' "${REPO_ROOT}/scripts/guided-setup.sh" > "${FUNCTIONS_FILE}"
+
+# Candidate placeholders: non-empty assignments in .env.example whose VALUE looks
+# like prose-instructions-to-a-human rather than a real default. Real defaults
+# (ports, booleans, durations, URLs, image refs, version pins) never match these
+# markers, so this stays quiet unless somebody genuinely ships a new placeholder
+# wording. Matching is on the value only — a key named REPLACE_ME with a real
+# default is not a placeholder.
+grep -E '^[A-Za-z_][A-Za-z0-9_]*=.+' "${ENV_EXAMPLE}" \
+  | grep -iE '=[^=]*(replace[-_ ]?with|change[-_ ]?me|change[-_ ]?in[-_ ]production|generate[-_ ]a[-_ ]random|your-super-secret|your-enrollment-secret|placeholder|__generate_me__|secure_password)' \
+  > "${CANDIDATES_FILE}" || true
+
+if [[ ! -s "${CANDIDATES_FILE}" ]]; then
+  echo "FAIL: found no placeholder-shaped values in .env.example." >&2
+  echo "Either every placeholder was replaced with a real default (then delete this guard)," >&2
+  echo "or the detection pattern above drifted and is now silently checking nothing." >&2
+  exit 1
+fi
+
+# Assertions run in a subshell so we can source the installer's functions and
+# relax the `set -euo pipefail` / EXIT trap / exiting `fail` it installs at top
+# level, without affecting this script's own strict mode. Mirrors the structure
+# of check-guided-setup-env-roundtrip.sh.
+(
+  # Sourcing the installer runs top-level code that derives ENV_FILE from
+  # WORK_DIR="${BREEZE_SETUP_DIR:-$(pwd)}". Point it at the sandbox BEFORE the
+  # source so nothing touches the developer's real ./.env.
+  export BREEZE_SETUP_DIR="${TMP_DIR}"
+  # shellcheck source=/dev/null
+  source "${FUNCTIONS_FILE}" >/dev/null 2>&1
+  ENV_FILE="${TMP_DIR}/.env"
+  trap - EXIT
+  set +e +u +o pipefail
+  warn() { :; }
+  log() { :; }
+  fail() { printf 'fail:%s\n' "$*" >&2; return 1; }
+
+  fails=0
+  checked=0
+  while IFS= read -r line; do
+    key="${line%%=*}"
+    value="${line#*=}"
+    [[ -n "${value}" ]] || continue
+    checked=$((checked + 1))
+    if ! looks_like_placeholder "${value}"; then
+      printf 'UNDETECTED PLACEHOLDER: %s=%s\n' "${key}" "${value}"
+      fails=$((fails + 1))
+    fi
+  done < "${CANDIDATES_FILE}"
+
+  # Guard the guard: a predicate that returns true for everything would pass the
+  # loop above while breaking the installer (it would regenerate real values the
+  # operator deliberately set). Assert it still rejects realistic secrets.
+  for real in \
+    "8f14e45fceea167a5a36dedd4bea2543" \
+    "aGVsbG8td29ybGQtdGhpcy1pcy1hLXJlYWwtc2VjcmV0LXZhbHVl" \
+    "breeze.example.com" \
+    "0.105.1"; do
+    if looks_like_placeholder "${real}"; then
+      printf 'FALSE POSITIVE: looks_like_placeholder rejected a real value: %s\n' "${real}"
+      fails=$((fails + 1))
+    fi
+  done
+
+  printf 'checked %d placeholder value(s) from .env.example\n' "${checked}"
+  if ((fails > 0)); then
+    printf '\n%d problem(s). Add the new wording to looks_like_placeholder() in scripts/guided-setup.sh.\n' "${fails}" >&2
+    printf 'Otherwise the guided installer copies the placeholder into .env verbatim and the API refuses to boot.\n' >&2
+    exit 1
+  fi
+  exit 0
+)
+
+echo "OK: every .env.example placeholder is detected by looks_like_placeholder()."

--- a/scripts/guided-setup.sh
+++ b/scripts/guided-setup.sh
@@ -2602,6 +2602,19 @@ set_env_value() {
   fi
 }
 
+# Recognises the placeholder values shipped in .env.example so prompt_secret()
+# treats them as "unset" and generates a real secret instead of keeping them.
+#
+# This is a substring allowlist of the exact wordings used in .env.example, which
+# makes it silently brittle: a secret added there with a NEW wording is not
+# matched, so `--yes` / auto mode copies the placeholder straight through and the
+# API refuses to boot. That is exactly how PARTNER_API_CURSOR_SIGNING_KEY shipped
+# broken — it was the only value in the file using `replace-with-...` while every
+# other secret used `generate-a-random-...` or `...-change-in-production`.
+#
+# envExamplePlaceholders.test.ts (required test-api job) asserts every secret
+# placeholder in .env.example is matched here, so the next new wording fails CI
+# instead of a self-hoster's install.
 looks_like_placeholder() {
   local value
   value="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
@@ -2611,6 +2624,7 @@ looks_like_placeholder() {
   [[ "${value}" == *change_me* ]] && return 0
   [[ "${value}" == *change-in-production* ]] && return 0
   [[ "${value}" == *generate-a-random* ]] && return 0
+  [[ "${value}" == *replace-with* ]] && return 0
   [[ "${value}" == *your-super-secret* ]] && return 0
   [[ "${value}" == *your-enrollment-secret* ]] && return 0
   [[ "${value}" == *yourdomain.com* ]] && return 0
@@ -3351,6 +3365,71 @@ fetch_latest_github_release_version() {
   return 1
 }
 
+# Returns 0 if every Breeze image for this version is pullable from GHCR, 1 if
+# any is definitely absent, and 2 if the registry could not be reached (unknown).
+#
+# A git tag is NOT proof that images exist: release.yml creates the GitHub
+# Release and tag first and only then builds images (`needs: [create-release]`),
+# so a build or signing failure leaves a version that resolves everywhere except
+# the registry. v0.105.2 and v0.106.0 are both in that state today. Selecting one
+# produces a setup that completes happily and then dies on `docker compose up`
+# with `not found` — which is precisely the failure .env.example's stale 0.81.0
+# pin caused for every self-hoster, so it is worth catching here too.
+breeze_version_images_published() {
+  local version="$1"
+  local registry="ghcr.io"
+  local namespace="lanternops/breeze"
+  local repo token http_status reachable=0 missing=0
+
+  for repo in api web portal binaries; do
+    token=""
+    token="$(curl -fsSL --connect-timeout 5 --max-time 15 \
+      "https://${registry}/token?scope=repository:${namespace}/${repo}:pull&service=${registry}" 2>/dev/null \
+      | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')" || true
+    if [[ -z "${token}" ]]; then
+      continue
+    fi
+
+    http_status="$(curl -fsS -o /dev/null -w '%{http_code}' \
+      --connect-timeout 5 --max-time 15 \
+      -H "Authorization: Bearer ${token}" \
+      -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json' \
+      "https://${registry}/v2/${namespace}/${repo}/manifests/${version}" 2>/dev/null)" || true
+    [[ -n "${http_status}" ]] || continue
+
+    reachable=1
+    [[ "${http_status}" == "200" ]] || missing=1
+  done
+
+  ((reachable == 1)) || return 2
+  ((missing == 0)) || return 1
+  return 0
+}
+
+# Warns (and in unattended mode, aborts) when the chosen version has no images.
+# Never blocks on an unreachable registry, and never blocks a deployment using
+# custom BREEZE_*_IMAGE_REF overrides — it only reports what GHCR actually has.
+confirm_breeze_version_available() {
+  local version="$1" rc=0
+
+  breeze_version_images_published "${version}" || rc=$?
+  case "${rc}" in
+    0) return 0 ;;
+    2) return 0 ;;
+  esac
+
+  warn "Breeze ${version} is tagged but its container images are not published to GHCR."
+  warn "Continuing will fail at 'docker compose up' with: not found."
+  warn "Pick the newest version listed at https://github.com/lanternops/breeze/releases"
+  warn "that has images, unless you build your own and set BREEZE_*_IMAGE_REF."
+
+  if [[ "${YES_MODE}" == "true" ]]; then
+    fail "BREEZE_VERSION=${version} has no published images; re-run without --yes to choose another."
+  fi
+
+  ask_yes_no "Use ${version} anyway?" "no"
+}
+
 select_breeze_version() {
   local current latest default_value answer
 
@@ -3385,6 +3464,7 @@ select_breeze_version() {
   if [[ "${YES_MODE}" == "true" ]]; then
     if [[ -n "${default_value}" ]]; then
       answer="${default_value#v}"
+      confirm_breeze_version_available "${answer}"
       SELECTED_BREEZE_VERSION="${answer}"
       log "Selected Breeze version: ${answer}"
       return
@@ -3406,6 +3486,9 @@ select_breeze_version() {
 
     if [[ -n "${answer}" ]]; then
       answer="${answer#v}"
+      if ! confirm_breeze_version_available "${answer}"; then
+        continue
+      fi
       SELECTED_BREEZE_VERSION="${answer}"
       log "Selected Breeze version: ${answer}"
       return

--- a/scripts/security/check-env-example-version-pin.sh
+++ b/scripts/security/check-env-example-version-pin.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Verify that .env.example's BREEZE_VERSION names a version whose images are
+# actually published to GHCR.
+#
+# Why this exists
+# ---------------
+# .env.example shipped BREEZE_VERSION=0.81.0 for ~25 releases because nothing
+# bumped it and nothing checked it. The quickstart tells self-hosters to
+# `cp .env.example .env && docker compose up -d`, so every new install pulled
+# 0.81.0 — and `ghcr.io/lanternops/breeze/portal:0.81.0` does not exist, because
+# the portal service was added to compose after that release. The result was a
+# hard `not found` on first boot for 100% of new self-hosters.
+#
+# "Bump it at release time" alone does NOT fix this: the GitHub Release and the
+# git tag are created BEFORE the image builds run (release.yml's build-docker-*
+# jobs declare `needs: [create-release]`), so a signing or build failure leaves a
+# tag with no images. That is not hypothetical — v0.105.2 and v0.106.0 are both
+# tagged today with nothing published. A release-time bump would have pinned
+# .env.example to exactly those broken versions.
+#
+# So the invariant is checked against the registry, which is the only thing that
+# knows what an operator can actually pull: every Breeze image repo must carry
+# the pinned tag.
+#
+# Usage:
+#   scripts/security/check-env-example-version-pin.sh            # check .env.example
+#   scripts/security/check-env-example-version-pin.sh 0.105.1    # check a version
+#
+# Exits non-zero (with the missing repos named) if any image is absent.
+# Exits 0 with a warning if GHCR is unreachable — this must not turn a registry
+# outage into a red build.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REGISTRY_HOST="ghcr.io"
+IMAGE_NAMESPACE="lanternops/breeze"
+# The four repos .env.example's BREEZE_*_IMAGE_REF lines resolve to. `portal` is
+# the one that catches a stale pin, so it must never be dropped from this list.
+IMAGE_REPOS=(api web portal binaries)
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+read_pinned_version() {
+  local env_example="${REPO_ROOT}/.env.example"
+  [[ -f "${env_example}" ]] || fail "${env_example} not found"
+
+  local value
+  value="$(awk -F= '/^BREEZE_VERSION=/ { print $2; exit }' "${env_example}")"
+  [[ -n "${value}" ]] || fail ".env.example does not set BREEZE_VERSION"
+  printf '%s' "${value}"
+}
+
+# Anonymous pull token. Public packages issue one without credentials, so this
+# works on forks and unauthenticated CI alike.
+registry_token() {
+  local repo="$1" body
+  body="$(curl -fsSL --connect-timeout 5 --max-time 15 \
+    "https://${REGISTRY_HOST}/token?scope=repository:${IMAGE_NAMESPACE}/${repo}:pull&service=${REGISTRY_HOST}" 2>/dev/null)" || return 1
+  printf '%s' "${body}" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p'
+}
+
+# Prints the HTTP status for the manifest, or nothing if the registry could not
+# be reached at all (so a network failure is distinguishable from a 404).
+manifest_status() {
+  local repo="$1" version="$2" token
+  token="$(registry_token "${repo}")" || return 1
+  [[ -n "${token}" ]] || return 1
+
+  curl -fsS -o /dev/null -w '%{http_code}' \
+    --connect-timeout 5 --max-time 15 \
+    -H "Authorization: Bearer ${token}" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json' \
+    "https://${REGISTRY_HOST}/v2/${IMAGE_NAMESPACE}/${repo}/manifests/${version}" 2>/dev/null || true
+}
+
+main() {
+  local version="${1:-}"
+  if [[ -z "${version}" ]]; then
+    version="$(read_pinned_version)"
+    printf 'Checking .env.example pin: BREEZE_VERSION=%s\n' "${version}"
+  else
+    printf 'Checking version: %s\n' "${version}"
+  fi
+
+  local missing=() unreachable=0 repo status
+  for repo in "${IMAGE_REPOS[@]}"; do
+    status="$(manifest_status "${repo}" "${version}")"
+    if [[ -z "${status}" ]]; then
+      printf '  %-9s %s  (registry unreachable)\n' "${repo}" "${version}"
+      unreachable=1
+      continue
+    fi
+    if [[ "${status}" == "200" ]]; then
+      printf '  %-9s %s  OK\n' "${repo}" "${version}"
+    else
+      printf '  %-9s %s  HTTP %s\n' "${repo}" "${version}" "${status}"
+      missing+=("${repo}")
+    fi
+  done
+
+  if ((${#missing[@]} > 0)); then
+    printf '\n' >&2
+    fail "$(printf 'BREEZE_VERSION=%s is not fully published to GHCR. Missing: %s\n' \
+      "${version}" "${missing[*]}")
+Self-hosters following the quickstart will hit \`not found\` on \`docker compose up\`.
+Pin .env.example to the newest version where ALL of (${IMAGE_REPOS[*]}) are published —
+a tagged release is not necessarily a published one."
+  fi
+
+  if ((unreachable == 1)); then
+    printf 'WARN: could not reach %s for every repo; pin not fully verified.\n' "${REGISTRY_HOST}" >&2
+    exit 0
+  fi
+
+  printf 'OK: BREEZE_VERSION=%s is published for all %d image repos.\n' "${version}" "${#IMAGE_REPOS[@]}"
+}
+
+main "$@"

--- a/scripts/security/check-relay-edge-hardening.sh
+++ b/scripts/security/check-relay-edge-hardening.sh
@@ -35,18 +35,118 @@ for file in docker/turnserver.conf docker-compose.yml deploy/docker-compose.prod
   require_grep 'no-multicast-peers|--no-multicast-peers' "$file" "$file must deny multicast TURN peers"
 done
 
-# SR-009: coturn must fail closed if TURN_SECRET is unset/empty. An empty
-# REST shared secret makes TURN credentials trivially forgeable (open relay).
-# Require the fail-closed `${TURN_SECRET:?...}` form and reject the silent
-# empty-default `${TURN_SECRET:-}` / bare `${TURN_SECRET}` forms.
+# SR-009: coturn must fail closed if TURN_SECRET is unset/empty. An empty REST
+# shared secret makes TURN credentials trivially forgeable (open relay).
+#
+# This check used to require the interpolation-time `${TURN_SECRET:?...}` form.
+# That did fail closed, but it failed closed for EVERYBODY: Compose interpolates
+# the entire file before it filters by profile, so a `:?` inside the profiled
+# coturn service aborted `docker compose up` for every self-hoster, TURN or not.
+# It was the first error every new install hit.
+#
+# The guarantee is now enforced at container start instead, and the secret is
+# delivered as a file-backed Compose secret rather than argv — strictly stronger
+# than before, since the old form exposed it via /proc/<pid>/cmdline to anything
+# running in the container.
+#
+# Assertions are scoped to the coturn service block, because a repo-wide grep can
+# be satisfied by a comment or an unrelated service and would pass vacuously.
+# coturn is the LAST service in both files, so the block must terminate on a
+# top-level key (`networks:`, `volumes:`, `secrets:`) as well as on a sibling
+# service — otherwise it swallows the rest of the file and the assertions below
+# can be satisfied by unrelated sections.
+coturn_block() {
+  awk '
+    /^  coturn:/ { inblk = 1; next }
+    inblk && /^[^[:space:]]/ { exit }
+    inblk && /^  [a-z_-]+:/ { exit }
+    inblk
+  ' "$1"
+}
+
+# YAML comments are prose, not configuration: the notes explaining this very rule
+# quote the forbidden `${TURN_SECRET:?...}` form. Strip them before asserting.
+without_comments() {
+  sed 's/[[:space:]]*#.*$//' "$1"
+}
+
 for file in docker-compose.yml deploy/docker-compose.prod.yml; do
-  reject_grep 'static-auth-secret=\$\{TURN_SECRET:-' "$file" \
-    "$file: TURN static-auth-secret must fail closed (\${TURN_SECRET:?...}), not default to empty (\${TURN_SECRET:-})"
-  reject_grep 'static-auth-secret=\$\{TURN_SECRET\}' "$file" \
-    "$file: TURN static-auth-secret must fail closed (\${TURN_SECRET:?...}), not use a bare \${TURN_SECRET}"
-  require_grep 'static-auth-secret=\$\{TURN_SECRET:\?' "$file" \
-    "$file: TURN static-auth-secret must use the fail-closed \${TURN_SECRET:?...} form"
+  blk="$(mktemp)"
+  code="$(mktemp)"
+  coturn_block "$file" > "$blk"
+  without_comments "$file" > "$code"
+  [ -s "$blk" ] || fail "$file: could not locate the coturn service block (did it get renamed?)"
+
+  # 1a. No `:?` form anywhere in the file. Compose evaluates every interpolation
+  #     before it filters by profile, so a single required-variable reference --
+  #     even inside a service nobody enables -- aborts `docker compose up` for
+  #     every deployment. This is the exact regression being guarded against.
+  #     (`${TURN_SECRET:-}` is fine and is how the api service receives it, so
+  #     that it can mint REST credentials for WebRTC clients.)
+  reject_grep '\$\{TURN_SECRET:\?' "$code" \
+    "$file: TURN_SECRET must not use the required-variable form \${TURN_SECRET:?...}. Compose interpolates the whole file before filtering by profile, so this aborts 'docker compose up' for every deployment that does not use TURN. Use \${TURN_SECRET:-} and let coturn fail closed at startup."
+
+  # 1b. The coturn service itself must not interpolate the secret at all -- it
+  #     receives it as a file-backed secret.
+  blk_code="$(mktemp)"
+  sed 's/[[:space:]]*#.*$//' "$blk" > "$blk_code"
+  reject_grep '\$\{TURN_SECRET' "$blk_code" \
+    "$file: the coturn service must not interpolate \${TURN_SECRET...}; it reads /run/secrets/turn_secret instead"
+  rm -f "$blk_code"
+
+  # 2. It must reach coturn as a secret file, not argv or the environment.
+  require_grep '^      - turn_secret$' "$blk" \
+    "$file: the coturn service must mount the turn_secret Compose secret"
+  require_grep '^  turn_secret:' "$file" \
+    "$file: a turn_secret Compose secret must be declared"
+  # The FLAG form is what leaks into argv. The `static-auth-secret=` config-file
+  # key written from /run/secrets is the intended path, so match only `--`.
+  reject_grep '\-\-static-auth-secret=' "$blk" \
+    "$file: the TURN shared secret must not be passed on coturn's command line (readable via /proc/<pid>/cmdline); write it to a 0600 config file from /run/secrets/turn_secret instead"
+
+  # 3. It must refuse to start on a missing/empty secret, BEFORE exec'ing
+  #    turnserver -- this is the fail-closed guarantee itself.
+  require_grep '\[ ! -s /run/secrets/turn_secret \]' "$blk" \
+    "$file: coturn must refuse to start when /run/secrets/turn_secret is missing or empty (open-relay risk)"
+  require_grep 'exit 1' "$blk" \
+    "$file: coturn's empty-secret check must exit non-zero"
+  require_grep 'umask 077' "$blk" \
+    "$file: the generated coturn secret config must be written with a restrictive umask"
+  require_grep 'exec turnserver -c /tmp/turn-secret\.conf' "$blk" \
+    "$file: coturn must exec turnserver with the generated secret config"
+
+  # 4. The auth mode that makes the secret meaningful must still be on.
+  require_grep '^      - --use-auth-secret$' "$blk" \
+    "$file: coturn must keep --use-auth-secret (REST shared-secret authentication)"
+
+  rm -f "$blk" "$code"
 done
+
+# Behavioral proof of the property this check exists for: with TURN_SECRET unset,
+# the compose file must still resolve. Requires Docker, so it is advisory when the
+# CLI is unavailable (the structural assertions above always run).
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  probe="$(mktemp -d)"
+  # Only coturn is under test; a stub keeps the probe independent of the many
+  # other required variables in the real file.
+  {
+    echo 'services:'
+    echo '  coturn:'
+    coturn_block docker-compose.yml
+    echo 'secrets:'
+    echo '  turn_secret:'
+    echo '    environment: TURN_SECRET'
+  } > "$probe/docker-compose.yml"
+
+  if ! (cd "$probe" && env -u TURN_SECRET COTURN_IMAGE_REF=coturn/coturn:latest \
+        docker compose config >/dev/null 2>"$probe/err"); then
+    echo "relay-edge-hardening: coturn config failed to resolve with TURN_SECRET unset:" >&2
+    cat "$probe/err" >&2
+    rm -rf "$probe"
+    fail "TURN_SECRET must not be required to bring up a stack that does not use TURN"
+  fi
+  rm -rf "$probe"
+fi
 
 reject_grep 'trusted_proxies[[:space:]]+static[[:space:]]+private_ranges' docker/Caddyfile.prod \
   "Caddy must not trust all private ranges as proxy hops"


### PR DESCRIPTION
A self-hoster reported that a from-scratch install on Ubuntu 24.04 could not be completed by any of the three documented paths. All four causes reproduce; none were user error. Each fix ships with a guard so it cannot silently return.

## 1. `.env.example` pinned a version whose images don't exist

`BREEZE_VERSION=0.81.0`, never bumped since the line was written (~25 releases ago). `portal` images start at `0.82.0`, because the portal service was added to compose after that release:

```
portal:0.81.0  → HTTP 404       api:0.81.0  → HTTP 200
```

So the documented quickstart — `cp .env.example .env && docker compose up -d` — ended in `not found` for **every** new self-hoster. Pinned to `0.105.1`, the newest version with all four images actually published.

**Guard:** `scripts/security/check-env-example-version-pin.sh` (Lint job) resolves `api`/`web`/`portal`/`binaries` manifests against GHCR. Verified it rejects the old pin and accepts the new one:

```
$ ./scripts/security/check-env-example-version-pin.sh 0.81.0
  portal    0.81.0  HTTP 404
FAIL: BREEZE_VERSION=0.81.0 is not fully published to GHCR. Missing: portal
```

A **tagged release is not a published one.** `release.yml` creates the tag and GitHub Release *before* the image jobs (`needs: [create-release]`), so `v0.105.2` and `v0.106.0` are both tagged right now with nothing in the registry — a release-time bump would have pinned `.env.example` to exactly those. Verification has to be against the registry.

## 2. `TURN_SECRET` blocked startup for everyone, TURN or not

Compose interpolates the entire file **before** filtering by profile, so `${TURN_SECRET:?...}` inside the profiled `coturn` service aborted `docker compose up` for every deployment:

```
error while interpolating services.coturn.command:
required variable TURN_SECRET is missing a value
```

The secret is now a file-backed Compose secret, validated at container start. **This is strictly stronger than what it replaces** — the old form put the secret in coturn's argv, readable from `/proc/<pid>/cmdline` by anything in the container; it now arrives via a 0600 config file. Only the secret moved; the peer-deny list and all 30 other flags are byte-identical (`diff` against `origin/main` shows exactly one flag removed per file). Applied to `deploy/docker-compose.prod.yml` too.

Verified end to end against the real image:

| Scenario | Result |
|---|---|
| `TURN_SECRET` absent, no profile | compose resolves, stack starts |
| profile on, secret empty | coturn exits **1** with a diagnostic |
| profile on, secret set | starts; REST credential derived from it **authenticates** |
| profile on, credential from a *wrong* secret | **rejected** |
| secret in `/proc/1/cmdline` or `/proc/1/environ` | **absent from both** |

**Guard:** SR-009 rewritten to assert the runtime guarantee rather than the interpolation-time one, scoped to the `coturn` block so a comment or unrelated service can't satisfy it. Note the api service legitimately keeps `${TURN_SECRET:-}` (safe form) to mint WebRTC credentials — the rule targets the `:?` form and any interpolation inside coturn. Mutation-tested; all five regressions are caught:

```
${TURN_SECRET:?} back in coturn argv  -> exit=1
fail-closed guard deleted             -> exit=1
--use-auth-secret removed             -> exit=1
turn_secret not mounted               -> exit=1
umask 077 removed                     -> exit=1
```

## 3. `guided-setup.sh` left `PARTNER_API_CURSOR_SIGNING_KEY` at its placeholder

The API then refuses to boot (canonical base64, ≥32 bytes, in production). `looks_like_placeholder()` is a substring allowlist of the wordings used in `.env.example`, and this was the **only** value using `replace-with-...` while every other secret used `generate-a-random-...` or `...-change-in-production`. One unlucky string.

**Guard:** `scripts/check-guided-setup-placeholders.sh` derives the expectation from `.env.example` instead of a hand-kept list, so the next new wording fails in Lint rather than in someone's install. It also asserts the predicate still *rejects* realistic secrets, so a predicate returning true for everything can't pass. Mutation-tested — reverting the one-line fix fails the guard naming the exact variable.

## 4. `select_breeze_version()` could pick a version with no images

Its fallback queries `/tags?per_page=1`, which returns `v0.106.0` today. It now verifies the four images resolve before accepting: warns and re-prompts interactively, fails under `--yes`, stays quiet when the registry is unreachable or images are custom (`BREEZE_*_IMAGE_REF` overrides).

## Docs

The hand-maintained secret list had already drifted — quickstart omitted `REDIS_PASSWORD` (which the API requires), `METRICS_SCRAPE_TOKEN`, and `PARTNER_API_CURSOR_SIGNING_KEY`, told readers to set `POSTGRES_PASSWORD=changeme`, and contradicted production on `JWT_SECRET` (`-base64 64` vs `-hex 32`; both actually satisfy the ≥32-char rule, but it reads like a bug). Quickstart now leads with the guided installer and points at `/deploy/environment/` as the authoritative list, so there is less to keep in sync.

Also fixed:
- **Headless access.** `BREEZE_DOMAIN=localhost` makes Caddy answer only for `Host: localhost`, so a minimal server install has no reachable UI even though `curl -k https://localhost/health` returns OK on the box. Added an SSH-tunnel / LAN-address / real-domain section. The reporter worked around this by reinstalling on desktop Ubuntu — there was no documented path.
- **Agent install snippet** told readers to run `BREEZE_SERVER=https://localhost` *on the target device*, where `localhost` is the target device. Could never work.
- **"Paste the output into `.env`"** was ambiguous against a file that already contained those keys. Both pages now rewrite placeholders in place, with a `grep` to confirm none survive.
- **`git clone` into the quickstart's `breeze/` directory fails.** Documented, including that renaming the directory is *not* enough — both stacks share container names and the `COMPOSE_PROJECT_NAME=breeze` volumes, so a "fresh" install silently reattaches the old database.

## Verification

- Compose tests: `composeBindMounts`, `envComposeParity`, `requestDatabaseCompose` — 17 passed
- All `check-guided-setup-*.sh`, `check-relay-edge-hardening.sh`, `check-supply-chain-hardening.sh`, `check-env-example-version-pin.sh` — pass
- `pnpm --filter @breeze/docs check` (0 errors) and `build` (165 pages)
- Both compose files parse; coturn keeps 31 flags and all 15 `denied-peer-ip` rules, identical between them
- `check-agent-binary-signatures.sh` and `install-osv-scanner.sh` fail on `origin/main` too — pre-existing, unrelated

## Follow-up (not in this PR)

The durable fix for the version pin is **publication-driven promotion**: a terminal `release.yml` job that runs after all four image builds succeed, verifies the pushed digests, and only then updates `.env.example` (plus a machine-generated record the guided installer can consume instead of GitHub's latest tag). That's release-pipeline work, it can't be exercised while the signing outage has the pipeline down, and it would make this bug-fix PR unreviewable. The registry check here catches rot on every PR in the meantime. Happy to file the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)