### PR TITLE
fix(mobile): surface real issues on Systems — active page, partial-failure tolerance, empty state

### DIFF
--- a/apps/mobile/src/screens/systems/SystemsScreen.tsx
+++ b/apps/mobile/src/screens/systems/SystemsScreen.tsx
@@ -225,6 +225,21 @@ export function SystemsScreen() {
   const showRecent = recent.length > 0;
   const showActiveIssues = activeIssues.length > 0;
   const showActiveSkeleton = loading && activeIssues.length === 0;
+  // Every section can hide independently, and the org filter suppresses the
+  // Organizations list outright — so a filtered org with nothing outstanding
+  // rendered a completely blank page under the chip, indistinguishable from a
+  // failed load. Say what is actually true instead.
+  // Gated on error and refreshing too: with all fetches failed the hook sets
+  // loading=false with empty slices, and an ungated banner would assert
+  // "everything is clear" directly beneath the failure notice.
+  const showNothingState =
+    !loading
+    && !refreshing
+    && !error
+    && !showOrgs
+    && !showRecent
+    && !showActiveIssues
+    && !showActiveSkeleton;
 
   return (
     <View style={{ flex: 1, backgroundColor: theme.bg0 }}>
@@ -351,6 +366,29 @@ export function SystemsScreen() {
               />
             ))}
           </>
+        ) : null}
+
+        {showNothingState ? (
+          <View style={{ paddingHorizontal: spacing[6], paddingTop: spacing[8] }}>
+            <Text
+              style={{ ...type.bodyMd, color: theme.textHi, textAlign: 'center' }}
+              accessibilityRole="text"
+            >
+              {filterOrgName ? `${filterOrgName} is all clear` : 'Everything is clear'}
+            </Text>
+            <Text
+              style={{
+                ...type.meta,
+                color: theme.textLo,
+                textAlign: 'center',
+                marginTop: spacing[2],
+              }}
+            >
+              {filterOrgName
+                ? 'No active issues for this organization. Clear the filter to see the rest of the fleet.'
+                : 'No active issues across your fleet.'}
+            </Text>
+          </View>
         ) : null}
       </ScrollView>
 

--- a/apps/mobile/src/screens/systems/mergeSystemsResults.test.ts
+++ b/apps/mobile/src/screens/systems/mergeSystemsResults.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  ALL_FAILED_MESSAGE,
+  PARTIAL_FAILED_MESSAGE,
+  mergeSystemsResults,
+  rejectionReasons,
+  type SystemsSlices,
+} from './mergeSystemsResults';
+import type { Alert, Device } from '../../services/api';
+
+const device = (id: string) => ({ id, name: id } as unknown as Device);
+const alert = (id: string) => ({ id } as unknown as Alert);
+
+const ok = <T,>(value: T): PromiseSettledResult<T> => ({ status: 'fulfilled', value });
+const bad = (reason: unknown): PromiseSettledResult<never> => ({ status: 'rejected', reason });
+
+const previous: SystemsSlices = {
+  summary: { online: 1 } as never,
+  alerts: [alert('a-old')],
+  activeAlerts: [alert('act-old')],
+  devices: [device('d-old')],
+  orgs: [{ id: 'o1', name: 'Org One' }],
+};
+
+const allOk = {
+  summary: ok({ online: 2 } as never),
+  alerts: ok([alert('a-new')]),
+  activeAlerts: ok([alert('act-new')]),
+  devices: ok([device('d1'), device('d2')]),
+  orgs: ok([{ id: 'o2', name: 'Org Two' }]),
+};
+
+describe('mergeSystemsResults', () => {
+  it('takes every fresh value when all four succeed, and reports no error', () => {
+    const { slices, error, failed } = mergeSystemsResults(previous, allOk);
+    expect(slices.devices).toHaveLength(2);
+    expect(slices.alerts[0].id).toBe('a-new');
+    expect(slices.activeAlerts[0].id).toBe('act-new');
+    expect(slices.orgs[0].id).toBe('o2');
+    expect(error).toBeNull();
+    expect(failed).toEqual([]);
+  });
+
+  it('KEEPS devices that loaded when an unrelated call fails', () => {
+    // The regression this exists for: under Promise.all a failing summary
+    // discarded a perfectly good device list and the fleet rendered empty.
+    const { slices, error, failed } = mergeSystemsResults(previous, {
+      ...allOk,
+      summary: bad(new Error('getMobileSummary failed: 500')),
+    });
+    expect(slices.devices).toHaveLength(2);
+    expect(slices.alerts[0].id).toBe('a-new');
+    expect(slices.summary).toEqual(previous.summary); // last-known retained
+    expect(error).toBe(PARTIAL_FAILED_MESSAGE);
+    expect(failed).toEqual(['summary']);
+  });
+
+  it('retains the previous value for each failed slice individually', () => {
+    const { slices } = mergeSystemsResults(previous, {
+      ...allOk,
+      devices: bad(new Error('boom')),
+      orgs: bad(new Error('boom')),
+    });
+    expect(slices.devices).toEqual(previous.devices);
+    expect(slices.orgs).toEqual(previous.orgs);
+    expect(slices.alerts[0].id).toBe('a-new'); // untouched by the failures
+  });
+
+  it('reports the all-failed message only when every call rejects', () => {
+    const { slices, error, failed } = mergeSystemsResults(previous, {
+      summary: bad(new Error('x')),
+      alerts: bad(new Error('x')),
+      activeAlerts: bad(new Error('x')),
+      devices: bad(new Error('x')),
+      orgs: bad(new Error('x')),
+    });
+    expect(error).toBe(ALL_FAILED_MESSAGE);
+    expect(failed).toHaveLength(5);
+    // Nothing is blanked even in the total-failure case — stale beats empty.
+    expect(slices).toEqual(previous);
+  });
+
+  it('treats an empty successful result as real data, not a failure', () => {
+    // A genuinely empty fleet must overwrite a previously non-empty one,
+    // otherwise deleted devices linger forever.
+    const { slices, error } = mergeSystemsResults(previous, {
+      ...allOk,
+      devices: ok([]),
+    });
+    expect(slices.devices).toEqual([]);
+    expect(error).toBeNull();
+  });
+});
+
+describe('rejectionReasons', () => {
+  it('returns only the rejected reasons, in slice order', () => {
+    const e1 = new Error('one');
+    const e2 = new Error('two');
+    expect(
+      rejectionReasons({ ...allOk, summary: bad(e1), devices: bad(e2) })
+    ).toEqual([e1, e2]);
+  });
+
+  it('is empty when nothing failed', () => {
+    expect(rejectionReasons(allOk)).toEqual([]);
+  });
+});
+
+
+describe('the two alert pages stay independent', () => {
+  it('keeps RECENT data when only the active page fails, and vice versa', () => {
+    // They serve different sections; one failing must not blank the other.
+    const activeDown = mergeSystemsResults(previous, {
+      ...allOk,
+      activeAlerts: bad(new Error('boom')),
+    });
+    expect(activeDown.slices.alerts[0].id).toBe('a-new');
+    expect(activeDown.slices.activeAlerts).toEqual(previous.activeAlerts);
+    expect(activeDown.error).toBe(PARTIAL_FAILED_MESSAGE);
+
+    const recentDown = mergeSystemsResults(previous, {
+      ...allOk,
+      alerts: bad(new Error('boom')),
+    });
+    expect(recentDown.slices.activeAlerts[0].id).toBe('act-new');
+    expect(recentDown.slices.alerts).toEqual(previous.alerts);
+  });
+});

--- a/apps/mobile/src/screens/systems/mergeSystemsResults.ts
+++ b/apps/mobile/src/screens/systems/mergeSystemsResults.ts
@@ -1,0 +1,94 @@
+import type { Alert, Device } from '../../services/api';
+import type { MobileSummary, OrganizationSummary } from '../../services/systems';
+
+/**
+ * The four independent fetches behind the Systems screen, in the order
+ * `fetchAll` issues them.
+ */
+export interface SystemsSlices {
+  summary: MobileSummary | null;
+  /**
+   * The unfiltered inbox page. Drives RECENT (24h), which deliberately shows
+   * acknowledged and resolved alerts as lifecycle context — `RecentRow` dims
+   * acknowledged rows rather than hiding them.
+   */
+  alerts: Alert[];
+  /**
+   * Active-only page. Drives ACTIVE ISSUES and the org issue counts, which the
+   * unfiltered page cannot serve: it is ordered by recency, so on a large fleet
+   * resolved low-severity rows fill it and nothing actionable survives.
+   */
+  activeAlerts: Alert[];
+  devices: Device[];
+  orgs: OrganizationSummary[];
+}
+
+export interface MergeOutcome {
+  slices: SystemsSlices;
+  /** null when everything succeeded. */
+  error: string | null;
+  /** Slice names that rejected, for error reporting. */
+  failed: Array<keyof SystemsSlices>;
+}
+
+export const ALL_FAILED_MESSAGE = 'Failed to load systems data.';
+export const PARTIAL_FAILED_MESSAGE = 'Some data could not be refreshed.';
+
+function take<T>(result: PromiseSettledResult<T>, previous: T): T {
+  return result.status === 'fulfilled' ? result.value : previous;
+}
+
+/**
+ * Merge the settled results of the four Systems fetches over the previously
+ * rendered data.
+ *
+ * The screen used to issue these through `Promise.all`, so a single rejection
+ * discarded ALL FOUR results — a transient failure on, say, the summary call
+ * blanked a fleet of devices that had loaded perfectly well, and the user saw an
+ * empty screen with a generic error. Each slice now stands on its own: whatever
+ * arrived is rendered, whatever failed keeps its last-known value, and the error
+ * line distinguishes "nothing loaded" from "some of this is stale".
+ */
+export function mergeSystemsResults(
+  previous: SystemsSlices,
+  results: {
+    summary: PromiseSettledResult<MobileSummary | null>;
+    alerts: PromiseSettledResult<Alert[]>;
+    activeAlerts: PromiseSettledResult<Alert[]>;
+    devices: PromiseSettledResult<Device[]>;
+    orgs: PromiseSettledResult<OrganizationSummary[]>;
+  }
+): MergeOutcome {
+  const failed: Array<keyof SystemsSlices> = [];
+  for (const key of ['summary', 'alerts', 'activeAlerts', 'devices', 'orgs'] as const) {
+    if (results[key].status === 'rejected') failed.push(key);
+  }
+
+  const slices: SystemsSlices = {
+    summary: take(results.summary, previous.summary),
+    alerts: take(results.alerts, previous.alerts),
+    activeAlerts: take(results.activeAlerts, previous.activeAlerts),
+    devices: take(results.devices, previous.devices),
+    orgs: take(results.orgs, previous.orgs),
+  };
+
+  const total = 5;
+  let error: string | null = null;
+  if (failed.length === total) {
+    error = ALL_FAILED_MESSAGE;
+  } else if (failed.length > 0) {
+    error = PARTIAL_FAILED_MESSAGE;
+  }
+
+  return { slices, error, failed };
+}
+
+/** The rejection reasons, for Sentry. Empty when nothing failed. */
+export function rejectionReasons(results: {
+  [K in keyof SystemsSlices]: PromiseSettledResult<unknown>;
+}): unknown[] {
+  return (['summary', 'alerts', 'activeAlerts', 'devices', 'orgs'] as const)
+    .map((k) => results[k])
+    .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+    .map((r) => r.reason);
+}

--- a/apps/mobile/src/screens/systems/useSystemsData.ts
+++ b/apps/mobile/src/screens/systems/useSystemsData.ts
@@ -16,6 +16,7 @@ import {
   type OrganizationSummary,
 } from '../../services/systems';
 import { createSystemsRealtimeClient } from '../../services/systemsRealtime';
+import { mergeSystemsResults, rejectionReasons } from './mergeSystemsResults';
 
 export interface OrgRollup {
   id: string;
@@ -27,6 +28,7 @@ export interface OrgRollup {
 export interface SystemsData {
   summary: MobileSummary | null;
   alerts: Alert[];
+  activeAlerts: Alert[];
   devices: Device[];
   orgs: OrganizationSummary[];
   loading: boolean;
@@ -64,6 +66,7 @@ export function useSystemsData() {
   const [data, setData] = useState<SystemsData>({
     summary: null,
     alerts: [],
+    activeAlerts: [],
     devices: [],
     orgs: [],
     loading: true,
@@ -84,35 +87,45 @@ export function useSystemsData() {
       error: null,
     }));
     try {
-      const [summary, alerts, devices, orgs] = await Promise.all([
+      // allSettled, NOT all: these five are independent, and a rejection in one
+      // must not discard the others. Under Promise.all a transient failure on
+      // any single call blanked the whole screen — devices that had loaded fine
+      // were thrown away and the user saw an empty fleet.
+      //
+      // Two alert pages on purpose. The inbox is ordered by RECENCY, so one
+      // page cannot serve both consumers: RECENT wants lifecycle context
+      // (acknowledged/resolved included), while ACTIVE ISSUES needs unresolved
+      // rows that a busy fleet pushes outside a recency window entirely.
+      const [summary, alerts, activeAlerts, devices, orgs] = await Promise.allSettled([
         getMobileSummary(),
-        getAlerts(),
+        getAlerts('all'),
+        getAlerts('active'),
         getDevices(),
-        // Org list is best-effort — partner-scope users get the rollup,
-        // org-scope users get a single row, and we tolerate failure since
-        // the hero + alerts still work without it.
-        listOrganizations().catch(() => [] as OrganizationSummary[]),
+        listOrganizations(),
       ]);
-      setData({
-        summary,
-        alerts,
-        devices,
-        orgs,
-        loading: false,
-        refreshing: false,
-        error: null,
+      const results = { summary, alerts, activeAlerts, devices, orgs };
+      // The raw messages are internal (function name + HTTP status) — report
+      // them to Sentry and keep only a static string in UI state (issue #3141).
+      for (const reason of rejectionReasons(results)) {
+        reportInternalError(reason, 'systems-data');
+      }
+      let failedCount = 0;
+      // Merge inside the updater so the previous slices come from committed
+      // state. Mirroring `data` into a ref during render would let an
+      // abandoned concurrent render supply the baseline.
+      setData((previous) => {
+        const merged = mergeSystemsResults(previous, results);
+        failedCount = merged.failed.length;
+        return {
+          ...merged.slices,
+          loading: false,
+          refreshing: false,
+          error: merged.error,
+        };
       });
-      lastFetchAt.current = Date.now();
-    } catch (err) {
-      // The raw message is internal (function name + HTTP status) — report it
-      // to Sentry and keep only a static string in UI state (issue #3141).
-      reportInternalError(err, 'systems-data');
-      setData((d) => ({
-        ...d,
-        loading: false,
-        refreshing: false,
-        error: 'Failed to load systems data.',
-      }));
+      // Only count as a successful fetch when something arrived; an all-failed
+      // round must not suppress the next focus refresh for a full minute.
+      if (failedCount < 5) lastFetchAt.current = Date.now();
     } finally {
       inFlight.current = false;
     }
@@ -172,16 +185,22 @@ export function useSystemsData() {
     return data.alerts.filter((a) => alertOrgId(a) === filterOrgId);
   }, [data.alerts, filterOrgId]);
 
+  // ACTIVE ISSUES reads the active-only page; RECENT reads the full one.
+  const filteredActiveAlerts = useMemo(() => {
+    if (!filterOrgId) return data.activeAlerts;
+    return data.activeAlerts.filter((a) => alertOrgId(a) === filterOrgId);
+  }, [data.activeAlerts, filterOrgId]);
+
   const activeIssues = useMemo(
     () =>
-      filteredAlerts
+      filteredActiveAlerts
         .filter((a) => !a.acknowledged && ISSUE_SEVERITIES.has(a.severity))
         .sort((a, b) => {
           const sev = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
           if (sev !== 0) return sev;
           return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
         }),
-    [filteredAlerts],
+    [filteredActiveAlerts],
   );
 
   const recent = useMemo(() => {
@@ -216,7 +235,10 @@ export function useSystemsData() {
     for (const d of data.devices) {
       if (d.organizationId) ensure(d.organizationId).deviceCount++;
     }
-    for (const a of data.alerts) {
+    // Issue counts come from the active page for the same reason the section
+    // does: the unfiltered page is recency-ordered and can contain no
+    // unresolved rows at all on a busy fleet.
+    for (const a of data.activeAlerts) {
       const id = alertOrgId(a);
       if (id && !a.acknowledged && ISSUE_SEVERITIES.has(a.severity)) {
         ensure(id).issueCount++;
@@ -227,7 +249,7 @@ export function useSystemsData() {
       if (b.issueCount !== a.issueCount) return b.issueCount - a.issueCount;
       return a.name.localeCompare(b.name);
     });
-  }, [data.alerts, data.devices, data.orgs, filterOrgId]);
+  }, [data.activeAlerts, data.devices, data.orgs, filterOrgId]);
 
   const filterOrgName = useMemo(() => {
     if (!filterOrgId) return null;

--- a/apps/mobile/src/services/alertsInbox.test.ts
+++ b/apps/mobile/src/services/alertsInbox.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn().mockResolvedValue('tok'),
+  setItemAsync: vi.fn(),
+  deleteItemAsync: vi.fn(),
+}));
+vi.mock('@sentry/react-native', () => ({ captureMessage: vi.fn(), captureException: vi.fn() }));
+vi.mock('./serverConfig', () => ({ getServerUrl: vi.fn().mockResolvedValue('https://example.test') }));
+vi.mock('./installationId', () => ({ getOrCreateInstallationId: vi.fn().mockResolvedValue('inst-1') }));
+
+const fetchWithTimeout = vi.fn();
+vi.mock('./fetchWithTimeout', () => ({
+  fetchWithTimeout: (...a: unknown[]) => fetchWithTimeout(...a),
+}));
+
+import { getAlerts } from './api';
+
+function jsonOnce(body: unknown) {
+  fetchWithTimeout.mockImplementationOnce(() =>
+    Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))
+  );
+}
+
+beforeEach(() => {
+  fetchWithTimeout.mockReset();
+});
+
+describe('getAlerts inbox query', () => {
+  it('requests active alerts by default', async () => {
+    // The inbox is ordered by recency with no severity weighting. Asking for
+    // everything lets resolved low-severity rows consume the page, which is how
+    // a fleet with thousands of alerts rendered zero issues.
+    jsonOnce({ data: [] });
+    await getAlerts();
+    const url = String(fetchWithTimeout.mock.calls[0][0]);
+    expect(url).toContain('/alerts/inbox');
+    expect(url).toContain('status=active');
+  });
+
+  it('can still request the unfiltered inbox explicitly', async () => {
+    jsonOnce({ data: [] });
+    await getAlerts('all');
+    const url = String(fetchWithTimeout.mock.calls[0][0]);
+    expect(url).toContain('/alerts/inbox');
+    expect(url).not.toContain('status=');
+  });
+
+  it('maps returned rows and preserves orgId for client-side org filtering', async () => {
+    jsonOnce({
+      data: [
+        { id: 'a1', title: 't', message: 'm', severity: 'high', status: 'active',
+          orgId: 'org-1', triggeredAt: '2026-08-18T00:00:00Z' },
+      ],
+    });
+    const alerts = await getAlerts();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe('high');
+    expect(alerts[0].acknowledged).toBe(false);
+    // The Systems org filter matches on metadata.orgId — losing it silently
+    // empties the filtered view.
+    expect((alerts[0].metadata as Record<string, unknown>).orgId).toBe('org-1');
+  });
+});

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -412,8 +412,21 @@ export async function changePassword(currentPassword: string, newPassword: strin
 }
 
 // Alerts API
-export async function getAlerts(): Promise<Alert[]> {
-  const response = await request<ListResponse<MobileAlertRecord>>('/alerts/inbox');
+/**
+ * Fetch the alert inbox.
+ *
+ * Defaults to `status=active` because the inbox is a RECENCY window, not a
+ * priority one: it returns the newest non-dismissed alerts and the client asks
+ * for one page. On a real fleet the page fills with resolved low-severity
+ * noise and never reaches anything actionable — measured on a 7,023-alert
+ * tenant, all 50 rows came back `low` and 48 of them resolved, so the Systems
+ * screen rendered zero issues while 18 unacknowledged high/medium alerts sat
+ * just outside the window. Asking for active-only makes the same page carry
+ * what the screen actually renders.
+ */
+export async function getAlerts(status: 'active' | 'all' = 'active'): Promise<Alert[]> {
+  const path = status === 'active' ? '/alerts/inbox?status=active' : '/alerts/inbox';
+  const response = await request<ListResponse<MobileAlertRecord>>(path);
   return response.data.map(mapAlert);
 }
 


### PR DESCRIPTION
Three defects that combine to render the mobile **Systems** screen blank on a real fleet. Found by running the app against a self-hosted tenant with 216 devices and 7,023 alerts; every number below is measured against that data.

## 1. Real issues never reach the client

`GET /mobile/alerts/inbox` returns the newest non-dismissed alerts ordered by `triggeredAt`, and the client asks for one page. On that tenant the page came back:

```
resolved | low | 48
active   | low |  2
```

All 50 rows `low`, 48 of them resolved — noise from a single org. The screen renders only unacknowledged `critical|high|medium`, so it displayed **zero issues while 18 unacknowledged high/medium alerts existed**, sitting just outside the recency window. The user sees an empty fleet and has no way to tell it apart from a failed load.

The screen now fetches **two** pages, because one cannot serve both consumers:

| call | drives | why |
|---|---|---|
| `getAlerts('all')` | RECENT (24h) | unchanged; RECENT deliberately shows acknowledged/resolved alerts as lifecycle context — `RecentRow` *dims* acknowledged rows rather than hiding them |
| `getAlerts('active')` | ACTIVE ISSUES, org issue counts | a recency-ordered page can contain no unresolved rows at all on a busy fleet |

With `status=active`, the same 50-row page carries all 18 renderable issues, and the tenant has only 21 active alerts total — so one page covers the whole fleet comfortably.

Worth flagging for maintainers: **the client-side split is a workaround.** The underlying issue is that the inbox has no severity weighting, so "most recent" and "most important" diverge as soon as a tenant accumulates resolved noise. A severity-ordered inbox (or a dedicated issues endpoint) would let the screen make one call. Happy to follow up if you'd prefer that shape.

## 2. One failed fetch discarded every dataset

`fetchAll` issued its calls through `Promise.all` with a `.catch()` on only the orgs call, so a rejection anywhere else threw away all results. A transient failure on the summary blanked a device list that had loaded perfectly well, and the user got an empty screen plus a generic error.

Now `Promise.allSettled`, merged through a pure `mergeSystemsResults` helper:

- each slice renders whatever arrived
- a failed slice keeps its last-known value — **stale beats empty**
- an empty *successful* result still overwrites, so deleted devices don't linger
- the error line distinguishes "nothing loaded" from "some of this is stale"
- an all-failed round no longer stamps `lastFetchAt`, so it can't suppress the next focus refresh for a minute

The merge runs inside the `setData` updater rather than against a ref mirrored during render, so an abandoned concurrent render can't supply the baseline.

## 3. A quiet filtered org rendered a blank page

All three sections hide independently and the org filter suppresses Organizations outright:

```js
showOrgs         = !filterOrgId && orgRollups.length > 0
showActiveIssues = activeIssues.length > 0
showRecent       = recent.length > 0
```

Filter to an org with nothing outstanding and every section vanishes, leaving a blank page under the filter chip. Adds an explicit all-clear state that names the filtered org and points back at the filter — gated on `error` and `refreshing` so it can never assert "everything is clear" directly beneath a failure notice.

## Verification

Node 22.23.2 (matching `.nvmrc`), the two commands the `test-mobile` job runs:

```
pnpm test --filter=breeze-mobile   33 files, 333 passed | 3 skipped
pnpm exec tsc --noEmit             exit 0
```

`mergeSystemsResults` is a pure function with direct coverage for the cases that matter: unrelated-failure retention, per-slice fallback, empty-success-overwrites, all-failed messaging, and the two alert pages failing independently.

## Review history

An adversarial review of the first revision caught a regression I'd introduced: making `active` the *sole* default silently broke RECENT's lifecycle history, since acknowledged alerts are intended input there. It also caught the empty state being able to render alongside an error banner, and the render-phase ref mutation. All three are fixed above — the two-page split exists specifically because of that first finding.
