### PR TITLE
feat(mobile): browsable devices list, and stop a slow acknowledge reading as failure

### DIFF
--- a/apps/mobile/src/navigation/MainNavigator.tsx
+++ b/apps/mobile/src/navigation/MainNavigator.tsx
@@ -3,6 +3,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 import { AlertDetailScreen } from '../screens/alerts/AlertDetailScreen';
 import { DeviceDetailScreen } from '../screens/devices/DeviceDetailScreen';
+import { DevicesListScreen } from '../screens/devices/DevicesListScreen';
 import { HomeScreen } from '../screens/chat/HomeScreen';
 import { SystemsScreen } from '../screens/systems/SystemsScreen';
 import { HomeIcon, SystemsIcon } from '../components/TabIcons';
@@ -11,6 +12,7 @@ import type { Alert, Device } from '../services/api';
 
 export type SystemsStackParamList = {
   Systems: undefined;
+  SystemsDevices: { orgId?: string | null; orgName?: string | null } | undefined;
   SystemsAlertDetail: { alert: Alert };
   SystemsDeviceDetail: { device: Device };
 };
@@ -41,6 +43,11 @@ function SystemsStackNavigator() {
       <SystemsStack.Screen
         name="Systems"
         component={SystemsScreen}
+        options={{ headerShown: false }}
+      />
+      <SystemsStack.Screen
+        name="SystemsDevices"
+        component={DevicesListScreen}
         options={{ headerShown: false }}
       />
       <SystemsStack.Screen

--- a/apps/mobile/src/screens/devices/DevicesListScreen.tsx
+++ b/apps/mobile/src/screens/devices/DevicesListScreen.tsx
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useFocusEffect, useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import { palette, radii, spacing, type } from '../../theme';
+import { getDevices, type Device } from '../../services/api';
+import { relativeTime } from '../../lib/relativeTime';
+import { reportInternalError } from '../../lib/errorReporting';
+import type { SystemsStackParamList } from '../../navigation/MainNavigator';
+
+import {
+  shapeDeviceList,
+  statusCounts,
+  type DeviceStatusFilter,
+} from './deviceListFilters';
+
+type Nav = NativeStackNavigationProp<SystemsStackParamList, 'SystemsDevices'>;
+type ScreenRoute = RouteProp<SystemsStackParamList, 'SystemsDevices'>;
+
+function statusColor(status: Device['status']): string {
+  if (status === 'online') return palette.approve.base;
+  if (status === 'offline') return palette.dark.textLo;
+  return palette.warning.base;
+}
+
+function Chip({
+  label,
+  active,
+  onPress,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+      style={[styles.chip, active && styles.chipActive]}
+    >
+      <Text style={[styles.chipText, active && styles.chipTextActive]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function DeviceRow({ device, onPress }: { device: Device; onPress: () => void }) {
+  return (
+    <Pressable onPress={onPress} accessibilityRole="button" style={styles.row}>
+      <View style={[styles.statusDot, { backgroundColor: statusColor(device.status) }]} />
+      <View style={styles.rowBody}>
+        <Text style={styles.name} numberOfLines={1}>
+          {device.name}
+        </Text>
+        <Text style={styles.meta} numberOfLines={1}>
+          {[device.os, device.siteName].filter(Boolean).join(' · ') || '—'}
+        </Text>
+      </View>
+      <Text style={styles.seen}>
+        {device.status === 'online' ? 'online' : relativeTime(device.lastSeen)}
+      </Text>
+    </Pressable>
+  );
+}
+
+/**
+ * Browsable fleet list.
+ *
+ * The Systems screen surfaces issues and org rollups but has never had a plain
+ * "show me my machines" view — devices were reachable only through search or an
+ * org drill-down, so a tech who wanted to scan the fleet had nowhere to go.
+ */
+export function DevicesListScreen() {
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation<Nav>();
+  const route = useRoute<ScreenRoute>();
+  const orgId = route.params?.orgId ?? null;
+  const orgName = route.params?.orgName ?? null;
+
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<DeviceStatusFilter>('all');
+  const [query, setQuery] = useState('');
+
+  // Focus and pull-to-refresh can overlap, so an older response must never
+  // replace a newer one — and nothing may write state after unmount.
+  const loadGeneration = useRef(0);
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const load = useCallback(async () => {
+    const generation = ++loadGeneration.current;
+    const isCurrent = () => mounted.current && loadGeneration.current === generation;
+    try {
+      if (isCurrent()) setError(null);
+      // Scope server-side: paging the whole fleet and filtering locally would
+      // miss an org whose devices sit past the first pages.
+      const rows = await getDevices(orgId);
+      if (!isCurrent()) return;
+      setDevices(rows);
+    } catch (err: unknown) {
+      reportInternalError(err, 'devices-list');
+      if (isCurrent()) setError('Could not load devices.');
+    } finally {
+      if (isCurrent()) setLoading(false);
+    }
+  }, [orgId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      void load();
+    }, [load])
+  );
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await load();
+    } finally {
+      setRefreshing(false);
+    }
+  }, [load]);
+
+  const counts = useMemo(() => statusCounts(devices), [devices]);
+  const shaped = useMemo(
+    () => shapeDeviceList(devices, { status, query, orgId }),
+    [devices, status, query, orgId]
+  );
+
+  return (
+    <View style={[styles.screen, { paddingTop: insets.top + spacing['2'] }]}>
+      <Text style={styles.title}>{orgName ?? 'Devices'}</Text>
+
+      <TextInput
+        value={query}
+        onChangeText={setQuery}
+        placeholder="Filter by name, site or OS"
+        placeholderTextColor={palette.dark.textLo}
+        autoCapitalize="none"
+        autoCorrect={false}
+        clearButtonMode="while-editing"
+        style={styles.search}
+        accessibilityLabel="Filter devices"
+      />
+
+      <View style={styles.filters}>
+        <Chip label={`All ${counts.all}`} active={status === 'all'} onPress={() => setStatus('all')} />
+        <Chip
+          label={`Online ${counts.online}`}
+          active={status === 'online'}
+          onPress={() => setStatus('online')}
+        />
+        <Chip
+          label={`Offline ${counts.offline}`}
+          active={status === 'offline'}
+          onPress={() => setStatus('offline')}
+        />
+      </View>
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      <FlatList
+        data={shaped}
+        keyExtractor={(d) => d.id}
+        renderItem={({ item }) => (
+          <DeviceRow
+            device={item}
+            onPress={() => navigation.navigate('SystemsDeviceDetail', { device: item })}
+          />
+        )}
+        contentContainerStyle={[styles.list, shaped.length === 0 && styles.listEmpty]}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={palette.dark.textLo}
+          />
+        }
+        ListEmptyComponent={
+          loading ? undefined : (
+            <Text style={styles.empty}>
+              {query.trim() ? 'No devices match that filter.' : 'No devices to show.'}
+            </Text>
+          )
+        }
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: palette.dark.bg0 },
+  title: { ...type.title, color: palette.dark.textHi, paddingHorizontal: spacing['4'] },
+  search: {
+    ...type.body,
+    color: palette.dark.textHi,
+    backgroundColor: palette.dark.bg1,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    paddingHorizontal: spacing['3'],
+    paddingVertical: spacing['2'],
+    marginHorizontal: spacing['4'],
+    marginTop: spacing['3'],
+  },
+  filters: {
+    flexDirection: 'row',
+    gap: spacing['2'],
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['3'],
+  },
+  chip: {
+    paddingHorizontal: spacing['3'],
+    paddingVertical: spacing['1'],
+    borderRadius: radii.full,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    backgroundColor: palette.dark.bg1,
+  },
+  chipActive: { backgroundColor: palette.brand.deep, borderColor: palette.brand.base },
+  chipText: { ...type.meta, color: palette.dark.textMd },
+  chipTextActive: { color: palette.dark.textHi },
+  list: { paddingHorizontal: spacing['4'], paddingBottom: spacing['8'] },
+  listEmpty: { flexGrow: 1, justifyContent: 'center' },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing['3'],
+    backgroundColor: palette.dark.bg1,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    padding: spacing['3'],
+    marginBottom: spacing['2'],
+  },
+  statusDot: { width: 10, height: 10, borderRadius: radii.full },
+  rowBody: { flex: 1 },
+  name: { ...type.bodyMd, color: palette.dark.textHi },
+  meta: { ...type.meta, color: palette.dark.textLo, marginTop: spacing['1'] },
+  seen: { ...type.meta, color: palette.dark.textLo },
+  error: {
+    ...type.meta,
+    color: palette.deny.base,
+    paddingHorizontal: spacing['4'],
+    paddingBottom: spacing['2'],
+  },
+  empty: { ...type.meta, color: palette.dark.textLo, textAlign: 'center' },
+});

--- a/apps/mobile/src/screens/devices/deviceListFilters.test.ts
+++ b/apps/mobile/src/screens/devices/deviceListFilters.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  matchesQuery,
+  matchesStatus,
+  shapeDeviceList,
+  statusCounts,
+} from './deviceListFilters';
+import type { Device } from '../../services/api';
+
+const dev = (over: Partial<Device>): Device =>
+  ({
+    id: over.id ?? 'd1',
+    name: over.name ?? 'BOX-1',
+    status: over.status ?? 'online',
+    hostname: over.hostname,
+    os: over.os,
+    siteName: over.siteName,
+    lastSeen: over.lastSeen,
+    organizationId: over.organizationId,
+    createdAt: '2026-08-18T00:00:00Z',
+    updatedAt: '2026-08-18T00:00:00Z',
+  }) as Device;
+
+describe('matchesStatus', () => {
+  it('treats warning as not-online, because a warning box is not healthy', () => {
+    expect(matchesStatus(dev({ status: 'warning' }), 'offline')).toBe(true);
+    expect(matchesStatus(dev({ status: 'warning' }), 'online')).toBe(false);
+  });
+
+  it('all matches everything', () => {
+    for (const s of ['online', 'offline', 'warning'] as const) {
+      expect(matchesStatus(dev({ status: s }), 'all')).toBe(true);
+    }
+  });
+});
+
+describe('matchesQuery', () => {
+  it('matches name, hostname, site and OS, case-insensitively', () => {
+    const d = dev({ name: 'Reception', hostname: 'RECEP-01', os: 'windows', siteName: 'HQ' });
+    for (const q of ['recep', 'RECEP-01', 'WINDOWS', 'hq']) {
+      expect(matchesQuery(d, q)).toBe(true);
+    }
+    expect(matchesQuery(d, 'zzz')).toBe(false);
+  });
+
+  it('an empty or whitespace query matches everything', () => {
+    expect(matchesQuery(dev({}), '   ')).toBe(true);
+  });
+
+  it('does not throw on devices missing optional fields', () => {
+    expect(matchesQuery(dev({ name: 'X', hostname: undefined, os: undefined }), 'x')).toBe(true);
+  });
+});
+
+describe('shapeDeviceList', () => {
+  const fleet = [
+    dev({ id: '1', name: 'Zulu', status: 'online' }),
+    dev({ id: '2', name: 'Alpha', status: 'offline' }),
+    dev({ id: '3', name: 'Mike', status: 'warning' }),
+    dev({ id: '4', name: 'Bravo', status: 'online' }),
+  ];
+
+  it('sorts problems first, then alphabetically', () => {
+    // A phone user opens this to find what is broken, so offline leads.
+    const out = shapeDeviceList(fleet, { status: 'all', query: '' });
+    expect(out.map((d) => d.name)).toEqual(['Alpha', 'Mike', 'Bravo', 'Zulu']);
+  });
+
+  it('restricts to one organization when asked', () => {
+    const scoped = [
+      dev({ id: '1', name: 'A', organizationId: 'o1' }),
+      dev({ id: '2', name: 'B', organizationId: 'o2' }),
+    ];
+    const out = shapeDeviceList(scoped, { status: 'all', query: '', orgId: 'o1' });
+    expect(out.map((d) => d.id)).toEqual(['1']);
+  });
+
+  it('combines status and text filters', () => {
+    const out = shapeDeviceList(fleet, { status: 'offline', query: 'a' });
+    expect(out.map((d) => d.name)).toEqual(['Alpha']);
+  });
+
+  it('does not mutate the input array', () => {
+    const before = fleet.map((d) => d.id);
+    shapeDeviceList(fleet, { status: 'all', query: '' });
+    expect(fleet.map((d) => d.id)).toEqual(before);
+  });
+});
+
+describe('statusCounts', () => {
+  it('counts warning devices as offline so the chips sum to the total', () => {
+    const c = statusCounts([
+      dev({ id: '1', status: 'online' }),
+      dev({ id: '2', status: 'offline' }),
+      dev({ id: '3', status: 'warning' }),
+    ]);
+    expect(c).toEqual({ all: 3, online: 1, offline: 2 });
+    expect(c.online + c.offline).toBe(c.all);
+  });
+});

--- a/apps/mobile/src/screens/devices/deviceListFilters.ts
+++ b/apps/mobile/src/screens/devices/deviceListFilters.ts
@@ -1,0 +1,70 @@
+import type { Device } from '../../services/api';
+
+export type DeviceStatusFilter = 'all' | 'online' | 'offline';
+
+/**
+ * Client-side list shaping for the devices browser.
+ *
+ * The fleet arrives as one page from `/mobile/devices` (50 by default), so
+ * filtering and sorting happen here rather than round-tripping. Kept pure so
+ * the ordering contract is testable without a renderer.
+ */
+
+/** Offline-first: the machines that need attention sort to the top. */
+const STATUS_WEIGHT: Record<Device['status'], number> = {
+  offline: 0,
+  warning: 1,
+  online: 2,
+};
+
+export function matchesStatus(device: Device, filter: DeviceStatusFilter): boolean {
+  if (filter === 'all') return true;
+  if (filter === 'online') return device.status === 'online';
+  // 'offline' deliberately includes 'warning': from a phone the question is
+  // "is this machine healthy", and a warning device is not.
+  return device.status !== 'online';
+}
+
+export function matchesQuery(device: Device, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    device.name.toLowerCase().includes(q)
+    || (device.hostname?.toLowerCase().includes(q) ?? false)
+    || (device.siteName?.toLowerCase().includes(q) ?? false)
+    || (device.os?.toLowerCase().includes(q) ?? false)
+  );
+}
+
+export interface DeviceListOptions {
+  status: DeviceStatusFilter;
+  query: string;
+  /** When set, restrict to one organization. */
+  orgId?: string | null;
+}
+
+export function shapeDeviceList(devices: Device[], options: DeviceListOptions): Device[] {
+  const filtered = devices.filter(
+    (d) =>
+      matchesStatus(d, options.status)
+      && matchesQuery(d, options.query)
+      && (!options.orgId || d.organizationId === options.orgId)
+  );
+
+  return [...filtered].sort((a, b) => {
+    const weight = STATUS_WEIGHT[a.status] - STATUS_WEIGHT[b.status];
+    if (weight !== 0) return weight;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+/** Counts for the filter chips, computed off the unfiltered fleet. */
+export function statusCounts(devices: Device[]): {
+  all: number;
+  online: number;
+  offline: number;
+} {
+  let online = 0;
+  for (const d of devices) if (d.status === 'online') online += 1;
+  return { all: devices.length, online, offline: devices.length - online };
+}

--- a/apps/mobile/src/screens/systems/SystemsScreen.tsx
+++ b/apps/mobile/src/screens/systems/SystemsScreen.tsx
@@ -280,6 +280,35 @@ export function SystemsScreen() {
           loading={loading}
         />
 
+        <Pressable
+          onPress={() =>
+            navigation.navigate('SystemsDevices', {
+              orgId: filterOrgId,
+              orgName: filterOrgName,
+            })
+          }
+          accessibilityRole="button"
+          accessibilityLabel="View all devices"
+          style={{
+            marginHorizontal: spacing[6],
+            marginTop: spacing[3],
+            paddingVertical: spacing[3],
+            paddingHorizontal: spacing[4],
+            borderRadius: 10,
+            borderWidth: 1,
+            borderColor: theme.border,
+            backgroundColor: theme.bg1,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Text style={{ ...type.bodyMd, color: theme.textHi }}>
+            {filterOrgName ? `${filterOrgName} devices` : 'All devices'}
+          </Text>
+          <Text style={{ ...type.meta, color: theme.textLo }}>View</Text>
+        </Pressable>
+
         {filterOrgId && filterOrgName ? (
           <FilterChip label={filterOrgName} onClear={() => setFilterOrgId(null)} />
         ) : null}

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -121,6 +121,8 @@ interface ListResponse<T> {
     page: number;
     limit: number;
     total: number;
+    /** Keyset cursor for the next page; null on the last page. */
+    nextCursor?: string | null;
   };
 }
 
@@ -197,7 +199,8 @@ async function getToken(): Promise<string | null> {
 async function requestWithPrefix<T>(
   endpoint: string,
   prefix: string,
-  options: RequestInit = {}
+  options: RequestInit = {},
+  timeoutMs?: number
 ): Promise<T> {
   const token = await getToken();
   const method = (options.method ?? 'GET').toUpperCase();
@@ -238,11 +241,11 @@ async function requestWithPrefix<T>(
 
   const baseUrl = (await getServerUrl()) || FALLBACK_API_BASE_URL;
   const url = `${baseUrl}${prefix}${endpoint}`;
-  const response = await fetchWithTimeout(url, {
-    ...options,
-    headers,
-    credentials: 'include',
-  });
+  const response = await fetchWithTimeout(
+    url,
+    { ...options, headers, credentials: 'include' },
+    timeoutMs
+  );
 
   if (!response.ok) {
     const body = await response.json().catch(() => ({} as Record<string, unknown>));
@@ -273,9 +276,10 @@ async function requestWithPrefix<T>(
 
 async function request<T>(
   endpoint: string,
-  options: RequestInit = {}
+  options: RequestInit = {},
+  timeoutMs?: number
 ): Promise<T> {
-  return requestWithPrefix<T>(endpoint, API_PREFIX, options);
+  return requestWithPrefix<T>(endpoint, API_PREFIX, options, timeoutMs);
 }
 
 export type DeviceAction = 'reboot' | 'shutdown' | 'wake' | 'update';
@@ -422,10 +426,24 @@ export async function getAlert(id: string): Promise<Alert> {
   return mapAlert(response);
 }
 
+/**
+ * Acknowledge an alert.
+ *
+ * Given a longer timeout than the 15s default because this write is slow on
+ * real deployments: the API awaits its local event handlers inside the request
+ * path (see upstream #1105 — the server itself logs "held a pooled connection
+ * ... for 15439ms"). Measured acknowledges of 13.4s and 15.2s returned 200
+ * while the client had already aborted at 15s and told the user it failed,
+ * which invites a retry of an action that already succeeded.
+ */
+export const ACKNOWLEDGE_TIMEOUT_MS = 45000;
+
 export async function acknowledgeAlert(id: string): Promise<Alert> {
-  const response = await request<MobileAlertRecord>(`/alerts/${id}/acknowledge`, {
-    method: 'POST',
-  });
+  const response = await request<MobileAlertRecord>(
+    `/alerts/${id}/acknowledge`,
+    { method: 'POST' },
+    ACKNOWLEDGE_TIMEOUT_MS
+  );
   return mapAlert(response);
 }
 
@@ -453,9 +471,47 @@ export async function getAlertStats(): Promise<{
 }
 
 // Devices API
-export async function getDevices(): Promise<Device[]> {
-  const response = await request<ListResponse<MobileDeviceRecord>>('/devices');
-  return response.data.map(mapDevice);
+/** Server cap on `limit` (patches/helpers.ts MAX_PAGE_LIMIT). */
+const DEVICE_PAGE_LIMIT = 200;
+/**
+ * Safety stop for the cursor walk. 20 pages x 200 = 4,000 devices, well beyond
+ * any fleet that belongs on a phone screen, and it bounds the loop if the
+ * server ever returns a non-advancing cursor.
+ */
+const MAX_DEVICE_PAGES = 20;
+
+/**
+ * Fetch devices, following the cursor to the end of the fleet.
+ *
+ * A single request returns `limit` rows (default 50, capped at 200), so asking
+ * once silently truncates: a 210-device tenant showed 50 and any client-side
+ * org filter then searched only that first page — an org whose machines sat
+ * further down rendered as empty. `orgId` is pushed to the server so a scoped
+ * view pages through that org rather than through the whole fleet.
+ */
+export async function getDevices(orgId?: string | null): Promise<Device[]> {
+  const out: MobileDeviceRecord[] = [];
+  let cursor: string | null = null;
+
+  for (let page = 0; page < MAX_DEVICE_PAGES; page += 1) {
+    const params = new URLSearchParams({ limit: String(DEVICE_PAGE_LIMIT) });
+    if (orgId) params.set('orgId', orgId);
+    if (cursor) params.set('cursor', cursor);
+
+    const response = await request<ListResponse<MobileDeviceRecord>>(
+      `/devices?${params.toString()}`
+    );
+    const rows = Array.isArray(response.data) ? response.data : [];
+    out.push(...rows);
+
+    const next = response.pagination?.nextCursor ?? null;
+    // Stop on a null cursor, a short page, or a cursor that did not advance —
+    // the last of these would otherwise spin until the page cap.
+    if (!next || next === cursor || rows.length === 0) break;
+    cursor = next;
+  }
+
+  return out.map(mapDevice);
 }
 
 export async function getDevice(id: string): Promise<Device> {

--- a/apps/mobile/src/services/devicesPaging.test.ts
+++ b/apps/mobile/src/services/devicesPaging.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn().mockResolvedValue('tok'),
+  setItemAsync: vi.fn(),
+  deleteItemAsync: vi.fn(),
+}));
+vi.mock('@sentry/react-native', () => ({ captureMessage: vi.fn(), captureException: vi.fn() }));
+vi.mock('./serverConfig', () => ({ getServerUrl: vi.fn().mockResolvedValue('https://example.test') }));
+vi.mock('./installationId', () => ({ getOrCreateInstallationId: vi.fn().mockResolvedValue('i') }));
+
+const fetchWithTimeout = vi.fn();
+vi.mock('./fetchWithTimeout', () => ({
+  fetchWithTimeout: (...a: unknown[]) => fetchWithTimeout(...a),
+}));
+
+import { getDevices } from './api';
+
+const row = (id: string) => ({ id, hostname: id, status: 'online', orgId: 'o1' });
+function page(rows: unknown[], nextCursor: string | null) {
+  return () =>
+    Promise.resolve(
+      new Response(JSON.stringify({ data: rows, pagination: { page: 1, limit: 200, total: 999, nextCursor } }), {
+        status: 200,
+      })
+    );
+}
+
+beforeEach(() => fetchWithTimeout.mockReset());
+
+describe('getDevices paging', () => {
+  it('follows nextCursor past the server page cap', async () => {
+    // 210 devices cannot arrive in one page (server caps limit at 200), and a
+    // single request silently truncated the fleet before this walk existed.
+    fetchWithTimeout
+      .mockImplementationOnce(page([row('a'), row('b')], 'cur1'))
+      .mockImplementationOnce(page([row('c')], null));
+    const devices = await getDevices();
+    expect(devices.map((d) => d.id)).toEqual(['a', 'b', 'c']);
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(2);
+    expect(String(fetchWithTimeout.mock.calls[1][0])).toContain('cursor=cur1');
+  });
+
+  it('requests the maximum page size', async () => {
+    fetchWithTimeout.mockImplementationOnce(page([], null));
+    await getDevices();
+    expect(String(fetchWithTimeout.mock.calls[0][0])).toContain('limit=200');
+  });
+
+  it('scopes to an org server-side rather than filtering a truncated page', async () => {
+    fetchWithTimeout.mockImplementationOnce(page([row('a')], null));
+    await getDevices('org-9');
+    expect(String(fetchWithTimeout.mock.calls[0][0])).toContain('orgId=org-9');
+  });
+
+  it('stops when the cursor does not advance, instead of spinning to the page cap', async () => {
+    fetchWithTimeout.mockImplementation(page([row('a')], 'same'));
+    const devices = await getDevices();
+    // Second response repeats the cursor -> stop.
+    expect(fetchWithTimeout.mock.calls.length).toBeLessThanOrEqual(2);
+    expect(devices.length).toBeGreaterThan(0);
+  });
+
+  it('stops on a null cursor without a second request', async () => {
+    fetchWithTimeout.mockImplementationOnce(page([row('a')], null));
+    await getDevices();
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Two defects found running the app against a real fleet of 216 devices and 7,023 alerts. Every number below is measured against that deployment.

## 1. There is no way to browse the fleet

The Systems screen surfaces issues and org rollups, but there has never been a plain "show me my machines" view — devices are reachable only through search or an org drill-down. A tech who wants to scan the fleet, or just confirm one box is online, has nowhere to go, even though the hero states a device count.

Adds a `SystemsDevices` screen: filter by name/hostname/site/OS, All/Online/Offline chips with counts, pull-to-refresh, and a tap through to the existing device detail. Reachable from Systems, and org-scoped when an org filter is active so the drill-down lands somewhere useful.

Ordering is deliberate: **problems first, then alphabetical**. Someone opening this on a phone is looking for what is broken. `warning` counts as not-online for both the filter and the chip totals, so Online + Offline always sums to All rather than silently dropping a bucket.

**`getDevices` now follows the cursor.** This is the part worth reviewing closely. A single request returns `limit` rows — default 50, server cap 200 (`MAX_PAGE_LIMIT`) — so asking once truncates the fleet:

- "All devices" would have meant *at most 50 devices*
- a client-side `orgId` filter then searched only that first page, so an org whose machines sat further down rendered as **empty**
- the chip counts described the first page, not the fleet

The walk requests `limit=200`, follows `nextCursor`, and stops on a null cursor, a short page, or a cursor that fails to advance — the last of those bounds the loop if the server ever returns a non-advancing cursor. Capped at 20 pages. `orgId` is now pushed to the server so a scoped view pages through that org rather than the whole fleet.

## 2. A slow acknowledge reports failure after succeeding

Measured on the live deployment:

```
POST /mobile/alerts/:id/acknowledge  status=200  duration_ms=13361
POST /mobile/alerts/:id/acknowledge  status=200  duration_ms=15163
```

The client's default timeout is **15,000ms**. The second call aborted *after* the server had already acknowledged the alert, so the user was told it failed and invited to retry an action that had succeeded.

The server-side cost is **#1105**, and the API logs it itself:

```
withDbAccessContext held a pooled connection in an open transaction for
15439ms (>= 2000ms) — long enough that it likely did slow non-DB work
(Redis/HTTP/loops) or a slow query inside the context
```

I ruled out the obvious causes on that deployment:

- **not the database** — PK read on `alerts` measured **0.369ms**, no triggers on the table, `alerts` is small
- **not fan-out** — that tenant has **zero** webhooks, automations, and alert rules
- **not Redis** — sub-1ms latency

`eventBus.publish` awaits its local handlers serially inside the request path, which matches both the timing and the connection-hold warnings.

Fixing that properly is a server change and out of scope here. What this PR does is stop the client turning a successful write into a visible failure: `acknowledgeAlert` gets a 45s timeout while every other call keeps the 15s default. `request`/`requestWithPrefix` gained an optional per-call timeout to carry it — passing `undefined` selects the existing default, so no other call site changes behaviour.

Happy to open a separate issue with the connection-hold measurements if that is useful for #1105; they came off a real fleet rather than a synthetic one.

## Async safety

Both screens guard their loads with a generation counter and a mounted ref. `useFocusEffect` and pull-to-refresh can overlap, and an older response must never replace a newer one or write after unmount.

## Verification

Node 22.23.2 (matching `.nvmrc`), the two commands `test-mobile` runs:

```
pnpm test --filter=breeze-mobile   33 files, 337 passed | 3 skipped
pnpm exec tsc --noEmit             exit 0
```

`deviceListFilters` and the paging walk are covered directly: sort order, non-mutation, chip totals agreeing with the status predicate, cursor following, org scoping, and the non-advancing-cursor stop.

## Review history

An adversarial review of the first revision caught the 50-device truncation — the screen looked correct in isolation and would have quietly shown a quarter of this fleet. It also caught the overlapping-load race. Both are fixed above; the cursor walk exists specifically because of that finding.
