### PR TITLE
fix(mobile): echo the server's CSRF token so the session can actually refresh (#3723)

### DIFF
--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -4,6 +4,12 @@ import * as Sentry from '@sentry/react-native';
 import { getServerUrl } from './serverConfig';
 import { getOrCreateInstallationId } from './installationId';
 import { fetchWithTimeout } from './fetchWithTimeout';
+import {
+  applyCsrfSignal,
+  forgetCsrfToken,
+  getCsrfHeaderValue,
+  readCsrfCookie,
+} from './csrfToken';
 
 export const FALLBACK_API_BASE_URL =
   process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
@@ -215,7 +221,10 @@ async function requestWithPrefix<T>(
   }
 
   if (!['GET', 'HEAD', 'OPTIONS'].includes(method)) {
-    (headers as Record<string, string>)[CSRF_HEADER_NAME] = CSRF_HEADER_VALUE;
+    // Echo the server's double-submit token. Sending the fixed bootstrap value
+    // once the CSRF cookie exists fails `safeCompareTokens` server-side and
+    // rejects every refresh, which ends the session at the access-token TTL.
+    (headers as Record<string, string>)[CSRF_HEADER_NAME] = await getCsrfHeaderValue();
   }
 
   // Always send the per-install id so the API can recognise this phone. This
@@ -247,6 +256,13 @@ async function requestWithPrefix<T>(
     timeoutMs
   );
 
+  // The server sets a fresh CSRF cookie on login and refresh, and clears it on
+  // sign-out or a rejected refresh. It is deliberately not HttpOnly so a native
+  // client can read and echo it. A `cleared` signal must drop our copy too —
+  // holding a token whose cookie is gone fails the server's no-cookie path,
+  // which accepts only the bootstrap literal.
+  await applyCsrfSignal(readCsrfCookie(response.headers.get('set-cookie')));
+
   if (!response.ok) {
     const body = await response.json().catch(() => ({} as Record<string, unknown>));
     const code = typeof body.code === 'string' ? body.code : undefined;
@@ -254,11 +270,22 @@ async function requestWithPrefix<T>(
       const reason = typeof body.reason === 'string' ? body.reason : null;
       notifyDeviceBlocked(reason);
     }
+    // Self-heal a token the server will not accept. The stored value can
+    // outlive its cookie — SecureStore survives an iOS reinstall while the
+    // cookie jar does not — and if `set-cookie` is not readable on this runtime
+    // we would never have learned a good one. Forgetting it makes the next
+    // request bootstrap with the literal the no-cookie path accepts, so the
+    // client recovers instead of looping.
+    const message =
+      (typeof body.error === 'string' && body.error)
+      || (typeof body.message === 'string' && body.message)
+      || 'An error occurred';
+    if (/csrf/i.test(message)) {
+      await forgetCsrfToken();
+    }
+
     const error: ApiError = {
-      message:
-        (typeof body.error === 'string' && body.error)
-        || (typeof body.message === 'string' && body.message)
-        || 'An error occurred',
+      message,
       code,
       statusCode: response.status
     };

--- a/apps/mobile/src/services/auth.test.ts
+++ b/apps/mobile/src/services/auth.test.ts
@@ -16,9 +16,23 @@ vi.mock('@sentry/react-native', () => ({
   captureException: (...a: unknown[]) => sentry.captureException(...a),
 }));
 
+// The CSRF wipe goes through its owning module, not SecureStore directly, so it
+// is invisible to the deleteItemAsync assertions above and needs its own mock.
+const csrf = {
+  clearCsrfToken: vi.fn(),
+};
+vi.mock('./csrfToken', () => ({
+  // auth.ts imports the canonical key from here too, so the factory must supply
+  // it — otherwise the deletions entry is keyed `undefined` and the wipe-failure
+  // report names nothing.
+  CSRF_TOKEN_KEY: 'breeze_csrf_token',
+  clearCsrfToken: (...a: unknown[]) => csrf.clearCsrfToken(...a),
+}));
+
 beforeEach(() => {
   secureStore.deleteItemAsync.mockReset().mockResolvedValue(undefined);
   sentry.captureException.mockReset();
+  csrf.clearCsrfToken.mockReset().mockResolvedValue(undefined);
 });
 afterEach(() => vi.restoreAllMocks());
 
@@ -31,6 +45,31 @@ describe('clearAuthData', () => {
 
     const keys = secureStore.deleteItemAsync.mock.calls.map((c) => c[0]);
     expect(keys).toContain('breeze.applock.state.v1');
+  });
+
+  it('removes the CSRF token, so the next account cannot inherit a stale double-submit value', async () => {
+    // The token is account-scoped: a survivor hands the next account a value
+    // that fails every write. This assertion is deliberately separate from the
+    // deleteItemAsync checks — the wipe runs through clearCsrfToken(), so it
+    // would not show up there even if it were working.
+    await clearAuthData();
+
+    expect(csrf.clearCsrfToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the real CSRF key when its wipe fails, and still runs every other delete', async () => {
+    // The failure path is the one that matters: a surviving CSRF token is only
+    // discoverable if SecureWipeError names the key that actually failed. This
+    // also pins the key to the module's exported constant, so renaming it there
+    // cannot silently leave this reporting a stale literal.
+    csrf.clearCsrfToken.mockRejectedValue(new Error('keychain locked'));
+
+    await expect(clearAuthData()).rejects.toBeInstanceOf(SecureWipeError);
+
+    const keys = secureStore.deleteItemAsync.mock.calls.map((c) => c[0]);
+    expect(keys).toContain('breeze_auth_token');
+    expect(keys).toContain('breeze.applock.state.v1');
+    expect(sentry.captureException).toHaveBeenCalled();
   });
 
   it('removes the auth token, the stored user, and the persistent approvals cache', async () => {

--- a/apps/mobile/src/services/auth.ts
+++ b/apps/mobile/src/services/auth.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react-native';
 import type { User } from './api';
 import { APPROVAL_CACHE_KEY, clearApprovalCacheOrThrow } from './approvalCache';
 import { APP_LOCK_STATE_KEY } from './appLockState';
+import { CSRF_TOKEN_KEY, clearCsrfToken } from './csrfToken';
 
 const TOKEN_KEY = 'breeze_auth_token';
 const USER_KEY = 'breeze_user';
@@ -120,6 +121,9 @@ export async function clearAuthData(): Promise<void> {
     // on the next launch and the leftover record waves it straight past the
     // lock. Deleting is the fail-secure direction — an absent record locks.
     { key: APP_LOCK_STATE_KEY, run: () => SecureStore.deleteItemAsync(APP_LOCK_STATE_KEY) },
+    // The CSRF token is account-scoped: leaving it behind would hand the next
+    // account a stale double-submit value that fails every write.
+    { key: CSRF_TOKEN_KEY, run: () => clearCsrfToken() },
   ];
 
   const results = await Promise.allSettled(deletions.map((d) => d.run()));

--- a/apps/mobile/src/services/csrfToken.test.ts
+++ b/apps/mobile/src/services/csrfToken.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const store = new Map<string, string>();
+// csrfToken now reports read failures directly to Sentry (it cannot use
+// lib/errorReporting without an api -> csrfToken import cycle), and the real
+// @sentry/react-native is a Flow source this .ts-only suite cannot parse.
+const sentry = { captureException: vi.fn(), captureMessage: vi.fn() };
+vi.mock('@sentry/react-native', () => ({
+  captureException: (...a: unknown[]) => sentry.captureException(...a),
+  captureMessage: (...a: unknown[]) => sentry.captureMessage(...a),
+}));
+
 vi.mock('expo-secure-store', () => ({
   WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'wutdo',
   getItemAsync: vi.fn(async (k: string) => store.get(k) ?? null),
@@ -145,5 +154,28 @@ describe('clearCsrfToken', () => {
     (store.deleteItemAsync as unknown as { mockRejectedValueOnce: (e: Error) => void })
       .mockRejectedValueOnce(new Error('keychain locked'));
     await expect(clearCsrfToken()).rejects.toThrow('keychain locked');
+  });
+});
+
+
+describe('getCsrfHeaderValue read failures', () => {
+  it('reports a keychain read failure instead of folding it into first-run', async () => {
+    // A read FAILURE and "nothing stored" are different states. Treated the
+    // same, a real stored token coexists with us sending the bootstrap
+    // literal — the server sees a genuine CSRF cookie against a bootstrap
+    // header, safeCompareTokens fails, refresh is rejected and the user is
+    // bounced. That is #3723's symptom with nothing in the logs to tell them
+    // apart, which is exactly what makes it expensive to diagnose.
+    const secureStore = await import('expo-secure-store');
+    sentry.captureException.mockClear();
+    __resetCsrfCacheForTests();
+    vi.mocked(secureStore.getItemAsync).mockRejectedValueOnce(new Error('keychain locked'));
+
+    const value = await getCsrfHeaderValue();
+
+    // Still falls back, so a genuine first run is unaffected...
+    expect(value).toBe(CSRF_BOOTSTRAP_VALUE);
+    // ...but the failure is now visible.
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/src/services/csrfToken.test.ts
+++ b/apps/mobile/src/services/csrfToken.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const store = new Map<string, string>();
+vi.mock('expo-secure-store', () => ({
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'wutdo',
+  getItemAsync: vi.fn(async (k: string) => store.get(k) ?? null),
+  setItemAsync: vi.fn(async (k: string, v: string) => void store.set(k, v)),
+  deleteItemAsync: vi.fn(async (k: string) => void store.delete(k)),
+}));
+
+import {
+  CSRF_BOOTSTRAP_VALUE,
+  applyCsrfSignal,
+  clearCsrfToken,
+  forgetCsrfToken,
+  getCsrfHeaderValue,
+  parseCsrfCookie,
+  readCsrfCookie,
+  rememberCsrfToken,
+  __resetCsrfCacheForTests,
+} from './csrfToken';
+
+beforeEach(() => {
+  store.clear();
+  __resetCsrfCacheForTests();
+});
+
+describe('parseCsrfCookie', () => {
+  it('extracts the token from a single set-cookie value', () => {
+    expect(parseCsrfCookie('breeze_csrf_token=abc123; Path=/; Max-Age=604800')).toBe('abc123');
+  });
+
+  it('finds it when several cookies are folded into one header', () => {
+    // The server sets the refresh cookie and the CSRF cookie together, and RN
+    // may present them folded — position must not matter.
+    const folded =
+      'breeze_refresh_token=xyz; Path=/api/v1/auth; HttpOnly, '
+      + 'breeze_csrf_token=deadbeef; Path=/; Max-Age=604800';
+    expect(parseCsrfCookie(folded)).toBe('deadbeef');
+  });
+
+  it('percent-decodes the value', () => {
+    expect(parseCsrfCookie('breeze_csrf_token=a%2Bb%3D; Path=/')).toBe('a+b=');
+  });
+
+  it('returns null when the cookie is absent, empty or the header is missing', () => {
+    expect(parseCsrfCookie('breeze_refresh_token=xyz; HttpOnly')).toBeNull();
+    expect(parseCsrfCookie('breeze_csrf_token=; Path=/')).toBeNull();
+    expect(parseCsrfCookie(null)).toBeNull();
+    expect(parseCsrfCookie(undefined)).toBeNull();
+  });
+
+  it('does not match a different cookie whose name merely ends the same way', () => {
+    expect(parseCsrfCookie('breeze_portal_csrf_token=nope; Path=/')).toBeNull();
+  });
+});
+
+describe('getCsrfHeaderValue', () => {
+  it('falls back to the bootstrap literal before any token is known', async () => {
+    // Matches the server's no-cookie compatibility path on a first run.
+    await expect(getCsrfHeaderValue()).resolves.toBe(CSRF_BOOTSTRAP_VALUE);
+  });
+
+  it('returns the remembered token once login has supplied one', async () => {
+    await rememberCsrfToken('real-token');
+    await expect(getCsrfHeaderValue()).resolves.toBe('real-token');
+  });
+
+  it('reads a persisted token in a fresh process', async () => {
+    await rememberCsrfToken('persisted');
+    __resetCsrfCacheForTests();
+    await expect(getCsrfHeaderValue()).resolves.toBe('persisted');
+  });
+
+  it('ignores a null token rather than clobbering a good one', async () => {
+    await rememberCsrfToken('keep-me');
+    await rememberCsrfToken(null);
+    await expect(getCsrfHeaderValue()).resolves.toBe('keep-me');
+  });
+});
+
+describe('clearCsrfToken', () => {
+  it('drops the token so the next account cannot inherit it', async () => {
+    await rememberCsrfToken('old-account');
+    await clearCsrfToken();
+    await expect(getCsrfHeaderValue()).resolves.toBe(CSRF_BOOTSTRAP_VALUE);
+  });
+});
+
+
+describe('readCsrfCookie signals', () => {
+  it('reports a cleared cookie distinctly from an absent one', () => {
+    // Sign-out and a rejected refresh emit an empty Max-Age=0 cookie. Treating
+    // that as "no information" would strand a token whose cookie is gone.
+    expect(readCsrfCookie('breeze_csrf_token=; Path=/; Max-Age=0')).toEqual({ kind: 'cleared' });
+    expect(readCsrfCookie('breeze_refresh_token=x; HttpOnly')).toEqual({ kind: 'absent' });
+    expect(readCsrfCookie(null)).toEqual({ kind: 'absent' });
+  });
+
+  it('takes the LAST occurrence when a clear and a re-set are folded together', () => {
+    const folded =
+      'breeze_csrf_token=; Path=/; Max-Age=0, breeze_csrf_token=fresh; Path=/; Max-Age=604800';
+    expect(readCsrfCookie(folded)).toEqual({ kind: 'set', token: 'fresh' });
+  });
+});
+
+describe('applyCsrfSignal', () => {
+  it('drops a stored token when the server clears the cookie', async () => {
+    // Otherwise the client keeps sending a real-looking token with no cookie,
+    // and the server's no-cookie path accepts only the bootstrap literal.
+    await rememberCsrfToken('live-token');
+    await applyCsrfSignal({ kind: 'cleared' });
+    await expect(getCsrfHeaderValue()).resolves.toBe(CSRF_BOOTSTRAP_VALUE);
+  });
+
+  it('leaves the token alone when a response carries no cookie information', async () => {
+    await rememberCsrfToken('live-token');
+    await applyCsrfSignal({ kind: 'absent' });
+    await expect(getCsrfHeaderValue()).resolves.toBe('live-token');
+  });
+
+  it('persists concurrent rotations in call order', async () => {
+    // Independent writes could otherwise land out of order and persist an
+    // older token than the cookie jar holds.
+    await Promise.all([
+      applyCsrfSignal({ kind: 'set', token: 'first' }),
+      applyCsrfSignal({ kind: 'set', token: 'second' }),
+    ]);
+    __resetCsrfCacheForTests();
+    await expect(getCsrfHeaderValue()).resolves.toBe('second');
+  });
+});
+
+describe('forgetCsrfToken', () => {
+  it('returns the client to bootstrap so a rejected token can self-heal', async () => {
+    await rememberCsrfToken('rejected');
+    await forgetCsrfToken();
+    await expect(getCsrfHeaderValue()).resolves.toBe(CSRF_BOOTSTRAP_VALUE);
+  });
+});
+
+describe('clearCsrfToken', () => {
+  it('propagates a keychain failure so a failed wipe is not reported as clean', async () => {
+    const store = await import('expo-secure-store');
+    (store.deleteItemAsync as unknown as { mockRejectedValueOnce: (e: Error) => void })
+      .mockRejectedValueOnce(new Error('keychain locked'));
+    await expect(clearCsrfToken()).rejects.toThrow('keychain locked');
+  });
+});

--- a/apps/mobile/src/services/csrfToken.ts
+++ b/apps/mobile/src/services/csrfToken.ts
@@ -1,4 +1,5 @@
 import * as SecureStore from 'expo-secure-store';
+import * as Sentry from '@sentry/react-native';
 
 /**
  * Double-submit CSRF token handling for the native client.
@@ -132,8 +133,26 @@ export async function getCsrfHeaderValue(): Promise<string> {
       cached = stored;
       return stored;
     }
-  } catch {
-    // fall through to bootstrap
+  } catch (err) {
+    // A read FAILURE is not the same as "nothing stored", and folding the two
+    // together recreates the bug this module exists to fix. If a token really
+    // is stored, the request carries a real CSRF cookie while we send the
+    // bootstrap literal — the mismatch fails safeCompareTokens server-side,
+    // the refresh is rejected, and the user is bounced. Identical to #3723's
+    // symptom, with nothing in the logs to distinguish it.
+    //
+    // Reported directly to Sentry rather than through lib/errorReporting:
+    // that module imports services/api, which imports this one, so routing it
+    // there would create csrfToken -> errorReporting -> api -> csrfToken.
+    Sentry.captureException(
+      err instanceof Error ? err : new Error(`csrf token read failed: ${String(err)}`),
+      { tags: { area: 'csrf-token-read' } }
+    );
+    // Deliberately NOT calling forgetCsrfToken() here. `cached` was already
+    // checked above, so there is no in-memory value to distrust, and the read
+    // failing tells us nothing about whether a stored token exists — a
+    // temporarily locked keychain would have us delete a perfectly good token.
+    // The self-heal on a CSRF-rejected response is the right place to discard.
   }
   return CSRF_BOOTSTRAP_VALUE;
 }

--- a/apps/mobile/src/services/csrfToken.ts
+++ b/apps/mobile/src/services/csrfToken.ts
@@ -1,0 +1,156 @@
+import * as SecureStore from 'expo-secure-store';
+
+/**
+ * Double-submit CSRF token handling for the native client.
+ *
+ * The server issues a random CSRF token as a NON-HttpOnly cookie
+ * (`breeze_csrf_token`) alongside the HttpOnly refresh cookie, and expects the
+ * same value echoed in the `x-breeze-csrf` header. `validateCookieCsrfRequest`
+ * only accepts the literal `1` when the CSRF cookie is ABSENT — a compatibility
+ * path for clients with no cookie access.
+ *
+ * React Native's networking layer keeps its own cookie store, so once login has
+ * happened the cookie IS sent back. A client that keeps sending `1` then fails
+ * the `safeCompareTokens` branch and every refresh is rejected, which ends the
+ * session as soon as the access token expires.
+ *
+ * The cookie is deliberately not HttpOnly, so the correct fix is to read it
+ * from the login response and echo the real value. This module owns that token.
+ */
+
+/** Canonical SecureStore key. Exported so the sign-out wipe reports the real
+  * key it failed on rather than a copy that can drift. */
+export const CSRF_TOKEN_KEY = 'breeze_csrf_token';
+export const CSRF_COOKIE_NAME = 'breeze_csrf_token';
+/** Sent only until a real token is known (the server's no-cookie path). */
+export const CSRF_BOOTSTRAP_VALUE = '1';
+
+let cached: string | null = null;
+
+/**
+ * What a `set-cookie` header says about our CSRF cookie.
+ *
+ * `cleared` matters as much as `set`: sign-out and rejected refreshes emit an
+ * empty `Max-Age=0` cookie. Treating that as "no information" would leave a
+ * stored token alive after the cookie jar dropped it, and the client would then
+ * send a real-looking token with no cookie — which the server rejects, because
+ * its no-cookie path accepts only the bootstrap literal. That would swap one
+ * login loop for another.
+ */
+export type CsrfCookieSignal =
+  | { kind: 'set'; token: string }
+  | { kind: 'cleared' }
+  | { kind: 'absent' };
+
+/**
+ * Read our cookie out of a `set-cookie` header.
+ *
+ * Several cookies can arrive folded into one value, so every occurrence is
+ * scanned and the LAST wins — a clear followed by a re-set in one header must
+ * resolve to the new token, not the clear.
+ */
+export function readCsrfCookie(setCookieHeader: string | null | undefined): CsrfCookieSignal {
+  if (!setCookieHeader) return { kind: 'absent' };
+  const pattern = new RegExp(`(?:^|[,;]\\s*)${CSRF_COOKIE_NAME}=([^;,\\s]*)`, 'g');
+  let last: string | null = null;
+  let seen = false;
+  for (const match of setCookieHeader.matchAll(pattern)) {
+    seen = true;
+    last = match[1] ?? '';
+  }
+  if (!seen) return { kind: 'absent' };
+  if (!last) return { kind: 'cleared' };
+  try {
+    return { kind: 'set', token: decodeURIComponent(last) };
+  } catch {
+    return { kind: 'set', token: last };
+  }
+}
+
+/** Back-compat helper: the token, or null for cleared/absent. */
+export function parseCsrfCookie(setCookieHeader: string | null | undefined): string | null {
+  const signal = readCsrfCookie(setCookieHeader);
+  return signal.kind === 'set' ? signal.token : null;
+}
+
+// Serialises SecureStore writes. Two responses can rotate the token
+// concurrently; without this the writes can land out of order and persist an
+// older token than the one the cookie jar holds.
+let writeChain: Promise<unknown> = Promise.resolve();
+
+function queueWrite(run: () => Promise<unknown>): Promise<void> {
+  writeChain = writeChain.then(run, run);
+  return writeChain.then(
+    () => undefined,
+    () => undefined
+  );
+}
+
+/** Apply what a response said about the cookie. */
+export async function applyCsrfSignal(signal: CsrfCookieSignal): Promise<void> {
+  if (signal.kind === 'absent') return;
+  if (signal.kind === 'cleared') {
+    await forgetCsrfToken();
+    return;
+  }
+  cached = signal.token;
+  await queueWrite(() =>
+    SecureStore.setItemAsync(CSRF_TOKEN_KEY, signal.token, {
+      keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    })
+  );
+}
+
+/** Persist a token. No-op for null. */
+export async function rememberCsrfToken(token: string | null): Promise<void> {
+  if (!token) return;
+  await applyCsrfSignal({ kind: 'set', token });
+}
+
+/**
+ * Drop the token so the next request falls back to the bootstrap literal.
+ *
+ * Used when the cookie is cleared, and when the server rejects our token —
+ * the stored value can outlive its cookie (SecureStore survives an iOS
+ * reinstall; the cookie jar does not), and bootstrapping is the only way back.
+ */
+export async function forgetCsrfToken(): Promise<void> {
+  cached = null;
+  await queueWrite(() => SecureStore.deleteItemAsync(CSRF_TOKEN_KEY));
+}
+
+/**
+ * The value to send in `x-breeze-csrf`. Falls back to the bootstrap literal so
+ * a first-run request (no cookie yet, no stored token) still takes the server's
+ * no-cookie path rather than failing closed.
+ */
+export async function getCsrfHeaderValue(): Promise<string> {
+  if (cached) return cached;
+  try {
+    const stored = await SecureStore.getItemAsync(CSRF_TOKEN_KEY);
+    if (stored) {
+      cached = stored;
+      return stored;
+    }
+  } catch {
+    // fall through to bootstrap
+  }
+  return CSRF_BOOTSTRAP_VALUE;
+}
+
+/**
+ * Clear on sign-out so the next account does not inherit a stale token.
+ *
+ * Deliberately does NOT swallow the deletion failure: `clearAuthData` reports
+ * surviving sensitive keys through `SecureWipeError`, and a silent catch here
+ * would make a failed wipe look successful.
+ */
+export async function clearCsrfToken(): Promise<void> {
+  cached = null;
+  await SecureStore.deleteItemAsync(CSRF_TOKEN_KEY);
+}
+
+/** Test seam. */
+export function __resetCsrfCacheForTests(): void {
+  cached = null;
+}


### PR DESCRIPTION
Fixes #3723.

The mobile client sends a fixed `x-breeze-csrf: 1` on every write, while the server issues a **random** `breeze_csrf_token` cookie at login. `validateCookieCsrfRequest` accepts the literal only when that cookie is **absent**:

```ts
if (!csrfCookie) {
  if (csrfHeader === '1' && !isBrowserSignal) return null;   // no-cookie path
  return 'Missing CSRF cookie';
}
if (!safeCompareTokens(csrfHeader, csrfCookie)) {
  return 'Invalid CSRF token';                               // '1' vs random
}
```

React Native's networking layer keeps its own cookie store and the client already asks for it with `credentials: 'include'`. So once login has happened the cookie **is** sent back, the fixed header fails the compare, and `/auth/refresh` is rejected. Because `resolveRefreshToken` reads the refresh token from the cookie only — no body or `Authorization` fallback, and `toPublicTokens()` deliberately keeps it out of the login JSON — there is nothing to retry with. The session ends at the access-token TTL and the user signs in again.

The compatibility path is self-defeating: it exists for clients that "do not expose cookie APIs", but the client it targets *receives* the cookie and simply never read it.

## The fix

The CSRF cookie is deliberately **not** HttpOnly (only the refresh cookie is), so the client can read and echo it. `services/csrfToken.ts` owns that token.

The parts worth reviewing:

**`cleared` is a distinct signal from `absent`.** Sign-out and a rejected refresh emit an empty `Max-Age=0` cookie. Treating that as "no information" would leave a stored token alive after the cookie jar dropped it — the client would then send a real-looking token with *no* cookie, which the no-cookie path rejects. That swaps one login loop for another, so a clear must drop our copy too.

**Last occurrence wins.** A clear and a re-set can be folded into one `set-cookie` value; resolving to the clear would discard the fresh token.

**Writes are serialised.** Two concurrent rotations could otherwise persist an older token than the cookie jar holds, which only shows up after a restart.

**Self-healing.** A response whose error mentions CSRF drops the stored token so the next request bootstraps. This covers the cases the client cannot otherwise detect — SecureStore survives an iOS reinstall while the cookie jar does not, so a stale token can outlive its cookie.

**`clearCsrfToken` does not swallow its keychain error**, so a failed wipe still surfaces through `clearAuthData`'s `SecureWipeError` rather than looking clean.

## What is not verified

Whether `response.headers.get('set-cookie')` is readable under Expo SDK 57's fetch. Expo installs `expo/fetch` as global fetch unless `EXPO_PUBLIC_USE_RN_FETCH=1`, and some fetch implementations do not expose `Set-Cookie`. I have not captured this on a device.

**The change is written so that does not matter for safety:** if the header is unreadable the client never learns a token, keeps sending `1`, and behaves exactly as it does today. The failure mode is "no improvement", not "worse". If a maintainer knows which fetch ships in SDK 57 and whether it surfaces that header, that would settle whether this is sufficient on its own.

## The alternative, if this is not sufficient

Accept the refresh token from a request body field or `Authorization` header for non-browser clients and persist it in SecureStore. That removes the dependency on native cookie persistence across cold launches entirely, and is the more robust fix — but it is a server-side auth change and felt like the maintainer's call rather than something to arrive unannounced in a PR. Happy to do it if preferred.

## Verification

Node 22.23.2 (matching `.nvmrc`), the two commands `test-mobile` runs:

```
pnpm test --filter=breeze-mobile   32 files, 339 passed | 3 skipped
pnpm exec tsc --noEmit             exit 0
```

17 tests cover the token module directly: cookie parsing (folded headers, percent-encoding, the near-miss `breeze_portal_csrf_token`), the cleared-vs-absent distinction, last-occurrence-wins, bootstrap fallback, cross-process persistence, concurrent-rotation ordering, self-heal, and the non-swallowed wipe failure.

## Review history

An adversarial review of the first revision found four defects, all fixed above. The most serious: the first version ignored the clearing cookie, which would have stranded a stale token after any 401 and produced a *different* permanent login loop. It also flagged the write-ordering race, the swallowed wipe error, and the iOS-reinstall case that motivated the self-heal.
