### PR TITLE
fix(ci): give the Tauri apt step per-command deadlines so a stall can retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1547,24 +1547,53 @@ jobs:
           # reds `main` and fires main-red-alert with zero code signal (#1605).
           # Switch to the canonical mirror and retry update+install with
           # backoff so a slow mirror doesn't masquerade as a build failure.
+          #
+          # The retry loop above only helps when apt EXITS non-zero. Observed
+          # failures instead STALL: apt stops emitting output right after the
+          # InRelease fetches and never returns, so no attempt ever completes
+          # and the job burns its full 35-minute budget without logging a single
+          # retry warning (#3730). Give each phase its own deadline so a stall
+          # fails fast and the retry logic can actually run.
+          #
+          # `timeout` is invoked under sudo (not `timeout sudo ...`) so it
+          # signals apt-get itself as root; wrapping sudo would kill the wrapper
+          # and leave a root apt-get orphaned holding the dpkg lock.
+          #
+          # Deadlines are sized so the WORST case still fails cleanly inside the
+          # job's 35-minute budget. Counting the --kill-after grace on every
+          # bound (each deadline can run to deadline + 30s), three attempts plus
+          # two recovery runs plus the sleeps come to under 27m, so the step
+          # reports its own error rather than being killed mid-attempt with no
+          # diagnostic. Normal runs finish in well under a minute, so these are
+          # roughly 10x headroom rather than tight.
           sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
             /etc/apt/sources.list \
             /etc/apt/sources.list.d/*.list \
             /etc/apt/sources.list.d/*.sources 2>/dev/null || true
           install_deps() {
-            sudo apt-get update && \
-            sudo apt-get install -y --no-install-recommends \
+            sudo timeout --kill-after=30s 2m apt-get update && \
+            sudo timeout --kill-after=30s 5m apt-get install -y --no-install-recommends \
               libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
           }
-          for attempt in 1 2 3; do
+          attempts=3
+          for attempt in $(seq 1 "${attempts}"); do
             if install_deps; then
               echo "Tauri system dependencies installed (attempt ${attempt})."
               exit 0
             fi
-            echo "::warning::apt install failed (attempt ${attempt}/3); retrying in $((attempt * 15))s"
+            if [ "${attempt}" -eq "${attempts}" ]; then
+              break
+            fi
+            echo "::warning::apt install failed (attempt ${attempt}/${attempts}); retrying in $((attempt * 15))s"
+            # A killed apt can leave the dpkg lock held or a package
+            # half-configured; clear that or the retry just fails on the lock.
+            # Bounded too: dpkg runs maintainer scripts and can block on its
+            # own, and an unbounded recovery would reintroduce the very stall
+            # this step exists to prevent.
+            sudo timeout --kill-after=30s 60s dpkg --configure -a || true
             sleep $((attempt * 15))
           done
-          echo "::error::Failed to install Tauri system dependencies after 3 attempts."
+          echo "::error::Failed to install Tauri system dependencies after ${attempts} attempts."
           exit 1
 
       - name: Setup Rust


### PR DESCRIPTION
Fixes the `Rust Check (Tauri apps)` failure mode reported in #3730.

## The failure is a stall, not an error

In run `32293853745` the step stopped emitting output immediately after the `InRelease` fetches and produced nothing for the next 34 minutes, until the job hit `timeout-minutes: 35`:

```
20:12:13.915  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
20:46:47.247  ##[error]The operation was canceled.
```

It reproduced on a rerun of the same commit with no code change (attempt 2: 35.4 min, attempt 3: 35.5 min, both stalling at the same phase boundary), so it is deterministic on this runner image rather than an unlucky network moment. It has hit four job runs today, including #3729 twice, which is itself the fix for the currently red `Security Scanning` on `main`.

## Why the existing retry loop never helped

The loop only re-attempts when `install_deps` **returns** non-zero. Neither `apt-get` call had a deadline, so a blocked invocation never came back and attempt 2 never started. The observable signature is that no `::warning::apt install failed` line appears in either run.

Worth stating plainly, since a `grep` for that string does hit once per log: the single match is the runner echoing the script source with `${attempt}` unexpanded, not an emitted warning. A real emission would show an expanded `attempt 1/3`.

## The change

- `apt-get update` and `apt-get install` each get their own deadline, so a stall fails fast enough for the retry logic to matter.
- `timeout` runs **under** `sudo` rather than wrapping it, so it signals `apt-get` itself as root. Wrapping `sudo` would kill the privilege wrapper and leave a root `apt-get` orphaned still holding the dpkg lock.
- A killed apt can leave the dpkg lock held or a package half-configured, so recovery runs between attempts. It is bounded as well, because `dpkg` executes maintainer scripts and can block on its own; an unbounded recovery would reintroduce the exact stall this removes.
- No recovery or sleep after the final attempt.

Deadlines are sized so the **worst** case still fails cleanly inside the job budget. Counting the `--kill-after` grace on every bound, three attempts plus two recovery runs plus the sleeps come to under 27 minutes, so the step reports its own error rather than being killed mid-attempt with no diagnostic. Normal runs finish in well under a minute, so this is roughly 10x headroom rather than a tight bound.

## What this is not

This is resilience hardening, not a root-cause fix, and I would rather say so than oversell it. The log does not identify which operation blocks: `apt-get update` stalling is the leading explanation since no `apt-get install` output ever appears, but it cannot be distinguished from `install` stalling before its first output or a lock wait. The Azure-to-canonical mirror rewrite demonstrably **works** in both runs, reaching the canonical mirror in about eight seconds, so the mirror is not implicated and I have not touched it. What changes here is that a hung dependency install can no longer consume an entire job silently.

## Verification

Gates run locally, matching the `Workflow Lint` job:

```
actionlint 1.7.12 -shellcheck=                          exit 0   (CI pins the same version)
node .github/scripts/check-workflow-security.mjs        exit 0
node --test check-workflow-security.test.mjs + pin-...  57 pass / 0 fail
shellcheck <extracted step body>                        exit 0
bash -n <extracted step body>                           OK
```

I also checked the gate can actually fail rather than trusting a green: injecting a malformed key into this step makes actionlint report `could not parse as YAML` at that line, and reverting restores exit 0.

Behaviour was verified against a command that hangs, using GNU `timeout`:

```
deadline fires on a hang        -> exit 124 at the deadline
command that succeeds           -> exit 0, not interfered with
new loop, all attempts stall    -> 3 attempts, exactly 2 warnings + 2 recoveries, clean exit 1
new loop, success on attempt 1  -> exit 0, no warning, no recovery
```

The success-path controls matter as much as the failure ones here: a deadline that killed working installs would turn a flaky-slow job into a hard failure.

This PR's own `Rust Check (Tauri apps)` run is the real test, since it exercises the changed step.
