### PR TITLE
feat(mobile): let a self-hosted build add its own associated domain

### DIFF
--- a/apps/mobile/STORE_SUBMISSION.md
+++ b/apps/mobile/STORE_SUBMISSION.md
@@ -143,11 +143,36 @@ Verify with:
 curl -sS -D- https://us.2breeze.app/.well-known/apple-app-site-association
 ```
 
-Three constraints worth recording:
+Four constraints worth recording:
 
-- The domain list is **static at build time** and can only name hosts we
-  control, so **self-hosted Breeze servers can never be covered** by it. Their
-  users get generic autofill, which is the same as today.
+- The domain list is **static at build time**, because Apple binds Associated
+  Domains into the signed entitlement. **The published App Store build therefore
+  cannot cover a self-hosted server** — that is a platform constraint, not
+  something a runtime setting can fix, and self-hosters should not chase it.
+  Those users get generic autofill.
+- A self-hoster **building the app themselves** can cover their own domain.
+  `app.config.js` merges `BREEZE_ASSOCIATED_DOMAINS` into the list from
+  `app.json`:
+
+  ```bash
+  BREEZE_ASSOCIATED_DOMAINS=breeze.example.com npx expo prebuild --platform ios
+  ```
+
+  Several entries may be separated by commas or whitespace, and a pasted URL is
+  accepted (`https://breeze.example.com/login` resolves to the host). The two
+  hosted regions above are always kept, so this can only add to the list and
+  cannot break autofill for hosted users. The self-hosted server still has to
+  serve the AASA file described above, with its own team ID and bundle
+  identifier if the build is signed under a different Apple account.
+
+  Only `webcredentials:` is emitted, and an entry that is not a usable hostname
+  **fails the build** rather than being skipped — wildcards, IP addresses,
+  `localhost`, and a bare host carrying a port or `?mode=developer` are all
+  rejected by name. An internationalised domain is punycoded automatically,
+  whether written bare or as a URL. Failing loudly is deliberate: a silently
+  dropped entry would ship an entitlement missing the domain, and the only
+  symptom would be autofill quietly not working. Edit `app.json` directly for
+  anything beyond a plain password-manager association.
 - `breezermm.com` was deliberately dropped: it is the marketing site behind
   Cloudflare, nobody signs into the app there, and claiming a domain that serves
   no AASA file just leaves an unanswered claim.

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -1,0 +1,31 @@
+const { resolveAssociatedDomains } = require('./src/config/associatedDomains');
+
+/**
+ * Dynamic config layered over `app.json`.
+ *
+ * Everything still lives in `app.json`; this exists only so a self-hosted build
+ * can add its own domain to `ios.associatedDomains`. Apple binds Associated
+ * Domains into the signed entitlement, so the list is fixed at build time and
+ * cannot be a runtime setting — a self-hoster has to build the app themselves
+ * for their domain to associate. The published App Store build can never cover
+ * an arbitrary domain, which is a platform constraint rather than a gap here.
+ *
+ *   BREEZE_ASSOCIATED_DOMAINS=breeze.example.com npx expo prebuild -p ios
+ *
+ * Accepts several entries separated by commas or whitespace and tolerates a
+ * pasted URL. The hosted regions in `app.json` are always kept, so this can
+ * only add to the list.
+ *
+ * Plain CommonJS on purpose: Expo transpiles this file but not the modules it
+ * requires, so the resolver next door has to stay `.js` too.
+ */
+module.exports = ({ config }) => ({
+  ...config,
+  ios: {
+    ...config.ios,
+    associatedDomains: resolveAssociatedDomains(
+      config.ios && config.ios.associatedDomains,
+      process.env.BREEZE_ASSOCIATED_DOMAINS
+    ),
+  },
+});

--- a/apps/mobile/src/config/associatedDomains.js
+++ b/apps/mobile/src/config/associatedDomains.js
@@ -1,0 +1,150 @@
+/**
+ * Associated Domains resolution for self-hosted builds.
+ *
+ * `app.json` pins `ios.associatedDomains` to the two hosted regions, which is
+ * right for the published App Store build but leaves self-hosters with no
+ * domain-to-app association. Without it a saved password-manager entry does not
+ * match the app, so the TOTP code is never suggested and has to be copied by
+ * hand on every sign-in — painful against a 15-minute access token.
+ *
+ * Apple binds Associated Domains into the signed entitlement, so this cannot be
+ * a runtime setting. It is resolved when the app is built: `BREEZE_ASSOCIATED_DOMAINS`
+ * is merged into the static list so someone building from source can cover
+ * their own server.
+ *
+ * Two deliberate restrictions, because the output lands in a SIGNED entitlement:
+ *
+ *  - Only `webcredentials:` is emitted. Accepting arbitrary service prefixes
+ *    would let a build-time env var widen the entitlement into `applinks:`
+ *    (which changes universal-link routing) for no benefit to this feature.
+ *  - Input is validated and a bad entry THROWS. Silently skipping junk is worse
+ *    than failing: the build succeeds, the entitlement is missing the domain,
+ *    and the operator has no idea until autofill quietly does not work.
+ *
+ * Deliberately plain CommonJS, not TypeScript: `app.config.js` is loaded by
+ * Expo through a bare `require`, and while Expo transpiles the config file
+ * itself it does NOT transpile modules the config imports. A `.ts` module here
+ * fails at `expo config`/`expo prebuild` time with "Cannot find module".
+ */
+
+/** Apple's service prefix for password-manager association. */
+const WEBCREDENTIALS_PREFIX = 'webcredentials:';
+
+const MAX_HOSTNAME_LENGTH = 253;
+const MAX_LABEL_LENGTH = 63;
+/** A single DNS label: alphanumeric, inner hyphens allowed. */
+const LABEL = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+/**
+ * Extract a hostname from either a bare host or a pasted URL.
+ *
+ * Operators paste the URL they type into the app rather than a bare host, so
+ * both are accepted. URLs go through the real parser instead of string
+ * splitting, which gets IPv6 literals and credentials right.
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function extractHostname(raw) {
+  const value = raw.trim();
+
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) {
+    let url;
+    try {
+      url = new URL(value);
+    } catch {
+      throw new Error(`BREEZE_ASSOCIATED_DOMAINS: "${raw}" is not a valid URL.`);
+    }
+    return url.hostname;
+  }
+
+  // Reject URL punctuation on what is meant to be a bare hostname rather than
+  // silently trimming it. In particular Apple's `?mode=developer` suffix is
+  // NOT supported here, and dropping it quietly would change behaviour.
+  if (/[/?#@:]/.test(value)) {
+    throw new Error(
+      `BREEZE_ASSOCIATED_DOMAINS: "${raw}" must be a bare hostname or a full URL. ` +
+        `Ports, paths and query suffixes such as "?mode=developer" are not ` +
+        `supported on a bare host; edit app.json directly if you need one.`
+    );
+  }
+
+  // Route bare hosts through the URL parser too, so an internationalised
+  // domain is punycoded the same way it would be from the URL form. Doing it
+  // by hand here would make `bücher.example.com` fail while
+  // `https://bücher.example.com` succeeded, for no reason the operator could see.
+  try {
+    return new URL(`https://${value}`).hostname;
+  } catch {
+    throw new Error(`BREEZE_ASSOCIATED_DOMAINS: "${raw}" is not a valid hostname.`);
+  }
+}
+
+/**
+ * Validate and canonicalise a hostname for use in an entitlement.
+ *
+ * @param {string} hostname
+ * @param {string} original
+ * @returns {string}
+ */
+function validateHostname(hostname, original) {
+  const fail = (why) => {
+    throw new Error(`BREEZE_ASSOCIATED_DOMAINS: "${original}" ${why}.`);
+  };
+
+  let host = hostname.trim().toLowerCase();
+  // A trailing dot is a valid FQDN spelling but never matches an entitlement.
+  if (host.endsWith('.')) host = host.slice(0, -1);
+
+  if (!host) fail('is empty');
+  if (host.startsWith('[') || host.includes(':')) fail('must not be an IP literal');
+  if (host.includes('*')) fail('must not use a wildcard');
+  if (host.length > MAX_HOSTNAME_LENGTH) fail(`exceeds ${MAX_HOSTNAME_LENGTH} characters`);
+
+  const labels = host.split('.');
+  if (labels.length < 2) fail('must be a fully qualified domain name');
+  for (const label of labels) {
+    if (!label) fail('has an empty label');
+    if (label.length > MAX_LABEL_LENGTH) fail(`has a label longer than ${MAX_LABEL_LENGTH} characters`);
+    if (!LABEL.test(label)) fail(`has an invalid label "${label}"`);
+  }
+  // All-numeric final label means this is an IPv4 address, not a domain.
+  if (/^\d+$/.test(labels[labels.length - 1])) fail('must be a domain name, not an IP address');
+
+  return host;
+}
+
+/**
+ * Merge extra associated domains into the static list.
+ *
+ * With no configured value the base list is returned verbatim, so the published
+ * App Store build cannot be affected by this code path at all.
+ *
+ * Accepts comma or whitespace separated values. Semicolon is deliberately NOT
+ * a separator: it is legal inside a URL path and splitting on it would reject a
+ * valid pasted URL.
+ *
+ * @param {readonly string[] | undefined} base
+ * @param {string | null | undefined} raw
+ * @returns {string[]}
+ * @throws {Error} when a configured entry is not a usable hostname
+ */
+function resolveAssociatedDomains(base, raw) {
+  const out = base ? base.slice() : [];
+  if (!raw || !String(raw).trim()) return out;
+
+  const seen = new Set(out.map((e) => e.trim().toLowerCase()));
+
+  for (const piece of String(raw).split(/[\s,]+/)) {
+    if (!piece) continue;
+    const host = validateHostname(extractHostname(piece), piece);
+    const entry = WEBCREDENTIALS_PREFIX + host;
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    out.push(entry);
+  }
+
+  return out;
+}
+
+module.exports = { resolveAssociatedDomains, WEBCREDENTIALS_PREFIX };

--- a/apps/mobile/src/config/associatedDomains.test.ts
+++ b/apps/mobile/src/config/associatedDomains.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveAssociatedDomains } from './associatedDomains';
+
+const HOSTED = ['webcredentials:us.2breeze.app', 'webcredentials:eu.2breeze.app'];
+
+describe('resolveAssociatedDomains', () => {
+  describe('the published build is untouched', () => {
+    it('returns the base list verbatim when nothing is configured', () => {
+      for (const raw of [undefined, null, '', '   ']) {
+        const result = resolveAssociatedDomains(HOSTED, raw);
+        expect(result).toEqual(HOSTED);
+      }
+    });
+
+    it('does not mutate or dedupe the caller list', () => {
+      // Even a base list with a duplicate comes back exactly as given; this is
+      // app.json's business, not ours, and quietly rewriting it would mean the
+      // shipped entitlement no longer matches the file.
+      const base = ['webcredentials:a.example.com', 'webcredentials:a.example.com'];
+      const result = resolveAssociatedDomains(base, undefined);
+      expect(result).toEqual(base);
+      expect(result).not.toBe(base);
+    });
+
+    it('keeps the hosted regions first when adding', () => {
+      const result = resolveAssociatedDomains(HOSTED, 'breeze.example.com');
+      expect(result.slice(0, 2)).toEqual(HOSTED);
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe('accepted input', () => {
+    it('prefixes a bare hostname', () => {
+      expect(resolveAssociatedDomains([], 'breeze.example.com')).toEqual([
+        'webcredentials:breeze.example.com',
+      ]);
+    });
+
+    it('accepts comma and whitespace separators', () => {
+      const expected = ['webcredentials:a.example.com', 'webcredentials:b.example.com'];
+      expect(resolveAssociatedDomains([], 'a.example.com,b.example.com')).toEqual(expected);
+      expect(resolveAssociatedDomains([], 'a.example.com b.example.com')).toEqual(expected);
+      expect(resolveAssociatedDomains([], ' a.example.com,  b.example.com ')).toEqual(expected);
+    });
+
+    // Semicolon is legal inside a URL path, so treating it as a separator
+    // would reject a valid pasted URL.
+    it('does not split on a semicolon inside a URL', () => {
+      expect(resolveAssociatedDomains([], 'https://breeze.example.com/login;a=1')).toEqual([
+        'webcredentials:breeze.example.com',
+      ]);
+    });
+
+    it('extracts the host from a pasted URL', () => {
+      for (const input of [
+        'https://breeze.example.com',
+        'https://breeze.example.com/',
+        'https://breeze.example.com/login?next=/x#frag',
+        'https://breeze.example.com:8443/login',
+        'https://user:pw@breeze.example.com/path',
+      ]) {
+        expect(resolveAssociatedDomains([], input)).toEqual([
+          'webcredentials:breeze.example.com',
+        ]);
+      }
+    });
+
+    it('lowercases, drops a trailing dot, and de-duplicates against the base', () => {
+      expect(resolveAssociatedDomains(HOSTED, 'US.2Breeze.app')).toEqual(HOSTED);
+      expect(resolveAssociatedDomains([], 'breeze.example.com.')).toEqual([
+        'webcredentials:breeze.example.com',
+      ]);
+      expect(
+        resolveAssociatedDomains([], 'breeze.example.com, BREEZE.EXAMPLE.COM')
+      ).toEqual(['webcredentials:breeze.example.com']);
+    });
+
+    it('accepts a punycode host', () => {
+      expect(resolveAssociatedDomains([], 'xn--bcher-kva.example.com')).toEqual([
+        'webcredentials:xn--bcher-kva.example.com',
+      ]);
+    });
+
+    // An internationalised domain must punycode identically whether it arrives
+    // bare or as a URL; rejecting one and accepting the other is a trap.
+    it('punycodes an internationalised domain consistently', () => {
+      const expected = ['webcredentials:xn--bcher-kva.example.com'];
+      expect(resolveAssociatedDomains([], 'b\u00fccher.example.com')).toEqual(expected);
+      expect(resolveAssociatedDomains([], 'https://b\u00fccher.example.com')).toEqual(expected);
+    });
+  });
+
+  // Silently skipping a bad entry would let the build succeed with the domain
+  // missing from the entitlement, which surfaces much later as "autofill just
+  // doesn't work". Failing the config evaluation is the kinder outcome.
+  describe('rejected input throws rather than disappearing', () => {
+    const bad: Array<[string, string]> = [
+      ['localhost', 'not fully qualified'],
+      ['example', 'no dot'],
+      ['*.example.com', 'wildcard'],
+      ['.example.com', 'leading dot / empty label'],
+      ['example..com', 'empty inner label'],
+      ['-example.com', 'leading hyphen'],
+      ['example-.com', 'trailing hyphen'],
+      ['foo_bar.example.com', 'underscore'],
+      ['192.168.1.10', 'IPv4 address'],
+      ['breeze.example.com:8443', 'bare host with a port'],
+      ['applinks:example.com', 'service prefix not accepted'],
+      ['example.com?mode=developer', 'query suffix not supported'],
+      ['https://', 'no host'],
+      [`${'a'.repeat(64)}.example.com`, 'label too long'],
+      [`${'a'.repeat(60)}.`.repeat(5) + 'example.com', 'hostname too long'],
+    ];
+
+    for (const [input, why] of bad) {
+      it(`rejects ${why}: ${input.slice(0, 40)}`, () => {
+        expect(() => resolveAssociatedDomains(HOSTED, input)).toThrow(
+          /BREEZE_ASSOCIATED_DOMAINS/
+        );
+      });
+    }
+
+    it('names the offending entry in the message', () => {
+      expect(() => resolveAssociatedDomains([], '*.example.com')).toThrow(/\*\.example\.com/);
+    });
+
+    it('rejects the whole value if any entry is bad', () => {
+      expect(() =>
+        resolveAssociatedDomains(HOSTED, 'good.example.com, *.bad.example.com')
+      ).toThrow(/BREEZE_ASSOCIATED_DOMAINS/);
+    });
+  });
+
+  it('handles a missing base list', () => {
+    expect(resolveAssociatedDomains(undefined, 'breeze.example.com')).toEqual([
+      'webcredentials:breeze.example.com',
+    ]);
+    expect(resolveAssociatedDomains(undefined, undefined)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #3725.

`ios.associatedDomains` is pinned in `app.json` to the two hosted regions, so a self-hosted deployment gets no domain-to-app association. A saved password entry then does not match the app and the TOTP code is never suggested, so signing in means leaving the app to copy it by hand — hit often against a 15-minute access token.

Apple binds Associated Domains into the signed entitlement, so this cannot be a runtime setting and **the published App Store build can never cover an arbitrary domain**. That part is a platform constraint and the docs now say so plainly, so self-hosters stop chasing it. What it *can* be is build-time: `app.config.js` merges `BREEZE_ASSOCIATED_DOMAINS` into the list from `app.json`, so a self-hoster building from source can cover their own server.

```bash
BREEZE_ASSOCIATED_DOMAINS=breeze.example.com npx expo prebuild --platform ios
```

## Two deliberate restrictions

The output lands in a signed entitlement, so this is more locked down than the issue asked for:

- **Only `webcredentials:` is ever emitted.** My first attempt also honoured `applinks:` and `activitycontinuation:` prefixes, which would let a build-time env var widen the entitlement into universal-link routing for no benefit to password autofill. Dropped.
- **A bad entry fails the build rather than being skipped.** A silently dropped entry ships an entitlement missing the domain, and the only symptom is autofill quietly not working, discovered much later. Wildcards, IP addresses, `localhost`, and a bare host carrying a port or `?mode=developer` are each rejected *by name* rather than trimmed:

```
$ BREEZE_ASSOCIATED_DOMAINS='*.example.com' npx expo config --type public
Error: Error reading Expo config at .../app.config.js:
BREEZE_ASSOCIATED_DOMAINS: "*.example.com" must not use a wildcard.
```

Silently rewriting an operator's input is how you end up with an entitlement that does not match what they asked for. `?mode=developer` is the sharp case: an earlier revision stripped it, which would have quietly changed behaviour.

With the variable unset the base list is returned verbatim — not merely equal, but uncopied and un-deduped — so the published build cannot be affected by this path at all. There is a test pinning that.

## Implementation note

The resolver is plain CommonJS, not TypeScript, and that is not a style choice. Expo transpiles `app.config.js` itself but **not** the modules it requires, so a `.ts` module fails at config evaluation:

```
Error: Cannot find module './src/config/associatedDomains'
```

That was the first thing I tried. The comment in the file records it so the next person does not repeat it.

## Verification

Through the real `expo config --type public` CLI, not a simulation:

| Input | `ios.associatedDomains` |
|---|---|
| *(unset)* | the two hosted regions, unchanged |
| `breeze.example.com` | hosted regions + `webcredentials:breeze.example.com` |
| `https://a.example.com/login US.2BREEZE.APP` | hosted regions + `webcredentials:a.example.com` (URL reduced, case-different duplicate dropped) |
| `*.example.com` | build fails with the message above |

Mobile CI gate, matching the `test-mobile` job:

```
pnpm test --filter=breeze-mobile     32 files, 350 passed, 3 skipped
pnpm exec tsc --noEmit               exit 0
```

The 28 new tests were checked against deliberately broken implementations rather than trusted because they were green — removing label validation fails 3, deduping the base list fails 1, and swapping the throw for a silent skip fails 17.

Independent adversarial review blocked the first revision of this and was right to: it caught the entitlement-widening prefixes, the destroyed `?mode=developer`, validation that amounted to "contains a dot", and silent skipping. A second pass then caught two false *rejections* — semicolon treated as a separator breaks a valid pasted URL containing one, and a bare `bücher.example.com` was rejected while `https://bücher.example.com` was accepted because `new URL()` punycodes it. Both fixed; bare hosts now go through the same parser so IDN behaves identically either way.
