### PR TITLE
fix(web): state the notification channel test verdict in text, not just an icon

### DIFF
--- a/apps/web/src/components/alerts/NotificationChannelList.testVerdict.test.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelList.testVerdict.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import '../../lib/i18n';
+import { describe, it, expect } from 'vitest';
+import NotificationChannelList, { type NotificationChannel } from './NotificationChannelList';
+
+// A channel test that FAILED used to look exactly like one that passed: the
+// text is the same string either way ("Last test: {{time}}") and the only
+// difference was a 12px icon. An operator reads "Last test: Just Now" and
+// concludes their on-call routing is verified when nothing was delivered.
+//
+// It was worse for assistive tech: lucide-react stamps aria-hidden="true" on
+// any icon with no children and no aria-* / role / title prop, so the verdict
+// was not in the accessibility tree at all. #3697.
+//
+// These assert the VISIBLE verdict rather than any particular markup, so a
+// future redesign (a pill, a differently worded line) can satisfy them without
+// being rewritten — the contract is "the outcome is stated", not "an <svg>
+// carries an aria-label".
+function channel(overrides: Partial<NotificationChannel>): NotificationChannel {
+  return {
+    id: 'ch-1',
+    name: 'QA Channel',
+    type: 'email',
+    enabled: true,
+    config: {},
+    createdAt: '2026-08-11T00:00:00Z',
+    updatedAt: '2026-08-11T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('NotificationChannelList — last test verdict', () => {
+  it('states that a failed test failed', () => {
+    render(
+      <NotificationChannelList
+        channels={[channel({ lastTestStatus: 'failed', lastTestedAt: '2026-08-17T21:02:03.233Z' })]}
+      />
+    );
+
+    expect(screen.getByText('Failed')).toBeTruthy();
+    expect(screen.queryByText('Success')).toBeNull();
+  });
+
+  it('states that a passing test succeeded', () => {
+    render(
+      <NotificationChannelList
+        channels={[channel({ lastTestStatus: 'success', lastTestedAt: '2026-08-17T21:02:03.233Z' })]}
+      />
+    );
+
+    expect(screen.getByText('Success')).toBeTruthy();
+    expect(screen.queryByText('Failed')).toBeNull();
+  });
+
+  // The defect itself: the two states must not render the same text. Comparing
+  // full text content catches a regression that reverts the verdict to an
+  // icon-only difference, which no single-string assertion would.
+  it('does not render a failed test identically to a passing one', () => {
+    const { container: passing, unmount } = render(
+      <NotificationChannelList channels={[channel({ lastTestStatus: 'success' })]} />
+    );
+    const passingText = passing.textContent ?? '';
+    unmount();
+
+    const { container: failing } = render(
+      <NotificationChannelList channels={[channel({ lastTestStatus: 'failed' })]} />
+    );
+
+    expect(failing.textContent).not.toEqual(passingText);
+  });
+
+  it('shows no verdict for a channel that was never tested', () => {
+    render(<NotificationChannelList channels={[channel({})]} />);
+
+    expect(screen.queryByText('Success')).toBeNull();
+    expect(screen.queryByText('Failed')).toBeNull();
+    expect(screen.getByText('Never Tested')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/alerts/NotificationChannelList.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelList.tsx
@@ -311,13 +311,34 @@ export default function NotificationChannelList({
                   {getChannelDescription(channel, t)}
                 </p>
 
-                {/* Last Test Status */}
+                {/* Last Test Status.
+                    The verdict used to live ONLY in the icon: the text beside
+                    it is byte-identical either way ("Last test: {time}"), so a
+                    failed channel test read as a success unless you noticed a
+                    12px glyph. It was worse than that for assistive tech —
+                    lucide-react stamps aria-hidden="true" on any icon with no
+                    children and no aria-, role or title prop, so the verdict was
+                    not in the accessibility tree at all.
+
+                    The status word now carries it as real text, which fixes both
+                    audiences at once and needs no new strings. The icon goes
+                    back to being decorative, which is what it now is. #3697. */}
                 <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
                   {channel.lastTestStatus === 'success' && (
-                    <CheckCircle className="h-3 w-3 text-green-600" />
+                    <>
+                      <CheckCircle className="h-3 w-3 text-green-600" />
+                      <span className="font-medium text-green-600">
+                        {t('common:shared.progress.status.success')}
+                      </span>
+                    </>
                   )}
                   {channel.lastTestStatus === 'failed' && (
-                    <XCircle className="h-3 w-3 text-red-600" />
+                    <>
+                      <XCircle className="h-3 w-3 text-red-600" />
+                      <span className="font-medium text-red-600">
+                        {t('common:shared.progress.status.failed')}
+                      </span>
+                    </>
                   )}
                   <span>
                     {channel.lastTestStatus


### PR DESCRIPTION
Refs #3697.

A failed channel test looked exactly like a passing one. The status line reads `Last test: {{time}}` for **both** outcomes, so the only difference was a 12px icon. An operator clicks Test, sees `Last test: Just Now`, and concludes their on-call routing is verified — when nothing was delivered.

It was worse for assistive tech. `lucide-react` stamps `aria-hidden="true"` on any icon rendered with no children and no `aria-`, `role` or `title` prop:

```js
// lucide-react/dist/esm/shared/src/utils/hasA11yProp.mjs
...!children && !hasA11yProp(rest) && { "aria-hidden": "true" },
```

Both verdict icons were rendered bare, so the verdict was not in the accessibility tree at all — a screen-reader user got no outcome whatsoever.

## The fix

Render the verdict as text beside the timestamp, reusing the existing `common:shared.progress.status.success` / `.failed` keys. Those are already translated in all eight locales, so this adds no strings and no locale-parity surface. It also avoids concatenating translated fragments into a sentence, whose word order would not survive translation. The icon stays bare and therefore decorative, which is now accurate: the text carries the meaning.

## This is not the root cause the issue proposed

Worth stating plainly, since the issue asserts the Test handler ignores `testResult.success`. **It does not.** I checked each layer:

- `NotificationChannelsPage.tsx` — `runChannelTest` already goes through `runAction`, and `onTest={handleTest}` is the only production wiring.
- `apiError.ts` — `isApiFailure` already special-cases the nested field: `if (tr && typeof tr === 'object' && tr.success === false) return true`.
- `channels.ts` — the API already persists `lastTestStatus: testResult.success ? 'success' : 'failed'`, and the list GET returns it.
- `NotificationChannelsPage.test.tsx` already has a passing test asserting the error toast for `testResult.success:false`.

So the failure did surface, as a transient toast. What was missing is any **durable** verdict on the card afterwards, which is what this changes. I have left the issue open rather than closing it, because the second half of its ask — persisting and surfacing the failure reason — is a separate piece, and the wording of a fuller line like `Last test: failed 2m ago` is a design call I would rather you make.

## Verification

```
pnpm test --filter=@breeze/web    601 files, 5936 tests, all passing
astro check                        25 errors WITH and WITHOUT this change (pre-existing on main)
locale parity + i18n               84 tests passing (no new keys, so nothing to translate)
```

Control, because a green test proves nothing on its own: reverting the component to the bare icons fails 3 of the 4 new tests. The fourth asserts *absence* of a verdict for a never-tested channel, so it correctly passes either way.

The tests assert the visible outcome rather than markup, so a future redesign of this line satisfies them without a rewrite. The load-bearing one compares full `textContent` between the two states, which is what catches a regression back to an icon-only difference.

One unrelated observation while running the full suite: `src/components/billing/InvoiceWorkspace.test.tsx` failed once in a full run and then passed in two subsequent full runs, including on pristine `main` in isolation. It looks order- or timing-dependent rather than related to anything here, but flagging it since I saw it.

An earlier revision of this patch only added `role="img"` + `aria-label` to the icons. Independent review pushed back that this fixed the accessibility tree while leaving a sighted operator to interpret a 12px glyph, and that asserting on `role="img"` would block a better implementation. Both were right, and this version came out of that.
