### PR TITLE
fix(api,web): return a per-org device count so the org card stops rendering " devices"

### DIFF
--- a/apps/api/src/routes/organizations.test.ts
+++ b/apps/api/src/routes/organizations.test.ts
@@ -325,6 +325,22 @@ describe('organization routes', () => {
               })
             })
           })
+        } as any)
+        // partner-settings read for the preferred org order
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as any)
+        // grouped per-org device counts (#3699)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              groupBy: vi.fn().mockResolvedValue([{ orgId: 'org-1', count: 3 }])
+            })
+          })
         } as any);
 
       const res = await app.request('/orgs/organizations?page=1&limit=50', {

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -1577,6 +1577,31 @@ describe('org routes', () => {
   });
 
   describe('GET /orgs/organizations', () => {
+    // GET /orgs/organizations ends with one grouped per-org device-count query
+    // (#3699), shaped as db.select({...}).from(devices).where(...).groupBy(...).
+    // Mirrors mockSiteDeviceCounts, which does the same for GET /orgs/sites.
+    // Only needed when the page returns rows — an empty page skips the query.
+    const mockOrgDeviceCounts = (rows: Array<{ orgId: string; count: number }>) =>
+      ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            groupBy: vi.fn().mockResolvedValue(rows)
+          })
+        })
+      }) as any;
+
+    // Partner scope reads partners.settings for the preferred org order, which
+    // lands BETWEEN the page query and the device counts. It has to be queued
+    // explicitly once anything follows it, or it consumes the next mock.
+    const mockPartnerOrderSettings = () =>
+      ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([])
+          })
+        })
+      }) as any;
+
     it('should return organizations with pagination', async () => {
       setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
       vi.mocked(db.select)
@@ -1595,7 +1620,9 @@ describe('org routes', () => {
               })
             })
           })
-        } as any);
+        } as any)
+        .mockReturnValueOnce(mockPartnerOrderSettings())
+        .mockReturnValueOnce(mockOrgDeviceCounts([{ orgId: 'org-1', count: 2 }]));
 
       const res = await app.request('/orgs/organizations?page=1&limit=1');
 
@@ -1603,6 +1630,79 @@ describe('org routes', () => {
       const body = await res.json();
       expect(body.data).toHaveLength(1);
       expect(body.pagination.total).toBe(1);
+    });
+
+    // #3699 — the web card renders `{{count}} devices`. With no count in the
+    // payload that interpolated to a bare " devices", which reads as either a
+    // loading bug or an empty tenant on the one screen where the number is the
+    // point. An org absent from the grouped result is a real 0, not unknown.
+    it('returns a device count per organization, defaulting an org with none to 0', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123', accessibleOrgIds: ['org-1', 'org-2'] });
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 2 }])
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  orderBy: vi.fn().mockResolvedValue([{ id: 'org-1' }, { id: 'org-2' }])
+                })
+              })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce(mockPartnerOrderSettings())
+        // org-2 has no devices, so the grouped query simply omits it.
+        .mockReturnValueOnce(mockOrgDeviceCounts([{ orgId: 'org-1', count: 12 }]));
+
+      const res = await app.request('/orgs/organizations?page=1&limit=10');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.find((o: { id: string }) => o.id === 'org-1').deviceCount).toBe(12);
+      expect(body.data.find((o: { id: string }) => o.id === 'org-2').deviceCount).toBe(0);
+    });
+
+    // The grouped count is ONE query for the whole page, not a per-row
+    // subselect: this endpoint is walked page-by-page by fetchAllOrganizations,
+    // so a correlated count would multiply into hundreds of queries per render.
+    it('costs one grouped query for the page rather than one per organization', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123', accessibleOrgIds: ['org-1', 'org-2', 'org-3'] });
+      const groupBySpy = vi.fn().mockResolvedValue([]);
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: 3 }])
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  orderBy: vi.fn().mockResolvedValue([{ id: 'org-1' }, { id: 'org-2' }, { id: 'org-3' }])
+                })
+              })
+            })
+          })
+        } as any)
+        .mockReturnValueOnce(mockPartnerOrderSettings())
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ groupBy: groupBySpy })
+          })
+        } as any);
+
+      const res = await app.request('/orgs/organizations?page=1&limit=10');
+
+      expect(res.status).toBe(200);
+      expect(groupBySpy).toHaveBeenCalledTimes(1);
+      const body = await res.json();
+      expect(body.data.every((o: { deviceCount: number }) => o.deviceCount === 0)).toBe(true);
     });
 
     // #3462: apps/web/src/lib/fetchAllOrganizations.ts pages through this
@@ -1663,7 +1763,9 @@ describe('org routes', () => {
               })
             })
           })
-        } as any);
+        } as any)
+        .mockReturnValueOnce(mockPartnerOrderSettings())
+        .mockReturnValueOnce(mockOrgDeviceCounts([]));
 
       const res = await app.request('/orgs/organizations?search=contoso');
 
@@ -4801,6 +4903,16 @@ describe('org routes', () => {
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             limit: vi.fn().mockRejectedValue(new Error('db blew up'))
+          })
+        })
+      } as any);
+      // 4) grouped per-org device counts (#3699) — runs after the soft-fail,
+      // proving the settings failure degrades ordering only and still yields
+      // a fully-shaped list response.
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            groupBy: vi.fn().mockResolvedValue([{ orgId: 'org-1', count: 7 }])
           })
         })
       } as any);

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -1259,8 +1259,36 @@ orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'
     }
   }
 
+  // Device count per organization. The list is where an MSP scans "how big is
+  // each customer", and the web card renders `{{count}} devices` — with no
+  // count in the payload that interpolated to a bare " devices" (#3699).
+  //
+  // ONE grouped query over the page's ids rather than a count per row. The
+  // page can hold 100 orgs and `fetchAllOrganizations.ts` walks this endpoint
+  // page by page, so a per-row count would repeat that scan 100x per page. It
+  // is index-backed: `org_id` leads both `devices_org_id_status_idx` and
+  // `devices_org_id_last_seen_at_idx`, and EXPLAIN on a populated deployment
+  // takes the index, not a seq scan.
+  //
+  // `devices` has no soft-delete or archive column, so every row is a live
+  // device and a plain count is the whole story. An org with no devices is
+  // absent from the grouped result, hence the `?? 0` rather than leaving it
+  // undefined — "0 devices" is the truth for a new tenant, and undefined is
+  // what produced the blank label in the first place.
+  const pageOrgIds = ordered.map((org) => org.id);
+  const deviceCounts = pageOrgIds.length
+    ? await db
+        .select({ orgId: devices.orgId, count: sql<number>`count(*)` })
+        .from(devices)
+        .where(inArray(devices.orgId, pageOrgIds))
+        .groupBy(devices.orgId)
+    : [];
+  const deviceCountByOrgId = new Map(
+    deviceCounts.map((row) => [row.orgId, Number(row.count)])
+  );
+
   return c.json({
-    data: ordered,
+    data: ordered.map((org) => ({ ...org, deviceCount: deviceCountByOrgId.get(org.id) ?? 0 })),
     pagination: { page, limit, total: Number(count) }
   });
 });

--- a/apps/web/src/components/settings/OrganizationList.tsx
+++ b/apps/web/src/components/settings/OrganizationList.tsx
@@ -7,7 +7,14 @@ export type Organization = {
   id: string;
   name: string;
   status: 'active' | 'trial' | 'suspended' | 'churned' | 'offboarding';
-  deviceCount: number;
+  /**
+   * Absent when the caller is organization-scoped: that branch of
+   * `GET /orgs/organizations` returns a deliberately minimal projection
+   * (id/name/slug/status) because those users reach the route without
+   * `organizations:read`. Optional here so the renderer has to decide what to
+   * show rather than interpolating `undefined` into a label (#3699).
+   */
+  deviceCount?: number;
   createdAt: string;
 };
 

--- a/apps/web/src/components/settings/OrganizationsPage.deviceCount.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.deviceCount.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowDeviceCount } from './OrganizationsPage';
+
+// #3699 — the org card renders `{{count}} devices`. The list endpoint returned
+// no count at all, so it interpolated to a bare " devices" (note the leading
+// space): it read as a loading bug or an empty tenant on the one screen where
+// the number is the point.
+//
+// The API now supplies it; this covers the renderer's half of the contract.
+// The count stays optional because the organization-scoped branch of the
+// endpoint returns a deliberately minimal projection without it.
+//
+// Asserted against the guard directly rather than through a rendered tree: an
+// earlier version of this file rendered OrganizationList and checked for the
+// absent label, which passed with or without the fix — that component shows a
+// bare number under a "Devices" column and never renders the string at all.
+describe('shouldShowDeviceCount', () => {
+  it('shows a real count', () => {
+    expect(shouldShowDeviceCount(12)).toBe(true);
+  });
+
+  // The bug this guards is the blank label, so 0 must still render — a
+  // truthiness check here would hide the count for every new tenant.
+  it('shows a real zero', () => {
+    expect(shouldShowDeviceCount(0)).toBe(true);
+  });
+
+  it('renders nothing when the endpoint omitted the count', () => {
+    expect(shouldShowDeviceCount(undefined)).toBe(false);
+  });
+
+  it('renders nothing for a non-finite value', () => {
+    expect(shouldShowDeviceCount(Number.NaN)).toBe(false);
+  });
+});

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -25,6 +25,21 @@ type OrganizationFormValues = {
   contractEnd?: string;
 };
 
+/**
+ * Whether the org card should render its `{{count}} devices` label.
+ *
+ * The count is absent for organization-scoped callers — that branch of
+ * `GET /orgs/organizations` returns a deliberately minimal projection. Rendering
+ * the label anyway interpolated `undefined` and produced a bare " devices",
+ * which reads as a loading bug or an empty tenant (#3699). `0` is a real value
+ * and must render, so this cannot be a truthiness check.
+ *
+ * Exported for test, like `fetchAllOrganizations` below it.
+ */
+export function shouldShowDeviceCount(count: number | undefined): boolean {
+  return typeof count === 'number' && Number.isFinite(count);
+}
+
 const statusLabelKeys: Record<Organization['status'], string> = {
   active: 'organizationsPage.status.active',
   trial: 'organizationsPage.status.trial',
@@ -618,9 +633,11 @@ export default function OrganizationsPage() {
                           >
                             {t(/* i18n-dynamic */ statusLabelKeys[org.status])}
                           </span>
-                          <span className="text-xs text-muted-foreground">
-                            {t('organizationsPage.deviceCount', { count: org.deviceCount })}
-                          </span>
+                          {shouldShowDeviceCount(org.deviceCount) && (
+                            <span className="text-xs text-muted-foreground">
+                              {t('organizationsPage.deviceCount', { count: org.deviceCount })}
+                            </span>
+                          )}
                         </div>
                       </div>
 
@@ -680,9 +697,11 @@ export default function OrganizationsPage() {
                       >
                         {t(/* i18n-dynamic */ statusLabelKeys[selectedOrg.status])}
                       </span>
-                      <span>
-                        {t('organizationsPage.deviceCount', { count: selectedOrg.deviceCount })}
-                      </span>
+                      {shouldShowDeviceCount(selectedOrg.deviceCount) && (
+                        <span>
+                          {t('organizationsPage.deviceCount', { count: selectedOrg.deviceCount })}
+                        </span>
+                      )}
                     </div>
                   </div>
                   <div className="flex gap-2">


### PR DESCRIPTION
Refs #3699.

Every card on `/settings/organizations` showed a bare, numberless `devices`. The web renders `{{count}} devices` and `GET /orgs/organizations` returned no count at all, so it interpolated `undefined` and left the leading space behind. On the one screen where an MSP scans "how big is each customer", that reads as a loading bug or an empty tenant.

## API

One grouped count over the page's org ids, appended to the response. Not a count per row: the page holds up to 100 orgs and `fetchAllOrganizations.ts` walks this endpoint page by page, so a per-row count would repeat that scan 100x per page.

`GET /orgs/sites` already does exactly this for sites (#1790), so this is the established shape in this file rather than a new pattern.

An org absent from the grouped result is a real `0`, not unknown — `devices` has no soft-delete or archive column, so every row is a live device.

**It is index-backed.** `org_id` leads both `devices_org_id_status_idx` and `devices_org_id_last_seen_at_idx`. `EXPLAIN (ANALYZE, BUFFERS)` of the shape against a populated deployment:

```
HashAggregate  (actual time=1.395..1.399 rows=17 loops=1)
  Group Key: devices.org_id
  ->  Hash Semi Join  (actual time=0.168..1.353 rows=216 loops=1)
        ->  Index Only Scan using devices_id_org_id_uniq on devices
              (actual time=0.093..1.239 rows=216 loops=1)
```

Index scan, not a sequential one, at ~1.4ms.

## Web

The count is **genuinely optional on the wire**. The organization-scoped branch of this endpoint returns a deliberately minimal projection (`id`/`name`/`slug`/`status`) because those callers reach the route without `organizations:read`. The type declared `deviceCount: number`, which was simply untrue, and asserting a field the API never sent is what let `undefined` reach the label in the first place.

So the type is now optional and both render sites are gated on `shouldShowDeviceCount` — a finite-number check, not a truthiness one, so a real `0` still renders. That predicate is exported for test, the same way `fetchAllOrganizations` already is in that file.

## Tenancy

The grouped query is bounded by the already-tenant-filtered page ids and runs inside the request's DB context under forced RLS on `devices`, so it cannot count outside what the caller can already see. Adding an explicit `accessibleOrgIds` predicate would be redundant, since the page ids are the narrower set.

## Verification

```
pnpm test --filter=@breeze/api    1390 files, 23153 passed, 5 skipped
pnpm test --filter=@breeze/web     601 files,  5936 passed
```

Controls, because green tests prove nothing on their own:

- Reverting the API change fails the new "returns a device count per organization" test.
- Swapping the guard to a truthiness check (`Boolean(count)`) fails the "shows a real zero" test — which is the point of the finite check.

My added query broke **three existing tests** that mock a fixed number of `db.select` calls (two in `orgs.test.ts`, one in `organizations.test.ts`). They are updated with the queued mocks, following the existing `mockSiteDeviceCounts` helper. Worth knowing for review: with partner scope the partner-settings read lands *between* the page query and the counts, so it has to be queued explicitly or it consumes the next mock.

## Two things worth flagging

**An earlier revision of the web test was vacuous.** It rendered `OrganizationList` and asserted the numberless label was absent — and passed whether or not the fix was present, because that component never renders that string. It shows a bare number under a "Devices" column; the `{{count}} devices` label is on the card in `OrganizationsPage`. Rewritten to assert the guard directly.

**`OrganizationList` is not mounted anywhere in the app** — only its `Organization` type is imported (by `OrganizationsPage` and `settings/index.ts`) and it is rendered only by its own tests. I have not touched or removed it beyond the type, since that is out of scope here, but it looks like dead UI worth a separate decision. Its table cell renders `{org.deviceCount}` unguarded, so if it is ever mounted it will show an empty cell for org-scoped callers.
