### PR TITLE
fix(ci): stop main-red-alert turning a green CI run red on a transient API error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2289,28 +2289,87 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SHA: ${{ github.sha }}
         run: |
-          set -euo pipefail
+          # NOTE: deliberately no `-e`. This job is a notifier, not a gate, and
+          # it is a normal job in the CI workflow — so an unhandled failure here
+          # turns an otherwise fully green run red at the workflow and
+          # check-suite level. That happened on a transient
+          # `HTTP 503 ... api.github.com/graphql` with 41/41 real jobs green and
+          # `CI Success` itself passing (#3692). Under `set -e` an
+          # assignment-only command takes the exit status of its command
+          # substitution, so a failed `gh issue list` aborted the script before
+          # the `case` block ever ran. Every call is handled explicitly below.
+          set -uo pipefail
+
+          # RETRIES ARE FOR READS ONLY.
+          #
+          # The GitHub API returns transient 5xx often enough that a single
+          # attempt is the actual bug here, but a retried WRITE is worse than a
+          # missed one: if the server accepted `gh issue create` and only the
+          # response was lost, retrying opens a second ci-red issue. Same for
+          # `issue comment`. Reads are idempotent, so only they are retried; the
+          # mutations below get one attempt and an annotation if they fail, and
+          # self-heal on the next push to main or a re-run of this job.
+          #
+          # Progress goes to STDERR, never stdout: this is called inside
+          # `existing=$(gh_read_retry gh issue list ...)`, and anything on stdout
+          # is captured into that variable. Writing the retry notice to stdout
+          # made `existing` the notice text with the issue number glued on the
+          # end, so the next call became `gh issue close "gh call failed...42"`.
+          # Caught by driving this script against a stubbed `gh`; no linter sees
+          # it.
+          gh_read_retry() {
+            local attempt
+            for attempt in 1 2 3; do
+              if "$@"; then
+                return 0
+              fi
+              echo "gh read failed (attempt ${attempt}/3): $*" >&2
+              # No sleep after the final attempt — there is no fourth.
+              if [ "$attempt" -lt 3 ]; then
+                sleep $(( attempt * 5 ))
+              fi
+            done
+            return 1
+          }
+
+          # Unchanged from before: one attempt, errors swallowed. The common
+          # failure is "already exists", which is why stderr is discarded.
           gh label create ci-red --repo "$GITHUB_REPOSITORY" \
             --color B60205 --description "CI is failing on main" 2>/dev/null || true
-          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label ci-red --state open \
-            --json number --jq ".[0].number // empty")
+
+          # Read the current state FIRST, and treat "could not read" as its own
+          # outcome rather than folding it into "none found". Defaulting to an
+          # empty string on failure would make the failure branch below open a
+          # SECOND ci-red issue every red push while the API is degraded.
+          if existing=$(gh_read_retry gh issue list --repo "$GITHUB_REPOSITORY" --label ci-red --state open \
+            --json number --jq ".[0].number // empty"); then
+            :
+          else
+            echo "::error::Could not read ci-red issues after 3 attempts; skipping reconciliation for this run."
+            echo "ci-success result was '$RESULT'. State is unchanged and will reconcile on the next push to main, or by re-running this job."
+            exit 0
+          fi
+
           short_sha="${SHA:0:8}"
           case "$RESULT" in
             success)
               if [ -n "$existing" ]; then
                 gh issue close "$existing" --repo "$GITHUB_REPOSITORY" \
-                  --comment "Main is green again as of \`$short_sha\`: $RUN_URL"
+                  --comment "Main is green again as of \`$short_sha\`: $RUN_URL" \
+                  || echo "::error::Failed to close ci-red issue #$existing; it will close on the next green main run."
               fi
               ;;
             failure)
               if [ -n "$existing" ]; then
                 gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
-                  --body "Still red at \`$short_sha\`: $RUN_URL"
+                  --body "Still red at \`$short_sha\`: $RUN_URL" \
+                  || echo "::error::Failed to comment on ci-red issue #$existing; the issue is already open, so main-red state is still tracked."
               else
                 body=$(printf "CI failed on a main push at \`%s\`.\n\nRun: %s\n\nThis issue is managed by the main-red-alert job: it stays open while main is red and closes automatically on the next green main run." "$short_sha" "$RUN_URL")
                 gh issue create --repo "$GITHUB_REPOSITORY" --label ci-red \
                   --title "CI is red on main" \
-                  --body "$body"
+                  --body "$body" \
+                  || echo "::error::Failed to open a ci-red issue for $short_sha — main is RED and untracked. Re-run this job once the API recovers."
               fi
               ;;
             *)


### PR DESCRIPTION
Refs #3692.

`main-red-alert` is a notifier, not a gate, but it is a normal job in the `CI` workflow — so when it fails the run conclusion and the check suite go red even though everything real passed. Observed with **41/41 jobs green and `CI Success` itself passing**, killed by `HTTP 503 ... api.github.com/graphql`.

## Mechanism

`set -euo pipefail` plus an assignment-only command:

```bash
existing=$(gh issue list ... --jq ".[0].number // empty")
```

An assignment takes the exit status of its command substitution, so one failed read aborted the script before the `case "$RESULT"` block ever ran. Only the first `gh` call was guarded.

## The change

Every call is handled explicitly and `-e` is dropped. **`-u` is kept deliberately**: an undefined variable is a script defect that should still abort, whereas a remote call failing is the expected condition this job exists to survive.

**Reads retry. Writes do not.** That asymmetry is the important part. If the server accepted `gh issue create` and only the response was lost, a retry opens a *second* ci-red issue. A missed alert self-heals on the next push to main or by re-running the job; a duplicate does not. So mutations get one attempt and an `::error::` annotation.

**An unreadable list is its own outcome**, not "none found". Defaulting to empty would make the failure branch open a duplicate issue on every red push while the API is degraded, so the job skips reconciliation for that run and says so.

**Retry progress goes to stderr, never stdout.** The helper is called inside `existing=$(gh_read_retry gh issue list ...)`, so anything on stdout is captured into the variable. An earlier revision wrote the retry notice to stdout, which made `existing` the notice text with the issue number glued on the end and turned the next call into `gh issue close "gh call failed...42"`. That one is invisible to every linter — it only showed up by running the script.

## Verification

Driven against a stubbed `gh`, comparing current `main` to this version by exit code and call counts:

| scenario | RESULT | main | this PR | calls (this PR) |
|---|---|---|---|---|
| all_ok | success | 0 | 0 | 1 list |
| existing_open | success | 0 | 0 | 1 list, 1 close |
| existing_open | failure | 0 | 0 | 1 list, 1 comment |
| no_existing | failure | 0 | 0 | 1 list, 1 create |
| **create_dead** | failure | **1** | **0** | 1 list, 1 create |
| **list_transient** | success | **1** | **0** | 3 list, 1 close |
| **list_dead** | failure | **1** | **0** | 3 list, **no create** |

Every happy path is byte-identical — same calls, same exit code. Only the failure paths change, and none of them can now red the run. `list_transient` also confirms the read retry recovers and closes the issue with a clean number; `list_dead` confirms no duplicate is created when state is unreadable.

`actionlint` 1.7.12 (the pinned CI version), the workflow security policy script and its 57 tests, `shellcheck`, and `bash -n` are all clean.

## Notes for review

- This does **not** add `continue-on-error` to the job. With every call handled the step cannot abort on a remote failure, and `continue-on-error` would additionally mask a genuine scripting bug.
- A persistent (non-transient) failure — bad permissions, expired credentials — will now leave main red and untracked while the job reports success, surfaced only by the `::error::` annotation. That is a deliberate trade against the alternative of reddening every green run, but it is a real gap and worth a follow-up if it ever bites.
- No conflict with #3731, my other open `ci.yml` change; `git merge-tree` reports zero conflicts (different job, ~700 lines apart).
