### PR TITLE
fix(web): a locale change no longer drops a live VNC session

### DIFF
--- a/apps/web/src/components/remote/VncViewer.localeStability.test.tsx
+++ b/apps/web/src/components/remote/VncViewer.localeStability.test.tsx
@@ -1,0 +1,82 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { i18n } from '../../lib/i18n';
+
+import VncViewer from './VncViewer';
+
+// #3632 — this is the assertion that matters for the reported symptom.
+//
+// The sibling test proves the ticket is minted once. That alone does NOT prove
+// the user-visible bug is gone: the disconnect came from THIS component's own
+// connection effect, whose cleanup calls `rfb.disconnect()`. With `t` in its
+// dependency array, a `languageChanged` event tore the live RFB session down
+// directly — no new wsUrl required.
+//
+// Reachable without touching the language picker:
+// `scheduleStoredLocaleAfterHydration()` fires `changeLanguage` after mount on
+// every page load for any user with a saved non-English locale.
+//
+// Rather than mock noVNC, this counts how many times the connect effect BODY
+// runs, which is the thing under test: the effect logs exactly once per attempt
+// on its way to `new RFB(...)`, so the count is a direct measure of effect
+// re-entry, and it holds regardless of how the RFB is constructed.
+//
+// Mocking `@/lib/novnc` is the obvious alternative and is a trap here: the
+// module is pulled in via a dynamic `import()` through the `@` alias, and this
+// project sets `clearMocks`/`restoreMocks`, which strips a factory-declared
+// implementation before each test. Both failure modes present identically — a
+// mock that silently never runs, while `connect().catch()` swallows the fallout
+// into an error state.
+const CONNECT_LOG = '[VNC] container size at connect:';
+
+// jsdom has no ResizeObserver; the viewer installs one to rescale the canvas.
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', StubResizeObserver);
+
+describe('VncViewer — a locale change must not re-run the connection effect', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  const connects = () =>
+    logSpy.mock.calls.filter((args: unknown[]) => String(args[0]).includes(CONNECT_LOG)).length;
+
+  beforeEach(async () => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await act(() => i18n.changeLanguage('en'));
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('connects once and does not reconnect when the language changes', async () => {
+    render(
+      <VncViewer wsUrl="wss://example.test/ws?ticket=abc" tunnelId="tunnel-1" onDisconnect={() => {}} />
+    );
+
+    await waitFor(() => expect(connects()).toBe(1));
+
+    // Exactly what hydration does for a user with a saved locale.
+    await act(() => i18n.changeLanguage('fr-FR'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Re-running the effect would tear the session down in its cleanup.
+    expect(connects()).toBe(1);
+  });
+
+  it('still reconnects when wsUrl actually changes, so the effect was not frozen', async () => {
+    // A fix that simply stopped the effect reacting would pass the test above
+    // and break every genuine reconnect.
+    const { rerender } = render(
+      <VncViewer wsUrl="wss://example.test/ws?ticket=abc" tunnelId="tunnel-1" onDisconnect={() => {}} />
+    );
+    await waitFor(() => expect(connects()).toBe(1));
+
+    rerender(
+      <VncViewer wsUrl="wss://example.test/ws?ticket=def" tunnelId="tunnel-1" onDisconnect={() => {}} />
+    );
+    await waitFor(() => expect(connects()).toBe(2));
+  });
+});

--- a/apps/web/src/components/remote/VncViewer.tsx
+++ b/apps/web/src/components/remote/VncViewer.tsx
@@ -48,6 +48,20 @@ const statusConfig: Record<ConnectionStatus, { labelKey: string; color: string }
 
 export default function VncViewer({ wsUrl, tunnelId, onDisconnect, className }: VncViewerProps) {
   const { t } = useTranslation('remote');
+
+  // `t` must NOT be an effect dependency. react-i18next returns a NEW `t`
+  // identity on `languageChanged`, and the connection effect's cleanup calls
+  // `rfb.disconnect()` — so a locale change tore down a LIVE RFB session. That
+  // is reachable without touching the language picker:
+  // `scheduleStoredLocaleAfterHydration()` fires `changeLanguage` after mount
+  // on every page load for any user with a saved non-English locale (#3632).
+  //
+  // Error strings still need the current translator, so keep it in a ref: read
+  // at call time, never a dependency.
+  const tRef = useRef(t);
+  useEffect(() => {
+    tRef.current = t;
+  }, [t]);
   const containerRef = useRef<HTMLDivElement>(null);
   const rfbRef = useRef<any>(null);
   // Whether noVNC ever reported `connect` for the CURRENT wsUrl. A ws-ticket is
@@ -105,7 +119,7 @@ export default function VncViewer({ wsUrl, tunnelId, onDisconnect, className }: 
           setStatus('disconnected');
         } else {
           setStatus('error');
-          setErrorMessage(t('vncViewer.errors.connectionLost'));
+          setErrorMessage(tRef.current('vncViewer.errors.connectionLost'));
         }
         // An unclean disconnect with no preceding `connect` is a handshake the
         // server refused before the upgrade — the caller needs to tell that
@@ -136,12 +150,12 @@ export default function VncViewer({ wsUrl, tunnelId, onDisconnect, className }: 
       rfb.addEventListener('securityfailure', (e: CustomEvent) => {
         console.warn('[VNC] securityfailure:', e.detail);
         if (disposed) return;
-        const reason = e.detail?.reason || t('vncViewer.errors.authenticationFailed');
+        const reason = e.detail?.reason || tRef.current('vncViewer.errors.authenticationFailed');
         setStatus('error');
         setErrorMessage(
-          e.detail?.status === 1 ? t('vncViewer.errors.authenticationDetail', { reason })
-          : e.detail?.status === 2 ? t('vncViewer.errors.securityType', { reason })
-          : t('vncViewer.errors.securityFailure', { reason })
+          e.detail?.status === 1 ? tRef.current('vncViewer.errors.authenticationDetail', { reason })
+          : e.detail?.status === 2 ? tRef.current('vncViewer.errors.securityType', { reason })
+          : tRef.current('vncViewer.errors.securityFailure', { reason })
         );
       });
       rfb.addEventListener('clipboard', (e: CustomEvent) => {
@@ -221,7 +235,7 @@ export default function VncViewer({ wsUrl, tunnelId, onDisconnect, className }: 
     connect().catch((err) => {
       if (!disposed) {
         setStatus('error');
-        setErrorMessage(err instanceof Error ? err.message : t('vncViewer.errors.loadViewer'));
+        setErrorMessage(err instanceof Error ? err.message : tRef.current('vncViewer.errors.loadViewer'));
       }
     });
 
@@ -233,7 +247,7 @@ export default function VncViewer({ wsUrl, tunnelId, onDisconnect, className }: 
       }
       rfbRef.current = null;
     };
-  }, [wsUrl, onDisconnect, t]);
+  }, [wsUrl, onDisconnect]);
 
   // Sync scale setting to RFB instance
   useEffect(() => {

--- a/apps/web/src/components/remote/VncViewerPage.localeStability.test.tsx
+++ b/apps/web/src/components/remote/VncViewerPage.localeStability.test.tsx
@@ -1,0 +1,68 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { i18n } from '../../lib/i18n';
+
+import VncViewerPage from './VncViewerPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+// #3632 — `t` from useTranslation gets a NEW identity on `languageChanged`.
+// With `t` in this effect's dependency array, a locale change re-ran the
+// ticket mint and installed a fresh wsUrl underneath a LIVE session. The
+// existing `attemptRef` guard does not catch it: it compares
+// `attemptRef.current === attempt`, and a `t`-triggered re-run leaves `attempt`
+// unchanged, so the new URL installs.
+//
+// This is reachable without touching the language picker.
+// `scheduleStoredLocaleAfterHydration()` fires `changeLanguage` after mount on
+// every page load for any user with a saved non-English locale, so an ordinary
+// page load dropped their remote session.
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+// The viewer itself pulls in noVNC; this suite is about the mint effect only.
+vi.mock('./VncViewer', () => ({
+  default: () => null,
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const ticketRes = (): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue({ ticket: 'ticket-abc' }),
+  }) as unknown as Response;
+
+describe('VncViewerPage — a locale change must not re-mint the tunnel ticket', () => {
+  beforeEach(async () => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(ticketRes());
+    await act(() => i18n.changeLanguage('en'));
+  });
+
+  it('does not POST a second ws-ticket when the language changes', async () => {
+    render(<VncViewerPage tunnelId="tunnel-1" />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith('/tunnels/tunnel-1/ws-ticket', { method: 'POST' });
+
+    // Exactly what happens on hydration for a user with a saved locale.
+    await act(() => i18n.changeLanguage('fr-FR'));
+
+    // Give any re-triggered effect a chance to fire before asserting absence.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still re-mints for a real retry, so the guard was not simply disabled', async () => {
+    // The effect must remain reactive to `attempt`/`tunnelId` — a fix that
+    // froze it entirely would pass the test above and break reconnect.
+    const { rerender } = render(<VncViewerPage tunnelId="tunnel-1" />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    rerender(<VncViewerPage tunnelId="tunnel-2" />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock).toHaveBeenLastCalledWith('/tunnels/tunnel-2/ws-ticket', { method: 'POST' });
+  });
+});

--- a/apps/web/src/components/remote/VncViewerPage.tsx
+++ b/apps/web/src/components/remote/VncViewerPage.tsx
@@ -29,6 +29,20 @@ export default function VncViewerPage({ tunnelId }: Props) {
   const [attempt, setAttempt] = useState(0);
   const attemptRef = useRef(0);
 
+  // `t` must NOT be an effect dependency. react-i18next hands back a NEW `t`
+  // identity on `languageChanged`, and `scheduleStoredLocaleAfterHydration()`
+  // fires `changeLanguage` after mount on EVERY page load for any user with a
+  // saved non-English locale. With `t` in the deps below, that re-ran the mint
+  // and installed a fresh wsUrl underneath a live session — the `attemptRef`
+  // guard does not catch it, because `attempt` is unchanged (#3632).
+  //
+  // The messages still need the current translator, so keep it in a ref: read
+  // at call time, never a dependency.
+  const tRef = useRef(t);
+  useEffect(() => {
+    tRef.current = t;
+  }, [t]);
+
   useEffect(() => {
     attemptRef.current = attempt;
     let cancelled = false;
@@ -38,19 +52,19 @@ export default function VncViewerPage({ tunnelId }: Props) {
         const res = await fetchWithAuth(`/tunnels/${tunnelId}/ws-ticket`, { method: 'POST' });
         if (!res.ok) {
           const body = await res.json().catch(() => ({}));
-          throw new Error(body.error || t('vncViewerPage.errors.obtainTicket'));
+          throw new Error(body.error || tRef.current('vncViewerPage.errors.obtainTicket'));
         }
         const body = await res.json();
         const ticket = typeof body.ticket === 'string' ? body.ticket : body.ticket?.ticket;
         if (!ticket) {
-          throw new Error(t('vncViewerPage.errors.invalidTicket'));
+          throw new Error(tRef.current('vncViewerPage.errors.invalidTicket'));
         }
         if (!cancelled && attemptRef.current === attempt) {
           setWsUrl(buildTunnelWsUrl(tunnelId, ticket));
         }
       } catch (err) {
         if (!cancelled && attemptRef.current === attempt) {
-          setError(err instanceof Error ? err.message : t('vncViewerPage.errors.connect'));
+          setError(err instanceof Error ? err.message : tRef.current('vncViewerPage.errors.connect'));
         }
       }
     };
@@ -59,7 +73,7 @@ export default function VncViewerPage({ tunnelId }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [tunnelId, attempt, t]);
+  }, [tunnelId, attempt]);
 
   // The tunnel is released exactly once. noVNC's own `disconnect` event fires
   // in addition to the operator's Disconnect click, so both land here.


### PR DESCRIPTION
Refs #3632 — the immediate item you called out: *"the VNC pair gets fixed first (pull `t` out of both effects — neither needs it for correctness)."*

## What was happening

`t` from `useTranslation` gets a new identity on `languageChanged`, and both remote-viewer effects listed it as a dependency:

- **`VncViewerPage`** re-POSTed `/tunnels/:id/ws-ticket` and installed a fresh `wsUrl` underneath a live session. The `attemptRef` guard does not catch this — it compares `attemptRef.current === attempt`, and a `t`-triggered re-run leaves `attempt` unchanged, so the new URL installs.
- **`VncViewer`**'s connection effect ends in cleanup calling `rfb.disconnect()`, so the locale change tore the RFB session down directly — no new `wsUrl` required.

And it is not just the language picker: `scheduleStoredLocaleAfterHydration()` fires `changeLanguage` **after mount on every page load** for any user with a saved non-English locale, so an ordinary page load dropped their remote session.

## The fix

Neither effect needs `t` for correctness — it only builds error strings. The current translator is held in a ref and read at call time, so `t` leaves both dependency arrays while the effects stay reactive to what actually matters (`tunnelId`, `attempt`, `wsUrl`, `onDisconnect`).

**`onDisconnect` was checked, not assumed.** An unstable callback would reproduce the identical teardown, so I traced the chain: `onViewerDisconnect` → `[handleSessionDropped, attempt]` → `[handleDisconnect]` → `[tunnelId]`. Nothing in it depends on `t`, so a locale change cannot change its identity. (Independent review raised this as the one thing that could have made the fix incomplete.)

## Tests, each with its control

| test | control: restore `t` to the deps |
|---|---|
| page does not re-mint the ticket on `languageChanged` | fails — `expected 1 times, got 2 times` |
| viewer does not re-run its connection effect on `languageChanged` | fails — `expected 2 to be 1` |

Both suites also assert the effects are **still reactive** — a new `tunnelId` re-mints, a new `wsUrl` reconnects — so a "fix" that simply froze the effect would fail them.

## One note for whoever writes the systemic sweep

The viewer test counts connect-effect entries instead of mocking `@/lib/novnc`. Mocking it is a trap, and I hit all of it before finding a way through:

- the module arrives via a dynamic `import()` behind the `@` alias, so a `vi.mock('../../lib/novnc', …)` targets a **different module id** than the component loads;
- a `vi.mock` factory is hoisted, so it cannot close over a plain `const` (TDZ);
- this project sets `clearMocks`/`restoreMocks`, which strips a factory-declared `mockImplementation` before each test.

All three fail **identically and silently**: the mock never runs, `connect().catch()` swallows the fallout into an error state, and the assertion reads as "the fix did nothing" while the component looks mounted. Counting effect entries sidesteps every one of them and measures the thing under test directly.

## Verification

```
pnpm test --filter=@breeze/web   602 files, 5936 tests passing
astro check                       0 errors, 0 warnings
```

Scope is deliberately the VNC pair only. The systemic answer — 74 dep arrays across all hook types, and `useStableT` versus a custom lint rule — stays on #3632 for your call.
