### PR TITLE
ci: dispatch-only hosted server-image builds (hosted-images.yml)

### DIFF
--- a/.github/workflows/hosted-images.yml
+++ b/.github/workflows/hosted-images.yml
@@ -1,0 +1,230 @@
+name: Hosted Server Images
+
+# Manual escape hatch for when the tag-triggered release pipeline is blocked on
+# artifact signing (e.g. a Trusted Signing outage): builds and pushes ONLY the
+# server-side container images for an already-pushed tag so the hosted droplets
+# can still receive server-side fixes.
+#
+# This workflow deliberately does NOT:
+#   - create, edit, or publish any GitHub Release. `/releases/latest` is
+#     untouched, so nothing in the fleet (self-hosted binary sync, agent
+#     auto-promote, the viewer's Tauri updater) can act on these images.
+#   - build the binaries-init image. Agent/viewer/helper binaries stay on the
+#     last fully-signed release; deployments consuming these images must pin
+#     BREEZE_BINARIES_IMAGE_REF to that release explicitly.
+#   - move the `latest`, `<major>`, or `<major>.<minor>` image tags. Only the
+#     exact `<version>` tag is pushed. release.yml remains the only workflow
+#     that advertises floating tags, and its "no signed release -> no images"
+#     gate is intentionally left intact.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to build from (e.g. v0.106.0)'
+        required: true
+        type: string
+      include_m365_executors:
+        description: 'Also build the three M365 executor images'
+        type: boolean
+        default: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# SR-007: least-privilege default; jobs that push to GHCR override with
+# packages: write.
+permissions:
+  contents: read
+
+concurrency:
+  group: hosted-images-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      sha: ${{ steps.version.outputs.sha }}
+    steps:
+      - name: Require an exact semver release tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::'$TAG' is not a vX.Y.Z release tag" >&2
+            exit 1
+          fi
+
+      - name: Checkout tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          persist-credentials: false
+
+      - name: Resolve version and commit
+        id: version
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  build-server-image:
+    name: Build & Push ${{ matrix.image }} (${{ inputs.tag }})
+    runs-on: ubuntu-latest
+    needs: [validate]
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: api
+            dockerfile: apps/api/Dockerfile
+            version-build-arg: APP_VERSION
+            extra-build-args: ''
+          - image: web
+            dockerfile: apps/web/Dockerfile
+            version-build-arg: PUBLIC_APP_VERSION
+            extra-build-args: ''
+          - image: portal
+            dockerfile: apps/portal/Dockerfile
+            version-build-arg: ''
+            extra-build-args: |
+              PORTAL_BASE_PATH=/portal
+              PUBLIC_API_URL=
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Container references must be lowercase; IMAGE_NAME is the mixed-case
+      # repository slug.
+      - name: Compute lowercase image base
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        run: |
+          BASE="${REGISTRY}/${IMAGE_NAME}"
+          echo "IMAGE_BASE=${BASE,,}" >> "$GITHUB_ENV"
+
+      - name: Compose build args
+        env:
+          VERSION_ARG: ${{ matrix.version-build-arg }}
+          EXTRA_ARGS: ${{ matrix.extra-build-args }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          {
+            echo 'BUILD_ARGS<<EOF'
+            if [[ -n "$VERSION_ARG" ]]; then
+              echo "${VERSION_ARG}=${VERSION}"
+            fi
+            if [[ -n "$EXTRA_ARGS" ]]; then
+              printf '%s\n' "$EXTRA_ARGS"
+            fi
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Build and push version-tagged image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ env.IMAGE_BASE }}/${{ matrix.image }}:${{ needs.validate.outputs.version }}
+          labels: |
+            org.opencontainers.image.revision=${{ needs.validate.outputs.sha }}
+            org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+          build-args: ${{ env.BUILD_ARGS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-m365-executor-image:
+    name: Build & Push ${{ matrix.image }} (${{ inputs.tag }})
+    runs-on: ubuntu-latest
+    needs: [validate]
+    if: ${{ inputs.include_m365_executors }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - m365-graph-read-executor
+          - m365-graph-actions-executor
+          - m365-communications-executor
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute lowercase image base
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        run: |
+          BASE="${REGISTRY}/${IMAGE_NAME}"
+          echo "IMAGE_BASE=${BASE,,}" >> "$GITHUB_ENV"
+
+      # Same push-by-digest -> scan -> promote flow as release.yml: no
+      # release-facing tag exists until the exact manifest passes the blocking
+      # vulnerability scan.
+      - name: Build and push unadvertised executor digest
+        id: push-executor-digest
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: apps/${{ matrix.image }}/Dockerfile
+          outputs: type=image,name=${{ env.IMAGE_BASE }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan exact executor digest
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_BASE }}/${{ matrix.image }}@${{ steps.push-executor-digest.outputs.digest }}
+          severity: 'HIGH,CRITICAL'
+          format: 'table'
+          exit-code: '1'
+
+      # imagetools only creates a tag reference; it never rebuilds or mutates
+      # the image layers.
+      - name: Promote scanned executor digest
+        env:
+          EXECUTOR_REPOSITORY: ${{ env.IMAGE_BASE }}/${{ matrix.image }}
+          EXECUTOR_IMAGE_DIGEST: ${{ steps.push-executor-digest.outputs.digest }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${EXECUTOR_REPOSITORY}:${VERSION}" \
+            "${EXECUTOR_REPOSITORY}@${EXECUTOR_IMAGE_DIGEST}"


### PR DESCRIPTION
Adds a manual `workflow_dispatch` workflow that builds and pushes **only the server-side container images** (api, web, portal; m365 executors behind an opt-in input) for an already-pushed tag.

Why: the tag-triggered release pipeline fails closed when Windows signing is unavailable (as designed), which currently also blocks every GHCR image — so hosted prod cannot receive server-side fixes while the Trusted Signing profile is suspended (v0.105.2 and v0.106.0 are both tagged with no images). This workflow is the additive escape hatch scoped on 2026-08-17: it leaves `release.yml` and its integrity gate completely untouched.

Safety properties:
- No GitHub Release is created or modified — `/releases/latest` is untouched, so self-hosted binary sync, agent auto-promote, and the viewer's Tauri updater cannot act on these images.
- No binaries-init image — agent/viewer/helper binaries stay on the last fully-signed release; consumers must pin `BREEZE_BINARIES_IMAGE_REF` explicitly.
- Only the exact `<version>` tag is pushed; `latest`/`<major>`/`<major>.<minor>` never move. `release.yml` remains the only workflow that advertises floating tags.
- Tag input is regex-validated before any checkout; executor images keep the same push-by-digest → blocking trivy scan → imagetools promote flow as `release.yml`.

Verified locally: `actionlint` clean, `check-supply-chain-hardening.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)