### PR TITLE
ci: build the validated commit in hosted-images, not the tag again

### DIFF
--- a/.github/workflows/hosted-images.yml
+++ b/.github/workflows/hosted-images.yml
@@ -99,10 +99,24 @@ jobs:
               PORTAL_BASE_PATH=/portal
               PUBLIC_API_URL=
     steps:
-      - name: Checkout tag
+      # An empty `ref` makes actions/checkout fall back to the triggering
+      # revision instead of failing, which would silently reintroduce the
+      # content-vs-label mismatch this pinning exists to prevent. Fail closed.
+      - name: Require a resolved commit sha
+        env:
+          SHA: ${{ needs.validate.outputs.sha }}
+        run: |
+          if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::validate did not produce a commit sha (got '$SHA')" >&2
+            exit 1
+          fi
+
+      # Checkout the commit `validate` resolved, so later tag movement cannot
+      # silently change the source built under the validated revision label.
+      - name: Checkout validated commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: refs/tags/${{ inputs.tag }}
+          ref: ${{ needs.validate.outputs.sha }}
           persist-credentials: false
 
       - name: Set up Docker Buildx
@@ -172,10 +186,24 @@ jobs:
           - m365-graph-actions-executor
           - m365-communications-executor
     steps:
-      - name: Checkout tag
+      # An empty `ref` makes actions/checkout fall back to the triggering
+      # revision instead of failing, which would silently reintroduce the
+      # content-vs-label mismatch this pinning exists to prevent. Fail closed.
+      - name: Require a resolved commit sha
+        env:
+          SHA: ${{ needs.validate.outputs.sha }}
+        run: |
+          if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::validate did not produce a commit sha (got '$SHA')" >&2
+            exit 1
+          fi
+
+      # Checkout the commit `validate` resolved, so later tag movement cannot
+      # silently change the source built under the validated revision label.
+      - name: Checkout validated commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: refs/tags/${{ inputs.tag }}
+          ref: ${{ needs.validate.outputs.sha }}
           persist-credentials: false
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Follow-up to #3741 (I reviewed it just after it merged, so this is the review as a patch).

## The problem

`validate` resolves the dispatched tag to a commit and exports it as `outputs.sha`, but both build jobs then check out `refs/tags/${{ inputs.tag }}` **again**. A tag is a mutable ref and each job resolves it independently when that job starts, so the exported sha constrained nothing — it was used only for the image label.

If the tag moves during a run, a build can produce an image from the new target while `org.opencontainers.image.revision` still reports the commit `validate` recorded, so the provenance label asserts a commit that wasn't built. Because `build-server-image` and `build-m365-executor-image` each re-resolve on their own, one invocation can also publish an internally inconsistent set of images.

`release.yml` isn't exposed to this: a tag-push pins `github.sha` once and none of its jobs override the checkout ref. This workflow is dispatch-triggered on an operator-supplied tag string, so it has to resolve that name itself, which is where the second resolution crept in.

## The change

Check out `needs.validate.outputs.sha` in both build jobs. `validate` keeps resolving the tag, since something has to turn the operator's mutable input into an immutable identity.

Each build job first asserts the value is a 40-char sha. That guard is the part I'd push back on cutting: **an empty `ref` makes `actions/checkout` fall back to the triggering revision rather than fail**, so if the output wiring ever broke, checkout would silently build the wrong source under the validated label — exactly the failure this pinning removes, restored by a typo. Validating inside `validate` wouldn't help, because a broken output mapping still passes its own check. The guard has to sit where the value is consumed.

## Tradeoff, stated plainly

If the tag is moved or deleted between validation and a build, fetching the recorded commit can now **fail** where re-resolving the tag would have "succeeded" by building the new target. That's a real availability regression on an emergency path, and it's deliberate: for a workflow used precisely when the normal integrity gate is unavailable, failing beats silently shipping mislabeled images.

## Out of scope

Images are still published under the version derived from `inputs.tag`, so a later dispatch for the same tag, after the git tag moved, can publish different content under the same container version tag. That's cross-run version-tag mutability and pre-exists this PR; this change only closes the within-run drift. Happy to file it separately if you think it's worth addressing.

## Local gate

- `actionlint .github/workflows/hosted-images.yml` — exit 0
- repo-wide `actionlint` output **byte-identical to pristine main** (12 pre-existing findings, none in this file), so this adds no new lint
- `scripts/security/check-supply-chain-hardening.sh` — passes, exit 0
- guard regex exercised directly: accepts a valid sha; rejects empty, short, over-long, non-hex, and uppercase

No behaviour change on the happy path: same tag, same commit, same images.
