### PR TITLE
docs: retire the plans-folder work queue; wire feature-lifecycle tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,25 @@ The `no-silent-mutations` test (`apps/web/src/lib/__tests__/no-silent-mutations.
 
 ---
 
+## Feature Lifecycle Tracking (multi-wave features)
+
+Features implemented in multiple waves/PRs are tracked on GitHub via the
+**`feature-lifecycle` MCP server** (parent issue labeled `feature`, one `wave`
+sub-issue per wave). Use the **`feature-lifecycle`** skill; state on GitHub is
+the source of truth — never trust the plan doc for current status.
+
+- **When `writing-plans` finishes a multi-wave plan:** call `register_feature`
+  and add `tracking_issue: LanternOps/breeze#<parent>` to the plan doc's
+  frontmatter. This is part of finishing the plan, not optional.
+- **When starting a wave:** `get_feature_status` first, branch
+  `feature/<parent#>-<slug>/wave-<subissue#>`, then `start_wave`.
+- **PR bodies:** include `Closes #<sub-issue>` so the wave auto-closes on merge.
+- **Resuming in any session:** `get_feature_status` before reading the plan.
+
+Single-PR fixes and small features don't need this — it's for work with waves.
+
+---
+
 ## Testing Standards
 
 ### Frameworks & Configuration

--- a/apps/api/src/services/contractDocumentService.ts
+++ b/apps/api/src/services/contractDocumentService.ts
@@ -1,5 +1,5 @@
 // Executed contract-document snapshots (Task 15 of the contract documents +
-// enhanced proposals plan, docs/superpowers/plans/
+// enhanced proposals plan, docs/superpowers/plans/billing/
 // 2026-07-16-contract-documents-and-enhanced-proposals.md).
 //
 // When a quote that embeds `contract` blocks is ACCEPTED, each block's pinned

--- a/apps/api/src/services/contractTemplateRender.ts
+++ b/apps/api/src/services/contractTemplateRender.ts
@@ -1,5 +1,5 @@
 // Contract block render data + `{{variable}}` substitution (Task 10 of the
-// contract documents + enhanced proposals plan, docs/superpowers/plans/
+// contract documents + enhanced proposals plan, docs/superpowers/plans/billing/
 // 2026-07-16-contract-documents-and-enhanced-proposals.md).
 //
 // Three independent concerns live here:

--- a/apps/docs/src/content/docs/contributing/coding-with-claude-code.mdx
+++ b/apps/docs/src/content/docs/contributing/coding-with-claude-code.mdx
@@ -19,15 +19,14 @@ see the top of [`CONTRIBUTING.md`](https://github.com/LanternOps/breeze/blob/mai
 
 ## The one idea to internalize
 
-Breeze doesn't have a public roadmap. Work is captured as **plan documents** in
-[`docs/superpowers/plans/`](https://github.com/LanternOps/breeze/tree/main/docs/superpowers/plans).
-A plan spells out the goal, the architecture, the tech stack, and a checklist of
-tasks — it's a ready-to-implement work order, written for an agent to execute.
+Work on Breeze is captured as **plan documents**. A plan spells out the goal,
+the architecture, the tech stack, and a checklist of tasks — it's a
+ready-to-implement work order, written for an agent to execute.
 
 That means a plan is two things at once:
 
-- **The roadmap** — it's what there is to build.
-- **The approval** — if a plan exists and is in the open lane, the *what* and the
+- **The work definition** — it's what there is to build.
+- **The approval** — if a plan exists and has been approved, the *what* and the
   *how* are already agreed. You don't need a separate sign-off to start.
 
 <Aside type="caution" title="Don't write feature code without an approved plan">
@@ -39,30 +38,39 @@ anyone spends effort, so nothing gets built the wrong way.
 
 ## 1. Find something to build
 
-Open plans live in one folder:
+<Aside type="note" title="Work tracking is moving to GitHub">
+This guide used to point at a folder of open plan documents in the repo. That
+folder has been reorganized and no longer reflects what's actually up for
+grabs, so don't mine `docs/superpowers/plans/` for work — it's an archive of
+completed, shipped plans kept for history. A GitHub-native replacement
+(issues, milestones, and a public roadmap) is in the works and this section
+will be updated when it lands.
+</Aside>
+
+Until then, find work on the issue tracker:
 
 <CardGrid>
   <LinkCard
-    title="The open lane"
-    description="docs/superpowers/plans/open/ — plans that are up for grabs right now."
-    href="https://github.com/LanternOps/breeze/tree/main/docs/superpowers/plans/open"
+    title="Help wanted"
+    description="Open issues tagged for outside contributors."
+    href="https://github.com/LanternOps/breeze/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22"
+  />
+  <LinkCard
+    title="Good first issues"
+    description="Smaller, well-scoped starters."
+    href="https://github.com/LanternOps/breeze/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22"
   />
 </CardGrid>
 
-Everything in the `plans/` root (400+ files) is **completed, shipped work** kept
-for history — ignore it when looking for something to do. Only `open/` is live.
-
 <Steps>
 
-1. Browse `docs/superpowers/plans/open/`. Each file is a complete work order:
-   goal, architecture, tech stack, a linked design spec, and `- [ ]` task
-   checkboxes.
+1. Browse the open issues above, or any open issue that interests you.
 
-2. Pick one that fits your appetite. The plan's own header tells you the blast
-   radius — some are small UI/CRUD jobs, some touch deeper systems.
+2. Pick one that fits your appetite — some are small UI/CRUD jobs, some touch
+   deeper systems.
 
-3. Give Todd a heads-up that you're taking it (so two people don't grab the same
-   plan). Then start.
+3. Comment on the issue that you're taking it (so two people don't grab the
+   same one). Then start with a plan, as below.
 
 </Steps>
 
@@ -76,8 +84,8 @@ Want to scratch your own itch? Great — but the plan comes first.
    pin down intent and requirements, then **`writing-plans`** to produce the plan
    document.
 
-2. Drop the finished plan in `docs/superpowers/plans/open/` and share it with
-   Todd.
+2. Share the finished plan with Todd — attach it to the GitHub issue you're
+   working from (open one if there isn't one yet).
 
 3. Wait for approval on the *plan*. Once it's a 👍, it's an open work order like
    any other — go build it.
@@ -151,14 +159,14 @@ venue and not work-in-progress.
 2. Keep it to **one concern**. Don't mix a feature, a refactor, and a docs sweep
    in one PR — small, single-purpose PRs review fast.
 
-3. Reference the plan you implemented in the PR description.
+3. Reference the plan and the issue you implemented in the PR description
+   (`Closes #NNN` if the PR completes the issue).
 
-4. Open it against `main`. Once it merges, the plan moves out of `open/` into the
-   `plans/` archive — the open lane always reflects only what's still available.
+4. Open it against `main`.
 
 </Steps>
 
 <Aside type="note">
 Squash-merge is the norm on this repo; merge commits are disabled. Todd handles
-the merge and the plan-archival housekeeping.
+the merge.
 </Aside>

--- a/docs/superpowers/plans/open/README.md
+++ b/docs/superpowers/plans/open/README.md
@@ -1,5 +1,11 @@
 # Open plans — up for grabs
 
+> ⚠️ **STALE — this lane is being retired.** Work tracking is moving to GitHub
+> (issues + milestones + a public roadmap); this folder no longer reliably
+> reflects what's up for grabs. Check the
+> [issue tracker](https://github.com/LanternOps/breeze/issues) instead, or ask
+> Todd. The contents below are kept until each plan is re-homed to an issue.
+
 > 📖 **New here? Read the guide first:**
 > [Contributing → Coding with Claude Code](https://docs.breezermm.com/contributing/coding-with-claude-code/)
 > (source: `apps/docs/src/content/docs/contributing/coding-with-claude-code.mdx`).


### PR DESCRIPTION
## What

The [Coding with Claude Code](https://docs.breezermm.com/contributing/coding-with-claude-code/) guide presented `docs/superpowers/plans/open/` as the roadmap and contributor work queue. The reorg of the plans tree into topical subfolders left that description stale (the "400+ files in the plans root" claim, the open-lane framing), and the lane itself drifted after its July 21 seeding. Work tracking is moving to GitHub-native (issues, milestones, public roadmap); this PR removes the folder-as-roadmap framing and puts an honest placeholder in until that lands.

## Changes

- **Contributing guide** (`apps/docs`): replaced the open-lane link card and folder claims with a "work tracking is moving to GitHub" aside plus interim pointers to the `help wanted` / `good first issue` issue queries. The plan-first approval workflow is unchanged — plans are now shared via the GitHub issue being worked instead of dropped in `open/`.
- **`docs/superpowers/plans/open/README.md`**: stamped the lane stale/being retired.
- **Broken plan-path references**: repo-wide sweep found only 4 stale flat `docs/superpowers/plans/<file>.md` refs left after the reorg (the docs tree was cleaned; `apps/api` code comments were missed). Fixed the 2 in TS service headers (`contractDocumentService.ts`, `contractTemplateRender.ts` → `plans/billing/...`). The other 2 sit in shipped SQL migrations, which are immutable — left as-is.
- **`CLAUDE.md`**: new "Feature Lifecycle Tracking" section wiring the `feature-lifecycle` MCP into the workflow — multi-wave features register a parent `feature` issue with `wave` sub-issues, `tracking_issue:` plan frontmatter, `feature/<parent#>-<slug>/wave-<subissue#>` branches, `Closes #<sub-issue>` PR bodies. (Server registered user-scope on the dev machine; `feature`/`wave`/`in-progress` labels created on the repo.)

## Verification

- `pnpm astro check` on `apps/docs`: 0 errors / 0 warnings.
- The two TS changes are comment-only.
- Sweep evidence: 46 file-specific plan refs checked repo-wide, 42 already resolved, 4 broken as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)