### PR TITLE
fix(mobile): make the iOS app lock survive process death

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -9,7 +9,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.breeze.rmm",
-      "buildNumber": "5",
+      "buildNumber": "6",
       "associatedDomains": [
         "webcredentials:us.2breeze.app",
         "webcredentials:eu.2breeze.app"

--- a/apps/mobile/src/navigation/AppLockGate.tsx
+++ b/apps/mobile/src/navigation/AppLockGate.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AppState, type AppStateStatus, Pressable, Text, View } from 'react-native';
+import { AppState, Pressable, Text, View } from 'react-native';
 import * as LocalAuthentication from 'expo-local-authentication';
 
 import { useAppDispatch, useAppSelector } from '../store';
@@ -9,6 +9,15 @@ import {
   getBiometricTypeName,
   getSecurityLevel,
 } from '../services/biometrics';
+import { LOCK_GRACE_MS } from '../services/appLockState';
+import { readAppLockState, writeAppLockState } from '../services/appLockStore';
+import {
+  initialLockState,
+  reduceLock,
+  type AppLifecycle,
+  type LockEvent,
+} from '../services/appLockMachine';
+import { reportInternalError } from '../lib/errorReporting';
 import { palette, radii, spacing, type } from '../theme';
 
 /**
@@ -19,31 +28,30 @@ import { palette, radii, spacing, type } from '../theme';
  * real exposure. Two distinct protections live here, and they are NOT the same
  * mechanism:
  *
- *  1. **Privacy cover** — rendered whenever the app is not `active`. iOS
- *     snapshots the UI on the way out to `inactive` to build the app-switcher
- *     card, and writes that snapshot to disk. Covering on `inactive` (not just
- *     `background`) is what keeps fleet data and pending approvals out of both
- *     the switcher and that on-disk image.
+ *  1. **Privacy cover** — rendered whenever the app is not `active`, and while
+ *     the cold-launch check is still running. iOS snapshots the UI on the way
+ *     out to `inactive` to build the app-switcher card, and writes that
+ *     snapshot to disk. Covering on `inactive` (not just `background`) is what
+ *     keeps fleet data and pending approvals out of both the switcher and that
+ *     on-disk image.
  *
- *  2. **Lock** — requires device authentication to get back in, but only after
- *     the app has actually been in the `background` for {@link LOCK_GRACE_MS}.
- *     Locking on bare `inactive` would be unusable: the Face ID sheet, Control
- *     Centre, and incoming-call banners all flip the app to `inactive`, and the
- *     biometric prompt doing so would make the unlock itself re-trigger a lock.
+ *  2. **Lock** — requires device authentication to get back in. Within one
+ *     process that means after {@link LOCK_GRACE_MS} in the `background`;
+ *     locking on bare `inactive` would be unusable, since the Face ID sheet,
+ *     Control Centre and incoming-call banners all flip the app to `inactive`
+ *     and the biometric prompt doing so would make the unlock re-trigger a
+ *     lock. Across a cold launch the same grace window applies, plus
+ *     fail-secure defaults a resume does not need — most importantly, no
+ *     persisted record at all locks.
  *
- * Scope boundary: this covers background → foreground within one process
- * lifetime. A cold launch is deliberately NOT gated on biometrics — that is a
- * separate product decision, and the session restore already re-validates
- * against the server.
+ * **This component holds no decisions.** Every rule lives in the pure
+ * `services/appLockMachine.ts`, because `vitest.config.ts` includes only `.ts`
+ * and so nothing in a `.tsx` file can be reached by a test. What remains here
+ * is wiring: subscribe to `AppState`, run the biometric prompt, perform the
+ * writes the machine asks for, render. Put logic back in this file and it
+ * becomes untestable again — which is how the background-launch bypass that
+ * `bootResolved` now closes went unnoticed in the first place.
  */
-
-/**
- * How long the app may sit in the background before it locks. Short enough that
- * a phone left on a desk locks, long enough that hopping to the authenticator
- * app or a password manager and straight back does not demand Face ID.
- */
-export const LOCK_GRACE_MS = 60_000;
-
 interface Props {
   children: React.ReactNode;
 }
@@ -52,110 +60,145 @@ export function AppLockGate({ children }: Props) {
   const dispatch = useAppDispatch();
   const token = useAppSelector((s) => s.auth.token);
 
-  const [obscured, setObscured] = useState(false);
-  const [locked, setLocked] = useState(false);
+  const [lock, setLock] = useState(initialLockState);
   const [unlocking, setUnlocking] = useState(false);
-  const [unlockFailed, setUnlockFailed] = useState(false);
   const [biometricName, setBiometricName] = useState('Face ID');
 
-  const backgroundedAt = useRef<number | null>(null);
-  const appState = useRef<AppStateStatus>((AppState.currentState ?? 'unknown') as AppStateStatus);
+  // The machine's state is mirrored in a ref so `send` can stay referentially
+  // stable: the AppState listener is registered once and would otherwise close
+  // over a stale snapshot. Written only from event handlers, never during
+  // render, so a discarded concurrent render cannot leave it lying.
+  const machine = useRef(initialLockState);
+  const lifecycle = useRef<AppLifecycle>((AppState.currentState ?? 'unknown') as AppLifecycle);
+  const bootStarted = useRef(false);
+
+  const send = useCallback((event: LockEvent) => {
+    const { state, persist } = reduceLock(machine.current, event, LOCK_GRACE_MS);
+    machine.current = state;
+    setLock(state);
+    if (persist) void writeAppLockState(persist);
+  }, []);
 
   useEffect(() => {
     getBiometricTypeName().then(setBiometricName).catch(() => {});
   }, []);
 
+  // No session, nothing to protect — and covering the login screen would just
+  // make sign-in flicker. This also releases the lock the sign-out path holds
+  // until the session is actually gone; both logoutAsync outcomes clear the
+  // token, so it always arrives.
   useEffect(() => {
-    // No session, nothing to protect — and covering the login screen would just
-    // make sign-in flicker. Reset so a later sign-in starts from a clean slate.
-    if (!token) {
-      setObscured(false);
-      setLocked(false);
-      backgroundedAt.current = null;
-      return;
-    }
+    if (token) return;
+    send({ type: 'signedOut' });
+  }, [token, send]);
 
+  // Cold-launch check, at most once per process. Runs the first time this
+  // process sees a session, which is either a restore from the keychain (lock
+  // per the persisted record) or an interactive sign-in, where
+  // `markAppLockUnlocked` has just stamped a fresh unlocked record.
+  useEffect(() => {
+    if (!token || bootStarted.current) return;
+    bootStarted.current = true;
+
+    let cancelled = false;
+    void (async () => {
+      const record = await readAppLockState();
+      // Dropping the result when the session vanished mid-read is what keeps a
+      // late verdict from locking the login screen; the `signedOut` effect above
+      // has already cleared the cover by then.
+      if (cancelled) return;
+      send({
+        type: 'bootResolved',
+        record,
+        lifecycle: lifecycle.current,
+        now: Date.now(),
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, send]);
+
+  // Gated on `token` so a signed-out app never stamps the record — an unlocked
+  // stamp written after sign-out would outlive the session it describes.
+  useEffect(() => {
+    if (!token) return;
     const sub = AppState.addEventListener('change', (next) => {
-      const prev = appState.current;
-      appState.current = next;
-
-      if (next === 'active') {
-        setObscured(false);
-        const since = backgroundedAt.current;
-        backgroundedAt.current = null;
-        if (since !== null && Date.now() - since >= LOCK_GRACE_MS) {
-          setUnlockFailed(false);
-          setLocked(true);
-        }
-        return;
-      }
-
-      setObscured(true);
-      // Only a real background starts the lock clock. `inactive` is transient
-      // (Face ID sheet, Control Centre, call banner) and must not — in
-      // particular the unlock prompt itself flips us to `inactive`, so treating
-      // that as a lock trigger would make unlocking re-arm the lock.
-      if (next === 'background' && prev !== 'background') {
-        backgroundedAt.current = Date.now();
-      }
+      const prev = lifecycle.current;
+      lifecycle.current = next as AppLifecycle;
+      send({ type: 'lifecycle', prev, next: next as AppLifecycle, now: Date.now() });
     });
-
     return () => sub.remove();
-  }, [token]);
+  }, [token, send]);
 
   const attemptUnlock = useCallback(async () => {
     setUnlocking(true);
     try {
       const ok = await authenticateWithBiometrics('Unlock Breeze');
-      if (ok) {
-        setLocked(false);
-        setUnlockFailed(false);
-      } else {
-        setUnlockFailed(true);
-      }
+      send(ok ? { type: 'unlockSucceeded', now: Date.now() } : { type: 'unlockRejected' });
+    } catch (error) {
+      // `authenticateWithBiometrics` swallows internally today, so this is
+      // defensive — but without it a throw would leave the button dead: no
+      // failure copy, no telemetry, and an unhandled rejection.
+      reportInternalError(error, 'app-lock-unlock');
+      send({ type: 'unlockRejected' });
     } finally {
       setUnlocking(false);
     }
-  }, []);
+  }, [send]);
 
   // Prompt as soon as the lock screen appears, so the common case is a single
-  // glance rather than "tap Unlock, then look".
+  // glance rather than "tap Unlock, then look". Neither a rejected unlock nor an
+  // unavailable authenticator changes `phase`, so this cannot re-fire into a
+  // prompt loop — the user drives retries from the button.
   useEffect(() => {
-    if (!locked) return;
+    if (lock.phase !== 'locked' || lock.signingOut || lock.authUnavailable) return;
     let cancelled = false;
-    (async () => {
-      // A device with neither biometrics nor a passcode cannot satisfy the
-      // prompt, and locking against an authenticator that does not exist would
-      // strand the user with no way back in. The device itself is unprotected
-      // in that case, so an app lock adds nothing anyway.
-      const level = await getSecurityLevel().catch(() => LocalAuthentication.SecurityLevel.NONE);
+
+    void (async () => {
+      let level: LocalAuthentication.SecurityLevel;
+      try {
+        level = await getSecurityLevel();
+      } catch (error) {
+        // "I could not find out" is not "there is no authenticator". Fail
+        // closed; the Sign out button remains the way forward.
+        if (cancelled) return;
+        reportInternalError(error, 'app-lock-security-level');
+        send({ type: 'authenticatorUnavailable' });
+        return;
+      }
       if (cancelled) return;
+
       if (level === LocalAuthentication.SecurityLevel.NONE) {
-        setLocked(false);
+        send({ type: 'noAuthenticator' });
         return;
       }
       await attemptUnlock();
     })();
+
     return () => {
       cancelled = true;
     };
-  }, [locked, attemptUnlock]);
+  }, [lock.phase, lock.signingOut, lock.authUnavailable, attemptUnlock, send]);
 
   return (
     <View style={{ flex: 1 }}>
       {children}
-      {locked ? (
+      {lock.phase === 'locked' ? (
         <LockScreen
           biometricName={biometricName}
-          busy={unlocking}
-          failed={unlockFailed}
+          busy={unlocking || lock.signingOut}
+          failed={lock.unlockFailed}
+          authUnavailable={lock.authUnavailable}
+          signingOut={lock.signingOut}
           onUnlock={attemptUnlock}
           onSignOut={() => {
-            setLocked(false);
+            send({ type: 'signOutRequested', now: Date.now() });
             void dispatch(logoutAsync());
           }}
         />
-      ) : obscured ? (
+      ) : lock.obscured || (lock.phase === 'booting' && Boolean(token)) ? (
         <PrivacyCover />
       ) : null}
     </View>
@@ -187,16 +230,39 @@ function PrivacyCover() {
   );
 }
 
+function lockScreenCopy({
+  biometricName,
+  authUnavailable,
+  signingOut,
+  failed,
+}: {
+  biometricName: string;
+  authUnavailable: boolean;
+  signingOut: boolean;
+  failed: boolean;
+}): string {
+  if (signingOut) return 'Signing out…';
+  if (authUnavailable) {
+    return "Couldn't check this device's security settings. Try again, or sign out.";
+  }
+  if (failed) return `${biometricName} didn't verify. Try again, or sign out.`;
+  return `Locked. Unlock with ${biometricName} to continue.`;
+}
+
 function LockScreen({
   biometricName,
   busy,
   failed,
+  authUnavailable,
+  signingOut,
   onUnlock,
   onSignOut,
 }: {
   biometricName: string;
   busy: boolean;
   failed: boolean;
+  authUnavailable: boolean;
+  signingOut: boolean;
   onUnlock: () => void;
   onSignOut: () => void;
 }) {
@@ -217,9 +283,7 @@ function LockScreen({
           { color: palette.dark.textMd, marginTop: spacing[3], textAlign: 'center' },
         ]}
       >
-        {failed
-          ? `${biometricName} didn't verify. Try again, or sign out.`
-          : `Locked. Unlock with ${biometricName} to continue.`}
+        {lockScreenCopy({ biometricName, authUnavailable, signingOut, failed })}
       </Text>
 
       <Pressable
@@ -242,9 +306,13 @@ function LockScreen({
 
       <Pressable
         onPress={onSignOut}
+        disabled={signingOut}
         accessibilityRole="button"
         hitSlop={8}
-        style={({ pressed }) => ({ marginTop: spacing[5], opacity: pressed ? 0.7 : 1 })}
+        style={({ pressed }) => ({
+          marginTop: spacing[5],
+          opacity: signingOut ? 0.5 : pressed ? 0.7 : 1,
+        })}
       >
         <Text style={[type.meta, { color: palette.dark.textLo }]}>Sign out</Text>
       </Pressable>

--- a/apps/mobile/src/services/appLockMachine.test.ts
+++ b/apps/mobile/src/services/appLockMachine.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  initialLockState,
+  reduceLock,
+  type AppLifecycle,
+  type LockEvent,
+  type LockMachineState,
+} from './appLockMachine';
+import { LOCK_GRACE_MS, type AppLockState } from './appLockState';
+
+const T0 = 1_800_000_000_000;
+
+/** Drive a sequence of events from the initial state, keeping every write. */
+function run(events: LockEvent[], from: LockMachineState = initialLockState) {
+  const writes: AppLockState[] = [];
+  let state = from;
+  for (const event of events) {
+    const result = reduceLock(state, event, LOCK_GRACE_MS);
+    state = result.state;
+    if (result.persist) writes.push(result.persist);
+  }
+  return { state, writes, lastWrite: writes[writes.length - 1] };
+}
+
+const boot = (record: AppLockState | null, lifecycle: AppLifecycle, now = T0): LockEvent => ({
+  type: 'bootResolved',
+  record,
+  lifecycle,
+  now,
+});
+const life = (prev: AppLifecycle, next: AppLifecycle, now: number): LockEvent => ({
+  type: 'lifecycle',
+  prev,
+  next,
+  now,
+});
+
+describe('cold launch', () => {
+  it('locks when there is no persisted record', () => {
+    const { state } = run([boot(null, 'active')]);
+    expect(state.phase).toBe('locked');
+  });
+
+  it('does not lock inside the grace window', () => {
+    const { state } = run([boot({ stampedAt: T0 - 1_000, locked: false }, 'active')]);
+    expect(state.phase).toBe('unlocked');
+  });
+
+  it('locks past the grace window', () => {
+    const { state } = run([boot({ stampedAt: T0 - LOCK_GRACE_MS, locked: false }, 'active')]);
+    expect(state.phase).toBe('locked');
+  });
+
+  it('makes the lock durable immediately instead of waiting for a lifecycle event', () => {
+    // A force-quit at the lock screen may never deliver another AppState event,
+    // so the record has to say `locked` before then.
+    const { lastWrite } = run([boot(null, 'active')]);
+    expect(lastWrite).toEqual({ stampedAt: T0, locked: true });
+  });
+
+  it('writes nothing when it decides not to lock', () => {
+    const { writes } = run([boot({ stampedAt: T0 - 1_000, locked: false }, 'active')]);
+    expect(writes).toEqual([]);
+  });
+
+  it('runs at most once per process', () => {
+    // A second session in the same process is an interactive sign-in, not a
+    // cold launch — re-running the check would lock a user who just signed in.
+    const { state } = run([
+      boot({ stampedAt: T0 - 1_000, locked: false }, 'active'),
+      { type: 'signedOut' },
+      boot(null, 'active', T0 + 5_000),
+    ]);
+    expect(state.phase).toBe('unlocked');
+  });
+
+  it('covers the UI while a session is restoring but not once resolved', () => {
+    expect(initialLockState.phase).toBe('booting');
+    const { state } = run([boot({ stampedAt: T0 - 1_000, locked: false }, 'active')]);
+    expect(state.phase).toBe('unlocked');
+    expect(state.obscured).toBe(false);
+  });
+
+  it('keeps a lock decided by a lifecycle event that landed mid-read', () => {
+    // The read's verdict must not be able to *undo* a lock, only add one.
+    const { state } = run([
+      life('active', 'background', T0 - LOCK_GRACE_MS * 2),
+      life('background', 'active', T0),
+      boot({ stampedAt: T0 - 1_000, locked: false }, 'active', T0),
+    ]);
+    expect(state.phase).toBe('locked');
+  });
+});
+
+describe('cold launch into the background', () => {
+  // The bypass: a process launched straight into the background (push wake, iOS
+  // prewarm) never observes an `active` -> `background` transition, so it has no
+  // `backgroundedAt` of its own. Before seeding, its first foregrounding found
+  // nothing to measure and opened the fleet however many hours later.
+  it('seeds the idle clock from the record so a later foregrounding still locks', () => {
+    const { state } = run([
+      // Woken 30s after the user backgrounded it — correctly does not lock yet.
+      boot({ stampedAt: T0, locked: false }, 'background', T0 + 30_000),
+      // ...then sits in the background for six hours and the icon is tapped.
+      life('background', 'active', T0 + 6 * 60 * 60 * 1000),
+    ]);
+    expect(state.phase).toBe('locked');
+  });
+
+  it('still honours the grace window for a genuinely quick return', () => {
+    const { state } = run([
+      boot({ stampedAt: T0, locked: false }, 'background', T0 + 1_000),
+      life('background', 'active', T0 + 2_000),
+    ]);
+    expect(state.phase).toBe('unlocked');
+  });
+
+  it('prefers the older of the seeded and observed timestamps', () => {
+    // A transition already seen in this process must not be able to shorten the
+    // window below what the record proves.
+    const { state } = run([
+      life('active', 'background', T0 + 50_000),
+      boot({ stampedAt: T0, locked: false }, 'background', T0 + 50_001),
+      // Past the grace window measured from the record (61s), well inside it
+      // measured from the transition this process happened to see (11s).
+      life('background', 'active', T0 + 61_000),
+    ]);
+    expect(state.phase).toBe('locked');
+  });
+
+  it('does not seed when the process launched into the foreground', () => {
+    // Seeding an active launch would make a brief Face ID sheet (active ->
+    // inactive -> active) measure from the stale record and lock spuriously.
+    const { state } = run([
+      boot({ stampedAt: T0 - 59_000, locked: false }, 'active', T0),
+      life('active', 'inactive', T0 + 100),
+      life('inactive', 'active', T0 + 200),
+    ]);
+    expect(state.phase).toBe('unlocked');
+  });
+
+  it('covers the UI when the process launched outside the foreground', () => {
+    const { state } = run([boot({ stampedAt: T0, locked: false }, 'background', T0 + 1_000)]);
+    expect(state.obscured).toBe(true);
+  });
+});
+
+describe('resume', () => {
+  it('locks at exactly the grace boundary, matching the cold-launch rule', () => {
+    // The two paths must not disagree at the boundary, or the same gesture
+    // behaves differently depending on whether iOS kept the process alive.
+    const { state } = run([
+      boot({ stampedAt: T0 - 1_000, locked: false }, 'active'),
+      life('active', 'background', T0),
+      life('background', 'active', T0 + LOCK_GRACE_MS),
+    ]);
+    expect(state.phase).toBe('locked');
+  });
+
+  it('does not lock one millisecond inside the boundary', () => {
+    const { state } = run([
+      boot({ stampedAt: T0 - 1_000, locked: false }, 'active'),
+      life('active', 'background', T0),
+      life('background', 'active', T0 + LOCK_GRACE_MS - 1),
+    ]);
+    expect(state.phase).toBe('unlocked');
+  });
+
+  it('clears a stale unlock failure when it re-locks', () => {
+    const { state } = run([
+      boot(null, 'active'),
+      { type: 'unlockRejected' },
+      { type: 'unlockSucceeded', now: T0 },
+      life('active', 'background', T0 + 1),
+      life('background', 'active', T0 + 1 + LOCK_GRACE_MS),
+    ]);
+    expect(state.phase).toBe('locked');
+    expect(state.unlockFailed).toBe(false);
+  });
+});
+
+describe('inactive must never start the lock clock', () => {
+  // The Face ID sheet itself flips the app to `inactive`. If that armed the
+  // lock, unlocking would re-arm it — an infinite biometric prompt loop that
+  // makes the app unusable for everyone, not just an edge case.
+  it('does not lock after a long stretch of bare inactive', () => {
+    const { state } = run([
+      boot({ stampedAt: T0 - 1_000, locked: false }, 'active'),
+      life('active', 'inactive', T0),
+      life('inactive', 'active', T0 + LOCK_GRACE_MS * 10),
+    ]);
+    expect(state.phase).toBe('unlocked');
+  });
+
+  it('does not restart the clock on background -> inactive -> background', () => {
+    // Only the FIRST entry into background starts it; a later `inactive` in the
+    // same excursion must not push the timestamp forward.
+    const { state } = run([
+      boot({ stampedAt: T0 - 1_000, locked: false }, 'active'),
+      life('active', 'background', T0),
+      life('background', 'inactive', T0 + LOCK_GRACE_MS - 1),
+      life('inactive', 'active', T0 + LOCK_GRACE_MS),
+    ]);
+    expect(state.phase).toBe('locked');
+  });
+
+  it('still raises the privacy cover on inactive', () => {
+    const { state } = run([
+      boot({ stampedAt: T0 - 1_000, locked: false }, 'active'),
+      life('active', 'inactive', T0),
+    ]);
+    expect(state.obscured).toBe(true);
+  });
+});
+
+describe('what reaches the keychain', () => {
+  it('stamps locked while the cold-launch check is still undecided', () => {
+    // Backgrounding during the keychain read must not stamp "unlocked" over a
+    // launch that was about to lock — a force-quit there would relaunch in.
+    const { lastWrite } = run([life('active', 'background', T0)]);
+    expect(lastWrite).toEqual({ stampedAt: T0, locked: true });
+  });
+
+  it('stamps locked on every transition while the lock screen is up', () => {
+    const { writes } = run([
+      boot(null, 'active'),
+      life('active', 'inactive', T0 + 1),
+      life('inactive', 'background', T0 + 2),
+    ]);
+    expect(writes.every((w) => w.locked)).toBe(true);
+  });
+
+  it('stamps unlocked only after a real unlock', () => {
+    const { lastWrite } = run([
+      boot(null, 'active'),
+      { type: 'unlockSucceeded', now: T0 + 500 },
+    ]);
+    expect(lastWrite).toEqual({ stampedAt: T0 + 500, locked: false });
+  });
+
+  it('re-stamps on resume so a later kill is measured from now', () => {
+    const { lastWrite } = run([
+      boot({ stampedAt: T0 - 1_000, locked: false }, 'active'),
+      life('active', 'background', T0),
+      life('background', 'active', T0 + 1_000),
+    ]);
+    expect(lastWrite).toEqual({ stampedAt: T0 + 1_000, locked: false });
+  });
+
+  it('never writes an unlocked record from a phase the user was not given', () => {
+    // The whole contract in one assertion: sweep every event from every phase
+    // and prove `locked: false` only ever escapes from `unlocked`.
+    const phases: LockPhaseFixture[] = [
+      { label: 'booting', state: initialLockState },
+      { label: 'locked', state: run([boot(null, 'active')]).state },
+      {
+        label: 'unlocked',
+        state: run([boot({ stampedAt: T0 - 1_000, locked: false }, 'active')]).state,
+      },
+    ];
+    const events: LockEvent[] = [
+      life('active', 'inactive', T0),
+      life('active', 'background', T0),
+      life('background', 'active', T0),
+      { type: 'signOutRequested', now: T0 },
+      { type: 'noAuthenticator' },
+      { type: 'authenticatorUnavailable' },
+      { type: 'unlockRejected' },
+    ];
+
+    const violations: string[] = [];
+    for (const { label, state } of phases) {
+      for (const event of events) {
+        const { persist } = reduceLock(state, event, LOCK_GRACE_MS);
+        if (persist && !persist.locked && label !== 'unlocked') {
+          violations.push(`${label} + ${event.type}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});
+
+interface LockPhaseFixture {
+  label: string;
+  state: LockMachineState;
+}
+
+describe('no authenticator on the device', () => {
+  it('unlocks rather than stranding the user', () => {
+    const { state } = run([boot(null, 'active'), { type: 'noAuthenticator' }]);
+    expect(state.phase).toBe('unlocked');
+  });
+
+  it('persists NOTHING, so the concession does not outlive the process', () => {
+    // No authentication happened. Writing an unlocked record here would let a
+    // transient "no authenticator" answer unlock every future launch too.
+    const { writes } = run([boot(null, 'active'), { type: 'noAuthenticator' }]);
+    expect(writes).toEqual([{ stampedAt: T0, locked: true }]);
+  });
+});
+
+describe('device-security check failure', () => {
+  it('stays locked instead of treating an unanswered check as "no authenticator"', () => {
+    const { state } = run([boot(null, 'active'), { type: 'authenticatorUnavailable' }]);
+    expect(state.phase).toBe('locked');
+    expect(state.authUnavailable).toBe(true);
+  });
+
+  it('is cleared by a successful unlock', () => {
+    const { state } = run([
+      boot(null, 'active'),
+      { type: 'authenticatorUnavailable' },
+      { type: 'unlockSucceeded', now: T0 },
+    ]);
+    expect(state.authUnavailable).toBe(false);
+    expect(state.phase).toBe('unlocked');
+  });
+});
+
+describe('sign out from the lock screen', () => {
+  // Clearing the lock optimistically revealed the fleet and every pending
+  // approval while the token was still live — up to the 15s fetch timeout on a
+  // stalled link — and backgrounding in that window stamped the app unlocked.
+  it('keeps the lock up until the session is actually gone', () => {
+    const { state } = run([boot(null, 'active'), { type: 'signOutRequested', now: T0 }]);
+    expect(state.phase).toBe('locked');
+    expect(state.signingOut).toBe(true);
+  });
+
+  it('stamps locked, so a force-quit mid-sign-out cannot relaunch unlocked', () => {
+    const { lastWrite } = run([
+      boot({ stampedAt: T0 - 1_000, locked: false }, 'active'),
+      { type: 'signOutRequested', now: T0 },
+    ]);
+    expect(lastWrite).toEqual({ stampedAt: T0, locked: true });
+  });
+
+  it('keeps stamping locked if the app is backgrounded while signing out', () => {
+    const { lastWrite } = run([
+      boot({ stampedAt: T0 - 1_000, locked: false }, 'active'),
+      { type: 'signOutRequested', now: T0 },
+      life('active', 'background', T0 + 100),
+    ]);
+    expect(lastWrite).toEqual({ stampedAt: T0 + 100, locked: true });
+  });
+
+  it('releases the lock once the session is gone, without covering the login screen', () => {
+    const { state } = run([
+      boot(null, 'active'),
+      { type: 'signOutRequested', now: T0 },
+      { type: 'signedOut' },
+    ]);
+    expect(state.phase).toBe('unlocked');
+    expect(state.obscured).toBe(false);
+    expect(state.signingOut).toBe(false);
+  });
+});
+
+describe('unlock attempts', () => {
+  it('a rejected unlock stays locked and shows the retry copy', () => {
+    const { state } = run([boot(null, 'active'), { type: 'unlockRejected' }]);
+    expect(state.phase).toBe('locked');
+    expect(state.unlockFailed).toBe(true);
+  });
+
+  it('a rejected unlock writes nothing', () => {
+    const before = run([boot(null, 'active')]);
+    const { persist } = reduceLock(before.state, { type: 'unlockRejected' }, LOCK_GRACE_MS);
+    expect(persist).toBeNull();
+  });
+
+  it('a successful unlock clears the failure flag', () => {
+    const { state } = run([
+      boot(null, 'active'),
+      { type: 'unlockRejected' },
+      { type: 'unlockSucceeded', now: T0 },
+    ]);
+    expect(state.phase).toBe('unlocked');
+    expect(state.unlockFailed).toBe(false);
+  });
+});

--- a/apps/mobile/src/services/appLockMachine.ts
+++ b/apps/mobile/src/services/appLockMachine.ts
@@ -1,0 +1,254 @@
+import { type AppLockState, shouldLockOnLaunch } from './appLockState';
+
+/**
+ * The app lock as a pure state machine.
+ *
+ * This logic used to live inline in `navigation/AppLockGate.tsx`. It moved here
+ * because the mobile app has no React Native test runtime — `vitest.config.ts`
+ * deliberately includes only `.ts`, never `.tsx`, so component code cannot be
+ * reached by a test at all. That left the half of the lock that can fail *open*
+ * as the only untested half, and it hid a real bypass: a process launched into
+ * the background (push wake, iOS prewarm) had no `backgroundedAt`, so its first
+ * foregrounding could never lock however long it had been sitting there.
+ *
+ * Everything that decides whether the lock appears now lives in `reduceLock`,
+ * and `AppLockGate` is a thin adapter that forwards events and performs the
+ * writes this returns. Keep it that way: logic added back to the component is
+ * logic no test can see.
+ *
+ * The one rule that governs every branch below: **`unlocked` is the only phase
+ * a user can be given, and only a proven authentication or a proven-recent
+ * record grants it.** Anything unknown, in-flight, or failed stays locked.
+ */
+
+/**
+ * Mirrors React Native's `AppStateStatus` union, restated so this module pulls
+ * no React Native import into the node-only test runtime.
+ */
+export type AppLifecycle = 'active' | 'background' | 'inactive' | 'unknown' | 'extension';
+
+/**
+ * `booting` is distinct from `locked` on purpose: it means the cold-launch
+ * decision has not been made yet, so nothing may be *shown* — but for the
+ * purpose of what gets written to disk it is treated exactly like `locked`,
+ * which is what stops a background-during-boot from stamping the app unlocked.
+ */
+export type LockPhase = 'booting' | 'locked' | 'unlocked';
+
+export interface LockMachineState {
+  phase: LockPhase;
+  /** Whether the app-switcher privacy cover should be up. */
+  obscured: boolean;
+  /**
+   * When the app was last provably outside the foreground, or null when it is
+   * in the foreground. Seeded at boot from the persisted record so that a
+   * process which launched in the background still measures its idle time.
+   */
+  backgroundedAt: number | null;
+  /** Whether the cold-launch check has run. It runs at most once per process. */
+  bootDecided: boolean;
+  /** The last unlock attempt was rejected — drives the retry copy. */
+  unlockFailed: boolean;
+  /** The device-security check itself failed, as opposed to reporting none. */
+  authUnavailable: boolean;
+  /** A sign-out is in flight; the lock stays up until the session is gone. */
+  signingOut: boolean;
+}
+
+export type LockEvent =
+  /** The persisted record came back from the keychain. */
+  | { type: 'bootResolved'; record: AppLockState | null; lifecycle: AppLifecycle; now: number }
+  | { type: 'lifecycle'; prev: AppLifecycle; next: AppLifecycle; now: number }
+  | { type: 'unlockSucceeded'; now: number }
+  | { type: 'unlockRejected' }
+  /** The device has no biometrics and no passcode. */
+  | { type: 'noAuthenticator' }
+  /** The device-security check could not be completed. */
+  | { type: 'authenticatorUnavailable' }
+  | { type: 'signOutRequested'; now: number }
+  /** The session is gone — the login screen is showing. */
+  | { type: 'signedOut' };
+
+export interface LockReduction {
+  state: LockMachineState;
+  /** The record to persist, or null to leave the keychain untouched. */
+  persist: AppLockState | null;
+}
+
+export const initialLockState: LockMachineState = {
+  phase: 'booting',
+  obscured: false,
+  backgroundedAt: null,
+  bootDecided: false,
+  unlockFailed: false,
+  authUnavailable: false,
+  signingOut: false,
+};
+
+/**
+ * What to write for a given phase. `booting` persists as locked — see
+ * {@link LockPhase} — so the only way a `locked: false` record reaches the
+ * keychain is from a phase the user was actually given.
+ */
+function stamp(phase: LockPhase, now: number): AppLockState {
+  return { stampedAt: now, locked: phase !== 'unlocked' };
+}
+
+/** The older of two optional timestamps; null only when both are null. */
+function earlier(a: number | null, b: number | null): number | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return Math.min(a, b);
+}
+
+export function reduceLock(
+  state: LockMachineState,
+  event: LockEvent,
+  graceMs: number
+): LockReduction {
+  switch (event.type) {
+    case 'bootResolved': {
+      // At most once per process. A second session in the same process (sign
+      // out, sign back in) is an interactive authentication, not a cold launch.
+      if (state.bootDecided) return { state, persist: null };
+
+      const { record, lifecycle, now } = event;
+      // A lock already decided by a lifecycle event that landed while the read
+      // was in flight must not be undone by the read's own verdict.
+      const lock = shouldLockOnLaunch(record, now, graceMs) || state.phase === 'locked';
+
+      // The bypass this seeding closes: a process launched straight into the
+      // background never observes an `active` -> `background` transition, so
+      // without a seed its `backgroundedAt` stays null and the first tap on the
+      // icon finds nothing to measure — opening the fleet however many hours
+      // later. Seed from the record so the elapsed test still applies, and take
+      // the *older* of the two candidates so a transition already seen in this
+      // process cannot shorten the window.
+      const seed = lifecycle === 'active' ? null : (record?.stampedAt ?? now);
+
+      return {
+        state: {
+          ...state,
+          bootDecided: true,
+          phase: lock ? 'locked' : 'unlocked',
+          unlockFailed: false,
+          obscured: lifecycle !== 'active',
+          backgroundedAt: lock ? null : earlier(state.backgroundedAt, seed),
+        },
+        // Make the lock durable immediately rather than waiting for the next
+        // lifecycle event, which a force-quit may never deliver.
+        persist: lock ? stamp('locked', now) : null,
+      };
+    }
+
+    case 'lifecycle': {
+      const { prev, next, now } = event;
+
+      if (next === 'active') {
+        const since = state.backgroundedAt;
+        const lockNow = since !== null && now - since >= graceMs;
+        // Never downgrade an existing lock, and never resolve `booting` here —
+        // that is `bootResolved`'s job, and until it runs this still persists
+        // as locked.
+        const phase: LockPhase =
+          state.phase === 'locked' || lockNow ? 'locked' : state.phase;
+
+        return {
+          state: {
+            ...state,
+            phase,
+            obscured: false,
+            backgroundedAt: null,
+            unlockFailed: phase === 'locked' && state.phase !== 'locked' ? false : state.unlockFailed,
+          },
+          // Re-stamp on the way in so a kill later in this session is measured
+          // from now rather than from whenever the app last backgrounded.
+          persist: stamp(phase, now),
+        };
+      }
+
+      // Only a real background starts the lock clock. `inactive` is transient
+      // (Face ID sheet, Control Centre, call banner) and must not — in
+      // particular the unlock prompt itself flips us to `inactive`, so treating
+      // that as a lock trigger would make unlocking re-arm the lock.
+      const backgroundedAt =
+        next === 'background' && prev !== 'background' ? now : state.backgroundedAt;
+
+      return {
+        // Cover on `inactive`, not just `background`: iOS snapshots the UI on
+        // the way out to build the app-switcher card and writes that image to
+        // disk.
+        state: { ...state, obscured: true, backgroundedAt },
+        // Stamp here too. A force-quit from the app switcher may only ever
+        // deliver `inactive`, and this write is fire-and-forget — if iOS
+        // suspends us before it lands, the record is simply stale or absent,
+        // both of which lock.
+        persist: stamp(state.phase, now),
+      };
+    }
+
+    case 'unlockSucceeded':
+      return {
+        state: {
+          ...state,
+          phase: 'unlocked',
+          unlockFailed: false,
+          authUnavailable: false,
+          signingOut: false,
+        },
+        persist: stamp('unlocked', event.now),
+      };
+
+    case 'unlockRejected':
+      return { state: { ...state, unlockFailed: true }, persist: null };
+
+    case 'noAuthenticator':
+      // A device with neither biometrics nor a passcode cannot satisfy the
+      // prompt, and locking against an authenticator that does not exist would
+      // strand the user with no way back in. The device itself is unprotected
+      // in that case, so an app lock adds nothing anyway.
+      //
+      // Deliberately persists NOTHING. No authentication happened here, so
+      // writing an unlocked record would make this concession outlive the
+      // process — and it costs nothing to omit, because a device with no
+      // passcode reaches this same branch again on the next launch.
+      return {
+        state: { ...state, phase: 'unlocked', unlockFailed: false, authUnavailable: false },
+        persist: null,
+      };
+
+    case 'authenticatorUnavailable':
+      // Distinct from `noAuthenticator`: the check did not answer, so we do not
+      // know whether an authenticator exists. Treating that as "none" would
+      // turn a transient native failure into an unlock — fail closed instead
+      // and leave the user the Sign out escape.
+      return { state: { ...state, phase: 'locked', authUnavailable: true }, persist: null };
+
+    case 'signOutRequested':
+      // The lock must NOT lift here. Clearing it optimistically revealed the
+      // fleet and every pending approval for as long as the logout request took
+      // to settle — up to the 15s fetch timeout on a stalled link — while the
+      // token was still live. Stay locked until the session is actually gone.
+      return {
+        state: { ...state, phase: 'locked', signingOut: true, unlockFailed: false },
+        persist: stamp('locked', event.now),
+      };
+
+    case 'signedOut':
+      // No session, nothing to protect — and covering the login screen would
+      // just make sign-in flicker. `bootDecided` deliberately survives: the
+      // cold launch already happened.
+      return {
+        state: {
+          ...state,
+          phase: 'unlocked',
+          obscured: false,
+          backgroundedAt: null,
+          unlockFailed: false,
+          authUnavailable: false,
+          signingOut: false,
+        },
+        persist: null,
+      };
+  }
+}

--- a/apps/mobile/src/services/appLockState.test.ts
+++ b/apps/mobile/src/services/appLockState.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+// No mocks: this module deliberately imports nothing, so the security-critical
+// logic is reachable from the node-only runtime. See appLockStore.test.ts for
+// the keychain half.
+import {
+  LOCK_GRACE_MS,
+  parseAppLockState,
+  shouldLockOnLaunch,
+  type AppLockState,
+} from './appLockState';
+
+const NOW = 1_800_000_000_000;
+
+describe('shouldLockOnLaunch', () => {
+  it('locks when there is no record at all', () => {
+    // First launch after this shipped, a wiped keychain, or a failed write.
+    expect(shouldLockOnLaunch(null, NOW, LOCK_GRACE_MS)).toBe(true);
+  });
+
+  it('locks when the app was already locked when the record was written', () => {
+    // Force-quitting at the lock screen must not be a way past it, however
+    // recent the record is.
+    expect(shouldLockOnLaunch({ stampedAt: NOW - 1, locked: true }, NOW, LOCK_GRACE_MS)).toBe(true);
+  });
+
+  it('does not lock inside the grace window', () => {
+    const record = { stampedAt: NOW - (LOCK_GRACE_MS - 1), locked: false };
+    expect(shouldLockOnLaunch(record, NOW, LOCK_GRACE_MS)).toBe(false);
+  });
+
+  it('locks exactly at the grace boundary', () => {
+    const record = { stampedAt: NOW - LOCK_GRACE_MS, locked: false };
+    expect(shouldLockOnLaunch(record, NOW, LOCK_GRACE_MS)).toBe(true);
+  });
+
+  it('locks well past the grace window', () => {
+    const record = { stampedAt: NOW - LOCK_GRACE_MS * 60, locked: false };
+    expect(shouldLockOnLaunch(record, NOW, LOCK_GRACE_MS)).toBe(true);
+  });
+
+  it('locks when the clock has moved backwards since the record was written', () => {
+    // Both a tampering signal and a case where elapsed time means nothing.
+    expect(shouldLockOnLaunch({ stampedAt: NOW + 5_000, locked: false }, NOW, LOCK_GRACE_MS)).toBe(
+      true
+    );
+  });
+
+  it('locks when the elapsed time is not finite', () => {
+    expect(shouldLockOnLaunch({ stampedAt: NOW, locked: false }, Number.NaN, LOCK_GRACE_MS)).toBe(
+      true
+    );
+  });
+
+  it('defaults graceMs, so the production call cannot transpose its arguments', () => {
+    // `shouldLockOnLaunch(record, Date.now())` takes two parameters of
+    // incompatible meaning; passing the grace where `now` belongs would be a
+    // silent wrong answer, so the two-argument form is the one call sites use.
+    const inside = { stampedAt: NOW - (LOCK_GRACE_MS - 1), locked: false };
+    const outside = { stampedAt: NOW - LOCK_GRACE_MS, locked: false };
+    expect(shouldLockOnLaunch(inside, NOW)).toBe(false);
+    expect(shouldLockOnLaunch(outside, NOW)).toBe(true);
+  });
+});
+
+describe('parseAppLockState', () => {
+  it('accepts a well-formed record', () => {
+    expect(parseAppLockState('{"stampedAt":123,"locked":true}')).toEqual({
+      stampedAt: 123,
+      locked: true,
+    });
+  });
+
+  it('ignores unknown keys — schema changes bump the storage key instead', () => {
+    expect(parseAppLockState('{"stampedAt":123,"locked":false,"v":2}')).toEqual({
+      stampedAt: 123,
+      locked: false,
+    });
+  });
+
+  it.each([
+    ['a missing key', null],
+    ['unparseable JSON', '{'],
+    ['a JSON scalar', '42'],
+    ['a JSON null', 'null'],
+    ['an array', '[]'],
+    ['a missing timestamp', '{"locked":false}'],
+    ['a null timestamp', '{"stampedAt":null,"locked":false}'],
+    ['a non-numeric timestamp', '{"stampedAt":"123","locked":false}'],
+    // JSON.stringify(Infinity) is "null", so our own writer cannot produce
+    // this — it only arrives from a hand-forged keychain item. Without the
+    // Number.isFinite half of the guard this parses, which is why the case is
+    // spelled out rather than folded into the null row above.
+    ['a non-finite timestamp', '{"stampedAt":1e999,"locked":false}'],
+    ['a missing locked flag', '{"stampedAt":123}'],
+    ['a non-boolean locked flag', '{"stampedAt":123,"locked":"false"}'],
+  ])('rejects %s', (_label, raw) => {
+    expect(parseAppLockState(raw)).toBeNull();
+  });
+
+  it('feeds a rejected record into a lock, not an unlock', () => {
+    // The two halves have to compose this way round: a forged or truncated
+    // keychain item must not be a way past the gate.
+    expect(shouldLockOnLaunch(parseAppLockState('{"stampedAt":0}'), 0, LOCK_GRACE_MS)).toBe(true);
+  });
+
+  it('round-trips a record it produced itself', () => {
+    const record: AppLockState = { stampedAt: NOW, locked: false };
+    expect(parseAppLockState(JSON.stringify(record))).toEqual(record);
+  });
+});

--- a/apps/mobile/src/services/appLockState.ts
+++ b/apps/mobile/src/services/appLockState.ts
@@ -1,0 +1,111 @@
+/**
+ * Cold-launch half of the app lock (see navigation/AppLockGate.tsx).
+ *
+ * `AppLockGate` only ever saw background → foreground transitions *within one
+ * process*. A cold launch — the technician swiping the app out of the switcher,
+ * or iOS reaping it under memory pressure — restored the session straight from
+ * the keychain with no challenge, because `services/auth.ts storeToken`
+ * persisted the token without `requireAuthentication` and nothing gated the
+ * restore in `navigation/RootNavigator.tsx checkAuth`.
+ *
+ * That made the same user gesture ("close the app, open it again") lock or not
+ * lock depending on whether iOS happened to keep the process alive, which reads
+ * as a flaky regression rather than the design gap it was.
+ *
+ * This module is the pure half: the record's shape, its parser, and the
+ * cold-launch decision. `appLockStore.ts` performs the keychain I/O and
+ * `appLockMachine.ts` owns the rest of the decisions. It deliberately imports
+ * nothing — not expo-secure-store, not Sentry — so the security-critical logic
+ * stays reachable from the node-only vitest runtime.
+ *
+ * Everything here is **fail-secure** — an absent, malformed, or
+ * unreadable record locks. The only cost of a false lock is one Face ID prompt;
+ * the cost of a false unlock is an unauthenticated stranger holding a console
+ * for someone else's fleet.
+ */
+export const APP_LOCK_STATE_KEY = 'breeze.applock.state.v1';
+
+/**
+ * How long the app may sit outside the foreground before it locks. Short enough
+ * that a phone left on a desk locks, long enough that hopping to the
+ * authenticator app or a password manager and straight back does not demand
+ * Face ID.
+ *
+ * Lives here rather than in `AppLockGate.tsx` so the decision logic can be
+ * unit-tested without pulling React Native into the node-only vitest runtime.
+ */
+export const LOCK_GRACE_MS = 60_000;
+
+export interface AppLockState {
+  /**
+   * `Date.now()` at the last lifecycle transition or authentication event —
+   * the most recent moment the session was provably live. Note this is NOT
+   * specifically the departure from `active`: `appLockMachine` also re-stamps
+   * on resume, on unlock, and on interactive sign-in.
+   */
+  stampedAt: number;
+  /**
+   * Whether the app was locked at that moment. Exists solely so that
+   * force-quitting *at* the lock screen and relaunching is not an unlock.
+   */
+  locked: boolean;
+}
+
+/**
+ * Parse a persisted record, returning null for anything we did not write.
+ *
+ * Deliberately strict about the fields it knows: a truncated write or a
+ * hand-forged value collapses to null, which {@link shouldLockOnLaunch} treats
+ * as "lock". Being lenient here would let a tampered keychain item unlock the
+ * app. Unknown extra keys are ignored — schema changes are handled by bumping
+ * {@link APP_LOCK_STATE_KEY}, not here, and a v2 reader simply finds nothing
+ * under its own key and locks.
+ */
+export function parseAppLockState(raw: string | null): AppLockState | null {
+  if (raw === null) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const { stampedAt, locked } = parsed as Record<string, unknown>;
+
+  if (typeof stampedAt !== 'number' || !Number.isFinite(stampedAt)) return null;
+  if (typeof locked !== 'boolean') return null;
+
+  return { stampedAt, locked };
+}
+
+/**
+ * Decide whether a cold launch that restores a session must show the lock.
+ *
+ * Pure so the whole truth table is testable. Returns true when:
+ *  - there is no record at all (first launch after this shipped, a failed
+ *    write, a wiped keychain) — we cannot prove the app was recently in use;
+ *  - the app was already locked when the record was written, so force-quitting
+ *    at the lock screen and relaunching must not be an unlock;
+ *  - more than `graceMs` has elapsed, matching the in-process rule;
+ *  - the elapsed time is not a finite number;
+ *  - the clock moved backwards since the record was written, which is both a
+ *    tampering signal and a case where the elapsed-time test is meaningless.
+ *
+ * `graceMs` is defaulted so the production call site passes two arguments of
+ * incompatible meaning and cannot silently transpose them.
+ */
+export function shouldLockOnLaunch(
+  record: AppLockState | null,
+  nowMs: number,
+  graceMs: number = LOCK_GRACE_MS
+): boolean {
+  if (record === null) return true;
+  if (record.locked) return true;
+
+  const elapsed = nowMs - record.stampedAt;
+  if (!Number.isFinite(elapsed) || elapsed < 0) return true;
+
+  return elapsed >= graceMs;
+}

--- a/apps/mobile/src/services/appLockStore.test.ts
+++ b/apps/mobile/src/services/appLockStore.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { APP_LOCK_STATE_KEY, LOCK_GRACE_MS, shouldLockOnLaunch } from './appLockState';
+import {
+  markAppLockUnlocked,
+  readAppLockState,
+  resetAppLockReportingForTests,
+  writeAppLockState,
+} from './appLockStore';
+
+const secureStore = {
+  getItemAsync: vi.fn(),
+  setItemAsync: vi.fn(),
+};
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: (...a: unknown[]) => secureStore.getItemAsync(...a),
+  setItemAsync: (...a: unknown[]) => secureStore.setItemAsync(...a),
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
+}));
+
+const sentry = { captureException: vi.fn() };
+vi.mock('@sentry/react-native', () => ({
+  captureException: (...a: unknown[]) => sentry.captureException(...a),
+}));
+
+beforeEach(() => {
+  secureStore.getItemAsync.mockReset().mockResolvedValue(null);
+  secureStore.setItemAsync.mockReset().mockResolvedValue(undefined);
+  sentry.captureException.mockReset();
+  resetAppLockReportingForTests();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('readAppLockState', () => {
+  it('reads the versioned key', async () => {
+    await readAppLockState();
+    expect(secureStore.getItemAsync).toHaveBeenCalledWith(APP_LOCK_STATE_KEY);
+  });
+
+  it('returns the parsed record', async () => {
+    secureStore.getItemAsync.mockResolvedValue('{"stampedAt":7,"locked":false}');
+    expect(await readAppLockState()).toEqual({ stampedAt: 7, locked: false });
+  });
+
+  it('reports a SecureStore failure as null, so the caller locks', async () => {
+    secureStore.getItemAsync.mockRejectedValue(new Error('keychain locked'));
+    const record = await readAppLockState();
+    expect(record).toBeNull();
+    expect(shouldLockOnLaunch(record, 0, LOCK_GRACE_MS)).toBe(true);
+  });
+
+  it('reports an unreadable keychain to Sentry', async () => {
+    // console.* goes nowhere a developer can see on a production TestFlight
+    // build, and all three failure modes present identically as "the app keeps
+    // asking for Face ID".
+    secureStore.getItemAsync.mockRejectedValue(new Error('keychain locked'));
+    await readAppLockState();
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(sentry.captureException.mock.calls[0][1]).toMatchObject({
+      tags: { area: 'app-lock-state-read' },
+    });
+  });
+
+  it('reports a malformed record separately — it should be impossible', async () => {
+    secureStore.getItemAsync.mockResolvedValue('{"stampedAt":"nope"}');
+    expect(await readAppLockState()).toBeNull();
+    expect(sentry.captureException.mock.calls[0][1]).toMatchObject({
+      tags: { area: 'app-lock-state-malformed' },
+    });
+  });
+
+  it('does NOT report an absent record — that is every first launch', async () => {
+    secureStore.getItemAsync.mockResolvedValue(null);
+    expect(await readAppLockState()).toBeNull();
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+});
+
+describe('writeAppLockState', () => {
+  it('persists device-only, so the record never rides an iCloud keychain', async () => {
+    await writeAppLockState({ stampedAt: 1, locked: false });
+    expect(secureStore.setItemAsync).toHaveBeenCalledWith(
+      APP_LOCK_STATE_KEY,
+      '{"stampedAt":1,"locked":false}',
+      { keychainAccessible: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY' }
+    );
+  });
+
+  it('swallows a write failure', async () => {
+    // Callers are mostly lifecycle handlers on the way to the background with
+    // no UI to report into, and a missed write degrades to a lock, not unlock.
+    secureStore.setItemAsync.mockRejectedValue(new Error('keychain locked'));
+    await expect(writeAppLockState({ stampedAt: 1, locked: false })).resolves.toBeUndefined();
+  });
+
+  it('reports a write failure to Sentry at most once per process', async () => {
+    // Writes fire on every lifecycle transition, so an unreadable keychain
+    // would otherwise emit one Sentry event per app switch.
+    secureStore.setItemAsync.mockRejectedValue(new Error('keychain locked'));
+    for (let i = 0; i < 5; i++) await writeAppLockState({ stampedAt: i, locked: false });
+    expect(secureStore.setItemAsync).toHaveBeenCalledTimes(5);
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('markAppLockUnlocked', () => {
+  it('stamps an unlocked record at the current time', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(4_242);
+    await markAppLockUnlocked();
+    expect(secureStore.setItemAsync).toHaveBeenCalledWith(
+      APP_LOCK_STATE_KEY,
+      '{"stampedAt":4242,"locked":false}',
+      expect.anything()
+    );
+  });
+
+  it('leaves a just-signed-in session unlocked on the cold-launch check', async () => {
+    // The gate cannot otherwise tell a token restored from the keychain from
+    // one the user just earned with a password.
+    vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    await markAppLockUnlocked();
+    const [, raw] = secureStore.setItemAsync.mock.calls[0];
+    expect(shouldLockOnLaunch(JSON.parse(raw as string), 1_000, LOCK_GRACE_MS)).toBe(false);
+  });
+});

--- a/apps/mobile/src/services/appLockStore.ts
+++ b/apps/mobile/src/services/appLockStore.ts
@@ -1,0 +1,105 @@
+import * as SecureStore from 'expo-secure-store';
+import * as Sentry from '@sentry/react-native';
+
+import { APP_LOCK_STATE_KEY, type AppLockState, parseAppLockState } from './appLockState';
+
+/**
+ * Keychain I/O for the app-lock record.
+ *
+ * Split from `appLockState.ts` so that the record's shape, its parser, and the
+ * cold-launch decision stay importable without expo-secure-store or Sentry —
+ * `vitest.config.ts` runs on node with no React Native runtime, so any module
+ * that reaches a native import takes its whole dependency tree out of test
+ * range. Only this file is untestable-by-mock; the logic is not.
+ */
+
+/**
+ * Read the persisted record. Both failure modes report null, which locks — see
+ * the fail-secure note in `appLockState.ts`.
+ *
+ * The two are reported to Sentry separately because they mean very different
+ * things: an unreadable keychain is an environment problem, while a *malformed*
+ * record should be impossible and may indicate tampering. `console.*` is not
+ * enough on its own — on a production TestFlight build it goes nowhere a
+ * developer can see, which is the same reasoning `clearAuthData` records.
+ */
+export async function readAppLockState(): Promise<AppLockState | null> {
+  let raw: string | null;
+  try {
+    raw = await SecureStore.getItemAsync(APP_LOCK_STATE_KEY);
+  } catch (error) {
+    console.error('Error reading app lock state:', error);
+    reportOnce('read', error);
+    return null;
+  }
+
+  const record = parseAppLockState(raw);
+  if (record === null && raw !== null) {
+    console.error('Discarding malformed app lock state');
+    reportOnce('malformed', new Error('Malformed app lock state record'));
+  }
+  return record;
+}
+
+/**
+ * Persist the record. Failures are swallowed rather than surfaced: no caller
+ * has a sensible place to report into — most are lifecycle handlers on the way
+ * to the background — and a missed write degrades to a lock on the next launch,
+ * never to an unlock.
+ */
+export async function writeAppLockState(state: AppLockState): Promise<void> {
+  try {
+    await SecureStore.setItemAsync(APP_LOCK_STATE_KEY, JSON.stringify(state), {
+      keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    });
+  } catch (error) {
+    console.error('Error writing app lock state:', error);
+    reportOnce('write', error);
+  }
+}
+
+/**
+ * Record that the user just authenticated interactively.
+ *
+ * Called from the login / MFA thunks rather than from `storeToken`, because
+ * `storeToken` only means "a token exists", not "a human just authenticated" —
+ * it is also the token-refresh path (today only `services/aiChat.ts`), and a
+ * refresh firing while the lock screen is up would otherwise stamp the app
+ * unlocked, letting a force-quit at that screen relaunch straight in.
+ *
+ * Without this, the first sign-in of a process would be met by the cold-launch
+ * lock a moment later: the gate cannot otherwise tell a token restored from the
+ * keychain from one the user just earned with a password. A silently failed
+ * write here therefore costs one spurious Face ID prompt — fail-secure, but the
+ * reason the write path reports to Sentry.
+ */
+export async function markAppLockUnlocked(): Promise<void> {
+  await writeAppLockState({ stampedAt: Date.now(), locked: false });
+}
+
+/**
+ * Report each failure kind at most once per process.
+ *
+ * Writes fire on every lifecycle transition, so an unreadable keychain would
+ * otherwise flood Sentry with one event per app switch. One event per kind is
+ * enough to tell "the keychain is broken on this device" from "the grace window
+ * is miscalculated", which is the distinction you cannot make from the field
+ * otherwise — all three failure modes present identically as "the app keeps
+ * asking for Face ID".
+ */
+type FailureKind = 'read' | 'write' | 'malformed';
+const reported = new Set<FailureKind>();
+
+function reportOnce(kind: FailureKind, error: unknown): void {
+  if (reported.has(kind)) return;
+  reported.add(kind);
+  Sentry.captureException(error instanceof Error ? error : new Error(String(error)), {
+    tags: { area: `app-lock-state-${kind}` },
+    ...(error instanceof Error ? {} : { extra: { raw: error } }),
+  });
+}
+
+/** Test seam — the once-per-process guard would otherwise leak between cases. */
+export function resetAppLockReportingForTests(): void {
+  reported.clear();
+}

--- a/apps/mobile/src/services/auth.test.ts
+++ b/apps/mobile/src/services/auth.test.ts
@@ -23,6 +23,16 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe('clearAuthData', () => {
+  it('removes the app-lock record, so no stale unlock outlives the session', async () => {
+    // The record is a standing assertion that THIS device is currently
+    // unlocked. If the token delete below fails, the surviving token restores
+    // on the next launch and a leftover `locked: false` waves it past the gate.
+    await clearAuthData();
+
+    const keys = secureStore.deleteItemAsync.mock.calls.map((c) => c[0]);
+    expect(keys).toContain('breeze.applock.state.v1');
+  });
+
   it('removes the auth token, the stored user, and the persistent approvals cache', async () => {
     await clearAuthData();
 

--- a/apps/mobile/src/services/auth.ts
+++ b/apps/mobile/src/services/auth.ts
@@ -2,6 +2,7 @@ import * as SecureStore from 'expo-secure-store';
 import * as Sentry from '@sentry/react-native';
 import type { User } from './api';
 import { APPROVAL_CACHE_KEY, clearApprovalCacheOrThrow } from './approvalCache';
+import { APP_LOCK_STATE_KEY } from './appLockState';
 
 const TOKEN_KEY = 'breeze_auth_token';
 const USER_KEY = 'breeze_user';
@@ -113,6 +114,12 @@ export async function clearAuthData(): Promise<void> {
     { key: TOKEN_KEY, run: () => SecureStore.deleteItemAsync(TOKEN_KEY) },
     { key: USER_KEY, run: () => SecureStore.deleteItemAsync(USER_KEY) },
     { key: APPROVAL_CACHE_KEY, run: () => clearApprovalCacheOrThrow() },
+    // The app-lock record is a standing assertion that THIS device is currently
+    // unlocked. Left behind, a stale `locked: false` outlives the session it
+    // describes: if the token delete below fails, the surviving token restores
+    // on the next launch and the leftover record waves it straight past the
+    // lock. Deleting is the fail-secure direction — an absent record locks.
+    { key: APP_LOCK_STATE_KEY, run: () => SecureStore.deleteItemAsync(APP_LOCK_STATE_KEY) },
   ];
 
   const results = await Promise.allSettled(deletions.map((d) => d.run()));

--- a/apps/mobile/src/services/biometrics.ts
+++ b/apps/mobile/src/services/biometrics.ts
@@ -163,10 +163,14 @@ export async function authenticateIfEnabled(): Promise<boolean> {
  * Get the security level of the device
  */
 export async function getSecurityLevel(): Promise<LocalAuthentication.SecurityLevel> {
-  try {
-    return await LocalAuthentication.getEnrolledLevelAsync();
-  } catch (error) {
-    console.error('Error getting security level:', error);
-    return LocalAuthentication.SecurityLevel.NONE;
-  }
+  // Deliberately does NOT swallow, unlike its neighbours in this file.
+  //
+  // Its only caller is the app lock (navigation/AppLockGate.tsx), where
+  // `SecurityLevel.NONE` means "this device has no authenticator, so do not
+  // lock" — an unlock. Returning NONE on a failed check would therefore turn a
+  // transient native error into a silent bypass of a security control, and
+  // would do it invisibly: the caller's own `.catch` could never fire, so the
+  // fail-open would look defended. Let it throw so the caller can tell "no
+  // authenticator exists" from "I could not find out" and fail closed.
+  return LocalAuthentication.getEnrolledLevelAsync();
 }

--- a/apps/mobile/src/store/authSlice.test.ts
+++ b/apps/mobile/src/store/authSlice.test.ts
@@ -26,6 +26,11 @@ vi.mock('../services/auth', () => ({
   storeUser: (...a: unknown[]) => auth.storeUser(...a),
 }));
 
+const appLock = { markAppLockUnlocked: vi.fn() };
+vi.mock('../services/appLockStore', () => ({
+  markAppLockUnlocked: (...a: unknown[]) => appLock.markAppLockUnlocked(...a),
+}));
+
 const sentry = { captureException: vi.fn() };
 vi.mock('@sentry/react-native', () => ({
   captureException: (...a: unknown[]) => sentry.captureException(...a),
@@ -55,10 +60,112 @@ const fakeUser: User = {
 
 beforeEach(() => {
   api.logout.mockReset().mockResolvedValue(undefined);
+  api.login.mockReset();
+  api.verifyMfa.mockReset();
   auth.clearAuthData.mockReset().mockResolvedValue(undefined);
+  auth.storeToken.mockReset().mockResolvedValue(undefined);
+  auth.storeUser.mockReset().mockResolvedValue(undefined);
+  appLock.markAppLockUnlocked.mockReset().mockResolvedValue(undefined);
   sentry.captureException.mockReset();
 });
 afterEach(() => vi.restoreAllMocks());
+
+describe('interactive sign-in stamps the app lock as unlocked', () => {
+  // navigation/AppLockGate.tsx runs its cold-launch check the first time a
+  // process sees a token, and cannot tell one restored from the keychain from
+  // one just earned with a password. Without this stamp the gate would throw a
+  // Face ID prompt at the user a moment after they finished typing it.
+  it('loginAsync marks unlocked once the token is stored', async () => {
+    api.login.mockResolvedValue({ kind: 'ok', token: 'tok-1', user: fakeUser });
+    const store = makeStore();
+
+    const result = await store.dispatch(loginAsync({ email: fakeUser.email, password: 'pw' }));
+
+    expect(result.type).toBe('auth/login/fulfilled');
+    expect(appLock.markAppLockUnlocked).toHaveBeenCalledTimes(1);
+    expect(auth.storeToken).toHaveBeenCalledWith('tok-1');
+  });
+
+  it('stamps only after the credentials are fully persisted', async () => {
+    // storeUser throws on failure, so a login the user was told failed must not
+    // leave an "unlocked" stamp behind. Ordering, not just presence.
+    api.login.mockResolvedValue({ kind: 'ok', token: 'tok-1', user: fakeUser });
+    const store = makeStore();
+
+    await store.dispatch(loginAsync({ email: fakeUser.email, password: 'pw' }));
+
+    const order = [
+      auth.storeToken.mock.invocationCallOrder[0],
+      auth.storeUser.mock.invocationCallOrder[0],
+      appLock.markAppLockUnlocked.mock.invocationCallOrder[0],
+    ];
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+  });
+
+  it('does NOT stamp when persisting the user fails', async () => {
+    api.login.mockResolvedValue({ kind: 'ok', token: 'tok-1', user: fakeUser });
+    auth.storeUser.mockRejectedValue(new Error('keychain locked'));
+    const store = makeStore();
+
+    const result = await store.dispatch(loginAsync({ email: fakeUser.email, password: 'pw' }));
+
+    expect(result.type).toBe('auth/login/rejected');
+    expect(appLock.markAppLockUnlocked).not.toHaveBeenCalled();
+  });
+
+  it('a failed stamp does not fail the login', async () => {
+    // writeAppLockState swallows, so this cannot happen today — pin it, because
+    // a throw here would reject a login whose token is already in the keychain.
+    // The cost of a silently missed stamp is one spurious Face ID prompt.
+    api.login.mockResolvedValue({ kind: 'ok', token: 'tok-1', user: fakeUser });
+    appLock.markAppLockUnlocked.mockRejectedValue(new Error('keychain locked'));
+    const store = makeStore();
+
+    const result = await store.dispatch(loginAsync({ email: fakeUser.email, password: 'pw' }));
+
+    expect(result.type).toBe('auth/login/fulfilled');
+  });
+
+  it('loginAsync does NOT mark unlocked when MFA is still outstanding', async () => {
+    // The user has not authenticated yet — stamping here would leave the app
+    // unlocked on the strength of a password alone.
+    api.login.mockResolvedValue({ kind: 'mfaRequired', challenge: { tempToken: 'tmp' } });
+    const store = makeStore();
+
+    await store.dispatch(loginAsync({ email: fakeUser.email, password: 'pw' }));
+
+    expect(appLock.markAppLockUnlocked).not.toHaveBeenCalled();
+  });
+
+  it('loginAsync does NOT mark unlocked when the API rejects', async () => {
+    api.login.mockRejectedValue({ message: 'bad credentials' });
+    const store = makeStore();
+
+    await store.dispatch(loginAsync({ email: fakeUser.email, password: 'pw' }));
+
+    expect(appLock.markAppLockUnlocked).not.toHaveBeenCalled();
+  });
+
+  it('verifyMfaAsync marks unlocked once the token is stored', async () => {
+    api.verifyMfa.mockResolvedValue({ token: 'tok-2', user: fakeUser });
+    const store = makeStore();
+
+    const result = await store.dispatch(verifyMfaAsync({ code: '123456', tempToken: 'tmp' }));
+
+    expect(result.type).toBe('auth/verifyMfa/fulfilled');
+    expect(appLock.markAppLockUnlocked).toHaveBeenCalledTimes(1);
+    expect(auth.storeToken).toHaveBeenCalledWith('tok-2');
+  });
+
+  it('verifyMfaAsync does NOT mark unlocked when the code is wrong', async () => {
+    api.verifyMfa.mockRejectedValue({ message: 'invalid code' });
+    const store = makeStore();
+
+    await store.dispatch(verifyMfaAsync({ code: '000000', tempToken: 'tmp' }));
+
+    expect(appLock.markAppLockUnlocked).not.toHaveBeenCalled();
+  });
+});
 
 describe('logoutAsync', () => {
   it('API ok + wipe ok → fulfilled, wipe runs exactly once', async () => {

--- a/apps/mobile/src/store/authSlice.ts
+++ b/apps/mobile/src/store/authSlice.ts
@@ -9,6 +9,7 @@ import {
   type User,
 } from '../services/api';
 import { storeToken, storeUser, clearAuthData } from '../services/auth';
+import { markAppLockUnlocked } from '../services/appLockStore';
 
 export type PushRegistrationStatus = 'idle' | 'ok' | 'failed' | 'unsupported';
 
@@ -69,6 +70,17 @@ export const loginAsync = createAsyncThunk(
 
       await storeToken(result.token);
       await storeUser(result.user);
+      // Last, and awaited: `storeUser` throws, and a login the user was told
+      // failed must not leave an "unlocked" stamp behind. Awaited because the
+      // token only reaches Redux on `fulfilled`, and the token reaching Redux
+      // is what triggers the cold-launch check that reads this record.
+      //
+      // Never allowed to fail the login, whose credentials are already in the
+      // keychain by now — rejecting here would strand the user on the login
+      // screen with a session that restores on the next launch anyway. A missed
+      // stamp costs one spurious Face ID prompt, and appLockStore has already
+      // reported it to Sentry.
+      await markAppLockUnlocked().catch(() => {});
 
       return { token: result.token, user: result.user, registerGrant: result.registerGrant };
     } catch (error: unknown) {
@@ -85,6 +97,7 @@ export const verifyMfaAsync = createAsyncThunk(
       const response = await apiVerifyMfa(code, tempToken);
       await storeToken(response.token);
       await storeUser(response.user);
+      await markAppLockUnlocked().catch(() => {});
       return response;
     } catch (error: unknown) {
       const apiError = error as { message?: string };


### PR DESCRIPTION
## The bug

`AppLockGate` only ever saw background → foreground transitions **within one process**. A cold launch — swiping the app out of the switcher, or iOS reaping it under memory pressure — restored the session straight from the keychain with no biometric challenge: `storeToken` persists the token without `requireAuthentication`, and nothing gated the restore in `RootNavigator.checkAuth`.

Reported as a regression, but nothing had regressed. The gate was intact and present in the shipped build-5 bundle. What made it *look* intermittent is that iOS decides whether your process survives, so the same gesture ("close the app, open it again") locked or not depending on the OS.

## The fix

Persist `{ stampedAt, locked }` to SecureStore and consult it on launch. Fail-secure throughout: absent, malformed, unreadable, or clock-rolled-backwards all lock. The cost of a false lock is one Face ID prompt; the cost of a false unlock is a stranger holding a console for someone else's fleet.

## Three further bypasses found in review

- **Sign out from the lock screen was an unlock primitive.** It cleared `locked` synchronously, but `logoutAsync.pending` leaves the token live — the fleet and every pending approval were readable for as long as the logout took to settle (up to the 15s fetch timeout), and backgrounding in that window stamped the app unlocked. Now the lock stays up until the session is actually gone.
- **A process launched into the background could never lock on its first foreground.** Push wake or iOS prewarm never observes an `active → background` transition, so there was no idle clock: the app sat for hours and opened straight into the fleet. The clock is now seeded from the persisted record.
- **`getSecurityLevel` failed open, invisibly.** It swallowed and returned `NONE`, which the gate reads as "no authenticator, do not lock". So a transient native failure was an unconditional unlock — and because it never threw, the caller's own `.catch` could never fire, making the fail-open *look* defended. It now propagates, and the gate distinguishes "no authenticator exists" from "I could not find out", failing closed on the latter.

## Structure

All decisions moved into a pure `appLockMachine.ts`; keychain I/O in `appLockStore.ts`; the record and parser in `appLockState.ts`.

`vitest.config.ts` includes only `.ts` (no React Native test runtime), so **anything left in the `.tsx` is unreachable by tests** — which is how the background-launch bypass survived review in the first place. The machine's suite needs no native mocks at all. Each bypass above was mutation-verified: deleting its guard fails tests.

## Also

- App-lock key registered in `clearAuthData` — a stale `locked: false` otherwise outlives the session it describes if the token delete fails.
- Read/write/malformed failures report to Sentry, once per process (writes fire on every lifecycle transition). `console.*` goes nowhere a developer can see on a TestFlight build, and all three failure modes present identically as "the app keeps asking for Face ID".
- The sign-in stamp lands after `storeUser` and is `.catch()`-isolated, so it can't fail a login whose credentials are already in the keychain.

## Testing

`pnpm test` 400 pass (was 353), `pnpm typecheck` clean, on RN 0.87.

## Note for whoever ships this

`app.json` still has `ios.buildNumber: "5"`, which is already uploaded — bump before archiving. Existing users get one lock on first launch after this ships (no record yet, fail-secure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)