### PR TITLE
docs(mobile): correct the associated-domains "returned verbatim" claim

### DIFF
--- a/apps/mobile/src/config/associatedDomains.js
+++ b/apps/mobile/src/config/associatedDomains.js
@@ -117,8 +117,12 @@ function validateHostname(hostname, original) {
 /**
  * Merge extra associated domains into the static list.
  *
- * With no configured value the base list is returned verbatim, so the published
- * App Store build cannot be affected by this code path at all.
+ * With no configured value the returned list is EQUAL to the base list, so the
+ * published App Store build cannot be affected by this code path at all. It is
+ * a copy, not the same array — `base.slice()` runs before `raw` is examined, and
+ * the test asserts `not.toBe(base)` deliberately. Do not "fix" this into
+ * returning `base` itself to match a stricter reading: handing the caller our
+ * internal array back would let a later mutation reach the entitlement list.
  *
  * Accepts comma or whitespace separated values. Semicolon is deliberately NOT
  * a separator: it is legal inside a URL path and splitting on it would reject a


### PR DESCRIPTION
Follow-up to your note on #3732 — you were right, and the prose was wrong in the direction that invites a regression.

`resolveAssociatedDomains` does `base.slice()` on line 133, *before* it examines `raw`, so the unset path on line 134 returns a copy. The comment claimed the base list was "returned verbatim", and the test at `associatedDomains.test.ts:23` asserts `expect(result).not.toBe(base)` — the test and the comment directly contradict each other, and the test is the one telling the truth.

Reworded to say the result is **equal to** the base list rather than verbatim, and to state why returning `base` itself would be worse: handing the caller our internal array back would let a later mutation reach the entitlement list. That's the "restore" you were worried about someone attempting, so I've made the reason explicit at the site rather than just removing the wrong word.

Comment-only change — `git diff -U0` shows every touched line inside the JSDoc block, and `node --check` passes. I did not run the mobile suite in this worktree because it has no `node_modules` and the change cannot affect behaviour; say the word if you'd rather see a full run anyway.
