### PR TITLE
fix(ci): bound the Tauri apt step so it cannot relocate the job timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1540,6 +1540,20 @@ jobs:
           persist-credentials: false
 
       - name: Install Tauri system dependencies
+        # Bound the STEP, not just the commands inside it. The per-command
+        # deadlines below sum to ~27.75m worst case (3 attempts x 8m, plus two
+        # 90s dpkg recoveries, plus 45s of backoff), and the job budget is 35m
+        # JOB-wide — so a worst-case apt would leave ~7m for Rust toolchain
+        # setup, a cold `cargo check` on two webkit2gtk-linked crates, and the
+        # viewer tests. On a cache miss that is not enough, and the job would
+        # die on GitHub's generic "job timed out" with no diagnostic: the exact
+        # failure #3730 reported and this step exists to prevent, merely
+        # relocated from apt to whatever ran last.
+        #
+        # 12m caps apt at roughly a third of the budget and fires as a labelled
+        # step timeout, leaving 23m for the Rust work regardless of how badly
+        # the mirror behaves.
+        timeout-minutes: 12
         run: |
           # The Azure apt mirror (azure.archive.ubuntu.com) is intermittently
           # degraded and can crawl at 1-4 min/package, blowing this job's
@@ -1559,12 +1573,13 @@ jobs:
           # signals apt-get itself as root; wrapping sudo would kill the wrapper
           # and leave a root apt-get orphaned holding the dpkg lock.
           #
-          # Deadlines are sized so the WORST case still fails cleanly inside the
-          # job's 35-minute budget. Counting the --kill-after grace on every
-          # bound (each deadline can run to deadline + 30s), three attempts plus
-          # two recovery runs plus the sleeps come to under 27m, so the step
-          # reports its own error rather than being killed mid-attempt with no
-          # diagnostic. Normal runs finish in well under a minute, so these are
+          # Deadlines bound each apt phase so a stall fails fast with a real
+          # message instead of consuming the job. Counting the --kill-after
+          # grace on every bound (each deadline can run to deadline + 30s),
+          # three attempts plus two recovery runs plus the sleeps come to
+          # ~27.75m — which is why the step-level timeout above exists: sized
+          # against the job budget alone, that worst case starves everything
+          # after it. Normal runs finish in well under a minute, so these are
           # roughly 10x headroom rather than tight.
           sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
             /etc/apt/sources.list \


### PR DESCRIPTION
Fixes item 1 of #3754. Your arithmetic reproduces exactly against `origin/main`.

The flaw is in my own comment on #3731, which says the deadlines are "sized so the WORST case still fails cleanly inside the job's 35-minute budget." That reasoned about apt fitting in the budget and never accounted for what runs *after* it in the same job — cache restore, Check helper, Check viewer, Test viewer. Worst-case apt at ~27.75m leaves ~7.25m for toolchain setup plus a cold `cargo check` on two webkit2gtk-linked crates plus tests, which on a cache miss is not enough. The job then dies on the generic "job timed out" with no diagnostic: #3730's failure mode, relocated from apt to whatever happened to run last.

**`timeout-minutes: 12` on the step.** apt is now capped independently of the job budget and fails as a labelled step timeout, leaving 23m for the Rust work regardless of the mirror. The per-command deadlines stay — they produce the specific diagnostic ("apt-get update exceeded 2m"), and the step cap is the backstop that keeps a pathological case from eating the job.

I picked a step cap over the alternatives deliberately: reducing attempts trades away the retry resilience that motivated #3731, and raising the job timeout makes a stalled run take longer to tell you it stalled.

`actionlint` output is byte-identical to pristine main — 12 pre-existing findings, none in the edited region, verified by running it against a stashed tree.

Item 2 (main-red-alert reporting success when it fails to file the ci-red issue) is untouched here — happy to take it separately, or leave it if you'd rather keep #3754 open as the tracking issue for it.
