### PR TITLE
fix(mobile): the device walk asks for a page size the server honours

### DIFF
--- a/apps/mobile/src/screens/devices/deviceListFilters.ts
+++ b/apps/mobile/src/screens/devices/deviceListFilters.ts
@@ -5,9 +5,12 @@ export type DeviceStatusFilter = 'all' | 'online' | 'offline';
 /**
  * Client-side list shaping for the devices browser.
  *
- * The fleet arrives as one page from `/mobile/devices` (50 by default), so
- * filtering and sorting happen here rather than round-tripping. Kept pure so
- * the ordering contract is testable without a renderer.
+ * `getDevices` walks the cursor to the end of the fleet before this runs, so
+ * filtering and sorting happen here over the whole in-memory list rather than
+ * round-tripping per keystroke. (This previously said the fleet "arrives as one
+ * page ... 50 by default" — true before #3720 added the walk, stale the moment
+ * it landed.) Kept pure so the ordering contract is testable without a
+ * renderer.
  */
 
 /** Offline-first: the machines that need attention sort to the top. */

--- a/apps/mobile/src/screens/systems/mergeSystemsResults.ts
+++ b/apps/mobile/src/screens/systems/mergeSystemsResults.ts
@@ -2,7 +2,7 @@ import type { Alert, Device } from '../../services/api';
 import type { MobileSummary, OrganizationSummary } from '../../services/systems';
 
 /**
- * The four independent fetches behind the Systems screen, in the order
+ * The five independent fetches behind the Systems screen, in the order
  * `fetchAll` issues them.
  */
 export interface SystemsSlices {
@@ -39,11 +39,11 @@ function take<T>(result: PromiseSettledResult<T>, previous: T): T {
 }
 
 /**
- * Merge the settled results of the four Systems fetches over the previously
+ * Merge the settled results of the five Systems fetches over the previously
  * rendered data.
  *
  * The screen used to issue these through `Promise.all`, so a single rejection
- * discarded ALL FOUR results — a transient failure on, say, the summary call
+ * discarded ALL FIVE results — a transient failure on, say, the summary call
  * blanked a fleet of devices that had loaded perfectly well, and the user saw an
  * empty screen with a generic error. Each slice now stands on its own: whatever
  * arrived is rendered, whatever failed keeps its last-known value, and the error

--- a/apps/mobile/src/screens/systems/useSystemsData.ts
+++ b/apps/mobile/src/screens/systems/useSystemsData.ts
@@ -58,7 +58,9 @@ function alertOrgId(a: Alert): string | undefined {
   return typeof id === 'string' ? id : undefined;
 }
 
-// Fetches summary, alerts, devices, and orgs in parallel. Owns the local
+// Fetches summary, alerts, activeAlerts, devices and orgs in parallel — five,
+// matching `const total = 5` in mergeSystemsResults. Miscounting here is not
+// cosmetic: that total is the threshold for "everything failed". Owns the local
 // org-filter state so the screen reads filtered slices straight from the
 // hook. Failures keep last-known data; only the in-section error banner
 // flips.

--- a/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
@@ -171,8 +171,16 @@ export function TicketDetailScreen() {
           applyStatusChange({
             id: ticketId,
             status: applied,
-            // The endpoint returns the custom label too; omitting it here would
-            // blank the queue row's label until the next list fetch.
+            // These are always null here, and that is not an oversight to
+            // tidy away: POST /tickets/:id/status returns the raw `tickets`
+            // row (`changeTicketStatus` in services/ticketService.ts ends in a
+            // bare `.returning()`), while statusName/statusColor exist only via
+            // the join in the list and detail GET routes. Writing them keeps
+            // the optimistic row shape consistent; the CORRECT labels come from
+            // the `load()` below.
+            //
+            // So that refetch is load-bearing, not a wasted round trip.
+            // Removing it reintroduces blank status labels.
             statusName: updated?.statusName ?? null,
             statusColor: updated?.statusColor ?? null,
           })

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -498,12 +498,23 @@ export async function getAlertStats(): Promise<{
 }
 
 // Devices API
-/** Server cap on `limit` (patches/helpers.ts MAX_PAGE_LIMIT). */
-const DEVICE_PAGE_LIMIT = 200;
 /**
- * Safety stop for the cursor walk. 20 pages x 200 = 4,000 devices, well beyond
- * any fleet that belongs on a phone screen, and it bounds the loop if the
- * server ever returns a non-advancing cursor.
+ * Server cap on `limit` for THIS route. `/mobile/devices` runs its query
+ * through `getPagination`, which does `Math.min(100, ...)` — it CLAMPS rather
+ * than rejecting, so asking for more is silently downgraded with nothing in the
+ * response to say so.
+ *
+ * This previously read 200, citing `patches/helpers.ts MAX_PAGE_LIMIT`. That is
+ * a different route's constant (the patches endpoints do cap at 200); the
+ * mobile route never has. The effect was a walk that read as 4,000 devices and
+ * delivered 2,000.
+ */
+const DEVICE_PAGE_LIMIT = 100;
+/**
+ * Safety stop for the cursor walk: 20 x 100 = 2,000 devices. Deliberate, not a
+ * by-product of the page size — it bounds the loop if the server ever returns a
+ * non-advancing cursor, and 2,000 is far beyond any fleet that belongs on a
+ * phone screen. Hitting it is reported rather than silently truncating.
  */
 const MAX_DEVICE_PAGES = 20;
 
@@ -534,8 +545,24 @@ export async function getDevices(orgId?: string | null): Promise<Device[]> {
     const next = response.pagination?.nextCursor ?? null;
     // Stop on a null cursor, a short page, or a cursor that did not advance —
     // the last of these would otherwise spin until the page cap.
-    if (!next || next === cursor || rows.length === 0) break;
+    if (!next || next === cursor || rows.length === 0) {
+      cursor = null;
+      break;
+    }
     cursor = next;
+  }
+
+  // Exhausting the page budget with a live cursor means the fleet is larger
+  // than the walk returns. Silently handing back a short list is the failure
+  // this cap would otherwise introduce: the caller cannot tell 2,000 devices
+  // from "the first 2,000 of more", and any client-side filter then searches a
+  // subset while looking authoritative.
+  if (cursor) {
+    Sentry.captureMessage('device walk hit its page cap; fleet is truncated', {
+      level: 'warning',
+      tags: { area: 'device-walk' },
+      extra: { returned: out.length, pageLimit: DEVICE_PAGE_LIMIT, maxPages: MAX_DEVICE_PAGES },
+    });
   }
 
   return out.map(mapDevice);

--- a/apps/mobile/src/services/devicesPaging.test.ts
+++ b/apps/mobile/src/services/devicesPaging.test.ts
@@ -41,10 +41,16 @@ describe('getDevices paging', () => {
     expect(String(fetchWithTimeout.mock.calls[1][0])).toContain('cursor=cur1');
   });
 
-  it('requests the maximum page size', async () => {
+  it('asks for a page size the server will actually honour', async () => {
+    // Was `limit=200`, asserted against `patches/helpers.ts MAX_PAGE_LIMIT` —
+    // the wrong route's constant. `/mobile/devices` runs through
+    // `getPagination`, which does `Math.min(100, ...)`: it CLAMPS silently, so
+    // asking 200 returned 100 and the 20-page walk delivered 2,000 devices
+    // while the code read as 4,000. The test agreed with the comment and both
+    // were wrong about the server, which is why neither caught it.
     fetchWithTimeout.mockImplementationOnce(page([], null));
     await getDevices();
-    expect(String(fetchWithTimeout.mock.calls[0][0])).toContain('limit=200');
+    expect(String(fetchWithTimeout.mock.calls[0][0])).toContain('limit=100');
   });
 
   it('scopes to an org server-side rather than filtering a truncated page', async () => {

--- a/apps/mobile/src/services/tickets.ts
+++ b/apps/mobile/src/services/tickets.ts
@@ -167,6 +167,11 @@ export async function addTicketComment(
  * Returns the updated ticket the endpoint responds with, so callers apply the
  * server's authoritative status (custom-status mapping can make it differ from
  * the requested one) rather than echoing their own request back into state.
+ *
+ * Note what it does NOT carry: this route returns the raw `tickets` row, so
+ * `statusName`/`statusColor` are absent — those come from a join present only
+ * on the list and detail GET routes. Callers needing the display label must
+ * refetch.
  */
 export async function changeTicketStatus(
   id: string,


### PR DESCRIPTION
Fixes #3755 — all four items. Each verified against `origin/main` before changing anything.

**The bug.** `DEVICE_PAGE_LIMIT = 200` cited `patches/helpers.ts MAX_PAGE_LIMIT`, which is a real constant but on a different route. `/mobile/devices` goes through `getPagination`, and `listDevicesSchema` declares `limit: z.string().optional()` with no bound, so validation passes 200 straight through to `Math.min(100, ...)` — a silent clamp, not a rejection. Client asks 200, gets 100, and 20 pages deliver 2,000 devices while the code reads as 4,000.

The part worth dwelling on: **the test asserted `limit=200` too.** Comment and test agreed with each other and both were wrong about the server, so nothing in the repo could catch it. That's the failure mode you described, with a test lending it false authority. Updated to the honoured value, with the reason recorded so it doesn't drift back.

**On your point that the ceiling should be deliberate with a truncation affordance** — agreed, and I've done both. 2,000 is now stated as the intended cap rather than a by-product of the page size, and exhausting the page budget with a live cursor reports rather than returning a short list silently. Without that, a caller can't distinguish 2,000 devices from "the first 2,000 of more", and any client-side filter over the truncated list looks authoritative.

**The three comments**, all confirmed:
- `deviceListFilters.ts` described the fleet arriving "as one page (50 by default)" — accurate before #3720 added the walk, stale the moment it landed. My own PR, my own stale comment.
- `mergeSystemsResults.ts` / `useSystemsData.ts` said "four independent fetches"; there are five and `const total = 5`. Your specific risk is the right one — someone reconciling comment to code could "correct" the threshold to 4 and silently change when the merge decides everything failed.
- `TicketDetailScreen.tsx` claimed the response "returns the custom label too". I traced it: `changeTicketStatus` in `services/ticketService.ts` ends in a bare `.returning()`, so it's the raw `tickets` row; `statusName`/`statusColor` exist only via the join on the list and detail GETs. That line always writes null, correctness comes entirely from the `load()` below, and the comment made that refetch look removable.

498 pass, `tsc` clean, and restoring the 200 fails the page-size test.

On the pattern: four of these were mine, and all four are the same shape — the code moved and the comment kept justifying the previous design. Worth me tightening that rather than treating them as one-offs.
