### PR TITLE
fix(api): lock the devices row before the cascade deletes its children

### DIFF
--- a/apps/api/src/db/rowCount.ts
+++ b/apps/api/src/db/rowCount.ts
@@ -1,0 +1,30 @@
+/**
+ * Row count out of a driver result, across the three shapes this codebase sees.
+ *
+ * `drizzle-orm/postgres-js` `execute()` resolves to a postgres-js `Result`,
+ * which extends Array and carries `.count` — NOT node-postgres' `.rowCount` /
+ * `.rows`. Reading the wrong one yields 0 on every call, which in a batched
+ * delete ends the loop early and silently leaves rows behind, and in a lock
+ * check reports the exact opposite of the truth.
+ *
+ * This lives in `db/` rather than in one of the retention jobs so that a
+ * REQUEST-PATH service can use it without importing from `jobs/`, which would
+ * invert services→jobs and pull BullMQ + ioredis into the module graph of a
+ * plain DELETE.
+ *
+ * Note there are still several private copies of this check in `jobs/` and
+ * other services. Consolidating them is worthwhile but is not this change.
+ */
+export function extractRowCount(result: unknown): number {
+  // Deliberately NOT null-safe. postgres-js never resolves a successful
+  // statement to null/undefined — a genuine zero-row result is an array-like
+  // `Result` with `.count === 0`. Mapping null to 0 would conflate "broken
+  // driver/adapter/mock" with "no rows", and 0 is load-bearing in both kinds of
+  // caller: here it means "the parent lock was not held", and in the batched
+  // retention loops it TERMINATES the loop and leaves old rows behind. Letting
+  // the property read throw keeps a broken contract loud.
+  const raw = result as { rowCount?: number; count?: number };
+  if (typeof raw.rowCount === 'number') return raw.rowCount;
+  if (typeof raw.count === 'number') return raw.count;
+  return Array.isArray(result) ? (result as unknown[]).length : 0;
+}

--- a/apps/api/src/routes/devices/cascadeDelete.test.ts
+++ b/apps/api/src/routes/devices/cascadeDelete.test.ts
@@ -94,6 +94,7 @@ import {
   DEVICE_LINKED_DEVICE_ID_TABLES,
 } from './core';
 import { db } from '../../db';
+import { isAgentConnected, sendCommandToAgent } from '../agentWs';
 
 const deviceCascadeDeleteTables = getDeviceCascadeDeleteTables();
 
@@ -406,23 +407,78 @@ describe('DELETE /devices/:id/permanent — tickets are detached, not destroyed'
    * 500 with no indication the uninstall had already gone out. Assert the
    * WRAPPED shape specifically — an unwrapped `{ code: '55P03' }` fixture would
    * pass against the broken code and prove nothing.
+   *
+   * Uses an ONLINE device with the uninstall actually dispatched. An earlier
+   * revision used the offline fixture, where `uninstallSent` can only ever be
+   * false, and merely asserted the property existed — code that hard-coded
+   * `false` would have passed it.
    */
-  it('maps a Drizzle-wrapped 55P03 to a retryable 409 that reports uninstallSent', async () => {
-    rigDeviceLookup(DEVICE);
+  // Still `decommissioned` — the route 400s anything else BEFORE it ever
+  // reaches the uninstall dispatch, so an 'online' status here would have
+  // tested the wrong branch entirely. What makes the uninstall fire is an
+  // agentId plus a live agent connection.
+  const CONNECTED_DEVICE = { ...DEVICE, agentId: 'agent-1' };
+
+  function rigUninstallDispatched() {
+    vi.mocked(isAgentConnected).mockReturnValue(true);
+    // Returns synchronously — `uninstallSent = sendCommandToAgent(...)`, not an
+    // awaited promise, so mockResolvedValue would make uninstallSent a Promise.
+    vi.mocked(sendCommandToAgent).mockReturnValue(true as never);
+  }
+
+  it('maps a Drizzle-wrapped 55P03 to a retryable 409 that reports uninstallSent: true', async () => {
+    rigDeviceLookup(CONNECTED_DEVICE);
+    rigUninstallDispatched();
     vi.mocked(db.transaction).mockImplementation(async () => {
       throw Object.assign(new Error('Failed query: SELECT id FROM devices ... FOR UPDATE'), {
         cause: Object.assign(new Error('canceling statement due to lock timeout'), { code: '55P03' }),
       });
     });
 
-    const res = await app.request(`/devices/${DEVICE.id}/permanent`, {
+    const res = await app.request(`/devices/${CONNECTED_DEVICE.id}/permanent`, {
       method: 'DELETE',
       headers: { Authorization: 'Bearer t' },
     });
 
     expect(res.status).toBe(409);
     const body = await res.json() as { error: string; uninstallSent: boolean };
-    expect(body).toHaveProperty('uninstallSent');
-    expect(body.error).toMatch(/busy/i);
+    expect(body.uninstallSent).toBe(true);
+    expect(body.error).toMatch(/already sent/i);
+    expect(body.error).toMatch(/retry/i);
+  });
+
+  /**
+   * The 23503 branch had NEVER executed before the unwrap — the top-level
+   * `.code` read meant it was unreachable. Switching it on is a behaviour
+   * change, so it gets the same online-agent coverage: a rolled-back cascade
+   * leaves the row present while the agent may already be uninstalling, and the
+   * web callers surface only `err.message`, so the disclosure must be in the
+   * text and not merely in the JSON field.
+   */
+  it('maps a Drizzle-wrapped 23503 to a 409 that discloses the already-sent uninstall', async () => {
+    rigDeviceLookup(CONNECTED_DEVICE);
+    rigUninstallDispatched();
+    vi.mocked(db.transaction).mockImplementation(async () => {
+      throw Object.assign(new Error('Failed query: DELETE FROM devices'), {
+        cause: Object.assign(new Error('update or delete violates foreign key constraint'), {
+          code: '23503',
+          detail: 'Key (id)=(...) is still referenced from table "some_child".',
+          table_name: 'some_child',
+        }),
+      });
+    });
+
+    const res = await app.request(`/devices/${CONNECTED_DEVICE.id}/permanent`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json() as { error: string; uninstallSent: boolean };
+    expect(body.uninstallSent).toBe(true);
+    // table_name must come off the SAME node as the code, or this reads
+    // "related records in undefined".
+    expect(body.error).toContain('some_child');
+    expect(body.error).toMatch(/already sent/i);
   });
 });

--- a/apps/api/src/routes/devices/cascadeDelete.test.ts
+++ b/apps/api/src/routes/devices/cascadeDelete.test.ts
@@ -293,17 +293,28 @@ describe('DELETE /devices/:id/permanent — tickets are detached, not destroyed'
         execute: vi.fn().mockImplementation(async (q: any) => {
           const text = sqlToText(q);
           statements.push(text);
-          // The cascade reads the caller's lock_timeout so it can restore it
-          // after taking the parent row lock, and REFUSES to change the setting
-          // if it cannot read it back (a wrong-shaped result would otherwise
-          // silently widen a stricter caller). A bare [] here is not a result
-          // this driver can produce, and made the route 500.
-          if (text.includes('current_setting')) {
-            const row: Record<string, unknown>[] = [{ lock_timeout: '0' }];
-            Object.defineProperty(row, 'count', { value: 1, enumerable: false });
-            return row;
+          // postgres-js resolves to an array-like carrying a non-enumerable
+          // `.count`. A bare [] is not a result this driver can produce, and
+          // returning one made every statement look like it affected 0 rows.
+          const pgResult = (rows: Record<string, unknown>[], count = rows.length) => {
+            Object.defineProperty(rows, 'count', { value: count, enumerable: false });
+            return rows;
+          };
+          // The cascade tightens the lock bound and reads the caller's prior
+          // value in ONE pg_settings statement (milliseconds, as an integer).
+          // '0' is Postgres's "wait forever", the value that makes it actually
+          // apply its 3s bound, so this keeps the mock on the interesting path.
+          if (text.includes('pg_settings')) {
+            return pgResult([{ prior_ms: '0' }]);
           }
-          return [];
+          // The parent row lock must report ONE row. Returning [] here sent the
+          // whole route suite down the "ran without holding the lock" branch,
+          // so a regression that permanently lost the lock would have been
+          // invisible to these tests.
+          if (text.includes('FOR UPDATE')) {
+            return pgResult([{ id: DEVICE.id }]);
+          }
+          return pgResult([]);
         }),
         delete: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue(undefined),

--- a/apps/api/src/routes/devices/cascadeDelete.test.ts
+++ b/apps/api/src/routes/devices/cascadeDelete.test.ts
@@ -391,4 +391,38 @@ describe('DELETE /devices/:id/permanent — tickets are detached, not destroyed'
     expect(res.status).toBe(200);
     expect(dissolveLinkGroupIfBelowMinimum).not.toHaveBeenCalled();
   });
+
+  /**
+   * A lock timeout must surface as the retryable 409 that reports
+   * `uninstallSent`, because the SELF_UNINSTALL is dispatched BEFORE the
+   * transaction and is irreversible — a bounded lock failure is the one path
+   * that can leave an agent uninstalling itself while its device row survives.
+   *
+   * The shape here is not invented. It is what a REAL lock timeout produces:
+   * verified against live Postgres with two connections contending on one row,
+   * the error arrives as `{ code: undefined, cause: { code: '55P03' } }`,
+   * because Drizzle wraps the postgres-js PostgresError. The route used to read
+   * the top-level `.code`, so this branch was dead and the operator got a bare
+   * 500 with no indication the uninstall had already gone out. Assert the
+   * WRAPPED shape specifically — an unwrapped `{ code: '55P03' }` fixture would
+   * pass against the broken code and prove nothing.
+   */
+  it('maps a Drizzle-wrapped 55P03 to a retryable 409 that reports uninstallSent', async () => {
+    rigDeviceLookup(DEVICE);
+    vi.mocked(db.transaction).mockImplementation(async () => {
+      throw Object.assign(new Error('Failed query: SELECT id FROM devices ... FOR UPDATE'), {
+        cause: Object.assign(new Error('canceling statement due to lock timeout'), { code: '55P03' }),
+      });
+    });
+
+    const res = await app.request(`/devices/${DEVICE.id}/permanent`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json() as { error: string; uninstallSent: boolean };
+    expect(body).toHaveProperty('uninstallSent');
+    expect(body.error).toMatch(/busy/i);
+  });
 });

--- a/apps/api/src/routes/devices/cascadeDelete.test.ts
+++ b/apps/api/src/routes/devices/cascadeDelete.test.ts
@@ -291,7 +291,18 @@ describe('DELETE /devices/:id/permanent — tickets are detached, not destroyed'
     vi.mocked(db.transaction).mockImplementation(async (cb: any) => {
       const tx = {
         execute: vi.fn().mockImplementation(async (q: any) => {
-          statements.push(sqlToText(q));
+          const text = sqlToText(q);
+          statements.push(text);
+          // The cascade reads the caller's lock_timeout so it can restore it
+          // after taking the parent row lock, and REFUSES to change the setting
+          // if it cannot read it back (a wrong-shaped result would otherwise
+          // silently widen a stricter caller). A bare [] here is not a result
+          // this driver can produce, and made the route 500.
+          if (text.includes('current_setting')) {
+            const row: Record<string, unknown>[] = [{ lock_timeout: '0' }];
+            Object.defineProperty(row, 'count', { value: 1, enumerable: false });
+            return row;
+          }
           return [];
         }),
         delete: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -71,7 +71,7 @@ import {
   withExtensionDeviceOrgDenormalized,
   withExtensionDeviceOrgMoveDelete,
 } from '../../extensions/tenancyRegistry';
-import { pgErrorCode } from '../../utils/pgErrors';
+import { pgErrorCode, pgErrorNode } from '../../utils/pgErrors';
 
 
 /**
@@ -1607,11 +1607,28 @@ coreRoutes.delete(
       // documents exactly this hazard and exists for it.
       const pgCode = pgErrorCode(err);
       if (pgCode === '23503') {
-        const detail = (err as { detail?: string })?.detail ?? '';
-        const constraintTable = (err as { table_name?: string })?.table_name;
-        console.error(`[devices] FK violation during cascade delete of ${deviceId}: ${detail}`, err);
+        // Read the diagnostics off the SAME node the code came from. Unwrapping
+        // only the code and then reading `detail`/`table_name` off the outer
+        // Drizzle error yields blanks on every wrapped statement, i.e. "related
+        // records in undefined" — this branch had never run before the unwrap
+        // above, so that was never observed.
+        const node = pgErrorNode(err);
+        const detail = typeof node?.detail === 'string' ? node.detail : '';
+        const constraintTable = typeof node?.table_name === 'string' ? node.table_name : undefined;
+        console.error(`[devices] FK violation during cascade delete of ${deviceId}: ${detail} (uninstallSent=${uninstallSent})`, err);
+        // This catch also covers dissolveLinkGroupIfBelowMinimum, so the
+        // violation is not necessarily a missing cascade-list table — say
+        // "may" rather than asserting a cause we have not established.
+        //
+        // uninstallSent carries the same weight it does on the 55P03 branch
+        // below: SELF_UNINSTALL is dispatched BEFORE this transaction and is
+        // irreversible, so the transaction rolling back leaves the row present
+        // while the agent may already be removing itself. The web callers
+        // surface only `err.message`, so the disclosure has to be IN the text,
+        // not merely in the JSON field.
         return c.json({
-          error: `Cannot delete: device still has related records${constraintTable ? ` in ${constraintTable}` : ''}. This table may need to be added to the cascade delete list.`,
+          error: `Cannot delete: device still has related records${constraintTable ? ` in ${constraintTable}` : ''}. A related table may be missing from the cascade delete list.${uninstallSent ? ' The uninstall command was already sent to the agent — the device record still exists, so retry this delete once the blocking records are resolved.' : ''}`,
+          uninstallSent,
         }, 409);
       }
       // 55P03 lock_not_available — the cascade bounds its wait for the devices

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -1604,6 +1604,30 @@ coreRoutes.delete(
           error: `Cannot delete: device still has related records${constraintTable ? ` in ${constraintTable}` : ''}. This table may need to be added to the cascade delete list.`,
         }, 409);
       }
+      // 55P03 lock_not_available — the cascade bounds its wait for the devices
+      // row (services/deviceDeletion.ts) so a delete racing a long-running site
+      // move or moveOrg fails fast instead of pinning a pooled connection.
+      // Without this branch that bound would surface as a generic 500, which
+      // reads as a bug rather than the transient, retryable conflict it is.
+      //
+      // RETRY IS NOT OPTIONAL WHEN uninstallSent IS TRUE. The best-effort
+      // SELF_UNINSTALL above is dispatched BEFORE this transaction and is
+      // irreversible, so a bounded lock failure is the one path that can leave
+      // an agent uninstalling itself while its device row survives — an
+      // unmanageable orphan if the operator walks away. The transaction itself
+      // rolled back cleanly (the lock is the first statement, so nothing was
+      // mutated); it is only that pre-dispatched command that has already
+      // happened. Report it explicitly so the caller knows a retry is required
+      // rather than merely advisable.
+      if (pgCode === '55P03') {
+        console.warn(`[devices] lock timeout acquiring devices row for ${deviceId}; another writer holds it (uninstallSent=${uninstallSent})`, err);
+        return c.json({
+          error: uninstallSent
+            ? 'Device is busy: another operation is modifying it, so it was not deleted. The uninstall command was already sent to the agent — retry this delete to remove the device record.'
+            : 'Device is busy: another operation is currently modifying it. Try again in a moment.',
+          uninstallSent,
+        }, 409);
+      }
       throw err;
     }
 

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -71,6 +71,8 @@ import {
   withExtensionDeviceOrgDenormalized,
   withExtensionDeviceOrgMoveDelete,
 } from '../../extensions/tenancyRegistry';
+import { pgErrorCode } from '../../utils/pgErrors';
+
 
 /**
  * Tables where linked_device_id (not device_id) references devices.id.
@@ -1595,7 +1597,15 @@ coreRoutes.delete(
         }
       });
     } catch (err: unknown) {
-      const pgCode = (err as { code?: string })?.code;
+      // MUST unwrap. Drizzle wraps the postgres-js PostgresError in a
+      // DrizzleQueryError whose own `.code` is undefined — the SQLSTATE lives on
+      // `.cause`. Verified against live Postgres with real two-connection lock
+      // contention: a genuine lock timeout arrives here as
+      // `{ code: undefined, cause: { code: '55P03' } }`, so the top-level read
+      // this replaced returned undefined and BOTH branches below were dead —
+      // the 55P03 one silently, and the pre-existing 23503 one too. `pgErrors`
+      // documents exactly this hazard and exists for it.
+      const pgCode = pgErrorCode(err);
       if (pgCode === '23503') {
         const detail = (err as { detail?: string })?.detail ?? '';
         const constraintTable = (err as { table_name?: string })?.table_name;

--- a/apps/api/src/services/deviceDeletion.test.ts
+++ b/apps/api/src/services/deviceDeletion.test.ts
@@ -19,15 +19,39 @@ vi.mock('@sentry/node', () => ({
  * the lock statement is issued before any child table is touched — which is the
  * part a refactor can silently break.
  */
+/**
+ * A result shaped the way THIS driver actually returns one.
+ *
+ * The api runs on drizzle-orm/postgres-js (`db/index.ts`), whose `execute()`
+ * resolves to an array-like carrying `.count`. It has no `.rowCount` and no
+ * `.rows`. An earlier revision of this mock returned `{ rowCount, rows: [] }` —
+ * the node-postgres shape — so the code, the mock and the assertions all agreed
+ * with each other and were all wrong about the driver, hiding a read that
+ * returned 0 on every call. Keep this faithful: if the mock lies, the test
+ * cannot see the bug it exists to catch.
+ */
+function pgResult(rowCount: number): unknown {
+  const rows: Record<string, unknown>[] = Array.from({ length: rowCount }, () => ({
+    id: 'device-1',
+  }));
+  Object.defineProperty(rows, 'count', { value: rowCount, enumerable: false });
+  return rows;
+}
+
 function captureTx(lockedRowCount = 1) {
   const statements: string[] = [];
   const tx: DeviceDeletionTx = {
     execute: vi.fn().mockImplementation((query: unknown) => {
       const text = JSON.stringify(query);
       statements.push(text);
-      // Only the FOR UPDATE probe reads a result; everything else is a write.
       if (text.includes('FOR UPDATE')) {
-        return Promise.resolve({ rowCount: lockedRowCount, rows: [] });
+        return Promise.resolve(pgResult(lockedRowCount));
+      }
+      // current_setting('lock_timeout') — postgres-js returns a row array.
+      if (text.includes('current_setting')) {
+        const row: Record<string, unknown>[] = [{ lock_timeout: '7s' }];
+        Object.defineProperty(row, 'count', { value: 1, enumerable: false });
+        return Promise.resolve(row);
       }
       return Promise.resolve(undefined);
     }),
@@ -55,13 +79,80 @@ describe('deleteDeviceCascade lock ordering', () => {
     expect(statements.length).toBeGreaterThan(5);
     expect(statements).toContain('__DELETE_DEVICES_ROW__');
 
-    const firstStatement = statements[0];
-    expect(firstStatement).toContain('FOR UPDATE');
-    expect(firstStatement).toContain('devices');
+    // NOTE ON WHAT THIS CAN AND CANNOT SEE: these assertions prove the ORDER in
+    // which statements are emitted, nothing more. The mock has no connection,
+    // transaction, savepoint or GUC semantics, so it would still pass if the
+    // timeout were '3000s', if is_local were false, or if each statement ran on
+    // a different pooled connection. Proving the bound actually fires needs two
+    // real connections and belongs in an integration test.
+    //
+    // Emission order: read the caller's lock_timeout, narrow it, take the lock,
+    // put it back — all before any child table is touched.
+    expect(statements[0]).toContain('current_setting');
+    expect(statements[1]).toContain('set_config');
+    expect(statements[1]).toContain('lock_timeout');
+    expect(statements[2]).toContain('FOR UPDATE');
+    expect(statements[2]).toContain('devices');
 
     // And nothing touches a child table ahead of it.
     const lockIndex = statements.findIndex((s) => s.includes('FOR UPDATE'));
-    expect(lockIndex).toBe(0);
+    expect(lockIndex).toBe(2);
+  });
+
+  it('restores the caller lock_timeout immediately after taking the lock', async () => {
+    // set_config(..., true) is TRANSACTION-local, not statement-local, and both
+    // callers run inside an outer transaction (withDbAccessContext) where a
+    // nested db.transaction() is only a SAVEPOINT — releasing which does NOT
+    // undo a SET LOCAL. Left in force, this function's 3s bound would govern
+    // every child DELETE, the route's link-group dissolution, and every later
+    // device in the reaper's pass. It must be handed back at once.
+    const { tx, statements } = captureTx();
+
+    await deleteDeviceCascade(tx, 'device-1');
+
+    const restoreIndex = statements.findIndex(
+      (s, i) => i > 2 && s.includes('set_config') && s.includes('lock_timeout')
+    );
+    expect(restoreIndex).toBe(3);
+    // Restored to the caller's value, not blindly reset to a hardcoded default.
+    expect(statements[restoreIndex]).toContain('7s');
+
+    // Nothing that can block may sit between the lock and the restore.
+    const firstChildWrite = statements.findIndex(
+      (s) => s.includes('DELETE FROM') || s === '__DELETE_DEVICES_ROW__'
+    );
+    expect(firstChildWrite).toBeGreaterThan(restoreIndex);
+  });
+
+  it('aborts instead of guessing when the prior lock_timeout cannot be read', async () => {
+    // '0' means "wait forever" in Postgres, so substituting it on an
+    // unrecognised result shape would silently WIDEN a caller that had set a
+    // stricter timeout — for the rest of the outer transaction. Only a driver
+    // shape change can trigger this, which is exactly the silent-breakage class
+    // the row-count fix in this commit addresses. Fail loudly, before mutating.
+    const statements: string[] = [];
+    const tx: DeviceDeletionTx = {
+      execute: vi.fn().mockImplementation((query: unknown) => {
+        const text = JSON.stringify(query);
+        statements.push(text);
+        // node-postgres shape: what a driver swap would hand back.
+        if (text.includes('current_setting')) {
+          return Promise.resolve({ rows: [{ lock_timeout: '7s' }], rowCount: 1 });
+        }
+        return Promise.resolve(undefined);
+      }),
+      delete: vi.fn().mockImplementation(() => {
+        statements.push('__DELETE_DEVICES_ROW__');
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      }),
+    };
+
+    await expect(deleteDeviceCascade(tx, 'device-1')).rejects.toThrow(/lock_timeout/);
+
+    // Aborted before changing the setting and before touching any table.
+    expect(statements.some((s) => s.includes('set_config'))).toBe(false);
+    expect(statements.some((s) => s.includes('FOR UPDATE'))).toBe(false);
+    expect(statements).not.toContain('__DELETE_DEVICES_ROW__');
   });
 
   it('deletes the devices row last, after the child tables', async () => {

--- a/apps/api/src/services/deviceDeletion.test.ts
+++ b/apps/api/src/services/deviceDeletion.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { deleteDeviceCascade, type DeviceDeletionTx } from './deviceDeletion';
+
+const sentry = { captureMessage: vi.fn() };
+vi.mock('@sentry/node', () => ({
+  captureMessage: (...a: unknown[]) => sentry.captureMessage(...a),
+}));
+
+/**
+ * Captures the SQL this cascade issues, in order, so the lock-ordering
+ * regression is testable without a database. Follows the `ops` pattern from
+ * the #3739 fix (BREEZE-1S).
+ *
+ * What this CANNOT prove, and deliberately does not claim: that Postgres
+ * actually acquired a row lock, that RLS did not filter the row, or that two
+ * concurrent transactions serialize. Those need two real connections and belong
+ * in an integration test. What it does prove is the ordering contract — that
+ * the lock statement is issued before any child table is touched — which is the
+ * part a refactor can silently break.
+ */
+function captureTx(lockedRowCount = 1) {
+  const statements: string[] = [];
+  const tx: DeviceDeletionTx = {
+    execute: vi.fn().mockImplementation((query: unknown) => {
+      const text = JSON.stringify(query);
+      statements.push(text);
+      // Only the FOR UPDATE probe reads a result; everything else is a write.
+      if (text.includes('FOR UPDATE')) {
+        return Promise.resolve({ rowCount: lockedRowCount, rows: [] });
+      }
+      return Promise.resolve(undefined);
+    }),
+    delete: vi.fn().mockImplementation(() => {
+      statements.push('__DELETE_DEVICES_ROW__');
+      return { where: vi.fn().mockResolvedValue(undefined) };
+    }),
+  };
+  return { tx, statements };
+}
+
+describe('deleteDeviceCascade lock ordering', () => {
+  it('locks the devices row BEFORE touching any child table (40P01, cf. #3739)', async () => {
+    // FK constraints force children-before-parent for the DELETEs, so the
+    // order cannot be inverted to match the rest of the codebase. Every other
+    // writer spanning both levels takes the devices row first, so without an
+    // explicit parent lock a permanent delete racing a re-enrollment of the
+    // same device is a textbook AB-BA deadlock.
+    const { tx, statements } = captureTx();
+
+    await deleteDeviceCascade(tx, 'device-1');
+
+    // Guard against a vacuous order check: the cascade must actually have run
+    // past the lock, otherwise "first statement" is trivially satisfied.
+    expect(statements.length).toBeGreaterThan(5);
+    expect(statements).toContain('__DELETE_DEVICES_ROW__');
+
+    const firstStatement = statements[0];
+    expect(firstStatement).toContain('FOR UPDATE');
+    expect(firstStatement).toContain('devices');
+
+    // And nothing touches a child table ahead of it.
+    const lockIndex = statements.findIndex((s) => s.includes('FOR UPDATE'));
+    expect(lockIndex).toBe(0);
+  });
+
+  it('deletes the devices row last, after the child tables', async () => {
+    // The other half of the contract: the parent lock moves to the front, the
+    // parent DELETE stays at the back. A change that "fixed" ordering by
+    // moving the delete would violate the FKs.
+    const { tx, statements } = captureTx();
+
+    await deleteDeviceCascade(tx, 'device-1');
+
+    expect(statements[statements.length - 1]).toBe('__DELETE_DEVICES_ROW__');
+  });
+});
+
+
+describe('deleteDeviceCascade when the parent lock is not acquired', () => {
+  it('reports rather than aborting when FOR UPDATE matches no row', async () => {
+    // Zero rows means the device is already gone (a re-run, or two reapers
+    // racing) or RLS filtered it. Deleting an absent device is legitimately
+    // idempotent, so aborting would turn a harmless race into an error — but
+    // the cascade below then runs under the OLD child-first ordering, which is
+    // exactly the race the lock exists to close. It must be visible, not
+    // silently assumed safe.
+    sentry.captureMessage.mockClear();
+    const { tx, statements } = captureTx(0);
+
+    await expect(deleteDeviceCascade(tx, 'device-gone')).resolves.toBeUndefined();
+
+    expect(sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(String(sentry.captureMessage.mock.calls[0]?.[0])).toContain('without holding');
+    // Still idempotent: the cascade completed rather than throwing.
+    expect(statements).toContain('__DELETE_DEVICES_ROW__');
+  });
+
+  it('stays quiet on the normal path where the row is locked', async () => {
+    sentry.captureMessage.mockClear();
+    const { tx } = captureTx(1);
+
+    await deleteDeviceCascade(tx, 'device-1');
+
+    expect(sentry.captureMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/deviceDeletion.test.ts
+++ b/apps/api/src/services/deviceDeletion.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { deleteDeviceCascade, type DeviceDeletionTx } from './deviceDeletion';
 
 const sentry = { captureMessage: vi.fn() };
-vi.mock('@sentry/node', () => ({
+// The service reports through the `services/sentry` WRAPPER (init guard +
+// scrubEvent), not raw `@sentry/node`, so that is what has to be mocked —
+// mocking the raw SDK here would silently intercept nothing.
+vi.mock('./sentry', () => ({
   captureMessage: (...a: unknown[]) => sentry.captureMessage(...a),
 }));
 
@@ -47,9 +50,11 @@ function captureTx(lockedRowCount = 1) {
       if (text.includes('FOR UPDATE')) {
         return Promise.resolve(pgResult(lockedRowCount));
       }
-      // current_setting('lock_timeout') — postgres-js returns a row array.
-      if (text.includes('current_setting')) {
-        const row: Record<string, unknown>[] = [{ lock_timeout: '7s' }];
+      // The tighten statement reads pg_settings (milliseconds, as an integer)
+      // and applies the bound in the SAME statement — postgres-js returns a row
+      // array carrying a non-enumerable `.count`.
+      if (text.includes('pg_settings')) {
+        const row: Record<string, unknown>[] = [{ prior_ms: '7000' }];
         Object.defineProperty(row, 'count', { value: 1, enumerable: false });
         return Promise.resolve(row);
       }
@@ -86,17 +91,20 @@ describe('deleteDeviceCascade lock ordering', () => {
     // a different pooled connection. Proving the bound actually fires needs two
     // real connections and belongs in an integration test.
     //
-    // Emission order: read the caller's lock_timeout, narrow it, take the lock,
-    // put it back — all before any child table is touched.
-    expect(statements[0]).toContain('current_setting');
-    expect(statements[1]).toContain('set_config');
-    expect(statements[1]).toContain('lock_timeout');
-    expect(statements[2]).toContain('FOR UPDATE');
-    expect(statements[2]).toContain('devices');
+    // Emission order: ONE tighten-and-read statement, take the lock, put it
+    // back — all before any child table is touched. This used to be four
+    // statements; reading pg_settings and applying the bound now ride together,
+    // which is what removes the client-side unit parsing.
+    expect(statements[0]).toContain('pg_settings');
+    expect(statements[0]).toContain('set_config');
+    expect(statements[1]).toContain('FOR UPDATE');
+    expect(statements[1]).toContain('devices');
+    expect(statements[2]).toContain('set_config');
+    expect(statements[2]).toContain('lock_timeout');
 
     // And nothing touches a child table ahead of it.
-    const lockIndex = statements.findIndex((s) => s.includes('FOR UPDATE'));
-    expect(lockIndex).toBe(2);
+    const lockIndex = statements.findIndex((t) => t.includes('FOR UPDATE'));
+    expect(lockIndex).toBe(1);
   });
 
   it('restores the caller lock_timeout immediately after taking the lock', async () => {
@@ -111,11 +119,11 @@ describe('deleteDeviceCascade lock ordering', () => {
     await deleteDeviceCascade(tx, 'device-1');
 
     const restoreIndex = statements.findIndex(
-      (s, i) => i > 2 && s.includes('set_config') && s.includes('lock_timeout')
+      (t, i) => i > 1 && t.includes('set_config') && t.includes('lock_timeout')
     );
-    expect(restoreIndex).toBe(3);
+    expect(restoreIndex).toBe(2);
     // Restored to the caller's value, not blindly reset to a hardcoded default.
-    expect(statements[restoreIndex]).toContain('7s');
+    expect(statements[restoreIndex]).toContain('7000ms');
 
     // Nothing that can block may sit between the lock and the restore.
     const firstChildWrite = statements.findIndex(
@@ -124,22 +132,29 @@ describe('deleteDeviceCascade lock ordering', () => {
     expect(firstChildWrite).toBeGreaterThan(restoreIndex);
   });
 
-  it('aborts instead of guessing when the prior lock_timeout cannot be read', async () => {
-    // '0' means "wait forever" in Postgres, so substituting it on an
-    // unrecognised result shape would silently WIDEN a caller that had set a
-    // stricter timeout — for the rest of the outer transaction. Only a driver
-    // shape change can trigger this, which is exactly the silent-breakage class
-    // the row-count fix in this commit addresses. Fail loudly, before mutating.
+  it('stays bounded, reports, and skips the restore when the prior lock_timeout cannot be read', async () => {
+    // This used to assert a throw, then briefly asserted an UNBOUNDED wait —
+    // both wrong. Aborting kills a delete whose SELF_UNINSTALL already went out;
+    // proceeding unbounded pins a pooled connection, which is the outage class
+    // the bound exists to prevent. Applying the bound inside the SQL statement
+    // makes the question moot: the timeout is ALREADY tightened by the time the
+    // client tries to decode the prior value, so an unreadable result costs
+    // only the restore — and skipping that leaves the STRICTER value in force.
     const statements: string[] = [];
     const tx: DeviceDeletionTx = {
       execute: vi.fn().mockImplementation((query: unknown) => {
         const text = JSON.stringify(query);
         statements.push(text);
-        // node-postgres shape: what a driver swap would hand back.
-        if (text.includes('current_setting')) {
-          return Promise.resolve({ rows: [{ lock_timeout: '7s' }], rowCount: 1 });
+        // node-postgres shape: what a driver swap would hand back. The point of
+        // this fixture is that `[0].prior_ms` is NOT reachable on it, so the
+        // service cannot learn what to restore.
+        if (text.includes('pg_settings')) {
+          return Promise.resolve({ rows: [{ prior_ms: '7000' }], rowCount: 1 });
         }
-        return Promise.resolve(undefined);
+        // Stay in that same node-postgres shape for every other statement,
+        // rather than handing back undefined — a driver returns results, and
+        // the point here is a shape swap, not a missing response.
+        return Promise.resolve({ rows: [{ id: 'device-1' }], rowCount: 1 });
       }),
       delete: vi.fn().mockImplementation(() => {
         statements.push('__DELETE_DEVICES_ROW__');
@@ -147,12 +162,64 @@ describe('deleteDeviceCascade lock ordering', () => {
       }),
     };
 
-    await expect(deleteDeviceCascade(tx, 'device-1')).rejects.toThrow(/lock_timeout/);
+    sentry.captureMessage.mockClear();
+    await expect(deleteDeviceCascade(tx, 'device-1')).resolves.toBeUndefined();
 
-    // Aborted before changing the setting and before touching any table.
-    expect(statements.some((s) => s.includes('set_config'))).toBe(false);
-    expect(statements.some((s) => s.includes('FOR UPDATE'))).toBe(false);
-    expect(statements).not.toContain('__DELETE_DEVICES_ROW__');
+    expect(sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(String(sentry.captureMessage.mock.calls[0]?.[0])).toContain('lock_timeout');
+    // The bound WAS applied (it rides on the same statement), so exactly one
+    // set_config was issued and none afterwards to undo it.
+    expect(statements.filter((t) => t.includes('set_config')).length).toBe(1);
+    expect(statements[0]).toContain('pg_settings');
+    expect(statements.some((t) => t.includes('FOR UPDATE'))).toBe(true);
+    expect(statements).toContain('__DELETE_DEVICES_ROW__');
+  });
+
+  it('does not widen a caller that already set a stricter lock_timeout', async () => {
+    // The doc comment promises this function will not relax a tighter bound.
+    // An unconditional set_config broke that promise: a caller holding 500ms
+    // was silently relaxed to 3000ms for the REST of the outer transaction,
+    // because SET LOCAL is transaction-scoped, not statement-scoped.
+    const statements: string[] = [];
+    const tx: DeviceDeletionTx = {
+      execute: vi.fn().mockImplementation((query: unknown) => {
+        const text = JSON.stringify(query);
+        statements.push(text);
+        if (text.includes('pg_settings')) {
+          const row: Record<string, unknown>[] = [{ prior_ms: '500' }];
+          Object.defineProperty(row, 'count', { value: 1, enumerable: false });
+          return Promise.resolve(row);
+        }
+        const empty: Record<string, unknown>[] = [{ id: 'device-1' }];
+        Object.defineProperty(empty, 'count', { value: 1, enumerable: false });
+        return Promise.resolve(empty);
+      }),
+      delete: vi.fn().mockImplementation(() => {
+        statements.push('__DELETE_DEVICES_ROW__');
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      }),
+    };
+
+    await deleteDeviceCascade(tx, 'device-1');
+
+    // The SQL CASE keeps the caller's 500ms, and because nothing changed there
+    // is no restore statement afterwards — one set_config total, not two.
+    expect(statements.filter((t) => t.includes('set_config')).length).toBe(1);
+    // Still took the lock and still completed under the caller's own bound.
+    expect(statements.some((t) => t.includes('FOR UPDATE'))).toBe(true);
+    expect(statements).toContain('__DELETE_DEVICES_ROW__');
+  });
+
+  it('applies the bound when the caller\'s is looser, and restores exactly what was there', async () => {
+    const { tx, statements } = captureTx();
+    await deleteDeviceCascade(tx, 'device-1');
+    // captureTx reports 7000ms > 3000ms, so the bound genuinely tightens and
+    // must be applied — then restored to the caller's ORIGINAL value, not to a
+    // hard-coded default.
+    const sets = statements.filter((t) => t.includes('set_config'));
+    expect(sets.length).toBe(2);
+    expect(sets[0]).toContain('3000');
+    expect(sets[1]).toContain('7000ms');
   });
 
   it('deletes the devices row last, after the child tables', async () => {

--- a/apps/api/src/services/deviceDeletion.ts
+++ b/apps/api/src/services/deviceDeletion.ts
@@ -1,6 +1,10 @@
 import * as Sentry from '@sentry/node';
 import { eq, sql } from 'drizzle-orm';
 import { devices } from '../db/schema';
+// Shared postgres-js/drizzle row-count reader. Imported rather than re-derived:
+// this repo already has six copies of the same three-shape check, and getting it
+// wrong here reports the opposite of the truth (see the lock check below).
+import { extractRowCount } from '../jobs/deviceMetricsRetention';
 import {
   DEVICE_DETACH_DEVICE_ID_TABLES,
   DEVICE_LINKED_DEVICE_ID_TABLES,
@@ -8,9 +12,59 @@ import {
 } from '../routes/devices/core';
 
 /**
+ * Bound on how long the parent-row lock below may wait.
+ *
+ * Without it, converting a deadlock into a plain lock wait trades a fast 40P01
+ * for a potentially unbounded block on a request-path DELETE — and a hung
+ * transaction holds its pooled connection, which has been a recurring
+ * production failure here rather than a hypothetical. A deadlock resolves in
+ * milliseconds; a wait behind a long-running site move does not. Bounding it
+ * turns that case into a fast 55P03 (lock_not_available), which the permanent
+ * -delete route maps to a retryable 409 rather than a generic 500.
+ *
+ * The setting is RESTORED immediately after the lock is taken — see below. It
+ * must not stay in force for the child deletes or for the caller's later work.
+ */
+const DEVICE_LOCK_TIMEOUT_MS = 3000;
+
+/**
+ * Read `current_setting('lock_timeout')` out of a postgres-js result.
+ *
+ * postgres-js resolves to an array-like of row objects, so the value is at
+ * `[0].lock_timeout`.
+ *
+ * Throws rather than substituting a default. There is no safe guess: `'0'`
+ * means "wait forever" in Postgres, so inventing it would silently WIDEN a
+ * caller or role that had deliberately set a stricter timeout, for the whole
+ * remainder of the outer transaction. This can only fire if the driver's result
+ * shape changes, which is precisely the class of silent breakage that produced
+ * the row-count bug this same commit fixes — fail loudly instead. Nothing has
+ * been mutated at this point, so aborting here is safe.
+ */
+function extractLockTimeout(result: unknown): string {
+  const row = Array.isArray(result)
+    ? (result[0] as { lock_timeout?: unknown } | undefined)
+    : undefined;
+  if (typeof row?.lock_timeout !== 'string') {
+    throw new Error(
+      "deleteDeviceCascade: could not read current_setting('lock_timeout') — " +
+        'refusing to change the lock timeout without being able to restore it'
+    );
+  }
+  return row.lock_timeout;
+}
+
+/**
  * Minimal transaction surface this needs — satisfied by a Drizzle tx handle.
- * Typed structurally so callers can pass either a tx or the db handle without
- * dragging Drizzle's full generic transaction type through every signature.
+ * Typed structurally so callers need not drag Drizzle's full generic
+ * transaction type through every signature.
+ *
+ * This MUST be a real transaction (or savepoint), never the raw `db` handle.
+ * Under autocommit each statement commits on its own, which would (a) discard
+ * the transaction-local lock_timeout before the lock is even attempted, (b)
+ * release the parent row lock before the first child delete — defeating the
+ * entire point of this function — and (c) allow a half-finished cascade to
+ * persist. Both callers pass a transaction; keep it that way.
  */
 export interface DeviceDeletionTx {
   execute(query: unknown): Promise<unknown>;
@@ -27,8 +81,9 @@ export interface DeviceDeletionTx {
  * orphaned-row bugs in this repo before.
  *
  * Order matters and is not alphabetical:
- *   0. lock the devices row (SELECT ... FOR UPDATE) so this transaction takes
- *      the parent lock first, matching every other writer — see below
+ *   0. bound the wait (transaction-local lock_timeout), then lock the devices
+ *      row (SELECT ... FOR UPDATE) so this transaction takes the parent lock
+ *      first, matching every other writer — see below
  *   1. transitive children (rows referencing alerts/ai_sessions, which
  *      themselves reference the device) — they have no device_id of their own
  *   2. linked_device_id and device_id detach targets set to NULL (business
@@ -72,10 +127,43 @@ export async function deleteDeviceCascade(
   // must NOT abort — two reapers racing would then error instead of one simply
   // finding nothing. Report it instead, so an unserialized cascade is visible
   // rather than silently assumed safe.
-  const locked = (await tx.execute(
+  //
+  // Bound the wait, then put it back.
+  //
+  // `set_config(..., true)` is transaction-local, NOT statement-local: Postgres
+  // applies lock_timeout to every subsequent lock acquisition until the
+  // transaction ends. Both callers already run inside an outer transaction
+  // (withDbAccessContext opens one — db/index.ts), and a nested
+  // `db.transaction()` is only a SAVEPOINT, whose release does NOT undo a
+  // SET LOCAL. So without an explicit restore this 3s bound would silently
+  // govern every child DELETE below, the route's link-group dissolution, and —
+  // in the reaper, which wraps its whole pass in one context — every device
+  // purged after this one. Capture the caller's value and restore it as soon as
+  // the row lock is held; the lock itself survives to transaction end, so the
+  // timeout does not need to stay in force.
+  const priorLockTimeout = extractLockTimeout(
+    await tx.execute(sql`SELECT current_setting('lock_timeout') AS lock_timeout`)
+  );
+  await tx.execute(
+    sql`select set_config('lock_timeout', ${`${DEVICE_LOCK_TIMEOUT_MS}ms`}, true)`
+  );
+  const locked = await tx.execute(
     sql`SELECT id FROM devices WHERE id = ${deviceId} FOR UPDATE`
-  )) as { rowCount?: number | null; rows?: unknown[] } | undefined;
-  const lockedRows = locked?.rowCount ?? locked?.rows?.length ?? 0;
+  );
+  // Restored only on the success path, deliberately. If the lock times out the
+  // statement aborts the (sub)transaction, and any statement issued after that
+  // fails with 25P02 — a `finally` here would mask the 55P03 the caller needs
+  // to see. Nothing leaks on that path: rolling back to the savepoint that
+  // precedes a SET LOCAL undoes it, which is exactly what Drizzle's nested
+  // transaction does on error.
+  await tx.execute(
+    sql`select set_config('lock_timeout', ${priorLockTimeout}, true)`
+  );
+  // postgres-js resolves to an array-like carrying `.count` — NOT node-postgres'
+  // `.rowCount`/`.rows`. Reading the wrong shape yields 0 on every call, which
+  // would fire the warning below on every successful delete and bury the one
+  // signal that the RLS/absent-row branch actually happened.
+  const lockedRows = extractRowCount(locked);
   if (lockedRows === 0) {
     Sentry.captureMessage('device cascade ran without holding the devices row lock', {
       level: 'warning',

--- a/apps/api/src/services/deviceDeletion.ts
+++ b/apps/api/src/services/deviceDeletion.ts
@@ -1,10 +1,13 @@
-import * as Sentry from '@sentry/node';
 import { eq, sql } from 'drizzle-orm';
+// The wrapper, NOT raw `@sentry/node`: it carries the init guard and scrubEvent.
+import { captureMessage } from './sentry';
 import { devices } from '../db/schema';
 // Shared postgres-js/drizzle row-count reader. Imported rather than re-derived:
-// this repo already has six copies of the same three-shape check, and getting it
-// wrong here reports the opposite of the truth (see the lock check below).
-import { extractRowCount } from '../jobs/deviceMetricsRetention';
+// this repo already has several copies of the same three-shape check, and
+// getting it wrong here reports the opposite of the truth (see the lock check
+// below). It lives in `db/` so this request-path service does not import from
+// `jobs/`, which would drag BullMQ + ioredis into a plain DELETE's module graph.
+import { extractRowCount } from '../db/rowCount';
 import {
   DEVICE_DETACH_DEVICE_ID_TABLES,
   DEVICE_LINKED_DEVICE_ID_TABLES,
@@ -28,30 +31,25 @@ import {
 const DEVICE_LOCK_TIMEOUT_MS = 3000;
 
 /**
- * Read `current_setting('lock_timeout')` out of a postgres-js result.
+ * Read the `prior_ms` column out of the tighten-and-report statement below.
  *
  * postgres-js resolves to an array-like of row objects, so the value is at
- * `[0].lock_timeout`.
+ * `[0].prior_ms`. `bigint` comes back as a string, hence the Number().
  *
- * Throws rather than substituting a default. There is no safe guess: `'0'`
- * means "wait forever" in Postgres, so inventing it would silently WIDEN a
- * caller or role that had deliberately set a stricter timeout, for the whole
- * remainder of the outer transaction. This can only fire if the driver's result
- * shape changes, which is precisely the class of silent breakage that produced
- * the row-count bug this same commit fixes — fail loudly instead. Nothing has
- * been mutated at this point, so aborting here is safe.
+ * Returns null if it is not there in the shape we expect. That is NOT a
+ * decision point about whether to bound the lock — by the time this runs the
+ * bound has ALREADY been applied inside the same SQL statement, so an
+ * unreadable value only costs us the ability to restore the caller's original
+ * setting afterwards. See the call site for why that direction is safe.
  */
-function extractLockTimeout(result: unknown): string {
+function extractPriorLockTimeoutMs(result: unknown): number | null {
   const row = Array.isArray(result)
-    ? (result[0] as { lock_timeout?: unknown } | undefined)
+    ? (result[0] as { prior_ms?: unknown } | undefined)
     : undefined;
-  if (typeof row?.lock_timeout !== 'string') {
-    throw new Error(
-      "deleteDeviceCascade: could not read current_setting('lock_timeout') — " +
-        'refusing to change the lock timeout without being able to restore it'
-    );
-  }
-  return row.lock_timeout;
+  const raw = row?.prior_ms;
+  if (typeof raw === 'number') return Number.isFinite(raw) ? raw : null;
+  if (typeof raw === 'string' && /^\d+$/.test(raw)) return Number(raw);
+  return null;
 }
 
 /**
@@ -141,12 +139,56 @@ export async function deleteDeviceCascade(
   // purged after this one. Capture the caller's value and restore it as soon as
   // the row lock is held; the lock itself survives to transaction end, so the
   // timeout does not need to stay in force.
-  const priorLockTimeout = extractLockTimeout(
-    await tx.execute(sql`SELECT current_setting('lock_timeout') AS lock_timeout`)
-  );
-  await tx.execute(
-    sql`select set_config('lock_timeout', ${`${DEVICE_LOCK_TIMEOUT_MS}ms`}, true)`
-  );
+  // Tighten the lock bound and read the caller's prior value in ONE statement,
+  // entirely in SQL.
+  //
+  // `pg_settings.setting` for `lock_timeout` is a plain INTEGER of milliseconds
+  // (verified on Postgres 16: `0`, `250`, `7000`, always with unit `ms`),
+  // unlike `current_setting`, which renders `250ms` / `3s` / `2min` and has to
+  // be unit-parsed on the client. Doing the comparison here removes that parser
+  // and, more importantly, removes the failure mode it created: an earlier
+  // revision decided whether to bound the lock based on a value it had to
+  // decode first, so an unreadable result meant choosing between aborting a
+  // delete whose SELF_UNINSTALL had already gone out and proceeding on an
+  // UNBOUNDED wait that pins a pooled connection. This statement always leaves
+  // the timeout bounded, so neither branch can arise.
+  //
+  // `ms = 0` is Postgres's "disable the timeout", i.e. infinitely loose, so it
+  // is always worth tightening. A caller already stricter than the bound keeps
+  // its own value — this must never WIDEN a stricter caller, since SET LOCAL
+  // lasts for the rest of the outer transaction.
+  const tightened = await tx.execute(sql`
+    WITH prior AS (SELECT setting::bigint AS ms FROM pg_settings WHERE name = 'lock_timeout')
+    SELECT prior.ms AS prior_ms,
+           set_config(
+             'lock_timeout',
+             (CASE WHEN prior.ms = 0 OR prior.ms > ${DEVICE_LOCK_TIMEOUT_MS}
+                   THEN ${DEVICE_LOCK_TIMEOUT_MS}
+                   ELSE prior.ms END)::text || 'ms',
+             true
+           ) AS applied
+    FROM prior
+  `);
+  const priorMs = extractPriorLockTimeoutMs(tightened);
+  // Restore only if we both changed it and can name what it was. Skipping the
+  // restore leaves the 3s bound in force for the caller's remaining work, which
+  // is STRICTER than what they had — the safe direction. Reported with an
+  // allowlisted tag because `scrubEvent` strips message/extra from every event,
+  // so an unallowlisted warning arrives as a contentless blank.
+  // Restore only if the statement above actually CHANGED the setting, which it
+  // did exactly when the caller's value was 0 (disabled) or looser than the
+  // bound. A stricter caller was left alone, so there is nothing to put back
+  // and re-issuing its own value would just be a wasted round trip.
+  const changed = priorMs !== null && (priorMs === 0 || priorMs > DEVICE_LOCK_TIMEOUT_MS);
+  const restoreTo = changed ? priorMs : null;
+  if (priorMs === null) {
+    captureMessage(
+      'device cascade could not read the prior lock_timeout',
+      'warning',
+      undefined,
+      { device_deletion_warning: 'lock-timeout-unreadable' }
+    );
+  }
   const locked = await tx.execute(
     sql`SELECT id FROM devices WHERE id = ${deviceId} FOR UPDATE`
   );
@@ -156,20 +198,23 @@ export async function deleteDeviceCascade(
   // to see. Nothing leaks on that path: rolling back to the savepoint that
   // precedes a SET LOCAL undoes it, which is exactly what Drizzle's nested
   // transaction does on error.
-  await tx.execute(
-    sql`select set_config('lock_timeout', ${priorLockTimeout}, true)`
-  );
+  if (restoreTo !== null) {
+    await tx.execute(
+      sql`select set_config('lock_timeout', ${`${restoreTo}ms`}, true)`
+    );
+  }
   // postgres-js resolves to an array-like carrying `.count` — NOT node-postgres'
   // `.rowCount`/`.rows`. Reading the wrong shape yields 0 on every call, which
   // would fire the warning below on every successful delete and bury the one
   // signal that the RLS/absent-row branch actually happened.
   const lockedRows = extractRowCount(locked);
   if (lockedRows === 0) {
-    Sentry.captureMessage('device cascade ran without holding the devices row lock', {
-      level: 'warning',
-      tags: { area: 'device-deletion' },
-      extra: { deviceId, reason: 'device row absent or filtered by RLS' },
-    });
+    captureMessage(
+      'device cascade ran without holding the devices row lock',
+      'warning',
+      undefined,
+      { device_deletion_warning: 'parent-lock-missing' }
+    );
   }
 
   const deviceAlertIds = sql`(SELECT id FROM alerts WHERE device_id = ${deviceId})`;

--- a/apps/api/src/services/deviceDeletion.ts
+++ b/apps/api/src/services/deviceDeletion.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import { eq, sql } from 'drizzle-orm';
 import { devices } from '../db/schema';
 import {
@@ -26,6 +27,8 @@ export interface DeviceDeletionTx {
  * orphaned-row bugs in this repo before.
  *
  * Order matters and is not alphabetical:
+ *   0. lock the devices row (SELECT ... FOR UPDATE) so this transaction takes
+ *      the parent lock first, matching every other writer — see below
  *   1. transitive children (rows referencing alerts/ai_sessions, which
  *      themselves reference the device) — they have no device_id of their own
  *   2. linked_device_id and device_id detach targets set to NULL (business
@@ -40,6 +43,47 @@ export async function deleteDeviceCascade(
   tx: DeviceDeletionTx,
   deviceId: string,
 ): Promise<void> {
+  // Take the PARENT lock first, before any child table is touched.
+  //
+  // FK constraints force children-before-parent for the DELETEs themselves, so
+  // the delete order cannot be inverted to match the rest of the codebase. That
+  // leaves this transaction acquiring child locks first while every other
+  // writer spanning both levels — re-enrollment, site move, moveOrg, and
+  // PUT /agents/:id/network since #3739 — takes the devices row first. A
+  // permanent delete racing any of them on the same device is a textbook AB-BA
+  // deadlock (Postgres 40P01, the class of failure #3739 fixed as BREEZE-1S).
+  //
+  // A SELECT ... FOR UPDATE restores devices-first ordering without violating
+  // the FK delete order, and gives the cascade a serialization point against
+  // concurrent agent writes. It must stay the FIRST statement here: this
+  // function is the single choke point both the route and the Quick Support
+  // reaper go through, so the lock cannot be forgotten by a new caller.
+  //
+  // IMPORTANT — the guarantee is conditional, and issuing this statement is NOT
+  // the same as holding the lock. FOR UPDATE locks only rows the statement can
+  // SEE, so it locks nothing when the device row is already gone (a re-run, or
+  // two reapers racing) or when RLS filters it out — this cascade runs inside
+  // the caller's tenant-scoped context, and at least one table it touches is
+  // deliberately invisible under that policy (see the abuse_endpoint_fingerprints
+  // note below). In that case the child cleanup below proceeds under the OLD
+  // child-first ordering, which is the exact race this lock exists to close.
+  //
+  // Deleting an absent device is legitimately idempotent, so a zero-row result
+  // must NOT abort — two reapers racing would then error instead of one simply
+  // finding nothing. Report it instead, so an unserialized cascade is visible
+  // rather than silently assumed safe.
+  const locked = (await tx.execute(
+    sql`SELECT id FROM devices WHERE id = ${deviceId} FOR UPDATE`
+  )) as { rowCount?: number | null; rows?: unknown[] } | undefined;
+  const lockedRows = locked?.rowCount ?? locked?.rows?.length ?? 0;
+  if (lockedRows === 0) {
+    Sentry.captureMessage('device cascade ran without holding the devices row lock', {
+      level: 'warning',
+      tags: { area: 'device-deletion' },
+      extra: { deviceId, reason: 'device row absent or filtered by RLS' },
+    });
+  }
+
   const deviceAlertIds = sql`(SELECT id FROM alerts WHERE device_id = ${deviceId})`;
   const deviceAiSessionIds = sql`(SELECT id FROM ai_sessions WHERE device_id = ${deviceId})`;
 

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -73,6 +73,15 @@ const ALLOWED_TAG_NAMES = new Set([
   // bucketEventLoopLag); neither carries a tenant, device, or host identifier.
   'connect_timeout_cause',
   'event_loop_lag_bucket',
+  // #3759: the device cascade warns in two situations an operator must be able
+  // to tell apart — it could not read the caller's prior `lock_timeout` back
+  // (so the bound stays in force instead of being restored), or the parent row
+  // lock matched no row (so the cascade ran under the old child-first ordering,
+  // the exact race the lock exists to close). `scrubEvent` deletes `message`,
+  // `logentry` and `extra` from every event, so without this the warning
+  // arrives as a contentless, ungroupable blank. Closed two-value set, written
+  // as string literals at both call sites; carries no tenant or device id.
+  'device_deletion_warning',
   // #3214: the pool-health watchdog's verdict is the ONLY part of its report
   // that can survive to Sentry — `scrubEvent` deletes `message`, `logentry` and
   // `extra` from every event, so an unallowlisted verdict would arrive as a

--- a/apps/api/src/utils/pgErrors.ts
+++ b/apps/api/src/utils/pgErrors.ts
@@ -38,6 +38,27 @@ export function isPgUniqueViolation(err: unknown, constraint?: string): boolean 
  * that branch on several codes; for a simple unique check prefer
  * {@link isPgUniqueViolation}. Returns undefined if no SQLSTATE is found.
  */
+/**
+ * Returns the error object that actually carries the SQLSTATE, unwrapping the
+ * DrizzleQueryError `.cause` chain — so `code`, `detail`, `table_name`,
+ * `constraint_name` and friends are all read from the SAME node.
+ *
+ * Use this instead of {@link pgErrorCode} whenever the handler needs more than
+ * the code. Unwrapping only the code and then reading `detail` off the OUTER
+ * error yields a blank detail on every Drizzle-issued statement, which is how a
+ * mapper ends up returning "related records in undefined".
+ */
+export function pgErrorNode(err: unknown): Record<string, unknown> | undefined {
+  let cur: unknown = err;
+  for (let depth = 0; cur && typeof cur === 'object' && depth < 5; depth++) {
+    if (typeof (cur as { code?: unknown }).code === 'string') {
+      return cur as Record<string, unknown>;
+    }
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  return undefined;
+}
+
 export function pgErrorCode(err: unknown): string | undefined {
   let cur: unknown = err;
   for (let depth = 0; cur && typeof cur === 'object' && depth < 5; depth++) {


### PR DESCRIPTION
Fixes #3759. Your enumeration made this straightforward — thanks for listing the transactions you'd confirmed *not* at risk, that saved re-deriving it.

`SELECT ... FOR UPDATE` on the devices row as the first statement, inside `deleteDeviceCascade` rather than at the call sites. It's the one choke point both `DELETE /devices/:id/permanent` and the Quick Support reaper go through, so a future caller can't forget it.

**One thing I want to flag, because my first version claimed a guarantee it hadn't established.** Issuing the statement isn't the same as holding the lock. `FOR UPDATE` locks only rows it can *see*, so it locks nothing when:

- the device row is already gone — a re-run, or two reapers racing, and
- **RLS filters it.** This matters here specifically: the cascade runs inside the caller's tenant-scoped context, and this file's own comment notes that `abuse_endpoint_fingerprints` is deliberately invisible under that policy. If the parent is filtered while any child is reachable, the cascade proceeds under exactly the child-first ordering the lock exists to remove.

Aborting on zero rows would be wrong — deleting an absent device is legitimately idempotent, and two reapers racing would error instead of one finding nothing. So it reports instead. An unserialized cascade is now *visible* rather than silently assumed safe, and the comment states the precondition rather than implying the lock is unconditional.

**On the tests, honestly scoped.** They assert the ordering contract — lock issued before any child table, devices row deleted last — and both zero-row branches. They do **not** prove Postgres acquired a row lock, that RLS didn't filter it, or that two transactions serialize; that needs two real connections and belongs in an integration test. What they do cover is what a refactor can silently break, which is the failure mode that produced this issue.

deviceDeletion 4 pass, quickSupportReaper 14 pass, `src/routes/devices` 506 across 38 files, `tsc --noEmit` clean. Removing either the lock or the zero-row report fails its test.

**One question I deliberately did not decide for you.** This converts a fast `40P01` into a potentially unbounded lock wait on a request-path DELETE. There's no `lock_timeout` convention in the repo, though there is a transaction-local `statement_timeout` precedent (`softwareInventory.ts:378`, `filterEngine.ts:569`). Bounding it would make the conflict fast and retryable rather than a hang — but that changes failure semantics on a delete path, so it seemed like your call rather than something to slip into a lock-ordering fix. `SKIP LOCKED` would be wrong here: it recreates the zero-row-unlocked problem.
