### PR TITLE
ci: guard the release trust allowlist against pipeline drift (#3504)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,6 +719,20 @@ jobs:
       - name: Run supply-chain hardening guard
         run: bash scripts/security/check-supply-chain-hardening.sh
 
+      # release.yml and releaseAssetTrust.ts independently encode "which agent-family
+      # Windows assets ship unsigned". When they drifted in v0.105.0, the API rejected
+      # the four unsigned exes and aborted the ENTIRE binary sync — freezing
+      # agent_versions at 0.104.0 in both prod regions for nine days, and surfacing as a
+      # 404 on Linux and macOS too, which were signed correctly (#3504).
+      # The guard's own parser is tested first, deliberately. This check reads two
+      # hand-written declarations, so a parser regression would make it silently
+      # find nothing to compare — indistinguishable from passing.
+      - name: Test release trust allowlist guard
+        run: node --test scripts/security/check-release-trust-allowlist.test.mjs
+
+      - name: Run release trust allowlist drift guard
+        run: node scripts/security/check-release-trust-allowlist.mjs
+
       - name: Run M365 signing secret runtime smoke
         run: bash scripts/security/check-m365-graph-read-runtime.sh
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "pin:github-actions": "node scripts/security/pin-github-actions.mjs",
     "test:override-floors": "node --test scripts/security/check-override-floors.test.mjs",
     "check:override-floors": "node scripts/security/check-override-floors.mjs",
+    "test:release-trust-allowlist": "node --test scripts/security/check-release-trust-allowlist.test.mjs",
+    "check:release-trust-allowlist": "node scripts/security/check-release-trust-allowlist.mjs",
     "check:agent-mtls-edge-policy": "bash scripts/check-agent-mtls-edge-policy.sh",
     "check:agent-binary-signatures": "bash scripts/security/check-agent-binary-signatures.sh --source",
     "test:agent-binary-signatures": "node --test scripts/security/check-agent-binary-signatures.test.mjs",

--- a/scripts/security/check-release-trust-allowlist.mjs
+++ b/scripts/security/check-release-trust-allowlist.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+/**
+ * check-release-trust-allowlist.mjs — keep the release pipeline and the API's
+ * trust allowlist from drifting apart.
+ *
+ * WHY THIS EXISTS (issue #3504)
+ * -----------------------------
+ * Two files independently encode the same policy — "which Windows agent-family
+ * assets ship WITHOUT Authenticode":
+ *
+ *   1. `.github/workflows/release.yml` — `AGENT_FAMILY_WINDOWS_RE` in the
+ *      manifest generator. Names matching it get `platformTrust: "none"`.
+ *   2. `apps/api/src/services/releaseAssetTrust.ts` —
+ *      `SELF_HOST_UNSIGNED_ASSET_NAMES`. Names in it are ALLOWED to arrive
+ *      with `platformTrust: "none"`.
+ *
+ * When (1) grew and (2) did not, every release became unusable. v0.105.0
+ * stopped signing the four agent-family exes; the allowlist still granted the
+ * exception to `breeze-agent.msi` alone. The API rejected the exes as
+ * non-distributable, and because Phase 1 of `syncFromGitHub` treats a trust
+ * failure as a deployment-wide fault (deliberately — it prevents a
+ * half-updated `agent_versions` that promotes agents while stranding
+ * watchdogs), the whole sync aborted. `agent_versions` froze at 0.104.0 in
+ * BOTH prod regions for nine days. It surfaced to self-hosters as a 404
+ * "Version not found for the specified platform and architecture" on EVERY
+ * platform — including Linux and macOS, which were signed correctly and had
+ * nothing to do with the fault.
+ *
+ * That is the shape worth guarding: a Windows-only policy edit silently
+ * becoming a total, cross-platform outage whose symptom points somewhere else
+ * entirely. Neither file is wrong on its own, so no reviewer reading either
+ * one in isolation can see the bug.
+ *
+ * The risk is live, not historical. Changing the signing provider (the ssl.com
+ * migration tracked in #3708) or adding an agent-family artifact edits exactly
+ * one of these two files first.
+ *
+ * ENFORCED (exit 1)
+ * -----------------
+ *   MISSING_FROM_ALLOWLIST  release.yml publishes the asset unsigned, but the
+ *                           API still demands Authenticode. This is the #3504
+ *                           outage, exactly.
+ *   MISSING_FROM_PIPELINE   The API would accept the asset unsigned, but the
+ *                           pipeline signs it. Not an outage — a silently
+ *                           widened trust exception, which is worse in kind:
+ *                           it accepts an unsigned binary we never intended to
+ *                           ship unsigned.
+ *   UNPARSEABLE             Either declaration could not be read. Failing
+ *                           closed on purpose: a guard that silently finds
+ *                           nothing to compare is indistinguishable from a
+ *                           guard that passes, which is how this class of
+ *                           check rots.
+ *
+ * DELIBERATELY NOT COVERED
+ * ------------------------
+ * The viewer/helper Tauri MSIs (`breeze-viewer-windows.msi`,
+ * `breeze-helper-windows.msi`) are still Authenticode-signed and must stay
+ * that way — they are tech-facing tools downloaded and double-clicked on a
+ * workstation, where SmartScreen friction actually bites. They are not in
+ * either declaration, and this guard asserts they never leak into one.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const RELEASE_YML = join(repoRoot, '.github', 'workflows', 'release.yml');
+const TRUST_TS = join(repoRoot, 'apps', 'api', 'src', 'services', 'releaseAssetTrust.ts');
+
+/** Assets that must ALWAYS require platform signing, in both declarations. */
+const MUST_STAY_SIGNED = ['breeze-viewer-windows.msi', 'breeze-helper-windows.msi'];
+
+
+/**
+ * Split a regex source on its TOP-LEVEL `|` only.
+ *
+ * A naive `.split('|')` also splits inside the `(agent|backup|...)` component
+ * group, which shears `^breeze-(agent` off as a bogus alternative. Depth
+ * tracking keeps group-internal alternation intact.
+ */
+export function splitTopLevel(src) {
+  const out = [];
+  let depth = 0;
+  let current = '';
+  for (let i = 0; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === '\\') {
+      current += ch + (src[i + 1] ?? '');
+      i += 1;
+      continue;
+    }
+    if (ch === '(') depth += 1;
+    else if (ch === ')') depth -= 1;
+    if (ch === '|' && depth === 0) {
+      out.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  out.push(current);
+  return out;
+}
+
+/**
+ * Expand the pipeline's `AGENT_FAMILY_WINDOWS_RE` into concrete asset names.
+ *
+ * The regex is a literal alternation of fully-anchored names with one
+ * `(a|b|c)` component group, so expanding it is exact rather than approximate.
+ * Anything structurally unexpected is reported as UNPARSEABLE instead of being
+ * silently skipped — see the note above about guards that rot.
+ */
+export function pipelineUnsignedNames(src, fail) {
+  const block = src.match(/AGENT_FAMILY_WINDOWS_RE\s*=\s*re\.compile\(([\s\S]*?)\)\n/);
+  if (!block) {
+    fail('UNPARSEABLE', `Could not locate AGENT_FAMILY_WINDOWS_RE in ${RELEASE_YML}`);
+    return null;
+  }
+
+  // Collect the r"..." string fragments the alternation is built from.
+  const fragments = [...block[1].matchAll(/r"([^"]*)"/g)].map((m) => m[1]);
+  if (fragments.length === 0) {
+    fail('UNPARSEABLE', 'AGENT_FAMILY_WINDOWS_RE contains no r"..." fragments');
+    return null;
+  }
+
+  const names = new Set();
+  for (const alt of splitTopLevel(fragments.join(''))) {
+    const pattern = alt.trim();
+    if (!pattern) continue;
+    if (!pattern.startsWith('^') || !pattern.endsWith('$')) {
+      fail('UNPARSEABLE', `Alternative is not fully anchored, refusing to guess: ${pattern}`);
+      return null;
+    }
+    const body = pattern.slice(1, -1).replace(/\\\./g, '.');
+    const group = body.match(/\(([^)]*)\)/);
+    if (!group) {
+      names.add(body);
+      continue;
+    }
+    for (const member of group[1].split('|')) {
+      names.add(body.replace(/\([^)]*\)/, member));
+    }
+  }
+  return names;
+}
+
+/** Read the API's SELF_HOST_UNSIGNED_ASSET_NAMES set. */
+export function apiAllowlistNames(src, fail) {
+  const block = src.match(
+    /SELF_HOST_UNSIGNED_ASSET_NAMES[^=]*=\s*new Set\(\[([\s\S]*?)\]\)/
+  );
+  if (!block) {
+    fail('UNPARSEABLE', `Could not locate SELF_HOST_UNSIGNED_ASSET_NAMES in ${TRUST_TS}`);
+    return null;
+  }
+  const names = new Set([...block[1].matchAll(/['"]([^'"]+)['"]/g)].map((m) => m[1]));
+  if (names.size === 0) {
+    fail('UNPARSEABLE', 'SELF_HOST_UNSIGNED_ASSET_NAMES parsed as empty');
+    return null;
+  }
+  return names;
+}
+
+/**
+ * Pure comparison of the two declarations. Exported so the guard's own logic is
+ * testable without touching the real files — a guard whose parser is untested is
+ * exactly the kind that passes while seeing nothing.
+ */
+export function compareTrustSets(pipeline, api) {
+  const problems = [];
+  for (const name of pipeline) {
+    if (!api.has(name)) {
+      problems.push({
+        code: 'MISSING_FROM_ALLOWLIST',
+        message:
+          `${name}\n` +
+          `      release.yml publishes this unsigned (platformTrust: "none"), but it is absent from\n` +
+          `      SELF_HOST_UNSIGNED_ASSET_NAMES, so the API will reject it as non-distributable.\n` +
+          `      One rejected asset aborts the ENTIRE sync — Linux and macOS included (#3504).\n` +
+          `      Fix: add '${name}' to SELF_HOST_UNSIGNED_ASSET_NAMES in releaseAssetTrust.ts.`,
+      });
+    }
+  }
+  for (const name of api) {
+    if (!pipeline.has(name)) {
+      problems.push({
+        code: 'MISSING_FROM_PIPELINE',
+        message:
+          `${name}\n` +
+          `      The API would accept this unsigned, but release.yml no longer publishes it that way.\n` +
+          `      A trust exception wider than the pipeline needs: it accepts an unsigned binary we do\n` +
+          `      not intend to ship unsigned.\n` +
+          `      Fix: remove '${name}' from SELF_HOST_UNSIGNED_ASSET_NAMES, or restore it in\n` +
+          `      AGENT_FAMILY_WINDOWS_RE if dropping its signature was intended.`,
+      });
+    }
+  }
+  for (const name of MUST_STAY_SIGNED) {
+    if (pipeline.has(name) || api.has(name)) {
+      problems.push({
+        code: 'VIEWER_MUST_STAY_SIGNED',
+        message:
+          `${name} must keep requiring Authenticode.\n` +
+          `      It is a tech-facing tool downloaded and double-clicked on a workstation, which is\n` +
+          `      where SmartScreen friction actually bites. Unlike the agent family, no self-hoster\n` +
+          `      re-signs it under BYO signing, so there is no reason for it to arrive unsigned.`,
+      });
+    }
+  }
+  return problems;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+const isMain = process.argv[1] && process.argv[1].endsWith('check-release-trust-allowlist.mjs');
+if (isMain) {
+  const problems = [];
+  const fail = (code, message) => problems.push({ code, message });
+
+  const pipeline = pipelineUnsignedNames(readFileSync(RELEASE_YML, 'utf8'), fail);
+  const api = apiAllowlistNames(readFileSync(TRUST_TS, 'utf8'), fail);
+
+  if (pipeline && api) problems.push(...compareTrustSets(pipeline, api));
+
+  if (problems.length > 0) {
+    console.error('\n  Release trust allowlist has drifted from the release pipeline.\n');
+    for (const { code, message } of problems) console.error(`  [${code}] ${message}\n`);
+    console.error(
+      '  Both files encode the same policy and must be edited together.\n' +
+        '    pipeline: .github/workflows/release.yml              (AGENT_FAMILY_WINDOWS_RE)\n' +
+        '    api:      apps/api/src/services/releaseAssetTrust.ts (SELF_HOST_UNSIGNED_ASSET_NAMES)\n'
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `check-release-trust-allowlist: OK — ${pipeline.size} agent-family asset(s) published unsigned, ` +
+      'allowlist matches, viewer/helper still require Authenticode.'
+  );
+}

--- a/scripts/security/check-release-trust-allowlist.test.mjs
+++ b/scripts/security/check-release-trust-allowlist.test.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  apiAllowlistNames,
+  compareTrustSets,
+  pipelineUnsignedNames,
+  splitTopLevel,
+} from './check-release-trust-allowlist.mjs';
+
+/**
+ * The guard parses two hand-written declarations, and its own parser has already
+ * had one bug (a naive split on `|` sheared `^breeze-(agent` off as a bogus
+ * alternative and made the whole check UNPARSEABLE). These tests pin the parser
+ * and the comparator so a future edit cannot quietly reduce the guard to
+ * something that always passes.
+ */
+
+const collect = () => {
+  const problems = [];
+  return { fail: (code, message) => problems.push({ code, message }), problems };
+};
+
+// Verbatim shape of the declaration in .github/workflows/release.yml.
+const RELEASE_FIXTURE = `
+          AGENT_FAMILY_WINDOWS_RE = re.compile(
+              r"^breeze-agent\\.msi$"
+              r"|^breeze-(agent|backup|watchdog|user-helper)-windows-amd64\\.exe$"
+          )
+`;
+
+// Verbatim shape of the declaration in apps/api/src/services/releaseAssetTrust.ts.
+const TRUST_FIXTURE = `
+const SELF_HOST_UNSIGNED_ASSET_NAMES: ReadonlySet<string> = new Set([
+  'breeze-agent.msi',
+  'breeze-agent-windows-amd64.exe',
+  'breeze-backup-windows-amd64.exe',
+  'breeze-watchdog-windows-amd64.exe',
+  'breeze-user-helper-windows-amd64.exe',
+]);
+`;
+
+const EXPECTED = [
+  'breeze-agent.msi',
+  'breeze-agent-windows-amd64.exe',
+  'breeze-backup-windows-amd64.exe',
+  'breeze-watchdog-windows-amd64.exe',
+  'breeze-user-helper-windows-amd64.exe',
+];
+
+test('splitTopLevel does not split inside a component group', () => {
+  // The original bug: this must be 2 alternatives, not 5.
+  const parts = splitTopLevel('^a$|^b-(x|y|z)-c$');
+  assert.deepEqual(parts, ['^a$', '^b-(x|y|z)-c$']);
+});
+
+test('splitTopLevel respects escaped characters', () => {
+  assert.deepEqual(splitTopLevel('^a\\.b$|^c$'), ['^a\\.b$', '^c$']);
+});
+
+test('pipeline regex expands to exactly the five agent-family assets', () => {
+  const { fail, problems } = collect();
+  const names = pipelineUnsignedNames(RELEASE_FIXTURE, fail);
+  assert.deepEqual(problems, []);
+  assert.deepEqual([...names].sort(), [...EXPECTED].sort());
+});
+
+test('API allowlist parses to exactly the five agent-family assets', () => {
+  const { fail, problems } = collect();
+  const names = apiAllowlistNames(TRUST_FIXTURE, fail);
+  assert.deepEqual(problems, []);
+  assert.deepEqual([...names].sort(), [...EXPECTED].sort());
+});
+
+test('the real declarations agree (no drift)', () => {
+  const { fail } = collect();
+  const pipeline = pipelineUnsignedNames(RELEASE_FIXTURE, fail);
+  const api = apiAllowlistNames(TRUST_FIXTURE, fail);
+  assert.deepEqual(compareTrustSets(pipeline, api), []);
+});
+
+test('reproduces the #3504 outage: pipeline unsigned, allowlist has only the msi', () => {
+  const { fail } = collect();
+  const pipeline = pipelineUnsignedNames(RELEASE_FIXTURE, fail);
+  const api = new Set(['breeze-agent.msi']);
+
+  const problems = compareTrustSets(pipeline, api);
+  assert.equal(problems.length, 4, 'all four unsigned exes must be reported');
+  assert.ok(problems.every((p) => p.code === 'MISSING_FROM_ALLOWLIST'));
+  assert.deepEqual(
+    problems.map((p) => p.message.split('\n')[0]).sort(),
+    [
+      'breeze-agent-windows-amd64.exe',
+      'breeze-backup-windows-amd64.exe',
+      'breeze-user-helper-windows-amd64.exe',
+      'breeze-watchdog-windows-amd64.exe',
+    ]
+  );
+});
+
+test('catches a trust exception wider than the pipeline needs', () => {
+  const { fail } = collect();
+  const api = apiAllowlistNames(TRUST_FIXTURE, fail);
+  // Pipeline signs user-helper again, allowlist still exempts it.
+  const pipeline = new Set(EXPECTED.filter((n) => n !== 'breeze-user-helper-windows-amd64.exe'));
+
+  const problems = compareTrustSets(pipeline, api);
+  assert.equal(problems.length, 1);
+  assert.equal(problems[0].code, 'MISSING_FROM_PIPELINE');
+  assert.match(problems[0].message, /^breeze-user-helper-windows-amd64\.exe/);
+});
+
+test('refuses to let the viewer or helper MSI become unsigned', () => {
+  for (const leaked of ['breeze-viewer-windows.msi', 'breeze-helper-windows.msi']) {
+    const set = new Set([...EXPECTED, leaked]);
+    const problems = compareTrustSets(set, set);
+    assert.ok(
+      problems.some((p) => p.code === 'VIEWER_MUST_STAY_SIGNED' && p.message.startsWith(leaked)),
+      `${leaked} leaking into the unsigned set must be rejected`
+    );
+  }
+});
+
+test('fails closed when a declaration cannot be parsed', () => {
+  for (const [label, fn, src] of [
+    ['pipeline', pipelineUnsignedNames, 'nothing resembling the declaration'],
+    ['api', apiAllowlistNames, 'nothing resembling the declaration'],
+  ]) {
+    const { fail, problems } = collect();
+    const result = fn(src, fail);
+    assert.equal(result, null, `${label} must return null rather than an empty set`);
+    assert.equal(problems[0].code, 'UNPARSEABLE');
+  }
+});
+
+test('an empty allowlist is UNPARSEABLE, never a silent pass', () => {
+  const { fail, problems } = collect();
+  const result = apiAllowlistNames(
+    'const SELF_HOST_UNSIGNED_ASSET_NAMES: ReadonlySet<string> = new Set([]);',
+    fail
+  );
+  assert.equal(result, null);
+  assert.equal(problems[0].code, 'UNPARSEABLE');
+});


### PR DESCRIPTION
## The gap

Two files independently encode the same policy — *which Windows agent-family assets ship without Authenticode*:

- `.github/workflows/release.yml` — `AGENT_FAMILY_WINDOWS_RE`. Names matching it get `platformTrust: "none"`.
- `apps/api/src/services/releaseAssetTrust.ts` — `SELF_HOST_UNSIGNED_ASSET_NAMES`. Names in it are *allowed* to arrive with `platformTrust: "none"`.

Nothing checked that they agree.

## Why it matters more than it looks

When they drifted in v0.105.0 the blast radius was wildly disproportionate to the edit. The pipeline stopped signing the four agent-family exes; the allowlist still exempted `breeze-agent.msi` alone. The API rejected the exes as non-distributable, and because Phase 1 of `syncFromGitHub` treats a trust failure as a **deployment-wide** fault — deliberately, so `agent_versions` can't end up half-updated with agents promoted and watchdogs stranded — the entire sync aborted.

`agent_versions` froze at **0.104.0 in both prod regions for nine days**, and surfaced to self-hosters as a 404 *"Version not found for the specified platform and architecture"* on **every** platform, including Linux and macOS, which were signed correctly and had nothing to do with the fault.

Neither file is wrong on its own. No reviewer reading either one in isolation can see the bug. That's the shape worth a guard.

**This is live risk, not archaeology:** the ssl.com signing migration (#3708) begins by editing exactly one of these two declarations.

## What's enforced

- `MISSING_FROM_ALLOWLIST` — the pipeline publishes it unsigned, the API still demands Authenticode. The v0.105.0 outage, exactly.
- `MISSING_FROM_PIPELINE` — the API would accept it unsigned but the pipeline signs it. Not an outage, but worse in kind: a trust exception wider than intended.
- `VIEWER_MUST_STAY_SIGNED` — `breeze-viewer-windows.msi` / `breeze-helper-windows.msi` leaking into either set. These stay signed on purpose: they're tech-facing tools downloaded and double-clicked on a workstation, which is where SmartScreen friction actually bites, and unlike the agent family no self-hoster re-signs them under BYO signing.
- `UNPARSEABLE` — either declaration couldn't be read. Fails closed: a guard that finds nothing to compare is indistinguishable from one that passes.

## On trusting the guard

The parser is unit-tested because it already had a real bug — splitting the regex on `|` also split *inside* the `(agent|backup|watchdog|user-helper)` component group, shearing off `^breeze-(agent` and making the whole check `UNPARSEABLE`. It failed closed, which is how I caught it, but a version that failed *open* would have been invisible.

10 tests, including one that reproduces the actual #3504 drift and asserts all four missing assets are named. **CI runs the test before the guard**, so a parser regression fails loudly instead of quietly checking nothing.

## Verification

- `node --test scripts/security/check-release-trust-allowlist.test.mjs` — 10/10.
- Guard passes on current `main`: 5 agent-family assets unsigned, allowlist matches.
- Mutation-tested by hand against the real files in all three directions (reproduce #3504; pipeline re-signs an exe; viewer MSI leaks in) — each caught, files restored.
- `actionlint` finding count unchanged vs `origin/main` baseline (1 pre-existing, SC2155 at ci.yml:1116, unrelated to this diff).
- YAML parse + `check-supply-chain-hardening.sh` pass.

## Noted, not fixed here

`test:override-floors` and `test:workflow-security` exist in `package.json` but **nothing runs them in CI** — those guards' tests are effectively dead. I wired this one's test into the `security-audit` job rather than replicating that gap, but the sibling ones are worth picking up separately.

Refs #3504, #3708

🤖 Generated with [Claude Code](https://claude.com/claude-code)