### PR TITLE
ci(release): make the Windows signing CA switchable (Azure | SSL.com)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1529,7 +1529,23 @@ jobs:
           name: breeze-helper-windows.msi
           path: staging/
 
-      - name: Validate signing configuration
+      # WINDOWS SIGNING PROVIDER SWITCH (#3708)
+      #
+      # `vars.WINDOWS_SIGNING_PROVIDER` selects the CA. Unset or anything other
+      # than "sslcom" means Azure, so the existing path is the default and an
+      # absent variable cannot silently disable signing.
+      #
+      # Both providers write an Authenticode signature in place over the same two
+      # staged MSIs, and the shared "Verify signatures" step below validates the
+      # result with Get-AuthenticodeSignature regardless of who produced it — so
+      # the provider swap cannot quietly ship an unsigned artifact.
+      #
+      # Stable vs prerelease certificates are selected by the job's GitHub
+      # Environment (signing-production / signing-prerelease), which is why the
+      # ssl.com path needs one step per file rather than Azure's one per
+      # file-and-profile: the environment already scopes SSLCOM_CREDENTIAL_ID.
+      - name: Validate signing configuration (Azure)
+        if: ${{ vars.WINDOWS_SIGNING_PROVIDER != 'sslcom' }}
         shell: pwsh
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -1544,7 +1560,24 @@ jobs:
             }
           }
 
+      - name: Validate signing configuration (SSL.com)
+        if: ${{ vars.WINDOWS_SIGNING_PROVIDER == 'sslcom' }}
+        shell: pwsh
+        env:
+          SSLCOM_USERNAME: ${{ secrets.SSLCOM_USERNAME }}
+          SSLCOM_PASSWORD: ${{ secrets.SSLCOM_PASSWORD }}
+          SSLCOM_CREDENTIAL_ID: ${{ secrets.SSLCOM_CREDENTIAL_ID }}
+          SSLCOM_TOTP_SECRET: ${{ secrets.SSLCOM_TOTP_SECRET }}
+        run: |
+          $required = @("SSLCOM_USERNAME", "SSLCOM_PASSWORD", "SSLCOM_CREDENTIAL_ID", "SSLCOM_TOTP_SECRET")
+          foreach ($name in $required) {
+            if ([string]::IsNullOrWhiteSpace((Get-Item "env:$name").Value)) {
+              throw "Missing required signing secret: $name"
+            }
+          }
+
       - name: Azure Login (OIDC)
+        if: ${{ vars.WINDOWS_SIGNING_PROVIDER != 'sslcom' }}
         uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -1552,7 +1585,7 @@ jobs:
           allow-no-subscriptions: true
 
       - name: Sign viewer MSI (stable profile)
-        if: ${{ !contains(github.ref_name, '-') }}
+        if: ${{ vars.WINDOWS_SIGNING_PROVIDER != 'sslcom' && !contains(github.ref_name, '-') }}
         uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
@@ -1564,7 +1597,7 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Sign viewer MSI (prerelease profile)
-        if: ${{ contains(github.ref_name, '-') }}
+        if: ${{ vars.WINDOWS_SIGNING_PROVIDER != 'sslcom' && contains(github.ref_name, '-') }}
         uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
@@ -1576,7 +1609,7 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Sign helper MSI (stable profile)
-        if: ${{ !contains(github.ref_name, '-') }}
+        if: ${{ vars.WINDOWS_SIGNING_PROVIDER != 'sslcom' && !contains(github.ref_name, '-') }}
         uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
@@ -1588,7 +1621,7 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Sign helper MSI (prerelease profile)
-        if: ${{ contains(github.ref_name, '-') }}
+        if: ${{ vars.WINDOWS_SIGNING_PROVIDER != 'sslcom' && contains(github.ref_name, '-') }}
         uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
@@ -1598,6 +1631,36 @@ jobs:
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
+
+      # SSL.com eSigner. `override: true` signs in place, matching what the Azure
+      # action does, so the staged paths the verify step checks are unchanged.
+      # No file-digest/timestamp inputs: eSigner timestamps internally rather
+      # than taking an RFC-3161 URL the way azure/artifact-signing-action does.
+      - name: Sign viewer MSI (SSL.com)
+        if: ${{ vars.WINDOWS_SIGNING_PROVIDER == 'sslcom' }}
+        uses: SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b # v1.3.2
+        with:
+          command: sign
+          username: ${{ secrets.SSLCOM_USERNAME }}
+          password: ${{ secrets.SSLCOM_PASSWORD }}
+          credential_id: ${{ secrets.SSLCOM_CREDENTIAL_ID }}
+          totp_secret: ${{ secrets.SSLCOM_TOTP_SECRET }}
+          file_path: ${{ github.workspace }}/staging/breeze-viewer-windows.msi
+          override: true
+          malware_block: false
+
+      - name: Sign helper MSI (SSL.com)
+        if: ${{ vars.WINDOWS_SIGNING_PROVIDER == 'sslcom' }}
+        uses: SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b # v1.3.2
+        with:
+          command: sign
+          username: ${{ secrets.SSLCOM_USERNAME }}
+          password: ${{ secrets.SSLCOM_PASSWORD }}
+          credential_id: ${{ secrets.SSLCOM_CREDENTIAL_ID }}
+          totp_secret: ${{ secrets.SSLCOM_TOTP_SECRET }}
+          file_path: ${{ github.workspace }}/staging/breeze-helper-windows.msi
+          override: true
+          malware_block: false
 
       - name: Verify signatures
         shell: pwsh


### PR DESCRIPTION
## Why

Azure Artifact Signing has returned 403 since 2026-08-12 (#3708). v0.105.2 and v0.106.0 both died at the signing gate, and **172 commits are stranded on `main`** — 127 of them user-visible `fix`/`feat`. SSL.com is the procurement fallback.

This wires the pipeline for SSL.com now, so when the certificate lands the swap is a **repo-variable flip** rather than pipeline surgery performed under pressure. Nothing is switched on here.

## How it works

`vars.WINDOWS_SIGNING_PROVIDER` selects the CA. Unset — or anything other than the literal `"sslcom"` — means Azure. The default is deliberately the *existing* path so an absent or typo'd variable cannot silently disable signing.

The two providers are mutually exclusive and exhaustive: every Azure step gained `!= 'sslcom'`, every SSL.com step is `== 'sslcom'`.

**The safety property that matters:** the shared `Verify signatures` step stays unconditional. It validates with `Get-AuthenticodeSignature`, so it doesn't care which CA produced the signature — a broken provider swap fails the job rather than shipping an unsigned MSI.

## Why SSL.com needs half the steps

Azure uses one step per *file and profile* (viewer/helper × stable/prerelease), because the cert profile is an input. SSL.com's analogue is `credential_id`, and stable vs prerelease is **already** selected by the job's GitHub Environment (`signing-production` / `signing-prerelease`) — the same mechanism that scopes the Azure profile names. So the environment scopes `SSLCOM_CREDENTIAL_ID` and the distinction is preserved with one step per file.

## Verified before writing it, not assumed

- `SSLcom/esigner-codesign` is a **node20** action, not Docker — so it runs on the existing `windows-latest` runner. A Docker action would not have, and that would have surfaced only at swap time.
- `override: true` signs **in place**, matching what `azure/artifact-signing-action` does, so the staged paths `Verify signatures` checks are unchanged.
- eSigner **timestamps internally** rather than taking an RFC-3161 URL, which is why Azure's `file-digest` / `timestamp-rfc3161` / `timestamp-digest` inputs have no counterpart here — their absence is correct, not an omission.
- Pinned to `cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b`, which I resolved from the `v1.3.2` tag ref directly rather than trusting a version string — see #3748 for why that distinction matters in this repo.

## Checks

- `release.yml` YAML parses.
- `actionlint`: **11 findings on this branch, 11 on the `origin/main` baseline** — no new findings.
- `check-supply-chain-hardening.sh` passes (its `release.yml` sentinel greps are intact).
- `test:workflow-security` 57/57; all external actions still SHA-pinned.

## Before flipping the variable

1. Add `SSLCOM_USERNAME`, `SSLCOM_PASSWORD`, `SSLCOM_CREDENTIAL_ID`, `SSLCOM_TOTP_SECRET` to **both** the `signing-production` and `signing-prerelease` environments — `credential_id` is what carries the stable/prerelease distinction.
2. Set `WINDOWS_SIGNING_PROVIDER=sslcom`.
3. Cut a prerelease tag first. `Verify signatures` gives a real pass/fail on the SSL.com path without risking a stable release.

## Certificate count: one is fine

Azure's two cert profiles map to SSL.com `credential_id`s, but a single certificate covers both
stable and prerelease — put the same `SSLCOM_CREDENTIAL_ID` in both environments and nothing else
changes. No code change either way; two certs would work identically if that ever becomes useful.

Refs #3708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
