### PR TITLE
fix(api): mount metricsMiddleware — http_requests_total and agent_heartbeat_total emit nothing in production

### DIFF
--- a/apps/api/src/index.metricsMiddleware.test.ts
+++ b/apps/api/src/index.metricsMiddleware.test.ts
@@ -39,7 +39,9 @@ describe('metricsMiddleware mount (index.ts)', () => {
     // a 429/413 stops being counted at all.
     const metricsAt = indexSource.indexOf("app.use('*', metricsMiddleware)");
     // The CALL site, not the import at the top of the file.
-    const bodyLimitAt = indexSource.indexOf('bodyLimitForPath(c.req.path)');
+    // Main applies the global body limit via createGlobalBodyLimitMiddleware({...})
+    // since #3660; the trailing '({' distinguishes the call from the import.
+    const bodyLimitAt = indexSource.indexOf('createGlobalBodyLimitMiddleware({');
     const rateLimitAt = indexSource.indexOf("app.use('*', globalRateLimit())");
 
     expect(metricsAt).toBeGreaterThan(-1);

--- a/apps/api/src/index.metricsMiddleware.test.ts
+++ b/apps/api/src/index.metricsMiddleware.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Source-level assertions on the metrics middleware MOUNT.
+ *
+ * This suite exists because of the exact shape of the bug it guards. Before this
+ * was written, `metricsMiddleware` was fully implemented and fully unit-tested —
+ * and never mounted. Every test passed while a production scrape carried no
+ * `http_requests_total` and no `http_request_duration_seconds` at all, so the
+ * SOC 2 A1.1 capacity evidence, the "Request Rate by Method" and "Top Endpoints"
+ * panels, and the `HighErrorRate` / `SlowResponseTime` / `EndpointLatencyHigh`
+ * rules all evaluated against an empty vector for months. An empty vector never
+ * fires an alert, so nothing complained.
+ *
+ * The behavioural tests in routes/metrics.test.ts mount the middleware on their
+ * OWN `new Hono()`, which means they can only ever prove it works — never that it
+ * is installed. Deleting the mount from index.ts left all of them green. Reading
+ * the source is the only thing that closes that gap without booting the server.
+ */
+const indexSource = readFileSync(new URL('./index.ts', import.meta.url), 'utf8');
+
+describe('metricsMiddleware mount (index.ts)', () => {
+  it('imports metricsMiddleware from the metrics route module', () => {
+    expect(indexSource).toMatch(
+      /import\s*\{[^}]*\bmetricsMiddleware\b[^}]*\}\s*from\s*'\.\/routes\/metrics'/,
+    );
+  });
+
+  it('mounts it globally on every path', () => {
+    expect(indexSource).toMatch(/app\.use\(\s*'\*'\s*,\s*metricsMiddleware\s*\)/);
+  });
+
+  it('mounts it ahead of rate limiting and the body-limit wrapper', () => {
+    // The docstring on the mount claims the recorded duration covers "the whole
+    // server-side cost of a request — rate limiting and body-limit rejections
+    // included". That is only true while it is registered first; a reorder that
+    // moves it below either one silently narrows what the histogram measures, and
+    // a 429/413 stops being counted at all.
+    const metricsAt = indexSource.indexOf("app.use('*', metricsMiddleware)");
+    // The CALL site, not the import at the top of the file.
+    const bodyLimitAt = indexSource.indexOf('bodyLimitForPath(c.req.path)');
+    const rateLimitAt = indexSource.indexOf("app.use('*', globalRateLimit())");
+
+    expect(metricsAt).toBeGreaterThan(-1);
+    expect(bodyLimitAt).toBeGreaterThan(-1);
+    expect(rateLimitAt).toBeGreaterThan(-1);
+    expect(metricsAt).toBeLessThan(bodyLimitAt);
+    expect(metricsAt).toBeLessThan(rateLimitAt);
+  });
+
+  it('mounts it before any route is registered, so no route escapes instrumentation', () => {
+    // Hono only applies a `use()` to handlers registered after it. A route
+    // registered above the mount is invisible to the counter forever.
+    const metricsAt = indexSource.indexOf("app.use('*', metricsMiddleware)");
+    const firstRouteAt = indexSource.search(/^app\.(get|post|put|patch|delete|route)\(/m);
+
+    expect(firstRouteAt).toBeGreaterThan(-1);
+    expect(metricsAt).toBeLessThan(firstRouteAt);
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -110,7 +110,7 @@ import { vulnerabilityRoutes, vulnerabilitySyncRoutes } from './routes/vulnerabi
 import { systemRoutes } from './routes/system';
 import { systemToolsRoutes } from './routes/systemTools';
 import { notificationRoutes } from './routes/notifications';
-import { metricsRoutes } from './routes/metrics';
+import { metricsRoutes, metricsMiddleware } from './routes/metrics';
 import { groupRoutes } from './routes/groups';
 import { integrationRoutes } from './routes/integrations';
 import { partnerRoutes } from './routes/partner';
@@ -482,6 +482,13 @@ const resolveCorsOrigin = createCorsOriginResolver({
 });
 
 // Global middleware
+// FIRST, deliberately: `http_requests_total` / `http_request_duration_seconds`
+// are the SOC 2 A1.1 capacity signals, and they should measure the whole
+// server-side cost of a request — rate limiting and body-limit rejections
+// included — not just the time spent inside a route handler. Registering it here
+// is also what fixes the underlying gap: the middleware existed and was tested,
+// but was never mounted, so neither series appeared in a production scrape.
+app.use('*', metricsMiddleware);
 app.use('*', requestPathLogger());
 app.use(
   '*',

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -209,6 +209,17 @@ vi.mock('../../services/manifestSigning', () => ({
   },
 }));
 
+// `routes/metrics` is mocked rather than loaded: heartbeat.ts imports
+// `recordAgentHeartbeat` from it directly (as routes/agents/helpers.ts already
+// did), and pulling the real module in would drag the whole metrics + db graph
+// into this suite. `resolveResponseStatus` keeps its real behaviour, since the
+// success/failed split depends on it.
+const recordAgentHeartbeatMock = vi.hoisted(() => vi.fn());
+vi.mock('../metrics', () => ({
+  recordAgentHeartbeat: recordAgentHeartbeatMock,
+  resolveResponseStatus: (c: any) => (c?.finalized ? (c.res?.status ?? 500) : 500),
+}));
+
 import { and, eq, notInArray } from 'drizzle-orm';
 import { heartbeatRoutes } from './heartbeat';
 import { devices } from '../../db/schema';
@@ -864,6 +875,95 @@ const watchdogDeviceRow = {
   watchdogStatus: 'connected',
   watchdogLastSeen: new Date(),
 };
+
+// `agent_heartbeat_total` had a Grafana panel and a `NoAgentHeartbeats` alert rule
+// but no producer — the route never touched the counter, so both read a flat zero
+// against a live fleet. These tests pin the producer in place.
+describe('POST /agents/:id/heartbeat — agent_heartbeat_total producer', () => {
+  let observed: string[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    observed = [];
+    recordAgentHeartbeatMock.mockImplementation((status: string) => {
+      observed.push(status);
+    });
+
+    selectMock.mockReturnValueOnce(selectChainResolving([watchdogDeviceRow]));
+    updateMock.mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) })),
+    });
+    insertMock.mockImplementation(() => ({ values: vi.fn(() => Promise.resolve(undefined)) }));
+    selectMock.mockReturnValue(selectChainResolving([]));
+  });
+
+  it('counts an accepted heartbeat as success', async () => {
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(observed).toEqual(['success']);
+  });
+
+  it('counts a rejected heartbeat as failed', async () => {
+    // No middleware sets `agent`, so the handler short-circuits with a 401.
+    //
+    // In production `agentRoutes.use('/:id/*', agentAuthMiddleware)` sits ABOVE
+    // this router, so a bad or missing agent token is rejected before reaching
+    // the counter — deliberately. `agent_heartbeat_total` answers "are enrolled
+    // agents checking in", and counting unauthenticated traffic to a public URL
+    // would let anyone on the internet inflate it. `failed` therefore means an
+    // authenticated agent whose beat was rejected downstream.
+    const app = new Hono();
+    app.route('/agents', heartbeatRoutes);
+
+    const resp = await app.request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(401);
+    expect(observed).toEqual(['failed']);
+  });
+
+  it('does not count requests to sibling routes on the same router', async () => {
+    const resp = await buildApp().request('/agents/device-1/config');
+
+    expect(resp.status).toBe(200);
+    expect(observed).toEqual([]);
+  });
+
+  // The middleware is POST-scoped. `use()` would register for every method, and an
+  // authenticated GET to this path 404s — which would be counted as a failed
+  // heartbeat and drag `NoAgentHeartbeats` toward firing on pure noise.
+  it('does not count a non-POST request to the heartbeat path', async () => {
+    const resp = await buildApp().request('/agents/device-1/heartbeat');
+
+    expect(resp.status).toBe(404);
+    expect(observed).toEqual([]);
+  });
+
+  // Pins the docstring claim that the middleware sits OUTSIDE `bodyLimit`, which
+  // holds only because the `on('POST', ...)` is registered before the route. An
+  // agent that starts sending oversized payloads is exactly what this counter is
+  // meant to surface, so the 413 must be counted rather than vanish.
+  // (`zValidator` is mocked to a passthrough in this suite, so the schema-rejection
+  // half of that claim cannot be exercised here — bodyLimit is the real thing.)
+  it('counts an oversized heartbeat rejected by bodyLimit as failed', async () => {
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'x'.repeat(5 * 1024 * 1024 + 1),
+    });
+
+    expect(resp.status).toBe(413);
+    expect(observed).toEqual(['failed']);
+  });
+});
 
 describe('POST /agents/:id/heartbeat — watchdog restart-stats logging (#799)', () => {
   // Track the values passed to the most recent agentLogs insert.

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -48,6 +48,7 @@ import {
 } from '../../services/manifestSigning';
 import { decryptClaimedCommandsForDelivery } from '../../services/commandDelivery';
 import { redactSecretsDeep } from '../../services/secretRedaction';
+import { recordAgentHeartbeat, resolveResponseStatus } from '../metrics';
 
 /**
  * #1121 — pure collapse detector for the watchdogState tolerance gap.
@@ -133,6 +134,45 @@ export function watchdogRestartLogCacheSizeForTests(): number {
 }
 
 export const heartbeatRoutes = new Hono();
+
+/**
+ * Producer for `agent_heartbeat_total`. The counter, its Grafana panel, and the
+ * `NoAgentHeartbeats` alert rule all predate this — nothing ever incremented it,
+ * so the panel read a flat zero against a live fleet.
+ *
+ * Recorded from a route-scoped middleware rather than at each `return`: the
+ * handler below has five response points plus awaited service calls that can
+ * throw, and a per-exit call would inevitably drift out of sync with them. The
+ * middleware also sits outside `bodyLimit` and `zValidator`, so a rejected
+ * oversized or malformed heartbeat is counted as `failed` instead of vanishing —
+ * an agent that has started sending garbage is exactly what this signal is for.
+ *
+ * It sits INSIDE agent-token auth, though: `agentRoutes.use('/:id/*', ...)` in
+ * ./index.ts rejects a bad or missing token before this router is reached. That
+ * is deliberate. The counter answers "are enrolled agents checking in", and
+ * counting unauthenticated requests to a publicly reachable URL would let anyone
+ * inflate it. `failed` means an authenticated agent whose beat was rejected.
+ *
+ * Scoped to POST because `use()` registers for every method, and an authenticated
+ * GET to this path 404s — which would otherwise be counted as a failed heartbeat.
+ *
+ * Registered before the handler because Hono only wraps handlers declared after
+ * the `use()` that is meant to cover them.
+ */
+heartbeatRoutes.on('POST', '/:id/heartbeat', async (c, next) => {
+  try {
+    await next();
+  } finally {
+    // `resolveResponseStatus`, not `c.res.status`: an unfinalized context yields a
+    // synthesised 200, which would book a request the client saw as a 500 as a
+    // SUCCESSFUL heartbeat. See the helper for the two ways that happens.
+    try {
+      recordAgentHeartbeat(resolveResponseStatus(c) < 400 ? 'success' : 'failed');
+    } catch (error) {
+      console.warn('[heartbeat] Failed to record heartbeat metric:', error);
+    }
+  }
+});
 
 heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onError: (c) => c.json({ error: 'Request body too large' }, 413) }), zValidator('json', heartbeatSchema), async (c) => {
   const agentId = c.req.param('id');

--- a/apps/api/src/routes/agents/heartbeatMetricsGate.test.ts
+++ b/apps/api/src/routes/agents/heartbeatMetricsGate.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+/**
+ * `agent_heartbeat_total` is produced by a middleware registered INSIDE
+ * `heartbeatRoutes`, which is in turn mounted below the agent-token gate in
+ * ./index.ts (`agentRoutes.use('/:id/*', ...)`).
+ *
+ * heartbeat.test.ts mounts `heartbeatRoutes` on a bare `new Hono()`, so it can
+ * only prove the counter fires — never that the gate sits above it. This suite
+ * composes the REAL `agentRoutes` so the ordering itself is under test. Two
+ * distinct regressions would otherwise ship silently:
+ *
+ *   1. Moving `agentRoutes.route('/', heartbeatRoutes)` above the `use('/:id/*')`
+ *      gate, or adding 'heartbeat' to AGENT_AUTH_SKIP_ID_SEGMENTS, makes the
+ *      counter writable by anyone who can reach POST /agents/<anything>/heartbeat.
+ *      `NoAgentHeartbeats` would then be suppressible — and inflatable — from the
+ *      open internet.
+ *   2. Removing the gate's `next()` passthrough would stop authenticated beats
+ *      from ever reaching the counter, restoring the flat zero this fixes.
+ */
+
+const recordAgentHeartbeatMock = vi.hoisted(() => vi.fn());
+vi.mock('../metrics', () => ({
+  recordAgentHeartbeat: recordAgentHeartbeatMock,
+  resolveResponseStatus: (c: any) => (c?.finalized ? (c.res?.status ?? 500) : 500),
+  // Pulled in by routes/agents/helpers.ts, which the heartbeat route imports.
+  recordSensitiveDataFinding: vi.fn(),
+  recordSensitiveDataRemediationDecision: vi.fn(),
+  recordSoftwareRemediationDecision: vi.fn(),
+}));
+
+vi.mock('../../middleware/agentAuth', () => ({
+  agentAuthMiddleware: vi.fn(async (c: any, next: any) => {
+    if (c.req.header('x-agent-token') !== 'valid') {
+      return c.json({ error: 'Invalid agent token' }, 401);
+    }
+    c.set('agent', {
+      deviceId: 'device-1',
+      agentId: 'agent-1',
+      orgId: 'org-1',
+      siteId: 'site-1',
+      role: 'agent',
+    });
+    return next();
+  }),
+  isAgentTokenRotationDue: vi.fn(() => false),
+}));
+
+// The heartbeat handler itself is not the subject here — only whether control
+// reaches the counter — so every DB call resolves empty and the handler is
+// allowed to fail past the gate.
+vi.mock('../../db', () => {
+  const chain: any = {
+    from: () => chain,
+    where: () => chain,
+    limit: () => Promise.resolve([]),
+    orderBy: () => chain,
+    set: () => chain,
+    values: () => Promise.resolve(undefined),
+    returning: () => Promise.resolve([]),
+    then: (resolve: any) => resolve([]),
+  };
+  return {
+    db: { select: () => chain, insert: () => chain, update: () => chain, delete: () => chain },
+    withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    runOutsideDbContext: vi.fn((fn: any) => fn()),
+  };
+});
+
+const { agentRoutes } = await import('./index');
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/agents', agentRoutes);
+  return app;
+}
+
+const body = JSON.stringify({
+  agentVersion: '0.65.10',
+  metrics: { cpuPercent: 5, ramPercent: 10, ramUsedMb: 1024, diskPercent: 15, diskUsedGb: 30 },
+});
+
+describe('agent_heartbeat_total auth gate', () => {
+  beforeEach(() => {
+    recordAgentHeartbeatMock.mockClear();
+  });
+
+  it('does not count a heartbeat rejected by agent-token auth', async () => {
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+    });
+
+    expect(resp.status).toBe(401);
+    // The counter must be unreachable without a valid agent token — otherwise it
+    // is a publicly writable metric.
+    expect(recordAgentHeartbeatMock).not.toHaveBeenCalled();
+  });
+
+  it('reaches the counter once the agent token is valid', async () => {
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-agent-token': 'valid' },
+      body,
+    });
+
+    expect(resp.status).not.toBe(401);
+    expect(recordAgentHeartbeatMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/routes/metrics.test.ts
+++ b/apps/api/src/routes/metrics.test.ts
@@ -43,10 +43,25 @@ vi.mock('drizzle-orm', async (importOriginal) => {
   };
 });
 
+// Records the ORDER in which db-context wrappers are entered, so a test can prove
+// the fleet query actually ran inside them. `toHaveBeenCalled()` alone is not
+// enough — see the nesting test below for why.
+const dbContextEvents = vi.hoisted(() => [] as string[]);
+
 vi.mock('../db', () => ({
-  runOutsideDbContext: vi.fn((fn) => fn()),
+  runOutsideDbContext: vi.fn((fn: any) => {
+    dbContextEvents.push('outside:enter');
+    return fn();
+  }),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
-  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+    dbContextEvents.push('system:enter');
+    try {
+      return await fn();
+    } finally {
+      dbContextEvents.push('system:exit');
+    }
+  }),
   db: {
     select: selectMock,
     insert: vi.fn(),
@@ -74,6 +89,7 @@ vi.mock('../middleware/auth', () => ({
 }));
 
 import { authMiddleware } from '../middleware/auth';
+import { runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { devices } from '../db/schema';
 import {
   metricsMiddleware,
@@ -222,6 +238,27 @@ function connectTimeoutStats(timeouts: number, windowMs = 300_000): DbConnectTim
   };
 }
 
+/**
+ * Stubs the single fleet-gauge pass (device counts + backup readiness) by TABLE
+ * rather than by call order, so reordering the two queries inside the shared
+ * transaction cannot break unrelated suites.
+ */
+function stubFleetGaugeQueries(
+  selectMock: ReturnType<typeof vi.fn>,
+  opts: { fleet?: Record<string, unknown>; readiness?: Record<string, unknown> } = {}
+): void {
+  selectMock.mockImplementation(() => ({
+    from: (table: unknown) => ({
+      where: () =>
+        Promise.resolve([
+          table === devices
+            ? (opts.fleet ?? { devicesActive: 0, organizationsActive: 0 })
+            : (opts.readiness ?? { count: 0 }),
+        ]),
+    }),
+  }));
+}
+
 function getMetricLine(metrics: string, name: string, labels?: Record<string, string>): string | undefined {
   const labelText = labels ? `{${Object.entries(labels).map(([k, v]) => `${k}="${v}"`).join(',')}}` : '';
   return metrics
@@ -270,6 +307,7 @@ describe('metrics routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    dbContextEvents.length = 0;
     selectMock.mockReset();
     selectMock.mockReturnValue({
       from: () => ({
@@ -602,19 +640,19 @@ describe('metrics routes', () => {
   });
 
   it('records and aggregates HTTP request metrics', async () => {
-    recordHttpRequest('GET', '/api/devices/123', 200, 0.2, 'org-1');
-    recordHttpRequest('GET', '/api/devices/456', 200, 0.4, 'org-1');
+    recordHttpRequest('GET', '/api/devices/:id', 200, 0.2);
+    recordHttpRequest('GET', '/api/devices/:id', 204, 0.4);
 
     const res = await app.request('/metrics', {
       headers: { Authorization: 'Bearer token' }
     });
     const body = await res.text();
 
+    // Both requests collapse onto one series: same route template, same class.
     const counterLine = getMetricLine(body, 'http_requests_total', {
       method: 'GET',
       route: '/api/devices/:id',
-      status: '200',
-      org_id: 'org-1'
+      status_class: '2xx'
     });
     expect(counterLine).toBeDefined();
     expect(counterLine?.endsWith(' 2')).toBe(true);
@@ -627,37 +665,493 @@ describe('metrics routes', () => {
     expect(countLine?.endsWith(' 2')).toBe(true);
   });
 
-  it('captures request metrics via middleware with org context', async () => {
-    const appWithMiddleware = new Hono();
-    appWithMiddleware.use('*', authMiddleware);
-    appWithMiddleware.use('*', metricsMiddleware);
-    appWithMiddleware.get('/widgets/:id', (c) => c.json({ ok: true }));
-    appWithMiddleware.route('/', metricsRoutes);
+  it('buckets responses by class rather than exact status code', async () => {
+    recordHttpRequest('POST', '/api/things', 500, 0.1);
+    recordHttpRequest('POST', '/api/things', 503, 0.1);
+    recordHttpRequest('POST', '/api/things', 404, 0.1);
 
-    const res = await appWithMiddleware.request('/widgets/42', {
-      headers: { Authorization: 'Bearer token' }
-    });
-    expect(res.status).toBe(200);
+    const body = await (
+      await app.request('/metrics', { headers: { Authorization: 'Bearer token' } })
+    ).text();
 
-    const metricsRes = await appWithMiddleware.request('/metrics', {
-      headers: { Authorization: 'Bearer token' }
-    });
-    const body = await metricsRes.text();
+    expect(
+      getMetricLine(body, 'http_requests_total', {
+        method: 'POST',
+        route: '/api/things',
+        status_class: '5xx'
+      })?.endsWith(' 2')
+    ).toBe(true);
+    expect(
+      getMetricLine(body, 'http_requests_total', {
+        method: 'POST',
+        route: '/api/things',
+        status_class: '4xx'
+      })?.endsWith(' 1')
+    ).toBe(true);
+    // The exact code must not survive as its own label.
+    expect(body).not.toContain('status="503"');
+  });
 
-    const counterLine = getMetricLine(body, 'http_requests_total', {
-      method: 'GET',
-      route: '/widgets/:id',
-      status: '200',
-      org_id: 'org-123'
+  it('normalizes unknown verbs so a probe cannot open a new series', async () => {
+    recordHttpRequest('PROPFIND', '/api/things', 405, 0.01);
+
+    const body = await (
+      await app.request('/metrics', { headers: { Authorization: 'Bearer token' } })
+    ).text();
+
+    expect(
+      getMetricLine(body, 'http_requests_total', {
+        method: 'other',
+        route: '/api/things',
+        status_class: '4xx'
+      })
+    ).toBeDefined();
+    expect(body).not.toContain('PROPFIND');
+  });
+
+  // The bug this file exists to prevent a repeat of: the middleware was written
+  // and unit-tested, but nothing mounted it, so a production scrape carried no
+  // per-request series at all. These assertions only hold when it is wired up.
+  describe('metricsMiddleware route labelling', () => {
+    function buildApp(): Hono {
+      const appWithMiddleware = new Hono();
+      appWithMiddleware.use('*', metricsMiddleware);
+      appWithMiddleware.use('*', authMiddleware);
+      appWithMiddleware.get('/widgets/:id', (c) => c.json({ ok: true }));
+      // A non-numeric, non-UUID path parameter: the label the OLD raw-path
+      // scrubber would have emitted verbatim.
+      appWithMiddleware.get('/orgs/:slug/detail', (c) => c.json({ ok: true }));
+      appWithMiddleware.get('/boom', () => {
+        throw new Error('handler exploded');
+      });
+      appWithMiddleware.route('/', metricsRoutes);
+      return appWithMiddleware;
+    }
+
+    async function scrape(target: Hono): Promise<string> {
+      const res = await target.request('/metrics', {
+        headers: { Authorization: 'Bearer token' }
+      });
+      return res.text();
+    }
+
+    it('labels a matched request with the Hono route template', async () => {
+      const appWithMiddleware = buildApp();
+      const res = await appWithMiddleware.request('/widgets/42', {
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(res.status).toBe(200);
+
+      const body = await scrape(appWithMiddleware);
+      expect(
+        getMetricLine(body, 'http_requests_total', {
+          method: 'GET',
+          route: '/widgets/:id',
+          status_class: '2xx'
+        })?.endsWith(' 1')
+      ).toBe(true);
+      expect(
+        getMetricLine(body, 'http_request_duration_seconds_count', {
+          method: 'GET',
+          route: '/widgets/:id'
+        })?.endsWith(' 1')
+      ).toBe(true);
     });
-    expect(counterLine).toBeDefined();
-    expect(counterLine?.endsWith(' 1')).toBe(true);
+
+    it('uses the template for a non-numeric path parameter instead of the raw value', async () => {
+      const appWithMiddleware = buildApp();
+      await appWithMiddleware.request('/orgs/acme-corp/detail', {
+        headers: { Authorization: 'Bearer token' }
+      });
+      await appWithMiddleware.request('/orgs/globex-industries/detail', {
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      const body = await scrape(appWithMiddleware);
+      expect(
+        getMetricLine(body, 'http_requests_total', {
+          method: 'GET',
+          route: '/orgs/:slug/detail',
+          status_class: '2xx'
+        })?.endsWith(' 2')
+      ).toBe(true);
+      expect(body).not.toContain('acme-corp');
+      expect(body).not.toContain('globex-industries');
+    });
+
+    it('collapses unrouted paths onto a single `unmatched` series', async () => {
+      const appWithMiddleware = buildApp();
+      await appWithMiddleware.request('/wp-admin/setup-config.php', {
+        headers: { Authorization: 'Bearer token' }
+      });
+      await appWithMiddleware.request('/.env', {
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      const body = await scrape(appWithMiddleware);
+      expect(
+        getMetricLine(body, 'http_requests_total', {
+          method: 'GET',
+          route: 'unmatched',
+          status_class: '4xx'
+        })?.endsWith(' 2')
+      ).toBe(true);
+      expect(body).not.toContain('wp-admin');
+    });
+
+    it('counts a throwing handler as 5xx and releases the in-flight gauge', async () => {
+      const appWithMiddleware = buildApp();
+      await appWithMiddleware.request('/boom', {
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      const body = await scrape(appWithMiddleware);
+      expect(
+        getMetricLine(body, 'http_requests_total', {
+          method: 'GET',
+          route: '/boom',
+          status_class: '5xx'
+        })?.endsWith(' 1')
+      ).toBe(true);
+      // The scrape itself is in flight while it renders, so 1 — never 2, which
+      // is what a `finally`-less decrement would leave behind.
+      expect(body).toContain('http_requests_in_flight 1');
+    });
+
+    it('does not carry an org_id label', async () => {
+      const appWithMiddleware = buildApp();
+      await appWithMiddleware.request('/widgets/42', {
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      const body = await scrape(appWithMiddleware);
+      const line = body
+        .split('\n')
+        .find((l) => l.startsWith('http_requests_total{') && l.includes('/widgets/:id'));
+      expect(line).toBeDefined();
+      expect(line).not.toContain('org_id');
+    });
+  });
+
+  // `breeze_active_devices` / `breeze_active_organizations` reported 0 in both
+  // production regions against a live fleet: they were seeded to 0 and the only
+  // setter had no production caller. These tests pin the refresh path AND the db
+  // context it runs in — a contextless read on RLS-forced `devices` returns zero
+  // rows silently, which would reproduce the original symptom exactly.
+  describe('fleet gauges (SOC 2 A1.1)', () => {
+    /**
+     * Discriminates on the TABLE rather than call order. An order-coupled mock
+     * (chained `mockReturnValueOnce`) breaks whenever the two queries are
+     * reordered inside one transaction, which is a refactor with no behavioural
+     * meaning.
+     */
+    function mockFleetQueries(opts: {
+      fleet?: Record<string, unknown>;
+      readiness?: Record<string, unknown>;
+      fleetError?: Error;
+    } = {}): any[] {
+      const captured: any[] = [];
+      selectMock.mockImplementation(() => ({
+        from: (table: unknown) => ({
+          where: (condition: any) => {
+            if (table === devices) {
+              captured.push(condition);
+              dbContextEvents.push('fleet-query');
+              if (opts.fleetError) return Promise.reject(opts.fleetError);
+              return Promise.resolve([
+                opts.fleet ?? { devicesActive: 0, organizationsActive: 0 },
+              ]);
+            }
+            return Promise.resolve([opts.readiness ?? { count: 0 }]);
+          },
+        }),
+      }));
+      return captured;
+    }
+
+    async function scrape(): Promise<string> {
+      const res = await app.request('/metrics', { headers: { Authorization: 'Bearer token' } });
+      return res.text();
+    }
+
+    it('publishes live device and organization counts on scrape', async () => {
+      mockFleetQueries({ fleet: { devicesActive: 4213, organizationsActive: 87 } });
+
+      const body = await scrape();
+
+      expect(getMetricLine(body, 'breeze_active_devices')).toBe('breeze_active_devices 4213');
+      expect(getMetricLine(body, 'breeze_active_organizations')).toBe(
+        'breeze_active_organizations 87'
+      );
+    });
+
+    it('refreshes the backup readiness gauge in the same pass', async () => {
+      mockFleetQueries({ readiness: { count: 3 } });
+
+      const body = await scrape();
+
+      expect(getMetricLine(body, 'breeze_backup_low_readiness_devices')).toBe(
+        'breeze_backup_low_readiness_devices 3'
+      );
+    });
+
+    it('coerces string counts from the driver', async () => {
+      mockFleetQueries({ fleet: { devicesActive: '12', organizationsActive: '3' } });
+
+      const body = await scrape();
+
+      expect(getMetricLine(body, 'breeze_active_devices')).toBe('breeze_active_devices 12');
+    });
+
+    // The predecessor of this test asserted only `toHaveBeenCalled()` on both
+    // wrappers — which passed even with the wrapper stripped off the fleet query,
+    // because the readiness query called them first. It also could not tell the
+    // correct nesting from the inverted one, and inverting it drops the system
+    // GUCs and returns zero rows under RLS: the exact original symptom.
+    it('runs the fleet query inside runOutsideDbContext → withSystemDbAccessContext', async () => {
+      mockFleetQueries();
+
+      await scrape();
+
+      const outside = dbContextEvents.lastIndexOf('outside:enter');
+      const system = dbContextEvents.lastIndexOf('system:enter');
+      const query = dbContextEvents.lastIndexOf('fleet-query');
+      const exit = dbContextEvents.indexOf('system:exit', system);
+
+      expect(outside).toBeGreaterThan(-1);
+      expect(query).toBeGreaterThan(-1);
+      // Order matters: exit the request context FIRST, then open a system one.
+      expect(outside).toBeLessThan(system);
+      expect(system).toBeLessThan(query);
+      // ...and the query must still be inside that context when it runs.
+      expect(query).toBeLessThan(exit);
+    });
+
+    it('opens exactly one db context per scrape for both gauges', async () => {
+      mockFleetQueries();
+
+      await scrape();
+
+      expect(dbContextEvents.filter((e) => e === 'system:enter')).toHaveLength(1);
+    });
+
+    it('excludes ephemeral and decommissioned devices and bounds by last heartbeat', async () => {
+      const captured = mockFleetQueries();
+
+      await scrape();
+
+      const condition = captured[0];
+      expect(findCondition(condition, 'eq', devices.isEphemeral)?.value).toBe(false);
+      const recency = findCondition(condition, 'gte', devices.lastSeenAt);
+      expect(recency?.value).toBeInstanceOf(Date);
+      // Default window is 300s; allow slack for test execution time.
+      const windowMs = Date.now() - (recency.value as Date).getTime();
+      expect(windowMs).toBeGreaterThan(290_000);
+      expect(windowMs).toBeLessThan(310_000);
+    });
+
+    it('honours METRICS_ACTIVE_DEVICE_WINDOW_SECONDS', async () => {
+      process.env.METRICS_ACTIVE_DEVICE_WINDOW_SECONDS = '60';
+      try {
+        const captured = mockFleetQueries();
+        await scrape();
+
+        const recency = findCondition(captured[0], 'gte', devices.lastSeenAt);
+        const windowMs = Date.now() - (recency.value as Date).getTime();
+        expect(windowMs).toBeGreaterThan(50_000);
+        expect(windowMs).toBeLessThan(70_000);
+      } finally {
+        delete process.env.METRICS_ACTIVE_DEVICE_WINDOW_SECONDS;
+      }
+    });
+
+    // The `> 0` clamp is what stops a misconfigured deploy from turning the TTL
+    // into "aggregate on every scrape" or the window into "the fleet is inactive".
+    it.each(['0', '-30', 'not-a-number'])(
+      'falls back to the default window when the env var is %s',
+      async (raw) => {
+        process.env.METRICS_ACTIVE_DEVICE_WINDOW_SECONDS = raw;
+        try {
+          const captured = mockFleetQueries();
+          await scrape();
+
+          const recency = findCondition(captured[0], 'gte', devices.lastSeenAt);
+          const windowMs = Date.now() - (recency.value as Date).getTime();
+          expect(windowMs).toBeGreaterThan(290_000);
+          expect(windowMs).toBeLessThan(310_000);
+        } finally {
+          delete process.env.METRICS_ACTIVE_DEVICE_WINDOW_SECONDS;
+        }
+      }
+    );
+
+    it('caches across back-to-back scrapes so a scrape loop cannot hammer the fleet query', async () => {
+      mockFleetQueries({ fleet: { devicesActive: 500, organizationsActive: 9 } });
+      await scrape();
+      mockFleetQueries({ fleet: { devicesActive: 999, organizationsActive: 99 } });
+      const body = await scrape();
+
+      expect(getMetricLine(body, 'breeze_active_devices')).toBe('breeze_active_devices 500');
+      expect(dbContextEvents.filter((e) => e === 'fleet-query')).toHaveLength(1);
+    });
+
+    // A timestamp alone throttles only scrapes arriving inside the TTL. The
+    // aggregate gets slow exactly when the database is unwell, which is when a
+    // second scrape would otherwise launch a concurrent full scan.
+    it('single-flights concurrent scrapes into one query', async () => {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      selectMock.mockImplementation(() => ({
+        from: (table: unknown) => ({
+          where: () => {
+            if (table === devices) {
+              dbContextEvents.push('fleet-query');
+              return gate.then(() => [{ devicesActive: 7, organizationsActive: 2 }]);
+            }
+            return Promise.resolve([{ count: 0 }]);
+          },
+        }),
+      }));
+
+      const both = Promise.all([scrape(), scrape()]);
+      release();
+      await both;
+
+      expect(dbContextEvents.filter((e) => e === 'fleet-query')).toHaveLength(1);
+    });
+
+    it('leaves the last known values in place when the query fails', async () => {
+      mockFleetQueries({ fleet: { devicesActive: 77, organizationsActive: 2 } });
+      await scrape();
+
+      process.env.METRICS_FLEET_GAUGE_TTL_SECONDS = '0.001';
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        mockFleetQueries({ fleetError: new Error('pool exhausted') });
+
+        const body = await scrape();
+
+        // A failed refresh must not silently republish 0 — that is the exact
+        // reading that hid this bug for months.
+        expect(getMetricLine(body, 'breeze_active_devices')).toBe('breeze_active_devices 77');
+        expect(warn).toHaveBeenCalled();
+        // ...but the staleness must be VISIBLE rather than merely survivable.
+        expect(getMetricLine(body, 'breeze_fleet_gauge_refresh_failures_total')).toBe(
+          'breeze_fleet_gauge_refresh_failures_total 1'
+        );
+      } finally {
+        warn.mockRestore();
+        delete process.env.METRICS_FLEET_GAUGE_TTL_SECONDS;
+      }
+    });
+
+    // Without this, a refresh that fails from boot onward publishes a flat 0 with
+    // nothing to distinguish it from an empty fleet — the original bug, with a
+    // console.warn nobody alerts on.
+    it('keeps the freshness timestamp at 0 until a refresh actually succeeds', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        mockFleetQueries({ fleetError: new Error('permission denied for table devices') });
+
+        const body = await scrape();
+
+        expect(getMetricLine(body, 'breeze_fleet_gauges_last_refresh_timestamp_seconds')).toBe(
+          'breeze_fleet_gauges_last_refresh_timestamp_seconds 0'
+        );
+        expect(getMetricLine(body, 'breeze_active_devices')).toBe('breeze_active_devices 0');
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('publishes a freshness timestamp once a refresh succeeds', async () => {
+      mockFleetQueries({ fleet: { devicesActive: 5, organizationsActive: 1 } });
+
+      const body = await scrape();
+
+      const line = getMetricLine(body, 'breeze_fleet_gauges_last_refresh_timestamp_seconds');
+      const seconds = Number(line?.split(' ').pop());
+      expect(seconds).toBeGreaterThan(Date.now() / 1000 - 60);
+    });
+
+    // A failed refresh must not burn the whole TTL: the next scrape retries.
+    it('retries on the next scrape after a failure', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        mockFleetQueries({ fleetError: new Error('transient') });
+        await scrape();
+
+        mockFleetQueries({ fleet: { devicesActive: 31, organizationsActive: 4 } });
+        const body = await scrape();
+
+        expect(getMetricLine(body, 'breeze_active_devices')).toBe('breeze_active_devices 31');
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    // The scrape is the only way to see inside a sick instance. Gating it on a
+    // database read means a pool stall takes every unrelated series with it and
+    // flips `up` to 0, which reads as a dead API rather than a sick database.
+    it('still renders the registry when the fleet query never settles', async () => {
+      process.env.METRICS_FLEET_GAUGE_TIMEOUT_SECONDS = '0.05';
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        selectMock.mockImplementation(() => ({
+          from: (table: unknown) => ({
+            where: () =>
+              table === devices ? new Promise(() => {}) : Promise.resolve([{ count: 0 }]),
+          }),
+        }));
+
+        const body = await scrape();
+
+        expect(body).toContain('http_requests_in_flight');
+        expect(getMetricLine(body, 'breeze_fleet_gauge_refresh_failures_total')).toBe(
+          'breeze_fleet_gauge_refresh_failures_total 1'
+        );
+      } finally {
+        warn.mockRestore();
+        delete process.env.METRICS_FLEET_GAUGE_TIMEOUT_SECONDS;
+      }
+    });
+
+    // A `count(*)` always returns one row, so no row is a driver anomaly — not an
+    // empty fleet. Publishing 0 for it is the misleading reading, not the safe one.
+    it('treats a missing result row as a failure rather than an empty fleet', async () => {
+      mockFleetQueries({ fleet: { devicesActive: 42, organizationsActive: 8 } });
+      await scrape();
+
+      process.env.METRICS_FLEET_GAUGE_TTL_SECONDS = '0.001';
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        selectMock.mockImplementation(() => ({
+          from: () => ({ where: () => Promise.resolve([]) }),
+        }));
+
+        const body = await scrape();
+
+        expect(getMetricLine(body, 'breeze_active_devices')).toBe('breeze_active_devices 42');
+        expect(getMetricLine(body, 'breeze_fleet_gauge_refresh_failures_total')).toBe(
+          'breeze_fleet_gauge_refresh_failures_total 1'
+        );
+      } finally {
+        warn.mockRestore();
+        delete process.env.METRICS_FLEET_GAUGE_TTL_SECONDS;
+      }
+    });
   });
 
   it('aggregates business metrics and counters', async () => {
+    // Device/org counts come from the scrape-time refresh, so they are seeded
+    // through the mocked query rather than the setter — the setter's values
+    // would be overwritten by the refresh that `/json` performs.
+    stubFleetGaugeQueries(selectMock, { fleet: { devicesActive: 12, organizationsActive: 3 } });
     updateBusinessMetrics({
-      devicesActive: 12,
-      organizationsTotal: 3,
       alertsActive: 5,
       alertQueueLength: 2
     });
@@ -682,6 +1176,39 @@ describe('metrics routes', () => {
         { labels: { status: 'success' }, value: 2 },
         { labels: { status: 'failed' }, value: 1 }
       ])
+    );
+  });
+
+  // The other half of the `agent_heartbeat_total` fix: the heartbeat route imports
+  // `recordAgentHeartbeat` from this module directly, so what this pins is that the
+  // counter it increments is the one actually rendered into the scrape.
+  it('renders agent heartbeats recorded through the exported counter', async () => {
+    recordAgentHeartbeat('success');
+    recordAgentHeartbeat('success');
+    recordAgentHeartbeat('failed');
+
+    const body = await (
+      await app.request('/metrics', { headers: { Authorization: 'Bearer token' } })
+    ).text();
+
+    expect(getMetricLine(body, 'agent_heartbeat_total', { status: 'success' })).toBe(
+      'agent_heartbeat_total{status="success"} 2'
+    );
+    expect(getMetricLine(body, 'agent_heartbeat_total', { status: 'failed' })).toBe(
+      'agent_heartbeat_total{status="failed"} 1'
+    );
+  });
+
+  it('keeps the agent-heartbeat counter usable after a metrics reset', async () => {
+    resetMetricsForTesting();
+    recordAgentHeartbeat('failed');
+
+    const body = await (
+      await app.request('/metrics', { headers: { Authorization: 'Bearer token' } })
+    ).text();
+
+    expect(getMetricLine(body, 'agent_heartbeat_total', { status: 'failed' })).toBe(
+      'agent_heartbeat_total{status="failed"} 1'
     );
   });
 
@@ -726,11 +1253,7 @@ describe('metrics routes', () => {
   });
 
   it('records backup operational metrics', async () => {
-    selectMock.mockReturnValueOnce({
-      from: () => ({
-        where: () => Promise.resolve([{ count: 3 }]),
-      }),
-    });
+    stubFleetGaugeQueries(selectMock, { readiness: { count: 3 } });
     recordBackupDispatchFailure('manual_restore', 'device_offline');
     recordBackupCommandTimeout('mssql_backup', 'sync_wait');
     recordBackupVerificationResult('test_restore', 'failed');

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -5,11 +5,12 @@
  */
 
 import { Hono } from 'hono';
+import { routePath as honoRoutePath } from 'hono/route';
 import { avg, and, eq, gte, inArray, sql } from 'drizzle-orm';
 import { Counter, Gauge, Histogram, Registry } from 'prom-client';
 import { createHash, timingSafeEqual } from 'crypto';
 
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { deviceMetrics, devices, metricRollups, recoveryReadiness as recoveryReadinessTable, remoteSessions } from '../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
@@ -54,6 +55,7 @@ import { registerM365GraphActionsPrometheusCounter } from '../services/m365Contr
 import { registerActionIntentPrometheusCounter } from '../services/actionIntents/metrics';
 import { registerAgentCertificateBindingPrometheusCounter } from '../services/agentCertificateBinding';
 import { setExtensionMetricsRecorder } from '../extensions/metrics';
+import { envFloat } from '../utils/envFloat';
 
 export {
   recordBackupCommandTimeout,
@@ -115,16 +117,48 @@ registerM365GraphActionsPrometheusCounter(register);
 registerActionIntentPrometheusCounter(register);
 registerAgentCertificateBindingPrometheusCounter(register);
 
+/**
+ * Route label for a request that never reached a registered handler — a 404, or
+ * a global middleware (rate limit, body limit, CORS preflight rejection) that
+ * short-circuited before routing. Collapsing these to one label is what keeps a
+ * path-scanning bot from minting a series per probed URL. Declared here, above
+ * `initializeMetricDefaults`, because that runs at module load.
+ */
+const UNMATCHED_ROUTE_LABEL = 'unmatched';
+
+// SOC 2 A1.1 capacity evidence. Both series were declared here from the start
+// and `docs/notes/SOC_A1.1_CAPACITY_NOTES.md` has always cited them, but nothing
+// mounted `metricsMiddleware` — so a live scrape carried `http_requests_in_flight`
+// (seeded to 0 at boot) and no per-request series at all, and every panel and
+// alert rule built on them matched nothing. `index.ts` now installs the
+// middleware as the outermost global handler.
+//
+// Labels are `method` × `route` × `status_class`, all closed sets:
+//   - `method` is normalised against the known HTTP verbs, else `other`.
+//   - `route` is the HONO ROUTE TEMPLATE (`/api/devices/:id`), read from
+//     `c.req.routePath` after the downstream handler has run, so it is drawn from
+//     the registered route table rather than the request path. The previous
+//     regex-scrubbing of the raw path only collapsed numeric and UUID segments —
+//     any other path parameter (slugs, hostnames, agent versions) went into the
+//     label verbatim and would have made this series unbounded the moment it was
+//     wired up.
+//   - `status_class` is the response class, not the exact code: six values
+//     (`1xx`-`5xx` plus `other`) instead of ~40, and every consumer of these
+//     metrics aggregates by class anyway. The cost is that 429s are no longer
+//     distinguishable from 404s, so rate-limit volume is not observable here.
+// The `org_id` label was dropped for the same reason — tenant count is unbounded.
+// It never carried a real value in production anyway: nothing mounted the
+// middleware, so the series did not exist at all.
 const httpRequestsTotal = new Counter({
   name: 'http_requests_total',
-  help: 'Total number of HTTP requests',
-  labelNames: ['method', 'route', 'status', 'org_id'] as const,
+  help: 'Total number of HTTP requests by method, matched route template, and response class',
+  labelNames: ['method', 'route', 'status_class'] as const,
   registers: [register]
 });
 
 const httpRequestDurationSeconds = new Histogram({
   name: 'http_request_duration_seconds',
-  help: 'HTTP request duration in seconds',
+  help: 'HTTP request duration in seconds by method and matched route template',
   labelNames: ['method', 'route'] as const,
   buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
   registers: [register]
@@ -136,15 +170,45 @@ const httpRequestsInFlight = new Gauge({
   registers: [register]
 });
 
+// Both gauges read a flat 0 in every region until the SOC 2 A1.1 review: they
+// were seeded to 0 by initializeMetricDefaults() and the only thing that could
+// move them, `updateBusinessMetrics()`, had no production caller — the export was
+// reachable from tests and nowhere else. `refreshFleetGauges()` now populates
+// them from the database on scrape. The setter is kept exported so the numbers
+// can also be pushed from a scheduler later without another rewrite.
 const devicesActiveGauge = new Gauge({
   name: 'breeze_active_devices',
-  help: 'Devices with recent heartbeat',
+  help: 'Non-decommissioned, non-ephemeral devices whose last heartbeat is within METRICS_ACTIVE_DEVICE_WINDOW_SECONDS',
   registers: [register]
 });
 
 const organizationsTotalGauge = new Gauge({
   name: 'breeze_active_organizations',
-  help: 'Organizations with active devices',
+  help: 'Distinct organizations owning at least one device counted by breeze_active_devices',
+  registers: [register]
+});
+
+// Freshness and failure for the fleet gauges above, mirroring
+// `breeze_db_pool_health_last_check_timestamp_seconds` /
+// `breeze_db_pool_health_check_failures`. Without these, a refresher that starts
+// throwing every scrape leaves `breeze_active_devices` asserting its last good
+// value forever — a flat, plausible line that cannot be told apart from a stable
+// fleet. Note that dropping the `.set(0)` seeds would NOT make absence visible
+// instead: prom-client emits an unlabelled Gauge as 0 whether or not it has ever
+// been set, so `absent()` never fires on these. An explicit freshness series is
+// the only way to distinguish "never read" from "read, and it is zero".
+//
+// Alert on `time() - ..._last_refresh_timestamp_seconds > 5 * TTL`, or on `== 0`
+// (never succeeded since boot).
+const fleetGaugeLastRefreshGauge = new Gauge({
+  name: 'breeze_fleet_gauges_last_refresh_timestamp_seconds',
+  help: 'Unix time of the last SUCCESSFUL fleet-gauge refresh (0 = never succeeded since process start)',
+  registers: [register]
+});
+
+const fleetGaugeRefreshFailuresTotal = new Counter({
+  name: 'breeze_fleet_gauge_refresh_failures_total',
+  help: 'Fleet-gauge refresh attempts that failed or timed out, since process start',
   registers: [register]
 });
 
@@ -282,9 +346,10 @@ const s1ActionPollTransitionsTotal = new Counter({
 
 // Anomaly-detection signals (launch-readiness CRITICAL #5). The `tenant` label
 // carries a partner identifier so a single noisy/attacked partner doesn't mask
-// the rest of the fleet, but it is redacted in production by default (same policy
-// as `org_id` on http_requests_total) so Prometheus never persists a tenant
-// identifier unless the operator opts in via METRICS_INCLUDE_ORG_ID.
+// the rest of the fleet, but it is redacted in production by default so Prometheus
+// never persists a tenant identifier unless the operator opts in via
+// METRICS_INCLUDE_ORG_ID. (`http_requests_total` declared an `org_id` label under
+// the same policy; it was dropped outright rather than redacted.)
 const failedLoginsTotal = new Counter({
   name: 'breeze_failed_logins_total',
   help: 'Failed login attempts by reason and tenant',
@@ -565,6 +630,13 @@ const dbPoolHealthProbeCloseFailuresGauge = new Gauge({
 
 function initializeMetricDefaults(): void {
   httpRequestsInFlight.set(0);
+  // Seeded so `sum(rate(http_requests_total{...}))` has a denominator from the
+  // first scrape. `unmatched`/`4xx` is a real combination (every 404 lands there),
+  // not a synthetic placeholder, so this publishes nothing that is untrue.
+  httpRequestsTotal.labels('GET', UNMATCHED_ROUTE_LABEL, '4xx').inc(0);
+  // 0 = "never successfully refreshed", which is exactly what it means at boot.
+  fleetGaugeLastRefreshGauge.set(0);
+  fleetGaugeRefreshFailuresTotal.inc(0);
   devicesActiveGauge.set(0);
   organizationsTotalGauge.set(0);
   commandsTotalCounter.labels('script').inc(0);
@@ -657,6 +729,72 @@ function normalizeRoute(route: string): string {
     .replace(/\/\d+/g, '/:id');
 }
 
+const KNOWN_HTTP_METHODS = new Set([
+  'GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'TRACE', 'CONNECT'
+]);
+
+/** Closed set, so a garbage verb on a probe request cannot open a new series. */
+function methodLabel(method: string | undefined): string {
+  const normalized = (method ?? '').toUpperCase();
+  return KNOWN_HTTP_METHODS.has(normalized) ? normalized : 'other';
+}
+
+/** `1xx`-`5xx`, or `other` for anything outside 100-599. Six values, closed. */
+function statusClassLabel(status: number): string {
+  if (!Number.isFinite(status)) return 'other';
+  const bucket = Math.floor(status / 100);
+  return bucket >= 1 && bucket <= 5 ? `${bucket}xx` : 'other';
+}
+
+/**
+ * Response status for a request that has finished unwinding.
+ *
+ * `c.finalized`, not `c.res`. `c.res` is a lazy getter — when nothing ever set a
+ * response it MATERIALISES one via `new Response(null, {headers})`, whose status
+ * is **200** (hono/dist/context.js). So reading `c.res.status` unconditionally
+ * books the two cases where Hono still returns a 500 to the client as a success:
+ *
+ *   1. a middleware that returns without responding and without `await next()` —
+ *      the chain unwinds unfinalized and `hono-base` throws "Context is not
+ *      finalized"; and
+ *   2. `next()` rejecting with a NON-`Error` value, which `compose` rethrows
+ *      instead of routing to `onError`.
+ *
+ * Booking those as 2xx is strictly worse than not measuring them: a heartbeat
+ * handler failing this way would drive `agent_heartbeat_total{status="success"}`
+ * at full fleet rate while every agent gets a 500 — a metric actively asserting
+ * the fleet is healthy. `finalized` is the only honest signal, and reading it
+ * first also avoids the getter's side effect of materialising a Response.
+ */
+export function resolveResponseStatus(c: any): number {
+  return c?.finalized ? (c.res?.status ?? 500) : 500;
+}
+
+/**
+ * The route TEMPLATE for the handler that actually ran.
+ *
+ * `routePath(c)` from `hono/route` rather than the `c.req.routePath` getter: the
+ * getter is deprecated in Hono 4.13 AND indexes `matchedRoutes[routeIndex]`
+ * unguarded, so an out-of-range index is a TypeError thrown from inside a
+ * `finally`. The helper is `.at(...)?.path ?? ''`, which degrades to `unmatched`.
+ *
+ * `compose` sets `routeIndex` before each dispatch and never restores it, so once
+ * `next()` has unwound this names the deepest handler that ran — with the prefix
+ * contributed by any `app.route()` mount already merged in at registration time.
+ * A request that matched no route is still sitting on the last global middleware's
+ * own registration; every global in index.ts is registered at `'*'`, which Hono
+ * normalises to `/*`, so that is what `unmatched` keys on. NOTE: this means a
+ * request short-circuited by a global middleware (rate limit, body limit) also
+ * reports `unmatched`, and a path-scoped guard reports ITS pattern
+ * (`/api/v1/agents/:id/*`) rather than the leaf route.
+ */
+function resolveRoutePattern(c: any): string {
+  const resolved = honoRoutePath(c);
+  const pattern = typeof resolved === 'string' ? resolved.trim() : '';
+  if (pattern.length === 0 || pattern === '/*' || pattern === '*') return UNMATCHED_ROUTE_LABEL;
+  return pattern;
+}
+
 function normalizeMetricLabel(value: string, fallback: string): string {
   const normalized = value
     .trim()
@@ -729,23 +867,30 @@ function upsertCounterState(state: Map<string, CounterValue>, labels: Record<str
   });
 }
 
+/**
+ * `route` MUST be a route TEMPLATE, not a request path — see the
+ * `httpRequestsTotal` declaration. `normalizeRoute` is deliberately NOT applied
+ * here: it was a backstop for raw paths, but its `/\/\d+/g` rule rewrites any
+ * digit-leading segment, so a future `/2fa/verify` route would be labelled
+ * `/:idfa`. Now that the only caller passes a template resolved from the route
+ * table, the backstop can only corrupt correct input. (`normalizeRoute` is still
+ * used by the extension-gateway recorder, which does receive raw paths.)
+ */
 export function recordHttpRequest(
   method: string,
   route: string,
   status: number,
-  durationSeconds: number,
-  orgId?: string
+  durationSeconds: number
 ): void {
-  const normalizedRoute = normalizeRoute(route);
   const labels = {
-    method,
-    route: normalizedRoute,
-    status: String(status),
-    org_id: METRICS_INCLUDE_ORG_ID ? (orgId ?? 'unknown') : 'redacted'
+    method: methodLabel(method),
+    route: route.trim() || UNMATCHED_ROUTE_LABEL,
+    status_class: statusClassLabel(status)
   };
+  const safeDuration = Number.isFinite(durationSeconds) ? Math.max(durationSeconds, 0) : 0;
 
-  httpRequestsTotal.labels(labels.method, labels.route, labels.status, labels.org_id).inc();
-  httpRequestDurationSeconds.labels(labels.method, labels.route).observe(durationSeconds);
+  httpRequestsTotal.labels(labels.method, labels.route, labels.status_class).inc();
+  httpRequestDurationSeconds.labels(labels.method, labels.route).observe(safeDuration);
   upsertCounterState(httpRequestState, labels);
 }
 
@@ -1041,6 +1186,7 @@ function bindMetricsRecorders(): void {
     onRequest: recordExtensionRequestMetric,
     onJob: recordExtensionJobMetric,
   });
+
 }
 
 bindMetricsRecorders();
@@ -1068,6 +1214,8 @@ export function resetMetricsForTesting(): void {
 
   backupLowReadinessDevices = 0;
   sensitiveDataScansQueuedTotal = 0;
+  fleetGaugesRefreshedAtMs = 0;
+  fleetGaugeRefreshInFlight = null;
   devicesActive = 0;
   organizationsTotal = 0;
   commandsTotal = 0;
@@ -1080,20 +1228,167 @@ export function resetMetricsForTesting(): void {
   bindMetricsRecorders();
 }
 
-async function refreshBackupOperationalGauges(): Promise<void> {
-  try {
-    const [row] = await db
+/**
+ * `envFloat` rather than raw `Number(...)`: compose threads unmapped variables in
+ * as `VAR=""`, and `Number('')` is 0 — which here would mean a zero-second cache
+ * TTL (a fleet aggregate on every scrape) or a zero-second activity window (every
+ * device counted as inactive). Both are the silent-misconfiguration failures the
+ * `noRawEnvNumberCoercion` contract exists to prevent. Fractional values are
+ * accepted so tests can drive a sub-second TTL.
+ */
+function envSeconds(name: string, fallback: number): number {
+  const parsed = envFloat(name, fallback);
+  return parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Fleet-wide gauges are read as a SYSTEM db context, never off the bare pool.
+ * `devices` and `recovery_readiness` are both RLS-enabled and FORCEd, and the API
+ * connects as unprivileged `breeze_app` — a contextless SELECT does not error, it
+ * returns zero rows. That failure mode is indistinguishable from "the fleet is
+ * empty", which is precisely how a wired-up gauge would keep reporting 0.
+ *
+ * `runOutsideDbContext` first because `/metrics/prometheus`, `/metrics/metrics`
+ * and `/metrics/json` reach here from inside an authenticated request that already
+ * holds a db context. Those routes are all `requireScope('system')`, so the
+ * inherited context would be system-scoped anyway — the reason this matters is the
+ * #1105 held-connection tripwire: `withDbAccessContext` early-returns when a store
+ * already exists, so without the exit the refresh would run on the REQUEST's
+ * transaction and extend its lifetime.
+ */
+function withFleetWideDbContext<T>(fn: () => Promise<T>): Promise<T> {
+  return runOutsideDbContext(() => withSystemDbAccessContext(fn));
+}
+
+const DEFAULT_FLEET_GAUGE_TTL_SECONDS = 30;
+// The agent heartbeats every 60s (see `heartbeatIntervalSeconds` in
+// routes/agents/enrollment.ts), so five minutes absorbs a few dropped beats
+// without counting an agent that is genuinely gone.
+const DEFAULT_ACTIVE_DEVICE_WINDOW_SECONDS = 300;
+// A scrape must never hang on the database. See `metricsResponse`.
+const DEFAULT_FLEET_GAUGE_TIMEOUT_SECONDS = 5;
+
+let fleetGaugesRefreshedAtMs = 0;
+let fleetGaugeRefreshInFlight: Promise<void> | null = null;
+
+function timeoutAfter(ms: number): { promise: Promise<never>; cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout>;
+  const promise = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`fleet gauge refresh exceeded ${ms}ms`)), ms);
+  });
+  return { promise, cancel: () => clearTimeout(timer) };
+}
+
+/**
+ * Reads every fleet-wide gauge in ONE system-context transaction:
+ * `breeze_active_devices`, `breeze_active_organizations`, and the backup
+ * low-readiness count.
+ *
+ * One transaction, not three: `withDbAccessContext` costs a BEGIN, six
+ * `set_config` round-trips and a COMMIT, and it holds a pooled connection for the
+ * duration. Against the documented 25-connection ceiling on the US droplet, a
+ * per-gauge transaction on every scrape is real pressure from the endpoint whose
+ * whole job is to observe that pressure.
+ *
+ * Ephemeral Quick Support devices and decommissioned records are excluded, the
+ * same exclusions `GET /metrics/` applies, so the gauge and the dashboard count
+ * the same fleet.
+ */
+async function readFleetGauges(nowMs: number): Promise<void> {
+  const activeSince = new Date(
+    nowMs - envSeconds('METRICS_ACTIVE_DEVICE_WINDOW_SECONDS', DEFAULT_ACTIVE_DEVICE_WINDOW_SECONDS) * 1000
+  );
+
+  await withFleetWideDbContext(async () => {
+    const [fleetRow] = await db
+      .select({
+        devicesActive: sql<number>`count(*)`,
+        organizationsActive: sql<number>`count(distinct ${devices.orgId})`
+      })
+      .from(devices)
+      .where(
+        and(
+          gte(devices.lastSeenAt, activeSince),
+          eq(devices.isEphemeral, false),
+          sql`${devices.status} != 'decommissioned'`
+        )
+      );
+
+    // A bare `count(*)` always returns exactly one row, so a missing row is a
+    // driver anomaly, NOT an empty fleet. Publishing 0 for it would recreate the
+    // reading this whole change exists to eliminate, so it fails loudly instead
+    // and lands in the failure counter below.
+    if (!fleetRow) throw new Error('[metrics] fleet gauge query returned no rows');
+
+    const [readinessRow] = await db
       .select({ count: sql<number>`count(*)` })
       .from(recoveryReadinessTable)
       .where(sql`${recoveryReadinessTable.readinessScore} < ${BACKUP_LOW_READINESS_THRESHOLD}`);
-    setLowReadinessDevicesMetric(Number(row?.count ?? 0));
-  } catch (error) {
-    console.warn('[metrics] Failed to refresh backup gauges:', error);
-  }
+    if (!readinessRow) throw new Error('[metrics] readiness gauge query returned no rows');
+
+    updateBusinessMetrics({
+      devicesActive: Number(fleetRow.devicesActive ?? 0),
+      organizationsTotal: Number(fleetRow.organizationsActive ?? 0)
+    });
+    setLowReadinessDevicesMetric(Number(readinessRow.count ?? 0));
+  });
+}
+
+/**
+ * Cache + single-flight in front of `readFleetGauges`.
+ *
+ * A timestamp alone is not enough. It throttles scrapes that arrive INSIDE the
+ * TTL, but the aggregate only gets slow when the database is already unwell —
+ * exactly when a query outlives the 30s TTL and the next scrape happily starts a
+ * second concurrent full scan. The in-flight promise is what actually bounds
+ * concurrency to one; the timestamp is the cheap fast path.
+ *
+ * The timestamp is advanced only on SUCCESS. Advancing it on failure would make a
+ * transient error suppress retries for a full TTL, and — worse — a failure on the
+ * very first refresh after boot would leave both gauges pinned at their seeded 0
+ * for that window, which reads as an empty fleet.
+ */
+async function refreshFleetGauges(): Promise<void> {
+  const now = Date.now();
+  const ttlMs = envSeconds('METRICS_FLEET_GAUGE_TTL_SECONDS', DEFAULT_FLEET_GAUGE_TTL_SECONDS) * 1000;
+  if (fleetGaugesRefreshedAtMs !== 0 && now - fleetGaugesRefreshedAtMs < ttlMs) return;
+  if (fleetGaugeRefreshInFlight) return fleetGaugeRefreshInFlight;
+
+  const timeoutMs = envSeconds('METRICS_FLEET_GAUGE_TIMEOUT_SECONDS', DEFAULT_FLEET_GAUGE_TIMEOUT_SECONDS) * 1000;
+  const timeout = timeoutAfter(timeoutMs);
+
+  fleetGaugeRefreshInFlight = Promise.race([readFleetGauges(now), timeout.promise])
+    .then(() => {
+      fleetGaugesRefreshedAtMs = Date.now();
+      fleetGaugeLastRefreshGauge.set(Math.floor(fleetGaugesRefreshedAtMs / 1000));
+    })
+    .catch((error) => {
+      // Gauges keep their last good values rather than reverting to 0 — but the
+      // staleness is now VISIBLE, via the timestamp gauge above (which is not
+      // advanced here) and the failure counter. Without those two series a dead
+      // refresher is indistinguishable from a stable fleet: a flat, entirely
+      // plausible line for as long as it keeps failing. This file already makes
+      // that argument for `breeze_db_pool_health` — the same rule applies here.
+      fleetGaugeRefreshFailuresTotal.inc();
+      console.warn('[metrics] Failed to refresh fleet gauges:', error);
+    })
+    .finally(() => {
+      timeout.cancel();
+      fleetGaugeRefreshInFlight = null;
+    });
+
+  return fleetGaugeRefreshInFlight;
 }
 
 async function metricsResponse(c: any): Promise<Response> {
-  await refreshBackupOperationalGauges();
+  // Deliberately NOT awaited before rendering when it would block: `register.metrics()`
+  // must always be reachable. Gating the response on a database read means that during
+  // the pool-exhaustion incidents these metrics exist to diagnose, the scrape times out
+  // and Prometheus loses EVERY series from this instance — event-loop lag, in-flight
+  // requests, connect-timeout counters — at the exact moment they matter most, and
+  // `up` flips to 0 so it reads as a dead API rather than a sick database.
+  // `refreshFleetGauges` is internally timeout-bounded and never rejects.
+  await refreshFleetGauges();
   updateProcessMetrics();
   const metrics = await register.metrics();
 
@@ -1344,7 +1639,7 @@ metricsRoutes.get('/scrape', async (c) => {
 });
 
 metricsRoutes.get('/json', authMiddleware, requireScope('system'), async (c) => {
-  await refreshBackupOperationalGauges();
+  await refreshFleetGauges();
   const s1Snapshot = getS1MetricsSnapshot();
   return c.json({
     http_requests_total: Array.from(httpRequestState.values()),
@@ -1398,6 +1693,16 @@ metricsRoutes.get('/metrics', authMiddleware, requireScope('system'), async (c) 
   return metricsResponse(c);
 });
 
+/**
+ * Mounted as the outermost global middleware in `index.ts`, so the duration it
+ * records is the full server-side cost of the request (rate limiting, body
+ * limits, auth, handler) rather than handler time alone.
+ *
+ * Everything runs in `finally`: a handler that throws still decrements the
+ * in-flight gauge and still lands in the counter as a 5xx. Reading the route
+ * template after `next()` has unwound is deliberate and is the reason this cannot
+ * be collapsed into the `try` block — see `resolveRoutePattern`.
+ */
 export async function metricsMiddleware(c: any, next: () => Promise<void>): Promise<void> {
   const start = performance.now();
   httpRequestsInFlight.inc();
@@ -1409,14 +1714,19 @@ export async function metricsMiddleware(c: any, next: () => Promise<void>): Prom
     httpRequestsInFlight.dec();
     inFlightRequests -= 1;
 
-    const duration = (performance.now() - start) / 1000;
-    const status = c.res?.status ?? 500;
-    const method = c.req.method;
-    const path = c.req.path;
-
-    const auth = c.get('auth');
-    const orgId = auth?.orgId;
-
-    recordHttpRequest(method, path, status, duration, orgId);
+    // The whole body is guarded: this is the OUTERMOST middleware, so anything
+    // thrown here escapes into `app.onError` and would turn a successful response
+    // into a 500 — instrumentation must never be able to break the request it is
+    // measuring, nor mask an in-flight exception on its way out.
+    try {
+      recordHttpRequest(
+        c.req.method,
+        resolveRoutePattern(c),
+        resolveResponseStatus(c),
+        (performance.now() - start) / 1000
+      );
+    } catch (error) {
+      console.warn('[metrics] Failed to record request metrics:', error);
+    }
   }
 }

--- a/docs/notes/SOC_A1.1_CAPACITY_NOTES.md
+++ b/docs/notes/SOC_A1.1_CAPACITY_NOTES.md
@@ -1,6 +1,6 @@
 # SOC 2 A1.1 Processing Capacity Notes (Breeze)
 
-Last updated: 2026-02-27
+Last updated: 2026-08-07
 
 ## Control Metadata
 
@@ -44,10 +44,76 @@ Current alert coverage includes:
 
 Current data sources:
 
-- Breeze API metrics (`http_requests_total`, request duration histogram, in-flight requests, business gauges)
+- Breeze API metrics:
+  - `http_requests_total{method,route,status_class}` — per-request counter. `route` is
+    the Hono route TEMPLATE (`/api/devices/:id`), never the request path, so the
+    series stays bounded by the registered route table; `status_class` is the
+    response class — six values, `1xx`–`5xx` plus `other` — not the exact code.
+    Requests that never reach a registered handler (404s, rate-limit rejections)
+    share the single route label `unmatched`. NOTE: because the exact code is
+    gone, 429s are not distinguishable from 404s, so rate-limit/load-shedding
+    volume is not observable from this series.
+  - `http_request_duration_seconds{method,route}` — duration histogram over the
+    same route templates. Measured by the outermost global middleware, so it
+    covers rate limiting and body-limit rejections, not just handler time.
+  - `http_requests_in_flight` — concurrency gauge. Counts requests whose handler
+    has not yet returned; SSE streams and WebSocket connections return their
+    Response at handshake, so the long-lived agent connections that dominate
+    sustained concurrency are NOT reflected here.
+  - `breeze_active_devices` / `breeze_active_organizations` — fleet gauges,
+    refreshed from the database on scrape. "Active" means a heartbeat within
+    `METRICS_ACTIVE_DEVICE_WINDOW_SECONDS` (default 300); refreshes are cached for
+    `METRICS_FLEET_GAUGE_TTL_SECONDS` (default 30).
+  - `agent_heartbeat_total{status}` — agent check-in counter, emitted by the
+    heartbeat route. Counts only heartbeats that passed agent-token auth, so it
+    cannot be inflated by unauthenticated traffic to the public URL.
+  - `breeze_fleet_gauges_last_refresh_timestamp_seconds` /
+    `breeze_fleet_gauge_refresh_failures_total` — freshness and failure for the
+    two fleet gauges. The gauges retain their last good values when a refresh
+    fails, so these are what distinguish a stable fleet from a dead refresher.
+    `0` on the timestamp means no refresh has ever succeeded since boot.
 - Redis exporter metrics
 - PostgreSQL exporter metrics
 - Node exporter metrics (host-level)
+
+Scrape jobs are named per region in production (`breeze-api-us`, `breeze-api-eu`
+— see `deploy/prometheus-remote-scrape.example.yml`, which is the in-repo record
+of the production scrape config); the bundled compose stack uses the bare
+`breeze-api`. Dashboards and alert rules
+therefore select on `job=~"breeze-api.*"` and evaluate ratios `by (job)` so one
+region cannot mask another.
+
+### 2026-08-07 — corrections from the capacity-evidence review
+
+The four API signals above were declared in `apps/api/src/routes/metrics.ts` but
+were **not** present in a production scrape, so evidence collected before this date
+should not be relied on:
+
+- `http_requests_total` and `http_request_duration_seconds` had no producer:
+  `metricsMiddleware` existed and was unit-tested, but was never mounted in
+  `index.ts`. Of these four signals, a live scrape carried only
+  `http_requests_in_flight` (seeded to 0 at boot).
+- `breeze_active_devices` / `breeze_active_organizations` reported 0 in both
+  regions. They were seeded to 0 at boot and their only setter had no production
+  caller. They are now refreshed from the database under a system DB context —
+  a contextless read of the RLS-forced `devices` table returns zero rows rather
+  than erroring, which is indistinguishable from an empty fleet.
+- `agent_heartbeat_total` was never incremented, so the "Agent Heartbeats" panel
+  read a flat zero. The `NoAgentHeartbeats` alert did not read zero — with the
+  stale `job` selector below it matched no series at all, so it returned NO DATA
+  and was silent rather than firing.
+- Dashboards and rules selected `job="breeze-api"`, which matches neither
+  production scrape job.
+
+Two consequences of the fix that the next review should expect:
+
+- `NoAgentHeartbeats` is now live. `agent_heartbeat_total` is seeded to 0 for both
+  label values, so in a region with a genuinely idle fleet the rule will page
+  after 5 minutes. That is new behaviour, not a regression.
+- `absent()`-based deadman rules (`CapacityMetricsMissing`, `FleetGaugesStale`)
+  were added so that a future unwiring of these producers surfaces as an alert
+  instead of as silently-passing rules. An empty vector never fires on its own,
+  which is why the original gap went unnoticed for months.
 
 ## Operational Procedure (Target for Audit Period)
 

--- a/docs/operations/MONITORING.md
+++ b/docs/operations/MONITORING.md
@@ -145,29 +145,66 @@ The main dashboard provides:
 
 Example query for request rate:
 ```promql
-sum(rate(http_requests_total{job="breeze-api"}[5m])) by (method)
+sum(rate(http_requests_total{job=~"breeze-api.*"}[5m])) by (method)
 ```
+
+The `job` selector is a regex because production runs one scrape job per region
+(`breeze-api-us`, `breeze-api-eu`) while the bundled compose stack uses the bare
+`breeze-api`. A literal `job="breeze-api"` matches nothing in production.
 
 ## Key Metrics
 
 ### HTTP Metrics
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `http_requests_total` | Counter | Total HTTP requests |
-| `http_request_duration_seconds` | Histogram | Request duration |
-| `breeze_active_connections` | Gauge | Current active connections |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `http_requests_total` | Counter | `method`, `route`, `status_class` | Total HTTP requests |
+| `http_request_duration_seconds` | Histogram | `method`, `route` | Request duration |
+| `http_requests_in_flight` | Gauge | — | Requests currently being processed (excludes SSE/WebSocket, see below) |
+
+`route` is the Hono route TEMPLATE (`/api/v1/devices/:id`), never the request
+path, which is what keeps these series bounded by the registered route table.
+Requests rejected before reaching a handler (404s, rate limiting) share the single
+label `route="unmatched"`; requests rejected by a path-scoped guard carry that
+guard's pattern (`/api/v1/agents/:id/*`). `status_class` is the response class —
+six values, `1xx`–`5xx` plus `other` — not the exact status code, so 429s cannot
+be told apart from 404s here.
+
+`http_requests_in_flight` counts requests whose handler has not yet returned.
+`streamSSE` and `upgradeWebSocket` return their Response at handshake, so
+long-lived agent connections — the dominant source of sustained concurrency — are
+not represented in it.
 
 ### Business Metrics
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `breeze_devices_active` | Gauge | Number of active devices |
-| `breeze_organizations_total` | Gauge | Total organizations |
-| `breeze_alerts_active` | Gauge | Active alerts count |
+| `breeze_active_devices` | Gauge | Devices with a heartbeat inside `METRICS_ACTIVE_DEVICE_WINDOW_SECONDS` (default 300) |
+| `breeze_active_organizations` | Gauge | Distinct organizations owning those devices |
+| `breeze_alerts_total` | Counter | Alerts fired, by severity |
 | `breeze_alert_queue_length` | Gauge | Alerts pending processing |
-| `agent_heartbeat_total` | Counter | Agent heartbeats received |
+| `agent_heartbeat_total` | Counter | Authenticated agent heartbeats, by `status` |
 | `breeze_scripts_executed_total` | Counter | Scripts executed |
+
+The two fleet gauges are refreshed from the database on scrape and cached for
+`METRICS_FLEET_GAUGE_TTL_SECONDS` (default 30), so a tight scrape loop cannot
+turn them into per-request load. The refresh is single-flighted and bounded by
+`METRICS_FLEET_GAUGE_TIMEOUT_SECONDS` (default 5) — the scrape renders regardless,
+so a stalled database can never take the rest of the metrics down with it.
+
+When a refresh fails the gauges keep their last good values, which on a chart is
+indistinguishable from a stable fleet. Two companion series make that visible and
+should be alerted on rather than trusted implicitly:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `breeze_fleet_gauges_last_refresh_timestamp_seconds` | Gauge | Unix time of the last SUCCESSFUL refresh; `0` = never succeeded since boot |
+| `breeze_fleet_gauge_refresh_failures_total` | Counter | Refresh attempts that failed or timed out |
+
+These three env vars are code-level defaults: they are read from `process.env` but
+are not currently threaded through `.env.example` or the compose `environment:`
+blocks, so overriding them on a deployed droplet requires adding them there first
+(see the Compose interpolation note in CLAUDE.md).
 
 ### Backup Operational Checks
 

--- a/monitoring/grafana/dashboards/breeze-overview.json
+++ b/monitoring/grafana/dashboards/breeze-overview.json
@@ -116,7 +116,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "up{job=\"breeze-api\"}",
+          "expr": "up{job=~\"breeze-api.*\"}",
           "refId": "A"
         }
       ],
@@ -202,7 +202,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(http_requests_total{job=\"breeze-api\"}[5m])) by (method)",
+          "expr": "sum(rate(http_requests_total{job=~\"breeze-api.*\"}[5m])) by (method)",
           "legendFormat": "{{method}}",
           "refId": "A"
         }
@@ -297,7 +297,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=\"breeze-api\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=~\"breeze-api.*\"}[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -306,7 +306,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"breeze-api\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=~\"breeze-api.*\"}[5m])) by (le))",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -315,7 +315,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"breeze-api\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=~\"breeze-api.*\"}[5m])) by (le))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -381,7 +381,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(http_requests_total{job=\"breeze-api\", status=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"breeze-api\"}[5m]))",
+          "expr": "sum(rate(http_requests_total{job=~\"breeze-api.*\", status_class=\"5xx\"}[5m])) / sum(rate(http_requests_total{job=~\"breeze-api.*\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -398,7 +398,7 @@
       },
       "id": 101,
       "panels": [],
-      "title": "HTTP Status Codes",
+      "title": "HTTP Response Classes",
       "type": "row"
     },
     {
@@ -541,12 +541,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(http_requests_total{job=\"breeze-api\"}[5m])) by (status)",
-          "legendFormat": "{{status}}",
+          "expr": "sum(rate(http_requests_total{job=~\"breeze-api.*\"}[5m])) by (status_class)",
+          "legendFormat": "{{status_class}}",
           "refId": "A"
         }
       ],
-      "title": "Requests by Status Code",
+      "title": "Requests by Response Class",
       "type": "timeseries"
     },
     {
@@ -649,12 +649,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(http_requests_total{job=\"breeze-api\"}[$__range])) by (status)",
-          "legendFormat": "{{status}}",
+          "expr": "sum(increase(http_requests_total{job=~\"breeze-api.*\"}[$__range])) by (status_class)",
+          "legendFormat": "{{status_class}}",
           "refId": "A"
         }
       ],
-      "title": "Status Code Distribution",
+      "title": "Response Class Distribution",
       "type": "piechart"
     },
     {
@@ -776,7 +776,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(http_requests_total{job=\"breeze-api\"}[5m])) by (route)",
+          "expr": "sum(rate(http_requests_total{job=~\"breeze-api.*\"}[5m])) by (route)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -787,7 +787,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(http_request_duration_seconds_sum{job=\"breeze-api\"}[5m])) by (route) / sum(rate(http_request_duration_seconds_count{job=\"breeze-api\"}[5m])) by (route)",
+          "expr": "sum(rate(http_request_duration_seconds_sum{job=~\"breeze-api.*\"}[5m])) by (route) / sum(rate(http_request_duration_seconds_count{job=~\"breeze-api.*\"}[5m])) by (route)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -1380,7 +1380,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(agent_heartbeat_total{job=\"breeze-api\"}[5m])) by (status)",
+          "expr": "sum(rate(agent_heartbeat_total{job=~\"breeze-api.*\"}[5m])) by (status)",
           "legendFormat": "{{status}}",
           "refId": "A"
         }
@@ -1541,7 +1541,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(breeze_backup_dispatch_failures_total{job=\"breeze-api\"}[24h]))",
+          "expr": "sum(increase(breeze_backup_dispatch_failures_total{job=~\"breeze-api.*\"}[24h]))",
           "refId": "A"
         }
       ],
@@ -1601,7 +1601,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(breeze_restore_timeouts_total{job=\"breeze-api\"}[24h]))",
+          "expr": "sum(increase(breeze_restore_timeouts_total{job=~\"breeze-api.*\"}[24h]))",
           "refId": "A"
         }
       ],
@@ -1661,7 +1661,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(breeze_backup_verification_skips_total{job=\"breeze-api\"}[24h]))",
+          "expr": "sum(increase(breeze_backup_verification_skips_total{job=~\"breeze-api.*\"}[24h]))",
           "refId": "A"
         }
       ],

--- a/monitoring/rules/breeze-rules.yml
+++ b/monitoring/rules/breeze-rules.yml
@@ -2,25 +2,29 @@ groups:
   - name: breeze-api-alerts
     interval: 30s
     rules:
+      # The `job` selector is a regex because production runs one scrape job per
+      # region (breeze-api-us, breeze-api-eu) while the bundled compose stack uses
+      # the bare `breeze-api`. Every ratio is evaluated `by (job)` so a bad region
+      # is not diluted by a healthy one sharing the same expression.
       - alert: HighErrorRate
         expr: |
           (
-            sum(rate(http_requests_total{job="breeze-api", status=~"5.."}[5m]))
+            sum(rate(http_requests_total{job=~"breeze-api.*", status_class="5xx"}[5m])) by (job)
             /
-            sum(rate(http_requests_total{job="breeze-api"}[5m]))
+            sum(rate(http_requests_total{job=~"breeze-api.*"}[5m])) by (job)
           ) > 0.05
         for: 5m
         labels:
           severity: critical
         annotations:
-          summary: "High HTTP error rate on Breeze API"
+          summary: "High HTTP error rate on {{ $labels.job }}"
           description: "Error rate is {{ $value | humanizePercentage }} over the last 5 minutes"
           runbook_url: "https://docs.breeze.local/runbooks/high-error-rate"
 
       - alert: SlowResponseTime
         expr: |
           histogram_quantile(0.95,
-            sum(rate(http_request_duration_seconds_bucket{job="breeze-api"}[5m])) by (le)
+            sum(rate(http_request_duration_seconds_bucket{job=~"breeze-api.*"}[5m])) by (le)
           ) > 2
         for: 10m
         labels:
@@ -31,7 +35,7 @@ groups:
           runbook_url: "https://docs.breeze.local/runbooks/slow-response"
 
       - alert: APIServiceDown
-        expr: up{job="breeze-api"} == 0
+        expr: up{job=~"breeze-api.*"} == 0
         for: 2m
         labels:
           severity: critical
@@ -43,7 +47,7 @@ groups:
       - alert: EndpointLatencyHigh
         expr: |
           histogram_quantile(0.95,
-            sum(rate(http_request_duration_seconds_bucket{job="breeze-api"}[5m])) by (le, route)
+            sum(rate(http_request_duration_seconds_bucket{job=~"breeze-api.*"}[5m])) by (le, route)
           ) > 5
         for: 5m
         labels:
@@ -55,15 +59,15 @@ groups:
       - alert: High4xxRate
         expr: |
           (
-            sum(rate(http_requests_total{job="breeze-api", status=~"4.."}[5m]))
+            sum(rate(http_requests_total{job=~"breeze-api.*", status_class="4xx"}[5m])) by (job)
             /
-            sum(rate(http_requests_total{job="breeze-api"}[5m]))
+            sum(rate(http_requests_total{job=~"breeze-api.*"}[5m])) by (job)
           ) > 0.2
         for: 10m
         labels:
           severity: warning
         annotations:
-          summary: "High rate of 4xx errors"
+          summary: "High rate of 4xx errors on {{ $labels.job }}"
           description: "4xx error rate is {{ $value | humanizePercentage }}"
 
   - name: breeze-infrastructure-alerts
@@ -119,15 +123,53 @@ groups:
   - name: breeze-business-alerts
     interval: 1m
     rules:
+      # Grouped `by (job)` — without it, one healthy region keeps the global sum
+      # above zero and a region whose agents have all gone silent never alerts.
       - alert: NoAgentHeartbeats
         expr: |
-          sum(rate(agent_heartbeat_total{job="breeze-api"}[5m])) == 0
+          sum(rate(agent_heartbeat_total{job=~"breeze-api.*"}[5m])) by (job) == 0
         for: 5m
         labels:
           severity: critical
         annotations:
-          summary: "No agent heartbeats received"
-          description: "No agents have checked in for the last 5 minutes"
+          summary: "No agent heartbeats received by {{ $labels.job }}"
+          description: "No agents have checked in to {{ $labels.job }} for the last 5 minutes"
+
+      # Deadman guards. The root cause of the 2026-08-07 capacity-evidence gap was
+      # that a series with NO PRODUCER makes every rule built on it evaluate
+      # against an empty vector — and an empty vector never fires. `HighErrorRate`,
+      # `SlowResponseTime`, `EndpointLatencyHigh` and `NoAgentHeartbeats` were all
+      # silently green for months for exactly that reason. `up` cannot catch it:
+      # the scrape succeeds, the series is simply absent.
+      #
+      # These fire if the producers are ever unwired again (e.g. the global
+      # `metricsMiddleware` mount being dropped from index.ts in a refactor).
+      - alert: CapacityMetricsMissing
+        expr: |
+          absent(http_requests_total{job=~"breeze-api.*"})
+          or absent(http_request_duration_seconds_count{job=~"breeze-api.*"})
+          or absent(agent_heartbeat_total{job=~"breeze-api.*"})
+          or absent(breeze_active_devices{job=~"breeze-api.*"})
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Breeze API capacity metrics are absent from the scrape"
+          description: "A SOC 2 A1.1 capacity series has no producer. Alerts built on it are silently passing, not healthy."
+
+      # The fleet gauges keep their last good values when a refresh fails, so a
+      # dead refresher looks like a perfectly stable fleet. Freshness is the only
+      # way to tell those apart. 0 = never succeeded since the process started.
+      - alert: FleetGaugesStale
+        expr: |
+          breeze_fleet_gauges_last_refresh_timestamp_seconds == 0
+          or (time() - breeze_fleet_gauges_last_refresh_timestamp_seconds) > 300
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "breeze_active_devices has not refreshed on {{ $labels.job }}"
+          description: "The fleet-gauge query is failing or timing out; device and organization counts are stale or never read."
 
       - alert: AlertProcessingBacklog
         expr: |
@@ -141,7 +183,7 @@ groups:
 
       - alert: BackupDispatchFailuresDetected
         expr: |
-          increase(breeze_backup_dispatch_failures_total{job="breeze-api"}[15m]) > 0
+          increase(breeze_backup_dispatch_failures_total{job=~"breeze-api.*"}[15m]) > 0
         for: 5m
         labels:
           severity: warning
@@ -151,7 +193,7 @@ groups:
 
       - alert: RestoreTimeoutsDetected
         expr: |
-          increase(breeze_restore_timeouts_total{job="breeze-api"}[15m]) > 0
+          increase(breeze_restore_timeouts_total{job=~"breeze-api.*"}[15m]) > 0
         for: 5m
         labels:
           severity: critical
@@ -161,7 +203,7 @@ groups:
 
       - alert: ScheduledVerificationSkipsDetected
         expr: |
-          increase(breeze_backup_verification_skips_total{job="breeze-api"}[1h]) > 0
+          increase(breeze_backup_verification_skips_total{job=~"breeze-api.*"}[1h]) > 0
         for: 10m
         labels:
           severity: warning
@@ -179,7 +221,7 @@ groups:
     rules:
       - alert: FailedLoginSpike
         expr: |
-          sum(increase(breeze_failed_logins_total{job="breeze-api"}[5m])) by (tenant) > 50
+          sum(increase(breeze_failed_logins_total{job=~"breeze-api.*"}[5m])) by (tenant) > 50
         for: 5m
         labels:
           severity: warning
@@ -190,7 +232,7 @@ groups:
 
       - alert: EnrollmentSpike
         expr: |
-          sum(increase(breeze_agent_enrollments_total{job="breeze-api"}[10m])) by (tenant) > 100
+          sum(increase(breeze_agent_enrollments_total{job=~"breeze-api.*"}[10m])) by (tenant) > 100
         for: 5m
         labels:
           severity: warning
@@ -201,7 +243,7 @@ groups:
 
       - alert: CommandDispatchSpike
         expr: |
-          sum(increase(breeze_commands_dispatched_total{job="breeze-api"}[5m])) by (tenant) > 200
+          sum(increase(breeze_commands_dispatched_total{job=~"breeze-api.*"}[5m])) by (tenant) > 200
         for: 5m
         labels:
           severity: warning
@@ -214,46 +256,50 @@ groups:
     interval: 30s
     rules:
       - record: breeze:http_requests:rate5m
-        expr: sum(rate(http_requests_total{job="breeze-api"}[5m])) by (status, method, route)
+        expr: sum(rate(http_requests_total{job=~"breeze-api.*"}[5m])) by (status_class, method, route)
 
       - record: breeze:http_error_rate:ratio5m
         expr: |
-          sum(rate(http_requests_total{job="breeze-api", status=~"5.."}[5m]))
+          sum(rate(http_requests_total{job=~"breeze-api.*", status_class="5xx"}[5m]))
           /
-          sum(rate(http_requests_total{job="breeze-api"}[5m]))
+          sum(rate(http_requests_total{job=~"breeze-api.*"}[5m]))
 
       - record: breeze:http_request_duration:avg5m
         expr: |
-          sum(rate(http_request_duration_seconds_sum{job="breeze-api"}[5m])) by (route)
+          sum(rate(http_request_duration_seconds_sum{job=~"breeze-api.*"}[5m])) by (route)
           /
-          sum(rate(http_request_duration_seconds_count{job="breeze-api"}[5m])) by (route)
+          sum(rate(http_request_duration_seconds_count{job=~"breeze-api.*"}[5m])) by (route)
 
       - record: breeze:http_request_duration:p95_5m
         expr: |
           histogram_quantile(0.95,
-            sum(rate(http_request_duration_seconds_bucket{job="breeze-api"}[5m])) by (le)
+            sum(rate(http_request_duration_seconds_bucket{job=~"breeze-api.*"}[5m])) by (le)
           )
 
       - record: breeze:http_request_duration:p99_5m
         expr: |
           histogram_quantile(0.99,
-            sum(rate(http_request_duration_seconds_bucket{job="breeze-api"}[5m])) by (le)
+            sum(rate(http_request_duration_seconds_bucket{job=~"breeze-api.*"}[5m])) by (le)
           )
 
       - record: breeze:devices:active_count
         expr: sum(breeze_active_devices)
 
       - record: breeze:backup_dispatch_failures:increase15m
-        expr: sum(increase(breeze_backup_dispatch_failures_total{job="breeze-api"}[15m])) by (operation, reason)
+        expr: sum(increase(breeze_backup_dispatch_failures_total{job=~"breeze-api.*"}[15m])) by (operation, reason)
 
       - record: breeze:restore_timeouts:increase15m
-        expr: sum(increase(breeze_restore_timeouts_total{job="breeze-api"}[15m])) by (command_type)
+        expr: sum(increase(breeze_restore_timeouts_total{job=~"breeze-api.*"}[15m])) by (command_type)
 
       - record: breeze:backup_verification_skips:increase1h
-        expr: sum(increase(breeze_backup_verification_skips_total{job="breeze-api"}[1h])) by (verification_type, reason)
+        expr: sum(increase(breeze_backup_verification_skips_total{job=~"breeze-api.*"}[1h])) by (verification_type, reason)
 
-      - record: breeze:http_requests:rate5m_by_org
-        expr: sum(rate(http_requests_total{job="breeze-api"}[5m])) by (org_id)
+      # `breeze:http_requests:rate5m_by_org` was removed with the `org_id` label on
+      # http_requests_total. It never produced per-tenant data in production — the
+      # label was redacted to a single literal there — and left in place it would
+      # now silently collapse to one unlabelled series that reads as a per-org
+      # breakdown. Per-tenant volume lives in breeze_commands_dispatched_total and
+      # breeze_agent_enrollments_total, which carry a deliberate `tenant` label.
 
       - record: breeze:redis_ops:rate5m
         expr: sum(rate(redis_commands_processed_total[5m]))
@@ -265,10 +311,10 @@ groups:
           rate(pg_stat_statements_calls_total[5m])
 
       - record: breeze:failed_logins:increase5m
-        expr: sum(increase(breeze_failed_logins_total{job="breeze-api"}[5m])) by (reason, tenant)
+        expr: sum(increase(breeze_failed_logins_total{job=~"breeze-api.*"}[5m])) by (reason, tenant)
 
       - record: breeze:agent_enrollments:increase10m
-        expr: sum(increase(breeze_agent_enrollments_total{job="breeze-api"}[10m])) by (result, tenant)
+        expr: sum(increase(breeze_agent_enrollments_total{job=~"breeze-api.*"}[10m])) by (result, tenant)
 
       - record: breeze:commands_dispatched:increase5m
-        expr: sum(increase(breeze_commands_dispatched_total{job="breeze-api"}[5m])) by (type, actor, tenant)
+        expr: sum(increase(breeze_commands_dispatched_total{job=~"breeze-api.*"}[5m])) by (type, actor, tenant)


### PR DESCRIPTION
## The bug

`metricsMiddleware` is exported from `apps/api/src/routes/metrics.ts` and has unit tests, but it was **never mounted** in `apps/api/src/index.ts`. Nothing calls it in production.

The consequence is that `http_requests_total`, `http_request_duration_seconds`, and `agent_heartbeat_total` are never incremented — while `monitoring/grafana/dashboards/breeze-overview.json` and `monitoring/rules/breeze-rules.yml` already reference them. So those Grafana panels render empty and the `NoAgentHeartbeats` alert can never fire, no matter what the fleet does.

This is a silent observability gap: nothing errors, the `/metrics` endpoint responds, the series just aren't there.

## The fix

- Mount `app.use('*', metricsMiddleware)` in `index.ts`, registered **first** — ahead of `createGlobalBodyLimitMiddleware` and `globalRateLimit` — so the histogram measures the whole server-side cost of a request and 413/429 rejections are still counted.
- Heartbeat metric gating in `routes/agents/heartbeat.ts`.
- Grafana dashboard + alert-rule updates, and SOC 2 A1.1 capacity / monitoring doc updates.
- New guard `index.metricsMiddleware.test.ts` asserts the middleware stays imported, stays mounted globally, and stays ahead of both the body-limit wrapper and rate limiting — a reorder silently narrows what the histogram measures.

## Provenance

Recovered from the unmerged local branch `ToddHebebrand/fixes`, found during a worktree audit. Despite the generic name, that branch was SOC 2 A1.1 observability work; it had no PR and was never pushed.

The ordering guard originally searched `index.ts` for `bodyLimitForPath(c.req.path)`, which main replaced with `createGlobalBodyLimitMiddleware({...})` in #3660. That made the test fail on a stale pattern rather than a real problem; the second commit retargets the search and keeps the assertion intact.

## Verification

- `vitest run` on the 4 affected suites: **191/191 passing**
- `tsc --noEmit` on `apps/api`: **0 errors** (needs `--max-old-space-size=8192`; the default heap OOMs on this package)
- Confirmed on `origin/main` before the fix: `metricsMiddleware` exported but zero references in `index.ts`, while 2 files under `monitoring/` already reference the metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)