### PR TITLE
fix(api): stop /sessions/live holding a pooled connection across a 10s agent round-trip

### DIFF
--- a/apps/api/src/middleware/selfManagedDbContextRoutes.test.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.test.ts
@@ -69,6 +69,12 @@ describe('isSelfManagedDbContextRoute', () => {
     ['POST', '/api/v1/psa/connections/conn-1/import'],
     ['POST', '/api/v1/psa/connections/conn-1/import/'],
     ['post', '/api/v1/psa/connections/conn-1/import'],
+
+    // Live agent session listing — awaits a 10s agent round-trip (#1105), so it
+    // must not hold a pooled connection idle-in-transaction.
+    ['GET', '/api/v1/devices/dev-1/sessions/live'],
+    ['GET', '/api/v1/devices/dev-1/sessions/live/'],
+    ['get', '/api/v1/devices/dev-1/sessions/live'],
   ];
 
   const NO_MATCH: ReadonlyArray<[string, string, string]> = [
@@ -144,6 +150,13 @@ describe('isSelfManagedDbContextRoute', () => {
     ['POST', '/api/v1/psa/connections//import/preview', 'empty connection id must not match'],
     ['POST', '/api/v1/psa/connections/conn-1/import/extra', 'extra segment must not match'],
     ['POST', '/api/v1/psa/connections/conn-1/import/preview/extra', 'extra segment must not match'],
+
+    // The sibling session routes do only DB work and MUST keep the ambient tx.
+    ['GET', '/api/v1/devices/dev-1/sessions/active', 'active listing is DB-only'],
+    ['GET', '/api/v1/devices/dev-1/sessions/history', 'history is DB-only'],
+    ['POST', '/api/v1/devices/dev-1/sessions/live', 'live is GET-only'],
+    ['GET', '/api/v1/devices//sessions/live', 'empty device id must not match'],
+    ['GET', '/api/v1/devices/dev-1/sessions/live/extra', 'extra segment must not match'],
   ];
 
   it.each(MATCH)('opts out: %s %s', (method, path) => {

--- a/apps/api/src/middleware/selfManagedDbContextRoutes.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.ts
@@ -131,6 +131,15 @@ const SELF_MANAGED_DB_CONTEXT_ROUTES: readonly SelfManagedRoute[] = [
   // blocks and do everything else outside any context.
   { method: 'POST', pattern: /^\/api\/v1\/psa\/connections\/[^/]+\/import\/preview\/?$/ },
   { method: 'POST', pattern: /^\/api\/v1\/psa\/connections\/[^/]+\/import\/?$/ },
+  // Live agent session listing — the handler issues a `list_sessions` command to
+  // the agent and awaits the round-trip for up to LIST_SESSIONS_TIMEOUT_MS (10s).
+  // That await is a network wait on a customer device, not a DB operation, so
+  // holding a pooled connection idle-in-transaction across it is the same #1105
+  // pool-poison as the routes above. A handful of concurrent dashboard tabs
+  // polling this route is enough to exhaust the pool and 503 the whole API.
+  // The handler reads the device row through a short `withAuthDbAccessContext`
+  // block and makes the agent call outside any context.
+  { method: 'GET', pattern: /^\/api\/v1\/devices\/[^/]+\/sessions\/live\/?$/ },
 ];
 
 /**

--- a/apps/api/src/routes/devices/sessions.ts
+++ b/apps/api/src/routes/devices/sessions.ts
@@ -5,7 +5,12 @@ import { and, desc, eq, gte, or, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';
 import { deviceSessions } from '../../db/schema';
-import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
+import {
+  authMiddleware,
+  requirePermission,
+  requireScope,
+  withAuthDbAccessContext,
+} from '../../middleware/auth';
 import { sendCommandToAgentAwaitResult } from '../../services/agentCommandAwait';
 import { PERMISSIONS } from '../../services/permissions';
 import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
@@ -129,7 +134,14 @@ sessionsRoutes.get(
     const auth = c.get('auth');
     const { id: deviceId } = c.req.valid('param');
 
-    const device = await getDeviceWithOrgAndSiteCheck(c, deviceId, auth);
+    // This route is registered in SELF_MANAGED_DB_CONTEXT_ROUTES, so the auth
+    // middleware does NOT open an ambient request transaction for it. Read the
+    // device row inside a short context of our own and let it close before the
+    // agent round-trip below, which can block for LIST_SESSIONS_TIMEOUT_MS (10s)
+    // waiting on a customer device (#1105).
+    const device = await withAuthDbAccessContext(auth, () =>
+      getDeviceWithOrgAndSiteCheck(c, deviceId, auth),
+    );
     if (device === SITE_ACCESS_DENIED) {
       return c.json({ error: 'Access to this site denied' }, 403);
     }


### PR DESCRIPTION
## The bug

`GET /api/v1/devices/:id/sessions/live` sends a `list_sessions` command to the agent and awaits the reply for up to `LIST_SESSIONS_TIMEOUT_MS` (10s).

That route is **not** in `SELF_MANAGED_DB_CONTEXT_ROUTES`, so `authMiddleware` wraps the handler in `withDbAccessContext` → `baseDb.transaction`. The 10-second wait on a customer device therefore happens **inside a held request transaction**, pinning a pooled Postgres connection idle-in-transaction for its entire duration.

This is the same `#1105` pool-poison that the invoice pay-link, QuickBooks customer-import and PSA import routes already opt out of — the allowlist even documents the pattern. The difference is that this one is reachable straight from the dashboard: a handful of tabs polling live sessions concurrently is enough to exhaust the pool and 503 the API.

## The fix

- Add `GET /api/v1/devices/:id/sessions/live` to `SELF_MANAGED_DB_CONTEXT_ROUTES`.
- Read the device row through a short `withAuthDbAccessContext(auth, ...)` block so the connection is returned **before** the agent round-trip.
- Sibling routes `/sessions/{active,history,experience}` are DB-only and deliberately keep the ambient transaction — the regex is scoped to `live` and verified against them.

Uses the canonical `withAuthDbAccessContext` helper (`middleware/auth.ts:458`) rather than adding a local clone; its docstring notes it already replaced five copy-pasted variants.

## Scope note

This is deliberately **only** the pool-starvation half of the old `ToddHebebrand/snmp-pool-starvation` branch, which was never PR'd. That branch also rewrote `snmpWorker.ts` DB-context handling — work since superseded by #3215/#3220, #3217/#3223 and #3226/#3378. A straight cherry-pick produced 16 conflict hunks and would have reverted those three merged fixes, so the SNMP-worker half is intentionally **not** included here.

Still outstanding from that branch, tracked separately: agent-side hex encoding of unsafe OCTET STRINGs, `sanitizeSnmpMetricValue` + Zod validation of the metrics payload, and a paired retry-budget/failure-classifier. Those need the Go agent to ship first and are not folded in here.

## Verification

- `selfManagedDbContextRoutes.test.ts` + `sessions.live.test.ts`: **126/126 passing** (adds 3 opt-out cases incl. trailing-slash and lowercase method, and 5 must-not-match cases covering the siblings, GET-only, empty id, and extra segment)
- Full `routes/devices/` + `middleware/` sweep: **1030/1030 passing, 62/62 files**
- `tsc --noEmit` on `apps/api`: **0 errors** (needs `--max-old-space-size=8192`)
- Confirmed on `origin/main` first: zero `sessions/live` entries in the allowlist, and `sessions.ts` imports no DB-context helper at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)