### PR TITLE
fix(agent): hex-encode SNMP octet strings that aren't safe text; stop trim-order data loss

### DIFF
--- a/agent/internal/discovery/adjacency.go
+++ b/agent/internal/discovery/adjacency.go
@@ -70,7 +70,14 @@ func snmpValueToString(pdu gosnmp.SnmpPDU) string {
 	case string:
 		return v
 	case []byte:
-		return string(v)
+		// Same hazard as snmppoll.OctetStringToText guards. lldpRemPortId with
+		// portIdSubtype = macAddress(3) is a raw 6-octet MAC, and this is also
+		// the fallback in macFromBytes/ipFromBytes for payloads that aren't
+		// exactly 6/4 bytes. These values only key in-memory lookups today, but
+		// they populate LldpNeighbor.RemotePortID/.RemoteSysName and
+		// CdpNeighbor.RemoteDeviceID, so the moment anyone persists them a raw
+		// cast becomes the same NUL insert failure.
+		return snmppoll.OctetStringToText(v)
 	default:
 		if pdu.Value == nil {
 			return ""

--- a/agent/internal/discovery/adjacency_test.go
+++ b/agent/internal/discovery/adjacency_test.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -37,6 +38,141 @@ func TestParseLLDPNeighbors(t *testing.T) {
 	}
 	if n.LocalPort != "0.1" {
 		t.Errorf("local port (lldp index prefix) = %q", n.LocalPort)
+	}
+}
+
+// lldpRemPortId with portIdSubtype = macAddress(3) is a raw 6-octet MAC — the
+// exact payload behind the production insert failure. It must arrive as hex, not
+// as a raw cast carrying a NUL, and ordinary text columns must stay untouched.
+func TestParseLLDPNeighborsSanitizesRawOctetStrings(t *testing.T) {
+	tests := []struct {
+		name        string
+		portID      any
+		sysName     any
+		wantPortID  string
+		wantSysName string
+	}{
+		{
+			name:        "mac_portid_with_nul_becomes_hex",
+			portID:      []byte{0x78, 0x8a, 0x20, 0x00, 0xd4, 0xe1},
+			sysName:     []byte("core-sw"),
+			wantPortID:  "788a2000d4e1",
+			wantSysName: "core-sw",
+		},
+		{
+			name:        "invalid_utf8_sysname_becomes_hex",
+			portID:      []byte("Gi0/1"),
+			sysName:     []byte{0xff, 0xfe, 0x41},
+			wantPortID:  "Gi0/1",
+			wantSysName: "fffe41",
+		},
+		{
+			name:        "nul_padded_sysname_recovers_to_text",
+			portID:      []byte("Gi0/1"),
+			sysName:     []byte("switch-01\x00"),
+			wantPortID:  "Gi0/1",
+			wantSysName: "switch-01",
+		},
+		{
+			// lldpRemPortId of an unconfigured/zeroed neighbour port. It must
+			// stay a flagged hex dump, not become the empty string that reads
+			// as "the neighbour reported no port".
+			name:        "all_nul_portid_becomes_hex",
+			portID:      []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			sysName:     []byte("core-sw"),
+			wantPortID:  "000000000000",
+			wantSysName: "core-sw",
+		},
+		{
+			// A real MAC whose last two octets are NUL: trimming first would
+			// store "Test" and drop two octets with no marker.
+			name:        "mac_portid_with_printable_prefix_and_trailing_nuls_stays_hex",
+			portID:      []byte{0x54, 0x65, 0x73, 0x74, 0x00, 0x00},
+			sysName:     []byte("core-sw"),
+			wantPortID:  "546573740000",
+			wantSysName: "core-sw",
+		},
+		{
+			name:        "invalid_utf8_sysname_with_trailing_nul_hexes_original_bytes",
+			portID:      []byte("Gi0/1"),
+			sysName:     []byte{0xff, 0xfe, 0x41, 0x00},
+			wantPortID:  "Gi0/1",
+			wantSysName: "fffe4100",
+		},
+		{
+			name:        "nul_padded_sysname_with_two_nuls_recovers_to_text",
+			portID:      []byte("Gi0/1"),
+			sysName:     []byte("switch-01\x00\x00"),
+			wantPortID:  "Gi0/1",
+			wantSysName: "switch-01",
+		},
+		{
+			name:        "nbsp_sysname_unchanged",
+			portID:      []byte("Gi0/1"),
+			sysName:     []byte("core\u00a0sw"),
+			wantPortID:  "Gi0/1",
+			wantSysName: "core\u00a0sw",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chassis := []gosnmp.SnmpPDU{
+				pdu(".1.0.8802.1.1.2.1.4.1.1.5.0.1.1", []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}, gosnmp.OctetString),
+			}
+			portID := []gosnmp.SnmpPDU{pdu(".1.0.8802.1.1.2.1.4.1.1.7.0.1.1", tt.portID, gosnmp.OctetString)}
+			sysName := []gosnmp.SnmpPDU{pdu(".1.0.8802.1.1.2.1.4.1.1.9.0.1.1", tt.sysName, gosnmp.OctetString)}
+
+			got := parseLLDPNeighbors(chassis, portID, sysName)
+			if len(got) != 1 {
+				t.Fatalf("expected 1 neighbor, got %d", len(got))
+			}
+			if got[0].RemotePortID != tt.wantPortID {
+				t.Errorf("RemotePortID = %q, want %q", got[0].RemotePortID, tt.wantPortID)
+			}
+			if got[0].RemoteSysName != tt.wantSysName {
+				t.Errorf("RemoteSysName = %q, want %q", got[0].RemoteSysName, tt.wantSysName)
+			}
+			// The chassis id keeps its colon-separated MAC formatting — that
+			// path knows it is formatting a MAC and is deliberately different
+			// from the unseparated hex fallback.
+			if got[0].RemoteChassisID != "00:11:22:33:44:55" {
+				t.Errorf("RemoteChassisID = %q, want colon-separated MAC", got[0].RemoteChassisID)
+			}
+			for _, v := range []string{got[0].RemotePortID, got[0].RemoteSysName} {
+				if strings.ContainsRune(v, 0) {
+					t.Errorf("%q contains a NUL byte", v)
+				}
+			}
+		})
+	}
+}
+
+// macFromBytes falls back to snmpValueToString when the payload is not exactly
+// 6 bytes, so that fallback must be sanitised too.
+func TestMacFromBytesNonSixByteFallbackIsSanitized(t *testing.T) {
+	got := macFromBytes(pdu(".1.0.8802.1.1.2.1.4.1.1.5.0.1.1", []byte{0x78, 0x8a, 0x00, 0xd4, 0xe1}, gosnmp.OctetString))
+	if got != "788a00d4e1" {
+		t.Errorf("macFromBytes(5-byte payload) = %q, want %q", got, "788a00d4e1")
+	}
+}
+
+// ipFromBytes falls back the same way when the address is not 4 bytes.
+func TestIPFromBytesNonFourByteFallbackIsSanitized(t *testing.T) {
+	got := ipFromBytes(pdu(".1.3.6.1.4.1.9.9.23.1.2.1.1.4.3.1", []byte{0x20, 0x01, 0x00, 0x0d, 0xb8}, gosnmp.OctetString))
+	if got != "2001000db8" {
+		t.Errorf("ipFromBytes(non-IPv4 payload) = %q, want %q", got, "2001000db8")
+	}
+}
+
+func TestParseCDPNeighborsSanitizesRawDeviceID(t *testing.T) {
+	deviceID := []gosnmp.SnmpPDU{pdu(".1.3.6.1.4.1.9.9.23.1.2.1.1.6.3.1", []byte{0x78, 0x8a, 0x20, 0x00, 0xd4, 0xe1}, gosnmp.OctetString)}
+	got := parseCDPNeighbors(deviceID, nil, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 cdp neighbor, got %d", len(got))
+	}
+	if got[0].RemoteDeviceID != "788a2000d4e1" {
+		t.Errorf("RemoteDeviceID = %q, want %q", got[0].RemoteDeviceID, "788a2000d4e1")
 	}
 }
 

--- a/agent/internal/discovery/snmp.go
+++ b/agent/internal/discovery/snmp.go
@@ -211,7 +211,11 @@ func snmpToString(variable gosnmp.SnmpPDU) string {
 	case string:
 		return value
 	case []byte:
-		return string(value)
+		// Same hazard snmppoll.OctetStringToText guards: sysDescr/sysName/sysObjectID land
+		// in Postgres `text`, and a device that answers with raw binary would
+		// otherwise smuggle NUL bytes into the insert. Non-text payloads become
+		// lowercase hex; ordinary text is untouched.
+		return snmppoll.OctetStringToText(value)
 	default:
 		return gosnmp.ToBigInt(value).String()
 	}

--- a/agent/internal/discovery/snmp_test.go
+++ b/agent/internal/discovery/snmp_test.go
@@ -126,6 +126,85 @@ func TestSnmpToString(t *testing.T) {
 			pdu:  gosnmp.SnmpPDU{Value: 42},
 			want: "42",
 		},
+		{
+			// A device answering a system OID with a raw MAC would otherwise
+			// smuggle a NUL byte into a Postgres `text` column.
+			name: "binary_mac_with_nul_becomes_hex",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0x78, 0x8a, 0x20, 0x00, 0xd4, 0xe1}},
+			want: "788a2000d4e1",
+		},
+		{
+			name: "invalid_utf8_becomes_hex",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0xff, 0xfe, 0x41}},
+			want: "fffe41",
+		},
+		{
+			name: "printable_sysdescr_unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("Linux UBNT 3.18.24 #1 SMP")},
+			want: "Linux UBNT 3.18.24 #1 SMP",
+		},
+		{
+			name: "multiline_sysdescr_unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("Cisco IOS Software\r\nCopyright (c) 2026")},
+			want: "Cisco IOS Software\r\nCopyright (c) 2026",
+		},
+		{
+			name: "multiline_tabbed_sysdescr_unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("Cisco IOS Software\r\nTechnical Support:\thttp://example.test\nCompiled\tMon")},
+			want: "Cisco IOS Software\r\nTechnical Support:\thttp://example.test\nCompiled\tMon",
+		},
+		{
+			// classify.go lowercases SysDescr and substring-matches vendor
+			// names. One hexed invisible byte would silently reclassify the
+			// device to unknown, so these must survive untouched.
+			name: "nbsp_in_syslocation_unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("Building A\u00a0Floor 3")},
+			want: "Building A\u00a0Floor 3",
+		},
+		{
+			name: "bom_and_thin_space_unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("\ufeffCisco IOS\u2009Software")},
+			want: "\ufeffCisco IOS\u2009Software",
+		},
+		{
+			name: "soft_hyphen_and_ideographic_space_unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("cata\u00adlyst\u30003850")},
+			want: "cata\u00adlyst\u30003850",
+		},
+		{
+			// C agents NUL-pad fixed-width sysName; that is text, not binary.
+			name: "nul_padded_sysname_recovers_to_text",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("switch-01\x00")},
+			want: "switch-01",
+		},
+		{
+			// A zeroed sysName/chassis id must not collapse to "": querySNMP
+			// treats an all-empty SysDescr/SysName/SysObjectID as "not SNMP
+			// capable" and would demote a live switch to unmanaged.
+			name: "all_nul_payload_becomes_hex_not_empty",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			want: "000000000000",
+		},
+		{
+			name: "binary_with_printable_prefix_and_trailing_nuls_becomes_hex",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0x54, 0x65, 0x73, 0x74, 0x00, 0x00}},
+			want: "546573740000",
+		},
+		{
+			name: "invalid_utf8_with_trailing_nul_hexes_original_bytes",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0xff, 0xfe, 0x41, 0x00}},
+			want: "fffe4100",
+		},
+		{
+			name: "nul_padded_sysname_with_two_nuls_recovers_to_text",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("switch-01\x00\x00")},
+			want: "switch-01",
+		},
+		{
+			name: "empty_byte_slice_stays_empty",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{}},
+			want: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -135,6 +214,24 @@ func TestSnmpToString(t *testing.T) {
 				t.Fatalf("snmpToString() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// querySNMP and querySNMPv3 both return nil — "this host is not SNMP capable" —
+// when SysDescr, SysName and SysObjectID are all empty. Any octet-string payload
+// must therefore render as something non-empty, or a device that answers with a
+// zeroed/binary sysName silently drops out of discovery altogether.
+func TestSNMPToStringNeverEmptiesANonEmptyPayload(t *testing.T) {
+	payloads := [][]byte{
+		{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		{0x00},
+		{0x54, 0x65, 0x73, 0x74, 0x00, 0x00},
+		[]byte("sw\x00\x00\x00"),
+	}
+	for _, payload := range payloads {
+		if got := snmpToString(gosnmp.SnmpPDU{Value: payload}); got == "" {
+			t.Errorf("snmpToString(% x) = %q, want a non-empty rendering", payload, got)
+		}
 	}
 }
 

--- a/agent/internal/snmppoll/fdb.go
+++ b/agent/internal/snmppoll/fdb.go
@@ -55,7 +55,15 @@ func parseFdbPortColumn(pdus []gosnmp.SnmpPDU) []FdbRow {
 		if !ok {
 			continue
 		}
-		v := ParseValue(pdu)
+		v, hexEncoded := parseValue(pdu)
+		if hexEncoded {
+			// A hex-encoded value is an octet dump of a binary payload, not a
+			// port number, and hex is all-digit often enough to sail through
+			// Atoi: an OCTET STRING {0x00,0x05} renders "0005" and would record
+			// a phantom bridge port 5, {0x05,0x00} port 500. The hex flag exists
+			// to stop exactly this numeric coercion, so drop the row instead.
+			continue
+		}
 		port, ok := toInt(v)
 		if !ok || port <= 0 {
 			continue
@@ -95,7 +103,11 @@ func parseBridgePortIfIndex(pdus []gosnmp.SnmpPDU) map[int]int {
 		if !ok {
 			continue
 		}
-		ifIndex, ok := toInt(ParseValue(pdu))
+		v, hexEncoded := parseValue(pdu)
+		if hexEncoded {
+			continue // same numeric-coercion hazard as parseFdbPortColumn
+		}
+		ifIndex, ok := toInt(v)
 		if !ok {
 			continue
 		}
@@ -112,7 +124,11 @@ func parseIfName(pdus []gosnmp.SnmpPDU) map[int]string {
 		if !ok {
 			continue
 		}
-		name, ok := ParseValue(pdu).(string)
+		v, hexEncoded := parseValue(pdu)
+		if hexEncoded {
+			continue // an octet dump is not an interface name
+		}
+		name, ok := v.(string)
 		if !ok || name == "" {
 			continue
 		}
@@ -204,7 +220,9 @@ func AssembleFdbEntries(fdbPortPDUs, basePortPDUs, ifNamePDUs, qBridgePDUs []gos
 	return entries
 }
 
-// toInt coerces a ParseValue result (int64/uint64/string) into an int.
+// toInt coerces a parseValue result (int64/uint64/string) into an int. Callers
+// must reject hex-encoded values BEFORE calling it: hex is often all-digit and
+// parses cleanly into a wrong number.
 func toInt(v any) (int, bool) {
 	switch n := v.(type) {
 	case int64:

--- a/agent/internal/snmppoll/fdb_test.go
+++ b/agent/internal/snmppoll/fdb_test.go
@@ -125,6 +125,84 @@ func TestParseFdbPortColumn_SkipsBadRows(t *testing.T) {
 	}
 }
 
+// dot1dTpFdbPort is INTEGER in the MIB, but agents have been observed answering
+// bridge columns with an OCTET STRING. Binary octet strings are hex-encoded, and
+// hex is all-digit far too often: {0x00,0x05} renders "0005" and Atoi-coerces
+// into a phantom bridge port 5, {0x05,0x00} into port 500. The hex flag exists
+// to prevent exactly that numeric coercion, so rows that had to be hex-encoded
+// are dropped rather than parsed.
+func TestParseFdbPortColumn_SkipsHexEncodedOctetStringPorts(t *testing.T) {
+	const oid = ".1.3.6.1.2.1.17.4.3.1.2.0.80.86.171.205.239"
+	tests := []struct {
+		name  string
+		value []byte
+	}{
+		{"leading NUL renders as 0005", []byte{0x00, 0x05}},
+		{"trailing NUL renders as 0500", []byte{0x05, 0x00}},
+		{"all-NUL renders as 0000", []byte{0x00, 0x00}},
+		{"invalid utf-8 renders as ff05", []byte{0xff, 0x05}},
+		{"binary MAC-shaped payload", []byte{0x00, 0x11, 0x22, 0x30, 0x40, 0x50}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows := parseFdbPortColumn([]gosnmp.SnmpPDU{
+				{Name: oid, Type: gosnmp.OctetString, Value: tt.value},
+			})
+			if len(rows) != 0 {
+				t.Fatalf("got %d rows, want 0 (hex-encoded value must not coerce to a port): %+v", len(rows), rows)
+			}
+		})
+	}
+}
+
+// An OCTET STRING that really is text still parses — only hex-encoded (binary)
+// values are dropped.
+func TestParseFdbPortColumn_AcceptsTextOctetStringPort(t *testing.T) {
+	rows := parseFdbPortColumn([]gosnmp.SnmpPDU{
+		{Name: ".1.3.6.1.2.1.17.4.3.1.2.0.80.86.171.205.239", Type: gosnmp.OctetString, Value: []byte("5")},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1: %+v", len(rows), rows)
+	}
+	if rows[0].MAC != "00:50:56:ab:cd:ef" || rows[0].BridgePort != 5 {
+		t.Fatalf("unexpected row: %+v", rows[0])
+	}
+}
+
+// Same hazard one column over: a hex-encoded dot1dBasePortIfIndex would invent
+// an ifIndex and silently mislabel every FDB row on that bridge port.
+func TestParseBridgePortIfIndex_SkipsHexEncodedOctetStrings(t *testing.T) {
+	got := parseBridgePortIfIndex([]gosnmp.SnmpPDU{
+		{Name: ".1.3.6.1.2.1.17.1.4.1.2.3", Type: gosnmp.OctetString, Value: []byte{0x00, 0x05}},
+		{Name: ".1.3.6.1.2.1.17.1.4.1.2.5", Type: gosnmp.Integer, Value: big.NewInt(10003)},
+	})
+	if _, ok := got[3]; ok {
+		t.Errorf("bridge port 3 got ifIndex %d from a hex-encoded value, want it dropped", got[3])
+	}
+	if got[5] != 10003 {
+		t.Errorf("bridge port 5: got ifIndex %d, want 10003", got[5])
+	}
+}
+
+// A hex-encoded ifName is an octet dump, not a name: recording it would label an
+// interface "0005".
+func TestParseIfName_SkipsHexEncodedOctetStrings(t *testing.T) {
+	got := parseIfName([]gosnmp.SnmpPDU{
+		{Name: ".1.3.6.1.2.1.31.1.1.1.1.10001", Type: gosnmp.OctetString, Value: []byte{0x00, 0x05}},
+		{Name: ".1.3.6.1.2.1.31.1.1.1.1.10002", Type: gosnmp.OctetString, Value: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+		{Name: ".1.3.6.1.2.1.31.1.1.1.1.10003", Type: gosnmp.OctetString, Value: []byte("Gi0/12\x00")},
+	})
+	if name, ok := got[10001]; ok {
+		t.Errorf("ifIndex 10001 got name %q from a hex-encoded value, want it dropped", name)
+	}
+	if name, ok := got[10002]; ok {
+		t.Errorf("ifIndex 10002 got name %q from an all-NUL value, want it dropped", name)
+	}
+	if got[10003] != "Gi0/12" {
+		t.Errorf("ifIndex 10003: got %q, want %q (NUL-padded text still recovers)", got[10003], "Gi0/12")
+	}
+}
+
 func TestParseBridgePortIfIndex(t *testing.T) {
 	pdus := []gosnmp.SnmpPDU{
 		{Name: ".1.3.6.1.2.1.17.1.4.1.2.3", Type: gosnmp.Integer, Value: big.NewInt(10001)},

--- a/agent/internal/snmppoll/metrics.go
+++ b/agent/internal/snmppoll/metrics.go
@@ -1,12 +1,23 @@
 package snmppoll
 
 import (
+	"bytes"
+	"encoding/hex"
 	"errors"
 	"math/big"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/gosnmp/gosnmp"
 )
+
+// ValueEncodingHex is the SNMPMetric.ValueEncoding marker for a value the agent
+// hex-encoded because the raw octet string could not be stored as text. Without
+// it the API cannot tell a hexed MAC ("001122304050") from a device that
+// genuinely reported that string, and all-digit hex gets swept into numeric
+// metric rollups.
+const ValueEncodingHex = "hex"
 
 // SNMPDevice defines the target and credentials for polling.
 type SNMPDevice struct {
@@ -21,11 +32,18 @@ type SNMPDevice struct {
 }
 
 // SNMPMetric represents a single SNMP value read.
+//
+// ValueEncoding declares how Value was encoded by the agent. It is set to
+// ValueEncodingHex only for octet strings the agent had to hex-encode, and is
+// omitted otherwise: `omitempty` keeps the wire format backward-compatible in
+// both directions (older APIs ignore the unknown field, older agents simply
+// never send it).
 type SNMPMetric struct {
-	OID       string    `json:"oid"`
-	Name      string    `json:"name"`
-	Value     any       `json:"value"`
-	Timestamp time.Time `json:"timestamp"`
+	OID           string    `json:"oid"`
+	Name          string    `json:"name"`
+	Value         any       `json:"value"`
+	Timestamp     time.Time `json:"timestamp"`
+	ValueEncoding string    `json:"valueEncoding,omitempty"`
 }
 
 // CollectMetrics fetches all configured OIDs for a device.
@@ -48,20 +66,27 @@ func CollectMetrics(device SNMPDevice) ([]SNMPMetric, error) {
 		return nil, err
 	}
 
+	return buildMetrics(pdus, time.Now().UTC()), nil
+}
+
+// buildMetrics maps varbinds onto SNMPMetric rows, declaring the encoding at the
+// same place the value is produced.
+func buildMetrics(pdus []gosnmp.SnmpPDU, stamp time.Time) []SNMPMetric {
 	metrics := make([]SNMPMetric, 0, len(pdus))
-	stamp := time.Now().UTC()
 	for _, pdu := range pdus {
-		value := ParseValue(pdu)
+		value, hexEncoded := parseValue(pdu)
 		metric := SNMPMetric{
 			OID:       pdu.Name,
 			Name:      pdu.Name,
 			Value:     value,
 			Timestamp: stamp,
 		}
+		if hexEncoded {
+			metric.ValueEncoding = ValueEncodingHex
+		}
 		metrics = append(metrics, metric)
 	}
-
-	return metrics, nil
+	return metrics
 }
 
 // ClientConfig converts an SNMPDevice into an SNMPClientConfig.
@@ -77,38 +102,198 @@ func (d SNMPDevice) ClientConfig() SNMPClientConfig {
 	}
 }
 
-// ParseValue converts SNMP PDUs into Go-friendly values.
-func ParseValue(pdu gosnmp.SnmpPDU) any {
+// parseValue converts SNMP PDUs into Go-friendly values, plus an encoding flag:
+// hexEncoded is true only when an octet string had to be rendered as hex because
+// it was not storable as text.
+//
+// The flag is not optional bookkeeping — every caller has to decide what to do
+// with a value that is an octet dump rather than the payload's own text. fdb.go
+// drops such rows precisely because "0005" would otherwise coerce to bridge port
+// 5 (see parseFdbPortColumn). A flagless wrapper existed here and had no
+// non-test callers, so it was removed rather than left to tempt the next caller
+// into the coercion it hides.
+func parseValue(pdu gosnmp.SnmpPDU) (value any, hexEncoded bool) {
 	if pdu.Value == nil {
-		return nil
+		return nil, false
 	}
 
-	switch value := pdu.Value.(type) {
+	switch v := pdu.Value.(type) {
 	case string:
-		return value
+		return v, false
 	case []byte:
-		return string(value)
+		return octetStringToText(v)
 	case *big.Int:
-		if value.IsInt64() {
-			return value.Int64()
-		}
-		if value.Sign() >= 0 && value.BitLen() <= 64 {
-			return value.Uint64()
-		}
-		return value.String()
+		return bigIntValue(v), false
 	default:
-		bi := gosnmp.ToBigInt(value)
+		bi := gosnmp.ToBigInt(v)
 		if bi == nil {
-			return nil
+			return nil, false
 		}
-		if bi.IsInt64() {
-			return bi.Int64()
-		}
-		if bi.Sign() >= 0 && bi.BitLen() <= 64 {
-			return bi.Uint64()
-		}
-		return bi.String()
+		return bigIntValue(bi), false
 	}
+}
+
+// bigIntValue narrows a big.Int to the tightest Go integer type, falling back to
+// its decimal string when it fits in neither int64 nor uint64.
+func bigIntValue(v *big.Int) any {
+	if v.IsInt64() {
+		return v.Int64()
+	}
+	if v.Sign() >= 0 && v.BitLen() <= 64 {
+		return v.Uint64()
+	}
+	return v.String()
+}
+
+// OctetStringToText renders an SNMP OCTET STRING payload as a value that is
+// safe to ship as JSON and store in a Postgres `text` column.
+//
+// Most octet strings are ordinary text (sysDescr, sysName, ifDescr) and are
+// returned verbatim. Some agents, however, answer bridge/FDB OIDs
+// (dot1dBaseBridgeAddress .1.3.6.1.2.1.17.1.1.0, dot1dTpFdbAddress
+// .1.3.6.1.2.1.17.4.3.1.1.*) or lldpRemPortId with portIdSubtype macAddress(3)
+// with a raw 6-octet MAC. A raw cast of those bytes smuggles a NUL into the
+// payload and Postgres rejects the insert with SQLSTATE 22021,
+// `invalid byte sequence for encoding "UTF8": 0x00` — observed in production
+// against a UniFi USW-24-PoE. Such payloads are returned as lowercase hex
+// instead (e.g. "788a20c3d4e1").
+//
+// NOTE: NUL is the only byte that ever produced that insert failure. Invalid
+// UTF-8 never reached Postgres intact — Go's json.Marshal silently replaces
+// invalid sequences with U+FFFD — so it corrupted the value rather than failing
+// the write. It is hexed here to keep such payloads recoverable, not to prevent
+// an error.
+//
+// The hex form here is deliberately unseparated, unlike macFromOIDSuffix in
+// fdb.go and macFromBytes in discovery/adjacency.go, which emit colon-separated
+// MACs ("78:8a:20:c3:d4:e1"). Those two know they are formatting a MAC; this
+// function does not know what the bytes mean, so it emits a plain octet dump and
+// leaves interpretation to the consumer. Callers that want a MAC should use the
+// MAC formatters, not this one.
+func OctetStringToText(value []byte) string {
+	text, _ := octetStringToText(value)
+	return text
+}
+
+// octetStringToText is OctetStringToText plus a flag reporting whether the
+// result is hex rather than the payload's own text.
+//
+// The order of the three steps is the whole point. The payload is tested BEFORE
+// anything is trimmed, so trimming can only ever RECOVER a payload that would
+// otherwise be hexed; it can never turn a binary payload into a plausible string.
+// Trimming first let the trim — not the payload — decide the outcome, which
+// silently returned "" for an all-NUL MAC and "Test" for the MAC
+// 54 65 73 74 00 00.
+func octetStringToText(value []byte) (string, bool) {
+	// 1. Storable as-is. Nothing is trimmed: a payload that passes this test has
+	//    no NUL, so it has no padding to remove. Empty stays "".
+	if isTextSafeOctetString(value) {
+		return string(value), false
+	}
+	// 2. Not storable, but it may be a C-style NUL-padded text field.
+	if text, ok := nulPaddedText(value); ok {
+		return text, false
+	}
+	// 3. Binary. Hex the ORIGINAL bytes — a MAC ending in 0x00 must keep that
+	//    octet, so this must never be handed a trimmed slice.
+	return hexOctets(value), true
+}
+
+// binaryIdentifierWidths are the octet counts this codebase already treats as
+// fixed-width binary identifiers rather than text: 4 (IPv4) and 6 (MAC/EUI-48),
+// the same two widths discovery/adjacency.go's ipFromBytes and macFromBytes
+// recognise. See nulPaddedText for why the length matters.
+var binaryIdentifierWidths = map[int]bool{4: true, 6: true}
+
+// nulPaddedText recovers the text of a C-style NUL-padded fixed-width field —
+// "switch-01\x00\x00" is a clean name, not binary — and reports false for
+// everything else.
+//
+// The rule, and it is a judgement call because the two cases are not separable
+// from the bytes alone:
+//
+//	Trim only when ALL of these hold —
+//	  a. every NUL is trailing (an interior NUL means binary, not padding);
+//	  b. something is left after the padding (an all-NUL payload is a zeroed
+//	     MAC/chassis id, routine on fresh hardware, NOT an empty string);
+//	  c. that remainder is affirmatively text — valid UTF-8 with no control
+//	     characters other than tab/CR/LF. This is deliberately stricter than
+//	     isTextSafeOctetString: an untrimmed payload only has to be *storable*
+//	     because it is returned unchanged, but a payload we are about to
+//	     shorten has to prove it is a text field;
+//	  d. the payload is not exactly a binary-identifier width (4 or 6).
+//
+// (d) is the tie-breaker for the genuinely ambiguous case. 54 65 73 74 00 00 is
+// a valid MAC (0x54 is a real OUI prefix) AND a valid 6-byte buffer holding
+// "Test" — no predicate can tell them apart. The ambiguity is resolved toward
+// hex because the two failure modes are not symmetric: hexing a real name is
+// lossless and carries the hex flag, while trimming a real MAC destroys octets
+// and is indistinguishable from a device that reported that string.
+//
+// Limits, stated plainly:
+//   - Text NUL-padded to exactly 4 or 6 octets ("Gi0/5\x00") is hexed. Recoverable
+//     and flagged, but it will read as an octet dump.
+//   - A binary payload of some other width whose non-NUL prefix happens to be
+//     entirely printable UTF-8 (e.g. 7 bytes "ABCDE" + 00 00) is still trimmed to
+//     text. Unresolvable without knowing the OID's syntax; it needs ~5 printable
+//     octets in a row to occur, which is why the width rule targets the short
+//     fixed-width identifiers where that is most likely.
+func nulPaddedText(value []byte) (string, bool) {
+	head := bytes.TrimRight(value, "\x00")
+	if len(head) == 0 || len(head) == len(value) {
+		// (b) entirely NUL, or (a) the NUL is not trailing at all.
+		return "", false
+	}
+	if binaryIdentifierWidths[len(value)] {
+		return "", false // (d)
+	}
+	if !isPaddedTextPayload(head) {
+		return "", false // (a) interior NUL, or (c) not text
+	}
+	return string(head), true
+}
+
+// isPaddedTextPayload reports whether the non-NUL remainder of a NUL-padded
+// payload looks like a text field: valid UTF-8 with no control characters beyond
+// tab, CR and LF. NUL is itself a control character, so an interior NUL fails
+// here too. Everything Postgres stores happily but that is not a control
+// character — NBSP, the BOM, soft hyphen, ideographic space — still passes.
+func isPaddedTextPayload(head []byte) bool {
+	if !utf8.Valid(head) {
+		return false
+	}
+	for _, r := range string(head) {
+		if unicode.IsControl(r) && r != '\t' && r != '\n' && r != '\r' {
+			return false
+		}
+	}
+	return true
+}
+
+// isTextSafeOctetString reports whether the payload can be stored verbatim in a
+// Postgres `text` column. That is exactly two conditions: valid UTF-8, and no
+// NUL byte.
+//
+// It is always asked about the payload as received, never about a trimmed copy —
+// trimming first makes the trim decide the answer. Payloads it rejects get a
+// second, stricter look from nulPaddedText.
+//
+// Nothing else is rejected. NBSP (U+00A0), the BOM (U+FEFF), soft hyphen
+// (U+00AD), ideographic space (U+3000), tabs, newlines and ordinary control
+// bytes are all stored fine by Postgres and must survive unchanged — a stricter
+// predicate (unicode.IsPrint, say) hexes the whole string over one invisible
+// byte, which also breaks the substring matching that discovery/classify.go runs
+// against SysDescr to determine device type.
+func isTextSafeOctetString(value []byte) bool {
+	return utf8.Valid(value) && bytes.IndexByte(value, 0) < 0
+}
+
+// hexOctets renders bytes as lowercase hex with no separator. Named rather than
+// inlined so the callers above read as intent ("hex the original bytes") and so
+// the unseparated-vs-colon rationale in OctetStringToText has something to point
+// at.
+func hexOctets(value []byte) string {
+	return hex.EncodeToString(value)
 }
 
 func getDevicePDUs(client *SNMPClient, oids []string) ([]gosnmp.SnmpPDU, error) {

--- a/agent/internal/snmppoll/metrics_test.go
+++ b/agent/internal/snmppoll/metrics_test.go
@@ -1,22 +1,25 @@
 package snmppoll
 
 import (
+	"encoding/json"
 	"math"
 	"math/big"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gosnmp/gosnmp"
 )
 
 // ---------------------------------------------------------------------------
-// ParseValue
+// parseValue
 // ---------------------------------------------------------------------------
 
 func TestParseValue_NilValue(t *testing.T) {
 	pdu := gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.1.1.0", Value: nil}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	if got != nil {
-		t.Errorf("ParseValue(nil value) = %v, want nil", got)
+		t.Errorf("parseValue(nil value) = %v, want nil", got)
 	}
 }
 
@@ -26,10 +29,10 @@ func TestParseValue_String(t *testing.T) {
 		Type:  gosnmp.OctetString,
 		Value: "router-1.example.com",
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	s, ok := got.(string)
 	if !ok || s != "router-1.example.com" {
-		t.Errorf("ParseValue(string) = %v (%T), want \"router-1.example.com\"", got, got)
+		t.Errorf("parseValue(string) = %v (%T), want \"router-1.example.com\"", got, got)
 	}
 }
 
@@ -39,10 +42,10 @@ func TestParseValue_EmptyString(t *testing.T) {
 		Type:  gosnmp.OctetString,
 		Value: "",
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	s, ok := got.(string)
 	if !ok || s != "" {
-		t.Errorf("ParseValue(empty string) = %v (%T), want \"\"", got, got)
+		t.Errorf("parseValue(empty string) = %v (%T), want \"\"", got, got)
 	}
 }
 
@@ -52,10 +55,10 @@ func TestParseValue_ByteSlice(t *testing.T) {
 		Type:  gosnmp.OctetString,
 		Value: []byte("switch-2"),
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	s, ok := got.(string)
 	if !ok || s != "switch-2" {
-		t.Errorf("ParseValue([]byte) = %v (%T), want \"switch-2\"", got, got)
+		t.Errorf("parseValue([]byte) = %v (%T), want \"switch-2\"", got, got)
 	}
 }
 
@@ -65,10 +68,10 @@ func TestParseValue_EmptyByteSlice(t *testing.T) {
 		Type:  gosnmp.OctetString,
 		Value: []byte{},
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	s, ok := got.(string)
 	if !ok || s != "" {
-		t.Errorf("ParseValue(empty []byte) = %v (%T), want \"\"", got, got)
+		t.Errorf("parseValue(empty []byte) = %v (%T), want \"\"", got, got)
 	}
 }
 
@@ -78,10 +81,10 @@ func TestParseValue_BigIntSmall(t *testing.T) {
 		Type:  gosnmp.Counter64,
 		Value: big.NewInt(42),
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	v, ok := got.(int64)
 	if !ok || v != 42 {
-		t.Errorf("ParseValue(big.Int 42) = %v (%T), want int64(42)", got, got)
+		t.Errorf("parseValue(big.Int 42) = %v (%T), want int64(42)", got, got)
 	}
 }
 
@@ -91,10 +94,10 @@ func TestParseValue_BigIntNegative(t *testing.T) {
 		Type:  gosnmp.Counter64,
 		Value: big.NewInt(-100),
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	v, ok := got.(int64)
 	if !ok || v != -100 {
-		t.Errorf("ParseValue(big.Int -100) = %v (%T), want int64(-100)", got, got)
+		t.Errorf("parseValue(big.Int -100) = %v (%T), want int64(-100)", got, got)
 	}
 }
 
@@ -104,10 +107,10 @@ func TestParseValue_BigIntMaxInt64(t *testing.T) {
 		Type:  gosnmp.Counter64,
 		Value: big.NewInt(math.MaxInt64),
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	v, ok := got.(int64)
 	if !ok || v != math.MaxInt64 {
-		t.Errorf("ParseValue(big.Int MaxInt64) = %v (%T), want int64(MaxInt64)", got, got)
+		t.Errorf("parseValue(big.Int MaxInt64) = %v (%T), want int64(MaxInt64)", got, got)
 	}
 }
 
@@ -119,10 +122,10 @@ func TestParseValue_BigIntUint64Range(t *testing.T) {
 		Type:  gosnmp.Counter64,
 		Value: val,
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	v, ok := got.(uint64)
 	if !ok || v != math.MaxUint64 {
-		t.Errorf("ParseValue(big.Int MaxUint64) = %v (%T), want uint64(MaxUint64)", got, got)
+		t.Errorf("parseValue(big.Int MaxUint64) = %v (%T), want uint64(MaxUint64)", got, got)
 	}
 }
 
@@ -137,13 +140,13 @@ func TestParseValue_BigIntOverflow(t *testing.T) {
 		Type:  gosnmp.Counter64,
 		Value: val,
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	s, ok := got.(string)
 	if !ok {
-		t.Errorf("ParseValue(huge big.Int) = %v (%T), want string", got, got)
+		t.Errorf("parseValue(huge big.Int) = %v (%T), want string", got, got)
 	}
 	if s != val.String() {
-		t.Errorf("ParseValue(huge big.Int) = %q, want %q", s, val.String())
+		t.Errorf("parseValue(huge big.Int) = %q, want %q", s, val.String())
 	}
 }
 
@@ -153,10 +156,10 @@ func TestParseValue_BigIntZero(t *testing.T) {
 		Type:  gosnmp.Counter64,
 		Value: big.NewInt(0),
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	v, ok := got.(int64)
 	if !ok || v != 0 {
-		t.Errorf("ParseValue(big.Int 0) = %v (%T), want int64(0)", got, got)
+		t.Errorf("parseValue(big.Int 0) = %v (%T), want int64(0)", got, got)
 	}
 }
 
@@ -167,11 +170,11 @@ func TestParseValue_IntegerType(t *testing.T) {
 		Type:  gosnmp.Integer,
 		Value: 1,
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	// gosnmp.ToBigInt converts int to *big.Int, which IsInt64, so we get int64.
 	v, ok := got.(int64)
 	if !ok || v != 1 {
-		t.Errorf("ParseValue(int 1) = %v (%T), want int64(1)", got, got)
+		t.Errorf("parseValue(int 1) = %v (%T), want int64(1)", got, got)
 	}
 }
 
@@ -181,10 +184,10 @@ func TestParseValue_Counter32(t *testing.T) {
 		Type:  gosnmp.Counter32,
 		Value: uint(123456),
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	v, ok := got.(int64)
 	if !ok || v != 123456 {
-		t.Errorf("ParseValue(Counter32 123456) = %v (%T), want int64(123456)", got, got)
+		t.Errorf("parseValue(Counter32 123456) = %v (%T), want int64(123456)", got, got)
 	}
 }
 
@@ -194,10 +197,10 @@ func TestParseValue_Gauge32(t *testing.T) {
 		Type:  gosnmp.Gauge32,
 		Value: uint(0),
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	v, ok := got.(int64)
 	if !ok || v != 0 {
-		t.Errorf("ParseValue(Gauge32 0) = %v (%T), want int64(0)", got, got)
+		t.Errorf("parseValue(Gauge32 0) = %v (%T), want int64(0)", got, got)
 	}
 }
 
@@ -208,10 +211,10 @@ func TestParseValue_TimeTicks(t *testing.T) {
 		Type:  gosnmp.TimeTicks,
 		Value: uint32(87654321),
 	}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	v, ok := got.(int64)
 	if !ok || v != 87654321 {
-		t.Errorf("ParseValue(TimeTicks) = %v (%T), want int64(87654321)", got, got)
+		t.Errorf("parseValue(TimeTicks) = %v (%T), want int64(87654321)", got, got)
 	}
 }
 
@@ -340,7 +343,7 @@ func TestSNMPMetric_FieldAssignment(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// ParseValue — table-driven comprehensive coverage
+// parseValue — table-driven comprehensive coverage
 // ---------------------------------------------------------------------------
 
 func TestParseValue_TableDriven(t *testing.T) {
@@ -393,7 +396,7 @@ func TestParseValue_TableDriven(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ParseValue(tt.pdu)
+			got, _ := parseValue(tt.pdu)
 			switch tt.wantType {
 			case "nil":
 				if got != nil {
@@ -417,7 +420,332 @@ func TestParseValue_TableDriven(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// ParseValue — big.Int negative overflow
+// parseValue — octet-string sanitisation (binary payloads become hex)
+// ---------------------------------------------------------------------------
+
+func TestParseValue_OctetStringSanitization(t *testing.T) {
+	tests := []struct {
+		name string
+		pdu  gosnmp.SnmpPDU
+		want string
+	}{
+		{
+			// dot1dBaseBridgeAddress on a UniFi USW-24-PoE: a raw 6-octet MAC
+			// with an embedded NUL that Postgres `text` rejects.
+			name: "binary MAC with NUL byte",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0x78, 0x8a, 0x20, 0x00, 0xd4, 0xe1}},
+			want: "788a2000d4e1",
+		},
+		{
+			name: "binary MAC without NUL byte",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0x78, 0x8a, 0x20, 0xc3, 0xd4, 0xe1}},
+			want: "788a20c3d4e1",
+		},
+		{
+			name: "printable ASCII text unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("USW-24-PoE")},
+			want: "USW-24-PoE",
+		},
+		{
+			name: "printable sysDescr unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("Linux UBNT 3.18.24 #1 SMP Thu Jan 1 00:00:00 UTC 2026")},
+			want: "Linux UBNT 3.18.24 #1 SMP Thu Jan 1 00:00:00 UTC 2026",
+		},
+		{
+			name: "multi-line sysDescr keeps newlines and tabs",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("Cisco IOS Software\r\nTechnical Support:\thttp://example.test")},
+			want: "Cisco IOS Software\r\nTechnical Support:\thttp://example.test",
+		},
+		{
+			name: "non-ASCII valid UTF-8 unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("Café-Switch-Ω")},
+			want: "Café-Switch-Ω",
+		},
+		{
+			name: "invalid UTF-8 becomes hex",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0xff, 0xfe, 0x41}},
+			want: "fffe41",
+		},
+		{
+			// C-based agents NUL-pad fixed-width fields; the name is clean text,
+			// not binary, and must not be hexed.
+			name: "NUL-padded fixed-width sysName recovers to text",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("switch-01\x00")},
+			want: "switch-01",
+		},
+		{
+			name: "multiple trailing NULs are trimmed",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("sw1\x00\x00\x00\x00")},
+			want: "sw1",
+		},
+		{
+			// Postgres stores NBSP fine, and sysLocation routinely carries one
+			// from pasted config or a non-English locale.
+			name: "NBSP in sysLocation passes through unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("Building A\u00a0Floor 3")},
+			want: "Building A\u00a0Floor 3",
+		},
+		{
+			name: "BOM and thin space pass through unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("\ufeffcore\u2009sw")},
+			want: "\ufeffcore\u2009sw",
+		},
+		{
+			name: "soft hyphen and ideographic space pass through unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("cata\u00adlyst\u30003850")},
+			want: "cata\u00adlyst\u30003850",
+		},
+		{
+			// Not text-unsafe for Postgres, so they survive: only NUL and
+			// invalid UTF-8 force hex.
+			name: "ordinary control characters pass through unchanged",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0x01, 0x02, 0x1f}},
+			want: "\x01\x02\x1f",
+		},
+		{
+			// A zeroed bridge MAC (00:00:00:00:00:00) is routine on freshly
+			// racked hardware, unresolved FDB entries and unconfigured chassis
+			// ids. Trimming before the safety test collapses it to "" —
+			// indistinguishable from "the OID returned nothing" — and the
+			// promise that the original bytes stay recoverable is broken.
+			name: "all-NUL payload hexes instead of collapsing to empty",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			want: "000000000000",
+		},
+		{
+			// 0x54 0x65 0x73 is a plausible OUI, so this is a real 6-octet MAC
+			// whose last two octets are NUL. Trimming first yields "Test": two
+			// octets destroyed, a wrong value stored, and no hex marker to
+			// signal it.
+			name: "MAC with a printable prefix and trailing NULs stays hex",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0x54, 0x65, 0x73, 0x74, 0x00, 0x00}},
+			want: "546573740000",
+		},
+		{
+			// Same as above at a width the binary-identifier rule does not
+			// cover, so the "nothing survives the padding" guard is the only
+			// thing keeping this out of the empty string.
+			name: "all-NUL payload of a non-identifier width still hexes",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0x00, 0x00, 0x00}},
+			want: "000000",
+		},
+		{
+			name: "MAC with an interior NUL and a trailing NUL hexes the original bytes",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0x00, 0x1a, 0x2b, 0x3c, 0x4d, 0x00}},
+			want: "001a2b3c4d00",
+		},
+		{
+			// Guards hexOctets(value) against hexOctets(trimmed): the trailing
+			// 00 must still appear in the dump, or any MAC ending in 0x00 is
+			// silently truncated.
+			name: "invalid UTF-8 with a trailing NUL hexes the ORIGINAL bytes",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0xff, 0xfe, 0x41, 0x00}},
+			want: "fffe4100",
+		},
+		{
+			// Control bytes are storable, so they pass through when the payload
+			// carries no NUL (case above). Once NULs force a decision, the
+			// non-NUL remainder has to look like text to earn the trim — these
+			// bytes do not.
+			name: "control bytes before trailing NULs stay hex",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{0x01, 0x02, 0x1f, 0x00, 0x00}},
+			want: "01021f0000",
+		},
+		{
+			name: "interior NUL between text runs stays hex",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("ab\x00cd")},
+			want: "6162006364",
+		},
+		{
+			name: "NUL-padded text wider than a binary identifier recovers to text",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("switch-01\x00\x00")},
+			want: "switch-01",
+		},
+		{
+			// The documented limit of the width rule: text NUL-padded to
+			// exactly a MAC (6) or IPv4 (4) width is hexed rather than trimmed,
+			// because "Gi0/5\x00" and a MAC ending in 0x00 are indistinguishable
+			// from the bytes alone. Hex is lossless and flagged, so this value
+			// is recoverable; silently truncating a real MAC would not be.
+			name: "text padded to exactly a MAC width is conservatively hexed",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("Gi0/5\x00")},
+			want: "4769302f3500",
+		},
+		{
+			name: "text padded past a MAC width recovers to text",
+			pdu:  gosnmp.SnmpPDU{Value: []byte("Gi0/5\x00\x00")},
+			want: "Gi0/5",
+		},
+		{
+			// Preserved current behaviour: an empty octet string stays "".
+			name: "empty byte slice stays empty string",
+			pdu:  gosnmp.SnmpPDU{Value: []byte{}},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := parseValue(tt.pdu)
+			s, ok := got.(string)
+			if !ok {
+				t.Fatalf("parseValue() = %v (%T), want string", got, got)
+			}
+			if s != tt.want {
+				t.Errorf("parseValue() = %q, want %q", s, tt.want)
+			}
+			if strings.ContainsRune(s, 0) {
+				t.Errorf("parseValue() = %q contains a NUL byte", s)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildMetrics — ValueEncoding declaration
+// ---------------------------------------------------------------------------
+
+func TestBuildMetrics_ValueEncoding(t *testing.T) {
+	tests := []struct {
+		name         string
+		pdu          gosnmp.SnmpPDU
+		wantValue    any
+		wantEncoding string
+	}{
+		{
+			name:         "binary MAC is declared hex",
+			pdu:          gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.17.1.1.0", Value: []byte{0x78, 0x8a, 0x20, 0x00, 0xd4, 0xe1}},
+			wantValue:    "788a2000d4e1",
+			wantEncoding: ValueEncodingHex,
+		},
+		{
+			// The case that motivates the field: hexed MAC is all digits and
+			// would otherwise be indistinguishable from a real numeric string.
+			name:         "all-digit hex MAC is declared hex",
+			pdu:          gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.17.1.1.0", Value: []byte{0x00, 0x11, 0x22, 0x30, 0x40, 0x50}},
+			wantValue:    "001122304050",
+			wantEncoding: ValueEncodingHex,
+		},
+		{
+			name:         "invalid UTF-8 is declared hex",
+			pdu:          gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.1.1.0", Value: []byte{0xff, 0xfe, 0x41}},
+			wantValue:    "fffe41",
+			wantEncoding: ValueEncodingHex,
+		},
+		{
+			// A zeroed MAC must arrive as a flagged hex string, not as an
+			// unflagged empty string that reads as "no value".
+			name:         "all-NUL MAC is declared hex",
+			pdu:          gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.17.1.1.0", Value: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+			wantValue:    "000000000000",
+			wantEncoding: ValueEncodingHex,
+		},
+		{
+			name:         "MAC with a printable prefix and trailing NULs is declared hex",
+			pdu:          gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.17.1.1.0", Value: []byte{0x54, 0x65, 0x73, 0x74, 0x00, 0x00}},
+			wantValue:    "546573740000",
+			wantEncoding: ValueEncodingHex,
+		},
+		{
+			name:         "invalid UTF-8 with a trailing NUL hexes the original bytes",
+			pdu:          gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.1.1.0", Value: []byte{0xff, 0xfe, 0x41, 0x00}},
+			wantValue:    "fffe4100",
+			wantEncoding: ValueEncodingHex,
+		},
+		{
+			name:         "plain text carries no encoding",
+			pdu:          gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.1.5.0", Value: []byte("switch-01")},
+			wantValue:    "switch-01",
+			wantEncoding: "",
+		},
+		{
+			name:         "NUL-padded text carries no encoding",
+			pdu:          gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.1.5.0", Value: []byte("switch-01\x00")},
+			wantValue:    "switch-01",
+			wantEncoding: "",
+		},
+		{
+			name:         "NBSP text carries no encoding",
+			pdu:          gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.1.6.0", Value: []byte("Building A\u00a0Floor 3")},
+			wantValue:    "Building A\u00a0Floor 3",
+			wantEncoding: "",
+		},
+		{
+			name:         "a device reporting the literal string 788a2000d4e1 carries no encoding",
+			pdu:          gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.1.5.0", Value: []byte("788a2000d4e1")},
+			wantValue:    "788a2000d4e1",
+			wantEncoding: "",
+		},
+		{
+			name:         "numeric value carries no encoding",
+			pdu:          gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.1.3.0", Type: gosnmp.TimeTicks, Value: uint32(4242)},
+			wantValue:    int64(4242),
+			wantEncoding: "",
+		},
+		{
+			name:         "empty byte slice carries no encoding",
+			pdu:          gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.1.5.0", Value: []byte{}},
+			wantValue:    "",
+			wantEncoding: "",
+		},
+	}
+
+	stamp := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildMetrics([]gosnmp.SnmpPDU{tt.pdu}, stamp)
+			if len(got) != 1 {
+				t.Fatalf("buildMetrics() returned %d metrics, want 1", len(got))
+			}
+			m := got[0]
+			if m.Value != tt.wantValue {
+				t.Errorf("Value = %v (%T), want %v (%T)", m.Value, m.Value, tt.wantValue, tt.wantValue)
+			}
+			if m.ValueEncoding != tt.wantEncoding {
+				t.Errorf("ValueEncoding = %q, want %q", m.ValueEncoding, tt.wantEncoding)
+			}
+			if m.OID != tt.pdu.Name || m.Name != tt.pdu.Name {
+				t.Errorf("OID/Name = %q/%q, want %q", m.OID, m.Name, tt.pdu.Name)
+			}
+			if !m.Timestamp.Equal(stamp) {
+				t.Errorf("Timestamp = %v, want %v", m.Timestamp, stamp)
+			}
+
+			// The wire contract: `valueEncoding` must be absent — not empty —
+			// when the agent did not hex-encode, so older APIs and older agents
+			// stay interoperable.
+			raw, err := json.Marshal(m)
+			if err != nil {
+				t.Fatalf("json.Marshal(metric) = %v", err)
+			}
+			hasField := strings.Contains(string(raw), `"valueEncoding"`)
+			if tt.wantEncoding == "" && hasField {
+				t.Errorf("json = %s, want no valueEncoding field", raw)
+			}
+			if tt.wantEncoding != "" {
+				if !hasField {
+					t.Errorf("json = %s, want a valueEncoding field", raw)
+				}
+				if !strings.Contains(string(raw), `"valueEncoding":"`+tt.wantEncoding+`"`) {
+					t.Errorf("json = %s, want valueEncoding %q", raw, tt.wantEncoding)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildMetrics_EmptyPDUsYieldsEmptySlice(t *testing.T) {
+	got := buildMetrics(nil, time.Now().UTC())
+	if got == nil {
+		t.Fatal("buildMetrics(nil) = nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("buildMetrics(nil) returned %d metrics, want 0", len(got))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseValue — big.Int negative overflow
 // ---------------------------------------------------------------------------
 
 func TestParseValue_BigIntNegativeOverflow(t *testing.T) {
@@ -427,10 +755,10 @@ func TestParseValue_BigIntNegativeOverflow(t *testing.T) {
 		big.NewInt(2),
 	))
 	pdu := gosnmp.SnmpPDU{Value: val}
-	got := ParseValue(pdu)
+	got, _ := parseValue(pdu)
 	s, ok := got.(string)
 	if !ok {
-		t.Errorf("ParseValue(large negative big.Int) = %v (%T), want string", got, got)
+		t.Errorf("parseValue(large negative big.Int) = %v (%T), want string", got, got)
 	}
 	if s != val.String() {
 		t.Errorf("ParseValue = %q, want %q", s, val.String())


### PR DESCRIPTION
## The bug

`parseValue` in `agent/internal/snmppoll/metrics.go` returned `string(value)` for **every** `[]byte` OCTET STRING:

```go
case []byte:
    return string(value)
```

So a value containing NUL bytes or non-UTF8 data went straight into `snmp_metrics.value`, a Postgres **`text`** column. `text` rejects NUL (`0x00`), so the insert fails — and it takes the whole poll batch with it. Every cycle. Forever, for as long as that device reports that OID.

A second bug in the same path: trailing NULs were stripped *before* deciding whether the remainder was text, silently truncating legitimate binary values.

## Why this still matters

The customer-visible symptom of this changed but did not go away. #3220/#3223 fixed the DB-pool starvation and removed the retry burn, so the 503s stopped — which makes it look shipped. Underneath, the batch is still discarded every cycle and the device is falsely marked `lastStatus='offline'` after `FAILURE_STATUS_THRESHOLD` dispatches.

It went from a loud outage to silent permanent data loss plus a lying status field.

## The fix

- Add `SNMPMetric.ValueEncoding` (`json:"valueEncoding,omitempty"`). Values that aren't affirmative text are hex-encoded and tagged `ValueEncodingHex` (`"hex"`) so the API can store them losslessly instead of failing the batch.
- `parseValue(pdu) (value any, hexEncoded bool)` replaces the flagless version; new `octetStringToText` classifies **first** and trims only when the NULs are trailing, the remainder is affirmative text, and the width isn't a fixed-width form (4/6 bytes — IPv4 and MAC).
- Same trim-order correction in `discovery/snmp.go` and `discovery/adjacency.go`.
- `fdb.go` takes the hex flag at all three call sites and skips hex rows rather than coercing them to numbers; the flagless exported `ParseValue` wrapper is dropped.

## Ordering

This is **agent-side only and must reach the fleet before the API half**. The API changes that consume `valueEncoding` (`sanitizeSnmpMetricValue`, Zod validation of the metrics payload, hex exclusion from rollups and top-interfaces ranking) are a no-op until agents actually emit the field, so they ship separately and after.

## Provenance

Recovered from the never-PR'd branch `ToddHebebrand/snmp-pool-starvation`. All four source files are **byte-identical** between `origin/main` and that branch's base — main has landed zero agent-side SNMP changes — so this applies with no conflicts. The branch's `snmpWorker.ts` half is deliberately excluded: it has been superseded by #3215/#3220, #3217/#3223 and #3226/#3378, and re-applying it would revert them.

## Verification

- `go build ./...` — clean
- `go vet ./internal/snmppoll/... ./internal/discovery/...` — clean
- `go test -race ./internal/snmppoll/... ./internal/discovery/...` — **both packages pass**
- Full `go test ./...` across the agent — **69 packages pass, 0 failures**
- Ported the 4 accompanying test files verbatim (+925 lines total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)