### PR TITLE
docs(agents): fix AGENTS.md saying Codex orchestrates work Codex handles (#3498)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,13 +172,13 @@ cd e2e-tests && pnpm test
 
 ## Codex Delegation
 
-This project uses OpenAI Codex CLI for task delegation. Codex orchestrates complex work while Codex handles isolated tasks.
+This project uses OpenAI Codex CLI for task delegation. Claude orchestrates complex work while Codex handles isolated tasks.
 
 ### Quick Commands
 
 ```bash
 # Standard task
-codex exec "<task>" --full-auto -C "/Users/toddhebebrand/breeze"
+codex exec "<task>" --full-auto -C "$(git rev-parse --show-toplevel)"
 
 # With reasoning level (low/medium/high/xhigh)
 codex exec "<task>" --full-auto -c 'model_reasoning_effort="xhigh"'
@@ -200,7 +200,7 @@ codex exec resume --last "<follow-up>"
 | Code analysis | high | "Review this for security issues" |
 | Architecture | xhigh | "Design the caching strategy" |
 
-#### Keep with Codex
+#### Keep with Claude
 - Multi-tenant data isolation
 - Authentication/authorization logic
 - Cross-module refactoring


### PR DESCRIPTION
## The bug

`AGENTS.md:175` on main currently reads:

> This project uses OpenAI Codex CLI for task delegation. **Codex orchestrates complex work while Codex handles isolated tasks.**

Both halves say Codex, so the sentence defines nothing. The delegation section heading has the same problem (`#### Keep with Codex` under guidance about what *not* to send to Codex).

This is a file agents read to decide how to delegate, so the contradiction propagates into their behaviour rather than just being a typo.

## The fix

- `Codex orchestrates` → **`Claude orchestrates`** (line 175)
- `#### Keep with Codex` → **`#### Keep with Claude`** (line 203)
- Replace the hardcoded `-C "/Users/toddhebebrand/breeze"` with `-C "$(git rev-parse --show-toplevel)"`, which was wrong for every worktree and every other machine

3 insertions, 3 deletions.

## Provenance

Cherry-picked from `docs/3498-agents-delegation`, which was committed 2026-08-14 but never pushed and never opened as a PR — found during a worktree audit. Issue #3498.

## Note, not fixed here

The example on line 181 still passes `--full-auto`, which I believe has been removed from the Codex CLI. I left it alone rather than widen a 3-line correction on a flag I haven't verified against the current CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)