### PR TITLE
docs: rescue 18 plan/spec docs that existed only in local worktrees

### DIFF
--- a/docs/superpowers/plans/remote-desktop/2026-08-10-remote-access-provider-preference-handoff.md
+++ b/docs/superpowers/plans/remote-desktop/2026-08-10-remote-access-provider-preference-handoff.md
@@ -1,0 +1,187 @@
+# Remote-access provider preference — handoff
+
+**Date:** 2026-08-10
+**Trigger:** PR #3391 (bdunncompany, draft) / issue #3389
+**Status:** decisions made, nothing implemented beyond Billy's backend. Nothing merged.
+
+---
+
+## TL;DR
+
+Billy built the backend half of a per-technician remote-access tool preference. It's correct and ships as-is. The only thing left for that feature is a UI in the user profile.
+
+Along the way three separate problems surfaced that are **not** Billy's and should be their own work: a wasteful/leaky device-detail path, missing validation on provider IDs, and the fact that remote-access providers live in a JSON blob keyed by a hand-typed string.
+
+---
+
+## 1. What Billy actually built (#3391)
+
+4 files, +137/−4, **backend only**. Two commits — the original, plus a fix pushed in response to review.
+
+- **`apps/api/src/services/remoteAccessLauncher.ts`** — `resolveRemoteAccessLaunch()` takes an optional third arg `preferredProviderId`. If it names a provider the tenant has *and* that provider is enabled, use it; otherwise fall through to `defaultProviderId`.
+- **`apps/api/src/routes/devices/core.ts`** — new `readPreferredProviderId(auth)` reads `users.preferences.remoteAccessProviderId`, gated on `isInteractiveUserSession`. Threaded into `resolveRemoteAccessLauncherForDevice`, which both the device-detail GET and the launch POST call.
+- Two test files. **No migration, no new table, no UI.**
+
+### Why it's a good PR
+
+- **The preference is an ID and nothing else.** It *selects* from the tenant's provider list; it never *supplies* one. `urlTemplate`, `password` and `customFieldKey` still come from the tenant record. That's what keeps the post-substitution `javascript:` guard meaningful — a per-user field that could carry a template would reopen exactly that hole.
+- **Gated on `isInteractiveUserSession`, not `auth.user.id`.** An MCP API key is built with `user.id = apiKey.createdBy`, so keying off identity alone would make a machine caller silently inherit the preferences of whoever minted the key. Good catch; would have shipped otherwise.
+- **Stale preference degrades quietly.** Unknown ID, foreign ID, or since-disabled provider all fall back to the default rather than failing the launch. A broken *default*, by contrast, hard-fails with `provider_disabled` (`remoteAccessLauncher.ts:69`). Quiet for user error, loud for tenant misconfiguration — correct asymmetry.
+
+### The catch
+
+**Nothing writes the preference.** `remoteAccessProviderId` appears twice in the diff, both on the read side. The value *can* be set — `PATCH /users` accepts `preferences` as an open `z.record(z.string().max(64), z.unknown())`, merged, 64KB cap (`routes/users.ts:415, 493-533`) — but no UI writes it. **Merged alone, the PR changes nothing for any user.**
+
+This is deliberate and declared (draft, "What is deliberately not here" section, two questions asked rather than guessed), which distinguishes it from the built-but-unwired pattern on #789/#778.
+
+### Review outcome
+
+One finding raised: `readPreferredProviderId` originally wrapped the `users` read in `withSystemDbAccessContext`. **Billy pushed a fix (`3bd437ea5`) and corrected the mechanism, and he was right:** `withDbAccessContext` early-returns when a store already exists (`db/index.ts:440`), so the nested call retained the request's scope — it was inert ceremony, not a self-deadlock risk. The second reason stood and is why he changed it: reading under the caller's own scope is the narrower privilege, and `users` policy already carries an `id = breeze_current_user_id()` branch, so no escalation was ever needed.
+
+---
+
+## 2. Decisions made
+
+| Question | Decision |
+|---|---|
+| Where the chooser lives | **User profile.** Not inline on Connect. |
+| Split button (default + dropdown arrow) | **Dropped.** |
+| Remembered per device | **No.** Per-user only. |
+| Billy's backend | **Ships as-is.** No changes requested. |
+
+### What was considered and rejected
+
+**Split button on Connect** — a default on the main button with a dropdown arrow for other enabled providers. Would have needed ~25 lines of backend (device GET must return the eligible provider list, not just a `hasRemoteAccessLauncher` boolean; launch POST must accept a `providerId`, re-validated server-side) plus 2–3 days of frontend. `ConnectDesktopButton.tsx` is 816 lines already multiplexing WebRTC desktop, VNC relay, the launcher path, helper lifecycle, entitlement and ~10 unavailable reasons — and **there is no shared dropdown/menu primitive in the codebase** (Header, OrgSwitcher, NotificationCenter and AlertList each hand-roll their own).
+
+**Per-device / per-device-role memory** — needs a real table: migration, RLS, four registration lists (org cascade order, device cascade, device-org-denormalized, export policy), contract tests, and a partner-wide-vs-org ownership decision. 5–10x the cost of the alternatives.
+
+**Refactoring Billy's call site to resolve an "effective provider set"** — I asked for this, then withdrew it. See §5.
+
+---
+
+## 3. Remaining work
+
+**A. Profile UI — the only thing needed to ship the feature.**
+A "preferred remote tool" control in user settings, writing `users.preferences.remoteAccessProviderId` via the existing `PATCH /users`. No backend work. Needs the list of the tenant's enabled providers to populate the control — check whether an existing endpoint exposes that, or whether it needs adding.
+
+**B. Provider ID validation — small, separate PR.**
+Two `.refine()` calls on the schema at `routes/orgs.ts:585-616`: provider IDs must be unique, and `defaultProviderId` must name one that exists. See §4.
+
+**C. Availability check vs credential issuance — separate issue.**
+See §4.
+
+**D. Providers out of the JSON blob — separate initiative.**
+See §6.
+
+**E. Org-level provider scoping — separate initiative.**
+See §7.
+
+---
+
+## 4. Bugs found (none are Billy's)
+
+### Provider IDs have no uniqueness constraint
+
+`routes/orgs.ts:585-616` validates each provider's fields and caps the array at 50, but nothing asserts IDs are distinct, and nothing asserts `defaultProviderId` names a provider in the list.
+
+- **Dangling default** → silently resolves to `no_provider_configured`. The Connect button just doesn't appear, with no hint the default points at nothing.
+- **Duplicate IDs** → credential selection becomes order-dependent. Each provider carries its own `urlTemplate` and `password`, and resolution is `providers.find(p => p.id === targetId)` (`remoteAccessLauncher.ts:63`) — first match wins. Two entries sharing an ID means reordering the array changes which endpoint and which password get substituted, with no error anywhere.
+- **The two paths disagree once #3391 lands.** The preference lookup is `find(p => p.id === preferredProviderId && p.enabled)` — it skips disabled duplicates. The default path's `find` has no `enabled` filter; it takes the first ID match and *then* fails `provider_disabled`. So with a duplicated ID where one copy is disabled, the same provider works via preference but errors via tenant default.
+
+Not exploitable — only partner admins write this list, and the scheme guard still applies to whichever template wins. It's a misconfiguration trap that would be painful to diagnose.
+
+### Device detail decrypts a password to compute a boolean
+
+`GET /devices/:id` calls `resolveRemoteAccessLauncherForDevice` (`core.ts:993`) purely to set `hasRemoteAccessLauncher`. That path decrypts the provider password and builds the full substituted launch URL (`remoteAccessLauncher.ts:87-89`), then discards it. Every device-detail load does this. Availability checking should be separated from credential-bearing issuance.
+
+*(Found by Codex, verified against source.)*
+
+---
+
+## 5. The design question: does the preference belong in the inheritance chain?
+
+**Context:** the repo already has a partner→org inheritance model — `getEffectiveOrgSettings` + `mergeCategory` + `locked` + `assertNotLocked` (`services/effectiveSettings.ts`). Security, notifications, eventLogs, defaults, branding and aiBudgets all go through it. `remoteAccessProviders` is *typed* `InheritableRemoteAccessSettings` but is **not** in `EffectiveOrgSettings` — the "Inheritable" prefix is aspirational. It's read straight off `partners.settings`.
+
+**Conclusion: keep the axes separate.**
+
+- **Config/policy** — which providers exist and are permitted. Partner → org. Belongs in an inheritance model.
+- **Preference** — which *permitted* provider I pick. Per-user. A selection over the resolved set, not a configuration tier.
+
+Collapsing them would be unsafe: if the user preference sat in the same merge chain it could enable something an org disallowed, or inject provider definitions. Billy's "selects, never supplies" shape is correct *because* it sits outside the chain.
+
+Codex's refinement, which is fair: "never a tier" is too categorical. It can be the final **selection** tier (`partner catalog → org restriction/default → user preferred ID`) as long as the user tier is a narrow `{ preferredProviderId?: string }` type that never shares `InheritableRemoteAccessSettings`.
+
+### The thing I got wrong
+
+I asked Billy to resolve against an "effective provider set" rather than `partners.settings` directly, so a future org tier would be a one-line change. **Withdrawn — the seam already exists.** Both GET and POST go through `resolveRemoteAccessLauncherForDevice` (`core.ts:993`, `core.ts:1082`), so org resolution can be introduced inside that single function without a call-site hunt. And it wouldn't be one line regardless: org settings accept `z.any()` (`orgs.ts:179`) and lock enforcement hardcodes five categories (`orgs.ts:1609`), so validation, authz and tests all change.
+
+---
+
+## 6. Design debt: providers are keyed on a hand-typed string in a JSON blob
+
+There is **no partner settings table.** `partners.settings` is a single `jsonb` column on `partners` (`db/schema/orgs.ts:33`) holding timezone, business hours, ticketing, branding, remote-access providers — everything.
+
+Providers are an array of objects in that blob, each with a self-assigned `id` string, referenced from two other places (`defaultProviderId`, and now the user preference), with nothing enforcing uniqueness or referential integrity. That's a foreign key without a foreign key, and org restriction lists would make it a third referrer.
+
+**Right shape:** a real `remote_access_providers` table, UUID primary key, with the default and the preference holding actual FKs. Uniqueness free, dangling references impossible, ordering ambiguity gone.
+
+**Real cost to know before committing:**
+- Provider passwords are encrypted with the AAD binding tied to the `partners.settings` column (`decryptForColumn('partners', 'settings', ...)`, `remoteAccessLauncher.ts:81-88`). Moving to a new table changes that binding — existing ciphertext must be re-encrypted.
+- Plus the usual: partner-axis RLS, cascade lists, `password` classified `excludedSensitive` in the export policy.
+- Call it a few days, not an afternoon.
+
+**There is precedent for exactly this move.** `timezone` was promoted out of `settings.timezone` to a first-class column under issue #1318 (`db/schema/orgs.ts:28-32`). The comment documents the transition: new column authoritative, legacy JSONB key kept in sync as the UI write target until every call site migrates. Same playbook works here, and the dual-write window is also where the re-encryption happens — no risky single cutover.
+
+**Does not block Billy.** His preference stores whatever the provider's ID is — string today, UUID after. Same shape either way.
+
+---
+
+## 7. Compliance / org-scoping gap (pre-existing)
+
+`remoteAccessProviders` is **partner-wide only**. The launcher walks device → org → partner and reads the partner row (`core.ts:1048`). `EffectiveOrgSettings` carries security, notifications, eventLogs, defaults, branding and aiBudgets — not remote access. So one customer forbidding ScreenConnect while another requires it is not expressible today.
+
+**This predates all of the above and is separable.** Two reasons it doesn't gate the preference work:
+
+1. **The audit trail already covers the compliance question.** Every launch writes `device.remote_access_launch_url.issued` with `details.providerId` (`core.ts:1131`), deliberately excluding the URL and password. "Which tech launched which tool against which machine" is already answerable.
+2. **Neither the preference nor a dropdown widens the reachable set.** Both only select from what the partner enabled. The surface is identical to today.
+
+**If/when it's built — orgs restrict only, never add.**
+
+- Store `allowedProviderIds` on the org, not copied provider objects. Optionally an org default chosen from what remains.
+- Letting orgs *add* providers transfers control of templates and credentials to the org and breaks the fixed `partners.settings` decryption binding.
+- **It cannot use `mergeCategory`.** Verified: partner fields always win wholesale (`effectiveSettings.ts:78-90`), so a partner `providers` array would lock orgs out entirely. Restriction needs set intersection, not shallow field inheritance.
+- Don't route it through generic `getEffectiveOrgSettings` — that endpoint is gated only on org-read permission (`orgs.ts:1446`), which is the wrong exposure path for credential-bearing config.
+- Estimate: 3–5 days.
+
+---
+
+## 8. Process note — Codex quorum
+
+Ran per the CLAUDE.md advisor-quorum rule (consequential design → independent read from Codex, read-only, `xhigh`). It read the same files, ~132k tokens. Outcome: agreed on the axis separation, **disagreed on the seam** (§5, and it was right), and surfaced the two bugs in §4 plus the `mergeCategory` and exposure-path points in §7. All claims spot-verified against source before being relied on.
+
+**Operational gotcha:** the first run exited **0 with no output** — `codex exec` printed "Reading additional input from stdin..." and consumed inherited stdin instead of the prompt argument. Re-running with `< /dev/null` worked. A zero exit code here looks like success.
+
+---
+
+## 9. What I still owe Billy
+
+A comment on #3391 with:
+- Both answers: chooser lives in the user profile; **not** remembered per device.
+- Split button is dropped — don't build it.
+- Backend ships as-is; the DB-context fix in `3bd437ea5` closed the only review item, and his correction on the mechanism was accepted.
+- Note that the PR is inert until the profile UI exists, so the two land together or the UI lands right behind it.
+- Provider-ID validation and the availability/issuance split are **not his** — separate issues, don't scope-creep the PR.
+
+**Done 2026-08-10 (follow-up session):** comment posted on #3391; issues filed — #3401 (provider-ID validation), #3402 (availability/issuance split), #3403 (providers → table), #3404 (org scoping, incl. the Partner-Wide-First deviation note and the slim `{id,name,enabled}` provider-list endpoint that also unblocks the profile UI for the §3A scope gap). §B implemented as PR #3406 (superRefine + 5 tests, 206/206 green).
+
+---
+
+## Appendix — session context
+
+This came out of a contributor review round on 2026-08-10. Other outcomes, unrelated to the above:
+
+- **#2826** (obsidiangroup, partner-api enrollment keys) — CHANGES_REQUESTED, round 5. Two blockers: the mint path runs every statement with **no DB access context**, and `breeze_current_scope()` defaults unset→`'system'`, so RLS is fully bypassed — their integration test passes *because* of the bypass. Second: `partner_enrollment_key_idempotency` (`org_id NOT NULL`) missing from `CORE_ORG_CASCADE_DELETE_ORDER` and `CORE_TENANT_EXPORT_POLICY`. PR is CONFLICTING with zero CI runs ever.
+- **#3366** (webhook cleartext) — CHANGES_REQUESTED. `workers/webhookDelivery.ts:134` passes neither flag; self-host private webhooks fail every delivery.
+- **#3399** (VM warranty exclusion) — CHANGES_REQUESTED. Manual refresh becomes a silent permanent dead-end.
+- **#3394** (secrets sealing), **#3396** (process-sample path id) — APPROVED, **not merged**.
+- Still open: 18 green dependabot PRs, 18 green own-PRs, 6 incoming issues awaiting first response (including two from a new contributor, cisspUser01).

--- a/docs/superpowers/plans/security-auth/2026-07-03-partner-sso-login-branding.md
+++ b/docs/superpowers/plans/security-auth/2026-07-03-partner-sso-login-branding.md
@@ -1,0 +1,1805 @@
+# Partner-Scope SSO + Login-Page Branding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an MSP's own technicians SSO into the partner dashboard via a partner-axis `sso_providers` row, and let the login page show partner branding + a partner SSO button on single-partner (self-hosted) instances. Spec: `docs/superpowers/specs/2026-07-03-partner-sso-login-branding-design.md`. Refs #2183.
+
+**Architecture:** Dual-axis extension of the existing org SSO subsystem per the epic #2135 playbook (`org_id XOR partner_id` on `sso_providers`), a new partner-only `partner_login_branding` table, a public `GET /auth/login-context` endpoint with a single-partner fast-path, and a prop/island-driven `AuthShellBranded`. The `jose`-based OIDC engine in `services/sso.ts` is reused unchanged.
+
+**Tech Stack:** Hono + Drizzle + hand-written SQL migrations, `jose` (already present), Vitest (unit + real-DB integration configs), React islands in Astro.
+
+## Global Constraints
+
+- **No new auth libraries.** `jose` only; no MSAL, no openid-client. `services/sso.ts` engine is reused, not modified (only consumed).
+- **Identity-first, NO JIT on the partner axis.** A partner-axis login NEVER creates a user. `defaultRoleId` on partner providers is validated + stored but NEVER applied at login in v1; users without a `partner_users` membership are rejected (`no_partner_access`) — never fall back to a default role (membershipless-user system-scope-token bug class).
+- **Email auto-link keeps the org flow's safety conditions** (password set OR linked to a different provider → `sso_link_required` error, no auto-link). Password-holding users link via the authenticated self-service **Connect SSO** flow (Task 6); the `sso_link_required` error copy directs them there. Settled with Todd 2026-07-03 — this is now spec, not a deviation.
+- **Break-glass preserved:** `enforceSSO` only suppresses password login for `status='active'` providers (`testing` never suppresses).
+- **No `z.any()`** in any new/modified schema. `ssoConfig` is REMOVED from partner/org Zod schemas (Task 3).
+- **Migration:** one file `apps/api/migrations/2026-07-03-sso-partner-axis-login-branding.sql`, idempotent, RLS in the same file, no inner `BEGIN;`/`COMMIT;`, never edit shipped migrations.
+- **Partner id always derived from the caller's token, never the request body.** Partner-scope writes gated on `canManagePartnerWidePolicies(auth)` (`apps/api/src/services/partnerWideAccess.ts:25`).
+- **Public SSO/auth endpoints run DB reads/writes inside `withSystemDbAccessContext`** (no request scope exists pre-auth; bare `db` silently returns 0 rows under RLS).
+- **Tests:** unit `pnpm test --filter=@breeze/api`; real-DB integration `pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/<file>` (Postgres on :5433 via `docker compose -f docker-compose.test.yml up -d`). TRAP: a worktree missing the `.env.test` symlink makes RLS forge tests vacuously pass under a BYPASSRLS role — verify `apps/api/.env.test` exists and points at the test DB before trusting green forge tests.
+- **PR text uses `Refs #2183`** (community issue — never `Closes`/`Fixes`).
+
+---
+
+### Task 1: Migration + Drizzle schema (dual-axis `sso_providers`, new `partner_login_branding`)
+
+**Files:**
+- Create: `apps/api/migrations/2026-07-03-sso-partner-axis-login-branding.sql`
+- Modify: `apps/api/src/db/schema/sso.ts` (ssoProviders table, lines 9-59)
+- Create: `apps/api/src/db/schema/partnerLoginBranding.ts`
+- Modify: `apps/api/src/db/schema/index.ts` (add export)
+
+**Interfaces:**
+- Produces: `ssoProviders.partnerId` (uuid, nullable) + nullable `ssoProviders.orgId`; `ssoSessions.linkUserId` (uuid, nullable — link-mode marker for Task 6); Drizzle table `partnerLoginBranding` with columns `partnerId` (PK), `logoUrl`, `accentColor`, `headline`, `createdAt`, `updatedAt`. All later tasks import these from `../db/schema`.
+
+**Note:** the table is named `partner_login_branding`, not the spec's `partner_branding` — a deliberate rename because the web app already has a "Partner Branding" feature (`PartnerBrandingTab.tsx`, inheritable org-branding defaults) and a `partner_branding` table would collide semantically with it.
+
+- [ ] **Step 1: Write the migration**
+
+Model on `apps/api/migrations/2026-06-27-config-policies-partner-ownership.sql` (the playbook reference). Full content:
+
+```sql
+-- Partner-axis SSO providers + partner login branding (#2183, epic #2135 playbook).
+--
+-- sso_providers becomes dual-ownership: org-axis (org_id set, partner_id NULL —
+-- the existing customer-org SSO shape) OR partner-axis (partner_id set, org_id
+-- NULL — the MSP's own technician login). Exactly one axis per row (CHECK).
+-- user_sso_identities is unchanged: it keys off provider_id, and the provider
+-- row carries ownership. sso_sessions gains a nullable link_user_id: when set,
+-- the session is a LINK-mode round-trip (an already-authenticated user
+-- connecting their SSO identity) rather than a login. sso_verified_domains
+-- stays org-only (it gates JIT, which partner-axis providers do not do in v1).
+--
+-- partner_login_branding is deliberately partner-ONLY (not dual-axis): org-level
+-- login branding already exists as portal_branding.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECK, DROP POLICY IF EXISTS
+-- then CREATE. No inner BEGIN/COMMIT (autoMigrate wraps each file).
+
+-- ============================================
+-- Step 1: sso_providers — add partner_id, relax org_id, exactly-one-axis
+-- ============================================
+
+ALTER TABLE sso_providers
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE sso_providers
+  ALTER COLUMN org_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'sso_providers_one_owner_chk'
+      AND conrelid = 'sso_providers'::regclass
+  ) THEN
+    ALTER TABLE sso_providers
+      ADD CONSTRAINT sso_providers_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS sso_providers_partner_id_idx
+  ON sso_providers(partner_id);
+
+-- Link-mode marker for the self-service Connect SSO flow: when set, the
+-- callback links the verified identity to THIS user instead of logging in.
+ALTER TABLE sso_sessions
+  ADD COLUMN IF NOT EXISTS link_user_id uuid REFERENCES users(id);
+
+-- ============================================
+-- Step 2: sso_providers RLS — dual-axis (org OR partner) + FORCE
+-- ============================================
+
+ALTER TABLE sso_providers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sso_providers FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS sso_providers_org_isolation ON sso_providers;
+CREATE POLICY sso_providers_org_isolation
+  ON sso_providers
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );
+
+-- ============================================
+-- Step 3: partner_login_branding — table + partner-axis RLS + FORCE
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS partner_login_branding (
+  partner_id uuid PRIMARY KEY REFERENCES partners(id) ON DELETE CASCADE,
+  logo_url text,
+  accent_color varchar(7),
+  headline varchar(120),
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+ALTER TABLE partner_login_branding ENABLE ROW LEVEL SECURITY;
+ALTER TABLE partner_login_branding FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS partner_login_branding_partner_isolation ON partner_login_branding;
+CREATE POLICY partner_login_branding_partner_isolation
+  ON partner_login_branding
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR public.breeze_has_partner_access(partner_id)
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR public.breeze_has_partner_access(partner_id)
+  );
+```
+
+**IMPORTANT pre-existing-policy check:** before finalizing, run against a migrated local DB: `SELECT policyname FROM pg_policies WHERE tablename = 'sso_providers';` and add a `DROP POLICY IF EXISTS <name>` line for EVERY existing policy name found (they may be per-command `breeze_org_isolation_select/insert/update/delete` style, not the single name assumed above). The dual-axis CREATE must replace all org-only policies, whatever their names.
+
+- [ ] **Step 2: Update Drizzle schema — `sso.ts`**
+
+In `apps/api/src/db/schema/sso.ts`, add the partners import and change the ssoProviders header block:
+
+```ts
+import { organizations, partners } from './orgs';
+```
+
+```ts
+// SSO Provider Configuration — dual ownership (#2183): org-axis (orgId set,
+// partnerId NULL — customer-org SSO) XOR partner-axis (partnerId set, orgId
+// NULL — the MSP's own technician login). Enforced by sso_providers_one_owner_chk.
+export const ssoProviders = pgTable('sso_providers', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
+```
+
+(Only `orgId` loses `.notNull()`; every other ssoProviders column is untouched.)
+
+Also add to the `ssoSessions` table definition (after `redirectUrl`):
+
+```ts
+  // Link-mode marker (#2183 Connect SSO): when set, the callback links the
+  // verified identity to this user instead of minting login tokens.
+  linkUserId: uuid('link_user_id').references(() => users.id),
+```
+
+- [ ] **Step 3: Create `apps/api/src/db/schema/partnerLoginBranding.ts`**
+
+```ts
+import { pgTable, uuid, varchar, text, timestamp } from 'drizzle-orm/pg-core';
+import { partners } from './orgs';
+
+// Login-page branding for the MSP's OWN technician login (#2183). Deliberately
+// partner-only (no org axis): org/customer login branding already exists as
+// portal_branding. One row per partner (PK = partner_id). RLS shape 3:
+// breeze_has_partner_access(partner_id), FORCE — see the 2026-07-03 migration.
+// NOT the same feature as the "Partner Branding" inheritable org-defaults tab.
+export const partnerLoginBranding = pgTable('partner_login_branding', {
+  partnerId: uuid('partner_id').primaryKey().references(() => partners.id, { onDelete: 'cascade' }),
+  logoUrl: text('logo_url'),
+  accentColor: varchar('accent_color', { length: 7 }),
+  headline: varchar('headline', { length: 120 }),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+```
+
+Add to `apps/api/src/db/schema/index.ts` following its existing export style (one line, alphabetical position): `export * from './partnerLoginBranding';`
+
+- [ ] **Step 4: Verify migration applies + drift check**
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"  # use your local dev DB
+pnpm db:check-drift
+```
+Expected: drift check passes (schema matches migrations). Also re-apply the migration a second time against the same DB (idempotency): re-running `autoMigrate` (or `psql -f` of the file) must be a no-op with no errors.
+
+- [ ] **Step 5: Run the autoMigrate ordering regression test**
+
+```bash
+pnpm test --filter=@breeze/api -- autoMigrate
+```
+Expected: PASS (filename sorts correctly after existing 2026-07 migrations).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/migrations/2026-07-03-sso-partner-axis-login-branding.sql apps/api/src/db/schema/sso.ts apps/api/src/db/schema/partnerLoginBranding.ts apps/api/src/db/schema/index.ts
+git commit -m "feat(sso): dual-axis sso_providers + partner_login_branding schema (#2183)
+
+Refs #2183
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: RLS registrations + partner-axis forge integration tests
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` (`DUAL_AXIS_TENANT_TABLES` at :204, `PARTNER_TENANT_TABLES` at :122)
+- Create: `apps/api/src/__tests__/integration/ssoProvidersPartnerRls.integration.test.ts`
+- Create: `apps/api/src/__tests__/integration/partnerLoginBrandingRls.integration.test.ts`
+- Possibly modify: `apps/api/src/services/tenantCascade.ts` (only if the cascade contract test fails — see Step 4)
+
+**Interfaces:**
+- Consumes: Task 1's schema. No exports; contract/forge coverage only.
+
+- [ ] **Step 1: Register both tables in the coverage contract**
+
+In `DUAL_AXIS_TENANT_TABLES` (rls-coverage.integration.test.ts:204), add with the same comment style as `configuration_policies`:
+
+```ts
+  // sso_providers (#2183): org-axis (org_id set — customer-org SSO, the
+  // original shape) OR partner-axis (partner_id set, org_id NULL — MSP
+  // technician login). Converted in 2026-07-03-sso-partner-axis-login-branding.
+  // Org auto-discovery asserts the org branch; this entry asserts the
+  // breeze_has_partner_access branch. CHECK sso_providers_one_owner_chk
+  // enforces exactly one axis. Functional forge proof:
+  // ssoProvidersPartnerRls.integration.test.ts.
+  'sso_providers',
+```
+
+In `PARTNER_TENANT_TABLES` (:122), add in list position: `['partner_login_branding', 'partner_id'],`
+
+- [ ] **Step 2: Write `ssoProvidersPartnerRls.integration.test.ts`**
+
+Copy the setup/teardown skeleton from `apps/api/src/__tests__/integration/configurationPoliciesPartnerRls.integration.test.ts` (two partners + a partner-scope access context helper), then assert, as `breeze_app` with partner-A context:
+
+```ts
+// 1. Functional second-axis insert: partner A inserts a partner-axis provider — succeeds.
+//    (values: partnerId: partnerA.id, orgId: null, name: 'Partner IdP', type: 'oidc', status: 'inactive')
+// 2. Cross-partner forge: partner A inserts a row with partnerId: partnerB.id — expect
+//    error.code === '42501' (new row violates row-level security policy).
+// 3. XOR: insert with BOTH orgId and partnerId set — expect error.code === '23514'
+//    (sso_providers_one_owner_chk). Insert with NEITHER — also '23514'.
+// 4. Visibility isolation: partner B context SELECTs — partner A's provider row absent.
+// 5. Org context (org under partner A) SELECTs — the partner-axis row is NOT
+//    visible (org tokens never pass breeze_has_partner_access; RLS stricter than app layer).
+```
+
+Write these as real inserts/selects through the test file's `breeze_app` client helper, matching the sibling file's helper names exactly (do not memoize fixtures across assertions — memoized-fixture forge tests go vacuous).
+
+- [ ] **Step 3: Write `partnerLoginBrandingRls.integration.test.ts`**
+
+Same skeleton: partner A upserts its row (succeeds), forges partner B's `partner_id` (42501), partner B sees nothing, `DELETE FROM partners` cascade removes the row (ON DELETE CASCADE).
+
+- [ ] **Step 4: Run coverage + cascade + forge suites**
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+ls -la apps/api/.env.test   # MUST exist (symlink) — otherwise forge tests are vacuous
+pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/rls-coverage.integration.test.ts src/__tests__/integration/ssoProvidersPartnerRls.integration.test.ts src/__tests__/integration/partnerLoginBrandingRls.integration.test.ts
+pnpm test --filter=@breeze/api -- tenantCascade
+```
+Expected: all PASS. If a tenant-cascade contract test fails naming `partner_login_branding` or `sso_providers`, register the table exactly where the failure message directs (org cascade at `tenantCascade.ts:63` deletes by `org_id`, so partner-axis rows with `org_id NULL` are naturally out of its scope; `partner_login_branding` cascades via FK `ON DELETE CASCADE`). Keep any list insertion in `localeCompare` order.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/
+git commit -m "test(sso): partner-axis RLS forge + coverage registration (#2183)
+
+Refs #2183
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Provider CRUD — `ownerScope`, partner gates, write-time role validation, `ssoConfig` removal
+
+**Files:**
+- Modify: `apps/api/src/routes/sso.ts` (schemas :125-151, list :376, get :402, create :427, update :512, delete :573, status :624)
+- Modify: `apps/api/src/routes/orgs.ts` (:60 `createPartnerSchema`, :120-ish `createOrganizationSchema` — remove `ssoConfig`)
+- Test: `apps/api/src/routes/sso.test.ts` (extend existing; create if absent)
+
+**Interfaces:**
+- Consumes: `canManagePartnerWidePolicies(auth)`, `PARTNER_WIDE_WRITE_DENIED_MESSAGE` from `../services/partnerWideAccess`; `ssoProviders.partnerId` from Task 1.
+- Produces: `createProviderSchema` gains `ownerScope: z.enum(['organization','partner']).default('organization')`; helpers `canAccessProviderRow(auth, row): boolean` and `canWriteProviderRow(auth, row): boolean` (also consumed by Tasks 5-7); partner-axis rows created with `orgId: null, partnerId: auth.partnerId`.
+
+- [ ] **Step 1: Write failing route tests**
+
+Extend `sso.test.ts` (Drizzle mock pattern per the `breeze-testing` skill; mirror the file's existing mocks) with:
+
+```ts
+describe('partner-axis provider CRUD (#2183)', () => {
+  it('creates a partner-axis provider for ownerScope=partner with orgAccess=all', async () => {
+    // auth mock: scope 'partner', partnerId 'p-1', partnerOrgAccess 'all'
+    // POST /providers { ownerScope: 'partner', name, type: 'oidc', ... }
+    // expect 201; inserted values orgId: null, partnerId: 'p-1'
+  });
+  it('403s ownerScope=partner when partnerOrgAccess is not all', async () => {
+    // partnerOrgAccess 'selected' → 403 with PARTNER_WIDE_WRITE_DENIED_MESSAGE
+  });
+  it('400s a partner-axis defaultRoleId that is not a partner-scoped role of the caller partner', async () => {});
+  it('rejects ownerScope on update (schema omits it)', async () => {
+    // PATCH body { ownerScope: 'partner' } → zod strips/rejects; axis unchanged
+  });
+  it('does not accept partnerId from the request body', async () => {
+    // POST { ownerScope:'partner', partnerId:'p-EVIL' } → row still created with token partnerId 'p-1'
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+pnpm test --filter=@breeze/api -- routes/sso
+```
+Expected: FAIL (ownerScope unknown key / handlers missing partner branch).
+
+- [ ] **Step 3: Implement schema + create-route changes in `routes/sso.ts`**
+
+Schema edits (at :125):
+
+```ts
+const createProviderSchema = z.object({
+  ownerScope: z.enum(['organization', 'partner']).default('organization'),
+  orgId: z.string().guid().optional(),
+  // ...existing fields unchanged...
+});
+
+const updateProviderSchema = createProviderSchema.omit({ orgId: true, ownerScope: true }).partial();
+```
+
+Add imports:
+
+```ts
+import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
+```
+
+Add row-access helpers next to `resolveOrgIdForProviderRoute` (:308):
+
+```ts
+type ProviderOwnerRow = { orgId: string | null; partnerId: string | null };
+
+// Read access: org rows by org access; partner rows only for the same partner's
+// partner/system-scope callers (org tokens never see partner-axis providers).
+function canAccessProviderRow(auth: AuthContext, row: ProviderOwnerRow): boolean {
+  if (row.orgId) return auth.canAccessOrg(row.orgId);
+  return (auth.scope === 'system' || auth.scope === 'partner') && auth.partnerId === row.partnerId;
+}
+
+// Write access: partner-axis rows additionally require full partner org access.
+function canWriteProviderRow(auth: AuthContext, row: ProviderOwnerRow): boolean {
+  if (row.orgId) return auth.canAccessOrg(row.orgId);
+  return auth.partnerId === row.partnerId && canManagePartnerWidePolicies(auth);
+}
+```
+
+In the create handler (:434), branch before the org resolution:
+
+```ts
+  const auth = c.get('auth') as AuthContext;
+  const body = c.req.valid('json');
+
+  let ownerColumns: { orgId: string | null; partnerId: string | null };
+  if (body.ownerScope === 'partner') {
+    if (auth.scope !== 'partner' || !auth.partnerId) {
+      return c.json({ error: 'Partner scope required for a partner-axis SSO provider' }, 400);
+    }
+    if (!canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+    if (body.defaultRoleId) {
+      const [role] = await db
+        .select({ id: roles.id })
+        .from(roles)
+        .where(and(
+          eq(roles.id, body.defaultRoleId),
+          eq(roles.scope, 'partner'),
+          eq(roles.partnerId, auth.partnerId)
+        ))
+        .limit(1);
+      if (!role) {
+        return c.json({ error: 'defaultRoleId must be a partner-scoped role belonging to your partner' }, 400);
+      }
+    }
+    ownerColumns = { orgId: null, partnerId: auth.partnerId };
+  } else {
+    const orgResult = resolveOrgIdForProviderRoute(auth, body.orgId);
+    if ('error' in orgResult) {
+      return c.json({ error: orgResult.error }, orgResult.status);
+    }
+    ownerColumns = { orgId: orgResult.orgId, partnerId: null };
+  }
+```
+
+…and in the `.values({...})` replace `orgId: orgResult.orgId,` with `...ownerColumns,`. The `writeRouteAudit` call keeps `orgId: provider.orgId` (nullable is fine for audit) and adds `partnerId: provider.partnerId` to `details`.
+
+- [ ] **Step 4: Update list/get/update/delete/status handlers**
+
+- List (:376): add a partner branch before org resolution — when `c.req.query('scope') === 'partner'`: require `auth.scope === 'partner' || auth.scope === 'system'` and `auth.partnerId`, return providers `where(eq(ssoProviders.partnerId, auth.partnerId))` with the same column projection + `partnerId`.
+- Get (:416): replace `if (!auth.canAccessOrg(provider.orgId))` with `if (!canAccessProviderRow(auth, provider))`.
+- Update (:525-551): select `{ id, orgId, partnerId }`; replace access check with `canWriteProviderRow`; when the body has `defaultRoleId` and the row is partner-axis, run the same partner-scoped role validation as create (against `existing.partnerId`); change the update `.where(...)` to `eq(ssoProviders.id, providerId)` only (RLS + the access check already scope it; the old `and(orgId)` clause would never match a partner row).
+- Delete (:584-605) and status (:637+): same `canWriteProviderRow` swap and same `.where(eq(id))` change.
+- All audit calls: `orgId: row.orgId` stays (may be null), add `partnerId` to `details`.
+
+- [ ] **Step 5: Remove `ssoConfig` from orgs schemas**
+
+In `apps/api/src/routes/orgs.ts` delete the `ssoConfig: z.any().optional(),` line from BOTH `createPartnerSchema` (:60) and `createOrganizationSchema` (:120 block). Grep the file for any handler line that forwards `body.ssoConfig` into an insert/update (`orgs.ts:285, :1106, :1229` per the audit) and delete those property lines too. Do NOT touch the DB columns.
+
+- [ ] **Step 6: Run tests + typecheck**
+
+```bash
+pnpm test --filter=@breeze/api -- routes/sso
+pnpm test --filter=@breeze/api -- routes/orgs
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+Expected: PASS (orgs tests may need their `ssoConfig` fixtures deleted — update them, they were asserting a write-only field).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/routes/sso.ts apps/api/src/routes/sso.test.ts apps/api/src/routes/orgs.ts apps/api/src/routes/orgs.test.ts
+git commit -m "feat(sso): ownerScope on provider CRUD, partner-wide gate, drop dormant ssoConfig (#2183)
+
+Refs #2183
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Partner login entry — `GET /sso/login/partner/:partnerId`
+
+**Files:**
+- Modify: `apps/api/src/routes/sso.ts` (insert the new route ABOVE the `/login/:orgId` handler at :904)
+- Test: `apps/api/src/routes/sso.test.ts`
+
+**Interfaces:**
+- Consumes: existing `generateState/generateNonce/generatePKCEChallenge/buildAuthorizationUrl/getOIDCConfig/buildSsoStateCookie/normalizeRedirectPath` helpers, `withSystemDbAccessContext`.
+- Produces: public URL shape `/api/v1/sso/login/partner/:partnerId?redirect=<path>` consumed by Task 8's `login-context` and Task 10's button.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+describe('GET /sso/login/partner/:partnerId', () => {
+  it('404s when the partner has no active partner-axis provider', async () => {});
+  it('redirects to the IdP authorization URL and sets the state cookie for an active provider', async () => {
+    // mock provider row { partnerId: 'p-1', orgId: null, status: 'active', type: 'oidc', ... }
+    // expect 302, Location startsWith mocked authorization URL, Set-Cookie contains breeze_sso_state
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+pnpm test --filter=@breeze/api -- routes/sso
+```
+Expected: FAIL (404 route not found).
+
+- [ ] **Step 3: Implement**
+
+Insert ABOVE the `/login/:orgId` route (:904) — Hono matches the 3-segment path first, but keeping it above documents the intent:
+
+```ts
+const partnerIdParamSchema = z.object({ partnerId: z.string().guid() });
+
+// Initiate partner-axis SSO login (#2183) — the MSP's own technician login.
+// Public route: all DB access MUST run under system context (no request scope
+// exists yet; bare `db` silently returns 0 rows under RLS).
+ssoRoutes.get('/login/partner/:partnerId', zValidator('param', partnerIdParamSchema), async (c) => {
+  const { partnerId } = c.req.valid('param');
+  const redirectUrl = normalizeRedirectPath(c.req.query('redirect'));
+
+  const [provider] = await withSystemDbAccessContext(async () =>
+    db
+      .select()
+      .from(ssoProviders)
+      .where(and(
+        eq(ssoProviders.partnerId, partnerId),
+        eq(ssoProviders.status, 'active')
+      ))
+      .limit(1)
+  );
+
+  if (!provider) {
+    return c.json({ error: 'No active SSO provider for this partner' }, 404);
+  }
+
+  if (provider.type !== 'oidc') {
+    return c.json({ error: 'Only OIDC login is currently supported' }, 400);
+  }
+
+  const config = getOIDCConfig(provider);
+  const pkce = generatePKCEChallenge();
+  const state = generateState();
+  const nonce = generateNonce();
+
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
+  await withSystemDbAccessContext(async () =>
+    db.insert(ssoSessions).values({
+      providerId: provider.id,
+      state,
+      nonce,
+      codeVerifier: pkce.codeVerifier,
+      redirectUrl,
+      expiresAt
+    })
+  );
+
+  const authUrl = buildAuthorizationUrl({
+    config,
+    state,
+    nonce,
+    redirectUri: buildSsoCallbackUri(),
+    pkce
+  });
+
+  const stateCookie = buildSsoStateCookie(state);
+  if (!stateCookie) {
+    return c.json({ error: 'SSO login binding secret is not configured on this instance' }, 500);
+  }
+  c.header('Set-Cookie', stateCookie, { append: true });
+
+  return c.redirect(authUrl);
+});
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm test --filter=@breeze/api -- routes/sso
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/sso.ts apps/api/src/routes/sso.test.ts
+git commit -m "feat(sso): partner-axis login initiation route (#2183)
+
+Refs #2183
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Callback partner-axis branch — identity-first resolution, `scope:'partner'` tokens
+
+**Files:**
+- Modify: `apps/api/src/routes/sso.ts` (`GET /callback`, :971-1402)
+- Test: `apps/api/src/routes/sso.test.ts`
+
+**Interfaces:**
+- Consumes: `partnerUsers` from `../db/schema` (add to the schema import at :8-17), `isNull` from `drizzle-orm` (add to import at :4), `auditLogin` from `./auth/helpers` (add import).
+- Produces: partner-axis token payload `{ sub, email, roleId, orgId: null, partnerId, scope: 'partner', mfa }`; error reason codes `invite_required`, `no_partner_access` (+ existing `sso_link_required`, `invalid_role_scope`, `invalid_provider_configuration`).
+
+**Safety rationale:** email auto-link keeps the org flow's safe-link conditions — auto-link only when the matched user has NO password and NO link to a different provider; otherwise redirect `sso_link_required`. Unconditional email-linking is the account-takeover surface the org flow deliberately closed (a partner admin repointing the IdP could assert another tech's email and capture their account). Password-holding users connect their identity through the authenticated self-service **Connect SSO** flow (Task 6); the `sso_link_required` error copy on the login page points them there (Task 6 Step 6).
+
+- [ ] **Step 1: Write failing callback tests**
+
+Model mocks on the file's existing callback tests (state cookie + session + provider + IdP token mocks). New cases:
+
+```ts
+describe('SSO callback — partner axis (#2183)', () => {
+  it('logs in linked partner staff with scope partner and null orgId', async () => {
+    // provider { partnerId: 'p-1', orgId: null }, user_sso_identities link exists,
+    // partner_users membership role scope 'partner'
+    // expect redirect #ssoCode=..., createTokenPair called with
+    // { orgId: null, partnerId: 'p-1', scope: 'partner' }
+  });
+  it('auto-links by email ONLY for passwordless unlinked partner staff', async () => {
+    // users row: partnerId p-1, orgId null, passwordHash null, no other link → linked + logged in
+  });
+  it('redirects sso_link_required for a password-holding email match', async () => {});
+  it('never resolves an org-bound user through a partner provider', async () => {
+    // users row with same email but orgId set → redirect invite_required
+  });
+  it('redirects invite_required for unknown identities (no JIT)', async () => {});
+  it('redirects no_partner_access when the user has no partner_users membership', async () => {});
+  it('rejects a partner provider whose defaultRoleId is not partner-scoped', async () => {
+    // → redirect invalid_provider_configuration
+  });
+  it('sets mfa true only with trustsIdpMfa AND amr mfa', async () => {});
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+pnpm test --filter=@breeze/api -- routes/sso
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the axis branch**
+
+3a. Default-role validation (:1034-1054) becomes axis-aware:
+
+```ts
+  let validatedDefaultRoleId: string | null = null;
+  if (provider.defaultRoleId) {
+    const roleCondition = provider.partnerId
+      ? and(
+          eq(roles.id, provider.defaultRoleId),
+          eq(roles.scope, 'partner'),
+          eq(roles.partnerId, provider.partnerId)
+        )
+      : and(
+          eq(roles.id, provider.defaultRoleId),
+          eq(roles.scope, 'organization'),
+          eq(roles.orgId, provider.orgId!)
+        );
+    const [defaultRole] = await withSystemDbAccessContext(async () =>
+      db.select({ id: roles.id }).from(roles).where(roleCondition).limit(1)
+    );
+    if (!defaultRole) {
+      clearStateCookie();
+      return c.redirect('/login?error=invalid_provider_configuration');
+    }
+    validatedDefaultRoleId = defaultRole.id;
+  }
+```
+
+(Note: v1 never APPLIES `validatedDefaultRoleId` on the partner axis — it is config validation only; the org JIT branch still uses it.)
+
+3b. Domain-verification gate (:1162-1174): org-axis only — wrap the existing block in `if (!user && provider.orgId) { ... }` (it gates JIT/link-by-email for orgs; partner axis has no JIT and its email-match is restricted to the partner's own staff pool below).
+
+3c. Email-match branch (:1176-1206): make the lookup axis-aware, keep the safety conditions verbatim:
+
+```ts
+      const emailCondition = provider.partnerId
+        ? and(
+            eq(users.email, attrs.email.toLowerCase()),
+            eq(users.partnerId, provider.partnerId),
+            isNull(users.orgId)
+          )
+        : eq(users.email, attrs.email.toLowerCase());
+      const [byEmail] = await withSystemDbAccessContext(async () =>
+        db.select().from(users).where(emailCondition).limit(1)
+      );
+```
+
+3d. JIT block (:1208-1265): partner axis never provisions — insert at the top:
+
+```ts
+    if (!user && provider.partnerId) {
+      clearStateCookie();
+      return c.redirect('/login?error=invite_required');
+    }
+```
+
+3e. Membership + token (:1267-1292 and :1362-1370): branch on axis:
+
+```ts
+    let tokenPayload: Parameters<typeof createTokenPair>[0];
+    if (provider.partnerId) {
+      const providerPartnerId = provider.partnerId;
+      const [partnerMembership] = await withSystemDbAccessContext(async () =>
+        db
+          .select({ roleId: partnerUsers.roleId, roleScope: roles.scope })
+          .from(partnerUsers)
+          .innerJoin(roles, eq(roles.id, partnerUsers.roleId))
+          .where(and(
+            eq(partnerUsers.userId, user.id),
+            eq(partnerUsers.partnerId, providerPartnerId)
+          ))
+          .limit(1)
+      );
+      if (!partnerMembership) {
+        clearStateCookie();
+        return c.redirect('/login?error=no_partner_access');
+      }
+      if (partnerMembership.roleScope !== 'partner') {
+        clearStateCookie();
+        return c.redirect('/login?error=invalid_role_scope');
+      }
+      tokenPayload = {
+        sub: user.id,
+        email: user.email,
+        roleId: partnerMembership.roleId,
+        orgId: null,
+        partnerId: providerPartnerId,
+        scope: 'partner' as const,
+        mfa: ssoMfa
+      };
+    } else {
+      // existing org branch: orgUser lookup + roleScope check + existing payload, unchanged
+    }
+```
+
+(The `ssoMfa` computation at :1360 is axis-independent — leave it where it is, above this branch.)
+
+3f. Audit: after the successful token mint (near :1389), add for the partner axis:
+
+```ts
+    if (provider.partnerId) {
+      auditLogin(c, user, { method: 'sso-partner', mfa: ssoMfa, scope: 'partner' });
+    }
+```
+
+(Match `auditLogin`'s exact signature at `routes/auth/helpers.ts:704` — adjust argument shape to it, keeping `method: 'sso-partner'`.)
+
+- [ ] **Step 4: Run tests + typecheck**
+
+```bash
+pnpm test --filter=@breeze/api -- routes/sso
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+Expected: PASS, including all pre-existing org callback tests (the org path behavior must be byte-for-byte unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/sso.ts apps/api/src/routes/sso.test.ts
+git commit -m "feat(sso): partner-axis callback — identity-first login, scope:partner tokens (#2183)
+
+Refs #2183
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Self-service "Connect SSO" link flow (authenticated identity linking)
+
+**Files:**
+- Modify: `apps/api/src/routes/sso.ts` (new authenticated routes + link-mode branch at the top of `GET /callback`)
+- Modify: `apps/web/src/components/settings/ProfileSecurityPage.tsx` — or whichever component renders the user's own security settings; locate it via `grep -rn "mfa" apps/web/src/pages/settings/profile.astro` and follow the import; add `ConnectSsoCard` there
+- Create: `apps/web/src/components/settings/ConnectSsoCard.tsx` + `ConnectSsoCard.test.tsx`
+- Test: `apps/api/src/routes/sso.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1's `ssoSessions.linkUserId`; Task 5's callback structure; existing `buildSsoStateCookie`/`generateState`/`generateNonce`/`generatePKCEChallenge`/`buildAuthorizationUrl`/`getOIDCConfig`; `authMiddleware`, `requireMfa` from `../middleware/auth`; `writeRouteAudit`; web `runAction`.
+- Produces: `GET /sso/link/options` → `{ data: Array<{ id, name, type, linked: boolean }> }`; `POST /sso/link/start/:providerId` → `{ authUrl: string }` (+ sets the state cookie); callback link-mode redirect `→ /settings/profile?ssoLinked=1` on success, `?ssoLinkError=<reason>` on failure. Login-page error copy for `sso_link_required` points at Profile → Security → Connect SSO.
+
+**Why:** password-holding users are never auto-linked (Task 5 safety conditions), so without this flow existing technicians could never adopt SSO. Settled with Todd 2026-07-03. Works for BOTH axes: an org user links an org-axis provider; a partner-staff user links a partner-axis provider.
+
+- [ ] **Step 1: Write failing API tests**
+
+Extend `sso.test.ts`:
+
+```ts
+describe('Connect SSO link flow (#2183)', () => {
+  it('GET /sso/link/options lists providers the user can link with linked flags', async () => {
+    // org user (orgId o-1) → org-axis providers of o-1 (status active|testing);
+    // partner-staff user (orgId null, partnerId p-1) → partner-axis providers of p-1.
+    // linked: true when a user_sso_identities row exists for (user, provider).
+  });
+  it('POST /sso/link/start/:providerId returns authUrl and sets the state cookie', async () => {
+    // expect res.json().authUrl startsWith mocked authorization URL,
+    // Set-Cookie contains breeze_sso_state, and the inserted sso_sessions row
+    // has linkUserId === auth.user.id
+  });
+  it('link/start 401s unauthenticated and 428/403s without MFA (requireMfa)', async () => {});
+  it('link/start 403s a provider outside the user axis pool', async () => {
+    // org user + partner-axis provider → 403; partner user + other partner → 403
+  });
+  it('callback in link mode creates the identity for the SESSION user after verification', async () => {
+    // session row { linkUserId: 'u-1' }, verified id_token email === u-1.email
+    // → user_sso_identities insert { userId: 'u-1', providerId, externalId: sub },
+    //   NO createTokenPair call, redirect /settings/profile?ssoLinked=1
+  });
+  it('callback link mode rejects an email mismatch', async () => {
+    // asserted email !== linking user's email → redirect ?ssoLinkError=email_mismatch, no insert
+  });
+  it('callback link mode rejects a (provider, sub) already linked to another user', async () => {
+    // → redirect ?ssoLinkError=identity_in_use, no insert
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+pnpm test --filter=@breeze/api -- routes/sso
+```
+Expected: FAIL (routes missing; callback has no link branch).
+
+- [ ] **Step 3: Implement the authenticated link routes in `routes/sso.ts`**
+
+Place with the other authenticated routes (below the provider CRUD, above the public login flow):
+
+```ts
+// ============================================
+// Self-service Connect SSO (authenticated identity linking, #2183)
+// ============================================
+
+// Providers the current user may link, with linked status.
+ssoRoutes.get('/link/options', authMiddleware, async (c) => {
+  const auth = c.get('auth') as AuthContext;
+
+  const axisCondition = auth.user.orgId
+    ? eq(ssoProviders.orgId, auth.user.orgId)
+    : auth.partnerId
+      ? eq(ssoProviders.partnerId, auth.partnerId)
+      : null;
+  if (!axisCondition) {
+    return c.json({ data: [] });
+  }
+
+  const providers = await db
+    .select({
+      id: ssoProviders.id,
+      name: ssoProviders.name,
+      type: ssoProviders.type,
+      linkedId: userSsoIdentities.id
+    })
+    .from(ssoProviders)
+    .leftJoin(userSsoIdentities, and(
+      eq(userSsoIdentities.providerId, ssoProviders.id),
+      eq(userSsoIdentities.userId, auth.user.id)
+    ))
+    .where(and(axisCondition, ne(ssoProviders.status, 'inactive')));
+
+  return c.json({
+    data: providers.map((p) => ({ id: p.id, name: p.name, type: p.type, linked: !!p.linkedId }))
+  });
+});
+
+// Start a link-mode IdP round-trip. requireMfa(): linking an SSO identity is a
+// security-sensitive account change (it adds a login credential).
+ssoRoutes.post(
+  '/link/start/:providerId',
+  authMiddleware,
+  requireMfa(),
+  zValidator('param', z.object({ providerId: z.string().guid() })),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const { providerId } = c.req.valid('param');
+
+    const [provider] = await db
+      .select()
+      .from(ssoProviders)
+      .where(eq(ssoProviders.id, providerId))
+      .limit(1);
+
+    if (!provider || provider.status === 'inactive') {
+      return c.json({ error: 'Provider not found' }, 404);
+    }
+
+    // Axis pool check: the user must belong to the provider's owner tenant.
+    const inPool = provider.orgId
+      ? auth.user.orgId === provider.orgId
+      : auth.user.orgId === null && auth.partnerId === provider.partnerId;
+    if (!inPool) {
+      return c.json({ error: 'You cannot link this SSO provider' }, 403);
+    }
+
+    if (provider.type !== 'oidc') {
+      return c.json({ error: 'Only OIDC linking is currently supported' }, 400);
+    }
+
+    const config = getOIDCConfig(provider);
+    const pkce = generatePKCEChallenge();
+    const state = generateState();
+    const nonce = generateNonce();
+
+    await db.insert(ssoSessions).values({
+      providerId: provider.id,
+      state,
+      nonce,
+      codeVerifier: pkce.codeVerifier,
+      redirectUrl: '/settings/profile',
+      linkUserId: auth.user.id,
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000)
+    });
+
+    const authUrl = buildAuthorizationUrl({
+      config,
+      state,
+      nonce,
+      redirectUri: buildSsoCallbackUri(),
+      pkce
+    });
+
+    const stateCookie = buildSsoStateCookie(state);
+    if (!stateCookie) {
+      return c.json({ error: 'SSO login binding secret is not configured on this instance' }, 500);
+    }
+    c.header('Set-Cookie', stateCookie, { append: true });
+
+    writeRouteAudit(c, {
+      orgId: provider.orgId,
+      action: 'sso.identity.link_started',
+      resourceType: 'sso_provider',
+      resourceId: provider.id,
+      resourceName: provider.name,
+      details: { partnerId: provider.partnerId }
+    });
+
+    return c.json({ authUrl });
+  }
+);
+```
+
+(This route runs authenticated, so bare `db` is fine here — RLS scopes it to the caller's tenant; the axis-pool check is defense-in-depth on top.)
+
+- [ ] **Step 4: Implement the callback link-mode branch**
+
+In `GET /callback`, immediately after the provider row is loaded and the id_token is fully verified (after the `sub`/`attrs.email` extraction, BEFORE the login-path identity resolution — i.e. right before the `let user = await withSystemDbAccessContext(...)` block), insert:
+
+```ts
+    // ── Link mode (#2183 Connect SSO): this round-trip belongs to an
+    // already-authenticated user connecting their identity — never a login.
+    if (session.linkUserId) {
+      const outcome = await withSystemDbAccessContext(async () => {
+        const [linkingUser] = await db
+          .select()
+          .from(users)
+          .where(eq(users.id, session.linkUserId!))
+          .limit(1);
+        if (!linkingUser) return { error: 'user_gone' as const };
+
+        // The verified assertion must be for the SAME person: asserted email
+        // must equal the linking user's email. Without this, a user could bind
+        // an arbitrary IdP account (or a phished consent) to their session.
+        if (attrs.email.toLowerCase() !== linkingUser.email.toLowerCase()) {
+          return { error: 'email_mismatch' as const };
+        }
+
+        // (provider, sub) must not already belong to someone else.
+        const [existing] = await db
+          .select({ id: userSsoIdentities.id, userId: userSsoIdentities.userId })
+          .from(userSsoIdentities)
+          .where(and(
+            eq(userSsoIdentities.providerId, provider.id),
+            eq(userSsoIdentities.externalId, externalSub)
+          ))
+          .limit(1);
+        if (existing && existing.userId !== linkingUser.id) {
+          return { error: 'identity_in_use' as const };
+        }
+
+        if (!existing) {
+          await db.insert(userSsoIdentities).values({
+            userId: linkingUser.id,
+            providerId: provider.id,
+            externalId: externalSub,
+            email: attrs.email,
+            profile: userInfo,
+            accessToken: encryptSecret(tokens.access_token),
+            refreshToken: encryptSecret(tokens.refresh_token),
+            tokenExpiresAt: tokens.expires_in
+              ? new Date(Date.now() + tokens.expires_in * 1000)
+              : null,
+            lastLoginAt: null
+          });
+        }
+        return { ok: true as const };
+      });
+
+      clearStateCookie();
+      if ('error' in outcome) {
+        return c.redirect(`/settings/profile?ssoLinkError=${outcome.error}`);
+      }
+      writeRouteAudit(c, {
+        orgId: provider.orgId,
+        action: 'sso.identity.linked',
+        resourceType: 'sso_provider',
+        resourceId: provider.id,
+        resourceName: provider.name,
+        details: { partnerId: provider.partnerId, userId: session.linkUserId }
+      });
+      return c.redirect('/settings/profile?ssoLinked=1');
+    }
+```
+
+Ordering constraints this placement guarantees: the state cookie + atomic session claim + full id_token signature/nonce verification + userinfo `sub` binding + allowedDomains check all run BEFORE link mode is considered; link mode never mints tokens and never touches the login path's user resolution. Note `attrs`/`externalSub`/`userInfo`/`tokens` are already in scope at this point in the handler.
+
+- [ ] **Step 5: Run API tests**
+
+```bash
+pnpm test --filter=@breeze/api -- routes/sso
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+Expected: PASS, org login-path tests unchanged.
+
+- [ ] **Step 6: Web — `ConnectSsoCard` + login error copy**
+
+Write the failing test first (`ConnectSsoCard.test.tsx`, jsdom):
+
+```tsx
+// - renders one row per provider from GET /sso/link/options with a
+//   "Connect" button (or a "Connected" badge when linked)
+// - clicking Connect triggers runAction wrapping POST /sso/link/start/:id and
+//   on success navigates to the returned authUrl (assert window.location.assign
+//   spy called with authUrl)
+// - shows a success toast/banner when the page loads with ?ssoLinked=1 and an
+//   error state for ?ssoLinkError=email_mismatch
+```
+
+Run `pnpm test --filter=@breeze/web -- ConnectSsoCard` → FAIL, then implement:
+
+```tsx
+import { useEffect, useState } from 'react';
+import { runAction } from '../../lib/runAction';
+
+type LinkOption = { id: string; name: string; type: string; linked: boolean };
+
+export default function ConnectSsoCard() {
+  const [options, setOptions] = useState<LinkOption[]>([]);
+  const apiHost = import.meta.env.PUBLIC_API_URL || '';
+
+  useEffect(() => {
+    fetch(`${apiHost}/api/v1/sso/link/options`, { credentials: 'include', headers: authHeaders() })
+      .then((r) => (r.ok ? r.json() : { data: [] }))
+      .then((body) => setOptions(body.data ?? []))
+      .catch(() => setOptions([]));
+  }, []);
+
+  async function connect(providerId: string) {
+    await runAction({
+      request: () =>
+        fetch(`${apiHost}/api/v1/sso/link/start/${providerId}`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: authHeaders()
+        }),
+      successMessage: 'Redirecting to your identity provider…',
+      errorMessage: 'Could not start SSO linking',
+      onSuccess: (body: { authUrl: string }) => window.location.assign(body.authUrl)
+    });
+  }
+
+  if (options.length === 0) return null;
+  return (
+    <section className="rounded-lg border p-4">
+      <h3 className="text-sm font-semibold">Single sign-on</h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Connect your identity provider account to sign in with SSO.
+      </p>
+      <ul className="mt-3 space-y-2">
+        {options.map((o) => (
+          <li key={o.id} className="flex items-center justify-between text-sm">
+            <span>{o.name}</span>
+            {o.linked
+              ? <span className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">Connected</span>
+              : <button type="button" onClick={() => connect(o.id)} className="rounded-md border px-3 py-1 text-xs font-medium hover:bg-muted" data-testid={`connect-sso-${o.id}`}>Connect</button>}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+```
+
+(Match `runAction`'s actual option names and the security page's existing `authHeaders`/fetch conventions.) Mount it in the user's own security/profile settings component (found via the grep in **Files**), and add `?ssoLinked=1` / `?ssoLinkError=` banner handling there.
+
+Login error copy: in `LoginPage.tsx`'s error-message mapping (grep `sso_link_required` — added to the map if absent), set the copy to: `"This account already has a password. Sign in with your password, then connect SSO under Profile → Security."`
+
+- [ ] **Step 7: Run web tests**
+
+```bash
+pnpm test --filter=@breeze/web -- ConnectSsoCard
+pnpm test --filter=@breeze/web -- no-silent-mutations
+```
+Expected: PASS (runAction usage; no allowlist entry).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/routes/sso.ts apps/api/src/routes/sso.test.ts apps/web/src/components/settings/ConnectSsoCard.tsx apps/web/src/components/settings/ConnectSsoCard.test.tsx apps/web/src/components/settings/ apps/web/src/components/auth/LoginPage.tsx
+git commit -m "feat(sso): self-service Connect SSO identity linking (#2183)
+
+Refs #2183
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: `enforceSSO` for partner staff (ssoPolicy partner branch)
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/ssoPolicy.ts`
+- Test: `apps/api/src/routes/auth/ssoPolicy.test.ts` (create alongside if absent)
+
+**Interfaces:**
+- Consumes: `ssoProviders.partnerId` (Task 1).
+- Produces: `isPasswordAuthDisabledBySso(context)` now accepts `Pick<UserTokenContext, 'scope' | 'orgId' | 'partnerId'>`. Callers (grep `assertPasswordAuthAllowedBySso` / `isPasswordAuthDisabledBySso` across `routes/auth/`) must pass `partnerId` — update every call site found.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+describe('isPasswordAuthDisabledBySso — partner scope (#2183)', () => {
+  it('true for partner-scope context when an active enforceSSO partner provider exists', async () => {});
+  it('false when the partner provider is testing (break-glass preserved)', async () => {});
+  it('false for partner scope with no partner provider', async () => {});
+  it('org behavior unchanged', async () => {});
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+pnpm test --filter=@breeze/api -- ssoPolicy
+```
+Expected: FAIL (partnerId not accepted / branch missing).
+
+- [ ] **Step 3: Implement**
+
+```ts
+export async function isPasswordAuthDisabledBySso(
+  context: Pick<UserTokenContext, 'scope' | 'orgId' | 'partnerId'>
+): Promise<boolean> {
+  if (context.scope === 'organization' && context.orgId) {
+    const orgId = context.orgId;
+    const [provider] = await withSystemDbAccessContext(async () =>
+      db
+        .select({ id: ssoProviders.id })
+        .from(ssoProviders)
+        .where(and(
+          eq(ssoProviders.orgId, orgId),
+          eq(ssoProviders.status, 'active'),
+          eq(ssoProviders.enforceSSO, true)
+        ))
+        .limit(1)
+    );
+    return Boolean(provider);
+  }
+
+  if (context.scope === 'partner' && context.partnerId) {
+    const partnerId = context.partnerId;
+    const [provider] = await withSystemDbAccessContext(async () =>
+      db
+        .select({ id: ssoProviders.id })
+        .from(ssoProviders)
+        .where(and(
+          eq(ssoProviders.partnerId, partnerId),
+          eq(ssoProviders.status, 'active'),
+          eq(ssoProviders.enforceSSO, true)
+        ))
+        .limit(1)
+    );
+    return Boolean(provider);
+  }
+
+  return false;
+}
+```
+
+Update `assertPasswordAuthAllowedBySso`'s `Pick<>` the same way, and every caller to include `partnerId` in the context object it passes.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm test --filter=@breeze/api -- ssoPolicy
+pnpm test --filter=@breeze/api -- routes/auth
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/auth/
+git commit -m "feat(auth): enforceSSO suppresses password login for partner staff (#2183)
+
+Refs #2183
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Public `GET /auth/login-context`
+
+**Files:**
+- Create: `apps/api/src/routes/auth/loginContext.ts`
+- Modify: `apps/api/src/routes/auth/index.ts` (import + `authRoutes.route('/', loginContextRoutes);`)
+- Test: `apps/api/src/routes/auth/loginContext.test.ts`
+
+**Interfaces:**
+- Consumes: `partners`, `ssoProviders`, `partnerLoginBranding` schema; `rateLimiter(redis, key, limit, windowSeconds)` + `getRedis` (same import path as `routes/auth/login.ts`); `getTrustedClientIp` from `../../services/clientIp`.
+- Produces: response shape consumed verbatim by Task 10's web lib:
+  `{ branding: { logoUrl: string|null, accentColor: string|null, headline: string|null } | null, partnerSso: { available: true, providerName: string, loginUrl: string } | null }`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+describe('GET /auth/login-context (#2183)', () => {
+  it('returns branding + partnerSso on a single-partner instance with both configured', async () => {});
+  it('returns branding null / partnerSso null when neither is configured (single partner)', async () => {});
+  it('returns all-null on a multi-partner instance (no tenant leakage)', async () => {});
+  it('omits provider config beyond name + loginUrl', async () => {});
+  it('429s past the rate limit', async () => {});
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+pnpm test --filter=@breeze/api -- loginContext
+```
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `loginContext.ts`**
+
+```ts
+import { Hono } from 'hono';
+import { and, eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { partners, ssoProviders, partnerLoginBranding } from '../../db/schema';
+import { getTrustedClientIp } from '../../services/clientIp';
+// rateLimiter + getRedis: import from the same modules routes/auth/login.ts uses.
+import { getRedis } from '../../services/redis';
+import { rateLimiter } from '../../services/rate-limit';
+
+export const loginContextRoutes = new Hono();
+
+// Public, unauthenticated. Single-partner (self-hosted) fast-path only: on a
+// multi-partner instance this endpoint deliberately reveals NOTHING (#2183
+// tenant-leakage constraint). The future /login/:partnerSlug variant returns
+// the same shape resolved by slug.
+loginContextRoutes.get('/login-context', async (c) => {
+  const redis = getRedis();
+  if (redis) {
+    const check = await rateLimiter(redis, `login-context:${getTrustedClientIp(c)}`, 30, 60);
+    if (!check.allowed) {
+      return c.json({ error: 'Too many requests' }, 429);
+    }
+  }
+
+  const context = await withSystemDbAccessContext(async () => {
+    const partnerRows = await db.select({ id: partners.id }).from(partners).limit(2);
+    if (partnerRows.length !== 1 || !partnerRows[0]) {
+      return { branding: null, partnerSso: null };
+    }
+    const partnerId = partnerRows[0].id;
+
+    const [brandingRow] = await db
+      .select({
+        logoUrl: partnerLoginBranding.logoUrl,
+        accentColor: partnerLoginBranding.accentColor,
+        headline: partnerLoginBranding.headline
+      })
+      .from(partnerLoginBranding)
+      .where(eq(partnerLoginBranding.partnerId, partnerId))
+      .limit(1);
+
+    const [provider] = await db
+      .select({ name: ssoProviders.name })
+      .from(ssoProviders)
+      .where(and(
+        eq(ssoProviders.partnerId, partnerId),
+        eq(ssoProviders.status, 'active')
+      ))
+      .limit(1);
+
+    return {
+      branding: brandingRow ?? null,
+      partnerSso: provider
+        ? {
+            available: true as const,
+            providerName: provider.name,
+            loginUrl: `/api/v1/sso/login/partner/${partnerId}`
+          }
+        : null
+    };
+  });
+
+  c.header('Cache-Control', 'public, max-age=60');
+  return c.json(context);
+});
+```
+
+(If `getRedis`/`rateLimiter` live at different paths than shown, match the imports in `routes/auth/login.ts` exactly.)
+
+Mount in `routes/auth/index.ts`: `import { loginContextRoutes } from './loginContext';` + `authRoutes.route('/', loginContextRoutes);`
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm test --filter=@breeze/api -- loginContext
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/auth/loginContext.ts apps/api/src/routes/auth/loginContext.test.ts apps/api/src/routes/auth/index.ts
+git commit -m "feat(auth): public login-context endpoint with single-partner fast-path (#2183)
+
+Refs #2183
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Partner login-branding API — `GET/PUT /partners/me/login-branding`
+
+**Files:**
+- Create: `apps/api/src/routes/partnerLoginBranding.ts`
+- Modify: `apps/api/src/routes/index.ts` (mount next to the other partner-scoped routes; grep for where `ssoRoutes` is mounted at :825 and follow the same style)
+- Test: `apps/api/src/routes/partnerLoginBranding.test.ts`
+
+**Interfaces:**
+- Consumes: `partnerLoginBranding` schema, `canManagePartnerWidePolicies` + `PARTNER_WIDE_WRITE_DENIED_MESSAGE`, `authMiddleware`/`requireScope`, `writeRouteAudit`.
+- Produces: `GET /partners/me/login-branding` → `{ data: { logoUrl, accentColor, headline } | null }`; `PUT` upserts and returns `{ data: {...} }`. Consumed by Task 11's settings card.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+describe('partner login branding routes (#2183)', () => {
+  it('GET returns null data when unset', async () => {});
+  it('PUT upserts for a partner admin with orgAccess=all', async () => {});
+  it('PUT 403s without canManagePartnerWidePolicies', async () => {});
+  it('PUT 400s a non-hex accentColor', async () => {});
+  it('PUT 400s a logoUrl that is neither https:// nor data:image/', async () => {});
+  it('PUT 400s a headline over 120 chars', async () => {});
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+pnpm test --filter=@breeze/api -- partnerLoginBranding
+```
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { partnerLoginBranding } from '../db/schema';
+import { authMiddleware, requireScope, type AuthContext } from '../middleware/auth';
+import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
+import { writeRouteAudit } from '../services/auditEvents';
+
+export const partnerLoginBrandingRoutes = new Hono();
+
+const brandingSchema = z.object({
+  logoUrl: z.string().max(400_000)
+    .refine((v) => v.startsWith('https://') || v.startsWith('data:image/'), {
+      message: 'logoUrl must be an https:// URL or a data:image/ URI'
+    })
+    .nullable().optional(),
+  accentColor: z.string().regex(/^#[0-9a-fA-F]{6}$/, 'accentColor must be a #rrggbb hex color')
+    .nullable().optional(),
+  headline: z.string().max(120).nullable().optional()
+});
+
+partnerLoginBrandingRoutes.get('/me/login-branding', authMiddleware, requireScope('partner'), async (c) => {
+  const auth = c.get('auth') as AuthContext;
+  if (!auth.partnerId) return c.json({ error: 'Partner context required' }, 400);
+
+  const [row] = await db
+    .select({
+      logoUrl: partnerLoginBranding.logoUrl,
+      accentColor: partnerLoginBranding.accentColor,
+      headline: partnerLoginBranding.headline
+    })
+    .from(partnerLoginBranding)
+    .where(eq(partnerLoginBranding.partnerId, auth.partnerId))
+    .limit(1);
+
+  return c.json({ data: row ?? null });
+});
+
+partnerLoginBrandingRoutes.put(
+  '/me/login-branding',
+  authMiddleware,
+  requireScope('partner'),
+  zValidator('json', brandingSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    if (!auth.partnerId) return c.json({ error: 'Partner context required' }, 400);
+    if (!canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+    }
+
+    const body = c.req.valid('json');
+    const [row] = await db
+      .insert(partnerLoginBranding)
+      .values({
+        partnerId: auth.partnerId,
+        logoUrl: body.logoUrl ?? null,
+        accentColor: body.accentColor ?? null,
+        headline: body.headline ?? null
+      })
+      .onConflictDoUpdate({
+        target: partnerLoginBranding.partnerId,
+        set: {
+          logoUrl: body.logoUrl ?? null,
+          accentColor: body.accentColor ?? null,
+          headline: body.headline ?? null,
+          updatedAt: new Date()
+        }
+      })
+      .returning({
+        logoUrl: partnerLoginBranding.logoUrl,
+        accentColor: partnerLoginBranding.accentColor,
+        headline: partnerLoginBranding.headline
+      });
+
+    writeRouteAudit(c, {
+      orgId: null,
+      action: 'partner.login_branding.update',
+      resourceType: 'partner_login_branding',
+      resourceId: auth.partnerId,
+      details: { partnerId: auth.partnerId, changedFields: Object.keys(body) }
+    });
+
+    return c.json({ data: row });
+  }
+);
+```
+
+Mount in `apps/api/src/routes/index.ts` under the same base path the existing `/partners` routes use (grep `'/partners'`) so the final URLs are `GET/PUT /api/v1/partners/me/login-branding`. If `writeRouteAudit`'s type requires a non-null `orgId`, follow whatever pattern existing partner-level audits use (grep `writeRouteAudit` for a null-orgId caller) rather than inventing one.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm test --filter=@breeze/api -- partnerLoginBranding
+pnpm --filter @breeze/api exec tsc --noEmit
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/partnerLoginBranding.ts apps/api/src/routes/partnerLoginBranding.test.ts apps/api/src/routes/index.ts
+git commit -m "feat(api): partner login-branding CRUD (#2183)
+
+Refs #2183
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Web — login-context client, branded shell island, partner SSO button
+
+**Files:**
+- Create: `apps/web/src/lib/loginContext.ts`
+- Create: `apps/web/src/components/auth/AuthPanelBranding.tsx`
+- Modify: `apps/web/src/layouts/AuthShellBranded.astro` (replace the static left panel :37-100 with the island)
+- Modify: `apps/web/src/components/auth/LoginPage.tsx` (SSO button)
+- Test: `apps/web/src/components/auth/AuthPanelBranding.test.tsx`, extend `apps/web/src/components/auth/LoginPage.test.tsx` if present
+
+**Interfaces:**
+- Consumes: Task 8's response shape.
+- Produces: `getLoginContext(): Promise<LoginContext>` (module-memoized — one fetch shared by the panel island and LoginPage).
+
+- [ ] **Step 1: Write `lib/loginContext.ts`**
+
+```ts
+export type LoginContextBranding = {
+  logoUrl: string | null;
+  accentColor: string | null;
+  headline: string | null;
+};
+
+export type LoginContext = {
+  branding: LoginContextBranding | null;
+  partnerSso: { available: boolean; providerName: string; loginUrl: string } | null;
+};
+
+const EMPTY: LoginContext = { branding: null, partnerSso: null };
+
+let cached: Promise<LoginContext> | null = null;
+
+/** Memoized: the branded panel island and LoginPage share one request. */
+export function getLoginContext(): Promise<LoginContext> {
+  if (!cached) cached = fetchLoginContext();
+  return cached;
+}
+
+async function fetchLoginContext(): Promise<LoginContext> {
+  try {
+    const apiHost = import.meta.env.PUBLIC_API_URL || '';
+    // Same timeout rationale as the CF Access check (LoginPage.tsx:38-58):
+    // a hung request must not stall the login page.
+    const res = await fetch(`${apiHost}/api/v1/auth/login-context`, {
+      signal: AbortSignal.timeout(4000)
+    });
+    if (!res.ok) return EMPTY;
+    const body = (await res.json()) as Partial<LoginContext>;
+    return { branding: body.branding ?? null, partnerSso: body.partnerSso ?? null };
+  } catch {
+    return EMPTY; // fail open to stock Breeze branding
+  }
+}
+```
+
+- [ ] **Step 2: Write failing component test**
+
+```tsx
+// AuthPanelBranding.test.tsx (jsdom): mock ../../lib/loginContext getLoginContext.
+// Case 1: resolves { branding: null } → stock content: "Breeze" wordmark,
+//   "Effortless endpoint" heading, "10,000+ endpoints" marketing block present.
+// Case 2: resolves { branding: { logoUrl: 'https://x/logo.png', accentColor: '#112233',
+//   headline: 'Acme IT' } } → await screen.findByText('Acme IT'); marketing copy
+//   ("10,000+ endpoints") ABSENT; img[data-testid="partner-logo"] present;
+//   panel style backgroundColor reflects #112233.
+```
+
+Run: `pnpm test --filter=@breeze/web -- AuthPanelBranding` — expected FAIL (component missing).
+
+- [ ] **Step 3: Implement `AuthPanelBranding.tsx`**
+
+React island rendering the ENTIRE left-panel content. Initial render = current stock markup (copy the JSX structure from `AuthShellBranded.astro:38-99`, converted to TSX: `class` → `className`, keep the inline SVG logo + three marketing blocks). On mount, `getLoginContext()`; when `branding` is non-null:
+
+```tsx
+import { useEffect, useState } from 'react';
+import { getLoginContext, type LoginContextBranding } from '../../lib/loginContext';
+import { sanitizeImageSrc } from '../../lib/safeImageSrc';
+
+export default function AuthPanelBranding({ tagline }: { tagline: string }) {
+  const [branding, setBranding] = useState<LoginContextBranding | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getLoginContext().then((ctx) => {
+      if (!cancelled && ctx.branding) setBranding(ctx.branding);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  const panelStyle = branding?.accentColor ? { backgroundColor: branding.accentColor } : undefined;
+  const safeLogo = branding?.logoUrl ? sanitizeImageSrc(branding.logoUrl) : null;
+
+  return (
+    <div className="hidden u-w-pct-42 flex-col justify-between bg-[hsl(225,62%,48%)] p-10 text-white md:flex lg:p-14" style={panelStyle}>
+      <div className="flex items-center gap-3">
+        {safeLogo
+          ? <img src={safeLogo} alt="" data-testid="partner-logo" className="h-8 max-w-[180px] object-contain" />
+          : (/* stock inline Breeze SVG + wordmark, copied from AuthShellBranded.astro:41-46 */)}
+      </div>
+      <div className="space-y-10">
+        <div>
+          <h2 className="text-2xl font-bold leading-snug tracking-tight lg:text-3xl">
+            {branding?.headline ?? <>Effortless endpoint<br />management</>}
+          </h2>
+          {!branding && <p className="mt-3 text-sm leading-relaxed text-white/70">{tagline}</p>}
+        </div>
+        {!branding && (/* the three stock marketing feature blocks, copied verbatim */)}
+      </div>
+      <p className="text-xs text-white/40">&copy; {new Date().getFullYear()} {branding ? '' : 'Breeze RMM'}</p>
+    </div>
+  );
+}
+```
+
+(The two "copied" comment spots are literal copies of the existing Astro markup — no redesign. `new Date()` is fine here; this is app code, not a workflow script.)
+
+In `AuthShellBranded.astro`, replace lines 37-100 (the whole left `<div>`) with:
+
+```astro
+<AuthPanelBranding tagline={tagline} client:load />
+```
+
+plus the frontmatter import: `import AuthPanelBranding from '../components/auth/AuthPanelBranding';`
+
+- [ ] **Step 4: Add the partner SSO button to `LoginPage.tsx`**
+
+State + effect (alongside the CF Access check, :38-58 pattern):
+
+```tsx
+const [partnerSso, setPartnerSso] = useState<{ providerName: string; loginUrl: string } | null>(null);
+
+useEffect(() => {
+  getLoginContext().then((ctx) => {
+    if (ctx.partnerSso?.available) {
+      setPartnerSso({ providerName: ctx.partnerSso.providerName, loginUrl: ctx.partnerSso.loginUrl });
+    }
+  });
+}, []);
+```
+
+Render above the password form:
+
+```tsx
+{partnerSso && (
+  <a
+    href={`${partnerSso.loginUrl}${safeNext ? `?redirect=${encodeURIComponent(safeNext)}` : ''}`}
+    data-testid="partner-sso-button"
+    className="mb-4 flex w-full items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-muted"
+  >
+    Sign in with {partnerSso.providerName}
+  </a>
+)}
+```
+
+- [ ] **Step 5: Run web tests + typecheck**
+
+```bash
+pnpm test --filter=@breeze/web -- AuthPanelBranding
+pnpm test --filter=@breeze/web -- LoginPage
+pnpm --filter @breeze/web exec astro check
+```
+Expected: PASS. (`astro check` covers the .astro edit; plain tsc skips .astro files.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/lib/loginContext.ts apps/web/src/components/auth/ apps/web/src/layouts/AuthShellBranded.astro
+git commit -m "feat(web): partner-branded login shell + partner SSO button (#2183)
+
+Refs #2183
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Web admin — SSO ownership selector + Login Branding settings card
+
+**Files:**
+- Modify: `apps/web/src/components/settings/SsoProviderForm.tsx` (+ its zod schema :6-27), `apps/web/src/components/settings/SsoProviderList.tsx`, `apps/web/src/components/settings/SsoProvidersPage.tsx`
+- Create: `apps/web/src/components/settings/LoginBrandingCard.tsx` + `LoginBrandingCard.test.tsx`
+- Modify: `apps/web/src/pages/settings/partner.astro` (or the tab component it renders — add the card where `PartnerCompanyTab`/`PartnerAiBudgetsTab` are registered)
+
+**Interfaces:**
+- Consumes: Task 3's `ownerScope` create field + `scope=partner` list query; Task 9's `GET/PUT /partners/me/login-branding`; `runAction` from `apps/web/src/lib/runAction.ts`.
+
+- [ ] **Step 1: Ownership selector on `SsoProviderForm`**
+
+Add to the form's zod schema: `ownerScope: z.enum(['organization', 'partner']).optional(),` and render a create-only radio group copied from the `PolicyForm.tsx:96-105` pattern:
+
+```tsx
+{mode === 'create' && (
+  <fieldset className="space-y-2">
+    <legend className="text-sm font-medium">Applies to</legend>
+    <label className="flex items-center gap-2 text-sm">
+      <input type="radio" value="organization" {...register('ownerScope')} defaultChecked />
+      This organization
+    </label>
+    <label className="flex items-center gap-2 text-sm">
+      <input type="radio" value="partner" {...register('ownerScope')} />
+      Partner (technician login) <span className="text-muted-foreground">(your own team signs in with this)</span>
+    </label>
+  </fieldset>
+)}
+```
+
+When `ownerScope === 'partner'`, the `defaultRoleId` dropdown must load PARTNER-scoped roles instead of org roles (reuse however the form currently fetches its `Role[]` prop/list, filtered by `scope === 'partner'`). Follow the existing form's mode/props conventions — this form was only skimmed; match what's there rather than restructuring it.
+
+- [ ] **Step 2: Badge + list wiring**
+
+`SsoProviderList.tsx`: render a "Partner" badge on rows where `partnerId` is set (same badge classes the "All orgs" badge uses in the software policy list). `SsoProvidersPage.tsx`: when the viewer has partner scope, also fetch `GET /sso/providers?scope=partner` and merge into the list.
+
+- [ ] **Step 3: Write failing `LoginBrandingCard` test**
+
+```tsx
+// jsdom: mock fetch/runAction. Renders three inputs (logo URL, accent color,
+// headline with a 120-char maxLength), loads current values from
+// GET /partners/me/login-branding, saves via runAction PUT, shows a live
+// preview div whose backgroundColor is the entered accent color.
+// Assert save button triggers runAction (no silent mutation).
+```
+
+Run: `pnpm test --filter=@breeze/web -- LoginBrandingCard` — expected FAIL.
+
+- [ ] **Step 4: Implement `LoginBrandingCard.tsx`**
+
+Form card following the settings-card conventions in `PartnerCompanyTab.tsx`: three controlled inputs (logo URL text input, `<input type="color">` + hex text for accent, headline input `maxLength={120}`), a preview block (`<div style={{ backgroundColor: accent }}>` with the headline + logo via `sanitizeImageSrc`), and:
+
+```tsx
+import { runAction } from '../../lib/runAction';
+
+async function save() {
+  await runAction({
+    request: () =>
+      fetch(`${apiHost}/api/v1/partners/me/login-branding`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        credentials: 'include',
+        body: JSON.stringify({ logoUrl: logoUrl || null, accentColor: accentColor || null, headline: headline || null })
+      }),
+    successMessage: 'Login branding saved',
+    errorMessage: 'Failed to save login branding'
+  });
+}
+```
+
+(Match `runAction`'s actual option names from `apps/web/src/lib/runAction.ts` — the shape above is representative; the requirement is that ALL mutations go through `runAction`.)
+
+Register the card in the partner settings page next to the existing partner tabs (follow how `PartnerAiBudgetsTab` is wired into `pages/settings/partner.astro`'s tab container). Label: "Login Branding".
+
+- [ ] **Step 5: Run tests + the silent-mutation guard**
+
+```bash
+pnpm test --filter=@breeze/web -- LoginBrandingCard
+pnpm test --filter=@breeze/web -- no-silent-mutations
+pnpm --filter @breeze/web exec astro check
+```
+Expected: PASS (runAction usage keeps the guard green; do NOT add an allowlist entry).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/settings/ apps/web/src/pages/settings/
+git commit -m "feat(web): SSO ownership selector + partner login-branding card (#2183)
+
+Refs #2183
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Real-DB end-to-end partner login + link-flow integration test + final sweeps
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts`
+
+**Interfaces:**
+- Consumes: everything above.
+
+- [ ] **Step 1: Write the integration test**
+
+Against real Postgres (integration config), no IdP mocking of the full browser flow — test the callback's resolution + token mint by exercising the route handlers with a stubbed IdP layer, the way existing SSO integration/route tests stub `exchangeCodeForTokens`/`verifyIdTokenSignature`/`getUserInfo` (grep for existing stubs of these in the integration suite; if none exist, stub via `vi.mock('../../services/sso', ...)` keeping non-network helpers real):
+
+```ts
+// Setup (real DB): partner P with partner-scoped role R, user U
+//   { partnerId: P, orgId: null, passwordHash: null } + partner_users membership
+//   { partnerId: P, userId: U, roleId: R, orgAccess: 'all' },
+//   active partner-axis provider (partnerId: P, trustsIdpMfa: false).
+// 1. GET /sso/login/partner/:P → 302 to IdP, sso_sessions row created, state cookie set.
+// 2. GET /sso/callback with matching state/cookie and stubbed IdP responses
+//    asserting email = U's email → 302 redirect containing #ssoCode=.
+// 3. POST /sso/exchange { code } → accessToken. Decode (jose decodeJwt):
+//    payload.scope === 'partner', payload.partnerId === P, payload.orgId === null,
+//    payload.roleId === R, payload.mfa === false.
+// 4. Negative: second user with same email but orgId set on another partner org
+//    never resolves (callback with their email-only assertion → /login?error=invite_required).
+// 5. Connect SSO flow (password-holding user, real DB): user V { partnerId: P,
+//    orgId: null, passwordHash: <bcrypt of anything> } + partner_users membership.
+//    a. Login-path callback asserting V's email → /login?error=sso_link_required
+//       (password holder is never auto-linked).
+//    b. Authenticated POST /sso/link/start/:providerId as V (mfa claim true in
+//       the test token) → { authUrl }, sso_sessions row has linkUserId = V.id.
+//    c. Callback with that state + stubbed IdP asserting V's email →
+//       redirect /settings/profile?ssoLinked=1, user_sso_identities row exists
+//       for (V, provider, sub-V).
+//    d. Login-path round-trip again for sub-V → NOW succeeds; decoded token
+//       scope === 'partner', sub === V.id.
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 3: Full-suite sweep + drift check**
+
+```bash
+pnpm test --filter=@breeze/api
+pnpm test --filter=@breeze/web
+pnpm --filter @breeze/api exec tsc --noEmit
+pnpm db:check-drift
+```
+Expected: all green. Then repo-wide call-site sweep (playbook step 7): `grep -rn "ssoProviders.orgId" apps/ packages/ --include='*.ts'` — every hit must be axis-aware or provably org-only (the org login route :904, org domain routes, and `/sso/check/:orgId` are legitimately org-only; anything else needs the Task 3/5 helpers).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/ssoPartnerLogin.integration.test.ts
+git commit -m "test(sso): end-to-end partner-axis login mints scope:partner tokens (#2183)
+
+Refs #2183
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Spec-coverage self-review (done during authoring)
+
+- Spec §1 data model → Tasks 1-2 (naming deviation: `partner_login_branding`, rationale in Task 1; `sso_sessions.link_user_id` added for the Connect SSO flow). ssoConfig deprecation → Task 3 Step 5.
+- Spec §2 auth flow → Tasks 4-7 (entry, callback branch, Connect SSO link flow, enforceSSO). Safe-link conditions + self-service linking settled with Todd 2026-07-03 (Task 5 rationale, Task 6).
+- Spec §3 login page → Tasks 8 + 10.
+- Spec §4 admin API/UI → Tasks 3, 9, 11.
+- Spec §5 security → axis checks (Tasks 3/5/6), leakage (Task 8 multi-partner nulls test), escalation (write-time role validation + membership-authoritative login), linking hardening (Task 6: requireMfa initiate, email match, identity-in-use check, full verification before link), lockout (Task 7 testing-status test), audit (Tasks 3/5/6/9), rate limits (the entry route relies on the same global limits as the org route; login-context has its own limiter).
+- Spec §6 testing → Tasks 2, 3, 5, 6, 7, 8, 10, 11, 12.
+- Out-of-scope items untouched: no JIT, no slug route, no SCIM, no custom CSS, columns not dropped.

--- a/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-02-effective-request-db-role.md
+++ b/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-02-effective-request-db-role.md
@@ -1,0 +1,87 @@
+# Security Review Wave 2: Effective Request Database Role Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Ensure the exact PostgreSQL pool exported to request handlers always uses a non-superuser, non-`BYPASSRLS` role, independently of automatic migrations.
+
+**Architecture:** Resolve one canonical request connection string before constructing any pool. Build the request client from that value and probe that exact pool during startup; keep the privileged system URL limited to migrations and system-context work.
+
+**Tech Stack:** TypeScript, Hono, Drizzle ORM, `pg`, Vitest, PostgreSQL through OrbStack.
+
+**Global Constraints:** Preserve `withDbAccessContext` semantics; never silently fall back to a privileged request pool in production; do not expose passwords in logs; keep `DATABASE_URL` available for migrations/system work.
+
+**Finding:** SR1-02.
+
+**Design:** `docs/superpowers/specs/2026-07-11-security-review-wave-02-effective-request-db-role-design.md`
+
+## File map
+
+- Create `apps/api/src/db/requestDatabaseConfig.ts` and adjacent test.
+- Modify `apps/api/src/db/index.ts`, `apps/api/src/db/autoMigrate.ts`, and `apps/api/src/index.ts` (startup wiring).
+- Modify `apps/api/src/config/validate.ts` and its test.
+- Modify `.env.example`, `docker-compose.yml`, and production compose examples that map API database variables.
+
+## Task 1: Canonical request database resolver
+
+- [ ] Add failing table-driven tests in `apps/api/src/db/requestDatabaseConfig.test.ts` for explicit `DATABASE_URL_APP`, derivation from `DATABASE_URL` plus `POSTGRES_APP_PASSWORD`, missing credentials, malformed URLs, and production refusal to use the privileged URL.
+- [ ] Run `pnpm --filter=@breeze/api test -- requestDatabaseConfig.test.ts`; expect RED because the module does not exist.
+- [ ] Implement:
+
+```ts
+export interface RequestDatabaseConfig {
+  systemUrl: string;
+  requestUrl: string;
+  source: 'explicit' | 'derived';
+}
+
+export function resolveRequestDatabaseConfig(env: NodeJS.ProcessEnv): RequestDatabaseConfig;
+```
+
+Use the existing URL rewrite behavior from `deriveAppConnectionString`; return no configuration containing logged credentials.
+- [ ] Move or re-export `deriveAppConnectionString` so `autoMigrate.ts` and the resolver share one implementation.
+- [ ] Re-run the focused test; expect GREEN.
+- [ ] Commit: `fix(db): resolve canonical request database role`.
+
+## Task 2: Construct the exported pool from the canonical URL
+
+- [ ] Add a failing module-isolation test beside `apps/api/src/db/index.ts` proving `DATABASE_URL_APP` wins and derived `breeze_app` credentials are used when the explicit URL is absent.
+- [ ] Refactor `apps/api/src/db/index.ts` so the resolver runs before `Pool` construction and export the resolved non-secret metadata for startup diagnostics.
+- [ ] Keep the system URL path confined to `runOutsideDbContext`, migrations, seeds, and explicit system helpers; confirm request `db` is backed only by `requestUrl`.
+- [ ] Run the new test plus `pnpm --filter=@breeze/api test -- db/contextlessWriteGuard.test.ts middleware/selfManagedDbContextRoutes.test.ts`; expect GREEN.
+- [ ] Commit: `fix(db): bind request client to resolved app role`.
+
+## Task 3: Probe the exact request pool on every startup
+
+- [ ] Add failing tests for `assertRequestPoolEnforcesRls(pool)` covering normal role success, `rolsuper=true`, `rolbypassrls=true`, and query failure.
+- [ ] Implement a query against the supplied pool:
+
+```sql
+SELECT current_user AS "user", rolsuper, rolbypassrls
+FROM pg_roles
+WHERE rolname = current_user
+```
+
+- [ ] Reject superuser or `BYPASSRLS` with a credential-free startup error. Log only role name, source (`explicit`/`derived`), and safe booleans.
+- [ ] Invoke this assertion in `apps/api/src/index.ts` before accepting traffic, regardless of `AUTO_MIGRATE`.
+- [ ] Remove the duplicate app-role probe from `autoMigrate.ts` or make it call the shared assertion against the exported request pool; do not retain two independently resolved URLs.
+- [ ] Run `pnpm --filter=@breeze/api test -- autoMigrate.test.ts requestDatabaseConfig.test.ts`; expect GREEN.
+- [ ] Commit: `fix(api): verify request role before startup`.
+
+## Task 4: Configuration and deployment contract
+
+- [ ] Update `apps/api/src/config/validate.test.ts` first to require either explicit app URL or enough data to derive it, and to reject production configurations that would use privileged credentials for requests.
+- [ ] Update `apps/api/src/config/validate.ts` descriptions and validation to match the resolver contract.
+- [ ] Map `DATABASE_URL_APP` and `POSTGRES_APP_PASSWORD` through API service environments in `docker-compose.yml`, `deploy/docker-compose.prod.yml`, and applicable examples, using placeholders only.
+- [ ] Update `.env.example` with the supported explicit and derived configurations; document that `AUTO_MIGRATE=false` does not disable the request-role check.
+- [ ] Run `pnpm --filter=@breeze/api test -- config/validate.test.ts config/env.test.ts`; expect GREEN.
+- [ ] Commit: `docs(config): define unprivileged request database contract`.
+
+## Task 5: OrbStack proof and final verification
+
+- [ ] Start the local database with OrbStack using the repository compose stack.
+- [ ] Run `pnpm --filter=@breeze/api test -- requestDatabaseConfig.test.ts autoMigrate.test.ts config/validate.test.ts`.
+- [ ] Run `pnpm --filter=@breeze/api test:rls-coverage` with `DATABASE_URL` set to the OrbStack PostgreSQL endpoint.
+- [ ] Boot once with `AUTO_MIGRATE=false` and `DATABASE_URL_APP` pointing at a privileged role; verify startup fails before the listener opens.
+- [ ] Boot with `breeze_app`; verify startup succeeds and a forged cross-tenant query remains denied.
+- [ ] Run `pnpm exec tsc --noEmit -p apps/api/tsconfig.json`, `pnpm db:check-drift`, and `git diff --check`.
+- [ ] Commit: `test(db): prove effective request role enforcement`.

--- a/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-03-partner-global-authorization.md
+++ b/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-03-partner-global-authorization.md
@@ -1,0 +1,99 @@
+# Security Review Wave 3: Partner-Global Authorization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Require explicit partner-wide authority for every route that reads or mutates partner-global configuration or data.
+
+**Architecture:** Centralize the full-partner-scope decision in `canManagePartnerWidePolicies(auth)`, add route-family-specific read/manage permissions, and combine full scope, permission, and MFA for sensitive writes. Never infer full scope by enumerating accessible organizations.
+
+**Tech Stack:** TypeScript, Hono middleware, Drizzle ORM, PostgreSQL migrations, Vitest, OrbStack.
+
+**Global Constraints:** Partner Admin retains intended access; custom roles receive no new grants automatically; denied reads reveal no global data; mutations are audited; account-deletion subjects are constrained by caller type and accessible organization.
+
+**Findings:** SR1-03, SR1-09, SR1-10, SR1-11, SR1-12, SR1-18, SR1-19, SR1-21, SR1-22, SR1-26, SR1-30.
+
+**Design:** `docs/superpowers/specs/2026-07-11-security-review-wave-03-partner-global-authorization-design.md`
+
+## File map
+
+- Modify `apps/api/src/services/partnerWideAccess.ts` and add/extend its test.
+- Add `apps/api/migrations/2026-07-11-a-partner-global-permissions.sql`; update `apps/api/src/db/seed.ts` and permission registry/tests.
+- Modify routes/tests: `roles.ts`, `accessReviews.ts`, `authenticator.ts`, `auth/accountDeletion.ts`, `updateRings.ts`, `patches/approvals.ts`, `connectedApps.ts`, `huntress.ts`, `clientAi/adminTemplates.ts`, `tickets/ticketResponseTemplates.ts`, and `invoices/settings.ts`.
+
+## Task 1: Freeze the partner-wide gate contract
+
+- [ ] Add failing tests for partner admin/full scope, unrestricted custom role, org-restricted role, site-restricted role, missing auth, and misleading “all currently existing orgs” access.
+- [ ] Implement or tighten:
+
+```ts
+export function canManagePartnerWidePolicies(auth: AuthContext): boolean;
+export function assertPartnerWideAccess(auth: AuthContext): void;
+```
+
+The result must derive from authenticated scope metadata, never an organization query.
+- [ ] Run `pnpm --filter=@breeze/api test -- services/partnerWideAccess.test.ts`; expect GREEN.
+- [ ] Commit: `fix(authz): centralize partner-wide scope gate`.
+
+## Task 2: Add explicit permission vocabulary
+
+- [ ] Add registry/seed tests for `update_rings:read/manage`, `patch_approvals:read/manage`, `integrations:read/manage`, `client_ai_templates:read/manage`, `ticket_response_templates:read/manage`, and `billing_settings:read/manage`.
+- [ ] Write idempotent migration `2026-07-11-a-partner-global-permissions.sql` inserting missing permissions and granting the approved conservative built-in-role matrix. Do not grant custom roles.
+- [ ] Update `apps/api/src/db/seed.ts` and shared permission constants to mirror the migration.
+- [ ] Run seed, permission, and migration tests plus `pnpm db:check-drift`; expect GREEN.
+- [ ] Commit: `feat(authz): add partner-global route permissions`.
+
+## Task 3: Roles and access reviews (SR1-03)
+
+- [ ] Add route tests proving org/site-restricted callers cannot list, inspect, create, update, or delete partner-level roles or access reviews, including when their org list happens to cover all current orgs.
+- [ ] Apply `assertPartnerWideAccess` before partner-global queries in `roles.ts` and `accessReviews.ts`; retain existing permission checks and require MFA on writes.
+- [ ] Scope any subject detail lookup before serialization and audit all mutations.
+- [ ] Run `roles.test.ts` and `accessReviews.test.ts`; expect GREEN.
+- [ ] Commit: `fix(authz): protect partner roles and access reviews`.
+
+## Task 4: Authenticator and account deletion (SR1-09, SR1-10)
+
+- [ ] Add tests for authenticator policy reads/writes across full, org-restricted, and site-restricted callers; require MFA on changes.
+- [ ] Add account-deletion tests: partner staff can act only with full-partner authority; org members can act only on subjects in an accessible org; cross-org and unknown subjects have indistinguishable denial.
+- [ ] Gate `authenticator.ts` and restructure `auth/accountDeletion.ts` to authorize the subject before returning status or mutating records.
+- [ ] Audit policy and deletion-request mutations with actor and target identifiers.
+- [ ] Run focused tests; expect GREEN.
+- [ ] Commit: `fix(authz): constrain authenticator and account deletion administration`.
+
+## Task 5: Update rings and patch approvals (SR1-11, SR1-12)
+
+- [ ] Add read/manage permission matrix tests to `updateRings_list_create.test.ts`, `updateRings_detail_update_delete.test.ts`, and `patches/approvals.test.ts`.
+- [ ] Require full partner scope plus the exact read permission for GET and exact manage permission plus MFA for mutations.
+- [ ] Apply gates before partner-level selects; audit create/update/delete/approval actions.
+- [ ] Run all update-ring and approval tests; expect GREEN.
+- [ ] Commit: `fix(authz): gate update rings and patch approvals`.
+
+## Task 6: Connected applications (SR1-18, SR1-19)
+
+- [ ] Add tests to `connectedApps.test.ts` and `huntress.test.ts` for read/manage separation, org/site restriction denial, secret-field minimization, and MFA on credential/configuration writes.
+- [ ] Gate `connectedApps.ts` and `huntress.ts` with full scope plus `integrations:read/manage` before queries or client construction.
+- [ ] Ensure responses never serialize credentials or internal error details and audit mutations without secrets.
+- [ ] Run focused tests; expect GREEN.
+- [ ] Commit: `fix(authz): protect partner integration settings`.
+
+## Task 7: Shared templates (SR1-21, SR1-22, SR1-26)
+
+- [ ] Add matrix tests to `clientAi/adminTemplates.test.ts` and `tickets/ticketResponseTemplates.test.ts` for list/detail/write paths.
+- [ ] Require full scope plus `client_ai_templates:read/manage` or `ticket_response_templates:read/manage`; require MFA on writes.
+- [ ] Filter or deny before template content is fetched, and audit all mutations.
+- [ ] Run focused tests; expect GREEN.
+- [ ] Commit: `fix(authz): gate partner template administration`.
+
+## Task 8: Billing settings (SR1-30)
+
+- [ ] Add tests to `invoices/settings.test.ts` proving `billing_settings:read` cannot write, manage requires full scope and MFA, and org/site-restricted callers cannot observe partner defaults.
+- [ ] Gate reads and mutations in `invoices/settings.ts`; minimize returned payment/provider configuration; audit changes with sanitized before/after data.
+- [ ] Run invoice settings and billing contact integration tests; expect GREEN.
+- [ ] Commit: `fix(authz): protect partner billing settings`.
+
+## Task 9: Cross-family regression and OrbStack verification
+
+- [ ] Add a table-driven contract test that enumerates every route family above and asserts org-restricted, site-restricted, read-only, manage-without-MFA, and full-authorized outcomes.
+- [ ] Apply the permission migration twice against OrbStack; verify idempotence and no custom-role grant changes.
+- [ ] Run all focused route tests, `pnpm exec tsc --noEmit -p apps/api/tsconfig.json`, `pnpm db:check-drift`, and `git diff --check`.
+- [ ] Manually inspect denied requests to confirm no counts, names, integration existence, templates, or billing values leak.
+- [ ] Commit: `test(authz): cover partner-global administration boundaries`.

--- a/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-04-atomic-provisioning-quota.md
+++ b/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-04-atomic-provisioning-quota.md
@@ -1,0 +1,77 @@
+# Security Review Wave 4: Atomic Provisioning Quota Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Make partner device-quota enforcement authoritative and race-safe during device provisioning.
+
+**Architecture:** Keep request authorization at the route, then enter one privileged service transaction that resolves authoritative ownership, serializes quota decisions on the partner row, counts all active partner devices outside request RLS, and inserts only while capacity remains.
+
+**Tech Stack:** TypeScript, Hono, Drizzle ORM, PostgreSQL transactions/row locks, Vitest, OrbStack.
+
+**Global Constraints:** Do not widen caller authorization; count every organization belonging to the partner; exclude only decommissioned devices; perform external work after commit; preserve the provisioning response contract.
+
+**Finding:** SR1-04.
+
+**Design:** `docs/superpowers/specs/2026-07-11-security-review-wave-04-atomic-provisioning-quota-design.md`
+
+## File map
+
+- Create `apps/api/src/services/deviceProvisioning.ts` and adjacent tests.
+- Modify `apps/api/src/routes/devices/provision.ts` and `provision.test.ts`.
+- Add `apps/api/src/__tests__/integration/deviceProvisioningQuota.integration.test.ts`.
+
+## Task 1: Define the privileged service boundary
+
+- [ ] Add failing unit tests for invalid org/site ownership, missing partner, unlimited quota, below-limit success, at-limit denial, and decommissioned-device exclusion.
+- [ ] Define explicit input/output types:
+
+```ts
+export interface ProvisionDeviceWithinPartnerQuotaInput {
+  orgId: string;
+  siteId: string;
+  device: NewDevice;
+}
+
+export async function provisionDeviceWithinPartnerQuota(
+  input: ProvisionDeviceWithinPartnerQuotaInput,
+): Promise<ProvisionedDevice>;
+```
+
+- [ ] Run `pnpm --filter=@breeze/api test -- services/deviceProvisioning.test.ts`; expect RED.
+- [ ] Implement validation using authoritative database rows, not caller-provided `partnerId`.
+- [ ] Re-run; expect GREEN.
+- [ ] Commit: `fix(provisioning): add authoritative quota service`.
+
+## Task 2: Serialize and enforce quota in one transaction
+
+- [ ] Extend tests to assert the order: begin system transaction, resolve org/site, lock partner `FOR UPDATE`, count, insert, commit.
+- [ ] Use `runOutsideDbContext` before `withSystemDbAccessContext` when invoked from a request.
+- [ ] Lock the partner row before the count. Count devices joined through organizations where device status is not `decommissioned`; treat `maxDevices IS NULL` as unlimited and `count >= maxDevices` as denial.
+- [ ] Insert the device in the same transaction. Throw a typed quota error mapped to the existing route status/body.
+- [ ] Ensure no event, command, queue, or network side effect happens inside the transaction.
+- [ ] Run focused service tests; expect GREEN.
+- [ ] Commit: `fix(provisioning): enforce quota under partner lock`.
+
+## Task 3: Route integration without authorization regression
+
+- [ ] Add route tests proving unauthenticated, wrong-org, wrong-site, and insufficient-permission callers never enter the privileged service.
+- [ ] Replace the route's pre-count/insert sequence with one call to `provisionDeviceWithinPartnerQuota` after existing auth and validation.
+- [ ] Move post-provisioning side effects after successful service return and make failure behavior explicit.
+- [ ] Run `pnpm --filter=@breeze/api test -- routes/devices/provision.test.ts services/deviceProvisioning.test.ts`; expect GREEN.
+- [ ] Commit: `fix(provisioning): route device creation through atomic quota gate`.
+
+## Task 4: Real concurrency proof in OrbStack
+
+- [ ] Add an integration test with a partner having exactly one slot left and two independent PostgreSQL connections provisioning concurrently.
+- [ ] Use a barrier so both requests begin before either commits; assert exactly one insert succeeds, the other receives quota denial, and final active count equals the limit.
+- [ ] Add cases for cross-partner devices not affecting the count and decommissioned devices freeing capacity.
+- [ ] Run the integration test against OrbStack PostgreSQL using the repository integration config; expect GREEN on repeated runs (`--repeat=10` if supported, otherwise a shell loop).
+- [ ] Commit: `test(provisioning): prove concurrent quota enforcement`.
+
+## Task 5: Full verification
+
+- [ ] Run `pnpm --filter=@breeze/api test -- routes/devices/provision.test.ts services/deviceProvisioning.test.ts`.
+- [ ] Run the new integration test with a real database.
+- [ ] Run `pnpm exec tsc --noEmit -p apps/api/tsconfig.json`, `pnpm db:check-drift`, and `git diff --check`.
+- [ ] Inspect SQL logging to confirm the partner lock precedes count and insert and that no cross-partner data is returned to the request.
+- [ ] Commit any verification-only fixtures as `test(provisioning): complete quota regression coverage`.

--- a/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-05-site-axis-enforcement.md
+++ b/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-05-site-axis-enforcement.md
@@ -1,0 +1,89 @@
+# Security Review Wave 5: Site-Axis Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Prevent site-restricted users from observing or mutating resources through org-wide onboarding, device-link groups, legacy groups, or ticket triage paths.
+
+**Architecture:** Introduce one site-target assertion, require explicit site attribution at onboarding creation, and authorize every current and target site used by group and triage operations. Reads project only visible membership; writes fail atomically when any touched site is hidden.
+
+**Tech Stack:** TypeScript, Hono, Drizzle ORM, Zod, Vitest, PostgreSQL/OrbStack.
+
+**Global Constraints:** Preserve org isolation; never treat null site as universally writable for restricted callers; do not partially apply multi-device mutations; avoid existence leaks; use the same ticket row/site predicate for triage detail joins.
+
+**Findings:** SR1-05, SR1-06, SR1-07, SR1-23.
+
+**Design:** `docs/superpowers/specs/2026-07-11-security-review-wave-05-site-axis-enforcement-design.md`
+
+## File map
+
+- Create `apps/api/src/services/siteTargetAccess.ts` and adjacent test.
+- Modify onboarding/enrollment route and tests: `routes/enrollmentKeys.ts`, `routes/enrollmentKeys_*test.ts`, `routes/agents/enrollment.ts`.
+- Modify `routes/devices/links.ts`, `services/deviceLinkGroups.ts`, and tests/integration coverage.
+- Modify `routes/devices/groups.ts` and `groups.test.ts`.
+- Modify `routes/tickets/tickets.ts`, `services/ticketTriage.ts`, and their tests.
+
+## Task 1: Shared site-target assertion
+
+- [ ] Add failing table-driven tests for unrestricted auth, allowed target, denied target, mixed targets, empty targets, null site, and duplicate targets.
+- [ ] Implement:
+
+```ts
+export function assertSiteTargetsAccessible(
+  auth: Pick<AuthContext, 'canAccessSite'>,
+  targets: Array<string | null | undefined>,
+): void;
+```
+
+For restricted callers, reject null/undefined and any inaccessible site with a non-enumerating forbidden error.
+- [ ] Run the focused test; expect GREEN.
+- [ ] Commit: `fix(authz): centralize site target validation`.
+
+## Task 2: Explicit-site onboarding (SR1-05)
+
+- [ ] Update enrollment-key schema tests first so create without `siteId` fails validation for every caller; wrong-org and inaccessible-site ids remain indistinguishable.
+- [ ] Require `siteId` in create input, resolve it under org scope, and call the shared assertion before inserting a token.
+- [ ] Keep agent enrollment bound to the token's immutable site and reject legacy site-less keys rather than assigning an org default.
+- [ ] Update web/API callers and fixtures that create onboarding tokens to send a selected site; surface validation through existing `runAction` UI behavior.
+- [ ] Run enrollment key and agent enrollment tests; expect GREEN.
+- [ ] Commit: `fix(enrollment): require explicit authorized site`.
+
+## Task 3: Link-group read projection (SR1-06)
+
+- [ ] Add tests for hidden-only groups (omitted), visible-only groups, mixed groups (visible members only plus a hidden-member indicator/count), and unrestricted callers.
+- [ ] Change `deviceLinkGroups.ts` query/projection so hidden device rows never reach serialization; compute the partial indicator without exposing ids, names, or hidden site details.
+- [ ] Apply identical behavior to list and detail routes in `devices/links.ts`.
+- [ ] Run link route tests and `deviceLinkGroupsRls.integration.test.ts`; expect GREEN.
+- [ ] Commit: `fix(authz): project link groups by visible sites`.
+
+## Task 4: Link-group mutation closure (SR1-06)
+
+- [ ] Add tests for add/remove/update/delete where one current or target member is hidden; assert total rollback and no existence leak.
+- [ ] In one transaction, lock the group and current membership, load authoritative device sites, validate every current and target site, then mutate.
+- [ ] Validate group-level target/parent site when applicable; do not authorize from request-supplied site ids.
+- [ ] Run focused tests; expect GREEN.
+- [ ] Commit: `fix(authz): validate complete link-group mutation scope`.
+
+## Task 5: Legacy device groups (SR1-07)
+
+- [ ] Extend `devices/groups.test.ts` for list/detail visibility, create/update target site, parent changes, membership additions/removals, and delete with hidden members.
+- [ ] Replace ad hoc `allowedSiteIds` filtering with `canAccessSite`/shared assertion and authoritative site lookups.
+- [ ] For every mutation, validate group current site, target site, parent site, and all affected device sites before writing.
+- [ ] Run legacy group and multi-tenant log tests; expect GREEN.
+- [ ] Commit: `fix(authz): close legacy group site-scope gaps`.
+
+## Task 6: Ticket triage same-row site enforcement (SR1-23)
+
+- [ ] Add tests covering visible ticket/hidden device, hidden ticket/visible device, mismatched joined device, deviceless visible ticket, and restricted count/list parity.
+- [ ] Refactor `ticketTriage.ts` so ticket ownership and site predicates apply to the same authoritative ticket row before any device or enrichment join.
+- [ ] Treat deviceless tickets with the existing org-visible ticket semantics; never infer visibility from an unrelated device row.
+- [ ] Apply the same predicate to triage list, counts, and detail route in `tickets.ts`.
+- [ ] Run `ticketTriage.test.ts`, `tickets.test.ts`, and site-scope tests; expect GREEN.
+- [ ] Commit: `fix(tickets): bind triage visibility to ticket site`.
+
+## Task 7: Full verification
+
+- [ ] Run all focused tests plus `pnpm exec tsc --noEmit -p apps/api/tsconfig.json`.
+- [ ] Run OrbStack integration tests for link-group RLS and enrollment flows.
+- [ ] Exercise one restricted user with two sites: verify hidden-only groups disappear, mixed groups redact, writes touching hidden members fail, and triage totals equal visible results.
+- [ ] Run `pnpm db:check-drift` and `git diff --check`.
+- [ ] Commit: `test(authz): verify site-axis enforcement wave`.

--- a/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-06-helper-remote-tunnel-authorization.md
+++ b/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-06-helper-remote-tunnel-authorization.md
@@ -1,0 +1,91 @@
+# Security Review Wave 6: Helper, Remote, and Tunnel Authorization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Revalidate tenant lifecycle, device ownership, site scope, permission, and MFA at every helper, remote-session, and tunnel capability boundary.
+
+**Architecture:** Extract a tenant/device lifecycle assertion shared by main-agent and helper authentication, then introduce a current-device capability gate used at session mint and close. Remote desktop keeps `remote:access`; tunnels receive exact `tunnels:access` permission.
+
+**Tech Stack:** TypeScript, Hono, JWT/capability tokens, WebSocket/HTTP tunnel routes, Drizzle ORM, Vitest, PostgreSQL/OrbStack.
+
+**Global Constraints:** Preserve wire formats and agent/helper compatibility; never authorize solely from a previously minted token; do not weaken MFA; close paths must recheck current authority; deny without cross-tenant existence disclosure.
+
+**Findings:** SR1-15, SR1-16, SR1-17, SR1-27.
+
+**Design:** `docs/superpowers/specs/2026-07-11-security-review-wave-06-helper-remote-tunnel-authorization-design.md`
+
+## File map
+
+- Create `apps/api/src/services/tenantDeviceLifecycle.ts` and adjacent test.
+- Modify `apps/api/src/middleware/agentAuth.ts`, `routes/helper/index.ts`, and their tests.
+- Create or extend `apps/api/src/services/deviceCapabilityAuthorization.ts` and test.
+- Modify `routes/remote/helpers.ts`, `routes/remote/sessions.ts`, `routes/tunnels.ts`, `routes/tunnelHttp.ts`, `routes/tunnelWs.ts`, and focused tests.
+- Add permission migration `apps/api/migrations/2026-07-11-b-tunnel-access-permission.sql`; update permission seed/registry.
+
+## Task 1: Shared tenant/device lifecycle assertion (SR1-15)
+
+- [ ] Add failing tests for active tenant/device, suspended organization, inactive partner, decommissioned device, moved device, mismatched agent id, and missing rows.
+- [ ] Implement a query returning the device, organization, and partner lifecycle in one authoritative lookup and expose:
+
+```ts
+export async function assertActiveTenantDevice(
+  db: RequestDb,
+  identity: { deviceId: string; agentId?: string },
+): Promise<ActiveTenantDevice>;
+```
+
+- [ ] Use the helper from `agentAuth.ts` without changing successful auth context shape.
+- [ ] Run middleware tests; expect GREEN.
+- [ ] Commit: `fix(agent-auth): centralize active tenant device validation`.
+
+## Task 2: Bring helper authentication to parity (SR1-15)
+
+- [ ] Add helper route tests for suspended org, inactive partner, decommissioned/moved device, expired helper role token, and valid helper.
+- [ ] Replace helper-only ownership shortcuts in `routes/helper/index.ts` with the shared lifecycle assertion after token verification.
+- [ ] Verify helper permissions still filter tools and that denials occur before tool metadata or device details are returned.
+- [ ] Run `routes/helper/index.test.ts`, `services/helperToolFilter.test.ts`, and `middleware/agentAuth.test.ts`; expect GREEN.
+- [ ] Commit: `fix(helper): enforce tenant lifecycle during authentication`.
+
+## Task 3: Current-device capability gate
+
+- [ ] Add failing tests for permission, MFA, ownership, active lifecycle, and current site scope, including authority revoked after an earlier successful check.
+- [ ] Implement:
+
+```ts
+export async function authorizeCurrentDeviceCapability(
+  auth: AuthContext,
+  deviceId: string,
+  capability: 'remote:access' | 'tunnels:access',
+  options: { requireMfa: boolean },
+): Promise<AuthorizedDeviceCapability>;
+```
+
+- [ ] Resolve the device under current database state and call `auth.canAccessSite` on the authoritative site.
+- [ ] Run focused tests; expect GREEN.
+- [ ] Commit: `fix(authz): add current device capability gate`.
+
+## Task 4: Remote-session mint and close (SR1-16, SR1-17)
+
+- [ ] Extend `remote/sessions.test.ts` and deny tests for missing `remote:access`, missing MFA, hidden site, moved/decommissioned device, suspended tenant, and permission revoked before close.
+- [ ] Call the current-device gate before every remote capability/session mint in `remote/helpers.ts` and `remote/sessions.ts`.
+- [ ] On close/terminate, lock or reload session ownership and re-run the current gate; allow only documented system cleanup paths to bypass user checks.
+- [ ] Keep payload and WebSocket negotiation formats unchanged and audit start/close denials and successes without tokens.
+- [ ] Run all remote route/service tests; expect GREEN.
+- [ ] Commit: `fix(remote): reauthorize session lifecycle operations`.
+
+## Task 5: Tunnel permission and lifecycle (SR1-27)
+
+- [ ] Add permission registry/seed tests and idempotent migration for `tunnels:access`, granting only the approved built-in roles; no custom-role auto grants.
+- [ ] Add HTTP and WebSocket route tests for missing permission, missing MFA, hidden/moved device, suspended tenant, expired token, permission revocation, and authorized success.
+- [ ] Gate every tunnel mint/open/close in `tunnels.ts`, `tunnelHttp.ts`, and `tunnelWs.ts`; bind claims to authorized user, device, partner/org, and short expiry while retaining the current wire schema.
+- [ ] Revalidate current authority when exchanging the token and closing a session.
+- [ ] Run tunnel tests and migration tests; expect GREEN.
+- [ ] Commit: `fix(tunnels): require current tunnel access authority`.
+
+## Task 6: OrbStack race and regression verification
+
+- [ ] Add integration coverage that mints a remote/tunnel token, then moves or decommissions the device or revokes the permission before exchange/close; assert denial.
+- [ ] Verify main agent and helper both reject suspended organizations using the same lifecycle fixture.
+- [ ] Apply the permission migration twice against OrbStack and verify idempotence.
+- [ ] Run focused helper/remote/tunnel tests, `pnpm exec tsc --noEmit -p apps/api/tsconfig.json`, `pnpm db:check-drift`, and `git diff --check`.
+- [ ] Commit: `test(authz): prove helper remote and tunnel reauthorization`.

--- a/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-07-pam-data-read-permissions.md
+++ b/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-07-pam-data-read-permissions.md
@@ -1,0 +1,79 @@
+# Security Review Wave 7: PAM and Data-Read Permissions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Separate sensitive PAM decisions and high-value data reads into explicit least-privilege permissions with query-time tenant/site scoping.
+
+**Architecture:** Add exact PAM, AI audit, alert read, and patch read permissions; enforce maker/checker plus MFA for PAM; scope AI transcripts in SQL; align alert summaries with list authorization; distinguish global patch catalog facts from device-derived site data.
+
+**Tech Stack:** TypeScript, Hono, Drizzle ORM, PostgreSQL migrations/RLS, Vitest, OrbStack.
+
+**Global Constraints:** PAM rules remain org-scoped under existing RLS; custom roles get no automatic grants; denials leak neither record existence nor aggregate counts; owner checks and site predicates occur in SQL, not post-fetch filtering.
+
+**Findings:** SR1-13, SR1-14, SR1-20, SR1-28, SR1-29.
+
+**Design:** `docs/superpowers/specs/2026-07-11-security-review-wave-07-pam-data-read-permissions-design.md`
+
+## File map
+
+- Add `apps/api/migrations/2026-07-11-c-pam-data-read-permissions.sql`; modify permission registry/seed and tests.
+- Modify `apps/api/src/routes/pam.ts` and `pam.test.ts`.
+- Modify `apps/api/src/routes/ai.ts`, `services/aiAgent.ts`, and authorization tests.
+- Modify `apps/api/src/routes/alerts/alerts.ts` and alert authorization tests.
+- Modify `apps/api/src/routes/patches/list.ts`, `patches/operations.ts`, and tests.
+
+## Task 1: Permission migration and built-in grants
+
+- [ ] Add failing permission registry/seed tests for `pam:approve`, `pam:manage_policy`, `ai:audit`, existing `alerts:read`, and new `patches:read`.
+- [ ] Write idempotent migration `2026-07-11-c-pam-data-read-permissions.sql`; insert missing permissions and grant only the approved built-in roles. Preserve custom roles exactly.
+- [ ] Update TypeScript permission constants and seed definitions to match the migration.
+- [ ] Apply twice against OrbStack, run permission tests and `pnpm db:check-drift`; expect GREEN.
+- [ ] Commit: `feat(authz): add PAM and sensitive read permissions`.
+
+## Task 2: PAM approval maker/checker (SR1-13)
+
+- [ ] Add tests for requester attempting self-approval, approver without `pam:approve`, no MFA, wrong org/site, expired/already-decided request, and valid independent approver.
+- [ ] Require exact permission and MFA before loading approval details; enforce `approverUserId !== requesterUserId` in the transactional decision path.
+- [ ] Lock the pending request before status transition and audit requester, approver, target device, decision, and policy id without secret payload.
+- [ ] Run `routes/pam.test.ts` and PAM approver/rule-engine tests; expect GREEN.
+- [ ] Commit: `fix(pam): enforce independent authorized approval`.
+
+## Task 3: PAM policy administration (SR1-14)
+
+- [ ] Add CRUD tests for `pam:manage_policy`, MFA on writes, org/site restrictions, cross-org ids, and read-only callers.
+- [ ] Gate policy writes before queries; retain org-scoped RLS and validate all referenced devices/sites/groups against current caller scope.
+- [ ] Audit sanitized before/after policy configuration.
+- [ ] Run PAM route, schema, rule-engine, and integration tests; expect GREEN.
+- [ ] Commit: `fix(pam): protect policy administration`.
+
+## Task 4: AI transcript authorization (SR1-20)
+
+- [ ] Add tests for session owner, non-owner without `ai:audit`, auditor with `ai:audit`, cross-partner auditor, hidden-site session, and absent session with indistinguishable denial.
+- [ ] Refactor `routes/ai.ts`/`services/aiAgent.ts` so the select predicate contains tenant, site, and `(owner = caller OR has ai:audit)` conditions.
+- [ ] Apply the same scoped predicate to transcript, message, event, export, and count paths; do not fetch then authorize.
+- [ ] Run `services/aiAgent.authz.test.ts` and related route tests; expect GREEN.
+- [ ] Commit: `fix(ai): scope transcript reads in SQL`.
+
+## Task 5: Alert summary/list parity (SR1-28)
+
+- [ ] Add authorization tests for alert list, summary, severity/status counts, and empty result under missing `alerts:read`, wrong org, and hidden site.
+- [ ] Require `alerts:read` before all aggregate queries and reuse the identical tenant/site predicate builder used by list.
+- [ ] Assert summary totals equal the visible list fixture and do not reveal hidden counts.
+- [ ] Run alert authz/by-id/list tests; expect GREEN.
+- [ ] Commit: `fix(alerts): align summary with scoped read permission`.
+
+## Task 6: Patch catalog versus device-derived reads (SR1-29)
+
+- [ ] Add tests for global catalog metadata with `patches:read`, device compliance/operations without permission, hidden-site devices, mixed visible/hidden devices, and aggregate/list parity.
+- [ ] Gate catalog facts with `patches:read`; for device-derived rows additionally join authoritative devices and apply org/site scope in SQL.
+- [ ] Update `patches/list.ts` and `patches/operations.ts` so no device names, state, counts, or operation history bypasses the device predicate.
+- [ ] Run patch list/index/compliance/operation tests; expect GREEN.
+- [ ] Commit: `fix(patches): scope device-derived read data`.
+
+## Task 7: Full OrbStack and static verification
+
+- [ ] Seed full, org-restricted, site-restricted, read-only, and custom roles; verify each endpoint matrix against OrbStack.
+- [ ] Forge cross-tenant PAM, AI, alert, and patch queries as `breeze_app`; verify RLS/query predicates deny or return empty without leaks.
+- [ ] Run all focused tests, `pnpm exec tsc --noEmit -p apps/api/tsconfig.json`, `pnpm --filter=@breeze/api test:rls-coverage`, `pnpm db:check-drift`, and `git diff --check`.
+- [ ] Confirm the permission migration did not grant any custom role.
+- [ ] Commit: `test(authz): verify PAM and data-read boundaries`.

--- a/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-08-ticket-financial-audit.md
+++ b/docs/superpowers/plans/security-auth/2026-07-11-security-review-wave-08-ticket-financial-audit.md
@@ -1,0 +1,65 @@
+# Security Review Wave 8: Ticket Financial Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Produce complete, actor-attributed, transactionally durable audit records for ticket-part financial mutations.
+
+**Architecture:** Add a transaction-aware audit primitive and execute each part mutation plus audit insert in the same database transaction. Lock rows before update/delete so before/after values reflect the serialized mutation.
+
+**Tech Stack:** TypeScript, Hono, Drizzle ORM, PostgreSQL, Vitest, OrbStack.
+
+**Global Constraints:** Preserve API request/response shapes; audit catalog item, part number, vendor, quantity, unit price, cost basis, billable flag, and billing status; do not include free-text description/notes; audit failure must roll back the mutation.
+
+**Finding:** SR1-24.
+
+**Design:** `docs/superpowers/specs/2026-07-11-security-review-wave-08-ticket-financial-audit-design.md`
+
+## File map
+
+- Modify `apps/api/src/services/auditService.ts` and `auditService.test.ts`.
+- Modify `apps/api/src/services/timeEntryService.ts` only if its transaction types are the canonical reusable pattern.
+- Modify `apps/api/src/routes/tickets/parts.ts` and `parts.test.ts`.
+- Add `apps/api/src/__tests__/integration/ticketPartsAudit.integration.test.ts`.
+
+## Task 1: Transaction-aware audit primitive
+
+- [ ] Add failing tests proving a caller-supplied transaction is used and no nested/out-of-context transaction is opened.
+- [ ] Export the transaction type and primitive:
+
+```ts
+export async function createAuditLogInTransaction(
+  tx: DbTransaction,
+  params: CreateAuditLogParams,
+): Promise<void>;
+```
+
+- [ ] Share audit-row construction with `createAuditLog`; keep existing async retry behavior unchanged for non-transactional callers.
+- [ ] Run `pnpm --filter=@breeze/api test -- services/auditService.test.ts`; expect GREEN after implementation.
+- [ ] Commit: `feat(audit): support transactional audit writes`.
+
+## Task 2: Audit part creation atomically
+
+- [ ] Add route tests asserting action `ticket_part.created`, actor identity, ticket/org target, and sanitized financial `after` fields.
+- [ ] Add a failure test where audit insert throws and assert the part insert is rolled back.
+- [ ] Wrap create in one request-context transaction and call `createAuditLogInTransaction` before commit.
+- [ ] Ensure the previously ignored actor parameter is required and threaded from authenticated context.
+- [ ] Run `pnpm --filter=@breeze/api test -- routes/tickets/parts.test.ts`; expect GREEN.
+- [ ] Commit: `fix(tickets): atomically audit part creation`.
+
+## Task 3: Lock and audit update/delete
+
+- [ ] Add failing tests for `ticket_part.updated` with exact `before`/`after` financial fields and `ticket_part.deleted` with exact `before` fields.
+- [ ] Add tests proving description and notes are excluded and no-op updates have an explicit, documented audit outcome.
+- [ ] Within the transaction, select the scoped part and parent ticket `FOR UPDATE`, then update/delete and insert the audit record.
+- [ ] Preserve not-found and cross-org behavior without revealing existence.
+- [ ] Add rollback tests for audit failure on both update and delete.
+- [ ] Run the route and audit service tests; expect GREEN.
+- [ ] Commit: `fix(tickets): lock and audit part financial changes`.
+
+## Task 4: Real database and concurrency verification
+
+- [ ] Add an OrbStack-backed integration test that concurrently updates one part from two connections and proves each audit `before` value equals the prior committed state.
+- [ ] Assert create/update/delete each produce one audit row with actor, org, ticket, part id, action, and allowed financial fields.
+- [ ] Force audit insertion failure and verify no part mutation commits.
+- [ ] Run the new integration test, `pnpm --filter=@breeze/api test -- routes/tickets/parts.test.ts services/auditService.test.ts`, `pnpm exec tsc --noEmit -p apps/api/tsconfig.json`, and `git diff --check`.
+- [ ] Commit: `test(tickets): prove transactional part audit trail`.

--- a/docs/superpowers/specs/security-auth/2026-07-03-partner-sso-login-branding-design.md
+++ b/docs/superpowers/specs/security-auth/2026-07-03-partner-sso-login-branding-design.md
@@ -1,0 +1,169 @@
+# Partner-Scope SSO + Login-Page Branding — Design
+
+**Issue:** #2183 (win-wxx, self-hosted MSP). **Epic alignment:** #2135 partner-wide-first dual-axis playbook.
+**Status:** Approved design, pre-implementation. **Date:** 2026-07-03.
+
+## Problem
+
+All live SSO is org-axis: `sso_providers.org_id` is NOT NULL, `defaultRoleId` must be an
+org-scoped role, and `/sso/check/:orgId` needs an org before a login button can render. An
+MSP's own technicians (partner-scope users, `users.orgId IS NULL`) have no SSO path into the
+partner dashboard. `partners.ssoConfig` / `organizations.ssoConfig` jsonb columns are
+write-only placeholders (no read call sites; responses project them out). The login shell
+(`AuthShellBranded.astro`) is hardcoded Breeze branding and marketing copy, which reads
+wrong on single-partner self-hosted instances.
+
+## Scope decisions (settled with Todd, 2026-07-03)
+
+- **Self-hosted first.** v1 targets single-partner instances; hosted multi-partner slug
+  discovery (`/login/:partnerSlug`) is deferred, but the public endpoint shape is designed
+  so the slug variant slots in without rework.
+- **Approach A:** dual-axis extension of the existing `sso_providers` table per the #2135
+  playbook — NOT a separate `partner_sso_providers` table, NOT the dormant jsonb columns.
+- **MFA mirrors org SSO:** per-provider `trustsIdpMfa` + `amr` claim check sets the JWT
+  `mfa` claim; role-level `forceMfa` (428 enrollment gate) backstops.
+- **Identity-first only in v1:** no JIT/auto-provisioning through partner providers. Users
+  must already exist (invited). JIT is an additive fast-follow reusing org machinery
+  (`sso_verified_domains` stays org-only until then).
+- **Minimal branding:** logo URL + accent color + headline. No custom CSS (XSS-adjacent),
+  no favicon/custom-domain work in v1.
+- **No MSAL / no new auth libraries.** The `jose`-based engine in `services/sso.ts`
+  (discovery, PKCE, JWKS id_token verification, SAML helpers, provider presets) is reused
+  unchanged. Entra remains a preset, not a dependency.
+- **Password-holding users are never auto-linked by email** (settled with Todd,
+  2026-07-03): login-path auto-link applies only to passwordless users with no link to a
+  different provider — the same safe-link conditions org SSO uses. Everyone else connects
+  their identity through an authenticated self-service **Connect SSO** flow (initiated
+  from their own security settings, `requireMfa()`-gated, full id_token verification +
+  email-match before the `user_sso_identities` row is created; works for both org-axis
+  and partner-axis providers). The `sso_link_required` login error directs users there.
+
+## 1. Data model & migration
+
+One migration (idempotent, RLS in same file, playbook reference:
+`2026-06-27-config-policies-partner-ownership.sql`):
+
+- `sso_providers`: `ADD COLUMN partner_id uuid REFERENCES partners(id)`, relax `org_id` to
+  nullable, `sso_providers_one_owner_chk` CHECK `((org_id IS NULL) <> (partner_id IS NULL))`,
+  index on `partner_id`, drop org-only RLS policies and create ONE dual-axis policy:
+  `system OR breeze_has_org_access(org_id) OR breeze_has_partner_access(partner_id)`
+  (FORCE kept).
+- `user_sso_identities`, `sso_sessions`: unchanged — they key off `provider_id`/`user_id`;
+  the provider row carries ownership.
+- `sso_verified_domains`: unchanged in v1 (gates JIT, which is out of scope).
+- **New `partner_branding`** (deliberately partner-only, NOT dual-axis — org login branding
+  already exists as `portal_branding`): `partner_id uuid PK REFERENCES partners(id)`,
+  `logo_url text`, `accent_color varchar(7)`, `headline varchar(120)`, timestamps.
+  Shape-3 RLS (`breeze_has_partner_access(partner_id)`), FORCE.
+- **Deprecations:** remove `ssoConfig` from org/partner create+update Zod schemas
+  (`routes/orgs.ts:60,120`) so writes stop. Columns remain (never edit shipped
+  migrations); a later cleanup migration may drop them.
+
+**Allowlists/tests to register:** `sso_providers` → `DUAL_AXIS_TENANT_TABLES`;
+`partner_branding` → `PARTNER_TENANT_TABLES` (both in
+`rls-coverage.integration.test.ts`). Tenant-cascade sweep must cover `partner_branding`.
+
+## 2. Auth flow
+
+- **Entry:** `GET /sso/login/partner/:partnerId` alongside existing `GET /sso/login/:orgId`;
+  mounted before it so `partner` never parses as an orgId. Same `sso_sessions`
+  state/nonce/PKCE machinery.
+- **Callback:** existing `GET /sso/callback` branches on the provider row's owner axis.
+  Partner-axis path: verify id_token exactly as today (JWKS, issuer, nonce), then
+  identity-first resolution ONLY —
+  1. match `user_sso_identities` for this provider;
+  2. else match verified email against users WHERE `partner_id = provider.partner_id`
+     AND `org_id IS NULL` (partner staff only; org users never resolve through a partner
+     provider) and auto-link ONLY under the safe-link conditions (no password, no link
+     to a different provider); a password-holding match error-redirects with
+     `sso_link_required`, pointing at the Connect SSO flow;
+  3. else error-redirect with reason `invite_required` (no user creation).
+- **Connect SSO (self-service linking):** an authenticated, `requireMfa()`-gated
+  `POST /sso/link/start/:providerId` starts an IdP round-trip using the same
+  `sso_sessions` state/PKCE machinery with a `link_user_id` marker; the callback
+  recognizes link mode and, after full id_token verification, an email match against
+  the linking user, and an identity-in-use check, creates the `user_sso_identities`
+  row for the CURRENT user (no token minting). Audited (`sso.identity.linked`).
+  Surfaced as a "Connect SSO" card in the user's own security settings. Both axes.
+- **Role & token:** provider-write-time validation requires `defaultRoleId` to be a
+  partner-scoped role when `partner_id` is set (mirror of the org check). In v1 the
+  default role is validated and stored but NEVER applied at login — identity-first means
+  the user's existing `partner_users` membership (incl. `orgAccess`) is always
+  authoritative, and users without membership are rejected (do not fall back; see the
+  membershipless-user system-scope-token bug class). The column becomes live only when
+  JIT ships. SSO never escalates beyond existing membership.
+  Tokens minted via existing `createTokenPair` with `scope: 'partner'`; refresh-cookie
+  exchange via the existing one-time `#ssoCode` flow.
+- **MFA:** `trustsIdpMfa` + `amr` → JWT `mfa` claim (unchanged code path); `forceMfa`
+  roles still hit the 428 enrollment gate without it.
+- **enforceSSO:** partner provider with `enforceSSO` suppresses password login for that
+  partner's staff via the existing `ssoPolicy` mechanism; break-glass preserved while
+  status is `testing` (same testing→active gate as org SSO).
+
+## 3. Login page & branding surface
+
+- **New public endpoint `GET /auth/login-context`** (unauthenticated, rate-limited,
+  cacheable). Single-partner instance → `{ branding: {logoUrl, accentColor, headline} |
+  null, partnerSso: { available, providerName, loginUrl } | null }` for that partner.
+  Multi-partner instance → `{ branding: null, partnerSso: null }` (stock Breeze page);
+  the future slug variant returns the same shape resolved by slug. Never leaks provider
+  config beyond name + login URL.
+- **Web:** `LoginPage.tsx` fetches login-context (same pattern as the `cfAccessLogin`
+  config check at `LoginPage.tsx:38-58`). `AuthShellBranded.astro` becomes prop-driven:
+  branding present → swap logo/accent/headline, drop hardcoded marketing copy.
+  `partnerSso.available` → "Sign in with {providerName}" button above the password form.
+
+## 4. Admin API & UI
+
+- `/sso/providers` CRUD gains `ownerScope: 'organization' | 'partner'` on create
+  (update schema `.omit({ ownerScope: true })`). Partner-scope writes gated on
+  `canManagePartnerWidePolicies(auth)` (`services/partnerWideAccess.ts`); partner id
+  derived from the caller's token, never the request body. Existing `requireMfa()` on
+  SSO admin routes stays.
+- SSO settings UI: create-only ownership selector + "Partner" badge (pattern:
+  `apps/web/src/components/software/PolicyForm.tsx`). Presets, testing→active flow,
+  test-login button inherit unchanged.
+- New "Login Branding" card under partner settings: logo URL, accent color (hex,
+  validated), headline (length-capped) + live preview; mutations via `runAction`;
+  strict Zod (no `z.any()`).
+
+## 5. Security & error handling
+
+- **Axis confusion:** callback derives user pool, role scope, and token scope from the
+  provider row's axis; a partner provider can never mint org-scoped tokens or resolve
+  org-bound users. Enforced in code + forge tests.
+- **Tenant leakage:** login-context reveals branding/SSO only on single-partner
+  instances; multi-partner returns nulls.
+- **Escalation:** `defaultRoleId` scope validated at write time; login never grants
+  beyond existing membership (identity-first).
+- **Redirect/interception:** unchanged org-SSO protections (one-time `#ssoCode`, PKCE,
+  nonce, SSRF guards on discovery URLs).
+- **Lockout:** break-glass password login preserved in `testing` status; `enforceSSO`
+  is an explicit opt-in. All SSO admin mutations via `writeRouteAudit`; logins audited
+  as `user.login` with `method: 'sso-partner'`.
+- **Error paths:** callback failures redirect with typed reason codes
+  (`invite_required`, `provider_error`, `state_mismatch`), never raw errors; login rate
+  limits (per-IP and per-IP+identity) apply to the new entry point.
+
+## 6. Testing
+
+- `ssoProvidersPartnerRls.integration.test.ts`: cross-partner forge (42501), XOR
+  (23514), org↔partner visibility isolation, functional second-axis insert.
+- `partner_branding` RLS forge + cascade coverage.
+- Route tests: ownerScope create/gate, partner-scoped defaultRoleId validation,
+  update-omits-ownerScope.
+- Callback unit tests: partner staff resolves; same-email org user does NOT; unknown
+  identity → `invite_required`; `trustsIdpMfa`/`amr` → `mfa` claim.
+- `login-context`: single-partner with/without branding; multi-partner nulls.
+- Web: branded shell render, SSO button, `no-silent-mutations` for the branding card.
+- Connect SSO: link-start auth/MFA/axis-pool gates; link-mode callback (email
+  mismatch rejected, identity-in-use rejected, happy path links the session user).
+- Real-DB e2e integration: partner-axis provider login mints a `scope: 'partner'`
+  token; a password-holding user hits `sso_link_required`, links via Connect SSO,
+  then logs in via SSO successfully.
+
+## Out of scope (recorded)
+
+JIT for partner providers (+ partner-axis `sso_verified_domains`), `/login/:partnerSlug`
+hosted discovery, group/claim-based role mapping, SCIM, favicon/custom-domain/custom-CSS
+branding, dropping the deprecated `ssoConfig` columns.

--- a/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-02-effective-request-db-role-design.md
+++ b/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-02-effective-request-db-role-design.md
@@ -1,0 +1,128 @@
+# Security Review Wave 2: Effective Request Database Role Design
+
+**Date:** 2026-07-11
+**Status:** Approved for planning
+**Finding:** SR1-02
+**Source:** `internal/security-findings/2026-07-11-playbook-01-multi-tenant-rls-authz.md`
+**Reviewed baseline:** `origin/main` at `0f05c1faa274f9c49b96ef57b829d9dbf2989477`
+
+## Objective
+
+Guarantee that every ordinary API request uses the exact PostgreSQL pool whose effective login role
+is non-superuser and cannot bypass row-level security. Configuration validation, startup probes,
+and exported database clients must all resolve one canonical request connection string before any
+pool is constructed.
+
+## Current boundary
+
+The API currently constructs the exported request client in `apps/api/src/db/index.ts` from
+`DATABASE_URL_APP || DATABASE_URL`. Separately, auto-migration derives or probes an application-role
+URL after migrations have run. In the supported password-only configuration, the probe can verify a
+derived `breeze_app` connection while request handlers continue using the earlier privileged
+`DATABASE_URL` pool. Disabling automatic migrations also skips the relevant probe.
+
+The defect is pool identity, not an RLS-policy defect. Existing tenant policies remain the required
+enforcement layer once the request pool is guaranteed to use a safe role.
+
+## Security invariants
+
+1. The request connection string is resolved exactly once before the exported request pool exists.
+2. `DATABASE_URL_APP`, when present, is the authoritative request URL.
+3. Without `DATABASE_URL_APP`, `BREEZE_APP_DB_PASSWORD` or `POSTGRES_PASSWORD` derives a URL using
+   the `breeze_app` login while preserving host, port, database, query parameters, and TLS settings.
+4. `DATABASE_URL` remains the system/migration connection and is never an implicit production
+   request fallback.
+5. Production startup probes the exact request pool used by `db`, not a temporary look-alike client.
+6. Startup refuses to serve when `current_user` is superuser or has `rolbypassrls`.
+7. The probe runs whether `AUTO_MIGRATE` is true or false.
+8. Logs may include the effective role name and Boolean safety flags, but never credentials or a
+   connection URL.
+
+## Architecture
+
+### Canonical configuration resolver
+
+Create a dependency-free database configuration module that exports a pure resolver:
+
+```ts
+interface RequestDatabaseConfig {
+  systemUrl: string;
+  requestUrl: string;
+  source: 'explicit-app-url' | 'derived-app-role' | 'development-default';
+}
+
+function resolveRequestDatabaseConfig(env: NodeJS.ProcessEnv): RequestDatabaseConfig;
+```
+
+The resolver validates URL syntax, derives `breeze_app` credentials before module-scope client
+construction, and returns sanitized error messages. Production configuration without an explicit or
+derivable request URL fails immediately. A development-only local default may remain, but must still
+be probed when the application starts in production mode.
+
+`apps/api/src/db/index.ts` consumes `requestUrl` for the exported request pool. Migration and seed
+code consumes `systemUrl` through its existing dedicated clients. No caller reconstructs precedence
+rules independently.
+
+### Exact-pool startup assertion
+
+Export a startup assertion that executes through the already-created request client:
+
+```sql
+SELECT current_user AS "user", rolsuper, rolbypassrls
+FROM pg_roles
+WHERE rolname = current_user
+```
+
+The assertion runs during API startup after configuration validation but independently of the
+auto-migration branch. A missing role row, connection failure, superuser, or BYPASSRLS result is a
+fatal startup error. The error identifies the unsafe effective role and explains which configuration
+values operators must set without printing secrets.
+
+Auto-migration may retain a post-grant diagnostic, but it must call the same assertion or be clearly
+non-authoritative. There must be only one security decision about whether the request pool is safe.
+
+### Testability and module loading
+
+Keep URL resolution pure and pool creation behind a narrow factory so tests can supply environment
+objects and fake probe clients without resetting unrelated application modules. Module-import tests
+must prove the resolver runs before client construction.
+
+## Configuration contract
+
+| Configuration | Result |
+|---|---|
+| `DATABASE_URL_APP` set | Use it exactly for requests; probe that pool |
+| App URL absent, app password set | Derive `breeze_app` request URL; probe that pool |
+| Neither app URL nor derivation password in production | Refuse startup |
+| Request role is superuser/BYPASSRLS | Refuse startup |
+| `AUTO_MIGRATE=false` | Skip migrations only; still probe request pool |
+
+`DATABASE_URL_APP` documentation must name `breeze_app` as the expected role rather than generic
+`app_user`. Password-only examples must state that the role must already exist when migrations are
+disabled.
+
+## Failure and rollout behavior
+
+This is intentionally fail closed. A previously bootable but unsafe production deployment may stop
+until its application-role credentials are corrected. The release note must include pre-deploy role
+creation, credential mapping through Compose, startup-log verification, and rollback instructions.
+
+Rollback is configuration-sensitive: an older binary may silently reuse `DATABASE_URL`. Operators
+must keep an explicit safe `DATABASE_URL_APP` in place before rolling back.
+
+## Verification
+
+- Pure resolver tests cover explicit URL, password-only derivation, URL parameter preservation,
+  malformed URLs, and missing production credentials.
+- Pool-construction tests prove the request factory receives the resolved app URL.
+- Startup tests prove the exact exported pool is probed with `AUTO_MIGRATE` both true and false.
+- Real PostgreSQL tests cover `breeze_app`, superuser, and a non-superuser role granted BYPASSRLS.
+- Existing request-context and RLS integration suites remain green under OrbStack.
+- API typecheck, build, configuration documentation checks, and `git diff --check` pass.
+
+## Non-goals
+
+- Redesigning RLS policies or database access-context GUCs.
+- Combining request, migration, audit-admin, and background credentials into one role.
+- Automatically creating `breeze_app` when migrations are disabled.
+- Logging or returning database credentials.

--- a/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-03-partner-global-authorization-design.md
+++ b/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-03-partner-global-authorization-design.md
@@ -1,0 +1,144 @@
+# Security Review Wave 3: Partner-Global Authorization Design
+
+**Date:** 2026-07-11
+**Status:** Approved for planning
+**Findings:** SR1-03, SR1-09, SR1-10, SR1-11, SR1-12, SR1-18, SR1-19, SR1-21,
+SR1-22, SR1-26, SR1-30
+**Source:** `internal/security-findings/2026-07-11-playbook-01-multi-tenant-rls-authz.md`
+**Reviewed baseline:** `origin/main` at `0f05c1faa274f9c49b96ef57b829d9dbf2989477`
+
+## Objective
+
+Make partner-global administration an explicit capability rather than an inference from rows visible
+through request RLS. Partner members with `orgAccess='selected'` or `'none'` must not manage state
+that applies to every present or future organization unless a route intentionally returns a
+site/org-scoped projection.
+
+## Shared authority contract
+
+All partner-global operations use `canManagePartnerWidePolicies(auth)` from
+`apps/api/src/services/partnerWideAccess.ts`. The capability is true only for system scope or partner
+scope with `partnerOrgAccess === 'all'`. It is never derived by querying organizations, comparing
+`accessibleOrgIds`, or treating an empty result as complete access.
+
+The helper remains a dependency-free leaf and is the sole semantic source for full-partner
+authority. Route-specific wrappers may supply a clearer denial message, but must not duplicate the
+logic.
+
+Partner-axis RLS continues to isolate different partners. It does not prove that a member may manage
+partner-global state inside their own partner.
+
+## Permission model
+
+Add canonical permissions and additive seed/migration rows:
+
+| Capability | Read permission | Manage permission |
+|---|---|---|
+| Update rings | `update_rings:read` | `update_rings:manage` |
+| Patch approvals | `patch_approvals:read` | `patch_approvals:manage` |
+| Connected apps and Huntress | `integrations:read` | `integrations:manage` |
+| Client AI templates | `client_ai_templates:read` | `client_ai_templates:manage` |
+| Partner ticket response templates | `ticket_response_templates:read` | `ticket_response_templates:manage` |
+| Partner invoice settings | `billing_settings:read` | `billing_settings:manage` |
+
+Partner Admin retains intended access. Read-only partner roles receive only the capabilities required
+by their product contract. Existing custom roles receive no new grant automatically. Permission
+migrations target system roles explicitly and idempotently.
+
+Sensitive writes retain existing MFA requirements and add MFA where sibling credential/policy
+administration already requires it. A dedicated permission never substitutes for full-partner
+authority; both are required for partner-global writes.
+
+## Route contracts
+
+### Roles and access reviews — SR1-03
+
+Role creation/update/deletion, partner-membership privilege changes, and access-review actions that
+can revoke or modify partner administrators require full-partner authority. Remove organization-list
+completeness checks. Denials occur before user/role queries that could mutate state.
+
+### Authenticator enforcement — SR1-09
+
+Partner-global authenticator-policy mutation requires the existing user-management permission, MFA
+where currently required, and full-partner authority. Audit bounded before/after enforcement fields.
+Organization-owned authenticator settings, if any, retain their organization contract.
+
+### Account deletion — SR1-10 product decision
+
+Partner-staff privacy requests are a partner-global workflow and require full-partner authority for
+list, review, and processing. Organization-member requests remain accessible only when their
+authoritative organization membership is within `accessibleOrgIds`. Mixed list responses are built
+as the union of these two authorized populations; selected users never receive partner-staff rows.
+
+### Update rings and patch approvals — SR1-11/SR1-12
+
+Update-ring and patch-approval lists require their dedicated read permission. Partner-global lists
+require full-partner authority unless the response is explicitly narrowed to authorized
+organizations/sites. Create, modify, enable, target, approve, decline, and defer operations require
+the manage permission, MFA, and full-partner authority. Derived counts use the same scope as returned
+rows.
+
+### Connected applications and integrations — SR1-18/SR1-21/SR1-30
+
+Connected-app/Huntress listing requires `integrations:read`; revoke, credential, and mapping changes
+require `integrations:manage`, MFA, and full-partner authority. Read DTOs minimize external tenant,
+token, and mapping identifiers. Revocation never accepts a request-controlled partner ID.
+
+### Client AI and response templates — SR1-19/SR1-22
+
+Partner-owned templates require their dedicated read/manage permissions and full-partner authority
+for mutation. Organization-owned templates remain org-scoped and must use authoritative org access.
+Ownership axis is selected from the persisted parent/template record, not solely request input.
+
+### Partner billing settings — SR1-26
+
+Partner invoice configuration requires `billing_settings:read/manage`; mutations additionally require
+full-partner authority and MFA when payment or credential-adjacent fields are affected. Invoice
+document permissions do not implicitly grant partner billing-policy administration.
+
+## Ordering and service defense
+
+Authorization middleware runs before request validation that performs external work and before any
+system-context transition. Services that mutate partner-global rows accept an explicit authority
+capability or independently call the shared helper when they are reachable outside HTTP routes.
+AI/MCP tools and background entry points use the same contract.
+
+Every denial proves no database mutation, token revocation, external API call, or audit-success event
+occurred. Security denials may emit a bounded denied audit event without sensitive payloads.
+
+## Audit and response minimization
+
+Write append-only audit events for role/admin revocation, authenticator-policy changes, update-ring
+and patch decisions, integration credential/mapping changes, partner template changes, and billing
+settings changes. Events identify actor, partner, resource, bounded changed fields, and outcome; they
+exclude tokens, secrets, full external responses, and unrestricted user lists.
+
+## Rollout
+
+This wave intentionally removes formerly implicit authority from selected/none and custom-role
+users. Release notes must list new permissions and explain that Partner Admin retains access while
+custom roles require deliberate updates. Permission migrations are additive and remain safe for
+older binaries, but rollback must not restore organization-query completeness checks.
+
+The wave should be implemented as one PR because the shared capability and permission vocabulary are
+reviewed together, but the implementation plan must use independently reviewed task groups for each
+route family.
+
+## Verification
+
+- A shared capability matrix covers system, partner all/selected/none, org, agent, helper, and missing
+  membership contexts.
+- Each route family tests unauthenticated, wrong scope, missing permission, selected/none, missing MFA,
+  and full-partner success with zero-side-effect denial assertions.
+- Read tests prove counts, identifiers, and rows share the same scope.
+- Mutation tests prove server-derived partner/ownership axes and append-only audit payloads.
+- Static route scans verify every adopted endpoint has live permission middleware.
+- API typecheck/build, permission seed consistency, focused integration tests, and `git diff --check`
+  pass.
+
+## Non-goals
+
+- Replacing partner-axis RLS with application-only authorization.
+- Automatically granting new capabilities to arbitrary custom roles.
+- Making all selected-user reads full-partner-only when a safe scoped projection exists.
+- Renaming the established shared capability helper as unrelated cleanup.

--- a/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-04-atomic-provisioning-quota-design.md
+++ b/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-04-atomic-provisioning-quota-design.md
@@ -1,0 +1,110 @@
+# Security Review Wave 4: Atomic Provisioning Quota Design
+
+**Date:** 2026-07-11
+**Status:** Approved for planning
+**Finding:** SR1-04
+**Source:** `internal/security-findings/2026-07-11-playbook-01-multi-tenant-rls-authz.md`
+**Reviewed baseline:** `origin/main` at `0f05c1faa274f9c49b96ef57b829d9dbf2989477`
+
+## Objective
+
+Enforce `partners.max_devices` across every provisioning scope without relying on request-RLS-visible
+counts, and serialize quota consumption so concurrent requests cannot exceed capacity.
+
+## Security boundary
+
+Ordinary route authorization still determines whether the caller may provision into the target
+organization and site. Only after those checks succeed may a narrowly scoped privileged operation
+derive the authoritative partner from the target organization, count partner devices, reserve
+capacity, and insert the device.
+
+The request may provide organization/site identifiers but never a partner ID. The privileged
+operation resolves the partner through persisted organization/site relationships and rejects any
+mismatch before quota work.
+
+## Atomic service contract
+
+Introduce one service entry point:
+
+```ts
+interface ProvisionAuthorizedDeviceInput {
+  orgId: string;
+  siteId: string;
+  deviceValues: AuthorizedDeviceInsert;
+}
+
+async function provisionDeviceWithinPartnerQuota(
+  input: ProvisionAuthorizedDeviceInput,
+): Promise<ProvisionedDevice>;
+```
+
+The route calls it only after current permission and site authorization. The service enters system
+database context outside any held request transaction, then opens one transaction that:
+
+1. Reads and locks the authoritative organization/site relationship.
+2. Locks the owning partner row with `FOR UPDATE`, creating a per-partner quota serialization point.
+3. Reads `max_devices` from that locked row.
+4. Counts all partner devices that are not decommissioned outside request RLS.
+5. Rejects when the next device would exceed a finite limit.
+6. Inserts the device with the authoritative org, site, and partner-derived relationships.
+7. Returns the inserted row before releasing the lock.
+
+The count and insert never occur in separate transactions. A SQL function is not required; a
+Drizzle/postgres transaction is acceptable if the lock and count are demonstrably issued on the same
+connection and every provisioning path uses the service.
+
+## Quota semantics
+
+- `max_devices IS NULL` means unlimited.
+- Only persisted devices with lifecycle state other than decommissioned count toward capacity.
+- A partner exactly at the limit cannot provision another device.
+- A partner already over the limit may manage or decommission existing devices but cannot provision.
+- Decommission and concurrent provisioning serialize through the same partner lock when they change
+  quota consumption, or the provisioning transaction re-evaluates after any decommission commit.
+- Failed/rolled-back inserts consume no capacity.
+- Repeated enrollment/provision requests retain existing idempotency or conflict behavior; quota
+  hardening must not create duplicate devices.
+
+## Error contract
+
+Quota exhaustion returns a stable conflict response such as `DEVICE_LIMIT_REACHED` without revealing
+other organizations' device counts. Logs/audit may record partner ID, configured limit, and bounded
+count under system visibility. Authorization failures remain indistinguishable from missing target
+resources where existing route contracts require 404.
+
+Database errors roll back the quota decision and insert. External network, queue, or notification
+work occurs only after the transaction commits.
+
+## Audit
+
+Successful provisioning and quota denial emit append-only events with actor type, authoritative
+partner/org/site, device ID on success, and a bounded reason code. Do not log enrollment secrets,
+agent tokens, hardware identifiers not already allowed by the audit schema, or full request bodies.
+
+## Rollout and compatibility
+
+No data migration is required unless implementation adds an explicit quota-reservation table; the
+preferred partner-row lock design does not. The behavioral change is immediate: org/selected callers
+that previously undercounted are denied at the true partner limit.
+
+If other provisioning entry points exist, the implementation cannot ship until they either use the
+same service or are proven not to create counted devices. Rollback may reintroduce over-provisioning,
+so operators should not roll back solely to bypass a legitimate quota denial.
+
+## Verification
+
+- Unit tests cover unlimited, below limit, exact limit, over limit, and decommissioned-device counts.
+- Authorization tests prove wrong org/site/partner inputs never enter privileged quota code.
+- Real PostgreSQL tests create two concurrent final-slot requests and prove exactly one insert commits.
+- A concurrent decommission/provision test proves results follow lock acquisition/commit order.
+- Selected/none/org-scope tests prove the count includes devices hidden by request RLS.
+- Failure tests prove rollback leaves no device and no reservation residue.
+- Existing enrollment/provisioning integration tests, RLS coverage, API typecheck/build, and
+  `git diff --check` pass under OrbStack.
+
+## Non-goals
+
+- Changing pricing, billing, or the meaning of `max_devices`.
+- Blocking management of already-provisioned devices for over-limit partners.
+- Accepting a request-controlled partner ID for quota selection.
+- Performing external work while holding the quota transaction.

--- a/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-05-site-axis-enforcement-design.md
+++ b/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-05-site-axis-enforcement-design.md
@@ -1,0 +1,141 @@
+# Security Review Wave 5: Site-Axis Enforcement Design
+
+**Date:** 2026-07-11
+**Status:** Approved for planning
+**Findings:** SR1-05, SR1-06, SR1-07, SR1-23
+**Source:** `internal/security-findings/2026-07-11-playbook-01-multi-tenant-rls-authz.md`
+**Reviewed baseline:** `origin/main` at `0f05c1faa274f9c49b96ef57b829d9dbf2989477`
+
+## Objective
+
+Apply current site restrictions to every object read or mutated by onboarding, device link/group,
+legacy group, and ticket-triage workflows. Organization access alone must not authorize effects on a
+hidden site.
+
+## Shared site-authorization model
+
+Introduce a shared fail-closed service that resolves authoritative sites and evaluates them against
+the authenticated context:
+
+```ts
+interface SiteAuthorizationTarget {
+  siteId: string;
+  orgId: string;
+}
+
+function assertSiteTargetsAccessible(
+  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'accessibleSiteIds'>,
+  targets: readonly SiteAuthorizationTarget[],
+): void;
+```
+
+The helper treats system scope and explicit all-site access according to the existing auth contract.
+An empty selected-site list means no site access, not all sites. Callers pass targets loaded from the
+database; request-supplied org/site relationships are never trusted without authoritative lookup.
+
+For multi-row mutations, resolution, authorization, row locking, and mutation occur in one
+transaction so membership cannot change between the check and write. Helpers return bounded IDs or
+throw a stable denied/not-found error; they do not enter system scope on behalf of an unauthorized
+request.
+
+## Onboarding token contract — SR1-05
+
+Onboarding token creation requires an explicit `siteId`. The route verifies that the site belongs to
+the authorized target organization and that the caller currently has site access. It no longer
+chooses an unordered first site.
+
+The web UI and API clients must supply the site selected by the administrator. Missing `siteId`
+returns a validation error with migration guidance. Public enrollment continues to consume the
+server-bound token site and cannot override it.
+
+Token records retain the authoritative org/site pair, and the enrollment transaction revalidates
+that the site still belongs to an active organization before creating the device. It does not need
+to re-evaluate the creating user's later permissions because the token is the delegated enrollment
+capability, but revocation/expiry behavior remains unchanged.
+
+## Device link groups — SR1-06
+
+List/read behavior follows these rules:
+
+- A group with no visible member is omitted.
+- A partially visible group returns only visible members and a bounded indicator that additional
+  hidden members exist; hidden device/site identifiers and total hidden count are not exposed.
+- Group metadata that would identify a hidden-only group is not returned.
+
+Rename, delete, dissolve, membership add/remove, and any operation that unlinks devices resolve and
+lock every current and target member. The mutation succeeds only when all affected sites are
+accessible. Partial mutation is forbidden.
+
+## Legacy device groups — SR1-07
+
+Create/update/delete/parent/membership operations use the shared helper for:
+
+- the group's current site;
+- the requested target site;
+- the current and requested parent group sites;
+- every device whose membership will be added, removed, or deleted;
+- descendants or inherited memberships affected by a destructive operation.
+
+Moving a group across sites requires access to both source and target. Setting a parent requires the
+child and parent to belong to compatible authorized organization/site axes. Delete/dissolve locks
+the group hierarchy and affected memberships before authorization.
+
+Read endpoints suppress inaccessible groups and do not leak parent names/counts derived from hidden
+sites. Existing full-site callers retain their current response shape.
+
+## Ticket triage metrics — SR1-23
+
+Triage feedback is not scoped by its own foreign key alone. Evaluation joins each feedback row to
+the authoritative ticket and, where present, device/site relationship, then reuses the same ticket
+site predicate as ticket listing.
+
+- Device-backed tickets are visible only when the device site is accessible.
+- Deviceless tickets follow established org-visible ticket semantics; they are not assigned an
+  arbitrary site.
+- Summary counts, override rate, numerator, and denominator use the identical predicate.
+- Empty visible populations return zero-valued metrics without falling back to org-wide data.
+
+## Transaction and error behavior
+
+All multi-object mutations authorize inside their write transaction using locked authoritative
+rows. A concurrent move or membership change either completes before the check and is included, or
+waits until the mutation finishes. No check-then-write gap is permitted.
+
+Denied objects use the existing 404/403 convention without disclosing hidden site existence. Lists
+filter rather than fail when their contract is visibility-oriented; mutations fail atomically when
+any affected target is hidden.
+
+## Audit
+
+Onboarding token creation and group mutations emit append-only events containing actor, org, visible
+site IDs, group/token ID, operation, and outcome. Events do not enumerate hidden members in a denied
+request. Triage reads do not require per-request audit unless existing analytics policy requires it.
+
+## Rollout
+
+This wave intentionally removes cross-site behavior from restricted users and makes `siteId`
+mandatory for onboarding-token creation. Update web/API clients in the same PR. Full-access partner
+and org administrators retain intended behavior after selecting a site.
+
+No schema migration is expected unless a missing authoritative site relationship must be added. Any
+new tenant column or table must follow the repository RLS workflow in the same migration.
+
+## Verification
+
+- Shared-helper matrix covers system, all sites, one selected site, empty selection, wrong org, and
+  stale/missing site.
+- Onboarding tests prove explicit accessible site success and missing/hidden/wrong-org rejection.
+- Link/group tests use one visible and one hidden site and prove list suppression/partial DTO plus
+  atomic mutation denial with zero membership changes.
+- Concurrency tests pause after row locking and prove member/site changes cannot bypass authorization.
+- Triage tests cover visible device tickets, hidden device tickets, deviceless tickets, mixed counts,
+  and empty populations with row/count parity.
+- Existing device/ticket RLS integrations, API typecheck/build, web client tests, and
+  `git diff --check` pass.
+
+## Non-goals
+
+- Adding site-axis RLS to every organization-scoped table.
+- Assigning synthetic sites to deviceless tickets.
+- Returning hidden member counts to make partial groups look complete.
+- Changing device enrollment wire formats beyond the authenticated token-creation request.

--- a/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-06-helper-remote-tunnel-authorization-design.md
+++ b/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-06-helper-remote-tunnel-authorization-design.md
@@ -1,0 +1,134 @@
+# Security Review Wave 6: Helper, Remote, and Tunnel Authorization Design
+
+**Date:** 2026-07-11
+**Status:** Approved for planning
+**Findings:** SR1-15, SR1-16, SR1-17, SR1-27
+**Source:** `internal/security-findings/2026-07-11-playbook-01-multi-tenant-rls-authz.md`
+**Reviewed baseline:** `origin/main` at `0f05c1faa274f9c49b96ef57b829d9dbf2989477`
+
+## Objective
+
+Re-evaluate current tenant lifecycle, user authority, ownership, MFA, and device site scope whenever
+Breeze mints or exercises helper/remote/tunnel capabilities. Previously authorized sessions must not
+remain a credential-minting shortcut after suspension or access reduction.
+
+## Shared current-authorization services
+
+### Tenant lifecycle assertion
+
+Extract the active partner/organization check used by main agent authentication into a shared leaf
+service. Both main agent and helper bearer authentication call the same function and receive the
+same suspended/inactive semantics. The helper path must not copy a subset of status checks.
+
+### Device capability assertion
+
+Create one current device-access service for remote desktop and tunnels:
+
+```ts
+interface DeviceCapabilityRequest {
+  auth: AuthContext;
+  deviceId: string;
+  sessionId?: string;
+  capability: 'remote_desktop' | 'tunnel';
+  operation: 'mint' | 'close';
+}
+
+async function authorizeCurrentDeviceCapability(
+  request: DeviceCapabilityRequest,
+): Promise<AuthorizedDeviceCapability>;
+```
+
+It loads the current user membership, tenant lifecycle, permission set, MFA state, session owner,
+device organization/site, and active session record from authoritative storage. It returns
+server-derived partner/org/site/device/session IDs. It never trusts authorization decisions cached
+in an older session.
+
+Remote desktop uses the established `remote:access` permission. Tunnel mint and close use a new
+canonical `tunnels:access` permission so ordinary remote-desktop authority does not silently include
+network tunneling. Partner Admin and the built-in roles whose existing product contract includes
+tunnels receive the grant explicitly; custom roles do not inherit it.
+
+## Helper bearer authentication — SR1-15
+
+After token signature/expiry and helper/device binding validation, helper authentication calls the
+shared tenant lifecycle assertion. Suspended partner, suspended organization, decommissioned device,
+or otherwise inactive tenant state rejects the request identically to main agent authentication.
+
+The response does not reveal which parent axis was suspended. Existing helper token format,
+rotation, and IPC/wire contracts remain unchanged.
+
+## Remote credential mint — SR1-16
+
+Every WebSocket/viewer/remote-desktop ticket mint re-runs the shared current capability assertion.
+The route requires current remote permission, required MFA, session ownership or explicitly allowed
+administrator override, and access to the device's current site. A stale remote session record is a
+resource locator only, not proof of authorization.
+
+Site moves and membership reductions take effect before the next ticket mint. Already-issued
+short-lived viewer tickets retain their existing cryptographic expiry; this wave does not add a
+revocation protocol to the viewer wire format.
+
+## Tunnel mint and close — SR1-17/SR1-27
+
+Tunnel WebSocket ticket mint requires current tunnel/remote permission, MFA, session ownership,
+active tenant/device, and current device-site access. Tunnel close uses the same capability service
+and authorization matrix as mint, with `operation='close'`; visibility alone is insufficient.
+
+Close remains idempotent for an already-closed authorized session. A caller who no longer has
+authority receives a denial without learning additional tunnel metadata. System-initiated cleanup
+uses an explicit system actor path rather than impersonating a user request.
+
+## Ordering and race behavior
+
+Authorization occurs immediately before credential signing or close mutation. The service locks or
+compare-and-sets the session record when ownership/status can change concurrently. The signed ticket
+contains only server-derived axes and a short expiry.
+
+External signaling occurs after the database transition commits. If authorization changes between
+the final check and an external send, the ticket verifier/consumer must still enforce signed device
+and session bindings; the implementation plan must add a deterministic race test at the closest
+available boundary.
+
+## MFA and permission behavior
+
+Routes use live `requirePermission` and `requireMfa` middleware, then service-level defense for
+non-route callers. Missing MFA, permission, membership, ownership, site access, or active lifecycle
+all fail before ticket signing and before queue/WebSocket side effects.
+
+Default role grants preserve intended Partner Admin/technician access. Existing custom roles retain
+access only if they already hold the chosen canonical permission; no broad new grant is automatic.
+
+## Audit and telemetry
+
+Audit successful and denied credential mint/close actions with actor, device, session, capability,
+and stable reason code. Never log bearer tokens, signed viewer/WS tickets, SDP/ICE details, tunnel
+secrets, or full headers. Helper suspension denials use bounded security telemetry without token
+contents.
+
+## Rollout
+
+Suspended tenants and users whose permissions/sites were reduced lose helper and new remote/tunnel
+credentials immediately. This is intended. Existing agent/helper/viewer message formats do not
+change, so API and agent releases remain wire-compatible.
+
+Rollback can restore stale authorization behavior and therefore requires explicit risk acceptance;
+there is no data migration to undo.
+
+## Verification
+
+- Shared lifecycle tests compare main agent and helper results for active/suspended partner/org and
+  inactive device states.
+- Credential matrices cover unauthenticated, missing permission, missing MFA, wrong owner, wrong org,
+  hidden site, moved device, reduced access, closed session, and success.
+- Deferred-promise tests reduce site/permission or suspend the tenant between session creation and
+  mint/close, proving no credential/signaling side effect.
+- Tunnel close and mint share contract tests so their authorization cannot drift.
+- Ticket claims are asserted to contain only server-derived IDs and expected expiry.
+- API typecheck/build, relevant agent tests, route scans, and `git diff --check` pass.
+
+## Non-goals
+
+- Changing agent, helper, viewer, WebRTC, or tunnel wire formats.
+- Revoking an already-issued viewer ticket before its current short expiry.
+- Treating stale session ownership as current authorization.
+- Adding unrelated remote transport or performance changes.

--- a/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-07-pam-data-read-permissions-design.md
+++ b/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-07-pam-data-read-permissions-design.md
@@ -1,0 +1,125 @@
+# Security Review Wave 7: PAM and Data-Read Permissions Design
+
+**Date:** 2026-07-11
+**Status:** Approved for planning
+**Findings:** SR1-13, SR1-14, SR1-20, SR1-28, SR1-29
+**Source:** `internal/security-findings/2026-07-11-playbook-01-multi-tenant-rls-authz.md`
+**Reviewed baseline:** `origin/main` at `0f05c1faa274f9c49b96ef57b829d9dbf2989477`
+
+## Objective
+
+Separate high-trust PAM decisions and cross-user/operational data reads from generic device or AI
+permissions. Preserve current tenant/site isolation while adding the missing capability boundaries.
+
+## Canonical permissions
+
+Add the following permission literals and idempotent permission/role migrations:
+
+| Capability | Permission |
+|---|---|
+| Approve/deny PAM elevation | `pam:approve` |
+| Create/update/delete PAM rules | `pam:manage_policy` |
+| Read another user's AI transcript | `ai:audit` |
+| Read alert summary/counts | existing `alerts:read` |
+| Read patch catalog/job metadata | `patches:read` |
+
+Partner Admin retains full access through its administrative grant. PAM approver and policy-admin
+permissions are assigned only to built-in roles whose product contract requires them. Ordinary
+technicians with `devices:execute` or `devices:write` do not inherit PAM authority. Existing custom
+roles receive no new permission automatically.
+
+## PAM approval — SR1-13
+
+Approval/denial routes require `pam:approve`, MFA, current request visibility, and the existing
+approval-policy rules. The request creator cannot approve their own elevation where maker/checker
+separation applies. The approver must remain distinct and authorized at the moment of decision.
+
+Generic device execution may remain necessary to perform the eventual authorized elevation, but it
+is neither sufficient nor a substitute for approver authority. Approval state transitions use an
+expected-state predicate so concurrent decisions cannot both succeed.
+
+Audit events record request, device/org, requester, approver, decision, policy reason, and bounded
+duration without command secrets or credential material.
+
+## PAM policy administration — SR1-14
+
+PAM rules are organization-scoped. Create/update/delete requires `pam:manage_policy`, existing MFA,
+and authoritative org/site access. This wave does not convert rules to partner scope or change their
+RLS tenancy shape.
+
+Rule changes retain validation and approval/review controls. Updates and deletes load the current
+rule inside the mutation transaction, authorize its persisted org/site, and audit bounded
+before/after conditions/actions. Request-supplied org IDs cannot move a rule across an unauthorized
+axis.
+
+## AI transcripts — SR1-20
+
+AI session lists and transcript-by-ID reads are owner-readable by default:
+
+```text
+session.user_id = auth.user.id
+```
+
+Cross-user reads require `ai:audit` in addition to ordinary AI read access and current org/partner
+scope. Query predicates include ownership unless the audited branch is active; checking after an
+unscoped lookup is not acceptable. Missing/foreign sessions return the established not-found
+response to avoid enumeration.
+
+List DTOs do not expose other users' session IDs, prompts, tool payloads, or cost metadata to
+owner-only callers. Cross-user audit reads emit a bounded audit event identifying reviewer, subject,
+session ID, and reason/outcome without copying transcript content.
+
+## Alert summary — SR1-28
+
+The alert summary endpoint requires live `alerts:read` permission. Its counts and groupings use the
+same organization/site/status predicate as the corresponding alert list for that caller. A summary
+cannot be broader than the rows the caller could enumerate.
+
+Missing permission denies before aggregate queries. Empty authorized scope returns zero-valued
+counts rather than global data.
+
+## Patch catalog and job metadata — SR1-29
+
+Patch catalog and job/operation metadata require `patches:read`. Device-derived job rows additionally
+join the authoritative device and apply current org/site visibility. Partner-global catalog facts
+that contain no tenant/device state may be returned with `patches:read`; rollout/job counts and
+device identifiers remain scope-narrowed.
+
+Mutation permissions are unchanged by this finding. Read DTOs minimize command payloads, hidden
+device identifiers, and provider/internal error text.
+
+## Middleware and service defense
+
+HTTP routes use live `requirePermission` middleware. Shared services accept subject/owner and
+accessible-axis inputs or perform an equivalent defense when reachable from AI/MCP/background entry
+points. Static route tests prove permission checks are live rather than comments or dead helper
+branches.
+
+## Rollout
+
+Custom roles lacking the new permissions lose formerly implicit PAM/cross-user/patch read access.
+Release notes must list the exact permission keys and recommended role review. Permission migrations
+are additive; no table migration or RLS change is expected.
+
+Rollback can broaden access again and should not remove additive permission rows. Role grants may be
+adjusted independently after deployment.
+
+## Verification
+
+- Permission registry/seed tests prove uniqueness and conservative built-in assignments.
+- PAM matrices cover generic device-only roles, approver/policy roles, MFA, maker/checker, wrong org,
+  hidden site, concurrent decision, and success.
+- AI tests cover owner list/read, foreign ID, audit permission, wrong org, and no ID enumeration.
+- Alert summary tests prove permission denial and exact list/aggregate scope parity.
+- Patch tests cover global catalog facts, device-derived jobs across visible/hidden sites, empty scope,
+  and minimized DTOs.
+- Audit tests assert exact event count and absence of transcript/credential/command secrets.
+- API typecheck/build, route scans, permission migrations, focused integration tests, and
+  `git diff --check` pass.
+
+## Non-goals
+
+- Changing PAM rule tenancy from organization to partner.
+- Granting PAM authority to every role that can execute or edit devices.
+- Making AI transcripts broadly readable inside an organization.
+- Exposing hidden-device counts through alert or patch aggregates.

--- a/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-08-ticket-financial-audit-design.md
+++ b/docs/superpowers/specs/security-auth/2026-07-11-security-review-wave-08-ticket-financial-audit-design.md
@@ -1,0 +1,149 @@
+# Security Review Wave 8: Ticket Financial Audit Coverage Design
+
+**Date:** 2026-07-11
+**Status:** Approved for planning
+**Finding:** SR1-24
+**Source:** `internal/security-findings/2026-07-11-playbook-01-multi-tenant-rls-authz.md`
+**Reviewed baseline:** `origin/main` at `0f05c1faa274f9c49b96ef57b829d9dbf2989477`
+
+## Objective
+
+Make every ticket-part financial mutation inseparable from an append-only audit record while
+preserving the existing ticket-parts HTTP contract and organization/site authorization.
+
+## Current boundary
+
+`apps/api/src/routes/tickets/parts.ts` supplies an actor to `addTicketPart`, `updateTicketPart`, and
+`deleteTicketPart`. The service currently ignores the actor on update/delete and performs part writes
+without a durable audit event. Update/delete also load the current row before a separate write,
+allowing the financial before-state to change between capture and mutation.
+
+Ticket parts remain organization-scoped with forced RLS. This wave adds atomic audit coverage rather
+than changing tenancy or permissions.
+
+## Atomic audit architecture
+
+Extend the audit service with a transaction-aware insert that shares the existing payload sanitizer
+and append-only schema:
+
+```ts
+async function createAuditLogInTransaction(
+  tx: DatabaseTransaction,
+  params: CreateAuditLogParams,
+): Promise<void>;
+```
+
+Each part service opens one transaction and performs authorization-compatible row access, mutation,
+and audit insert on that transaction. If either mutation or audit fails, both roll back. Fire-and-
+forget `writeAuditEvent` is not sufficient for this financial boundary.
+
+The transaction-aware helper does not weaken append-only protections and is not exported to request
+code as a general raw audit-table writer. It always sanitizes details and supplies the same actor,
+IP/user-agent snapshot, result, and initiated-by semantics as existing audit events.
+
+## Mutation contracts
+
+### Create
+
+Insert the part and then audit `ticket_part.created` in the same transaction. The event uses the
+returned part ID and authoritative ticket/org relationship. Failure to write the event rolls back
+the part.
+
+### Update
+
+Load and lock the current part with `FOR UPDATE`, authorize its authoritative ticket, calculate the
+validated update, write it with an expected row match, and audit `ticket_part.updated` with bounded
+before/after financial fields. A concurrent update serializes and captures the state it actually
+replaces.
+
+### Delete
+
+Load and lock the part, capture bounded fields and actor, delete it, and audit
+`ticket_part.deleted` before commit. The audit record survives the part deletion; a failed audit
+rolls back the delete.
+
+## Audit payload
+
+Common fields:
+
+```ts
+{
+  partnerId,
+  orgId,
+  ticketId,
+  partId,
+  actorUserId,
+  operation,
+  before?,
+  after?
+}
+```
+
+`before`/`after` are allowlists containing only:
+
+- `catalogItemId`
+- `partNumber`
+- `vendor`
+- `quantity`
+- `unitPrice`
+- `costBasis`
+- `isBillable`
+- `billingStatus`
+
+Description and notes are excluded because they may contain customer content and are not necessary
+for the financial trail. Numeric values use the persisted fixed-decimal string representation so
+the audit reflects exact stored amounts. Missing fields are omitted rather than serialized as an
+unbounded object diff.
+
+Audit `resourceType` is `ticket_part`, `resourceId` is the part UUID, and `resourceName` may use the
+bounded part number when present. Error payloads contain stable codes, not raw database or request
+bodies.
+
+## Actor and route integration
+
+The route continues deriving `TimeEntryActor` through `timeActorFrom(c)`, but the service must consume
+it for all three operations. Capture IP/user-agent request metadata before entering lower-level
+transactions if required by the audit helper. System/automation callers supply an explicit actor
+type rather than a fabricated user.
+
+Existing `tickets:write`, partner/system scope, scoped ticket lookup, validation, status codes, and
+response DTOs remain unchanged.
+
+## Error and retry behavior
+
+- Mutation failure: no audit success event and no data change.
+- Audit failure: mutation rolls back and the API returns a server error.
+- Duplicate client retry follows existing API semantics; the implementation does not introduce an
+  idempotency key. Each committed mutation has exactly one corresponding event.
+- Delete of a missing/inaccessible part retains the existing not-found behavior and emits no success
+  event.
+
+## Rollout
+
+This wave is additive and has no ticket-part data migration. If the transaction-aware audit helper
+requires a new index or constraint, add it through an idempotent date-prefixed migration without
+editing shipped audit migrations.
+
+Rollback removes new event production but must not delete existing audit rows or weaken append-only
+database protections.
+
+## Verification
+
+- Unit tests cover create/update/delete happy paths and exact allowlisted payloads.
+- Actor tests prove update/delete no longer discard the supplied actor.
+- Failure-injection tests prove audit failure rolls back each mutation and mutation failure writes no
+  success audit.
+- Real PostgreSQL concurrency tests prove two updates serialize and each audit before-state matches
+  the row it actually replaced.
+- Delete tests prove the audit survives deletion with captured financial state.
+- Multi-tenant/site tests prove cross-org or hidden-ticket parts remain inaccessible and unaudited.
+- Audit sanitizer/append-only integration tests remain green.
+- API typecheck/build, focused route/service tests, migration checks if applicable, and
+  `git diff --check` pass.
+
+## Non-goals
+
+- Changing ticket-part API schemas, permissions, pricing calculations, or invoice generation.
+- Storing free-form descriptions/notes in audit details.
+- Replacing the repository-wide audit subsystem with a new event platform.
+- Backfilling historical ticket-part changes that were never audited.

--- a/docs/testing/2026-07-27-prerelease-local-docker-test-log.md
+++ b/docs/testing/2026-07-27-prerelease-local-docker-test-log.md
@@ -1,0 +1,270 @@
+# Pre-release local docker test log — 2026-07-27
+
+**Scope:** everything merged to `main` since tag `v0.101.0`. This covers TWO untested releases' worth of change: the v0.102.0 contents (deployed to prod 2026-07-27 but never manually tested) plus everything merged after it — security waves 2/3/4/7 and today's PR-queue flush.
+
+**DO NOT COMMIT THIS FILE** (QA logs are local-only — leak risk from captured test data).
+
+Status legend: `[ ]` untested · `[x]` pass · `[!]` fail (file issue + note) · `[-]` skipped/n-a
+
+## SESSION RESULTS — 2026-07-28 (wt-stack on main @ dfcc8f6c6, NODE_ENV=development)
+
+**Verified PASS:**
+- [x] P0 boot: stack up with the 4 new env vars; all 6 containers healthy; `/health` 200. (P0b fail-closed: verified via CI evidence — smoke workflows on NODE_ENV=production died on the missing vars for 8h, booted after #2864. Dev stack can't exercise it: enforcement is production-only.)
+- [x] All 467 migrations incl. all 7 new ones applied on a fresh DB in one autoMigrate pass.
+- [x] Wave 3 login/token mint: login works, dashboard + seeded data render, zero console errors. (The mid-session logout was diagnosed as e2e-suite rate-limit collateral — refresh got 429, not a refresh regression. Token-refresh soak + role-change revocation still `[ ]`.)
+- [x] Org defaults editor (#2811+#2819 hand-merge): renders, enrollment-defaults section present, save persists to DB (`deviceGroup=Contractors` verified in psql).
+- [x] Enrollment TTL stack: Add Device modal both tabs have the expiry select; CLI tab 7-day TTL flows to DB (`expires_at - created_at` = 168h vs default 24h).
+- [x] Invoice editor (#2829): blank draft → manual line → autosave ("Saved" stamp) → totals correct in rail + sticky bar → taxable-no-rate warning → Issue → `status=sent, INV-2026-0001, 136.50` in DB.
+- [x] Analytics page renders with data (admin path, wave 2).
+- [x] Portal accept-invite ROUTE (#2825): portal-scoped API route mounted + reachable + proper JSON rejection of a bad token. Portal invite creates the `portal_users` row (`status=invited`).
+
+**FAIL / issues filed:**
+- [!] Org defaults device-group select rendered raw i18n keys (camelCase labelKeys vs PascalCase locale keys; pre-existing, live in prod too). Fix PR #2869.
+- [!] Portal accept-invite form: on island hydration failure, native GET submit puts the **password in the URL** and drops the token. Issue #2868. (Hydration failure itself = known dev-rig limitation; the fallback shape is the product concern.)
+- Minor observation (not filed): `/login?returnTo=%2Fdevices` lands on `/` after login, dropping returnTo.
+
+**Blocked in this rig `[-]`:**
+- Portal invite browser flow end-to-end (dev-rig island hydration 404 + in-memory portal tokens, `PORTAL_USE_REDIS=false` in development).
+- e2e suite: 7 passed; 13 failures diagnosed as environmental (parallel workers exhausted the IP-keyed login rate limiter — every client shares one IP behind caddy in dev — plus dev-mode compile timeouts and missing third-party-catalog seed data). Rerun serially (`pnpm wt-stack test -- --workers=1`) after clearing `login:*` keys in redis for a clean signal.
+
+## SESSION RESULTS — security-wave subagent sweep (live stack, main @ dfcc8f6c6)
+
+**Wave 7 (#2843) — ALL PASS.**
+- [x] Tenant/partner export: `GET /admin/tenant-export/:orgId` → 200, 257-table ZIP + manifest (sha256+rowCount); column preflight did NOT false-positive on current schema; `tenant.export` audit success row.
+- [x] Sensitive-download audit: `report.run.download` → 200; audit row `byteCount` exactly matches HTTP body (audit-after-byte-prep confirmed). Audit-failure-still-succeeds path = unit-test-only (can't throw live without code change).
+- [x] Public quote DTO + portal SSR: public API returns exactly `PublicQuoteHeader`'s 25 fields, no leaked internals; `/portal/quote/<token>` SSR renders full `PublicQuoteView` (lines, totals, accept/decline) — no missing-field errors, sent→viewed transition works.
+- [x] Route-template logging: all `route=` values are `:param` templates; 0 raw UUIDs in 20 min of logs; public accept JWT not logged.
+- [x] Time-entry audit org attribution correct.
+- **Two rig-seed gaps found (NOT wave bugs, but flag):** (a) dev seed admin lacks `is_platform_admin` (tenant-export needs it); (b) seeded Partner Admin role has NO `reports` role_permissions → report create 403s out of the box via the wave-3 live-authority resolver. Both worked once granted; worth confirming the PRODUCTION seed/role templates include reports perms so fresh partners aren't locked out of reporting.
+
+**#2828 (partner-axis system-context escape) — ALL PASS.** Proven with an org-scoped (`scope=organization`) token, and DB-proven that partner-axis rows are invisible to that scope without the escape (`partners`→0 rows under org GUCs).
+- [x] `GET /partner/me` 200 (was 404); ml-feature-flags all resolve `source:default` (no `org_not_found`); effective-settings 200; `PUT /ai/budget` 200.
+- [x] **Device cap behavior change**: set `max_devices=4` with 3 devices → provision #4 = 201, #5 = **403 DEVICE_LIMIT_REACHED** (was inert at org scope).
+- [x] **Step-up MFA fails closed**: enforcing policy → medium-tier L1 approve = **403 step_up_required** (was silent fail-open); low-tier still 200; deny still 200 (refusal never blocked).
+- [x] 45 min logs: zero RLS/42501 errors.
+- **Same seed gap as wave 7**: seeded Org Admin role lacks `organizations:read` — org admins 403 on their own effective-settings out of the box. Pre-existing RBAC/seed gap; confirm prod role templates.
+
+**Wave 2 (#2840) report scope — enforcement PASS, but ONE REAL BUG (#2874).**
+- [x] Admin create/run/download; site-scoped in-scope allow; out-of-scope hard-deny (404/403, no empty-success); scheduled reports still generate (fail-closed-before-generation regression NOT present — the highest-risk item is clean).
+- [!] **#2874 (code-verified, filed)**: `roleGrantsReportAction` (`siteScope.ts:650`, +:1052/:1123) filters permissions with a literal `eq(permissions.resource,'reports')` that never matches a `*|*` wildcard grant, while the canonical `services/permissions.ts:215` honors `*`. Consequence: the seeded **Partner Admin** super-role (natural state = `*|*` only) is **denied every report action** with 403 "Report scope is not authorized". This is the ROOT CAUSE of the "reports seed gap" the wave-7 and #2828 agents worked around — not three separate seed gaps, one wildcard divergence. Fix: honor `*` in the report authority check, or seed explicit `reports:*` on Partner Admin.
+
+**#2853 temp-password sealing — PASS (real mint untestable on this rig).**
+- [x] Sealing contract correct: credential never in `llmText`/model/transcript/`ai_messages`/`ai_tool_executions`/SSE; stored only as AES-256-GCM v3 AAD-bound ciphertext; one-time reveal via `/action-intents/:id/reveal-secret` with CAS burn; decrypt-failure returns 500 and does NOT burn the row (never burn what you can't return); uniform 404 (no oracle).
+- [x] DB-at-rest sweep: 0 plaintext rows across action_intents/ai_messages/ai_tool_executions/audit_logs; scrub migration applied.
+- [x] The PR's own tests: 255/255 unit + 6/6 real-Postgres integration pass. (Its merged-with-red-checks were the known lockfile dup + GO-2026-5051, not #2853.)
+- `[~]` A real provider-side mint (M365/Google) can't be exercised — no tenant wired, and **this local stack has no `APP_ENCRYPTION_KEY_ID`** so seal falls to the fail-closed "credential unavailable" branch (prod has `prod-1` per the deploy note). Durable-worker path proven fail-closed to the provider boundary; inline-chat path's secret tools aren't even registered without a connection.
+- **Local-QA gotcha to remember**: seal/encryption features need `APP_ENCRYPTION_KEY_ID` set on the api container (restart) to exercise the happy path locally; without it everything correctly takes the unavailable branch.
+
+**Wave 3 (#2841) live-authorization/revocation — PASS (1 tracking finding #2875).**
+- [x] Role change bumps `permissions_epoch` (all 4 migration triggers fire); permissions re-resolve live per request — old token got 403 on `POST /scripts` instantly after the change.
+- [x] Event-WS enforcement (`compat`): ticket consumed post-change → 4001 at open; held socket → **4003 "Access revoked" ~11s** after change (`permission_epoch_mismatch`).
+- [x] Explicit revocation (`DELETE /users/:id`): `auth_epoch` bumps, refresh family durably revoked, existing access+refresh tokens → 401 within the same second (redis cutoff hot-path).
+- [x] Refresh: 15m access TTL confirmed; rotation proven (jti + family); **reuse-detection** replay → 401 + family-wide durable kill + audit row.
+- [!] **#2875 (verified, filed, tracking-not-blocker)**: migration 2026-08-06-c's durable `quotes.public_response_*` columns have **no runtime writer** (0 code refs outside schema) — quote single-use is redis-only (`quote-accept-jti-revoked:<jti>`). Behavior correct today; durable authority the schema implies hasn't shipped. Likely intentional forward-prep per migration header.
+
+## SESSION RESULTS — live-agent round (Windows Server 2022 VM 100.101.150.55 over Tailscale)
+
+**Verified PASS:**
+- [x] **Enrollment end-to-end**: UI-minted CLI token + enrollment secret enrolled a real agent (`enroll --force` exit 0); device row created, **online**, heartbeating, agent 0.103.0-qa; inventory populated (135 processes, OS string, hardware).
+- [x] Remote Tools process manager: live process list streamed over the agent WS path.
+- [x] Terminal session ESTABLISHES: WS ticket mint → pre-upgrade validation → agent ConPTY spawn → banner delivered to browser xterm (the wave-4 handshake chain itself works).
+
+**FAIL — wave-4 regressions found (release blockers for remote terminal):**
+- [!] **#2870**: every `terminal_data` command executed TWICE on the agent (`component=websocket` + `component=heartbeat`, same commandId) → PTY input scrambled (`hostname` → `snehoe`); API logs `ws_result_terminal_cas` 0-row CAS writes. Dual-claim class (cf. #2407) resurfacing under #2842.
+- [!] **#2871**: terminal sessions die at exactly 60s (`pong timeout` / `revoked mid-session` — wave-3/4 ticket/lease renewal suspect) and the UI freezes silently: no disconnect banner, no reconnect.
+
+**Still untested:**
+- [ ] Remote DESKTOP connect/teardown (viewer WebRTC; blocked on fixing #2870/#2871 first — same relay machinery).
+- [ ] Wave 3: token-refresh soak past expiry; mid-session role-change revocation; event WS `compat`→`enforce` flip.
+- [ ] Wave 2: site-scoped user report run + scheduled report delivery.
+- [ ] #2828 org-scoped user smoke; #2781 offboarding drain (agent enrolled + ready for it — offboard a throwaway org, NOT Default Organization); wave 7 export + audit; #2806/#2812 AI drawer; #2804 winget ErrScanSkipped (Server 2022 has no winget — check the device's software scan status); #2853 temp-password sealing; locale spot-checks.
+
+**#2804 winget ErrScanSkipped — partial:** on the Server 2022 VM winget is never registered ("winget provisioning not yet implemented"), so the agent takes the *sibling* branch (unresolvable winget → not registered as a provider → third_party correctly NOT marked covered) — verified: no crash, 35 software_inventory rows still populated from other providers, no tombstoning. The #2804-specific branch (winget present but emits *unreadable table output* → `ErrScanSkipped` instead of empty) can't be reproduced on a box with no winget at all; that exact path stays unit-test-only. `[~]`
+
+## SESSION RESULTS — offboarding drain (#2781/#2808) + winget (#2804), live VM
+
+**#2804 winget ErrScanSkipped — now FULLY PASS** (agent planted a fake unreadable winget.exe to hit the exact branch):
+- [x] winget-absent: patch scan completes via WUA; targeted `third_party` scan fails explicitly (not empty-success).
+- [x] winget-present-but-unreadable-output (the #2804/#2726 trigger): full scan logs `partial coverage … uncoveredSources=[third_party]` (ErrScanSkipped firing); a pre-inserted `third_party` pending row SURVIVED (not tombstoned to missing) — the exact #2726 regression is fixed.
+
+**#2781/#2808 offboarding drain — core behavior PASS, but FOUR bugs found (2 blockers):**
+- [x] Core drain works when driven correctly: suspension severs the agent; **#2808 clears the superseded suspension on offboarding entry** (agent recovers, heartbeats through drain); auto-queued `self_uninstall` delivered + acked; non-allowlisted agent routes → **403 tenant_offboarding**; reaper finalizes fully-drained fleet → `churned`.
+- [!] **#2877 (BLOCKER)**: offboarding entry self-DEADLOCKS — request-txn holds the org row lock while `beginOrganizationOffboarding`'s nested `runOutsideDbContext(withSystemDbAccessContext)` UPDATEs the same row from a fresh connection. Wedges indefinitely; kill → torn entry (status rolled back, side effects committed). Code-verified (orgs.ts:1478-1490 + tenantOffboarding.ts:155). #1105 family.
+- [!] **#2878 (BLOCKER)**: Windows `self_uninstall` is a FALSE SUCCESS — `performSelfUninstall` runs `sc.exe stop BreezeAgent` (its own service) FIRST, killing the goroutine before `sc delete`/watchdog teardown/config removal. Agent left installed + auto-start + watchdog running + severed token → reboots into permanent 401s (#2796) while the drain reports clean. Code-verified (handlers_uninstall.go:218). Defeats the feature's whole purpose.
+- [!] **#2879**: suspended→offboarding is UNREACHABLE via API (`computeAccessibleOrgIds` filters `active`/`trial`; system admin fails requirePermission) — so #2808's fix can't be triggered on the real path (only via DB flip). Code-verified (auth.ts:271/286).
+- Minor (not filed separately, noted in #2877): `offboarding_completed` reported `uninstallsCompleted:0` despite a completed uninstall — JS-clock `drainStartedAt` vs DB-clock `created_at` gte with ~2ms skew.
+- **VM left in post-drain residual state** as evidence (agent stopped-but-installed, watchdog running); to reuse: fresh enroll into an active org + `Start-Service BreezeAgent`.
+
+**Rig state for the next session:** wt-stack up at `localhost:32773` (`.breeze-stack.json` has creds); VM .55 agent enrolled against `http://100.95.194.59:32773` (was previously on the backup-testing stack — re-point when done); scratch worktree branches cleaned; PR #2869 (i18n fix) merged.
+
+---
+
+## 0. Stack prerequisites (read before `docker compose up`)
+
+The next release is **NOT a rolling deploy** (wave 4 calls it a barrier deployment). The local stack must set **4 new hard-required env vars** (compose uses `:?` interpolation — the stack won't boot without them):
+
+```bash
+# .env additions for the local stack (recommended initial values)
+EVENT_PERMISSION_EPOCH_MODE=compat          # wave 3; switch to 'enforce' as a separate test
+REMOTE_ACCESS_ADMISSION_MODE=open           # wave 4; prod will start 'closed' — test both
+REMOTE_WS_AUTH_MODE=post_upgrade            # wave 4; test 'pre_upgrade' too
+REMOTE_WS_REDIS_TOPOLOGY=standalone-single-primary
+```
+
+Conditional/optional new vars (defaults exist): `OAUTH_AUTH_EPOCH_ENFORCE_AFTER` (required only when OAuth enabled in prod/staging), `REMOTE_WS_LEGACY_TICKET_WRITER_DRAINED_AT`, `REMOTE_WS_LEGACY_VIEWER_ISSUER_DRAINED_AT`, `OFFBOARDING_DRAIN_WINDOW_HOURS` (default 72), `CHILD_ENROLLMENT_KEY_TTL_MINUTES`, `INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES`, `INSTALLER_PARENT_MIN_REMAINING_SECONDS`, `ENROLLMENT_KEY_CLEANUP_ENABLED`, `ENROLLMENT_KEY_PURGE_AFTER_DAYS`, `ABUSE_SCRIPT_INDICATORS`.
+
+- [ ] **P0. Boot check:** stack boots with the 4 vars set. (Already evidenced in CI: the two smoke-binary-source workflows died at API startup for 8+ hours because wave 4 didn't add these vars to them — fixed by #2864. Any production-mode boot without them refuses to start, so a droplet deploy missing them = hard outage.)
+- [ ] **P0b. Fail-closed check:** remove one required var → API refuses to boot with the aggregated boot-report error (not a silent start, not an import-time stack trace).
+- [ ] **P0c. Dev-compose sanity (#2802):** dev override mode (`docker-compose.override.yml.dev`) comes up clean after the stale `tailwind.config.mjs` bind-mount removal — this is the stack you're testing in, so do it first.
+
+## 1. Migrations — apply all 7 in one pass (P0)
+
+On a v0.101.0-shaped DB, one `autoMigrate` pass must apply cleanly; re-run must be a no-op. As `breeze_app`-connected API (not superuser psql).
+
+| Migration | From |
+|---|---|
+| `2026-07-25-partner-billing-identity.sql` | #2799 |
+| `2026-07-25-abuse-script-hosts.sql` | #2782 |
+| `2026-08-05-offboarding-drain-state.sql` | #2781 |
+| `2026-08-05-metric-rollup-partition-maintenance-privileges.sql` | #2786 |
+| `2026-08-06-a-report-site-scope.sql` | wave 2 #2840 |
+| `2026-08-06-b-live-authorization.sql` | wave 3 #2841 — triggers + new RLS table `oauth_revocation_retries` |
+| `2026-08-06-c-quote-response-capability.sql` | wave 3 #2841 |
+
+- [ ] All apply on first boot; `breeze_migrations` shows all 7.
+- [ ] Second boot: no-op, no NOTICE/ERROR noise.
+
+## 2. Auth hot path — wave 3 (#2841) — HIGHEST RISK
+
+Every request crosses this. A regression = total outage.
+
+- [ ] Login → browse → token refresh → logout (Playwright: standard login flow).
+- [ ] Role change mid-session: change a logged-in user's role as admin → their session/permissions actually revoke (epoch advance via the new DB triggers).
+- [ ] Event WebSocket (live device status updates in UI) stays connected under `EVENT_PERMISSION_EPOCH_MODE=compat`.
+- [ ] Flip to `enforce`, restart API: event WS reconnects and works; stale sockets close on permission change.
+- [ ] MCP OAuth flow if enabled locally (token refresh, revocation).
+
+## 3. Remote desktop / terminal — wave 4 (#2842) — HIGHEST RISK
+
+Real agent↔API↔viewer WS handshakes — unit tests cannot cover this. Needs a real enrolled agent (local VM or the Windows test box).
+
+- [ ] Remote desktop: connect → interact → clean disconnect → reconnect.
+- [ ] Remote terminal session end-to-end.
+- [ ] Tunnel (if practical locally).
+- [ ] Abrupt viewer close (kill the tab) → desktop teardown finalizes on the agent (no orphaned session; reconnect works).
+- [ ] Repeat connect under `REMOTE_ACCESS_ADMISSION_MODE=closed` and `REMOTE_WS_AUTH_MODE=pre_upgrade` (the prod target modes).
+
+## 4. Reports — wave 2 (#2840)
+
+- [ ] Create/run/download a report as an org-scoped user.
+- [ ] Same as a **site-scoped** user — allowed within scope, denied outside (fail-closed must not break legitimate runs).
+- [ ] A scheduled report still generates and delivers.
+- [ ] Analytics page renders for a site-scoped tech (`AnalyticsPage.tsx` changed).
+
+## 5. Offboarding drain — #2781 + #2808
+
+Zero prod exercise. Pair test.
+
+- [ ] Transition a seeded org to `offboarding` in the UI.
+- [ ] User sessions/API keys die on entry (proactive revocation).
+- [ ] Agent keeps heartbeating/polling; queued `self_uninstall` is delivered.
+- [ ] Non-allowlisted agent routes return `403 tenant_offboarding`.
+- [ ] #2808 specifically: a tenant that was **suspended first, then moved to offboarding** — the superseded token suspension is cleared so the drain actually works.
+
+## 6. Enrollment TTL stack — #2816/#2817/#2818/#2819 + today's #2813
+
+One combined flow (this is the agent-onboarding critical path):
+
+- [ ] Partner settings: set enrollment default TTL/device-count + a TTL cap; org tab shows the inherited cap read-only (#2819).
+- [ ] Add Device modal (installer tab) seeds pickers from defaults, filters options above the cap.
+- [ ] **CLI Commands tab**: expiry select present and honored — `ttlMinutes` reaches the API (#2816 + #2813).
+- [ ] Over-cap mint → 400 naming the cap (#2818).
+- [ ] Long-TTL link: bootstrap token `expires_at` in DB is independent of the 60-min parent key (#2817; psql check).
+- [ ] **First-run guided setup enroll step** (empty-body POST regression risk called out in #2816).
+- [ ] End-to-end: enroll a real agent through a minted link.
+
+## 7. Portal — wave 7 (#2843) + #2825
+
+- [ ] Public quote page renders correctly (exact DTO change; portal has had render-parity gaps).
+- [ ] Quote accept/decline one-time response works; second attempt rejected (quote response capability migration).
+- [ ] **Portal invite** (#2825): invite a portal user from admin → accept-invite page → set password → logged in. (Was 100% broken before — posted to the admin route.)
+
+## 8. Org-scoped user smoke — #2828
+
+Partner-axis reads escaped to system RLS context; several silent zero-row bugs fixed, one behavior change.
+
+- [ ] Log in as an **org-scoped** (not partner-scoped) user: settings pages, AI-for-Office admin, effective settings all load (previously silent 404/empty).
+- [ ] Step-up MFA at org scope now fails **closed** — verify a step-up-gated action still works for a properly-MFA'd org user.
+- [ ] Device provision at the partner device cap → now actually rejected (was inert). Verify normal provisioning still works under cap.
+
+## 9. Exports + audit — wave 7 (#2843)
+
+- [ ] Partner/tenant export completes (column preflight + classification).
+- [ ] A sensitive download succeeds and produces an audit row (audit failure must never block an authorized download).
+
+## 10. Web UI spot-checks (today's merges)
+
+- [ ] Toasts appear after mutations across islands (#2807 — globalThis emitter; regression: swallowed toasts).
+- [ ] Org defaults save no longer 403s when a partner-locked field is present (#2811). Because #2811 was hand-merged with #2819's enrollment-defaults work in the same files, verify the combined editor thoroughly: locked fields render disabled + seeded from the partner's effective value, the partner cap notice still shows, enrollment TTL/device-count pickers still work, and a save with a partner-locked field present succeeds while changing a locked field still 403s.
+- [ ] AI drawer: search trigger label + heading order (#2806) — visual.
+- [ ] Localized page with glued JSX strings renders correct interpolation (#2809) — check a non-English locale.
+- [ ] AI chat: vulnerability tools are callable (#2812 — ask the chat a CVE question against a device).
+- [ ] General web build smoke after vite 8.1.5 (if merged) — no blank pages/console errors.
+- [ ] `/partners/me` projection (#2779): partner settings page renders (low priority — prod-exercised).
+- [ ] Invoice editor on the quote save grammar (#2829, MERGED): create/edit an invoice — autosave behavior, line add/remove (totals must update immediately during the delete-undo window), org combobox, Issue/send flow; specifically try to Issue while a field save is failing/pending → must be refused naming the field (the review-round bug). Spot-check one non-English locale (fr-CA/it-IT translations were agent-written).
+- [ ] Linked Profiles tab hidden on unlinked devices (#2867): device details for a device with no linked profiles → tab absent; with profiles → present.
+
+## 11. Not testable in local docker / defer
+
+- Agent Windows-specific: winget ErrScanSkipped (#2804) — needs Windows box, unit-covered.
+- Agent auth-dead backoff cap (#2793), backup helper logs (#2801) — unit-covered; observe on next agent deploy.
+- Wave 1 (#2800) — CI-only; its verification is CI being green.
+- Internal ops surfaces (#2778, #2780, #2782, #2795, #2799) — CI + migration apply only.
+- **Mobile**: #2833 (expo-sdk group) merged today; per the SDK-57 drift record the iOS native build is already broken by past bumps and nothing in CI builds native — needs an `expo install --check` alignment pass before the next TestFlight archive. Not part of this docker release.
+
+## 12. Post-release PROD checks (not local — schedule after deploy)
+
+- [ ] Tonight's metric-rollup partition maintenance runs without 42501 on US+EU (#2786 — first-ever successful run expected; retention has never run).
+- [ ] First nightly `enrollmentKeyCleanup` respects the live-token exemption (#2817).
+- [ ] Barrier-deploy sequencing for wave 4 (post-deployment steps 3–6 of its Task 10) + `OAUTH_AUTH_EPOCH_ENFORCE_AFTER` timing rule (≥1800s after new token writers start, choose once, never extend).
+- [ ] The 4 required env vars added to `/opt/breeze/.env` **and** mapped in the compose `environment:` blocks on both droplets (necessary-but-not-sufficient rule).
+
+---
+
+## Appendix: merged today (2026-07-27 queue flush)
+
+By me (staggered admin-squash, all reviewed via issue-fixer review summaries or dedicated review rounds):
+#2852, #2791, #2831, #2830, #2828 (batch 1) · #2793, #2801, #2802, #2803, #2804, #2808, #2810 (batch 2) · #2806, #2807, #2809, #2812 (batch 3) · #2859 (lockfile hotfix) · #2811 + #2805 (rebased/conflict-resolved) · #2861 (govulncheck allowlist + Type Check repair) · #2864 (smoke-binary-source env fix, subagent) · #2829 (invoice editor — subagent fixed its locale-parity red, full review round found + fixed a queued-Issue money bug before merge) · #2849 (vite 8.1.5) + #2839 (react group) via dependabot rebase-first protocol, lockfile dup-scanned clean after each.
+
+By Todd in parallel (GitHub UI): #2833, #2835, #2836, #2837, #2838, #2844, #2845, #2846, #2847, #2848, #2853, #2825.
+
+Closed without merge: #2813 (fully superseded by #2816, already on main).
+
+Incidents during the flush:
+1. Parallel admin-merges of #2845/#2846 while behind main 3-way-merged `pnpm-lock.yaml` and duplicated hono/postcss blocks → every JS CI job red at Install. Fixed forward by #2859 (surgical dedup). Recurrence of #1792/#2056/#2271.
+2. **GO-2026-5051** published mid-flush: go-smb2 `ReadDir` OOB-read/panic advisory with NO fixed release → Go Vulnerability Check red repo-wide. Fixed by #2861: recover guard in `smbFS.ReadDir` + govulncheck allowlist wrapper (`scripts/security/run-govulncheck.sh` + `govulncheck-allowlist.txt`), tracking issue #2860. This explains most of #2853's "red checks" too.
+3. #2811 (value-based `assertNotLocked`) and #2828 (partner-axis integration suite using the old signature) were individually green but incompatible on main → Type Check red; also #2811's typed `isLocked` collided with #2819's cap-notice call. Both repaired in #2861.
+
+**Note on #2853 (merged with red checks):** its Go Vulnerability Check / branch Security Scanning failures were NOT diagnosed before Todd merged it. The `smoke-binary-source-*` failures pre-exist on main, but the Go vuln check needs a follow-up look — if the next Security Scanning run on main is red on Go Vulnerability Check, that's the place to start. Its feature (sealing AI-minted temp passwords in action-intents) should get a manual pass: run an AI temp-password intent end-to-end and confirm the password is sealed in both execution paths.
+
+## Appendix: held PRs (NOT in this release until resolved)
+
+- #2826 — partner-api enrollment-keys (community, obsidiangroup): no CI checks ran; unreviewed. Review before any merge.
+- #2834 — react-native-animation bump: mobile-only, no native CI coverage (expo drift). Mobile ships separately; not a blocker for this docker release.
+
+## SESSION RESULTS — 2026-07-28 post-fix merge + live re-verification (wt-stack on main, VM .70)
+
+All 8 QA-filed issues driven to reviewed PRs, merged (staggered admin-squash, CI green or rerun-verified per PR), and the two release-blocker fixes re-verified live:
+
+**Merged:** #2884(→#2868) · #2885(→#2874) · #2886(→#2878) · #2887(→#2879) · #2888(→#2875) · #2889(→#2870) · #2890(→#2877) · #2892(→#2871). All issues auto-closed via Closes keywords (verified).
+
+**Live re-verification (VM .70 WIN-IMDR2GAIDMV — .55 was half-dead: tailscale pings but SSH+RDP down, needs console):**
+- [x] **Terminal ordering (#2870/#2889)**: `hostname` char-by-char → clean echo, correct output; 33-char rapid burst character-perfect; agent log shows exactly one dispatch+process per commandId (new `term-data-<ms>-<seq>` ids).
+- [x] **Terminal 60s survival (#2871/#2892)**: session responsive at 1m51s+ (old bug killed at exactly 60s); zero orphan_recovery/pong-timeout lines in API logs.
+- [x] **Offboarding deadlock (#2877/#2890)**: suspended→offboarding entry PATCH returned 200 in 0.107s (pre-fix: infinite wedge); self_uninstall queued in the same second (atomic entry).
+- [x] **Windows self_uninstall (#2878/#2886)**: REAL teardown verified — both services DELETED, agent+watchdog binaries REMOVED, ProgramData\Breeze REMOVED, zero breeze processes, no watchdog respawn; `offboarding_completed` audit row shows `uninstallsCompleted:1, failed:0` (count fix confirmed); reaper finalized org → churned.
+- Rig note: an initial no-echo terminal was a rig artifact (agent service restarted mid-session during setup → in-memory session map wiped; UI stayed "Connected" while writes failed "session not found"). Underlines the pre-existing follow-up: terminalWs ignores sendCommandToAgent returns on data/resize.
+
+**VM .70 state**: was prod-enrolled (2breeze.app) before QA; prod agent.yaml backup was lost (stored inside ProgramData\Breeze, which the uninstall correctly deletes). Restored to ready-to-enroll: prod-version binaries back in `C:\Program Files\Breeze`, services recreated Stopped/Manual. To return to prod: mint a prod enrollment key, `breeze-agent.exe enroll <key> --server https://2breeze.app --enrollment-secret <secret>`, set services Automatic, start.
+
+**Not re-tested live** (unit/integration-covered only): remote desktop under the new admission modes; #2885/#2887/#2888/#2884 (API/UI-level fixes, CI-verified).


### PR DESCRIPTION
## What this is

18 design/plan documents that describe **work which already shipped** — but the documents themselves never landed on `main`. They existed only as uncommitted or untracked files inside local worktrees.

A routine `git worktree remove` would have destroyed all of them silently. No commit, no branch, no reflog entry to recover from. They were found during a worktree audit that removed 137 stale worktrees.

## Contents

| Group | Files | Note |
|---|---|---|
| Security-review remediation **waves 02–08** | 14 | plan + design pairs. Main has only the consolidated `2026-07-11-security-review-remediation-design.md`; the per-wave breakdowns were never committed. |
| Partner SSO login-branding | 2 | plan + design. Its siblings (`sso-admin-gating`, `sso-domain-verification-backend`) are already on main; this pair wasn't. |
| Remote-access provider-preference handoff | 1 | #3391 merged the backend; this records the missing profile UI plus three spun-off problems (leaky device-detail path, missing provider-ID validation, JSON-blob provider keying). |
| 2026-07-27 prerelease local-Docker test log | 1 | |

Filed into the domain folders introduced by #2708, not the flat paths they were authored against.

## Deliberately excluded

- **6 salvaged docs already on main** under domain folders. My first pass checked flat paths (`docs/superpowers/plans/<file>`) and wrongly reported them missing; a basename sweep across all of `docs/` found them. Committing those would have created duplicates.
- `RELEASE-TEST-PLAN-v0.104.md` — superseded, v0.104 shipped long ago.
- Scratch API dumps (`orgs-list-response.json`, `snap1.yml`, `device-after-runscript.yml`).
- Two `FEATURE_TEST_LOG.md` diffs. Their base has diverged from main; appending them automatically risks mangling the log, so they need a human merge and are held outside the repo.

Docs-only — no code, no CI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)