### PR TITLE
feat(web,api): booking link on the pending-account screen so the payment wall isn't a dead end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -733,6 +733,12 @@ SESSION_SECRET=another-secret-for-sessions-change-in-production
 # value at runtime from GET /api/v1/config, so a plain restart applies a change
 # with no web rebuild (the old build-time PUBLIC_ENABLE_REGISTRATION is gone).
 ENABLE_REGISTRATION=false               # gates both the API endpoints and the "Register your MSP" UI
+# Optional scheduling link shown to pending (not-yet-activated) partners on the
+# /account/inactive screen next to the billing CTA, so stopping at the payment
+# step isn't a dead end. Must be an absolute http(s) URL; label defaults to
+# "Book a call with us".
+# PENDING_ACCOUNT_MEETING_URL=https://your-scheduler.example.com/intro-call
+# PENDING_ACCOUNT_MEETING_LABEL=
 ENABLE_2FA=true
 # Interactive Swagger UI at /docs (loads scripts/styles from unpkg). Defaults to
 # ON outside production and OFF in production; the raw OpenAPI spec at /docs is

--- a/apps/api/src/routes/partner.test.ts
+++ b/apps/api/src/routes/partner.test.ts
@@ -135,6 +135,61 @@ describe('partner routes', () => {
 
       expect(res.status).toBe(404);
     });
+
+    const mockPartnerRow = (settings: Record<string, unknown> = {}) => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'partner-123',
+              name: 'Acme MSP',
+              slug: 'acme',
+              status: 'pending',
+              settings,
+            }]),
+          }),
+        }),
+      } as any);
+    };
+
+    it('surfaces the configured meeting link for pending partners', async () => {
+      vi.stubEnv('PENDING_ACCOUNT_MEETING_URL', ' https://calendly.example.com/breeze ');
+      vi.stubEnv('PENDING_ACCOUNT_MEETING_LABEL', 'Book a demo');
+      try {
+        mockPartnerRow();
+        const res = await app.request('/partner/me', {
+          headers: { Authorization: 'Bearer token' },
+        });
+        expect(await res.json()).toMatchObject({
+          statusMeetingUrl: 'https://calendly.example.com/breeze',
+          statusMeetingLabel: 'Book a demo',
+        });
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('drops a non-http(s) meeting URL and nulls when unset', async () => {
+      vi.stubEnv('PENDING_ACCOUNT_MEETING_URL', 'javascript:alert(1)');
+      try {
+        mockPartnerRow();
+        const res = await app.request('/partner/me', {
+          headers: { Authorization: 'Bearer token' },
+        });
+        expect(await res.json()).toMatchObject({
+          statusMeetingUrl: null,
+          statusMeetingLabel: null,
+        });
+      } finally {
+        vi.unstubAllEnvs();
+      }
+
+      mockPartnerRow();
+      const res = await app.request('/partner/me', {
+        headers: { Authorization: 'Bearer token' },
+      });
+      expect(await res.json()).toMatchObject({ statusMeetingUrl: null });
+    });
   });
 
   it('returns partner dashboard customer payload', async () => {

--- a/apps/api/src/routes/partner.ts
+++ b/apps/api/src/routes/partner.ts
@@ -7,6 +7,24 @@ import { authMiddleware, requirePermission, requireScope } from '../middleware/a
 import { PERMISSIONS } from '../services/permissions';
 
 export const partnerRoutes = new Hono();
+
+/**
+ * Operator-configured scheduling link shown to inactive (pending) partners next
+ * to the billing CTA so the payment wall is never a dead end. Env-driven so the
+ * link can change without a deploy (same rationale as
+ * SIGNUP_BUSINESS_EMAIL_CONTACT_URL). Non-http(s) values are dropped here so no
+ * client has to trust the value.
+ */
+export function pendingAccountMeetingUrl(): string | null {
+  const raw = process.env.PENDING_ACCOUNT_MEETING_URL?.trim();
+  if (!raw) return null;
+  try {
+    const { protocol } = new URL(raw);
+    return protocol === 'http:' || protocol === 'https:' ? raw : null;
+  } catch {
+    return null;
+  }
+}
 const requirePartnerDashboardRead = requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action);
 const requirePartnerDeviceRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
 
@@ -66,6 +84,8 @@ partnerRoutes.get('/me', async (c) => {
     statusMessage: (settings.statusMessage as string) ?? null,
     statusActionUrl: (settings.statusActionUrl as string) ?? null,
     statusActionLabel: (settings.statusActionLabel as string) ?? null,
+    statusMeetingUrl: pendingAccountMeetingUrl(),
+    statusMeetingLabel: process.env.PENDING_ACCOUNT_MEETING_LABEL?.trim() || null,
   });
 });
 

--- a/apps/web/src/components/auth/AccountInactiveScreen.test.tsx
+++ b/apps/web/src/components/auth/AccountInactiveScreen.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authMocks = vi.hoisted(() => ({
+  fetchWithAuth: vi.fn(),
+  logout: vi.fn(),
+}));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: authMocks.fetchWithAuth,
+  useAuthStore: (selector: (s: { logout: () => void }) => unknown) =>
+    selector({ logout: authMocks.logout }),
+}));
+
+import AccountInactiveScreen from './AccountInactiveScreen';
+
+function mockPartnerMe(body: Record<string, unknown>) {
+  authMocks.fetchWithAuth.mockResolvedValue({
+    ok: true,
+    json: async () => body,
+  });
+}
+
+describe('AccountInactiveScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the booking link next to the billing CTA for a pending partner', async () => {
+    mockPartnerMe({
+      status: 'pending',
+      statusMessage: 'Pick a plan to activate your account.',
+      statusActionUrl: 'https://billing.example.com/checkout',
+      statusActionLabel: 'Choose a plan',
+      statusMeetingUrl: 'https://calendly.example.com/breeze',
+      statusMeetingLabel: null,
+    });
+
+    render(<AccountInactiveScreen />);
+
+    const booking = await screen.findByRole('link', { name: 'Book a call with us' });
+    expect(booking).toHaveAttribute('href', 'https://calendly.example.com/breeze');
+    expect(screen.getByRole('link', { name: 'Choose a plan' })).toHaveAttribute(
+      'href',
+      'https://billing.example.com/checkout',
+    );
+  });
+
+  it('still offers the booking link when the billing hook never supplied a CTA (stranded state)', async () => {
+    mockPartnerMe({
+      status: 'pending',
+      statusMessage: null,
+      statusActionUrl: null,
+      statusActionLabel: null,
+      statusMeetingUrl: 'https://calendly.example.com/breeze',
+      statusMeetingLabel: 'Talk to Todd',
+    });
+
+    render(<AccountInactiveScreen />);
+
+    expect(await screen.findByRole('link', { name: 'Talk to Todd' })).toHaveAttribute(
+      'href',
+      'https://calendly.example.com/breeze',
+    );
+  });
+
+  it('does not show the booking link for suspended partners or unsafe URLs', async () => {
+    mockPartnerMe({
+      status: 'suspended',
+      statusMessage: 'Suspended',
+      statusActionUrl: null,
+      statusActionLabel: null,
+      statusMeetingUrl: 'https://calendly.example.com/breeze',
+      statusMeetingLabel: null,
+    });
+
+    const { unmount } = render(<AccountInactiveScreen />);
+    await waitFor(() => expect(authMocks.fetchWithAuth).toHaveBeenCalled());
+    expect(screen.queryByRole('link', { name: 'Book a call with us' })).toBeNull();
+    unmount();
+
+    mockPartnerMe({
+      status: 'pending',
+      statusMessage: null,
+      statusActionUrl: null,
+      statusActionLabel: null,
+      statusMeetingUrl: 'javascript:alert(1)',
+      statusMeetingLabel: null,
+    });
+
+    render(<AccountInactiveScreen />);
+    await waitFor(() => expect(screen.queryByText('Almost There!')).not.toBeNull());
+    expect(screen.queryByRole('link', { name: 'Book a call with us' })).toBeNull();
+  });
+});

--- a/apps/web/src/components/auth/AccountInactiveScreen.tsx
+++ b/apps/web/src/components/auth/AccountInactiveScreen.tsx
@@ -12,6 +12,8 @@ interface StatusInfo {
   message: string | null;
   actionUrl: string | null;
   actionLabel: string | null;
+  meetingUrl: string | null;
+  meetingLabel: string | null;
 }
 
 function isSafeUrl(url: string): boolean {
@@ -52,6 +54,8 @@ export default function AccountInactiveScreen() {
           message: data.statusMessage ?? defaultMessages[data.status] ?? t('accountInactive.defaultMessages.generic', { defaultValue: 'Your account is not active.' }),
           actionUrl: data.statusActionUrl,
           actionLabel: data.statusActionLabel,
+          meetingUrl: data.statusMeetingUrl,
+          meetingLabel: data.statusMeetingLabel,
         });
       })
       .catch(() => {
@@ -60,6 +64,8 @@ export default function AccountInactiveScreen() {
           message: t('accountInactive.defaultMessages.loadFailed', { defaultValue: 'Unable to load account status. Please try again later.' }),
           actionUrl: null,
           actionLabel: null,
+          meetingUrl: null,
+          meetingLabel: null,
         });
       })
       .finally(() => setLoading(false));
@@ -103,6 +109,16 @@ export default function AccountInactiveScreen() {
               className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-xs hover:bg-primary/90"
             >
               {info.actionLabel ?? t('accountInactive.takeAction', { defaultValue: 'Take Action' })}
+            </a>
+          )}
+          {info?.status === 'pending' && info.meetingUrl && isSafeUrl(info.meetingUrl) && (
+            <a
+              href={info.meetingUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+            >
+              {info.meetingLabel ?? t('accountInactive.bookMeeting', { defaultValue: 'Book a call with us' })}
             </a>
           )}
           <button

--- a/apps/web/src/locales/de-DE/auth.json
+++ b/apps/web/src/locales/de-DE/auth.json
@@ -16,6 +16,7 @@
     "setPasswordAndSignIn": "Passwort festlegen und anmelden"
   },
   "accountInactive": {
+    "bookMeeting": "Termin mit uns vereinbaren",
     "defaultMessages": {
       "churned": "Ihr Konto ist nicht mehr aktiv. Wenden Sie sich an den Support.",
       "generic": "Ihr Konto ist nicht aktiv.",

--- a/apps/web/src/locales/en/auth.json
+++ b/apps/web/src/locales/en/auth.json
@@ -16,6 +16,7 @@
     "setPasswordAndSignIn": "Set password & sign in"
   },
   "accountInactive": {
+    "bookMeeting": "Book a call with us",
     "defaultMessages": {
       "churned": "Your account is no longer active. Please contact support.",
       "generic": "Your account is not active.",

--- a/apps/web/src/locales/es-419/auth.json
+++ b/apps/web/src/locales/es-419/auth.json
@@ -16,6 +16,7 @@
     "setPasswordAndSignIn": "Establecer contraseña e iniciar sesión"
   },
   "accountInactive": {
+    "bookMeeting": "Agende una llamada con nosotros",
     "defaultMessages": {
       "churned": "Su cuenta ya no está activa. Por favor contacte al soporte.",
       "generic": "Su cuenta no está activa.",

--- a/apps/web/src/locales/fr-CA/auth.json
+++ b/apps/web/src/locales/fr-CA/auth.json
@@ -16,6 +16,7 @@
     "setPasswordAndSignIn": "Définir le mot de passe et ouvrir une session"
   },
   "accountInactive": {
+    "bookMeeting": "Planifier un appel avec nous",
     "defaultMessages": {
       "churned": "Votre compte n’est plus actif. Merci de contacter le support.",
       "generic": "Votre compte n’est pas actif.",

--- a/apps/web/src/locales/fr-FR/auth.json
+++ b/apps/web/src/locales/fr-FR/auth.json
@@ -16,6 +16,7 @@
     "setPasswordAndSignIn": "Définir mot de passe et connexion"
   },
   "accountInactive": {
+    "bookMeeting": "Planifier un appel avec nous",
     "defaultMessages": {
       "churned": "Votre compte n’est plus actif. Merci de contacter le support.",
       "generic": "Votre compte n’est pas actif.",

--- a/apps/web/src/locales/it-IT/auth.json
+++ b/apps/web/src/locales/it-IT/auth.json
@@ -16,6 +16,7 @@
     "setPasswordAndSignIn": "Imposta password e accedi"
   },
   "accountInactive": {
+    "bookMeeting": "Prenota una chiamata con noi",
     "defaultMessages": {
       "churned": "Il tuo account non è più attivo. Contatta l'assistenza.",
       "generic": "Il tuo account non è attivo.",

--- a/apps/web/src/locales/pt-BR/auth.json
+++ b/apps/web/src/locales/pt-BR/auth.json
@@ -16,6 +16,7 @@
     "setPasswordAndSignIn": "Definir senha e entrar"
   },
   "accountInactive": {
+    "bookMeeting": "Agende uma chamada conosco",
     "defaultMessages": {
       "churned": "Sua conta não está mais ativa. Entre em contato com o suporte.",
       "generic": "Sua conta não está ativa.",

--- a/apps/web/src/locales/tr-TR/auth.json
+++ b/apps/web/src/locales/tr-TR/auth.json
@@ -16,6 +16,7 @@
     "setPasswordAndSignIn": "Şifreyi ayarlayın ve oturum açın"
   },
   "accountInactive": {
+    "bookMeeting": "Bizimle görüşme planlayın",
     "defaultMessages": {
       "churned": "Hesabınız artık aktif değil. Lütfen desteğe başvurun.",
       "generic": "Hesabınız aktif değil.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -392,6 +392,11 @@ services:
       # (#3239; #3236 was one instance of the same shape). All are `${VAR:-}`
       # for the reason spelled out above — '' reads as absent to envStr /
       # envFlag / envInt, so an unset knob still gets its in-code default.
+      # Booking link on the pending-account screen, shown beside BILLING_URL's
+      # CTA so stopping at the payment step isn't a dead end. Operator-set and
+      # changeable without a redeploy; the API drops non-http(s) URLs.
+      PENDING_ACCOUNT_MEETING_URL: ${PENDING_ACCOUNT_MEETING_URL:-}
+      PENDING_ACCOUNT_MEETING_LABEL: ${PENDING_ACCOUNT_MEETING_LABEL:-}
       # Auth cookie + CORS hardening. AUTH_/PORTAL_-prefixed names override the
       # generic COOKIE_* pair; that precedence is resolved with envStr (NOT `??`)
       # precisely because '' must fall through rather than shadow — see


### PR DESCRIPTION
## Why

Hosted signups land as `status='pending'` and sit on `/account/inactive` with a single billing CTA — or, when the registration hook failed to populate one, no button at all (the state that once stranded ~144 partners with no way forward). Prospects who aren't ready to enter a card have no path to a human. This adds an operator-configured "book a call" link next to the payment CTA.

## What

- **API**: `GET /partner/me` now returns `statusMeetingUrl` / `statusMeetingLabel` from new env vars `PENDING_ACCOUNT_MEETING_URL` / `PENDING_ACCOUNT_MEETING_LABEL` (mirrors the `SIGNUP_BUSINESS_EMAIL_CONTACT_URL` pattern — changeable without a deploy). Non-http(s) URLs are dropped server-side.
- **Web**: `AccountInactiveScreen` renders the link as a secondary action for `status='pending'` only — including the no-CTA fallback state, where it matters most. Client-side `isSafeUrl` guard retained; opens in a new tab. Label defaults to "Book a call with us" (env label overrides).
- `.env.example` documented.

## Deploy note

Prod droplets need the var in `/opt/breeze/.env` **and** an explicit mapping in the `api` service `environment:` block of the droplet compose file — `.env` alone is not interpolated (same trap as `IS_HOSTED`).

## Testing

- `apps/api/src/routes/partner.test.ts` — meeting fields returned, trimmed, `javascript:` dropped, null when unset (5 pass)
- `apps/web/src/components/auth/AccountInactiveScreen.test.tsx` — new suite: renders next to CTA, renders in stranded no-CTA state, hidden for suspended and for unsafe URLs (3 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)