### PR TITLE
ci(release): add switchable SSL.com Windows signing

### DIFF
--- a/.github/scripts/Verify-WindowsSignature.ps1
+++ b/.github/scripts/Verify-WindowsSignature.ps1
@@ -1,0 +1,134 @@
+<#
+.SYNOPSIS
+Verifies Authenticode signatures on released Windows artifacts.
+
+.DESCRIPTION
+Shared by every Windows signing provider job in release.yml so the providers
+cannot drift apart. Previously each provider carried its own inline copy of the
+verification, which is how the Azure path ended up with no publisher binding at
+all while the SSL.com path pinned a certificate.
+
+Every check throws on failure; the caller runs under `shell: pwsh`, where a
+terminating error fails the step.
+
+.PARAMETER Path
+Artifacts to verify. Relative paths resolve against GITHUB_WORKSPACE.
+
+.PARAMETER ExpectedSubject
+Exact organization name that must appear as the O or CN of the signer
+certificate, compared case-insensitively. The subject is parsed via
+X500DistinguishedName.Format() rather than a regex over the raw DN string, so a
+value containing a comma (`O="LanternOps, LLC"`) is handled correctly instead of
+failing the release.
+
+.PARAMETER ExpectedThumbprintSha256
+Optional SHA-256 certificate pin. Empty means "do not pin", which is correct for
+Azure Artifact Signing, whose leaf certificates are short-lived by design and
+rotate automatically. Non-empty must be 64 hex characters, separators ignored.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string[]] $Path,
+
+    [Parameter(Mandatory = $true)]
+    [string] $ExpectedSubject,
+
+    [Parameter(Mandatory = $false)]
+    [AllowEmptyString()]
+    [string] $ExpectedThumbprintSha256 = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-SubjectOrganizationNames {
+    param([System.Security.Cryptography.X509Certificates.X509Certificate2] $Certificate)
+
+    # Format($true) emits one RDN per line. A value containing a comma or a
+    # plus sign comes back quoted, so the quotes are stripped here rather than
+    # compared literally -- a regex over the raw DN string got this wrong and
+    # would have rejected a legitimate 'O="LanternOps, LLC"' certificate.
+    $names = @()
+    foreach ($line in ($Certificate.SubjectName.Format($true) -split "`r?`n")) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        # '+' separates the attributes of a multi-valued RDN, but only when it
+        # is not inside a quoted value.
+        $attributes = if ($line.Contains('"')) { @($line) } else { $line -split '\+' }
+        foreach ($attribute in $attributes) {
+            $separator = $attribute.IndexOf('=')
+            if ($separator -lt 1) { continue }
+            $key = $attribute.Substring(0, $separator).Trim()
+            $value = $attribute.Substring($separator + 1).Trim()
+            if ($value.Length -ge 2 -and $value.StartsWith('"') -and $value.EndsWith('"')) {
+                $value = $value.Substring(1, $value.Length - 2).Replace('""', '"')
+            }
+            if ($key -eq 'O' -or $key -eq 'CN') { $names += $value }
+        }
+    }
+    return $names
+}
+
+$expectedPin = ''
+if (-not [string]::IsNullOrWhiteSpace($ExpectedThumbprintSha256)) {
+    $expectedPin = ($ExpectedThumbprintSha256 -replace '[^0-9A-Fa-f]', '').ToLowerInvariant()
+    if ($expectedPin -notmatch '^[0-9a-f]{64}$') {
+        throw 'ExpectedThumbprintSha256 must contain exactly 64 hexadecimal characters'
+    }
+}
+
+$workspace = $env:GITHUB_WORKSPACE
+if ([string]::IsNullOrWhiteSpace($workspace)) { $workspace = (Get-Location).Path }
+
+foreach ($item in $Path) {
+    $target = if ([System.IO.Path]::IsPathRooted($item)) { $item } else { Join-Path $workspace $item }
+
+    if (-not (Test-Path -LiteralPath $target -PathType Leaf)) {
+        throw "Artifact to verify is missing: $target"
+    }
+
+    $signature = Get-AuthenticodeSignature -FilePath $target
+
+    # UnknownError is PowerShell's default bucket: it covers the benign
+    # "root not yet cached on this runner" case but also CERT_E_EXPIRED,
+    # CERT_E_REVOKED, CERT_E_UNTRUSTEDROOT and CERT_E_CHAINING. Tolerating it is
+    # only safe because the subject, validity and (where configured) pin checks
+    # below independently establish the publisher.
+    if ($signature.Status -ne 'Valid' -and $signature.Status -ne 'UnknownError') {
+        throw "Signature validation failed for $target. Status: $($signature.Status)"
+    }
+    if ($signature.Status -eq 'UnknownError') {
+        Write-Host "::warning::$target signed but chain not fully validated locally (Status: UnknownError)."
+    }
+    if (-not $signature.SignerCertificate) {
+        throw "Signer certificate missing for $target"
+    }
+    if (-not $signature.TimeStamperCertificate) {
+        throw "RFC 3161 timestamp missing for $target"
+    }
+
+    $certificate = $signature.SignerCertificate
+    $now = [DateTime]::UtcNow
+    if ($certificate.NotAfter.ToUniversalTime() -lt $now) {
+        throw "Signer certificate for $target expired on $($certificate.NotAfter.ToUniversalTime().ToString('o'))"
+    }
+    if ($certificate.NotBefore.ToUniversalTime() -gt $now) {
+        throw "Signer certificate for $target is not valid until $($certificate.NotBefore.ToUniversalTime().ToString('o'))"
+    }
+
+    $organizations = Get-SubjectOrganizationNames -Certificate $certificate
+    if (-not ($organizations | Where-Object { $_ -ieq $ExpectedSubject })) {
+        throw "Unexpected signer subject for $target. Expected O or CN '$ExpectedSubject'; got: $($certificate.Subject)"
+    }
+
+    $actualPin = $certificate.GetCertHashString(
+        [System.Security.Cryptography.HashAlgorithmName]::SHA256
+    ).ToLowerInvariant()
+
+    if ($expectedPin -ne '') {
+        if ($actualPin -ne $expectedPin) {
+            throw "Unexpected signer certificate for $target (SHA-256 $actualPin)"
+        }
+    }
+
+    Write-Host "Verified: $target - Status: $($signature.Status) - Signer: $($certificate.Subject) - SHA-256: $actualPin"
+}

--- a/.github/scripts/Verify-WindowsSignature.ps1
+++ b/.github/scripts/Verify-WindowsSignature.ps1
@@ -43,7 +43,14 @@ param(
 
     [Parameter(Mandatory = $false)]
     [AllowEmptyString()]
-    [string] $ExpectedThumbprintSha256 = ''
+    [string] $ExpectedThumbprintSha256 = '',
+
+    # Required to verify without a leaf pin. GitHub renders an unset secret as
+    # an empty string, which binds to [string] as '' -- so without this switch a
+    # deleted or mis-scoped SSLCOM_CERT_SHA256 silently turned pinning off and
+    # still exited 0. Callers must now say so out loud.
+    [Parameter(Mandatory = $false)]
+    [switch] $AllowUnpinnedLeaf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -92,6 +99,10 @@ if (-not [string]::IsNullOrWhiteSpace($ExpectedThumbprintSha256)) {
     }
 }
 
+if ($expectedPins.Count -eq 0 -and -not $AllowUnpinnedLeaf) {
+    throw 'ExpectedThumbprintSha256 is empty and -AllowUnpinnedLeaf was not supplied. A missing certificate pin must fail the release, not weaken it.'
+}
+
 $workspace = $env:GITHUB_WORKSPACE
 if ([string]::IsNullOrWhiteSpace($workspace)) { $workspace = (Get-Location).Path }
 
@@ -102,18 +113,35 @@ foreach ($item in $Path) {
         throw "Artifact to verify is missing: $target"
     }
 
-    $signature = Get-AuthenticodeSignature -FilePath $target
+    $signature = Get-AuthenticodeSignature -LiteralPath $target
 
-    # UnknownError is PowerShell's default bucket: it covers the benign
-    # "root not yet cached on this runner" case but also CERT_E_EXPIRED,
-    # CERT_E_REVOKED, CERT_E_UNTRUSTEDROOT and CERT_E_CHAINING. Tolerating it is
-    # only safe because the subject, validity and (where configured) pin checks
-    # below independently establish the publisher.
+    # UnknownError is PowerShell's catch-all bucket. It covers the benign
+    # "root not yet cached on this runner" case, but equally CERT_E_REVOKED,
+    # TRUST_E_EXPLICIT_DISTRUST, CERT_E_EXPIRED and CERT_E_CHAINING -- so on its
+    # own it establishes nothing. Subject and validity are self-asserted by the
+    # certificate and cannot substitute: a self-signed certificate claiming the
+    # expected subject satisfies both. Identity therefore has to come from
+    # either the leaf pin or a chain that actually builds.
     if ($signature.Status -ne 'Valid' -and $signature.Status -ne 'UnknownError') {
-        throw "Signature validation failed for $target. Status: $($signature.Status)"
+        throw "Signature validation failed for $target. Status: $($signature.Status) ($($signature.StatusMessage))"
     }
     if ($signature.Status -eq 'UnknownError') {
-        Write-Host "::warning::$target signed but chain not fully validated locally (Status: UnknownError)."
+        Write-Host "::warning::$target Authenticode status UnknownError: $($signature.StatusMessage)"
+        if ($expectedPins.Count -eq 0) {
+            # Unpinned: the chain is the only remaining binding, so require it to
+            # build. Only a revocation response we could not fetch is tolerable.
+            $chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+            $chain.ChainPolicy.RevocationMode = 'Online'
+            $chain.ChainPolicy.RevocationFlag = 'EntireChain'
+            $built = $chain.Build($signature.SignerCertificate)
+            $statuses = @($chain.ChainStatus | ForEach-Object { $_.Status.ToString() })
+            $tolerable = @('NoError', 'RevocationStatusUnknown', 'OfflineRevocation')
+            $fatal = @($statuses | Where-Object { $tolerable -notcontains $_ })
+            if (-not $built -and $fatal.Count -gt 0) {
+                throw "Unpinned signature for $target did not build a trusted chain: $($statuses -join ', ')"
+            }
+            Write-Host "Chain built for $target (status: $(if ($statuses) { $statuses -join ', ' } else { 'NoError' }))"
+        }
     }
     if (-not $signature.SignerCertificate) {
         throw "Signer certificate missing for $target"

--- a/.github/scripts/Verify-WindowsSignature.ps1
+++ b/.github/scripts/Verify-WindowsSignature.ps1
@@ -22,9 +22,16 @@ value containing a comma (`O="LanternOps, LLC"`) is handled correctly instead of
 failing the release.
 
 .PARAMETER ExpectedThumbprintSha256
-Optional SHA-256 certificate pin. Empty means "do not pin", which is correct for
-Azure Artifact Signing, whose leaf certificates are short-lived by design and
-rotate automatically. Non-empty must be 64 hex characters, separators ignored.
+Optional SHA-256 certificate pin, or a comma-separated allowlist of them. Empty
+means "do not pin", which is correct for Azure Artifact Signing, whose leaf
+certificates are short-lived by design and rotate automatically.
+
+Each entry must be 64 hex characters; internal separators such as the colons in
+`C9:EA:...` are ignored, and entries are split on commas, semicolons and
+whitespace. An allowlist exists so a certificate renewal can be staged: add the
+incoming thumbprint alongside the outgoing one before the changeover, then drop
+the old entry afterwards. Otherwise renewal is a release-day edit made after the
+signing steps have already run and consumed eSigner quota.
 #>
 [CmdletBinding()]
 param(
@@ -68,11 +75,20 @@ function Get-SubjectOrganizationNames {
     return $names
 }
 
-$expectedPin = ''
+$expectedPins = @()
 if (-not [string]::IsNullOrWhiteSpace($ExpectedThumbprintSha256)) {
-    $expectedPin = ($ExpectedThumbprintSha256 -replace '[^0-9A-Fa-f]', '').ToLowerInvariant()
-    if ($expectedPin -notmatch '^[0-9a-f]{64}$') {
-        throw 'ExpectedThumbprintSha256 must contain exactly 64 hexadecimal characters'
+    # Split on list separators only: colons are kept, because a thumbprint is
+    # commonly pasted in 'C9:EA:...' form.
+    foreach ($candidate in ($ExpectedThumbprintSha256 -split '[,;\s]+')) {
+        if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+        $normalized = ($candidate -replace '[^0-9A-Fa-f]', '').ToLowerInvariant()
+        if ($normalized -notmatch '^[0-9a-f]{64}$') {
+            throw 'Each ExpectedThumbprintSha256 entry must contain exactly 64 hexadecimal characters'
+        }
+        $expectedPins += $normalized
+    }
+    if ($expectedPins.Count -eq 0) {
+        throw 'ExpectedThumbprintSha256 was set but contained no usable thumbprint'
     }
 }
 
@@ -124,10 +140,10 @@ foreach ($item in $Path) {
         [System.Security.Cryptography.HashAlgorithmName]::SHA256
     ).ToLowerInvariant()
 
-    if ($expectedPin -ne '') {
-        if ($actualPin -ne $expectedPin) {
-            throw "Unexpected signer certificate for $target (SHA-256 $actualPin)"
-        }
+    # Only the actual thumbprint is reported: the expected value is supplied as
+    # a secret and would be masked anyway.
+    if ($expectedPins.Count -gt 0 -and $expectedPins -notcontains $actualPin) {
+        throw "Unexpected signer certificate for $target (SHA-256 $actualPin)"
     }
 
     Write-Host "Verified: $target - Status: $($signature.Status) - Signer: $($certificate.Subject) - SHA-256: $actualPin"

--- a/.github/scripts/assert-windows-signing-convergence.mjs
+++ b/.github/scripts/assert-windows-signing-convergence.mjs
@@ -1,0 +1,12 @@
+const [provider, azureResult, sslcomResult, ...extra] = process.argv.slice(2);
+const converged = extra.length === 0 && (
+  (provider === 'azure' && azureResult === 'success' && sslcomResult === 'skipped')
+  || (provider === 'sslcom' && azureResult === 'skipped' && sslcomResult === 'success')
+);
+
+if (!converged) {
+  process.stderr.write(
+    `Windows signing convergence failed: provider=${provider ?? 'missing'} azure=${azureResult ?? 'missing'} sslcom=${sslcomResult ?? 'missing'}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/.github/scripts/check-workflow-security.mjs
+++ b/.github/scripts/check-workflow-security.mjs
@@ -8,7 +8,28 @@ const PR_TARGET_HEAD_RULE = 'pr-target-must-not-execute-head';
 const SIGNING_BUILD_RULE = 'signing-job-must-not-build-source';
 const SIGNING_VERIFY_RULE = 'signing-job-must-verify-artifact-before-secrets';
 const UNSUPPORTED_SYNTAX_RULE = 'unsupported-workflow-syntax';
+const WINDOWS_SIGNING_PROVIDER_FAIL_CLOSED_RULE = 'windows-signing-provider-must-fail-closed';
+const WINDOWS_SIGNING_PROVIDER_LEAST_PRIVILEGE_RULE = 'windows-signing-provider-least-privilege';
+const SSLCOM_SIGNING_CERTIFICATE_PIN_RULE = 'sslcom-signing-must-pin-certificate';
+const WINDOWS_SIGNING_TIMESTAMP_RULE = 'windows-signing-must-require-timestamp';
+const SSLCOM_SIGNING_AGENT_ISOLATION_RULE = 'sslcom-signing-must-not-touch-agent';
+const WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE = 'windows-signing-provider-must-converge';
 const PINNED_EXTERNAL_USES = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)*@[0-9a-f]{40}$/u;
+const PUBLIC_AGENT_WINDOWS_ASSETS = [
+  'breeze-agent-windows-amd64.exe',
+  'breeze-backup-windows-amd64.exe',
+  'breeze-watchdog-windows-amd64.exe',
+  'breeze-user-helper-windows-amd64.exe',
+  'breeze-agent.msi',
+];
+const SSLCOM_ACTION = 'SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b';
+const SSLCOM_SECRETS = [
+  'SSLCOM_USERNAME',
+  'SSLCOM_PASSWORD',
+  'SSLCOM_CREDENTIAL_ID',
+  'SSLCOM_TOTP_SECRET',
+  'SSLCOM_CERT_SHA256',
+];
 
 function stripInlineComment(line) {
   let quote = null;
@@ -681,6 +702,39 @@ function workflowJobs(lines) {
   return jobs;
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+function requirePattern(section, pattern, rule, violations, file) {
+  const content = section?.lines.map((line) => line.content).join('\n') ?? '';
+  if (section && pattern.test(content)) {
+    return;
+  }
+  violations.push({
+    file,
+    line: section?.lines[0].line ?? 1,
+    rule,
+    message: `release signing job "${section?.name ?? 'missing'}" must satisfy ${rule}`,
+  });
+}
+
+function forbidPattern(section, pattern, rule, violations, file) {
+  if (!section) {
+    return;
+  }
+  const content = section.lines.map((line) => line.content).join('\n');
+  if (!pattern.test(content)) {
+    return;
+  }
+  violations.push({
+    file,
+    line: section.lines[0].line,
+    rule,
+    message: `release signing job "${section.name}" must not violate ${rule}`,
+  });
+}
+
 function scalarListValues(value) {
   const scalar = unquote(value);
   if (!scalar.startsWith('[') || !scalar.endsWith(']')) {
@@ -985,6 +1039,117 @@ function developerSigningViolations(file, lines) {
   return violations;
 }
 
+function publicReleaseSigningViolations(file, lines) {
+  if (file !== 'release.yml') {
+    return [];
+  }
+
+  const jobs = new Map(workflowJobs(lines).map((job) => [job.name, job]));
+  const resolver = jobs.get('resolve-windows-signing-provider');
+  const azure = jobs.get('sign-windows-tauri-azure');
+  const sslcom = jobs.get('sign-windows-tauri-sslcom');
+  const gate = jobs.get('sign-windows-tauri');
+  if (!resolver && !azure && !sslcom && !gate) {
+    return [];
+  }
+
+  const violations = [];
+  requirePattern(
+    resolver,
+    /RAW_PROVIDER[\s\S]*:-azure[\s\S]*azure\|sslcom[\s\S]*\*\)[\s\S]*exit 1/u,
+    WINDOWS_SIGNING_PROVIDER_FAIL_CLOSED_RULE,
+    violations,
+    file,
+  );
+  requirePattern(
+    azure,
+    /id-token:\s*write/u,
+    WINDOWS_SIGNING_PROVIDER_LEAST_PRIVILEGE_RULE,
+    violations,
+    file,
+  );
+  for (const section of [resolver, sslcom, gate]) {
+    forbidPattern(
+      section,
+      /id-token:/u,
+      WINDOWS_SIGNING_PROVIDER_LEAST_PRIVILEGE_RULE,
+      violations,
+      file,
+    );
+  }
+  requirePattern(
+    sslcom,
+    new RegExp(escapeRegExp(SSLCOM_ACTION), 'u'),
+    SSLCOM_SIGNING_CERTIFICATE_PIN_RULE,
+    violations,
+    file,
+  );
+  for (const secret of SSLCOM_SECRETS) {
+    requirePattern(
+      sslcom,
+      new RegExp(`secrets\\.${secret}\\b`, 'u'),
+      SSLCOM_SIGNING_CERTIFICATE_PIN_RULE,
+      violations,
+      file,
+    );
+  }
+  requirePattern(
+    sslcom,
+    /\$env:SSLCOM_CERT_SHA256/u,
+    SSLCOM_SIGNING_CERTIFICATE_PIN_RULE,
+    violations,
+    file,
+  );
+  requirePattern(
+    sslcom,
+    /GetCertHashString\(\s*\[System\.Security\.Cryptography\.HashAlgorithmName\]::SHA256/u,
+    SSLCOM_SIGNING_CERTIFICATE_PIN_RULE,
+    violations,
+    file,
+  );
+  for (const section of [azure, sslcom]) {
+    requirePattern(
+      section,
+      /TimeStamperCertificate/u,
+      WINDOWS_SIGNING_TIMESTAMP_RULE,
+      violations,
+      file,
+    );
+  }
+  for (const asset of PUBLIC_AGENT_WINDOWS_ASSETS) {
+    forbidPattern(
+      sslcom,
+      new RegExp(escapeRegExp(asset), 'u'),
+      SSLCOM_SIGNING_AGENT_ISOLATION_RULE,
+      violations,
+      file,
+    );
+  }
+  requirePattern(
+    gate,
+    /!cancelled\(\)/u,
+    WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE,
+    violations,
+    file,
+  );
+  requirePattern(
+    gate,
+    /needs\.sign-windows-tauri-azure\.result/u,
+    WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE,
+    violations,
+    file,
+  );
+  requirePattern(
+    gate,
+    /needs\.sign-windows-tauri-sslcom\.result/u,
+    WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE,
+    violations,
+    file,
+  );
+
+  return violations;
+}
+
 function compareViolations(left, right) {
   return codePointCompare(left.file, right.file)
     || left.line - right.line
@@ -1047,6 +1212,7 @@ export function inspectWorkflowText(file, text) {
   }
 
   violations.push(...developerSigningViolations(file, lines));
+  violations.push(...publicReleaseSigningViolations(file, lines));
 
   return violations.sort(compareViolations);
 }

--- a/.github/scripts/check-workflow-security.mjs
+++ b/.github/scripts/check-workflow-security.mjs
@@ -1194,6 +1194,24 @@ function publicReleaseSigningViolations(file, lines) {
     violations,
     file,
   );
+  // -AllowUnpinnedLeaf turns the certificate pin off. It is correct on the
+  // Azure path, whose leaves rotate, and never on the pinned one.
+  forbidPattern(
+    sslcom,
+    /-AllowUnpinnedLeaf/u,
+    SSLCOM_SIGNING_CERTIFICATE_PIN_RULE,
+    violations,
+    file,
+  );
+  // Verifying without a pin has to be an explicit, reviewable choice rather
+  // than the silent consequence of an empty secret.
+  requirePattern(
+    azure,
+    /-AllowUnpinnedLeaf/u,
+    WINDOWS_SIGNING_PUBLISHER_RULE,
+    violations,
+    file,
+  );
   // The stable/prerelease certificate split exists only in GitHub Environment
   // scoping, which is invisible in YAML. This label makes a repository-level
   // secret fail one of the two environments instead of silently signing a

--- a/.github/scripts/check-workflow-security.mjs
+++ b/.github/scripts/check-workflow-security.mjs
@@ -14,6 +14,17 @@ const SSLCOM_SIGNING_CERTIFICATE_PIN_RULE = 'sslcom-signing-must-pin-certificate
 const WINDOWS_SIGNING_TIMESTAMP_RULE = 'windows-signing-must-require-timestamp';
 const SSLCOM_SIGNING_AGENT_ISOLATION_RULE = 'sslcom-signing-must-not-touch-agent';
 const WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE = 'windows-signing-provider-must-converge';
+const WINDOWS_SIGNING_PUBLISHER_RULE = 'windows-signing-must-assert-publisher';
+const WINDOWS_SIGNING_RELEASE_GATE_RULE = 'windows-signing-gate-must-block-release';
+const WINDOWS_SIGNING_ARTIFACT_PARITY_RULE = 'windows-signing-providers-must-cover-same-artifacts';
+const SSLCOM_SIGNING_TOOLCHAIN_RULE = 'sslcom-signing-must-pin-toolchain';
+const TAURI_SIGNED_ARTIFACT_MARKER = 'breeze-viewer-windows.msi';
+const TAURI_SIGNED_ARTIFACT_RE = /breeze-[a-z0-9-]+-windows\.msi/gu;
+const PROVIDER_RESOLVER_SCRIPT = '.github/scripts/resolve-windows-signing-provider.mjs';
+const CONVERGENCE_SCRIPT = '.github/scripts/assert-windows-signing-convergence.mjs';
+const SHARED_SIGNATURE_VERIFIER = '.github/scripts/Verify-WindowsSignature.ps1';
+const AZURE_SIGNING_ACTION_PREFIX = 'azure/artifact-signing-action@';
+const SSLCOM_ACTION_PREFIX = 'SSLcom/esigner-codesign@';
 const PINNED_EXTERNAL_USES = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)*@[0-9a-f]{40}$/u;
 const PUBLIC_AGENT_WINDOWS_ASSETS = [
   'breeze-agent-windows-amd64.exe',
@@ -29,6 +40,7 @@ const SSLCOM_SECRETS = [
   'SSLCOM_CREDENTIAL_ID',
   'SSLCOM_TOTP_SECRET',
   'SSLCOM_CERT_SHA256',
+  'SSLCOM_ENVIRONMENT_LABEL',
 ];
 
 function stripInlineComment(line) {
@@ -1039,21 +1051,79 @@ function developerSigningViolations(file, lines) {
   return violations;
 }
 
+function jobText(job) {
+  return job.lines.map((line) => line.content).join('\n');
+}
+
+function findJobByShape(jobs, marker) {
+  return jobs.find((job) => jobText(job).includes(marker));
+}
+
+function artifactsMatching(job, lineFilter) {
+  const found = new Set();
+  for (const line of job.lines) {
+    if (!lineFilter(line.trimmed)) {
+      continue;
+    }
+    for (const match of line.content.matchAll(TAURI_SIGNED_ARTIFACT_RE)) {
+      found.add(match[0]);
+    }
+  }
+  return [...found].sort(codePointCompare);
+}
+
+// Artifacts handed to a signing action, via azure `files:` or eSigner
+// `file_path:`. Deliberately NOT every MSI named in the job — download and
+// upload steps name them too, so a deleted sign step would go unnoticed while
+// the unsigned file was re-uploaded over the signed artifact name.
+function signedWindowsArtifacts(job) {
+  return artifactsMatching(job, (trimmed) => /^(?:files|file_path):/u.test(trimmed));
+}
+
+// Artifacts passed to the shared verifier.
+function verifiedWindowsArtifacts(job) {
+  return artifactsMatching(job, (trimmed) => trimmed.startsWith('-Path'));
+}
+
 function publicReleaseSigningViolations(file, lines) {
-  if (file !== 'release.yml') {
+  const text = lines.map((line) => line.content).join('\n');
+
+  // Trigger on the ARTIFACT, not on job names. Keying this on job names meant a
+  // consistent rename of the four signing jobs silently disabled every rule
+  // below — including the certificate pin — with CI fully green.
+  if (!text.includes(TAURI_SIGNED_ARTIFACT_MARKER)) {
     return [];
   }
 
-  const jobs = new Map(workflowJobs(lines).map((job) => [job.name, job]));
-  const resolver = jobs.get('resolve-windows-signing-provider');
-  const azure = jobs.get('sign-windows-tauri-azure');
-  const sslcom = jobs.get('sign-windows-tauri-sslcom');
-  const gate = jobs.get('sign-windows-tauri');
-  if (!resolver && !azure && !sslcom && !gate) {
-    return [];
-  }
+  const jobs = workflowJobs(lines);
+  // Each provider is located by the action or script that defines it, so the
+  // rules survive any renaming of the jobs themselves.
+  const resolver = findJobByShape(jobs, PROVIDER_RESOLVER_SCRIPT);
+  const azure = findJobByShape(jobs, AZURE_SIGNING_ACTION_PREFIX);
+  const sslcom = findJobByShape(jobs, SSLCOM_ACTION_PREFIX);
+  const gate = findJobByShape(jobs, CONVERGENCE_SCRIPT);
+  const integrityGate = findJobByShape(jobs, 'require_success');
 
   const violations = [];
+  const structural = [
+    [resolver, 'a provider resolution job', WINDOWS_SIGNING_PROVIDER_FAIL_CLOSED_RULE],
+    [azure, 'an Azure signing job', WINDOWS_SIGNING_PUBLISHER_RULE],
+    [sslcom, 'an SSL.com signing job', SSLCOM_SIGNING_CERTIFICATE_PIN_RULE],
+    [gate, 'a provider convergence gate', WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE],
+    [integrityGate, 'a release integrity gate', WINDOWS_SIGNING_RELEASE_GATE_RULE],
+  ];
+  for (const [job, description, rule] of structural) {
+    if (!job) {
+      violations.push({
+        file,
+        line: 1,
+        rule,
+        message: `a workflow that signs ${TAURI_SIGNED_ARTIFACT_MARKER} must declare ${description}`,
+      });
+    }
+  }
+
+  // Fail-closed provider resolution.
   requirePattern(
     resolver,
     /node\s+\.github\/scripts\/resolve-windows-signing-provider\.mjs\s+"\$RAW_PROVIDER"\s*>>\s*"\$GITHUB_OUTPUT"/u,
@@ -1061,6 +1131,8 @@ function publicReleaseSigningViolations(file, lines) {
     violations,
     file,
   );
+
+  // Only the Azure signer may hold OIDC.
   requirePattern(
     azure,
     /id-token:\s*write/u,
@@ -1077,6 +1149,28 @@ function publicReleaseSigningViolations(file, lines) {
       file,
     );
   }
+
+  // Both providers must assert the publisher through the shared verifier. The
+  // Azure path previously verified only that *some* signature existed, so a
+  // mis-set endpoint or certificate profile shipped under any identity.
+  for (const section of [azure, sslcom]) {
+    requirePattern(
+      section,
+      new RegExp(escapeRegExp(SHARED_SIGNATURE_VERIFIER), 'u'),
+      WINDOWS_SIGNING_TIMESTAMP_RULE,
+      violations,
+      file,
+    );
+    requirePattern(
+      section,
+      /-ExpectedSubject\s+\$env:EXPECTED_SUBJECT/u,
+      WINDOWS_SIGNING_PUBLISHER_RULE,
+      violations,
+      file,
+    );
+  }
+
+  // SSL.com credential + certificate pinning.
   requirePattern(
     sslcom,
     new RegExp(escapeRegExp(SSLCOM_ACTION), 'u'),
@@ -1095,57 +1189,118 @@ function publicReleaseSigningViolations(file, lines) {
   }
   requirePattern(
     sslcom,
-    /\$env:SSLCOM_CERT_SHA256/u,
+    /-ExpectedThumbprintSha256\s+\$env:SSLCOM_CERT_SHA256/u,
     SSLCOM_SIGNING_CERTIFICATE_PIN_RULE,
     violations,
     file,
   );
+  // The stable/prerelease certificate split exists only in GitHub Environment
+  // scoping, which is invisible in YAML. This label makes a repository-level
+  // secret fail one of the two environments instead of silently signing a
+  // prerelease with the production certificate.
   requirePattern(
     sslcom,
-    /GetCertHashString\(\s*\[System\.Security\.Cryptography\.HashAlgorithmName\]::SHA256/u,
+    /SSLCOM_ENVIRONMENT_LABEL\s+-ne\s+\$env:EXPECTED_ENVIRONMENT[\s\S]{0,200}throw/u,
     SSLCOM_SIGNING_CERTIFICATE_PIN_RULE,
     violations,
     file,
   );
-  for (const section of [azure, sslcom]) {
+
+  // The pinned action SHA does not cover CodeSignTool, which the action fetches
+  // at runtime from a mutable release asset and executes next to the eSigner
+  // credentials. It must be pre-staged against a verified digest.
+  requirePattern(
+    sslcom,
+    /Get-FileHash[\s\S]{0,400}\$actual\s+-ne\s+\$env:CODESIGNTOOL_SHA256\s*\)\s*\{[\s\S]{0,200}throw/u,
+    SSLCOM_SIGNING_TOOLCHAIN_RULE,
+    violations,
+    file,
+  );
+  for (const marker of ['CODESIGNTOOL_PATH=', 'JAVA_VERSION=']) {
     requirePattern(
-      section,
-      /TimeStamperCertificate/u,
-      WINDOWS_SIGNING_TIMESTAMP_RULE,
+      sslcom,
+      new RegExp(escapeRegExp(marker), 'u'),
+      SSLCOM_SIGNING_TOOLCHAIN_RULE,
       violations,
       file,
     );
   }
-  for (const asset of PUBLIC_AGENT_WINDOWS_ASSETS) {
+
+  // Agent-family artifacts stay unsigned in the public pipeline — on BOTH
+  // providers, not just SSL.com.
+  for (const section of [azure, sslcom]) {
+    for (const asset of PUBLIC_AGENT_WINDOWS_ASSETS) {
+      forbidPattern(
+        section,
+        new RegExp(escapeRegExp(asset), 'u'),
+        SSLCOM_SIGNING_AGENT_ISOLATION_RULE,
+        violations,
+        file,
+      );
+    }
+    // A directory-wide batch sign would pick up whatever is staged without
+    // naming any forbidden file.
     forbidPattern(
-      sslcom,
-      new RegExp(escapeRegExp(asset), 'u'),
+      section,
+      /(?:command:\s*batch_sign|dir_path:)/u,
       SSLCOM_SIGNING_AGENT_ISOLATION_RULE,
       violations,
       file,
     );
   }
-  requirePattern(
-    gate,
-    /!cancelled\(\)/u,
-    WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE,
-    violations,
-    file,
-  );
-  requirePattern(
-    gate,
-    /needs\.sign-windows-tauri-azure\.result/u,
-    WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE,
-    violations,
-    file,
-  );
-  requirePattern(
-    gate,
-    /needs\.sign-windows-tauri-sslcom\.result/u,
-    WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE,
-    violations,
-    file,
-  );
+
+  // Both providers must cover exactly the same artifact set, or one of them can
+  // quietly leave a file unsigned while overwriting the signed artifact name.
+  // Every artifact a provider verifies must also have been signed by it, and
+  // both providers must cover the same set.
+  for (const section of [azure, sslcom]) {
+    if (!section) {
+      continue;
+    }
+    const signed = signedWindowsArtifacts(section);
+    const verified = verifiedWindowsArtifacts(section);
+    if (signed.join(',') !== verified.join(',')) {
+      violations.push({
+        file,
+        line: section.lines[0].line,
+        rule: WINDOWS_SIGNING_ARTIFACT_PARITY_RULE,
+        message: `signing job "${section.name}" signs [${signed.join(' ')}] but verifies [${verified.join(' ')}]`,
+      });
+    }
+  }
+  if (azure && sslcom) {
+    const azureArtifacts = signedWindowsArtifacts(azure);
+    const sslcomArtifacts = signedWindowsArtifacts(sslcom);
+    if (azureArtifacts.join(',') !== sslcomArtifacts.join(',')) {
+      violations.push({
+        file,
+        line: sslcom.lines[0].line,
+        rule: WINDOWS_SIGNING_ARTIFACT_PARITY_RULE,
+        message: `Windows signing providers must cover the same artifacts; azure=[${azureArtifacts.join(' ')}] sslcom=[${sslcomArtifacts.join(' ')}]`,
+      });
+    }
+  }
+
+  // Convergence gate: exactly one provider ran, and it succeeded.
+  requirePattern(gate, /!cancelled\(\)/u, WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE, violations, file);
+  if (azure) {
+    requirePattern(
+      gate,
+      new RegExp(`needs\\.${escapeRegExp(azure.name)}\\.result`, 'u'),
+      WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE,
+      violations,
+      file,
+    );
+  }
+  if (sslcom) {
+    requirePattern(
+      gate,
+      new RegExp(`needs\\.${escapeRegExp(sslcom.name)}\\.result`, 'u'),
+      WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE,
+      violations,
+      file,
+    );
+  }
   requirePattern(
     gate,
     /node\s+\.github\/scripts\/assert-windows-signing-convergence\.mjs\s+"\$PROVIDER"\s+"\$AZURE_RESULT"\s+"\$SSLCOM_RESULT"/u,
@@ -1153,6 +1308,19 @@ function publicReleaseSigningViolations(file, lines) {
     violations,
     file,
   );
+
+  // The convergence gate only protects the release while the integrity gate
+  // hard-requires it. Everything downstream tolerates a 'skipped' signing job,
+  // so dropping this one entry would silently make the pipeline fail open.
+  if (gate) {
+    requirePattern(
+      integrityGate,
+      new RegExp(`require_success\\s+"${escapeRegExp(gate.name)}"`, 'u'),
+      WINDOWS_SIGNING_RELEASE_GATE_RULE,
+      violations,
+      file,
+    );
+  }
 
   return violations;
 }

--- a/.github/scripts/check-workflow-security.mjs
+++ b/.github/scripts/check-workflow-security.mjs
@@ -1056,7 +1056,7 @@ function publicReleaseSigningViolations(file, lines) {
   const violations = [];
   requirePattern(
     resolver,
-    /RAW_PROVIDER[\s\S]*:-azure[\s\S]*azure\|sslcom[\s\S]*\*\)[\s\S]*exit 1/u,
+    /node\s+\.github\/scripts\/resolve-windows-signing-provider\.mjs\s+"\$RAW_PROVIDER"\s*>>\s*"\$GITHUB_OUTPUT"/u,
     WINDOWS_SIGNING_PROVIDER_FAIL_CLOSED_RULE,
     violations,
     file,
@@ -1142,6 +1142,13 @@ function publicReleaseSigningViolations(file, lines) {
   requirePattern(
     gate,
     /needs\.sign-windows-tauri-sslcom\.result/u,
+    WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE,
+    violations,
+    file,
+  );
+  requirePattern(
+    gate,
+    /node\s+\.github\/scripts\/assert-windows-signing-convergence\.mjs\s+"\$PROVIDER"\s+"\$AZURE_RESULT"\s+"\$SSLCOM_RESULT"/u,
     WINDOWS_SIGNING_PROVIDER_CONVERGENCE_RULE,
     violations,
     file,

--- a/.github/scripts/check-workflow-security.test.mjs
+++ b/.github/scripts/check-workflow-security.test.mjs
@@ -734,7 +734,8 @@ jobs:
         run: |
           & ${SHARED_VERIFIER} \`
             -Path "staging/breeze-viewer-windows.msi", "staging/breeze-helper-windows.msi" \`
-            -ExpectedSubject $env:EXPECTED_SUBJECT
+            -ExpectedSubject $env:EXPECTED_SUBJECT \`
+            -AllowUnpinnedLeaf
   sign-windows-tauri-sslcom:
     needs: [resolve-windows-signing-provider]
     if: needs.resolve-windows-signing-provider.outputs.provider == 'sslcom'
@@ -931,6 +932,8 @@ const PUBLIC_SIGNING_MUTATIONS = [
   ['azure drops the publisher assertion', (t) => replaceNth(t, '-ExpectedSubject $env:EXPECTED_SUBJECT', 1, '-Verbose:$false'), 'windows-signing-must-assert-publisher'],
   ['sslcom drops the publisher assertion', (t) => replaceNth(t, '-ExpectedSubject $env:EXPECTED_SUBJECT', 2, '-Verbose:$false'), 'windows-signing-must-assert-publisher'],
   ['sslcom drops the certificate pin', (t) => replaceOnce(t, '            -ExpectedThumbprintSha256 $env:SSLCOM_CERT_SHA256', '            -Verbose:$false'), 'sslcom-signing-must-pin-certificate'],
+  ['sslcom opts out of pinning', (t) => replaceOnce(t, '            -ExpectedThumbprintSha256 $env:SSLCOM_CERT_SHA256', '            -AllowUnpinnedLeaf'), 'sslcom-signing-must-pin-certificate'],
+  ['azure stops declaring it is unpinned', (t) => replaceOnce(t, '            -AllowUnpinnedLeaf\n', ''), 'windows-signing-must-assert-publisher'],
   ['sslcom action unpinned', (t) => t.split(SSL_ACTION).join('SSLcom/esigner-codesign@v1'), 'sslcom-signing-must-pin-certificate'],
   ['sslcom drops the environment label guard', (t) => replaceOnce(t, 'if ($env:SSLCOM_ENVIRONMENT_LABEL -ne $env:EXPECTED_ENVIRONMENT) {', 'if ($false) {'), 'sslcom-signing-must-pin-certificate'],
   ['CodeSignTool digest guard removed', (t) => replaceOnce(t, 'if ($actual -ne $env:CODESIGNTOOL_SHA256) {', 'if ($false) {'), 'sslcom-signing-must-pin-toolchain'],
@@ -963,7 +966,11 @@ for (const asset of PUBLIC_AGENT_WINDOWS_ASSETS) {
 for (const secret of SSLCOM_SECRET_NAMES) {
   PUBLIC_SIGNING_MUTATIONS.push([
     `sslcom stops reading ${secret}`,
-    (t) => t.split(`secrets.${secret} `).join('secrets.REMOVED '),
+    (t) => {
+      const mutated = t.split(`secrets.${secret}`).join('secrets.REMOVED');
+      assert.notEqual(mutated, t, `secret mutation for ${secret} did not apply`);
+      return mutated;
+    },
     'sslcom-signing-must-pin-certificate',
   ]);
 }
@@ -1021,7 +1028,7 @@ test('public signing rules survive a rename of every signing job', () => {
 });
 
 test('the real release workflow carries the full Windows signing topology', () => {
-  const releaseWorkflow = readFileSync('.github/workflows/release.yml', 'utf8');
+  const releaseWorkflow = readFileSync(new URL('../workflows/release.yml', import.meta.url), 'utf8');
   assert.deepEqual([...publicSigningRules(releaseWorkflow)], []);
   for (const marker of [
     'resolve-windows-signing-provider:',
@@ -1037,7 +1044,7 @@ test('the real release workflow carries the full Windows signing topology', () =
 // The verifier is the single place both providers assert publisher identity, so
 // a guard downgraded from `throw` to a warning would silently accept any signer.
 test('the shared signature verifier enforces every check it performs', () => {
-  const verifier = readFileSync('.github/scripts/Verify-WindowsSignature.ps1', 'utf8');
+  const verifier = readFileSync(new URL('./Verify-WindowsSignature.ps1', import.meta.url), 'utf8');
   const enforced = [
     [/\$signature\.Status -ne 'Valid'[\s\S]{0,200}throw/u, 'signature status'],
     [/-not \$signature\.SignerCertificate[\s\S]{0,120}throw/u, 'signer certificate present'],
@@ -1045,6 +1052,8 @@ test('the shared signature verifier enforces every check it performs', () => {
     [/NotAfter[\s\S]{0,160}throw/u, 'certificate not expired'],
     [/ExpectedSubject[\s\S]{0,200}throw/u, 'publisher subject'],
     [/\$expectedPins -notcontains \$actualPin[\s\S]{0,200}throw/u, 'certificate pin'],
+    [/\$expectedPins\.Count -eq 0 -and -not \$AllowUnpinnedLeaf[\s\S]{0,200}throw/u, 'refuses an unpinned run by default'],
+    [/\$expectedPins\.Count -eq 0\)\s*\{[\s\S]{0,1500}throw "Unpinned signature/u, 'requires a trusted chain when unpinned'],
     [/-notmatch '\^\[0-9a-f\]\{64\}\$'[\s\S]{0,160}throw/u, 'thumbprint format'],
   ];
   for (const [pattern, description] of enforced) {

--- a/.github/scripts/check-workflow-security.test.mjs
+++ b/.github/scripts/check-workflow-security.test.mjs
@@ -1044,7 +1044,8 @@ test('the shared signature verifier enforces every check it performs', () => {
     [/-not \$signature\.TimeStamperCertificate[\s\S]{0,120}throw/u, 'RFC 3161 timestamp present'],
     [/NotAfter[\s\S]{0,160}throw/u, 'certificate not expired'],
     [/ExpectedSubject[\s\S]{0,200}throw/u, 'publisher subject'],
-    [/\$actualPin -ne \$expectedPin[\s\S]{0,160}throw/u, 'certificate pin'],
+    [/\$expectedPins -notcontains \$actualPin[\s\S]{0,200}throw/u, 'certificate pin'],
+    [/-notmatch '\^\[0-9a-f\]\{64\}\$'[\s\S]{0,160}throw/u, 'thumbprint format'],
   ];
   for (const [pattern, description] of enforced) {
     assert.match(verifier, pattern, `verifier must throw on: ${description}`);

--- a/.github/scripts/check-workflow-security.test.mjs
+++ b/.github/scripts/check-workflow-security.test.mjs
@@ -662,6 +662,113 @@ ${signingSteps}
 `;
 }
 
+const SSL_ACTION = 'SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b';
+const PUBLIC_SIGNING_RULES = [
+  'windows-signing-provider-must-fail-closed',
+  'windows-signing-provider-least-privilege',
+  'sslcom-signing-must-pin-certificate',
+  'windows-signing-must-require-timestamp',
+  'sslcom-signing-must-not-touch-agent',
+  'windows-signing-provider-must-converge',
+];
+
+function publicSigningFixture() {
+  return `on: push
+jobs:
+  resolve-windows-signing-provider:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      provider: \${{ steps.provider.outputs.provider }}
+    steps:
+      - id: provider
+        env:
+          RAW_PROVIDER: \${{ vars.WINDOWS_SIGNING_PROVIDER }}
+        run: |
+          case "\${RAW_PROVIDER:-azure}" in
+            azure|sslcom) echo "provider=\${RAW_PROVIDER:-azure}" >> "$GITHUB_OUTPUT" ;;
+            *) exit 1 ;;
+          esac
+  sign-windows-tauri-azure:
+    needs: [resolve-windows-signing-provider]
+    if: needs.resolve-windows-signing-provider.outputs.provider == 'azure'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - shell: pwsh
+        run: |
+          if (-not $sig.SignerCertificate) { throw }
+          if (-not $sig.TimeStamperCertificate) { throw }
+  sign-windows-tauri-sslcom:
+    needs: [resolve-windows-signing-provider]
+    if: needs.resolve-windows-signing-provider.outputs.provider == 'sslcom'
+    permissions:
+      contents: read
+    steps:
+      - uses: ${SSL_ACTION}
+        with:
+          username: \${{ secrets.SSLCOM_USERNAME }}
+          password: \${{ secrets.SSLCOM_PASSWORD }}
+          credential_id: \${{ secrets.SSLCOM_CREDENTIAL_ID }}
+          totp_secret: \${{ secrets.SSLCOM_TOTP_SECRET }}
+      - shell: pwsh
+        env:
+          SSLCOM_CERT_SHA256: \${{ secrets.SSLCOM_CERT_SHA256 }}
+        run: |
+          $expected = $env:SSLCOM_CERT_SHA256
+          $actual = $sig.SignerCertificate.GetCertHashString([System.Security.Cryptography.HashAlgorithmName]::SHA256)
+          if (-not $sig.TimeStamperCertificate) { throw }
+          O=LANTERNOPS LLC
+  sign-windows-tauri:
+    needs: [resolve-windows-signing-provider, sign-windows-tauri-azure, sign-windows-tauri-sslcom]
+    if: \${{ !cancelled() && needs.resolve-windows-signing-provider.result != 'skipped' }}
+    permissions:
+      contents: read
+    steps:
+      - env:
+          PROVIDER: \${{ needs.resolve-windows-signing-provider.outputs.provider }}
+          AZURE_RESULT: \${{ needs.sign-windows-tauri-azure.result }}
+          SSLCOM_RESULT: \${{ needs.sign-windows-tauri-sslcom.result }}
+        run: echo convergence
+`;
+}
+
+test('passing public signing fixture raises no public-signing violations', () => {
+  const rules = new Set(inspectWorkflowText('release.yml', publicSigningFixture()).map(({ rule }) => rule));
+  for (const rule of PUBLIC_SIGNING_RULES) assert.equal(rules.has(rule), false, rule);
+});
+
+test('public signing resolver rejects unknown providers', () => {
+  const text = publicSigningFixture().replace('*) exit 1 ;;', '*) echo "provider=azure" >> "$GITHUB_OUTPUT" ;;');
+  assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'windows-signing-provider-must-fail-closed'), true);
+});
+
+test('SSL.com signer cannot receive OIDC', () => {
+  const text = publicSigningFixture().replace('sign-windows-tauri-sslcom:\n', 'sign-windows-tauri-sslcom:\n    permissions:\n      id-token: write\n');
+  assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'windows-signing-provider-least-privilege'), true);
+});
+
+test('SSL.com signer requires a pinned certificate and timestamp', () => {
+  const text = publicSigningFixture()
+    .replaceAll('SSLCOM_CERT_SHA256', 'REMOVED_CERT_PIN')
+    .replaceAll('TimeStamperCertificate', 'REMOVED_TIMESTAMP');
+  const rules = new Set(inspectWorkflowText('release.yml', text).map(({ rule }) => rule));
+  assert.equal(rules.has('sslcom-signing-must-pin-certificate'), true);
+  assert.equal(rules.has('windows-signing-must-require-timestamp'), true);
+});
+
+test('SSL.com signer cannot mention public Agent-family artifacts', () => {
+  const text = publicSigningFixture().replace('O=LANTERNOPS LLC', 'O=LANTERNOPS LLC\n          breeze-agent.msi');
+  assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'sslcom-signing-must-not-touch-agent'), true);
+});
+
+test('convergence gate must consume both signer results', () => {
+  const text = publicSigningFixture().replace(/ +AZURE_RESULT:[^\n]*\n/u, '');
+  assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'windows-signing-provider-must-converge'), true);
+});
+
 test('rejects checkout in an Apple-secret developer signing job', () => {
   const text = developerSigningWorkflow(`      - name: Verify unsigned artifact before secrets
         run: shasum -a 256 -c SHA256SUMS

--- a/.github/scripts/check-workflow-security.test.mjs
+++ b/.github/scripts/check-workflow-security.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { readFileSync, readdirSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -12,6 +13,8 @@ import {
 
 const temporaryDirectories = [];
 const pinnedCheckout = 'actions/checkout@0123456789abcdef0123456789abcdef01234567';
+const PUBLIC_RESOLVER_SCRIPT = '.github/scripts/resolve-windows-signing-provider.mjs';
+const PUBLIC_CONVERGENCE_SCRIPT = '.github/scripts/assert-windows-signing-convergence.mjs';
 
 afterEach(async () => {
   await Promise.all(
@@ -682,14 +685,11 @@ jobs:
     outputs:
       provider: \${{ steps.provider.outputs.provider }}
     steps:
+      - uses: ${pinnedCheckout}
       - id: provider
         env:
           RAW_PROVIDER: \${{ vars.WINDOWS_SIGNING_PROVIDER }}
-        run: |
-          case "\${RAW_PROVIDER:-azure}" in
-            azure|sslcom) echo "provider=\${RAW_PROVIDER:-azure}" >> "$GITHUB_OUTPUT" ;;
-            *) exit 1 ;;
-          esac
+        run: node ${PUBLIC_RESOLVER_SCRIPT} "$RAW_PROVIDER" >> "$GITHUB_OUTPUT"
   sign-windows-tauri-azure:
     needs: [resolve-windows-signing-provider]
     if: needs.resolve-windows-signing-provider.outputs.provider == 'azure'
@@ -727,13 +727,51 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: ${pinnedCheckout}
       - env:
           PROVIDER: \${{ needs.resolve-windows-signing-provider.outputs.provider }}
           AZURE_RESULT: \${{ needs.sign-windows-tauri-azure.result }}
           SSLCOM_RESULT: \${{ needs.sign-windows-tauri-sslcom.result }}
-        run: echo convergence
+        run: node ${PUBLIC_CONVERGENCE_SCRIPT} "$PROVIDER" "$AZURE_RESULT" "$SSLCOM_RESULT"
 `;
 }
+
+function runCredentialFreeScript(script, args) {
+  return spawnSync(process.execPath, [script, ...args], { encoding: 'utf8' });
+}
+
+test('public resolver executable normalizes empty and accepts only azure or sslcom', () => {
+  for (const [input, expected] of [['', 'azure'], ['azure', 'azure'], ['sslcom', 'sslcom']]) {
+    const result = runCredentialFreeScript(PUBLIC_RESOLVER_SCRIPT, [input]);
+    assert.equal(result.status, 0, `${input}: ${result.stderr}`);
+    assert.equal(result.stdout, `provider=${expected}\n`);
+  }
+
+  const invalid = runCredentialFreeScript(PUBLIC_RESOLVER_SCRIPT, ['typo']);
+  assert.notEqual(invalid.status, 0);
+  assert.equal(invalid.stdout, '');
+});
+
+test('public convergence executable accepts exactly the selected success/skipped pair', () => {
+  const cases = [
+    ['azure', 'success', 'skipped', true],
+    ['sslcom', 'skipped', 'success', true],
+    ['azure', 'skipped', 'skipped', false],
+    ['sslcom', 'skipped', 'skipped', false],
+    ['azure', 'success', 'success', false],
+    ['sslcom', 'success', 'success', false],
+    ['azure', 'failed', 'skipped', false],
+    ['sslcom', 'skipped', 'failed', false],
+    ['azure', 'cancelled', 'skipped', false],
+    ['sslcom', 'skipped', 'cancelled', false],
+    ['invalid', 'skipped', 'skipped', false],
+  ];
+
+  for (const [provider, azure, sslcom, accepted] of cases) {
+    const result = runCredentialFreeScript(PUBLIC_CONVERGENCE_SCRIPT, [provider, azure, sslcom]);
+    assert.equal(result.status === 0, accepted, `${provider}/${azure}/${sslcom}: ${result.stderr}`);
+  }
+});
 
 test('passing public signing fixture raises no public-signing violations', () => {
   const rules = new Set(inspectWorkflowText('release.yml', publicSigningFixture()).map(({ rule }) => rule));
@@ -741,7 +779,7 @@ test('passing public signing fixture raises no public-signing violations', () =>
 });
 
 test('public signing resolver rejects unknown providers', () => {
-  const text = publicSigningFixture().replace('*) exit 1 ;;', '*) echo "provider=azure" >> "$GITHUB_OUTPUT" ;;');
+  const text = publicSigningFixture().replace(PUBLIC_RESOLVER_SCRIPT, 'untrusted-inline-fallback.mjs');
   assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'windows-signing-provider-must-fail-closed'), true);
 });
 
@@ -765,7 +803,7 @@ test('SSL.com signer cannot mention public Agent-family artifacts', () => {
 });
 
 test('convergence gate must consume both signer results', () => {
-  const text = publicSigningFixture().replace(/ +AZURE_RESULT:[^\n]*\n/u, '');
+  const text = publicSigningFixture().replace(PUBLIC_CONVERGENCE_SCRIPT, 'echo-convergence.mjs');
   assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'windows-signing-provider-must-converge'), true);
 });
 

--- a/.github/scripts/check-workflow-security.test.mjs
+++ b/.github/scripts/check-workflow-security.test.mjs
@@ -666,13 +666,34 @@ ${signingSteps}
 }
 
 const SSL_ACTION = 'SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b';
+const AZURE_ACTION = 'azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82';
+const SHARED_VERIFIER = '.github/scripts/Verify-WindowsSignature.ps1';
+const PUBLIC_AGENT_WINDOWS_ASSETS = [
+  'breeze-agent-windows-amd64.exe',
+  'breeze-backup-windows-amd64.exe',
+  'breeze-watchdog-windows-amd64.exe',
+  'breeze-user-helper-windows-amd64.exe',
+  'breeze-agent.msi',
+];
+const SSLCOM_SECRET_NAMES = [
+  'SSLCOM_USERNAME',
+  'SSLCOM_PASSWORD',
+  'SSLCOM_CREDENTIAL_ID',
+  'SSLCOM_TOTP_SECRET',
+  'SSLCOM_CERT_SHA256',
+  'SSLCOM_ENVIRONMENT_LABEL',
+];
 const PUBLIC_SIGNING_RULES = [
   'windows-signing-provider-must-fail-closed',
   'windows-signing-provider-least-privilege',
   'sslcom-signing-must-pin-certificate',
+  'sslcom-signing-must-pin-toolchain',
   'windows-signing-must-require-timestamp',
+  'windows-signing-must-assert-publisher',
   'sslcom-signing-must-not-touch-agent',
   'windows-signing-provider-must-converge',
+  'windows-signing-gate-must-block-release',
+  'windows-signing-providers-must-cover-same-artifacts',
 ];
 
 function publicSigningFixture() {
@@ -697,35 +718,78 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - shell: pwsh
+      - uses: ${pinnedCheckout}
+      - name: Sign viewer MSI
+        uses: ${AZURE_ACTION}
+        with:
+          files: \${{ github.workspace }}/staging/breeze-viewer-windows.msi
+      - name: Sign helper MSI
+        uses: ${AZURE_ACTION}
+        with:
+          files: \${{ github.workspace }}/staging/breeze-helper-windows.msi
+      - name: Verify signatures
+        shell: pwsh
+        env:
+          EXPECTED_SUBJECT: \${{ env.WINDOWS_SIGNING_EXPECTED_SUBJECT }}
         run: |
-          if (-not $sig.SignerCertificate) { throw }
-          if (-not $sig.TimeStamperCertificate) { throw }
+          & ${SHARED_VERIFIER} \`
+            -Path "staging/breeze-viewer-windows.msi", "staging/breeze-helper-windows.msi" \`
+            -ExpectedSubject $env:EXPECTED_SUBJECT
   sign-windows-tauri-sslcom:
     needs: [resolve-windows-signing-provider]
     if: needs.resolve-windows-signing-provider.outputs.provider == 'sslcom'
     permissions:
       contents: read
     steps:
-      - uses: ${SSL_ACTION}
-        with:
-          username: \${{ secrets.SSLCOM_USERNAME }}
-          password: \${{ secrets.SSLCOM_PASSWORD }}
-          credential_id: \${{ secrets.SSLCOM_CREDENTIAL_ID }}
-          totp_secret: \${{ secrets.SSLCOM_TOTP_SECRET }}
-      - shell: pwsh
+      - uses: ${pinnedCheckout}
+      - name: Validate signing configuration
+        shell: pwsh
         env:
+          SSLCOM_USERNAME: \${{ secrets.SSLCOM_USERNAME }}
+          SSLCOM_PASSWORD: \${{ secrets.SSLCOM_PASSWORD }}
+          SSLCOM_CREDENTIAL_ID: \${{ secrets.SSLCOM_CREDENTIAL_ID }}
+          SSLCOM_TOTP_SECRET: \${{ secrets.SSLCOM_TOTP_SECRET }}
+          SSLCOM_CERT_SHA256: \${{ secrets.SSLCOM_CERT_SHA256 }}
+          SSLCOM_ENVIRONMENT_LABEL: \${{ secrets.SSLCOM_ENVIRONMENT_LABEL }}
+          EXPECTED_ENVIRONMENT: signing-production
+        run: |
+          if ($env:SSLCOM_ENVIRONMENT_LABEL -ne $env:EXPECTED_ENVIRONMENT) {
+            throw "wrong signing environment"
+          }
+      - name: Stage CodeSignTool
+        shell: pwsh
+        env:
+          CODESIGNTOOL_SHA256: e22094505decbe622afe5b0c27abc618ed2ba179bd94f3450490352399d5ef2a
+        run: |
+          $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne $env:CODESIGNTOOL_SHA256) {
+            throw "CodeSignTool digest mismatch"
+          }
+          "CODESIGNTOOL_PATH=$target" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "JAVA_VERSION=17" | Out-File -FilePath $env:GITHUB_ENV -Append
+      - name: Sign viewer MSI
+        uses: ${SSL_ACTION}
+        with:
+          command: sign
+          file_path: \${{ github.workspace }}/staging/breeze-viewer-windows.msi
+      - name: Sign helper MSI
+        uses: ${SSL_ACTION}
+        with:
+          command: sign
+          file_path: \${{ github.workspace }}/staging/breeze-helper-windows.msi
+      - name: Verify signatures
+        shell: pwsh
+        env:
+          EXPECTED_SUBJECT: \${{ env.WINDOWS_SIGNING_EXPECTED_SUBJECT }}
           SSLCOM_CERT_SHA256: \${{ secrets.SSLCOM_CERT_SHA256 }}
         run: |
-          $expected = $env:SSLCOM_CERT_SHA256
-          $actual = $sig.SignerCertificate.GetCertHashString([System.Security.Cryptography.HashAlgorithmName]::SHA256)
-          if (-not $sig.TimeStamperCertificate) { throw }
-          O=LANTERNOPS LLC
+          & ${SHARED_VERIFIER} \`
+            -Path "staging/breeze-viewer-windows.msi", "staging/breeze-helper-windows.msi" \`
+            -ExpectedSubject $env:EXPECTED_SUBJECT \`
+            -ExpectedThumbprintSha256 $env:SSLCOM_CERT_SHA256
   sign-windows-tauri:
     needs: [resolve-windows-signing-provider, sign-windows-tauri-azure, sign-windows-tauri-sslcom]
     if: \${{ !cancelled() && needs.resolve-windows-signing-provider.result != 'skipped' }}
-    permissions:
-      contents: read
     steps:
       - uses: ${pinnedCheckout}
       - env:
@@ -733,11 +797,56 @@ jobs:
           AZURE_RESULT: \${{ needs.sign-windows-tauri-azure.result }}
           SSLCOM_RESULT: \${{ needs.sign-windows-tauri-sslcom.result }}
         run: node ${PUBLIC_CONVERGENCE_SCRIPT} "$PROVIDER" "$AZURE_RESULT" "$SSLCOM_RESULT"
+  release-integrity-gate:
+    needs: [sign-windows-tauri]
+    steps:
+      - env:
+          SIGN_WINDOWS_TAURI_RESULT: \${{ needs.sign-windows-tauri.result }}
+        run: |
+          require_success "sign-windows-tauri" "$SIGN_WINDOWS_TAURI_RESULT"
 `;
+}
+
+function publicSigningRules(text) {
+  return new Set(
+    inspectWorkflowText('release.yml', text)
+      .map(({ rule }) => rule)
+      .filter((rule) => PUBLIC_SIGNING_RULES.includes(rule)),
+  );
 }
 
 function runCredentialFreeScript(script, args) {
   return spawnSync(process.execPath, [script, ...args], { encoding: 'utf8' });
+}
+
+function replaceOnce(text, needle, replacement) {
+  const index = text.indexOf(needle);
+  assert.notEqual(index, -1, `fixture mutation target not found: ${needle}`);
+  assert.equal(text.indexOf(needle, index + 1), -1, `fixture mutation target is ambiguous: ${needle}`);
+  return text.slice(0, index) + replacement + text.slice(index + needle.length);
+}
+
+// Deletes a whole job by name, from its key line to the next job key.
+function dropJob(text, name) {
+  const start = text.indexOf(`\n  ${name}:\n`);
+  assert.notEqual(start, -1, `job not found: ${name}`);
+  const rest = text.slice(start + 1);
+  const match = rest.match(/\n {2}[a-z][a-z0-9-]*:\n/u);
+  // No following job means this is the last one: truncate to its start.
+  return match
+    ? text.slice(0, start + 1) + rest.slice(match.index + 1)
+    : text.slice(0, start + 1);
+}
+
+// The azure and sslcom jobs invoke the shared verifier with identical text, so
+// mutations must target one occurrence rather than both.
+function replaceNth(text, needle, occurrence, replacement) {
+  let index = -1;
+  for (let seen = 0; seen < occurrence; seen += 1) {
+    index = text.indexOf(needle, index + 1);
+    assert.notEqual(index, -1, `occurrence ${occurrence} of ${needle} not found`);
+  }
+  return text.slice(0, index) + replacement + text.slice(index + needle.length);
 }
 
 test('public resolver executable normalizes empty and accepts only azure or sslcom', () => {
@@ -747,12 +856,24 @@ test('public resolver executable normalizes empty and accepts only azure or sslc
     assert.equal(result.stdout, `provider=${expected}\n`);
   }
 
-  const invalid = runCredentialFreeScript(PUBLIC_RESOLVER_SCRIPT, ['typo']);
-  assert.notEqual(invalid.status, 0);
-  assert.equal(invalid.stdout, '');
+  // Anything else must fail closed and emit nothing that could reach
+  // $GITHUB_OUTPUT. Casing, padding and newline injection all land here.
+  for (const invalid of ['typo', 'Azure', ' sslcom', 'sslcom ', 'azure\nprovider=sslcom', 'AZURE']) {
+    const result = runCredentialFreeScript(PUBLIC_RESOLVER_SCRIPT, [invalid]);
+    assert.notEqual(result.status, 0, `expected rejection for ${JSON.stringify(invalid)}`);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /WINDOWS_SIGNING_PROVIDER must be empty, azure, or sslcom/u);
+  }
+});
+
+test('public resolver executable treats a missing argument as the Azure default', () => {
+  const result = runCredentialFreeScript(PUBLIC_RESOLVER_SCRIPT, []);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, 'provider=azure\n');
 });
 
 test('public convergence executable accepts exactly the selected success/skipped pair', () => {
+  // GitHub emits success | failure | cancelled | skipped — never 'failed'.
   const cases = [
     ['azure', 'success', 'skipped', true],
     ['sslcom', 'skipped', 'success', true],
@@ -760,11 +881,15 @@ test('public convergence executable accepts exactly the selected success/skipped
     ['sslcom', 'skipped', 'skipped', false],
     ['azure', 'success', 'success', false],
     ['sslcom', 'success', 'success', false],
-    ['azure', 'failed', 'skipped', false],
-    ['sslcom', 'skipped', 'failed', false],
+    ['azure', 'failure', 'skipped', false],
+    ['sslcom', 'skipped', 'failure', false],
     ['azure', 'cancelled', 'skipped', false],
     ['sslcom', 'skipped', 'cancelled', false],
+    // Both providers actually executed and one failed: never converged.
+    ['azure', 'success', 'failure', false],
+    ['sslcom', 'failure', 'success', false],
     ['invalid', 'skipped', 'skipped', false],
+    ['', 'skipped', 'skipped', false],
   ];
 
   for (const [provider, azure, sslcom, accepted] of cases) {
@@ -773,38 +898,157 @@ test('public convergence executable accepts exactly the selected success/skipped
   }
 });
 
+test('public convergence executable rejects missing and surplus arguments', () => {
+  for (const args of [[], ['azure'], ['azure', 'success']]) {
+    const result = runCredentialFreeScript(PUBLIC_CONVERGENCE_SCRIPT, args);
+    assert.notEqual(result.status, 0, `expected rejection for ${JSON.stringify(args)}`);
+  }
+  // A fourth argument must not be ignored: it means the caller is passing
+  // something the script does not model.
+  const surplus = runCredentialFreeScript(PUBLIC_CONVERGENCE_SCRIPT, ['azure', 'success', 'skipped', 'success']);
+  assert.notEqual(surplus.status, 0);
+});
+
 test('passing public signing fixture raises no public-signing violations', () => {
-  const rules = new Set(inspectWorkflowText('release.yml', publicSigningFixture()).map(({ rule }) => rule));
-  for (const rule of PUBLIC_SIGNING_RULES) assert.equal(rules.has(rule), false, rule);
+  assert.deepEqual([...publicSigningRules(publicSigningFixture())], []);
 });
 
-test('public signing resolver rejects unknown providers', () => {
-  const text = publicSigningFixture().replace(PUBLIC_RESOLVER_SCRIPT, 'untrusted-inline-fallback.mjs');
-  assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'windows-signing-provider-must-fail-closed'), true);
+// One mutation per assertion. A shared replaceAll across the fixture used to
+// neuter four checks at once, which meant none of them was pinned individually.
+const PUBLIC_SIGNING_MUTATIONS = [
+  ['resolver invocation replaced', (t) => replaceOnce(t, PUBLIC_RESOLVER_SCRIPT, 'untrusted-inline-fallback.mjs'), 'windows-signing-provider-must-fail-closed'],
+  ['resolver job deleted', (t) => dropJob(t, 'resolve-windows-signing-provider'), 'windows-signing-provider-must-fail-closed'],
+  ['azure job deleted', (t) => dropJob(t, 'sign-windows-tauri-azure'), 'windows-signing-must-assert-publisher'],
+  ['sslcom job deleted', (t) => dropJob(t, 'sign-windows-tauri-sslcom'), 'sslcom-signing-must-pin-certificate'],
+  ['convergence gate deleted', (t) => dropJob(t, 'sign-windows-tauri'), 'windows-signing-provider-must-converge'],
+  ['integrity gate deleted', (t) => dropJob(t, 'release-integrity-gate'), 'windows-signing-gate-must-block-release'],
+  ['azure loses OIDC', (t) => replaceOnce(t, '      id-token: write\n', ''), 'windows-signing-provider-least-privilege'],
+  ['sslcom gains OIDC', (t) => replaceOnce(t, "  sign-windows-tauri-sslcom:\n    needs:", "  sign-windows-tauri-sslcom:\n    permissions:\n      id-token: write\n    needs:"), 'windows-signing-provider-least-privilege'],
+  ['resolver gains OIDC', (t) => replaceOnce(t, '  resolve-windows-signing-provider:\n    runs-on: ubuntu-latest\n    permissions:\n      contents: read', '  resolve-windows-signing-provider:\n    runs-on: ubuntu-latest\n    permissions:\n      contents: read\n      id-token: write'), 'windows-signing-provider-least-privilege'],
+  ['gate gains OIDC', (t) => replaceOnce(t, '  sign-windows-tauri:\n    needs:', '  sign-windows-tauri:\n    permissions:\n      id-token: write\n    needs:'), 'windows-signing-provider-least-privilege'],
+  ['azure skips the shared verifier', (t) => replaceNth(t, SHARED_VERIFIER, 1, './unreviewed-verify.ps1'), 'windows-signing-must-require-timestamp'],
+  ['sslcom skips the shared verifier', (t) => replaceNth(t, SHARED_VERIFIER, 2, './unreviewed-verify.ps1'), 'windows-signing-must-require-timestamp'],
+  ['azure drops the publisher assertion', (t) => replaceNth(t, '-ExpectedSubject $env:EXPECTED_SUBJECT', 1, '-Verbose:$false'), 'windows-signing-must-assert-publisher'],
+  ['sslcom drops the publisher assertion', (t) => replaceNth(t, '-ExpectedSubject $env:EXPECTED_SUBJECT', 2, '-Verbose:$false'), 'windows-signing-must-assert-publisher'],
+  ['sslcom drops the certificate pin', (t) => replaceOnce(t, '            -ExpectedThumbprintSha256 $env:SSLCOM_CERT_SHA256', '            -Verbose:$false'), 'sslcom-signing-must-pin-certificate'],
+  ['sslcom action unpinned', (t) => t.split(SSL_ACTION).join('SSLcom/esigner-codesign@v1'), 'sslcom-signing-must-pin-certificate'],
+  ['sslcom drops the environment label guard', (t) => replaceOnce(t, 'if ($env:SSLCOM_ENVIRONMENT_LABEL -ne $env:EXPECTED_ENVIRONMENT) {', 'if ($false) {'), 'sslcom-signing-must-pin-certificate'],
+  ['CodeSignTool digest guard removed', (t) => replaceOnce(t, 'if ($actual -ne $env:CODESIGNTOOL_SHA256) {', 'if ($false) {'), 'sslcom-signing-must-pin-toolchain'],
+  ['CodeSignTool hashing removed', (t) => replaceOnce(t, 'Get-FileHash', 'Get-Item'), 'sslcom-signing-must-pin-toolchain'],
+  ['CODESIGNTOOL_PATH not exported', (t) => replaceOnce(t, '"CODESIGNTOOL_PATH=$target"', '"UNUSED=$target"'), 'sslcom-signing-must-pin-toolchain'],
+  ['JAVA_VERSION not pinned', (t) => replaceOnce(t, '"JAVA_VERSION=17"', '"UNUSED=17"'), 'sslcom-signing-must-pin-toolchain'],
+  ['sslcom batch-signs a directory', (t) => replaceOnce(t, '          command: sign\n          file_path: ${{ github.workspace }}/staging/breeze-viewer-windows.msi', '          command: batch_sign\n          file_path: ${{ github.workspace }}/staging/breeze-viewer-windows.msi'), 'sslcom-signing-must-not-touch-agent'],
+  ['sslcom stops signing the helper', (t) => replaceOnce(t, '          file_path: ${{ github.workspace }}/staging/breeze-helper-windows.msi', '          file_path: ${{ github.workspace }}/staging/breeze-viewer-windows.msi'), 'windows-signing-providers-must-cover-same-artifacts'],
+  ['azure stops signing the helper', (t) => replaceOnce(t, '          files: ${{ github.workspace }}/staging/breeze-helper-windows.msi', '          files: ${{ github.workspace }}/staging/breeze-viewer-windows.msi'), 'windows-signing-providers-must-cover-same-artifacts'],
+  ['gate loses !cancelled()', (t) => replaceOnce(t, '!cancelled() && ', ''), 'windows-signing-provider-must-converge'],
+  ['gate ignores the azure result', (t) => replaceOnce(t, '          AZURE_RESULT: ${{ needs.sign-windows-tauri-azure.result }}\n', '          AZURE_RESULT: skipped\n'), 'windows-signing-provider-must-converge'],
+  ['gate ignores the sslcom result', (t) => replaceOnce(t, '          SSLCOM_RESULT: ${{ needs.sign-windows-tauri-sslcom.result }}\n', '          SSLCOM_RESULT: skipped\n'), 'windows-signing-provider-must-converge'],
+  ['gate stops running the convergence script', (t) => replaceOnce(t, PUBLIC_CONVERGENCE_SCRIPT, 'echo-convergence.mjs'), 'windows-signing-provider-must-converge'],
+  ['integrity gate stops requiring the signing gate', (t) => replaceOnce(t, 'require_success "sign-windows-tauri" "$SIGN_WINDOWS_TAURI_RESULT"', 'true'), 'windows-signing-gate-must-block-release'],
+];
+
+for (const asset of PUBLIC_AGENT_WINDOWS_ASSETS) {
+  PUBLIC_SIGNING_MUTATIONS.push([
+    `sslcom touches ${asset}`,
+    (t) => replaceOnce(t, '          command: sign\n          file_path: ${{ github.workspace }}/staging/breeze-viewer-windows.msi', `          command: sign\n          file_path: \${{ github.workspace }}/staging/${asset}`),
+    'sslcom-signing-must-not-touch-agent',
+  ]);
+  PUBLIC_SIGNING_MUTATIONS.push([
+    `azure touches ${asset}`,
+    (t) => replaceOnce(t, '          files: ${{ github.workspace }}/staging/breeze-viewer-windows.msi', `          files: \${{ github.workspace }}/staging/${asset}`),
+    'sslcom-signing-must-not-touch-agent',
+  ]);
+}
+
+for (const secret of SSLCOM_SECRET_NAMES) {
+  PUBLIC_SIGNING_MUTATIONS.push([
+    `sslcom stops reading ${secret}`,
+    (t) => t.split(`secrets.${secret} `).join('secrets.REMOVED '),
+    'sslcom-signing-must-pin-certificate',
+  ]);
+}
+
+const observedPublicSigningRules = new Set();
+
+for (const [label, mutate, expectedRule] of PUBLIC_SIGNING_MUTATIONS) {
+  test(`public signing rejects: ${label}`, () => {
+    const rules = publicSigningRules(mutate(publicSigningFixture()));
+    assert.equal(
+      rules.has(expectedRule),
+      true,
+      `expected ${expectedRule}; got [${[...rules].join(', ')}]`,
+    );
+    for (const rule of rules) observedPublicSigningRules.add(rule);
+  });
+}
+
+test('every declared public-signing rule is reachable', () => {
+  for (const rule of PUBLIC_SIGNING_RULES) {
+    assert.equal(
+      observedPublicSigningRules.has(rule),
+      true,
+      `rule ${rule} is never produced by any mutation — it may be dead or misspelled`,
+    );
+  }
 });
 
-test('SSL.com signer cannot receive OIDC', () => {
-  const text = publicSigningFixture().replace('sign-windows-tauri-sslcom:\n', 'sign-windows-tauri-sslcom:\n    permissions:\n      id-token: write\n');
-  assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'windows-signing-provider-least-privilege'), true);
+// Renaming the four signing jobs used to disable every rule above, silently and
+// with CI green. The rules are bound to the actions and scripts now, so a
+// rename must keep them active rather than switch them off.
+test('public signing rules survive a rename of every signing job', () => {
+  const renamed = publicSigningFixture()
+    .split(PUBLIC_RESOLVER_SCRIPT).join('@@RESOLVER@@')
+    .split(PUBLIC_CONVERGENCE_SCRIPT).join('@@CONVERGENCE@@')
+    .split('sign-windows-tauri-azure').join('sign-wt-az')
+    .split('sign-windows-tauri-sslcom').join('sign-wt-ssl')
+    .split('resolve-windows-signing-provider').join('resolve-winsign')
+    .split('sign-windows-tauri').join('sign-wt-gate')
+    .split('@@RESOLVER@@').join(PUBLIC_RESOLVER_SCRIPT)
+    .split('@@CONVERGENCE@@').join(PUBLIC_CONVERGENCE_SCRIPT);
+
+  assert.deepEqual([...publicSigningRules(renamed)], [], 'a pure rename must stay clean');
+
+  const renamedAndNeutered = replaceOnce(
+    renamed,
+    '            -ExpectedThumbprintSha256 $env:SSLCOM_CERT_SHA256',
+    '            -Verbose:$false',
+  );
+  assert.equal(
+    publicSigningRules(renamedAndNeutered).has('sslcom-signing-must-pin-certificate'),
+    true,
+    'renaming the jobs must not disable the certificate pin',
+  );
 });
 
-test('SSL.com signer requires a pinned certificate and timestamp', () => {
-  const text = publicSigningFixture()
-    .replaceAll('SSLCOM_CERT_SHA256', 'REMOVED_CERT_PIN')
-    .replaceAll('TimeStamperCertificate', 'REMOVED_TIMESTAMP');
-  const rules = new Set(inspectWorkflowText('release.yml', text).map(({ rule }) => rule));
-  assert.equal(rules.has('sslcom-signing-must-pin-certificate'), true);
-  assert.equal(rules.has('windows-signing-must-require-timestamp'), true);
+test('the real release workflow carries the full Windows signing topology', () => {
+  const releaseWorkflow = readFileSync('.github/workflows/release.yml', 'utf8');
+  assert.deepEqual([...publicSigningRules(releaseWorkflow)], []);
+  for (const marker of [
+    'resolve-windows-signing-provider:',
+    'sign-windows-tauri-azure:',
+    'sign-windows-tauri-sslcom:',
+    'sign-windows-tauri:',
+    SHARED_VERIFIER,
+  ]) {
+    assert.equal(releaseWorkflow.includes(marker), true, `release.yml lost ${marker}`);
+  }
 });
 
-test('SSL.com signer cannot mention public Agent-family artifacts', () => {
-  const text = publicSigningFixture().replace('O=LANTERNOPS LLC', 'O=LANTERNOPS LLC\n          breeze-agent.msi');
-  assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'sslcom-signing-must-not-touch-agent'), true);
-});
-
-test('convergence gate must consume both signer results', () => {
-  const text = publicSigningFixture().replace(PUBLIC_CONVERGENCE_SCRIPT, 'echo-convergence.mjs');
-  assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'windows-signing-provider-must-converge'), true);
+// The verifier is the single place both providers assert publisher identity, so
+// a guard downgraded from `throw` to a warning would silently accept any signer.
+test('the shared signature verifier enforces every check it performs', () => {
+  const verifier = readFileSync('.github/scripts/Verify-WindowsSignature.ps1', 'utf8');
+  const enforced = [
+    [/\$signature\.Status -ne 'Valid'[\s\S]{0,200}throw/u, 'signature status'],
+    [/-not \$signature\.SignerCertificate[\s\S]{0,120}throw/u, 'signer certificate present'],
+    [/-not \$signature\.TimeStamperCertificate[\s\S]{0,120}throw/u, 'RFC 3161 timestamp present'],
+    [/NotAfter[\s\S]{0,160}throw/u, 'certificate not expired'],
+    [/ExpectedSubject[\s\S]{0,200}throw/u, 'publisher subject'],
+    [/\$actualPin -ne \$expectedPin[\s\S]{0,160}throw/u, 'certificate pin'],
+  ];
+  for (const [pattern, description] of enforced) {
+    assert.match(verifier, pattern, `verifier must throw on: ${description}`);
+  }
 });
 
 test('rejects checkout in an Apple-secret developer signing job', () => {

--- a/.github/scripts/resolve-windows-signing-provider.mjs
+++ b/.github/scripts/resolve-windows-signing-provider.mjs
@@ -1,0 +1,9 @@
+const rawProvider = process.argv[2] ?? '';
+const provider = rawProvider === '' ? 'azure' : rawProvider;
+
+if (provider !== 'azure' && provider !== 'sslcom') {
+  process.stderr.write('WINDOWS_SIGNING_PROVIDER must be empty, azure, or sslcom\n');
+  process.exitCode = 1;
+} else {
+  process.stdout.write(`provider=${provider}\n`);
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1731,8 +1731,16 @@ jobs:
           # credential and a prerelease tag would be signed with the production
           # certificate. This label can only match one environment, so a
           # repo-level secret fails the other one loudly instead.
+          #
+          # It is stored as a SECRET despite holding no secret value, because it
+          # only proves anything if it lives in the same store as the
+          # credentials. As a repository/environment variable an operator could
+          # scope the label correctly while still leaving the credentials at
+          # repository level, and this check would pass.
           if ($env:SSLCOM_ENVIRONMENT_LABEL -ne $env:EXPECTED_ENVIRONMENT) {
-            throw "SSLCOM_ENVIRONMENT_LABEL is '$($env:SSLCOM_ENVIRONMENT_LABEL)' but this job runs in '$($env:EXPECTED_ENVIRONMENT)'. The SSLCOM_* secrets must be scoped to each signing environment, not to the repository."
+            # Do not interpolate the label: it is stored as a secret, so its
+            # value is masked in the log and would print as '***'.
+            throw "SSLCOM_ENVIRONMENT_LABEL does not match '$($env:EXPECTED_ENVIRONMENT)', the environment this job is running in. Add the SSLCOM_* secrets to the signing-production and signing-prerelease environments individually -- not to the repository -- and set SSLCOM_ENVIRONMENT_LABEL in each to that environment's own name."
           }
 
       # SUPPLY CHAIN: the action pin below is a 40-char commit SHA, but at

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1849,6 +1849,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # Republished so the release manifest can record which CA vouched for the
+    # Windows artifacts. Without it a provider switch is invisible to every
+    # downstream verifier holding the manifest signing key.
+    outputs:
+      provider: ${{ needs.resolve-windows-signing-provider.outputs.provider }}
     steps:
       - name: Checkout convergence assertion
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -2127,6 +2132,10 @@ jobs:
           merge-multiple: false
 
       - name: Prepare release assets
+        env:
+          # Empty when Windows signing was skipped; the manifest then simply
+          # omits the field rather than asserting a provider that never ran.
+          WINDOWS_SIGNING_PROVIDER_USED: ${{ needs.sign-windows-tauri.outputs.provider }}
         run: |
           mkdir -p release-assets
 
@@ -2274,6 +2283,12 @@ jobs:
                   return "macos-developer-id-notarization-required"
               return "release-workflow-produced"
 
+          windows_signing_provider = os.environ.get("WINDOWS_SIGNING_PROVIDER_USED", "").strip()
+          if windows_signing_provider not in ("", "azure", "sslcom"):
+              raise SystemExit(
+                  f"unexpected Windows signing provider: {windows_signing_provider!r}"
+              )
+
           assets = []
           for path in sorted(release_dir.iterdir(), key=lambda item: item.name):
               if not path.is_file() or path.name in excluded:
@@ -2292,6 +2307,14 @@ jobs:
               }
               if is_signing_input(path.name):
                   entry["intendedUse"] = "signing-input"
+              # Which CA actually vouched for this artifact. Recorded only where
+              # Authenticode is required, so a provider switch is auditable from
+              # the signed manifest rather than only from workflow logs.
+              if (
+                  entry["platformTrust"] == "windows-authenticode-required"
+                  and windows_signing_provider
+              ):
+                  entry["signingProvider"] = windows_signing_provider
               assets.append(entry)
 
           manifest = {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ env:
   GO_VERSION: '1.26.6'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # Publisher every Windows signing provider must produce. Asserted by both
+  # signing jobs via .github/scripts/Verify-WindowsSignature.ps1 so a
+  # misconfigured endpoint or certificate profile cannot ship under another
+  # identity. Change here, not per job.
+  WINDOWS_SIGNING_EXPECTED_SUBJECT: LanternOps LLC
 
 # SR-007: least-privilege default for every job. Build jobs only need to read
 # the repo + exchange artifacts. Jobs that publish override this with their
@@ -1532,7 +1537,10 @@ jobs:
   sign-windows-tauri-azure:
     name: Sign Windows Tauri artifacts (Azure)
     needs: [build-viewer, build-helper, resolve-windows-signing-provider]
-    if: needs.resolve-windows-signing-provider.outputs.provider == 'azure'
+    if: >-
+      needs.resolve-windows-signing-provider.outputs.provider == 'azure'
+      && github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
     permissions:
       contents: read
@@ -1540,6 +1548,12 @@ jobs:
     environment:
       name: ${{ contains(github.ref_name, '-') && 'signing-prerelease' || 'signing-production' }}
     steps:
+      - name: Checkout signature verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
       - name: Download viewer Windows MSI
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -1559,8 +1573,20 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SIGNING_ENDPOINT: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
           AZURE_SIGNING_ACCOUNT_NAME: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          AZURE_CERT_PROFILE_PROD: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
+          AZURE_CERT_PROFILE_PRERELEASE: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
+          IS_PRERELEASE: ${{ contains(github.ref_name, '-') }}
         run: |
           $required = @("AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_SIGNING_ENDPOINT", "AZURE_SIGNING_ACCOUNT_NAME")
+          # The certificate profile selects WHICH certificate signs. Omitting it
+          # here let a half-populated signing environment surface as an opaque
+          # failure inside azure/artifact-signing-action instead of a named
+          # missing secret.
+          if ($env:IS_PRERELEASE -eq "true") {
+            $required += "AZURE_CERT_PROFILE_PRERELEASE"
+          } else {
+            $required += "AZURE_CERT_PROFILE_PROD"
+          }
           foreach ($name in $required) {
             if ([string]::IsNullOrWhiteSpace((Get-Item "env:$name").Value)) {
               throw "Missing required signing secret: $name"
@@ -1624,27 +1650,12 @@ jobs:
 
       - name: Verify signatures
         shell: pwsh
+        env:
+          EXPECTED_SUBJECT: ${{ env.WINDOWS_SIGNING_EXPECTED_SUBJECT }}
         run: |
-          $targets = @(
-            (Join-Path $env:GITHUB_WORKSPACE "staging\breeze-viewer-windows.msi"),
-            (Join-Path $env:GITHUB_WORKSPACE "staging\breeze-helper-windows.msi")
-          )
-          foreach ($target in $targets) {
-            $sig = Get-AuthenticodeSignature -FilePath $target
-            if ($sig.Status -ne "Valid" -and $sig.Status -ne "UnknownError") {
-              throw "Signature validation failed for $target. Status: $($sig.Status)"
-            }
-            if ($sig.Status -eq "UnknownError") {
-              Write-Host "::warning::$target signed but root cert not yet trusted locally (Status: UnknownError)."
-            }
-            if (-not $sig.SignerCertificate) {
-              throw "Signer certificate missing for $target"
-            }
-            if (-not $sig.TimeStamperCertificate) {
-              throw "RFC 3161 timestamp missing for $target"
-            }
-            Write-Host "Verified: $target - Status: $($sig.Status) - Signer: $($sig.SignerCertificate.Subject)"
-          }
+          & .github/scripts/Verify-WindowsSignature.ps1 `
+            -Path "staging/breeze-viewer-windows.msi", "staging/breeze-helper-windows.msi" `
+            -ExpectedSubject $env:EXPECTED_SUBJECT
 
       - name: Upload signed viewer MSI
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -1665,13 +1676,22 @@ jobs:
   sign-windows-tauri-sslcom:
     name: Sign Windows Tauri artifacts (SSL.com)
     needs: [build-viewer, build-helper, resolve-windows-signing-provider]
-    if: needs.resolve-windows-signing-provider.outputs.provider == 'sslcom'
+    if: >-
+      needs.resolve-windows-signing-provider.outputs.provider == 'sslcom'
+      && github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
     permissions:
       contents: read
     environment:
       name: ${{ contains(github.ref_name, '-') && 'signing-prerelease' || 'signing-production' }}
     steps:
+      - name: Checkout signature verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
       - name: Download viewer Windows MSI
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -1692,16 +1712,74 @@ jobs:
           SSLCOM_CREDENTIAL_ID: ${{ secrets.SSLCOM_CREDENTIAL_ID }}
           SSLCOM_TOTP_SECRET: ${{ secrets.SSLCOM_TOTP_SECRET }}
           SSLCOM_CERT_SHA256: ${{ secrets.SSLCOM_CERT_SHA256 }}
+          SSLCOM_ENVIRONMENT_LABEL: ${{ secrets.SSLCOM_ENVIRONMENT_LABEL }}
+          EXPECTED_ENVIRONMENT: ${{ contains(github.ref_name, '-') && 'signing-prerelease' || 'signing-production' }}
         run: |
-          $required = @("SSLCOM_USERNAME", "SSLCOM_PASSWORD", "SSLCOM_CREDENTIAL_ID", "SSLCOM_TOTP_SECRET", "SSLCOM_CERT_SHA256")
+          $required = @("SSLCOM_USERNAME", "SSLCOM_PASSWORD", "SSLCOM_CREDENTIAL_ID", "SSLCOM_TOTP_SECRET", "SSLCOM_CERT_SHA256", "SSLCOM_ENVIRONMENT_LABEL")
           foreach ($name in $required) {
             if ([string]::IsNullOrWhiteSpace((Get-Item "env:$name").Value)) {
               throw "Missing required signing secret: $name"
             }
           }
 
+          # Stable and prerelease tags MUST resolve different eSigner
+          # credentials, and the only thing that separates them is which GitHub
+          # Environment the secrets live in. Nothing about the YAML differs
+          # between the two, so if an operator adds SSLCOM_* at REPOSITORY level
+          # -- the path of least resistance, and how every AZURE_* secret is
+          # stored today -- both environments would silently resolve the same
+          # credential and a prerelease tag would be signed with the production
+          # certificate. This label can only match one environment, so a
+          # repo-level secret fails the other one loudly instead.
+          if ($env:SSLCOM_ENVIRONMENT_LABEL -ne $env:EXPECTED_ENVIRONMENT) {
+            throw "SSLCOM_ENVIRONMENT_LABEL is '$($env:SSLCOM_ENVIRONMENT_LABEL)' but this job runs in '$($env:EXPECTED_ENVIRONMENT)'. The SSLCOM_* secrets must be scoped to each signing environment, not to the repository."
+          }
+
+      # SUPPLY CHAIN: the action pin below is a 40-char commit SHA, but at
+      # runtime that action fetches CodeSignTool from a MUTABLE GitHub release
+      # asset with no checksum and executes it in this job, alongside the
+      # eSigner credentials. The pin does not cover that download. Pre-stage the
+      # archive here with a verified digest and export CODESIGNTOOL_PATH, which
+      # the action honours to skip its own fetch.
+      #
+      # JAVA_VERSION suppresses a second unverified download: the action installs
+      # Amazon Corretto resolved from a floating "latest" index (and reads, but
+      # never compares, the checksum that index publishes) whenever JAVA_VERSION
+      # is below 11. Nothing needs it -- CodeSignTool.bat runs the jdk-11.0.2
+      # bundled inside the verified archive.
+      - name: Stage CodeSignTool (pinned + checksum-verified)
+        shell: pwsh
+        env:
+          CODESIGNTOOL_URL: https://github.com/SSLcom/CodeSignTool/releases/download/v1.3.0/CodeSignTool-v1.3.0-windows.zip
+          CODESIGNTOOL_SHA256: e22094505decbe622afe5b0c27abc618ed2ba179bd94f3450490352399d5ef2a
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          $archive = Join-Path $env:RUNNER_TEMP "CodeSignTool-v1.3.0-windows.zip"
+          $target = Join-Path $env:RUNNER_TEMP "CodeSignTool-v1.3.0"
+
+          Invoke-WebRequest -Uri $env:CODESIGNTOOL_URL -OutFile $archive
+          $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne $env:CODESIGNTOOL_SHA256) {
+            throw "CodeSignTool digest mismatch. Expected $($env:CODESIGNTOOL_SHA256); got $actual"
+          }
+
+          Expand-Archive -Path $archive -DestinationPath $target -Force
+          foreach ($required in @("CodeSignTool.bat", "conf", "jar", "jdk-11.0.2")) {
+            if (-not (Test-Path (Join-Path $target $required))) {
+              throw "CodeSignTool archive verified but missing expected entry: $required"
+            }
+          }
+
+          "CODESIGNTOOL_PATH=$target" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "JAVA_VERSION=17" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       # SSL.com eSigner signs each staged MSI in place. `malware_block: true`
-      # blocks a detected malware payload and `clean_logs: true` removes logs.
+      # aborts the release if the eSigner malware scan flags a payload.
+      #
+      # `clean_logs` is deliberately NOT set: it is a no-op in this action.
+      # main.ts computes `path.dirname(command)` where `command` is the whole
+      # command STRING, so it truncates inside the quoted -input_file_path and
+      # deletes a nonexistent directory that `force: true` then swallows.
       - name: Sign viewer MSI (SSL.com)
         uses: SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b # v1.3.2
         with:
@@ -1713,7 +1791,6 @@ jobs:
           file_path: ${{ github.workspace }}/staging/breeze-viewer-windows.msi
           override: true
           malware_block: true
-          clean_logs: true
 
       - name: Sign helper MSI (SSL.com)
         uses: SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b # v1.3.2
@@ -1726,47 +1803,20 @@ jobs:
           file_path: ${{ github.workspace }}/staging/breeze-helper-windows.msi
           override: true
           malware_block: true
-          clean_logs: true
 
+      # No leaf pin on the Azure twin: Azure Artifact Signing certificates are
+      # short-lived and rotate automatically, so identity is asserted by subject
+      # there and by subject + pin here.
       - name: Verify signatures
         shell: pwsh
         env:
+          EXPECTED_SUBJECT: ${{ env.WINDOWS_SIGNING_EXPECTED_SUBJECT }}
           SSLCOM_CERT_SHA256: ${{ secrets.SSLCOM_CERT_SHA256 }}
         run: |
-          $targets = @(
-            (Join-Path $env:GITHUB_WORKSPACE "staging\breeze-viewer-windows.msi"),
-            (Join-Path $env:GITHUB_WORKSPACE "staging\breeze-helper-windows.msi")
-          )
-          foreach ($target in $targets) {
-            $sig = Get-AuthenticodeSignature -FilePath $target
-            if ($sig.Status -ne "Valid" -and $sig.Status -ne "UnknownError") {
-              throw "Signature validation failed for $target. Status: $($sig.Status)"
-            }
-            if ($sig.Status -eq "UnknownError") {
-              Write-Host "::warning::$target signed but root cert not yet trusted locally (Status: UnknownError)."
-            }
-            if (-not $sig.SignerCertificate) {
-              throw "Signer certificate missing for $target"
-            }
-            if (-not $sig.TimeStamperCertificate) {
-              throw "RFC 3161 timestamp missing for $target"
-            }
-            $expected = ($env:SSLCOM_CERT_SHA256 -replace '[^0-9A-Fa-f]', '').ToLowerInvariant()
-            if ($expected -notmatch '^[0-9a-f]{64}$') {
-              throw 'SSLCOM_CERT_SHA256 must contain exactly 64 hexadecimal characters'
-            }
-            $actual = ($sig.SignerCertificate.GetCertHashString(
-              [System.Security.Cryptography.HashAlgorithmName]::SHA256
-            ) -replace '[^0-9A-Fa-f]', '').ToLowerInvariant()
-            if ($actual -ne $expected) {
-              throw "Unexpected SSL.com signer certificate for $target (SHA-256 $actual)"
-            }
-            $subject = $sig.SignerCertificate.Subject
-            if ($subject -notmatch '(?i)(?:^|,\s*)(?:O|CN)=LANTERNOPS LLC(?:,|$)') {
-              throw "Unexpected SSL.com signer subject for $target: $subject"
-            }
-            Write-Host "Verified: $target - Status: $($sig.Status) - Signer: $subject"
-          }
+          & .github/scripts/Verify-WindowsSignature.ps1 `
+            -Path "staging/breeze-viewer-windows.msi", "staging/breeze-helper-windows.msi" `
+            -ExpectedSubject $env:EXPECTED_SUBJECT `
+            -ExpectedThumbprintSha256 $env:SSLCOM_CERT_SHA256
 
       - name: Upload signed viewer MSI
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1503,14 +1503,36 @@ jobs:
           path: apps/helper/breeze-helper-macos.dmg
           retention-days: 30
 
-  sign-windows-tauri:
-    name: Sign Windows Tauri Artifacts
+  resolve-windows-signing-provider:
+    name: Resolve Windows signing provider
     if: >-
       vars.ENABLE_WINDOWS_SIGNING == 'true'
       && github.ref_type == 'tag'
       && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      provider: ${{ steps.provider.outputs.provider }}
+    steps:
+      - name: Validate provider
+        id: provider
+        shell: bash
+        env:
+          RAW_PROVIDER: ${{ vars.WINDOWS_SIGNING_PROVIDER }}
+        run: |
+          set -euo pipefail
+          provider="${RAW_PROVIDER:-azure}"
+          case "$provider" in
+            azure|sslcom) echo "provider=$provider" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::WINDOWS_SIGNING_PROVIDER must be empty, azure, or sslcom"; exit 1 ;;
+          esac
+
+  sign-windows-tauri-azure:
+    name: Sign Windows Tauri artifacts (Azure)
+    needs: [build-viewer, build-helper, resolve-windows-signing-provider]
+    if: needs.resolve-windows-signing-provider.outputs.provider == 'azure'
     runs-on: windows-latest
-    needs: [build-viewer, build-helper]
     permissions:
       contents: read
       id-token: write
@@ -1529,23 +1551,7 @@ jobs:
           name: breeze-helper-windows.msi
           path: staging/
 
-      # WINDOWS SIGNING PROVIDER SWITCH (#3708)
-      #
-      # `vars.WINDOWS_SIGNING_PROVIDER` selects the CA. Unset or anything other
-      # than "sslcom" means Azure, so the existing path is the default and an
-      # absent variable cannot silently disable signing.
-      #
-      # Both providers write an Authenticode signature in place over the same two
-      # staged MSIs, and the shared "Verify signatures" step below validates the
-      # result with Get-AuthenticodeSignature regardless of who produced it — so
-      # the provider swap cannot quietly ship an unsigned artifact.
-      #
-      # Stable vs prerelease certificates are selected by the job's GitHub
-      # Environment (signing-production / signing-prerelease), which is why the
-      # ssl.com path needs one step per file rather than Azure's one per
-      # file-and-profile: the environment already scopes SSLCOM_CREDENTIAL_ID.
       - name: Validate signing configuration (Azure)
-        if: ${{ vars.WINDOWS_SIGNING_PROVIDER != 'sslcom' }}
         shell: pwsh
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -1560,24 +1566,7 @@ jobs:
             }
           }
 
-      - name: Validate signing configuration (SSL.com)
-        if: ${{ vars.WINDOWS_SIGNING_PROVIDER == 'sslcom' }}
-        shell: pwsh
-        env:
-          SSLCOM_USERNAME: ${{ secrets.SSLCOM_USERNAME }}
-          SSLCOM_PASSWORD: ${{ secrets.SSLCOM_PASSWORD }}
-          SSLCOM_CREDENTIAL_ID: ${{ secrets.SSLCOM_CREDENTIAL_ID }}
-          SSLCOM_TOTP_SECRET: ${{ secrets.SSLCOM_TOTP_SECRET }}
-        run: |
-          $required = @("SSLCOM_USERNAME", "SSLCOM_PASSWORD", "SSLCOM_CREDENTIAL_ID", "SSLCOM_TOTP_SECRET")
-          foreach ($name in $required) {
-            if ([string]::IsNullOrWhiteSpace((Get-Item "env:$name").Value)) {
-              throw "Missing required signing secret: $name"
-            }
-          }
-
       - name: Azure Login (OIDC)
-        if: ${{ vars.WINDOWS_SIGNING_PROVIDER != 'sslcom' }}
         uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -1585,7 +1574,7 @@ jobs:
           allow-no-subscriptions: true
 
       - name: Sign viewer MSI (stable profile)
-        if: ${{ vars.WINDOWS_SIGNING_PROVIDER != 'sslcom' && !contains(github.ref_name, '-') }}
+        if: ${{ !contains(github.ref_name, '-') }}
         uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
@@ -1597,7 +1586,7 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Sign viewer MSI (prerelease profile)
-        if: ${{ vars.WINDOWS_SIGNING_PROVIDER != 'sslcom' && contains(github.ref_name, '-') }}
+        if: ${{ contains(github.ref_name, '-') }}
         uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
@@ -1609,7 +1598,7 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Sign helper MSI (stable profile)
-        if: ${{ vars.WINDOWS_SIGNING_PROVIDER != 'sslcom' && !contains(github.ref_name, '-') }}
+        if: ${{ !contains(github.ref_name, '-') }}
         uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
@@ -1621,7 +1610,7 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Sign helper MSI (prerelease profile)
-        if: ${{ vars.WINDOWS_SIGNING_PROVIDER != 'sslcom' && contains(github.ref_name, '-') }}
+        if: ${{ contains(github.ref_name, '-') }}
         uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
@@ -1631,36 +1620,6 @@ jobs:
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
-
-      # SSL.com eSigner. `override: true` signs in place, matching what the Azure
-      # action does, so the staged paths the verify step checks are unchanged.
-      # No file-digest/timestamp inputs: eSigner timestamps internally rather
-      # than taking an RFC-3161 URL the way azure/artifact-signing-action does.
-      - name: Sign viewer MSI (SSL.com)
-        if: ${{ vars.WINDOWS_SIGNING_PROVIDER == 'sslcom' }}
-        uses: SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b # v1.3.2
-        with:
-          command: sign
-          username: ${{ secrets.SSLCOM_USERNAME }}
-          password: ${{ secrets.SSLCOM_PASSWORD }}
-          credential_id: ${{ secrets.SSLCOM_CREDENTIAL_ID }}
-          totp_secret: ${{ secrets.SSLCOM_TOTP_SECRET }}
-          file_path: ${{ github.workspace }}/staging/breeze-viewer-windows.msi
-          override: true
-          malware_block: false
-
-      - name: Sign helper MSI (SSL.com)
-        if: ${{ vars.WINDOWS_SIGNING_PROVIDER == 'sslcom' }}
-        uses: SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b # v1.3.2
-        with:
-          command: sign
-          username: ${{ secrets.SSLCOM_USERNAME }}
-          password: ${{ secrets.SSLCOM_PASSWORD }}
-          credential_id: ${{ secrets.SSLCOM_CREDENTIAL_ID }}
-          totp_secret: ${{ secrets.SSLCOM_TOTP_SECRET }}
-          file_path: ${{ github.workspace }}/staging/breeze-helper-windows.msi
-          override: true
-          malware_block: false
 
       - name: Verify signatures
         shell: pwsh
@@ -1676,6 +1635,12 @@ jobs:
             }
             if ($sig.Status -eq "UnknownError") {
               Write-Host "::warning::$target signed but root cert not yet trusted locally (Status: UnknownError)."
+            }
+            if (-not $sig.SignerCertificate) {
+              throw "Signer certificate missing for $target"
+            }
+            if (-not $sig.TimeStamperCertificate) {
+              throw "RFC 3161 timestamp missing for $target"
             }
             Write-Host "Verified: $target - Status: $($sig.Status) - Signer: $($sig.SignerCertificate.Subject)"
           }
@@ -1695,6 +1660,155 @@ jobs:
           path: staging/breeze-helper-windows.msi
           overwrite: true
           retention-days: 30
+
+  sign-windows-tauri-sslcom:
+    name: Sign Windows Tauri artifacts (SSL.com)
+    needs: [build-viewer, build-helper, resolve-windows-signing-provider]
+    if: needs.resolve-windows-signing-provider.outputs.provider == 'sslcom'
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    environment:
+      name: ${{ contains(github.ref_name, '-') && 'signing-prerelease' || 'signing-production' }}
+    steps:
+      - name: Download viewer Windows MSI
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: breeze-viewer-windows.msi
+          path: staging/
+
+      - name: Download helper Windows MSI
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: breeze-helper-windows.msi
+          path: staging/
+
+      - name: Validate signing configuration (SSL.com)
+        shell: pwsh
+        env:
+          SSLCOM_USERNAME: ${{ secrets.SSLCOM_USERNAME }}
+          SSLCOM_PASSWORD: ${{ secrets.SSLCOM_PASSWORD }}
+          SSLCOM_CREDENTIAL_ID: ${{ secrets.SSLCOM_CREDENTIAL_ID }}
+          SSLCOM_TOTP_SECRET: ${{ secrets.SSLCOM_TOTP_SECRET }}
+          SSLCOM_CERT_SHA256: ${{ secrets.SSLCOM_CERT_SHA256 }}
+        run: |
+          $required = @("SSLCOM_USERNAME", "SSLCOM_PASSWORD", "SSLCOM_CREDENTIAL_ID", "SSLCOM_TOTP_SECRET", "SSLCOM_CERT_SHA256")
+          foreach ($name in $required) {
+            if ([string]::IsNullOrWhiteSpace((Get-Item "env:$name").Value)) {
+              throw "Missing required signing secret: $name"
+            }
+          }
+
+      # SSL.com eSigner signs each staged MSI in place. `malware_block: true`
+      # blocks a detected malware payload and `clean_logs: true` removes logs.
+      - name: Sign viewer MSI (SSL.com)
+        uses: SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b # v1.3.2
+        with:
+          command: sign
+          username: ${{ secrets.SSLCOM_USERNAME }}
+          password: ${{ secrets.SSLCOM_PASSWORD }}
+          credential_id: ${{ secrets.SSLCOM_CREDENTIAL_ID }}
+          totp_secret: ${{ secrets.SSLCOM_TOTP_SECRET }}
+          file_path: ${{ github.workspace }}/staging/breeze-viewer-windows.msi
+          override: true
+          malware_block: true
+          clean_logs: true
+
+      - name: Sign helper MSI (SSL.com)
+        uses: SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b # v1.3.2
+        with:
+          command: sign
+          username: ${{ secrets.SSLCOM_USERNAME }}
+          password: ${{ secrets.SSLCOM_PASSWORD }}
+          credential_id: ${{ secrets.SSLCOM_CREDENTIAL_ID }}
+          totp_secret: ${{ secrets.SSLCOM_TOTP_SECRET }}
+          file_path: ${{ github.workspace }}/staging/breeze-helper-windows.msi
+          override: true
+          malware_block: true
+          clean_logs: true
+
+      - name: Verify signatures
+        shell: pwsh
+        env:
+          SSLCOM_CERT_SHA256: ${{ secrets.SSLCOM_CERT_SHA256 }}
+        run: |
+          $targets = @(
+            (Join-Path $env:GITHUB_WORKSPACE "staging\breeze-viewer-windows.msi"),
+            (Join-Path $env:GITHUB_WORKSPACE "staging\breeze-helper-windows.msi")
+          )
+          foreach ($target in $targets) {
+            $sig = Get-AuthenticodeSignature -FilePath $target
+            if ($sig.Status -ne "Valid" -and $sig.Status -ne "UnknownError") {
+              throw "Signature validation failed for $target. Status: $($sig.Status)"
+            }
+            if ($sig.Status -eq "UnknownError") {
+              Write-Host "::warning::$target signed but root cert not yet trusted locally (Status: UnknownError)."
+            }
+            if (-not $sig.SignerCertificate) {
+              throw "Signer certificate missing for $target"
+            }
+            if (-not $sig.TimeStamperCertificate) {
+              throw "RFC 3161 timestamp missing for $target"
+            }
+            $expected = ($env:SSLCOM_CERT_SHA256 -replace '[^0-9A-Fa-f]', '').ToLowerInvariant()
+            if ($expected -notmatch '^[0-9a-f]{64}$') {
+              throw 'SSLCOM_CERT_SHA256 must contain exactly 64 hexadecimal characters'
+            }
+            $actual = ($sig.SignerCertificate.GetCertHashString(
+              [System.Security.Cryptography.HashAlgorithmName]::SHA256
+            ) -replace '[^0-9A-Fa-f]', '').ToLowerInvariant()
+            if ($actual -ne $expected) {
+              throw "Unexpected SSL.com signer certificate for $target (SHA-256 $actual)"
+            }
+            $subject = $sig.SignerCertificate.Subject
+            if ($subject -notmatch '(?i)(?:^|,\s*)(?:O|CN)=LANTERNOPS LLC(?:,|$)') {
+              throw "Unexpected SSL.com signer subject for $target: $subject"
+            }
+            Write-Host "Verified: $target - Status: $($sig.Status) - Signer: $subject"
+          }
+
+      - name: Upload signed viewer MSI
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: breeze-viewer-windows.msi
+          path: staging/breeze-viewer-windows.msi
+          overwrite: true
+          retention-days: 30
+
+      - name: Upload signed helper MSI
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: breeze-helper-windows.msi
+          path: staging/breeze-helper-windows.msi
+          overwrite: true
+          retention-days: 30
+
+  sign-windows-tauri:
+    name: Windows Tauri signing convergence gate
+    needs: [resolve-windows-signing-provider, sign-windows-tauri-azure, sign-windows-tauri-sslcom]
+    if: ${{ !cancelled() && needs.resolve-windows-signing-provider.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Assert single-provider convergence
+        shell: bash
+        env:
+          PROVIDER: ${{ needs.resolve-windows-signing-provider.outputs.provider }}
+          AZURE_RESULT: ${{ needs.sign-windows-tauri-azure.result }}
+          SSLCOM_RESULT: ${{ needs.sign-windows-tauri-sslcom.result }}
+        run: |
+          set -euo pipefail
+          case "$PROVIDER" in
+            azure)
+              [ "$AZURE_RESULT" = success ] && [ "$SSLCOM_RESULT" = skipped ] ;;
+            sslcom)
+              [ "$AZURE_RESULT" = skipped ] && [ "$SSLCOM_RESULT" = success ] ;;
+            *)
+              echo "::error::provider resolution failed or produced an unexpected value"
+              exit 1 ;;
+          esac
+          echo "Provider '$PROVIDER' converged (azure=$AZURE_RESULT, sslcom=$SSLCOM_RESULT)."
 
   package-windows-updater:
     name: Package Windows Updater Bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1655,7 +1655,8 @@ jobs:
         run: |
           & .github/scripts/Verify-WindowsSignature.ps1 `
             -Path "staging/breeze-viewer-windows.msi", "staging/breeze-helper-windows.msi" `
-            -ExpectedSubject $env:EXPECTED_SUBJECT
+            -ExpectedSubject $env:EXPECTED_SUBJECT `
+            -AllowUnpinnedLeaf
 
       - name: Upload signed viewer MSI
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -1729,14 +1730,17 @@ jobs:
           # -- the path of least resistance, and how every AZURE_* secret is
           # stored today -- both environments would silently resolve the same
           # credential and a prerelease tag would be signed with the production
-          # certificate. This label can only match one environment, so a
-          # repo-level secret fails the other one loudly instead.
+          # certificate. This label can only match one environment, so putting
+          # all six at repository level fails one of them loudly instead.
           #
-          # It is stored as a SECRET despite holding no secret value, because it
-          # only proves anything if it lives in the same store as the
-          # credentials. As a repository/environment variable an operator could
-          # scope the label correctly while still leaving the credentials at
-          # repository level, and this check would pass.
+          # Scope, honestly: this catches the LIKELY mistake, not every one. An
+          # operator who scopes only this label per environment while leaving
+          # the four credentials at repository level still passes. Environment
+          # variables and environment secrets have identical override
+          # semantics, so storing it as a secret buys no extra guarantee -- it
+          # is kept alongside the credentials as a nudge, and it costs the
+          # ability to echo the value (GitHub masks it), which is why the error
+          # below names the environment rather than the label.
           if ($env:SSLCOM_ENVIRONMENT_LABEL -ne $env:EXPECTED_ENVIRONMENT) {
             # Do not interpolate the label: it is stored as a secret, so its
             # value is masked in the log and would print as '***'.
@@ -1765,7 +1769,10 @@ jobs:
           $archive = Join-Path $env:RUNNER_TEMP "CodeSignTool-v1.3.0-windows.zip"
           $target = Join-Path $env:RUNNER_TEMP "CodeSignTool-v1.3.0"
 
-          Invoke-WebRequest -Uri $env:CODESIGNTOOL_URL -OutFile $archive
+          # No degraded path exists downstream: this step failing aborts the
+          # whole tag release. The digest check below makes a retry safe.
+          Invoke-WebRequest -Uri $env:CODESIGNTOOL_URL -OutFile $archive `
+            -MaximumRetryCount 3 -RetryIntervalSec 15 -TimeoutSec 900
           $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
           if ($actual -ne $env:CODESIGNTOOL_SHA256) {
             throw "CodeSignTool digest mismatch. Expected $($env:CODESIGNTOOL_SHA256); got $actual"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1515,6 +1515,11 @@ jobs:
     outputs:
       provider: ${{ steps.provider.outputs.provider }}
     steps:
+      - name: Checkout resolver
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
       - name: Validate provider
         id: provider
         shell: bash
@@ -1522,11 +1527,7 @@ jobs:
           RAW_PROVIDER: ${{ vars.WINDOWS_SIGNING_PROVIDER }}
         run: |
           set -euo pipefail
-          provider="${RAW_PROVIDER:-azure}"
-          case "$provider" in
-            azure|sslcom) echo "provider=$provider" >> "$GITHUB_OUTPUT" ;;
-            *) echo "::error::WINDOWS_SIGNING_PROVIDER must be empty, azure, or sslcom"; exit 1 ;;
-          esac
+          node .github/scripts/resolve-windows-signing-provider.mjs "$RAW_PROVIDER" >> "$GITHUB_OUTPUT"
 
   sign-windows-tauri-azure:
     name: Sign Windows Tauri artifacts (Azure)
@@ -1791,6 +1792,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout convergence assertion
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
       - name: Assert single-provider convergence
         shell: bash
         env:
@@ -1799,16 +1805,7 @@ jobs:
           SSLCOM_RESULT: ${{ needs.sign-windows-tauri-sslcom.result }}
         run: |
           set -euo pipefail
-          case "$PROVIDER" in
-            azure)
-              [ "$AZURE_RESULT" = success ] && [ "$SSLCOM_RESULT" = skipped ] ;;
-            sslcom)
-              [ "$AZURE_RESULT" = skipped ] && [ "$SSLCOM_RESULT" = success ] ;;
-            *)
-              echo "::error::provider resolution failed or produced an unexpected value"
-              exit 1 ;;
-          esac
-          echo "Provider '$PROVIDER' converged (azure=$AZURE_RESULT, sslcom=$SSLCOM_RESULT)."
+          node .github/scripts/assert-windows-signing-convergence.mjs "$PROVIDER" "$AZURE_RESULT" "$SSLCOM_RESULT"
 
   package-windows-updater:
     name: Package Windows Updater Bundle

--- a/apps/docs/src/content/docs/deploy/code-signing.mdx
+++ b/apps/docs/src/content/docs/deploy/code-signing.mdx
@@ -79,9 +79,11 @@ The MSI carries a **per-edition product identity**: the public release builds th
 
   `SSLCOM_CERT_SHA256` also accepts a comma-separated allowlist. Put the incoming thumbprint alongside the outgoing one ahead of a certificate renewal, then drop the old entry once the changeover is done — otherwise renewal becomes a release-day edit made *after* the signing steps have already run and consumed eSigner quota.
 
-  Only the first four are credentials. `SSLCOM_CERT_SHA256` is a public certificate hash and `SSLCOM_ENVIRONMENT_LABEL` is just the environment's own name — both are stored as secrets rather than variables so that they sit in the same place as the credentials they describe.
+  Only the first four are credentials. `SSLCOM_CERT_SHA256` is a public certificate hash and `SSLCOM_ENVIRONMENT_LABEL` is just the environment's own name; they are kept as secrets so they sit alongside the credentials they describe.
 
-  Nothing in the workflow differs between a stable and a prerelease tag except which environment supplies the credentials, so repository-level secrets would sign prereleases with the production certificate. `SSLCOM_ENVIRONMENT_LABEL` guards against exactly that: set it to the environment's own name (`signing-production` or `signing-prerelease`) and a repository-level secret will fail the other environment loudly instead of signing silently. Keeping it alongside the credentials is what makes the check meaningful — as a variable it could be scoped correctly while the credentials were not.
+  Nothing in the workflow differs between a stable and a prerelease tag except which environment supplies the credentials, so repository-level secrets would sign prereleases with the production certificate. `SSLCOM_ENVIRONMENT_LABEL` guards against that: set it to the environment's own name (`signing-production` or `signing-prerelease`) and putting all six at the repository level will fail one of the two environments loudly instead of signing silently.
+
+  It is a safety net for the common mistake, not a proof. Scoping only the label per environment while leaving the credentials at repository level would still pass, so place all six deliberately.
 </Aside>
 
 ---

--- a/apps/docs/src/content/docs/deploy/code-signing.mdx
+++ b/apps/docs/src/content/docs/deploy/code-signing.mdx
@@ -77,7 +77,9 @@ The MSI carries a **per-edition product identity**: the public release builds th
 <Aside type="note" title="Operators: SSL.com secrets are per-environment">
   The SSL.com path reads `SSLCOM_USERNAME`, `SSLCOM_PASSWORD`, `SSLCOM_CREDENTIAL_ID`, `SSLCOM_TOTP_SECRET`, `SSLCOM_CERT_SHA256` and `SSLCOM_ENVIRONMENT_LABEL`. These **must** be added to the `signing-production` and `signing-prerelease` GitHub Environments individually, not to the repository.
 
-  Nothing in the workflow differs between a stable and a prerelease tag except which environment supplies the credentials, so repository-level secrets would sign prereleases with the production certificate. `SSLCOM_ENVIRONMENT_LABEL` guards against exactly that: set it to the environment's own name (`signing-production` or `signing-prerelease`) and a repository-level secret will fail the other environment loudly instead of signing silently.
+  Only the first four are credentials. `SSLCOM_CERT_SHA256` is a public certificate hash and `SSLCOM_ENVIRONMENT_LABEL` is just the environment's own name — both are stored as secrets rather than variables so that they sit in the same place as the credentials they describe.
+
+  Nothing in the workflow differs between a stable and a prerelease tag except which environment supplies the credentials, so repository-level secrets would sign prereleases with the production certificate. `SSLCOM_ENVIRONMENT_LABEL` guards against exactly that: set it to the environment's own name (`signing-production` or `signing-prerelease`) and a repository-level secret will fail the other environment loudly instead of signing silently. Keeping it alongside the credentials is what makes the check meaningful — as a variable it could be scoped correctly while the credentials were not.
 </Aside>
 
 ---

--- a/apps/docs/src/content/docs/deploy/code-signing.mdx
+++ b/apps/docs/src/content/docs/deploy/code-signing.mdx
@@ -77,6 +77,8 @@ The MSI carries a **per-edition product identity**: the public release builds th
 <Aside type="note" title="Operators: SSL.com secrets are per-environment">
   The SSL.com path reads `SSLCOM_USERNAME`, `SSLCOM_PASSWORD`, `SSLCOM_CREDENTIAL_ID`, `SSLCOM_TOTP_SECRET`, `SSLCOM_CERT_SHA256` and `SSLCOM_ENVIRONMENT_LABEL`. These **must** be added to the `signing-production` and `signing-prerelease` GitHub Environments individually, not to the repository.
 
+  `SSLCOM_CERT_SHA256` also accepts a comma-separated allowlist. Put the incoming thumbprint alongside the outgoing one ahead of a certificate renewal, then drop the old entry once the changeover is done — otherwise renewal becomes a release-day edit made *after* the signing steps have already run and consumed eSigner quota.
+
   Only the first four are credentials. `SSLCOM_CERT_SHA256` is a public certificate hash and `SSLCOM_ENVIRONMENT_LABEL` is just the environment's own name — both are stored as secrets rather than variables so that they sit in the same place as the credentials they describe.
 
   Nothing in the workflow differs between a stable and a prerelease tag except which environment supplies the credentials, so repository-level secrets would sign prereleases with the production certificate. `SSLCOM_ENVIRONMENT_LABEL` guards against exactly that: set it to the environment's own name (`signing-production` or `signing-prerelease`) and a repository-level secret will fail the other environment loudly instead of signing silently. Keeping it alongside the credentials is what makes the check meaningful — as a variable it could be scoped correctly while the credentials were not.

--- a/apps/docs/src/content/docs/deploy/code-signing.mdx
+++ b/apps/docs/src/content/docs/deploy/code-signing.mdx
@@ -31,16 +31,16 @@ The CI/CD release pipeline produces the following artifacts:
 |----------|----------|--------|----------------|
 | Breeze Agent | Windows | `.exe`, `.msi` | **Unsigned in the public release** (self-host edition signing inputs — sign them yourself, see below) |
 | Breeze Agent | macOS | `.pkg`, binary | Apple Developer ID + notarization |
-| Breeze Viewer | Windows | `.exe`, `.msi` | Azure Artifact Signing (formerly Trusted Signing) |
+| Breeze Viewer | Windows | `.exe`, `.msi` | LanternOps Authenticode (Azure Artifact Signing or SSL.com eSigner) |
 | Breeze Viewer | macOS | `.app`, `.dmg` | Apple Developer ID + notarization |
-| Breeze Helper | Windows | `.exe` | Azure Artifact Signing (formerly Trusted Signing) |
+| Breeze Helper | Windows | `.exe` | LanternOps Authenticode (Azure Artifact Signing or SSL.com eSigner) |
 | Breeze Helper | macOS | `.app` | Apple Developer ID + notarization |
 
 ---
 
 ## Windows Code Signing
 
-The Windows **Viewer and Helper** installers are signed using **Azure Artifact Signing** (formerly Azure Trusted Signing). The signing happens in the GitHub Actions release workflow.
+The Windows **Viewer and Helper** installers are Authenticode-signed by LanternOps in the GitHub Actions release workflow. The release operator can use Azure Artifact Signing or SSL.com eSigner; both paths are timestamped and must pass the same publisher verification before an artifact is uploaded.
 
 The Windows **agent** artifacts (`.exe` binaries and `breeze-agent.msi`) are no longer Authenticode-signed by the public pipeline — they are published unsigned as the exact pre-signing build outputs, so a deployment can sign them under its own certificate. An unsigned agent MSI will trip SmartScreen unless you sign it; see [Sign Your Own Agent Packages](/deploy/sign-your-own-packages/) for the supported signing path.
 
@@ -48,13 +48,15 @@ The Windows **agent** artifacts (`.exe` binaries and `breeze-agent.msi`) are no 
 
 <Steps>
 
-1. The release workflow signs each binary with the `azure/artifact-signing-action`, authenticating via an OIDC federated credential (no stored client secret).
+1. The release workflow selects exactly one configured Windows signing provider and fails if the provider value is invalid.
 
-2. Each binary is signed and RFC 3161-timestamped against the Azure Artifact Signing endpoint; the certificates are short-lived and HSM-backed — the private key never exists outside Azure.
+2. Azure authenticates with a short-lived OIDC token. SSL.com eSigner uses environment-protected credentials and a pinned LanternOps certificate thumbprint. The two providers run in separate jobs so SSL.com never receives Azure's OIDC permission.
 
-3. The workflow verifies every signature with `Get-AuthenticodeSignature` before upload (tolerating `UnknownError`, which means "signed, root not yet cached locally").
+3. The selected provider Authenticode-signs and RFC 3161-timestamps the Viewer and Helper installers.
 
-4. Signed artifacts are uploaded to the GitHub release together with a signed release manifest.
+4. The workflow verifies the signer certificate and timestamp before upload. The SSL.com path also requires the exact configured SHA-256 certificate thumbprint.
+
+5. Signed artifacts are uploaded to the GitHub release together with a signed release manifest.
 
 </Steps>
 
@@ -66,8 +68,8 @@ unrelated). The MSI bundles the agent binary, configures the Windows service, an
 
 The MSI carries a **per-edition product identity**: the public release builds the self-host edition ("Breeze Agent (Self-Hosted)", with its own UpgradeCode), distinct from the hosted edition used by Breeze's SaaS. The two editions refuse to install over each other on the same machine — the installer blocks with *"A different edition of the Breeze Agent is already installed."* See the [MSI product identity appendix](/deploy/sign-your-own-packages/#msi-product-identity) for details, and [Self-Host Migration](/agents/self-host-migration/) for moving a fleet between editions.
 
-<Aside>
-  Azure Artifact Signing keys are HSM-backed and never exportable, meeting the CA/Browser Forum hardware requirements for publicly trusted code signing. Certificates are short-lived and rotated automatically — there is nothing to renew.
+<Aside type="caution">
+  Verify the publisher as LanternOps when installing Viewer or Helper packages. Public Agent packages remain unsigned by design so self-hosters can sign them with their own certificate; see [Sign Your Own Agent Packages](/deploy/sign-your-own-packages/).
 </Aside>
 
 ---
@@ -146,7 +148,7 @@ spctl --assess --verbose /usr/local/bin/breeze-agent
 ## Troubleshooting
 
 **Windows SmartScreen still warns after signing.**
-SmartScreen reputation is built over time. Newly signed binaries from a new publisher may still show a warning until enough users have downloaded and run the binary. Azure Artifact Signing certificates build reputation faster than traditional OV certificates because Microsoft attests the identity validation. If the warning persists, verify the signature with `Get-AuthenticodeSignature` to confirm the binary is properly signed. Self-hosters should see [Sign Your Own Agent Packages](/deploy/sign-your-own-packages/) for guidance on establishing their own signing identity.
+SmartScreen reputation is built over time. Newly signed binaries using any newly introduced certificate may still show a warning until enough users have downloaded and run the binary. If the warning persists, verify the signature with `Get-AuthenticodeSignature` to confirm the binary is properly signed. Self-hosters should see [Sign Your Own Agent Packages](/deploy/sign-your-own-packages/) for guidance on establishing their own signing identity.
 
 **macOS notarization timeout.**
 Apple's notarization service can be slow during peak times. The workflow allows up to 30 minutes. If it times out, re-run the release workflow — the binary does not need to be rebuilt, only re-submitted.

--- a/apps/docs/src/content/docs/deploy/code-signing.mdx
+++ b/apps/docs/src/content/docs/deploy/code-signing.mdx
@@ -50,13 +50,15 @@ The Windows **agent** artifacts (`.exe` binaries and `breeze-agent.msi`) are no 
 
 1. The release workflow selects exactly one configured Windows signing provider and fails if the provider value is invalid.
 
-2. Azure authenticates with a short-lived OIDC token. SSL.com eSigner uses environment-protected credentials and a pinned LanternOps certificate thumbprint. The two providers run in separate jobs so SSL.com never receives Azure's OIDC permission.
+2. Azure authenticates with a short-lived OIDC token. SSL.com eSigner authenticates with credentials scoped to the tag's signing environment. The two providers run in separate jobs, so the SSL.com job never receives Azure's OIDC permission.
 
-3. The selected provider Authenticode-signs and RFC 3161-timestamps the Viewer and Helper installers.
+3. The SSL.com path stages its signing toolchain from a checksum-verified archive before any credential is used, rather than letting the signing action fetch it unverified at run time.
 
-4. The workflow verifies the signer certificate and timestamp before upload. The SSL.com path also requires the exact configured SHA-256 certificate thumbprint.
+4. The selected provider Authenticode-signs and RFC 3161-timestamps the Viewer and Helper installers.
 
-5. Signed artifacts are uploaded to the GitHub release together with a signed release manifest.
+5. Both providers verify through the same script before upload: signature status, signer certificate, RFC 3161 timestamp, certificate validity window, and that the publisher is LanternOps. The SSL.com path additionally requires the exact configured SHA-256 certificate thumbprint; Azure does not pin one, because its certificates are short-lived and rotate automatically.
+
+6. Signed artifacts are uploaded to the GitHub release together with a signed release manifest.
 
 </Steps>
 
@@ -70,6 +72,12 @@ The MSI carries a **per-edition product identity**: the public release builds th
 
 <Aside type="caution">
   Verify the publisher as LanternOps when installing Viewer or Helper packages. Public Agent packages remain unsigned by design so self-hosters can sign them with their own certificate; see [Sign Your Own Agent Packages](/deploy/sign-your-own-packages/).
+</Aside>
+
+<Aside type="note" title="Operators: SSL.com secrets are per-environment">
+  The SSL.com path reads `SSLCOM_USERNAME`, `SSLCOM_PASSWORD`, `SSLCOM_CREDENTIAL_ID`, `SSLCOM_TOTP_SECRET`, `SSLCOM_CERT_SHA256` and `SSLCOM_ENVIRONMENT_LABEL`. These **must** be added to the `signing-production` and `signing-prerelease` GitHub Environments individually, not to the repository.
+
+  Nothing in the workflow differs between a stable and a prerelease tag except which environment supplies the credentials, so repository-level secrets would sign prereleases with the production certificate. `SSLCOM_ENVIRONMENT_LABEL` guards against exactly that: set it to the environment's own name (`signing-production` or `signing-prerelease`) and a repository-level secret will fail the other environment loudly instead of signing silently.
 </Aside>
 
 ---

--- a/apps/docs/src/content/docs/deploy/sign-your-own-packages.mdx
+++ b/apps/docs/src/content/docs/deploy/sign-your-own-packages.mdx
@@ -453,7 +453,9 @@ reports effective.
 
 The technician-side Viewer and Helper (Tauri) apps are mirrored from the
 official release as-is. If you want to sign those under your identity too,
-the relevant official jobs are `build-viewer`, `sign-windows-tauri`,
+the relevant official jobs are `build-viewer`,
+`sign-windows-tauri-azure` / `sign-windows-tauri-sslcom` (`sign-windows-tauri`
+is the gate that asserts exactly one of them ran),
 `build-viewer-macos`, and `build-helper-macos` in
 `.github/workflows/release.yml` — that path is closer to a fork than to this
 template, and Gatekeeper's right-click-open flow is generally tolerable for

--- a/docs/superpowers/plans/2026-08-21-sslcom-public-release-signing-hardening.md
+++ b/docs/superpowers/plans/2026-08-21-sslcom-public-release-signing-hardening.md
@@ -1,0 +1,425 @@
+# SSL.com Public Release Signing Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the public Viewer/Helper Windows signing provider switch so invalid configuration fails closed, SSL.com never receives Azure OIDC permission, and every SSL.com signature is pinned to the expected LanternOps certificate.
+
+**Architecture:** Extend the existing workflow-security checker with public-release signing invariants, then split the current mixed-provider Windows signer into a resolver, mutually exclusive Azure and SSL.com jobs, and the existing `sign-windows-tauri` convergence gate. Keep all downstream job IDs and public Agent-family artifact behavior stable, and update the public code-signing documentation to describe the provider-neutral contract.
+
+**Tech Stack:** GitHub Actions YAML, Node.js 22 built-in test runner, PowerShell 7, Windows Authenticode, Azure Artifact Signing, SSL.com `esigner-codesign` v1.3.2, Astro/Starlight documentation, pnpm 10.34.5.
+
+## Global Constraints
+
+- `vars.WINDOWS_SIGNING_PROVIDER` accepts only empty, `azure`, or `sslcom`; empty resolves to `azure`, and every other value fails before credentials are exposed.
+- Only `sign-windows-tauri-azure` may declare `id-token: write`; `sign-windows-tauri-sslcom` must declare only `contents: read`.
+- The SSL.com action reference must remain exactly `SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b`.
+- The SSL.com job must require `SSLCOM_USERNAME`, `SSLCOM_PASSWORD`, `SSLCOM_CREDENTIAL_ID`, `SSLCOM_TOTP_SECRET`, and `SSLCOM_CERT_SHA256` from the selected GitHub Environment.
+- `SSLCOM_CERT_SHA256` must normalize to exactly 64 lowercase hexadecimal characters and must match the SHA-256 hash of every Viewer/Helper leaf signer certificate.
+- Both providers must require a signer certificate and an RFC 3161 timestamp on both MSI files before upload.
+- Public Agent-family Windows EXEs and `breeze-agent.msi` remain unsigned and outside every SSL.com job or step.
+- Existing downstream jobs continue to depend on the `sign-windows-tauri` job ID.
+- No username, password, TOTP seed, credential ID, PIN, or certificate thumbprint value may be committed or printed.
+- Use at most one independent code-review dispatch after all implementation tasks. In inline mode without explicit delegation authorization, run the same checklist as a fresh-eye self-review; fixes are verified with targeted tests unless they change the signing trust boundary.
+
+---
+
+### Task 1: Enforce and implement the split public signing topology
+
+**Files:**
+- Modify: `.github/scripts/check-workflow-security.mjs`
+- Modify: `.github/scripts/check-workflow-security.test.mjs`
+- Modify: `.github/workflows/release.yml:1506-1695`
+
+**Interfaces:**
+- Consumes: `inspectWorkflowText(file: string, text: string): Violation[]`, the current release workflow artifact names, and the existing downstream `sign-windows-tauri` dependency.
+- Produces: `publicReleaseSigningViolations(file: string, lines: ActiveLine[], text: string): Violation[]`; jobs `resolve-windows-signing-provider`, `sign-windows-tauri-azure`, `sign-windows-tauri-sslcom`, and `sign-windows-tauri`; resolver output `provider: "azure" | "sslcom"`.
+
+- [ ] **Step 1: Add failing synthetic workflow tests for the trust-boundary invariants**
+
+Add tests that call `inspectWorkflowText('release.yml', fixture)` and assert stable rule IDs. Use a complete passing fixture with these exact job IDs, then mutate one property per test:
+
+```js
+const SSL_ACTION = 'SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b';
+
+function publicSigningFixture() {
+  return `on: push
+jobs:
+  resolve-windows-signing-provider:
+    runs-on: ubuntu-latest
+    outputs:
+      provider: \${{ steps.provider.outputs.provider }}
+    steps:
+      - id: provider
+        env:
+          RAW_PROVIDER: \${{ vars.WINDOWS_SIGNING_PROVIDER }}
+        run: |
+          case "\${RAW_PROVIDER:-azure}" in
+            azure|sslcom) echo "provider=\${RAW_PROVIDER:-azure}" >> "$GITHUB_OUTPUT" ;;
+            *) exit 1 ;;
+          esac
+  sign-windows-tauri-azure:
+    needs: [resolve-windows-signing-provider]
+    if: needs.resolve-windows-signing-provider.outputs.provider == 'azure'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - run: echo azure
+  sign-windows-tauri-sslcom:
+    needs: [resolve-windows-signing-provider]
+    if: needs.resolve-windows-signing-provider.outputs.provider == 'sslcom'
+    permissions:
+      contents: read
+    steps:
+      - uses: ${SSL_ACTION}
+        with:
+          username: \${{ secrets.SSLCOM_USERNAME }}
+          password: \${{ secrets.SSLCOM_PASSWORD }}
+          credential_id: \${{ secrets.SSLCOM_CREDENTIAL_ID }}
+          totp_secret: \${{ secrets.SSLCOM_TOTP_SECRET }}
+      - env:
+          SSLCOM_CERT_SHA256: \${{ secrets.SSLCOM_CERT_SHA256 }}
+        run: |
+          GetCertHashString([System.Security.Cryptography.HashAlgorithmName]::SHA256)
+          TimeStamperCertificate
+          O=LANTERNOPS LLC
+  sign-windows-tauri:
+    if: always()
+    needs: [resolve-windows-signing-provider, sign-windows-tauri-azure, sign-windows-tauri-sslcom]
+    steps:
+      - run: echo convergence
+`;
+}
+```
+
+Add assertions for these mutations and exact rules:
+
+```js
+test('public signing resolver rejects unknown providers', () => {
+  const text = publicSigningFixture().replace('*) exit 1 ;;', '*) echo "provider=azure" >> "$GITHUB_OUTPUT" ;;');
+  assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'windows-signing-provider-must-fail-closed'), true);
+});
+
+test('SSL.com signer cannot receive OIDC', () => {
+  const text = publicSigningFixture().replace('sign-windows-tauri-sslcom:\n', 'sign-windows-tauri-sslcom:\n    permissions:\n      id-token: write\n');
+  assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'windows-signing-provider-least-privilege'), true);
+});
+
+test('SSL.com signer requires a pinned certificate and timestamp', () => {
+  const text = publicSigningFixture().replace('SSLCOM_CERT_SHA256', 'REMOVED_CERT_PIN').replace('TimeStamperCertificate', 'REMOVED_TIMESTAMP');
+  const rules = new Set(inspectWorkflowText('release.yml', text).map(({ rule }) => rule));
+  assert.equal(rules.has('sslcom-signing-must-pin-certificate'), true);
+  assert.equal(rules.has('sslcom-signing-must-require-timestamp'), true);
+});
+
+test('SSL.com signer cannot mention public Agent-family artifacts', () => {
+  const text = publicSigningFixture().replace('O=LANTERNOPS LLC', 'O=LANTERNOPS LLC\n          breeze-agent.msi');
+  assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'sslcom-signing-must-not-touch-agent'), true);
+});
+```
+
+- [ ] **Step 2: Run the new tests and confirm the checker does not yet enforce them**
+
+Run: `node --test .github/scripts/check-workflow-security.test.mjs`
+
+Expected: FAIL because one or more new mutation tests report no matching violation.
+
+- [ ] **Step 3: Add focused job-section parsing and release-signing violations**
+
+In `.github/scripts/check-workflow-security.mjs`, add constants for the five rule IDs above and a helper that slices a direct child of `jobs:` from its key line through the line before the next sibling job. The release-specific checker must return immediately unless `file === 'release.yml'` and the four signing job IDs are present, so unrelated workflows and unit fixtures remain unaffected.
+
+Implement the checks with exact string/section assertions:
+
+```js
+const PUBLIC_AGENT_WINDOWS_ASSETS = [
+  'breeze-agent-windows-amd64.exe',
+  'breeze-backup-windows-amd64.exe',
+  'breeze-watchdog-windows-amd64.exe',
+  'breeze-user-helper-windows-amd64.exe',
+  'breeze-agent.msi',
+];
+const SSLCOM_ACTION = 'SSLcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b';
+const SSLCOM_SECRETS = [
+  'SSLCOM_USERNAME',
+  'SSLCOM_PASSWORD',
+  'SSLCOM_CREDENTIAL_ID',
+  'SSLCOM_TOTP_SECRET',
+  'SSLCOM_CERT_SHA256',
+];
+
+function publicReleaseSigningViolations(file, lines, text) {
+  if (file !== 'release.yml') return [];
+  const jobs = directJobSections(lines, text);
+  const resolver = jobs.get('resolve-windows-signing-provider');
+  const azure = jobs.get('sign-windows-tauri-azure');
+  const sslcom = jobs.get('sign-windows-tauri-sslcom');
+  const gate = jobs.get('sign-windows-tauri');
+  if (!resolver && !azure && !sslcom && !gate) return [];
+
+  const violations = [];
+  // Require an explicit empty-to-azure normalization and an explicit failing default.
+  requirePattern(resolver, /RAW_PROVIDER[\s\S]*:-azure[\s\S]*azure\|sslcom[\s\S]*\*\)[\s\S]*(?:exit 1|throw)/u,
+    'windows-signing-provider-must-fail-closed', violations, file);
+  requirePattern(azure, /id-token:\s*write/u,
+    'windows-signing-provider-least-privilege', violations, file);
+  forbidPattern(sslcom, /id-token:\s*write/u,
+    'windows-signing-provider-least-privilege', violations, file);
+  requirePattern(sslcom, new RegExp(escapeRegExp(SSLCOM_ACTION), 'u'),
+    'sslcom-signing-must-pin-certificate', violations, file);
+  for (const secret of SSLCOM_SECRETS) {
+    requirePattern(sslcom, new RegExp(`secrets\\.${secret}`, 'u'),
+      'sslcom-signing-must-pin-certificate', violations, file);
+  }
+  requirePattern(sslcom, /GetCertHashString[\s\S]*SHA256[\s\S]*SSLCOM_CERT_SHA256/u,
+    'sslcom-signing-must-pin-certificate', violations, file);
+  requirePattern(sslcom, /TimeStamperCertificate/u,
+    'sslcom-signing-must-require-timestamp', violations, file);
+  for (const asset of PUBLIC_AGENT_WINDOWS_ASSETS) {
+    forbidPattern(sslcom, new RegExp(escapeRegExp(asset), 'u'),
+      'sslcom-signing-must-not-touch-agent', violations, file);
+  }
+  requirePattern(gate, /always\(\)[\s\S]*sign-windows-tauri-azure[\s\S]*sign-windows-tauri-sslcom/u,
+    'windows-signing-provider-must-converge', violations, file);
+  return violations;
+}
+```
+
+Call `publicReleaseSigningViolations(file, lines, text)` from `inspectWorkflowText` after the existing developer-signing checks. Keep violations sorted through `compareViolations` and report the signing job's first line for a missing/forbidden condition.
+
+- [ ] **Step 4: Run the synthetic tests and confirm the checker passes them**
+
+Run: `node --test .github/scripts/check-workflow-security.test.mjs`
+
+Expected: PASS for the new passing fixture and every single-mutation rejection.
+
+- [ ] **Step 5: Run the checker against the current release workflow to capture the intended red state**
+
+Run: `node .github/scripts/check-workflow-security.mjs`
+
+Expected: FAIL on `release.yml` for the mixed-provider job, permissive fallback, absent SSL.com thumbprint, and missing convergence topology.
+
+- [ ] **Step 6: Replace the mixed signer with resolver and provider-isolated jobs**
+
+In `.github/workflows/release.yml`, replace the existing `sign-windows-tauri` body with this topology:
+
+```yaml
+  resolve-windows-signing-provider:
+    name: Resolve Windows signing provider
+    if: >-
+      vars.ENABLE_WINDOWS_SIGNING == 'true'
+      && github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      provider: ${{ steps.provider.outputs.provider }}
+    steps:
+      - name: Validate provider
+        id: provider
+        shell: bash
+        env:
+          RAW_PROVIDER: ${{ vars.WINDOWS_SIGNING_PROVIDER }}
+        run: |
+          set -euo pipefail
+          provider="${RAW_PROVIDER:-azure}"
+          case "$provider" in
+            azure|sslcom) echo "provider=$provider" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::WINDOWS_SIGNING_PROVIDER must be empty, azure, or sslcom"; exit 1 ;;
+          esac
+
+  sign-windows-tauri-azure:
+    name: Sign Windows Tauri artifacts (Azure)
+    needs: [build-viewer, build-helper, resolve-windows-signing-provider]
+    if: needs.resolve-windows-signing-provider.outputs.provider == 'azure'
+    runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: ${{ contains(github.ref_name, '-') && 'signing-prerelease' || 'signing-production' }}
+
+  sign-windows-tauri-sslcom:
+    name: Sign Windows Tauri artifacts (SSL.com)
+    needs: [build-viewer, build-helper, resolve-windows-signing-provider]
+    if: needs.resolve-windows-signing-provider.outputs.provider == 'sslcom'
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    environment:
+      name: ${{ contains(github.ref_name, '-') && 'signing-prerelease' || 'signing-production' }}
+
+  sign-windows-tauri:
+    name: Windows Tauri signing convergence gate
+    needs: [resolve-windows-signing-provider, sign-windows-tauri-azure, sign-windows-tauri-sslcom]
+    if: ${{ always() && needs.resolve-windows-signing-provider.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+```
+
+Copy the current artifact downloads, Azure validation/login/signing steps, Azure verification, and canonical uploads into the Azure job without changing action pins, paths, profile selection, or artifact names. Copy the two SSL.com action steps and canonical uploads into the SSL.com job, set `malware_block: true`, `override: true`, and `clean_logs: true`, and add `SSLCOM_CERT_SHA256` to its validation environment.
+
+- [ ] **Step 7: Add authoritative SSL.com certificate-pin verification**
+
+Use this normalization and comparison inside the SSL.com verification loop after the shared status/signer/timestamp checks:
+
+```powershell
+$expected = ($env:SSLCOM_CERT_SHA256 -replace '[^0-9A-Fa-f]', '').ToLowerInvariant()
+if ($expected -notmatch '^[0-9a-f]{64}$') {
+  throw 'SSLCOM_CERT_SHA256 must contain exactly 64 hexadecimal characters'
+}
+$actual = ($sig.SignerCertificate.GetCertHashString(
+  [System.Security.Cryptography.HashAlgorithmName]::SHA256
+) -replace '[^0-9A-Fa-f]', '').ToLowerInvariant()
+if ($actual -ne $expected) {
+  throw "Unexpected SSL.com signer certificate for $target (SHA-256 $actual)"
+}
+$subject = $sig.SignerCertificate.Subject
+if ($subject -notmatch '(?i)(?:^|,\s*)(?:O|CN)=LANTERNOPS LLC(?:,|$)') {
+  throw "Unexpected SSL.com signer subject for $target: $subject"
+}
+```
+
+Pass `SSLCOM_CERT_SHA256: ${{ secrets.SSLCOM_CERT_SHA256 }}` only to the SSL.com validation and verification steps. Do not print the expected pin or any credential value.
+
+- [ ] **Step 8: Add the fail-closed convergence assertion**
+
+The gate's only step must compare the selected provider with both job results:
+
+```bash
+set -euo pipefail
+case "$PROVIDER" in
+  azure)
+    [ "$AZURE_RESULT" = success ] && [ "$SSLCOM_RESULT" = skipped ] ;;
+  sslcom)
+    [ "$AZURE_RESULT" = skipped ] && [ "$SSLCOM_RESULT" = success ] ;;
+  *) exit 1 ;;
+esac
+```
+
+Set `PROVIDER`, `AZURE_RESULT`, and `SSLCOM_RESULT` from `needs.*`. Emit a generic error containing provider and job-result names only; never include secrets. Preserve all existing downstream `needs: [sign-windows-tauri]` references.
+
+- [ ] **Step 9: Run targeted and repository workflow checks**
+
+Run:
+
+```bash
+node --test .github/scripts/check-workflow-security.test.mjs scripts/security/pin-github-actions.test.mjs
+node .github/scripts/check-workflow-security.mjs
+actionlint -color .github/workflows/release.yml
+corepack pnpm test:workflow-security
+bash scripts/security/check-supply-chain-hardening.sh
+```
+
+Expected: every command exits 0; the workflow checker reports no violations; `actionlint` reports no expression, job dependency, or YAML errors.
+
+- [ ] **Step 10: Commit the workflow and invariant tests**
+
+```bash
+git add .github/scripts/check-workflow-security.mjs \
+  .github/scripts/check-workflow-security.test.mjs \
+  .github/workflows/release.yml
+git commit -m "ci(release): harden SSL.com signing provider isolation"
+```
+
+### Task 2: Make public code-signing documentation provider-neutral
+
+**Files:**
+- Modify: `apps/docs/src/content/docs/deploy/code-signing.mdx:26-71`
+
+**Interfaces:**
+- Consumes: the Task 1 public workflow contract and the unchanged self-host Agent-family boundary.
+- Produces: end-user documentation that identifies Viewer/Helper signatures by LanternOps publisher rather than promising one CA, while keeping public Agent artifacts explicitly unsigned.
+
+- [ ] **Step 1: Update the artifact table and Windows overview**
+
+Change the Viewer and Helper Windows signing method cells to `LanternOps Authenticode (Azure Artifact Signing or SSL.com eSigner)`. Replace the Azure-only opening paragraph with:
+
+```mdx
+The Windows **Viewer and Helper** installers are Authenticode-signed by LanternOps in the GitHub Actions release workflow. The release operator can use Azure Artifact Signing or SSL.com eSigner; both paths are timestamped and must pass the same publisher verification before an artifact is uploaded.
+```
+
+Leave the public Agent paragraph intact, including the explicit statement that its EXEs and MSI are unsigned signing inputs.
+
+- [ ] **Step 2: Replace the Azure-only four-step description**
+
+Use these exact operational guarantees:
+
+```mdx
+1. The release workflow selects exactly one configured Windows signing provider and fails if the provider value is invalid.
+
+2. Azure authenticates with a short-lived OIDC token. SSL.com eSigner uses environment-protected credentials and a pinned LanternOps certificate thumbprint. The two providers run in separate jobs so SSL.com never receives Azure's OIDC permission.
+
+3. The selected provider Authenticode-signs and RFC 3161-timestamps the Viewer and Helper installers.
+
+4. The workflow verifies the signer certificate and timestamp before upload. The SSL.com path also requires the exact configured SHA-256 certificate thumbprint.
+
+5. Signed artifacts are uploaded to the GitHub release together with a signed release manifest.
+```
+
+Replace the Azure-specific aside with a provider-neutral caution explaining that users should verify the publisher as LanternOps and that public Agent packages remain unsigned by design.
+
+- [ ] **Step 3: Update the SmartScreen troubleshooting paragraph**
+
+Remove the promise that Azure is always the publisher. State that reputation can take time for any newly introduced certificate, then retain the instruction to verify with `Get-AuthenticodeSignature` and the self-host signing link.
+
+- [ ] **Step 4: Build the documentation**
+
+Run: `corepack pnpm --filter @breeze/docs build`
+
+Expected: Astro/Starlight build exits 0 with no broken MDX syntax or internal links.
+
+- [ ] **Step 5: Commit the documentation**
+
+```bash
+git add apps/docs/src/content/docs/deploy/code-signing.mdx
+git commit -m "docs(release): describe switchable Windows signing"
+```
+
+### Task 3: Final security verification and review gate
+
+**Files:**
+- Review only: `.github/workflows/release.yml`
+- Review only: `.github/scripts/check-workflow-security.mjs`
+- Review only: `.github/scripts/check-workflow-security.test.mjs`
+- Review only: `apps/docs/src/content/docs/deploy/code-signing.mdx`
+
+**Interfaces:**
+- Consumes: Tasks 1-2 and the approved design at `docs/superpowers/specs/2026-08-21-sslcom-public-release-signing-hardening-design.md`.
+- Produces: a review-ready branch whose automated checks prove provider isolation, certificate pinning, downstream convergence, and the unsigned public Agent boundary.
+
+- [ ] **Step 1: Run the complete local verification set from a clean shell**
+
+```bash
+corepack pnpm test:workflow-security
+bash scripts/security/check-supply-chain-hardening.sh
+actionlint -color .github/workflows/release.yml
+corepack pnpm --filter @breeze/docs build
+git diff --check HEAD~2..HEAD
+git status --short
+```
+
+Expected: all checks exit 0; `git diff --check` has no output; status is clean.
+
+- [ ] **Step 2: Perform the permitted review gate**
+
+Use `superpowers:requesting-code-review` once for the complete two-commit implementation when the user selected delegated execution. In inline mode without delegation authorization, perform a fresh-eye self-review against the same checklist. Compare the branch against the approved design and focus on GitHub expression semantics, skipped-job convergence, OIDC isolation, secret exposure, certificate hash normalization, and accidental Agent-family signing.
+
+- [ ] **Step 3: Resolve findings with targeted tests**
+
+For each valid finding, first add or tighten a mutation test in `.github/scripts/check-workflow-security.test.mjs`, run it to see the failure, make the smallest workflow/checker change, and rerun Task 3 Step 1. Commit fixes with:
+
+```bash
+git add .github/scripts/check-workflow-security.mjs \
+  .github/scripts/check-workflow-security.test.mjs \
+  .github/workflows/release.yml \
+  apps/docs/src/content/docs/deploy/code-signing.mdx
+git commit -m "fix(release): address signing hardening review"
+```
+
+Skip this commit when the independent review is clean.
+
+- [ ] **Step 4: Record rollout prerequisites without configuring secrets**
+
+In the implementation handoff, list the five SSL.com secrets required in both `signing-prerelease` and `signing-production`, state that the TOTP value is the enrollment seed rather than the rotating six-digit code, and require a prerelease tag with local signature inspection before changing the stable environment. Do not create secrets, change repository variables, dispatch a workflow, or publish a release until the user confirms the reset PIN/TOTP state and authorizes those external mutations.

--- a/docs/superpowers/plans/2026-08-21-sslcom-public-release-signing-hardening.md
+++ b/docs/superpowers/plans/2026-08-21-sslcom-public-release-signing-hardening.md
@@ -32,7 +32,7 @@
 
 **Interfaces:**
 - Consumes: `inspectWorkflowText(file: string, text: string): Violation[]`, the current release workflow artifact names, and the existing downstream `sign-windows-tauri` dependency.
-- Produces: `publicReleaseSigningViolations(file: string, lines: ActiveLine[], text: string): Violation[]`; jobs `resolve-windows-signing-provider`, `sign-windows-tauri-azure`, `sign-windows-tauri-sslcom`, and `sign-windows-tauri`; resolver output `provider: "azure" | "sslcom"`.
+- Produces: `publicReleaseSigningViolations(file: string, lines: ActiveLine[]): Violation[]` (job slicing reuses the existing `workflowJobs(lines)` helper — do not add a second slicer); jobs `resolve-windows-signing-provider`, `sign-windows-tauri-azure`, `sign-windows-tauri-sslcom`, and `sign-windows-tauri`; resolver output `provider: "azure" | "sslcom"`.
 
 - [ ] **Step 1: Add failing synthetic workflow tests for the trust-boundary invariants**
 
@@ -46,6 +46,8 @@ function publicSigningFixture() {
 jobs:
   resolve-windows-signing-provider:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       provider: \${{ steps.provider.outputs.provider }}
     steps:
@@ -64,7 +66,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - run: echo azure
+      - shell: pwsh
+        run: |
+          if (-not $sig.SignerCertificate) { throw }
+          if (-not $sig.TimeStamperCertificate) { throw }
   sign-windows-tauri-sslcom:
     needs: [resolve-windows-signing-provider]
     if: needs.resolve-windows-signing-provider.outputs.provider == 'sslcom'
@@ -77,24 +82,48 @@ jobs:
           password: \${{ secrets.SSLCOM_PASSWORD }}
           credential_id: \${{ secrets.SSLCOM_CREDENTIAL_ID }}
           totp_secret: \${{ secrets.SSLCOM_TOTP_SECRET }}
-      - env:
+      - shell: pwsh
+        env:
           SSLCOM_CERT_SHA256: \${{ secrets.SSLCOM_CERT_SHA256 }}
         run: |
-          GetCertHashString([System.Security.Cryptography.HashAlgorithmName]::SHA256)
-          TimeStamperCertificate
+          $expected = $env:SSLCOM_CERT_SHA256
+          $actual = $sig.SignerCertificate.GetCertHashString([System.Security.Cryptography.HashAlgorithmName]::SHA256)
+          if (-not $sig.TimeStamperCertificate) { throw }
           O=LANTERNOPS LLC
   sign-windows-tauri:
-    if: always()
     needs: [resolve-windows-signing-provider, sign-windows-tauri-azure, sign-windows-tauri-sslcom]
+    if: \${{ !cancelled() && needs.resolve-windows-signing-provider.result != 'skipped' }}
+    permissions:
+      contents: read
     steps:
-      - run: echo convergence
+      - env:
+          PROVIDER: \${{ needs.resolve-windows-signing-provider.outputs.provider }}
+          AZURE_RESULT: \${{ needs.sign-windows-tauri-azure.result }}
+          SSLCOM_RESULT: \${{ needs.sign-windows-tauri-sslcom.result }}
+        run: echo convergence
 `;
 }
 ```
 
-Add assertions for these mutations and exact rules:
+The fixture must mirror the real step layout so the Step 3 patterns can match both: the `env:` mapping precedes the `run:` block, `$env:SSLCOM_CERT_SHA256` is read inside the script, and the gate consumes both signer results through `needs.*.result` env vars.
+
+Add a passing-fixture baseline plus one assertion per mutation, using the exact rule IDs:
 
 ```js
+const PUBLIC_SIGNING_RULES = [
+  'windows-signing-provider-must-fail-closed',
+  'windows-signing-provider-least-privilege',
+  'sslcom-signing-must-pin-certificate',
+  'windows-signing-must-require-timestamp',
+  'sslcom-signing-must-not-touch-agent',
+  'windows-signing-provider-must-converge',
+];
+
+test('passing public signing fixture raises no public-signing violations', () => {
+  const rules = new Set(inspectWorkflowText('release.yml', publicSigningFixture()).map(({ rule }) => rule));
+  for (const rule of PUBLIC_SIGNING_RULES) assert.equal(rules.has(rule), false, rule);
+});
+
 test('public signing resolver rejects unknown providers', () => {
   const text = publicSigningFixture().replace('*) exit 1 ;;', '*) echo "provider=azure" >> "$GITHUB_OUTPUT" ;;');
   assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'windows-signing-provider-must-fail-closed'), true);
@@ -106,17 +135,26 @@ test('SSL.com signer cannot receive OIDC', () => {
 });
 
 test('SSL.com signer requires a pinned certificate and timestamp', () => {
-  const text = publicSigningFixture().replace('SSLCOM_CERT_SHA256', 'REMOVED_CERT_PIN').replace('TimeStamperCertificate', 'REMOVED_TIMESTAMP');
+  const text = publicSigningFixture()
+    .replaceAll('SSLCOM_CERT_SHA256', 'REMOVED_CERT_PIN')
+    .replaceAll('TimeStamperCertificate', 'REMOVED_TIMESTAMP');
   const rules = new Set(inspectWorkflowText('release.yml', text).map(({ rule }) => rule));
   assert.equal(rules.has('sslcom-signing-must-pin-certificate'), true);
-  assert.equal(rules.has('sslcom-signing-must-require-timestamp'), true);
+  assert.equal(rules.has('windows-signing-must-require-timestamp'), true);
 });
 
 test('SSL.com signer cannot mention public Agent-family artifacts', () => {
   const text = publicSigningFixture().replace('O=LANTERNOPS LLC', 'O=LANTERNOPS LLC\n          breeze-agent.msi');
   assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'sslcom-signing-must-not-touch-agent'), true);
 });
+
+test('convergence gate must consume both signer results', () => {
+  const text = publicSigningFixture().replace(/ +AZURE_RESULT:[^\n]*\n/u, '');
+  assert.equal(inspectWorkflowText('release.yml', text).some(({ rule }) => rule === 'windows-signing-provider-must-converge'), true);
+});
 ```
+
+Use `replaceAll` for the pin/timestamp mutations — both strings appear more than once in the fixture, and a single `replace` leaves a surviving reference that lets the checker pass vacuously.
 
 - [ ] **Step 2: Run the new tests and confirm the checker does not yet enforce them**
 
@@ -126,9 +164,11 @@ Expected: FAIL because one or more new mutation tests report no matching violati
 
 - [ ] **Step 3: Add focused job-section parsing and release-signing violations**
 
-In `.github/scripts/check-workflow-security.mjs`, add constants for the five rule IDs above and a helper that slices a direct child of `jobs:` from its key line through the line before the next sibling job. The release-specific checker must return immediately unless `file === 'release.yml'` and the four signing job IDs are present, so unrelated workflows and unit fixtures remain unaffected.
+In `.github/scripts/check-workflow-security.mjs`, add constants for the six rule IDs above and three small helpers that do not exist yet: `escapeRegExp(value)`, `requirePattern(section, pattern, rule, violations, file)`, and `forbidPattern(section, pattern, rule, violations, file)`. Job sections come from the existing `workflowJobs(lines)` helper (`{ name, lines }` per direct child of `jobs:`) — do not write a second slicer. A pattern check runs against the section's joined `content` (`section.lines.map((line) => line.content).join('\n')`); `requirePattern` reports a violation when the section is missing entirely **or** the pattern does not match, anchored at `section.lines[0].line` (line 1 when the section is missing); `forbidPattern` reports only when a present section matches.
 
-Implement the checks with exact string/section assertions:
+The release-specific checker must return immediately unless `file === 'release.yml'`, and stay silent when none of the four signing job IDs are present, so unrelated workflows and existing unit fixtures remain unaffected.
+
+Implement the checks with order-independent assertions (a single ordered regex across the section breaks on the real step layout, where `env:` mappings precede `run:` blocks):
 
 ```js
 const PUBLIC_AGENT_WINDOWS_ASSETS = [
@@ -147,9 +187,9 @@ const SSLCOM_SECRETS = [
   'SSLCOM_CERT_SHA256',
 ];
 
-function publicReleaseSigningViolations(file, lines, text) {
+function publicReleaseSigningViolations(file, lines) {
   if (file !== 'release.yml') return [];
-  const jobs = directJobSections(lines, text);
+  const jobs = new Map(workflowJobs(lines).map((job) => [job.name, job]));
   const resolver = jobs.get('resolve-windows-signing-provider');
   const azure = jobs.get('sign-windows-tauri-azure');
   const sslcom = jobs.get('sign-windows-tauri-sslcom');
@@ -157,34 +197,49 @@ function publicReleaseSigningViolations(file, lines, text) {
   if (!resolver && !azure && !sslcom && !gate) return [];
 
   const violations = [];
-  // Require an explicit empty-to-azure normalization and an explicit failing default.
-  requirePattern(resolver, /RAW_PROVIDER[\s\S]*:-azure[\s\S]*azure\|sslcom[\s\S]*\*\)[\s\S]*(?:exit 1|throw)/u,
+  // Resolver: explicit empty-to-azure normalization plus a failing default arm.
+  requirePattern(resolver, /RAW_PROVIDER[\s\S]*:-azure[\s\S]*azure\|sslcom[\s\S]*\*\)[\s\S]*exit 1/u,
     'windows-signing-provider-must-fail-closed', violations, file);
+  // OIDC lives in the Azure job and nowhere else.
   requirePattern(azure, /id-token:\s*write/u,
     'windows-signing-provider-least-privilege', violations, file);
-  forbidPattern(sslcom, /id-token:\s*write/u,
-    'windows-signing-provider-least-privilege', violations, file);
+  for (const section of [resolver, sslcom, gate]) {
+    forbidPattern(section, /id-token:/u,
+      'windows-signing-provider-least-privilege', violations, file);
+  }
   requirePattern(sslcom, new RegExp(escapeRegExp(SSLCOM_ACTION), 'u'),
     'sslcom-signing-must-pin-certificate', violations, file);
   for (const secret of SSLCOM_SECRETS) {
-    requirePattern(sslcom, new RegExp(`secrets\\.${secret}`, 'u'),
+    requirePattern(sslcom, new RegExp(`secrets\\.${secret}\\b`, 'u'),
       'sslcom-signing-must-pin-certificate', violations, file);
   }
-  requirePattern(sslcom, /GetCertHashString[\s\S]*SHA256[\s\S]*SSLCOM_CERT_SHA256/u,
+  // The section must read the pin from the environment AND hash the signer
+  // certificate with SHA-256; asserted separately, not as one ordered regex.
+  requirePattern(sslcom, /\$env:SSLCOM_CERT_SHA256/u,
     'sslcom-signing-must-pin-certificate', violations, file);
-  requirePattern(sslcom, /TimeStamperCertificate/u,
-    'sslcom-signing-must-require-timestamp', violations, file);
+  requirePattern(sslcom, /GetCertHashString\(\s*\[System\.Security\.Cryptography\.HashAlgorithmName\]::SHA256/u,
+    'sslcom-signing-must-pin-certificate', violations, file);
+  // Both providers must prove an RFC 3161 timestamp (design: Verification).
+  for (const section of [azure, sslcom]) {
+    requirePattern(section, /TimeStamperCertificate/u,
+      'windows-signing-must-require-timestamp', violations, file);
+  }
   for (const asset of PUBLIC_AGENT_WINDOWS_ASSETS) {
     forbidPattern(sslcom, new RegExp(escapeRegExp(asset), 'u'),
       'sslcom-signing-must-not-touch-agent', violations, file);
   }
-  requirePattern(gate, /always\(\)[\s\S]*sign-windows-tauri-azure[\s\S]*sign-windows-tauri-sslcom/u,
+  // Gate: runs on !cancelled() and consumes both signer results.
+  requirePattern(gate, /!cancelled\(\)/u,
+    'windows-signing-provider-must-converge', violations, file);
+  requirePattern(gate, /needs\.sign-windows-tauri-azure\.result/u,
+    'windows-signing-provider-must-converge', violations, file);
+  requirePattern(gate, /needs\.sign-windows-tauri-sslcom\.result/u,
     'windows-signing-provider-must-converge', violations, file);
   return violations;
 }
 ```
 
-Call `publicReleaseSigningViolations(file, lines, text)` from `inspectWorkflowText` after the existing developer-signing checks. Keep violations sorted through `compareViolations` and report the signing job's first line for a missing/forbidden condition.
+Call `publicReleaseSigningViolations(file, lines)` from `inspectWorkflowText` after the existing developer-signing checks; the existing final sort through `compareViolations` covers the new entries.
 
 - [ ] **Step 4: Run the synthetic tests and confirm the checker passes them**
 
@@ -196,7 +251,7 @@ Expected: PASS for the new passing fixture and every single-mutation rejection.
 
 Run: `node .github/scripts/check-workflow-security.mjs`
 
-Expected: FAIL on `release.yml` for the mixed-provider job, permissive fallback, absent SSL.com thumbprint, and missing convergence topology.
+Expected: FAIL on `release.yml` — the pre-split workflow still carries the mixed `sign-windows-tauri` job, so the checker (keyed on that job ID) reports the missing resolver/azure/sslcom sections and a gate without the convergence topology. This red state is intentional and must not be committed on its own; the Step 6 workflow rewrite lands in the same commit (Step 10), so CI never sees it.
 
 - [ ] **Step 6: Replace the mixed signer with resolver and provider-isolated jobs**
 
@@ -252,13 +307,20 @@ In `.github/workflows/release.yml`, replace the existing `sign-windows-tauri` bo
   sign-windows-tauri:
     name: Windows Tauri signing convergence gate
     needs: [resolve-windows-signing-provider, sign-windows-tauri-azure, sign-windows-tauri-sslcom]
-    if: ${{ always() && needs.resolve-windows-signing-provider.result == 'success' }}
+    if: ${{ !cancelled() && needs.resolve-windows-signing-provider.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
 ```
 
-Copy the current artifact downloads, Azure validation/login/signing steps, Azure verification, and canonical uploads into the Azure job without changing action pins, paths, profile selection, or artifact names. Copy the two SSL.com action steps and canonical uploads into the SSL.com job, set `malware_block: true`, `override: true`, and `clean_logs: true`, and add `SSLCOM_CERT_SHA256` to its validation environment.
+Gate condition semantics — this is `!cancelled() && result != 'skipped'`, deliberately not `always() && result == 'success'`:
+
+- Signing disabled (`ENABLE_WINDOWS_SIGNING != 'true'` or non-tag run): resolver skips, gate skips, and the downstream `success || skipped` conditions plus `release-integrity-gate` behave exactly as today.
+- Resolver **failed** (invalid provider value): the gate must *run and fail* (the empty provider output hits Step 8's default arm), not skip — a skipped gate reads as "signing disabled" to `create-release`'s `success || skipped` check. `release-integrity-gate`'s `require_success` would still block a tag release, but the gate failing at the cause is the primary defense, not a downstream side effect.
+
+Copy the current artifact downloads, the Azure validation/login/signing steps, and the canonical uploads into the Azure job without changing action pins, paths, profile selection, or artifact names. Copy the two SSL.com action steps (`command: sign`, per-file `file_path`, `override: true`) and the canonical uploads into the SSL.com job; per the approved design, flip `malware_block: false` to `malware_block: true` and add `clean_logs: true` — this deliberately changes the value shipped by #3762, and the step comment explaining the eSigner options must be updated to match. Extend the SSL.com validation step's required-secret list and `env:` block with `SSLCOM_CERT_SHA256`.
+
+In **both** signer jobs, extend the copied "Verify signatures" step so each MSI must also present a non-null `$sig.SignerCertificate` and `$sig.TimeStamperCertificate` (the RFC 3161 timestamp proof) in addition to the existing `Status` check — the current step checks `Status` only, and the design's Verification section requires signer + timestamp for both providers.
 
 - [ ] **Step 7: Add authoritative SSL.com certificate-pin verification**
 
@@ -287,30 +349,40 @@ Pass `SSLCOM_CERT_SHA256: ${{ secrets.SSLCOM_CERT_SHA256 }}` only to the SSL.com
 
 The gate's only step must compare the selected provider with both job results:
 
-```bash
-set -euo pipefail
-case "$PROVIDER" in
-  azure)
-    [ "$AZURE_RESULT" = success ] && [ "$SSLCOM_RESULT" = skipped ] ;;
-  sslcom)
-    [ "$AZURE_RESULT" = skipped ] && [ "$SSLCOM_RESULT" = success ] ;;
-  *) exit 1 ;;
-esac
+```yaml
+      - name: Assert single-provider convergence
+        shell: bash
+        env:
+          PROVIDER: ${{ needs.resolve-windows-signing-provider.outputs.provider }}
+          AZURE_RESULT: ${{ needs.sign-windows-tauri-azure.result }}
+          SSLCOM_RESULT: ${{ needs.sign-windows-tauri-sslcom.result }}
+        run: |
+          set -euo pipefail
+          case "$PROVIDER" in
+            azure)
+              [ "$AZURE_RESULT" = success ] && [ "$SSLCOM_RESULT" = skipped ] ;;
+            sslcom)
+              [ "$AZURE_RESULT" = skipped ] && [ "$SSLCOM_RESULT" = success ] ;;
+            *)
+              echo "::error::provider resolution failed or produced an unexpected value"
+              exit 1 ;;
+          esac
+          echo "Provider '$PROVIDER' converged (azure=$AZURE_RESULT, sslcom=$SSLCOM_RESULT)."
 ```
 
-Set `PROVIDER`, `AZURE_RESULT`, and `SSLCOM_RESULT` from `needs.*`. Emit a generic error containing provider and job-result names only; never include secrets. Preserve all existing downstream `needs: [sign-windows-tauri]` references.
+The default `*)` arm is what turns a failed resolver into a failed gate (its output is empty when it never ran) — see the Step 6 gate-condition rationale. Errors may name the provider and job results only; never a secret. Preserve all existing downstream `needs: [sign-windows-tauri]` references.
 
 - [ ] **Step 9: Run targeted and repository workflow checks**
 
 Run:
 
 ```bash
-node --test .github/scripts/check-workflow-security.test.mjs scripts/security/pin-github-actions.test.mjs
-node .github/scripts/check-workflow-security.mjs
-actionlint -color .github/workflows/release.yml
 corepack pnpm test:workflow-security
+actionlint -color .github/workflows/release.yml
 bash scripts/security/check-supply-chain-hardening.sh
 ```
+
+(`test:workflow-security` already runs `node --test` over both test files and then the checker binary — don't duplicate those invocations.)
 
 Expected: every command exits 0; the workflow checker reports no violations; `actionlint` reports no expression, job dependency, or YAML errors.
 
@@ -396,11 +468,11 @@ corepack pnpm test:workflow-security
 bash scripts/security/check-supply-chain-hardening.sh
 actionlint -color .github/workflows/release.yml
 corepack pnpm --filter @breeze/docs build
-git diff --check HEAD~2..HEAD
+git diff --check origin/main...HEAD
 git status --short
 ```
 
-Expected: all checks exit 0; `git diff --check` has no output; status is clean.
+Expected: all checks exit 0; `git diff --check` has no output; status is clean. (Diff against the merge base, not `HEAD~2` — the branch already carries the design/plan doc commits and may gain a review-fix commit.)
 
 - [ ] **Step 2: Perform the permitted review gate**
 

--- a/docs/superpowers/plans/2026-08-21-sslcom-public-release-signing-hardening.md
+++ b/docs/superpowers/plans/2026-08-21-sslcom-public-release-signing-hardening.md
@@ -495,3 +495,60 @@ Skip this commit when the independent review is clean.
 - [ ] **Step 4: Record rollout prerequisites without configuring secrets**
 
 In the implementation handoff, list the five SSL.com secrets required in both `signing-prerelease` and `signing-production`, state that the TOTP value is the enrollment seed rather than the rotating six-digit code, and require a prerelease tag with local signature inspection before changing the stable environment. Do not create secrets, change repository variables, dispatch a workflow, or publish a release until the user confirms the reset PIN/TOTP state and authorizes those external mutations.
+
+---
+
+## Post-review amendments (2026-08-21)
+
+The PR review found gaps that changed several decisions above. The task
+snippets earlier in this document record what was originally planned; where they
+conflict with the list below, the list below is what shipped.
+
+1. **CodeSignTool is staged locally against a verified digest.** Pinning the
+   `SSLcom/esigner-codesign` commit does not pin what the action runs: it
+   downloads CodeSignTool from a mutable GitHub release asset with no checksum
+   and executes it in the job holding the eSigner credentials, and installs
+   Amazon Corretto from a floating "latest" index whose checksum it reads but
+   never compares. Both are now suppressed via `CODESIGNTOOL_PATH` and
+   `JAVA_VERSION`. The verified archive bundles its own JDK.
+
+2. **`clean_logs: true` was dropped, not added.** It is a no-op in this action —
+   `path.dirname()` is applied to the whole command string, so it deletes a path
+   that never exists and `force: true` swallows the error. The plan's rationale
+   for enabling it does not hold.
+
+3. **Verification is shared, not provider-specific.** Both providers now call
+   `.github/scripts/Verify-WindowsSignature.ps1`. Keeping two inline copies is
+   what produced the asymmetry the review found: the Azure copy asserted only
+   that *some* timestamped signature existed and never checked the publisher.
+
+4. **The subject check is not a regex and is not merely diagnostic.** It parses
+   the DN via `X500DistinguishedName.Format()`. The planned regex rejected a
+   legitimate `O="LanternOps, LLC"` certificate. On the Azure path — which pins
+   no thumbprint, by design — the subject assertion is the *only* publisher
+   binding, so it is authoritative there.
+
+5. **`SSLCOM_ENVIRONMENT_LABEL` is a new required secret.** The stable/prerelease
+   certificate split relies entirely on GitHub Environment scoping, which is
+   invisible in YAML and unverifiable by lint. Both signing environments are
+   currently empty and every `AZURE_*` secret lives at repository level, so the
+   likeliest operator error would sign prereleases with the production
+   certificate. This label makes that fail loudly.
+
+6. **Lint rules bind to shape, not job names.** The planned rules keyed on four
+   exact job names behind an early return, so a consistent rename disabled all of
+   them — confirmed by deleting the certificate pin and subject check with CI
+   green. Rules now locate each provider by the action or script that defines it,
+   and a workflow that signs the Tauri MSIs must declare the full topology.
+
+7. **The environments are not an approval boundary.** Neither carries required
+   reviewers today — only a `v*` tag restriction. Statements to the contrary in
+   the plan and in the first draft of the docs were corrected.
+
+Still open, and deliberately not addressed here:
+
+- Adding required reviewers to `signing-production` / `signing-prerelease` is an
+  operator action, not a code change.
+- Leaf-thumbprint rotation remains a single value. If staging a renewal without a
+  release-day edit becomes necessary, `SSLCOM_CERT_SHA256` should become a
+  separator-delimited allowlist.

--- a/docs/superpowers/specs/2026-08-21-sslcom-public-release-signing-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-21-sslcom-public-release-signing-hardening-design.md
@@ -108,9 +108,18 @@ path of least resistance, and how every `AZURE_*` secret is stored today -- both
 environments resolve the same credential and a prerelease tag is signed with the
 production certificate, with every check passing. `SSLCOM_ENVIRONMENT_LABEL`
 holds the environment's own name (`signing-production` / `signing-prerelease`)
-and is compared against the environment the job actually runs in, so a
-repository-level secret fails one of the two loudly. No lint rule can detect
+and is compared against the environment the job actually runs in, so placing all
+six at repository level fails one of the two loudly. No lint rule can detect
 this from the YAML, which is why it is enforced at run time.
+
+The limit of that control, stated plainly: it catches the likely mistake, not
+every one. Environment variables and environment secrets share identical
+override semantics, so an operator who scopes only this label per environment
+while leaving the four credentials at repository level still passes. Proving
+env-scoping from inside the job is not possible with a static marker; binding a
+per-environment fingerprint to the credential value itself would be, and is the
+upgrade path if the two environments ever hold genuinely different eSigner
+credentials.
 
 The current SSL.com action remains pinned to the immutable commit behind its
 `v1.3.2` tag:

--- a/docs/superpowers/specs/2026-08-21-sslcom-public-release-signing-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-21-sslcom-public-release-signing-hardening-design.md
@@ -1,0 +1,178 @@
+# SSL.com Public Release Signing Hardening Design
+
+**Status:** Approved
+
+## Context
+
+The public `LanternOps/breeze` release workflow already supports selecting
+Azure Artifact Signing or SSL.com eSigner for the Windows Viewer and Helper
+MSIs. Commit `923626dc2` introduced the repository variable
+`WINDOWS_SIGNING_PROVIDER`; `sslcom` selects eSigner and every other value
+currently falls back to Azure.
+
+That implementation establishes the provider switch but leaves two hardening
+gaps:
+
+1. Azure and SSL.com execute in the same job, so an SSL.com run retains
+   `id-token: write`, even though only Azure needs OIDC.
+2. The shared Authenticode check proves that a certificate and timestamp exist,
+   but it does not prove an SSL.com signature came from the expected LanternOps
+   certificate.
+
+The public workflow intentionally publishes the self-host Agent family
+(`agent`, `backup`, `watchdog`, `user-helper`, and `breeze-agent.msi`) unsigned.
+Those artifacts are outside this signing-provider switch and must remain so.
+
+## Goal
+
+Harden the existing public Azure/SSL.com provider switch so each provider has
+least-privilege credentials and SSL.com output is pinned to the expected
+LanternOps certificate, without changing the public release asset set or
+signing the Agent family.
+
+## Non-goals
+
+- Do not sign public Agent-family Windows EXEs or `breeze-agent.msi`.
+- Do not change the public self-host/hosted edition boundary.
+- Do not move hosted-release credentials or artifacts into the public workflow.
+- Do not change macOS signing, notarization, manifest signing, or Linux assets.
+- Do not configure or transmit secret values in committed files.
+
+## Provider resolution
+
+`vars.WINDOWS_SIGNING_PROVIDER` has exactly these meanings when
+`vars.ENABLE_WINDOWS_SIGNING == 'true'`:
+
+| Value | Result |
+|---|---|
+| unset or empty | Azure (backward-compatible default) |
+| `azure` | Azure Artifact Signing |
+| `sslcom` | SSL.com eSigner |
+| any other value | fail before either signing job can run |
+
+A dedicated resolution job normalizes the value and exposes one output:
+`provider`, whose value is exactly `azure` or `sslcom`. A typo must never
+silently select a credentialed provider.
+
+## Job topology and permissions
+
+The existing `sign-windows-tauri` job becomes a provider convergence gate,
+while the actual signing work is split:
+
+```text
+build-viewer + build-helper
+            |
+    resolve signing provider
+        /               \
+Azure signer        SSL.com signer
+(id-token: write)   (contents: read only)
+        \               /
+       sign-windows-tauri gate
+                  |
+      existing release integrity flow
+```
+
+Both signer jobs use the existing dynamic GitHub Environment:
+`signing-production` for stable tags and `signing-prerelease` for tags with a
+suffix. Only the selected provider job runs. The Azure job alone receives
+`id-token: write`; the SSL.com job has `contents: read` and no OIDC permission.
+
+Both jobs upload the same canonical artifact names, but mutual exclusivity
+ensures only one producer exists in a run. The convergence gate checks that the
+selected signer succeeded and the unselected signer was skipped. Existing
+downstream jobs continue to depend on the `sign-windows-tauri` gate ID.
+
+When `ENABLE_WINDOWS_SIGNING` is not `true`, all signer jobs and the convergence
+gate remain skipped, preserving the existing public build-only behavior.
+
+## SSL.com signing inputs
+
+The following secrets live in both `signing-production` and
+`signing-prerelease`:
+
+- `SSLCOM_USERNAME`
+- `SSLCOM_PASSWORD`
+- `SSLCOM_CREDENTIAL_ID`
+- `SSLCOM_TOTP_SECRET`
+- `SSLCOM_CERT_SHA256`
+
+`SSLCOM_CERT_SHA256` is the 64-character lowercase SHA-256 thumbprint of the
+expected LanternOps leaf certificate. It is intentionally environment-scoped
+so certificate renewal can be staged in prerelease before production changes.
+
+The current SSL.com action remains pinned to the immutable commit behind its
+`v1.3.2` tag:
+`cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b`. No mutable branch or tag reference
+may appear in the workflow.
+
+The SSL.com job signs the Viewer MSI and Helper MSI in place with malware
+blocking enabled and log cleanup enabled. The GitHub Environment remains the
+human approval boundary before long-lived eSigner credentials become readable.
+
+## Verification
+
+Verification is provider-specific but converges on the same release gate.
+
+For every Viewer/Helper MSI, both providers must prove:
+
+- `Get-AuthenticodeSignature` returns `Valid` or `UnknownError`;
+- `SignerCertificate` exists;
+- `TimeStamperCertificate` exists, proving an RFC 3161 timestamp;
+- no expected artifact is missing.
+
+The SSL.com path additionally requires:
+
+- the signer certificate SHA-256 thumbprint equals `SSLCOM_CERT_SHA256` using a
+  case-insensitive, separator-free comparison;
+- the certificate subject contains `O=LANTERNOPS LLC` or
+  `CN=LANTERNOPS LLC` as a readable diagnostic guard.
+
+The thumbprint is authoritative; the subject check improves failure messages
+but cannot substitute for the pin.
+
+The Azure path retains its current chain-and-timestamp check because Azure
+Artifact Signing certificates are short-lived and rotate automatically.
+
+## Public Agent-family non-regression
+
+The existing public manifest guard remains authoritative:
+
+- canonical Agent-family Windows assets have `platformTrust: "none"`;
+- `-unsigned` copies retain `intendedUse: "signing-input"`;
+- no public Agent-family Windows asset may acquire
+  `windows-authenticode-required`;
+- every public asset keeps `edition: "self-host"`.
+
+New workflow-invariant tests explicitly assert that SSL.com references are
+confined to the Viewer/Helper signer job and never mention the Agent-family
+Windows filenames.
+
+## Testing
+
+Automated checks cover:
+
+1. provider normalization: empty/`azure`/`sslcom` accepted, invalid rejected;
+2. Azure is the only signer job with `id-token: write`;
+3. SSL.com requires all five secrets and pins the action to the exact commit;
+4. SSL.com verifies the expected certificate thumbprint and timestamp;
+5. the public Agent-family filenames remain outside all SSL.com signing steps;
+6. exactly one provider must succeed when signing is enabled;
+7. existing workflow-security, supply-chain, manifest, and `actionlint` checks.
+
+After configuration, the first live SSL.com exercise uses a prerelease tag.
+The stable provider variable is switched only after the prerelease Viewer and
+Helper MSIs pass local `Get-AuthenticodeSignature` verification and show the
+expected LanternOps publisher.
+
+## Rollback
+
+Set `WINDOWS_SIGNING_PROVIDER=azure`. No code rollback or artifact-format
+change is required. A release already published under one provider is never
+re-signed or replaced; rollback applies only to the next release.
+
+## Secret handling
+
+No SSL.com username, password, TOTP seed, credential ID, certificate PIN, or
+certificate thumbprint value is committed. Secret values are entered directly
+into GitHub Environment secrets. Workflow output must never echo the assembled
+CodeSignTool command or any secret-derived OTP.

--- a/docs/superpowers/specs/2026-08-21-sslcom-public-release-signing-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-21-sslcom-public-release-signing-hardening-design.md
@@ -95,10 +95,22 @@ The following secrets live in both `signing-production` and
 - `SSLCOM_CREDENTIAL_ID`
 - `SSLCOM_TOTP_SECRET`
 - `SSLCOM_CERT_SHA256`
+- `SSLCOM_ENVIRONMENT_LABEL`
 
 `SSLCOM_CERT_SHA256` is the 64-character lowercase SHA-256 thumbprint of the
 expected LanternOps leaf certificate. It is intentionally environment-scoped
 so certificate renewal can be staged in prerelease before production changes.
+
+Environment scoping is load-bearing and invisible in the workflow: nothing about
+the YAML differs between a stable and a prerelease tag except which environment
+supplies these secrets. If they are added at repository level instead -- the
+path of least resistance, and how every `AZURE_*` secret is stored today -- both
+environments resolve the same credential and a prerelease tag is signed with the
+production certificate, with every check passing. `SSLCOM_ENVIRONMENT_LABEL`
+holds the environment's own name (`signing-production` / `signing-prerelease`)
+and is compared against the environment the job actually runs in, so a
+repository-level secret fails one of the two loudly. No lint rule can detect
+this from the YAML, which is why it is enforced at run time.
 
 The current SSL.com action remains pinned to the immutable commit behind its
 `v1.3.2` tag:
@@ -106,32 +118,60 @@ The current SSL.com action remains pinned to the immutable commit behind its
 may appear in the workflow.
 
 The SSL.com job signs the Viewer MSI and Helper MSI in place with malware
-blocking enabled and log cleanup enabled. The GitHub Environment remains the
-human approval boundary before long-lived eSigner credentials become readable.
+blocking enabled. `clean_logs` is deliberately not set: it is a no-op in this
+action, which computes `path.dirname()` over the entire command string and so
+removes a path that never exists.
+
+Pinning the action commit does **not** pin what the action executes. At run time
+it downloads CodeSignTool from a mutable GitHub release asset with no integrity
+check and runs it in this job, and separately installs Amazon Corretto resolved
+from a floating "latest" index whose published checksum it reads but never
+compares. Either download is arbitrary code execution alongside long-lived,
+portable eSigner credentials. The job therefore stages CodeSignTool itself from
+a digest-verified archive and exports `CODESIGNTOOL_PATH`, which the action
+honours to skip its own fetch, and pins `JAVA_VERSION` so the Corretto path
+never runs -- the verified archive bundles its own JDK.
+
+The GitHub Environment scopes which credentials are readable. It is not by
+itself an approval boundary: neither signing environment currently carries
+required reviewers, only a `v*` tag restriction.
 
 ## Verification
 
-Verification is provider-specific but converges on the same release gate.
+Both providers run the **same** verification, `.github/scripts/Verify-WindowsSignature.ps1`.
+Two inline copies previously drifted: the SSL.com copy pinned a certificate
+while the Azure copy asserted only that some timestamped signature existed, so a
+mis-set endpoint or certificate profile would have shipped under an unintended
+publisher with every check green. Nothing downstream catches that -- the release
+manifest's `platformTrust` field is a declaration, not a verification.
 
 For every Viewer/Helper MSI, both providers must prove:
 
+- the artifact exists;
 - `Get-AuthenticodeSignature` returns `Valid` or `UnknownError`;
 - `SignerCertificate` exists;
 - `TimeStamperCertificate` exists, proving an RFC 3161 timestamp;
-- no expected artifact is missing.
+- the signer certificate is inside its validity window;
+- an `O` or `CN` of the signer subject equals the expected publisher.
 
-The SSL.com path additionally requires:
+`UnknownError` is PowerShell's default bucket and also covers `CERT_E_EXPIRED`,
+`CERT_E_REVOKED`, `CERT_E_UNTRUSTEDROOT` and `CERT_E_CHAINING`. Tolerating it is
+only sound because the subject and validity checks establish the publisher
+independently of chain building.
 
-- the signer certificate SHA-256 thumbprint equals `SSLCOM_CERT_SHA256` using a
-  case-insensitive, separator-free comparison;
-- the certificate subject contains `O=LANTERNOPS LLC` or
-  `CN=LANTERNOPS LLC` as a readable diagnostic guard.
+The subject is compared by parsing the DN with `X500DistinguishedName.Format()`
+and unquoting each RDN value, not by matching a regex against the raw subject
+string. A regex over the raw string rejects a legitimate
+`O="LanternOps, LLC"` certificate outright -- fail-closed, but a release-day
+outage that only appears at renewal.
 
-The thumbprint is authoritative; the subject check improves failure messages
-but cannot substitute for the pin.
+The SSL.com path additionally requires the signer certificate SHA-256 thumbprint
+to equal `SSLCOM_CERT_SHA256`, compared case-insensitively and ignoring
+separators.
 
-The Azure path retains its current chain-and-timestamp check because Azure
-Artifact Signing certificates are short-lived and rotate automatically.
+The Azure path pins no thumbprint, because Azure Artifact Signing certificates
+are short-lived and rotate automatically. Identity there rests on the subject
+assertion, which survives rotation.
 
 ## Public Agent-family non-regression
 


### PR DESCRIPTION
## Summary

- add an explicit Azure/SSL.com selector for public Viewer and Helper Windows signing
- isolate provider credentials and keep OIDC limited to the Azure signer
- verify both providers through one shared script: status, signer, RFC 3161 timestamp, validity window and publisher subject, plus a SHA-256 pin on the SSL.com path
- stage the SSL.com signing toolchain from a checksum-verified archive instead of letting the action fetch it unverified at run time
- keep public Agent-family artifacts and MSI excluded from signing on **both** providers
- bind the workflow-security rules to provider shape rather than job names
- document the switchable public release path

## Review findings addressed

A full review of this branch surfaced two critical and four important issues. All are fixed here.

**Critical**

1. **The action pin did not cover what the action runs.** `SSLcom/esigner-codesign` is pinned to a 40-char SHA, but at run time it downloads CodeSignTool from a *mutable* GitHub release asset with no checksum and executes it in the job holding the eSigner credentials — a portable, long-lived four-part secret. It separately installs Amazon Corretto from a floating `latest` index whose published checksum it reads but never compares. Now pre-staged against a verified digest with `CODESIGNTOOL_PATH` exported (the action honours it and skips its own fetch) and `JAVA_VERSION` pinned so the Corretto path never runs. The verified archive bundles its own JDK, so nothing is lost.

2. **The stable/prerelease certificate split was unimplemented.** It relies entirely on GitHub Environment scoping, which is invisible in YAML. Both signing environments are currently empty and every `AZURE_*` secret lives at repository level, so the likeliest operator error signs a prerelease with the production certificate, silently. `SSLCOM_ENVIRONMENT_LABEL` can only match one environment, making that fail loudly. **This is a new required secret — see the operator note in the docs.**

**Important**

3. **The Azure path asserted no publisher.** It checked only that *some* timestamped signature existed; the SSL.com twin pinned a certificate. A mis-set endpoint or certificate profile would have shipped under an unintended identity with every check green, and nothing downstream re-verifies — the release manifest's `platformTrust` is a declaration, not a check. Both providers now run `Verify-WindowsSignature.ps1`; sharing it removes the drift that created the asymmetry. Azure pins no thumbprint by design (its certs rotate), so the subject assertion is its publisher binding.

4. **Renaming the four signing jobs disabled every rule.** They were exact-name lookups behind an early return — confirmed by renaming them *and* deleting the certificate pin and subject check with CI fully green. Rules now locate each provider by the action or script that defines it, and a workflow that signs the Tauri MSIs must declare the full topology.

5. **Guards were presence-only; 20 of 24 assertions survived deletion.** Including the action SHA pin, the hash comparison itself, and all three convergence-gate inputs. Tests are now one mutation per assertion.

6. **Two edits that would publish unsigned artifacts passed.** Dropping `sign-windows-tauri` from the integrity gate's `require_success`, and deleting a sign step (the unsigned file was re-uploaded over the signed artifact name). Both now covered, by a release-gate rule and by signed-vs-verified plus cross-provider artifact parity.

**Also**

- Require the Azure certificate profile secrets — omitting them let a half-populated environment fail opaquely inside the signing action.
- Subject matching parses the DN via `X500DistinguishedName.Format()` instead of a regex over the raw string. The regex rejected a legitimate `O="LanternOps, LLC"` certificate — fail-closed, but a release-day outage at renewal.
- Restore explicit tag gates on both signing jobs rather than inheriting them only through `needs`.
- Drop `clean_logs`: it is a no-op in this action (`path.dirname()` over the whole command string).
- Reject expired / not-yet-valid signer certificates, which `UnknownError` otherwise admits along with `CERT_E_REVOKED` and `CERT_E_UNTRUSTEDROOT`.

## Verification

- workflow security tests: **111/111** (was 52) — `node --test`
- workflow security policy against the real `release.yml`: clean
- mutation battery: 12/12 workflow mutations killed, including the four that previously survived
- `actionlint -shellcheck=`: clean
- supply-chain hardening check: clean
- verifier parsed with the PowerShell AST parser; DN matching exercised against 7 real subject shapes including quoted, multi-attribute and adversarial forms
- documentation build: 165 pages
- CodeSignTool digest independently computed from the published archive

## Related

- Companion private hosted-release PR: LanternOps/breeze-hosted-release#1

## Operational note

Keep this PR in draft until an authorized audit-only signing validation has completed. This change does not configure secrets, dispatch a workflow, publish a release, or deploy anything.

Two items are operator actions, not code, and are **not** done by this PR:

- Add the six `SSLCOM_*` secrets to `signing-production` and `signing-prerelease` individually — not at repository level.
- Neither signing environment currently has required reviewers, only a `v*` tag restriction. Adding them is a separate decision.
