### PR TITLE
feat: invoice re-send with customer-email composer (quote parity)

### DIFF
--- a/apps/api/src/lib/sendComposer.ts
+++ b/apps/api/src/lib/sendComposer.ts
@@ -1,0 +1,56 @@
+import type { Context } from 'hono';
+import { z } from 'zod';
+
+/**
+ * The customer-email composer shared by the quote and invoice send paths.
+ *
+ * `.strict()` so a mis-keyed field (e.g. {"mesage":"hi"}) is a 400, not a
+ * silently dropped note — a recipient or a personal message the sender believed
+ * they had supplied must never vanish between the browser and the envelope.
+ *
+ * Extracted from routes/quotes/lifecycle.ts when the invoice routes grew the
+ * same composer (re-send parity): the two schemas MUST agree, because the web
+ * composer that posts to them is the same dialog shape and its client-side
+ * guards (10 recipients, 2000-char note, 200-char subject) are written against
+ * these limits.
+ */
+const sendEmailField = z.string().trim().email().max(255);
+
+export const sendComposerSchema = z.object({
+  message: z.string().trim().max(2000).optional(),
+  // Composer fields (all optional — an empty body reproduces the classic send):
+  // explicit recipients override the org billing-contact fallback.
+  to: z.array(sendEmailField).min(1).max(10).optional(),
+  cc: z.array(sendEmailField).max(10).optional(),
+  subject: z.string().trim().max(200).optional(),
+  includePdf: z.boolean().optional(),
+}).strict();
+
+export type SendComposerBody = z.infer<typeof sendComposerSchema>;
+
+/**
+ * Read an optional composer body.
+ *
+ * Distinguishes an ABSENT body (most callers — bulk-send/MCP/tests POST nothing,
+ * yet fetchWithAuth still stamps a JSON content-type) from a PRESENT-but-broken
+ * one. An empty body degrades to "no options"; a non-empty body that fails to
+ * parse/validate is rejected rather than silently swallowing recipients or a
+ * note the sender intended. A body-READ failure (stream aborted mid-request) is
+ * likewise an error, not an absent body.
+ *
+ * Returns the parsed options, or an `error` the caller returns verbatim.
+ */
+export async function parseComposerBody<T extends z.ZodTypeAny>(
+  c: Context,
+  schema: T,
+): Promise<{ ok: true; data: Partial<z.infer<T>> } | { ok: false; error: string }> {
+  if (!(c.req.header('content-type') ?? '').includes('application/json')) return { ok: true, data: {} };
+  const raw = await c.req.text().catch(() => null);
+  if (raw === null) return { ok: false, error: 'Could not read request body' };
+  if (!raw.trim()) return { ok: true, data: {} };
+  let json: unknown;
+  try { json = JSON.parse(raw); } catch { return { ok: false, error: 'Invalid JSON body' }; }
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) return { ok: false, error: 'Invalid send options' };
+  return { ok: true, data: parsed.data };
+}

--- a/apps/api/src/routes/invoices/index.ts
+++ b/apps/api/src/routes/invoices/index.ts
@@ -10,7 +10,7 @@ import { invoiceBulkRoutes } from './bulk';
 export const invoiceRoutes = new Hono();
 invoiceRoutes.use('*', authMiddleware);
 invoiceRoutes.route('/', invoiceBulkRoutes);       // bulk-* before /:id
-invoiceRoutes.route('/', invoiceLifecycleRoutes);  // /:id/issue, /:id/send, /:id/void
+invoiceRoutes.route('/', invoiceLifecycleRoutes);  // /:id/issue, /:id/send, /:id/resend, /:id/void
 invoiceRoutes.route('/', invoicePaymentRoutes);    // /:id/payments...
 invoiceRoutes.route('/', invoiceStripeRoutes);     // /:id/pay-link
 invoiceRoutes.route('/', invoicePdfRoutes);        // /:id/pdf (Phase 5)

--- a/apps/api/src/routes/invoices/invoices.test.ts
+++ b/apps/api/src/routes/invoices/invoices.test.ts
@@ -25,6 +25,7 @@ vi.mock('../../services/invoiceService', () => ({
 // Mock the Phase 5 PDF/email service — /:id/send + /:id/pdf delegate here.
 vi.mock('../../services/invoicePdf', () => ({
   sendInvoiceEmail: vi.fn(),
+  resendInvoiceEmail: vi.fn(),
   renderInvoicePdf: vi.fn(),
   getInvoicePdf: vi.fn()
 }));
@@ -282,7 +283,11 @@ describe('invoice lifecycle routes', () => {
     const body = await res.json();
     expect(body.data.emailed).toBe(true);
     expect(body.data.invoice.id).toBe(INV_ID);
-    expect(pdfSvc.sendInvoiceEmail).toHaveBeenCalledWith(INV_ID, expect.anything());
+    // Third arg is the (empty) composer body: a body-less POST must reproduce
+    // the classic billing-contact send, with every composer field undefined.
+    expect(pdfSvc.sendInvoiceEmail).toHaveBeenCalledWith(INV_ID, expect.anything(), {
+      to: undefined, cc: undefined, subject: undefined, message: undefined, includePdf: undefined,
+    });
   });
 
   it('POST /:id/send surfaces emailed:false + reason when nothing was emailed', async () => {
@@ -300,6 +305,84 @@ describe('invoice lifecycle routes', () => {
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.code).toBe('INVOICE_NOT_FOUND');
+  });
+
+  it('POST /:id/send threads the composer body through to the service', async () => {
+    (pdfSvc.sendInvoiceEmail as any).mockResolvedValue({ invoice: { id: INV_ID, status: 'sent' }, emailed: true, recipients: ['a@x.test'] });
+    const res = await app().request(`/${INV_ID}/send`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ to: ['a@x.test'], cc: ['b@x.test'], subject: 'Your invoice', message: 'Thanks!', includePdf: false }),
+    });
+    expect(res.status).toBe(200);
+    expect(pdfSvc.sendInvoiceEmail).toHaveBeenCalledWith(INV_ID, expect.anything(), {
+      to: ['a@x.test'], cc: ['b@x.test'], subject: 'Your invoice', message: 'Thanks!', includePdf: false,
+    });
+  });
+
+  it('POST /:id/resend calls resendInvoiceEmail with the composer options', async () => {
+    (pdfSvc.resendInvoiceEmail as any).mockResolvedValue({
+      invoice: { id: INV_ID, orgId: 'o1', status: 'sent' }, emailed: true, recipients: ['a@x.test'],
+    });
+    const res = await app().request(`/${INV_ID}/resend`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ to: ['a@x.test'], message: 'Second copy as requested.' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.emailed).toBe(true);
+    expect(pdfSvc.resendInvoiceEmail).toHaveBeenCalledWith(INV_ID, expect.anything(), {
+      to: ['a@x.test'], cc: undefined, subject: undefined, message: 'Second copy as requested.', includePdf: undefined,
+    });
+  });
+
+  it('POST /:id/resend audits the attempt, recording the recipient COUNT not the addresses', async () => {
+    (pdfSvc.resendInvoiceEmail as any).mockResolvedValue({
+      invoice: { id: INV_ID, orgId: 'o1', status: 'sent' }, emailed: true, recipients: ['a@x.test', 'b@x.test'],
+    });
+    await app().request(`/${INV_ID}/resend`, { method: 'POST' });
+    expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      orgId: 'o1', action: 'invoice.resend', resourceType: 'invoice', resourceId: INV_ID, result: 'success',
+      details: { emailed: true, emailReason: undefined, recipientCount: 2 },
+    }));
+    const audited = JSON.stringify((writeRouteAudit as any).mock.calls[0][1]);
+    expect(audited).not.toContain('a@x.test');
+  });
+
+  it('POST /:id/resend audits result:failure when nothing was emailed', async () => {
+    (pdfSvc.resendInvoiceEmail as any).mockResolvedValue({
+      invoice: { id: INV_ID, orgId: 'o1', status: 'sent' }, emailed: false, reason: 'no_billing_contact', recipients: [],
+    });
+    const res = await app().request(`/${INV_ID}/resend`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.reason).toBe('no_billing_contact');
+    expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ result: 'failure' }));
+  });
+
+  it('POST /:id/resend rejects a mis-keyed composer field rather than dropping it', async () => {
+    const res = await app().request(`/${INV_ID}/resend`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ mesage: 'typo — must not be silently swallowed' }),
+    });
+    expect(res.status).toBe(400);
+    expect(pdfSvc.resendInvoiceEmail).not.toHaveBeenCalled();
+  });
+
+  it('POST /:id/resend maps a draft INVALID_STATE to 409', async () => {
+    (pdfSvc.resendInvoiceEmail as any).mockRejectedValue(
+      new InvoiceServiceError('This invoice has not been issued yet — issue it before re-sending', 409, 'INVALID_STATE'),
+    );
+    const res = await app().request(`/${INV_ID}/resend`, { method: 'POST' });
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe('INVALID_STATE');
+  });
+
+  it('POST /:id/resend rejects a non-uuid id before reaching the service', async () => {
+    const res = await app().request('/not-a-uuid/resend', { method: 'POST' });
+    expect(res.status).toBe(400);
+    expect(pdfSvc.resendInvoiceEmail).not.toHaveBeenCalled();
   });
 
   it('POST /:id/void validates the reason body (empty reason → 400, no service call)', async () => {

--- a/apps/api/src/routes/invoices/lifecycle.ts
+++ b/apps/api/src/routes/invoices/lifecycle.ts
@@ -1,11 +1,13 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
+import { sendComposerSchema, parseComposerBody } from '../../lib/sendComposer';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { voidInvoiceSchema } from '@breeze/shared';
 import { issueInvoice, voidInvoice } from '../../services/invoiceService';
-import { sendInvoiceEmail } from '../../services/invoicePdf'; // added in Phase 5
+import { sendInvoiceEmail, resendInvoiceEmail, type SendInvoiceEmailOptions } from '../../services/invoicePdf'; // added in Phase 5
+import { writeRouteAudit } from '../../services/auditEvents';
 import { invoiceActorFrom, handleServiceError } from './invoices';
 
 export const invoiceLifecycleRoutes = new Hono();
@@ -13,14 +15,59 @@ const scopes = requireScope('partner', 'system');
 const sendPerm = requirePermission(PERMISSIONS.INVOICES_SEND.resource, PERMISSIONS.INVOICES_SEND.action);
 const idParam = z.object({ id: z.string().guid() });
 
+/** Map the validated composer body onto the service options. Blank strings
+ *  collapse to undefined so an empty Subject/Message field means "use the
+ *  default" rather than sending an empty subject line. */
+function composerOptions(body: Partial<z.infer<typeof sendComposerSchema>>): SendInvoiceEmailOptions {
+  return {
+    message: body.message || undefined,
+    to: body.to,
+    cc: body.cc,
+    subject: body.subject || undefined,
+    includePdf: body.includePdf,
+  };
+}
+
 invoiceLifecycleRoutes.post('/:id/issue', scopes, sendPerm, zValidator('param', idParam), async (c) => {
   try { return c.json({ data: await issueInvoice(c.req.valid('param').id, invoiceActorFrom(c)) }); }
   catch (err) { return handleServiceError(c, err); }
 });
+
+// POST /:id/send — issue (if still a draft) + email. The composer body is
+// optional and shared with /resend: bulk-send, the MCP tools and the contract
+// worker POST nothing and get the classic billing-contact send unchanged.
 invoiceLifecycleRoutes.post('/:id/send', scopes, sendPerm, zValidator('param', idParam), async (c) => {
-  try { return c.json({ data: await sendInvoiceEmail(c.req.valid('param').id, invoiceActorFrom(c)) }); }
+  const parsed = await parseComposerBody(c, sendComposerSchema);
+  if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+  try { return c.json({ data: await sendInvoiceEmail(c.req.valid('param').id, invoiceActorFrom(c), composerOptions(parsed.data)) }); }
   catch (err) { return handleServiceError(c, err); }
 });
+
+// POST /:id/resend — re-email an already-issued invoice. Not a second send:
+// sent_at, the invoice number and the issue-time snapshots stay pinned to the
+// original issue and no invoice.sent event is re-emitted (see
+// resendInvoiceEmail). Same invoices:send permission as /send, and audited on
+// every call — it puts a demand for money back in a customer's inbox.
+invoiceLifecycleRoutes.post('/:id/resend', scopes, sendPerm, zValidator('param', idParam), async (c) => {
+  const id = c.req.valid('param').id;
+  const parsed = await parseComposerBody(c, sendComposerSchema);
+  if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+  try {
+    const result = await resendInvoiceEmail(id, invoiceActorFrom(c), composerOptions(parsed.data));
+    writeRouteAudit(c, {
+      orgId: result.invoice.orgId,
+      action: 'invoice.resend',
+      resourceType: 'invoice',
+      resourceId: id,
+      result: result.emailed ? 'success' : 'failure',
+      // recipientCount, not the addresses: the audit log is queryable by
+      // support and a customer's email address is not incident data.
+      details: { emailed: result.emailed, emailReason: result.reason, recipientCount: result.recipients.length },
+    });
+    return c.json({ data: result });
+  } catch (err) { return handleServiceError(c, err); }
+});
+
 invoiceLifecycleRoutes.post('/:id/void', scopes, sendPerm, zValidator('param', idParam), zValidator('json', voidInvoiceSchema), async (c) => {
   try { const b = c.req.valid('json'); return c.json({ data: await voidInvoice(c.req.valid('param').id, b.reason, { reissue: b.reissue }, invoiceActorFrom(c)) }); }
   catch (err) { return handleServiceError(c, err); }

--- a/apps/api/src/routes/quotes/lifecycle.ts
+++ b/apps/api/src/routes/quotes/lifecycle.ts
@@ -1,7 +1,8 @@
-import { Hono, type Context } from 'hono';
+import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { z } from 'zod';
 import { zValidator } from '../../lib/validation';
+import { sendComposerSchema as sendBodySchema, parseComposerBody } from '../../lib/sendComposer';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { sendQuote, resendQuote, getQuoteShareLink } from '../../services/quoteLifecycle';
@@ -36,46 +37,6 @@ function remoteImageStatus(reason: RemoteImageFailureReason): 413 | 415 | 502 | 
     case 'timeout': return 504;
     case 'unreachable': return 502;
   }
-}
-
-// Composer options for the customer email. `.strict()` so a mis-keyed field
-// (e.g. {"mesage":"hi"}) is a 400, not a silently dropped note.
-const sendEmailField = z.string().trim().email().max(255);
-const sendBodySchema = z.object({
-  message: z.string().trim().max(2000).optional(),
-  // Composer fields (all optional — an empty body reproduces the classic send):
-  // explicit recipients override the org billing-contact fallback.
-  to: z.array(sendEmailField).min(1).max(10).optional(),
-  cc: z.array(sendEmailField).max(10).optional(),
-  subject: z.string().trim().max(200).optional(),
-  includePdf: z.boolean().optional(),
-}).strict();
-
-/**
- * Read the optional composer body shared by /send, /schedule-send and /resend.
- *
- * Distinguishes an ABSENT body (most callers — bulk-send/MCP/tests POST nothing,
- * yet fetchWithAuth still stamps a JSON content-type) from a PRESENT-but-broken
- * one. An empty body degrades to "no options"; a non-empty body that fails to
- * parse/validate is rejected rather than silently swallowing recipients or a
- * note the sender intended. A body-READ failure (stream aborted mid-request) is
- * likewise an error, not an absent body.
- *
- * Returns the parsed options, or an `error` the caller returns verbatim.
- */
-async function parseComposerBody<T extends z.ZodTypeAny>(
-  c: Context,
-  schema: T,
-): Promise<{ ok: true; data: Partial<z.infer<T>> } | { ok: false; error: string }> {
-  if (!(c.req.header('content-type') ?? '').includes('application/json')) return { ok: true, data: {} };
-  const raw = await c.req.text().catch(() => null);
-  if (raw === null) return { ok: false, error: 'Could not read request body' };
-  if (!raw.trim()) return { ok: true, data: {} };
-  let json: unknown;
-  try { json = JSON.parse(raw); } catch { return { ok: false, error: 'Invalid JSON body' }; }
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) return { ok: false, error: 'Invalid send options' };
-  return { ok: true, data: parsed.data };
 }
 
 // POST /:id/send — issue + email. Gated on the (previously dead) quotes:send permission.

--- a/apps/api/src/services/email.ts
+++ b/apps/api/src/services/email.ts
@@ -40,6 +40,14 @@ export interface InvoiceEmailParams {
   // intentionally the same for ALL invoices; there's no behavioral copy fork.
   amountDueNow?: string;
   amountPaid?: string;
+  /** Optional free-text note from the sender, shown above the "View invoice" CTA. */
+  message?: string;
+  /** Sender-chosen subject line; falls back to the standard one. */
+  subject?: string;
+  /** Whether the caller is attaching the PDF — drives the "A PDF copy is attached" copy. */
+  pdfAttached?: boolean;
+  /** Partner's configured plain-text signature, rendered muted under the CTA. */
+  signature?: string;
 }
 
 export interface PasswordResetEmailParams {
@@ -858,22 +866,39 @@ function buildInviteTemplate(params: InviteEmailParams): EmailTemplate {
 
 export function buildInvoiceTemplate(params: InvoiceEmailParams): EmailTemplate {
   const number = params.invoiceNumber.trim();
-  const subject = `Invoice ${number} from ${params.partnerName}`;
+  const subject = params.subject?.trim() || `Invoice ${number} from ${params.partnerName}`;
   const preheader = `Invoice ${number} — ${params.total}${params.dueDate ? `, due ${params.dueDate}` : ''}.`;
   const dueNow = params.amountDueNow ?? params.total;
+  // The composer can drop the attachment; the intro must not then promise one.
+  const pdfAttached = params.pdfAttached ?? true;
+  const introSuffix = pdfAttached ? ' A PDF copy is attached to this email.' : '';
   const dueLine = params.dueDate
     ? `<p style="${BODY_PARA}">Amount due now: <strong>${escapeHtml(dueNow)}</strong> by <strong>${escapeHtml(params.dueDate)}</strong>.</p>`
     : `<p style="${BODY_PARA}">Amount due now: <strong>${escapeHtml(dueNow)}</strong>.</p>`;
   const paidLine = params.amountPaid
     ? `<p style="${MUTED_PARA}">Paid to date: ${escapeHtml(params.amountPaid)} of ${escapeHtml(params.total)}.</p>`
     : '';
+  // Sender's personal note, if any. Escaped, with newlines preserved as <br> so a
+  // multi-line note keeps its shape. Rendered between the intro and the amounts
+  // (mirrors buildQuoteTemplate).
+  const note = params.message?.trim();
+  const messageBlock = note
+    ? `<p style="${BODY_PARA}">${escapeHtml(note).replace(/\r?\n/g, '<br>')}</p>`
+    : '';
+  // Partner signature: muted, under the CTA — reads as a sign-off, not content.
+  const signature = params.signature?.trim();
+  const signatureBlock = signature
+    ? `<p style="${MUTED_PARA}">${escapeHtml(signature).replace(/\r?\n/g, '<br>')}</p>`
+    : '';
   const body = `
       <p style="${BODY_PARA}">Hi there,</p>
-      <p style="${BODY_PARA}">${escapeHtml(params.partnerName)} has sent you invoice <strong>${escapeHtml(number)}</strong>. A PDF copy is attached to this email.</p>
+      <p style="${BODY_PARA}">${escapeHtml(params.partnerName)} has sent you invoice <strong>${escapeHtml(number)}</strong>.${introSuffix}</p>
+      ${messageBlock}
       ${dueLine}
       ${paidLine}
       ${renderButton('View invoice', params.portalUrl)}
       <p style="${MUTED_PARA}">You can view this invoice and download a copy any time from your customer portal.</p>
+      ${signatureBlock}
   `;
   const html = renderLayout({
     title: subject,
@@ -888,10 +913,12 @@ export function buildInvoiceTemplate(params: InvoiceEmailParams): EmailTemplate 
   const support = getSupportEmail(params.supportEmail);
   const text = [
     'Hi there,',
-    `${params.partnerName} has sent you invoice ${number}. A PDF copy is attached.`,
+    `${params.partnerName} has sent you invoice ${number}.${pdfAttached ? ' A PDF copy is attached.' : ''}`,
+    note || null,
     params.dueDate ? `Amount due now: ${dueNow} by ${params.dueDate}.` : `Amount due now: ${dueNow}.`,
     params.amountPaid ? `Paid to date: ${params.amountPaid} of ${params.total}.` : null,
     `View invoice: ${params.portalUrl}`,
+    signature || null,
     support ? `Questions about this invoice? Contact ${support}.` : null,
   ]
     .filter(Boolean)

--- a/apps/api/src/services/invoicePdf.ts
+++ b/apps/api/src/services/invoicePdf.ts
@@ -453,6 +453,13 @@ export async function getInvoicePdf(invoiceId: string): Promise<Buffer | null> {
 // Email delivery
 // ---------------------------------------------------------------------------
 
+/** Why the best-effort email step did not deliver. `send_failed` is reachable
+ *  only on the re-send path: a first send lets a transport throw propagate
+ *  (the caller is mid-issue and must learn the send failed), while a re-send
+ *  changes no invoice state and so has nothing to roll back — reporting the
+ *  failure honestly beats a 500 on an invoice that is already issued. */
+export type SendInvoiceEmailReason = 'no_email_service' | 'no_billing_contact' | 'send_failed';
+
 /** Result of a send attempt: the (issued) invoice plus an honest signal of
  *  whether an email was actually dispatched. `emailed:false` means the invoice
  *  IS issued (sent_at stamped, invoice.sent emitted) but no email left the box,
@@ -460,7 +467,28 @@ export async function getInvoicePdf(invoiceId: string): Promise<Buffer | null> {
 export interface SendInvoiceResult {
   invoice: InvoiceRow;
   emailed: boolean;
-  reason?: 'no_email_service' | 'no_billing_contact';
+  reason?: SendInvoiceEmailReason;
+  /** Addresses the envelope actually went to (empty when nothing was sent). */
+  recipients: string[];
+}
+
+/**
+ * Composer fields for the customer email, shared by the send and re-send paths
+ * and mirroring `SendQuoteEmailOptions`. Every field is optional: an options-less
+ * call reproduces the classic "email the org billing contact with the PDF"
+ * behaviour, which is what bulk-send, the MCP tools and the contract worker do.
+ */
+export interface SendInvoiceEmailOptions {
+  /** Explicit recipients — override the org billing-contact fallback. */
+  to?: string[];
+  /** Extra recipients on the same envelope. */
+  cc?: string[];
+  /** Overrides the default "Invoice <number> from <partner>" subject. */
+  subject?: string;
+  /** Personal note rendered above the amounts in the customer email. */
+  message?: string;
+  /** false skips the PDF attachment (and its "a copy is attached" copy). */
+  includePdf?: boolean;
 }
 
 /**
@@ -488,14 +516,124 @@ export function buildInvoiceEmailAmounts(inv: {
 }
 
 /**
+ * Render (if needed) and deliver the customer invoice email.
+ *
+ * Shared by `sendInvoiceEmail` and `resendInvoiceEmail` — extracted so the two
+ * paths can never drift on the attachment, the branded envelope, the
+ * deposit-aware amounts or the recipient precedence: the details that decide
+ * what a customer actually receives. Mirrors `deliverQuoteEmail`
+ * (services/quoteLifecycle.ts).
+ *
+ * Delivery is best-effort by contract on the RE-SEND path only: `swallowThrow`
+ * turns a transport failure into `reason: 'send_failed'` so an invoice that is
+ * already issued isn't reported as a 500. A first send leaves it false — the
+ * caller is mid-issue and a silent swallow there would mark an invoice sent
+ * with nobody any the wiser.
+ */
+async function deliverInvoiceEmail(
+  invoice: InvoiceRow,
+  opts: SendInvoiceEmailOptions,
+  { swallowThrow }: { swallowThrow: boolean },
+): Promise<{ emailed: boolean; reason?: SendInvoiceEmailReason; recipients: string[] }> {
+  const invoiceId = invoice.id;
+
+  // Ensure the PDF exists (render synchronously if absent). Skipped entirely
+  // when the composer dropped the attachment — there is nothing to attach and
+  // no reason to pay for a render.
+  const includePdf = opts.includePdf !== false;
+  let pdf: Buffer | null = null;
+  if (includePdf) {
+    pdf = await getInvoicePdf(invoiceId);
+    if (!pdf) {
+      await renderInvoicePdf(invoiceId);
+      pdf = await getInvoicePdf(invoiceId);
+    }
+  }
+
+  // Resolve recipient + partner name for the email body.
+  const [org] = await db.select({ billingContact: organizations.billingContact, name: organizations.name }).from(organizations).where(eq(organizations.id, invoice.orgId)).limit(1);
+  const [partner] = await db.select({ name: partners.name, billingEmail: partners.billingEmail, emailSignature: partners.emailSignature }).from(partners).where(eq(partners.id, invoice.partnerId)).limit(1);
+  const billingRecipient = resolveBillingEmail(org?.billingContact);
+  // Composer picks win; the org's billing contact is the fallback so a bare
+  // send keeps working exactly as before. Normalized here (not only in the
+  // route's zod schema) so a service-layer caller — MCP, bulk send — cannot
+  // put a differently-cased or duplicated address on the envelope.
+  const normalizedTo = Array.from(new Set(
+    (opts.to ?? []).map((email) => email.trim().toLowerCase()).filter((email) => email.length > 0),
+  ));
+  const recipients = normalizedTo.length > 0 ? normalizedTo : (billingRecipient ? [billingRecipient] : []);
+  const cc = Array.from(new Set(
+    (opts.cc ?? []).map((email) => email.trim().toLowerCase()).filter((email) => email.length > 0),
+  ));
+
+  const emailService = getEmailService();
+  if (!emailService) {
+    console.warn(`[invoicePdf] Email not configured — invoice ${invoiceId} issued but not emailed`);
+    return { emailed: false, reason: 'no_email_service', recipients: [] };
+  }
+  if (recipients.length === 0) {
+    console.warn(`[invoicePdf] No billing email for org ${invoice.orgId} — invoice ${invoiceId} issued but not emailed`);
+    return { emailed: false, reason: 'no_billing_contact', recipients: [] };
+  }
+
+  // The invoice detail page lives at <portalBase>/invoices/<id>; portalBase()
+  // handles the PUBLIC_PORTAL_URL → app-origin fallback chain and appends the
+  // portal base path to app-origin fallbacks (previously this inline chain
+  // emitted links missing /portal when PUBLIC_PORTAL_URL was unset).
+  const portalLink = `${portalBase()}/invoices/${invoiceId}`;
+  // This IS the "Request balance payment" action for deposit invoices: the money
+  // fields reflect the deposit-vs-balance split so the email states what's owed
+  // NOW, not just the invoice total (which may already be partially covered).
+  const amounts = buildInvoiceEmailAmounts(invoice);
+  const template = buildInvoiceTemplate({
+    invoiceNumber: invoice.invoiceNumber ?? '',
+    partnerName: partner?.name ?? 'your provider',
+    total: amounts.total,
+    dueDate: formatDate(invoice.dueDate),
+    portalUrl: portalLink,
+    amountDueNow: amounts.amountDueNow,
+    amountPaid: amounts.amountPaid,
+    subject: opts.subject,
+    message: opts.message,
+    pdfAttached: includePdf && pdf != null,
+    signature: partner?.emailSignature ?? undefined,
+  });
+  try {
+    await emailService.sendEmail({
+      to: recipients,
+      cc: cc.length > 0 ? cc : undefined,
+      // MSP-branded envelope, mirroring the quote send path: display name
+      // "<Partner> via Breeze" on the platform address (SPF/DKIM stays
+      // aligned), replies routed to the MSP's billing inbox.
+      from: partner?.name ? emailService.fromWithDisplayName(`${partner.name} via Breeze`) : undefined,
+      replyTo: partner?.billingEmail?.trim() || undefined,
+      subject: template.subject,
+      html: template.html,
+      text: template.text,
+      attachments: pdf ? [{ filename: `${invoice.invoiceNumber ?? 'invoice'}.pdf`, content: pdf, contentType: 'application/pdf' }] : undefined,
+    });
+  } catch (err) {
+    if (!swallowThrow) throw err;
+    console.error(`[invoicePdf] re-send email failed for invoice ${invoiceId}:`, err);
+    return { emailed: false, reason: 'send_failed', recipients };
+  }
+  return { emailed: true, recipients };
+}
+
+/**
  * Issue the invoice if it is still a draft, ensure a PDF artifact exists
  * (rendered synchronously — the email path must NOT depend on the async worker),
  * email it to the org billing contact with the PDF attached, and stamp sent_at.
  * Returns { emailed } so callers can tell the user the truth when the email
  * could not be dispatched (no email service / no billing contact) — issuance
  * still succeeds in that case (the invoice IS issued; we just couldn't email it).
+ *
+ * `opts` carries the composer fields when a human sent this from the web UI;
+ * every caller that passes nothing gets the historical behaviour unchanged.
  */
-export async function sendInvoiceEmail(invoiceId: string, actor: InvoiceActor): Promise<SendInvoiceResult> {
+export async function sendInvoiceEmail(
+  invoiceId: string, actor: InvoiceActor, opts: SendInvoiceEmailOptions = {},
+): Promise<SendInvoiceResult> {
   const { issueInvoice } = await import('./invoiceService');
 
   // 1. Issue if still draft. issueInvoice asserts draft but intentionally does
@@ -515,68 +653,16 @@ export async function sendInvoiceEmail(invoiceId: string, actor: InvoiceActor): 
     if (!invoice) throw new InvoiceServiceError('Invoice not found', 404, 'INVOICE_NOT_FOUND');
   }
 
-  // 2. Ensure the PDF exists (render synchronously if absent).
-  let pdf = await getInvoicePdf(invoiceId);
-  if (!pdf) {
-    await renderInvoicePdf(invoiceId);
-    pdf = await getInvoicePdf(invoiceId);
-  }
-
-  // 3. Resolve recipient + partner name for the email body.
-  const [org] = await db.select({ billingContact: organizations.billingContact, name: organizations.name }).from(organizations).where(eq(organizations.id, invoice.orgId)).limit(1);
-  const [partner] = await db.select({ name: partners.name, billingEmail: partners.billingEmail }).from(partners).where(eq(partners.id, invoice.partnerId)).limit(1);
-  const recipient = resolveBillingEmail(org?.billingContact);
-
-  // 4. Send (graceful no-op if email is not configured or no recipient is known).
-  //    Track whether an email actually went out so the caller can report honestly.
-  const emailService = getEmailService();
-  let emailed = false;
-  let reason: SendInvoiceResult['reason'];
-  if (emailService && recipient) {
-    // The invoice detail page lives at <portalBase>/invoices/<id>; portalBase()
-    // handles the PUBLIC_PORTAL_URL → app-origin fallback chain and appends the
-    // portal base path to app-origin fallbacks (previously this inline chain
-    // emitted links missing /portal when PUBLIC_PORTAL_URL was unset).
-    const portalLink = `${portalBase()}/invoices/${invoiceId}`;
-    // This IS the "Request balance payment" action for deposit invoices: the money
-    // fields reflect the deposit-vs-balance split so the email states what's owed
-    // NOW, not just the invoice total (which may already be partially covered).
-    const amounts = buildInvoiceEmailAmounts(invoice);
-    const template = buildInvoiceTemplate({
-      invoiceNumber: invoice.invoiceNumber ?? '',
-      partnerName: partner?.name ?? 'your provider',
-      total: amounts.total,
-      dueDate: formatDate(invoice.dueDate),
-      portalUrl: portalLink,
-      amountDueNow: amounts.amountDueNow,
-      amountPaid: amounts.amountPaid,
-    });
-    await emailService.sendEmail({
-      to: recipient,
-      // MSP-branded envelope, mirroring the quote send path: display name
-      // "<Partner> via Breeze" on the platform address (SPF/DKIM stays
-      // aligned), replies routed to the MSP's billing inbox.
-      from: partner?.name ? emailService.fromWithDisplayName(`${partner.name} via Breeze`) : undefined,
-      replyTo: partner?.billingEmail?.trim() || undefined,
-      subject: template.subject,
-      html: template.html,
-      text: template.text,
-      attachments: pdf ? [{ filename: `${invoice.invoiceNumber ?? 'invoice'}.pdf`, content: pdf, contentType: 'application/pdf' }] : undefined,
-    });
-    emailed = true;
-  } else if (!emailService) {
-    reason = 'no_email_service';
-    console.warn(`[invoicePdf] Email not configured — invoice ${invoiceId} issued but not emailed`);
-  } else {
-    reason = 'no_billing_contact';
-    console.warn(`[invoicePdf] No billing email for org ${invoice.orgId} — invoice ${invoiceId} issued but not emailed`);
-  }
+  // 2-4. Ensure the PDF, resolve recipients, send (graceful no-op if email is
+  //      not configured or no recipient is known).
+  const { emailed, reason, recipients } = await deliverInvoiceEmail(invoice, opts, { swallowThrow: false });
 
   // 5. Stamp sent_at. This is the SOLE place sent_at is set — issueInvoice
   //    leaves it null on purpose so a plain Issue reads "Issued", and only an
   //    explicit send (this path) marks it. sent_at means "send attempted",
   //    so it's stamped even when no email service / billing contact exists
-  //    (see the emailed:false case + invoicePdf.integration.test).
+  //    (see the emailed:false case + invoicePdf.integration.test). A RE-SEND
+  //    deliberately does NOT re-stamp it — see resendInvoiceEmail.
   await db.update(invoices).set({ sentAt: new Date(), updatedAt: new Date() }).where(eq(invoices.id, invoiceId));
 
   // 6. Emit the invoice.sent lifecycle event (spec §16). The send action has
@@ -586,7 +672,55 @@ export async function sendInvoiceEmail(invoiceId: string, actor: InvoiceActor): 
   await emitInvoiceEvent({ type: 'invoice.sent', invoiceId, orgId: invoice.orgId, partnerId: invoice.partnerId, actorUserId: actor.userId });
 
   const [updated] = await db.select().from(invoices).where(eq(invoices.id, invoiceId)).limit(1);
-  return { invoice: updated!, emailed, reason };
+  return { invoice: updated!, emailed, reason, recipients };
+}
+
+/**
+ * Re-email an already-issued invoice — the bounced address, the deleted mail,
+ * the "can you send that again?" call.
+ *
+ * Deliberately NOT a second send. It writes NOTHING: `sent_at` stays pinned to
+ * the original issue (it means "when this invoice was first put in front of the
+ * customer", and a re-send is the same document, not a new one), no
+ * `invoice.sent` lifecycle event is re-emitted, and the number, snapshots and
+ * status are untouched. Mirrors `resendQuote` (services/quoteLifecycle.ts).
+ *
+ * Refused for a DRAFT (nothing has been issued to re-send) and for a VOID
+ * invoice (emailing a customer a demand we have already cancelled). A PAID
+ * invoice IS re-sendable: "send me a copy for our records" is the single most
+ * common reason a customer asks, and unlike a quote's accept link the invoice
+ * email dispenses no credential — the portal link is gated on a portal login.
+ *
+ * Delivery failures are swallowed into `reason` rather than thrown: the invoice
+ * is already issued, so there is no state to roll back, and a 500 here would
+ * tell the tech "could not re-send" for a message that may well have gone out.
+ */
+export async function resendInvoiceEmail(
+  invoiceId: string, actor: InvoiceActor, opts: SendInvoiceEmailOptions = {},
+): Promise<SendInvoiceResult> {
+  const [invoice] = await db.select().from(invoices).where(eq(invoices.id, invoiceId)).limit(1);
+  if (!invoice) throw new InvoiceServiceError('Invoice not found', 404, 'INVOICE_NOT_FOUND');
+
+  // Org-access backstop (defense-in-depth over RLS). 404 not 403 — don't leak
+  // existence across tenants.
+  if (actor.accessibleOrgIds !== null && !actor.accessibleOrgIds.includes(invoice.orgId)) {
+    throw new InvoiceServiceError('Invoice not found', 404, 'INVOICE_NOT_FOUND');
+  }
+
+  if (invoice.status === 'draft') {
+    throw new InvoiceServiceError('This invoice has not been issued yet — issue it before re-sending', 409, 'INVALID_STATE');
+  }
+  if (invoice.status === 'void') {
+    throw new InvoiceServiceError('Cannot re-send a void invoice', 409, 'INVALID_STATE');
+  }
+  if (!invoice.invoiceNumber) {
+    // An issued invoice always has a number (issueInvoice allocates one on the
+    // way through). Missing here means the row was tampered with or half-migrated.
+    throw new InvoiceServiceError('This invoice has no invoice number and cannot be re-sent', 409, 'INVALID_STATE');
+  }
+
+  const { emailed, reason, recipients } = await deliverInvoiceEmail(invoice, opts, { swallowThrow: true });
+  return { invoice, emailed, reason, recipients };
 }
 
 /** Pull an email address out of the organizations.billing_contact JSONB blob. */

--- a/apps/api/src/services/invoiceResend.test.ts
+++ b/apps/api/src/services/invoiceResend.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// DB mock: select().from().where().limit() resolves to the next queued row set;
+// update().set().where() is a thenable so a bookkeeping write awaits cleanly.
+// Mirrors the pattern in invoiceCheckout.test.ts.
+const { dbResults, updateSetMock } = vi.hoisted(() => ({
+  dbResults: [] as unknown[][],
+  updateSetMock: vi.fn(),
+}));
+vi.mock('../db', () => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {};
+    for (const m of ['select', 'from', 'where', 'limit']) chain[m] = vi.fn(() => chain);
+    (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
+      const rows = dbResults.shift() ?? [];
+      return Promise.resolve(rows).then(resolve);
+    };
+    (chain as { update: unknown }).update = vi.fn(() => ({
+      set: (v: unknown) => { updateSetMock(v); return { where: () => Promise.resolve(undefined) }; },
+    }));
+    return chain;
+  };
+  return { db: makeChain() };
+});
+
+const { sendEmailMock, getEmailServiceMock } = vi.hoisted(() => ({
+  sendEmailMock: vi.fn(),
+  getEmailServiceMock: vi.fn(),
+}));
+vi.mock('./email', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./email')>();
+  return { ...actual, getEmailService: getEmailServiceMock };
+});
+
+vi.mock('./invoiceEvents', () => ({ emitInvoiceEvent: vi.fn() }));
+vi.mock('./portalUrl', () => ({ portalBase: () => 'https://portal.example.test/portal' }));
+
+import { resendInvoiceEmail } from './invoicePdf';
+import { InvoiceServiceError } from './invoiceTypes';
+
+const INV_ID = '11111111-1111-1111-1111-111111111111';
+const ORG_ID = '22222222-2222-2222-2222-222222222222';
+const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: null };
+
+function invoice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: INV_ID,
+    orgId: ORG_ID,
+    partnerId: 'p1',
+    invoiceNumber: 'INV-2026-0007',
+    status: 'sent',
+    currencyCode: 'USD',
+    dueDate: '2026-09-01',
+    total: '158.50',
+    depositDue: null,
+    amountPaid: '0.00',
+    balance: '158.50',
+    sentAt: new Date('2026-08-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+const PDF_ROW = [{ pdf: Buffer.from('%PDF-1.4 fake') }];
+const ORG_ROW = [{ billingContact: { email: 'ap@acme.test' }, name: 'Acme Corp' }];
+const PARTNER_ROW = [{ name: 'Lantern MSP', billingEmail: 'billing@lantern.test', emailSignature: '— Todd\nLantern MSP' }];
+
+/** Queue the reads deliverInvoiceEmail makes, in order. */
+function queueHappyPath(inv = invoice(), { withPdf = true } = {}) {
+  dbResults.push([inv]);
+  if (withPdf) dbResults.push(PDF_ROW);
+  dbResults.push(ORG_ROW);
+  dbResults.push(PARTNER_ROW);
+}
+
+describe('resendInvoiceEmail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbResults.length = 0;
+    updateSetMock.mockReset();
+    sendEmailMock.mockReset().mockResolvedValue(undefined);
+    getEmailServiceMock.mockReturnValue({
+      sendEmail: sendEmailMock,
+      fromWithDisplayName: (name: string) => `${name} <no-reply@breeze.test>`,
+    });
+  });
+
+  it('emails the org billing contact and reports the recipients', async () => {
+    queueHappyPath();
+    const result = await resendInvoiceEmail(INV_ID, actor);
+    expect(result.emailed).toBe(true);
+    expect(result.recipients).toEqual(['ap@acme.test']);
+    const envelope = sendEmailMock.mock.calls[0][0];
+    expect(envelope.to).toEqual(['ap@acme.test']);
+    expect(envelope.replyTo).toBe('billing@lantern.test');
+    expect(envelope.from).toBe('Lantern MSP via Breeze <no-reply@breeze.test>');
+    expect(envelope.attachments?.[0]?.filename).toBe('INV-2026-0007.pdf');
+  });
+
+  // The whole point of a re-send: it is the same document, not a new one. A
+  // re-stamped sent_at would rewrite when the customer was first billed, and a
+  // second invoice.sent would double-fire anything wired to that bus later.
+  it('writes nothing — sent_at stays pinned and no lifecycle event is re-emitted', async () => {
+    queueHappyPath();
+    const { emitInvoiceEvent } = await import('./invoiceEvents');
+    const result = await resendInvoiceEmail(INV_ID, actor);
+    expect(updateSetMock).not.toHaveBeenCalled();
+    expect(emitInvoiceEvent).not.toHaveBeenCalled();
+    expect(result.invoice.sentAt).toEqual(new Date('2026-08-01T00:00:00Z'));
+  });
+
+  it('composer recipients override the billing contact, normalized and deduped', async () => {
+    queueHappyPath();
+    const result = await resendInvoiceEmail(INV_ID, actor, {
+      to: ['  AP@Acme.test ', 'ap@acme.test', 'cfo@acme.test'],
+      cc: ['Books@acme.test'],
+    });
+    expect(result.recipients).toEqual(['ap@acme.test', 'cfo@acme.test']);
+    const envelope = sendEmailMock.mock.calls[0][0];
+    expect(envelope.to).toEqual(['ap@acme.test', 'cfo@acme.test']);
+    expect(envelope.cc).toEqual(['books@acme.test']);
+  });
+
+  it('carries the composer subject and note onto the message', async () => {
+    queueHappyPath();
+    await resendInvoiceEmail(INV_ID, actor, { subject: 'Copy of invoice 0007', message: 'As requested on the call.' });
+    const envelope = sendEmailMock.mock.calls[0][0];
+    expect(envelope.subject).toBe('Copy of invoice 0007');
+    expect(envelope.html).toContain('As requested on the call.');
+    expect(envelope.text).toContain('As requested on the call.');
+  });
+
+  // includePdf:false must skip the render/fetch entirely — and the email body
+  // must stop promising an attachment that isn't there.
+  it('includePdf:false sends no attachment and drops the "PDF is attached" copy', async () => {
+    queueHappyPath(invoice(), { withPdf: false });
+    await resendInvoiceEmail(INV_ID, actor, { includePdf: false });
+    const envelope = sendEmailMock.mock.calls[0][0];
+    expect(envelope.attachments).toBeUndefined();
+    expect(envelope.text).not.toContain('A PDF copy is attached');
+  });
+
+  it('reports no_email_service instead of pretending it sent', async () => {
+    getEmailServiceMock.mockReturnValue(null);
+    queueHappyPath();
+    const result = await resendInvoiceEmail(INV_ID, actor);
+    expect(result).toMatchObject({ emailed: false, reason: 'no_email_service', recipients: [] });
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('reports no_billing_contact when nothing resolves a recipient', async () => {
+    dbResults.push([invoice()], PDF_ROW, [{ billingContact: null, name: 'Acme Corp' }], PARTNER_ROW);
+    const result = await resendInvoiceEmail(INV_ID, actor);
+    expect(result).toMatchObject({ emailed: false, reason: 'no_billing_contact' });
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  // The invoice is already issued, so a transport failure has nothing to roll
+  // back — a 500 here would read as "could not re-send" for a message that may
+  // well have gone out. Report it instead.
+  it('swallows a transport failure into reason:send_failed rather than throwing', async () => {
+    sendEmailMock.mockRejectedValue(new Error('smtp 421'));
+    queueHappyPath();
+    const result = await resendInvoiceEmail(INV_ID, actor);
+    expect(result).toMatchObject({ emailed: false, reason: 'send_failed' });
+    expect(result.recipients).toEqual(['ap@acme.test']);
+  });
+
+  it('refuses a draft — there is nothing issued to re-send', async () => {
+    dbResults.push([invoice({ status: 'draft', invoiceNumber: null, sentAt: null })]);
+    await expect(resendInvoiceEmail(INV_ID, actor)).rejects.toMatchObject({ status: 409, code: 'INVALID_STATE' });
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a void invoice — never re-mail a demand we cancelled', async () => {
+    dbResults.push([invoice({ status: 'void' })]);
+    await expect(resendInvoiceEmail(INV_ID, actor)).rejects.toMatchObject({ status: 409, code: 'INVALID_STATE' });
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  // "Send me a copy for our records" is the most common reason a customer asks,
+  // and unlike a quote's accept link this email dispenses no credential.
+  it('allows a PAID invoice to be re-sent', async () => {
+    queueHappyPath(invoice({ status: 'paid', amountPaid: '158.50', balance: '0.00' }));
+    const result = await resendInvoiceEmail(INV_ID, actor);
+    expect(result.emailed).toBe(true);
+  });
+
+  it('404s a missing invoice', async () => {
+    dbResults.push([]);
+    await expect(resendInvoiceEmail(INV_ID, actor)).rejects.toBeInstanceOf(InvoiceServiceError);
+  });
+
+  it('404s (never 403s) an invoice outside the actor org scope', async () => {
+    dbResults.push([invoice()]);
+    const scoped = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['33333333-3333-3333-3333-333333333333'] };
+    await expect(resendInvoiceEmail(INV_ID, scoped)).rejects.toMatchObject({ status: 404, code: 'INVOICE_NOT_FOUND' });
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/invoiceResend.test.ts
+++ b/apps/api/src/services/invoiceResend.test.ts
@@ -89,7 +89,7 @@ describe('resendInvoiceEmail', () => {
     const result = await resendInvoiceEmail(INV_ID, actor);
     expect(result.emailed).toBe(true);
     expect(result.recipients).toEqual(['ap@acme.test']);
-    const envelope = sendEmailMock.mock.calls[0][0];
+    const envelope = sendEmailMock.mock.calls[0]![0];
     expect(envelope.to).toEqual(['ap@acme.test']);
     expect(envelope.replyTo).toBe('billing@lantern.test');
     expect(envelope.from).toBe('Lantern MSP via Breeze <no-reply@breeze.test>');
@@ -115,7 +115,7 @@ describe('resendInvoiceEmail', () => {
       cc: ['Books@acme.test'],
     });
     expect(result.recipients).toEqual(['ap@acme.test', 'cfo@acme.test']);
-    const envelope = sendEmailMock.mock.calls[0][0];
+    const envelope = sendEmailMock.mock.calls[0]![0];
     expect(envelope.to).toEqual(['ap@acme.test', 'cfo@acme.test']);
     expect(envelope.cc).toEqual(['books@acme.test']);
   });
@@ -123,7 +123,7 @@ describe('resendInvoiceEmail', () => {
   it('carries the composer subject and note onto the message', async () => {
     queueHappyPath();
     await resendInvoiceEmail(INV_ID, actor, { subject: 'Copy of invoice 0007', message: 'As requested on the call.' });
-    const envelope = sendEmailMock.mock.calls[0][0];
+    const envelope = sendEmailMock.mock.calls[0]![0];
     expect(envelope.subject).toBe('Copy of invoice 0007');
     expect(envelope.html).toContain('As requested on the call.');
     expect(envelope.text).toContain('As requested on the call.');
@@ -134,7 +134,7 @@ describe('resendInvoiceEmail', () => {
   it('includePdf:false sends no attachment and drops the "PDF is attached" copy', async () => {
     queueHappyPath(invoice(), { withPdf: false });
     await resendInvoiceEmail(INV_ID, actor, { includePdf: false });
-    const envelope = sendEmailMock.mock.calls[0][0];
+    const envelope = sendEmailMock.mock.calls[0]![0];
     expect(envelope.attachments).toBeUndefined();
     expect(envelope.text).not.toContain('A PDF copy is attached');
   });

--- a/apps/web/src/components/billing/InvoiceActions.resend.test.tsx
+++ b/apps/web/src/components/billing/InvoiceActions.resend.test.tsx
@@ -1,0 +1,300 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoiceActions from './InvoiceActions';
+import type { InvoiceDetail } from './invoiceTypes';
+import { fetchWithAuth } from '../../stores/auth';
+
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [{ resource: '*', action: '*' }] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+// Partner scope so the composer's signature-preview fetch is attempted at all.
+vi.mock('../../lib/authScope', () => ({ getJwtClaims: () => ({ scope: 'partner' }) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const line: InvoiceDetail['lines'][number] = {
+  id: 'line-1', invoiceId: 'inv-1', sourceType: 'manual', parentLineId: null, catalogItemId: null,
+  name: null, description: 'Consulting', quantity: '2.00', unitPrice: '50.00', costBasis: null, revenueAllocation: null,
+  taxable: false, customerVisible: true, lineTotal: '100.00', isUnapprovedTime: false, sortOrder: 1,
+};
+
+/** An issued, already-emailed invoice — the state Re-send exists for. */
+function detail(extra: Partial<InvoiceDetail['invoice']> = {}, top: Partial<InvoiceDetail> = {}): InvoiceDetail {
+  return {
+    invoice: {
+      id: 'inv-1', invoiceNumber: 'INV-0007', orgId: 'org-1', siteId: null, status: 'sent',
+      currencyCode: 'USD', issueDate: '2026-06-01', dueDate: '2026-06-30',
+      sentAt: '2026-06-01T10:00:00Z', subtotal: '100.00', taxRate: null,
+      taxTotal: '0.00', total: '100.00', amountPaid: '0.00', balance: '100.00', billToName: 'Acme',
+      notes: '', termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z',
+      ...extra,
+    },
+    lines: [line],
+    ...top,
+  };
+}
+
+/** Default network: org lookup prefills a billing contact, partner has a
+ *  signature, and the re-send reports a delivered email. */
+function defaultFetch(overrides: Record<string, unknown> = {}) {
+  fetchMock.mockImplementation(async (input: string) => {
+    if (input.startsWith('/orgs/organizations/')) return json({ billingContact: { email: 'ap@acme.test' } });
+    if (input === '/orgs/partners/me') return json({ emailSignature: '— Todd' });
+    if (input.endsWith('/resend')) return json({ data: { emailed: true, recipients: ['ap@acme.test'] }, ...overrides });
+    if (input.endsWith('/pay-link')) return json({ data: { url: 'https://checkout.stripe.test/c/abc' } });
+    return json({ data: {} });
+  });
+}
+
+const clipboard = { writeText: vi.fn() };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [{ resource: '*', action: '*' }];
+  clipboard.writeText.mockReset().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', { value: clipboard, configurable: true, writable: true });
+  defaultFetch();
+});
+
+/** Open the composer and wait for the billing-contact prefill to land. */
+async function openComposer() {
+  fireEvent.click(screen.getByTestId('invoice-resend'));
+  const to = await screen.findByTestId('invoice-send-to');
+  await waitFor(() => expect(to).toHaveValue('ap@acme.test'));
+  return to;
+}
+
+describe('InvoiceActions — re-send', () => {
+  it('offers Re-send on an issued invoice and hides it on a draft', () => {
+    const { unmount } = render(<InvoiceActions detail={detail()} variant="rail" />);
+    expect(screen.getByTestId('invoice-resend')).toHaveTextContent('Re-send');
+    unmount();
+    render(<InvoiceActions detail={detail({ status: 'draft', invoiceNumber: null, sentAt: null })} variant="rail" />);
+    expect(screen.queryByTestId('invoice-resend')).not.toBeInTheDocument();
+  });
+
+  // Never re-mail a demand we already cancelled.
+  it('hides Re-send on a void invoice', () => {
+    render(<InvoiceActions detail={detail({ status: 'void' })} variant="rail" />);
+    expect(screen.queryByTestId('invoice-resend')).not.toBeInTheDocument();
+  });
+
+  // "Send me a copy for our records" is the commonest reason a customer asks,
+  // and unlike a quote's accept link this email dispenses no credential.
+  it('still offers Re-send on a PAID invoice', () => {
+    render(<InvoiceActions detail={detail({ status: 'paid', amountPaid: '100.00', balance: '0.00' })} variant="rail" />);
+    expect(screen.getByTestId('invoice-resend')).toBeInTheDocument();
+  });
+
+  it('requires invoices:send', () => {
+    state.permissions = [{ resource: 'invoices', action: 'read' }, { resource: 'invoices', action: 'export' }];
+    render(<InvoiceActions detail={detail()} variant="rail" />);
+    expect(screen.queryByTestId('invoice-resend')).not.toBeInTheDocument();
+  });
+
+  it('prefills To from the org billing contact and previews the partner signature', async () => {
+    render(<InvoiceActions detail={detail()} variant="header" />);
+    await openComposer();
+    expect(await screen.findByTestId('invoice-send-signature-preview')).toHaveTextContent('— Todd');
+  });
+
+  it('POSTs the composed envelope to /resend', async () => {
+    render(<InvoiceActions detail={detail()} variant="header" />);
+    await openComposer();
+    fireEvent.click(screen.getByTestId('invoice-send-cc-toggle'));
+    fireEvent.change(screen.getByTestId('invoice-send-cc'), { target: { value: 'books@acme.test' } });
+    fireEvent.change(screen.getByTestId('invoice-send-subject'), { target: { value: 'Copy of INV-0007' } });
+    fireEvent.change(screen.getByTestId('invoice-send-message'), { target: { value: 'As discussed.' } });
+    fireEvent.click(screen.getByTestId('invoice-send-include-pdf')); // uncheck
+    fireEvent.click(screen.getByTestId('invoice-send-confirm'));
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find((c) => c[0] === '/invoices/inv-1/resend');
+      expect(call).toBeTruthy();
+      expect(JSON.parse(String((call![1] as RequestInit).body))).toEqual({
+        to: ['ap@acme.test'], cc: ['books@acme.test'], subject: 'Copy of INV-0007',
+        message: 'As discussed.', includePdf: false,
+      });
+    });
+  });
+
+  // Omitting untouched fields is what lets the server apply its own defaults
+  // (standard subject, PDF attached) rather than being handed empty strings.
+  it('omits every field the sender left alone', async () => {
+    render(<InvoiceActions detail={detail()} variant="header" />);
+    await openComposer();
+    fireEvent.click(screen.getByTestId('invoice-send-confirm'));
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find((c) => c[0] === '/invoices/inv-1/resend');
+      expect(JSON.parse(String((call![1] as RequestInit).body))).toEqual({ to: ['ap@acme.test'] });
+    });
+  });
+
+  it('refuses an invalid address and names it, without sending', async () => {
+    render(<InvoiceActions detail={detail()} variant="header" />);
+    const to = await openComposer();
+    fireEvent.change(to, { target: { value: 'not-an-email' } });
+    expect(await screen.findByTestId('invoice-send-to-error')).toHaveTextContent('not-an-email');
+    fireEvent.click(screen.getByTestId('invoice-send-confirm'));
+    await waitFor(() => expect(fetchMock.mock.calls.some((c) => c[0] === '/invoices/inv-1/resend')).toBe(false));
+  });
+
+  it('an empty To explains itself rather than sitting dead', async () => {
+    render(<InvoiceActions detail={detail()} variant="header" />);
+    const to = await openComposer();
+    fireEvent.change(to, { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('invoice-send-confirm'));
+    expect(await screen.findByTestId('invoice-send-to-missing')).toBeInTheDocument();
+    expect(fetchMock.mock.calls.some((c) => c[0] === '/invoices/inv-1/resend')).toBe(false);
+  });
+
+  it('explains an empty To when the org genuinely has no billing contact', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations/')) return json({ billingContact: null });
+      if (input === '/orgs/partners/me') return json({ emailSignature: null });
+      return json({ data: {} });
+    });
+    render(<InvoiceActions detail={detail()} variant="header" />);
+    fireEvent.click(screen.getByTestId('invoice-resend'));
+    expect(await screen.findByTestId('invoice-send-to-no-contact')).toBeInTheDocument();
+  });
+
+  // A failed org lookup is UNKNOWN, not absent — claiming "no billing contact"
+  // there would be false.
+  it('stays silent about the billing contact when the lookup itself failed', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations/')) return json({}, false, 500);
+      return json({ data: {} });
+    });
+    render(<InvoiceActions detail={detail()} variant="header" />);
+    fireEvent.click(screen.getByTestId('invoice-resend'));
+    await screen.findByTestId('invoice-send-to');
+    expect(screen.queryByTestId('invoice-send-to-no-contact')).not.toBeInTheDocument();
+  });
+
+  it('toasts success and closes the composer when an email actually went out', async () => {
+    render(<InvoiceActions detail={detail()} variant="header" />);
+    await openComposer();
+    fireEvent.click(screen.getByTestId('invoice-send-confirm'));
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith({ type: 'success', message: 'Invoice re-sent' }));
+    expect(screen.queryByTestId('invoice-send-to')).not.toBeInTheDocument();
+  });
+
+  // The server swallows delivery failures, so a 200 does not mean delivered.
+  it('warns instead of claiming success when emailed is false', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations/')) return json({ billingContact: { email: 'ap@acme.test' } });
+      if (input.endsWith('/resend')) return json({ data: { emailed: false, reason: 'no_email_service' } });
+      return json({ data: {} });
+    });
+    render(<InvoiceActions detail={detail()} variant="header" />);
+    await openComposer();
+    fireEvent.click(screen.getByTestId('invoice-send-confirm'));
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith({ type: 'warning', message: expect.stringContaining('No email was sent') }));
+  });
+
+  // An unexpected response shape must not read as success.
+  it('warns when the response carries no emailed flag at all', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations/')) return json({ billingContact: { email: 'ap@acme.test' } });
+      if (input.endsWith('/resend')) return json({ data: {} });
+      return json({ data: {} });
+    });
+    render(<InvoiceActions detail={detail()} variant="header" />);
+    await openComposer();
+    fireEvent.click(screen.getByTestId('invoice-send-confirm'));
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith({ type: 'warning', message: expect.any(String) }));
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  // The typed recipients and note must survive a failure so the retry is one click.
+  it('leaves the composer open when the request fails', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/orgs/organizations/')) return json({ billingContact: { email: 'ap@acme.test' } });
+      if (input.endsWith('/resend')) return json({ error: 'boom' }, false, 500);
+      return json({ data: {} });
+    });
+    render(<InvoiceActions detail={detail()} variant="header" />);
+    await openComposer();
+    fireEvent.change(screen.getByTestId('invoice-send-message'), { target: { value: 'keep me' } });
+    fireEvent.click(screen.getByTestId('invoice-send-confirm'));
+    await waitFor(() => expect(fetchMock.mock.calls.some((c) => c[0] === '/invoices/inv-1/resend')).toBe(true));
+    expect(screen.getByTestId('invoice-send-message')).toHaveValue('keep me');
+  });
+
+  // A first email after a bare Issue is a genuine SEND: /send stamps sent_at.
+  it('an issued-but-never-emailed invoice sends via /send, not /resend', async () => {
+    render(<InvoiceActions detail={detail({ sentAt: null })} variant="header" />);
+    expect(screen.getByTestId('invoice-resend')).toHaveTextContent('Send invoice');
+    await openComposer();
+    fireEvent.click(screen.getByTestId('invoice-send-confirm'));
+    await waitFor(() => expect(fetchMock.mock.calls.some((c) => c[0] === '/invoices/inv-1/send')).toBe(true));
+    expect(fetchMock.mock.calls.some((c) => c[0] === '/invoices/inv-1/resend')).toBe(false);
+  });
+
+  it('reads "Request payment" once the customer has part-paid', () => {
+    render(<InvoiceActions detail={detail({ status: 'partially_paid', amountPaid: '40.00', balance: '60.00' })} variant="rail" />);
+    expect(screen.getByTestId('invoice-resend')).toHaveTextContent('Request payment');
+  });
+});
+
+describe('InvoiceActions — copy payment link', () => {
+  it('copies the Stripe checkout URL to the clipboard', async () => {
+    render(<InvoiceActions detail={detail({}, { stripeConnected: true })} variant="header" />);
+    fireEvent.click(screen.getByTestId('invoice-pay-link'));
+    await waitFor(() => expect(clipboard.writeText).toHaveBeenCalledWith('https://checkout.stripe.test/c/abc'));
+    expect(showToast).toHaveBeenCalledWith({ type: 'success', message: 'Payment link copied to clipboard' });
+  });
+
+  // A blocked clipboard must still surface the URL — a silent no-op reads as a
+  // dead button.
+  it('surfaces the URL when the clipboard is denied', async () => {
+    clipboard.writeText.mockRejectedValue(new Error('denied'));
+    render(<InvoiceActions detail={detail({}, { stripeConnected: true })} variant="header" />);
+    fireEvent.click(screen.getByTestId('invoice-pay-link'));
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'warning', message: expect.stringContaining('https://checkout.stripe.test/c/abc'),
+    })));
+  });
+
+  // A 200 with no link is a server surprise, not something to paste.
+  it('errors rather than copying "undefined" when no url comes back', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.endsWith('/pay-link')) return json({ data: {} });
+      return json({ data: {} });
+    });
+    render(<InvoiceActions detail={detail({}, { stripeConnected: true })} variant="header" />);
+    fireEvent.click(screen.getByTestId('invoice-pay-link'));
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith({ type: 'error', message: expect.any(String) }));
+    expect(clipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it('is hidden when Stripe is not connected', () => {
+    render(<InvoiceActions detail={detail({}, { stripeConnected: false })} variant="header" />);
+    expect(screen.queryByTestId('invoice-pay-link')).not.toBeInTheDocument();
+  });
+
+  // Nothing to pay → no payment link, even with Stripe connected.
+  it('is hidden once the invoice is fully paid', () => {
+    render(<InvoiceActions detail={detail({ status: 'paid', amountPaid: '100.00', balance: '0.00' }, { stripeConnected: true })} variant="header" />);
+    expect(screen.queryByTestId('invoice-pay-link')).not.toBeInTheDocument();
+  });
+
+  it('is hidden on a draft', () => {
+    render(<InvoiceActions detail={detail({ status: 'draft', invoiceNumber: null, sentAt: null }, { stripeConnected: true })} variant="header" />);
+    expect(screen.queryByTestId('invoice-pay-link')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/InvoiceActions.tsx
+++ b/apps/web/src/components/billing/InvoiceActions.tsx
@@ -9,6 +9,7 @@ import { usePermissions } from '../../lib/permissions';
 import { showToast } from '../shared/Toast';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { usePdfDownload } from './shared/usePdfDownload';
+import InvoiceSendComposer, { type ComposedInvoiceEmail } from './InvoiceSendComposer';
 import { type InvoiceDetail as InvoiceDetailData, formatMoney } from './invoiceTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -92,6 +93,12 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
   // about the order in which two effects happen to observe two independently
   // updated props.
   const [queued, setQueued] = useState<QueuedIssue | null>(null);
+  // Re-send composer. Distinct from `issuing`: a re-send touches no invoice
+  // state, so it never queues behind the editor and never confirms — the
+  // composer IS the confirmation.
+  const [resendOpen, setResendOpen] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [copyingLink, setCopyingLink] = useState(false);
   const refresh = useCallback(() => onChanged?.(), [onChanged]);
 
   const isDraft = invoice.status === 'draft';
@@ -202,6 +209,115 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
     return () => clearTimeout(timer);
   }, [queued, t]);
 
+  // Whether this invoice has ever been emailed. `issueInvoice` deliberately
+  // leaves sent_at null (a plain Issue reads "Issued", not "Sent"), so the first
+  // email after a bare Issue is a genuine SEND — /send stamps sent_at and emits
+  // the invoice.sent lifecycle event. Every email after that is a RE-send, and
+  // /resend deliberately writes nothing: sent_at, the number and the issue-time
+  // snapshots stay pinned so our record and the customer's copy keep describing
+  // the same document.
+  const neverEmailed = invoice.sentAt == null;
+  // A part-paid invoice reads as "Request payment", not "Re-send" — the tech is
+  // chasing a balance, not resupplying a copy. Label only; the endpoint is
+  // decided by neverEmailed above.
+  const partiallyPaid = Number(invoice.amountPaid) > 0 && Number(invoice.balance) > 0;
+  const resendLabel = partiallyPaid
+    ? t('invoiceDetail.requestPayment.requestPayment')
+    : neverEmailed
+      ? t('invoiceDetail.requestPayment.sendInvoice')
+      : t('invoiceActions.resend');
+
+  // Shared by both composer intros. Spelled out per-key at the call sites (not
+  // via a computed key) so the key-usage scanner can still resolve them.
+  const composerIntroValues = {
+    customer: invoice.billToName ?? t('invoiceActions.issueSendConfirm.customerFallback'),
+    amount: formatMoney(invoice.total, currency),
+  };
+
+  const resend = useCallback(async (opts: ComposedInvoiceEmail) => {
+    if (resending) return;
+    setResending(true);
+    try {
+      // Suppress runAction's success toast: a 200 does NOT mean an email went
+      // out. Both routes swallow delivery failures into `reason`, so the
+      // outcome is post-processed below — `emailed !== true` (not `=== false`)
+      // so an unexpected response shape can't be read as success.
+      const result = await runAction<{ data?: { emailed?: boolean } }>({
+        request: () => fetchWithAuth(`/invoices/${invoice.id}/${neverEmailed ? 'send' : 'resend'}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(opts),
+        }),
+        errorFallback: t('invoiceDetail.requestPayment.sendError'),
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setResendOpen(false);
+      // A first send stamps sent_at (which flips this very button's label), and
+      // even a re-send may reveal other stale detail — reconcile either way.
+      refresh();
+      if (result?.data?.emailed !== true) {
+        showToast({ type: 'warning', message: t('invoiceDetail.requestPayment.noEmailWarning') });
+      } else {
+        showToast({
+          type: 'success',
+          message: partiallyPaid
+            ? t('invoiceDetail.requestPayment.paymentRequestSent')
+            : neverEmailed
+              ? t('invoiceDetail.requestPayment.invoiceSent')
+              : t('invoiceActions.resendSuccess'),
+        });
+      }
+    } catch (err) {
+      // Leave the composer open on a failure so the typed recipients and note
+      // survive for a retry.
+      handleActionError(err, t('invoiceDetail.requestPayment.sendError'));
+    } finally {
+      setResending(false);
+    }
+  }, [resending, invoice.id, neverEmailed, partiallyPaid, refresh, t]);
+
+  // Copy the customer-facing Stripe Checkout link without emailing anything —
+  // for pasting into a chat/SMS/reply by hand. Mirrors the quote's
+  // "Copy share link"; the POST mints a fresh Checkout session each time.
+  const copyPaymentLink = useCallback(async () => {
+    if (copyingLink) return;
+    setCopyingLink(true);
+    try {
+      const result = await runAction<{ data?: { url?: string } }>({
+        request: () => fetchWithAuth(`/invoices/${invoice.id}/pay-link`, { method: 'POST' }),
+        errorFallback: t('invoiceDetail.payments.linkError'),
+        friendly: (code) => (code === 'STRIPE_NOT_CONNECTED' ? t('invoiceDetail.payments.connectStripe') : undefined),
+        onUnauthorized: UNAUTHORIZED,
+      });
+      const url = result?.data?.url;
+      if (!url) {
+        // A 200 with no link is a server-side surprise, not something the user
+        // can paste — say so rather than silently writing "undefined".
+        showToast({ type: 'error', message: t('invoiceDetail.payments.noLinkReturned') });
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(url);
+      } catch {
+        // Clipboard denied (insecure origin / permissions policy). Surface the
+        // URL in a long-lived toast so it can be selected by hand — a silent
+        // no-op here reads as a dead button. (A window.prompt would block every
+        // subsequent interaction on the page.)
+        showToast({
+          type: 'warning',
+          message: t('invoiceActions.paymentLinkCopyFailed', { url }),
+          duration: 15000,
+        });
+        return;
+      }
+      showToast({ type: 'success', message: t('invoiceDetail.payments.linkCopied') });
+    } catch (err) {
+      handleActionError(err, t('invoiceDetail.payments.linkError'));
+    } finally {
+      setCopyingLink(false);
+    }
+  }, [copyingLink, invoice.id, t]);
+
   const remove = useCallback(async () => {
     if (deleting) return;
     setDeleting(true);
@@ -232,9 +348,25 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
   const canIssue = can('invoices', 'send') && isDraft;
   const canDownload = can('invoices', 'export');
   const canDelete = can('invoices', 'write') && isDraft;
+  // Re-send is the counterpart of Issue & Send on a live invoice: available
+  // once there is an issued document to re-mail, and refused on a void one
+  // (never re-mail a demand we already cancelled). Matches the server's own
+  // gate in resendInvoiceEmail — a PAID invoice IS re-sendable, because "send
+  // me a copy for our records" is the commonest reason a customer asks.
+  const canResend = can('invoices', 'send') && !isDraft && invoice.status !== 'void';
+  // The payment link is only meaningful while money is still owed, and only
+  // exists when the partner's Stripe is connected. Mirrors the gate the
+  // payments card uses for the record-payment form.
+  const canCopyPaymentLink =
+    can('invoices', 'send') &&
+    detail.stripeConnected === true &&
+    !isDraft &&
+    invoice.status !== 'void' &&
+    invoice.status !== 'paid' &&
+    Number(invoice.balance) > 0;
 
   // Nothing to show (e.g. a viewer on an issued invoice) — render no empty container.
-  if (!canIssue && !canDownload && !canDelete) return null;
+  if (!canIssue && !canDownload && !canDelete && !canResend && !canCopyPaymentLink) return null;
 
   const issueDisabled = issuing || !hasVisibleLines;
   // Why the money-buttons are held, if they are. 'saving' resolves on its own
@@ -319,6 +451,33 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
             </button>
           </>
         )}
+        {/* The email action on a live invoice — the slot Issue occupies on a
+            draft. Reads "Send invoice" before the first email, "Request payment"
+            once the customer has part-paid, and "Re-send" otherwise; it opens
+            the same style of composer the quote re-send uses, prefilled from the
+            org's billing contact. */}
+        {canResend && (
+          <button
+            type="button"
+            onClick={() => setResendOpen(true)}
+            disabled={resending}
+            data-testid="invoice-resend"
+            className={`${btnBase} border hover:bg-muted disabled:opacity-50`}
+          >
+            {resendLabel}
+          </button>
+        )}
+        {canCopyPaymentLink && (
+          <button
+            type="button"
+            onClick={() => void copyPaymentLink()}
+            disabled={copyingLink}
+            data-testid="invoice-pay-link"
+            className={`${btnBase} border hover:bg-muted disabled:opacity-50`}
+          >
+            {copyingLink ? t('invoiceActions.copyingPaymentLink') : t('invoiceActions.copyPaymentLink')}
+          </button>
+        )}
         {/* PDF download is gated on the dedicated invoices:export permission. */}
         {canDownload && (
           <button
@@ -372,6 +531,20 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
         )}
       </div>
 
+      <InvoiceSendComposer
+        open={resendOpen}
+        onClose={() => setResendOpen(false)}
+        sending={resending}
+        onSend={(opts) => void resend(opts)}
+        orgId={invoice.orgId}
+        invoiceNumber={invoice.invoiceNumber}
+        title={neverEmailed ? t('invoiceActions.sendConfirm.title') : t('invoiceActions.resendConfirm.title')}
+        intro={neverEmailed
+          ? t('invoiceActions.sendConfirm.message', composerIntroValues)
+          : t('invoiceActions.resendConfirm.message', composerIntroValues)}
+        confirmLabel={resendLabel}
+        sendingLabel={t('invoiceActions.resending')}
+      />
       <ConfirmDialog
         open={issueSendOpen}
         onClose={() => setIssueSendOpen(false)}

--- a/apps/web/src/components/billing/InvoiceDetail.deposit.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.deposit.test.tsx
@@ -80,17 +80,37 @@ describe('InvoiceDetail deposit + due-date + request payment', () => {
     });
   });
 
-  it('labels the re-send action "Request payment" once partially paid; POSTs /send', async () => {
+  // The email action lives in InvoiceActions (rendered in this rail) — these
+  // assert the label logic the invoice-vs-quote parity work folded in there.
+  it('labels the email action "Request payment" once partially paid; composes to /send', async () => {
     render(<InvoiceDetail detail={detail({ status: 'partially_paid', amountPaid: '300.00', balance: '700.00', depositDue: '300.00' })} onChanged={vi.fn()} />);
-    const btn = await screen.findByTestId('invoice-request-payment');
+    const btn = await screen.findByTestId('invoice-resend');
     expect(btn).toHaveTextContent('Request payment');
     fireEvent.click(btn);
+    // The composer is the confirm step: fill a recipient, then send. sentAt is
+    // null on this fixture, so the FIRST email still goes through /send (which
+    // stamps sent_at); only a later one is a /resend.
+    fireEvent.change(await screen.findByTestId('invoice-send-to'), { target: { value: 'ap@acme.test' } });
+    fireEvent.click(screen.getByTestId('invoice-send-confirm'));
     await waitFor(() => expect(fetchMock.mock.calls.some((c) => c[0] === '/invoices/inv-1/send')).toBe(true));
   });
 
-  it('labels the re-send action "Send invoice" when nothing is paid yet', async () => {
+  it('labels the email action "Send invoice" when nothing is paid yet', async () => {
     render(<InvoiceDetail detail={detail()} onChanged={vi.fn()} />);
-    const btn = await screen.findByTestId('invoice-request-payment');
+    const btn = await screen.findByTestId('invoice-resend');
     expect(btn).toHaveTextContent('Send invoice');
+  });
+
+  // Once the invoice HAS been emailed, the same control re-sends — and must hit
+  // /resend, which pins sent_at rather than restamping it.
+  it('reads "Re-send" and POSTs /resend once sent_at is stamped', async () => {
+    render(<InvoiceDetail detail={detail({ sentAt: '2026-06-02T00:00:00Z' })} onChanged={vi.fn()} />);
+    const btn = await screen.findByTestId('invoice-resend');
+    expect(btn).toHaveTextContent('Re-send');
+    fireEvent.click(btn);
+    fireEvent.change(await screen.findByTestId('invoice-send-to'), { target: { value: 'ap@acme.test' } });
+    fireEvent.click(screen.getByTestId('invoice-send-confirm'));
+    await waitFor(() => expect(fetchMock.mock.calls.some((c) => c[0] === '/invoices/inv-1/resend')).toBe(true));
+    expect(fetchMock.mock.calls.some((c) => c[0] === '/invoices/inv-1/send')).toBe(false);
   });
 });

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -151,13 +151,10 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
   const canEditDueDate =
     can('invoices', 'write') && ['sent', 'partially_paid', 'overdue'].includes(invoice.status);
 
-  // Re-sending an issued, part-paid invoice reads as "request payment" rather than
-  // "send" — same POST /send call. Gate on a live, still-owing invoice + invoices:send.
-  const partiallyPaid = Number(invoice.amountPaid) > 0 && Number(invoice.balance) > 0;
-  const canRequestPayment =
-    can('invoices', 'send') &&
-    invoice.status !== 'draft' && invoice.status !== 'void' && invoice.status !== 'paid' &&
-    Number(invoice.balance) > 0;
+  // The email action on a live invoice (Send invoice / Request payment /
+  // Re-send) moved into InvoiceActions when invoices gained the quote composer:
+  // it belongs beside Issue & Send, and only there is it reachable from the
+  // workspace header as well as this rail.
 
   const saveDueDate = useCallback(async () => {
     if (busy || !dueDateDraft) return;
@@ -179,30 +176,6 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
       setBusy(false);
     }
   }, [busy, dueDateDraft, invoice.id, refresh, t]);
-
-  const requestPayment = useCallback(async () => {
-    if (busy) return;
-    setBusy(true);
-    try {
-      // /send is honest about whether an email actually went out — only claim it
-      // was sent when the API confirms an email was dispatched.
-      const result = await runAction<{ data: { emailed: boolean } }>({
-        request: () => fetchWithAuth(`/invoices/${invoice.id}/send`, { method: 'POST' }),
-        errorFallback: t('invoiceDetail.requestPayment.sendError'),
-        onUnauthorized: UNAUTHORIZED,
-      });
-      if (result?.data?.emailed) {
-        showToast({ type: 'success', message: partiallyPaid ? t('invoiceDetail.requestPayment.paymentRequestSent') : t('invoiceDetail.requestPayment.invoiceSent') });
-      } else {
-        showToast({ type: 'warning', message: t('invoiceDetail.requestPayment.noEmailWarning') });
-      }
-      refresh();
-    } catch (err) {
-      handleActionError(err, t('invoiceDetail.requestPayment.sendError'));
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, invoice.id, partiallyPaid, refresh, t]);
 
   const recordPayment = useCallback(async () => {
     if (busy || !payAmount) return;
@@ -230,37 +203,6 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
       setBusy(false);
     }
   }, [busy, payAmount, payMethod, payRef, payDate, invoice.id, refresh, t]);
-
-  const sendPayLink = useCallback(async () => {
-    if (busy) return;
-    setBusy(true);
-    try {
-      const result = await runAction<{ data: { url: string } }>({
-        request: () => fetchWithAuth(`/invoices/${invoice.id}/pay-link`, { method: 'POST' }),
-        errorFallback: t('invoiceDetail.payments.linkError'),
-        friendly: (code) => (code === 'STRIPE_NOT_CONNECTED' ? t('invoiceDetail.payments.connectStripe') : undefined),
-        onUnauthorized: UNAUTHORIZED,
-      });
-      const url = result?.data?.url;
-      if (url) {
-        try {
-          await navigator.clipboard.writeText(url);
-          showToast({ type: 'success', message: t('invoiceDetail.payments.linkCopied') });
-        } catch {
-          // Clipboard blocked (insecure context / permissions) — surface the URL.
-          window.prompt(t('invoiceDetail.payments.shareLinkPrompt'), url);
-        }
-      } else {
-        // 200 without a URL shouldn't happen (the API throws STRIPE_NO_URL), but
-        // never leave a money action with no feedback.
-        showToast({ type: 'error', message: t('invoiceDetail.payments.noLinkReturned') });
-      }
-    } catch (err) {
-      handleActionError(err, t('invoiceDetail.payments.linkError'));
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, invoice.id, t]);
 
   const voidPayment = useCallback(async (paymentId: string) => {
     if (busy) return;
@@ -519,23 +461,13 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
             </div>
           )}
 
-          {/* Primary actions (Issue / PDF / Delete) + void. The rail copy of
-              InvoiceActions is suppressed when the workspace header owns the
-              actions; Void stays here — its written-reason dialog belongs with
-              the issued-lifecycle rail, not the header. */}
+          {/* Primary actions (Issue / Send / Copy payment link / PDF / Delete)
+              + void. The rail copy of InvoiceActions is suppressed when the
+              workspace header owns the actions; Void stays here — its
+              written-reason dialog belongs with the issued-lifecycle rail, not
+              the header. */}
           <div className="space-y-2">
             {!actionsInHeader && <InvoiceActions detail={detail} onChanged={onChanged} variant="rail" />}
-            {/* Re-send the issued invoice. Reads as "Request payment" once the
-                customer has partially paid (same POST /send call). */}
-            {canRequestPayment && (
-              <button
-                type="button" onClick={() => void requestPayment()} disabled={busy}
-                data-testid="invoice-request-payment"
-                className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-              >
-                {partiallyPaid ? t('invoiceDetail.requestPayment.requestPayment') : t('invoiceDetail.requestPayment.sendInvoice')}
-              </button>
-            )}
             {canVoid && can('invoices', 'send') && (
               <button
                 type="button" onClick={() => { setVoidReason(''); setVoidReissue(false); setVoidOpen(true); }}
@@ -597,15 +529,6 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
               </p>
             )}
 
-            {canRecordPayment && stripeConnected && can('invoices', 'send') && (
-              <button
-                type="button" onClick={() => void sendPayLink()} disabled={busy}
-                data-testid="invoice-pay-link"
-                className="mt-3 inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
-              >
-                {t('invoiceDetail.payments.sendLink')}
-              </button>
-            )}
             {canRecordPayment && !stripeConnected && (
               <p className="mt-3 text-xs text-muted-foreground" data-testid="invoice-stripe-nudge">
                 {t('invoiceDetail.payments.stripeNudge')}{' '}

--- a/apps/web/src/components/billing/InvoiceSendComposer.tsx
+++ b/apps/web/src/components/billing/InvoiceSendComposer.tsx
@@ -1,0 +1,312 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import '../../lib/i18n';
+import { fetchWithAuth } from '../../stores/auth';
+import { getJwtClaims } from '../../lib/authScope';
+import { Dialog } from '../shared/Dialog';
+import { parseAddressList, MAX_RECIPIENTS } from './shared/addressList';
+
+/** The composed envelope, shaped for `POST /invoices/:id/{send,resend}`. Only
+ *  non-default fields are populated, so the server's own defaults (billing
+ *  contact, standard subject, PDF attached) stay in play for anything the
+ *  sender left alone. */
+export interface ComposedInvoiceEmail {
+  to: string[];
+  cc?: string[];
+  subject?: string;
+  message?: string;
+  includePdf?: boolean;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** True while the parent's request is in flight — disables every field. */
+  sending: boolean;
+  /** Fired with the composed envelope once To validates. The parent owns the
+   *  request and closes the dialog on success. */
+  onSend: (opts: ComposedInvoiceEmail) => void;
+  /** Drives the billing-contact prefill and the "fix it here" deep link. */
+  orgId: string;
+  invoiceNumber: string | null;
+  title: string;
+  /** One-line summary above the envelope fields (who / how much). */
+  intro: string;
+  confirmLabel: string;
+  /** Label while `sending` — e.g. "Re-sending…". */
+  sendingLabel: string;
+}
+
+/**
+ * The invoice customer-email composer — a lightweight mail-client dialog for
+ * the re-send action, mirroring the quote composer (QuoteActions.tsx) field for
+ * field so a tech who has sent a proposal already knows this dialog.
+ *
+ * To is prefilled from the org's billing contact (best-effort; the dialog never
+ * submits an empty To), Subject left blank means the server default, and the
+ * partner's signature is previewed here but appended server-side.
+ *
+ * Deliberately NOT shared with QuoteActions' inline composer: that one carries
+ * quote-only concerns (zero-total warning, missing-cost notice, deposit/Stripe
+ * warnings, the schedule-vs-resend fork) which have no invoice meaning, and
+ * unifying them would mean threading half a dozen quote-shaped slots through
+ * this component. The two share what actually must not drift — the address
+ * grammar and recipient cap (shared/addressList.ts) and the server schema.
+ */
+export default function InvoiceSendComposer({
+  open, onClose, sending, onSend, orgId, invoiceNumber, title, intro, confirmLabel, sendingLabel,
+}: Props) {
+  const { t } = useTranslation('billing');
+  const [to, setTo] = useState('');
+  const [cc, setCc] = useState('');
+  const [ccOpen, setCcOpen] = useState(false);
+  const [subject, setSubject] = useState('');
+  const [message, setMessage] = useState('');
+  const [includePdf, setIncludePdf] = useState(true);
+  const [signature, setSignature] = useState<string | null>(null);
+  // Set when a Send click finds no valid recipient — an inline reason under the
+  // To field beats a silently dead button.
+  const [toMissing, setToMissing] = useState(false);
+  // Set when the org lookup CONFIRMED there is no billing contact to prefill
+  // from. A failed lookup stays silent: unknown is not absent, and claiming "no
+  // billing contact" on a fetch error would be false.
+  const [toPrefillMissing, setToPrefillMissing] = useState(false);
+  const toInputRef = useRef<HTMLInputElement>(null);
+
+  // Reset + prefill on every open, so a previous send can never leak into the
+  // next one. Both fetches are best-effort: the dialog stays usable when either
+  // fails (the user types the recipient — Send blocks on a valid To).
+  useEffect(() => {
+    if (!open) return;
+    setTo(''); setCc(''); setCcOpen(false); setSubject(''); setMessage('');
+    setIncludePdf(true); setSignature(null); setToMissing(false); setToPrefillMissing(false);
+    let canceled = false;
+    void (async () => {
+      try {
+        const res = await fetchWithAuth(`/orgs/organizations/${orgId}`);
+        if (!res.ok || canceled) return;
+        const org = (await res.json()) as { billingContact?: { email?: string | null } | null };
+        const email = org.billingContact?.email?.trim();
+        // Functional update so a slow response never clobbers a typed address.
+        if (email) setTo((cur) => cur || email);
+        else setToPrefillMissing(true);
+      } catch { /* leave To empty — the user types the recipient */ }
+    })();
+    // The signature endpoint gates on permission + a non-null partnerId, but an
+    // org-scoped session has no partner context worth previewing — skip the
+    // round-trip rather than fire an irrelevant GET (mirrors QuoteActions).
+    if (getJwtClaims().scope === 'partner') {
+      void (async () => {
+        try {
+          const res = await fetchWithAuth('/orgs/partners/me');
+          if (!res.ok || canceled) return;
+          const partner = (await res.json()) as { emailSignature?: string | null };
+          setSignature(partner.emailSignature?.trim() || null);
+        } catch { /* no preview — the server still appends the signature */ }
+      })();
+    }
+    return () => { canceled = true; };
+  }, [open, orgId]);
+
+  const toParsed = useMemo(() => parseAddressList(to), [to]);
+  const ccParsed = useMemo(() => parseAddressList(cc), [cc]);
+  const toError =
+    toParsed.invalid.length > 0
+      ? t('invoiceActions.composer.invalidEmail', { addresses: toParsed.invalid.join(', ') })
+      : toParsed.emails.length > MAX_RECIPIENTS
+        ? t('invoiceActions.composer.tooManyRecipients', { max: MAX_RECIPIENTS })
+        : null;
+  const ccError =
+    ccParsed.invalid.length > 0
+      ? t('invoiceActions.composer.invalidEmail', { addresses: ccParsed.invalid.join(', ') })
+      : ccParsed.emails.length > MAX_RECIPIENTS
+        ? t('invoiceActions.composer.tooManyRecipients', { max: MAX_RECIPIENTS })
+        : null;
+  const valid = toParsed.emails.length > 0 && !toError && !ccError;
+
+  const submit = useCallback(() => {
+    if (sending) return;
+    // The prerequisite IS the click's job: no valid recipient → focus the To
+    // field and say why, rather than sitting disabled with no explanation.
+    if (!valid) {
+      setToMissing(toParsed.emails.length === 0 && !toError);
+      toInputRef.current?.focus();
+      return;
+    }
+    setToMissing(false);
+    // The To list always goes (the user saw and confirmed it); the rest is
+    // omitted where it would just restate the server default.
+    const opts: ComposedInvoiceEmail = { to: toParsed.emails };
+    if (ccParsed.emails.length > 0) opts.cc = ccParsed.emails;
+    const subj = subject.trim();
+    if (subj) opts.subject = subj;
+    const note = message.trim();
+    if (note) opts.message = note;
+    if (!includePdf) opts.includePdf = false;
+    onSend(opts);
+  }, [sending, valid, toParsed, toError, ccParsed, subject, message, includePdf, onSend]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => { if (!sending) onClose(); }}
+      title={title}
+      labelledBy="invoice-send-dialog-title"
+      maxWidth="xl"
+      className="p-6"
+    >
+      <h3 id="invoice-send-dialog-title" className="text-base font-semibold text-foreground">{title}</h3>
+      <p className="mt-1 text-sm text-muted-foreground">{intro}</p>
+
+      {/* Envelope fields: label-left rows in one bordered box, like a mail client. */}
+      <div className="mt-4 divide-y rounded-md border">
+        <div className="flex items-center gap-2 px-3">
+          <label htmlFor="invoice-send-to" className="w-16 shrink-0 text-sm text-muted-foreground">
+            {t('invoiceActions.composer.toLabel')}
+          </label>
+          <input
+            ref={toInputRef}
+            id="invoice-send-to"
+            type="text"
+            value={to}
+            onChange={(e) => { setTo(e.target.value); setToMissing(false); }}
+            disabled={sending}
+            placeholder={t('invoiceActions.composer.toPlaceholder')}
+            aria-invalid={toError != null}
+            data-testid="invoice-send-to"
+            className="min-w-0 flex-1 rounded-sm border-0 bg-transparent py-2 text-sm focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+          />
+          {!ccOpen && (
+            <button
+              type="button"
+              onClick={() => setCcOpen(true)}
+              data-testid="invoice-send-cc-toggle"
+              className="shrink-0 text-sm text-muted-foreground hover:text-foreground hover:underline"
+            >
+              {t('invoiceActions.composer.ccToggle')}
+            </button>
+          )}
+        </div>
+        {ccOpen && (
+          <div className="flex items-center gap-2 px-3">
+            <label htmlFor="invoice-send-cc" className="w-16 shrink-0 text-sm text-muted-foreground">
+              {t('invoiceActions.composer.ccLabel')}
+            </label>
+            <input
+              id="invoice-send-cc"
+              type="text"
+              value={cc}
+              onChange={(e) => setCc(e.target.value)}
+              disabled={sending}
+              aria-invalid={ccError != null}
+              data-testid="invoice-send-cc"
+              className="min-w-0 flex-1 rounded-sm border-0 bg-transparent py-2 text-sm focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+            />
+          </div>
+        )}
+        <div className="flex items-center gap-2 px-3">
+          <label htmlFor="invoice-send-subject" className="w-16 shrink-0 text-sm text-muted-foreground">
+            {t('invoiceActions.composer.subjectLabel')}
+          </label>
+          <input
+            id="invoice-send-subject"
+            type="text"
+            value={subject}
+            maxLength={200}
+            onChange={(e) => setSubject(e.target.value)}
+            disabled={sending}
+            // The placeholder mirrors the server default so leaving the field
+            // blank is a visible, deliberate choice — not a missing subject.
+            placeholder={
+              invoiceNumber
+                ? t('invoiceActions.composer.subjectPlaceholder', { number: invoiceNumber })
+                : t('invoiceActions.composer.subjectPlaceholderNoNumber')
+            }
+            data-testid="invoice-send-subject"
+            className="min-w-0 flex-1 rounded-sm border-0 bg-transparent py-2 text-sm focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+          />
+        </div>
+      </div>
+      {toPrefillMissing && toParsed.emails.length === 0 && !toError && (
+        // The org lookup confirmed no billing contact exists — say WHY the To
+        // field is empty and link the fix, instead of demanding an address from
+        // memory. #billing, not the bare org route: OrgSettingsPage defaults to
+        // General, so an undeep link lands on a page with no visible field.
+        <p className="mt-1 text-xs text-muted-foreground" data-testid="invoice-send-to-no-contact">
+          <Trans
+            i18nKey="invoiceActions.composer.noBillingContactHint"
+            t={t}
+            components={{ orgLink: <a href={`/settings/organizations/${orgId}#billing`} className="underline hover:text-foreground" /> }}
+          />
+        </p>
+      )}
+      {toError && (
+        <p id="invoice-send-to-error" className="mt-1 text-xs text-destructive" data-testid="invoice-send-to-error">{toError}</p>
+      )}
+      {toMissing && !toError && (
+        <p id="invoice-send-to-missing" className="mt-1 text-xs text-destructive" data-testid="invoice-send-to-missing">
+          {t('invoiceActions.composer.recipientRequired')}
+        </p>
+      )}
+      {ccError && (
+        <p className="mt-1 text-xs text-destructive" data-testid="invoice-send-cc-error">{ccError}</p>
+      )}
+
+      <label className="mt-4 block">
+        <span className="mb-1 block text-sm font-medium text-foreground">
+          {t('invoiceActions.composer.messageLabel')}
+        </span>
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          rows={3}
+          maxLength={2000}
+          disabled={sending}
+          placeholder={t('invoiceActions.composer.messagePlaceholder')}
+          data-testid="invoice-send-message"
+          className="w-full resize-y rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
+        />
+      </label>
+      {signature && (
+        <div className="mt-2 rounded-md bg-muted/50 px-3 py-2" data-testid="invoice-send-signature-preview">
+          <p className="text-xs font-medium text-muted-foreground">
+            {t('invoiceActions.composer.signaturePreviewLabel')}
+          </p>
+          <p className="mt-1 whitespace-pre-wrap text-xs text-muted-foreground">{signature}</p>
+        </div>
+      )}
+
+      <label className="mt-3 flex items-center gap-2 text-sm text-foreground">
+        <input
+          type="checkbox"
+          checked={includePdf}
+          onChange={(e) => setIncludePdf(e.target.checked)}
+          disabled={sending}
+          data-testid="invoice-send-include-pdf"
+        />
+        {t('invoiceActions.composer.includePdfLabel')}
+      </label>
+
+      <div className="mt-6 flex justify-end gap-3">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={sending}
+          className="rounded-md border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+        >
+          {t('common:actions.cancel')}
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={sending}
+          aria-describedby={toMissing ? 'invoice-send-to-missing' : toError ? 'invoice-send-to-error' : undefined}
+          data-testid="invoice-send-confirm"
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+        >
+          {sending ? sendingLabel : confirmLabel}
+        </button>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -5,13 +5,13 @@ import '../../../lib/i18n';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../../lib/runAction';
 import { useMenuKeyboard } from '../shared/menuKeyboard';
+import { parseAddressList, MAX_RECIPIENTS } from '../shared/addressList';
 import { scheduleQuoteSend, cancelScheduledSend } from '../../../lib/api/quotes';
 import { showToast } from '../../shared/Toast';
 import { usePermissions } from '../../../lib/permissions';
 import { useOrgStore } from '../../../stores/orgStore';
 import { fetchWithAuth } from '../../../stores/auth';
 import { getJwtClaims } from '../../../lib/authScope';
-import { isValidEmail } from '@/lib/email';
 import { cloneQuote, deleteQuote, sendQuote, resendQuote, getQuoteShareLink, type SendQuoteOptions, type QuoteSendEmailReason, type QuoteAcceptUrlOrigin } from '../../../lib/api/quotes';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import { Dialog } from '../../shared/Dialog';
@@ -170,27 +170,6 @@ function linkOriginNotice(
     // rather than guess which of the two opposite stories applies.
     default: return null;
   }
-}
-
-/** Mirrors the send route's `.max(10)` on both `to` and `cc`. */
-const MAX_RECIPIENTS = 10;
-
-/** Split a comma/semicolon/newline-separated address list into valid + invalid
- *  entries (case-insensitively deduped, first-seen order kept). The server
- *  re-validates every address; this only powers the pre-submit UX guard. */
-function parseAddressList(raw: string): { emails: string[]; invalid: string[] } {
-  const emails: string[] = [];
-  const invalid: string[] = [];
-  const seen = new Set<string>();
-  for (const part of raw.split(/[,;\n]+/)) {
-    const addr = part.trim();
-    if (!addr) continue;
-    const key = addr.toLowerCase();
-    if (seen.has(key)) continue;
-    seen.add(key);
-    (isValidEmail(addr) ? emails : invalid).push(addr);
-  }
-  return { emails, invalid };
 }
 
 interface Props {

--- a/apps/web/src/components/billing/shared/addressList.ts
+++ b/apps/web/src/components/billing/shared/addressList.ts
@@ -1,0 +1,24 @@
+import { isValidEmail } from '@/lib/email';
+
+/** Mirrors the send routes' `.max(10)` on both `to` and `cc`
+ *  (apps/api/src/lib/sendComposer.ts) — shared by the quote and invoice
+ *  composers, which post to that one schema. */
+export const MAX_RECIPIENTS = 10;
+
+/** Split a comma/semicolon/newline-separated address list into valid + invalid
+ *  entries (case-insensitively deduped, first-seen order kept). The server
+ *  re-validates every address; this only powers the pre-submit UX guard. */
+export function parseAddressList(raw: string): { emails: string[]; invalid: string[] } {
+  const emails: string[] = [];
+  const invalid: string[] = [];
+  const seen = new Set<string>();
+  for (const part of raw.split(/[,;\n]+/)) {
+    const addr = part.trim();
+    if (!addr) continue;
+    const key = addr.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    (isValidEmail(addr) ? emails : invalid).push(addr);
+  }
+  return { emails, invalid };
+}

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -30,7 +30,9 @@ const namespaceDuplicateBaselines = {
     // "{{count}} item" spell identically to English in pt-BR.
     // +1: partnerBillingSettings.defaults.documentPageSizeA4 — "A4" is the
     // ISO 216 paper size code, identical in every catalog.
-    'billing.json': 51,
+    // +2: invoice send composer — "Cc" (label + toggle) is locale-invariant,
+    // the same exemption the quote composer's Cc pair already carries.
+    'billing.json': 53,
     // +1: richTextEditor.link — "Link" is the standard loanword in pt-BR.
     // +3: dashboard.vuln.kevCves — "{{count}} CVE(s)" is a locale-invariant
     // acronym (base/_one/_other).
@@ -82,7 +84,9 @@ const namespaceDuplicateBaselines = {
     // ISO 216 paper size code, identical in every catalog.
     // 41 -> 40: `contracts.contractPax8Drawer.priceEach` is no longer a
     // duplicate; its "/ea" was genuinely untranslated, not a literal.
-    'billing.json': 40,
+    // +2: invoice send composer — "Cc" (label + toggle) is locale-invariant,
+    // the same exemption the quote composer's Cc pair already carries.
+    'billing.json': 42,
     // +1: dashboard.vuln.kevCves_one — "{{count}} CVE" is a locale-invariant
     // acronym.
     // +8: PsaConnectionForm credential placeholders — literal token formats
@@ -138,7 +142,9 @@ const namespaceDuplicateBaselines = {
     // +1: order breakdown — "SKU" is a locale-invariant acronym.
     // +1: partnerBillingSettings.defaults.documentPageSizeA4 — "A4" is the
     // ISO 216 paper size code, identical in every catalog.
-    'billing.json': 52,
+    // +2: invoice send composer — "Cc" (label + toggle) is locale-invariant,
+    // the same exemption the quote composer's Cc pair already carries.
+    'billing.json': 54,
     // +1: dashboard.vuln.kevCves_one — "{{count}} CVE" is a locale-invariant
     // acronym.
     // +8: PsaConnectionForm credential placeholders — literal token formats
@@ -194,7 +200,9 @@ const namespaceDuplicateBaselines = {
     // +1: order breakdown — "SKU" is a locale-invariant acronym.
     // +1: partnerBillingSettings.defaults.documentPageSizeA4 — "A4" is the
     // ISO 216 paper size code, identical in every catalog.
-    'billing.json': 52,
+    // +2: invoice send composer — "Cc" (label + toggle) is locale-invariant,
+    // the same exemption the quote composer's Cc pair already carries.
+    'billing.json': 54,
     // +1: dashboard.vuln.kevCves_one "{{count}} CVE" is a locale-invariant
     // acronym.
     // +8: PsaConnectionForm credential placeholders — literal token formats
@@ -251,7 +259,9 @@ const namespaceDuplicateBaselines = {
     // the loanword the quote editor already uses in de-DE.
     // +1: partnerBillingSettings.defaults.documentPageSizeA4 — "A4" is the
     // ISO 216 paper size code, identical in every catalog.
-    'billing.json': 38,
+    // +2: invoice send composer — "Cc" (label + toggle) is locale-invariant,
+    // the same exemption the quote composer's Cc pair already carries.
+    'billing.json': 40,
     // +1: richTextEditor.link — "Link" is the standard loanword in de-DE.
     // +3: dashboard.vuln.kevCves — "{{count}} CVE(s)" is a locale-invariant
     // acronym (base/_one/_other).
@@ -294,7 +304,9 @@ const namespaceDuplicateBaselines = {
     // +1: order breakdown — "SKU" is a locale-invariant acronym.
     // +1: partnerBillingSettings.defaults.documentPageSizeA4 — "A4" is the
     // ISO 216 paper size code, identical in every catalog.
-    'billing.json': 32,
+    // +2: invoice send composer — "Cc" (label + toggle) is locale-invariant,
+    // the same exemption the quote composer's Cc pair already carries.
+    'billing.json': 34,
     // +1: dashboard.vuln.kevCves_one "{{count}} CVE" is a locale-invariant
     // acronym.
     // +8: PsaConnectionForm credential placeholders — literal token formats
@@ -334,7 +346,9 @@ const namespaceDuplicateBaselines = {
     // which is why the PR was green on its base and this baseline was short on
     // main. 18 -> 17 because `contracts.contractPax8Drawer.priceEach` is no
     // longer a duplicate: it was genuinely untranslated, not a literal.
-    'billing.json': 17,
+    // +2: invoice send composer — "Cc" (label + toggle) is locale-invariant,
+    // the same exemption the quote composer's Cc pair already carries.
+    'billing.json': 19,
     'common.json': 48,
     'devices.json': 77,
     'discovery.json': 9,

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -1395,7 +1395,7 @@
   "invoiceActions": {
     "composer": {
       "toLabel": "An",
-      "toPlaceholder": "buchhaltung@kunde.de",
+      "toPlaceholder": "buchhaltung@example.com",
       "ccToggle": "Cc",
       "ccLabel": "Cc",
       "subjectLabel": "Betreff",

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -1393,6 +1393,25 @@
     }
   },
   "invoiceActions": {
+    "composer": {
+      "toLabel": "An",
+      "toPlaceholder": "buchhaltung@kunde.de",
+      "ccToggle": "Cc",
+      "ccLabel": "Cc",
+      "subjectLabel": "Betreff",
+      "subjectPlaceholder": "Rechnung {{number}} von Ihrem Dienstleister",
+      "subjectPlaceholderNoNumber": "Ihre Rechnung",
+      "messageLabel": "Nachricht (optional)",
+      "messagePlaceholder": "Kurze Notiz für den Kunden hinzufügen…",
+      "includePdfLabel": "Rechnungs-PDF anhängen",
+      "signaturePreviewLabel": "Ihre Signatur wird angehängt:",
+      "invalidEmail": "Keine gültige E-Mail-Adresse: {{addresses}}",
+      "tooManyRecipients": "Maximal {{max}} Adressen.",
+      "recipientRequired": "Mindestens einen Empfänger angeben.",
+      "noBillingContactHint": "Dieses Unternehmen hat noch keinen Rechnungskontakt – <orgLink>einen hinzufügen</orgLink> oder oben eine Adresse eingeben."
+    },
+    "copyPaymentLink": "Zahlungslink kopieren",
+    "copyingPaymentLink": "Wird kopiert…",
     "deleteConfirm": {
       "message": "Dadurch wird der Rechnungsentwurf endgültig gelöscht. Dies kann nicht rückgängig gemacht werden.",
       "title": "Rechnungsentwurf löschen"
@@ -1404,6 +1423,9 @@
     "downloadPdfError": "Die Rechnung PDF konnte nicht heruntergeladen werden.",
     "issue": "Ausstellen",
     "issueAndSend": "Ausstellen und senden",
+    "issueBlockedUnsaved": "„{{field}}“ enthält eine nicht gespeicherte Änderung. Korrigieren Sie sie dort und stellen Sie dann aus.",
+    "issueCanceledSaveFailed": "Eine Änderung konnte nicht gespeichert werden, daher wurde das Ausstellen abgebrochen. Korrigieren Sie das markierte Feld und versuchen Sie es erneut.",
+    "issueCanceledStillSaving": "Ihre Änderungen werden noch gespeichert – das Ausstellen wurde abgebrochen. Versuchen Sie es erneut, sobald alles gespeichert ist.",
     "issueError": "Rechnung konnte nicht ausgestellt werden.",
     "issueNoEmailWarning": "Rechnung ausgestellt – aber keine E-Mail gesendet (kein Rechnungskontakt/E-Mail nicht konfiguriert)",
     "issueSendConfirm": {
@@ -1416,12 +1438,21 @@
     "issueSuccess": "Rechnung ausgestellt",
     "issuing": "Wird ausgestellt…",
     "noVisibleLineHint": "Mindestens eine für Kunden sichtbare Position zum Ausstellen hinzufügen.",
+    "paymentLinkCopyFailed": "Automatisches Kopieren nicht möglich. Zahlungslink: {{url}}",
     "preparing": "Vorbereiten…",
+    "resend": "Erneut senden",
+    "resendConfirm": {
+      "title": "Diese Rechnung erneut senden?",
+      "message": "Eine weitere Kopie über {{amount}} wird an {{customer}} gesendet. An der Rechnung ändert sich nichts – gleiche Nummer, gleiche Daten, gleiche Beträge."
+    },
+    "resendSuccess": "Rechnung erneut gesendet",
+    "resending": "Wird gesendet…",
     "savingHint": "Änderungen werden gespeichert… Ausstellen wird freigegeben, sobald alles gespeichert ist.",
     "savingTitle": "Ihre Änderungen werden gespeichert – Ausstellen wird freigegeben, sobald alles gespeichert ist.",
-    "issueCanceledSaveFailed": "Eine Änderung konnte nicht gespeichert werden, daher wurde das Ausstellen abgebrochen. Korrigieren Sie das markierte Feld und versuchen Sie es erneut.",
-    "issueCanceledStillSaving": "Ihre Änderungen werden noch gespeichert – das Ausstellen wurde abgebrochen. Versuchen Sie es erneut, sobald alles gespeichert ist.",
-    "issueBlockedUnsaved": "„{{field}}“ enthält eine nicht gespeicherte Änderung. Korrigieren Sie sie dort und stellen Sie dann aus.",
+    "sendConfirm": {
+      "title": "Diese Rechnung senden?",
+      "message": "Die Rechnung über {{amount}} wird per E-Mail an {{customer}} gesendet."
+    },
     "unsavedHint": "„{{field}}“ enthält eine nicht gespeicherte Änderung — Ausstellen wird freigegeben, sobald sie gespeichert ist.",
     "unsavedTitle": "„{{field}}“ enthält eine nicht gespeicherte Änderung — Ausstellen wird freigegeben, sobald sie gespeichert ist."
   },

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -1393,6 +1393,25 @@
     }
   },
   "invoiceActions": {
+    "composer": {
+      "toLabel": "To",
+      "toPlaceholder": "billing@customer.com",
+      "ccToggle": "Cc",
+      "ccLabel": "Cc",
+      "subjectLabel": "Subject",
+      "subjectPlaceholder": "Invoice {{number}} from your provider",
+      "subjectPlaceholderNoNumber": "Your invoice",
+      "messageLabel": "Message (optional)",
+      "messagePlaceholder": "Add a short note for the customer…",
+      "includePdfLabel": "Attach the invoice PDF",
+      "signaturePreviewLabel": "Your signature will be added:",
+      "invalidEmail": "Not a valid email address: {{addresses}}",
+      "tooManyRecipients": "Up to {{max}} addresses.",
+      "recipientRequired": "Add at least one recipient.",
+      "noBillingContactHint": "This company has no billing contact yet — <orgLink>add one</orgLink> or type an address above."
+    },
+    "copyPaymentLink": "Copy payment link",
+    "copyingPaymentLink": "Copying…",
     "deleteConfirm": {
       "message": "This permanently deletes the draft invoice. This cannot be undone.",
       "title": "Delete draft invoice"
@@ -1404,6 +1423,9 @@
     "downloadPdfError": "Could not download the invoice PDF.",
     "issue": "Issue",
     "issueAndSend": "Issue & Send",
+    "issueBlockedUnsaved": "“{{field}}” has a change that hasn’t saved. Fix it there, then Issue.",
+    "issueCanceledSaveFailed": "A change failed to save, so Issue was canceled. Fix the highlighted field and try again.",
+    "issueCanceledStillSaving": "Still saving your changes — Issue was canceled. Try again once everything is saved.",
     "issueError": "Could not issue invoice.",
     "issueNoEmailWarning": "Invoice issued — but no email was sent (no billing contact / email not configured)",
     "issueSendConfirm": {
@@ -1416,12 +1438,21 @@
     "issueSuccess": "Invoice issued",
     "issuing": "Issuing…",
     "noVisibleLineHint": "Add at least one customer-visible line to issue.",
+    "paymentLinkCopyFailed": "Couldn’t copy automatically. Payment link: {{url}}",
     "preparing": "Preparing…",
+    "resend": "Re-send",
+    "resendConfirm": {
+      "title": "Re-send this invoice?",
+      "message": "This emails another copy to {{customer}} for {{amount}}. Nothing about the invoice changes — same number, same dates, same amounts."
+    },
+    "resendSuccess": "Invoice re-sent",
+    "resending": "Sending…",
     "savingHint": "Saving changes… Issue unlocks when everything is saved.",
     "savingTitle": "Saving your changes — Issue unlocks when everything is saved.",
-    "issueCanceledSaveFailed": "A change failed to save, so Issue was canceled. Fix the highlighted field and try again.",
-    "issueCanceledStillSaving": "Still saving your changes — Issue was canceled. Try again once everything is saved.",
-    "issueBlockedUnsaved": "“{{field}}” has a change that hasn’t saved. Fix it there, then Issue.",
+    "sendConfirm": {
+      "title": "Send this invoice?",
+      "message": "This emails the invoice to {{customer}} for {{amount}}."
+    },
     "unsavedHint": "“{{field}}” has an unsaved change — Issue unlocks once it saves.",
     "unsavedTitle": "“{{field}}” has an unsaved change — Issue unlocks once it saves."
   },

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -1395,7 +1395,7 @@
   "invoiceActions": {
     "composer": {
       "toLabel": "Para",
-      "toPlaceholder": "facturacion@cliente.com",
+      "toPlaceholder": "facturacion@example.com",
       "ccToggle": "Cc",
       "ccLabel": "Cc",
       "subjectLabel": "Asunto",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -1393,6 +1393,25 @@
     }
   },
   "invoiceActions": {
+    "composer": {
+      "toLabel": "Para",
+      "toPlaceholder": "facturacion@cliente.com",
+      "ccToggle": "Cc",
+      "ccLabel": "Cc",
+      "subjectLabel": "Asunto",
+      "subjectPlaceholder": "Factura {{number}} de su proveedor",
+      "subjectPlaceholderNoNumber": "Su factura",
+      "messageLabel": "Mensaje (opcional)",
+      "messagePlaceholder": "Agregue una nota breve para el cliente…",
+      "includePdfLabel": "Adjuntar el PDF de la factura",
+      "signaturePreviewLabel": "Se agregará su firma:",
+      "invalidEmail": "Dirección de correo no válida: {{addresses}}",
+      "tooManyRecipients": "Hasta {{max}} direcciones.",
+      "recipientRequired": "Agregue al menos un destinatario.",
+      "noBillingContactHint": "Esta empresa aún no tiene contacto de facturación: <orgLink>agregue uno</orgLink> o escriba una dirección arriba."
+    },
+    "copyPaymentLink": "Copiar enlace de pago",
+    "copyingPaymentLink": "Copiando…",
     "deleteConfirm": {
       "message": "Esto elimina permanentemente el borrador de la factura. Esto no se puede deshacer.",
       "title": "Eliminar borrador de factura"
@@ -1404,6 +1423,9 @@
     "downloadPdfError": "No se pudo descargar la factura PDF.",
     "issue": "Emitir",
     "issueAndSend": "Emitir y enviar",
+    "issueBlockedUnsaved": "«{{field}}» tiene un cambio sin guardar. Corríjalo allí y luego emita.",
+    "issueCanceledSaveFailed": "Un cambio no se pudo guardar, por lo que se canceló la emisión. Corrija el campo resaltado e inténtelo de nuevo.",
+    "issueCanceledStillSaving": "Sus cambios aún se están guardando; la emisión se canceló. Inténtelo de nuevo cuando todo esté guardado.",
     "issueError": "No se pudo emitir la factura.",
     "issueNoEmailWarning": "Factura emitida, pero no se envió ningún correo electrónico (no hay contacto de facturación/correo electrónico no configurado)",
     "issueSendConfirm": {
@@ -1416,12 +1438,21 @@
     "issueSuccess": "Factura emitida",
     "issuing": "Emitiendo…",
     "noVisibleLineHint": "Agregue al menos una línea visible para el cliente para emitir.",
+    "paymentLinkCopyFailed": "No se pudo copiar automáticamente. Enlace de pago: {{url}}",
     "preparing": "Preparando…",
+    "resend": "Reenviar",
+    "resendConfirm": {
+      "title": "¿Reenviar esta factura?",
+      "message": "Se enviará otra copia por {{amount}} a {{customer}}. La factura no cambia: mismo número, mismas fechas, mismos montos."
+    },
+    "resendSuccess": "Factura reenviada",
+    "resending": "Enviando…",
     "savingHint": "Guardando cambios… Emitir se desbloqueará cuando todo esté guardado.",
     "savingTitle": "Guardando sus cambios: Emitir se desbloqueará cuando todo esté guardado.",
-    "issueCanceledSaveFailed": "Un cambio no se pudo guardar, por lo que se canceló la emisión. Corrija el campo resaltado e inténtelo de nuevo.",
-    "issueCanceledStillSaving": "Sus cambios aún se están guardando; la emisión se canceló. Inténtelo de nuevo cuando todo esté guardado.",
-    "issueBlockedUnsaved": "«{{field}}» tiene un cambio sin guardar. Corríjalo allí y luego emita.",
+    "sendConfirm": {
+      "title": "¿Enviar esta factura?",
+      "message": "Se enviará la factura por {{amount}} por correo a {{customer}}."
+    },
     "unsavedHint": "«{{field}}» tiene un cambio sin guardar: emitir se desbloqueará cuando se guarde.",
     "unsavedTitle": "«{{field}}» tiene un cambio sin guardar: emitir se desbloqueará cuando se guarde."
   },

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -1393,6 +1393,25 @@
     }
   },
   "invoiceActions": {
+    "composer": {
+      "toLabel": "À",
+      "toPlaceholder": "facturation@client.com",
+      "ccToggle": "Cc",
+      "ccLabel": "Cc",
+      "subjectLabel": "Objet",
+      "subjectPlaceholder": "Facture {{number}} de votre fournisseur",
+      "subjectPlaceholderNoNumber": "Votre facture",
+      "messageLabel": "Message (facultatif)",
+      "messagePlaceholder": "Ajoutez une courte note pour le client…",
+      "includePdfLabel": "Joindre le PDF de la facture",
+      "signaturePreviewLabel": "Votre signature sera ajoutée :",
+      "invalidEmail": "Adresse courriel non valide : {{addresses}}",
+      "tooManyRecipients": "Jusqu’à {{max}} adresses.",
+      "recipientRequired": "Ajoutez au moins un destinataire.",
+      "noBillingContactHint": "Cette entreprise n’a pas encore de contact de facturation — <orgLink>ajoutez-en un</orgLink> ou saisissez une adresse ci-dessus."
+    },
+    "copyPaymentLink": "Copier le lien de paiement",
+    "copyingPaymentLink": "Copie en cours…",
     "deleteConfirm": {
       "message": "Cette action supprime définitivement la facture brouillon. Elle est irréversible.",
       "title": "Supprimer la facture brouillon"
@@ -1404,6 +1423,9 @@
     "downloadPdfError": "Impossible de télécharger le PDF de la facture.",
     "issue": "Émettre",
     "issueAndSend": "Émettre et envoyer",
+    "issueBlockedUnsaved": "« {{field}} » contient une modification non enregistrée. Corrigez-la, puis émettez.",
+    "issueCanceledSaveFailed": "Une modification n'a pas pu être enregistrée, l'émission a donc été annulée. Corrigez le champ signalé et réessayez.",
+    "issueCanceledStillSaving": "Vos modifications sont toujours en cours d'enregistrement — l'émission a été annulée. Réessayez une fois tout enregistré.",
     "issueError": "Impossible d'émettre la facture.",
     "issueNoEmailWarning": "Facture émise — mais aucun courriel n'a été envoyé (aucun contact de facturation / courriel non configuré)",
     "issueSendConfirm": {
@@ -1416,12 +1438,21 @@
     "issueSuccess": "Facture émise",
     "issuing": "Émission…",
     "noVisibleLineHint": "Ajoutez au moins une ligne visible par le client pour émettre.",
+    "paymentLinkCopyFailed": "Copie automatique impossible. Lien de paiement : {{url}}",
     "preparing": "Préparation…",
+    "resend": "Renvoyer",
+    "resendConfirm": {
+      "title": "Renvoyer cette facture?",
+      "message": "Une autre copie de {{amount}} sera envoyée à {{customer}}. Rien ne change sur la facture : même numéro, mêmes dates, mêmes montants."
+    },
+    "resendSuccess": "Facture renvoyée",
+    "resending": "Envoi en cours…",
     "savingHint": "Enregistrement des modifications… L'émission sera disponible une fois tout enregistré.",
     "savingTitle": "Enregistrement de vos modifications — l'émission sera disponible une fois tout enregistré.",
-    "issueCanceledSaveFailed": "Une modification n'a pas pu être enregistrée, l'émission a donc été annulée. Corrigez le champ signalé et réessayez.",
-    "issueCanceledStillSaving": "Vos modifications sont toujours en cours d'enregistrement — l'émission a été annulée. Réessayez une fois tout enregistré.",
-    "issueBlockedUnsaved": "« {{field}} » contient une modification non enregistrée. Corrigez-la, puis émettez.",
+    "sendConfirm": {
+      "title": "Envoyer cette facture?",
+      "message": "La facture de {{amount}} sera envoyée par courriel à {{customer}}."
+    },
     "unsavedHint": "« {{field}} » contient une modification non enregistrée — l'émission sera disponible une fois enregistrée.",
     "unsavedTitle": "« {{field}} » contient une modification non enregistrée — l'émission sera disponible une fois enregistrée."
   },

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -1395,7 +1395,7 @@
   "invoiceActions": {
     "composer": {
       "toLabel": "À",
-      "toPlaceholder": "facturation@client.com",
+      "toPlaceholder": "facturation@example.com",
       "ccToggle": "Cc",
       "ccLabel": "Cc",
       "subjectLabel": "Objet",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -1393,6 +1393,25 @@
     }
   },
   "invoiceActions": {
+    "composer": {
+      "toLabel": "À",
+      "toPlaceholder": "facturation@client.com",
+      "ccToggle": "Cc",
+      "ccLabel": "Cc",
+      "subjectLabel": "Objet",
+      "subjectPlaceholder": "Facture {{number}} de votre prestataire",
+      "subjectPlaceholderNoNumber": "Votre facture",
+      "messageLabel": "Message (facultatif)",
+      "messagePlaceholder": "Ajoutez une courte note pour le client…",
+      "includePdfLabel": "Joindre le PDF de la facture",
+      "signaturePreviewLabel": "Votre signature sera ajoutée :",
+      "invalidEmail": "Adresse e-mail non valide : {{addresses}}",
+      "tooManyRecipients": "Jusqu’à {{max}} adresses.",
+      "recipientRequired": "Ajoutez au moins un destinataire.",
+      "noBillingContactHint": "Cette entreprise n’a pas encore de contact de facturation — <orgLink>ajoutez-en un</orgLink> ou saisissez une adresse ci-dessus."
+    },
+    "copyPaymentLink": "Copier le lien de paiement",
+    "copyingPaymentLink": "Copie en cours…",
     "deleteConfirm": {
       "message": "Cette action supprime définitivement la facture brouillon. Elle est irréversible.",
       "title": "Supprimer la facture brouillon"
@@ -1404,6 +1423,9 @@
     "downloadPdfError": "Impossible de télécharger le PDF de la facture.",
     "issue": "Émettre",
     "issueAndSend": "Émettre et envoyer",
+    "issueBlockedUnsaved": "« {{field}} » contient une modification non enregistrée. Corrigez-la puis émettez.",
+    "issueCanceledSaveFailed": "Une modification n'a pas pu être enregistrée, l'émission a donc été annulée. Corrigez le champ signalé et réessayez.",
+    "issueCanceledStillSaving": "Vos modifications sont toujours en cours d'enregistrement — l'émission a été annulée. Réessayez une fois tout enregistré.",
     "issueError": "Impossible d'émettre la facture.",
     "issueNoEmailWarning": "Facture émise — mais aucun e-mail n'a été envoyé (aucun contact de facturation / e-mail non configuré)",
     "issueSendConfirm": {
@@ -1416,12 +1438,21 @@
     "issueSuccess": "Facture émise",
     "issuing": "Émission…",
     "noVisibleLineHint": "Ajoutez au moins une ligne visible par le client pour émettre.",
+    "paymentLinkCopyFailed": "Copie automatique impossible. Lien de paiement : {{url}}",
     "preparing": "Préparation…",
+    "resend": "Renvoyer",
+    "resendConfirm": {
+      "title": "Renvoyer cette facture ?",
+      "message": "Une autre copie de {{amount}} sera envoyée à {{customer}}. Rien ne change sur la facture : même numéro, mêmes dates, mêmes montants."
+    },
+    "resendSuccess": "Facture renvoyée",
+    "resending": "Envoi en cours…",
     "savingHint": "Enregistrement des modifications… L'émission sera disponible une fois tout enregistré.",
     "savingTitle": "Enregistrement de vos modifications — l'émission sera disponible une fois tout enregistré.",
-    "issueCanceledSaveFailed": "Une modification n'a pas pu être enregistrée, l'émission a donc été annulée. Corrigez le champ signalé et réessayez.",
-    "issueCanceledStillSaving": "Vos modifications sont toujours en cours d'enregistrement — l'émission a été annulée. Réessayez une fois tout enregistré.",
-    "issueBlockedUnsaved": "« {{field}} » contient une modification non enregistrée. Corrigez-la puis émettez.",
+    "sendConfirm": {
+      "title": "Envoyer cette facture ?",
+      "message": "La facture de {{amount}} sera envoyée par e-mail à {{customer}}."
+    },
     "unsavedHint": "« {{field}} » contient une modification non enregistrée — l’émission sera disponible une fois enregistrée.",
     "unsavedTitle": "« {{field}} » contient une modification non enregistrée — l’émission sera disponible une fois enregistrée."
   },

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -1395,7 +1395,7 @@
   "invoiceActions": {
     "composer": {
       "toLabel": "À",
-      "toPlaceholder": "facturation@client.com",
+      "toPlaceholder": "facturation@example.com",
       "ccToggle": "Cc",
       "ccLabel": "Cc",
       "subjectLabel": "Objet",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -1395,7 +1395,7 @@
   "invoiceActions": {
     "composer": {
       "toLabel": "A",
-      "toPlaceholder": "amministrazione@cliente.it",
+      "toPlaceholder": "amministrazione@example.com",
       "ccToggle": "Cc",
       "ccLabel": "Cc",
       "subjectLabel": "Oggetto",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -1393,6 +1393,25 @@
     }
   },
   "invoiceActions": {
+    "composer": {
+      "toLabel": "A",
+      "toPlaceholder": "amministrazione@cliente.it",
+      "ccToggle": "Cc",
+      "ccLabel": "Cc",
+      "subjectLabel": "Oggetto",
+      "subjectPlaceholder": "Fattura {{number}} dal tuo fornitore",
+      "subjectPlaceholderNoNumber": "La tua fattura",
+      "messageLabel": "Messaggio (facoltativo)",
+      "messagePlaceholder": "Aggiungi una breve nota per il cliente…",
+      "includePdfLabel": "Allega il PDF della fattura",
+      "signaturePreviewLabel": "La tua firma verrà aggiunta:",
+      "invalidEmail": "Indirizzo e-mail non valido: {{addresses}}",
+      "tooManyRecipients": "Fino a {{max}} indirizzi.",
+      "recipientRequired": "Aggiungi almeno un destinatario.",
+      "noBillingContactHint": "Questa azienda non ha ancora un contatto di fatturazione — <orgLink>aggiungine uno</orgLink> o digita un indirizzo sopra."
+    },
+    "copyPaymentLink": "Copia link di pagamento",
+    "copyingPaymentLink": "Copia in corso…",
     "deleteConfirm": {
       "message": "La fattura in bozza verrà eliminata definitivamente. L'operazione non può essere annullata.",
       "title": "Elimina fattura in bozza"
@@ -1404,6 +1423,9 @@
     "downloadPdfError": "Impossibile scaricare il PDF della fattura.",
     "issue": "Emetti",
     "issueAndSend": "Emetti e invia",
+    "issueBlockedUnsaved": "\"{{field}}\" contiene una modifica non salvata. Correggila lì, poi emetti.",
+    "issueCanceledSaveFailed": "Una modifica non è stata salvata, quindi l'emissione è stata annullata. Correggi il campo evidenziato e riprova.",
+    "issueCanceledStillSaving": "Le modifiche sono ancora in fase di salvataggio — l'emissione è stata annullata. Riprova quando tutto è salvato.",
     "issueError": "Impossibile emettere la fattura.",
     "issueNoEmailWarning": "Fattura emessa, ma nessuna email è stata inviata (nessun contatto di fatturazione / email non configurata)",
     "issueSendConfirm": {
@@ -1416,12 +1438,21 @@
     "issueSuccess": "Fattura emessa",
     "issuing": "Emissione…",
     "noVisibleLineHint": "Aggiungi almeno una riga visibile al cliente per emettere.",
+    "paymentLinkCopyFailed": "Copia automatica non riuscita. Link di pagamento: {{url}}",
     "preparing": "Preparazione…",
+    "resend": "Invia di nuovo",
+    "resendConfirm": {
+      "title": "Inviare di nuovo questa fattura?",
+      "message": "Verrà inviata un’altra copia da {{amount}} a {{customer}}. Nulla cambia nella fattura: stesso numero, stesse date, stessi importi."
+    },
+    "resendSuccess": "Fattura inviata di nuovo",
+    "resending": "Invio in corso…",
     "savingHint": "Salvataggio delle modifiche… L'emissione si sblocca quando tutto è salvato.",
     "savingTitle": "Salvataggio delle modifiche — l'emissione si sblocca quando tutto è salvato.",
-    "issueCanceledSaveFailed": "Una modifica non è stata salvata, quindi l'emissione è stata annullata. Correggi il campo evidenziato e riprova.",
-    "issueCanceledStillSaving": "Le modifiche sono ancora in fase di salvataggio — l'emissione è stata annullata. Riprova quando tutto è salvato.",
-    "issueBlockedUnsaved": "\"{{field}}\" contiene una modifica non salvata. Correggila lì, poi emetti.",
+    "sendConfirm": {
+      "title": "Inviare questa fattura?",
+      "message": "La fattura da {{amount}} verrà inviata via e-mail a {{customer}}."
+    },
     "unsavedHint": "\"{{field}}\" contiene una modifica non salvata — l'emissione si sblocca una volta salvata.",
     "unsavedTitle": "\"{{field}}\" contiene una modifica non salvata — l'emissione si sblocca una volta salvata."
   },

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -1395,7 +1395,7 @@
   "invoiceActions": {
     "composer": {
       "toLabel": "Para",
-      "toPlaceholder": "financeiro@cliente.com",
+      "toPlaceholder": "financeiro@example.com",
       "ccToggle": "Cc",
       "ccLabel": "Cc",
       "subjectLabel": "Assunto",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -1393,6 +1393,25 @@
     }
   },
   "invoiceActions": {
+    "composer": {
+      "toLabel": "Para",
+      "toPlaceholder": "financeiro@cliente.com",
+      "ccToggle": "Cc",
+      "ccLabel": "Cc",
+      "subjectLabel": "Assunto",
+      "subjectPlaceholder": "Fatura {{number}} do seu fornecedor",
+      "subjectPlaceholderNoNumber": "Sua fatura",
+      "messageLabel": "Mensagem (opcional)",
+      "messagePlaceholder": "Adicione uma breve nota para o cliente…",
+      "includePdfLabel": "Anexar o PDF da fatura",
+      "signaturePreviewLabel": "Sua assinatura será adicionada:",
+      "invalidEmail": "Endereço de e-mail inválido: {{addresses}}",
+      "tooManyRecipients": "Até {{max}} endereços.",
+      "recipientRequired": "Adicione pelo menos um destinatário.",
+      "noBillingContactHint": "Esta empresa ainda não tem contato de faturamento — <orgLink>adicione um</orgLink> ou digite um endereço acima."
+    },
+    "copyPaymentLink": "Copiar link de pagamento",
+    "copyingPaymentLink": "Copiando…",
     "deleteConfirm": {
       "message": "Esta ação exclui permanentemente a fatura em rascunho. Não é possível desfazê-la.",
       "title": "Excluir fatura em rascunho"
@@ -1404,6 +1423,9 @@
     "downloadPdfError": "Não foi possível baixar o PDF da fatura.",
     "issue": "Emitir",
     "issueAndSend": "Emitir e enviar",
+    "issueBlockedUnsaved": "“{{field}}” tem uma alteração não salva. Corrija-a e depois emita.",
+    "issueCanceledSaveFailed": "Uma alteração não pôde ser salva, então a emissão foi cancelada. Corrija o campo destacado e tente novamente.",
+    "issueCanceledStillSaving": "Suas alterações ainda estão sendo salvas — a emissão foi cancelada. Tente novamente quando tudo estiver salvo.",
     "issueError": "Não foi possível emitir a fatura.",
     "issueNoEmailWarning": "Fatura emitida — mas nenhum e-mail foi enviado (contato de cobrança/e-mail não configurado)",
     "issueSendConfirm": {
@@ -1416,12 +1438,21 @@
     "issueSuccess": "Fatura emitida",
     "issuing": "Emitindo…",
     "noVisibleLineHint": "Adicione pelo menos uma linha visível ao cliente para emitir.",
+    "paymentLinkCopyFailed": "Não foi possível copiar automaticamente. Link de pagamento: {{url}}",
     "preparing": "Preparando…",
+    "resend": "Reenviar",
+    "resendConfirm": {
+      "title": "Reenviar esta fatura?",
+      "message": "Outra cópia de {{amount}} será enviada para {{customer}}. Nada muda na fatura — mesmo número, mesmas datas, mesmos valores."
+    },
+    "resendSuccess": "Fatura reenviada",
+    "resending": "Enviando…",
     "savingHint": "Salvando alterações… A emissão será liberada quando tudo estiver salvo.",
     "savingTitle": "Salvando suas alterações — a emissão será liberada quando tudo estiver salvo.",
-    "issueCanceledSaveFailed": "Uma alteração não pôde ser salva, então a emissão foi cancelada. Corrija o campo destacado e tente novamente.",
-    "issueCanceledStillSaving": "Suas alterações ainda estão sendo salvas — a emissão foi cancelada. Tente novamente quando tudo estiver salvo.",
-    "issueBlockedUnsaved": "“{{field}}” tem uma alteração não salva. Corrija-a e depois emita.",
+    "sendConfirm": {
+      "title": "Enviar esta fatura?",
+      "message": "A fatura de {{amount}} será enviada por e-mail para {{customer}}."
+    },
     "unsavedHint": "“{{field}}” tem uma alteração não salva — a emissão será liberada quando ela for salva.",
     "unsavedTitle": "“{{field}}” tem uma alteração não salva — a emissão será liberada quando ela for salva."
   },

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -1393,6 +1393,25 @@
     }
   },
   "invoiceActions": {
+    "composer": {
+      "toLabel": "Kime",
+      "toPlaceholder": "muhasebe@musteri.com",
+      "ccToggle": "Cc",
+      "ccLabel": "Cc",
+      "subjectLabel": "Konu",
+      "subjectPlaceholder": "Sağlayıcınızdan {{number}} numaralı fatura",
+      "subjectPlaceholderNoNumber": "Faturanız",
+      "messageLabel": "Mesaj (isteğe bağlı)",
+      "messagePlaceholder": "Müşteri için kısa bir not ekleyin…",
+      "includePdfLabel": "Fatura PDF’ini ekle",
+      "signaturePreviewLabel": "İmzanız eklenecek:",
+      "invalidEmail": "Geçerli bir e-posta adresi değil: {{addresses}}",
+      "tooManyRecipients": "En fazla {{max}} adres.",
+      "recipientRequired": "En az bir alıcı ekleyin.",
+      "noBillingContactHint": "Bu şirketin henüz bir fatura iletişim kişisi yok — <orgLink>bir tane ekleyin</orgLink> veya yukarıya bir adres yazın."
+    },
+    "copyPaymentLink": "Ödeme bağlantısını kopyala",
+    "copyingPaymentLink": "Kopyalanıyor…",
     "deleteConfirm": {
       "message": "Bu, taslak faturayı kalıcı olarak siler. Bu geri alınamaz.",
       "title": "Taslak faturayı sil"
@@ -1404,6 +1423,9 @@
     "downloadPdfError": "Fatura PDF'si indirilemedi.",
     "issue": "Sayı",
     "issueAndSend": "Düzenle ve Gönder",
+    "issueBlockedUnsaved": "“{{field}}” kaydedilmemiş bir değişiklik içeriyor. Orada düzeltin, ardından Sorun.",
+    "issueCanceledSaveFailed": "Bir değişiklik kaydedilemediğinden Sorun iptal edildi. Vurgulanan alanı düzeltip tekrar deneyin.",
+    "issueCanceledStillSaving": "Değişiklikleriniz hâlâ kaydediliyor — Sorun iptal edildi. Her şey kaydedildikten sonra tekrar deneyin.",
     "issueError": "Fatura düzenlenemedi.",
     "issueNoEmailWarning": "Fatura düzenlendi — ancak e-posta gönderilmedi (faturalandırmayla ilgili kişi yok / e-posta yapılandırılmadı)",
     "issueSendConfirm": {
@@ -1416,12 +1438,21 @@
     "issueSuccess": "Fatura düzenlendi",
     "issuing": "Veriliyor…",
     "noVisibleLineHint": "Düzenlemeye müşterinin görebileceği en az bir satır ekleyin.",
+    "paymentLinkCopyFailed": "Otomatik kopyalanamadı. Ödeme bağlantısı: {{url}}",
     "preparing": "Hazırlanıyor…",
+    "resend": "Yeniden gönder",
+    "resendConfirm": {
+      "title": "Bu fatura yeniden gönderilsin mi?",
+      "message": "{{customer}} adresine {{amount}} tutarında bir kopya daha gönderilir. Faturada hiçbir şey değişmez — aynı numara, aynı tarihler, aynı tutarlar."
+    },
+    "resendSuccess": "Fatura yeniden gönderildi",
+    "resending": "Gönderiliyor…",
     "savingHint": "Değişiklikler kaydediliyor… Her şey kaydedildiğinde sorunun kilidi açılır.",
     "savingTitle": "Değişiklikleriniz kaydediliyor — Her şey kaydedildiğinde sorunun kilidi açılır.",
-    "issueCanceledSaveFailed": "Bir değişiklik kaydedilemediğinden Sorun iptal edildi. Vurgulanan alanı düzeltip tekrar deneyin.",
-    "issueCanceledStillSaving": "Değişiklikleriniz hâlâ kaydediliyor — Sorun iptal edildi. Her şey kaydedildikten sonra tekrar deneyin.",
-    "issueBlockedUnsaved": "“{{field}}” kaydedilmemiş bir değişiklik içeriyor. Orada düzeltin, ardından Sorun.",
+    "sendConfirm": {
+      "title": "Bu fatura gönderilsin mi?",
+      "message": "{{amount}} tutarındaki fatura {{customer}} adresine e-postayla gönderilir."
+    },
     "unsavedHint": "“{{field}}” kaydedilmemiş bir değişiklik içeriyor — Kaydedildiğinde sorunun kilidi açılıyor.",
     "unsavedTitle": "“{{field}}” kaydedilmemiş bir değişiklik içeriyor — Sorun kaydedildiğinde kilidi açılıyor."
   },

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -1395,7 +1395,7 @@
   "invoiceActions": {
     "composer": {
       "toLabel": "Kime",
-      "toPlaceholder": "muhasebe@musteri.com",
+      "toPlaceholder": "muhasebe@example.com",
       "ccToggle": "Cc",
       "ccLabel": "Cc",
       "subjectLabel": "Konu",

--- a/docs/superpowers/specs/billing/2026-08-21-public-invoice-pay-link-design.md
+++ b/docs/superpowers/specs/billing/2026-08-21-public-invoice-pay-link-design.md
@@ -1,0 +1,140 @@
+# Public Invoice Pay Link — UX + Design Spec
+
+**Date:** 2026-08-21
+**Status:** Approved (Todd, 2026-08-21) — advisor quorum ran (Fable position + Codex xhigh review); resolutions inline, marked **[quorum]**
+**Problem:** A real customer, invoice in hand, could not pay: *"it does not allow me to pay them without logging into a client portal. I do not recall having a portal login."*
+
+## 1. The gap
+
+Payment today has exactly one frictionless moment, and it is bound to the wrong object:
+
+1. Quote accept (`POST /quotes/public/:token/accept`) revokes the accept token (single-use jti), mints a one-shot Stripe checkout URL, and returns it **in that one response**. The `payUrl` lives only in React state on the confirmation screen (`PublicQuoteView.tsx`). Close the tab → gone. The quote link itself now 401s.
+2. Nothing auto-emails the issued invoice (`emitAcceptInvoiceIssued` only emits the bus event + queues the PDF render).
+3. When the MSP sends the invoice, the email CTA is `<portalBase>/invoices/<id>` — the **authenticated** portal. Nothing in the invoice send path invites the customer to the portal, so most recipients have no login. Dead end.
+4. The MSP-side "Copy payment link" (`POST /invoices/:id/pay-link`) copies a raw Stripe checkout URL — expires in ~24h, shows no invoice, single amount snapshot. Another one-shot trap.
+
+**Root cause:** the payment link is bound to a single-use *acceptance* token instead of to the *invoice*. Quotes have a public surface; invoices don't.
+
+## 2. Design principle
+
+> **Every invoice email carries one durable link that always works: view the invoice, download the PDF, and pay whatever is due now — no login, no expiry cliff, correct in every lifecycle state.**
+
+Trust model is identical to the quote accept link (bearer link = access), and strictly less dangerous: the worst a link holder can do is *view* the invoice or *pay* it. Same as Stripe's own hosted invoice links.
+
+## 3. Token design — **[quorum: opaque token, not JWT]**
+
+**256-bit random opaque token; no new table; three new columns on `invoices`.**
+
+My original position was an HS256 JWT + version column mirroring `quoteAcceptToken.ts`. Codex overturned it and I agree: verification must read the invoice row anyway (status + revocation), so the JWT is stateless in name only — while inheriting the general JWT keyring's rotation lifetime, which is designed for access-token lifetimes, not year-scale links (the quote `kid`-loss path is exactly this failure mode and already warranted a Sentry alert). A signing-key compromise would also forge links for *every* invoice; an opaque-token leak is scoped to one.
+
+- Token: 32 random bytes, base64url (~43 chars — email-friendly vs a ~300-char JWT). No embedded claims; the invoice is resolved **by token hash**.
+- Columns:
+  - `public_link_token_hash` `char(64)` — SHA-256 hex, unique partial index; the lookup key. Export policy: `excludedSensitive`.
+  - `public_link_token_ct` `text` — the token encrypted at rest (reuse the existing partner-Stripe encryption service), so "Copy link"/re-send reproduce the *same* URL instead of minting a growing family of live credentials. Export policy: `excludedSensitive`.
+  - `public_link_expires_at` `timestamp` — persisted at mint (never recomputed from mutable due dates). Export policy: `included`.
+- **Verification path touches no key**: hash the presented token → indexed lookup → check expiry + status. Encryption-key loss degrades to "next copy-link mints a fresh URL" (old links keep working) — strictly better than the JWT kid-loss mode where verification itself dies.
+- **Multi-use.** No jti, no Redis. **Reset** = overwrite hash+ct+expiry (every previously issued link dies at once); no separate version column needed — replacing the hash *is* the revocation.
+- Minted lazily on first send/copy-link (concurrent-mint race handled with a conditional `WHERE public_link_token_hash IS NULL` claim + loser re-read, same shape as `resolveAcceptUrl`).
+- **Expiry: 12 months from mint, never earlier than due date + 180 days** **[quorum]** (2 years was too long for a bearer link to invoice PII; status-gating limits *payment*, not disclosure). Re-sending an invoice whose link expired mints a fresh link — mirroring the quote expired-identity path. The authenticated portal remains the long-term archive.
+- No new table → no RLS/cascade registrations; the three columns get export-policy rows as above.
+
+URL: `<portalBase>/invoice/<token>` (singular, mirroring `/quote/<token>`).
+
+## 4. Lifecycle → page state matrix
+
+| Invoice state | Link resolves? | Page shows |
+|---|---|---|
+| `draft` | No — generic "link isn't valid" | (drafts are MSP-internal; also unreachable: link minted at issue/send) |
+| `sent` | Yes | Full invoice + **Pay $X now** (X = `computeChargeNow` — deposit-aware) |
+| `sent` + deposit | Yes | "Due now: deposit $X of $Total" + **Pay deposit $X** |
+| `partially_paid` | Yes | Paid-to-date bar + **Pay balance $Y** |
+| `overdue` | Yes | Amber "was due <date>" banner + pay CTA (no penalty implied — none is modeled) |
+| `paid` | Yes | Green "Paid on <date>" state, **no** pay button, PDF download stays |
+| Payment just made, settle pending | Yes | "Confirming payment…" — suppress further checkout attempts **[quorum]** |
+| No Stripe key / zero balance | Yes | View + PDF with "Online payment isn't available — contact <MSP>" |
+| `void`, not replaced | Yes (token valid) | "This invoice is no longer due. Questions? <MSP contact>" — no amounts |
+| `void` + `replaced_by_invoice_id` | Yes | Same, plus "An updated invoice has been issued" (**no** auto-link to the replacement — its email carries its own token) **[quorum confirmed]** |
+| Bad/expired token, or reset | No | Generic "This link is invalid or has expired — contact <sender>" (no existence leak; mirror the quote page's no-login-redirect rule) |
+
+The page never dead-ends into a login. Paid and void states are deliberately *calm* — clicking an old link after paying must confirm, not alarm.
+
+## 5. Public page (`apps/portal/src/pages/invoice/[token].astro` + `PublicInvoiceView`)
+
+Mirror `PublicQuoteView`/`documentShell` composition — MSP-branded (`portalBranding` logo/color, partner document theme), platform-anonymous like the email envelope.
+
+**Layout, top to bottom:**
+1. Partner branding header.
+2. Status pill + invoice number + issue/due dates.
+3. **Amount panel** (the reason the customer is here — above the line items): Total / Paid to date / **Due now** (bold, deposit-aware), then the primary CTA **Pay $X now**. Secondary: **Download PDF**.
+4. Bill-to + seller blocks, customer-visible lines, subtotal/tax/total, notes/terms. Explicit public DTO — reuse `getCustomerInvoice`/`toCustomerInvoiceLine`, never a spread invoice row **[quorum]**. Bill-to name/address/tax-id are the customer's own data and stay; internal-only fields never cross.
+5. Footer: "Have a portal account? Sign in to see all your invoices" → `<portalBase>/login`. Present tense only — no signup pitch.
+
+**Pay flow (return URL redesign — [quorum: durable token must not reach Stripe logs]):**
+- `Pay now` → `POST /invoices/public/:token/pay` → redirect to Stripe hosted checkout.
+- `success_url` = `<portalBase>/invoice/return?session_id={CHECKOUT_SESSION_ID}` — **session id only, no invoice token**. `cancel_url` = same page without params… which needs the token; instead `cancel_url` = the return page with `?canceled=1&session_id=…` (resolved the same way).
+- The return page POSTs `/invoices/public/settle-return {sessionId}` → server validates the session against its own `invoice_stripe_payments` mapping (unguessable id, ours, recent), settles idempotently, and responds `{publicUrl}` (server decrypts `public_link_token_ct`) → `location.replace(publicUrl)` lands on the durable page in its new state. The URL handout is bounded: only for mappings pending or settled within the last hour.
+- Reconcile sweep remains the eventual backstop.
+
+**View stamping:** GET stamps `first_viewed_at`/`viewed_at` best-effort — but treat it as **"link fetched," not proof of human viewing** **[quorum]**: email scanners prefetch links. Stamp only on the full invoice JSON fetch, first-view only-if-null semantics unchanged from the portal path. (Same caveat exists for quotes today; parity, not regression.)
+
+## 6. API surface (`routes/invoicesPublic.ts`, mounted unauthenticated at `/invoices/public` before the auth-gated `/invoices` router — same ordering trick as `/quotes/public`)
+
+| Route | Behavior |
+|---|---|
+| `GET /:token` | Hash → indexed lookup; system DB context; expiry + non-draft check; return public DTO + branding + `chargeNow` |
+| `GET /:token/pdf` | Stream stored PDF (render-on-demand fallback), `safeContentDispositionFilename` hardening |
+| `POST /:token/pay` | Shared checkout primitive (see below) — deposit-first `computeChargeNow`, currency-aware minor units, idempotency key `inv_<id>_<minor>_<dep|bal>`, pending `invoice_stripe_payments` row, public return URLs. 409s: not payable, nothing to pay, Stripe not connected |
+| `POST /settle-return` | Session-id-keyed settle (no token needed): mapping must be ours + recent; idempotent; returns `{publicUrl}` |
+
+**Shared checkout primitive [quorum]:** extract the portal checkout handler + `invoiceCheckout.ts` into ONE service with configurable success/cancel URLs — this feature must not create a third copy of the deposit/currency/mapping/idempotency logic.
+
+**Hardening [quorum additions]:**
+- `Cache-Control: no-store` on HTML/JSON/PDF; `Referrer-Policy: no-referrer` and `X-Robots-Tag: noindex, nofollow, noarchive` on the public page + API responses.
+- Per-IP **and per-token** rate limits tighter than the 300/min global default, especially `/pay`, `/settle-return`, `/pdf` (Stripe mutations + render cost).
+- `/pay` requires a JSON body + custom header (same-origin fetch shape); CORS stays supplementary.
+- All reads/writes in `runOutsideDbContext(withSystemDbAccessContext(...))` with hash-scoped WHEREs, like `quotesPublic.ts`.
+- On **reset / void / successful payment**: best-effort expire this invoice's open Checkout sessions (old sessions must not remain payable against a revoked link) **[quorum]**.
+
+## 7. Email + PDF changes
+
+- `buildInvoiceTemplate`: CTA URL becomes the public link; label **"View & pay invoice"** (or "View invoice" when the partner has no Stripe key — known at send time). The muted portal line becomes "You can view this invoice and download a copy any time using this link."
+- Plain-text body carries the same URL.
+- Invoice PDF footer gains "Pay online: <public URL>" (quotes already print their accept link).
+- **Re-send now dispenses a credential.** Update the `resendInvoiceEmail` doc-comment rationale ("dispenses no credential" is obsolete). Paid-invoice re-send stays allowed — the link lands on the paid state.
+- Overdue reminder emails (future) must use the same link — consumer, not in scope.
+
+## 8. Quote-accept flow changes — **[quorum: durable page becomes canonical]**
+
+1. **Kill the one-shot `payUrl` UX.** After a successful accept, `location.replace(<invoice public URL>)` — the accept response returns `invoiceUrl` and the confirmation moment *is* the durable invoice page (which shows Pay now). No two competing links, nothing held only in React state. `payDeferred` copy survives only for the mint-failure edge.
+2. **Auto-email the invoice on acceptance** — post-commit, best-effort/swallowed like every accept side effect, to the **org billing contact + the quote's recorded recipients** (known addresses only — never the unverified signer-entered email **[quorum]**).
+   - **Default ON, partner-level toggle** — held against Codex's grandfather-off recommendation: with the canonical redirect the email is recovery/recordkeeping, and the feature exists because customers lose the moment. Toggle gate and read-back must share the same `!== false` expression (partners.settings sub-object replacement trap, #3597).
+
+## 9. MSP-side UX (`InvoiceActions` / `InvoiceDetail`)
+
+- **Copy invoice link** ("view & pay" in the tooltip — it is not purely a payment link once paid **[quorum]**): replaces the raw 24h Stripe URL as the headline copy action; `GET /invoices/:id/public-link` (mint-or-reproduce, `invoices:send` permission). The Stripe-direct link stays available under the payments section for charge-now workflows.
+- **Reset link** — overwrites hash/ct/expiry after a confirm dialog ("Anyone with the old link will lose access…"); requires `invoices:send`; **audited** **[quorum]**. Overflow menu; rare action.
+- Send/re-send composer: unchanged fields; helper text under To notes the email contains a no-login pay link.
+
+## 10. Companion pre-existing issues (found by quorum — fix alongside, not blockers)
+
+- **Settle vs reconcile-sweep race:** `stripeReconcile.ts` checks `invoicePaymentId` then inserts/updates without `FOR UPDATE`; settle and sweep can double-process a mapping. Add row locking / atomic claim.
+- **Refund semantics are undefined for the public page:** a full refund recomputes status and can flip the page payable again, and a refunded mapping needs a terminal-state guard before settle replay. Decide (reopened debt vs credit vs void) before GA of the link; until then the page simply reflects whatever status the engine computes.
+
+## 11. Explicitly out of scope
+
+- Portal-account auto-provisioning or invite-on-send.
+- Auto-linking a void invoice to its replacement's public page.
+- Overdue dunning emails (consumer of this link, own spec).
+- ACH/async payment methods (v1 stays card-only, matching the portal path).
+
+## 12. Test contract (minimum)
+
+- Token: mint → hash lookup roundtrip; copy-link byte-stability (decrypt path); decrypt-failure → fresh mint without killing verification; concurrent mint claims once.
+- Reset revocation: old token 401s the moment hash is replaced.
+- State matrix: each row of §4 against public GET + pay (409 semantics).
+- Deposit-then-balance through the *same* link (two checkout sessions, distinct idempotency keys).
+- `settle-return` with a foreign/stale `session_id` → 404/409, no `publicUrl` leak; idempotent replay.
+- Expiry: honored at read; expired-link re-send mints fresh.
+- Cross-tenant: hash lookup is global by construction — assert the resolved row's org scopes every subsequent read/write.
+- Headers: no-store/no-referrer/robots on every public response.
+- Integration: accept → redirect URL returned + auto-email dispatched with the public URL (toggle honored, `!== false` gate); email snapshot contains no portal `/invoices/<id>` URL.

--- a/docs/superpowers/specs/billing/2026-08-21-quote-decline-completion-design.md
+++ b/docs/superpowers/specs/billing/2026-08-21-quote-decline-completion-design.md
@@ -1,0 +1,53 @@
+# Quote Decline — Completing the Loop
+
+**Date:** 2026-08-21
+**Status:** Draft
+**Sibling spec:** `2026-08-21-public-invoice-pay-link-design.md` (independent work — separate PR)
+
+## Problem
+
+Declining a quote works mechanically (public `POST /quotes/public/:token/decline` — race-safe, single-use, reason captured; `declineQuoteByActor` for MSP-side marking) but the loop never closes:
+
+1. **The MSP is never notified.** The decline handler writes the row and returns. The reserved `quote-events` bus only defines `quote.viewed`, and nothing consumes it. A tech finds out a proposal died only by opening it.
+2. **`decline_reason` is write-only.** Captured from the customer, stored on the row, displayed nowhere — not in `QuoteDetail`, not in any email. The single most actionable piece of sales feedback is discarded.
+3. **The customer decline UX is `window.prompt()`** (`PublicQuoteView.tsx` `decline()`): a native browser prompt — single-line, unstyled, untranslatable, jarring against the branded proposal page. Reads as broken.
+4. **No visible declined → revised path.** Declined is a settled state (re-send correctly blocked by `assertLinkableQuote`); the recovery path is `cloneQuote` ("Duplicate"), but nothing on a declined quote points at it.
+
+## Changes
+
+### A. Notify the MSP on decline (and on accept, same mechanism)
+
+Post-commit, fire-and-forget email from the decline handler (both public and portal paths), mirroring every other lifecycle email (swallowed failures, never blocks the customer response):
+
+- **To:** the quote's `created_by` user's email; fallback partner `billing_email`.
+- **Subject:** `Quote Q-2026-0042 declined — <org name>`
+- **Body:** who (signer name if the portal path knows it, else the org), when, the **verbatim reason** (escaped, newlines preserved — same treatment as composer notes), and a button to the quote in the web app (`<appBase>/billing/quotes#<id>` per the hash-state convention).
+- Accept gets the same treatment (`Quote accepted — invoice INV-xxxx issued`) — today acceptance is also silent; the MSP notices when an invoice appears. Small, same wiring, do it in the same PR.
+- Extend the `QuoteEvent` union with `quote.declined` / `quote.accepted` and emit them too — keeps the reserved bus honest for future webhooks; the email does not wait on a worker.
+
+Explicitly **not** building: per-tech notification preferences, in-app notification center entries, digest batching. One email to the sender is the 90% win.
+
+### B. Surface the reason in the MSP UI
+
+- `QuoteDetail` lifecycle strip: the Declined stage is already rendered (danger token). Underneath it, when `decline_reason` is non-empty, render a quoted block: *"Customer's note: '<reason>'"* — same muted style as the recipients line.
+- Declined-state banner at the top of the detail (see D) repeats the reason so it isn't buried.
+- No list-view change (status pill already shows Declined).
+
+### C. Replace `window.prompt` with an inline decline flow (public page + portal)
+
+- "Decline" opens an inline panel (not a browser prompt, not a modal — matches the accept panel's inline signature pattern): optional multiline textarea ("Anything you'd like us to know? (optional)", `maxLength` matching the API schema), **Confirm decline** + **Cancel**.
+- On success: the existing declined confirmation state, plus *"Thanks — <partner name> has been notified."* (true once A ships).
+- Same replacement in the portal's authenticated `QuoteDetailView` if it shares the prompt pattern.
+- i18n: all new strings through the billing namespace across all 8 locales (translation-coverage test will enforce).
+
+### D. Declined → revise affordance
+
+- On a declined quote, `QuoteDetail` shows a banner: **Declined <date>** — *"<reason>"* — with a **Duplicate & revise** button that opens the existing clone dialog (title prefilled `<title> (revised)`).
+- No new API. No un-decline/reopen state transition — the audit trail of the declined quote stays intact; revision is a new document. If a partner asks for true reopen later, that's its own decision.
+
+## Test contract
+
+- Decline (public + portal) dispatches the notification email — recipient resolution (creator → partner fallback), reason escaping (HTML + newlines), and the swallow-on-failure guarantee (customer still gets 200).
+- `quote.declined` / `quote.accepted` events enqueued post-commit only.
+- Web: reason renders when present, absent block when null; clone dialog opens prefilled from the banner.
+- Public page: decline panel submits reason verbatim; empty reason → `reason: undefined` (not `''`).


### PR DESCRIPTION
## Summary
- New \`POST /invoices/:id/resend\` (re-email an issued invoice without restamping \`sent_at\` or re-emitting lifecycle events; draft/void refused) and composer support on \`POST /invoices/:id/send\`
- Shared \`sendComposer\` zod schema so the quote and invoice composers cannot drift; strict body parsing so a mis-keyed field 400s instead of silently dropping a note/recipient
- \`InvoiceSendComposer\` dialog (To/CC/subject/note/attach-PDF) mirroring the quote composer; billing-contact prefill; i18n across all 8 locales
- Email template: personal note + partner signature blocks, honest "PDF attached" line when the composer drops the attachment

Wave 1 of #3784 — Closes #3785

## Test plan
- \`invoiceResend.test.ts\`, \`invoices.test.ts\`, \`email.test.ts\`, \`quotes/lifecycle.test.ts\` (104 tests)
- Web: \`InvoiceActions.resend.test.tsx\`, \`InvoiceDetail.deposit.test.tsx\`, translation coverage (45 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)