### PR TITLE
fix(mobile): throttle truncation reports to a state change (#3783)

### DIFF
--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -14,6 +14,7 @@ import {
 } from '../store/authSlice';
 import { getStoredToken, getStoredUser, clearAuthData, SecureWipeError } from '../services/auth';
 import { getCurrentUser, onDeviceBlocked } from '../services/api';
+import { resetTruncationTracking } from '../services/truncationReporting';
 import { spacing, type } from '../theme';
 import { identify as analyticsIdentify, reset as analyticsReset } from '../lib/analytics';
 import {
@@ -91,6 +92,11 @@ export function RootNavigator() {
     } else {
       Sentry.setUser(null);
       analyticsReset();
+      // Same reason, one layer down: the truncation tracker is module scope and
+      // outlives the session, so a previous account's "already reported" state
+      // would silently swallow the FIRST report for the next one — and the
+      // login screen can point at a different server entirely.
+      resetTruncationTracking();
     }
   }, [user]);
 

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/react-native';
 import { getServerUrl } from './serverConfig';
 import { getOrCreateInstallationId } from './installationId';
 import { fetchWithTimeout } from './fetchWithTimeout';
+import { currentTruncationEpoch, trackTruncation } from './truncationReporting';
 import {
   applyCsrfSignal,
   forgetCsrfToken,
@@ -484,15 +485,22 @@ const ALERT_PAGE_LIMIT = 100;
 export async function getAlertsPaged(
   status: 'active' | 'all' = 'active'
 ): Promise<PagedResult<Alert>> {
+  // Captured BEFORE the request: a result that arrives after a sign-out must
+  // not repopulate the tracker for the next session.
+  const epoch = currentTruncationEpoch();
   const { rows, total, truncated } = await fetchPage<MobileAlertRecord>((params) => {
     if (status === 'active') params.set('status', 'active');
     return `/alerts/inbox?${params.toString()}`;
   }, ALERT_PAGE_LIMIT);
 
-  if (truncated) {
+  // Change-only, as above (#3783). Keyed per status: the active inbox and the
+  // full history are different sets, and one being partial says nothing about
+  // the other.
+  const alertTruncation = trackTruncation(`alert-inbox:${status}`, total, rows.length, epoch);
+  if (alertTruncation) {
     Sentry.captureMessage('alert inbox is showing a partial set', {
       level: 'warning',
-      tags: { area: 'alert-inbox' },
+      tags: { area: 'alert-inbox', truncation: alertTruncation },
       extra: { returned: rows.length, total, status, pageLimit: ALERT_PAGE_LIMIT },
     });
   }
@@ -640,15 +648,33 @@ async function fetchPage<TRow>(
  * machines sat below the cut rendered as empty.
  */
 export async function getDevicesPaged(orgId?: string | null): Promise<PagedResult<Device>> {
+  // See getAlertsPaged: captured before the request, checked after it resolves.
+  const epoch = currentTruncationEpoch();
   const { rows, total, truncated } = await fetchPage<MobileDeviceRecord>((params) => {
     if (orgId) params.set('orgId', orgId);
     return `/devices?${params.toString()}`;
   }, DEVICE_PAGE_LIMIT);
 
-  if (truncated) {
+  // Only on a CHANGE of truncation state: any tenant above the page limit is
+  // permanently truncated, and this runs on mount, tab focus, pull-to-refresh,
+  // push delivery and WS updates, so reporting every time buried the signal
+  // under its own volume (#3783).
+  // Keyed by orgId because it is sent to the SERVER above: a scoped fetch and
+  // the unscoped fleet are different result sets, and one being partial says
+  // nothing about the other. Sharing one key broke both ways — an org's first
+  // partial was swallowed by the fleet's state, and a small complete org reset
+  // the key so the unchanged fleet reported again on every return to Systems,
+  // rebuilding the flood this fixes.
+  const deviceTruncation = trackTruncation(
+    `device-list:${orgId ?? 'all'}`,
+    total,
+    rows.length,
+    epoch
+  );
+  if (deviceTruncation) {
     Sentry.captureMessage('device list is showing a partial fleet', {
       level: 'warning',
-      tags: { area: 'device-list' },
+      tags: { area: 'device-list', truncation: deviceTruncation },
       extra: { returned: rows.length, total, pageLimit: DEVICE_PAGE_LIMIT },
     });
   }

--- a/apps/mobile/src/services/listPaging.test.ts
+++ b/apps/mobile/src/services/listPaging.test.ts
@@ -19,6 +19,7 @@ vi.mock('./fetchWithTimeout', () => ({
 }));
 
 import { getDevices, getDevicesPaged, getAlertsPaged } from './api';
+import { resetTruncationTracking } from './truncationReporting';
 
 const row = (id: string) => ({ id, hostname: id, status: 'online', orgId: 'o1' });
 const rows = (n: number) => Array.from({ length: n }, (_, i) => row(`d${i}`));
@@ -46,6 +47,12 @@ function page(data: unknown[], total: number | null) {
 beforeEach(() => {
   fetchWithTimeout.mockReset();
   captureMessage.mockReset();
+  // Truncation reporting is throttled to a state CHANGE (#3783), and that state
+  // is module scope so it survives between cases. Without this reset the second
+  // case to fetch the same list sees "already reported" and stays silent, so an
+  // assertion that the warning fires would fail for a reason that has nothing
+  // to do with what it is testing.
+  resetTruncationTracking();
 });
 
 describe('device list paging', () => {

--- a/apps/mobile/src/services/truncationReporting.test.ts
+++ b/apps/mobile/src/services/truncationReporting.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  classifyTruncation,
+  currentTruncationEpoch,
+  resetTruncationTracking,
+  shouldReportTruncation,
+  trackTruncation,
+} from './truncationReporting';
+
+/** Most cases track a result from the CURRENT session. */
+const now = () => currentTruncationEpoch();
+
+describe('classifyTruncation', () => {
+  it('is complete when everything the server counted came back', () => {
+    expect(classifyTruncation(42, 42)).toBe('complete');
+  });
+
+  it('is partial when the server counted more than it returned', () => {
+    expect(classifyTruncation(216, 100)).toBe('partial');
+  });
+
+  it('is unknown-total when the server reported no count', () => {
+    // Not "complete": a caller cannot distinguish N items from the first N of
+    // more, which is the whole point of #3753.
+    expect(classifyTruncation(null, 100)).toBe('unknown-total');
+    expect(classifyTruncation(null, 0)).toBe('unknown-total');
+  });
+
+  it('does not call an over-long page partial', () => {
+    // Defensive: a server returning more than it counted is odd, but it is not
+    // the "showing a sample as the whole set" failure this reports.
+    expect(classifyTruncation(10, 12)).toBe('complete');
+  });
+});
+
+describe('shouldReportTruncation', () => {
+  it('reports the first time a list is partial', () => {
+    expect(shouldReportTruncation(undefined, 'partial')).toBe(true);
+  });
+
+  it('stays quiet while it remains partial', () => {
+    // The bug: a 216-device tenant is permanently partial, so every mount, tab
+    // focus, pull-to-refresh, push and WS update re-reported the same fact.
+    expect(shouldReportTruncation('partial', 'partial')).toBe(false);
+  });
+
+  it('never reports completeness', () => {
+    expect(shouldReportTruncation('partial', 'complete')).toBe(false);
+    expect(shouldReportTruncation(undefined, 'complete')).toBe(false);
+  });
+
+  it('reports again after recovering and re-truncating', () => {
+    expect(shouldReportTruncation('complete', 'partial')).toBe(true);
+  });
+
+  it('treats unknown-total as its own state, so the transition is visible', () => {
+    expect(shouldReportTruncation('partial', 'unknown-total')).toBe(true);
+    expect(shouldReportTruncation('unknown-total', 'partial')).toBe(true);
+  });
+
+  it('reports EVERY unknown-total, unlike partial', () => {
+    // Asymmetric on purpose. A repeated `partial` says nothing new; a repeated
+    // "the server sent no count" does — whether it is ongoing, how many
+    // tenants/servers it spans, whether it came back after an account change —
+    // and it survives the first event being sampled or dropped.
+    expect(shouldReportTruncation('unknown-total', 'unknown-total')).toBe(true);
+  });
+});
+
+describe('trackTruncation', () => {
+  beforeEach(() => resetTruncationTracking());
+
+  it('reports once, then goes quiet for the steady state', () => {
+    expect(trackTruncation('device-list', 216, 100, now())).toBe('partial');
+    expect(trackTruncation('device-list', 216, 100, now())).toBeNull();
+    expect(trackTruncation('device-list', 216, 100, now())).toBeNull();
+  });
+
+  it('keeps lists independent', () => {
+    // A partial device list must not silence a newly partial alert inbox.
+    expect(trackTruncation('device-list', 216, 100, now())).toBe('partial');
+    expect(trackTruncation('alert-inbox', 500, 100, now())).toBe('partial');
+    expect(trackTruncation('device-list', 216, 100, now())).toBeNull();
+  });
+
+  it('re-reports when the state changes back and forth', () => {
+    expect(trackTruncation('device-list', 216, 100, now())).toBe('partial');
+    expect(trackTruncation('device-list', 90, 90, now())).toBeNull(); // complete
+    expect(trackTruncation('device-list', 216, 100, now())).toBe('partial');
+  });
+
+  it('keeps surfacing a server that reports no count', () => {
+    expect(trackTruncation('alert-inbox', 500, 100, now())).toBe('partial');
+    expect(trackTruncation('alert-inbox', null, 100, now())).toBe('unknown-total');
+    // Still reported: an ongoing missing count is a live defect, not noise.
+    expect(trackTruncation('alert-inbox', null, 100, now())).toBe('unknown-total');
+  });
+
+  it('does not let one org silence another, or a small org re-arm the fleet', () => {
+    // orgId is sent to the server, so these are different result sets. Sharing
+    // one key broke both ways: the fleet swallowed an org's first report, and a
+    // complete org reset the key so the unchanged fleet reported again on every
+    // return to Systems.
+    expect(trackTruncation('device-list:all', 216, 100, now())).toBe('partial');
+    expect(trackTruncation('device-list:org-a', 400, 100, now())).toBe('partial');
+    expect(trackTruncation('device-list:org-small', 12, 12, now())).toBeNull();
+    expect(trackTruncation('device-list:all', 216, 100, now())).toBeNull();
+  });
+
+  it('reset clears the state so a new session reports again', () => {
+    expect(trackTruncation('device-list', 216, 100, now())).toBe('partial');
+    resetTruncationTracking();
+    expect(trackTruncation('device-list', 216, 100, now())).toBe('partial');
+  });
+
+  it('ignores a result from a session that has already been torn down', () => {
+    // Clearing on sign-out is not enough on its own: a request issued by the
+    // OLD session can resolve AFTER the reset and write its state back, which
+    // then suppresses the first report of the next user — possibly on a
+    // different server. The epoch captured at request time closes that window.
+    const oldSession = now();
+    expect(trackTruncation('device-list:all', 216, 100, oldSession)).toBe('partial');
+
+    resetTruncationTracking(); // sign-out
+
+    // Old in-flight request lands now. It must neither report nor record.
+    expect(trackTruncation('device-list:all', 216, 100, oldSession)).toBeNull();
+
+    // The next session's first fetch is therefore still the first report.
+    expect(trackTruncation('device-list:all', 216, 100, now())).toBe('partial');
+  });
+
+  it('retains only currently-partial keys, so browsing many orgs cannot grow forever', () => {
+    // complete needs no suppression, and unknown-total reports every time, so
+    // storing either would just accumulate a UUID per org for the life of the
+    // runtime. Proven by behaviour: a completed org forgets its key, so the
+    // next partial on that key reports as a first sighting.
+    expect(trackTruncation('device-list:org-a', 400, 100, now())).toBe('partial');
+    expect(trackTruncation('device-list:org-a', 50, 50, now())).toBeNull(); // complete -> forgotten
+    expect(trackTruncation('device-list:org-a', 400, 100, now())).toBe('partial');
+  });
+});

--- a/apps/mobile/src/services/truncationReporting.ts
+++ b/apps/mobile/src/services/truncationReporting.ts
@@ -1,0 +1,117 @@
+/**
+ * Throttle the "this list is partial" reports to state CHANGES.
+ *
+ * `getDevicesPaged` / `getAlertsPaged` report truncation to Sentry, and
+ * truncation is true for any tenant above the 100-row page limit — the ordinary
+ * steady state for a real fleet, not an anomaly. Those fetches run on mount, tab
+ * focus, pull-to-refresh, push delivery and WS updates, so a 216-device tenant
+ * emitted one on essentially every interaction, indefinitely (#3783).
+ *
+ * The reports are TRUE, which is what makes them awkward: they aren't false
+ * positives to delete, they're correct statements at a volume that destroys
+ * their value — crowding out the case actually worth seeing, a server that
+ * reported no count at all.
+ *
+ * So: report on entry to a non-complete state, then stay quiet until the state
+ * changes. Deliberately module scope and deliberately not persisted — surviving
+ * a cold start would mean a genuinely new session never reports.
+ */
+
+export type TruncationState =
+  /** The server's count matched what came back. Nothing to say. */
+  | 'complete'
+  /** The server counted more rows than it returned. Expected above the limit. */
+  | 'partial'
+  /** The server reported NO count, so completeness is unknowable. Diagnostic. */
+  | 'unknown-total';
+
+export function classifyTruncation(total: number | null, returned: number): TruncationState {
+  if (total === null) return 'unknown-total';
+  return returned < total ? 'partial' : 'complete';
+}
+
+/**
+ * Report on a CHANGE into `partial`, and EVERY TIME for `unknown-total`.
+ *
+ * The asymmetry is deliberate (#3783). `partial` is the ordinary steady state
+ * of any tenant above the page limit, so repeating it says nothing new.
+ * `unknown-total` means the server reported no count at all — rare, and each
+ * occurrence carries information a first report cannot: whether it is still
+ * happening, how many tenants or servers it spans, whether it returned after an
+ * account change, and it survives the first event being sampled or dropped.
+ * Throttling it would trade a real diagnostic for volume that was never the
+ * problem.
+ */
+export function shouldReportTruncation(
+  previous: TruncationState | undefined,
+  next: TruncationState
+): boolean {
+  if (next === 'complete') return false;
+  if (next === 'unknown-total') return true;
+  return previous !== next;
+}
+
+/**
+ * Only `partial` keys are retained.
+ *
+ * `complete` needs no suppression and `unknown-total` reports every time, so
+ * storing either would just accumulate — a partner browsing thousands of orgs
+ * would retain a UUID per org for the life of the runtime. Holding only what
+ * actually suppresses something bounds this by the number of CURRENTLY partial
+ * lists.
+ */
+const partialKeys = new Set<string>();
+
+/** Bumped by {@link resetTruncationTracking}; see the epoch note below. */
+let epoch = 0;
+
+/** Capture BEFORE issuing the request whose result you will track. */
+export function currentTruncationEpoch(): number {
+  return epoch;
+}
+
+/**
+ * Stateful wrapper over the pure functions above.
+ *
+ * Returns the state when it should be reported, or `null` to stay quiet. The
+ * caller owns what a report looks like, so this module stays free of Sentry.
+ *
+ * `startedAtEpoch` closes a race that clearing on sign-out alone does not: a
+ * request issued by the OLD session can resolve after the reset and write its
+ * state back, which would then suppress the first report of the NEXT session —
+ * possibly a different user on a different server. A result from a superseded
+ * session is dropped rather than recorded.
+ */
+export function trackTruncation(
+  key: string,
+  total: number | null,
+  returned: number,
+  startedAtEpoch: number
+): TruncationState | null {
+  const next = classifyTruncation(total, returned);
+  const report = shouldReportTruncation(partialKeys.has(key) ? 'partial' : undefined, next);
+
+  // Stale session: report nothing and, crucially, record nothing.
+  if (startedAtEpoch !== epoch) return null;
+
+  if (next === 'partial') partialKeys.add(key);
+  else partialKeys.delete(key);
+
+  return report ? next : null;
+}
+
+/**
+ * Clear all tracking.
+ *
+ * MUST be called on sign-out. The Map lives for the life of the JS runtime,
+ * which outlives a session: without this, user A's `partial` would suppress the
+ * FIRST report for user B — possibly on a different server, since the login
+ * screen can change it — and that report would simply never exist. Also the
+ * test seam, since module state would otherwise leak between cases.
+ */
+export function resetTruncationTracking(): void {
+  partialKeys.clear();
+  // Invalidate anything already in flight, so a request issued by the session
+  // being torn down cannot repopulate what we just cleared.
+  epoch += 1;
+}


### PR DESCRIPTION
Fixes #3783.

`truncated` is true for any tenant above the 100-row page limit, and `fetchAll` runs on mount, tab focus, pull-to-refresh, push delivery and WS updates — so a 216-device tenant emitted one of these on essentially every interaction, indefinitely.

As you said, the awkward part is that they're *true*. So this doesn't delete them, it reports on **entry** to a non-complete state.

**`unknown-total` still reports every time, as you asked.** I initially throttled it too, on the theory that if it's rare the behaviours are identical and if it isn't rare "always" rebuilds the same flood. I backed that out: a repeated missing count carries information a first report can't — whether it's ongoing, how many tenants or servers it spans, whether it came back after an account change — and it survives the first event being sampled or dropped. Your call was right.

**Three things the naive version got wrong.** All three suppress a report that should fire, which is the same class of bug as the noise:

- **`device-list` ignored `orgId`** even though it's sent to the server, so a scoped fetch and the unscoped fleet shared one state. It broke both ways: an org's first partial was swallowed by the fleet's state, and a small *complete* org reset the key so the unchanged fleet reported again on every return to Systems — rebuilding the flood. Now keyed `device-list:<orgId|all>`, which is what the alert inbox was already doing with `status`.

- **The tracker outlives a session.** It's module scope, so user A's `partial` would suppress the *first* report for user B — possibly on a different server, since the login screen can change it. Now reset alongside `Sentry.setUser(null)` / `analyticsReset()` in `RootNavigator`.

- **Clearing on sign-out isn't sufficient on its own.** A request issued by the old session can resolve *after* the reset and write its state back, re-creating the suppression. Each caller captures an epoch before its request; a result whose epoch has been superseded neither reports nor records. There's a test for exactly that sequence.

Only currently-partial keys are retained (`complete` needs no suppression, `unknown-total` always reports), so browsing many orgs can't grow the map without bound.

`listPaging.test.ts` needed a `resetTruncationTracking()` in `beforeEach` — the tracker's state is module scope, so without it the second case to fetch the same list sees "already reported" and goes quiet. Worth knowing that's now a property of these tests.

**Gate**, matching the `test-mobile` job: `tsc --noEmit` clean, full `vitest run` 44 files / 546 passed / 3 skipped. `pnpm audit` unchanged from main (5 pre-existing: 1 low, 2 moderate, 2 high). No Go, dependency or workflow changes, so those gates aren't affected by this diff. Each new assertion was control-tested by reverting the fix and confirming the test fails.
