### PR TITLE
ci(release): keep package-windows-updater alive when the non-selected signing provider job is skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1879,8 +1879,15 @@ jobs:
 
   package-windows-updater:
     name: Package Windows Updater Bundle
+    # `!cancelled()` + an explicit result check, not the implicit `success()`:
+    # exactly one of sign-windows-tauri-{azure,sslcom} is always skipped (the
+    # non-selected provider), and the implicit success() is evaluated over the
+    # whole transitive needs chain, so without this the bundle job is skipped
+    # and release-integrity-gate fails closed on it (v0.107.0-rc.1).
     if: >-
-      vars.ENABLE_WINDOWS_SIGNING == 'true'
+      !cancelled()
+      && needs.sign-windows-tauri.result == 'success'
+      && vars.ENABLE_WINDOWS_SIGNING == 'true'
       && github.ref_type == 'tag'
       && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `package-windows-updater` used the implicit `success()` condition. After #3781 split Windows signing into `sign-windows-tauri-{azure,sslcom}`, exactly one of those is always `skipped`, and GitHub evaluates the implicit `success()` over the whole transitive `needs` chain — so the bundle job was skipped and `release-integrity-gate` failed closed on it.
- Seen on `v0.107.0-rc.1` (run 32543776398): SSL.com signing on `signing-prerelease` **succeeded**; the gate then failed with `package-windows-updater must succeed for tag release v0.107.0-rc.1; got 'skipped'`.
- Fix: gate on `!cancelled() && needs.sign-windows-tauri.result == 'success'` like every other job downstream of the convergence gate. Audited all 13 jobs downstream of the split — this was the only one without a status function.

## Verification
- `node .github/scripts/check-workflow-security.mjs` clean
- `node --test .github/scripts/check-workflow-security.test.mjs` green
- actionlint: only pre-existing SC2046 warnings at untouched lines 661/925

Follow-up: retag `v0.107.0-rc.2` off the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)