### PR TITLE
feat(api,web): activate secret tenant variables in scripts via tenantSecret parameters (#3409 PR4c-2)

### DIFF
--- a/apps/api/src/__tests__/integration/scriptSecretDelivery.integration.test.ts
+++ b/apps/api/src/__tests__/integration/scriptSecretDelivery.integration.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Secret delivery end to end against real Postgres (#3409 PR4c-2).
+ *
+ * The unit suites (`services/scriptSecretDelivery.test.ts`,
+ * `services/scriptDispatch.test.ts`, `services/sourcedParameters.test.ts`)
+ * all mock `../db`, so every one of them asserts the SHAPE of a write that
+ * never happens. The properties this feature actually exists for only mean
+ * something once a row is really stored and read back:
+ *
+ *   1. ENQUEUE — a `tenantSecret` parameter is resolved, sealed, and STORED
+ *      as an AAD-bound `secretEnvEnvelope`; neither the persisted command row
+ *      nor the persisted execution row contains the plaintext anywhere, and
+ *      the envelope opens — with the stored row's own id as AAD — back to the
+ *      exact value the encrypted `tenant_variables` row holds. That round
+ *      trip crosses four independent encodings (tenant-variable AAD, jsonb
+ *      storage, envelope AAD, canonical envelope JSON); a mocked db proves
+ *      none of them agree.
+ *   2. CLAIM — after a real agent downgrade (`script_secret_env_version` back
+ *      to 0), the real claim batch + `decryptClaimedCommandsForDelivery`
+ *      withholds the command AND drives both it and its linked execution row
+ *      terminal, with the payload erased. The `status = 'sent'` guard on that
+ *      terminal UPDATE only has meaning against a row the claim actually
+ *      flipped to `sent`.
+ *   3-4. The two enqueue refusals that must leave NO orphan rows behind
+ *      (an incapable agent, and a user-context run) — "no orphan" is a
+ *      statement about the database, so it is asserted by counting rows.
+ *
+ * Fixture note: the `tenant_variables` row is sealed through the service's own
+ * `encryptTenantVariableValue` (as `tenantVariableResolution.integration.
+ * test.ts` does), because the ciphertext AAD binds the row id — a plaintext
+ * literal would fail to decrypt, drop out of the resolved scope, and turn
+ * every assertion below into a vacuous "unresolved parameter" failure.
+ *
+ * The device snapshot handed to `dispatchScriptToDevice` deliberately carries
+ * NO `agentId`: the immediate-send path would otherwise claim the command
+ * itself, and test 2 needs the row to still be `pending` for the real claim
+ * batch to take.
+ *
+ * Lives under `src/__tests__/integration/`, so the config's
+ * `src/__tests__/integration/**` include glob already covers it.
+ */
+import './setup';
+import { randomUUID } from 'crypto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import type { ScriptParameterDefinition } from '@breeze/shared';
+
+import { withSystemDbAccessContext } from '../../db';
+import { getTestDb } from './setup';
+import { deviceCommands, devices, scriptExecutions, scripts, tenantVariables } from '../../db/schema';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { encryptTenantVariableValue } from '../../services/tenantVariables';
+import { loadTenantVariableScope } from '../../services/tenantVariableResolution';
+import { dispatchScriptToDevice, type DispatchScriptInput } from '../../services/scriptDispatch';
+import { claimPendingCommandsForDevice } from '../../services/commandDispatch';
+import { decryptClaimedCommandsForDelivery } from '../../services/commandDelivery';
+import { openSecretEnv } from '../../services/scriptSecretEnvelope';
+import { AGENT_UPGRADE_REQUIRED_MESSAGE } from '../../services/scriptSecretDelivery';
+
+const SECRET_KEY = 'vendor_token';
+/** Long enough to clear MIN_SECRET_TENANT_VARIABLE_VALUE_LENGTH and distinctive
+ * enough that a `JSON.stringify(row)` substring search is meaningful. */
+const SECRET_VALUE = 'sk-live-integration-9f3a2b7c4d1e';
+const PARAM_NAME = 'api_token';
+
+const SECRET_PARAMETERS: ScriptParameterDefinition[] = [
+  { name: PARAM_NAME, type: 'string', required: true, source: 'tenantSecret', variableKey: SECRET_KEY },
+];
+
+interface Scenario {
+  orgId: string;
+  deviceId: string;
+  variableId: string;
+  variableVersion: number;
+  script: typeof scripts.$inferSelect;
+  /**
+   * The snapshot dispatch receives. `agentId` is nulled on purpose (see the
+   * file header) — the column itself is NOT NULL, so this is a property of the
+   * caller's snapshot, not of the stored row.
+   */
+  deviceSnapshot: DispatchScriptInput['device'];
+}
+
+async function seedScenario(): Promise<Scenario> {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+
+  const [device] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId: org.id,
+      siteId: site!.id,
+      agentId: randomUUID(),
+      hostname: `secret-delivery-${randomUUID().slice(0, 8)}`,
+      osType: 'linux',
+      osVersion: '24.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+      // The PR4b capability floor. Test 2 walks it back down to 0.
+      scriptSecretEnvVersion: 1,
+    })
+    .returning();
+
+  const variableId = randomUUID();
+  const [variable] = await getTestDb()
+    .insert(tenantVariables)
+    .values({
+      id: variableId,
+      orgId: org.id,
+      key: SECRET_KEY,
+      value: encryptTenantVariableValue(variableId, SECRET_VALUE),
+      isSecret: true,
+    })
+    .returning();
+
+  const [script] = await getTestDb()
+    .insert(scripts)
+    .values({
+      orgId: org.id,
+      name: `secret-delivery-${randomUUID().slice(0, 8)}`,
+      osTypes: ['linux'],
+      language: 'bash',
+      content: '#!/bin/bash\ncurl -H "Authorization: Bearer $BREEZE_VAR_API_TOKEN" https://vendor.example.test',
+      parameters: SECRET_PARAMETERS,
+      runAs: 'system',
+      timeoutSeconds: 300,
+    })
+    .returning();
+
+  return {
+    orgId: org.id,
+    deviceId: device!.id,
+    variableId: variable!.id,
+    variableVersion: variable!.version,
+    script: script!,
+    deviceSnapshot: {
+      id: device!.id,
+      orgId: device!.orgId,
+      osType: device!.osType,
+      status: device!.status,
+      // Forces the "queued for later" path — no immediate claim/send.
+      agentId: null as unknown as string,
+      hostname: device!.hostname,
+      siteId: device!.siteId,
+      customFields: device!.customFields,
+    },
+  };
+}
+
+async function dispatch(
+  scn: Scenario,
+  overrides: Partial<DispatchScriptInput> = {},
+): Promise<Awaited<ReturnType<typeof dispatchScriptToDevice>>> {
+  const variableScope = await loadTenantVariableScope([scn.orgId]);
+  return withSystemDbAccessContext(() =>
+    dispatchScriptToDevice({
+      device: scn.deviceSnapshot,
+      source: { kind: 'saved', script: scn.script },
+      variableScope,
+      triggerType: 'manual',
+      ...overrides,
+    }),
+  );
+}
+
+async function commandsForDevice(deviceId: string) {
+  return getTestDb().select().from(deviceCommands).where(eq(deviceCommands.deviceId, deviceId));
+}
+
+async function executionsForDevice(deviceId: string) {
+  return getTestDb().select().from(scriptExecutions).where(eq(scriptExecutions.deviceId, deviceId));
+}
+
+async function setSecretEnvVersion(deviceId: string, version: number): Promise<void> {
+  await getTestDb().update(devices).set({ scriptSecretEnvVersion: version }).where(eq(devices.id, deviceId));
+}
+
+describe('script secret delivery (integration)', () => {
+  let scn: Scenario;
+
+  beforeEach(async () => {
+    scn = await seedScenario();
+  });
+
+  it('1. seals the resolved secret into the stored command and never persists the plaintext', async () => {
+    const result = await dispatch(scn);
+    expect(result).toMatchObject({ ok: true, deliveryOutcome: 'no_agent' });
+    if (!result.ok) throw new Error(result.error);
+
+    const [commandRow] = await commandsForDevice(scn.deviceId);
+    expect(commandRow).toBeDefined();
+    expect(commandRow!.id).toBe(result.commandId);
+
+    const payload = commandRow!.payload as Record<string, unknown>;
+    expect(typeof payload.secretEnvEnvelope).toBe('string');
+    expect(payload.secretEnvEnvelope as string).toMatch(/^enc:v3:/);
+    // The wire-only field name must never survive to storage: seeing BOTH
+    // would mean the seal ran but failed to consume its input.
+    expect(Object.keys(payload)).not.toContain('secretEnv');
+    // The agent substitutes every entry of `parameters` into the script text,
+    // so the secret must not be there either.
+    expect(payload.parameters).toEqual({});
+
+    const [executionRow] = await executionsForDevice(scn.deviceId);
+    expect(executionRow).toBeDefined();
+    expect(JSON.stringify(commandRow)).not.toContain(SECRET_VALUE);
+    expect(JSON.stringify(executionRow)).not.toContain(SECRET_VALUE);
+
+    // The whole point: the STORED envelope, opened with the STORED row's own
+    // AAD, is the value the encrypted tenant_variables row holds.
+    expect(
+      openSecretEnv(payload.secretEnvEnvelope as string, {
+        commandId: commandRow!.id,
+        deviceId: scn.deviceId,
+      }),
+    ).toEqual({ [PARAM_NAME]: SECRET_VALUE });
+
+    // History records the binding's IDENTITY and nothing else.
+    const bindings = (executionRow!.parameters as Record<string, unknown>).$bindings;
+    expect(bindings).toEqual([
+      {
+        key: PARAM_NAME,
+        source: 'tenantSecret',
+        variableId: scn.variableId,
+        ownerScope: 'organization',
+        version: scn.variableVersion,
+      },
+    ]);
+  });
+
+  it('2. fails an already-enqueued secret command when the agent is downgraded before claim', async () => {
+    const result = await dispatch(scn);
+    if (!result.ok) throw new Error(result.error);
+
+    // The agent restarts on an older build: the heartbeat writes this column
+    // non-sticky every beat, so the capability really can drop after enqueue.
+    await setSecretEnvVersion(scn.deviceId, 0);
+
+    const deliverable = await withSystemDbAccessContext(async () => {
+      const claimed = await claimPendingCommandsForDevice(scn.deviceId);
+      expect(claimed).toHaveLength(1);
+      return decryptClaimedCommandsForDelivery(
+        claimed.map((cmd) => ({
+          id: cmd.id,
+          type: cmd.type,
+          deviceId: cmd.deviceId,
+          payload: cmd.payload,
+          executedAt: cmd.executedAt,
+        })),
+      );
+    });
+
+    // Nothing reaches the agent...
+    expect(deliverable).toEqual([]);
+
+    // ...and the command is TERMINAL, not released back to pending (an
+    // incapable agent would only re-claim it), with the envelope erased.
+    const [commandRow] = await commandsForDevice(scn.deviceId);
+    expect(commandRow!.status).toBe('failed');
+    expect(commandRow!.completedAt).toBeInstanceOf(Date);
+    expect(commandRow!.result).toMatchObject({ error: AGENT_UPGRADE_REQUIRED_MESSAGE });
+    expect(Object.keys(commandRow!.payload as Record<string, unknown>)).not.toContain(
+      'secretEnvEnvelope',
+    );
+
+    const [executionRow] = await executionsForDevice(scn.deviceId);
+    expect(executionRow!.status).toBe('failed');
+    expect(executionRow!.errorMessage).toBe(AGENT_UPGRADE_REQUIRED_MESSAGE);
+  });
+
+  it('3. refuses at enqueue for an agent without secret-env support, leaving no orphan rows', async () => {
+    await setSecretEnvVersion(scn.deviceId, 0);
+
+    const result = await dispatch(scn);
+    expect(result).toMatchObject({ ok: false, code: 'agent_upgrade_required' });
+
+    expect(await commandsForDevice(scn.deviceId)).toHaveLength(0);
+    expect(await executionsForDevice(scn.deviceId)).toHaveLength(0);
+  });
+
+  it('4. refuses a user-context run, leaving no orphan rows', async () => {
+    const result = await dispatch(scn, { runAs: 'user' });
+    expect(result).toMatchObject({ ok: false, code: 'secrets_unsupported_run_as' });
+
+    expect(await commandsForDevice(scn.deviceId)).toHaveLength(0);
+    expect(await executionsForDevice(scn.deviceId)).toHaveLength(0);
+  });
+});

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1689,7 +1689,8 @@ async function processCommandResult(
     // the per-type handler dispatch further down) script_executions. The
     // name-based heuristic pass at the top of this function stays: it catches
     // secrets this command never carried, which the exact pass cannot see.
-    // Inert until PR4c — no command carries an envelope yet.
+    // Live since PR4c-2: scriptDispatch sets `secretEnv` for `tenantSecret`
+    // parameters, so script commands can carry a sealed envelope.
     const { result: normalizedResult, stdout } = redactResultAgainstCommandSecrets(
       { id: command.id, type: command.type, deviceId: resolvedDeviceId, payload: command.payload },
       rawNormalizedResult,

--- a/apps/api/src/routes/agents/commands.test.ts
+++ b/apps/api/src/routes/agents/commands.test.ts
@@ -9,6 +9,19 @@ process.env.APP_ENCRYPTION_KEYRING = JSON.stringify({ current: 'current-key-mate
 const selectMock = vi.fn();
 const updateMock = vi.fn();
 const runOutsideDbContextMock = vi.fn((fn: () => unknown) => fn());
+// Tracks whether we are currently INSIDE the route's explicit system context.
+// This route is self-managed-context (middleware/agentAuth leaves none behind
+// on the REST paths), so anything touching the DB must run inside it.
+let insideSystemDbContext = false;
+const withSystemDbAccessContextMock = vi.fn(async (fn: () => any) => {
+  const prior = insideSystemDbContext;
+  insideSystemDbContext = true;
+  try {
+    return await fn();
+  } finally {
+    insideSystemDbContext = prior;
+  }
+});
 const updateRestoreJobByCommandIdMock = vi.fn().mockResolvedValue(true);
 const claimPendingCommandsForDeviceMock = vi.fn();
 
@@ -26,7 +39,8 @@ vi.mock('../../db', () => ({
     update: (...args: unknown[]) => updateMock(...(args as [])),
   },
   runOutsideDbContext: (...args: unknown[]) => runOutsideDbContextMock(...(args as [any])),
-  withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
+  withSystemDbAccessContext: (...args: unknown[]) =>
+    withSystemDbAccessContextMock(...(args as [any])),
 }));
 
 vi.mock('../../db/schema', () => ({
@@ -66,6 +80,28 @@ vi.mock('../../services/commandQueue', () => ({
 
 vi.mock('../../services/commandDispatch', () => ({
   claimPendingCommandsForDevice: (...args: unknown[]) => claimPendingCommandsForDeviceMock(...(args as [])),
+  releaseClaimedCommandDelivery: vi.fn(async () => undefined),
+}));
+
+// #3409 PR4c-2 — the secret-delivery claim gate. `services/commandDelivery`
+// itself runs for real here (that is the point of the route-level test); only
+// the gate's DB work is stubbed. The stub records the context it was called
+// in, and models a capability-0 device by withholding envelope-bearing script
+// commands — its real terminal-write behavior has its own suite in
+// services/scriptSecretDelivery.test.ts.
+const secretGateContexts: boolean[] = [];
+let secretGateWithholds = false;
+const failClaimedSecretCommandsMock = vi.fn(async (claimed: any[]) => {
+  secretGateContexts.push(insideSystemDbContext);
+  return secretGateWithholds
+    ? claimed.filter(
+        (cmd) => !(cmd.type === 'script' && typeof cmd.payload?.secretEnvEnvelope === 'string'),
+      )
+    : claimed;
+});
+vi.mock('../../services/scriptSecretDelivery', () => ({
+  failClaimedSecretCommandsForUnsupportedAgent: (...args: unknown[]) =>
+    failClaimedSecretCommandsMock(...(args as [any])),
 }));
 
 vi.mock('../../services/vaultSyncPersistence', () => ({
@@ -123,6 +159,9 @@ describe('agent commands routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    secretGateContexts.length = 0;
+    secretGateWithholds = false;
+    insideSystemDbContext = false;
     app = new Hono();
     app.use('*', async (c, next) => {
       c.set('agent', {
@@ -304,6 +343,47 @@ describe('agent commands routes', () => {
       'agent',
       ['self_uninstall']
     );
+  });
+
+  // #3409 PR4c-2 — the claim gate reads `devices` (RLS) and drives offending
+  // device_commands/script_executions rows terminal, so it MUST run inside the
+  // route's own system context. Calling it after the claim closure returned
+  // would make those contextless bare-pool queries (#1375).
+  it('runs the secret-delivery claim gate inside the route system db context', async () => {
+    claimPendingCommandsForDeviceMock.mockResolvedValueOnce([
+      { id: commandId, type: 'run_script', deviceId: 'device-1', payload: { scriptId: 'script-1' } },
+    ]);
+
+    const res = await app.request(`/agents/${agentId}/commands`, { method: 'GET' });
+
+    expect(res.status).toBe(200);
+    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    expect(failClaimedSecretCommandsMock).toHaveBeenCalledTimes(1);
+    expect(secretGateContexts).toEqual([true]);
+    // …and the whole thing still ran outside any inherited request context.
+    expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('withholds an envelope-bearing command from the poll response when the agent cannot open it', async () => {
+    secretGateWithholds = true;
+    claimPendingCommandsForDeviceMock.mockResolvedValueOnce([
+      {
+        id: commandId,
+        type: 'script',
+        deviceId: 'device-1',
+        payload: { scriptId: 'script-1', executionId: 'exec-1', secretEnvEnvelope: 'enc:v3:key-1:ciphertext' },
+      },
+      { id: 'cmd-sibling', type: 'run_script', deviceId: 'device-1', payload: { scriptId: 'script-2' } },
+    ]);
+
+    const res = await app.request(`/agents/${agentId}/commands`, { method: 'GET' });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { commands: Array<{ id: string }> };
+    // The secret-bearing command is gone; its sibling still delivers.
+    expect(body.commands.map((cmd) => cmd.id)).toEqual(['cmd-sibling']);
+    expect(JSON.stringify(body)).not.toContain('secretEnvEnvelope');
+    expect(secretGateContexts).toEqual([true]);
   });
 
   // A complete, well-formed PEM private-key block (header + base64 body +

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -178,24 +178,33 @@ commandsRoutes.get('/:id/commands', async (c) => {
     return c.json({ error: 'Agent context not found' }, 401);
   }
 
-  const commands = await runOutsideDbContext(() =>
-    withSystemDbAccessContext(() =>
-      claimPendingCommandsForDevice(
+  // #2414 — decrypt just-in-time; a command whose payload fails decryption is
+  // released back to `pending` (not stranded as `sent`) while its siblings
+  // still deliver.
+  //
+  // Both the claim AND the delivery pass run inside the SAME system context.
+  // This route is self-managed-context (agentAuth leaves no ambient context
+  // behind on the REST paths), and since #3409 PR4c-2 the delivery pass is no
+  // longer pure CPU: `decryptClaimedCommandsForDelivery` first runs the
+  // secret-delivery claim gate, which reads `devices` (RLS-scoped) and drives
+  // offending `device_commands` / `script_executions` rows terminal. Called
+  // outside the closure those would be contextless bare-pool queries (#1375).
+  // Unlike the heartbeat there is no capability report on this path, so the
+  // gate reads the stored column.
+  const deliverableCommands = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const commands = await claimPendingCommandsForDevice(
         agent.deviceId,
         10,
         agent.role,
         // #2774 — offboarding drain: only self_uninstall is deliverable.
         agent.tenantDraining ? ['self_uninstall'] : undefined
-      )
-    )
+      );
+      return decryptClaimedCommandsForDelivery(commands);
+    })
   );
 
-  // #2414 — decrypt just-in-time; a command whose payload fails decryption is
-  // released back to `pending` (not stranded as `sent`) while its siblings
-  // still deliver.
-  return c.json({
-    commands: await decryptClaimedCommandsForDelivery(commands),
-  });
+  return c.json({ commands: deliverableCommands });
 });
 
 commandsRoutes.post(

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -305,8 +305,9 @@ commandsRoutes.post(
     // secrets THIS command carried, before the device_commands write below and
     // before the per-type handlers persist anything. Unlike the heuristic above
     // this DOES touch stdout, because a script that echoes a credential is
-    // exactly the case it exists for. Inert until PR4c — no command carries an
-    // envelope yet, so both bindings are the originals unchanged.
+    // exactly the case it exists for. Live since PR4c-2: scriptDispatch sets
+    // `secretEnv` for `tenantSecret` parameters, so a script command can carry
+    // a sealed envelope whose values this pass strips from both bindings.
     const { result: normalizedData, stdout } = redactResultAgainstCommandSecrets(
       { id: commandId, type: command.type, deviceId, payload: command.payload },
       heuristicallyRedacted,

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -83,6 +83,25 @@ vi.mock('../../db/schema', () => ({
     tokenIssuedAt: 'devices.token_issued_at',
   },
   deviceMetrics: { deviceId: 'device_metrics.device_id' },
+  // #3409 PR4c-2 — the real services/commandDelivery runs here, and its
+  // secret-delivery claim gate touches these three tables when it withholds
+  // an envelope-bearing command.
+  deviceCommands: {
+    id: 'device_commands.id',
+    status: 'device_commands.status',
+    payload: 'device_commands.payload',
+  },
+  scriptExecutions: {
+    id: 'script_executions.id',
+    deviceId: 'script_executions.device_id',
+    status: 'script_executions.status',
+    scriptId: 'script_executions.script_id',
+  },
+  scriptExecutionBatches: {
+    id: 'script_execution_batches.id',
+    scriptId: 'script_execution_batches.script_id',
+    devicesFailed: 'script_execution_batches.devices_failed',
+  },
   agentLogs: { deviceId: 'agent_logs.device_id' },
   agentVersions: {
     platform: 'agent_versions.platform',
@@ -3701,6 +3720,122 @@ describe('POST /agents/:id/heartbeat — undecryptable claimed commands are rele
     expect(claimPendingCommandsForDeviceMock).toHaveBeenCalledWith('device-1', 10, 'agent', [
       'self_uninstall',
     ]);
+  });
+
+  // #3409 PR4c-2 Amendment A — the claim gate trusts the capability THIS
+  // heartbeat REPORTED, not the stored column. The device write that persists
+  // it is guarded on the device not being decommissioned/quarantined and is a
+  // separate statement from the claim, so a stale stored 1 must never win over
+  // a reported 0. Proven by asserting the capability SELECT never happens:
+  // the only possible source of the verdict is the reported value.
+  const capabilitySelects = () =>
+    selectMock.mock.calls.filter(
+      (call) => call[0] && typeof call[0] === 'object' && 'scriptSecretEnvVersion' in (call[0] as object),
+    );
+
+  const secretCommand = {
+    id: 'cmd-secret',
+    type: 'script',
+    deviceId: 'device-1',
+    payload: { scriptId: 'script-1', secretEnvEnvelope: 'enc:v3:key-1:ciphertext' },
+    executedAt: claimedAt,
+  };
+
+  const seedAgentDeviceLookup = () => {
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          siteId: 'site-1',
+          hostname: 'host-1',
+          osType: 'linux',
+          architecture: 'amd64',
+          agentVersion: '0.65.10',
+          agentTokenHash: 'hash',
+          tokenIssuedAt: new Date(),
+        },
+      ]),
+    );
+    selectMock.mockReturnValue(selectChainResolving([]));
+  };
+
+  it('agent path: withholds a secret-bearing command when THIS beat reports capability 0', async () => {
+    seedAgentDeviceLookup();
+    claimPendingCommandsForDeviceMock.mockResolvedValueOnce([goodCommand, secretCommand]);
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ...minimalHeartbeatBody,
+        securityCapabilities: { scriptSecretEnvVersion: 0 },
+      }),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { commands: Array<{ id: string }> };
+    expect(body.commands.map((cmd) => cmd.id)).toEqual(['cmd-good']);
+    expect(JSON.stringify(body)).not.toContain('secretEnvEnvelope');
+    // Terminal, NOT released back to pending — an incapable agent would just
+    // re-claim it.
+    expect(releaseClaimedCommandDeliveryMock).not.toHaveBeenCalled();
+    // The verdict came from the report, not from a (possibly stale) read.
+    expect(capabilitySelects()).toHaveLength(0);
+  });
+
+  // Capability 1: the gate must NOT withhold. The stand-in envelope here is not
+  // decryptable (no keyring in this suite), so the command then falls into the
+  // ordinary #2414 decrypt-failure path — being RELEASED back to pending is
+  // precisely the proof that the gate passed it through instead of driving it
+  // terminal, which is the one thing the gate would have done at capability 0.
+  it('agent path: passes the secret-bearing command through the gate when THIS beat reports capability 1, with no capability read', async () => {
+    seedAgentDeviceLookup();
+    claimPendingCommandsForDeviceMock.mockResolvedValueOnce([goodCommand, secretCommand]);
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ...minimalHeartbeatBody,
+        securityCapabilities: { scriptSecretEnvVersion: 1 },
+      }),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { commands: Array<{ id: string }> };
+    expect(body.commands.map((cmd) => cmd.id)).toEqual(['cmd-good']);
+    expect(releaseClaimedCommandDeliveryMock).toHaveBeenCalledWith('cmd-secret', claimedAt);
+    expect(capabilitySelects()).toHaveLength(0);
+  });
+
+  it('watchdog path: withholds a secret-bearing command when the beat reports capability 0', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChainResolving([
+        {
+          id: 'device-1',
+          orgId: 'org-1',
+          hostname: 'host-1',
+          osType: 'linux',
+          architecture: 'amd64',
+          lastSeenAt: new Date(),
+          mainAgentSilentSince: null,
+        },
+      ]),
+    );
+    selectMock.mockReturnValue(selectChainResolving([]));
+    claimPendingCommandsForDeviceMock.mockResolvedValueOnce([goodCommand, secretCommand]);
+
+    const resp = await buildWatchdogApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agentVersion: '0.65.15', role: 'watchdog', watchdogState: 'MONITORING' }),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { commands: Array<{ id: string }> };
+    expect(body.commands.map((cmd) => cmd.id)).toEqual(['cmd-good']);
+    expect(capabilitySelects()).toHaveLength(0);
   });
 
   it('watchdog path: narrows the claim to self_uninstall when the tenant is draining', async () => {

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -47,6 +47,7 @@ import {
   type ManifestKeyDelegation,
 } from '../../services/manifestSigning';
 import { decryptClaimedCommandsForDelivery } from '../../services/commandDelivery';
+import { normalizeReportedScriptSecretEnvVersion } from '../../services/scriptSecretDelivery';
 import { redactSecretsDeep } from '../../services/secretRedaction';
 import { recordAgentHeartbeat, resolveResponseStatus } from '../metrics';
 
@@ -489,8 +490,17 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     // #2414 — decrypt just-in-time; a command whose payload fails decryption is
     // released back to `pending` (not stranded as `sent`) while its siblings
     // still deliver.
+    //
+    // #3409 PR4c-2 — hand the gate the capability THIS beat reported rather
+    // than letting it re-read the column: the watchdog branch returns before
+    // the device update at all, so the stored value here is always from an
+    // earlier beat.
     return c.json({
-      commands: await decryptClaimedCommandsForDelivery(watchdogCommands),
+      commands: await decryptClaimedCommandsForDelivery(watchdogCommands, {
+        reportedScriptSecretEnvVersion: normalizeReportedScriptSecretEnvVersion(
+          data.securityCapabilities?.scriptSecretEnvVersion,
+        ),
+      }),
       watchdogUpgradeTo,
       upgradeTo: agentUpgradeTo,
     });
@@ -518,7 +528,7 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     // beat so a downgrade is detected. PR4c re-checks this at CLAIM time too,
     // not only at enqueue, because an offline-queued command can be claimed
     // after the agent downgraded.
-    scriptSecretEnvVersion: data.securityCapabilities?.scriptSecretEnvVersion === 1 ? 1 : 0,
+    scriptSecretEnvVersion: normalizeReportedScriptSecretEnvVersion(data.securityCapabilities?.scriptSecretEnvVersion),
     // Migration-banner Task 2 — self-reported install edition + migration
     // flag. Written UNCONDITIONALLY every heartbeat, mirroring
     // outboundNetworkPolicyVersion above: an agent that stops reporting these
@@ -1159,7 +1169,17 @@ if (latestHelper) {
   // #2414 — decrypt just-in-time; a command whose payload fails decryption is
   // released back to `pending` (not stranded as `sent`) while its siblings
   // still deliver.
-  const deliverableCommands = await decryptClaimedCommandsForDelivery(commands);
+  //
+  // #3409 PR4c-2 — the secret-delivery claim gate uses the capability THIS
+  // heartbeat reported, not the stored column. The device write above carries
+  // the same value but is guarded on the device not being decommissioned/
+  // quarantined, so it can be skipped entirely; trusting the stored value
+  // could then deliver a sealed secret to an agent that just reported 0.
+  const deliverableCommands = await decryptClaimedCommandsForDelivery(commands, {
+    reportedScriptSecretEnvVersion: normalizeReportedScriptSecretEnvVersion(
+      data.securityCapabilities?.scriptSecretEnvVersion,
+    ),
+  });
 
   // Main-branch response payload — built inside the org context, but the
   // manifest-trust-keyset and policy probe config are fetched AFTER this

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -659,18 +659,24 @@ describe('scripts routes', () => {
   });
 
   // -------------------------------------------------------------------
-  // MSP -> customer descent on a PARTNER-WIDE secret (#3409 PR4c-2).
+  // Ownership TIER of the secret vs. the SCRIPT (#3409 PR4c-2 review).
   // -------------------------------------------------------------------
-  // `tenantVariableReadCondition` deliberately widens partner-wide rows to
-  // ORGANIZATION-scope sessions (keys only, never values) and `resolveForOrg`
-  // inherits them into every org, so an Org Admin of a CUSTOMER org can SEE
-  // the MSP's partner-wide secret keys. Binding one into a script they can
-  // also run is the only channel in the product through which a secret's
-  // plaintext leaves the server, and both redactors are exact-substring, so
-  // base64 defeats them. Binding a PARTNER-owned secret therefore requires
-  // partner-wide management capability — the same gate every other
-  // partner-wide write uses.
-  describe('partner-wide secret binding requires partner-wide capability', () => {
+  // A script may resolve a secret at or below its own ownership tier, never
+  // above: a partner-wide script (org_id NULL) may bind a partner-owned OR an
+  // org-owned secret; an ORG-scoped script may bind only an org-owned one.
+  //
+  // It is deliberately NOT a caller-capability check. `tenantVariableRead-
+  // Condition` widens partner-wide variable KEYS to organization-scope
+  // sessions and `resolveForOrg` inherits the ROWS into every org, so an org
+  // admin who could bind the MSP's partner-wide secret into an org-scoped
+  // script could base64 it out through script output (both redactors are
+  // exact-substring). Gating on the caller instead of the script does not
+  // stop that: a full-partner admin's org-scoped script is editable and
+  // runnable by that org's own admins afterwards.
+  //
+  // Dispatch is the authority (services/sourcedParameters.ts, `tenantSecret`
+  // arm); these cases pin the save-time FAST FAIL.
+  describe('secret ownership tier vs. script scope', () => {
     // org_id IS NULL on the tenant_variables row -> ownerScope 'partner'.
     const partnerSecretRow = {
       id: 'tv-3', key: 'psa_api_token', value: 'shh', isSecret: true, version: 1,
@@ -681,7 +687,18 @@ describe('scripts routes', () => {
       ownerOrgId: ORG_ID, forOrgId: ORG_ID
     };
     const DENIED =
-      'Parameter "psa" binds partner-wide secret variable "psa_api_token"; only a partner administrator can bind a partner-wide secret.';
+      'Parameter "psa" binds partner-wide secret variable "psa_api_token"; an organization-scoped script cannot use one — make the script partner-wide, or use an organization-owned secret.';
+
+    // The partner-wide branch of the save-time lookup reads tenant_variables
+    // directly (org_id IS NULL AND partner_id = ...) — no resolver join, so
+    // the chain shape differs from mockTenantVariableScopeRows above.
+    function mockPartnerWideVariableRows(rows: unknown[]): void {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(rows)
+        })
+      } as any);
+    }
 
     const secretParam = (variableKey: string) => ({
       name: 'psa', type: 'string', source: 'tenantSecret', variableKey
@@ -729,27 +746,52 @@ describe('scripts routes', () => {
       expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
     });
 
-    it('ALLOWS a full-partner admin to bind a partner-wide secret into an org-scoped script', async () => {
+    // The tier is the SCRIPT's, not the caller's: a full-partner admin creating
+    // a script for ONE org is creating an org-scoped script, which that org's
+    // admins can edit and run afterwards.
+    it('400s a full-partner admin binding a partner-wide secret into an ORG-scoped script', async () => {
       await usePartnerAuth('all');
       mockTenantVariableScopeRows([partnerSecretRow]);
-      vi.mocked(db.insert).mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'Binds PSA token', orgId: ORG_ID }])
-        })
-      } as any);
       const res = await createWithParams([secretParam('psa_api_token')], { orgId: ORG_ID, availability: 'org' });
-      expect(res.status).toBe(201);
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe(DENIED);
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
     });
 
-    // Partner SCOPE is not partner-wide CAPABILITY (#3262) — the same
-    // distinction the create gate already draws.
-    it('400s a SELECTED-access partner user binding a partner-wide secret', async () => {
+    it('400s a SELECTED-access partner user binding a partner-wide secret into an ORG-scoped script', async () => {
       await usePartnerAuth('selected');
       mockTenantVariableScopeRows([partnerSecretRow]);
       const res = await createWithParams([secretParam('psa_api_token')], { orgId: ORG_ID, availability: 'org' });
       expect(res.status).toBe(400);
       expect((await res.json()).error).toBe(DENIED);
       expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it("ALLOWS a PARTNER-WIDE create binding the partner's own secret", async () => {
+      await usePartnerAuth('all');
+      mockPartnerWideVariableRows([{ key: 'psa_api_token', isSecret: true }]);
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'Binds PSA token', orgId: null }])
+        })
+      } as any);
+      const res = await createWithParams([secretParam('psa_api_token')], { availability: 'partner' });
+      expect(res.status).toBe(201);
+    });
+
+    // The PRIMARY use case: one partner-wide script, each target org's OWN
+    // value resolved per device at dispatch. The key is simply not visible to
+    // the partner-wide lookup at save time, and must not be rejected for that.
+    it('ALLOWS a PARTNER-WIDE create binding a key that only exists as an ORG-owned secret', async () => {
+      await usePartnerAuth('all');
+      mockPartnerWideVariableRows([]); // no partner-wide row named s1_token
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'Binds PSA token', orgId: null }])
+        })
+      } as any);
+      const res = await createWithParams([secretParam('s1_token')], { availability: 'partner' });
+      expect(res.status).toBe(201);
     });
 
     it('leaves an ORG-owned secret binding unaffected for the same org-scope caller', async () => {
@@ -787,6 +829,36 @@ describe('scripts routes', () => {
       expect(res.status).toBe(400);
       expect((await res.json()).error).toBe(DENIED);
       expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+    });
+
+    it("ALLOWS an UPDATE of an already PARTNER-WIDE script binding the partner's own secret", async () => {
+      await usePartnerAuth('all');
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: SCRIPT_ID_1, name: 'Existing', content: 'echo hi', version: 1,
+              isSystem: false, orgId: null, partnerId: PARTNER_ID, parameters: []
+            }])
+          })
+        })
+      } as any);
+      mockPartnerWideVariableRows([{ key: 'psa_api_token', isSecret: true }]);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'Existing', orgId: null }])
+          })
+        })
+      } as any);
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ parameters: [secretParam('psa_api_token')] })
+      });
+
+      expect(res.status).toBe(200);
     });
   });
 
@@ -846,7 +918,7 @@ describe('scripts routes', () => {
       const res = await clone();
       expect(res.status).toBe(400);
       expect((await res.json()).error).toBe(
-        'Parameter "psa" binds partner-wide secret variable "psa_api_token"; only a partner administrator can bind a partner-wide secret.'
+        'Parameter "psa" binds partner-wide secret variable "psa_api_token"; an organization-scoped script cannot use one — make the script partner-wide, or use an organization-owned secret.'
       );
       expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
     });

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -524,6 +524,140 @@ describe('scripts routes', () => {
     });
   });
 
+  // -------------------------------------------------------------------
+  // Save-time parameter-binding secret mismatch (#3409 PR4c-2, Task 6)
+  // -------------------------------------------------------------------
+  // Symmetric to the content check above: a `tenantVariable` binding whose
+  // target is a secret, or a `tenantSecret` binding whose target is NOT a
+  // secret, is rejected when the definitions are stored — the web warning
+  // already promises "the save will be rejected". Unknown keys pass (a
+  // partner-wide script resolves per org later).
+  describe('save-time parameter-binding secret mismatch', () => {
+    const mockExistingScript = () =>
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: SCRIPT_ID_1,
+              name: 'Existing',
+              content: 'echo hi',
+              version: 1,
+              isSystem: false,
+              orgId: ORG_ID,
+              parameters: []
+            }])
+          })
+        })
+      } as any);
+
+    const createWith = (parameters: unknown[]) =>
+      app.request('/scripts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({
+          name: 'Bound params',
+          osTypes: ['linux'],
+          language: 'bash',
+          content: 'echo "$BREEZE_PARAM_P"',
+          parameters
+        })
+      });
+
+    const updateWith = (parameters: unknown[]) =>
+      app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ parameters })
+      });
+
+    const secretRow = { id: 'tv-1', key: 's1_token', value: 'shh', isSecret: true, version: 1, ownerOrgId: ORG_ID, forOrgId: ORG_ID };
+    const plainRow = { id: 'tv-2', key: 'repo_url', value: 'https://dl.example', isSecret: false, version: 1, ownerOrgId: ORG_ID, forOrgId: ORG_ID };
+
+    it('400s a create whose tenantVariable parameter binds a SECRET variable', async () => {
+      mockTenantVariableScopeRows([secretRow]);
+      const res = await createWith([{ name: 'p', type: 'string', source: 'tenantVariable', variableKey: 's1_token' }]);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe(
+        'Parameter "p" binds secret variable "s1_token" with source "From a variable"; use a secret parameter instead'
+      );
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it('400s a create whose tenantSecret parameter binds a NON-secret variable', async () => {
+      mockTenantVariableScopeRows([plainRow]);
+      const res = await createWith([{ name: 'p', type: 'string', source: 'tenantSecret', variableKey: 'repo_url' }]);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Parameter "p" is a secret parameter but variable "repo_url" is not a secret');
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it('accepts a create whose bindings target UNKNOWN keys (either source) — resolved per org at dispatch', async () => {
+      mockTenantVariableScopeRows([]);
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'Bound params', orgId: ORG_ID }])
+        })
+      } as any);
+      const res = await createWith([
+        { name: 'p', type: 'string', source: 'tenantVariable', variableKey: 'not_yet_created' },
+        { name: 'q', type: 'string', source: 'tenantSecret', variableKey: 'also_not_yet' }
+      ]);
+      expect(res.status).toBe(201);
+    });
+
+    it('accepts a create whose bindings match their targets (plain→tenantVariable, secret→tenantSecret)', async () => {
+      mockTenantVariableScopeRows([secretRow, plainRow]);
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'Bound params', orgId: ORG_ID }])
+        })
+      } as any);
+      const res = await createWith([
+        { name: 'p', type: 'string', source: 'tenantVariable', variableKey: 'repo_url' },
+        { name: 'q', type: 'string', source: 'tenantSecret', variableKey: 's1_token' }
+      ]);
+      expect(res.status).toBe(201);
+    });
+
+    it('400s an UPDATE whose new tenantVariable parameter binds a SECRET variable, and never writes it', async () => {
+      mockExistingScript();
+      mockTenantVariableScopeRows([secretRow]);
+      const res = await updateWith([{ name: 'p', type: 'string', source: 'tenantVariable', variableKey: 's1_token' }]);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe(
+        'Parameter "p" binds secret variable "s1_token" with source "From a variable"; use a secret parameter instead'
+      );
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+    });
+
+    it('400s an UPDATE whose new tenantSecret parameter binds a NON-secret variable, and never writes it', async () => {
+      mockExistingScript();
+      mockTenantVariableScopeRows([plainRow]);
+      const res = await updateWith([{ name: 'p', type: 'string', source: 'tenantSecret', variableKey: 'repo_url' }]);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Parameter "p" is a secret parameter but variable "repo_url" is not a secret');
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+    });
+
+    it('accepts an UPDATE whose new bindings target UNKNOWN keys', async () => {
+      mockExistingScript();
+      mockTenantVariableScopeRows([]);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'Existing', orgId: ORG_ID, version: 2 }])
+          })
+        })
+      } as any);
+      const res = await updateWith([{ name: 'p', type: 'string', source: 'tenantSecret', variableKey: 'not_yet_created' }]);
+      expect(res.status).toBe(200);
+    });
+  });
+
   it('should prevent deleting scripts with active executions', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce({
@@ -2117,6 +2251,10 @@ describe('scripts routes', () => {
               { id: SCRIPT_ID_1, name: 'S', content: 'echo hi', version: 7, isSystem: false, orgId: ORG_ID, ...stored },
             ]),
           }),
+          // A tenantVariable/tenantSecret binding triggers the save-time
+          // mismatch lookup (loadTenantVariableScope: innerJoin + where).
+          // No rows → unknown key → allowed.
+          innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
         }),
       } as any);
       const set = vi.fn().mockReturnValue({
@@ -2149,6 +2287,9 @@ describe('scripts routes', () => {
 
     it('accepts every bound source on create', async () => {
       mockCreateInsert();
+      // The tenantVariable binding triggers the save-time mismatch lookup
+      // (#3409 PR4c-2); no rows → unknown key → allowed.
+      mockTenantVariableScopeRows([]);
       const res = await post([
         { name: 'apiKey', type: 'string', source: 'tenantVariable', variableKey: 'vendor_api_key' },
         { name: 'assetTag', type: 'string', source: 'deviceCustomField', fieldKey: 'asset_tag' },

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -658,6 +658,243 @@ describe('scripts routes', () => {
     });
   });
 
+  // -------------------------------------------------------------------
+  // MSP -> customer descent on a PARTNER-WIDE secret (#3409 PR4c-2).
+  // -------------------------------------------------------------------
+  // `tenantVariableReadCondition` deliberately widens partner-wide rows to
+  // ORGANIZATION-scope sessions (keys only, never values) and `resolveForOrg`
+  // inherits them into every org, so an Org Admin of a CUSTOMER org can SEE
+  // the MSP's partner-wide secret keys. Binding one into a script they can
+  // also run is the only channel in the product through which a secret's
+  // plaintext leaves the server, and both redactors are exact-substring, so
+  // base64 defeats them. Binding a PARTNER-owned secret therefore requires
+  // partner-wide management capability — the same gate every other
+  // partner-wide write uses.
+  describe('partner-wide secret binding requires partner-wide capability', () => {
+    // org_id IS NULL on the tenant_variables row -> ownerScope 'partner'.
+    const partnerSecretRow = {
+      id: 'tv-3', key: 'psa_api_token', value: 'shh', isSecret: true, version: 1,
+      ownerOrgId: null, forOrgId: ORG_ID
+    };
+    const orgSecretRow = {
+      id: 'tv-1', key: 's1_token', value: 'shh', isSecret: true, version: 1,
+      ownerOrgId: ORG_ID, forOrgId: ORG_ID
+    };
+    const DENIED =
+      'Parameter "psa" binds partner-wide secret variable "psa_api_token"; only a partner administrator can bind a partner-wide secret.';
+
+    const secretParam = (variableKey: string) => ({
+      name: 'psa', type: 'string', source: 'tenantSecret', variableKey
+    });
+
+    async function usePartnerAuth(partnerOrgAccess: 'all' | 'selected') {
+      const { authMiddleware } = await import('../middleware/auth');
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          scope: 'partner' as const,
+          partnerId: PARTNER_ID,
+          partnerOrgAccess,
+          orgId: null,
+          token: {
+            sub: 'user-123', email: 'test@example.com', roleId: 'role-123',
+            orgId: null, partnerId: PARTNER_ID, scope: 'partner', type: 'access', mfa: true,
+          },
+          accessibleOrgIds: [ORG_ID],
+          canAccessOrg: (id: string) => id === ORG_ID,
+        });
+        return next();
+      });
+    }
+
+    const createWithParams = (parameters: unknown[], extra: Record<string, unknown> = {}) =>
+      app.request('/scripts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({
+          name: 'Binds PSA token',
+          osTypes: ['linux'],
+          language: 'bash',
+          content: 'echo hi',
+          parameters,
+          ...extra
+        })
+      });
+
+    it('400s a create by an ORG-scope caller binding a partner-wide secret, and never inserts', async () => {
+      mockTenantVariableScopeRows([partnerSecretRow]);
+      const res = await createWithParams([secretParam('psa_api_token')]);
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe(DENIED);
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it('ALLOWS a full-partner admin to bind a partner-wide secret into an org-scoped script', async () => {
+      await usePartnerAuth('all');
+      mockTenantVariableScopeRows([partnerSecretRow]);
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'Binds PSA token', orgId: ORG_ID }])
+        })
+      } as any);
+      const res = await createWithParams([secretParam('psa_api_token')], { orgId: ORG_ID, availability: 'org' });
+      expect(res.status).toBe(201);
+    });
+
+    // Partner SCOPE is not partner-wide CAPABILITY (#3262) — the same
+    // distinction the create gate already draws.
+    it('400s a SELECTED-access partner user binding a partner-wide secret', async () => {
+      await usePartnerAuth('selected');
+      mockTenantVariableScopeRows([partnerSecretRow]);
+      const res = await createWithParams([secretParam('psa_api_token')], { orgId: ORG_ID, availability: 'org' });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe(DENIED);
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it('leaves an ORG-owned secret binding unaffected for the same org-scope caller', async () => {
+      mockTenantVariableScopeRows([orgSecretRow]);
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'Binds PSA token', orgId: ORG_ID }])
+        })
+      } as any);
+      const res = await createWithParams([
+        { name: 'psa', type: 'string', source: 'tenantSecret', variableKey: 's1_token' }
+      ]);
+      expect(res.status).toBe(201);
+    });
+
+    it('400s an UPDATE by an ORG-scope caller binding a partner-wide secret, and never writes it', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: SCRIPT_ID_1, name: 'Existing', content: 'echo hi', version: 1,
+              isSystem: false, orgId: ORG_ID, parameters: []
+            }])
+          })
+        })
+      } as any);
+      mockTenantVariableScopeRows([partnerSecretRow]);
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ parameters: [secretParam('psa_api_token')] })
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe(DENIED);
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // POST /scripts/import/:id — the fourth write ingress (#3409 PR4c-2).
+  // -------------------------------------------------------------------
+  // Cloning a system script copies `source.parameters` verbatim. Before this
+  // change the clone ran NEITHER save-time secret check, so it was a straight
+  // bypass of both the content gate and the partner-wide binding gate above.
+  describe('clone a system script — save-time secret checks', () => {
+    const systemSource = (overrides: Record<string, unknown> = {}) => ({
+      id: SCRIPT_ID_2,
+      name: 'System Script',
+      description: null,
+      category: null,
+      osTypes: ['linux'],
+      language: 'bash',
+      content: 'echo hi',
+      parameters: null,
+      timeoutSeconds: 300,
+      runAs: 'system',
+      isSystem: true,
+      ...overrides
+    });
+
+    function mockClonePreamble(source: Record<string, unknown>, existing: unknown[] = []) {
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([source]) })
+          })
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(existing) })
+          })
+        } as any);
+    }
+
+    const clone = () =>
+      app.request(`/scripts/import/${SCRIPT_ID_2}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({})
+      });
+
+    it('400s a clone whose copied parameters bind a partner-wide secret, and never inserts', async () => {
+      mockClonePreamble(
+        systemSource({
+          parameters: [{ name: 'psa', type: 'string', source: 'tenantSecret', variableKey: 'psa_api_token' }]
+        })
+      );
+      mockTenantVariableScopeRows([
+        { id: 'tv-3', key: 'psa_api_token', value: 'shh', isSecret: true, version: 1, ownerOrgId: null, forOrgId: ORG_ID }
+      ]);
+
+      const res = await clone();
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe(
+        'Parameter "psa" binds partner-wide secret variable "psa_api_token"; only a partner administrator can bind a partner-wide secret.'
+      );
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it('400s a clone whose copied parameters bind an ORG secret with the plain tenantVariable source', async () => {
+      mockClonePreamble(
+        systemSource({
+          parameters: [{ name: 'p', type: 'string', source: 'tenantVariable', variableKey: 's1_token' }]
+        })
+      );
+      mockTenantVariableScopeRows([
+        { id: 'tv-1', key: 's1_token', value: 'shh', isSecret: true, version: 1, ownerOrgId: ORG_ID, forOrgId: ORG_ID }
+      ]);
+
+      const res = await clone();
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe(
+        'Parameter "p" binds secret variable "s1_token" with source "From a variable"; use a secret parameter instead'
+      );
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it('400s a clone whose copied CONTENT references a secret variable', async () => {
+      mockClonePreamble(systemSource({ content: 'echo {{var.s1_token}}' }));
+      mockTenantVariableScopeRows([
+        { id: 'tv-1', key: 's1_token', value: 'shh', isSecret: true, version: 1, ownerOrgId: ORG_ID, forOrgId: ORG_ID }
+      ]);
+
+      const res = await clone();
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toContain('s1_token');
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it('clones a clean system script unchanged', async () => {
+      mockClonePreamble(systemSource());
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'System Script', orgId: ORG_ID }])
+        })
+      } as any);
+
+      const res = await clone();
+      expect(res.status).toBe(201);
+      expect(vi.mocked(db.insert)).toHaveBeenCalled();
+    });
+  });
+
   it('should prevent deleting scripts with active executions', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce({

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -36,7 +36,9 @@ import {
   type ScriptCreateScope,
 } from '../services/scriptWrite';
 import {
+  describeParameterSecretMismatch,
   describeSecretVariableRejection,
+  findParameterSecretMismatches,
   findSecretVariableReferences,
 } from '../services/scriptBundle';
 import { scriptBundleRoutes } from './scriptBundle';
@@ -616,6 +618,12 @@ scriptRoutes.post(
     if (secretRefs.length > 0) {
       return c.json({ error: describeSecretVariableRejection(secretRefs) }, 400);
     }
+    // Parameter-binding twin (#3409 PR4c-2): tenantVariable→secret and
+    // tenantSecret→non-secret are both rejected; unknown keys pass.
+    const mismatches = await findParameterSecretMismatches(scope, data.parameters);
+    if (mismatches.length > 0) {
+      return c.json({ error: describeParameterSecretMismatch(mismatches) }, 400);
+    }
 
     const script = await insertScriptRow(auth, scope, data, {
       requestedIsSystem: data.isSystem
@@ -808,6 +816,17 @@ scriptRoutes.put(
       }
       updates.content = data.content;
       versionChanged = true;
+    }
+
+    if (data.parameters !== undefined) {
+      // Parameter-binding twin of the content check (#3409 PR4c-2), against
+      // the same EFFECTIVE scope. Only the INCOMING definitions are checked —
+      // a PUT that leaves `parameters` untouched does not re-validate what is
+      // already stored.
+      const mismatches = await findParameterSecretMismatches(effectiveScope, data.parameters);
+      if (mismatches.length > 0) {
+        return c.json({ error: describeParameterSecretMismatch(mismatches) }, 400);
+      }
     }
 
     if (versionChanged) {

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -529,6 +529,25 @@ scriptRoutes.post(
       return c.json({ error: 'A script with this name already exists in your organization' }, 409);
     }
 
+    // The FOURTH write ingress for `scripts.content` / `scripts.parameters`
+    // (#3409 PR4c-2). A clone copies the source's content and parameter
+    // definitions verbatim, so both save-time secret checks apply here exactly
+    // as they do on POST/PUT — including the partner-wide binding gate, which
+    // dispatch can never re-check (see ParameterSecretCheckOptions). Skipping
+    // them here would make the clone a bypass of the gate, not just a place
+    // the error surfaces later.
+    const cloneScope: ScriptCreateScope = { orgId, partnerId: auth.partnerId ?? null };
+    const secretRefs = await findSecretVariableReferences(cloneScope, source.content);
+    if (secretRefs.length > 0) {
+      return c.json({ error: describeSecretVariableRejection(secretRefs) }, 400);
+    }
+    const mismatches = await findParameterSecretMismatches(cloneScope, source.parameters, {
+      allowPartnerOwnedSecrets: canManagePartnerWidePolicies(auth)
+    });
+    if (mismatches.length > 0) {
+      return c.json({ error: describeParameterSecretMismatch(mismatches) }, 400);
+    }
+
     // Clone into the org
     const [cloned] = await db
       .insert(scripts)
@@ -619,8 +638,13 @@ scriptRoutes.post(
       return c.json({ error: describeSecretVariableRejection(secretRefs) }, 400);
     }
     // Parameter-binding twin (#3409 PR4c-2): tenantVariable→secret and
-    // tenantSecret→non-secret are both rejected; unknown keys pass.
-    const mismatches = await findParameterSecretMismatches(scope, data.parameters);
+    // tenantSecret→non-secret are both rejected; unknown keys pass. Binding a
+    // PARTNER-OWNED secret additionally requires partner-wide capability —
+    // see ParameterSecretCheckOptions for why that gate can only live at the
+    // write ingresses.
+    const mismatches = await findParameterSecretMismatches(scope, data.parameters, {
+      allowPartnerOwnedSecrets: canManagePartnerWidePolicies(auth)
+    });
     if (mismatches.length > 0) {
       return c.json({ error: describeParameterSecretMismatch(mismatches) }, 400);
     }
@@ -823,7 +847,9 @@ scriptRoutes.put(
       // the same EFFECTIVE scope. Only the INCOMING definitions are checked —
       // a PUT that leaves `parameters` untouched does not re-validate what is
       // already stored.
-      const mismatches = await findParameterSecretMismatches(effectiveScope, data.parameters);
+      const mismatches = await findParameterSecretMismatches(effectiveScope, data.parameters, {
+        allowPartnerOwnedSecrets: canManagePartnerWidePolicies(auth)
+      });
       if (mismatches.length > 0) {
         return c.json({ error: describeParameterSecretMismatch(mismatches) }, 400);
       }

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -532,18 +532,16 @@ scriptRoutes.post(
     // The FOURTH write ingress for `scripts.content` / `scripts.parameters`
     // (#3409 PR4c-2). A clone copies the source's content and parameter
     // definitions verbatim, so both save-time secret checks apply here exactly
-    // as they do on POST/PUT — including the partner-wide binding gate, which
-    // dispatch can never re-check (see ParameterSecretCheckOptions). Skipping
-    // them here would make the clone a bypass of the gate, not just a place
-    // the error surfaces later.
+    // as they do on POST/PUT — the clone always lands in ONE org (orgId is
+    // required above), so it is org-scoped and may not bind a partner-owned
+    // secret. Skipping the checks here would only defer the error to dispatch,
+    // which is where the rule is actually enforced.
     const cloneScope: ScriptCreateScope = { orgId, partnerId: auth.partnerId ?? null };
     const secretRefs = await findSecretVariableReferences(cloneScope, source.content);
     if (secretRefs.length > 0) {
       return c.json({ error: describeSecretVariableRejection(secretRefs) }, 400);
     }
-    const mismatches = await findParameterSecretMismatches(cloneScope, source.parameters, {
-      allowPartnerOwnedSecrets: canManagePartnerWidePolicies(auth)
-    });
+    const mismatches = await findParameterSecretMismatches(cloneScope, source.parameters);
     if (mismatches.length > 0) {
       return c.json({ error: describeParameterSecretMismatch(mismatches) }, 400);
     }
@@ -638,13 +636,11 @@ scriptRoutes.post(
       return c.json({ error: describeSecretVariableRejection(secretRefs) }, 400);
     }
     // Parameter-binding twin (#3409 PR4c-2): tenantVariable→secret and
-    // tenantSecret→non-secret are both rejected; unknown keys pass. Binding a
-    // PARTNER-OWNED secret additionally requires partner-wide capability —
-    // see ParameterSecretCheckOptions for why that gate can only live at the
-    // write ingresses.
-    const mismatches = await findParameterSecretMismatches(scope, data.parameters, {
-      allowPartnerOwnedSecrets: canManagePartnerWidePolicies(auth)
-    });
+    // tenantSecret→non-secret are both rejected; unknown keys pass. A
+    // PARTNER-OWNED secret is additionally rejected unless `scope` is itself
+    // partner-wide — the ownership-tier rule, whose authority is dispatch
+    // (see findParameterSecretMismatches).
+    const mismatches = await findParameterSecretMismatches(scope, data.parameters);
     if (mismatches.length > 0) {
       return c.json({ error: describeParameterSecretMismatch(mismatches) }, 400);
     }
@@ -844,12 +840,11 @@ scriptRoutes.put(
 
     if (data.parameters !== undefined) {
       // Parameter-binding twin of the content check (#3409 PR4c-2), against
-      // the same EFFECTIVE scope. Only the INCOMING definitions are checked —
-      // a PUT that leaves `parameters` untouched does not re-validate what is
-      // already stored.
-      const mismatches = await findParameterSecretMismatches(effectiveScope, data.parameters, {
-        allowPartnerOwnedSecrets: canManagePartnerWidePolicies(auth)
-      });
+      // the same EFFECTIVE (post-rescope) scope — so a save that widens the
+      // script to partner-wide is judged at the tier it ENDS at. Only the
+      // INCOMING definitions are checked: a PUT that leaves `parameters`
+      // untouched does not re-validate what is already stored.
+      const mismatches = await findParameterSecretMismatches(effectiveScope, data.parameters);
       if (mismatches.length > 0) {
         return c.json({ error: describeParameterSecretMismatch(mismatches) }, 400);
       }

--- a/apps/api/src/services/actionIntents/runScriptSnapshot.test.ts
+++ b/apps/api/src/services/actionIntents/runScriptSnapshot.test.ts
@@ -404,6 +404,38 @@ describe('runScriptDigestMaterial drift sensitivity', () => {
 });
 
 describe('buildRunScriptSnapshot variable references', () => {
+  // #3409 PR4c-2: the declared-delivery arm is a reference like any other.
+  // The snapshot pins the secret's IDENTITY so a rotation between approval and
+  // release is detected, and the digest material must never carry its value.
+  it('pins a tenantSecret-bound parameter by identity and keeps its value out of the material', async () => {
+    const plaintext = 'hunter2-super-secret-value';
+    const built = await builtOf({
+      script: scriptRow({
+        content: 'echo "$BREEZE_VAR_TOKEN"',
+        parameters: [{ name: 'token', type: 'string', source: 'tenantSecret', variableKey: 'api_token' }],
+      }),
+      scope: fakeScope([
+        {
+          orgId: 'org-1',
+          present: [variable({ key: 'api_token', value: plaintext, variableId: 'var-s', version: 4, isSecret: true })],
+        },
+      ]),
+    });
+    expect(built.snapshot.variableReferences).toEqual([
+      {
+        orgId: 'org-1',
+        key: 'api_token',
+        state: 'present',
+        variableId: 'var-s',
+        version: 4,
+        isSecret: true,
+        ownerScope: 'organization',
+      },
+    ]);
+    expect(runScriptDigestMaterial(built.snapshot)).not.toContain(plaintext);
+    expect(JSON.stringify(built.snapshot)).not.toContain(plaintext);
+  });
+
   it('references the union of content tokens and parameter variableKeys', async () => {
     const snapshot = await snapshotOf({
       script: scriptRow({

--- a/apps/api/src/services/actionIntents/runScriptSnapshot.ts
+++ b/apps/api/src/services/actionIntents/runScriptSnapshot.ts
@@ -163,8 +163,11 @@ function byCodePoint(a: string, b: string): number {
 
 /**
  * Every tenant-variable key this run will consult: the union of the content's
- * `{{var.*}}` tokens and every `tenantVariable`-bound parameter's
- * `variableKey`.
+ * `{{var.*}}` tokens and every `tenantVariable`- or `tenantSecret`-bound
+ * parameter's `variableKey`. A `tenantSecret` reference (#3409 PR4c-2) is
+ * pinned by identity exactly like any other — variableId / version /
+ * isSecret — so a secret rotated between approval and release is a
+ * `content_changed`, while its VALUE never enters the material.
  *
  * Definitions are parsed ELEMENT BY ELEMENT with the shared schema, matching
  * `sourcedParameters.ts`'s `parseDefinitions` — a live database holds lists
@@ -179,7 +182,12 @@ function referencedVariableKeys(content: string, parameters: unknown): string[] 
   if (Array.isArray(parameters)) {
     for (const element of parameters) {
       const parsed = scriptParameterDefinitionSchema.safeParse(element);
-      if (parsed.success && parsed.data.source === 'tenantVariable') keys.add(parsed.data.variableKey);
+      if (
+        parsed.success &&
+        (parsed.data.source === 'tenantVariable' || parsed.data.source === 'tenantSecret')
+      ) {
+        keys.add(parsed.data.variableKey);
+      }
     }
   }
   return [...keys].sort(byCodePoint);

--- a/apps/api/src/services/commandDelivery.test.ts
+++ b/apps/api/src/services/commandDelivery.test.ts
@@ -189,5 +189,21 @@ describe('decryptClaimedCommandsForDelivery (#2414)', () => {
       await decryptClaimedCommandsForDelivery([secretCommand]);
       expect(failClaimedSecretCommandsMock).toHaveBeenCalledWith([secretCommand], {});
     });
+
+    it('propagates a gate contract violation instead of delivering the batch', async () => {
+      // The gate throws on a misuse it cannot safely resolve (e.g. one
+      // agent's self-reported capability handed to a multi-device batch).
+      // Delivery must fail loudly: nothing decrypted, nothing released, and
+      // no sealed secret shipped on the strength of another device's report.
+      failClaimedSecretCommandsMock.mockRejectedValueOnce(new Error('reportedVersion contract violation'));
+
+      await expect(
+        decryptClaimedCommandsForDelivery([plainCommand, secretCommand], {
+          reportedScriptSecretEnvVersion: 1,
+        }),
+      ).rejects.toThrow('reportedVersion contract violation');
+
+      expect(releaseClaimedCommandDeliveryMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/services/commandDelivery.test.ts
+++ b/apps/api/src/services/commandDelivery.test.ts
@@ -13,6 +13,15 @@ vi.mock('./sentry', () => ({
   captureException: (...args: unknown[]) => captureExceptionMock(...(args as [])),
 }));
 
+// #3409 PR4c-2 — the claim gate. Mocked here (it has its own DB-level suite in
+// scriptSecretDelivery.test.ts); these tests assert the WIRING: it runs before
+// any decryption, and only what it returns is decrypted and released.
+const failClaimedSecretCommandsMock = vi.fn(async (claimed: unknown[]) => claimed);
+vi.mock('./scriptSecretDelivery', () => ({
+  failClaimedSecretCommandsForUnsupportedAgent: (...args: unknown[]) =>
+    failClaimedSecretCommandsMock(...(args as [any])),
+}));
+
 import { decryptClaimedCommandsForDelivery } from './commandDelivery';
 import { encryptSensitivePayloadFields } from './sensitiveCommandPayload';
 
@@ -33,6 +42,7 @@ const undecryptable = {
 describe('decryptClaimedCommandsForDelivery (#2414)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    failClaimedSecretCommandsMock.mockImplementation(async (claimed: unknown[]) => claimed);
   });
 
   it('releases a command that fails decryption back to pending while its siblings still deliver', async () => {
@@ -102,5 +112,82 @@ describe('decryptClaimedCommandsForDelivery (#2414)', () => {
   it('returns an empty array for an empty batch', async () => {
     await expect(decryptClaimedCommandsForDelivery([])).resolves.toEqual([]);
     expect(releaseClaimedCommandDeliveryMock).not.toHaveBeenCalled();
+  });
+
+  // ── #3409 PR4c-2: the secret-delivery claim gate ───────────────────
+
+  describe('secret-delivery claim gate', () => {
+    const secretCommand = {
+      id: 'cmd-secret',
+      type: 'script',
+      deviceId: CLAIM_DEVICE,
+      payload: { scriptId: 's-secret', secretEnvEnvelope: 'enc:v3:key-1:ciphertext' },
+      executedAt: claimedAt,
+    };
+    const plainCommand = {
+      id: 'cmd-plain',
+      type: 'run_script',
+      deviceId: CLAIM_DEVICE,
+      payload: { scriptId: 's-1' },
+      executedAt: claimedAt,
+    };
+
+    it('runs the gate on the claimed batch BEFORE anything is decrypted', async () => {
+      const goodEncrypted = encryptSensitivePayloadFields('encryption_rotate_key', { password: 'pw' });
+      const claimed = [
+        plainCommand,
+        { id: 'cmd-good', type: 'encryption_rotate_key', deviceId: CLAIM_DEVICE, payload: goodEncrypted, executedAt: claimedAt },
+      ];
+
+      const delivered = await decryptClaimedCommandsForDelivery(claimed);
+
+      expect(failClaimedSecretCommandsMock).toHaveBeenCalledTimes(1);
+      // Called with the RAW claimed rows — still sealed, never the decrypted
+      // ones (the gate must never see plaintext).
+      expect(failClaimedSecretCommandsMock.mock.calls[0]![0]).toBe(claimed);
+      expect((claimed[1]!.payload as Record<string, unknown>).password).toBe(goodEncrypted.password);
+      expect(delivered.map((cmd) => cmd.id)).toEqual(['cmd-plain', 'cmd-good']);
+    });
+
+    it('decrypts and delivers ONLY what the gate returned', async () => {
+      failClaimedSecretCommandsMock.mockResolvedValueOnce([plainCommand]);
+
+      const delivered = await decryptClaimedCommandsForDelivery([plainCommand, secretCommand]);
+
+      expect(delivered.map((cmd) => cmd.id)).toEqual(['cmd-plain']);
+    });
+
+    it('does NOT release a withheld command back to pending — it is terminal', async () => {
+      // The gate already drove `cmd-secret` to `failed` with its payload
+      // erased; releasing it would hand it straight back to the same
+      // incapable agent on the next claim.
+      failClaimedSecretCommandsMock.mockResolvedValueOnce([plainCommand]);
+
+      const delivered = await decryptClaimedCommandsForDelivery([plainCommand, secretCommand]);
+
+      expect(delivered.map((cmd) => cmd.id)).toEqual(['cmd-plain']);
+      expect(releaseClaimedCommandDeliveryMock).not.toHaveBeenCalled();
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('still releases a DECRYPT failure among the gate survivors (#2414 is unaffected)', async () => {
+      failClaimedSecretCommandsMock.mockResolvedValueOnce([plainCommand, undecryptable]);
+
+      const delivered = await decryptClaimedCommandsForDelivery([plainCommand, undecryptable, secretCommand]);
+
+      expect(delivered.map((cmd) => cmd.id)).toEqual(['cmd-plain']);
+      expect(releaseClaimedCommandDeliveryMock).toHaveBeenCalledTimes(1);
+      expect(releaseClaimedCommandDeliveryMock).toHaveBeenCalledWith('cmd-bad', claimedAt);
+    });
+
+    it('threads a caller-reported capability through to the gate as authoritative', async () => {
+      await decryptClaimedCommandsForDelivery([secretCommand], { reportedScriptSecretEnvVersion: 0 });
+      expect(failClaimedSecretCommandsMock).toHaveBeenCalledWith([secretCommand], { reportedVersion: 0 });
+    });
+
+    it('passes no reported version when the caller has none (stored-column fallback)', async () => {
+      await decryptClaimedCommandsForDelivery([secretCommand]);
+      expect(failClaimedSecretCommandsMock).toHaveBeenCalledWith([secretCommand], {});
+    });
   });
 });

--- a/apps/api/src/services/commandDelivery.ts
+++ b/apps/api/src/services/commandDelivery.ts
@@ -1,4 +1,5 @@
 import { releaseClaimedCommandDelivery } from './commandDispatch';
+import { failClaimedSecretCommandsForUnsupportedAgent } from './scriptSecretDelivery';
 import {
   decryptCommandsForDelivery,
   type DeliverableCommand,
@@ -39,24 +40,51 @@ export type ClaimedCommand = {
  * Successfully decrypted siblings in the same batch are always returned — one
  * bad payload never sinks the batch (and a release failure never throws out of
  * the delivery path).
+ *
+ * #3409 PR4c-2 — the secret-delivery claim gate runs FIRST, before anything is
+ * decrypted: a `script` command carrying a sealed `secretEnvEnvelope` must
+ * never be opened for an agent that cannot export the env var, because that
+ * agent would run the script with the credential silently unset. The gate
+ * drives such a command TERMINAL (`failed`, payload erased) and withholds it
+ * from the batch. Unlike the #2414 decrypt-failure path below, a withheld
+ * command is deliberately NOT released back to `pending` — an incapable agent
+ * would immediately re-claim it. Withheld ids therefore never reach the
+ * release loop, which only ever sees the gate's survivors.
+ *
+ * The gate needs the DB (a capability read plus terminal writes), so this
+ * function must be called inside a DB access context — the heartbeat's
+ * ambient org context on the heartbeat paths, an explicit system context on
+ * the self-managed-context REST poll (routes/agents/commands.ts).
+ *
+ * `opts.reportedScriptSecretEnvVersion` lets a caller that just received the
+ * agent's own capability report (the heartbeat) hand it to the gate as
+ * authoritative, avoiding both the extra select and the race against the
+ * heartbeat's own non-sticky device write.
  */
 export async function decryptClaimedCommandsForDelivery(
   claimed: ClaimedCommand[],
+  opts?: { reportedScriptSecretEnvVersion?: number },
 ): Promise<DeliverableCommand[]> {
+  const deliverable = await failClaimedSecretCommandsForUnsupportedAgent(claimed, {
+    ...(typeof opts?.reportedScriptSecretEnvVersion === 'number'
+      ? { reportedVersion: opts.reportedScriptSecretEnvVersion }
+      : {}),
+  });
+
   const delivered = decryptCommandsForDelivery(
-    claimed.map((cmd) => ({
+    deliverable.map((cmd) => ({
       id: cmd.id,
       type: cmd.type,
       deviceId: cmd.deviceId,
       payload: cmd.payload,
     })),
   );
-  if (delivered.length === claimed.length) {
+  if (delivered.length === deliverable.length) {
     return delivered;
   }
 
   const deliveredIds = new Set(delivered.map((cmd) => cmd.id));
-  for (const cmd of claimed) {
+  for (const cmd of deliverable) {
     if (deliveredIds.has(cmd.id)) continue;
     try {
       if (!cmd.executedAt) {

--- a/apps/api/src/services/commandDelivery.ts
+++ b/apps/api/src/services/commandDelivery.ts
@@ -45,11 +45,19 @@ export type ClaimedCommand = {
  * decrypted: a `script` command carrying a sealed `secretEnvEnvelope` must
  * never be opened for an agent that cannot export the env var, because that
  * agent would run the script with the credential silently unset. The gate
- * drives such a command TERMINAL (`failed`, payload erased) and withholds it
- * from the batch. Unlike the #2414 decrypt-failure path below, a withheld
- * command is deliberately NOT released back to `pending` — an incapable agent
- * would immediately re-claim it. Withheld ids therefore never reach the
- * release loop, which only ever sees the gate's survivors.
+ * withholds such a command from the batch — driving it TERMINAL (`failed`,
+ * payload erased) when the device row actually reports an unsupported
+ * version, or leaving it `sent` for the stale reaper when the device row
+ * could not be read at all (that refusal has to stay reversible; see
+ * scriptSecretDelivery.ts). Either way, and unlike the #2414 decrypt-failure
+ * path below, a withheld command is deliberately NOT released back to
+ * `pending` — an incapable agent would immediately re-claim it. Withheld ids
+ * therefore never reach the release loop, which only ever sees the gate's
+ * survivors.
+ *
+ * The gate throws only on a caller contract violation (a single agent's
+ * reported capability handed to a multi-device batch); that must surface, not
+ * be swallowed into a delivery.
  *
  * The gate needs the DB (a capability read plus terminal writes), so this
  * function must be called inside a DB access context — the heartbeat's

--- a/apps/api/src/services/fleetFindings/dispatch.test.ts
+++ b/apps/api/src/services/fleetFindings/dispatch.test.ts
@@ -149,6 +149,7 @@ vi.mock('../../db/schema', () => ({
     content: 'scripts.content',
     timeoutSeconds: 'scripts.timeoutSeconds',
     runAs: 'scripts.runAs',
+    parameters: 'scripts.parameters',
   },
 }));
 
@@ -237,6 +238,7 @@ vi.mock('../sensitiveCommandPayload', () => ({
 import {
   createRemediationRun,
   DISPATCH_ENQUEUE_FAILED_REASON,
+  REMEDIATION_BOUND_PARAMETER_ERROR,
   dispatchRunChunk,
   isTerminalRunStatus,
   markRunDispatchFailed,
@@ -394,6 +396,99 @@ describe('createRemediationRun — script validation', () => {
   it('accepts a script whose orgId matches the finding org', async () => {
     getFleetFindingMock.mockResolvedValue(findingDetail({ orgId: ORG_1 }));
     h.selectQueue.push([{ id: SCRIPT_1, orgId: ORG_1 }]);
+    h.selectQueue.push([]);
+    h.insertReturningQueue.push([{ id: RUN_1 }]);
+
+    const req: RemediateRequest = { actionKind: 'script', scriptId: SCRIPT_1, parameters: {} };
+    const result = await createRemediationRun(makeAuth(), FINDING_1, req);
+    expect(result.runId).toBe(RUN_1);
+  });
+});
+
+/**
+ * #3409 PR4c-2. Fleet remediation is the FOURTH script-dispatch path and the
+ * only one that does not go through `dispatchScriptToDevice`, so nothing here
+ * resolves a bound parameter, opens the tenant-variable scope, or seals a
+ * secret envelope. Until it does, a script that declares ANY non-`runtime`
+ * parameter must be refused rather than dispatched with the binding silently
+ * unresolved.
+ */
+describe('createRemediationRun — server-resolved parameter rejection (#3409 PR4c-2)', () => {
+  async function expectBoundParameterRejection(parameters: unknown): Promise<void> {
+    getFleetFindingMock.mockResolvedValue(findingDetail({ orgId: ORG_1 }));
+    h.selectQueue.push([{ id: SCRIPT_1, orgId: ORG_1, parameters }]);
+
+    const req: RemediateRequest = { actionKind: 'script', scriptId: SCRIPT_1, parameters: {} };
+    let caught: unknown;
+    try {
+      await createRemediationRun(makeAuth(), FINDING_1, req);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(RemediationRequestError);
+    expect((caught as RemediationRequestError).status).toBe(400);
+    expect((caught as RemediationRequestError).message).toBe(REMEDIATION_BOUND_PARAMETER_ERROR);
+    // Fails BEFORE the run row exists — a rejected remediation must leave no
+    // run for the worker to pick up.
+    expect(h.mockInsert).not.toHaveBeenCalled();
+  }
+
+  it('400s a script with a tenantSecret parameter', async () => {
+    await expectBoundParameterRejection([
+      { name: 'api_key', type: 'string', source: 'tenantSecret', variableKey: 'vendor_api_key' },
+    ]);
+  });
+
+  it('400s a script with a tenantVariable parameter', async () => {
+    await expectBoundParameterRejection([
+      { name: 'endpoint', type: 'string', source: 'tenantVariable', variableKey: 'vendor_endpoint' },
+    ]);
+  });
+
+  it('400s a script with a builtin parameter', async () => {
+    await expectBoundParameterRejection([{ name: 'org', type: 'string', source: 'builtin', builtinKey: 'org.name' }]);
+  });
+
+  it('400s a script with a deviceCustomField parameter', async () => {
+    await expectBoundParameterRejection([
+      { name: 'asset_tag', type: 'string', source: 'deviceCustomField', customFieldKey: 'asset_tag' },
+    ]);
+  });
+
+  it('400s a script whose ONLY bound definition is malformed (a binding we cannot read is never downgraded)', async () => {
+    await expectBoundParameterRejection([{ name: 'api_key', source: 'tenantSecret' }]);
+  });
+
+  it('400s when a bound parameter sits alongside runtime ones', async () => {
+    await expectBoundParameterRejection([
+      { name: 'first', type: 'string', source: 'runtime' },
+      { name: 'api_key', type: 'string', source: 'tenantSecret', variableKey: 'vendor_api_key' },
+    ]);
+  });
+
+  it('still accepts a script whose parameters are all runtime-sourced', async () => {
+    getFleetFindingMock.mockResolvedValue(findingDetail({ orgId: ORG_1 }));
+    h.selectQueue.push([
+      {
+        id: SCRIPT_1,
+        orgId: ORG_1,
+        parameters: [
+          { name: 'service_name', type: 'string', source: 'runtime' },
+          { name: 'implicit_default', type: 'string' },
+        ],
+      },
+    ]);
+    h.selectQueue.push([]);
+    h.insertReturningQueue.push([{ id: RUN_1 }]);
+
+    const req: RemediateRequest = { actionKind: 'script', scriptId: SCRIPT_1, parameters: { service_name: 'spooler' } };
+    const result = await createRemediationRun(makeAuth(), FINDING_1, req);
+    expect(result.runId).toBe(RUN_1);
+  });
+
+  it('still accepts a script with no parameter definitions at all', async () => {
+    getFleetFindingMock.mockResolvedValue(findingDetail({ orgId: ORG_1 }));
+    h.selectQueue.push([{ id: SCRIPT_1, orgId: ORG_1, parameters: null }]);
     h.selectQueue.push([]);
     h.insertReturningQueue.push([{ id: RUN_1 }]);
 
@@ -843,6 +938,61 @@ describe('dispatchRunChunk', () => {
     h.selectQueue.push([{ orgId: null, language: 'bash', content: 'echo hi', timeoutSeconds: 60, runAs: 'system' }]);
     h.updateReturningQueue.push([{ targetDeviceUuid: DEVICE_1 }]);
     queueCommandForExecutionMock.mockResolvedValue({ command: { id: 'cmd-4' } });
+
+    await dispatchRunChunk(RUN_1, 0);
+
+    expect(queueCommandForExecutionMock).toHaveBeenCalledWith(
+      DEVICE_1,
+      'script',
+      expect.objectContaining({ content: 'echo hi' }),
+      expect.anything()
+    );
+  });
+
+  /**
+   * #3409 PR4c-2 drift guard. The re-fetch exists precisely because a script
+   * can be edited between run creation and dispatch; adding a bound parameter
+   * is the edit that turns an accepted run into an unresolved-binding run.
+   */
+  it('regression: fails a script target when the script GAINED a bound parameter after run creation', async () => {
+    h.selectQueue.push([runRow({ status: 'running', actionKind: 'script', commandType: null, scriptId: SCRIPT_1 })]);
+    h.selectQueue.push([{ runId: RUN_1, orgId: ORG_1, targetDeviceUuid: DEVICE_1, status: 'pending' }]);
+    h.selectQueue.push([{ id: DEVICE_1, status: 'online' }]); // liveness probe
+    h.selectQueue.push([
+      {
+        orgId: ORG_1,
+        language: 'bash',
+        content: 'echo $BREEZE_VAR_API_KEY',
+        timeoutSeconds: 60,
+        runAs: 'system',
+        parameters: [{ name: 'api_key', type: 'string', source: 'tenantSecret', variableKey: 'vendor_api_key' }],
+      },
+    ]);
+    h.updateReturningQueue.push([{ targetDeviceUuid: DEVICE_1 }]);
+
+    await dispatchRunChunk(RUN_1, 0);
+
+    expect(queueCommandForExecutionMock).not.toHaveBeenCalled();
+    const failedUpdate = h.capturedUpdates.find((u) => (u.values as Record<string, unknown>).status === 'failed')!;
+    expect(failedUpdate.values).toMatchObject({ status: 'failed', resultSummary: REMEDIATION_BOUND_PARAMETER_ERROR });
+  });
+
+  it('still dispatches a script target whose parameters are all runtime-sourced', async () => {
+    h.selectQueue.push([runRow({ status: 'running', actionKind: 'script', commandType: null, scriptId: SCRIPT_1 })]);
+    h.selectQueue.push([{ runId: RUN_1, orgId: ORG_1, targetDeviceUuid: DEVICE_1, status: 'pending' }]);
+    h.selectQueue.push([{ id: DEVICE_1, status: 'online' }]); // liveness probe
+    h.selectQueue.push([
+      {
+        orgId: ORG_1,
+        language: 'bash',
+        content: 'echo hi',
+        timeoutSeconds: 60,
+        runAs: 'system',
+        parameters: [{ name: 'service_name', type: 'string', source: 'runtime' }],
+      },
+    ]);
+    h.updateReturningQueue.push([{ targetDeviceUuid: DEVICE_1 }]);
+    queueCommandForExecutionMock.mockResolvedValue({ command: { id: 'cmd-5' } });
 
     await dispatchRunChunk(RUN_1, 0);
 

--- a/apps/api/src/services/fleetFindings/dispatch.ts
+++ b/apps/api/src/services/fleetFindings/dispatch.ts
@@ -27,7 +27,9 @@
  *     shape compatible with this dispatcher's one-command-per-target model.
  *   - 'script' actionKind (not a commandType) -> CommandTypes.SCRIPT ('script'),
  *     requires `scriptId`; payload built from the resolved script row,
- *     mirroring aiToolsScripts.ts's `run_script` tool.
+ *     mirroring aiToolsScripts.ts's `run_script` tool. RESTRICTED to scripts
+ *     whose parameters are all `runtime`-sourced — see
+ *     {@link REMEDIATION_BOUND_PARAMETER_ERROR}.
  */
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 
@@ -46,11 +48,48 @@ import type { AuthContext } from '../../middleware/auth';
 import { CommandTypes, queueCommandForExecution } from '../commandQueue';
 import { terminalPayloadErasureSet } from '../sensitiveCommandPayload';
 import { captureException } from '../sentry';
+import { hasTenantVariableBoundParameters } from '../sourcedParameters';
 import { getFleetFinding } from './query';
 
 /** Real commandType values a caller may request under `actionKind: 'command'`. */
 export const REMEDIATION_COMMAND_TYPE_ALLOWLIST = ['restart_service', 'reboot'] as const;
 export type RemediationCommandType = (typeof REMEDIATION_COMMAND_TYPE_ALLOWLIST)[number];
+
+/**
+ * #3409 PR4c-2. Fleet remediation is the FOURTH script-dispatch path and the
+ * only one that does not go through `dispatchScriptToDevice`
+ * (`services/scriptDispatch.ts`) — it owns its own bulk target/result model,
+ * so it never calls `resolveSourcedParameters`, never opens the tenant
+ * variable scope, and never seals a `secretEnvEnvelope`. A script declaring a
+ * bound (non-`runtime`) parameter therefore cannot be dispatched from here
+ * without silently running with that binding UNRESOLVED — `BREEZE_VAR_*`
+ * unset, `BREEZE_PARAM_*` empty, and no error anywhere. For a `tenantSecret`
+ * that is the exact silent-wrong-run PR4c exists to prevent, so this path
+ * refuses the script instead, at run creation AND again at dispatch.
+ */
+export const REMEDIATION_BOUND_PARAMETER_ERROR =
+  'Scripts with server-resolved parameters (variables, secrets, device fields) cannot be used for fleet remediation yet';
+
+/**
+ * Does this script declare ANY parameter whose value the SERVER must resolve?
+ *
+ * `hasTenantVariableBoundParameters` (`services/sourcedParameters.ts`, the one
+ * authority) answers this for the two variable-backed sources; `builtin` and
+ * `deviceCustomField` are equally unresolvable on this path, so they are
+ * folded in with the same deliberately-tolerant element-by-element scan. A
+ * `source` that is present but not the string `'runtime'` counts as bound even
+ * when the rest of the element fails to parse — a binding we cannot READ must
+ * never be downgraded to "the caller may supply it".
+ */
+function hasServerResolvedParameters(parameters: unknown): boolean {
+  if (hasTenantVariableBoundParameters(parameters)) return true;
+  if (!Array.isArray(parameters)) return false;
+  return parameters.some((element) => {
+    if (element === null || typeof element !== 'object') return false;
+    const source = (element as { source?: unknown }).source;
+    return typeof source === 'string' && source !== 'runtime';
+  });
+}
 
 interface RemediateRequestBase {
   parameters: Record<string, unknown>;
@@ -400,7 +439,7 @@ async function validateRemediationScript(
   findingOrgId: string
 ): Promise<{ error?: string }> {
   const [script] = await db
-    .select({ id: scripts.id, orgId: scripts.orgId })
+    .select({ id: scripts.id, orgId: scripts.orgId, parameters: scripts.parameters })
     .from(scripts)
     .where(and(eq(scripts.id, scriptId), isNull(scripts.deletedAt)))
     .limit(1);
@@ -410,6 +449,12 @@ async function validateRemediationScript(
   }
   if (script.orgId !== null && script.orgId !== findingOrgId) {
     return { error: 'Script does not belong to an accessible organization' };
+  }
+  // Refuse at CREATION so the caller gets a 400 they can act on, rather than a
+  // run that queues and then fails every target. See
+  // REMEDIATION_BOUND_PARAMETER_ERROR for why this path cannot resolve them.
+  if (hasServerResolvedParameters(script.parameters)) {
+    return { error: REMEDIATION_BOUND_PARAMETER_ERROR };
   }
   return {};
 }
@@ -552,6 +597,11 @@ export async function dispatchRunChunk(runId: string, chunkIndex: number): Promi
   let reportedUnexpected = false;
 
   let scriptPayload: { language: string; content: string; timeoutSeconds: number; runAs: string } | null = null;
+  // Why the reason is a variable: a script that GAINED a bound parameter since
+  // run creation is unavailable to this path for a different reason than one
+  // that was deleted or re-tenanted, and "Script no longer available" would
+  // send the operator looking for a deletion that never happened.
+  let scriptUnavailableReason = 'Script no longer available';
   if (run.actionKind === 'script' && run.scriptId) {
     // Re-fetch under the SAME guards as validateRemediationScript at
     // creation time: non-deleted, and either org-less (system/universal
@@ -566,11 +616,23 @@ export async function dispatchRunChunk(runId: string, chunkIndex: number): Promi
         content: scripts.content,
         timeoutSeconds: scripts.timeoutSeconds,
         runAs: scripts.runAs,
+        parameters: scripts.parameters,
       })
       .from(scripts)
       .where(and(eq(scripts.id, run.scriptId), isNull(scripts.deletedAt)))
       .limit(1);
-    scriptPayload = script && (script.orgId === null || script.orgId === run.orgId) ? script : null;
+    if (script && (script.orgId === null || script.orgId === run.orgId)) {
+      // Defence in depth for #3409 PR4c-2: `validateRemediationScript` already
+      // refused this script at creation, but the re-fetch exists precisely
+      // because the row can be EDITED in between — and adding a bound
+      // parameter is the edit that turns an accepted run into one that would
+      // dispatch with the binding unresolved. Fail the targets loudly instead.
+      if (hasServerResolvedParameters(script.parameters)) {
+        scriptUnavailableReason = REMEDIATION_BOUND_PARAMETER_ERROR;
+      } else {
+        scriptPayload = script;
+      }
+    }
   }
 
   for (const target of pendingTargets) {
@@ -617,9 +679,14 @@ export async function dispatchRunChunk(runId: string, chunkIndex: number): Promi
 
       if (run.actionKind === 'script') {
         if (!scriptPayload) {
-          throw new Error('Script no longer available');
+          throw new Error(scriptUnavailableReason);
         }
         type = CommandTypes.SCRIPT;
+        // #3409 PR4c-2: `parameters` here is the caller's snapshot verbatim —
+        // this path has no server-side resolution and NO secret envelope, so
+        // only runtime-sourced scripts ever reach it (guarded twice above).
+        // Adding a bound parameter to this payload requires routing the path
+        // through `dispatchScriptToDevice` first, not a resolver call here.
         payload = {
           scriptId: run.scriptId,
           language: scriptPayload.language,

--- a/apps/api/src/services/scriptBundle/index.test.ts
+++ b/apps/api/src/services/scriptBundle/index.test.ts
@@ -71,6 +71,8 @@ import {
   MAX_BUNDLE_CONTENT_LENGTH
 } from './schema';
 import { PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../partnerWideAccess';
+import { MAX_SECRET_ENV_ENTRIES } from '../scriptSecretEnvelope';
+import { MAX_SECRET_SCRIPT_PARAMETERS } from '@breeze/shared';
 
 function makeAuth(overrides: Partial<BundleAuth> = {}): BundleAuth {
   return {
@@ -723,6 +725,109 @@ describe('importBundle', () => {
       );
     }
     expect(h.state.inserts).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------
+  // MSP -> customer descent: binding a PARTNER-WIDE secret (#3409 PR4c-2).
+  //
+  // `tenantVariableReadCondition` deliberately shows partner-wide variable
+  // KEYS to organization-scope sessions, and `resolveForOrg` inherits
+  // partner-wide rows into every org. Without a gate an Org Admin of a
+  // CUSTOMER org could bind the MSP's own partner-wide secret and base64 it
+  // out through script output (both redactors are exact-substring). This is
+  // the only channel in the product through which a secret's plaintext leaves
+  // the server at all, so it must not cross the MSP -> customer boundary.
+  // ---------------------------------------------------------------------
+  // A partner-wide tenant_variables row: org_id IS NULL, hence ownerScope
+  // 'partner' once resolveForOrg attributes it to the target org.
+  const partnerSecretRow = {
+    id: 'tv-3',
+    key: 'psa_api_token',
+    value: 'shh',
+    isSecret: true,
+    version: 1,
+    ownerOrgId: null,
+    forOrgId: ORG_ID
+  };
+
+  it('rejects an org-scope import binding a PARTNER-WIDE secret (no partner-wide capability)', async () => {
+    const bundle = validBundle([
+      { ...baseEntry, parameters: [{ name: 'psa', type: 'string', source: 'tenantSecret', variableKey: 'psa_api_token' }] }
+    ]);
+    h.state.selectQueue.push([partnerSecretRow]);
+    const result = await importBundle(makeAuth(), bundle, { mode: 'skip', availability: 'org' });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) {
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]!.error).toBe(
+        'Parameter "psa" binds partner-wide secret variable "psa_api_token"; only a partner administrator can bind a partner-wide secret.'
+      );
+    }
+    expect(h.state.inserts).toHaveLength(0);
+  });
+
+  it('ALLOWS a full-partner admin to bind a partner-wide secret into an org-scoped script', async () => {
+    const auth = makeAuth({
+      scope: 'partner',
+      orgId: null,
+      partnerOrgAccess: 'all',
+      accessibleOrgIds: [ORG_ID]
+    });
+    const bundle = validBundle([
+      { ...baseEntry, parameters: [{ name: 'psa', type: 'string', source: 'tenantSecret', variableKey: 'psa_api_token' }] }
+    ]);
+    h.state.selectQueue.push(
+      [partnerSecretRow], // parameter lookup via resolveForOrg(ORG_ID)
+      [] // findConflictByName -> none
+    );
+    const result = await importBundle(auth, bundle, { mode: 'skip', availability: 'org', orgId: ORG_ID });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) expect(result.errors).toHaveLength(0);
+    if ('imported' in result) expect(result.imported).toBe(1);
+  });
+
+  it('leaves an ORG-owned secret binding unaffected for the same org-scope caller', async () => {
+    const bundle = validBundle([
+      { ...baseEntry, parameters: [{ name: 'q', type: 'string', source: 'tenantSecret', variableKey: 's1_token' }] }
+    ]);
+    h.state.selectQueue.push(
+      [secretRow], // ownerOrgId === ORG_ID -> ownerScope 'organization'
+      [] // findConflictByName -> none
+    );
+    const result = await importBundle(makeAuth(), bundle, { mode: 'skip', availability: 'org' });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) expect(result.errors).toHaveLength(0);
+    if ('imported' in result) expect(result.imported).toBe(1);
+  });
+
+  // A tenantVariable (non-secret source) binding to a partner-wide SECRET is
+  // still the pre-existing secretBoundAsPlain rejection, not the new one —
+  // the new kind must not swallow the older, more specific message.
+  it('still reports secretBoundAsPlain for a tenantVariable bound to a partner-wide secret', async () => {
+    const bundle = validBundle([
+      { ...baseEntry, parameters: [{ name: 'psa', type: 'string', source: 'tenantVariable', variableKey: 'psa_api_token' }] }
+    ]);
+    h.state.selectQueue.push([partnerSecretRow]);
+    const result = await importBundle(makeAuth(), bundle, { mode: 'skip', availability: 'org' });
+    if ('errors' in result) {
+      expect(result.errors[0]!.error).toBe(
+        'Parameter "psa" binds secret variable "psa_api_token" with source "From a variable"; use a secret parameter instead'
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Secret-parameter cap parity (#3409 PR4c-2, finding 3).
+//
+// `packages/shared` may not import from `apps/api`, so the save-time cap is a
+// restatement of the envelope's own bound. This assertion is the ONLY thing
+// stopping the two from drifting — if the envelope limit moves, the save-time
+// schema must move with it or scripts save that can never dispatch.
+// ---------------------------------------------------------------------------
+describe('secret-parameter cap parity', () => {
+  it('pins MAX_SECRET_SCRIPT_PARAMETERS to the envelope authority MAX_SECRET_ENV_ENTRIES', () => {
+    expect(MAX_SECRET_SCRIPT_PARAMETERS).toBe(MAX_SECRET_ENV_ENTRIES);
   });
 });
 

--- a/apps/api/src/services/scriptBundle/index.test.ts
+++ b/apps/api/src/services/scriptBundle/index.test.ts
@@ -640,6 +640,90 @@ describe('importBundle', () => {
     }
     expect(h.state.inserts).toHaveLength(0);
   });
+
+  // ---------------------------------------------------------------------
+  // Save-time parameter-binding secret mismatch (#3409 PR4c-2, Task 6)
+  // ---------------------------------------------------------------------
+  const secretRow = { id: 'tv-1', key: 's1_token', value: 'shh', isSecret: true, version: 1, ownerOrgId: ORG_ID, forOrgId: ORG_ID };
+  const plainRow = { id: 'tv-2', key: 'repo_url', value: 'https://dl.example', isSecret: false, version: 1, ownerOrgId: ORG_ID, forOrgId: ORG_ID };
+
+  it('rejects a bundle entry whose tenantVariable parameter binds a SECRET variable, per-entry', async () => {
+    const bundle = validBundle([
+      { ...baseEntry, parameters: [{ name: 'p', type: 'string', source: 'tenantVariable', variableKey: 's1_token' }] },
+      { ...baseEntry, name: 'Second script' }
+    ]);
+    h.state.selectQueue.push(
+      [secretRow], // entry 1: content has no tokens → only the parameter lookup (loadTenantVariableScope)
+      [] // entry 2: findExistingByName → none
+    );
+    const result = await importBundle(makeAuth(), bundle, { mode: 'skip', availability: 'org' });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) {
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]!.index).toBe(0);
+      expect(result.errors[0]!.error).toBe(
+        'Parameter "p" binds secret variable "s1_token" with source "From a variable"; use a secret parameter instead'
+      );
+      expect(result.imported).toBe(1);
+    }
+    expect(h.state.inserts.filter((i) => i.table === scripts)).toHaveLength(1);
+  });
+
+  it('rejects a bundle entry whose tenantSecret parameter binds a NON-secret variable, per-entry', async () => {
+    const bundle = validBundle([
+      { ...baseEntry, parameters: [{ name: 'p', type: 'string', source: 'tenantSecret', variableKey: 'repo_url' }] }
+    ]);
+    h.state.selectQueue.push([plainRow]);
+    const result = await importBundle(makeAuth(), bundle, { mode: 'skip', availability: 'org' });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) {
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]!.error).toBe('Parameter "p" is a secret parameter but variable "repo_url" is not a secret');
+      expect(result.imported).toBe(0);
+    }
+    expect(h.state.inserts).toHaveLength(0);
+  });
+
+  it('imports a bundle entry whose bindings target UNKNOWN keys or match their targets', async () => {
+    const bundle = validBundle([
+      {
+        ...baseEntry,
+        parameters: [
+          { name: 'p', type: 'string', source: 'tenantVariable', variableKey: 'repo_url' },
+          { name: 'q', type: 'string', source: 'tenantSecret', variableKey: 's1_token' },
+          { name: 'r', type: 'string', source: 'tenantSecret', variableKey: 'not_yet_created' }
+        ]
+      }
+    ]);
+    h.state.selectQueue.push(
+      [secretRow, plainRow], // loadTenantVariableScope([ORG_ID])
+      [] // findExistingByName → none
+    );
+    const result = await importBundle(makeAuth(), bundle, { mode: 'skip', availability: 'org' });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) expect(result.errors).toHaveLength(0);
+    if ('imported' in result) expect(result.imported).toBe(1);
+  });
+
+  it('still rejects on CONTENT secrets first, with the content message, when both content and parameters offend', async () => {
+    const bundle = validBundle([
+      {
+        ...baseEntry,
+        content: 'echo {{var.s1_token}}',
+        parameters: [{ name: 'p', type: 'string', source: 'tenantVariable', variableKey: 's1_token' }]
+      }
+    ]);
+    h.state.selectQueue.push([secretRow]); // content lookup short-circuits before the parameter lookup
+    const result = await importBundle(makeAuth(), bundle, { mode: 'skip', availability: 'org' });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) {
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]!.error).toBe(
+        'Script content references secret variable(s): {{var.s1_token}}. Secret variables cannot be substituted into script content.'
+      );
+    }
+    expect(h.state.inserts).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/services/scriptBundle/index.test.ts
+++ b/apps/api/src/services/scriptBundle/index.test.ts
@@ -728,15 +728,17 @@ describe('importBundle', () => {
   });
 
   // ---------------------------------------------------------------------
-  // MSP -> customer descent: binding a PARTNER-WIDE secret (#3409 PR4c-2).
+  // Ownership TIER of the secret vs. the SCRIPT (#3409 PR4c-2 review).
   //
-  // `tenantVariableReadCondition` deliberately shows partner-wide variable
-  // KEYS to organization-scope sessions, and `resolveForOrg` inherits
-  // partner-wide rows into every org. Without a gate an Org Admin of a
-  // CUSTOMER org could bind the MSP's own partner-wide secret and base64 it
-  // out through script output (both redactors are exact-substring). This is
-  // the only channel in the product through which a secret's plaintext leaves
-  // the server at all, so it must not cross the MSP -> customer boundary.
+  // A script may resolve a secret at or below its own ownership tier, never
+  // above: a partner-wide script (org_id NULL) may bind a partner-owned OR an
+  // org-owned secret; an ORG-scoped script may bind only an org-owned one.
+  // The rule is NOT a caller capability — a full-partner admin saving an
+  // org-scoped script is still denied, because that script is afterwards
+  // editable and runnable by the customer org's own admins.
+  //
+  // Dispatch is the authority (services/sourcedParameters.ts, `tenantSecret`
+  // arm); these cases pin the save-time FAST FAIL.
   // ---------------------------------------------------------------------
   // A partner-wide tenant_variables row: org_id IS NULL, hence ownerScope
   // 'partner' once resolveForOrg attributes it to the target org.
@@ -750,23 +752,69 @@ describe('importBundle', () => {
     forOrgId: ORG_ID
   };
 
-  it('rejects an org-scope import binding a PARTNER-WIDE secret (no partner-wide capability)', async () => {
-    const bundle = validBundle([
-      { ...baseEntry, parameters: [{ name: 'psa', type: 'string', source: 'tenantSecret', variableKey: 'psa_api_token' }] }
-    ]);
+  const TIER_DENIED =
+    'Parameter "psa" binds partner-wide secret variable "psa_api_token"; an organization-scoped script cannot use one — make the script partner-wide, or use an organization-owned secret.';
+
+  const psaSecretParam = { name: 'psa', type: 'string', source: 'tenantSecret', variableKey: 'psa_api_token' };
+
+  it('rejects an ORG-scoped import binding a PARTNER-WIDE secret', async () => {
+    const bundle = validBundle([{ ...baseEntry, parameters: [psaSecretParam] }]);
     h.state.selectQueue.push([partnerSecretRow]);
     const result = await importBundle(makeAuth(), bundle, { mode: 'skip', availability: 'org' });
     expect('error' in result).toBe(false);
     if ('errors' in result) {
       expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]!.error).toBe(
-        'Parameter "psa" binds partner-wide secret variable "psa_api_token"; only a partner administrator can bind a partner-wide secret.'
-      );
+      expect(result.errors[0]!.error).toBe(TIER_DENIED);
     }
     expect(h.state.inserts).toHaveLength(0);
   });
 
-  it('ALLOWS a full-partner admin to bind a partner-wide secret into an org-scoped script', async () => {
+  // The rule is the SCRIPT's tier, not the caller's capability: a full-partner
+  // admin importing into ONE org is writing an org-scoped script, which that
+  // org's admins can then edit and run.
+  it('rejects an ORG-scoped import binding a PARTNER-WIDE secret even for a full-partner admin', async () => {
+    const auth = makeAuth({
+      scope: 'partner',
+      orgId: null,
+      partnerOrgAccess: 'all',
+      accessibleOrgIds: [ORG_ID]
+    });
+    const bundle = validBundle([{ ...baseEntry, parameters: [psaSecretParam] }]);
+    h.state.selectQueue.push([partnerSecretRow]);
+    const result = await importBundle(auth, bundle, { mode: 'skip', availability: 'org', orgId: ORG_ID });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) {
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]!.error).toBe(TIER_DENIED);
+    }
+    expect(h.state.inserts).toHaveLength(0);
+  });
+
+  it("ALLOWS a PARTNER-WIDE import binding the partner's own secret", async () => {
+    const auth = makeAuth({
+      scope: 'partner',
+      orgId: null,
+      partnerOrgAccess: 'all',
+      accessibleOrgIds: [ORG_ID]
+    });
+    const bundle = validBundle([{ ...baseEntry, parameters: [psaSecretParam] }]);
+    h.state.selectQueue.push(
+      // Partner-wide branch: tenant_variables read directly (org_id IS NULL).
+      [{ key: 'psa_api_token', isSecret: true }],
+      [] // findConflictByName -> none
+    );
+    const result = await importBundle(auth, bundle, { mode: 'skip', availability: 'partner' });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) expect(result.errors).toHaveLength(0);
+    if ('imported' in result) expect(result.imported).toBe(1);
+    const values = h.state.inserts.find((i) => i.table === scripts)!.values as Record<string, unknown>;
+    expect(values.orgId).toBeNull();
+  });
+
+  // The PRIMARY use case: one partner-wide script, each target org's OWN value
+  // resolved per device at dispatch. Save time sees no partner-wide row for the
+  // key, so it is "unknown" here — and must not be rejected on that basis.
+  it('ALLOWS a PARTNER-WIDE import binding a key that only exists as an ORG-owned secret', async () => {
     const auth = makeAuth({
       scope: 'partner',
       orgId: null,
@@ -774,13 +822,13 @@ describe('importBundle', () => {
       accessibleOrgIds: [ORG_ID]
     });
     const bundle = validBundle([
-      { ...baseEntry, parameters: [{ name: 'psa', type: 'string', source: 'tenantSecret', variableKey: 'psa_api_token' }] }
+      { ...baseEntry, parameters: [{ name: 'q', type: 'string', source: 'tenantSecret', variableKey: 's1_token' }] }
     ]);
     h.state.selectQueue.push(
-      [partnerSecretRow], // parameter lookup via resolveForOrg(ORG_ID)
+      [], // no partner-wide row named s1_token
       [] // findConflictByName -> none
     );
-    const result = await importBundle(auth, bundle, { mode: 'skip', availability: 'org', orgId: ORG_ID });
+    const result = await importBundle(auth, bundle, { mode: 'skip', availability: 'partner' });
     expect('error' in result).toBe(false);
     if ('errors' in result) expect(result.errors).toHaveLength(0);
     if ('imported' in result) expect(result.imported).toBe(1);

--- a/apps/api/src/services/scriptBundle/index.ts
+++ b/apps/api/src/services/scriptBundle/index.ts
@@ -87,11 +87,32 @@ export async function findSecretVariableReferences(
 ): Promise<string[]> {
   const keys = findVariableTokens(content);
   if (keys.length === 0) return [];
+  const isSecretByKey = await lookupIsSecretByKey(scope, keys);
+  return keys.filter((key) => isSecretByKey.get(key) === true);
+}
+
+/**
+ * The single save-time "is this key a secret for this scope?" lookup shared
+ * by {@link findSecretVariableReferences} (content tokens) and
+ * {@link findParameterSecretMismatches} (parameter bindings). One DB round
+ * trip per call. A key with no matching row is ABSENT from the result — the
+ * two callers each treat absence as "unknown, allow" (see their docblocks).
+ */
+async function lookupIsSecretByKey(
+  scope: ScriptCreateScope,
+  keys: string[]
+): Promise<Map<string, boolean>> {
+  const result = new Map<string, boolean>();
+  if (keys.length === 0) return result;
 
   if (scope.orgId) {
     const variableScope = await loadTenantVariableScope([scope.orgId]);
     const resolved = resolveForOrg(variableScope, scope.orgId);
-    return keys.filter((key) => resolved.get(key)?.isSecret === true);
+    for (const key of keys) {
+      const variable = resolved.get(key);
+      if (variable) result.set(key, variable.isSecret === true);
+    }
+    return result;
   }
 
   if (scope.partnerId) {
@@ -105,17 +126,116 @@ export async function findSecretVariableReferences(
           inArray(tenantVariables.key, keys)
         )
       );
-    const secretKeys = new Set(rows.filter((r) => r.isSecret).map((r) => r.key));
-    return keys.filter((key) => secretKeys.has(key));
+    for (const row of rows) result.set(row.key, row.isSecret === true);
+    return result;
   }
 
-  return [];
+  return result;
 }
 
 /** User-facing 400 message for {@link findSecretVariableReferences}'s non-empty result. Names only KEYS, never a value. */
 export function describeSecretVariableRejection(offendingKeys: string[]): string {
   const tokens = offendingKeys.map((key) => `{{var.${key}}}`).join(', ');
   return `Script content references secret variable(s): ${tokens}. Secret variables cannot be substituted into script content.`;
+}
+
+export type ParameterSecretMismatchKind = 'secretBoundAsPlain' | 'plainBoundAsSecret';
+
+export interface ParameterSecretMismatch {
+  /** Parameter NAME — never a value. */
+  name: string;
+  /** Tenant-variable KEY — never a value. */
+  variableKey: string;
+  kind: ParameterSecretMismatchKind;
+}
+
+/**
+ * A raw parameter definition element that binds to a tenant variable.
+ * Parsed TOLERANTLY, element by element (same posture as `parseDefinitions`
+ * in services/sourcedParameters.ts): a malformed sibling must not hide a
+ * real mismatch, and this check must not depend on the full union parsing —
+ * it only needs `source` and `variableKey`, which it reads straight off the
+ * element.
+ */
+interface VariableBoundParameter {
+  name: string;
+  source: 'tenantVariable' | 'tenantSecret';
+  variableKey: string;
+}
+
+function readVariableBoundParameters(parameters: unknown): VariableBoundParameter[] {
+  if (!Array.isArray(parameters)) return [];
+  const bound: VariableBoundParameter[] = [];
+  for (const element of parameters) {
+    if (!element || typeof element !== 'object') continue;
+    const { name, source, variableKey } = element as Record<string, unknown>;
+    if (source !== 'tenantVariable' && source !== 'tenantSecret') continue;
+    if (typeof variableKey !== 'string' || variableKey.length === 0) continue;
+    bound.push({
+      name: typeof name === 'string' ? name : '',
+      source,
+      variableKey
+    });
+  }
+  return bound;
+}
+
+/**
+ * Save-time parameter-binding secret check (#3409 PR4c-2, Task 6) — the
+ * parameter-side twin of {@link findSecretVariableReferences}, called at the
+ * same three ingresses (POST/PUT `/scripts`, `importBundle`) right after it.
+ *
+ * Secret delivery is DECLARED, never inferred (settled design §1):
+ *
+ * - `source: 'tenantVariable'` bound to a SECRET key → `secretBoundAsPlain`.
+ *   Dispatch already denies this per device; rejecting it at save time is
+ *   what the web form's warning ("the save will be rejected") promises.
+ * - `source: 'tenantSecret'` bound to a NON-secret key → `plainBoundAsSecret`.
+ *   Dispatch fails that device closed; a save-time 400 says why up front.
+ *
+ * An UNKNOWN key produces NO mismatch, for the same reason as the content
+ * check: the variable may not exist yet, and a partner-wide script is
+ * resolved per org at dispatch, where each device fails loudly on its own.
+ * Only one lookup is issued per call, whatever the number of bindings.
+ */
+export async function findParameterSecretMismatches(
+  scope: ScriptCreateScope,
+  parameters: unknown
+): Promise<ParameterSecretMismatch[]> {
+  const bound = readVariableBoundParameters(parameters);
+  if (bound.length === 0) return [];
+
+  const keys = [...new Set(bound.map((p) => p.variableKey))];
+  const isSecretByKey = await lookupIsSecretByKey(scope, keys);
+
+  const mismatches: ParameterSecretMismatch[] = [];
+  for (const parameter of bound) {
+    const isSecret = isSecretByKey.get(parameter.variableKey);
+    if (isSecret === undefined) continue; // unknown key — allowed
+    if (parameter.source === 'tenantVariable' && isSecret) {
+      mismatches.push({ name: parameter.name, variableKey: parameter.variableKey, kind: 'secretBoundAsPlain' });
+    } else if (parameter.source === 'tenantSecret' && !isSecret) {
+      mismatches.push({ name: parameter.name, variableKey: parameter.variableKey, kind: 'plainBoundAsSecret' });
+    }
+  }
+  return mismatches;
+}
+
+/**
+ * User-facing 400 message for {@link findParameterSecretMismatches}'s
+ * non-empty result. Names parameter NAMES and variable KEYS only — never a
+ * value (settled design §5). "From a variable" is the web form's label for
+ * the `tenantVariable` source, so the message reads against what the tech
+ * actually selected.
+ */
+export function describeParameterSecretMismatch(mismatches: ParameterSecretMismatch[]): string {
+  return mismatches
+    .map((m) =>
+      m.kind === 'secretBoundAsPlain'
+        ? `Parameter "${m.name}" binds secret variable "${m.variableKey}" with source "From a variable"; use a secret parameter instead`
+        : `Parameter "${m.name}" is a secret parameter but variable "${m.variableKey}" is not a secret`
+    )
+    .join('; ');
 }
 
 export type BundleAuth = ScriptWriteAuth & Pick<AuthContext, 'user'>;
@@ -504,6 +624,14 @@ export async function importBundle(
       const secretRefs = await findSecretVariableReferences(scope, entry.content);
       if (secretRefs.length > 0) {
         result.errors.push({ index, name: entry.name, error: describeSecretVariableRejection(secretRefs) });
+        continue;
+      }
+      // Parameter-binding twin of the content check (#3409 PR4c-2, Task 6):
+      // a tenantVariable→secret or tenantSecret→non-secret binding is a
+      // per-entry error the same way.
+      const mismatches = await findParameterSecretMismatches(scope, entry.parameters);
+      if (mismatches.length > 0) {
+        result.errors.push({ index, name: entry.name, error: describeParameterSecretMismatch(mismatches) });
         continue;
       }
 

--- a/apps/api/src/services/scriptBundle/index.ts
+++ b/apps/api/src/services/scriptBundle/index.ts
@@ -34,7 +34,6 @@ import {
   type ScriptScopeError,
   type ScriptWriteAuth
 } from '../scriptWrite';
-import { canManagePartnerWidePolicies } from '../partnerWideAccess';
 import { loadTenantVariableScope, resolveForOrg } from '../tenantVariableResolution';
 import {
   SCRIPT_BUNDLE_VERSION,
@@ -198,48 +197,11 @@ function readVariableBoundParameters(parameters: unknown): VariableBoundParamete
 }
 
 /**
- * Caller capability, computed at the route/service boundary and passed in
- * rather than read off an `AuthContext` here — this module never sees auth.
- *
- * `allowPartnerOwnedSecrets` is ALWAYS `canManagePartnerWidePolicies(auth)`
- * (services/partnerWideAccess.ts — the repo's single source of truth for
- * partner-wide writes, which admits system scope and full-partner admins only).
- *
- * ## Why the gate exists
- *
- * `tenantVariableReadCondition` deliberately widens partner-wide variable rows
- * to ORGANIZATION-scope sessions (keys only — values are always dropped), and
- * `resolveForOrg` inherits partner-wide rows into every org under the partner.
- * Without this gate an Org Admin of a CUSTOMER org could bind the MSP's own
- * partner-wide secret into an org-scoped script — `resolveScriptCreateScope`
- * grants any org-scope caller with `scripts:write` an org-scoped script — and
- * run it on their own device. `tenantSecret` delivery is the first and only
- * channel through which a secret's PLAINTEXT leaves the server, and both
- * redactors are exact-substring, so trivial re-encoding (base64) defeats them.
- *
- * The settled "running a script implies use of the secrets it binds" position
- * was written for ORG-owned secrets, where the script author already owns the
- * value. It does not license the partner→org descent, which crosses the
- * MSP→customer trust boundary.
- *
- * ## Why it must be enforced at EVERY write ingress
- *
- * This is a SAVE-time gate and cannot be re-checked at dispatch: automation,
- * schedules and AI dispatch run under a system DB context with no author auth
- * to test, so there is nothing to gate on by then. Every path that writes
- * `scripts.parameters` must therefore carry it — POST /scripts, PUT
- * /scripts/:id, POST /scripts/import/:id (the clone), and `importBundle`. A
- * missed ingress is a straight bypass, not a deferred error.
- */
-export interface ParameterSecretCheckOptions {
-  /** `canManagePartnerWidePolicies(auth)` — never a looser derivation. */
-  allowPartnerOwnedSecrets: boolean;
-}
-
-/**
- * Save-time parameter-binding secret check (#3409 PR4c-2, Task 6) — the
- * parameter-side twin of {@link findSecretVariableReferences}, called at the
- * same three ingresses (POST/PUT `/scripts`, `importBundle`) right after it.
+ * Save-time parameter-binding secret check (#3409 PR4c-2) — the parameter-side
+ * twin of {@link findSecretVariableReferences}, called at all FOUR write
+ * ingresses for `scripts.parameters` right after it: `POST /scripts`,
+ * `PUT /scripts/:id`, `POST /scripts/import/:id` (the clone) and
+ * {@link importBundle}.
  *
  * Secret delivery is DECLARED, never inferred (settled design §1):
  *
@@ -248,23 +210,69 @@ export interface ParameterSecretCheckOptions {
  *   what the web form's warning ("the save will be rejected") promises.
  * - `source: 'tenantSecret'` bound to a NON-secret key → `plainBoundAsSecret`.
  *   Dispatch fails that device closed; a save-time 400 says why up front.
+ * - `source: 'tenantSecret'` bound to a PARTNER-owned secret from an
+ *   ORG-scoped script → `partnerSecretNotPermitted`.
  *
- * - `source: 'tenantSecret'` bound to a secret key owned by the PARTNER, when
- *   the caller lacks partner-wide management capability →
- *   `partnerSecretNotPermitted`. See {@link ParameterSecretCheckOptions}.
+ * ## The ownership-tier rule
  *
- * An UNKNOWN key produces NO mismatch, for the same reason as the content
- * check: the variable may not exist yet, and a partner-wide script is
- * resolved per org at dispatch, where each device fails loudly on its own.
+ * A script may resolve a secret at or below its own ownership tier, never
+ * above:
+ *
+ * - A partner-wide script (`scripts.org_id IS NULL`) may resolve a
+ *   partner-owned OR an org-owned secret. The org-owned case is a PRIMARY use
+ *   case: one partner-wide script, each target org's own value resolved per
+ *   device. (Such a key is simply INVISIBLE to the partner-wide lookup below,
+ *   so it lands in the unknown-key allowance.)
+ * - An org-scoped script may resolve only org-owned secrets. A partner-owned
+ *   one is denied: `tenantVariableReadCondition` shows partner-wide variable
+ *   KEYS to organization-scope sessions and `resolveForOrg` inherits the ROWS
+ *   into every org, so without this an org admin could bind the MSP's own
+ *   secret into a script they can run and base64 it out through script output
+ *   (both redactors are exact-substring). `tenantSecret` delivery is the first
+ *   and only channel through which a secret's PLAINTEXT leaves the server.
+ *
+ * The tier is the SCRIPT's, not the CALLER's capability: a full-partner admin
+ * saving an ORG-scoped script is denied too, because that script is afterwards
+ * editable and runnable by the customer org's own admins.
+ *
+ * ## Dispatch is the authority; this is a fast fail
+ *
+ * The same rule is enforced per device at dispatch, in the `tenantSecret` arm
+ * of services/sourcedParameters.ts — which is where it HAS to live. Variable
+ * key uniqueness is per-scope, so an org admin can create an org-owned secret
+ * shadowing a partner-wide key, save a binding that resolves the ORG row (this
+ * check passes, correctly), then delete their own row and let `resolveForOrg`
+ * inherit the partner-wide value. Binding a not-yet-existing key is the same
+ * hole in time. Save time cannot close either; dispatch can, and does.
+ *
+ * What this check buys is a good error while the tech is still looking at the
+ * form, instead of a per-device failure at run time. It is also why an UNKNOWN
+ * key produces NO mismatch: the variable may not exist yet, and a partner-wide
+ * script resolves per org at dispatch, where every device is checked against
+ * the row it actually resolves.
+ *
  * Only one lookup is issued per call, whatever the number of bindings.
  */
 export async function findParameterSecretMismatches(
   scope: ScriptCreateScope,
-  parameters: unknown,
-  options: ParameterSecretCheckOptions
+  parameters: unknown
 ): Promise<ParameterSecretMismatch[]> {
   const bound = readVariableBoundParameters(parameters);
   if (bound.length === 0) return [];
+
+  // The tier the script itself is being written at. Derived from `scope`
+  // rather than passed as a separate flag: `scope` is already the scope the
+  // row will LIVE at for every ingress (the create/import target, the clone's
+  // target org, the PUT's post-rescope effective scope), and a second
+  // parameter could only ever disagree with it.
+  //
+  // No capability check belongs here: producing `orgId === null` at all
+  // already requires `canManagePartnerWidePolicies` upstream — see
+  // `resolveScriptCreateScope` (services/scriptWrite.ts) for create/import and
+  // `resolveRescopeTarget` (routes/scripts.ts) for the PUT re-scope. (System
+  // scope also reaches `orgId === null`, and `canManagePartnerWidePolicies`
+  // admits system scope, so that path agrees.)
+  const scriptIsPartnerWide = scope.orgId === null;
 
   const keys = [...new Set(bound.map((p) => p.variableKey))];
   const secrecyByKey = await lookupVariableSecrecyByKey(scope, keys);
@@ -275,10 +283,10 @@ export async function findParameterSecretMismatches(
     if (secrecy === undefined) continue; // unknown key — allowed
     const { isSecret, ownerScope } = secrecy;
     if (parameter.source === 'tenantVariable' && isSecret) {
-      // Checked BEFORE the partner-wide gate: a `tenantVariable` binding to a
-      // secret is rejected for everyone, and its message names the actual fix
-      // (switch the source), so it must not be masked by the capability
-      // message for a partner-owned target.
+      // Checked BEFORE the ownership-tier arm: a `tenantVariable` binding to
+      // a secret is rejected at every tier, and its message names the actual
+      // fix (switch the source), so it must not be masked by the tier message
+      // when the target happens to be partner-owned.
       mismatches.push({ name: parameter.name, variableKey: parameter.variableKey, kind: 'secretBoundAsPlain' });
     } else if (parameter.source === 'tenantSecret' && !isSecret) {
       mismatches.push({ name: parameter.name, variableKey: parameter.variableKey, kind: 'plainBoundAsSecret' });
@@ -286,7 +294,7 @@ export async function findParameterSecretMismatches(
       parameter.source === 'tenantSecret' &&
       isSecret &&
       ownerScope === 'partner' &&
-      !options.allowPartnerOwnedSecrets
+      !scriptIsPartnerWide
     ) {
       mismatches.push({ name: parameter.name, variableKey: parameter.variableKey, kind: 'partnerSecretNotPermitted' });
     }
@@ -310,7 +318,7 @@ export function describeParameterSecretMismatch(mismatches: ParameterSecretMisma
         case 'plainBoundAsSecret':
           return `Parameter "${m.name}" is a secret parameter but variable "${m.variableKey}" is not a secret`;
         case 'partnerSecretNotPermitted':
-          return `Parameter "${m.name}" binds partner-wide secret variable "${m.variableKey}"; only a partner administrator can bind a partner-wide secret.`;
+          return `Parameter "${m.name}" binds partner-wide secret variable "${m.variableKey}"; an organization-scoped script cannot use one — make the script partner-wide, or use an organization-owned secret.`;
       }
     })
     .join('; ');
@@ -705,14 +713,11 @@ export async function importBundle(
         continue;
       }
       // Parameter-binding twin of the content check (#3409 PR4c-2, Task 6):
-      // a tenantVariable→secret, a tenantSecret→non-secret, and a
-      // tenantSecret→PARTNER-WIDE-secret binding without partner-wide
-      // capability are all per-entry errors the same way. The capability is
-      // computed here, at the ingress, because dispatch cannot re-check it —
-      // see ParameterSecretCheckOptions.
-      const mismatches = await findParameterSecretMismatches(scope, entry.parameters, {
-        allowPartnerOwnedSecrets: canManagePartnerWidePolicies(auth)
-      });
+      // a tenantVariable→secret, a tenantSecret→non-secret, and — for an
+      // ORG-scoped import target — a tenantSecret→PARTNER-owned-secret binding
+      // are all per-entry errors the same way. The ownership tier comes from
+      // `scope`, the tier this bundle is being imported at.
+      const mismatches = await findParameterSecretMismatches(scope, entry.parameters);
       if (mismatches.length > 0) {
         result.errors.push({ index, name: entry.name, error: describeParameterSecretMismatch(mismatches) });
         continue;

--- a/apps/api/src/services/scriptBundle/index.ts
+++ b/apps/api/src/services/scriptBundle/index.ts
@@ -34,6 +34,7 @@ import {
   type ScriptScopeError,
   type ScriptWriteAuth
 } from '../scriptWrite';
+import { canManagePartnerWidePolicies } from '../partnerWideAccess';
 import { loadTenantVariableScope, resolveForOrg } from '../tenantVariableResolution';
 import {
   SCRIPT_BUNDLE_VERSION,
@@ -87,22 +88,36 @@ export async function findSecretVariableReferences(
 ): Promise<string[]> {
   const keys = findVariableTokens(content);
   if (keys.length === 0) return [];
-  const isSecretByKey = await lookupIsSecretByKey(scope, keys);
-  return keys.filter((key) => isSecretByKey.get(key) === true);
+  const secrecyByKey = await lookupVariableSecrecyByKey(scope, keys);
+  return keys.filter((key) => secrecyByKey.get(key)?.isSecret === true);
 }
 
 /**
- * The single save-time "is this key a secret for this scope?" lookup shared
- * by {@link findSecretVariableReferences} (content tokens) and
+ * What the save-time lookup knows about one tenant-variable key.
+ *
+ * `ownerScope` mirrors `ResolvedVariable.ownerScope`: `'partner'` for a
+ * partner-wide row (`tenant_variables.org_id IS NULL`), `'organization'` for
+ * an org-owned row (including one that SHADOWS a partner-wide key of the same
+ * name — the org row is what this org actually resolves, and it is the org's
+ * own value, so it carries no MSP→customer descent).
+ */
+interface VariableSecrecy {
+  isSecret: boolean;
+  ownerScope: 'organization' | 'partner';
+}
+
+/**
+ * The single save-time "what is this key for this scope?" lookup shared by
+ * {@link findSecretVariableReferences} (content tokens) and
  * {@link findParameterSecretMismatches} (parameter bindings). One DB round
  * trip per call. A key with no matching row is ABSENT from the result — the
  * two callers each treat absence as "unknown, allow" (see their docblocks).
  */
-async function lookupIsSecretByKey(
+async function lookupVariableSecrecyByKey(
   scope: ScriptCreateScope,
   keys: string[]
-): Promise<Map<string, boolean>> {
-  const result = new Map<string, boolean>();
+): Promise<Map<string, VariableSecrecy>> {
+  const result = new Map<string, VariableSecrecy>();
   if (keys.length === 0) return result;
 
   if (scope.orgId) {
@@ -110,7 +125,7 @@ async function lookupIsSecretByKey(
     const resolved = resolveForOrg(variableScope, scope.orgId);
     for (const key of keys) {
       const variable = resolved.get(key);
-      if (variable) result.set(key, variable.isSecret === true);
+      if (variable) result.set(key, { isSecret: variable.isSecret === true, ownerScope: variable.ownerScope });
     }
     return result;
   }
@@ -126,7 +141,9 @@ async function lookupIsSecretByKey(
           inArray(tenantVariables.key, keys)
         )
       );
-    for (const row of rows) result.set(row.key, row.isSecret === true);
+    // `org_id IS NULL` is in the WHERE clause, so every row here is
+    // partner-wide by construction — no need to project org_id back out.
+    for (const row of rows) result.set(row.key, { isSecret: row.isSecret === true, ownerScope: 'partner' });
     return result;
   }
 
@@ -139,7 +156,7 @@ export function describeSecretVariableRejection(offendingKeys: string[]): string
   return `Script content references secret variable(s): ${tokens}. Secret variables cannot be substituted into script content.`;
 }
 
-export type ParameterSecretMismatchKind = 'secretBoundAsPlain' | 'plainBoundAsSecret';
+export type ParameterSecretMismatchKind = 'secretBoundAsPlain' | 'plainBoundAsSecret' | 'partnerSecretNotPermitted';
 
 export interface ParameterSecretMismatch {
   /** Parameter NAME — never a value. */
@@ -181,6 +198,45 @@ function readVariableBoundParameters(parameters: unknown): VariableBoundParamete
 }
 
 /**
+ * Caller capability, computed at the route/service boundary and passed in
+ * rather than read off an `AuthContext` here — this module never sees auth.
+ *
+ * `allowPartnerOwnedSecrets` is ALWAYS `canManagePartnerWidePolicies(auth)`
+ * (services/partnerWideAccess.ts — the repo's single source of truth for
+ * partner-wide writes, which admits system scope and full-partner admins only).
+ *
+ * ## Why the gate exists
+ *
+ * `tenantVariableReadCondition` deliberately widens partner-wide variable rows
+ * to ORGANIZATION-scope sessions (keys only — values are always dropped), and
+ * `resolveForOrg` inherits partner-wide rows into every org under the partner.
+ * Without this gate an Org Admin of a CUSTOMER org could bind the MSP's own
+ * partner-wide secret into an org-scoped script — `resolveScriptCreateScope`
+ * grants any org-scope caller with `scripts:write` an org-scoped script — and
+ * run it on their own device. `tenantSecret` delivery is the first and only
+ * channel through which a secret's PLAINTEXT leaves the server, and both
+ * redactors are exact-substring, so trivial re-encoding (base64) defeats them.
+ *
+ * The settled "running a script implies use of the secrets it binds" position
+ * was written for ORG-owned secrets, where the script author already owns the
+ * value. It does not license the partner→org descent, which crosses the
+ * MSP→customer trust boundary.
+ *
+ * ## Why it must be enforced at EVERY write ingress
+ *
+ * This is a SAVE-time gate and cannot be re-checked at dispatch: automation,
+ * schedules and AI dispatch run under a system DB context with no author auth
+ * to test, so there is nothing to gate on by then. Every path that writes
+ * `scripts.parameters` must therefore carry it — POST /scripts, PUT
+ * /scripts/:id, POST /scripts/import/:id (the clone), and `importBundle`. A
+ * missed ingress is a straight bypass, not a deferred error.
+ */
+export interface ParameterSecretCheckOptions {
+  /** `canManagePartnerWidePolicies(auth)` — never a looser derivation. */
+  allowPartnerOwnedSecrets: boolean;
+}
+
+/**
  * Save-time parameter-binding secret check (#3409 PR4c-2, Task 6) — the
  * parameter-side twin of {@link findSecretVariableReferences}, called at the
  * same three ingresses (POST/PUT `/scripts`, `importBundle`) right after it.
@@ -193,6 +249,10 @@ function readVariableBoundParameters(parameters: unknown): VariableBoundParamete
  * - `source: 'tenantSecret'` bound to a NON-secret key → `plainBoundAsSecret`.
  *   Dispatch fails that device closed; a save-time 400 says why up front.
  *
+ * - `source: 'tenantSecret'` bound to a secret key owned by the PARTNER, when
+ *   the caller lacks partner-wide management capability →
+ *   `partnerSecretNotPermitted`. See {@link ParameterSecretCheckOptions}.
+ *
  * An UNKNOWN key produces NO mismatch, for the same reason as the content
  * check: the variable may not exist yet, and a partner-wide script is
  * resolved per org at dispatch, where each device fails loudly on its own.
@@ -200,22 +260,35 @@ function readVariableBoundParameters(parameters: unknown): VariableBoundParamete
  */
 export async function findParameterSecretMismatches(
   scope: ScriptCreateScope,
-  parameters: unknown
+  parameters: unknown,
+  options: ParameterSecretCheckOptions
 ): Promise<ParameterSecretMismatch[]> {
   const bound = readVariableBoundParameters(parameters);
   if (bound.length === 0) return [];
 
   const keys = [...new Set(bound.map((p) => p.variableKey))];
-  const isSecretByKey = await lookupIsSecretByKey(scope, keys);
+  const secrecyByKey = await lookupVariableSecrecyByKey(scope, keys);
 
   const mismatches: ParameterSecretMismatch[] = [];
   for (const parameter of bound) {
-    const isSecret = isSecretByKey.get(parameter.variableKey);
-    if (isSecret === undefined) continue; // unknown key — allowed
+    const secrecy = secrecyByKey.get(parameter.variableKey);
+    if (secrecy === undefined) continue; // unknown key — allowed
+    const { isSecret, ownerScope } = secrecy;
     if (parameter.source === 'tenantVariable' && isSecret) {
+      // Checked BEFORE the partner-wide gate: a `tenantVariable` binding to a
+      // secret is rejected for everyone, and its message names the actual fix
+      // (switch the source), so it must not be masked by the capability
+      // message for a partner-owned target.
       mismatches.push({ name: parameter.name, variableKey: parameter.variableKey, kind: 'secretBoundAsPlain' });
     } else if (parameter.source === 'tenantSecret' && !isSecret) {
       mismatches.push({ name: parameter.name, variableKey: parameter.variableKey, kind: 'plainBoundAsSecret' });
+    } else if (
+      parameter.source === 'tenantSecret' &&
+      isSecret &&
+      ownerScope === 'partner' &&
+      !options.allowPartnerOwnedSecrets
+    ) {
+      mismatches.push({ name: parameter.name, variableKey: parameter.variableKey, kind: 'partnerSecretNotPermitted' });
     }
   }
   return mismatches;
@@ -230,11 +303,16 @@ export async function findParameterSecretMismatches(
  */
 export function describeParameterSecretMismatch(mismatches: ParameterSecretMismatch[]): string {
   return mismatches
-    .map((m) =>
-      m.kind === 'secretBoundAsPlain'
-        ? `Parameter "${m.name}" binds secret variable "${m.variableKey}" with source "From a variable"; use a secret parameter instead`
-        : `Parameter "${m.name}" is a secret parameter but variable "${m.variableKey}" is not a secret`
-    )
+    .map((m) => {
+      switch (m.kind) {
+        case 'secretBoundAsPlain':
+          return `Parameter "${m.name}" binds secret variable "${m.variableKey}" with source "From a variable"; use a secret parameter instead`;
+        case 'plainBoundAsSecret':
+          return `Parameter "${m.name}" is a secret parameter but variable "${m.variableKey}" is not a secret`;
+        case 'partnerSecretNotPermitted':
+          return `Parameter "${m.name}" binds partner-wide secret variable "${m.variableKey}"; only a partner administrator can bind a partner-wide secret.`;
+      }
+    })
     .join('; ');
 }
 
@@ -627,9 +705,14 @@ export async function importBundle(
         continue;
       }
       // Parameter-binding twin of the content check (#3409 PR4c-2, Task 6):
-      // a tenantVariable→secret or tenantSecret→non-secret binding is a
-      // per-entry error the same way.
-      const mismatches = await findParameterSecretMismatches(scope, entry.parameters);
+      // a tenantVariable→secret, a tenantSecret→non-secret, and a
+      // tenantSecret→PARTNER-WIDE-secret binding without partner-wide
+      // capability are all per-entry errors the same way. The capability is
+      // computed here, at the ingress, because dispatch cannot re-check it —
+      // see ParameterSecretCheckOptions.
+      const mismatches = await findParameterSecretMismatches(scope, entry.parameters, {
+        allowPartnerOwnedSecrets: canManagePartnerWidePolicies(auth)
+      });
       if (mismatches.length > 0) {
         result.errors.push({ index, name: entry.name, error: describeParameterSecretMismatch(mismatches) });
         continue;

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -26,6 +26,7 @@ vi.mock('./scriptSecretDelivery', () => ({
   // dispatch refusal only has to carry it through verbatim, so a stand-in
   // string is enough here and keeps this file free of the real module.
   AGENT_UPGRADE_REQUIRED_MESSAGE: 'Agent upgrade required: mocked message',
+  SECRET_GATE_UNAVAILABLE_MESSAGE: 'Secret gate unavailable: mocked message',
   secretDeliveryPreflight: vi.fn().mockResolvedValue({ ok: true }),
   failClaimedSecretCommandsForUnsupportedAgent: vi.fn((claimed: unknown[]) => Promise.resolve(claimed)),
 }));
@@ -39,6 +40,7 @@ import { sendCommandToAgent } from '../routes/agentWs';
 import { captureException } from './sentry';
 import {
   AGENT_UPGRADE_REQUIRED_MESSAGE,
+  SECRET_GATE_UNAVAILABLE_MESSAGE,
   failClaimedSecretCommandsForUnsupportedAgent,
   secretDeliveryPreflight,
 } from './scriptSecretDelivery';
@@ -69,13 +71,27 @@ const device = (o = {}) => ({
 // tenantVariableResolution.ts's private `InternalTenantVariableScope`
 // exactly (orgIds + byOrg); TenantVariableScope itself only declares
 // `orgIds`, so this is cast through `unknown`.
-const resolvedVar = (key: string, value: string, isSecret = false): ResolvedVariable => ({
-  key, value, isSecret, variableId: `var-${key}`, version: 1, ownerScope: 'organization',
+const resolvedVar = (
+  key: string,
+  value: string,
+  isSecret = false,
+  ownerScope: 'organization' | 'partner' = 'organization',
+): ResolvedVariable => ({
+  key, value, isSecret, variableId: `var-${key}`, version: 1, ownerScope,
 });
 
-const buildScope = (orgId: string, vars: ResolvedVariable[] = []): TenantVariableScope => ({
+// `unreadableKeys` mirrors the snapshot's third field — keys whose row EXISTS
+// but failed to decrypt. `unreadableForOrg` is used UNMOCKED here (like
+// `resolveForOrg`), so this map must be present on every scope or that
+// accessor has nothing to read.
+const buildScope = (
+  orgId: string,
+  vars: ResolvedVariable[] = [],
+  unreadableKeys: string[] = [],
+): TenantVariableScope => ({
   orgIds: new Set([orgId]),
   byOrg: new Map([[orgId, new Map(vars.map((v) => [v.key, v]))]]),
+  unreadableKeysByOrg: new Map([[orgId, new Set(unreadableKeys)]]),
 } as unknown as TenantVariableScope);
 
 const insertReturning = (rows: unknown[]) => ({
@@ -705,6 +721,54 @@ describe('dispatchScriptToDevice — sourced parameters', () => {
     expect(JSON.stringify(vi.mocked(queueCommand).mock.calls)).not.toContain(SECRET_VALUE);
   });
 
+  // #3409 PR4c-2 review finding 2 — the "unreadable vs unset" distinction was
+  // implemented in the resolver but the ONLY production caller never passed
+  // the set, so it could not fire anywhere outside the resolver's own unit
+  // tests. This asserts dispatch actually forwards `unreadableForOrg(...)`.
+  it('reports an UNREADABLE bound variable as unreadable, not as "no value"', async () => {
+    const scope = buildScope('org-a', [], ['api_token']);
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: {
+        kind: 'saved',
+        script: scriptWithParams([
+          { name: 'token', type: 'string', required: true, source: 'tenantVariable', variableKey: 'api_token' },
+        ]),
+      },
+      variableScope: scope,
+    });
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('unresolved_parameters');
+      // The remediation is "go look at the encryption keys", NOT "create the
+      // variable" — the two wordings send a tech to opposite places.
+      expect(r.error).toContain('could not be read');
+      expect(r.error).not.toContain('no value for required parameter');
+      expect(r.error).toContain('api_token');
+    }
+  });
+
+  it('reports a genuinely ABSENT variable as "no value", never as unreadable', async () => {
+    const scope = buildScope('org-a', [], ['some_other_key']);
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: {
+        kind: 'saved',
+        script: scriptWithParams([
+          { name: 'token', type: 'string', required: true, source: 'tenantVariable', variableKey: 'api_token' },
+        ]),
+      },
+      variableScope: scope,
+    });
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toContain('no value for required parameter');
+      expect(r.error).not.toContain('could not be read');
+    }
+  });
+
   it('requires a variableScope only for a tenantVariable binding, not for the other sources', async () => {
     const r = await dispatchScriptToDevice({
       device: device({ customFields: { asset_tag: 'A-1' } }),
@@ -958,6 +1022,69 @@ describe('dispatchScriptToDevice — tenantSecret parameters', () => {
     expect(JSON.stringify(execValues)).not.toContain(SECRET_VALUE);
   });
 
+  // #3409 PR4c-2 review BLOCKER — dispatch is where the script's ownership
+  // tier is KNOWN, so it is where the "never resolve a secret above your own
+  // tier" rule is actually enforced. These assert the derivation
+  // (`scripts.org_id IS NULL` -> 'partner') reaches the resolver.
+  describe('secret ownership tier', () => {
+    const partnerSecretScope = () =>
+      buildScope('org-a', [resolvedVar('vendor_token', SECRET_VALUE, true, 'partner')]);
+
+    it('refuses an ORG-owned script bound to a PARTNER-WIDE secret, sealing nothing', async () => {
+      const r = await dispatchScriptToDevice({
+        device: device(),
+        source: { kind: 'saved', script: secretScript(undefined, { orgId: 'org-a' }) },
+        variableScope: partnerSecretScope(),
+      });
+
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.code).toBe('unresolved_parameters');
+        expect(r.error).toContain('partner-wide secret variable');
+      }
+      // Refused BEFORE anything is written or sealed — no orphan rows, and
+      // the credential never reaches the seal.
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(queueCommand).not.toHaveBeenCalled();
+      expect(encryptSensitivePayloadFields).not.toHaveBeenCalled();
+      expect(JSON.stringify(vi.mocked(encryptSensitivePayloadFields).mock.calls)).not.toContain(SECRET_VALUE);
+    });
+
+    it('ALLOWS a partner-wide script (orgId null) bound to a partner-wide secret', async () => {
+      mockSealOnce();
+      const r = await dispatchScriptToDevice({
+        device: device(),
+        source: { kind: 'saved', script: secretScript(undefined, { orgId: null }) },
+        variableScope: partnerSecretScope(),
+      });
+
+      expect(r.ok).toBe(true);
+      const sealInput = vi.mocked(encryptSensitivePayloadFields).mock.calls[0]![1] as Record<string, unknown>;
+      expect(sealInput.secretEnv).toEqual({ api_token: SECRET_VALUE });
+    });
+
+    // The primary use case, not an escalation: one partner-wide script, each
+    // target org's own value resolved per device.
+    it('ALLOWS a partner-wide script bound to an ORG-owned secret (per-org value)', async () => {
+      mockSealOnce();
+      const r = await dispatchScriptToDevice({
+        device: device(),
+        source: { kind: 'saved', script: secretScript(undefined, { orgId: null }) },
+        variableScope: secretScope(),
+      });
+
+      expect(r.ok).toBe(true);
+      const sealInput = vi.mocked(encryptSensitivePayloadFields).mock.calls[0]![1] as Record<string, unknown>;
+      expect(sealInput.secretEnv).toEqual({ api_token: SECRET_VALUE });
+    });
+
+    it('ALLOWS an org-owned script bound to its own org-owned secret', async () => {
+      mockSealOnce();
+      const r = await dispatchSecret();
+      expect(r.ok).toBe(true);
+    });
+  });
+
   it('runs the enqueue preflight with the effective runAs and target session', async () => {
     mockSealOnce();
     await dispatchSecret({ runAs: 'elevated', targetSessionId: undefined });
@@ -1066,7 +1193,14 @@ describe('dispatchScriptToDevice — tenantSecret parameters', () => {
   // "queued on N devices" for a credentialed run that had already been failed.
   // It is a refusal (`ok: false`), and 'agent_unsupported' no longer exists as
   // a deliveryOutcome.
-  it('immediate send: refuses with agent_upgrade_required when the claim gate fails the command', async () => {
+  //
+  // #3409 PR4c-2 review finding 3: the code is DISTINCT from the enqueue
+  // preflight's 'agent_upgrade_required'. Both mean "upgrade the agent" to the
+  // operator (same message), but only THIS one arrives with its
+  // script_executions row and batch slot already written by the gate — and
+  // `DISPATCH_CODES_ALREADY_RECORDED` keys on the code, so sharing one value
+  // silently suppressed the far more common enqueue refusal's failure row.
+  it('immediate send: refuses with agent_upgrade_required_recorded when the claim gate fails the command', async () => {
     mockSealOnce();
     const executedAt = new Date('2026-08-22T00:00:00Z');
     vi.mocked(claimPendingCommandForDelivery).mockResolvedValue({ executedAt } as any);
@@ -1085,7 +1219,9 @@ describe('dispatchScriptToDevice — tenantSecret parameters', () => {
     expect(db.update).not.toHaveBeenCalled();
     expect(r.ok).toBe(false);
     if (!r.ok) {
-      expect(r.code).toBe('agent_upgrade_required');
+      expect(r.code).toBe('agent_upgrade_required_recorded');
+      // Same operator-facing text as the enqueue refusal — only the code,
+      // which decides row ownership, differs.
       expect(r.error).toBe(AGENT_UPGRADE_REQUIRED_MESSAGE);
     }
   });
@@ -1108,8 +1244,15 @@ describe('dispatchScriptToDevice — tenantSecret parameters', () => {
 
     expect(r.ok).toBe(false);
     if (!r.ok) {
-      expect(r.code).toBe('agent_upgrade_required');
-      expect(r.error).toBe(AGENT_UPGRADE_REQUIRED_MESSAGE);
+      // An INFRASTRUCTURE fault, not a capability claim: telling the operator
+      // to upgrade a perfectly current agent would send them to fix the wrong
+      // thing, and nothing was written on this path, so the refusal must also
+      // stay OUT of DISPATCH_CODES_ALREADY_RECORDED (asserted in
+      // scriptExecution.test.ts) or the device's failure row is dropped.
+      expect(r.code).toBe('secret_gate_unavailable');
+      expect(r.code).not.toBe('agent_upgrade_required_recorded');
+      expect(r.error).toBe(SECRET_GATE_UNAVAILABLE_MESSAGE);
+      expect(r.error).not.toBe(AGENT_UPGRADE_REQUIRED_MESSAGE);
     }
     // Fail CLOSED: an unknown gate verdict must never decrypt or send.
     expect(decryptCommandForDelivery).not.toHaveBeenCalled();

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -22,6 +22,10 @@ vi.mock('../routes/agentWs', () => ({ sendCommandToAgent: vi.fn().mockReturnValu
 // file tests the WIRING — that dispatch calls them at the right two points,
 // only for a secret-bearing script, and honours their verdicts.
 vi.mock('./scriptSecretDelivery', () => ({
+  // The real constant's text is asserted in scriptSecretDelivery.test.ts; the
+  // dispatch refusal only has to carry it through verbatim, so a stand-in
+  // string is enough here and keeps this file free of the real module.
+  AGENT_UPGRADE_REQUIRED_MESSAGE: 'Agent upgrade required: mocked message',
   secretDeliveryPreflight: vi.fn().mockResolvedValue({ ok: true }),
   failClaimedSecretCommandsForUnsupportedAgent: vi.fn((claimed: unknown[]) => Promise.resolve(claimed)),
 }));
@@ -34,6 +38,7 @@ import { decryptCommandForDelivery, encryptSensitivePayloadFields } from './sens
 import { sendCommandToAgent } from '../routes/agentWs';
 import { captureException } from './sentry';
 import {
+  AGENT_UPGRADE_REQUIRED_MESSAGE,
   failClaimedSecretCommandsForUnsupportedAgent,
   secretDeliveryPreflight,
 } from './scriptSecretDelivery';
@@ -1055,7 +1060,13 @@ describe('dispatchScriptToDevice — tenantSecret parameters', () => {
   // itself and never reaches decryptClaimedCommandsForDelivery, so without
   // this gate a downgraded agent would receive the script with the credential
   // unset.
-  it('immediate send: withholds and reports agent_unsupported when the claim gate fails the command', async () => {
+  //
+  // The gate outcome is TERMINAL, and every caller of dispatchScriptToDevice
+  // branches on `ok` alone — so reporting it as `ok: true` told the operator
+  // "queued on N devices" for a credentialed run that had already been failed.
+  // It is a refusal (`ok: false`), and 'agent_unsupported' no longer exists as
+  // a deliveryOutcome.
+  it('immediate send: refuses with agent_upgrade_required when the claim gate fails the command', async () => {
     mockSealOnce();
     const executedAt = new Date('2026-08-22T00:00:00Z');
     vi.mocked(claimPendingCommandForDelivery).mockResolvedValue({ executedAt } as any);
@@ -1072,13 +1083,43 @@ describe('dispatchScriptToDevice — tenantSecret parameters', () => {
     expect(releaseClaimedCommandDelivery).not.toHaveBeenCalled();
     // ...and the execution row is NOT flipped to 'running' here.
     expect(db.update).not.toHaveBeenCalled();
-    expect(r.ok).toBe(true);
-    if (r.ok) {
-      expect(r.delivered).toBe(false);
-      expect(r.deliveryOutcome).toBe('agent_unsupported');
-      expect(r.commandId).toBe('cmd-1');
-      expect(r.executionId).toBe('exec-1');
-      expect(r.executedAt).toBeNull();
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('agent_upgrade_required');
+      expect(r.error).toBe(AGENT_UPGRADE_REQUIRED_MESSAGE);
     }
+  });
+
+  // The gate's own try/catch covers only its writes: the capability SELECT
+  // (and its multi-device contract-violation throw) can propagate out AFTER
+  // `claimPendingCommandForDelivery` already flipped the row to 'sent'. Left
+  // bare, that 500s the caller and aborts a large fan-out mid-run.
+  it('immediate send: a gate throw becomes the same refusal, reported to Sentry, nothing sent', async () => {
+    mockSealOnce();
+    const executedAt = new Date('2026-08-22T00:00:00Z');
+    vi.mocked(claimPendingCommandForDelivery).mockResolvedValue({ executedAt } as any);
+    vi.mocked(sendCommandToAgent).mockReturnValue(true);
+    const boom = new Error('capability select exploded');
+    vi.mocked(failClaimedSecretCommandsForUnsupportedAgent).mockRejectedValue(boom);
+    const { releaseClaimedCommandDelivery } = await import('./commandDispatch');
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const r = await dispatchSecret({ device: device({ agentId: 'agent-1' }) });
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('agent_upgrade_required');
+      expect(r.error).toBe(AGENT_UPGRADE_REQUIRED_MESSAGE);
+    }
+    // Fail CLOSED: an unknown gate verdict must never decrypt or send.
+    expect(decryptCommandForDelivery).not.toHaveBeenCalled();
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+    expect(releaseClaimedCommandDelivery).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalledWith(boom);
+    // Log line carries ids only — never the sealed payload or the plaintext.
+    expect(JSON.stringify(warn.mock.calls)).not.toContain(SECRET_VALUE);
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('sealed-envelope');
+    warn.mockRestore();
   });
 });

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -17,6 +17,14 @@ vi.mock('./sensitiveCommandPayload', () => ({
   })),
 }));
 vi.mock('../routes/agentWs', () => ({ sendCommandToAgent: vi.fn().mockReturnValue(false) }));
+// #3409 PR4c-2: the secret-delivery gates are unit-tested against their own
+// drizzle mocks in scriptSecretDelivery.test.ts. Here they are mocked so this
+// file tests the WIRING — that dispatch calls them at the right two points,
+// only for a secret-bearing script, and honours their verdicts.
+vi.mock('./scriptSecretDelivery', () => ({
+  secretDeliveryPreflight: vi.fn().mockResolvedValue({ ok: true }),
+  failClaimedSecretCommandsForUnsupportedAgent: vi.fn((claimed: unknown[]) => Promise.resolve(claimed)),
+}));
 vi.mock('./sentry', () => ({ captureException: vi.fn() }));
 
 import { db } from '../db';
@@ -25,6 +33,10 @@ import { claimPendingCommandForDelivery } from './commandDispatch';
 import { decryptCommandForDelivery, encryptSensitivePayloadFields } from './sensitiveCommandPayload';
 import { sendCommandToAgent } from '../routes/agentWs';
 import { captureException } from './sentry';
+import {
+  failClaimedSecretCommandsForUnsupportedAgent,
+  secretDeliveryPreflight,
+} from './scriptSecretDelivery';
 import { dispatchScriptToDevice } from './scriptDispatch';
 import type { ResolvedVariable, TenantVariableScope } from './tenantVariableResolution';
 
@@ -137,6 +149,12 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(db.insert).mockReturnValue(insertReturning([{ id: 'exec-1' }]) as any);
   vi.mocked(queueCommand).mockResolvedValue({ id: 'cmd-1', payload: {} } as any);
+  // Permissive defaults re-established per test so a `…Once` override or a
+  // per-test verdict never leaks into the next test.
+  vi.mocked(secretDeliveryPreflight).mockResolvedValue({ ok: true });
+  vi.mocked(failClaimedSecretCommandsForUnsupportedAgent).mockImplementation(
+    (claimed: any) => Promise.resolve(claimed),
+  );
 });
 
 describe('dispatchScriptToDevice — invariants', () => {
@@ -845,5 +863,222 @@ describe('dispatchScriptToDevice — sourced parameters', () => {
       expect(db.select).not.toHaveBeenCalled();
       expect(payloadParameters()).toEqual({ org_id: 'org-a', site_id: 'site-1', host: 'host-1' });
     });
+  });
+});
+
+// #3409 PR4c-2: `tenantSecret` parameters — the sealed out-of-band channel
+// plus the two activation gates (enqueue preflight, claim-time re-check).
+// The gates themselves are covered against their own DB mocks in
+// scriptSecretDelivery.test.ts; these tests pin the WIRING.
+describe('dispatchScriptToDevice — tenantSecret parameters', () => {
+  const SECRET_VALUE = 'sup3r-s3cret-value-xyz';
+
+  const secretScript = (extra: unknown[] = [], overrides = {}) =>
+    savedScript({
+      parameters: [
+        { name: 'api_token', source: 'tenantSecret', variableKey: 'vendor_token' },
+        ...extra,
+      ],
+      ...overrides,
+    });
+
+  const secretScope = () => buildScope('org-a', [resolvedVar('vendor_token', SECRET_VALUE, true)]);
+
+  // Stands in for the real seal (the module is mocked file-wide): consumes
+  // `secretEnv` and leaves the ciphertext string the agent frame carries.
+  const mockSealOnce = () => {
+    vi.mocked(encryptSensitivePayloadFields).mockImplementationOnce((_t: string, payload: any) => {
+      const out = { ...payload };
+      if (out.secretEnv !== undefined) {
+        delete out.secretEnv;
+        out.secretEnvEnvelope = 'enc:v3:sealed-envelope';
+      }
+      return out;
+    });
+  };
+
+  const dispatchSecret = (input: Record<string, unknown> = {}) =>
+    dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'saved', script: secretScript() },
+      variableScope: secretScope(),
+      ...input,
+    } as any);
+
+  it('hands the resolved secret to the seal in secretEnv, never in parameters', async () => {
+    mockSealOnce();
+    const r = await dispatchSecret({
+      source: {
+        kind: 'saved',
+        script: secretScript([{ name: 'level', type: 'string', source: 'runtime' }]),
+      },
+      parameters: { level: 'debug' },
+    });
+
+    expect(r.ok).toBe(true);
+    const sealInput = vi.mocked(encryptSensitivePayloadFields).mock.calls[0]![1] as Record<string, unknown>;
+    expect(sealInput.secretEnv).toEqual({ api_token: SECRET_VALUE });
+    expect(sealInput.parameters).toEqual({ level: 'debug' });
+    expect(JSON.stringify(sealInput.parameters)).not.toContain(SECRET_VALUE);
+  });
+
+  it('queues the SEALED payload: secretEnvEnvelope string, no secretEnv', async () => {
+    mockSealOnce();
+    await dispatchSecret();
+
+    const [, , payload] = vi.mocked(queueCommand).mock.calls[0]!;
+    const queued = payload as Record<string, unknown>;
+    expect(typeof queued.secretEnvEnvelope).toBe('string');
+    expect(queued).not.toHaveProperty('secretEnv');
+    expect(JSON.stringify(queued)).not.toContain(SECRET_VALUE);
+  });
+
+  it('stores an identity-only $bindings row and no value in script_executions', async () => {
+    mockSealOnce();
+    await dispatchSecret();
+
+    const execValues = vi.mocked(db.insert).mock.results[0]!.value.values.mock.calls[0]![0];
+    expect(execValues.parameters).toEqual({
+      $bindings: [
+        {
+          key: 'api_token',
+          source: 'tenantSecret',
+          variableId: 'var-vendor_token',
+          ownerScope: 'organization',
+          version: 1,
+        },
+      ],
+    });
+    // The whole serialized insert — not just the parameters column.
+    expect(JSON.stringify(execValues)).not.toContain(SECRET_VALUE);
+  });
+
+  it('runs the enqueue preflight with the effective runAs and target session', async () => {
+    mockSealOnce();
+    await dispatchSecret({ runAs: 'elevated', targetSessionId: undefined });
+
+    expect(secretDeliveryPreflight).toHaveBeenCalledWith({
+      deviceId: 'device-1',
+      runAs: 'elevated',
+      targetSessionId: undefined,
+    });
+    // BEFORE the execution insert — a refused device must leave no orphan row.
+    expect(vi.mocked(secretDeliveryPreflight).mock.invocationCallOrder[0]!)
+      .toBeLessThan(vi.mocked(db.insert).mock.invocationCallOrder[0]!);
+  });
+
+  // The three preflight refusals, propagated verbatim with no orphan rows.
+  for (const code of [
+    'secrets_unsupported_run_as',
+    'secret_delivery_unavailable',
+    'agent_upgrade_required',
+  ] as const) {
+    it(`fails the device with ${code} and leaves no execution or command behind`, async () => {
+      vi.mocked(secretDeliveryPreflight).mockResolvedValue({ ok: false, code, error: `refused: ${code}` });
+      const r = await dispatchSecret({ runAs: 'user' });
+
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.code).toBe(code);
+        expect(r.error).toBe(`refused: ${code}`);
+      }
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(queueCommand).not.toHaveBeenCalled();
+      expect(encryptSensitivePayloadFields).not.toHaveBeenCalled();
+      expect(JSON.stringify(vi.mocked(queueCommand).mock.calls)).not.toContain(SECRET_VALUE);
+    });
+  }
+
+  // Hot-path regression guard (the preload trap from PR2): the gate must cost
+  // nothing for the overwhelming majority of scripts, which have no secret.
+  it('never calls the preflight for a script with no tenantSecret parameter', async () => {
+    await dispatchScriptToDevice({
+      device: device(),
+      source: {
+        kind: 'saved',
+        script: savedScript({ parameters: [{ name: 'level', type: 'string', source: 'runtime' }] }),
+      },
+      parameters: { level: 'debug' },
+    });
+
+    expect(secretDeliveryPreflight).not.toHaveBeenCalled();
+    expect(failClaimedSecretCommandsForUnsupportedAgent).not.toHaveBeenCalled();
+  });
+
+  it('never calls the claim gate on the immediate-send path for a secret-free script', async () => {
+    vi.mocked(claimPendingCommandForDelivery).mockResolvedValue({ executedAt: new Date() } as any);
+    vi.mocked(sendCommandToAgent).mockReturnValue(true);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+
+    const r = await dispatchScriptToDevice({
+      device: device({ agentId: 'agent-1' }),
+      source: { kind: 'saved', script: savedScript() },
+    });
+
+    expect(failClaimedSecretCommandsForUnsupportedAgent).not.toHaveBeenCalled();
+    if (r.ok) expect(r.deliveryOutcome).toBe('sent');
+  });
+
+  it('immediate send: re-checks the claimed command through the claim gate, then sends', async () => {
+    mockSealOnce();
+    const executedAt = new Date('2026-08-22T00:00:00Z');
+    vi.mocked(claimPendingCommandForDelivery).mockResolvedValue({ executedAt } as any);
+    vi.mocked(sendCommandToAgent).mockReturnValue(true);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+
+    const r = await dispatchSecret({ device: device({ agentId: 'agent-1' }) });
+
+    expect(failClaimedSecretCommandsForUnsupportedAgent).toHaveBeenCalledWith([
+      {
+        id: 'cmd-1',
+        type: 'script',
+        deviceId: 'device-1',
+        payload: expect.objectContaining({ secretEnvEnvelope: 'enc:v3:sealed-envelope' }),
+        executedAt,
+      },
+    ]);
+    // Gate first, send second — never the other way round.
+    expect(vi.mocked(failClaimedSecretCommandsForUnsupportedAgent).mock.invocationCallOrder[0]!)
+      .toBeLessThan(vi.mocked(sendCommandToAgent).mock.invocationCallOrder[0]!);
+    expect(sendCommandToAgent).toHaveBeenCalled();
+    if (r.ok) {
+      expect(r.delivered).toBe(true);
+      expect(r.deliveryOutcome).toBe('sent');
+    }
+  });
+
+  // The blocker the review caught: the immediate-send path claims the command
+  // itself and never reaches decryptClaimedCommandsForDelivery, so without
+  // this gate a downgraded agent would receive the script with the credential
+  // unset.
+  it('immediate send: withholds and reports agent_unsupported when the claim gate fails the command', async () => {
+    mockSealOnce();
+    const executedAt = new Date('2026-08-22T00:00:00Z');
+    vi.mocked(claimPendingCommandForDelivery).mockResolvedValue({ executedAt } as any);
+    vi.mocked(sendCommandToAgent).mockReturnValue(true);
+    vi.mocked(failClaimedSecretCommandsForUnsupportedAgent).mockResolvedValue([]);
+    const { releaseClaimedCommandDelivery } = await import('./commandDispatch');
+
+    const r = await dispatchSecret({ device: device({ agentId: 'agent-1' }) });
+
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+    expect(decryptCommandForDelivery).not.toHaveBeenCalled();
+    // Terminal, not retryable: the gate already failed both rows, so the
+    // command must NOT go back to pending for the same agent to re-claim.
+    expect(releaseClaimedCommandDelivery).not.toHaveBeenCalled();
+    // ...and the execution row is NOT flipped to 'running' here.
+    expect(db.update).not.toHaveBeenCalled();
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.delivered).toBe(false);
+      expect(r.deliveryOutcome).toBe('agent_unsupported');
+      expect(r.commandId).toBe('cmd-1');
+      expect(r.executionId).toBe('exec-1');
+      expect(r.executedAt).toBeNull();
+    }
   });
 });

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -24,6 +24,7 @@ import {
   type TenantVariableScope,
 } from './tenantVariableResolution';
 import {
+  AGENT_UPGRADE_REQUIRED_MESSAGE,
   failClaimedSecretCommandsForUnsupportedAgent,
   secretDeliveryPreflight,
   type SecretDeliveryPreflightFailureCode,
@@ -94,21 +95,17 @@ export type DispatchScriptResult =
       // 'send_failed' all mean we had a connected agent and still failed to
       // reach it — operationally different, and worth a log line (see below).
       //
-      // 'agent_unsupported' (#3409 PR4c-2) is the only outcome that is
-      // TERMINAL rather than retryable: the claim-time secret gate found the
-      // agent's `scriptSecretEnvVersion` had dropped below the floor between
-      // enqueue and delivery, and already drove BOTH the command row and the
-      // linked execution row to 'failed' (with the payload erased). The
-      // dispatch still returns `ok: true` because the rows exist and carry
-      // the outcome — the caller reads execution history for the reason
-      // rather than getting a `code` here; the command is NOT released back
-      // to pending, since the same agent would only re-claim it.
+      // Every value here is a QUEUED outcome: the command exists and can
+      // still reach the agent. A terminal refusal is never reported on this
+      // arm — the claim-time secret gate's outcome is an `ok: false` /
+      // 'agent_upgrade_required' refusal (see below), because every caller
+      // branches on `ok` alone and would otherwise report a run that had
+      // already been failed as successfully queued.
       deliveryOutcome:
         | 'sent'
         | 'claim_lost'
         | 'decrypt_failed'
         | 'send_failed'
-        | 'agent_unsupported'
         | 'no_agent';
       executedAt: Date | null;
       // Bound parameter keys the caller supplied a value for (#3409 PR3
@@ -151,6 +148,14 @@ export type DispatchScriptResult =
         //       credential UNSET.
         // All three are per-device and refuse BEFORE the execution insert, so
         // a refused device leaves no orphan 'pending' row.
+        //
+        // 'agent_upgrade_required' is ALSO returned from the claim-time gate
+        // on the immediate-send path below, where it is the one refusal whose
+        // rows were written by someone else: the gate already drove the
+        // command AND the linked execution row to 'failed' and already spent
+        // the batch's `devicesFailed` slot. A fan-out caller must therefore
+        // record it WITHOUT writing its own failure row (see
+        // DISPATCH_CODES_ALREADY_RECORDED in scriptExecution.ts).
         | SecretDeliveryPreflightFailureCode;
       error: string;
     };
@@ -424,7 +429,6 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
     | 'claim_lost'
     | 'decrypt_failed'
     | 'send_failed'
-    | 'agent_unsupported'
     | 'no_agent' = 'no_agent';
   if (device.agentId) {
     const claimed = await claimPendingCommandForDelivery(command.id);
@@ -439,10 +443,22 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
       // A `[]` return means the gate already drove the command AND its
       // execution row terminal: do not send, and do NOT release the claim
       // back to pending (an incapable agent would just re-claim it).
-      const gated =
-        hasSecrets &&
-        (
-          await failClaimedSecretCommandsForUnsupportedAgent([
+      //
+      // The gate's own try/catch covers only its writes — the capability
+      // SELECT (and its multi-device contract-violation throw) propagates
+      // out of here. Left bare that would escape AFTER
+      // `claimPendingCommandForDelivery` already flipped the row to 'sent',
+      // 500 the caller, and abort a large fan-out mid-run. So a throw is
+      // treated exactly like a gate refusal: fail CLOSED (never decrypt,
+      // never send) and return the per-device refusal so the fan-out
+      // continues. The command row is deliberately LEFT 'sent' with its
+      // envelope intact for the stale-command reaper to strip — this path
+      // cannot know whether the gate's terminal write landed, and writing
+      // over it blind could clobber a row something else already moved.
+      let gated = false;
+      if (hasSecrets) {
+        try {
+          const survivors = await failClaimedSecretCommandsForUnsupportedAgent([
             {
               id: command.id,
               type: 'script',
@@ -450,19 +466,22 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
               payload,
               executedAt: claimed.executedAt,
             },
-          ])
-        ).length === 0;
+          ]);
+          gated = survivors.length === 0;
+        } catch (gateErr) {
+          // ids only — never the payload, sealed or otherwise.
+          console.error('[scriptDispatch] secret claim gate threw; refusing delivery', {
+            commandId: command.id,
+            deviceId: device.id,
+            executionId,
+            error: gateErr instanceof Error ? gateErr.message : String(gateErr),
+          });
+          captureException(gateErr);
+          gated = true;
+        }
+      }
       if (gated) {
-        deliveryOutcome = 'agent_unsupported';
-        return {
-          ok: true,
-          commandId: command.id,
-          executionId,
-          delivered,
-          deliveryOutcome,
-          executedAt,
-          ignoredParameters,
-        };
+        return { ok: false, code: 'agent_upgrade_required', error: AGENT_UPGRADE_REQUIRED_MESSAGE };
       }
       const deliverable = decryptCommandForDelivery({
         id: command.id,

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -20,11 +20,13 @@ import {
   describeVariableFailure,
   resolveForOrg,
   substituteTenantVariables,
+  unreadableForOrg,
   type ResolvedVariable,
   type TenantVariableScope,
 } from './tenantVariableResolution';
 import {
   AGENT_UPGRADE_REQUIRED_MESSAGE,
+  SECRET_GATE_UNAVAILABLE_MESSAGE,
   failClaimedSecretCommandsForUnsupportedAgent,
   secretDeliveryPreflight,
   type SecretDeliveryPreflightFailureCode,
@@ -98,9 +100,9 @@ export type DispatchScriptResult =
       // Every value here is a QUEUED outcome: the command exists and can
       // still reach the agent. A terminal refusal is never reported on this
       // arm — the claim-time secret gate's outcome is an `ok: false` /
-      // 'agent_upgrade_required' refusal (see below), because every caller
-      // branches on `ok` alone and would otherwise report a run that had
-      // already been failed as successfully queued.
+      // 'agent_upgrade_required_recorded' refusal (see below), because every
+      // caller branches on `ok` alone and would otherwise report a run that
+      // had already been failed as successfully queued.
       deliveryOutcome:
         | 'sent'
         | 'claim_lost'
@@ -135,7 +137,7 @@ export type DispatchScriptResult =
         // failure and a content-token failure are different operational
         // conditions and must stay distinguishable in execution history.
         | 'unresolved_parameters'
-        // #3409 PR4c-2 — the three enqueue-time secret-delivery refusals,
+        // #3409 PR4c-2 — the three ENQUEUE-time secret-delivery refusals,
         // raised ONLY when the script actually resolved a `tenantSecret`
         // parameter (see services/scriptSecretDelivery.ts for the messages):
         //   'secrets_unsupported_run_as'   — runAs 'user' / a targetSessionId:
@@ -145,18 +147,30 @@ export type DispatchScriptResult =
         //       secret-encryption key, so the envelope cannot be sealed.
         //   'agent_upgrade_required'       — the device agent does not declare
         //       secret-env support and would run the script with the
-        //       credential UNSET.
+        //       credential UNSET. The ORDINARY outcome for any pre-PR4b agent.
         // All three are per-device and refuse BEFORE the execution insert, so
-        // a refused device leaves no orphan 'pending' row.
-        //
-        // 'agent_upgrade_required' is ALSO returned from the claim-time gate
-        // on the immediate-send path below, where it is the one refusal whose
-        // rows were written by someone else: the gate already drove the
-        // command AND the linked execution row to 'failed' and already spent
-        // the batch's `devicesFailed` slot. A fan-out caller must therefore
-        // record it WITHOUT writing its own failure row (see
-        // DISPATCH_CODES_ALREADY_RECORDED in scriptExecution.ts).
-        | SecretDeliveryPreflightFailureCode;
+        // a refused device leaves NO rows behind and its caller owes it the
+        // ordinary per-device failure row.
+        | SecretDeliveryPreflightFailureCode
+        // The two CLAIM-time refusals from the immediate-send path below.
+        // Split from the enqueue codes above because row ownership differs,
+        // and `DISPATCH_CODES_ALREADY_RECORDED` (scriptExecution.ts) keys on
+        // the code alone:
+        //   'agent_upgrade_required_recorded' — the gate returned a verdict
+        //       and, in doing so, already drove the command AND the linked
+        //       execution row to 'failed' and already spent the batch's
+        //       `devicesFailed` slot. The ONLY code a fan-out must record
+        //       WITHOUT writing its own failure row. Rare: it needs an agent
+        //       downgrade between enqueue and claim. Carries
+        //       AGENT_UPGRADE_REQUIRED_MESSAGE, same as the enqueue refusal —
+        //       only the bookkeeping differs, not the remediation.
+        //   'secret_gate_unavailable'        — the gate FAULTED (its
+        //       capability select threw) instead of returning a verdict. We
+        //       fail closed, but nothing was written on this path, so it must
+        //       stay OUT of DISPATCH_CODES_ALREADY_RECORDED, and its message
+        //       must not blame an agent version that may be perfectly current.
+        | 'agent_upgrade_required_recorded'
+        | 'secret_gate_unavailable';
       error: string;
     };
 
@@ -259,11 +273,19 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
     // with no such binding never requires a scope — mirroring the
     // content-token gate directly above.
     let variables: Map<string, ResolvedVariable> | undefined;
+    // Keys whose row EXISTS for this org but failed to decrypt (#3409 PR4c-1).
+    // Loaded from the SAME snapshot and in the same branch as `variables` —
+    // the two are read together or not at all. Without it the resolver cannot
+    // tell an undecryptable secret from an unset one and reports "no value
+    // for required parameter", which sends a tech to create a duplicate
+    // variable mid-rotation instead of looking at the encryption keys.
+    let unreadableVariableKeys: ReadonlySet<string> | undefined;
     if (hasTenantVariableBoundParameters(definitions)) {
       if (!input.variableScope) {
         throw new Error('variableScope is required to dispatch a script with a tenantVariable-bound parameter');
       }
       variables = resolveForOrg(input.variableScope, device.orgId);
+      unreadableVariableKeys = unreadableForOrg(input.variableScope, device.orgId);
     }
 
     const resolution = resolveSourcedParameters({
@@ -272,6 +294,14 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
       device,
       names: await loadBuiltinNameContext(definitions, device),
       variables,
+      unreadableVariableKeys,
+      // The script's own ownership tier, read off the row dispatch already
+      // holds. `scripts.org_id IS NULL` is partner-wide (or system) — the
+      // same expression the org-equality invariant above uses. This is the
+      // AUTHORITATIVE input to the "never resolve a secret above your own
+      // tier" gate; see ResolveSourcedParametersInput.scriptOwnerScope for
+      // why save-time validation cannot stand in for it.
+      scriptOwnerScope: source.script.orgId === null ? 'partner' : 'organization',
     });
     if (!resolution.ok) {
       return { ok: false, code: resolution.code, error: resolution.error };
@@ -448,14 +478,18 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
       // SELECT (and its multi-device contract-violation throw) propagates
       // out of here. Left bare that would escape AFTER
       // `claimPendingCommandForDelivery` already flipped the row to 'sent',
-      // 500 the caller, and abort a large fan-out mid-run. So a throw is
-      // treated exactly like a gate refusal: fail CLOSED (never decrypt,
-      // never send) and return the per-device refusal so the fan-out
-      // continues. The command row is deliberately LEFT 'sent' with its
-      // envelope intact for the stale-command reaper to strip — this path
-      // cannot know whether the gate's terminal write landed, and writing
-      // over it blind could clobber a row something else already moved.
-      let gated = false;
+      // 500 the caller, and abort a large fan-out mid-run. So a throw fails
+      // CLOSED (never decrypt, never send) and returns a per-device refusal
+      // so the fan-out continues — but under its OWN code
+      // ('secret_gate_unavailable'), not the capability one: nothing was
+      // written on that path, and the agent may be perfectly current. The
+      // command row is deliberately LEFT 'sent' with its envelope intact for
+      // the stale-command reaper to strip — this path cannot know whether the
+      // gate's terminal write landed, and writing over it blind could clobber
+      // a row something else already moved.
+      // `false` = deliver; a code = refuse with it. Distinct values because
+      // the two refusals differ in whether rows were already written.
+      let gated: false | 'agent_upgrade_required_recorded' | 'secret_gate_unavailable' = false;
       if (hasSecrets) {
         try {
           const survivors = await failClaimedSecretCommandsForUnsupportedAgent([
@@ -467,7 +501,7 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
               executedAt: claimed.executedAt,
             },
           ]);
-          gated = survivors.length === 0;
+          gated = survivors.length === 0 ? 'agent_upgrade_required_recorded' : false;
         } catch (gateErr) {
           // ids only — never the payload, sealed or otherwise.
           console.error('[scriptDispatch] secret claim gate threw; refusing delivery', {
@@ -477,11 +511,17 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
             error: gateErr instanceof Error ? gateErr.message : String(gateErr),
           });
           captureException(gateErr);
-          gated = true;
+          // NOT the capability refusal: this branch wrote nothing, and the
+          // agent may be perfectly current. A distinct code keeps it out of
+          // DISPATCH_CODES_ALREADY_RECORDED (so the device still gets its
+          // failure row) and off the "go upgrade your agent" remediation.
+          gated = 'secret_gate_unavailable';
         }
       }
       if (gated) {
-        return { ok: false, code: 'agent_upgrade_required', error: AGENT_UPGRADE_REQUIRED_MESSAGE };
+        return gated === 'agent_upgrade_required_recorded'
+          ? { ok: false, code: gated, error: AGENT_UPGRADE_REQUIRED_MESSAGE }
+          : { ok: false, code: gated, error: SECRET_GATE_UNAVAILABLE_MESSAGE };
       }
       const deliverable = decryptCommandForDelivery({
         id: command.id,

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -24,6 +24,11 @@ import {
   type TenantVariableScope,
 } from './tenantVariableResolution';
 import {
+  failClaimedSecretCommandsForUnsupportedAgent,
+  secretDeliveryPreflight,
+  type SecretDeliveryPreflightFailureCode,
+} from './scriptSecretDelivery';
+import {
   builtinNameContextNeeds,
   EXECUTION_PARAMETER_BINDINGS_KEY,
   hasTenantVariableBoundParameters,
@@ -88,7 +93,23 @@ export type DispatchScriptResult =
       // "queued for later" case; 'claim_lost', 'decrypt_failed', and
       // 'send_failed' all mean we had a connected agent and still failed to
       // reach it — operationally different, and worth a log line (see below).
-      deliveryOutcome: 'sent' | 'claim_lost' | 'decrypt_failed' | 'send_failed' | 'no_agent';
+      //
+      // 'agent_unsupported' (#3409 PR4c-2) is the only outcome that is
+      // TERMINAL rather than retryable: the claim-time secret gate found the
+      // agent's `scriptSecretEnvVersion` had dropped below the floor between
+      // enqueue and delivery, and already drove BOTH the command row and the
+      // linked execution row to 'failed' (with the payload erased). The
+      // dispatch still returns `ok: true` because the rows exist and carry
+      // the outcome — the caller reads execution history for the reason
+      // rather than getting a `code` here; the command is NOT released back
+      // to pending, since the same agent would only re-claim it.
+      deliveryOutcome:
+        | 'sent'
+        | 'claim_lost'
+        | 'decrypt_failed'
+        | 'send_failed'
+        | 'agent_unsupported'
+        | 'no_agent';
       executedAt: Date | null;
       // Bound parameter keys the caller supplied a value for (#3409 PR3
       // §2.2). The binding wins authoritatively and the supplied value is
@@ -116,7 +137,21 @@ export type DispatchScriptResult =
         // distinct from 'unresolved_variables' above — a parameter-binding
         // failure and a content-token failure are different operational
         // conditions and must stay distinguishable in execution history.
-        | 'unresolved_parameters';
+        | 'unresolved_parameters'
+        // #3409 PR4c-2 — the three enqueue-time secret-delivery refusals,
+        // raised ONLY when the script actually resolved a `tenantSecret`
+        // parameter (see services/scriptSecretDelivery.ts for the messages):
+        //   'secrets_unsupported_run_as'   — runAs 'user' / a targetSessionId:
+        //       the helper IPC carries no environment, so the credential
+        //       simply could not arrive.
+        //   'secret_delivery_unavailable'  — this server has no active
+        //       secret-encryption key, so the envelope cannot be sealed.
+        //   'agent_upgrade_required'       — the device agent does not declare
+        //       secret-env support and would run the script with the
+        //       credential UNSET.
+        // All three are per-device and refuse BEFORE the execution insert, so
+        // a refused device leaves no orphan 'pending' row.
+        | SecretDeliveryPreflightFailureCode;
       error: string;
     };
 
@@ -211,6 +246,7 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
   >;
   let parameterBindings: ScriptParameterBindingDescriptor[] = [];
   let ignoredParameters: string[] = [];
+  let secretEnv: Record<string, string> = {};
   if (source.kind === 'saved' && Array.isArray(source.script.parameters) && source.script.parameters.length > 0) {
     const definitions = source.script.parameters;
     // Only a tenantVariable binding needs the snapshot; the other three
@@ -238,6 +274,27 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
     resolvedParameters = resolution.parameters;
     parameterBindings = resolution.bindings;
     ignoredParameters = resolution.ignoredParameters;
+    secretEnv = resolution.secretEnv;
+  }
+
+  // #3409 PR4c-2: the enqueue-time secret-delivery gate. Only a script that
+  // actually resolved a `tenantSecret` parameter pays for it — `hasSecrets`
+  // is known locally here, so the hot path never inspects a payload and never
+  // reads the device's capability column.
+  //
+  // Sits BEFORE the script_executions insert for the same reason PR2's
+  // substitution and PR3's resolution do: a refused device must leave no
+  // orphan 'pending' row for the reaper to later mislabel 'timeout'.
+  const hasSecrets = Object.keys(secretEnv).length > 0;
+  if (hasSecrets) {
+    const preflight = await secretDeliveryPreflight({
+      deviceId: device.id,
+      runAs,
+      targetSessionId: input.targetSessionId,
+    });
+    if (!preflight.ok) {
+      return { ok: false, code: preflight.code, error: preflight.error };
+    }
   }
 
   let executionId: string | null = null;
@@ -315,7 +372,8 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
     // The secret envelope's AAD binds the command id, so the id must exist
     // BEFORE encryption. Reserving it here (rather than reading it back from
     // the insert) is what keeps encryption inside this guarded region.
-    // Inert until PR4c: nothing sets `secretEnv` yet, so this is a passthrough.
+    // Live since PR4c-2: `secretEnv` is set for `tenantSecret` parameters and
+    // sealed here into `secretEnvEnvelope`; without one this is a passthrough.
     const reservedCommandId = randomUUID();
     payload = encryptSensitivePayloadFields('script', {
       scriptId: payloadScriptId,
@@ -335,6 +393,13 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
       // exist. For a script with no parameter definitions this is the
       // caller's map unchanged, i.e. exactly PR2's behaviour.
       parameters: canonicalizeScriptParameters(resolvedParameters),
+      // #3409 PR4c-2: resolved `tenantSecret` values, deliberately OUTSIDE
+      // `parameters` (which the agent substitutes into the script text and
+      // mirrors as BREEZE_PARAM_*). `encryptSensitivePayloadFields` consumes
+      // this key and replaces it with the sealed `secretEnvEnvelope` string,
+      // so no plaintext secret is ever stored on the command row. The key is
+      // omitted entirely when there are none — the seal path is opt-in.
+      ...(hasSecrets ? { secretEnv } : {}),
       timeoutSeconds,
       runAs,
       ...(input.targetSessionId != null ? { targetSessionId: input.targetSessionId } : {}),
@@ -354,10 +419,51 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
 
   let delivered = false;
   let executedAt: Date | null = null;
-  let deliveryOutcome: 'sent' | 'claim_lost' | 'decrypt_failed' | 'send_failed' | 'no_agent' = 'no_agent';
+  let deliveryOutcome:
+    | 'sent'
+    | 'claim_lost'
+    | 'decrypt_failed'
+    | 'send_failed'
+    | 'agent_unsupported'
+    | 'no_agent' = 'no_agent';
   if (device.agentId) {
     const claimed = await claimPendingCommandForDelivery(command.id);
     if (claimed) {
+      // #3409 PR4c-2: the immediate-send path claims the command itself and
+      // hands it straight to the WS, bypassing
+      // `decryptClaimedCommandsForDelivery` — so the claim-time gate has to
+      // run HERE too, or a device whose agent lost the capability between the
+      // preflight above and this claim would receive the script with the
+      // credential unset. Only the secret-bearing path pays for it.
+      //
+      // A `[]` return means the gate already drove the command AND its
+      // execution row terminal: do not send, and do NOT release the claim
+      // back to pending (an incapable agent would just re-claim it).
+      const gated =
+        hasSecrets &&
+        (
+          await failClaimedSecretCommandsForUnsupportedAgent([
+            {
+              id: command.id,
+              type: 'script',
+              deviceId: device.id,
+              payload,
+              executedAt: claimed.executedAt,
+            },
+          ])
+        ).length === 0;
+      if (gated) {
+        deliveryOutcome = 'agent_unsupported';
+        return {
+          ok: true,
+          commandId: command.id,
+          executionId,
+          delivered,
+          deliveryOutcome,
+          executedAt,
+          ignoredParameters,
+        };
+      }
       const deliverable = decryptCommandForDelivery({
         id: command.id,
         type: 'script',

--- a/apps/api/src/services/scriptExecution.test.ts
+++ b/apps/api/src/services/scriptExecution.test.ts
@@ -351,6 +351,107 @@ describe('executeScriptOnDevices — per-device dispatch failures (#3409 PR2 Tas
   });
 });
 
+// #3409 PR4c-2: the claim-time secret gate ALREADY wrote the failed
+// script_executions row and ALREADY spent the batch's devicesFailed slot
+// before dispatch returned. The fan-out must report the device as failed
+// without writing a SECOND row or double-counting the batch.
+describe('executeScriptOnDevices — dispatch codes the gate already recorded', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.insert).mockReturnValue(insertReturning([{ id: 'inserted-1' }]) as any);
+    vi.mocked(db.update).mockReturnValue(updateChain() as any);
+  });
+
+  const twoDeviceSelect = () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-b' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([
+        baseDevice({ id: 'device-a', orgId: 'org-b' }),
+        baseDevice({ id: 'device-b', orgId: 'org-b' }),
+      ]) as any);
+  };
+
+  const okDispatch = (suffix: string) => ({
+    ok: true as const,
+    commandId: `cmd-${suffix}`,
+    executionId: `exec-${suffix}`,
+    delivered: false,
+    deliveryOutcome: 'no_agent' as const,
+    executedAt: null,
+    ignoredParameters: [],
+  });
+
+  it('reports agent_upgrade_required in failures without a second execution insert or batch increment', async () => {
+    twoDeviceSelect();
+    vi.mocked(dispatchScriptToDevice)
+      .mockResolvedValueOnce(okDispatch('a'))
+      .mockResolvedValueOnce({
+        ok: false,
+        code: 'agent_upgrade_required',
+        error: 'Agent upgrade required: ...; script not executed',
+      });
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-a', 'device-b'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // The operator still learns the device failed and why.
+    expect(result.failures).toEqual([
+      { deviceId: 'device-b', code: 'agent_upgrade_required', error: expect.any(String) },
+    ]);
+    expect(result.executions.map((e) => e.deviceId)).toEqual(['device-a']);
+    expect(result.devicesTargeted).toBe(2);
+
+    // db.insert's chain is a single shared mock: call 0 is the batch insert.
+    // A second `.values(...)` call would be the duplicate failed-execution row.
+    const insertChain = vi.mocked(db.insert).mock.results[0]!.value;
+    expect(insertChain.values.mock.calls).toHaveLength(1);
+    // The only db.update left is the final batch-status write — no
+    // devicesFailed increment (the gate already spent that slot).
+    const updateCalls = vi.mocked(db.update).mock.results;
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]!.value.set.mock.calls[0][0]).not.toHaveProperty('devicesFailed');
+  });
+
+  it('still writes the row and increments the batch for a code the gate did NOT record', async () => {
+    twoDeviceSelect();
+    vi.mocked(dispatchScriptToDevice)
+      .mockResolvedValueOnce(okDispatch('a'))
+      .mockResolvedValueOnce({
+        ok: false,
+        code: 'secret_delivery_unavailable',
+        error: 'Secret delivery is not configured on this server',
+      });
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-a', 'device-b'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.failures).toEqual([
+      { deviceId: 'device-b', code: 'secret_delivery_unavailable', error: expect.any(String) },
+    ]);
+
+    const insertChain = vi.mocked(db.insert).mock.results[0]!.value;
+    expect(insertChain.values.mock.calls).toHaveLength(2);
+    expect(insertChain.values.mock.calls[1][0]).toMatchObject({
+      deviceId: 'device-b',
+      orgId: 'org-b',
+      status: 'failed',
+    });
+    const updateCalls = vi.mocked(db.update).mock.results;
+    expect(updateCalls).toHaveLength(2);
+    expect(updateCalls[0]!.value.set.mock.calls[0][0]).toHaveProperty('devicesFailed');
+  });
+});
+
 describe('executeScriptOnDevices — ignored bound parameters (#3409 PR3 §2.2)', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/api/src/services/scriptExecution.test.ts
+++ b/apps/api/src/services/scriptExecution.test.ts
@@ -381,7 +381,50 @@ describe('executeScriptOnDevices — dispatch codes the gate already recorded', 
     ignoredParameters: [],
   });
 
-  it('reports agent_upgrade_required in failures without a second execution insert or batch increment', async () => {
+  it('reports agent_upgrade_required_recorded in failures without a second execution insert or batch increment', async () => {
+    twoDeviceSelect();
+    vi.mocked(dispatchScriptToDevice)
+      .mockResolvedValueOnce(okDispatch('a'))
+      .mockResolvedValueOnce({
+        ok: false,
+        code: 'agent_upgrade_required_recorded',
+        error: 'Agent upgrade required: ...; script not executed',
+      });
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-a', 'device-b'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // The operator still learns the device failed and why.
+    expect(result.failures).toEqual([
+      { deviceId: 'device-b', code: 'agent_upgrade_required_recorded', error: expect.any(String) },
+    ]);
+    expect(result.executions.map((e) => e.deviceId)).toEqual(['device-a']);
+    expect(result.devicesTargeted).toBe(2);
+
+    // db.insert's chain is a single shared mock: call 0 is the batch insert.
+    // A second `.values(...)` call would be the duplicate failed-execution row.
+    const insertChain = vi.mocked(db.insert).mock.results[0]!.value;
+    expect(insertChain.values.mock.calls).toHaveLength(1);
+    // The only db.update left is the final batch-status write — no
+    // devicesFailed increment (the gate already spent that slot).
+    const updateCalls = vi.mocked(db.update).mock.results;
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]!.value.set.mock.calls[0][0]).not.toHaveProperty('devicesFailed');
+  });
+
+  // #3409 PR4c-2 review finding 3 — THE regression this split exists for.
+  // 'agent_upgrade_required' is overwhelmingly the ENQUEUE preflight's
+  // refusal, which returns BEFORE any script_executions row is written. While
+  // it shared a code with the claim-time gate it was suppressed here, so a
+  // batch of 10 devices with 3 pre-PR4b agents showed 7 accounted rows and
+  // `devicesCompleted + devicesFailed >= devicesTargeted` never held — the
+  // batch could never finalize.
+  it('DOES write the row and increment the batch for the ENQUEUE agent_upgrade_required refusal', async () => {
     twoDeviceSelect();
     vi.mocked(dispatchScriptToDevice)
       .mockResolvedValueOnce(okDispatch('a'))
@@ -399,22 +442,47 @@ describe('executeScriptOnDevices — dispatch codes the gate already recorded', 
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    // The operator still learns the device failed and why.
     expect(result.failures).toEqual([
       { deviceId: 'device-b', code: 'agent_upgrade_required', error: expect.any(String) },
     ]);
-    expect(result.executions.map((e) => e.deviceId)).toEqual(['device-a']);
-    expect(result.devicesTargeted).toBe(2);
 
-    // db.insert's chain is a single shared mock: call 0 is the batch insert.
-    // A second `.values(...)` call would be the duplicate failed-execution row.
     const insertChain = vi.mocked(db.insert).mock.results[0]!.value;
-    expect(insertChain.values.mock.calls).toHaveLength(1);
-    // The only db.update left is the final batch-status write — no
-    // devicesFailed increment (the gate already spent that slot).
+    expect(insertChain.values.mock.calls).toHaveLength(2);
+    expect(insertChain.values.mock.calls[1][0]).toMatchObject({
+      deviceId: 'device-b',
+      orgId: 'org-b',
+      status: 'failed',
+    });
     const updateCalls = vi.mocked(db.update).mock.results;
-    expect(updateCalls).toHaveLength(1);
-    expect(updateCalls[0]!.value.set.mock.calls[0][0]).not.toHaveProperty('devicesFailed');
+    expect(updateCalls).toHaveLength(2);
+    expect(updateCalls[0]!.value.set.mock.calls[0][0]).toHaveProperty('devicesFailed');
+  });
+
+  // The claim gate's infrastructure-fault path writes NOTHING (it cannot know
+  // whether the gate's terminal write landed), so its refusal must also take
+  // the ordinary per-device failure row.
+  it('DOES write the row and increment the batch for secret_gate_unavailable', async () => {
+    twoDeviceSelect();
+    vi.mocked(dispatchScriptToDevice)
+      .mockResolvedValueOnce(okDispatch('a'))
+      .mockResolvedValueOnce({
+        ok: false,
+        code: 'secret_gate_unavailable',
+        error: 'The server could not verify ...; script not executed',
+      });
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-a', 'device-b'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const insertChain = vi.mocked(db.insert).mock.results[0]!.value;
+    expect(insertChain.values.mock.calls).toHaveLength(2);
+    const updateCalls = vi.mocked(db.update).mock.results;
+    expect(updateCalls[0]!.value.set.mock.calls[0][0]).toHaveProperty('devicesFailed');
   });
 
   it('still writes the row and increments the batch for a code the gate did NOT record', async () => {

--- a/apps/api/src/services/scriptExecution.ts
+++ b/apps/api/src/services/scriptExecution.ts
@@ -85,23 +85,32 @@ export type ExecuteScriptOnDevicesResult = ExecuteScriptOnDevicesSuccess | Execu
  * returned — so this fan-out must record the device in `failures` but must
  * NOT write its own duplicate row or double-spend the batch slot.
  *
- * Today that is exactly the claim-time secret gate's refusal (#3409 PR4c-2):
- * `failClaimedSecretCommandsForUnsupportedAgent` drives the command AND its
- * linked execution row to 'failed' and bumps the batch itself before dispatch
- * turns that into an 'agent_upgrade_required' refusal.
+ * Exactly one code qualifies: the claim-time secret gate's refusal (#3409
+ * PR4c-2). `failClaimedSecretCommandsForUnsupportedAgent` drives the command
+ * AND its linked execution row to 'failed' and bumps the batch itself before
+ * dispatch turns that into an 'agent_upgrade_required_recorded' refusal.
  *
- * The SAME code is also produced by the ENQUEUE preflight, which refuses
- * before any row exists, and the code alone cannot tell the two apart — so
- * this set errs toward NOT writing. A duplicate row plus a double-spent batch
- * slot (the operator sees the device fail twice, and `devicesFailed` can
- * exceed `devicesTargeted`) is worse than an enqueue-refused device that
- * surfaces only in the returned `failures`. If the enqueue refusal ever needs
- * a row of its own, give it a distinct code rather than dropping this entry.
+ * Membership must be argued per code, not inferred from the message. The
+ * three neighbours that look similar and are NOT members:
+ *
+ * - 'agent_upgrade_required' — the ENQUEUE preflight, which refuses before
+ *   any row exists. It is the ORDINARY outcome for any pre-PR4b agent, and
+ *   it originally shared a code with the claim-time gate: on 10 devices with
+ *   3 old agents the batch showed 7 accounted rows and
+ *   `devicesCompleted + devicesFailed >= devicesTargeted` never held, so the
+ *   batch could never finalize. That is why the claim-time path carries a
+ *   code of its own.
+ * - 'secret_gate_unavailable' — the claim gate FAULTED rather than returning
+ *   a verdict, so it wrote nothing.
+ * - 'secrets_unsupported_run_as' / 'secret_delivery_unavailable' — enqueue
+ *   refusals, likewise nothing written.
  *
  * A named set rather than an inline `===` so a future code is added here
  * deliberately, with that ownership question answered.
  */
-const DISPATCH_CODES_ALREADY_RECORDED: ReadonlySet<string> = new Set(['agent_upgrade_required']);
+const DISPATCH_CODES_ALREADY_RECORDED: ReadonlySet<string> = new Set([
+  'agent_upgrade_required_recorded',
+]);
 
 function ensureOrgAccess(orgId: string, auth: Pick<ScriptExecutionAuth, 'canAccessOrg'>) {
   return auth.canAccessOrg(orgId);
@@ -290,13 +299,22 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
       variableScope,
     });
     if (!dispatch.ok) {
-      // 'insert_failed' means queueCommand/the execution insert itself broke
-      // — a programming error, not a per-device condition. Every other code
-      // ('unresolved_variables' from PR2's content substitution,
-      // 'unresolved_parameters' from PR3's sourced parameters, plus the
-      // device-state codes) is a condition specific to this device and must
-      // not truncate the rest of the fan-out — see
-      // softwareDeployment.ts:399-414 for the pattern this mirrors.
+      // Three-way branch on the code, by ROW OWNERSHIP:
+      //
+      //   1. 'insert_failed' — queueCommand/the execution insert itself broke.
+      //      A programming error, not a per-device condition: throw and abort
+      //      the run rather than recording N identical device failures.
+      //   2. a DISPATCH_CODES_ALREADY_RECORDED code — a per-device condition
+      //      whose failure row and batch slot the dispatch core's own gate
+      //      already wrote. Report it, write nothing.
+      //   3. everything else ('unresolved_variables' from PR2's content
+      //      substitution, 'unresolved_parameters' from PR3's sourced
+      //      parameters, the enqueue secret refusals, and the device-state
+      //      codes) — a per-device condition that owns no rows yet, so this
+      //      loop writes the failure row and spends the batch slot. It must
+      //      not truncate the rest of the fan-out; `dispatchManagerInstalls`
+      //      (softwareDeployment.ts) is the pattern this mirrors — named
+      //      rather than cited by line number so the reference cannot rot.
       if (dispatch.code === 'insert_failed') {
         throw new Error(dispatch.error);
       }

--- a/apps/api/src/services/scriptExecution.ts
+++ b/apps/api/src/services/scriptExecution.ts
@@ -50,7 +50,9 @@ type ExecuteScriptOnDevicesSuccess = {
   // devices are excluded from `executions` but still counted in
   // `devicesTargeted` — they were targeted, just failed to dispatch. Each one
   // gets its own 'failed' script_executions row (see the dispatch loop below)
-  // so `devicesTargeted` never outlives the rows a caller can find.
+  // so `devicesTargeted` never outlives the rows a caller can find — except
+  // for the codes in DISPATCH_CODES_ALREADY_RECORDED, whose row the dispatch
+  // core's own gate already wrote.
   failures: Array<{ deviceId: string; code: string; error: string }>;
   // Bound parameter keys the caller supplied a value for, unioned across the
   // fan-out and de-duplicated (#3409 PR3 §2.2). The binding is authoritative,
@@ -76,6 +78,30 @@ type ExecuteScriptOnDevicesSuccess = {
 };
 
 export type ExecuteScriptOnDevicesResult = ExecuteScriptOnDevicesSuccess | ExecuteScriptOnDevicesFailure;
+
+/**
+ * Dispatch failure codes whose `script_executions` row and `devicesFailed`
+ * batch increment were ALREADY written before `dispatchScriptToDevice`
+ * returned — so this fan-out must record the device in `failures` but must
+ * NOT write its own duplicate row or double-spend the batch slot.
+ *
+ * Today that is exactly the claim-time secret gate's refusal (#3409 PR4c-2):
+ * `failClaimedSecretCommandsForUnsupportedAgent` drives the command AND its
+ * linked execution row to 'failed' and bumps the batch itself before dispatch
+ * turns that into an 'agent_upgrade_required' refusal.
+ *
+ * The SAME code is also produced by the ENQUEUE preflight, which refuses
+ * before any row exists, and the code alone cannot tell the two apart — so
+ * this set errs toward NOT writing. A duplicate row plus a double-spent batch
+ * slot (the operator sees the device fail twice, and `devicesFailed` can
+ * exceed `devicesTargeted`) is worse than an enqueue-refused device that
+ * surfaces only in the returned `failures`. If the enqueue refusal ever needs
+ * a row of its own, give it a distinct code rather than dropping this entry.
+ *
+ * A named set rather than an inline `===` so a future code is added here
+ * deliberately, with that ownership question answered.
+ */
+const DISPATCH_CODES_ALREADY_RECORDED: ReadonlySet<string> = new Set(['agent_upgrade_required']);
 
 function ensureOrgAccess(orgId: string, auth: Pick<ScriptExecutionAuth, 'canAccessOrg'>) {
   return auth.canAccessOrg(orgId);
@@ -273,6 +299,12 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
       // softwareDeployment.ts:399-414 for the pattern this mirrors.
       if (dispatch.code === 'insert_failed') {
         throw new Error(dispatch.error);
+      }
+      // The device still lands in `failures` — the operator must see it — but
+      // its row and batch slot are already spent by whoever owns this code.
+      if (DISPATCH_CODES_ALREADY_RECORDED.has(dispatch.code)) {
+        failures.push({ deviceId: device.id, code: dispatch.code, error: dispatch.error });
+        continue;
       }
       await db.insert(scriptExecutions).values({
         scriptId: input.scriptId,

--- a/apps/api/src/services/scriptSecretDelivery.test.ts
+++ b/apps/api/src/services/scriptSecretDelivery.test.ts
@@ -23,6 +23,7 @@ import {
   AGENT_UPGRADE_REQUIRED_MESSAGE,
   SCRIPT_SECRET_ENV_REQUIRED_VERSION,
   SECRET_DELIVERY_UNAVAILABLE_MESSAGE,
+  SECRET_GATE_UNAVAILABLE_MESSAGE,
   SECRETS_RUN_AS_MESSAGE,
   failClaimedSecretCommandsForUnsupportedAgent,
   loadScriptSecretEnvVersion,
@@ -282,6 +283,25 @@ describe('secretDeliveryPreflight', () => {
     mockSelect(() => []);
     const r = await secretDeliveryPreflight({ deviceId: DEVICE_A, runAs: 'system' });
     expect(r).toEqual({ ok: false, code: 'agent_upgrade_required', error: AGENT_UPGRADE_REQUIRED_MESSAGE });
+  });
+
+  // #3409 PR4c-2 review finding 3: the ENQUEUE preflight keeps
+  // 'agent_upgrade_required' — it returns before any row is written, so the
+  // fan-out must take the ordinary per-device failure insert for it. Only the
+  // CLAIM-time gate's refusal (scriptDispatch's
+  // 'agent_upgrade_required_recorded') arrives with rows already written.
+  it('never returns the claim-time-only code from the enqueue preflight', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 0 }));
+    const r = await secretDeliveryPreflight({ deviceId: DEVICE_A, runAs: 'system' });
+    expect(r).not.toMatchObject({ code: 'agent_upgrade_required_recorded' });
+  });
+
+  // The infrastructure-fault message must NOT tell the operator to upgrade an
+  // agent that may be perfectly current.
+  it('SECRET_GATE_UNAVAILABLE_MESSAGE is distinct and does not blame the agent version', () => {
+    expect(SECRET_GATE_UNAVAILABLE_MESSAGE).not.toBe(AGENT_UPGRADE_REQUIRED_MESSAGE);
+    expect(SECRET_GATE_UNAVAILABLE_MESSAGE).not.toMatch(/upgrade/i);
+    expect(SECRET_GATE_UNAVAILABLE_MESSAGE).toMatch(/not executed/i);
   });
 
   it('passes at the required version', async () => {

--- a/apps/api/src/services/scriptSecretDelivery.test.ts
+++ b/apps/api/src/services/scriptSecretDelivery.test.ts
@@ -1,0 +1,479 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SQL, Param } from 'drizzle-orm';
+
+vi.mock('../db', () => ({ db: { select: vi.fn(), update: vi.fn() } }));
+vi.mock('./secretCrypto', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./secretCrypto')>()),
+  getActiveSecretEncryptionKeyId: vi.fn(),
+}));
+vi.mock('./sensitiveCommandPayload', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./sensitiveCommandPayload')>()),
+  terminalPayloadErasureSet: vi.fn(() => ({ payload: 'ERASED-PAYLOAD-SENTINEL' })),
+}));
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+
+import { db } from '../db';
+import { deviceCommands, devices, scriptExecutionBatches, scriptExecutions } from '../db/schema';
+import { getActiveSecretEncryptionKeyId } from './secretCrypto';
+import { terminalPayloadErasureSet } from './sensitiveCommandPayload';
+import { SCRIPT_SECRET_ENVELOPE_FIELD } from './scriptSecretEnvelope';
+import { captureException } from './sentry';
+import type { ClaimedCommand } from './commandDelivery';
+import {
+  AGENT_UPGRADE_REQUIRED_MESSAGE,
+  SCRIPT_SECRET_ENV_REQUIRED_VERSION,
+  SECRET_DELIVERY_UNAVAILABLE_MESSAGE,
+  SECRETS_RUN_AS_MESSAGE,
+  failClaimedSecretCommandsForUnsupportedAgent,
+  loadScriptSecretEnvVersion,
+  runAsSupportsSecretEnv,
+  secretDeliveryPreflight,
+} from './scriptSecretDelivery';
+
+const DEVICE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const DEVICE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const EXEC_1 = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const BATCH_1 = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const SECRET_VALUE = 'hunter2-super-secret-value';
+const claimedAt = new Date('2026-08-22T00:00:00Z');
+
+// ── Drizzle mock plumbing ────────────────────────────────────────────
+
+// Extracts the actually-BOUND query parameters (column name + literal value)
+// from a drizzle SQL condition tree. Walks ONLY `SQL`/`Param` nodes — never
+// the column/table metadata graph, which itself contains strings like
+// 'status' and would make a `toContain` assertion pass against a deleted
+// guard (memory: vacuous_drizzle_where_clause_assertions). Duplicated from
+// scriptDispatch.test.ts on purpose (test helpers stay local).
+function collectBoundParams(node: unknown): { column: string; value: unknown }[] {
+  const found: { column: string; value: unknown }[] = [];
+  const seen = new WeakSet<object>();
+  const visit = (value: unknown) => {
+    if (value == null || typeof value !== 'object') return;
+    if (seen.has(value as object)) return;
+    seen.add(value as object);
+    if (value instanceof Param) {
+      const encoder = (value as { encoder?: { name?: string } }).encoder;
+      found.push({ column: encoder?.name ?? '<unknown>', value: (value as { value: unknown }).value });
+      return;
+    }
+    if (value instanceof SQL) {
+      for (const chunk of (value as unknown as { queryChunks: unknown[] }).queryChunks) visit(chunk);
+    } else if (Array.isArray(value)) {
+      // `inArray(col, [...])` embeds a plain JS array of Param nodes as one
+      // query chunk (drizzle-orm 0.45).
+      for (const item of value) visit(item);
+    }
+  };
+  visit(node);
+  return found;
+}
+
+type SelectCall = { columns: unknown; table: unknown; where: unknown };
+type UpdateCall = { table: unknown; set: Record<string, unknown> | undefined; where: unknown };
+
+const selectCalls: SelectCall[] = [];
+const updateCalls: UpdateCall[] = [];
+
+// Models `db.select(cols).from(table).where(cond)` resolving to `rows`
+// (optionally per-table). Records every call so a test can assert the
+// predicate's bound params and the query COUNT.
+function mockSelect(rowsFor: (table: unknown) => unknown[] | Promise<unknown[]>) {
+  vi.mocked(db.select).mockImplementation(((columns: unknown) => {
+    const call: SelectCall = { columns, table: undefined, where: undefined };
+    selectCalls.push(call);
+    return {
+      from: vi.fn((table: unknown) => {
+        call.table = table;
+        return {
+          where: vi.fn((cond: unknown) => {
+            call.where = cond;
+            return Promise.resolve(rowsFor(table));
+          }),
+        };
+      }),
+    };
+  }) as any);
+}
+
+// Models `db.update(table).set(v).where(cond)` (awaitable) and the same
+// chain with `.returning(cols)`; `returningFor` picks the returned rows per
+// table, or throws to model a failing write.
+function mockUpdate(returningFor: (table: unknown) => unknown[]) {
+  vi.mocked(db.update).mockImplementation(((table: unknown) => {
+    const call: UpdateCall = { table, set: undefined, where: undefined };
+    updateCalls.push(call);
+    const resolveRows = () => {
+      try {
+        return Promise.resolve(returningFor(table));
+      } catch (err) {
+        return Promise.reject(err);
+      }
+    };
+    return {
+      set: vi.fn((values: Record<string, unknown>) => {
+        call.set = values;
+        return {
+          where: vi.fn((cond: unknown) => {
+            call.where = cond;
+            return Object.assign(resolveRows(), {
+              returning: vi.fn(() => resolveRows()),
+            });
+          }),
+        };
+      }),
+    };
+  }) as any);
+}
+
+const capabilityRows = (versions: Record<string, number>) =>
+  Object.entries(versions).map(([id, scriptSecretEnvVersion]) => ({ id, scriptSecretEnvVersion }));
+
+const envelopeCommand = (o: Partial<ClaimedCommand> = {}): ClaimedCommand => ({
+  id: 'cmd-secret',
+  type: 'script',
+  deviceId: DEVICE_A,
+  payload: {
+    scriptId: 'script-1',
+    executionId: EXEC_1,
+    [SCRIPT_SECRET_ENVELOPE_FIELD]: 'enc:v3:key-1:ciphertext',
+  },
+  executedAt: claimedAt,
+  ...o,
+});
+
+const plainCommand = (o: Partial<ClaimedCommand> = {}): ClaimedCommand => ({
+  id: 'cmd-plain',
+  type: 'script',
+  deviceId: DEVICE_A,
+  payload: { scriptId: 'script-2', parameters: {} },
+  executedAt: claimedAt,
+  ...o,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectCalls.length = 0;
+  updateCalls.length = 0;
+  vi.mocked(getActiveSecretEncryptionKeyId).mockReturnValue('key-1');
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+// ── Pure helpers ─────────────────────────────────────────────────────
+
+describe('SCRIPT_SECRET_ENV_REQUIRED_VERSION', () => {
+  it('is the PR4b agent capability version', () => {
+    expect(SCRIPT_SECRET_ENV_REQUIRED_VERSION).toBe(1);
+  });
+});
+
+describe('runAsSupportsSecretEnv', () => {
+  it.each([
+    ['system', undefined, true],
+    ['elevated', undefined, true],
+    ['user', undefined, false],
+    [undefined, undefined, true],
+    ['system', 3, false],
+    ['elevated', 0, false],
+    ['system', null, true],
+  ] as const)('runAs=%s targetSessionId=%s → %s', (runAs, targetSessionId, expected) => {
+    expect(runAsSupportsSecretEnv(runAs as any, targetSessionId as any)).toBe(expected);
+  });
+});
+
+// ── loadScriptSecretEnvVersion ───────────────────────────────────────
+
+describe('loadScriptSecretEnvVersion', () => {
+  it('reads devices.script_secret_env_version for the device', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 1 }));
+    await expect(loadScriptSecretEnvVersion(DEVICE_A)).resolves.toBe(1);
+    expect(selectCalls).toHaveLength(1);
+    expect(selectCalls[0]!.table).toBe(devices);
+    expect(collectBoundParams(selectCalls[0]!.where)).toEqual([{ column: 'id', value: DEVICE_A }]);
+  });
+
+  it('returns null when the device row is gone', async () => {
+    mockSelect(() => []);
+    await expect(loadScriptSecretEnvVersion(DEVICE_A)).resolves.toBeNull();
+  });
+});
+
+// ── secretDeliveryPreflight ──────────────────────────────────────────
+
+describe('secretDeliveryPreflight', () => {
+  it('refuses a user-context run before touching the key or the DB', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 1 }));
+    const r = await secretDeliveryPreflight({ deviceId: DEVICE_A, runAs: 'user' });
+    expect(r).toEqual({ ok: false, code: 'secrets_unsupported_run_as', error: SECRETS_RUN_AS_MESSAGE });
+    expect(getActiveSecretEncryptionKeyId).not.toHaveBeenCalled();
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('refuses a targeted-session run even as system', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 1 }));
+    const r = await secretDeliveryPreflight({ deviceId: DEVICE_A, runAs: 'system', targetSessionId: 2 });
+    expect(r).toEqual({ ok: false, code: 'secrets_unsupported_run_as', error: SECRETS_RUN_AS_MESSAGE });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('refuses when no secret-encryption key is active, before the capability query', async () => {
+    vi.mocked(getActiveSecretEncryptionKeyId).mockReturnValue(null);
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 1 }));
+    const r = await secretDeliveryPreflight({ deviceId: DEVICE_A, runAs: 'system' });
+    expect(r).toEqual({
+      ok: false,
+      code: 'secret_delivery_unavailable',
+      error: SECRET_DELIVERY_UNAVAILABLE_MESSAGE,
+    });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('refuses a device whose agent reports capability 0', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 0 }));
+    const r = await secretDeliveryPreflight({ deviceId: DEVICE_A, runAs: 'elevated' });
+    expect(r).toEqual({ ok: false, code: 'agent_upgrade_required', error: AGENT_UPGRADE_REQUIRED_MESSAGE });
+    expect(selectCalls).toHaveLength(1);
+    expect(selectCalls[0]!.table).toBe(devices);
+    expect(collectBoundParams(selectCalls[0]!.where)).toEqual([{ column: 'id', value: DEVICE_A }]);
+  });
+
+  it('refuses when the device row is gone (fail closed, not open)', async () => {
+    mockSelect(() => []);
+    const r = await secretDeliveryPreflight({ deviceId: DEVICE_A, runAs: 'system' });
+    expect(r).toEqual({ ok: false, code: 'agent_upgrade_required', error: AGENT_UPGRADE_REQUIRED_MESSAGE });
+  });
+
+  it('passes at the required version', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: SCRIPT_SECRET_ENV_REQUIRED_VERSION }));
+    await expect(secretDeliveryPreflight({ deviceId: DEVICE_A, runAs: 'system' })).resolves.toEqual({ ok: true });
+  });
+
+  it('passes at a newer version (floor, not equality)', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: SCRIPT_SECRET_ENV_REQUIRED_VERSION + 1 }));
+    await expect(secretDeliveryPreflight({ deviceId: DEVICE_A, runAs: 'system' })).resolves.toEqual({ ok: true });
+  });
+
+  it('treats an absent runAs as the system default', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 1 }));
+    await expect(secretDeliveryPreflight({ deviceId: DEVICE_A, runAs: undefined })).resolves.toEqual({ ok: true });
+  });
+});
+
+// ── failClaimedSecretCommandsForUnsupportedAgent ─────────────────────
+
+describe('failClaimedSecretCommandsForUnsupportedAgent', () => {
+  it('returns the batch unchanged and issues NO query when nothing carries an envelope', async () => {
+    const claimed = [
+      plainCommand(),
+      // A non-script command must not be gated even if it happens to carry
+      // a field by the same name.
+      plainCommand({ id: 'cmd-other', type: 'run_script', payload: { [SCRIPT_SECRET_ENVELOPE_FIELD]: 'x' } }),
+      // An envelope that is not a non-empty string is not an envelope.
+      plainCommand({ id: 'cmd-empty', payload: { [SCRIPT_SECRET_ENVELOPE_FIELD]: '' } }),
+      plainCommand({ id: 'cmd-null-payload', payload: null }),
+    ];
+    const out = await failClaimedSecretCommandsForUnsupportedAgent(claimed);
+    expect(out).toBe(claimed);
+    expect(db.select).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty batch untouched', async () => {
+    await expect(failClaimedSecretCommandsForUnsupportedAgent([])).resolves.toEqual([]);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('leaves an envelope-bearing command alone when the agent is capable (one select, no update)', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 1 }));
+    const claimed = [plainCommand(), envelopeCommand()];
+    const out = await failClaimedSecretCommandsForUnsupportedAgent(claimed);
+    expect(out.map((c) => c.id)).toEqual(['cmd-plain', 'cmd-secret']);
+    expect(selectCalls).toHaveLength(1);
+    expect(selectCalls[0]!.table).toBe(devices);
+    expect(collectBoundParams(selectCalls[0]!.where)).toEqual([{ column: 'id', value: DEVICE_A }]);
+    expect(db.update).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('fails the envelope-bearing command terminally on a capability-0 agent and returns the siblings', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 0 }));
+    mockUpdate((table) => (table === deviceCommands ? [{ id: 'cmd-secret' }] : [{ id: EXEC_1, scriptId: 'script-1' }]));
+
+    const claimed = [plainCommand(), envelopeCommand(), plainCommand({ id: 'cmd-plain-2' })];
+    const out = await failClaimedSecretCommandsForUnsupportedAgent(claimed);
+
+    expect(out.map((c) => c.id)).toEqual(['cmd-plain', 'cmd-plain-2']);
+    expect(selectCalls).toHaveLength(1);
+
+    const cmdUpdate = updateCalls.find((u) => u.table === deviceCommands);
+    expect(cmdUpdate).toBeDefined();
+    expect(cmdUpdate!.set).toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        completedAt: expect.any(Date),
+        result: { status: 'failed', error: AGENT_UPGRADE_REQUIRED_MESSAGE, exitCode: 1 },
+        payload: 'ERASED-PAYLOAD-SENTINEL',
+      }),
+    );
+    expect(terminalPayloadErasureSet).toHaveBeenCalledTimes(1);
+    // Guarded on the claim state: `id = ? AND status = 'sent'` — never an
+    // unconditional overwrite of a row something else already drove terminal.
+    expect(collectBoundParams(cmdUpdate!.where)).toEqual([
+      { column: 'id', value: 'cmd-secret' },
+      { column: 'status', value: 'sent' },
+    ]);
+
+    // One warning, naming the command and device — never the payload.
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    const [warnMessage, warnContext] = vi.mocked(console.warn).mock.calls[0]!;
+    expect(String(warnMessage)).toContain('[scriptSecretDelivery]');
+    expect(warnContext).toEqual(expect.objectContaining({ commandId: 'cmd-secret', deviceId: DEVICE_A }));
+    expect(JSON.stringify(vi.mocked(console.warn).mock.calls)).not.toContain('ciphertext');
+    expect(JSON.stringify(vi.mocked(console.warn).mock.calls)).not.toContain('payload');
+  });
+
+  it('propagates the failure to the linked script_executions row and bumps the batch failure counter', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 0 }));
+    mockUpdate((table) => (table === deviceCommands ? [{ id: 'cmd-secret' }] : [{ id: EXEC_1, scriptId: 'script-1' }]));
+
+    await failClaimedSecretCommandsForUnsupportedAgent([
+      envelopeCommand({ payload: { ...(envelopeCommand().payload as object), batchId: BATCH_1 } }),
+    ]);
+
+    const execUpdate = updateCalls.find((u) => u.table === scriptExecutions);
+    expect(execUpdate).toBeDefined();
+    expect(execUpdate!.set).toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        completedAt: expect.any(Date),
+        errorMessage: AGENT_UPGRADE_REQUIRED_MESSAGE,
+      }),
+    );
+    expect(collectBoundParams(execUpdate!.where)).toEqual([
+      { column: 'id', value: EXEC_1 },
+      { column: 'device_id', value: DEVICE_A },
+      { column: 'status', value: 'pending' },
+      { column: 'status', value: 'queued' },
+      { column: 'status', value: 'running' },
+    ]);
+
+    const batchUpdate = updateCalls.find((u) => u.table === scriptExecutionBatches);
+    expect(batchUpdate).toBeDefined();
+    expect(Object.keys(batchUpdate!.set ?? {})).toEqual(['devicesFailed']);
+    expect(collectBoundParams(batchUpdate!.where)).toEqual([
+      { column: 'id', value: BATCH_1 },
+      { column: 'script_id', value: 'script-1' },
+    ]);
+
+    // The command row is updated BEFORE the execution row (the agent-facing
+    // state is the one the claim path is racing on).
+    expect(updateCalls.map((u) => u.table)).toEqual([deviceCommands, scriptExecutions, scriptExecutionBatches]);
+  });
+
+  it('does not touch the batch counter when the execution was already terminal', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 0 }));
+    mockUpdate((table) => (table === deviceCommands ? [{ id: 'cmd-secret' }] : []));
+
+    await failClaimedSecretCommandsForUnsupportedAgent([
+      envelopeCommand({ payload: { ...(envelopeCommand().payload as object), batchId: BATCH_1 } }),
+    ]);
+
+    expect(updateCalls.map((u) => u.table)).toEqual([deviceCommands, scriptExecutions]);
+  });
+
+  it('skips execution propagation when the payload carries no (uuid) executionId', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 0 }));
+    mockUpdate(() => [{ id: 'cmd-secret' }]);
+
+    await failClaimedSecretCommandsForUnsupportedAgent([
+      envelopeCommand({ id: 'cmd-no-exec', payload: { [SCRIPT_SECRET_ENVELOPE_FIELD]: 'enc:v3:k:c' } }),
+      envelopeCommand({ id: 'cmd-bad-exec', payload: { [SCRIPT_SECRET_ENVELOPE_FIELD]: 'enc:v3:k:c', executionId: 'not-a-uuid' } }),
+    ]);
+
+    expect(updateCalls.map((u) => u.table)).toEqual([deviceCommands, deviceCommands]);
+  });
+
+  it('does not propagate (or double-count) when the command row was no longer `sent`', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 0 }));
+    mockUpdate(() => []);
+
+    const out = await failClaimedSecretCommandsForUnsupportedAgent([plainCommand(), envelopeCommand()]);
+
+    // Still withheld from delivery — a lost race is not a reason to ship it.
+    expect(out.map((c) => c.id)).toEqual(['cmd-plain']);
+    expect(updateCalls.map((u) => u.table)).toEqual([deviceCommands]);
+  });
+
+  it('treats a missing device row as unsupported', async () => {
+    mockSelect(() => []);
+    mockUpdate(() => [{ id: 'cmd-secret' }]);
+    const out = await failClaimedSecretCommandsForUnsupportedAgent([envelopeCommand()]);
+    expect(out).toEqual([]);
+    expect(updateCalls[0]?.table).toBe(deviceCommands);
+  });
+
+  it('issues ONE capability select for a batch spanning several devices', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 1, [DEVICE_B]: 0 }));
+    mockUpdate(() => [{ id: 'x' }]);
+
+    const out = await failClaimedSecretCommandsForUnsupportedAgent([
+      envelopeCommand({ id: 'cmd-a', deviceId: DEVICE_A }),
+      envelopeCommand({ id: 'cmd-b', deviceId: DEVICE_B }),
+      envelopeCommand({ id: 'cmd-b2', deviceId: DEVICE_B }),
+    ]);
+
+    expect(out.map((c) => c.id)).toEqual(['cmd-a']);
+    expect(selectCalls).toHaveLength(1);
+    const bound = collectBoundParams(selectCalls[0]!.where);
+    expect(bound.map((b) => b.column)).toEqual(['id', 'id']);
+    expect(bound.map((b) => b.value).sort()).toEqual([DEVICE_A, DEVICE_B].sort());
+    expect(updateCalls.filter((u) => u.table === deviceCommands).map((u) => collectBoundParams(u.where)[0]!.value))
+      .toEqual(['cmd-b', 'cmd-b2']);
+  });
+
+  it('captures a propagation failure and still returns the siblings (and still withholds the command)', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 0 }));
+    mockUpdate((table) => {
+      if (table === deviceCommands) return [{ id: 'cmd-secret' }];
+      throw new Error('script_executions write exploded');
+    });
+
+    const out = await failClaimedSecretCommandsForUnsupportedAgent([plainCommand(), envelopeCommand()]);
+
+    expect(out.map((c) => c.id)).toEqual(['cmd-plain']);
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(captureException).mock.calls[0]![0]).toBeInstanceOf(Error);
+    expect(String((vi.mocked(captureException).mock.calls[0]![0] as Error).message)).toContain('cmd-secret');
+  });
+
+  it('captures a terminal-update failure, withholds the command, and still returns the siblings', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 0 }));
+    mockUpdate(() => {
+      throw new Error('device_commands write exploded');
+    });
+
+    const out = await failClaimedSecretCommandsForUnsupportedAgent([envelopeCommand(), plainCommand()]);
+
+    expect(out.map((c) => c.id)).toEqual(['cmd-plain']);
+    expect(captureException).toHaveBeenCalledTimes(1);
+    // No execution propagation after a failed command write.
+    expect(updateCalls.map((u) => u.table)).toEqual([deviceCommands]);
+  });
+
+  it('never echoes the envelope or a secret value into logs or Sentry', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 0 }));
+    mockUpdate(() => {
+      throw new Error('boom');
+    });
+    await failClaimedSecretCommandsForUnsupportedAgent([
+      envelopeCommand({ payload: { [SCRIPT_SECRET_ENVELOPE_FIELD]: `enc:v3:k:${SECRET_VALUE}`, executionId: EXEC_1 } }),
+    ]);
+    const everything = JSON.stringify([
+      vi.mocked(console.warn).mock.calls,
+      vi.mocked(console.error).mock.calls,
+      vi.mocked(captureException).mock.calls.map((c) => (c[0] as Error).message),
+    ]);
+    expect(everything).not.toContain(SECRET_VALUE);
+  });
+});

--- a/apps/api/src/services/scriptSecretDelivery.test.ts
+++ b/apps/api/src/services/scriptSecretDelivery.test.ts
@@ -178,6 +178,20 @@ describe('runAsSupportsSecretEnv', () => {
     ['system', 3, false],
     ['elevated', 0, false],
     ['system', null, true],
+    // Mirrors the agent's `runAsSupportsSecrets` (handlers_script.go): the
+    // value is lowercased/trimmed, and ONLY ''/system/elevated are admitted.
+    ['', undefined, true],
+    ['   ', undefined, true],
+    ['SYSTEM', undefined, true],
+    ['  System  ', undefined, true],
+    ['Elevated', undefined, true],
+    ['USER', undefined, false],
+    ['User', undefined, false],
+    // An explicit username is a helper-IPC (targeted session) run at the
+    // agent: no env, so the secret would simply be absent.
+    ['alice', undefined, false],
+    ['DOMAIN\\alice', undefined, false],
+    [null, undefined, true],
   ] as const)('runAs=%s targetSessionId=%s → %s', (runAs, targetSessionId, expected) => {
     expect(runAsSupportsSecretEnv(runAs as any, targetSessionId as any)).toBe(expected);
   });
@@ -226,6 +240,13 @@ describe('secretDeliveryPreflight', () => {
     const r = await secretDeliveryPreflight({ deviceId: DEVICE_A, runAs: 'user' });
     expect(r).toEqual({ ok: false, code: 'secrets_unsupported_run_as', error: SECRETS_RUN_AS_MESSAGE });
     expect(getActiveSecretEncryptionKeyId).not.toHaveBeenCalled();
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('refuses an explicit-username run before touching the key or the DB', async () => {
+    mockSelect(() => capabilityRows({ [DEVICE_A]: 1 }));
+    const r = await secretDeliveryPreflight({ deviceId: DEVICE_A, runAs: 'alice' as any });
+    expect(r).toEqual({ ok: false, code: 'secrets_unsupported_run_as', error: SECRETS_RUN_AS_MESSAGE });
     expect(db.select).not.toHaveBeenCalled();
   });
 
@@ -411,6 +432,19 @@ describe('failClaimedSecretCommandsForUnsupportedAgent', () => {
     ]);
 
     expect(updateCalls.map((u) => u.table)).toEqual([deviceCommands, deviceCommands]);
+    // Leaves a breadcrumb rather than returning silently: a later reaper pass
+    // would otherwise mislabel this server-side refusal an agent timeout.
+    const skipWarnings = vi
+      .mocked(console.warn)
+      .mock.calls.filter(([msg]) => String(msg).includes('no linked script execution'));
+    expect(skipWarnings).toHaveLength(2);
+    expect(skipWarnings.map(([, ctx]) => (ctx as Record<string, unknown>).commandId)).toEqual([
+      'cmd-no-exec',
+      'cmd-bad-exec',
+    ]);
+    expect(skipWarnings.every(([, ctx]) => (ctx as Record<string, unknown>).deviceId === DEVICE_A)).toBe(true);
+    // Never the payload / envelope.
+    expect(JSON.stringify(vi.mocked(console.warn).mock.calls)).not.toContain('enc:v3:k:c');
   });
 
   it('does not propagate (or double-count) when the command row was no longer `sent`', async () => {
@@ -422,14 +456,90 @@ describe('failClaimedSecretCommandsForUnsupportedAgent', () => {
     // Still withheld from delivery — a lost race is not a reason to ship it.
     expect(out.map((c) => c.id)).toEqual(['cmd-plain']);
     expect(updateCalls.map((u) => u.table)).toEqual([deviceCommands]);
+    // A 0-row terminal update on a row claimed microseconds earlier is
+    // genuinely unexpected: warn AND report, or the linked execution row
+    // strands non-terminal with no breadcrumb at all.
+    const raceWarnings = vi
+      .mocked(console.warn)
+      .mock.calls.filter(([msg]) => String(msg).includes('no longer `sent`'));
+    expect(raceWarnings).toHaveLength(1);
+    expect(raceWarnings[0]![1]).toEqual(
+      expect.objectContaining({ commandId: 'cmd-secret', deviceId: DEVICE_A }),
+    );
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(String((vi.mocked(captureException).mock.calls[0]![0] as Error).message)).toContain('cmd-secret');
   });
 
-  it('treats a missing device row as unsupported', async () => {
-    mockSelect(() => []);
-    mockUpdate(() => [{ id: 'cmd-secret' }]);
-    const out = await failClaimedSecretCommandsForUnsupportedAgent([envelopeCommand()]);
-    expect(out).toEqual([]);
-    expect(updateCalls[0]?.table).toBe(deviceCommands);
+  // ── A MISSING device row is not a capability claim ─────────────────
+  //
+  // `loadScriptSecretEnvVersions` builds its map from returned rows only, so
+  // an absent row is "we don't know", not "version 0". Driving the command
+  // terminal there would erase the payload IRREVERSIBLY and tell the operator
+  // to upgrade an agent that may well be current — while the real cause is an
+  // RLS/context regression, a device deleted mid-batch, or replica lag.
+  describe('device row not found', () => {
+    it('withholds the command but does NOT drive it terminal or erase its payload', async () => {
+      mockSelect(() => []);
+      mockUpdate(() => [{ id: 'cmd-secret' }]);
+
+      const out = await failClaimedSecretCommandsForUnsupportedAgent([plainCommand(), envelopeCommand()]);
+
+      // Withheld from delivery (never ship a sealed secret on a guess)…
+      expect(out.map((c) => c.id)).toEqual(['cmd-plain']);
+      // …but nothing was written: the row stays `sent` for the stale reaper,
+      // so the refusal stays reversible.
+      expect(db.update).not.toHaveBeenCalled();
+      expect(terminalPayloadErasureSet).not.toHaveBeenCalled();
+    });
+
+    it('reports the unknown device to Sentry (a fleet-wide occurrence must not be invisible)', async () => {
+      mockSelect(() => []);
+      mockUpdate(() => [{ id: 'cmd-secret' }]);
+
+      await failClaimedSecretCommandsForUnsupportedAgent([envelopeCommand()]);
+
+      expect(captureException).toHaveBeenCalledTimes(1);
+      const reported = vi.mocked(captureException).mock.calls[0]![0] as Error;
+      expect(reported).toBeInstanceOf(Error);
+      expect(reported.message).toContain('device row not found');
+      expect(reported.message).toContain('cmd-secret');
+      expect(reported.message).toContain(DEVICE_A);
+      expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('still fails a device that EXISTS and reports 0 in the same batch', async () => {
+      // DEVICE_A row is gone; DEVICE_B exists and is incapable.
+      mockSelect(() => capabilityRows({ [DEVICE_B]: 0 }));
+      mockUpdate((table) => (table === deviceCommands ? [{ id: 'cmd-b' }] : []));
+
+      const out = await failClaimedSecretCommandsForUnsupportedAgent([
+        envelopeCommand({ id: 'cmd-a', deviceId: DEVICE_A }),
+        envelopeCommand({ id: 'cmd-b', deviceId: DEVICE_B }),
+      ]);
+
+      expect(out).toEqual([]);
+      // Exactly one terminal write, and it is for the device that actually
+      // claimed an unsupported version.
+      const cmdUpdates = updateCalls.filter((u) => u.table === deviceCommands);
+      expect(cmdUpdates).toHaveLength(1);
+      expect(collectBoundParams(cmdUpdates[0]!.where)).toEqual([
+        { column: 'id', value: 'cmd-b' },
+        { column: 'status', value: 'sent' },
+      ]);
+    });
+
+    it('delivers a capable sibling device while withholding the unknown one', async () => {
+      mockSelect(() => capabilityRows({ [DEVICE_B]: 1 }));
+      mockUpdate(() => [{ id: 'x' }]);
+
+      const out = await failClaimedSecretCommandsForUnsupportedAgent([
+        envelopeCommand({ id: 'cmd-a', deviceId: DEVICE_A }),
+        envelopeCommand({ id: 'cmd-b', deviceId: DEVICE_B }),
+      ]);
+
+      expect(out.map((c) => c.id)).toEqual(['cmd-b']);
+      expect(db.update).not.toHaveBeenCalled();
+    });
   });
 
   it('issues ONE capability select for a batch spanning several devices', async () => {
@@ -541,6 +651,85 @@ describe('failClaimedSecretCommandsForUnsupportedAgent', () => {
       expect(out).toBe(claimed);
       expect(db.select).not.toHaveBeenCalled();
       expect(db.update).not.toHaveBeenCalled();
+    });
+
+    // The gate compares with `>= REQUIRED`, the normalizer with `=== 1`. The
+    // param is typed bare `number` and only DOCUMENTED as pre-normalized, so
+    // normalize defensively: an un-normalized future caller must not be able
+    // to widen the gate by reporting 2.
+    it.each([2, 99, 1.5, Number.MAX_SAFE_INTEGER])(
+      'normalizes an un-normalized reported version (%s) down to unsupported',
+      async (reported) => {
+        mockSelect(() => capabilityRows({ [DEVICE_A]: 1 }));
+        mockUpdate((table) => (table === deviceCommands ? [{ id: 'cmd-secret' }] : [{ id: EXEC_1, scriptId: 'script-1' }]));
+
+        const out = await failClaimedSecretCommandsForUnsupportedAgent([plainCommand(), envelopeCommand()], {
+          reportedVersion: reported,
+        });
+
+        expect(out.map((c) => c.id)).toEqual(['cmd-plain']);
+        // Still authoritative: the stored 1 is never consulted.
+        expect(db.select).not.toHaveBeenCalled();
+        expect(updateCalls.find((u) => u.table === deviceCommands)).toBeDefined();
+      },
+    );
+
+    it('keeps "not supplied" distinguishable from a reported 0', async () => {
+      mockSelect(() => capabilityRows({ [DEVICE_A]: 1 }));
+      mockUpdate(() => [{ id: 'cmd-secret' }]);
+
+      const out = await failClaimedSecretCommandsForUnsupportedAgent([envelopeCommand()], {
+        reportedVersion: undefined,
+      });
+
+      // undefined ⇒ fall back to the stored column (which says capable).
+      expect(out.map((c) => c.id)).toEqual(['cmd-secret']);
+      expect(selectCalls).toHaveLength(1);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    // A reported version is ONE agent's self-report about ITSELF. Spreading it
+    // across a multi-device batch would let device A's report authorise a
+    // secret for device B. There is no such caller today (one device per
+    // beat); the contract is enforced so a future batched-claim optimisation
+    // cannot silently introduce one.
+    it('throws when a reported version is handed a batch spanning several devices', async () => {
+      mockSelect(() => capabilityRows({ [DEVICE_A]: 0, [DEVICE_B]: 0 }));
+      mockUpdate(() => [{ id: 'x' }]);
+
+      await expect(
+        failClaimedSecretCommandsForUnsupportedAgent(
+          [
+            envelopeCommand({ id: 'cmd-a', deviceId: DEVICE_A }),
+            envelopeCommand({ id: 'cmd-b', deviceId: DEVICE_B }),
+          ],
+          { reportedVersion: 1 },
+        ),
+      ).rejects.toThrow(/reportedVersion/i);
+
+      // Nothing was delivered, read, or written on the way out.
+      expect(db.select).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('allows several commands for the SAME device under a reported version', async () => {
+      const claimed = [
+        envelopeCommand({ id: 'cmd-1', deviceId: DEVICE_A }),
+        envelopeCommand({ id: 'cmd-2', deviceId: DEVICE_A }),
+      ];
+      const out = await failClaimedSecretCommandsForUnsupportedAgent(claimed, { reportedVersion: 1 });
+      expect(out.map((c) => c.id)).toEqual(['cmd-1', 'cmd-2']);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('does not throw on a multi-device batch when NO version was reported', async () => {
+      mockSelect(() => capabilityRows({ [DEVICE_A]: 1, [DEVICE_B]: 1 }));
+      const out = await failClaimedSecretCommandsForUnsupportedAgent([
+        envelopeCommand({ id: 'cmd-a', deviceId: DEVICE_A }),
+        envelopeCommand({ id: 'cmd-b', deviceId: DEVICE_B }),
+      ]);
+      expect(out.map((c) => c.id)).toEqual(['cmd-a', 'cmd-b']);
+      expect(selectCalls).toHaveLength(1);
     });
   });
 

--- a/apps/api/src/services/scriptSecretDelivery.test.ts
+++ b/apps/api/src/services/scriptSecretDelivery.test.ts
@@ -26,6 +26,7 @@ import {
   SECRETS_RUN_AS_MESSAGE,
   failClaimedSecretCommandsForUnsupportedAgent,
   loadScriptSecretEnvVersion,
+  normalizeReportedScriptSecretEnvVersion,
   runAsSupportsSecretEnv,
   secretDeliveryPreflight,
 } from './scriptSecretDelivery';
@@ -179,6 +180,24 @@ describe('runAsSupportsSecretEnv', () => {
     ['system', null, true],
   ] as const)('runAs=%s targetSessionId=%s → %s', (runAs, targetSessionId, expected) => {
     expect(runAsSupportsSecretEnv(runAs as any, targetSessionId as any)).toBe(expected);
+  });
+});
+
+describe('normalizeReportedScriptSecretEnvVersion', () => {
+  // Must stay identical to the expression the heartbeat writes into
+  // devices.script_secret_env_version — they share this function precisely so
+  // the gate's trusted value and the stored value can never diverge.
+  it.each([
+    [1, 1],
+    [0, 0],
+    [2, 0],
+    [99, 0],
+    ['1', 0],
+    [undefined, 0],
+    [null, 0],
+    [true, 0],
+  ] as const)('%s → %s', (reported, expected) => {
+    expect(normalizeReportedScriptSecretEnvVersion(reported)).toBe(expected);
   });
 });
 
@@ -459,6 +478,70 @@ describe('failClaimedSecretCommandsForUnsupportedAgent', () => {
     expect(captureException).toHaveBeenCalledTimes(1);
     // No execution propagation after a failed command write.
     expect(updateCalls.map((u) => u.table)).toEqual([deviceCommands]);
+  });
+
+  // ── Amendment A: the heartbeat's REPORTED capability wins ──────────
+  //
+  // The heartbeat writes `devices.script_secret_env_version` non-sticky, but
+  // that write is guarded on the device not being decommissioned/quarantined
+  // and is a separate statement from the claim. A skipped or lost write would
+  // leave a STALE stored 1 while the agent just reported 0 — so when the
+  // caller knows what THIS beat reported, that value is authoritative and no
+  // devices select is issued at all.
+  describe('opts.reportedVersion', () => {
+    it('fails the command on a reported 0 even though the stored column still says 1', async () => {
+      mockSelect(() => capabilityRows({ [DEVICE_A]: 1 }));
+      mockUpdate((table) => (table === deviceCommands ? [{ id: 'cmd-secret' }] : [{ id: EXEC_1, scriptId: 'script-1' }]));
+
+      const out = await failClaimedSecretCommandsForUnsupportedAgent(
+        [plainCommand(), envelopeCommand()],
+        { reportedVersion: 0 },
+      );
+
+      expect(out.map((c) => c.id)).toEqual(['cmd-plain']);
+      // The authoritative value came from the caller: no capability read.
+      expect(db.select).not.toHaveBeenCalled();
+      const cmdUpdate = updateCalls.find((u) => u.table === deviceCommands);
+      expect(cmdUpdate!.set).toEqual(
+        expect.objectContaining({
+          status: 'failed',
+          result: { status: 'failed', error: AGENT_UPGRADE_REQUIRED_MESSAGE, exitCode: 1 },
+        }),
+      );
+    });
+
+    it('delivers on a reported 1 without issuing a capability select', async () => {
+      mockSelect(() => capabilityRows({ [DEVICE_A]: 0 }));
+      mockUpdate(() => [{ id: 'cmd-secret' }]);
+
+      const claimed = [plainCommand(), envelopeCommand()];
+      const out = await failClaimedSecretCommandsForUnsupportedAgent(claimed, {
+        reportedVersion: SCRIPT_SECRET_ENV_REQUIRED_VERSION,
+      });
+
+      expect(out.map((c) => c.id)).toEqual(['cmd-plain', 'cmd-secret']);
+      expect(db.select).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the stored column when no reported version is supplied', async () => {
+      mockSelect(() => capabilityRows({ [DEVICE_A]: 1 }));
+      mockUpdate(() => [{ id: 'cmd-secret' }]);
+
+      const out = await failClaimedSecretCommandsForUnsupportedAgent([envelopeCommand()], {});
+
+      expect(out.map((c) => c.id)).toEqual(['cmd-secret']);
+      expect(selectCalls).toHaveLength(1);
+      expect(selectCalls[0]!.table).toBe(devices);
+    });
+
+    it('still issues no query when the batch carries no envelope, whatever was reported', async () => {
+      const claimed = [plainCommand()];
+      const out = await failClaimedSecretCommandsForUnsupportedAgent(claimed, { reportedVersion: 0 });
+      expect(out).toBe(claimed);
+      expect(db.select).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
+    });
   });
 
   it('never echoes the envelope or a secret value into logs or Sentry', async () => {

--- a/apps/api/src/services/scriptSecretDelivery.ts
+++ b/apps/api/src/services/scriptSecretDelivery.ts
@@ -18,10 +18,15 @@ import { captureException } from './sentry';
  * script with the credential UNSET — so the rule is "fail loudly, never run":
  *
  *   - `secretDeliveryPreflight` at ENQUEUE (scriptDispatch), before the
- *     execution row exists, so a refused dispatch leaves no orphan.
+ *     execution row exists, so a refused dispatch leaves no orphan. This is
+ *     the ORDINARY case for any pre-PR4b agent, and it refuses with
+ *     `agent_upgrade_required`.
  *   - `failClaimedSecretCommandsForUnsupportedAgent` at CLAIM (commandDelivery),
  *     because the capability is non-sticky (devices.ts: written every beat)
- *     and an agent can be downgraded between enqueue and delivery.
+ *     and an agent can be downgraded between enqueue and delivery. RARE (it
+ *     needs a downgrade race), and by the time it refuses it has already
+ *     written both the command and the execution row — which is why dispatch
+ *     reports it under the distinct `agent_upgrade_required_recorded` code.
  *
  * User-context runs — `user`, any explicit username, any targeted session —
  * are refused too: they execute through the helper IPC (or a `sudo -n`
@@ -44,11 +49,46 @@ export const SECRETS_RUN_AS_MESSAGE =
 export const SECRET_DELIVERY_UNAVAILABLE_MESSAGE =
   'Secret delivery is not configured on this server (no active secret-encryption key); script not executed';
 
+/**
+ * Shared by BOTH agent-capability refusals — the enqueue preflight's
+ * `agent_upgrade_required` and the claim-time gate's
+ * `agent_upgrade_required_recorded` (scriptDispatch.ts). The two codes exist
+ * to say WHO already wrote the failure rows, which is a server-side
+ * bookkeeping distinction; to the operator the remediation is identical, so
+ * the text must not fork.
+ */
 export const AGENT_UPGRADE_REQUIRED_MESSAGE =
   'Agent upgrade required: this script uses secret variables and the device agent does not support secure secret delivery; script not executed';
 
+/**
+ * The claim-time gate FAULTED (its capability select threw, or its
+ * single-agent contract was violated) rather than returning a verdict.
+ *
+ * Deliberately says nothing about the agent's version: the agent may be
+ * perfectly current, and `AGENT_UPGRADE_REQUIRED_MESSAGE` would send the
+ * operator to upgrade software over what is a server-side fault. Nothing is
+ * written on that path, so the refusal it carries
+ * (`secret_gate_unavailable`) takes the ordinary per-device failure row.
+ */
+export const SECRET_GATE_UNAVAILABLE_MESSAGE =
+  'The server could not verify this device\'s secret-delivery capability, and this script uses secret variables; script not executed';
+
 export type ScriptRunAs = 'system' | 'user' | 'elevated';
 
+/**
+ * The ENQUEUE-time refusals only. All three return BEFORE the
+ * `script_executions` insert, so each one leaves NO rows behind and the
+ * fan-out owes the device its ordinary failure row — including
+ * `agent_upgrade_required`, which is the ordinary outcome for any pre-PR4b
+ * agent and therefore the common case, not an edge one.
+ *
+ * The claim-time gate's refusal is deliberately NOT in this union: it arrives
+ * with the command AND execution rows already written, so it carries the
+ * distinct `agent_upgrade_required_recorded` code (declared on
+ * `DispatchScriptResult` in scriptDispatch.ts, and the sole member of
+ * `DISPATCH_CODES_ALREADY_RECORDED` in scriptExecution.ts). Sharing one code
+ * between the two suppressed the enqueue case's failure row entirely.
+ */
 export type SecretDeliveryPreflightFailureCode =
   | 'secrets_unsupported_run_as'
   | 'secret_delivery_unavailable'
@@ -129,6 +169,10 @@ export function normalizeReportedScriptSecretEnvVersion(reported: unknown): numb
 /**
  * Enqueue-time gate. Checks are ordered cheapest / most deterministic first so
  * a refused dispatch costs no query: run-as → server key → agent capability.
+ *
+ * Returns `agent_upgrade_required` (never the claim-time
+ * `agent_upgrade_required_recorded`): nothing has been written when this
+ * refuses, so the caller must record the device's failure itself.
  */
 export async function secretDeliveryPreflight(input: {
   deviceId: string;

--- a/apps/api/src/services/scriptSecretDelivery.ts
+++ b/apps/api/src/services/scriptSecretDelivery.ts
@@ -23,9 +23,12 @@ import { captureException } from './sentry';
  *     because the capability is non-sticky (devices.ts: written every beat)
  *     and an agent can be downgraded between enqueue and delivery.
  *
- * User-context runs are refused too: the helper IPC carries no env, mirroring
- * the agent's own `runAsSupportsSecrets`
- * (agent/internal/heartbeat/handlers_script.go).
+ * User-context runs — `user`, any explicit username, any targeted session —
+ * are refused too: they execute through the helper IPC (or a `sudo -n`
+ * re-exec), neither of which carries env, so the credential would simply be
+ * absent. `runAsSupportsSecretEnv` mirrors the agent's own
+ * `runAsSupportsSecrets` (agent/internal/heartbeat/handlers_script.go)
+ * allowlist-for-allowlist.
  *
  * Nothing in this module ever sees a plaintext secret — it handles the
  * ciphertext envelope only as an opaque presence check — and no log line or
@@ -56,17 +59,38 @@ export type SecretDeliveryPreflightResult =
   | { ok: false; code: SecretDeliveryPreflightFailureCode; error: string };
 
 /**
- * Server-side mirror of the agent's `runAsSupportsSecrets`: `system` and
- * `elevated` (the default, when unset) run under the service and can receive
- * env; `user`, or ANY targeted session, is executed through the helper IPC
- * which carries no environment — the secret would simply be absent.
+ * Server-side mirror of the agent's `runAsSupportsSecrets`
+ * (agent/internal/heartbeat/handlers_script.go): unset/`system` (and
+ * `elevated`) run under the service and can receive env; `user`, ANY explicit
+ * username, or ANY targeted session is executed through the helper IPC — or
+ * re-exec'd through `sudo -n` — which carries no environment, so the secret
+ * would simply be absent.
+ *
+ * Matched to the agent deliberately: same trim + lowercase, same ALLOWLIST
+ * (an unrecognized value is a username, never a mode). The parameter is
+ * `string` rather than `ScriptRunAs` because the value reaches us from stored
+ * script config and API input, not only from the union.
+ *
+ * The one divergence we cannot model here: the agent admits `elevated` only
+ * when `isRunningElevated()`, which is a runtime property of that host. So an
+ * `elevated` run this predicate passes may still be refused agent-side —
+ * fail-closed there, and modelling it server-side would be a guess. Every
+ * other divergence is fail-closed at the agent too; tightening here only
+ * moves the refusal EARLIER, to before the `script_executions` insert.
  */
 export function runAsSupportsSecretEnv(
-  runAs: ScriptRunAs | undefined,
+  runAs: string | null | undefined,
   targetSessionId: number | null | undefined,
 ): boolean {
   if (targetSessionId != null) return false;
-  return runAs !== 'user';
+  switch ((runAs ?? '').trim().toLowerCase()) {
+    case '':
+    case 'system':
+    case 'elevated':
+      return true;
+    default:
+      return false;
+  }
 }
 
 async function loadScriptSecretEnvVersions(deviceIds: string[]): Promise<Map<string, number>> {
@@ -117,6 +141,14 @@ export async function secretDeliveryPreflight(input: {
   if (getActiveSecretEncryptionKeyId() === null) {
     return { ok: false, code: 'secret_delivery_unavailable', error: SECRET_DELIVERY_UNAVAILABLE_MESSAGE };
   }
+  // A missing device row (`null`) refuses here, unlike at CLAIM time where it
+  // only WITHHOLDS. The asymmetry is deliberate: refusing an enqueue destroys
+  // nothing — no command row, no execution row, nothing to erase, and the
+  // caller gets an immediate error it can retry. At claim time the command
+  // already exists with its sealed payload, so treating "row not found" as
+  // "agent too old" would irreversibly erase that payload over what may be an
+  // RLS/context regression or replica lag. See
+  // `failClaimedSecretCommandsForUnsupportedAgent`.
   const version = await loadScriptSecretEnvVersion(input.deviceId);
   if (!agentSupportsSecretEnv(version)) {
     return { ok: false, code: 'agent_upgrade_required', error: AGENT_UPGRADE_REQUIRED_MESSAGE };
@@ -152,7 +184,17 @@ function carriesSecretEnvelope(cmd: ClaimedCommand): boolean {
 async function failLinkedScriptExecution(cmd: ClaimedCommand, completedAt: Date): Promise<void> {
   const payload = cmd.payload as Record<string, unknown>;
   const executionId = payload.executionId;
-  if (typeof executionId !== 'string' || !PG_UUID_REGEX.test(executionId)) return;
+  if (typeof executionId !== 'string' || !PG_UUID_REGEX.test(executionId)) {
+    // Not an error (an ad-hoc command legitimately has no execution row), but
+    // it must leave a trace: without one, a `script_executions` row that IS
+    // linked under a key we failed to read stays non-terminal and the reaper
+    // later reports it as an agent timeout rather than a server-side refusal.
+    console.warn(
+      '[scriptSecretDelivery] withheld command has no linked script execution to fail (missing or non-uuid executionId)',
+      { commandId: cmd.id, deviceId: cmd.deviceId },
+    );
+    return;
+  }
 
   const updated = await db
     .update(scriptExecutions)
@@ -201,12 +243,23 @@ function reportGateFailure(stage: string, cmd: ClaimedCommand, err: unknown): vo
  * Cost model: zero queries unless some claimed `script` command actually
  * carries an envelope, then exactly ONE capability select for the batch
  * however many devices it spans — and ZERO selects when the caller already
- * knows the answer (see `opts.reportedVersion`). Offending commands are driven terminal —
- * `failed`, `result.exitCode: 1`, payload erased via
- * `terminalPayloadErasureSet` — guarded on `status = 'sent'` so a row
- * something else already moved is never overwritten, then propagated to the
- * linked execution. They are NOT released back to `pending` (unlike a
- * decrypt failure, #2414): an incapable agent would just re-claim them.
+ * knows the answer (see `opts.reportedVersion`).
+ *
+ * Three outcomes per envelope-bearing command:
+ *
+ *   1. Device row EXISTS and meets the floor → delivered untouched.
+ *   2. Device row EXISTS and reports below the floor → a real capability
+ *      claim, so the command is driven terminal (`failed`,
+ *      `result.exitCode: 1`, payload erased via `terminalPayloadErasureSet`,
+ *      guarded on `status = 'sent'` so a row something else already moved is
+ *      never overwritten) and propagated to the linked execution. NOT
+ *      released back to `pending` (unlike a decrypt failure, #2414): an
+ *      incapable agent would just re-claim it.
+ *   3. Device row NOT RETURNED AT ALL → unknown, never assumed to be 0. The
+ *      command is withheld and reported to Sentry, but nothing is written:
+ *      the row stays `sent` for the stale reaper, so the refusal stays
+ *      reversible rather than erasing a payload over an RLS/context
+ *      regression, a mid-batch delete, or replica lag.
  *
  * Every failure path withholds the command from the returned batch. A
  * command whose terminal write or propagation throws is reported to Sentry
@@ -216,9 +269,11 @@ export async function failClaimedSecretCommandsForUnsupportedAgent(
   claimed: ClaimedCommand[],
   opts?: {
     /**
-     * The capability the agent reported in THIS request, already normalized
-     * with `normalizeReportedScriptSecretEnvVersion`. When present it is
-     * AUTHORITATIVE and no `devices` select is issued at all.
+     * The capability the agent reported in THIS request. When present it is
+     * AUTHORITATIVE and no `devices` select is issued at all. Callers should
+     * pass a `normalizeReportedScriptSecretEnvVersion` value, but the gate
+     * re-normalizes defensively so an un-normalized future value cannot
+     * widen it.
      *
      * Why: the heartbeat writes this column non-sticky (routes/agents/
      * heartbeat.ts) but that write is guarded on the device not being
@@ -226,8 +281,12 @@ export async function failClaimedSecretCommandsForUnsupportedAgent(
      * claim. If the write is skipped — or simply loses the race — a STORED
      * value of 1 would let a batch through for an agent that just reported 0
      * in the very same beat. The reported value cannot be stale by
-     * construction, so prefer it. A batch spanning devices (there is none on
-     * the heartbeat path — one device per beat) must not pass this.
+     * construction, so prefer it.
+     *
+     * It describes exactly ONE agent, so a batch spanning several devices
+     * must not be passed with it — that is ENFORCED (throws), not assumed:
+     * otherwise device A's self-report could authorise device B's secret.
+     * There is no such caller today (one device per beat).
      */
     reportedVersion?: number;
   },
@@ -235,20 +294,61 @@ export async function failClaimedSecretCommandsForUnsupportedAgent(
   const gated = claimed.filter(carriesSecretEnvelope);
   if (gated.length === 0) return claimed;
 
-  const reportedVersion = opts?.reportedVersion;
-  const versions =
-    typeof reportedVersion === 'number'
-      ? new Map(gated.map((cmd) => [cmd.deviceId, reportedVersion]))
-      : await loadScriptSecretEnvVersions([...new Set(gated.map((cmd) => cmd.deviceId))]);
-  const unsupported = gated.filter((cmd) => !agentSupportsSecretEnv(versions.get(cmd.deviceId)));
-  if (unsupported.length === 0) return claimed;
+  // Normalize defensively rather than trusting the docblock: the gate below
+  // compares with `>= SCRIPT_SECRET_ENV_REQUIRED_VERSION` while the stored
+  // column only ever holds `normalizeReportedScriptSecretEnvVersion`'s
+  // `=== 1`. A future caller that forgot to normalize must not be able to
+  // widen the gate by handing us an unrecognized `2`. `undefined` (not
+  // supplied) stays distinguishable from a reported `0`.
+  const reportedVersion =
+    typeof opts?.reportedVersion === 'number'
+      ? normalizeReportedScriptSecretEnvVersion(opts.reportedVersion)
+      : undefined;
 
-  for (const cmd of unsupported) {
+  const deviceIds = [...new Set(gated.map((cmd) => cmd.deviceId))];
+  if (reportedVersion !== undefined && deviceIds.length > 1) {
+    // ENFORCED, not merely documented: a reported version is ONE agent's
+    // self-report about ITSELF. Spreading it over a batch would let device
+    // A's report authorise a sealed secret for device B. No caller does this
+    // today (one device per heartbeat); a future batched-claim optimisation
+    // must fail loudly here instead of silently mis-authorising.
+    throw new Error(
+      `[scriptSecretDelivery] opts.reportedVersion is a single agent's self-report and cannot authorise a batch spanning ${deviceIds.length} devices`,
+    );
+  }
+
+  const versions =
+    reportedVersion !== undefined
+      ? new Map(deviceIds.map((deviceId) => [deviceId, reportedVersion]))
+      : await loadScriptSecretEnvVersions(deviceIds);
+
+  const withheld = new Set<string>();
+  for (const cmd of gated) {
+    // `.has()`, not `?? null`: a device id ABSENT from the map means the row
+    // was not returned at all — an RLS/context regression, a device deleted
+    // mid-batch, replica lag — which is "we don't know", never a capability
+    // claim of 0. Withhold (we will not ship a sealed secret on a guess) but
+    // do NOT drive the command terminal: that write erases the payload
+    // irreversibly and tells the operator to upgrade an agent that may be
+    // perfectly current. Left `sent`, the stale reaper handles it and the
+    // refusal stays reversible once the real cause is fixed.
+    if (!versions.has(cmd.deviceId)) {
+      withheld.add(cmd.id);
+      reportGateFailure('device row not found', cmd, new Error('no devices row'));
+      continue;
+    }
+
+    const version = versions.get(cmd.deviceId);
+    if (agentSupportsSecretEnv(version)) continue;
+
+    // The row EXISTS and reports below the floor: a real capability claim, so
+    // the terminal write is warranted.
+    withheld.add(cmd.id);
     const completedAt = new Date();
     console.warn('[scriptSecretDelivery] withholding secret-bearing script from an agent without secret-env support; failing it', {
       commandId: cmd.id,
       deviceId: cmd.deviceId,
-      scriptSecretEnvVersion: versions.get(cmd.deviceId) ?? null,
+      scriptSecretEnvVersion: version ?? null,
       requiredVersion: SCRIPT_SECRET_ENV_REQUIRED_VERSION,
     });
 
@@ -269,7 +369,19 @@ export async function failClaimedSecretCommandsForUnsupportedAgent(
       reportGateFailure('terminal update', cmd, err);
       continue;
     }
-    if (!drivenTerminal) continue;
+    if (!drivenTerminal) {
+      // Zero rows on a row claimed microseconds ago: something else moved it
+      // off `sent` mid-flight. Correct to skip propagation (whatever moved it
+      // owns the outcome), but not to skip SILENTLY — the linked execution
+      // row is left non-terminal and a later reaper pass would mislabel this
+      // server-side refusal an agent timeout.
+      console.warn('[scriptSecretDelivery] withheld command was no longer `sent`; skipping execution propagation', {
+        commandId: cmd.id,
+        deviceId: cmd.deviceId,
+      });
+      reportGateFailure('terminal update claim race', cmd, new Error('0 rows updated'));
+      continue;
+    }
 
     try {
       await failLinkedScriptExecution(cmd, completedAt);
@@ -278,6 +390,6 @@ export async function failClaimedSecretCommandsForUnsupportedAgent(
     }
   }
 
-  const withheld = new Set(unsupported.map((cmd) => cmd.id));
+  if (withheld.size === 0) return claimed;
   return claimed.filter((cmd) => !withheld.has(cmd.id));
 }

--- a/apps/api/src/services/scriptSecretDelivery.ts
+++ b/apps/api/src/services/scriptSecretDelivery.ts
@@ -90,6 +90,19 @@ function agentSupportsSecretEnv(version: number | null | undefined): boolean {
 }
 
 /**
+ * The single expression that turns an agent's SELF-REPORTED capability into
+ * the value stored in `devices.script_secret_env_version`: only the exact
+ * recognized integer 1 counts, everything else (absent object, unknown future
+ * value, a downgraded build) reports back down to 0.
+ *
+ * Shared with the heartbeat's device write so the value the gate trusts and
+ * the value the column stores can never drift apart.
+ */
+export function normalizeReportedScriptSecretEnvVersion(reported: unknown): number {
+  return reported === 1 ? 1 : 0;
+}
+
+/**
  * Enqueue-time gate. Checks are ordered cheapest / most deterministic first so
  * a refused dispatch costs no query: run-as → server key → agent capability.
  */
@@ -187,7 +200,8 @@ function reportGateFailure(stage: string, cmd: ClaimedCommand, err: unknown): vo
  *
  * Cost model: zero queries unless some claimed `script` command actually
  * carries an envelope, then exactly ONE capability select for the batch
- * however many devices it spans. Offending commands are driven terminal —
+ * however many devices it spans — and ZERO selects when the caller already
+ * knows the answer (see `opts.reportedVersion`). Offending commands are driven terminal —
  * `failed`, `result.exitCode: 1`, payload erased via
  * `terminalPayloadErasureSet` — guarded on `status = 'sent'` so a row
  * something else already moved is never overwritten, then propagated to the
@@ -200,11 +214,32 @@ function reportGateFailure(stage: string, cmd: ClaimedCommand, err: unknown): vo
  */
 export async function failClaimedSecretCommandsForUnsupportedAgent(
   claimed: ClaimedCommand[],
+  opts?: {
+    /**
+     * The capability the agent reported in THIS request, already normalized
+     * with `normalizeReportedScriptSecretEnvVersion`. When present it is
+     * AUTHORITATIVE and no `devices` select is issued at all.
+     *
+     * Why: the heartbeat writes this column non-sticky (routes/agents/
+     * heartbeat.ts) but that write is guarded on the device not being
+     * decommissioned/quarantined, and it is a separate statement from the
+     * claim. If the write is skipped — or simply loses the race — a STORED
+     * value of 1 would let a batch through for an agent that just reported 0
+     * in the very same beat. The reported value cannot be stale by
+     * construction, so prefer it. A batch spanning devices (there is none on
+     * the heartbeat path — one device per beat) must not pass this.
+     */
+    reportedVersion?: number;
+  },
 ): Promise<ClaimedCommand[]> {
   const gated = claimed.filter(carriesSecretEnvelope);
   if (gated.length === 0) return claimed;
 
-  const versions = await loadScriptSecretEnvVersions([...new Set(gated.map((cmd) => cmd.deviceId))]);
+  const reportedVersion = opts?.reportedVersion;
+  const versions =
+    typeof reportedVersion === 'number'
+      ? new Map(gated.map((cmd) => [cmd.deviceId, reportedVersion]))
+      : await loadScriptSecretEnvVersions([...new Set(gated.map((cmd) => cmd.deviceId))]);
   const unsupported = gated.filter((cmd) => !agentSupportsSecretEnv(versions.get(cmd.deviceId)));
   if (unsupported.length === 0) return claimed;
 

--- a/apps/api/src/services/scriptSecretDelivery.ts
+++ b/apps/api/src/services/scriptSecretDelivery.ts
@@ -1,0 +1,248 @@
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { db } from '../db';
+import { deviceCommands, devices, scriptExecutionBatches, scriptExecutions } from '../db/schema';
+import { PG_UUID_REGEX } from '../utils/uuid';
+import type { ClaimedCommand } from './commandDelivery';
+import { SCRIPT_SECRET_ENVELOPE_FIELD } from './scriptSecretEnvelope';
+import { getActiveSecretEncryptionKeyId } from './secretCrypto';
+import { terminalPayloadErasureSet } from './sensitiveCommandPayload';
+import { captureException } from './sentry';
+
+/**
+ * #3409 PR4c-2 — the activation gates for secret delivery.
+ *
+ * A `tenantSecret` parameter reaches the agent only inside the sealed
+ * `secretEnvEnvelope` (scriptSecretEnvelope.ts), and only an agent that
+ * declares `scriptSecretEnvVersion >= 1` (PR4b) knows to open it and export
+ * `BREEZE_VAR_<NAME>`. An older agent silently ignores the field and runs the
+ * script with the credential UNSET — so the rule is "fail loudly, never run":
+ *
+ *   - `secretDeliveryPreflight` at ENQUEUE (scriptDispatch), before the
+ *     execution row exists, so a refused dispatch leaves no orphan.
+ *   - `failClaimedSecretCommandsForUnsupportedAgent` at CLAIM (commandDelivery),
+ *     because the capability is non-sticky (devices.ts: written every beat)
+ *     and an agent can be downgraded between enqueue and delivery.
+ *
+ * User-context runs are refused too: the helper IPC carries no env, mirroring
+ * the agent's own `runAsSupportsSecrets`
+ * (agent/internal/heartbeat/handlers_script.go).
+ *
+ * Nothing in this module ever sees a plaintext secret — it handles the
+ * ciphertext envelope only as an opaque presence check — and no log line or
+ * error string here carries the payload.
+ */
+
+/** The `devices.script_secret_env_version` floor written by a PR4b agent. */
+export const SCRIPT_SECRET_ENV_REQUIRED_VERSION = 1;
+
+export const SECRETS_RUN_AS_MESSAGE =
+  'This script uses secret variables, which require system-context execution; it is configured to run as a user and was not executed';
+
+export const SECRET_DELIVERY_UNAVAILABLE_MESSAGE =
+  'Secret delivery is not configured on this server (no active secret-encryption key); script not executed';
+
+export const AGENT_UPGRADE_REQUIRED_MESSAGE =
+  'Agent upgrade required: this script uses secret variables and the device agent does not support secure secret delivery; script not executed';
+
+export type ScriptRunAs = 'system' | 'user' | 'elevated';
+
+export type SecretDeliveryPreflightFailureCode =
+  | 'secrets_unsupported_run_as'
+  | 'secret_delivery_unavailable'
+  | 'agent_upgrade_required';
+
+export type SecretDeliveryPreflightResult =
+  | { ok: true }
+  | { ok: false; code: SecretDeliveryPreflightFailureCode; error: string };
+
+/**
+ * Server-side mirror of the agent's `runAsSupportsSecrets`: `system` and
+ * `elevated` (the default, when unset) run under the service and can receive
+ * env; `user`, or ANY targeted session, is executed through the helper IPC
+ * which carries no environment — the secret would simply be absent.
+ */
+export function runAsSupportsSecretEnv(
+  runAs: ScriptRunAs | undefined,
+  targetSessionId: number | null | undefined,
+): boolean {
+  if (targetSessionId != null) return false;
+  return runAs !== 'user';
+}
+
+async function loadScriptSecretEnvVersions(deviceIds: string[]): Promise<Map<string, number>> {
+  const [first] = deviceIds;
+  if (first === undefined) return new Map();
+  const rows = await db
+    .select({ id: devices.id, scriptSecretEnvVersion: devices.scriptSecretEnvVersion })
+    .from(devices)
+    .where(deviceIds.length === 1 ? eq(devices.id, first) : inArray(devices.id, deviceIds));
+  return new Map(rows.map((row) => [row.id, row.scriptSecretEnvVersion]));
+}
+
+/** Live read of the non-sticky capability; `null` when the device row is gone. */
+export async function loadScriptSecretEnvVersion(deviceId: string): Promise<number | null> {
+  const versions = await loadScriptSecretEnvVersions([deviceId]);
+  return versions.get(deviceId) ?? null;
+}
+
+function agentSupportsSecretEnv(version: number | null | undefined): boolean {
+  return typeof version === 'number' && version >= SCRIPT_SECRET_ENV_REQUIRED_VERSION;
+}
+
+/**
+ * Enqueue-time gate. Checks are ordered cheapest / most deterministic first so
+ * a refused dispatch costs no query: run-as → server key → agent capability.
+ */
+export async function secretDeliveryPreflight(input: {
+  deviceId: string;
+  runAs: ScriptRunAs | undefined;
+  targetSessionId?: number | null;
+}): Promise<SecretDeliveryPreflightResult> {
+  if (!runAsSupportsSecretEnv(input.runAs, input.targetSessionId)) {
+    return { ok: false, code: 'secrets_unsupported_run_as', error: SECRETS_RUN_AS_MESSAGE };
+  }
+  if (getActiveSecretEncryptionKeyId() === null) {
+    return { ok: false, code: 'secret_delivery_unavailable', error: SECRET_DELIVERY_UNAVAILABLE_MESSAGE };
+  }
+  const version = await loadScriptSecretEnvVersion(input.deviceId);
+  if (!agentSupportsSecretEnv(version)) {
+    return { ok: false, code: 'agent_upgrade_required', error: AGENT_UPGRADE_REQUIRED_MESSAGE };
+  }
+  return { ok: true };
+}
+
+function carriesSecretEnvelope(cmd: ClaimedCommand): boolean {
+  if (cmd.type !== 'script') return false;
+  const payload = cmd.payload;
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return false;
+  const envelope = (payload as Record<string, unknown>)[SCRIPT_SECRET_ENVELOPE_FIELD];
+  return typeof envelope === 'string' && envelope.length > 0;
+}
+
+/**
+ * Mark the linked `script_executions` row failed and spend its batch slot.
+ *
+ * This is deliberately NOT `propagateTimedOutDeviceCommand`
+ * (jobs/staleCommandReaper.ts): that helper fails linked `restore_jobs` and
+ * kicks DR reconcile — it never touches `script_executions`, and its
+ * `timedOutBy: 'server'` stamp is a load-bearing #3607 marker that would be a
+ * lie here. A script command has no restore job, so calling it would be a
+ * no-op dressed up as propagation.
+ *
+ * Mirrors `handleScriptResult` (commandResultHandlers.ts) instead: the same
+ * `(id, deviceId, status IN non-terminal)` guard, the same scriptId-scoped
+ * batch counter bump, counted only when THIS write drove the row terminal so
+ * a lost race never double-spends the batch slot. Leaves `exitCode`/`stdout`
+ * NULL on purpose — that is the #3607 "never received the agent's output"
+ * discriminator, and there genuinely is none.
+ */
+async function failLinkedScriptExecution(cmd: ClaimedCommand, completedAt: Date): Promise<void> {
+  const payload = cmd.payload as Record<string, unknown>;
+  const executionId = payload.executionId;
+  if (typeof executionId !== 'string' || !PG_UUID_REGEX.test(executionId)) return;
+
+  const updated = await db
+    .update(scriptExecutions)
+    .set({ status: 'failed', completedAt, errorMessage: AGENT_UPGRADE_REQUIRED_MESSAGE })
+    .where(
+      and(
+        eq(scriptExecutions.id, executionId),
+        eq(scriptExecutions.deviceId, cmd.deviceId),
+        inArray(scriptExecutions.status, ['pending', 'queued', 'running']),
+      ),
+    )
+    .returning({ id: scriptExecutions.id, scriptId: scriptExecutions.scriptId });
+
+  const batchId = payload.batchId;
+  if (typeof batchId !== 'string' || !updated[0]) return;
+  await db
+    .update(scriptExecutionBatches)
+    .set({ devicesFailed: sql`${scriptExecutionBatches.devicesFailed} + 1` })
+    .where(
+      and(
+        eq(scriptExecutionBatches.id, batchId),
+        eq(scriptExecutionBatches.scriptId, updated[0].scriptId),
+      ),
+    );
+}
+
+function reportGateFailure(stage: string, cmd: ClaimedCommand, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`[scriptSecretDelivery] ${stage} failed for secret-bearing command`, {
+    commandId: cmd.id,
+    deviceId: cmd.deviceId,
+    error: message,
+  });
+  captureException(
+    new Error(
+      `[scriptSecretDelivery] ${stage} failed (commandId=${cmd.id}, deviceId=${cmd.deviceId}): ${message}`,
+    ),
+  );
+}
+
+/**
+ * Claim-time gate. Runs BEFORE decryption on every batch
+ * `claimPendingCommandsForDevice` hands to delivery (heartbeat main,
+ * watchdog, REST poll).
+ *
+ * Cost model: zero queries unless some claimed `script` command actually
+ * carries an envelope, then exactly ONE capability select for the batch
+ * however many devices it spans. Offending commands are driven terminal —
+ * `failed`, `result.exitCode: 1`, payload erased via
+ * `terminalPayloadErasureSet` — guarded on `status = 'sent'` so a row
+ * something else already moved is never overwritten, then propagated to the
+ * linked execution. They are NOT released back to `pending` (unlike a
+ * decrypt failure, #2414): an incapable agent would just re-claim them.
+ *
+ * Every failure path withholds the command from the returned batch. A
+ * command whose terminal write or propagation throws is reported to Sentry
+ * and still withheld; its siblings are always returned.
+ */
+export async function failClaimedSecretCommandsForUnsupportedAgent(
+  claimed: ClaimedCommand[],
+): Promise<ClaimedCommand[]> {
+  const gated = claimed.filter(carriesSecretEnvelope);
+  if (gated.length === 0) return claimed;
+
+  const versions = await loadScriptSecretEnvVersions([...new Set(gated.map((cmd) => cmd.deviceId))]);
+  const unsupported = gated.filter((cmd) => !agentSupportsSecretEnv(versions.get(cmd.deviceId)));
+  if (unsupported.length === 0) return claimed;
+
+  for (const cmd of unsupported) {
+    const completedAt = new Date();
+    console.warn('[scriptSecretDelivery] withholding secret-bearing script from an agent without secret-env support; failing it', {
+      commandId: cmd.id,
+      deviceId: cmd.deviceId,
+      scriptSecretEnvVersion: versions.get(cmd.deviceId) ?? null,
+      requiredVersion: SCRIPT_SECRET_ENV_REQUIRED_VERSION,
+    });
+
+    let drivenTerminal = false;
+    try {
+      const updated = await db
+        .update(deviceCommands)
+        .set({
+          status: 'failed',
+          completedAt,
+          result: { status: 'failed', error: AGENT_UPGRADE_REQUIRED_MESSAGE, exitCode: 1 },
+          ...terminalPayloadErasureSet(),
+        })
+        .where(and(eq(deviceCommands.id, cmd.id), eq(deviceCommands.status, 'sent')))
+        .returning({ id: deviceCommands.id });
+      drivenTerminal = updated.length > 0;
+    } catch (err) {
+      reportGateFailure('terminal update', cmd, err);
+      continue;
+    }
+    if (!drivenTerminal) continue;
+
+    try {
+      await failLinkedScriptExecution(cmd, completedAt);
+    } catch (err) {
+      reportGateFailure('execution propagation', cmd, err);
+    }
+  }
+
+  const withheld = new Set(unsupported.map((cmd) => cmd.id));
+  return claimed.filter((cmd) => !withheld.has(cmd.id));
+}

--- a/apps/api/src/services/softwareDeployment.test.ts
+++ b/apps/api/src/services/softwareDeployment.test.ts
@@ -514,7 +514,7 @@ describe('createSoftwareDeployment', () => {
     );
   });
 
-  it('fails the device (no dispatch) through the existing unresolved branch when the URL references a SECRET tenant variable (#3409 PR2)', async () => {
+  it('fails the device (no dispatch) with an explicit secret-template message when the URL references a SECRET tenant variable (#3409 PR4c-2)', async () => {
     const versionRecord = {
       id: 'ver-var3',
       catalogId: 'cat-1',
@@ -553,21 +553,86 @@ describe('createSoftwareDeployment', () => {
       createdBy: null,
     });
 
-    // The secret is OMITTED from the vars map entirely (softwareDeployment.ts),
-    // so `{{var.super_secret}}` is indistinguishable from an unknown token here
-    // — it fails through the PRE-EXISTING unresolved branch, no new failure
-    // code or counter. The only (and last) device failed resolution, so the
-    // batch itself reports failed too (mirrors the sibling "cannot be
-    // resolved" test above).
+    // PR4c-2: the secret is still never flattened into the vars map, but the
+    // failure is now EXPLICIT — the per-device deployment_results write names
+    // the rule (and the key) instead of reading as an unknown token. Same
+    // channel and counter as the `unresolved` branch, so the batch-level
+    // outcome is unchanged: the only device failed, the batch reports failed.
     expect(result.status).toBe('failed');
     expect(result.dispatchedDeviceIds).toEqual([]);
     expect(sendCommandMock).not.toHaveBeenCalled();
     expect(queueCommandMock).not.toHaveBeenCalled();
-    const failureWrite = updateSetCalls.find(
-      (c) => typeof c.errorMessage === 'string' && c.errorMessage.includes('super_secret'),
+    const failureWrites = updateSetCalls.filter((c) => c.status === 'failed');
+    expect(failureWrites).toHaveLength(1);
+    expect(failureWrites[0]?.errorMessage).toBe(
+      'Software deployment templates cannot use secret variable(s) {{var.super_secret}}',
     );
-    expect(failureWrite).toBeDefined();
-    expect(failureWrite?.status).toBe('failed');
+    expect(failureWrites[0]?.completedAt).toBeInstanceOf(Date);
+    // The VALUE never lands anywhere a human or the agent could read it.
+    expect(JSON.stringify({ result, updateSetCalls })).not.toContain('sekrit');
+  });
+
+  it('lists EVERY secret key referenced across downloadUrl and silentInstallArgs (keys only, never values) (#3409 PR4c-2)', async () => {
+    const versionRecord = {
+      id: 'ver-var4',
+      catalogId: 'cat-1',
+      s3Key: null,
+      downloadUrl: 'https://dl/{{var.zeta_secret}}/app.msi',
+      checksum: null,
+      originalFileName: 'app.msi',
+      fileType: 'msi',
+      silentInstallArgs: '/S /KEY={{var.alpha_secret}} /REPO={{var.repo_token}}',
+      version: '2.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-var4', orgId: 'org-1' };
+    const targetDevices = [
+      { id: 'dev-1', agentId: 'agent-1', siteId: 'site-1', hostname: 'WKS-1', customFields: {} },
+      { id: 'dev-2', agentId: 'agent-2', siteId: 'site-1', hostname: 'WKS-2', customFields: {} },
+    ];
+    const variableRows = [
+      { id: 'tv-1', key: 'repo_token', value: 'tok-live', isSecret: false, version: 1, ownerOrgId: 'org-1', forOrgId: 'org-1' },
+      { id: 'tv-2', key: 'zeta_secret', value: 'zeta-plaintext', isSecret: true, version: 1, ownerOrgId: 'org-1', forOrgId: 'org-1' },
+      { id: 'tv-3', key: 'alpha_secret', value: 'alpha-plaintext', isSecret: true, version: 1, ownerOrgId: 'org-1', forOrgId: 'org-1' },
+      // A secret the templates do NOT reference must not be named either.
+      { id: 'tv-4', key: 'unrelated_secret', value: 'unrelated-plaintext', isSecret: true, version: 1, ownerOrgId: 'org-1', forOrgId: 'org-1' },
+    ];
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices))
+      .mockReturnValueOnce(selLimit([{ name: 'Acme' }])) // organizations
+      .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }])) // sites
+      .mockReturnValueOnce(selJoin(variableRows)); // tenant variable scope
+    insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-var4',
+      deploymentType: 'install',
+      deviceIds: ['dev-1', 'dev-2'],
+      scheduleType: 'immediate',
+      createdBy: null,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.message).toBe('All target devices failed installer variable resolution');
+    expect(sendCommandMock).not.toHaveBeenCalled();
+    expect(queueCommandMock).not.toHaveBeenCalled();
+    // One failure row per device, all carrying the same sorted key list.
+    const failureWrites = updateSetCalls.filter((c) => c.status === 'failed');
+    expect(failureWrites).toHaveLength(2);
+    for (const write of failureWrites) {
+      expect(write.errorMessage).toBe(
+        'Software deployment templates cannot use secret variable(s) {{var.alpha_secret}}, {{var.zeta_secret}}',
+      );
+    }
+    const recorded = JSON.stringify({ result, updateSetCalls });
+    expect(recorded).not.toContain('unrelated_secret');
+    for (const value of ['zeta-plaintext', 'alpha-plaintext', 'unrelated-plaintext']) {
+      expect(recorded).not.toContain(value);
+    }
   });
 
   it('dispatches a built-in EDR install using the resolver-provided URL/args', async () => {

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray } from 'drizzle-orm';
-import { isSoftwareFileType } from '@breeze/shared';
+import { findVariableTokens, isSoftwareFileType, variableToken } from '@breeze/shared';
 import { db } from '../db';
 import {
   deploymentResults,
@@ -540,12 +540,20 @@ export async function buildAndDispatchSoftwareInstalls(
   const siteNames = new Map<string, string>();
   // Tenant variables (#3409 PR2): flattened KEY -> non-secret VALUE map for
   // the `var.<key>` arm of installerVariables.ts's resolveKey. Secret
-  // variables are omitted entirely here — not merely left unresolved — so a
-  // template referencing one falls through to the pre-existing `unresolved`
-  // failure branch below with no new failure code or counter (dispatch's own
-  // per-device secret check, wired separately, is the actual security gate;
-  // this omission is a defense-in-depth belt on the deploy path too).
+  // variables never enter this map — a deploy template is substituted into a
+  // download URL / install args that ride the command payload in the clear.
+  //
+  // #3409 PR4c-2: a template that references a secret is an EXPLICIT failure,
+  // not a silent omission. Before PR4c-2 the secret was merely left out of
+  // the map so the token fell through to the generic `unresolved` branch,
+  // which read as "unknown variable" and sent the author looking for a typo.
+  // `secretTemplateKeys` holds the secret KEYS the templates reference (keys
+  // only — never values); when non-empty every device fails through the same
+  // per-device channel the `unresolved` branch uses, with a message that
+  // names the rule instead. The script path's declared-delivery arm
+  // (`source: 'tenantSecret'`) has no deploy-template equivalent by design.
   const tenantVars: Record<string, string> = {};
+  const secretTemplateKeys: string[] = [];
   if (templatesUseVariables) {
     const [org] = await db
       .select({ name: organizations.name })
@@ -559,10 +567,19 @@ export async function buildAndDispatchSoftwareInstalls(
       .where(eq(sites.orgId, orgId));
     for (const s of siteRows) siteNames.set(s.id, s.name);
 
+    const referencedTemplateKeys = new Set([
+      ...findVariableTokens(finalDownloadUrl ?? ''),
+      ...findVariableTokens(finalSilentInstallArgs ?? ''),
+    ]);
     const variableScope = await loadTenantVariableScope([orgId]);
     for (const [key, variable] of resolveForOrg(variableScope, orgId)) {
-      if (!variable.isSecret) tenantVars[key] = variable.value;
+      if (variable.isSecret) {
+        if (referencedTemplateKeys.has(key)) secretTemplateKeys.push(key);
+      } else {
+        tenantVars[key] = variable.value;
+      }
     }
+    secretTemplateKeys.sort();
   }
 
   // Detection rules (#2022) and the force-reinstall toggle ride along with the
@@ -618,6 +635,29 @@ export async function buildAndDispatchSoftwareInstalls(
     let deviceDownloadUrl = finalDownloadUrl;
     let deviceSilentInstallArgs = finalSilentInstallArgs;
     if (templatesUseVariables) {
+      // Secret-referencing templates fail every device identically (the
+      // check is template-level, not device-level) through the same
+      // deployment_results write + counter as an unresolvable token, so the
+      // batch-level outcome below is unchanged. Keys only in the message.
+      if (secretTemplateKeys.length > 0) {
+        await db
+          .update(deploymentResults)
+          .set({
+            status: 'failed',
+            errorMessage:
+              'Software deployment templates cannot use secret variable(s) ' +
+              secretTemplateKeys.map(variableToken).join(', '),
+            completedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(deploymentResults.deploymentId, deploymentId),
+              eq(deploymentResults.deviceId, device.id),
+            ),
+          );
+        variableFailureCount++;
+        continue;
+      }
       const ctx: InstallerVariableContext = {
         org: { id: orgId, name: orgName },
         site: { id: device.siteId, name: siteNames.get(device.siteId) ?? '' },

--- a/apps/api/src/services/sourcedParameters.test.ts
+++ b/apps/api/src/services/sourcedParameters.test.ts
@@ -462,6 +462,193 @@ describe('resolveSourcedParameters — tenantSecret source (secretEnv)', () => {
   });
 });
 
+// #3409 PR4c-2 review finding 2 — every fixture above declares exactly ONE
+// `tenantSecret` parameter, so a bug that dropped all but the last entry
+// (assigning `secretEnv` instead of accumulating into it) would pass the whole
+// suite. These cases put TWO secrets on one script, and then mix them with the
+// other two delivery channels, so accumulation is actually asserted.
+describe('resolveSourcedParameters — MULTIPLE tenantSecret parameters', () => {
+  it('accumulates every secret into secretEnv, with a descriptor each and nothing in parameters', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'api_token', source: 'tenantSecret', variableKey: 'vendor_token' },
+          { name: 'db_password', source: 'tenantSecret', variableKey: 'vendor_db_password' },
+        ],
+        variables: varsWith(
+          variable({ key: 'vendor_token', value: 'sup3r-s3cret', isSecret: true, variableId: 'var-9', version: 3 }),
+          variable({
+            key: 'vendor_db_password',
+            value: 'hunter2-hunter2',
+            isSecret: true,
+            variableId: 'var-10',
+            version: 5,
+            ownerScope: 'partner',
+          }),
+        ),
+      }),
+    );
+
+    // BOTH keys present, with the right values — an assignment-instead-of-
+    // accumulation bug leaves only `db_password` here.
+    expect(result.secretEnv).toEqual({ api_token: 'sup3r-s3cret', db_password: 'hunter2-hunter2' });
+    // Neither name may appear in the map the agent substitutes into script text.
+    expect(result.parameters).toEqual({});
+    expect(Object.keys(result.parameters)).not.toContain('api_token');
+    expect(Object.keys(result.parameters)).not.toContain('db_password');
+    // Both descriptors, identity only — never a value.
+    expect(result.bindings).toEqual([
+      { key: 'api_token', source: 'tenantSecret', variableId: 'var-9', ownerScope: 'organization', version: 3 },
+      { key: 'db_password', source: 'tenantSecret', variableId: 'var-10', ownerScope: 'partner', version: 5 },
+    ]);
+    expect(JSON.stringify(result.bindings)).not.toContain('sup3r-s3cret');
+    expect(JSON.stringify(result.bindings)).not.toContain('hunter2-hunter2');
+  });
+
+  it('keeps the three delivery channels separate when two secrets share a script with a runtime and a tenantVariable parameter', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [
+          { name: 'api_token', source: 'tenantSecret', variableKey: 'vendor_token' },
+          { name: 'level', type: 'string', source: 'runtime' },
+          { name: 'db_password', source: 'tenantSecret', variableKey: 'vendor_db_password' },
+          { name: 'repo', type: 'string', source: 'tenantVariable', variableKey: 'repo_url' },
+        ],
+        callerParameters: { level: 'debug' },
+        variables: varsWith(
+          variable({ key: 'vendor_token', value: 'sup3r-s3cret', isSecret: true, variableId: 'var-9', version: 3 }),
+          variable({ key: 'vendor_db_password', value: 'hunter2-hunter2', isSecret: true, variableId: 'var-10', version: 5 }),
+          variable({ key: 'repo_url', value: 'https://repo.example', variableId: 'var-11', version: 2 }),
+        ),
+      }),
+    );
+
+    // Channel 1 — sealed secret envelope: both secrets, nothing else.
+    expect(result.secretEnv).toEqual({ api_token: 'sup3r-s3cret', db_password: 'hunter2-hunter2' });
+    // Channel 2 — the wire parameter map: the runtime value and the plaintext
+    // variable, and NEITHER secret name.
+    expect(result.parameters).toEqual({ level: 'debug', repo: 'https://repo.example' });
+    // Channel 3 — persisted descriptors: every BOUND parameter, no runtime one.
+    expect(result.bindings).toEqual([
+      { key: 'api_token', source: 'tenantSecret', variableId: 'var-9', ownerScope: 'organization', version: 3 },
+      { key: 'db_password', source: 'tenantSecret', variableId: 'var-10', ownerScope: 'organization', version: 5 },
+      { key: 'repo', source: 'tenantVariable', variableId: 'var-11', ownerScope: 'organization', version: 2 },
+    ]);
+    expect(JSON.stringify(result.parameters)).not.toContain('sup3r-s3cret');
+    expect(JSON.stringify(result.parameters)).not.toContain('hunter2-hunter2');
+  });
+});
+
+// #3409 PR4c-2 review finding 1 — a variable whose stored row exists but
+// cannot be DECRYPTED must not be reported as "not set". The two states demand
+// opposite remediations: "not set" tells a tech to create the variable, while
+// unreadable means the ciphertext is there and the KEY MATERIAL is wrong — and
+// creating a duplicate during a key rotation is precisely the wrong move.
+// `unreadableForOrg` (tenantVariableResolution.ts) is the channel that keeps
+// them distinguishable; this is the resolver consuming it.
+describe('resolveSourcedParameters — unreadable tenant variables', () => {
+  it('reports a tenantVariable binding to an unreadable key as unreadable, not as missing', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [{ name: 'repo', type: 'string', required: true, source: 'tenantVariable', variableKey: 'repo_url' }],
+        variables: varsWith(),
+        unreadableVariableKeys: new Set(['repo_url']),
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+    expect(result.error).toContain('could not be read');
+    expect(result.error).toContain('repo');
+    expect(result.error).toContain('repo_url');
+    // Must NOT be reported through the "operator never set this" bucket.
+    expect(result.error).not.toContain('no value for required parameter');
+  });
+
+  it('reports a tenantSecret binding to an unreadable key as unreadable, not as missing', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [{ name: 'api_token', source: 'tenantSecret', variableKey: 'vendor_token' }],
+        variables: varsWith(),
+        unreadableVariableKeys: new Set(['vendor_token']),
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+    expect(result.error).toContain('could not be read');
+    expect(result.error).toContain('api_token');
+    expect(result.error).toContain('vendor_token');
+    expect(result.error).not.toContain('no value for required parameter');
+    expect(result.error).not.toContain('is not a secret');
+  });
+
+  // An unreadable row is a denial, exactly like the secret denials above: the
+  // definition default is a stale plaintext the operator's ciphertext was meant
+  // to replace, so falling back to it would silently ship the wrong value.
+  it('does NOT fall back to the definition default for an unreadable variable', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [
+          { name: 'repo', type: 'string', source: 'tenantVariable', variableKey: 'repo_url', defaultValue: 'the-default' },
+        ],
+        variables: varsWith(),
+        unreadableVariableKeys: new Set(['repo_url']),
+      }),
+    );
+
+    expect(result.error).toContain('could not be read');
+    expect(result.error).not.toContain('the-default');
+  });
+
+  // Discrimination: the unreadable set must be consulted for the bound KEY,
+  // not blanket-applied. A genuinely absent variable still reports "not set"
+  // even while some OTHER key in the same org is unreadable.
+  it('still reports a genuinely absent variable as missing when a DIFFERENT key is unreadable', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [{ name: 'repo', type: 'string', required: true, source: 'tenantVariable', variableKey: 'repo_url' }],
+        variables: varsWith(),
+        unreadableVariableKeys: new Set(['some_other_key']),
+      }),
+    );
+
+    expect(result.error).toContain('no value for required parameter');
+    expect(result.error).not.toContain('could not be read');
+  });
+
+  // A readable value must win over a stale unreadable listing for the same key
+  // — the map is the authority when it has an entry.
+  it('prefers the resolved value when the key is both resolvable and (stale) listed unreadable', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'repo', type: 'string', source: 'tenantVariable', variableKey: 'repo_url' }],
+        variables: varsWith(variable({ key: 'repo_url', value: 'https://repo.example' })),
+        unreadableVariableKeys: new Set(['repo_url']),
+      }),
+    );
+
+    expect(result.parameters).toEqual({ repo: 'https://repo.example' });
+  });
+
+  it('names an unreadable parameter alongside a genuinely missing one in a single pass', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [
+          { name: 'repo', type: 'string', required: true, source: 'tenantVariable', variableKey: 'repo_url' },
+          { name: 'gone', type: 'string', required: true, source: 'tenantVariable', variableKey: 'absent' },
+        ],
+        variables: varsWith(),
+        unreadableVariableKeys: new Set(['repo_url']),
+      }),
+    );
+
+    expect(result.error).toContain('could not be read');
+    expect(result.error).toContain('repo_url');
+    expect(result.error).toContain('gone');
+    expect(result.error).toContain('no value for required parameter');
+  });
+});
+
+
 // Plan §2.2 — ignored, not rejected. A stored automation action is validated
 // without consulting the referenced script's definitions, so a hard reject
 // would turn a previously-valid automation into a delayed runtime failure the

--- a/apps/api/src/services/sourcedParameters.test.ts
+++ b/apps/api/src/services/sourcedParameters.test.ts
@@ -343,6 +343,125 @@ describe('resolveSourcedParameters — secret denial', () => {
   });
 });
 
+// #3409 PR4c-2 — the `tenantSecret` arm. The mirror image of the denial above:
+// secret delivery is DECLARED, never inferred, so this source demands a secret
+// target and refuses a plaintext one, and the resolved value never touches the
+// `parameters` map (which the agent substitutes into the script text).
+describe('resolveSourcedParameters — tenantSecret source (secretEnv)', () => {
+  const secretParam = (extra: Record<string, unknown> = {}) => ({
+    name: 'api_token',
+    source: 'tenantSecret',
+    variableKey: 'vendor_token',
+    ...extra,
+  });
+
+  it('routes the value into secretEnv, never into parameters, and records a descriptor', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [secretParam()],
+        variables: varsWith(
+          variable({ key: 'vendor_token', value: 'sup3r-s3cret', isSecret: true, variableId: 'var-9', version: 3 }),
+        ),
+      }),
+    );
+
+    expect(result.parameters).toEqual({});
+    expect(result.secretEnv).toEqual({ api_token: 'sup3r-s3cret' });
+    expect(result.bindings).toEqual([
+      {
+        key: 'api_token',
+        source: 'tenantSecret',
+        variableId: 'var-9',
+        ownerScope: 'organization',
+        version: 3,
+      },
+    ]);
+  });
+
+  it('exposes an empty secretEnv when the script declares no secret parameter', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'level', type: 'string', source: 'runtime' }],
+        callerParameters: { level: 'debug' },
+      }),
+    );
+
+    expect(result.secretEnv).toEqual({});
+  });
+
+  it('fails the device when the target variable is NOT a secret', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [secretParam()],
+        variables: varsWith(variable({ key: 'vendor_token', value: 'plaintext-value', isSecret: false })),
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+    expect(result.error).toContain('is not a secret');
+    expect(result.error).toContain('api_token');
+    expect(result.error).toContain('vendor_token');
+    // Denial strings carry KEYS only — the target is plaintext here, so a
+    // leak would be silent rather than obviously wrong.
+    expect(result.error).not.toContain('plaintext-value');
+  });
+
+  it('fails the device when the target variable is missing (never a default, there is none)', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [secretParam()],
+        variables: varsWith(),
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+    expect(result.error).toContain('api_token');
+    expect(result.error).not.toContain('is not a secret');
+  });
+
+  it('throws when no variables map was supplied (call-site programming error)', () => {
+    expect(() =>
+      resolve({
+        definitions: [secretParam()],
+      }),
+    ).toThrow(/variables map is required/i);
+  });
+
+  it('drops a caller-supplied value for the secret key and reports it as ignored', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [secretParam()],
+        callerParameters: { api_token: 'caller-supplied', free: 'kept' },
+        variables: varsWith(variable({ key: 'vendor_token', value: 'sup3r-s3cret', isSecret: true })),
+      }),
+    );
+
+    expect(result.parameters).toEqual({ free: 'kept' });
+    expect(result.ignoredParameters).toEqual(['api_token']);
+    expect(result.secretEnv).toEqual({ api_token: 'sup3r-s3cret' });
+  });
+
+  it('reports a notSecret denial alongside a tenantVariable secret denial in one pass', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [
+          secretParam(),
+          { name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' },
+        ],
+        variables: varsWith(
+          variable({ key: 'vendor_token', value: 'plaintext-value', isSecret: false }),
+          variable({ key: 'api_token', value: 'sup3r-s3cret', isSecret: true }),
+        ),
+      }),
+    );
+
+    expect(result.error).toContain('is not a secret');
+    expect(result.error).toContain('cannot be used in script parameters');
+    expect(result.error).not.toContain('sup3r-s3cret');
+    expect(result.error).not.toContain('plaintext-value');
+  });
+});
+
 // Plan §2.2 — ignored, not rejected. A stored automation action is validated
 // without consulting the referenced script's definitions, so a hard reject
 // would turn a previously-valid automation into a delayed runtime failure the
@@ -630,6 +749,14 @@ describe('hasTenantVariableBoundParameters', () => {
     expect(hasTenantVariableBoundParameters([{ name: 'x', type: 'string', source: 'tenantVariable', variableKey: 'k' }])).toBe(true);
   });
 
+  // Both variable-backed sources gate the SAME scope preload; missing the
+  // secret arm here would resolve every secret binding against an empty map.
+  it('detects a tenantSecret binding', () => {
+    expect(
+      hasTenantVariableBoundParameters([{ name: 'x', source: 'tenantSecret', variableKey: 'k' }]),
+    ).toBe(true);
+  });
+
   it('is false for the other sources and for legacy definitions', () => {
     expect(hasTenantVariableBoundParameters([{ name: 'x', type: 'string' }])).toBe(false);
     expect(hasTenantVariableBoundParameters([{ name: 'x', type: 'string', source: 'builtin', builtinKey: 'org.id' }])).toBe(false);
@@ -662,6 +789,15 @@ describe('scriptNeedsVariableScope (plan §3 P1)', () => {
       scriptNeedsVariableScope({
         content: 'echo hi',
         parameters: [{ name: 'token', type: 'string', source: 'tenantVariable', variableKey: 'api_token' }],
+      }),
+    ).toBe(true);
+  });
+
+  it('is true for a script with a tenantSecret-bound PARAMETER and no content token', () => {
+    expect(
+      scriptNeedsVariableScope({
+        content: 'echo hi',
+        parameters: [{ name: 'api_token', source: 'tenantSecret', variableKey: 'vendor_token' }],
       }),
     ).toBe(true);
   });

--- a/apps/api/src/services/sourcedParameters.test.ts
+++ b/apps/api/src/services/sourcedParameters.test.ts
@@ -44,6 +44,11 @@ function resolve(overrides: Partial<ResolveSourcedParametersInput> = {}) {
     definitions: [],
     callerParameters: {},
     device: DEVICE,
+    // The stricter of the two tiers, so every pre-existing case below keeps
+    // its original meaning: an ORG-owned script may only reach an org-owned
+    // secret, which is what `variable()`'s default `ownerScope` produces. The
+    // ownership-tier cases override this explicitly.
+    scriptOwnerScope: 'organization',
     ...overrides,
   });
 }
@@ -486,6 +491,12 @@ describe('resolveSourcedParameters — MULTIPLE tenantSecret parameters', () => 
             ownerScope: 'partner',
           }),
         ),
+        // A PARTNER-WIDE script, because one of the two secrets below is
+        // partner-owned and an org-owned script may not reach above its own
+        // tier (see the ownership-tier block). Partner-wide is the tier that
+        // legitimately spans both, which is what lets this case keep
+        // asserting that MIXED `ownerScope` descriptors survive.
+        scriptOwnerScope: 'partner',
       }),
     );
 
@@ -536,6 +547,161 @@ describe('resolveSourcedParameters — MULTIPLE tenantSecret parameters', () => 
     ]);
     expect(JSON.stringify(result.parameters)).not.toContain('sup3r-s3cret');
     expect(JSON.stringify(result.parameters)).not.toContain('hunter2-hunter2');
+  });
+});
+
+// #3409 PR4c-2 review BLOCKER — the secret ownership-tier gate.
+//
+// Variable-key uniqueness is PER SCOPE (`tenant_variables_org_key_uniq` /
+// `tenant_variables_partner_key_uniq`), so an org admin can create an
+// org-owned secret that SHADOWS a partner-wide key of the same name, pass the
+// save-time gate against their own row, then delete it — after which
+// `resolveForOrg` inherits the partner-wide row and the MSP's credential would
+// be sealed and delivered to an org-owned script. The rule:
+//
+//   a script may resolve a secret at or BELOW its own ownership tier, never
+//   above.
+//
+// All four rows of the table are asserted below. The one that is easy to get
+// backwards is `partner-wide script + org-owned secret` — that is a PRIMARY
+// use case (one partner-wide script, each target org's own value resolved per
+// device), not an escalation, so it must ALLOW.
+describe('resolveSourcedParameters — secret ownership tier (scriptOwnerScope)', () => {
+  const secretParam = () => ({
+    name: 'api_token',
+    source: 'tenantSecret',
+    variableKey: 'vendor_token',
+  });
+
+  const secretVar = (ownerScope: 'organization' | 'partner') =>
+    varsWith(variable({ key: 'vendor_token', value: 'sup3r-s3cret', isSecret: true, ownerScope }));
+
+  it('ALLOWS a partner-wide script resolving a partner-wide secret (same tier)', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [secretParam()],
+        variables: secretVar('partner'),
+        scriptOwnerScope: 'partner',
+      }),
+    );
+
+    expect(result.secretEnv).toEqual({ api_token: 'sup3r-s3cret' });
+    expect(result.bindings[0]).toMatchObject({ key: 'api_token', ownerScope: 'partner' });
+  });
+
+  // THE use case, not an escalation: one partner-wide script, each target
+  // org's own value (a per-org site key) resolved per device.
+  it('ALLOWS a partner-wide script resolving an ORG-owned secret (the per-org use case)', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [secretParam()],
+        variables: secretVar('organization'),
+        scriptOwnerScope: 'partner',
+      }),
+    );
+
+    expect(result.secretEnv).toEqual({ api_token: 'sup3r-s3cret' });
+    expect(result.bindings[0]).toMatchObject({ key: 'api_token', ownerScope: 'organization' });
+  });
+
+  it('ALLOWS an org-owned script resolving an org-owned secret (same tier)', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [secretParam()],
+        variables: secretVar('organization'),
+        scriptOwnerScope: 'organization',
+      }),
+    );
+
+    expect(result.secretEnv).toEqual({ api_token: 'sup3r-s3cret' });
+  });
+
+  it('DENIES an org-owned script resolving a PARTNER-WIDE secret (the escalation)', () => {
+    const SECRET = 'sup3r-s3cret';
+    const result = expectFailed(
+      resolve({
+        definitions: [secretParam()],
+        variables: secretVar('partner'),
+        scriptOwnerScope: 'organization',
+      }),
+    );
+
+    expect(result.code).toBe('unresolved_parameters');
+    // Names both keys and says what to do about it — never the value.
+    expect(result.error).toContain('api_token');
+    expect(result.error).toContain('vendor_token');
+    expect(result.error).toContain('partner-wide secret variable');
+    expect(result.error).toMatch(/make the script partner-wide/i);
+    expect(result.error).not.toContain(SECRET);
+  });
+
+  // The gate is deliberately NOT applied to `tenantVariable`: a partner-wide
+  // NON-secret value is already readable by an org session through the
+  // variables API, so there is no escalation to prevent — the gate exists
+  // solely because a secret's plaintext has no other read path.
+  it('does NOT gate a tenantVariable binding to a partner-wide NON-secret value', () => {
+    const result = expectOk(
+      resolve({
+        definitions: [{ name: 'repo', type: 'string', source: 'tenantVariable', variableKey: 'repo_url' }],
+        variables: varsWith(
+          variable({ key: 'repo_url', value: 'https://git.example.test/x', ownerScope: 'partner' }),
+        ),
+        scriptOwnerScope: 'organization',
+      }),
+    );
+
+    expect(result.parameters).toEqual({ repo: 'https://git.example.test/x' });
+  });
+
+  // Ordering: the `isSecret` check comes FIRST, so a plaintext partner-wide
+  // target is reported as "not a secret" (reclassify it) rather than as a
+  // tier violation (make the script partner-wide) — the latter would send the
+  // operator to fix the wrong thing.
+  it('reports a partner-wide NON-secret target under a tenantSecret binding as notSecret, not as a tier violation', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [secretParam()],
+        variables: varsWith(
+          variable({ key: 'vendor_token', value: 'plaintext-value', isSecret: false, ownerScope: 'partner' }),
+        ),
+        scriptOwnerScope: 'organization',
+      }),
+    );
+
+    expect(result.error).toContain('is not a secret');
+    expect(result.error).not.toContain('partner-wide secret variable');
+  });
+
+  // A denial, never a fallthrough: the caller's value must not satisfy the
+  // key, and the parameter must not be omitted from the run.
+  it('is a DENIAL — a caller-supplied value never satisfies the gated key', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [secretParam()],
+        callerParameters: { api_token: 'caller-supplied' },
+        variables: secretVar('partner'),
+        scriptOwnerScope: 'organization',
+      }),
+    );
+
+    expect(result.error).toContain('partner-wide secret variable');
+    expect(result.ignoredParameters).toEqual(['api_token']);
+  });
+
+  it('reports a tier violation alongside a genuinely missing parameter in one pass', () => {
+    const result = expectFailed(
+      resolve({
+        definitions: [
+          secretParam(),
+          { name: 'level', type: 'string', required: true, source: 'runtime' },
+        ],
+        variables: secretVar('partner'),
+        scriptOwnerScope: 'organization',
+      }),
+    );
+
+    expect(result.error).toContain('no value for required parameter(s) "level"');
+    expect(result.error).toContain('partner-wide secret variable');
   });
 });
 

--- a/apps/api/src/services/sourcedParameters.ts
+++ b/apps/api/src/services/sourcedParameters.ts
@@ -37,7 +37,10 @@ import type { ResolvedVariable } from './tenantVariableResolution';
  * `tenantSecret` binding has no default and no caller candidate at all, so its
  * precedence is simply `secret variable -> fail the device`, and its value
  * leaves through {@link ResolveSourcedParametersSuccess.secretEnv} rather than
- * `parameters`.
+ * `parameters`. That arm additionally carries a PRIVILEGE gate — a script may
+ * resolve a secret at or below its own ownership tier, never above (see
+ * {@link ResolveSourcedParametersInput.scriptOwnerScope}) — which is why this
+ * otherwise device-only resolver is told about the SCRIPT's ownership too.
  */
 
 /** Where `scriptDispatch` reads device-scoped sources from. */
@@ -112,6 +115,39 @@ export interface ResolveSourcedParametersInput {
    * wrong — and creating a duplicate mid-rotation is the opposite of the fix.
    */
   unreadableVariableKeys?: ReadonlySet<string>;
+  /**
+   * The OWNERSHIP TIER of the script being dispatched — `'partner'` for a
+   * partner-wide script (`scripts.org_id IS NULL`), `'organization'` for an
+   * org-owned one. Derived at the dispatch seam from the script row itself.
+   *
+   * Enforces one rule, on the `tenantSecret` arm only (#3409 PR4c-2 review):
+   *
+   *   a script may resolve a secret AT OR BELOW its own ownership tier,
+   *   never above.
+   *
+   * | script       | variable `ownerScope` | outcome |
+   * |--------------|-----------------------|---------|
+   * | partner-wide | `'partner'`           | allow   |
+   * | partner-wide | `'organization'`      | allow — the primary use case: one partner-wide script, each target org's own value resolved per device |
+   * | org-owned    | `'organization'`      | allow (necessarily this org's own row — dispatch enforces script/device org equality) |
+   * | org-owned    | `'partner'`           | DENY    |
+   *
+   * REQUIRED, not optional, and deliberately so: an omitted tier would have to
+   * default to something, and either default is wrong — `'partner'` opens the
+   * escalation for every caller that forgets, while `'organization'` breaks the
+   * per-org use case silently. A missing value is a compile error instead.
+   *
+   * This check is the AUTHORITATIVE one. Save-time validation cannot replace
+   * it: variable-key uniqueness is PER SCOPE
+   * (`tenant_variables_org_key_uniq` / `tenant_variables_partner_key_uniq`),
+   * so an org admin can create an org-owned secret that SHADOWS a partner-wide
+   * key, pass a save-time gate against their own row, then delete it — after
+   * which `resolveForOrg` inherits the partner-wide row. Binding a key that
+   * does not exist yet reaches the same place. Only dispatch, which holds the
+   * script row and the freshly-resolved variable, can see the pair that
+   * actually ships.
+   */
+  scriptOwnerScope: 'organization' | 'partner';
 }
 
 export interface ResolveSourcedParametersSuccess {
@@ -363,6 +399,11 @@ function readCustomField(customFields: unknown, fieldKey: string): unknown {
  * - `secretValue`   — the only success path for `tenantSecret`. The value
  *   goes to `secretEnv`, never to `parameters`.
  *
+ * `partnerSecretAboveScriptScope` is the privilege denial: an ORG-owned script
+ * reaching a PARTNER-WIDE secret. See
+ * {@link ResolveSourcedParametersInput.scriptOwnerScope} for the full table
+ * and why dispatch is the only place this can be decided.
+ *
  * `unreadable` is a third denial, and the reason it is not folded into
  * `missing`: the variable's row exists, it simply could not be DECRYPTED
  * (see `tenantVariableResolution.ts`'s `decryptRow`). Reported as "no value
@@ -376,6 +417,7 @@ type SourceLookup =
   | { kind: 'unreadable'; variableKey: string }
   | { kind: 'secretAsPlain'; variableKey: string }
   | { kind: 'notSecret'; variableKey: string }
+  | { kind: 'partnerSecretAboveScriptScope'; variableKey: string }
   | { kind: 'secretValue'; value: string; descriptor: ScriptParameterBindingDescriptor };
 
 /**
@@ -410,8 +452,16 @@ function lookupBoundSource(
       // PLAN §2.4 — a secret target is a POLICY DENIAL, not "missing". It must
       // not fall through to the definition default (which would silently
       // substitute a stale plaintext an operator deliberately reclassified),
-      // must not fall back to a caller value, and must not be omitted. PR4
-      // adds the out-of-band channel; until then the device fails.
+      // must not fall back to a caller value, and must not be omitted.
+      //
+      // The denial is PERMANENT, not a placeholder: `tenantVariable` is the
+      // plaintext channel, and its values are substituted into the script text
+      // and mirrored as `BREEZE_PARAM_*`. There is exactly ONE way to deliver
+      // a secret — an explicit `source: 'tenantSecret'` binding, which rides
+      // the sealed `secretEnv` envelope. Do NOT "fix" this by routing a
+      // secret-valued `tenantVariable` into `secretEnv`: secret delivery is
+      // DECLARED by the script author, never inferred from what the target
+      // variable happens to be classified as today.
       if (variable.isSecret) return { kind: 'secretAsPlain', variableKey: definition.variableKey };
       const value = toNonBlankString(variable.value);
       if (value === undefined) return { kind: 'missing' };
@@ -439,6 +489,21 @@ function lookupBoundSource(
       // one), so a missing target can only fail the device.
       if (!variable) return lookupAbsent(definition.variableKey, input);
       if (!variable.isSecret) return { kind: 'notSecret', variableKey: definition.variableKey };
+      // PRIVILEGE GATE — AFTER the `isSecret` check on purpose: a plaintext
+      // partner-wide target must be reported as "not a secret" (reclassify it)
+      // rather than as a tier violation ("make the script partner-wide"),
+      // which would send the operator to fix the wrong thing.
+      //
+      // An org-scoped actor must not be able to have an MSP's partner-wide
+      // credential sealed and delivered by a script they own. Applied to THIS
+      // arm only, never to `tenantVariable`: a partner-wide NON-secret value is
+      // already readable by an org session through the variables API, so there
+      // is no escalation to prevent there. This gate exists solely because a
+      // secret's plaintext has no other read path — the sealed envelope is the
+      // only way its value ever leaves the server.
+      if (variable.ownerScope === 'partner' && input.scriptOwnerScope === 'organization') {
+        return { kind: 'partnerSecretAboveScriptScope', variableKey: definition.variableKey };
+      }
       // The raw value, NOT `toNonBlankString`: a secret is delivered verbatim
       // or not at all, and silently trimming or blanking a credential would
       // turn an authentication failure into an unexplained one.
@@ -487,6 +552,7 @@ export function resolveSourcedParameters(
   const missing: string[] = [];
   const secretDenied: Array<{ key: string; variableKey: string }> = [];
   const notSecret: Array<{ key: string; variableKey: string }> = [];
+  const aboveScope: Array<{ key: string; variableKey: string }> = [];
   const unreadable: Array<{ key: string; variableKey: string }> = [];
 
   for (const definition of definitions) {
@@ -529,6 +595,14 @@ export function resolveSourcedParameters(
       if (lookup.kind === 'notSecret') {
         notSecret.push({ key: name, variableKey: lookup.variableKey });
         continue; // likewise a denial, not a fallthrough
+      }
+      if (lookup.kind === 'partnerSecretAboveScriptScope') {
+        // A privilege denial, so the same rule as every denial above: no
+        // default, no caller value, no omission. The `tenantSecret` arm has
+        // no default to fall through to anyway; the `continue` is what keeps
+        // the key out of `parameters` and out of the required/missing tail.
+        aboveScope.push({ key: name, variableKey: lookup.variableKey });
+        continue;
       }
       if (lookup.kind === 'secretValue') {
         // The one branch that never touches `parameters` or `resolved`: the
@@ -573,12 +647,13 @@ export function resolveSourcedParameters(
     unreadable.length > 0 ||
     secretDenied.length > 0 ||
     notSecret.length > 0 ||
+    aboveScope.length > 0 ||
     malformedBound.length > 0
   ) {
     return {
       ok: false,
       code: 'unresolved_parameters',
-      error: describeParameterFailure(missing, unreadable, secretDenied, notSecret, malformedBound),
+      error: describeParameterFailure(missing, unreadable, secretDenied, notSecret, aboveScope, malformedBound),
       ignoredParameters,
     };
   }
@@ -605,6 +680,7 @@ function describeParameterFailure(
   unreadable: Array<{ key: string; variableKey: string }>,
   secretDenied: Array<{ key: string; variableKey: string }>,
   notSecret: Array<{ key: string; variableKey: string }>,
+  aboveScope: Array<{ key: string; variableKey: string }>,
   malformedBound: MalformedDefinition[],
 ): string {
   const parts: string[] = [];
@@ -639,6 +715,21 @@ function describeParameterFailure(
     parts.push(
       notSecret
         .map((entry) => `"${entry.key}" is a secret parameter but variable "${entry.variableKey}" is not a secret`)
+        .join('; '),
+    );
+  }
+  if (aboveScope.length > 0) {
+    // Names both keys and BOTH remediations, because the right one depends on
+    // intent: if the credential really is the MSP's, the script belongs at the
+    // partner tier; if this org needs its own, it needs its own secret. Never
+    // a value — and there is a real one behind this key, unlike the notSecret
+    // case, so the rule bites here.
+    parts.push(
+      aboveScope
+        .map(
+          (entry) =>
+            `"${entry.key}" is bound to partner-wide secret variable "${entry.variableKey}", which an organization-scoped script cannot use; make the script partner-wide, or use an organization-owned secret`,
+        )
         .join('; '),
     );
   }

--- a/apps/api/src/services/sourcedParameters.ts
+++ b/apps/api/src/services/sourcedParameters.ts
@@ -32,6 +32,12 @@ import type { ResolvedVariable } from './tenantVariableResolution';
  * source, and an invoker could override the org's configured value simply by
  * naming the key. The supplied value is ignored (not rejected — see
  * {@link ResolveSourcedParametersSuccess.ignoredParameters}) and reported.
+ *
+ * #3409 PR4c-2 adds one exception to the table, not a new rule inside it: a
+ * `tenantSecret` binding has no default and no caller candidate at all, so its
+ * precedence is simply `secret variable -> fail the device`, and its value
+ * leaves through {@link ResolveSourcedParametersSuccess.secretEnv} rather than
+ * `parameters`.
  */
 
 /** Where `scriptDispatch` reads device-scoped sources from. */
@@ -97,6 +103,26 @@ export interface ResolveSourcedParametersSuccess {
   parameters: Record<string, string | number | boolean>;
   /** Identity-only record of the bound parameters, for `script_executions`. */
   bindings: ScriptParameterBindingDescriptor[];
+  /**
+   * Resolved SECRET values, keyed by parameter name (#3409 PR4c-2). Always
+   * present; `{}` for the overwhelming majority of scripts.
+   *
+   * Deliberately a SEPARATE map from {@link parameters}: the agent substitutes
+   * every entry of `parameters` into the script text and mirrors it as
+   * `BREEZE_PARAM_*`, so a secret placed there would be written into the
+   * script body, echoed by `-x` tracing and persisted in the command payload.
+   * These entries instead ride the sealed `secretEnv` envelope and reach the
+   * child process only as `BREEZE_VAR_<UPPER(name)>`.
+   *
+   * Values are NOT re-validated here. The envelope's `validateSecretEnv`
+   * (`services/scriptSecretEnvelope.ts`) is the single authority for the wire
+   * rules (key grammar, 4..4096 length); the key grammar is already
+   * guaranteed by the `tenantSecret` arm's `name` regex, and the minimum
+   * length by `MIN_SECRET_TENANT_VARIABLE_VALUE_LENGTH` at variable save
+   * (`services/tenantVariables.ts`). Duplicating either check here would give
+   * two places to disagree.
+   */
+  secretEnv: Record<string, string>;
   /** Bound keys the caller supplied a value for. Ignored, never rejected (plan §2.2). */
   ignoredParameters: string[];
 }
@@ -218,18 +244,27 @@ function parseDefinitions(value: unknown): ParsedDefinitions {
 }
 
 /**
- * Does this script's stored definition list contain a `tenantVariable`
- * binding?
+ * Does this script's stored definition list contain a binding to EITHER
+ * variable-backed source — `tenantVariable` or `tenantSecret` (#3409 PR4c-2)?
+ *
+ * Both resolve out of the same `resolveForOrg` map, so both must open the
+ * scope. The name is kept (it is exported and read at three preload sites)
+ * because the question it answers is unchanged: "does dispatching this script
+ * require the tenant-variable scope?"
  *
  * Deliberately tolerant — it scans raw elements rather than requiring the
  * whole list to parse. This predicate gates a CHEAP action (loading the
  * variable scope), so the failure it must avoid is a false negative: a list
  * with one unparseable element must not cause every binding in it to resolve
- * against an empty scope.
+ * against an empty scope. For `tenantSecret` a false negative is worse still:
+ * the resolver throws on an absent map rather than failing the device.
  */
 export function hasTenantVariableBoundParameters(parameters: unknown): boolean {
   if (!Array.isArray(parameters)) return false;
-  return parameters.some((element) => readSource(element) === 'tenantVariable');
+  return parameters.some((element) => {
+    const source = readSource(element);
+    return source === 'tenantVariable' || source === 'tenantSecret';
+  });
 }
 
 /**
@@ -296,11 +331,27 @@ function readCustomField(customFields: unknown, fieldKey: string): unknown {
   return (customFields as Record<string, unknown>)[fieldKey];
 }
 
-/** One bound parameter's source lookup, before default fallback. */
+/**
+ * One bound parameter's source lookup, before default fallback.
+ *
+ * The two secret outcomes are opposites, one per variable-backed source, and
+ * are kept distinct so neither can be reached from the wrong arm:
+ *
+ * - `secretAsPlain` — a `tenantVariable` binding whose target IS a secret.
+ *   A policy denial (plan §2.4): secret delivery is declared, never inferred.
+ * - `notSecret`     — a `tenantSecret` binding whose target is NOT a secret.
+ *   Equally a denial: the author declared a credential channel, and quietly
+ *   satisfying it from a plaintext row would deliver an unprotected value
+ *   through a path that promises protection.
+ * - `secretValue`   — the only success path for `tenantSecret`. The value
+ *   goes to `secretEnv`, never to `parameters`.
+ */
 type SourceLookup =
   | { kind: 'value'; value: string; descriptor: ScriptParameterBindingDescriptor }
   | { kind: 'missing' }
-  | { kind: 'secret'; variableKey: string };
+  | { kind: 'secretAsPlain'; variableKey: string }
+  | { kind: 'notSecret'; variableKey: string }
+  | { kind: 'secretValue'; value: string; descriptor: ScriptParameterBindingDescriptor };
 
 function lookupBoundSource(
   definition: Exclude<ScriptParameterDefinition, { source: 'runtime' }>,
@@ -320,7 +371,7 @@ function lookupBoundSource(
       // substitute a stale plaintext an operator deliberately reclassified),
       // must not fall back to a caller value, and must not be omitted. PR4
       // adds the out-of-band channel; until then the device fails.
-      if (variable.isSecret) return { kind: 'secret', variableKey: definition.variableKey };
+      if (variable.isSecret) return { kind: 'secretAsPlain', variableKey: definition.variableKey };
       const value = toNonBlankString(variable.value);
       if (value === undefined) return { kind: 'missing' };
       return {
@@ -329,6 +380,33 @@ function lookupBoundSource(
         descriptor: {
           key: definition.name,
           source: 'tenantVariable',
+          variableId: variable.variableId,
+          ownerScope: variable.ownerScope,
+          version: variable.version,
+        },
+      };
+    }
+    case 'tenantSecret': {
+      if (!input.variables) {
+        throw new Error(
+          'variables map is required to dispatch a script with a tenantSecret-bound parameter',
+        );
+      }
+      const variable = input.variables.get(definition.variableKey);
+      // No default, no caller value, no omission — the arm is always
+      // `required: true` and carries no `defaultValue` (the schema rejects
+      // one), so a missing target can only fail the device.
+      if (!variable) return { kind: 'missing' };
+      if (!variable.isSecret) return { kind: 'notSecret', variableKey: definition.variableKey };
+      // The raw value, NOT `toNonBlankString`: a secret is delivered verbatim
+      // or not at all, and silently trimming or blanking a credential would
+      // turn an authentication failure into an unexplained one.
+      return {
+        kind: 'secretValue',
+        value: variable.value,
+        descriptor: {
+          key: definition.name,
+          source: 'tenantSecret',
           variableId: variable.variableId,
           ownerScope: variable.ownerScope,
           version: variable.version,
@@ -364,8 +442,10 @@ export function resolveSourcedParameters(
   const parameters: Record<string, unknown> = { ...input.callerParameters };
   const bindings: ScriptParameterBindingDescriptor[] = [];
   const ignoredParameters: string[] = [];
+  const secretEnv: Record<string, string> = {};
   const missing: string[] = [];
   const secretDenied: Array<{ key: string; variableKey: string }> = [];
+  const notSecret: Array<{ key: string; variableKey: string }> = [];
 
   for (const definition of definitions) {
     const name = definition.name;
@@ -391,9 +471,22 @@ export function resolveSourcedParameters(
     } else {
       if (callerValue !== undefined) ignoredParameters.push(name);
       const lookup = lookupBoundSource(definition, input);
-      if (lookup.kind === 'secret') {
+      if (lookup.kind === 'secretAsPlain') {
         secretDenied.push({ key: name, variableKey: lookup.variableKey });
         continue; // no default, no caller value, no omission — the device fails
+      }
+      if (lookup.kind === 'notSecret') {
+        notSecret.push({ key: name, variableKey: lookup.variableKey });
+        continue; // likewise a denial, not a fallthrough
+      }
+      if (lookup.kind === 'secretValue') {
+        // The one branch that never touches `parameters` or `resolved`: the
+        // value leaves through `secretEnv` only, and `continue` skips the
+        // default/required tail below (the arm has no default and is always
+        // required, so reaching that tail could only misreport it as missing).
+        secretEnv[name] = lookup.value;
+        bindings.push(lookup.descriptor);
+        continue;
       }
       if (lookup.kind === 'value') {
         resolved = lookup.value;
@@ -424,11 +517,11 @@ export function resolveSourcedParameters(
   // undo the binding's authority. Fail the device instead.
   const malformedBound = malformed.filter((entry) => entry.boundSource !== null);
 
-  if (missing.length > 0 || secretDenied.length > 0 || malformedBound.length > 0) {
+  if (missing.length > 0 || secretDenied.length > 0 || notSecret.length > 0 || malformedBound.length > 0) {
     return {
       ok: false,
       code: 'unresolved_parameters',
-      error: describeParameterFailure(missing, secretDenied, malformedBound),
+      error: describeParameterFailure(missing, secretDenied, notSecret, malformedBound),
       ignoredParameters,
     };
   }
@@ -437,6 +530,7 @@ export function resolveSourcedParameters(
     ok: true,
     parameters: parameters as Record<string, string | number | boolean>,
     bindings,
+    secretEnv,
     ignoredParameters,
   };
 }
@@ -452,6 +546,7 @@ const quoteList = (values: string[]): string => values.map((value) => `"${value}
 function describeParameterFailure(
   missing: string[],
   secretDenied: Array<{ key: string; variableKey: string }>,
+  notSecret: Array<{ key: string; variableKey: string }>,
   malformedBound: MalformedDefinition[],
 ): string {
   const parts: string[] = [];
@@ -463,6 +558,16 @@ function describeParameterFailure(
       `${quoteList(secretDenied.map((entry) => entry.key))} ${
         secretDenied.length === 1 ? 'is bound to secret tenant variable' : 'are bound to secret tenant variables'
       } ${quoteList(secretDenied.map((entry) => entry.variableKey))}, which cannot be used in script parameters`,
+    );
+  }
+  if (notSecret.length > 0) {
+    // The mirror of the denial above, and worth its own sentence: the author
+    // asked for the secure channel and the variable is not eligible for it.
+    // Naming both keys tells the operator exactly which one to reclassify.
+    parts.push(
+      notSecret
+        .map((entry) => `"${entry.key}" is a secret parameter but variable "${entry.variableKey}" is not a secret`)
+        .join('; '),
     );
   }
   if (malformedBound.length > 0) {

--- a/apps/api/src/services/sourcedParameters.ts
+++ b/apps/api/src/services/sourcedParameters.ts
@@ -95,6 +95,23 @@ export interface ResolveSourcedParametersInput {
    * and throws, matching the content-substitution path's contract.
    */
   variables?: ReadonlyMap<string, ResolvedVariable>;
+  /**
+   * Variable keys for this device's org whose row EXISTS but could not be
+   * decrypted — i.e. `unreadableForOrg(scope, device.orgId)` (#3409 PR4c-1).
+   *
+   * Deliberately a second collection rather than sentinel entries in
+   * {@link variables}: an unreadable variable must never resolve to a value,
+   * and `resolveForOrg`'s map is the "has a value" channel by contract.
+   *
+   * Optional, and omitting it is not a silent downgrade of anything the
+   * resolver would otherwise get right — a key that is unreadable is absent
+   * from `variables` either way, so the only difference is WHICH failure the
+   * operator is shown ({@link SourceLookup} `'unreadable'` vs `'missing'`).
+   * That difference matters: "not set" tells a tech to create the variable,
+   * while unreadable means the ciphertext is present and the KEY MATERIAL is
+   * wrong — and creating a duplicate mid-rotation is the opposite of the fix.
+   */
+  unreadableVariableKeys?: ReadonlySet<string>;
 }
 
 export interface ResolveSourcedParametersSuccess {
@@ -345,13 +362,37 @@ function readCustomField(customFields: unknown, fieldKey: string): unknown {
  *   through a path that promises protection.
  * - `secretValue`   — the only success path for `tenantSecret`. The value
  *   goes to `secretEnv`, never to `parameters`.
+ *
+ * `unreadable` is a third denial, and the reason it is not folded into
+ * `missing`: the variable's row exists, it simply could not be DECRYPTED
+ * (see `tenantVariableResolution.ts`'s `decryptRow`). Reported as "no value
+ * for required parameter", it sends a tech to create a duplicate variable —
+ * exactly the wrong remediation during a key rotation, and one that leaves
+ * the undecryptable row in place.
  */
 type SourceLookup =
   | { kind: 'value'; value: string; descriptor: ScriptParameterBindingDescriptor }
   | { kind: 'missing' }
+  | { kind: 'unreadable'; variableKey: string }
   | { kind: 'secretAsPlain'; variableKey: string }
   | { kind: 'notSecret'; variableKey: string }
   | { kind: 'secretValue'; value: string; descriptor: ScriptParameterBindingDescriptor };
+
+/**
+ * Why a variable key produced no entry in {@link ResolveSourcedParametersInput.variables}.
+ *
+ * Shared by both variable-backed arms, which had the identical confusion: the
+ * map is the "has a readable value" channel, so an unreadable row and a
+ * never-created one are both simply absent from it, and only the snapshot's
+ * unreadable set can tell them apart.
+ *
+ * The map wins when it HAS the key: a listing here is only consulted on
+ * absence, so a stale entry can never suppress a value that actually resolved.
+ */
+function lookupAbsent(variableKey: string, input: ResolveSourcedParametersInput): SourceLookup {
+  if (input.unreadableVariableKeys?.has(variableKey)) return { kind: 'unreadable', variableKey };
+  return { kind: 'missing' };
+}
 
 function lookupBoundSource(
   definition: Exclude<ScriptParameterDefinition, { source: 'runtime' }>,
@@ -365,7 +406,7 @@ function lookupBoundSource(
         );
       }
       const variable = input.variables.get(definition.variableKey);
-      if (!variable) return { kind: 'missing' };
+      if (!variable) return lookupAbsent(definition.variableKey, input);
       // PLAN §2.4 — a secret target is a POLICY DENIAL, not "missing". It must
       // not fall through to the definition default (which would silently
       // substitute a stale plaintext an operator deliberately reclassified),
@@ -396,7 +437,7 @@ function lookupBoundSource(
       // No default, no caller value, no omission — the arm is always
       // `required: true` and carries no `defaultValue` (the schema rejects
       // one), so a missing target can only fail the device.
-      if (!variable) return { kind: 'missing' };
+      if (!variable) return lookupAbsent(definition.variableKey, input);
       if (!variable.isSecret) return { kind: 'notSecret', variableKey: definition.variableKey };
       // The raw value, NOT `toNonBlankString`: a secret is delivered verbatim
       // or not at all, and silently trimming or blanking a credential would
@@ -446,6 +487,7 @@ export function resolveSourcedParameters(
   const missing: string[] = [];
   const secretDenied: Array<{ key: string; variableKey: string }> = [];
   const notSecret: Array<{ key: string; variableKey: string }> = [];
+  const unreadable: Array<{ key: string; variableKey: string }> = [];
 
   for (const definition of definitions) {
     const name = definition.name;
@@ -471,6 +513,15 @@ export function resolveSourcedParameters(
     } else {
       if (callerValue !== undefined) ignoredParameters.push(name);
       const lookup = lookupBoundSource(definition, input);
+      if (lookup.kind === 'unreadable') {
+        // A denial, exactly like the two secret denials below — never a
+        // fallthrough to the definition default. That default is the stale
+        // plaintext the operator's (now unreadable) row was created to
+        // replace, so shipping it would substitute the very value the
+        // binding overrode, under a variable the UI still shows as set.
+        unreadable.push({ key: name, variableKey: lookup.variableKey });
+        continue;
+      }
       if (lookup.kind === 'secretAsPlain') {
         secretDenied.push({ key: name, variableKey: lookup.variableKey });
         continue; // no default, no caller value, no omission — the device fails
@@ -517,11 +568,17 @@ export function resolveSourcedParameters(
   // undo the binding's authority. Fail the device instead.
   const malformedBound = malformed.filter((entry) => entry.boundSource !== null);
 
-  if (missing.length > 0 || secretDenied.length > 0 || notSecret.length > 0 || malformedBound.length > 0) {
+  if (
+    missing.length > 0 ||
+    unreadable.length > 0 ||
+    secretDenied.length > 0 ||
+    notSecret.length > 0 ||
+    malformedBound.length > 0
+  ) {
     return {
       ok: false,
       code: 'unresolved_parameters',
-      error: describeParameterFailure(missing, secretDenied, notSecret, malformedBound),
+      error: describeParameterFailure(missing, unreadable, secretDenied, notSecret, malformedBound),
       ignoredParameters,
     };
   }
@@ -545,6 +602,7 @@ const quoteList = (values: string[]): string => values.map((value) => `"${value}
  */
 function describeParameterFailure(
   missing: string[],
+  unreadable: Array<{ key: string; variableKey: string }>,
   secretDenied: Array<{ key: string; variableKey: string }>,
   notSecret: Array<{ key: string; variableKey: string }>,
   malformedBound: MalformedDefinition[],
@@ -552,6 +610,20 @@ function describeParameterFailure(
   const parts: string[] = [];
   if (missing.length > 0) {
     parts.push(`no value for required parameter(s) ${quoteList(missing)}`);
+  }
+  if (unreadable.length > 0) {
+    // Its own sentence, and pointedly NOT the "no value" wording above: the
+    // row exists, so the operator must go look at key material rather than
+    // create the variable again. Names both keys, never a value — there is
+    // no plaintext to leak here anyway, but the rule is unconditional.
+    parts.push(
+      unreadable
+        .map(
+          (entry) =>
+            `"${entry.key}" is bound to variable "${entry.variableKey}", whose stored value could not be read (check the server's encryption keys)`,
+        )
+        .join('; '),
+    );
   }
   if (secretDenied.length > 0) {
     parts.push(

--- a/apps/api/src/services/tenantVariableResolution.test.ts
+++ b/apps/api/src/services/tenantVariableResolution.test.ts
@@ -25,6 +25,16 @@ vi.mock('../db', () => {
   };
 });
 
+// `./sentry` is mocked so the decrypt-failure report can be ASSERTED rather
+// than merely not-crashing: a real `captureException` no-ops without a DSN
+// (services/sentry.ts's `initialized` guard), which is exactly the unit-test
+// environment — so an un-mocked module would let the missing report pass.
+vi.mock('./sentry', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args)
+}));
+
+const mockCaptureException = vi.fn();
+
 import {
   db,
   getCurrentDbAccessContext,
@@ -317,6 +327,39 @@ describe('loadTenantVariableScope', () => {
     expect(resolved.get('k')?.value).not.toBe('partner-value');
     expect(unreadableForOrg(scope, ORG_A).has('k')).toBe(true);
     warn.mockRestore();
+  });
+
+  // #3409 PR4c-2 review finding 1 — a decrypt failure is a KEY-MATERIAL
+  // incident (a botched rotation, a keyring missing the id a row was sealed
+  // under), not a per-row curiosity. Reported only to `console.warn`, it is
+  // invisible on hosted, where nobody reads container logs and the operator's
+  // only symptom is scripts failing on a variable that visibly exists. It has
+  // to reach Sentry.
+  it('reports a decrypt failure to Sentry, carrying the row id and never the value', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stubSelect([
+      { id: ROW_BAD, key: 'broken', value: 'enc:v3:unit:not.real.ciphertext', isSecret: false, version: 1, ownerOrgId: ORG_A, forOrgId: ORG_A }
+    ]);
+
+    await loadTenantVariableScope([ORG_A]);
+
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    const [err, context, tags] = mockCaptureException.mock.calls[0] as [unknown, unknown, Record<string, string>];
+    expect(err).toBeInstanceOf(Error);
+    expect(context).toBeUndefined();
+    expect(tags?.tenantVariableId).toBe(ROW_BAD);
+    // Identity only: never the ciphertext, never an attempted plaintext, and
+    // never the variable's key name (which can itself be descriptive).
+    expect(JSON.stringify({ tags, message: (err as Error).message })).not.toContain('not.real.ciphertext');
+    // The existing log line is kept — Sentry is an addition, not a swap.
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('does not report to Sentry when every row decrypts', async () => {
+    stubSelect([encryptedRow(ROW_ORG, 'v', { key: 'k', ownerOrgId: ORG_A, forOrgId: ORG_A })]);
+    await loadTenantVariableScope([ORG_A]);
+    expect(mockCaptureException).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/tenantVariableResolution.ts
+++ b/apps/api/src/services/tenantVariableResolution.ts
@@ -8,6 +8,7 @@ import {
   type Database
 } from '../db';
 import { organizations, tenantVariables } from '../db/schema';
+import { captureException } from './sentry';
 import { decryptTenantVariableValue } from './tenantVariables';
 
 /**
@@ -105,11 +106,20 @@ interface RawResolvedRow {
 }
 
 /**
- * Decrypt one row, or return null and warn (id only — never the ciphertext or
- * an attempted plaintext) on failure. An unreadable variable must fail the
+ * Decrypt one row, or return null and report (id only — never the ciphertext
+ * or an attempted plaintext) on failure. An unreadable variable must fail the
  * device it would have been substituted into, never silently resolve to an
  * empty string, so the row is OMITTED from the snapshot rather than inserted
  * with a placeholder value.
+ *
+ * Reported to BOTH channels, deliberately. A decrypt failure here is not a
+ * per-row curiosity: the plausible causes are a botched key rotation, a
+ * keyring that no longer carries the key id a row was sealed under, or a
+ * restored database meeting the wrong `APP_ENCRYPTION_KEY` — all of which
+ * fail EVERY affected row at once and break script dispatch for a variable
+ * the UI still shows as set. Left on `console.warn` alone it is invisible on
+ * hosted (nobody tails container logs) and the operator's only symptom is
+ * devices failing on a variable that visibly exists.
  */
 function decryptRow(row: RawResolvedRow): ResolvedVariable | null {
   try {
@@ -124,6 +134,13 @@ function decryptRow(row: RawResolvedRow): ResolvedVariable | null {
     };
   } catch (err) {
     console.warn('[tenant-variable-resolution] failed to decrypt tenant variable value', { id: row.id });
+    // Identity only. `err` comes from the crypto layer and the tag set is
+    // hand-built, so neither carries the ciphertext, an attempted plaintext,
+    // or the variable's key name (which can itself describe the credential).
+    captureException(err instanceof Error ? err : new Error(String(err)), undefined, {
+      service: 'tenantVariableResolution',
+      tenantVariableId: row.id
+    });
     return null;
   }
 }

--- a/apps/docs/src/content/docs/features/scripts.mdx
+++ b/apps/docs/src/content/docs/features/scripts.mdx
@@ -357,6 +357,18 @@ Parameters let you create reusable scripts with configurable values. Define para
 }
 ```
 
+### Parameter sources
+
+Every parameter has a **source** that decides where its value comes from. By default the value is asked for at run time; the other sources resolve it automatically, per device, when the script is dispatched — nobody is prompted for them.
+
+| Source | Resolves to |
+|---|---|
+| **Asked at run time** | A value supplied by whoever starts the run (or by the automation/schedule that triggers it). |
+| **From a variable** | A non-secret [variable](#variables) for the target device's organization. |
+| **From a secret variable (environment variable)** | A [secret variable](#secret-variables-in-scripts), delivered to the script only as an environment variable. |
+| **From a device custom field** | A custom field value on the target device. |
+| **From a device property** | A built-in device property, such as hostname or OS type. |
+
 ### Using parameters in script content
 
 The agent substitutes parameter placeholders before execution. Two placeholder formats are supported:
@@ -413,10 +425,63 @@ Breeze resolves each reference **per device at dispatch**, using the variable th
 
 ### Secret variables
 
-Tick **Secret** and the value becomes write-once: it is never displayed again after saving — the list shows `••••••••` and the API returns no value at all. Secrets are delivered to the script as an environment variable rather than pasted into the script body, and are redacted from captured output.
+Tick **Secret** and the value becomes write-once: it is never displayed again after saving — the list shows `••••••••` and the API returns no value at all. Secrets are never pasted into a script body: a script binds one through a parameter and reads it as an environment variable. See [Secret variables in scripts](#secret-variables-in-scripts).
 
 <Aside type="caution">
   A secret cannot be recovered through the UI or the API once saved. To change it, overwrite it with a new value.
+</Aside>
+
+### Secret variables in scripts
+
+A secret is never pasted into script text. `{{var.key}}` pointing at a secret is rejected when the script is saved. A script reaches a secret through a **parameter** instead:
+
+<Steps>
+
+1. In the script editor, add a parameter and set its **source** to **From a secret variable (environment variable)**.
+2. Bind it to a secret variable key. Non-secret variables are not offered for this source.
+3. Name the parameter using lowercase letters, digits and underscores — the name becomes the environment variable the script reads.
+
+</Steps>
+
+At dispatch, Breeze resolves the secret for each target device's organization and delivers it as the environment variable `BREEZE_VAR_<NAME>`, where `<NAME>` is the parameter name in uppercase. A parameter named `api_token` arrives as `BREEZE_VAR_API_TOKEN`:
+
+<Tabs>
+  <TabItem label="PowerShell">
+    ```powershell
+    Invoke-RestMethod -Uri $Url -Headers @{ Authorization = "Bearer $env:BREEZE_VAR_API_TOKEN" }
+    ```
+  </TabItem>
+  <TabItem label="Bash">
+    ```bash
+    curl -H "Authorization: Bearer $BREEZE_VAR_API_TOKEN" "$URL"
+    ```
+  </TabItem>
+</Tabs>
+
+The value is never substituted into the script body, never mirrored into `BREEZE_PARAM_*`, and never written to the execution record.
+
+**Binding rules**
+
+- Binding a secret through the plain **From a variable** source is rejected when the script is saved. So is binding a non-secret variable through the secret source.
+- At run time, a target organization where the bound key resolves to a non-secret variable — or has no variable with that key — fails on that device with a message naming the parameter and the variable key. Devices whose organizations do resolve the secret still run.
+
+**Requirements**
+
+| Requirement | If it is not met |
+|---|---|
+| System-context execution | A script set to **Run as user**, or a run targeted at a specific user session, is refused: *"This script uses secret variables, which require system-context execution; ... was not executed."* |
+| An agent that supports secure secret delivery — agents from the release that ships this feature (v0.107.0 or later) | The device fails with *"Agent upgrade required: ... script not executed."* This is checked both when the run is queued and again when the agent picks the command up, so a script never runs with its secret environment variable unset. |
+
+While the command waits for the device, the value is held in an encrypted envelope bound to that specific command, and it is erased from the command record once the run completes.
+
+**Output redaction.** Exact occurrences of the secret value in stdout, stderr and error text are replaced with `[REDACTED]` — on the agent before the result is sent, and again on the server before the result is stored.
+
+<Aside type="caution" title="Redaction is accidental-leak protection, not DLP">
+  Only the exact value is matched. A script that dumps its environment (`env`, `printenv`, `Get-ChildItem Env:`), traces itself (`bash -x`), or emits the value transformed in any way — base64, URL-encoded, split across lines — will disclose it. Treat permission to run a script as permission to use every secret that script binds.
+</Aside>
+
+<Aside type="note">
+  [Software deployment](/features/software-inventory/#software-deployments) templates cannot use secret variables. A template that references a secret key fails the deployment with an explicit error rather than silently omitting the value.
 </Aside>
 
 ### Variables and approvals

--- a/apps/docs/src/content/docs/features/scripts.mdx
+++ b/apps/docs/src/content/docs/features/scripts.mdx
@@ -463,6 +463,8 @@ The value is never substituted into the script body, never mirrored into `BREEZE
 **Binding rules**
 
 - Binding a secret through the plain **From a variable** source is rejected when the script is saved. So is binding a non-secret variable through the secret source.
+- Binding a **partner-wide** secret requires an account with access to **all** of the partner's organizations — the same rule as editing a partner-wide script. An organization-scoped user can see that a partner-wide secret key exists, and can run a script that already binds one, but cannot create the binding. This keeps a customer's own administrator from turning your MSP-level credentials into script output.
+- A script can declare at most **32** secret parameters.
 - At run time, a target organization where the bound key resolves to a non-secret variable — or has no variable with that key — fails on that device with a message naming the parameter and the variable key. Devices whose organizations do resolve the secret still run.
 
 **Requirements**
@@ -477,11 +479,13 @@ While the command waits for the device, the value is held in an encrypted envelo
 **Output redaction.** Exact occurrences of the secret value in stdout, stderr and error text are replaced with `[REDACTED]` — on the agent before the result is sent, and again on the server before the result is stored.
 
 <Aside type="caution" title="Redaction is accidental-leak protection, not DLP">
-  Only the exact value is matched. A script that dumps its environment (`env`, `printenv`, `Get-ChildItem Env:`), traces itself (`bash -x`), or emits the value transformed in any way — base64, URL-encoded, split across lines — will disclose it. Treat permission to run a script as permission to use every secret that script binds.
+  Only the exact value is matched. A script that dumps its environment (`env`, `printenv`, `Get-ChildItem Env:`), traces itself (`bash -x`), or emits the value transformed in any way — base64, URL-encoded, split across lines — will disclose it. Treat permission to run a script as permission to use every secret that script binds — which is why creating a binding to a *partner-wide* secret is restricted to full-partner accounts.
 </Aside>
 
 <Aside type="note">
   [Software deployment](/features/software-inventory/#software-deployments) templates cannot use secret variables. A template that references a secret key fails the deployment with an explicit error rather than silently omitting the value.
+
+  Fleet remediation cannot run a script that declares **any** server-resolved parameter — secret, variable, device field, or device property. That path resolves nothing per device, so such a script is rejected when the remediation run is created rather than executed with the values missing.
 </Aside>
 
 ### Variables and approvals

--- a/apps/docs/src/content/docs/features/scripts.mdx
+++ b/apps/docs/src/content/docs/features/scripts.mdx
@@ -27,7 +27,7 @@ The Script Library displays your scripts in a searchable list with columns for n
 
 A script is owned either by a **single organization** or **partner-wide** — available to every organization you manage. Partner-scope users with more than one organization see an **Available to** picker on the script form: choose **All my organizations** to make the script partner-wide, or **A specific organization** to scope it down. An existing script can be re-scoped the same way — moved between organizations or promoted to partner-wide.
 
-Creating, editing, or re-scoping a **partner-wide** script requires an account with access to **all** of the partner's organizations — the same rule as other partner-wide policies. A technician restricted to selected organizations can still *see and run* partner-wide scripts, but the form marks them read-only and the partner-wide option is unavailable when they create scripts.
+Creating, editing, or re-scoping a **partner-wide** script requires a partner account with full organization access (org access set to **"all"**) — the same rule as other partner-wide policies. Selecting every organization individually is not enough: the capability is the "all organizations" setting itself, because a partner-wide script also reaches organizations created later. A technician restricted to selected organizations can still *see and run* partner-wide scripts, but the form marks them read-only and the partner-wide option is unavailable when they create scripts.
 
 ### Importing from the system library
 
@@ -463,7 +463,10 @@ The value is never substituted into the script body, never mirrored into `BREEZE
 **Binding rules**
 
 - Binding a secret through the plain **From a variable** source is rejected when the script is saved. So is binding a non-secret variable through the secret source.
-- Binding a **partner-wide** secret requires an account with access to **all** of the partner's organizations — the same rule as editing a partner-wide script. An organization-scoped user can see that a partner-wide secret key exists, and can run a script that already binds one, but cannot create the binding. This keeps a customer's own administrator from turning your MSP-level credentials into script output.
+- A script may bind a secret **at or below its own ownership tier, never above**.
+  - A **partner-wide** script may bind a partner-wide secret — and may equally bind an *organization-owned* one, which resolves to each target device's own organization at run time. That per-organization resolution is the point: one partner-wide script, and every customer supplies their own value for the same key — a per-org site key, vendor token, or tenant identifier — without a copy of the script per customer.
+  - An **organization-scoped** script may bind only that organization's own secrets. A partner-wide secret is refused when the script is saved, with a message naming the parameter, and refused again at dispatch. The second check is what makes the rule airtight: a script cannot be re-scoped or re-pointed into reaching a secret above its own tier.
+- Where an organization defines a secret with the same key as a partner-wide one, the organization's value wins — the same org-over-partner precedence as ordinary variables. This is what makes the per-organization pattern work: set the partner-wide secret as the default, and override it only for the customers that need their own value.
 - A script can declare at most **32** secret parameters.
 - At run time, a target organization where the bound key resolves to a non-secret variable — or has no variable with that key — fails on that device with a message naming the parameter and the variable key. Devices whose organizations do resolve the secret still run.
 
@@ -472,14 +475,14 @@ The value is never substituted into the script body, never mirrored into `BREEZE
 | Requirement | If it is not met |
 |---|---|
 | System-context execution | A script set to **Run as user**, or a run targeted at a specific user session, is refused: *"This script uses secret variables, which require system-context execution; ... was not executed."* |
-| An agent that supports secure secret delivery — agents from the release that ships this feature (v0.107.0 or later) | The device fails with *"Agent upgrade required: ... script not executed."* This is checked both when the run is queued and again when the agent picks the command up, so a script never runs with its secret environment variable unset. |
+| An agent that supports secure secret delivery — **agent v0.106.0 or later** | The device fails with *"Agent upgrade required: ... script not executed."* This is checked both when the run is queued and again when the agent picks the command up, so a script never runs with its secret environment variable unset. |
 
 While the command waits for the device, the value is held in an encrypted envelope bound to that specific command, and it is erased from the command record once the run completes.
 
 **Output redaction.** Exact occurrences of the secret value in stdout, stderr and error text are replaced with `[REDACTED]` — on the agent before the result is sent, and again on the server before the result is stored.
 
 <Aside type="caution" title="Redaction is accidental-leak protection, not DLP">
-  Only the exact value is matched. A script that dumps its environment (`env`, `printenv`, `Get-ChildItem Env:`), traces itself (`bash -x`), or emits the value transformed in any way — base64, URL-encoded, split across lines — will disclose it. Treat permission to run a script as permission to use every secret that script binds — which is why creating a binding to a *partner-wide* secret is restricted to full-partner accounts.
+  Only the exact value is matched. A script that dumps its environment (`env`, `printenv`, `Get-ChildItem Env:`), traces itself (`bash -x`), or emits the value transformed in any way — base64, URL-encoded, split across lines — will disclose it. Treat permission to run a script as permission to use every secret that script binds — which is why a script can only bind secrets at or below its own ownership tier, and an organization-scoped script can never reach a partner-wide secret.
 </Aside>
 
 <Aside type="note">

--- a/apps/docs/src/content/docs/features/software-inventory.mdx
+++ b/apps/docs/src/content/docs/features/software-inventory.mdx
@@ -154,7 +154,7 @@ Search the catalog by name or enter an ID directly (for example `Google.Chrome` 
 A package can be scoped to **All organizations** (partner-wide) or to a single organization. Partner-wide packages let you define software once and deploy it to every customer you manage, which is usually what you want for standard applications.
 
 <Aside>
-  Variables work here too — reference values like `{{org.name}}` in a URL or install arguments and Breeze resolves them per organization at deploy time. See [Variables](/features/scripts/#variables).
+  Variables work here too — reference values like `{{org.name}}` in a URL or install arguments and Breeze resolves them per organization at deploy time. See [Variables](/features/scripts/#variables). Secret variables are the exception — deployment templates cannot use them, and a template that references a secret key fails the deployment with an explicit error.
 </Aside>
 
 ---

--- a/apps/web/src/components/devices/ScriptPickerModal.test.tsx
+++ b/apps/web/src/components/devices/ScriptPickerModal.test.tsx
@@ -445,3 +445,100 @@ describe('ScriptPickerModal session targeting', () => {
     );
   });
 });
+
+// #3409 PR4c-2: a `tenantSecret` parameter rides an env var in the sealed
+// command envelope. The server refuses the run outright for a user-context run
+// AND for any targeted session (`runAsSupportsSecretEnv`), so this surface —
+// which offers both controls — has to say so before the operator submits.
+describe('ScriptPickerModal secret parameters (#3409 PR4c-2)', () => {
+  const SECRET_SCRIPTS = [
+    {
+      id: 's1',
+      name: 'Secret Script',
+      language: 'bash',
+      category: 'General',
+      osTypes: ['linux', 'windows'],
+      parameters: [
+        { name: 'message', type: 'string', required: true, defaultValue: 'hi' },
+        { name: 'api_token', type: 'string', required: true, source: 'tenantSecret', variableKey: 'vendor_password' },
+      ],
+    },
+    {
+      id: 's2',
+      name: 'Plain Script',
+      language: 'bash',
+      category: 'General',
+      osTypes: ['linux', 'windows'],
+      parameters: [{ name: 'message', type: 'string', required: true, defaultValue: 'hi' }],
+    },
+  ];
+
+  const routeSecretFetch = () =>
+    fetchWithAuthMock.mockImplementation(async (url: string) =>
+      url.startsWith('/devices/') ? makeJsonResponse(SESSIONS_RESPONSE) : makeJsonResponse(SECRET_SCRIPTS)
+    );
+
+  const openParamsFor = async (name: string) => {
+    await waitFor(() => expect(screen.getByText(name)).toBeDefined());
+    fireEvent.click(screen.getByText(name));
+    await waitFor(() => expect(screen.getByText('Run Script')).toBeDefined());
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routeSecretFetch();
+  });
+
+  it('says nothing for an untargeted system run', async () => {
+    render(<ScriptPickerModal isOpen onClose={vi.fn()} onSelect={vi.fn()} />);
+    await openParamsFor('Secret Script');
+    expect(screen.queryByTestId('script-picker-secrets-require-system')).toBeNull();
+  });
+
+  it('warns once Run as user is selected', async () => {
+    render(<ScriptPickerModal isOpen onClose={vi.fn()} onSelect={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('Secret Script')).toBeDefined());
+    fireEvent.change(screen.getByTestId('script-run-as'), { target: { value: 'user' } });
+    await openParamsFor('Secret Script');
+
+    expect(screen.getByTestId('script-picker-secrets-require-system')).toHaveTextContent(
+      /secret variables/i
+    );
+  });
+
+  it('warns when a specific session is targeted', async () => {
+    render(
+      <ScriptPickerModal isOpen onClose={vi.fn()} onSelect={vi.fn()} deviceHostname="rds-01"
+        deviceId="dev-1" helperLifecycleMode="on-demand" />
+    );
+    fireEvent.change(screen.getByTestId('script-run-as'), { target: { value: 'user' } });
+    await waitFor(() => expect(screen.getByTestId('script-session-target')).toBeDefined());
+    fireEvent.change(screen.getByTestId('script-session-target'), { target: { value: '5' } });
+    await openParamsFor('Secret Script');
+
+    expect(screen.getByTestId('script-picker-secrets-require-system')).toBeDefined();
+  });
+
+  it('says nothing for a user run when no parameter is a secret', async () => {
+    render(<ScriptPickerModal isOpen onClose={vi.fn()} onSelect={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('Plain Script')).toBeDefined());
+    fireEvent.change(screen.getByTestId('script-run-as'), { target: { value: 'user' } });
+    await openParamsFor('Plain Script');
+
+    expect(screen.queryByTestId('script-picker-secrets-require-system')).toBeNull();
+  });
+
+  it('is a warning, not a block — the run still submits', async () => {
+    const onSelect = vi.fn();
+    render(<ScriptPickerModal isOpen onClose={vi.fn()} onSelect={onSelect} />);
+    await waitFor(() => expect(screen.getByText('Secret Script')).toBeDefined());
+    fireEvent.change(screen.getByTestId('script-run-as'), { target: { value: 'user' } });
+    await openParamsFor('Secret Script');
+
+    expect(screen.getByTestId('script-picker-secrets-require-system')).toBeDefined();
+    fireEvent.click(screen.getByText('Run Script'));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][1]).toBe('user');
+  });
+});

--- a/apps/web/src/components/devices/ScriptPickerModal.tsx
+++ b/apps/web/src/components/devices/ScriptPickerModal.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { Dialog } from '../shared/Dialog';
 import { fetchLiveSessions, type LiveSession } from '../../services/deviceActions';
-import { runtimeParameters, type ScriptParameter } from '../scripts/ScriptFormSchema';
+import { hasSecretParameters, runtimeParameters, secretsBlockedForRun, type ScriptParameter } from '../scripts/ScriptFormSchema';
 import ScriptParametersForm, { validateParameters } from '../scripts/ScriptParametersForm';
 import { fetchAllScripts } from '@/lib/scriptsFetch';
 
@@ -188,6 +188,15 @@ export default function ScriptPickerModal({
     setParamError(undefined);
     setView('params');
   };
+
+  // Secrets ride an environment variable in the sealed command envelope, which
+  // neither the user-context helper IPC nor a session-targeted run can carry —
+  // the server refuses both (#3409 PR4c-2). The run context is chosen on the
+  // list step and the script on the parameter step, so this is the first point
+  // where both halves are known. Advisory only: the server gate is
+  // authoritative and the operator may still submit.
+  const secretsBlocked = hasSecretParameters(selectedScript?.parameters)
+    && secretsBlockedForRun({ runAs, targetSessionId: showSessionTarget ? targetSessionId : undefined });
 
   const handleBack = () => {
     setSelectedScript(null);
@@ -408,6 +417,14 @@ export default function ScriptPickerModal({
               <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
                 {paramError}
               </div>
+            )}
+            {secretsBlocked && (
+              <p
+                data-testid="script-picker-secrets-require-system"
+                className="rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-xs text-amber-600 dark:text-amber-500"
+              >
+                {t('scripts:secretParameters.requiresSystemContext')}
+              </p>
             )}
             {selectedScript?.parameters && (
               <ScriptParametersForm

--- a/apps/web/src/components/scripts/ScriptExecutionModal.test.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.test.tsx
@@ -144,3 +144,52 @@ describe('ScriptExecutionModal sourced parameters (#3409 PR3)', () => {
     expect(onExecute).not.toHaveBeenCalled();
   });
 });
+
+// #3409 PR4c-2: secrets ride an env var the helper IPC cannot carry, so a
+// user-context run refuses them server-side. Warn before the operator submits.
+describe('ScriptExecutionModal secret parameters (#3409 PR4c-2)', () => {
+  const secretParam: ScriptParameter = {
+    name: 'api_token',
+    source: 'tenantSecret',
+    variableKey: 'vendor_password',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const selectRunAs = (value: 'system' | 'user') => {
+    fireEvent.change(screen.getByDisplayValue('System'), { target: { value } });
+  };
+
+  it('warns that secrets require system context once Run as user is selected', () => {
+    renderModal([secretParam]);
+    expect(screen.queryByTestId('script-secrets-require-system')).toBeNull();
+
+    selectRunAs('user');
+
+    expect(screen.getByTestId('script-secrets-require-system')).toHaveTextContent(
+      /secret variables/i
+    );
+  });
+
+  it('does not warn for a user run when no parameter is a secret', () => {
+    renderModal([
+      { name: 'api_key', type: 'string', source: 'tenantVariable', variableKey: 'vendor_token' },
+    ]);
+
+    selectRunAs('user');
+
+    expect(screen.queryByTestId('script-secrets-require-system')).toBeNull();
+  });
+
+  it('is a warning, not a block — the run still submits', async () => {
+    const { onExecute } = renderModal([secretParam]);
+    selectRunAs('user');
+
+    await execute();
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute.mock.calls[0][3]).toBe('user');
+  });
+});

--- a/apps/web/src/components/scripts/ScriptExecutionModal.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 import { Dialog } from '../shared/Dialog';
 import ProgressBar, { ProgressItemList, type ProgressItem } from '../shared/ProgressBar';
 import type { Script } from './ScriptList';
-import { runtimeParameters, type ScriptParameter } from './ScriptFormSchema';
+import { hasSecretParameters, runtimeParameters, type ScriptParameter } from './ScriptFormSchema';
 import type { FilterConditionGroup } from '@breeze/shared';
 import { FilterBuilder, DEFAULT_FILTER_FIELDS } from '../filters/FilterBuilder';
 import { useFilterPreview } from '../../hooks/useFilterPreview';
@@ -254,6 +254,19 @@ export default function ScriptExecutionModal({
                 ? t('scriptExecutionModal.runAs.systemDescription')
                 : t('scriptExecutionModal.runAs.userDescription')}
             </p>
+            {/* Secrets ride an environment variable in the sealed command
+                envelope, which the user-context helper IPC cannot carry, so the
+                server refuses the run per device (#3409 PR4c-2). Advisory only:
+                the operator may still submit and get that same message back per
+                device — this just says it before the round trip. */}
+            {runAs === 'user' && hasSecretParameters(script.parameters) && (
+              <p
+                data-testid="script-secrets-require-system"
+                className="text-xs text-amber-600 dark:text-amber-500"
+              >
+                {t('scriptExecutionModal.secretsRequireSystem')}
+              </p>
+            )}
           </div>
 
           {/* Parameters — shown whenever the script HAS parameters, bound or

--- a/apps/web/src/components/scripts/ScriptExecutionModal.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 import { Dialog } from '../shared/Dialog';
 import ProgressBar, { ProgressItemList, type ProgressItem } from '../shared/ProgressBar';
 import type { Script } from './ScriptList';
-import { hasSecretParameters, runtimeParameters, type ScriptParameter } from './ScriptFormSchema';
+import { hasSecretParameters, runtimeParameters, secretsBlockedForRun, type ScriptParameter } from './ScriptFormSchema';
 import type { FilterConditionGroup } from '@breeze/shared';
 import { FilterBuilder, DEFAULT_FILTER_FIELDS } from '../filters/FilterBuilder';
 import { useFilterPreview } from '../../hooks/useFilterPreview';
@@ -256,15 +256,18 @@ export default function ScriptExecutionModal({
             </p>
             {/* Secrets ride an environment variable in the sealed command
                 envelope, which the user-context helper IPC cannot carry, so the
-                server refuses the run per device (#3409 PR4c-2). Advisory only:
-                the operator may still submit and get that same message back per
+                server refuses the run per device (#3409 PR4c-2). The full rule
+                lives in `secretsBlockedForRun` — this surface targets no
+                session today, but reading the shared predicate is what keeps
+                the wording honest if it ever gains one. Advisory only: the
+                operator may still submit and get that same message back per
                 device — this just says it before the round trip. */}
-            {runAs === 'user' && hasSecretParameters(script.parameters) && (
+            {hasSecretParameters(script.parameters) && secretsBlockedForRun({ runAs }) && (
               <p
                 data-testid="script-secrets-require-system"
                 className="text-xs text-amber-600 dark:text-amber-500"
               >
-                {t('scriptExecutionModal.secretsRequireSystem')}
+                {t('secretParameters.requiresSystemContext')}
               </p>
             )}
           </div>

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -546,6 +546,167 @@ describe('ScriptForm sourced parameters', () => {
     expect(screen.getByText('device.hostname')).toBeInTheDocument();
   });
 
+  // #3409 PR4c-2: the fifth arm — a SECRET tenant variable, delivered to the
+  // agent only as an environment variable.
+  it('renders the secret binding field and its env-var hint, and hides value-bearing fields', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [{ name: 'api_token', source: 'tenantSecret', variableKey: 'api_password' }],
+        }}
+      />
+    );
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    const hint = await screen.findByTestId('script-parameter-secret-hint');
+    expect(hint).toHaveTextContent('BREEZE_VAR_API_TOKEN');
+    expect(screen.getByPlaceholderText('e.g. vendor_token')).toBeInTheDocument();
+    // A secret parameter is always required, always a string, and can carry no
+    // default — the API rejects any of those, so the form must not offer them.
+    expect(screen.queryByPlaceholderText('Default')).toBeNull();
+    expect(screen.queryByText('Required')).toBeNull();
+    // The plain-mode "this is a secret, the save will be rejected" warning must
+    // NOT fire here — a secret is exactly what this arm wants.
+    expect(screen.queryByTestId('script-parameter-secret-warning')).toBeNull();
+    expect(screen.queryByTestId('script-parameter-not-secret-warning')).toBeNull();
+  });
+
+  it('falls back to a placeholder env name while the parameter name is blank', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [{ name: '', source: 'tenantSecret', variableKey: '' }],
+        }}
+      />
+    );
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    expect(await screen.findByTestId('script-parameter-secret-hint')).toHaveTextContent('BREEZE_VAR_NAME');
+  });
+
+  it('warns when a secret parameter is bound to a variable that is NOT a secret', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [{ name: 'api_token', source: 'tenantSecret', variableKey: 'vendor_token' }],
+        }}
+      />
+    );
+
+    const warning = await screen.findByTestId('script-parameter-not-secret-warning');
+    expect(warning).toHaveTextContent(/vendor_token/);
+    expect(warning).toHaveTextContent(/not a secret/i);
+  });
+
+  it('inverts the picker in secret mode: secrets selectable, plain variables disabled', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [{ name: 'api_token', source: 'tenantSecret', variableKey: '' }],
+        }}
+      />
+    );
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    fireEvent.click(screen.getByTitle('Choose a variable'));
+    const plainRow = await screen.findByRole('menuitem', { name: /Vendor portal token/i });
+    expect(plainRow).toBeDisabled();
+    expect(plainRow).toHaveTextContent('Not a secret');
+
+    const secretRow = await screen.findByRole('menuitem', { name: /Vendor API password/i });
+    expect(secretRow).not.toBeDisabled();
+    fireEvent.click(secretRow);
+    const keyInput = screen.getByPlaceholderText('e.g. vendor_token') as HTMLInputElement;
+    await waitFor(() => expect(keyInput.value).toBe('api_password'));
+  });
+
+  it('clears the abandoned key and the secret-only fields when switching off tenantSecret', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [{ name: 'api_token', source: 'tenantSecret', variableKey: 'api_password' }],
+        }}
+      />
+    );
+
+    await screen.findByTestId('script-parameter-secret-hint');
+    fireEvent.change(screen.getByLabelText('Source for parameter 1'), {
+      target: { value: 'tenantVariable' },
+    });
+
+    expect(screen.queryByTestId('script-parameter-secret-hint')).toBeNull();
+    expect((screen.getByPlaceholderText('e.g. vendor_token') as HTMLInputElement).value).toBe('');
+    // The value-bearing fields come back for a non-secret arm.
+    expect(screen.getByPlaceholderText('Default')).toBeInTheDocument();
+  });
+
+  it('clears a runtime row\'s default and options when it becomes a secret parameter', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [{ name: 'api_token', type: 'select', defaultValue: 'a', options: 'a,b' }],
+        }}
+      />
+    );
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    fireEvent.change(screen.getByLabelText('Source for parameter 1'), {
+      target: { value: 'tenantSecret' },
+    });
+    await screen.findByTestId('script-parameter-secret-hint');
+
+    // Switching back proves the values were cleared rather than merely hidden —
+    // a stray `defaultValue: 'a'` would 400 at save.
+    fireEvent.change(screen.getByLabelText('Source for parameter 1'), {
+      target: { value: 'runtime' },
+    });
+    expect((screen.getByPlaceholderText('Default') as HTMLInputElement).value).toBe('');
+    // `type` is forced to `string` for a secret, so the options input (which only
+    // renders for `select`) is gone — its stored value was cleared with it.
+    expect(screen.queryByPlaceholderText('option1, option2, option3')).toBeNull();
+  });
+
+  it('submits a secret row without the seeded default/options the API would 400', async () => {
+    const onSubmit = vi.fn();
+    render(
+      <ScriptForm
+        isNew
+        onSubmit={onSubmit}
+        defaultValues={{ ...draft, parameters: [{ name: 'api_token', type: 'string' }] }}
+      />
+    );
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    fireEvent.change(screen.getByLabelText('Source for parameter 1'), {
+      target: { value: 'tenantSecret' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('e.g. vendor_token'), {
+      target: { value: 'api_password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save script/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0].parameters[0]).toEqual({
+      name: 'api_token',
+      source: 'tenantSecret',
+      variableKey: 'api_password',
+      type: 'string',
+      required: true,
+    });
+  });
+
   it('clears the previous arm\'s binding key when the source changes', async () => {
     render(
       <ScriptForm

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -18,7 +18,7 @@ import type { EditorProps } from '@monaco-editor/react';
 // static bundle (see lib/monacoLoader.ts).
 import 'monaco-editor/min/vs/editor/editor.main.css';
 
-import { SCRIPT_BUILTIN_PARAMETER_KEYS, SCRIPT_PARAMETER_SOURCES } from '@breeze/shared';
+import { SCRIPT_BUILTIN_PARAMETER_KEYS, SCRIPT_PARAMETER_SOURCES, scriptSecretEnvName } from '@breeze/shared';
 import ScriptAiPanel from './ScriptAiPanel';
 import ScriptTestRunner from './ScriptTestRunner';
 import CollapsibleSection from './CollapsibleSection';
@@ -36,25 +36,37 @@ import { getJwtClaims } from '@/lib/authScope';
 import {
   scriptSchema, languageOptions, categoryOptions,
   runAsOptions, parameterTypeOptions, severityOptions,
-  rowsToMapping, parameterBindingKey, parameterSource,
+  rowsToMapping, parameterBindingKey, parameterSource, stripSecretParameterValueFields,
   type ScriptFormDefaults, type ScriptFormValues, type ScriptSubmitValues,
 } from './ScriptFormSchema';
 
 export type { ScriptFormValues, ScriptParameter, ScriptSubmitValues } from './ScriptFormSchema';
 
 /**
- * The `tenantVariable` binding cell: a free-text key plus the shared picker.
+ * The variable-binding cell: a free-text key plus the shared picker.
  *
- * Its own component purely so the secret warning can own a `useId` — the row
- * lives inside a `.map`, where a hook cannot be called, and a single shared id
- * would mean two parameters bound to two different secrets announce only one of
- * them (the same rule `VariableInput` follows for its two warning paragraphs).
+ * Serves BOTH variable-backed arms, and the two are exact mirrors of each other
+ * (#3409 PR4c-2):
+ *
+ * - `mode="plain"` (`source: 'tenantVariable'`) wants a NON-secret; picking a
+ *   secret is refused by the API at save.
+ * - `mode="secret"` (`source: 'tenantSecret'`) wants a SECRET; the value is
+ *   never substituted into the script, it reaches the agent only as
+ *   `BREEZE_VAR_<UPPER(name)>`, so a plain variable there is the error.
+ *
+ * One component rather than two so the picker predicate, the typed-key warning
+ * and the field chrome cannot drift apart between the arms.
+ *
+ * Its own component purely so the warning can own a `useId` — the row lives
+ * inside a `.map`, where a hook cannot be called, and a single shared id would
+ * mean two parameters bound to two different secrets announce only one of them
+ * (the same rule `VariableInput` follows for its two warning paragraphs).
  *
  * The warning is deliberately advisory rather than a submit gate: the API
- * rejects a secret binding with a 400 at save, so the point here is to say so
- * BEFORE the round trip, not to re-implement the rule. Typing a key by hand is
- * still allowed — the picker disables secret rows, but a key can also be
- * classified secret after the script was authored.
+ * rejects a mismatched binding with a 400 at save, so the point here is to say
+ * so BEFORE the round trip, not to re-implement the rule. Typing a key by hand
+ * is still allowed — the picker disables the wrong rows, but a key can also be
+ * re-classified after the script was authored.
  */
 function TenantVariableBindingField({
   registration,
@@ -62,16 +74,28 @@ function TenantVariableBindingField({
   variables,
   onPick,
   error,
+  mode = 'plain',
+  parameterName = '',
 }: {
   registration: UseFormRegisterReturn;
   value: string;
   variables: TenantVariableEntry[];
   onPick: (key: string) => void;
   error?: string;
+  mode?: 'plain' | 'secret';
+  parameterName?: string;
 }) {
   const { t } = useTranslation('scripts');
   const warnId = useId();
-  const isSecret = variables.some(v => v.key === value && v.isSecret);
+  const secretMode = mode === 'secret';
+  const matched = variables.find(v => v.key === value);
+  // Only a KNOWN variable can be judged: an unknown key is a legitimate
+  // mid-typing state (and, for partner-wide scripts, a key that exists in
+  // another org), so it warns about nothing.
+  const mismatch = secretMode ? !!value && matched !== undefined && !matched.isSecret : !!matched?.isSecret;
+  const warningTestId = secretMode
+    ? 'script-parameter-not-secret-warning'
+    : 'script-parameter-secret-warning';
 
   return (
     <div className="space-y-1 sm:col-span-2">
@@ -82,11 +106,11 @@ function TenantVariableBindingField({
         <input
           {...registration}
           placeholder={t('scriptForm.parameterBinding.variablePlaceholder')}
-          aria-invalid={isSecret || undefined}
-          aria-describedby={isSecret ? warnId : undefined}
+          aria-invalid={mismatch || undefined}
+          aria-describedby={mismatch ? warnId : undefined}
           className={cn(
             'h-9 min-w-0 flex-1 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring',
-            isSecret && 'border-destructive/60 focus:ring-destructive/40'
+            mismatch && 'border-destructive/60 focus:ring-destructive/40'
           )}
         />
         <TenantVariableMenu
@@ -96,19 +120,41 @@ function TenantVariableBindingField({
           // the key itself — showing `{{var.key}}` here would advertise a shape
           // this field must not contain.
           formatDetail={key => key}
+          selectable={secretMode ? v => v.isSecret : undefined}
+          disabledReason={
+            secretMode
+              ? v => (v.isSecret ? undefined : t('scriptForm.parameterBinding.notSecretRow'))
+              : undefined
+          }
           trigger={<Braces className="h-3.5 w-3.5" />}
           triggerTitle={t('scriptForm.parameterBinding.chooseTitle')}
           triggerClassName="h-9 shrink-0 bg-background px-3"
         />
       </div>
-      {isSecret && (
+      {mismatch && (
         <p
           id={warnId}
-          data-testid="script-parameter-secret-warning"
+          data-testid={warningTestId}
           className="flex items-start gap-1.5 text-xs text-destructive"
         >
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-          <span>{t('scriptForm.parameterBinding.secretRejected', { key: value })}</span>
+          <span>
+            {secretMode
+              ? t('scriptForm.parameterBinding.notSecret', { key: value })
+              : t('scriptForm.parameterBinding.secretRejected', { key: value })}
+          </span>
+        </p>
+      )}
+      {secretMode && (
+        <p
+          data-testid="script-parameter-secret-hint"
+          className="text-xs text-muted-foreground"
+        >
+          {t('scriptForm.parameterBinding.secretHint', {
+            // `name` is the env-var key, so the hint is only accurate once the
+            // row is named; until then it shows the shape, not a real name.
+            env: scriptSecretEnvName(parameterName || 'name'),
+          })}
         </p>
       )}
       {error && <p className="text-xs text-destructive">{error}</p>}
@@ -243,7 +289,17 @@ export default function ScriptForm({
     reset,
     formState: { errors, isSubmitting, isDirty }
   } = useForm<ScriptFormValues>({
-    resolver: zodResolver(scriptSchema) as never,
+    // Sanitized on the way in: a row switched to `tenantSecret` still carries
+    // the runtime seed's `defaultValue: ''` / `options: ''` in form state (RHF
+    // keeps values of unmounted inputs), and the secret arm rejects a PRESENT
+    // default outright. The sanitized object is also what `handleSubmit`
+    // forwards, so nothing empty reaches the API.
+    resolver: ((values: ScriptFormValues, context: unknown, options: unknown) =>
+      (zodResolver(scriptSchema) as never as (
+        v: ScriptFormValues,
+        c: unknown,
+        o: unknown
+      ) => unknown)(stripSecretParameterValueFields(values), context, options)) as never,
     mode: 'onTouched',
     defaultValues: {
       name: '',
@@ -472,7 +528,7 @@ export default function ScriptForm({
    * on the value it visually displays rather than on an empty non-option.
    */
   const handleParameterSourceChange = (index: number, next: string) => {
-    const set = (field: string, value: string | undefined) => {
+    const set = (field: string, value: unknown) => {
       setValue(
         `parameters.${index}.${field}` as unknown as keyof ScriptFormValues,
         value as never,
@@ -480,9 +536,24 @@ export default function ScriptForm({
       );
     };
     set('source', next);
+    // Both variable-backed arms store the key under `variableKey`, so switching
+    // between them must clear it too — a secret key left behind on the plain arm
+    // (or the reverse) is exactly the mismatch the API 400s.
     set('variableKey', '');
     set('fieldKey', '');
     set('builtinKey', next === 'builtin' ? SCRIPT_BUILTIN_PARAMETER_KEYS[0] : '');
+    if (next === 'tenantSecret') {
+      // The secret arm is `{type:'string', required:true}` with NO defaultValue
+      // and NO options — the inputs are cleared here so switching back does not
+      // resurrect an abandoned value; `stripSecretParameterValueFields` is what
+      // keeps the resulting `''` out of the schema and off the wire. `required` is not reset when switching away: `true`
+      // is a legitimate value on every other arm, and clobbering it would throw
+      // away an intentional choice.
+      set('type', 'string');
+      set('required', true);
+      set('defaultValue', '');
+      set('options', '');
+    }
   };
 
   /**
@@ -800,6 +871,11 @@ export default function ScriptForm({
             const row = watchParameters?.[index];
             const source = row ? parameterSource(row) : 'runtime';
             const isBound = source !== 'runtime';
+            // A secret parameter's type/required/default are fixed by the
+            // schema, so the inputs that would edit them are not rendered —
+            // offering a control whose every non-default value is a 400 is
+            // worse than not offering it.
+            const isSecretParam = source === 'tenantSecret';
             return (
             <div key={field.id} className="rounded-md border bg-muted/20 p-4">
               <div className="flex items-start gap-3">
@@ -826,12 +902,14 @@ export default function ScriptForm({
                       {SCRIPT_PARAMETER_SOURCES.map(value => <option key={value} value={value}>{parameterSourceLabel(value)}</option>)}
                     </select>
                   </div>
-                  {source === 'tenantVariable' && (
+                  {(source === 'tenantVariable' || isSecretParam) && (
                     <TenantVariableBindingField
                       registration={register(`parameters.${index}.variableKey` as unknown as keyof ScriptFormValues)}
                       value={(row && parameterBindingKey(row)) || ''}
                       variables={tenantVariables}
                       error={parameterFieldError(index, 'variableKey')}
+                      mode={isSecretParam ? 'secret' : 'plain'}
+                      parameterName={row?.name ?? ''}
                       onPick={key => setValue(
                         `parameters.${index}.variableKey` as unknown as keyof ScriptFormValues,
                         key as never,
@@ -862,22 +940,27 @@ export default function ScriptForm({
                       {parameterFieldError(index, 'builtinKey') && <p className="text-xs text-destructive">{parameterFieldError(index, 'builtinKey')}</p>}
                     </div>
                   )}
+                  {!isSecretParam && (
                   <div className="space-y-1">
                     <label className="text-xs font-medium text-muted-foreground">{t('common:labels.type')}</label>
                     <select className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring" {...register(`parameters.${index}.type`)}>
                       {parameterTypeOptions.map(opt => <option key={opt.value} value={opt.value}>{parameterTypeLabel(opt.value)}</option>)}
                     </select>
                   </div>
+                  )}
                   {/* Bound parameters keep a default — resolution is
                       `resolved value -> definition default -> missing` — but it
                       is a fallback, not a prefilled answer, so it is labelled as
                       one. */}
+                  {!isSecretParam && (
                   <div className="space-y-1">
                     <label className="text-xs font-medium text-muted-foreground">
                       {isBound ? t('scriptForm.fields.fallbackValue') : t('scriptForm.fields.defaultValue')}
                     </label>
                     <input placeholder={t('scriptForm.placeholders.defaultValue')} className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring" {...register(`parameters.${index}.defaultValue`)} />
                   </div>
+                  )}
+                  {!isSecretParam && (
                   <div className="space-y-1">
                     <label className="text-xs font-medium text-muted-foreground">{t('common:labels.required')}</label>
                     <div className="flex items-center h-9">
@@ -885,10 +968,11 @@ export default function ScriptForm({
                       <span className="ml-2 text-sm">{t('common:labels.yes')}</span>
                     </div>
                   </div>
+                  )}
                   {/* `options` renders the run-time `<select>`. A bound parameter
                       is never prompted for, so a choice list has nothing to
                       drive and is hidden rather than silently ignored. */}
-                  {!isBound && row?.type === 'select' && (
+                  {!isBound && !isSecretParam && row?.type === 'select' && (
                     <div className="space-y-1 sm:col-span-2 md:col-span-4">
                       <label className="text-xs font-medium text-muted-foreground">{t('scriptForm.fields.options')}</label>
                       <input placeholder={t('scriptForm.placeholders.options')} className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring" {...register(`parameters.${index}.options`)} />

--- a/apps/web/src/components/scripts/ScriptFormSchema.test.ts
+++ b/apps/web/src/components/scripts/ScriptFormSchema.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
+  hasSecretParameters,
+  stripSecretParameterValueFields,
   mappingToRows,
+  parameterBindingKey,
   rowsToMapping,
+  runtimeParameters,
   scriptSchema,
   SUPPRESS_SEVERITY,
   type ExitCodeSeverityMapping,
   type ExitCodeSeverityRow,
+  type ScriptParameter,
 } from './ScriptFormSchema';
 
 describe('rowsToMapping / mappingToRows', () => {
@@ -77,5 +82,115 @@ describe('scriptSchema timeoutSeconds', () => {
       const issue = result.error.issues.find((i) => i.path[0] === 'timeoutSeconds');
       expect(issue?.message).toBe('Timeout cannot exceed 1 hour (3600 seconds)');
     }
+  });
+});
+
+// #3409 PR4c-2: a parameter can declare a SECRET tenant variable, delivered to
+// the agent only as `BREEZE_VAR_<NAME>` — never substituted into the script.
+describe('tenantSecret parameters', () => {
+  const secretRow: ScriptParameter = {
+    name: 'api_token',
+    source: 'tenantSecret',
+    variableKey: 'vendor_password',
+  };
+
+  it('reports the bound variable key so run surfaces can name it', () => {
+    expect(parameterBindingKey(secretRow)).toBe('vendor_password');
+  });
+
+  it('returns null for a secret row whose key has not been chosen yet', () => {
+    expect(parameterBindingKey({ ...secretRow, variableKey: '' })).toBeNull();
+  });
+
+  it('never prompts for a secret parameter — it is bound, not runtime', () => {
+    expect(runtimeParameters([secretRow, { name: 'msg', type: 'string' }]).map(p => p.name)).toEqual(['msg']);
+  });
+
+  it('detects secret parameters in a list', () => {
+    expect(hasSecretParameters([secretRow])).toBe(true);
+    expect(hasSecretParameters([{ name: 'msg', type: 'string' }])).toBe(false);
+    expect(hasSecretParameters(undefined)).toBe(false);
+    expect(
+      hasSecretParameters([{ name: 'a', type: 'string', source: 'tenantVariable', variableKey: 'k' }])
+    ).toBe(false);
+  });
+
+  it('accepts a secret parameter through the form schema', () => {
+    const result = scriptSchema.safeParse({
+      name: 'S',
+      category: 'Custom',
+      language: 'powershell',
+      osTypes: ['windows'],
+      content: 'echo hi',
+      timeoutSeconds: 300,
+      runAs: 'system',
+      parameters: [secretRow],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const parsed = result.data.parameters?.[0];
+      expect(parsed).toMatchObject({ source: 'tenantSecret', type: 'string', required: true });
+    }
+  });
+
+  it('rejects an upper-case secret parameter name under `name` (it is the env-var key)', () => {
+    const result = scriptSchema.safeParse({
+      name: 'S',
+      category: 'Custom',
+      language: 'powershell',
+      osTypes: ['windows'],
+      content: 'echo hi',
+      timeoutSeconds: 300,
+      runAs: 'system',
+      parameters: [{ ...secretRow, name: 'API_TOKEN' }],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(i => i.path.join('.') === 'parameters.0.name')).toBe(true);
+    }
+  });
+
+  it('rejects a default value on a secret parameter — that would be a plaintext credential', () => {
+    const result = scriptSchema.safeParse({
+      name: 'S',
+      category: 'Custom',
+      language: 'powershell',
+      osTypes: ['windows'],
+      content: 'echo hi',
+      timeoutSeconds: 300,
+      runAs: 'system',
+      parameters: [{ ...secretRow, defaultValue: 'hunter2' }],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('stripSecretParameterValueFields', () => {
+  it('drops the seeded empty default/options and pins type + required on a secret row', () => {
+    const out = stripSecretParameterValueFields({
+      name: 'S',
+      parameters: [
+        { name: 'api_token', source: 'tenantSecret', variableKey: 'k', type: 'select', defaultValue: '', options: '', required: false },
+      ],
+    });
+    expect(out.parameters[0]).toEqual({
+      name: 'api_token',
+      source: 'tenantSecret',
+      variableKey: 'k',
+      type: 'string',
+      required: true,
+    });
+  });
+
+  it('leaves every other arm untouched, object identity included', () => {
+    const values = {
+      parameters: [{ name: 'msg', type: 'string', defaultValue: '', options: '', required: false }],
+    };
+    expect(stripSecretParameterValueFields(values)).toBe(values);
+  });
+
+  it('tolerates values with no parameters at all', () => {
+    const values = { name: 'S' };
+    expect(stripSecretParameterValueFields(values)).toBe(values);
   });
 });

--- a/apps/web/src/components/scripts/ScriptFormSchema.test.ts
+++ b/apps/web/src/components/scripts/ScriptFormSchema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   hasSecretParameters,
+  secretsBlockedForRun,
   stripSecretParameterValueFields,
   mappingToRows,
   parameterBindingKey,
@@ -192,5 +193,28 @@ describe('stripSecretParameterValueFields', () => {
   it('tolerates values with no parameters at all', () => {
     const values = { name: 'S' };
     expect(stripSecretParameterValueFields(values)).toBe(values);
+  });
+});
+
+// #3409 PR4c-2: the web-side mirror of the server's `runAsSupportsSecretEnv`
+// (apps/api/src/services/scriptSecretDelivery.ts). Both halves of the rule
+// matter — a targeted session is refused even under `system`.
+describe('secretsBlockedForRun', () => {
+  it('allows an untargeted system or elevated run', () => {
+    expect(secretsBlockedForRun({ runAs: 'system' })).toBe(false);
+    expect(secretsBlockedForRun({ runAs: 'elevated' })).toBe(false);
+    expect(secretsBlockedForRun({ runAs: 'system', targetSessionId: null })).toBe(false);
+    // Unset run-as defaults to the service context server-side.
+    expect(secretsBlockedForRun({})).toBe(false);
+  });
+
+  it('blocks a user-context run', () => {
+    expect(secretsBlockedForRun({ runAs: 'user' })).toBe(true);
+  });
+
+  it('blocks ANY targeted session, including session 0, even under system', () => {
+    expect(secretsBlockedForRun({ runAs: 'system', targetSessionId: 3 })).toBe(true);
+    expect(secretsBlockedForRun({ runAs: 'system', targetSessionId: 0 })).toBe(true);
+    expect(secretsBlockedForRun({ targetSessionId: 1 })).toBe(true);
   });
 });

--- a/apps/web/src/components/scripts/ScriptFormSchema.ts
+++ b/apps/web/src/components/scripts/ScriptFormSchema.ts
@@ -168,6 +168,36 @@ export function hasSecretParameters(parameters: readonly ScriptParameter[] | und
 }
 
 /**
+ * Would the server refuse to deliver a secret for a run with this context
+ * (#3409 PR4c-2)?
+ *
+ * The ONE web-side mirror of `runAsSupportsSecretEnv`
+ * (`apps/api/src/services/scriptSecretDelivery.ts`), which itself mirrors the
+ * agent's `runAsSupportsSecrets`: the secret rides an environment variable in
+ * the sealed command envelope, and a user-context run OR a run aimed at a
+ * specific session is executed through the helper IPC, which carries no
+ * environment. `elevated` and an unset run-as both run under the service, so
+ * both are fine.
+ *
+ * Both halves matter, and a surface that states only the run-as half tells the
+ * operator a half-truth — hence one shared predicate rather than a per-modal
+ * `runAs === 'user'` check that a surface gaining a session picker would
+ * silently inherit.
+ *
+ * ADVISORY ONLY. The server gate is authoritative; no run surface may block on
+ * this.
+ */
+export function secretsBlockedForRun(run: {
+  runAs?: 'system' | 'user' | 'elevated' | null;
+  targetSessionId?: number | null;
+}): boolean {
+  // `!= null` on purpose: session 0 is a real Windows session id, so a
+  // truthiness check would silently allow the one case the server refuses.
+  if (run.targetSessionId != null) return true;
+  return run.runAs === 'user';
+}
+
+/**
  * Drop the fields a `tenantSecret` row may not carry, and force the two the
  * schema pins (#3409 PR4c-2).
  *

--- a/apps/web/src/components/scripts/ScriptFormSchema.ts
+++ b/apps/web/src/components/scripts/ScriptFormSchema.ts
@@ -141,9 +141,63 @@ export function parameterBindingKey(parameter: ScriptParameter): string | null {
       return parameter.fieldKey || null;
     case 'builtin':
       return parameter.builtinKey || null;
+    // A secret parameter names the variable it binds, exactly like the plain
+    // `tenantVariable` arm — the KEY is not sensitive, only the value is, and
+    // the run surfaces have to be able to say what will be injected.
+    case 'tenantSecret':
+      return parameter.variableKey || null;
     default:
       return null;
   }
+}
+
+/**
+ * Is this parameter delivered as a SECRET environment variable (#3409 PR4c-2)?
+ *
+ * Secrets ride `BREEZE_VAR_<NAME>` in the sealed envelope, which the user-context
+ * helper IPC cannot carry — so run surfaces have to know a script contains one
+ * before the operator picks a run context.
+ */
+export function isSecretParameter(parameter: ScriptParameter): boolean {
+  return parameterSource(parameter) === 'tenantSecret';
+}
+
+/** Does this parameter list contain at least one secret-backed parameter? */
+export function hasSecretParameters(parameters: readonly ScriptParameter[] | undefined): boolean {
+  return (parameters ?? []).some(isSecretParameter);
+}
+
+/**
+ * Drop the fields a `tenantSecret` row may not carry, and force the two the
+ * schema pins (#3409 PR4c-2).
+ *
+ * The authoring form seeds every new parameter row with `defaultValue: ''` and
+ * `options: ''`, and RHF keeps a field's value when its input unmounts. An
+ * empty string is a PRESENT value, and the secret arm rejects a present
+ * `defaultValue`/`options` outright ("A secret parameter cannot carry a default
+ * value") — so a row switched to `tenantSecret` would fail validation on data
+ * the user never typed and can no longer see. Sanitizing on the way INTO the
+ * resolver fixes both halves at once: validation sees the real contract, and
+ * the sanitized object is what `handleSubmit` hands the caller, so no empty
+ * string reaches the API either.
+ *
+ * Deliberately not a schema `.transform()`: the same normalization has to apply
+ * before the union picks an arm, and a transform runs after.
+ */
+export function stripSecretParameterValueFields<T>(values: T): T {
+  const record = values as { parameters?: unknown } | null;
+  const parameters = record?.parameters;
+  if (!Array.isArray(parameters)) return values;
+  let changed = false;
+  const next = parameters.map(parameter => {
+    const row = parameter as Record<string, unknown> | null;
+    if (!row || row.source !== 'tenantSecret') return parameter;
+    changed = true;
+    const { defaultValue: _default, options: _options, ...rest } = row;
+    return { ...rest, type: 'string', required: true };
+  });
+  if (!changed) return values;
+  return { ...(record as object), parameters: next } as T;
 }
 
 // Wire shape sent to / received from the API. Form-side editing keeps an

--- a/apps/web/src/components/scripts/ScriptParametersForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptParametersForm.test.tsx
@@ -170,6 +170,20 @@ describe('ScriptParametersForm rendering', () => {
     );
   });
 
+  it('renders a secret parameter as a locked chip with no input (#3409 PR4c-2)', () => {
+    const params: ScriptParameter[] = [
+      { name: 'api_token', source: 'tenantSecret', variableKey: 'vendor_password' },
+    ];
+    render(<ScriptParametersForm parameters={params} values={{}} onChange={vi.fn()} />);
+
+    const chip = screen.getByTestId('script-bound-parameter-api_token');
+    expect(chip).toHaveTextContent(
+      'Supplied securely from secret variable vendor_password as an environment variable'
+    );
+    expect(chip.querySelector('input')).toBeNull();
+    expect(screen.getByTestId('script-parameters-all-supplied')).toBeInTheDocument();
+  });
+
   it('still shows the section when every parameter is bound — the operator must see what gets injected', () => {
     const { container } = render(
       <ScriptParametersForm parameters={[boundVariable]} values={{}} onChange={vi.fn()} />

--- a/apps/web/src/components/scripts/ScriptTestRunner.test.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.test.tsx
@@ -156,6 +156,88 @@ describe('ScriptTestRunner', () => {
     expect(screen.getByText(/target/)).toBeInTheDocument();
   });
 
+  // #3409 PR4c-2: a `tenantSecret` row is forced `required: true` and the shared
+  // schema REJECTS a `defaultValue` on it, so gating Test Run on
+  // "required with no default" over the whole list locked the button forever and
+  // told the author to do something the schema forbids.
+  it('leaves test runs enabled when the only required parameter is a secret', async () => {
+    render(
+      <ScriptTestRunner
+        scriptId={SCRIPT_ID}
+        osTypes={['windows']}
+        parameters={[
+          { name: 'api_token', type: 'string', required: true, source: 'tenantSecret', variableKey: 'vendor_password' },
+        ]}
+        isDirty={false}
+        onSaveChanges={async () => true}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('test-box')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    expect(screen.getByTestId('test-run-button')).toBeEnabled();
+    expect(screen.queryByText(/Required parameters without defaults/i)).toBeNull();
+  });
+
+  it('leaves test runs enabled when a required parameter is bound to a tenant variable', async () => {
+    render(
+      <ScriptTestRunner
+        scriptId={SCRIPT_ID}
+        osTypes={['windows']}
+        parameters={[
+          { name: 'api_key', type: 'string', required: true, source: 'tenantVariable', variableKey: 'vendor_token' },
+        ]}
+        isDirty={false}
+        onSaveChanges={async () => true}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('test-box')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    expect(screen.getByTestId('test-run-button')).toBeEnabled();
+  });
+
+  // A bound parameter's `defaultValue` is the SERVER's fallback (resolved value
+  // -> definition default -> missing). Sending it as a runtime value would be
+  // ignored and reported back in `ignoredParameters`.
+  it('never submits a bound parameter as a runtime value', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.startsWith('/devices')) return jsonResponse({ data: [onlineDevice] });
+      if (url === `/scripts/${SCRIPT_ID}/execute` && init?.method === 'POST') {
+        return jsonResponse({ executions: [{ executionId: EXECUTION_ID, deviceId: DEVICE_ID }] }, 201);
+      }
+      if (url === `/scripts/executions/${EXECUTION_ID}`) {
+        return jsonResponse({ id: EXECUTION_ID, status: 'completed', exitCode: 0, stdout: '', stderr: '' });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    render(
+      <ScriptTestRunner
+        scriptId={SCRIPT_ID}
+        osTypes={['windows']}
+        parameters={[
+          { name: 'message', type: 'string', required: true, defaultValue: 'hello' },
+          { name: 'api_key', type: 'string', required: true, defaultValue: 'fallback', source: 'tenantVariable', variableKey: 'vendor_token' },
+          { name: 'org', type: 'string', required: true, defaultValue: 'seed', source: 'builtin', builtinKey: 'org.name' },
+        ]}
+        isDirty={false}
+        onSaveChanges={async () => true}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('test-box')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    fireEvent.click(screen.getByTestId('test-run-button'));
+
+    await waitFor(() => expect(
+      fetchWithAuthMock.mock.calls.some(([url]) => url === `/scripts/${SCRIPT_ID}/execute`)
+    ).toBe(true));
+    const executeCall = fetchWithAuthMock.mock.calls.find(([url]) => url === `/scripts/${SCRIPT_ID}/execute`);
+    const body = JSON.parse((executeCall![1] as RequestInit).body as string) as { parameters: Record<string, unknown> };
+    expect(body.parameters).toEqual({ message: 'hello' });
+  });
+
   it('treats a cancelled execution as terminal and shows its status', async () => {
     fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url.startsWith('/devices')) return jsonResponse({ data: [onlineDevice] });

--- a/apps/web/src/components/scripts/ScriptTestRunner.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.tsx
@@ -8,7 +8,7 @@ import { navigateTo } from '@/lib/navigation';
 import { asList } from '@/lib/asList';
 import { OutputSection } from './ExecutionDetails';
 import type { OSType } from './ScriptList';
-import type { ScriptParameter } from './ScriptFormSchema';
+import { runtimeParameters, type ScriptParameter } from './ScriptFormSchema';
 
 export type TestDevice = {
   id: string;
@@ -212,14 +212,24 @@ export default function ScriptTestRunner({
     onTestDeviceChange?.(deviceId || null);
   };
 
+  // Runtime parameters only (#3409 PR3/PR4c-2). A BOUND parameter is resolved
+  // per target device by the server, so a `required` one with no default is not
+  // missing anything the author can supply here — and a `tenantSecret` row is
+  // forced `required: true` with a `defaultValue` the shared schema REJECTS, so
+  // gating on the whole list disabled Test Run forever and asked the author for
+  // something the schema forbids.
   const missingRequiredParams = useMemo(
-    () => (parameters ?? []).filter(p => p.required && !p.defaultValue).map(p => p.name),
+    () => runtimeParameters(parameters).filter(p => p.required && !p.defaultValue).map(p => p.name),
     [parameters]
   );
 
+  // Same reason on the submit side: a bound parameter's `defaultValue` is the
+  // SERVER's fallback (resolved value -> definition default -> missing), so
+  // sending it as a runtime value would be ignored and reported back in
+  // `ignoredParameters`.
   const defaultParameters = useMemo(() => {
     const result: Record<string, string | number | boolean> = {};
-    for (const p of parameters ?? []) {
+    for (const p of runtimeParameters(parameters)) {
       if (p.defaultValue === undefined || p.defaultValue === '') continue;
       if (p.type === 'number') result[p.name] = Number(p.defaultValue);
       else if (p.type === 'boolean') result[p.name] = p.defaultValue === 'true';

--- a/apps/web/src/components/scripts/ScriptVariablePicker.test.tsx
+++ b/apps/web/src/components/scripts/ScriptVariablePicker.test.tsx
@@ -88,7 +88,9 @@ describe('ScriptVariablePicker', () => {
     openMenu();
     const secret = screen.getByRole('menuitem', { name: /Vendor API password/i });
     expect(secret).toBeDisabled();
-    expect(secret).toHaveTextContent(/environment variable/i);
+    // Copy changed in #3409 PR4c-2: a secret is no longer "not yet available",
+    // it is bound through a `tenantSecret` PARAMETER instead of a content token.
+    expect(secret).toHaveTextContent(/From a secret variable/i);
 
     fireEvent.click(secret);
     expect(editor.executeEdits).not.toHaveBeenCalled();

--- a/apps/web/src/components/scripts/TenantVariableMenu.tsx
+++ b/apps/web/src/components/scripts/TenantVariableMenu.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 import type { TenantVariableEntry } from '@/lib/tenantVariableTokens';
 
 export interface TenantVariableMenuProps {
-  /** Offerable variables; secrets render disabled (PR 4 delivers them out-of-band). */
+  /** Offerable variables. Selectability is decided by {@link selectable}. */
   variables: TenantVariableEntry[];
   /**
    * Receives the KEY, never a token. Callers that want `{{var.<key>}}` build it
@@ -19,6 +19,20 @@ export interface TenantVariableMenuProps {
    * is what the content editor inserts; the key picker passes identity.
    */
   formatDetail?: (key: string) => string;
+  /**
+   * Which rows can be picked. Defaults to "everything except a secret" — the
+   * content editor and the plain `tenantVariable` binding both reject secrets.
+   * The `tenantSecret` binding (#3409 PR4c-2) inverts it (`v => v.isSecret`),
+   * which is why this is a predicate rather than a boolean flag: exactly one
+   * rule decides both the `disabled` attribute and the reason line, so the two
+   * can never disagree.
+   */
+  selectable?: (variable: TenantVariableEntry) => boolean;
+  /**
+   * Secondary reason line for a row, rendered in amber. Defaults to the
+   * secret-unavailable copy for secret rows and nothing for the rest.
+   */
+  disabledReason?: (variable: TenantVariableEntry) => string | undefined;
   /** Trigger contents. Defaults to the Braces icon + the "Variables" label. */
   trigger?: ReactNode;
   triggerTitle?: string;
@@ -40,12 +54,18 @@ export default function TenantVariableMenu({
   variables,
   onSelect,
   formatDetail = variableToken,
+  selectable = variable => !variable.isSecret,
+  disabledReason,
   trigger,
   triggerTitle,
   triggerClassName,
 }: TenantVariableMenuProps) {
   const { t } = useTranslation('scripts');
   const [open, setOpen] = useState(false);
+  const reasonFor =
+    disabledReason ??
+    ((variable: TenantVariableEntry) =>
+      variable.isSecret ? t('scriptForm.variables.secretUnavailable') : undefined);
   const menuRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
@@ -107,32 +127,36 @@ export default function TenantVariableMenu({
               {t('scriptForm.variables.empty')}
             </p>
           ) : (
-            variables.map(v => (
-              <button
-                key={v.key}
-                type="button"
-                role="menuitem"
-                disabled={v.isSecret}
-                aria-disabled={v.isSecret || undefined}
-                onClick={() => {
-                  setOpen(false);
-                  onSelect(v.key);
-                }}
-                className="w-full rounded px-2 py-1.5 text-left hover:bg-muted focus:bg-muted focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:bg-transparent"
-              >
-                <span className="block truncate text-sm text-foreground">
-                  {v.description || v.key}
-                </span>
-                <span className="block truncate font-mono text-[11px] text-muted-foreground">
-                  {formatDetail(v.key)}
-                </span>
-                {v.isSecret && (
-                  <span className="mt-0.5 block text-[11px] text-amber-600 dark:text-amber-500">
-                    {t('scriptForm.variables.secretUnavailable')}
+            variables.map(v => {
+              const canSelect = selectable(v);
+              const reason = reasonFor(v);
+              return (
+                <button
+                  key={v.key}
+                  type="button"
+                  role="menuitem"
+                  disabled={!canSelect}
+                  aria-disabled={!canSelect || undefined}
+                  onClick={() => {
+                    setOpen(false);
+                    onSelect(v.key);
+                  }}
+                  className="w-full rounded px-2 py-1.5 text-left hover:bg-muted focus:bg-muted focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:bg-transparent"
+                >
+                  <span className="block truncate text-sm text-foreground">
+                    {v.description || v.key}
                   </span>
-                )}
-              </button>
-            ))
+                  <span className="block truncate font-mono text-[11px] text-muted-foreground">
+                    {formatDetail(v.key)}
+                  </span>
+                  {reason && (
+                    <span className="mt-0.5 block text-[11px] text-amber-600 dark:text-amber-500">
+                      {reason}
+                    </span>
+                  )}
+                </button>
+              );
+            })
           )}
         </div>
       )}

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -797,6 +797,7 @@
       "systemDescription": "Wird im Agentendienstkontext ausgeführt.",
       "userDescription": "Wird im Kontext des aktuell angemeldeten Benutzers ausgeführt, wenn ein Benutzerhelfer verbunden ist."
     },
+    "secretsRequireSystem": "Dieses Skript verwendet geheime Variablen, die nur an Ausführungen im Systemkontext übergeben werden. Unter „Angemeldeter Benutzer“ schlagen die Geräte mit „nicht ausgeführt“ fehl.",
     "sections": {
       "selectDevices": "Wählen Sie Geräte aus"
     },
@@ -998,14 +999,15 @@
       "button": "Variablen",
       "insertTitle": "Variable einfügen",
       "empty": "Noch keine Variablen.",
-      "secretUnavailable": "Geheim – wird erst in einer späteren Version als Umgebungsvariable übergeben.",
+      "secretUnavailable": "Geheim – binden Sie sie über einen Parameter mit der Quelle „Aus einer geheimen Variablen“ ein.",
       "unknown": "Für {{keys}} existiert keine Variable – die Ausführung schlägt auf jedem Zielgerät fehl, bis Sie sie anlegen."
     },
     "parameterSources": {
       "runtime": "Wird bei der Ausführung abgefragt",
       "tenantVariable": "Aus einer Variablen",
       "deviceCustomField": "Aus einem benutzerdefinierten Gerätefeld",
-      "builtin": "Aus einer Geräteeigenschaft"
+      "builtin": "Aus einer Geräteeigenschaft",
+      "tenantSecret": "Aus einer geheimen Variablen (Umgebungsvariable)"
     },
     "parameterBinding": {
       "variableLabel": "Variablenschlüssel",
@@ -1015,6 +1017,9 @@
       "builtinLabel": "Eigenschaft",
       "chooseTitle": "Variable auswählen",
       "secretRejected": "„{{key}}“ ist geheim – das Speichern wird abgelehnt. Wählen Sie eine Variable, die nicht geheim ist.",
+      "notSecret": "„{{key}}“ ist nicht geheim. Wählen Sie eine geheime Variable oder stellen Sie die Quelle auf „Aus einer Variablen“ um.",
+      "notSecretRow": "Nicht geheim – „Aus einer Variablen“ verwenden",
+      "secretHint": "Wird ausschließlich als Umgebungsvariable {{env}} übergeben – niemals in das Skript geschrieben. Erfordert die Ausführung im Systemkontext und einen Agenten, der die sichere Übergabe von Geheimnissen unterstützt.",
       "hint": "Wird bei der Ausführung für jedes Zielgerät aufgelöst – niemand wird danach gefragt."
     }
   },
@@ -1077,7 +1082,8 @@
     "suppliedBy": {
       "tenantVariable": "Wird automatisch aus der Variablen {{key}} übernommen",
       "deviceCustomField": "Wird automatisch aus dem benutzerdefinierten Gerätefeld {{key}} übernommen",
-      "builtin": "Wird automatisch aus {{key}} übernommen"
+      "builtin": "Wird automatisch aus {{key}} übernommen",
+      "tenantSecret": "Wird sicher aus der geheimen Variablen {{key}} als Umgebungsvariable übergeben"
     }
   },
   "scriptTagManager": {

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -797,7 +797,6 @@
       "systemDescription": "Wird im Agentendienstkontext ausgeführt.",
       "userDescription": "Wird im Kontext des aktuell angemeldeten Benutzers ausgeführt, wenn ein Benutzerhelfer verbunden ist."
     },
-    "secretsRequireSystem": "Dieses Skript verwendet geheime Variablen, die nur an Ausführungen im Systemkontext übergeben werden. Unter „Angemeldeter Benutzer“ schlagen die Geräte mit „nicht ausgeführt“ fehl.",
     "sections": {
       "selectDevices": "Wählen Sie Geräte aus"
     },
@@ -843,6 +842,9 @@
       "macos": "macOS",
       "linux": "Linux"
     }
+  },
+  "secretParameters": {
+    "requiresSystemContext": "Dieses Skript verwendet geheime Variablen, die nur an Ausführungen im Systemkontext ohne Sitzungsziel übergeben werden. Unter „Angemeldeter Benutzer“ oder bei einer bestimmten Zielsitzung schlagen die Geräte mit „nicht ausgeführt“ fehl."
   },
   "scriptExecutionsPage": {
     "errors": {

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -797,7 +797,6 @@
       "systemDescription": "Runs in the agent service context.",
       "userDescription": "Runs in the currently logged-in user context when a user helper is connected."
     },
-    "secretsRequireSystem": "This script uses secret variables, which are only delivered to system-context runs. Devices will fail with \"not executed\" under Run as user.",
     "sections": {
       "selectDevices": "Select Devices"
     },
@@ -843,6 +842,9 @@
       "macos": "macOS",
       "linux": "Linux"
     }
+  },
+  "secretParameters": {
+    "requiresSystemContext": "This script uses secret variables, which are only delivered to system-context runs with no session target. Devices will fail with \"not executed\" under Run as user, or when a specific session is targeted."
   },
   "scriptExecutionsPage": {
     "errors": {

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -797,6 +797,7 @@
       "systemDescription": "Runs in the agent service context.",
       "userDescription": "Runs in the currently logged-in user context when a user helper is connected."
     },
+    "secretsRequireSystem": "This script uses secret variables, which are only delivered to system-context runs. Devices will fail with \"not executed\" under Run as user.",
     "sections": {
       "selectDevices": "Select Devices"
     },
@@ -998,14 +999,15 @@
       "button": "Variables",
       "insertTitle": "Insert a variable",
       "empty": "No variables yet.",
-      "secretUnavailable": "Secret — a later release delivers it as an environment variable.",
+      "secretUnavailable": "Secret — bind it through a parameter with source \"From a secret variable\".",
       "unknown": "No variable exists for {{keys}} — targeted devices will fail until you create it."
     },
     "parameterSources": {
       "runtime": "Asked at run time",
       "tenantVariable": "From a variable",
       "deviceCustomField": "From a device custom field",
-      "builtin": "From a device property"
+      "builtin": "From a device property",
+      "tenantSecret": "From a secret variable (environment variable)"
     },
     "parameterBinding": {
       "variableLabel": "Variable key",
@@ -1015,6 +1017,9 @@
       "builtinLabel": "Property",
       "chooseTitle": "Choose a variable",
       "secretRejected": "\"{{key}}\" is a secret — the save will be rejected. Choose a variable that is not a secret.",
+      "notSecret": "\"{{key}}\" is not a secret. Choose a secret variable, or switch the source to \"From a variable\".",
+      "notSecretRow": "Not a secret — use \"From a variable\"",
+      "secretHint": "Delivered only as the environment variable {{env}} — never written into the script. Requires system-context execution and an agent that supports secure secret delivery.",
       "hint": "Resolved for every target device when the script runs — nobody is asked for it."
     }
   },
@@ -1077,7 +1082,8 @@
     "suppliedBy": {
       "tenantVariable": "Supplied automatically from variable {{key}}",
       "deviceCustomField": "Supplied automatically from device custom field {{key}}",
-      "builtin": "Supplied automatically from {{key}}"
+      "builtin": "Supplied automatically from {{key}}",
+      "tenantSecret": "Supplied securely from secret variable {{key}} as an environment variable"
     }
   },
   "scriptTagManager": {

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -797,7 +797,6 @@
       "systemDescription": "Se ejecuta en el contexto del servicio del agente.",
       "userDescription": "Se ejecuta en el contexto del usuario actualmente conectado cuando se conecta un ayudante de usuario."
     },
-    "secretsRequireSystem": "Este script usa variables secretas, que solo se entregan en ejecuciones con contexto de sistema. Con \"Usuario registrado\" los dispositivos fallarán con \"no ejecutado\".",
     "sections": {
       "selectDevices": "Seleccionar dispositivos"
     },
@@ -843,6 +842,9 @@
       "macos": "macOS",
       "linux": "Linux"
     }
+  },
+  "secretParameters": {
+    "requiresSystemContext": "Este script usa variables secretas, que solo se entregan en ejecuciones con contexto de sistema y sin sesión de destino. Con \"Usuario registrado\", o al elegir una sesión específica, los dispositivos fallarán con \"no ejecutado\"."
   },
   "scriptExecutionsPage": {
     "errors": {

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -797,6 +797,7 @@
       "systemDescription": "Se ejecuta en el contexto del servicio del agente.",
       "userDescription": "Se ejecuta en el contexto del usuario actualmente conectado cuando se conecta un ayudante de usuario."
     },
+    "secretsRequireSystem": "Este script usa variables secretas, que solo se entregan en ejecuciones con contexto de sistema. Con \"Usuario registrado\" los dispositivos fallarán con \"no ejecutado\".",
     "sections": {
       "selectDevices": "Seleccionar dispositivos"
     },
@@ -998,14 +999,15 @@
       "button": "Variables",
       "insertTitle": "Insertar una variable",
       "empty": "Aún no hay variables.",
-      "secretUnavailable": "Secreto: una versión posterior lo entregará como variable de entorno.",
+      "secretUnavailable": "Secreto: vincúlalo con un parámetro cuyo origen sea \"Desde una variable secreta\".",
       "unknown": "No existe ninguna variable para {{keys}}: los dispositivos seleccionados fallarán hasta que la crees."
     },
     "parameterSources": {
       "runtime": "Se pregunta al ejecutar",
       "tenantVariable": "Desde una variable",
       "deviceCustomField": "Desde un campo personalizado del dispositivo",
-      "builtin": "Desde una propiedad del dispositivo"
+      "builtin": "Desde una propiedad del dispositivo",
+      "tenantSecret": "Desde una variable secreta (variable de entorno)"
     },
     "parameterBinding": {
       "variableLabel": "Clave de la variable",
@@ -1015,6 +1017,9 @@
       "builtinLabel": "Propiedad",
       "chooseTitle": "Elegir una variable",
       "secretRejected": "\"{{key}}\" es secreta: se rechazará el guardado. Elige una variable que no sea secreta.",
+      "notSecret": "\"{{key}}\" no es secreta. Elige una variable secreta o cambia el origen a \"Desde una variable\".",
+      "notSecretRow": "No es secreta: usa \"Desde una variable\"",
+      "secretHint": "Se entrega únicamente como la variable de entorno {{env}}: nunca se escribe en el script. Requiere ejecución en contexto de sistema y un agente compatible con la entrega segura de secretos.",
       "hint": "Se resuelve para cada dispositivo de destino al ejecutar el script: nadie tiene que indicarlo."
     }
   },
@@ -1077,7 +1082,8 @@
     "suppliedBy": {
       "tenantVariable": "Se completa automáticamente desde la variable {{key}}",
       "deviceCustomField": "Se completa automáticamente desde el campo personalizado del dispositivo {{key}}",
-      "builtin": "Se completa automáticamente desde {{key}}"
+      "builtin": "Se completa automáticamente desde {{key}}",
+      "tenantSecret": "Se entrega de forma segura desde la variable secreta {{key}} como variable de entorno"
     }
   },
   "scriptTagManager": {

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -797,6 +797,7 @@
       "systemDescription": "S’exécute dans le contexte du service agent.",
       "userDescription": "S’exécute dans le contexte de l’utilisateur actuellement connecté lorsqu’un assistant utilisateur est connecté."
     },
+    "secretsRequireSystem": "Ce script utilise des variables secrètes, qui ne sont transmises qu’aux exécutions dans le contexte système. Avec « Utilisateur connecté », les appareils échoueront avec « non exécuté ».",
     "sections": {
       "selectDevices": "Sélectionner des appareils"
     },
@@ -998,14 +999,15 @@
       "button": "Variables",
       "insertTitle": "Insérer une variable",
       "empty": "Aucune variable pour l'instant.",
-      "secretUnavailable": "Secret — une version ultérieure la transmettra comme variable d'environnement.",
+      "secretUnavailable": "Secret — liez-le par un paramètre dont la source est « À partir d’une variable secrète ».",
       "unknown": "Aucune variable ne correspond à {{keys}} — les appareils ciblés échoueront tant qu'elle n'existe pas."
     },
     "parameterSources": {
       "runtime": "Demandé à l’exécution",
       "tenantVariable": "À partir d’une variable",
       "deviceCustomField": "À partir d’un champ personnalisé de l’appareil",
-      "builtin": "À partir d’une propriété de l’appareil"
+      "builtin": "À partir d’une propriété de l’appareil",
+      "tenantSecret": "À partir d’une variable secrète (variable d’environnement)"
     },
     "parameterBinding": {
       "variableLabel": "Clé de la variable",
@@ -1015,6 +1017,9 @@
       "builtinLabel": "Propriété",
       "chooseTitle": "Choisir une variable",
       "secretRejected": "« {{key}} » est un secret — l’enregistrement sera refusé. Choisissez une variable non secrète.",
+      "notSecret": "« {{key}} » n’est pas un secret. Choisissez une variable secrète ou changez la source pour « À partir d’une variable ».",
+      "notSecretRow": "Pas un secret — utilisez « À partir d’une variable »",
+      "secretHint": "Transmise uniquement comme variable d’environnement {{env}} — jamais écrite dans le script. Nécessite une exécution dans le contexte système et un agent prenant en charge la transmission sécurisée des secrets.",
       "hint": "Résolu pour chaque appareil ciblé au moment de l’exécution — personne n’a à le saisir."
     }
   },
@@ -1077,7 +1082,8 @@
     "suppliedBy": {
       "tenantVariable": "Fourni automatiquement par la variable {{key}}",
       "deviceCustomField": "Fourni automatiquement par le champ personnalisé de l’appareil {{key}}",
-      "builtin": "Fourni automatiquement par {{key}}"
+      "builtin": "Fourni automatiquement par {{key}}",
+      "tenantSecret": "Fourni de façon sécurisée par la variable secrète {{key}}, comme variable d’environnement"
     }
   },
   "scriptTagManager": {

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -797,7 +797,6 @@
       "systemDescription": "S’exécute dans le contexte du service agent.",
       "userDescription": "S’exécute dans le contexte de l’utilisateur actuellement connecté lorsqu’un assistant utilisateur est connecté."
     },
-    "secretsRequireSystem": "Ce script utilise des variables secrètes, qui ne sont transmises qu’aux exécutions dans le contexte système. Avec « Utilisateur connecté », les appareils échoueront avec « non exécuté ».",
     "sections": {
       "selectDevices": "Sélectionner des appareils"
     },
@@ -843,6 +842,9 @@
       "macos": "macOS",
       "linux": "Linux"
     }
+  },
+  "secretParameters": {
+    "requiresSystemContext": "Ce script utilise des variables secrètes, qui ne sont transmises qu’aux exécutions dans le contexte système sans session ciblée. Avec « Utilisateur connecté », ou lorsqu’une session précise est ciblée, les appareils échoueront avec « non exécuté »."
   },
   "scriptExecutionsPage": {
     "errors": {

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -797,6 +797,7 @@
       "systemDescription": "S’exécute dans le contexte du service agent.",
       "userDescription": "S’exécute dans le contexte de l’utilisateur actuellement connecté lorsqu’un assistant utilisateur est connecté."
     },
+    "secretsRequireSystem": "Ce script utilise des variables secrètes, qui ne sont transmises qu’aux exécutions dans le contexte système. Avec « Utilisateur connecté », les appareils échoueront avec « non exécuté ».",
     "sections": {
       "selectDevices": "Sélectionner des appareils"
     },
@@ -998,14 +999,15 @@
       "button": "Variables",
       "insertTitle": "Insérer une variable",
       "empty": "Aucune variable pour l'instant.",
-      "secretUnavailable": "Secret — une version ultérieure la transmettra comme variable d'environnement.",
+      "secretUnavailable": "Secret — liez-le par un paramètre dont la source est « À partir d’une variable secrète ».",
       "unknown": "Aucune variable ne correspond à {{keys}} — les appareils ciblés échoueront tant qu'elle n'existe pas."
     },
     "parameterSources": {
       "runtime": "Demandé à l’exécution",
       "tenantVariable": "À partir d’une variable",
       "deviceCustomField": "À partir d’un champ personnalisé de l’appareil",
-      "builtin": "À partir d’une propriété de l’appareil"
+      "builtin": "À partir d’une propriété de l’appareil",
+      "tenantSecret": "À partir d’une variable secrète (variable d’environnement)"
     },
     "parameterBinding": {
       "variableLabel": "Clé de la variable",
@@ -1015,6 +1017,9 @@
       "builtinLabel": "Propriété",
       "chooseTitle": "Choisir une variable",
       "secretRejected": "« {{key}} » est un secret — l’enregistrement sera refusé. Choisissez une variable non secrète.",
+      "notSecret": "« {{key}} » n’est pas un secret. Choisissez une variable secrète ou changez la source pour « À partir d’une variable ».",
+      "notSecretRow": "Pas un secret — utilisez « À partir d’une variable »",
+      "secretHint": "Transmise uniquement comme variable d’environnement {{env}} — jamais écrite dans le script. Nécessite une exécution dans le contexte système et un agent prenant en charge la transmission sécurisée des secrets.",
       "hint": "Résolu pour chaque appareil ciblé au moment de l’exécution — personne n’a à le saisir."
     }
   },
@@ -1077,7 +1082,8 @@
     "suppliedBy": {
       "tenantVariable": "Fourni automatiquement par la variable {{key}}",
       "deviceCustomField": "Fourni automatiquement par le champ personnalisé de l’appareil {{key}}",
-      "builtin": "Fourni automatiquement par {{key}}"
+      "builtin": "Fourni automatiquement par {{key}}",
+      "tenantSecret": "Fourni de façon sécurisée par la variable secrète {{key}}, comme variable d’environnement"
     }
   },
   "scriptTagManager": {

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -797,7 +797,6 @@
       "systemDescription": "S’exécute dans le contexte du service agent.",
       "userDescription": "S’exécute dans le contexte de l’utilisateur actuellement connecté lorsqu’un assistant utilisateur est connecté."
     },
-    "secretsRequireSystem": "Ce script utilise des variables secrètes, qui ne sont transmises qu’aux exécutions dans le contexte système. Avec « Utilisateur connecté », les appareils échoueront avec « non exécuté ».",
     "sections": {
       "selectDevices": "Sélectionner des appareils"
     },
@@ -843,6 +842,9 @@
       "macos": "macOS",
       "linux": "Linux"
     }
+  },
+  "secretParameters": {
+    "requiresSystemContext": "Ce script utilise des variables secrètes, qui ne sont transmises qu’aux exécutions dans le contexte système sans session ciblée. Avec « Utilisateur connecté », ou lorsqu’une session précise est ciblée, les appareils échoueront avec « non exécuté »."
   },
   "scriptExecutionsPage": {
     "errors": {

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -797,6 +797,7 @@
       "systemDescription": "Esegue nel contesto del servizio agent.",
       "userDescription": "Esegue nel contesto dell'utente attualmente connesso quando è collegato un helper utente."
     },
+    "secretsRequireSystem": "Questo script usa variabili segrete, consegnate solo alle esecuzioni nel contesto di sistema. Con \"Utente connesso\" i dispositivi falliranno con \"non eseguito\".",
     "sections": {
       "selectDevices": "Seleziona dispositivi"
     },
@@ -998,14 +999,15 @@
       "button": "Variabili",
       "insertTitle": "Inserisci una variabile",
       "empty": "Ancora nessuna variabile.",
-      "secretUnavailable": "Segreto: una versione futura lo passerà come variabile d'ambiente.",
+      "secretUnavailable": "Segreto: collegalo tramite un parametro con origine \"Da una variabile segreta\".",
       "unknown": "Non esiste alcuna variabile per {{keys}}: i dispositivi selezionati falliranno finché non la crei."
     },
     "parameterSources": {
       "runtime": "Richiesto all’esecuzione",
       "tenantVariable": "Da una variabile",
       "deviceCustomField": "Da un campo personalizzato del dispositivo",
-      "builtin": "Da una proprietà del dispositivo"
+      "builtin": "Da una proprietà del dispositivo",
+      "tenantSecret": "Da una variabile segreta (variabile d’ambiente)"
     },
     "parameterBinding": {
       "variableLabel": "Chiave della variabile",
@@ -1015,6 +1017,9 @@
       "builtinLabel": "Proprietà",
       "chooseTitle": "Scegli una variabile",
       "secretRejected": "\"{{key}}\" è segreta: il salvataggio verrà rifiutato. Scegli una variabile non segreta.",
+      "notSecret": "\"{{key}}\" non è segreta. Scegli una variabile segreta oppure cambia l’origine in \"Da una variabile\".",
+      "notSecretRow": "Non è segreta: usa \"Da una variabile\"",
+      "secretHint": "Consegnata solo come variabile d’ambiente {{env}}: non viene mai scritta nello script. Richiede l’esecuzione nel contesto di sistema e un agent che supporti la consegna sicura dei segreti.",
       "hint": "Viene risolto per ogni dispositivo di destinazione all’esecuzione dello script: nessuno deve indicarlo."
     }
   },
@@ -1077,7 +1082,8 @@
     "suppliedBy": {
       "tenantVariable": "Fornito automaticamente dalla variabile {{key}}",
       "deviceCustomField": "Fornito automaticamente dal campo personalizzato del dispositivo {{key}}",
-      "builtin": "Fornito automaticamente da {{key}}"
+      "builtin": "Fornito automaticamente da {{key}}",
+      "tenantSecret": "Fornito in modo sicuro dalla variabile segreta {{key}} come variabile d’ambiente"
     }
   },
   "scriptTagManager": {

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -797,7 +797,6 @@
       "systemDescription": "Esegue nel contesto del servizio agent.",
       "userDescription": "Esegue nel contesto dell'utente attualmente connesso quando è collegato un helper utente."
     },
-    "secretsRequireSystem": "Questo script usa variabili segrete, consegnate solo alle esecuzioni nel contesto di sistema. Con \"Utente connesso\" i dispositivi falliranno con \"non eseguito\".",
     "sections": {
       "selectDevices": "Seleziona dispositivi"
     },
@@ -843,6 +842,9 @@
       "macos": "macOS",
       "linux": "Linux"
     }
+  },
+  "secretParameters": {
+    "requiresSystemContext": "Questo script usa variabili segrete, consegnate solo alle esecuzioni nel contesto di sistema senza sessione di destinazione. Con \"Utente connesso\", o quando si sceglie una sessione specifica, i dispositivi falliranno con \"non eseguito\"."
   },
   "scriptExecutionsPage": {
     "errors": {

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -797,6 +797,7 @@
       "systemDescription": "Executa no contexto do serviço do agente.",
       "userDescription": "Executa no contexto do usuário conectado no momento quando um helper de usuário está conectado."
     },
+    "secretsRequireSystem": "Este script usa variáveis secretas, que só são entregues em execuções no contexto do sistema. Em \"Usuário conectado\", os dispositivos vão falhar com \"não executado\".",
     "sections": {
       "selectDevices": "Selecionar dispositivos"
     },
@@ -998,14 +999,15 @@
       "button": "Variáveis",
       "insertTitle": "Inserir uma variável",
       "empty": "Nenhuma variável ainda.",
-      "secretUnavailable": "Secreto — uma versão futura o entregará como variável de ambiente.",
+      "secretUnavailable": "Secreto — vincule por um parâmetro com origem \"De uma variável secreta\".",
       "unknown": "Não existe variável para {{keys}} — os dispositivos selecionados vão falhar até você criá-la."
     },
     "parameterSources": {
       "runtime": "Perguntado na execução",
       "tenantVariable": "De uma variável",
       "deviceCustomField": "De um campo personalizado do dispositivo",
-      "builtin": "De uma propriedade do dispositivo"
+      "builtin": "De uma propriedade do dispositivo",
+      "tenantSecret": "De uma variável secreta (variável de ambiente)"
     },
     "parameterBinding": {
       "variableLabel": "Chave da variável",
@@ -1015,6 +1017,9 @@
       "builtinLabel": "Propriedade",
       "chooseTitle": "Escolher uma variável",
       "secretRejected": "\"{{key}}\" é secreta — o salvamento será rejeitado. Escolha uma variável que não seja secreta.",
+      "notSecret": "\"{{key}}\" não é secreta. Escolha uma variável secreta ou mude a origem para \"De uma variável\".",
+      "notSecretRow": "Não é secreta — use \"De uma variável\"",
+      "secretHint": "Entregue apenas como a variável de ambiente {{env}} — nunca escrita no script. Exige execução no contexto do sistema e um agente compatível com a entrega segura de segredos.",
       "hint": "Resolvido para cada dispositivo de destino quando o script é executado — ninguém precisa informar."
     }
   },
@@ -1077,7 +1082,8 @@
     "suppliedBy": {
       "tenantVariable": "Fornecido automaticamente pela variável {{key}}",
       "deviceCustomField": "Fornecido automaticamente pelo campo personalizado do dispositivo {{key}}",
-      "builtin": "Fornecido automaticamente por {{key}}"
+      "builtin": "Fornecido automaticamente por {{key}}",
+      "tenantSecret": "Fornecido com segurança pela variável secreta {{key}} como variável de ambiente"
     }
   },
   "scriptTagManager": {

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -797,7 +797,6 @@
       "systemDescription": "Executa no contexto do serviço do agente.",
       "userDescription": "Executa no contexto do usuário conectado no momento quando um helper de usuário está conectado."
     },
-    "secretsRequireSystem": "Este script usa variáveis secretas, que só são entregues em execuções no contexto do sistema. Em \"Usuário conectado\", os dispositivos vão falhar com \"não executado\".",
     "sections": {
       "selectDevices": "Selecionar dispositivos"
     },
@@ -843,6 +842,9 @@
       "macos": "macOS",
       "linux": "Linux"
     }
+  },
+  "secretParameters": {
+    "requiresSystemContext": "Este script usa variáveis secretas, que só são entregues em execuções no contexto do sistema e sem sessão de destino. Em \"Usuário conectado\", ou ao selecionar uma sessão específica, os dispositivos vão falhar com \"não executado\"."
   },
   "scriptExecutionsPage": {
     "errors": {

--- a/apps/web/src/locales/tr-TR/scripts.json
+++ b/apps/web/src/locales/tr-TR/scripts.json
@@ -797,6 +797,7 @@
       "systemDescription": "Aracı hizmeti bağlamında çalışır.",
       "userDescription": "Bir kullanıcı yardımcısı bağlandığında, halihazırda oturum açmış olan kullanıcı bağlamında çalışır."
     },
+    "secretsRequireSystem": "Bu komut dosyası gizli değişkenler kullanır; bunlar yalnızca sistem bağlamındaki çalıştırmalara iletilir. \"Oturum açmış kullanıcı\" seçiliyken cihazlar \"çalıştırılmadı\" hatasıyla başarısız olur.",
     "sections": {
       "selectDevices": "Cihazları Seçin"
     },
@@ -952,13 +953,17 @@
       "builtinLabel": "Özellik",
       "chooseTitle": "Bir değişken seçin",
       "secretRejected": "\"{{key}}\" bir gizli bilgidir — kaydetme reddedilir. Gizli olmayan bir değişken seçin.",
+      "notSecret": "\"{{key}}\" gizli değil. Gizli bir değişken seçin veya kaynağı \"Bir değişkenden\" olarak değiştirin.",
+      "notSecretRow": "Gizli değil — \"Bir değişkenden\" kullanın",
+      "secretHint": "Yalnızca {{env}} ortam değişkeni olarak iletilir; komut dosyasına asla yazılmaz. Sistem bağlamında çalıştırma ve güvenli gizli bilgi iletimini destekleyen bir aracı gerektirir.",
       "hint": "Komut dosyası çalıştığında her hedef cihaz için çözülür; kimseden istenmez."
     },
     "parameterSources": {
       "runtime": "Çalışma anında sorulur",
       "tenantVariable": "Bir değişkenden",
       "deviceCustomField": "Cihaz özel alanından",
-      "builtin": "Cihaz özelliğinden"
+      "builtin": "Cihaz özelliğinden",
+      "tenantSecret": "Gizli bir değişkenden (ortam değişkeni)"
     },
     "execution": {
       "timeoutHint": "Komut dosyası bu sürenin sonunda sonlandırılır. Varsayılan 300 saniye (5 dakika) çoğu görev için uygundur. Maksimum 3600s (1 saat).",
@@ -1014,7 +1019,7 @@
       "button": "Değişkenler",
       "insertTitle": "Bir değişken ekleyin",
       "empty": "Henüz değişken yok.",
-      "secretUnavailable": "Secret — daha sonraki bir sürüm bunu bir ortam değişkeni olarak sunar.",
+      "secretUnavailable": "Gizli — kaynağı \"Gizli bir değişkenden\" olan bir parametre üzerinden bağlayın.",
       "unknown": "{{keys}} için değişken yok — hedeflenen cihazlar siz onu oluşturana kadar başarısız olacaktır."
     }
   },
@@ -1077,7 +1082,8 @@
     "suppliedBy": {
       "tenantVariable": "{{key}} değişkeninden otomatik sağlanır",
       "deviceCustomField": "{{key}} cihaz özel alanından otomatik sağlanır",
-      "builtin": "{{key}} değerinden otomatik sağlanır"
+      "builtin": "{{key}} değerinden otomatik sağlanır",
+      "tenantSecret": "{{key}} gizli değişkeninden ortam değişkeni olarak güvenli biçimde sağlanır"
     }
   },
   "scriptTagManager": {

--- a/apps/web/src/locales/tr-TR/scripts.json
+++ b/apps/web/src/locales/tr-TR/scripts.json
@@ -797,7 +797,6 @@
       "systemDescription": "Aracı hizmeti bağlamında çalışır.",
       "userDescription": "Bir kullanıcı yardımcısı bağlandığında, halihazırda oturum açmış olan kullanıcı bağlamında çalışır."
     },
-    "secretsRequireSystem": "Bu komut dosyası gizli değişkenler kullanır; bunlar yalnızca sistem bağlamındaki çalıştırmalara iletilir. \"Oturum açmış kullanıcı\" seçiliyken cihazlar \"çalıştırılmadı\" hatasıyla başarısız olur.",
     "sections": {
       "selectDevices": "Cihazları Seçin"
     },
@@ -843,6 +842,9 @@
       "macos": "macOS",
       "linux": "Linux"
     }
+  },
+  "secretParameters": {
+    "requiresSystemContext": "Bu komut dosyası gizli değişkenler kullanır; bunlar yalnızca hedef oturum seçilmeyen, sistem bağlamındaki çalıştırmalara iletilir. \"Oturum açmış kullanıcı\" seçiliyken veya belirli bir oturum hedeflendiğinde cihazlar \"çalıştırılmadı\" hatasıyla başarısız olur."
   },
   "scriptExecutionsPage": {
     "errors": {

--- a/docs/superpowers/plans/2026-08-22-pr4c2-secret-activation.md
+++ b/docs/superpowers/plans/2026-08-22-pr4c2-secret-activation.md
@@ -1,0 +1,230 @@
+# Tenant Variables #3409 — PR4c-2 Implementation Plan (secret activation: `source: 'tenantSecret'`)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a script declare a parameter whose value is a **secret** tenant variable and have that value reach the agent **only** as an environment variable (`BREEZE_VAR_<UPPER_NAME>`), sealed in the PR4a envelope, gated on agent capability at enqueue **and** claim, blocked for user-context runs, and redacted from results. This is the last PR of #3409; after it, secrets are usable end-to-end.
+
+**Branch:** `ToddHebebrand/tenant-variables-pr4c2`, based on `origin/main` at `56674b437` (contains PR0–PR4c-1). Worktree: `/Users/toddhebebrand/.herdr/worktrees/breeze/custom-script-variables`.
+
+**Prior art (read, do not re-derive):** `2026-08-14-pr4-secret-delivery-handoff.md` (§3 design, §4 seams), `2026-08-15-pr4c1-digest-pinning-snapshot.md` (snapshot/digest), `2026-08-14-pr4a-secret-envelope-server.md`, `2026-08-14-pr4b-agent-secret-env.md`.
+
+---
+
+## Settled design (advisor quorum 2026-08-15, user-approved — do not relitigate)
+
+1. **Secret delivery is DECLARED, never inferred.** A new parameter-definition arm
+   `{ name, source: 'tenantSecret', variableKey }` is the only way a secret reaches a script.
+   - `source: 'tenantVariable'` keeps **rejecting** a secret target (policy denial, unchanged).
+   - `{{var.<secret>}}` content tokens stay **permanently** rejected (save 400 + dispatch failure, unchanged).
+   - A `tenantSecret` binding whose target is **not** a secret, or is missing/unreadable, **fails the device closed**. No default value, no caller override, no fallback to a plaintext variable.
+2. The secret never enters the ordinary `parameters` map (the agent substitutes every entry of that map into the script text and mirrors it as `BREEZE_PARAM_*`). It rides `payload.secretEnv[name]` → sealed to `payload.secretEnvEnvelope` by `encryptSensitivePayloadFields('script', …)` → opened at delivery → agent exports `BREEZE_VAR_<UPPER(name)>`.
+3. **Fail loudly on an old agent** — enqueue gate AND claim-time gate on `devices.script_secret_env_version >= 1` (non-sticky capability, see `routes/agents/heartbeat.ts:519-521`). Never run a script with its credential env var unset.
+4. **User-context runs cannot use secrets** (helper IPC carries no env). Server mirrors the agent's `runAsSupportsSecrets` (`agent/internal/heartbeat/handlers_script.go:246-257`): `system` and `elevated` allowed; `user` or any `targetSessionId` refused.
+5. **Never put a resolved secret value** in: `script_executions.parameters`, `device_commands.result`, any error string, any log line, the digest material, or the AI tool's returned text. Error strings name parameter names and variable **keys** only.
+
+---
+
+## Current-state facts (verified 2026-08-22 against `56674b437`)
+
+| What | Where |
+|---|---|
+| Parameter-definition union (4 arms, `unionFallback`) | `packages/shared/src/validators/scriptParameterDefinitions.ts:32-146` |
+| Env-name collision refinement (`scriptParameterEnvSuffix`) | same file `:150-196` |
+| `TENANT_VARIABLE_KEY_PATTERN = /^[a-z][a-z0-9_]{0,63}$/`, `MIN_SECRET_TENANT_VARIABLE_VALUE_LENGTH = 4` | `packages/shared/src/validators/tenantVariables.ts:14-30` |
+| Resolver: `lookupBoundSource` secret denial, `resolveSourcedParameters`, `describeParameterFailure` | `apps/api/src/services/sourcedParameters.ts:323, :357-442, :452-478` |
+| `hasTenantVariableBoundParameters` (scans raw `source`), `scriptNeedsVariableScope` | `sourcedParameters.ts:222-250` |
+| Dispatch: param resolution → execution insert → payload build/seal (`reservedCommandId`, "Inert until PR4c" comment) → `queueCommand` → immediate send | `apps/api/src/services/scriptDispatch.ts:198-241, :243-270, :307-345, :352-397` |
+| `DispatchScriptResult` failure-code union | `scriptDispatch.ts:100-119` |
+| `encryptSensitivePayloadFields('script')` turns `secretEnv` → `secretEnvEnvelope`, throws without ctx | `apps/api/src/services/sensitiveCommandPayload.ts:93-125` |
+| `sealSecretEnv` throws when `getActiveSecretEncryptionKeyId()` is unset; `validateSecretEnv` rules (keys match tenant-key grammar, values 4..4096, ≤32 entries) | `apps/api/src/services/scriptSecretEnvelope.ts:68-145` |
+| Claim batch chokepoint used by heartbeat main, watchdog and REST poll | `apps/api/src/services/commandDelivery.ts:43` `decryptClaimedCommandsForDelivery`; callers `routes/agents/heartbeat.ts:493, :1162`, `routes/agents/commands.ts:197` |
+| Capability column + heartbeat write (non-sticky) | `apps/api/src/db/schema/devices.ts:157-164`; `routes/agents/heartbeat.ts:521` |
+| Redaction already wired at both ingests ("Inert until PR4c" comments) | `routes/agentWs.ts:1693`, `routes/agents/commands.ts:310` via `services/commandSecretRedaction.ts` |
+| Server-side terminal failure precedent (status/result/erasure + `propagateTimedOutDeviceCommand`) | `apps/api/src/jobs/staleCommandReaper.ts:246-283` |
+| Digest: `referencedVariableKeys` only sees `tenantVariable` | `apps/api/src/services/actionIntents/runScriptSnapshot.ts:177-186` |
+| Save-time secret check (content only) + bundle import | `apps/api/src/services/scriptBundle/index.ts:86-118`, `routes/scripts.ts:613-618, :802-808`, `scriptBundle/index.ts:500-507` |
+| Software-deploy silent secret omission | `apps/api/src/services/softwareDeployment.ts:541-565` |
+| Web: source `<select>`, `TenantVariableBindingField`, `TenantVariableMenu` (`disabled={v.isSecret}`) | `apps/web/src/components/scripts/ScriptForm.tsx:59-117, :812-841`, `TenantVariableMenu.tsx:110-131` |
+| Web: `parameterBindingKey` switch, `runtimeParameters` | `apps/web/src/components/scripts/ScriptFormSchema.ts:109-148` |
+| Web: run-modal bound rows use dynamic `suppliedBy.<source>` | `apps/web/src/components/scripts/ScriptParametersForm.tsx:136-158` |
+| i18n: 8 locales × `scripts.json` (`scriptForm.parameterSources`, `scriptForm.parameterBinding`, `scriptForm.variables.secretUnavailable`, `scriptParametersForm.suppliedBy`) | `apps/web/src/locales/{en,de-DE,es-419,fr-CA,fr-FR,it-IT,pt-BR,tr-TR}/scripts.json`; coverage test `apps/web/src/lib/i18n/translationCoverage.test.ts` |
+
+**Gap found while scoping:** the API never rejects a `tenantVariable` parameter bound to a secret at **save** time (only `content` is checked), although the web warning says "the save will be rejected". Task 6 closes it alongside the symmetric `tenantSecret`→non-secret check.
+
+**Traps carried from earlier PRs:** no `sql.raw` in shared code (breaks drizzle mocks); run the FULL API suite, not slices; mutation-verify every new guard; `ipAllowlistMode.config.test.ts` fails in this worktree for lack of `.env` — known-environmental, do not inject env vars.
+
+---
+
+## File structure
+
+**Create**
+| File | Responsibility |
+|---|---|
+| `apps/api/src/services/scriptSecretDelivery.ts` | The activation gates: `runAsSupportsSecretEnv`, `loadScriptSecretEnvVersion`, `secretDeliveryPreflight` (enqueue), `failClaimedSecretCommandsForUnsupportedAgent` (claim). Messages module-local. |
+| `apps/api/src/services/scriptSecretDelivery.test.ts` | Unit tests (drizzle mocks). |
+| `apps/api/src/__tests__/integration/scriptSecretDelivery.integration.test.ts` | Real-Postgres proof: dispatch seals an envelope, the stored payload has no plaintext, `openSecretEnv` with the row's AAD recovers the value, and the claim gate fails the command on a downgraded agent. |
+
+**Modify**
+| File | Change |
+|---|---|
+| `packages/shared/src/validators/scriptParameterDefinitions.ts` (+ test) | Fifth arm `tenantSecret`; env-name helper for secrets. |
+| `packages/shared/src/types/scripts.ts` (or wherever `ScriptParameter` lives — grep `variableKey`) | Widen the TS type if it is not inferred. |
+| `apps/api/src/services/sourcedParameters.ts` (+ test) | `secretEnv` output; `tenantSecret` lookup; `notSecret` denial; predicate covers both variable-backed sources. |
+| `apps/api/src/services/scriptDispatch.ts` (+ test) | Gates + `secretEnv` in payload; new failure codes; drop "inert" comment. |
+| `apps/api/src/services/commandDelivery.ts` (+ test) | Claim-time gate before decrypt. |
+| `apps/api/src/services/actionIntents/runScriptSnapshot.ts` (+ test) | `referencedVariableKeys` includes `tenantSecret`. |
+| `apps/api/src/services/scriptBundle/index.ts` (+ test), `apps/api/src/routes/scripts.ts` (+ test) | Save-time parameter/secret mismatch 400s at create, update, import. |
+| `apps/api/src/services/softwareDeployment.ts` (+ test) | Explicit per-device failure for a secret referenced in a template. |
+| `apps/api/src/routes/agentWs.ts`, `apps/api/src/routes/agents/commands.ts` | Comment-only: redaction is live now. |
+| `apps/web/src/components/scripts/{ScriptForm.tsx,ScriptFormSchema.ts,TenantVariableMenu.tsx,ScriptParametersForm.tsx,ScriptExecutionModal.tsx}` (+ tests) | Authoring arm, picker filtering, run-modal chip, runAs warning. |
+| `apps/web/src/locales/*/scripts.json` (8) | New keys; refresh the stale `secretUnavailable` copy. |
+| `apps/docs/…` tenant variables page (grep `BREEZE_VAR_` / "tenant variables") | Document the secret parameter, env name, agent floor, runAs restriction, redaction limits. |
+
+---
+
+### Task 1: Shared schema — the `tenantSecret` arm
+
+**Files:** `packages/shared/src/validators/scriptParameterDefinitions.ts`, `…/scriptParameterDefinitions.test.ts`
+
+- [ ] **Tests first** (RED):
+  - `{name:'api_token', source:'tenantSecret', variableKey:'vendor_token'}` parses; `type` defaults to `'string'`; `required` is `true` after parse regardless of input.
+  - `name` outside `TENANT_VARIABLE_KEY_PATTERN` is rejected **at `[i,'name']`** (e.g. `Api-Token`, `API_TOKEN`) — the secretEnv key grammar is the tenant-key grammar, so the wire name must already match it.
+  - `defaultValue` present → rejected with a message saying a secret parameter cannot carry a default (a default would be a plaintext credential in the script definition).
+  - `options` / `type:'select'` rejected.
+  - `scriptSecretEnvName('api_token') === 'BREEZE_VAR_API_TOKEN'` (mirrors agent: `"BREEZE_VAR_" + strings.ToUpper(key)`, `agent/internal/executor/executor.go` PR4b env loop).
+  - Collision refinement: a `tenantSecret` named `token` and a runtime parameter named `token` still fail as a duplicate name (the existing suffix rule already does this — add the assertion so nobody "fixes" it).
+  - `canonicalizeScriptParameterDefinitions` output for a `tenantSecret` definition is stable and includes `source` and `variableKey`.
+- [ ] **Implement:** add `'tenantSecret'` to `SCRIPT_PARAMETER_SOURCES` **last** (the order is the web `<select>` order). New arm:
+  ```ts
+  const tenantSecretParameterDefinitionSchema = z.object({
+    name: z.string().regex(TENANT_VARIABLE_KEY_PATTERN, '…lowercase letters, digits and underscores…'),
+    source: z.literal('tenantSecret'),
+    variableKey: tenantVariableKeySchema,
+    type: z.literal('string').default('string'),
+    required: z.literal(true).default(true),
+    defaultValue: z.undefined({ message: 'A secret parameter cannot carry a default value' }),
+    options: z.undefined({ message: 'A secret parameter cannot declare options' }),
+  });
+  ```
+  Export `scriptSecretEnvName(name)`. Update the arm docblock at `:25-31`.
+- [ ] GREEN; `pnpm --filter @breeze/shared test`; `pnpm --filter @breeze/shared build` if the API consumes `dist`.
+- [ ] Commit: `feat(shared): tenantSecret script-parameter arm (#3409 PR4c-2)`
+
+### Task 2: Resolver — produce `secretEnv`, fail closed on a non-secret target
+
+**Files:** `apps/api/src/services/sourcedParameters.ts`, `…/sourcedParameters.test.ts`
+
+- [ ] **Tests first**:
+  - `tenantSecret` bound to a secret variable → `ok`, `parameters` has **no** key for it, `secretEnv = {api_token: '<value>'}`, binding descriptor `{key, source:'tenantSecret', variableId, ownerScope, version}`.
+  - Target exists but `isSecret:false` → `ok:false`, `code:'unresolved_parameters'`, message names param + variable key, contains the phrase `is not a secret`, and **does not contain the value**.
+  - Target missing → `ok:false` (never falls to a default; there is none).
+  - No `variables` map supplied → throws (programming error, same as `tenantVariable`).
+  - Caller supplied a value for the secret param → it is dropped and reported in `ignoredParameters`; `secretEnv` still comes from the variable.
+  - `tenantVariable` → secret target still denied (existing tests at `:268-345` stay green; keep them).
+  - `hasTenantVariableBoundParameters([{source:'tenantSecret'}])` is `true`; `scriptNeedsVariableScope` likewise.
+  - Existing assertion "names keys, never the value" extended to the new denial.
+- [ ] **Implement:** `SourceLookup` gains `{kind:'secret'; …}` → split into `secretAsPlain` (existing denial) and a new `{kind:'secretValue', value, descriptor}` for the `tenantSecret` arm plus `{kind:'notSecret', variableKey}`. `ResolveSourcedParametersResult` ok-branch gains `secretEnv: Record<string,string>`. Update `describeParameterFailure` with the new bucket. Rename nothing public; widen the docblocks.
+- [ ] GREEN, mutation-verify (make `isSecret` check return true for both → new test fails, nothing else). Commit: `feat(api): resolve tenantSecret parameters into secretEnv (#3409 PR4c-2)`
+
+### Task 3: Delivery gates module
+
+**Files:** create `apps/api/src/services/scriptSecretDelivery.ts` + `.test.ts`
+
+- [ ] **Tests first**:
+  - `runAsSupportsSecretEnv('system', undefined) === true`, `'elevated'` true, `'user'` false, `('system', 3)` false.
+  - `secretDeliveryPreflight({deviceId, runAs, targetSessionId})` returns `{ok:false, code:'secrets_unsupported_run_as'}` for user; `{ok:false, code:'secret_delivery_unavailable'}` when `getActiveSecretEncryptionKeyId()` is null (mock `secretCrypto`); `{ok:false, code:'agent_upgrade_required'}` when the selected `scriptSecretEnvVersion` is 0 or the device row is gone; `{ok:true}` at 1. Order: runAs → server key → capability (cheapest/most-deterministic first, no query for the first two).
+  - `failClaimedSecretCommandsForUnsupportedAgent(claimed)`: with no envelope-bearing command → returns input unchanged **and issues no query**; with an envelope-bearing `script` command and capability 0 → updates that row to `status:'failed'`, `result:{status:'failed', error:<agent upgrade message>, exitCode:1}`, spreads `terminalPayloadErasureSet()`, guarded `status='sent'`; calls the execution propagation helper; returns the siblings only. Capability 1 → untouched. Walk the bound params of the `.where` (see memory `vacuous_drizzle_where_clause_assertions`).
+- [ ] **Implement.** Error messages (module constants, reuse in tests):
+  - `SECRETS_RUN_AS_MESSAGE = 'This script uses secret variables, which require system-context execution; it is configured to run as a user and was not executed'`
+  - `SECRET_DELIVERY_UNAVAILABLE_MESSAGE = 'Secret delivery is not configured on this server (no active secret-encryption key); script not executed'`
+  - `AGENT_UPGRADE_REQUIRED_MESSAGE = 'Agent upgrade required: this script uses secret variables and the device agent does not support secure secret delivery; script not executed'`
+  For propagation to `script_executions`, reuse `propagateTimedOutDeviceCommand` if its contract is "mark the linked execution failed with this error" (read `services/commandResultHandlers.ts` / wherever it lives); if its wording is timeout-specific, extract a neutral `propagateServerSideCommandFailure` and have the reaper call it — do not duplicate the body.
+- [ ] Commit: `feat(api): secret-delivery preflight and claim-time agent gate (#3409 PR4c-2)`
+
+### Task 4: Dispatch activation
+
+**Files:** `apps/api/src/services/scriptDispatch.ts`, `…/scriptDispatch.test.ts`
+
+- [ ] **Tests first** (existing `:660` "fails the device when a bound parameter targets a SECRET tenant variable" stays — it is the `tenantVariable` arm):
+  - A `tenantSecret` binding on a capable device (`scriptSecretEnvVersion:1`, key id configured): the object passed to `encryptSensitivePayloadFields` contains `secretEnv:{api_token:'…'}` and `parameters` lacks `api_token`; the payload handed to `queueCommand` has `secretEnvEnvelope` (string) and **no** `secretEnv`; `script_executions.parameters` contains `$bindings` with `source:'tenantSecret'` and **no value** (assert the serialized insert does not contain the secret string anywhere).
+  - `runAs:'user'` → `{ok:false, code:'secrets_unsupported_run_as'}`, **no** `script_executions` insert, no `queueCommand`.
+  - capability 0 → `{ok:false, code:'agent_upgrade_required'}`, same no-orphan assertion.
+  - key id unset → `{ok:false, code:'secret_delivery_unavailable'}`.
+  - A script with no `tenantSecret` parameter **never** queries `script_secret_env_version` (hot-path regression guard — the preload trap from PR2).
+  - `deliveryOutcome` unchanged semantics; immediate-send path still decrypts and sends the frame with `secretEnv` present and `secretEnvEnvelope` absent (`toAgentCommandFrame`).
+- [ ] **Implement:** after `resolveSourcedParameters`, `const secretEnv = resolution.secretEnv`; if `Object.keys(secretEnv).length > 0` → `await secretDeliveryPreflight(...)` BEFORE the execution insert; add `...(hasSecrets ? { secretEnv } : {})` to the payload object; extend the `code` union with the three new codes and docblock them; replace the "Inert until PR4c" comment.
+- [ ] Commit: `feat(api): dispatch tenantSecret parameters through the sealed envelope (#3409 PR4c-2)`
+
+### Task 5: Claim-time gate wiring
+
+**Files:** `apps/api/src/services/commandDelivery.ts`, `…/commandDelivery.test.ts`
+
+- [ ] Test: `decryptClaimedCommandsForDelivery` calls `failClaimedSecretCommandsForUnsupportedAgent` first and only decrypts what it returns; a failed command is **not** released back to pending (it is terminal).
+- [ ] Implement (one line + import). Confirm by reading `routes/agents/heartbeat.ts` that the device update carrying `scriptSecretEnvVersion` (`:521`) executes **before** `claimPendingCommandsForDevice` (`:889`) in the same request, so the gate's fresh select observes this beat's capability — cite the line numbers in the commit body.
+- [ ] Note in the PR body (no code): `commandQueue.ts:685/:954` direct pushes are not gated because no producer enqueues a `script` command with an envelope through them — `scriptDispatch` is the only producer and gates at enqueue.
+- [ ] Commit: `feat(api): re-check secret-delivery capability at claim time (#3409 PR4c-2)`
+
+### Task 6: Save-time checks (create / update / bundle import)
+
+**Files:** `apps/api/src/services/scriptBundle/index.ts` (+test), `apps/api/src/routes/scripts.ts` (+test)
+
+- [ ] Tests: create/update with `parameters:[{source:'tenantVariable', variableKey:'s'}]` where `s` is secret → 400 `Parameter "p" binds secret variable "s" with source "From a variable"; use a secret parameter instead`; `tenantSecret` bound to a **non-secret** key → 400 `Parameter "p" is a secret parameter but variable "k" is not a secret`; unknown key → allowed (partner-wide scripts resolve per org later); bundle import pushes the per-entry error like the content check.
+- [ ] Implement: refactor the lookup in `findSecretVariableReferences` into a private `lookupIsSecretByKey(scope, keys): Promise<Map<string, boolean>>`; add `findParameterSecretMismatches(scope, definitions)`; call at the three ingresses right after the content check.
+- [ ] Commit: `fix(api): reject secret/plain parameter-binding mismatches at save time (#3409 PR4c-2)`
+
+### Task 7: Digest + software deploy + comments
+
+- [ ] `runScriptSnapshot.ts:181` → `parsed.data.source === 'tenantVariable' || parsed.data.source === 'tenantSecret'`; test in `runScriptSnapshot.test.ts` that a `tenantSecret` reference is pinned (state/variableId/version/isSecret) and that material contains no value. Run `effectDigestCoverage.contract.test.ts`.
+- [ ] `softwareDeployment.ts:541-565`: compute the secret keys referenced by the templates; if any, fail those devices with `Software deployment templates cannot use secret variable(s) {{var.k}}` through the existing per-device failure channel (read how the `unresolved` branch records a `deploymentResults` row and mirror it). Test in `softwareDeployment.test.ts` next to `:517`.
+- [ ] Replace the two "Inert until PR4c" comments at `agentWs.ts:1693` and `agents/commands.ts:310` and the one in `scriptDispatch.ts` with "live since PR4c-2".
+- [ ] Commit: `feat(api): pin tenantSecret references; explicit deploy-template secret failure (#3409 PR4c-2)`
+
+### Task 8: Web authoring + run surfaces
+
+**Files:** `ScriptFormSchema.ts`, `ScriptForm.tsx`, `TenantVariableMenu.tsx`, `ScriptParametersForm.tsx`, `ScriptExecutionModal.tsx` (+ their tests), 8 × `locales/*/scripts.json`
+
+- [ ] `ScriptFormSchema.ts`: `parameterBindingKey` handles `tenantSecret`; form-side validation mirrors Task 1 (lowercase name, no default) so the first feedback is inline, not an API 400. `runtimeParameters` already excludes it (non-runtime).
+- [ ] `TenantVariableMenu`: replace `disabled={v.isSecret}` with a `selectable?: (v) => boolean` prop (default: `!v.isSecret`, preserving every existing caller); secondary line text comes from a `disabledReason?: (v) => string | undefined` prop with the old default.
+- [ ] `ScriptForm.tsx`: `TenantVariableBindingField` gains `mode: 'plain' | 'secret'`. Secret mode: menu `selectable = v => v.isSecret`, non-secret rows show `scriptForm.parameterBinding.notSecretRow`; typed non-secret key shows warning `scriptForm.parameterBinding.notSecret`; under the field render the hint `scriptForm.parameterBinding.secretHint` with the interpolated env name from `scriptSecretEnvName(row.name)` (falls back to `BREEZE_VAR_…` while the name is blank). `handleParameterSourceChange` clears `variableKey` on both variable-backed arms. Tests next to `ScriptForm.test.tsx:457-514`.
+- [ ] `ScriptParametersForm.tsx`: nothing structural; add `scriptParametersForm.suppliedBy.tenantSecret`. Test renders the chip for a `tenantSecret` param and never renders an input for it.
+- [ ] `ScriptExecutionModal.tsx`: when the script has a `tenantSecret` parameter and `runAs === 'user'` is selected, show `scriptExecutionModal.secretsRequireSystem` inline (warning, not a block — the server fails the device with the same message). Test.
+- [ ] i18n keys (en copy; translate the other 7 in their own voice, no machine-literal artifacts):
+  - `scriptForm.parameterSources.tenantSecret`: "From a secret variable (environment variable)"
+  - `scriptForm.parameterBinding.notSecret`: "\"{{key}}\" is not a secret. Choose a secret variable, or switch the source to \"From a variable\"."
+  - `scriptForm.parameterBinding.notSecretRow`: "Not a secret — use \"From a variable\""
+  - `scriptForm.parameterBinding.secretHint`: "Delivered only as the environment variable {{env}} — never written into the script. Requires system-context execution and an agent that supports secure secret delivery."
+  - `scriptForm.variables.secretUnavailable` → "Secret — bind it through a parameter with source \"From a secret variable\"."
+  - `scriptParametersForm.suppliedBy.tenantSecret`: "Supplied securely from secret variable {{key}} as an environment variable"
+  - `scriptExecutionModal.secretsRequireSystem`: "This script uses secret variables, which are only delivered to system-context runs. Devices will fail with \"not executed\" under Run as user."
+  Run `pnpm --filter @breeze/web test -- src/lib/i18n` and the touched component tests; `pnpm --filter @breeze/web exec astro check` if the form types changed.
+- [ ] Commit: `feat(web): author and run scripts with secret-variable parameters (#3409 PR4c-2)`
+
+### Task 9: Integration proof (real Postgres)
+
+**File:** `apps/api/src/__tests__/integration/scriptSecretDelivery.integration.test.ts` (pattern: `tenantVariableResolution.integration.test.ts`, `effectDigestToctou.integration.test.ts`)
+
+- [ ] Seed partner/org/device (`scriptSecretEnvVersion:1`), a secret variable (through `services/tenantVariables.ts` so it is encrypted the real way), a script with a `tenantSecret` parameter; set the active key id the way `scriptSecretEnvelope.test.ts` does.
+- [ ] `dispatchScriptToDevice` → assert the stored `device_commands.payload` has `secretEnvEnvelope` starting `enc:v3:`, has no `secretEnv`, and `JSON.stringify(row)` does not contain the plaintext; `openSecretEnv(envelope, {commandId,deviceId})` returns `{api_token: value}`; `script_executions.parameters.$bindings[0].source === 'tenantSecret'`.
+- [ ] Downgrade the device to `scriptSecretEnvVersion:0`, claim via `claimPendingCommandsForDevice`, run `decryptClaimedCommandsForDelivery` → returns `[]`; the command row is `failed` with the upgrade message and `payload` lacks the envelope (erased); the execution row is `failed`.
+- [ ] Run: `pnpm --filter @breeze/api test:integration -- src/__tests__/integration/scriptSecretDelivery.integration.test.ts` (needs `DATABASE_URL` to a test DB — see `docker-compose.test.yml`; if a sibling session's test DB is in use, bring up your own via `pnpm --filter @breeze/api test:docker:up`).
+- [ ] Commit: `test(api): secret delivery end-to-end against Postgres (#3409 PR4c-2)`
+
+### Task 10: Docs, full verification, PR
+
+- [ ] Docs: find the tenant-variables page under `apps/docs` (`grep -rl "tenant variable" apps/docs/src`) and add a "Secret variables in scripts" section: the parameter source, `BREEZE_VAR_<NAME>` (PowerShell `$env:BREEZE_VAR_NAME`, bash `$BREEZE_VAR_NAME`), no content substitution, system-context only, agent-capability floor (the first agent release carrying PR4b — check `git tag --contains 66e148fcf`-equivalent on main; if unreleased, say "agents from the release that ships this feature"), redaction scope and its honest limit (accidental-leak protection, not DLP: `env`/`printenv`/`bash -x` will print it, as will any transformation).
+- [ ] Full suites: `pnpm --filter @breeze/shared test`, `pnpm --filter @breeze/api test` (full, not slices), `pnpm --filter @breeze/web test`, `pnpm --filter @breeze/api test -- src/services/actionIntents/effectDigestCoverage.contract.test.ts`, the new integration test, and `effectDigestToctou.integration.test.ts`. Typecheck via `pnpm --filter @breeze/api exec tsc --noEmit -p tsconfig.json` (watch the OOM note in memory) and `astro check` for web.
+- [ ] No schema/migration change in this PR — verify with `git diff --stat origin/main...HEAD -- apps/api/migrations apps/api/src/db/schema` and report the (empty) result.
+- [ ] Grep invariant: `grep -rn "secretEnv\b" apps/api/src --include=*.ts | grep -v test` — every producer is in `scriptDispatch.ts`/`sourcedParameters.ts`; every consumer opens through `scriptSecretEnvelope.ts`. Show it in the PR.
+- [ ] Rebase onto current `origin/main` BEFORE opening; re-run touched slices.
+- [ ] Open the PR against `main` (never stacked). Body: what activates, the declared-not-inferred rule, the three dispatch gates, claim gate, save-time fix, software-deploy change, release note ("secret tenant variables are now usable from scripts via a `From a secret variable` parameter; requires agent ≥ <version>; user-context runs are refused"), the `Inert` comments removed, and the test matrix. `Refs #3409` (do not close — the user decides). **Stop at the open PR.** Do not merge.
+
+---
+
+## Explicitly out of scope
+
+| Item | Where |
+|---|---|
+| Secrets for `runAs: 'user'` (needs a helper IPC capability bump) | future issue |
+| Site-scoped variables | deferred since PR1 |
+| Better per-device messages for an *unreadable* variable at the five `resolveForOrg` callers | own issue (recorded in PR4c-1) |
+| Automation parameter-capture UI, `deviceCustomField` picker | PR3 follow-ups |

--- a/packages/shared/src/validators/scriptParameterDefinitions.test.ts
+++ b/packages/shared/src/validators/scriptParameterDefinitions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   DEVICE_CUSTOM_FIELD_KEY_PATTERN,
   MAX_SCRIPT_PARAMETER_OPTIONS_LENGTH,
+  MAX_SECRET_SCRIPT_PARAMETERS,
   SCRIPT_BUILTIN_PARAMETER_KEYS,
   SCRIPT_PARAMETER_SOURCES,
   canonicalizeScriptParameterDefinitions,
@@ -451,6 +452,55 @@ describe('scriptParameterDefinitionsSchema — array', () => {
 
   it('rejects a non-array', () => {
     expect(scriptParameterDefinitionsSchema.safeParse({ name: 'x', type: 'string' }).success).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------
+  // Secret-parameter cap (#3409 PR4c-2, finding 3).
+  //
+  // MAX_SCRIPT_PARAMETERS (64) is twice MAX_SECRET_SCRIPT_PARAMETERS (32), so
+  // without this rule a script declaring 33+ tenantSecret parameters SAVES
+  // cleanly and then blows up at dispatch inside the envelope builder — which
+  // rethrows, taking the whole fan-out down with a 500 instead of failing one
+  // device. The cap has to be a SAVE-time rule for that reason.
+  // ---------------------------------------------------------------------
+  const secretDefinition = (name: string) => ({
+    name,
+    source: 'tenantSecret' as const,
+    variableKey: name,
+  });
+
+  it(`accepts exactly ${MAX_SECRET_SCRIPT_PARAMETERS} tenantSecret definitions`, () => {
+    const definitions = Array.from({ length: MAX_SECRET_SCRIPT_PARAMETERS }, (_, i) => secretDefinition(`s${i}`));
+    expect(scriptParameterDefinitionsSchema.safeParse(definitions).success).toBe(true);
+  });
+
+  it(`rejects ${MAX_SECRET_SCRIPT_PARAMETERS + 1} tenantSecret definitions`, () => {
+    const definitions = Array.from({ length: MAX_SECRET_SCRIPT_PARAMETERS + 1 }, (_, i) => secretDefinition(`s${i}`));
+    const result = scriptParameterDefinitionsSchema.safeParse(definitions);
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain(
+      `A script cannot declare more than ${MAX_SECRET_SCRIPT_PARAMETERS} secret parameters`
+    );
+  });
+
+  // The cap counts ONLY tenantSecret rows — a script may still declare up to
+  // MAX_SCRIPT_PARAMETERS parameters overall, and non-secret sources never
+  // reach the secretEnv envelope.
+  it('counts only tenantSecret rows, not the whole definition list', () => {
+    const definitions = [
+      ...Array.from({ length: MAX_SECRET_SCRIPT_PARAMETERS }, (_, i) => secretDefinition(`s${i}`)),
+      ...Array.from({ length: MAX_SCRIPT_PARAMETERS - MAX_SECRET_SCRIPT_PARAMETERS }, (_, i) => runtimeDefinition(`p${i}`)),
+    ];
+    expect(definitions).toHaveLength(MAX_SCRIPT_PARAMETERS);
+    expect(scriptParameterDefinitionsSchema.safeParse(definitions).success).toBe(true);
+  });
+
+  it('reports the secret cap on the first over-limit element, not the whole array', () => {
+    const definitions = Array.from({ length: MAX_SECRET_SCRIPT_PARAMETERS + 2 }, (_, i) => secretDefinition(`s${i}`));
+    const result = scriptParameterDefinitionsSchema.safeParse(definitions);
+    expect(result.success).toBe(false);
+    const paths = result.error?.issues.map((issue) => issue.path.join('.')) ?? [];
+    expect(paths).toContain(`${MAX_SECRET_SCRIPT_PARAMETERS}.source`);
   });
 
   it('does not mutate when a caller applies a tighter cap', () => {

--- a/packages/shared/src/validators/scriptParameterDefinitions.test.ts
+++ b/packages/shared/src/validators/scriptParameterDefinitions.test.ts
@@ -4,12 +4,14 @@ import {
   MAX_SCRIPT_PARAMETER_OPTIONS_LENGTH,
   SCRIPT_BUILTIN_PARAMETER_KEYS,
   SCRIPT_PARAMETER_SOURCES,
+  canonicalizeScriptParameterDefinitions,
   normalizeScriptParameterDefinitions,
   scriptParameterDefinitionSchema,
   scriptParameterDefinitionsEqual,
   scriptParameterDefinitionsSchema,
   scriptParameterEnvName,
   scriptParameterEnvSuffix,
+  scriptSecretEnvName,
 } from './scriptParameterDefinitions';
 import { MAX_SCRIPT_PARAMETERS, MAX_SCRIPT_PARAMETER_VALUE_LENGTH } from './scriptParameters';
 
@@ -53,8 +55,14 @@ describe('scriptParameterDefinitionSchema — source default', () => {
     expect(scriptParameterDefinitionSchema.safeParse({ name: 'x', type: 'string', source: 'magic' }).success).toBe(false);
   });
 
-  it('enumerates exactly the four supported sources', () => {
-    expect([...SCRIPT_PARAMETER_SOURCES]).toEqual(['runtime', 'tenantVariable', 'deviceCustomField', 'builtin']);
+  it('enumerates exactly the five supported sources, tenantSecret last (web <select> order)', () => {
+    expect([...SCRIPT_PARAMETER_SOURCES]).toEqual([
+      'runtime',
+      'tenantVariable',
+      'deviceCustomField',
+      'builtin',
+      'tenantSecret',
+    ]);
   });
 });
 
@@ -173,6 +181,118 @@ describe('scriptParameterDefinitionSchema — tenantVariable arm', () => {
     });
     expect(result.success).toBe(true);
     expect(result.data).not.toHaveProperty('fieldKey');
+  });
+});
+
+describe('scriptParameterDefinitionSchema — tenantSecret arm (#3409 PR4c-2)', () => {
+  const secretDefinition = { name: 'api_token', source: 'tenantSecret' as const, variableKey: 'vendor_token' };
+
+  it('accepts a minimal secret binding, defaulting type to string and required to true', () => {
+    const result = scriptParameterDefinitionSchema.safeParse(secretDefinition);
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      name: 'api_token',
+      source: 'tenantSecret',
+      variableKey: 'vendor_token',
+      type: 'string',
+      required: true,
+    });
+  });
+
+  it('forces required to true regardless of input', () => {
+    const result = scriptParameterDefinitionSchema.safeParse({ ...secretDefinition, required: false });
+    // A secret that is missing fails the device closed — there is no optional
+    // secret, so `required:false` is not a thing a definition can say.
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['required']);
+    const explicit = scriptParameterDefinitionSchema.safeParse({ ...secretDefinition, required: true });
+    expect(explicit.success && explicit.data.required).toBe(true);
+  });
+
+  it('requires variableKey at the arm path', () => {
+    const result = scriptParameterDefinitionSchema.safeParse({ name: 'api_token', source: 'tenantSecret' });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['variableKey']);
+  });
+
+  it.each(['Uppercase', '9leading', 'has-hyphen', '', 'a'.repeat(65)])(
+    'rejects variableKey %j (tenant-variable key grammar)',
+    (variableKey) => {
+      expect(scriptParameterDefinitionSchema.safeParse({ ...secretDefinition, variableKey }).success).toBe(false);
+    }
+  );
+
+  // The secretEnv wire key IS the env-var name source on the agent
+  // (`BREEZE_VAR_` + ToUpper(key), no `-` folding) and the agent's
+  // ParseSecretEnv validates it against the tenant-key grammar, so a name the
+  // ordinary parameter grammar would accept must already be rejected here.
+  it.each(['Api-Token', 'API_TOKEN', 'api-token', '_leading', '9leading', 'a'.repeat(65)])(
+    'rejects name %j outside the tenant-variable key grammar at [name]',
+    (name) => {
+      const result = scriptParameterDefinitionSchema.safeParse({ ...secretDefinition, name });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0]?.path).toEqual(['name']);
+    }
+  );
+
+  it('rejects a defaultValue — it would be a plaintext credential in the definition', () => {
+    const result = scriptParameterDefinitionSchema.safeParse({ ...secretDefinition, defaultValue: 'hunter22' });
+    expect(result.success).toBe(false);
+    const issue = result.error?.issues.find((candidate) => candidate.path[0] === 'defaultValue');
+    expect(issue?.message).toMatch(/cannot carry a default/i);
+  });
+
+  it('rejects options', () => {
+    const result = scriptParameterDefinitionSchema.safeParse({ ...secretDefinition, options: 'a,b' });
+    expect(result.success).toBe(false);
+    const issue = result.error?.issues.find((candidate) => candidate.path[0] === 'options');
+    expect(issue?.message).toMatch(/cannot declare options/i);
+  });
+
+  it.each(['select', 'number', 'boolean'])('rejects type %j', (type) => {
+    const result = scriptParameterDefinitionSchema.safeParse({ ...secretDefinition, type });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['type']);
+  });
+
+  it('still collides with a runtime parameter of the same name', () => {
+    // The suffix rule keys on `name` for every arm. A secret and a runtime
+    // parameter sharing a name is a duplicate even though they land in
+    // different env vars (BREEZE_VAR_ vs BREEZE_PARAM_) — do not "fix" this.
+    const result = scriptParameterDefinitionsSchema.safeParse([
+      runtimeDefinition('token'),
+      { name: 'token', source: 'tenantSecret', variableKey: 'vendor_token' },
+    ]);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual([1, 'name']);
+    expect(result.error?.issues[0]?.message).toMatch(/Duplicate parameter name "token"/);
+  });
+
+  it('canonicalizes stably, including source and variableKey', () => {
+    const canonical = canonicalizeScriptParameterDefinitions([secretDefinition]);
+    expect(canonical).toBe(
+      JSON.stringify([
+        JSON.stringify([
+          ['name', 'api_token'],
+          ['required', true],
+          ['source', 'tenantSecret'],
+          ['type', 'string'],
+          ['variableKey', 'vendor_token'],
+        ]),
+      ])
+    );
+    expect(
+      canonicalizeScriptParameterDefinitions([
+        { variableKey: 'vendor_token', source: 'tenantSecret', name: 'api_token', required: true, type: 'string' },
+      ])
+    ).toBe(canonical);
+  });
+});
+
+describe('scriptSecretEnvName', () => {
+  it('mirrors the agent: BREEZE_VAR_ + ToUpper(name), no separator folding', () => {
+    expect(scriptSecretEnvName('api_token')).toBe('BREEZE_VAR_API_TOKEN');
+    expect(scriptSecretEnvName('a1_b2')).toBe('BREEZE_VAR_A1_B2');
   });
 });
 

--- a/packages/shared/src/validators/scriptParameterDefinitions.ts
+++ b/packages/shared/src/validators/scriptParameterDefinitions.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { MAX_SCRIPT_PARAMETERS, MAX_SCRIPT_PARAMETER_VALUE_LENGTH, SCRIPT_PARAMETER_KEY_PATTERN } from './scriptParameters';
-import { tenantVariableKeySchema } from './tenantVariables';
+import { TENANT_VARIABLE_KEY_PATTERN, tenantVariableKeySchema } from './tenantVariables';
 
 /**
  * Script parameter DEFINITIONS (#3409 PR3) — the authoring-time declaration of
@@ -28,8 +28,15 @@ import { tenantVariableKeySchema } from './tenantVariables';
  *   org (org > partner).
  * - `deviceCustomField` — the target device's `custom_fields` JSONB.
  * - `builtin` — an org / site / device property.
+ * - `tenantSecret` — a SECRET `tenant_variables` row (#3409 PR4c). The value
+ *   never enters the `parameters` map or the script text; it rides the sealed
+ *   `secretEnv` envelope and the agent exports it as `BREEZE_VAR_<UPPER(name)>`
+ *   (see {@link scriptSecretEnvName}). `tenantVariable` keeps REJECTING a
+ *   secret target — secret delivery is declared, never inferred.
+ *
+ * Order is the web `<select>` order; append, never reorder.
  */
-export const SCRIPT_PARAMETER_SOURCES = ['runtime', 'tenantVariable', 'deviceCustomField', 'builtin'] as const;
+export const SCRIPT_PARAMETER_SOURCES = ['runtime', 'tenantVariable', 'deviceCustomField', 'builtin', 'tenantSecret'] as const;
 export type ScriptParameterSource = (typeof SCRIPT_PARAMETER_SOURCES)[number];
 
 export const SCRIPT_PARAMETER_TYPES = ['string', 'number', 'boolean', 'select'] as const;
@@ -121,6 +128,39 @@ const builtinParameterDefinitionSchema = z.object({
 });
 
 /**
+ * The `tenantSecret` arm deliberately does NOT spread the base:
+ *
+ * - `name` must match the TENANT-VARIABLE key grammar, not the looser
+ *   parameter grammar. The name is the `secretEnv` wire key, the agent's
+ *   `ParseSecretEnv` validates it against that grammar and fails the whole
+ *   command closed on a miss, and the env var is derived as
+ *   `BREEZE_VAR_` + ToUpper(name) with no `-` folding. Rejecting at save beats
+ *   failing per device.
+ * - `type` is always `string` and `required` is always `true`: a missing or
+ *   unreadable secret fails the device closed, so there is no optional secret
+ *   and nothing to coerce.
+ * - `defaultValue` and `options` are rejected when present. A default would be
+ *   a plaintext credential stored in the script definition; the value is never
+ *   a choice list. Zod 4 treats a bare `z.undefined()` object field as a
+ *   required key (`expected nonoptional`), hence the `.optional()` — the
+ *   custom message still fires when the key is present with a value.
+ */
+const tenantSecretParameterDefinitionSchema = z.object({
+  name: z
+    .string()
+    .regex(
+      TENANT_VARIABLE_KEY_PATTERN,
+      'Secret parameter names must be lowercase letters, digits and underscores, and start with a letter'
+    ),
+  source: z.literal('tenantSecret'),
+  variableKey: tenantVariableKeySchema,
+  type: z.literal('string').default('string'),
+  required: z.literal(true).default(true),
+  defaultValue: z.undefined({ message: 'A secret parameter cannot carry a default value' }).optional(),
+  options: z.undefined({ message: 'A secret parameter cannot declare options' }).optional(),
+});
+
+/**
  * One definition, discriminated on `source`, each arm requiring only its own
  * binding field.
  *
@@ -132,7 +172,7 @@ const builtinParameterDefinitionSchema = z.object({
  * to ordinary union matching, where the `runtime` arm applies its default and
  * succeeds. Inputs that DO carry a valid `source` still take the fast path and
  * still get arm-specific errors (e.g. a missing `variableKey` reports at
- * `["variableKey"]`, not as a four-branch union failure).
+ * `["variableKey"]`, not as a five-branch union failure).
  */
 export const scriptParameterDefinitionSchema = z.discriminatedUnion(
   'source',
@@ -141,6 +181,7 @@ export const scriptParameterDefinitionSchema = z.discriminatedUnion(
     tenantVariableParameterDefinitionSchema,
     deviceCustomFieldParameterDefinitionSchema,
     builtinParameterDefinitionSchema,
+    tenantSecretParameterDefinitionSchema,
   ],
   { unionFallback: true }
 );
@@ -165,6 +206,17 @@ export function scriptParameterEnvName(name: string): string {
 }
 
 /**
+ * The env var the agent exports for a `tenantSecret` parameter:
+ * `"BREEZE_VAR_" + strings.ToUpper(key)` (`SecretEnv.EnvKey`,
+ * `agent/internal/executor/secretenv.go`). No `-` folding, unlike
+ * {@link scriptParameterEnvName} — the tenant-key grammar admits no hyphen, so
+ * there is nothing to fold. E.g. `api_token` -> `BREEZE_VAR_API_TOKEN`.
+ */
+export function scriptSecretEnvName(name: string): string {
+  return `BREEZE_VAR_${name.toUpperCase()}`;
+}
+
+/**
  * Rejects two parameter names that collapse to the SAME `BREEZE_PARAM_*` env
  * var on the agent.
  *
@@ -175,6 +227,11 @@ export function scriptParameterEnvName(name: string): string {
  * randomizes map iteration order, so which value wins varies between runs of
  * the same script on the same device. Uppercasing widens the equivalence
  * class further: `logLevel`, `LOGLEVEL` and `loglevel` all collide too.
+ *
+ * The rule keys on `name` for EVERY arm, `tenantSecret` included. A secret and
+ * a runtime parameter sharing a name land in different env vars
+ * (`BREEZE_VAR_` vs `BREEZE_PARAM_`) but are still one parameter name in the
+ * run modal and the definition list, so they are rejected as duplicates.
  *
  * Exported separately from the array schema so a caller that needs a different
  * length cap can rebuild the array without re-implementing the rule.

--- a/packages/shared/src/validators/scriptParameterDefinitions.ts
+++ b/packages/shared/src/validators/scriptParameterDefinitions.ts
@@ -260,15 +260,64 @@ export function refineScriptParameterKeyCollisions(
 }
 
 /**
+ * How many `tenantSecret` parameters one script may declare (#3409 PR4c-2).
+ *
+ * This MUST equal `MAX_SECRET_ENV_ENTRIES` in
+ * `apps/api/src/services/scriptSecretEnvelope.ts`, which is the AUTHORITY —
+ * it is the bound the sealed `secretEnv` envelope actually enforces at
+ * dispatch. It is restated here rather than imported because `packages/shared`
+ * must not depend on `apps/api`; the two are pinned together by an equality
+ * assertion in `apps/api/src/services/scriptBundle/index.test.ts`, so they
+ * cannot drift.
+ *
+ * Deliberately LOWER than {@link MAX_SCRIPT_PARAMETERS} (64). Without a
+ * save-time rule a script declaring 33+ secret parameters saves cleanly and
+ * then throws inside `encryptSensitivePayloadFields` at dispatch — inside
+ * `scriptDispatch`'s guarded region, which RETHROWS, and
+ * `executeScriptOnDevices` does not wrap the per-device call. The result is a
+ * 500 with an internal message that kills the ENTIRE fan-out, not one device.
+ */
+export const MAX_SECRET_SCRIPT_PARAMETERS = 32;
+
+/**
+ * Rejects more `tenantSecret` parameters than the secret-delivery envelope can
+ * carry. Reported on the FIRST over-limit element's `source` (not on the whole
+ * array) so the web form can point at the parameter the tech should remove,
+ * and so it never masks the array-level {@link MAX_SCRIPT_PARAMETERS} cap.
+ *
+ * Exported alongside {@link refineScriptParameterKeyCollisions} for the same
+ * reason: a caller rebuilding the array with a different length cap must be
+ * able to reapply this rule without re-implementing it.
+ */
+export function refineSecretScriptParameterCap(
+  definitions: ReadonlyArray<{ source?: string }>,
+  ctx: z.RefinementCtx
+): void {
+  let secretCount = 0;
+  definitions.forEach((definition, index) => {
+    if (definition.source !== 'tenantSecret') return;
+    secretCount += 1;
+    if (secretCount <= MAX_SECRET_SCRIPT_PARAMETERS) return;
+    ctx.addIssue({
+      code: 'custom',
+      path: [index, 'source'],
+      message: `A script cannot declare more than ${MAX_SECRET_SCRIPT_PARAMETERS} secret parameters`,
+    });
+  });
+}
+
+/**
  * The array as stored in `scripts.parameters`. Capped at
  * {@link MAX_SCRIPT_PARAMETERS}, the same bound the run-time value map uses —
  * a definition list longer than the value map could accept would declare
- * parameters that can never be supplied.
+ * parameters that can never be supplied. `tenantSecret` rows carry the
+ * additional, tighter {@link MAX_SECRET_SCRIPT_PARAMETERS} cap.
  */
 export const scriptParameterDefinitionsSchema = z
   .array(scriptParameterDefinitionSchema)
   .max(MAX_SCRIPT_PARAMETERS, `A script cannot declare more than ${MAX_SCRIPT_PARAMETERS} parameters`)
-  .superRefine(refineScriptParameterKeyCollisions);
+  .superRefine(refineScriptParameterKeyCollisions)
+  .superRefine(refineSecretScriptParameterCap);
 
 /**
  * Parse an unvalidated stored/incoming value into normalized definitions.


### PR DESCRIPTION
Refs #3409 — PR4c-2, the last PR of the tenant-variables initiative. After this, secret tenant variables are usable from scripts end-to-end.

## What activates

A new script-parameter source **`tenantSecret`** ("From a secret variable"):

```json
{ "name": "api_token", "source": "tenantSecret", "variableKey": "vendor_token" }
```

The resolved value never enters the ordinary `parameters` map. It rides `payload.secretEnv[name]`, is sealed by the PR4a envelope (`secretEnvEnvelope`, AAD-bound to command id + device id), is opened only at delivery, and the PR4b agent exports it as **`BREEZE_VAR_API_TOKEN`**. The secret is never written into the script text.

**Declared, never inferred** (quorum ruling 2026-08-15): `source: 'tenantVariable'` keeps rejecting a secret target; `{{var.<secret>}}` content tokens stay permanently rejected. A `tenantSecret` binding whose target is missing or not actually a secret fails that device closed — no default, no caller override, no fallback.

## Gates (server)

At dispatch, before the `script_executions` insert (no orphan rows):
1. `runAs` — `system`/`elevated` only; `user` or any `targetSessionId` → `secrets_unsupported_run_as` (mirrors the agent's `runAsSupportsSecrets`).
2. Server key — no active secret-encryption key id → `secret_delivery_unavailable` (the envelope refuses to degrade to v1/no-AAD).
3. Agent capability — `devices.script_secret_env_version < 1` → `agent_upgrade_required`.

**At claim time, again** (an offline-queued command can be claimed after a downgrade): `decryptClaimedCommandsForDelivery` runs `failClaimedSecretCommandsForUnsupportedAgent` first and decrypts only the survivors. An unsupported agent never receives the frame; the command and its execution are driven `failed` with "Agent upgrade required…" and the envelope is erased. Two review findings are folded in:
- The heartbeat passes the capability **this beat reported** to the gate (not the stored column) — the device write is guarded on decommissioned/quarantined and can be skipped, so the stored value can be stale.
- The REST command poll (`routes/agents/commands.ts`, self-managed context) runs the gate inside the same system-context closure as the claim — it reads RLS'd `devices`.
- `scriptDispatch`'s immediate WebSocket send also runs the gate after its own claim (it never goes through the batch path); a withheld command reports `deliveryOutcome: 'agent_unsupported'`.

`commandQueue.ts:685/:954` (generic direct pushes) are not gated: no producer enqueues a `script` command with an envelope through them — `scriptDispatch` is the only producer and gates at enqueue.

## Save-time fix (pre-existing gap)

The API only ever checked `content` for secret references; the web warning claimed "the save will be rejected" for a `tenantVariable`→secret parameter but no 400 existed. Create, update and bundle import now reject both mismatch directions (`tenantVariable`→secret, `tenantSecret`→non-secret). Unknown keys still pass (partner-wide scripts resolve per org).

## Also
- Approval digest: `tenantSecret` references are pinned like `tenantVariable` ones (state/variableId/version/isSecret; never the value). No material version bump needed.
- Software deployment templates: a referenced secret now fails the device explicitly instead of being silently omitted.
- Web: source option, secret-mode variable picker (only secret rows selectable), `$BREEZE_VAR_…` hint, run-modal chip, Run-as-user warning; 8 locales; stale "a later release delivers it…" copy refreshed.
- Docs: `features/scripts.mdx` parameter-source table + "Secret variables in scripts" (env name, requirements, redaction limits); `software-inventory.mdx` note.
- The three "Inert until PR4c" comments are retired.

## Invariants checked
- `grep -rn "secretEnv\b" apps/api/src --include='*.ts' | grep -v test` — producers only in `sourcedParameters.ts`/`scriptDispatch.ts`; the only consumer seals via `sensitiveCommandPayload.ts` → `scriptSecretEnvelope.ts`.
- No schema or migration change: `git diff --stat origin/main...HEAD -- apps/api/migrations apps/api/src/db/schema` is empty.
- Secret values never reach `script_executions.parameters` (identity-only `$bindings`), `device_commands.result`, error strings, digest material, logs, or the AI tool's returned text — asserted by unit + integration tests.

## Tests
- shared 2013 · API unit 23,608 (full suite) · web 6,080 (one 5s load-timeout in `terminologyQuality.test.ts` during the concurrent run; green in isolation) · `astro check` 0 errors · API `tsc` 0 errors.
- Contract: `effectDigestCoverage.contract.test.ts`, `terminalPayloadErasure.coverage.test.ts`.
- Integration (real Postgres): new `scriptSecretDelivery.integration.test.ts` — sealed `enc:v3:` envelope stored with no plaintext anywhere in the row, `openSecretEnv` round-trip, identity-only bindings, claim-time downgrade → terminal failure + erasure, preflight refusals leave zero rows. Mutation-verified.
- Every new guard was mutation-verified (gate off → only its tests fail).

## Release note
Secret tenant variables are now usable from scripts via a **"From a secret variable"** parameter; the value is delivered only as `BREEZE_VAR_<NAME>`. Requires an agent with secure secret delivery (the release that ships PR4b — v0.107.0 or later); older agents fail the device with "Agent upgrade required" instead of running without the secret. User-context runs refuse secrets. Saving a script that binds a secret through the plain "From a variable" source is now rejected (previously only failed at run time).

Plan: `docs/superpowers/plans/2026-08-22-pr4c2-secret-activation.md`. Independent plan review (Codex, read-only) found 1 blocker + 4 majors, all addressed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
