### PR TITLE
feat(quotes): W02 — reviseQuote service + POST /quotes/:id/revise

### DIFF
--- a/apps/api/src/db/schema/quotes.ts
+++ b/apps/api/src/db/schema/quotes.ts
@@ -112,13 +112,14 @@ export const quotes = pgTable('quotes', {
   publicResponseOutcome: varchar('public_response_outcome', { length: 16 }),
   publicLinkRevokedAt: timestamp('public_link_revoked_at', { withTimezone: true }),
   // Quote revisions: immediate-parent link + 1-based position in the lineage.
-  // Schema and constraints only so far — nothing writes a non-null parent yet.
+  // cloneLineagePair writes the parent link and correlated revision number.
   // Enforced TODAY: linearity via quotes_revision_of_uq (one successor ever),
   // root-vs-revision via quotes_revision_number_chk, and same-tenant lineage
   // via the composite FK to (id, org_id).
-  // PLANNED (docs/superpowers/plans/2026-08-17-quote-revisions.md): a revision
-  // will keep the root's number with an -R<n> suffix, and sending one will flip
-  // its parent to 'superseded'. Neither behavior exists in sendQuote yet.
+  // Revisions keep the root's number with an -R<n> suffix. Sending one will
+  // flip its parent to 'superseded' in a later wave (see
+  // docs/superpowers/plans/2026-08-17-quote-revisions.md); that behavior does
+  // not exist in sendQuote yet.
   revisionOfQuoteId: uuid('revision_of_quote_id'),
   revisionNumber: integer('revision_number').notNull().default(1),
   createdBy: uuid('created_by').references(() => users.id),

--- a/apps/api/src/routes/quotes/quotes.revise.test.ts
+++ b/apps/api/src/routes/quotes/quotes.revise.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// Drive the real mounted router and real auth middleware. Only the DB-backed
+// permission lookup is controlled so a missing or incorrect route gate produces
+// a real HTTP response rather than a vacuous permission-constant comparison.
+const permState = vi.hoisted(() => ({ perms: ['quotes:read', 'quotes:write'] }));
+
+vi.mock('../../services/permissions', async (importActual) => {
+  const actual = await importActual<typeof import('../../services/permissions')>();
+  return {
+    ...actual,
+    getUserPermissions: vi.fn(async () => ({
+      permissions: permState.perms.map((p) => {
+        const [resource, action] = p.split(':');
+        return { resource, action };
+      }),
+      partnerId: 'p1', orgId: null, roleId: 'r1', scope: 'partner' as const,
+    })),
+  };
+});
+
+vi.mock('../../services/quoteService', () => ({
+  createQuote: vi.fn(), cloneQuote: vi.fn(), reviseQuote: vi.fn(), getQuote: vi.fn(),
+  listQuotes: vi.fn(), updateQuote: vi.fn(), deleteDraftQuote: vi.fn(),
+  addBlock: vi.fn(), updateBlock: vi.fn(), deleteBlock: vi.fn(),
+  addManualLine: vi.fn(), addCatalogLine: vi.fn(), updateLine: vi.fn(), removeLine: vi.fn(),
+  reorderBlocks: vi.fn(), reorderLines: vi.fn(), moveLineToBlock: vi.fn(),
+  changeQuoteCurrency: vi.fn(),
+}));
+vi.mock('../../services/quoteOrderService', () => ({
+  createQuoteOrder: vi.fn(), updateQuoteOrder: vi.fn(), updateQuoteOrderLine: vi.fn(),
+}));
+vi.mock('../../db', () => ({
+  db: { select: () => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }) }) },
+}));
+vi.mock('../../services/catalogImageStorage', () => ({ readCatalogItemImage: vi.fn() }));
+vi.mock('../../services/quoteBranding', () => ({ resolveQuoteBranding: vi.fn() }));
+vi.mock('../../services/quoteLifecycle', () => ({ getQuoteRecipients: vi.fn() }));
+vi.mock('../../services/contractTemplateRender', () => ({
+  renderContractBlocksForClient: vi.fn(), loadContractPdfInputs: vi.fn(),
+  loadContractBlockAuthoring: vi.fn(), attachContractAuthoring: vi.fn(),
+}));
+const audit = vi.hoisted(() => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: audit.writeRouteAudit }));
+
+import { quoteCrudRoutes } from './quotes';
+import { getQuote, reviseQuote } from '../../services/quoteService';
+import { QuoteServiceError } from '../../services/quoteTypes';
+
+const QUOTE_ID = '11111111-1111-4111-8111-111111111111';
+const REVISION_ID = '22222222-2222-4222-8222-222222222222';
+const actor = {
+  userId: 'u1', partnerId: 'p1', accessibleOrgIds: null, allowedSiteIds: undefined,
+};
+const parent = { id: QUOTE_ID, orgId: 'org1', status: 'sent', revisionNumber: 1 };
+const revision = {
+  id: REVISION_ID,
+  orgId: 'org1',
+  status: 'draft',
+  quoteNumber: 'Q-2026-0042-R2',
+  revisionOfQuoteId: QUOTE_ID,
+  revisionNumber: 2,
+};
+
+function appWith(perms: string[]) {
+  permState.perms = perms;
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', {
+      user: { id: 'u1' }, partnerId: 'p1', orgId: null, scope: 'partner',
+      accessibleOrgIds: null,
+    } as never);
+    await next();
+  });
+  app.route('/', quoteCrudRoutes);
+  return app;
+}
+
+describe('POST /:id/revise', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getQuote).mockResolvedValue({ quote: parent } as never);
+    vi.mocked(reviseQuote).mockResolvedValue(revision as never);
+  });
+
+  it('returns the new draft and revises with the authenticated actor', async () => {
+    const res = await appWith(['quotes:read', 'quotes:write'])
+      .request(`/${QUOTE_ID}/revise`, { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: revision });
+    expect(reviseQuote).toHaveBeenCalledWith(QUOTE_ID, actor);
+  });
+
+  it('returns HTTP 403 without quotes:write', async () => {
+    const res = await appWith(['quotes:read'])
+      .request(`/${QUOTE_ID}/revise`, { method: 'POST' });
+
+    expect(res.status).toBe(403);
+    expect(getQuote).not.toHaveBeenCalled();
+    expect(reviseQuote).not.toHaveBeenCalled();
+  });
+
+  it('serializes REVISION_IN_PROGRESS metadata', async () => {
+    vi.mocked(reviseQuote).mockRejectedValue(new QuoteServiceError(
+      'A revision of this quote is already in progress',
+      409,
+      'REVISION_IN_PROGRESS',
+      { revisionQuoteId: REVISION_ID },
+    ));
+
+    const res = await appWith(['quotes:read', 'quotes:write'])
+      .request(`/${QUOTE_ID}/revise`, { method: 'POST' });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: 'A revision of this quote is already in progress',
+      code: 'REVISION_IN_PROGRESS',
+      meta: { revisionQuoteId: REVISION_ID },
+    });
+  });
+
+  it('audits the parent lineage and status', async () => {
+    await appWith(['quotes:read', 'quotes:write'])
+      .request(`/${QUOTE_ID}/revise`, { method: 'POST' });
+
+    expect(audit.writeRouteAudit).toHaveBeenCalledWith(expect.anything(), {
+      orgId: 'org1',
+      action: 'quote.revised',
+      resourceType: 'quote',
+      resourceId: REVISION_ID,
+      result: 'success',
+      details: { parentQuoteId: QUOTE_ID, revisionNumber: 2, parentStatus: 'sent' },
+    });
+  });
+});

--- a/apps/api/src/routes/quotes/quotes.revise.test.ts
+++ b/apps/api/src/routes/quotes/quotes.revise.test.ts
@@ -119,6 +119,7 @@ describe('POST /:id/revise', () => {
       code: 'REVISION_IN_PROGRESS',
       meta: { revisionQuoteId: REVISION_ID },
     });
+    expect(audit.writeRouteAudit).not.toHaveBeenCalled();
   });
 
   it('audits the parent lineage and status', async () => {

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -12,7 +12,7 @@ import {
   changeCurrencySchema,
 } from '@breeze/shared';
 import {
-  createQuote, cloneQuote, getQuote, listQuotes, updateQuote, deleteDraftQuote,
+  createQuote, cloneQuote, reviseQuote, getQuote, listQuotes, updateQuote, deleteDraftQuote,
   addManualLine, addCatalogLine, updateLine, removeLine, addBlock, updateBlock, deleteBlock,
   reorderBlocks, reorderLines, moveLineToBlock, changeQuoteCurrency,
 } from '../../services/quoteService';
@@ -53,7 +53,9 @@ export function quoteActorFrom(c: { get: (k: string) => unknown }): QuoteActor {
   return { userId: auth.user.id, partnerId: auth.partnerId ?? null, accessibleOrgIds: auth.accessibleOrgIds, allowedSiteIds: auth.allowedSiteIds };
 }
 export function handleServiceError(c: { json: (b: unknown, s: number) => Response }, err: unknown): Response {
-  if (err instanceof QuoteServiceError) return c.json({ error: err.message, code: err.code }, err.status);
+  if (err instanceof QuoteServiceError) {
+    return c.json(err.meta ? { error: err.message, code: err.code, meta: err.meta } : { error: err.message, code: err.code }, err.status);
+  }
   if (err instanceof ContractTemplateServiceError) return c.json({ error: err.message, code: err.code }, err.status);
   // An unloadable/encrypted uploaded contract PDF surfaces as a 4xx (typed) here
   // rather than an uncaught 500 — uploads are validated at write time, so this is
@@ -89,6 +91,26 @@ quoteCrudRoutes.post('/:id/clone', scopes, writePerm, zValidator('param', idPara
   }
   try { return c.json({ data: await cloneQuote(c.req.valid('param').id, quoteActorFrom(c), input) }); }
   catch (err) { return handleServiceError(c, err); }
+});
+// POST /:id/revise — create a linked draft revision of an issued quote. The
+// parent stays live until the revision is SENT (sendQuote supersedes it).
+// quotes:write like clone; the send itself will require quotes:send.
+quoteCrudRoutes.post('/:id/revise', scopes, writePerm, zValidator('param', idParam), async (c) => {
+  const id = c.req.valid('param').id;
+  try {
+    const actor = quoteActorFrom(c);
+    const { quote: parent } = await getQuote(id, actor);
+    const revision = await reviseQuote(id, actor);
+    writeRouteAudit(c, {
+      orgId: revision.orgId,
+      action: 'quote.revised',
+      resourceType: 'quote',
+      resourceId: revision.id,
+      result: 'success',
+      details: { parentQuoteId: id, revisionNumber: revision.revisionNumber, parentStatus: parent.status },
+    });
+    return c.json({ data: revision });
+  } catch (err) { return handleServiceError(c, err); }
 });
 quoteCrudRoutes.get('/:id', scopes, readPerm, zValidator('param', idParam), async (c) => {
   const id = c.req.valid('param').id;

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -93,7 +93,8 @@ quoteCrudRoutes.post('/:id/clone', scopes, writePerm, zValidator('param', idPara
   catch (err) { return handleServiceError(c, err); }
 });
 // POST /:id/revise — create a linked draft revision of an issued quote. The
-// parent stays live until the revision is SENT (sendQuote supersedes it).
+// parent stays live; superseding it on send belongs to a later wave documented
+// in docs/superpowers/plans/2026-08-17-quote-revisions.md.
 // quotes:write like clone; the send itself will require quotes:send.
 quoteCrudRoutes.post('/:id/revise', scopes, writePerm, zValidator('param', idParam), async (c) => {
   const id = c.req.valid('param').id;

--- a/apps/api/src/services/quoteLifecycle.test.ts
+++ b/apps/api/src/services/quoteLifecycle.test.ts
@@ -220,6 +220,7 @@ describe('sendQuote deposit validation', () => {
     queueResult([]); // blocks
     queueResult([]); // lines — none at all, so dueOnAcceptanceTotal is $0
     queueResult([]); // no staged Pax8 order
+    queueResult([]); // no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
 
@@ -234,6 +235,7 @@ describe('sendQuote deposit validation', () => {
     queueResult([]); // blocks
     queueResult([{ quantity: '1', unitPrice: '1000.00', taxable: true, customerVisible: true, recurrence: 'one_time', depositEligible: false }]);
     queueResult([]); // no staged Pax8 order
+    queueResult([]); // no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
 
@@ -253,6 +255,7 @@ describe('sendQuote deposit validation', () => {
     // A one-time line exists (so dueOnAcceptance > 0) but NONE are depositEligible.
     queueResult([{ quantity: '1', unitPrice: '1000.00', taxable: true, customerVisible: true, recurrence: 'one_time', depositEligible: false }]);
     queueResult([]); // no staged Pax8 order
+    queueResult([]); // no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
 
@@ -267,6 +270,7 @@ describe('sendQuote deposit validation', () => {
     queueResult([]); // blocks
     queueResult([]); // lines
     queueResult([]); // no staged Pax8 order
+    queueResult([]); // no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
 
@@ -317,6 +321,7 @@ describe('sendQuote customer-facing PDF', () => {
     queueResult([]); // blocks
     queueResult([visibleLine, internalLine]); // lines
     queueResult([]); // no staged Pax8 order
+    queueResult([]); // no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
     queueResult([{ name: 'Customer Co', taxId: null, billingAddressLine1: null, billingAddressLine2: null, billingAddressCity: null, billingAddressRegion: null, billingAddressPostalCode: null, billingAddressCountry: null }]); // getQuote's own draft billTo org lookup
@@ -377,6 +382,7 @@ describe('sendQuote email delivery status', () => {
     queueResult([]); // blocks
     queueResult([lineRow]); // lines
     queueResult([]); // no staged Pax8 order
+    queueResult([]); // no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
     queueResult([org]); // getQuote's draft billTo org lookup
@@ -584,6 +590,7 @@ describe('sendQuote bill-to snapshot', () => {
     queueResult([]);       // getQuote: blocks
     queueResult([{ quantity: '1', unitPrice: '100.00', taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false, lineTotal: '100.00' }]); // getQuote: lines
     queueResult([]);       // getQuote: no staged Pax8 order
+    queueResult([]);       // getQuote: no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
     queueResult([org]);    // getQuote's own draft billTo org lookup (status is 'draft' for every quote sent through this helper)
@@ -726,6 +733,7 @@ describe('sendQuote presentation snapshot', () => {
     queueResult([]);       // getQuote: blocks
     queueResult([{ quantity: '1', unitPrice: '100.00', taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false, lineTotal: '100.00' }]); // getQuote: lines
     queueResult([]);       // getQuote: no staged Pax8 order
+    queueResult([]);       // getQuote: no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
     queueResult([{ name: 'Customer Co', taxId: null, billingAddressLine1: null, billingAddressLine2: null, billingAddressCity: null, billingAddressRegion: null, billingAddressPostalCode: null, billingAddressCountry: null }]); // getQuote's own draft billTo org lookup
@@ -810,6 +818,7 @@ describe('sendQuote document_locale stamp', () => {
     queueResult([]);       // getQuote: blocks
     queueResult([{ quantity: '1', unitPrice: '100.00', taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false, lineTotal: '100.00' }]); // getQuote: lines
     queueResult([]);       // getQuote: no staged Pax8 order
+    queueResult([]);       // getQuote: no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
     queueResult([{ name: 'Customer Co', taxId: null, billingAddressLine1: null, billingAddressLine2: null, billingAddressCity: null, billingAddressRegion: null, billingAddressPostalCode: null, billingAddressCountry: null }]); // getQuote's own draft billTo org lookup
@@ -938,6 +947,7 @@ describe('sendQuote contract-variable gate', () => {
     queueResult([contractBlock({})]);       // getQuote: blocks — governing_state left blank
     queueResult([]);                        // getQuote: lines
     queueResult([]);                        // getQuote: no staged Pax8 order
+    queueResult([]);                        // getQuote: no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
     queueResult([org]);                     // getQuote's own draft billTo org lookup
@@ -958,6 +968,7 @@ describe('sendQuote contract-variable gate', () => {
     queueResult([contractBlock({})]);
     queueResult([]);
     queueResult([]); // getQuote: no staged Pax8 order
+    queueResult([]); // getQuote: no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
     queueResult([org]);
@@ -975,6 +986,7 @@ describe('sendQuote contract-variable gate', () => {
     queueResult([contractBlock({ governing_state: 'Texas' })]); // getQuote: blocks — filled in
     queueResult([{ quantity: '1', unitPrice: '100.00', taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false, lineTotal: '100.00' }]); // getQuote: lines
     queueResult([]);                        // getQuote: no staged Pax8 order
+    queueResult([]);                        // getQuote: no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
     queueResult([org]);                     // getQuote's own draft billTo org lookup
@@ -1015,6 +1027,7 @@ describe('sendQuote contract-variable gate', () => {
     queueResult([contractBlock({})]);        // getQuote: blocks
     queueResult([{ quantity: '1', unitPrice: '100.00', taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false, lineTotal: '100.00' }]); // getQuote: lines
     queueResult([]);                         // getQuote: no staged Pax8 order
+    queueResult([]);                         // getQuote: no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
     queueResult([org]);                      // getQuote's own draft billTo org lookup
@@ -1069,6 +1082,7 @@ describe('resendQuote', () => {
     queueResult([]); // blocks
     queueResult([{ quantity: '1', unitPrice: '1000.00', taxable: false, customerVisible: true, recurrence: 'one_time', depositEligible: false }]);
     queueResult([]); // no staged Pax8 order
+    queueResult([]); // no successor revision
     queueResult([]); // listQuoteOrders — headers
     queueResult([]); // listQuoteOrders — lines
   }
@@ -1231,6 +1245,7 @@ describe('getQuoteShareLink', () => {
     queueResult([]);
     queueResult([]);
     queueResult([]);
+    queueResult([]); // no successor revision
     queueResult([]);
     queueResult([]);
   }

--- a/apps/api/src/services/quoteService.clone.test.ts
+++ b/apps/api/src/services/quoteService.clone.test.ts
@@ -98,6 +98,7 @@ describe('cloneQuote', () => {
       // here means "no staged order", which short-circuits the pax8OrderLineSummary
       // query below it so no extra select is consumed from this queue.
       [],
+      [], // no successor revision
       [], // getQuote: listQuoteOrders — order headers
       [], // getQuote: listQuoteOrders — order lines
       [{ id: 'image-1', quoteId: 'quote-1', orgId: 'org-1', imageData: Buffer.from('image'), mime: 'image/png', byteSize: 5, sha256: 'hash', createdAt: new Date() }],
@@ -140,6 +141,7 @@ describe('cloneQuote', () => {
       [{ id: 'block-lines', quoteId: 'quote-1', orgId: 'org-1', blockType: 'line_items', content: { label: 'Services' }, sortOrder: 0, createdAt: new Date() }],
       [{ id: 'line-1', quoteId: 'quote-1', blockId: 'block-lines', orgId: 'org-1', sourceType: 'manual', catalogItemId: null, parentLineId: null, name: 'Server', description: null, quantity: '1.00', unitPrice: '100.00', taxable: true, customerVisible: true, lineTotal: '100.00', recurrence: 'one_time', termMonths: null, billingFrequency: null, unitCost: null, depositEligible: true, itemType: 'hardware', sku: null, partNumber: null, imageId: 'image-1', sortOrder: 0, createdAt: new Date() }],
       [], // no staged Pax8 order
+      [], // no successor revision
       [], // getQuote: listQuoteOrders — order headers
       [], // getQuote: listQuoteOrders — order lines
       [{ id: 'image-1', quoteId: 'quote-1', orgId: 'org-1', imageData: Buffer.from('image'), mime: 'image/png', byteSize: 5, sha256: 'hash', createdAt: new Date() }],
@@ -218,6 +220,7 @@ describe('cloneQuote', () => {
       [], // no blocks
       [], // no lines
       [], // no staged Pax8 order
+      [], // no successor revision
       [], // getQuote: listQuoteOrders — order headers
       [], // getQuote: listQuoteOrders — order lines
       [], // no images
@@ -282,6 +285,7 @@ describe('cloneQuote', () => {
       [{ id: 'block-contract', quoteId: 'quote-1', orgId: 'org-1', blockType: 'contract', content: contractContent, sortOrder: 0, createdAt: new Date() }],
       [], // no lines
       [], // no staged Pax8 order
+      [], // no successor revision
       [], // getQuote: listQuoteOrders — order headers
       [], // getQuote: listQuoteOrders — order lines
       [], // no images
@@ -305,6 +309,7 @@ describe('cloneQuote', () => {
       [{ id: 'block-contract', quoteId: 'quote-1', orgId: 'org-1', blockType: 'contract', content: contractContent, sortOrder: 0, createdAt: new Date() }],
       [], // no lines
       [], // no staged Pax8 order
+      [], // no successor revision
       [], // getQuote: listQuoteOrders — order headers
       [], // getQuote: listQuoteOrders — order lines
       [], // no images
@@ -332,6 +337,7 @@ describe('cloneQuote', () => {
       [], // no blocks
       [], // no lines
       [], // no staged Pax8 order
+      [], // no successor revision
       [], // getQuote: listQuoteOrders — order headers
       [], // getQuote: listQuoteOrders — order lines
       [{ id: 'image-1', quoteId: 'quote-1', orgId: 'org-1', imageData: Buffer.from('image'), mime: 'image/png', byteSize: 5, sha256: 'hash', createdAt: new Date() }],

--- a/apps/api/src/services/quoteService.revise.test.ts
+++ b/apps/api/src/services/quoteService.revise.test.ts
@@ -68,6 +68,10 @@ function collectBoundParams(node: unknown): { column: string; value: unknown }[]
 }
 
 const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+const siteRestrictedActor = {
+  ...actor,
+  allowedSiteIds: ['site-allowed'],
+};
 const quote = (over: Record<string, unknown> = {}) => ({
   id: 'q1',
   partnerId: 'p1',
@@ -96,7 +100,7 @@ function queueGetQuote(row: Record<string, unknown>) {
   queueResult([]); // lines
   queueResult([]); // no staged Pax8 order
   if (row.revisionOfQuoteId) {
-    queueResult([{ id: row.revisionOfQuoteId, quoteNumber: null }]); // immediate parent
+    queueResult([{ id: row.revisionOfQuoteId, quoteNumber: null, siteId: row.siteId ?? null }]); // immediate parent
     queueResult([]); // parent recipients
   }
   queueResult([]); // no successor
@@ -131,6 +135,13 @@ describe('reviseQuote', () => {
       .rejects.toMatchObject({ code: 'PARENT_CONVERTED', status: 409 });
   });
 
+  it('rejects an accepted parent with PARENT_CONVERTED', async () => {
+    queueGetQuote(quote({ status: 'accepted' }));
+
+    await expect(svc.reviseQuote('q1', actor))
+      .rejects.toMatchObject({ code: 'PARENT_CONVERTED', status: 409 });
+  });
+
   it('rejects a superseded parent and reports its successor id', async () => {
     queueGetQuote(quote({ status: 'superseded' }));
     queueResult([{ id: 'q2' }]);
@@ -139,6 +150,24 @@ describe('reviseQuote', () => {
       code: 'ALREADY_SUPERSEDED',
       status: 409,
       meta: { successorQuoteId: 'q2' },
+    });
+
+    // Pin THIS lookup's predicate (the last where before the throw). A
+    // toContainEqual would also be satisfied by getQuote's internal successor
+    // query, staying green even if this branch queried the wrong column.
+    const predicates = (db as unknown as Chain).where.mock.calls
+      .map(([where]) => collectBoundParams(where));
+    expect(predicates.at(-1)).toEqual([{ column: 'revision_of_quote_id', value: 'q1' }]);
+  });
+
+  it('uses a distinct error when a superseded parent has no successor row', async () => {
+    queueGetQuote(quote({ status: 'superseded' }));
+    queueResult([]);
+
+    await expect(svc.reviseQuote('q1', actor)).rejects.toMatchObject({
+      code: 'ALREADY_SUPERSEDED',
+      status: 409,
+      message: 'This quote is marked as superseded, but its replacement could not be found',
     });
   });
 
@@ -151,6 +180,14 @@ describe('reviseQuote', () => {
       status: 409,
       meta: { revisionQuoteId: 'q2' },
     });
+
+    // Pin the PRE-CHECK's own predicate (the last where before the throw), not
+    // merely "some query somewhere used revision_of_quote_id" — getQuote's
+    // internal successor lookup also matches that, so a toContainEqual here
+    // stays green even when this pre-check queries the wrong column.
+    const predicates = (db as unknown as Chain).where.mock.calls
+      .map(([where]) => collectBoundParams(where));
+    expect(predicates.at(-1)).toEqual([{ column: 'revision_of_quote_id', value: 'q1' }]);
   });
 
   it('creates R2 from a sent root without allocating a new quote counter', async () => {
@@ -159,15 +196,8 @@ describe('reviseQuote', () => {
     queueResult([]); // no successor
     queueSuccessfulClone(parent, quote({ id: 'q2', status: 'draft', quoteNumber: 'Q-2026-0042-R2', revisionOfQuoteId: 'q1', revisionNumber: 2 }));
 
-    const revised = await svc.reviseQuote('q1', actor);
+    await svc.reviseQuote('q1', actor);
 
-    expect(revised).toMatchObject({
-      id: 'q2',
-      status: 'draft',
-      quoteNumber: 'Q-2026-0042-R2',
-      revisionOfQuoteId: 'q1',
-      revisionNumber: 2,
-    });
     expect(allocateQuoteCounter).not.toHaveBeenCalled();
     const inserted = (db as unknown as Chain).values.mock.calls[0]![0];
     expect(inserted).toMatchObject({
@@ -189,15 +219,51 @@ describe('reviseQuote', () => {
     queueResult([quote({ id: 'q1' })]); // lineage root read
     queueSuccessfulClone(parent, quote({ id: 'q3', status: 'draft', quoteNumber: 'Q-2026-0042-R3', revisionOfQuoteId: 'q2', revisionNumber: 3 }));
 
-    const revised = await svc.reviseQuote('q2', actor);
+    await svc.reviseQuote('q2', actor);
 
-    expect(revised.quoteNumber).toBe('Q-2026-0042-R3');
-    expect(revised.quoteNumber).not.toContain('-R2-R3');
     const inserted = (db as unknown as Chain).values.mock.calls[0]![0];
     expect(inserted).toMatchObject({
       quoteNumber: 'Q-2026-0042-R3',
       revisionOfQuoteId: 'q2',
       revisionNumber: 3,
+    });
+    // Pin the WALK's direction: the lineage read is the query immediately after
+    // the successor pre-check, and it must look the parent up BY ID. A bare
+    // toContainEqual passes even when the walk is inverted to
+    // `revision_of_quote_id = current.id`, which would climb the wrong way and
+    // derive the number from the wrong root.
+    const predicates = (db as unknown as Chain).where.mock.calls
+      .map(([where]) => collectBoundParams(where));
+    // `revision_of_quote_id = q2` occurs three times here (getQuote's own
+    // successor field, this pre-check, then clone's getQuote), so neither the
+    // first nor the last match is the pre-check. Assert the ADJACENT PAIR
+    // instead: the pre-check must be followed immediately by the walk looking
+    // the parent up BY ID. Inverting the walk to `revision_of_quote_id =
+    // current.id` breaks the pair, which a bare toContainEqual would not catch.
+    const seq = predicates.map((p) => JSON.stringify(p));
+    const preCheck = JSON.stringify([{ column: 'revision_of_quote_id', value: 'q2' }]);
+    const walk = JSON.stringify([{ column: 'id', value: 'q1' }]);
+    const pairFound = seq.some((p, i) => p === preCheck && seq[i + 1] === walk);
+    expect(pairFound).toBe(true);
+  });
+
+  it.each(['viewed', 'declined', 'expired'])('creates a revision from a %s parent', async (status) => {
+    const parent = quote({ status });
+    queueGetQuote(parent);
+    queueResult([]); // no successor
+    queueSuccessfulClone(parent, quote({
+      id: 'q2',
+      status: 'draft',
+      quoteNumber: 'Q-2026-0042-R2',
+      revisionOfQuoteId: 'q1',
+      revisionNumber: 2,
+    }));
+
+    await svc.reviseQuote('q1', actor);
+
+    expect((db as unknown as Chain).values.mock.calls[0]![0]).toMatchObject({
+      revisionOfQuoteId: 'q1',
+      revisionNumber: 2,
     });
   });
 
@@ -208,21 +274,116 @@ describe('reviseQuote', () => {
       .rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
   });
 
-  it('maps the unique-successor insert race to REVISION_IN_PROGRESS', async () => {
+  it('maps a wrapped unique-successor insert race to REVISION_IN_PROGRESS with the winner id', async () => {
     const parent = quote();
     queueGetQuote(parent);
     queueResult([]); // no successor
     queueGetQuote(parent); // clone source read
     queueResult([]); // images
-    queueError(Object.assign(new Error('duplicate key'), {
-      code: '23505',
-      constraint: 'quotes_revision_of_uq',
+    queueError(Object.assign(new Error('Failed query: insert into quotes'), {
+      cause: {
+        code: '23505',
+        constraint_name: 'quotes_revision_of_uq',
+        message: 'duplicate key value violates unique constraint "quotes_revision_of_uq"',
+      },
     }));
+    queueResult([{ id: 'q-race-winner' }]);
 
     await expect(svc.reviseQuote('q1', actor)).rejects.toMatchObject({
       code: 'REVISION_IN_PROGRESS',
       status: 409,
+      meta: { revisionQuoteId: 'q-race-winner' },
     });
+  });
+
+  it('propagates a wrapped 23505 from a different constraint unchanged', async () => {
+    const parent = quote();
+    const error = Object.assign(new Error('Failed query: insert into quotes'), {
+      cause: {
+        code: '23505',
+        constraint_name: 'quotes_partner_number_uq',
+        message: 'duplicate key value violates unique constraint "quotes_partner_number_uq"',
+      },
+    });
+    queueGetQuote(parent);
+    queueResult([]); // no successor
+    queueGetQuote(parent); // clone source read
+    queueResult([]); // images
+    queueError(error);
+
+    await expect(svc.reviseQuote('q1', actor)).rejects.toBe(error);
+  });
+
+  it('propagates a generic clone insert error unchanged', async () => {
+    const parent = quote();
+    const error = new Error('boom');
+    queueGetQuote(parent);
+    queueResult([]); // no successor
+    queueGetQuote(parent); // clone source read
+    queueResult([]); // images
+    queueError(error);
+
+    await expect(svc.reviseQuote('q1', actor)).rejects.toBe(error);
+  });
+
+  it('rejects a corrupt lineage whose parent row is missing', async () => {
+    const parent = quote({ id: 'q2', revisionOfQuoteId: 'q1', revisionNumber: 2 });
+    queueGetQuote(parent);
+    queueResult([]); // no successor
+    queueResult([]); // lineage parent missing
+
+    await expect(svc.reviseQuote('q2', actor))
+      .rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
+  });
+
+  it('rejects a lineage that exhausts the 100-hop cycle guard', async () => {
+    const parent = quote({ id: 'q101', revisionOfQuoteId: 'q100', revisionNumber: 101 });
+    queueGetQuote(parent);
+    queueResult([]); // no successor
+    for (let id = 100; id >= 1; id -= 1) {
+      queueResult([quote({ id: `q${id}`, revisionOfQuoteId: `q${id - 1}`, revisionNumber: id })]);
+    }
+
+    await expect(svc.reviseQuote('q101', actor))
+      .rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
+  });
+
+  it.each([
+    ['a revision number below 2', quote({ revisionNumber: 0 })],
+    ['a non-integer revision number', quote({ revisionNumber: 1.5 })],
+    ['an empty parent id', quote({ id: '' })],
+  ])('rejects clone lineage with %s', async (_label, parent) => {
+    queueGetQuote(parent);
+    queueResult([]); // no successor
+    queueGetQuote(parent); // clone source read
+    queueResult([]); // images
+
+    await expect(svc.reviseQuote(String(parent.id), actor))
+      .rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
+  });
+});
+
+describe('cloneQuote revision boundary', () => {
+  beforeEach(() => {
+    results.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('rejects retargeting when an internal revision override is supplied', async () => {
+    const cloneWithInternalOverride = svc.cloneQuote as unknown as (
+      id: string,
+      quoteActor: typeof actor,
+      input: { orgId: string },
+      revision: { quoteNumber: string; revisionOfQuoteId: string; revisionNumber: number },
+    ) => Promise<unknown>;
+    queueGetQuote(quote());
+    queueResult([]); // images
+
+    await expect(cloneWithInternalOverride('q1', actor, { orgId: 'org2' }, {
+      quoteNumber: 'Q-2026-0042-R2',
+      revisionOfQuoteId: 'q1',
+      revisionNumber: 2,
+    })).rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
   });
 });
 
@@ -244,9 +405,9 @@ describe('getQuote revision lineage', () => {
     queueResult([]); // blocks
     queueResult([]); // lines
     queueResult([]); // no staged Pax8 order
-    queueResult([{ id: 'q1', quoteNumber: 'Q-2026-0042' }]);
+    queueResult([{ id: 'q1', quoteNumber: 'Q-2026-0042', siteId: null }]);
     queueResult([{ email: 'buyer@example.com' }, { email: 'cfo@example.com' }]);
-    queueResult([{ id: 'q3', quoteNumber: 'Q-2026-0042-R3', status: 'draft' }]);
+    queueResult([{ id: 'q3', quoteNumber: 'Q-2026-0042-R3', status: 'draft', siteId: null }]);
     queueResult([]); // quote order headers
     queueResult([]); // quote order lines
 
@@ -268,6 +429,67 @@ describe('getQuote revision lineage', () => {
     expect(predicates).toContainEqual([{ column: 'id', value: 'q1' }]);
     expect(predicates).toContainEqual([{ column: 'quote_id', value: 'q1' }]);
     expect(predicates).toContainEqual([{ column: 'revision_of_quote_id', value: 'q2' }]);
+  });
+
+  it('hides revisionOf and parent recipients when the parent site is denied', async () => {
+    const child = quote({
+      id: 'q2',
+      siteId: 'site-allowed',
+      revisionOfQuoteId: 'q1',
+      revisionNumber: 2,
+    });
+    queueResult([child]);
+    queueResult([]); // blocks
+    queueResult([]); // lines
+    queueResult([]); // no staged Pax8 order
+    queueResult([{ id: 'q1', quoteNumber: 'Q-2026-0042', siteId: 'site-denied' }]);
+    queueResult([]); // no successor
+    queueResult([]); // quote order headers
+    queueResult([]); // quote order lines
+
+    const detail = await svc.getQuote('q2', siteRestrictedActor);
+
+    expect(detail.revisionOf).toBeNull();
+    const predicates = (db as unknown as Chain).where.mock.calls
+      .map(([where]) => collectBoundParams(where));
+    expect(predicates).not.toContainEqual([{ column: 'quote_id', value: 'q1' }]);
+  });
+
+  it('hides successor when the successor site is denied', async () => {
+    const parent = quote({ siteId: 'site-allowed' });
+    queueResult([parent]);
+    queueResult([]); // blocks
+    queueResult([]); // lines
+    queueResult([]); // no staged Pax8 order
+    queueResult([{ id: 'q2', quoteNumber: 'Q-2026-0042-R2', status: 'draft', siteId: 'site-denied' }]);
+    queueResult([]); // quote order headers
+    queueResult([]); // quote order lines
+
+    const detail = await svc.getQuote('q1', siteRestrictedActor);
+
+    expect(detail.successor).toBeNull();
+  });
+
+  it('logs a stable error id and stays non-fatal when a linked parent is missing', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const child = quote({ id: 'q2', revisionOfQuoteId: 'q1', revisionNumber: 2 });
+    queueResult([child]);
+    queueResult([]); // blocks
+    queueResult([]); // lines
+    queueResult([]); // no staged Pax8 order
+    queueResult([]); // corrupt missing parent
+    queueResult([]); // no successor
+    queueResult([]); // quote order headers
+    queueResult([]); // quote order lines
+
+    const detail = await svc.getQuote('q2', actor);
+
+    expect(detail.revisionOf).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('QUOTE_LINEAGE_PARENT_MISSING'),
+      expect.objectContaining({ quoteId: 'q2', revisionOfQuoteId: 'q1' }),
+    );
+    errorSpy.mockRestore();
   });
 });
 

--- a/apps/api/src/services/quoteService.revise.test.ts
+++ b/apps/api/src/services/quoteService.revise.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Param, SQL } from 'drizzle-orm';
 
 // Controllable Drizzle chain mock (same pattern as quoteService.test.ts): every
 // builder method returns the same chain; a query resolves when awaited. The
@@ -44,7 +45,27 @@ import * as svc from './quoteService';
 type Chain = {
   set: { mock: { calls: unknown[][] } };
   values: { mock: { calls: unknown[][] } };
+  where: { mock: { calls: unknown[][] } };
 };
+
+function collectBoundParams(node: unknown): { column: string; value: unknown }[] {
+  const found: { column: string; value: unknown }[] = [];
+  const seen = new WeakSet<object>();
+  const visit = (value: unknown) => {
+    if (value == null || typeof value !== 'object' || seen.has(value as object)) return;
+    seen.add(value as object);
+    if (value instanceof Param) {
+      const encoder = (value as { encoder?: { name?: string } }).encoder;
+      found.push({ column: encoder?.name ?? '<unknown>', value: (value as { value: unknown }).value });
+      return;
+    }
+    if (value instanceof SQL) {
+      for (const chunk of (value as unknown as { queryChunks: unknown[] }).queryChunks) visit(chunk);
+    }
+  };
+  visit(node);
+  return found;
+}
 
 const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
 const quote = (over: Record<string, unknown> = {}) => ({
@@ -74,6 +95,11 @@ function queueGetQuote(row: Record<string, unknown>) {
   queueResult([]); // blocks
   queueResult([]); // lines
   queueResult([]); // no staged Pax8 order
+  if (row.revisionOfQuoteId) {
+    queueResult([{ id: row.revisionOfQuoteId, quoteNumber: null }]); // immediate parent
+    queueResult([]); // parent recipients
+  }
+  queueResult([]); // no successor
   queueResult([]); // quote order headers
   queueResult([]); // quote order lines
   if (row.status === 'draft') queueResult([{ name: 'Customer' }]); // draft bill-to org
@@ -197,6 +223,51 @@ describe('reviseQuote', () => {
       code: 'REVISION_IN_PROGRESS',
       status: 409,
     });
+  });
+});
+
+describe('getQuote revision lineage', () => {
+  beforeEach(() => {
+    results.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('populates the immediate parent recipients and immediate successor', async () => {
+    const child = quote({
+      id: 'q2',
+      status: 'sent',
+      quoteNumber: 'Q-2026-0042-R2',
+      revisionOfQuoteId: 'q1',
+      revisionNumber: 2,
+    });
+    queueResult([child]);
+    queueResult([]); // blocks
+    queueResult([]); // lines
+    queueResult([]); // no staged Pax8 order
+    queueResult([{ id: 'q1', quoteNumber: 'Q-2026-0042' }]);
+    queueResult([{ email: 'buyer@example.com' }, { email: 'cfo@example.com' }]);
+    queueResult([{ id: 'q3', quoteNumber: 'Q-2026-0042-R3', status: 'draft' }]);
+    queueResult([]); // quote order headers
+    queueResult([]); // quote order lines
+
+    const detail = await svc.getQuote('q2', actor);
+
+    expect(detail.revisionOf).toEqual({
+      id: 'q1',
+      quoteNumber: 'Q-2026-0042',
+      recipients: ['buyer@example.com', 'cfo@example.com'],
+    });
+    expect(detail.successor).toEqual({
+      id: 'q3',
+      quoteNumber: 'Q-2026-0042-R3',
+      status: 'draft',
+    });
+
+    const predicates = (db as unknown as Chain).where.mock.calls
+      .map(([where]) => collectBoundParams(where));
+    expect(predicates).toContainEqual([{ column: 'id', value: 'q1' }]);
+    expect(predicates).toContainEqual([{ column: 'quote_id', value: 'q1' }]);
+    expect(predicates).toContainEqual([{ column: 'revision_of_quote_id', value: 'q2' }]);
   });
 });
 

--- a/apps/api/src/services/quoteService.revise.test.ts
+++ b/apps/api/src/services/quoteService.revise.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Controllable Drizzle chain mock (same pattern as quoteService.test.ts): every
+// builder method returns the same chain; a query resolves when awaited. The
+// error variant lets the insert race test surface a Postgres-shaped rejection.
+const results: Array<unknown[] | Error> = [];
+function queueResult(rows: unknown[]) { results.push(rows); }
+function queueError(error: Error) { results.push(error); }
+
+vi.mock('../db', () => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {};
+    const methods = ['select', 'from', 'where', 'limit', 'orderBy', 'insert', 'values', 'returning', 'update', 'set', 'delete', 'for', 'innerJoin', 'leftJoin', 'execute'];
+    for (const method of methods) chain[method] = vi.fn(() => chain);
+    chain.transaction = vi.fn(async (run: (tx: unknown) => unknown) => run(chain));
+    (chain as { then: unknown }).then = (
+      resolve: (value: unknown) => unknown,
+      reject: (reason: unknown) => unknown,
+    ) => {
+      const result = results.shift() ?? [];
+      return result instanceof Error
+        ? Promise.reject(result).then(resolve, reject)
+        : Promise.resolve(result).then(resolve, reject);
+    };
+    return chain;
+  };
+  const db = makeChain();
+  return {
+    db,
+    runOutsideDbContext: (fn: () => unknown) => fn(),
+    withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  };
+});
+
+vi.mock('./quoteNumbers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./quoteNumbers')>();
+  return { ...actual, allocateQuoteCounter: vi.fn() };
+});
+
+import { db } from '../db';
+import { allocateQuoteCounter } from './quoteNumbers';
+import * as svc from './quoteService';
+
+type Chain = {
+  set: { mock: { calls: unknown[][] } };
+  values: { mock: { calls: unknown[][] } };
+};
+
+const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+const quote = (over: Record<string, unknown> = {}) => ({
+  id: 'q1',
+  partnerId: 'p1',
+  orgId: 'org1',
+  siteId: null,
+  quoteNumber: 'Q-2026-0042',
+  title: 'Proposal',
+  status: 'sent',
+  currencyCode: 'USD',
+  taxRate: null,
+  depositType: 'none',
+  depositPercent: null,
+  billToName: 'Customer',
+  billToAddress: null,
+  billToTaxId: null,
+  coverPage: null,
+  revisionOfQuoteId: null,
+  revisionNumber: 1,
+  ...over,
+});
+
+/** Queue the complete read shape issued by getQuote for an empty quote. */
+function queueGetQuote(row: Record<string, unknown>) {
+  queueResult([row]);
+  queueResult([]); // blocks
+  queueResult([]); // lines
+  queueResult([]); // no staged Pax8 order
+  queueResult([]); // quote order headers
+  queueResult([]); // quote order lines
+  if (row.status === 'draft') queueResult([{ name: 'Customer' }]); // draft bill-to org
+}
+
+function queueSuccessfulClone(source: Record<string, unknown>, inserted: Record<string, unknown>) {
+  queueGetQuote(source);
+  queueResult([]); // images
+  queueResult([inserted]); // quote insert returning
+}
+
+describe('reviseQuote', () => {
+  beforeEach(() => {
+    results.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('rejects a draft parent with INVALID_STATE', async () => {
+    queueGetQuote(quote({ status: 'draft' }));
+
+    await expect(svc.reviseQuote('q1', actor))
+      .rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
+  });
+
+  it('rejects a converted parent with PARENT_CONVERTED', async () => {
+    queueGetQuote(quote({ status: 'converted' }));
+
+    await expect(svc.reviseQuote('q1', actor))
+      .rejects.toMatchObject({ code: 'PARENT_CONVERTED', status: 409 });
+  });
+
+  it('rejects a superseded parent and reports its successor id', async () => {
+    queueGetQuote(quote({ status: 'superseded' }));
+    queueResult([{ id: 'q2' }]);
+
+    await expect(svc.reviseQuote('q1', actor)).rejects.toMatchObject({
+      code: 'ALREADY_SUPERSEDED',
+      status: 409,
+      meta: { successorQuoteId: 'q2' },
+    });
+  });
+
+  it('rejects a parent with an existing draft successor', async () => {
+    queueGetQuote(quote());
+    queueResult([{ id: 'q2', status: 'draft' }]);
+
+    await expect(svc.reviseQuote('q1', actor)).rejects.toMatchObject({
+      code: 'REVISION_IN_PROGRESS',
+      status: 409,
+      meta: { revisionQuoteId: 'q2' },
+    });
+  });
+
+  it('creates R2 from a sent root without allocating a new quote counter', async () => {
+    const parent = quote();
+    queueGetQuote(parent);
+    queueResult([]); // no successor
+    queueSuccessfulClone(parent, quote({ id: 'q2', status: 'draft', quoteNumber: 'Q-2026-0042-R2', revisionOfQuoteId: 'q1', revisionNumber: 2 }));
+
+    const revised = await svc.reviseQuote('q1', actor);
+
+    expect(revised).toMatchObject({
+      id: 'q2',
+      status: 'draft',
+      quoteNumber: 'Q-2026-0042-R2',
+      revisionOfQuoteId: 'q1',
+      revisionNumber: 2,
+    });
+    expect(allocateQuoteCounter).not.toHaveBeenCalled();
+    const inserted = (db as unknown as Chain).values.mock.calls[0]![0];
+    expect(inserted).toMatchObject({
+      quoteNumber: 'Q-2026-0042-R2',
+      revisionOfQuoteId: 'q1',
+      revisionNumber: 2,
+    });
+  });
+
+  it('creates R3 from the root stored number instead of appending to the R2 number', async () => {
+    const parent = quote({
+      id: 'q2',
+      quoteNumber: 'Q-2026-0042-R2',
+      revisionOfQuoteId: 'q1',
+      revisionNumber: 2,
+    });
+    queueGetQuote(parent);
+    queueResult([]); // no successor
+    queueResult([quote({ id: 'q1' })]); // lineage root read
+    queueSuccessfulClone(parent, quote({ id: 'q3', status: 'draft', quoteNumber: 'Q-2026-0042-R3', revisionOfQuoteId: 'q2', revisionNumber: 3 }));
+
+    const revised = await svc.reviseQuote('q2', actor);
+
+    expect(revised.quoteNumber).toBe('Q-2026-0042-R3');
+    expect(revised.quoteNumber).not.toContain('-R2-R3');
+    const inserted = (db as unknown as Chain).values.mock.calls[0]![0];
+    expect(inserted).toMatchObject({
+      quoteNumber: 'Q-2026-0042-R3',
+      revisionOfQuoteId: 'q2',
+      revisionNumber: 3,
+    });
+  });
+
+  it('rejects a legacy parent without a quote number', async () => {
+    queueGetQuote(quote({ quoteNumber: null }));
+
+    await expect(svc.reviseQuote('q1', actor))
+      .rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
+  });
+
+  it('maps the unique-successor insert race to REVISION_IN_PROGRESS', async () => {
+    const parent = quote();
+    queueGetQuote(parent);
+    queueResult([]); // no successor
+    queueGetQuote(parent); // clone source read
+    queueResult([]); // images
+    queueError(Object.assign(new Error('duplicate key'), {
+      code: '23505',
+      constraint: 'quotes_revision_of_uq',
+    }));
+
+    await expect(svc.reviseQuote('q1', actor)).rejects.toMatchObject({
+      code: 'REVISION_IN_PROGRESS',
+      status: 409,
+    });
+  });
+});
+
+describe('updateQuote revision retarget guard', () => {
+  beforeEach(() => {
+    results.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('rejects moving a revision draft to another org before any write', async () => {
+    const orgActor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1', 'org2'] };
+    queueResult([quote({
+      id: 'q2',
+      status: 'draft',
+      revisionOfQuoteId: 'q1',
+      revisionNumber: 2,
+    })]);
+
+    await expect(svc.updateQuote('q2', { orgId: 'org2' }, orgActor))
+      .rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
+    expect((db as unknown as Chain).set.mock.calls).toEqual([]);
+  });
+});

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -396,6 +396,7 @@ describe('quoteService deposits', () => {
     queueResult(blocks); // getQuote: blocks
     queueResult(lines); // getQuote: lines
     queueResult([]); // getQuote: no staged Pax8 order
+    queueResult([]); // getQuote: no successor revision
     queueResult([]); // getQuote: listQuoteOrders — order headers
     queueResult([]); // getQuote: listQuoteOrders — order lines
     queueResult([{ name: 'Org Inc' }]); // getQuote: draft bill-to org lookup
@@ -480,6 +481,7 @@ describe('quoteService deposits', () => {
     queueResult([]); // blocks
     queueResult([]); // lines
     queueResult([]); // no staged Pax8 order
+    queueResult([]); // no successor revision
     queueResult([
       { id: 'ord-1', quoteId: 'q1', orgId: 'org1', clientRequestId: 'c1' },
       { id: 'ord-2', quoteId: 'q1', orgId: 'org1', clientRequestId: 'c2' },
@@ -507,6 +509,7 @@ describe('quoteService deposits', () => {
     queueResult([]); // blocks
     queueResult([{ quantity: '1', unitPrice: '1000.00', taxable: true, customerVisible: true, recurrence: 'one_time', depositEligible: false, itemType: 'hardware' }]); // lines
     queueResult([]); // no staged Pax8 order
+    queueResult([]); // no successor revision
     queueResult([]); // listQuoteOrders — order headers
     queueResult([]); // listQuoteOrders — order lines
 
@@ -527,6 +530,9 @@ describe('quoteService deposits', () => {
       { sourceQuoteLineId: 'ql-1', submitState: 'pending', quantity: '1.00' },
       { sourceQuoteLineId: 'ql-2', submitState: 'pending', quantity: '2.00' },
     ]);
+    queueResult([]); // no successor revision
+    queueResult([]); // listQuoteOrders — order headers
+    queueResult([]); // listQuoteOrders — order lines
 
     const detail = await svc.getQuote('q1', actor);
 
@@ -547,6 +553,9 @@ describe('quoteService deposits', () => {
     queueResult([]); // blocks
     queueResult([]); // quote lines
     queueResult([]); // no Pax8 order for this quote/tenant
+    queueResult([]); // no successor revision
+    queueResult([]); // listQuoteOrders — order headers
+    queueResult([]); // listQuoteOrders — order lines
 
     const detail = await svc.getQuote('q1', actor);
 
@@ -563,6 +572,9 @@ describe('quoteService deposits', () => {
     queueResult([]); // blocks
     queueResult([]); // lines
     queueResult([]); // no staged Pax8 order
+    queueResult([]); // no successor revision
+    queueResult([]); // listQuoteOrders — order headers
+    queueResult([]); // listQuoteOrders — order lines
     // Deliberately queue NO org row: a sent quote must not query the live org at all.
 
     const { billTo } = await svc.getQuote('q1', actor);
@@ -576,6 +588,7 @@ describe('quoteService deposits', () => {
     queueResult([]); // blocks
     queueResult([]); // lines
     queueResult([]); // no staged Pax8 order
+    queueResult([]); // no successor revision
     queueResult([]); // listQuoteOrders — order headers
     queueResult([]); // listQuoteOrders — order lines
     queueResult([{ name: 'Org Inc', taxId: 'ORG-TAX', billingAddressLine1: 'Org St', billingAddressLine2: null, billingAddressCity: 'Berthoud', billingAddressRegion: 'CO', billingAddressPostalCode: '80513', billingAddressCountry: 'US' }]); // org billing
@@ -667,6 +680,9 @@ describe('quoteService deposits', () => {
     ]); // blocks (one legacy dirty row, one unrelated block type)
     queueResult([]); // quote lines
     queueResult([]); // no staged Pax8 order
+    queueResult([]); // no successor revision
+    queueResult([]); // listQuoteOrders — order headers
+    queueResult([]); // listQuoteOrders — order lines
 
     const { blocks } = await svc.getQuote('q1', actor);
 

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -15,6 +15,7 @@ import { buildBillToAddress, type BillToAddress } from './sellerSnapshot';
 import { computeQuoteTotals, validateQuoteDeposit, toQuoteDepositConfig, type QuoteLineForMath } from './quoteMath';
 import { QuoteServiceError, assertOrg, assertSite, assertQuoteAccess, type QuoteActor } from './quoteTypes';
 import { allocateQuoteCounter, formatQuoteNumber } from './quoteNumbers';
+import { isPgUniqueViolation } from '../utils/pgErrors';
 import {
   sanitizeRichTextHtml,
   sanitizeRichTextHtmlWithReport,
@@ -205,6 +206,14 @@ function logStrippedMarkup(op: string, quoteId: string, blockId: string, warning
     blockId,
     warnings: warnings.map((w) => ({ field: w.field, removedTags: w.removedTags })),
   });
+}
+
+const errorIds = {
+  QUOTE_LINEAGE_PARENT_MISSING: 'QUOTE_LINEAGE_PARENT_MISSING',
+} as const;
+
+function logError(errorId: typeof errorIds[keyof typeof errorIds], message: string, context: Record<string, unknown>): void {
+  console.error(`[quoteService] ${errorId} ${message}`, context);
 }
 
 function resolvePartner(actor: QuoteActor): string {
@@ -398,20 +407,6 @@ function remapCoverPageImageId(coverPage: unknown, imageIds: Map<string, string>
   return { ...cp, coverImageId: imageIds.get(sourceImageId) ?? null };
 }
 
-/**
- * Deep-copy an accessible quote into a new draft. Images and every aggregate
- * relationship receive fresh IDs because image rendering is constrained to
- * image.quote_id and line items can reference blocks, images, and parent lines.
- * Lifecycle, document, seller/customer snapshots, and expiry are intentionally
- * reset so an old accepted/expired quote is safe to revise and send again.
- *
- * `input` optionally retargets the clone to another organization of the same
- * partner and/or renames it. Retargeting clears the site and billToName (both
- * belong to the OLD customer) and re-resolves the tax rate for the new org —
- * the same precedence createQuote uses — so totals are correct for the new
- * customer; a same-org clone keeps the source rate verbatim (it may have been
- * hand-set via the API).
- */
 /** Internal revision overrides for the clone core — never exposed on a route. */
 interface CloneRevisionOverrides {
   quoteNumber: string;
@@ -435,18 +430,37 @@ function cloneLineagePair(revision?: CloneRevisionOverrides): CloneLineagePair {
   };
 }
 
-export async function cloneQuote(
+function assertRevisionCloneTarget(input: CloneQuoteInput, revision?: CloneRevisionOverrides): void {
+  if (revision && input.orgId) {
+    throw new QuoteServiceError('A revision cannot be retargeted to another organization', 409, 'INVALID_STATE');
+  }
+}
+
+/**
+ * Deep-copy an accessible quote into a new draft. Images and every aggregate
+ * relationship receive fresh IDs because image rendering is constrained to
+ * image.quote_id and line items can reference blocks, images, and parent lines.
+ * Lifecycle, document, seller/customer snapshots, and expiry are intentionally
+ * reset so an old accepted/expired quote is safe to revise and send again.
+ *
+ * `input` optionally retargets the clone to another organization of the same
+ * partner and/or renames it. Retargeting clears the site and billToName (both
+ * belong to the OLD customer) and re-resolves the tax rate for the new org —
+ * the same precedence createQuote uses — so totals are correct for the new
+ * customer; a same-org clone keeps the source rate verbatim (it may have been
+ * hand-set via the API).
+ *
+ * @param revision Module-private lineage fields used only by reviseQuote.
+ */
+async function cloneQuoteCore(
   id: string,
   actor: QuoteActor,
   input: CloneQuoteInput = {},
   revision?: CloneRevisionOverrides,
 ) {
+  assertRevisionCloneTarget(input, revision);
   const { quote: source, blocks, lines } = await getQuote(id, actor);
   const images = await db.select().from(quoteImages).where(eq(quoteImages.quoteId, id));
-
-  if (revision && input.orgId) {
-    throw new QuoteServiceError('A revision cannot be retargeted to another organization', 409, 'INVALID_STATE');
-  }
 
   const targetOrgId = input.orgId ?? source.orgId;
   const orgChanged = targetOrgId !== source.orgId;
@@ -658,7 +672,25 @@ export async function cloneQuote(
   });
 }
 
-/** Walk parent links to the lineage root, with a corruption safety bound. */
+/**
+ * Public clone surface. Revision overrides stay inside this module; the
+ * runtime check also rejects an untyped JavaScript caller attempting the old
+ * four-argument form.
+ */
+export async function cloneQuote(id: string, actor: QuoteActor, input: CloneQuoteInput = {}) {
+  const unsupportedRevision = arguments[3] as CloneRevisionOverrides | undefined;
+  assertRevisionCloneTarget(input, unsupportedRevision);
+  if (unsupportedRevision) {
+    throw new QuoteServiceError('Quote revision overrides are internal', 409, 'INVALID_STATE');
+  }
+  return cloneQuoteCore(id, actor, input);
+}
+
+/**
+ * Walk parent links to the lineage root with a 100-hop cycle guard. The ceiling
+ * is data-dependent: a legitimate lineage deeper than 100 revisions is also
+ * rejected rather than risking an unbounded walk through corrupt cyclic data.
+ */
 async function resolveQuoteLineageRoot(
   quote: typeof quotes.$inferSelect,
 ): Promise<typeof quotes.$inferSelect> {
@@ -678,8 +710,9 @@ async function resolveQuoteLineageRoot(
 const REVISABLE_STATUSES = new Set(['sent', 'viewed', 'declined', 'expired']);
 
 /**
- * Create a linked draft revision without touching the live parent. Sending the
- * draft is what eventually supersedes its parent.
+ * Create a linked draft revision without touching the live parent. Superseding
+ * the parent on send belongs to a later wave; see
+ * docs/superpowers/plans/2026-08-17-quote-revisions.md.
  */
 export async function reviseQuote(id: string, actor: QuoteActor) {
   const { quote: parent } = await getQuote(id, actor);
@@ -697,7 +730,9 @@ export async function reviseQuote(id: string, actor: QuoteActor) {
     const [successor] = await db.select({ id: quotes.id }).from(quotes)
       .where(eq(quotes.revisionOfQuoteId, parent.id)).limit(1);
     throw new QuoteServiceError(
-      'This quote was already replaced — revise the newer version',
+      successor
+        ? 'This quote was already replaced — revise the newer version'
+        : 'This quote is marked as superseded, but its replacement could not be found',
       409,
       'ALREADY_SUPERSEDED',
       successor ? { successorQuoteId: successor.id } : undefined,
@@ -709,6 +744,9 @@ export async function reviseQuote(id: string, actor: QuoteActor) {
   if (!parent.quoteNumber) {
     throw new QuoteServiceError('This quote has no quote number and cannot be revised', 409, 'INVALID_STATE');
   }
+  // Linearity is enforced by quotes_revision_of_uq. This pre-check is only a
+  // TOCTOU-racy convenience for a friendlier 409 carrying revisionQuoteId; the
+  // unique constraint remains the invariant under concurrent revision attempts.
   const [existing] = await db.select({ id: quotes.id, status: quotes.status }).from(quotes)
     .where(eq(quotes.revisionOfQuoteId, parent.id)).limit(1);
   if (existing) {
@@ -721,21 +759,24 @@ export async function reviseQuote(id: string, actor: QuoteActor) {
   }
   const root = await resolveQuoteLineageRoot(parent);
   if (!root.quoteNumber) {
-    throw new QuoteServiceError('This quote has no quote number and cannot be revised', 409, 'INVALID_STATE');
+    throw new QuoteServiceError('The root quote has no quote number and cannot be revised', 409, 'INVALID_STATE');
   }
   const revisionNumber = parent.revisionNumber + 1;
   try {
-    return await cloneQuote(id, actor, {}, {
+    return await cloneQuoteCore(id, actor, {}, {
       quoteNumber: `${root.quoteNumber}-R${revisionNumber}`,
       revisionOfQuoteId: parent.id,
       revisionNumber,
     });
   } catch (err) {
-    if (typeof err === 'object' && err !== null && (err as { code?: string }).code === '23505') {
+    if (isPgUniqueViolation(err, 'quotes_revision_of_uq')) {
+      const [existingRevision] = await db.select({ id: quotes.id }).from(quotes)
+        .where(eq(quotes.revisionOfQuoteId, parent.id)).limit(1);
       throw new QuoteServiceError(
         'A revision of this quote is already in progress',
         409,
         'REVISION_IN_PROGRESS',
+        existingRevision ? { revisionQuoteId: existingRevision.id } : undefined,
       );
     }
     throw err;
@@ -777,16 +818,36 @@ export async function getQuote(id: string, actor: QuoteActor) {
       ))
     : [];
   const revisionOf = q.revisionOfQuoteId ? await (async () => {
-    const [parent] = await db.select({ id: quotes.id, quoteNumber: quotes.quoteNumber })
+    const [parent] = await db.select({ id: quotes.id, quoteNumber: quotes.quoteNumber, siteId: quotes.siteId })
       .from(quotes).where(eq(quotes.id, q.revisionOfQuoteId!)).limit(1);
-    if (!parent) return null;
-    // Same-org by FK; safe unfiltered in this request context (see getQuoteRecipients).
+    if (!parent) {
+      logError(
+        errorIds.QUOTE_LINEAGE_PARENT_MISSING,
+        'linked quote parent could not be read',
+        { quoteId: q.id, revisionOfQuoteId: q.revisionOfQuoteId },
+      );
+      return null;
+    }
+    // Match assertSite semantics without turning an authorized read of q into a
+    // 403 for an inaccessible linked quote. Check before loading recipient PII.
+    if (actor.allowedSiteIds && (!parent.siteId || !actor.allowedSiteIds.includes(parent.siteId))) return null;
+    // The composite (revision_of_quote_id, org_id) FK guarantees same-org
+    // lineage under every DB context; no separate org-axis filter is needed.
     const recipients = await db.select({ email: quoteRecipients.email }).from(quoteRecipients)
       .where(eq(quoteRecipients.quoteId, parent.id)).orderBy(quoteRecipients.createdAt);
     return { id: parent.id, quoteNumber: parent.quoteNumber, recipients: recipients.map((r) => r.email) };
   })() : null;
-  const [successorRow] = await db.select({ id: quotes.id, quoteNumber: quotes.quoteNumber, status: quotes.status })
+  const [successorRow] = await db.select({
+    id: quotes.id,
+    quoteNumber: quotes.quoteNumber,
+    status: quotes.status,
+    siteId: quotes.siteId,
+  })
     .from(quotes).where(eq(quotes.revisionOfQuoteId, q.id)).limit(1);
+  const successor = successorRow
+    && (!actor.allowedSiteIds || (!!successorRow.siteId && actor.allowedSiteIds.includes(successorRow.siteId)))
+    ? { id: successorRow.id, quoteNumber: successorRow.quoteNumber, status: successorRow.status }
+    : null;
   // Procurement order tracking (Task 11): every PO header + its line-level
   // allocations recorded against this quote, so the editor can show fulfillment
   // status alongside the pax8 auto-order summary above.
@@ -867,7 +928,7 @@ export async function getQuote(id: string, actor: QuoteActor) {
       ? { id: pax8OrderSummary.pax8OrderId, status: pax8OrderSummary.status, lines: pax8LineRows }
       : null,
     revisionOf,
-    successor: successorRow ?? null,
+    successor,
   };
 }
 

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq, inArray, lt, or, sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { quotes, quoteLines, quoteBlocks, quoteImages } from '../db/schema/quotes';
+import { quotes, quoteLines, quoteBlocks, quoteImages, quoteRecipients } from '../db/schema/quotes';
 import { invoices } from '../db/schema/invoices';
 import { organizations, partners } from '../db/schema/orgs';
 import { contractTemplates, contractTemplateVersions } from '../db/schema/contractDocuments';
@@ -776,6 +776,17 @@ export async function getQuote(id: string, actor: QuoteActor) {
         eq(pax8OrderLines.orgId, q.orgId),
       ))
     : [];
+  const revisionOf = q.revisionOfQuoteId ? await (async () => {
+    const [parent] = await db.select({ id: quotes.id, quoteNumber: quotes.quoteNumber })
+      .from(quotes).where(eq(quotes.id, q.revisionOfQuoteId!)).limit(1);
+    if (!parent) return null;
+    // Same-org by FK; safe unfiltered in this request context (see getQuoteRecipients).
+    const recipients = await db.select({ email: quoteRecipients.email }).from(quoteRecipients)
+      .where(eq(quoteRecipients.quoteId, parent.id)).orderBy(quoteRecipients.createdAt);
+    return { id: parent.id, quoteNumber: parent.quoteNumber, recipients: recipients.map((r) => r.email) };
+  })() : null;
+  const [successorRow] = await db.select({ id: quotes.id, quoteNumber: quotes.quoteNumber, status: quotes.status })
+    .from(quotes).where(eq(quotes.revisionOfQuoteId, q.id)).limit(1);
   // Procurement order tracking (Task 11): every PO header + its line-level
   // allocations recorded against this quote, so the editor can show fulfillment
   // status alongside the pax8 auto-order summary above.
@@ -855,6 +866,8 @@ export async function getQuote(id: string, actor: QuoteActor) {
     pax8Order: pax8OrderSummary
       ? { id: pax8OrderSummary.pax8OrderId, status: pax8OrderSummary.status, lines: pax8LineRows }
       : null,
+    revisionOf,
+    successor: successorRow ?? null,
   };
 }
 

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -412,9 +412,41 @@ function remapCoverPageImageId(coverPage: unknown, imageIds: Map<string, string>
  * customer; a same-org clone keeps the source rate verbatim (it may have been
  * hand-set via the API).
  */
-export async function cloneQuote(id: string, actor: QuoteActor, input: CloneQuoteInput = {}) {
+/** Internal revision overrides for the clone core — never exposed on a route. */
+interface CloneRevisionOverrides {
+  quoteNumber: string;
+  revisionOfQuoteId: string;
+  revisionNumber: number;
+}
+
+type CloneLineagePair =
+  | { revisionOfQuoteId: null; revisionNumber: 1 }
+  | { revisionOfQuoteId: string; revisionNumber: number };
+
+/** Build the correlated lineage columns together so the DB CHECK is a backstop. */
+function cloneLineagePair(revision?: CloneRevisionOverrides): CloneLineagePair {
+  if (!revision) return { revisionOfQuoteId: null, revisionNumber: 1 };
+  if (!revision.revisionOfQuoteId || !Number.isInteger(revision.revisionNumber) || revision.revisionNumber < 2) {
+    throw new QuoteServiceError('Invalid quote revision lineage', 409, 'INVALID_STATE');
+  }
+  return {
+    revisionOfQuoteId: revision.revisionOfQuoteId,
+    revisionNumber: revision.revisionNumber,
+  };
+}
+
+export async function cloneQuote(
+  id: string,
+  actor: QuoteActor,
+  input: CloneQuoteInput = {},
+  revision?: CloneRevisionOverrides,
+) {
   const { quote: source, blocks, lines } = await getQuote(id, actor);
   const images = await db.select().from(quoteImages).where(eq(quoteImages.quoteId, id));
+
+  if (revision && input.orgId) {
+    throw new QuoteServiceError('A revision cannot be retargeted to another organization', 409, 'INVALID_STATE');
+  }
 
   const targetOrgId = input.orgId ?? source.orgId;
   const orgChanged = targetOrgId !== source.orgId;
@@ -451,9 +483,14 @@ export async function cloneQuote(id: string, actor: QuoteActor, input: CloneQuot
     : source.taxRate;
   const title = input.title !== undefined ? (input.title.trim() || null) : source.title;
 
-  const year = new Date().getUTCFullYear();
-  const counter = await allocateQuoteCounter(source.partnerId, year);
-  const quoteNumber = formatQuoteNumber('Q', year, counter);
+  let quoteNumber: string;
+  if (revision) {
+    quoteNumber = revision.quoteNumber;
+  } else {
+    const year = new Date().getUTCFullYear();
+    const counter = await allocateQuoteCounter(source.partnerId, year);
+    quoteNumber = formatQuoteNumber('Q', year, counter);
+  }
   const quoteId = randomUUID();
 
   const imageIds = new Map(images.map((image) => [image.id, randomUUID()]));
@@ -504,6 +541,7 @@ export async function cloneQuote(id: string, actor: QuoteActor, input: CloneQuot
       orgId: targetOrgId,
       siteId: orgChanged ? null : source.siteId,
       quoteNumber,
+      ...cloneLineagePair(revision),
       title,
       status: 'draft',
       currencyCode: source.currencyCode,
@@ -618,6 +656,90 @@ export async function cloneQuote(id: string, actor: QuoteActor, input: CloneQuot
 
     return cloned!;
   });
+}
+
+/** Walk parent links to the lineage root, with a corruption safety bound. */
+async function resolveQuoteLineageRoot(
+  quote: typeof quotes.$inferSelect,
+): Promise<typeof quotes.$inferSelect> {
+  let current = quote;
+  for (let hop = 0; hop < 100 && current.revisionOfQuoteId; hop++) {
+    const [parent] = await db.select().from(quotes)
+      .where(eq(quotes.id, current.revisionOfQuoteId)).limit(1);
+    if (!parent) throw new QuoteServiceError('Quote lineage is corrupt', 409, 'INVALID_STATE');
+    current = parent;
+  }
+  if (current.revisionOfQuoteId) {
+    throw new QuoteServiceError('Quote lineage is corrupt', 409, 'INVALID_STATE');
+  }
+  return current;
+}
+
+const REVISABLE_STATUSES = new Set(['sent', 'viewed', 'declined', 'expired']);
+
+/**
+ * Create a linked draft revision without touching the live parent. Sending the
+ * draft is what eventually supersedes its parent.
+ */
+export async function reviseQuote(id: string, actor: QuoteActor) {
+  const { quote: parent } = await getQuote(id, actor);
+  if (parent.status === 'draft') {
+    throw new QuoteServiceError('This quote is still a draft — edit it directly', 409, 'INVALID_STATE');
+  }
+  if (parent.status === 'converted' || parent.status === 'accepted') {
+    throw new QuoteServiceError(
+      'This quote was accepted — changes go through its invoice or contract',
+      409,
+      'PARENT_CONVERTED',
+    );
+  }
+  if (parent.status === 'superseded') {
+    const [successor] = await db.select({ id: quotes.id }).from(quotes)
+      .where(eq(quotes.revisionOfQuoteId, parent.id)).limit(1);
+    throw new QuoteServiceError(
+      'This quote was already replaced — revise the newer version',
+      409,
+      'ALREADY_SUPERSEDED',
+      successor ? { successorQuoteId: successor.id } : undefined,
+    );
+  }
+  if (!REVISABLE_STATUSES.has(parent.status)) {
+    throw new QuoteServiceError(`Cannot revise a quote in status ${parent.status}`, 409, 'INVALID_STATE');
+  }
+  if (!parent.quoteNumber) {
+    throw new QuoteServiceError('This quote has no quote number and cannot be revised', 409, 'INVALID_STATE');
+  }
+  const [existing] = await db.select({ id: quotes.id, status: quotes.status }).from(quotes)
+    .where(eq(quotes.revisionOfQuoteId, parent.id)).limit(1);
+  if (existing) {
+    throw new QuoteServiceError(
+      'A revision of this quote is already in progress',
+      409,
+      'REVISION_IN_PROGRESS',
+      { revisionQuoteId: existing.id },
+    );
+  }
+  const root = await resolveQuoteLineageRoot(parent);
+  if (!root.quoteNumber) {
+    throw new QuoteServiceError('This quote has no quote number and cannot be revised', 409, 'INVALID_STATE');
+  }
+  const revisionNumber = parent.revisionNumber + 1;
+  try {
+    return await cloneQuote(id, actor, {}, {
+      quoteNumber: `${root.quoteNumber}-R${revisionNumber}`,
+      revisionOfQuoteId: parent.id,
+      revisionNumber,
+    });
+  } catch (err) {
+    if (typeof err === 'object' && err !== null && (err as { code?: string }).code === '23505') {
+      throw new QuoteServiceError(
+        'A revision of this quote is already in progress',
+        409,
+        'REVISION_IN_PROGRESS',
+      );
+    }
+    throw err;
+  }
 }
 
 export async function getQuote(id: string, actor: QuoteActor) {
@@ -787,6 +909,13 @@ export async function updateQuote(id: string, input: UpdateQuoteInput, actor: Qu
   // Re-resolved org tax default; undefined = org unchanged (keep current rate).
   let orgTaxRate: string | null | undefined;
   if (orgChanged) {
+    if (q.revisionOfQuoteId != null) {
+      throw new QuoteServiceError(
+        'A revision draft cannot be moved to another organization',
+        409,
+        'INVALID_STATE',
+      );
+    }
     const targetOrgId = input.orgId!;
     assertOrg(actor, targetOrgId);
     // Reassignment clears the site, and a site-restricted caller can never see a

--- a/apps/api/src/services/quoteTypes.ts
+++ b/apps/api/src/services/quoteTypes.ts
@@ -42,6 +42,9 @@ export type QuoteServiceErrorCode =
   // partner). Any violation collapses to this single 422 code.
   | 'INVALID_CONTRACT_TEMPLATE'
   | 'INVALID_STATE'
+  | 'PARENT_CONVERTED'
+  | 'ALREADY_SUPERSEDED'
+  | 'REVISION_IN_PROGRESS'
   // Multi-currency wave 2 (#3774): a cross-org retarget (cloneQuote input.orgId,
   // updateQuote org move) whose target org is billed in a different currency
   // than the document's stamp. Blocked outright — a quote's amounts are never
@@ -113,7 +116,9 @@ export class QuoteServiceError extends Error {
   constructor(
     message: string,
     public status: 400 | 401 | 403 | 404 | 409 | 410 | 422 | 500 = 400,
-    public code?: QuoteServiceErrorCode
+    public code?: QuoteServiceErrorCode,
+    /** Optional machine-readable context for typed conflict recovery. */
+    public meta?: Record<string, string>,
   ) {
     super(message);
     this.name = 'QuoteServiceError';

--- a/apps/api/src/services/quoteTypes.ts
+++ b/apps/api/src/services/quoteTypes.ts
@@ -112,13 +112,22 @@ export type QuoteServiceErrorCode =
   // status. Reject it explicitly instead.
   | 'QUOTE_ORDER_LINE_CANCELLED';
 
+export type QuoteServiceErrorMeta = {
+  successorQuoteId?: string;
+  revisionQuoteId?: string;
+};
+
 export class QuoteServiceError extends Error {
   constructor(
     message: string,
     public status: 400 | 401 | 403 | 404 | 409 | 410 | 422 | 500 = 400,
     public code?: QuoteServiceErrorCode,
-    /** Optional machine-readable context for typed conflict recovery. */
-    public meta?: Record<string, string>,
+    /**
+     * Optional machine-readable context for typed conflict recovery. This is
+     * spliced verbatim into HTTP response bodies by handleServiceError; never
+     * include data the caller is not already authorized to see.
+     */
+    public meta?: QuoteServiceErrorMeta,
   ) {
     super(message);
     this.name = 'QuoteServiceError';


### PR DESCRIPTION
Wave 2 of the quote-revisions feature (#3796). Adds the ability to create a linked draft revision of an issued quote. The parent is **not** touched here — it stays live until the revision is actually sent, which is W03's job.

Closes #3798

## What's in it

**`reviseQuote()` service** (`quoteService.ts`) — deep-copies an issued quote into a linked draft:
- Numbering derives from the **lineage root**, so revising an `R2` yields `Q-2026-0042-R3`, never `Q-2026-0042-R2-R3`. `resolveQuoteLineageRoot()` walks parent links with a bounded loop so corrupt data can't spin.
- No counter allocation for revisions — the root's number is reused with an `-R<n>` suffix.
- Typed 409s for every refusal path: `INVALID_STATE` (draft parent, legacy quote with no number), `PARENT_CONVERTED`, `ALREADY_SUPERSEDED` (carries the successor id), `REVISION_IN_PROGRESS` (carries the existing draft id).
- Linearity is DB-enforced by `quotes_revision_of_uq`; the pre-check exists only to return a helpful 409, and a `23505` catch closes the race when a concurrent revise loses.

**`POST /api/v1/quotes/:id/revise`** — gated on `quotes:write`, audited as `quote.revised` with `parentQuoteId` / `revisionNumber` / `parentStatus`. `handleServiceError` now serializes the optional `meta` payload so clients get the conflicting quote's id rather than just a message.

**Lineage in the read payload** — `getQuote` gains `revisionOf` (immediate parent + its recipients, for the composer prefill) and `successor` (immediate child, any status).

## Review findings from W01 carried in

Both were recorded in the plan under "Carried into later waves by the W01 review":

1. **Org retarget now rejects revision drafts.** `updateQuote`'s `orgChanged` branch moves a draft to another customer. On a revision draft that stranded `revision_of_quote_id` pointing into the old org, so the composite FK `(revision_of_quote_id, org_id)` no longer resolved and Postgres raised a bare `23503` that surfaced as a **500**. It's now a typed 409.
2. **The lineage pair is built in one place.** `revisionOfQuoteId` and `revisionNumber` are correlated, but the Drizzle types permitted illegal pairs — only `quotes_revision_number_chk` rejected them. They're now a discriminated union, so an illegal pair doesn't typecheck and the CHECK is a backstop rather than the only defense.

`isOpenQuoteStatus()` was deliberately **not** introduced — the plan defers it until a third call site justifies it.

## Testing

- `quoteService.revise.test.ts` (new) — all eight refusal/success cases from the plan, including the R2→R3 root-derivation case and the `23505` race.
- `quotes.revise.test.ts` (new) — HTTP-level: 200 with `quotes:write`, real **403** without it, 409 with `meta` serialized, and the `quote.revised` audit shape.
- Changes to the existing `quoteService.test.ts` are purely additive `queueResult` entries realigning the mock queue for the new successor lookup — no assertion was weakened.

Local: **125 passing** across the four affected suites; `tsc --noEmit` clean.

## Notes

- No schema changes — W01 shipped the columns.
- No `quotes` mutation in this wave is a bare `WHERE id = ?` status write.
- The double `getQuote` in the route is intentional (two cheap reads in one request transaction) and called out in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)