### PR TITLE
feat(api,web): gate AI agent policies on ai_agents:read/write

### DIFF
--- a/apps/api/migrations/2026-09-03-ai-agents-permissions.sql
+++ b/apps/api/migrations/2026-09-03-ai-agents-permissions.sql
@@ -1,0 +1,48 @@
+-- #3821 wave 1 follow-up: give AI agent policies their own capability instead
+-- of gating them on organizations:write.
+--
+-- Authoring an agent policy is what will eventually authorize autonomous action
+-- on customer machines (wave 4 enables `act` mode). Riding on
+-- organizations:write would mean every existing org admin silently acquired
+-- agent-authoring authority the day that shipped, without the partner who
+-- granted organizations:write ever deciding to hand it over. Splitting it now
+-- is cheap; splitting it after a release means re-granting on roles already in
+-- the wild. Same reasoning as ai_sessions:read_all (2026-07-11).
+--
+-- Operates ONLY on the global Org Admin system role row (partner_id IS NULL,
+-- is_system = TRUE). Per-partner cloned Partner Admin rows carry *:* and keep
+-- everything; custom roles are untouched. Idempotent.
+
+-- 1. Catalog rows, exactly once each (permissions has no unique(resource,action)).
+INSERT INTO permissions (resource, action, description)
+SELECT 'ai_agents', 'read', 'View AI agent policies'
+WHERE NOT EXISTS (
+  SELECT 1 FROM permissions WHERE resource = 'ai_agents' AND action = 'read'
+);
+
+INSERT INTO permissions (resource, action, description)
+SELECT 'ai_agents', 'write', 'Create, edit and disable AI agent policies'
+WHERE NOT EXISTS (
+  SELECT 1 FROM permissions WHERE resource = 'ai_agents' AND action = 'write'
+);
+
+-- 2. Grant both to the global Org Admin system role. An org admin may tighten
+--    their OWN org's policy; creating a partner-wide baseline additionally
+--    requires partner scope with org_access='all', enforced in the app layer by
+--    canManagePartnerWidePolicies, so this grant cannot reach across orgs.
+DO $$
+DECLARE n integer;
+BEGIN
+  INSERT INTO role_permissions (role_id, permission_id)
+  SELECT r.id, p.id
+  FROM roles r
+  CROSS JOIN (
+    SELECT id FROM permissions
+    WHERE resource = 'ai_agents' AND action IN ('read', 'write')
+  ) p
+  WHERE r.partner_id IS NULL AND r.scope = 'organization'
+    AND r.name = 'Org Admin' AND r.is_system = TRUE
+  ON CONFLICT (role_id, permission_id) DO NOTHING;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RAISE WARNING 'ai-agents-permissions: granted ai_agents:read/write to Org Admin (% row(s))', n;
+END $$;

--- a/apps/api/src/__tests__/integration/aiAgents.routes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiAgents.routes.integration.test.ts
@@ -423,11 +423,40 @@ describe('/api/v1/ai/agents', () => {
     expect((await res.json() as { code?: string }).code).toBe('MFA_REQUIRED');
   });
 
-  it('refuses a write from a role holding only organizations:read', async () => {
+  it('refuses every read to a role holding organizations:* but not ai_agents:*', async () => {
+    // The gate is a DEDICATED capability, not organizations:*. If these routes
+    // ever slip back to ORGS_READ/ORGS_WRITE, every org admin silently regains
+    // agent-authoring authority — which, once wave 4 enables `act`, is authority
+    // over customer machines.
     const app = buildApp();
     const seeded = await createIntegrationTestClient(app, {
       scope: 'partner',
-      rolePermissions: [{ resource: 'organizations', action: 'read' }],
+      rolePermissions: [
+        { resource: 'organizations', action: 'read' },
+        { resource: 'organizations', action: 'write' },
+      ],
+    });
+    const orgOnly = await mfaClient(app, {
+      userId: seeded.env.user.id,
+      email: seeded.env.user.email,
+      roleId: seeded.env.role.id,
+      orgId: null,
+      partnerId: seeded.env.partner.id,
+      scope: 'partner',
+    });
+
+    expect((await orgOnly.get('/api/v1/ai/agents')).status).toBe(403);
+    const res = await orgOnly.post('/api/v1/ai/agents', {
+      ownerScope: 'partner', kind: 'triage', name: 'Org perms only', mode: 'shadow',
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('refuses a write from a role holding only ai_agents:read', async () => {
+    const app = buildApp();
+    const seeded = await createIntegrationTestClient(app, {
+      scope: 'partner',
+      rolePermissions: [{ resource: 'ai_agents', action: 'read' }],
     });
     const readOnly = await mfaClient(app, {
       userId: seeded.env.user.id,

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -204,6 +204,12 @@ export const DEFAULT_PERMISSIONS = [
   { resource: 'ai_sessions', action: 'read_all',
     description: "View all users' AI session history (admin audit dashboard)" },
 
+  // AI agents (#3821)
+  { resource: 'ai_agents', action: 'read',
+    description: 'View AI agent policies' },
+  { resource: 'ai_agents', action: 'write',
+    description: 'Create, edit and disable AI agent policies' },
+
   // Action intents / durable approvals
   { resource: 'approvals', action: 'decide',
     description: 'Decide (approve/deny) pending action-intent approvals' },
@@ -293,6 +299,11 @@ export const SYSTEM_ROLES = [
       'audit:read',
       'vulnerabilities:accept_risk',
       'ai_sessions:read_all',
+      // An org admin may tighten their own org's agent policy. Creating a
+      // PARTNER-WIDE baseline additionally requires partner scope with
+      // org_access='all' (canManagePartnerWidePolicies), so this grant cannot
+      // reach across orgs.
+      'ai_agents:read', 'ai_agents:write',
       'approvals:decide',
       // Tenant variables (#3409): managing the definitions is an admin task;
       // running a script that USES one only needs scripts:execute.

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -25,8 +25,13 @@ import { resolveOrgId } from './networkShared';
 export const aiAgentsRoutes = new Hono();
 aiAgentsRoutes.use('*', authMiddleware);
 
-const requireAiRead = requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action);
-const requireAiWrite = requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action);
+// Dedicated capabilities, NOT organizations:read/write. Authoring an agent
+// policy is what will eventually authorize autonomous action on customer
+// machines, and organizations:write is held by every org admin — sharing it
+// would hand agent-authoring authority to all of them the day wave 4 enables
+// `act` mode, with nobody having decided to. Partner Admin keeps access via *:*.
+const requireAiRead = requirePermission(PERMISSIONS.AI_AGENTS_READ.resource, PERMISSIONS.AI_AGENTS_READ.action);
+const requireAiWrite = requirePermission(PERMISSIONS.AI_AGENTS_WRITE.resource, PERMISSIONS.AI_AGENTS_WRITE.action);
 const scopes = requireScope('organization', 'partner', 'system');
 
 // NOTE (deviation from the plan, deliberate): these handlers do NOT call

--- a/apps/api/src/routes/permissionsCatalog.ts
+++ b/apps/api/src/routes/permissionsCatalog.ts
@@ -33,6 +33,7 @@ const RESOURCE_LABELS: Record<string, string> = {
   topology: 'Network Topology',
   vulnerabilities: 'Vulnerabilities',
   ai_sessions: 'AI Sessions',
+  ai_agents: 'AI Agents',
   approvals: 'Approvals',
   variables: 'Variables'
 };

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -295,7 +295,7 @@ export const navSections: NavSection[] = [
       { name: 'Partner', labelKey: 'nav.partner', href: '/settings/partner', icon: Building, partnerScopeOnly: true },
       { name: 'Organizations', labelKey: 'nav.organizations', href: '/settings/organizations', icon: Building2, requiredPermission: { resource: 'organizations', action: 'read' } },
       { name: 'AI Usage & Budget', labelKey: 'nav.aiUsageBudget', href: '/settings/ai-usage', icon: BrainCircuit, partnerScopeOnly: true },
-      { name: 'AI Agents', labelKey: 'nav.aiAgents', href: '/settings/ai-agents', icon: Bot, requiredPermission: { resource: 'organizations', action: 'read' } },
+      { name: 'AI Agents', labelKey: 'nav.aiAgents', href: '/settings/ai-agents', icon: Bot, requiredPermission: { resource: 'ai_agents', action: 'read' } },
       { name: 'Custom Fields', labelKey: 'nav.customFields', href: '/settings/custom-fields', icon: ListChecks, requiredPermission: { resource: 'organizations', action: 'read' } },
       { name: 'Variables', labelKey: 'nav.variables', href: '/settings/variables', icon: Braces, requiredPermission: { resource: 'variables', action: 'read' } },
       { name: 'Saved Filters', labelKey: 'nav.savedFilters', href: '/settings/filters', icon: Filter },

--- a/packages/shared/src/constants/permissions.ts
+++ b/packages/shared/src/constants/permissions.ts
@@ -132,6 +132,15 @@ export const PERMISSION_GRANTS = {
   // cross-user admin/audit surface must NOT be gated on organizations:read.
   AI_SESSIONS_READ_ALL: { resource: 'ai_sessions', action: 'read_all' },
 
+  // AI agents (#3821) — authoring an agent policy is what will eventually
+  // authorize autonomous action on customer machines, so it gets its own
+  // capability rather than riding on organizations:write. Sharing that grant
+  // would mean every existing org admin silently acquired agent-authoring
+  // authority the day wave 4 enabled `act` mode, with no deliberate decision
+  // by the partner who granted it. Same reasoning as AI_SESSIONS_READ_ALL.
+  AI_AGENTS_READ: { resource: 'ai_agents', action: 'read' },
+  AI_AGENTS_WRITE: { resource: 'ai_agents', action: 'write' },
+
   // Action intents / durable approvals — gates who may decide (approve/deny) a
   // pending action-intent approval, distinct from creating/reading intents.
   APPROVALS_DECIDE: { resource: 'approvals', action: 'decide' },


### PR DESCRIPTION
## Summary

Follow-up to AI agents wave 1 (#3838). Moves the agent-policy routes off
`organizations:read`/`organizations:write` onto dedicated
`ai_agents:read`/`ai_agents:write`.

**Why now rather than later:** authoring an agent policy is what will eventually
authorize autonomous action on customer machines — wave 4 (#3826) enables `act`
mode. `organizations:write` is held by every org admin, so on the day `act`
shipped, all of them would have silently acquired agent-authoring authority
without the partner who granted `organizations:write` ever deciding to hand it
over. Splitting now costs one migration. Splitting after a release means
re-granting on roles already in the wild.

Same reasoning and the same shape as `ai_sessions:read_all`
(`2026-07-11-ai-sessions-read-all-permission.sql`), which was split out of
`organizations:read` for exactly this reason (SR5-09).

## Who gets what

- **Partner Admin** — unchanged, keeps access via its `*:*` grant.
- **Org Admin** — granted both. An org admin may tighten their *own* org's
  policy; creating a **partner-wide** baseline still additionally requires
  partner scope with `org_access='all'` (`canManagePartnerWidePolicies`), so
  this grant cannot reach across orgs.
- **Custom roles** — untouched. The migration operates only on the global
  Org Admin system role row (`partner_id IS NULL`, `is_system = TRUE`).

## Six registration points, not four

The full sweep caught two I had missed on the first pass:

| Where | What |
|---|---|
| `packages/shared/src/constants/permissions.ts` | `PERMISSION_GRANTS` entries |
| `apps/api/src/db/seed.ts` | `DEFAULT_PERMISSIONS` catalog + the Org Admin grant list |
| `apps/api/migrations/2026-09-03-ai-agents-permissions.sql` | catalog rows + Org Admin grant, idempotent |
| `apps/api/src/routes/aiAgents.ts` | the route gate |
| `apps/web/src/components/layout/Sidebar.tsx` | `requiredPermission` on the nav item |
| `apps/api/src/routes/permissionsCatalog.ts` | **`RESOURCE_LABELS`** — the catalog route asserts every permission has a UI label, and this is what failed the suite |

## Verification

- Two new integration cases, both of which **fail if the gate reverts** to
  `organizations:*` (verified by mutation, not assumed): a role holding
  `organizations:read` + `organizations:write` but not `ai_agents:*` is refused
  on both read and write; a role holding only `ai_agents:read` is refused on write.
- `apps/api` unit: 1416 files / 24041 tests pass
- `apps/web`: 614 files / 6174 tests pass · `packages/shared`: 77 / 2044 pass
- Integration: agent routes, partner RLS, effective policy, runs, tenantCascade,
  tenant-export-policy, erasure roundtrip — 7 files / 39 pass
- `rls-coverage` 75 · `rls` 22 · API `tsc --noEmit` clean · `astro check` 0 errors
  · `pnpm lint` clean · `check-migration-naming` OK

Follows #3838. Part of #3821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
