### PR TITLE
fix(api): hosted agent update 409 — canonical asset names, key-ID-bound verification, fail-closed local registration (#3836)

### DIFF
--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -2586,6 +2586,53 @@ describe("validateReleaseManifest — key-ID-aware dispatch (Task 2, #3836)", ()
     expect(result).toEqual({ ok: false, reason: "invalid_release_manifest_signature" });
   });
 
+  it("REJECTS a deploy-* key ID when getActiveTrustKeyset (manifest_signing_keys lookup) fails outright", async () => {
+    // Fix round 1 review finding: the try/catch around getActiveTrustKeyset
+    // in verifyManifestSignatureForSigningKeyId's deploy-* branch had no
+    // test. A transient DB failure while resolving the ONE key a deploy-*
+    // signingKeyId names must fail closed, not silently fall through to a
+    // wider trust set.
+    const deployKey = generateKeyPairSync("ed25519");
+    const manifest = legacyManifest();
+    const signature = sign(null, Buffer.from(manifest, "utf8"), deployKey.privateKey).toString("base64");
+    vi.spyOn(manifestSigning, "getActiveTrustKeyset").mockRejectedValue(
+      new Error("connection refused"),
+    );
+
+    const result = await validateReleaseManifest({
+      ...legacyArgsBase,
+      manifest,
+      signature,
+      signingKeyId: "deploy-2026-08-01-aaaa",
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid_release_manifest_signature" });
+  });
+
+  it("REJECTS a deploy-* key ID whose matched manifest_signing_keys row decodes to a non-32-byte key (corrupted row)", async () => {
+    // Optional coverage (fix round 1 review): the rawKey.length !== 32 guard
+    // in verifyEd25519SignatureAgainstSingleRawKey.
+    const deployKey = generateKeyPairSync("ed25519");
+    const manifest = legacyManifest();
+    const signature = sign(null, Buffer.from(manifest, "utf8"), deployKey.privateKey).toString("base64");
+    vi.spyOn(manifestSigning, "getActiveTrustKeyset").mockResolvedValue([
+      {
+        keyId: "deploy-2026-08-01-aaaa",
+        publicKeyB64: Buffer.from("too-short").toString("base64"),
+        validFrom: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await validateReleaseManifest({
+      ...legacyArgsBase,
+      manifest,
+      signature,
+      signingKeyId: "deploy-2026-08-01-aaaa",
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid_release_manifest_signature" });
+  });
+
   it("keeps the legacy whole-set behavior unchanged for absent/unrecognized signingKeyId (no ID narrowing applies)", async () => {
     const trusted = generateKeyPairSync("ed25519");
     process.env.AGENT_UPDATE_MANIFEST_PUBLIC_KEYS = rawPub(trusted.publicKey).toString("base64");

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -2178,11 +2178,17 @@ describe("verifyEd25519ManifestSignature — empty-keyset opt-in (#643)", () => 
 });
 
 // D1 (#3836): canonicalReleaseAssetName must reproduce EXACTLY the filenames
-// binarySync.ts's scanBinaryDir/parseBinaryFilename (agent/watchdog/backup),
-// USER_HELPER_TARGETS (user-helper), and the release pipeline's raw macOS
-// helper binary (release.yml, releaseAssetTrust.ts's DARWIN_BINARY_RE)
-// produce — every case below is cross-checked against those sources, not
-// invented independently.
+// binarySync.ts's scanBinaryDir/parseBinaryFilename (agent/watchdog/backup)
+// and USER_HELPER_TARGETS (user-helper) produce — every case below is
+// cross-checked against those sources, not invented independently.
+// component="helper" is deliberately always null: its real registration is
+// HELPER_TARGETS (binarySync.ts ~line 59), a per-OS (not per-arch) asset
+// name (windows -> breeze-helper-windows.msi, darwin (both arches, same
+// file) -> breeze-helper-macos.dmg, linux -> breeze-helper-linux.AppImage) —
+// see the controller-review regression test below for why an earlier
+// version of this function (returning "breeze-desktop-helper-darwin-<arch>"
+// for helper/macos) was WRONG and would have 409'd real
+// BINARY_SOURCE=github helper rows.
 describe("canonicalReleaseAssetName (D1, #3836)", () => {
   const cases: Array<[string, string, string, string | null]> = [
     // agent — windows/linux/darwin, both arches. Also proves "macos" (the DB
@@ -2216,13 +2222,12 @@ describe("canonicalReleaseAssetName (D1, #3836)", () => {
     ["user-helper", "macos", "amd64", null],
     ["user-helper", "linux", "amd64", null],
 
-    // helper — the raw macOS desktop-helper Mach-O binary bundled into the
-    // agent .pkg (DARWIN_BINARY_RE in releaseAssetTrust.ts, release.yml). No
-    // per-arch Windows/Linux asset ships under this shape today; the Tauri
-    // "helper" app's own non-per-arch installer (breeze-helper-macos.dmg
-    // etc.) is a different shape this function does not claim.
-    ["helper", "macos", "amd64", "breeze-desktop-helper-darwin-amd64"],
-    ["helper", "macos", "arm64", "breeze-desktop-helper-darwin-arm64"],
+    // helper — always null (see the describe-block comment above): the real
+    // asset name (breeze-helper-macos.dmg / -windows.msi / -linux.AppImage)
+    // is per-OS, not per-arch, so it must resolve via the URL-basename
+    // fallback instead.
+    ["helper", "macos", "amd64", null],
+    ["helper", "macos", "arm64", null],
     ["helper", "windows", "amd64", null],
     ["helper", "linux", "amd64", null],
 

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -1630,21 +1630,41 @@ describe("agentVersions routes", () => {
   // requests it that way (updater.downloadBinary). These three cases are the
   // per-component coverage those two route names were describing.
   describe("GET /agent-versions/:version/download — signingKeyId passthrough", () => {
+    // Task 2 (#3836): the download path is now key-ID-aware, so each case
+    // must configure trust that actually matches its claimed signingKeyId
+    // (official ID -> RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS, deploy-* ->
+    // the matching manifest_signing_keys row) for the manifest to verify —
+    // exactly the binding this suite exists to prove is enforced.
     const cases = [
       {
         component: "agent",
         assetName: "breeze-agent-linux-amd64",
         signingKeyId: "release-artifact-manifest-ed25519",
+        configureTrust: (signed: { publicKey: string }) => {
+          process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+        },
       },
       {
         component: "helper",
         assetName: "breeze-helper-linux.AppImage",
         signingKeyId: "deploy-2026-07-23-helper",
+        configureTrust: (signed: { publicKey: string }) => {
+          vi.spyOn(manifestSigning, "getActiveTrustKeyset").mockResolvedValue([
+            {
+              keyId: "deploy-2026-07-23-helper",
+              publicKeyB64: signed.publicKey,
+              validFrom: new Date().toISOString(),
+            },
+          ]);
+        },
       },
       {
         component: "watchdog",
         assetName: "breeze-watchdog-linux-amd64",
         signingKeyId: "release-artifact-manifest-ed25519",
+        configureTrust: (signed: { publicKey: string }) => {
+          process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+        },
       },
     ];
 
@@ -1660,6 +1680,7 @@ describe("agentVersions routes", () => {
           checksum,
           size: 4096,
         });
+        tc.configureTrust(signed);
 
         vi.mocked(db.select).mockReturnValue({
           from: vi.fn().mockReturnValue({
@@ -2386,5 +2407,232 @@ describe("validateReleaseManifest — schema-v1 reason split (D3, #3836)", () =>
       ok: false,
       reason: "invalid_release_manifest_signature",
     });
+  });
+});
+
+// Task 2 (#3836): key-ID-aware dispatch for validateReleaseManifest.
+// Mirrors the agent's exact-ID semantics (agent/internal/updater/
+// updater.go verifyManifestSignature, ~line 769): an explicit signingKeyId
+// binds verification to that ONE key — never a fallback across the whole
+// trusted set. Before this, the legacy (non schema-v1) branch checked a
+// row's signature against the UNION of env keys and every DB deployment
+// key regardless of what signingKeyId claimed, so a row stamped with the
+// official key ID but actually signed by a per-deployment key (or
+// vice-versa) passed the server even though a real agent's exact-ID
+// lookup would reject it.
+describe("validateReleaseManifest — key-ID-aware dispatch (Task 2, #3836)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_UPDATE_MANIFEST_PUBLIC_KEYS;
+    delete process.env.BREEZE_UPDATE_MANIFEST_PUBLIC_KEYS;
+    delete process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+    delete process.env.BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+    vi.spyOn(manifestSigning, "getActiveTrustKeyset").mockResolvedValue([]);
+  });
+
+  function rawPub(publicKey: { export: (opts: { format: "der"; type: "spki" }) => Buffer }): Buffer {
+    const der = publicKey.export({ format: "der", type: "spki" });
+    return der.subarray(der.length - 32);
+  }
+
+  function legacyManifest() {
+    return JSON.stringify({
+      version: "1.0.0",
+      component: "agent",
+      platform: "linux",
+      arch: "amd64",
+      url: "https://s3.example.com/agent-1.0.0",
+      checksum: "b".repeat(64),
+      size: 45000000,
+    });
+  }
+
+  const legacyArgsBase = {
+    version: "1.0.0",
+    platform: "linux",
+    arch: "amd64",
+    component: "agent",
+    downloadUrl: "https://s3.example.com/agent-1.0.0",
+    checksum: "b".repeat(64),
+    fileSize: 45000000,
+  };
+
+  it("REJECTS a row stamped with the official key ID but signed by a DB-trusted deployment key (the exact bug this task closes)", async () => {
+    const deployKey = generateKeyPairSync("ed25519");
+    const manifest = legacyManifest();
+    const signature = sign(null, Buffer.from(manifest, "utf8"), deployKey.privateKey).toString("base64");
+
+    // The deploy key IS otherwise trusted (present in manifest_signing_keys)
+    // — that's the point: a legitimately-trusted key must still be rejected
+    // when it isn't the ONE key the claimed ID names.
+    vi.spyOn(manifestSigning, "getActiveTrustKeyset").mockResolvedValue([
+      {
+        keyId: "deploy-2026-08-01-aaaa",
+        publicKeyB64: rawPub(deployKey.publicKey).toString("base64"),
+        validFrom: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await validateReleaseManifest({
+      ...legacyArgsBase,
+      manifest,
+      signature,
+      signingKeyId: "release-artifact-manifest-ed25519",
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid_release_manifest_signature" });
+  });
+
+  it("ACCEPTS a row stamped with the official key ID when signed by a genuinely official (RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS) key", async () => {
+    const official = generateKeyPairSync("ed25519");
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = rawPub(official.publicKey).toString("base64");
+    const manifest = legacyManifest();
+    const signature = sign(null, Buffer.from(manifest, "utf8"), official.privateKey).toString("base64");
+
+    const result = await validateReleaseManifest({
+      ...legacyArgsBase,
+      manifest,
+      signature,
+      signingKeyId: "release-artifact-manifest-ed25519",
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("REJECTS a row stamped with the official key ID when no official key is configured, even with DB deployment keys present", async () => {
+    const deployKey = generateKeyPairSync("ed25519");
+    const manifest = legacyManifest();
+    const signature = sign(null, Buffer.from(manifest, "utf8"), deployKey.privateKey).toString("base64");
+    vi.spyOn(manifestSigning, "getActiveTrustKeyset").mockResolvedValue([
+      {
+        keyId: "deploy-2026-08-01-aaaa",
+        publicKeyB64: rawPub(deployKey.publicKey).toString("base64"),
+        validFrom: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await validateReleaseManifest({
+      ...legacyArgsBase,
+      manifest,
+      signature,
+      signingKeyId: "release-artifact-manifest-ed25519",
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid_release_manifest_signature" });
+  });
+
+  it("REJECTS a row stamped with a deploy-* key ID when signed by the OFFICIAL key instead of that DB key row (vice-versa case)", async () => {
+    const official = generateKeyPairSync("ed25519");
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = rawPub(official.publicKey).toString("base64");
+    const manifest = legacyManifest();
+    const signature = sign(null, Buffer.from(manifest, "utf8"), official.privateKey).toString("base64");
+
+    // A DIFFERENT deploy key row exists under the claimed ID — its actual
+    // public key never signed this manifest.
+    const otherDeployKey = generateKeyPairSync("ed25519");
+    vi.spyOn(manifestSigning, "getActiveTrustKeyset").mockResolvedValue([
+      {
+        keyId: "deploy-2026-08-01-aaaa",
+        publicKeyB64: rawPub(otherDeployKey.publicKey).toString("base64"),
+        validFrom: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await validateReleaseManifest({
+      ...legacyArgsBase,
+      manifest,
+      signature,
+      signingKeyId: "deploy-2026-08-01-aaaa",
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid_release_manifest_signature" });
+  });
+
+  it("ACCEPTS a row stamped with a deploy-* key ID when signed by exactly that DB key row", async () => {
+    const deployKey = generateKeyPairSync("ed25519");
+    const manifest = legacyManifest();
+    const signature = sign(null, Buffer.from(manifest, "utf8"), deployKey.privateKey).toString("base64");
+    vi.spyOn(manifestSigning, "getActiveTrustKeyset").mockResolvedValue([
+      {
+        keyId: "deploy-2026-08-01-aaaa",
+        publicKeyB64: rawPub(deployKey.publicKey).toString("base64"),
+        validFrom: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await validateReleaseManifest({
+      ...legacyArgsBase,
+      manifest,
+      signature,
+      signingKeyId: "deploy-2026-08-01-aaaa",
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("REJECTS a deploy-* key ID with no matching manifest_signing_keys row (rotated out / never existed)", async () => {
+    const deployKey = generateKeyPairSync("ed25519");
+    const manifest = legacyManifest();
+    const signature = sign(null, Buffer.from(manifest, "utf8"), deployKey.privateKey).toString("base64");
+    vi.spyOn(manifestSigning, "getActiveTrustKeyset").mockResolvedValue([]);
+
+    const result = await validateReleaseManifest({
+      ...legacyArgsBase,
+      manifest,
+      signature,
+      signingKeyId: "deploy-2026-08-01-aaaa",
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid_release_manifest_signature" });
+  });
+
+  it("keeps the legacy whole-set behavior unchanged for absent/unrecognized signingKeyId (no ID narrowing applies)", async () => {
+    const trusted = generateKeyPairSync("ed25519");
+    process.env.AGENT_UPDATE_MANIFEST_PUBLIC_KEYS = rawPub(trusted.publicKey).toString("base64");
+    const manifest = legacyManifest();
+    const signature = sign(null, Buffer.from(manifest, "utf8"), trusted.privateKey).toString("base64");
+
+    const result = await validateReleaseManifest({
+      ...legacyArgsBase,
+      manifest,
+      signature,
+      // no signingKeyId at all
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects a schema-v1 row whose stamped key ID is NOT the official ID, even though the signature verifies under the official key (schema-v1 can only ever prove official provenance)", async () => {
+    const official = generateKeyPairSync("ed25519");
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = rawPub(official.publicKey).toString("base64");
+
+    const manifest = JSON.stringify({
+      schemaVersion: 1,
+      repository: "LanternOps/breeze",
+      release: "v1.0.0",
+      assets: [
+        {
+          name: "breeze-agent-linux-amd64",
+          sha256: "a".repeat(64),
+          size: 10,
+          platformTrust: requiredPlatformTrustFor("breeze-agent-linux-amd64") ?? undefined,
+        },
+      ],
+    });
+    const signature = sign(null, Buffer.from(manifest, "utf8"), official.privateKey).toString("base64");
+
+    const result = await validateReleaseManifest({
+      manifest,
+      signature,
+      signingKeyId: "deploy-2026-08-01-aaaa",
+      version: "1.0.0",
+      platform: "linux",
+      arch: "amd64",
+      component: "agent",
+      downloadUrl: "https://s3.example.com/agent-1.0.0",
+      checksum: "a".repeat(64),
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid_release_manifest_signature" });
   });
 });

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -70,6 +70,7 @@ import {
   agentVersionRoutes,
   validateReleaseManifest,
   verifyEd25519ManifestSignature,
+  canonicalReleaseAssetName,
 } from "./agentVersions";
 import { db } from "../db";
 import { agentVersions } from "../db/schema";
@@ -2173,5 +2174,212 @@ describe("verifyEd25519ManifestSignature — empty-keyset opt-in (#643)", () => 
       { allowEmptyKeysetSoftPass: true },
     );
     expect(result).toBe(false);
+  });
+});
+
+// D1 (#3836): canonicalReleaseAssetName must reproduce EXACTLY the filenames
+// binarySync.ts's scanBinaryDir/parseBinaryFilename (agent/watchdog/backup),
+// USER_HELPER_TARGETS (user-helper), and the release pipeline's raw macOS
+// helper binary (release.yml, releaseAssetTrust.ts's DARWIN_BINARY_RE)
+// produce — every case below is cross-checked against those sources, not
+// invented independently.
+describe("canonicalReleaseAssetName (D1, #3836)", () => {
+  const cases: Array<[string, string, string, string | null]> = [
+    // agent — windows/linux/darwin, both arches. Also proves "macos" (the DB
+    // platform value) and "darwin" (the wire/manifest value some callers use)
+    // both resolve to the same on-disk name.
+    ["agent", "windows", "amd64", "breeze-agent-windows-amd64.exe"],
+    ["agent", "windows", "arm64", "breeze-agent-windows-arm64.exe"],
+    ["agent", "linux", "amd64", "breeze-agent-linux-amd64"],
+    ["agent", "linux", "arm64", "breeze-agent-linux-arm64"],
+    ["agent", "macos", "amd64", "breeze-agent-darwin-amd64"],
+    ["agent", "macos", "arm64", "breeze-agent-darwin-arm64"],
+    ["agent", "darwin", "amd64", "breeze-agent-darwin-amd64"],
+
+    // watchdog — same shape as agent (WATCHDOG_TARGETS = AGENT_TARGETS).
+    ["watchdog", "windows", "amd64", "breeze-watchdog-windows-amd64.exe"],
+    ["watchdog", "linux", "amd64", "breeze-watchdog-linux-amd64"],
+    ["watchdog", "linux", "arm64", "breeze-watchdog-linux-arm64"],
+    ["watchdog", "macos", "amd64", "breeze-watchdog-darwin-amd64"],
+    ["watchdog", "macos", "arm64", "breeze-watchdog-darwin-arm64"],
+
+    // backup — same shape as agent (BACKUP_TARGETS = AGENT_TARGETS).
+    ["backup", "windows", "amd64", "breeze-backup-windows-amd64.exe"],
+    ["backup", "linux", "amd64", "breeze-backup-linux-amd64"],
+    ["backup", "linux", "arm64", "breeze-backup-linux-arm64"],
+    ["backup", "macos", "amd64", "breeze-backup-darwin-amd64"],
+    ["backup", "macos", "arm64", "breeze-backup-darwin-arm64"],
+
+    // user-helper — Windows only (USER_HELPER_TARGETS).
+    ["user-helper", "windows", "amd64", "breeze-user-helper-windows-amd64.exe"],
+    ["user-helper", "windows", "arm64", "breeze-user-helper-windows-arm64.exe"],
+    ["user-helper", "macos", "amd64", null],
+    ["user-helper", "linux", "amd64", null],
+
+    // helper — the raw macOS desktop-helper Mach-O binary bundled into the
+    // agent .pkg (DARWIN_BINARY_RE in releaseAssetTrust.ts, release.yml). No
+    // per-arch Windows/Linux asset ships under this shape today; the Tauri
+    // "helper" app's own non-per-arch installer (breeze-helper-macos.dmg
+    // etc.) is a different shape this function does not claim.
+    ["helper", "macos", "amd64", "breeze-desktop-helper-darwin-amd64"],
+    ["helper", "macos", "arm64", "breeze-desktop-helper-darwin-arm64"],
+    ["helper", "windows", "amd64", null],
+    ["helper", "linux", "amd64", null],
+
+    // Unknown component/platform/arch — every unrecognized shape falls back
+    // to the caller's assetNameFromDownloadUrl, never fabricates a name.
+    ["viewer", "windows", "amd64", null],
+    ["not-a-real-component", "linux", "amd64", null],
+    ["agent", "solaris", "amd64", null],
+    ["agent", "linux", "mips", null],
+  ];
+
+  it.each(cases)(
+    "component=%s platform=%s arch=%s -> %s",
+    (component, platform, arch, expected) => {
+      expect(canonicalReleaseAssetName(component, platform, arch)).toBe(expected);
+    },
+  );
+});
+
+// D3 (#3836): the schema-v1 catch in validateReleaseManifest used to
+// collapse EVERY throw from verifyReleaseArtifactManifestAsset into
+// invalid_release_manifest_signature. These tests pin the split to typed
+// errors exported from releaseArtifactManifest.ts.
+describe("validateReleaseManifest — schema-v1 reason split (D3, #3836)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+    delete process.env.BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+  });
+
+  function makeSignedSchemaV1Manifest(
+    assets: Array<{
+      name: string;
+      sha256: string;
+      size: number;
+      platformTrust?: string;
+      edition?: string;
+    }>,
+    release = "v1.0.0",
+  ) {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+    const rawPublicKey = publicDer.subarray(publicDer.length - 32);
+    const manifest = JSON.stringify({
+      schemaVersion: 1,
+      repository: "LanternOps/breeze",
+      release,
+      assets,
+    });
+    return {
+      manifest,
+      signature: sign(null, Buffer.from(manifest, "utf8"), privateKey).toString(
+        "base64",
+      ),
+      publicKey: rawPublicKey.toString("base64"),
+    };
+  }
+
+  it("returns release_manifest_asset_lookup_failed when the canonical asset is absent from a validly-signed manifest", async () => {
+    const signed = makeSignedSchemaV1Manifest([
+      {
+        name: "breeze-agent-windows-amd64.exe",
+        sha256: "a".repeat(64),
+        size: 10,
+        platformTrust: requiredPlatformTrustFor("breeze-agent-windows-amd64.exe") ?? undefined,
+      },
+    ]);
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+    const result = await validateReleaseManifest({
+      manifest: signed.manifest,
+      signature: signed.signature,
+      version: "1.0.0",
+      platform: "linux",
+      arch: "amd64",
+      component: "agent",
+      // Deliberately irrelevant: D1 makes the canonical (component, platform,
+      // arch) shape win over the URL basename, so this URL is never consulted.
+      downloadUrl: "https://s3.example.com/agent-1.0.0",
+      checksum: "b".repeat(64),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "release_manifest_asset_lookup_failed",
+    });
+  });
+
+  it("returns release_asset_not_distributable when the asset entry fails the platform-trust policy check", async () => {
+    const assetName = "breeze-agent-windows-amd64.exe";
+    const checksum = "c".repeat(64);
+    const signed = makeSignedSchemaV1Manifest([
+      // Windows .exe requires "windows-authenticode-required"; "none" with no
+      // edition claim is refused by assertDistributableReleaseAsset.
+      { name: assetName, sha256: checksum, size: 10, platformTrust: "none" },
+    ]);
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+    const result = await validateReleaseManifest({
+      manifest: signed.manifest,
+      signature: signed.signature,
+      version: "1.0.0",
+      platform: "windows",
+      arch: "amd64",
+      component: "agent",
+      downloadUrl: "https://s3.example.com/agent-1.0.0",
+      checksum,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "release_asset_not_distributable",
+    });
+  });
+
+  it("#641 — a forged signature still returns invalid_release_manifest_signature even though the asset would otherwise fail lookup", async () => {
+    // The manifest is well-formed but does NOT include the asset a valid
+    // signature would need to cover — if signature verification were skipped
+    // or ran second, this would leak release_manifest_asset_lookup_failed to
+    // an attacker who never held the signing key. It must not: verify
+    // ReleaseArtifactManifestAsset checks the signature before ever
+    // attempting the lookup.
+    const attacker = generateKeyPairSync("ed25519");
+    const trusted = generateKeyPairSync("ed25519");
+    const manifest = JSON.stringify({
+      schemaVersion: 1,
+      repository: "LanternOps/breeze",
+      release: "v1.0.0",
+      assets: [{ name: "breeze-agent-windows-amd64.exe", sha256: "a".repeat(64), size: 10 }],
+    });
+    const forgedSignature = sign(
+      null,
+      Buffer.from(manifest, "utf8"),
+      attacker.privateKey,
+    ).toString("base64");
+    const trustedPublicDer = trusted.publicKey.export({
+      format: "der",
+      type: "spki",
+    }) as Buffer;
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = trustedPublicDer
+      .subarray(trustedPublicDer.length - 32)
+      .toString("base64");
+
+    const result = await validateReleaseManifest({
+      manifest,
+      signature: forgedSignature,
+      version: "1.0.0",
+      platform: "linux", // resolves to breeze-agent-linux-amd64 — not in `assets` above
+      arch: "amd64",
+      component: "agent",
+      downloadUrl: "https://s3.example.com/agent-1.0.0",
+      checksum: "b".repeat(64),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "invalid_release_manifest_signature",
+    });
   });
 });

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -21,6 +21,7 @@ import {
   verifyReleaseArtifactManifestAsset,
   ReleaseAssetNotDistributableError,
   ReleaseManifestAssetLookupError,
+  ReleaseManifestSignatureError,
 } from "../services/releaseArtifactManifest";
 import { EDITION_HOSTED, EDITION_SELF_HOST } from "../services/releaseAssetTrust";
 import { getActivePublicKeys as getActiveDeploymentSigningPubKeys } from "../services/manifestSigning";
@@ -274,15 +275,15 @@ function assetNameFromDownloadUrl(downloadUrl: string): string | null {
 // every agent heartbeat for a correctly-signed row.
 //
 // This function reproduces EXACTLY the filenames binarySync.ts's
-// scanBinaryDir/parseBinaryFilename (agent/watchdog/backup),
-// USER_HELPER_TARGETS (user-helper), and the release pipeline's raw macOS
-// helper binary (release.yml / releaseAssetTrust.ts's DARWIN_BINARY_RE)
-// produce for every (component, platform, arch) triple this server can
-// register — see the cross-check list in the D1 unit tests. It is the
-// preferred source of truth; assetNameFromDownloadUrl(downloadUrl) remains
-// the fallback for any (component, platform) shape this function doesn't
-// recognize (including the GitHub-sourced case above), so behavior for
-// BINARY_SOURCE=github rows is unchanged.
+// scanBinaryDir/parseBinaryFilename (agent/watchdog/backup) and
+// USER_HELPER_TARGETS (user-helper) produce for every (component, platform,
+// arch) triple this server can register locally — see the cross-check list
+// in the D1 unit tests. It is the preferred source of truth for those
+// shapes; assetNameFromDownloadUrl(downloadUrl) remains the fallback for
+// every other (component, platform) combination, INCLUDING component=
+// "helper" (see that branch below for why it always falls through) and the
+// GitHub-sourced case, so behavior for BINARY_SOURCE=github rows is
+// unchanged.
 export function canonicalReleaseAssetName(
   component: string,
   platform: string,
@@ -307,18 +308,21 @@ export function canonicalReleaseAssetName(
     return `breeze-user-helper-windows-${architecture}.exe`;
   }
 
-  // The raw macOS remote-desktop companion binary bundled into the agent
-  // .pkg installer (agent/installer/macos/build-pkg.sh, release.yml). No
-  // per-arch Windows/Linux equivalent ships as its own asset today — the
-  // Tauri "helper" app's own installer (breeze-helper-{macos.dmg,windows.msi,
-  // linux.AppImage} — see HELPER_FILENAMES in services/binarySource.ts) is a
-  // different, non-per-arch asset shape this function deliberately does not
-  // claim to resolve; that shape falls through to the URL-basename fallback.
-  if (component === "helper") {
-    if (goos !== "darwin") return null;
-    return `breeze-desktop-helper-darwin-${architecture}`;
-  }
-
+  // component="helper" (the Tauri Helper app) has NO canonical raw-binary
+  // name here: its real registration is HELPER_TARGETS
+  // (services/binarySync.ts, ~line 59) — windows -> breeze-helper-windows.msi,
+  // darwin (amd64 AND arm64, same file) -> breeze-helper-macos.dmg, linux ->
+  // breeze-helper-linux.AppImage. That shape is per-OS, not per-arch, and
+  // isn't derivable from (component, platform, arch) alone (darwin/amd64 and
+  // darwin/arm64 both resolve to the SAME asset name). An earlier version of
+  // this function returned "breeze-desktop-helper-darwin-<arch>" for
+  // component="helper" — that is a DIFFERENT artifact (the raw Mach-O binary
+  // bundled inside the agent .pkg, never its own agentVersions row) and,
+  // being non-null, wrongly WON over the correct URL-basename fallback for
+  // real BINARY_SOURCE=github helper rows, which would have 409'd them.
+  // Falling through to the final `return null` below lets
+  // assetNameFromDownloadUrl(downloadUrl) resolve "helper" instead, which is
+  // correct for every helper row that exists today.
   return null;
 }
 
@@ -473,10 +477,17 @@ export async function validateReleaseManifest(args: {
         );
         return { ok: false, reason: "release_manifest_asset_lookup_failed" };
       }
-      // Signature verification failure, or any unrecognized error shape —
-      // fail closed to the least-specific reason.
+      if (err instanceof ReleaseManifestSignatureError) {
+        console.error(
+          "[agentVersions] Release manifest signature verification failed:",
+          err.message,
+        );
+        return { ok: false, reason: "invalid_release_manifest_signature" };
+      }
+      // Any unrecognized error shape — fail closed to the least-specific
+      // reason rather than assume it's safe to be more specific.
       console.error(
-        "[agentVersions] Release manifest signature verification failed:",
+        "[agentVersions] Unrecognized error verifying release manifest asset, failing closed:",
         err instanceof Error ? err.message : err,
       );
       return { ok: false, reason: "invalid_release_manifest_signature" };

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -17,7 +17,11 @@ import { syncFromGitHub } from "../services/binarySync";
 import { getBinaryEdition } from "../services/binaryEdition";
 import { getGithubReleaseVersion } from "../services/binarySource";
 import { PERMISSIONS } from "../services/permissions";
-import { verifyReleaseArtifactManifestAsset } from "../services/releaseArtifactManifest";
+import {
+  verifyReleaseArtifactManifestAsset,
+  ReleaseAssetNotDistributableError,
+  ReleaseManifestAssetLookupError,
+} from "../services/releaseArtifactManifest";
 import { EDITION_HOSTED, EDITION_SELF_HOST } from "../services/releaseAssetTrust";
 import { getActivePublicKeys as getActiveDeploymentSigningPubKeys } from "../services/manifestSigning";
 
@@ -253,6 +257,71 @@ function assetNameFromDownloadUrl(downloadUrl: string): string | null {
   }
 }
 
+// D1 (issue #3836): canonical asset-name resolution for schema-v1
+// release-artifact manifests.
+//
+// validateReleaseManifest's schema-v1 branch used to derive the manifest
+// asset name to look up SOLELY from assetNameFromDownloadUrl(downloadUrl) —
+// the URL's last path segment. That is correct for a GitHub-sourced
+// downloadUrl (".../releases/download/v1.0.0/breeze-agent-linux-amd64") but
+// wrong for a BINARY_SOURCE=local row: registerFromOfficialManifest
+// (services/binarySync.ts) stores a server-relative downloadUrl
+// (".../api/v1/agents/download/{os}/{arch}" — see
+// buildServerRelativeAgentDownloadUrl above), whose last path segment is the
+// ARCH, not an asset name. Every local-mode row's schema-v1 lookup therefore
+// searched the manifest for e.g. "amd64", never found it, and the failure
+// collapsed into invalid_release_manifest_signature — a fleet-wide 409 on
+// every agent heartbeat for a correctly-signed row.
+//
+// This function reproduces EXACTLY the filenames binarySync.ts's
+// scanBinaryDir/parseBinaryFilename (agent/watchdog/backup),
+// USER_HELPER_TARGETS (user-helper), and the release pipeline's raw macOS
+// helper binary (release.yml / releaseAssetTrust.ts's DARWIN_BINARY_RE)
+// produce for every (component, platform, arch) triple this server can
+// register — see the cross-check list in the D1 unit tests. It is the
+// preferred source of truth; assetNameFromDownloadUrl(downloadUrl) remains
+// the fallback for any (component, platform) shape this function doesn't
+// recognize (including the GitHub-sourced case above), so behavior for
+// BINARY_SOURCE=github rows is unchanged.
+export function canonicalReleaseAssetName(
+  component: string,
+  platform: string,
+  architecture: string,
+): string | null {
+  // DB / manifest platform values use "macos"; on-disk/release asset
+  // filenames use Go's GOOS naming, "darwin".
+  const goos = platform === "macos" ? "darwin" : platform;
+  const isKnownArch = architecture === "amd64" || architecture === "arm64";
+  if (!isKnownArch) return null;
+
+  if (component === "agent" || component === "watchdog" || component === "backup") {
+    if (goos !== "windows" && goos !== "linux" && goos !== "darwin") return null;
+    const suffix = goos === "windows" ? ".exe" : "";
+    return `breeze-${component}-${goos}-${architecture}${suffix}`;
+  }
+
+  // breeze-user-helper (#816/#1878): Windows-only GUI-subsystem sibling of
+  // breeze-agent.
+  if (component === "user-helper") {
+    if (goos !== "windows") return null;
+    return `breeze-user-helper-windows-${architecture}.exe`;
+  }
+
+  // The raw macOS remote-desktop companion binary bundled into the agent
+  // .pkg installer (agent/installer/macos/build-pkg.sh, release.yml). No
+  // per-arch Windows/Linux equivalent ships as its own asset today — the
+  // Tauri "helper" app's own installer (breeze-helper-{macos.dmg,windows.msi,
+  // linux.AppImage} — see HELPER_FILENAMES in services/binarySource.ts) is a
+  // different, non-per-arch asset shape this function deliberately does not
+  // claim to resolve; that shape falls through to the URL-basename fallback.
+  if (component === "helper") {
+    if (goos !== "darwin") return null;
+    return `breeze-desktop-helper-darwin-${architecture}`;
+  }
+
+  return null;
+}
+
 // Server-origin discovery for handing agents a download URL that matches
 // their configured control-plane host. The agent's downloadFromURL enforces
 // host equality with its ServerURL to prevent leaking the bearer token to a
@@ -352,7 +421,15 @@ export async function validateReleaseManifest(args: {
   }
 
   if (parsed.schemaVersion === 1 && Array.isArray(parsed.assets)) {
-    const assetName = assetNameFromDownloadUrl(args.downloadUrl);
+    // D1 (#3836): canonical resolution wins when the (component, platform,
+    // arch) shape is known — the URL basename stays only as a fallback for
+    // shapes canonicalReleaseAssetName doesn't recognize (e.g. a genuine
+    // GitHub-sourced downloadUrl). See canonicalReleaseAssetName's own
+    // comment for why the URL-basename-only approach was wrong for
+    // BINARY_SOURCE=local rows.
+    const assetName =
+      canonicalReleaseAssetName(args.component, args.platform, args.arch) ??
+      assetNameFromDownloadUrl(args.downloadUrl);
     if (!assetName) {
       return { ok: false, reason: "release_manifest_metadata_mismatch" };
     }
@@ -373,7 +450,35 @@ export async function validateReleaseManifest(args: {
         return { ok: false, reason: "release_manifest_metadata_mismatch" };
       }
       return { ok: true };
-    } catch {
+    } catch (err) {
+      // D3 (#3836): verifyReleaseArtifactManifestAsset verifies the Ed25519
+      // signature FIRST, unconditionally, before it ever attempts an asset
+      // lookup or a distributability check (releaseArtifactManifest.ts) — so
+      // reaching either typed branch below already implies a signature that
+      // verified. That preserves the #641 anti-probing property: a reason
+      // more specific than "signature invalid" is only ever returned after a
+      // real signature check passed. Never leak `err.message` to the agent
+      // response body — log it server-side only.
+      if (err instanceof ReleaseAssetNotDistributableError) {
+        console.error(
+          "[agentVersions] Release asset not distributable:",
+          err.message,
+        );
+        return { ok: false, reason: "release_asset_not_distributable" };
+      }
+      if (err instanceof ReleaseManifestAssetLookupError) {
+        console.error(
+          "[agentVersions] Release manifest asset lookup failed:",
+          err.message,
+        );
+        return { ok: false, reason: "release_manifest_asset_lookup_failed" };
+      }
+      // Signature verification failure, or any unrecognized error shape —
+      // fail closed to the least-specific reason.
+      console.error(
+        "[agentVersions] Release manifest signature verification failed:",
+        err instanceof Error ? err.message : err,
+      );
       return { ok: false, reason: "invalid_release_manifest_signature" };
     }
   }

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -22,9 +22,20 @@ import {
   ReleaseAssetNotDistributableError,
   ReleaseManifestAssetLookupError,
   ReleaseManifestSignatureError,
+  verifyManifestSignatureAgainstOfficialKeysOnly,
 } from "../services/releaseArtifactManifest";
 import { EDITION_HOSTED, EDITION_SELF_HOST } from "../services/releaseAssetTrust";
-import { getActivePublicKeys as getActiveDeploymentSigningPubKeys } from "../services/manifestSigning";
+import {
+  getActivePublicKeys as getActiveDeploymentSigningPubKeys,
+  getActiveTrustKeyset,
+} from "../services/manifestSigning";
+
+// The one key ID hard-bound in every agent build to the embedded LanternOps
+// release-signing public key (agent/internal/updater/updater.go, ~line 395).
+// Any OTHER signingKeyId value is either a `deploy-*` per-deployment key
+// (manifest_signing_keys) or unrecognized/absent (legacy normalized rows
+// predating signingKeyId).
+const OFFICIAL_MANIFEST_SIGNING_KEY_ID = "release-artifact-manifest-ed25519";
 
 // Map Go GOOS / user-facing platform names to DB platform names
 const PLATFORM_MAP: Record<string, string> = {
@@ -247,6 +258,95 @@ export async function verifyEd25519ManifestSignature(
   });
 }
 
+// Verifies `signature` against exactly ONE raw 32-byte Ed25519 key — the
+// deploy-* single-key-row branch of verifyManifestSignatureForSigningKeyId
+// below. Deliberately duplicates the small signature-bytes check inline
+// (rather than refactoring the well-tested verifyEd25519ManifestSignature
+// above to take a caller-supplied key list) so that function's existing
+// logging/soft-pass semantics — which several tests pin — stay untouched.
+function verifyEd25519SignatureAgainstSingleRawKey(
+  manifest: string,
+  signature: string,
+  rawKey: Buffer,
+): boolean {
+  if (rawKey.length !== 32) return false;
+  let signatureBytes: Buffer;
+  try {
+    signatureBytes = Buffer.from(signature, "base64");
+  } catch {
+    return false;
+  }
+  if (signatureBytes.length !== 64) return false;
+
+  try {
+    const spki = Buffer.concat([
+      Buffer.from("302a300506032b6570032100", "hex"),
+      rawKey,
+    ]);
+    const publicKey = createPublicKey({ key: spki, format: "der", type: "spki" });
+    return verifySignature(
+      null,
+      Buffer.from(manifest, "utf8"),
+      publicKey,
+      signatureBytes,
+    );
+  } catch {
+    return false;
+  }
+}
+
+// Key-ID-aware verification for the LEGACY (non schema-v1) manifest shape —
+// Task 2 (#3836). Mirrors the agent's exact-ID semantics (agent/internal/
+// updater/updater.go verifyManifestSignature, ~line 769): when a key ID is
+// present it binds verification to that ONE key, with no fallback across
+// the rest of the trusted set. This narrows what an EXPLICIT signingKeyId
+// can accept — it never widens acceptance relative to the prior whole-set
+// behavior, and unrecognized/absent IDs keep exactly that prior behavior.
+//
+//  - OFFICIAL_MANIFEST_SIGNING_KEY_ID: the OFFICIAL configured key set
+//    (RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS / getConfiguredPublicKeys via
+//    verifyManifestSignatureAgainstOfficialKeysOnly) ONLY — a DB deployment
+//    key must never satisfy a claim of official provenance.
+//  - `deploy-*`: exactly the one manifest_signing_keys row with that keyId
+//    — env keys and every OTHER deploy key must NOT satisfy it. A missing
+//    row (rotated out, never existed, DB load failure) fails closed.
+//  - absent/unrecognized (legacy normalized rows predating signingKeyId, or
+//    any other value): unchanged whole-set verifyEd25519ManifestSignature
+//    behavior — this task narrows what an explicit ID accepts, it does not
+//    newly require one.
+async function verifyManifestSignatureForSigningKeyId(
+  manifest: string,
+  signature: string,
+  signingKeyId: string | null | undefined,
+): Promise<boolean> {
+  const id = signingKeyId?.trim();
+
+  if (id === OFFICIAL_MANIFEST_SIGNING_KEY_ID) {
+    return verifyManifestSignatureAgainstOfficialKeysOnly(manifest, signature);
+  }
+
+  if (id && id.startsWith("deploy-")) {
+    let keyset: { keyId: string; publicKeyB64: string }[];
+    try {
+      keyset = await getActiveTrustKeyset();
+    } catch (err) {
+      console.warn(
+        `[agentVersions] Failed to load manifest_signing_keys for signingKeyId=${id} lookup (failing closed):`,
+        err,
+      );
+      return false;
+    }
+    const row = keyset.find((k) => k.keyId === id);
+    if (!row) return false;
+    const rawKey = Buffer.from(row.publicKeyB64, "base64");
+    return verifyEd25519SignatureAgainstSingleRawKey(manifest, signature, rawKey);
+  }
+
+  return verifyEd25519ManifestSignature(manifest, signature, {
+    allowEmptyKeysetSoftPass: true,
+  });
+}
+
 function assetNameFromDownloadUrl(downloadUrl: string): string | null {
   try {
     const parsed = new URL(downloadUrl);
@@ -411,6 +511,7 @@ export async function validateReleaseManifest(args: {
   downloadUrl: string;
   checksum: string;
   fileSize?: number | bigint | null;
+  signingKeyId?: string | null;
 }): Promise<{ ok: true } | { ok: false; reason: string }> {
   if (!args.manifest || !args.signature) {
     return { ok: false, reason: "signed_release_manifest_required" };
@@ -425,6 +526,24 @@ export async function validateReleaseManifest(args: {
   }
 
   if (parsed.schemaVersion === 1 && Array.isArray(parsed.assets)) {
+    // Task 2 (#3836) key-ID-aware guard: verifyReleaseArtifactManifestAsset
+    // below only ever trusts the OFFICIAL configured key set
+    // (getConfiguredPublicKeys) — it has no DB-deployment-key code path, so
+    // a schema-v1 row can only ever validly prove OFFICIAL provenance. A
+    // `deploy-*` (or other non-official) signingKeyId reaching this branch
+    // can never be honestly satisfied: an official signature wouldn't
+    // verify against an agent's TOFU-pinned deploy key either, so accepting
+    // it here would just be a claim the agent itself would reject. Reject
+    // before even asking whether the signature verifies, since no outcome
+    // of that check could make the ID claim true. No row
+    // registerFromOfficialManifest/getReleaseAssetMetadata (binarySync.ts)
+    // produces today hits this — it's defense in depth against a
+    // future/corrupted row.
+    const claimedKeyId = args.signingKeyId?.trim();
+    if (claimedKeyId && claimedKeyId !== OFFICIAL_MANIFEST_SIGNING_KEY_ID) {
+      return { ok: false, reason: "invalid_release_manifest_signature" };
+    }
+
     // D1 (#3836): canonical resolution wins when the (component, platform,
     // arch) shape is known — the URL basename stays only as a fallback for
     // shapes canonicalReleaseAssetName doesn't recognize (e.g. a genuine
@@ -498,10 +617,17 @@ export async function validateReleaseManifest(args: {
   // specific `release_manifest_metadata_mismatch` reason to a caller whose
   // signature was forged, we let attackers probe which DB-row field would
   // have mismatched without ever holding a valid signing key (#641).
+  //
+  // Task 2 (#3836): key-ID-aware dispatch replaces the unconditional
+  // whole-set verifyEd25519ManifestSignature call — see
+  // verifyManifestSignatureForSigningKeyId's own comment for the exact
+  // binding this enforces.
   if (
-    !(await verifyEd25519ManifestSignature(args.manifest, args.signature, {
-      allowEmptyKeysetSoftPass: true,
-    }))
+    !(await verifyManifestSignatureForSigningKeyId(
+      args.manifest,
+      args.signature,
+      args.signingKeyId,
+    ))
   ) {
     return { ok: false, reason: "invalid_release_manifest_signature" };
   }
@@ -649,6 +775,7 @@ agentVersionRoutes.get(
       downloadUrl: versionInfo.downloadUrl,
       checksum: versionInfo.checksum,
       fileSize: versionInfo.fileSize,
+      signingKeyId: versionInfo.signingKeyId,
     });
     if (!manifestCheck.ok) {
       return c.json(
@@ -742,6 +869,7 @@ agentVersionRoutes.post(
       downloadUrl: data.downloadUrl,
       checksum: data.checksum,
       fileSize: data.fileSize,
+      signingKeyId: data.signingKeyId,
     });
     if (!createManifestCheck.ok) {
       return c.json(
@@ -1007,6 +1135,7 @@ agentVersionRoutes.post(
         fileSize: agentVersions.fileSize,
         releaseManifest: agentVersions.releaseManifest,
         manifestSignature: agentVersions.manifestSignature,
+        signingKeyId: agentVersions.signingKeyId,
       })
       .from(agentVersions)
       .where(
@@ -1063,6 +1192,7 @@ agentVersionRoutes.post(
         downloadUrl: row.downloadUrl,
         checksum: row.checksum,
         fileSize: row.fileSize,
+        signingKeyId: row.signingKeyId,
       });
       if (!check.ok) {
         invalidTargets.push({

--- a/apps/api/src/routes/agentVersionsLocalModeRoundtrip.test.ts
+++ b/apps/api/src/routes/agentVersionsLocalModeRoundtrip.test.ts
@@ -57,6 +57,7 @@ vi.mock("../services/auditEvents", () => ({
 }));
 vi.mock("../services/manifestSigning", () => ({
   getActivePublicKeys: vi.fn().mockResolvedValue([]),
+  getActiveTrustKeyset: vi.fn().mockResolvedValue([]),
   ensureActiveSigningKey: vi
     .fn()
     .mockResolvedValue({ keyId: "test-key", publicKeyB64: "" }),
@@ -83,6 +84,7 @@ vi.mock("node:fs", () => ({
 import { syncBinaries, syncFromGitHub } from "../services/binarySync";
 import { validateReleaseManifest } from "./agentVersions";
 import { requiredPlatformTrustFor } from "../services/releaseAssetTrust";
+import * as manifestSigning from "../services/manifestSigning";
 
 function localAssetChecksum(): string {
   return createHash("sha256").update("local agent bytes").digest("hex");
@@ -164,7 +166,7 @@ describe("D1 — local-mode registration roundtrip survives validateReleaseManif
     expect(dbMocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({ signingKeyId: "release-artifact-manifest-ed25519" }),
     );
-    const row = dbMocks.insertValues.mock.calls[0]![0] as {
+    const row = (dbMocks.insertValues.mock.calls as unknown[][])[0]![0] as {
       version: string;
       component: string;
       platform: string;
@@ -174,6 +176,7 @@ describe("D1 — local-mode registration roundtrip survives validateReleaseManif
       fileSize: bigint;
       releaseManifest: string;
       manifestSignature: string;
+      signingKeyId: string;
     };
 
     // Confirms this row really does carry the server-relative shape the
@@ -191,9 +194,119 @@ describe("D1 — local-mode registration roundtrip survives validateReleaseManif
       downloadUrl: row.downloadUrl,
       checksum: row.checksum,
       fileSize: row.fileSize,
+      // Task 2 (#3836): pass the real stamped signingKeyId through, matching
+      // GET /:version/download's own call — this is now load-bearing, not
+      // cosmetic. See the "key-ID-aware verification" suite below for the
+      // negative case this makes possible.
+      signingKeyId: row.signingKeyId,
     });
 
     expect(result).toEqual({ ok: true });
+  });
+});
+
+// Task 2 (#3836): key-ID-aware verification. Extends the roundtrip above
+// with the negative case that motivated it — a row can genuinely register
+// via registerFromOfficialManifest (real stamp: signingKeyId =
+// "release-artifact-manifest-ed25519"), and validateReleaseManifest must
+// still refuse to serve it at download time if the bytes it is ACTUALLY
+// asked to verify were not signed by the configured OFFICIAL key — even
+// when a different key that IS otherwise trusted (a manifest_signing_keys /
+// deploy-* row) made that signature. Before this task, validateReleaseManifest's
+// legacy (non schema-v1) branch checked the UNION of env keys and every DB
+// deployment key regardless of what signingKeyId claimed, so this exact
+// combination would have passed the server while a real agent's exact-ID
+// lookup (agent/internal/updater/updater.go verifyManifestSignature) would
+// still reject it. See agentVersions.test.ts's "key-ID-aware dispatch"
+// suite for the exhaustive unit-level cases (both directions, plus the
+// schema-v1 defensive guard).
+describe("Task 2 — key-ID-aware verification rejects an official-ID row not actually signed by the official key (#3836)", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.BINARY_SOURCE = "local";
+    process.env.AGENT_BINARY_DIR = "/data/binaries/agent";
+    process.env.BINARY_VERSION_FILE = "/fake/version";
+    delete process.env.BREEZE_VERSION;
+    delete process.env.PUBLIC_API_URL;
+    delete process.env.PUBLIC_APP_URL;
+    delete process.env.BREEZE_SERVER;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("rejects a legacy-shape manifest stamped with the genuinely-registered official key ID but signed by an otherwise-trusted deployment key", async () => {
+    const assetName = "breeze-agent-windows-amd64.exe";
+    const official = makeOfficialLocalManifest(assetName);
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = official.publicKey;
+    fsMocks.readdir.mockResolvedValue([assetName] as never);
+    fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 18 } as never);
+    mockReadFileWithOfficialManifest("1.2.3", official.manifest, official.signature);
+
+    await syncBinaries();
+
+    const row = (dbMocks.insertValues.mock.calls as unknown[][])[0]![0] as {
+      version: string;
+      component: string;
+      platform: string;
+      architecture: string;
+      downloadUrl: string;
+      checksum: string;
+      fileSize: bigint;
+      signingKeyId: string;
+    };
+    // Sanity: this really is the official-ID stamp the bug depends on.
+    expect(row.signingKeyId).toBe("release-artifact-manifest-ed25519");
+
+    // Simulate the exact bug this task closes: the row still claims the
+    // official key ID, but the manifest bytes actually being verified were
+    // signed by a per-deployment key that IS otherwise trusted (present in
+    // manifest_signing_keys) — never a genuinely official signature.
+    const deployKey = generateKeyPairSync("ed25519");
+    const rawDeployPub = (
+      deployKey.publicKey.export({ format: "der", type: "spki" }) as Buffer
+    ).subarray(-32);
+    const legacyManifest = JSON.stringify({
+      version: row.version,
+      component: row.component,
+      platform: row.platform,
+      arch: row.architecture,
+      url: row.downloadUrl,
+      checksum: row.checksum,
+      size: Number(row.fileSize),
+    });
+    const deploySignature = sign(
+      null,
+      Buffer.from(legacyManifest, "utf8"),
+      deployKey.privateKey,
+    ).toString("base64");
+
+    vi.spyOn(manifestSigning, "getActiveTrustKeyset").mockResolvedValue([
+      {
+        keyId: "deploy-2026-08-01-aaaa",
+        publicKeyB64: rawDeployPub.toString("base64"),
+        validFrom: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await validateReleaseManifest({
+      manifest: legacyManifest,
+      signature: deploySignature,
+      version: row.version,
+      platform: row.platform,
+      arch: row.architecture,
+      component: row.component,
+      downloadUrl: row.downloadUrl,
+      checksum: row.checksum,
+      fileSize: row.fileSize,
+      signingKeyId: row.signingKeyId,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid_release_manifest_signature" });
   });
 });
 
@@ -320,6 +433,7 @@ describe("D1 fix-round-1 — GitHub-mode helper registration stays byte-for-byte
       fileSize: bigint;
       releaseManifest: string;
       manifestSignature: string;
+      signingKeyId: string;
     };
 
     // Confirms this row really does carry the GitHub-sourced shape the
@@ -339,6 +453,7 @@ describe("D1 fix-round-1 — GitHub-mode helper registration stays byte-for-byte
       downloadUrl: row.downloadUrl,
       checksum: row.checksum,
       fileSize: row.fileSize,
+      signingKeyId: row.signingKeyId,
     });
 
     expect(result).toEqual({ ok: true });

--- a/apps/api/src/routes/agentVersionsLocalModeRoundtrip.test.ts
+++ b/apps/api/src/routes/agentVersionsLocalModeRoundtrip.test.ts
@@ -80,7 +80,7 @@ vi.mock("node:fs", () => ({
   },
 }));
 
-import { syncBinaries } from "../services/binarySync";
+import { syncBinaries, syncFromGitHub } from "../services/binarySync";
 import { validateReleaseManifest } from "./agentVersions";
 import { requiredPlatformTrustFor } from "../services/releaseAssetTrust";
 
@@ -180,6 +180,154 @@ describe("D1 — local-mode registration roundtrip survives validateReleaseManif
     // production bug depends on — the last path segment is the ARCH, not an
     // asset name.
     expect(row.downloadUrl).toMatch(/\/api\/v1\/agents\/download\/windows\/amd64$/);
+
+    const result = await validateReleaseManifest({
+      manifest: row.releaseManifest,
+      signature: row.manifestSignature,
+      version: row.version,
+      platform: row.platform,
+      arch: row.architecture,
+      component: row.component,
+      downloadUrl: row.downloadUrl,
+      checksum: row.checksum,
+      fileSize: row.fileSize,
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+// Fix-round-1 controller correction (#3836): an earlier version of
+// canonicalReleaseAssetName returned a non-null (WRONG) name for
+// component="helper"/platform="macos", which would have WON over the
+// correct URL-basename fallback and 409'd every real, currently-working
+// BINARY_SOURCE=github helper row. This suite exercises the REAL
+// syncFromGitHub helper registration path (HELPER_TARGETS,
+// services/binarySync.ts ~line 59) exactly the way it registers a helper row
+// in production, then feeds that row into the REAL validateReleaseManifest —
+// pinning that GitHub-mode helper rows keep working byte-for-byte.
+describe("D1 fix-round-1 — GitHub-mode helper registration stays byte-for-byte unchanged (#3836)", () => {
+  const originalEnv = process.env;
+
+  function makeSignedReleaseArtifactManifestFor(
+    assetName: string,
+    buffer: Buffer,
+    release = "v1.2.3",
+  ) {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+    const rawPublicKey = publicDer.subarray(publicDer.length - 32).toString("base64");
+    const checksum = createHash("sha256").update(buffer).digest("hex");
+    const manifest = JSON.stringify({
+      schemaVersion: 1,
+      repository: "LanternOps/breeze",
+      release,
+      assets: [
+        {
+          name: assetName,
+          sha256: checksum,
+          size: buffer.length,
+          platformTrust:
+            requiredPlatformTrustFor(assetName) ?? "release-workflow-produced",
+        },
+      ],
+    });
+    const signature = sign(null, Buffer.from(manifest, "utf8"), privateKey).toString(
+      "base64",
+    );
+    return { manifest, signature, publicKey: rawPublicKey, release };
+  }
+
+  function stubGitHubReleaseFetchForHelper(
+    signed: { manifest: string; signature: string; release: string },
+    assetName: string,
+    assetBuffer: Buffer,
+  ) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("/releases/latest")) {
+          return new Response(
+            JSON.stringify({
+              tag_name: signed.release,
+              body: "release notes",
+              assets: [
+                {
+                  name: assetName,
+                  browser_download_url: `https://github.com/LanternOps/breeze/releases/download/${signed.release}/${assetName}`,
+                  size: assetBuffer.length,
+                },
+                {
+                  name: "release-artifact-manifest.json",
+                  browser_download_url: `https://github.com/LanternOps/breeze/releases/download/${signed.release}/release-artifact-manifest.json`,
+                  size: signed.manifest.length,
+                },
+                {
+                  name: "release-artifact-manifest.json.ed25519",
+                  browser_download_url: `https://github.com/LanternOps/breeze/releases/download/${signed.release}/release-artifact-manifest.json.ed25519`,
+                  size: signed.signature.length,
+                },
+              ],
+            }),
+          );
+        }
+        if (url.endsWith("/release-artifact-manifest.json")) {
+          return new Response(signed.manifest);
+        }
+        if (url.endsWith("/release-artifact-manifest.json.ed25519")) {
+          return new Response(signed.signature);
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.BINARY_SOURCE = "github";
+    delete process.env.BINARY_GITHUB_REPOSITORY;
+    delete process.env.GITHUB_REPO;
+    delete process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+    delete process.env.BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+  });
+
+  it("registers a macOS helper row (breeze-helper-macos.dmg) via syncFromGitHub that validateReleaseManifest accepts", async () => {
+    const assetName = "breeze-helper-macos.dmg";
+    const assetBuffer = Buffer.from("helper dmg bytes");
+    const signed = makeSignedReleaseArtifactManifestFor(assetName, assetBuffer);
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+    stubGitHubReleaseFetchForHelper(signed, assetName, assetBuffer);
+
+    await syncFromGitHub();
+
+    const helperInsert = (dbMocks.insertValues.mock.calls as unknown[][]).find(
+      (call) => (call[0] as { component: string }).component === "helper",
+    );
+    expect(helperInsert).toBeDefined();
+    const row = helperInsert![0] as {
+      version: string;
+      component: string;
+      platform: string;
+      architecture: string;
+      downloadUrl: string;
+      checksum: string;
+      fileSize: bigint;
+      releaseManifest: string;
+      manifestSignature: string;
+    };
+
+    // Confirms this row really does carry the GitHub-sourced shape the
+    // regression is about: the URL basename IS the real asset name, unlike
+    // the local-mode row in the suite above.
+    expect(row.downloadUrl).toBe(
+      `https://github.com/LanternOps/breeze/releases/download/${signed.release}/${assetName}`,
+    );
 
     const result = await validateReleaseManifest({
       manifest: row.releaseManifest,

--- a/apps/api/src/routes/agentVersionsLocalModeRoundtrip.test.ts
+++ b/apps/api/src/routes/agentVersionsLocalModeRoundtrip.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHash, generateKeyPairSync, sign } from "node:crypto";
+
+// This suite exercises the REAL local-mode registration path
+// (binarySync.syncBinaries -> registerFromOfficialManifest) and feeds its
+// exact output into the REAL validateReleaseManifest (agentVersions.ts) — a
+// true end-to-end roundtrip of what production sees under
+// BINARY_SOURCE=local, rather than a hand-constructed fixture that only
+// tests my understanding of the two modules' contract.
+//
+// Bug (#3836): BINARY_SOURCE=local stores a server-relative downloadUrl
+// (".../api/v1/agents/download/{os}/{arch}" — see
+// buildServerRelativeAgentDownloadUrl / registerFromOfficialManifest in
+// binarySync.ts) whose last path segment is the ARCH, not an asset name.
+// validateReleaseManifest's schema-v1 branch used to derive the manifest
+// asset name from that URL basename (assetNameFromDownloadUrl), so it looked
+// up "amd64" in the manifest's asset list instead of
+// "breeze-agent-windows-amd64.exe", threw, and the catch collapsed that into
+// `invalid_release_manifest_signature` — a fleet-wide 409 on every agent
+// heartbeat for a perfectly valid, correctly-signed row.
+
+const dbMocks = vi.hoisted(() => {
+  const updateWhere = vi.fn().mockResolvedValue(undefined);
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const txUpdate = vi.fn(() => ({ set: updateSet }));
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const insertValues = vi.fn(() => ({ onConflictDoUpdate }));
+  const txInsert = vi.fn(() => ({ values: insertValues }));
+  const tx = { update: txUpdate, insert: txInsert };
+  const select = vi.fn();
+  return {
+    insertValues,
+    select,
+    transaction: vi.fn(async (fn: (tx: unknown) => Promise<void>) => fn(tx)),
+  };
+});
+
+vi.mock("../db", () => ({
+  db: { transaction: dbMocks.transaction, select: dbMocks.select },
+}));
+
+// agentVersions.ts imports these middlewares/services at module scope; stub
+// them out (same shape as agentVersions.test.ts) so this file doesn't need
+// to drag in real auth/audit machinery just to reach the pure
+// validateReleaseManifest export.
+vi.mock("../middleware/auth", () => ({
+  authMiddleware: vi.fn(async (_c: unknown, next: () => unknown) => next()),
+  requireScope: () => vi.fn(async (_c: unknown, next: () => unknown) => next()),
+  requirePermission: () => vi.fn(async (_c: unknown, next: () => unknown) => next()),
+  requireMfa: () => vi.fn(async (_c: unknown, next: () => unknown) => next()),
+}));
+vi.mock("../middleware/platformAdmin", () => ({
+  platformAdminMiddleware: vi.fn(async (_c: unknown, next: () => unknown) => next()),
+}));
+vi.mock("../services/auditEvents", () => ({
+  writeRouteAudit: vi.fn(),
+}));
+vi.mock("../services/manifestSigning", () => ({
+  getActivePublicKeys: vi.fn().mockResolvedValue([]),
+  ensureActiveSigningKey: vi
+    .fn()
+    .mockResolvedValue({ keyId: "test-key", publicKeyB64: "" }),
+  signManifest: vi.fn().mockResolvedValue("test-signature"),
+}));
+vi.mock("../services/s3Storage", () => ({
+  isS3Configured: () => false,
+  syncDirectory: vi.fn(),
+}));
+
+const fsMocks = vi.hoisted(() => ({
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+  stat: vi.fn(),
+}));
+vi.mock("node:fs/promises", () => fsMocks);
+vi.mock("node:fs", () => ({
+  createReadStream: () => {
+    const { Readable } = require("node:stream");
+    return Readable.from(Buffer.from("local agent bytes"));
+  },
+}));
+
+import { syncBinaries } from "../services/binarySync";
+import { validateReleaseManifest } from "./agentVersions";
+import { requiredPlatformTrustFor } from "../services/releaseAssetTrust";
+
+function localAssetChecksum(): string {
+  return createHash("sha256").update("local agent bytes").digest("hex");
+}
+
+function makeOfficialLocalManifest(assetName: string) {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  const rawPublicKey = publicDer.subarray(publicDer.length - 32).toString("base64");
+  const manifest = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 1,
+      repository: "LanternOps/breeze",
+      release: "v1.2.3",
+      assets: [
+        {
+          name: assetName,
+          sha256: localAssetChecksum(),
+          size: 18, // Buffer.byteLength("local agent bytes")
+          platformTrust: requiredPlatformTrustFor(assetName) ?? "release-workflow-produced",
+          edition: "self-host",
+        },
+      ],
+    }),
+  );
+  const signature = Buffer.from(sign(null, manifest, privateKey).toString("base64"));
+  return { manifest, signature, publicKey: rawPublicKey };
+}
+
+function mockReadFileWithOfficialManifest(
+  versionFileContent: string,
+  manifest: Buffer,
+  signature: Buffer,
+) {
+  fsMocks.readFile.mockImplementation((path: unknown) => {
+    if (typeof path === "string" && path.endsWith("release-artifact-manifest.json.ed25519")) {
+      return Promise.resolve(signature);
+    }
+    if (typeof path === "string" && path.endsWith("release-artifact-manifest.json")) {
+      return Promise.resolve(manifest);
+    }
+    return Promise.resolve(versionFileContent);
+  });
+}
+
+describe("D1 — local-mode registration roundtrip survives validateReleaseManifest (#3836)", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.BINARY_SOURCE = "local";
+    process.env.AGENT_BINARY_DIR = "/data/binaries/agent";
+    process.env.BINARY_VERSION_FILE = "/fake/version";
+    delete process.env.BREEZE_VERSION;
+    delete process.env.PUBLIC_API_URL;
+    delete process.env.PUBLIC_APP_URL;
+    delete process.env.BREEZE_SERVER;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("windows agent binary registered via registerFromOfficialManifest validates ok:true", async () => {
+    const assetName = "breeze-agent-windows-amd64.exe";
+    const official = makeOfficialLocalManifest(assetName);
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = official.publicKey;
+    fsMocks.readdir.mockResolvedValue([assetName] as never);
+    fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 18 } as never);
+    mockReadFileWithOfficialManifest("1.2.3", official.manifest, official.signature);
+
+    await syncBinaries();
+
+    // Sanity: the row actually registered from the OFFICIAL manifest path
+    // (registerFromOfficialManifest), not the per-deployment re-sign
+    // fallback — otherwise this wouldn't be exercising the local-mode
+    // server-relative-downloadUrl shape the bug is about.
+    expect(dbMocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ signingKeyId: "release-artifact-manifest-ed25519" }),
+    );
+    const row = dbMocks.insertValues.mock.calls[0]![0] as {
+      version: string;
+      component: string;
+      platform: string;
+      architecture: string;
+      downloadUrl: string;
+      checksum: string;
+      fileSize: bigint;
+      releaseManifest: string;
+      manifestSignature: string;
+    };
+
+    // Confirms this row really does carry the server-relative shape the
+    // production bug depends on — the last path segment is the ARCH, not an
+    // asset name.
+    expect(row.downloadUrl).toMatch(/\/api\/v1\/agents\/download\/windows\/amd64$/);
+
+    const result = await validateReleaseManifest({
+      manifest: row.releaseManifest,
+      signature: row.manifestSignature,
+      version: row.version,
+      platform: row.platform,
+      arch: row.architecture,
+      component: row.component,
+      downloadUrl: row.downloadUrl,
+      checksum: row.checksum,
+      fileSize: row.fileSize,
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -1300,6 +1300,26 @@ describe("binarySync", () => {
       return createHash("sha256").update("local agent bytes").digest("hex");
     }
 
+    // NOTE (Task 2, #3836): this helper configures RELEASE_ARTIFACT_MANIFEST_
+    // PUBLIC_KEYS to an arbitrary freshly-generated key and signs with the
+    // SAME key, then the tests below assert the row gets stamped
+    // signingKeyId="release-artifact-manifest-ed25519". That only proves
+    // registration correctly identifies "signed by whatever this test run
+    // configured as official" — it does NOT, on its own, prove the
+    // server-side download-path binding (that an official-ID stamp can
+    // ONLY ever be satisfied by that same official key, never by a
+    // DB-provisioned per-deployment key). This file mocks db/manifestSigning
+    // too heavily to reach the real validateReleaseManifest for that
+    // property cheaply — the exact-binding assertions live instead in:
+    //   - apps/api/src/routes/agentVersions.test.ts, describe
+    //     "validateReleaseManifest — key-ID-aware dispatch (Task 2, #3836)"
+    //     (unit-level, both directions: official-ID-vs-deploy-key and
+    //     deploy-ID-vs-official-key)
+    //   - apps/api/src/routes/agentVersionsLocalModeRoundtrip.test.ts,
+    //     describe "Task 2 — key-ID-aware verification rejects an
+    //     official-ID row not actually signed by the official key" (a real
+    //     registerFromOfficialManifest row fed into the real
+    //     validateReleaseManifest, proving the negative case end-to-end).
     function makeOfficialLocalManifest(
       assets: { name: string; sha256: string; size: number; edition?: string }[],
     ) {
@@ -1365,6 +1385,10 @@ describe("binarySync", () => {
 
       await syncBinaries();
 
+      // This asserts REGISTRATION stamping only (unchanged by Task 2 — see
+      // the NOTE above makeOfficialLocalManifest for where the download-path
+      // exact-binding property this used to be conflated with is actually
+      // proven).
       expect(dbMocks.insertValues).toHaveBeenCalledWith(
         expect.objectContaining({
           signingKeyId: "release-artifact-manifest-ed25519",

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -77,7 +77,13 @@ const manifestSigningMocks = vi.hoisted(() => ({
 
 vi.mock("./manifestSigning", () => manifestSigningMocks);
 
-import { syncBinaries, syncFromGitHub } from "./binarySync";
+vi.mock("./sentry", () => ({ captureException: vi.fn() }));
+
+import {
+  __resetRefusedManifestAssetWarnCache,
+  syncBinaries,
+  syncFromGitHub,
+} from "./binarySync";
 import { requiredPlatformTrustFor } from "./releaseAssetTrust";
 
 function fixturePlatformTrust(name: string): string {
@@ -203,6 +209,9 @@ describe("binarySync", () => {
     delete process.env.BINARY_GITHUB_REPOSITORY;
     delete process.env.GITHUB_REPO;
     vi.clearAllMocks();
+    // Clear the per-(component/assetName) refused-manifest-asset capture
+    // dedup so a prior test's Sentry assertion doesn't suppress this one's.
+    __resetRefusedManifestAssetWarnCache();
   });
 
   afterEach(() => {
@@ -1321,7 +1330,17 @@ describe("binarySync", () => {
     //     registerFromOfficialManifest row fed into the real
     //     validateReleaseManifest, proving the negative case end-to-end).
     function makeOfficialLocalManifest(
-      assets: { name: string; sha256: string; size: number; edition?: string }[],
+      assets: {
+        name: string;
+        sha256: string;
+        size: number;
+        edition?: string;
+        // Override for tests that need a platformTrust label that
+        // deliberately contradicts what the asset name requires (D4, #3836:
+        // the distributability-policy-refused branch). Defaults to the
+        // name-derived value, same as before this field existed.
+        platformTrust?: string;
+      }[],
     ) {
       const { publicKey, privateKey } = generateKeyPairSync("ed25519");
       const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
@@ -1335,7 +1354,7 @@ describe("binarySync", () => {
             name: a.name,
             sha256: a.sha256,
             size: a.size,
-            platformTrust: fixturePlatformTrust(a.name),
+            platformTrust: a.platformTrust ?? fixturePlatformTrust(a.name),
             ...(a.edition ? { edition: a.edition } : {}),
           })),
         }),
@@ -1421,29 +1440,42 @@ describe("binarySync", () => {
       expect(manifestSigningMocks.signManifest).toHaveBeenCalled();
     });
 
-    it("falls back to per-deployment re-signing when the local checksum disagrees with the manifest", async () => {
+    // D4 (#3836): a checksum mismatch between the local file and the
+    // manifest's claim for it used to fall through to registerLocalBinaries
+    // (deploy-key re-sign), which has no distributability gate at all —
+    // silently serving whatever bytes are on disk under a signature that
+    // vouches for a DIFFERENT (manifest-claimed) checksum. That must fail
+    // closed instead: excluded from both the official path and the
+    // per-deployment fallback. See the "no silent policy-bypass fallback"
+    // describe block below for the sibling policy-refused case and the
+    // shared fail-closed assertions.
+    it("checksum mismatch is excluded from BOTH the official path and the local fallback (fail closed), not silently re-signed", async () => {
       setLocalScanEnv();
       const official = makeOfficialLocalManifest([
         {
           name: "breeze-agent-linux-amd64",
-          sha256: "b".repeat(64), // deliberately wrong
+          sha256: "b".repeat(64), // deliberately wrong vs the local file's real checksum
           size: 18,
         },
       ]);
       process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = official.publicKey;
       mockReadFileWithOfficialManifest("0.65.9", official.manifest, official.signature);
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const { captureException } = await import("./sentry");
 
       await syncBinaries();
 
-      expect(dbMocks.insertValues).toHaveBeenCalledWith(
-        expect.objectContaining({ signingKeyId: "deploy-test-aaaaaaaa" }),
-      );
+      // Never registered via the official path, and never falls through to
+      // registerLocalBinaries either.
+      expect(dbMocks.insertValues).not.toHaveBeenCalled();
+      expect(manifestSigningMocks.signManifest).not.toHaveBeenCalled();
       expect(
         errorSpy.mock.calls.some((args) =>
-          String(args[0] ?? "").includes("Checksum mismatch"),
+          String(args[0] ?? "").includes("Checksum mismatch") &&
+          String(args[0] ?? "").includes("breeze-agent-linux-amd64"),
         ),
       ).toBe(true);
+      expect(vi.mocked(captureException)).toHaveBeenCalledTimes(1);
       errorSpy.mockRestore();
     });
 
@@ -1499,6 +1531,138 @@ describe("binarySync", () => {
       expect(dbMocks.insertValues).toHaveBeenCalledWith(
         expect.objectContaining({ signingKeyId: "deploy-test-aaaaaaaa" }),
       );
+    });
+  });
+
+  // D4 (#3836): registerFromOfficialManifest's per-binary catch used to treat
+  // EVERY verifyReleaseArtifactManifestAsset failure as "manifest doesn't
+  // cover this file" and fall through to registerLocalBinaries — which
+  // deploy-key re-signs and registers the binary with NO distributability
+  // gate at all. That is exactly how unsigned darwin binaries (manifest-
+  // labeled release-workflow-produced, refused by assertDistributableReleaseAsset
+  // which requires macos-developer-id-notarization-required for darwin
+  // Mach-Os) shipped to production macOS devices with the trust policy
+  // silently bypassed. The checksum-mismatch sibling case lives in the
+  // "official manifest from local dir" describe block above (it needed the
+  // same helpers); this block covers the distributability-policy-refusal
+  // branch plus propagation to a second component (watchdog).
+  describe("no silent policy-bypass fallback in local binary registration (D4, #3836)", () => {
+    function setLocalScanEnvDarwinAgent() {
+      process.env.BINARY_SOURCE = "local";
+      process.env.AGENT_BINARY_DIR = "/data/binaries/agent";
+      process.env.BINARY_VERSION_FILE = "/fake/version";
+      delete process.env.BREEZE_VERSION;
+      fsMocks.readdir.mockResolvedValue(["breeze-agent-darwin-amd64"] as any);
+      fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 1234 } as any);
+    }
+
+    function setLocalScanEnvLinuxAgent() {
+      process.env.BINARY_SOURCE = "local";
+      process.env.AGENT_BINARY_DIR = "/data/binaries/agent";
+      process.env.BINARY_VERSION_FILE = "/fake/version";
+      delete process.env.BREEZE_VERSION;
+      fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
+      fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 1234 } as any);
+    }
+
+    function makeSignedOfficialManifest(
+      assets: { name: string; sha256: string; size: number; edition?: string; platformTrust?: string }[],
+    ) {
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+      const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+      const rawPublicKey = publicDer.subarray(publicDer.length - 32).toString("base64");
+      const manifest = Buffer.from(
+        JSON.stringify({
+          schemaVersion: 1,
+          repository: "LanternOps/breeze",
+          release: "v1.2.3",
+          assets: assets.map((a) => ({
+            name: a.name,
+            sha256: a.sha256,
+            size: a.size,
+            platformTrust: a.platformTrust ?? fixturePlatformTrust(a.name),
+            ...(a.edition ? { edition: a.edition } : {}),
+          })),
+        }),
+      );
+      const signature = Buffer.from(sign(null, manifest, privateKey).toString("base64"));
+      return { manifest, signature, publicKey: rawPublicKey };
+    }
+
+    function mockReadFileWithManifest(
+      versionFileContent: string,
+      manifest: Buffer,
+      signature: Buffer,
+    ) {
+      fsMocks.readFile.mockImplementation((path: unknown) => {
+        if (typeof path === "string" && path.endsWith("release-artifact-manifest.json.ed25519")) {
+          return Promise.resolve(signature);
+        }
+        if (typeof path === "string" && path.endsWith("release-artifact-manifest.json")) {
+          return Promise.resolve(manifest);
+        }
+        return Promise.resolve(versionFileContent);
+      });
+    }
+
+    it("a policy-refused asset present in the manifest (unsigned darwin) is excluded from BOTH the official path and the local-resign fallback, and reports once via console.error + captureException", async () => {
+      setLocalScanEnvDarwinAgent();
+      const checksum = createHash("sha256").update("local agent bytes").digest("hex");
+      const official = makeSignedOfficialManifest([
+        {
+          name: "breeze-agent-darwin-amd64",
+          sha256: checksum,
+          size: 18, // Buffer.byteLength("local agent bytes")
+          edition: "self-host",
+          // Deliberately wrong: darwin Mach-O binaries require
+          // macos-developer-id-notarization-required. Today's actual hosted
+          // release manifests label these release-workflow-produced (unsigned) —
+          // this fixture reproduces that exact shape.
+          platformTrust: "release-workflow-produced",
+        },
+      ]);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = official.publicKey;
+      mockReadFileWithManifest("0.65.9", official.manifest, official.signature);
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const { captureException } = await import("./sentry");
+
+      await syncBinaries();
+
+      // Never registered via the official path...
+      expect(dbMocks.insertValues).not.toHaveBeenCalled();
+      // ...and never falls through to registerLocalBinaries either — that
+      // path has no distributability gate and would silently serve the
+      // policy-refused binary deploy-signed.
+      expect(manifestSigningMocks.signManifest).not.toHaveBeenCalled();
+      expect(
+        errorSpy.mock.calls.some((args) =>
+          String(args[0] ?? "").includes("breeze-agent-darwin-amd64"),
+        ),
+      ).toBe(true);
+      expect(vi.mocked(captureException)).toHaveBeenCalledTimes(1);
+      errorSpy.mockRestore();
+    });
+
+    it("the absent case is unaffected: an asset the manifest genuinely does not cover still falls back to per-deployment re-signing", async () => {
+      setLocalScanEnvLinuxAgent();
+      const official = makeSignedOfficialManifest([
+        {
+          name: "breeze-agent-windows-amd64.exe", // does not match the scanned linux binary
+          sha256: "a".repeat(64),
+          size: 999,
+        },
+      ]);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = official.publicKey;
+      mockReadFileWithManifest("0.65.9", official.manifest, official.signature);
+      const { captureException } = await import("./sentry");
+
+      await syncBinaries();
+
+      expect(dbMocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ signingKeyId: "deploy-test-aaaaaaaa" }),
+      );
+      expect(manifestSigningMocks.signManifest).toHaveBeenCalled();
+      expect(captureException).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -15,7 +15,7 @@ import {
 import { getBinaryEdition } from "./binaryEdition";
 import {
   isReleaseArtifactManifestVerificationConfigured,
-  ReleaseManifestAssetLookupError,
+  ReleaseManifestAssetAbsentError,
   verifyReleaseArtifactManifestAsset,
   verifyReleaseArtifactManifestIntegrity,
 } from "./releaseArtifactManifest";
@@ -490,21 +490,22 @@ export function __resetRefusedManifestAssetWarnCache(): void {
 // two very different shapes: the asset name isn't in the manifest's `assets`
 // array at all (the legitimate local/BYO case — this component simply isn't
 // covered by the staged official manifest), and the asset name IS present but
-// its entry is malformed (invalid/missing sha256 or size). Only the former is
-// "absent"; the latter is a manifest that affirmatively claims to cover this
-// asset with garbage metadata, which must fail closed exactly like a
-// distributability-policy refusal. selectManifestAsset's not-found message
-// ("...does not include <name>") is the only textual signal that
-// distinguishes the two — there is no separate error class because no other
-// caller in the repo has needed the distinction (agentVersions.ts's
-// validateReleaseManifest treats the whole class as one "asset lookup
-// failed" reason, which is fine for a serve-or-refuse decision but not for
-// this absent-vs-refused fallback decision).
+// its entry is malformed (invalid/missing sha256 or size) or the manifest
+// fails a repository/release identity check. Only the former is "absent";
+// the latter is a manifest that affirmatively claims to cover this asset
+// with garbage or mismatched metadata, which must fail closed exactly like a
+// distributability-policy refusal.
+//
+// This checks the typed ReleaseManifestAssetAbsentError subclass — thrown
+// ONLY at selectManifestAsset's "not found in assets" site
+// (releaseArtifactManifest.ts) — not `.message` text. A substring match on
+// the message was tried first and rejected in review: `.message` is not a
+// contract, so any OTHER lookup-error message coincidentally gaining a
+// matching substring would misclassify a present-but-malformed entry as
+// absent and let it through the ungated fallback — the exact fail-open
+// direction this task closes (D4, #3836, fix round 1).
 function isAssetAbsentFromManifest(err: unknown): boolean {
-  return (
-    err instanceof ReleaseManifestAssetLookupError &&
-    err.message.includes("does not include")
-  );
+  return err instanceof ReleaseManifestAssetAbsentError;
 }
 
 // Reports (console.error + deduped captureException) a manifest asset that

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -15,6 +15,7 @@ import {
 import { getBinaryEdition } from "./binaryEdition";
 import {
   isReleaseArtifactManifestVerificationConfigured,
+  ReleaseManifestAssetLookupError,
   verifyReleaseArtifactManifestAsset,
   verifyReleaseArtifactManifestIntegrity,
 } from "./releaseArtifactManifest";
@@ -25,6 +26,7 @@ import {
   getReleaseSourceRepository,
   isOfficialReleaseSource,
 } from "./releaseSource";
+import { captureException } from "./sentry";
 
 const GH_PLATFORM_MAP: Record<string, string> = {
   linux: "linux",
@@ -470,12 +472,95 @@ async function loadOfficialLocalManifestPair(
   }
 }
 
+// Per-(component, assetName) dedup for the "policy-refused / mismatched
+// manifest asset" report below (D4, #3836). syncBinaries() only runs at boot
+// (index.ts), so in practice this fires at most once per process per asset —
+// but it exists for the same reason warnedMissingPinBuilds
+// (routes/agents/helpers.ts) does: a persistent misconfig (e.g. today's
+// unsigned hosted darwin artifacts, see below) must not flood Sentry on
+// every future call site that resyncs.
+const warnedRefusedManifestAssets = new Set<string>();
+
+/** Test-only: reset the per-asset refusal dedup between cases. */
+export function __resetRefusedManifestAssetWarnCache(): void {
+  warnedRefusedManifestAssets.clear();
+}
+
+// verifyReleaseArtifactManifestAsset's ReleaseManifestAssetLookupError covers
+// two very different shapes: the asset name isn't in the manifest's `assets`
+// array at all (the legitimate local/BYO case — this component simply isn't
+// covered by the staged official manifest), and the asset name IS present but
+// its entry is malformed (invalid/missing sha256 or size). Only the former is
+// "absent"; the latter is a manifest that affirmatively claims to cover this
+// asset with garbage metadata, which must fail closed exactly like a
+// distributability-policy refusal. selectManifestAsset's not-found message
+// ("...does not include <name>") is the only textual signal that
+// distinguishes the two — there is no separate error class because no other
+// caller in the repo has needed the distinction (agentVersions.ts's
+// validateReleaseManifest treats the whole class as one "asset lookup
+// failed" reason, which is fine for a serve-or-refuse decision but not for
+// this absent-vs-refused fallback decision).
+function isAssetAbsentFromManifest(err: unknown): boolean {
+  return (
+    err instanceof ReleaseManifestAssetLookupError &&
+    err.message.includes("does not include")
+  );
+}
+
+// Reports (console.error + deduped captureException) a manifest asset that
+// was PRESENT but refused, or whose local file disagrees with the manifest's
+// claim for it — the two "fail closed" branches of registerFromOfficialManifest
+// below. Never called for the "genuinely absent from the manifest" branch,
+// which is the legitimate local/BYO case and keeps its own (non-Sentry)
+// console.warn.
+function reportRefusedManifestAsset(
+  component: string,
+  assetName: string,
+  err: unknown,
+): void {
+  const reason = err instanceof Error ? err.message : String(err);
+  console.error(
+    `[binarySync] Refusing to register ${component} asset ${assetName} from the official release manifest — fail closed, excluded from the per-deployment fallback too: ${reason}`,
+  );
+  const key = `${component}:${assetName}`;
+  if (warnedRefusedManifestAssets.has(key)) return;
+  warnedRefusedManifestAssets.add(key);
+  captureException(
+    new Error(
+      `[binarySync] Official-manifest asset registration refused (D4, #3836): ${component} asset ${assetName} is present in the manifest but was rejected — ${reason}. Excluded from BOTH the official-manifest path and the per-deployment re-sign fallback (fail closed): registerLocalBinaries has no distributability gate, so falling back would silently serve the very artifact the manifest (or its checksum) refused.`,
+    ),
+  );
+}
+
 // Registers whichever of `binaries` the official manifest actually covers
 // (matched by on-disk filename == manifest asset name), verifying each
 // asset's checksum against the LOCAL file before trusting the manifest's
-// claim for it. Binaries the manifest doesn't cover (or whose local checksum
-// disagrees with it) are left unregistered here — the caller falls back to
-// registerLocalBinaries (deploy-key re-sign) for those.
+// claim for it.
+//
+// Three outcomes per binary:
+//   - genuinely ABSENT from the manifest (no entry for this filename at all)
+//     → left unregistered here; the caller falls back to registerLocalBinaries
+//     (deploy-key re-sign). This is the legitimate local/BYO case: a
+//     self-hoster's staged official manifest simply doesn't claim to cover
+//     this component/asset.
+//   - PRESENT but refused (assertDistributableReleaseAsset's policy checks,
+//     unknown platformTrust/edition vocabulary, or a malformed sha256/size
+//     entry) or PRESENT with a checksum that disagrees with the local file
+//     → FAIL CLOSED: not registered here AND excluded from the
+//     registerLocalBinaries fallback (see excludedFilenames below). A
+//     policy-refused or mismatched artifact must never be served through the
+//     weaker per-deployment-resign path, which has no distributability gate
+//     at all — this is exactly how unsigned darwin binaries (manifest-labeled
+//     release-workflow-produced, refused because darwin Mach-Os require
+//     macos-developer-id-notarization-required) shipped to production macOS
+//     devices with the trust policy silently bypassed (D4, #3836).
+//
+// NOTE: with this fail-closed behavior and TODAY's (unsigned) hosted darwin
+// release artifacts, a fresh local sync registers NO macOS agent rows — every
+// darwin binary hits the "present but refused" branch above. That is the
+// INTENDED outcome, not a bug: macOS serving resumes once D2 (signed darwin
+// artifacts + manifest coverage) ships a manifest that actually labels them
+// macos-developer-id-notarization-required.
 async function registerFromOfficialManifest(args: {
   binaries: BinaryInfo[];
   component: string;
@@ -483,12 +568,16 @@ async function registerFromOfficialManifest(args: {
   manifestBytes: Buffer;
   signatureBytes: Buffer;
   downloadUrlFor: (osParam: string, arch: string) => string;
-}): Promise<{ registeredFilenames: Set<string> }> {
+}): Promise<{ registeredFilenames: Set<string>; excludedFilenames: Set<string> }> {
   const { binaries, component, version, manifestBytes, signatureBytes, downloadUrlFor } = args;
   const autoPromote = getAgentAutoPromote();
   const manifestString = manifestBytes.toString("utf8");
   const signatureString = signatureBytes.toString("utf8").trim();
   const registeredFilenames = new Set<string>();
+  // Present-but-refused or checksum-mismatched assets (D4, #3836) — the
+  // caller must exclude these from the registerLocalBinaries fallback too,
+  // not just skip them here.
+  const excludedFilenames = new Set<string>();
 
   await db.transaction(async (tx) => {
     for (const bin of binaries) {
@@ -500,16 +589,27 @@ async function registerFromOfficialManifest(args: {
           signatureBytes,
         });
       } catch (err) {
-        console.warn(
-          `[binarySync] Official release manifest does not cover ${bin.filename}: ${err instanceof Error ? err.message : err}`,
-        );
+        if (isAssetAbsentFromManifest(err)) {
+          console.warn(
+            `[binarySync] Official release manifest does not cover ${bin.filename}: ${err instanceof Error ? err.message : err}`,
+          );
+          continue;
+        }
+        // Present in the manifest but refused: distributability policy,
+        // unknown platformTrust/edition vocabulary, or a malformed
+        // sha256/size entry. Fail closed — see the function doc comment.
+        reportRefusedManifestAsset(component, bin.filename, err);
+        excludedFilenames.add(bin.filename);
         continue;
       }
 
       if (verified.sha256 !== bin.checksum) {
-        console.error(
-          `[binarySync] Checksum mismatch between the local file and the official release manifest for ${bin.filename} — not registering from the official manifest for this asset`,
+        reportRefusedManifestAsset(
+          component,
+          bin.filename,
+          `Checksum mismatch between the local file (${bin.checksum}) and the official release manifest (${verified.sha256}) for ${bin.filename}`,
         );
+        excludedFilenames.add(bin.filename);
         continue;
       }
 
@@ -571,7 +671,7 @@ async function registerFromOfficialManifest(args: {
     }
   });
 
-  return { registeredFilenames };
+  return { registeredFilenames, excludedFilenames };
 }
 
 /**
@@ -741,6 +841,10 @@ export async function syncBinaries(): Promise<void> {
     const { keyId } = await ensureActiveSigningKey();
 
     let coveredAgentFilenames = new Set<string>();
+    // D4 (#3836): assets present in the official manifest but refused (policy)
+    // or checksum-mismatched must be excluded from the registerLocalBinaries
+    // fallback below too — that path has no distributability gate at all.
+    let excludedAgentFilenames = new Set<string>();
     if (officialManifest) {
       const result = await registerFromOfficialManifest({
         binaries,
@@ -752,6 +856,7 @@ export async function syncBinaries(): Promise<void> {
           `${serverUrl}/api/v1/agents/download/${osParam}/${arch}`,
       });
       coveredAgentFilenames = result.registeredFilenames;
+      excludedAgentFilenames = result.excludedFilenames;
       if (coveredAgentFilenames.size > 0) {
         console.log(
           `[binarySync] Registered ${coveredAgentFilenames.size} agent binaries from the official release manifest (version: ${version})`,
@@ -760,7 +865,7 @@ export async function syncBinaries(): Promise<void> {
     }
 
     const remainingAgentBinaries = binaries.filter(
-      (b) => !coveredAgentFilenames.has(b.filename),
+      (b) => !coveredAgentFilenames.has(b.filename) && !excludedAgentFilenames.has(b.filename),
     );
     if (remainingAgentBinaries.length > 0) {
       await registerLocalBinaries({
@@ -787,6 +892,10 @@ export async function syncBinaries(): Promise<void> {
       // registered — mirrors the GitHub path's per-component try/catch.
       try {
         let coveredWatchdogFilenames = new Set<string>();
+        // D4 (#3836): same exclusion as the agent loop above — a
+        // policy-refused or checksum-mismatched watchdog asset must not fall
+        // through to registerLocalBinaries either.
+        let excludedWatchdogFilenames = new Set<string>();
         if (officialManifest) {
           const result = await registerFromOfficialManifest({
             binaries: watchdogBinaries,
@@ -798,9 +907,12 @@ export async function syncBinaries(): Promise<void> {
               `${serverUrl}/api/v1/agents/download/watchdog/${osParam}/${arch}`,
           });
           coveredWatchdogFilenames = result.registeredFilenames;
+          excludedWatchdogFilenames = result.excludedFilenames;
         }
         const remainingWatchdogBinaries = watchdogBinaries.filter(
-          (b) => !coveredWatchdogFilenames.has(b.filename),
+          (b) =>
+            !coveredWatchdogFilenames.has(b.filename) &&
+            !excludedWatchdogFilenames.has(b.filename),
         );
         if (remainingWatchdogBinaries.length > 0) {
           await registerLocalBinaries({

--- a/apps/api/src/services/releaseArtifactManifest.test.ts
+++ b/apps/api/src/services/releaseArtifactManifest.test.ts
@@ -206,6 +206,66 @@ describe("releaseArtifactManifest", () => {
     );
   });
 
+  // D4 (#3836) fix round 1: binarySync.ts's registerFromOfficialManifest
+  // needs to tell "asset genuinely absent from the manifest" (legitimate
+  // local/BYO fallback case) apart from "asset present but its entry is
+  // wrong" (must fail closed) WITHOUT matching on `.message` text, which is
+  // not a contract. These two tests pin the typed discriminant that makes
+  // that safe: only the true not-found case is ReleaseManifestAssetAbsentError;
+  // every other ReleaseManifestAssetLookupError variant (e.g. a malformed
+  // sha256 on a PRESENT entry) is deliberately NOT that subclass, even
+  // though its message text could say anything.
+  describe("asset lookup error typing (D4, #3836 fix round 1)", () => {
+    it("an asset name absent from the manifest's assets array throws ReleaseManifestAssetAbsentError", async () => {
+      const { ReleaseManifestAssetAbsentError } = await import("./releaseArtifactManifest");
+      const asset = Buffer.from("trusted-agent-binary");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent-linux-amd64",
+        assetBuffer: asset,
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      await expect(
+        verifyReleaseArtifactManifestAsset({
+          assetName: "breeze-agent-windows-amd64.exe", // not in the manifest
+          manifestBytes: signed.manifest,
+          signatureBytes: signed.signature,
+        }),
+      ).rejects.toThrow(ReleaseManifestAssetAbsentError);
+    });
+
+    it("an asset PRESENT with a malformed sha256 throws the base ReleaseManifestAssetLookupError, NOT the absent subclass", async () => {
+      const { ReleaseManifestAssetAbsentError, ReleaseManifestAssetLookupError } =
+        await import("./releaseArtifactManifest");
+      const asset = Buffer.from("trusted-agent-binary");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent-linux-amd64",
+        assetBuffer: asset,
+        assetOverrides: { sha256: "not-a-valid-sha256" },
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      expect.assertions(3);
+      try {
+        await verifyReleaseArtifactManifestAsset({
+          assetName: "breeze-agent-linux-amd64", // present, just malformed
+          manifestBytes: signed.manifest,
+          signatureBytes: signed.signature,
+        });
+      } catch (err) {
+        expect(err).toBeInstanceOf(ReleaseManifestAssetLookupError);
+        // This is the tripwire: even though the base-class instance's
+        // message ("...has invalid sha256 for...") does not currently
+        // contain "does not include", a caller distinguishing by message
+        // text alone would be one coincidental wording change away from
+        // misclassifying this as absent. instanceof must reject it
+        // regardless of message content.
+        expect(err).not.toBeInstanceOf(ReleaseManifestAssetAbsentError);
+        expect((err as Error).message).toMatch(/invalid sha256/);
+      }
+    });
+  });
+
   it("skips GitHub manifest fetches when no API trust root is configured", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/api/src/services/releaseArtifactManifest.test.ts
+++ b/apps/api/src/services/releaseArtifactManifest.test.ts
@@ -5,6 +5,7 @@ import {
   verifyReleaseArtifactManifestAsset,
   verifyReleaseArtifactBuffer,
   verifyReleaseArtifactManifestIntegrity,
+  verifyManifestSignatureAgainstOfficialKeysOnly,
 } from "./releaseArtifactManifest";
 import { requiredPlatformTrustFor } from "./releaseAssetTrust";
 
@@ -624,6 +625,70 @@ describe("releaseArtifactManifest", () => {
       expect(() =>
         verifyReleaseArtifactManifestIntegrity(signed.manifest, signed.signature),
       ).toThrow(/public key is not configured/);
+    });
+  });
+
+  // Task 2 (#3836): agentVersions.ts's legacy (non schema-v1) manifest
+  // verification dispatches an official-signingKeyId row here instead of
+  // the whole-set (env + DB deployment keys) check it used before. This
+  // function is the "official keys ONLY, no DB access" primitive that
+  // makes that narrowing possible.
+  describe("verifyManifestSignatureAgainstOfficialKeysOnly (Task 2, #3836)", () => {
+    it("returns true for a signature that verifies under a configured official key", () => {
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+      const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+      const rawPublicKey = publicDer.subarray(publicDer.length - 32).toString("base64");
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = rawPublicKey;
+      const manifest = JSON.stringify({ foo: "bar" });
+      const signature = sign(null, Buffer.from(manifest, "utf8"), privateKey).toString("base64");
+
+      expect(verifyManifestSignatureAgainstOfficialKeysOnly(manifest, signature)).toBe(true);
+    });
+
+    it("returns false for a signature made by a DIFFERENT key, even one otherwise present in the process (not falling back to any other trust store)", () => {
+      const official = generateKeyPairSync("ed25519");
+      const officialDer = official.publicKey.export({ format: "der", type: "spki" }) as Buffer;
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = officialDer
+        .subarray(officialDer.length - 32)
+        .toString("base64");
+
+      const other = generateKeyPairSync("ed25519");
+      const manifest = JSON.stringify({ foo: "bar" });
+      const signature = sign(null, Buffer.from(manifest, "utf8"), other.privateKey).toString(
+        "base64",
+      );
+
+      expect(verifyManifestSignatureAgainstOfficialKeysOnly(manifest, signature)).toBe(false);
+    });
+
+    it("returns false (no soft-pass) when no official key is configured", () => {
+      delete process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+      delete process.env.BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+
+      expect(
+        verifyManifestSignatureAgainstOfficialKeysOnly("{}", "A".repeat(88)),
+      ).toBe(false);
+    });
+
+    it("returns false (never throws) when the configured official key value is malformed", () => {
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = "not-a-valid-key===";
+
+      expect(() =>
+        verifyManifestSignatureAgainstOfficialKeysOnly("{}", "A".repeat(88)),
+      ).not.toThrow();
+      expect(verifyManifestSignatureAgainstOfficialKeysOnly("{}", "A".repeat(88))).toBe(false);
+    });
+
+    it("returns false for a malformed (wrong-length) signature", () => {
+      const { publicKey } = generateKeyPairSync("ed25519");
+      const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = publicDer
+        .subarray(publicDer.length - 32)
+        .toString("base64");
+
+      expect(
+        verifyManifestSignatureAgainstOfficialKeysOnly("{}", "too-short"),
+      ).toBe(false);
     });
   });
 });

--- a/apps/api/src/services/releaseArtifactManifest.ts
+++ b/apps/api/src/services/releaseArtifactManifest.ts
@@ -62,6 +62,27 @@ export class ReleaseManifestAssetLookupError extends Error {
   }
 }
 
+// The one ReleaseManifestAssetLookupError variant that means the asset name
+// simply isn't in the manifest's `assets` array at all — as opposed to being
+// present with malformed metadata (invalid sha256/size) or a repository/
+// release identity mismatch, both of which are still ReleaseManifestAssetLookupError
+// but must NOT be treated as "absent" by a caller like binarySync.ts's
+// registerFromOfficialManifest, which uses "absent" to decide whether a
+// local/BYO fallback is legitimate (D4, #3836). A caller distinguishing
+// "absent" from "present but wrong" needs a typed discriminant here rather
+// than matching on `.message` text, which is not a contract and could
+// coincidentally collide with wording used by an unrelated lookup failure —
+// silently flipping a fail-closed decision to fail-open (review finding,
+// fix round 1). Thrown ONLY at the single "not found in assets" site in
+// selectManifestAsset below; every other ReleaseManifestAssetLookupError
+// throw in this file stays the base class.
+export class ReleaseManifestAssetAbsentError extends ReleaseManifestAssetLookupError {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReleaseManifestAssetAbsentError";
+  }
+}
+
 // The manifest's signature verified and the asset entry was found, but
 // policy refuses to serve it: assertDistributableReleaseAsset's intendedUse/
 // signing-input/platformTrust/edition checks, or the caller's own
@@ -426,7 +447,7 @@ function selectManifestAsset(args: {
   const assets = manifest.assets as ReleaseArtifactManifestAsset[];
   const entry = assets.find((candidate) => candidate.name === args.assetName);
   if (!entry) {
-    throw new ReleaseManifestAssetLookupError(
+    throw new ReleaseManifestAssetAbsentError(
       `Release artifact manifest does not include ${args.assetName}`,
     );
   }

--- a/apps/api/src/services/releaseArtifactManifest.ts
+++ b/apps/api/src/services/releaseArtifactManifest.ts
@@ -173,6 +173,64 @@ export function isReleaseArtifactManifestVerificationConfigured(): boolean {
   return getConfiguredPublicKeyStrings().length > 0;
 }
 
+// Task 2 (#3836): agentVersions.ts's legacy (non schema-v1) manifest
+// verification used to check a row's signature against the UNION of env
+// keys AND every DB-provisioned per-deployment key (manifest_signing_keys),
+// regardless of what the row's signingKeyId actually claimed. That let a row
+// stamped with the official key ID ("release-artifact-manifest-ed25519")
+// pass the server by virtue of an otherwise-trusted deployment key's
+// signature — even though a real agent's exact-ID lookup (agent/internal/
+// updater/updater.go verifyManifestSignature) binds that ID to ONLY its
+// embedded official key and would reject it (P1-UPD-001-style confusion,
+// just moved from "any trusted key" to "any trusted key regardless of the
+// claimed ID"). This function is what closes that gap for the legacy
+// manifest shape: it answers "does this verify against an official key",
+// using exactly the same trust root (getConfiguredPublicKeys) the schema-v1
+// path (verifyManifestSignature above) already uses, with no DB access.
+//
+// Returns false (never throws) on any failure — no configured official
+// keys, malformed signature, or a signature that doesn't verify against any
+// of them. Deliberately no soft-pass-when-empty (unlike agentVersions.ts's
+// verifyEd25519ManifestSignature default): an explicit claim of official
+// provenance must be provable, not assumed — this is narrower than the
+// default because it is only reached once a row has ALREADY claimed to be
+// officially signed.
+export function verifyManifestSignatureAgainstOfficialKeysOnly(
+  manifest: string,
+  signature: string,
+): boolean {
+  let publicKeys: KeyObject[];
+  try {
+    // getConfiguredPublicKeys throws if a configured key string is
+    // malformed. Unlike the schema-v1 path (verifyManifestSignature above),
+    // this function's caller (agentVersions.ts's legacy-shape dispatch) has
+    // no surrounding try/catch of its own — fail closed here rather than let
+    // a misconfigured env var surface as an uncaught exception on the
+    // download route.
+    publicKeys = getConfiguredPublicKeys();
+  } catch {
+    return false;
+  }
+  if (publicKeys.length === 0) return false;
+
+  let signatureBytes: Buffer;
+  try {
+    signatureBytes = Buffer.from(signature, "base64");
+  } catch {
+    return false;
+  }
+  if (signatureBytes.length !== 64) return false;
+
+  const manifestBytes = Buffer.from(manifest, "utf8");
+  return publicKeys.some((publicKey) => {
+    try {
+      return verifySignature(null, manifestBytes, publicKey, signatureBytes);
+    } catch {
+      return false;
+    }
+  });
+}
+
 function releaseArtifactManifestVerificationRequired(): boolean {
   const mode =
     process.env.RELEASE_ARTIFACT_MANIFEST_VERIFICATION?.trim().toLowerCase();

--- a/apps/api/src/services/releaseArtifactManifest.ts
+++ b/apps/api/src/services/releaseArtifactManifest.ts
@@ -31,6 +31,48 @@ function warnIfUnsignedSelfHostAsset(
   );
 }
 
+// Typed failures for verifyReleaseArtifactManifestAsset (D3, issue #3836).
+// Before this, EVERY throw from the combined verify-then-select call
+// collapsed into a single "invalid signature" reason at the caller
+// (agentVersions.ts validateReleaseManifest), which was both wrong (an
+// asset-not-found or a distributability refusal is not a signature failure)
+// and unhelpful for operators debugging a 409. Subclassing preserves every
+// existing `.message` (nothing here changes wording, only exposes an
+// `instanceof`-checkable failure category) and, critically, preserves
+// ordering: verifyReleaseArtifactManifestAsset always calls
+// verifyManifestSignature() FIRST, before parseManifest/selectManifestAsset
+// can throw — so a caller distinguishing by class still only learns "asset
+// lookup failed" or "not distributable" AFTER the signature has actually
+// verified. That ordering is what #641 requires: metadata-probing reasons
+// must never be reachable with a forged signature.
+export class ReleaseManifestSignatureError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReleaseManifestSignatureError";
+  }
+}
+
+// The manifest's signature verified, but the requested asset couldn't be
+// resolved from it: not present in `assets`, or present with a malformed
+// sha256/size, or (defense in depth) a repository/release identity mismatch.
+export class ReleaseManifestAssetLookupError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReleaseManifestAssetLookupError";
+  }
+}
+
+// The manifest's signature verified and the asset entry was found, but
+// policy refuses to serve it: assertDistributableReleaseAsset's intendedUse/
+// signing-input/platformTrust/edition checks, or the caller's own
+// expectedPlatformTrust mismatch.
+export class ReleaseAssetNotDistributableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReleaseAssetNotDistributableError";
+  }
+}
+
 const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
 const MAX_MANIFEST_BYTES = 1024 * 1024;
 const PUBLIC_KEY_ENV_NAMES = [
@@ -144,7 +186,7 @@ function parseSignature(signatureBytes: Buffer): Buffer {
   const trimmed = signatureBytes.toString("utf8").trim();
   const signature = Buffer.from(trimmed, "base64");
   if (signature.length !== 64) {
-    throw new Error(
+    throw new ReleaseManifestSignatureError(
       "Release artifact manifest signature must be a base64 Ed25519 signature",
     );
   }
@@ -157,7 +199,9 @@ function verifyManifestSignature(
 ): void {
   const publicKeys = getConfiguredPublicKeys();
   if (publicKeys.length === 0) {
-    throw new Error("Release artifact manifest public key is not configured");
+    throw new ReleaseManifestSignatureError(
+      "Release artifact manifest public key is not configured",
+    );
   }
 
   const signature = parseSignature(signatureBytes);
@@ -170,10 +214,17 @@ function verifyManifestSignature(
   });
 
   if (!trusted) {
-    throw new Error("Release artifact manifest signature verification failed");
+    throw new ReleaseManifestSignatureError(
+      "Release artifact manifest signature verification failed",
+    );
   }
 }
 
+// Runs AFTER verifyManifestSignature in every caller (verifyReleaseArtifactBuffer,
+// verifyReleaseArtifactManifestAsset), so a malformed manifest here can only be
+// reached with an already-verified signature — these are lookup-shape failures
+// (the referenced asset can't be resolved from an unparseable/mis-shaped
+// manifest), not signature failures.
 function parseManifest(manifestBytes: Buffer): ReleaseArtifactManifest {
   let parsed: ReleaseArtifactManifest;
   try {
@@ -181,7 +232,9 @@ function parseManifest(manifestBytes: Buffer): ReleaseArtifactManifest {
       manifestBytes.toString("utf8"),
     ) as ReleaseArtifactManifest;
   } catch {
-    throw new Error("Release artifact manifest is not valid JSON");
+    throw new ReleaseManifestAssetLookupError(
+      "Release artifact manifest is not valid JSON",
+    );
   }
 
   if (
@@ -190,7 +243,9 @@ function parseManifest(manifestBytes: Buffer): ReleaseArtifactManifest {
     typeof parsed.release !== "string" ||
     !Array.isArray(parsed.assets)
   ) {
-    throw new Error("Release artifact manifest has an invalid schema");
+    throw new ReleaseManifestAssetLookupError(
+      "Release artifact manifest has an invalid schema",
+    );
   }
 
   return parsed;
@@ -202,7 +257,7 @@ function assertStringEqual(
   label: string,
 ): void {
   if (actual !== expected) {
-    throw new Error(
+    throw new ReleaseManifestAssetLookupError(
       `Release artifact manifest ${label} mismatch: expected ${expected}, got ${String(actual)}`,
     );
   }
@@ -301,7 +356,7 @@ function selectManifestAsset(args: {
       typeof manifest.repository !== "string" ||
       manifest.repository.toLowerCase() !== args.expectedRepository.toLowerCase()
     ) {
-      throw new Error(
+      throw new ReleaseManifestAssetLookupError(
         `Release artifact manifest repository mismatch: expected ${args.expectedRepository}, got ${String(manifest.repository)}`,
       );
     }
@@ -313,7 +368,7 @@ function selectManifestAsset(args: {
   const assets = manifest.assets as ReleaseArtifactManifestAsset[];
   const entry = assets.find((candidate) => candidate.name === args.assetName);
   if (!entry) {
-    throw new Error(
+    throw new ReleaseManifestAssetLookupError(
       `Release artifact manifest does not include ${args.assetName}`,
     );
   }
@@ -321,7 +376,7 @@ function selectManifestAsset(args: {
     typeof entry.sha256 !== "string" ||
     !/^[a-f0-9]{64}$/.test(entry.sha256)
   ) {
-    throw new Error(
+    throw new ReleaseManifestAssetLookupError(
       `Release artifact manifest has invalid sha256 for ${args.assetName}`,
     );
   }
@@ -330,7 +385,7 @@ function selectManifestAsset(args: {
     !Number.isSafeInteger(entry.size) ||
     entry.size < 0
   ) {
-    throw new Error(
+    throw new ReleaseManifestAssetLookupError(
       `Release artifact manifest has invalid size for ${args.assetName}`,
     );
   }
@@ -338,12 +393,18 @@ function selectManifestAsset(args: {
   // github sync registration, installer/support asset pre-flight, and recovery
   // media all funnel through here. expectedPlatformTrust (below) remains as a
   // caller-supplied stricter expectation on top of this baseline.
-  assertDistributableReleaseAsset({
-    assetName: args.assetName,
-    platformTrust: typeof entry.platformTrust === 'string' ? entry.platformTrust : null,
-    intendedUse: readIntendedUse(entry, args.assetName),
-    edition: typeof entry.edition === 'string' ? entry.edition : null,
-  });
+  try {
+    assertDistributableReleaseAsset({
+      assetName: args.assetName,
+      platformTrust: typeof entry.platformTrust === 'string' ? entry.platformTrust : null,
+      intendedUse: readIntendedUse(entry, args.assetName),
+      edition: typeof entry.edition === 'string' ? entry.edition : null,
+    });
+  } catch (err) {
+    throw new ReleaseAssetNotDistributableError(
+      err instanceof Error ? err.message : String(err),
+    );
+  }
   warnIfUnsignedSelfHostAsset(
     args.assetName,
     typeof entry.platformTrust === 'string' ? entry.platformTrust : null,
@@ -353,7 +414,7 @@ function selectManifestAsset(args: {
     args.expectedPlatformTrust &&
     entry.platformTrust !== args.expectedPlatformTrust
   ) {
-    throw new Error(
+    throw new ReleaseAssetNotDistributableError(
       `Release artifact manifest platform trust mismatch for ${args.assetName}: expected ${args.expectedPlatformTrust}, got ${String(entry.platformTrust)}`,
     );
   }


### PR DESCRIPTION
Part of #3836 (does NOT close it — the hosted-lane darwin signing PR and the fleet promote remain).

## What this fixes

**The fleet-blocking 409** (`invalid_release_manifest_signature` on every hosted Windows/Linux agent download) was not a trust failure: local-mode registration stores server-relative download URLs whose basename is the *architecture*, and schema-v1 download validation derived the manifest asset name from that basename — so it looked up an asset literally named `amd64`, threw, and the catch collapsed everything into the signature reason. Corrected diagnosis: https://github.com/LanternOps/breeze/issues/3836#issuecomment-5383783112

## Changes

1. **Canonical asset-name resolution (D1)** — `canonicalReleaseAssetName(component, platform, arch)` resolves schema-v1 asset names for known components; URL basename remains the fallback (and the `helper` component deliberately has no canonical name — its real rows are `breeze-helper-macos.dmg`-shaped, pinned by a new GitHub-mode roundtrip test).
2. **409 reason split (D3)** — typed errors distinguish `invalid_release_manifest_signature` (Ed25519 failure only) from `release_manifest_asset_lookup_failed` and `release_asset_not_distributable`; underlying errors are logged server-side only. #641 anti-probing preserved: specific reasons only after a verified signature.
3. **Key-ID-aware verification (Task 2)** — server now mirrors the agent's exact-ID semantics (`updater.go:769-801`): official key ID ⇒ official env keys only; `deploy-*` ⇒ exactly that `manifest_signing_keys` row; legacy no-ID rows unchanged. The tests that encoded the old confusion (arbitrary trusted key + official ID stamp) are rewritten as exact-binding assertions, both directions.
4. **Fail-closed local registration (D4)** — a manifest-covered asset that is *refused* (distributability policy, checksum/size mismatch) is now excluded from the ungated `registerLocalBinaries` fallback instead of silently served deploy-signed (this is how unsigned darwin binaries shipped and destroyed macOS code signatures — see the issue's canary evidence). Genuinely-absent assets keep the legit local/BYO fallback, discriminated by a typed `ReleaseManifestAssetAbsentError`, with an anti-message-matching tripwire test.

## Verification

- TDD throughout: the register→validate roundtrip regression test fails on main (reproduces the 409) and passes here; RED/GREEN captured per task.
- 193/193 across the four affected suites at HEAD; eslint clean.
- Whole-branch final review (row-shape enumeration over every producible row): no legitimately-produced row shape fails that previously succeeded; the only newly-failing shapes are forged/confused rows the agent's exact-ID verification already rejected.

## Known follow-ups (deliberately not in this PR)

- `backup` component never consults the official manifest in local mode (pre-existing) — same hazard class D4 closes; needs its own pass.
- `download.ts` `/pkg` github-redirect branch has no edition-aware rejection (defense-in-depth vs the boot validator).
- Tighten the server's unrecognized-key-ID branch to fail closed once `require_manifest_signing_key_id` is fleet-wide.
- Hosted-lane darwin Developer-ID signing + `.pkg` manifest coverage: separate PR in `breeze-hosted-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
