### PR TITLE
feat(quotes): W04 — retired public link dies at every token route

### DIFF
--- a/apps/api/src/routes/portal/quotes.test.ts
+++ b/apps/api/src/routes/portal/quotes.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 // DB mock: select().from().where().limit()/orderBy() resolves to the next queued
 // row set, consumed FIFO in call order. Mirrors the pattern in
 // routes/portal/invoices.test.ts and services/invoiceCheckout.test.ts.
-const { dbResults } = vi.hoisted(() => ({ dbResults: [] as unknown[][] }));
+const { dbResults, whereCalls } = vi.hoisted(() => ({ dbResults: [] as unknown[][], whereCalls: [] as unknown[] }));
 vi.mock('../../db', () => {
   const makeChain = () => {
     const chain: Record<string, unknown> = {};
-    for (const m of ['select', 'from', 'where', 'orderBy', 'limit']) chain[m] = vi.fn(() => chain);
+    for (const m of ['select', 'from', 'orderBy', 'limit']) chain[m] = vi.fn(() => chain);
+    chain.where = vi.fn((predicate: unknown) => { whereCalls.push(predicate); return chain; });
     (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
       const rows = dbResults.shift() ?? [];
       return Promise.resolve(rows).then(resolve);
@@ -63,6 +66,7 @@ import { PdfMergeError } from '../../services/pdfMerge';
 
 const ORG_ID = '22222222-2222-2222-2222-222222222222';
 const QUOTE_ID = '11111111-1111-1111-1111-111111111111';
+const SUCCESSOR_ID = '99999999-9999-9999-9999-999999999999';
 const PARTNER_ID = '33333333-3333-3333-3333-333333333333';
 const TEMPLATE_ID = '44444444-4444-4444-4444-444444444444';
 const VERSION_ID = '55555555-5555-5555-5555-555555555555';
@@ -85,6 +89,64 @@ describe('portal quotes GET /quotes/:id', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     dbResults.length = 0;
+    whereCalls.length = 0;
+  });
+
+  /** Compile a captured predicate to SQL text + params, so assertions see the
+   *  OPERATORS (and/or, =/<>) and not merely a bag of bound values. */
+  const compilePredicate = (node: unknown) => {
+    const q = new PgDialect().sqlToQuery(node as SQL);
+    return { sql: q.sql, params: q.params as unknown[] };
+  };
+
+  /** Queue every read the detail handler issues, up to the successor lookup. */
+  const queueDetailReads = (over: Record<string, unknown> = {}) => {
+    dbResults.push([{
+      id: QUOTE_ID, orgId: ORG_ID, partnerId: PARTNER_ID, status: 'sent',
+      quoteNumber: 'Q-1', currencyCode: 'USD', taxRate: null,
+      depositType: 'none', depositPercent: null, ...over,
+    }]); // quote SELECT
+    dbResults.push([]); // quoteBlocks
+    dbResults.push([]); // quoteLines
+    dbResults.push([]); // markQuoteViewed's own quotes SELECT
+    dbResults.push([{ name: 'Lantern IT' }]); // partners
+    dbResults.push([]); // portalBranding
+  };
+
+  it('exposes the sent successor as supersededByQuoteId so the portal can link the replacement', async () => {
+    queueDetailReads({ status: 'superseded' });
+    dbResults.push([{ id: SUCCESSOR_ID }]); // successor SELECT
+
+    const res = await app().request(`/quotes/${QUOTE_ID}`, { method: 'GET' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.quote.supersededByQuoteId).toBe(SUCCESSOR_ID);
+  });
+
+  it('reports no successor when the lookup finds none', async () => {
+    queueDetailReads();
+    dbResults.push([]); // successor SELECT — nothing
+
+    const res = await app().request(`/quotes/${QUOTE_ID}`, { method: 'GET' });
+    expect((await res.json()).data.quote.supersededByQuoteId).toBeNull();
+  });
+
+  it('never reveals a DRAFT successor — a customer must not learn a revision is being prepared', async () => {
+    queueDetailReads();
+    dbResults.push([]); // successor SELECT
+
+    await app().request(`/quotes/${QUOTE_ID}`, { method: 'GET' });
+
+    // The privacy guard lives in the predicate, and the mock would happily hand
+    // back a draft row, so assert the SQL itself. Exact string: dropping the
+    // status filter, or flipping `<>` to `=`, or `and` to `or`, must all fail.
+    const successorPredicate = whereCalls
+      .map(compilePredicate)
+      .find((p) => p.sql.includes('"revision_of_quote_id"'));
+    expect(successorPredicate).toBeDefined();
+    expect(successorPredicate!.sql).toBe(
+      '("quotes"."revision_of_quote_id" = $1 and "quotes"."status" <> $2)',
+    );
+    expect(successorPredicate!.params).toEqual([QUOTE_ID, 'draft']);
   });
 
   it('sanitizes a legacy dirty rich_text block (script tag) before it leaves the API', async () => {

--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -81,7 +81,11 @@ quoteRoutes.get('/quotes/:id', zValidator('param', idParam), async (c) => {
     const serializedLines = attachCustomerLineImages(lines, (lineId) => `/portal/quotes/${id}/line-image/${lineId}`);
     const theme = resolveThemeId(presentationSnap?.theme ?? partner?.documentTheme);
     const pageSize = resolvePageSize(presentationSnap?.pageSize ?? partner?.documentPageSize);
-    return c.json({ data: { quote: { ...quote, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal, depositDueTotal: totals.depositDueTotal, categoryBreakdown: totals.categoryBreakdown }, blocks, lines: serializedLines, branding: {
+    // Draft successors stay private until sent; customers must not learn that a
+    // revision is still being prepared for them.
+    const [successor] = await db.select({ id: quotes.id }).from(quotes)
+      .where(and(eq(quotes.revisionOfQuoteId, quote.id), ne(quotes.status, 'draft'))).limit(1);
+    return c.json({ data: { quote: { ...quote, supersededByQuoteId: successor?.id ?? null, dueOnAcceptanceTotal: totals.dueOnAcceptanceTotal, depositDueTotal: totals.depositDueTotal, categoryBreakdown: totals.categoryBreakdown }, blocks, lines: serializedLines, branding: {
       partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
       supportEmail: brand?.supportEmail ?? null, supportPhone: brand?.supportPhone ?? null,
       theme, pageSize,

--- a/apps/api/src/routes/quotesPublic.superseded.test.ts
+++ b/apps/api/src/routes/quotesPublic.superseded.test.ts
@@ -1,0 +1,413 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// DB mock: select().from().where().limit()/orderBy() resolves to the next queued
+// row set, consumed FIFO in call order. Keep each test's queue aligned with the
+// literal query order in quotesPublic.ts.
+const { dbResults } = vi.hoisted(() => ({ dbResults: [] as unknown[][] }));
+vi.mock('../db', () => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {};
+    for (const m of ['select', 'from', 'where', 'orderBy', 'limit', 'update', 'set', 'returning', 'for']) {
+      chain[m] = vi.fn(() => chain);
+    }
+    (chain as { then: unknown }).then = (resolve: (value: unknown) => unknown) => {
+      const rows = dbResults.shift() ?? [];
+      return Promise.resolve(rows).then(resolve);
+    };
+    return chain;
+  };
+  return {
+    db: makeChain(),
+    runOutsideDbContext: <T>(fn: () => T): T => fn(),
+    withSystemDbAccessContext: <T>(fn: () => Promise<T>): Promise<T> => fn(),
+  };
+});
+
+vi.mock('../services/quoteAcceptToken', () => ({
+  verifyQuoteAcceptToken: vi.fn(),
+  isQuoteAcceptJtiRevoked: vi.fn(),
+  revokeQuoteAcceptJti: vi.fn(),
+}));
+vi.mock('../services/quoteLifecycle', () => ({ markQuoteViewed: vi.fn() }));
+vi.mock('../services/quoteOutcomeNotify', () => ({
+  notifyQuoteOutcome: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { db } from '../db';
+import {
+  isQuoteAcceptJtiRevoked,
+  revokeQuoteAcceptJti,
+  verifyQuoteAcceptToken,
+} from '../services/quoteAcceptToken';
+import { markQuoteViewed } from '../services/quoteLifecycle';
+import { quotesPublicRoutes } from './quotesPublic';
+
+const QUOTE_ID = '11111111-1111-1111-1111-111111111111';
+const ORG_ID = '22222222-2222-2222-2222-222222222222';
+const PARTNER_ID = '33333333-3333-3333-3333-333333333333';
+const IMAGE_ID = '44444444-4444-4444-4444-444444444444';
+const LINE_ID = '55555555-5555-5555-5555-555555555555';
+const BLOCK_ID = '66666666-6666-6666-6666-666666666666';
+const TEMPLATE_ID = '77777777-7777-7777-7777-777777777777';
+const VERSION_ID = '88888888-8888-8888-8888-888888888888';
+const TOKEN = 'a-valid-looking-token-1234567890';
+const REVOKED_AT = new Date('2026-08-23T12:00:00.000Z');
+
+function app() {
+  const instance = new Hono();
+  instance.route('/quotes/public', quotesPublicRoutes);
+  return instance;
+}
+
+function quoteRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: QUOTE_ID,
+    orgId: ORG_ID,
+    partnerId: PARTNER_ID,
+    status: 'sent',
+    publicLinkRevokedAt: null,
+    revisionOfQuoteId: null,
+    revisionNumber: 1,
+    quoteNumber: 'Q-2026-0001',
+    title: 'Managed Services',
+    currencyCode: 'USD',
+    taxRate: null,
+    expiryDate: null,
+    depositType: 'none',
+    depositPercent: null,
+    presentationSnapshot: null,
+    documentLocale: null,
+    ...overrides,
+  };
+}
+
+const partnerRow = {
+  name: 'Acme MSP',
+  documentTheme: null,
+  documentPageSize: null,
+  settings: {},
+};
+
+const imageRow = {
+  data: Buffer.from('PNGDATA'),
+  mime: 'image/png',
+  byteSize: 7,
+};
+
+const contractBlock = {
+  id: BLOCK_ID,
+  quoteId: QUOTE_ID,
+  orgId: ORG_ID,
+  blockType: 'contract',
+  content: {
+    templateId: TEMPLATE_ID,
+    templateVersionId: VERSION_ID,
+    variableValues: {},
+  },
+  sortOrder: 0,
+};
+
+const contractVersion = {
+  id: VERSION_ID,
+  templateId: TEMPLATE_ID,
+  orgId: null,
+  partnerId: PARTNER_ID,
+  versionNumber: 1,
+  status: 'published',
+  sourceType: 'uploaded',
+  bodyHtml: null,
+  fileData: Buffer.from('%PDF-1.4'),
+  mime: 'application/pdf',
+  byteSize: 8,
+  sha256: 'sha',
+  declaredVariables: [],
+  publishedAt: new Date('2026-07-01T00:00:00.000Z'),
+  createdBy: 'user-1',
+  createdAt: new Date('2026-07-01T00:00:00.000Z'),
+};
+
+const contractTemplate = {
+  id: TEMPLATE_ID,
+  orgId: null,
+  partnerId: PARTNER_ID,
+  name: 'MSA',
+  description: null,
+  status: 'active',
+  createdBy: 'user-1',
+  createdAt: new Date('2026-07-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+};
+
+function resetTokenMocks() {
+  (verifyQuoteAcceptToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+    quoteId: QUOTE_ID,
+    orgId: ORG_ID,
+    partnerId: PARTNER_ID,
+    jti: 'jti-1',
+  });
+  (isQuoteAcceptJtiRevoked as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+  (revokeQuoteAcceptJti as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  (markQuoteViewed as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+}
+
+function collectKeys(value: unknown): string[] {
+  if (Array.isArray(value)) return value.flatMap(collectKeys);
+  if (!value || typeof value !== 'object') return [];
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, nested]) => [key, ...collectKeys(nested)]);
+}
+
+async function expectSupersededTombstone(response: Response) {
+  expect(response.status).toBe(410);
+  const body = await response.json();
+  expect(body).toMatchObject({
+    code: 'QUOTE_SUPERSEDED',
+    data: { branding: { partnerName: 'Acme MSP' } },
+  });
+
+  expect(body.data).not.toHaveProperty('blocks');
+  expect(body.data).not.toHaveProperty('lines');
+  expect(body.data).not.toHaveProperty('quote');
+  expect(body.data).not.toHaveProperty('totals');
+  expect(body.data).not.toHaveProperty('subtotal');
+  expect(body.data).not.toHaveProperty('total');
+  expect(body.data).not.toHaveProperty('dueOnAcceptanceTotal');
+
+  const exposedRevisionIdentifiers = collectKeys(body).filter((key) =>
+    /(?:successor|revision|replacement|supersededBy).*(?:id|token)|(?:id|token).*(?:successor|revision|replacement|supersededBy)/i.test(key),
+  );
+  expect(exposedRevisionIdentifiers).toEqual([]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbResults.length = 0;
+  resetTokenMocks();
+});
+
+describe('quotesPublic retired-link tombstone', () => {
+  it('GET /:token returns a branded, content-free 410 for a superseded quote', async () => {
+    dbResults.push([quoteRow({ status: 'superseded' })]);
+    dbResults.push([{ name: 'Acme MSP' }]);
+
+    const response = await app().request(`/quotes/public/${TOKEN}`);
+
+    await expectSupersededTombstone(response);
+  });
+
+  it('GET /:token returns the same branded, content-free 410 when only publicLinkRevokedAt is set', async () => {
+    dbResults.push([quoteRow({ status: 'sent', publicLinkRevokedAt: REVOKED_AT })]);
+    dbResults.push([{ name: 'Acme MSP' }]);
+
+    const response = await app().request(`/quotes/public/${TOKEN}`);
+
+    await expectSupersededTombstone(response);
+  });
+
+  it('GET /:token still returns 200 for a live sent quote', async () => {
+    dbResults.push([quoteRow({ status: 'sent', publicLinkRevokedAt: null })]);
+    dbResults.push([]); // quoteBlocks SELECT
+    dbResults.push([]); // quoteLines SELECT
+    dbResults.push([partnerRow]); // partners SELECT
+    dbResults.push([]); // portalBranding SELECT
+
+    const response = await app().request(`/quotes/public/${TOKEN}`);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.quote.id).toBe(QUOTE_ID);
+    expect(body.data.branding.partnerName).toBe('Acme MSP');
+  });
+});
+
+type AssetCase = {
+  name: string;
+  path: string;
+  error: string;
+  queuedReads: (quote: Record<string, unknown>) => unknown[][];
+};
+
+const assetCases: AssetCase[] = [
+  {
+    name: 'GET /:token/images/:imageId',
+    path: `/quotes/public/${TOKEN}/images/${IMAGE_ID}`,
+    error: 'Image not found',
+    queuedReads: (quote) => [[quote], [imageRow]],
+  },
+  {
+    name: 'GET /:token/line-image/:lineId',
+    path: `/quotes/public/${TOKEN}/line-image/${LINE_ID}`,
+    error: 'Image not found',
+    queuedReads: (quote) => [
+      [quote],
+      [{ imageId: IMAGE_ID, catalogItemId: null, customerVisible: true }],
+      [imageRow],
+    ],
+  },
+  {
+    name: 'GET /:token/contract-file/:blockId',
+    path: `/quotes/public/${TOKEN}/contract-file/${BLOCK_ID}`,
+    error: 'Contract file not found',
+    queuedReads: (quote) => [[quote], [contractBlock], [contractVersion], [contractTemplate]],
+  },
+];
+
+describe('quotesPublic retired-link assets', () => {
+  it.each(assetCases)('$name returns 404 for a superseded quote', async ({ path, error, queuedReads }) => {
+    dbResults.push(...queuedReads(quoteRow({ status: 'superseded' })));
+
+    const response = await app().request(path);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({ error });
+  });
+
+  it.each(assetCases)('$name returns 404 when publicLinkRevokedAt is set', async ({ path, error, queuedReads }) => {
+    dbResults.push(...queuedReads(quoteRow({ status: 'sent', publicLinkRevokedAt: REVOKED_AT })));
+
+    const response = await app().request(path);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({ error });
+  });
+});
+
+describe('quotesPublic retired-link decline', () => {
+  async function decline(quote: Record<string, unknown>) {
+    dbResults.push([quote]);
+    return app().request(`/quotes/public/${TOKEN}/decline`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'Using the revised proposal' }),
+    });
+  }
+
+  it('POST /:token/decline returns 410 QUOTE_SUPERSEDED for a superseded quote', async () => {
+    const response = await decline(quoteRow({ status: 'superseded' }));
+
+    expect(response.status).toBe(410);
+    expect(await response.json()).toMatchObject({ code: 'QUOTE_SUPERSEDED' });
+  });
+
+  it('POST /:token/decline returns 410 QUOTE_SUPERSEDED when publicLinkRevokedAt is set', async () => {
+    const response = await decline(quoteRow({ status: 'sent', publicLinkRevokedAt: REVOKED_AT }));
+
+    expect(response.status).toBe(410);
+    expect(await response.json()).toMatchObject({ code: 'QUOTE_SUPERSEDED' });
+  });
+});
+
+describe('quotesPublic Redis-revoked token ordering', () => {
+  const tokenGateCases = [
+    { name: 'GET /:token', path: `/quotes/public/${TOKEN}` },
+    { name: 'GET /:token/images/:imageId', path: `/quotes/public/${TOKEN}/images/${IMAGE_ID}` },
+    { name: 'GET /:token/line-image/:lineId', path: `/quotes/public/${TOKEN}/line-image/${LINE_ID}` },
+    { name: 'GET /:token/contract-file/:blockId', path: `/quotes/public/${TOKEN}/contract-file/${BLOCK_ID}` },
+  ];
+
+  it.each(tokenGateCases)('$name returns 401 before any quote liveness read', async ({ path }) => {
+    (isQuoteAcceptJtiRevoked as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+    const response = await app().request(path);
+
+    expect(response.status).toBe(401);
+    expect((db as unknown as { select: ReturnType<typeof vi.fn> }).select).not.toHaveBeenCalled();
+  });
+});
+
+type TokenRouteCase = {
+  name: string;
+  method: 'GET' | 'POST';
+  path: string;
+  queuedReads: unknown[][];
+};
+
+function materializePath(path: string) {
+  return path
+    .replace(':token', TOKEN)
+    .replace(':imageId', IMAGE_ID)
+    .replace(':lineId', LINE_ID)
+    .replace(':blockId', BLOCK_ID);
+}
+
+describe('quotesPublic token-route liveness enumeration', () => {
+  it('keeps every token-authenticated route non-2xx after the quote link is revoked', async () => {
+    const revokedQuote = quoteRow({ status: 'sent', publicLinkRevokedAt: REVOKED_AT });
+    // Enumeration guard: this list must be kept in sync with quotesPublic.ts.
+    // Adding a token-authenticated route without a liveness check must make this
+    // test fail, so the registered route inventory comparison is intentionally strict.
+    const tokenRoutes: TokenRouteCase[] = [
+      {
+        name: 'view quote',
+        method: 'GET',
+        path: '/:token',
+        queuedReads: [[revokedQuote], [], [], [partnerRow], []],
+      },
+      {
+        name: 'quote image',
+        method: 'GET',
+        path: '/:token/images/:imageId',
+        queuedReads: [[revokedQuote], [imageRow]],
+      },
+      {
+        name: 'line image',
+        method: 'GET',
+        path: '/:token/line-image/:lineId',
+        queuedReads: [
+          [revokedQuote],
+          [{ imageId: IMAGE_ID, catalogItemId: null, customerVisible: true }],
+          [imageRow],
+        ],
+      },
+      {
+        name: 'contract file',
+        method: 'GET',
+        path: '/:token/contract-file/:blockId',
+        queuedReads: [[revokedQuote], [contractBlock], [contractVersion], [contractTemplate]],
+      },
+      {
+        name: 'accept quote',
+        method: 'POST',
+        path: '/:token/accept',
+        queuedReads: [[], [revokedQuote]],
+      },
+      {
+        name: 'decline quote',
+        method: 'POST',
+        path: '/:token/decline',
+        queuedReads: [[revokedQuote], [{ id: QUOTE_ID }]],
+      },
+    ];
+
+    const registeredRoutes = Array.from(new Set(
+      (quotesPublicRoutes as unknown as { routes: Array<{ method: string; path: string }> }).routes
+        .map((route) => `${route.method} ${route.path}`),
+    )).sort();
+    const enumeratedRoutes = tokenRoutes.map((route) => `${route.method} ${route.path}`).sort();
+    expect(registeredRoutes).toEqual(enumeratedRoutes);
+
+    for (const route of tokenRoutes) {
+      vi.clearAllMocks();
+      dbResults.length = 0;
+      resetTokenMocks();
+      dbResults.push(...route.queuedReads);
+
+      const requestPath = `/quotes/public${materializePath(route.path)}`;
+      const init = route.method === 'POST'
+        ? {
+            method: route.method,
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(route.path.endsWith('/accept')
+              ? { signerName: 'Customer Signer' }
+              : { reason: 'Using the revision' }),
+          }
+        : { method: route.method };
+      const response = await app().request(requestPath, init);
+
+      expect(
+        response.status < 200 || response.status >= 300,
+        `${route.name} returned ${response.status} for a revoked public link`,
+      ).toBe(true);
+    }
+  });
+});

--- a/apps/api/src/routes/quotesPublic.ts
+++ b/apps/api/src/routes/quotesPublic.ts
@@ -49,6 +49,35 @@ async function resolve(c: { req: { valid: (k: 'param') => { token: string } } })
   return claims;
 }
 
+/** The columns every token route needs to judge whether the link is still live. */
+const publicLinkColumns = {
+  id: quotes.id,
+  status: quotes.status,
+  publicLinkRevokedAt: quotes.publicLinkRevokedAt,
+};
+
+/**
+ * A replaced quote's public link is dead: the revision that superseded it revoked
+ * it in the same statement that flipped its status. Both are checked because
+ * publicLinkRevokedAt is the DB-authoritative revocation and must keep working for
+ * any future standalone link-revoke that does not change status.
+ *
+ * ONE predicate, used by every token route, so adding a route cannot silently
+ * reopen a revoked link. quotesPublic.superseded.test.ts enumerates the routes and
+ * fails if a new one skips this.
+ */
+function isPublicLinkDead(q: { status: string; publicLinkRevokedAt: Date | null }): boolean {
+  return q.status === 'superseded' || q.publicLinkRevokedAt != null;
+}
+
+/** Load the token's quote for an asset route, or null when the link is dead. */
+async function loadLiveAssetQuote(claims: { quoteId: string; orgId: string }) {
+  const [quote] = await db.select(publicLinkColumns).from(quotes)
+    .where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
+  if (!quote || isPublicLinkDead(quote)) return null;
+  return quote;
+}
+
 // GET /:token — view. Stamps first_viewed_at + sent→viewed. Customer-visible content only.
 quotesPublicRoutes.get('/:token', zValidator('param', tokenParam), async (c) => {
   const { token } = c.req.valid('param');
@@ -58,6 +87,11 @@ quotesPublicRoutes.get('/:token', zValidator('param', tokenParam), async (c) => 
     const data = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
       const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
       if (!quote || quote.status === 'draft') return null;
+      if (isPublicLinkDead(quote)) {
+        const [p] = await db.select({ name: partners.name }).from(partners)
+          .where(eq(partners.id, quote.partnerId)).limit(1);
+        return { superseded: true as const, partnerName: p?.name ?? 'your provider' };
+      }
       const rawBlocks = sanitizeQuoteBlocksForRead(await db.select().from(quoteBlocks).where(eq(quoteBlocks.quoteId, quote.id)).orderBy(quoteBlocks.sortOrder));
       const lines = toCustomerLines((await db.select().from(quoteLines).where(eq(quoteLines.quoteId, quote.id)).orderBy(quoteLines.sortOrder)).filter((l) => l.customerVisible));
       const [partner] = await db.select({ name: partners.name, documentTheme: partners.documentTheme, documentPageSize: partners.documentPageSize, settings: partners.settings }).from(partners).where(eq(partners.id, quote.partnerId)).limit(1);
@@ -92,13 +126,20 @@ quotesPublicRoutes.get('/:token', zValidator('param', tokenParam), async (c) => 
         theme, pageSize,
       }, presentation: toPublicQuotePresentation(theme, pageSize) };
     }));
+    if (data && 'superseded' in data) {
+      // Deliberately withhold the successor: the latest email is the customer's
+      // authorization path, and exposing it here would reveal an unsent document.
+      return c.json({
+        error: 'This proposal has been replaced by an updated version — please use the link in the latest email.',
+        code: 'QUOTE_SUPERSEDED',
+        data: { branding: { partnerName: data.partnerName } },
+      }, 410);
+    }
     if (!data) return c.json({ error: 'Quote not found' }, 404);
     return c.json({ data });
   } catch (err) {
     if (err instanceof ContractTemplateServiceError) return c.json({ error: err.message, code: err.code }, err.status);
-    // A superseded quote refuses serialization in toPublicQuoteHeader (its
-    // prices are withdrawn). Answer the customer with that status rather than
-    // letting it reach the global handler as an opaque 500.
+    // Fail-closed floor for any retired status that reaches serialization.
     if (err instanceof QuoteServiceError) return c.json({ error: err.message, code: err.code }, err.status);
     throw err;
   }
@@ -109,7 +150,7 @@ quotesPublicRoutes.get('/:token/images/:imageId', zValidator('param', tokenImage
   const claims = await resolve(c); const { imageId } = c.req.valid('param');
   if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
   const img = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
-    const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
+    const quote = await loadLiveAssetQuote(claims);
     if (!quote) return null;
     return readQuoteImage(imageId, quote.id);
   }));
@@ -127,7 +168,7 @@ quotesPublicRoutes.get('/:token/line-image/:lineId', zValidator('param', tokenLi
   const claims = await resolve(c); const { lineId } = c.req.valid('param');
   if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
   const img = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
-    const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
+    const quote = await loadLiveAssetQuote(claims);
     if (!quote) return null;
     return loadCustomerLineImage(quote.id, lineId);
   }));
@@ -143,7 +184,7 @@ quotesPublicRoutes.get('/:token/contract-file/:blockId', zValidator('param', tok
   const claims = await resolve(c); const { blockId } = c.req.valid('param');
   if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
   const block = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
-    const [quote] = await db.select({ id: quotes.id }).from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
+    const quote = await loadLiveAssetQuote(claims);
     if (!quote) return null;
     const [b] = await db.select().from(quoteBlocks).where(and(eq(quoteBlocks.id, blockId), eq(quoteBlocks.quoteId, quote.id), eq(quoteBlocks.blockType, 'contract'))).limit(1);
     return b ?? null;
@@ -226,6 +267,7 @@ quotesPublicRoutes.post('/:token/decline', zValidator('param', tokenParam), zVal
     // public_token_version=1): a version-1 row may only be consumed by the jti
     // it was issued with. Inert for today's version-0 rows.
     if ((quote.publicTokenVersion ?? 0) !== 0 && quote.publicResponseJti !== claims.jti) return 'consumed' as const;
+    if (isPublicLinkDead(quote)) return 'superseded' as const;
     if (quote.status !== 'sent' && quote.status !== 'viewed') return 'bad_state' as const;
     // Read-time expiry guard (Phase 3): an expired quote is terminal — mirror the
     // acceptQuote / declineQuoteByActor 410 so the sub-sweep window is covered here too.
@@ -252,6 +294,7 @@ quotesPublicRoutes.post('/:token/decline', zValidator('param', tokenParam), zVal
     return 'ok' as const;
   }));
   if (result === 'expired') return c.json({ error: 'This quote has expired', code: 'QUOTE_EXPIRED' }, 410);
+  if (result === 'superseded') return c.json({ error: 'This quote has been replaced by a newer version', code: 'QUOTE_SUPERSEDED' }, 410);
   if (result === 'consumed') {
     // Re-arm the lost Redis marker so repeat replays die at the cheap
     // resolve() gate instead of re-reading the row each time; the durable

--- a/apps/api/src/services/quoteAcceptService.test.ts
+++ b/apps/api/src/services/quoteAcceptService.test.ts
@@ -586,3 +586,58 @@ describe('acceptQuote contract document snapshot', () => {
     expect(createExecutedDocumentsMock).not.toHaveBeenCalled();
   });
 });
+
+describe('acceptQuote superseded public-link guard', () => {
+  beforeEach(() => {
+    results.length = 0;
+    vi.clearAllMocks();
+    stagePax8OrderFromQuoteMock.mockResolvedValue({ orderId: null, lineCount: 0 });
+  });
+
+  function queueGuardQuote(overrides: Record<string, unknown>) {
+    queueResult([{
+      id: 'q1',
+      orgId: 'org1',
+      partnerId: 'p1',
+      quoteNumber: 'Q-2026-0001',
+      currencyCode: 'USD',
+      expiryDate: null,
+      publicResponseConsumedAt: null,
+      publicResponseJti: null,
+      publicTokenVersion: 0,
+      ...overrides,
+    }]);
+  }
+
+  it('rejects a superseded quote with 410 QUOTE_SUPERSEDED', async () => {
+    queueGuardQuote({ status: 'superseded', publicLinkRevokedAt: null });
+
+    await expect(acceptQuote(baseParams)).rejects.toMatchObject({
+      status: 410,
+      code: 'QUOTE_SUPERSEDED',
+    });
+  });
+
+  it('rejects a sent quote whose publicLinkRevokedAt is set with 410 QUOTE_SUPERSEDED', async () => {
+    queueGuardQuote({ status: 'sent', publicLinkRevokedAt: new Date('2026-08-23T12:00:00.000Z') });
+
+    await expect(acceptQuote(baseParams)).rejects.toMatchObject({
+      status: 410,
+      code: 'QUOTE_SUPERSEDED',
+    });
+  });
+
+  it('reports QUOTE_SUPERSEDED before the generic non-sent INVALID_STATE guard', async () => {
+    queueGuardQuote({ status: 'superseded', publicLinkRevokedAt: new Date('2026-08-23T12:00:00.000Z') });
+
+    let thrown: unknown;
+    try {
+      await acceptQuote(baseParams);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toMatchObject({ status: 410, code: 'QUOTE_SUPERSEDED' });
+    expect(thrown).not.toMatchObject({ status: 409, code: 'INVALID_STATE' });
+  });
+});


### PR DESCRIPTION
Closes #3800

**Stacked on #3873 (W03).** Base is the W03 branch, so the diff here is W04 only. Rebase onto `main` once W03 merges.

## The problem, confirmed empirically

Sending a revision retires its parent and stamps `publicLinkRevokedAt` — but the customer still holds a signed token for that parent. Before this wave the link only *half* died.

The RED tests proved it: a revoked link still returned **the full quote with prices (200)**, and all three asset routes still served content, **including uploaded contract PDFs**. Only `GET /:token` failed closed, and only indirectly — `toPublicStatus` throws for `'superseded'` and the route converts that to a 410, after loading blocks, lines and partner and marking the quote viewed, and keyed on `status` alone, never on the revocation column.

## One predicate, not five copies

The plan called for repeating the condition inline at each route. That is exactly how the next token route forgets it, so this adds a shared `isPublicLinkDead()` plus a `loadLiveAssetQuote()` loader the three asset routes share.

The loop is closed by a **table-driven test that enumerates every token route** and fails if any returns 2xx for a revoked link — so adding a route without the check breaks the build instead of quietly reopening a withdrawn proposal.

Both halves of the predicate earn their place: `status === 'superseded'` is the normal path, and `publicLinkRevokedAt != null` keeps working for any future standalone link-revoke that doesn't change status. Mutation-verified — dropping the revocation half fails 6 tests; stripping the check from the shared loader fails 7.

## Behaviour

| Route | Retired link |
|---|---|
| `GET /:token` | **410** `QUOTE_SUPERSEDED`, partner name for branding, nothing else |
| `GET /:token/images/:imageId` | **404** |
| `GET /:token/line-image/:lineId` | **404** |
| `GET /:token/contract-file/:blockId` | **404** |
| `POST /:token/accept` | **410** (W03 service guard — now actually tested) |
| `POST /:token/decline` | **410** `QUOTE_SUPERSEDED` (was a generic 409) |

The 410 body carries no header, no blocks, no lines, no totals — and **no successor id**. That is deliberate: the customer reaches the replacement through the new email, and leaking the id here would hand out a document they were never sent. The branch also runs before `markQuoteViewed`, so a retired quote is no longer stamped viewed.

Replay ordering is unchanged: the consumed/`jti` guards still fire first, so a replayed link keeps 401ing. A test pins that.

`acceptQuote`'s 410 shipped in W03 with **zero tests**; three are added here, including that it beats the generic `INVALID_STATE` 409.

## Portal

Detail gains `supersededByQuoteId`, restricted to **non-draft** children — an authenticated customer must not learn a revision is being prepared for them.

That filter is the privacy guard, and a mock will happily hand back a draft row, so the test asserts the **compiled SQL** rather than the result: dropping the filter or flipping `<>` to `=` both fail it. Writing that test is what caught the gap — all 159 portal tests passed with the filter deleted. The portal harness now captures `where()` predicates and compiles them with `PgDialect`, the same operator-aware technique the W03 review introduced.

## Verification

Typecheck clean; **24,073** API tests pass. CI dispatched manually via `gh workflow run` — a PR based on a sibling branch triggers no CI (`ci.yml` is `pull_request: branches: [main]`), so `gh pr checks` reading green here would be meaningless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)