### PR TITLE
feat(quotes): W05 — Revise action, lineage banners, portal replaced views

### DIFF
--- a/apps/portal/src/components/portal/PublicQuoteView.superseded.test.tsx
+++ b/apps/portal/src/components/portal/PublicQuoteView.superseded.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+import { PublicQuoteView } from './PublicQuoteView';
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+
+describe('PublicQuoteView — replaced proposal', () => {
+  it('renders a branded notice naming the partner, not a broken-link error', () => {
+    render(<PublicQuoteView token="t" initial={null} superseded={{ partnerName: 'Acme MSP' }} />);
+
+    const notice = screen.getByTestId('public-quote-superseded');
+    expect(notice.textContent).toContain('replaced by an updated version');
+    expect(notice.textContent).toContain('Acme MSP');
+    // Telling the customer their link is "invalid or expired" would send them
+    // back to the MSP for a fix that is already sitting in their inbox.
+    expect(screen.queryByTestId('public-quote-error')).toBeNull();
+  });
+
+  it('still reads sensibly when the partner name is missing', () => {
+    render(<PublicQuoteView token="t" initial={null} superseded={{}} />);
+
+    const notice = screen.getByTestId('public-quote-superseded');
+    expect(notice.textContent).toContain('replaced by an updated version');
+    expect(notice.textContent).not.toContain('or contact');
+  });
+
+  it('shows no pricing, no actions, and no link to the replacement', () => {
+    const { container } = render(
+      <PublicQuoteView token="t" initial={null} superseded={{ partnerName: 'Acme MSP' }} />,
+    );
+
+    // The withdrawn prices must not leak, the customer must not be able to act
+    // on a retired proposal, and the successor is reached through the newer
+    // email — its id is not ours to hand out on a dead link.
+    expect(screen.queryByTestId('public-quote-accept')).toBeNull();
+    expect(screen.queryByTestId('public-quote-decline')).toBeNull();
+    expect(container.textContent).not.toMatch(/\$\s?\d/);
+    expect(container.querySelector('a[href*="/quote/"]')).toBeNull();
+  });
+
+  it('takes precedence over the generic invalid-link fallback', () => {
+    render(<PublicQuoteView token="t" initial={null} error="This link is invalid or has expired" superseded={{ partnerName: 'Acme MSP' }} />);
+
+    expect(screen.getByTestId('public-quote-superseded')).not.toBeNull();
+    expect(screen.queryByTestId('public-quote-error')).toBeNull();
+  });
+
+  it('leaves the ordinary invalid-link path alone when nothing was superseded', () => {
+    render(<PublicQuoteView token="t" initial={null} error="This link is invalid or has expired" />);
+
+    expect(screen.getByTestId('public-quote-error')).not.toBeNull();
+    expect(screen.queryByTestId('public-quote-superseded')).toBeNull();
+  });
+});

--- a/apps/portal/src/components/portal/PublicQuoteView.tsx
+++ b/apps/portal/src/components/portal/PublicQuoteView.tsx
@@ -10,6 +10,10 @@ interface PublicQuoteViewProps {
   token: string;
   initial: PublicQuoteDetail | null;
   error?: string | null;
+  /** Set when the API answered 410 QUOTE_SUPERSEDED: this proposal was replaced
+   *  by a newer revision and its link was revoked. Carries only the partner's
+   *  name — the server withholds everything else, including the successor's id. */
+  superseded?: { partnerName?: string | null } | null;
 }
 
 function shortDate(value: string | null | undefined): string {
@@ -19,11 +23,28 @@ function shortDate(value: string | null | undefined): string {
   return d.toLocaleDateString();
 }
 
-export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps) {
+export function PublicQuoteView({ token, initial, error, superseded }: PublicQuoteViewProps) {
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState(initial?.quote.status ?? '');
   const [msg, setMsg] = useState<string | null>(null);
   const [msgError, setMsgError] = useState(false);
+
+  // A replaced proposal is NOT a broken link, and telling the customer their
+  // link is "invalid or expired" would send them back to the MSP for a fix that
+  // is already in their inbox. Checked before the generic fallback for that
+  // reason. Deliberately renders no totals, no accept/decline, and no link to
+  // the successor — they reach it through the newer email, and the id is not
+  // ours to hand out here.
+  if (superseded) {
+    return (
+      <div data-testid="public-quote-superseded" role="status" className="mx-auto max-w-lg p-8 text-center">
+        <p className="text-sm">
+          This proposal has been replaced by an updated version — please use the link in the latest email
+          {superseded.partnerName ? `, or contact ${superseded.partnerName}` : ''}.
+        </p>
+      </div>
+    );
+  }
 
   if (error || !initial) {
     return (
@@ -60,7 +81,9 @@ export function PublicQuoteView({ token, initial, error }: PublicQuoteViewProps)
         ? 'Declined'
         : status === 'expired'
           ? 'Expired'
-          : undefined;
+          : status === 'superseded'
+            ? 'Replaced'
+            : undefined;
 
   const headerDates = [
     ...(quote.issueDate ? [{ label: 'Issued', value: shortDate(quote.issueDate) }] : []),

--- a/apps/portal/src/components/portal/QuoteDetailView.tsx
+++ b/apps/portal/src/components/portal/QuoteDetailView.tsx
@@ -24,6 +24,9 @@ const STATUS_LABELS: Record<string, string> = {
   declined: 'Declined',
   expired: 'Expired',
   converted: 'Accepted',
+  // Without this the `?? status` fallback renders the raw enum "superseded" to
+  // the customer. This status only became reachable when revisions shipped.
+  superseded: 'Replaced',
 };
 
 export function QuoteDetailView({ detail, error, statusCode }: QuoteDetailViewProps) {
@@ -192,6 +195,21 @@ export function QuoteDetailView({ detail, error, statusCode }: QuoteDetailViewPr
           Download PDF
         </a>
       </div>
+
+      {/* A replaced proposal is read-only and its public link is dead. Say so
+          plainly, and link the replacement when the API supplied one — in-portal
+          by id, which the customer's own portal auth and the successor's
+          recipient list still gate. */}
+      {status === 'superseded' && (
+        <div className="rounded-md border border-muted-foreground/30 bg-muted/40 p-4 text-sm" data-testid="portal-quote-superseded">
+          <p>This proposal has been replaced by a newer version.</p>
+          {quote.supersededByQuoteId && (
+            <a className="underline" href={withBase(`/quotes/${quote.supersededByQuoteId}`)} data-testid="portal-quote-successor-link">
+              View the current proposal
+            </a>
+          )}
+        </div>
+      )}
 
       <DocumentPaper primaryColor={branding?.primaryColor} docTheme={presentation?.theme}>
         <DocumentHeader

--- a/apps/portal/src/components/portal/QuoteList.tsx
+++ b/apps/portal/src/components/portal/QuoteList.tsx
@@ -20,6 +20,9 @@ const STATUS_LABELS: Record<string, string> = {
   declined: 'Declined',
   expired: 'Expired',
   converted: 'Accepted',
+  // Without this the `?? status` fallback renders the raw enum "superseded" to
+  // the customer. This status only became reachable when revisions shipped.
+  superseded: 'Replaced',
 };
 
 

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -156,6 +156,12 @@ export interface ApiResponse<T> {
   error?: string;
   /** Machine-readable error code from the API body (e.g. PORTAL_TICKETS_DISABLED). */
   code?: string;
+  /** The `data` payload carried BY AN ERROR body, kept separate from `data` so
+   *  presence of `data` still means "the request succeeded". Some errors are
+   *  renderable rather than fatal — a 410 QUOTE_SUPERSEDED carries the partner's
+   *  branding so a replaced proposal can show a branded notice instead of a bare
+   *  failure. */
+  errorData?: unknown;
   statusCode?: number;
   headers?: Headers;
 }
@@ -226,6 +232,7 @@ export async function apiRequest<T>(
       return {
         error: body?.error || 'That didn\'t go through. Nothing was lost — try again in a moment.',
         code: typeof body?.code === 'string' ? body.code : undefined,
+        errorData: body?.data,
         statusCode: response.status,
         headers: response.headers
       };
@@ -564,7 +571,12 @@ export interface QuoteBranding {
 }
 
 export interface QuoteDetail {
-  quote: QuoteHeader;
+  quote: QuoteHeader & {
+    /** Set when a NON-DRAFT revision has replaced this quote. The API withholds
+     *  draft successors on purpose — a customer must not learn a revision is
+     *  being prepared for them. */
+    supersededByQuoteId?: string | null;
+  };
   blocks: QuoteBlock[];
   lines: QuoteLine[];
   /** Optional for API responses that predate the branding field. */

--- a/apps/portal/src/pages/quote/[token].astro
+++ b/apps/portal/src/pages/quote/[token].astro
@@ -12,8 +12,14 @@ const response = await portalApi.getPublicQuote(token!, buildServerApiConfig(Ast
 // PublicQuoteView's own "invalid or expired" fallback (no specific error text
 // for the generic 401, which would otherwise read "Session expired").
 const initial = response.data?.data ?? null;
-const error = response.statusCode === 401 ? undefined : response.error;
-const partnerName = initial?.branding?.partnerName;
+// A replaced proposal answers 410 QUOTE_SUPERSEDED and carries only the
+// partner's branding — enough to say who to contact, nothing that would leak
+// the withdrawn pricing or the successor's link.
+const supersededBranding = response.statusCode === 410 && response.code === 'QUOTE_SUPERSEDED'
+  ? ((response.errorData as { branding?: { partnerName?: string } } | undefined)?.branding ?? {})
+  : null;
+const error = response.statusCode === 401 || supersededBranding ? undefined : response.error;
+const partnerName = initial?.branding?.partnerName ?? supersededBranding?.partnerName;
 const title = partnerName ? `Proposal from ${partnerName}` : 'Proposal';
 ---
 
@@ -24,5 +30,5 @@ const title = partnerName ? `Proposal from ${partnerName}` : 'Proposal';
   supportPhone={initial?.branding?.supportPhone}
   partnerName={partnerName}
 >
-  <PublicQuoteView token={token!} initial={initial} error={error} client:load />
+  <PublicQuoteView token={token!} initial={initial} error={error} superseded={supersededBranding} client:load />
 </PublicDocumentLayout>

--- a/apps/web/src/components/billing/quotes/QuoteActions.revise.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.revise.test.tsx
@@ -19,7 +19,16 @@ vi.mock('../../../stores/orgStore', () => ({
   useOrgStore: (sel: (s: { organizations: unknown[] }) => unknown) => sel({ organizations: mocks.organizations }),
 }));
 vi.mock('@/lib/navigation', () => ({ navigateTo: mocks.navigateTo }));
-vi.mock('../../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+// The send composer fires background support fetches (billing contact,
+// signature) that reach useAuthStore. Without it here those land as Vitest
+// "unhandled errors" after the test finishes — green, but flagged as capable of
+// producing false positives.
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(() => null, { getState: () => ({ tokens: null }) }),
+}));
 vi.mock('../../../lib/api/quotes', () => ({
   reviseQuote: mocks.reviseQuote,
   cloneQuote: vi.fn(),
@@ -47,8 +56,16 @@ const detailWith = (over: Partial<QuoteDetailData['quote']> = {}, rest: Partial<
     createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-02T00:00:00Z',
     ...over,
   },
-  blocks: [],
-  lines: [],
+  // A quote with no customer-visible line is "empty" and Send stays disabled,
+  // so the composer tests need one real line.
+  blocks: [{ id: 'b-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items', content: {}, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z' }],
+  lines: [{
+    id: 'l-1', quoteId: 'q-1', blockId: 'b-1', orgId: 'org-1', sourceType: 'manual',
+    catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+    name: 'Support', description: null, quantity: '1.00', unitPrice: '100.00', taxable: false,
+    customerVisible: true, lineTotal: '100.00', recurrence: 'one_time', termMonths: null,
+    billingFrequency: null, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+  }],
   ...rest,
 });
 
@@ -139,5 +156,44 @@ describe('QuoteActions — Revise', () => {
     // /billing/quotes/undefined.
     await waitFor(() => expect(mocks.runAction).toHaveBeenCalled());
     expect(mocks.navigateTo).not.toHaveBeenCalled();
+  });
+});
+
+describe('QuoteActions — sending a revision', () => {
+  beforeEach(() => {
+    mocks.can.mockImplementation((_r: string, action: string) => action === 'read' || action === 'write' || action === 'send');
+  });
+
+  const revisionDraft = () => detailWith(
+    { status: 'draft', revisionOfQuoteId: 'q-0', revisionNumber: 2 },
+    { revisionOf: { id: 'q-0', quoteNumber: 'Q-2026-000001', recipients: ['buyer@customer.test'] } },
+  );
+
+  // The consequence of this send — the original is retired and the customer's
+  // existing link stops working — appears nowhere else in the dialog, and it
+  // cannot be undone once the send commits.
+  it('warns in the send composer that the original will be replaced', async () => {
+    render(<QuoteActions detail={revisionDraft()} variant="header" />);
+    fireEvent.click(screen.getByTestId('quote-send'));
+
+    await waitFor(() => expect(screen.getByTestId('quote-send-revision-warning')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-send-revision-warning')).toHaveTextContent('Q-2026-000001');
+  });
+
+  it('does not warn when the draft is not a revision', async () => {
+    render(<QuoteActions detail={detailWith({ status: 'draft' })} variant="header" />);
+    fireEvent.click(screen.getByTestId('quote-send'));
+
+    await waitFor(() => expect(screen.getByTestId('quote-send-to')).toBeInTheDocument());
+    expect(screen.queryByTestId('quote-send-revision-warning')).not.toBeInTheDocument();
+  });
+
+  // Display honesty: the server falls back to the parent's recipients anyway,
+  // so an empty To would misrepresent who is about to receive this.
+  it('prefills To with the addresses the original went to', async () => {
+    render(<QuoteActions detail={revisionDraft()} variant="header" />);
+    fireEvent.click(screen.getByTestId('quote-send'));
+
+    await waitFor(() => expect(screen.getByTestId('quote-send-to')).toHaveValue('buyer@customer.test'));
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteActions.revise.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.revise.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteActions from './QuoteActions';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { ActionError } from '../../../lib/runAction';
+
+const mocks = vi.hoisted(() => ({
+  can: vi.fn(),
+  reviseQuote: vi.fn(),
+  navigateTo: vi.fn(),
+  runAction: vi.fn(),
+  showToast: vi.fn(),
+  organizations: [] as Array<{ id: string; name: string }>,
+}));
+
+vi.mock('../../../lib/permissions', () => ({ usePermissions: () => ({ can: mocks.can }) }));
+vi.mock('../../../stores/orgStore', () => ({
+  useOrgStore: (sel: (s: { organizations: unknown[] }) => unknown) => sel({ organizations: mocks.organizations }),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: mocks.navigateTo }));
+vi.mock('../../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../../lib/api/quotes', () => ({
+  reviseQuote: mocks.reviseQuote,
+  cloneQuote: vi.fn(),
+  sendQuote: vi.fn(),
+  deleteQuote: vi.fn(),
+  quotePdfUrl: vi.fn().mockReturnValue('/quotes/q-1/pdf'),
+}));
+// Keep the REAL ActionError class so the component's `instanceof` check resolves
+// against the same constructor this test throws.
+vi.mock('../../../lib/runAction', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/runAction')>();
+  return { ...actual, runAction: mocks.runAction, handleActionError: vi.fn() };
+});
+vi.mock('../../shared/Toast', () => ({ showToast: mocks.showToast }));
+vi.mock('../../shared/ConfirmDialog', () => ({ ConfirmDialog: () => null }));
+
+const detailWith = (over: Partial<QuoteDetailData['quote']> = {}, rest: Partial<QuoteDetailData> = {}): QuoteDetailData => ({
+  quote: {
+    id: 'q-1', quoteNumber: 'Q-2026-000001', partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'sent',
+    currencyCode: 'USD', issueDate: '2026-06-01', expiryDate: null, subtotal: '100.00', taxRate: null,
+    taxTotal: '0.00', total: '100.00', oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '100.00', billToName: null, introNotes: null,
+    terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: '2026-06-01', viewedAt: null,
+    createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-02T00:00:00Z',
+    ...over,
+  },
+  blocks: [],
+  lines: [],
+  ...rest,
+});
+
+/** Header variant folds Revise into the ⋯ overflow menu, same as Clone. */
+function openMenu() {
+  fireEvent.click(screen.getByTestId('quote-actions-menu'));
+}
+
+describe('QuoteActions — Revise', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.organizations = [{ id: 'org-1', name: 'Acme' }];
+    mocks.can.mockImplementation((_r: string, action: string) => action === 'read' || action === 'write');
+    mocks.runAction.mockImplementation(async ({ request }: { request: () => Promise<unknown> }) => {
+      await request();
+      return { data: { id: 'q-2' } };
+    });
+    mocks.reviseQuote.mockResolvedValue(new Response(JSON.stringify({ data: { id: 'q-2' } }), { status: 200 }));
+  });
+
+  // A revision REPLACES a live proposal, so it is offered exactly on the
+  // statuses the server will supersede — never on a draft (nothing to replace),
+  // and never on a settled or already-retired quote.
+  it.each(['sent', 'viewed', 'declined', 'expired'])('offers Revise on a %s quote', (status) => {
+    render(<QuoteActions detail={detailWith({ status: status as never })} variant="header" />);
+    openMenu();
+    expect(screen.getByTestId('quote-revise')).toBeInTheDocument();
+  });
+
+  it.each(['draft', 'accepted', 'converted', 'superseded'])('does not offer Revise on a %s quote', (status) => {
+    render(<QuoteActions detail={detailWith({ status: status as never })} variant="header" />);
+    openMenu();
+    expect(screen.queryByTestId('quote-revise')).not.toBeInTheDocument();
+  });
+
+  it('does not offer Revise to a read-only viewer', () => {
+    mocks.can.mockImplementation((_r: string, action: string) => action === 'read');
+    render(<QuoteActions detail={detailWith()} variant="header" />);
+    // A read-only viewer gets no write actions at all, so the overflow menu
+    // itself is absent — assert directly rather than trying to open it.
+    expect(screen.queryByTestId('quote-actions-menu')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quote-revise')).not.toBeInTheDocument();
+  });
+
+  it('creates the revision and opens the new draft, the same navigation seam clone uses', async () => {
+    render(<QuoteActions detail={detailWith()} variant="header" />);
+    openMenu();
+    fireEvent.click(screen.getByTestId('quote-revise'));
+
+    await waitFor(() => expect(mocks.reviseQuote).toHaveBeenCalledWith('q-1'));
+    expect(mocks.runAction).toHaveBeenCalledWith(expect.objectContaining({
+      successMessage: expect.any(String),
+      errorFallback: expect.any(String),
+    }));
+    expect(mocks.navigateTo).toHaveBeenCalledWith('/billing/quotes/q-2');
+  });
+
+  // The server allows only ONE open revision per quote. Without this branch the
+  // tech gets a bare 409 and no way to reach the draft that is blocking them.
+  it('recovers from REVISION_IN_PROGRESS by opening the existing revision', async () => {
+    mocks.runAction.mockRejectedValue(new ActionError(
+      'A revision of this quote is already in progress',
+      409,
+      'REVISION_IN_PROGRESS',
+      { error: 'x', code: 'REVISION_IN_PROGRESS', meta: { revisionQuoteId: 'q-existing' } },
+    ));
+
+    render(<QuoteActions detail={detailWith()} variant="header" />);
+    openMenu();
+    fireEvent.click(screen.getByTestId('quote-revise'));
+
+    await waitFor(() => expect(mocks.navigateTo).toHaveBeenCalledWith('/billing/quotes/q-existing'));
+  });
+
+  // A 409 without the id is not actionable — it must not navigate to undefined.
+  it('does not navigate when REVISION_IN_PROGRESS carries no revision id', async () => {
+    mocks.runAction.mockRejectedValue(new ActionError(
+      'A revision of this quote is already in progress', 409, 'REVISION_IN_PROGRESS',
+      { error: 'x', code: 'REVISION_IN_PROGRESS' },
+    ));
+
+    render(<QuoteActions detail={detailWith()} variant="header" />);
+    openMenu();
+    fireEvent.click(screen.getByTestId('quote-revise'));
+
+    // runAction is mocked at the seam, so the inner request never runs; what
+    // matters is that an id-less 409 navigates NOWHERE rather than to
+    // /billing/quotes/undefined.
+    await waitFor(() => expect(mocks.runAction).toHaveBeenCalled());
+    expect(mocks.navigateTo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { AlertTriangle, Loader2, MoreHorizontal } from 'lucide-react';
 import '../../../lib/i18n';
 import { navigateTo } from '@/lib/navigation';
-import { runAction, handleActionError } from '../../../lib/runAction';
+import { runAction, handleActionError, ActionError } from '../../../lib/runAction';
 import { useMenuKeyboard } from '../shared/menuKeyboard';
 import { parseAddressList, MAX_RECIPIENTS } from '../shared/addressList';
 import { scheduleQuoteSend, cancelScheduledSend } from '../../../lib/api/quotes';
@@ -12,7 +12,7 @@ import { usePermissions } from '../../../lib/permissions';
 import { useOrgStore } from '../../../stores/orgStore';
 import { fetchWithAuth } from '../../../stores/auth';
 import { getJwtClaims } from '../../../lib/authScope';
-import { cloneQuote, deleteQuote, sendQuote, resendQuote, getQuoteShareLink, type SendQuoteOptions, type QuoteSendEmailReason, type QuoteAcceptUrlOrigin } from '../../../lib/api/quotes';
+import { cloneQuote, reviseQuote, deleteQuote, sendQuote, resendQuote, getQuoteShareLink, type SendQuoteOptions, type QuoteSendEmailReason, type QuoteAcceptUrlOrigin } from '../../../lib/api/quotes';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import { Dialog } from '../../shared/Dialog';
 import { OrgCombobox, orgComboboxOptions } from '../shared/OrgCombobox';
@@ -714,6 +714,42 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
     }
   }, [cloning, quote.id, cloneOrgId, cloneTitle, savePending, t]);
 
+  // Revise: create a linked draft that will REPLACE this quote when sent.
+  // Distinct from Clone, which starts an unrelated quote and leaves this one
+  // live. Navigation mirrors clone() exactly so both land the tech on the new
+  // draft the same way.
+  const [revising, setRevising] = useState(false);
+  const revise = useCallback(async () => {
+    if (revising || savePending) return;
+    setRevising(true);
+    setMenuOpen(false);
+    try {
+      const result = await runAction<{ data: { id: string } }>({
+        request: () => reviseQuote(quote.id),
+        errorFallback: t('quotes.actions.reviseError'),
+        successMessage: t('quotes.actions.reviseSuccess'),
+        onUnauthorized: UNAUTHORIZED,
+      });
+      if (result?.data?.id) void navigateTo(`/billing/quotes/${result.data.id}`);
+    } catch (err) {
+      // Only one open revision per quote is allowed. A bare 409 would leave the
+      // tech stuck with no route to the draft that is blocking them, so steer
+      // them to it instead. Without the id there is nothing to open — fall
+      // through to the normal error handling rather than navigating nowhere.
+      const existingId = err instanceof ActionError && err.status === 409 && err.code === 'REVISION_IN_PROGRESS'
+        ? (err.body as { meta?: { revisionQuoteId?: string } } | undefined)?.meta?.revisionQuoteId
+        : undefined;
+      if (existingId) {
+        showToast({ message: t('quotes.actions.reviseInProgress'), type: 'info' });
+        void navigateTo(`/billing/quotes/${existingId}`);
+      } else {
+        handleActionError(err, t('quotes.actions.reviseError'));
+      }
+    } finally {
+      setRevising(false);
+    }
+  }, [revising, quote.id, savePending, t]);
+
   const header = variant === 'header';
   // Rail buttons stretch full-width and stack; header buttons size to content and
   // sit in a row. The class fragments below are the only thing the variant changes.
@@ -812,6 +848,11 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
 
   const canSend = can('quotes', 'send') && isDraft;
   const canClone = can('quotes', 'write');
+  // Exactly the statuses the server will supersede (SUPERSEDABLE in
+  // services/quoteLifecycle.ts). A draft has nothing to replace; accepted and
+  // converted are settled; superseded is already retired.
+  const canRevise = can('quotes', 'write')
+    && (['sent', 'viewed', 'declined', 'expired'] as const).includes(quote.status as 'sent');
   const canDelete = can('quotes', 'write') && isDraft;
   // Resend and share-link share one gate (see quoteShareLinkAvailable above,
   // which mirrors assertLinkableQuote in services/quoteLifecycle.ts).
@@ -950,6 +991,18 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             {copyingLink ? t('quotes.actions.copyingShareLink') : t('quotes.actions.copyShareLink')}
           </button>
         )}
+        {!header && canRevise && (
+          <button
+            type="button"
+            onClick={() => void revise()}
+            disabled={revising || savePending}
+            title={savePending ? t('quotes.actions.cloneSavingTitle') : undefined}
+            data-testid="quote-revise"
+            className={`${btnBase} border hover:bg-muted disabled:opacity-50`}
+          >
+            {revising ? t('quotes.actions.revising') : t('quotes.actions.reviseQuote')}
+          </button>
+        )}
         {!header && canClone && (
           <button
             type="button"
@@ -1019,6 +1072,20 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
                     className="block w-full px-3 py-2 text-left text-sm hover:bg-muted focus:bg-muted focus:outline-hidden disabled:opacity-50"
                   >
                     {copyingLink ? t('quotes.actions.copyingShareLink') : t('quotes.actions.copyShareLink')}
+                  </button>
+                )}
+                {canRevise && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    tabIndex={-1}
+                    onClick={() => void revise()}
+                    disabled={revising || savePending}
+                    title={savePending ? t('quotes.actions.cloneSavingTitle') : undefined}
+                    data-testid="quote-revise"
+                    className="block w-full px-3 py-2 text-left text-sm hover:bg-muted focus:bg-muted focus:outline-hidden disabled:opacity-50"
+                  >
+                    {revising ? t('quotes.actions.revising') : t('quotes.actions.reviseQuote')}
                   </button>
                 )}
                 {canClone && (

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -212,7 +212,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
   const organizations = useOrgStore((s) => s.organizations);
-  const { quote, lines } = detail;
+  const { quote, lines, revisionOf } = detail;
   const recipients = useMemo(() => detail.recipients ?? [], [detail.recipients]);
   const currency = quote.currencyCode;
 
@@ -391,7 +391,15 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
     }
   }, [quote.orgId]);
 
-  const openSend = useCallback(() => openComposer({ resend: false, prefillTo: [] }), [openComposer]);
+  // A revision prefills the addresses the ORIGINAL went to. The server already
+  // falls back to the parent's recipients when To is empty, so this is display
+  // honesty — showing the tech who is about to receive it — rather than
+  // correctness. Falls through to the billing-contact lookup when the parent
+  // has no recorded recipients.
+  const openSend = useCallback(
+    () => openComposer({ resend: false, prefillTo: revisionOf?.recipients ?? [] }),
+    [openComposer, revisionOf],
+  );
   const openResend = useCallback(() => {
     setMenuOpen(false);
     openComposer({ resend: true, prefillTo: recipients });
@@ -1148,6 +1156,15 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
                 amount: formatMoney(quote.dueOnAcceptanceTotal ?? quote.oneTimeTotal, currency),
               })}
         </p>
+        {/* A revision send is not an ordinary send: it retires the parent and
+            revokes the link the customer is currently holding. Nothing else in
+            this dialog says so, and it is not undoable. */}
+        {!resendMode && revisionOf && (
+          <p className="mt-2 flex items-start gap-1 rounded-md border border-warning/40 bg-warning/10 px-2 py-1 text-xs text-warning-foreground dark:text-warning" data-testid="quote-send-revision-warning">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" aria-hidden="true" />
+            <span>{t('quotes.actions.sendConfirm.revisionWarning', { number: revisionOf.quoteNumber ?? '' })}</span>
+          </p>
+        )}
         {zeroTotal && (
           <p className="mt-2 rounded-md border border-warning/40 bg-warning/10 px-2 py-1 text-xs text-warning-foreground dark:text-warning" data-testid="quote-send-zero-warning">
             {t('quotes.actions.sendConfirm.zeroTotalWarning', { zero: formatMoney(0, quote.currencyCode) })}

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -17,6 +17,7 @@ import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import { Dialog } from '../../shared/Dialog';
 import { OrgCombobox, orgComboboxOptions } from '../shared/OrgCombobox';
 import { useShowMargin } from '../billingUi';
+import { useReviseQuote, isRevisable } from './useReviseQuote';
 import { computeQuoteProfit, type QuoteProfit } from '@breeze/shared';
 import { useQuotePdfDownload } from './useQuoteImage';
 import { type Quote, type QuoteDetail as QuoteDetailData, formatMoney } from './quoteTypes';
@@ -716,39 +717,9 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
 
   // Revise: create a linked draft that will REPLACE this quote when sent.
   // Distinct from Clone, which starts an unrelated quote and leaves this one
-  // live. Navigation mirrors clone() exactly so both land the tech on the new
-  // draft the same way.
-  const [revising, setRevising] = useState(false);
-  const revise = useCallback(async () => {
-    if (revising || savePending) return;
-    setRevising(true);
-    setMenuOpen(false);
-    try {
-      const result = await runAction<{ data: { id: string } }>({
-        request: () => reviseQuote(quote.id),
-        errorFallback: t('quotes.actions.reviseError'),
-        successMessage: t('quotes.actions.reviseSuccess'),
-        onUnauthorized: UNAUTHORIZED,
-      });
-      if (result?.data?.id) void navigateTo(`/billing/quotes/${result.data.id}`);
-    } catch (err) {
-      // Only one open revision per quote is allowed. A bare 409 would leave the
-      // tech stuck with no route to the draft that is blocking them, so steer
-      // them to it instead. Without the id there is nothing to open — fall
-      // through to the normal error handling rather than navigating nowhere.
-      const existingId = err instanceof ActionError && err.status === 409 && err.code === 'REVISION_IN_PROGRESS'
-        ? (err.body as { meta?: { revisionQuoteId?: string } } | undefined)?.meta?.revisionQuoteId
-        : undefined;
-      if (existingId) {
-        showToast({ message: t('quotes.actions.reviseInProgress'), type: 'info' });
-        void navigateTo(`/billing/quotes/${existingId}`);
-      } else {
-        handleActionError(err, t('quotes.actions.reviseError'));
-      }
-    } finally {
-      setRevising(false);
-    }
-  }, [revising, quote.id, savePending, t]);
+  // live. Shared with the declined banner's Revise via useReviseQuote so both
+  // entry points mean the same thing.
+  const { revise, revising } = useReviseQuote(quote.id, { onStart: () => setMenuOpen(false) });
 
   const header = variant === 'header';
   // Rail buttons stretch full-width and stack; header buttons size to content and
@@ -851,8 +822,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
   // Exactly the statuses the server will supersede (SUPERSEDABLE in
   // services/quoteLifecycle.ts). A draft has nothing to replace; accepted and
   // converted are settled; superseded is already retired.
-  const canRevise = can('quotes', 'write')
-    && (['sent', 'viewed', 'declined', 'expired'] as const).includes(quote.status as 'sent');
+  const canRevise = can('quotes', 'write') && isRevisable(quote.status);
   const canDelete = can('quotes', 'write') && isDraft;
   // Resend and share-link share one gate (see quoteShareLinkAvailable above,
   // which mirrors assertLinkableQuote in services/quoteLifecycle.ts).

--- a/apps/web/src/components/billing/quotes/QuoteDetail.revise.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.revise.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteDetail from './QuoteDetail';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { useOrgStore } from '../../../stores/orgStore';
+
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+const mocks = vi.hoisted(() => ({ reviseQuote: vi.fn(), cloneQuote: vi.fn(), runAction: vi.fn(), navigateTo: vi.fn() }));
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: mocks.navigateTo }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../../lib/api/quotes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/api/quotes')>();
+  return { ...actual, reviseQuote: mocks.reviseQuote, cloneQuote: mocks.cloneQuote };
+});
+vi.mock('../../../lib/runAction', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/runAction')>();
+  return { ...actual, runAction: mocks.runAction, handleActionError: vi.fn() };
+});
+
+const ORG_ID = 'aa0e43c8-1111-2222-3333-444455556666';
+
+function detailWith(
+  overrides: Partial<QuoteDetailData['quote']>,
+  detailOverrides: Partial<QuoteDetailData> = {},
+): QuoteDetailData {
+  return {
+    quote: {
+      id: 'q-1', quoteNumber: 'Q-1', partnerId: 'p-1', orgId: ORG_ID, siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+      taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+      annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '0.00',
+      billToName: 'Acme Inc.', introNotes: null, terms: null, termsAndConditions: null, sellerSnapshot: null,
+      acceptedAt: null, declinedAt: null, convertedAt: null, convertedInvoiceId: null, sentAt: null,
+      viewedAt: null, createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+      ...overrides,
+    },
+    blocks: [],
+    lines: [],
+    ...detailOverrides,
+  };
+}
+
+const initialOrgState = useOrgStore.getState();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [{ resource: 'quotes', action: 'read' }, { resource: 'quotes', action: 'write' }];
+  useOrgStore.setState({ organizations: [] });
+  mocks.runAction.mockImplementation(async ({ request }: { request: () => Promise<unknown> }) => {
+    await request();
+    return { data: { id: 'q-new' } };
+  });
+  mocks.reviseQuote.mockResolvedValue(new Response(JSON.stringify({ data: { id: 'q-new' } }), { status: 200 }));
+});
+
+afterEach(() => { useOrgStore.setState(initialOrgState, true); });
+
+describe('QuoteDetail — declined banner Revise', () => {
+  // Regression: this button used to CLONE, producing an unlinked quote and
+  // leaving the declined original live. "Revise" must mean the same thing here
+  // as it does in the actions menu — a linked revision.
+  it('creates a LINKED revision, not a clone', async () => {
+    render(<QuoteDetail detail={detailWith({ status: 'declined', declinedAt: '2026-06-05T00:00:00Z' })} onChanged={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId('quote-declined-revise'));
+
+    await waitFor(() => expect(mocks.reviseQuote).toHaveBeenCalledWith('q-1'));
+    expect(mocks.cloneQuote).not.toHaveBeenCalled();
+    expect(mocks.navigateTo).toHaveBeenCalledWith('/billing/quotes/q-new');
+  });
+});
+
+describe('QuoteDetail — lineage banner', () => {
+  it('points a superseded quote at its replacement', async () => {
+    render(<QuoteDetail
+      detail={detailWith({ status: 'superseded' }, { successor: { id: 'q-2', quoteNumber: 'Q-2', status: 'sent' } })}
+      onChanged={vi.fn()}
+    />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    expect(screen.getByTestId('quote-lineage-superseded')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-lineage-successor-link')).toHaveAttribute('href', '/billing/quotes/q-2');
+    expect(screen.getByTestId('quote-lineage-successor-link')).toHaveTextContent('Q-2');
+  });
+
+  it('warns on a live quote that a revision is being drafted against it', async () => {
+    render(<QuoteDetail
+      detail={detailWith({ status: 'sent' }, { successor: { id: 'q-2', quoteNumber: 'Q-2', status: 'draft' } })}
+      onChanged={vi.fn()}
+    />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    // The warning matters: sending that draft retires THIS quote and kills the
+    // link the customer is currently holding.
+    expect(screen.getByTestId('quote-lineage-in-progress')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-lineage-draft-link')).toHaveAttribute('href', '/billing/quotes/q-2');
+    expect(screen.queryByTestId('quote-lineage-superseded')).not.toBeInTheDocument();
+  });
+
+  it('shows the parent on a revision', async () => {
+    render(<QuoteDetail
+      detail={detailWith({ status: 'draft', revisionOfQuoteId: 'q-0', revisionNumber: 2 },
+        { revisionOf: { id: 'q-0', quoteNumber: 'Q-0', recipients: ['a@b.test'] } })}
+      onChanged={vi.fn()}
+    />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    expect(screen.getByTestId('quote-lineage-parent-link')).toHaveAttribute('href', '/billing/quotes/q-0');
+    expect(screen.getByTestId('quote-lineage-parent-link')).toHaveTextContent('Q-0');
+  });
+
+  it('renders nothing for a quote with no lineage', async () => {
+    render(<QuoteDetail detail={detailWith({ status: 'sent' })} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('quote-lineage-banner')).not.toBeInTheDocument();
+  });
+
+  // A superseded quote's successor is the replacement, never an "in progress"
+  // warning — the two branches must not both fire.
+  it('does not show the in-progress warning on an already-superseded quote', async () => {
+    render(<QuoteDetail
+      detail={detailWith({ status: 'superseded' }, { successor: { id: 'q-2', quoteNumber: 'Q-2', status: 'draft' } })}
+      onChanged={vi.fn()}
+    />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('quote-lineage-in-progress')).not.toBeInTheDocument();
+    expect(screen.getByTestId('quote-lineage-superseded')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next';
 import '../../../lib/i18n';
 import { usePermissions } from '../../../lib/permissions';
 import { useOrgStore } from '../../../stores/orgStore';
-import { quoteImageUrl, cloneQuote } from '../../../lib/api/quotes';
-import { runAction, handleActionError } from '../../../lib/runAction';
+import { quoteImageUrl } from '../../../lib/api/quotes';
+import { useReviseQuote } from './useReviseQuote';
 import { navigateTo } from '@/lib/navigation';
 import { useAuthedImage } from './useQuoteImage';
 import QuoteActions, { QuoteSendOutcomeBanners } from './QuoteActions';
@@ -114,6 +114,7 @@ export default function QuoteDetail({ detail, onChanged, actionsInHeader }: Prop
           alone are race-dependent — these survive reload/return visits. */}
       <QuoteSendOutcomeBanners quote={quote} orgName={orgName} />
       <QuoteDeclinedBanner quote={quote} canWrite={can('quotes', 'write')} />
+      <QuoteLineageBanner detail={detail} />
       {/* xl (not lg): matches the editor tab — below xl the rail stacks under the
           content so the line tables aren't starved into sideways scrolling. */}
       <div className="grid gap-6 xl:grid-cols-[1fr_300px]">
@@ -467,30 +468,15 @@ function LineTable({ lines, currency, label, testId, taxRate, showTax }: { lines
  *  audit trail of the declined quote stays intact). */
 function QuoteDeclinedBanner({ quote, canWrite }: { quote: QuoteDetailData['quote']; canWrite: boolean }) {
   const { t } = useTranslation('billing');
-  const [cloning, setCloning] = useState(false);
+  // This button used to CLONE, which produced an unlinked quote and left the
+  // declined original live — the same word meaning something different from the
+  // Revise action in the toolbar. It now creates the linked revision, which is
+  // what "revise a declined quote" actually means: sending it retires the
+  // original. (A declined quote is in the server's supersedable set.)
+  const { revise, revising: cloning } = useReviseQuote(quote.id);
   if (quote.status !== 'declined') return null;
   const reason = quote.declineReason?.trim();
 
-  const revise = async () => {
-    if (cloning) return;
-    setCloning(true);
-    try {
-      const result = await runAction<{ data: { id: string } }>({
-        request: () => cloneQuote(quote.id, {
-          orgId: quote.orgId,
-          title: t('quotes.actions.cloneDialog.defaultTitle', { name: quote.title?.trim() || quote.quoteNumber || '' }).slice(0, 200),
-        }),
-        errorFallback: t('quotes.actions.cloneError'),
-        successMessage: t('quotes.actions.cloneSuccess'),
-        onUnauthorized: () => void navigateTo('/login', { replace: true }),
-      });
-      if (result?.data?.id) void navigateTo(`/billing/quotes/${result.data.id}`);
-    } catch (err) {
-      handleActionError(err, t('quotes.actions.cloneError'));
-    } finally {
-      setCloning(false);
-    }
-  };
 
   return (
     <div className="rounded-md border border-destructive/30 bg-destructive/5 p-4" data-testid="quote-declined-banner">
@@ -518,6 +504,60 @@ function QuoteDeclinedBanner({ quote, canWrite }: { quote: QuoteDetailData['quot
           </button>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Lineage banner: where this quote sits in a revision chain.
+ *
+ * Three distinct situations, each with a different urgency, so they get
+ * different treatment rather than one generic "related quote" line:
+ *  - This quote HAS BEEN replaced (status superseded) — terminal. The customer's
+ *    link is dead; the replacement is where the conversation now lives.
+ *  - This quote IS a revision of an earlier one — orienting context.
+ *  - A revision of this quote is being DRAFTED — a warning, because sending that
+ *    draft will retire THIS quote and revoke the link the customer is holding.
+ *
+ * Links are plain in-app hrefs by id; the server already scoped `revisionOf` and
+ * `successor` to what this viewer may see (site scope), so an id present here is
+ * one they are allowed to open.
+ */
+function QuoteLineageBanner({ detail }: { detail: QuoteDetailData }) {
+  const { t } = useTranslation('billing');
+  const { quote, revisionOf, successor } = detail;
+  const supersededBy = quote.status === 'superseded' ? successor : null;
+  const pendingRevision = successor && successor.status === 'draft' && quote.status !== 'superseded'
+    ? successor
+    : null;
+  if (!supersededBy && !revisionOf && !pendingRevision) return null;
+
+  return (
+    <div className="space-y-2" data-testid="quote-lineage-banner">
+      {supersededBy && (
+        <div className="rounded-md border border-muted-foreground/30 bg-muted/40 p-4 text-sm" data-testid="quote-lineage-superseded">
+          <span className="font-medium">{t('quotes.detail.lineage.supersededTitle')}</span>{' '}
+          <a className="underline" href={`/billing/quotes/${supersededBy.id}`} data-testid="quote-lineage-successor-link">
+            {supersededBy.quoteNumber ?? t('quotes.detail.lineage.untitled')}
+          </a>
+        </div>
+      )}
+      {pendingRevision && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-4 text-sm" data-testid="quote-lineage-in-progress">
+          <span className="font-medium">{t('quotes.detail.lineage.inProgressTitle')}</span>{' '}
+          <a className="underline" href={`/billing/quotes/${pendingRevision.id}`} data-testid="quote-lineage-draft-link">
+            {pendingRevision.quoteNumber ?? t('quotes.detail.lineage.untitled')}
+          </a>
+        </div>
+      )}
+      {revisionOf && (
+        <div className="rounded-md border bg-card p-4 text-sm" data-testid="quote-lineage-parent">
+          <span className="font-medium">{t('quotes.detail.lineage.revisionOfTitle')}</span>{' '}
+          <a className="underline" href={`/billing/quotes/${revisionOf.id}`} data-testid="quote-lineage-parent-link">
+            {revisionOf.quoteNumber ?? t('quotes.detail.lineage.untitled')}
+          </a>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
@@ -88,3 +88,59 @@ describe('QuoteWorkspace tabs', () => {
     expect(screen.getByTestId('quote-workspace-status')).toHaveTextContent('Accepted');
   });
 });
+
+
+describe('QuoteWorkspace — revision banner', () => {
+  // A revision draft is indistinguishable from any other draft in the editor,
+  // and drafts open on the Editor tab — so the consequence of sending (the
+  // original is retired, the customer's existing link dies) would otherwise
+  // first appear in the send dialog.
+  const revisionDraft = {
+    ...sentQuote,
+    quote: { ...sentQuote.quote, status: 'draft', revisionOfQuoteId: 'q-0', revisionNumber: 2 },
+    revisionOf: { id: 'q-0', quoteNumber: 'Q-2026-0001', recipients: [] as string[] },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+  });
+
+  it('warns on a revision draft, naming the quote it will replace', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === '/quotes/q-1') return json({ data: revisionDraft });
+      // A draft mounts the Editor tab, whose catalog/distributor probes call
+      // .filter() on data — an object fallback surfaces as an unhandled
+      // rejection that Vitest flags as a false-positive risk.
+      return json({ data: [] });
+    });
+    render(<QuoteWorkspace id="q-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('quote-workspace-revision-banner')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-workspace-revision-banner')).toHaveTextContent('Q-2026-0001');
+  });
+
+  it('does not warn once the revision has been sent — the replacement already happened', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === '/quotes/q-1') {
+        return json({ data: { ...revisionDraft, quote: { ...revisionDraft.quote, status: 'sent' } } });
+      }
+      return json({ data: [] });
+    });
+    render(<QuoteWorkspace id="q-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('quote-workspace')).toBeInTheDocument());
+    expect(screen.queryByTestId('quote-workspace-revision-banner')).not.toBeInTheDocument();
+  });
+
+  it('does not warn on an ordinary draft', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === '/quotes/q-1') return json({ data: sentQuote });
+      return json({ data: {} });
+    });
+    render(<QuoteWorkspace id="q-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('quote-workspace')).toBeInTheDocument());
+    expect(screen.queryByTestId('quote-workspace-revision-banner')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -235,6 +235,19 @@ export default function QuoteWorkspace({ id }: Props) {
           />
         </div>
       )}
+      {/* A revision draft looks exactly like any other draft in the editor, and
+          the consequence of sending it — the original is retired and the link
+          the customer already has stops working — is invisible until the send
+          dialog. Drafts open on the Editor tab, so this rides above every tab
+          rather than living in QuoteDetail. */}
+      {detail.revisionOf && detail.quote.status === 'draft' && (
+        <div
+          className="mb-4 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm"
+          data-testid="quote-workspace-revision-banner"
+        >
+          {t('quotes.workspace.revisionBanner', { number: detail.revisionOf.quoteNumber ?? '' })}
+        </div>
+      )}
       {/* The editor stays MOUNTED across tab switches (hidden, not unmounted):
           unmounting discarded any half-typed add-line/add-section input the
           moment a tech flipped to Preview "just to check" — brutal mid-flow

--- a/apps/web/src/components/billing/quotes/quoteTypes.ts
+++ b/apps/web/src/components/billing/quotes/quoteTypes.ts
@@ -76,6 +76,12 @@ export interface ContractBlockAuthoring {
 /** A row from `GET /quotes` / the `quote` field of `GET /quotes/:id`. */
 export interface Quote {
   id: string;
+  /** Lineage: the quote this one revises, and its position in the chain.
+   *  Optional so existing fixtures and older cached payloads stay assignable;
+   *  absent/null both mean "not a revision". `revisionNumber` is 1 for an
+   *  original. */
+  revisionOfQuoteId?: string | null;
+  revisionNumber?: number;
   quoteNumber: string | null;
   /** Tech-authored display title; optional so long-standing test fixtures and
    *  older cached payloads without the column stay assignable. */
@@ -317,6 +323,17 @@ export interface QuoteDetail {
    *  tracking). Optional: older payloads and list fixtures don't carry it, and
    *  a quote nobody has ordered against yet gets an empty array. */
   orders?: QuoteOrder[];
+  /** The quote this one revises. Carries the parent's recipients so the send
+   *  composer can prefill the addresses the original actually went to — the
+   *  server falls back to them anyway when To is empty, so this is display
+   *  honesty rather than correctness. null when this quote is not a revision,
+   *  or when the parent is outside the viewer's site scope. */
+  revisionOf?: { id: string; quoteNumber: string | null; recipients: string[] } | null;
+  /** The revision that replaces this quote, if one exists. A `draft` successor
+   *  means a revision is in progress; a non-draft one means this quote has been
+   *  (or is about to be) superseded. null when none, or when the successor is
+   *  outside the viewer's site scope. */
+  successor?: { id: string; quoteNumber: string | null; status: QuoteStatus } | null;
   /** Whether the quote's partner has a connected Stripe account (gates the
    *  send composer's deposit-can't-be-paid warning). `null` = the server could
    *  not look it up (show neither note); omitted on older payloads/fixtures,

--- a/apps/web/src/components/billing/quotes/useReviseQuote.ts
+++ b/apps/web/src/components/billing/quotes/useReviseQuote.ts
@@ -1,0 +1,65 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { navigateTo } from '@/lib/navigation';
+import { runAction, handleActionError, ActionError } from '../../../lib/runAction';
+import { showToast } from '../../shared/Toast';
+import { reviseQuote } from '../../../lib/api/quotes';
+
+/**
+ * Create a linked revision draft and open it.
+ *
+ * Shared by every Revise affordance (the actions menu, the declined banner) so
+ * the word means ONE thing everywhere: a draft bound to its parent, whose send
+ * retires the original and revokes the customer's link. Before this hook the
+ * declined banner's "Revise" button cloned instead, which produced an unlinked
+ * quote that left the declined original live — same label, different outcome.
+ *
+ * The server permits only one open revision per quote and refuses a second with
+ * 409 REVISION_IN_PROGRESS + meta.revisionQuoteId. A bare 409 would strand the
+ * tech with no route to the draft blocking them, so that case opens the
+ * existing revision. An id-less 409 is not actionable and falls through to
+ * normal error handling rather than navigating to /billing/quotes/undefined.
+ */
+export function useReviseQuote(quoteId: string, opts: { onStart?: () => void } = {}) {
+  const { t } = useTranslation('billing');
+  const [revising, setRevising] = useState(false);
+  const { onStart } = opts;
+
+  const revise = useCallback(async () => {
+    if (revising) return;
+    setRevising(true);
+    onStart?.();
+    try {
+      const result = await runAction<{ data: { id: string } }>({
+        request: () => reviseQuote(quoteId),
+        errorFallback: t('quotes.actions.reviseError'),
+        successMessage: t('quotes.actions.reviseSuccess'),
+        onUnauthorized: () => void navigateTo('/login', { replace: true }),
+      });
+      if (result?.data?.id) void navigateTo(`/billing/quotes/${result.data.id}`);
+    } catch (err) {
+      const existingId = err instanceof ActionError && err.status === 409 && err.code === 'REVISION_IN_PROGRESS'
+        ? (err.body as { meta?: { revisionQuoteId?: string } } | undefined)?.meta?.revisionQuoteId
+        : undefined;
+      if (existingId) {
+        showToast({ message: t('quotes.actions.reviseInProgress'), type: 'warning' });
+        void navigateTo(`/billing/quotes/${existingId}`);
+      } else {
+        handleActionError(err, t('quotes.actions.reviseError'));
+      }
+    } finally {
+      setRevising(false);
+    }
+  }, [revising, quoteId, onStart, t]);
+
+  return { revise, revising };
+}
+
+/** Statuses the server will supersede (SUPERSEDABLE in services/quoteLifecycle.ts).
+ *  A draft has nothing to replace; accepted/converted are settled outcomes with
+ *  an invoice or contract behind them; superseded is already retired. */
+export const REVISABLE_STATUSES = ['sent', 'viewed', 'declined', 'expired'] as const;
+
+export function isRevisable(status: string): boolean {
+  return (REVISABLE_STATUSES as readonly string[]).includes(status);
+}

--- a/apps/web/src/lib/api/quotes.ts
+++ b/apps/web/src/lib/api/quotes.ts
@@ -99,6 +99,15 @@ export function cloneQuote(id: string, body?: { orgId?: string; title?: string }
   });
 }
 
+/** Create a linked draft revision of a sent quote. Unlike `cloneQuote` (which
+ *  starts an unrelated quote), the draft this returns is bound to its parent:
+ *  sending it retires the original and revokes the customer's link. Refuses
+ *  with 409 `REVISION_IN_PROGRESS` + `meta.revisionQuoteId` when one already
+ *  exists — only one open revision per quote. */
+export function reviseQuote(id: string): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}/revise`, { method: 'POST' });
+}
+
 export function updateQuote(id: string, body: UpdateQuoteInput): Promise<Response> {
   return fetchWithAuth(`/quotes/${id}`, {
     method: 'PATCH',

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -920,6 +920,11 @@
       "cloneError": "Das Angebot konnte nicht dupliziert werden.",
       "cloneQuote": "Angebot duplizieren",
       "cloneSavingTitle": "Warten Sie vor dem Duplizieren, bis die Änderungen gespeichert sind.",
+      "reviseQuote": "Angebot überarbeiten",
+      "revising": "Überarbeitung wird erstellt…",
+      "reviseSuccess": "Überarbeitung erstellt.",
+      "reviseError": "Überarbeitung konnte nicht erstellt werden.",
+      "reviseInProgress": "Eine Überarbeitung läuft bereits – sie wird geöffnet.",
       "cloneSuccess": "Angebot dupliziert.",
       "cloning": "Wird dupliziert…",
       "deleteConfirm": {

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -960,7 +960,8 @@
         "toPlaceholder": "Empfänger hinzufügen…",
         "tooManyRecipients": "Verwenden Sie höchstens {{max}} Adressen.",
         "zeroTotalWarning": "Dieses Angebot beträgt {{zero}} — prüfen Sie vor dem Senden, ob die Positionen bepreist sind.",
-        "noBillingContactHint": "Für diese Organisation ist kein Rechnungskontakt hinterlegt – geben Sie eine E-Mail-Adresse ein oder ergänzen Sie eine in den <orgLink>Organisationseinstellungen</orgLink>."
+        "noBillingContactHint": "Für diese Organisation ist kein Rechnungskontakt hinterlegt – geben Sie eine E-Mail-Adresse ein oder ergänzen Sie eine in den <orgLink>Organisationseinstellungen</orgLink>.",
+        "revisionWarning": "Durch das Senden wird {{number}} ersetzt und der bereits vorhandene Kundenlink deaktiviert."
       },
       "sendEmailWarning": {
         "noBillingContact": "Vorschlag als Gesendet markiert, aber es wurde keine E-Mail zugestellt — {{orgName}} hat keine Rechnungskontakt-E-Mail. Fügen Sie eine in den Organisationseinstellungen hinzu und senden Sie dann erneut.",
@@ -1343,7 +1344,8 @@
         "preview": "Vorschau",
         "detail": "Detailansicht"
       },
-      "loading": "Angebot wird geladen…"
+      "loading": "Angebot wird geladen…",
+      "revisionBanner": "Dies ist eine Überarbeitung von {{number}}. Beim Senden wird das Original ersetzt und der bereits vorhandene Kundenlink deaktiviert."
     }
   },
   "billingUi": {

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -1124,6 +1124,12 @@
         "reasonLabel": "Anmerkung des Kunden:",
         "revise": "Duplizieren & überarbeiten",
         "revising": "Wird dupliziert…"
+      },
+      "lineage": {
+        "supersededTitle": "Dieses Angebot wurde ersetzt durch",
+        "inProgressTitle": "Eine Überarbeitung dieses Angebots wird erstellt – beim Senden wird dieses Angebot ersetzt und der Kundenlink deaktiviert:",
+        "revisionOfTitle": "Überarbeitung von",
+        "untitled": "eine neuere Version"
       }
     },
     "distributorLookup": {

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -920,6 +920,11 @@
       "cloneError": "Could not clone the quote.",
       "cloneQuote": "Clone quote",
       "cloneSavingTitle": "Wait for changes to finish saving before cloning.",
+      "reviseQuote": "Revise quote",
+      "revising": "Creating revision…",
+      "reviseSuccess": "Revision created.",
+      "reviseError": "Could not create a revision.",
+      "reviseInProgress": "A revision is already in progress — opening it.",
       "cloneSuccess": "Quote cloned.",
       "cloning": "Cloning…",
       "deleteConfirm": {

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -1124,6 +1124,12 @@
         "reasonLabel": "Customer's note:",
         "revise": "Duplicate & revise",
         "revising": "Duplicating…"
+      },
+      "lineage": {
+        "supersededTitle": "This quote was replaced by",
+        "inProgressTitle": "A revision of this quote is being drafted — sending it will replace this quote and disable the customer’s link:",
+        "revisionOfTitle": "Revision of",
+        "untitled": "a newer version"
       }
     },
     "distributorLookup": {

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -960,7 +960,8 @@
         "toPlaceholder": "Add recipient…",
         "tooManyRecipients": "Use at most {{max}} addresses.",
         "zeroTotalWarning": "This quote totals {{zero}} — check that its items are priced before sending.",
-        "noBillingContactHint": "No billing contact is saved for this organization — enter an email, or add one in the <orgLink>organization settings</orgLink>."
+        "noBillingContactHint": "No billing contact is saved for this organization — enter an email, or add one in the <orgLink>organization settings</orgLink>.",
+        "revisionWarning": "Sending this replaces {{number}} and disables the link the customer already has."
       },
       "sendEmailWarning": {
         "noBillingContact": "Proposal marked Sent, but no email was delivered — {{orgName}} has no billing contact email. Add one in the organization settings, then resend.",
@@ -1343,7 +1344,8 @@
         "preview": "Preview",
         "detail": "Details"
       },
-      "loading": "Loading quote…"
+      "loading": "Loading quote…",
+      "revisionBanner": "This is a revision of {{number}}. Sending it will replace the original and disable the link the customer already has."
     }
   },
   "billingUi": {

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -960,7 +960,8 @@
         "toPlaceholder": "Agregar destinatario…",
         "tooManyRecipients": "Usa como máximo {{max}} direcciones.",
         "zeroTotalWarning": "Esta cotización totaliza {{zero}} — verifica que sus ítems tengan precio antes de enviar.",
-        "noBillingContactHint": "Esta organización no tiene un contacto de facturación guardado: ingresa un correo o agrega uno en la <orgLink>configuración de la organización</orgLink>."
+        "noBillingContactHint": "Esta organización no tiene un contacto de facturación guardado: ingresa un correo o agrega uno en la <orgLink>configuración de la organización</orgLink>.",
+        "revisionWarning": "Al enviarla se reemplazará {{number}} y se desactivará el enlace que el cliente ya tiene."
       },
       "sendEmailWarning": {
         "noBillingContact": "La propuesta se marcó como Enviada, pero no se entregó ningún correo — {{orgName}} no tiene correo de contacto de facturación. Agregue uno en la configuración de la organización y vuelva a enviar.",
@@ -1343,7 +1344,8 @@
         "preview": "Vista previa",
         "detail": "Detalles"
       },
-      "loading": "Cargando cotización…"
+      "loading": "Cargando cotización…",
+      "revisionBanner": "Esta es una revisión de {{number}}. Al enviarla se reemplazará el original y se desactivará el enlace que el cliente ya tiene."
     }
   },
   "billingUi": {

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -920,6 +920,11 @@
       "cloneError": "No se pudo clonar la cotización.",
       "cloneQuote": "Clonar cotización",
       "cloneSavingTitle": "Espere a que se guarden los cambios antes de clonar.",
+      "reviseQuote": "Revisar cotización",
+      "revising": "Creando revisión…",
+      "reviseSuccess": "Revisión creada.",
+      "reviseError": "No se pudo crear una revisión.",
+      "reviseInProgress": "Ya hay una revisión en curso: se abrirá.",
       "cloneSuccess": "Cotización clonada.",
       "cloning": "Clonando…",
       "deleteConfirm": {

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -1124,6 +1124,12 @@
         "reasonLabel": "Nota del cliente:",
         "revise": "Duplicar y revisar",
         "revising": "Duplicando…"
+      },
+      "lineage": {
+        "supersededTitle": "Esta cotización fue reemplazada por",
+        "inProgressTitle": "Se está preparando una revisión de esta cotización: al enviarla se reemplazará esta cotización y se desactivará el enlace del cliente:",
+        "revisionOfTitle": "Revisión de",
+        "untitled": "una versión más reciente"
       }
     },
     "distributorLookup": {

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -1124,6 +1124,12 @@
         "reasonLabel": "Note du client :",
         "revise": "Dupliquer et réviser",
         "revising": "Duplication…"
+      },
+      "lineage": {
+        "supersededTitle": "Cette soumission a été remplacée par",
+        "inProgressTitle": "Une révision de cette soumission est en préparation — l'envoyer remplacera cette soumission et désactivera le lien du client :",
+        "revisionOfTitle": "Révision de",
+        "untitled": "une version plus récente"
       }
     },
     "distributorLookup": {

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -960,7 +960,8 @@
         "toPlaceholder": "Ajouter un destinataire…",
         "tooManyRecipients": "Utilisez au maximum {{max}} adresses.",
         "zeroTotalWarning": "Ce devis totalise {{zero}} — vérifiez que ses lignes sont tarifées avant l'envoi.",
-        "noBillingContactHint": "Aucun contact de facturation n'est enregistré pour cette organisation — saisissez une adresse courriel ou ajoutez-en une dans les <orgLink>paramètres de l'organisation</orgLink>."
+        "noBillingContactHint": "Aucun contact de facturation n'est enregistré pour cette organisation — saisissez une adresse courriel ou ajoutez-en une dans les <orgLink>paramètres de l'organisation</orgLink>.",
+        "revisionWarning": "L’envoi remplace {{number}} et désactive le lien que le client possède déjà."
       },
       "sendEmailWarning": {
         "noBillingContact": "Proposition marquée comme Envoyée, mais aucun courriel n'a été remis — {{orgName}} n'a pas d'adresse courriel de contact de facturation. Ajoutez-en une dans les paramètres de l'organisation, puis renvoyez.",
@@ -1343,7 +1344,8 @@
         "preview": "Aperçu",
         "detail": "Détail"
       },
-      "loading": "Chargement du devis…"
+      "loading": "Chargement du devis…",
+      "revisionBanner": "Il s’agit d’une révision de {{number}}. L’envoyer remplacera l’original et désactivera le lien que le client possède déjà."
     }
   },
   "billingUi": {

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -920,6 +920,11 @@
       "cloneError": "Impossible de dupliquer le devis.",
       "cloneQuote": "Dupliquer le devis",
       "cloneSavingTitle": "Attendez la fin de l'enregistrement avant de dupliquer.",
+      "reviseQuote": "Réviser la soumission",
+      "revising": "Création de la révision…",
+      "reviseSuccess": "Révision créée.",
+      "reviseError": "Impossible de créer une révision.",
+      "reviseInProgress": "Une révision est déjà en cours — ouverture.",
       "cloneSuccess": "Devis dupliqué.",
       "cloning": "Duplication…",
       "deleteConfirm": {

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -960,7 +960,8 @@
         "toPlaceholder": "Ajouter un destinataire…",
         "tooManyRecipients": "Utilisez au maximum {{max}} adresses.",
         "zeroTotalWarning": "Ce devis totalise {{zero}} — vérifiez que ses lignes sont tarifées avant l'envoi.",
-        "noBillingContactHint": "Aucun contact de facturation n'est enregistré pour cette organisation — saisissez un e-mail ou ajoutez-en un dans les <orgLink>paramètres de l'organisation</orgLink>."
+        "noBillingContactHint": "Aucun contact de facturation n'est enregistré pour cette organisation — saisissez un e-mail ou ajoutez-en un dans les <orgLink>paramètres de l'organisation</orgLink>.",
+        "revisionWarning": "L’envoi remplace {{number}} et désactive le lien que le client possède déjà."
       },
       "sendEmailWarning": {
         "noBillingContact": "Proposition marquée comme Envoyée, mais aucun e-mail n'a été remis — {{orgName}} n'a pas d'adresse e-mail de contact de facturation. Ajoutez-en une dans les paramètres de l'organisation, puis renvoyez.",
@@ -1343,7 +1344,8 @@
         "preview": "Aperçu",
         "detail": "Détails"
       },
-      "loading": "Chargement du devis…"
+      "loading": "Chargement du devis…",
+      "revisionBanner": "Il s’agit d’une révision de {{number}}. L’envoyer remplacera l’original et désactivera le lien que le client possède déjà."
     }
   },
   "billingUi": {

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -920,6 +920,11 @@
       "cloneError": "Impossible de dupliquer le devis.",
       "cloneQuote": "Dupliquer le devis",
       "cloneSavingTitle": "Attendez la fin de l'enregistrement avant de dupliquer.",
+      "reviseQuote": "Réviser le devis",
+      "revising": "Création de la révision…",
+      "reviseSuccess": "Révision créée.",
+      "reviseError": "Impossible de créer une révision.",
+      "reviseInProgress": "Une révision est déjà en cours — ouverture.",
       "cloneSuccess": "Devis dupliqué.",
       "cloning": "Duplication…",
       "deleteConfirm": {

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -1124,6 +1124,12 @@
         "reasonLabel": "Note du client :",
         "revise": "Dupliquer et réviser",
         "revising": "Duplication…"
+      },
+      "lineage": {
+        "supersededTitle": "Ce devis a été remplacé par",
+        "inProgressTitle": "Une révision de ce devis est en préparation — l'envoyer remplacera ce devis et désactivera le lien du client :",
+        "revisionOfTitle": "Révision de",
+        "untitled": "une version plus récente"
       }
     },
     "distributorLookup": {

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -960,7 +960,8 @@
         "toPlaceholder": "Aggiungi destinatario…",
         "tooManyRecipients": "Usa al massimo {{max}} indirizzi.",
         "zeroTotalWarning": "Il totale di questo preventivo è {{zero}}: verifica che gli elementi abbiano un prezzo prima dell'invio.",
-        "noBillingContactHint": "Nessun contatto di fatturazione è salvato per questa organizzazione — inserisci un'email oppure aggiungine uno nelle <orgLink>impostazioni dell'organizzazione</orgLink>."
+        "noBillingContactHint": "Nessun contatto di fatturazione è salvato per questa organizzazione — inserisci un'email oppure aggiungine uno nelle <orgLink>impostazioni dell'organizzazione</orgLink>.",
+        "revisionWarning": "L’invio sostituisce {{number}} e disattiva il link che il cliente possiede già."
       },
       "sendEmailWarning": {
         "noBillingContact": "Proposta contrassegnata come Inviata, ma nessuna email è stata consegnata: {{orgName}} non ha un'email di contatto per la fatturazione. Aggiungine una nelle impostazioni dell'organizzazione, poi invia di nuovo.",
@@ -1343,7 +1344,8 @@
         "preview": "Anteprima",
         "detail": "Dettaglio"
       },
-      "loading": "Caricamento del preventivo…"
+      "loading": "Caricamento del preventivo…",
+      "revisionBanner": "Questa è una revisione di {{number}}. Inviarla sostituirà l’originale e disattiverà il link che il cliente possiede già."
     }
   },
   "billingUi": {

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -1124,6 +1124,12 @@
         "reasonLabel": "Nota del cliente:",
         "revise": "Duplica e rivedi",
         "revising": "Duplicazione…"
+      },
+      "lineage": {
+        "supersededTitle": "Questo preventivo è stato sostituito da",
+        "inProgressTitle": "È in preparazione una revisione di questo preventivo: inviarla sostituirà questo preventivo e disattiverà il link del cliente:",
+        "revisionOfTitle": "Revisione di",
+        "untitled": "una versione più recente"
       }
     },
     "distributorLookup": {

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -920,6 +920,11 @@
       "cloneError": "Impossibile clonare il preventivo.",
       "cloneQuote": "Clona preventivo",
       "cloneSavingTitle": "Attendi il salvataggio delle modifiche prima di clonare.",
+      "reviseQuote": "Rivedi preventivo",
+      "revising": "Creazione revisione…",
+      "reviseSuccess": "Revisione creata.",
+      "reviseError": "Impossibile creare una revisione.",
+      "reviseInProgress": "Una revisione è già in corso: verrà aperta.",
       "cloneSuccess": "Preventivo clonato.",
       "cloning": "Clonazione…",
       "deleteConfirm": {

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -1124,6 +1124,12 @@
         "reasonLabel": "Observação do cliente:",
         "revise": "Duplicar e revisar",
         "revising": "Duplicando…"
+      },
+      "lineage": {
+        "supersededTitle": "Este orçamento foi substituído por",
+        "inProgressTitle": "Uma revisão deste orçamento está sendo preparada — enviá-la substituirá este orçamento e desativará o link do cliente:",
+        "revisionOfTitle": "Revisão de",
+        "untitled": "uma versão mais recente"
       }
     },
     "distributorLookup": {

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -960,7 +960,8 @@
         "toPlaceholder": "Adicionar destinatário…",
         "tooManyRecipients": "Use no máximo {{max}} endereços.",
         "zeroTotalWarning": "Este orçamento totaliza {{zero}} — verifique se os itens têm preço antes de enviar.",
-        "noBillingContactHint": "Esta organização não tem um contato de cobrança salvo — digite um e-mail ou adicione um nas <orgLink>configurações da organização</orgLink>."
+        "noBillingContactHint": "Esta organização não tem um contato de cobrança salvo — digite um e-mail ou adicione um nas <orgLink>configurações da organização</orgLink>.",
+        "revisionWarning": "Enviar substitui {{number}} e desativa o link que o cliente já possui."
       },
       "sendEmailWarning": {
         "noBillingContact": "Proposta marcada como Enviada, mas nenhum e-mail foi entregue — {{orgName}} não tem e-mail de contato de cobrança. Adicione um nas configurações da organização e envie novamente.",
@@ -1333,7 +1334,8 @@
         "preview": "Visualização",
         "detail": "Detalhes"
       },
-      "loading": "Carregando orçamento…"
+      "loading": "Carregando orçamento…",
+      "revisionBanner": "Esta é uma revisão de {{number}}. Enviá-la substituirá o original e desativará o link que o cliente já possui."
     },
     "status": {
       "draft": "Rascunho",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -920,6 +920,11 @@
       "cloneError": "Não foi possível clonar a cotação.",
       "cloneQuote": "Clonar cotação",
       "cloneSavingTitle": "Aguarde até que as alterações sejam salvas antes de clonar.",
+      "reviseQuote": "Revisar orçamento",
+      "revising": "Criando revisão…",
+      "reviseSuccess": "Revisão criada.",
+      "reviseError": "Não foi possível criar uma revisão.",
+      "reviseInProgress": "Já há uma revisão em andamento — abrindo.",
       "cloneSuccess": "Cotação clonada.",
       "cloning": "Clonando…",
       "deleteConfirm": {

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -1124,6 +1124,12 @@
         "reasonLabel": "Müşterinin notu:",
         "revise": "Çoğalt ve gözden geçir",
         "revising": "Çoğaltılıyor…"
+      },
+      "lineage": {
+        "supersededTitle": "Bu teklifin yerini alan",
+        "inProgressTitle": "Bu teklifin bir revizyonu hazırlanıyor — gönderildiğinde bu teklifin yerini alacak ve müşteri bağlantısını devre dışı bırakacak:",
+        "revisionOfTitle": "Şu teklifin revizyonu:",
+        "untitled": "daha yeni bir sürüm"
       }
     },
     "distributorLookup": {

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -960,7 +960,8 @@
         "toPlaceholder": "Alıcı ekle…",
         "tooManyRecipients": "En fazla {{max}} adresi kullanın.",
         "zeroTotalWarning": "Bu fiyat teklifinin toplamı {{zero}} — göndermeden önce öğelerinin fiyatlandırıldığını kontrol edin.",
-        "noBillingContactHint": "Bu kuruluş için kayıtlı fatura iletişim kişisi yok — bir e-posta girin veya <orgLink>kuruluş ayarları</orgLink>'e bir e-posta ekleyin."
+        "noBillingContactHint": "Bu kuruluş için kayıtlı fatura iletişim kişisi yok — bir e-posta girin veya <orgLink>kuruluş ayarları</orgLink>'e bir e-posta ekleyin.",
+        "revisionWarning": "Bunu göndermek {{number}} teklifinin yerini alır ve müşterinin mevcut bağlantısını devre dışı bırakır."
       },
       "sendEmailWarning": {
         "noBillingContact": "Teklif Gönderildi olarak işaretlendi ancak e-posta teslim edilmedi — {{orgName}}'de fatura iletişim e-postası yok. Kuruluş ayarlarına bir tane ekleyin ve yeniden gönderin.",
@@ -1343,7 +1344,8 @@
         "preview": "Önizleme",
         "detail": "Ayrıntılar"
       },
-      "loading": "Teklif yükleniyor…"
+      "loading": "Teklif yükleniyor…",
+      "revisionBanner": "Bu, {{number}} teklifinin bir revizyonudur. Gönderildiğinde orijinalin yerini alır ve müşterinin mevcut bağlantısını devre dışı bırakır."
     }
   },
   "billingUi": {

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -920,6 +920,11 @@
       "cloneError": "Alıntı kopyalanamadı.",
       "cloneQuote": "Klon alıntısı",
       "cloneSavingTitle": "Klonlamadan önce değişikliklerin kaydedilmesinin tamamlanmasını bekleyin.",
+      "reviseQuote": "Teklifi revize et",
+      "revising": "Revizyon oluşturuluyor…",
+      "reviseSuccess": "Revizyon oluşturuldu.",
+      "reviseError": "Revizyon oluşturulamadı.",
+      "reviseInProgress": "Zaten devam eden bir revizyon var — açılıyor.",
       "cloneSuccess": "Alıntı kopyalandı.",
       "cloning": "Klonlanıyor…",
       "deleteConfirm": {


### PR DESCRIPTION
Closes #3801

**Stacked on #3875 (W04), which is stacked on #3873 (W03).** Base is the W04 branch so the diff is W05 only. Rebase down as the stack merges.

Completes the feature's UI: the tech-facing Revise flow, the lineage banners, and what the customer sees when their proposal has been replaced.

## One meaning for "Revise"

`QuoteDetail`'s declined banner already shipped a button labelled **Revise** that called `cloneQuote` — producing an *unlinked* quote and leaving the declined original live. Adding a real Revise to the actions menu would have made the same word mean two different things on the same quote.

Both now go through `useReviseQuote`. The declined path gets the behaviour its label always implied: a declined quote is in the server's supersedable set, so revising it creates a linked draft whose send retires the original.

That button had **zero test coverage**, so nothing failed when its behaviour changed. It is now pinned — the test asserts `reviseQuote` was called *and* `cloneQuote` was not.

Gating mirrors the server's `SUPERSEDABLE` exactly (sent/viewed/declined/expired). The server permits only one open revision and refuses a second with `409 REVISION_IN_PROGRESS` + `meta.revisionQuoteId`; a bare 409 would strand the tech with no route to the draft blocking them, so that branch opens the existing revision. An id-less 409 navigates nowhere rather than to `/billing/quotes/undefined`.

## Telling people what a revision send costs

Sending a revision revokes the link the customer is holding, and it can't be undone. Two places said nothing:

- **Send composer** — warning naming the quote being replaced. First send only; a re-send reuses the same link, so the warning would be false there.
- **Workspace banner** — a revision draft looks like any other draft, and drafts open on the Editor tab, so the consequence first appeared in the send dialog, after the work was done.

The composer also prefills To with the addresses the original went to. The server already falls back to the parent's recipients, so this is display honesty rather than correctness.

## Lineage banners

Three situations with genuinely different urgency, rendered differently rather than as one generic "related quote" line: **superseded** (terminal — where the conversation moved), **a revision is being drafted against this live quote** (amber warning — sending it kills the customer's current link), and **this quote is a revision** (neutral context). The first two are mutually exclusive.

## Portal

A replaced proposal is **not a broken link**. Telling the customer their link is "invalid or expired" sends them back to the MSP for a fix already sitting in their inbox — so the superseded branch is checked *before* the generic fallback and names the partner to contact. It renders no pricing, no accept/decline, and **no link to the successor**: the withdrawn prices must not leak, and the successor's id is not ours to hand out on a link we just revoked.

This also closes the raw-enum leak flagged in the W03 review: both portal status maps lacked `superseded`, so `?? status` rendered the literal string **"superseded"** to customers.

The API client needed a change to make the branded notice possible — on a non-2xx it kept only `error`/`code` and dropped the body's `data`. Added `errorData` rather than populating `data`, so presence of `data` still means the request succeeded and no existing caller changes meaning.

## Verification

Every new behaviour is mutation-verified — the status gate, the id-less 409 branch, the two lineage branches, the declined-banner rewire, the composer warning, the prefill, and the workspace draft condition each fail a named test when broken.

Three harness problems were caught by verifying rather than by a red test, and are worth knowing about:

- The composer tests first "passed" against a fixture with no customer-visible line, so Send was disabled and the click did nothing — the tests looked like they exercised the composer and exercised nothing.
- The suite went green with **4 unhandled Vitest errors** (a missing `useAuthStore` in my auth mock, and an Editor-tab catalog probe calling `.filter()` on an object fixture). Vitest flags these as capable of producing false positives; both are fixed, and the suite now reports zero.
- The portal's base-path contract test caught a hardcoded `/portal/quotes/...` href where `withBase()` already supplies the prefix — it would have doubled.

Locale keys added to all eight locales with real translations, so no `translationCoverage` baseline bumps were needed. All 118 i18n tests pass.

Typecheck clean for web and portal; **6,198** web and **255** portal tests pass. CI dispatched manually — a PR based on a sibling branch triggers none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)