### PR TITLE
feat(api): per-partner LLM BYOK wave 1 — partner_llm_configs, fail-loud resolver, /ai/provider routes

### DIFF
--- a/apps/api/migrations/2026-09-04-partner-llm-configs.sql
+++ b/apps/api/migrations/2026-09-04-partner-llm-configs.sql
@@ -1,0 +1,77 @@
+CREATE TABLE IF NOT EXISTS partner_llm_configs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id uuid NOT NULL REFERENCES partners(id) ON DELETE CASCADE,
+  provider text NOT NULL DEFAULT 'anthropic',
+  api_key_encrypted text NOT NULL,
+  key_last4 text NOT NULL,
+  key_fingerprint text NOT NULL,
+  base_url text,
+  default_model text,
+  status text NOT NULL DEFAULT 'active',
+  config_version integer NOT NULL DEFAULT 1,
+  last_error text,
+  verified_at timestamptz,
+  connected_by uuid REFERENCES users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT partner_llm_configs_provider_chk CHECK (provider = 'anthropic'),
+  CONSTRAINT partner_llm_configs_base_url_chk CHECK (base_url IS NULL),
+  CONSTRAINT partner_llm_configs_status_chk CHECK (status IN ('active', 'error'))
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'partner_llm_configs_provider_chk'
+      AND conrelid = 'partner_llm_configs'::regclass
+  ) THEN
+    ALTER TABLE partner_llm_configs
+      ADD CONSTRAINT partner_llm_configs_provider_chk CHECK (provider = 'anthropic');
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'partner_llm_configs_base_url_chk'
+      AND conrelid = 'partner_llm_configs'::regclass
+  ) THEN
+    ALTER TABLE partner_llm_configs
+      ADD CONSTRAINT partner_llm_configs_base_url_chk CHECK (base_url IS NULL);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'partner_llm_configs_status_chk'
+      AND conrelid = 'partner_llm_configs'::regclass
+  ) THEN
+    ALTER TABLE partner_llm_configs
+      ADD CONSTRAINT partner_llm_configs_status_chk CHECK (status IN ('active', 'error'));
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS partner_llm_configs_partner_uq
+  ON partner_llm_configs(partner_id);
+
+ALTER TABLE partner_llm_configs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE partner_llm_configs FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'partner_llm_configs'
+      AND policyname = 'partner_llm_configs_partner_access'
+  ) THEN
+    CREATE POLICY partner_llm_configs_partner_access ON partner_llm_configs
+      FOR ALL TO breeze_app
+      USING (
+        public.breeze_current_scope() = 'system'
+        OR public.breeze_has_partner_access(partner_id)
+      )
+      WITH CHECK (
+        public.breeze_current_scope() = 'system'
+        OR public.breeze_has_partner_access(partner_id)
+      );
+  END IF;
+END $$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON partner_llm_configs TO breeze_app;

--- a/apps/api/src/__tests__/integration/partnerLlmConfigsPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerLlmConfigsPartnerRls.integration.test.ts
@@ -1,0 +1,121 @@
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import { partnerLlmConfigs } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function partnerContext(partnerId: string): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: [],
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const configValues = {
+  apiKeyEncrypted: 'enc:test-key',
+  keyLast4: 'test',
+  keyFingerprint: 'test-fingerprint',
+};
+
+describe('partner_llm_configs partner-axis RLS', () => {
+  runDb('rejects a forged cross-partner INSERT with 42501', async () => {
+    const [partnerA, partnerB] = await withSystemDbAccessContext(async () => [
+      await createPartner(),
+      await createPartner(),
+    ]);
+
+    await expect(
+      withDbAccessContext(partnerContext(partnerA.id), () =>
+        db.insert(partnerLlmConfigs).values({
+          partnerId: partnerB.id,
+          ...configValues,
+        }),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  runDb('partner A cannot SELECT partner B config', async () => {
+    const [partnerA, partnerB] = await withSystemDbAccessContext(async () => [
+      await createPartner(),
+      await createPartner(),
+    ]);
+    const [configB] = await withSystemDbAccessContext(() =>
+      db
+        .insert(partnerLlmConfigs)
+        .values({ partnerId: partnerB.id, ...configValues })
+        .returning({ id: partnerLlmConfigs.id }),
+    );
+
+    const visible = await withDbAccessContext(partnerContext(partnerA.id), () =>
+      db
+        .select({ id: partnerLlmConfigs.id })
+        .from(partnerLlmConfigs)
+        .where(eq(partnerLlmConfigs.id, configB!.id)),
+    );
+
+    expect(visible).toEqual([]);
+  });
+
+  runDb('org-scoped context cannot read partner config rows', async () => {
+    const { partner, org } = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      return { partner, org };
+    });
+    const [config] = await withSystemDbAccessContext(() =>
+      db
+        .insert(partnerLlmConfigs)
+        .values({ partnerId: partner.id, ...configValues })
+        .returning({ id: partnerLlmConfigs.id }),
+    );
+
+    const visible = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: partnerLlmConfigs.id })
+        .from(partnerLlmConfigs)
+        .where(eq(partnerLlmConfigs.id, config!.id)),
+    );
+
+    expect(visible).toEqual([]);
+  });
+
+  runDb('system context can write and read config rows', async () => {
+    const partner = await withSystemDbAccessContext(() => createPartner());
+    const [inserted] = await withSystemDbAccessContext(() =>
+      db
+        .insert(partnerLlmConfigs)
+        .values({ partnerId: partner.id, ...configValues })
+        .returning({ id: partnerLlmConfigs.id }),
+    );
+
+    const visible = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: partnerLlmConfigs.id })
+        .from(partnerLlmConfigs)
+        .where(eq(partnerLlmConfigs.id, inserted!.id)),
+    );
+
+    expect(visible).toEqual([{ id: inserted!.id }]);
+  });
+});

--- a/apps/api/src/__tests__/integration/partnerLlmConfigsPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerLlmConfigsPartnerRls.integration.test.ts
@@ -100,6 +100,41 @@ describe('partner_llm_configs partner-axis RLS', () => {
     expect(visible).toEqual([]);
   });
 
+  runDb('partner scope can SELECT, UPDATE, and DELETE its own config row', async () => {
+    const partner = await withSystemDbAccessContext(() => createPartner());
+    const [inserted] = await withSystemDbAccessContext(() =>
+      db
+        .insert(partnerLlmConfigs)
+        .values({ partnerId: partner.id, ...configValues })
+        .returning({ id: partnerLlmConfigs.id }),
+    );
+
+    const visible = await withDbAccessContext(partnerContext(partner.id), () =>
+      db
+        .select({ id: partnerLlmConfigs.id })
+        .from(partnerLlmConfigs)
+        .where(eq(partnerLlmConfigs.id, inserted!.id)),
+    );
+    expect(visible).toEqual([{ id: inserted!.id }]);
+
+    const updated = await withDbAccessContext(partnerContext(partner.id), () =>
+      db
+        .update(partnerLlmConfigs)
+        .set({ defaultModel: 'claude-haiku-4-5' })
+        .where(eq(partnerLlmConfigs.id, inserted!.id))
+        .returning({ id: partnerLlmConfigs.id, defaultModel: partnerLlmConfigs.defaultModel }),
+    );
+    expect(updated).toEqual([{ id: inserted!.id, defaultModel: 'claude-haiku-4-5' }]);
+
+    const deleted = await withDbAccessContext(partnerContext(partner.id), () =>
+      db
+        .delete(partnerLlmConfigs)
+        .where(eq(partnerLlmConfigs.id, inserted!.id))
+        .returning({ id: partnerLlmConfigs.id }),
+    );
+    expect(deleted).toEqual([{ id: inserted!.id }]);
+  });
+
   runDb('system context can write and read config rows', async () => {
     const partner = await withSystemDbAccessContext(() => createPartner());
     const [inserted] = await withSystemDbAccessContext(() =>

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -241,6 +241,7 @@ const PARTNER_TENANT_TABLES: ReadonlyMap<string, string> = new Map<string, strin
   // auto-discovered as an ordinary shape-1 org-tenant table — not listed here.
   // Functional cross-partner forge proof: stripe-payments-rls.integration.test.ts.
   ['stripe_connect_accounts', 'partner_id'],
+  ['partner_llm_configs', 'partner_id'],
   // authenticator_policies: per-MSP approval-security policy (Shape 3). One row
   // per partner; policy gates on breeze_has_partner_access(partner_id) with a
   // system-scope OR branch. Functional forge: authenticatorRls.integration.test.ts.

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -101,6 +101,7 @@ export * from './catalog';
 export * from './timeTracking';
 export * from './invoices';
 export * from './stripePayments';
+export * from './partnerLlmConfigs';
 export * from './invoiceDocuments';
 export * from './contracts';
 export * from './quotes';

--- a/apps/api/src/db/schema/partnerLlmConfigs.ts
+++ b/apps/api/src/db/schema/partnerLlmConfigs.ts
@@ -1,0 +1,37 @@
+import { sql } from 'drizzle-orm';
+import {
+  check,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import { partners } from './orgs';
+import { users } from './users';
+
+export const partnerLlmConfigs = pgTable('partner_llm_configs', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  partnerId: uuid('partner_id')
+    .notNull()
+    .references(() => partners.id, { onDelete: 'cascade' }),
+  provider: text('provider').notNull().default('anthropic'),
+  apiKeyEncrypted: text('api_key_encrypted').notNull(),
+  keyLast4: text('key_last4').notNull(),
+  keyFingerprint: text('key_fingerprint').notNull(),
+  baseUrl: text('base_url'),
+  defaultModel: text('default_model'),
+  status: text('status').notNull().default('active'),
+  configVersion: integer('config_version').notNull().default(1),
+  lastError: text('last_error'),
+  verifiedAt: timestamp('verified_at', { withTimezone: true }),
+  connectedBy: uuid('connected_by').references(() => users.id, { onDelete: 'set null' }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (table) => [
+  uniqueIndex('partner_llm_configs_partner_uq').on(table.partnerId),
+  check('partner_llm_configs_provider_chk', sql`${table.provider} = 'anthropic'`),
+  check('partner_llm_configs_base_url_chk', sql`${table.baseUrl} IS NULL`),
+  check('partner_llm_configs_status_chk', sql`${table.status} IN ('active', 'error')`),
+]);

--- a/apps/api/src/db/schema/partnerLlmConfigs.ts
+++ b/apps/api/src/db/schema/partnerLlmConfigs.ts
@@ -16,13 +16,13 @@ export const partnerLlmConfigs = pgTable('partner_llm_configs', {
   partnerId: uuid('partner_id')
     .notNull()
     .references(() => partners.id, { onDelete: 'cascade' }),
-  provider: text('provider').notNull().default('anthropic'),
+  provider: text('provider', { enum: ['anthropic'] }).notNull().default('anthropic'),
   apiKeyEncrypted: text('api_key_encrypted').notNull(),
   keyLast4: text('key_last4').notNull(),
   keyFingerprint: text('key_fingerprint').notNull(),
   baseUrl: text('base_url'),
   defaultModel: text('default_model'),
-  status: text('status').notNull().default('active'),
+  status: text('status', { enum: ['active', 'error'] }).notNull().default('active'),
   configVersion: integer('config_version').notNull().default(1),
   lastError: text('last_error'),
   verifiedAt: timestamp('verified_at', { withTimezone: true }),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -130,6 +130,7 @@ import { tunnelRoutes, vncExchangeRoutes, vncViewerRoutes } from './routes/tunne
 import { agentVersionRoutes } from './routes/agentVersions';
 import { viewerRoutes } from './routes/viewers';
 import { aiRoutes } from './routes/ai';
+import { aiProviderRoutes } from './routes/aiProvider';
 import { aiAgentsRoutes } from './routes/aiAgents';
 import { scriptAiRoutes } from './routes/scriptAi';
 import { mcpServerRoutes, initMcpBootstrapForStartup } from './routes/mcpServer';
@@ -1133,6 +1134,7 @@ api.route('/metrics', metricsRoutes);
 api.route('/agent-ws', createAgentWsRoutes(upgradeWebSocket));
 api.route('/agent-versions', agentVersionRoutes);
 api.route('/viewers', viewerRoutes);
+api.route('/ai/provider', aiProviderRoutes);
 api.route('/ai/agents', aiAgentsRoutes);
 api.route('/ai', aiRoutes);
 api.route('/ai/script-builder', scriptAiRoutes);

--- a/apps/api/src/routes/aiProvider.test.ts
+++ b/apps/api/src/routes/aiProvider.test.ts
@@ -64,6 +64,7 @@ vi.mock('../services/partnerLlmConfig', () => {
 });
 
 import { aiProviderRoutes } from './aiProvider';
+import { requirePermission } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { captureException } from '../services/sentry';
 import {
@@ -84,7 +85,12 @@ function postKey(apiKey = 'sk-ant-api03-route-test-key-1234567890') {
 
 describe('AI provider routes', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    captureExceptionMock.mockClear();
+    vi.mocked(writeRouteAudit).mockClear();
+    vi.mocked(getPartnerLlmStatus).mockClear();
+    vi.mocked(savePartnerLlmKey).mockClear();
+    vi.mocked(updatePartnerLlmConfig).mockClear();
+    vi.mocked(deletePartnerLlmConfig).mockClear();
     authGates.permissionDenied = false;
     authGates.mfaDenied = false;
     authState.value = {
@@ -175,6 +181,34 @@ describe('AI provider routes', () => {
     expect(deletePartnerLlmConfig).not.toHaveBeenCalled();
   });
 
+  it.each(handlerRequests)('%s stops at the billing permission gate before calling the service', async (_name, request) => {
+    authGates.permissionDenied = true;
+
+    const response = await request();
+
+    expect(response.status).toBe(403);
+    expect(getPartnerLlmStatus).not.toHaveBeenCalled();
+    expect(savePartnerLlmKey).not.toHaveBeenCalled();
+    expect(updatePartnerLlmConfig).not.toHaveBeenCalled();
+    expect(deletePartnerLlmConfig).not.toHaveBeenCalled();
+  });
+
+  it('registers every handler with the billing manage permission', async () => {
+    expect(requirePermission).toHaveBeenCalledTimes(4);
+    expect(requirePermission).toHaveBeenCalledWith('billing', 'manage');
+  });
+
+  it('GET / uses read-specific copy when full partner org access is missing', async () => {
+    authState.value.partnerOrgAccess = 'selected';
+
+    const response = await aiProviderRoutes.request('/', { method: 'GET' });
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toContain(
+      'Viewing the partner AI provider configuration requires full partner org access (orgAccess must be "all")',
+    );
+  });
+
   it('requires MFA for POST /key', async () => {
     authGates.mfaDenied = true;
 
@@ -233,9 +267,11 @@ describe('AI provider routes', () => {
   });
 
   it('POST /key saves and audits only last4 and configVersion', async () => {
-    const response = await postKey();
+    const submittedKey = 'sk-ant-api03-route-test-key-1234567890';
+    const response = await postKey(submittedKey);
 
     expect(response.status).toBe(200);
+    expect(await response.text()).not.toContain(submittedKey);
     expect(savePartnerLlmKey).toHaveBeenCalledWith({
       partnerId: '22222222-2222-4222-8222-222222222222',
       apiKey: 'sk-ant-api03-route-test-key-1234567890',
@@ -266,6 +302,22 @@ describe('AI provider routes', () => {
     expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       action: 'ai_provider.updated',
     }));
+  });
+
+  it('PATCH / deliberately succeeds without requiring MFA because only key writes and removal are gated', async () => {
+    authGates.mfaDenied = true;
+
+    const response = await aiProviderRoutes.request('/', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ defaultModel: 'claude-haiku-4-5' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(updatePartnerLlmConfig).toHaveBeenCalledWith({
+      partnerId: '22222222-2222-4222-8222-222222222222',
+      defaultModel: 'claude-haiku-4-5',
+    });
   });
 
   it('PATCH / captures mapped PartnerLlmError responses at 5xx', async () => {

--- a/apps/api/src/routes/aiProvider.test.ts
+++ b/apps/api/src/routes/aiProvider.test.ts
@@ -5,10 +5,16 @@ const authGates = vi.hoisted(() => ({
   mfaDenied: false,
 }));
 
+const { captureExceptionMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+}));
+
 const authState: { value: any } = {
   value: {
     user: { id: '11111111-1111-4111-8111-111111111111', email: 'admin@example.com', name: 'Admin' },
+    scope: 'partner',
     partnerId: '22222222-2222-4222-8222-222222222222',
+    partnerOrgAccess: 'all',
   },
 };
 
@@ -37,6 +43,10 @@ vi.mock('../services/auditEvents', () => ({
   writeRouteAudit: vi.fn(),
 }));
 
+vi.mock('../services/sentry', () => ({
+  captureException: captureExceptionMock,
+}));
+
 vi.mock('../services/partnerLlmConfig', () => {
   class PartnerLlmError extends Error {
     constructor(message: string, readonly status: 400 | 409 | 500 | 503) {
@@ -55,6 +65,7 @@ vi.mock('../services/partnerLlmConfig', () => {
 
 import { aiProviderRoutes } from './aiProvider';
 import { writeRouteAudit } from '../services/auditEvents';
+import { captureException } from '../services/sentry';
 import {
   deletePartnerLlmConfig,
   getPartnerLlmStatus,
@@ -78,7 +89,9 @@ describe('AI provider routes', () => {
     authGates.mfaDenied = false;
     authState.value = {
       user: { id: '11111111-1111-4111-8111-111111111111', email: 'admin@example.com', name: 'Admin' },
+      scope: 'partner',
       partnerId: '22222222-2222-4222-8222-222222222222',
+      partnerOrgAccess: 'all',
     };
     vi.mocked(getPartnerLlmStatus).mockResolvedValue({
       configured: true,
@@ -101,7 +114,7 @@ describe('AI provider routes', () => {
       defaultModel: 'claude-haiku-4-5',
       configVersion: 4,
     });
-    vi.mocked(deletePartnerLlmConfig).mockResolvedValue(undefined);
+    vi.mocked(deletePartnerLlmConfig).mockResolvedValue(true);
   });
 
   it('returns 403 when the authenticated request has no partner context', async () => {
@@ -114,6 +127,52 @@ describe('AI provider routes', () => {
 
     expect(response.status).toBe(403);
     expect(getPartnerLlmStatus).not.toHaveBeenCalled();
+  });
+
+  const handlerRequests = [
+    ['GET /', () => aiProviderRoutes.request('/', { method: 'GET' })],
+    ['POST /key', () => postKey()],
+    ['PATCH /', () => aiProviderRoutes.request('/', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ defaultModel: 'claude-haiku-4-5' }),
+    })],
+    ['DELETE /', () => aiProviderRoutes.request('/', { method: 'DELETE' })],
+  ] as const;
+
+  it.each(handlerRequests)('%s rejects organization-scoped auth even when it carries a partnerId', async (_name, request) => {
+    authState.value = {
+      user: { id: '11111111-1111-4111-8111-111111111111', email: 'admin@example.com', name: 'Admin' },
+      scope: 'organization',
+      orgId: '33333333-3333-4333-8333-333333333333',
+      partnerId: '22222222-2222-4222-8222-222222222222',
+      partnerOrgAccess: null,
+    };
+
+    const response = await request();
+
+    expect(response.status).toBe(403);
+    expect(getPartnerLlmStatus).not.toHaveBeenCalled();
+    expect(savePartnerLlmKey).not.toHaveBeenCalled();
+    expect(updatePartnerLlmConfig).not.toHaveBeenCalled();
+    expect(deletePartnerLlmConfig).not.toHaveBeenCalled();
+  });
+
+  it.each(handlerRequests)('%s rejects partner auth limited to selected organizations', async (_name, request) => {
+    authState.value = {
+      user: { id: '11111111-1111-4111-8111-111111111111', email: 'admin@example.com', name: 'Admin' },
+      scope: 'partner',
+      partnerId: '22222222-2222-4222-8222-222222222222',
+      partnerOrgAccess: 'selected',
+    };
+
+    const response = await request();
+
+    expect(response.status).toBe(403);
+    expect(getPartnerLlmStatus).not.toHaveBeenCalled();
+    expect(savePartnerLlmKey).not.toHaveBeenCalled();
+    expect(updatePartnerLlmConfig).not.toHaveBeenCalled();
+    expect(deletePartnerLlmConfig).not.toHaveBeenCalled();
   });
 
   it('requires MFA for POST /key', async () => {
@@ -163,6 +222,16 @@ describe('AI provider routes', () => {
     expect(writeRouteAudit).not.toHaveBeenCalled();
   });
 
+  it('POST /key captures mapped PartnerLlmError responses at 5xx', async () => {
+    const error = new PartnerLlmError('Anthropic could not verify the API key right now.', 503);
+    vi.mocked(savePartnerLlmKey).mockRejectedValue(error);
+
+    const response = await postKey();
+
+    expect(response.status).toBe(503);
+    expect(captureException).toHaveBeenCalledWith(error, undefined, { service: 'aiProvider' });
+  });
+
   it('POST /key saves and audits only last4 and configVersion', async () => {
     const response = await postKey();
 
@@ -199,6 +268,20 @@ describe('AI provider routes', () => {
     }));
   });
 
+  it('PATCH / captures mapped PartnerLlmError responses at 5xx', async () => {
+    const error = new PartnerLlmError('Could not update the Anthropic configuration.', 500);
+    vi.mocked(updatePartnerLlmConfig).mockRejectedValue(error);
+
+    const response = await aiProviderRoutes.request('/', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ defaultModel: 'claude-haiku-4-5' }),
+    });
+
+    expect(response.status).toBe(500);
+    expect(captureException).toHaveBeenCalledWith(error, undefined, { service: 'aiProvider' });
+  });
+
   it('DELETE / removes the config and audits the disconnect', async () => {
     const response = await aiProviderRoutes.request('/', { method: 'DELETE' });
 
@@ -207,5 +290,15 @@ describe('AI provider routes', () => {
     expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       action: 'ai_provider.disconnected',
     }));
+  });
+
+  it('DELETE / remains idempotent without auditing when no config existed', async () => {
+    vi.mocked(deletePartnerLlmConfig).mockResolvedValue(false);
+
+    const response = await aiProviderRoutes.request('/', { method: 'DELETE' });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ configured: false, status: 'platform' });
+    expect(writeRouteAudit).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/aiProvider.test.ts
+++ b/apps/api/src/routes/aiProvider.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authGates = vi.hoisted(() => ({
+  permissionDenied: false,
+  mfaDenied: false,
+}));
+
+const authState: { value: any } = {
+  value: {
+    user: { id: '11111111-1111-4111-8111-111111111111', email: 'admin@example.com', name: 'Admin' },
+    partnerId: '22222222-2222-4222-8222-222222222222',
+  },
+};
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('auth', authState.value);
+    await next();
+  },
+  requirePermission: vi.fn(() => async (c: any, next: any) => {
+    if (authGates.permissionDenied) return c.json({ error: 'Permission denied' }, 403);
+    await next();
+  }),
+  requireMfa: vi.fn(() => async (c: any, next: any) => {
+    if (authGates.mfaDenied) return c.json({ error: 'MFA required' }, 403);
+    await next();
+  }),
+}));
+
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: {
+    BILLING_MANAGE: { resource: 'billing', action: 'manage' },
+  },
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../services/partnerLlmConfig', () => {
+  class PartnerLlmError extends Error {
+    constructor(message: string, readonly status: 400 | 409 | 500 | 503) {
+      super(message);
+      this.name = 'PartnerLlmError';
+    }
+  }
+  return {
+    PartnerLlmError,
+    savePartnerLlmKey: vi.fn(),
+    getPartnerLlmStatus: vi.fn(),
+    updatePartnerLlmConfig: vi.fn(),
+    deletePartnerLlmConfig: vi.fn(),
+  };
+});
+
+import { aiProviderRoutes } from './aiProvider';
+import { writeRouteAudit } from '../services/auditEvents';
+import {
+  deletePartnerLlmConfig,
+  getPartnerLlmStatus,
+  PartnerLlmError,
+  savePartnerLlmKey,
+  updatePartnerLlmConfig,
+} from '../services/partnerLlmConfig';
+
+function postKey(apiKey = 'sk-ant-api03-route-test-key-1234567890') {
+  return aiProviderRoutes.request('/key', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ apiKey }),
+  });
+}
+
+describe('AI provider routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authGates.permissionDenied = false;
+    authGates.mfaDenied = false;
+    authState.value = {
+      user: { id: '11111111-1111-4111-8111-111111111111', email: 'admin@example.com', name: 'Admin' },
+      partnerId: '22222222-2222-4222-8222-222222222222',
+    };
+    vi.mocked(getPartnerLlmStatus).mockResolvedValue({
+      configured: true,
+      provider: 'anthropic',
+      keyLast4: '7890',
+      defaultModel: 'claude-sonnet-4-6',
+      status: 'active',
+      verifiedAt: new Date('2026-08-23T12:00:00.000Z'),
+      lastError: null,
+      apiKey: 'must-not-leak',
+      keyFingerprint: 'must-not-leak-either',
+    } as any);
+    vi.mocked(savePartnerLlmKey).mockResolvedValue({
+      last4: '7890',
+      model: 'claude-sonnet-4-6',
+      verifiedAt: new Date('2026-08-23T12:00:00.000Z'),
+      configVersion: 3,
+    });
+    vi.mocked(updatePartnerLlmConfig).mockResolvedValue({
+      defaultModel: 'claude-haiku-4-5',
+      configVersion: 4,
+    });
+    vi.mocked(deletePartnerLlmConfig).mockResolvedValue(undefined);
+  });
+
+  it('returns 403 when the authenticated request has no partner context', async () => {
+    authState.value = {
+      user: { id: '11111111-1111-4111-8111-111111111111', email: 'admin@example.com', name: 'Admin' },
+      partnerId: null,
+    };
+
+    const response = await aiProviderRoutes.request('/', { method: 'GET' });
+
+    expect(response.status).toBe(403);
+    expect(getPartnerLlmStatus).not.toHaveBeenCalled();
+  });
+
+  it('requires MFA for POST /key', async () => {
+    authGates.mfaDenied = true;
+
+    const response = await postKey();
+
+    expect(response.status).toBe(403);
+    expect(savePartnerLlmKey).not.toHaveBeenCalled();
+  });
+
+  it('requires MFA for DELETE /', async () => {
+    authGates.mfaDenied = true;
+
+    const response = await aiProviderRoutes.request('/', { method: 'DELETE' });
+
+    expect(response.status).toBe(403);
+    expect(deletePartnerLlmConfig).not.toHaveBeenCalled();
+  });
+
+  it('GET / whitelists status fields and never returns the key or fingerprint', async () => {
+    const response = await aiProviderRoutes.request('/', { method: 'GET' });
+
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).not.toContain('must-not-leak');
+    expect(JSON.parse(text)).toEqual({
+      configured: true,
+      provider: 'anthropic',
+      keyLast4: '7890',
+      defaultModel: 'claude-sonnet-4-6',
+      status: 'active',
+      verifiedAt: '2026-08-23T12:00:00.000Z',
+      lastError: null,
+    });
+  });
+
+  it('POST /key maps PartnerLlmError to its typed HTTP status', async () => {
+    vi.mocked(savePartnerLlmKey).mockRejectedValue(
+      new PartnerLlmError('Anthropic denied access for that API key.', 409),
+    );
+
+    const response = await postKey();
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: 'Anthropic denied access for that API key.' });
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  it('POST /key saves and audits only last4 and configVersion', async () => {
+    const response = await postKey();
+
+    expect(response.status).toBe(200);
+    expect(savePartnerLlmKey).toHaveBeenCalledWith({
+      partnerId: '22222222-2222-4222-8222-222222222222',
+      apiKey: 'sk-ant-api03-route-test-key-1234567890',
+      userId: '11111111-1111-4111-8111-111111111111',
+    });
+    expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), {
+      orgId: null,
+      action: 'ai_provider.connected',
+      resourceType: 'partner',
+      resourceId: '22222222-2222-4222-8222-222222222222',
+      details: { last4: '7890', configVersion: 3 },
+    });
+    expect(JSON.stringify(vi.mocked(writeRouteAudit).mock.calls[0])).not.toContain('sk-ant-api03');
+  });
+
+  it('PATCH / updates the model and audits the mutation', async () => {
+    const response = await aiProviderRoutes.request('/', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ defaultModel: 'claude-haiku-4-5' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(updatePartnerLlmConfig).toHaveBeenCalledWith({
+      partnerId: '22222222-2222-4222-8222-222222222222',
+      defaultModel: 'claude-haiku-4-5',
+    });
+    expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: 'ai_provider.updated',
+    }));
+  });
+
+  it('DELETE / removes the config and audits the disconnect', async () => {
+    const response = await aiProviderRoutes.request('/', { method: 'DELETE' });
+
+    expect(response.status).toBe(200);
+    expect(deletePartnerLlmConfig).toHaveBeenCalledWith('22222222-2222-4222-8222-222222222222');
+    expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: 'ai_provider.disconnected',
+    }));
+  });
+});

--- a/apps/api/src/routes/aiProvider.ts
+++ b/apps/api/src/routes/aiProvider.ts
@@ -36,7 +36,11 @@ aiProviderRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     if (!auth?.partnerId) throw new HTTPException(403, { message: 'Partner context required' });
-    if (!canManagePartnerWidePolicies(auth)) throw new HTTPException(403, { message: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    if (!canManagePartnerWidePolicies(auth)) {
+      throw new HTTPException(403, {
+        message: 'Viewing the partner AI provider configuration requires full partner org access (orgAccess must be "all")',
+      });
+    }
     const status = await getPartnerLlmStatus(auth.partnerId);
     return c.json({
       configured: status.configured,

--- a/apps/api/src/routes/aiProvider.ts
+++ b/apps/api/src/routes/aiProvider.ts
@@ -12,6 +12,11 @@ import {
   updatePartnerLlmConfig,
 } from '../services/partnerLlmConfig';
 import { PERMISSIONS } from '../services/permissions';
+import {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+} from '../services/partnerWideAccess';
+import { captureException } from '../services/sentry';
 
 export const aiProviderRoutes = new Hono();
 
@@ -31,6 +36,7 @@ aiProviderRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     if (!auth?.partnerId) throw new HTTPException(403, { message: 'Partner context required' });
+    if (!canManagePartnerWidePolicies(auth)) throw new HTTPException(403, { message: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
     const status = await getPartnerLlmStatus(auth.partnerId);
     return c.json({
       configured: status.configured,
@@ -52,6 +58,7 @@ aiProviderRoutes.post(
   async (c) => {
     const auth = c.get('auth');
     if (!auth?.partnerId) throw new HTTPException(403, { message: 'Partner context required' });
+    if (!canManagePartnerWidePolicies(auth)) throw new HTTPException(403, { message: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
     const { apiKey } = c.req.valid('json');
     try {
       const result = await savePartnerLlmKey({
@@ -77,6 +84,7 @@ aiProviderRoutes.post(
       });
     } catch (error) {
       if (error instanceof PartnerLlmError) {
+        if (error.status >= 500) captureException(error, undefined, { service: 'aiProvider' });
         return c.json({ error: error.message }, error.status);
       }
       throw error;
@@ -91,6 +99,7 @@ aiProviderRoutes.patch(
   async (c) => {
     const auth = c.get('auth');
     if (!auth?.partnerId) throw new HTTPException(403, { message: 'Partner context required' });
+    if (!canManagePartnerWidePolicies(auth)) throw new HTTPException(403, { message: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
     const { defaultModel } = c.req.valid('json');
     try {
       const result = await updatePartnerLlmConfig({ partnerId: auth.partnerId, defaultModel });
@@ -104,6 +113,7 @@ aiProviderRoutes.patch(
       return c.json(result);
     } catch (error) {
       if (error instanceof PartnerLlmError) {
+        if (error.status >= 500) captureException(error, undefined, { service: 'aiProvider' });
         return c.json({ error: error.message }, error.status);
       }
       throw error;
@@ -118,13 +128,16 @@ aiProviderRoutes.delete(
   async (c) => {
     const auth = c.get('auth');
     if (!auth?.partnerId) throw new HTTPException(403, { message: 'Partner context required' });
-    await deletePartnerLlmConfig(auth.partnerId);
-    writeRouteAudit(c, {
-      orgId: null,
-      action: 'ai_provider.disconnected',
-      resourceType: 'partner',
-      resourceId: auth.partnerId,
-    });
+    if (!canManagePartnerWidePolicies(auth)) throw new HTTPException(403, { message: PARTNER_WIDE_WRITE_DENIED_MESSAGE });
+    const deleted = await deletePartnerLlmConfig(auth.partnerId);
+    if (deleted) {
+      writeRouteAudit(c, {
+        orgId: null,
+        action: 'ai_provider.disconnected',
+        resourceType: 'partner',
+        resourceId: auth.partnerId,
+      });
+    }
     return c.json({ configured: false, status: 'platform' });
   },
 );

--- a/apps/api/src/routes/aiProvider.ts
+++ b/apps/api/src/routes/aiProvider.ts
@@ -1,0 +1,130 @@
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { z } from 'zod';
+import { zValidator } from '../lib/validation';
+import { authMiddleware, requireMfa, requirePermission } from '../middleware/auth';
+import { writeRouteAudit } from '../services/auditEvents';
+import {
+  deletePartnerLlmConfig,
+  getPartnerLlmStatus,
+  PartnerLlmError,
+  savePartnerLlmKey,
+  updatePartnerLlmConfig,
+} from '../services/partnerLlmConfig';
+import { PERMISSIONS } from '../services/permissions';
+
+export const aiProviderRoutes = new Hono();
+
+const saveKeySchema = z.object({
+  apiKey: z.string().trim().min(20, 'Enter a valid Anthropic API key.'),
+});
+
+const updateConfigSchema = z.object({
+  defaultModel: z.string().trim().min(1).nullable(),
+});
+
+aiProviderRoutes.use('*', authMiddleware);
+
+aiProviderRoutes.get(
+  '/',
+  requirePermission(PERMISSIONS.BILLING_MANAGE.resource, PERMISSIONS.BILLING_MANAGE.action),
+  async (c) => {
+    const auth = c.get('auth');
+    if (!auth?.partnerId) throw new HTTPException(403, { message: 'Partner context required' });
+    const status = await getPartnerLlmStatus(auth.partnerId);
+    return c.json({
+      configured: status.configured,
+      provider: status.provider,
+      keyLast4: status.keyLast4,
+      defaultModel: status.defaultModel,
+      status: status.status,
+      verifiedAt: status.verifiedAt?.toISOString() ?? null,
+      lastError: status.lastError,
+    });
+  },
+);
+
+aiProviderRoutes.post(
+  '/key',
+  requirePermission(PERMISSIONS.BILLING_MANAGE.resource, PERMISSIONS.BILLING_MANAGE.action),
+  requireMfa(),
+  zValidator('json', saveKeySchema),
+  async (c) => {
+    const auth = c.get('auth');
+    if (!auth?.partnerId) throw new HTTPException(403, { message: 'Partner context required' });
+    const { apiKey } = c.req.valid('json');
+    try {
+      const result = await savePartnerLlmKey({
+        partnerId: auth.partnerId,
+        apiKey,
+        userId: auth.user.id,
+      });
+      writeRouteAudit(c, {
+        orgId: null,
+        action: 'ai_provider.connected',
+        resourceType: 'partner',
+        resourceId: auth.partnerId,
+        details: { last4: result.last4, configVersion: result.configVersion },
+      });
+      return c.json({
+        configured: true,
+        provider: 'anthropic',
+        keyLast4: result.last4,
+        defaultModel: result.model,
+        status: 'active',
+        verifiedAt: result.verifiedAt.toISOString(),
+        lastError: null,
+      });
+    } catch (error) {
+      if (error instanceof PartnerLlmError) {
+        return c.json({ error: error.message }, error.status);
+      }
+      throw error;
+    }
+  },
+);
+
+aiProviderRoutes.patch(
+  '/',
+  requirePermission(PERMISSIONS.BILLING_MANAGE.resource, PERMISSIONS.BILLING_MANAGE.action),
+  zValidator('json', updateConfigSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    if (!auth?.partnerId) throw new HTTPException(403, { message: 'Partner context required' });
+    const { defaultModel } = c.req.valid('json');
+    try {
+      const result = await updatePartnerLlmConfig({ partnerId: auth.partnerId, defaultModel });
+      writeRouteAudit(c, {
+        orgId: null,
+        action: 'ai_provider.updated',
+        resourceType: 'partner',
+        resourceId: auth.partnerId,
+        details: { defaultModel, configVersion: result.configVersion },
+      });
+      return c.json(result);
+    } catch (error) {
+      if (error instanceof PartnerLlmError) {
+        return c.json({ error: error.message }, error.status);
+      }
+      throw error;
+    }
+  },
+);
+
+aiProviderRoutes.delete(
+  '/',
+  requirePermission(PERMISSIONS.BILLING_MANAGE.resource, PERMISSIONS.BILLING_MANAGE.action),
+  requireMfa(),
+  async (c) => {
+    const auth = c.get('auth');
+    if (!auth?.partnerId) throw new HTTPException(403, { message: 'Partner context required' });
+    await deletePartnerLlmConfig(auth.partnerId);
+    writeRouteAudit(c, {
+      orgId: null,
+      action: 'ai_provider.disconnected',
+      resourceType: 'partner',
+      resourceId: auth.partnerId,
+    });
+    return c.json({ configured: false, status: 'platform' });
+  },
+);

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -30,6 +30,8 @@ const MODEL_PRICING: Record<string, { inputPerMillion: number; outputPerMillion:
   'claude-sonnet-4-5-20250929': { inputPerMillion: 300, outputPerMillion: 1500 }
 };
 
+export const SUPPORTED_AI_MODELS: readonly string[] = Object.freeze(Object.keys(MODEL_PRICING));
+
 // Conservative last-resort pricing for an unrecognized model id. Mirrors the most
 // expensive current Opus-tier rate so we never silently undercount. Hitting this is logged.
 const DEFAULT_PRICING = { inputPerMillion: 500, outputPerMillion: 2500 };

--- a/apps/api/src/services/encryptedColumnRegistry.ts
+++ b/apps/api/src/services/encryptedColumnRegistry.ts
@@ -91,6 +91,7 @@ export const encryptedColumnRegistry: EncryptedColumnSpec[] = [
   { table: 'psa_connections', column: 'credentials', kind: 'json', description: 'PSA connection credentials' },
   { table: 'stripe_connect_accounts', column: 'credentials', kind: 'json', description: 'Stripe Connect OAuth token (deauthorize use)' },
   { table: 'stripe_connect_accounts', column: 'api_key', kind: 'text', description: 'Per-partner Stripe secret/restricted key (API-key billing model)' },
+  { table: 'partner_llm_configs', column: 'api_key_encrypted', kind: 'text', aadBinding: 'row', description: 'Per-partner Anthropic API key (#3228) — AAD bound to the row id' },
   { table: 'huntress_integrations', column: 'api_key_encrypted', kind: 'text', description: 'Huntress API key' },
   { table: 'huntress_integrations', column: 'webhook_secret_encrypted', kind: 'text', description: 'Huntress webhook secret' },
   { table: 'pax8_integrations', column: 'client_id_encrypted', kind: 'text', description: 'Pax8 OAuth client id' },

--- a/apps/api/src/services/llm/llmConfigResolver.test.ts
+++ b/apps/api/src/services/llm/llmConfigResolver.test.ts
@@ -4,9 +4,17 @@ import { PgDialect } from 'drizzle-orm/pg-core';
 const PARTNER_ID = '11111111-1111-4111-8111-111111111111';
 const CONFIG_ID = '22222222-2222-4222-8222-222222222222';
 
-const { anthropicOptions, captureExceptionMock, dbState, decryptMock, contextState } = vi.hoisted(() => ({
+const {
+  anthropicOptions,
+  captureExceptionMock,
+  captureMessageMock,
+  dbState,
+  decryptMock,
+  contextState,
+} = vi.hoisted(() => ({
   anthropicOptions: [] as Array<{ apiKey?: string }>,
   captureExceptionMock: vi.fn(),
+  captureMessageMock: vi.fn(),
   dbState: {
     selectResults: [] as unknown[][],
     updateResults: [] as unknown[][],
@@ -36,6 +44,7 @@ vi.mock('../partnerLlmConfig', () => ({
 
 vi.mock('../sentry', () => ({
   captureException: captureExceptionMock,
+  captureMessage: captureMessageMock,
 }));
 
 vi.mock('../../db', () => ({
@@ -80,7 +89,7 @@ import {
   resolveLlmConfig,
 } from './llmConfigResolver';
 import { SecretKeyMaterialError } from '../secretCrypto';
-import { captureException } from '../sentry';
+import { captureException, captureMessage } from '../sentry';
 
 const originalPlatformKey = process.env.ANTHROPIC_API_KEY;
 
@@ -116,6 +125,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   if (originalPlatformKey === undefined) delete process.env.ANTHROPIC_API_KEY;
   else process.env.ANTHROPIC_API_KEY = originalPlatformKey;
 });
@@ -128,6 +138,19 @@ describe('resolveLlmConfig', () => {
       model: 'claude-sonnet-4-6',
     });
     expect(contextState.systemCalls).toBe(0);
+  });
+
+  it('returns the platform config when the partner has no configuration row', async () => {
+    dbState.selectResults.push([]);
+
+    await expect(resolveLlmConfig(PARTNER_ID)).resolves.toEqual({
+      source: 'platform',
+      apiKey: 'platform-key',
+      model: 'claude-sonnet-4-6',
+    });
+    expect(contextState.outsideCalls).toBe(1);
+    expect(contextState.systemCalls).toBe(1);
+    expect(decryptMock).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -183,7 +206,7 @@ describe('resolveLlmConfig', () => {
     await expect(resolveLlmConfig(PARTNER_ID)).resolves.toEqual({
       source: 'unavailable',
       partnerId: PARTNER_ID,
-      reason: 'key_error',
+      reason: 'key_material',
     });
     expect(dbState.updateSets).toHaveLength(0);
     expect(captureException).toHaveBeenCalledWith(error, undefined, {
@@ -194,6 +217,27 @@ describe('resolveLlmConfig', () => {
       '[llmConfigResolver] partner config cannot be decrypted with this node key material',
       { partnerId: PARTNER_ID, error },
     );
+    consoleError.mockRestore();
+  });
+
+  it('throttles node key-material captures per partner for one hour', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-23T12:00:00.000Z'));
+    const partnerId = '44444444-4444-4444-8444-444444444444';
+    const error = new SecretKeyMaterialError('Unknown encrypted secret key ID');
+    dbState.selectResults.push([row()], [row()], [row()]);
+    decryptMock.mockImplementation(() => {
+      throw error;
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await resolveLlmConfig(partnerId);
+    await resolveLlmConfig(partnerId);
+    expect(captureException).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(60 * 60 * 1000);
+    await resolveLlmConfig(partnerId);
+    expect(captureException).toHaveBeenCalledTimes(2);
     consoleError.mockRestore();
   });
 
@@ -258,6 +302,16 @@ describe('markPartnerLlmError', () => {
 });
 
 describe('getAnthropicClientForPartner', () => {
+  it('constructs the Anthropic client with the partner key instead of the platform key', async () => {
+    dbState.selectResults.push([row()]);
+
+    const result = await getAnthropicClientForPartner(PARTNER_ID);
+
+    expect(result.resolved).toMatchObject({ source: 'partner', apiKey: 'partner-plaintext-key' });
+    expect(anthropicOptions).toEqual([{ apiKey: 'partner-plaintext-key' }]);
+    expect(anthropicOptions[0]?.apiKey).not.toBe('platform-key');
+  });
+
   it('throws LlmUnavailableError instead of constructing a client for unavailable config', async () => {
     dbState.selectResults.push([row({ status: 'error' })]);
 
@@ -266,20 +320,26 @@ describe('getAnthropicClientForPartner', () => {
   });
 
   it('reports a deployment configuration error when the platform key is blank', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-23T12:00:00.000Z'));
     process.env.ANTHROPIC_API_KEY = '   ';
 
     await expect(getAnthropicClientForPartner(null)).rejects.toMatchObject({
       name: 'LlmUnavailableError',
       message: 'AI is not configured on this deployment.',
     });
-    expect(captureException).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'LlmUnavailableError',
-        message: 'AI is not configured on this deployment.',
-      }),
+    await expect(getAnthropicClientForPartner(null)).rejects.toBeInstanceOf(LlmUnavailableError);
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(captureMessage).toHaveBeenCalledWith(
+      'AI is not configured on this deployment.',
+      'warning',
       undefined,
       { service: 'llmConfigResolver' },
     );
+
+    vi.advanceTimersByTime(60 * 60 * 1000);
+    await expect(getAnthropicClientForPartner(null)).rejects.toBeInstanceOf(LlmUnavailableError);
+    expect(captureMessage).toHaveBeenCalledTimes(2);
     expect(anthropicOptions).toHaveLength(0);
   });
 });

--- a/apps/api/src/services/llm/llmConfigResolver.test.ts
+++ b/apps/api/src/services/llm/llmConfigResolver.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 const PARTNER_ID = '11111111-1111-4111-8111-111111111111';
 const CONFIG_ID = '22222222-2222-4222-8222-222222222222';
 
-const { anthropicOptions, dbState, decryptMock, contextState } = vi.hoisted(() => ({
+const { anthropicOptions, captureExceptionMock, dbState, decryptMock, contextState } = vi.hoisted(() => ({
   anthropicOptions: [] as Array<{ apiKey?: string }>,
+  captureExceptionMock: vi.fn(),
   dbState: {
     selectResults: [] as unknown[][],
     updateResults: [] as unknown[][],
+    updateError: null as unknown,
     updateSets: [] as Array<Record<string, unknown>>,
     updateWheres: [] as unknown[],
   },
@@ -29,6 +32,10 @@ vi.mock('../aiAgent', () => ({
 
 vi.mock('../partnerLlmConfig', () => ({
   decryptPartnerLlmApiKey: decryptMock,
+}));
+
+vi.mock('../sentry', () => ({
+  captureException: captureExceptionMock,
 }));
 
 vi.mock('../../db', () => ({
@@ -55,7 +62,9 @@ vi.mock('../../db', () => ({
           where: vi.fn((condition: unknown) => {
             dbState.updateWheres.push(condition);
             return {
-              returning: vi.fn(() => Promise.resolve(dbState.updateResults.shift() ?? [])),
+              returning: vi.fn(() => dbState.updateError
+                ? Promise.reject(dbState.updateError)
+                : Promise.resolve(dbState.updateResults.shift() ?? [])),
             };
           }),
         };
@@ -70,6 +79,8 @@ import {
   markPartnerLlmError,
   resolveLlmConfig,
 } from './llmConfigResolver';
+import { SecretKeyMaterialError } from '../secretCrypto';
+import { captureException } from '../sentry';
 
 const originalPlatformKey = process.env.ANTHROPIC_API_KEY;
 
@@ -85,17 +96,9 @@ function row(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function boundParams(node: unknown, out: unknown[] = []): unknown[] {
-  if (!node || typeof node !== 'object') return out;
-  const record = node as Record<string, unknown>;
-  if (Array.isArray(record.queryChunks)) {
-    for (const chunk of record.queryChunks) boundParams(chunk, out);
-  } else if (Array.isArray(node)) {
-    for (const chunk of node) boundParams(chunk, out);
-  } else if ('encoder' in record && 'value' in record) {
-    out.push(record.value);
-  }
-  return out;
+function compileWhere(condition: unknown): { sql: string; params: unknown[] } {
+  const { sql, params } = new PgDialect().sqlToQuery(condition as never);
+  return { sql, params };
 }
 
 beforeEach(() => {
@@ -103,6 +106,7 @@ beforeEach(() => {
   anthropicOptions.length = 0;
   dbState.selectResults.length = 0;
   dbState.updateResults.length = 0;
+  dbState.updateError = null;
   dbState.updateSets.length = 0;
   dbState.updateWheres.length = 0;
   contextState.outsideCalls = 0;
@@ -145,11 +149,12 @@ describe('resolveLlmConfig', () => {
     expect(contextState.systemCalls).toBe(1);
   });
 
-  it('marks an undecryptable active row as errored and returns unavailable', async () => {
+  it('marks a deterministic decrypt failure by config id and returns unavailable', async () => {
     dbState.selectResults.push([row()]);
     dbState.updateResults.push([{ id: CONFIG_ID }]);
+    const error = new Error('bad auth tag');
     decryptMock.mockImplementation(() => {
-      throw new Error('bad auth tag');
+      throw error;
     });
 
     await expect(resolveLlmConfig(PARTNER_ID)).resolves.toEqual({
@@ -158,6 +163,65 @@ describe('resolveLlmConfig', () => {
       reason: 'key_error',
     });
     expect(dbState.updateSets[0]).toMatchObject({ status: 'error', lastError: 'decrypt_failed' });
+    const compiled = compileWhere(dbState.updateWheres[0]);
+    expect(compiled.sql).toBe('(\"partner_llm_configs\".\"id\" = $1 and \"partner_llm_configs\".\"config_version\" = $2)');
+    expect(compiled.params).toEqual([CONFIG_ID, 4]);
+    expect(captureException).toHaveBeenCalledWith(error, undefined, {
+      service: 'llmConfigResolver',
+      partnerId: PARTNER_ID,
+    });
+  });
+
+  it('returns unavailable without persisting when decrypt fails from node key material', async () => {
+    dbState.selectResults.push([row()]);
+    const error = new SecretKeyMaterialError('Unknown encrypted secret key ID');
+    decryptMock.mockImplementation(() => {
+      throw error;
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(resolveLlmConfig(PARTNER_ID)).resolves.toEqual({
+      source: 'unavailable',
+      partnerId: PARTNER_ID,
+      reason: 'key_error',
+    });
+    expect(dbState.updateSets).toHaveLength(0);
+    expect(captureException).toHaveBeenCalledWith(error, undefined, {
+      service: 'llmConfigResolver',
+      partnerId: PARTNER_ID,
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      '[llmConfigResolver] partner config cannot be decrypted with this node key material',
+      { partnerId: PARTNER_ID, error },
+    );
+    consoleError.mockRestore();
+  });
+
+  it('captures a failure to persist deterministic decrypt status', async () => {
+    dbState.selectResults.push([row()]);
+    const decryptError = new Error('bad auth tag');
+    const persistError = new Error('database unavailable');
+    decryptMock.mockImplementation(() => {
+      throw decryptError;
+    });
+    dbState.updateError = persistError;
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(resolveLlmConfig(PARTNER_ID)).resolves.toMatchObject({ source: 'unavailable' });
+
+    expect(captureException).toHaveBeenNthCalledWith(1, decryptError, undefined, {
+      service: 'llmConfigResolver',
+      partnerId: PARTNER_ID,
+    });
+    expect(captureException).toHaveBeenNthCalledWith(2, persistError, undefined, {
+      service: 'llmConfigResolver',
+      partnerId: PARTNER_ID,
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      '[llmConfigResolver] failed to mark unreadable partner config',
+      { partnerId: PARTNER_ID, configVersion: 4, error: persistError },
+    );
+    consoleError.mockRestore();
   });
 
   it('returns unavailable for an error row without attempting decryption', async () => {
@@ -178,18 +242,18 @@ describe('markPartnerLlmError', () => {
     dbState.updateResults.push([]);
 
     await expect(markPartnerLlmError({
-      partnerId: PARTNER_ID,
+      configId: CONFIG_ID,
       configVersion: 3,
-      reason: 'anthropic_auth_error:401',
+      reason: 'auth_rejected',
     })).resolves.toBe(false);
 
     expect(dbState.updateSets[0]).toMatchObject({
       status: 'error',
-      lastError: 'anthropic_auth_error:401',
+      lastError: 'auth_rejected',
     });
-    const params = boundParams(dbState.updateWheres[0]);
-    expect(params).toContain(PARTNER_ID);
-    expect(params).toContain(3);
+    const compiled = compileWhere(dbState.updateWheres[0]);
+    expect(compiled.sql).toBe('(\"partner_llm_configs\".\"id\" = $1 and \"partner_llm_configs\".\"config_version\" = $2)');
+    expect(compiled.params).toEqual([CONFIG_ID, 3]);
   });
 });
 
@@ -198,6 +262,24 @@ describe('getAnthropicClientForPartner', () => {
     dbState.selectResults.push([row({ status: 'error' })]);
 
     await expect(getAnthropicClientForPartner(PARTNER_ID)).rejects.toBeInstanceOf(LlmUnavailableError);
+    expect(anthropicOptions).toHaveLength(0);
+  });
+
+  it('reports a deployment configuration error when the platform key is blank', async () => {
+    process.env.ANTHROPIC_API_KEY = '   ';
+
+    await expect(getAnthropicClientForPartner(null)).rejects.toMatchObject({
+      name: 'LlmUnavailableError',
+      message: 'AI is not configured on this deployment.',
+    });
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'LlmUnavailableError',
+        message: 'AI is not configured on this deployment.',
+      }),
+      undefined,
+      { service: 'llmConfigResolver' },
+    );
     expect(anthropicOptions).toHaveLength(0);
   });
 });

--- a/apps/api/src/services/llm/llmConfigResolver.test.ts
+++ b/apps/api/src/services/llm/llmConfigResolver.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const PARTNER_ID = '11111111-1111-4111-8111-111111111111';
+const CONFIG_ID = '22222222-2222-4222-8222-222222222222';
+
+const { anthropicOptions, dbState, decryptMock, contextState } = vi.hoisted(() => ({
+  anthropicOptions: [] as Array<{ apiKey?: string }>,
+  dbState: {
+    selectResults: [] as unknown[][],
+    updateResults: [] as unknown[][],
+    updateSets: [] as Array<Record<string, unknown>>,
+    updateWheres: [] as unknown[],
+  },
+  decryptMock: vi.fn(),
+  contextState: { outsideCalls: 0, systemCalls: 0 },
+}));
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    constructor(options: { apiKey?: string }) {
+      anthropicOptions.push(options);
+    }
+  },
+}));
+
+vi.mock('../aiAgent', () => ({
+  resolveDefaultModel: () => 'claude-sonnet-4-6',
+}));
+
+vi.mock('../partnerLlmConfig', () => ({
+  decryptPartnerLlmApiKey: decryptMock,
+}));
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: (fn: () => unknown) => {
+    contextState.outsideCalls += 1;
+    return fn();
+  },
+  withSystemDbAccessContext: async (fn: () => unknown) => {
+    contextState.systemCalls += 1;
+    return fn();
+  },
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve(dbState.selectResults.shift() ?? [])),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: Record<string, unknown>) => {
+        dbState.updateSets.push(values);
+        return {
+          where: vi.fn((condition: unknown) => {
+            dbState.updateWheres.push(condition);
+            return {
+              returning: vi.fn(() => Promise.resolve(dbState.updateResults.shift() ?? [])),
+            };
+          }),
+        };
+      }),
+    })),
+  },
+}));
+
+import {
+  getAnthropicClientForPartner,
+  LlmUnavailableError,
+  markPartnerLlmError,
+  resolveLlmConfig,
+} from './llmConfigResolver';
+
+const originalPlatformKey = process.env.ANTHROPIC_API_KEY;
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: CONFIG_ID,
+    partnerId: PARTNER_ID,
+    apiKeyEncrypted: 'ciphertext',
+    defaultModel: null,
+    status: 'active',
+    configVersion: 4,
+    ...overrides,
+  };
+}
+
+function boundParams(node: unknown, out: unknown[] = []): unknown[] {
+  if (!node || typeof node !== 'object') return out;
+  const record = node as Record<string, unknown>;
+  if (Array.isArray(record.queryChunks)) {
+    for (const chunk of record.queryChunks) boundParams(chunk, out);
+  } else if (Array.isArray(node)) {
+    for (const chunk of node) boundParams(chunk, out);
+  } else if ('encoder' in record && 'value' in record) {
+    out.push(record.value);
+  }
+  return out;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  anthropicOptions.length = 0;
+  dbState.selectResults.length = 0;
+  dbState.updateResults.length = 0;
+  dbState.updateSets.length = 0;
+  dbState.updateWheres.length = 0;
+  contextState.outsideCalls = 0;
+  contextState.systemCalls = 0;
+  decryptMock.mockReturnValue('partner-plaintext-key');
+  process.env.ANTHROPIC_API_KEY = 'platform-key';
+});
+
+afterEach(() => {
+  if (originalPlatformKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+  else process.env.ANTHROPIC_API_KEY = originalPlatformKey;
+});
+
+describe('resolveLlmConfig', () => {
+  it('returns the platform config for a null partner without reading the database', async () => {
+    await expect(resolveLlmConfig(null)).resolves.toEqual({
+      source: 'platform',
+      apiKey: 'platform-key',
+      model: 'claude-sonnet-4-6',
+    });
+    expect(contextState.systemCalls).toBe(0);
+  });
+
+  it.each([
+    ['claude-haiku-4-5', 'claude-haiku-4-5'],
+    [null, 'claude-sonnet-4-6'],
+  ])('returns a decrypted partner config using the row model %s and fallback %s', async (defaultModel, expectedModel) => {
+    dbState.selectResults.push([row({ defaultModel })]);
+
+    await expect(resolveLlmConfig(PARTNER_ID)).resolves.toEqual({
+      source: 'partner',
+      partnerId: PARTNER_ID,
+      apiKey: 'partner-plaintext-key',
+      model: expectedModel,
+      configId: CONFIG_ID,
+      configVersion: 4,
+    });
+    expect(decryptMock).toHaveBeenCalledWith({ id: CONFIG_ID, apiKeyEncrypted: 'ciphertext' });
+    expect(contextState.outsideCalls).toBe(1);
+    expect(contextState.systemCalls).toBe(1);
+  });
+
+  it('marks an undecryptable active row as errored and returns unavailable', async () => {
+    dbState.selectResults.push([row()]);
+    dbState.updateResults.push([{ id: CONFIG_ID }]);
+    decryptMock.mockImplementation(() => {
+      throw new Error('bad auth tag');
+    });
+
+    await expect(resolveLlmConfig(PARTNER_ID)).resolves.toEqual({
+      source: 'unavailable',
+      partnerId: PARTNER_ID,
+      reason: 'key_error',
+    });
+    expect(dbState.updateSets[0]).toMatchObject({ status: 'error', lastError: 'decrypt_failed' });
+  });
+
+  it('returns unavailable for an error row without attempting decryption', async () => {
+    dbState.selectResults.push([row({ status: 'error' })]);
+
+    await expect(resolveLlmConfig(PARTNER_ID)).resolves.toEqual({
+      source: 'unavailable',
+      partnerId: PARTNER_ID,
+      reason: 'key_error',
+    });
+    expect(decryptMock).not.toHaveBeenCalled();
+    expect(dbState.updateSets).toHaveLength(0);
+  });
+});
+
+describe('markPartnerLlmError', () => {
+  it('is a no-op when the config version is stale', async () => {
+    dbState.updateResults.push([]);
+
+    await expect(markPartnerLlmError({
+      partnerId: PARTNER_ID,
+      configVersion: 3,
+      reason: 'anthropic_auth_error:401',
+    })).resolves.toBe(false);
+
+    expect(dbState.updateSets[0]).toMatchObject({
+      status: 'error',
+      lastError: 'anthropic_auth_error:401',
+    });
+    const params = boundParams(dbState.updateWheres[0]);
+    expect(params).toContain(PARTNER_ID);
+    expect(params).toContain(3);
+  });
+});
+
+describe('getAnthropicClientForPartner', () => {
+  it('throws LlmUnavailableError instead of constructing a client for unavailable config', async () => {
+    dbState.selectResults.push([row({ status: 'error' })]);
+
+    await expect(getAnthropicClientForPartner(PARTNER_ID)).rejects.toBeInstanceOf(LlmUnavailableError);
+    expect(anthropicOptions).toHaveLength(0);
+  });
+});

--- a/apps/api/src/services/llm/llmConfigResolver.ts
+++ b/apps/api/src/services/llm/llmConfigResolver.ts
@@ -4,6 +4,8 @@ import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { partnerLlmConfigs } from '../../db/schema';
 import { resolveDefaultModel } from '../aiAgent';
 import { decryptPartnerLlmApiKey } from '../partnerLlmConfig';
+import { SecretKeyMaterialError } from '../secretCrypto';
+import { captureException } from '../sentry';
 
 export type ResolvedLlmConfig =
   | { source: 'platform'; apiKey: string | undefined; model: string }
@@ -21,8 +23,8 @@ export class LlmUnavailableError extends Error {
   readonly status = 503;
   readonly code = 'ai_unavailable';
 
-  constructor() {
-    super('AI is unavailable until the Anthropic API key is reconnected.');
+  constructor(message = 'AI is unavailable until the Anthropic API key is reconnected.') {
+    super(message);
     this.name = 'LlmUnavailableError';
   }
 }
@@ -65,18 +67,28 @@ export async function resolveLlmConfig(partnerId: string | null): Promise<Resolv
   let apiKey: string;
   try {
     apiKey = decryptPartnerLlmApiKey({ id: row.id, apiKeyEncrypted: row.apiKeyEncrypted });
-  } catch {
+  } catch (error) {
+    captureException(error, undefined, { service: 'llmConfigResolver', partnerId });
+    if (error instanceof SecretKeyMaterialError) {
+      console.error(
+        '[llmConfigResolver] partner config cannot be decrypted with this node key material',
+        { partnerId, error },
+      );
+      return { source: 'unavailable', partnerId, reason: 'key_error' };
+    }
     try {
       await markPartnerLlmError({
-        partnerId,
+        configId: row.id,
         configVersion: row.configVersion,
         reason: 'decrypt_failed',
       });
-    } catch {
+    } catch (markError) {
       console.error('[llmConfigResolver] failed to mark unreadable partner config', {
         partnerId,
         configVersion: row.configVersion,
+        error: markError,
       });
+      captureException(markError, undefined, { service: 'llmConfigResolver', partnerId });
     }
     return { source: 'unavailable', partnerId, reason: 'key_error' };
   }
@@ -92,13 +104,16 @@ export async function resolveLlmConfig(partnerId: string | null): Promise<Resolv
 }
 
 /**
- * Marks normalized credential failures only. Callers must not invoke this for
- * Anthropic 429, 5xx, network, timeout, or other retryable failures.
+ * Marks normalized credential failures only when the exact config row id and
+ * version still match. Callers must not invoke this for Anthropic 429, 5xx,
+ * network, timeout, or other retryable failures.
  */
+export type PartnerLlmErrorReason = 'decrypt_failed' | 'auth_rejected';
+
 export async function markPartnerLlmError(input: {
-  partnerId: string;
+  configId: string;
   configVersion: number;
-  reason: string;
+  reason: PartnerLlmErrorReason;
 }): Promise<boolean> {
   const reason = input.reason.trim().slice(0, 160) || 'credential_error';
   return runOutsideDbContext(() =>
@@ -111,7 +126,7 @@ export async function markPartnerLlmError(input: {
           updatedAt: new Date(),
         })
         .where(and(
-          eq(partnerLlmConfigs.partnerId, input.partnerId),
+          eq(partnerLlmConfigs.id, input.configId),
           eq(partnerLlmConfigs.configVersion, input.configVersion),
         ))
         .returning({ id: partnerLlmConfigs.id });
@@ -125,8 +140,13 @@ export async function getAnthropicClientForPartner(partnerId: string | null): Pr
   resolved: Exclude<ResolvedLlmConfig, { source: 'unavailable' }>;
 }> {
   const resolved = await resolveLlmConfig(partnerId);
-  if (resolved.source === 'unavailable' || !resolved.apiKey?.trim()) {
+  if (resolved.source === 'unavailable') {
     throw new LlmUnavailableError();
+  }
+  if (!resolved.apiKey?.trim()) {
+    const error = new LlmUnavailableError('AI is not configured on this deployment.');
+    captureException(error, undefined, { service: 'llmConfigResolver' });
+    throw error;
   }
   return {
     client: new Anthropic({ apiKey: resolved.apiKey }),

--- a/apps/api/src/services/llm/llmConfigResolver.ts
+++ b/apps/api/src/services/llm/llmConfigResolver.ts
@@ -5,7 +5,18 @@ import { partnerLlmConfigs } from '../../db/schema';
 import { resolveDefaultModel } from '../aiAgent';
 import { decryptPartnerLlmApiKey } from '../partnerLlmConfig';
 import { SecretKeyMaterialError } from '../secretCrypto';
-import { captureException } from '../sentry';
+import { captureException, captureMessage } from '../sentry';
+
+const SENTRY_CAPTURE_THROTTLE_MS = 60 * 60 * 1000;
+const sentryCaptureTimestamps = new Map<string, number>();
+
+function captureAtMostHourly(key: string, capture: () => void): void {
+  const now = Date.now();
+  const lastCapture = sentryCaptureTimestamps.get(key);
+  if (lastCapture !== undefined && now - lastCapture < SENTRY_CAPTURE_THROTTLE_MS) return;
+  sentryCaptureTimestamps.set(key, now);
+  capture();
+}
 
 export type ResolvedLlmConfig =
   | { source: 'platform'; apiKey: string | undefined; model: string }
@@ -17,7 +28,13 @@ export type ResolvedLlmConfig =
       configId: string;
       configVersion: number;
     }
-  | { source: 'unavailable'; partnerId: string; reason: 'key_error' };
+  | {
+      source: 'unavailable';
+      partnerId: string;
+      reason: 'key_error' | 'key_material';
+    };
+
+export type UsableLlmConfig = Exclude<ResolvedLlmConfig, { source: 'unavailable' }>;
 
 export class LlmUnavailableError extends Error {
   readonly status = 503;
@@ -68,14 +85,17 @@ export async function resolveLlmConfig(partnerId: string | null): Promise<Resolv
   try {
     apiKey = decryptPartnerLlmApiKey({ id: row.id, apiKeyEncrypted: row.apiKeyEncrypted });
   } catch (error) {
-    captureException(error, undefined, { service: 'llmConfigResolver', partnerId });
     if (error instanceof SecretKeyMaterialError) {
+      captureAtMostHourly(`key-material:${partnerId}`, () => {
+        captureException(error, undefined, { service: 'llmConfigResolver', partnerId });
+      });
       console.error(
         '[llmConfigResolver] partner config cannot be decrypted with this node key material',
         { partnerId, error },
       );
-      return { source: 'unavailable', partnerId, reason: 'key_error' };
+      return { source: 'unavailable', partnerId, reason: 'key_material' };
     }
+    captureException(error, undefined, { service: 'llmConfigResolver', partnerId });
     try {
       await markPartnerLlmError({
         configId: row.id,
@@ -103,26 +123,25 @@ export async function resolveLlmConfig(partnerId: string | null): Promise<Resolv
   };
 }
 
+export type PartnerLlmErrorReason = 'decrypt_failed' | 'auth_rejected';
+
 /**
  * Marks normalized credential failures only when the exact config row id and
  * version still match. Callers must not invoke this for Anthropic 429, 5xx,
  * network, timeout, or other retryable failures.
  */
-export type PartnerLlmErrorReason = 'decrypt_failed' | 'auth_rejected';
-
 export async function markPartnerLlmError(input: {
   configId: string;
   configVersion: number;
   reason: PartnerLlmErrorReason;
 }): Promise<boolean> {
-  const reason = input.reason.trim().slice(0, 160) || 'credential_error';
   return runOutsideDbContext(() =>
     withSystemDbAccessContext(async () => {
       const [updated] = await db
         .update(partnerLlmConfigs)
         .set({
           status: 'error',
-          lastError: reason,
+          lastError: input.reason,
           updatedAt: new Date(),
         })
         .where(and(
@@ -137,7 +156,7 @@ export async function markPartnerLlmError(input: {
 
 export async function getAnthropicClientForPartner(partnerId: string | null): Promise<{
   client: Anthropic;
-  resolved: Exclude<ResolvedLlmConfig, { source: 'unavailable' }>;
+  resolved: UsableLlmConfig;
 }> {
   const resolved = await resolveLlmConfig(partnerId);
   if (resolved.source === 'unavailable') {
@@ -145,7 +164,14 @@ export async function getAnthropicClientForPartner(partnerId: string | null): Pr
   }
   if (!resolved.apiKey?.trim()) {
     const error = new LlmUnavailableError('AI is not configured on this deployment.');
-    captureException(error, undefined, { service: 'llmConfigResolver' });
+    captureAtMostHourly('blank-platform-key:platform', () => {
+      captureMessage(
+        'AI is not configured on this deployment.',
+        'warning',
+        undefined,
+        { service: 'llmConfigResolver' },
+      );
+    });
     throw error;
   }
   return {

--- a/apps/api/src/services/llm/llmConfigResolver.ts
+++ b/apps/api/src/services/llm/llmConfigResolver.ts
@@ -1,0 +1,135 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { and, eq } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { partnerLlmConfigs } from '../../db/schema';
+import { resolveDefaultModel } from '../aiAgent';
+import { decryptPartnerLlmApiKey } from '../partnerLlmConfig';
+
+export type ResolvedLlmConfig =
+  | { source: 'platform'; apiKey: string | undefined; model: string }
+  | {
+      source: 'partner';
+      partnerId: string;
+      apiKey: string;
+      model: string;
+      configId: string;
+      configVersion: number;
+    }
+  | { source: 'unavailable'; partnerId: string; reason: 'key_error' };
+
+export class LlmUnavailableError extends Error {
+  readonly status = 503;
+  readonly code = 'ai_unavailable';
+
+  constructor() {
+    super('AI is unavailable until the Anthropic API key is reconnected.');
+    this.name = 'LlmUnavailableError';
+  }
+}
+
+async function readPartnerLlmConfig(partnerId: string) {
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const [row] = await db
+        .select({
+          id: partnerLlmConfigs.id,
+          partnerId: partnerLlmConfigs.partnerId,
+          apiKeyEncrypted: partnerLlmConfigs.apiKeyEncrypted,
+          defaultModel: partnerLlmConfigs.defaultModel,
+          status: partnerLlmConfigs.status,
+          configVersion: partnerLlmConfigs.configVersion,
+        })
+        .from(partnerLlmConfigs)
+        .where(eq(partnerLlmConfigs.partnerId, partnerId))
+        .limit(1);
+      return row;
+    }),
+  );
+}
+
+export async function resolveLlmConfig(partnerId: string | null): Promise<ResolvedLlmConfig> {
+  const platform = (): ResolvedLlmConfig => ({
+    source: 'platform',
+    apiKey: process.env.ANTHROPIC_API_KEY,
+    model: resolveDefaultModel(),
+  });
+
+  if (!partnerId) return platform();
+
+  const row = await readPartnerLlmConfig(partnerId);
+  if (!row) return platform();
+  if (row.status === 'error') {
+    return { source: 'unavailable', partnerId, reason: 'key_error' };
+  }
+
+  let apiKey: string;
+  try {
+    apiKey = decryptPartnerLlmApiKey({ id: row.id, apiKeyEncrypted: row.apiKeyEncrypted });
+  } catch {
+    try {
+      await markPartnerLlmError({
+        partnerId,
+        configVersion: row.configVersion,
+        reason: 'decrypt_failed',
+      });
+    } catch {
+      console.error('[llmConfigResolver] failed to mark unreadable partner config', {
+        partnerId,
+        configVersion: row.configVersion,
+      });
+    }
+    return { source: 'unavailable', partnerId, reason: 'key_error' };
+  }
+
+  return {
+    source: 'partner',
+    partnerId,
+    apiKey,
+    model: row.defaultModel ?? resolveDefaultModel(),
+    configId: row.id,
+    configVersion: row.configVersion,
+  };
+}
+
+/**
+ * Marks normalized credential failures only. Callers must not invoke this for
+ * Anthropic 429, 5xx, network, timeout, or other retryable failures.
+ */
+export async function markPartnerLlmError(input: {
+  partnerId: string;
+  configVersion: number;
+  reason: string;
+}): Promise<boolean> {
+  const reason = input.reason.trim().slice(0, 160) || 'credential_error';
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const [updated] = await db
+        .update(partnerLlmConfigs)
+        .set({
+          status: 'error',
+          lastError: reason,
+          updatedAt: new Date(),
+        })
+        .where(and(
+          eq(partnerLlmConfigs.partnerId, input.partnerId),
+          eq(partnerLlmConfigs.configVersion, input.configVersion),
+        ))
+        .returning({ id: partnerLlmConfigs.id });
+      return updated !== undefined;
+    }),
+  );
+}
+
+export async function getAnthropicClientForPartner(partnerId: string | null): Promise<{
+  client: Anthropic;
+  resolved: Exclude<ResolvedLlmConfig, { source: 'unavailable' }>;
+}> {
+  const resolved = await resolveLlmConfig(partnerId);
+  if (resolved.source === 'unavailable' || !resolved.apiKey?.trim()) {
+    throw new LlmUnavailableError();
+  }
+  return {
+    client: new Anthropic({ apiKey: resolved.apiKey }),
+    resolved,
+  };
+}

--- a/apps/api/src/services/partnerLlmConfig.test.ts
+++ b/apps/api/src/services/partnerLlmConfig.test.ts
@@ -1,5 +1,6 @@
 import { createHash, createHmac } from 'node:crypto';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 const PARTNER_ID = '11111111-1111-4111-8111-111111111111';
 const USER_ID = '22222222-2222-4222-8222-222222222222';
@@ -28,6 +29,7 @@ const { anthropicState, captureExceptionMock, dbState } = vi.hoisted(() => {
       deleteResults: [] as unknown[][],
       insertedValues: [] as Array<Record<string, unknown>>,
       updateSets: [] as Array<Record<string, unknown>>,
+      updateWheres: [] as unknown[],
       deleteWheres: [] as unknown[],
     },
   };
@@ -77,9 +79,12 @@ vi.mock('../db', () => ({
       set: vi.fn((values: Record<string, unknown>) => {
         dbState.updateSets.push(values);
         return {
-          where: vi.fn(() => ({
-            returning: vi.fn(() => Promise.resolve(dbState.updateResults.shift() ?? [])),
-          })),
+          where: vi.fn((condition: unknown) => {
+            dbState.updateWheres.push(condition);
+            return {
+              returning: vi.fn(() => Promise.resolve(dbState.updateResults.shift() ?? [])),
+            };
+          }),
         };
       }),
     })),
@@ -131,6 +136,11 @@ function apiKeyAad(id: string): string {
   return columnAad(spec, id);
 }
 
+function compileSql(expression: unknown): { sql: string; params: unknown[] } {
+  const { sql, params } = new PgDialect().sqlToQuery(expression as never);
+  return { sql, params };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   anthropicState.constructorOptions.length = 0;
@@ -140,6 +150,7 @@ beforeEach(() => {
   dbState.deleteResults.length = 0;
   dbState.insertedValues.length = 0;
   dbState.updateSets.length = 0;
+  dbState.updateWheres.length = 0;
   dbState.deleteWheres.length = 0;
   anthropicState.create.mockResolvedValue({ content: [], usage: { input_tokens: 1, output_tokens: 1 } });
 });
@@ -273,6 +284,14 @@ describe('savePartnerLlmKey', () => {
     expect(decryptSecret(String(updates.apiKeyEncrypted), { aad: apiKeyAad(CONFIG_ID) })).toBe(API_KEY);
     expect(updates.status).toBe('active');
     expect(updates.lastError).toBeNull();
+    expect(compileSql(updates.configVersion)).toEqual({
+      sql: '"partner_llm_configs"."config_version" + 1',
+      params: [],
+    });
+    expect(compileSql(dbState.updateWheres[0])).toEqual({
+      sql: '("partner_llm_configs"."partner_id" = $1 and "partner_llm_configs"."id" = $2)',
+      params: [PARTNER_ID, CONFIG_ID],
+    });
     expect(result).toMatchObject({ model: 'claude-haiku-4-5', configVersion: 8 });
   });
 });
@@ -283,6 +302,27 @@ describe('updatePartnerLlmConfig', () => {
       updatePartnerLlmConfig({ partnerId: PARTNER_ID, defaultModel: 'claude-made-up-model' }),
     ).rejects.toMatchObject({ name: 'PartnerLlmError', status: 400 });
     expect(dbState.updateSets).toHaveLength(0);
+  });
+
+  it('increments the config version with SQL when updating the default model', async () => {
+    dbState.updateResults.push([{ configVersion: 9 }]);
+
+    await expect(updatePartnerLlmConfig({
+      partnerId: PARTNER_ID,
+      defaultModel: 'claude-haiku-4-5',
+    })).resolves.toEqual({
+      defaultModel: 'claude-haiku-4-5',
+      configVersion: 9,
+    });
+
+    expect(compileSql(dbState.updateSets[0]?.configVersion)).toEqual({
+      sql: '"partner_llm_configs"."config_version" + 1',
+      params: [],
+    });
+    expect(compileSql(dbState.updateWheres[0])).toEqual({
+      sql: '"partner_llm_configs"."partner_id" = $1',
+      params: [PARTNER_ID],
+    });
   });
 });
 
@@ -312,5 +352,9 @@ describe('deletePartnerLlmConfig', () => {
     dbState.deleteResults.push([...deletedRows]);
 
     await expect(deletePartnerLlmConfig(PARTNER_ID)).resolves.toBe(expected);
+    expect(compileSql(dbState.deleteWheres[0])).toEqual({
+      sql: '"partner_llm_configs"."partner_id" = $1',
+      params: [PARTNER_ID],
+    });
   });
 });

--- a/apps/api/src/services/partnerLlmConfig.test.ts
+++ b/apps/api/src/services/partnerLlmConfig.test.ts
@@ -1,0 +1,241 @@
+import { createHash, createHmac } from 'node:crypto';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const PARTNER_ID = '11111111-1111-4111-8111-111111111111';
+const USER_ID = '22222222-2222-4222-8222-222222222222';
+const CONFIG_ID = '33333333-3333-4333-8333-333333333333';
+const API_KEY = 'sk-ant-api03-unit-test-key-1234567890';
+
+const { anthropicState, dbState } = vi.hoisted(() => ({
+  anthropicState: {
+    constructorOptions: [] as Array<{ apiKey?: string }>,
+    create: vi.fn(),
+  },
+  dbState: {
+    insertResults: [] as unknown[][],
+    selectResults: [] as unknown[][],
+    updateResults: [] as unknown[][],
+    insertedValues: [] as Array<Record<string, unknown>>,
+    updateSets: [] as Array<Record<string, unknown>>,
+    deleteWheres: [] as unknown[],
+  },
+}));
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = { create: anthropicState.create };
+    constructor(options: { apiKey?: string }) {
+      anthropicState.constructorOptions.push(options);
+    }
+  },
+}));
+
+vi.mock('./aiAgent', () => ({
+  resolveDefaultModel: () => 'claude-sonnet-4-6',
+}));
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: async (fn: () => unknown) => fn(),
+  db: {
+    insert: vi.fn(() => ({
+      values: vi.fn((values: Record<string, unknown>) => {
+        dbState.insertedValues.push(values);
+        return {
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn(() => Promise.resolve(dbState.insertResults.shift() ?? [])),
+          })),
+        };
+      }),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve(dbState.selectResults.shift() ?? [])),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: Record<string, unknown>) => {
+        dbState.updateSets.push(values);
+        return {
+          where: vi.fn(() => ({
+            returning: vi.fn(() => Promise.resolve(dbState.updateResults.shift() ?? [])),
+          })),
+        };
+      }),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn((condition: unknown) => {
+        dbState.deleteWheres.push(condition);
+        return Promise.resolve();
+      }),
+    })),
+  },
+}));
+
+import { decryptSecret } from './secretCrypto';
+import { columnAad, encryptedColumnRegistry } from './encryptedColumnRegistry';
+import {
+  getPartnerLlmStatus,
+  PartnerLlmError,
+  savePartnerLlmKey,
+  updatePartnerLlmConfig,
+} from './partnerLlmConfig';
+
+const originalEncryptionEnv = {
+  key: process.env.APP_ENCRYPTION_KEY,
+  keyId: process.env.APP_ENCRYPTION_KEY_ID,
+  keyring: process.env.APP_ENCRYPTION_KEYRING,
+};
+
+process.env.APP_ENCRYPTION_KEY = 'partner-llm-unit-test-key-material';
+process.env.APP_ENCRYPTION_KEY_ID = 'partner-llm-test';
+delete process.env.APP_ENCRYPTION_KEYRING;
+
+function expectedFingerprint(value: string): string {
+  const encryptionKey = createHash('sha256')
+    .update('partner-llm-unit-test-key-material')
+    .digest();
+  return createHmac('sha256', encryptionKey).update(value).digest('hex');
+}
+
+function apiKeyAad(id: string): string {
+  const spec = encryptedColumnRegistry.find(
+    (entry) => entry.table === 'partner_llm_configs' && entry.column === 'api_key_encrypted',
+  );
+  if (!spec) throw new Error('partner LLM encrypted-column registration missing');
+  return columnAad(spec, id);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  anthropicState.constructorOptions.length = 0;
+  dbState.insertResults.length = 0;
+  dbState.selectResults.length = 0;
+  dbState.updateResults.length = 0;
+  dbState.insertedValues.length = 0;
+  dbState.updateSets.length = 0;
+  dbState.deleteWheres.length = 0;
+  anthropicState.create.mockResolvedValue({ content: [], usage: { input_tokens: 1, output_tokens: 1 } });
+});
+
+afterAll(() => {
+  if (originalEncryptionEnv.key === undefined) delete process.env.APP_ENCRYPTION_KEY;
+  else process.env.APP_ENCRYPTION_KEY = originalEncryptionEnv.key;
+  if (originalEncryptionEnv.keyId === undefined) delete process.env.APP_ENCRYPTION_KEY_ID;
+  else process.env.APP_ENCRYPTION_KEY_ID = originalEncryptionEnv.keyId;
+  if (originalEncryptionEnv.keyring === undefined) delete process.env.APP_ENCRYPTION_KEYRING;
+  else process.env.APP_ENCRYPTION_KEYRING = originalEncryptionEnv.keyring;
+});
+
+describe('savePartnerLlmKey', () => {
+  it('leaves the existing row untouched when Anthropic rejects the probe', async () => {
+    anthropicState.create.mockRejectedValue(Object.assign(new Error('rejected'), { status: 401 }));
+
+    await expect(
+      savePartnerLlmKey({ partnerId: PARTNER_ID, apiKey: API_KEY, userId: USER_ID }),
+    ).rejects.toMatchObject({
+      name: 'PartnerLlmError',
+      status: 400,
+      message: expect.stringContaining('rejected'),
+    });
+
+    expect(dbState.insertedValues).toHaveLength(0);
+    expect(dbState.updateSets).toHaveLength(0);
+  });
+
+  it('maps an Anthropic permission rejection to 409 without persisting', async () => {
+    anthropicState.create.mockRejectedValue(Object.assign(new Error('forbidden'), { status: 403 }));
+
+    await expect(
+      savePartnerLlmKey({ partnerId: PARTNER_ID, apiKey: API_KEY, userId: USER_ID }),
+    ).rejects.toMatchObject({ name: 'PartnerLlmError', status: 409 });
+
+    expect(dbState.insertedValues).toHaveLength(0);
+    expect(dbState.updateSets).toHaveLength(0);
+  });
+
+  it('rejects an encrypted-envelope paste before probing or writing', async () => {
+    await expect(
+      savePartnerLlmKey({ partnerId: PARTNER_ID, apiKey: 'enc:v3:key:pretend.payload.here', userId: USER_ID }),
+    ).rejects.toBeInstanceOf(PartnerLlmError);
+
+    expect(anthropicState.create).not.toHaveBeenCalled();
+    expect(dbState.insertedValues).toHaveLength(0);
+    expect(dbState.updateSets).toHaveLength(0);
+  });
+
+  it('probes first and persists a row-bound ciphertext, last4, HMAC fingerprint, and version 1', async () => {
+    dbState.insertResults.push([{ id: CONFIG_ID, configVersion: 1 }]);
+
+    const result = await savePartnerLlmKey({
+      partnerId: PARTNER_ID,
+      apiKey: `  ${API_KEY}  `,
+      userId: USER_ID,
+    });
+
+    expect(anthropicState.constructorOptions).toEqual([{ apiKey: API_KEY }]);
+    expect(anthropicState.create).toHaveBeenCalledWith({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 1,
+      messages: [{ role: 'user', content: 'ping' }],
+    });
+    const values = dbState.insertedValues[0]!;
+    expect(values.apiKeyEncrypted).not.toBe(API_KEY);
+    expect(String(values.apiKeyEncrypted)).not.toContain(API_KEY);
+    expect(decryptSecret(String(values.apiKeyEncrypted), { aad: apiKeyAad(String(values.id)) })).toBe(API_KEY);
+    expect(values.keyLast4).toBe('7890');
+    expect(values.keyFingerprint).toBe(expectedFingerprint(API_KEY));
+    expect(values.configVersion).toBe(1);
+    expect(values.status).toBe('active');
+    expect(values.lastError).toBeNull();
+    expect(result).toMatchObject({
+      last4: '7890',
+      model: 'claude-sonnet-4-6',
+      configVersion: 1,
+      verifiedAt: expect.any(Date),
+    });
+  });
+
+  it('re-encrypts against the existing row id and increments the version on replacement', async () => {
+    dbState.insertResults.push([]);
+    dbState.selectResults.push([{ id: CONFIG_ID, defaultModel: 'claude-haiku-4-5' }]);
+    dbState.updateResults.push([{ configVersion: 8 }]);
+
+    const result = await savePartnerLlmKey({ partnerId: PARTNER_ID, apiKey: API_KEY, userId: USER_ID });
+
+    const updates = dbState.updateSets[0]!;
+    expect(decryptSecret(String(updates.apiKeyEncrypted), { aad: apiKeyAad(CONFIG_ID) })).toBe(API_KEY);
+    expect(updates.status).toBe('active');
+    expect(updates.lastError).toBeNull();
+    expect(result).toMatchObject({ model: 'claude-haiku-4-5', configVersion: 8 });
+  });
+});
+
+describe('updatePartnerLlmConfig', () => {
+  it('rejects an unknown default model without writing', async () => {
+    await expect(
+      updatePartnerLlmConfig({ partnerId: PARTNER_ID, defaultModel: 'claude-made-up-model' }),
+    ).rejects.toMatchObject({ name: 'PartnerLlmError', status: 400 });
+    expect(dbState.updateSets).toHaveLength(0);
+  });
+});
+
+describe('getPartnerLlmStatus', () => {
+  it('preserves null defaultModel so callers can distinguish platform inheritance', async () => {
+    dbState.selectResults.push([{
+      provider: 'anthropic',
+      keyLast4: '7890',
+      defaultModel: null,
+      status: 'active',
+      verifiedAt: new Date('2026-08-23T12:00:00.000Z'),
+      lastError: null,
+    }]);
+
+    await expect(getPartnerLlmStatus(PARTNER_ID)).resolves.toMatchObject({
+      configured: true,
+      defaultModel: null,
+    });
+  });
+});

--- a/apps/api/src/services/partnerLlmConfig.test.ts
+++ b/apps/api/src/services/partnerLlmConfig.test.ts
@@ -6,32 +6,50 @@ const USER_ID = '22222222-2222-4222-8222-222222222222';
 const CONFIG_ID = '33333333-3333-4333-8333-333333333333';
 const API_KEY = 'sk-ant-api03-unit-test-key-1234567890';
 
-const { anthropicState, dbState } = vi.hoisted(() => ({
-  anthropicState: {
-    constructorOptions: [] as Array<{ apiKey?: string }>,
-    create: vi.fn(),
-  },
-  dbState: {
-    insertResults: [] as unknown[][],
-    selectResults: [] as unknown[][],
-    updateResults: [] as unknown[][],
-    insertedValues: [] as Array<Record<string, unknown>>,
-    updateSets: [] as Array<Record<string, unknown>>,
-    deleteWheres: [] as unknown[],
-  },
-}));
+const { anthropicState, captureExceptionMock, dbState } = vi.hoisted(() => {
+  class MockAnthropicApiError extends Error {
+    constructor(message: string, readonly status?: number) {
+      super(message);
+      this.name = 'APIError';
+    }
+  }
 
-vi.mock('@anthropic-ai/sdk', () => ({
-  default: class MockAnthropic {
+  return {
+    anthropicState: {
+      constructorOptions: [] as Array<{ apiKey?: string }>,
+      create: vi.fn(),
+      apiErrorClass: MockAnthropicApiError,
+    },
+    captureExceptionMock: vi.fn(),
+    dbState: {
+      insertResults: [] as unknown[][],
+      selectResults: [] as unknown[][],
+      updateResults: [] as unknown[][],
+      deleteResults: [] as unknown[][],
+      insertedValues: [] as Array<Record<string, unknown>>,
+      updateSets: [] as Array<Record<string, unknown>>,
+      deleteWheres: [] as unknown[],
+    },
+  };
+});
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class MockAnthropic {
+    static APIError = anthropicState.apiErrorClass;
     messages = { create: anthropicState.create };
     constructor(options: { apiKey?: string }) {
       anthropicState.constructorOptions.push(options);
     }
-  },
-}));
+  }
+  return { default: MockAnthropic };
+});
 
 vi.mock('./aiAgent', () => ({
   resolveDefaultModel: () => 'claude-sonnet-4-6',
+}));
+
+vi.mock('./sentry', () => ({
+  captureException: captureExceptionMock,
 }));
 
 vi.mock('../db', () => ({
@@ -68,7 +86,9 @@ vi.mock('../db', () => ({
     delete: vi.fn(() => ({
       where: vi.fn((condition: unknown) => {
         dbState.deleteWheres.push(condition);
-        return Promise.resolve();
+        return {
+          returning: vi.fn(() => Promise.resolve(dbState.deleteResults.shift() ?? [])),
+        };
       }),
     })),
   },
@@ -77,11 +97,13 @@ vi.mock('../db', () => ({
 import { decryptSecret } from './secretCrypto';
 import { columnAad, encryptedColumnRegistry } from './encryptedColumnRegistry';
 import {
+  deletePartnerLlmConfig,
   getPartnerLlmStatus,
   PartnerLlmError,
   savePartnerLlmKey,
   updatePartnerLlmConfig,
 } from './partnerLlmConfig';
+import { captureException } from './sentry';
 
 const originalEncryptionEnv = {
   key: process.env.APP_ENCRYPTION_KEY,
@@ -97,7 +119,8 @@ function expectedFingerprint(value: string): string {
   const encryptionKey = createHash('sha256')
     .update('partner-llm-unit-test-key-material')
     .digest();
-  return createHmac('sha256', encryptionKey).update(value).digest('hex');
+  const hex = createHmac('sha256', encryptionKey).update(value).digest('hex');
+  return `fp1:partner-llm-test:${hex}`;
 }
 
 function apiKeyAad(id: string): string {
@@ -114,6 +137,7 @@ beforeEach(() => {
   dbState.insertResults.length = 0;
   dbState.selectResults.length = 0;
   dbState.updateResults.length = 0;
+  dbState.deleteResults.length = 0;
   dbState.insertedValues.length = 0;
   dbState.updateSets.length = 0;
   dbState.deleteWheres.length = 0;
@@ -131,7 +155,7 @@ afterAll(() => {
 
 describe('savePartnerLlmKey', () => {
   it('leaves the existing row untouched when Anthropic rejects the probe', async () => {
-    anthropicState.create.mockRejectedValue(Object.assign(new Error('rejected'), { status: 401 }));
+    anthropicState.create.mockRejectedValue(new anthropicState.apiErrorClass('rejected', 401));
 
     await expect(
       savePartnerLlmKey({ partnerId: PARTNER_ID, apiKey: API_KEY, userId: USER_ID }),
@@ -146,11 +170,51 @@ describe('savePartnerLlmKey', () => {
   });
 
   it('maps an Anthropic permission rejection to 409 without persisting', async () => {
-    anthropicState.create.mockRejectedValue(Object.assign(new Error('forbidden'), { status: 403 }));
+    anthropicState.create.mockRejectedValue(new anthropicState.apiErrorClass('forbidden', 403));
 
     await expect(
       savePartnerLlmKey({ partnerId: PARTNER_ID, apiKey: API_KEY, userId: USER_ID }),
     ).rejects.toMatchObject({ name: 'PartnerLlmError', status: 409 });
+
+    expect(dbState.insertedValues).toHaveLength(0);
+    expect(dbState.updateSets).toHaveLength(0);
+  });
+
+  it('rethrows a non-APIError from the probe without wrapping or persisting', async () => {
+    const error = new Error('unexpected programming failure');
+    anthropicState.create.mockRejectedValue(error);
+
+    await expect(
+      savePartnerLlmKey({ partnerId: PARTNER_ID, apiKey: API_KEY, userId: USER_ID }),
+    ).rejects.toBe(error);
+
+    expect(dbState.insertedValues).toHaveLength(0);
+    expect(dbState.updateSets).toHaveLength(0);
+  });
+
+  it('maps another Anthropic 4xx rejection to 400 without exposing the response body', async () => {
+    const error = new anthropicState.apiErrorClass('sensitive upstream response', 404);
+    anthropicState.create.mockRejectedValue(error);
+
+    await expect(
+      savePartnerLlmKey({ partnerId: PARTNER_ID, apiKey: API_KEY, userId: USER_ID }),
+    ).rejects.toMatchObject({
+      name: 'PartnerLlmError',
+      status: 400,
+      message: 'Anthropic rejected the verification request (HTTP 404). The probe model may be unavailable — contact support if this persists.',
+    });
+
+    expect(captureException).toHaveBeenCalledWith(error, undefined, { service: 'partnerLlmConfig' });
+    expect(dbState.insertedValues).toHaveLength(0);
+    expect(dbState.updateSets).toHaveLength(0);
+  });
+
+  it('maps Anthropic rate limiting to a transient 503 without persisting', async () => {
+    anthropicState.create.mockRejectedValue(new anthropicState.apiErrorClass('rate limited', 429));
+
+    await expect(
+      savePartnerLlmKey({ partnerId: PARTNER_ID, apiKey: API_KEY, userId: USER_ID }),
+    ).rejects.toMatchObject({ name: 'PartnerLlmError', status: 503 });
 
     expect(dbState.insertedValues).toHaveLength(0);
     expect(dbState.updateSets).toHaveLength(0);
@@ -237,5 +301,16 @@ describe('getPartnerLlmStatus', () => {
       configured: true,
       defaultModel: null,
     });
+  });
+});
+
+describe('deletePartnerLlmConfig', () => {
+  it.each([
+    [[{ id: CONFIG_ID }], true],
+    [[], false],
+  ] as const)('returns whether a config row was deleted', async (deletedRows, expected) => {
+    dbState.deleteResults.push([...deletedRows]);
+
+    await expect(deletePartnerLlmConfig(PARTNER_ID)).resolves.toBe(expected);
   });
 });

--- a/apps/api/src/services/partnerLlmConfig.ts
+++ b/apps/api/src/services/partnerLlmConfig.ts
@@ -1,0 +1,236 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { randomUUID } from 'node:crypto';
+import { and, eq, sql } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { partnerLlmConfigs } from '../db/schema';
+import { resolveDefaultModel } from './aiAgent';
+import { SUPPORTED_AI_MODELS } from './aiCostTracker';
+import {
+  columnAad,
+  encryptedColumnRegistry,
+  type EncryptedColumnSpec,
+} from './encryptedColumnRegistry';
+import { decryptSecret, encryptSecret, hmacFingerprint } from './secretCrypto';
+
+const API_KEY_SPEC: EncryptedColumnSpec = (() => {
+  const spec = encryptedColumnRegistry.find(
+    (entry) => entry.table === 'partner_llm_configs' && entry.column === 'api_key_encrypted',
+  );
+  if (!spec) throw new Error('partner_llm_configs.api_key_encrypted is missing from encryptedColumnRegistry');
+  return spec;
+})();
+
+export class PartnerLlmError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 400 | 409 | 500 | 503,
+  ) {
+    super(message);
+    this.name = 'PartnerLlmError';
+  }
+}
+
+export interface PartnerLlmStatus {
+  configured: boolean;
+  provider: 'anthropic';
+  keyLast4: string | null;
+  defaultModel: string | null;
+  status: 'platform' | 'active' | 'error';
+  verifiedAt: Date | null;
+  lastError: string | null;
+}
+
+function encryptPartnerLlmApiKey(id: string, apiKey: string): string {
+  const encrypted = encryptSecret(apiKey, { aad: columnAad(API_KEY_SPEC, id) });
+  if (!encrypted) throw new PartnerLlmError('Could not encrypt the Anthropic API key.', 500);
+  return encrypted;
+}
+
+export function decryptPartnerLlmApiKey(row: { id: string; apiKeyEncrypted: string }): string {
+  const apiKey = decryptSecret(row.apiKeyEncrypted, { aad: columnAad(API_KEY_SPEC, row.id) });
+  if (!apiKey) throw new Error('Stored Anthropic API key decrypted to an empty value');
+  return apiKey;
+}
+
+function anthropicStatus(error: unknown): number | undefined {
+  return (error as { status?: number } | null)?.status;
+}
+
+async function probeAnthropicKey(apiKey: string): Promise<void> {
+  try {
+    const client = new Anthropic({ apiKey });
+    await runOutsideDbContext(() => client.messages.create({
+      model: resolveDefaultModel(),
+      max_tokens: 1,
+      messages: [{ role: 'user', content: 'ping' }],
+    }));
+  } catch (error) {
+    const status = anthropicStatus(error);
+    if (status === 401) {
+      throw new PartnerLlmError('That Anthropic API key was rejected. Check the key and try again.', 400);
+    }
+    if (status === 403) {
+      throw new PartnerLlmError('Anthropic denied access for that API key. Check its permissions and try again.', 409);
+    }
+    throw new PartnerLlmError('Anthropic could not verify the API key right now. Try again later.', 503);
+  }
+}
+
+export async function savePartnerLlmKey(input: {
+  partnerId: string;
+  apiKey: string;
+  userId: string;
+}): Promise<{
+  last4: string;
+  model: string;
+  verifiedAt: Date;
+  configVersion: number;
+}> {
+  const apiKey = input.apiKey.trim();
+  if (apiKey.startsWith('enc:')) {
+    throw new PartnerLlmError('Anthropic API keys must not start with the encrypted-value prefix.', 400);
+  }
+
+  await probeAnthropicKey(apiKey);
+
+  const id = randomUUID();
+  const last4 = apiKey.slice(-4);
+  const fingerprint = hmacFingerprint(apiKey);
+  const verifiedAt = new Date();
+
+  const stored = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const [inserted] = await db
+        .insert(partnerLlmConfigs)
+        .values({
+          id,
+          partnerId: input.partnerId,
+          apiKeyEncrypted: encryptPartnerLlmApiKey(id, apiKey),
+          keyLast4: last4,
+          keyFingerprint: fingerprint,
+          status: 'active',
+          configVersion: 1,
+          lastError: null,
+          verifiedAt,
+          connectedBy: input.userId,
+          updatedAt: verifiedAt,
+        })
+        .onConflictDoNothing({ target: partnerLlmConfigs.partnerId })
+        .returning({ id: partnerLlmConfigs.id, configVersion: partnerLlmConfigs.configVersion });
+
+      if (inserted) {
+        return { configVersion: inserted.configVersion, defaultModel: null as string | null };
+      }
+
+      const [existing] = await db
+        .select({
+          id: partnerLlmConfigs.id,
+          defaultModel: partnerLlmConfigs.defaultModel,
+        })
+        .from(partnerLlmConfigs)
+        .where(eq(partnerLlmConfigs.partnerId, input.partnerId))
+        .limit(1);
+      if (!existing) {
+        throw new PartnerLlmError('Could not replace the Anthropic API key.', 500);
+      }
+
+      const [updated] = await db
+        .update(partnerLlmConfigs)
+        .set({
+          apiKeyEncrypted: encryptPartnerLlmApiKey(existing.id, apiKey),
+          keyLast4: last4,
+          keyFingerprint: fingerprint,
+          status: 'active',
+          configVersion: sql`${partnerLlmConfigs.configVersion} + 1`,
+          lastError: null,
+          verifiedAt,
+          connectedBy: input.userId,
+          updatedAt: verifiedAt,
+        })
+        .where(and(
+          eq(partnerLlmConfigs.partnerId, input.partnerId),
+          eq(partnerLlmConfigs.id, existing.id),
+        ))
+        .returning({ configVersion: partnerLlmConfigs.configVersion });
+      if (!updated) {
+        throw new PartnerLlmError('Could not replace the Anthropic API key.', 500);
+      }
+      return { configVersion: updated.configVersion, defaultModel: existing.defaultModel };
+    }),
+  );
+
+  return {
+    last4,
+    model: stored.defaultModel ?? resolveDefaultModel(),
+    verifiedAt,
+    configVersion: stored.configVersion,
+  };
+}
+
+export async function getPartnerLlmStatus(partnerId: string): Promise<PartnerLlmStatus> {
+  const [row] = await db
+    .select({
+      provider: partnerLlmConfigs.provider,
+      keyLast4: partnerLlmConfigs.keyLast4,
+      defaultModel: partnerLlmConfigs.defaultModel,
+      status: partnerLlmConfigs.status,
+      verifiedAt: partnerLlmConfigs.verifiedAt,
+      lastError: partnerLlmConfigs.lastError,
+    })
+    .from(partnerLlmConfigs)
+    .where(eq(partnerLlmConfigs.partnerId, partnerId))
+    .limit(1);
+
+  if (!row) {
+    return {
+      configured: false,
+      provider: 'anthropic',
+      keyLast4: null,
+      defaultModel: null,
+      status: 'platform',
+      verifiedAt: null,
+      lastError: null,
+    };
+  }
+
+  return {
+    configured: true,
+    provider: 'anthropic',
+    keyLast4: row.keyLast4,
+    defaultModel: row.defaultModel,
+    status: row.status === 'error' ? 'error' : 'active',
+    verifiedAt: row.verifiedAt,
+    lastError: row.lastError,
+  };
+}
+
+export async function updatePartnerLlmConfig(input: {
+  partnerId: string;
+  defaultModel: string | null;
+}): Promise<{ defaultModel: string | null; configVersion: number }> {
+  if (input.defaultModel !== null && !SUPPORTED_AI_MODELS.includes(input.defaultModel)) {
+    throw new PartnerLlmError('Unsupported Anthropic model.', 400);
+  }
+
+  const [updated] = await db
+    .update(partnerLlmConfigs)
+    .set({
+      defaultModel: input.defaultModel,
+      configVersion: sql`${partnerLlmConfigs.configVersion} + 1`,
+      updatedAt: new Date(),
+    })
+    .where(eq(partnerLlmConfigs.partnerId, input.partnerId))
+    .returning({ configVersion: partnerLlmConfigs.configVersion });
+  if (!updated) {
+    throw new PartnerLlmError('Connect an Anthropic API key before selecting a model.', 409);
+  }
+
+  return {
+    defaultModel: input.defaultModel,
+    configVersion: updated.configVersion,
+  };
+}
+
+export async function deletePartnerLlmConfig(partnerId: string): Promise<void> {
+  await db.delete(partnerLlmConfigs).where(eq(partnerLlmConfigs.partnerId, partnerId));
+}

--- a/apps/api/src/services/partnerLlmConfig.ts
+++ b/apps/api/src/services/partnerLlmConfig.ts
@@ -205,7 +205,7 @@ export async function getPartnerLlmStatus(partnerId: string): Promise<PartnerLlm
     provider: 'anthropic',
     keyLast4: row.keyLast4,
     defaultModel: row.defaultModel,
-    status: row.status === 'error' ? 'error' : 'active',
+    status: row.status,
     verifiedAt: row.verifiedAt,
     lastError: row.lastError,
   };

--- a/apps/api/src/services/partnerLlmConfig.ts
+++ b/apps/api/src/services/partnerLlmConfig.ts
@@ -11,6 +11,7 @@ import {
   type EncryptedColumnSpec,
 } from './encryptedColumnRegistry';
 import { decryptSecret, encryptSecret, hmacFingerprint } from './secretCrypto';
+import { captureException } from './sentry';
 
 const API_KEY_SPEC: EncryptedColumnSpec = (() => {
   const spec = encryptedColumnRegistry.find(
@@ -52,25 +53,31 @@ export function decryptPartnerLlmApiKey(row: { id: string; apiKeyEncrypted: stri
   return apiKey;
 }
 
-function anthropicStatus(error: unknown): number | undefined {
-  return (error as { status?: number } | null)?.status;
-}
-
 async function probeAnthropicKey(apiKey: string): Promise<void> {
+  const model = resolveDefaultModel();
   try {
     const client = new Anthropic({ apiKey });
     await runOutsideDbContext(() => client.messages.create({
-      model: resolveDefaultModel(),
+      model,
       max_tokens: 1,
       messages: [{ role: 'user', content: 'ping' }],
     }));
   } catch (error) {
-    const status = anthropicStatus(error);
+    if (!(error instanceof Anthropic.APIError)) throw error;
+    const status = error.status;
     if (status === 401) {
       throw new PartnerLlmError('That Anthropic API key was rejected. Check the key and try again.', 400);
     }
     if (status === 403) {
       throw new PartnerLlmError('Anthropic denied access for that API key. Check its permissions and try again.', 409);
+    }
+    if (status !== undefined && status >= 400 && status < 500 && status !== 429) {
+      captureException(error, undefined, { service: 'partnerLlmConfig' });
+      throw new PartnerLlmError(
+        `Anthropic rejected the verification request (HTTP ${status}). ` +
+        'The probe model may be unavailable — contact support if this persists.',
+        400,
+      );
     }
     throw new PartnerLlmError('Anthropic could not verify the API key right now. Try again later.', 503);
   }
@@ -231,6 +238,10 @@ export async function updatePartnerLlmConfig(input: {
   };
 }
 
-export async function deletePartnerLlmConfig(partnerId: string): Promise<void> {
-  await db.delete(partnerLlmConfigs).where(eq(partnerLlmConfigs.partnerId, partnerId));
+export async function deletePartnerLlmConfig(partnerId: string): Promise<boolean> {
+  const [deleted] = await db
+    .delete(partnerLlmConfigs)
+    .where(eq(partnerLlmConfigs.partnerId, partnerId))
+    .returning({ id: partnerLlmConfigs.id });
+  return deleted !== undefined;
 }

--- a/apps/api/src/services/secretCrypto.test.ts
+++ b/apps/api/src/services/secretCrypto.test.ts
@@ -13,6 +13,7 @@ const ENV_KEYS = [
 ] as const;
 
 const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+const originalNodeEnv = process.env.NODE_ENV;
 
 async function loadSecretCrypto(env: Partial<Record<(typeof ENV_KEYS)[number], string>> = {}) {
   vi.resetModules();
@@ -21,6 +22,15 @@ async function loadSecretCrypto(env: Partial<Record<(typeof ENV_KEYS)[number], s
   }
   Object.assign(process.env, env);
   return import('./secretCrypto');
+}
+
+function caughtError(fn: () => unknown): unknown {
+  try {
+    fn();
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected function to throw');
 }
 
 describe('secretCrypto', () => {
@@ -44,6 +54,8 @@ describe('secretCrypto', () => {
         process.env[key] = value;
       }
     }
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
   });
 
   it('encrypts and decrypts a value', async () => {
@@ -189,7 +201,36 @@ describe('secretCrypto', () => {
       APP_ENCRYPTION_KEYRING: JSON.stringify({ current: 'current-key-material' })
     });
 
-    expect(() => currentCrypto.decryptSecret(oldCiphertext)).toThrow('Unknown encrypted secret key ID');
+    const error = caughtError(() => currentCrypto.decryptSecret(oldCiphertext));
+    expect(currentCrypto.SecretKeyMaterialError).toBeTypeOf('function');
+    expect(error).toBeInstanceOf(currentCrypto.SecretKeyMaterialError);
+    expect(error).toMatchObject({ message: 'Unknown encrypted secret key ID' });
+  });
+
+  it('types a missing production encryption key as key-material failure', async () => {
+    process.env.NODE_ENV = 'production';
+    const crypto = await loadSecretCrypto();
+
+    const error = caughtError(() => crypto.encryptSecret('secret'));
+    expect(crypto.SecretKeyMaterialError).toBeTypeOf('function');
+    expect(error).toBeInstanceOf(crypto.SecretKeyMaterialError);
+    expect(error).toMatchObject({
+      message: 'Missing APP_ENCRYPTION_KEY for secret encryption in production. ' +
+        'Set APP_ENCRYPTION_KEY (or SSO_ENCRYPTION_KEY/SECRET_ENCRYPTION_KEY) in your environment.',
+    });
+  });
+
+  it('scopes HMAC fingerprints to the active encryption key generation', async () => {
+    const currentCrypto = await loadSecretCrypto({
+      APP_ENCRYPTION_KEY: 'current-key-material',
+      APP_ENCRYPTION_KEY_ID: 'current',
+    });
+    expect(currentCrypto.hmacFingerprint('same-secret')).toMatch(/^fp1:current:[a-f0-9]{64}$/);
+
+    const legacyCrypto = await loadSecretCrypto({
+      APP_ENCRYPTION_KEY: 'legacy-key-material',
+    });
+    expect(legacyCrypto.hmacFingerprint('same-secret')).toMatch(/^fp1:legacy:[a-f0-9]{64}$/);
   });
 
   it('rejects malformed keyring configuration when needed', async () => {
@@ -279,13 +320,16 @@ describe('secretCrypto', () => {
     });
 
     it('refuses to decrypt v3 without aad', async () => {
-      const { encryptSecret, decryptSecret } = await loadSecretCrypto({
+      const crypto = await loadSecretCrypto({
         APP_ENCRYPTION_KEY: 'current-key-material',
         APP_ENCRYPTION_KEY_ID: 'current',
       });
 
-      const encrypted = encryptSecret('hello', { aad: 'webhooks.secret' });
-      expect(() => decryptSecret(encrypted)).toThrow();
+      const encrypted = crypto.encryptSecret('hello', { aad: 'webhooks.secret' });
+      const error = caughtError(() => crypto.decryptSecret(encrypted));
+      expect(crypto.SecretKeyMaterialError).toBeTypeOf('function');
+      expect(error).toBeInstanceOf(crypto.SecretKeyMaterialError);
+      expect(error).toMatchObject({ message: 'AAD is required to decrypt v3 secrets' });
     });
 
     it('continues to decrypt v2 (no aad) without breaking', async () => {

--- a/apps/api/src/services/secretCrypto.ts
+++ b/apps/api/src/services/secretCrypto.ts
@@ -6,6 +6,13 @@ const ENCRYPTED_V3_PREFIX = 'enc:v3:';
 const ENCRYPTION_ALGORITHM = 'aes-256-gcm';
 const KEY_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
 
+export class SecretKeyMaterialError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SecretKeyMaterialError';
+  }
+}
+
 export interface SecretCryptoOptions {
   /**
    * Optional Additional Authenticated Data (AAD) binding for the ciphertext.
@@ -98,7 +105,7 @@ function getEncryptionKey(): Buffer {
         'Set APP_ENCRYPTION_KEY to a dedicated random value. See .env.example for details.'
       );
     }
-    throw new Error(
+    throw new SecretKeyMaterialError(
       'Missing APP_ENCRYPTION_KEY for secret encryption in production. ' +
       'Set APP_ENCRYPTION_KEY (or SSO_ENCRYPTION_KEY/SECRET_ENCRYPTION_KEY) in your environment.'
     );
@@ -121,7 +128,9 @@ function getEncryptionKey(): Buffer {
 export function hmacFingerprint(value: string): string {
   const activeKeyId = getActiveKeyId();
   const key = activeKeyId ? getV2EncryptionKey(activeKeyId) : getEncryptionKey();
-  return createHmac('sha256', key).update(value).digest('hex');
+  const hex = createHmac('sha256', key).update(value).digest('hex');
+  // Fingerprints are comparable only within one encryption-key generation.
+  return `fp1:${activeKeyId ?? 'legacy'}:${hex}`;
 }
 
 function getActiveKeyId(): string | null {
@@ -197,7 +206,7 @@ function getV2EncryptionKey(keyId: string): Buffer {
     }
   }
 
-  throw new Error('Unknown encrypted secret key ID');
+  throw new SecretKeyMaterialError('Unknown encrypted secret key ID');
 }
 
 function parseEncryptedPayload(encoded: string): {
@@ -409,7 +418,7 @@ export function decryptSecret(
     // decrypt with empty AAD which doesn't match what we encrypted with. We
     // fail closed instead of trying empty AAD.
     if (!options.aad) {
-      throw new Error('AAD is required to decrypt v3 secrets');
+      throw new SecretKeyMaterialError('AAD is required to decrypt v3 secrets');
     }
     return decryptWithKey(payload, getV2EncryptionKey(keyId), Buffer.from(options.aad, 'utf8'));
   }

--- a/apps/api/src/services/secretCrypto.ts
+++ b/apps/api/src/services/secretCrypto.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto';
+import { createCipheriv, createDecipheriv, createHash, createHmac, randomBytes } from 'crypto';
 
 const ENCRYPTED_V1_PREFIX = 'enc:v1:';
 const ENCRYPTED_V2_PREFIX = 'enc:v2:';
@@ -116,6 +116,12 @@ function getEncryptionKey(): Buffer {
 
   cachedEncryptionKey = deriveEncryptionKey(keySource);
   return cachedEncryptionKey;
+}
+
+export function hmacFingerprint(value: string): string {
+  const activeKeyId = getActiveKeyId();
+  const key = activeKeyId ? getV2EncryptionKey(activeKeyId) : getEncryptionKey();
+  return createHmac('sha256', key).update(value).digest('hex');
 }
 
 function getActiveKeyId(): string | null {


### PR DESCRIPTION
Wave 1 of the per-partner LLM BYOK feature (#3228, spec: `docs/superpowers/specs/ai-mcp/2026-08-23-per-partner-llm-byok-design.md`). DB layer + resolution seam + partner-facing config API. No LLM call-site threading (W02 #3885), no cost/billing changes (W03 #3886), no UI (W04 #3887).

Closes #3884

## What's in

- **`partner_llm_configs`** (migration `2026-09-04`): partner-unique, phase-1 CHECKs freeze `provider='anthropic'` / `base_url IS NULL`, partner-axis RLS (shape 3) mirroring `stripe_connect_accounts`, registered in `PARTNER_TENANT_TABLES` + `encryptedColumnRegistry` (row-bound AAD). No org_id → no cascade/export-policy entries.
- **`partnerLlmConfig` service**: probe-before-persist (atomic rotation — a failed probe leaves the working key untouched), HMAC fingerprint scoped by encryption-key generation, `config_version` bump on every write, `enc:`-prefix rejection.
- **`llmConfigResolver`**: `resolveLlmConfig(partnerId)` → platform / partner / unavailable, fail-loud (never falls back to the platform key). `status='error'` only on deterministic credential failures, keyed by config row id + version; key-material misconfig (stale keyring on a node) reports to Sentry without bricking the partner.
- **`/api/v1/ai/provider` routes**: GET/POST `/key`/PATCH/DELETE, gated `BILLING_MANAGE` + `requireMfa()` on key writes + `canManagePartnerWidePolicies` (org tokens carry a partnerId; the save path writes under a system DB context where RLS is no backstop). Key never returned; audit events carry last4 + version only.

## Review

One independent round (code-reviewer + silent-failure-hunter), all findings fixed in `3b00ecc8f` — notably the partner-wide scope gate, the sticky decrypt-error brick, config_version-reset poisoning of the error stamp, and several Sentry-blind error paths.

Note: `routes/stripeConnect` (the pattern this mirrors) gates only on `auth.partnerId` + `BILLING_MANAGE` without `canManagePartnerWidePolicies` — same class of exposure for the Stripe key, worth a follow-up issue.

## Verification

- `tsc --noEmit` clean; new + adjacent unit suites green (87 tests across the four new files, stripeConnect + secretCrypto + autoMigrate + encryptedColumnRegistry unaffected).
- Partner-axis RLS integration suite (5 tests incl. positive control) run against isolated Postgres locally; runs again in the blocking `integration-test` job here.
- Migration applied twice against isolated Postgres (idempotency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)