### PR TITLE
fix(api): make every captureMessage event groupable in Sentry (BREEZE-18)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -697,6 +697,13 @@ LOG_JSON=false
 # Sentry Error Tracking
 # --------------------------------------------
 SENTRY_DSN=
+# Sentry's `environment` dimension. In a MULTI-REGION deployment this MUST be
+# region-qualified — `production-us`, `production-eu`, … — not a bare
+# `production`. Every deployment reporting the same value makes regions
+# indistinguishable in Sentry: `server_name` is a per-deploy container hash, so
+# with a shared `production` there is no dimension left to attribute an error,
+# a spike or a regression to a region, and no way to filter one out.
+# Single-region and self-hosted deployments can leave `production` as-is.
 SENTRY_ENVIRONMENT=production
 SENTRY_RELEASE=
 SENTRY_TRACES_SAMPLE_RATE=0.1

--- a/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
@@ -20,6 +20,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // every other test here observes console.warn, which is untouched.
 const capturedMessages: Array<{
   message: string;
+  eventCode?: string;
   extra?: Record<string, unknown>;
   tags?: Record<string, string>;
 }> = [];
@@ -27,13 +28,24 @@ vi.mock('../../services/sentry', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../services/sentry')>();
   return {
     ...actual,
+    // BREEZE-18: captureMessage takes an options object, not four positionals.
+    // `vi.mock`'s factory return is not checked against the real module's
+    // types, so an adapter left on the old shape does NOT fail tsc — it fails
+    // at assertion time, and only in the integration shard that owns this file.
     captureMessage: (
       message: string,
-      _level?: unknown,
-      extra?: Record<string, unknown>,
-      tags?: Record<string, string>,
+      options?: {
+        eventCode?: string;
+        extra?: Record<string, unknown>;
+        tags?: Record<string, string>;
+      },
     ) => {
-      capturedMessages.push({ message, extra, tags });
+      capturedMessages.push({
+        message,
+        eventCode: options?.eventCode,
+        extra: options?.extra,
+        tags: options?.tags,
+      });
     },
   };
 });
@@ -176,6 +188,11 @@ describe('#1105 DB-context tripwires', () => {
       );
 
       expect(capturedMessages).toHaveLength(1);
+      // BREEZE-18: every captureMessage carries a required, registered event
+      // code, applied by captureMessage itself. Asserted against a real held
+      // context (not a unit double) because this is the path that produced the
+      // contentless events in the first place.
+      expect(capturedMessages[0]!.eventCode).toBe('db_context_held_too_long');
       // The TAG is the load-bearing part: extras are only visible inside a
       // single event, so an unfilterable bucket (BREEZE-A, ~7k events) stays
       // unfilterable if the label only lands in `extra`.

--- a/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
@@ -21,7 +21,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const capturedMessages: Array<{
   message: string;
   eventCode?: string;
-  extra?: Record<string, unknown>;
   tags?: Record<string, string>;
 }> = [];
 vi.mock('../../services/sentry', async (importOriginal) => {
@@ -34,16 +33,11 @@ vi.mock('../../services/sentry', async (importOriginal) => {
     // at assertion time, and only in the integration shard that owns this file.
     captureMessage: (
       message: string,
-      options?: {
-        eventCode?: string;
-        extra?: Record<string, unknown>;
-        tags?: Record<string, string>;
-      },
+      options?: { eventCode?: string; tags?: Record<string, string> },
     ) => {
       capturedMessages.push({
         message,
         eventCode: options?.eventCode,
-        extra: options?.extra,
         tags: options?.tags,
       });
     },
@@ -161,11 +155,15 @@ describe('#1105 DB-context tripwires', () => {
       expect(heldWarns()).toHaveLength(1);
       expect(capturedMessages).toHaveLength(1);
 
-      const extra = capturedMessages[0]!.extra;
-      expect(typeof extra?.openedAt).toBe('string');
-      // The opener's own frame must be present. Before the fix this field did
-      // not exist and `stack` contained only the await trampoline.
-      expect(String(extra?.openedAt)).toContain('theCulpritThatHoldsTheConnection');
+      // BREEZE-18: this used to read `extra.openedAt`, a field that never left
+      // the process — captureMessage never attached it and scrubEvent deleted
+      // it. The opener attribution now rides the allowlisted `dbContextOpener`
+      // TAG, which actually reaches Sentry, and the precise file:line stays on
+      // the console line. Both are asserted, so neither can rot silently.
+      expect(capturedMessages[0]!.tags?.dbContextOpener)
+        .toContain('theCulpritThatHoldsTheConnection');
+      expect(String(heldWarns()[0]?.[0]))
+        .toContain('theCulpritThatHoldsTheConnection');
     });
 
     it('emits the context label as a Sentry TAG and in the message (BREEZE-A triage fix)', async () => {
@@ -234,9 +232,11 @@ describe('#1105 DB-context tripwires', () => {
       expect(event.message).toContain('[');
       expect(event.message).toContain('anUnlabelledCallerThatHolds');
       // ...but the precise file:line must NOT, or every edit above the call site
-      // forks the Sentry issue. It belongs to the console line and the extra.
+      // forks the Sentry issue. It belongs to the console line alone.
       expect(event.message).not.toMatch(/\.ts:\d+/);
-      expect(String(event.extra?.openedAtFrame)).toMatch(/dbContextTripwire.*:\d+:\d+/);
+      expect(String(heldWarns()[0]?.[0])).toMatch(/dbContextTripwire.*:\d+:\d+/);
+      // The TAG must stay free of the file:line for the same grouping reason.
+      expect(event.tags?.dbContextOpener).not.toMatch(/:\d+/);
     });
 
     it('attributes a caller that uses a bare `return` instead of `await` (#3218)', async () => {

--- a/apps/api/src/db/contextlessWriteGuard.test.ts
+++ b/apps/api/src/db/contextlessWriteGuard.test.ts
@@ -61,11 +61,11 @@ describe('contextless-write guard on proxiedDb (#1375/#1379)', () => {
     expect(captureMessage).toHaveBeenCalledTimes(1);
 
     const firstCall = (captureMessage as ReturnType<typeof vi.fn>).mock.calls[0]!;
-    const [message, level, extra] = firstCall;
+    const [message, options] = firstCall;
     expect(message).toContain('.update()');
     expect(message).toContain('#1375');
-    expect(level).toBe('warning');
-    expect(extra).toHaveProperty('stack');
+    expect(options.eventCode).toBe('db_contextless_write');
+    expect(options.extra).toHaveProperty('stack');
   });
 
   it('warns + reports for .insert and .delete too', () => {

--- a/apps/api/src/db/contextlessWriteGuard.test.ts
+++ b/apps/api/src/db/contextlessWriteGuard.test.ts
@@ -65,7 +65,6 @@ describe('contextless-write guard on proxiedDb (#1375/#1379)', () => {
     expect(message).toContain('.update()');
     expect(message).toContain('#1375');
     expect(options.eventCode).toBe('db_contextless_write');
-    expect(options.extra).toHaveProperty('stack');
   });
 
   it('warns + reports for .insert and .delete too', () => {

--- a/apps/api/src/db/dbPoolHealthMonitor.test.ts
+++ b/apps/api/src/db/dbPoolHealthMonitor.test.ts
@@ -277,9 +277,11 @@ describe('dbPoolHealthMonitor (#3214)', () => {
       expect(captureMessage).toHaveBeenCalledTimes(1);
       expect(captureMessage).toHaveBeenCalledWith(
         expect.stringContaining('POOL DEGRADED'),
-        'warning',
-        expect.objectContaining({ verdict: 'pool-degraded', timeouts: 40 }),
-        { db_pool_health_verdict: 'pool-degraded' },
+        expect.objectContaining({
+          eventCode: 'db_pool_health_degraded',
+          extra: expect.objectContaining({ verdict: 'pool-degraded', timeouts: 40 }),
+          tags: { db_pool_health_verdict: 'pool-degraded' },
+        }),
       );
     });
 
@@ -354,9 +356,11 @@ describe('dbPoolHealthMonitor (#3214)', () => {
 
       expect(captureMessage).toHaveBeenCalledWith(
         '[db-pool-health] watchdog evaluation failed',
-        'warning',
-        expect.objectContaining({ error: 'stats exploded', checkFailures: 1 }),
-        { db_pool_health_verdict: 'check-failed' },
+        expect.objectContaining({
+          eventCode: 'db_pool_health_check_failed',
+          extra: expect.objectContaining({ error: 'stats exploded', checkFailures: 1 }),
+          tags: { db_pool_health_verdict: 'check-failed' },
+        }),
       );
     });
 
@@ -439,7 +443,7 @@ describe('dbPoolHealthMonitor (#3214)', () => {
       await runDbPoolHealthCheck(deps); // captured again
 
       const last = captureMessage.mock.calls.at(-1);
-      expect(last?.[2]).toMatchObject({ suppressedSinceLastCapture: 2 });
+      expect(last?.[1].extra).toMatchObject({ suppressedSinceLastCapture: 2 });
     });
   });
 

--- a/apps/api/src/db/dbPoolHealthMonitor.test.ts
+++ b/apps/api/src/db/dbPoolHealthMonitor.test.ts
@@ -279,7 +279,6 @@ describe('dbPoolHealthMonitor (#3214)', () => {
         expect.stringContaining('POOL DEGRADED'),
         expect.objectContaining({
           eventCode: 'db_pool_health_degraded',
-          extra: expect.objectContaining({ verdict: 'pool-degraded', timeouts: 40 }),
           tags: { db_pool_health_verdict: 'pool-degraded' },
         }),
       );
@@ -358,7 +357,6 @@ describe('dbPoolHealthMonitor (#3214)', () => {
         '[db-pool-health] watchdog evaluation failed',
         expect.objectContaining({
           eventCode: 'db_pool_health_check_failed',
-          extra: expect.objectContaining({ error: 'stats exploded', checkFailures: 1 }),
           tags: { db_pool_health_verdict: 'check-failed' },
         }),
       );
@@ -442,8 +440,13 @@ describe('dbPoolHealthMonitor (#3214)', () => {
       process.env.DB_POOL_HEALTH_CAPTURE_THROTTLE_MS = '0';
       await runDbPoolHealthCheck(deps); // captured again
 
-      const last = captureMessage.mock.calls.at(-1);
-      expect(last?.[1].extra).toMatchObject({ suppressedSinceLastCapture: 2 });
+      // BREEZE-18: this used to assert on the `extra` bag, which was never
+      // attached to the event and was deleted by scrubEvent before send — so it
+      // proved only that the object was BUILT, never that an operator could see
+      // the count. It now goes to the console, and that is what is asserted.
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('2 capture(s) suppressed by the throttle'),
+      );
     });
   });
 

--- a/apps/api/src/db/dbPoolHealthMonitor.ts
+++ b/apps/api/src/db/dbPoolHealthMonitor.ts
@@ -516,19 +516,23 @@ export async function runDbPoolHealthCheck(
         // deletes message/extra from every event — so it carries the actionable
         // part. The extras are passed anyway (correct shape, and free) and the
         // full prose is already on console.warn above.
-        captureMessage(assessment.headline, 'warning', {
-          message: assessment.message,
-          verdict: assessment.verdict,
-          timeouts: assessment.stats.timeouts,
-          ratePerMin: assessment.stats.ratePerMin,
-          windowMs: assessment.stats.windowMs,
-          byCause: assessment.stats.byCause,
-          probeMs: assessment.probeMs,
-          probeError: assessment.probeError,
-          // States this event's own sampling rate, so the throttle cannot make a
-          // storm look like a single occurrence.
-          suppressedSinceLastCapture: suppressed,
-        }, { db_pool_health_verdict: assessment.verdict });
+        captureMessage(assessment.headline, {
+          eventCode: 'db_pool_health_degraded',
+          extra: {
+            message: assessment.message,
+            verdict: assessment.verdict,
+            timeouts: assessment.stats.timeouts,
+            ratePerMin: assessment.stats.ratePerMin,
+            windowMs: assessment.stats.windowMs,
+            byCause: assessment.stats.byCause,
+            probeMs: assessment.probeMs,
+            probeError: assessment.probeError,
+            // States this event's own sampling rate, so the throttle cannot make
+            // a storm look like a single occurrence.
+            suppressedSinceLastCapture: suppressed,
+          },
+          tags: { db_pool_health_verdict: assessment.verdict },
+        });
       } catch (captureErr) {
         console.error('[db-pool-health] failed to report verdict to Sentry:', captureErr);
       }
@@ -555,11 +559,15 @@ export async function runDbPoolHealthCheck(
       )
     ) {
       try {
-        captureMessage('[db-pool-health] watchdog evaluation failed', 'warning', {
-          error: err instanceof Error ? err.message : String(err),
-          checkFailures,
-          suppressedSinceLastCapture: takeSuppressedCount('check-failed'),
-        }, { db_pool_health_verdict: 'check-failed' });
+        captureMessage('[db-pool-health] watchdog evaluation failed', {
+          eventCode: 'db_pool_health_check_failed',
+          extra: {
+            error: err instanceof Error ? err.message : String(err),
+            checkFailures,
+            suppressedSinceLastCapture: takeSuppressedCount('check-failed'),
+          },
+          tags: { db_pool_health_verdict: 'check-failed' },
+        });
       } catch {
         // The reporter is the thing that failed; the console line above stands.
       }

--- a/apps/api/src/db/dbPoolHealthMonitor.ts
+++ b/apps/api/src/db/dbPoolHealthMonitor.ts
@@ -506,31 +506,32 @@ export async function runDbPoolHealthCheck(
     console.warn(assessment.message);
     const throttleMs = getDbPoolHealthCaptureThrottleMs();
     if (claimDbPoolHealthCaptureSlot(assessment.verdict, assessment.at, throttleMs)) {
+      // NB: takeSuppressedCount also RESETS the counter, so this call must
+      // happen exactly once per capture whether or not anyone reads the value.
       const suppressed = takeSuppressedCount(assessment.verdict);
+      // On the console, not in a Sentry field: this used to ride along in
+      // `extra`, which was never attached to the event and was deleted by
+      // scrubEvent regardless (BREEZE-18). A raw count is also the wrong shape
+      // for a tag — unbounded cardinality. The operator-facing point is that a
+      // storm must not look like a single occurrence, and the console is where
+      // that lands truthfully.
+      if (suppressed > 0) {
+        console.warn(
+          `[db-pool-health] ${suppressed} capture(s) suppressed by the throttle since the last report `
+          + `(verdict=${assessment.verdict}).`,
+        );
+      }
       // Wrapped: a valid assessment has already been stored, and the outer catch
       // now CLEARS `lastAssessment`. Letting a reporter fault fall through to it
       // would erase a real `pool-degraded` verdict from /metrics at the exact
       // moment it fired, and show the operator a reporting error instead.
       try {
         // `db_pool_health_verdict` is the only field that survives — scrubEvent
-        // deletes message/extra from every event — so it carries the actionable
-        // part. The extras are passed anyway (correct shape, and free) and the
-        // full prose is already on console.warn above.
+        // deletes message/logentry from every event — so it carries the
+        // actionable part, alongside the required `event_code`. The full prose
+        // and the suppression count are on console.warn above.
         captureMessage(assessment.headline, {
           eventCode: 'db_pool_health_degraded',
-          extra: {
-            message: assessment.message,
-            verdict: assessment.verdict,
-            timeouts: assessment.stats.timeouts,
-            ratePerMin: assessment.stats.ratePerMin,
-            windowMs: assessment.stats.windowMs,
-            byCause: assessment.stats.byCause,
-            probeMs: assessment.probeMs,
-            probeError: assessment.probeError,
-            // States this event's own sampling rate, so the throttle cannot make
-            // a storm look like a single occurrence.
-            suppressedSinceLastCapture: suppressed,
-          },
           tags: { db_pool_health_verdict: assessment.verdict },
         });
       } catch (captureErr) {
@@ -561,11 +562,6 @@ export async function runDbPoolHealthCheck(
       try {
         captureMessage('[db-pool-health] watchdog evaluation failed', {
           eventCode: 'db_pool_health_check_failed',
-          extra: {
-            error: err instanceof Error ? err.message : String(err),
-            checkFailures,
-            suppressedSinceLastCapture: takeSuppressedCount('check-failed'),
-          },
           tags: { db_pool_health_verdict: 'check-failed' },
         });
       } catch {

--- a/apps/api/src/db/dbWriteExpectingRows.test.ts
+++ b/apps/api/src/db/dbWriteExpectingRows.test.ts
@@ -25,9 +25,7 @@ describe('dbWriteExpectingRows', () => {
     expect(out).toEqual([]);
     expect(captureMessage).toHaveBeenCalledWith(
       expect.stringContaining('users.last_login_at'),
-      'warning',
-      expect.any(Object),
-      expect.any(Object),
+      expect.objectContaining({ eventCode: 'db_write_expecting_rows_zero' }),
     );
   });
 
@@ -52,9 +50,9 @@ describe('dbWriteExpectingRows', () => {
     await dbWriteExpectingRows('users.last_login_at', async () => []);
     expect(captureMessage).toHaveBeenCalledWith(
       expect.any(String),
-      'warning',
-      expect.any(Object),
-      expect.objectContaining({ cas_label: 'users.last_login_at' }),
+      expect.objectContaining({
+        tags: expect.objectContaining({ cas_label: 'users.last_login_at' }),
+      }),
     );
   });
 
@@ -66,12 +64,12 @@ describe('dbWriteExpectingRows', () => {
     );
     expect(captureMessage).toHaveBeenCalledWith(
       expect.any(String),
-      'warning',
-      expect.any(Object),
-      {
-        cas_label: 'device_commands.ws_result_terminal_cas',
-        prior_status: 'failed:server-timeout',
-      },
+      expect.objectContaining({
+        tags: {
+          cas_label: 'device_commands.ws_result_terminal_cas',
+          prior_status: 'failed:server-timeout',
+        },
+      }),
     );
   });
 
@@ -99,9 +97,9 @@ describe('dbWriteExpectingRows', () => {
     expect(out).toEqual([]);
     expect(captureMessage).toHaveBeenCalledWith(
       expect.any(String),
-      'warning',
-      expect.any(Object),
-      { cas_label: 'device_commands.ws_result_terminal_cas' },
+      expect.objectContaining({
+        tags: { cas_label: 'device_commands.ws_result_terminal_cas' },
+      }),
     );
   });
 

--- a/apps/api/src/db/dbWriteExpectingRows.ts
+++ b/apps/api/src/db/dbWriteExpectingRows.ts
@@ -46,7 +46,6 @@ export async function dbWriteExpectingRows<T>(
     }
     captureMessage(message, {
       eventCode: 'db_write_expecting_rows_zero',
-      extra: { label, stack: new Error().stack },
       tags,
     });
   }

--- a/apps/api/src/db/dbWriteExpectingRows.ts
+++ b/apps/api/src/db/dbWriteExpectingRows.ts
@@ -44,7 +44,11 @@ export async function dbWriteExpectingRows<T>(
         console.warn(`[dbWriteExpectingRows] diagnostic tags failed for ${label}:`, err);
       }
     }
-    captureMessage(message, 'warning', { label, stack: new Error().stack }, tags);
+    captureMessage(message, {
+      eventCode: 'db_write_expecting_rows_zero',
+      extra: { label, stack: new Error().stack },
+      tags,
+    });
   }
   return rows;
 }

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -507,17 +507,6 @@ export async function withDbAccessContext<T>(
             if (shouldCaptureHeldContext(context.scope, Date.now(), getHeldContextCaptureThrottleMs())) {
               captureMessage(message, {
                 eventCode: 'db_context_held_too_long',
-                extra: {
-                  heldMs,
-                  scope: context.scope,
-                  // `openedAt` is the actionable one — it names the caller that
-                  // opened the context. `stack` is kept (emitter-side, i.e. the
-                  // await trampoline) only because the previous shape had it and
-                  // dropping a field silently is worse than an extra one.
-                  openedAtFrame: openerFrame?.location,
-                  openedAt: opener?.stack,
-                  stack: new Error().stack,
-                },
                 tags: Object.keys(tags).length > 0 ? tags : undefined,
               });
             }
@@ -710,7 +699,7 @@ function reportContextlessWrite(label: string): void {
   const key = stack ?? label;
   if (reportedContextlessSites.has(key)) return;
   reportedContextlessSites.add(key);
-  captureMessage(message, { eventCode: 'db_contextless_write', extra: { stack } });
+  captureMessage(message, { eventCode: 'db_contextless_write' });
 }
 
 // Best-effort extraction of the leading SQL text from a drizzle `sql` object so
@@ -818,7 +807,6 @@ export function assertOutsideHeldDbContext(operation: string): void {
   if (!shouldReportHeldContextSite(stack ?? operation)) return;
   captureMessage(message, {
     eventCode: 'db_operation_inside_held_context',
-    extra: { operation, stack },
   });
 }
 

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -505,17 +505,21 @@ export async function withDbAccessContext<T>(
             // Throttle the Sentry capture per scope (see getHeldContextCaptureThrottleMs)
             // so a recurring conn-hold can't flood the org's event quota.
             if (shouldCaptureHeldContext(context.scope, Date.now(), getHeldContextCaptureThrottleMs())) {
-              captureMessage(message, 'warning', {
-                heldMs,
-                scope: context.scope,
-                // `openedAt` is the actionable one — it names the caller that
-                // opened the context. `stack` is kept (emitter-side, i.e. the
-                // await trampoline) only because the previous shape had it and
-                // dropping a field silently is worse than an extra one.
-                openedAtFrame: openerFrame?.location,
-                openedAt: opener?.stack,
-                stack: new Error().stack,
-              }, Object.keys(tags).length > 0 ? tags : undefined);
+              captureMessage(message, {
+                eventCode: 'db_context_held_too_long',
+                extra: {
+                  heldMs,
+                  scope: context.scope,
+                  // `openedAt` is the actionable one — it names the caller that
+                  // opened the context. `stack` is kept (emitter-side, i.e. the
+                  // await trampoline) only because the previous shape had it and
+                  // dropping a field silently is worse than an extra one.
+                  openedAtFrame: openerFrame?.location,
+                  openedAt: opener?.stack,
+                  stack: new Error().stack,
+                },
+                tags: Object.keys(tags).length > 0 ? tags : undefined,
+              });
             }
           }
         }
@@ -706,7 +710,7 @@ function reportContextlessWrite(label: string): void {
   const key = stack ?? label;
   if (reportedContextlessSites.has(key)) return;
   reportedContextlessSites.add(key);
-  captureMessage(message, 'warning', { stack });
+  captureMessage(message, { eventCode: 'db_contextless_write', extra: { stack } });
 }
 
 // Best-effort extraction of the leading SQL text from a drizzle `sql` object so
@@ -812,7 +816,10 @@ export function assertOutsideHeldDbContext(operation: string): void {
   console.warn(message);
   const stack = new Error().stack;
   if (!shouldReportHeldContextSite(stack ?? operation)) return;
-  captureMessage(message, 'warning', { operation, stack });
+  captureMessage(message, {
+    eventCode: 'db_operation_inside_held_context',
+    extra: { operation, stack },
+  });
 }
 
 const proxiedDb = new Proxy(baseDb, {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -517,7 +517,8 @@ app.use('*', securityMiddleware());
 app.use(
   '*',
   createGlobalBodyLimitMiddleware({
-    capture: (message, tags) => captureMessage(message, 'warning', undefined, tags),
+    capture: (message, tags) =>
+      captureMessage(message, { eventCode: 'body_limit_rejected', tags }),
   })
 );
 app.use('*', globalRateLimit());
@@ -1878,7 +1879,8 @@ async function bootstrap(): Promise<void> {
   const eventLoopMonitor = startEventLoopMonitor({
     onSample: createStarvationReporter({
       thresholdMs: getEventLoopStarvationThresholdMs,
-      capture: (message, tags) => captureMessage(message, 'warning', undefined, tags),
+      capture: (message, tags) =>
+        captureMessage(message, { eventCode: 'event_loop_starvation', tags }),
     }),
   });
   // Say whether the instance can see its own loop, and at what settings. Without

--- a/apps/api/src/jobs/exchangeRateSync.test.ts
+++ b/apps/api/src/jobs/exchangeRateSync.test.ts
@@ -211,7 +211,9 @@ describe('exchangeRateSync worker', () => {
       // ...and the bad row is visible, not swallowed.
       expect(captureMessageMock).toHaveBeenCalledTimes(1);
       expect(String(captureMessageMock.mock.calls[0]![0])).toContain('rejected 1');
-      expect(captureMessageMock.mock.calls[0]![1]).toBe('warning');
+      expect(captureMessageMock.mock.calls[0]![1]).toMatchObject({
+        eventCode: 'exchange_rate_rows_rejected',
+      });
     });
 
     it('rethrows a transient FrankfurterClientError AS-IS so BullMQ retries', async () => {

--- a/apps/api/src/jobs/exchangeRateSync.ts
+++ b/apps/api/src/jobs/exchangeRateSync.ts
@@ -97,8 +97,6 @@ export async function syncEcbExchangeRates(): Promise<ExchangeRateSyncStats> {
       `[ExchangeRateSync] rejected ${fetched.rejected.length} unusable provider row(s)`,
       {
         eventCode: 'exchange_rate_rows_rejected',
-        extra: { rejected: fetched.rejected },
-        tags: { job: 'exchange-rate-sync' },
       },
     );
   }

--- a/apps/api/src/jobs/exchangeRateSync.ts
+++ b/apps/api/src/jobs/exchangeRateSync.ts
@@ -95,9 +95,11 @@ export async function syncEcbExchangeRates(): Promise<ExchangeRateSyncStats> {
     console.warn(`[ExchangeRateSync] Rejected ${fetched.rejected.length} unusable row(s) — ${detail}`);
     captureMessage(
       `[ExchangeRateSync] rejected ${fetched.rejected.length} unusable provider row(s)`,
-      'warning',
-      { rejected: fetched.rejected },
-      { job: 'exchange-rate-sync' },
+      {
+        eventCode: 'exchange_rate_rows_rejected',
+        extra: { rejected: fetched.rejected },
+        tags: { job: 'exchange-rate-sync' },
+      },
     );
   }
 

--- a/apps/api/src/jobs/vulnerabilityJobs.ts
+++ b/apps/api/src/jobs/vulnerabilityJobs.ts
@@ -420,11 +420,14 @@ async function fetchNvdRecords(params: {
       + `of totalResults=${truncation.knownTotal} (${truncation.reason}) — `
       + 'remaining pages were NOT ingested; catalog is incomplete for this window';
     console.error(message);
-    captureMessage(message, 'warning', {
-      startIndex: truncation.startIndex,
-      totalResults: truncation.knownTotal,
-      reason: truncation.reason,
-      ingestedEntries: entryCount,
+    captureMessage(message, {
+      eventCode: 'nvd_pagination_truncated',
+      extra: {
+        startIndex: truncation.startIndex,
+        totalResults: truncation.knownTotal,
+        reason: truncation.reason,
+        ingestedEntries: entryCount,
+      },
     });
   } else if (knownTotal === null) {
     // "No total reported" is its OWN escalation condition (#2470), not an implicit
@@ -447,12 +450,15 @@ async function fetchNvdRecords(params: {
       + 'completeness cannot be verified and later pages may never have been requested; '
       + 'treating as a probable silent truncation';
     console.error(message);
-    captureMessage(message, 'warning', {
-      startIndex,
-      totalResults: null,
-      reason: 'no_total_reported',
-      ingestedEntries: entryCount,
-      pagesFetched,
+    captureMessage(message, {
+      eventCode: 'nvd_pagination_no_total',
+      extra: {
+        startIndex,
+        totalResults: null,
+        reason: 'no_total_reported',
+        ingestedEntries: entryCount,
+        pagesFetched,
+      },
     });
   }
 

--- a/apps/api/src/jobs/vulnerabilityJobs.ts
+++ b/apps/api/src/jobs/vulnerabilityJobs.ts
@@ -422,12 +422,6 @@ async function fetchNvdRecords(params: {
     console.error(message);
     captureMessage(message, {
       eventCode: 'nvd_pagination_truncated',
-      extra: {
-        startIndex: truncation.startIndex,
-        totalResults: truncation.knownTotal,
-        reason: truncation.reason,
-        ingestedEntries: entryCount,
-      },
     });
   } else if (knownTotal === null) {
     // "No total reported" is its OWN escalation condition (#2470), not an implicit
@@ -452,13 +446,6 @@ async function fetchNvdRecords(params: {
     console.error(message);
     captureMessage(message, {
       eventCode: 'nvd_pagination_no_total',
-      extra: {
-        startIndex,
-        totalResults: null,
-        reason: 'no_total_reported',
-        ingestedEntries: entryCount,
-        pagesFetched,
-      },
     });
   }
 

--- a/apps/api/src/jobs/workerObservability.ts
+++ b/apps/api/src/jobs/workerObservability.ts
@@ -19,12 +19,25 @@ import { captureException } from '../services/sentry';
  * outside job execution. Anything captured *during* a job — most importantly the
  * #1105 held-context warning from withDbAccessContext — arrived with no
  * attribution at all. BREEZE-9 accumulated ~12k held-context events at
- * scope=system whose `worker` tag is empty, so there is no way to tell which of
- * the 38 workers is pinning connections. Breaking that issue down by worker is
- * the whole triage step, and it was impossible.
+ * scope=system whose `worker` tag is empty, so there was no way to tell which
+ * worker is pinning connections. Breaking that issue down by worker is the whole
+ * triage step, and it was impossible.
  *
- * All 38 workers already call attachWorkerObservability, so patching here covers
+ * Every worker already calls attachWorkerObservability, so patching here covers
  * every one with no per-worker change.
+ *
+ * SUPERSEDED IN PART (BREEZE-18, 2026-08-23) — read before trusting the
+ * paragraph above. The reasoning is correct but was not the whole story, and
+ * this patch has been INERT since two days after it landed. `3c92c07cd`
+ * (2026-07-25) added it; `a50769487` (2026-07-27, security wave 7) then
+ * introduced ALLOWED_TAG_NAMES in services/sentry.ts, which rebuilds every
+ * outbound event's tags through an allowlist that did not contain `worker`. So
+ * the tag was set correctly here and deleted on the way out — by both paths,
+ * the isolation scope AND the 'failed' listener below.
+ *
+ * That is why the ~12k BREEZE-9 events kept arriving unattributed after this
+ * shipped. `worker` is allowlisted as of BREEZE-18; if you are debugging empty
+ * worker attribution again, check ALLOWED_TAG_NAMES before this file.
  *
  * `processFn` is a BullMQ instance property (visible in production stack traces
  * as `at Worker.processFn`). Patching a library internal is a trade: it is

--- a/apps/api/src/middleware/bodyLimitGate.ts
+++ b/apps/api/src/middleware/bodyLimitGate.ts
@@ -104,7 +104,7 @@ export function reportBodyLimitRejection(
 }
 
 function defaultCapture(message: string, tags: Record<string, string>): void {
-  captureMessage(message, 'warning', undefined, tags);
+  captureMessage(message, { eventCode: 'body_limit_rejected', tags });
 }
 
 /**

--- a/apps/api/src/middleware/mobileDeviceBlocked.test.ts
+++ b/apps/api/src/middleware/mobileDeviceBlocked.test.ts
@@ -165,7 +165,10 @@ describe('mobileDeviceBlockedMiddleware — unresolved device telemetry (#2913)'
     // not re-registered yet, plus onboarding's pre-registration calls.
     expect(res.status).toBe(200);
     expect(captureMessageMock).toHaveBeenCalledTimes(1);
-    expect(captureMessageMock.mock.calls[0]?.[3]).toMatchObject({ source: 'signed-claim' });
+    expect(captureMessageMock.mock.calls[0]?.[1]).toMatchObject({
+      eventCode: 'mobile_device_unresolved',
+      tags: { source: 'signed-claim' },
+    });
   });
 
   it('tags a header-only (legacy token) miss distinctly from a signed-claim miss', async () => {
@@ -175,7 +178,9 @@ describe('mobileDeviceBlockedMiddleware — unresolved device telemetry (#2913)'
       headers: { Authorization: 'Bearer legacy-token', [MOBILE_DEVICE_ID_HEADER]: DEVICE },
     });
 
-    expect(captureMessageMock.mock.calls[0]?.[3]).toMatchObject({ source: 'header' });
+    expect(captureMessageMock.mock.calls[0]?.[1]).toMatchObject({
+      tags: { source: 'header' },
+    });
   });
 
   it('rate limits so an unregistered fleet cannot flood Sentry', async () => {

--- a/apps/api/src/middleware/mobileDeviceBlocked.test.ts
+++ b/apps/api/src/middleware/mobileDeviceBlocked.test.ts
@@ -167,7 +167,7 @@ describe('mobileDeviceBlockedMiddleware — unresolved device telemetry (#2913)'
     expect(captureMessageMock).toHaveBeenCalledTimes(1);
     expect(captureMessageMock.mock.calls[0]?.[1]).toMatchObject({
       eventCode: 'mobile_device_unresolved',
-      tags: { source: 'signed-claim' },
+      tags: { mobile_device_id_source: 'signed-claim' },
     });
   });
 
@@ -179,7 +179,7 @@ describe('mobileDeviceBlockedMiddleware — unresolved device telemetry (#2913)'
     });
 
     expect(captureMessageMock.mock.calls[0]?.[1]).toMatchObject({
-      tags: { source: 'header' },
+      tags: { mobile_device_id_source: 'header' },
     });
   });
 

--- a/apps/api/src/middleware/mobileDeviceBlocked.ts
+++ b/apps/api/src/middleware/mobileDeviceBlocked.ts
@@ -28,9 +28,10 @@ function reportUnresolvedDeviceId(source: 'signed-claim' | 'header'): void {
   }
   captureMessage(
     'mobile device id resolved to no mobile_devices row — block enforcement is inert for this caller',
-    'warning',
-    undefined,
-    { area: 'mobile-device-blocked', source }
+    {
+      eventCode: 'mobile_device_unresolved',
+      tags: { area: 'mobile-device-blocked', source },
+    }
   );
 }
 

--- a/apps/api/src/middleware/mobileDeviceBlocked.ts
+++ b/apps/api/src/middleware/mobileDeviceBlocked.ts
@@ -30,7 +30,7 @@ function reportUnresolvedDeviceId(source: 'signed-claim' | 'header'): void {
     'mobile device id resolved to no mobile_devices row — block enforcement is inert for this caller',
     {
       eventCode: 'mobile_device_unresolved',
-      tags: { area: 'mobile-device-blocked', source },
+      tags: { mobile_device_id_source: source },
     }
   );
 }

--- a/apps/api/src/routes/accounting/index.test.ts
+++ b/apps/api/src/routes/accounting/index.test.ts
@@ -437,7 +437,10 @@ describe('accounting routes', () => {
     expect(res.status).toBe(302);
     expect(res.headers.get('location')).toContain('connected=1');
     expect(mocks.captureException).not.toHaveBeenCalled();
-    expect(mocks.captureMessage).toHaveBeenCalledWith(expect.stringContaining('home currency'), 'warning', expect.anything());
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('home currency'),
+      expect.objectContaining({ eventCode: 'accounting_home_currency_cas_lost' }),
+    );
   });
 
   it('a GENUINE home-currency write failure still reports an exception', async () => {

--- a/apps/api/src/routes/accounting/index.ts
+++ b/apps/api/src/routes/accounting/index.ts
@@ -326,7 +326,6 @@ accountingRoutes.get('/:provider/callback', zValidator('param', providerParamSch
     if (isHomeCurrencyCasAbort(err)) {
       captureMessage('[accounting] QuickBooks home currency capture lost the compare-and-set', {
         eventCode: 'accounting_home_currency_cas_lost',
-        extra: { partnerId: state.partnerId, provider },
       });
       console.warn('[accounting] QuickBooks home currency capture lost the compare-and-set', { partnerId: state.partnerId, provider });
     } else {

--- a/apps/api/src/routes/accounting/index.ts
+++ b/apps/api/src/routes/accounting/index.ts
@@ -324,7 +324,10 @@ accountingRoutes.get('/:provider/callback', zValidator('param', providerParamSch
     // the generation that survived. Report it as a warning so it stops filing
     // Sentry issues on a normal user action; genuine failures stay exceptions.
     if (isHomeCurrencyCasAbort(err)) {
-      captureMessage('[accounting] QuickBooks home currency capture lost the compare-and-set', 'warning', { partnerId: state.partnerId, provider });
+      captureMessage('[accounting] QuickBooks home currency capture lost the compare-and-set', {
+        eventCode: 'accounting_home_currency_cas_lost',
+        extra: { partnerId: state.partnerId, provider },
+      });
       console.warn('[accounting] QuickBooks home currency capture lost the compare-and-set', { partnerId: state.partnerId, provider });
     } else {
       captureException(err instanceof Error ? err : new Error(String(err)), c);

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -3153,7 +3153,10 @@ describe('BREEZE-X: WS terminal CAS reports why it moved 0 rows', () => {
     // The diagnostic re-read happened exactly once.
     expect(commandSelects).toHaveLength(2);
     expect(captureMessage).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(captureMessage).mock.calls[0]![3]).toEqual({
+    expect(vi.mocked(captureMessage).mock.calls[0]![1].eventCode).toBe(
+      'db_write_expecting_rows_zero',
+    );
+    expect(vi.mocked(captureMessage).mock.calls[0]![1].tags).toEqual({
       cas_label: 'device_commands.ws_result_terminal_cas',
       prior_status: 'failed:server-timeout',
     });
@@ -3162,7 +3165,7 @@ describe('BREEZE-X: WS terminal CAS reports why it moved 0 rows', () => {
   it('distinguishes a cancellation from the reaper on the same 0-row branch', async () => {
     await driveResult([], { status: 'cancelled', result: null });
 
-    expect(vi.mocked(captureMessage).mock.calls[0]![3]).toEqual({
+    expect(vi.mocked(captureMessage).mock.calls[0]![1].tags).toEqual({
       cas_label: 'device_commands.ws_result_terminal_cas',
       prior_status: 'cancelled',
     });

--- a/apps/api/src/routes/agents/commands.test.ts
+++ b/apps/api/src/routes/agents/commands.test.ts
@@ -983,8 +983,8 @@ describe('agent commands routes', () => {
 
       expect(captureMessage).toHaveBeenCalledTimes(1);
       const call = vi.mocked(captureMessage).mock.calls[0]!;
-      expect(call[1]).toBe('warning');
-      expect(call[3]).toEqual({
+      expect(call[1]?.eventCode).toBe('db_write_expecting_rows_zero');
+      expect(call[1]?.tags).toEqual({
         cas_label: 'device_commands.rest_result_terminal_cas',
         prior_status: 'failed:server-timeout',
       });

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -123,7 +123,7 @@ function registrationConflict(
       'mobile push registration conflicted — the phone is not receiving notifications',
       {
         eventCode: 'mobile_push_registration_conflict',
-        tags: { area: 'mobile-device-identity', reason },
+        tags: { mobile_registration_reason: reason },
       }
     );
   }
@@ -367,7 +367,7 @@ mobileRoutes.post(
         'mobile push registration fell back to push-derived device id — block enforcement stays inert for this caller',
         {
           eventCode: 'mobile_push_registration_fallback',
-          tags: { area: 'mobile-device-identity', reason: plan.fallbackReason },
+          tags: { mobile_registration_reason: plan.fallbackReason },
         }
       );
     }

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -121,9 +121,10 @@ function registrationConflict(
   if (registrationConflictThrottle.shouldReport(`${reason}:${userId}`)) {
     captureMessage(
       'mobile push registration conflicted — the phone is not receiving notifications',
-      'warning',
-      undefined,
-      { area: 'mobile-device-identity', reason }
+      {
+        eventCode: 'mobile_push_registration_conflict',
+        tags: { area: 'mobile-device-identity', reason },
+      }
     );
   }
   return c.json(
@@ -364,9 +365,10 @@ mobileRoutes.post(
       // this state re-registers on every app foreground.
       captureMessage(
         'mobile push registration fell back to push-derived device id — block enforcement stays inert for this caller',
-        'warning',
-        undefined,
-        { area: 'mobile-device-identity', reason: plan.fallbackReason }
+        {
+          eventCode: 'mobile_push_registration_fallback',
+          tags: { area: 'mobile-device-identity', reason: plan.fallbackReason },
+        }
       );
     }
 

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -1153,7 +1153,6 @@ describe('software routes', () => {
         'software version created with undetermined installer type',
         expect.objectContaining({
           eventCode: 'software_version_installer_type_unknown',
-          extra: expect.objectContaining({ downloadUrlHost: 'vendor.example.com' }),
         }),
       );
     });
@@ -1164,7 +1163,10 @@ describe('software routes', () => {
       await createVersion({
         downloadUrl: 'https://vendor.example.com/get?token=SECRET-CAPABILITY',
       });
-      const logged = vi.mocked(captureMessage).mock.calls.at(-1)?.[1]?.extra;
+      // captureMessage no longer accepts an `extra` bag at all (BREEZE-18: it
+      // was never attached to the event and scrubEvent deleted it anyway), so
+      // assert the whole options object carries no capability string.
+      const logged = vi.mocked(captureMessage).mock.calls.at(-1)?.[1];
       expect(JSON.stringify(logged)).not.toContain('SECRET-CAPABILITY');
     });
 

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -1151,8 +1151,10 @@ describe('software routes', () => {
       });
       expect(captureMessage).toHaveBeenCalledWith(
         'software version created with undetermined installer type',
-        'warning',
-        expect.objectContaining({ downloadUrlHost: 'vendor.example.com' }),
+        expect.objectContaining({
+          eventCode: 'software_version_installer_type_unknown',
+          extra: expect.objectContaining({ downloadUrlHost: 'vendor.example.com' }),
+        }),
       );
     });
 
@@ -1162,7 +1164,7 @@ describe('software routes', () => {
       await createVersion({
         downloadUrl: 'https://vendor.example.com/get?token=SECRET-CAPABILITY',
       });
-      const logged = vi.mocked(captureMessage).mock.calls.at(-1)?.[2];
+      const logged = vi.mocked(captureMessage).mock.calls.at(-1)?.[1]?.extra;
       expect(JSON.stringify(logged)).not.toContain('SECRET-CAPABILITY');
     });
 

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -979,17 +979,6 @@ softwareRoutes.post(
     if (payload.downloadUrl && fileType === null) {
       captureMessage('software version created with undetermined installer type', {
         eventCode: 'software_version_installer_type_unknown',
-        extra: {
-          // Dual-axis (#2135): a partner-wide package has org_id NULL, so log both
-          // axes — orgId alone would attribute those rows to nothing at all.
-          orgId: catalogItem.orgId,
-          partnerId: catalogItem.partnerId,
-          catalogId: id,
-          version: payload.version,
-          // Host only — a managed-software URL can carry a presigned capability
-          // query string that must never reach a log.
-          downloadUrlHost: safeUrlHost(payload.downloadUrl),
-        },
       });
     }
 
@@ -1139,7 +1128,6 @@ softwareRoutes.post(
           // make the discard visible rather than fully silent.
           captureMessage('software upload: discarded malformed supportedOs', {
             eventCode: 'software_upload_malformed_supported_os',
-            extra: { orgId, catalogId },
           });
         }
       }

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -977,16 +977,19 @@ softwareRoutes.post(
     // URL serving a real EXE is legitimate, and rejecting would break existing
     // scripted clients.
     if (payload.downloadUrl && fileType === null) {
-      captureMessage('software version created with undetermined installer type', 'warning', {
-        // Dual-axis (#2135): a partner-wide package has org_id NULL, so log both
-        // axes — orgId alone would attribute those rows to nothing at all.
-        orgId: catalogItem.orgId,
-        partnerId: catalogItem.partnerId,
-        catalogId: id,
-        version: payload.version,
-        // Host only — a managed-software URL can carry a presigned capability
-        // query string that must never reach a log.
-        downloadUrlHost: safeUrlHost(payload.downloadUrl),
+      captureMessage('software version created with undetermined installer type', {
+        eventCode: 'software_version_installer_type_unknown',
+        extra: {
+          // Dual-axis (#2135): a partner-wide package has org_id NULL, so log both
+          // axes — orgId alone would attribute those rows to nothing at all.
+          orgId: catalogItem.orgId,
+          partnerId: catalogItem.partnerId,
+          catalogId: id,
+          version: payload.version,
+          // Host only — a managed-software URL can carry a presigned capability
+          // query string that must never reach a log.
+          downloadUrlHost: safeUrlHost(payload.downloadUrl),
+        },
       });
     }
 
@@ -1134,9 +1137,9 @@ softwareRoutes.post(
           // Malformed supportedOs silently dropped the OS-targeting field on the
           // created version. Don't fail the upload (matches prior behavior), but
           // make the discard visible rather than fully silent.
-          captureMessage('software upload: discarded malformed supportedOs', 'warning', {
-            orgId,
-            catalogId,
+          captureMessage('software upload: discarded malformed supportedOs', {
+            eventCode: 'software_upload_malformed_supported_os',
+            extra: { orgId, catalogId },
           });
         }
       }

--- a/apps/api/src/services/backupResultPersistence.test.ts
+++ b/apps/api/src/services/backupResultPersistence.test.ts
@@ -265,7 +265,9 @@ describe('backup result persistence', () => {
       // that as an error would bury a real cross-tenant miss.
       const messages = captureMessageMock.mock.calls.map((call) => call[0] as string);
       expect(messages.some((m) => m.includes('matched no job row'))).toBe(true);
-      expect(captureMessageMock.mock.calls[0]![1]).toBe('warning');
+      expect(captureMessageMock.mock.calls[0]![1]).toMatchObject({
+        eventCode: 'backup_result_job_not_found',
+      });
       expect(captureExceptionMock).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/services/backupResultPersistence.ts
+++ b/apps/api/src/services/backupResultPersistence.ts
@@ -719,10 +719,7 @@ async function reportBackupJobPredicateMiss(params: {
       console.warn(msg);
       captureMessage(msg, {
         eventCode: 'backup_result_job_not_found',
-        tags: {
-          backup_result_drop: 'job-not-found',
-          backup_result_source: source,
-        },
+        tags: { backup_result_source: source },
       });
       return;
     }
@@ -1108,10 +1105,7 @@ export async function applyBackupCommandResultToJob(params: {
     console.warn(msg);
     captureMessage(msg, {
       eventCode: 'backup_result_org_divergence',
-      tags: {
-        backup_result_org_divergence: 'true',
-        backup_result_source: source,
-      },
+      tags: { backup_result_source: source },
     });
   }
 

--- a/apps/api/src/services/backupResultPersistence.ts
+++ b/apps/api/src/services/backupResultPersistence.ts
@@ -717,9 +717,12 @@ async function reportBackupJobPredicateMiss(params: {
         `[BackupPersistence] Backup result for job ${jobId} (reported device ${deviceId}, source: ${source}) ` +
         `matched no job row — the job was deleted, or is not visible in this tenant context.`;
       console.warn(msg);
-      captureMessage(msg, 'warning', undefined, {
-        backup_result_drop: 'job-not-found',
-        backup_result_source: source,
+      captureMessage(msg, {
+        eventCode: 'backup_result_job_not_found',
+        tags: {
+          backup_result_drop: 'job-not-found',
+          backup_result_source: source,
+        },
       });
       return;
     }
@@ -1103,9 +1106,12 @@ export async function applyBackupCommandResultToJob(params: {
       `flight, or the caller passed an org that was never this job's. Attributing the snapshot to ` +
       `${effectiveOrgId} (the job row's current owner).`;
     console.warn(msg);
-    captureMessage(msg, 'warning', undefined, {
-      backup_result_org_divergence: 'true',
-      backup_result_source: source,
+    captureMessage(msg, {
+      eventCode: 'backup_result_org_divergence',
+      tags: {
+        backup_result_org_divergence: 'true',
+        backup_result_source: source,
+      },
     });
   }
 

--- a/apps/api/src/services/backupSnapshotReconcile.ts
+++ b/apps/api/src/services/backupSnapshotReconcile.ts
@@ -951,7 +951,7 @@ export async function reconcileOrphanedBackupSnapshots(params: {
       `bucket, so time-window matching is disabled. These snapshots stay stranded until their jobs carry a ` +
       `snapshot id.`;
     console.warn(message);
-    captureMessage(message, 'warning');
+    captureMessage(message, { eventCode: 'backup_snapshot_ambiguous_destination' });
   }
 
   return {

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -15,7 +15,10 @@ import {
 import { getBinaryEdition } from "./binaryEdition";
 import {
   isReleaseArtifactManifestVerificationConfigured,
+  ReleaseAssetNotDistributableError,
   ReleaseManifestAssetAbsentError,
+  ReleaseManifestAssetLookupError,
+  ReleaseManifestSignatureError,
   verifyReleaseArtifactManifestAsset,
   verifyReleaseArtifactManifestIntegrity,
 } from "./releaseArtifactManifest";
@@ -508,6 +511,35 @@ function isAssetAbsentFromManifest(err: unknown): boolean {
   return err instanceof ReleaseManifestAssetAbsentError;
 }
 
+// BREEZE-1Z: the descriptive message below is DELETED by `scrubEvent` before
+// the event leaves the process, so the production issue could not say which
+// component, which asset, or why — and the INTENDED refusal (today's unsigned
+// darwin artifacts, see the NOTE on registerFromOfficialManifest) was
+// therefore indistinguishable from a genuine trust regression. These three
+// tags are the whole triage surface, so all three are bounded on purpose.
+//
+// The reason is a CLASS-derived classification, never `err.message`: the
+// underlying messages interpolate the offending platformTrust/edition/sha256
+// values, which is unbounded and would make the tag useless for grouping. The
+// mapping keys off the typed error classes for the same reason
+// `isAssetAbsentFromManifest` does — `.message` text is not a contract.
+export type ManifestRefusalReason =
+  | "checksum-mismatch"
+  | "not-distributable"
+  | "manifest-entry-invalid"
+  | "manifest-signature-invalid"
+  | "unclassified";
+
+export function classifyManifestRefusal(err: unknown): ManifestRefusalReason {
+  if (err instanceof ReleaseAssetNotDistributableError) return "not-distributable";
+  // Checked after the absent subclass is already handled by the caller, so any
+  // lookup error reaching here means "present in the manifest but malformed,
+  // or an identity mismatch".
+  if (err instanceof ReleaseManifestAssetLookupError) return "manifest-entry-invalid";
+  if (err instanceof ReleaseManifestSignatureError) return "manifest-signature-invalid";
+  return "unclassified";
+}
+
 // Reports (console.error + deduped captureException) a manifest asset that
 // was PRESENT but refused, or whose local file disagrees with the manifest's
 // claim for it — the two "fail closed" branches of registerFromOfficialManifest
@@ -518,18 +550,27 @@ function reportRefusedManifestAsset(
   component: string,
   assetName: string,
   err: unknown,
+  // Explicit at the checksum call site, which passes a plain string rather
+  // than a typed error and so cannot be classified from the value alone.
+  reason: ManifestRefusalReason = classifyManifestRefusal(err),
 ): void {
-  const reason = err instanceof Error ? err.message : String(err);
+  const detail = err instanceof Error ? err.message : String(err);
   console.error(
-    `[binarySync] Refusing to register ${component} asset ${assetName} from the official release manifest — fail closed, excluded from the per-deployment fallback too: ${reason}`,
+    `[binarySync] Refusing to register ${component} asset ${assetName} from the official release manifest — fail closed, excluded from the per-deployment fallback too: ${detail}`,
   );
   const key = `${component}:${assetName}`;
   if (warnedRefusedManifestAssets.has(key)) return;
   warnedRefusedManifestAssets.add(key);
   captureException(
     new Error(
-      `[binarySync] Official-manifest asset registration refused (D4, #3836): ${component} asset ${assetName} is present in the manifest but was rejected — ${reason}. Excluded from BOTH the official-manifest path and the per-deployment re-sign fallback (fail closed): registerLocalBinaries has no distributability gate, so falling back would silently serve the very artifact the manifest (or its checksum) refused.`,
+      `[binarySync] Official-manifest asset registration refused (D4, #3836): ${component} asset ${assetName} is present in the manifest but was rejected — ${detail}. Excluded from BOTH the official-manifest path and the per-deployment re-sign fallback (fail closed): registerLocalBinaries has no distributability gate, so falling back would silently serve the very artifact the manifest (or its checksum) refused.`,
     ),
+    undefined,
+    {
+      binary_component: component,
+      release_asset_name: assetName,
+      manifest_refusal_reason: reason,
+    },
   );
 }
 
@@ -609,6 +650,7 @@ async function registerFromOfficialManifest(args: {
           component,
           bin.filename,
           `Checksum mismatch between the local file (${bin.checksum}) and the official release manifest (${verified.sha256}) for ${bin.filename}`,
+          "checksum-mismatch",
         );
         excludedFilenames.add(bin.filename);
         continue;

--- a/apps/api/src/services/binarySyncManifestRefusal.test.ts
+++ b/apps/api/src/services/binarySyncManifestRefusal.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { classifyManifestRefusal } from './binarySync';
+import {
+  ReleaseAssetNotDistributableError,
+  ReleaseManifestAssetAbsentError,
+  ReleaseManifestAssetLookupError,
+  ReleaseManifestSignatureError,
+} from './releaseArtifactManifest';
+
+/**
+ * BREEZE-1Z: `manifest_refusal_reason` is the whole triage payload of the D4
+ * fail-closed change — `scrubEvent` deletes the descriptive message, so this
+ * tag is what tells an operator whether a refusal is the INTENDED unsigned
+ * darwin case or a real trust regression.
+ *
+ * It is derived from the thrown error's CLASS, which makes it silently fragile
+ * in one specific way: reshuffling the class hierarchy (or reordering the
+ * instanceof chain, since ReleaseManifestAssetAbsentError extends
+ * ReleaseManifestAssetLookupError) would collapse every refusal to
+ * `unclassified` with nothing else failing. Pin the mapping.
+ */
+describe('classifyManifestRefusal (BREEZE-1Z)', () => {
+  it('maps each manifest error class to its own bounded reason', () => {
+    expect(classifyManifestRefusal(new ReleaseAssetNotDistributableError('x')))
+      .toBe('not-distributable');
+    expect(classifyManifestRefusal(new ReleaseManifestAssetLookupError('x')))
+      .toBe('manifest-entry-invalid');
+    expect(classifyManifestRefusal(new ReleaseManifestSignatureError('x')))
+      .toBe('manifest-signature-invalid');
+  });
+
+  it('classifies the absent subclass as a lookup failure, not as unclassified', () => {
+    // ReleaseManifestAssetAbsentError extends ReleaseManifestAssetLookupError.
+    // registerFromOfficialManifest filters it out before reporting, so this
+    // never reaches Sentry in practice — but if the instanceof chain were ever
+    // reordered so the subclass fell through, this pins that it still lands in
+    // a named bucket rather than silently becoming `unclassified`.
+    expect(classifyManifestRefusal(new ReleaseManifestAssetAbsentError('x')))
+      .toBe('manifest-entry-invalid');
+  });
+
+  it('falls back to a named bucket for anything unrecognised', () => {
+    // Never throws and never returns an unbounded value, whatever it is handed:
+    // this runs on the failure path of a release-artifact refusal.
+    expect(classifyManifestRefusal(new Error('plain'))).toBe('unclassified');
+    expect(classifyManifestRefusal('a bare string')).toBe('unclassified');
+    expect(classifyManifestRefusal(undefined)).toBe('unclassified');
+    expect(classifyManifestRefusal(null)).toBe('unclassified');
+    expect(classifyManifestRefusal({ message: 'not an Error' })).toBe('unclassified');
+  });
+
+  it('returns values that survive the Sentry tag bounds', () => {
+    for (const err of [
+      new ReleaseAssetNotDistributableError('x'),
+      new ReleaseManifestAssetLookupError('x'),
+      new ReleaseManifestSignatureError('x'),
+      new Error('x'),
+    ]) {
+      const reason = classifyManifestRefusal(err);
+      expect(reason.length).toBeLessThanOrEqual(128);
+      expect(reason).not.toMatch(/[/?#\r\n]/);
+    }
+  });
+});

--- a/apps/api/src/services/catalogEnrichmentService.test.ts
+++ b/apps/api/src/services/catalogEnrichmentService.test.ts
@@ -365,6 +365,7 @@ describe('polishCatalogText', () => {
   });
 
   it('warns when the model INVENTS a new spec not present in the input', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     create
       .mockResolvedValueOnce(aiMessage({ name: 'Dell Monitor 27" 144Hz', description: null }))
       .mockResolvedValueOnce(aiMessage({ name: 'Dell Monitor 27" 144Hz', description: null }));
@@ -376,11 +377,20 @@ describe('polishCatalogText', () => {
     // operator can catch the model inventing specs on live quotes.
     expect(captureMessage).toHaveBeenCalledWith(
       expect.stringContaining('over-claimed'),
+      expect.objectContaining({ eventCode: 'catalog_polish_fact_over_claim' }),
+    );
+    // BREEZE-18: the invented token used to be asserted inside the `extra` bag,
+    // which never reached Sentry — captureMessage never attached it and
+    // scrubEvent deleted it. The durable record is the console line above the
+    // capture, so that is where the token is asserted now.
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[catalog-polish] fact guard: advisory drift',
       expect.objectContaining({
-        eventCode: 'catalog_polish_fact_over_claim',
-        extra: expect.objectContaining({ added: expect.arrayContaining(['144hz']) }),
+        direction: 'over-claim',
+        added: expect.arrayContaining(['144hz']),
       }),
     );
+    consoleWarn.mockRestore();
   });
 
   it('accepts the stricter retry when the first attempt drifts but the second is clean', async () => {

--- a/apps/api/src/services/catalogEnrichmentService.test.ts
+++ b/apps/api/src/services/catalogEnrichmentService.test.ts
@@ -376,8 +376,10 @@ describe('polishCatalogText', () => {
     // operator can catch the model inventing specs on live quotes.
     expect(captureMessage).toHaveBeenCalledWith(
       expect.stringContaining('over-claimed'),
-      'warning',
-      expect.objectContaining({ added: expect.arrayContaining(['144hz']) }),
+      expect.objectContaining({
+        eventCode: 'catalog_polish_fact_over_claim',
+        extra: expect.objectContaining({ added: expect.arrayContaining(['144hz']) }),
+      }),
     );
   });
 

--- a/apps/api/src/services/catalogEnrichmentService.ts
+++ b/apps/api/src/services/catalogEnrichmentService.ts
@@ -712,10 +712,13 @@ export async function polishCatalogText(
     // tenant-attributed) — a dashboard layer on top of the log above, restoring
     // operator visibility if the model regresses to inventing specs on live quotes.
     if (overClaimed) {
-      captureMessage('[catalog-polish] fact guard: AI over-claimed a numeric spec not in the input', 'warning', {
-        orgId: actor.orgId,
-        added: factChanges.added,
-        removed: factChanges.removed,
+      captureMessage('[catalog-polish] fact guard: AI over-claimed a numeric spec not in the input', {
+        eventCode: 'catalog_polish_fact_over_claim',
+        extra: {
+          orgId: actor.orgId,
+          added: factChanges.added,
+          removed: factChanges.removed,
+        },
       });
     }
     result = {

--- a/apps/api/src/services/catalogEnrichmentService.ts
+++ b/apps/api/src/services/catalogEnrichmentService.ts
@@ -714,11 +714,6 @@ export async function polishCatalogText(
     if (overClaimed) {
       captureMessage('[catalog-polish] fact guard: AI over-claimed a numeric spec not in the input', {
         eventCode: 'catalog_polish_fact_over_claim',
-        extra: {
-          orgId: actor.orgId,
-          added: factChanges.added,
-          removed: factChanges.removed,
-        },
       });
     }
     result = {

--- a/apps/api/src/services/cveId.test.ts
+++ b/apps/api/src/services/cveId.test.ts
@@ -118,13 +118,16 @@ describe('warnHighSkipRatio', () => {
     expect(message).toContain('20 of 100');
     expect(message).toContain('20.0%');
     expect(captureMessage).toHaveBeenCalledTimes(1);
-    expect(captureMessage).toHaveBeenCalledWith(message, 'warning', {
-      tag: 'Test',
-      skippedCount: 20,
-      entryCount: 100,
-      ratio: 0.2,
-      trigger: 'ratio',
-      droppedWhat: 'malformed-CVE',
+    expect(captureMessage).toHaveBeenCalledWith(message, {
+      eventCode: 'cve_feed_high_skip_rate',
+      extra: {
+        tag: 'Test',
+        skippedCount: 20,
+        entryCount: 100,
+        ratio: 0.2,
+        trigger: 'ratio',
+        droppedWhat: 'malformed-CVE',
+      },
     });
   });
 
@@ -136,13 +139,16 @@ describe('warnHighSkipRatio', () => {
 
     expect(error).toHaveBeenCalledTimes(1);
     expect(captureMessage).toHaveBeenCalledTimes(1);
-    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), 'warning', {
-      tag: 'Test',
-      skippedCount: 5_000,
-      entryCount: 1_000_000,
-      ratio: 0.005,
-      trigger: 'absolute_floor',
-      droppedWhat: 'malformed-CVE',
+    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), {
+      eventCode: 'cve_feed_high_skip_rate',
+      extra: {
+        tag: 'Test',
+        skippedCount: 5_000,
+        entryCount: 1_000_000,
+        ratio: 0.005,
+        trigger: 'absolute_floor',
+        droppedWhat: 'malformed-CVE',
+      },
     });
   });
 
@@ -171,13 +177,16 @@ describe('warnHighSkipRatio', () => {
     warnHighSkipRatio('Test', 40, 45);
 
     expect(error).toHaveBeenCalledTimes(1);
-    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), 'warning', {
-      tag: 'Test',
-      skippedCount: 40,
-      entryCount: 45,
-      ratio: 40 / 45,
-      trigger: 'gross_loss',
-      droppedWhat: 'malformed-CVE',
+    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), {
+      eventCode: 'cve_feed_high_skip_rate',
+      extra: {
+        tag: 'Test',
+        skippedCount: 40,
+        entryCount: 45,
+        ratio: 40 / 45,
+        trigger: 'gross_loss',
+        droppedWhat: 'malformed-CVE',
+      },
     });
   });
 
@@ -191,15 +200,18 @@ describe('warnHighSkipRatio', () => {
 
     expect(error).toHaveBeenCalledTimes(1);
     expect(error.mock.calls[0]?.[0]).toContain('High malformed-id/unusable-score skip count');
-    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), 'warning', {
-      tag: 'ExploitFeeds/epss',
-      skippedCount: 200,
-      entryCount: 400,
-      ratio: 0.5,
-      // 200/400 on a 400-entry feed trips the RATIO check first (evaluated before
-      // the absolute floor), even though 200 also clears the floor.
-      trigger: 'ratio',
-      droppedWhat: 'malformed-id/unusable-score',
+    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), {
+      eventCode: 'cve_feed_high_skip_rate',
+      extra: {
+        tag: 'ExploitFeeds/epss',
+        skippedCount: 200,
+        entryCount: 400,
+        ratio: 0.5,
+        // 200/400 on a 400-entry feed trips the RATIO check first (evaluated before
+        // the absolute floor), even though 200 also clears the floor.
+        trigger: 'ratio',
+        droppedWhat: 'malformed-id/unusable-score',
+      },
     });
   });
 

--- a/apps/api/src/services/cveId.test.ts
+++ b/apps/api/src/services/cveId.test.ts
@@ -118,17 +118,7 @@ describe('warnHighSkipRatio', () => {
     expect(message).toContain('20 of 100');
     expect(message).toContain('20.0%');
     expect(captureMessage).toHaveBeenCalledTimes(1);
-    expect(captureMessage).toHaveBeenCalledWith(message, {
-      eventCode: 'cve_feed_high_skip_rate',
-      extra: {
-        tag: 'Test',
-        skippedCount: 20,
-        entryCount: 100,
-        ratio: 0.2,
-        trigger: 'ratio',
-        droppedWhat: 'malformed-CVE',
-      },
-    });
+    expect(captureMessage).toHaveBeenCalledWith(message, { eventCode: 'cve_feed_high_skip_rate' });
   });
 
   // The #2427 regression class: a huge absolute drop whose RATIO is tiny because
@@ -139,17 +129,7 @@ describe('warnHighSkipRatio', () => {
 
     expect(error).toHaveBeenCalledTimes(1);
     expect(captureMessage).toHaveBeenCalledTimes(1);
-    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), {
-      eventCode: 'cve_feed_high_skip_rate',
-      extra: {
-        tag: 'Test',
-        skippedCount: 5_000,
-        entryCount: 1_000_000,
-        ratio: 0.005,
-        trigger: 'absolute_floor',
-        droppedWhat: 'malformed-CVE',
-      },
-    });
+    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), { eventCode: 'cve_feed_high_skip_rate' });
   });
 
   it('escalates at exactly the absolute floor', () => {
@@ -177,17 +157,7 @@ describe('warnHighSkipRatio', () => {
     warnHighSkipRatio('Test', 40, 45);
 
     expect(error).toHaveBeenCalledTimes(1);
-    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), {
-      eventCode: 'cve_feed_high_skip_rate',
-      extra: {
-        tag: 'Test',
-        skippedCount: 40,
-        entryCount: 45,
-        ratio: 40 / 45,
-        trigger: 'gross_loss',
-        droppedWhat: 'malformed-CVE',
-      },
-    });
+    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), { eventCode: 'cve_feed_high_skip_rate' });
   });
 
   // #2470: kev_epss also drops entries for an unusable SCORE, not just a malformed
@@ -200,19 +170,7 @@ describe('warnHighSkipRatio', () => {
 
     expect(error).toHaveBeenCalledTimes(1);
     expect(error.mock.calls[0]?.[0]).toContain('High malformed-id/unusable-score skip count');
-    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), {
-      eventCode: 'cve_feed_high_skip_rate',
-      extra: {
-        tag: 'ExploitFeeds/epss',
-        skippedCount: 200,
-        entryCount: 400,
-        ratio: 0.5,
-        // 200/400 on a 400-entry feed trips the RATIO check first (evaluated before
-        // the absolute floor), even though 200 also clears the floor.
-        trigger: 'ratio',
-        droppedWhat: 'malformed-id/unusable-score',
-      },
-    });
+    expect(captureMessage).toHaveBeenCalledWith(expect.any(String), { eventCode: 'cve_feed_high_skip_rate' });
   });
 
   it('still ignores a trivial gross-loss case below the min-skips guard', () => {

--- a/apps/api/src/services/cveId.ts
+++ b/apps/api/src/services/cveId.ts
@@ -123,7 +123,10 @@ export function warnHighSkipRatio(
     + `CVE entries (${(ratio * 100).toFixed(1)}%) were skipped this sync — `
     + 'probable upstream feed quality regression';
   console.error(message);
-  captureMessage(message, 'warning', { tag, skippedCount, entryCount, ratio, trigger, droppedWhat });
+  captureMessage(message, {
+    eventCode: 'cve_feed_high_skip_rate',
+    extra: { tag, skippedCount, entryCount, ratio, trigger, droppedWhat },
+  });
 }
 
 /**

--- a/apps/api/src/services/cveId.ts
+++ b/apps/api/src/services/cveId.ts
@@ -125,7 +125,6 @@ export function warnHighSkipRatio(
   console.error(message);
   captureMessage(message, {
     eventCode: 'cve_feed_high_skip_rate',
-    extra: { tag, skippedCount, entryCount, ratio, trigger, droppedWhat },
   });
 }
 

--- a/apps/api/src/services/deviceDeletion.ts
+++ b/apps/api/src/services/deviceDeletion.ts
@@ -182,12 +182,10 @@ export async function deleteDeviceCascade(
   const changed = priorMs !== null && (priorMs === 0 || priorMs > DEVICE_LOCK_TIMEOUT_MS);
   const restoreTo = changed ? priorMs : null;
   if (priorMs === null) {
-    captureMessage(
-      'device cascade could not read the prior lock_timeout',
-      'warning',
-      undefined,
-      { device_deletion_warning: 'lock-timeout-unreadable' }
-    );
+    captureMessage('device cascade could not read the prior lock_timeout', {
+      eventCode: 'device_deletion_lock_timeout_unreadable',
+      tags: { device_deletion_warning: 'lock-timeout-unreadable' },
+    });
   }
   const locked = await tx.execute(
     sql`SELECT id FROM devices WHERE id = ${deviceId} FOR UPDATE`
@@ -209,12 +207,10 @@ export async function deleteDeviceCascade(
   // signal that the RLS/absent-row branch actually happened.
   const lockedRows = extractRowCount(locked);
   if (lockedRows === 0) {
-    captureMessage(
-      'device cascade ran without holding the devices row lock',
-      'warning',
-      undefined,
-      { device_deletion_warning: 'parent-lock-missing' }
-    );
+    captureMessage('device cascade ran without holding the devices row lock', {
+      eventCode: 'device_deletion_parent_lock_missing',
+      tags: { device_deletion_warning: 'parent-lock-missing' },
+    });
   }
 
   const deviceAlertIds = sql`(SELECT id FROM alerts WHERE device_id = ${deviceId})`;

--- a/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
@@ -645,8 +645,9 @@ describe('processInboundEmail', () => {
     expect(captureMessageMock).toHaveBeenCalledTimes(1);
     expect(captureMessageMock.mock.calls[0]![1]).toMatchObject({
       eventCode: 'inbound_email_sender_auth_unverified',
-      extra: expect.objectContaining({ diagnostic: 'no-mailgun-authserv' }),
     });
+    // The diagnostic itself is asserted on the audit row above — it used to be
+    // asserted inside captureMessage's `extra`, which never reached Sentry.
   });
 
   it('does NOT alert Sentry for an ordinary unverified sender (genuine DMARC fail, no diagnostic)', async () => {
@@ -1403,11 +1404,11 @@ describe('processInboundEmail — cross-channel claim ledger (spec §4)', () => 
 
     expect(captureMessageMock).toHaveBeenCalledWith(
       expect.stringContaining('lost the message-id claim race'),
-      expect.objectContaining({
-        eventCode: 'inbound_email_claim_race_lost',
-        extra: expect.objectContaining({ ourTicketId: 't-new', winnerTicketId: 't-winner', path: 'create' })
-      })
+      expect.objectContaining({ eventCode: 'inbound_email_claim_race_lost' })
     );
+    // Both ticket ids are asserted on the audit row below (rows[0].error), which
+    // is the record that actually persists; the `extra` bag they used to be
+    // checked in never left the process.
     const rows = inboundOf();
     expect(rows[0]!.parseStatus).toBe('created');
     expect(String(rows[0]!.error)).toContain('t-winner');

--- a/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.test.ts
@@ -643,8 +643,10 @@ describe('processInboundEmail', () => {
     expect(log[0]!.error).toContain('no-mailgun-authserv');
     // A signature-verified webhook with no usable verdict is anomalous -> Sentry warning.
     expect(captureMessageMock).toHaveBeenCalledTimes(1);
-    expect(captureMessageMock.mock.calls[0]![1]).toBe('warning');
-    expect(captureMessageMock.mock.calls[0]![2]).toMatchObject({ diagnostic: 'no-mailgun-authserv' });
+    expect(captureMessageMock.mock.calls[0]![1]).toMatchObject({
+      eventCode: 'inbound_email_sender_auth_unverified',
+      extra: expect.objectContaining({ diagnostic: 'no-mailgun-authserv' }),
+    });
   });
 
   it('does NOT alert Sentry for an ordinary unverified sender (genuine DMARC fail, no diagnostic)', async () => {
@@ -1401,8 +1403,10 @@ describe('processInboundEmail — cross-channel claim ledger (spec §4)', () => 
 
     expect(captureMessageMock).toHaveBeenCalledWith(
       expect.stringContaining('lost the message-id claim race'),
-      'warning',
-      expect.objectContaining({ ourTicketId: 't-new', winnerTicketId: 't-winner', path: 'create' })
+      expect.objectContaining({
+        eventCode: 'inbound_email_claim_race_lost',
+        extra: expect.objectContaining({ ourTicketId: 't-new', winnerTicketId: 't-winner', path: 'create' })
+      })
     );
     const rows = inboundOf();
     expect(rows[0]!.parseStatus).toBe('created');

--- a/apps/api/src/services/inboundEmail/inboundEmailService.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.ts
@@ -309,7 +309,6 @@ export async function processInboundEmail(
           'Inbound email quarantined: no usable provider sender-auth verdict on a signature-verified webhook',
           {
             eventCode: 'inbound_email_sender_auth_unverified',
-            extra: { provider: n.provider, recipient: n.to, diagnostic: gap, providerMessageId: n.providerMessageId },
           }
         );
       }
@@ -671,15 +670,6 @@ function warnLostClaim(
     'Inbound email lost the message-id claim race: duplicate ticket/comment written',
     {
       eventCode: 'inbound_email_claim_race_lost',
-      extra: {
-        path,
-        partnerId,
-        provider: n.provider,
-        providerMessageId: n.providerMessageId,
-        messageId: n.messageId,
-        ourTicketId,
-        winnerTicketId,
-      },
     }
   );
 }

--- a/apps/api/src/services/inboundEmail/inboundEmailService.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmailService.ts
@@ -307,8 +307,10 @@ export async function processInboundEmail(
       if (gap) {
         captureMessage(
           'Inbound email quarantined: no usable provider sender-auth verdict on a signature-verified webhook',
-          'warning',
-          { provider: n.provider, recipient: n.to, diagnostic: gap, providerMessageId: n.providerMessageId }
+          {
+            eventCode: 'inbound_email_sender_auth_unverified',
+            extra: { provider: n.provider, recipient: n.to, diagnostic: gap, providerMessageId: n.providerMessageId },
+          }
         );
       }
       const reason = gap
@@ -667,15 +669,17 @@ function warnLostClaim(
 ): void {
   captureMessage(
     'Inbound email lost the message-id claim race: duplicate ticket/comment written',
-    'warning',
     {
-      path,
-      partnerId,
-      provider: n.provider,
-      providerMessageId: n.providerMessageId,
-      messageId: n.messageId,
-      ourTicketId,
-      winnerTicketId,
+      eventCode: 'inbound_email_claim_race_lost',
+      extra: {
+        path,
+        partnerId,
+        provider: n.provider,
+        providerMessageId: n.providerMessageId,
+        messageId: n.messageId,
+        ourTicketId,
+        winnerTicketId,
+      },
     }
   );
 }

--- a/apps/api/src/services/llm/llmConfigResolver.test.ts
+++ b/apps/api/src/services/llm/llmConfigResolver.test.ts
@@ -387,10 +387,7 @@ describe('getAnthropicClientForPartner', () => {
     expect(captureMessage).toHaveBeenCalledTimes(1);
     expect(captureMessage).toHaveBeenCalledWith(
       'AI is not configured on this deployment.',
-      {
-        eventCode: 'llm_platform_key_missing',
-        tags: { service: 'llmConfigResolver' },
-      },
+      { eventCode: 'llm_platform_key_missing' },
     );
 
     vi.advanceTimersByTime(60 * 60 * 1000);

--- a/apps/api/src/services/llm/llmConfigResolver.test.ts
+++ b/apps/api/src/services/llm/llmConfigResolver.test.ts
@@ -387,9 +387,10 @@ describe('getAnthropicClientForPartner', () => {
     expect(captureMessage).toHaveBeenCalledTimes(1);
     expect(captureMessage).toHaveBeenCalledWith(
       'AI is not configured on this deployment.',
-      'warning',
-      undefined,
-      { service: 'llmConfigResolver' },
+      {
+        eventCode: 'llm_platform_key_missing',
+        tags: { service: 'llmConfigResolver' },
+      },
     );
 
     vi.advanceTimersByTime(60 * 60 * 1000);

--- a/apps/api/src/services/llm/llmConfigResolver.ts
+++ b/apps/api/src/services/llm/llmConfigResolver.ts
@@ -196,7 +196,6 @@ export async function getAnthropicClientForPartner(partnerId: string | null): Pr
     captureAtMostHourly('blank-platform-key:platform', () => {
       captureMessage('AI is not configured on this deployment.', {
         eventCode: 'llm_platform_key_missing',
-        tags: { service: 'llmConfigResolver' },
       });
     });
     throw error;

--- a/apps/api/src/services/llm/llmConfigResolver.ts
+++ b/apps/api/src/services/llm/llmConfigResolver.ts
@@ -194,12 +194,10 @@ export async function getAnthropicClientForPartner(partnerId: string | null): Pr
   if (!resolved.apiKey?.trim()) {
     const error = new LlmUnavailableError('AI is not configured on this deployment.');
     captureAtMostHourly('blank-platform-key:platform', () => {
-      captureMessage(
-        'AI is not configured on this deployment.',
-        'warning',
-        undefined,
-        { service: 'llmConfigResolver' },
-      );
+      captureMessage('AI is not configured on this deployment.', {
+        eventCode: 'llm_platform_key_missing',
+        tags: { service: 'llmConfigResolver' },
+      });
     });
     throw error;
   }

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -463,6 +463,11 @@ describe('scrubEvent', () => {
         binary_component: 'agent',
         release_asset_name: 'breeze-agent-darwin-arm64',
         manifest_refusal_reason: 'not-distributable',
+        worker: 'patchScheduler',
+        worker_failure_reason: 'desktop_stop_pending',
+        patch_reconcile_stage: 'enqueue_failed',
+        patch_reconcile_repeat: '2-4',
+        jobId: 'bull-job-918273',
         path: '/public/quotes/raw-capability',
         arbitrary: 'raw-capability',
       },
@@ -531,6 +536,19 @@ describe('scrubEvent', () => {
       binary_component: 'agent',
       release_asset_name: 'breeze-agent-darwin-arm64',
       manifest_refusal_reason: 'not-distributable',
+      // #1379/BREEZE-9: attachWorkerObservability sets this on all 38 workers
+      // and the scrubber has been discarding it the whole time, which is why
+      // ~12k held-context events carry an empty `worker`. Dropped here, no
+      // worker-attributed triage is possible at all.
+      worker: 'patchScheduler',
+      // #3912's tags. Inert until that PR lands, but asserted now so a future
+      // edit to ALLOWED_TAG_NAMES cannot quietly un-allowlist them.
+      worker_failure_reason: 'desktop_stop_pending',
+      patch_reconcile_stage: 'enqueue_failed',
+      patch_reconcile_repeat: '2-4',
+      // NB: `jobId` was in the input bag and is deliberately absent here — a
+      // BullMQ per-job counter is unbounded by construction, so allowlisting it
+      // would inflate Sentry's tag index without making anything triageable.
     });
     expect(out.exception).toEqual({
       values: [{

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -80,7 +80,6 @@ describe('sentry service', () => {
     captureMessage('held a pooled connection', {
       eventCode: 'db_context_held_too_long',
       level: 'warning',
-      extra: { heldMs: 12000 },
       tags: { dbContextLabel: 'agentWs.heartbeat' },
     });
 
@@ -536,10 +535,10 @@ describe('scrubEvent', () => {
       binary_component: 'agent',
       release_asset_name: 'breeze-agent-darwin-arm64',
       manifest_refusal_reason: 'not-distributable',
-      // #1379/BREEZE-9: attachWorkerObservability sets this on all 38 workers
-      // and the scrubber has been discarding it the whole time, which is why
-      // ~12k held-context events carry an empty `worker`. Dropped here, no
-      // worker-attributed triage is possible at all.
+      // #1379/BREEZE-9: attachWorkerObservability sets this on every worker,
+      // and the allowlist introduced two days later (a50769487) has discarded
+      // it ever since, which is why ~12k held-context events carry an empty
+      // `worker`. Dropped here, no worker-attributed triage is possible.
       worker: 'patchScheduler',
       // #3912's tags. Inert until that PR lands, but asserted now so a future
       // edit to ALLOWED_TAG_NAMES cannot quietly un-allowlist them.

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -77,8 +77,11 @@ describe('sentry service', () => {
     const { initSentry, captureMessage } = await import('./sentry');
     initSentry();
 
-    captureMessage('held a pooled connection', 'warning', { heldMs: 12000 }, {
-      dbContextLabel: 'agentWs.heartbeat',
+    captureMessage('held a pooled connection', {
+      eventCode: 'db_context_held_too_long',
+      level: 'warning',
+      extra: { heldMs: 12000 },
+      tags: { dbContextLabel: 'agentWs.heartbeat' },
     });
 
     expect(captureMessageMock).toHaveBeenCalledWith('held a pooled connection');
@@ -92,7 +95,10 @@ describe('sentry service', () => {
     const { initSentry, captureMessage } = await import('./sentry');
     initSentry();
 
-    captureMessage('database warning', 'warning', undefined, {
+    captureMessage('database warning', {
+      eventCode: 'db_contextless_write',
+      level: 'warning',
+      tags: {
       pg_code: '42501',
       org_id: '00000000-0000-4000-8000-000000000001',
       // #3517: without these the body-limit 413 event arrives contentless —
@@ -102,6 +108,7 @@ describe('sentry service', () => {
       path: '/quotes/raw-capability',
       route_template: '/quotes/:token',
       partner_id: 'x'.repeat(129),
+      },
     });
 
     expect(setTagMock).toHaveBeenCalledWith('pg_code', '42501');
@@ -125,9 +132,13 @@ describe('sentry service', () => {
     const { initSentry, captureMessage } = await import('./sentry');
     initSentry();
 
-    captureMessage('Expected-rows write affected 0 rows', 'warning', undefined, {
-      cas_label: 'device_commands.ws_result_terminal_cas',
-      prior_status: 'failed:server-timeout',
+    captureMessage('Expected-rows write affected 0 rows', {
+      eventCode: 'db_write_expecting_rows_zero',
+      level: 'warning',
+      tags: {
+        cas_label: 'device_commands.ws_result_terminal_cas',
+        prior_status: 'failed:server-timeout',
+      },
     });
 
     expect(setTagMock).toHaveBeenCalledWith(
@@ -193,15 +204,53 @@ describe('sentry service', () => {
     expect(setTagMock).not.toHaveBeenCalledWith('connect_timeout_cause', expect.anything());
   });
 
-  it('captureMessage sets no tags when none are passed (existing callers unaffected)', async () => {
+  // BREEZE-18: this used to assert that a bare captureMessage set NO tags —
+  // which was exactly the defect. `scrubEvent` deletes message/logentry/extra,
+  // so a tagless event ships completely empty and Sentry folds every one of
+  // them into a single 11k-occurrence issue. The required `eventCode` is now
+  // applied by captureMessage itself, so the floor is one tag, never zero.
+  it('captureMessage always tags event_code even when the caller passes nothing else', async () => {
     process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
     const { initSentry, captureMessage } = await import('./sentry');
     initSentry();
 
-    captureMessage('plain warning');
+    captureMessage('plain warning', { eventCode: 'db_contextless_write' });
 
     expect(captureMessageMock).toHaveBeenCalledWith('plain warning');
-    expect(setTagMock).not.toHaveBeenCalled();
+    expect(setTagMock).toHaveBeenCalledWith('event_code', 'db_contextless_write');
+    expect(setTagMock).toHaveBeenCalledTimes(1);
+    expect(setLevelMock).toHaveBeenCalledWith('warning');
+  });
+
+  it('captureMessage will not let a caller tag bag override the call site event code', async () => {
+    process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
+    const { initSentry, captureMessage } = await import('./sentry');
+    initSentry();
+
+    captureMessage('plain warning', {
+      eventCode: 'db_contextless_write',
+      // A caller could plausibly reach for the tag name directly; the call
+      // site's own code has to win, or two conditions merge back into one
+      // untriageable bucket.
+      tags: { event_code: 'something_else' },
+    });
+
+    expect(setTagMock).toHaveBeenLastCalledWith('event_code', 'db_contextless_write');
+  });
+
+  it('captureMessage degrades an unregistered event code to a named sentinel', async () => {
+    process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
+    const { initSentry, captureMessage } = await import('./sentry');
+    initSentry();
+
+    // Reachable from compiled JS, an `any`-typed test double or an ee/
+    // extension, none of which tsc checked. A bogus value must not become an
+    // unbounded tag — but it must still leave the event groupable.
+    captureMessage('plain warning', {
+      eventCode: 'totally-made-up' as never,
+    });
+
+    expect(setTagMock).toHaveBeenCalledWith('event_code', 'unregistered_event_code');
   });
 
   it('does not initialize the SDK when no DSN is configured', async () => {
@@ -410,6 +459,10 @@ describe('scrubEvent', () => {
         connect_timeout_cause: 'event-loop-starvation',
         event_loop_lag_bucket: 'over-10s',
         db_pool_health_verdict: 'pool-degraded',
+        event_code: 'db_write_expecting_rows_zero',
+        binary_component: 'agent',
+        release_asset_name: 'breeze-agent-darwin-arm64',
+        manifest_refusal_reason: 'not-distributable',
         path: '/public/quotes/raw-capability',
         arbitrary: 'raw-capability',
       },
@@ -467,6 +520,17 @@ describe('scrubEvent', () => {
       // and it is the field that decides whether the operator restarts the API.
       // Dropped here, the watchdog's alerts arrive as contentless blanks.
       db_pool_health_verdict: 'pool-degraded',
+      // BREEZE-18: the tag that makes a captureMessage event groupable at all.
+      // captureMessage sets it on every call, so if the scrubber dropped it
+      // here EVERY message event would go back to arriving contentless — the
+      // 11,466-occurrence single-issue bucket this whole mechanism removes.
+      event_code: 'db_write_expecting_rows_zero',
+      // BREEZE-1Z: the three tags that make a refused release artifact
+      // identifiable. Without them the operator cannot tell the intended
+      // unsigned-darwin refusal from a real trust regression.
+      binary_component: 'agent',
+      release_asset_name: 'breeze-agent-darwin-arm64',
+      manifest_refusal_reason: 'not-distributable',
     });
     expect(out.exception).toEqual({
       values: [{

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -9,6 +9,10 @@ import {
   UNMATCHED_ROUTE_LABEL,
   safeMatchedRouteLabel,
 } from './safeRequestLabel';
+import {
+  isRegisteredSentryEventCode,
+  type SentryEventCode,
+} from './sentryEventCodes';
 
 // SQLSTATE 42501 (insufficient_privilege) is what forced row-level security
 // raises when `breeze_app` writes a row that fails a policy's WITH CHECK clause
@@ -101,6 +105,31 @@ const ALLOWED_TAG_NAMES = new Set([
   // cluster groupable and actionable.
   'body_limit_rule',
   'body_limit_max_size',
+  // BREEZE-18: the required `captureMessage` discriminator. `scrubEvent`
+  // deletes `message`, `logentry` and `extra` from every event, so before this
+  // existed any captureMessage that happened not to carry one of the tags above
+  // shipped a completely EMPTY event — Sentry grouped 11,466 of them into one
+  // untriageable issue, 95% of its recent events carrying zero tags at all.
+  // Every entry above it is the same lesson relearned per incident; this one
+  // closes the class. Bounded by construction: the value is a string literal
+  // from the closed SENTRY_EVENT_CODES registry (services/sentryEventCodes.ts),
+  // type-enforced by `tsc` and re-checked at runtime, so it can never carry a
+  // tenant, device, host or path.
+  'event_code',
+  // #3836/D4: a refused official-manifest asset (binarySync) is reported as an
+  // exception whose descriptive message the scrubber deletes, so the production
+  // issue could not say WHICH asset was refused — and the INTENDED case
+  // (unsigned darwin artifacts, pending signed macOS releases) was therefore
+  // indistinguishable from a real trust regression. `binary_component` is the
+  // hardcoded component name from the sync call sites ('agent', 'viewer', …);
+  // `release_asset_name` is a RELEASE ARTIFACT filename — a build output name
+  // like `breeze-agent-windows-amd64.exe`, bounded by the release matrix and
+  // carrying no tenant, device, org or host identifier; `manifest_refusal_reason`
+  // is a closed set derived from the thrown error's CLASS (never its message
+  // text, which is unbounded and interpolates the offending values).
+  'binary_component',
+  'release_asset_name',
+  'manifest_refusal_reason',
 ]);
 const UNSAFE_TAG_CHARACTERS = /[/?#\r\n]/;
 const SAFE_STRUCTURAL_NAME = /^[A-Za-z_$<][A-Za-z0-9_.$<>:[\] ]{0,127}$/;
@@ -385,30 +414,62 @@ export function captureException(
 }
 
 /**
- * `tags` mirrors captureException's third parameter. Prefer it over `extra` for
- * any low-cardinality discriminator you will want to GROUP BY in Sentry: extras
- * are only visible once you open an individual event, while tags are
- * searchable and drive the "break down by" UI. Attributing a recurring warning
- * to its source is exactly that job — an unfilterable 7k-event bucket
- * (BREEZE-A) is what happens without it.
+ * Options bag for `captureMessage`.
+ *
+ * WHY AN OPTIONS OBJECT (BREEZE-18): `eventCode` had to become REQUIRED, which
+ * changes the arity of every call however it is added, so there was no
+ * "cheaper" positional variant to prefer. Given a free choice, the object wins
+ * on the three things that outlive this change:
+ *   - the required field sits adjacent to `message` and is self-labelling at
+ *     the call site, instead of being an unlabelled literal in slot 2 or 5;
+ *   - the four optional fields stop being order-dependent — a dozen call sites
+ *     previously padded `undefined` into `extra` purely to reach `tags`;
+ *   - the next optional knob (a `fingerprint`, a sampling hint) is added
+ *     without touching a single existing caller.
+ * `captureException` keeps its positional shape deliberately: it has no
+ * required discriminator, and churning it would buy nothing.
+ *
+ * Prefer `tags` over `extra` for any low-cardinality discriminator you will
+ * want to GROUP BY in Sentry: extras are only visible once you open an
+ * individual event (and `scrubEvent` deletes them outright before send), while
+ * tags are searchable and drive the "break down by" UI.
  *
  * Keep tag values low-cardinality (a handler name, not an id) — high-cardinality
  * tags inflate Sentry's index without making anything more triageable.
  */
-export function captureMessage(
-  message: string,
-  level: 'info' | 'warning' | 'error' = 'warning',
-  extra?: Record<string, unknown>,
-  tags?: Record<string, string>
-): void {
+export interface CaptureMessageOptions {
+  /**
+   * REQUIRED, and applied as the `event_code` tag by `captureMessage` itself
+   * rather than threaded through `tags` — a caller cannot forget it, misspell
+   * the tag name, or have it silently dropped by the allowlist. Must be a
+   * hardcoded literal from SENTRY_EVENT_CODES; never interpolate an id.
+   */
+  eventCode: SentryEventCode;
+  level?: 'info' | 'warning' | 'error';
+  /** Deleted by `scrubEvent` before send; kept for local console parity only. */
+  extra?: Record<string, unknown>;
+  tags?: Record<string, string>;
+}
+
+export function captureMessage(message: string, options: CaptureMessageOptions): void {
   if (!initialized) {
     return;
   }
+
+  const { eventCode, level = 'warning', extra, tags } = options;
 
   Sentry.withScope((scope) => {
     scope.setLevel(level);
     void extra;
     setCallerTags(scope, tags);
+    // Set AFTER the caller's tags so a `tags: { event_code: ... }` bag can never
+    // override the call site's own code, and guarded so an unregistered value
+    // arriving from untyped JS degrades to a named sentinel rather than an
+    // unbounded tag or (worse) the contentless event this exists to prevent.
+    scope.setTag(
+      'event_code',
+      isRegisteredSentryEventCode(eventCode) ? eventCode : 'unregistered_event_code',
+    );
     Sentry.captureMessage(message);
   });
 }

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -130,6 +130,43 @@ const ALLOWED_TAG_NAMES = new Set([
   'binary_component',
   'release_asset_name',
   'manifest_refusal_reason',
+  // #1379/BREEZE-9: `attachWorkerObservability` has been setting this tag on
+  // every one of the 38 workers ALL ALONG — twice, in fact: on the per-job
+  // isolation scope (so anything captured DURING a job inherits it) and again
+  // on the `failed` listener. `pickAllowedTags` then dropped it on the way out,
+  // every time. That is the same defect as the contentless captureMessage
+  // events above, and it invalidates the diagnosis recorded in
+  // jobs/workerObservability.ts: BREEZE-9's ~12k held-context events with an
+  // empty `worker` tag were blamed on the listener firing outside job
+  // execution, and the fix (patching Worker.processFn) could never have worked
+  // while the scrubber deleted the tag regardless of where it was set.
+  // Attributing events by worker is the stated entire point of that
+  // integration. Closed set of 38 hardcoded worker-name literals passed to
+  // attachWorkerObservability; carries no tenant, device or host identifier.
+  //
+  // Its two neighbours there are deliberately NOT allowlisted: `jobName` is
+  // bounded but redundant with `worker` for triage, and `jobId` is a BullMQ
+  // per-job counter — unbounded by construction, exactly the high-cardinality
+  // tag the captureMessage doc comment warns against.
+  'worker',
+  // Set by fix/sentry-worker-job-failures (#3912), which deliberately does not
+  // touch this file. Inert until that lands — an allowlist entry only ever
+  // preserves a tag something else sets, so listing it early cannot leak
+  // anything. `worker_failure_reason` is a closed set of hardcoded labels from
+  // a classifier function (`desktop_stop_pending`,
+  // `desktop_intent_already_released` today), never derived from job data; it
+  // is what separates "the agent was offline for a second" from a real fault.
+  'worker_failure_reason',
+  // Also #3912. `patch_reconcile_stage` is a closed 4-value set
+  // (recovered | stalled | enqueue_failed | sweep_failed) written as string
+  // literals at four call sites in enqueueScanResults
+  // (jobs/patchSchedulerWorker.ts) — without it those four captures are
+  // distinguishable only by bundle line number, which changes every build.
+  // `patch_reconcile_repeat` is a BUCKETED streak length (1 | 2-4 | 5-9 | 10+),
+  // bucketed precisely so a long-running reconcile loop cannot turn a counter
+  // into unbounded tag cardinality. Neither carries a tenant, device or job id.
+  'patch_reconcile_stage',
+  'patch_reconcile_repeat',
 ]);
 const UNSAFE_TAG_CHARACTERS = /[/?#\r\n]/;
 const SAFE_STRUCTURAL_NAME = /^[A-Za-z_$<][A-Za-z0-9_.$<>:[\] ]{0,127}$/;

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -121,7 +121,10 @@ const ALLOWED_TAG_NAMES = new Set([
   // issue could not say WHICH asset was refused — and the INTENDED case
   // (unsigned darwin artifacts, pending signed macOS releases) was therefore
   // indistinguishable from a real trust regression. `binary_component` is the
-  // hardcoded component name from the sync call sites ('agent', 'viewer', …);
+  // hardcoded component name from the only two call sites that can reach this
+  // report: `registerFromOfficialManifest` is invoked with exactly "agent" and
+  // "watchdog". The "backup", "helper" and "user-helper" components go through
+  // registerLocalBinaries, which never refuses an asset and never reports here;
   // `release_asset_name` is a RELEASE ARTIFACT filename — a build output name
   // like `breeze-agent-windows-amd64.exe`, bounded by the release matrix and
   // carrying no tenant, device, org or host identifier; `manifest_refusal_reason`
@@ -130,19 +133,25 @@ const ALLOWED_TAG_NAMES = new Set([
   'binary_component',
   'release_asset_name',
   'manifest_refusal_reason',
-  // #1379/BREEZE-9: `attachWorkerObservability` has been setting this tag on
-  // every one of the 38 workers ALL ALONG — twice, in fact: on the per-job
-  // isolation scope (so anything captured DURING a job inherits it) and again
-  // on the `failed` listener. `pickAllowedTags` then dropped it on the way out,
-  // every time. That is the same defect as the contentless captureMessage
-  // events above, and it invalidates the diagnosis recorded in
-  // jobs/workerObservability.ts: BREEZE-9's ~12k held-context events with an
-  // empty `worker` tag were blamed on the listener firing outside job
-  // execution, and the fix (patching Worker.processFn) could never have worked
-  // while the scrubber deleted the tag regardless of where it was set.
-  // Attributing events by worker is the stated entire point of that
-  // integration. Closed set of 38 hardcoded worker-name literals passed to
-  // attachWorkerObservability; carries no tenant, device or host identifier.
+  // #1379/BREEZE-9: `attachWorkerObservability` sets this tag on every worker —
+  // twice, in fact: on the per-job isolation scope (so anything captured DURING
+  // a job inherits it) and again on the `failed` listener. It is a closed set of
+  // hardcoded worker-name literals passed to attachWorkerObservability; no
+  // tenant, device or host identifier.
+  //
+  // Chronology matters here, because it explains a two-day-old regression rather
+  // than an original defect. `3c92c07cd` (2026-07-25, #2786) added the
+  // processFn patch that put `worker` on the per-job scope, and it WORKED:
+  // `git show a50769487^:apps/api/src/services/sentry.ts` has no tag filtering
+  // at all. Two days later `a50769487` (2026-07-27, #2843, security wave 7)
+  // introduced this allowlist and silently dropped `worker` on the way out. So
+  // the BREEZE-9 fix was live for two days and has been inert since — the
+  // hardening regressed it, and nothing failed to say so.
+  //
+  // The diagnosis in jobs/workerObservability.ts is therefore correct but
+  // incomplete, not wrong: the `failed` listener genuinely does fire outside job
+  // execution, which is why the processFn patch was needed. This allowlist gap
+  // is a second, later defect stacked on top of it.
   //
   // Its two neighbours there are deliberately NOT allowlisted: `jobName` is
   // bounded but redundant with `worker` for triage, and `jobId` is a BullMQ
@@ -167,6 +176,44 @@ const ALLOWED_TAG_NAMES = new Set([
   // into unbounded tag cardinality. Neither carries a tenant, device or job id.
   'patch_reconcile_stage',
   'patch_reconcile_repeat',
+  // These were being passed to captureMessage and silently dropped — the same
+  // defect as `worker`, found by auditing every tag key against this list
+  // rather than trusting that a passed tag arrives.
+  //
+  // `mobile_device_id_source` is the TypeScript union `'signed-claim' | 'header'`
+  // (middleware/mobileDeviceBlocked.ts) — it says whether the caller's device id
+  // came from a signed token claim or a legacy header, which is what decides
+  // whether the fleet needs re-registration or the token issuer is at fault.
+  // `mobile_registration_reason` carries two disjoint closed unions from
+  // routes/mobile.ts: 'displace-insert-conflict' | 'upsert-guard-matched-no-row'
+  // on the conflict path, and 'foreign-blocked-row' |
+  // 'unverified-installation-claim' on the fallback path. Both are declared
+  // unions, never interpolated, and neither carries a user or device id.
+  //
+  // Both are named specifically rather than `source` / `reason`. The allowlist
+  // is keyed by NAME, so a generic key would hand a free pass to any future
+  // caller that reaches for the same obvious word with an unbounded value —
+  // `reason` being the single most likely name for a raw error string.
+  'mobile_device_id_source',
+  'mobile_registration_reason',
+  // `'agent' | 'reconcile'` (services/backupResultPersistence.ts) — which
+  // ingestion path reported the result. Not redundant with `event_code`: the
+  // same drop can arrive from either path and they fail for different reasons.
+  'backup_result_source',
+  // BREEZE-A/#3218: the derived `${file}.${fn}` attribution for a held DB
+  // context. Structurally bounded — parseOpenerFrame builds it from a matched
+  // stack frame's source basename and stripped function name, and deliberately
+  // omits line numbers so an unrelated edit above the call site cannot fork the
+  // issue. This is the ONLY attribution that reaches Sentry for a held context:
+  // scrubEvent deletes `message`, so the label baked into the message text
+  // (formatHeldContextWarning) never arrives either.
+  //
+  // Its sibling `dbContextLabel` is NOT allowlisted, deliberately. It is
+  // caller-supplied `withDbAccessContext({ label })` typed as bare `string` and
+  // threaded through helpers like agentWs's runWithAgentOrgDbAccess(label, …),
+  // so proving every current and future path passes a hardcoded literal is a
+  // real sweep, not a glance. Unproven means not allowlisted.
+  'dbContextOpener',
 ]);
 const UNSAFE_TAG_CHARACTERS = /[/?#\r\n]/;
 const SAFE_STRUCTURAL_NAME = /^[A-Za-z_$<][A-Za-z0-9_.$<>:[\] ]{0,127}$/;
@@ -466,10 +513,11 @@ export function captureException(
  * `captureException` keeps its positional shape deliberately: it has no
  * required discriminator, and churning it would buy nothing.
  *
- * Prefer `tags` over `extra` for any low-cardinality discriminator you will
- * want to GROUP BY in Sentry: extras are only visible once you open an
- * individual event (and `scrubEvent` deletes them outright before send), while
- * tags are searchable and drive the "break down by" UI.
+ * `tags` is the ONLY channel that reaches Sentry from here. Anything you want to
+ * GROUP BY must be a bounded, allowlisted tag: `scrubEvent` deletes `message`,
+ * `logentry` and `extra` from every outbound event, so a discriminator that is
+ * not an allowlisted tag does not exist as far as triage is concerned. Console
+ * output is the place for unbounded detail.
  *
  * Keep tag values low-cardinality (a handler name, not an id) — high-cardinality
  * tags inflate Sentry's index without making anything more triageable.
@@ -483,21 +531,28 @@ export interface CaptureMessageOptions {
    */
   eventCode: SentryEventCode;
   level?: 'info' | 'warning' | 'error';
-  /** Deleted by `scrubEvent` before send; kept for local console parity only. */
-  extra?: Record<string, unknown>;
   tags?: Record<string, string>;
 }
+
+// There is deliberately NO `extra` field. The old one was dead twice over: this
+// function never called `scope.setExtras`, so nothing was attached to the
+// event, and `scrubEvent` deletes `extra` from every outbound event anyway.
+// Sixteen call sites were nonetheless building payloads for it — several
+// capturing stack traces — that went nowhere. A type advertising a capability
+// it does not have is the same failure this PR is about, so the field is gone
+// rather than documented. If you want a diagnostic locally, `console.warn` it
+// at the call site (most already do); if you want it in Sentry, it has to be a
+// bounded, allowlisted TAG.
 
 export function captureMessage(message: string, options: CaptureMessageOptions): void {
   if (!initialized) {
     return;
   }
 
-  const { eventCode, level = 'warning', extra, tags } = options;
+  const { eventCode, level = 'warning', tags } = options;
 
   Sentry.withScope((scope) => {
     scope.setLevel(level);
-    void extra;
     setCallerTags(scope, tags);
     // Set AFTER the caller's tags so a `tags: { event_code: ... }` bag can never
     // override the call site's own code, and guarded so an unregistered value

--- a/apps/api/src/services/sentryEventCodes.test.ts
+++ b/apps/api/src/services/sentryEventCodes.test.ts
@@ -56,6 +56,48 @@ function walk(dir: string): string[] {
   return out;
 }
 
+/**
+ * Blank out `//` and block comments, preserving length and newlines so every
+ * offset and line number computed later still lines up with the real source.
+ *
+ * Required, not cosmetic: `callArguments` treats `'` as a string delimiter, so
+ * an apostrophe inside a comment desynchronises it. That is live in this repo —
+ * `db/dbPoolHealthMonitor.ts` has `// States this event's own sampling rate`
+ * inside a captureMessage options block, which made the parser run past the
+ * call and return null for it.
+ */
+function blankComments(source: string): string {
+  let out = '';
+  let i = 0;
+  let quote: string | null = null;
+  while (i < source.length) {
+    const ch = source[i]!;
+    const next = source[i + 1];
+    if (quote) {
+      out += ch;
+      if (ch === '\\') { out += next ?? ''; i += 2; continue; }
+      if (ch === quote) quote = null;
+      i += 1;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') { quote = ch; out += ch; i += 1; continue; }
+    if (ch === '/' && next === '/') {
+      while (i < source.length && source[i] !== '\n') { out += ' '; i += 1; }
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
+        out += source[i] === '\n' ? '\n' : ' ';
+        i += 1;
+      }
+      out += '  '; i += 2;
+      continue;
+    }
+    out += ch; i += 1;
+  }
+  return out;
+}
+
 /** Slice the argument list of the call whose `(` follows `openIndex`. */
 function callArguments(source: string, openIndex: number): string | null {
   let depth = 0;
@@ -86,7 +128,8 @@ function callArguments(source: string, openIndex: number): string | null {
 interface CallSite {
   file: string;
   line: number;
-  args: string;
+  /** null when the argument list could not be parsed — an offender, never a skip. */
+  args: string | null;
 }
 
 function findCaptureMessageCalls(): CallSite[] {
@@ -95,7 +138,7 @@ function findCaptureMessageCalls(): CallSite[] {
   );
   const sites: CallSite[] = [];
   for (const file of files) {
-    const source = readFileSync(file, 'utf8');
+    const source = blankComments(readFileSync(file, 'utf8'));
     // Only files that actually import OUR captureMessage. apps/web and
     // apps/mobile call the Sentry SDK's own captureMessage, which has a
     // different contract; neither is under the roots scanned here, but the
@@ -106,7 +149,6 @@ function findCaptureMessageCalls(): CallSite[] {
     while ((match = pattern.exec(source)) !== null) {
       const openIndex = source.indexOf('(', match.index);
       const args = callArguments(source, openIndex);
-      if (args === null) continue;
       sites.push({
         file: relative(REPO_ROOT, file),
         line: source.slice(0, match.index).split('\n').length,
@@ -145,13 +187,25 @@ describe('captureMessage call sites (BREEZE-18)', () => {
     // helper or moves the tree would otherwise turn this whole suite green by
     // scanning zero files. The floor is deliberately well under the current
     // count so ordinary churn does not touch it.
-    expect(sites.length).toBeGreaterThanOrEqual(20);
+    // Tightened after the comment-stripping fix: the apostrophe desync meant
+    // this scanner silently discarded one of 28 real call sites, and a floor of
+    // 20 could never have noticed. Kept a little under the true count so
+    // ordinary churn does not touch it, but close enough to catch a collapse.
+    expect(sites.length).toBeGreaterThanOrEqual(26);
   });
 
   it('passes a hardcoded, registered eventCode at every call site', () => {
     const offenders: string[] = [];
     for (const site of sites) {
       const where = `${site.file}:${site.line}`;
+      // A call whose arguments we could not parse is an OFFENDER, not a skip.
+      // Skipping it silently is how a scanner passes while covering less than
+      // it claims — and a desynced parser can also over-run into the NEXT
+      // call's arguments, letting one site's code vouch for another's.
+      if (site.args === null) {
+        offenders.push(`${where} — could not parse the argument list; the scanner cannot vouch for this call site`);
+        continue;
+      }
       const match = /(?:^|[\s,{])eventCode\s*:\s*(.+)/s.exec(site.args);
       if (!match) {
         offenders.push(`${where} — no eventCode (event ships contentless)`);

--- a/apps/api/src/services/sentryEventCodes.test.ts
+++ b/apps/api/src/services/sentryEventCodes.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  SENTRY_EVENT_CODES,
+  isRegisteredSentryEventCode,
+} from './sentryEventCodes';
+
+/**
+ * BREEZE-18 contract suite.
+ *
+ * `tsc` already rejects a `captureMessage` call with no `eventCode`, or with a
+ * code outside the registry — that is the primary guard and it is why the
+ * option is typed as a string-literal union rather than `string`. This suite
+ * covers the two things the type system cannot see:
+ *
+ *   1. INTERPOLATION. `eventCode: \`db_${kind}\`` is a template literal whose
+ *      type can still narrow to a union member, so tsc would accept it while a
+ *      variant of it explodes the tag's cardinality in production. Only a
+ *      source scan catches "must be a hardcoded literal".
+ *   2. UNTYPED REACH. `ee/` extensions and any `any`-typed indirection can call
+ *      captureMessage without tsc ever checking the argument.
+ *
+ * Precedent for scanning source in a unit test: `composeBindMounts.test.ts`
+ * (apps/api) and `no-silent-mutations.test.ts` (apps/web). Following the
+ * former: pure filesystem reads, no DB, so it runs in the required Test API
+ * job rather than the integration shards, where a regression could hide behind
+ * a stale base (see CLAUDE.md).
+ */
+
+const API_SRC = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const REPO_ROOT = resolve(API_SRC, '../../..');
+const EE_ROOT = join(REPO_ROOT, 'ee');
+const SENTRY_MODULE = join(API_SRC, 'services/sentry.ts');
+
+function walk(dir: string): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of entries) {
+    if (entry === 'node_modules' || entry === 'dist' || entry === '.turbo') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+      continue;
+    }
+    if (!/\.tsx?$/.test(entry)) continue;
+    if (/\.(test|spec)\.tsx?$/.test(entry)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+/** Slice the argument list of the call whose `(` follows `openIndex`. */
+function callArguments(source: string, openIndex: number): string | null {
+  let depth = 0;
+  let quote: string | null = null;
+  for (let i = openIndex; i < source.length; i += 1) {
+    const ch = source[i]!;
+    if (quote) {
+      if (ch === '\\') {
+        i += 1;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '(') depth += 1;
+    else if (ch === ')') {
+      depth -= 1;
+      if (depth === 0) return source.slice(openIndex + 1, i);
+    }
+  }
+  return null;
+}
+
+interface CallSite {
+  file: string;
+  line: number;
+  args: string;
+}
+
+function findCaptureMessageCalls(): CallSite[] {
+  const files = [...walk(API_SRC), ...walk(EE_ROOT)].filter(
+    (file) => file !== SENTRY_MODULE,
+  );
+  const sites: CallSite[] = [];
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8');
+    // Only files that actually import OUR captureMessage. apps/web and
+    // apps/mobile call the Sentry SDK's own captureMessage, which has a
+    // different contract; neither is under the roots scanned here, but the
+    // guard keeps that true if a future module re-exports the SDK.
+    if (!/from\s+['"][^'"]*\/sentry['"]/.test(source)) continue;
+    const pattern = /(?<![.\w])captureMessage\s*\(/g;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(source)) !== null) {
+      const openIndex = source.indexOf('(', match.index);
+      const args = callArguments(source, openIndex);
+      if (args === null) continue;
+      sites.push({
+        file: relative(REPO_ROOT, file),
+        line: source.slice(0, match.index).split('\n').length,
+        args,
+      });
+    }
+  }
+  return sites;
+}
+
+describe('SENTRY_EVENT_CODES registry', () => {
+  it('holds unique, bounded, low-cardinality codes', () => {
+    expect(new Set(SENTRY_EVENT_CODES).size).toBe(SENTRY_EVENT_CODES.length);
+    for (const code of SENTRY_EVENT_CODES) {
+      // Same ceiling `isBoundedTagValue` applies in the scrubber, and the same
+      // characters `UNSAFE_TAG_CHARACTERS` rejects — a code that fails either
+      // would be silently dropped from the event, restoring the blank.
+      expect(code.length).toBeLessThanOrEqual(128);
+      expect(code).toMatch(/^[a-z][a-z0-9_]*$/);
+    }
+  });
+
+  it('recognises registered codes and rejects everything else at runtime', () => {
+    expect(isRegisteredSentryEventCode(SENTRY_EVENT_CODES[0])).toBe(true);
+    expect(isRegisteredSentryEventCode('not_a_real_code')).toBe(false);
+    expect(isRegisteredSentryEventCode(undefined)).toBe(false);
+    expect(isRegisteredSentryEventCode(42)).toBe(false);
+  });
+});
+
+describe('captureMessage call sites (BREEZE-18)', () => {
+  const sites = findCaptureMessageCalls();
+
+  it('finds the call sites at all — a scanner matching nothing proves nothing', () => {
+    // Guards against the silent-pass failure mode: a refactor that renames the
+    // helper or moves the tree would otherwise turn this whole suite green by
+    // scanning zero files. The floor is deliberately well under the current
+    // count so ordinary churn does not touch it.
+    expect(sites.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it('passes a hardcoded, registered eventCode at every call site', () => {
+    const offenders: string[] = [];
+    for (const site of sites) {
+      const where = `${site.file}:${site.line}`;
+      const match = /(?:^|[\s,{])eventCode\s*:\s*(.+)/s.exec(site.args);
+      if (!match) {
+        offenders.push(`${where} — no eventCode (event ships contentless)`);
+        continue;
+      }
+      const literal = /^'([^'\\]*)'|^"([^"\\]*)"/.exec(match[1]!.trim());
+      if (!literal) {
+        offenders.push(
+          `${where} — eventCode is not a plain string literal; it must never be `
+          + `interpolated, computed or read from a variable`,
+        );
+        continue;
+      }
+      const code = literal[1] ?? literal[2]!;
+      if (!isRegisteredSentryEventCode(code)) {
+        offenders.push(`${where} — '${code}' is not in SENTRY_EVENT_CODES`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/api/src/services/sentryEventCodes.ts
+++ b/apps/api/src/services/sentryEventCodes.ts
@@ -1,0 +1,122 @@
+/**
+ * The closed set of `captureMessage` event codes (BREEZE-18).
+ *
+ * WHY THIS EXISTS: `scrubEvent` (services/sentry.ts) deletes `message`,
+ * `logentry` and `extra` from every outbound event and rebuilds `tags` through
+ * an allowlist. A `captureMessage` call that carried no allowlisted tag
+ * therefore shipped a completely EMPTY event — no message, no tags, no
+ * stacktrace — and Sentry grouped every one of them into a single issue.
+ * Measured in production on 2026-08-23: BREEZE-18 held 11,466 occurrences
+ * across 27 users (the org's top issue), and 2,610 of its most recent 2,738
+ * events (95%) carried zero tags and were untriageable.
+ *
+ * Every allowlist entry added before this file — `cas_label`, `prior_status`,
+ * `db_pool_health_verdict`, `body_limit_rule`, … — was the same problem being
+ * rediscovered one incident at a time. `event_code` fixes it once, for every
+ * call site, by construction: `captureMessage` requires one and applies it as a
+ * tag itself, so no caller can ship a contentless event even by forgetting.
+ *
+ * RULES for adding a code:
+ *   - Add it here first. The type is derived from this array, so a call site
+ *     using an unregistered code fails `tsc` — the set cannot drift open.
+ *   - It must be a HARDCODED string literal at the call site. Never
+ *     interpolate an id, tenant, device, hostname or path into it: the whole
+ *     point is a low-cardinality dimension Sentry can group and alert on.
+ *     `sentryEventCodes.test.ts` scans the source and fails on interpolation.
+ *   - One code per distinct condition, not per module. Two branches an
+ *     operator would act on differently deserve two codes.
+ *   - snake_case, and short enough to stay under the 128-char bounded-tag
+ *     ceiling `isBoundedTagValue` enforces.
+ */
+export const SENTRY_EVENT_CODES = [
+  // --- middleware -------------------------------------------------------
+  /** A request was refused by a body-size limit (global gate or route rule). */
+  'body_limit_rejected',
+  /** A mobile caller's device id resolved to no `mobile_devices` row. */
+  'mobile_device_unresolved',
+
+  // --- database / pool --------------------------------------------------
+  /** Pool-health watchdog published a non-healthy verdict. */
+  'db_pool_health_degraded',
+  /** Pool-health watchdog itself threw while evaluating. */
+  'db_pool_health_check_failed',
+  /** A `withDbAccessContext` transaction was held past the warn threshold. */
+  'db_context_held_too_long',
+  /** A write reached Postgres with no DB access context set (#1380 guard). */
+  'db_contextless_write',
+  /** Slow work ran INSIDE a held DB access context (#1105 tripwire). */
+  'db_operation_inside_held_context',
+  /** A compare-and-set write that expected rows affected zero (BREEZE-X). */
+  'db_write_expecting_rows_zero',
+
+  // --- process health ---------------------------------------------------
+  /** The event loop was starved past the configured threshold (#3022). */
+  'event_loop_starvation',
+
+  // --- jobs -------------------------------------------------------------
+  /** NVD pagination stopped before the feed's reported total (#2470). */
+  'nvd_pagination_truncated',
+  /** NVD pagination finished without the feed ever reporting a total. */
+  'nvd_pagination_no_total',
+  /** A CVE feed sync skipped an abnormal share of its entries. */
+  'cve_feed_high_skip_rate',
+  /** The FX provider returned rows the sync could not use. */
+  'exchange_rate_rows_rejected',
+
+  // --- software / catalog -----------------------------------------------
+  /** A software version was stored with an undetermined installer type. */
+  'software_version_installer_type_unknown',
+  /** A software upload discarded a malformed `supportedOs` field. */
+  'software_upload_malformed_supported_os',
+  /** The catalog-polish fact guard caught the model inventing a numeric spec. */
+  'catalog_polish_fact_over_claim',
+
+  // --- mobile -----------------------------------------------------------
+  /** Push registration lost a race and the phone gets no notifications. */
+  'mobile_push_registration_conflict',
+  /** Push registration fell back to a push-derived device id (#2913). */
+  'mobile_push_registration_fallback',
+
+  // --- integrations -----------------------------------------------------
+  /** QuickBooks home-currency capture lost its compare-and-set (benign race). */
+  'accounting_home_currency_cas_lost',
+  /** Inbound mail arrived with no usable provider sender-auth verdict. */
+  'inbound_email_sender_auth_unverified',
+  /** Inbound mail lost the message-id claim race and duplicated a ticket. */
+  'inbound_email_claim_race_lost',
+  /** No usable platform LLM key is configured on this deployment. */
+  'llm_platform_key_missing',
+
+  // --- backup -----------------------------------------------------------
+  /** A backup result matched no job row (deleted, or invisible under RLS). */
+  'backup_result_job_not_found',
+  /** A backup result's reported org disagreed with the job row's org. */
+  'backup_result_org_divergence',
+  /** Snapshots are unattributable because two orgs share a destination. */
+  'backup_snapshot_ambiguous_destination',
+
+  // --- device lifecycle -------------------------------------------------
+  /** The device cascade could not read the caller's prior `lock_timeout`. */
+  'device_deletion_lock_timeout_unreadable',
+  /** The device cascade ran without holding the parent `devices` row lock. */
+  'device_deletion_parent_lock_missing',
+] as const;
+
+/**
+ * Required discriminator on every `captureMessage`. A string-literal union
+ * rather than `string` so `tsc` — not a lint, not review — is what rejects an
+ * unregistered or interpolated code.
+ */
+export type SentryEventCode = (typeof SENTRY_EVENT_CODES)[number];
+
+const REGISTERED_EVENT_CODES: ReadonlySet<string> = new Set(SENTRY_EVENT_CODES);
+
+/**
+ * Runtime backstop for the type. Compiled JS, `any`-typed test doubles and
+ * `ee/` extensions can all reach `captureMessage` without `tsc` having checked
+ * the argument, and an unbounded value here would defeat the grouping this
+ * whole mechanism exists to provide.
+ */
+export function isRegisteredSentryEventCode(value: unknown): value is SentryEventCode {
+  return typeof value === 'string' && REGISTERED_EVENT_CODES.has(value);
+}

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -321,7 +321,7 @@ Both API and web Sentry integrations are off by default. Leave the DSN variables
 | Variable | Default | Description |
 |---|---|---|
 | `SENTRY_DSN` | — | API Sentry DSN. Leave blank to disable server-side error tracking. |
-| `SENTRY_ENVIRONMENT` | `production` | Sentry environment tag |
+| `SENTRY_ENVIRONMENT` | `production` | Sentry environment tag. In a **multi-region** deployment use a region-qualified value (`production-us`, `production-eu`) — a bare `production` on every region makes them indistinguishable in Sentry, and `server_name` is a per-deploy container hash, so nothing else can attribute an error to a region. |
 | `SENTRY_RELEASE` | — | Sentry release tag (e.g. git SHA) |
 | `SENTRY_TRACES_SAMPLE_RATE` | `0.1` | Sentry performance trace sample rate (0.0-1.0) |
 | `SENTRY_PROFILES_SAMPLE_RATE` | — | API performance-profiling sample rate (0.0-1.0). Leave blank to disable profiling. |

--- a/apps/docs/src/content/docs/security/error-tracking.mdx
+++ b/apps/docs/src/content/docs/security/error-tracking.mdx
@@ -43,6 +43,10 @@ Set in `.env`:
 ```bash
 # API
 SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project>
+# Multi-region: use a region-qualified value (production-us, production-eu).
+# A bare `production` on every region makes them indistinguishable in Sentry —
+# `server_name` is a per-deploy container hash, so no other field can attribute
+# an error to a region.
 SENTRY_ENVIRONMENT=production
 SENTRY_RELEASE=0.62.23
 SENTRY_TRACES_SAMPLE_RATE=0.1

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -6,7 +6,13 @@
 # ── Region ──────────────────────────────────────────────────────────
 BREEZE_DOMAIN=
 CORS_ALLOWED_ORIGINS=https://${BREEZE_DOMAIN}
-SENTRY_ENVIRONMENT=production
+# Region-qualified on purpose: this file is copied to EVERY droplet, so a bare
+# `production` on more than one of them collapses all regions into a single
+# Sentry environment. `server_name` is a per-deploy container hash and cannot
+# stand in, so errors then cannot be attributed to — or filtered by — a region.
+# Use `production-<region>` (e.g. `production-us`, `production-eu`) to match the
+# region this droplet serves.
+SENTRY_ENVIRONMENT=production-<region>
 
 # ── Release image integrity ────────────────────────────────────────
 # This is the strict, digest-pinned production deploy path


### PR DESCRIPTION
## The bug

`scrubEvent` in `apps/api/src/services/sentry.ts` — wired as Sentry's `beforeSend` — deletes `message`, `logentry`, `extra`, `breadcrumbs` and `contexts` from **every** outbound event, and rebuilds `tags` through the `ALLOWED_TAG_NAMES` allowlist.

Consequence: any `captureMessage()` call that did not happen to pass an allowlisted tag shipped a **completely empty event** — no message, no tags, no stacktrace (`attachStacktrace` is not set). Sentry has nothing left to group on, so it grouped all of them together.

That bucket is [**BREEZE-18**](https://olivetech-ks.sentry.io/issues/BREEZE-18): **11,466 occurrences, 27 users**, the org's top issue by ~20×. Measured in production on 2026-08-23, **95% of its recent events carried zero tags** and were untriageable.

The existing allowlist entries (`cas_label`, `db_pool_health_verdict`, `body_limit_rule`, …) are the same lesson rediscovered one incident at a time — each carries a comment saying that without it the event arrives contentless.

## The fix

`captureMessage(message, { eventCode, level?, extra?, tags? })`, where `eventCode` is a string-literal union derived from a registry in the new `apps/api/src/services/sentryEventCodes.ts`. An omitted, misspelled or unregistered code fails `tsc` — not lint. The tag is applied **inside** `captureMessage`, after the caller's tag bag, so a caller cannot override it, and `event_code` is allowlisted so it survives the scrubber.

- **28 call sites backfilled** across `apps/api/src` (and `ee/`, which has none), each with a hardcoded literal code.
- **8 tags allowlisted**, each with a justification comment: `event_code`, `binary_component`, `release_asset_name`, `manifest_refusal_reason`, plus `worker`, `worker_failure_reason`, `patch_reconcile_stage`, `patch_reconcile_repeat` (the last three are set by sibling PR #3912).
- **`worker` is the notable one** — `attachWorkerObservability` has been setting it on every failed job for every worker all along, and `pickAllowedTags` was discarding it.
- **`binarySync.ts`'s manifest-refusal `captureException`** gains bounded tags so a refused release asset is identifiable; the refusal reason is derived from the error **class**, never `err.message` (which interpolates unbounded values).
- **Per-region `SENTRY_ENVIRONMENT`** documented in `.env.example` and `deploy/.env.example`: production currently reports `environment: production` from both regions, and `server_name` is a per-deploy container hash, so errors cannot be attributed to a region. No code change — `initSentry` already reads it and compose already maps it.

## Tests

- `scrubEvent` preserves `event_code`; the caller cannot override it; an unregistered code degrades to a bounded sentinel rather than a blank.
- A source-scanning contract test asserts every `captureMessage` call site passes a hardcoded, registered code, with a site-count floor so it cannot pass vacuously.
- `jobId` is deliberately **not** allowlisted (unbounded by construction) and is asserted absent from scrubbed output, so that stays a recorded decision.


---

## Review round: 10-lens findings addressed (`f0d956b2b`)

**1. The phantom `extra` field — deleted, not documented.** `captureMessage` never called `scope.setExtras`, so `extra` was never attached to the event, and `scrubEvent` deletes it before send regardless — dead twice over. Sixteen call sites (not nine) were building payloads for it, several capturing stack traces. Deleting the field was the only option consistent with this PR's thesis: a type that advertises a capability it does not have is the same defect as a tag the code sets and the scrubber discards.

Three data points were genuinely worth keeping, so they moved to channels that work rather than being dropped:
- the pool-health throttle's **suppressed-capture count** → `console.warn` (a raw count is also the wrong shape for a tag — unbounded cardinality);
- the catalog fact-guard's **invented token** → the existing `console.warn` above the capture;
- the held-context **opener attribution** → the newly-allowlisted `dbContextOpener` tag.

Their tests moved with them. Those assertions had been checking values that provably never left the process — vacuous in effect, and deleting the field is what exposed them.

**2. The contract scanner could silently skip a call site.** `callArguments` treated `'` as a string delimiter without stripping comments, so the apostrophe in `dbPoolHealthMonitor.ts`'s `// States this event's own sampling rate` desynced the parser, and `if (args === null) continue;` discarded the site in silence. Comments are now blanked length-preservingly before scanning (offsets and line numbers still line up), and a parse failure is pushed as an **offender** instead of skipped — a desynced parser can also over-run into the next call's arguments, letting one site's code vouch for another's.

Verified rather than assumed: the scanner found **27 of 28** sites before the fix and **28** after (proved by moving the floor — passes at 28, fails at 29). The old `>= 20` floor could never have caught it; it is now `>= 26`.

**3. The chronology was wrong, and the corrected version is more damning.** `3c92c07cd` (2026-07-25, #2786) added the `processFn` patch and it **worked** — `git show a50769487^:apps/api/src/services/sentry.ts` has no tag filtering at all. `a50769487` (2026-07-27, #2843, security wave 7) then introduced `ALLOWED_TAG_NAMES` and silently regressed it. So the BREEZE-9 fix was live for two days and has been inert since. The diagnosis in `workerObservability.ts` is **correct but incomplete**, not refuted: the `failed` listener genuinely does fire outside job execution, which is why the patch was needed; the allowlist gap is a second, later defect stacked on top.

**4. "38 workers" was wrong** (actual: 43 production registrations across 43 distinct names). Dropped the number from all three places rather than correcting a figure that will rot again — "a closed set of hardcoded worker-name literals" is the part that is verifiable and the part that matters.

**5. `workerObservability.ts` is now actually updated.** The previous commit claimed it and did not touch the file, which left `sentry.ts` pointing readers at a superseded diagnosis presented as current fact.

**6. `binary_component`'s example values were wrong.** Only `"agent"` and `"watchdog"` can reach that tag — there are exactly two `registerFromOfficialManifest` call sites. `"backup"`, `"helper"` and `"user-helper"` go through `registerLocalBinaries`, which never refuses an asset and never reports. Removed the invented `'viewer'` and the open-set ellipsis. (One reviewer's suggested `agent/watchdog/backup` was also wrong.)

**7. Silently-dropped discriminator tags — per-tag decisions.**

| Tag | Decision | Why |
|---|---|---|
| `source` → **`mobile_device_id_source`** | allowlisted, renamed | TS union `'signed-claim' \| 'header'`; decides whether the fleet needs re-registration or the token issuer is at fault |
| `reason` → **`mobile_registration_reason`** | allowlisted, renamed | Two disjoint declared unions (`displace-insert-conflict \| upsert-guard-matched-no-row`, `foreign-blocked-row \| unverified-installation-claim`); never interpolated |
| `backup_result_source` | allowlisted | `'agent' \| 'reconcile'`; **not** redundant with `event_code` — the same drop arrives from either path for different reasons |
| `area` (×3) | deleted | Single hardcoded literal per site, fully subsumed by `event_code` |
| `backup_result_drop` | deleted | Single literal `'job-not-found'`, subsumed by its event code |
| `backup_result_org_divergence` | deleted | Single literal `'true'`, subsumed by its event code |
| `job` | deleted | Single literal `'exchange-rate-sync'`, subsumed by its event code |
| `service` | deleted | Single literal `'llmConfigResolver'`, subsumed by its event code |

The two renames are deliberate. The allowlist is keyed by **name**, so a generic `reason` would hand a free pass to any future caller reaching for the same obvious word with an unbounded value — `reason` being the single most likely name for a raw error string.

**Found while auditing (not in the review): `dbContextOpener`.** Same defect as `worker` — passed as a tag, dropped by the allowlist. It is the *only* attribution that reaches Sentry for a held DB context, because `scrubEvent` deletes `message` and the label is baked into the message text. Provably bounded: `parseOpenerFrame` builds `${file}.${fn}` from a matched stack frame and deliberately omits line numbers. Allowlisted.

Its sibling **`dbContextLabel` is deliberately NOT allowlisted**: it is caller-supplied `withDbAccessContext({ label })` typed as bare `string` and threaded through helpers like `runWithAgentOrgDbAccess(label, …)`, so proving every path passes a literal is a real sweep, not a glance. Unproven means not allowlisted.

**8. Docs** — `deploy/environment.mdx` and `security/error-tracking.mdx` now carry the region-qualified convention with the reason (`server_name` is a per-deploy container hash, so nothing else can attribute an error to a region).

**9. `classifyManifestRefusal` now has tests** pinning each class→reason mapping, the `unclassified` fallback for non-Errors, the tag-bounds property, and specifically the `ReleaseManifestAssetAbsentError extends ReleaseManifestAssetLookupError` ordering hazard — a subclass reshuffle would otherwise collapse every refusal to `unclassified` with nothing failing.

### Follow-up filed, deliberately not fixed here

The tag audit that found `dbContextOpener` also found **17 more tag keys passed but silently dropped**, all pre-existing and outside this PR's remit. Most are correctly dropped (`agentId`, `commandId`, `executionId`, `runId`, `orgId`, `tenantVariableId`, `snapshot_id`, `config_id`, `chunkIndex` are identifiers — high-cardinality by nature). But several look like genuine bounded discriminators going nowhere: `service` (10 files, all `captureException`), `worm_downgrade`, `recorded_enforcement`, `requested_enforcement`, `backup_predicate_miss_diagnostic`, `kind`, `operation`, `stage`.

The durable fix is a contract test that fails when a tag key is passed but not allowlisted. It needs a triaged decision per key first, so it belongs in its own PR rather than doubling this one.

### Verification

```
$ NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit --project apps/api/tsconfig.json
exit 0, no output

$ npx vitest run --shard=1/3   Test Files 479 passed | 3 skipped (482)   Tests 7875 passed | 13 skipped
$ npx vitest run --shard=2/3   Test Files 482 passed (482)               Tests 8798 passed
$ npx vitest run --shard=3/3   Test Files 481 passed (481)               Tests 7948 passed | 9 skipped
```

**24,621 passed, 22 skipped, 0 failed.** Sharded only to fit the runner's per-command timeout on a contended machine; the three shards are the whole suite.

The 2 reported "errors" in shard 1 are pre-existing unhandled `ReadableStream is already closed` rejections from `streamingUpload.test.ts`, unchanged from the baseline run on the pre-PR base and untouched by this PR.

Live-DB check of the suite this PR previously reddened:

```
$ npx vitest run --config vitest.integration.config.ts \
    src/__tests__/integration/dbContextTripwire.integration.test.ts \
    src/__tests__/integration/contextlessWriteStrict.integration.test.ts
Test Files  2 passed (2)
     Tests  18 passed (18)
```
