### PR TITLE
feat(web,docs): per-partner LLM BYOK wave 4 — AI Provider settings tab, usage indicator, BYO-LLM docs

### DIFF
--- a/apps/api/src/routes/aiProvider.test.ts
+++ b/apps/api/src/routes/aiProvider.test.ts
@@ -47,6 +47,10 @@ vi.mock('../services/sentry', () => ({
   captureException: captureExceptionMock,
 }));
 
+vi.mock('../services/aiCostTracker', () => ({
+  SUPPORTED_AI_MODELS: Object.freeze(['claude-sonnet-4-6', 'claude-haiku-4-5']),
+}));
+
 vi.mock('../services/partnerLlmConfig', () => {
   class PartnerLlmError extends Error {
     constructor(message: string, readonly status: 400 | 409 | 500 | 503) {
@@ -241,7 +245,16 @@ describe('AI provider routes', () => {
       status: 'active',
       verifiedAt: '2026-08-23T12:00:00.000Z',
       lastError: null,
+      supportedModels: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
     });
+  });
+
+  it('GET / returns supportedModels from the cost-tracker registry for the model select', async () => {
+    const response = await aiProviderRoutes.request('/', { method: 'GET' });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.supportedModels).toEqual(['claude-sonnet-4-6', 'claude-haiku-4-5']);
   });
 
   it('POST /key maps PartnerLlmError to its typed HTTP status', async () => {

--- a/apps/api/src/routes/aiProvider.test.ts
+++ b/apps/api/src/routes/aiProvider.test.ts
@@ -48,7 +48,7 @@ vi.mock('../services/sentry', () => ({
 }));
 
 vi.mock('../services/aiCostTracker', () => ({
-  SUPPORTED_AI_MODELS: Object.freeze(['claude-sonnet-4-6', 'claude-haiku-4-5']),
+  OFFERABLE_AI_MODELS: Object.freeze(['claude-sonnet-4-6', 'claude-haiku-4-5']),
 }));
 
 vi.mock('../services/partnerLlmConfig', () => {

--- a/apps/api/src/routes/aiProvider.ts
+++ b/apps/api/src/routes/aiProvider.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { zValidator } from '../lib/validation';
 import { authMiddleware, requireMfa, requirePermission } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
-import { SUPPORTED_AI_MODELS } from '../services/aiCostTracker';
+import { OFFERABLE_AI_MODELS } from '../services/aiCostTracker';
 import {
   deletePartnerLlmConfig,
   getPartnerLlmStatus,
@@ -54,7 +54,7 @@ aiProviderRoutes.get(
       // Options for the web UI's default-model select. Sourced from the cost
       // tracker's pricing registry so the UI can never offer a model we can't
       // meter.
-      supportedModels: [...SUPPORTED_AI_MODELS],
+      supportedModels: [...OFFERABLE_AI_MODELS],
     });
   },
 );

--- a/apps/api/src/routes/aiProvider.ts
+++ b/apps/api/src/routes/aiProvider.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { zValidator } from '../lib/validation';
 import { authMiddleware, requireMfa, requirePermission } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
+import { SUPPORTED_AI_MODELS } from '../services/aiCostTracker';
 import {
   deletePartnerLlmConfig,
   getPartnerLlmStatus,
@@ -50,6 +51,10 @@ aiProviderRoutes.get(
       status: status.status,
       verifiedAt: status.verifiedAt?.toISOString() ?? null,
       lastError: status.lastError,
+      // Options for the web UI's default-model select. Sourced from the cost
+      // tracker's pricing registry so the UI can never offer a model we can't
+      // meter.
+      supportedModels: [...SUPPORTED_AI_MODELS],
     });
   },
 );

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -33,7 +33,16 @@ const MODEL_PRICING: Record<string, { inputPerMillion: number; outputPerMillion:
   'claude-sonnet-4-5-20250929': { inputPerMillion: 300, outputPerMillion: 1500 }
 };
 
-export const SUPPORTED_AI_MODELS: readonly string[] = Object.freeze(Object.keys(MODEL_PRICING));
+// Models a partner may pin as their BYOK default. MODEL_PRICING keeps legacy
+// snapshot ids for cost attribution on old sessions; those must not be offered
+// (or accepted) as new defaults — a retired snapshot pinned partner-wide fails
+// every AI session against the partner's own key.
+export const OFFERABLE_AI_MODELS: readonly string[] = Object.freeze([
+  'claude-opus-4-8',
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5',
+  'claude-fable-5',
+]);
 
 // Conservative last-resort pricing for an unrecognized model id. Mirrors the most
 // expensive current Opus-tier rate so we never silently undercount. Hitting this is logged.

--- a/apps/api/src/services/partnerLlmConfig.ts
+++ b/apps/api/src/services/partnerLlmConfig.ts
@@ -4,7 +4,7 @@ import { and, eq, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { partnerLlmConfigs } from '../db/schema';
 import { resolveDefaultModel } from './aiModel';
-import { SUPPORTED_AI_MODELS } from './aiCostTracker';
+import { OFFERABLE_AI_MODELS } from './aiCostTracker';
 import {
   columnAad,
   encryptedColumnRegistry,
@@ -215,7 +215,7 @@ export async function updatePartnerLlmConfig(input: {
   partnerId: string;
   defaultModel: string | null;
 }): Promise<{ defaultModel: string | null; configVersion: number }> {
-  if (input.defaultModel !== null && !SUPPORTED_AI_MODELS.includes(input.defaultModel)) {
+  if (input.defaultModel !== null && !OFFERABLE_AI_MODELS.includes(input.defaultModel)) {
     throw new PartnerLlmError('Unsupported Anthropic model.', 400);
   }
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -134,6 +134,7 @@ export default defineConfig({
               label: 'AI & Intelligence',
               items: [
                 { slug: 'features/ai' },
+                { slug: 'features/bring-your-own-llm-key' },
                 { slug: 'features/ml-insights' },
                 { slug: 'features/fleet-hygiene' },
                 { slug: 'features/ai-computer-control' },

--- a/apps/docs/src/content/docs/features/bring-your-own-llm-key.mdx
+++ b/apps/docs/src/content/docs/features/bring-your-own-llm-key.mdx
@@ -46,7 +46,7 @@ To return to the Breeze platform key and Breeze AI credits, click **Disconnect**
 
 Organization AI budgets and rate limits still apply. With BYOK enabled, those controls limit usage billed to your own Anthropic account rather than consumption of Breeze AI credits.
 
-AI usage history is labeled **Billed to your key** while the partner key is active.
+While the partner key is active, the AI usage page shows the note **"Billed to your key — AI usage goes to your own Anthropic account, not Breeze AI credits."**
 
 <Aside type="caution">
   If the key is invalid, revoked, or rejected by Anthropic, AI is unavailable and Breeze shows an error banner. Breeze never silently falls back to the platform key, because doing so could consume Breeze AI credits without your intent. Replace the key or disconnect it explicitly to restore service.

--- a/apps/docs/src/content/docs/features/bring-your-own-llm-key.mdx
+++ b/apps/docs/src/content/docs/features/bring-your-own-llm-key.mdx
@@ -1,0 +1,88 @@
+---
+title: Bring Your Own LLM Key
+description: Use a partner-owned Anthropic API key for Breeze AI, or configure an instance-wide LLM backend on a self-hosted deployment.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+Breeze supports two ways to use your own LLM provider configuration:
+
+- **Hosted BYOK** lets a partner use its own Anthropic API key for Breeze AI.
+- **Self-hosted instance configuration** routes platform-keyed AI usage to an Anthropic-compatible or OpenAI-compatible endpoint.
+
+If both are configured, a partner's BYOK configuration takes precedence. Instance environment variables apply only to AI usage that would otherwise use the platform key.
+
+## Hosted: use your own Anthropic key
+
+When you connect your own Anthropic API key, all AI features for your partner use that key and are billed directly to your Anthropic account. Breeze AI credits are not consumed.
+
+Workspace content enrichment is currently an exception: it continues to use the Breeze platform key.
+
+### Requirements
+
+You must be a partner admin with access to all organizations and the billing management permission. You must also complete MFA when you connect, replace, or disconnect a key.
+
+### Connect a key
+
+<Steps>
+
+1. Open **Partner Settings → AI Provider**.
+
+2. Paste your Anthropic API key into the write-only key field.
+
+3. Optionally select a default model from the supported model list.
+
+4. Click **Save**. Breeze verifies the key with Anthropic before storing it.
+
+</Steps>
+
+The page shows that your key is active and displays only its last four characters. Breeze never returns the full key after you save it.
+
+To rotate the key, paste the replacement and save it. Breeze verifies the replacement before changing the stored key, so a failed verification leaves the existing working key in place.
+
+To return to the Breeze platform key and Breeze AI credits, click **Disconnect** and complete MFA. Breeze does not switch back automatically.
+
+### Usage, budgets, and failures
+
+Organization AI budgets and rate limits still apply. With BYOK enabled, those controls limit usage billed to your own Anthropic account rather than consumption of Breeze AI credits.
+
+AI usage history is labeled **Billed to your key** while the partner key is active.
+
+<Aside type="caution">
+  If the key is invalid, revoked, or rejected by Anthropic, AI is unavailable and Breeze shows an error banner. Breeze never silently falls back to the platform key, because doing so could consume Breeze AI credits without your intent. Replace the key or disconnect it explicitly to restore service.
+</Aside>
+
+## Self-hosted: configure an instance-wide provider
+
+Self-hosted operators can configure an LLM backend for platform-keyed usage with environment variables. These settings apply across the instance, except for partners that have their own BYOK configuration.
+
+### Anthropic-compatible endpoint with tool calling
+
+Use this path to route the full, tool-capable Breeze Agent through an endpoint that implements the Anthropic `/v1/messages` API, such as vLLM 0.23+ or LiteLLM.
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `ANTHROPIC_BASE_URL` | Yes | Base URL for the Anthropic-compatible endpoint. It must be a valid HTTP or HTTPS URL. |
+| `ANTHROPIC_AUTH_TOKEN` | As required by the endpoint | Authentication token sent by the Anthropic SDK. |
+| `ANTHROPIC_MODEL` | Optional | Overrides the default model ID, including for a raw vLLM model name or a LiteLLM alias. |
+
+`ANTHROPIC_BASE_URL` is self-hosted only. Breeze refuses to start with this variable set unless `IS_HOSTED` is explicitly set to `false` (or another recognized false value). Hosted deployments cannot use a custom per-partner or instance-wide base URL.
+
+### OpenAI-compatible chat without tool calling
+
+Use this path for a chat-only backend that implements the OpenAI API dialect. Tool calling is not supported on this path.
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `MCP_LLM_PROVIDER` | Yes | Set to `openai-compatible`. |
+| `MCP_LLM_BASE_URL` | Yes | Base URL for the OpenAI-compatible endpoint. It must be a valid URL. |
+| `MCP_LLM_MODEL` | Yes | Model ID exposed by the endpoint. |
+| `MCP_LLM_API_KEY` | Yes | API key used to authenticate with the endpoint. |
+| `MCP_LLM_PRICE_INPUT_PER_M_USD` | Optional | Input-token price in USD per million tokens. Defaults to `0`. |
+| `MCP_LLM_PRICE_OUTPUT_PER_M_USD` | Optional | Output-token price in USD per million tokens. Defaults to `0`. |
+
+The API validates the base URL and requires the model and API key when `MCP_LLM_PROVIDER=openai-compatible`. Both price values must be zero or greater.
+
+<Aside type="note">
+  Provider precedence is **partner BYOK configuration → instance environment**. A partner-owned Anthropic key always overrides these instance settings. The instance environment applies only when Breeze resolves the request as platform-keyed usage.
+</Aside>

--- a/apps/web/src/components/settings/AiUsagePage.test.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.test.tsx
@@ -43,7 +43,7 @@ describe('AiUsagePage billedTo indicator', () => {
 
     await waitFor(() => expect(screen.getByTestId('ai-usage-billed-to-note')).toBeInTheDocument());
     expect(screen.getByTestId('ai-usage-billed-to-note').textContent)
-      .toContain("AI usage is billed to your organization's own Anthropic key");
+      .toContain('Billed to your key — AI usage goes to your own Anthropic account, not Breeze AI credits');
   });
 
   it('does not render the note when usage is billed to the platform', async () => {

--- a/apps/web/src/components/settings/AiUsagePage.test.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+vi.mock('../../stores/orgStore', () => ({ useOrgStore: () => ({ currentOrgId: null }) }));
+
+import AiUsagePage from './AiUsagePage';
+
+function jsonRes(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function usageBody(billedTo?: 'platform' | 'partner_key') {
+  return {
+    daily: { inputTokens: 10, outputTokens: 20, totalCostCents: 5, messageCount: 1 },
+    monthly: { inputTokens: 100, outputTokens: 200, totalCostCents: 50, messageCount: 10 },
+    budget: null,
+    ...(billedTo ? { billedTo } : {}),
+  };
+}
+
+function mockUsage(billedTo?: 'platform' | 'partner_key') {
+  fetchWithAuth.mockImplementation((url: string) => {
+    if (url === '/ai/usage') return Promise.resolve(jsonRes(usageBody(billedTo)));
+    if (url.startsWith('/ai/admin/sessions')) return Promise.resolve(jsonRes({ data: [] }));
+    return Promise.resolve(jsonRes({ data: [] }));
+  });
+}
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+});
+
+describe('AiUsagePage billedTo indicator', () => {
+  it('renders the partner-key billing note when usage is billed to the partner key', async () => {
+    mockUsage('partner_key');
+    render(<AiUsagePage />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-usage-billed-to-note')).toBeInTheDocument());
+    expect(screen.getByTestId('ai-usage-billed-to-note').textContent)
+      .toContain("AI usage is billed to your organization's own Anthropic key");
+  });
+
+  it('does not render the note when usage is billed to the platform', async () => {
+    mockUsage('platform');
+    render(<AiUsagePage />);
+
+    await waitFor(() => expect(screen.getByText('Budget Configuration')).toBeInTheDocument());
+    expect(screen.queryByTestId('ai-usage-billed-to-note')).toBeNull();
+  });
+
+  it('does not render the note when the response omits billedTo (older API)', async () => {
+    mockUsage(undefined);
+    render(<AiUsagePage />);
+
+    await waitFor(() => expect(screen.getByText('Budget Configuration')).toBeInTheDocument());
+    expect(screen.queryByTestId('ai-usage-billed-to-note')).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/AiUsagePage.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.tsx
@@ -10,6 +10,8 @@ import { formatCurrency, formatNumber } from '@/lib/i18n/format';
 interface UsageData {
   daily: { inputTokens: number; outputTokens: number; totalCostCents: number; messageCount: number };
   monthly: { inputTokens: number; outputTokens: number; totalCostCents: number; messageCount: number };
+  /** Who pays for LLM calls: the platform key or the partner's own Anthropic key (BYOK). */
+  billedTo?: 'platform' | 'partner_key';
   budget: {
     enabled: boolean;
     monthlyBudgetCents: number | null;
@@ -177,6 +179,11 @@ export default function AiUsagePage() {
       <div>
         <h1 className="text-xl font-semibold tracking-tight">{t('aiUsagePage.aIUsageBudget')}</h1>
         <p className="text-muted-foreground">{t('aiUsagePage.monitorAIAssistantUsageAndConfigureBudgetLimits')}</p>
+        {usage?.billedTo === 'partner_key' && (
+          <p className="mt-1 text-sm text-muted-foreground" data-testid="ai-usage-billed-to-note">
+            {t('aiUsagePage.billedToPartnerKey')}
+          </p>
+        )}
       </div>
 
       {error && (

--- a/apps/web/src/components/settings/PartnerAiProviderTab.test.tsx
+++ b/apps/web/src/components/settings/PartnerAiProviderTab.test.tsx
@@ -91,18 +91,33 @@ describe('PartnerAiProviderTab', () => {
       .toBe('claude-sonnet-4-6');
   });
 
-  it('saves the key via POST and never renders it afterwards', async () => {
+  it('saves the key via POST, refetches the stored state, and never renders the key afterwards', async () => {
     const secret = 'sk-ant-api03-super-secret-key-1234567890';
-    mockApi(platformStatus, {
-      'POST /ai/provider/key': () => jsonRes({
-        configured: true,
-        provider: 'anthropic',
-        keyLast4: '7890',
-        defaultModel: null,
-        status: 'active',
-        verifiedAt: '2026-08-23T12:00:00.000Z',
-        lastError: null,
-      }),
+    // Model the real API: POST echoes the EFFECTIVE model (stored ?? platform
+    // default) while the stored default_model stays NULL on a fresh connect.
+    // The component must refetch rather than merge the POST echo, so the
+    // select shows "Platform default", not a pin that was never saved.
+    let connected = false;
+    fetchWithAuth.mockImplementation((url: string, options?: RequestInit) => {
+      const method = options?.method ?? 'GET';
+      if (method === 'POST' && url === '/ai/provider/key') {
+        connected = true;
+        return Promise.resolve(jsonRes({
+          configured: true,
+          provider: 'anthropic',
+          keyLast4: '7890',
+          defaultModel: 'claude-sonnet-4-6',
+          status: 'active',
+          verifiedAt: '2026-08-23T12:00:00.000Z',
+          lastError: null,
+        }));
+      }
+      if (method === 'GET' && url === '/ai/provider') {
+        return Promise.resolve(jsonRes(connected
+          ? { ...connectedStatus, keyLast4: '7890', defaultModel: null }
+          : platformStatus));
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
     });
     const { container } = render(<PartnerAiProviderTab />);
 
@@ -123,6 +138,9 @@ describe('PartnerAiProviderTab', () => {
     expect(showToast).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'success', message: 'Anthropic key saved and verified.' }),
     );
+    // Stored default_model is NULL — the POST echo's effective model must not
+    // appear as a selected pin.
+    expect((screen.getByTestId('ai-provider-model-select') as HTMLSelectElement).value).toBe('');
   });
 
   it('surfaces the API error message when the key is rejected', async () => {

--- a/apps/web/src/components/settings/PartnerAiProviderTab.test.tsx
+++ b/apps/web/src/components/settings/PartnerAiProviderTab.test.tsx
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (...a: unknown[]) => showToast(...a) }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+// Deliberately NOT mocking runAction: these tests exercise the real
+// no-silent-mutations wrapper so failure toasts carry the API's `error` text.
+import PartnerAiProviderTab from './PartnerAiProviderTab';
+
+function jsonRes(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const SUPPORTED_MODELS = ['claude-sonnet-4-6', 'claude-haiku-4-5', 'claude-opus-4-8'];
+
+const platformStatus = {
+  configured: false,
+  provider: null,
+  keyLast4: null,
+  defaultModel: null,
+  status: 'platform',
+  verifiedAt: null,
+  lastError: null,
+  supportedModels: SUPPORTED_MODELS,
+};
+
+const connectedStatus = {
+  configured: true,
+  provider: 'anthropic',
+  keyLast4: '7890',
+  defaultModel: 'claude-sonnet-4-6',
+  status: 'active',
+  verifiedAt: '2026-08-23T12:00:00.000Z',
+  lastError: null,
+  supportedModels: SUPPORTED_MODELS,
+};
+
+/** Route the mock fetch by method+url; GET / falls through to `initial`. */
+function mockApi(initial: unknown, handlers: Record<string, () => Response> = {}) {
+  fetchWithAuth.mockImplementation((url: string, options?: RequestInit) => {
+    const method = options?.method ?? 'GET';
+    const handler = handlers[`${method} ${url}`];
+    if (handler) return Promise.resolve(handler());
+    if (method === 'GET' && url === '/ai/provider') return Promise.resolve(jsonRes(initial));
+    throw new Error(`Unexpected request: ${method} ${url}`);
+  });
+}
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+  showToast.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('PartnerAiProviderTab', () => {
+  it('renders the platform-key state when no partner key is configured', async () => {
+    mockApi(platformStatus);
+    render(<PartnerAiProviderTab />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-provider-status-card')).toBeInTheDocument());
+    expect(screen.getByText('Platform key')).toBeInTheDocument();
+    // No model select / disconnect until a key is connected.
+    expect(screen.queryByTestId('ai-provider-model-select')).toBeNull();
+    expect(screen.queryByTestId('ai-provider-disconnect')).toBeNull();
+    // Spec §3 non-goal disclosure is always visible.
+    expect(screen.getByTestId('ai-provider-workspace-note').textContent)
+      .toContain('Workspace content enrichment currently uses the platform key');
+  });
+
+  it('renders the connected state from GET (last4, verified date, model)', async () => {
+    mockApi(connectedStatus);
+    render(<PartnerAiProviderTab />);
+
+    await waitFor(() => expect(screen.getByText('Your key •••• 7890')).toBeInTheDocument());
+    expect(screen.getByText(/^Verified /).textContent).toMatch(/Verified .*2026/);
+    expect(screen.getByTestId('ai-provider-disconnect')).toBeInTheDocument();
+    // The select's rendered value is bound to the FETCHED defaultModel — an
+    // orphan select reading '' would silently show "Platform default" here.
+    expect((screen.getByTestId('ai-provider-model-select') as HTMLSelectElement).value)
+      .toBe('claude-sonnet-4-6');
+  });
+
+  it('saves the key via POST and never renders it afterwards', async () => {
+    const secret = 'sk-ant-api03-super-secret-key-1234567890';
+    mockApi(platformStatus, {
+      'POST /ai/provider/key': () => jsonRes({
+        configured: true,
+        provider: 'anthropic',
+        keyLast4: '7890',
+        defaultModel: null,
+        status: 'active',
+        verifiedAt: '2026-08-23T12:00:00.000Z',
+        lastError: null,
+      }),
+    });
+    const { container } = render(<PartnerAiProviderTab />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-provider-key-input')).toBeInTheDocument());
+    const input = screen.getByTestId('ai-provider-key-input') as HTMLInputElement;
+    expect(input.type).toBe('password'); // write-only field
+    fireEvent.change(input, { target: { value: secret } });
+    fireEvent.click(screen.getByTestId('ai-provider-save-key'));
+
+    await waitFor(() => expect(screen.getByText('Your key •••• 7890')).toBeInTheDocument());
+    expect(fetchWithAuth).toHaveBeenCalledWith('/ai/provider/key', {
+      method: 'POST',
+      body: JSON.stringify({ apiKey: secret }),
+    });
+    // The key must be gone from the input and absent from the DOM entirely.
+    expect(input.value).toBe('');
+    expect(container.innerHTML).not.toContain(secret);
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success', message: 'Anthropic key saved and verified.' }),
+    );
+  });
+
+  it('surfaces the API error message when the key is rejected', async () => {
+    mockApi(platformStatus, {
+      'POST /ai/provider/key': () => jsonRes({ error: 'Anthropic denied access for that API key.' }, 409),
+    });
+    render(<PartnerAiProviderTab />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-provider-key-input')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('ai-provider-key-input'), {
+      target: { value: 'sk-ant-api03-rejected-key-1234567890' },
+    });
+    fireEvent.click(screen.getByTestId('ai-provider-save-key'));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', message: 'Anthropic denied access for that API key.' }),
+    ));
+    // Still the platform state — the rejected key connected nothing.
+    expect(screen.getByText('Platform key')).toBeInTheDocument();
+  });
+
+  it('PATCHes the default model on change and keeps the select bound', async () => {
+    mockApi(connectedStatus, {
+      'PATCH /ai/provider': () => jsonRes({ defaultModel: 'claude-haiku-4-5', configVersion: 4 }),
+    });
+    render(<PartnerAiProviderTab />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-provider-model-select')).toBeInTheDocument());
+    const select = screen.getByTestId('ai-provider-model-select') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'claude-haiku-4-5' } });
+
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith('/ai/provider', {
+      method: 'PATCH',
+      body: JSON.stringify({ defaultModel: 'claude-haiku-4-5' }),
+    }));
+    expect(select.value).toBe('claude-haiku-4-5');
+  });
+
+  it('sends defaultModel null when "Platform default" is selected', async () => {
+    mockApi(connectedStatus, {
+      'PATCH /ai/provider': () => jsonRes({ defaultModel: null, configVersion: 4 }),
+    });
+    render(<PartnerAiProviderTab />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-provider-model-select')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('ai-provider-model-select'), { target: { value: '' } });
+
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith('/ai/provider', {
+      method: 'PATCH',
+      body: JSON.stringify({ defaultModel: null }),
+    }));
+  });
+
+  it('reverts the model selection when the PATCH fails', async () => {
+    mockApi(connectedStatus, {
+      'PATCH /ai/provider': () => jsonRes({ error: 'Unsupported model.' }, 400),
+    });
+    render(<PartnerAiProviderTab />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-provider-model-select')).toBeInTheDocument());
+    const select = screen.getByTestId('ai-provider-model-select') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'claude-haiku-4-5' } });
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', message: 'Unsupported model.' }),
+    ));
+    await waitFor(() => expect(select.value).toBe('claude-sonnet-4-6'));
+  });
+
+  it('disconnects after confirmation and returns to the platform state', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockApi(connectedStatus, {
+      'DELETE /ai/provider': () => jsonRes({ configured: false, status: 'platform' }),
+    });
+    render(<PartnerAiProviderTab />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-provider-disconnect')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('ai-provider-disconnect'));
+
+    await waitFor(() => expect(screen.getByText('Platform key')).toBeInTheDocument());
+    expect(window.confirm).toHaveBeenCalled();
+    expect(fetchWithAuth).toHaveBeenCalledWith('/ai/provider', { method: 'DELETE' });
+    expect(screen.queryByTestId('ai-provider-model-select')).toBeNull();
+  });
+
+  it('does not DELETE when the disconnect confirmation is declined', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    mockApi(connectedStatus);
+    render(<PartnerAiProviderTab />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-provider-disconnect')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('ai-provider-disconnect'));
+
+    expect(fetchWithAuth).not.toHaveBeenCalledWith('/ai/provider', { method: 'DELETE' });
+    expect(screen.getByText('Your key •••• 7890')).toBeInTheDocument();
+  });
+
+  it('renders the lastError banner with a reconnect hint in the error state', async () => {
+    mockApi({
+      ...connectedStatus,
+      status: 'error',
+      lastError: 'Anthropic rejected the saved key (401 authentication_error).',
+    });
+    render(<PartnerAiProviderTab />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-provider-error-banner')).toBeInTheDocument());
+    const banner = screen.getByTestId('ai-provider-error-banner');
+    expect(banner.textContent).toContain('Anthropic rejected the saved key (401 authentication_error).');
+    expect(banner.textContent).toContain('until you save a working key below');
+  });
+
+  it('shows the permission message on a 403 instead of the platform card', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes({ error: 'Permission denied' }, 403));
+    render(<PartnerAiProviderTab />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-provider-forbidden')).toBeInTheDocument());
+    expect(screen.queryByTestId('ai-provider-status-card')).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/PartnerAiProviderTab.tsx
+++ b/apps/web/src/components/settings/PartnerAiProviderTab.tsx
@@ -1,0 +1,309 @@
+import '@/lib/i18n';
+import { useTranslation } from 'react-i18next';
+import { useCallback, useEffect, useState } from 'react';
+import { AlertTriangle, KeyRound, Loader2, Save, Unplug } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction, ActionError } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
+import { navigateTo } from '@/lib/navigation';
+import { formatDateTime } from '@/lib/dateTimeFormat';
+
+/** Shape of GET /ai/provider. The API never returns the key itself. */
+type ProviderStatus = {
+  configured: boolean;
+  provider: string | null;
+  keyLast4: string | null;
+  defaultModel: string | null;
+  status: 'platform' | 'active' | 'error';
+  verifiedAt: string | null;
+  lastError: string | null;
+  supportedModels: string[];
+};
+
+/** Mutation responses (POST /key, DELETE) omit supportedModels — preserve it. */
+type ProviderMutationResult = Omit<Partial<ProviderStatus>, 'supportedModels'>;
+
+export default function PartnerAiProviderTab() {
+  const { t } = useTranslation('settings');
+  const [status, setStatus] = useState<ProviderStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  // Track fetch failures separately: a 403 means "not allowed to manage this",
+  // anything else is an outage — neither should read as the platform-key state.
+  const [loadError, setLoadError] = useState<'forbidden' | 'failed' | null>(null);
+  const [apiKey, setApiKey] = useState('');
+  const [savingKey, setSavingKey] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const response = await fetchWithAuth('/ai/provider');
+      if (!response.ok) {
+        if (response.status === 401) { void navigateTo('/login', { replace: true }); return; }
+        setLoadError(response.status === 403 ? 'forbidden' : 'failed');
+        return;
+      }
+      const data: ProviderStatus = await response.json();
+      setStatus({ ...data, supportedModels: Array.isArray(data.supportedModels) ? data.supportedModels : [] });
+    } catch {
+      setLoadError('failed');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void fetchStatus(); }, [fetchStatus]);
+
+  const onUnauthorized = () => { void navigateTo('/login', { replace: true }); };
+
+  const applyMutationResult = (result: ProviderMutationResult) => {
+    setStatus(prev => prev
+      ? { ...prev, ...result, supportedModels: prev.supportedModels }
+      : prev);
+  };
+
+  const handleSaveKey = async () => {
+    const trimmed = apiKey.trim();
+    if (!trimmed || savingKey) return;
+    setSavingKey(true);
+    try {
+      const result = await runAction<ProviderMutationResult>({
+        request: () => fetchWithAuth('/ai/provider/key', {
+          method: 'POST',
+          body: JSON.stringify({ apiKey: trimmed }),
+        }),
+        successMessage: t('partnerAiProvider.keySaved'),
+        errorFallback: t('partnerAiProvider.keySaveFailed'),
+        onUnauthorized,
+      });
+      // Write-only field: never keep the key around after a successful save.
+      setApiKey('');
+      applyMutationResult(result);
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) showToast({ type: 'error', message: t('partnerAiProvider.keySaveFailed') });
+      // non-401 ActionError already toasted by runAction (it surfaces the API's `error` message)
+    } finally {
+      setSavingKey(false);
+    }
+  };
+
+  const handleModelChange = async (raw: string) => {
+    if (!status) return;
+    const next = raw === '' ? null : raw;
+    const previous = status.defaultModel;
+    // Keep the select bound to state so the rendered value always reflects the
+    // fetched (or just-chosen) model — never an orphan '' read.
+    setStatus(prev => (prev ? { ...prev, defaultModel: next } : prev));
+    try {
+      await runAction({
+        request: () => fetchWithAuth('/ai/provider', {
+          method: 'PATCH',
+          body: JSON.stringify({ defaultModel: next }),
+        }),
+        successMessage: t('partnerAiProvider.modelUpdated'),
+        errorFallback: t('partnerAiProvider.modelUpdateFailed'),
+        onUnauthorized,
+      });
+    } catch (err) {
+      // Revert the optimistic selection — the server kept the old model.
+      setStatus(prev => (prev ? { ...prev, defaultModel: previous } : prev));
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) showToast({ type: 'error', message: t('partnerAiProvider.modelUpdateFailed') });
+    }
+  };
+
+  const handleDisconnect = async () => {
+    if (disconnecting) return;
+    if (!window.confirm(t('partnerAiProvider.disconnectConfirm'))) return;
+    setDisconnecting(true);
+    try {
+      await runAction({
+        request: () => fetchWithAuth('/ai/provider', { method: 'DELETE' }),
+        successMessage: t('partnerAiProvider.disconnected'),
+        errorFallback: t('partnerAiProvider.disconnectFailed'),
+        onUnauthorized,
+      });
+      applyMutationResult({
+        configured: false,
+        keyLast4: null,
+        defaultModel: null,
+        status: 'platform',
+        verifiedAt: null,
+        lastError: null,
+      });
+    } catch (err) {
+      if (err instanceof ActionError && err.status === 401) return;
+      if (!(err instanceof ActionError)) showToast({ type: 'error', message: t('partnerAiProvider.disconnectFailed') });
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12" data-testid="ai-provider-loading">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (loadError === 'forbidden') {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="ai-provider-forbidden">
+        {t('partnerAiProvider.permissionDenied')}
+      </p>
+    );
+  }
+
+  if (loadError === 'failed' || !status) {
+    return (
+      <div className="space-y-3" data-testid="ai-provider-load-error">
+        <p className="text-sm text-destructive">{t('partnerAiProvider.loadFailed')}</p>
+        <button
+          type="button"
+          onClick={() => { void fetchStatus(); }}
+          className="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted"
+        >
+          {t('common:actions.retry')}
+        </button>
+      </div>
+    );
+  }
+
+  const connected = status.configured;
+
+  return (
+    <div className="space-y-6" data-testid="partner-ai-provider-tab">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold">{t('partnerAiProvider.title')}</h2>
+        <p className="text-sm text-muted-foreground">{t('partnerAiProvider.subtitle')}</p>
+      </div>
+
+      {/* Status card */}
+      <div className="rounded-md border bg-muted/30 p-4" data-testid="ai-provider-status-card">
+        <div className="flex items-start gap-3">
+          <KeyRound className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          {connected ? (
+            <div className="space-y-1">
+              <p className="text-sm font-medium">
+                {t('partnerAiProvider.yourKey', { last4: status.keyLast4 ?? '' })}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {status.verifiedAt
+                  ? t('partnerAiProvider.verifiedAt', { date: formatDateTime(status.verifiedAt) })
+                  : t('partnerAiProvider.notVerifiedYet')}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {t('partnerAiProvider.defaultModelValue', {
+                  model: status.defaultModel ?? t('partnerAiProvider.platformDefault'),
+                })}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              <p className="text-sm font-medium">{t('partnerAiProvider.platformKey')}</p>
+              <p className="text-xs text-muted-foreground">{t('partnerAiProvider.platformKeyDescription')}</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Error state: the saved key stopped working — fail-loud, never a silent fallback. */}
+      {connected && status.status === 'error' && (
+        <div
+          role="alert"
+          className="space-y-1 rounded-md border border-destructive/40 bg-destructive/10 p-4 text-destructive"
+          data-testid="ai-provider-error-banner"
+        >
+          <p className="flex items-center gap-2 text-sm font-medium">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            {t('partnerAiProvider.keyErrorTitle')}
+          </p>
+          {status.lastError && <p className="text-sm">{status.lastError}</p>}
+          <p className="text-sm">{t('partnerAiProvider.reconnectHint')}</p>
+        </div>
+      )}
+
+      {/* Connect / replace form */}
+      <div className="space-y-3 rounded-md border p-4">
+        <h3 className="text-sm font-semibold">
+          {connected ? t('partnerAiProvider.replaceKeyTitle') : t('partnerAiProvider.connectKeyTitle')}
+        </h3>
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="ai-provider-key-input">
+            {t('partnerAiProvider.keyLabel')}
+          </label>
+          <input
+            id="ai-provider-key-input"
+            data-testid="ai-provider-key-input"
+            type="password"
+            autoComplete="new-password"
+            value={apiKey}
+            onChange={e => setApiKey(e.target.value)}
+            placeholder="sk-ant-…"
+            className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+          />
+          <p className="text-xs text-muted-foreground">{t('partnerAiProvider.writeOnlyHint')}</p>
+        </div>
+        <button
+          type="button"
+          data-testid="ai-provider-save-key"
+          onClick={() => { void handleSaveKey(); }}
+          disabled={savingKey || apiKey.trim() === ''}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+        >
+          {savingKey ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+          {savingKey ? t('common:states.saving') : t('partnerAiProvider.saveKey')}
+        </button>
+      </div>
+
+      {/* Default model + disconnect only apply while a partner key is connected. */}
+      {connected && (
+        <>
+          <div className="space-y-2 rounded-md border p-4">
+            <label className="text-sm font-medium" htmlFor="ai-provider-model-select">
+              {t('partnerAiProvider.defaultModelLabel')}
+            </label>
+            <select
+              id="ai-provider-model-select"
+              data-testid="ai-provider-model-select"
+              value={status.defaultModel ?? ''}
+              onChange={e => { void handleModelChange(e.target.value); }}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+            >
+              <option value="">{t('partnerAiProvider.platformDefault')}</option>
+              {status.supportedModels.map(model => (
+                <option key={model} value={model}>{model}</option>
+              ))}
+            </select>
+            <p className="text-xs text-muted-foreground">{t('partnerAiProvider.defaultModelHint')}</p>
+          </div>
+
+          <div className="flex items-center justify-between rounded-md border border-destructive/40 p-4">
+            <div className="space-y-1">
+              <p className="text-sm font-medium">{t('partnerAiProvider.disconnectTitle')}</p>
+              <p className="text-xs text-muted-foreground">{t('partnerAiProvider.disconnectDescription')}</p>
+            </div>
+            <button
+              type="button"
+              data-testid="ai-provider-disconnect"
+              onClick={() => { void handleDisconnect(); }}
+              disabled={disconnecting}
+              className="inline-flex items-center gap-2 rounded-md border border-destructive/60 px-3 py-2 text-sm font-medium text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-50"
+            >
+              {disconnecting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Unplug className="h-4 w-4" />}
+              {t('partnerAiProvider.disconnect')}
+            </button>
+          </div>
+        </>
+      )}
+
+      {/* Spec §3 non-goal disclosure: workspace enrichment stays on the platform key. */}
+      <p className="text-xs text-muted-foreground" data-testid="ai-provider-workspace-note">
+        {t('partnerAiProvider.workspaceDisclosure')}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/PartnerAiProviderTab.tsx
+++ b/apps/web/src/components/settings/PartnerAiProviderTab.tsx
@@ -68,7 +68,7 @@ export default function PartnerAiProviderTab() {
     if (!trimmed || savingKey) return;
     setSavingKey(true);
     try {
-      const result = await runAction<ProviderMutationResult>({
+      await runAction<ProviderMutationResult>({
         request: () => fetchWithAuth('/ai/provider/key', {
           method: 'POST',
           body: JSON.stringify({ apiKey: trimmed }),
@@ -79,7 +79,10 @@ export default function PartnerAiProviderTab() {
       });
       // Write-only field: never keep the key around after a successful save.
       setApiKey('');
-      applyMutationResult(result);
+      // Refetch rather than merging the POST echo: the route reports the
+      // *effective* model (stored ?? platform default), which is not the
+      // stored value — merging it would show a pin that was never saved.
+      await fetchStatus();
     } catch (err) {
       if (err instanceof ActionError && err.status === 401) return;
       if (!(err instanceof ActionError)) showToast({ type: 'error', message: t('partnerAiProvider.keySaveFailed') });

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -3,6 +3,7 @@ import {
   Bell,
   Building2,
   Globe,
+  KeyRound,
   Loader2,
   LogIn,
   MonitorSmartphone,
@@ -27,6 +28,7 @@ import PartnerDefaultsTab from './PartnerDefaultsTab';
 import type { PinnableVersions } from './AgentVersionPinSelectors';
 import PartnerBrandingTab from './PartnerBrandingTab';
 import PartnerAiBudgetsTab from './PartnerAiBudgetsTab';
+import PartnerAiProviderTab from './PartnerAiProviderTab';
 import PartnerRemoteAccessTab from './PartnerRemoteAccessTab';
 import PartnerCompanyTab from './PartnerCompanyTab';
 import PartnerRegionalTab, { DEFAULT_BUSINESS_HOURS } from './PartnerRegionalTab';
@@ -54,7 +56,7 @@ import { useTranslation } from 'react-i18next';
 import { i18n } from '@/lib/i18n';
 import { normalizeLocale } from '@/lib/appearance';
 
-type TabKey = 'company' | 'regional' | 'security' | 'notifications' | 'eventLogs' | 'defaults' | 'branding' | 'loginBranding' | 'aiBudgets' | 'remoteAccess' | 'ticketing';
+type TabKey = 'company' | 'regional' | 'security' | 'notifications' | 'eventLogs' | 'defaults' | 'branding' | 'loginBranding' | 'aiBudgets' | 'aiProvider' | 'remoteAccess' | 'ticketing';
 
 type Partner = {
   id: string;
@@ -106,6 +108,7 @@ const TAB_GROUPS: { label: string; tabs: TabDef[] }[] = [
       { key: 'notifications', hash: 'notifications', label: 'partnerSettingsPage.tabs.notifications.label', description: 'partnerSettingsPage.tabs.notifications.description', icon: Bell, enforced: true },
       { key: 'ticketing', hash: 'ticketing', label: 'partnerSettingsPage.tabs.ticketing.label', description: 'partnerSettingsPage.tabs.ticketing.description', icon: Ticket, selfSaving: true },
       { key: 'aiBudgets', hash: 'ai-budgets', label: 'partnerSettingsPage.tabs.aiBudgets.label', description: 'partnerSettingsPage.tabs.aiBudgets.description', icon: Wallet, enforced: true },
+      { key: 'aiProvider', hash: 'ai-provider', label: 'partnerSettingsPage.tabs.aiProvider.label', description: 'partnerSettingsPage.tabs.aiProvider.description', icon: KeyRound, selfSaving: true },
     ],
   },
   {
@@ -145,7 +148,7 @@ function getTabFromHash(): TabKey | null {
 // The per-tab keys whose form state participates in dirty tracking. Self-saving
 // tabs (Ticketing, Login Branding) persist independently and are never "dirty"
 // from this page's perspective.
-type SnapshotKey = Exclude<TabKey, 'ticketing' | 'loginBranding'>;
+type SnapshotKey = Exclude<TabKey, 'ticketing' | 'loginBranding' | 'aiProvider'>;
 type Snapshot = Record<SnapshotKey, string>;
 
 // Exported for unit-testing without mounting the full component.
@@ -653,6 +656,14 @@ export default function PartnerSettingsPage() {
           {activeTab === 'aiBudgets' && (
             <section className="rounded-lg border bg-card p-6 shadow-xs">
               <PartnerAiBudgetsTab data={aiBudgetsData} onChange={setAiBudgetsData} />
+            </section>
+          )}
+
+          {/* AI Provider: self-contained BYOK card with its own load/save (the
+              top-level "Save Settings" button does not apply here). */}
+          {activeTab === 'aiProvider' && (
+            <section className="rounded-lg border bg-card p-6 shadow-xs">
+              <PartnerAiProviderTab />
             </section>
           )}
 

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -32,6 +32,7 @@ const TARGET_GLOBS = [
   'src/components/alerts/AlertsPage.tsx',
   'src/components/alerts/AlertDetailPage.tsx',
   'src/components/settings/PartnerSettingsPage.tsx',
+  'src/components/settings/PartnerAiProviderTab.tsx',
   'src/components/settings/OrgSettingsPage.tsx',
   'src/components/settings/LoginBrandingCard.tsx',
   'src/components/settings/ConnectSsoCard.tsx',
@@ -349,7 +350,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(95);
+    expect(absoluteFiles.length).toBe(96);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1309,7 +1309,7 @@
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Tools der Stufe 2 werden automatisch mit Audit-Protokollierung ausgeführt. Werkzeuge der Stufe 3 sind weiterhin genehmigungspflichtig.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Wie ein Aktionsplan, plus Live-Screenshots zwischen den Schritten und eine dauerhafte Stopp-Schaltfläche.",
     "untitled": "Ohne Titel",
-    "billedToPartnerKey": "Die KI-Nutzung wird über den eigenen Anthropic-Schlüssel Ihrer Organisation abgerechnet"
+    "billedToPartnerKey": "Abrechnung über Ihren Schlüssel — die KI-Nutzung läuft über Ihr eigenes Anthropic-Konto, nicht über Breeze-KI-Guthaben"
   },
   "aiAgentsPage": {
     "title": "KI-Agenten",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -128,6 +128,39 @@
       "hybridPlan": "Hybridplan"
     }
   },
+  "partnerAiProvider": {
+    "title": "KI-Anbieter",
+    "subtitle": "Breeze-KI mit Ihrem eigenen Anthropic-API-Schlüssel statt mit dem Plattform-Schlüssel ausführen.",
+    "platformKey": "Plattform-Schlüssel",
+    "platformKeyDescription": "KI-Funktionen nutzen den Anthropic-Schlüssel von Breeze und werden als Breeze-KI-Guthaben abgerechnet.",
+    "yourKey": "Ihr Schlüssel •••• {{last4}}",
+    "verifiedAt": "Verifiziert am {{date}}",
+    "notVerifiedYet": "Noch nicht verifiziert",
+    "defaultModelValue": "Standardmodell: {{model}}",
+    "platformDefault": "Plattform-Standard",
+    "keyErrorTitle": "Ihr Anthropic-Schlüssel funktioniert nicht",
+    "reconnectHint": "KI-Funktionen sind für Ihre Organisationen nicht verfügbar, bis Sie unten einen funktionierenden Schlüssel speichern.",
+    "connectKeyTitle": "Ihren Anthropic-Schlüssel verbinden",
+    "replaceKeyTitle": "Ihren Anthropic-Schlüssel ersetzen",
+    "keyLabel": "Anthropic-API-Schlüssel",
+    "writeOnlyHint": "Der Schlüssel wird beim Speichern verifiziert und danach nie wieder angezeigt.",
+    "saveKey": "Schlüssel speichern",
+    "keySaved": "Anthropic-Schlüssel gespeichert und verifiziert.",
+    "keySaveFailed": "Der Anthropic-Schlüssel konnte nicht gespeichert werden.",
+    "defaultModelLabel": "Standardmodell",
+    "defaultModelHint": "Wird für neue KI-Sitzungen in allen Ihren Organisationen verwendet.",
+    "modelUpdated": "Standardmodell aktualisiert.",
+    "modelUpdateFailed": "Das Standardmodell konnte nicht aktualisiert werden.",
+    "disconnectTitle": "Zurück zum Plattform-Schlüssel wechseln",
+    "disconnectDescription": "Entfernt Ihren Anthropic-Schlüssel. Die KI-Nutzung wird wieder als Breeze-KI-Guthaben abgerechnet.",
+    "disconnect": "Trennen",
+    "disconnectConfirm": "Ihren Anthropic-Schlüssel trennen? KI-Funktionen wechseln zurück zum Plattform-Schlüssel und zu Breeze-KI-Guthaben.",
+    "disconnected": "Anthropic-Schlüssel entfernt. KI-Funktionen nutzen jetzt den Plattform-Schlüssel.",
+    "disconnectFailed": "Der Anthropic-Schlüssel konnte nicht getrennt werden.",
+    "permissionDenied": "Zum Verwalten des KI-Anbieters sind Abrechnungsberechtigungen und Zugriff auf alle Organisationen erforderlich.",
+    "loadFailed": "Die Konfiguration des KI-Anbieters konnte nicht geladen werden.",
+    "workspaceDisclosure": "Die Workspace-Inhaltsanreicherung verwendet derzeit den Plattform-Schlüssel."
+  },
   "partnerDefaults": {
     "notSet": "Nicht festgelegt – Organisationen werden individuell konfiguriert",
     "updatePolicy": "Agent-Update-Richtlinie",
@@ -416,6 +449,10 @@
       "aiBudgets": {
         "label": "KI-Budgets",
         "description": "KI-Ausgabenlimits"
+      },
+      "aiProvider": {
+        "label": "KI-Anbieter",
+        "description": "Eigenen Anthropic-Schlüssel verwenden"
       },
       "branding": {
         "label": "Branding",
@@ -1271,7 +1308,8 @@
     "aIProposesAMultiStepPlanUserApprovesTheWholePlanAtOnceTh": "AI schlägt einen mehrstufigen Plan vor. Der Benutzer genehmigt den gesamten Plan auf einmal und die Schritte werden dann automatisch ausgeführt.",
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Tools der Stufe 2 werden automatisch mit Audit-Protokollierung ausgeführt. Werkzeuge der Stufe 3 sind weiterhin genehmigungspflichtig.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Wie ein Aktionsplan, plus Live-Screenshots zwischen den Schritten und eine dauerhafte Stopp-Schaltfläche.",
-    "untitled": "Ohne Titel"
+    "untitled": "Ohne Titel",
+    "billedToPartnerKey": "Die KI-Nutzung wird über den eigenen Anthropic-Schlüssel Ihrer Organisation abgerechnet"
   },
   "aiAgentsPage": {
     "title": "KI-Agenten",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1309,7 +1309,7 @@
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Tier 2 tools auto-execute with audit logging. Tier 3 tools still require approval.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Like Action Plan, plus live screenshots between steps and a persistent Stop button.",
     "untitled": "Untitled",
-    "billedToPartnerKey": "AI usage is billed to your organization's own Anthropic key"
+    "billedToPartnerKey": "Billed to your key — AI usage goes to your own Anthropic account, not Breeze AI credits"
   },
   "aiAgentsPage": {
     "title": "AI Agents",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -128,6 +128,39 @@
       "hybridPlan": "Hybrid Plan"
     }
   },
+  "partnerAiProvider": {
+    "title": "AI Provider",
+    "subtitle": "Run Breeze AI on your own Anthropic API key instead of the platform key.",
+    "platformKey": "Platform key",
+    "platformKeyDescription": "AI features run on Breeze's Anthropic key and are billed as Breeze AI credits.",
+    "yourKey": "Your key •••• {{last4}}",
+    "verifiedAt": "Verified {{date}}",
+    "notVerifiedYet": "Not verified yet",
+    "defaultModelValue": "Default model: {{model}}",
+    "platformDefault": "Platform default",
+    "keyErrorTitle": "Your Anthropic key is not working",
+    "reconnectHint": "AI features are unavailable for your organizations until you save a working key below.",
+    "connectKeyTitle": "Connect your Anthropic key",
+    "replaceKeyTitle": "Replace your Anthropic key",
+    "keyLabel": "Anthropic API key",
+    "writeOnlyHint": "The key is verified when you save it and is never shown again.",
+    "saveKey": "Save key",
+    "keySaved": "Anthropic key saved and verified.",
+    "keySaveFailed": "Could not save the Anthropic key.",
+    "defaultModelLabel": "Default model",
+    "defaultModelHint": "Used for new AI sessions across all your organizations.",
+    "modelUpdated": "Default model updated.",
+    "modelUpdateFailed": "Could not update the default model.",
+    "disconnectTitle": "Switch back to the platform key",
+    "disconnectDescription": "Removes your Anthropic key. AI usage is billed as Breeze AI credits again.",
+    "disconnect": "Disconnect",
+    "disconnectConfirm": "Disconnect your Anthropic key? AI features will switch back to the platform key and Breeze AI credits.",
+    "disconnected": "Anthropic key removed. AI features now use the platform key.",
+    "disconnectFailed": "Could not disconnect the Anthropic key.",
+    "permissionDenied": "Managing the AI provider requires billing permissions and access to all organizations.",
+    "loadFailed": "Could not load the AI provider configuration.",
+    "workspaceDisclosure": "Workspace content enrichment currently uses the platform key."
+  },
   "partnerDefaults": {
     "notSet": "Not set — orgs configure individually",
     "updatePolicy": "Agent Update Policy",
@@ -416,6 +449,10 @@
       "aiBudgets": {
         "label": "AI Budgets",
         "description": "AI spending limits"
+      },
+      "aiProvider": {
+        "label": "AI Provider",
+        "description": "Bring your own Anthropic key"
       },
       "branding": {
         "label": "Branding",
@@ -1271,7 +1308,8 @@
     "aIProposesAMultiStepPlanUserApprovesTheWholePlanAtOnceTh": "AI proposes a multi-step plan. User approves the whole plan at once, then steps auto-execute.",
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Tier 2 tools auto-execute with audit logging. Tier 3 tools still require approval.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Like Action Plan, plus live screenshots between steps and a persistent Stop button.",
-    "untitled": "Untitled"
+    "untitled": "Untitled",
+    "billedToPartnerKey": "AI usage is billed to your organization's own Anthropic key"
   },
   "aiAgentsPage": {
     "title": "AI Agents",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -128,6 +128,39 @@
       "hybridPlan": "Plan híbrido"
     }
   },
+  "partnerAiProvider": {
+    "title": "Proveedor de IA",
+    "subtitle": "Ejecuta la IA de Breeze con tu propia clave de API de Anthropic en lugar de la clave de la plataforma.",
+    "platformKey": "Clave de la plataforma",
+    "platformKeyDescription": "Las funciones de IA usan la clave de Anthropic de Breeze y se cobran como créditos de IA de Breeze.",
+    "yourKey": "Tu clave •••• {{last4}}",
+    "verifiedAt": "Verificada el {{date}}",
+    "notVerifiedYet": "Aún sin verificar",
+    "defaultModelValue": "Modelo predeterminado: {{model}}",
+    "platformDefault": "Predeterminado de la plataforma",
+    "keyErrorTitle": "Tu clave de Anthropic no está funcionando",
+    "reconnectHint": "Las funciones de IA no estarán disponibles para tus organizaciones hasta que guardes una clave válida abajo.",
+    "connectKeyTitle": "Conectar tu clave de Anthropic",
+    "replaceKeyTitle": "Reemplazar tu clave de Anthropic",
+    "keyLabel": "Clave de API de Anthropic",
+    "writeOnlyHint": "La clave se verifica al guardarla y no vuelve a mostrarse.",
+    "saveKey": "Guardar clave",
+    "keySaved": "Clave de Anthropic guardada y verificada.",
+    "keySaveFailed": "No se pudo guardar la clave de Anthropic.",
+    "defaultModelLabel": "Modelo predeterminado",
+    "defaultModelHint": "Se usa en las nuevas sesiones de IA de todas tus organizaciones.",
+    "modelUpdated": "Modelo predeterminado actualizado.",
+    "modelUpdateFailed": "No se pudo actualizar el modelo predeterminado.",
+    "disconnectTitle": "Volver a la clave de la plataforma",
+    "disconnectDescription": "Elimina tu clave de Anthropic. El uso de IA vuelve a cobrarse como créditos de IA de Breeze.",
+    "disconnect": "Desconectar",
+    "disconnectConfirm": "¿Desconectar tu clave de Anthropic? Las funciones de IA volverán a usar la clave de la plataforma y los créditos de IA de Breeze.",
+    "disconnected": "Clave de Anthropic eliminada. Las funciones de IA ahora usan la clave de la plataforma.",
+    "disconnectFailed": "No se pudo desconectar la clave de Anthropic.",
+    "permissionDenied": "Administrar el proveedor de IA requiere permisos de facturación y acceso a todas las organizaciones.",
+    "loadFailed": "No se pudo cargar la configuración del proveedor de IA.",
+    "workspaceDisclosure": "El enriquecimiento de contenido de Workspace actualmente usa la clave de la plataforma."
+  },
   "partnerDefaults": {
     "notSet": "No configurado: las organizaciones se configuran individualmente",
     "updatePolicy": "Política de actualización del agente",
@@ -416,6 +449,10 @@
       "aiBudgets": {
         "label": "AI Presupuestos",
         "description": "límites de gasto AI"
+      },
+      "aiProvider": {
+        "label": "Proveedor de IA",
+        "description": "Usa tu propia clave de Anthropic"
       },
       "branding": {
         "label": "Marca",
@@ -1271,7 +1308,8 @@
     "aIProposesAMultiStepPlanUserApprovesTheWholePlanAtOnceTh": "AI propone un plan de varios pasos. El usuario aprueba todo el plan a la vez y luego los pasos se ejecutan automáticamente.",
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Las herramientas de nivel 2 se ejecutan automáticamente con registro de auditoría. Las herramientas de nivel 3 aún requieren aprobación.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Como Plan de acción, además de capturas de pantalla en vivo entre los pasos y un botón Detener persistente.",
-    "untitled": "Sin título"
+    "untitled": "Sin título",
+    "billedToPartnerKey": "El uso de IA se cobra a la clave de Anthropic de tu propia organización"
   },
   "aiAgentsPage": {
     "title": "Agentes de IA",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1309,7 +1309,7 @@
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Las herramientas de nivel 2 se ejecutan automáticamente con registro de auditoría. Las herramientas de nivel 3 aún requieren aprobación.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Como Plan de acción, además de capturas de pantalla en vivo entre los pasos y un botón Detener persistente.",
     "untitled": "Sin título",
-    "billedToPartnerKey": "El uso de IA se cobra a la clave de Anthropic de tu propia organización"
+    "billedToPartnerKey": "Facturado a tu clave: el uso de IA se cobra a tu propia cuenta de Anthropic, no a los créditos de IA de Breeze"
   },
   "aiAgentsPage": {
     "title": "Agentes de IA",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -128,6 +128,39 @@
       "hybridPlan": "Plan hybride"
     }
   },
+  "partnerAiProvider": {
+    "title": "Fournisseur d'IA",
+    "subtitle": "Exécutez l'IA de Breeze avec votre propre clé d'API Anthropic au lieu de la clé de la plateforme.",
+    "platformKey": "Clé de la plateforme",
+    "platformKeyDescription": "Les fonctionnalités d'IA utilisent la clé Anthropic de Breeze et sont facturées en crédits d'IA Breeze.",
+    "yourKey": "Votre clé •••• {{last4}}",
+    "verifiedAt": "Vérifiée le {{date}}",
+    "notVerifiedYet": "Pas encore vérifiée",
+    "defaultModelValue": "Modèle par défaut : {{model}}",
+    "platformDefault": "Valeur par défaut de la plateforme",
+    "keyErrorTitle": "Votre clé Anthropic ne fonctionne pas",
+    "reconnectHint": "Les fonctionnalités d'IA sont indisponibles pour vos organisations tant que vous n'avez pas enregistré une clé valide ci-dessous.",
+    "connectKeyTitle": "Connecter votre clé Anthropic",
+    "replaceKeyTitle": "Remplacer votre clé Anthropic",
+    "keyLabel": "Clé d'API Anthropic",
+    "writeOnlyHint": "La clé est vérifiée à l'enregistrement et n'est plus jamais affichée.",
+    "saveKey": "Enregistrer la clé",
+    "keySaved": "Clé Anthropic enregistrée et vérifiée.",
+    "keySaveFailed": "Impossible d'enregistrer la clé Anthropic.",
+    "defaultModelLabel": "Modèle par défaut",
+    "defaultModelHint": "Utilisé pour les nouvelles sessions d'IA dans toutes vos organisations.",
+    "modelUpdated": "Modèle par défaut mis à jour.",
+    "modelUpdateFailed": "Impossible de mettre à jour le modèle par défaut.",
+    "disconnectTitle": "Revenir à la clé de la plateforme",
+    "disconnectDescription": "Supprime votre clé Anthropic. L'utilisation de l'IA est de nouveau facturée en crédits d'IA Breeze.",
+    "disconnect": "Déconnecter",
+    "disconnectConfirm": "Déconnecter votre clé Anthropic ? Les fonctionnalités d'IA reviendront à la clé de la plateforme et aux crédits d'IA Breeze.",
+    "disconnected": "Clé Anthropic supprimée. Les fonctionnalités d'IA utilisent désormais la clé de la plateforme.",
+    "disconnectFailed": "Impossible de déconnecter la clé Anthropic.",
+    "permissionDenied": "La gestion du fournisseur d'IA nécessite des autorisations de facturation et l'accès à toutes les organisations.",
+    "loadFailed": "Impossible de charger la configuration du fournisseur d'IA.",
+    "workspaceDisclosure": "L'enrichissement de contenu Workspace utilise actuellement la clé de la plateforme."
+  },
   "partnerDefaults": {
     "notSet": "Non défini — les organisations se configurent individuellement",
     "updatePolicy": "Politique de mise à jour de l’agent",
@@ -416,6 +449,10 @@
       "aiBudgets": {
         "label": "Budgets IA",
         "description": "Limites de dépenses en IA"
+      },
+      "aiProvider": {
+        "label": "Fournisseur d'IA",
+        "description": "Utilisez votre propre clé Anthropic"
       },
       "branding": {
         "label": "Image de marque",
@@ -1271,7 +1308,8 @@
     "aIProposesAMultiStepPlanUserApprovesTheWholePlanAtOnceTh": "L’IA propose un plan en plusieurs étapes. L’utilisateur approuve tout le plan d’un coup, puis s’exécute automatiquement par procédés.",
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Les outils de niveau 2 s’exécutent automatiquement avec des journaux d’audit. Les outils de niveau 3 nécessitent toujours une approbation.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Comme Action Plan, plus des captures d’écran en direct entre les étapes et un bouton Stop persistant.",
-    "untitled": "Sans titre"
+    "untitled": "Sans titre",
+    "billedToPartnerKey": "L'utilisation de l'IA est facturée sur la clé Anthropic de votre propre organisation"
   },
   "aiAgentsPage": {
     "title": "Agents IA",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1309,7 +1309,7 @@
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Les outils de niveau 2 s’exécutent automatiquement avec des journaux d’audit. Les outils de niveau 3 nécessitent toujours une approbation.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Comme Action Plan, plus des captures d’écran en direct entre les étapes et un bouton Stop persistant.",
     "untitled": "Sans titre",
-    "billedToPartnerKey": "L'utilisation de l'IA est facturée sur la clé Anthropic de votre propre organisation"
+    "billedToPartnerKey": "Facturé sur votre clé — l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze"
   },
   "aiAgentsPage": {
     "title": "Agents IA",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -128,6 +128,39 @@
       "hybridPlan": "Plan hybride"
     }
   },
+  "partnerAiProvider": {
+    "title": "Fournisseur d'IA",
+    "subtitle": "Exécutez l'IA de Breeze avec votre propre clé d'API Anthropic au lieu de la clé de la plateforme.",
+    "platformKey": "Clé de la plateforme",
+    "platformKeyDescription": "Les fonctionnalités d'IA utilisent la clé Anthropic de Breeze et sont facturées en crédits d'IA Breeze.",
+    "yourKey": "Votre clé •••• {{last4}}",
+    "verifiedAt": "Vérifiée le {{date}}",
+    "notVerifiedYet": "Pas encore vérifiée",
+    "defaultModelValue": "Modèle par défaut : {{model}}",
+    "platformDefault": "Valeur par défaut de la plateforme",
+    "keyErrorTitle": "Votre clé Anthropic ne fonctionne pas",
+    "reconnectHint": "Les fonctionnalités d'IA sont indisponibles pour vos organisations tant que vous n'avez pas enregistré une clé valide ci-dessous.",
+    "connectKeyTitle": "Connecter votre clé Anthropic",
+    "replaceKeyTitle": "Remplacer votre clé Anthropic",
+    "keyLabel": "Clé d'API Anthropic",
+    "writeOnlyHint": "La clé est vérifiée à l'enregistrement et n'est plus jamais affichée.",
+    "saveKey": "Enregistrer la clé",
+    "keySaved": "Clé Anthropic enregistrée et vérifiée.",
+    "keySaveFailed": "Impossible d'enregistrer la clé Anthropic.",
+    "defaultModelLabel": "Modèle par défaut",
+    "defaultModelHint": "Utilisé pour les nouvelles sessions d'IA dans toutes vos organisations.",
+    "modelUpdated": "Modèle par défaut mis à jour.",
+    "modelUpdateFailed": "Impossible de mettre à jour le modèle par défaut.",
+    "disconnectTitle": "Revenir à la clé de la plateforme",
+    "disconnectDescription": "Supprime votre clé Anthropic. L'utilisation de l'IA est de nouveau facturée en crédits d'IA Breeze.",
+    "disconnect": "Déconnecter",
+    "disconnectConfirm": "Déconnecter votre clé Anthropic ? Les fonctionnalités d'IA reviendront à la clé de la plateforme et aux crédits d'IA Breeze.",
+    "disconnected": "Clé Anthropic supprimée. Les fonctionnalités d'IA utilisent désormais la clé de la plateforme.",
+    "disconnectFailed": "Impossible de déconnecter la clé Anthropic.",
+    "permissionDenied": "La gestion du fournisseur d'IA nécessite des autorisations de facturation et l'accès à toutes les organisations.",
+    "loadFailed": "Impossible de charger la configuration du fournisseur d'IA.",
+    "workspaceDisclosure": "L'enrichissement de contenu Workspace utilise actuellement la clé de la plateforme."
+  },
   "partnerDefaults": {
     "notSet": "Non défini — les organisations se configurent individuellement",
     "updatePolicy": "Politique de mise à jour de l’agent",
@@ -416,6 +449,10 @@
       "aiBudgets": {
         "label": "Budgets IA",
         "description": "Limites de dépenses en IA"
+      },
+      "aiProvider": {
+        "label": "Fournisseur d'IA",
+        "description": "Utilisez votre propre clé Anthropic"
       },
       "branding": {
         "label": "Image de marque",
@@ -1271,7 +1308,8 @@
     "aIProposesAMultiStepPlanUserApprovesTheWholePlanAtOnceTh": "L’IA propose un plan en plusieurs étapes. L’utilisateur approuve tout le plan d’un coup, puis s’exécute automatiquement par procédés.",
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Les outils de niveau 2 s’exécutent automatiquement avec des journaux d’audit. Les outils de niveau 3 nécessitent toujours une approbation.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Comme Action Plan, plus des captures d’écran en direct entre les étapes et un bouton Stop persistant.",
-    "untitled": "Sans titre"
+    "untitled": "Sans titre",
+    "billedToPartnerKey": "L'utilisation de l'IA est facturée sur la clé Anthropic de votre propre organisation"
   },
   "aiAgentsPage": {
     "title": "Agents IA",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1309,7 +1309,7 @@
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Les outils de niveau 2 s’exécutent automatiquement avec des journaux d’audit. Les outils de niveau 3 nécessitent toujours une approbation.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Comme Action Plan, plus des captures d’écran en direct entre les étapes et un bouton Stop persistant.",
     "untitled": "Sans titre",
-    "billedToPartnerKey": "L'utilisation de l'IA est facturée sur la clé Anthropic de votre propre organisation"
+    "billedToPartnerKey": "Facturé sur votre clé — l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze"
   },
   "aiAgentsPage": {
     "title": "Agents IA",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1309,7 +1309,7 @@
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Gli strumenti Tier 2 vengono eseguiti automaticamente con registrazione di audit. Gli strumenti Tier 3 richiedono ancora approvazione.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Come Piano d'azione, più screenshot live tra i passaggi e un pulsante Interrompi persistente.",
     "untitled": "Senza titolo",
-    "billedToPartnerKey": "L'utilizzo dell'IA viene addebitato sulla chiave Anthropic della tua organizzazione"
+    "billedToPartnerKey": "Addebitato sulla tua chiave: l'utilizzo dell'IA va sul tuo account Anthropic, non sui crediti IA di Breeze"
   },
   "aiAgentsPage": {
     "title": "Agenti AI",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -128,6 +128,39 @@
       "hybridPlan": "Piano ibrido"
     }
   },
+  "partnerAiProvider": {
+    "title": "Provider IA",
+    "subtitle": "Esegui l'IA di Breeze con la tua chiave API Anthropic invece della chiave della piattaforma.",
+    "platformKey": "Chiave della piattaforma",
+    "platformKeyDescription": "Le funzionalità di IA usano la chiave Anthropic di Breeze e vengono addebitate come crediti IA di Breeze.",
+    "yourKey": "La tua chiave •••• {{last4}}",
+    "verifiedAt": "Verificata il {{date}}",
+    "notVerifiedYet": "Non ancora verificata",
+    "defaultModelValue": "Modello predefinito: {{model}}",
+    "platformDefault": "Predefinito della piattaforma",
+    "keyErrorTitle": "La tua chiave Anthropic non funziona",
+    "reconnectHint": "Le funzionalità di IA non sono disponibili per le tue organizzazioni finché non salvi una chiave funzionante qui sotto.",
+    "connectKeyTitle": "Collega la tua chiave Anthropic",
+    "replaceKeyTitle": "Sostituisci la tua chiave Anthropic",
+    "keyLabel": "Chiave API Anthropic",
+    "writeOnlyHint": "La chiave viene verificata al salvataggio e non viene mai più mostrata.",
+    "saveKey": "Salva chiave",
+    "keySaved": "Chiave Anthropic salvata e verificata.",
+    "keySaveFailed": "Impossibile salvare la chiave Anthropic.",
+    "defaultModelLabel": "Modello predefinito",
+    "defaultModelHint": "Usato per le nuove sessioni di IA in tutte le tue organizzazioni.",
+    "modelUpdated": "Modello predefinito aggiornato.",
+    "modelUpdateFailed": "Impossibile aggiornare il modello predefinito.",
+    "disconnectTitle": "Torna alla chiave della piattaforma",
+    "disconnectDescription": "Rimuove la tua chiave Anthropic. L'utilizzo dell'IA torna a essere addebitato come crediti IA di Breeze.",
+    "disconnect": "Disconnetti",
+    "disconnectConfirm": "Disconnettere la tua chiave Anthropic? Le funzionalità di IA torneranno alla chiave della piattaforma e ai crediti IA di Breeze.",
+    "disconnected": "Chiave Anthropic rimossa. Le funzionalità di IA ora usano la chiave della piattaforma.",
+    "disconnectFailed": "Impossibile disconnettere la chiave Anthropic.",
+    "permissionDenied": "La gestione del provider IA richiede autorizzazioni di fatturazione e l'accesso a tutte le organizzazioni.",
+    "loadFailed": "Impossibile caricare la configurazione del provider IA.",
+    "workspaceDisclosure": "L'arricchimento dei contenuti di Workspace attualmente usa la chiave della piattaforma."
+  },
   "partnerDefaults": {
     "notSet": "Non impostato — le org si configurano singolarmente",
     "updatePolicy": "Criterio di aggiornamento agent",
@@ -416,6 +449,10 @@
       "aiBudgets": {
         "label": "Budget AI",
         "description": "Limiti di spesa AI"
+      },
+      "aiProvider": {
+        "label": "Provider IA",
+        "description": "Usa la tua chiave Anthropic"
       },
       "branding": {
         "label": "Branding",
@@ -1271,7 +1308,8 @@
     "aIProposesAMultiStepPlanUserApprovesTheWholePlanAtOnceTh": "L'AI propone un piano in più passaggi. L'utente approva l'intero piano in una volta, poi i passaggi vengono eseguiti automaticamente.",
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Gli strumenti Tier 2 vengono eseguiti automaticamente con registrazione di audit. Gli strumenti Tier 3 richiedono ancora approvazione.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Come Piano d'azione, più screenshot live tra i passaggi e un pulsante Interrompi persistente.",
-    "untitled": "Senza titolo"
+    "untitled": "Senza titolo",
+    "billedToPartnerKey": "L'utilizzo dell'IA viene addebitato sulla chiave Anthropic della tua organizzazione"
   },
   "aiAgentsPage": {
     "title": "Agenti AI",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1309,7 +1309,7 @@
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "As ferramentas de nível 2 são executadas automaticamente com registro de auditoria. As ferramentas de nível 3 ainda exigem aprovação.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Como o Plano de Ação, além de capturas de tela ao vivo entre as etapas e um botão Parar persistente.",
     "untitled": "Sem título",
-    "billedToPartnerKey": "O uso de IA é cobrado na chave Anthropic da sua própria organização"
+    "billedToPartnerKey": "Cobrado na sua chave — o uso de IA vai para a sua própria conta da Anthropic, não para os créditos de IA do Breeze"
   },
   "aiAgentsPage": {
     "title": "Agentes de IA",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -128,6 +128,39 @@
       "hybridPlan": "Plano híbrido"
     }
   },
+  "partnerAiProvider": {
+    "title": "Provedor de IA",
+    "subtitle": "Execute a IA do Breeze com sua própria chave de API da Anthropic em vez da chave da plataforma.",
+    "platformKey": "Chave da plataforma",
+    "platformKeyDescription": "Os recursos de IA usam a chave Anthropic do Breeze e são cobrados como créditos de IA do Breeze.",
+    "yourKey": "Sua chave •••• {{last4}}",
+    "verifiedAt": "Verificada em {{date}}",
+    "notVerifiedYet": "Ainda não verificada",
+    "defaultModelValue": "Modelo padrão: {{model}}",
+    "platformDefault": "Padrão da plataforma",
+    "keyErrorTitle": "Sua chave Anthropic não está funcionando",
+    "reconnectHint": "Os recursos de IA ficam indisponíveis para suas organizações até você salvar uma chave válida abaixo.",
+    "connectKeyTitle": "Conectar sua chave Anthropic",
+    "replaceKeyTitle": "Substituir sua chave Anthropic",
+    "keyLabel": "Chave de API da Anthropic",
+    "writeOnlyHint": "A chave é verificada ao salvar e nunca é exibida novamente.",
+    "saveKey": "Salvar chave",
+    "keySaved": "Chave Anthropic salva e verificada.",
+    "keySaveFailed": "Não foi possível salvar a chave Anthropic.",
+    "defaultModelLabel": "Modelo padrão",
+    "defaultModelHint": "Usado em novas sessões de IA em todas as suas organizações.",
+    "modelUpdated": "Modelo padrão atualizado.",
+    "modelUpdateFailed": "Não foi possível atualizar o modelo padrão.",
+    "disconnectTitle": "Voltar para a chave da plataforma",
+    "disconnectDescription": "Remove sua chave Anthropic. O uso de IA volta a ser cobrado como créditos de IA do Breeze.",
+    "disconnect": "Desconectar",
+    "disconnectConfirm": "Desconectar sua chave Anthropic? Os recursos de IA voltarão a usar a chave da plataforma e os créditos de IA do Breeze.",
+    "disconnected": "Chave Anthropic removida. Os recursos de IA agora usam a chave da plataforma.",
+    "disconnectFailed": "Não foi possível desconectar a chave Anthropic.",
+    "permissionDenied": "Gerenciar o provedor de IA exige permissões de faturamento e acesso a todas as organizações.",
+    "loadFailed": "Não foi possível carregar a configuração do provedor de IA.",
+    "workspaceDisclosure": "O enriquecimento de conteúdo do Workspace atualmente usa a chave da plataforma."
+  },
   "partnerDefaults": {
     "notSet": "Não definido — as organizações configuram individualmente",
     "updatePolicy": "Política de atualização do agente",
@@ -416,6 +449,10 @@
       "aiBudgets": {
         "label": "Orçamentos de IA",
         "description": "Limites de gastos com IA"
+      },
+      "aiProvider": {
+        "label": "Provedor de IA",
+        "description": "Use sua própria chave Anthropic"
       },
       "branding": {
         "label": "Identidade visual",
@@ -1271,7 +1308,8 @@
     "aIProposesAMultiStepPlanUserApprovesTheWholePlanAtOnceTh": "A IA propõe um plano de várias etapas. O usuário aprova o plano inteiro de uma só vez; depois, as etapas são executadas automaticamente.",
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "As ferramentas de nível 2 são executadas automaticamente com registro de auditoria. As ferramentas de nível 3 ainda exigem aprovação.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Como o Plano de Ação, além de capturas de tela ao vivo entre as etapas e um botão Parar persistente.",
-    "untitled": "Sem título"
+    "untitled": "Sem título",
+    "billedToPartnerKey": "O uso de IA é cobrado na chave Anthropic da sua própria organização"
   },
   "aiAgentsPage": {
     "title": "Agentes de IA",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -128,6 +128,39 @@
       "hybridPlan": "Hibrit Plan"
     }
   },
+  "partnerAiProvider": {
+    "title": "Yapay Zeka Sağlayıcısı",
+    "subtitle": "Breeze yapay zekasını platform anahtarı yerine kendi Anthropic API anahtarınızla çalıştırın.",
+    "platformKey": "Platform anahtarı",
+    "platformKeyDescription": "Yapay zeka özellikleri Breeze'in Anthropic anahtarını kullanır ve Breeze yapay zeka kredisi olarak faturalandırılır.",
+    "yourKey": "Anahtarınız •••• {{last4}}",
+    "verifiedAt": "{{date}} tarihinde doğrulandı",
+    "notVerifiedYet": "Henüz doğrulanmadı",
+    "defaultModelValue": "Varsayılan model: {{model}}",
+    "platformDefault": "Platform varsayılanı",
+    "keyErrorTitle": "Anthropic anahtarınız çalışmıyor",
+    "reconnectHint": "Aşağıya çalışan bir anahtar kaydedene kadar yapay zeka özellikleri kuruluşlarınız için kullanılamaz.",
+    "connectKeyTitle": "Anthropic anahtarınızı bağlayın",
+    "replaceKeyTitle": "Anthropic anahtarınızı değiştirin",
+    "keyLabel": "Anthropic API anahtarı",
+    "writeOnlyHint": "Anahtar kaydedilirken doğrulanır ve bir daha asla gösterilmez.",
+    "saveKey": "Anahtarı kaydet",
+    "keySaved": "Anthropic anahtarı kaydedildi ve doğrulandı.",
+    "keySaveFailed": "Anthropic anahtarı kaydedilemedi.",
+    "defaultModelLabel": "Varsayılan model",
+    "defaultModelHint": "Tüm kuruluşlarınızdaki yeni yapay zeka oturumlarında kullanılır.",
+    "modelUpdated": "Varsayılan model güncellendi.",
+    "modelUpdateFailed": "Varsayılan model güncellenemedi.",
+    "disconnectTitle": "Platform anahtarına geri dön",
+    "disconnectDescription": "Anthropic anahtarınızı kaldırır. Yapay zeka kullanımı yeniden Breeze yapay zeka kredisi olarak faturalandırılır.",
+    "disconnect": "Bağlantıyı kes",
+    "disconnectConfirm": "Anthropic anahtarınızın bağlantısı kesilsin mi? Yapay zeka özellikleri platform anahtarına ve Breeze yapay zeka kredilerine geri döner.",
+    "disconnected": "Anthropic anahtarı kaldırıldı. Yapay zeka özellikleri artık platform anahtarını kullanıyor.",
+    "disconnectFailed": "Anthropic anahtarının bağlantısı kesilemedi.",
+    "permissionDenied": "Yapay zeka sağlayıcısını yönetmek için faturalama izinleri ve tüm kuruluşlara erişim gerekir.",
+    "loadFailed": "Yapay zeka sağlayıcısı yapılandırması yüklenemedi.",
+    "workspaceDisclosure": "Workspace içerik zenginleştirme şu anda platform anahtarını kullanıyor."
+  },
   "partnerDefaults": {
     "notSet": "Ayarlanmadı — kuruluşlar ayrı ayrı yapılandırılır",
     "updatePolicy": "Temsilci Güncelleme Politikası",
@@ -416,6 +449,10 @@
       "aiBudgets": {
         "label": "Yapay Zeka Bütçeleri",
         "description": "AI harcama sınırları"
+      },
+      "aiProvider": {
+        "label": "Yapay Zeka Sağlayıcısı",
+        "description": "Kendi Anthropic anahtarınızı kullanın"
       },
       "branding": {
         "label": "Markalama",
@@ -1271,7 +1308,8 @@
     "aIProposesAMultiStepPlanUserApprovesTheWholePlanAtOnceTh": "AI, çok adımlı bir plan önerir. Kullanıcı tüm planı bir kerede onaylar ve ardından otomatik yürütme adımlarını atar.",
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Tier 2 araçları, denetim günlüğüyle otomatik olarak yürütülür. 3. Katman araçlarının hâlâ onaylanması gerekiyor.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Eylem Planını beğenin, artı adımlar arasında canlı ekran görüntüleri ve kalıcı Durdur düğmesi.",
-    "untitled": "Başlıksız"
+    "untitled": "Başlıksız",
+    "billedToPartnerKey": "Yapay zeka kullanımı kuruluşunuzun kendi Anthropic anahtarına faturalandırılır"
   },
   "aiAgentsPage": {
     "title": "Yapay Zeka Aracıları",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1309,7 +1309,7 @@
     "tier2ToolsAutoExecuteWithAuditLoggingTier3ToolsStillRequ": "Tier 2 araçları, denetim günlüğüyle otomatik olarak yürütülür. 3. Katman araçlarının hâlâ onaylanması gerekiyor.",
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Eylem Planını beğenin, artı adımlar arasında canlı ekran görüntüleri ve kalıcı Durdur düğmesi.",
     "untitled": "Başlıksız",
-    "billedToPartnerKey": "Yapay zeka kullanımı kuruluşunuzun kendi Anthropic anahtarına faturalandırılır"
+    "billedToPartnerKey": "Anahtarınıza faturalandırılır — yapay zeka kullanımı Breeze yapay zeka kredilerine değil, kendi Anthropic hesabınıza yansır"
   },
   "aiAgentsPage": {
     "title": "Yapay Zeka Aracıları",


### PR DESCRIPTION
Wave 4 (final) of per-partner LLM BYOK (#3228, spec §5/§6 in `docs/superpowers/specs/ai-mcp/2026-08-23-per-partner-llm-byok-design.md`).

Closes #3887

## What's in

- **AI Provider tab** on Partner Settings (`#ai-provider`, PartnerAiBudgetsTab pattern): status card (platform / connected with last4 + verified date / error banner with `lastError`), write-only key paste (probe errors surfaced verbatim, key cleared and never re-rendered after save), default-model select bound to the fetched stored value, confirm-gated disconnect, and the workspace-enrichment platform-key disclosure. All mutations via `runAction` with the repo catch contract; component registered in the no-silent-mutations guard.
- **AiUsagePage** shows "Billed to your key…" when the usage response reports `billedTo: 'partner_key'`.
- **API**: `GET /ai/provider` returns `supportedModels` from a new curated `OFFERABLE_AI_MODELS` (current models only) — the PATCH allowlist uses the same list, so legacy pricing-registry snapshots can't be pinned as partner defaults.
- **Docs**: new "Bring Your Own LLM Key" page — hosted BYOK flow plus the previously-undocumented self-host env matrix (`ANTHROPIC_BASE_URL`, `MCP_LLM_*`) with partner-config-over-instance-env precedence, verified against `config/validate.ts`.
- Locale entries in all 8 languages (key-parity checked).

## Review

One independent round; findings fixed in `de22ebc03`: refetch-after-connect (the POST echo reports the *effective* model, which displayed a never-saved pin), the curated model list, and partner-accurate billing copy across locales + docs.

## Verification

Full web suite green locally (6,332 tests) plus the settings/i18n suites after the fix round; API `tsc` clean and aiProvider suites green; docs build clean (166 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)