### PR TITLE
fix(api): unwrap DrizzleQueryError when reading SQLSTATE in softwareInstallMethods (#3881)

### DIFF
--- a/apps/api/src/routes/softwareInstallMethods.test.ts
+++ b/apps/api/src/routes/softwareInstallMethods.test.ts
@@ -100,8 +100,10 @@ function ownedCatalogItem(overrides: Record<string, unknown> = {}) {
  */
 function drizzleWrapped(code: string, message: string, extra: Record<string, unknown> = {}) {
   const pgError = Object.assign(new Error(message), { code, severity: 'ERROR', ...extra });
+  // NB: no `name` override — the real DrizzleQueryError never sets `this.name`,
+  // so a genuine instance reports `name === 'Error'`. Keeping the fixture
+  // faithful here matters: it is the whole point of this builder.
   const wrapper = Object.assign(new Error('Failed query: insert into "software_install_methods" ...'), {
-    name: 'DrizzleQueryError',
     cause: pgError,
   });
   return wrapper;

--- a/apps/api/src/routes/softwareInstallMethods.test.ts
+++ b/apps/api/src/routes/softwareInstallMethods.test.ts
@@ -91,6 +91,32 @@ function ownedCatalogItem(overrides: Record<string, unknown> = {}) {
   };
 }
 
+/**
+ * The shape drizzle-orm/postgres-js actually throws: a DrizzleQueryError whose
+ * OWN `.code` is undefined, wrapping the postgres-js PostgresError on `.cause`.
+ * A flat `{ code }` fixture passes against a broken top-level `err.code` check
+ * and proves nothing (issue #3881), so every SQLSTATE mapping is exercised
+ * through this builder as well as the flat one below.
+ */
+function drizzleWrapped(code: string, message: string, extra: Record<string, unknown> = {}) {
+  const pgError = Object.assign(new Error(message), { code, severity: 'ERROR', ...extra });
+  const wrapper = Object.assign(new Error('Failed query: insert into "software_install_methods" ...'), {
+    name: 'DrizzleQueryError',
+    cause: pgError,
+  });
+  return wrapper;
+}
+
+/** Raw postgres-js shape (no Drizzle wrapper) — still must map. */
+function flatPgError(code: string, message: string, extra: Record<string, unknown> = {}) {
+  return Object.assign(new Error(message), { code, severity: 'ERROR', ...extra });
+}
+
+const SQLSTATE_SHAPES = [
+  ['DrizzleQueryError-wrapped (real driver shape)', drizzleWrapped] as const,
+  ['flat postgres-js error', flatPgError] as const,
+];
+
 function installedMethod(overrides: Record<string, unknown> = {}) {
   return {
     id: METHOD_ID,
@@ -223,19 +249,40 @@ describe('softwareInstallMethodRoutes', () => {
       expect(db.insert).not.toHaveBeenCalled();
     });
 
-    it('maps unique-violation to 409', async () => {
-      vi.mocked(db.select).mockReturnValueOnce(chainMock([ownedCatalogItem()]) as any);
-      vi.mocked(db.insert).mockImplementationOnce(() => {
-        throw Object.assign(new Error('duplicate'), { code: '23505' });
-      });
-
-      const res = await app.request(`/software/catalog/${CATALOG_ID}/install-methods`, {
+    async function postDuplicate() {
+      return app.request(`/software/catalog/${CATALOG_ID}/install-methods`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
         body: JSON.stringify({ platform: 'windows', kind: 'winget', packageId: 'Vendor.App' }),
       });
+    }
+
+    it.each(SQLSTATE_SHAPES)('maps unique-violation (23505) to 409 — %s', async (_label, build) => {
+      vi.mocked(db.select).mockReturnValueOnce(chainMock([ownedCatalogItem()]) as any);
+      vi.mocked(db.insert).mockImplementationOnce(() => {
+        throw build('23505', 'duplicate key value violates unique constraint', {
+          constraint_name: 'software_install_methods_catalog_platform_kind_uniq',
+        });
+      });
+
+      const res = await postDuplicate();
 
       expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toMatch(/already exists/i);
+      expect(writeRouteAudit).not.toHaveBeenCalled();
+    });
+
+    it('does not swallow a non-unique-violation error as a 409', async () => {
+      vi.mocked(db.select).mockReturnValueOnce(chainMock([ownedCatalogItem()]) as any);
+      vi.mocked(db.insert).mockImplementationOnce(() => {
+        throw drizzleWrapped('23502', 'null value in column "package_id" violates not-null constraint');
+      });
+
+      const res = await postDuplicate();
+
+      expect(res.status).toBe(500);
+      expect(writeRouteAudit).not.toHaveBeenCalled();
     });
   });
 
@@ -310,22 +357,48 @@ describe('softwareInstallMethodRoutes', () => {
       );
     });
 
-    it('maps a referencing-deployment FK violation to 409 without auditing', async () => {
+    function mockOwnedMethodLookup() {
       vi.mocked(db.select)
         .mockReturnValueOnce(chainMock([ownedCatalogItem()]) as any)
         .mockReturnValueOnce(chainMock([installedMethod()]) as any);
-      vi.mocked(db.delete).mockImplementationOnce(() => {
-        throw Object.assign(new Error('update or delete on table violates foreign key constraint'), { code: '23503' });
-      });
+    }
 
-      const res = await app.request(`/software/catalog/${CATALOG_ID}/install-methods/${METHOD_ID}`, {
+    async function deleteMethod() {
+      return app.request(`/software/catalog/${CATALOG_ID}/install-methods/${METHOD_ID}`, {
         method: 'DELETE',
         headers: { Authorization: 'Bearer token' },
       });
+    }
 
-      expect(res.status).toBe(409);
-      const body = await res.json();
-      expect(body.error).toMatch(/referenced by past deployments/i);
+    it.each(SQLSTATE_SHAPES)(
+      'maps a referencing-deployment FK violation (23503) to 409 without auditing — %s',
+      async (_label, build) => {
+        mockOwnedMethodLookup();
+        vi.mocked(db.delete).mockImplementationOnce(() => {
+          throw build('23503', 'update or delete on table violates foreign key constraint', {
+            table_name: 'software_deployments',
+            detail: 'Key (id)=(...) is still referenced from table "software_deployments".',
+          });
+        });
+
+        const res = await deleteMethod();
+
+        expect(res.status).toBe(409);
+        const body = await res.json();
+        expect(body.error).toMatch(/referenced by past deployments/i);
+        expect(writeRouteAudit).not.toHaveBeenCalled();
+      },
+    );
+
+    it('does not swallow a non-FK-violation error as a 409', async () => {
+      mockOwnedMethodLookup();
+      vi.mocked(db.delete).mockImplementationOnce(() => {
+        throw drizzleWrapped('40P01', 'deadlock detected');
+      });
+
+      const res = await deleteMethod();
+
+      expect(res.status).toBe(500);
       expect(writeRouteAudit).not.toHaveBeenCalled();
     });
   });

--- a/apps/api/src/routes/softwareInstallMethods.ts
+++ b/apps/api/src/routes/softwareInstallMethods.ts
@@ -17,6 +17,7 @@ import { authMiddleware, requireMfa, requirePermission, requireScope } from '../
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS } from '../services/permissions';
 import { resolveScopedOrgId, type AuthScopeContext } from '../services/softwareVersionShared';
+import { pgErrorCode } from '../utils/pgErrors';
 
 export const WINGET_PACKAGE_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
 export const BREW_PACKAGE_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9+._/@-]{0,255}$/;
@@ -129,7 +130,10 @@ softwareInstallMethodRoutes.post(
       });
       return c.json({ data: method }, 201);
     } catch (err: unknown) {
-      if ((err as { code?: string }).code === '23505') {
+      // Read the SQLSTATE through pgErrorCode: drizzle-orm/postgres-js rethrows
+      // the PostgresError inside a DrizzleQueryError whose own `.code` is
+      // undefined, so a top-level `err.code` check never fires (issue #3881).
+      if (pgErrorCode(err) === '23505') {
         return c.json({ error: 'An install method for this platform and kind already exists' }, 409);
       }
       throw err;
@@ -283,7 +287,8 @@ softwareInstallMethodRoutes.delete(
       await db.delete(softwareInstallMethods)
         .where(and(eq(softwareInstallMethods.id, existing.id), eq(softwareInstallMethods.catalogId, item.id)));
     } catch (err: unknown) {
-      if ((err as { code?: string }).code === '23503') {
+      // Same DrizzleQueryError unwrap as the create handler above (#3881).
+      if (pgErrorCode(err) === '23503') {
         return c.json({
           error: 'This install method is referenced by past deployments — disable it instead of deleting it',
         }, 409);


### PR DESCRIPTION
## What

Two error mappers in `apps/api/src/routes/softwareInstallMethods.ts` read the SQLSTATE off the **top-level** error. `drizzle-orm/postgres-js` rethrows the postgres-js `PostgresError` inside a `DrizzleQueryError` whose own `.code` is `undefined` — the SQLSTATE lives on `.cause`. Both branches were unreachable, and each replaced a deliberate, user-facing 409 with a bare 500.

| Handler | SQLSTATE | Message that had never been shown |
|---|---|---|
| `POST …/install-methods` (create) | `23505` | "An install method for this platform and kind already exists" |
| `DELETE …/install-methods/:methodId` | `23503` | "This install method is referenced by past deployments — disable it instead of deleting it" |

## The fix

The repo already has the canonical helper — `pgErrorCode()` in `apps/api/src/utils/pgErrors.ts` (added in #3760), which walks the `.cause` chain and handles the raw postgres-js shape too. **No new helper was introduced**; both call sites now read through it.

```ts
if (pgErrorCode(err) === '23505') { … }
```

## Tests

The two pre-existing 409 tests used a **flat** `{ code: '23505' }` fixture — which passes against the broken top-level check and proves nothing. They are now parametrised over both shapes via `it.each`:

- `drizzleWrapped()` — the real driver shape: outer error with **no** `.code`, `PostgresError` on `.cause`
- `flatPgError()` — raw postgres-js, no Drizzle wrapper

**Verified red before the fix.** With the source stashed and only the tests applied, exactly the two wrapped-shape cases fail (`expected 500 to be 409`) while the flat ones pass — so the fixtures are non-vacuous and the bug reproduces:

```
Tests  2 failed | 27 passed (29)
```

With the fix: `Test Files 2 passed (2) · Tests 49 passed (49)` (`softwareInstallMethods.test.ts` + `pgErrors.test.ts`). `tsc --noEmit` on `apps/api` exits 0.

Also added negative cases so an unrelated SQLSTATE (`23502` on create, `40P01` on delete) is **not** swallowed as a 409.

## Out-of-scope sweep — other sites with the same latent bug

I swept `apps/api/src` for every Postgres SQLSTATE literal comparison and traced each hit to where its error originates. **None of these are fixed here** — listed so they can be filed/triaged separately:

| Site | Impact |
|---|---|
| `services/tenantCascade.ts:814` (`isUndefinedTable`) | **Worst of the four.** Top-level `42P01` check on `db.execute(sql…)` results. A legitimately-missing optional table now hits the "abort the whole erasure" branch instead of being tolerated — a real GDPR org-erasure regression, not just a silent no-op. Adjacent to #3880. |
| `routes/aiAgents.ts:95` (`isUniqueViolation`) | `23505` from `db.insert/update(aiAgents)` never maps → 500 instead of the intended 409. |
| `routes/networkBaselines.ts:542` | `23503` from a Drizzle `db.transaction`/`db.delete` never maps → 500. |
| `routes/agents/connections.ts:101` | Diagnostic-only: reads `code`/`detail`/`table_name`/`column_name`/`constraint_name` off the top level, so every logged `pgCode`/`pgDetail`/… field is always `undefined`. The diagnostics that comment promises never fire. |

Confirmed **fine** (already unwrap `.cause`, or read non-Postgres codes): `partnerApi/provisioning.ts`, `services/tenantVariables.ts`, `services/pax8SyncService.ts`, `services/pax8OrderService.ts`, `services/m365ControlPlane/connectionService.ts`, `routes/partnerServicePrincipals.ts`, `routes/clientAi/admin.ts`, the five `jobs/*Worker.ts` `42P01` helpers, `aiToolsPolicyPrereqs.ts` / `aiToolsFleet.ts` (already on `pgErrorCode`), and the `jose` / Stripe / Twilio / custom-app-code sites (`bearerTokenAuth.ts`, `cfAccessJwt.ts`, `clientAiEntraJwt.ts`, `m365ConsentCallback.ts`, `m365CustomerGraph{Read,Actions}.ts`, `accountingConnectionService.ts`).

No schema, migration, tenancy, or cascade surface is touched.

Closes #3881

🤖 Generated with [Claude Code](https://claude.com/claude-code)
