### PR TITLE
fix(web,api): alert rule "Test" reports the real evaluation verdict (#3752)

### DIFF
--- a/apps/api/src/routes/alerts/rules.siteScope.test.ts
+++ b/apps/api/src/routes/alerts/rules.siteScope.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../db/schema', () => ({
   alerts: { ruleId: 'alert.ruleId', status: 'alert.status' },
   devices: { id: 'device.id', orgId: 'device.orgId', siteId: 'device.siteId' },
   deviceGroups: { id: 'group.id', orgId: 'group.orgId', siteId: 'group.siteId' },
+  deviceGroupMemberships: { deviceId: 'membership.deviceId', groupId: 'membership.groupId' },
   sites: { id: 'site.id', orgId: 'site.orgId' },
   organizations: { id: 'org.id', partnerId: 'org.partnerId' },
 }));

--- a/apps/api/src/routes/alerts/rules.testVerdict.test.ts
+++ b/apps/api/src/routes/alerts/rules.testVerdict.test.ts
@@ -1,0 +1,324 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// #3752: POST /alerts/rules/:id/test never evaluated anything. It pushed
+// `result: false` for every top-level key of `template.conditions`, so
+// `wouldTrigger` was a function of key count rather than of device state — no
+// rule carrying a condition could report that it would fire, and no rule
+// without one could report that it would not. It also read the template
+// conditions directly (the firing path prefers overrideSettings.conditions),
+// and evaluated `targetMatch` only for targetType 'device' so every other
+// target type reported a match it had never checked.
+
+const { authRef, selectQueue, ruleRef, evaluateConditionsMock } = vi.hoisted(() => ({
+  authRef: { current: {} as any },
+  selectQueue: [] as unknown[][],
+  ruleRef: { current: null as Record<string, unknown> | null },
+  evaluateConditionsMock: vi.fn(),
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  requireScope: () => async (c: any, next: any) => { c.set('auth', authRef.current); await next(); },
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+  siteAccessCheck: () => () => true,
+}));
+
+vi.mock('../../db/schema', () => ({
+  alertRules: { id: 'rule.id', orgId: 'rule.orgId', partnerId: 'rule.partnerId', templateId: 'rule.templateId', targetType: 'rule.targetType', targetId: 'rule.targetId', isActive: 'rule.isActive', createdAt: 'rule.createdAt' },
+  alertTemplates: { id: 'template.id' },
+  alerts: { ruleId: 'alert.ruleId', status: 'alert.status' },
+  devices: { id: 'device.id', orgId: 'device.orgId', siteId: 'device.siteId' },
+  deviceGroups: { id: 'group.id', orgId: 'group.orgId', siteId: 'group.siteId' },
+  deviceGroupMemberships: { deviceId: 'membership.deviceId', groupId: 'membership.groupId' },
+  sites: { id: 'site.id', orgId: 'site.orgId' },
+  organizations: { id: 'org.id', partnerId: 'org.partnerId' },
+}));
+
+vi.mock('../../db', () => {
+  const makeSelect = () => {
+    const chain: any = {
+      from: () => chain,
+      leftJoin: () => chain,
+      where: () => chain,
+      orderBy: () => chain,
+      limit: () => chain,
+      offset: () => chain,
+      then: (resolve: (value: unknown) => unknown) => Promise.resolve(selectQueue.shift() ?? []).then(resolve),
+    };
+    return chain;
+  };
+  return {
+    db: {
+      select: vi.fn(() => makeSelect()),
+      insert: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../../services/partnerWideAccess', () => ({
+  canManagePartnerWidePolicies: vi.fn(() => true),
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE: 'Partner-wide denied',
+}));
+vi.mock('../../services/alertConditions', () => ({
+  conditionPayloadsFrom: vi.fn(() => []),
+  evaluateConditions: evaluateConditionsMock,
+  retiredConditionTypeError: vi.fn(() => null),
+}));
+vi.mock('./helpers', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 1, offset: 0 })),
+  ensureOrgAccess: vi.fn(() => true),
+  getAlertRuleWithOrgCheck: vi.fn(async () => ruleRef.current),
+  isRecord: (value: unknown) => !!value && typeof value === 'object' && !Array.isArray(value),
+  getOverrides: (value: unknown) => (value && typeof value === 'object' ? { ...(value as Record<string, unknown>) } : {}),
+  normalizeTargetsForRule: vi.fn(),
+  getNotificationChannelIds: vi.fn(() => []),
+  containsNotificationBindingOverride: vi.fn(() => false),
+  validateAlertRuleNotificationBindings: vi.fn(async () => null),
+  formatAlertRuleResponse: (rule: unknown) => rule,
+  resolveAlertTemplate: vi.fn(),
+  retiredConditionReactivationError: vi.fn(() => null),
+}));
+
+import { rulesRoutes } from './rules';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_ORG_ID = '1a1a1a1a-1111-4111-8111-111111111111';
+const SITE_ID = '22222222-2222-4222-8222-222222222222';
+const OTHER_SITE_ID = '2a2a2a2a-2222-4222-8222-222222222222';
+const GROUP_ID = '33333333-3333-4333-8333-333333333333';
+const DEVICE_ID = '44444444-4444-4444-8444-444444444444';
+const OTHER_DEVICE_ID = '4a4a4a4a-4444-4444-8444-444444444444';
+const TEMPLATE_ID = '66666666-6666-4666-8666-666666666666';
+const RULE_ID = '77777777-7777-4777-8777-777777777777';
+
+const DEVICE = { id: DEVICE_ID, orgId: ORG_ID, siteId: SITE_ID, hostname: 'ws-01', osType: 'windows' };
+const CPU_CONDITIONS = { logic: 'and', conditions: [{ type: 'threshold', metric: 'cpu_usage', operator: 'gt', value: 80 }] };
+
+function app() {
+  const instance = new Hono();
+  instance.route('/alerts', rulesRoutes);
+  return instance;
+}
+
+function rule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RULE_ID,
+    orgId: ORG_ID,
+    partnerId: null,
+    name: 'High CPU',
+    templateId: TEMPLATE_ID,
+    targetType: 'all',
+    targetId: ORG_ID,
+    isActive: true,
+    overrideSettings: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Queue the two selects the handler always makes (device, then template),
+ * plus any extra rows a target type needs (group membership).
+ */
+function queueLookups(template: Record<string, unknown>, extra: unknown[][] = []) {
+  selectQueue.push([DEVICE]);
+  selectQueue.push([template]);
+  for (const rows of extra) selectQueue.push(rows);
+}
+
+async function runTest() {
+  return app().request(`/alerts/rules/${RULE_ID}/test`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ deviceId: DEVICE_ID }),
+  });
+}
+
+describe('POST /alerts/rules/:id/test — real verdict', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectQueue.length = 0;
+    ruleRef.current = rule();
+    authRef.current = {
+      scope: 'organization',
+      orgId: ORG_ID,
+      partnerId: null,
+      allowedSiteIds: undefined,
+      canAccessOrg: () => true,
+      user: { id: 'user-1' },
+    };
+    evaluateConditionsMock.mockResolvedValue({
+      triggered: false,
+      conditionsMet: [],
+      conditionsNotMet: [],
+      context: { deviceId: DEVICE_ID, evaluatedAt: '2026-08-23T00:00:00.000Z' },
+    });
+  });
+
+  // The core defect: a rule whose conditions the evaluator says ARE met must
+  // report that it would fire. The old code could not, because every condition
+  // key was hardcoded to `result: false`.
+  it('reports wouldTrigger true when the evaluator says the conditions are met', async () => {
+    queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS });
+    evaluateConditionsMock.mockResolvedValue({
+      triggered: true,
+      conditionsMet: ['cpu_usage > 80 for 5min'],
+      conditionsNotMet: [],
+      context: { deviceId: DEVICE_ID, evaluatedAt: '2026-08-23T00:00:00.000Z' },
+    });
+
+    const res = await runTest();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.wouldTrigger).toBe(true);
+    expect(body.conditionResults).toEqual([
+      { condition: 'cpu_usage > 80 for 5min', result: true, reason: 'cpu_usage > 80 for 5min' },
+    ]);
+  });
+
+  it('reports the evaluator’s real unmet conditions rather than a simulated placeholder', async () => {
+    queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS });
+    evaluateConditionsMock.mockResolvedValue({
+      triggered: false,
+      conditionsMet: [],
+      conditionsNotMet: ['cpu_usage > 80 for 5min'],
+      context: { deviceId: DEVICE_ID, evaluatedAt: '2026-08-23T00:00:00.000Z' },
+    });
+
+    const body = await (await runTest()).json();
+
+    expect(body.wouldTrigger).toBe(false);
+    expect(body.conditionResults).toEqual([
+      { condition: 'cpu_usage > 80 for 5min', result: false, reason: 'cpu_usage > 80 for 5min' },
+    ]);
+    // The old placeholder text must be gone.
+    expect(JSON.stringify(body)).not.toContain('Test evaluation of');
+  });
+
+  // An OR group can trigger with some conditions unmet, so the old
+  // `conditionResults.every(r => r.result)` was the wrong verdict function.
+  it('honours the evaluator verdict when an OR group triggers with an unmet condition', async () => {
+    queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: { logic: 'or', conditions: [] } });
+    evaluateConditionsMock.mockResolvedValue({
+      triggered: true,
+      conditionsMet: ['Device offline for 5min'],
+      conditionsNotMet: ['cpu_usage > 80 for 5min'],
+      context: { deviceId: DEVICE_ID, evaluatedAt: '2026-08-23T00:00:00.000Z' },
+    });
+
+    const body = await (await runTest()).json();
+
+    expect(body.wouldTrigger).toBe(true);
+    expect(body.conditionResults.some((r: { result: boolean }) => !r.result)).toBe(true);
+  });
+
+  // The firing path resolves overrideSettings.conditions first; testing the
+  // template instead reports on conditions the rule does not use.
+  it('evaluates the override conditions in preference to the template', async () => {
+    const override = { logic: 'and', conditions: [{ type: 'offline', durationMinutes: 10 }] };
+    ruleRef.current = rule({ overrideSettings: { conditions: override } });
+    queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS });
+
+    await runTest();
+
+    expect(evaluateConditionsMock).toHaveBeenCalledWith(override, DEVICE_ID);
+  });
+
+  it('uses the override severity when one is set', async () => {
+    ruleRef.current = rule({ overrideSettings: { severity: 'critical' } });
+    queueLookups({ id: TEMPLATE_ID, severity: 'low', conditions: CPU_CONDITIONS });
+
+    const body = await (await runTest()).json();
+
+    expect(body.rule.severity).toBe('critical');
+  });
+
+  describe('target matching', () => {
+    it('reports a site-targeted rule as not matching a device in another site', async () => {
+      ruleRef.current = rule({ targetType: 'site', targetId: OTHER_SITE_ID });
+      queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS });
+      evaluateConditionsMock.mockResolvedValue({
+        triggered: true, conditionsMet: ['cpu_usage > 80 for 5min'], conditionsNotMet: [],
+        context: { deviceId: DEVICE_ID, evaluatedAt: '2026-08-23T00:00:00.000Z' },
+      });
+
+      const body = await (await runTest()).json();
+
+      expect(body.targetMatch).toBe(false);
+      // Conditions met but the rule does not target this device: still no fire.
+      expect(body.wouldTrigger).toBe(false);
+      expect(body.targetReason).toBeTruthy();
+    });
+
+    it('reports a site-targeted rule as matching a device in that site', async () => {
+      ruleRef.current = rule({ targetType: 'site', targetId: SITE_ID });
+      queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS });
+
+      const body = await (await runTest()).json();
+      expect(body.targetMatch).toBe(true);
+    });
+
+    it('reports an org-targeted rule as not matching a device in another org', async () => {
+      ruleRef.current = rule({ targetType: 'org', targetId: OTHER_ORG_ID });
+      queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS });
+
+      const body = await (await runTest()).json();
+      expect(body.targetMatch).toBe(false);
+    });
+
+    it('checks group membership for a group-targeted rule', async () => {
+      ruleRef.current = rule({ targetType: 'group', targetId: GROUP_ID });
+      queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS }, [[]]);
+
+      const body = await (await runTest()).json();
+      expect(body.targetMatch).toBe(false);
+    });
+
+    it('matches a group-targeted rule when the device is a member', async () => {
+      ruleRef.current = rule({ targetType: 'group', targetId: GROUP_ID });
+      queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS }, [[{ groupId: GROUP_ID }]]);
+
+      const body = await (await runTest()).json();
+      expect(body.targetMatch).toBe(true);
+    });
+
+    it('reports a device-targeted rule as not matching a different device', async () => {
+      ruleRef.current = rule({ targetType: 'device', targetId: OTHER_DEVICE_ID });
+      queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS });
+
+      const body = await (await runTest()).json();
+      expect(body.targetMatch).toBe(false);
+    });
+  });
+
+  // A disabled rule is filtered out by getApplicableRules, so it never fires
+  // however well its conditions evaluate.
+  it('reports a disabled rule as not firing even when its conditions are met', async () => {
+    ruleRef.current = rule({ isActive: false });
+    queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS });
+    evaluateConditionsMock.mockResolvedValue({
+      triggered: true, conditionsMet: ['cpu_usage > 80 for 5min'], conditionsNotMet: [],
+      context: { deviceId: DEVICE_ID, evaluatedAt: '2026-08-23T00:00:00.000Z' },
+    });
+
+    const body = await (await runTest()).json();
+
+    expect(body.wouldTrigger).toBe(false);
+    expect(body.rule.enabled).toBe(false);
+  });
+
+  // The response must not carry the invented fields the client used to read.
+  it('does not return success/message fields', async () => {
+    queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS });
+
+    const body = await (await runTest()).json();
+
+    expect(body).not.toHaveProperty('success');
+    expect(body).not.toHaveProperty('message');
+    expect(body).toHaveProperty('wouldTrigger');
+  });
+});

--- a/apps/api/src/routes/alerts/rules.testVerdict.test.ts
+++ b/apps/api/src/routes/alerts/rules.testVerdict.test.ts
@@ -167,7 +167,13 @@ describe('POST /alerts/rules/:id/test — real verdict', () => {
       triggered: true,
       conditionsMet: ['cpu_usage > 80 for 5min'],
       conditionsNotMet: [],
-      context: { deviceId: DEVICE_ID, evaluatedAt: '2026-08-23T00:00:00.000Z' },
+      context: {
+        deviceId: DEVICE_ID,
+        evaluatedAt: '2026-08-23T00:00:00.000Z',
+        metric: 'cpu_usage',
+        actualValue: 91,
+        threshold: 80,
+      },
     });
 
     const res = await runTest();
@@ -178,6 +184,19 @@ describe('POST /alerts/rules/:id/test — real verdict', () => {
     expect(body.conditionResults).toEqual([
       { condition: 'cpu_usage > 80 for 5min', result: true, reason: 'cpu_usage > 80 for 5min' },
     ]);
+    // With no override, the template's own conditions are what gets evaluated.
+    expect(evaluateConditionsMock).toHaveBeenCalledWith(CPU_CONDITIONS, DEVICE_ID);
+    // The measured values that explain the verdict are passed through intact.
+    expect(body.evaluationContext).toEqual({
+      deviceId: DEVICE_ID,
+      evaluatedAt: '2026-08-23T00:00:00.000Z',
+      metric: 'cpu_usage',
+      actualValue: 91,
+      threshold: 80,
+    });
+    // The row content queried for the device and template reaches the response.
+    expect(body.device).toEqual({ id: DEVICE_ID, hostname: 'ws-01', osType: 'windows' });
+    expect(body.rule.severity).toBe('high');
   });
 
   it('reports the evaluator’s real unmet conditions rather than a simulated placeholder', async () => {
@@ -238,6 +257,15 @@ describe('POST /alerts/rules/:id/test — real verdict', () => {
   });
 
   describe('target matching', () => {
+    it('matches an all-targeted rule against any device', async () => {
+      queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS });
+
+      const body = await (await runTest()).json();
+
+      expect(body.targetMatch).toBe(true);
+      expect(body.targetReason).toBe('Rule applies to all devices');
+    });
+
     it('reports a site-targeted rule as not matching a device in another site', async () => {
       ruleRef.current = rule({ targetType: 'site', targetId: OTHER_SITE_ID });
       queueLookups({ id: TEMPLATE_ID, severity: 'high', conditions: CPU_CONDITIONS });

--- a/apps/api/src/routes/alerts/rules.ts
+++ b/apps/api/src/routes/alerts/rules.ts
@@ -860,10 +860,12 @@ rulesRoutes.post(
     const effectiveSeverity = (testOverrides.severity as string | undefined) ?? template.severity;
 
     // Does the rule actually target this device? Mirrors the SQL target
-    // matching in getApplicableRules() — that function is the authority for
-    // what fires in production, so the two must stay in sync. Previously only
-    // 'device' was checked and every other target type reported a match it had
-    // never evaluated.
+    // matching in getApplicableRules() — the firing path for standalone
+    // alertRules, which is this endpoint's rule type — so the two must stay in
+    // sync. Config-policy-linked alert rules resolve targets through a separate
+    // path (getApplicableRulesFromPolicy) that this endpoint does not exercise.
+    // Previously only 'device' was checked and every other target type reported
+    // a match it had never evaluated.
     let targetMatch: boolean;
     let targetReason: string;
     switch (rule.targetType) {
@@ -937,6 +939,11 @@ rulesRoutes.post(
     // Note: OR groups mean `conditionResults.every(...)` is NOT the verdict —
     // a compound rule can trigger with some conditions unmet. evaluation
     // .triggered is the value the firing path uses.
+    //
+    // SCOPE: this is the condition + target verdict, not a promise that an
+    // alert row appears. createAlert() additionally applies cooldown, open-alert
+    // dedup and flapping suppression (services/alertService.ts), none of which
+    // are simulated here. The UI says so rather than overstating a green result.
     const wouldTrigger = rule.isActive && targetMatch && evaluation.triggered;
 
     return c.json({
@@ -954,6 +961,9 @@ rulesRoutes.post(
       targetMatch,
       targetReason,
       conditionResults,
+      // Measured values behind the verdict (metric, actual value, threshold).
+      // Returned for API consumers and for a follow-up that surfaces "82% vs a
+      // threshold of 80%" in the modal; the current UI does not render it.
       evaluationContext: evaluation.context,
       wouldTrigger,
       testedAt: new Date().toISOString()

--- a/apps/api/src/routes/alerts/rules.ts
+++ b/apps/api/src/routes/alerts/rules.ts
@@ -2,9 +2,9 @@ import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { and, eq, sql, desc, inArray, isNull, or, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
-import { alertRules, alertTemplates, alerts, devices, deviceGroups, organizations, sites } from '../../db/schema';
+import { alertRules, alertTemplates, alerts, devices, deviceGroupMemberships, deviceGroups, organizations, sites } from '../../db/schema';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
-import { conditionPayloadsFrom, retiredConditionTypeError } from '../../services/alertConditions';
+import { conditionPayloadsFrom, evaluateConditions, retiredConditionTypeError } from '../../services/alertConditions';
 import { requireMfa, requirePermission, requireScope, siteAccessCheck } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
@@ -849,36 +849,102 @@ rulesRoutes.post(
       return c.json({ error: 'Alert template not found' }, 404);
     }
 
-    // Evaluate conditions against device
-    // This is a simplified simulation - real implementation would evaluate all conditions
-    const conditions = template.conditions as Record<string, unknown>;
+    // Resolve what would ACTUALLY be evaluated. The firing path reads
+    // overrideSettings.conditions before falling back to the template
+    // (getApplicableRules, services/alertService.ts), so a rule whose
+    // conditions were overridden has to be tested against the override —
+    // reading template.conditions here reported on conditions the rule does
+    // not use (#3752).
+    const testOverrides = getOverrides(rule.overrideSettings);
+    const effectiveConditions = (testOverrides.conditions as unknown) ?? template.conditions;
+    const effectiveSeverity = (testOverrides.severity as string | undefined) ?? template.severity;
 
-    // Check if device matches targets
-    let targetMatch = true;
-    if (rule.targetType === 'device') {
-      targetMatch = rule.targetId === device.id;
-    }
-
-    // Simulate condition evaluation
-    const conditionResults: Array<{ condition: string; result: boolean; reason: string }> = [];
-
-    // Example condition evaluation - would be more complex in production
-    if (conditions && typeof conditions === 'object') {
-      for (const key of Object.keys(conditions)) {
-        // Simulate evaluation based on condition type
-        conditionResults.push({
-          condition: key,
-          result: false, // Would evaluate actual condition
-          reason: `Test evaluation of ${key} condition`
-        });
+    // Does the rule actually target this device? Mirrors the SQL target
+    // matching in getApplicableRules() — that function is the authority for
+    // what fires in production, so the two must stay in sync. Previously only
+    // 'device' was checked and every other target type reported a match it had
+    // never evaluated.
+    let targetMatch: boolean;
+    let targetReason: string;
+    switch (rule.targetType) {
+      case 'all':
+        targetMatch = true;
+        targetReason = 'Rule applies to all devices';
+        break;
+      case 'org':
+        targetMatch = rule.targetId === device.orgId;
+        targetReason = targetMatch
+          ? 'Device belongs to the targeted organization'
+          : 'Device belongs to a different organization than the rule targets';
+        break;
+      case 'site':
+        targetMatch = rule.targetId === device.siteId;
+        targetReason = targetMatch
+          ? 'Device belongs to the targeted site'
+          : 'Device is not in the targeted site';
+        break;
+      case 'group': {
+        const [membership] = await db
+          .select({ groupId: deviceGroupMemberships.groupId })
+          .from(deviceGroupMemberships)
+          .where(
+            and(
+              eq(deviceGroupMemberships.deviceId, device.id),
+              eq(deviceGroupMemberships.groupId, rule.targetId)
+            )
+          )
+          .limit(1);
+        targetMatch = Boolean(membership);
+        targetReason = targetMatch
+          ? 'Device is a member of the targeted device group'
+          : 'Device is not a member of the targeted device group';
+        break;
       }
+      case 'device':
+        targetMatch = rule.targetId === device.id;
+        targetReason = targetMatch
+          ? 'Rule targets this device'
+          : 'Rule targets a different device';
+        break;
+      default:
+        targetMatch = false;
+        targetReason = `Unrecognized rule target type "${rule.targetType}"`;
     }
+
+    // Run the real evaluator. The previous code pushed `result: false` for
+    // every top-level key of the conditions object, so the verdict was a
+    // function of key count rather than of device state — no rule with any
+    // condition could ever report that it would fire (#3752).
+    const evaluation = await evaluateConditions(effectiveConditions, device.id);
+
+    const conditionResults: Array<{ condition: string; result: boolean; reason: string }> = [
+      ...evaluation.conditionsMet.map(description => ({
+        condition: description,
+        result: true,
+        reason: description,
+      })),
+      ...evaluation.conditionsNotMet.map(description => ({
+        condition: description,
+        result: false,
+        reason: description,
+      })),
+    ];
+
+    // A disabled rule is excluded by getApplicableRules and therefore never
+    // fires, however well its conditions evaluate. Report that rather than
+    // implying the rule is live.
+    //
+    // Note: OR groups mean `conditionResults.every(...)` is NOT the verdict —
+    // a compound rule can trigger with some conditions unmet. evaluation
+    // .triggered is the value the firing path uses.
+    const wouldTrigger = rule.isActive && targetMatch && evaluation.triggered;
 
     return c.json({
       rule: {
         id: rule.id,
         name: rule.name,
-        severity: template.severity
+        severity: effectiveSeverity,
+        enabled: rule.isActive
       },
       device: {
         id: device.id,
@@ -886,8 +952,10 @@ rulesRoutes.post(
         osType: device.osType
       },
       targetMatch,
+      targetReason,
       conditionResults,
-      wouldTrigger: targetMatch && conditionResults.every(r => r.result),
+      evaluationContext: evaluation.context,
+      wouldTrigger,
       testedAt: new Date().toISOString()
     });
   }

--- a/apps/web/src/components/alerts/AlertRuleList.tsx
+++ b/apps/web/src/components/alerts/AlertRuleList.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../../lib/i18n';
-import { Pencil, Plus, Trash2, ToggleLeft, ToggleRight } from 'lucide-react';
+import { FlaskConical, Pencil, Plus, Trash2, ToggleLeft, ToggleRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ResponsiveTable, DataCard, CardField, CardActions } from '../shared/ResponsiveTable';
 import type { AlertSeverity } from './AlertList';
@@ -125,7 +125,8 @@ export default function AlertRuleList({
   onEdit,
   onDelete,
   onToggle,
-  onCreate
+  onCreate,
+  onTest
 }: AlertRuleListProps) {
   const { t } = useTranslation('alerts');
   const [templateFilter, setTemplateFilter] = useState('all');
@@ -203,6 +204,19 @@ export default function AlertRuleList({
       >
         <Pencil className="h-4 w-4" />
       </button>
+      {onTest && (
+        <button
+          type="button"
+          onClick={event => {
+            event.stopPropagation();
+            onTest(rule);
+          }}
+          className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
+          title={t('alertRuleList.testRule')}
+        >
+          <FlaskConical className="h-4 w-4" />
+        </button>
+      )}
       <button
         type="button"
         onClick={event => {

--- a/apps/web/src/components/alerts/AlertRulesPage.testVerdict.test.tsx
+++ b/apps/web/src/components/alerts/AlertRulesPage.testVerdict.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import AlertRulesPage from './AlertRulesPage';
 import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
 
 // #3752: the test modal read `data.success` and `data.message` — two fields the
 // API has never sent. `data.success ?? true` therefore fired on every 200 and
@@ -20,6 +21,7 @@ vi.mock('../../stores/auth', async (importOriginal) => ({
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 
 const fetchMock = vi.mocked(fetchWithAuth);
+const navigateMock = vi.mocked(navigateTo);
 
 function jsonResponse(payload: unknown, ok = true, status = 200): Response {
   return {
@@ -38,17 +40,17 @@ const RULE = {
 
 const DEVICE = { id: 'dev-1', hostname: 'ws-01' };
 
-/** Captured bodies of every POST to the rule-test endpoint. */
-let testRequestBodies: string[] = [];
+/** Captured paths and bodies of every POST to the rule-test endpoint. */
+let testRequests: Array<{ path: string; body: string }> = [];
 
-function mockApi(testResponse: Response) {
+function mockApi(testResponse: Response, devicesResponse?: Response) {
   fetchMock.mockImplementation(async (path: string, init?: RequestInit) => {
     if (path.startsWith('/alerts/rules/') && path.endsWith('/test')) {
-      testRequestBodies.push(String(init?.body ?? ''));
+      testRequests.push({ path, body: String(init?.body ?? '') });
       return testResponse;
     }
     if (path.startsWith('/alerts/rules')) return jsonResponse({ rules: [RULE] });
-    if (path.startsWith('/devices')) return jsonResponse({ devices: [DEVICE] });
+    if (path.startsWith('/devices')) return devicesResponse ?? jsonResponse({ devices: [DEVICE] });
     throw new Error(`Unexpected request: ${path}`);
   });
 }
@@ -71,7 +73,7 @@ async function runTest() {
 }
 
 beforeEach(() => {
-  testRequestBodies = [];
+  testRequests = [];
 });
 
 describe('AlertRulesPage — alert rule test verdict', () => {
@@ -218,8 +220,92 @@ describe('AlertRulesPage — alert rule test verdict', () => {
 
     await runTest();
 
-    await waitFor(() => expect(testRequestBodies).toHaveLength(1));
-    expect(JSON.parse(testRequestBodies[0])).toEqual({ deviceId: DEVICE.id });
+    await waitFor(() => expect(testRequests).toHaveLength(1));
+    expect(JSON.parse(testRequests[0].body)).toEqual({ deviceId: DEVICE.id });
+    // Pin the exact path too: a stale rule id would still match a loose
+    // startsWith/endsWith mock and pass a body-only assertion.
+    expect(testRequests[0].path).toBe(`/alerts/rules/${RULE.id}/test`);
+  });
+
+  // Changing the device must not leave the previous device's verdict on
+  // screen — a verdict attributed to the wrong device is the same lie in a new
+  // costume.
+  it('clears a verdict when a different device is selected', async () => {
+    fetchMock.mockImplementation(async (path: string) => {
+      if (path.startsWith('/alerts/rules/') && path.endsWith('/test')) {
+        return jsonResponse({
+          rule: { id: RULE.id, name: RULE.name, severity: 'high', enabled: true },
+          device: { id: DEVICE.id, hostname: DEVICE.hostname, osType: 'windows' },
+          targetMatch: true,
+          conditionResults: [],
+          wouldTrigger: true,
+          testedAt: '2026-08-23T00:00:00.000Z',
+        });
+      }
+      if (path.startsWith('/alerts/rules')) return jsonResponse({ rules: [RULE] });
+      if (path.startsWith('/devices')) {
+        return jsonResponse({ devices: [DEVICE, { id: 'dev-2', hostname: 'ws-02' }] });
+      }
+      throw new Error(`Unexpected request: ${path}`);
+    });
+
+    render(<AlertRulesPage />);
+    fireEvent.click((await screen.findAllByTitle('Test rule'))[0]);
+    const select = await screen.findByLabelText('Test against device');
+    await waitFor(() => expect(screen.getByRole('option', { name: 'ws-02' })).toBeTruthy());
+    fireEvent.change(select, { target: { value: DEVICE.id } });
+    fireEvent.click(screen.getByRole('button', { name: 'Run Test' }));
+
+    expect(await screen.findByText('Rule would fire')).toBeTruthy();
+    // The verdict names the device it was computed for.
+    expect(screen.getByText('Evaluated against ws-01')).toBeTruthy();
+
+    fireEvent.change(select, { target: { value: 'dev-2' } });
+
+    expect(screen.queryByText('Rule would fire')).toBeNull();
+    expect(screen.queryByText('Evaluated against ws-01')).toBeNull();
+  });
+
+  it('surfaces a failure to load the device list', async () => {
+    mockApi(jsonResponse({}), jsonResponse({ error: 'Devices unavailable' }, false, 500));
+
+    render(<AlertRulesPage />);
+    fireEvent.click((await screen.findAllByTitle('Test rule'))[0]);
+
+    expect(await screen.findByText('Devices unavailable')).toBeTruthy();
+    expect((screen.getByRole('button', { name: 'Run Test' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('says so when there are no devices to test against', async () => {
+    mockApi(jsonResponse({}), jsonResponse({ devices: [] }));
+
+    render(<AlertRulesPage />);
+    fireEvent.click((await screen.findAllByTitle('Test rule'))[0]);
+
+    expect(
+      await screen.findByText('No devices are available to test this rule against.')
+    ).toBeTruthy();
+    expect((screen.getByRole('button', { name: 'Run Test' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('redirects to login when the device list returns 401', async () => {
+    mockApi(jsonResponse({}), jsonResponse({ error: 'Unauthorized' }, false, 401));
+
+    render(<AlertRulesPage />);
+    fireEvent.click((await screen.findAllByTitle('Test rule'))[0]);
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true }));
+    expect(screen.queryByText('Unauthorized')).toBeNull();
+  });
+
+  it('redirects to login when the test request returns 401', async () => {
+    mockApi(jsonResponse({ error: 'Unauthorized' }, false, 401));
+
+    await runTest();
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true }));
+    expect(screen.queryByText('Test Failed')).toBeNull();
+    expect(screen.queryByText('Rule would fire')).toBeNull();
   });
 
   it('does not render a negative verdict identically to a positive one', async () => {

--- a/apps/web/src/components/alerts/AlertRulesPage.testVerdict.test.tsx
+++ b/apps/web/src/components/alerts/AlertRulesPage.testVerdict.test.tsx
@@ -1,0 +1,260 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import AlertRulesPage from './AlertRulesPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+// #3752: the test modal read `data.success` and `data.message` — two fields the
+// API has never sent. `data.success ?? true` therefore fired on every 200 and
+// the modal rendered a green "Test Passed" whatever the evaluation actually
+// concluded. The fields carrying the real verdict (`wouldTrigger`,
+// `conditionResults`) were read nowhere in the file.
+//
+// These assert the VISIBLE verdict rather than any particular markup, so a
+// redesign can satisfy them without a rewrite — the contract is "the outcome
+// the server computed is the outcome shown", not "a particular <div> exists".
+
+vi.mock('../../stores/auth', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../stores/auth')>()),
+  fetchWithAuth: vi.fn(),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+function jsonResponse(payload: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => payload,
+  } as unknown as Response;
+}
+
+const RULE = {
+  id: 'rule-1',
+  name: 'High CPU',
+  enabled: true,
+  targets: { type: 'all' as const, ids: [] },
+};
+
+const DEVICE = { id: 'dev-1', hostname: 'ws-01' };
+
+/** Captured bodies of every POST to the rule-test endpoint. */
+let testRequestBodies: string[] = [];
+
+function mockApi(testResponse: Response) {
+  fetchMock.mockImplementation(async (path: string, init?: RequestInit) => {
+    if (path.startsWith('/alerts/rules/') && path.endsWith('/test')) {
+      testRequestBodies.push(String(init?.body ?? ''));
+      return testResponse;
+    }
+    if (path.startsWith('/alerts/rules')) return jsonResponse({ rules: [RULE] });
+    if (path.startsWith('/devices')) return jsonResponse({ devices: [DEVICE] });
+    throw new Error(`Unexpected request: ${path}`);
+  });
+}
+
+/** Open the test modal, pick the device, and run the test. */
+async function runTest() {
+  render(<AlertRulesPage />);
+
+  // ResponsiveTable renders both a table row and a mobile card, so the row
+  // actions appear twice in jsdom; either copy opens the same modal.
+  const testButtons = await screen.findAllByTitle('Test rule');
+  fireEvent.click(testButtons[0]);
+
+  const select = await screen.findByLabelText('Test against device');
+  await waitFor(() => expect(screen.getByRole('option', { name: 'ws-01' })).toBeTruthy());
+  fireEvent.change(select, { target: { value: DEVICE.id } });
+  expect((select as HTMLSelectElement).value).toBe(DEVICE.id);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Run Test' }));
+}
+
+beforeEach(() => {
+  testRequestBodies = [];
+});
+
+describe('AlertRulesPage — alert rule test verdict', () => {
+  // The defect itself. Under the old handler this response produced
+  // "Test Passed", because `success` is absent and `?? true` supplied one.
+  it('states that a rule which would not fire did not fire', async () => {
+    mockApi(
+      jsonResponse({
+        rule: { id: RULE.id, name: RULE.name, severity: 'high', enabled: true },
+        device: { id: DEVICE.id, hostname: DEVICE.hostname, osType: 'windows' },
+        targetMatch: true,
+        targetReason: 'Rule applies to all devices',
+        conditionResults: [
+          {
+            condition: 'cpu_usage > 80 for 5min',
+            result: false,
+            reason: 'cpu_usage > 80 for 5min',
+          },
+        ],
+        wouldTrigger: false,
+        testedAt: '2026-08-23T00:00:00.000Z',
+      })
+    );
+
+    await runTest();
+
+    expect(await screen.findByText('Rule would not fire')).toBeTruthy();
+    expect(screen.queryByText('Rule would fire')).toBeNull();
+    // No fabricated pass, in any of its old spellings.
+    expect(screen.queryByText('Test Passed')).toBeNull();
+    expect(screen.queryByText('Test completed successfully')).toBeNull();
+    // The unmet condition is what makes the negative actionable.
+    expect(screen.getByText('Not met: cpu_usage > 80 for 5min')).toBeTruthy();
+  });
+
+  it('states that a rule which would fire would fire', async () => {
+    mockApi(
+      jsonResponse({
+        rule: { id: RULE.id, name: RULE.name, severity: 'high', enabled: true },
+        device: { id: DEVICE.id, hostname: DEVICE.hostname, osType: 'windows' },
+        targetMatch: true,
+        targetReason: 'Rule applies to all devices',
+        conditionResults: [
+          {
+            condition: 'cpu_usage > 80 for 5min',
+            result: true,
+            reason: 'cpu_usage > 80 for 5min',
+          },
+        ],
+        wouldTrigger: true,
+        testedAt: '2026-08-23T00:00:00.000Z',
+      })
+    );
+
+    await runTest();
+
+    expect(await screen.findByText('Rule would fire')).toBeTruthy();
+    expect(screen.queryByText('Rule would not fire')).toBeNull();
+    expect(screen.getByText('Met: cpu_usage > 80 for 5min')).toBeTruthy();
+  });
+
+  it('explains a negative caused by targeting rather than by conditions', async () => {
+    mockApi(
+      jsonResponse({
+        rule: { id: RULE.id, name: RULE.name, severity: 'high', enabled: true },
+        device: { id: DEVICE.id, hostname: DEVICE.hostname, osType: 'windows' },
+        targetMatch: false,
+        targetReason: 'Device is not a member of the targeted device group',
+        conditionResults: [
+          {
+            condition: 'cpu_usage > 80 for 5min',
+            result: true,
+            reason: 'cpu_usage > 80 for 5min',
+          },
+        ],
+        wouldTrigger: false,
+        testedAt: '2026-08-23T00:00:00.000Z',
+      })
+    );
+
+    await runTest();
+
+    expect(await screen.findByText('Rule would not fire')).toBeTruthy();
+    expect(
+      screen.getByText('Device is not a member of the targeted device group')
+    ).toBeTruthy();
+  });
+
+  it('says a disabled rule will not fire', async () => {
+    mockApi(
+      jsonResponse({
+        rule: { id: RULE.id, name: RULE.name, severity: 'high', enabled: false },
+        device: { id: DEVICE.id, hostname: DEVICE.hostname, osType: 'windows' },
+        targetMatch: true,
+        targetReason: 'Rule applies to all devices',
+        conditionResults: [],
+        wouldTrigger: false,
+        testedAt: '2026-08-23T00:00:00.000Z',
+      })
+    );
+
+    await runTest();
+
+    expect(await screen.findByText('Rule would not fire')).toBeTruthy();
+    expect(
+      screen.getByText('This rule is disabled, so it will not fire until you enable it.')
+    ).toBeTruthy();
+  });
+
+  // A body with no verdict in it is a failure to report, not a pass to assume.
+  it('reports a failure when the response carries no verdict', async () => {
+    mockApi(jsonResponse({ testedAt: '2026-08-23T00:00:00.000Z' }));
+
+    await runTest();
+
+    expect(await screen.findByText('Test Failed')).toBeTruthy();
+    expect(screen.queryByText('Rule would fire')).toBeNull();
+    expect(screen.queryByText('Test Passed')).toBeNull();
+  });
+
+  it('reports a failure when the request fails', async () => {
+    mockApi(jsonResponse({ error: 'Device not found' }, false, 404));
+
+    await runTest();
+
+    expect(await screen.findByText('Test Failed')).toBeTruthy();
+    expect(screen.getByText('Device not found')).toBeTruthy();
+    expect(screen.queryByText('Rule would fire')).toBeNull();
+  });
+
+  // The endpoint validates `{ deviceId }` as a required body. The old handler
+  // sent no body at all, so every test 400'd before reaching any evaluation.
+  it('sends the selected deviceId with the test request', async () => {
+    mockApi(
+      jsonResponse({
+        rule: { id: RULE.id, name: RULE.name, severity: 'high', enabled: true },
+        device: { id: DEVICE.id, hostname: DEVICE.hostname, osType: 'windows' },
+        targetMatch: true,
+        conditionResults: [],
+        wouldTrigger: true,
+        testedAt: '2026-08-23T00:00:00.000Z',
+      })
+    );
+
+    await runTest();
+
+    await waitFor(() => expect(testRequestBodies).toHaveLength(1));
+    expect(JSON.parse(testRequestBodies[0])).toEqual({ deviceId: DEVICE.id });
+  });
+
+  it('does not render a negative verdict identically to a positive one', async () => {
+    const body = (wouldTrigger: boolean) => ({
+      rule: { id: RULE.id, name: RULE.name, severity: 'high', enabled: true },
+      device: { id: DEVICE.id, hostname: DEVICE.hostname, osType: 'windows' },
+      targetMatch: true,
+      targetReason: 'Rule applies to all devices',
+      conditionResults: [
+        { condition: 'cpu_usage > 80 for 5min', result: wouldTrigger, reason: 'cpu_usage > 80 for 5min' },
+      ],
+      wouldTrigger,
+      testedAt: '2026-08-23T00:00:00.000Z',
+    });
+
+    mockApi(jsonResponse(body(true)));
+    const { container: passing, unmount } = render(<AlertRulesPage />);
+    fireEvent.click((await screen.findAllByTitle('Test rule'))[0]);
+    fireEvent.change(await screen.findByLabelText('Test against device'), {
+      target: { value: DEVICE.id },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Run Test' }));
+    await screen.findByText('Rule would fire');
+    const passingText = passing.textContent ?? '';
+    unmount();
+
+    mockApi(jsonResponse(body(false)));
+    const { container: failing } = render(<AlertRulesPage />);
+    fireEvent.click((await screen.findAllByTitle('Test rule'))[0]);
+    fireEvent.change(await screen.findByLabelText('Test against device'), {
+      target: { value: DEVICE.id },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Run Test' }));
+    await screen.findByText('Rule would not fire');
+
+    expect(failing.textContent).not.toEqual(passingText);
+  });
+});

--- a/apps/web/src/components/alerts/AlertRulesPage.tsx
+++ b/apps/web/src/components/alerts/AlertRulesPage.tsx
@@ -12,6 +12,30 @@ import { asList } from '@/lib/asList';
 
 type ModalMode = 'closed' | 'delete' | 'test';
 
+type TestConditionResult = { condition: string; result: boolean; reason: string };
+
+/**
+ * The verdict the API actually returns for POST /alerts/rules/:id/test.
+ * `wouldTrigger` is the same boolean the firing path computes; `targetMatch`
+ * and `conditionResults` explain it. There is deliberately no `success` /
+ * `message` pair here — reading those invented fields is what made every test
+ * report "Test Passed" (#3752).
+ */
+type RuleTestVerdict = {
+  wouldTrigger: boolean;
+  targetMatch: boolean;
+  targetReason?: string;
+  conditionResults: TestConditionResult[];
+  rule?: { enabled?: boolean };
+  device?: { hostname?: string };
+};
+
+type TestState =
+  | { status: 'error'; message: string }
+  | { status: 'verdict'; verdict: RuleTestVerdict };
+
+type TestDevice = { id: string; name: string };
+
 export default function AlertRulesPage() {
   const { t } = useTranslation('alerts');
   const [rules, setRules] = useState<AlertRule[]>([]);
@@ -20,7 +44,11 @@ export default function AlertRulesPage() {
   const [modalMode, setModalMode] = useState<ModalMode>('closed');
   const [selectedRule, setSelectedRule] = useState<AlertRule | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [testResult, setTestResult] = useState<TestState | null>(null);
+  const [testDevices, setTestDevices] = useState<TestDevice[]>([]);
+  const [devicesLoading, setDevicesLoading] = useState(false);
+  const [devicesError, setDevicesError] = useState<string>();
+  const [testDeviceId, setTestDeviceId] = useState('');
 
   const fetchRules = useCallback(async () => {
     try {
@@ -57,15 +85,50 @@ export default function AlertRulesPage() {
     setModalMode('delete');
   };
 
+  // The endpoint evaluates a rule against ONE device and requires a deviceId
+  // body, so the modal has to ask which device before it can test anything.
   const handleTest = async (rule: AlertRule) => {
     setSelectedRule(rule);
     setTestResult(null);
+    setTestDeviceId('');
+    setDevicesError(undefined);
     setModalMode('test');
+
+    setDevicesLoading(true);
+    try {
+      const response = await fetchWithAuth('/devices');
+      if (!response.ok) {
+        if (response.status === 401) {
+          void navigateTo('/login', { replace: true });
+          return;
+        }
+        const errData = await response.json().catch(() => null);
+        throw new Error(extractApiError(errData, t('alertRulesPage.failedToLoadDevices')));
+      }
+      const data = await response.json();
+      setTestDevices(
+        asList(data, 'devices').map((d: { id: string; hostname?: string; displayName?: string }) => ({
+          id: d.id,
+          name: d.displayName || d.hostname || d.id
+        }))
+      );
+    } catch (err) {
+      setDevicesError(err instanceof Error ? err.message : t('alertRulesPage.failedToLoadDevices'));
+    } finally {
+      setDevicesLoading(false);
+    }
+  };
+
+  const handleRunTest = async () => {
+    if (!selectedRule || !testDeviceId) return;
+
+    setTestResult(null);
     setSubmitting(true);
 
     try {
-      const response = await fetchWithAuth(`/alerts/rules/${rule.id}/test`, {
-        method: 'POST'
+      const response = await fetchWithAuth(`/alerts/rules/${selectedRule.id}/test`, {
+        method: 'POST',
+        body: JSON.stringify({ deviceId: testDeviceId })
       });
 
       if (!response.ok) {
@@ -74,18 +137,36 @@ export default function AlertRulesPage() {
           return;
         }
         const errData = await response.json().catch(() => null);
-        throw new Error(extractApiError(errData, 'Failed to test rule'));
+        throw new Error(extractApiError(errData, t('alertRulesPage.failedToTestRule')));
       }
 
-      const data = await response.json();
+      // Read the verdict the server actually computes. `wouldTrigger` is the
+      // boolean the firing path uses; a rule that would not fire must never
+      // render as a pass (#3752).
+      const data = (await response.json()) as Partial<RuleTestVerdict>;
+
+      // A response with no verdict in it is a failure to report, not a pass to
+      // assume. The previous code defaulted the missing field to `true`, which
+      // is exactly how every test came back green.
+      if (typeof data.wouldTrigger !== 'boolean') {
+        throw new Error(t('alertRulesPage.testVerdictMissing'));
+      }
+
       setTestResult({
-        success: data.success ?? true,
-        message: data.message ?? 'Test completed successfully'
+        status: 'verdict',
+        verdict: {
+          wouldTrigger: data.wouldTrigger,
+          targetMatch: data.targetMatch === true,
+          targetReason: data.targetReason,
+          conditionResults: Array.isArray(data.conditionResults) ? data.conditionResults : [],
+          rule: data.rule,
+          device: data.device
+        }
       });
     } catch (err) {
       setTestResult({
-        success: false,
-        message: err instanceof Error ? err.message : 'An error occurred'
+        status: 'error',
+        message: err instanceof Error ? err.message : t('alertRulesPage.anErrorOccurred')
       });
     } finally {
       setSubmitting(false);
@@ -120,6 +201,9 @@ export default function AlertRulesPage() {
     setModalMode('closed');
     setSelectedRule(null);
     setTestResult(null);
+    setTestDevices([]);
+    setTestDeviceId('');
+    setDevicesError(undefined);
   };
 
   const handleConfirmDelete = async () => {
@@ -269,32 +353,102 @@ export default function AlertRulesPage() {
             <p className="mt-2 text-sm text-muted-foreground">
               {t('alertRulesPage.testing')} <span className="font-medium">{selectedRule.name}</span>
             </p>
+
+            <div className="mt-4">
+              <label htmlFor="test-rule-device" className="block text-sm font-medium">
+                {t('alertRulesPage.testAgainstDevice')}
+              </label>
+              <select
+                id="test-rule-device"
+                value={testDeviceId}
+                disabled={devicesLoading || submitting}
+                onChange={(e) => setTestDeviceId(e.target.value)}
+                className="mt-1 h-10 w-full rounded-md border bg-background px-3 text-sm disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <option value="">
+                  {devicesLoading
+                    ? t('alertRulesPage.loadingDevices')
+                    : t('alertRulesPage.selectADevice')}
+                </option>
+                {testDevices.map((device) => (
+                  <option key={device.id} value={device.id}>
+                    {device.name}
+                  </option>
+                ))}
+              </select>
+              {devicesError && (
+                <p className="mt-2 text-sm text-destructive">{devicesError}</p>
+              )}
+              {!devicesLoading && !devicesError && testDevices.length === 0 && (
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {t('alertRulesPage.noDevicesAvailable')}
+                </p>
+              )}
+            </div>
+
             {submitting ? (
               <div className="mt-4 flex items-center gap-2">
                 <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
                 <span className="text-sm">{t('alertRulesPage.runningTest')}</span>
               </div>
-            ) : testResult ? (
+            ) : testResult?.status === 'error' ? (
+              <div className="mt-4 rounded-md border border-red-500/40 bg-red-500/10 p-3 text-red-700">
+                <p className="text-sm font-medium">{t('alertRulesPage.testFailed')}</p>
+                <p className="mt-1 text-sm">{testResult.message}</p>
+              </div>
+            ) : testResult?.status === 'verdict' ? (
               <div
                 className={`mt-4 rounded-md border p-3 ${
-                  testResult.success
+                  testResult.verdict.wouldTrigger
                     ? 'border-green-500/40 bg-green-500/10 text-green-700'
-                    : 'border-red-500/40 bg-red-500/10 text-red-700'
+                    : 'border-amber-500/40 bg-amber-500/10 text-amber-700'
                 }`}
               >
                 <p className="text-sm font-medium">
-                  {testResult.success ? 'Test Passed' : 'Test Failed'}
+                  {testResult.verdict.wouldTrigger
+                    ? t('alertRulesPage.ruleWouldFire')
+                    : t('alertRulesPage.ruleWouldNotFire')}
                 </p>
-                <p className="text-sm mt-1">{testResult.message}</p>
+
+                {testResult.verdict.rule?.enabled === false && (
+                  <p className="mt-1 text-sm">{t('alertRulesPage.ruleIsDisabled')}</p>
+                )}
+
+                {testResult.verdict.targetReason && (
+                  <p className="mt-1 text-sm">{testResult.verdict.targetReason}</p>
+                )}
+
+                {testResult.verdict.conditionResults.length > 0 ? (
+                  <ul className="mt-2 space-y-1">
+                    {testResult.verdict.conditionResults.map((condition, index) => (
+                      <li key={`${condition.condition}-${index}`} className="text-sm">
+                        {condition.result
+                          ? t('alertRulesPage.conditionMet', { condition: condition.reason })
+                          : t('alertRulesPage.conditionNotMet', { condition: condition.reason })}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="mt-1 text-sm">{t('alertRulesPage.noConditionsEvaluated')}</p>
+                )}
               </div>
             ) : null}
-            <div className="mt-6 flex justify-end">
+
+            <div className="mt-6 flex justify-end gap-3">
               <button
                 type="button"
                 onClick={handleCloseModal}
                 className="h-10 rounded-md border px-4 text-sm font-medium transition hover:bg-muted"
               >
                 {t('alertRulesPage.close')}
+              </button>
+              <button
+                type="button"
+                onClick={handleRunTest}
+                disabled={!testDeviceId || submitting || devicesLoading}
+                className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {t('alertRulesPage.runTest')}
               </button>
             </div>
           </div>

--- a/apps/web/src/components/alerts/AlertRulesPage.tsx
+++ b/apps/web/src/components/alerts/AlertRulesPage.tsx
@@ -16,10 +16,16 @@ type TestConditionResult = { condition: string; result: boolean; reason: string 
 
 /**
  * The verdict the API actually returns for POST /alerts/rules/:id/test.
- * `wouldTrigger` is the same boolean the firing path computes; `targetMatch`
- * and `conditionResults` explain it. There is deliberately no `success` /
- * `message` pair here — reading those invented fields is what made every test
- * report "Test Passed" (#3752).
+ *
+ * `wouldTrigger` mirrors the condition + target evaluation the firing path
+ * performs (`isActive && targetMatch && evaluation.triggered`); `targetMatch`
+ * and `conditionResults` explain it. It is NOT a promise that an alert row
+ * appears: `createAlert()` additionally applies cooldown, open-alert dedup and
+ * flapping suppression, which this endpoint does not simulate — hence the
+ * caveat rendered alongside a positive verdict.
+ *
+ * There is deliberately no `success` / `message` pair here — reading those
+ * invented fields is what made every test report "Test Passed" (#3752).
  */
 type RuleTestVerdict = {
   wouldTrigger: boolean;
@@ -362,7 +368,13 @@ export default function AlertRulesPage() {
                 id="test-rule-device"
                 value={testDeviceId}
                 disabled={devicesLoading || submitting}
-                onChange={(e) => setTestDeviceId(e.target.value)}
+                onChange={(e) => {
+                  // Drop the previous verdict: it belongs to the device that
+                  // was selected when it was computed. Leaving it on screen
+                  // beside a new selection is the same lie in a new costume.
+                  setTestResult(null);
+                  setTestDeviceId(e.target.value);
+                }}
                 className="mt-1 h-10 w-full rounded-md border bg-background px-3 text-sm disabled:cursor-not-allowed disabled:opacity-60"
               >
                 <option value="">
@@ -409,6 +421,20 @@ export default function AlertRulesPage() {
                     ? t('alertRulesPage.ruleWouldFire')
                     : t('alertRulesPage.ruleWouldNotFire')}
                 </p>
+
+                {/* Name the device the verdict was computed for, so a verdict
+                    can never be read as belonging to a different selection. */}
+                {testResult.verdict.device?.hostname && (
+                  <p className="mt-1 text-sm">
+                    {t('alertRulesPage.evaluatedAgainst', {
+                      hostname: testResult.verdict.device.hostname
+                    })}
+                  </p>
+                )}
+
+                {testResult.verdict.wouldTrigger && (
+                  <p className="mt-1 text-sm">{t('alertRulesPage.fireSuppressionNote')}</p>
+                )}
 
                 {testResult.verdict.rule?.enabled === false && (
                   <p className="mt-1 text-sm">{t('alertRulesPage.ruleIsDisabled')}</p>

--- a/apps/web/src/locales/de-DE/alerts.json
+++ b/apps/web/src/locales/de-DE/alerts.json
@@ -423,7 +423,9 @@
     "ruleIsDisabled": "Diese Regel ist deaktiviert und wird daher nicht ausgelöst, bis Sie sie aktivieren.",
     "conditionMet": "Erfüllt: {{condition}}",
     "conditionNotMet": "Nicht erfüllt: {{condition}}",
-    "noConditionsEvaluated": "Für diese Regel wurden keine Bedingungen ausgewertet."
+    "noConditionsEvaluated": "Für diese Regel wurden keine Bedingungen ausgewertet.",
+    "evaluatedAgainst": "Gegen {{hostname}} ausgewertet",
+    "fireSuppressionNote": "Cooldown, eine bereits offene Warnung oder eine Flapping-Unterdrückung können weiterhin verhindern, dass beim Ausführen der Regel eine Warnung ausgelöst wird."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Benachrichtigungsvorlage wird geladen...",

--- a/apps/web/src/locales/de-DE/alerts.json
+++ b/apps/web/src/locales/de-DE/alerts.json
@@ -366,6 +366,7 @@
   "alertRuleList": {
     "editRule": "Regel bearbeiten",
     "deleteRule": "Regel löschen",
+    "testRule": "Regel testen",
     "alertRules": "Alarmregeln",
     "of": "von",
     "rules": "Regeln",
@@ -406,7 +407,23 @@
     "deletionCancelled": "Löschung der Warnungsregel abgebrochen",
     "testing": "Testen",
     "runningTest": "Test wird ausgeführt...",
-    "close": "Schließen"
+    "close": "Schließen",
+    "failedToLoadDevices": "Geräte konnten nicht geladen werden",
+    "failedToTestRule": "Regel konnte nicht getestet werden",
+    "anErrorOccurred": "Ein Fehler ist aufgetreten",
+    "testVerdictMissing": "Der Server hat kein Testergebnis zurückgegeben, daher wurde diese Regel nicht überprüft.",
+    "testAgainstDevice": "Gegen Gerät testen",
+    "loadingDevices": "Geräte werden geladen...",
+    "selectADevice": "Gerät auswählen...",
+    "noDevicesAvailable": "Es sind keine Geräte verfügbar, um diese Regel zu testen.",
+    "runTest": "Test ausführen",
+    "testFailed": "Test fehlgeschlagen",
+    "ruleWouldFire": "Regel würde auslösen",
+    "ruleWouldNotFire": "Regel würde nicht auslösen",
+    "ruleIsDisabled": "Diese Regel ist deaktiviert und wird daher nicht ausgelöst, bis Sie sie aktivieren.",
+    "conditionMet": "Erfüllt: {{condition}}",
+    "conditionNotMet": "Nicht erfüllt: {{condition}}",
+    "noConditionsEvaluated": "Für diese Regel wurden keine Bedingungen ausgewertet."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Benachrichtigungsvorlage wird geladen...",

--- a/apps/web/src/locales/en/alerts.json
+++ b/apps/web/src/locales/en/alerts.json
@@ -423,7 +423,9 @@
     "ruleIsDisabled": "This rule is disabled, so it will not fire until you enable it.",
     "conditionMet": "Met: {{condition}}",
     "conditionNotMet": "Not met: {{condition}}",
-    "noConditionsEvaluated": "No conditions were evaluated for this rule."
+    "noConditionsEvaluated": "No conditions were evaluated for this rule.",
+    "evaluatedAgainst": "Evaluated against {{hostname}}",
+    "fireSuppressionNote": "Cooldown, an alert that is already open, or flapping suppression may still stop an alert being created when the rule runs."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Loading alert template...",

--- a/apps/web/src/locales/en/alerts.json
+++ b/apps/web/src/locales/en/alerts.json
@@ -366,6 +366,7 @@
   "alertRuleList": {
     "editRule": "Edit rule",
     "deleteRule": "Delete rule",
+    "testRule": "Test rule",
     "alertRules": "Alert Rules",
     "of": "of",
     "rules": "rules",
@@ -406,7 +407,23 @@
     "deletionCancelled": "Alert rule deletion cancelled",
     "testing": "Testing",
     "runningTest": "Running test...",
-    "close": "Close"
+    "close": "Close",
+    "failedToLoadDevices": "Failed to load devices",
+    "failedToTestRule": "Failed to test rule",
+    "anErrorOccurred": "An error occurred",
+    "testVerdictMissing": "The server did not return a test verdict, so this rule was not verified.",
+    "testAgainstDevice": "Test against device",
+    "loadingDevices": "Loading devices...",
+    "selectADevice": "Select a device...",
+    "noDevicesAvailable": "No devices are available to test this rule against.",
+    "runTest": "Run Test",
+    "testFailed": "Test Failed",
+    "ruleWouldFire": "Rule would fire",
+    "ruleWouldNotFire": "Rule would not fire",
+    "ruleIsDisabled": "This rule is disabled, so it will not fire until you enable it.",
+    "conditionMet": "Met: {{condition}}",
+    "conditionNotMet": "Not met: {{condition}}",
+    "noConditionsEvaluated": "No conditions were evaluated for this rule."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Loading alert template...",

--- a/apps/web/src/locales/es-419/alerts.json
+++ b/apps/web/src/locales/es-419/alerts.json
@@ -366,6 +366,7 @@
   "alertRuleList": {
     "editRule": "Editar regla",
     "deleteRule": "Eliminar regla",
+    "testRule": "Probar regla",
     "alertRules": "Reglas de alerta",
     "of": "de",
     "rules": "normas",
@@ -406,7 +407,23 @@
     "deletionCancelled": "Eliminación de regla de alerta cancelada",
     "testing": "Probando",
     "runningTest": "Ejecutando prueba...",
-    "close": "Cerrar"
+    "close": "Cerrar",
+    "failedToLoadDevices": "No se pudieron cargar los dispositivos",
+    "failedToTestRule": "No se pudo probar la regla",
+    "anErrorOccurred": "Se produjo un error",
+    "testVerdictMissing": "El servidor no devolvió un resultado de prueba, por lo que esta regla no se verificó.",
+    "testAgainstDevice": "Probar con un dispositivo",
+    "loadingDevices": "Cargando dispositivos...",
+    "selectADevice": "Seleccione un dispositivo...",
+    "noDevicesAvailable": "No hay dispositivos disponibles para probar esta regla.",
+    "runTest": "Ejecutar prueba",
+    "testFailed": "Prueba fallida",
+    "ruleWouldFire": "La regla se activaría",
+    "ruleWouldNotFire": "La regla no se activaría",
+    "ruleIsDisabled": "Esta regla está deshabilitada, por lo que no se activará hasta que la habilite.",
+    "conditionMet": "Cumplida: {{condition}}",
+    "conditionNotMet": "No cumplida: {{condition}}",
+    "noConditionsEvaluated": "No se evaluó ninguna condición para esta regla."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Cargando plantilla de alerta...",

--- a/apps/web/src/locales/es-419/alerts.json
+++ b/apps/web/src/locales/es-419/alerts.json
@@ -423,7 +423,9 @@
     "ruleIsDisabled": "Esta regla está deshabilitada, por lo que no se activará hasta que la habilite.",
     "conditionMet": "Cumplida: {{condition}}",
     "conditionNotMet": "No cumplida: {{condition}}",
-    "noConditionsEvaluated": "No se evaluó ninguna condición para esta regla."
+    "noConditionsEvaluated": "No se evaluó ninguna condición para esta regla.",
+    "evaluatedAgainst": "Evaluado contra {{hostname}}",
+    "fireSuppressionNote": "El período de enfriamiento, una alerta que ya está abierta o la supresión por fluctuaciones (flapping) pueden seguir impidiendo que se cree una alerta cuando se ejecute la regla."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Cargando plantilla de alerta...",

--- a/apps/web/src/locales/fr-CA/alerts.json
+++ b/apps/web/src/locales/fr-CA/alerts.json
@@ -366,6 +366,7 @@
   "alertRuleList": {
     "editRule": "Modifier la règle",
     "deleteRule": "Supprimer la règle",
+    "testRule": "Tester la règle",
     "alertRules": "Règles d’alerte",
     "of": "de",
     "rules": "Règles",
@@ -406,7 +407,23 @@
     "deletionCancelled": "Suppression de la règle d’alerte annulée",
     "testing": "Essais",
     "runningTest": "En cours de test...",
-    "close": "Fermer"
+    "close": "Fermer",
+    "failedToLoadDevices": "Échec du chargement des appareils",
+    "failedToTestRule": "Échec du test de la règle",
+    "anErrorOccurred": "Une erreur s’est produite",
+    "testVerdictMissing": "Le serveur n’a pas renvoyé de résultat de test, cette règle n’a donc pas été vérifiée.",
+    "testAgainstDevice": "Tester sur un appareil",
+    "loadingDevices": "Chargement des appareils...",
+    "selectADevice": "Sélectionner un appareil...",
+    "noDevicesAvailable": "Aucun appareil n’est disponible pour tester cette règle.",
+    "runTest": "Exécuter le test",
+    "testFailed": "Échec du test",
+    "ruleWouldFire": "La règle se déclencherait",
+    "ruleWouldNotFire": "La règle ne se déclencherait pas",
+    "ruleIsDisabled": "Cette règle est désactivée ; elle ne se déclenchera donc pas tant que vous ne l’activerez pas.",
+    "conditionMet": "Remplie : {{condition}}",
+    "conditionNotMet": "Non remplie : {{condition}}",
+    "noConditionsEvaluated": "Aucune condition n’a été évaluée pour cette règle."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Chargement du modèle d’alerte...",

--- a/apps/web/src/locales/fr-CA/alerts.json
+++ b/apps/web/src/locales/fr-CA/alerts.json
@@ -423,7 +423,9 @@
     "ruleIsDisabled": "Cette règle est désactivée ; elle ne se déclenchera donc pas tant que vous ne l’activerez pas.",
     "conditionMet": "Remplie : {{condition}}",
     "conditionNotMet": "Non remplie : {{condition}}",
-    "noConditionsEvaluated": "Aucune condition n’a été évaluée pour cette règle."
+    "noConditionsEvaluated": "Aucune condition n’a été évaluée pour cette règle.",
+    "evaluatedAgainst": "Évalué par rapport à {{hostname}}",
+    "fireSuppressionNote": "Le cooldown, une alerte déjà ouverte ou la suppression du flapping peuvent quand même empêcher la création d’une alerte lorsque la règle s’exécute."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Chargement du modèle d’alerte...",

--- a/apps/web/src/locales/fr-FR/alerts.json
+++ b/apps/web/src/locales/fr-FR/alerts.json
@@ -366,6 +366,7 @@
   "alertRuleList": {
     "editRule": "Modifier la règle",
     "deleteRule": "Supprimer la règle",
+    "testRule": "Tester la règle",
     "alertRules": "Règles d’alerte",
     "of": "de",
     "rules": "Règles",
@@ -406,7 +407,23 @@
     "deletionCancelled": "Suppression de la règle d’alerte annulée",
     "testing": "Essais",
     "runningTest": "En cours de test...",
-    "close": "Fermer"
+    "close": "Fermer",
+    "failedToLoadDevices": "Échec du chargement des appareils",
+    "failedToTestRule": "Échec du test de la règle",
+    "anErrorOccurred": "Une erreur s’est produite",
+    "testVerdictMissing": "Le serveur n’a pas renvoyé de résultat de test, cette règle n’a donc pas été vérifiée.",
+    "testAgainstDevice": "Tester sur un appareil",
+    "loadingDevices": "Chargement des appareils...",
+    "selectADevice": "Sélectionner un appareil...",
+    "noDevicesAvailable": "Aucun appareil n’est disponible pour tester cette règle.",
+    "runTest": "Exécuter le test",
+    "testFailed": "Échec du test",
+    "ruleWouldFire": "La règle se déclencherait",
+    "ruleWouldNotFire": "La règle ne se déclencherait pas",
+    "ruleIsDisabled": "Cette règle est désactivée ; elle ne se déclenchera donc pas tant que vous ne l’activerez pas.",
+    "conditionMet": "Remplie : {{condition}}",
+    "conditionNotMet": "Non remplie : {{condition}}",
+    "noConditionsEvaluated": "Aucune condition n’a été évaluée pour cette règle."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Chargement du modèle d’alerte...",

--- a/apps/web/src/locales/fr-FR/alerts.json
+++ b/apps/web/src/locales/fr-FR/alerts.json
@@ -423,7 +423,9 @@
     "ruleIsDisabled": "Cette règle est désactivée ; elle ne se déclenchera donc pas tant que vous ne l’activerez pas.",
     "conditionMet": "Remplie : {{condition}}",
     "conditionNotMet": "Non remplie : {{condition}}",
-    "noConditionsEvaluated": "Aucune condition n’a été évaluée pour cette règle."
+    "noConditionsEvaluated": "Aucune condition n’a été évaluée pour cette règle.",
+    "evaluatedAgainst": "Évalué par rapport à {{hostname}}",
+    "fireSuppressionNote": "Le cooldown, une alerte déjà ouverte ou la suppression du flapping peuvent quand même empêcher la création d’une alerte lorsque la règle s’exécute."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Chargement du modèle d’alerte...",

--- a/apps/web/src/locales/it-IT/alerts.json
+++ b/apps/web/src/locales/it-IT/alerts.json
@@ -423,7 +423,9 @@
     "ruleIsDisabled": "Questa regola è disattivata, quindi non si attiverà finché non la abiliti.",
     "conditionMet": "Soddisfatta: {{condition}}",
     "conditionNotMet": "Non soddisfatta: {{condition}}",
-    "noConditionsEvaluated": "Per questa regola non è stata valutata alcuna condizione."
+    "noConditionsEvaluated": "Per questa regola non è stata valutata alcuna condizione.",
+    "evaluatedAgainst": "Valutato rispetto a {{hostname}}",
+    "fireSuppressionNote": "Il cooldown, un avviso già aperto o la soppressione per flapping potrebbero comunque impedire che venga creato un avviso quando la regola viene eseguita."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Caricamento modello avviso...",

--- a/apps/web/src/locales/it-IT/alerts.json
+++ b/apps/web/src/locales/it-IT/alerts.json
@@ -366,6 +366,7 @@
   "alertRuleList": {
     "editRule": "Modifica regola",
     "deleteRule": "Elimina regola",
+    "testRule": "Testa regola",
     "alertRules": "Regole avviso",
     "of": "di",
     "rules": "regole",
@@ -406,7 +407,23 @@
     "deletionCancelled": "Eliminazione regola avviso annullata",
     "testing": "Test in corso",
     "runningTest": "Esecuzione test...",
-    "close": "Chiudi"
+    "close": "Chiudi",
+    "failedToLoadDevices": "Impossibile caricare i dispositivi",
+    "failedToTestRule": "Impossibile testare la regola",
+    "anErrorOccurred": "Si è verificato un errore",
+    "testVerdictMissing": "Il server non ha restituito un esito del test, quindi questa regola non è stata verificata.",
+    "testAgainstDevice": "Testa su un dispositivo",
+    "loadingDevices": "Caricamento dispositivi...",
+    "selectADevice": "Seleziona un dispositivo...",
+    "noDevicesAvailable": "Non ci sono dispositivi disponibili per testare questa regola.",
+    "runTest": "Esegui test",
+    "testFailed": "Test non riuscito",
+    "ruleWouldFire": "La regola si attiverebbe",
+    "ruleWouldNotFire": "La regola non si attiverebbe",
+    "ruleIsDisabled": "Questa regola è disattivata, quindi non si attiverà finché non la abiliti.",
+    "conditionMet": "Soddisfatta: {{condition}}",
+    "conditionNotMet": "Non soddisfatta: {{condition}}",
+    "noConditionsEvaluated": "Per questa regola non è stata valutata alcuna condizione."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Caricamento modello avviso...",

--- a/apps/web/src/locales/pt-BR/alerts.json
+++ b/apps/web/src/locales/pt-BR/alerts.json
@@ -423,7 +423,9 @@
     "ruleIsDisabled": "Esta regra está desativada, portanto não será disparada até que você a ative.",
     "conditionMet": "Atendida: {{condition}}",
     "conditionNotMet": "Não atendida: {{condition}}",
-    "noConditionsEvaluated": "Nenhuma condição foi avaliada para esta regra."
+    "noConditionsEvaluated": "Nenhuma condição foi avaliada para esta regra.",
+    "evaluatedAgainst": "Avaliado em relação a {{hostname}}",
+    "fireSuppressionNote": "O período de espera (cooldown), um alerta que já está aberto ou a supressão de oscilação (flapping) ainda podem impedir a criação de um alerta quando a regra for executada."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Carregando modelo de alerta...",

--- a/apps/web/src/locales/pt-BR/alerts.json
+++ b/apps/web/src/locales/pt-BR/alerts.json
@@ -366,6 +366,7 @@
   "alertRuleList": {
     "editRule": "Editar regra",
     "deleteRule": "Excluir regra",
+    "testRule": "Testar regra",
     "alertRules": "Regras de alerta",
     "of": "de",
     "rules": "regras",
@@ -406,7 +407,23 @@
     "deletionCancelled": "Exclusão da regra de alerta cancelada",
     "testing": "Testando",
     "runningTest": "Executando teste...",
-    "close": "Fechar"
+    "close": "Fechar",
+    "failedToLoadDevices": "Falha ao carregar dispositivos",
+    "failedToTestRule": "Falha ao testar a regra",
+    "anErrorOccurred": "Ocorreu um erro",
+    "testVerdictMissing": "O servidor não retornou um resultado de teste, portanto esta regra não foi verificada.",
+    "testAgainstDevice": "Testar em um dispositivo",
+    "loadingDevices": "Carregando dispositivos...",
+    "selectADevice": "Selecione um dispositivo...",
+    "noDevicesAvailable": "Não há dispositivos disponíveis para testar esta regra.",
+    "runTest": "Executar teste",
+    "testFailed": "Teste falhou",
+    "ruleWouldFire": "A regra seria disparada",
+    "ruleWouldNotFire": "A regra não seria disparada",
+    "ruleIsDisabled": "Esta regra está desativada, portanto não será disparada até que você a ative.",
+    "conditionMet": "Atendida: {{condition}}",
+    "conditionNotMet": "Não atendida: {{condition}}",
+    "noConditionsEvaluated": "Nenhuma condição foi avaliada para esta regra."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Carregando modelo de alerta...",

--- a/apps/web/src/locales/tr-TR/alerts.json
+++ b/apps/web/src/locales/tr-TR/alerts.json
@@ -366,6 +366,7 @@
   "alertRuleList": {
     "editRule": "Kuralı düzenle",
     "deleteRule": "Kuralı sil",
+    "testRule": "Kuralı test et",
     "alertRules": "Uyarı Kuralları",
     "of": "arasında",
     "rules": "kuralları",
@@ -406,7 +407,23 @@
     "deletionCancelled": "Uyarı kuralının silinmesi iptal edildi",
     "testing": "Test ediliyor",
     "runningTest": "Test çalıştırılıyor...",
-    "close": "Kapat"
+    "close": "Kapat",
+    "failedToLoadDevices": "Cihazlar yüklenemedi",
+    "failedToTestRule": "Kural test edilemedi",
+    "anErrorOccurred": "Bir hata oluştu",
+    "testVerdictMissing": "Sunucu bir test sonucu döndürmedi, bu nedenle bu kural doğrulanmadı.",
+    "testAgainstDevice": "Cihaza karşı test et",
+    "loadingDevices": "Cihazlar yükleniyor...",
+    "selectADevice": "Bir cihaz seçin...",
+    "noDevicesAvailable": "Bu kuralı test etmek için kullanılabilir cihaz yok.",
+    "runTest": "Testi Çalıştır",
+    "testFailed": "Test Başarısız",
+    "ruleWouldFire": "Kural tetiklenir",
+    "ruleWouldNotFire": "Kural tetiklenmez",
+    "ruleIsDisabled": "Bu kural devre dışı, bu nedenle siz etkinleştirene kadar tetiklenmeyecek.",
+    "conditionMet": "Karşılandı: {{condition}}",
+    "conditionNotMet": "Karşılanmadı: {{condition}}",
+    "noConditionsEvaluated": "Bu kural için hiçbir koşul değerlendirilmedi."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Uyarı şablonu yükleniyor...",

--- a/apps/web/src/locales/tr-TR/alerts.json
+++ b/apps/web/src/locales/tr-TR/alerts.json
@@ -423,7 +423,9 @@
     "ruleIsDisabled": "Bu kural devre dışı, bu nedenle siz etkinleştirene kadar tetiklenmeyecek.",
     "conditionMet": "Karşılandı: {{condition}}",
     "conditionNotMet": "Karşılanmadı: {{condition}}",
-    "noConditionsEvaluated": "Bu kural için hiçbir koşul değerlendirilmedi."
+    "noConditionsEvaluated": "Bu kural için hiçbir koşul değerlendirilmedi.",
+    "evaluatedAgainst": "{{hostname}} için değerlendirildi",
+    "fireSuppressionNote": "Bekleme süresi (cooldown), zaten açık olan bir uyarı veya çalkalanma (flapping) bastırma, kural çalıştığında bir uyarı oluşturulmasını yine de engelleyebilir."
   },
   "alertTemplateEditor": {
     "loadingAlertTemplate": "Uyarı şablonu yükleniyor...",


### PR DESCRIPTION
Closes #3752

## The bug

`AlertRulesPage.tsx` read `data.success` and `data.message` from `POST /alerts/rules/:id/test`. The endpoint returns neither, so `data.success ?? true` fired on every 200 and the modal rendered a green **"Test Passed — Test completed successfully"** whatever the evaluation concluded. `wouldTrigger` and `conditionResults` — the fields carrying the actual verdict — were read nowhere in the file.

## Why this could not be fixed client-side

Picking up @bdunncompany's analysis in the issue thread: gating the UI on `wouldTrigger` as written would have replaced a fabricated green with a fabricated red, because the endpoint did not compute a verdict. Confirmed against `origin/main` and fixed here. Five defects in the same handler:

| Defect | Effect |
|---|---|
| Condition evaluation was simulated — `result: false` pushed for every top-level key of `template.conditions` | The verdict was a function of key count, not device state. No rule carrying a condition could ever report that it would fire |
| Read `template.conditions` directly | The firing path resolves `overrideSettings.conditions ?? template.conditions` (`alertService.ts`), so an override-conditioned rule was tested against conditions it does not use |
| `targetMatch` only evaluated for `targetType === 'device'` | Every other target type started `true` and stayed `true` — an unevaluated match reported as a match |
| `wouldTrigger = targetMatch && conditionResults.every(r => r.result)` | Wrong verdict function for an OR group, which can trigger with conditions unmet |
| `alertRules.isActive` ignored | A disabled rule — filtered out by `getApplicableRules`, so it never fires — could report that it would |

And two reachability defects that meant the feature had never worked end to end:

- The client sent **no body**, while the route validates `{ deviceId: z.string().guid() }` as required — so every test 400'd before reaching any logic. What users saw was a red failure on every test, not the green one described in the issue; the fabrication became reachable the moment a body was supplied.
- `AlertRuleList` accepted an `onTest` prop it **never rendered**. There was no Test button in the UI at all, so the modal was unreachable.

## The fix

**API** (`apps/api/src/routes/alerts/rules.ts`) — compute a real verdict:

- Run the production `evaluateConditions()` against the **effective** conditions (`overrideSettings.conditions ?? template.conditions`), mirroring `getApplicableRules`.
- Match targets the way the firing path does: `all` / `org` / `site` / `group` (real `device_group_memberships` lookup) / `device`.
- `wouldTrigger = rule.isActive && targetMatch && evaluation.triggered`.
- Response gains `targetReason`, real `conditionResults`, `evaluationContext` (metric / actual value / threshold, so a negative is actionable), effective severity, and `rule.enabled`. No `success` / `message` keys are introduced — the client now reads what the server actually computes.

**Web** (`AlertRulesPage.tsx`, `AlertRuleList.tsx`):

- Test modal asks which device to evaluate against and sends `{ deviceId }`.
- Three distinct states instead of two: request failed / **Rule would fire** / **Rule would not fire**, the latter listing the unmet conditions and the targeting reason.
- A 200 whose body carries no `wouldTrigger` boolean is surfaced as a **failure**, not assumed to be a pass — that defaulting is the whole bug.
- `AlertRuleList` renders a Test action wired to the existing `onTest` prop.
- 17 new `alerts` i18n keys, translated across all 8 locales (parity suite green).

## Notes for review

- **`runAction` not wired here, deliberately.** `AlertRulesPage.tsx` stays on `RUN_ACTION_MIGRATION_BACKLOG`: the verdict is a three-state inline render in a modal, not a toast, and its other mutation handlers are unmigrated so the file cannot leave the backlog in this PR. Failures are surfaced inline, never silently. `runAction.ts` / `runActionAllowlist.ts` are untouched to avoid conflicting with the in-flight #3697 fix.
- **Locale-file conflict risk:** the sibling #3697 PR also edits `apps/web/src/locales/*/alerts.json`. Whichever merges second will need a trivial JSON conflict resolution.
- **Pre-existing divergence, deliberately not changed:** `formatAlertRuleResponse` exposes multi-target rules via `overrides.targets.ids`, but `getApplicableRules` evaluates only the persisted `targetType`/`targetId` columns. This PR mirrors the evaluation path, so a rule with extra override target ids will honestly report "not targeted" for devices under those extra ids. That surfaces the real product behaviour rather than hiding it; worth a separate issue.

## Verification

- `apps/api` alerts routes: **15 files, 186 tests passed** (`vitest run --no-file-parallelism src/routes/alerts/`)
- `apps/web` alerts + locale parity + no-silent-mutations: **17 files, 295 tests passed**
- New `rules.testVerdict.test.ts` (13 tests): **9 fail against the pre-fix handler**, all pass after.
- New `AlertRulesPage.testVerdict.test.tsx` (8 tests): **all 8 fail against the pre-fix components**, all pass after.
- `tsc --noEmit` clean in `apps/api`; `astro check` **0 errors, 0 warnings** in `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)