### PR TITLE
fix(api,shared): source audit actor_type/result enums from shared constants (#3908)

### DIFF
--- a/apps/api/src/db/schema/audit.enums.test.ts
+++ b/apps/api/src/db/schema/audit.enums.test.ts
@@ -10,9 +10,15 @@
  * cannot reach: the Drizzle enum (a runtime call, verified below) and the
  * OpenAPI document, whose `enum:` arrays are plain JSON and had silently
  * drifted — `actor_type` was missing both `api_key` and `ai_agent`, and
- * `audit_result` was missing `denied` (#3908). The OpenAPI checks walk the
- * whole spec rather than pinning line numbers, so a THIRD hand-written site
- * added later fails here too. Mirrors ticketEnums.test.ts.
+ * `audit_result` was missing `denied` (#3908). The checks walk the document
+ * rather than pinning line numbers, so a THIRD hand-written site added later
+ * fails here too — whole-spec for `actorType`, scoped to the audit subtrees
+ * for the generically-named `result` (see the caveat on that test).
+ *
+ * What this suite does NOT cover: the live Postgres type. `enumValues` is just
+ * the array handed to `pgEnum`, so a widening that updates the constant but
+ * forgets the `ALTER TYPE ... ADD VALUE` migration still passes here.
+ * Mirrors ticketEnums.test.ts.
  */
 import { describe, it, expect } from 'vitest';
 import { auditQuerySchema, ACTOR_TYPES, AUDIT_RESULTS, type ActorType } from '@breeze/shared';

--- a/apps/api/src/db/schema/audit.enums.test.ts
+++ b/apps/api/src/db/schema/audit.enums.test.ts
@@ -19,10 +19,22 @@ import { auditQuerySchema, ACTOR_TYPES, AUDIT_RESULTS, type ActorType } from '@b
 import { actorTypeEnum, auditResultEnum } from './audit';
 import { openApiSpec } from '../../openapi';
 
-// Compile-time exhaustiveness: adding a value to the shared ActorType union
-// without listing it here is a type error, and vice versa via the runtime
-// comparison below.
-const SHARED_ACTOR_TYPES: readonly ActorType[] = ['user', 'api_key', 'agent', 'system', 'ai_agent'];
+// Real compile-time exhaustiveness. A `readonly ActorType[]` would NOT give us
+// this — TypeScript happily accepts an array literal that omits union members,
+// so the old annotation here only ever caught *extra* values. `satisfies
+// Record<ActorType, true>` catches both directions: a widened ActorType leaves
+// a key missing (error), and a stale key that is no longer an ActorType is an
+// excess property (error). Widening ACTOR_TYPES therefore fails to COMPILE
+// until this list is updated too, which is the point.
+const ACTOR_TYPE_EXPECTATIONS = {
+  user: true,
+  api_key: true,
+  agent: true,
+  system: true,
+  ai_agent: true
+} satisfies Record<ActorType, true>;
+
+const SHARED_ACTOR_TYPES = Object.keys(ACTOR_TYPE_EXPECTATIONS) as ActorType[];
 
 /**
  * Collect every `enum: [...]` array in the OpenAPI document that describes the
@@ -103,8 +115,12 @@ describe('actor_type enum parity (shared ↔ DB schema ↔ validators ↔ OpenAP
   });
 
   it('the audit result enums in the OpenAPI spec match the DB enum', () => {
-    // `result` is a generic key name elsewhere in the spec, so scope the walk to
-    // the two audit subtrees rather than searching the whole document.
+    // `result` is a generic key name elsewhere in the spec (e.g. the unrelated
+    // `result: { type: 'object' }` on the script-execution schema), so scope the
+    // walk to the two audit subtrees rather than searching the whole document.
+    // Trade-off vs. the actorType check above: an audit-adjacent endpoint added
+    // OUTSIDE these two subtrees with its own inline `result` enum would not be
+    // covered here — add its subtree below if that ever happens.
     const spec = openApiSpec as unknown as Record<string, unknown>;
     const components = spec.components as { schemas?: Record<string, unknown> } | undefined;
     const auditLogSchema = components?.schemas?.AuditLog;

--- a/apps/api/src/db/schema/audit.enums.test.ts
+++ b/apps/api/src/db/schema/audit.enums.test.ts
@@ -1,23 +1,84 @@
 /**
- * Enum parity for `actor_type`: unlike ActionIntentSource (defined once in
- * the schema file), the actor-type value set is hand-synced across the
- * Postgres enum, the shared TS type, the shared Zod validator and the local
- * union in services/auditEvents.ts. Wave 3a widened all of them with
- * 'ai_agent' by grep discipline — this test makes the NEXT widening loud
- * instead. Mirrors ticketEnums.test.ts.
+ * Enum parity for `actor_type` / `audit_result`.
+ *
+ * These value sets used to be hand-synced across the Postgres enum, the shared
+ * TS type, the shared Zod validator and the local union in
+ * services/auditEvents.ts. They now all derive from ACTOR_TYPES / AUDIT_RESULTS
+ * in @breeze/shared, so a widening is a one-line change at the source.
+ *
+ * This suite is the backstop for the surfaces that a `typeof X[number]` import
+ * cannot reach: the Drizzle enum (a runtime call, verified below) and the
+ * OpenAPI document, whose `enum:` arrays are plain JSON and had silently
+ * drifted — `actor_type` was missing both `api_key` and `ai_agent`, and
+ * `audit_result` was missing `denied` (#3908). The OpenAPI checks walk the
+ * whole spec rather than pinning line numbers, so a THIRD hand-written site
+ * added later fails here too. Mirrors ticketEnums.test.ts.
  */
 import { describe, it, expect } from 'vitest';
-import { auditQuerySchema, type ActorType } from '@breeze/shared';
+import { auditQuerySchema, ACTOR_TYPES, AUDIT_RESULTS, type ActorType } from '@breeze/shared';
 import { actorTypeEnum, auditResultEnum } from './audit';
+import { openApiSpec } from '../../openapi';
 
 // Compile-time exhaustiveness: adding a value to the shared ActorType union
 // without listing it here is a type error, and vice versa via the runtime
 // comparison below.
 const SHARED_ACTOR_TYPES: readonly ActorType[] = ['user', 'api_key', 'agent', 'system', 'ai_agent'];
 
-describe('actor_type enum parity (shared ↔ DB schema ↔ validators)', () => {
+/**
+ * Collect every `enum: [...]` array in the OpenAPI document that describes the
+ * named audit field, in either of the two shapes the spec uses:
+ *   - a component-schema property:  properties: { actorType: { enum: [...] } }
+ *   - a query parameter:            { name: 'actorType', schema: { enum: [...] } }
+ */
+function collectSpecEnums(root: unknown, field: string): string[][] {
+  const found: string[][] = [];
+  const seen = new Set<object>();
+
+  const enumOf = (node: unknown): string[] | undefined => {
+    if (!node || typeof node !== 'object') return undefined;
+    const e = (node as { enum?: unknown }).enum;
+    return Array.isArray(e) ? (e as string[]) : undefined;
+  };
+
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    if (seen.has(node as object)) return;
+    seen.add(node as object);
+
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+
+    const obj = node as Record<string, unknown>;
+
+    // Query-parameter shape: { name: '<field>', schema: { enum: [...] } }
+    if (obj.name === field) {
+      const e = enumOf(obj.schema) ?? enumOf(obj);
+      if (e) found.push(e);
+    }
+
+    for (const [key, value] of Object.entries(obj)) {
+      // Schema-property shape: properties: { '<field>': { enum: [...] } }
+      if (key === field) {
+        const e = enumOf(value);
+        if (e) found.push(e);
+      }
+      walk(value);
+    }
+  };
+
+  walk(root);
+  return found;
+}
+
+describe('actor_type enum parity (shared ↔ DB schema ↔ validators ↔ OpenAPI)', () => {
   it('Drizzle enumValues match the shared ActorType union', () => {
     expect([...actorTypeEnum.enumValues].sort()).toEqual([...SHARED_ACTOR_TYPES].sort());
+  });
+
+  it('the exported ACTOR_TYPES constant matches the shared ActorType union', () => {
+    expect([...ACTOR_TYPES].sort()).toEqual([...SHARED_ACTOR_TYPES].sort());
   });
 
   it('the shared auditQuerySchema actorType filter matches the DB enum', () => {
@@ -25,7 +86,42 @@ describe('actor_type enum parity (shared ↔ DB schema ↔ validators)', () => {
     expect([...zodOptions].sort()).toEqual([...actorTypeEnum.enumValues].sort());
   });
 
+  it('every actorType enum in the OpenAPI spec matches the DB enum', () => {
+    const specEnums = collectSpecEnums(openApiSpec, 'actorType');
+    // Guard against a vacuous pass if the audit surfaces are renamed or removed.
+    expect(specEnums.length).toBeGreaterThanOrEqual(2);
+    for (const values of specEnums) {
+      expect([...values].sort()).toEqual([...actorTypeEnum.enumValues].sort());
+    }
+  });
+
   it('audit_result parity stays intact alongside', () => {
     expect([...auditResultEnum.enumValues].sort()).toEqual(['denied', 'failure', 'success']);
+    expect([...AUDIT_RESULTS].sort()).toEqual([...auditResultEnum.enumValues].sort());
+    const zodOptions = auditQuerySchema.shape.result.unwrap().options;
+    expect([...zodOptions].sort()).toEqual([...auditResultEnum.enumValues].sort());
+  });
+
+  it('the audit result enums in the OpenAPI spec match the DB enum', () => {
+    // `result` is a generic key name elsewhere in the spec, so scope the walk to
+    // the two audit subtrees rather than searching the whole document.
+    const spec = openApiSpec as unknown as Record<string, unknown>;
+    const components = spec.components as { schemas?: Record<string, unknown> } | undefined;
+    const auditLogSchema = components?.schemas?.AuditLog;
+    expect(auditLogSchema).toBeDefined();
+
+    const paths = spec.paths as Record<string, unknown> | undefined;
+    const auditLogsPath = paths?.['/audit/logs'];
+    expect(auditLogsPath).toBeDefined();
+
+    const specEnums = [
+      ...collectSpecEnums(auditLogSchema, 'result'),
+      ...collectSpecEnums(auditLogsPath, 'result')
+    ];
+    // Guard against a vacuous pass if the audit surfaces are renamed or removed.
+    expect(specEnums.length).toBeGreaterThanOrEqual(2);
+    for (const values of specEnums) {
+      expect([...values].sort()).toEqual([...auditResultEnum.enumValues].sort());
+    }
   });
 });

--- a/apps/api/src/db/schema/audit.ts
+++ b/apps/api/src/db/schema/audit.ts
@@ -1,11 +1,13 @@
 import { pgTable, uuid, varchar, text, timestamp, jsonb, pgEnum, integer, boolean, bigserial, bigint } from 'drizzle-orm/pg-core';
+import { ACTOR_TYPES, AUDIT_RESULTS } from '@breeze/shared';
 import { organizations } from './orgs';
 
 // 'agent' is the Go device agent; 'ai_agent' is the autonomous AI agent
 // principal (wave 3). They are different actors and must stay distinguishable
-// in the audit trail.
-export const actorTypeEnum = pgEnum('actor_type', ['user', 'api_key', 'agent', 'system', 'ai_agent']);
-export const auditResultEnum = pgEnum('audit_result', ['success', 'failure', 'denied']);
+// in the audit trail. Values come from @breeze/shared so the DB enum, the
+// shared union, the validators and the OpenAPI spec cannot drift apart (#3908).
+export const actorTypeEnum = pgEnum('actor_type', ACTOR_TYPES);
+export const auditResultEnum = pgEnum('audit_result', AUDIT_RESULTS);
 export const initiatedByEnum = pgEnum('initiated_by_type', ['manual', 'ai', 'automation', 'policy', 'schedule', 'agent', 'integration']);
 
 export const auditLogs = pgTable('audit_logs', {

--- a/apps/api/src/db/schema/audit.ts
+++ b/apps/api/src/db/schema/audit.ts
@@ -5,7 +5,10 @@ import { organizations } from './orgs';
 // 'agent' is the Go device agent; 'ai_agent' is the autonomous AI agent
 // principal (wave 3). They are different actors and must stay distinguishable
 // in the audit trail. Values come from @breeze/shared so the DB enum, the
-// shared union, the validators and the OpenAPI spec cannot drift apart (#3908).
+// shared union, the validators, the AI tool schemas and the OpenAPI spec all
+// widen together. NOTE: this does not author the Postgres type — that is
+// hand-written SQL in migrations/, so a new value still needs an
+// `ALTER TYPE ... ADD VALUE` migration alongside the constant (#3908).
 export const actorTypeEnum = pgEnum('actor_type', ACTOR_TYPES);
 export const auditResultEnum = pgEnum('audit_result', AUDIT_RESULTS);
 export const initiatedByEnum = pgEnum('initiated_by_type', ['manual', 'ai', 'automation', 'policy', 'schedule', 'agent', 'integration']);

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -5,6 +5,8 @@
  * Documentation is served via Swagger UI at /api/v1/docs
  */
 
+import { ACTOR_TYPES, AUDIT_RESULTS } from '@breeze/shared';
+
 export const openApiSpec = {
   openapi: '3.0.3',
   info: {
@@ -730,7 +732,7 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
         properties: {
           id: { type: 'string', format: 'uuid' },
           timestamp: { type: 'string', format: 'date-time' },
-          actorType: { type: 'string', enum: ['user', 'system', 'agent'] },
+          actorType: { type: 'string', enum: [...ACTOR_TYPES] },
           actorId: { type: 'string', format: 'uuid' },
           actorEmail: { type: 'string' },
           action: { type: 'string' },
@@ -740,7 +742,7 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
           details: { type: 'object' },
           ipAddress: { type: 'string' },
           userAgent: { type: 'string' },
-          result: { type: 'string', enum: ['success', 'failure'] }
+          result: { type: 'string', enum: [...AUDIT_RESULTS] }
         }
       }
     },
@@ -4202,13 +4204,13 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
           { $ref: '#/components/parameters/pageParam' },
           { $ref: '#/components/parameters/limitParam' },
           { name: 'actorId', in: 'query', schema: { type: 'string', format: 'uuid' } },
-          { name: 'actorType', in: 'query', schema: { type: 'string', enum: ['user', 'system', 'agent'] } },
+          { name: 'actorType', in: 'query', schema: { type: 'string', enum: [...ACTOR_TYPES] } },
           { name: 'action', in: 'query', schema: { type: 'string' } },
           { name: 'resourceType', in: 'query', schema: { type: 'string' } },
           { name: 'resourceId', in: 'query', schema: { type: 'string', format: 'uuid' } },
           { name: 'from', in: 'query', schema: { type: 'string', format: 'date-time' } },
           { name: 'to', in: 'query', schema: { type: 'string', format: 'date-time' } },
-          { name: 'result', in: 'query', schema: { type: 'string', enum: ['success', 'failure'] } }
+          { name: 'result', in: 'query', schema: { type: 'string', enum: [...AUDIT_RESULTS] } }
         ],
         responses: {
           '200': {

--- a/apps/api/src/routes/auditLogs.ts
+++ b/apps/api/src/routes/auditLogs.ts
@@ -8,6 +8,7 @@ import { authMiddleware, requireMfa, requirePermission } from '../middleware/aut
 import { writeRouteAudit } from '../services/auditEvents';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { csvRow } from '../services/spreadsheetExport';
+import type { ActorType, AuditResult } from '@breeze/shared';
 
 export const auditLogRoutes = new Hono();
 const requireAuditLogRead = requirePermission(
@@ -365,7 +366,7 @@ interface LateralAuditRow extends Record<string, unknown> {
   id: string;
   org_id: string | null;
   timestamp: Date | string;
-  actor_type: 'user' | 'api_key' | 'agent' | 'system' | 'ai_agent';
+  actor_type: ActorType;
   actor_id: string;
   actor_email: string | null;
   action: string;
@@ -375,7 +376,7 @@ interface LateralAuditRow extends Record<string, unknown> {
   details: unknown;
   ip_address: string | null;
   user_agent: string | null;
-  result: 'success' | 'failure' | 'denied';
+  result: AuditResult;
   error_message: string | null;
   checksum: string | null;
   initiated_by: string | null;

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'hono';
+import type { AuditResult } from '@breeze/shared';
 import { and, eq, isNull, sql } from 'drizzle-orm';
 import * as dbModule from '../../db';
 import { users, partnerUsers, organizationUsers, organizations, userPasskeys } from '../../db/schema';
@@ -1162,7 +1163,7 @@ export function writeAuthAudit(
   opts: {
     orgId?: string;
     action: string;
-    result: 'success' | 'failure' | 'denied';
+    result: AuditResult;
     reason?: string;
     userId?: string;
     email?: string;

--- a/apps/api/src/routes/backup/bmr.ts
+++ b/apps/api/src/routes/backup/bmr.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import type { AuditResult } from '@breeze/shared';
 import { z } from 'zod';
 import { zValidator } from '../../lib/validation';
 import { and, desc, eq, inArray } from 'drizzle-orm';
@@ -169,7 +170,7 @@ function writeRecoveryDownloadAudit(
   c: any,
   params: {
     orgId: string | null;
-    result: 'success' | 'failure' | 'denied';
+    result: AuditResult;
     resourceId?: string | null;
     snapshotId?: string | null;
     path?: string;

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { AUDIT_RESULTS } from '@breeze/shared';
 import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { eq, desc, and, ilike, sql, or, gte, lte, SQL } from 'drizzle-orm';
@@ -81,7 +82,7 @@ export function buildActionConditions(
 const eventsQuerySchema = z.object({
   search: z.string().max(200).optional(),
   category: eventCategoryEnum.optional(),
-  result: z.enum(['success', 'failure', 'denied']).optional(),
+  result: z.enum(AUDIT_RESULTS).optional(),
   initiatedBy: z
     .enum(['manual', 'ai', 'automation', 'policy', 'schedule', 'agent', 'integration'])
     .optional(),

--- a/apps/api/src/routes/partnerApi/audit.ts
+++ b/apps/api/src/routes/partnerApi/audit.ts
@@ -25,7 +25,7 @@ declare module 'hono' {
   }
 }
 
-type AuditResult = 'success' | 'failure' | 'denied';
+type AuditResult = import('@breeze/shared').AuditResult;
 
 type PublicError = {
   status: number;

--- a/apps/api/src/routes/patches/helpers.ts
+++ b/apps/api/src/routes/patches/helpers.ts
@@ -1,4 +1,5 @@
 import { eq, sql } from 'drizzle-orm';
+import type { AuditResult } from '@breeze/shared';
 import { db } from '../../db';
 import { organizations, patchPolicies } from '../../db/schema';
 import { writeRouteAudit, type AuthContext } from '../../services/auditEvents';
@@ -61,7 +62,7 @@ export function writePatchAuditForOrgIds(
     resourceType: string;
     resourceId?: string;
     resourceName?: string;
-    result?: 'success' | 'failure' | 'denied';
+    result?: AuditResult;
     details?: Record<string, unknown>;
   }
 ): void {

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -26,7 +26,7 @@ import {
   peripheralPolicyActionEnum,
 } from '../db/schema';
 import { CONFIG_FEATURE_TYPES } from './configFeatureTypes';
-import { INVOICE_STATUSES } from '@breeze/shared';
+import { ACTOR_TYPES, INVOICE_STATUSES } from '@breeze/shared';
 import { getToolTimeout, withToolTimeout } from './toolTimeouts';
 import {
   m365LookupUserHandler, m365RecentSigninsHandler, m365ListGroupMembershipsHandler,
@@ -1406,7 +1406,7 @@ export function createBreezeMcpServer(
         action: z.string().max(100).optional(),
         resourceType: z.string().max(100).optional(),
         resourceId: uuid.optional(),
-        actorType: z.enum(['user', 'api_key', 'agent', 'system', 'ai_agent']).optional(),
+        actorType: z.enum(ACTOR_TYPES).optional(),
         hoursBack: z.number().int().min(1).max(168).optional(),
         limit: z.number().int().min(1).max(100).optional(),
       },

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -8,7 +8,7 @@
 
 import { z } from 'zod';
 import { isIP } from 'node:net';
-import { INVOICE_STATUSES, currencyCodeSchema } from '@breeze/shared';
+import { ACTOR_TYPES, INVOICE_STATUSES, currencyCodeSchema } from '@breeze/shared';
 import { backupProfileSelectionsSchema, ringAutoApproveSchema } from '@breeze/shared/validators';
 import { fleetToolInputSchemas } from './aiToolSchemasFleet';
 import { backupToolSchemas } from './aiToolSchemasBackup';
@@ -847,7 +847,7 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
     action: z.string().max(100).optional(),
     resourceType: z.string().max(100).optional(),
     resourceId: uuid.optional(),
-    actorType: z.enum(['user', 'api_key', 'agent', 'system', 'ai_agent']).optional(),
+    actorType: z.enum(ACTOR_TYPES).optional(),
     hoursBack: z.number().int().min(1).max(168).optional(),
     limit: z.number().int().min(1).max(100).optional(),
   }),

--- a/apps/api/src/services/aiToolsAudit.ts
+++ b/apps/api/src/services/aiToolsAudit.ts
@@ -7,6 +7,7 @@
  */
 
 import { db } from '../db';
+import { ACTOR_TYPES } from '@breeze/shared';
 import { devices, auditLogs, deviceChangeLog } from '../db/schema';
 import { eq, ne, or, and, not, isNull, desc, sql, gte, lte, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
@@ -57,7 +58,7 @@ export function registerAuditTools(aiTools: Map<string, AiTool>): void {
           action: { type: 'string', description: 'Filter by action (e.g., "agent.command.script")' },
           resourceType: { type: 'string', description: 'Filter by resource type (e.g., "device")' },
           resourceId: { type: 'string', description: 'Filter by resource UUID' },
-          actorType: { type: 'string', enum: ['user', 'api_key', 'agent', 'system', 'ai_agent'], description: 'Filter by actor type' },
+          actorType: { type: 'string', enum: [...ACTOR_TYPES], description: 'Filter by actor type' },
           hoursBack: { type: 'number', description: 'How many hours back to search (default: 24, max: 168)' },
           limit: { type: 'number', description: 'Max results (default 25, max 100)' }
         }

--- a/apps/api/src/services/auditEvents.ts
+++ b/apps/api/src/services/auditEvents.ts
@@ -8,7 +8,7 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3
 // Aliased to the shared ActorType so this file cannot drift from the DB enum
 // and the shared validators — parity pinned by db/schema/audit.enums.test.ts.
 type AuditActorType = import('@breeze/shared').ActorType;
-type AuditResult = 'success' | 'failure' | 'denied';
+type AuditResult = import('@breeze/shared').AuditResult;
 
 export type RequestLike = {
   req: {

--- a/apps/api/src/services/auditService.ts
+++ b/apps/api/src/services/auditService.ts
@@ -1,4 +1,5 @@
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import type { AuditResult } from '@breeze/shared';
 import { auditLogs } from '../db/schema';
 import { captureException } from './sentry';
 
@@ -16,7 +17,7 @@ export interface CreateAuditLogParams {
   details?: Record<string, unknown>;
   ipAddress?: string;
   userAgent?: string;
-  result: 'success' | 'failure' | 'denied';
+  result: AuditResult;
   errorMessage?: string;
   initiatedBy?: InitiatedByType;
 }

--- a/apps/api/src/services/clientAiTools.ts
+++ b/apps/api/src/services/clientAiTools.ts
@@ -15,6 +15,7 @@
  */
 
 import { z } from 'zod';
+import type { AuditResult } from '@breeze/shared';
 import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { db, withDbAccessContext, runOutsideDbContext } from '../db';
 import { aiMessages, aiToolExecutions } from '../db/schema';
@@ -621,7 +622,7 @@ function auditClientTool(
   params: {
     toolUseId: string;
     toolName: string;
-    result: 'success' | 'failure' | 'denied';
+    result: AuditResult;
     details?: Record<string, unknown>;
   },
 ): void {

--- a/apps/docs/src/content/docs/features/ai-computer-control.mdx
+++ b/apps/docs/src/content/docs/features/ai-computer-control.mdx
@@ -362,7 +362,7 @@ Searches the audit log for recent actions. Useful for investigating what happene
 | `action` | Filter by action type (e.g., `agent.command.script`) |
 | `resourceType` | Filter by resource type (e.g., `device`) |
 | `resourceId` | Filter by specific resource UUID |
-| `actorType` | Filter by `user`, `api_key`, `agent`, or `system` |
+| `actorType` | Filter by `user`, `api_key`, `agent`, `system`, or `ai_agent` |
 | `hoursBack` | Time range: 1-168 hours (default: 24) |
 
 ```

--- a/apps/docs/src/content/docs/reference/audit-logs.mdx
+++ b/apps/docs/src/content/docs/reference/audit-logs.mdx
@@ -33,7 +33,7 @@ Each audit log entry contains the following fields:
 | `id` | UUID | Unique identifier for the log entry |
 | `orgId` | UUID | Organization the action belongs to (multi-tenant scoping) |
 | `timestamp` | Timestamp | When the action occurred (defaults to current time) |
-| `actorType` | Enum | Who performed the action: `user`, `api_key`, `agent`, or `system` |
+| `actorType` | Enum | Who performed the action: `user`, `api_key`, `agent`, `system`, or `ai_agent` |
 | `actorId` | UUID | Identifier of the actor (user ID, agent ID, etc.) |
 | `actorEmail` | String (255) | Email address of the actor (when available) |
 | `action` | String (100) | The action performed (e.g., `user.login`, `device.create`, `script.execute`) |
@@ -768,7 +768,7 @@ All audit log queries are automatically scoped to the caller's organization. The
 1. Verify that the action handler calls `writeAuditEvent()` or `writeRouteAudit()`. Events are written asynchronously, so failures do not block request handling.
 2. Check the API server console for `[audit] Failed to write audit log:` messages, which indicate database insert failures.
 3. Confirm the `orgId` is being passed. Events with a null or undefined `orgId` are silently dropped. Look for `[audit] Dropped event (no orgId):` warnings in the console.
-4. Ensure the `actorType` value is one of the four valid enum values: `user`, `api_key`, `agent`, or `system`.
+4. Ensure the `actorType` value is one of the five valid enum values: `user`, `api_key`, `agent`, `system`, or `ai_agent`.
 </Steps>
 
 ### Agent diagnostic logs are not appearing

--- a/apps/docs/src/content/docs/security/hardening.mdx
+++ b/apps/docs/src/content/docs/security/hardening.mdx
@@ -99,7 +99,7 @@ All mutating operations are automatically logged with:
 
 | Field | Description |
 |---|---|
-| `actorType` | `user`, `api_key`, `agent`, or `system` |
+| `actorType` | `user`, `api_key`, `agent`, `system`, or `ai_agent` |
 | `actorId` | User ID or device ID |
 | `action` | Operation performed |
 | `resource` | Target resource type |

--- a/apps/docs/src/content/docs/security/overview.mdx
+++ b/apps/docs/src/content/docs/security/overview.mdx
@@ -273,7 +273,7 @@ Every security-relevant operation is recorded in the `audit_logs` table:
 
 | Field | Description |
 |-------|-------------|
-| `actorType` | `user`, `api_key`, `agent`, or `system` |
+| `actorType` | `user`, `api_key`, `agent`, `system`, or `ai_agent` |
 | `actorId` | UUID of the actor |
 | `action` | Specific operation (e.g., `device.command.execute`) |
 | `resourceType` | Target entity type |

--- a/apps/web/src/components/devices/DeviceActivityFeed.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { AuditResult } from "@breeze/shared";
 import {
   Activity,
   AlertTriangle,
@@ -25,7 +26,7 @@ type ActivityEvent = {
   id: string;
   action?: string;
   message?: string;
-  result?: "success" | "failure" | "denied";
+  result?: AuditResult;
   initiatedBy?: string | null;
   timestamp?: string;
   actor?: { type?: string; name?: string; email?: string | null };

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -38,6 +38,16 @@ export const USER_STATUSES = ['active', 'invited', 'disabled'] as const;
 // Notification Channel Types
 export const NOTIFICATION_CHANNEL_TYPES = ['email', 'slack', 'teams', 'webhook', 'pagerduty', 'sms', 'pushover'] as const;
 
+// Audit Actor Types — the single runtime source for the `actor_type` Postgres
+// enum, the shared `ActorType` union, the audit query validator and the
+// OpenAPI spec. 'agent' is the Go device agent; 'ai_agent' is the autonomous
+// AI agent principal. Widen HERE, never at a call site (#3908).
+export const ACTOR_TYPES = ['user', 'api_key', 'agent', 'system', 'ai_agent'] as const;
+
+// Audit Results — single runtime source for the `audit_result` Postgres enum,
+// the shared `AuditResult` union, the audit query validator and the OpenAPI spec.
+export const AUDIT_RESULTS = ['success', 'failure', 'denied'] as const;
+
 // Remote Session Types
 export const REMOTE_SESSION_TYPES = ['terminal', 'desktop', 'file_transfer'] as const;
 

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -38,14 +38,20 @@ export const USER_STATUSES = ['active', 'invited', 'disabled'] as const;
 // Notification Channel Types
 export const NOTIFICATION_CHANNEL_TYPES = ['email', 'slack', 'teams', 'webhook', 'pagerduty', 'sms', 'pushover'] as const;
 
-// Audit Actor Types — the single runtime source for the `actor_type` Postgres
-// enum, the shared `ActorType` union, the audit query validator and the
-// OpenAPI spec. 'agent' is the Go device agent; 'ai_agent' is the autonomous
-// AI agent principal. Widen HERE, never at a call site (#3908).
+// Audit Actor Types — the runtime source for the `actor_type` Postgres enum,
+// the shared `ActorType` union, the audit query validator, the AI tool schemas
+// and the OpenAPI spec. 'agent' is the Go device agent; 'ai_agent' is the
+// autonomous AI agent principal.
+//
+// Widen HERE and nowhere else. Type positions pick the new value up for free;
+// the two runtime surfaces that cannot (the Drizzle `pgEnum` and the OpenAPI
+// JSON) are pinned by apps/api/src/db/schema/audit.enums.test.ts. A new value
+// still needs a migration (`ALTER TYPE ... ADD VALUE`) — the Postgres type is
+// authored by hand-written SQL and is NOT derived from this array (#3908).
 export const ACTOR_TYPES = ['user', 'api_key', 'agent', 'system', 'ai_agent'] as const;
 
-// Audit Results — single runtime source for the `audit_result` Postgres enum,
-// the shared `AuditResult` union, the audit query validator and the OpenAPI spec.
+// Audit Results — same contract as ACTOR_TYPES above, for the `audit_result`
+// Postgres enum.
 export const AUDIT_RESULTS = ['success', 'failure', 'denied'] as const;
 
 // Remote Session Types

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -466,7 +466,7 @@ export interface Policy {
 // Alert Types
 // ============================================
 
-import { NOTIFICATION_CHANNEL_TYPES } from '../constants';
+import { ACTOR_TYPES, AUDIT_RESULTS, NOTIFICATION_CHANNEL_TYPES } from '../constants';
 
 export type AlertSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 export type AlertStatus = 'active' | 'acknowledged' | 'resolved' | 'suppressed' | 'dismissed';
@@ -534,8 +534,8 @@ export interface RemoteSession {
 // Audit Types
 // ============================================
 
-export type ActorType = 'user' | 'api_key' | 'agent' | 'system' | 'ai_agent';
-export type AuditResult = 'success' | 'failure' | 'denied';
+export type ActorType = (typeof ACTOR_TYPES)[number];
+export type AuditResult = (typeof AUDIT_RESULTS)[number];
 
 export interface AuditLog {
   id: string;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 import {
+  ACTOR_TYPES,
+  AUDIT_RESULTS,
   OS_TYPES,
   DEVICE_STATUSES,
   ALERT_SEVERITIES,
@@ -499,11 +501,11 @@ export * from './filters';
 
 export const auditQuerySchema = paginationSchema.merge(dateRangeSchema).extend({
   actorId: z.string().guid().optional(),
-  actorType: z.enum(['user', 'api_key', 'agent', 'system', 'ai_agent']).optional(),
+  actorType: z.enum(ACTOR_TYPES).optional(),
   action: z.string().optional(),
   resourceType: z.string().optional(),
   resourceId: z.string().guid().optional(),
-  result: z.enum(['success', 'failure', 'denied']).optional()
+  result: z.enum(AUDIT_RESULTS).optional()
 });
 
 // ============================================


### PR DESCRIPTION
Closes #3908

## The drift

The `actor_type` / `audit_result` value sets were hand-synced across many surfaces. `apps/api/src/db/schema/audit.enums.test.ts` pinned three of them; the OpenAPI document was the one it did not cover — and it had drifted on **both** enums, at **two sites each**:

| Site | Was | Should be |
|---|---|---|
| `AuditLog.actorType` (openapi.ts:733) | `['user', 'system', 'agent']` | + `api_key`, `ai_agent` |
| `/audit/logs` `actorType` param (:4205) | `['user', 'system', 'agent']` | + `api_key`, `ai_agent` |
| `AuditLog.result` (:741) | `['success', 'failure']` | + `denied` |
| `/audit/logs` `result` param (:4211) | `['success', 'failure']` | + `denied` |

`api_key` had been missing since the enum was introduced; `ai_agent` was added by #3893. The `result` drift is the same class of bug one line below and was found while fixing the first — published API docs advertised four wrong enums, so a client generated from the spec would reject valid audit rows.

## The fix — one source, not four patched literals

Following the existing `NOTIFICATION_CHANNEL_TYPES` pattern, `ACTOR_TYPES` and `AUDIT_RESULTS` land in `packages/shared/src/constants/index.ts` and everything derives from them:

- shared `ActorType` / `AuditResult` → `(typeof X)[number]`
- `auditQuerySchema` → `z.enum(ACTOR_TYPES)` / `z.enum(AUDIT_RESULTS)`
- Drizzle `actorTypeEnum` / `auditResultEnum` → take the constants (**identical values and order**, so no schema drift and no migration)
- `openapi.ts` → spreads them at all four sites

### Repo-wide sweep (second commit, from review)

Review flagged that the first commit fixed the reported surface but left **twelve more hand-written copies** elsewhere — so the "single source" claim wasn't yet true. All now derive from the shared constants:

- **AI tool schemas** — `aiToolsAudit.ts`, `aiAgentSdkTools.ts`, `aiToolSchemas.ts`. `aiToolsAudit.ts:60` was a JSON-schema `enum:` array handed to the LLM: **structurally the same bug as #3908**, just a different document.
- **services** — `auditService.ts` (the primary audit-write path), `auditEvents.ts`, `clientAiTools.ts`
- **routes** — `partnerApi/audit.ts`, `devices/events.ts`, `auth/helpers.ts`, `patches/helpers.ts`, `backup/bmr.ts`
- **web** — `components/devices/DeviceActivityFeed.tsx`

`auditEvents.ts` is the tell: its `AuditActorType` was already aliased to the shared type in wave 3a, but `AuditResult` one line below was left behind — this PR's exact failure mode, inside one file.

None were stale *today*, so this fixes no live bug — it removes twelve latent repeats of #3908.

## Backstop for what `typeof` cannot reach

The Drizzle enum and the OpenAPI JSON are runtime values, not type positions, so an import alone cannot stop someone re-hardcoding a literal. `audit.enums.test.ts` gains assertions that **walk the OpenAPI document** for every `actorType` / `result` enum and compare against the DB enum — no line numbers are pinned, so a *third* hand-written site added later fails too. Each has a minimum-count guard so it cannot pass vacuously.

The old `// Compile-time exhaustiveness` comment was **false**: a `readonly ActorType[]` does not error when the literal omits a union member (verified with `tsc --strict`) — it only ever caught *extra* values. Replaced with `satisfies Record<ActorType, true>`, which enforces both directions.

## Verification

Every guard in this PR was **negative-tested** — I confirmed each one fails before trusting it:

- Reverting the OpenAPI enums to their pre-fix literals turns the new assertions **red** (2 failures for `actorType`, 1 for `result`), green after restoring.
- Adding a value to `ACTOR_TYPES` now **fails to compile** — `TS1360` in `audit.enums.test.ts` — until the exhaustiveness list is updated.
- Confirmed the web `tsc` genuinely covers the changed `.tsx` (deliberately broke the type; tsc caught it).

Test/typecheck status:

- `apps/api` — 133 passed (schema, auditLogs, docs, auditEvents, devices/events, partnerApi/audit) + 759 passed (AI tool schemas, auditService, clientAiTools, backup, patches, auth)
- `apps/web` — 670 passed (`src/components/devices`)
- `packages/shared` — 2062/2063; the single failure is a repo-scanning `optionalQueryBoolean` test hitting its 7s timeout under full-suite load, and it passes on this same tree in isolation (verified) — unrelated
- `tsc --noEmit` — **clean** for `apps/api` and `apps/web`; `packages/shared` has 4 errors all in `src/validators/quotes.test.ts`, **verified byte-identical on stashed `origin/main`** (pre-existing)

## Note for the reviewer

**No migration, by design.** The Postgres enums are unchanged — only where their values are written down. Confirmed against `0001-baseline.sql` (`user, api_key, agent, system`; `success, failure, denied`) plus `2026-09-05-b-audit-actor-type-ai-agent.sql` (`ADD VALUE 'ai_agent'`): insertion order is exactly `ACTOR_TYPES` / `AUDIT_RESULTS` order. Both `Check Migrations` jobs pass.

**Known remaining gap (deliberately not in scope):** nothing asserts the *live* Postgres enum against `ACTOR_TYPES` — `actorTypeEnum.enumValues` is just the in-memory array, so a future widening that updates the constant but forgets the `ALTER TYPE ... ADD VALUE` migration would still pass CI. Closing that needs an integration test querying `pg_enum`, which I could not verify locally without a database. The comments now state explicitly that a migration is still required. Happy to file it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)