### PR TITLE
fix(web): stop a double-click on a confirm dialog hit-testing through to the list (#3705)

### DIFF
--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -1292,11 +1292,15 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
 
     // An impatient double-click on a bulk REBOOT must not reboot the fleet twice.
     //
-    // Two things fence this now (#3705), and the unmount is no longer either of
-    // them: ConfirmDialog holds a synchronous ref latch, so converting this to a
-    // stay-mounted + spinner pattern no longer lets the second click through
-    // (`disabled` and runBulkAction's `actionInProgress` both read a closure
-    // captured at render and still cannot help). It does NOT discriminate the
+    // Be precise about what THIS test fences, because it is narrower than it
+    // looks: it re-dispatches at a stale reference to a button already detached
+    // by the first click, so the second event never reaches React's delegated
+    // listener. The unmount is still the only thing it exercises. It stays
+    // green with the #3705 latch reverted.
+    //
+    // In production the latch is the guard that matters, because it also holds
+    // when the dialog STAYS mounted — see ConfirmDialog.test.tsx, which drives
+    // that case directly. What neither test discriminates is the
     // set-state-before-dispatch ORDER: under React 18 both updates flush
     // together at the end of the handler, so swapping them would still pass.
     fireEvent.click(confirm);

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -1292,18 +1292,59 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
 
     // An impatient double-click on a bulk REBOOT must not reboot the fleet twice.
     //
-    // What this actually fences: converting the dialog to a stay-mounted +
-    // spinner pattern (leaning on ConfirmDialog's `disabled`, or on the
-    // actionInProgress guard — which reads a stale `false` closure and cannot
-    // help) lets the second click through and fires sendBulkCommand twice.
-    // It does NOT discriminate the set-state-before-dispatch ORDER: under React
-    // 18 both updates flush together at the end of the handler, so swapping them
-    // would still pass. The unmount is the guard; the ordering is not load-bearing.
+    // Two things fence this now (#3705), and the unmount is no longer either of
+    // them: ConfirmDialog holds a synchronous ref latch, so converting this to a
+    // stay-mounted + spinner pattern no longer lets the second click through
+    // (`disabled` and runBulkAction's `actionInProgress` both read a closure
+    // captured at render and still cannot help). It does NOT discriminate the
+    // set-state-before-dispatch ORDER: under React 18 both updates flush
+    // together at the end of the handler, so swapping them would still pass.
     fireEvent.click(confirm);
     fireEvent.click(confirm);
 
     await waitFor(() => expect(vi.mocked(sendBulkCommand)).toHaveBeenCalledTimes(1));
     expect(vi.mocked(sendBulkCommand)).toHaveBeenCalledTimes(1);
+  });
+
+  // #3705, the OTHER half of the double-click. The one above proves the same
+  // button cannot fire twice. This proves the second press cannot fire
+  // something ELSE: confirming tears the portal out, and in a browser that
+  // press is hit-tested afterwards against whatever now occupies those
+  // coordinates — the bulk bar and the device rows the dialog was centred over.
+  //
+  // jsdom has no layout, so it cannot pick that target itself; the test hands
+  // the press to the bulk Wake button directly, which is what a browser does.
+  // What is faithfully modelled is the part that matters: the press arrives
+  // carrying detail === 2, because the platform click counter comes from the
+  // time and distance between presses, never from the hit-test target.
+  it('a double-click on confirm cannot fire an unrelated action underneath', async () => {
+    const { sendDeviceCommand, sendBulkWakeCommand } = await import('../../services/deviceActions');
+    vi.mocked(sendDeviceCommand).mockResolvedValue({ command: {} } as never);
+    vi.mocked(sendBulkWakeCommand).mockResolvedValue({ sent: [], failed: [] } as never);
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [{ ...rawDevice(DEV_1, 'host-alpha'), status: 'online' }],
+    } as never);
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByTestId(`row-reboot-${DEV_1}`));
+
+    // Press 1 of the double-click: lands on Confirm, unmounts the dialog.
+    const confirmBtn = await screen.findByTestId('confirm-device-action');
+    fireEvent.mouseDown(confirmBtn, { detail: 1 });
+    fireEvent.mouseUp(confirmBtn, { detail: 1 });
+    fireEvent.click(confirmBtn, { detail: 1 });
+    await waitFor(() => expect(vi.mocked(sendDeviceCommand)).toHaveBeenCalledTimes(1));
+
+    // Press 2, now hit-testing through to the fleet Wake the operator never
+    // aimed at. Wake is deliberately UNGATED, so nothing else would stop it.
+    const wake = screen.getByTestId('bulk-wake');
+    fireEvent.mouseDown(wake, { detail: 2 });
+    fireEvent.mouseUp(wake, { detail: 2 });
+    fireEvent.click(wake, { detail: 2 });
+
+    expect(vi.mocked(sendBulkWakeCommand)).not.toHaveBeenCalled();
+    expect(vi.mocked(sendDeviceCommand)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(sendDeviceCommand)).toHaveBeenCalledWith(DEV_1, 'reboot');
   });
 });
 

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -1429,7 +1429,9 @@ export default function DevicesPage() {
           // row underneath. Previously only the unmount protected this, and it
           // protected only the first of those two failures.
           // (The set-state/dispatch ORDER below is not load-bearing either:
-          // React batches both.) DevicesPage.test.tsx pins both halves.
+          // React batches both.) The click-through half is pinned in
+          // DevicesPage.test.tsx; the latch half in ConfirmDialog.test.tsx,
+          // which can hold the dialog mounted the way this call site does not.
           onConfirm={() => {
             const p = pendingDecommissionedSkip;
             setPendingDecommissionedSkip(null);

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -1421,14 +1421,15 @@ export default function DevicesPage() {
         <ConfirmDialog
           open={true}
           onClose={() => setPendingDecommissionedSkip(null)}
-          // Confirming UNMOUNTS this dialog, which is what makes a double-click
-          // safe — a second click has no button to hit. No isLoading/spinner
-          // here on purpose: that would mean keeping the dialog mounted, and
-          // then neither guard holds — ConfirmDialog's `disabled` and
-          // runBulkAction's `actionInProgress` both read a closure captured at
-          // render, still `false` on the second click, so the fleet reboots
-          // twice. (The set-state/dispatch ORDER below is not what saves us:
-          // React batches both. The unmount is.) DevicesPage.test.tsx pins it.
+          // Double-click safety lives in the shared components now (#3705), not
+          // in this call site. ConfirmDialog holds a synchronous ref latch, so
+          // the fleet cannot reboot twice even if the dialog stayed mounted;
+          // and Dialog swallows the tail of the gesture after its portal is
+          // torn out, so the second press cannot hit-test through to a device
+          // row underneath. Previously only the unmount protected this, and it
+          // protected only the first of those two failures.
+          // (The set-state/dispatch ORDER below is not load-bearing either:
+          // React batches both.) DevicesPage.test.tsx pins both halves.
           onConfirm={() => {
             const p = pendingDecommissionedSkip;
             setPendingDecommissionedSkip(null);
@@ -1448,9 +1449,8 @@ export default function DevicesPage() {
 
       {/* #3698: mirror of the device-detail confirm gate, reusing the SAME
           deviceActions.confirm.* copy so the two screens read identically and
-          no new locale keys are needed. Confirming UNMOUNTS the dialog, which
-          is what makes a double-click safe — see the decommissioned-skip
-          dialog above for why isLoading is deliberately absent. */}
+          no new locale keys are needed. Double-click safety is the shared
+          components' job (#3705) — see the decommissioned-skip dialog above. */}
       {pendingDeviceAction && (
         <ConfirmDialog
           open={true}

--- a/apps/web/src/components/shared/ConfirmDialog.test.tsx
+++ b/apps/web/src/components/shared/ConfirmDialog.test.tsx
@@ -93,11 +93,28 @@ describe('ConfirmDialog — double-click safety (#3705)', () => {
       expect(onConfirm).toHaveBeenCalledTimes(2);
     });
 
-    // NOTE: the matching "onConfirm throws → latch releases" path is covered by
-    // code inspection only. React 19 does not propagate a handler throw back
-    // through dispatchEvent — it reports it as a window error event — so it
-    // cannot be asserted through fireEvent without destabilising the whole
-    // worker. See the try/catch in ConfirmDialog.handleConfirm.
+    // React 19 does not propagate a handler throw back through dispatchEvent —
+    // it re-reports it as a window `error` event. Swallowing that event keeps
+    // the throw from failing the worker while still exercising the real path.
+    it('releases the latch when onConfirm throws, instead of killing the button', () => {
+      const swallow = (e: ErrorEvent) => e.preventDefault();
+      window.addEventListener('error', swallow);
+      try {
+        const onConfirm = vi.fn(() => {
+          throw new Error('boom');
+        });
+        render(<StayOpen onConfirm={onConfirm} />);
+        const confirm = screen.getByTestId('confirm');
+
+        // A synchronous throw never reaches the close or the isLoading toggle,
+        // so a latch left set would make Confirm dead for the rest of its life.
+        firstPress(confirm);
+        firstPress(confirm);
+        expect(onConfirm).toHaveBeenCalledTimes(2);
+      } finally {
+        window.removeEventListener('error', swallow);
+      }
+    });
   });
 
   describe('the tail of the gesture cannot reach what was underneath', () => {
@@ -181,21 +198,51 @@ describe('ConfirmDialog — double-click safety (#3705)', () => {
       expect(underneath).not.toHaveBeenCalled();
     });
 
-    // The guard is scoped to teardowns a press could have caused. An Escape
-    // close has no gesture in flight, so arming there would only create the
-    // opposite bug: eating a deliberate click that the platform happens to
+    // The guard is scoped to teardowns a completed click could have caused. An
+    // Escape close has no gesture in flight, so arming there would only create
+    // the opposite bug: eating a deliberate click that the platform happens to
     // count as the second of a pair. Same reasoning covers an async settle and
     // a route change, and it is what keeps StrictMode's extra cleanup inert.
-    it('does NOT arm after an Escape close — no gesture was in flight', () => {
+    //
+    // The interesting ordering is a press that starts INSIDE the dialog and
+    // never completes a click there — dragging out a text selection, then
+    // dismissing with Escape. Keying the arm condition on `mousedown` would arm
+    // here and eat the user's next click; keying it on `click` does not. A test
+    // that reaches Escape without any preceding press inside the dialog passes
+    // under either rule and so proves nothing, which is why this one presses
+    // first.
+    it('does NOT arm after a press inside the dialog that ends in Escape', () => {
       const underneath = vi.fn();
-      const { container } = render(<Harness underneath={underneath} />);
-      void container;
+      render(<Harness underneath={underneath} />);
 
       const backdrop = document.querySelector('.dialog-backdrop') as HTMLElement;
+      const message = screen.getByText('This reboots host-alpha.');
+      fireEvent.mouseDown(message, { detail: 1 });
+      fireEvent.mouseUp(message, { detail: 1 });
+
       fireEvent.keyDown(backdrop, { key: 'Escape' });
       expect(screen.queryByTestId('confirm')).toBeNull();
 
       secondPress(screen.getByTestId('underneath'));
+      expect(underneath).toHaveBeenCalledTimes(1);
+    });
+
+    // The module keeps a single active guard (`disarmActiveGestureTailGuard`),
+    // so two dialogs closing back to back must not leave a stale listener
+    // behind or double-suppress.
+    it('survives two dialogs closing back to back', () => {
+      const underneath = vi.fn();
+      const { unmount } = render(<Harness underneath={underneath} />);
+      firstPress(screen.getByTestId('confirm'));
+      unmount();
+
+      render(<Harness underneath={underneath} />);
+      firstPress(screen.getByTestId('confirm'));
+
+      secondPress(screen.getByTestId('underneath'));
+      expect(underneath).not.toHaveBeenCalled();
+
+      firstPress(screen.getByTestId('underneath'));
       expect(underneath).toHaveBeenCalledTimes(1);
     });
   });

--- a/apps/web/src/components/shared/ConfirmDialog.test.tsx
+++ b/apps/web/src/components/shared/ConfirmDialog.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useState } from 'react';
+import { ConfirmDialog } from './ConfirmDialog';
+
+/**
+ * #3705 — the failure this file exists for.
+ *
+ * A ConfirmDialog closes by tearing its portal out of the DOM. On a REAL
+ * double-click the second physical press is hit-tested AFTER that teardown,
+ * against whatever now occupies those coordinates — a device row, a bulk
+ * action bar, a grid card. So the hazard is not a duplicate of the action the
+ * user just confirmed; it is an UNRELATED action firing from the second half
+ * of the gesture.
+ *
+ * jsdom has no layout and no hit-testing, so it cannot decide for itself which
+ * element the second press lands on. What it CAN pin is the part that is
+ * actually ours: the browser hands that press to the element underneath
+ * carrying `detail === 2` (the platform click counter is derived from the
+ * button, time and distance between presses, never from the hit-test target),
+ * and the guard must swallow it. These tests deliver that press explicitly,
+ * which is what a browser does — only without asking jsdom to compute the
+ * target.
+ */
+
+/** A brand-new, deliberate press. */
+function firstPress(el: HTMLElement) {
+  fireEvent.mouseDown(el, { detail: 1 });
+  fireEvent.mouseUp(el, { detail: 1 });
+  fireEvent.click(el, { detail: 1 });
+}
+
+/** The second half of a double-click, as the browser delivers it. */
+function secondPress(el: HTMLElement) {
+  fireEvent.mouseDown(el, { detail: 2 });
+  fireEvent.mouseUp(el, { detail: 2 });
+  fireEvent.click(el, { detail: 2 });
+}
+
+describe('ConfirmDialog — double-click safety (#3705)', () => {
+  beforeEach(() => {
+    // Testing Library unmounts the previous test's tree between tests, and an
+    // unmounting Dialog can arm the guard. Retire it with a fresh single press
+    // so no test inherits an armed guard from its predecessor.
+    fireEvent.mouseDown(document.body, { detail: 1 });
+  });
+
+  describe('the confirm button itself fires once per open dialog', () => {
+    function StayOpen({ onConfirm, isLoading }: { onConfirm: () => void; isLoading?: boolean }) {
+      // Deliberately does NOT close on confirm — this isolates the latch from
+      // the unmount. A call site that unmounts is protected by the unmount too;
+      // one that keeps the dialog mounted behind a spinner has only the latch.
+      return (
+        <ConfirmDialog
+          open
+          onClose={() => {}}
+          onConfirm={onConfirm}
+          title="Reboot the fleet"
+          message="This reboots every selected device."
+          confirmTestId="confirm"
+          isLoading={isLoading}
+        />
+      );
+    }
+
+    it('ignores the second click of a double-click on a dialog that stays mounted', () => {
+      const onConfirm = vi.fn();
+      render(<StayOpen onConfirm={onConfirm} />);
+
+      const confirm = screen.getByTestId('confirm');
+      firstPress(confirm);
+      secondPress(confirm);
+
+      // `disabled={isLoading}` cannot hold here — it reads a value captured at
+      // render, still false on the second click. The ref reads current.
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the latch when an in-flight action settles, so a failure is retryable', () => {
+      const onConfirm = vi.fn();
+      const { rerender } = render(<StayOpen onConfirm={onConfirm} isLoading={false} />);
+
+      firstPress(screen.getByTestId('confirm'));
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+
+      // Action runs, then fails and leaves the dialog open. The call sites that
+      // do this (ContractEditor, InvoiceActions, QuoteActions, …) rely on the
+      // user being able to press Confirm again.
+      rerender(<StayOpen onConfirm={onConfirm} isLoading />);
+      rerender(<StayOpen onConfirm={onConfirm} isLoading={false} />);
+
+      firstPress(screen.getByTestId('confirm'));
+      expect(onConfirm).toHaveBeenCalledTimes(2);
+    });
+
+    // NOTE: the matching "onConfirm throws → latch releases" path is covered by
+    // code inspection only. React 19 does not propagate a handler throw back
+    // through dispatchEvent — it reports it as a window error event — so it
+    // cannot be asserted through fireEvent without destabilising the whole
+    // worker. See the try/catch in ConfirmDialog.handleConfirm.
+  });
+
+  describe('the tail of the gesture cannot reach what was underneath', () => {
+    function Harness({ underneath }: { underneath: () => void }) {
+      const [open, setOpen] = useState(true);
+      return (
+        <>
+          {/* Stands in for the list the confirm button is centred over. */}
+          <button type="button" data-testid="underneath" onClick={underneath}>
+            wake
+          </button>
+          <ConfirmDialog
+            open={open}
+            onClose={() => setOpen(false)}
+            onConfirm={() => setOpen(false)}
+            title="Reboot host-alpha"
+            message="This reboots host-alpha."
+            confirmTestId="confirm"
+          />
+        </>
+      );
+    }
+
+    it('swallows the second press after the dialog is torn down', () => {
+      const underneath = vi.fn();
+      render(<Harness underneath={underneath} />);
+
+      firstPress(screen.getByTestId('confirm'));
+      expect(screen.queryByTestId('confirm')).toBeNull();
+
+      secondPress(screen.getByTestId('underneath'));
+
+      // Without the guard this is 1: an unrelated fleet Wake, queued by the
+      // half of a double-click the user never aimed at anything.
+      expect(underneath).not.toHaveBeenCalled();
+    });
+
+    it('still lets the next deliberate click through', () => {
+      const underneath = vi.fn();
+      render(<Harness underneath={underneath} />);
+
+      firstPress(screen.getByTestId('confirm'));
+      firstPress(screen.getByTestId('underneath'));
+
+      expect(underneath).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not eat a deliberate double-click aimed at the list afterwards', () => {
+      const underneath = vi.fn();
+      render(<Harness underneath={underneath} />);
+
+      firstPress(screen.getByTestId('confirm'));
+
+      // A NEW gesture opens with detail 1, which stands the guard down before
+      // its own second press arrives — so both clicks land.
+      const target = screen.getByTestId('underneath');
+      firstPress(target);
+      secondPress(target);
+
+      expect(underneath).toHaveBeenCalledTimes(2);
+    });
+
+    it('leaves keyboard-driven clicks alone (they report detail 0)', () => {
+      const underneath = vi.fn();
+      render(<Harness underneath={underneath} />);
+
+      firstPress(screen.getByTestId('confirm'));
+      fireEvent.click(screen.getByTestId('underneath'), { detail: 0 });
+
+      expect(underneath).toHaveBeenCalledTimes(1);
+    });
+
+    it('guards a Cancel press too — same teardown, same hole', () => {
+      const underneath = vi.fn();
+      render(<Harness underneath={underneath} />);
+
+      firstPress(screen.getByText('Cancel'));
+      expect(screen.queryByTestId('confirm')).toBeNull();
+
+      secondPress(screen.getByTestId('underneath'));
+      expect(underneath).not.toHaveBeenCalled();
+    });
+
+    // The guard is scoped to teardowns a press could have caused. An Escape
+    // close has no gesture in flight, so arming there would only create the
+    // opposite bug: eating a deliberate click that the platform happens to
+    // count as the second of a pair. Same reasoning covers an async settle and
+    // a route change, and it is what keeps StrictMode's extra cleanup inert.
+    it('does NOT arm after an Escape close — no gesture was in flight', () => {
+      const underneath = vi.fn();
+      const { container } = render(<Harness underneath={underneath} />);
+      void container;
+
+      const backdrop = document.querySelector('.dialog-backdrop') as HTMLElement;
+      fireEvent.keyDown(backdrop, { key: 'Escape' });
+      expect(screen.queryByTestId('confirm')).toBeNull();
+
+      secondPress(screen.getByTestId('underneath'));
+      expect(underneath).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/components/shared/ConfirmDialog.tsx
+++ b/apps/web/src/components/shared/ConfirmDialog.tsx
@@ -52,18 +52,41 @@ export function ConfirmDialog({
   }, [open, isLoading]);
 
   const handleConfirm = useCallback(() => {
-    if (confirmLatchRef.current) return;
+    if (confirmLatchRef.current) {
+      // The latch releasing depends on the call site either closing the dialog
+      // or driving `isLoading`. Every current call site does one or the other,
+      // but nothing enforces it, and a site that does neither would leave
+      // Confirm permanently dead with no toast, log or console output — the
+      // exact silent failure this component is meant to prevent. A blocked
+      // click while `isLoading` is false is precisely that violation, so say so
+      // in dev rather than letting site #49 discover it in production.
+      if (import.meta.env.DEV && !isLoading) {
+        console.warn(
+          `[ConfirmDialog] "${title}": Confirm was pressed again while the ` +
+            'previous press is still latched, but isLoading is false and the ' +
+            'dialog is still open. onConfirm must either close the dialog or ' +
+            'drive isLoading, otherwise this button is now permanently inert.',
+        );
+      }
+      return;
+    }
     confirmLatchRef.current = true;
     try {
       onConfirm();
     } catch (err) {
-      // A handler that throws synchronously never gets to close the dialog or
-      // toggle isLoading, so the latch would stick and the button would be dead
-      // for the rest of its life. Release it and let the error propagate.
+      // Releases the latch so the BUTTON survives a handler that throws
+      // synchronously — it protects the control, not the user. Two limits worth
+      // knowing: every current call site wraps async work as
+      // `() => void someAsyncFn()`, whose rejection lands after this function
+      // has already returned, so this branch is inert for the failure mode that
+      // actually happens; and React 19 does not propagate a handler throw back
+      // through dispatchEvent, it re-reports it as a window error event. So
+      // rethrowing surfaces nothing to the user. Reporting the outcome of the
+      // action remains the call site's job, via runAction.
       confirmLatchRef.current = false;
       throw err;
     }
-  }, [onConfirm]);
+  }, [onConfirm, isLoading, title]);
 
   return (
     <Dialog open={open} onClose={onClose} title={title} maxWidth="md" className="p-6">

--- a/apps/web/src/components/shared/ConfirmDialog.tsx
+++ b/apps/web/src/components/shared/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { AlertOctagon, AlertTriangle } from 'lucide-react';
 import { Dialog } from './Dialog';
 import { useTranslation } from 'react-i18next';
@@ -36,6 +36,35 @@ export function ConfirmDialog({
   // non-destructive action like activate/generate). Colorblind users and a
   // glance-read both get the distinction without relying on red-vs-amber.
   const Icon = variant === 'destructive' ? AlertOctagon : AlertTriangle;
+
+  // #3705: single-fire latch. `disabled={isLoading}` cannot hold on the second
+  // half of a double-click — it reads a value captured at render, still `false`
+  // when the second click lands — and neither can a call site's own
+  // `actionInProgress` flag, for the same reason. A ref reads CURRENT, so it
+  // holds synchronously inside the one handler invocation.
+  //
+  // Call sites that keep the dialog mounted across an async action get the
+  // latch released when `isLoading` settles back to false, so a failed action
+  // is still retryable. Sites that unmount on confirm get a fresh ref anyway.
+  const confirmLatchRef = useRef(false);
+  useEffect(() => {
+    if (!open || !isLoading) confirmLatchRef.current = false;
+  }, [open, isLoading]);
+
+  const handleConfirm = useCallback(() => {
+    if (confirmLatchRef.current) return;
+    confirmLatchRef.current = true;
+    try {
+      onConfirm();
+    } catch (err) {
+      // A handler that throws synchronously never gets to close the dialog or
+      // toggle isLoading, so the latch would stick and the button would be dead
+      // for the rest of its life. Release it and let the error propagate.
+      confirmLatchRef.current = false;
+      throw err;
+    }
+  }, [onConfirm]);
+
   return (
     <Dialog open={open} onClose={onClose} title={title} maxWidth="md" className="p-6">
       <div className="flex gap-4">
@@ -68,7 +97,7 @@ export function ConfirmDialog({
         </button>
         <button
           type="button"
-          onClick={onConfirm}
+          onClick={handleConfirm}
           disabled={isLoading}
           data-testid={confirmTestId}
           className={`rounded-md px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 ${

--- a/apps/web/src/components/shared/Dialog.tsx
+++ b/apps/web/src/components/shared/Dialog.tsx
@@ -36,40 +36,58 @@ const FOCUSABLE =
  * the hazard is not a duplicate of the action just confirmed; it is an
  * UNRELATED action firing from the second half of the gesture.
  *
- * The discriminator is `MouseEvent.detail`, the platform click counter.
- * Chromium, Gecko and WebKit all derive it from the button, the time and the
- * distance between presses rather than from the DOM target, so the second
- * press still reports `detail === 2` even though it now lands on a different
- * element. (That is consistent de-facto behaviour across the three engines
- * rather than a normative guarantee: UI Events defines the counter but does not
- * say that a change of target must leave it alone. The latch in ConfirmDialog
- * is the belt to this pair of braces.)
+ * The discriminator is `MouseEvent.detail`, the platform click counter. It is
+ * computed from the button, the time and the distance between presses rather
+ * than from the DOM target, so the second press still reports `detail === 2`
+ * even though it now lands on a different element.
+ *
+ * Confidence, honestly graded, because the whole guard leans on this: verified
+ * in Chromium source (`ui/events/event.cc` gates only on matching button flags,
+ * elapsed time and a <=2px position delta) and in WebKit, which on macOS simply
+ * copies `NSEvent.clickCount` and so is even further from the DOM. Gecko is
+ * asserted from observed behaviour, not from source. None of it is normative
+ * either way — UI Events defines the counter but never says a change of target
+ * must leave it alone. The latch in ConfirmDialog is the belt to these braces.
  *
  * A deliberate NEW double-click after the dialog closed begins with a press
  * whose `detail` is 1, which stands the guard down before its own second press
  * arrives — so intentional double-clicks keep working. That is also what bounds
  * the guard's lifetime: it retires on the next fresh press rather than on a
- * timer, because OS double-click intervals are user-configurable (Windows
- * allows up to 5s) and any fixed ceiling would either expire before the second
+ * timer, because OS double-click intervals are configurable (the Win32
+ * double-click-time API clamps at 5s, well past the ~900ms the Windows control
+ * panel exposes) and any fixed ceiling would either expire before the second
  * press or linger well past it.
  *
  * KNOWN TRADE-OFF. The counter cannot distinguish "second half of an
  * accidental double-click" from "deliberate fast click at the same spot right
  * after confirming" — both arrive as `detail >= 2`, and the second one is
- * therefore swallowed until the user pauses long enough for the counter to
- * reset. Because the counter only increments for presses within a few pixels
- * of the last one, that costs at most a repeated click at the coordinates the
- * confirm button just vacated, and it errs on the side of not firing a
- * destructive command the user did not aim at. The place most likely to feel
+ * therefore swallowed. Recovery does not require waiting: any press the
+ * platform counts as fresh clears the guard, so a click anywhere far enough
+ * away — or the same click repeated a moment later — goes straight through.
+ * Because the counter only increments for presses within a few pixels of the
+ * last one, that costs at most a repeated click at the coordinates the confirm
+ * button just vacated, and it errs on the side of not firing a destructive
+ * command the user did not aim at.
+ *
+ * That includes across a client-side route change: the platform counter is not
+ * reset by SPA navigation, so if `onConfirm` navigates and the new screen puts
+ * a control where the confirm button was, the user's first click on it can be
+ * counted as the second of a pair and swallowed. Scoping the guard by
+ * coordinates would not help — a `detail >= 2` event is already, by
+ * construction, within a few pixels of the click that armed it. Clicking again
+ * works, which is the same recovery as every other case above. The place most likely to feel
  * it is the remote FileManager, whose table rows are double-click-to-open and
  * reflow underneath a delete confirm.
  *
  * SCOPE — deliberately narrow. This blocks the mouse/click activation tail and
  * nothing else. Handlers bound to `pointerdown`/`pointerup` are NOT covered:
- * those report `detail === 0`, so the same discriminator cannot classify them,
- * and suppressing them wholesale would eat the opening press of a legitimate
- * new gesture (and interfere with pointer capture and dragging). Keyboard- and
- * AT-synthesised clicks also report 0 and pass through untouched, by design.
+ * those report `detail === 0` in current engines (de-facto again — w3c/pointer
+ * events#98 is still open on whether that is required), so the same
+ * discriminator cannot classify them, and suppressing them wholesale would eat
+ * the opening press of a legitimate new gesture and interfere with pointer
+ * capture and dragging. Keyboard- and AT-synthesised clicks also report 0 and
+ * pass through untouched, by design — that one IS normative, since a click
+ * dispatched with no underlying native event initialises `detail` to 0.
  */
 const GUARDED_EVENTS = ['mousedown', 'mouseup', 'click', 'dblclick'] as const;
 
@@ -104,10 +122,17 @@ function armGestureTailGuard() {
   disarmActiveGestureTailGuard = disarm;
 }
 
-/** How long after a press inside the dialog a teardown still counts as caused
- *  by that press. Only decides whether to ARM; the guard's own lifetime is
- *  bounded by the next fresh press, not by this. */
-const POINTER_CAUSED_CLOSE_MS = 1000;
+/** How long after a COMPLETED click inside the dialog a teardown still counts
+ *  as caused by that click. Only decides whether to ARM; the guard's own
+ *  lifetime is bounded by the next fresh press, not by this.
+ *
+ *  Deliberately keyed on `click`, not `mousedown`: a press that never completes
+ *  a click inside the dialog — starting a text selection, then dismissing with
+ *  Escape — leaves no gesture tail to guard against, and arming there would
+ *  only create the opposite bug. A completed click immediately followed by an
+ *  Escape close inside this window does still arm; that costs one ignored click
+ *  at the vacated coordinates, the same trade-off documented above. */
+const CLICK_CAUSED_CLOSE_MS = 150;
 
 // The portal must be gone before the guard is installed, and the listener must
 // be in place before the browser dispatches the next press. A layout effect's
@@ -175,17 +200,23 @@ export function Dialog({
     };
   }, [open]);
 
-  // #3705: arm the guard as the portal is torn out — but ONLY when a press
-  // inside the dialog could have caused the teardown (confirm, Cancel, a
-  // backdrop click). Escape, an async settle and a route change have no gesture
-  // in flight, and arming after those would let the guard eat a deliberate
-  // click, or leak into whatever screen renders next. StrictMode's extra
-  // setup/cleanup cycle is filtered out by the same test.
-  const lastPointerDownAtRef = useRef(0);
+  // #3705: arm the guard as the portal is torn out — but ONLY when a completed
+  // click inside the dialog could plausibly have caused the teardown (Confirm,
+  // Cancel, a backdrop click). Escape with no completed click, a slow async
+  // settle and a route change all leave the guard off, and arming after those
+  // would let it eat a deliberate click or leak into whatever screen renders
+  // next. StrictMode's extra setup/cleanup cycle is filtered out by the same
+  // test, since `lastClickInsideAtRef` is still 0 at mount.
+  //
+  // "Plausibly" is doing real work here: this is a time window, not causation.
+  // An action that settles and closes the dialog in under CLICK_CAUSED_CLOSE_MS
+  // still arms. That is the conservative direction — the cost is the same one
+  // ignored click documented above, at coordinates the user just clicked.
+  const lastClickInsideAtRef = useRef(0);
   useIsomorphicLayoutEffect(() => {
     if (!open) return;
     return () => {
-      if (Date.now() - lastPointerDownAtRef.current < POINTER_CAUSED_CLOSE_MS) {
+      if (Date.now() - lastClickInsideAtRef.current < CLICK_CAUSED_CLOSE_MS) {
         armGestureTailGuard();
       }
     };
@@ -232,8 +263,8 @@ export function Dialog({
       style={{ animation: 'dialog-backdrop-in 150ms ease-out' }}
       onClick={handleBackdropClick}
       onKeyDown={handleKeyDown}
-      onMouseDownCapture={() => {
-        lastPointerDownAtRef.current = Date.now();
+      onClickCapture={() => {
+        lastClickInsideAtRef.current = Date.now();
       }}
     >
       <div

--- a/apps/web/src/components/shared/Dialog.tsx
+++ b/apps/web/src/components/shared/Dialog.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useLayoutEffect,
   useRef,
   useCallback,
   type ReactNode,
@@ -25,6 +26,93 @@ const maxWidthClass: Record<DialogMaxWidth, string> = {
 
 const FOCUSABLE =
   'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+/* Gesture-tail guard (#3705).
+ *
+ * A dialog closes by tearing its portal out of the DOM, so on a REAL
+ * double-click the second physical press is hit-tested AFTER the backdrop is
+ * gone — against whatever now occupies those coordinates. Confirm buttons sit
+ * centred over dense list and grid layouts whose rows carry live actions, so
+ * the hazard is not a duplicate of the action just confirmed; it is an
+ * UNRELATED action firing from the second half of the gesture.
+ *
+ * The discriminator is `MouseEvent.detail`, the platform click counter.
+ * Chromium, Gecko and WebKit all derive it from the button, the time and the
+ * distance between presses rather than from the DOM target, so the second
+ * press still reports `detail === 2` even though it now lands on a different
+ * element. (That is consistent de-facto behaviour across the three engines
+ * rather than a normative guarantee: UI Events defines the counter but does not
+ * say that a change of target must leave it alone. The latch in ConfirmDialog
+ * is the belt to this pair of braces.)
+ *
+ * A deliberate NEW double-click after the dialog closed begins with a press
+ * whose `detail` is 1, which stands the guard down before its own second press
+ * arrives — so intentional double-clicks keep working. That is also what bounds
+ * the guard's lifetime: it retires on the next fresh press rather than on a
+ * timer, because OS double-click intervals are user-configurable (Windows
+ * allows up to 5s) and any fixed ceiling would either expire before the second
+ * press or linger well past it.
+ *
+ * KNOWN TRADE-OFF. The counter cannot distinguish "second half of an
+ * accidental double-click" from "deliberate fast click at the same spot right
+ * after confirming" — both arrive as `detail >= 2`, and the second one is
+ * therefore swallowed until the user pauses long enough for the counter to
+ * reset. Because the counter only increments for presses within a few pixels
+ * of the last one, that costs at most a repeated click at the coordinates the
+ * confirm button just vacated, and it errs on the side of not firing a
+ * destructive command the user did not aim at. The place most likely to feel
+ * it is the remote FileManager, whose table rows are double-click-to-open and
+ * reflow underneath a delete confirm.
+ *
+ * SCOPE — deliberately narrow. This blocks the mouse/click activation tail and
+ * nothing else. Handlers bound to `pointerdown`/`pointerup` are NOT covered:
+ * those report `detail === 0`, so the same discriminator cannot classify them,
+ * and suppressing them wholesale would eat the opening press of a legitimate
+ * new gesture (and interfere with pointer capture and dragging). Keyboard- and
+ * AT-synthesised clicks also report 0 and pass through untouched, by design.
+ */
+const GUARDED_EVENTS = ['mousedown', 'mouseup', 'click', 'dblclick'] as const;
+
+let disarmActiveGestureTailGuard: (() => void) | null = null;
+
+function armGestureTailGuard() {
+  if (typeof document === 'undefined') return;
+  // Stacked dialogs: only ever one guard installed.
+  disarmActiveGestureTailGuard?.();
+
+  const disarm = () => {
+    for (const type of GUARDED_EVENTS) document.removeEventListener(type, onEvent, true);
+    if (disarmActiveGestureTailGuard === disarm) disarmActiveGestureTailGuard = null;
+  };
+
+  // `UIEvent`, not React's imported `MouseEvent` — these are native events.
+  function onEvent(e: Event) {
+    if ((e as UIEvent).detail >= 2) {
+      e.preventDefault();
+      e.stopPropagation();
+      // React attaches its listener to the root container, a descendant of
+      // document, so stopping here in the capture phase means the tail of the
+      // gesture never reaches any handler underneath.
+      e.stopImmediatePropagation();
+      return;
+    }
+    // detail <= 1 — a genuinely new gesture. Stand down and let it through.
+    if (e.type === 'mousedown' || e.type === 'click') disarm();
+  }
+
+  for (const type of GUARDED_EVENTS) document.addEventListener(type, onEvent, true);
+  disarmActiveGestureTailGuard = disarm;
+}
+
+/** How long after a press inside the dialog a teardown still counts as caused
+ *  by that press. Only decides whether to ARM; the guard's own lifetime is
+ *  bounded by the next fresh press, not by this. */
+const POINTER_CAUSED_CLOSE_MS = 1000;
+
+// The portal must be gone before the guard is installed, and the listener must
+// be in place before the browser dispatches the next press. A layout effect's
+// cleanup runs inside the commit, which is both; a passive one runs after.
+const useIsomorphicLayoutEffect = typeof document !== 'undefined' ? useLayoutEffect : useEffect;
 
 export interface DialogProps {
   open: boolean;
@@ -87,6 +175,22 @@ export function Dialog({
     };
   }, [open]);
 
+  // #3705: arm the guard as the portal is torn out — but ONLY when a press
+  // inside the dialog could have caused the teardown (confirm, Cancel, a
+  // backdrop click). Escape, an async settle and a route change have no gesture
+  // in flight, and arming after those would let the guard eat a deliberate
+  // click, or leak into whatever screen renders next. StrictMode's extra
+  // setup/cleanup cycle is filtered out by the same test.
+  const lastPointerDownAtRef = useRef(0);
+  useIsomorphicLayoutEffect(() => {
+    if (!open) return;
+    return () => {
+      if (Date.now() - lastPointerDownAtRef.current < POINTER_CAUSED_CLOSE_MS) {
+        armGestureTailGuard();
+      }
+    };
+  }, [open]);
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
       if (e.key === 'Escape') {
@@ -128,6 +232,9 @@ export function Dialog({
       style={{ animation: 'dialog-backdrop-in 150ms ease-out' }}
       onClick={handleBackdropClick}
       onKeyDown={handleKeyDown}
+      onMouseDownCapture={() => {
+        lastPointerDownAtRef.current = Date.now();
+      }}
     >
       <div
         ref={panelRef}


### PR DESCRIPTION
Closes #3705.

You framed this against all three `ConfirmDialog` call sites in `DevicesPage.tsx` rather than the one #3703 added, and said you had not confirmed the click-through actually reproduces.

**It reproduces.** With the fix reverted and the new tests kept, a double-click on the device-reboot confirm queues a **fleet Wake** — an action the operator never aimed at.

## Files touched (5)

| File | What |
|---|---|
| `apps/web/src/components/shared/Dialog.tsx` | gesture-tail guard (new) |
| `apps/web/src/components/shared/ConfirmDialog.tsx` | synchronous single-fire latch (new) |
| `apps/web/src/components/shared/ConfirmDialog.test.tsx` | **new file**, 10 tests |
| `apps/web/src/components/devices/DevicesPage.tsx` | comments only — the two that documented the old "the unmount is what saves us" reasoning |
| `apps/web/src/components/devices/DevicesPage.test.tsx` | 1 new test (the reproduction) |

## The bug

`Dialog` returns `null` when `!open`, so confirming removes the backdrop and the panel together. The first press lands on Confirm, React flushes, the portal is gone — and the second press of the same physical double-click is hit-tested against whatever now occupies those coordinates. The `DevicesPage` confirms sit centred over the bulk action bar and the device rows.

The existing coverage could not see this: it dispatches twice at a cached, detached node, which proves only that the *same* button cannot fire twice.

---

## ⚠️ I diverged from your suggested direction — please accept or reject this on the merits

Your suggestion in the issue was: **keep the dialog open with `isLoading` while the action runs so the backdrop keeps absorbing clicks, add a `useRef` re-entry guard, close on settle.**

I took the ref guard as you described it. I did **not** take the hold-the-dialog-open half, and instead put the click-through fix inside `Dialog`. Two reasons:

1. **Holding the dialog open only moves the window; it does not close it.** When the action settles and the dialog finally does close, a double-click *at that moment* has exactly the same click-through. So does a double-click on **Cancel**, and so does one on the **backdrop** — neither of which an `isLoading` spinner covers at all, because neither runs an action. The teardown is the hazard, and every exit path has one.
2. **It would be a behavioural contract change at 48 call sites.** Every `ConfirmDialog` caller would have to make `onConfirm` awaitable to get any benefit, and until it did it would stay exposed. Fixing it in the shared component covers all of them without touching any.

**What your direction is better at, and what I have therefore left on the table:** for a slow network-backed action, keeping the backdrop up genuinely does absorb the *whole* original gesture, communicates progress, and blocks unrelated interaction while something destructive is pending. That is better UX than what is here. The latch below is what makes that pattern *safe* to adopt — the trap documented in `DevicesPage.tsx` ("no `isLoading` here on purpose") is now gone. I deliberately did not convert the three call sites myself: that reshapes three destructive-action flows and is your call, not a side effect of a bug fix. Happy to do it in a follow-up if you want it.

If you would rather have your original shape, say so and I will rework it.

---

## What changed

### 1. `ConfirmDialog` — synchronous single-fire latch (your suggestion)

A `useRef` latch on the confirm handler. `disabled={isLoading}` and a call site's own `actionInProgress` both read a value captured at render and are still `false` when the second click lands; a ref reads current. It releases when `isLoading` settles back to false so a failed action stays retryable, and on a synchronous throw — which never reaches the close or the `isLoading` toggle — so the button cannot be permanently killed.

### 2. `Dialog` — gesture-tail guard

On teardown, a capture-phase document listener swallows any `mousedown`/`mouseup`/`click`/`dblclick` carrying `detail >= 2`.

`MouseEvent.detail` is the platform click counter. Chromium, Gecko and WebKit all derive it from the button, the time and the distance between presses, never from the DOM target — so the second press still reports `detail === 2` even though it now lands on a different element. That identifies "tail of the gesture that ended on the dialog" with no coordinate maths. (This is consistent de-facto behaviour across the three engines, not a normative guarantee; the latch above is the belt to this pair of braces.)

Three things stop it over-blocking:

- **A new gesture disarms it.** A deliberate double-click after the dialog closes opens with a press whose `detail` is 1, standing the guard down before its own second press arrives. That also bounds its lifetime — there is no timer, because OS double-click intervals are user-configurable (Windows allows up to 5s) and any fixed ceiling would either expire early or linger.
- **It only arms on a teardown a completed *click* inside the dialog could have caused** (within 150ms). Keying this on `mousedown` — which is what the first push did — armed on orderings with no gesture in flight, most concretely "start a text selection inside the dialog, dismiss with Escape", which then ate the user's next click. This also makes StrictMode's extra cleanup cycle inert. It is a time window, not causation: an action that settles and closes in under 150ms still arms, which is the conservative direction.
- **Keyboard and AT clicks report `detail === 0`** and pass through untouched.

---

## ⚠️ This guard is on the shared `Dialog`, so it affects every dialog in the app

Not just the three `DevicesPage` confirms. Swept:

- **Shared `Dialog`: 57 render sites across 50 non-test files.**
- **Shared `ConfirmDialog`: 48 render sites across 38 non-test files.**

(`admin/AccountDeletionRequestDetail.tsx` defines its own unrelated local `ConfirmDialog` and is excluded. `remote/DeleteConfirmDialog.tsx` wraps the shared `Dialog` directly and is counted in the `Dialog` totals.)

All 48 `ConfirmDialog` sites were checked against the **latch** — the only change with call-site-visible behaviour — and **none need changes**. Each is either sync-close-on-confirm (latch moot), or keeps the dialog open behind an `isLoading` that toggles in a `try/finally` (which is exactly what unlatches it for retry), or renders conditionally so the ref resets on unmount.

### Where a wanted click could now be swallowed

The guard cannot distinguish "second half of an accidental double-click" from "deliberate fast click at the same spot right after confirming" — both arrive as `detail >= 2`. Because the counter only increments for presses within a few pixels of the previous one, the cost is bounded to a repeated click at the coordinates the confirm button just vacated. Erring that way is the right side for a destructive-action confirm, but it is a real trade-off and it is documented in the code.

It also survives a client-side route change — the platform counter is not reset by SPA navigation — so if `onConfirm` navigates and the new screen puts a control where the confirm button was, the user's first click on it can be counted as the second of a pair and swallowed. Scoping the guard by coordinates would not help: a `detail >= 2` event is already, by construction, within a few pixels of the click that armed it. Clicking again works, which is the recovery in every case.

**One concrete place it is likely to be felt: `apps/web/src/components/remote/FileManager.tsx`.** Its table rows are `onDoubleClick`-to-open (`:1484` → `initiateDownload`), and both the delete confirm (`:1692`) and the disk-cleanup confirm (`:1698`) are centred modals over that table. Delete files → confirm → the table reflows → immediately double-click a row to open the next file, and that double-click can land in the vacated confirm-button spot inside the counter window and be ignored. The user clicks again and it works; nothing is lost. It is one of only three `onDoubleClick` handlers in the whole web app.

Explicitly checked and **ruled out**:

- **Nested dialogs.** All 12 files importing both were checked. Only `DRExecutionView.tsx` and `PatchApprovalModal.tsx` are genuinely nested (inner opens while outer stays mounted); in both, the outer dialog's remaining content is a sparse form / static status list with nothing clickable under the confirm's position. The other 10 are page-level siblings that cannot be open simultaneously.
- **Steppers / +/- / repeat-click controls.** None exist — quantity in the quote/invoice/contract line-item editors is a plain `type="number"` input throughout.
- **`onMouseDown`/`onPointerDown` action handlers.** Four app-wide, none near a dialog teardown: a drag-start in `DashboardCustomizer.tsx:830`, an autocomplete select in `AuditFilters.tsx:224`, and two `preventDefault`-only focus-preservers in rich-text toolbars.

**Not verified:** actual pixel overlap between a closing confirm button and the row that reflows under it. That needs a running browser, not static analysis — the FileManager risk above is a layout-plausibility judgement, not a measurement.

## Verification

**Tests.** `ConfirmDialog.test.tsx` (new, 8) + 1 new `DevicesPage.test.tsx` case. jsdom has no layout, so it cannot pick the hit-test target itself — the tests hand the second press to the element underneath, which is what a browser does. What *is* faithfully modelled is the part that is ours: the press arrives carrying `detail === 2` and the guard must swallow it. A Playwright `dblclick()` in both list and grid layouts remains the stronger proof and is worth adding to the e2e suite separately.

**Control run** (both guards reverted, tests kept):

| Test | Against `origin/main` |
|---|---|
| `a double-click on confirm cannot fire an unrelated action underneath` (DevicesPage) | **FAILS** — `sendBulkWakeCommand` called once. This is #3705. |
| `swallows the second press after the dialog is torn down` | FAILS |
| `guards a Cancel press too` | FAILS |
| `ignores the second click on a dialog that stays mounted` | FAILS |
| `survives two dialogs closing back to back` | FAILS |
| the over-blocking guards (fresh click, deliberate dblclick, keyboard click, press-then-Escape) | pass — correctly unaffected |

`does NOT arm after a press inside the dialog that ends in Escape` passes against `origin/main` (no guard, nothing to swallow) and **fails against the first commit of this PR**, which armed on `mousedown`. That is the regression it exists to catch. `releases the latch when onConfirm throws` likewise passes against `origin/main` (no latch to stick) and fails if the `catch` is stripped from the latched version.

**Local runs** (`--pool=forks --maxWorkers=1`), every directory that renders a dialog:

| Scope | Result |
|---|---|
| `components/shared` | 10 files / 73 tests |
| `components/devices` | 56 files / 671 tests |
| `components/dr` + `patches` | 11 files / 114 tests |
| `components/remote` + `contracts` | 38 files / 257 tests |
| `components/billing` + `settings` | 154 files / 1391 tests |
| `tickets`, `snmp`, `pam`, `clientAi`, `software`, `monitors`, `discovery`, `sensitiveData`, `account` | 60 files / 630 tests |
| **Total** | **329 files / 3136 tests, all passing** |

- `astro check`: **0 errors, 0 warnings** (1672 files)
- `eslint`: clean on all five touched files
- **CI: `Test Web`, `Test API` and `Lint` all green** on the first commit — that is the full web suite, and it covers what I could not finish locally.
- **Full `@breeze/web` suite: NOT run to completion locally** — concurrent runs on this host kept getting killed for resource contention. Relying on CI's **Test Web** job for the remainder. Everything above is the dialog-consuming surface, but it is not the whole suite and I am not claiming it is.

## Not addressed

- **Keyboard key-repeat through focus restoration.** `Dialog` returns focus to the trigger on close, so a held Enter could in principle re-activate it. Different mechanism from the coordinate hit-test this issue is about; out of scope here.
- **`PossibleReplacementBanner.handleDecommission`** resets its busy/close state by hand on both paths instead of `try/finally` — the one outlier among ~20 similar handlers. Functionally safe today, more fragile to future edits. Pre-existing, untouched here; worth a separate tidy.
- Converting the three `DevicesPage` dialogs to the stay-mounted spinner shape — now safe, but your call (see the divergence section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
