### PR TITLE
feat(api): agent-originated intents live — propose, decide, release (AI agents wave 3b)

### DIFF
--- a/apps/api/migrations/2026-09-06-a-agent-runs-org-immutable.sql
+++ b/apps/api/migrations/2026-09-06-a-agent-runs-org-immutable.sql
@@ -1,0 +1,107 @@
+-- AI agents wave 3b (#3824): agent-run history stays with the source org.
+--
+-- Owner decision 2026-08-23: when a device moves between orgs, its
+-- ai_agent_runs (and the action_intents attributed to them via the composite
+-- tenant FK) do NOT follow. moveOrg.ts now detaches device_id instead of
+-- re-stamping org_id, and ai_agent_runs is no longer in
+-- CORE_DEVICE_ORG_DENORMALIZED_TABLES. With that, no legitimate writer of
+-- org_id remains, so it joins the immutable set the 2026-09-02 migration
+-- deliberately left it out of ("moveOrg re-stamps it in the same
+-- transaction") — that rationale is now retired.
+--
+-- THREE function replacements, all fix-forward (the shipped 2026-05-18 and
+-- 2026-09-02 files are untouched). CREATE OR REPLACE replaces the WHOLE body:
+-- each block below is the live pg_get_functiondef output plus ONLY the change
+-- its comment names — verify before commit, a dropped line is a permanently
+-- missing guard.
+
+-- 1) The DB-layer device-move cascade (#750, 2026-05-18) discovers every
+--    table carrying uuid device_id + uuid org_id dynamically, so it would
+--    keep re-stamping ai_agent_runs.org_id on ANY devices.org_id flip —
+--    raising against the immutability guard below (and, before that guard,
+--    23503 against the action_intents composite tenant FK the moment an
+--    agent proposal existed). ai_agent_runs is the one device-child table
+--    whose org_id must NOT follow the device, so exclude it from discovery.
+--    (The rls-coverage drift audit iterates this same function; retained
+--    runs are detached — device_id NULL — so they can never drift anyway.)
+--    Change vs live body: the `t.relname <> 'ai_agent_runs'` predicate.
+CREATE OR REPLACE FUNCTION public.breeze_device_child_orgid_tables()
+  RETURNS SETOF text
+  LANGUAGE sql
+  STABLE
+  AS $$
+  SELECT t.relname::text
+  FROM pg_class t
+  JOIN pg_namespace n ON n.oid = t.relnamespace
+  WHERE n.nspname = 'public'
+    AND t.relkind = 'r'
+    AND t.relname <> 'devices'
+    -- ai_agent_runs: agent-run history stays with the SOURCE org on a device
+    -- move (owner decision 2026-08-23); its org_id is trigger-immutable.
+    AND t.relname <> 'ai_agent_runs'
+    AND EXISTS (
+      SELECT 1 FROM pg_attribute a
+      WHERE a.attrelid = t.oid AND a.attname = 'device_id'
+        AND NOT a.attisdropped AND a.atttypid = 'uuid'::regtype
+    )
+    AND EXISTS (
+      SELECT 1 FROM pg_attribute a
+      WHERE a.attrelid = t.oid AND a.attname = 'org_id'
+        AND NOT a.attisdropped AND a.atttypid = 'uuid'::regtype
+    );
+$$;
+
+-- 2) The cascade trigger enforces the owner decision at the DB layer for
+--    EVERY path that flips devices.org_id (the 2026-05-18 rationale: org
+--    moves also come from ops/direct SQL, not just the moveOrg route): it
+--    now severs the moved device's run lineage instead of re-stamping it.
+--    All three FKs are ON DELETE SET NULL — nullable by design. alerts and
+--    ai_sessions DO follow the device (re-stamped by the loop), so a
+--    retained source-org run keeping alert_id/session_id would point across
+--    tenants. moveOrg.ts runs the same detach explicitly; after this
+--    trigger fires it matches nothing, which is fine (idempotent).
+--    Change vs live body: the ai_agent_runs detach UPDATE before the loop.
+CREATE OR REPLACE FUNCTION public.breeze_cascade_device_org_id()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_catalog
+  AS $$
+DECLARE
+  child_table text;
+BEGIN
+  -- Agent-run history stays with the SOURCE org (owner decision 2026-08-23):
+  -- sever the moved device's lineage links instead of re-stamping org_id.
+  UPDATE public.ai_agent_runs
+    SET device_id = NULL, alert_id = NULL, session_id = NULL
+    WHERE device_id = NEW.id;
+  FOR child_table IN SELECT public.breeze_device_child_orgid_tables() LOOP
+    EXECUTE format(
+      'UPDATE public.%I SET org_id = $1 WHERE device_id = $2 AND org_id IS DISTINCT FROM $1',
+      child_table
+    ) USING NEW.org_id, NEW.id;
+  END LOOP;
+  RETURN NULL; -- AFTER trigger; return value ignored
+END;
+$$;
+
+-- 3) The immutability guard (2026-09-02) gains org_id: with moveOrg no
+--    longer re-stamping and the cascade above no longer touching the table,
+--    no legitimate writer of org_id remains. RLS WITH CHECK still fences
+--    cross-org writes; this also stops a same-actor rewrite.
+--    Change vs live body: the org_id line.
+CREATE OR REPLACE FUNCTION public.ai_agent_runs_immutable_guard() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.agent_id IS DISTINCT FROM OLD.agent_id
+     OR NEW.org_id IS DISTINCT FROM OLD.org_id
+     OR NEW.trigger_kind IS DISTINCT FROM OLD.trigger_kind
+     OR NEW.trigger_event_id IS DISTINCT FROM OLD.trigger_event_id
+     OR NEW.trigger_ref IS DISTINCT FROM OLD.trigger_ref
+     OR NEW.dedupe_key IS DISTINCT FROM OLD.dedupe_key
+     OR NEW.mode_at_start IS DISTINCT FROM OLD.mode_at_start
+     OR NEW.policy_snapshot IS DISTINCT FROM OLD.policy_snapshot THEN
+    RAISE EXCEPTION 'ai_agent_runs: immutable column changed' USING ERRCODE = 'integrity_constraint_violation';
+  END IF;
+  RETURN NEW;
+END $$;

--- a/apps/api/src/__tests__/integration/agentIntentLifecycle.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentIntentLifecycle.integration.test.ts
@@ -1,0 +1,598 @@
+/**
+ * End-to-end integration proof for wave 3b (#3824): an agent-originated
+ * action intent lives its whole life against real Postgres — an `ai_agent`
+ * principal proposes, an action-and-target-eligible human sees and decides
+ * it, and the durable release worker re-derives authority from the run's
+ * policy snapshot AND the agent's current effective policy before executing
+ * under the reconstructed agent context. This is the regression barrier PR
+ * 3c builds its runner on.
+ *
+ * Why integration and not unit: every unit suite on this path mocks `../db`
+ * wholesale, so none of them can prove the cross-context choreography —
+ * system-scoped fan-out under Shape-6 RLS, the decide route's live
+ * `isAgentIntentDecideAuthorized` re-check, the release worker's
+ * snapshot ∧ current double-gate, and the REAL DB effect (a
+ * `device_commands` row) of the released tool. The fixture tool is
+ * `manage_services` `restart` — genuinely Tier 3 (TIER3_ACTIONS) and
+ * `supervised`-scoped (TIER3_SUPERVISED_ACTIONS), dispatching an observable
+ * `restart_service` device command.
+ *
+ * Lives under `src/__tests__/integration/` so both vitest configs' wholesale
+ * globs pick it up (anywhere else runs in ZERO CI jobs — see
+ * intentFanout.integration.test.ts's header for the full rationale).
+ */
+import './setup';
+import { getTestDb } from './setup';
+
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { createAiAgentSchema } from '@breeze/shared';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  actionIntents,
+  aiAgentRuns,
+  aiAgents,
+  approvalRequests,
+  deviceCommands,
+  devices,
+  organizationUsers,
+} from '../../db/schema';
+import { buildOrgAccessClosures, type AuthContext } from '../../middleware/auth';
+import { buildAgentAuthContext } from '../../services/aiAgents/agentAuthContext';
+import { createAgent } from '../../services/aiAgents/agentService';
+import { InvalidAgentRecipientsError, validateAgentRecipients } from '../../services/aiAgents/recipients';
+import { createActionIntent, ActionIntentError } from '../../services/actionIntents/intentService';
+import { isAgentIntentDecideAuthorized } from '../../services/actionIntents/intentApprovers';
+import { checkToolPermission } from '../../services/aiGuardrails';
+import { releaseApprovedIntent } from '../../jobs/intentReleaseWorker';
+import { approvalRoutes } from '../../routes/approvals';
+import { createAccessToken, type TokenPayload } from '../../services/jwt';
+import {
+  assignUserToOrganization,
+  createOrganization,
+  createPartner,
+  createRole,
+  createSite,
+  createUser,
+  grantRolePermissions,
+} from './db-utils';
+
+const TOOL_NAME = 'manage_services';
+const SERVICE_NAME = 'spooler';
+const DEVICES_EXECUTE = { resource: 'devices', action: 'execute' } as const;
+
+/** The effective policy the fixture agent runs under: shadow mode (proposes,
+ * never executes unilaterally) with manage_services allowlisted. */
+function effectivePolicyFields() {
+  return {
+    enabled: true,
+    mode: 'shadow' as const,
+    model: null,
+    toolAllowlist: [TOOL_NAME],
+    protectedResources: { services: [], paths: [], registryKeys: [], deviceTags: [] },
+    limits: {},
+    triggers: {},
+    recipients: { userIds: [], roleIds: [] },
+    instructions: null,
+    cooldownSeconds: 900,
+  };
+}
+
+interface Scenario {
+  partner: { id: string };
+  org: { id: string };
+  site: { id: string };
+  otherSite: { id: string };
+  device: typeof devices.$inferSelect;
+  agent: { id: string; name: string };
+  run: { id: string };
+  creator: { id: string; email: string };
+  /** Org member holding devices:execute with NO site restriction — the one eligible decider. */
+  eligible: { id: string; email: string };
+  /** Same RBAC, but site-restricted to otherSite — action authority without target reach. */
+  wrongSite: { id: string; email: string };
+  /** Org member with approvals:decide but NOT devices:execute — four_eyes-shaped
+   * authority that must NOT qualify for a supervised agent intent. */
+  noRbac: { id: string; email: string };
+  eligibleRoleId: string;
+  decideOnlyRoleId: string;
+}
+
+/** Seeds the whole tenancy: partner-owned baseline agent (the shape
+ * resolveEffectiveAgent requires — an org-owned agent has no partner baseline
+ * and resolves to null), a device-bound run in the org, and the three-user
+ * eligibility population. */
+async function seedScenario(): Promise<Scenario> {
+  const adminDb = getTestDb() as any;
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+  const otherSite = await createSite({ orgId: org.id });
+
+  const creator = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `creator-${randomUUID()}@agentlifecycle.test`,
+  });
+
+  const eligibleRole = await createRole({ scope: 'organization', orgId: org.id });
+  await grantRolePermissions(eligibleRole.id, [DEVICES_EXECUTE]);
+
+  const decideOnlyRole = await createRole({ scope: 'organization', orgId: org.id });
+  await grantRolePermissions(decideOnlyRole.id, [{ resource: 'approvals', action: 'decide' }]);
+
+  const eligible = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `eligible-${randomUUID()}@agentlifecycle.test`,
+  });
+  await assignUserToOrganization(eligible.id, org.id, eligibleRole.id);
+
+  const wrongSite = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `wrongsite-${randomUUID()}@agentlifecycle.test`,
+  });
+  // Same role as `eligible`, but the membership row pins them to otherSite —
+  // getUserPermissions surfaces this as allowedSiteIds, which
+  // userHasActionAndTargetAuthority checks against the intent's target site.
+  await adminDb.insert(organizationUsers).values({
+    userId: wrongSite.id,
+    orgId: org.id,
+    roleId: eligibleRole.id,
+    siteIds: [otherSite.id],
+  });
+
+  const noRbac = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `norbac-${randomUUID()}@agentlifecycle.test`,
+  });
+  await assignUserToOrganization(noRbac.id, org.id, decideOnlyRole.id);
+
+  const unique = randomUUID().slice(0, 8);
+  const [device] = await adminDb
+    .insert(devices)
+    .values({
+      orgId: org.id,
+      siteId: site.id,
+      agentId: `lifecycle-agent-${unique}`,
+      hostname: `lifecycle-host-${unique}`,
+      osType: 'linux',
+      osVersion: '22.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      // Online is load-bearing: executeCommand refuses offline devices before
+      // it writes the device_commands row this suite observes.
+      status: 'online',
+    })
+    .returning();
+
+  // PARTNER-owned baseline (orgId NULL): resolveEffectiveAgent keys the
+  // current-policy half of the release gate off this row, and
+  // checkAgentReleaseAuthority requires resolved.agentId === run.agentId.
+  const [agent] = await withSystemDbAccessContext(() =>
+    db
+      .insert(aiAgents)
+      .values({
+        partnerId: partner.id,
+        orgId: null,
+        kind: 'triage',
+        name: 'Nightly Triage',
+        ...effectivePolicyFields(),
+        createdBy: creator.id,
+      })
+      .returning(),
+  );
+
+  const snapshot = {
+    schemaVersion: 1,
+    agentId: agent!.id,
+    kind: 'triage',
+    effective: effectivePolicyFields(),
+    resolvedAt: new Date().toISOString(),
+  };
+  const [run] = await withSystemDbAccessContext(() =>
+    db
+      .insert(aiAgentRuns)
+      .values({
+        agentId: agent!.id,
+        orgId: org.id,
+        deviceId: device.id,
+        triggerKind: 'alert',
+        dedupeKey: `agent-lifecycle-${randomUUID()}`,
+        modeAtStart: 'shadow',
+        policySnapshot: snapshot as never,
+      })
+      .returning(),
+  );
+
+  return {
+    partner,
+    org,
+    site,
+    otherSite,
+    device: device as typeof devices.$inferSelect,
+    agent: { id: agent!.id, name: agent!.name },
+    run: { id: run!.id },
+    creator: { id: creator.id, email: creator.email },
+    eligible: { id: eligible.id, email: eligible.email },
+    wrongSite: { id: wrongSite.id, email: wrongSite.email },
+    noRbac: { id: noRbac.id, email: noRbac.email },
+    eligibleRoleId: eligibleRole.id,
+    decideOnlyRoleId: decideOnlyRole.id,
+  };
+}
+
+/** The exact AuthContext shape PR 3c's runner will hold — built through the
+ * same factory the release path reconstructs with. */
+function agentAuthFor(s: Scenario): AuthContext {
+  return buildAgentAuthContext(
+    { id: s.agent.id, orgId: null, partnerId: s.partner.id, name: s.agent.name, kind: 'triage' },
+    { id: s.run.id, orgId: s.org.id, deviceId: s.device.id, deviceSiteId: s.site.id },
+    { id: s.org.id, partnerId: s.partner.id },
+  );
+}
+
+function restartInput(s: Scenario): Record<string, unknown> {
+  return { deviceId: s.device.id, action: 'restart', serviceName: SERVICE_NAME };
+}
+
+async function createAgentIntent(s: Scenario) {
+  return createActionIntent(agentAuthFor(s), {
+    toolName: TOOL_NAME,
+    input: restartInput(s),
+    source: 'ai_agent',
+  });
+}
+
+async function accessTokenFor(
+  user: { id: string; email: string },
+  orgId: string,
+  partnerId: string,
+  roleId: string,
+): Promise<string> {
+  const payload: Omit<TokenPayload, 'type'> = {
+    sub: user.id,
+    email: user.email,
+    roleId,
+    orgId,
+    partnerId,
+    scope: 'organization',
+    mfa: false,
+    aep: 1,
+    mep: 1,
+    sid: randomUUID(),
+  };
+  return createAccessToken(payload);
+}
+
+function approvalsApp(): Hono {
+  const app = new Hono();
+  app.route('/approvals', approvalRoutes);
+  return app;
+}
+
+async function approveViaRoute(
+  s: Scenario,
+  decider: { id: string; email: string },
+  roleId: string,
+  approvalRowId: string,
+): Promise<Response> {
+  const token = await accessTokenFor(decider, s.org.id, s.partner.id, roleId);
+  return approvalsApp().request(`/approvals/${approvalRowId}/approve`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+}
+
+async function readIntent(intentId: string) {
+  const [row] = await withSystemDbAccessContext(() =>
+    db.select().from(actionIntents).where(eq(actionIntents.id, intentId)).limit(1),
+  );
+  return row!;
+}
+
+async function fanOutRowsFor(intentId: string) {
+  return withSystemDbAccessContext(() =>
+    db
+      .select({ id: approvalRequests.id, userId: approvalRequests.userId })
+      .from(approvalRequests)
+      .where(eq(approvalRequests.intentId, intentId)),
+  );
+}
+
+async function restartCommandsFor(deviceId: string) {
+  const adminDb = getTestDb() as any;
+  return adminDb
+    .select()
+    .from(deviceCommands)
+    .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.type, 'restart_service')));
+}
+
+/** Plays the device's part: polls for the dispatched restart_service command
+ * and completes it, so executeCommand's waitForCommandResult loop returns a
+ * real result instead of burning its 30s timeout. Runs concurrently with
+ * releaseApprovedIntent. */
+async function completeRestartCommand(deviceId: string): Promise<string | null> {
+  const adminDb = getTestDb() as any;
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const rows = await restartCommandsFor(deviceId);
+    const cmd = rows[0];
+    if (cmd) {
+      await adminDb
+        .update(deviceCommands)
+        .set({
+          status: 'completed',
+          result: { status: 'completed', output: `${SERVICE_NAME} restarted` },
+          completedAt: new Date(),
+        })
+        .where(eq(deviceCommands.id, cmd.id));
+      return cmd.id as string;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  return null;
+}
+
+/** Creates a pending agent intent and approves it through the real route as
+ * the eligible decider — the shared preamble of the release-path tests. */
+async function createAndApprove(s: Scenario): Promise<string> {
+  const snapshot = await createAgentIntent(s);
+  expect(snapshot.status).toBe('pending_approval');
+  const rows = await fanOutRowsFor(snapshot.id);
+  expect(rows).toHaveLength(1);
+  const res = await approveViaRoute(s, s.eligible, s.eligibleRoleId, rows[0]!.id);
+  expect(res.status, JSON.stringify(await res.clone().json())).toBe(200);
+  const approved = await readIntent(snapshot.id);
+  expect(approved.status).toBe('approved');
+  return snapshot.id;
+}
+
+beforeEach(() => {
+  // The kill switch defaults OFF; every guardrail evaluation on this path
+  // (creation re-verify, release snapshot ∧ current) reads it at call time.
+  vi.stubEnv('BREEZE_AI_AGENTS_ENABLED', 'true');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('agent-originated intent lifecycle (real Postgres, breeze_app)', () => {
+  it('full lifecycle: agent creates -> eligible human sees -> approves -> release executes under agent auth', async () => {
+    const s = await seedScenario();
+
+    // 1. The agent proposes. Requester-less, attributed to the run, and the
+    // supervised fan-out lands on EXACTLY the action-and-target-eligible
+    // human: not the wrong-site holder of the same role, not the
+    // approvals:decide holder without devices:execute.
+    const snapshot = await createAgentIntent(s);
+    expect(snapshot.status).toBe('pending_approval');
+    const intentRow = await readIntent(snapshot.id);
+    expect(intentRow.source).toBe('ai_agent');
+    expect(intentRow.originPrincipalKind).toBe('ai_agent');
+    expect(intentRow.originPrincipalId).toBe(s.agent.id);
+    expect(intentRow.requestedByUserId).toBeNull();
+    expect(intentRow.requestingAgentRunId).toBe(s.run.id);
+    expect(intentRow.approvalScope).toBe('supervised');
+
+    const fanOut = await fanOutRowsFor(snapshot.id);
+    expect(fanOut.map((r) => r.userId)).toEqual([s.eligible.id]);
+
+    // 2. The eligible human SEES it: the live-authorized /pending feed
+    // includes the row and labels its agent origin (gap 5 + Task 9 serialize).
+    const token = await accessTokenFor(s.eligible, s.org.id, s.partner.id, s.eligibleRoleId);
+    const pendingRes = await approvalsApp().request('/approvals/pending', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(pendingRes.status).toBe(200);
+    const pending = (await pendingRes.json()) as {
+      approvals: Array<{ id: string; origin: string; agentName: string | null }>;
+    };
+    const mine = pending.approvals.find((a) => a.id === fanOut[0]!.id);
+    expect(mine).toBeDefined();
+    expect(mine!.origin).toBe('ai_agent');
+    expect(mine!.agentName).toBe('Nightly Triage');
+
+    // 3. They approve through the REAL route (live isAgentIntentDecideAuthorized
+    // re-check + the full assurance ladder — agent intents never take the
+    // supervised self-decide skip).
+    const approveRes = await approveViaRoute(s, s.eligible, s.eligibleRoleId, fanOut[0]!.id);
+    expect(approveRes.status, JSON.stringify(await approveRes.clone().json())).toBe(200);
+    expect((await readIntent(snapshot.id)).status).toBe('approved');
+
+    // 4. The durable worker releases: revalidation reconstructs the ai_agent
+    // context from the run (buildAgentOwnedAuthContext), checkAgentReleaseAuthority
+    // passes on snapshot AND current policy, and the tool executes — the real,
+    // observable DB effect is the restart_service device command.
+    const completer = completeRestartCommand(s.device.id);
+    await releaseApprovedIntent(snapshot.id);
+    const commandId = await completer;
+    expect(commandId, 'expected the released tool to dispatch a restart_service device command').not.toBeNull();
+
+    const released = await readIntent(snapshot.id);
+    expect(released.status).toBe('completed');
+    expect(released.executedAt).not.toBeNull();
+
+    const commands = await restartCommandsFor(s.device.id);
+    expect(commands).toHaveLength(1);
+    expect(commands[0].payload).toMatchObject({ name: SERVICE_NAME });
+    // The synthetic agent id is NOT a users row: created_by must be NULL
+    // (attribution lives on the intent/run), never a dangling or forged user id.
+    expect(commands[0].createdBy).toBeNull();
+  }, 60_000);
+
+  it('release vetoes after the operator narrows the allowlist post-approval', async () => {
+    const s = await seedScenario();
+    const intentId = await createAndApprove(s);
+
+    // Operator narrows the CURRENT policy after approval; the run's snapshot
+    // still allowlists the tool, so only the current-policy half of
+    // checkAgentReleaseAuthority can produce this veto.
+    await withSystemDbAccessContext(() =>
+      db.update(aiAgents).set({ toolAllowlist: [] }).where(eq(aiAgents.id, s.agent.id)),
+    );
+
+    await releaseApprovedIntent(intentId);
+    const released = await readIntent(intentId);
+    expect(released.status).toBe('failed');
+    expect(released.errorCode).toBe('agent_policy_denied');
+    expect(released.executedAt).toBeNull();
+    expect(await restartCommandsFor(s.device.id)).toHaveLength(0);
+  }, 60_000);
+
+  it('release vetoes after the agent is disabled post-approval', async () => {
+    const s = await seedScenario();
+    const intentId = await createAndApprove(s);
+
+    await withSystemDbAccessContext(() =>
+      db.update(aiAgents).set({ enabled: false }).where(eq(aiAgents.id, s.agent.id)),
+    );
+
+    await releaseApprovedIntent(intentId);
+    const released = await readIntent(intentId);
+    expect(released.status).toBe('failed');
+    expect(released.errorCode).toBe('agent_policy_denied');
+    expect(await restartCommandsFor(s.device.id)).toHaveLength(0);
+  }, 60_000);
+
+  it('an ineligible user (wrong site) never gets a fan-out row and cannot decide', async () => {
+    const s = await seedScenario();
+    const snapshot = await createAgentIntent(s);
+    const fanOut = await fanOutRowsFor(snapshot.id);
+
+    // No row for the wrong-site holder of the SAME role, nor for the
+    // approvals:decide holder lacking the tool's RBAC.
+    expect(fanOut.map((r) => r.userId)).toEqual([s.eligible.id]);
+
+    // The decide-time predicate itself refuses both.
+    const intentRow = await readIntent(snapshot.id);
+    await expect(isAgentIntentDecideAuthorized(s.wrongSite.id, intentRow)).resolves.toBe(false);
+    await expect(isAgentIntentDecideAuthorized(s.noRbac.id, intentRow)).resolves.toBe(false);
+    await expect(isAgentIntentDecideAuthorized(s.eligible.id, intentRow)).resolves.toBe(true);
+
+    // And the route: the eligible user's row is not theirs to decide (the
+    // ownership filter 404s before anything else).
+    const res = await approveViaRoute(s, s.wrongSite, s.eligibleRoleId, fanOut[0]!.id);
+    expect(res.status).toBe(404);
+    expect((await readIntent(snapshot.id)).status).toBe('pending_approval');
+  }, 60_000);
+
+  it('RBAC deny is intact: checkToolPermission still refuses the reconstructed agent context', async () => {
+    const s = await seedScenario();
+    // Direct call with the built agent auth — pins that 3b bypassed AROUND
+    // the RBAC guard (into checkAgentReleaseAuthority), never through it.
+    const denial = await checkToolPermission(TOOL_NAME, restartInput(s), agentAuthFor(s));
+    expect(denial).toMatch(/never granted user permissions/);
+  });
+
+  it('secret invariant: a secret-bearing tool cannot become an agent intent', async () => {
+    const s = await seedScenario();
+    // m365_reset_password is Tier 3 (passes the tier gates) and secret-bearing
+    // — the agent guardrail denies it categorically, which is what keeps
+    // routes/actionIntents.ts's requester-less temp-password reveal fallback
+    // unreachable for agent intents.
+    let caught: unknown;
+    try {
+      await createActionIntent(agentAuthFor(s), {
+        toolName: 'm365_reset_password',
+        input: { userPrincipalName: 'target@customer.example' },
+        source: 'ai_agent',
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ActionIntentError);
+    expect((caught as ActionIntentError).code).toBe('agent_policy_denied');
+    expect((caught as ActionIntentError).message).toMatch(/secret-bearing/);
+
+    // Nothing was written.
+    const rows = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: actionIntents.id })
+        .from(actionIntents)
+        .where(and(eq(actionIntents.orgId, s.org.id), eq(actionIntents.actionName, 'm365_reset_password'))),
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('cross-tenant recipients cannot be stored (invalid_recipients at service level)', async () => {
+    const s = await seedScenario();
+    const foreignPartner = await createPartner();
+    const foreignOrg = await createOrganization({ partnerId: foreignPartner.id });
+    const foreignRole = await createRole({ scope: 'organization', orgId: foreignOrg.id });
+    const foreignUser = await createUser({
+      partnerId: foreignPartner.id,
+      orgId: foreignOrg.id,
+      email: `foreign-${randomUUID()}@agentlifecycle.test`,
+    });
+    await assignUserToOrganization(foreignUser.id, foreignOrg.id, foreignRole.id);
+
+    // The validator itself: an active member of ANOTHER partner's org is
+    // invalid for an org-owned agent under s.org.
+    let validationError: unknown;
+    try {
+      await validateAgentRecipients(
+        { orgId: s.org.id, partnerId: null },
+        { userIds: [foreignUser.id], roleIds: [] },
+      );
+    } catch (err) {
+      validationError = err;
+    }
+    expect(validationError).toBeInstanceOf(InvalidAgentRecipientsError);
+    expect((validationError as InvalidAgentRecipientsError).invalidUserIds).toContain(foreignUser.id);
+
+    // And through createAgent: the write is refused BEFORE anything persists.
+    const { orgCondition, canAccessOrg } = buildOrgAccessClosures([s.org.id]);
+    const creatorAuth: AuthContext = {
+      principal: { kind: 'user_session' },
+      user: { id: s.creator.id, email: s.creator.email, name: 'Creator', isPlatformAdmin: false },
+      token: {
+        sub: s.creator.id,
+        email: s.creator.email,
+        roleId: s.eligibleRoleId,
+        orgId: s.org.id,
+        partnerId: s.partner.id,
+        scope: 'organization',
+        type: 'access',
+        mfa: true,
+      },
+      partnerId: s.partner.id,
+      orgId: s.org.id,
+      scope: 'organization',
+      accessibleOrgIds: [s.org.id],
+      orgCondition,
+      canAccessOrg,
+    };
+    const orgCtx: DbAccessContext = {
+      scope: 'organization',
+      orgId: s.org.id,
+      accessibleOrgIds: [s.org.id],
+      accessiblePartnerIds: [],
+      userId: s.creator.id,
+      currentPartnerId: s.partner.id,
+    };
+    const input = createAiAgentSchema.parse({
+      kind: 'helpdesk',
+      name: 'Recipients Probe',
+      recipients: { userIds: [foreignUser.id] },
+    });
+    await expect(
+      withDbAccessContext(orgCtx, () =>
+        createAgent(creatorAuth, { orgId: s.org.id, partnerId: null }, input),
+      ),
+    ).rejects.toBeInstanceOf(InvalidAgentRecipientsError);
+
+    const stored = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: aiAgents.id })
+        .from(aiAgents)
+        .where(eq(aiAgents.orgId, s.org.id)),
+    );
+    expect(stored).toHaveLength(0);
+  });
+});

--- a/apps/api/src/__tests__/integration/agentRunMoveSemantics.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentRunMoveSemantics.integration.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Live-Postgres proof of the wave-3b move semantics for ai_agent_runs
+ * (owner decision 2026-08-23): when a device moves between orgs, its
+ * agent-run history STAYS with the source org. moveOrg no longer re-stamps
+ * ai_agent_runs.org_id (the table left CORE_DEVICE_ORG_DENORMALIZED_TABLES);
+ * instead it severs the run's device-lineage links (device_id, alert_id,
+ * session_id → NULL). With no legitimate org_id writer left, org_id joined
+ * the immutability guard (2026-09-06-a-agent-runs-org-immutable.sql).
+ *
+ * Why each case exists:
+ *  1. org_id immutability — inverts the pre-3b contract pinned by
+ *     aiAgentRuns.integration.test.ts ("org_id stays re-stampable"). A
+ *     dual-org context (what moveOrg actually runs under) passes RLS
+ *     WITH CHECK for both orgs, so the trigger is the ONLY thing stopping
+ *     a re-stamp now.
+ *  2. The exact detach statement moveOrg runs must NOT trip the composite
+ *     tenant FK (action_intents.requesting_agent_run_id, org_id) →
+ *     ai_agent_runs(id, org_id): neither referenced column changes.
+ *  3. The REAL route: a direct-SQL test alone cannot catch a forgotten
+ *     route change — this drives POST /devices/:id/move-org end to end and
+ *     asserts no cross-tenant reference survives on the retained run.
+ */
+import './setup';
+import { getTestDb } from './setup';
+
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  actionIntents,
+  aiAgentRuns,
+  aiAgents,
+  aiSessions,
+  alerts,
+  devices,
+} from '../../db/schema';
+import type { NewActionIntent } from '../../db/schema/actionIntents';
+import { createAccessToken } from '../../services/jwt';
+import { moveOrgRoutes } from '../../routes/devices/moveOrg';
+import {
+  createOrganization,
+  createPartner,
+  createSite,
+  createUser,
+  setupTestEnvironment,
+} from './db-utils';
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+function orgContext(orgId: string, currentPartnerId: string | null): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+    currentPartnerId,
+  };
+}
+
+/**
+ * SQLSTATE lands on `.cause.code` (DrizzleQueryError wraps the pg error and
+ * its own `.code`/`.message` carry the query, not the violation), so a plain
+ * `.rejects.toThrow(/immutable column changed/)` would miss even when the
+ * guard fires — mirror aiAgentRuns.integration.test.ts's unwrapping and pin
+ * BOTH the SQLSTATE and the guard's message on the cause.
+ */
+async function expectImmutableViolation(fn: () => Promise<unknown>): Promise<void> {
+  let raised: unknown;
+  try {
+    await fn();
+  } catch (err) {
+    raised = err;
+  }
+  expect(raised, 'expected the immutability guard to fire, but the statement succeeded').toBeDefined();
+  const cause = (raised as { cause?: { code?: string; message?: string } })?.cause;
+  expect(cause?.code ?? (raised as { code?: string })?.code).toBe('23000');
+  expect(cause?.message ?? (raised as Error)?.message).toMatch(/immutable column changed/);
+}
+
+function runValues(agentId: string, orgId: string, dedupeKey: string) {
+  return {
+    agentId,
+    orgId,
+    triggerKind: 'alert' as const,
+    dedupeKey,
+    modeAtStart: 'shadow' as const,
+    policySnapshot: { schemaVersion: 1 } as never,
+  };
+}
+
+/** An org with its own live triage agent (mirrors aiAgentRuns.integration.test.ts). */
+async function orgWithAgent() {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const user = await createUser({ partnerId: partner.id });
+  const [agent] = await withDbAccessContext(SYSTEM_CTX, () =>
+    db
+      .insert(aiAgents)
+      .values({ orgId: org.id, partnerId: null, kind: 'triage', name: 'Triage', createdBy: user.id })
+      .returning(),
+  );
+  return { partner, org, user, agent: agent! };
+}
+
+/** Inserts a device row directly via the admin connection. */
+async function insertDevice(orgId: string, siteId: string) {
+  const adminDb = getTestDb() as any;
+  const unique = randomUUID().slice(0, 8);
+  const [device] = await adminDb
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `run-move-agent-${unique}`,
+      hostname: `run-move-host-${unique}`,
+      osType: 'linux',
+      osVersion: '22.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+    })
+    .returning();
+  return device as typeof devices.$inferSelect;
+}
+
+/** Full device lineage: alert + ai_session on the device, run linking all three. */
+async function insertLineage(t: {
+  org: { id: string };
+  partner: { id: string };
+  agent: { id: string };
+  device: { id: string };
+}) {
+  const adminDb = getTestDb() as any;
+  const [alert] = await adminDb
+    .insert(alerts)
+    .values({
+      orgId: t.org.id,
+      deviceId: t.device.id,
+      severity: 'medium',
+      title: 'agent-run move semantics fixture alert',
+    })
+    .returning();
+  const [session] = await adminDb
+    .insert(aiSessions)
+    .values({ orgId: t.org.id, deviceId: t.device.id, type: 'general' })
+    .returning();
+  const [run] = await withSystemDbAccessContext(() =>
+    db
+      .insert(aiAgentRuns)
+      .values({
+        ...runValues(t.agent.id, t.org.id, `run-move-lineage-${randomUUID()}`),
+        deviceId: t.device.id,
+        alertId: alert.id,
+        sessionId: session.id,
+      })
+      .returning(),
+  );
+  return { alert, session, run: run! };
+}
+
+/** An agent-originated intent attributed to the run (composite tenant FK live). */
+async function insertAgentIntent(
+  orgId: string,
+  partnerId: string,
+  agentId: string,
+  runId: string,
+): Promise<string> {
+  const sfx = randomUUID().slice(0, 8);
+  const values: NewActionIntent = {
+    orgId,
+    partnerId,
+    requestedByUserId: null,
+    requestingApiKeyId: null,
+    requestingAgentRunId: runId,
+    source: 'ai_agent',
+    originPrincipalKind: 'ai_agent',
+    originPrincipalId: agentId,
+    actionName: 'm365.mailbox.disable',
+    actionVersion: 1,
+    arguments: { mailbox: 'user@example.com' },
+    argumentDigest: 'a'.repeat(64),
+    targetSummary: 'Disable mailbox user@example.com',
+    impactSummary: 'User loses mailbox access immediately',
+    reason: 'Offboarding',
+    riskTier: 3,
+    idempotencyKey: `idem-run-move-${sfx}`,
+    correlationId: randomUUID(),
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+  };
+  const [row] = await withSystemDbAccessContext(() =>
+    db.insert(actionIntents).values(values).returning({ id: actionIntents.id }),
+  );
+  return row!.id;
+}
+
+describe('agent-run move semantics (owner decision 2026-08-23)', () => {
+  it('org_id on ai_agent_runs is immutable even for a dual-org context', async () => {
+    // Inverts the pre-3b contract: moveOrg no longer re-stamps runs, so no
+    // legitimate org_id writer remains and the guard now covers it.
+    const t = await orgWithAgent();
+    const target = await createOrganization({ partnerId: t.partner.id });
+    const [row] = await withDbAccessContext(orgContext(t.org.id, t.partner.id), () =>
+      db.insert(aiAgentRuns).values(runValues(t.agent.id, t.org.id, 'move-sem-1')).returning(),
+    );
+    const bothOrgs: DbAccessContext = {
+      scope: 'organization',
+      orgId: t.org.id,
+      accessibleOrgIds: [t.org.id, target.id],
+      accessiblePartnerIds: [],
+      userId: null,
+      currentPartnerId: t.partner.id,
+    };
+    await expectImmutableViolation(() =>
+      withDbAccessContext(bothOrgs, () =>
+        db
+          .update(aiAgentRuns)
+          .set({ orgId: target.id })
+          .where(eq(aiAgentRuns.id, row!.id))
+          .returning(),
+      ),
+    );
+  });
+
+  it('detaching the lineage links succeeds while an intent still attributes the run', async () => {
+    // The exact statement moveOrg now runs. It must NOT trip the composite FK:
+    // (requesting_agent_run_id, org_id) references (id, org_id) and neither
+    // changes on detach.
+    const t = await orgWithAgent();
+    const site = await createSite({ orgId: t.org.id });
+    const device = await insertDevice(t.org.id, site.id);
+    const lineage = await insertLineage({ ...t, device });
+    await insertAgentIntent(t.org.id, t.partner.id, t.agent.id, lineage.run.id);
+
+    const [detached] = await withSystemDbAccessContext(() =>
+      db
+        .update(aiAgentRuns)
+        .set({ deviceId: null, alertId: null, sessionId: null })
+        .where(eq(aiAgentRuns.deviceId, device.id))
+        .returning(),
+    );
+    expect(detached!.deviceId).toBeNull();
+    expect(detached!.alertId).toBeNull();
+    expect(detached!.sessionId).toBeNull();
+    expect(detached!.orgId).toBe(t.org.id); // stayed home
+  });
+
+  it('the REAL move route leaves no cross-tenant reference on retained runs', async () => {
+    // Drives POST /devices/:id/move-org through the route harness (mirrors
+    // deviceMoveOrgCurrency.integration.test.ts) with a run that has
+    // device_id, alert_id AND session_id populated and an agent intent
+    // attached. After the move: the device, its alert and its ai_session are
+    // in the target org; the run remains in the SOURCE org with all three
+    // lineage links NULL; the intent is untouched. A direct-SQL test alone
+    // cannot catch a forgotten route change — this exercises the transaction
+    // the product actually runs.
+    const adminDb = getTestDb() as any;
+    const env = await setupTestEnvironment({ scope: 'partner' });
+    const { partner, organization: orgA, site: siteA, user, role } = env;
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const siteB = await createSite({ orgId: orgB.id });
+
+    const device = await insertDevice(orgA.id, siteA.id);
+    const [agent] = await withSystemDbAccessContext(() =>
+      db
+        .insert(aiAgents)
+        .values({ orgId: orgA.id, partnerId: null, kind: 'triage', name: 'Triage', createdBy: user.id })
+        .returning(),
+    );
+    const lineage = await insertLineage({ org: orgA, partner, agent: agent!, device });
+    const intentId = await insertAgentIntent(orgA.id, partner.id, agent!.id, lineage.run.id);
+
+    const token = await createAccessToken({
+      sub: user.id,
+      email: user.email,
+      roleId: role.id,
+      orgId: null,
+      partnerId: partner.id,
+      scope: 'partner',
+      mfa: true,
+      aep: 1,
+      mep: 1,
+      sid: randomUUID(),
+    });
+
+    const app = new Hono();
+    app.route('/devices', moveOrgRoutes);
+    const res = await app.request(`/devices/${device.id}/move-org`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orgId: orgB.id, siteId: siteB.id }),
+    });
+    expect(res.status, JSON.stringify(await res.clone().json())).toBe(200);
+
+    // Device, alert and session followed the move.
+    const [movedDevice] = await adminDb.select().from(devices).where(eq(devices.id, device.id));
+    expect(movedDevice.orgId).toBe(orgB.id);
+    const [movedAlert] = await adminDb.select().from(alerts).where(eq(alerts.id, lineage.alert.id));
+    expect(movedAlert.orgId).toBe(orgB.id);
+    const [movedSession] = await adminDb
+      .select()
+      .from(aiSessions)
+      .where(eq(aiSessions.id, lineage.session.id));
+    expect(movedSession.orgId).toBe(orgB.id);
+
+    // The run stayed home, fully detached — no cross-tenant reference left.
+    const [run] = await adminDb.select().from(aiAgentRuns).where(eq(aiAgentRuns.id, lineage.run.id));
+    expect(run.orgId).toBe(orgA.id);
+    expect(run.deviceId).toBeNull();
+    expect(run.alertId).toBeNull();
+    expect(run.sessionId).toBeNull();
+
+    // The attributed intent is untouched.
+    const [intent] = await adminDb.select().from(actionIntents).where(eq(actionIntents.id, intentId));
+    expect(intent.orgId).toBe(orgA.id);
+    expect(intent.requestingAgentRunId).toBe(lineage.run.id);
+  });
+});

--- a/apps/api/src/__tests__/integration/aiAgentRuns.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiAgentRuns.integration.test.ts
@@ -158,11 +158,13 @@ describe('ai_agent_runs — org isolation, dedupe scope, immutability', () => {
     );
   });
 
-  it('org_id stays re-stampable so moveOrg can re-tenant the ledger', async () => {
-    // Regression: org_id was in the immutability guard while the table is in
-    // CORE_DEVICE_ORG_DENORMALIZED_TABLES. moveOrg re-stamps org_id in the same
-    // transaction that flips devices.org_id, so the guard rolled the whole move
-    // back with 23000 and permanently stranded any device an agent had touched.
+  it('org_id is immutable — moveOrg no longer re-tenants the ledger', async () => {
+    // Owner decision 2026-08-23 (wave 3b): agent-run history stays with the
+    // source org on a device move; moveOrg detaches device lineage instead of
+    // re-stamping org_id. With no legitimate org_id writer left, the guard now
+    // covers it (2026-09-06-a-agent-runs-org-immutable.sql). This inverts the
+    // pre-3b "org_id stays re-stampable" pin; the full move semantics live in
+    // agentRunMoveSemantics.integration.test.ts.
     const t = await orgWithAgent();
     const target = await createOrganization({ partnerId: t.partner.id });
     const [row] = await withDbAccessContext(orgContext(t.org.id, t.partner.id), () =>
@@ -170,8 +172,8 @@ describe('ai_agent_runs — org isolation, dedupe scope, immutability', () => {
     );
     createdRuns.push(row!.id);
 
-    // moveOrg runs under a context holding BOTH orgs; RLS WITH CHECK is what
-    // fences this, not the trigger.
+    // Even a context holding BOTH orgs (which passes RLS WITH CHECK on the
+    // post-image) is stopped by the trigger now.
     const bothOrgs: DbAccessContext = {
       scope: 'organization',
       orgId: t.org.id,
@@ -180,9 +182,12 @@ describe('ai_agent_runs — org isolation, dedupe scope, immutability', () => {
       userId: null,
       currentPartnerId: t.partner.id,
     };
-    const [moved] = await withDbAccessContext(bothOrgs, () =>
-      db.update(aiAgentRuns).set({ orgId: target.id }).where(inArray(aiAgentRuns.id, [row!.id])).returning(),
+    await expectSqlState(
+      () =>
+        withDbAccessContext(bothOrgs, () =>
+          db.update(aiAgentRuns).set({ orgId: target.id }).where(inArray(aiAgentRuns.id, [row!.id])).returning(),
+        ),
+      '23000',
     );
-    expect(moved!.orgId).toBe(target.id);
   });
 });

--- a/apps/api/src/__tests__/integration/aiAgents.routes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiAgents.routes.integration.test.ts
@@ -319,8 +319,12 @@ describe('/api/v1/ai/agents', () => {
     // save — silently WIDENING its blast radius. Proven against real jsonb,
     // not a Drizzle mock.
     const app = buildApp();
-    const { partnerAdmin } = await createSamePartnerClients(app);
+    const { partnerAdmin, env } = await createSamePartnerClients(app);
 
+    // Wave 3b validates recipients at write time (services/aiAgents/recipients.ts):
+    // a made-up userId now 400s on create, so the fixture recipient must be a
+    // real active member of the owning partner — the seeded partner admin.
+    const recipientUserId = env.user.id;
     const created = await partnerAdmin.post('/api/v1/ai/agents', {
       ownerScope: 'partner',
       kind: 'triage',
@@ -334,7 +338,7 @@ describe('/api/v1/ai/agents', () => {
         respectMaintenanceWindows: true,
       },
       protectedResources: { services: ['sshd'], paths: ['/etc'], registryKeys: [], deviceTags: ['db'] },
-      recipients: { userIds: ['33333333-3333-4333-8333-333333333333'], roleIds: [] },
+      recipients: { userIds: [recipientUserId], roleIds: [] },
     });
     expect(created.status).toBe(201);
     const agentId = (await created.json() as { data: { id: string } }).data.id;
@@ -364,7 +368,7 @@ describe('/api/v1/ai/agents', () => {
     expect(row.triggers.deviceGroupIds).toEqual(['22222222-2222-4222-8222-222222222222']);
     expect(row.triggers.deviceTags).toEqual(['prod']);
     expect(row.protectedResources.deviceTags).toEqual(['db']);
-    expect(row.recipients.userIds).toEqual(['33333333-3333-4333-8333-333333333333']);
+    expect(row.recipients.userIds).toEqual([recipientUserId]);
   });
 
   it('answers 404 (never 500) for a non-uuid path id', async () => {

--- a/apps/api/src/db/schema/actionIntents.ts
+++ b/apps/api/src/db/schema/actionIntents.ts
@@ -50,10 +50,9 @@ export type ActionIntentStatus = (typeof actionIntentStatusEnum)[number];
 
 // 'ai_agent' (wave 3, #3824): a headless agent proposal. Distinct from 'chat'
 // because nobody is watching a chat pane — supervised agent intents must be
-// notified. computeExpiresAt (intentService.ts) currently branches only on
-// `source === 'chat'`, so 'ai_agent' silently inherits the 24-hour MCP
-// expiry window rather than an agent-specific one; picking a deadline that
-// actually fits headless agent proposals is a decision for the next PR.
+// notified. computeExpiresAt (intentService.ts) gives it an explicit
+// AGENT_INTENT_EXPIRY_MS branch (wave 3b) — deliberately 24h, no longer
+// inherited from the MCP window by accident.
 export const actionIntentSourceEnum = ['chat', 'mcp_api', 'ai_agent'] as const;
 export type ActionIntentSource = (typeof actionIntentSourceEnum)[number];
 

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -5,20 +5,32 @@ import { canonicalizeArguments, computeArgumentDigest } from '@breeze/shared/can
 // Hoisted shared mock state
 // ---------------------------------------------------------------------------
 
-const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, aiToolsMock, aiGuardrailsMock, authMock, auditMock, metricsMock, sentryMock, toolTimeoutsMock, googleHeadlessMock, m365HeadlessMock, effectDigestMock, notifyMock } = vi.hoisted(() => {
+const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, aiToolsMock, aiGuardrailsMock, authMock, auditMock, metricsMock, sentryMock, toolTimeoutsMock, googleHeadlessMock, m365HeadlessMock, effectDigestMock, notifyMock, recipientsMock } = vi.hoisted(() => {
   const col = (name: string) => ({ name });
   const actionIntentsTbl = { id: col('id') };
   const approvalRequestsTbl = { id: col('id'), intentId: col('intent_id'), status: col('status') };
+  const aiAgentRunsTbl = { id: col('id'), agentId: col('agent_id') };
+  const aiAgentsTbl = { id: col('id'), orgId: col('org_id'), partnerId: col('partner_id'), recipients: col('recipients') };
 
   const notifyMock = {
     createNotification: vi.fn(async (_input: Record<string, unknown>) => 'notif-1' as string | null),
   };
+  const recipientsMock = {
+    // Membership resolution is unit-tested where it lives
+    // (services/aiAgents/recipients.test.ts); here it is a collaborator — the
+    // worker must hand it the loaded agent row plus the INTENT's org, and
+    // notify exactly what it returns.
+    resolveRecipientUserIds: vi.fn(async (_agent: unknown, _orgId: string) => [] as string[]),
+  };
   return {
     notifyMock,
-    schema: { actionIntentsTbl, approvalRequestsTbl },
+    recipientsMock,
+    schema: { actionIntentsTbl, approvalRequestsTbl, aiAgentRunsTbl, aiAgentsTbl },
     dbState: {
       selectActionIntentsResults: [] as unknown[][],
       selectApprovalRequestsResults: [] as unknown[][],
+      selectAgentRunsResults: [] as unknown[][],
+      selectAgentsResults: [] as unknown[][],
     },
     intentServiceMock: { transitionIntent: vi.fn() },
     actorContextMock: { buildAuthContextForIntent: vi.fn() },
@@ -98,6 +110,12 @@ vi.mock('../db', () => ({
             if (table === schema.approvalRequestsTbl) {
               return Promise.resolve(dbState.selectApprovalRequestsResults.shift() ?? []);
             }
+            if (table === schema.aiAgentRunsTbl) {
+              return Promise.resolve(dbState.selectAgentRunsResults.shift() ?? []);
+            }
+            if (table === schema.aiAgentsTbl) {
+              return Promise.resolve(dbState.selectAgentsResults.shift() ?? []);
+            }
             throw new Error('unexpected select table in mock');
           }),
         })),
@@ -111,6 +129,13 @@ vi.mock('../db', () => ({
 
 vi.mock('../db/schema/actionIntents', () => ({ actionIntents: schema.actionIntentsTbl }));
 vi.mock('../db/schema/approvals', () => ({ approvalRequests: schema.approvalRequestsTbl }));
+// Partial: only the two table objects become routable sentinels; every other
+// export stays real so transitive importers (revalidateRelease ->
+// agentReleaseAuthority -> effectivePolicy) keep loading unchanged.
+vi.mock('../db/schema/aiAgents', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db/schema/aiAgents')>();
+  return { ...actual, aiAgentRuns: schema.aiAgentRunsTbl, aiAgents: schema.aiAgentsTbl };
+});
 
 vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
 vi.mock('../services/sentry', () => ({ captureException: sentryMock.captureException }));
@@ -203,6 +228,10 @@ vi.mock('../services/userNotifications', () => ({
   createNotification: notifyMock.createNotification,
 }));
 
+vi.mock('../services/aiAgents/recipients', () => ({
+  resolveRecipientUserIds: recipientsMock.resolveRecipientUserIds,
+}));
+
 // bullmq is a real dependency we don't want to spin up — mock Worker/Job to
 // inert stand-ins since these tests only exercise the exported functions,
 // never `createWorker` itself.
@@ -219,7 +248,7 @@ import { releaseApprovedIntent, processIntentReleaseJob } from './intentReleaseW
 // The mocked db handle the worker threads into the digest recompute — imported
 // so that call can be asserted against the real object rather than
 // expect.anything().
-import { db as mockedDb } from '../db';
+import { db as mockedDb, runOutsideDbContext as mockedRunOutside } from '../db';
 import type { ActionIntent } from '../db/schema/actionIntents';
 import { GoogleConnectionUnavailableError } from '../services/googleToolsHeadless';
 import { M365ConnectionUnavailableError } from '../services/m365ToolsHeadless';
@@ -299,6 +328,8 @@ const FOUR_EYES_INTENT = {
 function resetDbState() {
   dbState.selectActionIntentsResults.length = 0;
   dbState.selectApprovalRequestsResults.length = 0;
+  dbState.selectAgentRunsResults.length = 0;
+  dbState.selectAgentsResults.length = 0;
 }
 
 /** Clears GOOGLE_HEADLESS_SECRET_ACTIONS keys in place (see the hoisted
@@ -1441,5 +1472,133 @@ describe('processIntentReleaseJob', () => {
       expect.objectContaining({ executedAt: null, executionStartedAt: expect.any(Date) }),
       { requireNotExpired: 'release' },
     );
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// Agent-originated outcome notifications (wave 3b, Task 8)
+// ---------------------------------------------------------------------------
+
+describe('agent-originated outcome notifications', () => {
+  const AGENT_INTENT = {
+    id: 'intent-1',
+    orgId: 'org-1',
+    // Headless proposal: "the requester is watching" is false — there is no
+    // requester at all.
+    requestedByUserId: null,
+    requestingAgentRunId: 'run-1',
+    requestingClientLabel: 'Patch triage',
+    targetSummary: 'run_script(deviceId=d-1)',
+    status: 'rejected',
+    // SUPERVISED on purpose: both the four_eyes-only early-out and the
+    // no-human-requester guard would swallow this row if the agent branch
+    // did not run before them.
+    approvalScope: 'supervised',
+  };
+  const RUN_ROW = { id: 'run-1', agentId: 'agent-1' };
+  const AGENT_ROW = { id: 'agent-1', orgId: 'org-1', partnerId: null, recipients: { userIds: ['user-a'] } };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDbState();
+  });
+
+  it('notifies every validated recipient of a supervised agent intent', async () => {
+    dbState.selectActionIntentsResults.push([AGENT_INTENT]);
+    dbState.selectAgentRunsResults.push([RUN_ROW]);
+    dbState.selectAgentsResults.push([AGENT_ROW]);
+    recipientsMock.resolveRecipientUserIds.mockResolvedValueOnce(['user-a', 'user-b']);
+
+    const result = await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_rejected' });
+
+    expect(result).toEqual({ released: false });
+    // Live membership resolution, keyed on the INTENT's org (the tenant whose
+    // data the notification describes), never the raw stored ids.
+    expect(recipientsMock.resolveRecipientUserIds).toHaveBeenCalledWith(AGENT_ROW, 'org-1');
+    expect(notifyMock.createNotification).toHaveBeenCalledTimes(2);
+    expect(notifyMock.createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-a',
+        orgId: 'org-1',
+        type: 'ai',
+        link: '/approvals',
+        title: 'Agent proposal denied',
+        message: 'Patch triage: run_script(deviceId=d-1) was denied and will not run.',
+        metadata: { intentId: 'intent-1', agentId: 'agent-1', agentRunId: 'run-1', status: 'rejected' },
+        // Status-scoped: a later, MORE ACCURATE status must not be suppressed
+        // by the earlier notification's dedupe row.
+        dedupeKey: 'agent-intent-outcome:intent-1:rejected',
+      }),
+    );
+    expect(notifyMock.createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-b' }),
+    );
+    // The run/agent load AND each cross-user insert must escape any ambient
+    // context first — a bare system wrapper inside one is a passthrough.
+    expect(vi.mocked(mockedRunOutside).mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('derives agent copy from the re-read status, never the event type', async () => {
+    // intent_approved arrives but the release did not run (lost CAS) and the
+    // row now says failed — recipients must hear the truth, at high priority.
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+    dbState.selectActionIntentsResults.push([{ ...AGENT_INTENT, status: 'failed' }]);
+    dbState.selectAgentRunsResults.push([RUN_ROW]);
+    dbState.selectAgentsResults.push([AGENT_ROW]);
+    recipientsMock.resolveRecipientUserIds.mockResolvedValueOnce(['user-a']);
+
+    await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_approved' });
+
+    const arg = notifyMock.createNotification.mock.calls[0]?.[0] as {
+      title: string; message: string; priority: string; dedupeKey: string;
+    };
+    expect(arg.title).toBe('Agent action failed');
+    expect(arg.message).not.toContain('is now running');
+    expect(arg.priority).toBe('high');
+    expect(arg.dedupeKey).toBe('agent-intent-outcome:intent-1:failed');
+  });
+
+  it('stays silent when the run is gone', async () => {
+    dbState.selectActionIntentsResults.push([AGENT_INTENT]);
+    dbState.selectAgentRunsResults.push([]);
+
+    await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_rejected' });
+
+    expect(recipientsMock.resolveRecipientUserIds).not.toHaveBeenCalled();
+    expect(notifyMock.createNotification).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the agent row is gone', async () => {
+    dbState.selectActionIntentsResults.push([AGENT_INTENT]);
+    dbState.selectAgentRunsResults.push([RUN_ROW]);
+    dbState.selectAgentsResults.push([]);
+
+    await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_rejected' });
+
+    expect(recipientsMock.resolveRecipientUserIds).not.toHaveBeenCalled();
+    expect(notifyMock.createNotification).not.toHaveBeenCalled();
+  });
+
+  it('notifies nobody when live membership resolution returns empty', async () => {
+    dbState.selectActionIntentsResults.push([AGENT_INTENT]);
+    dbState.selectAgentRunsResults.push([RUN_ROW]);
+    dbState.selectAgentsResults.push([AGENT_ROW]);
+    recipientsMock.resolveRecipientUserIds.mockResolvedValueOnce([]);
+
+    await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_rejected' });
+
+    expect(notifyMock.createNotification).not.toHaveBeenCalled();
+  });
+
+  it('a requester-less NON-agent intent (API-key sourced) stays on the silent path', async () => {
+    dbState.selectActionIntentsResults.push([
+      { ...FOUR_EYES_INTENT, status: 'rejected', requestedByUserId: null, requestingAgentRunId: null },
+    ]);
+
+    await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_rejected' });
+
+    expect(recipientsMock.resolveRecipientUserIds).not.toHaveBeenCalled();
+    expect(notifyMock.createNotification).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -1,13 +1,16 @@
 import { Job, Worker } from 'bullmq';
+import type { AiAgentRecipients } from '@breeze/shared';
 import { and, eq } from 'drizzle-orm';
-import { db, withSystemDbAccessContext } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { actionIntents, type ActionIntent } from '../db/schema/actionIntents';
+import { aiAgentRuns, aiAgents } from '../db/schema/aiAgents';
 import { approvalRequests } from '../db/schema/approvals';
 import { getBullMQConnection } from '../services/redis';
 import { captureException } from '../services/sentry';
 import { writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
 import { recordActionIntentEvent, recordActionIntentMetric } from '../services/actionIntents/metrics';
 import { createNotification } from '../services/userNotifications';
+import { resolveRecipientUserIds } from '../services/aiAgents/recipients';
 import { transitionIntent } from '../services/actionIntents/intentService';
 import { revalidateApprovedIntentForRelease } from '../services/actionIntents/revalidateRelease';
 import { computeEffectDigestForRelease, hasPinnedDigest } from '../services/actionIntents/effectDigest';
@@ -617,6 +620,76 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
 }
 
 /**
+ * The run + agent behind an agent-originated intent, loaded under GENUINE
+ * system scope. `runOutsideDbContext` first is load-bearing: a bare system
+ * wrapper inside an ambient context is a passthrough (db/index.ts), and while
+ * this worker normally runs contextless, the notify path must stay correct if
+ * it is ever invoked from inside a request transaction.
+ */
+async function loadRunAndAgent(runId: string): Promise<{
+  run: { id: string; agentId: string } | null;
+  agent: {
+    id: string;
+    orgId: string | null;
+    partnerId: string | null;
+    recipients: Partial<AiAgentRecipients>;
+  } | null;
+}> {
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const [run] = await db
+        .select({ id: aiAgentRuns.id, agentId: aiAgentRuns.agentId })
+        .from(aiAgentRuns)
+        .where(eq(aiAgentRuns.id, runId))
+        .limit(1);
+      if (!run) return { run: null, agent: null };
+      const [agent] = await db
+        .select({
+          id: aiAgents.id,
+          orgId: aiAgents.orgId,
+          partnerId: aiAgents.partnerId,
+          recipients: aiAgents.recipients,
+        })
+        .from(aiAgents)
+        .where(eq(aiAgents.id, run.agentId))
+        .limit(1);
+      return { run, agent: agent ?? null };
+    }));
+}
+
+/**
+ * Same status switch the requester path uses below — the copy MUST derive
+ * from the freshly re-read `intent.status`, never the outbox event (see the
+ * long rationale in notifyRequesterOfOutcome) — but worded for a recipient
+ * who never asked for anything: an AGENT proposed this, a human decided it.
+ */
+function agentOutcomeCopy(intent: { targetSummary: string; status: string }): {
+  title: string;
+  message: string;
+  priority: 'normal' | 'high';
+} {
+  const summary = intent.targetSummary;
+  switch (intent.status) {
+    case 'approved':
+    case 'executing':
+      return { title: 'Agent action approved', message: `${summary} was approved and is now running.`, priority: 'normal' };
+    case 'completed':
+      return { title: 'Agent action completed', message: `${summary} was approved and has finished.`, priority: 'normal' };
+    case 'failed':
+      // Approved but did not run. The distinction matters most here.
+      return { title: 'Agent action failed', message: `${summary} was approved but could not run.`, priority: 'high' };
+    case 'rejected':
+      return { title: 'Agent proposal denied', message: `${summary} was denied and will not run.`, priority: 'normal' };
+    case 'cancelled':
+      return { title: 'Agent proposal cancelled', message: `${summary} was cancelled and will not run.`, priority: 'normal' };
+    case 'expired':
+      return { title: 'Agent proposal expired', message: `${summary} expired before anyone decided and will not run.`, priority: 'normal' };
+    default:
+      return { title: 'Agent proposal update', message: `${summary} changed state.`, priority: 'normal' };
+  }
+}
+
+/**
  * Tell the requester how their intent ended.
  *
  * The point of doing this from the outbox rather than inline at decide time:
@@ -641,6 +714,8 @@ async function notifyRequesterOfOutcome(
         targetSummary: actionIntents.targetSummary,
         status: actionIntents.status,
         approvalScope: actionIntents.approvalScope,
+        requestingAgentRunId: actionIntents.requestingAgentRunId,
+        requestingClientLabel: actionIntents.requestingClientLabel,
       })
       .from(actionIntents)
       .where(eq(actionIntents.id, intentId))
@@ -651,11 +726,46 @@ async function notifyRequesterOfOutcome(
     captureException(new Error(`intent ${intentId} not found for outcome notification`));
     return;
   }
+  // Agent-originated intent (wave 3b): a headless proposal has NO requester,
+  // so "the requester was watching" is false at every approval scope — this
+  // branch must run BEFORE both the four_eyes early-out and the
+  // no-human-requester guard below, either of which would swallow it. Notify
+  // the agent's validated recipients, resolved against LIVE membership
+  // (resolveRecipientUserIds), never the raw stored ids. Copy derives from
+  // the re-read intent.status exactly like the requester path, because the
+  // outbox event may be late or release may have failed after approval.
+  if (!intent.requestedByUserId && intent.requestingAgentRunId) {
+    const { run, agent } = await loadRunAndAgent(intent.requestingAgentRunId);
+    if (!run || !agent) return;
+    const userIds = await resolveRecipientUserIds(agent, intent.orgId);
+    const { title, message, priority } = agentOutcomeCopy(intent);
+    for (const userId of userIds) {
+      // runOutsideDbContext first — a bare system wrapper inside an ambient
+      // request context is a passthrough, and this is a cross-user insert.
+      await runOutsideDbContext(() =>
+        withSystemDbAccessContext(() =>
+          createNotification({
+            userId,
+            orgId: intent.orgId,
+            type: 'ai',
+            priority,
+            title,
+            message: `${intent.requestingClientLabel ?? 'AI agent'}: ${message}`,
+            link: '/approvals',
+            metadata: { intentId: intent.id, agentId: agent.id, agentRunId: run.id, status: intent.status },
+            // Status-scoped: a later, MORE ACCURATE status (approved -> failed)
+            // must not be suppressed by the earlier notification's dedupe row.
+            dedupeKey: `agent-intent-outcome:${intent.id}:${intent.status}`,
+          })));
+    }
+    return;
+  }
+
   // Defensive today: no creation path sets requestingApiKeyId yet —
   // createActionIntent attributes every intent to auth.user.id (see
   // actorContext.ts). When API-key-owned MCP intents land (Plan 2), those rows
   // have no human requester and correctly stay silent; agent-originated
-  // intents (wave 3b) get their own recipient routing instead of this early
+  // intents (wave 3b) were routed to recipients above, before this early
   // return. org_id is NOT NULL in the schema, so it is deliberately not
   // checked here.
   if (!intent.requestedByUserId) return;

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -18,6 +18,7 @@ import {
   AgentInvariantError, AgentKindConflictError, UnsupportedAgentModeError,
 } from '../services/aiAgents/agentService';
 import { resolveEffectiveAgent } from '../services/aiAgents/effectivePolicy';
+import { InvalidAgentRecipientsError } from '../services/aiAgents/recipients';
 import { SUPPORTED_AGENT_MODES } from '../services/aiAgents/constants';
 import { PERMISSIONS } from '../services/permissions';
 import { resolveOrgId } from './networkShared';
@@ -103,6 +104,15 @@ function mapError(c: Context, err: unknown) {
   }
   if (err instanceof AgentKindConflictError) {
     return c.json({ error: err.message, code: err.code }, 409);
+  }
+  // Membership-validation failure on recipients (services/aiAgents/recipients.ts):
+  // actionable client error — the body names exactly which ids were refused.
+  if (err instanceof InvalidAgentRecipientsError) {
+    return c.json({
+      error: 'invalid_recipients',
+      invalidUserIds: err.invalidUserIds,
+      invalidRoleIds: err.invalidRoleIds,
+    }, 400);
   }
   // The pre-check in createAgent cannot win a concurrent create; the partial
   // unique index settles that race. Answer it the same way rather than letting

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -115,6 +115,11 @@ vi.mock('../services/authenticatorPolicy', () => ({
 vi.mock('../services/actionIntents/intentApprovers', () => ({
   // Literal id, not TEST_USER — vi.mock factories are hoisted above the const.
   resolveIntentApprovers: vi.fn(async () => ['00000000-0000-0000-0000-000000000001']),
+  // Wave 3b Task 6: agent-originated supervised intents are decided via
+  // action-and-target authority (not approvals:decide, not requester
+  // identity). Permissive default (an eligible decider); the ineligible-
+  // decider tests override it per-case.
+  isAgentIntentDecideAuthorized: vi.fn(async () => true),
 }));
 
 // The decide handler re-resolves the DECIDER's live authorization before an
@@ -231,6 +236,10 @@ const TEST_USER = {
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
     c.set('auth', {
+      // Wave 3b Task 6: the decide handler now asserts a human principal
+      // (`human_decision_required`), so the default mocked auth context must
+      // carry the interactive-session discriminator the real middleware sets.
+      principal: { kind: 'user_session' },
       scope: 'partner',
       partnerId: 'partner-123',
       orgId: null,
@@ -241,6 +250,8 @@ vi.mock('../middleware/auth', () => ({
     });
     return next();
   }),
+  // Same rule as the real helper (middleware/auth.ts): an allowlist of ONE.
+  isInteractiveUserSession: (auth: any) => auth?.principal?.kind === 'user_session',
   requirePermission: vi.fn(() => (c: any, next: any) => next()),
   requireScope: vi.fn(() => (c: any, next: any) => next()),
   requireMfa: vi.fn(() => (c: any, next: any) => next()),
@@ -257,7 +268,7 @@ import { issueMobileAssertionNonce } from '../services/mobileHwKey';
 import { requireCurrentPasswordStepUp } from './auth/helpers';
 import { recordActionIntentEvent } from '../services/actionIntents/metrics';
 import { getUserPermissions, userCanDecideApprovals, canAccessOrg } from '../services/permissions';
-import { resolveIntentApprovers } from '../services/actionIntents/intentApprovers';
+import { resolveIntentApprovers, isAgentIntentDecideAuthorized } from '../services/actionIntents/intentApprovers';
 import { checkToolPermission } from '../services/aiGuardrails';
 import { buildAuthContextForIntent } from '../services/actionIntents/actorContext';
 import { loadPartnerPolicy, isEnforcing } from '../services/authenticatorPolicy';
@@ -420,6 +431,9 @@ beforeEach(() => {
   // #2685: re-establish the "decider is still the only eligible approver"
   // default after clearAllMocks wipes the factory implementation.
   vi.mocked(resolveIntentApprovers).mockResolvedValue([TEST_USER.id]);
+  // Wave 3b Task 6: re-establish the permissive agent-decide default after
+  // clearAllMocks wipes the factory implementation.
+  vi.mocked(isAgentIntentDecideAuthorized).mockResolvedValue(true);
   // Task 6: re-establish the supervised-branch live-RBAC defaults (permissive)
   // after clearAllMocks wipes the factory implementation.
   vi.mocked(checkToolPermission).mockResolvedValue(null);
@@ -443,6 +457,7 @@ beforeEach(() => {
   vi.mocked(isEnforcing).mockReturnValue(false);
   vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
     c.set('auth', {
+      principal: { kind: 'user_session' },
       scope: 'partner',
       partnerId: 'partner-123',
       orgId: null,
@@ -3002,5 +3017,366 @@ describe('POST /approvals/dev/seed', () => {
     } finally {
       process.env.NODE_ENV = orig;
     }
+  });
+});
+
+describe('wave 3b Task 6: agent-originated intents — see it, decide it', () => {
+  const AGENT_RUN_ID = 'run-ag-1';
+  const AGENT_NAME = 'Patch Hygiene Agent';
+
+  function buildAgentIntent(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'intent-ag-1',
+      orgId: 'org-9',
+      actionName: 'execute_command',
+      arguments: { deviceId: 'dev-1', commandType: 'kill_process' },
+      argumentDigest: 'digest-abc',
+      source: 'ai_agent',
+      status: 'pending_approval',
+      approvalScope: 'supervised',
+      requestedByUserId: null,
+      requestingAgentRunId: AGENT_RUN_ID,
+      requestingClientLabel: AGENT_NAME,
+      ...overrides,
+    };
+  }
+
+  function mockPendingJoinResolvesAgent(
+    rows: Array<{ approval: unknown; intent: unknown | null }>,
+  ) {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue(rows),
+          }),
+        }),
+      }),
+    } as any);
+  }
+
+  function buildAgentApproval(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'appr-ag-1',
+      userId: TEST_USER.id,
+      requestingClientLabel: AGENT_NAME,
+      requestingMachineLabel: null,
+      requestingClientId: null,
+      requestingSessionId: null,
+      actionLabel: 'Kill process on dev-1',
+      actionToolName: 'execute_command',
+      actionArguments: { deviceId: 'dev-1', commandType: 'kill_process' },
+      riskTier: 'high',
+      riskSummary: 'Terminates a process on a managed device.',
+      status: 'pending',
+      expiresAt: new Date(Date.now() + 60_000),
+      decidedAt: null,
+      decisionReason: null,
+      executionId: null,
+      elevationRequestId: null,
+      intentId: 'intent-ag-1',
+      boundArgumentDigest: 'digest-abc',
+      isRecursive: false,
+      createdAt: new Date(),
+      ...overrides,
+    };
+  }
+
+  // -------------------------------------------------------------- /pending --
+
+  it('lists a supervised agent intent for its fanned-out eligible user', async () => {
+    mockPendingJoinResolvesAgent([
+      { approval: buildAgentApproval(), intent: buildAgentIntent() },
+    ]);
+
+    const res = await buildApp().request('/approvals/pending');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.approvals.map((a: any) => a.id)).toEqual(['appr-ag-1']);
+    // Authority is the per-user action-and-target predicate, never requester
+    // identity (requestedByUserId is NULL) and never approvals:decide.
+    expect(vi.mocked(isAgentIntentDecideAuthorized)).toHaveBeenCalledWith(
+      TEST_USER.id,
+      expect.objectContaining({ id: 'intent-ag-1', requestingAgentRunId: AGENT_RUN_ID }),
+    );
+  });
+
+  it('hides it from a user who lost the action permission since fan-out', async () => {
+    mockPendingJoinResolvesAgent([
+      { approval: buildAgentApproval(), intent: buildAgentIntent() },
+    ]);
+    vi.mocked(isAgentIntentDecideAuthorized).mockResolvedValue(false);
+
+    const res = await buildApp().request('/approvals/pending');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.approvals).toEqual([]);
+
+    const countRes = await buildApp().request('/approvals/pending/count');
+    expect(await countRes.json()).toEqual({ count: 0 });
+  });
+
+  it('serializes origin ai_agent and the agent name (human rows stay origin human)', async () => {
+    mockPendingJoinResolvesAgent([
+      {
+        approval: buildAgentApproval({ createdAt: new Date(Date.now()) }),
+        intent: buildAgentIntent(),
+      },
+      {
+        approval: buildPendingApproval({
+          id: 'appr-hu-1',
+          intentId: 'intent-hu-1',
+          createdAt: new Date(Date.now() - 1000),
+        }),
+        intent: {
+          id: 'intent-hu-1',
+          orgId: 'org-9',
+          status: 'pending_approval',
+          approvalScope: 'supervised',
+          requestedByUserId: TEST_USER.id,
+          requestingAgentRunId: null,
+          requestingClientLabel: 'Breeze AI',
+        },
+      },
+      {
+        approval: buildPendingApproval({ id: 'appr-plain', createdAt: new Date(Date.now() - 2000) }),
+        intent: null,
+      },
+    ]);
+
+    const res = await buildApp().request('/approvals/pending');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.approvals.map((a: any) => [a.id, a.origin, a.agentName])).toEqual([
+      ['appr-ag-1', 'ai_agent', AGENT_NAME],
+      ['appr-hu-1', 'human', null],
+      ['appr-plain', 'human', null],
+    ]);
+  });
+
+  it('a four_eyes agent intent keeps the org approvals:decide visibility rule', async () => {
+    mockPendingJoinResolvesAgent([
+      {
+        approval: buildAgentApproval(),
+        intent: buildAgentIntent({ approvalScope: 'four_eyes' }),
+      },
+    ]);
+    // Demoted from approvals:decide → the four_eyes rule hides the row, and
+    // the per-user action-authority predicate is never consulted for it.
+    // (`Once` on purpose: clearAllMocks never resets a persistent override.)
+    vi.mocked(userCanDecideApprovals).mockReturnValueOnce(false);
+
+    const res = await buildApp().request('/approvals/pending');
+    const body = await res.json();
+    expect(body.approvals).toEqual([]);
+    expect(vi.mocked(isAgentIntentDecideAuthorized)).not.toHaveBeenCalled();
+  });
+
+  // ------------------------------------------------------------ GET /:id ---
+
+  function mockDetailWithAgentIntent(intent: unknown | null) {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([buildAgentApproval()]),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(intent ? [intent] : []),
+        }),
+      } as any);
+  }
+
+  it('GET /:id serializes origin ai_agent / agentName under the same live rule', async () => {
+    mockDetailWithAgentIntent(buildAgentIntent());
+
+    const res = await buildApp().request('/approvals/appr-ag-1');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.approval.origin).toBe('ai_agent');
+    expect(body.approval.agentName).toBe(AGENT_NAME);
+    expect(body.approval.approvalScope).toBe('supervised');
+  });
+
+  it('GET /:id 404s for a user who is no longer action-and-target authorized', async () => {
+    mockDetailWithAgentIntent(buildAgentIntent());
+    vi.mocked(isAgentIntentDecideAuthorized).mockResolvedValue(false);
+
+    const res = await buildApp().request('/approvals/appr-ag-1');
+    expect(res.status).toBe(404);
+    const raw = await res.text();
+    expect(raw).not.toContain('kill_process');
+  });
+
+  // -------------------------------------------------------------- decide ---
+
+  let lastAgentApprovalRow: Record<string, unknown> | undefined;
+
+  function mockDecideWithAgentIntent(opts: { intentOverrides?: Record<string, unknown> } = {}) {
+    const approvalRow = buildAgentApproval();
+    const intentRow = buildAgentIntent(opts.intentOverrides);
+
+    // 1) pre-fetch select (the deciding user's own approval row)
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([approvalRow]),
+      }),
+    } as any);
+    // 2) intent load select (system context, by id)
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([intentRow]),
+      }),
+    } as any);
+
+    lastAgentApprovalRow = approvalRow;
+    return { approvalRow, intentRow };
+  }
+
+  function mockAgentFanInTx() {
+    const approvalCasReturning = vi
+      .fn()
+      .mockResolvedValue([{ ...(lastAgentApprovalRow ?? {}), status: 'approved' }]);
+    const approvalCasSet = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: approvalCasReturning }),
+    });
+    const intentCasReturning = vi.fn().mockResolvedValue([{ id: 'intent-ag-1' }]);
+    const intentCasSet = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: intentCasReturning }),
+    });
+    const siblingSet = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    const outboxValues = vi.fn().mockResolvedValue(undefined);
+    const tx = {
+      select: txSelectForUpdateStub([{ id: 'intent-ag-1', status: 'pending_approval' }]),
+      update: vi
+        .fn()
+        .mockReturnValueOnce({ set: approvalCasSet } as any)
+        .mockReturnValueOnce({ set: intentCasSet } as any)
+        .mockReturnValueOnce({ set: siblingSet } as any),
+      insert: vi.fn(() => ({ values: outboxValues }) as any),
+    };
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+    return { approvalCasSet, intentCasSet, siblingSet, outboxValues, tx };
+  }
+
+  it('decides a supervised agent intent via action-and-target authority', async () => {
+    mockDecideWithAgentIntent();
+    const { intentCasSet, outboxValues } = mockAgentFanInTx();
+
+    const res = await buildApp().request('/approvals/appr-ag-1/approve', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(isAgentIntentDecideAuthorized)).toHaveBeenCalledWith(
+      TEST_USER.id,
+      expect.objectContaining({ id: 'intent-ag-1', requestingAgentRunId: AGENT_RUN_ID }),
+    );
+    // Review blocker 2: the requester-RBAC re-check is SKIPPED for agent
+    // intents — a reconstructed ai_agent principal would be denied by
+    // checkToolPermission's first statement, 403ing every agent approval.
+    expect(vi.mocked(buildAuthContextForIntent)).not.toHaveBeenCalled();
+    expect(vi.mocked(checkToolPermission)).not.toHaveBeenCalled();
+    // The intent still transitions and the outbox row is written.
+    expect(intentCasSet).toHaveBeenCalledWith(expect.objectContaining({ status: 'approved' }));
+    expect(outboxValues).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'intent_approved' }),
+    );
+  });
+
+  it('403s not_authorized_for_agent_intent for an ineligible decider', async () => {
+    mockDecideWithAgentIntent();
+    vi.mocked(isAgentIntentDecideAuthorized).mockResolvedValue(false);
+
+    const res = await buildApp().request('/approvals/appr-ag-1/approve', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'not_authorized_for_agent_intent' });
+    // Refused BEFORE the decide-write transaction — the intent is untouched.
+    expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+  });
+
+  it('an agent-intent DENY is also gated on action-and-target authority (fail closed)', async () => {
+    mockDecideWithAgentIntent();
+    vi.mocked(isAgentIntentDecideAuthorized).mockResolvedValue(false);
+
+    const res = await buildApp().request('/approvals/appr-ag-1/deny', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'not_authorized_for_agent_intent' });
+    expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+  });
+
+  it('never skips the assurance ladder for an agent intent', async () => {
+    mockDecideWithAgentIntent();
+    mockAgentFanInTx();
+
+    const res = await buildApp().request('/approvals/appr-ag-1/approve', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(200);
+    // isSupervisedSelfDecide stays FALSE for an agent intent: even a plain
+    // no-proof click goes through assertApprovalAssurance — the same ceremony
+    // a four_eyes decision gets — never the supervised plain-click skip.
+    expect(vi.mocked(assertApprovalAssurance)).toHaveBeenCalledWith(
+      expect.objectContaining({ approvalId: 'appr-ag-1', decision: 'approved' }),
+    );
+  });
+
+  it('403s human_decision_required for a non-user_session principal', async () => {
+    vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+      c.set('auth', {
+        principal: { kind: 'api_key', apiKeyId: 'key-1' },
+        scope: 'partner',
+        partnerId: 'partner-123',
+        orgId: null,
+        user: TEST_USER,
+        accessibleOrgIds: [],
+        canAccessOrg: () => false,
+        orgCondition: () => undefined,
+      });
+      return next();
+    });
+
+    const res = await buildApp().request('/approvals/appr-ag-1/approve', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'human_decision_required' });
+    // Refused before the pre-fetch — no row is ever read.
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+  });
+
+  it('the decide response serializes origin ai_agent and the agent name', async () => {
+    mockDecideWithAgentIntent();
+    mockAgentFanInTx();
+
+    const res = await buildApp().request('/approvals/appr-ag-1/approve', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.approval.origin).toBe('ai_agent');
+    expect(body.approval.agentName).toBe(AGENT_NAME);
   });
 });

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -4,7 +4,7 @@ import { zValidator } from '../lib/validation';
 import { and, eq, exists, gt, desc, inArray, isNull, ne, sql } from 'drizzle-orm';
 
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { authMiddleware } from '../middleware/auth';
+import { authMiddleware, isInteractiveUserSession } from '../middleware/auth';
 import { approvalRequests } from '../db/schema/approvals';
 import { elevationRequests, elevationAudit } from '../db/schema/elevations';
 import { aiToolExecutions, aiSessions } from '../db/schema/ai';
@@ -29,7 +29,10 @@ import {
 } from '../services/authenticatorAssurance';
 import { recordActionIntentEvent } from '../services/actionIntents/metrics';
 import { RELEASE_LEASE_MS } from '../services/actionIntents/intentService';
-import { resolveIntentApprovers } from '../services/actionIntents/intentApprovers';
+import {
+  resolveIntentApprovers,
+  isAgentIntentDecideAuthorized,
+} from '../services/actionIntents/intentApprovers';
 import { buildAuthContextForIntent } from '../services/actionIntents/actorContext';
 import { checkToolPermission } from '../services/aiGuardrails';
 import { loadPartnerPolicy, isEnforcing } from '../services/authenticatorPolicy';
@@ -104,19 +107,43 @@ function isAfterPendingCursor(
   return row.id < cursor.id;
 }
 
-/** The only fields of a linked intent the live-authorization rule reads. */
+/** The only fields of a linked intent the live-authorization rule reads.
+ * Wave 3b: agent-originated intents (`requestingAgentRunId` set) are
+ * authorized per-user via `isAgentIntentDecideAuthorized`, which needs the
+ * intent's id (memoization key + run lookup), actionName and arguments. */
 type LiveAuthzIntent = Pick<
   ActionIntent,
-  'status' | 'approvalScope' | 'orgId' | 'requestedByUserId'
+  | 'id'
+  | 'status'
+  | 'approvalScope'
+  | 'orgId'
+  | 'requestedByUserId'
+  | 'requestingAgentRunId'
+  | 'actionName'
+  | 'arguments'
 >;
+
+/**
+ * Minimal attribution projection of a linked intent (wave 3b Task 6): just
+ * enough for `serialize` to say WHO asked — a human, or an AI agent (and
+ * which one, via `requestingClientLabel`, stamped with the agent's name at
+ * creation so no join is needed). Null when the row has no intent.
+ */
+type IntentAttribution = Pick<
+  ActionIntent,
+  'id' | 'requestingAgentRunId' | 'requestingClientLabel'
+> | null;
 
 /** An approval row paired with its linked intent's scope (null when the row
  * has no intent). The scope is what lets a client tell a supervised row —
  * decided with a plain click — from a four_eyes one that may demand a
- * step-up, so it must not be dropped on the way out of the projection. */
+ * step-up, so it must not be dropped on the way out of the projection.
+ * `attribution` (wave 3b) rides along for the same reason: without it the
+ * serializer cannot mark a row as agent-originated. */
 interface AuthorizedApproval {
   approval: typeof approvalRequests.$inferSelect;
   approvalScope: ActionIntentApprovalScope | null;
+  attribution: IntentAttribution;
 }
 
 /**
@@ -152,6 +179,41 @@ function makeOrgDecideAuthorizer(
 }
 
 /**
+ * Per-user live authority over a SUPERVISED AGENT-originated intent (wave 3b
+ * Task 6), memoised per intent id for the lifetime of one request — the
+ * pending list is already per-user rows, so this runs once per visible agent
+ * intent. Delegates to `isAgentIntentDecideAuthorized` (action-and-target
+ * authority: the tool's full RBAC mapping AND reach over the intent's
+ * concrete target — never `approvals:decide`, never requester identity, which
+ * is NULL for a requester-less intent).
+ */
+function makeAgentDecideAuthorizer(
+  userId: string,
+): (intent: LiveAuthzIntent) => Promise<boolean> {
+  const cache = new Map<string, Promise<boolean>>();
+  return (intent: LiveAuthzIntent) => {
+    let resolved = cache.get(intent.id);
+    if (!resolved) {
+      resolved = isAgentIntentDecideAuthorized(userId, intent);
+      cache.set(intent.id, resolved);
+    }
+    return resolved;
+  };
+}
+
+/** Attribution projection for `serialize` — null when there is no intent. */
+function toIntentAttribution(
+  intent: Pick<ActionIntent, 'id' | 'requestingAgentRunId' | 'requestingClientLabel'> | null,
+): IntentAttribution {
+  if (!intent) return null;
+  return {
+    id: intent.id,
+    requestingAgentRunId: intent.requestingAgentRunId,
+    requestingClientLabel: intent.requestingClientLabel,
+  };
+}
+
+/**
  * THE live-authorization rule for an intent-linked approval row (spec
  * docs/superpowers/specs/ai-mcp/2026-08-05-tier3-supervised-four-eyes-split-design.md
  * §4.2). Deliberately one function shared by every read surface that can hand
@@ -175,8 +237,19 @@ async function isIntentRowLiveAuthorized(
   intent: LiveAuthzIntent | null,
   userId: string,
   orgDecideAuthorizer: (orgId: string) => Promise<boolean>,
+  agentDecideAuthorizer: (intent: LiveAuthzIntent) => Promise<boolean>,
 ): Promise<boolean> {
   if (!intent || intent.status !== 'pending_approval') return false;
+  // Wave 3b: an AGENT-originated intent has no requester, so the supervised
+  // identity rule below can never authorize anyone for it. Supervised agent
+  // rows are fanned out to action-and-target-eligible humans and re-checked
+  // per user here; four_eyes agent rows keep the unchanged org
+  // approvals:decide rule. (`!= null` on purpose: never routes a legacy row
+  // whose projection lacks the column into the agent branch.)
+  if (intent.requestingAgentRunId != null) {
+    if (intent.approvalScope !== 'supervised') return orgDecideAuthorizer(intent.orgId);
+    return agentDecideAuthorizer(intent);
+  }
   if (intent.approvalScope === 'supervised') return intent.requestedByUserId === userId;
   return orgDecideAuthorizer(intent.orgId);
 }
@@ -199,8 +272,12 @@ async function resolveRowLiveAuthorization(
   row: typeof approvalRequests.$inferSelect,
   userId: string,
   partnerId: string | null,
-): Promise<{ authorized: boolean; approvalScope: ActionIntentApprovalScope | null }> {
-  if (!row.intentId) return { authorized: true, approvalScope: null };
+): Promise<{
+  authorized: boolean;
+  approvalScope: ActionIntentApprovalScope | null;
+  attribution: IntentAttribution;
+}> {
+  if (!row.intentId) return { authorized: true, approvalScope: null, attribution: null };
   const intentId = row.intentId;
   const intent = await runOutsideDbContext(() =>
     withSystemDbAccessContext(async () => {
@@ -215,8 +292,13 @@ async function resolveRowLiveAuthorization(
     intent,
     userId,
     makeOrgDecideAuthorizer(userId, partnerId),
+    makeAgentDecideAuthorizer(userId),
   );
-  return { authorized, approvalScope: intent?.approvalScope ?? null };
+  return {
+    authorized,
+    approvalScope: intent?.approvalScope ?? null,
+    attribution: toIntentAttribution(intent),
+  };
 }
 
 /**
@@ -256,14 +338,19 @@ async function fetchAuthorizedPendingApprovals(
   );
 
   const orgDecideAuthorizer = makeOrgDecideAuthorizer(userId, partnerId);
+  const agentDecideAuthorizer = makeAgentDecideAuthorizer(userId);
   const authorized: AuthorizedApproval[] = [];
   for (const { approval, intent } of rows) {
     if (!approval.intentId) {
-      authorized.push({ approval, approvalScope: null });
+      authorized.push({ approval, approvalScope: null, attribution: null });
       continue;
     }
-    if (await isIntentRowLiveAuthorized(intent, userId, orgDecideAuthorizer)) {
-      authorized.push({ approval, approvalScope: intent?.approvalScope ?? null });
+    if (await isIntentRowLiveAuthorized(intent, userId, orgDecideAuthorizer, agentDecideAuthorizer)) {
+      authorized.push({
+        approval,
+        approvalScope: intent?.approvalScope ?? null,
+        attribution: toIntentAttribution(intent),
+      });
     }
   }
   return authorized;
@@ -297,11 +384,12 @@ approvalRoutes.get('/pending', async (c) => {
   // mutation rows in this page (no N+1).
   const tenants = await lookupCustomerTenants(page.map((r) => r.approval));
   return c.json({
-    approvals: page.map(({ approval, approvalScope }) =>
+    approvals: page.map(({ approval, approvalScope, attribution }) =>
       serialize(
         approval,
         (approval.executionId && tenants.get(approval.executionId)) || null,
         approvalScope,
+        attribution,
       ),
     ),
     nextCursor,
@@ -410,7 +498,7 @@ approvalRoutes.get('/:id', async (c) => {
 
   const tenants = await lookupCustomerTenants([row]);
   const customerTenant = (row.executionId && tenants.get(row.executionId)) || null;
-  return c.json({ approval: serialize(row, customerTenant, live.approvalScope) });
+  return c.json({ approval: serialize(row, customerTenant, live.approvalScope, live.attribution) });
 });
 
 // Phase 2: issue a short-lived (120s) WebAuthn assertion challenge bound to
@@ -1034,6 +1122,15 @@ async function decideHandler(
   proof?: ApprovalProof,
   reauthVerified = false
 ) {
+  // Wave 3b (parent plan §1.2): approval decisions are made by HUMANS,
+  // structurally — asserted here on the principal discriminator rather than
+  // relying on routing topology (no non-human route mounts this handler
+  // today, but nothing else guarantees that stays true). An allowlist of
+  // one: api_key, oauth_grant, ai_agent, system — none of them decide.
+  if (!isInteractiveUserSession(c.get('auth'))) {
+    return c.json({ error: 'human_decision_required' }, 403);
+  }
+
   const userId = c.get('auth').user.id;
   const id = c.req.param('id');
   if (!id) return c.json({ error: 'Bad request' }, 400);
@@ -1121,7 +1218,46 @@ async function decideHandler(
     // re-derivation, the WebAuthn/step-up ladder) applies to it. Branching
     // here, BEFORE any of that runs, is what lets a supervised requester who
     // holds no approvals:decide permission at all still decide their own row.
-    if (linkedIntent.approvalScope === 'supervised') {
+    //
+    // Wave 3b Task 6 (review blocker 2): a supervised AGENT-originated intent
+    // (`requestingAgentRunId` set, requester NULL) takes a COMPLETELY separate
+    // branch — swapping only the `not_requester` 403 would not be enough:
+    //
+    //  - Authority is the live action-and-target re-check
+    //    (`isAgentIntentDecideAuthorized`): does THIS decider currently hold
+    //    the tool's full RBAC mapping AND reach the intent's concrete target?
+    //    Exactly the predicate creation fanned out on, re-derived at decide
+    //    time the way four_eyes re-derives approvals:decide.
+    //  - The human branch's requester-RBAC re-check (buildAuthContextForIntent
+    //    + checkToolPermission) must be SKIPPED: Task 7 reconstructs an
+    //    `ai_agent` principal for this intent, and checkToolPermission's first
+    //    statement denies that kind — left in place, EVERY supervised agent
+    //    approval would 403. The decider's own action RBAC was just verified
+    //    above; the agent-policy re-check happens at release (Task 7).
+    //  - `isSupervisedSelfDecide` stays FALSE: agent intents never skip the
+    //    assurance ladder — a headless proposal gets the same ceremony a
+    //    four_eyes decision would.
+    //
+    // Unconditional (approve AND deny), like the human identity gate: rows are
+    // only ever fanned out to eligible users, so an ineligible decider here is
+    // a lost permission or a tampered row — fail closed either way. (The
+    // requester-less cancel contract for `approvals:decide` holders is the
+    // cancel endpoint, Task 8 — not this handler.)
+    if (linkedIntent.approvalScope === 'supervised' && linkedIntent.requestingAgentRunId != null) {
+      if (!(await isAgentIntentDecideAuthorized(userId, linkedIntent))) {
+        recordActionIntentEvent({
+          orgId: linkedIntent.orgId,
+          intentId: linkedIntent.id,
+          actionName: linkedIntent.actionName,
+          argumentDigest: linkedIntent.argumentDigest,
+          source: linkedIntent.source,
+          outcome: 'approver_unauthorized',
+          actorId: userId,
+          details: { approvalId: existing.id, errorCode: 'not_authorized_for_agent_intent' },
+        });
+        return c.json({ error: 'not_authorized_for_agent_intent' }, 403);
+      }
+    } else if (linkedIntent.approvalScope === 'supervised') {
       isSupervisedSelfDecide = true;
 
       // Identity gate: even if a non-requester somehow reached this row (a
@@ -1756,7 +1892,14 @@ async function decideHandler(
     });
   }
 
-  return c.json({ approval: serialize(updated, null, linkedIntent?.approvalScope ?? null) });
+  return c.json({
+    approval: serialize(
+      updated,
+      null,
+      linkedIntent?.approvalScope ?? null,
+      toIntentAttribution(linkedIntent),
+    ),
+  });
 }
 
 // The two M365 mutation tools (tier 3) that create an approval card. Read-only
@@ -1816,9 +1959,19 @@ function serialize(
    * affordance ahead of the request.
    */
   approvalScope: ActionIntentApprovalScope | null = null,
+  /**
+   * Attribution projection of the linked intent (wave 3b Task 6), or null for
+   * a row with no intent. Drives `origin`/`agentName` so the inbox can say an
+   * AI agent asked — `requestingClientLabel` was stamped with the agent's
+   * name at intent creation, so no join is needed. Web Task 9 consumes both.
+   */
+  attribution: IntentAttribution = null,
 ) {
+  const isAgentOriginated = attribution?.requestingAgentRunId != null;
   return {
     id: r.id,
+    origin: isAgentOriginated ? ('ai_agent' as const) : ('human' as const),
+    agentName: isAgentOriginated ? (attribution?.requestingClientLabel ?? null) : null,
     requestingClientLabel: r.requestingClientLabel,
     requestingMachineLabel: r.requestingMachineLabel ?? null,
     actionLabel: r.actionLabel,

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -118,9 +118,15 @@ export const DEVICE_DETACH_DEVICE_ID_TABLES = [
  *   device_commands (system-scoped per RLS policy), device_software,
  *   patch_job_results, patch_rollbacks,
  *   psa_ticket_mappings, software_compliance_status
+ *
+ * ai_agent_runs is deliberately ABSENT (wave 3b, owner decision 2026-08-23):
+ * agent-run history stays with the source org on a cross-org move — moveOrg
+ * detaches device_id instead. It is listed in INTENTIONALLY_NO_ORG_ID in
+ * moveOrg.coverage.test.ts. Its org_id is trigger-immutable
+ * (2026-09-06-a-agent-runs-org-immutable.sql).
  */
 const CORE_DEVICE_ORG_DENORMALIZED_TABLES = [
-  'agent_logs', 'ai_agent_runs', 'ai_screenshots', 'ai_sessions', 'alerts', 'asset_checkouts',
+  'agent_logs', 'ai_screenshots', 'ai_sessions', 'alerts', 'asset_checkouts',
   'audit_baseline_results', 'audit_policy_states',
   'automation_run_device_results',
   'backup_chains', 'backup_jobs', 'backup_sla_events',

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -27,6 +27,10 @@ import {
  * here and must match the comment in core.ts.
  */
 const INTENTIONALLY_NO_ORG_ID: ReadonlySet<string> = new Set([
+  // Has org_id, but it is intentionally NOT re-stamped on move: agent-run
+  // history stays with the source org (owner decision 2026-08-23) — see the
+  // CORE_DEVICE_ORG_DENORMALIZED_TABLES comment in core.ts.
+  'ai_agent_runs',
   'automation_policy_compliance',
   'deployment_devices',
   'deployment_results',

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -229,6 +229,20 @@ moveOrgRoutes.post(
           linkGroupDissolved = await dissolveLinkGroupIfBelowMinimum(tx, device.linkGroupId);
         }
 
+        // Agent-run history stays with the SOURCE org (owner decision 2026-08-23):
+        // runs are not re-stamped (org_id is trigger-immutable, and re-stamping
+        // would 23503 against the action_intents composite tenant FK the moment an
+        // agent proposal exists). Sever ALL device-lineage links, not just
+        // device_id: alerts and ai_sessions ARE re-stamped to the target org by
+        // the loop below, so a retained source-org run keeping alert_id/session_id
+        // would point across tenants (and /ai-agents/:id/runs would serve those
+        // foreign ids to the source org). All three FKs are ON DELETE SET NULL —
+        // nullable by design.
+        await tx.execute(
+          sql`UPDATE ai_agent_runs SET device_id = NULL, alert_id = NULL, session_id = NULL
+              WHERE device_id = ${deviceId}::uuid`,
+        );
+
         // Rewrite the denormalized org_id on every device-scoped table.
         // Skipping any of these strands pre-existing rows under RLS.
         for (const table of getDeviceOrgDenormalizedTables()) {

--- a/apps/api/src/services/actionIntents/actorContext.test.ts
+++ b/apps/api/src/services/actionIntents/actorContext.test.ts
@@ -14,12 +14,31 @@ const { schema, dbState, permState } = vi.hoisted(() => {
     isPlatformAdmin: col('is_platform_admin'),
   };
   const apiKeysTbl = { id: col('id'), status: col('status') };
+  const aiAgentRunsTbl = {
+    id: col('id'),
+    agentId: col('agent_id'),
+    orgId: col('org_id'),
+    deviceId: col('device_id'),
+  };
+  const aiAgentsTbl = {
+    id: col('id'),
+    orgId: col('org_id'),
+    partnerId: col('partner_id'),
+    name: col('name'),
+    kind: col('kind'),
+  };
+  const organizationsTbl = { id: col('id'), partnerId: col('partner_id') };
+  const devicesTbl = { id: col('id'), siteId: col('site_id') };
 
   return {
-    schema: { usersTbl, apiKeysTbl },
+    schema: { usersTbl, apiKeysTbl, aiAgentRunsTbl, aiAgentsTbl, organizationsTbl, devicesTbl },
     dbState: {
       selectUsersResults: [] as unknown[][],
       selectApiKeysResults: [] as unknown[][],
+      selectAgentRunsResults: [] as unknown[][],
+      selectAgentsResults: [] as unknown[][],
+      selectOrgsResults: [] as unknown[][],
+      selectDevicesResults: [] as unknown[][],
     },
     permState: {
       getUserPermissions: vi.fn(),
@@ -44,16 +63,35 @@ vi.mock('../../db', () => ({
           if (table === schema.apiKeysTbl) {
             return resultBox(() => dbState.selectApiKeysResults.shift() ?? []);
           }
+          if (table === schema.aiAgentRunsTbl) {
+            return resultBox(() => dbState.selectAgentRunsResults.shift() ?? []);
+          }
+          if (table === schema.aiAgentsTbl) {
+            return resultBox(() => dbState.selectAgentsResults.shift() ?? []);
+          }
+          if (table === schema.organizationsTbl) {
+            return resultBox(() => dbState.selectOrgsResults.shift() ?? []);
+          }
+          if (table === schema.devicesTbl) {
+            return resultBox(() => dbState.selectDevicesResults.shift() ?? []);
+          }
           throw new Error('unexpected select table in mock');
         }),
       })),
     })),
   },
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
 }));
 
 vi.mock('../../db/schema/users', () => ({ users: schema.usersTbl }));
 vi.mock('../../db/schema/apiKeys', () => ({ apiKeys: schema.apiKeysTbl }));
+vi.mock('../../db/schema/aiAgents', () => ({
+  aiAgentRuns: schema.aiAgentRunsTbl,
+  aiAgents: schema.aiAgentsTbl,
+}));
+vi.mock('../../db/schema/orgs', () => ({ organizations: schema.organizationsTbl }));
+vi.mock('../../db/schema/devices', () => ({ devices: schema.devicesTbl }));
 
 vi.mock('../permissions', () => ({
   getUserPermissions: permState.getUserPermissions,
@@ -106,7 +144,7 @@ vi.mock('drizzle-orm', () => ({
 // Import under test (after mocks)
 // ---------------------------------------------------------------------------
 
-import { buildAuthContextForIntent } from './actorContext';
+import { buildAuthContextForIntent, originPrincipalFor } from './actorContext';
 import type { ActionIntent } from '../../db/schema/actionIntents';
 
 function baseIntent(overrides: Partial<ActionIntent> = {}): ActionIntent {
@@ -341,21 +379,108 @@ describe('buildAuthContextForIntent — malformed intent (neither actor set)', (
   });
 });
 
-describe('buildAuthContextForIntent — agent-originated intent (wave 3a inert window)', () => {
-  it('fails closed (null) for a requester-less intent that carries a run id', async () => {
-    // Pins that release stays fail-closed for agent intents until PR 3b wires
-    // the requester-less reconstruction: a run-attributed intent must map to
-    // actor_invalid, not to a half-built context.
-    const result = await buildAuthContextForIntent(
-      baseIntent({
-        requestedByUserId: null,
-        requestingApiKeyId: null,
-        requestingAgentRunId: 'run-1',
-        originPrincipalKind: 'ai_agent',
-        originPrincipalId: 'agent-1',
-      }),
-    );
+describe('buildAuthContextForIntent — agent-owned intents (wave 3b)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState.selectAgentRunsResults.length = 0;
+    dbState.selectAgentsResults.length = 0;
+    dbState.selectOrgsResults.length = 0;
+    dbState.selectDevicesResults.length = 0;
+  });
 
-    expect(result).toBeNull();
+  const agentIntent = (overrides: Partial<ActionIntent> = {}) => baseIntent({
+    requestedByUserId: null,
+    requestingApiKeyId: null,
+    requestingAgentRunId: 'run-1',
+    originPrincipalKind: 'ai_agent',
+    originPrincipalId: 'agent-1',
+    source: 'ai_agent',
+    ...overrides,
+  } as Partial<ActionIntent>);
+
+  const runRow = { id: 'run-1', agentId: 'agent-1', orgId: 'org-1', deviceId: 'dev-1' };
+  const agentRow = { id: 'agent-1', orgId: null, partnerId: 'partner-1', name: 'Alert Triage', kind: 'triage' };
+
+  it('builds an ai_agent context pinned to the run org and the device site', async () => {
+    dbState.selectAgentRunsResults.push([runRow]);
+    dbState.selectAgentsResults.push([agentRow]);
+    dbState.selectOrgsResults.push([{ partnerId: 'partner-1' }]);
+    dbState.selectDevicesResults.push([{ siteId: 'site-1' }]);
+
+    const result = await buildAuthContextForIntent(agentIntent());
+
+    expect(result).not.toBeNull();
+    expect(result!.principal).toEqual({ kind: 'ai_agent', agentId: 'agent-1', runId: 'run-1' });
+    expect(result!.orgId).toBe('org-1');
+    expect(result!.accessibleOrgIds).toEqual(['org-1']);
+    expect(result!.canAccessOrg('org-1')).toBe(true);
+    expect(result!.canAccessOrg('org-2')).toBe(false);
+    // Spec §3.2: a device-bound run is pinned to the device's CURRENT site.
+    expect(result!.allowedSiteIds).toEqual(['site-1']);
+    expect(result!.canAccessSite!('site-1')).toBe(true);
+    expect(result!.canAccessSite!('site-2')).toBe(false);
+    // No user token is ever minted for an agent; RBAC paths must keep denying it.
+    expect(result!.token).toBeNull();
+    expect(permState.getUserPermissions).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the run is missing', async () => {
+    dbState.selectAgentRunsResults.push([]);
+
+    expect(await buildAuthContextForIntent(agentIntent())).toBeNull();
+  });
+
+  it('returns null when the run targets another org than the intent', async () => {
+    dbState.selectAgentRunsResults.push([{ ...runRow, orgId: 'org-2' }]);
+
+    expect(await buildAuthContextForIntent(agentIntent())).toBeNull();
+  });
+
+  it('returns null when the run agent does not match originPrincipalId', async () => {
+    dbState.selectAgentRunsResults.push([{ ...runRow, agentId: 'agent-9' }]);
+
+    expect(await buildAuthContextForIntent(agentIntent())).toBeNull();
+  });
+
+  it('returns null when the agent row is gone', async () => {
+    dbState.selectAgentRunsResults.push([runRow]);
+    dbState.selectAgentsResults.push([]);
+
+    expect(await buildAuthContextForIntent(agentIntent())).toBeNull();
+  });
+
+  it('returns null when run ownership fails (org agent of another org)', async () => {
+    dbState.selectAgentRunsResults.push([runRow]);
+    dbState.selectAgentsResults.push([{ ...agentRow, orgId: 'org-2', partnerId: null }]);
+    dbState.selectOrgsResults.push([{ partnerId: 'partner-1' }]);
+    dbState.selectDevicesResults.push([{ siteId: 'site-1' }]);
+
+    expect(await buildAuthContextForIntent(agentIntent())).toBeNull();
+  });
+});
+
+describe('originPrincipalFor — ai_agent', () => {
+  it('maps an agent intent to { kind: ai_agent, agentId, runId }', () => {
+    const principal = originPrincipalFor(baseIntent({
+      requestedByUserId: null,
+      requestingAgentRunId: 'run-1',
+      originPrincipalKind: 'ai_agent',
+      originPrincipalId: 'agent-1',
+    } as Partial<ActionIntent>));
+
+    expect(principal).toEqual({ kind: 'ai_agent', agentId: 'agent-1', runId: 'run-1' });
+  });
+
+  it('falls to unknown when the run id or agent id is missing (corruption stays untrusted)', () => {
+    expect(originPrincipalFor(baseIntent({
+      originPrincipalKind: 'ai_agent',
+      originPrincipalId: 'agent-1',
+      requestingAgentRunId: null,
+    } as Partial<ActionIntent>))).toEqual({ kind: 'unknown' });
+    expect(originPrincipalFor(baseIntent({
+      originPrincipalKind: 'ai_agent',
+      originPrincipalId: null,
+      requestingAgentRunId: 'run-1',
+    } as Partial<ActionIntent>))).toEqual({ kind: 'unknown' });
   });
 });

--- a/apps/api/src/services/actionIntents/actorContext.ts
+++ b/apps/api/src/services/actionIntents/actorContext.ts
@@ -1,8 +1,15 @@
 import { eq } from 'drizzle-orm';
-import { db, withSystemDbAccessContext } from '../../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { users } from '../../db/schema/users';
 import { apiKeys } from '../../db/schema/apiKeys';
+import { aiAgentRuns, aiAgents } from '../../db/schema/aiAgents';
+import { organizations } from '../../db/schema/orgs';
+import { devices } from '../../db/schema/devices';
 import type { ActionIntent } from '../../db/schema/actionIntents';
+import {
+  AgentRunOwnershipError,
+  buildAgentAuthContext,
+} from '../aiAgents/agentAuthContext';
 import { getUserPermissions, canAccessOrg as permsCanAccessOrg } from '../permissions';
 import { buildOrgAccessClosures, siteAccessCheck, type AuthContext } from '../../middleware/auth';
 import type { TokenPayload } from '../jwt';
@@ -32,21 +39,11 @@ export async function buildAuthContextForIntent(intent: ActionIntent): Promise<A
 
   // The migration's action_intents_one_actor_chk CHECK guarantees exactly
   // one of requestedByUserId/requestingApiKeyId/requestingAgentRunId is set.
-  // An agent-originated intent (requestingAgentRunId set) falling through to
-  // here is EXPECTED, not corruption: createActionIntent fails closed on the
-  // 'ai_agent' principal, so no code today produces an agent-originated
-  // intent — and if one ever reaches this function ahead of PR 3b's
-  // requester-less release path, failing closed here is the designed
-  // behavior. Fail closed the same as any other actor_invalid case rather
-  // than throwing out of a background worker — but log the two states
-  // distinguishably: a run-attributed intent is well-formed and merely
-  // unsupported, while an all-NULL actor row would be a data-integrity
-  // violation the CHECK should have made impossible.
+  // An agent-originated intent reconstructs the RUN's agent identity (wave
+  // 3b): structural, never a user token — checkToolPermission keeps denying
+  // the resulting principal, and release authority is checkAgentReleaseAuthority.
   if (intent.requestingAgentRunId) {
-    console.error(
-      `[actorContext] intent ${intent.id} is agent-originated (run ${intent.requestingAgentRunId}); requester-less release reconstruction is not implemented until PR 3b — failing closed`,
-    );
-    return null;
+    return buildAgentOwnedAuthContext(intent, intent.requestingAgentRunId);
   }
   console.error(
     `[actorContext] intent ${intent.id} has no actor column set (requestedByUserId/requestingApiKeyId/requestingAgentRunId all NULL) — data-integrity violation`,
@@ -63,7 +60,7 @@ export async function buildAuthContextForIntent(intent: ActionIntent): Promise<A
  * trust every historical record, turning a fail-closed marker into an
  * escalation. `unknown` is trusted by nothing.
  */
-function originPrincipalFor(intent: ActionIntent): AuthContext['principal'] {
+export function originPrincipalFor(intent: ActionIntent): AuthContext['principal'] {
   switch (intent.originPrincipalKind) {
     case 'user_session':
       return { kind: 'user_session' };
@@ -80,12 +77,17 @@ function originPrincipalFor(intent: ActionIntent): AuthContext['principal'] {
     case 'system':
       return { kind: 'system', reason: 'intent-origin-system' };
     case 'ai_agent':
-      // Recorded but NOT buildable here yet: the ai_agent principal requires
-      // agentId + runId resolved from requesting_agent_run_id, which is PR
-      // 3b's release-reconstruction work. Mapping to `unknown` keeps this
-      // fail-closed (`unknown` is trusted by nothing) instead of minting a
-      // half-formed agent principal.
-      return { kind: 'unknown' };
+      // agentId is originPrincipalId; runId is the FK column. Both are
+      // REQUIRED on the principal type — an agent intent without them cannot
+      // exist (action_intents_agent_origin_chk), so falling to 'unknown' here
+      // would only hide corruption.
+      return intent.requestingAgentRunId && intent.originPrincipalId
+        ? {
+            kind: 'ai_agent',
+            agentId: intent.originPrincipalId,
+            runId: intent.requestingAgentRunId,
+          }
+        : { kind: 'unknown' };
     default: {
       // Compile-time exhaustiveness: when the origin-kind union widens again,
       // this assignment errors instead of silently downgrading the new kind
@@ -214,6 +216,119 @@ async function buildUserOwnedAuthContext(
       canAccessSite: siteAccessCheck(allowedSiteIds),
     };
   });
+}
+
+/**
+ * Agent-owned intents (`requesting_agent_run_id` set, `source: 'ai_agent'`,
+ * wave 3b). Reconstructs the RUN's agent AuthContext — the same shape PR 3c's
+ * runner will hold live — via `buildAgentAuthContext`, whose
+ * `assertRunOwnership` re-proves the agent→run→org lineage at release time.
+ * Any doubt (missing run/agent/org, run pointing at another org or agent than
+ * the intent records, ownership mismatch) maps to `null` ⇒ `actor_invalid`,
+ * the same fail-closed shape as the other branches.
+ *
+ * The context carries `token: null` and an attribution-only synthetic user;
+ * `checkToolPermission`/`checkPermissionRequirements` continue to deny the
+ * `ai_agent` principal outright — release authority for agent intents is the
+ * separate structural check in `agentReleaseAuthority.ts`.
+ */
+async function buildAgentOwnedAuthContext(
+  intent: ActionIntent,
+  runId: string,
+): Promise<AuthContext | null> {
+  // runOutsideDbContext is load-bearing: the release worker runs with no
+  // ambient request context (where a bare system wrapper is fine), but the
+  // inline chat release path calls this INSIDE a request context, where
+  // withSystemDbAccessContext alone is a passthrough to the ambient org
+  // scope (db/index.ts ~440) and these cross-axis reads would be denied.
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async (): Promise<AuthContext | null> => {
+      const [run] = await db
+        .select({
+          id: aiAgentRuns.id,
+          agentId: aiAgentRuns.agentId,
+          orgId: aiAgentRuns.orgId,
+          deviceId: aiAgentRuns.deviceId,
+        })
+        .from(aiAgentRuns)
+        .where(eq(aiAgentRuns.id, runId))
+        .limit(1);
+      if (!run) {
+        console.error(
+          `[actorContext] intent ${intent.id} references agent run ${runId}, which does not exist — failing closed`,
+        );
+        return null;
+      }
+      // The composite FK (requesting_agent_run_id, org_id) →
+      // ai_agent_runs(id, org_id) guarantees the org match, and
+      // action_intents_agent_origin_chk pins originPrincipalId. Assert both
+      // anyway so a future schema change fails loud instead of executing an
+      // intent under the wrong run's identity.
+      if (run.orgId !== intent.orgId || run.agentId !== intent.originPrincipalId) {
+        console.error(
+          `[actorContext] intent ${intent.id} run ${runId} lineage mismatch `
+          + `(run.orgId=${run.orgId} intent.orgId=${intent.orgId} `
+          + `run.agentId=${run.agentId} originPrincipalId=${intent.originPrincipalId}) — failing closed`,
+        );
+        return null;
+      }
+      const [agent] = await db
+        .select({
+          id: aiAgents.id,
+          orgId: aiAgents.orgId,
+          partnerId: aiAgents.partnerId,
+          name: aiAgents.name,
+          kind: aiAgents.kind,
+        })
+        .from(aiAgents)
+        .where(eq(aiAgents.id, run.agentId))
+        .limit(1);
+      if (!agent) {
+        return null;
+      }
+      const [org] = await db
+        .select({ partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(eq(organizations.id, run.orgId))
+        .limit(1);
+      if (!org) {
+        return null;
+      }
+      // The device's CURRENT site, not the site at proposal time — spec §3.2
+      // pins a device-bound run to its device's site, and release must
+      // reflect where the device lives NOW.
+      let deviceSiteId: string | null = null;
+      if (run.deviceId) {
+        const [device] = await db
+          .select({ siteId: devices.siteId })
+          .from(devices)
+          .where(eq(devices.id, run.deviceId))
+          .limit(1);
+        deviceSiteId = device?.siteId ?? null;
+      }
+      try {
+        return buildAgentAuthContext(
+          {
+            id: agent.id,
+            orgId: agent.orgId,
+            partnerId: agent.partnerId,
+            name: agent.name,
+            kind: agent.kind,
+          },
+          { id: run.id, orgId: run.orgId, deviceId: run.deviceId, deviceSiteId },
+          { id: run.orgId, partnerId: org.partnerId },
+        );
+      } catch (error) {
+        if (error instanceof AgentRunOwnershipError) {
+          console.error(
+            `[actorContext] intent ${intent.id} run ${runId}: ${error.message} — failing closed`,
+          );
+          return null;
+        }
+        throw error;
+      }
+    }),
+  );
 }
 
 /**

--- a/apps/api/src/services/actionIntents/agentReleaseAuthority.test.ts
+++ b/apps/api/src/services/actionIntents/agentReleaseAuthority.test.ts
@@ -1,0 +1,311 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted shared mock state. The REAL checkAgentGuardrails and the REAL
+// buildAgentAuthContext/assertRunOwnership run in this suite — the whole point
+// of the stricter-combination veto is the structural gate itself, so stubbing
+// it would make every test vacuous. Only the db and the effective-policy
+// resolver are mocked.
+// ---------------------------------------------------------------------------
+
+const { dbState, policyState } = vi.hoisted(() => ({
+  dbState: {
+    selectAgentRunsResults: [] as unknown[][],
+    selectAgentsResults: [] as unknown[][],
+    selectOrgsResults: [] as unknown[][],
+    selectDevicesResults: [] as unknown[][],
+  },
+  policyState: {
+    resolveEffectiveAgent: vi.fn(),
+  },
+}));
+
+vi.mock('../../db', async () => {
+  const { aiAgentRuns, aiAgents } = await import('../../db/schema/aiAgents');
+  const { organizations } = await import('../../db/schema/orgs');
+  const { devices } = await import('../../db/schema/devices');
+  const resultBox = (getResult: () => unknown) => ({
+    limit: vi.fn(() => Promise.resolve(getResult())),
+  });
+  return {
+    db: {
+      select: vi.fn(() => ({
+        from: vi.fn((table: unknown) => ({
+          where: vi.fn(() => {
+            if (table === aiAgentRuns) return resultBox(() => dbState.selectAgentRunsResults.shift() ?? []);
+            if (table === aiAgents) return resultBox(() => dbState.selectAgentsResults.shift() ?? []);
+            if (table === organizations) return resultBox(() => dbState.selectOrgsResults.shift() ?? []);
+            if (table === devices) return resultBox(() => dbState.selectDevicesResults.shift() ?? []);
+            throw new Error('unexpected select table in mock');
+          }),
+        })),
+      })),
+    },
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  };
+});
+
+vi.mock('../aiAgents/effectivePolicy', () => ({
+  resolveEffectiveAgent: policyState.resolveEffectiveAgent,
+}));
+
+import { AI_AGENT_LIMIT_DEFAULTS, type AiAgentPolicy } from '@breeze/shared';
+import type { ActionIntent } from '../../db/schema/actionIntents';
+import { checkAgentReleaseAuthority } from './agentReleaseAuthority';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const effectivePolicy = (overrides: Partial<AiAgentPolicy> = {}): AiAgentPolicy => ({
+  enabled: true,
+  mode: 'shadow',
+  model: null,
+  toolAllowlist: ['manage_services:restart'],
+  protectedResources: { services: [], paths: [], registryKeys: [], deviceTags: [] },
+  limits: AI_AGENT_LIMIT_DEFAULTS,
+  triggers: { alertSeverities: ['critical'], respectMaintenanceWindows: true },
+  recipients: { userIds: [], roleIds: [] },
+  instructions: null,
+  cooldownSeconds: 0,
+  ...overrides,
+});
+
+const runRow = (snapshotEffective: AiAgentPolicy = effectivePolicy()) => ({
+  id: 'run-1',
+  agentId: 'agent-1',
+  orgId: 'org-1',
+  deviceId: 'dev-1',
+  policySnapshot: {
+    schemaVersion: 1,
+    agentId: 'agent-1',
+    kind: 'triage',
+    effective: snapshotEffective,
+    provenance: {},
+    resolvedAt: '2026-08-23T00:00:00.000Z',
+  },
+});
+
+const agentRow = {
+  id: 'agent-1', orgId: null, partnerId: 'partner-1', name: 'Alert Triage', kind: 'triage',
+};
+
+const resolvedAgent = (eff: AiAgentPolicy = effectivePolicy(), agentId = 'agent-1') => ({
+  schemaVersion: 1,
+  agentId,
+  kind: 'triage',
+  effective: eff,
+  provenance: {},
+  resolvedAt: '2026-08-23T01:00:00.000Z',
+});
+
+function intentFixture(overrides: Partial<ActionIntent> = {}): ActionIntent {
+  return {
+    id: 'intent-1',
+    orgId: 'org-1',
+    partnerId: 'partner-1',
+    requestedByUserId: null,
+    requestingApiKeyId: null,
+    requestingAgentRunId: 'run-1',
+    originPrincipalKind: 'ai_agent',
+    originPrincipalId: 'agent-1',
+    source: 'ai_agent',
+    actionName: 'manage_services',
+    arguments: { deviceId: 'dev-1', action: 'restart', serviceName: 'spooler', siteId: 'site-a' },
+    riskTier: 3,
+    ...overrides,
+  } as ActionIntent;
+}
+
+function seedHappyRows(overrides: {
+  run?: unknown; agent?: unknown; org?: unknown; deviceSiteId?: string | null;
+} = {}) {
+  dbState.selectAgentRunsResults.push([overrides.run ?? runRow()]);
+  dbState.selectAgentsResults.push([overrides.agent ?? agentRow]);
+  dbState.selectOrgsResults.push([overrides.org ?? { partnerId: 'partner-1' }]);
+  dbState.selectDevicesResults.push([{ siteId: overrides.deviceSiteId === undefined ? 'site-a' : overrides.deviceSiteId }]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('BREEZE_AI_AGENTS_ENABLED', 'true');
+  dbState.selectAgentRunsResults.length = 0;
+  dbState.selectAgentsResults.length = 0;
+  dbState.selectOrgsResults.length = 0;
+  dbState.selectDevicesResults.length = 0;
+  policyState.resolveEffectiveAgent.mockResolvedValue(resolvedAgent());
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// The stricter-combination veto
+// ---------------------------------------------------------------------------
+
+describe('checkAgentReleaseAuthority', () => {
+  it('passes when both snapshot and current policy yield propose', async () => {
+    seedHappyRows();
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toEqual({ ok: true });
+    // The current policy is resolved through the reconstructed AGENT auth
+    // (structural, never user RBAC) for the run's org + the agent's kind.
+    expect(policyState.resolveEffectiveAgent).toHaveBeenCalledTimes(1);
+    const [auth, orgId, kind] = policyState.resolveEffectiveAgent.mock.calls[0]!;
+    expect(auth.principal).toEqual({ kind: 'ai_agent', agentId: 'agent-1', runId: 'run-1' });
+    expect(orgId).toBe('org-1');
+    expect(kind).toBe('triage');
+  });
+
+  it('vetoes when the CURRENT allowlist dropped the tool (snapshot still allows)', async () => {
+    seedHappyRows();
+    policyState.resolveEffectiveAgent.mockResolvedValue(
+      resolvedAgent(effectivePolicy({ toolAllowlist: [] })),
+    );
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toMatchObject({
+      ok: false,
+      errorCode: 'agent_policy_denied',
+      details: { policy: 'current' },
+    });
+  });
+
+  it('vetoes when the agent was disabled after approval', async () => {
+    seedHappyRows();
+    policyState.resolveEffectiveAgent.mockResolvedValue(
+      resolvedAgent(effectivePolicy({ enabled: false })),
+    );
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toMatchObject({
+      ok: false,
+      errorCode: 'agent_policy_denied',
+      details: { policy: 'current' },
+    });
+  });
+
+  it('vetoes agent_policy_denied when no effective agent resolves any more', async () => {
+    seedHappyRows();
+    policyState.resolveEffectiveAgent.mockResolvedValue(null);
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toMatchObject({
+      ok: false,
+      errorCode: 'agent_policy_denied',
+      details: { reason: 'no effective agent' },
+    });
+  });
+
+  it('vetoes when the kill switch is off', async () => {
+    vi.stubEnv('BREEZE_AI_AGENTS_ENABLED', 'false');
+    seedHappyRows();
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toMatchObject({ ok: false, errorCode: 'agent_policy_denied' });
+  });
+
+  it('vetoes when current mode is off', async () => {
+    seedHappyRows();
+    policyState.resolveEffectiveAgent.mockResolvedValue(
+      resolvedAgent(effectivePolicy({ mode: 'off' })),
+    );
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toMatchObject({
+      ok: false,
+      errorCode: 'agent_policy_denied',
+      details: { policy: 'current' },
+    });
+  });
+
+  it('vetoes agent_identity_changed when the org+kind resolves to a different agent', async () => {
+    seedHappyRows();
+    policyState.resolveEffectiveAgent.mockResolvedValue(
+      resolvedAgent(effectivePolicy(), 'agent-2'),
+    );
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toMatchObject({ ok: false, errorCode: 'agent_identity_changed' });
+  });
+
+  it('re-resolves the device site at release (device moved site => site-scoped input vetoes)', async () => {
+    // The proposal cited siteId 'site-a' and was approved while the device
+    // lived there; the device has since moved to site-b. BOTH evaluations use
+    // the CURRENT site, so even the snapshot policy now denies.
+    seedHappyRows({ deviceSiteId: 'site-b' });
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toMatchObject({
+      ok: false,
+      errorCode: 'agent_policy_denied',
+      details: { policy: 'snapshot' },
+    });
+  });
+
+  it('fails agent_run_invalid when the run is missing', async () => {
+    dbState.selectAgentRunsResults.push([]);
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toMatchObject({ ok: false, errorCode: 'agent_run_invalid' });
+    expect(policyState.resolveEffectiveAgent).not.toHaveBeenCalled();
+  });
+
+  it('fails agent_run_invalid when the run targets another org than the intent', async () => {
+    seedHappyRows({ run: { ...runRow(), orgId: 'org-2' } });
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toMatchObject({ ok: false, errorCode: 'agent_run_invalid' });
+  });
+
+  it('fails agent_run_invalid when the run agent does not match originPrincipalId', async () => {
+    seedHappyRows({ run: { ...runRow(), agentId: 'agent-9' } });
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toMatchObject({ ok: false, errorCode: 'agent_run_invalid' });
+  });
+
+  it('fails agent_run_invalid on ownership mismatch (org agent of another org)', async () => {
+    seedHappyRows({ agent: { ...agentRow, orgId: 'org-2', partnerId: null } });
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toMatchObject({ ok: false, errorCode: 'agent_run_invalid' });
+  });
+
+  it('fails agent_run_invalid for an intent that is not agent-originated', async () => {
+    const result = await checkAgentReleaseAuthority(
+      intentFixture({ requestingAgentRunId: null } as Partial<ActionIntent>),
+    );
+
+    expect(result).toMatchObject({ ok: false, errorCode: 'agent_run_invalid' });
+  });
+
+  it('vetoes on a malformed policy snapshot (fail closed, policy: snapshot)', async () => {
+    seedHappyRows({
+      run: { ...runRow(), policySnapshot: { schemaVersion: 1, effective: null } },
+    });
+
+    const result = await checkAgentReleaseAuthority(intentFixture());
+
+    expect(result).toMatchObject({
+      ok: false,
+      errorCode: 'agent_policy_denied',
+      details: { policy: 'snapshot' },
+    });
+  });
+});

--- a/apps/api/src/services/actionIntents/agentReleaseAuthority.ts
+++ b/apps/api/src/services/actionIntents/agentReleaseAuthority.ts
@@ -1,0 +1,205 @@
+import { eq } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { aiAgentRuns, aiAgents } from '../../db/schema/aiAgents';
+import { organizations } from '../../db/schema/orgs';
+import { devices } from '../../db/schema/devices';
+import type { ActionIntent } from '../../db/schema/actionIntents';
+import { checkAgentGuardrails, type AgentGuardrailPolicy } from '../aiGuardrails';
+import {
+  AgentRunOwnershipError,
+  buildAgentAuthContext,
+} from '../aiAgents/agentAuthContext';
+import { resolveEffectiveAgent } from '../aiAgents/effectivePolicy';
+
+export type AgentReleaseAuthority =
+  | { ok: true }
+  | { ok: false; errorCode: string; details?: Record<string, unknown> };
+
+/**
+ * Release-time authority check for an AGENT-originated intent (wave 3b,
+ * parent plan §1.3). The human decision has already been recorded; this is
+ * the last gate before a real Tier-3 mutation executes, so it evaluates the
+ * SAME structural gate twice:
+ *
+ *   1. against the run's immutable `policy_snapshot` — what authorized the
+ *      proposal in the first place, and
+ *   2. against the agent's CURRENT effective policy — what the operator
+ *      believes now.
+ *
+ * Either verdict being 'deny' vetoes the release: a flipped kill switch
+ * (`checkAgentGuardrails` reads BREEZE_AI_AGENTS_ENABLED itself), a disabled
+ * agent, mode 'off', a narrowed allowlist or a newly protected resource all
+ * stop an already-approved proposal. 'propose' PASSES here on purpose:
+ * shadow mode means the agent may not execute unilaterally — a human
+ * decision is exactly what release has.
+ *
+ * This path never consults user RBAC. `checkToolPermission` keeps denying
+ * the ai_agent principal as its first statement; release BRANCHES AROUND it
+ * into this structural check, it does not soften it.
+ */
+export async function checkAgentReleaseAuthority(
+  intent: ActionIntent,
+): Promise<AgentReleaseAuthority> {
+  const runId = intent.requestingAgentRunId;
+  if (!runId) {
+    return {
+      ok: false,
+      errorCode: 'agent_run_invalid',
+      details: { reason: 'intent is not agent-originated' },
+    };
+  }
+
+  // runOutsideDbContext is load-bearing: a bare system wrapper inside an
+  // ambient request/worker context is a passthrough (db/index.ts ~440), and
+  // these reads must not depend on whatever org context the caller holds —
+  // the release worker runs with NO ambient context, where contextless reads
+  // are DENIED, not open.
+  const loaded = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const [run] = await db
+        .select({
+          id: aiAgentRuns.id,
+          agentId: aiAgentRuns.agentId,
+          orgId: aiAgentRuns.orgId,
+          deviceId: aiAgentRuns.deviceId,
+          policySnapshot: aiAgentRuns.policySnapshot,
+        })
+        .from(aiAgentRuns)
+        .where(eq(aiAgentRuns.id, runId))
+        .limit(1);
+      if (!run) return null;
+      // The composite FK (requesting_agent_run_id, org_id) →
+      // ai_agent_runs(id, org_id) guarantees the org match; assert both
+      // anyway so a future schema change fails loud instead of executing
+      // under the wrong lineage.
+      if (run.orgId !== intent.orgId || run.agentId !== intent.originPrincipalId) return null;
+      const [agent] = await db
+        .select({
+          id: aiAgents.id,
+          orgId: aiAgents.orgId,
+          partnerId: aiAgents.partnerId,
+          name: aiAgents.name,
+          kind: aiAgents.kind,
+        })
+        .from(aiAgents)
+        .where(eq(aiAgents.id, run.agentId))
+        .limit(1);
+      if (!agent) return null;
+      const [org] = await db
+        .select({ partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(eq(organizations.id, run.orgId))
+        .limit(1);
+      if (!org) return null;
+      // Re-resolve the device's CURRENT site — never the site the snapshot
+      // was taken under. A device moved out of its site since approval makes
+      // site-scoped input veto below.
+      let deviceSiteId: string | null = null;
+      if (run.deviceId) {
+        const [device] = await db
+          .select({ siteId: devices.siteId })
+          .from(devices)
+          .where(eq(devices.id, run.deviceId))
+          .limit(1);
+        deviceSiteId = device?.siteId ?? null;
+      }
+      return { run, agent, org, deviceSiteId };
+    }),
+  );
+  if (!loaded) {
+    return {
+      ok: false,
+      errorCode: 'agent_run_invalid',
+      details: {
+        reason: 'run is missing, belongs to another agent, or targets another org',
+        runId,
+      },
+    };
+  }
+  const { run, agent, org, deviceSiteId } = loaded;
+
+  // Reconstruct the agent's own AuthContext — assertRunOwnership inside
+  // re-proves the org/partner lineage. Its canAccessOrg covers exactly the
+  // run org, which is what resolveEffectiveAgent authorizes against.
+  let agentAuth;
+  try {
+    agentAuth = buildAgentAuthContext(
+      {
+        id: agent.id,
+        orgId: agent.orgId,
+        partnerId: agent.partnerId,
+        name: agent.name,
+        kind: agent.kind,
+      },
+      { id: run.id, orgId: run.orgId, deviceId: run.deviceId, deviceSiteId },
+      { id: run.orgId, partnerId: org.partnerId },
+    );
+  } catch (error) {
+    if (error instanceof AgentRunOwnershipError) {
+      return {
+        ok: false,
+        errorCode: 'agent_run_invalid',
+        details: { reason: error.message },
+      };
+    }
+    throw error;
+  }
+
+  // Current effective policy for the run's org + the agent's kind. System
+  // context for the same reason as above; the app-layer authorization is the
+  // agentAuth's canAccessOrg, which resolveEffectiveAgent enforces itself.
+  const resolved = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      resolveEffectiveAgent(agentAuth, intent.orgId, agent.kind),
+    ),
+  );
+  if (!resolved) {
+    return {
+      ok: false,
+      errorCode: 'agent_policy_denied',
+      details: { reason: 'no effective agent' },
+    };
+  }
+  if (resolved.agentId !== run.agentId) {
+    // The baseline row for this org+kind is no longer the run's agent — the
+    // approval no longer describes the identity that would execute.
+    return {
+      ok: false,
+      errorCode: 'agent_identity_changed',
+      details: { runAgentId: run.agentId, resolvedAgentId: resolved.agentId },
+    };
+  }
+
+  const candidates = [
+    { policy: 'snapshot' as const, effective: run.policySnapshot?.effective },
+    { policy: 'current' as const, effective: resolved.effective },
+  ];
+  for (const { policy, effective } of candidates) {
+    // deviceId/deviceSiteId come from the RUN row and the device's CURRENT
+    // site — never from tool input. A malformed snapshot fails
+    // isAgentGuardrailPolicy inside checkAgentGuardrails and denies, which is
+    // the fail-closed shape we want, hence the cast instead of a hand-rolled
+    // validator (same shape as intentService's creation-time check).
+    const verdict = checkAgentGuardrails(
+      intent.actionName,
+      intent.arguments as Record<string, unknown>,
+      {
+        enabled: effective?.enabled,
+        mode: effective?.mode,
+        toolAllowlist: effective?.toolAllowlist,
+        protectedResources: effective?.protectedResources,
+        deviceId: run.deviceId ?? null,
+        deviceSiteId,
+      } as AgentGuardrailPolicy,
+    );
+    if (verdict.disposition === 'deny') {
+      return {
+        ok: false,
+        errorCode: 'agent_policy_denied',
+        details: { policy, reason: verdict.reason ?? 'denied' },
+      };
+    }
+  }
+
+  return { ok: true };
+}

--- a/apps/api/src/services/actionIntents/intentApprovers.deviceTargets.contract.test.ts
+++ b/apps/api/src/services/actionIntents/intentApprovers.deviceTargets.contract.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { aiTools } from '../aiTools';
+import { DEVICE_COMPLETE_TARGET_TOOLS } from './intentApprovers';
+
+/**
+ * Contract (wave 3b, review blocker 1): `DEVICE_COMPLETE_TARGET_TOOLS` is the
+ * hand-verified allowlist of tools whose COMPLETE target surface is expressed
+ * by their registered `deviceArgs`. `resolveIntentTargetScope` derives the
+ * target-site set for a supervised agent intent from those args; every tool
+ * OUTSIDE the set is treated as having indirect targets (deployments, groups,
+ * filters) and fans out to site-UNRESTRICTED approvers only.
+ *
+ * This file runs against the REAL registry (unlike intentApprovers.test.ts,
+ * whose partial db/schema mocks force a stub registry): a listed tool that is
+ * renamed, unregistered, or loses its deviceArgs declaration must fail here —
+ * otherwise the target-scope resolution silently degrades to an empty device
+ * union for that tool.
+ */
+describe('DEVICE_COMPLETE_TARGET_TOOLS contract', () => {
+  it('every listed tool declares deviceArgs in the registry', () => {
+    expect(DEVICE_COMPLETE_TARGET_TOOLS.size).toBeGreaterThan(0);
+    for (const name of DEVICE_COMPLETE_TARGET_TOOLS) {
+      const tool = aiTools.get(name);
+      expect(tool, `"${name}" is listed in DEVICE_COMPLETE_TARGET_TOOLS but not registered in aiTools`).toBeDefined();
+      expect(
+        tool?.deviceArgs?.length ?? 0,
+        `"${name}" is listed in DEVICE_COMPLETE_TARGET_TOOLS but declares no deviceArgs`,
+      ).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/api/src/services/actionIntents/intentApprovers.test.ts
+++ b/apps/api/src/services/actionIntents/intentApprovers.test.ts
@@ -53,7 +53,7 @@ vi.mock('../permissions', async (importOriginal) => {
 });
 
 import { db } from '../../db';
-import { organizationUsers, partnerUsers, users } from '../../db/schema';
+import { devices, organizationUsers, partnerUsers, users } from '../../db/schema';
 import { requiredPermissionsForTool } from '../aiGuardrails';
 import { getUserPermissions, type UserPermissions } from '../permissions';
 import {
@@ -470,6 +470,7 @@ describe('resolveIntentTargetScope', () => {
       'run_script',
       { scriptId: 'script-1', deviceIds: ['dev-1', 'dev-2'] },
       { deviceId: 'dev-3' },
+      'org-1',
     );
     expect(scope.kind).toBe('devices');
     if (scope.kind !== 'devices') throw new Error('unreachable');
@@ -481,6 +482,7 @@ describe('resolveIntentTargetScope', () => {
       'manage_deployments',
       { targetType: 'all' },
       { deviceId: 'dev-1' },
+      'org-1',
     );
     expect(scope).toEqual({ kind: 'indirect' });
     // Fails closed WITHOUT resolving anything from deviceArgs / the run device.
@@ -491,8 +493,35 @@ describe('resolveIntentTargetScope', () => {
     queueDeviceSiteSelect([{ id: 'dev-1', siteId: 'site-1' }]);
 
     await expect(
-      resolveIntentTargetScope('execute_command', { deviceId: 'dev-404' }, { deviceId: 'dev-1' }),
+      resolveIntentTargetScope('execute_command', { deviceId: 'dev-404' }, { deviceId: 'dev-1' }, 'org-1'),
     ).rejects.toThrow(/dev-404/);
+  });
+
+  it('pins the device read to the intent org so a cross-tenant device id fails like a nonexistent one', async () => {
+    // Review finding 1: the system-scoped devices select MUST carry an org
+    // predicate. Without it, an org-A proposal citing an existing org-B
+    // device UUID would (a) silently pull the foreign device's site into the
+    // fan-out scope and (b) act as a cross-tenant device-UUID existence
+    // oracle (existing foreign id → intent created; nonexistent id → throw).
+    // The queued row simulates Postgres filtering the foreign device out via
+    // the org pin: only the in-org device comes back.
+    const { where } = queueDeviceSiteSelect([{ id: 'dev-1', siteId: 'site-1' }]);
+
+    await expect(
+      resolveIntentTargetScope(
+        'execute_command',
+        { deviceId: 'dev-foreign' },
+        { deviceId: 'dev-1' },
+        'org-1',
+      ),
+    ).rejects.toThrow(/dev-foreign/);
+
+    // Structural pin on the WHERE clause itself: ids restricted AND org
+    // pinned — not just the inArray alone.
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(where).toHaveBeenCalledWith(
+      and(inArray(devices.id as never, ['dev-foreign', 'dev-1']), eq(devices.orgId as never, 'org-1')),
+    );
   });
 
   it('fails closed to indirect when no device id can be resolved at all', async () => {
@@ -500,7 +529,7 @@ describe('resolveIntentTargetScope', () => {
     // AND a detached run (device_id NULL after a device move) must not yield
     // {kind:'devices', siteIds: []} — an empty site list would vacuously pass
     // every candidate's site check.
-    const scope = await resolveIntentTargetScope('execute_command', {}, { deviceId: null });
+    const scope = await resolveIntentTargetScope('execute_command', {}, { deviceId: null }, 'org-1');
     expect(scope).toEqual({ kind: 'indirect' });
     expect(db.select).not.toHaveBeenCalled();
   });
@@ -598,6 +627,24 @@ describe('isAgentIntentDecideAuthorized', () => {
     stubPermsByUser({ 'u-a': makePerms() });
 
     await expect(isAgentIntentDecideAuthorized('u-a', intent)).resolves.toBe(false);
+  });
+
+  it('pins the decide-time device read to the INTENT org (cross-tenant cited device fails closed)', async () => {
+    // Review finding 1, decide-time leg: the device-site resolution must be
+    // scoped to intent.orgId, so a cited device that exists in another tenant
+    // is filtered out by the org pin and behaves exactly like a deleted one.
+    queueDecideSelects({
+      run: [{ orgId: 'org-1', deviceId: null }],
+      org: [{ partnerId: 'partner-1' }],
+    });
+    // dev-1 exists — in ANOTHER org, so the org-pinned select returns nothing.
+    const { where } = queueDeviceSiteSelect([]);
+    stubPermsByUser({ 'u-a': makePerms() });
+
+    await expect(isAgentIntentDecideAuthorized('u-a', intent)).resolves.toBe(false);
+    expect(where).toHaveBeenCalledWith(
+      and(inArray(devices.id as never, ['dev-1']), eq(devices.orgId as never, 'org-1')),
+    );
   });
 });
 

--- a/apps/api/src/services/actionIntents/intentApprovers.test.ts
+++ b/apps/api/src/services/actionIntents/intentApprovers.test.ts
@@ -3,6 +3,8 @@ import { and, eq, inArray } from 'drizzle-orm';
 
 vi.mock('../../db', () => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContext: vi.fn(<T,>(fn: () => T): T => fn()),
+  getCurrentDbAccessContext: vi.fn(() => null),
   db: {
     select: vi.fn(),
   },
@@ -15,11 +17,52 @@ vi.mock('../../db/schema', () => ({
   rolePermissions: { roleId: 'role_id', permissionId: 'permission_id' },
   permissions: { id: 'id', resource: 'resource', action: 'action' },
   users: { id: 'id', status: 'status' },
+  roles: { id: 'id' },
+  devices: { id: 'id', siteId: 'site_id', orgId: 'org_id' },
+  aiAgentRuns: { id: 'id', orgId: 'org_id', deviceId: 'device_id', agentId: 'agent_id' },
 }));
+
+// The full tool registry drags in every aiTools* domain module (and their
+// schema imports), which this file's partial schema mock cannot satisfy —
+// mock just the shapes resolveIntentTargetScope reads. The REAL registry is
+// pinned by intentApprovers.deviceTargets.contract.test.ts, which asserts
+// every DEVICE_COMPLETE_TARGET_TOOLS entry declares deviceArgs for real.
+vi.mock('../aiTools', () => ({
+  aiTools: new Map<string, { deviceArgs?: readonly string[] }>([
+    ['execute_command', { deviceArgs: ['deviceId'] }],
+    ['run_script', { deviceArgs: ['deviceIds'] }],
+    ['manage_services', { deviceArgs: ['deviceId'] }],
+    // Registered but NOT in DEVICE_COMPLETE_TARGET_TOOLS — the canonical
+    // indirect-target tool (targetType: all/group/filter, no deviceArgs).
+    ['manage_deployments', {}],
+  ]),
+}));
+
+// aiGuardrails transitively imports the whole tool hub too; only
+// requiredPermissionsForTool is consumed here.
+vi.mock('../aiGuardrails', () => ({
+  requiredPermissionsForTool: vi.fn(),
+}));
+
+// Keep the REAL pure helpers (hasPermission / canAccessOrg / canAccessSite /
+// PERMISSIONS) so eligibility semantics are exercised for real — only the
+// per-user permission resolution is stubbed.
+vi.mock('../permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../permissions')>();
+  return { ...actual, getUserPermissions: vi.fn() };
+});
 
 import { db } from '../../db';
 import { organizationUsers, partnerUsers, users } from '../../db/schema';
-import { resolveIntentApprovers } from './intentApprovers';
+import { requiredPermissionsForTool } from '../aiGuardrails';
+import { getUserPermissions, type UserPermissions } from '../permissions';
+import {
+  DEVICE_COMPLETE_TARGET_TOOLS,
+  isAgentIntentDecideAuthorized,
+  resolveAgentIntentApprovers,
+  resolveIntentApprovers,
+  resolveIntentTargetScope,
+} from './intentApprovers';
 
 /**
  * The resolver issues these selects in order:
@@ -203,5 +246,367 @@ describe('resolveIntentApprovers', () => {
 
     const result = await resolveIntentApprovers('org-1');
     expect(result).toEqual(['u-requester']);
+  });
+});
+
+// ============================================================
+// Wave 3b — agent-intent eligibility (action-and-target, spec §3.4)
+// ============================================================
+
+/** Builder for the permission sets getUserPermissions returns per user. */
+function makePerms(overrides: Partial<UserPermissions> = {}): UserPermissions {
+  return {
+    permissions: [{ resource: 'devices', action: 'execute' }],
+    partnerId: null,
+    orgId: 'org-1',
+    roleId: 'role-x',
+    scope: 'organization',
+    ...overrides,
+  };
+}
+
+function stubPermsByUser(byUser: Record<string, UserPermissions | null>) {
+  vi.mocked(getUserPermissions).mockImplementation(async (userId: string) => byUser[userId] ?? null);
+}
+
+/**
+ * resolveAgentIntentApprovers issues exactly these selects, in order, inside
+ * runOutsideDbContext(() => withSystemDbAccessContext(...)):
+ *   1. org partner:     select().from(organizations).where().limit()
+ *   2. org members:     select().from(organizationUsers).innerJoin(users).where()
+ *   3. partner members: select().from(partnerUsers).innerJoin(users).where()
+ * (3 is skipped when the org has no partner.) NO granting-roles query — the
+ * candidate pool is every active member; RBAC is evaluated per user via
+ * getUserPermissions, not via an approvals:decide role restriction.
+ */
+function queueAgentApproverSelects(opts: {
+  org: Array<{ partnerId: string | null }>;
+  orgMembers: Array<{ userId: string }>;
+  partnerMembers?: Array<{ userId: string; orgAccess: string; orgIds: string[] | null }>;
+}) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(opts.org) }),
+    }),
+  } as any);
+
+  const orgMembersWhere = vi.fn().mockResolvedValue(opts.orgMembers);
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({ where: orgMembersWhere }),
+    }),
+  } as any);
+
+  if (opts.partnerMembers) {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(opts.partnerMembers) }),
+      }),
+    } as any);
+  }
+
+  return { orgMembersWhere };
+}
+
+/** Device-site lookup: select({id, siteId}).from(devices).where(inArray(...)). */
+function queueDeviceSiteSelect(rows: Array<{ id: string; siteId: string }>) {
+  const where = vi.fn().mockResolvedValue(rows);
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({ where }),
+  } as any);
+  return { where };
+}
+
+const DEVICES_EXECUTE = [{ resource: 'devices', action: 'execute' }];
+
+describe('resolveAgentIntentApprovers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    vi.mocked(requiredPermissionsForTool).mockReturnValue(DEVICES_EXECUTE);
+  });
+
+  it('excludes a member missing the action permission', async () => {
+    queueAgentApproverSelects({
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [{ userId: 'u-a' }, { userId: 'u-b' }],
+      partnerMembers: [],
+    });
+    stubPermsByUser({
+      'u-a': makePerms(),
+      'u-b': makePerms({ permissions: [{ resource: 'devices', action: 'read' }] }),
+    });
+
+    const result = await resolveAgentIntentApprovers({
+      orgId: 'org-1',
+      toolName: 'execute_command',
+      input: { deviceId: 'dev-1' },
+      targetScope: { kind: 'devices', siteIds: ['site-1'] },
+    });
+    expect(result).toEqual(['u-a']);
+  });
+
+  it('excludes a member whose allowedSiteIds miss a target site', async () => {
+    queueAgentApproverSelects({
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [{ userId: 'u-a' }, { userId: 'u-b' }],
+      partnerMembers: [],
+    });
+    stubPermsByUser({
+      'u-a': makePerms(),
+      'u-b': makePerms({ allowedSiteIds: ['site-2'] }),
+    });
+
+    const result = await resolveAgentIntentApprovers({
+      orgId: 'org-1',
+      toolName: 'execute_command',
+      input: { deviceId: 'dev-1' },
+      targetScope: { kind: 'devices', siteIds: ['site-1'] },
+    });
+    expect(result).toEqual(['u-a']);
+  });
+
+  it('indirect target scope admits ONLY site-unrestricted members', async () => {
+    queueAgentApproverSelects({
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [{ userId: 'u-a' }, { userId: 'u-b' }],
+      partnerMembers: [],
+    });
+    // u-b's restriction even COVERS the run device's site — irrelevant: an
+    // indirect target (deployment/group/filter) can reach devices anywhere in
+    // the org, so only a site-unrestricted human could lawfully do it themselves.
+    stubPermsByUser({
+      'u-a': makePerms(),
+      'u-b': makePerms({ allowedSiteIds: ['site-1'] }),
+    });
+
+    const result = await resolveAgentIntentApprovers({
+      orgId: 'org-1',
+      toolName: 'manage_deployments',
+      input: { targetType: 'all' },
+      targetScope: { kind: 'indirect' },
+    });
+    expect(result).toEqual(['u-a']);
+  });
+
+  it('includes a partner-only technician (partnerId passed to getUserPermissions)', async () => {
+    queueAgentApproverSelects({
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [],
+      partnerMembers: [
+        { userId: 'u-tech', orgAccess: 'all', orgIds: null },
+        { userId: 'u-tech-elsewhere', orgAccess: 'selected', orgIds: ['org-other'] },
+      ],
+    });
+    stubPermsByUser({
+      'u-tech': makePerms({ scope: 'partner', partnerId: 'partner-1', orgId: null, orgAccess: 'all' }),
+    });
+
+    const result = await resolveAgentIntentApprovers({
+      orgId: 'org-1',
+      toolName: 'execute_command',
+      input: { deviceId: 'dev-1' },
+      targetScope: { kind: 'devices', siteIds: ['site-1'] },
+    });
+    expect(result).toEqual(['u-tech']);
+    // The partner axis is only evaluated when context.partnerId is supplied
+    // (permissions.ts) — omitting it silently discards every partner-only tech.
+    expect(getUserPermissions).toHaveBeenCalledWith('u-tech', { orgId: 'org-1', partnerId: 'partner-1' });
+  });
+
+  it('returns [] when the tool has no RBAC mapping', async () => {
+    vi.mocked(requiredPermissionsForTool).mockReturnValue(null);
+
+    const result = await resolveAgentIntentApprovers({
+      orgId: 'org-1',
+      toolName: 'unmapped_tool',
+      input: {},
+      targetScope: { kind: 'devices', siteIds: ['site-1'] },
+    });
+    expect(result).toEqual([]);
+    // Deny-all short-circuits before any membership lookup.
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('never consults recipients', async () => {
+    // `ai_agents.recipients` is notification-only and must NEVER influence
+    // eligibility. Structural pin: the resolver issues exactly the three
+    // membership selects (org partner, org members, partner members) — no
+    // agent-row read, no recipients module involvement — and the only other
+    // inputs are per-user permission resolutions.
+    queueAgentApproverSelects({
+      org: [{ partnerId: 'partner-1' }],
+      orgMembers: [{ userId: 'u-a' }],
+      partnerMembers: [],
+    });
+    stubPermsByUser({ 'u-a': makePerms() });
+
+    const result = await resolveAgentIntentApprovers({
+      orgId: 'org-1',
+      toolName: 'execute_command',
+      input: { deviceId: 'dev-1' },
+      targetScope: { kind: 'devices', siteIds: ['site-1'] },
+    });
+    expect(result).toEqual(['u-a']);
+    expect(db.select).toHaveBeenCalledTimes(3);
+    expect(getUserPermissions).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('resolveIntentTargetScope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+  });
+
+  it('unions deviceArgs devices with the run device and dedupes sites', async () => {
+    queueDeviceSiteSelect([
+      { id: 'dev-1', siteId: 'site-1' },
+      { id: 'dev-2', siteId: 'site-2' },
+      { id: 'dev-3', siteId: 'site-1' },
+    ]);
+
+    const scope = await resolveIntentTargetScope(
+      'run_script',
+      { scriptId: 'script-1', deviceIds: ['dev-1', 'dev-2'] },
+      { deviceId: 'dev-3' },
+    );
+    expect(scope.kind).toBe('devices');
+    if (scope.kind !== 'devices') throw new Error('unreachable');
+    expect([...scope.siteIds].sort()).toEqual(['site-1', 'site-2']);
+  });
+
+  it('returns indirect for any tool outside DEVICE_COMPLETE_TARGET_TOOLS', async () => {
+    const scope = await resolveIntentTargetScope(
+      'manage_deployments',
+      { targetType: 'all' },
+      { deviceId: 'dev-1' },
+    );
+    expect(scope).toEqual({ kind: 'indirect' });
+    // Fails closed WITHOUT resolving anything from deviceArgs / the run device.
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('throws on an unknown device id', async () => {
+    queueDeviceSiteSelect([{ id: 'dev-1', siteId: 'site-1' }]);
+
+    await expect(
+      resolveIntentTargetScope('execute_command', { deviceId: 'dev-404' }, { deviceId: 'dev-1' }),
+    ).rejects.toThrow(/dev-404/);
+  });
+
+  it('fails closed to indirect when no device id can be resolved at all', async () => {
+    // A DEVICE_COMPLETE_TARGET_TOOLS tool with malformed/absent device args
+    // AND a detached run (device_id NULL after a device move) must not yield
+    // {kind:'devices', siteIds: []} — an empty site list would vacuously pass
+    // every candidate's site check.
+    const scope = await resolveIntentTargetScope('execute_command', {}, { deviceId: null });
+    expect(scope).toEqual({ kind: 'indirect' });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('isAgentIntentDecideAuthorized', () => {
+  const intent = {
+    id: 'intent-1',
+    orgId: 'org-1',
+    actionName: 'execute_command',
+    arguments: { deviceId: 'dev-1' } as Record<string, unknown>,
+    requestingAgentRunId: 'run-1',
+  };
+
+  /**
+   * Select order: 1. run row (select().from(aiAgentRuns).where().limit()),
+   * 2. org partner (select().from(organizations).where().limit()),
+   * 3. device sites (select().from(devices).where()).
+   */
+  function queueDecideSelects(opts: {
+    run: Array<{ orgId: string; deviceId: string | null }>;
+    org?: Array<{ partnerId: string | null }>;
+    deviceSites?: Array<{ id: string; siteId: string }>;
+  }) {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(opts.run) }),
+      }),
+    } as any);
+    if (opts.org) {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(opts.org) }),
+        }),
+      } as any);
+    }
+    if (opts.deviceSites) queueDeviceSiteSelect(opts.deviceSites);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    vi.mocked(requiredPermissionsForTool).mockReturnValue(DEVICES_EXECUTE);
+  });
+
+  it('authorizes a user with the action permission and access to every target site', async () => {
+    queueDecideSelects({
+      run: [{ orgId: 'org-1', deviceId: 'dev-2' }],
+      org: [{ partnerId: 'partner-1' }],
+      deviceSites: [
+        { id: 'dev-1', siteId: 'site-1' },
+        { id: 'dev-2', siteId: 'site-1' },
+      ],
+    });
+    stubPermsByUser({ 'u-a': makePerms({ allowedSiteIds: ['site-1'] }) });
+
+    await expect(isAgentIntentDecideAuthorized('u-a', intent)).resolves.toBe(true);
+  });
+
+  it('denies a user whose site restriction misses a target site', async () => {
+    queueDecideSelects({
+      run: [{ orgId: 'org-1', deviceId: null }],
+      org: [{ partnerId: 'partner-1' }],
+      deviceSites: [{ id: 'dev-1', siteId: 'site-1' }],
+    });
+    stubPermsByUser({ 'u-b': makePerms({ allowedSiteIds: ['site-2'] }) });
+
+    await expect(isAgentIntentDecideAuthorized('u-b', intent)).resolves.toBe(false);
+  });
+
+  it('fails closed when the intent has no requesting run', async () => {
+    await expect(
+      isAgentIntentDecideAuthorized('u-a', { ...intent, requestingAgentRunId: null }),
+    ).resolves.toBe(false);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the run does not exist or belongs to another org', async () => {
+    queueDecideSelects({ run: [], org: [{ partnerId: 'partner-1' }] });
+    await expect(isAgentIntentDecideAuthorized('u-a', intent)).resolves.toBe(false);
+  });
+
+  it('fails closed when the tool has no RBAC mapping', async () => {
+    vi.mocked(requiredPermissionsForTool).mockReturnValue(null);
+    await expect(isAgentIntentDecideAuthorized('u-a', intent)).resolves.toBe(false);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('fails closed (false, not throw) when a cited device no longer exists', async () => {
+    queueDecideSelects({
+      run: [{ orgId: 'org-1', deviceId: null }],
+      org: [{ partnerId: 'partner-1' }],
+      deviceSites: [], // dev-1 has been deleted since the proposal was created
+    });
+    stubPermsByUser({ 'u-a': makePerms() });
+
+    await expect(isAgentIntentDecideAuthorized('u-a', intent)).resolves.toBe(false);
+  });
+});
+
+describe('DEVICE_COMPLETE_TARGET_TOOLS', () => {
+  it('contains exactly the hand-verified mutating device tools', () => {
+    expect([...DEVICE_COMPLETE_TARGET_TOOLS].sort()).toEqual([
+      'execute_command',
+      'manage_services',
+      'run_script',
+    ]);
   });
 });

--- a/apps/api/src/services/actionIntents/intentApprovers.ts
+++ b/apps/api/src/services/actionIntents/intentApprovers.ts
@@ -33,16 +33,27 @@
  */
 
 import { eq, and, inArray } from 'drizzle-orm';
-import { db, withSystemDbAccessContext } from '../../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import {
+  aiAgentRuns,
+  devices,
   organizations,
   organizationUsers,
   partnerUsers,
   rolePermissions,
   permissions,
   users,
+  type ActionIntent,
 } from '../../db/schema';
-import { PERMISSIONS } from '../permissions';
+import { aiTools } from '../aiTools';
+import { requiredPermissionsForTool } from '../aiGuardrails';
+import {
+  PERMISSIONS,
+  canAccessOrg,
+  canAccessSite,
+  getUserPermissions,
+  hasPermission,
+} from '../permissions';
 
 /**
  * Resolve the distinct user ids eligible to decide an action intent for
@@ -129,5 +140,279 @@ export async function resolveIntentApprovers(orgId: string): Promise<string[]> {
     }
 
     return [...candidateUserIds];
+  });
+}
+
+// ============================================================
+// Wave 3b — agent-intent eligibility (action-and-target, spec §3.4)
+// ============================================================
+//
+// A SUPERVISED intent proposed by an ai_agent principal has no requester, so
+// the "requester decides own intent" path can never apply. Eligibility is
+// ACTION-AND-TARGET instead: the humans who could lawfully perform the action
+// on the concrete target themselves — NOT `approvals:decide` holders
+// (four_eyes keeps `resolveIntentApprovers` above, unchanged). The agent must
+// never influence eligibility: `ai_agents.recipients` is notification-only
+// and is deliberately never read here.
+
+/**
+ * Tools whose COMPLETE target set is expressed by their registered
+ * `deviceArgs` (verified by hand against each handler). Anything not listed
+ * is treated as having INDIRECT targets — deployments, groups, filters —
+ * and only site-UNRESTRICTED humans are eligible for it.
+ *
+ * Hand-verification record (2026-08-23), re-check the handler before adding
+ * an entry — `intentApprovers.deviceTargets.contract.test.ts` only proves a
+ * listed tool DECLARES deviceArgs, not that the declaration is complete:
+ * - execute_command  (aiToolsScripts.ts): acts on the single required
+ *   `deviceId`; nothing else in the input reaches another device.
+ * - run_script       (aiToolsScripts.ts): iterates the required `deviceIds`
+ *   array only (first 10); scriptId selects content, not targets.
+ * - manage_services  (aiToolsScripts.ts): single required `deviceId`;
+ *   serviceName is a name on that device, not a target.
+ */
+export const DEVICE_COMPLETE_TARGET_TOOLS: ReadonlySet<string> = new Set([
+  'execute_command',
+  'manage_services',
+  'run_script',
+]);
+
+export type IntentTargetScope =
+  | { kind: 'devices'; siteIds: string[] } // fully resolved via deviceArgs ∪ run.deviceId
+  | { kind: 'indirect' }; // fail closed: unrestricted-site approvers only
+
+/**
+ * Resolve the concrete target scope of a proposed agent intent. For a
+ * DEVICE_COMPLETE_TARGET_TOOLS tool: the distinct site ids of every device
+ * named in the tool's `deviceArgs` inputs, unioned with the run's own device.
+ * Every other tool — and any call where no device id can be resolved at all —
+ * is `{kind:'indirect'}`, which fails closed to site-unrestricted approvers
+ * (review blocker 1: deviceArgs explicitly does not cover indirect or
+ * list-returning targets, and e.g. manage_deployments accepts
+ * targetType all/group/filter with no site check in its handler).
+ *
+ * Throws on an unknown device id: a proposal citing a nonexistent device must
+ * not be fanned out.
+ */
+export async function resolveIntentTargetScope(
+  toolName: string,
+  args: Record<string, unknown>,
+  run: { deviceId: string | null },
+): Promise<IntentTargetScope> {
+  if (!DEVICE_COMPLETE_TARGET_TOOLS.has(toolName)) return { kind: 'indirect' };
+
+  const deviceIds = new Set<string>();
+  const tool = aiTools.get(toolName);
+  for (const argName of tool?.deviceArgs ?? []) {
+    if (!(argName in args)) continue;
+    const value = args[argName];
+    if (typeof value === 'string') {
+      if (value) deviceIds.add(value);
+    } else if (Array.isArray(value) && value.every((entry) => typeof entry === 'string')) {
+      for (const entry of value) if (entry) deviceIds.add(entry as string);
+    }
+    // A present-but-malformed value contributes nothing; if that leaves the
+    // union empty we fall through to the fail-closed indirect branch below.
+  }
+  if (run.deviceId) deviceIds.add(run.deviceId);
+
+  // No resolvable device at all (malformed args + a detached run after a
+  // device move): {kind:'devices', siteIds: []} would vacuously pass every
+  // candidate's site check, so fail closed to the indirect rule instead.
+  if (deviceIds.size === 0) return { kind: 'indirect' };
+
+  const ids = [...deviceIds];
+  // System context: the fan-out runs from creation/decide paths whose ambient
+  // RLS context is the AGENT's org scope (or none); device rows are read by
+  // explicit equality-keyed ids only. The runOutsideDbContext wrapper is
+  // load-bearing — a bare system wrapper inside an ambient request context is
+  // a no-op (db/index.ts).
+  const rows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () =>
+      db
+        .select({ id: devices.id, siteId: devices.siteId })
+        .from(devices)
+        .where(inArray(devices.id, ids)),
+    ),
+  );
+
+  const siteByDevice = new Map(rows.map((row) => [row.id, row.siteId]));
+  for (const id of ids) {
+    if (!siteByDevice.has(id)) {
+      throw new Error(`resolveIntentTargetScope: unknown device "${id}" cited by tool "${toolName}"`);
+    }
+  }
+  return { kind: 'devices', siteIds: [...new Set(rows.map((row) => row.siteId))] };
+}
+
+/**
+ * The per-user action-and-target predicate shared by fan-out (creation) and
+ * decide-time revalidation. `partnerId` MUST be supplied when the org has a
+ * partner: the permission service only evaluates the partner axis when
+ * `context.partnerId` is present (permissions.ts) — omitting it silently
+ * discards every partner-only technician.
+ */
+async function userHasActionAndTargetAuthority(
+  userId: string,
+  opts: {
+    orgId: string;
+    partnerId: string | null;
+    required: Array<{ resource: string; action: string }>;
+    targetScope: IntentTargetScope;
+  },
+): Promise<boolean> {
+  const userPerms = await getUserPermissions(userId, {
+    orgId: opts.orgId,
+    ...(opts.partnerId ? { partnerId: opts.partnerId } : {}),
+  });
+  if (!userPerms) return false;
+  for (const requirement of opts.required) {
+    if (!hasPermission(userPerms, requirement.resource, requirement.action)) return false;
+  }
+  if (!canAccessOrg(userPerms, opts.orgId)) return false;
+  if (opts.targetScope.kind === 'devices') {
+    return opts.targetScope.siteIds.every((siteId) => canAccessSite(userPerms, siteId));
+  }
+  // Indirect targets: only a human with NO site restriction could lawfully
+  // perform an org-wide action themselves.
+  return userPerms.allowedSiteIds === undefined;
+}
+
+/**
+ * Resolve the user ids eligible to decide a SUPERVISED agent-originated
+ * intent: every active member of (or covering) the org who holds the tool's
+ * full RBAC mapping AND can reach the intent's concrete target. Empty array
+ * when the tool has no RBAC mapping (deny-all) or nobody qualifies.
+ *
+ * Per-candidate permission loads are acceptable here: proposal creation is
+ * rare and org member counts are MSP-sized — do not pre-optimise.
+ */
+export async function resolveAgentIntentApprovers(opts: {
+  orgId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  targetScope: IntentTargetScope;
+}): Promise<string[]> {
+  // No RBAC mapping (unknown tool / unknown action / missing action on a
+  // multiplexed tool) ⇒ nobody is eligible. Short-circuits before any
+  // membership lookup.
+  const required = requiredPermissionsForTool(opts.toolName, opts.input);
+  if (required === null) return [];
+
+  // Candidate pool: the same active-member union resolveIntentApprovers
+  // builds, WITHOUT the approvals:decide role restriction — RBAC is evaluated
+  // per user below. System context for the same RLS reasons as above (and the
+  // same runOutsideDbContext caveat); the per-candidate permission loop runs
+  // AFTER the context closes so no pg transaction is held across the
+  // getUserPermissions cache/redis round-trips.
+  const { partnerId, candidateUserIds } = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const [org] = await db
+        .select({ partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(eq(organizations.id, opts.orgId))
+        .limit(1);
+
+      const candidates = new Set<string>();
+
+      const orgMembers = await db
+        .select({ userId: organizationUsers.userId })
+        .from(organizationUsers)
+        .innerJoin(users, eq(users.id, organizationUsers.userId))
+        .where(and(eq(organizationUsers.orgId, opts.orgId), eq(users.status, 'active')));
+      for (const member of orgMembers) candidates.add(member.userId);
+
+      if (org?.partnerId) {
+        const partnerMembers = await db
+          .select({
+            userId: partnerUsers.userId,
+            orgAccess: partnerUsers.orgAccess,
+            orgIds: partnerUsers.orgIds,
+          })
+          .from(partnerUsers)
+          .innerJoin(users, eq(users.id, partnerUsers.userId))
+          .where(and(eq(partnerUsers.partnerId, org.partnerId), eq(users.status, 'active')));
+        for (const member of partnerMembers) {
+          if (member.orgAccess === 'all') {
+            candidates.add(member.userId);
+          } else if (member.orgAccess === 'selected' && member.orgIds?.includes(opts.orgId)) {
+            candidates.add(member.userId);
+          }
+        }
+      }
+
+      return { partnerId: org?.partnerId ?? null, candidateUserIds: candidates };
+    }),
+  );
+
+  const eligible: string[] = [];
+  for (const userId of candidateUserIds) {
+    if (
+      await userHasActionAndTargetAuthority(userId, {
+        orgId: opts.orgId,
+        partnerId,
+        required,
+        targetScope: opts.targetScope,
+      })
+    ) {
+      eligible.push(userId);
+    }
+  }
+  return eligible;
+}
+
+/**
+ * Live decide-time revalidation for a supervised agent intent (Task 6):
+ * recomputes the target scope from the intent's STORED actionName/arguments
+ * plus its run (loaded system-scoped via requestingAgentRunId), then applies
+ * the same per-user action-and-target predicate as the creation fan-out —
+ * exactly like four_eyes re-checks decide authority at decision time.
+ * Every failure mode returns false (fail closed), including a cited device
+ * that no longer exists.
+ */
+export async function isAgentIntentDecideAuthorized(
+  userId: string,
+  intent: Pick<ActionIntent, 'id' | 'orgId' | 'actionName' | 'arguments' | 'requestingAgentRunId'>,
+): Promise<boolean> {
+  const runId = intent.requestingAgentRunId;
+  if (!runId) return false;
+
+  const required = requiredPermissionsForTool(intent.actionName, intent.arguments ?? {});
+  if (required === null) return false;
+
+  const { run, partnerId } = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const [runRow] = await db
+        .select({ orgId: aiAgentRuns.orgId, deviceId: aiAgentRuns.deviceId })
+        .from(aiAgentRuns)
+        .where(eq(aiAgentRuns.id, runId))
+        .limit(1);
+      const [org] = await db
+        .select({ partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(eq(organizations.id, intent.orgId))
+        .limit(1);
+      return { run: runRow ?? null, partnerId: org?.partnerId ?? null };
+    }),
+  );
+  // Belt-and-braces: the composite FK already pins the run to the intent org.
+  if (!run || run.orgId !== intent.orgId) return false;
+
+  let targetScope: IntentTargetScope;
+  try {
+    targetScope = await resolveIntentTargetScope(intent.actionName, intent.arguments ?? {}, {
+      deviceId: run.deviceId,
+    });
+  } catch {
+    // A cited device that has since been deleted: the target can no longer be
+    // verified, so nobody is decide-authorized.
+    return false;
+  }
+
+  return userHasActionAndTargetAuthority(userId, {
+    orgId: intent.orgId,
+    partnerId,
+    required,
+    targetScope,
   });
 }

--- a/apps/api/src/services/actionIntents/intentApprovers.ts
+++ b/apps/api/src/services/actionIntents/intentApprovers.ts
@@ -192,12 +192,18 @@ export type IntentTargetScope =
  * targetType all/group/filter with no site check in its handler).
  *
  * Throws on an unknown device id: a proposal citing a nonexistent device must
- * not be fanned out.
+ * not be fanned out. The device read is pinned to `orgId` (the intent's org),
+ * so a cross-tenant device id is indistinguishable from a nonexistent one and
+ * hits the same throw — tool args are LLM/runner-produced, and silently
+ * accepting a foreign device's site into the scope would both violate the
+ * fail-closed fan-out contract and act as a cross-tenant device-UUID
+ * existence oracle (review finding 1).
  */
 export async function resolveIntentTargetScope(
   toolName: string,
   args: Record<string, unknown>,
   run: { deviceId: string | null },
+  orgId: string,
 ): Promise<IntentTargetScope> {
   if (!DEVICE_COMPLETE_TARGET_TOOLS.has(toolName)) return { kind: 'indirect' };
 
@@ -232,7 +238,9 @@ export async function resolveIntentTargetScope(
       db
         .select({ id: devices.id, siteId: devices.siteId })
         .from(devices)
-        .where(inArray(devices.id, ids)),
+        // Org pin is load-bearing (review finding 1): without it the
+        // system-scoped read resolves devices from ANY tenant.
+        .where(and(inArray(devices.id, ids), eq(devices.orgId, orgId))),
     ),
   );
 
@@ -400,12 +408,16 @@ export async function isAgentIntentDecideAuthorized(
 
   let targetScope: IntentTargetScope;
   try {
-    targetScope = await resolveIntentTargetScope(intent.actionName, intent.arguments ?? {}, {
-      deviceId: run.deviceId,
-    });
+    targetScope = await resolveIntentTargetScope(
+      intent.actionName,
+      intent.arguments ?? {},
+      { deviceId: run.deviceId },
+      intent.orgId,
+    );
   } catch {
-    // A cited device that has since been deleted: the target can no longer be
-    // verified, so nobody is decide-authorized.
+    // A cited device that has since been deleted (or that never belonged to
+    // the intent's org): the target can no longer be verified, so nobody is
+    // decide-authorized.
     return false;
   }
 

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -1695,6 +1695,40 @@ describe('cancelActionIntent', () => {
     expect(result).toEqual({ ok: true, status: 'cancelled' });
   });
 
+  it('lets an approvals:decide holder cancel an agent-originated intent', async () => {
+    // Owner decision 2026-08-23 (wave 3b): an agent intent has NO requester,
+    // so "requester or approver" deliberately collapses to "any
+    // approvals:decide holder in the org" — a human can dismiss an agent
+    // proposal without approving it.
+    dbState.selectActionIntentsResults.push([
+      makeIntentRow({
+        id: 'intent-1',
+        requestedByUserId: null,
+        source: 'ai_agent',
+        requestingAgentRunId: RUN_ID,
+        approvalScope: 'supervised',
+      }),
+    ]);
+    permState.getUserPermissions.mockResolvedValue({ canDecide: true });
+    dbState.updateActionIntentsResults.push([{ id: 'intent-1' }]);
+    const result = await cancelActionIntent(makeAuth(), 'intent-1');
+    expect(result).toEqual({ ok: true, status: 'cancelled' });
+  });
+
+  it('denies cancel to a user with neither requester identity nor approvals:decide', async () => {
+    dbState.selectActionIntentsResults.push([
+      makeIntentRow({
+        id: 'intent-1',
+        requestedByUserId: null,
+        source: 'ai_agent',
+        requestingAgentRunId: RUN_ID,
+        approvalScope: 'supervised',
+      }),
+    ]);
+    permState.getUserPermissions.mockResolvedValue(null);
+    await expect(cancelActionIntent(makeAuth(), 'intent-1')).rejects.toBeInstanceOf(ActionIntentAuthorizationError);
+  });
+
   it('reports the lost race with the current status when the CAS affects zero rows', async () => {
     dbState.selectActionIntentsResults.push([makeIntentRow({ id: 'intent-1', requestedByUserId: REQUESTER_ID })]);
     dbState.updateActionIntentsResults.push([]); // CAS lost

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -670,6 +670,9 @@ describe('createActionIntent — ai_agent branch (wave 3b)', () => {
       'manage_services',
       expect.objectContaining({ action: 'restart' }),
       expect.objectContaining({ deviceId: DEVICE_ID }),
+      // The intent org MUST be threaded through so the device resolution is
+      // org-pinned (review finding 1).
+      ORG_ID,
     );
     expect(intentApproversState.resolveAgentIntentApprovers).toHaveBeenCalledWith({
       orgId: ORG_ID,
@@ -761,6 +764,7 @@ describe('createActionIntent — ai_agent branch (wave 3b)', () => {
       makeIntentRow({
         id: 'same-run-intent',
         source: 'ai_agent',
+        actionName: 'manage_services',
         requestedByUserId: null,
         requestingAgentRunId: RUN_ID,
         argumentDigest: computeArgumentDigest(canonicalizeArguments(agentInput().input)),
@@ -777,6 +781,33 @@ describe('createActionIntent — ai_agent branch (wave 3b)', () => {
     expect(snap.requesterApprovalRequestId).toBeNull();
     expect(dbState.insertedApprovalRequestsValues).toHaveLength(0);
     expect(metricsMock.recordActionIntentEvent).not.toHaveBeenCalled();
+  });
+
+  it('a replay hit for a DIFFERENT tool under the same explicit key throws idempotency_conflict', async () => {
+    // Review finding 2: the replay check must bind the key to the action
+    // name. With an explicit caller-supplied key, two different tools can
+    // collide with byte-identical canonical arguments (the default key embeds
+    // actionName, an explicit one need not) — same source, same run, same
+    // digest, different tool. Treating tool B as a replay of tool A would
+    // silently drop proposal B: no second intent, no fan-out, no error.
+    supervisedGuardrail();
+    queueAgentContext();
+    dbState.insertActionIntentsResults.push([]);
+    dbState.selectActionIntentsResults.push([
+      makeIntentRow({
+        id: 'other-tool-intent',
+        source: 'ai_agent',
+        actionName: 'execute_command', // ≠ agentInput().toolName ('manage_services')
+        requestedByUserId: null,
+        requestingAgentRunId: RUN_ID,
+        argumentDigest: computeArgumentDigest(canonicalizeArguments(agentInput().input)),
+      }),
+    ]);
+
+    await expect(
+      createActionIntent(makeAgentAuth(), agentInput({ idempotencyKey: 'shared-key' })),
+    ).rejects.toMatchObject({ code: 'idempotency_conflict' });
+    expect(dbState.insertedApprovalRequestsValues).toHaveLength(0);
   });
 
   it('audits agent creation as ai_agent with run details', async () => {

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -28,9 +28,20 @@ const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushS
   // requesterApprovalRequestId assertion below passes vacuously.
   const approvalRequestsTbl = { id: col('id'), intentId: col('intent_id'), userId: col('user_id') };
   const intentOutboxTbl = { id: col('id'), intentId: col('intent_id') };
+  // Agent-branch (wave 3b) tables: loaded system-scoped inside
+  // createActionIntent to verify the run and rebuild the guardrail policy.
+  const aiAgentRunsTbl = {
+    id: col('id'),
+    agentId: col('agent_id'),
+    orgId: col('org_id'),
+    deviceId: col('device_id'),
+    policySnapshot: col('policy_snapshot'),
+  };
+  const aiAgentsTbl = { id: col('id'), name: col('name') };
+  const devicesTbl = { id: col('id'), siteId: col('site_id') };
 
   return {
-    schema: { actionIntentsTbl, approvalRequestsTbl, intentOutboxTbl },
+    schema: { actionIntentsTbl, approvalRequestsTbl, intentOutboxTbl, aiAgentRunsTbl, aiAgentsTbl, devicesTbl },
     dbState: {
       // Most entries are a plain queued row array (existing convention). A
       // few new scope/deadline tests instead queue a FUNCTION that receives
@@ -48,6 +59,9 @@ const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushS
       insertedOutboxValues: [] as Record<string, unknown>[],
       updateActionIntentsSets: [] as Record<string, unknown>[],
       updateActionIntentsWheres: [] as unknown[],
+      selectAgentRunsResults: [] as unknown[][],
+      selectAgentsResults: [] as unknown[][],
+      selectDevicesResults: [] as unknown[][],
     },
     authMock: { dbAccessContextFromAuth: vi.fn((auth: { scope: string; orgId: string | null; accessibleOrgIds: string[] | null; user: { id: string } }) => ({
       scope: auth.scope,
@@ -55,7 +69,7 @@ const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushS
       accessibleOrgIds: auth.accessibleOrgIds,
       userId: auth.user.id,
     })) },
-    guardrailMock: { checkGuardrails: vi.fn() },
+    guardrailMock: { checkGuardrails: vi.fn(), checkAgentGuardrails: vi.fn() },
     aiToolsState: {
       tools: new Map<string, { definition: { description?: string } }>(),
       resolveWritableToolOrgId: vi.fn(),
@@ -76,7 +90,11 @@ const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushS
     // (org + partner axis) instead of an organization_users select + N
     // getUserPermissions round-trips, so it's mocked wholesale here rather
     // than reconstructed from db-table mocks.
-    intentApproversState: { resolveIntentApprovers: vi.fn(async () => [] as string[]) },
+    intentApproversState: {
+      resolveIntentApprovers: vi.fn(async () => [] as string[]),
+      resolveAgentIntentApprovers: vi.fn(async () => [] as string[]),
+      resolveIntentTargetScope: vi.fn(async () => ({ kind: 'indirect' }) as unknown),
+    },
     // Task 7 (effect-digest pinning): effectDigest.ts has its own dedicated
     // unit suite (effectDigest.test.ts) covering the resolver map itself —
     // mocked wholesale here so this file stays a test of createActionIntent's
@@ -137,6 +155,15 @@ vi.mock('../../db', () => ({
           if (table === schema.approvalRequestsTbl) {
             return resultBox(() => dbState.selectApprovalRequestsResults.shift() ?? []);
           }
+          if (table === schema.aiAgentRunsTbl) {
+            return resultBox(() => dbState.selectAgentRunsResults.shift() ?? []);
+          }
+          if (table === schema.aiAgentsTbl) {
+            return resultBox(() => dbState.selectAgentsResults.shift() ?? []);
+          }
+          if (table === schema.devicesTbl) {
+            return resultBox(() => dbState.selectDevicesResults.shift() ?? []);
+          }
           throw new Error('unexpected select table in mock');
         }),
       })),
@@ -172,6 +199,8 @@ vi.mock('../../db/schema/approvals', () => ({
 
 vi.mock('./intentApprovers', () => ({
   resolveIntentApprovers: intentApproversState.resolveIntentApprovers,
+  resolveAgentIntentApprovers: intentApproversState.resolveAgentIntentApprovers,
+  resolveIntentTargetScope: intentApproversState.resolveIntentTargetScope,
 }));
 
 vi.mock('../../middleware/auth', () => ({
@@ -185,6 +214,16 @@ vi.mock('../aiTools', () => ({
 
 vi.mock('../aiGuardrails', () => ({
   checkGuardrails: guardrailMock.checkGuardrails,
+  checkAgentGuardrails: guardrailMock.checkAgentGuardrails,
+}));
+
+vi.mock('../../db/schema/aiAgents', () => ({
+  aiAgents: schema.aiAgentsTbl,
+  aiAgentRuns: schema.aiAgentRunsTbl,
+}));
+
+vi.mock('../../db/schema/devices', () => ({
+  devices: schema.devicesTbl,
 }));
 
 vi.mock('../permissions', () => ({
@@ -254,6 +293,11 @@ const REQUESTER_ID = '22222222-2222-4222-8222-222222222222';
 const APPROVER_1 = '33333333-3333-4333-8333-333333333333';
 const APPROVER_2 = '44444444-4444-4444-8444-444444444444';
 const PARTNER_ID = '55555555-5555-4555-8555-555555555555';
+const AGENT_ID = '66666666-6666-4666-8666-666666666666';
+const RUN_ID = '77777777-7777-4777-8777-777777777777';
+const RUN_ID_2 = '88888888-8888-4888-8888-888888888888';
+const DEVICE_ID = '99999999-9999-4999-8999-999999999999';
+const SITE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 
 function makeAuth(overrides?: { partnerId?: string | null; principal?: unknown }) {
   return {
@@ -286,6 +330,9 @@ function resetDbState() {
   dbState.insertedOutboxValues.length = 0;
   dbState.updateActionIntentsSets.length = 0;
   dbState.updateActionIntentsWheres.length = 0;
+  dbState.selectAgentRunsResults.length = 0;
+  dbState.selectAgentsResults.length = 0;
+  dbState.selectDevicesResults.length = 0;
 }
 
 function makeIntentRow(overrides?: Record<string, unknown>) {
@@ -349,6 +396,70 @@ function msUntil(date: Date): number {
   return date.getTime() - Date.now();
 }
 
+// ---------------------------------------------------------------------------
+// ai_agent branch fixtures (wave 3b)
+// ---------------------------------------------------------------------------
+
+function makeAgentAuth(runId: string = RUN_ID) {
+  return {
+    principal: { kind: 'ai_agent', agentId: AGENT_ID, runId },
+    // Attribution-only synthetic user (buildAgentAuthContext): id is the
+    // AGENT id — the requester-less write path must never stamp it into
+    // requestedByUserId nor derive the default idempotency key from it.
+    user: { id: AGENT_ID, email: `agent+${AGENT_ID}@breeze.internal`, name: 'Patch agent' },
+    orgId: ORG_ID,
+    partnerId: PARTNER_ID,
+    scope: 'organization' as const,
+    accessibleOrgIds: [ORG_ID],
+  } as unknown as Parameters<typeof createActionIntent>[0];
+}
+
+function agentInput(overrides?: Partial<CreateActionIntentInput>): CreateActionIntentInput {
+  return {
+    toolName: 'manage_services',
+    input: { deviceId: DEVICE_ID, action: 'restart', serviceName: 'spooler' },
+    source: 'ai_agent',
+    ...overrides,
+  };
+}
+
+function makeRunRow(overrides?: Record<string, unknown>) {
+  return {
+    id: RUN_ID,
+    agentId: AGENT_ID,
+    orgId: ORG_ID,
+    deviceId: DEVICE_ID,
+    policySnapshot: {
+      schemaVersion: 1,
+      agentId: AGENT_ID,
+      kind: 'patch',
+      effective: {
+        enabled: true,
+        mode: 'shadow',
+        toolAllowlist: ['manage_services'],
+        protectedResources: { services: [], paths: [], registryKeys: [], deviceTags: [] },
+      },
+      provenance: {},
+      resolvedAt: new Date().toISOString(),
+    },
+    ...overrides,
+  };
+}
+
+function makeAgentRow(overrides?: Record<string, unknown>) {
+  return { id: AGENT_ID, orgId: ORG_ID, partnerId: null, name: 'Patch agent', kind: 'patch', ...overrides };
+}
+
+/** Queues the run → agent → device system-context loads the agent branch performs. */
+function queueAgentContext(opts?: { run?: Record<string, unknown>; agent?: Record<string, unknown> }) {
+  const run = makeRunRow(opts?.run);
+  dbState.selectAgentRunsResults.push([run]);
+  dbState.selectAgentsResults.push([makeAgentRow(opts?.agent)]);
+  if (run.deviceId) {
+    dbState.selectDevicesResults.push([{ id: run.deviceId, siteId: SITE_ID }]);
+  }
+}
+
 beforeEach(() => {
   resetDbState();
   vi.clearAllMocks();
@@ -360,6 +471,18 @@ beforeEach(() => {
     requiresApproval: true,
     description: 'Run a script on one or more devices',
   });
+  // Agent-branch defaults: 'propose' (the shadow-mode verdict createActionIntent
+  // accepts); deny is opted into per test. Target scope resolves to the run
+  // device's site; eligibility resolves to nobody unless a test opts in.
+  guardrailMock.checkAgentGuardrails.mockReturnValue({
+    tier: 3,
+    allowed: false,
+    requiresApproval: false,
+    disposition: 'propose',
+    description: 'Manage services on a device',
+  });
+  intentApproversState.resolveAgentIntentApprovers.mockResolvedValue([]);
+  intentApproversState.resolveIntentTargetScope.mockResolvedValue({ kind: 'devices', siteIds: [SITE_ID] });
   permState.getUserPermissions.mockResolvedValue(null);
   permState.userCanDecideApprovals.mockImplementation((perms: { canDecide?: boolean } | null) => !!perms?.canDecide);
   pushState.getUserPushTokens.mockResolvedValue([]);
@@ -403,29 +526,302 @@ describe('createActionIntent — tier gating', () => {
 // Digest stability
 // ---------------------------------------------------------------------------
 
-describe('createActionIntent — ai_agent principal fails closed (wave 3a inert guard)', () => {
-  // This one `if` is the entire reason PR 3a is safe to merge: the schema can
-  // now HOLD a requester-less agent intent, and the type-level exclusion in
-  // originPrincipal.test.ts was inverted to admit 'ai_agent' — so nothing but
-  // this guard keeps an agent principal out of a write path that stamps
-  // requestedByUserId unconditionally. If 3b's rebase drops or reorders it,
-  // this test is what goes red.
-  it('rejects with agent_origin_unsupported before touching the database', async () => {
-    const agentAuth = makeAuth({
-      principal: { kind: 'ai_agent', agentId: 'agent-1', runId: 'run-1' },
-    });
+describe('createActionIntent — ai_agent branch (wave 3b)', () => {
+  // Wave 3a's inert guard (agent_origin_unsupported) is gone: an ai_agent
+  // principal now takes the requester-less branch. What replaces the guard is
+  // the mutual source/principal pairing below plus in-service re-verification
+  // of the run and its guardrail verdict — the caller is never trusted.
 
-    let caught: unknown;
-    try {
-      await createActionIntent(agentAuth, baseInput());
-    } catch (err) {
-      caught = err;
-    }
-    expect(caught).toBeInstanceOf(ActionIntentError);
-    expect((caught as ActionIntentError).code).toBe('agent_origin_unsupported');
-    // Fails closed BEFORE any write: no intent row, no approval fan-out.
+  function supervisedGuardrail() {
+    guardrailMock.checkGuardrails.mockReturnValue({
+      tier: 3,
+      allowed: true,
+      requiresApproval: true,
+      description: 'Manage services on a device',
+      approvalScope: 'supervised',
+    });
+  }
+
+  it('creates a requester-less intent for an ai_agent principal', async () => {
+    supervisedGuardrail();
+    queueAgentContext();
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValueOnce([APPROVER_1]);
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-agent' }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-agent-1' }]);
+
+    const snap = await createActionIntent(makeAgentAuth(), agentInput());
+
+    const inserted = dbState.insertedActionIntentValues[0]!;
+    expect(inserted.requestedByUserId).toBeNull();
+    expect(inserted.requestingAgentRunId).toBe(RUN_ID);
+    expect(inserted.originPrincipalKind).toBe('ai_agent');
+    expect(inserted.originPrincipalId).toBe(AGENT_ID);
+    expect(inserted.source).toBe('ai_agent');
+    // No requestingClientLabel in the input → the agent's display name.
+    expect(inserted.requestingClientLabel).toBe('Patch agent');
+    expect(snap.status).toBe('pending_approval');
+    // There is no requester, so there is never a requester-owned row.
+    expect(snap.requesterApprovalRequestId).toBeNull();
+  });
+
+  it('re-verifies the guardrail verdict in-service from the run snapshot (device pins from the RUN row)', async () => {
+    supervisedGuardrail();
+    queueAgentContext();
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValueOnce([APPROVER_1]);
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-agent-verify' }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-agent-verify' }]);
+
+    await createActionIntent(makeAgentAuth(), agentInput());
+
+    expect(guardrailMock.checkAgentGuardrails).toHaveBeenCalledWith(
+      'manage_services',
+      expect.objectContaining({ action: 'restart' }),
+      expect.objectContaining({
+        enabled: true,
+        mode: 'shadow',
+        toolAllowlist: ['manage_services'],
+        // Task 3 contract: deviceId/deviceSiteId come from the RUN row, never
+        // from tool input; an absent deviceId fails validation and denies.
+        deviceId: DEVICE_ID,
+        deviceSiteId: SITE_ID,
+      }),
+    );
+  });
+
+  it('rejects an ai_agent principal whose source is not ai_agent', async () => {
+    await expect(
+      createActionIntent(makeAgentAuth(), agentInput({ source: 'chat' })),
+    ).rejects.toMatchObject({ code: 'agent_source_mismatch' });
     expect(dbState.insertedActionIntentValues).toHaveLength(0);
+  });
+
+  it('rejects a human principal claiming source ai_agent', async () => {
+    await expect(
+      createActionIntent(makeAuth(), baseInput({ source: 'ai_agent' })),
+    ).rejects.toMatchObject({ code: 'agent_source_mismatch' });
+    expect(dbState.insertedActionIntentValues).toHaveLength(0);
+  });
+
+  it('rejects when the run does not belong to the principal', async () => {
+    supervisedGuardrail();
+    dbState.selectAgentRunsResults.push([
+      makeRunRow({ agentId: '00000000-0000-4000-8000-00000000dead' }),
+    ]);
+    await expect(createActionIntent(makeAgentAuth(), agentInput())).rejects.toMatchObject({
+      code: 'agent_run_invalid',
+    });
+    expect(dbState.insertedActionIntentValues).toHaveLength(0);
+  });
+
+  it('rejects a missing run and a cross-org run alike', async () => {
+    supervisedGuardrail();
+    dbState.selectAgentRunsResults.push([]);
+    await expect(createActionIntent(makeAgentAuth(), agentInput())).rejects.toMatchObject({
+      code: 'agent_run_invalid',
+    });
+    dbState.selectAgentRunsResults.push([
+      makeRunRow({ orgId: '00000000-0000-4000-8000-0000000000bb' }),
+    ]);
+    await expect(createActionIntent(makeAgentAuth(), agentInput())).rejects.toMatchObject({
+      code: 'agent_run_invalid',
+    });
+    expect(dbState.insertedActionIntentValues).toHaveLength(0);
+  });
+
+  it('rejects when the guardrail verdict is deny', async () => {
+    supervisedGuardrail();
+    queueAgentContext();
+    guardrailMock.checkAgentGuardrails.mockReturnValue({
+      tier: 3,
+      allowed: false,
+      requiresApproval: false,
+      disposition: 'deny',
+      reason: 'Tool "manage_services" is not in the agent allowlist',
+    });
+    await expect(createActionIntent(makeAgentAuth(), agentInput())).rejects.toMatchObject({
+      code: 'agent_policy_denied',
+    });
+    expect(dbState.insertedActionIntentValues).toHaveLength(0);
+  });
+
+  it('gives ai_agent intents the explicit 24h agent expiry', async () => {
+    supervisedGuardrail();
+    queueAgentContext();
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValueOnce([APPROVER_1]);
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-agent-expiry' }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-agent-expiry' }]);
+
+    const snap = await createActionIntent(makeAgentAuth(), agentInput());
+
+    expect(msUntil(snap.expiresAt)).toBeCloseTo(24 * 60 * 60 * 1000, -4);
+    expect(msUntil(snap.approvalExpiresAt!)).toBeCloseTo(24 * 60 * 60 * 1000, -4);
+  });
+
+  it('fans a supervised agent intent out to action-and-target-eligible humans', async () => {
+    supervisedGuardrail();
+    queueAgentContext();
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValueOnce([APPROVER_1, APPROVER_2]);
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-agent-fanout' }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-af-1' }, { id: 'approval-af-2' }]);
+
+    const snap = await createActionIntent(makeAgentAuth(), agentInput());
+
+    expect(intentApproversState.resolveIntentTargetScope).toHaveBeenCalledWith(
+      'manage_services',
+      expect.objectContaining({ action: 'restart' }),
+      expect.objectContaining({ deviceId: DEVICE_ID }),
+    );
+    expect(intentApproversState.resolveAgentIntentApprovers).toHaveBeenCalledWith({
+      orgId: ORG_ID,
+      toolName: 'manage_services',
+      input: expect.objectContaining({ action: 'restart' }),
+      targetScope: { kind: 'devices', siteIds: [SITE_ID] },
+    });
+    const inserted = dbState.insertedApprovalRequestsValues[0] as Array<{ userId: string }>;
+    expect(inserted.map((r) => r.userId)).toEqual([APPROVER_1, APPROVER_2]);
+    expect(snap.fanOutUserIds).toEqual([APPROVER_1, APPROVER_2]);
+    expect(snap.requesterApprovalRequestId).toBeNull();
+  });
+
+  it('cancels no_eligible_approvers when nobody is eligible', async () => {
+    supervisedGuardrail();
+    queueAgentContext();
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValueOnce([]);
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-agent-none' }));
+    dbState.updateActionIntentsResults.push([
+      makeIntentRow({
+        id: 'intent-agent-none',
+        source: 'ai_agent',
+        status: 'cancelled',
+        errorCode: 'no_eligible_approvers',
+      }),
+    ]);
+
+    const snap = await createActionIntent(makeAgentAuth(), agentInput());
+
+    expect(snap.status).toBe('cancelled');
+    expect(snap.errorCode).toBe('no_eligible_approvers');
     expect(dbState.insertedApprovalRequestsValues).toHaveLength(0);
+    // A cancelled agent intent notifies nobody, widened gate or not.
+    expect(notifyState.createNotification).not.toHaveBeenCalled();
+    expect(pushState.dispatchApprovalPushToTokens).not.toHaveBeenCalled();
+  });
+
+  it('two runs of the same agent with identical args get DISTINCT intents (run-scoped idempotency key)', async () => {
+    supervisedGuardrail();
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValue([APPROVER_1]);
+
+    queueAgentContext();
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-run-a' }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-run-a' }]);
+    await createActionIntent(makeAgentAuth(RUN_ID), agentInput());
+
+    queueAgentContext({ run: { id: RUN_ID_2 } });
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-run-b' }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-run-b' }]);
+    await createActionIntent(makeAgentAuth(RUN_ID_2), agentInput());
+
+    const [first, second] = dbState.insertedActionIntentValues;
+    expect(first!.idempotencyKey).toBeTruthy();
+    expect(second!.idempotencyKey).toBeTruthy();
+    expect(first!.idempotencyKey).not.toBe(second!.idempotencyKey);
+    expect(first!.requestingAgentRunId).toBe(RUN_ID);
+    expect(second!.requestingAgentRunId).toBe(RUN_ID_2);
+  });
+
+  it('a replay hit that mismatches source/run/digest throws idempotency_conflict', async () => {
+    supervisedGuardrail();
+    queueAgentContext();
+    // Conflict on (org_id, idempotency_key)…
+    dbState.insertActionIntentsResults.push([]);
+    // …but the live row belongs to ANOTHER run (identical args, so the digest
+    // matches — only the run attribution differs). Returning it would hand
+    // run A an intent immutably attributed to run B, whose policy snapshot
+    // the release path would then evaluate.
+    dbState.selectActionIntentsResults.push([
+      makeIntentRow({
+        id: 'foreign-run-intent',
+        source: 'ai_agent',
+        requestedByUserId: null,
+        requestingAgentRunId: RUN_ID_2,
+        argumentDigest: computeArgumentDigest(canonicalizeArguments(agentInput().input)),
+      }),
+    ]);
+
+    await expect(
+      createActionIntent(makeAgentAuth(), agentInput({ idempotencyKey: 'collide-key' })),
+    ).rejects.toMatchObject({ code: 'idempotency_conflict' });
+  });
+
+  it('a replay hit matching source/run/digest converges on the existing intent', async () => {
+    supervisedGuardrail();
+    queueAgentContext();
+    dbState.insertActionIntentsResults.push([]);
+    dbState.selectActionIntentsResults.push([
+      makeIntentRow({
+        id: 'same-run-intent',
+        source: 'ai_agent',
+        requestedByUserId: null,
+        requestingAgentRunId: RUN_ID,
+        argumentDigest: computeArgumentDigest(canonicalizeArguments(agentInput().input)),
+      }),
+    ]);
+    dbState.selectApprovalRequestsResults.push([{ id: 'approval-existing', userId: APPROVER_1 }]);
+
+    const snap = await createActionIntent(
+      makeAgentAuth(),
+      agentInput({ idempotencyKey: 'replay-key' }),
+    );
+
+    expect(snap.id).toBe('same-run-intent');
+    expect(snap.requesterApprovalRequestId).toBeNull();
+    expect(dbState.insertedApprovalRequestsValues).toHaveLength(0);
+    expect(metricsMock.recordActionIntentEvent).not.toHaveBeenCalled();
+  });
+
+  it('audits agent creation as ai_agent with run details', async () => {
+    supervisedGuardrail();
+    queueAgentContext();
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValueOnce([APPROVER_1]);
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-agent-audit' }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-agent-audit' }]);
+
+    await createActionIntent(makeAgentAuth(), agentInput());
+
+    expect(metricsMock.recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: 'created',
+        actorType: 'ai_agent',
+        details: expect.objectContaining({ agentId: AGENT_ID, agentRunId: RUN_ID }),
+      }),
+    );
+    const createdCall = metricsMock.recordActionIntentEvent.mock.calls.find(
+      (call) => (call[0] as { outcome: string }).outcome === 'created',
+    )![0] as { actorId?: string };
+    expect(createdCall.actorId).toBeUndefined();
+  });
+
+  it('notifies supervised agent-intent approvers (gate widened past four_eyes)', async () => {
+    supervisedGuardrail();
+    queueAgentContext();
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValueOnce([APPROVER_1]);
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-agent-notify' }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-agent-notify' }]);
+
+    await createActionIntent(makeAgentAuth(), agentInput());
+
+    expect(notifyState.createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: APPROVER_1,
+        type: 'approval',
+        link: '/approvals',
+        message: expect.stringContaining('Patch agent'),
+        dedupeKey: 'intent-approval:intent-agent-notify',
+      }),
+    );
+    // Push is attempted for agent approvers too (headless: nobody is watching
+    // a chat pane that would surface the proposal).
+    expect(pushState.dispatchApprovalPushToTokens).toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -14,14 +14,26 @@ import {
   type ActionIntentStatus,
 } from '../../db/schema/actionIntents';
 import { approvalRequests } from '../../db/schema/approvals';
+import { aiAgentRuns, aiAgents } from '../../db/schema/aiAgents';
+import { devices } from '../../db/schema/devices';
 import { type AuthContext, dbAccessContextFromAuth } from '../../middleware/auth';
 import { aiTools, resolveWritableToolOrgId } from '../aiTools';
-import { checkGuardrails, type GuardrailCheck } from '../aiGuardrails';
+import {
+  checkAgentGuardrails,
+  checkGuardrails,
+  type AgentGuardrailPolicy,
+  type GuardrailCheck,
+} from '../aiGuardrails';
 import { getUserPermissions, userCanDecideApprovals } from '../permissions';
 import { dispatchApprovalPushToTokens, getUserPushTokens } from '../expoPush';
 import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
 import { recordActionIntentEvent } from './metrics';
-import { resolveIntentApprovers } from './intentApprovers';
+import {
+  resolveAgentIntentApprovers,
+  resolveIntentApprovers,
+  resolveIntentTargetScope,
+  type IntentTargetScope,
+} from './intentApprovers';
 import { computeEffectDigestOutcome, type EffectDigestOutcome } from './effectDigest';
 
 /** Statuses the partial `action_intents_org_idem_uniq` index dedupes on
@@ -78,13 +90,13 @@ export interface CreateActionIntentInput {
   input: Record<string, unknown>;
   reason?: string;
   /**
-   * Deliberately excludes 'ai_agent' until the requester-less create path
-   * lands (PR 3b) — belt-and-suspenders with the principal guard at the top
-   * of createActionIntent. Kept as an explicit literal union (not
-   * Exclude<ActionIntentSource, …>) so a future source value is opted into
-   * this public input on purpose, never inherited.
+   * 'ai_agent' (wave 3b) is valid ONLY for an ai_agent principal — and
+   * required for one: createActionIntent enforces the pairing in both
+   * directions (agent_source_mismatch). Kept as an explicit literal union
+   * (not ActionIntentSource) so a future source value is opted into this
+   * public input on purpose, never inherited.
    */
-  source: 'chat' | 'mcp_api';
+  source: 'chat' | 'mcp_api' | 'ai_agent';
   requestingClientLabel?: string;
   /** MCP callers pass this explicitly; derived deterministically for chat. */
   idempotencyKey?: string;
@@ -154,6 +166,11 @@ export interface ActionIntentTransitionPatch {
 const CHAT_EXPIRY_MS = 5 * 60 * 1000;
 const FOUR_EYES_CHAT_EXPIRY_MS = 60 * 60 * 1000;
 const MCP_EXPIRY_MS = 24 * 60 * 60 * 1000;
+// Headless agent proposals have no human watching a chat pane; give
+// reviewers a working day. Deliberate, not inherited from the MCP window
+// (which it happens to equal today) — change one without silently changing
+// the other.
+const AGENT_INTENT_EXPIRY_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Fixed release lease (tier3-supervised-four-eyes design §4.2): how long an
@@ -234,6 +251,7 @@ function deriveIdempotencyKey(actorId: string, actionName: string, digest: strin
 }
 
 function computeExpiresAt(source: ActionIntentSource, approvalScope: ActionIntentApprovalScope): Date {
+  if (source === 'ai_agent') return new Date(Date.now() + AGENT_INTENT_EXPIRY_MS);
   if (source !== 'chat') return new Date(Date.now() + MCP_EXPIRY_MS);
   const ms = approvalScope === 'supervised' ? CHAT_EXPIRY_MS : FOUR_EYES_CHAT_EXPIRY_MS;
   return new Date(Date.now() + ms);
@@ -283,26 +301,25 @@ export async function createActionIntent(
   auth: AuthContext,
   input: CreateActionIntentInput,
 ): Promise<ActionIntentSnapshot> {
-  // Agent-originated intents are a wave-3b design (requester-less model:
-  // this function writes requestedByUserId unconditionally, supervised
-  // read/decide keys on requestedByUserId via isIntentRowLiveAuthorized in
-  // routes/approvals.ts, and cancel keys on it via isRequester below).
-  // 'ai_agent' is already a valid value in
-  // action_intents_origin_principal_kind_chk, but the requester-less write
-  // path, fan-out, decide, and release reconstruction for it aren't
-  // implemented yet — so an agent reaching this path fails CLOSED until PR
-  // 3b, rather than being recorded as whatever synthetic user its
-  // attribution record carries.
-  if (auth.principal.kind === 'ai_agent') {
+  // Mutual source/principal consistency (wave 3b): an ai_agent principal may
+  // ONLY write source='ai_agent' rows, and nothing else may claim that
+  // source. The requester-less attribution facts (requestedByUserId NULL +
+  // requestingAgentRunId) key off this pairing, so a mismatch is rejected
+  // outright rather than recorded as whatever synthetic user the agent's
+  // attribution record carries — or, in the other direction, as a human
+  // intent masquerading as an agent proposal.
+  const isAgentIntent = auth.principal.kind === 'ai_agent';
+  if (isAgentIntent !== (input.source === 'ai_agent')) {
     throw new ActionIntentError(
-      'AI agents cannot create action intents yet (agent-originated intents ship in wave 3)',
-      'agent_origin_unsupported',
+      isAgentIntent
+        ? `AI agent principals must create intents with source 'ai_agent' (got '${input.source}')`
+        : `source 'ai_agent' is reserved for ai_agent principals (got principal '${auth.principal.kind}')`,
+      'agent_source_mismatch',
     );
   }
   // Captured here, at the top level, on purpose: TypeScript discards property
   // narrowing inside the transaction closure below, so reading
-  // `auth.principal.kind` at the insert site would widen back to include the
-  // 'ai_agent' the guard above just excluded.
+  // `auth.principal.kind` at the insert site would widen the type back out.
   const originPrincipalKind: ActionIntentOriginPrincipalKind = auth.principal.kind;
 
   const guardrail = checkGuardrails(input.toolName, input.input);
@@ -346,14 +363,102 @@ export async function createActionIntent(
     }
   }
 
+  // -------------------------------------------------------------------------
+  // Agent-originated intents (wave 3b): load + verify the run, then re-verify
+  // the guardrail verdict INSIDE the service. The caller's claimed verdict is
+  // never trusted (spec §5.3) — a compromised or buggy runner must not be able
+  // to smuggle a proposal past the run's own policy snapshot.
+  // -------------------------------------------------------------------------
+  let agentRun: {
+    id: string;
+    agentId: string;
+    orgId: string;
+    deviceId: string | null;
+  } | null = null;
+  let agentRow: { id: string; name: string } | null = null;
+  if (auth.principal.kind === 'ai_agent') {
+    const principal = auth.principal;
+    // runOutsideDbContext is load-bearing: a bare system wrapper inside an
+    // ambient request context is a passthrough (db/index.ts ~440) and the
+    // run/agent/device reads below must not silently run under whatever org
+    // context the caller happens to hold.
+    const loaded = await runOutsideDbContext(() =>
+      withSystemDbAccessContext(async () => {
+        const [run] = await db
+          .select({
+            id: aiAgentRuns.id,
+            agentId: aiAgentRuns.agentId,
+            orgId: aiAgentRuns.orgId,
+            deviceId: aiAgentRuns.deviceId,
+            policySnapshot: aiAgentRuns.policySnapshot,
+          })
+          .from(aiAgentRuns)
+          .where(eq(aiAgentRuns.id, principal.runId))
+          .limit(1);
+        if (!run || run.agentId !== principal.agentId || run.orgId !== orgId) return null;
+        const [agent] = await db
+          .select({ id: aiAgents.id, name: aiAgents.name })
+          .from(aiAgents)
+          .where(eq(aiAgents.id, run.agentId))
+          .limit(1);
+        if (!agent) return null;
+        let deviceSiteId: string | null = null;
+        if (run.deviceId) {
+          const [device] = await db
+            .select({ siteId: devices.siteId })
+            .from(devices)
+            .where(eq(devices.id, run.deviceId))
+            .limit(1);
+          deviceSiteId = device?.siteId ?? null;
+        }
+        return { run, agent, deviceSiteId };
+      }),
+    );
+    if (!loaded) {
+      throw new ActionIntentError(
+        'AI agent run is missing, belongs to another agent, or targets another org',
+        'agent_run_invalid',
+      );
+    }
+    agentRun = loaded.run;
+    agentRow = loaded.agent;
+
+    // Re-verify the verdict from the run's own policy snapshot. deviceId and
+    // deviceSiteId come from the RUN row, never from tool input (Task 3:
+    // isAgentGuardrailPolicy rejects an absent deviceId, so it must be
+    // populated explicitly — a malformed snapshot fails validation inside
+    // checkAgentGuardrails and denies, which is the fail-closed shape we
+    // want, hence the cast instead of a hand-rolled validator here).
+    const effective = loaded.run.policySnapshot?.effective;
+    const verdict = checkAgentGuardrails(input.toolName, input.input, {
+      enabled: effective?.enabled,
+      mode: effective?.mode,
+      toolAllowlist: effective?.toolAllowlist,
+      protectedResources: effective?.protectedResources,
+      deviceId: loaded.run.deviceId ?? null,
+      deviceSiteId: loaded.deviceSiteId,
+    } as AgentGuardrailPolicy);
+    if (verdict.disposition === 'deny') {
+      throw new ActionIntentError(
+        `Agent policy denies "${input.toolName}": ${verdict.reason ?? 'denied'}`,
+        'agent_policy_denied',
+      );
+    }
+  }
+
   const canonical = canonicalizeArguments(input.input);
   const argumentDigest = computeArgumentDigest(canonical);
-  const idempotencyKey = input.idempotencyKey ?? deriveIdempotencyKey(requesterId, input.toolName, argumentDigest);
+  // Agent default key is RUN-scoped (run id, not the synthetic agent user
+  // id): two runs of the same agent proposing identical arguments must
+  // yield DISTINCT intents — an intent is immutably attributed to one run,
+  // whose policy snapshot the release path evaluates (review major 4).
+  const idempotencyKey = input.idempotencyKey
+    ?? deriveIdempotencyKey(agentRun ? agentRun.id : requesterId, input.toolName, argumentDigest);
   const targetSummary = buildTargetSummary(input.toolName, input.input);
   const impactSummary = buildImpactSummary(input.toolName, guardrail);
   const expiresAt = computeExpiresAt(input.source, approvalScope);
   const requestingClientLabel = input.requestingClientLabel
-    ?? (input.source === 'chat' ? 'Breeze AI' : 'MCP API client');
+    ?? (agentRow ? agentRow.name : input.source === 'chat' ? 'Breeze AI' : 'MCP API client');
   // Tier → riskTier mapping mirrors aiAgentSdk.ts's mobile-approval bridge.
   // Tier is always 3 by the time we reach here (T4 refused, T<=2 rejected
   // above), but computed generically for forward-compat.
@@ -381,6 +486,34 @@ export async function createActionIntent(
   const eligibleAll = await resolveIntentApprovers(orgId);
   const eligibleApprovers = eligibleAll.filter((userId) => userId !== requesterId);
   const requesterEligible = eligibleAll.includes(requesterId);
+
+  // Agent action-and-target eligibility (Task 3), resolved OUTSIDE the
+  // transaction for the same connection-hold reasons as
+  // resolveIntentApprovers above — both helpers manage their own
+  // system-scoped contexts internally (runOutsideDbContext inside the
+  // creation transaction would be actively wrong). Resolved for EVERY agent
+  // intent, not just supervised ones, so a proposal citing a nonexistent
+  // device is refused before anything is written, regardless of scope.
+  let agentEligibleApprovers: string[] = [];
+  if (agentRun) {
+    let targetScope: IntentTargetScope;
+    try {
+      targetScope = await resolveIntentTargetScope(input.toolName, input.input, {
+        deviceId: agentRun.deviceId,
+      });
+    } catch (err) {
+      throw new ActionIntentError(
+        err instanceof Error ? err.message : 'Agent intent target could not be resolved',
+        'agent_target_invalid',
+      );
+    }
+    agentEligibleApprovers = await resolveAgentIntentApprovers({
+      orgId,
+      toolName: input.toolName,
+      input: input.input,
+      targetScope,
+    });
+  }
 
   // ONE system-scoped transaction (durability): insert the intent row (or
   // detect an idempotent replay) AND, in the SAME transaction, fan out the
@@ -444,7 +577,10 @@ export async function createActionIntent(
         .values({
           orgId,
           partnerId: auth.partnerId ?? null,
-          requestedByUserId: requesterId,
+          // Agent intents are requester-less by design (wave 3b): the run is
+          // the attribution record, never the agent's synthetic user id.
+          requestedByUserId: agentRun ? null : requesterId,
+          requestingAgentRunId: agentRun?.id ?? null,
           // Record the ORIGIN principal as a fact, at the one moment it is
           // known for certain. Do NOT derive this later from `source` or from
           // which actor column is populated — see the column's doc comment.
@@ -454,7 +590,9 @@ export async function createActionIntent(
               ? auth.principal.apiKeyId ?? null
               : auth.principal.kind === 'oauth_grant'
                 ? auth.principal.grantId ?? null
-                : null,
+                : agentRow
+                  ? agentRow.id
+                  : null,
           connectionId: input.binding?.connectionId ?? null,
           tenantId: input.binding?.tenantId ?? null,
           source: input.source,
@@ -522,6 +660,22 @@ export async function createActionIntent(
             'idempotency_race',
           );
         }
+        // Review major 4: a key collision is only a replay when it is the
+        // SAME logical request. Source, run attribution, and the argument
+        // digest must all match — otherwise returning the row would hand this
+        // caller an intent belonging to someone else (for agents: another
+        // run, whose immutably-attributed policy snapshot the release path
+        // would then evaluate).
+        if (
+          existing.source !== input.source ||
+          (existing.requestingAgentRunId ?? null) !== (agentRun?.id ?? null) ||
+          existing.argumentDigest !== argumentDigest
+        ) {
+          throw new ActionIntentError(
+            'Idempotency key already belongs to a different live request (source/run/arguments mismatch)',
+            'idempotency_conflict',
+          );
+        }
         const approvalRows = await db
           .select({ id: approvalRequests.id, userId: approvalRequests.userId })
           .from(approvalRequests)
@@ -582,7 +736,24 @@ export async function createActionIntent(
         return { approvalRequestIds: [], requesterApprovalRequestId: null, fanOutUserIds: [] };
       };
 
-      if (approvalScope === 'supervised') {
+      if (agentRun) {
+        // Agent intents have NO requester, so neither the supervised
+        // requester short-circuit nor the sole-operator fallback below can
+        // apply. Supervised fans out to the action-and-target-eligible humans
+        // resolved above (spec §3.4: any human with the action's RBAC AND
+        // access to the concrete target); four_eyes keeps the org-wide
+        // approvals:decide pool unchanged. An empty pool falls through to the
+        // no_eligible_approvers cancellation below.
+        const pool = approvalScope === 'four_eyes' ? eligibleApprovers : agentEligibleApprovers;
+        if (pool.length > 0) {
+          const rows = await db
+            .insert(approvalRequests)
+            .values(pool.map(approvalRowFor))
+            .returning({ id: approvalRequests.id });
+          approvalRequestIds = rows.map((r) => r.id);
+          fanOutUserIds = pool;
+        }
+      } else if (approvalScope === 'supervised') {
         // Supervised short-circuit (tier3-supervised-four-eyes split design
         // §4.2): exactly one approval row, always owned by the requester,
         // BEFORE the eligible-approver branch below — supervised does not
@@ -664,10 +835,16 @@ export async function createActionIntent(
   // Best-effort push AFTER the creation transaction commits (#1105) — never
   // hold a DB transaction open across the push network round-trip. Token
   // reads happen inside a fresh context per approver; the sends happen after.
-  // Supervised intents never push: the sole row belongs to the requester
-  // themselves, who is already looking at the chat/MCP response that created
-  // it — pushing would just notify them about their own pending action.
-  if (creation.isNew && creation.intent.status === 'pending_approval' && creation.intent.approvalScope === 'four_eyes') {
+  // Supervised HUMAN intents never push: the sole row belongs to the
+  // requester themselves, who is already looking at the chat/MCP response
+  // that created it. Agent intents notify at EVERY scope (wave 3b): the
+  // proposal is headless — nobody is watching a chat pane, so without this
+  // widened gate a supervised agent proposal would notify NOBODY (gap 4).
+  if (
+    creation.isNew &&
+    creation.intent.status === 'pending_approval' &&
+    (creation.intent.approvalScope === 'four_eyes' || creation.intent.source === 'ai_agent')
+  ) {
     for (let i = 0; i < creation.approvalRequestIds.length; i++) {
       const approvalId = creation.approvalRequestIds[i];
       const userId = creation.fanOutUserIds[i];
@@ -731,6 +908,16 @@ export async function createActionIntent(
   // surface that quietly stopped being pinnable leaves no trace anywhere.
   // Gated on isNew: a replay recomputes the same outcome for a row that
   // already emitted this once.
+  // Agent creations are audited as the AGENT (actorType 'ai_agent', no
+  // actorId — the synthetic user id must never masquerade as a person),
+  // carrying the agent/run ids in details (gap 13).
+  const auditActor = agentRun
+    ? { actorType: 'ai_agent' as const }
+    : { actorId: requesterId };
+  const agentAuditDetails = agentRun && agentRow
+    ? { agentId: agentRow.id, agentRunId: agentRun.id }
+    : {};
+
   if (creation.isNew && creation.effectDigestOutcome.kind === 'unresolved') {
     recordActionIntentEvent({
       orgId,
@@ -739,10 +926,11 @@ export async function createActionIntent(
       argumentDigest,
       source: input.source,
       outcome: 'effect_digest_unpinned',
-      actorId: requesterId,
+      ...auditActor,
       details: {
         reason: creation.effectDigestOutcome.reason,
         approvalScope,
+        ...agentAuditDetails,
       },
     });
   }
@@ -756,9 +944,9 @@ export async function createActionIntent(
       argumentDigest,
       source: input.source,
       outcome: cancelledForNoApprovers ? 'cancelled' : 'created',
-      actorId: requesterId,
+      ...auditActor,
       details: cancelledForNoApprovers
-        ? { errorCode: creation.intent.errorCode ?? 'no_eligible_approvers' }
+        ? { errorCode: creation.intent.errorCode ?? 'no_eligible_approvers', ...agentAuditDetails }
         : {
           approverCount: creation.approvalRequestIds.length,
           // Gated on four_eyes: supervised intents always have exactly one
@@ -771,6 +959,7 @@ export async function createActionIntent(
             approvalScope === 'four_eyes' &&
             creation.fanOutUserIds.length === 1 &&
             creation.fanOutUserIds[0] === requesterId,
+          ...agentAuditDetails,
         },
     });
   }

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -498,9 +498,14 @@ export async function createActionIntent(
   if (agentRun) {
     let targetScope: IntentTargetScope;
     try {
-      targetScope = await resolveIntentTargetScope(input.toolName, input.input, {
-        deviceId: agentRun.deviceId,
-      });
+      // orgId pins the device resolution to the intent's org (review finding
+      // 1): a cross-tenant device id must fail exactly like a nonexistent one.
+      targetScope = await resolveIntentTargetScope(
+        input.toolName,
+        input.input,
+        { deviceId: agentRun.deviceId },
+        orgId,
+      );
     } catch (err) {
       throw new ActionIntentError(
         err instanceof Error ? err.message : 'Agent intent target could not be resolved',
@@ -661,18 +666,23 @@ export async function createActionIntent(
           );
         }
         // Review major 4: a key collision is only a replay when it is the
-        // SAME logical request. Source, run attribution, and the argument
-        // digest must all match — otherwise returning the row would hand this
-        // caller an intent belonging to someone else (for agents: another
-        // run, whose immutably-attributed policy snapshot the release path
-        // would then evaluate).
+        // SAME logical request. Action name, source, run attribution, and the
+        // argument digest must all match — otherwise returning the row would
+        // hand this caller an intent belonging to someone else (for agents:
+        // another run, whose immutably-attributed policy snapshot the release
+        // path would then evaluate). The actionName check matters when the
+        // caller supplies an EXPLICIT key: two different tools can share a
+        // key AND a byte-identical canonical argument shape (e.g. both take
+        // only {deviceId}), and treating tool B as a replay of tool A would
+        // silently drop proposal B (review finding 2).
         if (
+          existing.actionName !== input.toolName ||
           existing.source !== input.source ||
           (existing.requestingAgentRunId ?? null) !== (agentRun?.id ?? null) ||
           existing.argumentDigest !== argumentDigest
         ) {
           throw new ActionIntentError(
-            'Idempotency key already belongs to a different live request (source/run/arguments mismatch)',
+            'Idempotency key already belongs to a different live request (action/source/run/arguments mismatch)',
             'idempotency_conflict',
           );
         }

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -1011,7 +1011,10 @@ export async function cancelActionIntent(
     throw new ActionIntentNotFoundError(intentId);
   }
 
-  // Requester-or-approver only (spec §6.2).
+  // Requester-or-approver only (spec §6.2). For an agent-originated intent
+  // requestedByUserId is NULL, so this deliberately collapses to "any
+  // approvals:decide holder in the org" — a human can dismiss an agent
+  // proposal without approving it (owner decision 2026-08-23, wave 3b).
   const isRequester = intent.requestedByUserId === auth.user.id;
   let isApprover = false;
   if (!isRequester) {

--- a/apps/api/src/services/actionIntents/revalidateRelease.test.ts
+++ b/apps/api/src/services/actionIntents/revalidateRelease.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { canonicalizeArguments, computeArgumentDigest } from '@breeze/shared/canonicalize';
 
 vi.mock('../aiTools', () => ({ getToolTier: vi.fn(() => 3) }));
-vi.mock('../aiGuardrails', () => ({ checkToolPermission: vi.fn(() => ({ allowed: true })) }));
+vi.mock('../aiGuardrails', () => ({ checkToolPermission: vi.fn(async () => null) }));
+vi.mock('./agentReleaseAuthority', () => ({
+  checkAgentReleaseAuthority: vi.fn(async () => ({ ok: true })),
+}));
 vi.mock('../tenantStatus', () => ({ getActiveOrgTenant: vi.fn(async () => ({ status: 'active' })) }));
 vi.mock('./actorContext', () => ({
   buildAuthContextForIntent: vi.fn(async () => ({
@@ -12,6 +15,8 @@ vi.mock('./actorContext', () => ({
 }));
 
 import { revalidateApprovedIntentForRelease } from './revalidateRelease';
+import { checkToolPermission } from '../aiGuardrails';
+import { checkAgentReleaseAuthority } from './agentReleaseAuthority';
 
 /** Minimal ActionIntent shape the function actually reads. */
 function intentFixture(overrides: Record<string, unknown> = {}) {
@@ -59,5 +64,66 @@ describe('revalidateApprovedIntentForRelease digest recompute', () => {
     // Later checks (tier, actor) are exercised by this file's other tests;
     // assert only that we did not fail on the digest.
     if (result.ok === false) expect(result.errorCode).not.toBe('digest_mismatch');
+  });
+});
+
+describe('revalidateApprovedIntentForRelease agent branch (wave 3b)', () => {
+  const args = { deviceId: 'dev-1', action: 'restart', serviceName: 'spooler' };
+  const digest = computeArgumentDigest(canonicalizeArguments(args));
+  const agentIntent = (overrides: Record<string, unknown> = {}) => intentFixture({
+    requestedByUserId: null,
+    requestingAgentRunId: 'run-1',
+    originPrincipalKind: 'ai_agent',
+    originPrincipalId: 'agent-1',
+    source: 'ai_agent',
+    actionName: 'manage_services',
+    arguments: args,
+    argumentDigest: digest,
+    ...overrides,
+  });
+
+  it('consults checkAgentReleaseAuthority INSTEAD of checkToolPermission', async () => {
+    const result = await revalidateApprovedIntentForRelease(
+      agentIntent(),
+      { boundArgumentDigest: digest },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(checkAgentReleaseAuthority).toHaveBeenCalledTimes(1);
+    // The RBAC check would deny the ai_agent principal anyway; the branch is
+    // what makes agent release POSSIBLE. It must be skipped, not softened.
+    expect(checkToolPermission).not.toHaveBeenCalled();
+  });
+
+  it('propagates the authority veto verbatim', async () => {
+    vi.mocked(checkAgentReleaseAuthority).mockResolvedValueOnce({
+      ok: false,
+      errorCode: 'agent_policy_denied',
+      details: { policy: 'current', reason: 'Agent is disabled' },
+    });
+
+    const result = await revalidateApprovedIntentForRelease(
+      agentIntent(),
+      { boundArgumentDigest: digest },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      errorCode: 'agent_policy_denied',
+      details: { policy: 'current', reason: 'Agent is disabled' },
+    });
+  });
+
+  it('human intents still go through checkToolPermission, never the agent authority', async () => {
+    const humanArgs = { to: ['a@example.com'], subject: 's', bodyText: 'b' };
+    const humanDigest = computeArgumentDigest(canonicalizeArguments(humanArgs));
+    const result = await revalidateApprovedIntentForRelease(
+      intentFixture({ arguments: humanArgs, argumentDigest: humanDigest }),
+      { boundArgumentDigest: humanDigest },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(checkToolPermission).toHaveBeenCalledTimes(1);
+    expect(checkAgentReleaseAuthority).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/actionIntents/revalidateRelease.ts
+++ b/apps/api/src/services/actionIntents/revalidateRelease.ts
@@ -4,6 +4,7 @@ import { getToolTier } from '../aiTools';
 import { checkToolPermission } from '../aiGuardrails';
 import { getActiveOrgTenant } from '../tenantStatus';
 import { buildAuthContextForIntent } from './actorContext';
+import { checkAgentReleaseAuthority } from './agentReleaseAuthority';
 import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
 
 /**
@@ -86,7 +87,21 @@ export async function revalidateApprovedIntentForRelease(
     return { ok: false, errorCode: 'org_inactive' };
   }
 
-  // (e) The actor must STILL hold the specific RBAC permission the tool
+  // (e) Authority re-check. For an AGENT-originated intent there is no user
+  // RBAC to consult — checkToolPermission denies the ai_agent principal as
+  // its first statement, and that deny is deliberately untouched. Release
+  // branches into the STRUCTURAL authority check instead: the stricter
+  // combination of the run's immutable policy_snapshot and the agent's
+  // CURRENT effective policy (agentReleaseAuthority.ts).
+  if (intent.requestingAgentRunId) {
+    const authority = await checkAgentReleaseAuthority(intent);
+    if (!authority.ok) {
+      return authority;
+    }
+    return { ok: true, auth };
+  }
+
+  // The actor must STILL hold the specific RBAC permission the tool
   // requires, checked against the rebuilt `auth` from (c) — not the caller's
   // original, now possibly stale, permission check.
   const permissionDenial = await checkToolPermission(intent.actionName, intent.arguments, auth);

--- a/apps/api/src/services/aiAgents/agentService.test.ts
+++ b/apps/api/src/services/aiAgents/agentService.test.ts
@@ -13,6 +13,7 @@ const state = vi.hoisted(() => ({
   selectWhere: undefined as unknown,
   audit: vi.fn(),
   publish: vi.fn(),
+  validateRecipients: vi.fn(),
 }));
 
 const schema = vi.hoisted(() => ({
@@ -66,6 +67,21 @@ vi.mock('../../db', () => ({
     })),
   },
 }));
+
+// Membership validation has its own suite (recipients.test.ts) against mocked
+// membership queries; here it is stubbed so this suite's fixtures count as
+// valid-membership, and the CONTRACT — called with the owner and exactly the
+// recipients object that will be stored, before any write — is asserted below.
+vi.mock('./recipients', () => {
+  class InvalidAgentRecipientsError extends Error {
+    readonly code = 'invalid_recipients';
+    constructor(public invalidUserIds: string[], public invalidRoleIds: string[]) {
+      super('invalid_recipients');
+      this.name = 'InvalidAgentRecipientsError';
+    }
+  }
+  return { InvalidAgentRecipientsError, validateAgentRecipients: state.validateRecipients };
+});
 
 vi.mock('../auditService', () => ({ createAuditLog: state.audit }));
 vi.mock('../eventBus', () => ({ getEventBus: () => ({ publish: state.publish }) }));
@@ -178,6 +194,7 @@ const createInput = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  state.validateRecipients.mockResolvedValue(undefined);
   state.currentRow = null;
   state.listRows = [];
   state.returnedRow = null;
@@ -220,6 +237,10 @@ describe('agent mutations', () => {
     await createAgent(auth(), { orgId: 'o1', partnerId: null }, createInput as never);
 
     expect(state.insertedValues).toMatchObject({ orgId: 'o1', partnerId: null, kind: 'alert_triage' });
+    expect(state.validateRecipients).toHaveBeenCalledWith(
+      { orgId: 'o1', partnerId: null },
+      createInput.recipients,
+    );
     expect(state.audit).toHaveBeenCalledWith(expect.objectContaining({
       action: 'ai.agent.created', resourceType: 'ai_agent', resourceId: 'a1', result: 'success',
     }));
@@ -229,6 +250,27 @@ describe('agent mutations', () => {
       expect.objectContaining({ agentId: 'a1', change: 'created' }),
       'ai-agents',
     );
+  });
+
+  it('refuses invalid recipients before anything is written', async () => {
+    const { InvalidAgentRecipientsError } = await import('./recipients');
+    state.validateRecipients.mockRejectedValue(
+      new InvalidAgentRecipientsError(['u-bad'], []),
+    );
+    state.returnedRow = storedRow;
+
+    await expect(createAgent(auth(), { orgId: 'o1', partnerId: null }, createInput as never))
+      .rejects.toBeInstanceOf(InvalidAgentRecipientsError);
+    expect(state.insertedValues).toBeNull();
+    expect(state.audit).not.toHaveBeenCalled();
+    expect(state.publish).not.toHaveBeenCalled();
+
+    // Same contract on update: a recipients patch is validated (as the merged
+    // object) before the UPDATE is issued.
+    state.currentRow = storedRow;
+    await expect(updateAgent(auth(), 'a1', { recipients: { userIds: ['u-bad'] } } as never))
+      .rejects.toBeInstanceOf(InvalidAgentRecipientsError);
+    expect(state.updatedValues).toBeNull();
   });
 
   it('refuses a second active agent of the same kind before the insert runs', async () => {
@@ -317,6 +359,12 @@ describe('agent mutations', () => {
       triggers: { ...storedRow.triggers, respectMaintenanceWindows: false },
       recipients: { ...storedRow.recipients, userIds: ['u2'] },
     });
+    // The validated object IS the merged object that gets stored — validating
+    // only the patch would let a stale-but-stored sibling id survive unchecked.
+    expect(state.validateRecipients).toHaveBeenCalledWith(
+      { orgId: 'o1', partnerId: null },
+      { ...storedRow.recipients, userIds: ['u2'] },
+    );
     expect(state.audit).toHaveBeenCalledWith(expect.objectContaining({
       action: 'ai.agent.updated', resourceId: 'a1', result: 'success',
     }));
@@ -339,6 +387,8 @@ describe('agent mutations', () => {
     expect(state.updatedValues).not.toHaveProperty('ownerScope');
     expect(state.updatedValues).not.toHaveProperty('orgId');
     expect(state.updatedValues).not.toHaveProperty('partnerId');
+    // No recipients in the patch → no membership validation round-trip.
+    expect(state.validateRecipients).not.toHaveBeenCalled();
   });
 
   it('rejects the DB-legal act mode as unsupported', async () => {

--- a/apps/api/src/services/aiAgents/agentService.ts
+++ b/apps/api/src/services/aiAgents/agentService.ts
@@ -9,6 +9,7 @@ import { getEventBus } from '../eventBus';
 import { AgentAccessDeniedError, assertAgentWriteAllowed } from './access';
 import { isSupportedAgentMode } from './constants';
 import { normalizeAgentPolicy } from './effectivePolicy';
+import { validateAgentRecipients } from './recipients';
 
 export class UnsupportedAgentModeError extends Error {
   readonly code = 'mode_not_supported';
@@ -268,6 +269,13 @@ export async function createAgent(
 ): Promise<AiAgentRow> {
   assertAgentWriteAllowed(auth, owner);
 
+  // Recipients are membership-validated BEFORE anything is written: a typo'd
+  // or cross-tenant id must never be persisted, because notification-time
+  // resolution silently drops what it cannot verify (services/aiAgents/
+  // recipients.ts) — an invalid entry stored here would be a recipient that
+  // silently never hears anything.
+  await validateAgentRecipients(owner, input.recipients ?? {});
+
   // Pre-check the partial unique indexes on (partner_id, kind) and (org_id,
   // kind) WHERE disabled_at IS NULL. Letting the insert trip 23505 is not an
   // option here: the whole request runs inside one withDbAccessContext
@@ -317,6 +325,16 @@ export async function updateAgent(
     throw new AgentAccessDeniedError('Agent not found');
   }
   assertAgentWriteAllowed(auth, existing);
+
+  // Validate the MERGED recipients — the exact object updatePolicyColumns
+  // persists ({ ...stored, ...patch }), so what is checked is what is stored.
+  if (input.recipients !== undefined) {
+    const stored = normalizeAgentPolicy(existing);
+    await validateAgentRecipients(
+      { orgId: existing.orgId, partnerId: existing.partnerId },
+      { ...stored.recipients, ...input.recipients },
+    );
+  }
 
   const [row] = await db
     .update(aiAgents)

--- a/apps/api/src/services/aiAgents/effectivePolicy.ts
+++ b/apps/api/src/services/aiAgents/effectivePolicy.ts
@@ -17,7 +17,12 @@ import {
 import { envFlag } from '../../config/env';
 import { db } from '../../db';
 import { readWithPartnerAxisVisibility } from '../../db/partnerAxisRead';
-import { aiAgents, aiBudgets, organizations, type AiAgentRow } from '../../db/schema';
+// Direct module imports, NOT the ../../db/schema barrel: this module now sits
+// on the intent-release path (wave 3b), and pulling the barrel would force
+// every partial-mock unit test of that path to stub the entire schema surface.
+import { aiAgents, type AiAgentRow } from '../../db/schema/aiAgents';
+import { aiBudgets } from '../../db/schema/ai';
+import { organizations } from '../../db/schema/orgs';
 import type { AuthContext } from '../../middleware/auth';
 
 type PolicyRowFields = Pick<

--- a/apps/api/src/services/aiAgents/recipients.test.ts
+++ b/apps/api/src/services/aiAgents/recipients.test.ts
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('drizzle-orm', () => ({
+  and: (...conditions: unknown[]) => ({ and: conditions }),
+  eq: (column: unknown, value: unknown) => ({ eq: [column, value] }),
+  inArray: (column: unknown, values: unknown) => ({ inArray: [column, values] }),
+}));
+
+vi.mock('../../db/schema', () => ({
+  organizations: { id: 'organizations.id', partnerId: 'organizations.partnerId' },
+  organizationUsers: {
+    userId: 'organizationUsers.userId',
+    orgId: 'organizationUsers.orgId',
+    roleId: 'organizationUsers.roleId',
+  },
+  partnerUsers: {
+    userId: 'partnerUsers.userId',
+    partnerId: 'partnerUsers.partnerId',
+    roleId: 'partnerUsers.roleId',
+    orgAccess: 'partnerUsers.orgAccess',
+    orgIds: 'partnerUsers.orgIds',
+  },
+  users: { id: 'users.id', status: 'users.status' },
+  roles: {
+    id: 'roles.id',
+    partnerId: 'roles.partnerId',
+    orgId: 'roles.orgId',
+    isSystem: 'roles.isSystem',
+  },
+}));
+
+vi.mock('../../db', () => ({
+  db: { select: vi.fn() },
+  // Pass-throughs — the tests assert BOTH wrappers were entered, because a bare
+  // withSystemDbAccessContext inside an ambient request context is a no-op
+  // (db/index.ts): the runOutsideDbContext wrapper is load-bearing.
+  runOutsideDbContext: vi.fn(<T,>(fn: () => T): T => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import {
+  InvalidAgentRecipientsError,
+  resolveRecipientUserIds,
+  validateAgentRecipients,
+} from './recipients';
+
+/**
+ * Queue one select's result rows, in issue order. The returned capture object
+ * records the bound `from` table and `where` predicate so tests can pin the
+ * query shape (active-status gate, id filters) instead of only the JS logic.
+ */
+function queueSelect(rows: unknown[]) {
+  const capture: { from?: unknown; where?: unknown } = {};
+  vi.mocked(db.select).mockImplementationOnce(() => {
+    const chain = {
+      from: (table: unknown) => {
+        capture.from = table;
+        return chain;
+      },
+      innerJoin: () => chain,
+      where: (condition: unknown) => {
+        capture.where = condition;
+        return Object.assign(Promise.resolve(rows), { limit: async () => rows });
+      },
+    };
+    return chain as never;
+  });
+  return capture;
+}
+
+async function expectInvalid(
+  promise: Promise<void>,
+): Promise<InvalidAgentRecipientsError> {
+  try {
+    await promise;
+  } catch (err) {
+    expect(err).toBeInstanceOf(InvalidAgentRecipientsError);
+    return err as InvalidAgentRecipientsError;
+  }
+  throw new Error('expected InvalidAgentRecipientsError, resolved instead');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(db.select).mockReset();
+});
+
+describe('validateAgentRecipients', () => {
+  it('accepts active org members for an org-owned agent', async () => {
+    queueSelect([{ partnerId: 'p1' }]); // organizations → owning partner
+    const orgMembers = queueSelect([{ userId: 'u1' }, { userId: 'u2' }]);
+    queueSelect([]); // partner members — none needed
+
+    await expect(
+      validateAgentRecipients(
+        { orgId: 'o1', partnerId: null },
+        { userIds: ['u1', 'u2'], roleIds: [] },
+      ),
+    ).resolves.toBeUndefined();
+
+    // The membership read must be the active-member join, keyed by the org and
+    // the exact candidate ids — not an unfiltered table scan.
+    const bound = JSON.stringify(orgMembers.where);
+    expect(orgMembers.from).toMatchObject({ orgId: 'organizationUsers.orgId' });
+    expect(bound).toContain('"organizationUsers.orgId","o1"');
+    expect(bound).toContain('"users.status","active"');
+    expect(bound).toContain('u1');
+    expect(bound).toContain('u2');
+
+    // System context, with the load-bearing outside-context escape.
+    expect(runOutsideDbContext).toHaveBeenCalledTimes(1);
+    expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a userId from a different org (lists it in invalidUserIds)', async () => {
+    queueSelect([{ partnerId: 'p1' }]);
+    queueSelect([{ userId: 'u1' }]); // only u1 is a member of o1
+    queueSelect([]); // not a partner user either
+
+    const err = await expectInvalid(
+      validateAgentRecipients(
+        { orgId: 'o1', partnerId: null },
+        { userIds: ['u1', 'u-other-org'], roleIds: [] },
+      ),
+    );
+    expect(err.invalidUserIds).toEqual(['u-other-org']);
+    expect(err.invalidRoleIds).toEqual([]);
+    expect(err.code).toBe('invalid_recipients');
+  });
+
+  it('rejects an inactive user', async () => {
+    queueSelect([{ partnerId: 'p1' }]);
+    // The queries join users and gate on status='active', so a disabled or
+    // still-invited member simply does not come back.
+    const orgMembers = queueSelect([]);
+    const partnerMembers = queueSelect([]);
+
+    const err = await expectInvalid(
+      validateAgentRecipients(
+        { orgId: 'o1', partnerId: null },
+        { userIds: ['u-disabled'], roleIds: [] },
+      ),
+    );
+    expect(err.invalidUserIds).toEqual(['u-disabled']);
+    expect(JSON.stringify(orgMembers.where)).toContain('"users.status","active"');
+    expect(JSON.stringify(partnerMembers.where)).toContain('"users.status","active"');
+  });
+
+  it('rejects a roleId belonging to another tenant', async () => {
+    queueSelect([{ partnerId: 'p1' }]);
+    queueSelect([
+      { id: 'r-mine', partnerId: null, orgId: 'o1', isSystem: false },
+      { id: 'r-foreign', partnerId: null, orgId: 'o-other', isSystem: false },
+      { id: 'r-foreign-partner', partnerId: 'p-other', orgId: null, isSystem: false },
+    ]); // roles lookup — r-missing has no row at all
+
+    const err = await expectInvalid(
+      validateAgentRecipients(
+        { orgId: 'o1', partnerId: null },
+        { userIds: [], roleIds: ['r-mine', 'r-foreign', 'r-foreign-partner', 'r-missing'] },
+      ),
+    );
+    expect(err.invalidUserIds).toEqual([]);
+    expect(err.invalidRoleIds).toEqual(['r-foreign', 'r-foreign-partner', 'r-missing']);
+  });
+
+  it('accepts a partner user with orgAccess=selected covering the org', async () => {
+    queueSelect([{ partnerId: 'p1' }]);
+    queueSelect([]); // no direct org membership
+    queueSelect([
+      { userId: 'u-partner', orgAccess: 'selected', orgIds: ['o1', 'o9'] },
+    ]);
+
+    await expect(
+      validateAgentRecipients(
+        { orgId: 'o1', partnerId: null },
+        { userIds: ['u-partner'], roleIds: [] },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects a partner user whose orgAccess=selected does NOT cover the org', async () => {
+    queueSelect([{ partnerId: 'p1' }]);
+    queueSelect([]);
+    queueSelect([
+      { userId: 'u-partner', orgAccess: 'selected', orgIds: ['o-other'] },
+    ]);
+
+    const err = await expectInvalid(
+      validateAgentRecipients(
+        { orgId: 'o1', partnerId: null },
+        { userIds: ['u-partner'], roleIds: [] },
+      ),
+    );
+    expect(err.invalidUserIds).toEqual(['u-partner']);
+  });
+
+  it('accepts the owning partner tenancy for a partner-owned agent (members, roles, system roles)', async () => {
+    // Partner-owned agent: no organizations lookup — the owner IS the tenant.
+    const partnerMembers = queueSelect([{ userId: 'u-tech' }]);
+    queueSelect([
+      { id: 'r-partner', partnerId: 'p1', orgId: null, isSystem: false },
+      { id: 'r-system', partnerId: null, orgId: null, isSystem: true },
+    ]);
+
+    await expect(
+      validateAgentRecipients(
+        { orgId: null, partnerId: 'p1' },
+        { userIds: ['u-tech'], roleIds: ['r-partner', 'r-system'] },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(partnerMembers.from).toMatchObject({ partnerId: 'partnerUsers.partnerId' });
+    const bound = JSON.stringify(partnerMembers.where);
+    expect(bound).toContain('"partnerUsers.partnerId","p1"');
+    expect(bound).toContain('"users.status","active"');
+  });
+
+  it('issues no queries when there is nothing to validate', async () => {
+    await expect(
+      validateAgentRecipients({ orgId: 'o1', partnerId: null }, {}),
+    ).resolves.toBeUndefined();
+    await expect(
+      validateAgentRecipients({ orgId: 'o1', partnerId: null }, { userIds: [], roleIds: [] }),
+    ).resolves.toBeUndefined();
+    expect(db.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveRecipientUserIds', () => {
+  it('expands roleIds to current holders with access to the run org', async () => {
+    queueSelect([{ partnerId: 'p1' }]); // organizations → run org's partner
+    // userIds is empty, so the two explicit-userIds selects are skipped.
+    const orgHolders = queueSelect([{ userId: 'u-org-holder' }]);
+    queueSelect([
+      { userId: 'u-partner-all', orgAccess: 'all', orgIds: null },
+      { userId: 'u-partner-covered', orgAccess: 'selected', orgIds: ['o1'] },
+      { userId: 'u-partner-uncovered', orgAccess: 'selected', orgIds: ['o-other'] },
+      { userId: 'u-partner-none', orgAccess: 'none', orgIds: null },
+    ]);
+
+    const result = await resolveRecipientUserIds(
+      { orgId: null, partnerId: 'p1', recipients: { userIds: [], roleIds: ['r1'] } },
+      'o1',
+    );
+
+    expect([...result].sort()).toEqual(['u-org-holder', 'u-partner-all', 'u-partner-covered']);
+    // Role expansion is keyed on role membership in the RUN org, not the
+    // agent's owner: the where binds the run org and the role ids.
+    const bound = JSON.stringify(orgHolders.where);
+    expect(bound).toContain('"organizationUsers.orgId","o1"');
+    expect(bound).toContain('"organizationUsers.roleId"');
+    expect(bound).toContain('r1');
+    expect(bound).toContain('"users.status","active"');
+    expect(runOutsideDbContext).toHaveBeenCalledTimes(1);
+    expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a userId whose membership was since revoked', async () => {
+    queueSelect([{ partnerId: 'p1' }]);
+    queueSelect([{ userId: 'u-still-member' }]); // u-gone no longer comes back
+    queueSelect([]); // not a covering partner user either
+
+    const result = await resolveRecipientUserIds(
+      {
+        orgId: 'o1',
+        partnerId: null,
+        recipients: { userIds: ['u-still-member', 'u-gone'], roleIds: [] },
+      },
+      'o1',
+    );
+
+    expect(result).toEqual(['u-still-member']);
+  });
+
+  it('dedupes a user matched by both userIds and roleIds', async () => {
+    queueSelect([{ partnerId: 'p1' }]);
+    queueSelect([{ userId: 'u1' }]); // explicit userIds — org member
+    queueSelect([]); // explicit userIds — partner arm
+    queueSelect([{ userId: 'u1' }]); // role holders — same user again
+    queueSelect([]); // role holders — partner arm
+
+    const result = await resolveRecipientUserIds(
+      { orgId: 'o1', partnerId: null, recipients: { userIds: ['u1'], roleIds: ['r1'] } },
+      'o1',
+    );
+
+    expect(result).toEqual(['u1']);
+  });
+
+  it('returns [] without querying when the recipients are empty', async () => {
+    await expect(
+      resolveRecipientUserIds({ orgId: 'o1', partnerId: null, recipients: {} }, 'o1'),
+    ).resolves.toEqual([]);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiAgents/recipients.ts
+++ b/apps/api/src/services/aiAgents/recipients.ts
@@ -1,0 +1,258 @@
+/**
+ * AI agent notification recipients — validated at write time, re-resolved at
+ * notification time (spec §4.3, wave-1 gap closed by wave 3b, owner decision 3).
+ *
+ * `ai_agents.recipients` is notification-only data: it must NEVER influence an
+ * authorization or eligibility decision (the fan-out/eligibility resolvers in
+ * services/actionIntents/intentApprovers.ts are structurally pinned to never
+ * consult this module). Two contracts live here:
+ *
+ * - **Write time** (`validateAgentRecipients`): every stored id must be real
+ *   and belong to the agent owner's tenant, so a typo'd or cross-tenant id can
+ *   never be persisted. Org-owned agent: a userId must be an active direct
+ *   member of the org, or a partner user of the org's owning partner whose
+ *   orgAccess covers it. Partner-owned agent: an active member of that
+ *   partner. A roleId must exist and be visible to the owner tenant — its own
+ *   org/partner roles, the owning partner's roles for an org-owned agent, or a
+ *   seeded system role (mirrors GET /roles visibility, routes/roles.ts).
+ *
+ * - **Notification time** (`resolveRecipientUserIds`): membership is
+ *   re-derived live against the RUN org — the tenant whose data the
+ *   notification will describe. A stale id (revoked membership, disabled
+ *   account, role unassigned) silently drops rather than erroring: the
+ *   notification layer must never receive an unvalidated userId, because
+ *   createNotification (services/userNotifications.ts) inserts whatever it is
+ *   handed under a system context.
+ *
+ * Both functions read membership tables (organization_users, partner_users —
+ * partner-axis RLS a caller's org-scoped context can never see) under
+ * `runOutsideDbContext(() => withSystemDbAccessContext(...))`. The
+ * runOutsideDbContext wrapper is load-bearing: a bare system wrapper inside an
+ * ambient request context is a no-op (db/index.ts), and both entry points are
+ * called from inside request transactions (agentService mutations; wave-3b
+ * outcome notify).
+ */
+
+import { and, eq, inArray } from 'drizzle-orm';
+import type { AiAgentRecipients } from '@breeze/shared';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import {
+  organizations,
+  organizationUsers,
+  partnerUsers,
+  roles,
+  users,
+} from '../../db/schema';
+
+export class InvalidAgentRecipientsError extends Error {
+  readonly code = 'invalid_recipients';
+
+  constructor(
+    public invalidUserIds: string[],
+    public invalidRoleIds: string[],
+  ) {
+    super(
+      `invalid_recipients: userIds=[${invalidUserIds.join(', ')}] roleIds=[${invalidRoleIds.join(', ')}]`,
+    );
+    this.name = 'InvalidAgentRecipientsError';
+  }
+}
+
+export interface AgentRecipientsOwner {
+  orgId: string | null;
+  partnerId: string | null;
+}
+
+function coversOrg(
+  member: { orgAccess: string; orgIds: string[] | null },
+  orgId: string,
+): boolean {
+  return (
+    member.orgAccess === 'all' ||
+    (member.orgAccess === 'selected' && (member.orgIds?.includes(orgId) ?? false))
+  );
+}
+
+/**
+ * Active direct members of `orgId` among `userIds` (or holding one of
+ * `roleIds` when keyed by role). Join shape mirrors resolveIntentApprovers
+ * (intentApprovers.ts) / getUsersForAlert (notifications.ts): join `users`,
+ * gate on status='active' — a disabled or still-invited account is never a
+ * valid recipient.
+ */
+async function activeOrgMembers(
+  orgId: string,
+  key: { userIds: string[] } | { roleIds: string[] },
+): Promise<string[]> {
+  const keyCondition =
+    'userIds' in key
+      ? inArray(organizationUsers.userId, key.userIds)
+      : inArray(organizationUsers.roleId, key.roleIds);
+  const rows = await db
+    .select({ userId: organizationUsers.userId })
+    .from(organizationUsers)
+    .innerJoin(users, eq(users.id, organizationUsers.userId))
+    .where(and(eq(organizationUsers.orgId, orgId), keyCondition, eq(users.status, 'active')));
+  return rows.map((row) => row.userId);
+}
+
+/** Active members of `partnerId` among `userIds`/`roleIds`, with their org coverage. */
+async function activePartnerMembers(
+  partnerId: string,
+  key: { userIds: string[] } | { roleIds: string[] },
+): Promise<Array<{ userId: string; orgAccess: string; orgIds: string[] | null }>> {
+  const keyCondition =
+    'userIds' in key
+      ? inArray(partnerUsers.userId, key.userIds)
+      : inArray(partnerUsers.roleId, key.roleIds);
+  return db
+    .select({
+      userId: partnerUsers.userId,
+      orgAccess: partnerUsers.orgAccess,
+      orgIds: partnerUsers.orgIds,
+    })
+    .from(partnerUsers)
+    .innerJoin(users, eq(users.id, partnerUsers.userId))
+    .where(and(eq(partnerUsers.partnerId, partnerId), keyCondition, eq(users.status, 'active')));
+}
+
+/**
+ * Throw InvalidAgentRecipientsError unless every entry of `recipients` is
+ * valid for the owner tenant. Input ids are de-duplicated before querying;
+ * an empty/absent recipients object validates without touching the DB.
+ */
+export async function validateAgentRecipients(
+  owner: AgentRecipientsOwner,
+  recipients: Partial<AiAgentRecipients>,
+): Promise<void> {
+  const userIds = [...new Set(recipients.userIds ?? [])];
+  const roleIds = [...new Set(recipients.roleIds ?? [])];
+  if (userIds.length === 0 && roleIds.length === 0) return;
+
+  const { validUserIds, validRoleIds } = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const validUsers = new Set<string>();
+      const validRoles = new Set<string>();
+
+      // The partner axis of the owner tenant: the owner itself for a
+      // partner-owned agent, the org's owning partner for an org-owned one.
+      let partnerId = owner.partnerId;
+      if (owner.orgId) {
+        const [org] = await db
+          .select({ partnerId: organizations.partnerId })
+          .from(organizations)
+          .where(eq(organizations.id, owner.orgId))
+          .limit(1);
+        partnerId = org?.partnerId ?? null;
+      }
+
+      if (userIds.length > 0) {
+        if (owner.orgId) {
+          for (const userId of await activeOrgMembers(owner.orgId, { userIds })) {
+            validUsers.add(userId);
+          }
+          if (partnerId) {
+            for (const member of await activePartnerMembers(partnerId, { userIds })) {
+              if (coversOrg(member, owner.orgId)) validUsers.add(member.userId);
+            }
+          }
+        } else if (partnerId) {
+          // Partner-owned agent: membership in the partner is enough at write
+          // time — which orgs the user can actually see is enforced per run
+          // org at notification time by resolveRecipientUserIds.
+          for (const member of await activePartnerMembers(partnerId, { userIds })) {
+            validUsers.add(member.userId);
+          }
+        }
+      }
+
+      if (roleIds.length > 0) {
+        const roleRows = await db
+          .select({
+            id: roles.id,
+            partnerId: roles.partnerId,
+            orgId: roles.orgId,
+            isSystem: roles.isSystem,
+          })
+          .from(roles)
+          .where(inArray(roles.id, roleIds));
+        for (const role of roleRows) {
+          const visibleToOwner =
+            role.isSystem ||
+            (owner.orgId !== null && role.orgId === owner.orgId) ||
+            (partnerId !== null && role.partnerId === partnerId);
+          if (visibleToOwner) validRoles.add(role.id);
+        }
+      }
+
+      return { validUserIds: validUsers, validRoleIds: validRoles };
+    }),
+  );
+
+  const invalidUserIds = userIds.filter((id) => !validUserIds.has(id));
+  const invalidRoleIds = roleIds.filter((id) => !validRoleIds.has(id));
+  if (invalidUserIds.length > 0 || invalidRoleIds.length > 0) {
+    throw new InvalidAgentRecipientsError(invalidUserIds, invalidRoleIds);
+  }
+}
+
+/**
+ * Resolve the user ids to notify about a run/intent in `orgId`, from live
+ * membership. Explicit userIds are kept only while currently active with
+ * access to the org (direct member, or partner user of the org's owning
+ * partner whose orgAccess covers it); roleIds expand to the users currently
+ * holding the role with the same access rule; union, dedupe. Stale entries
+ * drop silently — see the module header.
+ */
+export async function resolveRecipientUserIds(
+  agent: {
+    orgId: string | null;
+    partnerId: string | null;
+    recipients: Partial<AiAgentRecipients>;
+  },
+  orgId: string,
+): Promise<string[]> {
+  const userIds = [...new Set(agent.recipients.userIds ?? [])];
+  const roleIds = [...new Set(agent.recipients.roleIds ?? [])];
+  if (userIds.length === 0 && roleIds.length === 0) return [];
+
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const resolved = new Set<string>();
+
+      // Always keyed by the RUN org's owning partner, not the agent's owner:
+      // access to the org whose data the notification describes is what
+      // qualifies a recipient.
+      const [org] = await db
+        .select({ partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(eq(organizations.id, orgId))
+        .limit(1);
+      const partnerId = org?.partnerId ?? null;
+
+      if (userIds.length > 0) {
+        for (const userId of await activeOrgMembers(orgId, { userIds })) {
+          resolved.add(userId);
+        }
+        if (partnerId) {
+          for (const member of await activePartnerMembers(partnerId, { userIds })) {
+            if (coversOrg(member, orgId)) resolved.add(member.userId);
+          }
+        }
+      }
+
+      if (roleIds.length > 0) {
+        for (const userId of await activeOrgMembers(orgId, { roleIds })) {
+          resolved.add(userId);
+        }
+        if (partnerId) {
+          for (const member of await activePartnerMembers(partnerId, { roleIds })) {
+            if (coversOrg(member, orgId)) resolved.add(member.userId);
+          }
+        }
+      }
+
+      return [...resolved];
+    }),
+  );
+}

--- a/apps/api/src/services/aiGuardrails.agentPrincipal.contract.test.ts
+++ b/apps/api/src/services/aiGuardrails.agentPrincipal.contract.test.ts
@@ -28,7 +28,69 @@ const EMPTY = {
     deviceTags: [],
   },
   deviceSiteId: 'site-a',
+  deviceId: 'dev-1',
 } satisfies AgentGuardrailPolicy;
+
+const policyWith = (
+  overrides: Partial<AgentGuardrailPolicy>,
+): AgentGuardrailPolicy => ({ ...EMPTY, ...overrides });
+
+describe('disposition (wave 3b tri-state)', () => {
+  beforeEach(() => {
+    vi.stubEnv('BREEZE_AI_AGENTS_ENABLED', 'true');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('shadow + mutating + allowlisted => propose, not deny', () => {
+    const check = checkAgentGuardrails('manage_services',
+      { deviceId: 'dev-1', action: 'restart', serviceName: 'spooler' },
+      policyWith({ mode: 'shadow', toolAllowlist: ['manage_services:restart'] }));
+    expect(check.disposition).toBe('propose');
+    expect(check.allowed).toBe(false); // propose NEVER executes
+  });
+
+  it('shadow + mutating + NOT allowlisted => deny (ordering: allowlist beats propose)', () => {
+    const check = checkAgentGuardrails('manage_services',
+      { deviceId: 'dev-1', action: 'restart', serviceName: 'spooler' },
+      policyWith({ mode: 'shadow', toolAllowlist: [] }));
+    expect(check.disposition).toBe('deny');
+  });
+
+  it('shadow + mutating + protected resource => deny even when allowlisted', () => {
+    const check = checkAgentGuardrails('manage_services',
+      { deviceId: 'dev-1', action: 'stop', serviceName: 'backup-agent' },
+      policyWith({
+        mode: 'shadow',
+        toolAllowlist: ['manage_services:stop'],
+        protectedResources: { services: ['backup-agent'], paths: [], registryKeys: [], deviceTags: [] },
+      }));
+    expect(check.disposition).toBe('deny');
+  });
+
+  it('read-only tool in shadow => allow', () => {
+    const check = checkAgentGuardrails('get_device_details', { deviceId: 'dev-1' },
+      policyWith({ mode: 'shadow' }));
+    expect(check.disposition).toBe('allow');
+    expect(check.allowed).toBe(true);
+  });
+
+  it('device-less run cannot propose a mutation', () => {
+    const check = checkAgentGuardrails('manage_services',
+      { deviceId: 'dev-1', action: 'restart', serviceName: 'spooler' },
+      policyWith({ mode: 'shadow', toolAllowlist: ['manage_services:restart'], deviceId: null }));
+    expect(check.disposition).toBe('deny');
+    expect(check.reason).toMatch(/device-bound/);
+  });
+
+  it('every deny keeps disposition deny (kill switch case)', () => {
+    vi.stubEnv('BREEZE_AI_AGENTS_ENABLED', 'false');
+    const check = checkAgentGuardrails('get_device_details', {}, policyWith({}));
+    expect(check.disposition).toBe('deny');
+  });
+});
 
 /**
  * Every tool an agent may call with NO allowlist entry. Deliberately a literal:

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -1190,6 +1190,15 @@ export type GuardrailCheck =
       approvalScope: AiApprovalScope;
     });
 
+export type GuardrailDisposition = 'allow' | 'propose' | 'deny';
+
+/**
+ * checkAgentGuardrails' verdict. `allowed` stays false for 'propose' on
+ * purpose: a consumer that only reads `allowed` (every pre-3b consumer)
+ * fails CLOSED rather than executing a proposal.
+ */
+export type AgentGuardrailCheck = GuardrailCheck & { disposition: GuardrailDisposition };
+
 /**
  * Check guardrails for a tool invocation.
  * Returns the effective tier and whether approval is needed.
@@ -1301,6 +1310,14 @@ export interface AgentGuardrailPolicy {
   protectedResources: AiAgentProtectedResources;
   /** Resolved from the run device, not from caller-controlled tool input. */
   deviceSiteId?: string | null;
+  /**
+   * The run's device id, resolved from the run row (never from tool input).
+   * null = device-less run. A device-less run skips the site gate entirely
+   * (buildAgentAuthContext only pins allowedSiteIds when a device exists), so
+   * mutating tools are denied outright for it — there is no site scope to
+   * bound the blast radius.
+   */
+  deviceId: string | null;
 }
 
 const SERVICE_INPUT_KEYS = ['serviceName', 'service', 'name'];
@@ -1476,6 +1493,7 @@ function isAgentGuardrailPolicy(
 ): policy is AgentGuardrailPolicy {
   if (!policy || !Array.isArray(policy.toolAllowlist)) return false;
   if (typeof policy.enabled !== 'boolean') return false;
+  if (policy.deviceId !== null && typeof policy.deviceId !== 'string') return false;
   if (policy.mode !== 'off' && policy.mode !== 'shadow' && policy.mode !== 'act') return false;
   if (!policy.toolAllowlist.every((toolName) => typeof toolName === 'string')) return false;
 
@@ -1521,10 +1539,10 @@ export function checkAgentGuardrails(
   toolName: string,
   input: Record<string, unknown>,
   policy: AgentGuardrailPolicy | null | undefined,
-): GuardrailCheck {
+): AgentGuardrailCheck {
   const base = checkGuardrails(toolName, input);
-  const deny = (reason: string): GuardrailCheck =>
-    ({ ...base, allowed: false, requiresApproval: false, reason });
+  const deny = (reason: string): AgentGuardrailCheck =>
+    ({ ...base, allowed: false, requiresApproval: false, disposition: 'deny', reason });
 
   // envFlag reads process.env at CALL time and shares its normalization with
   // config/env, so the two readers of this flag cannot disagree (a module-level
@@ -1569,10 +1587,14 @@ export function checkAgentGuardrails(
   const readOnly = base.tier === 1
     || (base.tier === 2 && (base.readOnly === true || TIER2_READONLY_TOOLS.has(toolName)));
 
-  // shadow mode proposes; it never mutates. Read-only tools stay available.
-  if (policy.mode === 'shadow' && !readOnly) {
-    return deny(`Tool "${toolName}" mutates; the agent is in shadow mode`);
+  // A device-less run has no site scope (buildAgentAuthContext pins
+  // allowedSiteIds only when a device exists), so a mutation from it would be
+  // org-wide. Deny rather than propose: a human approving it could not see
+  // what it is bounded to.
+  if (!readOnly && policy.deviceId === null) {
+    return deny(`Tool "${toolName}" mutates and the run is not device-bound`);
   }
+
   const allowlisted = policy.toolAllowlist.includes(toolName)
     || (action !== undefined && policy.toolAllowlist.includes(`${toolName}:${action}`));
   if (!readOnly && !allowlisted) {
@@ -1582,7 +1604,21 @@ export function checkAgentGuardrails(
   const protectedHit = touchesProtected(input, policy.protectedResources);
   if (protectedHit) return deny(`Denied: ${protectedHit}`);
 
-  return base;
+  // Shadow proposes; it never mutates — and this branch now sits AFTER the
+  // allowlist and protected checks so 'propose' is only reachable for a call
+  // the agent could legitimately make. allowed:false is load-bearing (see
+  // AgentGuardrailCheck).
+  if (policy.mode === 'shadow' && !readOnly) {
+    return {
+      ...base,
+      allowed: false,
+      requiresApproval: false,
+      disposition: 'propose',
+      reason: `Tool "${toolName}" mutates; shadow mode records a proposal instead of executing`,
+    };
+  }
+
+  return { ...base, disposition: 'allow' };
 }
 
 /**
@@ -1648,6 +1684,72 @@ export async function checkPermissionRequirements(
   return null;
 }
 
+type ToolPermissionRequirement = { resource: string; action: string };
+
+type ToolPermissionResolution =
+  | { ok: true; requirements: ToolPermissionRequirement[] }
+  | { ok: false; denial: string };
+
+function resolveToolPermissionRequirements(
+  toolName: string,
+  input: Record<string, unknown>,
+): ToolPermissionResolution {
+  const permDef = TOOL_PERMISSIONS[toolName];
+  if (!permDef) {
+    return { ok: false, denial: `No RBAC permission mapping for tool "${toolName}"` };
+  }
+
+  // Resolve the required permission (may be action-dependent)
+  let required: ToolPermissionRequirement;
+  const action = input.action as string | undefined;
+
+  if ('resource' in permDef && 'action' in permDef) {
+    required = permDef as ToolPermissionRequirement;
+  } else if (action && (permDef as Record<string, ToolPermissionRequirement>)[action]) {
+    required = (permDef as Record<string, ToolPermissionRequirement>)[action]!;
+  } else if (action) {
+    // Unknown action for a mapped tool — deny (fail-closed)
+    // Include redirect hints for tools that have been replaced by policy-based management
+    const redirectHints: Record<string, string> = {
+      manage_service_monitors: 'To add, update, or remove monitoring watches, use manage_policy_feature_link with the existing policy\'s featureLinkId and action "update". First call get_configuration_policy to find the monitoring featureLinkId and current inlineSettings.watches array, then update it with the new watch appended.',
+    };
+    const hint = redirectHints[toolName];
+    return {
+      ok: false,
+      denial: `Unknown action "${action}" for tool "${toolName}".${hint ? ` ${hint}` : ''}`,
+    };
+  } else {
+    // Action-multiplexed tool invoked without an `action` arg — deny (fail-closed).
+    // Each sub-operation has its own RBAC permission; without an action we can't
+    // resolve which one applies, so allowing here would let any caller bypass
+    // per-action checks. Zod schemas require `action` anyway; this is defense in depth.
+    return {
+      ok: false,
+      denial: `Missing required "action" argument for tool "${toolName}"`,
+    };
+  }
+
+  return {
+    ok: true,
+    requirements: [required, ...(TOOL_EXTRA_PERMISSIONS[toolName] ?? [])],
+  };
+}
+
+/**
+ * The RBAC requirements a HUMAN needs for this tool call. Used by wave-3b
+ * approver eligibility (a human approving an agent proposal must hold what
+ * they would need to do it themselves). Returns null when the tool has no
+ * mapping — callers must treat null as "nobody is eligible", mirroring
+ * checkToolPermission's deny.
+ */
+export function requiredPermissionsForTool(
+  toolName: string,
+  input: Record<string, unknown>,
+): Array<{ resource: string; action: string }> | null {
+  const resolution = resolveToolPermissionRequirements(toolName, input);
+  return resolution.ok ? resolution.requirements : null;
+}
+
 /**
  * Check RBAC permissions for a tool invocation.
  * Returns null if allowed, or an error message if denied.
@@ -1673,40 +1775,13 @@ export async function checkToolPermission(
   }
   if (auth.token.roleId === null) return null;
 
-  const permDef = TOOL_PERMISSIONS[toolName];
-  if (!permDef) return `No RBAC permission mapping for tool "${toolName}"`;
-
-  // Resolve the required permission (may be action-dependent)
-  let required: { resource: string; action: string };
-  const action = input.action as string | undefined;
-
-  if ('resource' in permDef && 'action' in permDef) {
-    required = permDef as { resource: string; action: string };
-  } else if (action && (permDef as Record<string, { resource: string; action: string }>)[action]) {
-    required = (permDef as Record<string, { resource: string; action: string }>)[action]!;
-  } else if (action) {
-    // Unknown action for a mapped tool — deny (fail-closed)
-    // Include redirect hints for tools that have been replaced by policy-based management
-    const redirectHints: Record<string, string> = {
-      manage_service_monitors: 'To add, update, or remove monitoring watches, use manage_policy_feature_link with the existing policy\'s featureLinkId and action "update". First call get_configuration_policy to find the monitoring featureLinkId and current inlineSettings.watches array, then update it with the new watch appended.',
-    };
-    const hint = redirectHints[toolName];
-    return `Unknown action "${action}" for tool "${toolName}".${hint ? ` ${hint}` : ''}`;
-  } else {
-    // Action-multiplexed tool invoked without an `action` arg — deny (fail-closed).
-    // Each sub-operation has its own RBAC permission; without an action we can't
-    // resolve which one applies, so allowing here would let any caller bypass
-    // per-action checks. Zod schemas require `action` anyway; this is defense in depth.
-    return `Missing required "action" argument for tool "${toolName}"`;
-  }
+  const resolution = resolveToolPermissionRequirements(toolName, input);
+  if (!resolution.ok) return resolution.denial;
 
   // One getUserPermissions resolution covers the base requirement and every
   // extra permission; denials keep the same first-failure ordering as the
   // old per-requirement loop.
-  return checkPermissionRequirements(auth, [
-    required,
-    ...(TOOL_EXTRA_PERMISSIONS[toolName] ?? []),
-  ]);
+  return checkPermissionRequirements(auth, resolution.requirements);
 }
 
 /**

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -421,6 +421,78 @@ describe('command queue service', () => {
     expect(result).toEqual({ ...completed.result, commandId: completed.id });
   });
 
+  // Wave 3b (#3824): device_commands.created_by FK-references users(id), but
+  // synthetic principals (ai_agent auth carries the agent's ai_agents id as
+  // auth.user.id) reach executeCommand through the same tool handlers as
+  // humans. The chokepoint probes users once and degrades a non-user id to
+  // created_by NULL instead of aborting the dispatch with a 23503 AFTER the
+  // human approval already happened.
+  it('keeps created_by when the caller userId resolves to a real users row', async () => {
+    const device = { id: 'dev-2', status: 'online', orgId: 'org-1', hostname: 'host-a', agentId: null };
+    const completed = { id: 'cmd-user', status: 'completed', result: { status: 'completed' } };
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([device]) })
+        })
+      } as any)
+      // users existence probe — the id IS a users row.
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: 'user-1' }]) })
+        })
+      } as any)
+      .mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([completed]) })
+        })
+      } as any);
+
+    const insertValues = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 'cmd-user' }])
+    });
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+    const result = await executeCommand('dev-2', 'list_services', {}, { userId: 'user-1' });
+
+    expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ createdBy: 'user-1' }));
+    expect(result.status).toBe('completed');
+  });
+
+  it('nulls created_by when the caller userId is not a users row (synthetic ai_agent id)', async () => {
+    const device = { id: 'dev-2', status: 'online', orgId: 'org-1', hostname: 'host-a', agentId: null };
+    const completed = { id: 'cmd-agent', status: 'completed', result: { status: 'completed' } };
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([device]) })
+        })
+      } as any)
+      // users existence probe — no row: the id is an ai_agents id, not a user.
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) })
+        })
+      } as any)
+      .mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([completed]) })
+        })
+      } as any);
+
+    const insertValues = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 'cmd-agent' }])
+    });
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+    const result = await executeCommand('dev-2', 'list_services', {}, { userId: 'agent-synthetic-1' });
+
+    expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ createdBy: null }));
+    expect(result.status).toBe('completed');
+  });
+
   // #3112: the agent's helper-IPC path bounded its own wait with a hardcoded
   // per-attempt timeout, so `timeoutMs` governed only how long the SERVER waited
   // while the device gave up underneath on its own schedule. The budget now

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -1,6 +1,6 @@
 import { eq, and, inArray } from 'drizzle-orm';
 import { db, runOutsideDbContext, withDbAccessContext, withSystemDbAccessContext } from '../db';
-import { deviceCommands, devices, auditLogs } from '../db/schema';
+import { deviceCommands, devices, auditLogs, users } from '../db/schema';
 import { sendCommandToAgent, isAgentConnected } from '../routes/agentWs';
 import { captureException } from './sentry';
 import { recordBackupCommandTimeout, recordRestoreTimeout } from './backupMetrics';
@@ -858,9 +858,36 @@ export async function executeCommand(
   //    INSERT commits immediately and is visible to the WS handler.
   return runOutsideDbContextSafe(async () => {
     // Validate userId for FK constraint: device_commands.created_by references users.id.
-    // Helper sessions use a synthetic auth where auth.user.id is actually the device ID
-    // (no real user record exists). Detect this by checking if userId equals deviceId.
-    const safeUserId = userId && userId !== deviceId ? userId : null;
+    // Two synthetic-auth classes reach here with a userId that is NOT a users row:
+    //  - Helper sessions: auth.user.id is actually the device ID (detected by
+    //    the equality check below — no DB read needed).
+    //  - ai_agent principals (wave 3b, #3824): auth.user.id is the agent's
+    //    ai_agents id. The intent release worker executes approved agent
+    //    intents through the same tool handlers every human path uses, and
+    //    they all pass auth.user.id verbatim — before this probe, the first
+    //    agent-released device command died on the created_by FK (23503)
+    //    AFTER approval, at execution time (caught by
+    //    agentIntentLifecycle.integration.test.ts).
+    // The handlers cannot cheaply know which ids resolve to users, so settle it
+    // here at executeCommand's own insert: one indexed PK probe per dispatch,
+    // and any id that is not a users row degrades to created_by NULL
+    // (attribution for agent commands lives on the intent/run —
+    // requesting_agent_run_id — not this column). NOTE for PR 3c: queueCommand/
+    // queueCommandForExecution is a SIBLING insert site with the same verbatim
+    // created_by stamp; tools that dispatch through it (hyperv, backup, vault,
+    // mssql, incident, agent-logs) will need the same treatment before the
+    // runner releases agent intents for them.
+    const candidateUserId = userId && userId !== deviceId ? userId : null;
+    const safeUserId = candidateUserId
+      ? await withSystemDbAccessContext(async () => {
+          const [userRow] = await db
+            .select({ id: users.id })
+            .from(users)
+            .where(eq(users.id, candidateUserId))
+            .limit(1);
+          return userRow ? candidateUserId : null;
+        })
+      : null;
 
     // #3112: the caller's budget has to travel WITH the command, not merely bound
     // the server-side wait below. The agent's helper-IPC path used a hardcoded

--- a/apps/web/src/components/approvals/ApprovalsInbox.test.tsx
+++ b/apps/web/src/components/approvals/ApprovalsInbox.test.tsx
@@ -49,6 +49,8 @@ const pendingApproval = {
   approvalScope: 'four_eyes',
   isRecursive: false,
   createdAt: '2026-08-23T12:00:00.000Z',
+  origin: 'human',
+  agentName: null,
 };
 
 beforeEach(() => {
@@ -71,6 +73,64 @@ describe('ApprovalsInbox', () => {
     expect(row).toHaveTextContent('Restart accounting server');
     expect(row).toHaveTextContent('Helpdesk Copilot');
     expect(row).toHaveTextContent(/high/i);
+  });
+
+  it('marks an agent-originated approval with the agent badge and attribution', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        approvals: [
+          {
+            ...pendingApproval,
+            id: 'approval-agent',
+            intentId: 'intent-agent',
+            origin: 'ai_agent',
+            agentName: 'Triage',
+          },
+        ],
+        nextCursor: null,
+      }),
+    );
+
+    render(<ApprovalsInbox />);
+
+    const row = await screen.findByTestId('approval-row-approval-agent');
+    expect(
+      screen.getByTestId('approval-agent-badge-approval-agent'),
+    ).toBeInTheDocument();
+    expect(row).toHaveTextContent('Proposed by Triage (AI agent)');
+    expect(row).not.toHaveTextContent('Requested by');
+  });
+
+  it('falls back to the requesting client label when the agent name is missing', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        approvals: [
+          {
+            ...pendingApproval,
+            id: 'approval-agent-2',
+            intentId: 'intent-agent-2',
+            origin: 'ai_agent',
+            agentName: null,
+          },
+        ],
+        nextCursor: null,
+      }),
+    );
+
+    render(<ApprovalsInbox />);
+
+    const row = await screen.findByTestId('approval-row-approval-agent-2');
+    expect(row).toHaveTextContent('Proposed by Helpdesk Copilot (AI agent)');
+  });
+
+  it('keeps human attribution and shows no agent badge on human rows', async () => {
+    render(<ApprovalsInbox />);
+
+    const row = await screen.findByTestId('approval-row-approval-1');
+    expect(row).toHaveTextContent('Requested by Helpdesk Copilot');
+    expect(
+      screen.queryByTestId('approval-agent-badge-approval-1'),
+    ).not.toBeInTheDocument();
   });
 
   it('shows a load error and never misrepresents it as an empty inbox', async () => {

--- a/apps/web/src/components/approvals/ApprovalsInbox.tsx
+++ b/apps/web/src/components/approvals/ApprovalsInbox.tsx
@@ -1,6 +1,6 @@
 import '@/lib/i18n';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AlertTriangle, Check, Loader2, ShieldCheck, X } from 'lucide-react';
+import { AlertTriangle, Bot, Check, Loader2, ShieldCheck, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useEventStream } from '@/hooks/useEventStream';
 import {
@@ -51,6 +51,10 @@ interface PendingApproval {
   approvalScope: string | null;
   isRecursive: boolean;
   createdAt: string;
+  /** Wave 3b: who proposed this intent. Serialize emits it on every row;
+   *  anything but 'ai_agent' renders the classic requester attribution. */
+  origin: 'human' | 'ai_agent';
+  agentName: string | null;
 }
 
 const riskClass: Record<RiskTier, string> = {
@@ -308,7 +312,22 @@ export default function ApprovalsInbox() {
                       </span>
                     </div>
                     <p className="mt-1 text-sm text-muted-foreground">
-                      {t('requestedBy', { client: approval.requestingClientLabel })}
+                      {approval.origin === 'ai_agent' ? (
+                        <>
+                          {/* Purple Bot badge matches NotificationCenter's `ai` typeConfig. */}
+                          <span
+                            className="mr-1.5 inline-flex items-center rounded-full bg-purple-100 px-1.5 py-0.5 align-middle text-purple-700 dark:bg-purple-900/40 dark:text-purple-200"
+                            data-testid={`approval-agent-badge-${approval.id}`}
+                          >
+                            <Bot className="h-3.5 w-3.5" aria-hidden="true" />
+                          </span>
+                          {t('proposedByAgent', {
+                            agent: approval.agentName ?? approval.requestingClientLabel,
+                          })}
+                        </>
+                      ) : (
+                        t('requestedBy', { client: approval.requestingClientLabel })
+                      )}
                       <span aria-hidden="true"> &middot; </span>
                       {formatRelativeTime(new Date(approval.createdAt))}
                       <span aria-hidden="true"> &middot; </span>

--- a/apps/web/src/locales/de-DE/approvals.json
+++ b/apps/web/src/locales/de-DE/approvals.json
@@ -9,6 +9,7 @@
     "description": "Neue Anfragen erscheinen hier, sobald Ihre Entscheidung erforderlich ist."
   },
   "requestedBy": "Angefordert von {{client}}",
+  "proposedByAgent": "Vorgeschlagen von {{agent}} (KI-Agent)",
   "risk": {
     "low": "Niedriges Risiko",
     "medium": "Mittleres Risiko",

--- a/apps/web/src/locales/en/approvals.json
+++ b/apps/web/src/locales/en/approvals.json
@@ -9,6 +9,7 @@
     "description": "New requests will appear here when your decision is needed."
   },
   "requestedBy": "Requested by {{client}}",
+  "proposedByAgent": "Proposed by {{agent}} (AI agent)",
   "risk": {
     "low": "Low risk",
     "medium": "Medium risk",

--- a/apps/web/src/locales/es-419/approvals.json
+++ b/apps/web/src/locales/es-419/approvals.json
@@ -9,6 +9,7 @@
     "description": "Las nuevas solicitudes aparecerán aquí cuando se necesite tu decisión."
   },
   "requestedBy": "Solicitado por {{client}}",
+  "proposedByAgent": "Propuesto por {{agent}} (agente de IA)",
   "risk": {
     "low": "Riesgo bajo",
     "medium": "Riesgo medio",

--- a/apps/web/src/locales/fr-CA/approvals.json
+++ b/apps/web/src/locales/fr-CA/approvals.json
@@ -9,6 +9,7 @@
     "description": "Les nouvelles demandes s’afficheront ici lorsqu’une décision sera requise."
   },
   "requestedBy": "Demandé par {{client}}",
+  "proposedByAgent": "Proposé par {{agent}} (agent d’IA)",
   "risk": {
     "low": "Risque faible",
     "medium": "Risque moyen",

--- a/apps/web/src/locales/fr-FR/approvals.json
+++ b/apps/web/src/locales/fr-FR/approvals.json
@@ -9,6 +9,7 @@
     "description": "Les nouvelles demandes apparaîtront ici lorsqu’une décision sera requise."
   },
   "requestedBy": "Demandé par {{client}}",
+  "proposedByAgent": "Proposé par {{agent}} (agent d’IA)",
   "risk": {
     "low": "Risque faible",
     "medium": "Risque moyen",

--- a/apps/web/src/locales/it-IT/approvals.json
+++ b/apps/web/src/locales/it-IT/approvals.json
@@ -9,6 +9,7 @@
     "description": "Le nuove richieste appariranno qui quando servirà la tua decisione."
   },
   "requestedBy": "Richiesto da {{client}}",
+  "proposedByAgent": "Proposto da {{agent}} (agente IA)",
   "risk": {
     "low": "Rischio basso",
     "medium": "Rischio medio",

--- a/apps/web/src/locales/pt-BR/approvals.json
+++ b/apps/web/src/locales/pt-BR/approvals.json
@@ -9,6 +9,7 @@
     "description": "Novas solicitações aparecerão aqui quando sua decisão for necessária."
   },
   "requestedBy": "Solicitado por {{client}}",
+  "proposedByAgent": "Proposto por {{agent}} (agente de IA)",
   "risk": {
     "low": "Risco baixo",
     "medium": "Risco médio",

--- a/apps/web/src/locales/tr-TR/approvals.json
+++ b/apps/web/src/locales/tr-TR/approvals.json
@@ -9,6 +9,7 @@
     "description": "Kararınız gerektiğinde yeni istekler burada görünür."
   },
   "requestedBy": "İsteyen: {{client}}",
+  "proposedByAgent": "{{agent}} tarafından önerildi (yapay zeka temsilcisi)",
   "risk": {
     "low": "Düşük risk",
     "medium": "Orta risk",


### PR DESCRIPTION
Second of four PRs for AI agents wave 3 (#3824). Builds on the 3a schema
(#3893) and the wave-2 inbox (#3877). Still inert in production: the kill
switch defaults off and no runner exists until 3c — but the machinery is now
real: an ai_agent principal can create a requester-less intent, an
action-and-target-eligible human decides it in /approvals, and release
re-derives authority from the run snapshot AND the agent's current policy.

## Owner decisions implemented (2026-08-23)
- Device moves: agent history stays with the source org (runs org-immutable,
  device link severed).
- Cancel on agent intents = any approvals:decide holder, pinned by test.
- recipients membership validation shipped here, before first read.

## Deviation from the wave plan
The tri-state guardrail verdict (allow/propose/deny) moved from 3c into this
PR — create, decide-eligibility and release all consume it, and duplicating
the allowlist/protected/site logic three times was the alternative. 3c
consumes the verdict.

## Security invariants preserved (each pinned by test)
- checkToolPermission still denies ai_agent unconditionally.
- Secret-bearing tools cannot become agent intents.
- propose never executes (allowed:false).
- Agent intents never skip the assurance ladder; decide is user_session-only.
- recipients never influence approver eligibility.

Refs #3824

🤖 Generated with [Claude Code](https://claude.com/claude-code)