### PR TITLE
fix(deps): repair broken pnpm-lock.yaml (duplicated hono key reddens every CI job)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8240,10 +8240,6 @@ packages:
     resolution: {integrity: sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.13.3:
-    resolution: {integrity: sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==}
-    engines: {node: '>=16.9.0'}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -20228,8 +20224,6 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
-
-  hono@4.13.3: {}
 
   hono@4.13.3: {}
 


### PR DESCRIPTION
## main is currently red on every job

`38d11a7ab` fails with:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "pnpm-lock.yaml" is broken: duplicated mapping key (8243:3)
```

Because `pnpm install --frozen-lockfile` is the first step of every job, **all 17 jobs fail** — Lint, Type Check, every `Test *`, Check Migrations, Security Audit, CI Success. Nothing merged after this point gets meaningful CI.

## Cause

Today's dependabot merge sweep. #3942 bumped hono to 4.13.3, and git's textual merge of `pnpm-lock.yaml` against a sibling dependabot branch **appended a second byte-identical block instead of conflicting**. Every one of those PRs was green on its own head — the corruption exists only in the merge result, which is the classic "green PR reddens main" shape from CLAUDE.md, via the lockfile rather than a stale base.

## Fix

Pure dedupe, 6 lines deleted:

- `packages:` — duplicate `hono@4.13.3` (resolution + engines)
- `snapshots:` — duplicate `hono@4.13.3: {}`

Both removed blocks were asserted **byte-identical** to the ones kept before deleting, so no resolution, integrity hash, or transitive version changes. I deliberately did **not** regenerate the lockfile — that would have risked unrelated transitive drift while main is already broken.

## Verification

`pnpm install --frozen-lockfile` — the exact CI command — **fails on `main`, succeeds on this branch** (Done in 43.7s).

Note the first repair attempt was incomplete: my initial duplicate scan missed the `snapshots:` twin because that entry carries an inline value (`: {}`) and my key regex required a line-terminating colon. `pnpm` itself caught it, and the scan was rewritten to handle inline-value and quoted keys before re-verifying. Scanning the full file with the corrected matcher now reports **zero** duplicate keys in any section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)