### PR TITLE
fix(agent): force a desktop repaint before the remote-desktop startup probe (#3951)

### DIFF
--- a/agent/internal/remote/desktop/desktop_repaint_other.go
+++ b/agent/internal/remote/desktop/desktop_repaint_other.go
@@ -8,3 +8,8 @@ func forceDesktopRepaint() {}
 
 // nudgeSecureDesktop is a no-op on non-Windows platforms.
 func nudgeSecureDesktop() {}
+
+// forceProbeRepaint is a no-op on non-Windows platforms.
+// macOS CGDisplayStream / Linux X11 capture return a frame for an idle desktop,
+// so the startup probe has nothing to shake loose.
+func forceProbeRepaint() {}

--- a/agent/internal/remote/desktop/desktop_repaint_other.go
+++ b/agent/internal/remote/desktop/desktop_repaint_other.go
@@ -9,7 +9,9 @@ func forceDesktopRepaint() {}
 // nudgeSecureDesktop is a no-op on non-Windows platforms.
 func nudgeSecureDesktop() {}
 
-// forceProbeRepaint is a no-op on non-Windows platforms.
-// macOS CGDisplayStream / Linux X11 capture return a frame for an idle desktop,
-// so the startup probe has nothing to shake loose.
-func forceProbeRepaint() {}
+// newProbeRepainter is a no-op on non-Windows platforms: macOS CGDisplayStream
+// and Linux X11 capture return a frame for an idle desktop, so the startup
+// probe has nothing to shake loose and no thread desktop to attach to.
+func newProbeRepainter() (repaint func(), release func()) {
+	return func() {}, func() {}
+}

--- a/agent/internal/remote/desktop/desktop_repaint_windows.go
+++ b/agent/internal/remote/desktop/desktop_repaint_windows.go
@@ -4,6 +4,7 @@ package desktop
 
 import (
 	"log/slog"
+	"runtime"
 	"unsafe"
 )
 
@@ -59,4 +60,25 @@ func nudgeSecureDesktop() {
 	if ret != uintptr(len(nudges)) {
 		slog.Debug("nudgeSecureDesktop: SendInput did not inject full nudge sequence", "sent", ret)
 	}
+}
+
+// forceProbeRepaint shakes a frame out of an idle desktop for the startup
+// capture probe (see probeCapture). It runs the same warm-up pair the capture
+// loop uses on a static display — nudgeSecureDesktop followed by
+// forceDesktopRepaint (session_capture.go). Both are needed: InvalidateRect has
+// no HWND to target on a windowless desktop, and the SendInput jiggle is what
+// makes the DWM compositor produce dirty rects there.
+//
+// It pins and re-attaches the calling thread to the input desktop first.
+// Unlike the capture loop, the probe does not run on a prepareCaptureThread
+// goroutine: newPlatformCapturer releases its OS-thread lock once DXGI is
+// initialized, so Go may have migrated StartSession onto a thread that is not
+// on the input desktop — and SendInput, InvalidateRect and RedrawWindow all
+// act on the calling thread's desktop.
+func forceProbeRepaint() {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	switchThreadToInputDesktop()
+	nudgeSecureDesktop()
+	forceDesktopRepaint()
 }

--- a/agent/internal/remote/desktop/desktop_repaint_windows.go
+++ b/agent/internal/remote/desktop/desktop_repaint_windows.go
@@ -62,23 +62,30 @@ func nudgeSecureDesktop() {
 	}
 }
 
-// forceProbeRepaint shakes a frame out of an idle desktop for the startup
-// capture probe (see probeCapture). It runs the same warm-up pair the capture
-// loop uses on a static display — nudgeSecureDesktop followed by
-// forceDesktopRepaint (session_capture.go). Both are needed: InvalidateRect has
-// no HWND to target on a windowless desktop, and the SendInput jiggle is what
-// makes the DWM compositor produce dirty rects there.
+// newProbeRepainter returns the repaint callback for the startup capture probe
+// (see probeCapture) plus a release func the caller MUST invoke once the probe
+// returns — on the failure path too.
 //
-// It pins and re-attaches the calling thread to the input desktop first.
-// Unlike the capture loop, the probe does not run on a prepareCaptureThread
-// goroutine: newPlatformCapturer releases its OS-thread lock once DXGI is
-// initialized, so Go may have migrated StartSession onto a thread that is not
-// on the input desktop — and SendInput, InvalidateRect and RedrawWindow all
-// act on the calling thread's desktop.
-func forceProbeRepaint() {
+// The repaint itself is the same warm-up pair the capture loop uses on a static
+// display: nudgeSecureDesktop followed by forceDesktopRepaint (session_capture.go).
+// Both are needed — InvalidateRect has no HWND to target on a windowless
+// desktop, and the SendInput jiggle is what makes the DWM compositor emit dirty
+// rects there.
+//
+// The thread is pinned and attached to the input desktop ONCE, around the whole
+// probe rather than per attempt, for two reasons. First, SendInput,
+// InvalidateRect and RedrawWindow all act on the *calling thread's* desktop, and
+// unlike the capture loop the probe does not run on a prepareCaptureThread
+// goroutine — newPlatformCapturer releases its OS-thread lock once initDXGI
+// succeeds, so Go may have migrated StartSession onto a thread that is not on
+// the input desktop. Second, switchThreadToInputDesktop deliberately leaves its
+// HDESK open (closing it would detach the thread), so calling it per attempt
+// would leak one desktop handle per attempt.
+func newProbeRepainter() (repaint func(), release func()) {
 	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 	switchThreadToInputDesktop()
-	nudgeSecureDesktop()
-	forceDesktopRepaint()
+	return func() {
+		nudgeSecureDesktop()
+		forceDesktopRepaint()
+	}, runtime.UnlockOSThread
 }

--- a/agent/internal/remote/desktop/probe.go
+++ b/agent/internal/remote/desktop/probe.go
@@ -3,6 +3,7 @@ package desktop
 import (
 	"fmt"
 	"image"
+	"log/slog"
 	"time"
 )
 
@@ -13,18 +14,41 @@ import (
 // no input desktop) would otherwise start and stream black. Nil-frame results
 // are retried with a short delay to ride out secure-desktop transitions; a
 // hard error fails immediately.
-func probeCapture(capture func() (*image.RGBA, error), attempts int, delay time.Duration) (*image.RGBA, error) {
+//
+// repaint is invoked immediately before every capture attempt, including the
+// first. DXGI Desktop Duplication only hands back a frame when desktop content
+// *changes*, so a perfectly capturable but idle desktop answers
+// DXGI_ERROR_WAIT_TIMEOUT for the whole probe budget and the session aborts
+// with "no capturable desktop" even though nothing is wrong (#3951). The
+// streaming loop has always known this and forces a repaint in eleven places
+// in session_capture.go; the startup probe forced one in none. A nil repaint is
+// allowed for callers that have nothing to shake loose.
+//
+// The retry ceiling and the genuine-failure path are unchanged: a hard capture
+// error (device lost, no output, access denied) still aborts on the first
+// attempt with the underlying error.
+func probeCapture(capture func() (*image.RGBA, error), attempts int, delay time.Duration, repaint func()) (*image.RGBA, error) {
 	for i := 0; i < attempts; i++ {
 		if i > 0 {
 			time.Sleep(delay)
+		}
+		// Force a repaint before the capture, not after: RedrawWindow with
+		// RDW_UPDATENOW processes WM_PAINT synchronously, so the dirty rects
+		// are already queued for DXGI by the time AcquireNextFrame runs.
+		if repaint != nil {
+			repaint()
 		}
 		img, err := capture()
 		if err != nil {
 			return nil, err
 		}
 		if img != nil {
+			if i > 0 {
+				slog.Debug("Capture probe produced a frame after retry",
+					"attempt", i+1, "attempts", attempts)
+			}
 			return img, nil
 		}
 	}
-	return nil, fmt.Errorf("screen capture produced no frame after %d attempts (session may have no capturable desktop)", attempts)
+	return nil, fmt.Errorf("screen capture produced no frame after %d attempts with forced desktop repaints (session may have no capturable desktop)", attempts)
 }

--- a/agent/internal/remote/desktop/probe_test.go
+++ b/agent/internal/remote/desktop/probe_test.go
@@ -3,13 +3,14 @@ package desktop
 import (
 	"errors"
 	"image"
+	"slices"
 	"testing"
 	"time"
 )
 
 func TestProbeCaptureFirstFrame(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
-	got, err := probeCapture(func() (*image.RGBA, error) { return img, nil }, 3, time.Millisecond)
+	got, err := probeCapture(func() (*image.RGBA, error) { return img, nil }, 3, time.Millisecond, nil)
 	if err != nil || got != img {
 		t.Fatalf("got %v err %v", got, err)
 	}
@@ -24,14 +25,14 @@ func TestProbeCaptureRetriesNilFrame(t *testing.T) {
 			return nil, nil // GDI transient: no frame, no error
 		}
 		return img, nil
-	}, 5, time.Millisecond)
+	}, 5, time.Millisecond, nil)
 	if err != nil || got != img || calls != 3 {
 		t.Fatalf("got %v err %v calls %d", got, err, calls)
 	}
 }
 
 func TestProbeCaptureNilFrameExhausted(t *testing.T) {
-	got, err := probeCapture(func() (*image.RGBA, error) { return nil, nil }, 4, time.Millisecond)
+	got, err := probeCapture(func() (*image.RGBA, error) { return nil, nil }, 4, time.Millisecond, nil)
 	if got != nil || err == nil {
 		t.Fatalf("exhausted nil-frame probe must error, got %v err %v", got, err)
 	}
@@ -40,8 +41,118 @@ func TestProbeCaptureNilFrameExhausted(t *testing.T) {
 func TestProbeCaptureHardErrorImmediate(t *testing.T) {
 	sentinel := errors.New("boom")
 	calls := 0
-	_, err := probeCapture(func() (*image.RGBA, error) { calls++; return nil, sentinel }, 5, time.Millisecond)
+	_, err := probeCapture(func() (*image.RGBA, error) { calls++; return nil, sentinel }, 5, time.Millisecond, nil)
 	if !errors.Is(err, sentinel) || calls != 1 {
 		t.Fatalf("hard error must propagate on first call, err %v calls %d", err, calls)
+	}
+}
+
+// TestProbeCaptureNilRepaintIsSafe guards the non-Windows caller shape, where
+// forceProbeRepaint is a no-op and callers may pass nil outright.
+func TestProbeCaptureNilRepaintIsSafe(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	got, err := probeCapture(func() (*image.RGBA, error) { return img, nil }, 3, time.Millisecond, nil)
+	if err != nil || got != img {
+		t.Fatalf("nil repaint must not panic; got %v err %v", got, err)
+	}
+}
+
+// captureResult is one scripted (img, err) answer from the fake capturer.
+type captureResult struct {
+	img *image.RGBA
+	err error
+}
+
+// errExhaustedMarker stands in for "probeCapture should return its own
+// out-of-attempts error". That error is built with fmt.Errorf and wraps
+// nothing, so it can't be matched with errors.Is — the marker keeps the table
+// declarative.
+var errExhaustedMarker = errors.New("test marker: attempts exhausted")
+
+// TestProbeCaptureRepaintSequence pins the #3951 contract: the probe must force
+// a desktop repaint before *every* capture attempt, including the first,
+// because DXGI Desktop Duplication only yields a frame when desktop content
+// changes. The recorded event sequence is the assertion — a "capture" not
+// immediately preceded by a "repaint" is the bug this fixes. It also pins the
+// two behaviours the fix must NOT change: the retry ceiling, and a hard
+// capture error aborting immediately.
+func TestProbeCaptureRepaintSequence(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	deviceLost := errors.New("AcquireNextFrame: 0x887A0026")
+
+	tests := []struct {
+		name     string
+		attempts int
+		// results is consumed one per attempt; the last entry repeats.
+		results []captureResult
+		wantSeq []string
+		wantImg *image.RGBA
+		wantErr error
+	}{
+		{
+			name:     "frame on first attempt is still preceded by a repaint",
+			attempts: 5,
+			results:  []captureResult{{img, nil}},
+			wantSeq:  []string{"repaint", "capture"},
+			wantImg:  img,
+		},
+		{
+			name:     "idle desktop: a repaint precedes every retry until a frame lands",
+			attempts: 5,
+			results:  []captureResult{{nil, nil}, {nil, nil}, {img, nil}},
+			wantSeq:  []string{"repaint", "capture", "repaint", "capture", "repaint", "capture"},
+			wantImg:  img,
+		},
+		{
+			name:     "genuinely dead desktop: one repaint per attempt, ceiling unchanged",
+			attempts: 3,
+			results:  []captureResult{{nil, nil}},
+			wantSeq:  []string{"repaint", "capture", "repaint", "capture", "repaint", "capture"},
+			wantErr:  errExhaustedMarker,
+		},
+		{
+			name:     "hard capture error aborts after the first repaint+capture",
+			attempts: 5,
+			results:  []captureResult{{nil, deviceLost}},
+			wantSeq:  []string{"repaint", "capture"},
+			wantErr:  deviceLost,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var seq []string
+			attempt := 0
+			capture := func() (*image.RGBA, error) {
+				seq = append(seq, "capture")
+				r := tc.results[min(attempt, len(tc.results)-1)]
+				attempt++
+				return r.img, r.err
+			}
+			repaint := func() { seq = append(seq, "repaint") }
+
+			got, err := probeCapture(capture, tc.attempts, time.Millisecond, repaint)
+
+			if !slices.Equal(seq, tc.wantSeq) {
+				t.Errorf("event sequence = %v, want %v", seq, tc.wantSeq)
+			}
+			if got != tc.wantImg {
+				t.Errorf("img = %v, want %v", got, tc.wantImg)
+			}
+			switch {
+			case tc.wantErr == errExhaustedMarker:
+				if err == nil {
+					t.Errorf("want out-of-attempts error, got nil")
+				}
+			case tc.wantErr != nil:
+				if !errors.Is(err, tc.wantErr) {
+					t.Errorf("err = %v, want %v", err, tc.wantErr)
+				}
+			default:
+				if err != nil {
+					t.Errorf("unexpected err %v", err)
+				}
+			}
+		})
 	}
 }

--- a/agent/internal/remote/desktop/probe_test.go
+++ b/agent/internal/remote/desktop/probe_test.go
@@ -48,7 +48,7 @@ func TestProbeCaptureHardErrorImmediate(t *testing.T) {
 }
 
 // TestProbeCaptureNilRepaintIsSafe guards the non-Windows caller shape, where
-// forceProbeRepaint is a no-op and callers may pass nil outright.
+// newProbeRepainter returns a no-op, and any caller that passes nil outright.
 func TestProbeCaptureNilRepaintIsSafe(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
 	got, err := probeCapture(func() (*image.RGBA, error) { return img, nil }, 3, time.Millisecond, nil)

--- a/agent/internal/remote/desktop/session_webrtc.go
+++ b/agent/internal/remote/desktop/session_webrtc.go
@@ -265,11 +265,14 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 		return "", fmt.Errorf("failed to get screen bounds: %w", err)
 	}
 	probeStart := time.Now()
-	// forceProbeRepaint runs before every attempt: DXGI only produces a frame
-	// when desktop content changes, so an idle-but-healthy desktop would
-	// otherwise time out through the whole probe budget and abort the session
-	// (#3951). No-op on non-Windows.
-	probeImg, probeErr := probeCapture(capturer.Capture, 5, 200*time.Millisecond, forceProbeRepaint)
+	// repaintProbe runs before every attempt: DXGI only produces a frame when
+	// desktop content changes, so an idle-but-healthy desktop would otherwise
+	// time out through the whole probe budget and abort the session (#3951).
+	// releaseProbeThread is called unconditionally before the error check —
+	// the probe's OS-thread pin must not outlive the probe. No-op on non-Windows.
+	repaintProbe, releaseProbeThread := newProbeRepainter()
+	probeImg, probeErr := probeCapture(capturer.Capture, 5, 200*time.Millisecond, repaintProbe)
+	releaseProbeThread()
 	if probeErr != nil {
 		// The display is inaccessible (disconnected Windows session, no input
 		// desktop, GDI handle churn). Abort instead of returning a WebRTC

--- a/agent/internal/remote/desktop/session_webrtc.go
+++ b/agent/internal/remote/desktop/session_webrtc.go
@@ -265,7 +265,11 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 		return "", fmt.Errorf("failed to get screen bounds: %w", err)
 	}
 	probeStart := time.Now()
-	probeImg, probeErr := probeCapture(capturer.Capture, 5, 200*time.Millisecond)
+	// forceProbeRepaint runs before every attempt: DXGI only produces a frame
+	// when desktop content changes, so an idle-but-healthy desktop would
+	// otherwise time out through the whole probe budget and abort the session
+	// (#3951). No-op on non-Windows.
+	probeImg, probeErr := probeCapture(capturer.Capture, 5, 200*time.Millisecond, forceProbeRepaint)
 	if probeErr != nil {
 		// The display is inaccessible (disconnected Windows session, no input
 		// desktop, GDI handle churn). Abort instead of returning a WebRTC


### PR DESCRIPTION
## Root cause

The Windows Remote Desktop startup probe aborts healthy sessions on an **idle desktop**.

`StartSession` (`agent/internal/remote/desktop/session_webrtc.go:268`) creates a fresh DXGI duplication and immediately runs:

```go
probeCapture(capturer.Capture, 5, 200*time.Millisecond)
```

DXGI's `AcquireNextFrame` only delivers a frame when desktop content **changes**. On a static desktop it returns `DXGI_ERROR_WAIT_TIMEOUT`, which `dxgi_capture_windows.go` correctly maps to "no frame yet" — `(nil, nil)`. The probe treats a persistent `(nil, nil)` as proof the desktop is uncapturable. Five attempts × (50 ms acquire timeout + 200 ms sleep) is ~1.25 s of budget; if nothing repaints in that window the session dies before an SDP answer is ever created, with:

```
screen capture produced no frame after 5 attempts (session may have no capturable desktop)
```

TURN, ICE, HAProxy and Caddy are never reached — which matches the report exactly.

### The asymmetry

The **streaming loop already knows about this failure mode.** `session_capture.go` calls `forceDesktopRepaint()` in **eleven** places (thirteen repo-wide, counting `session.go` and `session_control.go`) — post-monitor-switch, startup warm-up, secure-desktop, idle cached-frame resend, GPU-encode-error fallback. Its own comment says it out loud:

> Critical for static displays where DXGI produces zero dirty rects naturally.

The **startup probe called it zero times.** That's the bug. (The maintainer's triage comment on the issue said "five places" — the distinct *scenarios*; the literal call-site count is eleven.)

This also explains why the reporter's step 7/8 — wake the display, generate activity, retry — still failed: by the time the new session's duplication is created and probed, the desktop has gone static again.

## The fix

`probeCapture` takes a `repaint func()` and invokes it **immediately before every capture attempt, including the first**. Repaint-before-capture (not after) is deliberate: `RedrawWindow` with `RDW_UPDATENOW` processes `WM_PAINT` synchronously, so the dirty rects are already queued by the time `AcquireNextFrame` runs.

On Windows the callback comes from a new `newProbeRepainter()`, which **composes the existing helpers rather than inventing a mechanism** — it runs the same pair the capture loop's static-display warm-up uses:

```go
func newProbeRepainter() (repaint func(), release func()) {
	runtime.LockOSThread()
	switchThreadToInputDesktop()
	return func() {
		nudgeSecureDesktop()
		forceDesktopRepaint()
	}, runtime.UnlockOSThread
}
```

Both halves of the repaint are needed, per the existing comment in `session_capture.go`: `InvalidateRect` has no HWND to target on a windowless desktop, and the `SendInput` jiggle is what makes the DWM compositor emit dirty rects there. The `+1/-1` relative move nets to zero and the streaming loop already injects it during the first ~2 s of every session.

The `LockOSThread` + `switchThreadToInputDesktop()` prologue is load-bearing: unlike the capture loop, the probe does **not** run on a `prepareCaptureThread()` goroutine — `newPlatformCapturer` releases its OS-thread lock once `initDXGI` succeeds, so Go may have migrated `StartSession` onto a thread that isn't on the input desktop, and `SendInput` / `InvalidateRect` / `RedrawWindow` all act on the *calling thread's* desktop.

It is hoisted to **once per probe, not per attempt** (second commit, a self-review catch): `switchThreadToInputDesktop` deliberately leaves its `HDESK` open — closing it would detach the thread (`dxgi_desktop_windows.go:322`) — so calling it per attempt would have leaked five desktop handles per session. `StartSession` calls `release()` unconditionally right after `probeCapture`, **before** the error check, so the pin never outlives the probe on either path. On macOS/Linux `newProbeRepainter` returns two no-ops alongside the existing stubs.

### Explicitly unchanged

- **Retry ceiling** — still `5 × 200ms`.
- **Genuine-failure path** — a hard capture error (device lost, no output, access denied) still aborts on the **first** attempt with the underlying error. This removes a false negative on idle desktops; it does not disable the probe.

The exhausted-attempts message now reads `...after %d attempts **with forced desktop repaints** (session may have no capturable desktop)`, so field logs distinguish a pre-fix from a post-fix agent at a glance.

## Test coverage

`TestProbeCaptureRepaintSequence` is table-driven and asserts on a recorded `repaint`/`capture` **event sequence** — a `capture` not immediately preceded by a `repaint` is the bug. Cases:

| Case | Asserts |
|---|---|
| frame on first attempt | repaint still fires first (`[repaint capture]`) |
| idle desktop, frame on 3rd try | `[repaint capture ×3]` — one repaint per retry |
| genuinely dead desktop | one repaint per attempt, **ceiling still 3/5** |
| hard capture error | aborts after `[repaint capture]` — no extra attempts |

Plus `TestProbeCaptureNilRepaintIsSafe` for the nil-callback shape. Verified non-vacuous by mutation: deleting the `repaint()` call reds all four sub-cases (`event sequence = [capture], want [repaint capture]`).

**Field verification only** (not unit-testable — Win32 syscalls with no seam): that `forceProbeRepaint` actually shakes a DXGI frame loose on real hardware, and that the `switchThreadToInputDesktop` prologue matters for a SYSTEM-spawned helper. The reporter's repro is the verification.

## Verification

```
$ cd agent && go test -race ./...
exit=0 — 69 packages ok, 5 with no test files, 0 FAIL, 0 data races
ok  github.com/breeze-rmm/agent/internal/remote/desktop  1.729s   (-count=1)
```

`gofmt -l` clean; `go vet` clean on darwin; `GOOS=windows go build ./...` and `go vet` clean (the `possible misuse of unsafe.Pointer` notes are pre-existing in untouched `mft_*`/`dxgi_*`/`encoder_*` files).

Refs #3951

🤖 Generated with [Claude Code](https://claude.com/claude-code)
