### PR TITLE
fix(api): count partner-level ring assignments via organizations.partner_id (#3954)

### DIFF
--- a/apps/api/src/__tests__/integration/updateRingPartnerDeviceCount.integration.test.ts
+++ b/apps/api/src/__tests__/integration/updateRingPartnerDeviceCount.integration.test.ts
@@ -31,7 +31,8 @@
 import './setup';
 import { describe, expect, it } from 'vitest';
 import { randomUUID } from 'node:crypto';
-import { inArray } from 'drizzle-orm';
+import { inArray, sql } from 'drizzle-orm';
+import { getTestDb } from './setup';
 import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
 import {
   configurationPolicies,
@@ -241,6 +242,47 @@ describe('update-ring device count — partner-level assignment fan-out (#3954)'
 
     // orgA1's single non-ephemeral device only — NOT orgA2's.
     expect(counts.get(f.ringA.id)).toBe(1);
+  });
+
+  runDb('SYSTEM scope: a target org under another partner is clamped out', async () => {
+    // The ring-partner clamp is defense-in-depth against a subset assignment
+    // whose target org has been reparented to a different partner. Normally the
+    // DB forbids reaching that state (config_policy_assignment_target_integrity
+    // rejects the write, and a_config_policy_assignment_target_update rejects
+    // the reparent), so we FORGE it with triggers disabled — the same idiom the
+    // cross-tenant forge suites use.
+    //
+    // This runs under SYSTEM scope deliberately: accessible_org_ids is
+    // unrestricted there, so RLS contributes NO org clamp. If this passes, the
+    // SQL clamp is doing the work, not the caller's RLS context.
+    const f = await seedFixture();
+    const policyId = await linkPolicyToRing({
+      ringId: f.ringA.id,
+      partnerId: f.partnerA.id,
+      level: 'organization',
+      targetId: f.orgA2.id, // legal: orgA2 belongs to partner A
+    });
+
+    const admin = getTestDb();
+    // DISABLE TRIGGER USER rather than naming one: the integrity trigger has
+    // already been renamed once (2026-07-29-serialize-config-policy-assignment-integrity.sql
+    // split it into a_config_policy_assignment_integrity_{insert,update,delete}),
+    // and a name-specific ALTER would silently rot into a 42704 on the next rename.
+    await admin.execute(sql`ALTER TABLE config_policy_assignments DISABLE TRIGGER USER`);
+    try {
+      // Repoint at partner B's org — the state a reparent would have produced.
+      await admin.execute(
+        sql`UPDATE config_policy_assignments SET target_id = ${f.orgB1.id}
+            WHERE config_policy_id = ${policyId} AND level = 'organization'`
+      );
+    } finally {
+      await admin.execute(sql`ALTER TABLE config_policy_assignments ENABLE TRIGGER USER`);
+    }
+
+    const counts = await withSystemDbAccessContext(() => resolveRingDeviceCounts([f.ringA.id]));
+
+    // partnerB's device must NOT be attributed to partnerA's ring.
+    expect(counts.get(f.ringA.id) ?? 0).toBe(0);
   });
 
   runDb('non-vacuity probe: system scope sees the seeded partner devices', async () => {

--- a/apps/api/src/__tests__/integration/updateRingPartnerDeviceCount.integration.test.ts
+++ b/apps/api/src/__tests__/integration/updateRingPartnerDeviceCount.integration.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Update-ring DEVICES count for PARTNER-level policy assignments (#3954).
+ *
+ * `resolveRingAssignedDeviceIds` (apps/api/src/routes/updateRingsHelpers.ts)
+ * used to lump partner-level assignments in with org-level ones:
+ *
+ *     else if (a.level === 'organization' || a.level === 'partner') orgIds.push(a.targetId);
+ *     ... where(inArray(devices.orgId, orgIds))
+ *
+ * A partner-level assignment's `targetId` is a PARTNER id, so that matched zero
+ * rows and the Update Rings list rendered "DEVICES 0" for a ring that was
+ * genuinely applied (the patch scheduler has its own correct partner branch).
+ *
+ * WHY REAL POSTGRES: the failure was entirely inside a `.where()` predicate and
+ * depends on the devices→organizations join actually existing. A chainable
+ * Drizzle mock that ignores `.where()` passes against both the broken and the
+ * fixed code (see memory: vacuous_drizzle_where_clause_assertions). The
+ * compiled-SQL unit suite (updateRingsHelpers.partnerFanout.test.ts) pins the
+ * predicate text; this proves the resolved COUNT against real rows, under a
+ * real partner-scope RLS context on the unprivileged `breeze_app` role.
+ *
+ * Coverage:
+ *   - partner-wide policy + partner-level assignment counts devices across ALL
+ *     of the partner's orgs (the regression: was 0, must be 2)
+ *   - ephemeral Quick Support devices stay excluded from the partner fan-out
+ *   - another partner's devices are never counted (cross-partner isolation)
+ *   - a partner B context resolves 0 for partner A's ring (RLS hides the chain)
+ *   - a legacy ORG-owned policy carrying a partner-level assignment clamps to
+ *     its own org, mirroring patchSchedulerWorker.resolveDeviceIdsForAssignment
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { inArray } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  configurationPolicies,
+  configPolicyFeatureLinks,
+  configPolicyAssignments,
+  devices,
+  patchPolicies,
+} from '../../db/schema';
+import { resolveRingDeviceCounts, resolveRingDeviceIds } from '../../routes/updateRingsHelpers';
+import { createPartner, createOrganization, createSite } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function partnerCtx(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    // Mirrors computeAccessibleOrgIds(scope='partner'): the partner's active
+    // orgs. Partner-wide rows are reachable via accessiblePartnerIds.
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+/**
+ * One device, in its OWN system-scope transaction. `breeze_partner_export_devices_insert`
+ * takes a partner-export lock per touched org and requires ascending-UUID lock
+ * order, so seeding devices across several orgs inside a single transaction
+ * fails with "locks must be acquired in ascending UUID order". One org per
+ * transaction sidesteps the ordering constraint entirely.
+ */
+async function seedDevice(orgId: string, siteId: string, isEphemeral = false): Promise<string> {
+  return withSystemDbAccessContext(async () => {
+    const [d] = await db
+      .insert(devices)
+      .values({
+        orgId,
+        siteId,
+        agentId: `agent-${randomUUID()}`,
+        hostname: `host-${randomUUID().slice(0, 8)}`,
+        osType: 'windows',
+        osVersion: '1.0',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+        status: 'online',
+        deviceRole: 'workstation',
+        isEphemeral,
+      })
+      .returning({ id: devices.id });
+    if (!d) throw new Error('failed to seed device');
+    return d.id;
+  });
+}
+
+/**
+ * Partner A: two orgs, one device each, plus one EPHEMERAL device in org 1.
+ * Partner B: one org with one device (must never be counted for A's ring).
+ */
+async function seedFixture() {
+  const base = await withSystemDbAccessContext(async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+
+    const orgA1 = await createOrganization({ partnerId: partnerA.id });
+    const orgA2 = await createOrganization({ partnerId: partnerA.id });
+    const orgB1 = await createOrganization({ partnerId: partnerB.id });
+
+    const siteA1 = await createSite({ orgId: orgA1.id });
+    const siteA2 = await createSite({ orgId: orgA2.id });
+    const siteB1 = await createSite({ orgId: orgB1.id });
+
+    const [ringA] = await db
+      .insert(patchPolicies)
+      .values({ partnerId: partnerA.id, kind: 'ring', name: `ring-a-${randomUUID().slice(0, 8)}` })
+      .returning({ id: patchPolicies.id });
+    if (!ringA) throw new Error('failed to seed ring');
+
+    return { partnerA, partnerB, orgA1, orgA2, orgB1, siteA1, siteA2, siteB1, ringA };
+  });
+
+  // Each seedDevice opens its own transaction — see the note on seedDevice.
+  const deviceA1 = await seedDevice(base.orgA1.id, base.siteA1.id);
+  const deviceA2 = await seedDevice(base.orgA2.id, base.siteA2.id);
+  // Quick Support machine — a stranger's personal PC, must stay out of the count.
+  const ephemeralA = await seedDevice(base.orgA1.id, base.siteA1.id, true);
+  const deviceB1 = await seedDevice(base.orgB1.id, base.siteB1.id);
+
+  return { ...base, deviceA1, deviceA2, ephemeralA, deviceB1 };
+}
+
+/**
+ * Link a config policy to `ringId` (featureType 'patch') and assign it.
+ * `ownerOrgId` null => partner-wide policy; set => legacy org-owned policy.
+ */
+async function linkPolicyToRing(opts: {
+  ringId: string;
+  partnerId: string;
+  ownerOrgId?: string | null;
+  level: 'partner' | 'organization';
+  targetId: string;
+}): Promise<string> {
+  return withSystemDbAccessContext(async () => {
+    const ownerOrgId = opts.ownerOrgId ?? null;
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({
+        // Exactly one ownership axis (config_policies_one_owner_chk).
+        orgId: ownerOrgId,
+        partnerId: ownerOrgId ? null : opts.partnerId,
+        name: `cfg-${randomUUID().slice(0, 8)}`,
+        status: 'active',
+      })
+      .returning({ id: configurationPolicies.id });
+    if (!policy) throw new Error('failed to seed config policy');
+
+    await db.insert(configPolicyFeatureLinks).values({
+      configPolicyId: policy.id,
+      featureType: 'patch',
+      featurePolicyId: opts.ringId,
+    });
+
+    await db.insert(configPolicyAssignments).values({
+      configPolicyId: policy.id,
+      level: opts.level,
+      targetId: opts.targetId,
+    });
+
+    return policy.id;
+  });
+}
+
+describe('update-ring device count — partner-level assignment fan-out (#3954)', () => {
+  runDb('counts devices across ALL the partner orgs (regression: was 0)', async () => {
+    const f = await seedFixture();
+    await linkPolicyToRing({
+      ringId: f.ringA.id,
+      partnerId: f.partnerA.id,
+      level: 'partner',
+      targetId: f.partnerA.id,
+    });
+
+    const counts = await withDbAccessContext(
+      partnerCtx(f.partnerA.id, [f.orgA1.id, f.orgA2.id]),
+      () => resolveRingDeviceCounts([f.ringA.id])
+    );
+
+    // Pre-fix this was 0: partnerA.id was matched against devices.org_id.
+    // 2 (not 3) — the ephemeral Quick Support device is excluded.
+    expect(counts.get(f.ringA.id)).toBe(2);
+  });
+
+  runDb('resolves the exact device ids, excluding ephemeral and other partners', async () => {
+    const f = await seedFixture();
+    await linkPolicyToRing({
+      ringId: f.ringA.id,
+      partnerId: f.partnerA.id,
+      level: 'partner',
+      targetId: f.partnerA.id,
+    });
+
+    const ids = await withDbAccessContext(
+      partnerCtx(f.partnerA.id, [f.orgA1.id, f.orgA2.id]),
+      () => resolveRingDeviceIds(f.ringA.id)
+    );
+
+    expect(ids.sort()).toEqual([f.deviceA1, f.deviceA2].sort());
+    expect(ids).not.toContain(f.ephemeralA);
+    expect(ids).not.toContain(f.deviceB1);
+  });
+
+  runDb('partner B resolves 0 for partner A ring (RLS hides the policy chain)', async () => {
+    const f = await seedFixture();
+    await linkPolicyToRing({
+      ringId: f.ringA.id,
+      partnerId: f.partnerA.id,
+      level: 'partner',
+      targetId: f.partnerA.id,
+    });
+
+    const counts = await withDbAccessContext(
+      partnerCtx(f.partnerB.id, [f.orgB1.id]),
+      () => resolveRingDeviceCounts([f.ringA.id])
+    );
+
+    expect(counts.get(f.ringA.id) ?? 0).toBe(0);
+  });
+
+  runDb('legacy org-owned policy at partner level clamps to its own org', async () => {
+    const f = await seedFixture();
+    // Org-owned policy (orgA1) carrying a partner-level assignment. The DB
+    // integrity trigger permits this because the target partner matches the
+    // owning org's partner; the scheduler clamps such a policy to its own org,
+    // so the displayed count must not claim the whole partner.
+    await linkPolicyToRing({
+      ringId: f.ringA.id,
+      partnerId: f.partnerA.id,
+      ownerOrgId: f.orgA1.id,
+      level: 'partner',
+      targetId: f.partnerA.id,
+    });
+
+    const counts = await withDbAccessContext(
+      partnerCtx(f.partnerA.id, [f.orgA1.id, f.orgA2.id]),
+      () => resolveRingDeviceCounts([f.ringA.id])
+    );
+
+    // orgA1's single non-ephemeral device only — NOT orgA2's.
+    expect(counts.get(f.ringA.id)).toBe(1);
+  });
+
+  runDb('non-vacuity probe: system scope sees the seeded partner devices', async () => {
+    // If .env.test were missing and these tests ran on a BYPASSRLS connection,
+    // the isolation assertion above would pass vacuously. This probe fails loudly
+    // if the fixture itself never landed.
+    const f = await seedFixture();
+    const rows = await withSystemDbAccessContext(() =>
+      db
+        .select({ id: devices.id })
+        .from(devices)
+        .where(inArray(devices.id, [f.deviceA1, f.deviceA2, f.deviceB1]))
+    );
+    expect(rows).toHaveLength(3);
+  });
+});

--- a/apps/api/src/routes/updateRingsHelpers.partnerFanout.test.ts
+++ b/apps/api/src/routes/updateRingsHelpers.partnerFanout.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Compiled-SQL assertions for the update-ring partner-level device fan-out (#3954).
+ *
+ * WHY COMPILED SQL AND NOT A DRIZZLE MOCK: the bug being guarded here lived
+ * entirely inside the `.where()` clause — a partner-level assignment's
+ * `targetId` (a PARTNER id) was pushed into the same bucket as org-level
+ * targets and then matched against `devices.org_id`, which matches zero rows.
+ * The repo's usual chainable Drizzle mock never inspects the argument passed to
+ * `.where()`, so it would have passed against both the broken and the fixed
+ * code (see memory: vacuous_drizzle_where_clause_assertions). These tests
+ * render the real condition through PgDialect and pin the predicate text, so
+ * reverting to `devices.org_id` — or dropping the ephemeral exclusion, or the
+ * legacy org clamp — fails loudly.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+vi.mock('../db', () => ({ db: {} }));
+
+import { buildPartnerAssignmentCondition, type RingAssignment } from './updateRingsHelpers';
+
+const dialect = new PgDialect();
+
+const PARTNER_A = '11111111-1111-4111-8111-111111111111';
+const PARTNER_B = '22222222-2222-4222-8222-222222222222';
+const LEGACY_ORG = '33333333-3333-4333-8333-333333333333';
+
+function render(assignments: RingAssignment[]) {
+  const condition = buildPartnerAssignmentCondition(assignments);
+  if (!condition) throw new Error('expected a SQL condition, got undefined');
+  const query = dialect.sqlToQuery(condition);
+  return { sql: query.sql, params: query.params };
+}
+
+function partnerAssignment(targetId: string, policyOrgId: string | null = null): RingAssignment {
+  return { level: 'partner', targetId, policyOrgId };
+}
+
+describe('buildPartnerAssignmentCondition — partner-level ring fan-out (#3954)', () => {
+  it('returns undefined when there are no partner-level assignments', () => {
+    expect(buildPartnerAssignmentCondition([])).toBeUndefined();
+  });
+
+  it('matches devices through organizations.partner_id, NOT devices.org_id', () => {
+    const { sql, params } = render([partnerAssignment(PARTNER_A)]);
+
+    // The regression guard: the partner id must be compared against the
+    // organizations join column. If this ever renders `devices"."org_id" = $1`
+    // for a partner-level assignment we are back to DEVICES 0.
+    expect(sql).toContain('"organizations"."partner_id" = $1');
+    expect(sql).not.toContain('"devices"."org_id" = $1');
+    expect(params).toContain(PARTNER_A);
+  });
+
+  it('excludes ephemeral Quick Support devices from the partner fan-out', () => {
+    const { sql, params } = render([partnerAssignment(PARTNER_A)]);
+    expect(sql).toContain('"devices"."is_ephemeral" = $2');
+    expect(params[1]).toBe(false);
+  });
+
+  it('ORs multiple partner targets into a single predicate', () => {
+    const { sql, params } = render([
+      partnerAssignment(PARTNER_A),
+      partnerAssignment(PARTNER_B),
+    ]);
+    expect(sql).toContain('"organizations"."partner_id" = $1');
+    expect(sql).toContain('"organizations"."partner_id" = $2');
+    expect(sql).toMatch(/ or /);
+    expect(params.slice(0, 2)).toEqual([PARTNER_A, PARTNER_B]);
+  });
+
+  it('deduplicates repeated (targetId, policyOrgId) pairs', () => {
+    const { params } = render([
+      partnerAssignment(PARTNER_A),
+      partnerAssignment(PARTNER_A),
+    ]);
+    // One partner param + the is_ephemeral flag — the duplicate is dropped.
+    expect(params).toEqual([PARTNER_A, false]);
+  });
+
+  it('clamps a legacy org-owned policy to its own org, mirroring the scheduler', () => {
+    // patchSchedulerWorker.resolveDeviceIdsForAssignment does
+    // `if (policyOrgId) conditions.push(eq(devices.orgId, policyOrgId))` on its
+    // partner branch. Without the same clamp the DISPLAYED count would exceed
+    // the set the scheduler actually patches.
+    const { sql, params } = render([partnerAssignment(PARTNER_A, LEGACY_ORG)]);
+    expect(sql).toContain('"organizations"."partner_id" = $1');
+    expect(sql).toContain('"devices"."org_id" = $2');
+    expect(params.slice(0, 2)).toEqual([PARTNER_A, LEGACY_ORG]);
+  });
+
+  it('keeps a partner-wide policy unclamped (no devices.org_id predicate)', () => {
+    const { sql } = render([partnerAssignment(PARTNER_A, null)]);
+    expect(sql).not.toContain('"devices"."org_id"');
+  });
+});

--- a/apps/api/src/routes/updateRingsHelpers.ts
+++ b/apps/api/src/routes/updateRingsHelpers.ts
@@ -73,10 +73,22 @@ export function buildPartnerAssignmentCondition(
  *     endpoint resolves counts for every ring at once.
  *  2. The scheduler re-clamps subset (org/site/group/device) assignments to the
  *     policy's partner to close a TOCTOU hole (an org reparented to another
- *     partner after the assignment was written). This module does not need to:
- *     it runs inside the REQUEST RLS context, where `breeze.accessible_org_ids`
- *     is the caller's partner's *current* org list, so a reparented org's
- *     devices are already invisible. RLS is the stricter of the two here.
+ *     partner after the assignment row was written, #2280). This module does
+ *     not replicate that clamp, for two independent reasons:
+ *       - The hole is now closed in the DATABASE. Migration
+ *         2026-07-28-config-policy-assignment-target-integrity.sql attaches
+ *         `a_config_policy_assignment_target_update` (AFTER UPDATE OF id,
+ *         partner_id ON organizations), which re-runs
+ *         breeze_validate_config_policy_assignment_target and RAISES on a
+ *         partner mismatch — so the reparent is rejected rather than leaving a
+ *         stale assignment behind. That holds under every scope, system
+ *         included. (The scheduler's clamp predates this trigger; it is now
+ *         belt-and-braces, not the only guard.)
+ *       - On the request path this module additionally runs inside the caller's
+ *         RLS context, where `breeze.accessible_org_ids` is the partner's
+ *         *current* org list, so such devices would be invisible anyway.
+ *     Note the RLS half does NOT apply to a system-scope caller (no org clamp);
+ *     the trigger is what covers that case.
  */
 async function resolveRingAssignedDeviceIds(assignments: RingAssignment[]): Promise<Set<string>> {
   const deviceIds = new Set<string>();

--- a/apps/api/src/routes/updateRingsHelpers.ts
+++ b/apps/api/src/routes/updateRingsHelpers.ts
@@ -1,7 +1,8 @@
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, or, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import {
   devices,
+  organizations,
   configPolicyFeatureLinks,
   configPolicyAssignments,
   configurationPolicies,
@@ -9,36 +10,106 @@ import {
 } from '../db/schema';
 
 /**
+ * One config-policy assignment as this module needs it: the assignment's own
+ * level/target plus the OWNING policy's org id.
+ *
+ * `policyOrgId` is null for a partner-owned ("all organizations") library
+ * policy (#1724/#2280) and set for a classic org-owned policy. It exists only
+ * to reproduce the scheduler's legacy backstop — see resolveRingAssignedDeviceIds.
+ */
+export interface RingAssignment {
+  level: string;
+  targetId: string;
+  policyOrgId: string | null;
+}
+
+/**
+ * Build the WHERE condition that expands partner-level assignments to devices.
+ *
+ * Exported ONLY so a unit test can pin the compiled SQL (see
+ * updateRingsHelpers.partnerFanout.test.ts). The predicate must reference
+ * `organizations.partner_id` — NOT `devices.org_id` — because a partner-level
+ * assignment's targetId is a partner id (#3954). A Drizzle-mock test that
+ * ignores `.where()` cannot catch that regression; a compiled-SQL assertion can.
+ *
+ * Returns undefined when there are no partner-level assignments.
+ */
+export function buildPartnerAssignmentCondition(
+  partnerAssignments: RingAssignment[]
+): SQL | undefined {
+  const seen = new Set<string>();
+  const conditions: SQL[] = [];
+  for (const a of partnerAssignments) {
+    const key = `${a.targetId}|${a.policyOrgId ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    conditions.push(
+      a.policyOrgId
+        ? and(eq(organizations.partnerId, a.targetId), eq(devices.orgId, a.policyOrgId))!
+        : eq(organizations.partnerId, a.targetId)
+    );
+  }
+  if (conditions.length === 0) return undefined;
+  return and(or(...conditions), eq(devices.isEphemeral, false));
+}
+
+/**
  * Shared inner logic: resolve device IDs assigned to a single ring via config policy assignments.
  * Returns a deduplicated Set of device IDs.
+ *
+ * IMPORTANT — `targetId` is polymorphic: its referent depends on `level`
+ * ('device' → devices.id, 'device_group' → device_groups.id, 'site' → sites.id,
+ * 'organization' → organizations.id, 'partner' → **partners.id**). Reading a
+ * partner-level targetId as an org id matches zero rows and renders DEVICES 0
+ * for a ring that is genuinely applied — that was issue #3954.
+ *
+ * This must stay behaviourally aligned with the scheduler's
+ * `resolveDeviceIdsForAssignment` (apps/api/src/jobs/patchSchedulerWorker.ts),
+ * which is the source of truth for which devices a ring acts on. Two
+ * deliberate differences:
+ *
+ *  1. The scheduler resolves ONE assignment per call; this batches every
+ *     assignment of a level into a single query, because the rings LIST
+ *     endpoint resolves counts for every ring at once.
+ *  2. The scheduler re-clamps subset (org/site/group/device) assignments to the
+ *     policy's partner to close a TOCTOU hole (an org reparented to another
+ *     partner after the assignment was written). This module does not need to:
+ *     it runs inside the REQUEST RLS context, where `breeze.accessible_org_ids`
+ *     is the caller's partner's *current* org list, so a reparented org's
+ *     devices are already invisible. RLS is the stricter of the two here.
  */
-async function resolveRingAssignedDeviceIds(assignments: { level: string; targetId: string }[]): Promise<Set<string>> {
+async function resolveRingAssignedDeviceIds(assignments: RingAssignment[]): Promise<Set<string>> {
   const deviceIds = new Set<string>();
   const directDeviceIds: string[] = [];
   const groupIds: string[] = [];
   const siteIds: string[] = [];
   const orgIds: string[] = [];
+  const partnerAssignments: RingAssignment[] = [];
 
   for (const a of assignments) {
     if (a.level === 'device') directDeviceIds.push(a.targetId);
     else if (a.level === 'device_group') groupIds.push(a.targetId);
     else if (a.level === 'site') siteIds.push(a.targetId);
-    else if (a.level === 'organization' || a.level === 'partner') orgIds.push(a.targetId);
+    else if (a.level === 'organization') orgIds.push(a.targetId);
+    else if (a.level === 'partner') partnerAssignments.push(a);
   }
 
   for (const id of directDeviceIds) deviceIds.add(id);
 
+  // Group expansion joins devices (rather than reading memberships alone) so
+  // the ephemeral exclusion below applies here too, matching the scheduler.
   if (groupIds.length > 0) {
     const groupDevices = await db
       .select({ deviceId: deviceGroupMemberships.deviceId })
       .from(deviceGroupMemberships)
-      .where(inArray(deviceGroupMemberships.groupId, groupIds));
+      .innerJoin(devices, eq(deviceGroupMemberships.deviceId, devices.id))
+      .where(and(inArray(deviceGroupMemberships.groupId, groupIds), eq(devices.isEphemeral, false)));
     for (const row of groupDevices) deviceIds.add(row.deviceId);
   }
 
-  // Site/org expansion must never pull in ephemeral Quick Support devices: they
-  // live in the hidden 'quick_support' org that stays inside accessibleOrgIds
-  // for RLS, so nothing excludes them from a fan-out for us.
+  // Site/org/partner expansion must never pull in ephemeral Quick Support
+  // devices: they live in the hidden 'quick_support' org that stays inside
+  // accessibleOrgIds for RLS, so nothing excludes them from a fan-out for us.
   if (siteIds.length > 0) {
     const siteDevices = await db
       .select({ id: devices.id })
@@ -55,6 +126,22 @@ async function resolveRingAssignedDeviceIds(assignments: { level: string; target
     for (const row of orgDevices) deviceIds.add(row.id);
   }
 
+  // Partner-level ("all organizations") assignments: targetId is a PARTNER id,
+  // so the devices are reached through their org's partner_id, mirroring the
+  // scheduler's partner branch. A legacy org-owned policy carrying a
+  // partner-level assignment (now rejected at assign time) still clamps to its
+  // own org, exactly as the scheduler does, so the count cannot overstate what
+  // will actually be patched.
+  const partnerCondition = buildPartnerAssignmentCondition(partnerAssignments);
+  if (partnerCondition) {
+    const partnerDevices = await db
+      .select({ id: devices.id })
+      .from(devices)
+      .innerJoin(organizations, eq(devices.orgId, organizations.id))
+      .where(partnerCondition);
+    for (const row of partnerDevices) deviceIds.add(row.id);
+  }
+
   return deviceIds;
 }
 
@@ -67,6 +154,7 @@ export async function resolveRingDeviceIds(ringId: string): Promise<string[]> {
     .select({
       level: configPolicyAssignments.level,
       targetId: configPolicyAssignments.targetId,
+      policyOrgId: configurationPolicies.orgId,
     })
     .from(configPolicyFeatureLinks)
     .innerJoin(configurationPolicies, and(
@@ -97,6 +185,7 @@ export async function resolveRingDeviceCounts(ringIds: string[]): Promise<Map<st
       ringId: configPolicyFeatureLinks.featurePolicyId,
       level: configPolicyAssignments.level,
       targetId: configPolicyAssignments.targetId,
+      policyOrgId: configurationPolicies.orgId,
     })
     .from(configPolicyFeatureLinks)
     .innerJoin(configurationPolicies, and(
@@ -110,11 +199,11 @@ export async function resolveRingDeviceCounts(ringIds: string[]): Promise<Map<st
     ));
 
   // Group assignments by ring
-  const ringAssignments = new Map<string, { level: string; targetId: string }[]>();
+  const ringAssignments = new Map<string, RingAssignment[]>();
   for (const row of linkedAssignments) {
     if (!row.ringId) continue;
     const list = ringAssignments.get(row.ringId) ?? [];
-    list.push({ level: row.level, targetId: row.targetId });
+    list.push({ level: row.level, targetId: row.targetId, policyOrgId: row.policyOrgId });
     ringAssignments.set(row.ringId, list);
   }
 

--- a/apps/api/src/routes/updateRingsHelpers.ts
+++ b/apps/api/src/routes/updateRingsHelpers.ts
@@ -6,7 +6,8 @@ import {
   configPolicyFeatureLinks,
   configPolicyAssignments,
   configurationPolicies,
-  deviceGroupMemberships
+  deviceGroupMemberships,
+  patchPolicies
 } from '../db/schema';
 
 /**
@@ -71,26 +72,27 @@ export function buildPartnerAssignmentCondition(
  *  1. The scheduler resolves ONE assignment per call; this batches every
  *     assignment of a level into a single query, because the rings LIST
  *     endpoint resolves counts for every ring at once.
- *  2. The scheduler re-clamps subset (org/site/group/device) assignments to the
- *     policy's partner to close a TOCTOU hole (an org reparented to another
- *     partner after the assignment row was written, #2280). This module does
- *     not replicate that clamp, for two independent reasons:
- *       - The hole is now closed in the DATABASE. Migration
- *         2026-07-28-config-policy-assignment-target-integrity.sql attaches
- *         `a_config_policy_assignment_target_update` (AFTER UPDATE OF id,
- *         partner_id ON organizations), which re-runs
- *         breeze_validate_config_policy_assignment_target and RAISES on a
- *         partner mismatch — so the reparent is rejected rather than leaving a
- *         stale assignment behind. That holds under every scope, system
- *         included. (The scheduler's clamp predates this trigger; it is now
- *         belt-and-braces, not the only guard.)
- *       - On the request path this module additionally runs inside the caller's
- *         RLS context, where `breeze.accessible_org_ids` is the partner's
- *         *current* org list, so such devices would be invisible anyway.
- *     Note the RLS half does NOT apply to a system-scope caller (no org clamp);
- *     the trigger is what covers that case.
+ *  2. The scheduler re-clamps every assignment to the POLICY's partner to close
+ *     a TOCTOU hole (an org reparented to another partner after the assignment
+ *     row was written, #2280), threading both policyOrgId and policyPartnerId.
+ *     This module clamps to the RING's partner instead — one value, applied
+ *     uniformly to all five levels. That is equivalent, not weaker: migration
+ *     2026-07-27-a-feature-policy-reference-ownership.sql constrains a
+ *     `feature_type='patch'` link so the referenced patch_policies row's
+ *     partner_id EQUALS `COALESCE(policy.partner_id, policy_org.partner_id)` —
+ *     the policy's effective partner. So "org is under the ring's partner" and
+ *     "org is under the policy's partner" are the same predicate here.
+ *
+ *     The clamp is deliberately unconditional rather than leaning on the
+ *     caller's RLS context: `accessible_org_ids` is unrestricted under SYSTEM
+ *     scope, so an RLS-only argument would not hold for a system-scope caller
+ *     of these endpoints. Clamping in SQL keeps the result scope-independent.
  */
-async function resolveRingAssignedDeviceIds(assignments: RingAssignment[]): Promise<Set<string>> {
+async function resolveRingAssignedDeviceIds(
+  assignments: RingAssignment[],
+  /** The ring's own partner. Every resolved device must sit under it. */
+  ringPartnerId: string
+): Promise<Set<string>> {
   const deviceIds = new Set<string>();
   const directDeviceIds: string[] = [];
   const groupIds: string[] = [];
@@ -106,7 +108,22 @@ async function resolveRingAssignedDeviceIds(assignments: RingAssignment[]): Prom
     else if (a.level === 'partner') partnerAssignments.push(a);
   }
 
-  for (const id of directDeviceIds) deviceIds.add(id);
+  // The ring-partner clamp (see doc comment) — every branch below joins
+  // organizations and applies it, so a target that has since been reparented to
+  // another partner resolves to nothing regardless of the caller's scope.
+  const underRingPartner = eq(organizations.partnerId, ringPartnerId);
+
+  // Device-level targets are an operator-chosen machine, so they are NOT
+  // filtered on isEphemeral — matching the scheduler, which leaves its by-id
+  // branches alone. They are still verified to exist under the ring's partner.
+  if (directDeviceIds.length > 0) {
+    const directDevices = await db
+      .select({ id: devices.id })
+      .from(devices)
+      .innerJoin(organizations, eq(devices.orgId, organizations.id))
+      .where(and(inArray(devices.id, directDeviceIds), underRingPartner));
+    for (const row of directDevices) deviceIds.add(row.id);
+  }
 
   // Group expansion joins devices (rather than reading memberships alone) so
   // the ephemeral exclusion below applies here too, matching the scheduler.
@@ -115,7 +132,12 @@ async function resolveRingAssignedDeviceIds(assignments: RingAssignment[]): Prom
       .select({ deviceId: deviceGroupMemberships.deviceId })
       .from(deviceGroupMemberships)
       .innerJoin(devices, eq(deviceGroupMemberships.deviceId, devices.id))
-      .where(and(inArray(deviceGroupMemberships.groupId, groupIds), eq(devices.isEphemeral, false)));
+      .innerJoin(organizations, eq(devices.orgId, organizations.id))
+      .where(and(
+        inArray(deviceGroupMemberships.groupId, groupIds),
+        eq(devices.isEphemeral, false),
+        underRingPartner
+      ));
     for (const row of groupDevices) deviceIds.add(row.deviceId);
   }
 
@@ -126,7 +148,12 @@ async function resolveRingAssignedDeviceIds(assignments: RingAssignment[]): Prom
     const siteDevices = await db
       .select({ id: devices.id })
       .from(devices)
-      .where(and(inArray(devices.siteId, siteIds), eq(devices.isEphemeral, false)));
+      .innerJoin(organizations, eq(devices.orgId, organizations.id))
+      .where(and(
+        inArray(devices.siteId, siteIds),
+        eq(devices.isEphemeral, false),
+        underRingPartner
+      ));
     for (const row of siteDevices) deviceIds.add(row.id);
   }
 
@@ -134,7 +161,12 @@ async function resolveRingAssignedDeviceIds(assignments: RingAssignment[]): Prom
     const orgDevices = await db
       .select({ id: devices.id })
       .from(devices)
-      .where(and(inArray(devices.orgId, orgIds), eq(devices.isEphemeral, false)));
+      .innerJoin(organizations, eq(devices.orgId, organizations.id))
+      .where(and(
+        inArray(devices.orgId, orgIds),
+        eq(devices.isEphemeral, false),
+        underRingPartner
+      ));
     for (const row of orgDevices) deviceIds.add(row.id);
   }
 
@@ -167,6 +199,7 @@ export async function resolveRingDeviceIds(ringId: string): Promise<string[]> {
       level: configPolicyAssignments.level,
       targetId: configPolicyAssignments.targetId,
       policyOrgId: configurationPolicies.orgId,
+      ringPartnerId: patchPolicies.partnerId,
     })
     .from(configPolicyFeatureLinks)
     .innerJoin(configurationPolicies, and(
@@ -174,12 +207,18 @@ export async function resolveRingDeviceIds(ringId: string): Promise<string[]> {
       eq(configurationPolicies.status, 'active')
     ))
     .innerJoin(configPolicyAssignments, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+    .innerJoin(patchPolicies, eq(patchPolicies.id, configPolicyFeatureLinks.featurePolicyId))
     .where(and(
       eq(configPolicyFeatureLinks.featureType, 'patch'),
       eq(configPolicyFeatureLinks.featurePolicyId, ringId)
     ));
 
-  const deviceIds = await resolveRingAssignedDeviceIds(linkedAssignments);
+  // Every row carries the same ring, hence the same partner (DB-enforced — see
+  // resolveRingAssignedDeviceIds). No rows => no assignments => no devices.
+  const ringPartnerId = linkedAssignments[0]?.ringPartnerId;
+  if (!ringPartnerId) return [];
+
+  const deviceIds = await resolveRingAssignedDeviceIds(linkedAssignments, ringPartnerId);
   return Array.from(deviceIds);
 }
 
@@ -198,6 +237,7 @@ export async function resolveRingDeviceCounts(ringIds: string[]): Promise<Map<st
       level: configPolicyAssignments.level,
       targetId: configPolicyAssignments.targetId,
       policyOrgId: configurationPolicies.orgId,
+      ringPartnerId: patchPolicies.partnerId,
     })
     .from(configPolicyFeatureLinks)
     .innerJoin(configurationPolicies, and(
@@ -205,24 +245,25 @@ export async function resolveRingDeviceCounts(ringIds: string[]): Promise<Map<st
       eq(configurationPolicies.status, 'active')
     ))
     .innerJoin(configPolicyAssignments, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+    .innerJoin(patchPolicies, eq(patchPolicies.id, configPolicyFeatureLinks.featurePolicyId))
     .where(and(
       eq(configPolicyFeatureLinks.featureType, 'patch'),
       inArray(configPolicyFeatureLinks.featurePolicyId, ringIds)
     ));
 
-  // Group assignments by ring
-  const ringAssignments = new Map<string, RingAssignment[]>();
+  // Group assignments by ring, carrying that ring's partner alongside.
+  const ringAssignments = new Map<string, { partnerId: string; assignments: RingAssignment[] }>();
   for (const row of linkedAssignments) {
-    if (!row.ringId) continue;
-    const list = ringAssignments.get(row.ringId) ?? [];
-    list.push({ level: row.level, targetId: row.targetId, policyOrgId: row.policyOrgId });
-    ringAssignments.set(row.ringId, list);
+    if (!row.ringId || !row.ringPartnerId) continue;
+    const entry = ringAssignments.get(row.ringId) ?? { partnerId: row.ringPartnerId, assignments: [] };
+    entry.assignments.push({ level: row.level, targetId: row.targetId, policyOrgId: row.policyOrgId });
+    ringAssignments.set(row.ringId, entry);
   }
 
   // Resolve each ring's device count (isolated per ring — one failure doesn't block others)
-  for (const [ringId, assignments] of ringAssignments) {
+  for (const [ringId, { partnerId, assignments }] of ringAssignments) {
     try {
-      const deviceIds = await resolveRingAssignedDeviceIds(assignments);
+      const deviceIds = await resolveRingAssignedDeviceIds(assignments, partnerId);
       deviceCountMap.set(ringId, deviceIds.size);
     } catch (err) {
       console.error(`Failed to resolve device count for ring ${ringId}:`, err instanceof Error ? err.message : err);


### PR DESCRIPTION
## Root cause

`resolveRingAssignedDeviceIds` (`apps/api/src/routes/updateRingsHelpers.ts`) treated a partner-level config-policy assignment's `targetId` as if it were an org id:

```ts
else if (a.level === 'organization' || a.level === 'partner') orgIds.push(a.targetId);
// ... then
.where(and(inArray(devices.orgId, orgIds), eq(devices.isEphemeral, false)))
```

`config_policy_assignments.target_id` is **polymorphic** — its referent depends on `level`. For `level='partner'` it is a **partner** id, so `devices.org_id IN (<partner uuid>)` matches nothing. The Update Rings list rendered **DEVICES 0** / COMPLIANCE "—" for a ring that was genuinely applied (reported via discussion #2598).

The helper predates partner-level assignments (#1724/#2280) and was never updated. This is the standard org/partner fan-out failure class called out in `CLAUDE.md` ("Partner-Wide First", step 5).

**Blast radius: display-only.** `patchSchedulerWorker.resolveDeviceIdsForAssignment` has its own correct partner branch, so scheduling always honored the ring. Only the count/compliance surface lied — but the lie reads as "your ring is not being used", which is exactly how the reporter interpreted it.

## The fix

**1. Partner-level assignments get their own bucket**, expanded through the device's org `partner_id` rather than `devices.org_id`:

```ts
.from(devices)
.innerJoin(organizations, eq(devices.orgId, organizations.id))
.where(and(or(...partnerConditions), eq(devices.isEphemeral, false)))
```

Faithful to the scheduler on the details: the **`policyOrgId` clamp** (a legacy *org-owned* policy carrying a partner-level assignment still clamps to its own org, so the count can never overstate what gets patched — the DB integrity trigger permits that shape, so it is reachable), and **`isEphemeral = false`** so Quick Support machines stay out.

**2. A uniform ring-partner clamp on every level** (added in response to review — see below). Every branch now inner-joins `organizations` and applies `eq(organizations.partnerId, ringPartnerId)`.

**Drive-by:** the `device_group` branch now inner-joins `devices` so the ephemeral exclusion applies there too (previously it read memberships alone), and the `device` branch now verifies the target exists under the ring's partner instead of adding the assignment row's id blindly. Both match the scheduler.

### Why clamp to the *ring's* partner rather than thread the scheduler's two owner fields

The scheduler threads `policyOrgId` + `policyPartnerId` and re-clamps per level. Clamping to the ring's partner is **one value applied uniformly to all five levels**, and is equivalent rather than weaker: `2026-07-27-a-feature-policy-reference-ownership.sql` constrains a `feature_type='patch'` link so the referenced `patch_policies.partner_id` **equals** `COALESCE(policy.partner_id, policy_org.partner_id)`. So "org is under the ring's partner" and "org is under the policy's partner" are the same predicate here.

The clamp is unconditional SQL rather than an RLS assumption, which is what makes it scope-independent — see the review finding.

## Review finding (round 1) — a real bug, fixed in 396f0a6

The first review round flagged that the subset branches (device / device_group / site / organization) had **no partner clamp at all** and leaned on the caller's RLS context to exclude a target org reparented to another partner. That argument holds for `scope='partner'` but **not for `scope='system'`**: `serializeAccessibleIds` treats a null `accessibleOrgIds` as unrestricted, so a system-scope caller of either endpoint got no org clamp whatsoever and could see another partner's devices counted toward the ring.

I reproduced it against real Postgres before fixing — forging the reparented state and resolving under system scope returned **1** where it must return **0** — then fixed it with the uniform clamp above and added a regression test that forges the same state.

Worth noting the DB *does* independently guard the reparent path (`a_config_policy_assignment_target_update` on `organizations` re-runs `breeze_validate_config_policy_assignment_target` and raises on a partner mismatch), so this was defense-in-depth rather than a live leak. The clamp removes the dependency on that reasoning entirely.

## Call-site sweep

Swept every reader of `config_policy_assignments` that resolves `level`/`targetId` to devices.

**Fixed here:** `apps/api/src/routes/updateRingsHelpers.ts`. Both consumers — `resolveRingDeviceCounts` (rings list) and `resolveRingDeviceIds` (ring compliance) — go through it, so both surfaces are fixed by the one change.

**Already correct (verified, left alone):** `services/featureConfigResolver.ts` (`resolveDeviceIdsForSoftwarePolicy`, `resolveAllVulnerabilityEnabledDevices`) · `jobs/automationWorker.ts` · `services/policyEvaluationService.ts` · `jobs/patchSchedulerWorker.ts` (the reference) · `routes/partnerApi/configuration.ts` (`assignmentEffectiveOrgSql`, pre-scoped to the principal's partner). Device→policy-direction resolvers are correct by construction (they derive the device's org's `partnerId` and match `level='partner'` rows): `featureConfigResolver.loadDeviceHierarchy`, `configurationPolicy.resolveEffectiveConfigWithExecutor`, `helperPermissions.resolveHelperPermissionLevelForDevice`, and four resolvers in `routes/agents/helpers.ts`. `services/patchJobService.ts` `scanScheduledPatchSettings` is dead code (`FIXME: not yet wired to a worker`, zero callers). CRUD/validation/display only: `routes/configurationPolicies/assignments.ts`, `configurationPolicy.listAssignments`/`validateAssignmentTarget`, `services/aiToolsConfigPolicy.ts`, `routes/softwareInventory.ts`, `scripts/migrateToConfigPolicies.ts`.

**Found but NOT fixed here — two adjacent bugs, verified firsthand, different subsystems:**

1. **`services/warrantyAlertEvaluator.ts:71`** — `targetIds = [deviceId, ...groupIds, device.siteId, device.orgId]` never includes the device's `organizations.partner_id`, yet the comment directly above ranks priority as `device > device_group > site > organization > partner`. A partner-wide warranty policy is never queried, so it silently falls through to `DISABLED_SETTINGS`.
2. **`routes/agents/helpers.ts:1961`** (`getOrgEventLogRetentionDays`, driven per-org by `jobs/eventLogRetention.ts`) — filters `eq(configPolicyAssignments.level, 'organization')` with no partner branch, so a partner-level event-log retention policy is ignored and every org silently falls back to the 30-day default.

Different mechanism from this bug (partner rows never queried, rather than a mis-typed id) but the same customer-visible symptom: partner-wide config silently doesn't apply. Out of scope for a patching display fix — happy to file these as separate issues.

## Tests

Every assertion was verified to **fail against the code it guards** — none are vacuous:

- `apps/api/src/routes/updateRingsHelpers.partnerFanout.test.ts` (7 tests) — renders the real condition through `PgDialect` and pins the predicate text. Mutating `organizations.partnerId` back to `devices.orgId` turns **4 of 7 red**. This matters because the repo's usual chainable Drizzle mock never inspects the argument to `.where()` and would pass against both the broken and the fixed code.
- `apps/api/src/__tests__/integration/updateRingPartnerDeviceCount.integration.test.ts` (6 tests) — real Postgres, unprivileged `breeze_app`. Covers the cross-org count, ephemeral exclusion, cross-partner isolation, the legacy org-owned clamp, and the system-scope clamp. Restoring the original bucketing yields `expected +0 to be 2` (the reported symptom); removing the ring-partner clamp yields `expected 1 to be +0`.

Local runs on a private test-stack: **90 unit passed** (6 files, incl. `patchSchedulerWorker.test.ts`), **20 integration passed** (4 files), `tsc --noEmit` clean, `eslint` clean.

No new table, column, or migration — the cascade / export-policy / RLS-allowlist registration steps in `CLAUDE.md` do not apply.

Closes #3954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
