### PR TITLE
fix(api): unwrap the SQLSTATE in tenantCascade's isUndefinedTable (#3927)

### DIFF
--- a/apps/api/src/routes/agents/connections.ts
+++ b/apps/api/src/routes/agents/connections.ts
@@ -7,6 +7,7 @@ import { devices, deviceConnections } from '../../db/schema';
 import { captureException } from '../../services/sentry';
 import { requireAgentRole } from '../../middleware/requireAgentRole';
 import { submitConnectionsSchema } from './schemas';
+import { pgErrorNode } from '../../utils/pgErrors';
 
 // Hard caps that match the device_connections column widths. Agent
 // collectors emit kernel-bound values (TCP states, /proc comm names) that
@@ -98,7 +99,15 @@ connectionsRoutes.put(
     // Global onError returns a generic 500; re-log with pg error fields
     // (code/constraint/column) so server logs retain diagnostic context,
     // and capture to Sentry for durability.
-    const pg = err as { code?: string; detail?: string; table_name?: string; column_name?: string; constraint_name?: string; message?: string };
+    // `pgErrorNode` returns the error that actually CARRIES the SQLSTATE, so
+    // code/detail/table_name all come from the same object. Reading them off
+    // the top-level error left every POSTGRES DIAGNOSTIC field below
+    // permanently `undefined` under drizzle-orm/postgres-js — code, detail,
+    // table_name, column_name, constraint_name. (`message` was never missing:
+    // the outer DrizzleQueryError has its own. Note it now reports the inner
+    // Postgres message rather than the outer query-and-params text, which is
+    // the more useful half for these diagnostics.)
+    const pg = (pgErrorNode(err) ?? {}) as { code?: string; detail?: string; table_name?: string; column_name?: string; constraint_name?: string; message?: string };
     console.error('connections-inventory insert failed', {
       agentId,
       deviceId: device.id,

--- a/apps/api/src/services/tenantCascade.test.ts
+++ b/apps/api/src/services/tenantCascade.test.ts
@@ -207,7 +207,11 @@ describe('cascadeDeleteOrg', () => {
     expect(stats.totalRowsDeleted).toBe(5 + 3 * cascadeOrder.length);
   });
 
-  it('tolerates a missing associated system-scoped table (42P01)', async () => {
+  it('tolerates a missing associated system-scoped table (42P01, FLAT shape)', async () => {
+    // The flat shape — SQLSTATE on the error itself. Kept, but note it does
+    // NOT exercise what production actually throws: see the wrapped-shape test
+    // below, which is the one that fails against a top-level `.code` read.
+    //
     // Override the default mock to make ONLY the device_commands DELETE
     // throw 42P01; everything else returns 0.
     vi.mocked(db.execute).mockImplementation(((q: unknown) => {
@@ -230,9 +234,51 @@ describe('cascadeDeleteOrg', () => {
     expect(stats.totalRowsDeleted).toBe(0);
   });
 
+  /**
+   * The shape production ACTUALLY throws.
+   *
+   * `drizzle-orm/postgres-js` catches the postgres-js `PostgresError` and
+   * rethrows a `DrizzleQueryError` whose own `.code` is undefined — the
+   * SQLSTATE is on `.cause`. The flat fixture above passes whether
+   * `isUndefinedTable` reads `err.code` or unwraps, so it proved nothing; this
+   * one fails against the top-level read.
+   *
+   * What that broken read cost: `isUndefinedTable` returns false for a
+   * genuinely missing table, so the `!isUndefinedTable(err)` branch fires,
+   * writes an erasure-FAILED forensic audit, and throws — aborting a GDPR org
+   * erasure partway through on any deployment that simply does not have one of
+   * the optional tables. The helper exists to tolerate exactly that.
+   */
+  it('tolerates a missing associated table when the SQLSTATE is WRAPPED (DrizzleQueryError)', async () => {
+    vi.mocked(db.execute).mockImplementation(((q: unknown) => {
+      const text = sqlToText(q);
+      if (text.includes('pg_constraint') || text.includes('contype')) {
+        return Promise.resolve(mockState.fkEdges);
+      }
+      if (text.includes('device_commands')) {
+        // Faithful to Drizzle: own `.code` undefined, SQLSTATE on `.cause`.
+        const cause: any = new Error('relation "device_commands" does not exist');
+        cause.code = '42P01';
+        const wrapped: any = new Error('Failed query: delete from device_commands');
+        wrapped.name = 'DrizzleQueryError';
+        wrapped.cause = cause;
+        return Promise.reject(wrapped);
+      }
+      return Promise.resolve({ rowCount: 0 });
+    }) as any);
+
+    // Must COMPLETE. Against the top-level read this rejects instead.
+    const stats = await cascadeDeleteOrg(
+      '00000000-0000-0000-0000-000000000001',
+      '00000000-0000-0000-0000-000000000002',
+    );
+    expect(stats.totalRowsDeleted).toBe(0);
+  });
+
   it('re-throws and aborts cascade on a non-42P01 error', async () => {
     // FK edge query returns []; the first DELETE call AFTER the associated
-    // pre-clears (device_commands + the two SSO FK children, #2195) throws a
+    // pre-clears (ASSOCIATED_SYSTEM_SCOPED_TABLES — seven of them now, not the
+    // three this comment used to name) throws a
     // non-42P01 — i.e. the first ordered cascade-table DELETE, which is the
     // path that wraps errors with `DELETE from "<table>"` context.
     const associatedCount = __testOnly.ASSOCIATED_SYSTEM_SCOPED_TABLES.length;

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -45,6 +45,7 @@ import { createAuditLog } from './auditService';
 // internal calls interceptable by `vi.spyOn(mod, ...)` (an ESM live-binding
 // reference, which bare in-module calls bypass).
 import * as self from './tenantCascade';
+import { pgErrorCode } from '../utils/pgErrors';
 
 /**
  * Authoritative list of `org_id`-scoped public tables that participate
@@ -811,9 +812,18 @@ function extractRowCount(result: unknown): number {
 }
 
 function isUndefinedTable(err: unknown): boolean {
-  const code = (err as { code?: string })?.code;
-  // Postgres SQLSTATE 42P01 = undefined_table
-  return code === '42P01';
+  // Postgres SQLSTATE 42P01 = undefined_table.
+  //
+  // Read through `pgErrorCode`, NOT off the top-level error. These errors come
+  // from `db.execute(...)`, and `drizzle-orm/postgres-js` rethrows the
+  // postgres-js `PostgresError` wrapped in a `DrizzleQueryError` whose own
+  // `.code` is undefined — the SQLSTATE is on `.cause`. A top-level read
+  // therefore returns false for a genuinely missing table, which inverts this
+  // helper's whole purpose: both call sites use it to TOLERATE an optional
+  // table that a deployment does not have, so a false here turns "skip it and
+  // carry on" into "write a failed-erasure audit and abort", partway through a
+  // GDPR erasure or a partner purge.
+  return pgErrorCode(err) === '42P01';
 }
 
 /**


### PR DESCRIPTION
Closes #3927.

`isUndefinedTable` read the SQLSTATE off the **top-level** error. These errors come from `db.execute(...)`, and `drizzle-orm/postgres-js` rethrows the driver error wrapped in a `DrizzleQueryError` whose own `.code` is `undefined` — the SQLSTATE is on `.cause`. So it returned `false` for a genuinely missing table, which **inverts the helper's purpose**: both call sites use it to tolerate an optional table a deployment does not have, so a `false` turns *skip it and carry on* into *write an erasure-failed forensic audit and throw*, aborting a GDPR org erasure or a partner purge partway through.

Routed through the canonical `pgErrorCode()`, as the issue proposed.

### The test that existed proved nothing

There was already a test named `tolerates a missing associated system-scoped table (42P01)`. It used a **flat** `err.code = '42P01'` fixture, which passes whether the helper unwraps or not — exactly what the issue predicted. It is kept (renamed to say `FLAT shape`) and a second test added using the shape production actually throws: own `.code` undefined, `cause.code = '42P01'`.

Control, run both ways:

```
# with the top-level read restored
× tolerates a missing associated table when the SQLSTATE is WRAPPED (DrizzleQueryError)
  Error: [tenantCascade] DELETE from "device_commands" failed for org=…
  Tests  1 failed | 16 passed        <- the FLAT test still passed
```

That error text is the production failure itself: the erasure aborting on a table that is merely absent.

### On the three "latent sites" in the issue — one is included, two are not, and the reason matters

**Included:** `routes/agents/connections.ts`. It reads diagnostics off the top-level error, so every logged `pgCode` / `pgDetail` / `pgTable` / `pgColumn` / `pgConstraint` was permanently `undefined` — the diagnostics that block promises never fired. Now uses `pgErrorNode()` so all of them come from the same node. (Logging is not transactional, so this one genuinely works. Note it now reports the inner Postgres message rather than the outer query-and-params text; `message` itself was never missing.)

**Deliberately NOT included: `aiAgents.ts` (23505 → 409) and `networkBaselines.ts` (23503 → 409).** Unwrapping the SQLSTATE there does **not** deliver the 409, because a second, independent defect sits underneath: those routes run inside the request-wide `withDbAccessContext` transaction, and postgres.js re-throws the rejected statement at commit even after JavaScript has caught it and returned a response. The mapping is not wrong — it is unreachable. This repo already documents exactly that, twice:

> `routes/networkBaselines.ts` — *"ON CONFLICT DO NOTHING instead of catch-and-map: the request runs inside the withDbAccessContext transaction, and postgres.js re-throws a raised unique violation at commit time even after it's caught here, turning the mapped 409 back into a raw 500."*

> `services/aiAgents/agentService.ts` — *"Letting the insert trip 23505 is not an option here: the whole request runs inside one withDbAccessContext transaction, so an in-statement error poisons it and the COMMIT 500s."*

So those two need `ON CONFLICT` / a pre-check / a savepoint, not an unwrap. I started both changes and reverted them rather than ship something that reads as a fix and alters nothing. Worth noting a mocked route test would happily confirm the 409, because a mock has no transaction to poison.

### On the suggested repo-wide sweep

`grep "as { code?: string }"` outside tests returns four more hits, and **three of them must not be changed**: `middleware/bearerTokenAuth.ts`, `services/cfAccessJwt.ts` and `services/clientAiEntraJwt.ts` each wrap `jwtVerify` and read **jose** error codes (`ERR_JWS_*` / `ERR_JWT_*`), not Postgres. `pgErrorCode` is the wrong abstraction there. A blind sweep or a lint rule keyed on the cast shape would break them — worth scoping any future rule to files that actually touch the driver.

### Verification

`tsc --noEmit` clean. Full API unit suite **25,210 passed, 0 failed**. Both controls above run and observed failing before the fix.
