### PR TITLE
fix(web): un-nest the AutomationTab delete button from the row expander (#3990)

### DIFF
--- a/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.test.tsx
@@ -165,6 +165,68 @@ describe('AutomationTab — schedule timezone picker', () => {
     }
   });
 
+  /**
+   * #3990 — the row's delete control used to be a <button> NESTED inside the
+   * row's expand <button>.
+   *
+   * Three things were wrong and only one of them was cosmetic: invalid HTML
+   * React flags as a hydration hazard; a click on delete bubbling to the expand
+   * handler so removing a row also toggled it; and nested interactive controls
+   * that keyboard and screen-reader users cannot reach reliably.
+   *
+   * The bubbling was masked by an `e.stopPropagation()` in the delete handler,
+   * which made the symptom invisible while leaving the invalid markup — so this
+   * asserts the STRUCTURE, not just the behaviour. A test that only clicked
+   * delete and checked the row vanished would pass with the nesting restored
+   * and stopPropagation back in place.
+   */
+  it('renders the expand and delete controls as siblings, not nested', () => {
+    addAutomation();
+
+    const del = screen.getAllByRole('button', { name: /^Delete:/i })[0];
+    // Walk up from the PARENT. `del.closest('button')` matches the delete
+    // button itself, so it can never fail — that version of this assertion
+    // passed with the nesting fully restored.
+    expect(del.parentElement?.closest('button')).toBeNull();
+  });
+
+  /**
+   * Deleting a COLLAPSED row must not disturb the expanded one.
+   *
+   * The sequence matters, and an earlier version of this test got it wrong in a
+   * way that made it a false positive: it expanded row 0 implicitly, added a
+   * second row, deleted row 0, and counted the survivors. That passes with the
+   * nesting restored — `deleteItem` shifts `expandedIndex` from 1 to 0 when the
+   * row below is removed, and a LEAKED row-0 expand handler also sets 0, so the
+   * two outcomes are indistinguishable. It only went red in the control because
+   * the old markup had no `aria-expanded` for the query to find, i.e. for the
+   * wrong reason entirely.
+   *
+   * Expanding row 0 and deleting the COLLAPSED row 1 separates them: with
+   * correct code `expandedIndex` stays 0 and row 0 keeps its form mounted; with
+   * bubbling, the delete click first toggles row 1 open (setting the index to
+   * 1), and `deleteItem(1)` then clears it to null — so the survivor collapses.
+   */
+  it('deleting a collapsed row leaves the expanded row expanded', () => {
+    addAutomation();                                   // row 0, auto-expanded
+    fireEvent.click(screen.getAllByRole('button', { name: /Add Automation/i })[0]); // row 1, now expanded
+
+    // Put the expansion back on row 0, leaving row 1 collapsed.
+    const expandControls = screen.getAllByRole('button', { expanded: false });
+    fireEvent.click(expandControls[0]);
+    expect(screen.getAllByRole('button', { expanded: true }).length).toBe(1);
+
+    // Delete the COLLAPSED row (row 1) — its delete button is the second one.
+    const deletes = screen.getAllByRole('button', { name: /^Delete:/i });
+    expect(deletes.length).toBe(2);
+    fireEvent.click(deletes[1]);
+
+    // One row left, still expanded, and its form is still mounted.
+    expect(screen.getAllByRole('button', { name: /^Delete:/i }).length).toBe(1);
+    expect(screen.getAllByRole('button', { expanded: true }).length).toBe(1);
+    expect(screen.getByTestId('automation-timezone-0-trigger')).toBeTruthy();
+  });
+
   it('defaults to UTC and leaves it intact when untouched', async () => {
     addAutomation();
     expect(screen.getByTestId('automation-timezone-0-trigger').textContent).toContain('UTC');

--- a/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.tsx
@@ -405,13 +405,26 @@ export default function AutomationTab({
           const isExpanded = expandedIndex === index;
           return (
             <div key={index} className="rounded-md border bg-muted/10">
-              {/* Collapsed header */}
-              <button
-                type="button"
-                onClick={() => setExpandedIndex(isExpanded ? null : index)}
-                className="flex w-full items-center justify-between px-4 py-3 text-left"
-              >
-                <div className="flex items-center gap-3">
+              {/* Collapsed header.
+                  The expand control and the delete control are SIBLINGS inside
+                  a plain <div>, not nested. A <button> inside a <button> is
+                  invalid HTML that React flags as a hydration hazard, and it
+                  made a click on delete bubble to the expand handler — so
+                  deleting a row also toggled it. The `e.stopPropagation()` that
+                  used to hide that was load-bearing: remove it and the bug
+                  reappears. Siblings mean there is nothing to stop. */}
+              <div className="flex w-full items-center justify-between pr-4">
+                {/* The padding lives on the BUTTON, not the wrapper. Putting it
+                    on the inert wrapper shrinks the disclosure hit target to
+                    the text height and leaves the surrounding padding dead —
+                    the old markup had a full-row target and this must keep it.
+                    `self-stretch` gives it the full header height. */}
+                <button
+                  type="button"
+                  onClick={() => setExpandedIndex(isExpanded ? null : index)}
+                  aria-expanded={isExpanded}
+                  className="flex flex-1 items-center gap-3 self-stretch py-3 pl-4 text-left"
+                >
                   {isExpanded ? (
                     <ChevronDown className="h-4 w-4 text-muted-foreground" />
                   ) : (
@@ -440,18 +453,24 @@ export default function AutomationTab({
                       {i18n.t("common:states.disabled")}
                     </span>
                   )}
-                </div>
+                </button>
                 <button
                   type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    deleteItem(index);
-                  }}
-                  className="flex h-7 w-7 items-center justify-center rounded-md text-destructive hover:bg-destructive/10"
+                  onClick={() => deleteItem(index)}
+                  // Row-qualified, matching ConfigPolicyList: a bare "Delete"
+                  // leaves every row's button identical in a screen-reader
+                  // button list.
+                  aria-label={`${i18n.t("common:actions.delete")}: ${
+                    item.name ||
+                    i18n.t(
+                      "policies:configurationPolicies.featureTabs.automationTab.untitledAutomation",
+                    )
+                  }`}
+                  className="ml-2 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-destructive hover:bg-destructive/10"
                 >
                   <Trash2 className="h-3.5 w-3.5" />
                 </button>
-              </button>
+              </div>
 
               {/* Expanded form */}
               {isExpanded && (


### PR DESCRIPTION
Closes #3990.

The row's **delete** control was a `<button>` nested inside the row's **expand** `<button>`. Three consequences, only one of them cosmetic:

1. Invalid HTML that React explicitly flags as a hydration hazard.
2. A click on delete bubbled to the expand handler, so deleting a row also toggled it.
3. Nested interactive controls are not reliably reachable or announced by keyboard and screen readers.

The expand and delete controls are now **siblings** inside a plain `<div>`, as the issue proposed.

### The `stopPropagation` was load-bearing

The bubbling in (2) was masked by an `e.stopPropagation()` in the delete handler. That is why this survived: the symptom was invisible while the invalid markup stayed. With siblings there is nothing to stop, so the call is gone rather than kept "just in case" — leaving it would have preserved the thing that hid the bug.

### Keeping the full-row hit target

Worth calling out because the obvious restructure silently regresses it. Moving the old button's `px-4 py-3` onto the new wrapper `<div>` leaves the disclosure control at roughly text height inside a ~46px header, with the surrounding padding dead space — visually identical, materially worse to click. The padding therefore lives on the **expand button**, with `self-stretch` so it fills the header height; the wrapper keeps only the right padding for the delete control.

### Accessibility

`aria-expanded` on the expand control, and the icon-only delete button is named **`Delete: <automation name>`**, following the existing `ConfigPolicyList` precedent — a bare "Delete" leaves every row's button identical in a screen-reader button list. It reuses the existing `common:actions.delete` key plus the automation's own name, so there are no new locale entries and nothing for `localeParity.test.ts` to catch across the 7 translated locales.

### Tests, and one that was a false positive

Two tests: **structural** (the delete button has no `<button>` ancestor) and **behavioural** (deleting a collapsed row leaves the expanded row expanded, with its form still mounted).

The behavioural one is deliberately sequenced. An earlier version expanded row 0 implicitly, added a second row, deleted row 0 and counted survivors — and that **passes with the bug present**: `deleteItem` shifts `expandedIndex` from 1 to 0 when the row below is removed, and a leaked row-0 expand handler also sets 0, so the two outcomes are indistinguishable. It only went red in the control because the old markup had no `aria-expanded` for the query to find, i.e. for the wrong reason entirely.

Expanding row 0 and deleting the **collapsed** row 1 separates them: correct code leaves `expandedIndex` at 0, whereas bubbling toggles row 1 open first and `deleteItem(1)` then clears it to null, collapsing the survivor.

Control, with the leak reintroduced and the DOM otherwise untouched, so the red is about bubbling and not a missing query target:

```
× deleting a collapsed row leaves the expanded row expanded
  Tests  1 failed | 7 passed
```

Also worth recording: my first structural assertion was `expect(del.closest('button')).toBe(del)`, which **can never fail** — `closest()` matches the element it starts from, so it passed with the nesting fully restored. It now walks up from `parentElement`.

### Verification

Full web suite green, `eslint src` clean, node 22.23.2 per the repo `.nvmrc`. Both controls above were run and observed failing before the fix.
