### PR TITLE
fix(web): surface the API's own error on the Organizations page mutations (#3989)

### DIFF
--- a/apps/web/src/components/alerts/NotificationChannelsPage.test.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelsPage.test.tsx
@@ -73,6 +73,45 @@ describe('runChannelSave', () => {
     expect(ON_UNAUTHORIZED).not.toHaveBeenCalled();
   });
 
+  // #3989 — the exact reported symptom. The route answers with the reason in a
+  // plain `details` string array, and the user used to see only the generic
+  // top-level sentence: identical whether the scheme was wrong, the hostname
+  // was missing, or SSRF protection rejected the target.
+  //
+  // Asserts the toast TEXT, not merely that an error toast happened. The test
+  // above checks `{ type: 'error' }` only, so the whole regression could return
+  // while it stayed green.
+  it('surfaces the details[] reasons in the error toast, not just the generic error', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse(
+        {
+          error: 'Invalid webhook channel configuration',
+          details: ['Webhook URL must use HTTPS', 'Webhook URL hostname is required'],
+        },
+        false,
+        400
+      )
+    );
+
+    await expect(
+      runChannelSave(
+        { url: '/alerts/channels', method: 'POST', payload: {}, channelName: '', isCreate: true },
+        { onUnauthorized: ON_UNAUTHORIZED }
+      )
+    ).rejects.toThrow();
+
+    // ONE exact error-toast call, not a join across every call. Joining passes
+    // if the two reasons arrive in separate toasts, or in a success toast —
+    // neither of which is the contract. The extractor's own unit test asserts
+    // the exact string; this asserts the integration actually delivers it.
+    expect(showToastMock).toHaveBeenCalledTimes(1);
+    expect(showToastMock).toHaveBeenCalledWith({
+      message:
+        'Invalid webhook channel configuration: Webhook URL must use HTTPS; Webhook URL hostname is required',
+      type: 'error',
+    });
+  });
+
   it('calls onUnauthorized and does not show an error toast on 401', async () => {
     fetchWithAuthMock.mockResolvedValue(makeJsonResponse({}, false, 401));
     const onUnauthorized = vi.fn();

--- a/apps/web/src/components/settings/OrganizationsPage.firstSite.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.firstSite.test.tsx
@@ -4,8 +4,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import OrganizationsPage from './OrganizationsPage';
 import { fetchWithAuth } from '../../stores/auth';
 
+// handleSessionExpired is the `onUnauthorized` callback for every mutation on
+// this page. Mocking the module replaces ALL of its exports, so omitting it
+// makes the mere ACT of building the runAction options throw
+// ("No export is defined on the mock") before any request is made — which
+// reads as the create flow silently doing nothing.
 vi.mock('../../stores/auth', () => ({
-  fetchWithAuth: vi.fn()
+  fetchWithAuth: vi.fn(),
+  handleSessionExpired: vi.fn()
 }));
 
 const navigateTo = vi.fn();

--- a/apps/web/src/components/settings/OrganizationsPage.mutationFeedback.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.mutationFeedback.test.tsx
@@ -1,0 +1,209 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OrganizationsPage from './OrganizationsPage';
+import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  handleSessionExpired: vi.fn()
+}));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const storeFetchOrganizations = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: { getState: () => ({ fetchOrganizations: storeFetchOrganizations }) }
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const sessionExpiredMock = vi.mocked(handleSessionExpired);
+const toastMock = vi.mocked(showToast);
+
+const ORG_A = { id: 'aaaaaaaa-1111-4111-8111-111111111111', name: 'Alpha Ltd', status: 'active', deviceCount: 0, createdAt: '2026-01-01T00:00:00Z' };
+const ORG_B = { id: 'bbbbbbbb-2222-4222-8222-222222222222', name: 'Beta Ltd', status: 'active', deviceCount: 0, createdAt: '2026-01-02T00:00:00Z' };
+const ORG_C = { id: 'cccccccc-3333-4333-8333-333333333333', name: 'Gamma Ltd', status: 'active', deviceCount: 0, createdAt: '2026-01-03T00:00:00Z' };
+
+/** Drag the row with `sourceId` onto the row with `targetId`. */
+function drag(sourceId: string, targetId: string) {
+  const source = screen.getByTestId(`org-row-${sourceId}`);
+  const target = screen.getByTestId(`org-row-${targetId}`);
+  const dataTransfer = { effectAllowed: '', setData: vi.fn(), dropEffect: '' };
+  fireEvent.dragStart(source, { dataTransfer });
+  fireEvent.dragOver(target, { dataTransfer });
+  fireEvent.drop(target, { dataTransfer });
+}
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERROR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+/** Rendered order of the org rows, top to bottom. */
+function renderedOrgIds(): string[] {
+  return Array.from(document.querySelectorAll('[data-testid^="org-row-"]')).map(
+    el => (el.getAttribute('data-testid') ?? '').replace('org-row-', '')
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  navigateTo.mockReset();
+  sessionExpiredMock.mockReset();
+  toastMock.mockReset();
+  storeFetchOrganizations.mockClear();
+  window.location.hash = '';
+});
+
+describe('OrganizationsPage — the list GET is not a second, poorer redirect', () => {
+  it('routes a 401 through handleSessionExpired instead of a bare /login navigation', async () => {
+    // fetchWithAuth funnels a real session expiry through handleSessionExpired,
+    // which redirects carrying `next` and `reason`. A bare navigateTo('/login')
+    // here would race that and replace it with a destination-less /login.
+    fetchMock.mockImplementation(async () => jsonResponse({ error: 'Unauthorized' }, false, 401));
+
+    render(<OrganizationsPage />);
+
+    await waitFor(() => expect(sessionExpiredMock).toHaveBeenCalled());
+    expect(navigateTo).not.toHaveBeenCalledWith('/login', expect.anything());
+  });
+});
+
+describe('OrganizationsPage — a failed reorder reconciles with the server', () => {
+  /** The order the mock server reports; tests set what it should be believed to hold. */
+  let serverOrgs = [ORG_A, ORG_B, ORG_C];
+  let listGets = 0;
+  let patchCount = 0;
+
+  function mockApi(onPatch: (n: number) => Promise<Response>) {
+    serverOrgs = [ORG_A, ORG_B, ORG_C];
+    listGets = 0;
+    patchCount = 0;
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.startsWith('/orgs/organizations/order')) {
+        patchCount += 1;
+        return onPatch(patchCount);
+      }
+      if (url.startsWith('/orgs/organizations') && init?.method === undefined) {
+        listGets += 1;
+        return jsonResponse({ data: serverOrgs });
+      }
+      return jsonResponse({ data: [] });
+    });
+  }
+
+  async function renderAndSettle() {
+    render(<OrganizationsPage />);
+    expect(await screen.findByText('Alpha Ltd')).toBeInTheDocument();
+    await waitFor(() => expect(renderedOrgIds()).toEqual([ORG_A.id, ORG_B.id, ORG_C.id]));
+  }
+
+  /**
+   * runAction collapses ANY request-side throw to status 0, so the client cannot
+   * tell "never reached the server" from "committed, response lost". That is why
+   * reconciliation asks the server instead of restoring a local snapshot: here
+   * the PATCH DID commit, and the correct final state is the server's new order.
+   */
+  it('adopts the server order after an ambiguous transport failure that actually committed', async () => {
+    mockApi(async () => {
+      serverOrgs = [ORG_B, ORG_A, ORG_C]; // the write landed; only the ack was lost
+      throw new TypeError('Failed to fetch');
+    });
+    await renderAndSettle();
+    const getsBefore = listGets;
+
+    drag(ORG_B.id, ORG_A.id);
+    // Optimistic order first — rules out a regression where dragging is a no-op.
+    await waitFor(() => expect(renderedOrgIds()).toEqual([ORG_B.id, ORG_A.id, ORG_C.id]));
+
+    await waitFor(() => expect(patchCount).toBe(1));
+    await waitFor(() => expect(listGets).toBeGreaterThan(getsBefore));
+    // A local rollback would show [A,B,C] here and contradict the server.
+    await waitFor(() => expect(renderedOrgIds()).toEqual([ORG_B.id, ORG_A.id, ORG_C.id]));
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+
+  /** The distinguishing case: the server order DIFFERS from what the drag produced. */
+  it('restores the server order when the PATCH is genuinely rejected', async () => {
+    mockApi(async () => jsonResponse({ error: 'Could not save order' }, false, 500));
+    await renderAndSettle();
+    const getsBefore = listGets;
+
+    drag(ORG_B.id, ORG_A.id);
+    await waitFor(() => expect(renderedOrgIds()).toEqual([ORG_B.id, ORG_A.id, ORG_C.id]));
+
+    await waitFor(() => expect(patchCount).toBe(1));
+    await waitFor(() => expect(listGets).toBeGreaterThan(getsBefore));
+    await waitFor(() => expect(renderedOrgIds()).toEqual([ORG_A.id, ORG_B.id, ORG_C.id]));
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+
+  /**
+   * Every stale-order race on this page needs a SECOND drag to start while the
+   * first request or its reconciling GET is still in flight. Dragging is
+   * disabled for that whole window, which removes the class rather than
+   * guarding each instance.
+   */
+  it('refuses a second reorder while the first is still in flight', async () => {
+    let releasePatch: ((r: Response) => void) | undefined;
+    mockApi(async () => new Promise<Response>((resolve) => { releasePatch = resolve; }));
+    await renderAndSettle();
+
+    drag(ORG_B.id, ORG_A.id);
+    await waitFor(() => expect(patchCount).toBe(1));
+    const afterFirst = renderedOrgIds();
+
+    drag(ORG_C.id, ORG_B.id); // attempted mid-flight
+
+    expect(patchCount).toBe(1);
+    expect(renderedOrgIds()).toEqual(afterFirst);
+
+    releasePatch!(jsonResponse({ ok: true }));
+    await waitFor(() => expect(patchCount).toBe(1));
+  });
+
+  /**
+   * `loading` is an early return that swaps the whole page for a spinner. The
+   * assertions must run WHILE the reconciling GET is in flight — an earlier
+   * version asserted after it resolved and passed with the fix reverted.
+   */
+  it('reconciles without blanking the page to the loading spinner', async () => {
+    let releaseGet: (() => void) | undefined;
+    let getHeld = false;
+
+    serverOrgs = [ORG_A, ORG_B, ORG_C];
+    listGets = 0;
+    patchCount = 0;
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.startsWith('/orgs/organizations/order')) {
+        patchCount += 1;
+        return jsonResponse({ error: 'nope' }, false, 500);
+      }
+      if (url.startsWith('/orgs/organizations') && init?.method === undefined) {
+        listGets += 1;
+        if (listGets > 1) {
+          getHeld = true;
+          return new Promise<Response>((resolve) => {
+            releaseGet = () => resolve(jsonResponse({ data: serverOrgs }));
+          });
+        }
+        return jsonResponse({ data: serverOrgs });
+      }
+      return jsonResponse({ data: [] });
+    });
+
+    await renderAndSettle();
+    drag(ORG_B.id, ORG_A.id);
+    await waitFor(() => expect(getHeld).toBe(true));
+
+    expect(renderedOrgIds().length).toBe(3);
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+
+    releaseGet!();
+    await waitFor(() => expect(renderedOrgIds()).toEqual([ORG_A.id, ORG_B.id, ORG_C.id]));
+  });
+});

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -7,9 +7,11 @@ import OrganizationForm from './OrganizationForm';
 import SiteList, { type Site } from './SiteList';
 import SiteForm from './SiteForm';
 import BulkOrgImport from '../organizations/BulkOrgImport';
-import { fetchWithAuth } from '../../stores/auth';
+import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import { extractApiError } from '@/lib/apiError';
+import { runAction, ActionError } from '@/lib/runAction';
+import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 
 type ModalMode = 'closed' | 'add' | 'edit' | 'delete';
@@ -81,6 +83,18 @@ export default function OrganizationsPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [showBulkImport, setShowBulkImport] = useState(false);
   const [draggedOrgId, setDraggedOrgId] = useState<string | null>(null);
+  /**
+   * True from the moment a reorder PATCH is issued until its reconciliation
+   * settles. Dragging is disabled meanwhile, which SERIALIZES reorders: every
+   * stale-order race on this page needs a second drag to start while the first
+   * request (or its reconciling GET) is still in flight, so removing that
+   * overlap removes the class rather than guarding each instance.
+   *
+   * Before this change the overlap was blocked only as a side effect of the
+   * full-page loading spinner unmounting the draggable rows — which the silent
+   * reconciliation above deliberately no longer does.
+   */
+  const [reorderPending, setReorderPending] = useState(false);
   const [dragOverOrgId, setDragOverOrgId] = useState<string | null>(null);
 
   // Sites state
@@ -106,15 +120,33 @@ export default function OrganizationsPage() {
     return organizations.filter(org => org.name.toLowerCase().includes(q));
   }, [organizations, searchQuery]);
 
-  const fetchOrganizations = useCallback(async () => {
+  /**
+   * `silent` skips the page-level loading flag. `loading` is an EARLY RETURN
+   * that replaces the whole page with a spinner, which is right for the first
+   * load and wrong for a background reconciliation: the reorder catch would
+   * otherwise blank the list the user is looking at, right as its error toast
+   * appears, and take their scroll position and selected org with it.
+   */
+  const fetchOrganizations = useCallback(async (options?: { silent?: boolean }) => {
+    const silent = options?.silent === true;
     try {
-      setLoading(true);
+      if (!silent) setLoading(true);
       setError(undefined);
       const organizations = await fetchAllOrganizations<Organization>(async (page, limit) => {
         const response = await fetchWithAuth(`/orgs/organizations?page=${page}&limit=${limit}`);
         if (!response.ok) {
           if (response.status === 401) {
-            void navigateTo('/login', { replace: true });
+            // handleSessionExpired, NOT a bare navigateTo('/login'): this GET
+            // runs immediately after a successful create/delete (via
+            // refreshOrgs), so its 401 lands while fetchWithAuth may already
+            // have started the real expiry redirect — which carries `next` and
+            // `reason`. A second, bare navigation replaces that destination
+            // with a plain /login. handleSessionExpired is idempotent
+            // (sessionExpiryInFlight), so calling it here either no-ops into
+            // the redirect already running, or performs the full logout for a
+            // 401 that survived a SUCCESSFUL refresh — the case where
+            // fetchWithAuth returns the 401 without handling it at all.
+            handleSessionExpired();
             return null;
           }
           throw new Error(t('organizationsPage.errors.fetchOrganizations'));
@@ -126,7 +158,7 @@ export default function OrganizationsPage() {
     } catch (err) {
       setError(err instanceof Error ? err.message : t('organizationsPage.errors.generic'));
     } finally {
-      setLoading(false);
+      if (!silent) setLoading(false);
     }
   }, [t]);
 
@@ -251,16 +283,65 @@ export default function OrganizationsPage() {
   };
 
   const persistOrganizationOrder = useCallback(async (orderedIds: string[]) => {
+    setReorderPending(true);
     try {
-      const res = await fetchWithAuth('/orgs/organizations/order', {
-        method: 'PATCH',
-        body: JSON.stringify({ orderedIds })
+      // runAction, not setError: this handler was SILENT. It set the page error
+      // and then called fetchOrganizations() to revert the optimistic order —
+      // and that function calls setError(undefined) before its first await, so
+      // React batches the two updates and renders no failure at all. A toast
+      // survives the refetch.
+      await runAction({
+        request: () =>
+          fetchWithAuth('/orgs/organizations/order', {
+            method: 'PATCH',
+            body: JSON.stringify({ orderedIds })
+          }),
+        errorFallback: t('organizationsPage.errors.saveOrder'),
+        onUnauthorized: handleSessionExpired,
       });
-      if (!res.ok) throw new Error(`Reorder failed (${res.status})`);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t('organizationsPage.errors.saveOrder'));
-      // Revert by re-fetching the authoritative order from the server.
-      void fetchOrganizations();
+    } catch {
+      // Re-fetch the authoritative order. Two earlier attempts were wrong in
+      // instructive ways, so the reasoning is worth keeping:
+      //
+      //   1. Skipping reconciliation for status 0 (to dodge a redirect race)
+      //      left an ordinary dropped connection showing an order the server
+      //      never accepted, with only a transient toast and no correction.
+      //   2. Restoring a locally captured pre-drag array fixes that but CANNOT
+      //      be correct: `runAction` collapses every request-side throw to
+      //      status 0, so a PATCH that COMMITTED and then lost its response is
+      //      indistinguishable from one that never arrived. Restoring locally
+      //      would then show an order the server does not have — the same
+      //      lie, in the other direction. It also races an in-flight
+      //      authoritative GET and can clobber newer data with an older
+      //      snapshot.
+      //
+      // Only the server knows what actually persisted, so the closest thing to
+      // a correct answer is to ask it. Two limits, stated rather than implied:
+      //
+      //   - A slow GET could install an order that a later reorder already
+      //     superseded. That needs a SECOND drag to overlap the first request,
+      //     which `reorderPending` now prevents by disabling dragging until
+      //     this settles. A client generation counter was tried first and
+      //     reverted: it discarded genuinely current create/delete/import
+      //     refreshes — leaving a newly created org invisible — while still
+      //     not covering a GET resolving during an in-flight PATCH.
+      //     Serializing the drags removes the overlap those guards were
+      //     chasing. Two reorders from SEPARATE TABS can still interleave;
+      //     that one needs a revision or compare-and-swap on the endpoint,
+      //     which has neither.
+      //   - The list endpoint pages by `created_at, id` and applies the
+      //     partner's preferred order only WITHIN each page, so past the first
+      //     page it cannot report a cross-page order at all. Reconciliation is
+      //     therefore authoritative only up to that pre-existing server-side
+      //     limit, which this change does not introduce or fix.
+      //
+      // The refetch was previously unsafe purely because fetchOrganizations
+      // answered its own 401 with a bare navigateTo('/login'), which raced the
+      // richer session-expiry redirect. That is fixed at its source above, so
+      // the 401 path of this second GET is idempotent.
+      await fetchOrganizations({ silent: true });
+    } finally {
+      setReorderPending(false);
     }
   }, [fetchOrganizations, t]);
 
@@ -316,16 +397,23 @@ export default function OrganizationsPage() {
   const handleSubmit = async (values: OrganizationFormValues) => {
     setSubmitting(true);
     try {
-      const response = await fetchWithAuth('/orgs/organizations', {
-        method: 'POST',
-        body: JSON.stringify(values)
+      // runAction, not setError. The failure has to be VISIBLE, and the page
+      // error banner is not: it renders outside this modal, which stays open on
+      // failure behind a `fixed inset-0 z-50` overlay, so the message landed
+      // underneath the form the user is still looking at. Nothing is rendered
+      // inside the dialog itself. The toast container is mounted after the page
+      // slot in DashboardLayout at the same z-50, so it paints above the
+      // overlay — which is what makes the API's own text reachable at all.
+      const createdOrg = await runAction<{ id?: string } | null>({
+        request: () =>
+          fetchWithAuth('/orgs/organizations', {
+            method: 'POST',
+            body: JSON.stringify(values)
+          }),
+        errorFallback: t('organizationsPage.errors.saveOrganization'),
+        onUnauthorized: handleSessionExpired,
+        parseSuccess: (data) => (data ?? null) as { id?: string } | null,
       });
-
-      if (!response.ok) {
-        throw new Error(t('organizationsPage.errors.saveOrganization'));
-      }
-
-      const createdOrg = await response.json().catch(() => null) as { id?: string } | null;
 
       await refreshOrgs();
       handleCloseModal();
@@ -359,7 +447,23 @@ export default function OrganizationsPage() {
         }
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : t('organizationsPage.errors.generic'));
+      // runAction already surfaced an ActionError as a toast, and onUnauthorized
+      // is redirecting on 401 — re-storing either in the page banner would be a
+      // second, INVISIBLE copy (it renders behind this modal). Only a
+      // non-ActionError escaped runAction untoasted, so only that is surfaced.
+      if (!(err instanceof ActionError)) {
+        // A toast, NOT setError. The modal is still open on failure and the
+        // page banner renders behind its `fixed inset-0 z-50` overlay, so
+        // routing an unexpected error there reproduces the exact invisibility
+        // this change removes. Reachable in practice: `runAction` calls
+        // `onUnauthorized` OUTSIDE its request try/catch, so a throw from
+        // handleSessionExpired's logout or location.replace arrives here as a
+        // non-ActionError.
+        showToast({
+          message: err instanceof Error ? err.message : t('organizationsPage.errors.generic'),
+          type: 'error'
+        });
+      }
     } finally {
       setSubmitting(false);
     }
@@ -370,13 +474,14 @@ export default function OrganizationsPage() {
 
     setSubmitting(true);
     try {
-      const response = await fetchWithAuth(`/orgs/organizations/${selectedOrg.id}`, {
-        method: 'DELETE'
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/orgs/organizations/${selectedOrg.id}`, {
+            method: 'DELETE'
+          }),
+        errorFallback: t('organizationsPage.errors.deleteOrganization'),
+        onUnauthorized: handleSessionExpired,
       });
-
-      if (!response.ok) {
-        throw new Error(t('organizationsPage.errors.deleteOrganization'));
-      }
 
       const deletedId = selectedOrg.id;
       await refreshOrgs();
@@ -386,7 +491,23 @@ export default function OrganizationsPage() {
         setSelectedOrg(null);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : t('organizationsPage.errors.generic'));
+      // runAction already surfaced an ActionError as a toast, and onUnauthorized
+      // is redirecting on 401 — re-storing either in the page banner would be a
+      // second, INVISIBLE copy (it renders behind this modal). Only a
+      // non-ActionError escaped runAction untoasted, so only that is surfaced.
+      if (!(err instanceof ActionError)) {
+        // A toast, NOT setError. The modal is still open on failure and the
+        // page banner renders behind its `fixed inset-0 z-50` overlay, so
+        // routing an unexpected error there reproduces the exact invisibility
+        // this change removes. Reachable in practice: `runAction` calls
+        // `onUnauthorized` OUTSIDE its request try/catch, so a throw from
+        // handleSessionExpired's logout or location.replace arrives here as a
+        // non-ActionError.
+        showToast({
+          message: err instanceof Error ? err.message : t('organizationsPage.errors.generic'),
+          type: 'error'
+        });
+      }
     } finally {
       setSubmitting(false);
     }
@@ -442,20 +563,39 @@ export default function OrganizationsPage() {
         : '/orgs/sites';
       const method = siteModalMode === 'edit' ? 'PATCH' : 'POST';
 
-      const response = await fetchWithAuth(url, {
-        method,
-        body: JSON.stringify(payload)
+      // This handler already read the body — but it threw into `setError`,
+      // whose banner sits behind the still-open site modal. runAction keeps the
+      // extracted message and puts it somewhere the user can actually see.
+      await runAction({
+        request: () => fetchWithAuth(url, { method, body: JSON.stringify(payload) }),
+        // `organizationsPage.errors.saveSite` interpolates {{status}}, which
+        // runAction does not expose when building the fallback — passing 0
+        // renders the nonsense "Failed to save site (0)". This is the existing
+        // status-free sibling, present in all 8 locales, so no new keys and
+        // nothing for localeParity to catch.
+        errorFallback: t('siteDetailPage.errors.saveSite'),
+        onUnauthorized: handleSessionExpired,
       });
-
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(extractApiError(data, t('organizationsPage.errors.saveSite', { status: response.status })));
-      }
 
       await fetchSites(selectedOrg.id);
       handleCloseSiteModal();
     } catch (err) {
-      setError(err instanceof Error ? err.message : t('organizationsPage.errors.generic'));
+      // See the org handlers above: runAction already toasted an ActionError,
+      // and onUnauthorized handles 401. Only a non-ActionError escape is
+      // unsurfaced, and the page banner is invisible behind this modal anyway.
+      if (!(err instanceof ActionError)) {
+        // A toast, NOT setError. The modal is still open on failure and the
+        // page banner renders behind its `fixed inset-0 z-50` overlay, so
+        // routing an unexpected error there reproduces the exact invisibility
+        // this change removes. Reachable in practice: `runAction` calls
+        // `onUnauthorized` OUTSIDE its request try/catch, so a throw from
+        // handleSessionExpired's logout or location.replace arrives here as a
+        // non-ActionError.
+        showToast({
+          message: err instanceof Error ? err.message : t('organizationsPage.errors.generic'),
+          type: 'error'
+        });
+      }
     } finally {
       setSiteSubmitting(false);
     }
@@ -465,15 +605,32 @@ export default function OrganizationsPage() {
     if (!selectedSite || !selectedOrg) return;
     setSiteSubmitting(true);
     try {
-      const response = await fetchWithAuth(`/orgs/sites/${selectedSite.id}`, {
-        method: 'DELETE'
+      await runAction({
+        request: () =>
+          fetchWithAuth(`/orgs/sites/${selectedSite.id}`, { method: 'DELETE' }),
+        errorFallback: t('organizationsPage.errors.deleteSite'),
+        onUnauthorized: handleSessionExpired,
       });
-      if (!response.ok) throw new Error(t('organizationsPage.errors.deleteSite'));
 
       await fetchSites(selectedOrg.id);
       handleCloseSiteModal();
     } catch (err) {
-      setError(err instanceof Error ? err.message : t('organizationsPage.errors.generic'));
+      // See the org handlers above: runAction already toasted an ActionError,
+      // and onUnauthorized handles 401. Only a non-ActionError escape is
+      // unsurfaced, and the page banner is invisible behind this modal anyway.
+      if (!(err instanceof ActionError)) {
+        // A toast, NOT setError. The modal is still open on failure and the
+        // page banner renders behind its `fixed inset-0 z-50` overlay, so
+        // routing an unexpected error there reproduces the exact invisibility
+        // this change removes. Reachable in practice: `runAction` calls
+        // `onUnauthorized` OUTSIDE its request try/catch, so a throw from
+        // handleSessionExpired's logout or location.replace arrives here as a
+        // non-ActionError.
+        showToast({
+          message: err instanceof Error ? err.message : t('organizationsPage.errors.generic'),
+          type: 'error'
+        });
+      }
     } finally {
       setSiteSubmitting(false);
     }
@@ -510,7 +667,7 @@ export default function OrganizationsPage() {
         <p className="text-sm text-destructive">{error}</p>
         <button
           type="button"
-          onClick={fetchOrganizations}
+          onClick={() => void fetchOrganizations()}
           className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
         >
           {t('organizationsPage.actions.tryAgain')}
@@ -550,7 +707,7 @@ export default function OrganizationsPage() {
         <BulkOrgImport
           onImported={() => void fetchOrganizations()}
           onClose={() => setShowBulkImport(false)}
-          onUnauthorized={() => void navigateTo('/login', { replace: true })}
+          onUnauthorized={handleSessionExpired}
         />
       )}
 
@@ -587,7 +744,7 @@ export default function OrganizationsPage() {
             ) : (
               <ul className="divide-y">
                 {filteredOrgs.map(org => {
-                  const dragEnabled = searchQuery.trim().length === 0;
+                  const dragEnabled = searchQuery.trim().length === 0 && !reorderPending;
                   const isDragging = draggedOrgId === org.id;
                   const isDropTarget = dragOverOrgId === org.id && draggedOrgId !== org.id;
                   return (

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -34,6 +34,14 @@ const TARGET_GLOBS = [
   'src/components/settings/PartnerSettingsPage.tsx',
   'src/components/settings/PartnerAiProviderTab.tsx',
   'src/components/settings/OrgSettingsPage.tsx',
+  // Adopted in #3989: every mutation here (org create/delete, site save/delete,
+  // and the drag-reorder PATCH that was fully silent) now goes through
+  // runAction. Note what this guard does and does not enforce: it checks that
+  // each mutating fetch is lexically INSIDE a runAction call, so it catches a
+  // new mutation added outside one. It does NOT inspect catch blocks, so it
+  // cannot by itself stop a handler routing an error back to setError, whose
+  // banner renders behind this page's modals.
+  'src/components/settings/OrganizationsPage.tsx',
   'src/components/settings/LoginBrandingCard.tsx',
   'src/components/settings/ConnectSsoCard.tsx',
   'src/components/patches/PatchesPage.tsx',
@@ -350,7 +358,8 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(96);
+    // 97 since #3989 added OrganizationsPage.tsx to the guarded set.
+    expect(absoluteFiles.length).toBe(97);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/apiError.test.ts
+++ b/apps/web/src/lib/apiError.test.ts
@@ -225,4 +225,89 @@ describe('extractApiError — new shapes', () => {
   it('falls back when nothing parses', () => {
     expect(extractApiError({ weird: 1 }, 'fallback msg')).toBe('fallback msg');
   });
+
+  // #3989 — hand-rolled route validators return `details` as a plain array of
+  // strings, not a zod payload. `joinZodIssues` wants objects carrying
+  // `.message` and returns null for strings, so this was dropped entirely and
+  // the user saw only the generic top-level `error`: the same sentence whether
+  // the scheme was wrong, the hostname was missing, or SSRF protection rejected
+  // the target.
+  it('renders a plain string[] details alongside the top-level error', () => {
+    expect(
+      extractApiError(
+        {
+          error: 'Invalid webhook channel configuration',
+          details: ['Webhook URL must use HTTPS', 'Webhook URL hostname is required'],
+        },
+        'FALLBACK'
+      )
+    ).toBe(
+      'Invalid webhook channel configuration: Webhook URL must use HTTPS; Webhook URL hostname is required'
+    );
+  });
+
+  it('ignores non-string entries rather than printing [object Object]', () => {
+    // EXACT, not toContain: `toContain('real message')` also passes when the
+    // output additionally contains "[object Object]" or "null", which is the
+    // precise thing this test exists to rule out.
+    expect(
+      extractApiError({ error: 'Nope', details: [{ a: 1 }, 'real message', null] }, 'FALLBACK')
+    ).toBe('Nope: real message');
+  });
+
+  // The ordering bug: with a zod-issues branch tried BEFORE a string branch,
+  // this returned 'Bad request: name is required' and silently dropped the
+  // plain string. Both representations can appear in one array and both are
+  // reasons the user needs.
+  it('keeps BOTH object .message and plain-string entries in a mixed array', () => {
+    expect(
+      extractApiError(
+        {
+          error: 'Bad request',
+          details: [{ message: 'name is required' }, 'Webhook URL must use HTTPS']
+        },
+        'FALLBACK'
+      )
+    ).toBe('Bad request: name is required; Webhook URL must use HTTPS');
+  });
+
+  // A pure zod issues array must render EXACTLY as it did before the array
+  // branches were merged. `toBe`, not `toContain`: toContain would also pass
+  // on duplicated text, a changed prefix, or extra trailing garbage, which is
+  // precisely what a bad merge would produce.
+  it('renders a pure zod issues array identically after the branch merge', () => {
+    expect(
+      extractApiError({ error: 'Bad', details: [{ message: 'name is required' }] }, 'FALLBACK')
+    ).toBe('Bad: name is required');
+  });
+
+  // The aggregate shape: the top-level error is the SAME text as the details,
+  // just joined. No individual message equals it, so a per-message rule alone
+  // prints the whole thing twice.
+  it('suppresses details that are only the top-level error split into parts', () => {
+    expect(
+      extractApiError(
+        {
+          error: 'name is required; email is invalid',
+          details: [{ message: 'name is required' }, { message: 'email is invalid' }]
+        },
+        'FALLBACK'
+      )
+    ).toBe('name is required; email is invalid');
+  });
+
+  // The per-message dedup: comparing the top-level error against the WHOLE
+  // joined details string only dedupes when every detail repeats it, so this
+  // input printed 'name is required' twice.
+  it('drops only the detail that repeats the top-level error, keeping the rest', () => {
+    expect(
+      extractApiError(
+        {
+          error: 'name is required',
+          details: [{ message: 'name is required' }, 'Webhook URL must use HTTPS']
+        },
+        'FALLBACK'
+      )
+    ).toBe('name is required: Webhook URL must use HTTPS');
+  });
 });

--- a/apps/web/src/lib/apiError.ts
+++ b/apps/web/src/lib/apiError.ts
@@ -1,7 +1,8 @@
 // Parses error response bodies returned by the API. Shapes handled: the
 // shared zValidator wrapper's `{error: string, details}` (every validation
 // 400 since #2201 — apps/api/src/lib/validation.ts), a plain
-// `{error: string}`, Hono's default `{message: string}`, and the legacy
+// `{error: string}`, a plain `details: string[]` from hand-rolled route
+// validators, Hono's default `{message: string}`, and the legacy
 // pre-#2201 raw zod-validator `{error: {issues: [...]}}` / serialized
 // ZodError bodies (kept defensively for older deployed APIs).
 // Falling back to `new Error(obj)` produces `[object Object]` in the UI;
@@ -45,12 +46,79 @@ function joinZodFlatten(value: unknown): string | null {
   return parts.length > 0 ? parts.join('; ') : null;
 }
 
-function detailsToString(details: unknown): string | null {
-  if (typeof details === 'string' && details.length > 0) return details;
-  const fromIssues = joinZodIssues(details);
-  if (fromIssues) return fromIssues;
+// Renders a `details` ARRAY in ONE pass, accepting both representations an
+// entry can take: a plain message string (what hand-rolled route validators
+// emit, e.g. the notification-channel create's `{ error: 'Invalid webhook
+// channel configuration', details: ['Webhook URL must use HTTPS', ...] }`) and
+// a zod-style object carrying `.message`.
+//
+// One pass rather than two branches, because trying `joinZodIssues` first and
+// falling back to a string-only join DROPS HALF of a mixed array: the first
+// branch returns as soon as any object has a `.message`, so
+// `[{ message: 'name is required' }, 'Webhook URL must use HTTPS']` rendered
+// only the object's message and silently discarded the string. Nothing
+// guarantees a route emits a homogeneous array, and dropping a reason is the
+// exact failure this whole change exists to remove.
+//
+// Equivalent to the old zod-issues path for a pure-object array: joinZodIssues
+// reads ONLY `.message` (it ignores `path`), so an all-objects array renders
+// identically here.
+function collectMessageArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const messages = value
+    .map((entry) => {
+      if (typeof entry === 'string') return entry.length > 0 ? entry : null;
+      if (entry && typeof entry === 'object') {
+        const m = (entry as ZodIssue).message;
+        return typeof m === 'string' && m.length > 0 ? m : null;
+      }
+      return null;
+    })
+    .filter((m): m is string => m !== null);
+  return messages.length > 0 ? messages : null;
+}
+
+/**
+ * `exclude` holds the message parts already chosen (currently the top-level
+ * `error`). Array details are de-duplicated PER MESSAGE against it, not as one
+ * joined blob: comparing the whole joined string only dedupes when EVERY
+ * detail repeats the top-level error, so
+ * `{ error: 'name is required', details: [{ message: 'name is required' },
+ * 'Webhook URL must use HTTPS'] }` rendered the first message twice.
+ */
+function detailsToString(details: unknown, exclude: readonly string[]): string | null {
+  if (typeof details === 'string' && details.length > 0) {
+    return exclude.includes(details) ? null : details;
+  }
+  // Handles zod issue objects AND plain strings in the same array — see
+  // collectMessageArray for why these are not two ordered branches.
+  const messages = collectMessageArray(details);
+  if (messages) {
+    // Two dedup rules, because each alone regresses a real shape:
+    //
+    //   per-message — `{ error: 'name is required', details: [{message:'name
+    //   is required'}, 'Webhook URL must use HTTPS'] }` must not echo the
+    //   first message; comparing only the JOINED string never matches here.
+    //
+    //   whole-string — `{ error: 'a; b', details: [{message:'a'},
+    //   {message:'b'}] }` is the SAME text split up; no individual message
+    //   equals the aggregate, so per-message alone renders it all twice.
+    //
+    // Removing at most one occurrence per excluded part (rather than every
+    // match) keeps a repeat that a second, distinct failure produced.
+    const remaining = [...exclude];
+    const fresh = messages.filter((m) => {
+      const i = remaining.indexOf(m);
+      if (i === -1) return true;
+      remaining.splice(i, 1);
+      return false;
+    });
+    if (fresh.length === 0) return null;
+    const joined = fresh.join('; ');
+    return exclude.includes(joined) ? null : joined;
+  }
   const fromFlatten = joinZodFlatten(details);
-  if (fromFlatten) return fromFlatten;
+  if (fromFlatten) return exclude.includes(fromFlatten) ? null : fromFlatten;
   return null;
 }
 
@@ -84,8 +152,8 @@ export function extractApiError(data: unknown, fallback: string): string {
     if (fromError) parts.push(fromError);
   }
 
-  const fromDetails = detailsToString(body.details);
-  if (fromDetails && !parts.includes(fromDetails)) parts.push(fromDetails);
+  const fromDetails = detailsToString(body.details, parts);
+  if (fromDetails) parts.push(fromDetails);
 
   if (parts.length === 0 && topLevelIssues) parts.push(topLevelIssues);
 


### PR DESCRIPTION
Closes #3989.

Two flows discarded the specific error the API returned. Investigating turned up that **each half of the issue was right about a different thing, and I got the first attempt wrong** — recording that here because it shaped the diff.

### Part 1 — `runAction` alone would not have fixed the channel case

The issue notes that `runAction` "already has `extractApiError()`, which would have surfaced the real message". True for the org 409. **Not** true for the channel 400:

```jsonc
{ "error": "Invalid webhook channel configuration",
  "details": ["Webhook URL must use HTTPS", "Webhook URL hostname is required"] }
```

`extractApiError` returned only the generic sentence. `detailsToString` tries a string, then `joinZodIssues` — which requires objects carrying `.message` and returns `null` for strings — then `joinZodFlatten` (`{formErrors, fieldErrors}`). A plain `string[]` matches none, so `details` was dropped before any caller saw it.

Added a `joinStringArray` branch **after** the zod branches, so an issues array still renders through its own path. Control:

```
× renders a plain string[] details alongside the top-level error
× ignores non-string entries rather than printing [object Object]
× surfaces the details[] reasons in the error toast, not just the generic error
  Tests  3 failed | 51 passed
```

That third one is end-to-end through the channel save path. The existing channel test asserted only `{ type: 'error' }`, so the whole regression could return while it stayed green.

### Part 2 — my first attempt made the message correct and still invisible

I initially read the body into `setError` and argued against converting to `runAction`, on the grounds that it would duplicate an inline form error. **That was wrong, and I had not checked it.** In this file:

- the error banner renders at `OrganizationsPage.tsx:579`, **outside** the modals
- every modal is `fixed inset-0 z-50` (lines 791/811/841/895) and covers it
- **nothing renders inside any dialog**
- the modal closes only on success

So a 409 landed underneath the form the user is still looking at. The pre-existing site-save handler has the same shape — it reads the body correctly and puts the result somewhere invisible.

Toasts do clear it: `DashboardLayout.astro` renders `<slot />` at line 56 and `<ToastContainer>` at line 62, so at equal `z-50` the toast is later in DOM order and paints above the overlay.

**So all five mutations now go through `runAction`:** org create, org delete, site save, site delete — and the drag-reorder `PATCH`, which was **entirely silent**. That one set the page error and then called `fetchOrganizations()` to revert the optimistic order; that function calls `setError(undefined)` before its first `await`, so React batches the two updates and renders no failure at all.

`OrganizationsPage.tsx` is added to the guarded set in `no-silent-mutations.test.ts` so it cannot regress, which required bumping that suite's file count 96 → 97.

This also settles the contract point: the file previously had zero `runAction` calls, was not in `runActionAllowlist.ts`, and was not in the guarded target set — so CI blessed the `AGENTS.md` violation by omission.

### Two further fixes from review

**`onUnauthorized` on every call.** `runAction` deliberately does not toast a 401 — it relies on that callback for navigation. Omitting it meant a 401 fell into the catch and back into the page banner behind the modal: silent again, the exact bug this PR exists to remove. All five now pass `handleSessionExpired` — **not** a bare `navigateTo('/login')`, which is what
the rest of this file and ~44 other call sites do. A bare navigate races and clobbers a richer
destination: `fetchWithAuth` funnels its own expiry 401s through `handleSessionExpired`, which has
already called `window.location.replace(loginPathWithNext() + '&reason=...')`, so a second bare
navigation drops both the `next` and the `reason`. Passing the function itself is correct in both
directions — it early-returns on `sessionExpiryInFlight` when an expiry is already redirecting, and
on a 401 that is *not* session expiry it performs the real logout the bare navigate only implied.
**Changing the five callbacks did not close every 401 path on the page.** `fetchOrganizations` had
its own bare navigate, and create/delete call it immediately after a successful mutation through
`refreshOrgs` — so a 401 on that follow-up GET produced exactly the clobber the callbacks had just
been fixed to avoid. There is a second variant with no redirect at all behind it: when a token
refresh *succeeds* but the replayed GET still returns 401, `fetchWithAuth` returns that response
without calling `handleSessionExpired`, so the bare navigation was the only redirect and `next` and
`reason` were simply lost. That branch now calls `handleSessionExpired` too.

The `BulkOrgImport` prop passed a bare navigate too, and it is reached from this page's own bulk
mutations, so it now passes `handleSessionExpired` as well. The four modal catches now only `setError` for a **non**-`ActionError` escape, since `runAction` has already toasted anything else — otherwise every failure had a second, invisible copy. `fetchOrganizations`' catch is untouched: it is a GET, and its banner is not behind a modal.

**The failed reorder reconciles with the server, and getting there took three attempts.** The
reorder is optimistic, so a failure leaves the user looking at an order the server may not have.

1. I first *skipped* reconciliation for `ActionError` status 0, to dodge a race between the revert
   GET and the login redirect. That was worse: `runAction` collapses any request-side throw to 0, so
   an ordinary dropped connection took the skip path and left a wrong order on screen indefinitely,
   corrected only by a page load nothing guarantees.
2. I then captured the pre-drag array and restored it locally. That fixes the visible symptom and is
   still wrong, for a reason worth stating plainly: **status 0 does not mean the server rejected the
   write.** A `PATCH` that committed and then lost its response is indistinguishable, client-side,
   from one that never arrived. Restoring locally would show an order the server does not have —
   the same lie in the other direction. It also races an in-flight authoritative GET and can clobber
   newer data with an older snapshot, and it needed a sequence guard for overlapping drags that
   still could not produce a correct answer when both requests failed.
3. Only the server knows what persisted, so the catch asks it: `void fetchOrganizations()`.

The refetch was never the problem. It was unsafe **only** because `fetchOrganizations` answered its
own 401 with a bare `navigateTo('/login')` — the very bug fixed above. With that gone, a second GET
is harmless, and reconciliation needs no status special-casing and no sequence guard: whichever
refetch lands last reports the server's real order, whatever combination of requests committed.

**Reorders are serialized, which is what actually removes the stale-order races.** Every one of them
needs a *second* drag to begin while the first request or its reconciling GET is still in flight, so
dragging is disabled from the moment a reorder is issued until it settles (`reorderPending`).

I reached that by discarding two worse answers. A client generation counter (bump per load and per
committed reorder, discard stale loads) was implemented and **reverted**: it threw away genuinely
current create/delete/import refreshes — a newly created org could stay invisible with no
replacement fetch — while still not covering a GET that resolves during an in-flight PATCH. And the
overlap had previously been blocked only as an *accident* of the full-page loading spinner
unmounting the draggable rows, which the silent reconciliation above deliberately stops doing; so
"this race predates the PR" was not quite true, and serializing is what makes it true again.

What is still not fixed, and is written at the call site: two reorders from **separate tabs** can
interleave, because the endpoint fully replaces the stored order with no revision or
compare-and-swap.

**Pagination.** `GET /orgs/organizations` pages by `created_at, id` (`LIMIT`/`OFFSET`) and applies
the partner's `organizationOrder` **only within the page it just selected**, so past the first page
it cannot express a cross-page order at all. That affects the ordinary list render, not just
reconciliation. Pre-existing, not fixed here — filed as #4004.

**Reconciliation is silent.** `loading` is an early return that swaps the whole page for a spinner —
right for the first load, wrong for a background correction. Because the refetch now runs on *every*
reorder failure rather than rarely, it blanked the list at the exact moment the failure toast
appeared, taking the user's scroll position and selected org with it. `fetchOrganizations` takes a
`{ silent }` option that skips only the loading flag. `tsc` caught a related hazard while adding it:
the retry button passed `fetchOrganizations` directly as `onClick`, so a click event would have
arrived as the options object — fixed at the call site rather than by widening the parameter type.

**The `saveSite` fallback string.** `organizationsPage.errors.saveSite` interpolates `{{status}}`, which `runAction` does not expose when building a fallback — passing `0` renders "Failed to save site (0)". It now uses the existing status-free sibling `siteDetailPage.errors.saveSite`, which is present in all 8 locales, so no new keys and nothing for locale parity to catch.

**The reorder's revert refetch on 401.** `persistOrganizationOrder` re-fetches the authoritative order after a failure. On a 401 that second authenticated GET races the `onUnauthorized` redirect and can start its own bare `/login` navigation from the fetch's own 401 branch, dropping the destination the session-expiry redirect intended to carry. It no longer needs a status guard at all: reconciliation is unconditional and authoritative.

### Two more fixes from review

**Mixed `details` arrays lost half their messages.** With a zod-issues branch tried before a
string branch, `details: [{ message: 'name is required' }, 'Webhook URL must use HTTPS']` rendered
only the object's message and silently dropped the string — the same class of loss this PR exists
to remove, reintroduced by my own fix's branch ordering. Nothing guarantees a route emits a
homogeneous array. The two branches are now a single pass that accepts both representations, which
is also less code. Equivalent for a pure-object array, because `joinZodIssues` reads only
`.message` and ignores `path`. Control: restoring the ordered branches reds the new mixed test and
nothing else (`1 failed | 38 passed`).

**Unexpected modal errors went to the known-invisible banner.** The four modal catches fell back to
`setError` for a non-`ActionError` — the same banner the comment two lines above calls invisible.
Reachable in practice: `runAction` invokes `onUnauthorized` *outside* its request try/catch, so a
throw from `handleSessionExpired`'s `logout()` or `location.replace` arrives there. They toast now.

### One red the fix caused, and the control on the repair

Adding the `handleSessionExpired` import broke four tests in
`OrganizationsPage.firstSite.test.tsx` — a **pre-existing** file this diff otherwise does not touch.
It mocks `../../stores/auth` with a factory returning only `fetchWithAuth`, and Vitest throws on any
export the factory omits. So merely *building* the `runAction` options object threw
`No "handleSessionExpired" export is defined on the mock` before a request was ever made, and the
create flow appeared to silently do nothing — which looks nothing like a missing mock entry. The
factory now returns it, with a comment saying why.

The repair is test-infrastructure, so the useful question is whether the test still discriminates.
Control — break only the nag decision (`existingSites?.length === 0` → `=== -1`), smallest possible
mutation, query surface untouched:

```
Tests  1 failed | 3 passed (4)
```

Exactly the nag test reds and the other three stay green. That rules out the failure mode where a
control reds because it removed the thing the test queries by, which would have killed all four.

### Verification

- `tsc --noEmit` clean
- `eslint src` clean
- full web suite green (see the run cited below)
- node v22.23.2, matching `apps/web/.nvmrc`

`OrganizationsPage.mutationFeedback.test.tsx` is new. Its reorder tests drive reconciliation
through a mock server whose order the test controls, so they prove the list came from the SERVER
rather than a client snapshot. The important one simulates the ambiguous case — the `PATCH`
commits, then the response is lost — and asserts the UI ends on the server's NEW order; a local
rollback fails it. Each also asserts the optimistic order appeared FIRST, so a regression making
the drag a no-op cannot satisfy the final assertion for free. Each was controlled:

| control | expected | observed |
|---|---|---|
| revert to a local snapshot rollback | all three reorder tests red, 401 test green | `3 failed \| 1 passed` |
| restore the bare `navigateTo('/login')` | only the 401 test red | `1 failed \| 2 passed` |
| dedup on the whole joined string | only the dedup test red | `1 failed \| 39 passed` |
| restore the ordered zod/string branches | only the mixed-array test red | `1 failed \| 38 passed` |
| make reconciliation non-silent | only the spinner test red | `1 failed \| 4 passed` |
| remove the `reorderPending` drag gate | only the serialization test red | `1 failed \| 4 passed` |
| per-message dedup only | only the aggregate test red | `1 failed \| 40 passed` |
| whole-string dedup only | only the mixed-array test red | `1 failed \| 40 passed` |

The overlap test waits on the reconciling GET rather than on the PATCH count — the count was
already satisfied before the late rejection, so waiting on it could have finished the test before a
broken rollback ever ran.

**Dedup needs both rules; each alone regresses a real shape.** Per-message matching is required for
`{ error: 'name is required', details: [{message:'name is required'}, 'Webhook URL must use
HTTPS'] }`, where no comparison against the joined string ever matches and the first message echoes.
Whole-string matching is required for `{ error: 'a; b', details: [{message:'a'}, {message:'b'}] }`,
which is the same text split up — no individual message equals the aggregate, so per-message alone
prints all of it twice. Applying both, and removing at most one occurrence per excluded part rather
than every match, satisfies both. The two controls below show each half is load-bearing.

One of these controls initially did **not** discriminate, which is worth recording. The first
version of the spinner test passed with the fix reverted: the spinner exists only *while* the
reconciling GET is in flight, and the assertions ran after it resolved, so the test was checking a
window that had already closed. It now holds the GET open and asserts inside it. A green test whose
control stays green is not evidence of anything.

Every control above was run and observed failing against the broken version before the fix. Gate
artifacts were confirmed newer than every changed source file, so none of the results are stale.
