### PR TITLE
fix(web): confirm-gate decommission from the device list/grid kebab (#4009)

### DIFF
--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -1,6 +1,6 @@
 import '@/lib/i18n';
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import DevicesPage from './DevicesPage';
@@ -118,9 +118,10 @@ vi.mock('./DeviceFilterToolbar', () => ({ DeviceFilterToolbar: () => null }));
 vi.mock('../shared/ProgressBar', () => ({ default: () => null }));
 
 // DeviceCard stub renders the hostname so the grid contents are assertable, and
-// re-emits reboot so the GRID path through handleDeviceAction is covered too —
-// the real DeviceCard emits it from its own kebab (DeviceCard.tsx), and #3698's
-// gate lives on the shared handler, so both surfaces inherit it.
+// re-emits reboot + decommission so the GRID path through handleDeviceAction is
+// covered too — the real DeviceCard emits both from its own kebab
+// (DeviceCard.tsx:278 reboot, :320 decommission), and the #3698/#4009 gate
+// lives on the shared handler, so both surfaces inherit it.
 vi.mock('./DeviceCard', () => ({
   default: ({ device, onAction }: { device: { id: string; hostname: string }; onAction?: (action: string, device: unknown) => void }) => (
     <div data-testid={`device-card-${device.id}`}>
@@ -132,6 +133,12 @@ vi.mock('./DeviceCard', () => ({
         aria-label="card reboot"
         data-testid={`card-reboot-${device.id}`}
         onClick={() => onAction?.('reboot', device)}
+      />
+      <button
+        type="button"
+        aria-label="card decommission"
+        data-testid={`card-decommission-${device.id}`}
+        onClick={() => onAction?.('decommission', device)}
       />
     </div>
   ),
@@ -176,7 +183,11 @@ vi.mock('./DeviceList', () => ({
         </button>
       ))}
       {/* Drives DevicesPage.handleDeviceAction for ONE device — the row-menu /
-          grid-card path, as opposed to the bulk buttons above. */}
+          grid-card path, as opposed to the bulk buttons above. The real row
+          kebab emits these from DeviceList.tsx (:2450 reboot, :2490 restore,
+          :2502 decommission). The decommission/restore buttons are deliberately
+          text-free so they cannot collide with the sibling getByText assertions
+          that match on the word "decommissioned". */}
       {devices.map(d => (
         <button
           key={`row-reboot-${d.id}`}
@@ -186,6 +197,24 @@ vi.mock('./DeviceList', () => ({
         >
           row reboot {d.id}
         </button>
+      ))}
+      {devices.map(d => (
+        <button
+          key={`row-decommission-${d.id}`}
+          type="button"
+          aria-label={`row decommission ${d.id}`}
+          data-testid={`row-decommission-${d.id}`}
+          onClick={() => onAction?.('decommission', d)}
+        />
+      ))}
+      {devices.map(d => (
+        <button
+          key={`row-restore-${d.id}`}
+          type="button"
+          aria-label={`row restore ${d.id}`}
+          data-testid={`row-restore-${d.id}`}
+          onClick={() => onAction?.('restore', d)}
+        />
       ))}
       {onShowDecommissioned && (
         <button
@@ -1349,6 +1378,132 @@ describe('DevicesPage — bulk agent commands gated on decommissioned only (#246
     expect(vi.mocked(sendBulkWakeCommand)).not.toHaveBeenCalled();
     expect(vi.mocked(sendDeviceCommand)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(sendDeviceCommand)).toHaveBeenCalledWith(DEV_1, 'reboot');
+  });
+});
+
+// #4009: `decommission` from the row kebab / grid card fired on a single click
+// while the device DETAIL page had always confirmed it — the same split-brain
+// #3698 set out to remove, left on the one kebab action that pulls a machine out
+// of monitoring. Nothing had to be built: the dialog renderer already composes
+// `deviceActions.confirm.${action}.*` and those decommission strings already
+// shipped for the detail page. Only CONFIRM_REQUIRED_ACTIONS omitted the action,
+// which is precisely the kind of one-token regression a test pins cheaply.
+//
+// Note the 5s undo toast inside runDeviceAction is NOT this gate. It is a
+// post-hoc recovery window that a user who has looked away never sees, and it
+// was already there while the bug was live.
+describe('DevicesPage — decommission from the row/grid kebab is confirm-gated (#4009)', () => {
+  beforeEach(() => {
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [{ ...rawDevice(DEV_1, 'host-alpha'), status: 'online' }],
+    } as never);
+  });
+
+  async function mockedDecommission() {
+    const { decommissionDevice } = await import('../../services/deviceActions');
+    vi.mocked(decommissionDevice).mockResolvedValue(undefined as never);
+    return vi.mocked(decommissionDevice);
+  }
+
+  async function toastTypes(): Promise<string[]> {
+    const { showToast } = await import('../shared/Toast');
+    return vi.mocked(showToast).mock.calls.map(c => c[0].type);
+  }
+
+  it('row kebab opens the dialog instead of decommissioning, in the detail page\'s own words', async () => {
+    const decommissionDevice = await mockedDecommission();
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByTestId(`row-decommission-${DEV_1}`));
+
+    // Pre-#4009 this went straight into runDeviceAction, whose decommission
+    // branch synchronously raises the undo toast and schedules the API call.
+    // Neither may happen before the operator has answered.
+    expect(decommissionDevice).not.toHaveBeenCalled();
+    expect(await toastTypes()).not.toContain('undo');
+
+    // The SAME keys DeviceActions.tsx renders — proving no new copy was needed
+    // and that the two screens still read identically.
+    expect(await screen.findByText('Decommission Device')).toBeTruthy();
+    expect(screen.getByText(/decommission host-alpha\?/i)).toBeTruthy();
+
+    const confirmBtn = await screen.findByTestId('confirm-device-action');
+    expect(confirmBtn.textContent).toBe('Decommission');
+    // DeviceActions.tsx grades decommission `destructive`. ConfirmDialog encodes
+    // that as a stop-octagon, not just a colour, so a drift to `warning` here
+    // would visibly downgrade the severity on the denser of the two surfaces.
+    expect(confirmBtn.className).toContain('bg-destructive');
+  });
+
+  it('cancelling the dialog decommissions nothing', async () => {
+    const decommissionDevice = await mockedDecommission();
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByTestId(`row-decommission-${DEV_1}`));
+    await screen.findByTestId('confirm-device-action');
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    await waitFor(() => expect(screen.queryByTestId('confirm-device-action')).toBeNull());
+    expect(decommissionDevice).not.toHaveBeenCalled();
+    expect(await toastTypes()).not.toContain('undo');
+  });
+
+  it('confirming still decommissions the device, undo window and all', async () => {
+    const decommissionDevice = await mockedDecommission();
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByTestId(`row-decommission-${DEV_1}`));
+    const confirmBtn = await screen.findByTestId('confirm-device-action');
+
+    // Only setTimeout is faked: the undo window is a plain 5s timer inside
+    // runDeviceAction, and faking Date/microtasks as well would disturb React's
+    // own scheduling for the rest of this render.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      fireEvent.click(confirmBtn);
+      // The decommission branch runs synchronously up to the timer, so both of
+      // these are already settled: gate cleared, nothing sent yet.
+      expect(await toastTypes()).toContain('undo');
+      expect(decommissionDevice).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(decommissionDevice).toHaveBeenCalledTimes(1);
+    expect(decommissionDevice).toHaveBeenCalledWith(DEV_1);
+  });
+
+  // The gate lives on the shared handleDeviceAction, so the grid card inherits
+  // it — the same follow-up Todd flagged as gated-but-untested on #3698.
+  it('grid card decommission is gated on the same terms as the list row', async () => {
+    const decommissionDevice = await mockedDecommission();
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByLabelText('Grid view'));
+    fireEvent.click(await screen.findByTestId(`card-decommission-${DEV_1}`));
+
+    expect(decommissionDevice).not.toHaveBeenCalled();
+    expect(await screen.findByText('Decommission Device')).toBeTruthy();
+  });
+
+  // Deliberate scope boundary (#4009): `restore` is the UNDO of a decommission.
+  // Gating it would put a dialog in front of the recovery path, so it stays
+  // ungated — pinned here so a future "confirm every lifecycle action" sweep has
+  // to argue with a test rather than quietly change the answer.
+  it('restore stays ungated — it is the recovery path, not a destructive one', async () => {
+    const { restoreDevice } = await import('../../services/deviceActions');
+    vi.mocked(restoreDevice).mockResolvedValue(undefined as never);
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByTestId(`row-restore-${DEV_1}`));
+
+    await waitFor(() => expect(vi.mocked(restoreDevice)).toHaveBeenCalledWith(DEV_1));
+    expect(screen.queryByTestId('confirm-device-action')).toBeNull();
   });
 });
 

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -119,9 +119,9 @@ vi.mock('../shared/ProgressBar', () => ({ default: () => null }));
 
 // DeviceCard stub renders the hostname so the grid contents are assertable, and
 // re-emits reboot + decommission so the GRID path through handleDeviceAction is
-// covered too — the real DeviceCard emits both from its own kebab
-// (DeviceCard.tsx:278 reboot, :320 decommission), and the #3698/#4009 gate
-// lives on the shared handler, so both surfaces inherit it.
+// covered too — the real DeviceCard's kebab emits both via the same
+// `onAction?.(...)` calls, and the #3698/#4009 gate lives on the shared handler,
+// so both surfaces inherit it.
 vi.mock('./DeviceCard', () => ({
   default: ({ device, onAction }: { device: { id: string; hostname: string }; onAction?: (action: string, device: unknown) => void }) => (
     <div data-testid={`device-card-${device.id}`}>
@@ -184,10 +184,16 @@ vi.mock('./DeviceList', () => ({
       ))}
       {/* Drives DevicesPage.handleDeviceAction for ONE device — the row-menu /
           grid-card path, as opposed to the bulk buttons above. The real row
-          kebab emits these from DeviceList.tsx (:2450 reboot, :2490 restore,
-          :2502 decommission). The decommission/restore buttons are deliberately
+          kebab emits the same three via `onAction?.(...)` from DeviceList's
+          actions cell. The decommission/restore buttons are deliberately
           text-free so they cannot collide with the sibling getByText assertions
-          that match on the word "decommissioned". */}
+          that match on the word "decommissioned".
+
+          Status is NOT modelled here: in the real menus `restore` renders only
+          for a decommissioned device and `decommission` only for one that is
+          not, so this stub proves handleDeviceAction's dispatch, never that the
+          two are mutually exclusive on screen. That conditional belongs to
+          DeviceList/DeviceCard's own suites. */}
       {devices.map(d => (
         <button
           key={`row-reboot-${d.id}`}
@@ -1480,6 +1486,14 @@ describe('DevicesPage — decommission from the row/grid kebab is confirm-gated 
 
   // The gate lives on the shared handleDeviceAction, so the grid card inherits
   // it — the same follow-up Todd flagged as gated-but-untested on #3698.
+  //
+  // Scope, so this is not read as a clean bill of health for the grid kebab:
+  // it proves the CONFIRM gate reaches the card, nothing more. DeviceCard has
+  // no deviceClass branch at all, where DeviceList swaps the whole actions cell
+  // for a "View" button on network rows (their id is a discovered_assets.id,
+  // not a devices.id — #1322). So the grid kebab still offers decommission,
+  // reboot and terminal for a network asset. That predates #4009 and is filed
+  // as #4014; the confirm added here at least puts a dialog in front of it.
   it('grid card decommission is gated on the same terms as the list row', async () => {
     const decommissionDevice = await mockedDecommission();
 

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -99,8 +99,9 @@ function summarizeFailedDevices(names: string[]): string {
 // #4009: `decommission` belongs here and was missed by #3698. The dialog copy
 // it needs (deviceActions.confirm.decommission.*) already shipped for the
 // detail page, which has always gated it; only the list and grid kebabs fired
-// it on a single click. That is the densest, easiest-to-mis-click surface in
-// the product, so it is the last one that should be ungated.
+// it on a single click. A kebab in a dense row/card grid is easier to hit by
+// accident than the detail page's own button, so it was the wrong one to leave
+// ungated.
 // Module scope — these are constant, so there is no reason to rebuild them on
 // every render.
 const CONFIRM_REQUIRED_ACTIONS = new Set(['reboot', 'reboot_safe_mode', 'shutdown', 'decommission']);

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -93,9 +93,23 @@ function summarizeFailedDevices(names: string[]): string {
 // #3698: destructive single-device actions, confirm-gated to match the device
 // detail page. `lock` is deliberately NOT here: it is reversible and does not
 // disconnect the machine, which is where DeviceActions.tsx draws the same line.
+// `restore` fails the same test and then some: it UNDOES a decommission, so
+// gating it would put a dialog in front of the recovery path.
+//
+// #4009: `decommission` belongs here and was missed by #3698. The dialog copy
+// it needs (deviceActions.confirm.decommission.*) already shipped for the
+// detail page, which has always gated it; only the list and grid kebabs fired
+// it on a single click. That is the densest, easiest-to-mis-click surface in
+// the product, so it is the last one that should be ungated.
 // Module scope — these are constant, so there is no reason to rebuild them on
 // every render.
-const CONFIRM_REQUIRED_ACTIONS = new Set(['reboot', 'reboot_safe_mode', 'shutdown']);
+const CONFIRM_REQUIRED_ACTIONS = new Set(['reboot', 'reboot_safe_mode', 'shutdown', 'decommission']);
+
+// ConfirmDialog encodes severity by SHAPE as well as colour (stop-octagon vs
+// caution-triangle), so the grading has to match the detail page rather than
+// drift from it: DeviceActions.tsx marks shutdown and decommission
+// `destructive` and every other confirm `warning`.
+const DESTRUCTIVE_CONFIRM_ACTIONS = new Set(['shutdown', 'decommission']);
 
 // The command name is snake_case; the locale keys are camelCase.
 const confirmKeyFor = (action: string): string =>
@@ -1467,7 +1481,7 @@ export default function DevicesPage() {
             hostname: pendingDeviceAction.device.hostname,
           })}
           confirmLabel={t(/* i18n-dynamic */ `deviceActions.confirm.${confirmKeyFor(pendingDeviceAction.action)}.confirm`)}
-          variant={pendingDeviceAction.action === 'shutdown' ? 'destructive' : 'warning'}
+          variant={DESTRUCTIVE_CONFIRM_ACTIONS.has(pendingDeviceAction.action) ? 'destructive' : 'warning'}
           confirmTestId="confirm-device-action"
         />
       )}


### PR DESCRIPTION
Closes #4009

## What was wrong

Decommissioning from the **device list row kebab** or the **grid card kebab** executed on a single click — no dialog, a past-tense "Decommissioned" toast, and the row gone. The device **detail** page has always confirmed the same action, so whether retiring a production machine asked a question depended on which screen you happened to be on. That is exactly the inconsistency #3698 set out to remove; decommission was simply left out of the set.

## The fix

One token in `apps/web/src/components/devices/DevicesPage.tsx`:

```ts
const CONFIRM_REQUIRED_ACTIONS = new Set(['reboot', 'reboot_safe_mode', 'shutdown', 'decommission']);
```

Verified end-to-end rather than assumed:

- The dialog renderer (`:1456-1470`) already composes `deviceActions.confirm.${action}.{title,message,confirm}` dynamically, so it lights up with no new UI.
- Those decommission keys already exist **in all eight locales** (`de-DE`, `en`, `es-419`, `fr-CA`, `fr-FR`, `it-IT`, `pt-BR`, `tr-TR`) — the detail page has been rendering them for a while. **No locale files are touched by this PR**, so there is no parity exposure.
- Both kebabs (`DeviceList.tsx:2502`, `DeviceCard.tsx:320`) dispatch into the shared `handleDeviceAction`, so both surfaces inherit the gate from the one change.

One extra line, deliberately: the dialog's `variant` was `action === 'shutdown' ? 'destructive' : 'warning'`, which would have rendered decommission as a caution-triangle while `DeviceActions.tsx:176-182` renders it as a stop-octagon. `ConfirmDialog` encodes severity by **shape** as well as colour (for glance-reading and colourblind users), so that would have been a visible severity downgrade on the denser of the two surfaces. Replaced with a small `DESTRUCTIVE_CONFIRM_ACTIONS` set that mirrors the detail page's own grading.

## Decision: `restore` stays ungated

The issue asked this to be decided deliberately. **It does not belong in the set.** `restore` is the *undo* of a decommission — the recovery path. Gating it would put a dialog in front of the thing you reach for after a mis-click, which makes the recovery slower without protecting anything: nothing is destroyed, and the action is itself reversible (decommission again). `lock` is excluded on the same reasoning today. There is now a test pinning this, so a future "confirm every lifecycle action" sweep has to argue with a test rather than quietly change the answer.

## What this PR does NOT do

- **The confirm copy is separately wrong and is out of scope.** `devices.json:187` claims the action is permanent and that the agent stops reporting; neither holds (Restore exists, and the agent keeps checking in). That is tracked in **#3987** (the offboarding Remove-vs-Delete-permanently redesign). **This PR lands first and turns those strings on for the list/grid**, so whoever takes #3987 is now rewording copy that is live on three surfaces (detail page, list kebab, grid kebab) instead of one. No new strings were added here, so #3987 rewords exactly the keys it already planned to.
- **The 5s undo toast in `runDeviceAction` is untouched.** It is a *post-hoc recovery window*, not a confirmation — it was already there while this bug was live, and a user who has looked away never sees it. Confirm-before plus undo-after is belt-and-braces on the most consequential single-device action in the kebab; collapsing the two is a UX call that belongs with #3987, not here.

## Tests

Five cases in `DevicesPage.test.tsx`, alongside the existing #3698/#3929 reboot coverage:

1. Row kebab opens the dialog instead of decommissioning — asserts the API is untouched, that *no undo toast fires either* (the pre-fix path raised one synchronously), that the dialog carries the detail page's own copy, and that the confirm button is graded `destructive`.
2. Cancelling decommissions nothing.
3. Confirming still performs the action — drives the 5s undo window with faked `setTimeout` and asserts `decommissionDevice(DEV_1)` fires exactly once after it elapses.
4. Grid card is gated on the same terms (the gate lives on the shared handler; this pins that it actually reaches the card).
5. `restore` stays ungated — the scope decision above, as an assertion.

**Revert probe:** with the one-token change reverted, 4 of the 5 fail (the 5th is the `restore` boundary, which is a pin rather than a regression test). Reverting *only* the `variant` line fails the severity assertion on its own, so that assertion is not vacuous either.

## Verification

- `vitest run src/components/devices` — 56 files, 676 tests, green.
- `vitest run src/components/devices/DevicesPage.test.tsx` — 60 passed.
- `vitest run src/lib/i18n src/components/shared/ConfirmDialog.test.tsx src/lib/__tests__/no-silent-mutations.test.ts` — 255 passed (the i18n dynamic-key guard covers the `/* i18n-dynamic */` call sites this touches).
- `tsc --noEmit -p apps/web/tsconfig.json` — clean.
- `eslint` on both changed files — clean.
- No `e2e-tests` spec references decommission, so nothing there needs updating.

## Review follow-up — new issue #4014 (not fixed here)

The `pr-test-analyzer` pass surfaced a real, **pre-existing** gap that this PR deliberately does not fix: `DeviceCard.tsx` has no `deviceClass` branch anywhere, where `DeviceList.tsx:2308-2321` replaces its whole actions cell with a "View" button for `deviceClass === 'network'` rows (their id is a `discovered_assets.id`, not a `devices.id` — #1322). So the **grid** kebab still offers decommission, reboot and terminal for a network-discovered asset. Filed as **#4014**; the confirm added here at least puts a dialog in front of it. The grid-card test now carries a comment naming that limit, so it is not misread as vetting the grid kebab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
