### PR TITLE
fix(web): keep the #rings deep link alive until the JWT scope is known (#4010)

### DIFF
--- a/apps/web/src/components/patches/PatchesPage.scopeResolution.test.tsx
+++ b/apps/web/src/components/patches/PatchesPage.scopeResolution.test.tsx
@@ -117,6 +117,13 @@ describe('PatchesPage #rings deep link vs. late-arriving JWT scope (#4010)', () 
     expect(await screen.findByRole('button', { name: /Compliance/i })).toBeInTheDocument();
     // Deferred, not granted: the rings tab is not offered while the scope is unknown.
     expect(screen.queryByRole('button', { name: 'Update Rings' })).toBeNull();
+    // ...and the hash is still intact at this point. The guard cannot know in
+    // advance which way an unresolved user will go, so it must defer for
+    // EVERYONE — including the ones who will turn out to be denied. Without this
+    // assertion the test passes against the buggy code too, since the old
+    // premature clear and the new deferred-then-real clear reach the same final
+    // state for an org user.
+    expect(window.location.hash).toBe('#rings');
 
     tokenArrives({ scope: 'organization', orgId: 'org-1' });
 
@@ -134,6 +141,8 @@ describe('PatchesPage #rings deep link vs. late-arriving JWT scope (#4010)', () 
     // "scope pending" state that never clears a bookmark an org user can't use.
     render(<PatchesPage />);
     expect(await screen.findByRole('button', { name: /Compliance/i })).toBeInTheDocument();
+    // Same discriminating assertion as above: intact until the token exists.
+    expect(window.location.hash).toBe('#rings');
 
     act(() => {
       useAuthStore.setState({ tokens: { accessToken: 'not-a-jwt', expiresInSeconds: 900 } });
@@ -141,6 +150,47 @@ describe('PatchesPage #rings deep link vs. late-arriving JWT scope (#4010)', () 
 
     await waitFor(() => expect(window.location.hash).toBe(''));
     expect(screen.queryByRole('button', { name: 'Update Rings' })).toBeNull();
+  });
+
+  it('a token going away again (throttled refresh / logout) hides rings but does NOT wipe the hash', async () => {
+    // The resolved -> unresolved transition is a real sequence: while
+    // /auth/refresh is rate limited the session is valid and yet tokenless for
+    // up to 90s (#3696). Wiping the deep link there would be #4010 in slow
+    // motion, so the guard defers exactly as it does before the first token.
+    render(<PatchesPage />);
+    tokenArrives({ scope: 'partner', partnerId: 'p-1' });
+    await waitFor(() => expect(navTab('Update Rings')).toHaveClass('border-primary'));
+
+    act(() => {
+      useAuthStore.setState({ tokens: null });
+    });
+
+    // Falls closed on the view...
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Update Rings' })).toBeNull());
+    expect(screen.queryByRole('button', { name: /New Ring/i })).toBeNull();
+    // ...but the deep link survives, so the same session recovers on re-auth.
+    expect(window.location.hash).toBe('#rings');
+
+    tokenArrives({ scope: 'partner', partnerId: 'p-1' });
+    await waitFor(() => expect(navTab('Update Rings')).toHaveClass('border-primary'));
+  });
+
+  it('a token landing while the user is on #patches reveals the Update Rings tab without moving them', async () => {
+    // The nav chrome is gated on `mounted && canManageRings`, a separate path
+    // from the hash guard: a partner browsing Patches during the unresolved
+    // window must gain the tab when the token lands, and must not be yanked off
+    // the tab they are on.
+    window.history.replaceState({}, '', '/#patches');
+
+    render(<PatchesPage />);
+    await waitFor(() => expect(navTab('Patches')).toHaveClass('border-primary'));
+    expect(screen.queryByRole('button', { name: 'Update Rings' })).toBeNull();
+
+    tokenArrives({ scope: 'partner', partnerId: 'p-1' });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Update Rings' })).toBeInTheDocument());
+    expect(navTab('Patches')).toHaveClass('border-primary');
+    expect(window.location.hash).toBe('#patches');
   });
 
   it('a hashchange back to #rings while the scope is still unknown does not wipe the hash', async () => {

--- a/apps/web/src/components/patches/PatchesPage.scopeResolution.test.tsx
+++ b/apps/web/src/components/patches/PatchesPage.scopeResolution.test.tsx
@@ -1,0 +1,166 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@/lib/i18n';
+
+// #4010. PatchesPage.test.tsx mocks `lib/authScope` with a scope that is already
+// known on the first render, which is exactly the state a cold page load does NOT
+// start in: access tokens are never persisted (`partialize` in stores/auth.ts
+// keeps only `user` + `isAuthenticated`), so at first paint the store is empty and
+// EVERY user decodes as `scope: null`. This suite therefore mocks neither
+// authScope nor the auth store — it drives the real `useJwtClaims` against the
+// real store so the token genuinely arrives after mount, which is the only way to
+// pin the bug: the mount-time guard used to downgrade #rings AND clear the hash,
+// destroying the deep link before the scope it depends on existed.
+
+vi.mock('../../components/shared/Toast', () => ({ showToast: vi.fn() }));
+
+// Real auth store (the subject), stubbed network helper.
+vi.mock('../../stores/auth', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../stores/auth')>()),
+  fetchWithAuth: vi.fn(),
+}));
+
+const orgState = vi.hoisted(() => ({ currentOrgId: null as string | null }));
+
+vi.mock('../../stores/orgStore', () => {
+  const organizations = [{ id: 'org-1', name: 'Acme Corp' }];
+  const read = () => ({ currentOrgId: orgState.currentOrgId, organizations });
+  return { useOrgStore: Object.assign(read, { getState: read }) };
+});
+
+import PatchesPage from './PatchesPage';
+import { fetchWithAuth, useAuthStore } from '../../stores/auth';
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const emptyDataFetch = async (input: unknown): Promise<Response> => {
+  const url = String(input);
+  if (url === '/update-rings') return makeJsonResponse({ data: [] });
+  if (url === '/patches?limit=200') return makeJsonResponse({ data: [] });
+  if (url === '/patches/compliance') {
+    return makeJsonResponse({ data: { totalDevices: 0, compliantDevices: 0, devicesNeedingPatches: [] } });
+  }
+  if (url === '/devices?limit=200') return makeJsonResponse({ devices: [] });
+  return makeJsonResponse({}, false, 404);
+};
+
+function makeToken(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).replace(/=/g, '');
+  const body = btoa(JSON.stringify(payload)).replace(/=/g, '');
+  return `${header}.${body}.sig`;
+}
+
+/** Simulate /auth/refresh returning an access token some time after first paint. */
+function tokenArrives(payload: Record<string, unknown>) {
+  act(() => {
+    useAuthStore.setState({ tokens: { accessToken: makeToken(payload), expiresInSeconds: 900 } });
+  });
+}
+
+// Tab nav buttons are the only buttons carrying `border-b-2`, which disambiguates
+// them from same-named buttons inside the tab bodies.
+const navTab = (name: string | RegExp) =>
+  screen.getAllByRole('button', { name }).find(b => b.className.includes('border-b-2'));
+
+describe('PatchesPage #rings deep link vs. late-arriving JWT scope (#4010)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    orgState.currentOrgId = null;
+    useAuthStore.setState({ tokens: null });
+    window.history.replaceState({}, '', '/#rings');
+    fetchMock.mockImplementation(emptyDataFetch);
+  });
+
+  afterEach(() => {
+    useAuthStore.setState({ tokens: null });
+    window.history.replaceState({}, '', '/');
+  });
+
+  it.each(['partner', 'system'] as const)(
+    '%s scope: keeps #rings through the unresolved window and selects Update Rings once the token lands',
+    async (scope) => {
+      render(<PatchesPage />);
+
+      // First paint: no token yet, so the scope is unknown. The view falls back to
+      // Compliance (rings chrome and body stay hidden — an unknown scope is never
+      // treated as a grant), but the hash MUST survive: this assertion is the
+      // regression. Before the fix the mount-time downgrade routed through
+      // setTabInHash and left the URL at a bare `/`.
+      expect(await screen.findByRole('button', { name: /Compliance/i })).toBeInTheDocument();
+      expect(window.location.hash).toBe('#rings');
+      expect(screen.queryByRole('button', { name: 'Update Rings' })).toBeNull();
+      expect(screen.queryByRole('button', { name: /New Ring/i })).toBeNull();
+
+      tokenArrives({ scope, partnerId: 'p-1' });
+
+      // Scope resolved and permitted: the guard re-runs, re-reads the hash it did
+      // not destroy, and lands on Update Rings.
+      await waitFor(() => expect(navTab('Update Rings')).toHaveClass('border-primary'));
+      expect(navTab(/Compliance/i)).not.toHaveClass('border-primary');
+      expect(window.location.hash).toBe('#rings');
+    },
+  );
+
+  it('org scope: still downgrades to Compliance and clears the stale #rings once the token lands', async () => {
+    orgState.currentOrgId = 'org-1';
+
+    render(<PatchesPage />);
+
+    expect(await screen.findByRole('button', { name: /Compliance/i })).toBeInTheDocument();
+    // Deferred, not granted: the rings tab is not offered while the scope is unknown.
+    expect(screen.queryByRole('button', { name: 'Update Rings' })).toBeNull();
+
+    tokenArrives({ scope: 'organization', orgId: 'org-1' });
+
+    // Known-denied: now the downgrade is real, so the stale hash is wiped.
+    await waitFor(() => expect(window.location.hash).toBe(''));
+    expect(navTab(/Compliance/i)).toHaveClass('border-primary');
+    expect(screen.queryByRole('button', { name: 'Update Rings' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /New Ring/i })).toBeNull();
+  });
+
+  it('undecodable token: treated as resolved-and-denied, so the stale #rings is cleared', async () => {
+    // A present-but-garbage token means we DID look and got no claims. Failing
+    // closed (clear the hash, stay on Compliance) matches what the server would
+    // do with the same token, and stops the deferral from becoming a permanent
+    // "scope pending" state that never clears a bookmark an org user can't use.
+    render(<PatchesPage />);
+    expect(await screen.findByRole('button', { name: /Compliance/i })).toBeInTheDocument();
+
+    act(() => {
+      useAuthStore.setState({ tokens: { accessToken: 'not-a-jwt', expiresInSeconds: 900 } });
+    });
+
+    await waitFor(() => expect(window.location.hash).toBe(''));
+    expect(screen.queryByRole('button', { name: 'Update Rings' })).toBeNull();
+  });
+
+  it('a hashchange back to #rings while the scope is still unknown does not wipe the hash', async () => {
+    // Browser back/forward can land on #rings before the refresh round trip has
+    // finished. The listener runs the same guard as mount, so it must defer too.
+    window.history.replaceState({}, '', '/');
+    render(<PatchesPage />);
+    await screen.findByRole('button', { name: /Compliance/i });
+
+    act(() => {
+      window.location.hash = '#rings';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+
+    expect(window.location.hash).toBe('#rings');
+    expect(screen.queryByRole('button', { name: 'Update Rings' })).toBeNull();
+
+    tokenArrives({ scope: 'partner', partnerId: 'p-1' });
+
+    await waitFor(() => expect(navTab('Update Rings')).toHaveClass('border-primary'));
+    expect(window.location.hash).toBe('#rings');
+  });
+});

--- a/apps/web/src/components/patches/PatchesPage.test.tsx
+++ b/apps/web/src/components/patches/PatchesPage.test.tsx
@@ -47,7 +47,11 @@ vi.mock('../../lib/authScope', () => {
   });
   return {
     getJwtClaims: claims,
-    useJwtClaims: () => ({ ...claims(), resolved: true }),
+    // NOTE: `status` is hard-wired to 'resolved' and is deliberately NOT derived
+    // from `jwtScope` — flipping `jwtScope.scope` to null here models an org-ish
+    // user with no claims, NOT the pre-token window. There is no way to reach
+    // 'unresolved' from this file; use PatchesPage.scopeResolution.test.tsx.
+    useJwtClaims: () => ({ status: 'resolved' as const, claims: claims() }),
   };
 });
 

--- a/apps/web/src/components/patches/PatchesPage.test.tsx
+++ b/apps/web/src/components/patches/PatchesPage.test.tsx
@@ -33,15 +33,23 @@ vi.mock('../../stores/orgStore', () => {
 });
 
 // Mutable JWT scope so individual tests can simulate partner vs. org-scoped sessions.
+// Every test here models a session whose access token has already landed, so
+// `resolved` is true throughout — the not-yet-resolved cold-load window that
+// #4010 turns on is covered by PatchesPage.scopeResolution.test.tsx, which drives
+// the real useJwtClaims against a live auth store instead of mocking it.
 const jwtScope = vi.hoisted(() => ({ scope: 'partner' as 'partner' | 'system' | 'organization' | null }));
 
-vi.mock('../../lib/authScope', () => ({
-  getJwtClaims: () => ({
+vi.mock('../../lib/authScope', () => {
+  const claims = () => ({
     scope: jwtScope.scope,
     partnerId: jwtScope.scope !== 'organization' ? 'p1' : null,
     orgId: jwtScope.scope === 'organization' ? 'org-1' : null,
-  }),
-}));
+  });
+  return {
+    getJwtClaims: claims,
+    useJwtClaims: () => ({ ...claims(), resolved: true }),
+  };
+});
 
 const fetchMock = vi.mocked(fetchWithAuth);
 

--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -31,9 +31,11 @@ type TabKey = 'rings' | 'patches' | 'compliance';
 const validTabs: TabKey[] = ['rings', 'patches', 'compliance'];
 
 // Tab state lives in window.location.hash (`#patches`) per the project
-// convention for transient UI state (CLAUDE.md), matching DiscoveryPage and
-// DeviceDetails. The default `compliance` tab keeps the hash empty so the URL
-// stays clean.
+// convention for transient UI state (CLAUDE.md); DiscoveryPage and DeviceDetails
+// follow the same convention, but note that neither gates its hash-derived tab
+// on a permission — this page is the only one that does, which is what made the
+// #4010 ordering bug possible here and nowhere else. The default `compliance`
+// tab keeps the hash empty so the URL stays clean.
 function getTabFromHash(): TabKey {
   if (typeof window === 'undefined') return 'compliance';
   const hash = window.location.hash.replace(/^#/, '');
@@ -50,6 +52,11 @@ function setTabInHash(tab: TabKey) {
 // Resolve a hash-derived tab against the user's access. Rings are partner-scoped:
 // an org user landing on #rings (a stale bookmark, a hand-edited URL, or browser
 // back/forward) can't see the rings body, so fall back to compliance.
+//
+// This answers "which tab do we RENDER", never "may we rewrite the URL". Its
+// boolean is deliberately fail-closed and so is false both for a real denial and
+// for a scope that hasn't resolved yet; a caller that acts destructively on the
+// downgrade must consult ringAccess instead (see the sync effect below, #4010).
 function resolveTab(tab: TabKey, canManageRings: boolean): TabKey {
   return tab === 'rings' && !canManageRings ? 'compliance' : tab;
 }
@@ -81,20 +88,38 @@ export default function PatchesPage() {
   const currentOrg = organizations.find(o => o.id === currentOrgId) ?? null;
   // Reactive claims, not the one-shot getJwtClaims(): access tokens are never
   // persisted, so on a cold load the store is empty at first paint and only
-  // fills once the refresh cookie has been exchanged. `scopeResolved` is what
-  // separates "not a partner" from "we don't know yet" (#4010).
-  const { scope, resolved: scopeResolved } = useJwtClaims();
+  // fills once the refresh cookie has been exchanged (#4010).
+  //
   // Rings + approvals are partner-scoped: only partner/system users manage them.
-  const canManageRings = scope === 'partner' || scope === 'system';
+  // Keep all THREE access states rather than collapsing to a boolean — 'denied'
+  // and 'unresolved' both have to hide the rings UI, but only 'denied' may
+  // destroy the #rings deep link. Collapsing them is the bug.
+  const jwt = useJwtClaims();
+  const ringAccess: 'unresolved' | 'allowed' | 'denied' =
+    jwt.status === 'unresolved'
+      ? 'unresolved'
+      : jwt.claims.scope === 'partner' || jwt.claims.scope === 'system'
+        ? 'allowed'
+        : 'denied';
+  // Fail closed for everything that only HIDES or DISABLES ui.
+  const canManageRings = ringAccess === 'allowed';
   const RING_SCOPE_HINT = t('patchesPage.ringScopeHint');
 
   // The Update Rings tab is gated on the client-only JWT scope (canManageRings),
   // which is absent during SSR, so the server renders two tabs and the client
   // three. Render the tab list from an SSR-stable value until after mount so the
   // first client render matches the server markup — companion to the #2421
-  // active-tab fix below. canManageRings itself stays accurate everywhere else
-  // (the hash-resolution effect, ring actions) so the #rings deep-link and
-  // scope guards are unaffected.
+  // active-tab fix below.
+  //
+  // `mounted` is NOT a stand-in for "scope known". It flips on the first client
+  // effect, which is still well before the access token lands; the tab list is
+  // simply allowed to be briefly two-tabbed. What used to be wrong here was the
+  // assumption that canManageRings stayed accurate everywhere else — it does not
+  // during the pre-token window, and the hash-resolution effect below acting on
+  // that assumption is exactly what #4010 was. Anything that DESTROYS state on a
+  // falsy canManageRings must branch on ringAccess === 'denied'; anything that
+  // merely hides UI (this tab list, the ring action guards) is safe to fail
+  // closed on canManageRings.
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
@@ -112,23 +137,29 @@ export default function PatchesPage() {
   // The org-scope guard is re-applied on each sync (resolveTab): a #rings hash an
   // org user can't access falls back to compliance.
   //
-  // A downgrade only *clears* the hash once the scope is actually known (#4010).
-  // The first paint of a cold load always has an empty auth store, so an
-  // unconditional clear here would delete the `#rings` this very effect needs to
-  // re-read when the token lands a beat later — the deep link could never
+  // Only a *denial* may clear the hash — never an unresolved scope (#4010). The
+  // first paint of a cold load always has an empty auth store, so clearing on
+  // any falsy canManageRings deletes the `#rings` this very effect needs to
+  // re-read when the token lands a beat later, and the deep link can never
   // survive a reload, for anyone. While the scope is unresolved we render the
-  // fallback tab but leave the URL untouched, so the re-run (canManageRings /
-  // scopeResolved are both deps) can still recover the requested tab. An org
-  // user is unaffected: their downgrade is simply deferred to the moment their
-  // scope is known, and the rings body is never rendered in the meantime.
+  // fallback tab but leave the URL untouched, so the re-run (ringAccess is a
+  // dep) recovers the requested tab. An org user is unaffected: their downgrade
+  // is deferred to the moment it is real, and the rings body is never rendered
+  // in the meantime.
+  //
+  // Deferring on the resolved -> unresolved transition (a token going away) is
+  // deliberate too: while /auth/refresh is rate limited the session is valid and
+  // yet tokenless for up to 90s (#3696), and wiping the hash there would be
+  // #4010 again in slow motion. Logout also lands here, and leaves `#rings`
+  // behind — harmless, because every logout path navigates away from the page.
   useEffect(() => {
     const syncFromHash = () => {
       const raw = getTabFromHash();
-      const resolved = resolveTab(raw, canManageRings);
+      const resolved = resolveTab(raw, ringAccess === 'allowed');
       if (resolved === raw) {
         setActiveTabState(resolved);
-      } else if (scopeResolved) {
-        setActiveTab(resolved); // known-denied downgrade — also clears the stale hash
+      } else if (ringAccess === 'denied') {
+        setActiveTab(resolved); // real denial — also clears the stale hash
       } else {
         setActiveTabState(resolved); // scope unknown — downgrade the view, keep the hash
       }
@@ -136,7 +167,7 @@ export default function PatchesPage() {
     syncFromHash();
     window.addEventListener('hashchange', syncFromHash);
     return () => window.removeEventListener('hashchange', syncFromHash);
-  }, [canManageRings, scopeResolved, setActiveTab]);
+  }, [ringAccess, setActiveTab]);
   const [selectedRingId, setSelectedRingId] = useState<string | null>(null);
   const [selectedPatch, setSelectedPatch] = useState<Patch | null>(null);
   const [modalOpen, setModalOpen] = useState(false);

--- a/apps/web/src/components/patches/PatchesPage.tsx
+++ b/apps/web/src/components/patches/PatchesPage.tsx
@@ -14,7 +14,7 @@ import SourceFilterChips from './SourceFilterChips';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { useOrgStore } from '../../stores/orgStore';
-import { getJwtClaims } from '../../lib/authScope';
+import { useJwtClaims } from '../../lib/authScope';
 import { normalizePatch, normalizeRing } from './patchHelpers';
 import { extractApiError } from '@/lib/apiError';
 import { showToast } from '../shared/Toast';
@@ -79,7 +79,11 @@ export default function PatchesPage() {
   const { t } = useTranslation('patches');
   const { organizations, currentOrgId } = useOrgStore();
   const currentOrg = organizations.find(o => o.id === currentOrgId) ?? null;
-  const { scope } = getJwtClaims();
+  // Reactive claims, not the one-shot getJwtClaims(): access tokens are never
+  // persisted, so on a cold load the store is empty at first paint and only
+  // fills once the refresh cookie has been exchanged. `scopeResolved` is what
+  // separates "not a partner" from "we don't know yet" (#4010).
+  const { scope, resolved: scopeResolved } = useJwtClaims();
   // Rings + approvals are partner-scoped: only partner/system users manage them.
   const canManageRings = scope === 'partner' || scope === 'system';
   const RING_SCOPE_HINT = t('patchesPage.ringScopeHint');
@@ -106,25 +110,33 @@ export default function PatchesPage() {
   // Sync the active tab from the hash on mount and on every hashchange — browser
   // back/forward and manual hash edits re-select the tab, mirroring DiscoveryPage.
   // The org-scope guard is re-applied on each sync (resolveTab): a #rings hash an
-  // org user can't access falls back to compliance, and when that downgrade fires
-  // we route through setActiveTab so the stale #rings is cleared from the URL
-  // rather than left pointing at a tab the user isn't on. Depending on
-  // canManageRings also re-runs the guard when scope/permissions arrive after the
-  // first render (defense-in-depth).
+  // org user can't access falls back to compliance.
+  //
+  // A downgrade only *clears* the hash once the scope is actually known (#4010).
+  // The first paint of a cold load always has an empty auth store, so an
+  // unconditional clear here would delete the `#rings` this very effect needs to
+  // re-read when the token lands a beat later — the deep link could never
+  // survive a reload, for anyone. While the scope is unresolved we render the
+  // fallback tab but leave the URL untouched, so the re-run (canManageRings /
+  // scopeResolved are both deps) can still recover the requested tab. An org
+  // user is unaffected: their downgrade is simply deferred to the moment their
+  // scope is known, and the rings body is never rendered in the meantime.
   useEffect(() => {
     const syncFromHash = () => {
       const raw = getTabFromHash();
       const resolved = resolveTab(raw, canManageRings);
-      if (resolved !== raw) {
-        setActiveTab(resolved); // downgrade — also clears the stale hash
-      } else {
+      if (resolved === raw) {
         setActiveTabState(resolved);
+      } else if (scopeResolved) {
+        setActiveTab(resolved); // known-denied downgrade — also clears the stale hash
+      } else {
+        setActiveTabState(resolved); // scope unknown — downgrade the view, keep the hash
       }
     };
     syncFromHash();
     window.addEventListener('hashchange', syncFromHash);
     return () => window.removeEventListener('hashchange', syncFromHash);
-  }, [canManageRings, setActiveTab]);
+  }, [canManageRings, scopeResolved, setActiveTab]);
   const [selectedRingId, setSelectedRingId] = useState<string | null>(null);
   const [selectedPatch, setSelectedPatch] = useState<Patch | null>(null);
   const [modalOpen, setModalOpen] = useState(false);

--- a/apps/web/src/lib/authScope.test.ts
+++ b/apps/web/src/lib/authScope.test.ts
@@ -1,6 +1,7 @@
+import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { useAuthStore } from '../stores/auth';
-import { getJwtClaims, loginPathWithNext } from './authScope';
+import { getJwtClaims, loginPathWithNext, useJwtClaims } from './authScope';
 
 function makeToken(payload: Record<string, unknown>): string {
   const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
@@ -78,6 +79,58 @@ describe('getJwtClaims', () => {
     const c = getJwtClaims();
     expect(c.orgId).toBeNull();
     expect(c.partnerId).toBeNull();
+  });
+});
+
+describe('useJwtClaims', () => {
+  // #4010: the point of the hook over getJwtClaims() is that it distinguishes
+  // "no token yet" (unknown) from "token says not permitted" (denied), and
+  // re-renders when the token lands. Callers that destroy state on a denial —
+  // clearing a deep-link hash, redirecting — hang off exactly that difference.
+  it('reports resolved: false with all-null claims when no token is present', () => {
+    const { result } = renderHook(() => useJwtClaims());
+    expect(result.current).toEqual({ scope: null, orgId: null, partnerId: null, resolved: false });
+  });
+
+  it('reports resolved: true with decoded claims once a token is present', () => {
+    useAuthStore.setState({
+      tokens: { accessToken: makeToken({ scope: 'partner', partnerId: 'p-1' }), expiresInSeconds: 900 },
+    });
+    const { result } = renderHook(() => useJwtClaims());
+    expect(result.current).toEqual({ scope: 'partner', orgId: null, partnerId: 'p-1', resolved: true });
+  });
+
+  it('re-renders with the new claims when the token arrives after first render', () => {
+    const { result } = renderHook(() => useJwtClaims());
+    expect(result.current.resolved).toBe(false);
+
+    act(() => {
+      useAuthStore.setState({
+        tokens: { accessToken: makeToken({ scope: 'organization', orgId: 'org-1' }), expiresInSeconds: 900 },
+      });
+    });
+
+    expect(result.current).toEqual({ scope: 'organization', orgId: 'org-1', partnerId: null, resolved: true });
+  });
+
+  it('counts an undecodable token as resolved (we looked; the answer is no claims)', () => {
+    useAuthStore.setState({ tokens: { accessToken: 'notavalidjwt', expiresInSeconds: 900 } });
+    const { result } = renderHook(() => useJwtClaims());
+    expect(result.current).toEqual({ scope: null, orgId: null, partnerId: null, resolved: true });
+  });
+
+  it('goes back to unresolved when the token is cleared (logout)', () => {
+    useAuthStore.setState({
+      tokens: { accessToken: makeToken({ scope: 'system' }), expiresInSeconds: 900 },
+    });
+    const { result } = renderHook(() => useJwtClaims());
+    expect(result.current.resolved).toBe(true);
+
+    act(() => {
+      useAuthStore.setState({ tokens: null });
+    });
+
+    expect(result.current).toEqual({ scope: null, orgId: null, partnerId: null, resolved: false });
   });
 });
 

--- a/apps/web/src/lib/authScope.test.ts
+++ b/apps/web/src/lib/authScope.test.ts
@@ -143,13 +143,34 @@ describe('useJwtClaims', () => {
     expect(result.current).toEqual({ status: 'unresolved' });
   });
 
-  it('keeps the same object identity while the token is unchanged', () => {
-    // The value feeds effect dependency arrays; a fresh object every render would
-    // re-run them on every unrelated store write.
+  it('keeps the same object identity across re-renders while the token is unchanged', () => {
+    // Consumers derive effect dependencies from this value; a fresh object every
+    // render would re-run them on every unrelated store write. The RESOLVED
+    // branch is the one that matters — it builds a new object literal inside the
+    // memo callback, so it is where a future edit could silently drop the
+    // caching. (The unresolved branch returns a shared constant and would look
+    // stable even without the memo, so asserting only that proves nothing.)
+    useAuthStore.setState({
+      tokens: { accessToken: makeToken({ scope: 'partner', partnerId: 'p-1' }), expiresInSeconds: 900 },
+    });
     const { result, rerender } = renderHook(() => useJwtClaims());
     const first = result.current;
+    expect(first.status).toBe('resolved');
+
     rerender();
     expect(result.current).toBe(first);
+
+    // A genuinely new token must produce a new value, or the memo is over-caching.
+    act(() => {
+      useAuthStore.setState({
+        tokens: { accessToken: makeToken({ scope: 'system' }), expiresInSeconds: 900 },
+      });
+    });
+    expect(result.current).not.toBe(first);
+    expect(result.current).toEqual({
+      status: 'resolved',
+      claims: { scope: 'system', orgId: null, partnerId: null },
+    });
   });
 });
 

--- a/apps/web/src/lib/authScope.test.ts
+++ b/apps/web/src/lib/authScope.test.ts
@@ -86,23 +86,27 @@ describe('useJwtClaims', () => {
   // #4010: the point of the hook over getJwtClaims() is that it distinguishes
   // "no token yet" (unknown) from "token says not permitted" (denied), and
   // re-renders when the token lands. Callers that destroy state on a denial —
-  // clearing a deep-link hash, redirecting — hang off exactly that difference.
-  it('reports resolved: false with all-null claims when no token is present', () => {
+  // clearing a deep-link hash, redirecting — hang off exactly that difference,
+  // which is why the shape is a union that hides `claims` until it is narrowed.
+  it('is unresolved when no token is present', () => {
     const { result } = renderHook(() => useJwtClaims());
-    expect(result.current).toEqual({ scope: null, orgId: null, partnerId: null, resolved: false });
+    expect(result.current).toEqual({ status: 'unresolved' });
   });
 
-  it('reports resolved: true with decoded claims once a token is present', () => {
+  it('is resolved with decoded claims once a token is present', () => {
     useAuthStore.setState({
       tokens: { accessToken: makeToken({ scope: 'partner', partnerId: 'p-1' }), expiresInSeconds: 900 },
     });
     const { result } = renderHook(() => useJwtClaims());
-    expect(result.current).toEqual({ scope: 'partner', orgId: null, partnerId: 'p-1', resolved: true });
+    expect(result.current).toEqual({
+      status: 'resolved',
+      claims: { scope: 'partner', orgId: null, partnerId: 'p-1' },
+    });
   });
 
   it('re-renders with the new claims when the token arrives after first render', () => {
     const { result } = renderHook(() => useJwtClaims());
-    expect(result.current.resolved).toBe(false);
+    expect(result.current.status).toBe('unresolved');
 
     act(() => {
       useAuthStore.setState({
@@ -110,27 +114,42 @@ describe('useJwtClaims', () => {
       });
     });
 
-    expect(result.current).toEqual({ scope: 'organization', orgId: 'org-1', partnerId: null, resolved: true });
+    expect(result.current).toEqual({
+      status: 'resolved',
+      claims: { scope: 'organization', orgId: 'org-1', partnerId: null },
+    });
   });
 
   it('counts an undecodable token as resolved (we looked; the answer is no claims)', () => {
     useAuthStore.setState({ tokens: { accessToken: 'notavalidjwt', expiresInSeconds: 900 } });
     const { result } = renderHook(() => useJwtClaims());
-    expect(result.current).toEqual({ scope: null, orgId: null, partnerId: null, resolved: true });
+    expect(result.current).toEqual({
+      status: 'resolved',
+      claims: { scope: null, orgId: null, partnerId: null },
+    });
   });
 
-  it('goes back to unresolved when the token is cleared (logout)', () => {
+  it('goes back to unresolved when the token is cleared (logout, or a throttled refresh)', () => {
     useAuthStore.setState({
       tokens: { accessToken: makeToken({ scope: 'system' }), expiresInSeconds: 900 },
     });
     const { result } = renderHook(() => useJwtClaims());
-    expect(result.current.resolved).toBe(true);
+    expect(result.current.status).toBe('resolved');
 
     act(() => {
       useAuthStore.setState({ tokens: null });
     });
 
-    expect(result.current).toEqual({ scope: null, orgId: null, partnerId: null, resolved: false });
+    expect(result.current).toEqual({ status: 'unresolved' });
+  });
+
+  it('keeps the same object identity while the token is unchanged', () => {
+    // The value feeds effect dependency arrays; a fresh object every render would
+    // re-run them on every unrelated store write.
+    const { result, rerender } = renderHook(() => useJwtClaims());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
   });
 });
 

--- a/apps/web/src/lib/authScope.ts
+++ b/apps/web/src/lib/authScope.ts
@@ -11,25 +11,38 @@ export interface JwtClaims {
 }
 
 /**
- * Claims plus an explicit "we have actually looked at a token" bit.
+ * The outcome of *attempting* to read the claims — deliberately a union, not
+ * `JwtClaims & { resolved: boolean }`, so that `.claims` (and therefore `.scope`)
+ * is unreachable until the caller has narrowed on `status`.
  *
- * `resolved: false` means *unknown*, not *denied*: there is no access token in
- * the store yet, so every field is null for a partner and an org user alike.
- * Access tokens are deliberately never persisted (see `partialize` in
- * `stores/auth.ts` — only `user` and `isAuthenticated` survive a reload), so on
- * every cold page load `resolved` starts false and flips once the refresh cookie
- * has been exchanged. Callers that would otherwise destroy state on a denial
- * (clearing a deep-link hash, redirecting) must wait for `resolved` before
- * treating a null scope as a "no".
+ * `'unresolved'` means *unknown*, not *denied*: there is no access token in the
+ * store yet, so a partner and an org user are indistinguishable. Access tokens
+ * are deliberately never persisted (see `partialize` and `migrate` in
+ * `stores/auth.ts` — only `user` and `isAuthenticated` survive a reload), so
+ * every cold page load starts here and flips once the refresh cookie has been
+ * exchanged. That window is not always brief: while `/auth/refresh` is rate
+ * limited (#3696) the session is perfectly valid and yet tokenless for up to 90
+ * seconds.
  *
- * A present-but-undecodable token counts as resolved: we looked, and the answer
- * is "no claims", which fails closed the same way the server would.
+ * Conflating `'unresolved'` with a denial is exactly what #4010 was, and a flat
+ * `scope: null` invites precisely that — which is why the shape forces the
+ * check. Code that merely HIDES ui on a denial can narrow and fail closed in one
+ * line; code that DESTROYS state on a denial (clearing a deep-link hash,
+ * redirecting, resetting a form) must act only on a genuine `'resolved'` denial.
+ *
+ * A present-but-undecodable token is `'resolved'` with all-null claims: we
+ * looked, and the answer is "no claims". Note this is a client-side UX decision
+ * only — it denies the partner-gated UI just as a real org token would, and is
+ * NOT a replay of the server, which rejects an undecodable token outright with
+ * a 401 rather than degrading the page.
  */
-export interface ResolvedJwtClaims extends JwtClaims {
-  resolved: boolean;
-}
+export type JwtClaimsState =
+  | { status: 'unresolved' }
+  | { status: 'resolved'; claims: JwtClaims };
 
 const NO_CLAIMS: Readonly<JwtClaims> = { scope: null, orgId: null, partnerId: null };
+
+const UNRESOLVED: Readonly<JwtClaimsState> = { status: 'unresolved' };
 
 function decodeClaims(token: string | null | undefined): JwtClaims {
   if (!token) return NO_CLAIMS;
@@ -66,13 +79,18 @@ export function getJwtClaims(): JwtClaims {
 
 /**
  * Reactive form of `getJwtClaims()`: subscribes to the access token, so the
- * component re-renders when the token arrives after first paint, and reports
- * `resolved` so a null scope can be told apart from a denied one (#4010).
+ * component re-renders when it arrives after first paint, and returns a state
+ * that keeps "no token yet" distinguishable from "token says no" (#4010).
+ *
+ * Prefer this over `getJwtClaims()` in any component. The one-shot read is only
+ * correct where a stale answer cannot outlive the call (an event handler, a
+ * request builder); captured into render state or a `[]`-dep memo it freezes the
+ * empty-store answer for the life of the mount.
  */
-export function useJwtClaims(): ResolvedJwtClaims {
+export function useJwtClaims(): JwtClaimsState {
   const accessToken = useAuthStore((s) => s.tokens?.accessToken ?? null);
-  return useMemo(
-    () => ({ ...decodeClaims(accessToken), resolved: accessToken !== null }),
+  return useMemo<JwtClaimsState>(
+    () => (accessToken === null ? UNRESOLVED : { status: 'resolved', claims: decodeClaims(accessToken) }),
     [accessToken],
   );
 }

--- a/apps/web/src/lib/authScope.ts
+++ b/apps/web/src/lib/authScope.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useAuthStore } from '../stores/auth';
 import { loginPathWithNext } from './authNext';
 
@@ -9,17 +10,28 @@ export interface JwtClaims {
   partnerId: string | null;
 }
 
+/**
+ * Claims plus an explicit "we have actually looked at a token" bit.
+ *
+ * `resolved: false` means *unknown*, not *denied*: there is no access token in
+ * the store yet, so every field is null for a partner and an org user alike.
+ * Access tokens are deliberately never persisted (see `partialize` in
+ * `stores/auth.ts` — only `user` and `isAuthenticated` survive a reload), so on
+ * every cold page load `resolved` starts false and flips once the refresh cookie
+ * has been exchanged. Callers that would otherwise destroy state on a denial
+ * (clearing a deep-link hash, redirecting) must wait for `resolved` before
+ * treating a null scope as a "no".
+ *
+ * A present-but-undecodable token counts as resolved: we looked, and the answer
+ * is "no claims", which fails closed the same way the server would.
+ */
+export interface ResolvedJwtClaims extends JwtClaims {
+  resolved: boolean;
+}
+
 const NO_CLAIMS: Readonly<JwtClaims> = { scope: null, orgId: null, partnerId: null };
 
-/**
- * Decode the access-token claims WITHOUT verification. Browser-side only, used
- * to avoid known 403s (partner-only endpoints under org scope) and to pre-fill
- * context — never as an authorization decision; the server re-checks everything.
- * Returns all-null when the token is absent or undecodable; callers must fall
- * through to server behavior in that case.
- */
-export function getJwtClaims(): JwtClaims {
-  const token = useAuthStore.getState().tokens?.accessToken;
+function decodeClaims(token: string | null | undefined): JwtClaims {
   if (!token) return NO_CLAIMS;
   try {
     const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
@@ -34,4 +46,33 @@ export function getJwtClaims(): JwtClaims {
   } catch {
     return NO_CLAIMS;
   }
+}
+
+/**
+ * Decode the access-token claims WITHOUT verification. Browser-side only, used
+ * to avoid known 403s (partner-only endpoints under org scope) and to pre-fill
+ * context — never as an authorization decision; the server re-checks everything.
+ * Returns all-null when the token is absent or undecodable; callers must fall
+ * through to server behavior in that case.
+ *
+ * This is a one-shot read of a store that is EMPTY on every cold load. A
+ * component that renders a scope-dependent decision — and especially one that
+ * writes that decision back to the URL — wants `useJwtClaims()` instead, which
+ * re-renders when the token lands and reports whether the scope is known yet.
+ */
+export function getJwtClaims(): JwtClaims {
+  return decodeClaims(useAuthStore.getState().tokens?.accessToken);
+}
+
+/**
+ * Reactive form of `getJwtClaims()`: subscribes to the access token, so the
+ * component re-renders when the token arrives after first paint, and reports
+ * `resolved` so a null scope can be told apart from a denied one (#4010).
+ */
+export function useJwtClaims(): ResolvedJwtClaims {
+  const accessToken = useAuthStore((s) => s.tokens?.accessToken ?? null);
+  return useMemo(
+    () => ({ ...decodeClaims(accessToken), resolved: accessToken !== null }),
+    [accessToken],
+  );
 }

--- a/apps/web/src/lib/authScope.ts
+++ b/apps/web/src/lib/authScope.ts
@@ -40,9 +40,11 @@ export type JwtClaimsState =
   | { status: 'unresolved' }
   | { status: 'resolved'; claims: JwtClaims };
 
-const NO_CLAIMS: Readonly<JwtClaims> = { scope: null, orgId: null, partnerId: null };
+// Both are shared singletons handed straight back to callers, so freeze them for
+// real rather than relying on `Readonly<>`, which erases at runtime.
+const NO_CLAIMS: Readonly<JwtClaims> = Object.freeze({ scope: null, orgId: null, partnerId: null });
 
-const UNRESOLVED: Readonly<JwtClaimsState> = { status: 'unresolved' };
+const UNRESOLVED: Readonly<JwtClaimsState> = Object.freeze({ status: 'unresolved' as const });
 
 function decodeClaims(token: string | null | undefined): JwtClaims {
   if (!token) return NO_CLAIMS;


### PR DESCRIPTION
## Problem

`/patches#rings` is written into the URL when you click **Update Rings**, but it can never be read back. Every cold load of that URL renders **Compliance** and rewrites the address bar to a bare `/patches`.

The tab guard derived `canManageRings` from `getJwtClaims().scope`, and access tokens are deliberately never persisted — `partialize` in `stores/auth.ts` keeps only `user` and `isAuthenticated`. So at first paint the auth store is empty and **every** user decodes as `scope: null`. The mount-time sync effect took the downgrade branch, which routes through `setActiveTab` → `setTabInHash` and deletes the hash. The effect's `canManageRings` dependency *did* re-run once the token landed — but by then `getTabFromHash()` had nothing left to read. Deterministic, not a race.

## Fix — option 1 from the issue (with a slice of option 2)

Option 1 asked for an explicit "claims resolved" signal instead of inferring one from a falsy `canManageRings`; option 2 asked to downgrade the view without rewriting the URL. Neither alone is quite right — option 1 still needs to decide what to render during the unresolved window, and option 2 alone leaves `canManageRings` non-reactive. Doing both, in the two places they belong:

**`lib/authScope.ts` — new `useJwtClaims()`**, a reactive companion to `getJwtClaims()`:
- subscribes to the access token, so the component genuinely re-renders when it arrives rather than relying on an incidental re-render from some unrelated fetch;
- returns a **discriminated union**, `JwtClaimsState = { status: 'unresolved' } | { status: 'resolved'; claims: JwtClaims }`, so `.claims.scope` is unreachable until the caller narrows on `status`. That is deliberate: a flat `{ ...claims, resolved: boolean }` would let the next caller destructure `{ scope }`, ignore the flag, and reproduce #4010 with the compiler's blessing. The check is structural, not a comment.
- a present-but-undecodable token is `'resolved'` with all-null claims, so we still fail closed. (Client-side UX only — the server rejects such a token outright with a 401 rather than degrading the page.)

`getJwtClaims()` is unchanged for its existing callers; the decoder is factored into a shared pure function so there is still one implementation.

**`PatchesPage.tsx`** keeps all three access states as `ringAccess: 'unresolved' | 'allowed' | 'denied'` rather than collapsing to a boolean. `'denied'` and `'unresolved'` both hide the rings UI, but **only `'denied'` may clear the hash** — the destructive branch keys on a positive `=== 'denied'`, not on the absence of a flag. Everything that merely hides or disables UI still reads the fail-closed `canManageRings = ringAccess === 'allowed'`.

The **resolved → unresolved** transition (a token going *away*) defers too, and that is deliberate rather than an oversight: while `/auth/refresh` is rate limited the session is perfectly valid and yet tokenless for up to 90 seconds (#3696), so wiping the deep link there would be #4010 again in slow motion. Logout lands on the same branch and leaves `#rings` behind, which is harmless because every logout path navigates away from the page. Pinned by a test.

**Option 3 was not taken** — deliberately. Swapping the guard to `user.canManagePartnerWide` changes *what authorizes a partner-scoped tab* from JWT scope to a different predicate (#3262: false for partner users with `org_access = 'selected'`). That is a product decision about who may manage update rings, not a bug fix, so it stays out of this PR.

### The security property is unchanged

An org user on `#rings` still lands on Compliance, and the rings tab and body are never rendered while the scope is unknown — an unknown scope is treated as *not yet a grant*, never as a grant. Their downgrade (and hash clear) is merely deferred to the moment it is real. Both directions are pinned by tests.

## Tests

`PatchesPage.scopeResolution.test.tsx` is new and mocks **neither** `authScope` nor the auth store — it drives the real `useJwtClaims` against the real store so the token genuinely arrives after mount, which is the only way to reproduce this bug. (The existing `PatchesPage.test.tsx` mocks `authScope` with an already-known scope, i.e. the one state a cold load never starts in; that is why the bug shipped past a suite that already had four `#rings` guard tests.)

Coverage:
- partner **and** system scope arriving after first paint → `#rings` survives the unresolved window and the Update Rings tab becomes active;
- org scope arriving after first paint → still downgrades to Compliance **and** clears the stale `#rings`;
- undecodable token → resolved-and-denied, hash cleared (fails closed);
- a `hashchange` back to `#rings` during the unresolved window → also deferred, not wiped;
- a token going *away* again (throttled refresh / logout) → rings hidden, hash deliberately kept, and rings restored when the token returns;
- a token landing while the user is on `#patches` → the Update Rings nav chrome appears without yanking them off their tab;
- `useJwtClaims` unresolved/resolved/undecodable/logout semantics and return-value identity stability in `authScope.test.ts`.

**Revert probe:** restoring the old effect body fails **6 of the 7** cases in the new suite with the bug's signature, `AssertionError: expected '' to be '#rings'`. The one that passes either way is the `#patches` case, which has no rings hash to destroy.

Two of the original five cases initially passed against the reverted code — the old premature clear and the new deliberate clear reach the same *final* state for a denied user, and those tests only asserted the final state. They now assert the hash is intact *before* the token lands, which is the property that actually differs. That was a review finding, and it is the difference between 3/5 and 6/7 discriminating.

## Review

Four reviewers ran (`code-reviewer`, `pr-test-analyzer`, `comment-analyzer`, `type-design-analyzer`), plus an independent second opinion from Codex on the type-shape question.

`code-reviewer` returned **0 Critical / 0 Important**, having traced that no ordering — SSR, hydration, `hashchange` during the unresolved window, logout mid-session — can turn "unresolved" into a grant. The rest of the findings are addressed in the follow-up commit: the union refactor above (raised independently by `type-design-analyzer` and Codex, which is why it was adopted rather than deferred), the two non-discriminating tests, two missing sequences, and three stale comments — the worst of which asserted that "canManageRings itself stays accurate everywhere else (the hash-resolution effect, ring actions) so the #rings deep-link and scope guards are unaffected", a claim #4010 disproved, sitting fifteen lines above its own fix.

## Sibling pages — swept, and the sweep found something else

The issue asked whether `DiscoveryPage` and `DeviceDetails`, cited in the code comments as precedent for this hash pattern, share the shape. **Neither does**, and the chain breaks in a different place in each:

- **`DiscoveryPage.tsx`** — the mount effect's `getTabFromHash()` (`:247-254`, called at `:286-291`) only checks membership in `DISCOVERY_TABS`. There is no permission gate on the hash value at all. The page's `useOrgScope()` (`:281`) gates *rendering* (`:658-660`) and never touches `location.hash`; hash writes happen only in the user-driven `navigateToTab` (`:601-604`).
- **`DeviceDetails.tsx`** — reads through `useHashState` (`:318`), whose contract is read-only on mount (`lib/useHashState.ts:19-20`). Its one gate (`:370-371`) is derived from `device.linkGroupId`, not a permission, and only overrides a local render variable — it never writes the URL. `getJwtClaims` is not referenced in the file.

A repo-wide cross-reference (every file calling `getJwtClaims` × every file touching `location.hash`/`replaceState`/`pushState`) leaves five candidates: this file plus `PartnerSettingsPage`, `TicketingSettingsTabs`, `QuickbooksIntegration` and `IntegrationsPage`. None of the other four reproduces the full shape — each either has no permission gate on the hash value, or gates render only and never writes the URL. **`PatchesPage` was the only instance.**

The sweep did turn up a **different** latent bug with the same root cause, filed as #4013 rather than widened into this PR:

> `TicketingSettingsTabs.tsx:80` — `const canManageInbound = useMemo(() => getJwtClaims().scope === 'partner', [])`. Empty deps freeze a value read from a store that is empty at first paint, so on a cold load it is pinned `false` for the life of the mount. It gates render only (never a URL write), so it is not #4010's shape — but it hides Intake Forms / Inbound Email / Canned Responses from partner users who land directly on `/settings/partner#ticketing`, which is exactly where the permanent 301 alias at `pages/settings/ticketing.astro` sends every old bookmark. `useJwtClaims()` from this PR is the ready-made fix.

## Verification

- `apps/web` — `vitest run src/lib/authScope.test.ts src/components/patches/` → **11 files, 130 tests passed** (single-fork).
- Wider authScope-consumer sweep (settings + tickets suites that mock `authScope`) → **21 files, 381 tests passed**.
- `astro check` → **0 errors, 0 warnings** (1679 files).
- `eslint` on all five changed files → clean.

Closes #4010

🤖 Generated with [Claude Code](https://claude.com/claude-code)
