### PR TITLE
fix(api): redact channel credentials before composing the test-failure reason (#3992)

### DIFF
--- a/apps/api/src/routes/alerts/channels.testOutcomePersist.test.ts
+++ b/apps/api/src/routes/alerts/channels.testOutcomePersist.test.ts
@@ -296,3 +296,65 @@ describe('POST /alerts/channels/:id/test — persisted test outcome (#3697)', ()
     expect(stored).toContain('no_service');
   });
 });
+
+// The reason reaches the operator on TWO surfaces: the persisted card (above)
+// and the toast fired at test time, which renders `testResult.message` from
+// this response. The response carried the RAW provider text, so the card was
+// scrubbed while the toast next to it showed the credential (#3992).
+describe('POST /alerts/channels/:id/test — the toast surface (#3992)', () => {
+  beforeEach(() => {
+    updateSetRef.current = undefined;
+    updateRowCountRef.current = 1;
+    capturedExceptionsRef.current = [];
+    channelRowRef.current = emailChannel();
+  });
+
+  it('does not echo a slack webhook URL back in the response the toast renders', async () => {
+    const webhookUrl = fakeSlackWebhookUrl('YYYYYYYYYYYYYYYYYYYYYYYY');
+    channelRowRef.current = emailChannel({ type: 'slack', config: { webhookUrl } });
+    senderResultRef.current = { success: false, error: `HTTP 404: no_service for ${webhookUrl}` };
+
+    const res = await makeApp().request(`/alerts/channels/${CHANNEL_ID}/test`, { method: 'POST' });
+    const body = await res.json() as { testResult: { success: boolean; message: string } };
+
+    expect(body.testResult.success).toBe(false);
+    expect(body.testResult.message).not.toContain(webhookUrl);
+    expect(body.testResult.message).not.toContain('YYYYYYYYYYYYYYYYYYYYYYYY');
+    expect(body.testResult.message).toContain('no_service');
+  });
+
+  // Card and toast must not diverge: an operator who dismisses the toast and
+  // reads the card should see the same sentence.
+  it('renders the same reason on both surfaces', async () => {
+    senderResultRef.current = { success: false, error: RESEND_ERROR };
+
+    const res = await makeApp().request(`/alerts/channels/${CHANNEL_ID}/test`, { method: 'POST' });
+    const body = await res.json() as { testResult: { message: string } };
+
+    expect(body.testResult.message).toBe(updateSetRef.current?.lastTestError);
+    expect(body.testResult.message).toBe(RESEND_ERROR);
+  });
+
+  it('leaves a successful test message untouched', async () => {
+    senderResultRef.current = { success: true };
+
+    const res = await makeApp().request(`/alerts/channels/${CHANNEL_ID}/test`, { method: 'POST' });
+    const body = await res.json() as { testResult: { success: boolean; message: string } };
+
+    expect(body.testResult.success).toBe(true);
+    expect(body.testResult.message).toBe('Test email sent successfully');
+  });
+
+  // scrubChannelTestError returns null for an empty/whitespace-only message
+  // (never as a result of scrubbing itself — redaction substitutes a non-empty
+  // placeholder). The toast must not go blank when a sender hands us one.
+  it('falls back to a generic reason when scrubbing leaves nothing', async () => {
+    senderResultRef.current = { success: false, error: '   ' };
+
+    const res = await makeApp().request(`/alerts/channels/${CHANNEL_ID}/test`, { method: 'POST' });
+    const body = await res.json() as { testResult: { message: string } };
+
+    expect(body.testResult.message.trim().length).toBeGreaterThan(0);
+    expect(body.testResult.message).toContain('check the channel configuration');
+  });
+});

--- a/apps/api/src/routes/alerts/channels.ts
+++ b/apps/api/src/routes/alerts/channels.ts
@@ -688,6 +688,22 @@ channelsRoutes.post(
       ? null
       : scrubChannelTestError(channel.type, channelConfig, testResult.message);
 
+    // The reason reaches the operator TWICE: the persisted card, and the toast
+    // fired at test time — and the toast renders `testResult.message`, which
+    // until now was the raw provider text. So the card was scrubbed while the
+    // toast still showed the destination URL that, for slack/teams/webhook, IS
+    // the credential (#3992). Both surfaces render the same scrubbed string
+    // from here on. `scrubChannelTestError` returns null only for a non-string
+    // or an empty/whitespace-only message — never as a RESULT of scrubbing,
+    // since every redaction pass substitutes a non-empty placeholder — but the
+    // fallback keeps the toast from going blank when a sender hands us one.
+    if (!testResult.success) {
+      testResult = {
+        ...testResult,
+        message: lastTestError ?? 'Test failed — check the channel configuration.',
+      };
+    }
+
     try {
       const persistResult = await withAuthDbAccessContext(auth, () =>
         db.update(notificationChannels)

--- a/apps/api/src/services/httpFailureMessage.test.ts
+++ b/apps/api/src/services/httpFailureMessage.test.ts
@@ -1,0 +1,405 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatHttpFailure,
+  formatHttpFailureDetail,
+  summarizeResponseBody,
+  MAX_OPERATOR_ERROR_LENGTH,
+} from './httpFailureMessage';
+import { scrubChannelTestError } from './notificationChannelSecrets';
+
+// The reported body, verbatim from #3992: a webhook channel pointed at a URL
+// that answers 405 with an HTML error page. 500 characters of this landed in
+// the channel card and buried the only useful token.
+const EXAMPLE_DOMAIN_405 =
+  '<!doctype html><html lang="en"><head><title>Example Domain</title>' +
+  '<link rel="icon" href="data:,">' +
+  '<meta name="viewport" content="width=device-width, initial-scale=1">' +
+  '<style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}</style>' +
+  '</head><body><h1>Example Domain</h1>' +
+  '<p>This domain is for use in illustrative examples in documents.</p>' +
+  '</body></html>';
+
+describe('summarizeResponseBody', () => {
+  it('reduces the reported HTML error page to readable prose', () => {
+    const summary = summarizeResponseBody(EXAMPLE_DOMAIN_405);
+
+    expect(summary).toContain('Example Domain');
+    expect(summary).toContain('This domain is for use in illustrative examples');
+    // No markup, and — the part a naive tag-strip gets wrong — no leftover CSS.
+    expect(summary).not.toContain('<');
+    expect(summary).not.toContain('>');
+    expect(summary).not.toContain('background:#eee');
+    expect(summary).not.toContain('font-family');
+    expect(summary).not.toContain('doctype');
+  });
+
+  it('drops script contents, not just the script tags', () => {
+    const summary = summarizeResponseBody(
+      '<html><body><script>var token="leaky";alert(1)</script><p>Method Not Allowed</p></body></html>'
+    );
+
+    expect(summary).toBe('Method Not Allowed');
+  });
+
+  it('handles a body truncated mid-tag or mid-script without leaking the fragment', () => {
+    expect(summarizeResponseBody('<p>Not allowed</p><div class="foot')).toBe('Not allowed');
+    expect(summarizeResponseBody('<p>Not allowed</p><script>var secret="abc')).toBe('Not allowed');
+    expect(summarizeResponseBody('<p>Not allowed</p><!-- internal note about')).toBe('Not allowed');
+    // A DECLARATION cut mid-write needs its own rule — the tag pattern requires
+    // a letter after the optional `/`, so it never matches `<!doctype htm` and
+    // the fragment used to survive into the card. A proxy timeout or a reset
+    // partway through the response reproduces this exactly.
+    expect(summarizeResponseBody('<p>Not allowed</p><!doctype htm')).toBe('Not allowed');
+    expect(summarizeResponseBody('<p>Not allowed</p><![CDATA[ leftover')).toBe('Not allowed');
+  });
+
+  it('collapses newlines and indentation into single spaces', () => {
+    expect(summarizeResponseBody('{\n  "error":\n\t"invalid_payload"\n}')).toBe('{ "error": "invalid_payload" }');
+  });
+
+  it('decodes the entities that would otherwise render as noise', () => {
+    expect(summarizeResponseBody('<p>Tenant &amp; site&nbsp;mismatch &#8212; retry</p>')).toBe(
+      'Tenant & site mismatch — retry'
+    );
+    // Hex numeric entities take the other fork of the same branch.
+    expect(summarizeResponseBody('rate limit &#x2014; retry after 30s')).toBe('rate limit — retry after 30s');
+    // Anything unusable stays literal rather than becoming mojibake.
+    expect(summarizeResponseBody('a &#x110000; b &notarealentity; c')).toBe(
+      'a &#x110000; b &notarealentity; c'
+    );
+  });
+
+  it('leaves a plain-text body alone apart from trimming', () => {
+    expect(summarizeResponseBody('  invalid_payload: field "text" is required  ')).toBe(
+      'invalid_payload: field "text" is required'
+    );
+  });
+
+  // Angle brackets around an address are ordinary in provider prose. Treating
+  // them as markup would delete the one thing the operator needs to see.
+  it('does not mistake an angle-bracketed address for a tag', () => {
+    expect(summarizeResponseBody('recipient <ops@example.com> was rejected')).toBe(
+      'recipient <ops@example.com> was rejected'
+    );
+  });
+
+  it('returns an empty string when nothing readable survives', () => {
+    expect(summarizeResponseBody('<html><head><style>b{color:red}</style></head><body></body></html>')).toBe('');
+    expect(summarizeResponseBody('')).toBe('');
+    expect(summarizeResponseBody(undefined)).toBe('');
+    expect(summarizeResponseBody(null)).toBe('');
+  });
+
+  it('truncates at a word boundary rather than mid-token', () => {
+    const summary = summarizeResponseBody(`${'alpha bravo '.repeat(40)}`, 40);
+
+    expect(summary.length).toBeLessThanOrEqual(40);
+    expect(summary.endsWith('…')).toBe(true);
+    // Every kept token is whole.
+    for (const token of summary.replace('…', '').trim().split(' ')) {
+      expect(['alpha', 'bravo']).toContain(token);
+    }
+  });
+
+  // A hostile destination can return an unbounded body (the senders pass no
+  // `maxBytes` to safeFetch), and SCRIPT_OR_STYLE_BLOCK is a lazy scan with a
+  // backreference — quadratic on a body full of unclosed `<script` tags. The
+  // input window keeps that constant. This asserts the bound holds by timing
+  // the pathological shape rather than by reading the code.
+  it('does not degrade on a hostile multi-megabyte body', () => {
+    const hostile = '<script src="x" '.repeat(60_000); // ~1MB, 60k unclosed opens
+
+    const started = Date.now();
+    const summary = summarizeResponseBody(hostile);
+    const elapsed = Date.now() - started;
+
+    expect(summary.length).toBeLessThanOrEqual(MAX_OPERATOR_ERROR_LENGTH);
+    expect(elapsed).toBeLessThan(1000);
+  });
+
+  // A window with no boundary anywhere is one opaque blob — which is exactly
+  // the shape a credential has. It is dropped rather than sliced through, and
+  // the caller falls back to a bare `HTTP <status>`.
+  it('drops a window with no boundary rather than slicing through it', () => {
+    expect(summarizeResponseBody('x'.repeat(400), 40)).toBe('');
+  });
+
+  // What dropping a whitespace-free window does NOT cost: truncation only
+  // engages above the cap, so an ordinary short minified body is returned
+  // whole and never reaches the boundary rule at all.
+  it('returns a short minified body whole, boundary rule never engaged', () => {
+    expect(summarizeResponseBody('{"error":"invalid_grant"}')).toBe('{"error":"invalid_grant"}');
+  });
+});
+
+describe('formatHttpFailure', () => {
+  it('keeps the status token in front and caps the whole message', () => {
+    const message = formatHttpFailure(405, EXAMPLE_DOMAIN_405);
+
+    expect(message.startsWith('HTTP 405: ')).toBe(true);
+    expect(message).toContain('Example Domain');
+    expect(message.length).toBeLessThanOrEqual(MAX_OPERATOR_ERROR_LENGTH);
+  });
+
+  it('omits the separator when the body carried nothing readable', () => {
+    expect(formatHttpFailure(502, '<html><body></body></html>')).toBe('HTTP 502');
+    expect(formatHttpFailure(502, undefined)).toBe('HTTP 502');
+  });
+
+  it('degrades to a generic prefix when the status is unknown', () => {
+    expect(formatHttpFailure(undefined, undefined)).toBe('HTTP error');
+  });
+
+  it('never exceeds the operator cap, whatever the destination returns', () => {
+    for (const body of ['y'.repeat(5000), `${'word '.repeat(500)}`, '<p>a</p>'.repeat(500)]) {
+      expect(formatHttpFailure(500, body).length).toBeLessThanOrEqual(MAX_OPERATOR_ERROR_LENGTH);
+    }
+  });
+});
+
+describe('formatHttpFailureDetail', () => {
+  it('keeps the unshortened body for the log line', () => {
+    const detail = formatHttpFailureDetail(405, EXAMPLE_DOMAIN_405);
+
+    expect(detail).toContain('<!doctype html>');
+    expect(detail.length).toBeGreaterThan(MAX_OPERATOR_ERROR_LENGTH);
+  });
+
+  it('still bounds a hostile destination', () => {
+    expect(formatHttpFailureDetail(500, 'z'.repeat(50_000)).length).toBeLessThanOrEqual(512);
+  });
+});
+
+// The operator-facing shortening happens BEFORE `scrubChannelTestError` runs,
+// so it must not hand the scrubber a credential it can no longer recognise.
+// Assembled at runtime, never written as a literal: GitHub push protection
+// blocks a Slack-webhook-shaped string in source even when it is fabricated.
+describe('composition does not weaken credential scrubbing', () => {
+  const webhookUrl = `https://${['hooks', 'slack', 'com'].join('.')}/services/T00000000/B00000000/SECRETTOKENVALUE00000001`;
+
+  it('still scrubs a webhook URL the destination echoed inside an HTML body', () => {
+    const composed = formatHttpFailure(404, `<html><body><p>no_service for ${webhookUrl}</p></body></html>`);
+    const scrubbed = scrubChannelTestError('slack', { webhookUrl }, composed);
+
+    expect(scrubbed).not.toContain(webhookUrl);
+    expect(scrubbed).not.toContain('SECRETTOKENVALUE00000001');
+    expect(scrubbed).toContain('no_service');
+  });
+
+  // The reason the truncation cuts at a word boundary: a hard slice through a
+  // URL leaves a prefix that literal-substring scrubbing cannot match.
+  //
+  // The fixture is tuned so the token STRADDLES the cut — with a naive hard
+  // slice, 17 characters of it survive. The first assertion proves that
+  // precondition, so this test cannot quietly become vacuous if the cap, the
+  // prefix width or the URL length ever changes: if the token stops straddling,
+  // the control fails rather than the guarantee passing for free.
+  it('drops an echoed URL whole rather than leaving a scrubber-proof prefix', () => {
+    const body = `the destination refused this delivery attempt outright and returned no_service ${webhookUrl}`;
+    const budget = MAX_OPERATOR_ERROR_LENGTH - 'HTTP 404'.length - 2;
+
+    // Control: a hard slice at the same budget WOULD publish part of the token.
+    const hardSliced = body.slice(0, budget - 1);
+    expect(hardSliced).toContain('SECRETTOKENVALUE');
+    expect(hardSliced).not.toContain('SECRETTOKENVALUE00000001');
+
+    const composed = formatHttpFailure(404, body);
+    const scrubbed = scrubChannelTestError('slack', { webhookUrl }, composed) ?? '';
+
+    // The real thing drops the URL whole, so no fragment of the token is left.
+    expect(composed).not.toContain('SECRETTOKENVALUE');
+    expect(scrubbed).not.toContain('SECRETTOKENVALUE');
+    expect(scrubbed).not.toContain('hooks.slack.com');
+    // ...and the operator still learns what happened.
+    expect(scrubbed).toContain('no_service');
+  });
+
+  // The sharpest form of the leak, and the one a hard-cut fallback could not
+  // survive: a destination that answers with nothing but the URL it was called
+  // on — `res.status(404).send(req.originalUrl)` — so the body has no
+  // whitespace at all and the token sits past the cap. Pass 2's pattern
+  // matcher is no help here: a token carried as a PATH SEGMENT looks like
+  // nothing in particular. Measured before the fix: 38 characters of the token
+  // survived into the card.
+  it('drops an echoed URL that is the whole body, token past the cap', () => {
+    const token = 'SUPERSECRETTOKENVALUE0123456789ABCDEFGHIJ';
+    const url =
+      'https://hooks.vendor.example/services/tenant-acme-corporation-holdings-emea-region/workspace-primary-alerts/in' +
+      token;
+
+    // Control: the token really does straddle the cut for this fixture, so the
+    // test cannot go vacuous if the cap or the URL shape changes.
+    const cut = MAX_OPERATOR_ERROR_LENGTH - 'HTTP 404'.length - 2 - 1;
+    expect(url.indexOf(token)).toBeLessThan(cut);
+    expect(url.indexOf(token) + token.length).toBeGreaterThan(cut);
+    expect(/\s/.test(url)).toBe(false);
+
+    const composed = formatHttpFailure(404, url);
+    const scrubbed = scrubChannelTestError('webhook', { url }, composed) ?? '';
+
+    expect(composed).toBe('HTTP 404');
+    expect(scrubbed).not.toContain('SUPERSECRETTOKEN');
+  });
+
+  // Entity decoding runs BEFORE truncation, so a destination that echoes a
+  // secret as `TOKEN&quot;PART` hands the truncator a `"` sitting INSIDE the
+  // secret. Treating punctuation as a cut point let the cut land on that
+  // injected quote and publish `TOKENPART1`.
+  it('does not cut on a boundary an HTML entity injected into a secret', () => {
+    const secret = 'TOKENPART1"TOKENPART2LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG';
+    const body = `${'x'.repeat(100)} TOKENPART1&quot;TOKENPART2LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG`;
+
+    const composed = formatHttpFailure(404, body);
+    const scrubbed = scrubChannelTestError('webhook', { headers: { 'X-Key': secret } }, composed) ?? '';
+
+    expect(scrubbed).not.toContain('TOKENPART1');
+  });
+
+  // The case that killed the structural-punctuation fallback. A webhook
+  // channel's secrets are not only its URL: secretKeysForType('webhook')
+  // covers authToken, authPassword and apiKeyValue, which are admin-typed with
+  // no charset restriction (`config: z.record(z.string(), z.unknown())`, and
+  // validateOutboundHeader constrains header NAMES, not values). So a `|` or a
+  // `"` inside an API key is entirely legal, and an unspaced
+  // `error=…;description=…` echo let the cut land inside it — 44 characters of
+  // the key survived. Cutting only at whitespace is what closes this.
+  it('does not cut inside an api key that contains punctuation', () => {
+    const apiKey = 'PLACEHOLDERAPIKEY_ABCDEFGHIJKLMNOPQRSTUVWXYZ|MOREDATAAFTERPIPE1234567890abcdefghijklmnopqrstuvwxyz';
+    const body = `error=invalid_token;description=the_supplied_key(${apiKey})did_not_match_any_record_for_this_account`;
+
+    // Control: no whitespace anywhere, and the key straddles the cut.
+    expect(/\s/.test(body)).toBe(false);
+    expect(body.length).toBeGreaterThan(MAX_OPERATOR_ERROR_LENGTH);
+
+    const composed = formatHttpFailure(404, body);
+    const scrubbed = scrubChannelTestError('webhook', { apiKeyValue: apiKey }, composed) ?? '';
+
+    expect(composed).toBe('HTTP 404');
+    expect(scrubbed).not.toContain('PLACEHOLDERAPIKEY');
+  });
+});
+
+// #3992 round 2. The composer normalises (strips tags, decodes entities,
+// collapses whitespace, truncates) and `scrubChannelTestError` at the route
+// removes the channel's own credentials by LITERAL substring — so scrubbing
+// only afterwards cannot catch what normalising rewrote, and the credential
+// reaches the channel card and the test toast.
+//
+// The obvious alternative — keep scrubbing afterwards, but also search for the
+// NORMALISED form of each secret — is unsound, and the third case below is the
+// proof. Redaction has to run on the raw body, before the first lossy step.
+//
+// Every case carries a control asserting the leak IS reachable without the
+// fix, so none of them can pass vacuously.
+describe('credentials in the raw body are redacted before anything rewrites it', () => {
+  it('masks a secret whose repeated whitespace the summary collapses', () => {
+    const secret = 'alpha  beta  gamma';
+    const body = `<p>rejected credential ${secret}</p>`;
+
+    expect(formatHttpFailure(401, body)).toContain('alpha beta gamma'); // control
+
+    const out = formatHttpFailure(401, body, { secrets: [secret] });
+
+    expect(out).not.toContain('alpha beta gamma');
+    expect(out).not.toContain(secret);
+    expect(out).toContain('********');
+  });
+
+  it('masks a secret that tag-stripping splits in two', () => {
+    const secret = 'alpha<b>beta-secret';
+    const body = `rejected credential ${secret}`;
+
+    expect(formatHttpFailure(401, body)).toContain('beta-secret'); // control
+
+    const out = formatHttpFailure(401, body, { secrets: [secret] });
+
+    expect(out).not.toContain('beta-secret');
+    expect(out).not.toContain('alpha beta-secret');
+  });
+
+  // THE decisive case. Entity decoding consumes the `;` that came from OUTSIDE
+  // the secret, so the transformed text contains neither `abcd&amp` (the raw
+  // secret) nor any normalisation of it — it contains `abcd&`. No variant-
+  // matching scheme can catch this, because the string being looked for does
+  // not exist in either form. Redacting first is immune: the secret is gone
+  // before the decoder runs.
+  it('masks a secret whose trailing entity is completed by the text around it', () => {
+    const secret = 'abcd&amp';
+    const body = `rejected credential ${secret};`;
+
+    const control = formatHttpFailure(401, body);
+    expect(control).toContain('abcd&'); // control: the leak is real
+    expect(control).not.toContain('abcd&amp'); // and no variant would have matched
+
+    const out = formatHttpFailure(401, body, { secrets: [secret] });
+
+    expect(out).not.toContain('abcd&');
+    expect(out).toContain('********');
+  });
+
+  // truncate() cuts at whitespace, and the module documents its own residual:
+  // a secret that CONTAINS whitespace can still be split, leaving a prefix that
+  // no complete-secret match can find. Redacting first removes it first.
+  it('masks a secret that truncation would otherwise cut in half', () => {
+    const secret = 'front-half back-half-tail';
+    const body = `reject ${secret}`;
+
+    expect(formatHttpFailure(500, body, { maxLength: 40 })).toContain('front-half'); // control
+
+    const out = formatHttpFailure(500, body, { secrets: [secret], maxLength: 40 });
+
+    expect(out).not.toContain('front-half');
+  });
+
+  // A secret straddling the 8 KB scan bound would be cut by that slice before
+  // masking could see it, publishing the prefix. Masking runs on a window
+  // widened by the longest secret, so no occurrence starting inside the scan
+  // window is ever bisected by the bound.
+  it('masks a secret straddling the summary input window', () => {
+    const secret = 'boundary-secret-value';
+    const body = 'ab '.repeat(2729) + secret; // secret starts at 8187, window ends at 8192
+
+    expect(summarizeResponseBody(body, 20000)).toContain('bound'); // control: prefix survives
+
+    const out = summarizeResponseBody(body, 20000, [secret]);
+
+    expect(out).not.toContain('bound');
+  });
+
+  // The log/delivery-record form is un-normalised on purpose so debugging loses
+  // nothing — but nothing downstream scrubs it, so it must not carry the
+  // channel's own credentials either.
+  it('masks the unshortened detail form too', () => {
+    const secret = 'detail-secret-value';
+
+    expect(formatHttpFailureDetail(500, `boom ${secret}`)).toContain(secret); // control
+
+    expect(formatHttpFailureDetail(500, `boom ${secret}`, [secret])).not.toContain(secret);
+  });
+
+  // Ordering invariant: a shorter secret that is a prefix of a longer one must
+  // not replace its head first and carve the longer one into a fragment that no
+  // longer matches. Sorted longest-first across ALL secrets, not per caller.
+  it('masks the longer secret when one secret is a prefix of another', () => {
+    const short = 'abcdefgh';
+    const long = 'abcdefghSECRETTAIL';
+
+    const out = formatHttpFailure(401, `rejected ${long}`, { secrets: [short, long] });
+
+    expect(out).not.toContain('SECRETTAIL');
+  });
+
+  // The composer is not the only producer — a thrown Error.message reaches the
+  // route scrub un-normalised — so the route scrub stays the second bracket.
+  it('leaves the route scrub able to catch an untransformed message', () => {
+    const authPassword = 'plain-secret-value';
+
+    const scrubbed = scrubChannelTestError(
+      'webhook',
+      { authPassword },
+      `rejected ${authPassword}`
+    );
+
+    expect(scrubbed).not.toContain(authPassword);
+  });
+});

--- a/apps/api/src/services/httpFailureMessage.ts
+++ b/apps/api/src/services/httpFailureMessage.ts
@@ -1,0 +1,310 @@
+/**
+ * Operator-facing failure messages for outbound HTTP calls.
+ *
+ * Several senders (webhook, Pushover, PagerDuty) and the webhook-delivery
+ * worker compose their failure string by splicing the destination's raw
+ * response body straight into `HTTP <status>: <body>`. When the destination
+ * answers with an HTML error page — which is what a misconfigured URL usually
+ * returns — the operator-facing string becomes 500 characters of markup, and
+ * the one token that matters (`HTTP 405`) is buried in the first ten (#3992).
+ *
+ * That string is not developer log output: it is persisted into
+ * `notification_channels.last_test_error` and rendered in the channel card, and
+ * it is echoed back in the channel-test response where it becomes a toast. Both
+ * surfaces need a short, readable sentence.
+ *
+ * The unshortened body is not lost anywhere this is used:
+ *
+ * - `webhookSender` — in its `console.error` line, via `formatHttpFailureDetail`.
+ * - `workers/webhookDelivery` — in the delivery record's own `responseBody`
+ *   field, which already stored 1000 characters independently of the error.
+ * - `pushoverSender` / `pagerDutySender` — in a `console.error` added alongside
+ *   this change. Neither logged anything before and neither holds a second copy
+ *   of the body, so shortening their `error` string would have been the end of
+ *   it — and that string is not a toast: the dispatcher persists it into
+ *   `alert_notifications.error_message` on the LIVE alert path, so an on-call
+ *   engineer debugging a PagerDuty outage would have been left with 160
+ *   characters and nothing else. The log line is not a new secrets surface;
+ *   the dispatcher's own `console.error` already carried the unshortened body.
+ */
+
+/**
+ * Cap for the composed operator-facing message.
+ *
+ * ~160 characters is room for `HTTP 405` plus a real sentence from the
+ * destination, and not enough for a markup dump to bury it. It is a judgement
+ * call, not a measurement: the card clamps to two lines and keeps the full
+ * string on `title`, so a message slightly over two lines still degrades
+ * gracefully — the failure mode this guards against is 500 characters, not 170.
+ * Deliberately far below `MAX_CHANNEL_TEST_ERROR_LENGTH` (500), which stays the
+ * storage-side backstop for messages that never pass through here (a thrown
+ * `Error.message`, a provider SDK string).
+ */
+export const MAX_OPERATOR_ERROR_LENGTH = 160;
+
+/**
+ * How much of the raw body is worth keeping for logs / delivery records.
+ * Unchanged from the pre-#3992 splice so debugging loses nothing.
+ */
+export const MAX_LOGGED_RESPONSE_BODY_LENGTH = 500;
+
+/**
+ * How much of the body the normaliser is allowed to look at.
+ *
+ * `safeFetch` accepts a `maxBytes` ceiling but the senders do not pass one, so
+ * a hostile destination can answer with a multi-megabyte body — and
+ * `SCRIPT_OR_STYLE_BLOCK` is a lazy scan with a backreference, which degrades
+ * to O(opens × length) on a body full of unclosed `<script` tags. Measured: a
+ * 1 MB body of 60k unclosed opens took 45 seconds unbounded, under 1 ms
+ * bounded. The old code was immune only because it did nothing but
+ * `slice(0, 500)`.
+ *
+ * 8 KB is far more than any error page needs to get its readable sentence out
+ * (a `<title>` is in the first few hundred bytes); the cost is that a body whose
+ * only prose sits past 8 KB summarises to nothing and the caller falls back to a
+ * bare `HTTP <status>`, which is the same outcome as a body of pure markup.
+ */
+const MAX_SUMMARY_INPUT_LENGTH = 8192;
+
+/**
+ * A real HTML tag: a name, then either `>` straight away or whitespace before
+ * the attributes. The whitespace requirement is what keeps `<bad@example.com>`
+ * — an ordinary shape in an SMTP or validation error — from being mistaken for
+ * markup and deleted.
+ */
+const HTML_TAG = /<\/?[a-z][a-z0-9-]*(?:\s[^<>]*)?\/?>/gi;
+
+/** `<script>`/`<style>` are stripped WITH their contents; otherwise a stripped
+ * page leaves its CSS behind and the summary reads `body{background:#eee;...}`,
+ * which is exactly the noise this is here to remove. */
+const SCRIPT_OR_STYLE_BLOCK = /<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi;
+/** Same, for a body truncated mid-block by the sender's own cap. */
+const UNTERMINATED_SCRIPT_OR_STYLE = /<(script|style)\b[^>]*>[\s\S]*$/i;
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+function decodeEntities(text: string): string {
+  return text.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, entity: string) => {
+    const lower = entity.toLowerCase();
+    if (lower.startsWith('#')) {
+      const codePoint = lower.startsWith('#x')
+        ? Number.parseInt(lower.slice(2), 16)
+        : Number.parseInt(lower.slice(1), 10);
+      // Control characters would just become whitespace noise; anything out of
+      // range is left as the literal entity. `Infinity` from an absurdly long
+      // digit run fails the upper bound and `NaN` fails `isFinite`, so this
+      // guard is what actually keeps `fromCodePoint` from throwing — the catch
+      // below is belt-and-braces and is unreachable by construction today.
+      if (!Number.isFinite(codePoint) || codePoint < 0x20 || codePoint > 0x10ffff) return match;
+      try {
+        return String.fromCodePoint(codePoint);
+      } catch {
+        return match;
+      }
+    }
+    return NAMED_ENTITIES[lower] ?? match;
+  });
+}
+
+/**
+ * Truncate at whitespace, or not at all.
+ *
+ * Readability is only half the reason. `scrubChannelTestError` removes the
+ * channel's own credentials by *literal substring* replacement, so a secret cut
+ * in half no longer matches and its prefix reaches the channel card and the
+ * test toast. A credential is a single unbroken token, so cutting only at
+ * whitespace present in the destination's own text means an echoed secret is
+ * either wholly kept (and therefore scrubbable) or wholly gone.
+ *
+ * A window with no whitespace is one opaque blob — the shape a credential has —
+ * and is dropped entirely; the caller falls back to a bare `HTTP <status>`.
+ * That costs less than it looks: truncation only engages above ~150 characters,
+ * so a short minified body (`{"error":"invalid_grant"}`) is returned whole and
+ * never reaches this function. What is given up is a partial view of a
+ * whitespace-free body longer than the cap — and the unshortened body is still
+ * in a log line or a delivery record on every path (see the module header).
+ *
+ * Four rules were tried before this one, each leaking where the last did not.
+ * Recording them because each looked obviously safe until it was executed:
+ *
+ * 1. Word boundary, honoured only past 60% of the budget. A 77-character
+ *    webhook URL at the end of a sentence pushes the last space before that
+ *    mark → forced hard cut → 17 characters of the token published.
+ * 2. Word boundary wherever it falls, hard cut when there is none. A
+ *    destination answering with only `req.originalUrl` has no whitespace at
+ *    all → 38 characters of a 151-character URL's token published.
+ * 3. Whitespace and structural punctuation as one boundary set. Entity decoding
+ *    runs BEFORE this, so a body echoing `TOKEN&quot;PART` puts a `"` INSIDE
+ *    the secret → cut landed there → `TOKENPART1` published.
+ * 4. Whitespace first, punctuation only as a fallback. Survived every shape
+ *    with whitespace in it, but the fallback still cut inside a secret in a
+ *    whitespace-free body — and the claim that no credential format allows
+ *    those characters was simply wrong: `secretKeysForType('webhook')` covers
+ *    `authToken`, `authPassword` and `apiKeyValue`, which are admin-typed with
+ *    no charset restriction (`config: z.record(z.string(), z.unknown())`, and
+ *    `validateOutboundHeader` constrains header NAMES, not values). A body of
+ *    `error=…;description=…(KEY|MORE)…` leaked a 44-character prefix.
+ *
+ * Residual, stated plainly rather than argued away: a secret that itself
+ * contains whitespace could still be split. Nothing here can prevent that —
+ * only the scrubber can, and it needs the whole secret to match. Truncation's
+ * job is to avoid making the scrubber's job impossible, not to replace it.
+ */
+function truncate(text: string, maxLength: number): string {
+  if (maxLength <= 0) return '';
+  if (text.length <= maxLength) return text;
+
+  const budget = maxLength - 1; // room for the ellipsis
+  const cut = text.slice(0, budget).lastIndexOf(' ');
+  if (cut <= 0) return '';
+
+  const kept = text.slice(0, cut).trimEnd();
+  return kept.length === 0 ? '' : `${kept}…`;
+}
+
+/** Same placeholder `scrubChannelTestError` uses, so a message that passes
+ *  through both reads consistently whichever half caught the secret. */
+const MASKED_SECRET = '********';
+
+/**
+ * Remove the caller's own credentials from a raw body BEFORE anything rewrites
+ * it.
+ *
+ * This is the load-bearing half of the fix for #3992, and the ordering is the
+ * whole point. `scrubChannelTestError` matches secrets by literal substring; a
+ * message that has already been entity-decoded, tag-stripped, whitespace-
+ * collapsed and truncated is no longer guaranteed to contain the configured
+ * string, so scrubbing only afterwards silently publishes the credential.
+ *
+ * Matching the transformed secret instead of redacting first was considered and
+ * is unsound — normalisation is not substring-preserving. A configured
+ * `abcd&amp` echoed inside `rejected abcd&amp;` decodes to `rejected abcd&`
+ * because the terminating `;` came from OUTSIDE the secret: neither the raw nor
+ * the normalised form of the secret appears in the result. Tag stripping splits
+ * a secret the same way (`alpha<b>beta` → `alpha beta`), and truncation can cut
+ * a whitespace-containing secret in half, leaving a prefix no complete variant
+ * can match. Redacting first is immune to all three, because the secret is gone
+ * before any of them run.
+ */
+function maskSecrets(body: string, secrets: readonly string[]): string {
+  if (secrets.length === 0) return body;
+
+  // Longest first, de-duplicated, sorted across ALL secrets rather than in the
+  // order the caller supplied them: a shorter secret that is a prefix of a
+  // longer one would otherwise replace its head and carve the longer one into
+  // fragments that no longer match.
+  const ordered = [...new Set(secrets)]
+    .filter(secret => secret.length > 0)
+    .sort((a, b) => b.length - a.length);
+
+  let masked = body;
+  // split/join, not RegExp — secrets are full of regex metacharacters (`?`,
+  // `.`, `+` are ordinary in a URL) and escaping them is a bug waiting to
+  // happen. Same reasoning as `scrubChannelTestError`.
+  for (const secret of ordered) masked = masked.split(secret).join(MASKED_SECRET);
+  return masked;
+}
+
+/**
+ * Reduce an untrusted third-party response body to one short readable line:
+ * markup removed, entities decoded, whitespace collapsed, length capped.
+ *
+ * Returns `''` when nothing readable is left (an empty body, or a page that was
+ * pure markup) so the caller can drop the separator instead of rendering a
+ * dangling `HTTP 405: `.
+ */
+export function summarizeResponseBody(
+  body: string | null | undefined,
+  maxLength: number = MAX_OPERATOR_ERROR_LENGTH,
+  secrets: readonly string[] = []
+): string {
+  if (typeof body !== 'string' || body.length === 0) return '';
+
+  // Mask across a window WIDER than the one we summarise, then narrow. A
+  // secret that begins inside the summary window always ends within
+  // `MAX_SUMMARY_INPUT_LENGTH + longest`, so widening by that much means no
+  // occurrence is ever cut in half by the bound before it can be masked.
+  // Narrowing afterwards is safe because the whole window was masked — every
+  // prefix of it is masked too, including content that masking pulled forward.
+  const longestSecret = secrets.reduce((longest, secret) => Math.max(longest, secret.length), 0);
+  const masked = maskSecrets(body.slice(0, MAX_SUMMARY_INPUT_LENGTH + longestSecret), secrets);
+
+  let text = masked
+    .slice(0, MAX_SUMMARY_INPUT_LENGTH)
+    .replace(SCRIPT_OR_STYLE_BLOCK, ' ')
+    .replace(UNTERMINATED_SCRIPT_OR_STYLE, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<!--[\s\S]*$/, ' ')
+    // Doctype and other `<!…>` declarations.
+    .replace(/<![^>]*>/g, ' ')
+    .replace(HTML_TAG, ' ')
+    // Tags and declarations left dangling by a truncated body. The declaration
+    // rule needs its own pattern: the tag rule requires a letter after the
+    // optional `/`, so it never matches `<!doctype htm` and a body cut mid-
+    // doctype used to publish that fragment into the card.
+    .replace(/<![^<>]*$/, ' ')
+    .replace(/<\/?[a-z][a-z0-9-]*(?:\s[^<>]*)?$/i, ' ');
+
+  text = decodeEntities(text)
+    // Collapse every run of whitespace — a raw body is full of newlines and
+    // indentation that render as a single unreadable smear in a card anyway.
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return truncate(text, maxLength);
+}
+
+/**
+ * Compose the operator-facing message for a non-2xx response.
+ *
+ * `HTTP 405: The method is not allowed for the requested URL.` — or bare
+ * `HTTP 405` when the body carried nothing a human can read.
+ */
+export type HttpFailureOptions = {
+  /**
+   * The CALLER's own credential strings, removed from the raw body before any
+   * transform runs. Every sender that holds a channel config should pass
+   * `collectChannelSecretStrings(type, config)`; omitting it is what let a
+   * configured secret survive into the channel card and the test toast (#3992).
+   */
+  secrets?: readonly string[];
+  maxLength?: number;
+};
+
+export function formatHttpFailure(
+  status: number | undefined,
+  body: string | null | undefined,
+  options: HttpFailureOptions = {}
+): string {
+  const { secrets = [], maxLength = MAX_OPERATOR_ERROR_LENGTH } = options;
+  const prefix = status === undefined ? 'HTTP error' : `HTTP ${status}`;
+  // `: ` is two characters the summary does not get to spend.
+  const summary = summarizeResponseBody(body, maxLength - prefix.length - 2, secrets);
+  return summary ? `${prefix}: ${summary}` : prefix;
+}
+
+/**
+ * The unshortened, un-normalised form for logs and delivery records — bounded
+ * only so a hostile destination cannot flood them.
+ */
+export function formatHttpFailureDetail(
+  status: number | undefined,
+  body: string | null | undefined,
+  secrets: readonly string[] = []
+): string {
+  const prefix = status === undefined ? 'HTTP error' : `HTTP ${status}`;
+  if (typeof body !== 'string' || body.length === 0) return prefix;
+  // Masked too. This form is un-normalised on purpose so debugging loses
+  // nothing, but "un-normalised" was never meant to include the channel's own
+  // credentials — and unlike the operator string, nothing downstream scrubs it.
+  const longestSecret = secrets.reduce((longest, secret) => Math.max(longest, secret.length), 0);
+  const window = body.slice(0, MAX_LOGGED_RESPONSE_BODY_LENGTH + longestSecret);
+  return `${prefix}: ${maskSecrets(window, secrets).slice(0, MAX_LOGGED_RESPONSE_BODY_LENGTH)}`;
+}

--- a/apps/api/src/services/notificationChannelSecrets.ts
+++ b/apps/api/src/services/notificationChannelSecrets.ts
@@ -196,6 +196,21 @@ const MIN_SCRUBBABLE_SECRET_LENGTH = 8;
 // shows a reason, not a payload dump.
 export const MAX_CHANNEL_TEST_ERROR_LENGTH = 500;
 
+/**
+ * The channel's own credential strings, longest first.
+ *
+ * Exported because the senders need it BEFORE they compose an operator-facing
+ * message. `scrubChannelTestError` runs at the route, on text the sender has
+ * already stripped of markup, decoded entities in, and collapsed whitespace in
+ * — and it matches by literal substring, so any of those transforms can rewrite
+ * a configured secret into something that no longer matches itself. Redaction
+ * therefore has to happen on the RAW body, before the first lossy step; the
+ * route scrub stays as the second half of the bracket (#3992).
+ */
+export function collectChannelSecretStrings(type: string, config: unknown): string[] {
+  return collectSecretStrings(type, config);
+}
+
 function collectSecretStrings(type: string, config: unknown): string[] {
   if (!isRecord(config)) return [];
   const found: string[] = [];

--- a/apps/api/src/services/notificationSenders/failureMessage.test.ts
+++ b/apps/api/src/services/notificationSenders/failureMessage.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// #3992: every sender that talks HTTP spliced the destination's raw response
+// body into `HTTP <status>: <500 chars>`. When the destination answers with an
+// HTML error page — the usual answer from a misconfigured URL — the operator
+// got a wall of markup in the channel card and in the test toast, with the one
+// useful token (`HTTP 405`) buried in the first ten characters. These tests are
+// at the COMPOSITION point, which is where the fix lives; they fail against the
+// old splice on both counts (length, and markup surviving).
+
+const { safeFetchMock } = vi.hoisted(() => ({ safeFetchMock: vi.fn() }));
+vi.mock('../urlSafety', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../urlSafety')>();
+  return { ...actual, safeFetch: safeFetchMock };
+});
+
+import { sendWebhookNotification } from './webhookSender';
+import { sendPagerDutyNotification } from './pagerDutySender';
+import { sendPushoverNotification } from './pushoverSender';
+import { MAX_OPERATOR_ERROR_LENGTH } from '../httpFailureMessage';
+import type { AlertSeverity } from '../email';
+
+// The body from the issue report, cut down but the same shape: doctype, head
+// with an inline stylesheet, then the one sentence a human wants.
+const HTML_405 =
+  '<!doctype html><html lang="en"><head><title>Example Domain</title>' +
+  '<style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}</style>' +
+  '</head><body><h1>Example Domain</h1><p>The method is not allowed for the requested URL.</p></body></html>';
+
+function htmlResponse(status: number): Response {
+  return {
+    ok: false,
+    status,
+    text: async () => HTML_405,
+  } as unknown as Response;
+}
+
+const basePayload = {
+  alertId: 'alert-1',
+  alertName: 'Test Alert',
+  severity: 'high' as AlertSeverity,
+  summary: 'summary',
+  orgId: 'org-1',
+  triggeredAt: '2026-08-25T00:00:00.000Z',
+};
+
+/** What a debugger is entitled to: the unshortened body reached a log line. */
+function expectFullBodyLogged(errorSpy: { mock: { calls: unknown[][] } }) {
+  const logged = errorSpy.mock.calls.map((call) => String(call[0] ?? '')).join('\n');
+  expect(logged).toContain('<!doctype html>');
+  expect(logged).toContain('background:#eee');
+}
+
+/** What the operator is entitled to: the status, a readable sentence, no markup. */
+function expectOperatorReadable(message: string | undefined, status: number) {
+  expect(message).toBeDefined();
+  expect(message!).toContain(`HTTP ${status}`);
+  expect(message!).toContain('The method is not allowed');
+  expect(message!.length).toBeLessThanOrEqual(MAX_OPERATOR_ERROR_LENGTH);
+  expect(message!).not.toContain('<');
+  expect(message!).not.toContain('doctype');
+  expect(message!).not.toContain('background:#eee');
+}
+
+describe('sender failure messages are operator-readable (#3992)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    safeFetchMock.mockReset();
+  });
+
+  it('webhookSender: an HTML error page becomes one short line', async () => {
+    safeFetchMock.mockResolvedValue(htmlResponse(405));
+    // console.error is the sender's own log line; silence it but keep the arg.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await sendWebhookNotification(
+      { url: 'https://example.com/hook', method: 'POST', retryCount: 0 },
+      basePayload
+    );
+
+    expect(result.success).toBe(false);
+    expectOperatorReadable(result.error, 405);
+
+    // ...and the full body is still there for whoever has to debug it.
+    expectFullBodyLogged(errorSpy);
+  });
+
+  // PagerDuty and Pushover carry no second copy of the body — their result
+  // objects have no `responseBody` field and neither logged anything before
+  // #3992 — and their `error` string is NOT a toast: the dispatcher persists it
+  // into alert_notifications.error_message on the LIVE alert path. Shortening
+  // it without a log line would have left on-call with 160 characters and
+  // nothing else, so each asserts BOTH halves.
+  it('pagerDutySender: an HTML error page becomes one short line, full body logged', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(htmlResponse(502));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await sendPagerDutyNotification({ routingKey: 'R0UT1NGK3Y0123456789' }, basePayload);
+
+    expect(result.success).toBe(false);
+    expectOperatorReadable(result.error, 502);
+    expectFullBodyLogged(errorSpy);
+  });
+
+  it('pushoverSender: an HTML error page becomes one short line, full body logged', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(htmlResponse(500));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await sendPushoverNotification(
+      { token: 'atokenatokenatoken12', user: 'auseruseruseruser123' },
+      basePayload
+    );
+
+    expect(result.success).toBe(false);
+    expectOperatorReadable(result.error, 500);
+    expectFullBodyLogged(errorSpy);
+  });
+
+  // Pushover reports its own structured errors; those were already readable and
+  // must keep bypassing the body-summarising path entirely.
+  it('pushoverSender still prefers the provider\'s own error list', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({ status: 0, errors: ['application token is invalid'] }),
+    } as unknown as Response);
+
+    const result = await sendPushoverNotification(
+      { token: 'atokenatokenatoken12', user: 'auseruseruseruser123' },
+      basePayload
+    );
+
+    expect(result.error).toBe('application token is invalid');
+  });
+});

--- a/apps/api/src/services/notificationSenders/pagerDutySender.ts
+++ b/apps/api/src/services/notificationSenders/pagerDutySender.ts
@@ -5,6 +5,8 @@
  */
 
 import type { AlertSeverity } from '../email';
+import { formatHttpFailure, formatHttpFailureDetail } from '../httpFailureMessage';
+import { collectChannelSecretStrings } from '../notificationChannelSecrets';
 
 const PAGERDUTY_EVENTS_URL = 'https://events.pagerduty.com/v2/enqueue';
 const DEFAULT_TIMEOUT_MS = 15000;
@@ -175,11 +177,24 @@ export async function sendPagerDutyNotification(
 
     const responseBody = await response.text();
     if (!response.ok) {
+      // Redact the channel's own credentials from the RAW body before it is
+      // transformed. Nothing scrubs this string on the live alert path — it
+      // goes straight into alert_notifications.error_message (#3992).
+      const secrets = collectChannelSecretStrings('pagerduty', config);
+      // The returned `error` is operator-facing: the dispatcher persists it
+      // into alert_notifications.error_message and it is rendered in the UI, so
+      // it is short and markup-free (#3992). This sender keeps no other copy of
+      // the body, so without this line the shortening would be the end of it on
+      // the live alert path. Not a new secrets surface — the dispatcher's own
+      // console.error already carried the unshortened form before #3992.
+      console.error(
+        `[PagerDutySender] Failed to send: ${formatHttpFailureDetail(response.status, responseBody, secrets)}`
+      );
       return {
         success: false,
         statusCode: response.status,
         dedupKey,
-        error: `HTTP ${response.status}: ${responseBody.slice(0, 500)}`
+        error: formatHttpFailure(response.status, responseBody, { secrets })
       };
     }
 

--- a/apps/api/src/services/notificationSenders/pushoverSender.ts
+++ b/apps/api/src/services/notificationSenders/pushoverSender.ts
@@ -6,6 +6,8 @@
  */
 
 import type { AlertSeverity } from '../email';
+import { formatHttpFailure, formatHttpFailureDetail } from '../httpFailureMessage';
+import { collectChannelSecretStrings } from '../notificationChannelSecrets';
 
 const PUSHOVER_MESSAGES_URL = 'https://api.pushover.net/1/messages.json';
 const DEFAULT_TIMEOUT_MS = 15000;
@@ -179,9 +181,22 @@ export async function sendPushoverNotification(
     }
 
     if (!response.ok || parsed.status !== 1) {
+      // Redact the channel's own credentials from the RAW body before it is
+      // transformed. Nothing scrubs this string on the live alert path — it
+      // goes straight into alert_notifications.error_message (#3992).
+      const secrets = collectChannelSecretStrings('pushover', config);
       const errMsg = parsed.errors?.length
         ? parsed.errors.join('; ')
-        : `HTTP ${response.status}: ${responseBody.slice(0, 500)}`;
+        : formatHttpFailure(response.status, responseBody, { secrets });
+      // `errMsg` is operator-facing: the dispatcher persists it into
+      // alert_notifications.error_message and it is rendered in the UI, so it is
+      // short and markup-free (#3992). This sender keeps no other copy of the
+      // body, so without this line the shortening would be the end of it on the
+      // live alert path. Not a new secrets surface — the dispatcher's own
+      // console.error already carried the unshortened form before #3992.
+      console.error(
+        `[PushoverSender] Failed to send: ${formatHttpFailureDetail(response.status, responseBody, secrets)}`
+      );
       return {
         success: false,
         statusCode: response.status,

--- a/apps/api/src/services/notificationSenders/webhookSender.ts
+++ b/apps/api/src/services/notificationSenders/webhookSender.ts
@@ -15,6 +15,8 @@ import {
 } from '../urlSafety';
 import { selfHostAllowsPrivateNetwork } from '../../config/env';
 import { getOutboundHeaderValidationErrors, sanitizeOutboundHeaders, validateOutboundHeader } from '../outboundHeaders';
+import { formatHttpFailure, formatHttpFailureDetail } from '../httpFailureMessage';
+import { collectChannelSecretStrings } from '../notificationChannelSecrets';
 
 export function redactUrlForLogs(rawUrl: string): string {
   try {
@@ -261,6 +263,10 @@ export async function sendWebhookNotification(
 
   // Send request with retries
   let lastError: string | undefined;
+  // The operator-facing `lastError` is deliberately short and markup-free
+  // (#3992); the unshortened form is kept for the log line below so debugging
+  // a strange destination loses nothing.
+  let lastErrorDetail: string | undefined;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       const controller = new AbortController();
@@ -295,7 +301,12 @@ export async function sendWebhookNotification(
       }
 
       // Non-2xx response
-      lastError = `HTTP ${response.status}: ${responseBody.substring(0, 500)}`;
+      // Redact the channel's own credentials from the RAW body first: the
+      // route's scrub runs on the already-transformed string and matches by
+      // literal substring, so it cannot catch what normalisation rewrote (#3992).
+      const secrets = collectChannelSecretStrings('webhook', config);
+      lastError = formatHttpFailure(response.status, responseBody, { secrets });
+      lastErrorDetail = formatHttpFailureDetail(response.status, responseBody, secrets);
 
       // Don't retry on 4xx errors (client errors)
       if (response.status >= 400 && response.status < 500) {
@@ -313,11 +324,14 @@ export async function sendWebhookNotification(
       if (error instanceof Error) {
         if (error.name === 'AbortError') {
           lastError = 'Request timed out';
+          lastErrorDetail = lastError;
         } else {
           lastError = error.message;
+          lastErrorDetail = lastError;
         }
       } else {
         lastError = 'Unknown error';
+        lastErrorDetail = lastError;
       }
     }
 
@@ -327,7 +341,7 @@ export async function sendWebhookNotification(
     }
   }
 
-  console.error(`[WebhookSender] Failed to send to ${redactUrlForLogs(config.url)}: ${lastError}`);
+  console.error(`[WebhookSender] Failed to send to ${redactUrlForLogs(config.url)}: ${lastErrorDetail ?? lastError}`);
 
   return {
     success: false,

--- a/apps/api/src/workers/webhookDelivery.test.ts
+++ b/apps/api/src/workers/webhookDelivery.test.ts
@@ -32,6 +32,7 @@ vi.mock('../db', () => ({
 
 import { SsrfBlockedError } from '../services/urlSafety';
 import { deliverWebhook, type WebhookDeliveryJob } from './webhookDelivery';
+import { MAX_OPERATOR_ERROR_LENGTH } from '../services/httpFailureMessage';
 
 function makeJob(overrides: Partial<WebhookDeliveryJob> = {}): WebhookDeliveryJob {
   return {
@@ -120,6 +121,32 @@ describe('webhook delivery worker', () => {
     expect(result.success).toBe(true);
     expect(validateWebhookUrlSafetyWithDnsMock).not.toHaveBeenCalled();
     expect(safeFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // #3992: the worker composes its own failure string, separately from the
+  // three senders. Before the fix it spliced the destination's raw body into
+  // `HTTP <status>: <500 chars>`, so a delivery to a URL that answers with an
+  // HTML error page filled the delivery record's errorMessage with markup.
+  it('reduces a non-2xx HTML error page to a short readable errorMessage', async () => {
+    const htmlBody =
+      '<!doctype html><html><head><title>Example Domain</title>' +
+      '<style>body{background:#eee;font-family:system-ui}</style></head>' +
+      '<body><h1>Example Domain</h1><p>The method is not allowed for the requested URL.</p></body></html>';
+    safeFetchMock.mockResolvedValueOnce(new Response(htmlBody, { status: 405 }));
+
+    const result = await deliverWebhook(makeJob());
+
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toContain('HTTP 405');
+    expect(result.errorMessage).toContain('The method is not allowed');
+    expect(result.errorMessage!.length).toBeLessThanOrEqual(MAX_OPERATOR_ERROR_LENGTH);
+    expect(result.errorMessage).not.toContain('<');
+    expect(result.errorMessage).not.toContain('background:#eee');
+
+    // The raw body is NOT lost — the delivery record keeps its own copy, which
+    // is what makes shortening the operator-facing string safe here.
+    expect(result.responseBody).toContain('<!doctype html>');
+    expect(result.responseStatus).toBe(405);
   });
 
   it('carries the private-network and cleartext flags into the delivery call', async () => {

--- a/apps/api/src/workers/webhookDelivery.ts
+++ b/apps/api/src/workers/webhookDelivery.ts
@@ -5,6 +5,8 @@ import { getEventBus, type BreezeEvent } from '../services/eventBus';
 import { safeFetch, SsrfBlockedError } from '../services/urlSafety';
 import { selfHostAllowsPrivateNetwork } from '../config/env';
 import { sanitizeOutboundHeaders } from '../services/outboundHeaders';
+import { formatHttpFailure } from '../services/httpFailureMessage';
+import { collectChannelSecretStrings } from '../services/notificationChannelSecrets';
 import * as dbModule from '../db';
 
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -164,7 +166,23 @@ async function deliverWebhook(job: WebhookDeliveryJob): Promise<WebhookDeliveryR
       };
     }
 
-    errorMessage = `HTTP ${responseStatus}: ${responseBody?.slice(0, 500)}`;
+    // Operator-facing and therefore short + markup-free (#3992). The raw
+    // body is not lost: the delivery record below keeps 1000 characters of it
+    // in its own `responseBody` field.
+    //
+    // Redacted against the webhook's own credentials BEFORE the body is
+    // transformed — nothing scrubs this string downstream, unlike the channel
+    // test path. `secret` is routed through the `authToken` key so it picks up
+    // the collector's own trim and minimum-length rules rather than being
+    // pushed in raw; it is the HMAC signing key and is every bit as sensitive
+    // as the URL.
+    errorMessage = formatHttpFailure(responseStatus, responseBody, {
+      secrets: collectChannelSecretStrings('webhook', {
+        url: webhook.url,
+        headers: webhook.headers,
+        authToken: webhook.secret
+      })
+    });
   } catch (err) {
     if (err instanceof SsrfBlockedError) {
       errorMessage = `Unsafe webhook URL: ${err.message}`;

--- a/apps/web/src/components/alerts/NotificationChannelList.testVerdict.test.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelList.testVerdict.test.tsx
@@ -106,10 +106,12 @@ describe('NotificationChannelList — last test verdict', () => {
       expect(screen.queryByTestId('notification-channel-last-test-error')).toBeNull();
     });
 
-    // Webhook/PagerDuty/Pushover errors carry up to 500 characters of the
-    // destination's own response body. The card clamps that to two lines, so
-    // the full string has to remain reachable — otherwise clamping silently
-    // recreates the "operator cannot see what is wrong" defect.
+    // #3992 caps a composed HTTP failure at 160 characters, but the column
+    // still accepts up to MAX_CHANNEL_TEST_ERROR_LENGTH (500) for reasons that
+    // never pass through that helper (a thrown Error.message, a provider SDK
+    // string). The card clamps to two lines either way, so the full string has
+    // to remain reachable — otherwise clamping silently recreates the
+    // "operator cannot see what is wrong" defect.
     it('keeps the full reason reachable when the visible line is clamped', () => {
       const long = `HTTP 500: ${'diagnostic detail '.repeat(30)}`;
 
@@ -129,5 +131,36 @@ describe('NotificationChannelList — last test verdict', () => {
     expect(screen.queryByText('Success')).toBeNull();
     expect(screen.queryByText('Failed')).toBeNull();
     expect(screen.getByText('Never Tested')).toBeTruthy();
+  });
+
+  // The card's own relative-time strings were extracted into title-cased
+  // labels that also dropped the `{{count}}` placeholder the caller passes, so
+  // it read "Last test: Hours Ago" — wrong case, and no number at all. The
+  // component now uses the shared `alerts:relativeTime.*` catalog, which is
+  // correct in all eight locales (#3992).
+  describe('relative timestamp', () => {
+    it('states how long ago, with the count', () => {
+      const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+
+      render(
+        <NotificationChannelList
+          channels={[channel({ lastTestStatus: 'success', lastTestedAt: threeHoursAgo })]}
+        />
+      );
+
+      expect(screen.getByText('Last test: 3h ago')).toBeTruthy();
+      expect(screen.queryByText(/Hours Ago/)).toBeNull();
+    });
+
+    it('is not title-cased for a just-now test', () => {
+      render(
+        <NotificationChannelList
+          channels={[channel({ lastTestStatus: 'success', lastTestedAt: new Date().toISOString() })]}
+        />
+      );
+
+      expect(screen.getByText('Last test: Just now')).toBeTruthy();
+      expect(screen.queryByText(/Just Now/)).toBeNull();
+    });
   });
 });

--- a/apps/web/src/components/alerts/NotificationChannelList.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelList.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { NotificationChannelType } from '@breeze/shared';
+import { formatRelativeTime } from './alertConfig';
 
 export type { NotificationChannelType };
 
@@ -86,23 +87,14 @@ const channelTypeConfig: Record<
   }
 };
 
+// Delegates to the shared `alerts:relativeTime.*` catalog rather than keeping a
+// private copy. The private copy was extracted into title-cased strings that
+// also dropped the `{{count}}` placeholder the caller passes, so the card read
+// "Last test: Hours Ago" — no case agreement and no number (#3992). The shared
+// node is correct in all eight locales and is what the alerts list already uses.
 function formatLastTested(dateString: string | undefined, t: AlertsT): string {
   if (!dateString) return t('notificationChannelList.neverTested');
-
-  const date = new Date(dateString);
-  if (Number.isNaN(date.getTime())) return dateString;
-
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / (1000 * 60));
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-  if (diffMins < 1) return t('notificationChannelList.justNow');
-  if (diffMins < 60) return t('notificationChannelList.minutesAgo', { count: diffMins });
-  if (diffHours < 24) return t('notificationChannelList.hoursAgo', { count: diffHours });
-  if (diffDays < 7) return t('notificationChannelList.daysAgo', { count: diffDays });
-  return date.toLocaleDateString();
+  return formatRelativeTime(dateString);
 }
 
 /**


### PR DESCRIPTION
Part 2 of #3992. **Part 1 shipped in #4032** (@bdunncompany) — this branch was rebuilt as a single commit on top of it and no longer touches the empty states, `ConfigPolicyList`, or `policies.json`.

Closes #3992

## The reported bug

A webhook channel test that failed showed the operator 500 characters of the destination's HTML error page, burying the only useful token. `formatHttpFailure` now reduces the body to one readable sentence — markup stripped, entities decoded, whitespace collapsed, capped at 160 characters — and the unshortened form is still kept in a log line or the delivery record on every path.

## The security-relevant part: ordering

`scrubChannelTestError` runs at the route (`apps/api/src/routes/alerts/channels.ts:689`) and removes the channel's own credentials by **literal substring**. Composing first and scrubbing afterwards therefore publishes any secret the transform rewrote. Two reachable shapes, both found by @bdunncompany on #3992:

- a configured value containing a repeated space is collapsed before the scrub looks for it;
- one containing `&amp;` is decoded before the scrub looks for it.

Both reach the channel card **and** the test toast in the clear. These are admin-typed values validated as `z.record(z.string(), z.unknown())` with no charset restriction, so neither shape is theoretical.

## Why not "also match the normalised secret"

That was my first design and it is **unsound** — normalisation is not substring-preserving. A configured `abcd&amp` echoed inside `rejected abcd&amp;` decodes to `rejected abcd&`, because the terminating `;` came from *outside* the secret. The transformed text contains neither the raw secret nor any normalisation of it, so no variant-matching scheme can find it. Tag stripping splits a secret the same way (`alpha<b>beta` → `alpha beta`), and truncation can cut a whitespace-containing secret in half — the residual the module's own `truncate` header already documents.

Redacting first is immune to all three, because the secret is gone before any of them run.

## What changed

- Senders pass their own secrets into the composer (`collectChannelSecretStrings(type, config)`), which masks them **before the first lossy step**. The route scrub stays as the second half of the bracket, for messages that never pass through the composer — a thrown `Error.message`, a provider SDK string.
- Masking runs on a window widened by the longest secret, so the 8 KB scan bound cannot bisect an occurrence; and sorts longest-first across *all* secrets, so a shorter secret that is a prefix of a longer one cannot carve it into a fragment that no longer matches.
- `formatHttpFailureDetail` masks too. It is deliberately un-normalised so debugging loses nothing, but nothing downstream scrubs it — and the webhook worker's HMAC signing secret rides that path.
- Also fixes the relative timestamp on the same card, which read "Last test: **Hours Ago**": the private formatter had been extracted into title-cased strings that dropped the `{{count}}` placeholder. It now delegates to the shared `alerts:relativeTime.*` catalog the alerts list already uses. This half was orphaned by the split — #4032 did not carry it.

## Tests

Seven leak cases, each with a **control asserting the leak is reachable without the fix**. All seven fail against a neutered mask (verified, not assumed). Locally: 347 API tests and 131 web tests green, including #4032's empty-state suites.

## Not in scope

The two pre-existing scrub bypasses @bdunncompany found — the case-sensitive host match and the numeric character reference — reproduce on `main` unchanged and are getting their own issue rather than being folded in here.
