### PR TITLE
fix(web): update #4009's confirm-dialog assertions to #3994's renamed copy (main is red)

### DIFF
--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -1505,12 +1505,15 @@ describe('DevicesPage — decommission from the row/grid kebab is confirm-gated 
     expect(await toastTypes()).not.toContain('undo');
 
     // The SAME keys DeviceActions.tsx renders — proving no new copy was needed
-    // and that the two screens still read identically.
-    expect(await screen.findByText('Decommission Device')).toBeTruthy();
-    expect(screen.getByText(/decommission host-alpha\?/i)).toBeTruthy();
+    // and that the two screens still read identically. The VALUES moved to
+    // "Remove" in #3987/#3994 (the action id stayed `decommission`); asserting
+    // the rendered text is what makes a future divergence between the two
+    // screens visible here, so these track the copy deliberately.
+    expect(await screen.findByText('Remove Device')).toBeTruthy();
+    expect(screen.getByText(/remove host-alpha\?/i)).toBeTruthy();
 
     const confirmBtn = await screen.findByTestId('confirm-device-action');
-    expect(confirmBtn.textContent).toBe('Decommission');
+    expect(confirmBtn.textContent).toBe('Remove');
     // DeviceActions.tsx grades decommission `destructive`. ConfirmDialog encodes
     // that as a stop-octagon, not just a colour, so a drift to `warning` here
     // would visibly downgrade the severity on the denser of the two surfaces.
@@ -1578,7 +1581,7 @@ describe('DevicesPage — decommission from the row/grid kebab is confirm-gated 
     fireEvent.click(await screen.findByTestId(`card-decommission-${DEV_1}`));
 
     expect(decommissionDevice).not.toHaveBeenCalled();
-    expect(await screen.findByText('Decommission Device')).toBeTruthy();
+    expect(await screen.findByText('Remove Device')).toBeTruthy();
   });
 
   // Deliberate scope boundary (#4009): `restore` is the UNDO of a decommission.


### PR DESCRIPTION
**Main is red on Test Web. This is the fix-forward.**

`DevicesPage.test.tsx > DevicesPage — decommission from the row/grid kebab is confirm-gated (#4009)` fails two tests on `main` @ `9ff8b0f1a`.

**Neither PR was wrong, and git had nothing to flag.** #4011 (confirm-gate the kebab, #4009) and #3994 (rename Decommission → Remove, #3987) were both fully green, both based on `c2f9db1ce`, and their `DevicesPage.tsx` hunks do not overlap — #4011 touches the `CONFIRM_REQUIRED_ACTIONS` set near the top and the `variant=` line near the bottom, #3994 touches the middle. So they auto-merged with no conflict. The collision is purely semantic: #4011's tests assert the dialog renders *the detail page's own words*, and #3994 changed what those words are.

**What moved.** The action id is still `decommission`; only the rendered copy changed:

- `deviceActions.confirm.decommission.title` — "Decommission Device" → "Remove Device"
- `deviceActions.confirm.decommission.confirm` — "Decommission" → "Remove"
- `.message` — now "Remove {{hostname}}? It will be taken out of your active fleet…"

**Four assertions updated**, all in `apps/web/src/components/devices/DevicesPage.test.tsx`. I checked the rest of `components/devices/**` for the same stale copy and this is the only file carrying it.

I also updated the comment above them. These assertions deliberately track the rendered strings rather than the keys — that is what makes a future divergence between `DevicesPage` and `DeviceActions` visible, which was #4009's whole point — so the right fix is to move them with the copy, not to loosen them into key-based matching.

**On the process failure, since it is the more useful part:** I merged #4011 and #3994 back to back without re-running CI on the second against the first. I had spotted the same hazard between #4016 and #4015 over their shared locale files and refreshed #4015's branch for exactly this reason — then didn't apply it to the device pair, because I checked their `DevicesPage.tsx` hunks for *textual* overlap, saw none, and stopped there. Non-overlapping hunks are not evidence of semantic independence, and a shared test file asserting on copy one of them renames is a standing example.

Test-only change; no production code touched.
