### PR TITLE
test(web): update DevicesPage assertions to the Remove copy that #3994 shipped

### DIFF
--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -1506,11 +1506,11 @@ describe('DevicesPage — decommission from the row/grid kebab is confirm-gated 
 
     // The SAME keys DeviceActions.tsx renders — proving no new copy was needed
     // and that the two screens still read identically.
-    expect(await screen.findByText('Decommission Device')).toBeTruthy();
-    expect(screen.getByText(/decommission host-alpha\?/i)).toBeTruthy();
+    expect(await screen.findByText('Remove Device')).toBeTruthy();
+    expect(screen.getByText(/remove host-alpha\?/i)).toBeTruthy();
 
     const confirmBtn = await screen.findByTestId('confirm-device-action');
-    expect(confirmBtn.textContent).toBe('Decommission');
+    expect(confirmBtn.textContent).toBe('Remove');
     // DeviceActions.tsx grades decommission `destructive`. ConfirmDialog encodes
     // that as a stop-octagon, not just a colour, so a drift to `warning` here
     // would visibly downgrade the severity on the denser of the two surfaces.
@@ -1578,7 +1578,7 @@ describe('DevicesPage — decommission from the row/grid kebab is confirm-gated 
     fireEvent.click(await screen.findByTestId(`card-decommission-${DEV_1}`));
 
     expect(decommissionDevice).not.toHaveBeenCalled();
-    expect(await screen.findByText('Decommission Device')).toBeTruthy();
+    expect(await screen.findByText('Remove Device')).toBeTruthy();
   });
 
   // Deliberate scope boundary (#4009): `restore` is the UNDO of a decommission.


### PR DESCRIPTION
## Why

`main` is currently red on **Test Web**.

#3994 renamed the device *Decommission* action to *Remove*, including `deviceActions.confirm.decommission.{title,message,confirm}` in `en/devices.json`. Three assertions in `DevicesPage.test.tsx` still expect the pre-rename strings, so #4009's confirm-gate tests fail:

```
TestingLibraryElementError: Unable to find an element with the text: /decommission host-alpha\?/i
Unable to find an element with the text: Decommission Device
```

## What

Copy-only. The behaviour under test — #4009's confirm gate on the row/grid kebab — is unchanged and still asserted.

| assertion | was | now |
|---|---|---|
| dialog title (×2) | `Decommission Device` | `Remove Device` |
| dialog message | `/decommission host-alpha\?/i` | `/remove host-alpha\?/i` |
| confirm button | `Decommission` | `Remove` |

## Verification

`pnpm vitest run src/components/devices/DevicesPage.test.tsx` → **63 passed** (was 2 failed | 61 passed).

Found while investigating an unrelated File Browser bug (#4024) — the full web suite on a fresh branch off `main` surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)