### PR TITLE
fix(api,web): stop losing agent error messages behind Cloudflare's 502/504 page

### DIFF
--- a/agent/internal/remote/tools/limits_test.go
+++ b/agent/internal/remote/tools/limits_test.go
@@ -1,0 +1,98 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// sharedReadCapPath is the TypeScript file that mirrors maxFileReadSize for the
+// web layer. Relative to this package's directory.
+const sharedReadCapPath = "../../../../packages/shared/src/constants/agentFileTransfer.ts"
+
+// TestMaxFileReadSizeMatchesSharedConstant pins maxFileReadSize to the literal
+// AND to the mirror the browser reads.
+//
+// The mirror exists so the File Browser can refuse an over-cap download before
+// making a request (the directory listing already knows each entry's size).
+// That pre-flight is only honest while the two numbers agree: if the agent cap
+// moved and this mirror did not, the UI would either wave through a download
+// the device then refuses, or block one the device would happily serve. Both
+// read to a technician as "the file browser is broken", which is exactly the
+// confusion this pin exists to prevent.
+//
+// Parsing the TypeScript catches the dangerous direction — raising the Go cap
+// and never touching the web constant.
+func TestMaxFileReadSizeMatchesSharedConstant(t *testing.T) {
+	// The literal, spelled out, so a local edit fails here first.
+	if maxFileReadSize != 1024*1024 {
+		t.Fatalf("maxFileReadSize = %d, want %d; it is mirrored by AGENT_MAX_FILE_READ_BYTES in "+
+			"packages/shared/src/constants/agentFileTransfer.ts — change both sides in the SAME commit",
+			maxFileReadSize, 1024*1024)
+	}
+
+	path := filepath.Clean(sharedReadCapPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// A missing file is a failure, not a skip: this assertion is the only
+		// thing tying the two sides together, and a silently skipped
+		// cross-language pin is the same as no pin at all.
+		t.Fatalf("cannot read the shared constant at %s to verify the mirrored cap: %v", path, err)
+	}
+
+	// Anchored on the declaration keyword so the doc comment above it — which
+	// legitimately discusses other byte caps — cannot retarget the pin onto prose.
+	re := regexp.MustCompile(`export\s+const\s+AGENT_MAX_FILE_READ_BYTES\s*=\s*([0-9_*\s]+?);`)
+	m := re.FindSubmatch(data)
+	if m == nil {
+		t.Fatalf("no `export const AGENT_MAX_FILE_READ_BYTES = <expr>;` declaration found in %s — if it "+
+			"was renamed or moved, update sharedReadCapPath and this pattern", path)
+	}
+
+	sharedValue, err := evalByteProduct(string(m[1]))
+	if err != nil {
+		t.Fatalf("could not parse AGENT_MAX_FILE_READ_BYTES value %q: %v", m[1], err)
+	}
+	if sharedValue != maxFileReadSize {
+		t.Fatalf("shared AGENT_MAX_FILE_READ_BYTES = %d but Go maxFileReadSize = %d; the web layer "+
+			"pre-flights downloads against the shared value, so a mismatch means the UI is enforcing "+
+			"a limit the agent does not",
+			sharedValue, maxFileReadSize)
+	}
+}
+
+// TestMaxFileReadSizeFitsCommandResultBudget guards the reason the read cap is
+// far below the write cap: a file_read result is base64-encoded inline into the
+// command result's `stdout`, which the server bounds at MAX_COMMAND_RESULT_BYTES
+// (5,000,000). base64 inflates by 4/3, so the cap must leave room for the
+// encoded form plus the surrounding JSON envelope. Raising maxFileReadSize past
+// that ceiling would not produce a clean "file too large" error — it would
+// produce a rejected frame and a 30-second command timeout instead.
+func TestMaxFileReadSizeFitsCommandResultBudget(t *testing.T) {
+	const serverResultCap = 5000000
+	encoded := (maxFileReadSize + 2) / 3 * 4
+	if encoded >= serverResultCap {
+		t.Fatalf("maxFileReadSize = %d encodes to %d base64 bytes, which does not fit the server's "+
+			"%d-byte command-result cap; a file_read at this size would be rejected as an oversized "+
+			"frame rather than failing cleanly. Add a chunked transfer path before raising the cap.",
+			maxFileReadSize, encoded, serverResultCap)
+	}
+}
+
+// evalByteProduct evaluates the small `A * B` integer products these mirrored
+// byte constants are written as (e.g. `1024 * 1024`), so the pin reads the
+// declaration as authored instead of forcing it to be a bare literal.
+func evalByteProduct(expr string) (int, error) {
+	product := 1
+	for _, part := range strings.Split(expr, "*") {
+		n, err := strconv.Atoi(strings.ReplaceAll(strings.TrimSpace(part), "_", ""))
+		if err != nil {
+			return 0, err
+		}
+		product *= n
+	}
+	return product, nil
+}

--- a/apps/api/src/routes/devices/diagnose.ts
+++ b/apps/api/src/routes/devices/diagnose.ts
@@ -39,7 +39,9 @@ diagnoseRoutes.post(
       }, { userId: auth.user.id, timeoutMs: 30000 });
 
       if (screenshotResult.status !== 'completed') {
-        return c.json({ error: screenshotResult.error || 'Screenshot capture failed' }, 502);
+        // 500, not 502: Cloudflare replaces an origin 502 body with its own
+        // branded page, which would blank the agent's reason on hosted deployments.
+        return c.json({ error: screenshotResult.error || 'Screenshot capture failed', code: 'agent_execution_failed' }, 500);
       }
 
       let screenshotData: { imageBase64?: string; width?: number; height?: number; capturedAt?: string };

--- a/apps/api/src/routes/devices/filesystem.ts
+++ b/apps/api/src/routes/devices/filesystem.ts
@@ -229,7 +229,9 @@ filesystemRoutes.post(
     );
 
     if (!queued.command) {
-      return c.json({ error: queued.error || 'Failed to queue filesystem analysis' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own branded
+      // page, which would blank the queue's reason on hosted deployments.
+      return c.json({ error: queued.error || 'Failed to queue filesystem analysis', code: 'agent_execution_failed' }, 500);
     }
 
     writeRouteAudit(c, {

--- a/apps/api/src/routes/remote/sessions.ts
+++ b/apps/api/src/routes/remote/sessions.ts
@@ -886,7 +886,9 @@ sessionRoutes.post(
     // The agent will create a pion PeerConnection and return the answer
     if (!device.agentId) {
       console.error(`[Remote] Device ${device.id} has no agentId, cannot send start_desktop for session ${sessionId}`);
-      return c.json({ error: 'Device has no agent connection identifier' }, 502);
+      // 500, not 502: this is our own state defect (a device row with no
+      // agentId), and a 502 body is replaced by Cloudflare's branded page.
+      return c.json({ error: 'Device has no agent connection identifier', code: 'agent_execution_failed' }, 500);
     }
 
     // Look up GPU vendor from device hardware inventory
@@ -941,7 +943,9 @@ sessionRoutes.post(
 
     if (!agentReachable) {
       console.warn(`[Remote] Agent ${device.agentId} not connected, cannot send start_desktop for session ${sessionId}`);
-      return c.json({ error: 'Agent is not currently connected. Please verify the device is online and try again.' }, 502);
+      // 503, not 502: the device is temporarily unreachable, which is exactly
+      // what 503 means — and unlike 502 the body survives Cloudflare.
+      return c.json({ error: 'Agent is not currently connected. Please verify the device is online and try again.', code: 'device_unreachable' }, 503);
     }
 
     return c.json({

--- a/apps/api/src/routes/systemTools.test.ts
+++ b/apps/api/src/routes/systemTools.test.ts
@@ -227,7 +227,7 @@ describe('system tools routes', () => {
     expect(mockExecuteCommand).not.toHaveBeenCalled();
   });
 
-  it('returns 502 on invalid process payload from agent', async () => {
+  it('returns 500 on invalid process payload from agent', async () => {
     mockDeviceSelect();
     mockExecuteCommand.mockResolvedValue({
       status: 'completed',
@@ -236,9 +236,12 @@ describe('system tools routes', () => {
 
     const res = await app.request(`/system-tools/devices/${deviceId}/processes`);
 
-    expect(res.status).toBe(502);
+    // 500, not 502: an origin 502 body is replaced by Cloudflare's branded
+    // error page on hosted deployments, so the client can never read this.
+    expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toContain('Failed to parse agent response');
+    expect(body.code).toBe('invalid_agent_response');
   });
 
   it('gets process details via agent command', async () => {
@@ -754,7 +757,7 @@ describe('system tools routes', () => {
     expect(body.meta.total).toBe(1);
   });
 
-  it('returns 502 on invalid scheduled task payload from agent', async () => {
+  it('returns 500 on invalid scheduled task payload from agent', async () => {
     mockDeviceSelect();
     mockExecuteCommand.mockResolvedValue({
       status: 'completed',
@@ -763,9 +766,12 @@ describe('system tools routes', () => {
 
     const res = await app.request(`/system-tools/devices/${deviceId}/tasks?limit=2&page=1`);
 
-    expect(res.status).toBe(502);
+    // 500, not 502: an origin 502 body is replaced by Cloudflare's branded
+    // error page on hosted deployments, so the client can never read this.
+    expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toContain('Failed to parse agent response');
+    expect(body.code).toBe('invalid_agent_response');
   });
 
   it('gets task details via agent command', async () => {
@@ -945,12 +951,16 @@ describe('system tools routes', () => {
         })
       });
 
-      // All items failed, so the route returns 502
-      expect(res.status).toBe(502);
+      // 200 even when every item failed: the batch WAS processed, and the
+      // per-item detail below is the payload that matters. Answering 502 got
+      // this body replaced by Cloudflare's branded page, so the UI could only
+      // say "Copy failed" with no per-item reason at all.
+      expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.results).toHaveLength(1);
       expect(body.results[0].status).toBe('failure');
       expect(body.results[0].error).toBe('Permission denied');
+      expect(body.results[0].code).toBe('agent_execution_failed');
     });
   });
 

--- a/apps/api/src/routes/systemTools/eventLogs.ts
+++ b/apps/api/src/routes/systemTools/eventLogs.ts
@@ -105,7 +105,9 @@ eventLogsRoutes.get(
       return c.json({ data: logs });
     } catch (error) {
       console.error('Failed to parse agent response for event logs:', error);
-      return c.json({ error: 'Failed to parse agent response for event logs' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for event logs', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -151,7 +153,9 @@ eventLogsRoutes.get(
       return c.json({ data: log });
     } catch (error) {
       console.error('Failed to parse agent response for event log info:', error);
-      return c.json({ error: 'Failed to parse agent response for event log info' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for event log info', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -208,7 +212,9 @@ eventLogsRoutes.get(
       });
     } catch (error) {
       console.error('Failed to parse agent response for event query:', error);
-      return c.json({ error: 'Failed to parse agent response for event query' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for event query', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -245,12 +251,16 @@ eventLogsRoutes.get(
       const payload = JSON.parse(result.stdout || '{}');
       const event = mapEventEntryFromAgent(payload);
       if (!event) {
-        return c.json({ error: 'Invalid event payload from agent' }, 502);
+        // 500, not 502: Cloudflare replaces an origin 502 body with its own
+        // branded page, blanking this message on hosted deployments.
+        return c.json({ error: 'Invalid event payload from agent', code: 'invalid_agent_response' }, 500);
       }
       return c.json({ data: event });
     } catch (error) {
       console.error('Failed to parse agent response for event detail:', error);
-      return c.json({ error: 'Failed to parse agent response for event detail' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for event detail', code: 'invalid_agent_response' }, 500);
     }
   }
 );

--- a/apps/api/src/routes/systemTools/fileBrowser.audit.test.ts
+++ b/apps/api/src/routes/systemTools/fileBrowser.audit.test.ts
@@ -155,7 +155,8 @@ describe('file browser sensitive-read audit', () => {
       `/devices/${DEVICE_ID}/files/download?path=${encodeURIComponent('/private/file.txt')}`,
     );
 
-    expect(res.status).toBe(502);
+    // 500, not 502 — Cloudflare swallows an origin 502 body.
+    expect(res.status).toBe(500);
     expect(auditSensitiveReadMock).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/routes/systemTools/fileBrowser.ts
+++ b/apps/api/src/routes/systemTools/fileBrowser.ts
@@ -43,8 +43,8 @@ fileBrowserRoutes.get(
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
     if (isCommandFailure(result)) {
-      const { message, status } = mapCommandFailure(result, 'Failed to list files.');
-      return c.json({ error: message }, status);
+      const { message, status, code } = mapCommandFailure(result, 'Failed to list files.');
+      return c.json({ error: message, code }, status);
     }
 
     try {
@@ -57,7 +57,9 @@ fileBrowserRoutes.get(
       const listedPath = typeof data.path === 'string' && data.path ? data.path : path;
       return c.json({ data: data.entries || [], path: listedPath });
     } catch {
-      return c.json({ error: 'Failed to parse agent response for file listing' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, which would blank this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for file listing', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -86,15 +88,17 @@ fileBrowserRoutes.get(
     });
 
     if (isCommandFailure(result)) {
-      const { message, status } = mapCommandFailure(result, 'Failed to list drives.');
-      return c.json({ error: message }, status);
+      const { message, status, code } = mapCommandFailure(result, 'Failed to list drives.');
+      return c.json({ error: message, code }, status);
     }
 
     try {
       const data = JSON.parse(result.stdout || '{}');
       return c.json({ data: data.drives || [] });
     } catch {
-      return c.json({ error: 'Failed to parse agent response for drive listing' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, which would blank this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for drive listing', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -125,24 +129,25 @@ fileBrowserRoutes.get(
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
     if (isCommandFailure(result)) {
-      const raw = result.error || '';
-      if (raw.toLowerCase().includes('not found')) {
-        return c.json({ error: raw }, 404);
-      }
-      const { message, status } = mapCommandFailure(result, 'Failed to read file.');
-      return c.json({ error: message }, status);
+      // The local `not found` test that used to live here is now part of
+      // classifyCommandFailure, which also recognises the agent's other two
+      // spellings (`path does not exist:`, `source path does not exist:`) —
+      // neither contains the words "not found", so a plain mistyped path used
+      // to fall through to the catch-all instead of answering 404.
+      const { message, status, code } = mapCommandFailure(result, 'Failed to read file.');
+      return c.json({ error: message, code }, status);
     }
 
     try {
       const payload = JSON.parse(result.stdout || '{}');
       const encodedContent = typeof payload.content === 'string' ? payload.content : '';
       if (!encodedContent) {
-        return c.json({ error: 'Invalid file payload from agent' }, 502);
+        return c.json({ error: 'Invalid file payload from agent', code: 'invalid_agent_response' }, 500);
       }
       if (
         !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(encodedContent)
       ) {
-        return c.json({ error: 'Invalid file payload from agent' }, 502);
+        return c.json({ error: 'Invalid file payload from agent', code: 'invalid_agent_response' }, 500);
       }
 
       const fileData = Buffer.from(encodedContent, 'base64');
@@ -170,7 +175,9 @@ fileBrowserRoutes.get(
       return c.body(fileData);
     } catch (error) {
       console.error('Failed to parse agent response for file download:', error);
-      return c.json({ error: 'Failed to parse agent response for file download' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, which would blank this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for file download', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -284,6 +291,9 @@ fileBrowserRoutes.post(
           destPath: item.destPath,
           status: success ? 'success' : 'failure',
           error: failure?.message,
+          // Stable discriminant so a caller can tell an agent refusal from a
+          // device fault without matching on English prose.
+          code: failure?.code,
           unverified: failure?.unverified || undefined,
         });
 
@@ -306,12 +316,16 @@ fileBrowserRoutes.post(
           destPath: item.destPath,
           status: 'failure',
           error: err instanceof Error ? err.message : 'Unexpected error',
+          code: 'agent_execution_failed',
         });
       }
     }
 
-    const allFailed = results.length > 0 && results.every(r => r.status === 'failure');
-    return c.json({ results }, allFailed ? 502 : 200);
+    // Always 200: the batch itself was processed, and `results` carries each
+    // item's status/code/error. Answering 502 when every item failed made
+    // Cloudflare replace this body with its branded error page, so the caller
+    // lost the per-item reasons entirely and could only say "Copy failed".
+    return c.json({ results }, 200);
   }
 );
 
@@ -350,6 +364,9 @@ fileBrowserRoutes.post(
           destPath: item.destPath,
           status: success ? 'success' : 'failure',
           error: failure?.message,
+          // Stable discriminant so a caller can tell an agent refusal from a
+          // device fault without matching on English prose.
+          code: failure?.code,
           unverified: failure?.unverified || undefined,
         });
 
@@ -372,12 +389,16 @@ fileBrowserRoutes.post(
           destPath: item.destPath,
           status: 'failure',
           error: err instanceof Error ? err.message : 'Unexpected error',
+          code: 'agent_execution_failed',
         });
       }
     }
 
-    const allFailed = results.length > 0 && results.every(r => r.status === 'failure');
-    return c.json({ results }, allFailed ? 502 : 200);
+    // Always 200: the batch itself was processed, and `results` carries each
+    // item's status/code/error. Answering 502 when every item failed made
+    // Cloudflare replace this body with its branded error page, so the caller
+    // lost the per-item reasons entirely and could only say "Copy failed".
+    return c.json({ results }, 200);
   }
 );
 
@@ -417,6 +438,9 @@ fileBrowserRoutes.post(
           path,
           status: success ? 'success' : 'failure',
           error: failure?.message,
+          // Stable discriminant so a caller can tell an agent refusal from a
+          // device fault without matching on English prose.
+          code: failure?.code,
           unverified: failure?.unverified || undefined,
         });
 
@@ -438,12 +462,16 @@ fileBrowserRoutes.post(
           path,
           status: 'failure',
           error: err instanceof Error ? err.message : 'Unexpected error',
+          code: 'agent_execution_failed',
         });
       }
     }
 
-    const allFailed = results.length > 0 && results.every(r => r.status === 'failure');
-    return c.json({ results }, allFailed ? 502 : 200);
+    // Always 200: the batch itself was processed, and `results` carries each
+    // item's status/code/error. Answering 502 when every item failed made
+    // Cloudflare replace this body with its branded error page, so the caller
+    // lost the per-item reasons entirely and could only say "Copy failed".
+    return c.json({ results }, 200);
   }
 );
 
@@ -468,15 +496,17 @@ fileBrowserRoutes.get(
     const result = await executeCommand(deviceId, CommandTypes.FILE_TRASH_LIST, {}, { userId: auth.user?.id, timeoutMs: 30000 });
 
     if (isCommandFailure(result)) {
-      const { message, status } = mapCommandFailure(result, 'Failed to list trash.');
-      return c.json({ error: message }, status);
+      const { message, status, code } = mapCommandFailure(result, 'Failed to list trash.');
+      return c.json({ error: message, code }, status);
     }
 
     try {
       const data = JSON.parse(result.stdout || '{}');
       return c.json({ data: data.items || [] });
     } catch {
-      return c.json({ error: 'Failed to parse trash list response' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, which would blank this message on hosted deployments.
+      return c.json({ error: 'Failed to parse trash list response', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -525,6 +555,9 @@ fileBrowserRoutes.post(
           status: success ? 'success' : 'failure',
           restoredPath,
           error: failure?.message,
+          // Stable discriminant so a caller can tell an agent refusal from a
+          // device fault without matching on English prose.
+          code: failure?.code,
           unverified: failure?.unverified || undefined,
         });
 
@@ -546,6 +579,7 @@ fileBrowserRoutes.post(
           trashId,
           status: 'failure',
           error: err instanceof Error ? err.message : 'Unexpected error',
+          code: 'agent_execution_failed',
         });
       }
     }
@@ -599,8 +633,8 @@ fileBrowserRoutes.post(
     }).catch(auditErr => console.error(`[fileBrowser] audit log failed for device ${deviceId}:`, auditErr instanceof Error ? auditErr.message : auditErr));
 
     if (isCommandFailure(result)) {
-      const { message, status } = mapCommandFailure(result, 'Failed to purge trash.', { mutating: true });
-      return c.json({ error: message }, status);
+      const { message, status, code } = mapCommandFailure(result, 'Failed to purge trash.', { mutating: true });
+      return c.json({ error: message, code }, status);
     }
 
     try {

--- a/apps/api/src/routes/systemTools/fileBrowserHelpers.test.ts
+++ b/apps/api/src/routes/systemTools/fileBrowserHelpers.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
   isCommandFailure,
+  classifyCommandFailure,
   mapCommandFailure,
   buildBulkItemFailure,
   auditErrorMessage,
   buildSingleItemUploadBody,
+  CLOUDFLARE_SWALLOWED_STATUSES,
 } from './fileBrowserHelpers';
 import { DEVICE_UNREACHABLE_ERROR, type CommandResult } from '../../services/commandQueue';
 
@@ -24,41 +26,170 @@ describe('isCommandFailure', () => {
   });
 });
 
+// Every distinct agent failure string this API can surface, taken verbatim
+// from agent/internal/remote/tools/fileops.go. Used by the Cloudflare guard
+// below so the invariant is asserted against real inputs rather than a
+// hand-picked few.
+const REAL_AGENT_ERRORS: readonly string[] = [
+  'file too large: 8981850 bytes (max 1048576 bytes)',
+  'file write payload too large: 9000000 bytes (max 4194304 bytes)',
+  'path is a directory, not a file',
+  'read denied on sensitive path: /Users/x/Library/Keychains',
+  'operation denied on system path: C:\\Windows\\System32',
+  'recursive delete denied on top-level path: C:\\ProgramData\\Foo\\bar.txt',
+  'delete denied: cannot verify directory contents: permission denied',
+  'cannot copy directory into itself: /a -> /a/b',
+  'cannot restore: path already exists: /home/user/report.pdf',
+  'directory too large to clear for /tmp (over 5000 entries)',
+  'trash metadata exceeds maximum size of 65536 bytes',
+  'unsupported encoding: rot13',
+  'path is required',
+  'trashId is required',
+  'path does not exist: C:\\nope.txt',
+  'source path does not exist: /missing',
+  'trash item not found: abc123',
+  'failed to read file: input/output error',
+  'failed to stat file: permission denied',
+  'failed to rename file: device or resource busy',
+  'Permission denied',
+  DEVICE_UNREACHABLE_ERROR,
+  'Device is offline, cannot execute command',
+  'Command timed out after 30000ms',
+  '',
+];
+
+describe('Cloudflare 502/504 invariant', () => {
+  // The bug this whole classifier exists to prevent: Cloudflare replaces an
+  // origin 502 or 504 body with its own branded HTML page, so the client's
+  // response.json() throws and every message collapses to a generic
+  // "Failed to ...". A user was told "Failed to download" when the agent had
+  // said "file too large: 8981850 bytes (max 1048576 bytes)".
+  //
+  // This is a property test, not an example test: it must hold for inputs
+  // nobody thought to enumerate, including ones a future agent version adds.
+  it('never classifies any real agent error as a Cloudflare-swallowed status', () => {
+    for (const error of REAL_AGENT_ERRORS) {
+      for (const mutating of [false, true]) {
+        for (const status of ['failed', 'timeout'] as const) {
+          const failure = classifyCommandFailure({ status, error }, { mutating });
+          expect(
+            CLOUDFLARE_SWALLOWED_STATUSES,
+            `${status}/${error || '<empty>'} (mutating=${mutating}) classified as ${failure.status}`,
+          ).not.toContain(failure.status);
+        }
+      }
+    }
+  });
+
+  it('pins the swallowed set to 502 and 504', () => {
+    expect([...CLOUDFLARE_SWALLOWED_STATUSES].sort()).toEqual([502, 504]);
+  });
+});
+
+describe('classifyCommandFailure', () => {
+  it('maps a size-cap refusal to 422 and keeps the agent numbers verbatim', () => {
+    // The exact production failure. The technician needs the bytes, not a
+    // generic "Failed to download".
+    const failure = classifyCommandFailure({
+      status: 'failed',
+      error: 'file too large: 8981850 bytes (max 1048576 bytes)',
+    });
+    expect(failure).toEqual({
+      kind: 'agent_command_rejected',
+      code: 'agent_command_rejected',
+      message: 'file too large: 8981850 bytes (max 1048576 bytes)',
+      status: 422,
+    });
+  });
+
+  it.each([
+    'path is a directory, not a file',
+    'read denied on sensitive path: /Users/x/Library/Keychains',
+    'operation denied on system path: C:\\Windows\\System32',
+    'recursive delete denied on top-level path: C:\\ProgramData\\Foo\\bar.txt',
+    'cannot copy directory into itself: /a -> /a/b',
+    'unsupported encoding: rot13',
+    'destPath is required',
+  ])('classifies the deterministic refusal %j as 422', (error) => {
+    const failure = classifyCommandFailure({ status: 'failed', error });
+    expect(failure.kind).toBe('agent_command_rejected');
+    expect(failure.status).toBe(422);
+  });
+
+  it.each([
+    'path does not exist: C:\\nope.txt',
+    'source path does not exist: /missing',
+    'trash item not found: abc123',
+  ])('classifies the absent path %j as 404', (error) => {
+    // Two of these three do not contain the words "not found", which is why
+    // the download route's old local `includes('not found')` test missed them
+    // and answered 502 for a plain mistyped path.
+    const failure = classifyCommandFailure({ status: 'failed', error });
+    expect(failure.kind).toBe('path_not_found');
+    expect(failure.status).toBe(404);
+  });
+
+  it('classifies an already-exists restore as a 409 conflict, not a generic refusal', () => {
+    const failure = classifyCommandFailure({
+      status: 'failed',
+      error: 'cannot restore: path already exists: /home/user/report.pdf',
+    });
+    expect(failure.kind).toBe('path_conflict');
+    expect(failure.status).toBe(409);
+  });
+
+  it('degrades an unrecognised failure to 500 rather than claiming the user can fix it', () => {
+    // Prose matching cannot recognise everything. The safe direction is to
+    // over-report a server fault, not to tell a technician their request was
+    // invalid when the device actually hit a disk error.
+    const failure = classifyCommandFailure({
+      status: 'failed',
+      error: 'failed to read file: input/output error',
+    });
+    expect(failure.kind).toBe('agent_execution_failed');
+    expect(failure.status).toBe(500);
+  });
+});
+
 describe('mapCommandFailure', () => {
   it('maps DEVICE_UNREACHABLE_ERROR to 503 with the sentinel message', () => {
     const result: CommandResult = { status: 'failed', error: DEVICE_UNREACHABLE_ERROR };
     expect(mapCommandFailure(result, 'fallback')).toEqual({
+      kind: 'device_unreachable',
+      code: 'device_unreachable',
       message: DEVICE_UNREACHABLE_ERROR,
       status: 503,
     });
   });
 
-  it('maps timeout status to 504 with the friendly retry message', () => {
+  it('maps timeout status to 503 with the friendly retry message', () => {
     const result: CommandResult = { status: 'timeout', error: 'Command timed out after 30000ms' };
     const mapped = mapCommandFailure(result, 'fallback');
-    expect(mapped.status).toBe(504);
+    expect(mapped.status).toBe(503);
+    expect(mapped.code).toBe('agent_timeout');
     expect(mapped.message).toMatch(/didn't respond in time/i);
     expect(mapped.message).toMatch(/please try again/i);
   });
 
-  it('maps "timed out" error string to 504 even when status is failed', () => {
+  it('maps "timed out" error string to a timeout even when status is failed', () => {
     // Some agent paths return status='failed' with a timeout-shaped error
     // string. The regex fallback must still classify these as timeouts so the
     // user gets the same UI treatment.
     const result: CommandResult = { status: 'failed', error: 'agent: command timed out at 30s' };
     const mapped = mapCommandFailure(result, 'fallback');
-    expect(mapped.status).toBe(504);
+    expect(mapped.code).toBe('agent_timeout');
+    expect(mapped.status).toBe(503);
     expect(mapped.message).toMatch(/didn't respond in time/i);
   });
 
-  it('maps "did not complete" error string to 504', () => {
+  it('maps "did not complete" error string to a timeout', () => {
     const result: CommandResult = { status: 'failed', error: 'Command did not complete' };
-    expect(mapCommandFailure(result, 'fallback').status).toBe(504);
+    expect(mapCommandFailure(result, 'fallback').code).toBe('agent_timeout');
   });
 
   it('regex matching is case-insensitive', () => {
     const result: CommandResult = { status: 'failed', error: 'COMMAND TIMED OUT' };
-    expect(mapCommandFailure(result, 'fallback').status).toBe(504);
+    expect(mapCommandFailure(result, 'fallback').code).toBe('agent_timeout');
   });
 
   it('uses the mutating message when opts.mutating is true', () => {
@@ -69,6 +200,12 @@ describe('mapCommandFailure', () => {
     // Critical: must NOT tell the user to "try again" — that's dangerous for
     // mutations whose final state is unknown.
     expect(mapped.message).not.toMatch(/please try again/i);
+    expect(mapped.unverified).toBe(true);
+  });
+
+  it('does not mark a read-only timeout as unverified', () => {
+    const result: CommandResult = { status: 'timeout', error: 'Command timed out after 30000ms' };
+    expect(mapCommandFailure(result, 'fallback').unverified).toBeUndefined();
   });
 
   it('maps offline-shaped errors to 503 with a clean message', () => {
@@ -77,6 +214,8 @@ describe('mapCommandFailure', () => {
       error: 'Device is offline, cannot execute command',
     };
     expect(mapCommandFailure(result, 'fallback')).toEqual({
+      kind: 'device_offline',
+      code: 'device_offline',
       message: 'The device is offline.',
       status: 503,
     });
@@ -87,19 +226,23 @@ describe('mapCommandFailure', () => {
     expect(mapCommandFailure(result, 'fallback').status).toBe(503);
   });
 
-  it('falls through to 502 with the raw error for generic failures', () => {
+  it('falls through to 500 with the raw error for unclassified failures', () => {
     const result: CommandResult = { status: 'failed', error: 'Permission denied' };
     expect(mapCommandFailure(result, 'fallback')).toEqual({
+      kind: 'agent_execution_failed',
+      code: 'agent_execution_failed',
       message: 'Permission denied',
-      status: 502,
+      status: 500,
     });
   });
 
   it('uses the fallback string when no error is present', () => {
     const result: CommandResult = { status: 'failed' };
     expect(mapCommandFailure(result, 'Failed to do the thing.')).toEqual({
+      kind: 'agent_execution_failed',
+      code: 'agent_execution_failed',
       message: 'Failed to do the thing.',
-      status: 502,
+      status: 500,
     });
   });
 
@@ -118,7 +261,22 @@ describe('buildBulkItemFailure', () => {
     const result: CommandResult = { status: 'timeout', error: 'Command timed out after 60000ms' };
     const failure = buildBulkItemFailure(result);
     expect(failure.unverified).toBe(true);
-    expect(failure.message).toMatch(/may have completed on the device/i);
+    // Wording is now shared with mapCommandFailure's mutating branch rather
+    // than duplicated here; the safety guidance is what must hold.
+    expect(failure.message).toMatch(/may have completed/i);
+    expect(failure.message).toMatch(/refresh to verify/i);
+    expect(failure.message).not.toMatch(/please try again/i);
+  });
+
+  it('marks a timeout-shaped error on failed status as unverified too', () => {
+    // Regression: this helper used to test `status === 'timeout'` literally
+    // while mapCommandFailure also recognised timeout-shaped prose. A bulk
+    // delete that timed out but reported status='failed' was therefore
+    // presented as a verified failure that was safe to retry — against a
+    // device that may already have deleted the file.
+    const result: CommandResult = { status: 'failed', error: 'agent: command timed out at 60s' };
+    const failure = buildBulkItemFailure(result);
+    expect(failure.unverified).toBe(true);
     expect(failure.message).toMatch(/refresh to verify/i);
   });
 
@@ -127,6 +285,7 @@ describe('buildBulkItemFailure', () => {
     const failure = buildBulkItemFailure(result);
     expect(failure.unverified).toBe(false);
     expect(failure.message).toBe('Permission denied');
+    expect(failure.code).toBe('agent_execution_failed');
   });
 
   it('passes the unreachable sentinel through with unverified=false', () => {
@@ -143,6 +302,13 @@ describe('auditErrorMessage', () => {
   it('tags timeouts with [unverified] so admins can spot them in audit logs', () => {
     const result: CommandResult = { status: 'timeout', error: 'Command timed out after 60000ms' };
     expect(auditErrorMessage(result)).toBe('[unverified] Command timed out after 60000ms');
+  });
+
+  it('tags a timeout-shaped error on failed status as unverified', () => {
+    // The audit trail and the API response must not disagree about whether the
+    // device's final state was confirmed.
+    const result: CommandResult = { status: 'failed', error: 'agent: command timed out at 60s' };
+    expect(auditErrorMessage(result)).toBe('[unverified] agent: command timed out at 60s');
   });
 
   it('tags timeouts even when result.error is missing', () => {
@@ -170,7 +336,25 @@ describe('buildSingleItemUploadBody', () => {
     expect(body.unverified).toBe(true);
     expect(body.error).toMatch(/may have completed/i);
     expect(body.error).toMatch(/refresh to verify/i);
-    expect(body.status).toBe(504);
+    expect(body.status).toBe(503);
+    expect(body.code).toBe('agent_timeout');
+  });
+
+  it('keeps unverified distinct from offline now that both answer 503', () => {
+    // This helper used to infer "timeout" from `status === 504`. Once timeout
+    // and offline both answer 503, a status test would silently drop the
+    // warning that the upload may have landed on the device.
+    const timedOut = buildSingleItemUploadBody(
+      { status: 'timeout', error: 'Command timed out after 30000ms' },
+      'Upload failed.',
+    );
+    const offline = buildSingleItemUploadBody(
+      { status: 'failed', error: 'Device is offline, cannot execute command' },
+      'Upload failed.',
+    );
+    expect(timedOut.status).toBe(offline.status);
+    expect(timedOut.unverified).toBe(true);
+    expect(offline.unverified).toBeUndefined();
   });
 
   it('does not mark hard failures as unverified', () => {
@@ -178,14 +362,24 @@ describe('buildSingleItemUploadBody', () => {
     const body = buildSingleItemUploadBody(result, 'Upload failed.');
     expect(body.unverified).toBeUndefined();
     expect(body.error).toBe('permission denied');
-    expect(body.status).toBe(502);
+    expect(body.status).toBe(500);
+  });
+
+  it('maps an oversized write refusal to 422 with the agent numbers intact', () => {
+    const result: CommandResult = {
+      status: 'failed',
+      error: 'file write payload too large: 9000000 bytes (max 4194304 bytes)',
+    };
+    const body = buildSingleItemUploadBody(result, 'Upload failed.');
+    expect(body.status).toBe(422);
+    expect(body.error).toMatch(/max 4194304 bytes/);
   });
 
   it('maps timeout-shaped error strings on failed status to unverified', () => {
     const result: CommandResult = { status: 'failed', error: 'agent: command timed out at 30s' };
     const body = buildSingleItemUploadBody(result, 'Upload failed.');
     expect(body.unverified).toBe(true);
-    expect(body.status).toBe(504);
+    expect(body.status).toBe(503);
   });
 
   it('maps DEVICE_UNREACHABLE_ERROR to 503 without unverified', () => {

--- a/apps/api/src/routes/systemTools/fileBrowserHelpers.ts
+++ b/apps/api/src/routes/systemTools/fileBrowserHelpers.ts
@@ -12,10 +12,191 @@ export function isCommandFailure(result: CommandResult): boolean {
   return result.status === 'failed' || result.status === 'timeout';
 }
 
+/**
+ * What actually went wrong, independent of how it is spelled on the wire.
+ *
+ * Callers that need to make a decision (is this retryable? did the device
+ * maybe complete the work anyway?) must branch on this, NEVER on the HTTP
+ * status: several kinds deliberately share a status, and the statuses
+ * themselves are constrained by the Cloudflare rule below rather than by pure
+ * semantics.
+ */
+export type CommandFailureKind =
+  | 'device_unreachable'
+  | 'device_offline'
+  | 'agent_timeout'
+  | 'path_not_found'
+  | 'path_conflict'
+  | 'agent_command_rejected'
+  | 'agent_execution_failed';
+
+export type CommandFailure = {
+  kind: CommandFailureKind;
+  message: string;
+  status: ContentfulStatusCode;
+  /** Stable machine-readable discriminant, mirrored into the response body. */
+  code: CommandFailureKind;
+  /** Set only when the device may have completed the work despite the error. */
+  unverified?: true;
+};
+
+/**
+ * NEVER map an agent failure to 502 or 504.
+ *
+ * Cloudflare fronts the hosted deployments and, by its own documentation,
+ * "returns a Cloudflare-branded HTTP 502 or 504 error when your origin web
+ * server responds with a standard HTTP 502 bad gateway or 504 gateway timeout
+ * error". Origin-error pass-thru is Enterprise-only and is not enabled. The
+ * branded page REPLACES our JSON body, so the client's `response.json()`
+ * throws and every message below is reduced to a generic "Failed to ..." — the
+ * exact production bug this classifier exists to prevent: a user was told
+ * "Failed to download" when the agent had actually said
+ * "file too large: 8981850 bytes (max 1048576 bytes)".
+ *
+ * Self-hosted deployments have no Cloudflare in front and saw the real message
+ * all along, which is why this survived so long undetected.
+ *
+ * 500 and 503 pass through Cloudflare untouched, as do all 4xx.
+ *
+ * Exported so fileBrowserHelpers.test.ts can assert it against every
+ * classifier outcome — a future edit cannot quietly reintroduce a swallowed
+ * body.
+ */
+export const CLOUDFLARE_SWALLOWED_STATUSES = [502, 504] as const;
+
+/**
+ * Deterministic refusals: the agent understood a well-formed command and
+ * declined to carry it out (a policy denial, a size cap, a shape mismatch).
+ * These are NOT server faults — surfacing them as 5xx both misleads the
+ * technician and inflates our error-rate alerting with working-as-intended
+ * outcomes.
+ *
+ * Matched against the agent's prose because `CommandResult` carries only
+ * `status` and a human string today. That is a known weakness, not a
+ * preference: an unrecognised refusal degrades to `agent_execution_failed`
+ * (500), which is the safe direction — it over-reports a fault rather than
+ * silently claiming the user can fix something they cannot. The durable fix is
+ * a typed `errorCode` on the Go CommandResult; see the follow-up issue.
+ *
+ * Every pattern below is anchored to a literal in
+ * agent/internal/remote/tools/fileops.go.
+ */
+const REFUSAL_PATTERNS: readonly RegExp[] = [
+  /^file too large:/i,
+  /file write payload too large/i,
+  /^path is a directory, not a file/i,
+  /denied on sensitive path/i,
+  /^operation denied on system path:/i,
+  /^recursive delete denied on top-level path:/i,
+  /denied: cannot verify directory contents/i,
+  /^cannot copy directory into itself:/i,
+  /^directory too large to clear/i,
+  /^trash metadata exceeds maximum size/i,
+  /^unsupported encoding:/i,
+  /^(path|destPath|newPath|oldPath|sourcePath|trashId) is required/i,
+];
+
+/** Refusals that are specifically a state conflict the user can reconcile. */
+const CONFLICT_PATTERNS: readonly RegExp[] = [
+  /^cannot restore: path already exists:/i,
+];
+
+/**
+ * Absent-path refusals. Kept separate from the generic refusals so they get a
+ * 404 rather than a 422 — the agent spells this three different ways and only
+ * one of them contains the words "not found", which is why the download route
+ * used to miss `path does not exist:` and return a 502 for a plain typo.
+ */
+const NOT_FOUND_PATTERNS: readonly RegExp[] = [
+  /not found/i,
+  /^path does not exist:/i,
+  /^source path does not exist:/i,
+];
+
+function matchesAny(patterns: readonly RegExp[], raw: string): boolean {
+  return patterns.some((pattern) => pattern.test(raw));
+}
+
+/**
+ * Single source of truth for "the agent did not do what we asked".
+ *
+ * `mutating` marks routes that change state on the device. It only affects
+ * timeouts: on a timeout we genuinely cannot tell whether the device completed
+ * the operation (the queue marks the row failed, and a late result only
+ * updates rows still marked `sent`), so a mutation is reported as
+ * `unverified` and the message tells the user to verify before retrying.
+ * Re-running a delete/move/purge against a half-completed state can compound
+ * the damage.
+ */
+export function classifyCommandFailure(
+  result: CommandResult,
+  opts: { mutating?: boolean } = {},
+): CommandFailure {
+  const raw = result.error || '';
+
+  if (raw === DEVICE_UNREACHABLE_ERROR) {
+    return {
+      kind: 'device_unreachable',
+      message: DEVICE_UNREACHABLE_ERROR,
+      status: 503,
+      code: 'device_unreachable',
+    };
+  }
+
+  // `status === 'timeout'` is the reliable signal; the prose test catches
+  // agents and queue paths that report a timeout as a plain failure. Both must
+  // land here, or a timed-out mutation gets reported as a verified failure and
+  // the user retries a delete that may already have happened.
+  if (result.status === 'timeout' || /timed out|did not complete/i.test(raw)) {
+    return {
+      kind: 'agent_timeout',
+      message: opts.mutating
+        ? "The device didn't respond in time. The operation may have completed — refresh to verify before retrying."
+        : "The device didn't respond in time. This usually means a brief network issue. Please try again.",
+      status: 503,
+      code: 'agent_timeout',
+      ...(opts.mutating ? { unverified: true as const } : {}),
+    };
+  }
+
+  if (/cannot execute command|is offline|is unknown/i.test(raw)) {
+    return {
+      kind: 'device_offline',
+      message: 'The device is offline.',
+      status: 503,
+      code: 'device_offline',
+    };
+  }
+
+  if (matchesAny(NOT_FOUND_PATTERNS, raw)) {
+    return { kind: 'path_not_found', message: raw, status: 404, code: 'path_not_found' };
+  }
+
+  if (matchesAny(CONFLICT_PATTERNS, raw)) {
+    return { kind: 'path_conflict', message: raw, status: 409, code: 'path_conflict' };
+  }
+
+  if (matchesAny(REFUSAL_PATTERNS, raw)) {
+    return {
+      kind: 'agent_command_rejected',
+      message: raw,
+      status: 422,
+      code: 'agent_command_rejected',
+    };
+  }
+
+  return {
+    kind: 'agent_execution_failed',
+    message: raw,
+    status: 500,
+    code: 'agent_execution_failed',
+  };
+}
+
 // Map a failed/timed-out agent CommandResult to a user-facing message + HTTP
-// status. The shared sentinels (DEVICE_UNREACHABLE_ERROR, status === 'timeout')
-// let us distinguish "device is gone" from "we lost a packet to a brief
-// hiccup", which the user otherwise has no way to tell apart.
+// status + machine-readable code. Thin wrapper over classifyCommandFailure
+// that applies the route's fallback text when the agent gave us nothing to
+// show.
 //
 // `mutating` flips the timeout-branch message to warn the user that the
 // operation may have already completed on the device, so they verify before
@@ -24,23 +205,9 @@ export function mapCommandFailure(
   result: CommandResult,
   fallback: string,
   opts: { mutating?: boolean } = {},
-): { message: string; status: ContentfulStatusCode } {
-  const raw = result.error || '';
-  if (raw === DEVICE_UNREACHABLE_ERROR) {
-    return { message: DEVICE_UNREACHABLE_ERROR, status: 503 };
-  }
-  if (result.status === 'timeout' || /timed out|did not complete/i.test(raw)) {
-    return {
-      message: opts.mutating
-        ? "The device didn't respond in time. The operation may have completed — refresh to verify before retrying."
-        : "The device didn't respond in time. This usually means a brief network issue. Please try again.",
-      status: 504,
-    };
-  }
-  if (/cannot execute command|is offline|is unknown/i.test(raw)) {
-    return { message: 'The device is offline.', status: 503 };
-  }
-  return { message: raw || fallback, status: 502 };
+): CommandFailure {
+  const failure = classifyCommandFailure(result, opts);
+  return failure.message ? failure : { ...failure, message: fallback };
 }
 
 // Bulk-item variant for routes that mutate state per item (copy/move/delete/
@@ -51,39 +218,58 @@ export function mapCommandFailure(
 // `unverified` so the UI can prompt the user to refresh and check.
 export function buildBulkItemFailure(result: CommandResult): {
   message: string;
+  code: CommandFailureKind;
   unverified: boolean;
 } {
-  if (result.status === 'timeout') {
-    return {
-      message:
-        "The device didn't respond in time. The operation may have completed on the device — refresh to verify before retrying.",
-      unverified: true,
-    };
-  }
+  // Always classified as mutating: every caller of this helper changes device
+  // state. Deriving `unverified` from the classifier (rather than re-testing
+  // `status === 'timeout'` here) is what keeps a prose-only timeout —
+  // `{status:'failed', error:'command timed out'}` — from being reported as a
+  // verified failure that is safe to retry.
+  const failure = mapCommandFailure(result, 'Operation failed.', { mutating: true });
   return {
-    message: mapCommandFailure(result, 'Operation failed.').message,
-    unverified: false,
+    message: failure.message,
+    code: failure.code,
+    unverified: failure.unverified === true,
   };
 }
 
 // Single-item upload variant. Mirrors buildBulkItemFailure, but returns the
-// full { error, unverified?, status } shape the upload route needs.
+// full { error, code, unverified?, status } shape the upload route needs.
 export function buildSingleItemUploadBody(
   result: CommandResult,
   fallback: string,
-): { error: string; status: ContentfulStatusCode; unverified?: true } {
-  const { message, status } = mapCommandFailure(result, fallback, { mutating: true });
-  if (status === 504) {
-    return { error: message, status, unverified: true };
-  }
-  return { error: message, status };
+): {
+  error: string;
+  code: CommandFailureKind;
+  status: ContentfulStatusCode;
+  unverified?: true;
+} {
+  const failure = mapCommandFailure(result, fallback, { mutating: true });
+  // Branch on the classified kind, never on the HTTP status: timeout and
+  // offline both answer 503, so a status test here would silently drop the
+  // `unverified` warning that tells the user their upload may have landed.
+  return {
+    error: failure.message,
+    code: failure.code,
+    status: failure.status,
+    ...(failure.unverified ? { unverified: true as const } : {}),
+  };
 }
 
 // Tag audit-log errorMessage so admins reviewing the audit trail can spot
 // commands whose final state on the device is unverified. Returns undefined
 // for successes so callers can pass the result through unchanged.
 export function auditErrorMessage(result: CommandResult): string | undefined {
-  if (result.status === 'timeout') {
+  // Classified rather than testing `status === 'timeout'` directly, so a
+  // prose-only timeout is tagged `[unverified]` in the audit trail too — the
+  // trail and the API response must not disagree about whether a device's
+  // final state was confirmed.
+  //
+  // Gated on isCommandFailure so classification never runs on a COMPLETED
+  // command: the prose test would otherwise tag a successful command whose
+  // output merely mentions "timed out" as unverified.
+  if (isCommandFailure(result) && classifyCommandFailure(result).kind === 'agent_timeout') {
     return `[unverified] ${result.error || 'Command timed out — agent state not confirmed.'}`;
   }
   return result.error || undefined;

--- a/apps/api/src/routes/systemTools/processes.ts
+++ b/apps/api/src/routes/systemTools/processes.ts
@@ -62,7 +62,9 @@ processesRoutes.get(
       });
     } catch (parseError) {
       console.error('Failed to parse agent response for process listing:', parseError);
-      return c.json({ error: 'Failed to parse agent response for process listing' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for process listing', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -99,7 +101,9 @@ processesRoutes.get(
       return c.json({ data: payload });
     } catch (error) {
       console.error('Failed to parse agent response for process details:', error);
-      return c.json({ error: 'Failed to parse agent response for process details' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for process details', code: 'invalid_agent_response' }, 500);
     }
   }
 );

--- a/apps/api/src/routes/systemTools/registry.ts
+++ b/apps/api/src/routes/systemTools/registry.ts
@@ -212,7 +212,9 @@ registryRoutes.get(
       return c.json({ data: keys });
     } catch (error) {
       console.error('Failed to parse agent response for registry keys:', error);
-      return c.json({ error: 'Failed to parse agent response for registry keys' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for registry keys', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -254,7 +256,9 @@ registryRoutes.get(
       return c.json({ data: values });
     } catch (error) {
       console.error('Failed to parse agent response for registry values:', error);
-      return c.json({ error: 'Failed to parse agent response for registry values' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for registry values', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -294,7 +298,9 @@ registryRoutes.get(
       const payload = JSON.parse(result.stdout || '{}');
       const value = mapRegistryValueFromAgent(payload);
       if (!value) {
-        return c.json({ error: 'Invalid registry value payload from agent' }, 502);
+        // 500, not 502: Cloudflare replaces an origin 502 body with its own
+        // branded page, blanking this message on hosted deployments.
+        return c.json({ error: 'Invalid registry value payload from agent', code: 'invalid_agent_response' }, 500);
       }
 
       const fullPath = value.name === '(Default)'
@@ -309,7 +315,9 @@ registryRoutes.get(
       });
     } catch (error) {
       console.error('Failed to parse agent response for registry value:', error);
-      return c.json({ error: 'Failed to parse agent response for registry value' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for registry value', code: 'invalid_agent_response' }, 500);
     }
   }
 );

--- a/apps/api/src/routes/systemTools/scheduledTasks.ts
+++ b/apps/api/src/routes/systemTools/scheduledTasks.ts
@@ -193,7 +193,9 @@ scheduledTasksRoutes.get(
       });
     } catch (error) {
       console.error('Failed to parse agent response for task listing:', error);
-      return c.json({ error: 'Failed to parse agent response for task listing' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for task listing', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -229,12 +231,16 @@ scheduledTasksRoutes.get(
       const payload = JSON.parse(result.stdout || '{}');
       const task = normalizeScheduledTask(payload);
       if (!task) {
-        return c.json({ error: 'Invalid task payload from agent' }, 502);
+        // 500, not 502: Cloudflare replaces an origin 502 body with its own
+        // branded page, blanking this message on hosted deployments.
+        return c.json({ error: 'Invalid task payload from agent', code: 'invalid_agent_response' }, 500);
       }
       return c.json({ data: task });
     } catch (error) {
       console.error('Failed to parse agent response for task details:', error);
-      return c.json({ error: 'Failed to parse agent response for task details' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for task details', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -288,7 +294,9 @@ scheduledTasksRoutes.get(
       });
     } catch (error) {
       console.error('Failed to parse agent response for task history:', error);
-      return c.json({ error: 'Failed to parse agent response for task history' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for task history', code: 'invalid_agent_response' }, 500);
     }
   }
 );

--- a/apps/api/src/routes/systemTools/services.ts
+++ b/apps/api/src/routes/systemTools/services.ts
@@ -133,7 +133,9 @@ servicesRoutes.get(
       });
     } catch (parseError) {
       console.error('Failed to parse agent response for service listing:', parseError);
-      return c.json({ error: 'Failed to parse agent response for service listing' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for service listing', code: 'invalid_agent_response' }, 500);
     }
   }
 );
@@ -169,12 +171,16 @@ servicesRoutes.get(
       const payload = JSON.parse(result.stdout || '{}');
       const service = mapServiceFromAgent(payload);
       if (!service) {
-        return c.json({ error: 'Invalid service payload from agent' }, 502);
+        // 500, not 502: Cloudflare replaces an origin 502 body with its own
+        // branded page, blanking this message on hosted deployments.
+        return c.json({ error: 'Invalid service payload from agent', code: 'invalid_agent_response' }, 500);
       }
       return c.json({ data: service });
     } catch (error) {
       console.error('Failed to parse agent response for service details:', error);
-      return c.json({ error: 'Failed to parse agent response for service details' }, 502);
+      // 500, not 502: Cloudflare replaces an origin 502 body with its own
+      // branded page, blanking this message on hosted deployments.
+      return c.json({ error: 'Failed to parse agent response for service details', code: 'invalid_agent_response' }, 500);
     }
   }
 );

--- a/apps/docs/src/content/docs/features/system-tools.mdx
+++ b/apps/docs/src/content/docs/features/system-tools.mdx
@@ -613,24 +613,26 @@ Every System Tools request verifies that the device exists and that the authenti
 - Your user account has access to the organization that owns the device.
 - The device has been enrolled (not deleted).
 
-### Agent failed / device may be offline (502)
+### Agent command failures
 
-System Tools commands are dispatched to the agent via the command queue with a 30-second timeout (15 seconds for process kill). A 502 or 500 response with a message like "Failed to get processes" or "Agent failed to list files" indicates:
+System Tools commands are dispatched to the agent via the command queue with a 30-second timeout (15 seconds for process kill). Failures carry both a human-readable `error` and a stable `code` you can branch on:
 
-- The device agent is offline or unreachable.
-- The agent did not respond within the timeout window.
-- The agent encountered an internal error executing the command.
+| `code` | HTTP | Meaning |
+|---|---:|---|
+| `device_unreachable` | 503 | No live agent connection at dispatch time. Safe to retry. |
+| `device_offline` | 503 | The device is offline. Wait for it to come back. |
+| `agent_timeout` | 503 | The agent did not answer within the timeout. Read-only commands are safe to retry; for commands that change state the body also carries `unverified: true` — the operation may have completed on the device, so refresh and verify before retrying. |
+| `path_not_found` | 404 | The requested path or trash item does not exist on the device. |
+| `path_conflict` | 409 | The destination already exists. |
+| `agent_command_rejected` | 422 | The agent understood the command and refused it — for example `file too large: 8981850 bytes (max 1048576 bytes)`. Working as intended; adjust the request. |
+| `agent_execution_failed` | 500 | The agent hit an error carrying out the command (I/O error, permissions). |
+| `invalid_agent_response` | 500 | The agent returned a payload the API could not parse — usually an outdated agent. Update the agent and retry. |
 
-Check the device's online status on its detail page before retrying.
+Bulk operations (copy, move, delete, trash restore) always answer **200** once the batch has been processed, even when every item failed. Inspect the per-item `status`, `code`, `error`, and `unverified` fields in `results` rather than the HTTP status.
 
-### "Failed to parse agent response" (502)
-
-This means the agent returned a response that the API could not parse as valid JSON. This can happen if:
-
-- The agent version is outdated and returns a different payload format.
-- The command produced unexpected output (e.g., a system error message instead of JSON).
-
-Update the agent to the latest version and retry.
+:::note[These endpoints never return 502 or 504]
+Cloudflare replaces an origin 502 or 504 response with its own branded error page, which discards the JSON body — so on hosted deployments a 502 would hide the very message you need. Agent failures are therefore mapped onto statuses that pass through unchanged. Genuine proxy and tunnel endpoints elsewhere in the API may still return 502/504.
+:::
 
 ### "Registry is only supported on Windows" / "Event logs are only supported on Windows" / "Scheduled tasks are only supported on Windows"
 

--- a/apps/web/src/components/remote/FileManager.test.tsx
+++ b/apps/web/src/components/remote/FileManager.test.tsx
@@ -83,6 +83,97 @@ describe('FileManager downloads', () => {
     // Cancelled rows swap the cancel button for a dismiss affordance.
     expect(screen.getByTitle('Dismiss')).toBeInTheDocument();
   });
+
+  describe('over-cap pre-flight', () => {
+    // The agent refuses any file_read over 1MB. The listing already knows each
+    // entry's size, so these assert the UI never spends a doomed round trip —
+    // and, just as importantly, that it never blocks a transfer the agent WOULD
+    // have served.
+    const OVER_CAP = 2 * 1024 * 1024;
+    const AT_CAP = 1024 * 1024;
+
+    function renderWithEntry(entry: Record<string, unknown>) {
+      mockFetchWithAuth.mockImplementation((url: string) => {
+        if (url.includes('/download?')) {
+          return Promise.resolve({
+            ok: true,
+            blob: async () => new Blob(['x']),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ data: [entry] }),
+        });
+      });
+
+      return render(
+        <FileManager
+          deviceId="device-1"
+          deviceHostname="workstation-1"
+          initialPath="/"
+        />
+      );
+    }
+
+    function downloadUrlCalls() {
+      return mockFetchWithAuth.mock.calls.filter(
+        ([url]) => typeof url === 'string' && url.includes('/download?')
+      );
+    }
+
+    it('refuses an over-cap download with the real numbers and never calls the API', async () => {
+      renderWithEntry({ name: 'manual.pdf', path: '/manual.pdf', type: 'file', size: OVER_CAP });
+
+      await screen.findByText('manual.pdf');
+      fireEvent.click(screen.getByTitle('Download'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Too large to download (2.0 MB). The file browser transfers files up to 1.0 MB.')
+        ).toBeInTheDocument();
+      });
+      // The point of the guard: no round trip at all.
+      expect(downloadUrlCalls()).toHaveLength(0);
+      // And it must not be reported as the old generic failure.
+      expect(screen.queryByText('Failed to download')).not.toBeInTheDocument();
+    });
+
+    it('allows a file exactly at the cap through — the agent rejects only what exceeds it', async () => {
+      renderWithEntry({ name: 'atcap.bin', path: '/atcap.bin', type: 'file', size: AT_CAP });
+
+      await screen.findByText('atcap.bin');
+      fireEvent.click(screen.getByTitle('Download'));
+
+      await waitFor(() => expect(downloadUrlCalls()).toHaveLength(1));
+    });
+
+    it('lets a macOS alias through even when the alias file itself looks over-cap', async () => {
+      // `size` describes the alias, not the target the agent resolves and reads,
+      // so the client cannot judge it — fail open and let the agent decide.
+      renderWithEntry({
+        name: 'shortcut',
+        path: '/shortcut',
+        type: 'file',
+        size: OVER_CAP,
+        isAlias: true,
+        aliasTarget: '/elsewhere/real.pdf',
+      });
+
+      await screen.findByText('shortcut');
+      fireEvent.click(screen.getByTitle('Download'));
+
+      await waitFor(() => expect(downloadUrlCalls()).toHaveLength(1));
+    });
+
+    it('lets an entry with no reported size through rather than guessing', async () => {
+      renderWithEntry({ name: 'unsized.bin', path: '/unsized.bin', type: 'file' });
+
+      await screen.findByText('unsized.bin');
+      fireEvent.click(screen.getByTitle('Download'));
+
+      await waitFor(() => expect(downloadUrlCalls()).toHaveLength(1));
+    });
+  });
 });
 
 describe('FileManager uploads', () => {

--- a/apps/web/src/components/remote/FileManager.tsx
+++ b/apps/web/src/components/remote/FileManager.tsx
@@ -48,6 +48,7 @@ import FileActivityPanel from './FileActivityPanel';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import type { FileActivity } from './FileActivityPanel';
 import { useTranslation } from 'react-i18next';
+import { AGENT_MAX_FILE_READ_BYTES } from '@breeze/shared';
 import '@/lib/i18n';
 
 export type FileEntry = {
@@ -426,6 +427,32 @@ export default function FileManager({
   // Initiate file download
   const initiateDownload = useCallback(async (entry: FileEntry) => {
     const transferId = crypto.randomUUID();
+
+    // Pre-flight the agent's 1MB read cap. The directory listing already carries
+    // every entry's size, so an over-cap file can be refused here — with the
+    // actual numbers — instead of spending a round trip to have the device
+    // answer "file too large" in bytes.
+    //
+    // Fail OPEN on anything we cannot measure: an absent size, or a macOS alias
+    // whose `size` describes the alias file and not the target the agent
+    // resolves and reads. The agent enforces the real cap regardless; this guard
+    // exists to save a doomed round trip, not to be the enforcement point.
+    if (!entry.isAlias && typeof entry.size === 'number' && entry.size > AGENT_MAX_FILE_READ_BYTES) {
+      setTransfers(prev => [...prev, {
+        id: transferId,
+        filename: entry.name,
+        direction: 'download',
+        status: 'failed',
+        progress: 0,
+        size: entry.size ?? 0,
+        error: t('fileManager.errors.downloadTooLarge', {
+          size: formatSize(entry.size),
+          max: formatSize(AGENT_MAX_FILE_READ_BYTES),
+        }),
+      }]);
+      return;
+    }
+
     const controller = new AbortController();
     transferControllersRef.current.set(transferId, controller);
 

--- a/apps/web/src/locales/de-DE/remote.json
+++ b/apps/web/src/locales/de-DE/remote.json
@@ -246,6 +246,7 @@
       "copy": "Kopieren fehlgeschlagen",
       "delete": "Fehler beim Löschen",
       "download": "Download fehlgeschlagen",
+      "downloadTooLarge": "Zu groß für den Download ({{size}}). Der Dateibrowser überträgt Dateien bis {{max}}.",
       "loadDirectory": "Das Verzeichnis konnte nicht geladen werden",
       "move": "Fehler beim Verschieben",
       "readFile": "Datei konnte nicht gelesen werden",

--- a/apps/web/src/locales/en/remote.json
+++ b/apps/web/src/locales/en/remote.json
@@ -246,6 +246,7 @@
       "copy": "Failed to copy",
       "delete": "Failed to delete",
       "download": "Failed to download",
+      "downloadTooLarge": "Too large to download ({{size}}). The file browser transfers files up to {{max}}.",
       "loadDirectory": "Failed to load directory",
       "move": "Failed to move",
       "readFile": "Failed to read file",

--- a/apps/web/src/locales/es-419/remote.json
+++ b/apps/web/src/locales/es-419/remote.json
@@ -246,6 +246,7 @@
       "copy": "No se pudo copiar",
       "delete": "No se pudo eliminar",
       "download": "No se pudo descargar",
+      "downloadTooLarge": "Demasiado grande para descargar ({{size}}). El explorador de archivos transfiere archivos de hasta {{max}}.",
       "loadDirectory": "No se pudo cargar el directorio",
       "move": "No se pudo mover",
       "readFile": "No se pudo leer el archivo",

--- a/apps/web/src/locales/fr-CA/remote.json
+++ b/apps/web/src/locales/fr-CA/remote.json
@@ -246,6 +246,7 @@
       "copy": "Impossible de copier",
       "delete": "Impossible de supprimer",
       "download": "Impossible de télécharger",
+      "downloadTooLarge": "Trop volumineux pour être téléchargé ({{size}}). L’explorateur de fichiers transfère des fichiers jusqu’à {{max}}.",
       "loadDirectory": "Impossible de charger le répertoire",
       "move": "Impossible de déplacer l’élément",
       "readFile": "Impossible de lire le fichier",

--- a/apps/web/src/locales/fr-FR/remote.json
+++ b/apps/web/src/locales/fr-FR/remote.json
@@ -246,6 +246,7 @@
       "copy": "Impossible de copier",
       "delete": "Impossible de supprimer",
       "download": "Impossible de télécharger",
+      "downloadTooLarge": "Trop volumineux pour être téléchargé ({{size}}). L’explorateur de fichiers transfère des fichiers jusqu’à {{max}}.",
       "loadDirectory": "Impossible de charger le répertoire",
       "move": "Impossible de déplacer l’élément",
       "readFile": "Impossible de lire le fichier",

--- a/apps/web/src/locales/it-IT/remote.json
+++ b/apps/web/src/locales/it-IT/remote.json
@@ -246,6 +246,7 @@
       "copy": "Impossibile copiare",
       "delete": "Impossibile eliminare",
       "download": "Impossibile scaricare",
+      "downloadTooLarge": "Troppo grande per il download ({{size}}). Il browser file trasferisce file fino a {{max}}.",
       "loadDirectory": "Impossibile caricare la directory",
       "move": "Impossibile spostare",
       "readFile": "Impossibile leggere il file",

--- a/apps/web/src/locales/pt-BR/remote.json
+++ b/apps/web/src/locales/pt-BR/remote.json
@@ -246,6 +246,7 @@
       "copy": "Falha ao copiar",
       "delete": "Falha ao excluir",
       "download": "Falha ao baixar",
+      "downloadTooLarge": "Muito grande para baixar ({{size}}). O navegador de arquivos transfere arquivos de até {{max}}.",
       "loadDirectory": "Falha ao carregar a pasta",
       "move": "Falha ao mover",
       "readFile": "Falha ao ler o arquivo",

--- a/apps/web/src/locales/tr-TR/remote.json
+++ b/apps/web/src/locales/tr-TR/remote.json
@@ -246,6 +246,7 @@
       "copy": "Kopyalanamadı",
       "delete": "Silinemedi",
       "download": "İndirilemedi",
+      "downloadTooLarge": "İndirilemeyecek kadar büyük ({{size}}). Dosya tarayıcısı en fazla {{max}} boyutunda dosya aktarır.",
       "loadDirectory": "Dizin yüklenemedi",
       "move": "Taşınamadı",
       "readFile": "Dosya okunamadı",

--- a/packages/shared/src/constants/agentFileTransfer.ts
+++ b/packages/shared/src/constants/agentFileTransfer.ts
@@ -1,0 +1,33 @@
+/**
+ * Agent file-transfer caps — the single source of truth for the WEB layer.
+ *
+ * The authoritative values live in the Go agent
+ * (`agent/internal/remote/tools/fileops.go`). These mirrors exist because the
+ * browser needs to know the caps *before* it issues a request: the file
+ * listing already carries each entry's size, so the File Browser can refuse an
+ * over-cap download up front instead of spending a round trip to learn the
+ * answer from the device.
+ *
+ * Both directions are pinned from Go so a one-sided edit fails CI:
+ *   - read  → `TestMaxFileReadSizeMatchesSharedConstant` (agent/internal/remote/tools/limits_test.go),
+ *             which parses THIS file's `AGENT_MAX_FILE_READ_BYTES` declaration.
+ *   - write → `TestMaxMessageSizeCoversLargestLegitimateFrame` (agent/internal/websocket/limits_test.go),
+ *             mirrored API-side by `AGENT_MAX_FILE_WRITE_BYTES` in
+ *             `apps/api/src/routes/systemTools/schemas.ts`.
+ *
+ * Note the asymmetry is real, not a typo: the agent reads at most 1 MB but
+ * accepts writes up to 4 MB. Raising the read cap is NOT a one-line change —
+ * a file_read result is base64'd inline into `stdout`, which the API bounds at
+ * `MAX_COMMAND_RESULT_BYTES` (5,000,000) in
+ * `apps/api/src/routes/agents/schemas.ts`. 1 MB decoded is ~1.4 MB encoded and
+ * fits; anything past ~3.6 MB decoded does not, and the agent's SendResult
+ * sheds only the `result` field on overflow, never `stdout`. Lifting this cap
+ * requires a chunked transfer path first.
+ */
+
+/**
+ * Largest file the agent will read for a `file_read` command
+ * (`maxFileReadSize` in agent/internal/remote/tools/fileops.go). Over this the
+ * agent fails the command with `file too large: <size> bytes (max <cap> bytes)`.
+ */
+export const AGENT_MAX_FILE_READ_BYTES = 1024 * 1024;

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -8,6 +8,10 @@ export * from './configFeatureTypes';
 // Canonical in-app notification types shared by API filters and web UI.
 export * from './notificationTypes';
 
+// Agent file-transfer caps mirrored from the Go agent, so the web layer can
+// pre-flight a transfer instead of learning the limit from a failed round trip.
+export * from './agentFileTransfer';
+
 // OS Types
 export const OS_TYPES = ['windows', 'macos', 'linux'] as const;
 


### PR DESCRIPTION
Closes #4024

## The bug

A technician downloading an 8.9 MB PDF from **Remote Tools → File Browser** saw only **"Failed to download"**, twice. Traced end-to-end in US production:

1. **The agent refused it — correctly.** `maxFileReadSize` is 1 MB. `device_commands` recorded:
   ```
   file_read | failed | {"error": "file too large: 8981850 bytes (max 1048576 bytes)"}
   ```
2. **The API returned that message with HTTP 502** (`mapCommandFailure`'s catch-all). API log confirms `status=502` on both attempts.
3. **Cloudflare replaced the body.** [Per its docs](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-502-504/): *"Cloudflare returns a Cloudflare-branded HTTP 502 or 504 error when your origin web server responds with a standard HTTP 502 bad gateway or 504 gateway timeout error."* Origin-error pass-thru is Enterprise-only and is not enabled on our zone.
4. **The client fell back to the generic string**, because `res.json()` threw on Cloudflare's HTML.

502 was `mapCommandFailure`'s catch-all and 504 its timeout branch — **exactly the two statuses Cloudflare intercepts**. So this blanked the reason for *every* File Browser failure on hosted. Self-hosted has no Cloudflare in front and has been showing the real messages all along, which is why it went unnoticed.

## API — classify, then pick a status that survives the edge

`classifyCommandFailure()` becomes the single source of truth, returning a stable `code` alongside the message:

| `code` | HTTP | when |
|---|---:|---|
| `device_unreachable` / `device_offline` / `agent_timeout` | 503 | no connection / offline / no answer in time |
| `path_not_found` | 404 | path or trash item absent |
| `path_conflict` | 409 | destination already exists |
| `agent_command_rejected` | 422 | deterministic agent refusal (`file too large`, containment denial, …) |
| `agent_execution_failed` | 500 | unclassified execution fault |
| `invalid_agent_response` | 500 | agent sent an unparseable payload |

A **property test** asserts no classifier outcome is ever 502 or 504, run over a corpus of the real error strings from `fileops.go` — so a future edit can't quietly reintroduce a swallowed body.

Refusals are matched on the agent's prose because `CommandResult` carries no error code today. Unrecognised strings degrade to **500**, which over-reports a fault rather than telling a technician they can fix something they can't. The durable fix — a typed `errorCode` on the Go `CommandResult` — is filed as #4026.

### Two safety bugs found while centralising this

- **`buildBulkItemFailure` tested `status === 'timeout'` literally** while `mapCommandFailure` also recognised timeout-shaped prose. A bulk delete that timed out but reported `status: 'failed'` was presented as a **verified** failure that was safe to retry — against a device that may already have deleted the file. Both now derive `unverified` from one classification, as does `auditErrorMessage`, so the audit trail and the API response can no longer disagree about whether a device's final state was confirmed.
- **`buildSingleItemUploadBody` inferred "timeout" from `status === 504`.** With timeout and offline both answering 503 that test would have silently dropped the warning that an upload may have landed; it now branches on the classified kind. There's a test pinning exactly this.

### Also

- **Bulk copy/move/delete/restore now always answer 200** once the batch has been processed. Answering 502 when every item failed got the whole per-item `results` array discarded at the edge, so the UI could only say "Copy failed". The client already handles this shape (`summarizeBulkResults`); per-item `code` was added.
- The download route's local `includes('not found')` test moves into the classifier, which also recognises the agent's **two other spellings** for an absent path (`path does not exist:`, `source path does not exist:`) — neither contains the words "not found", so a plain mistyped path used to answer 502 instead of 404.
- Protocol-defect 502s in `processes/services/registry/eventLogs/scheduledTasks`, plus `devices/filesystem`, `devices/diagnose` and `remote/sessions`, moved off 502.

## Web — refuse an over-cap download before the round trip

The directory listing already carries every entry's size, so `FileManager` now rejects an over-cap file up front with the real numbers instead of a doomed request.

It **fails open** on anything it can't measure — an absent size, or a macOS alias whose `size` describes the alias rather than the target the agent resolves — because the agent remains the enforcement point. Tests cover the at-cap boundary, the alias case, and the unknown-size case, and assert the blocked case makes **zero** API calls.

The cap lives in `packages/shared` as `AGENT_MAX_FILE_READ_BYTES` and is **pinned to the Go constant** by a new `agent/internal/remote/tools/limits_test.go` that parses the TypeScript declaration — so the UI can never enforce a limit the agent doesn't. A second Go test pins the read cap under the 5 MB `MAX_COMMAND_RESULT_BYTES` ceiling, documenting why raising it isn't a one-liner: 8.6 MB decoded is ~11.5 MB base64, and `SendResult` sheds only `result` on overflow, never `stdout` — a raised cap would swap a clean error for a 30 s timeout.

New locale key added to all 8 catalogs; `localeParity` / `translationCoverage` / `terminologyQuality` all pass.

## Not in this PR

- **#4025 — System Tools routes treat a timeout as success.** The sibling routes test `status === 'failed'` only, so a timed-out `kill_process` answers `success: true, "Process N terminated successfully"` when the agent never replied, and a timed-out listing renders empty. ~20 sites across 5 files, each needing its own test. Verified against the code, filed separately.
- **#4026 — typed `errorCode` on `CommandResult`**, replacing the prose matching.
- `apps/api/src/data/docsIndex.json` is stale on `main` from unrelated PRs; regenerating it here would have added 260 lines of unrelated churn, so I left it. Nothing in CI enforces its freshness.

## Design review

The status-code contract was reviewed by an independent Codex pass (read-only, `xhigh`) before implementation. It agreed on direction and sharpened three things, all adopted: 422 reserved for *known* refusals with unclassified failures degrading to 500; `code` made mandatory once several conditions share 503; and the fix extended to the bulk and parse paths rather than just `mapCommandFailure`. It also flagged the `buildSingleItemUploadBody` 504 coupling and the #4025 fall-through, both of which I verified independently against the code.

## Verification

| suite | result |
|---|---|
| API `systemTools` + `devices` + `remote` + filesystem cap | **727 passed** |
| `fileBrowserHelpers.test.ts` | **45 passed** |
| Web `FileManager.test.tsx` | **8 passed** |
| Web i18n (parity / coverage / terminology / extraction / keyUsage) | **111 passed** |
| `packages/shared` | **2066 passed** |
| Go `remote/tools`, `websocket`, `wire` | **ok** |
| `tsc --noEmit -p apps/api` | clean |

Both new guards were **revert-probed** — disabling the pre-flight fails the over-cap test, and drifting the shared constant fails the Go pin.

> Note for monitoring: agent refusals move from 5xx to 4xx. That's the point — "file too large" was never a server fault — but it will show up in the response-class metrics in `metrics.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
