### PR TITLE
fix(web): react to late-arriving JWT scope in ticketing tabs + patch approval (#4013)

### DIFF
--- a/apps/web/src/components/patches/PatchApprovalModal.coldLoad.test.tsx
+++ b/apps/web/src/components/patches/PatchApprovalModal.coldLoad.test.tsx
@@ -1,0 +1,129 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@/lib/i18n';
+
+// #4013. PatchApprovalModal.test.tsx mocks `lib/authScope` with a scope that is
+// already known on the first render — the one state a cold page load never
+// starts in. Access tokens are deliberately never persisted (`partialize` in
+// stores/auth.ts keeps only `user` + `isAuthenticated`), so at first paint the
+// store is empty and EVERY user decodes as `scope: null`.
+//
+// It matters HERE and not only in principle because PatchesPage renders this
+// modal UNCONDITIONALLY — `<PatchApprovalModal open={modalOpen} patch={...} />`
+// sits in the page body, not behind `{modalOpen && ...}`, and PatchesPage has no
+// early return in front of it. So the modal's first render happens during the
+// page's cold load, with `patch={null}`, long before anyone opens it. Hooks run
+// on that render, which is why the old
+// `useMemo(() => getJwtClaims().scope === 'organization', [])` captured the
+// empty-store answer and pinned `isOrgScope=false` for the life of the PAGE.
+//
+// Every case below therefore mounts the modal CLOSED first and opens it later,
+// which is the sequence the app actually produces, and mocks neither `authScope`
+// nor the auth store.
+
+vi.mock('../../stores/auth', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../stores/auth')>()),
+  fetchWithAuth: vi.fn(),
+}));
+
+import PatchApprovalModal from './PatchApprovalModal';
+import { useAuthStore } from '../../stores/auth';
+
+const PATCH = {
+  id: 'patch-1',
+  title: 'Security Update',
+  severity: 'critical' as const,
+  source: 'Microsoft',
+  os: 'Windows',
+  releaseDate: '2026-04-01T00:00:00.000Z',
+  approvalStatus: 'pending' as const,
+};
+
+function makeToken(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).replace(/=/g, '');
+  const body = btoa(JSON.stringify(payload)).replace(/=/g, '');
+  return `${header}.${body}.sig`;
+}
+
+/** Simulate /auth/refresh returning an access token some time after first paint. */
+function tokenArrives(payload: Record<string, unknown>) {
+  act(() => {
+    useAuthStore.setState({ tokens: { accessToken: makeToken(payload), expiresInSeconds: 900 } });
+  });
+}
+
+const PARTNER_LEVEL = /patch approvals are managed at the partner level/i;
+
+describe('PatchApprovalModal vs. late-arriving JWT scope (#4013)', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ tokens: null });
+  });
+
+  afterEach(() => {
+    useAuthStore.setState({ tokens: null });
+  });
+
+  it('org scope arriving after the page mounted the closed modal: explains the denial and disables Approve', async () => {
+    // The exact sequence a cold load of /patches produces for an org-scoped
+    // user. THE REGRESSION: with the frozen memo the scope was captured here,
+    // from an empty store, and stayed `not organization` for the whole page —
+    // so this user was handed an enabled Approve button and no explanation, and
+    // only found out it was refused after clicking through the confirm dialog.
+    const { rerender } = render(<PatchApprovalModal open={false} patch={null} onClose={() => {}} />);
+
+    tokenArrives({ scope: 'organization', orgId: 'org-1' });
+
+    rerender(<PatchApprovalModal open patch={PATCH} ringId={null} onClose={() => {}} />);
+
+    expect(await screen.findByText(PARTNER_LEVEL)).toBeInTheDocument();
+    const submit = screen.getByTestId('patch-approval-submit');
+    expect(submit).toBeDisabled();
+    expect(submit).toHaveAttribute('title', 'Patch approvals are managed at the partner level');
+  });
+
+  it('partner scope arriving after the closed mount: Approve becomes available, with no false denial', async () => {
+    const { rerender } = render(<PatchApprovalModal open={false} patch={null} onClose={() => {}} />);
+
+    tokenArrives({ scope: 'partner', partnerId: 'partner-1' });
+
+    rerender(<PatchApprovalModal open patch={PATCH} ringId={null} onClose={() => {}} />);
+
+    await waitFor(() => expect(screen.getByTestId('patch-approval-submit')).not.toBeDisabled());
+    expect(screen.queryByText(PARTNER_LEVEL)).toBeNull();
+    expect(screen.getByTestId('patch-approval-submit')).not.toHaveAttribute('title');
+  });
+
+  it('unresolved scope: Approve is withheld, but NOT as a partner-level denial', async () => {
+    // The third state has to render as its own thing. Disabling submit is the
+    // fail-closed half (an unknown scope is not a grant); withholding the
+    // "managed at the partner level" banner is the honest half — we have not
+    // been told no, we have not been told anything.
+    render(<PatchApprovalModal open patch={PATCH} ringId={null} onClose={() => {}} />);
+
+    const submit = await screen.findByTestId('patch-approval-submit');
+    expect(submit).toBeDisabled();
+    expect(submit).toHaveAttribute('title', 'Checking your access...');
+    expect(screen.queryByText(PARTNER_LEVEL)).toBeNull();
+
+    tokenArrives({ scope: 'partner', partnerId: 'partner-1' });
+
+    await waitFor(() => expect(screen.getByTestId('patch-approval-submit')).not.toBeDisabled());
+  });
+
+  it('a present-but-undecodable token resolves without claiming a partner-level denial', async () => {
+    render(<PatchApprovalModal open patch={PATCH} ringId={null} onClose={() => {}} />);
+    expect(await screen.findByTestId('patch-approval-submit')).toBeDisabled();
+
+    act(() => {
+      useAuthStore.setState({ tokens: { accessToken: 'not-a-jwt', expiresInSeconds: 900 } });
+    });
+
+    // Resolved, and NOT org-scoped — so the gate matches what `handleSubmit` and
+    // the server enforce, both of which key on `scope === 'organization'`. This
+    // is deliberately unchanged by the fix: telling someone whose token cannot
+    // be decoded that "approvals are managed at the partner level" would be a
+    // wrong explanation for what is really a 401 on the next request.
+    await waitFor(() => expect(screen.getByTestId('patch-approval-submit')).not.toBeDisabled());
+    expect(screen.queryByText(PARTNER_LEVEL)).toBeNull();
+  });
+});

--- a/apps/web/src/components/patches/PatchApprovalModal.coldLoad.test.tsx
+++ b/apps/web/src/components/patches/PatchApprovalModal.coldLoad.test.tsx
@@ -76,6 +76,7 @@ describe('PatchApprovalModal vs. late-arriving JWT scope (#4013)', () => {
     rerender(<PatchApprovalModal open patch={PATCH} ringId={null} onClose={() => {}} />);
 
     expect(await screen.findByText(PARTNER_LEVEL)).toBeInTheDocument();
+    expect(screen.getByTestId('patch-approval-scope-notice')).toHaveTextContent(PARTNER_LEVEL);
     const submit = screen.getByTestId('patch-approval-submit');
     expect(submit).toBeDisabled();
     expect(submit).toHaveAttribute('title', 'Patch approvals are managed at the partner level');
@@ -104,10 +105,37 @@ describe('PatchApprovalModal vs. late-arriving JWT scope (#4013)', () => {
     expect(submit).toBeDisabled();
     expect(submit).toHaveAttribute('title', 'Checking your access...');
     expect(screen.queryByText(PARTNER_LEVEL)).toBeNull();
+    // ...and the reason is VISIBLE, not tooltip-only: a disabled button is out
+    // of the tab order and has no hover on touch, so `title` alone would leave
+    // the modal reading as broken rather than busy.
+    expect(screen.getByTestId('patch-approval-scope-notice')).toHaveTextContent('Checking your access...');
 
     tokenArrives({ scope: 'partner', partnerId: 'partner-1' });
 
     await waitFor(() => expect(screen.getByTestId('patch-approval-submit')).not.toBeDisabled());
+    expect(screen.queryByTestId('patch-approval-scope-notice')).toBeNull();
+  });
+
+  it('a token going away again re-withholds Approve instead of keeping the stale grant', async () => {
+    // #4013 was a "this value never updates" bug, so pin the reverse direction
+    // too: the grant must not outlive the token that justified it. In practice
+    // the only path that nulls an in-memory token mid-session is logout
+    // (stores/auth.ts — a failed/throttled refresh never calls setTokens(null)),
+    // and every logout path navigates away, so this is a guard against a future
+    // regression rather than a live sequence.
+    render(<PatchApprovalModal open patch={PATCH} ringId={null} onClose={() => {}} />);
+
+    tokenArrives({ scope: 'partner', partnerId: 'partner-1' });
+    await waitFor(() => expect(screen.getByTestId('patch-approval-submit')).not.toBeDisabled());
+
+    act(() => {
+      useAuthStore.setState({ tokens: null });
+    });
+
+    await waitFor(() => expect(screen.getByTestId('patch-approval-submit')).toBeDisabled());
+    // Back to pending, NOT to a denial we were never told about.
+    expect(screen.getByTestId('patch-approval-scope-notice')).toHaveTextContent('Checking your access...');
+    expect(screen.queryByText(PARTNER_LEVEL)).toBeNull();
   });
 
   it('a present-but-undecodable token resolves without claiming a partner-level denial', async () => {

--- a/apps/web/src/components/patches/PatchApprovalModal.test.tsx
+++ b/apps/web/src/components/patches/PatchApprovalModal.test.tsx
@@ -9,9 +9,17 @@ vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
 }));
 
-vi.mock('../../lib/authScope', () => ({
-  getJwtClaims: vi.fn(),
-}));
+// Every case in this file describes an already-WARM page: the scope is known
+// before the modal renders, so `useJwtClaims` simply reports the same claims as
+// resolved. The cold-load window (`status: 'unresolved'`) is what
+// PatchApprovalModal.coldLoad.test.tsx covers, driving the real auth store.
+vi.mock('../../lib/authScope', () => {
+  const getJwtClaims = vi.fn();
+  return {
+    getJwtClaims,
+    useJwtClaims: () => ({ status: 'resolved' as const, claims: getJwtClaims() }),
+  };
+});
 
 import { getJwtClaims } from '../../lib/authScope';
 const getJwtClaimsMock = vi.mocked(getJwtClaims);

--- a/apps/web/src/components/patches/PatchApprovalModal.tsx
+++ b/apps/web/src/components/patches/PatchApprovalModal.tsx
@@ -8,7 +8,7 @@ import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, ActionError } from '@/lib/runAction';
-import { getJwtClaims } from '../../lib/authScope';
+import { getJwtClaims, useJwtClaims } from '../../lib/authScope';
 
 export type PatchApprovalAction = 'approve' | 'decline' | 'defer';
 
@@ -84,20 +84,44 @@ export default function PatchApprovalModal({
   const isSubmitting = useMemo(() => loading ?? submitting, [loading, submitting]);
   // Approval is partner-scoped. Partner/system users can approve partner-wide
   // (no ring) or ring-scoped (ring selected). Org-scoped users cannot approve.
-  const isOrgScope = useMemo(() => getJwtClaims().scope === 'organization', []);
+  //
+  // THREE states, not two (#4013). PatchesPage renders this modal
+  // UNCONDITIONALLY — it is not behind `{modalOpen && ...}` — so it first
+  // renders during the page's cold load, long before the user opens it and
+  // before /auth/refresh has produced an access token. Access tokens are never
+  // persisted, so at that moment every user decodes as `scope: null`. The
+  // previous `useMemo(() => getJwtClaims().scope === 'organization', [])` froze
+  // that answer for the life of the PAGE, so an org-scoped user who cold-loaded
+  // /patches was shown an enabled Approve button with no explanation.
+  //
+  // 'unresolved' is neither: not a denial (no "partner level" banner — we have
+  // not been told no), and not a grant (submit stays disabled — we have not been
+  // told yes). Only a resolved org scope is a denial, which keeps the predicate
+  // identical to the one `handleSubmit` and the server enforce.
+  const jwt = useJwtClaims();
+  const approvalScope: 'unresolved' | 'orgScoped' | 'eligible' =
+    jwt.status === 'unresolved'
+      ? 'unresolved'
+      : jwt.claims.scope === 'organization'
+        ? 'orgScoped'
+        : 'eligible';
+  const isOrgScope = approvalScope === 'orgScoped';
   const canSubmit = useMemo(() => {
     if (isSubmitting) return false;
-    if (isOrgScope) return false;
+    if (approvalScope !== 'eligible') return false;
     if (action !== 'defer') return true;
     return deferUntil.trim().length > 0;
-  }, [action, deferUntil, isSubmitting, isOrgScope]);
+  }, [action, deferUntil, isSubmitting, approvalScope]);
 
   if (!patch) return null;
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
     // Approval is partner-scoped. Org-scoped users cannot approve — block early
-    // before opening the approve confirm dialog.
+    // before opening the approve confirm dialog. The one-shot read is correct
+    // HERE (and only here): an event handler wants the scope as of the click,
+    // and the answer cannot outlive the call. Render-time gates use the reactive
+    // `useJwtClaims()` above.
     const { scope } = getJwtClaims();
     if (scope === 'organization') {
       setSubmitError(t('patchApprovalModal.errors.partnerLevel'));
@@ -263,7 +287,13 @@ export default function PatchApprovalModal({
             onClick={handleSubmit}
             disabled={!canSubmit}
             data-testid="patch-approval-submit"
-            title={isOrgScope ? t('patchApprovalModal.errors.partnerLevel') : undefined}
+            title={
+              isOrgScope
+                ? t('patchApprovalModal.errors.partnerLevel')
+                : approvalScope === 'unresolved'
+                  ? t('patchApprovalModal.checkingAccess')
+                  : undefined
+            }
             className="h-10 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <span className="inline-flex items-center gap-2">

--- a/apps/web/src/components/patches/PatchApprovalModal.tsx
+++ b/apps/web/src/components/patches/PatchApprovalModal.tsx
@@ -96,22 +96,28 @@ export default function PatchApprovalModal({
   //
   // 'unresolved' is neither: not a denial (no "partner level" banner — we have
   // not been told no), and not a grant (submit stays disabled — we have not been
-  // told yes). Only a resolved org scope is a denial, which keeps the predicate
-  // identical to the one `handleSubmit` and the server enforce.
+  // told yes). Only a resolved org scope is 'denied', which keeps this gate on
+  // the same predicate `handleSubmit` and the server enforce.
+  //
+  // Note the deliberate contrast with `ringAccess` in PatchesPage.tsx, which
+  // looks like the same pattern and treats one case the opposite way: a resolved
+  // but UNDECODABLE token (all-null claims) is 'denied' there and 'allowed'
+  // here. That is not drift. `ringAccess` gates visibility of a whole feature
+  // surface with no matching server predicate to mirror, so the conservative
+  // default is to hide it. This gates one mutating action whose server-side rule
+  // already exists, so inventing a stricter client rule would show a false "you
+  // cannot do this" for a case the server does not actually reject on scope —
+  // it rejects the broken token itself, with a 401. Do not "harmonize" these
+  // two without reading both.
   const jwt = useJwtClaims();
-  const approvalScope: 'unresolved' | 'orgScoped' | 'eligible' =
-    jwt.status === 'unresolved'
-      ? 'unresolved'
-      : jwt.claims.scope === 'organization'
-        ? 'orgScoped'
-        : 'eligible';
-  const isOrgScope = approvalScope === 'orgScoped';
+  const approvalAccess: 'unresolved' | 'allowed' | 'denied' =
+    jwt.status === 'unresolved' ? 'unresolved' : jwt.claims.scope === 'organization' ? 'denied' : 'allowed';
   const canSubmit = useMemo(() => {
     if (isSubmitting) return false;
-    if (approvalScope !== 'eligible') return false;
+    if (approvalAccess !== 'allowed') return false;
     if (action !== 'defer') return true;
     return deferUntil.trim().length > 0;
-  }, [action, deferUntil, isSubmitting, approvalScope]);
+  }, [action, deferUntil, isSubmitting, approvalAccess]);
 
   if (!patch) return null;
 
@@ -261,9 +267,19 @@ export default function PatchApprovalModal({
           </div>
         )}
 
-        {isOrgScope && !submitError && (
-          <div className="mt-4 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
-            {t('patchApprovalModal.errors.partnerLevel')}
+        {/* Both non-'allowed' states disable submit, so both owe the user a
+            VISIBLE reason. A disabled button is out of the tab order in every
+            major browser and has no hover on touch, so the `title` below can
+            never be the only explanation — that would make the modal read as
+            broken rather than busy. */}
+        {approvalAccess !== 'allowed' && !submitError && (
+          <div
+            data-testid="patch-approval-scope-notice"
+            className="mt-4 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning-foreground"
+          >
+            {approvalAccess === 'denied'
+              ? t('patchApprovalModal.errors.partnerLevel')
+              : t('patchApprovalModal.checkingAccess')}
           </div>
         )}
 
@@ -288,9 +304,9 @@ export default function PatchApprovalModal({
             disabled={!canSubmit}
             data-testid="patch-approval-submit"
             title={
-              isOrgScope
+              approvalAccess === 'denied'
                 ? t('patchApprovalModal.errors.partnerLevel')
-                : approvalScope === 'unresolved'
+                : approvalAccess === 'unresolved'
                   ? t('patchApprovalModal.checkingAccess')
                   : undefined
             }

--- a/apps/web/src/components/patches/PatchesPage.scopeResolution.test.tsx
+++ b/apps/web/src/components/patches/PatchesPage.scopeResolution.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@/lib/i18n';
 
@@ -212,5 +212,76 @@ describe('PatchesPage #rings deep link vs. late-arriving JWT scope (#4010)', () 
 
     await waitFor(() => expect(navTab('Update Rings')).toHaveClass('border-primary'));
     expect(window.location.hash).toBe('#rings');
+  });
+});
+
+// PatchesPage renders <PatchApprovalModal> UNCONDITIONALLY — it sits in the page
+// body, not behind `{modalOpen && ...}`, and nothing returns early in front of
+// it. So the modal's own hooks run during this cold load, with `patch={null}`,
+// long before anyone opens it. That is what made #4013's second site genuinely
+// reachable rather than merely fragile: its
+// `useMemo(() => getJwtClaims().scope === 'organization', [])` captured the
+// empty-store answer HERE and kept it for the life of the page, so the org user
+// who eventually opened the modal was offered an Approve button the API refuses.
+describe('PatchApprovalModal opened after a cold load of PatchesPage (#4013)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    orgState.currentOrgId = 'org-1';
+    useAuthStore.setState({ tokens: null });
+    window.history.replaceState({}, '', '/#patches');
+    fetchMock.mockImplementation(async (input: unknown) => {
+      if (String(input) === '/patches?limit=200') {
+        return makeJsonResponse({
+          data: [
+            {
+              id: 'patch-1',
+              title: 'Security Update',
+              severity: 'critical',
+              source: 'Microsoft',
+              os: 'Windows',
+              releaseDate: '2026-04-01T00:00:00.000Z',
+              approvalStatus: 'pending',
+            },
+          ],
+        });
+      }
+      return emptyDataFetch(input);
+    });
+  });
+
+  afterEach(() => {
+    useAuthStore.setState({ tokens: null });
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('org scope arriving after the page mounted: the modal still explains the partner-level denial', async () => {
+    render(<PatchesPage />);
+    // The modal has already mounted (and, before the fix, already frozen its
+    // scope) by the time this row is on screen.
+    await waitFor(() => expect(navTab('Patches')).toHaveClass('border-primary'));
+
+    tokenArrives({ scope: 'organization', orgId: 'org-1' });
+
+    // ResponsiveTable renders a table row AND a card for the same patch; either
+    // affordance opens the same modal.
+    fireEvent.click((await screen.findAllByTestId('patch-row-patch-1-review'))[0]);
+
+    expect(await screen.findByText(/patch approvals are managed at the partner level/i)).toBeInTheDocument();
+    expect(screen.getByTestId('patch-approval-submit')).toBeDisabled();
+  });
+
+  it('partner scope arriving after the page mounted: the modal offers Approve', async () => {
+    orgState.currentOrgId = null;
+    render(<PatchesPage />);
+    await waitFor(() => expect(navTab('Patches')).toHaveClass('border-primary'));
+
+    tokenArrives({ scope: 'partner', partnerId: 'p-1' });
+
+    // ResponsiveTable renders a table row AND a card for the same patch; either
+    // affordance opens the same modal.
+    fireEvent.click((await screen.findAllByTestId('patch-row-patch-1-review'))[0]);
+
+    await waitFor(() => expect(screen.getByTestId('patch-approval-submit')).not.toBeDisabled());
+    expect(screen.queryByText(/patch approvals are managed at the partner level/i)).toBeNull();
   });
 });

--- a/apps/web/src/components/settings/TicketingSettingsTabs.coldLoad.test.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.coldLoad.test.tsx
@@ -1,0 +1,174 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@/lib/i18n';
+
+// #4013. TicketingSettingsTabs.test.tsx mocks `lib/authScope` with a partner
+// scope that is already known on the first render — which is exactly the state a
+// cold page load does NOT start in. Access tokens are deliberately never
+// persisted (`partialize` in stores/auth.ts keeps only `user` +
+// `isAuthenticated`), so at first paint the store is empty and EVERY user
+// decodes as `scope: null`.
+//
+// This suite therefore mocks neither `authScope` nor the auth store: it drives
+// the real `useJwtClaims` against the real store so the token genuinely arrives
+// after mount, which is the only way to pin the bug. The gate used to be
+// `useMemo(() => getJwtClaims().scope === 'partner', [])`, whose empty dep array
+// froze the empty-store answer for the life of the mount — so Intake Forms,
+// Inbound Email and Canned Responses stayed hidden from partner users forever,
+// on precisely the surface the permanent `/settings/ticketing` 301 and the M365
+// consent return both land on.
+
+const { grantedActions } = vi.hoisted(() => ({ grantedActions: new Set<string>() }));
+vi.mock('../../lib/permissions', () => ({
+  usePermissions: () => ({
+    can: (resource: string, action: string) => grantedActions.has(`${resource}:${action}`),
+  }),
+}));
+
+// Stub child components — this suite is about the scope gate, not the cards.
+vi.mock('./TicketCategoriesPage', () => ({ default: () => <div data-testid="stub-ticket-categories-page" /> }));
+vi.mock('./BillablesExportCard', () => ({ default: () => <div data-testid="stub-billables-export-card" /> }));
+vi.mock('./TicketStatusesTab', () => ({ default: () => <div data-testid="stub-ticket-statuses-tab" /> }));
+vi.mock('./TicketPrioritiesTab', () => ({ default: () => <div data-testid="stub-ticket-priorities-tab" /> }));
+vi.mock('./InboundEmailCard', () => ({ default: () => <div data-testid="stub-inbound-email-card" /> }));
+vi.mock('./M365MailboxCard', () => ({ default: () => <div data-testid="m365-mailbox-card" /> }));
+vi.mock('./CannedResponsesCard', () => ({ default: () => <div data-testid="stub-canned-responses-card" /> }));
+vi.mock('./TicketFormsCard', () => ({ default: () => <div data-testid="stub-ticket-forms-card" /> }));
+
+import TicketingSettingsTabs from './TicketingSettingsTabs';
+import { useAuthStore } from '../../stores/auth';
+import { i18n } from '@/lib/i18n';
+
+function makeToken(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).replace(/=/g, '');
+  const body = btoa(JSON.stringify(payload)).replace(/=/g, '');
+  return `${header}.${body}.sig`;
+}
+
+/** Simulate /auth/refresh returning an access token some time after first paint. */
+function tokenArrives(payload: Record<string, unknown>) {
+  act(() => {
+    useAuthStore.setState({ tokens: { accessToken: makeToken(payload), expiresInSeconds: 900 } });
+  });
+}
+
+const PARTNER_ONLY = [
+  { tab: 'forms', panel: 'ticketing-tab-panel-forms', card: 'stub-ticket-forms-card' },
+  { tab: 'inbound', panel: 'ticketing-tab-panel-inbound', card: 'stub-inbound-email-card' },
+  { tab: 'canned', panel: 'ticketing-tab-panel-canned', card: 'stub-canned-responses-card' },
+] as const;
+
+describe('TicketingSettingsTabs vs. late-arriving JWT scope (#4013)', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+    grantedActions.clear();
+    useAuthStore.setState({ tokens: null });
+    window.location.hash = '';
+  });
+
+  afterEach(async () => {
+    useAuthStore.setState({ tokens: null });
+    window.location.hash = '';
+    await i18n.changeLanguage('en');
+  });
+
+  it('partner scope arriving after first paint reveals all three partner-only tabs', async () => {
+    render(<TicketingSettingsTabs />);
+
+    // First paint: no token, so the scope is unknown. The tabs fail closed —
+    // an unknown scope is never treated as a grant.
+    expect(await screen.findByTestId('ticketing-tab-statuses')).toBeInTheDocument();
+    for (const { tab } of PARTNER_ONLY) {
+      expect(screen.queryByTestId(`ticketing-tab-${tab}`)).toBeNull();
+    }
+    // The default tab is not partner-only, so there is nothing pending to say.
+    expect(screen.queryByTestId('ticketing-tab-panel-pending')).toBeNull();
+
+    tokenArrives({ scope: 'partner', partnerId: 'partner-1' });
+
+    // THE REGRESSION: with the frozen memo these never appeared, at all, ever.
+    for (const { tab } of PARTNER_ONLY) {
+      await waitFor(() => expect(screen.getByTestId(`ticketing-tab-${tab}`)).toBeInTheDocument());
+    }
+    // The four base tabs are still there — the gate only ever adds.
+    expect(screen.getByTestId('ticketing-tab-export')).toBeInTheDocument();
+  });
+
+  it.each(PARTNER_ONLY)(
+    '#tab=$tab deep link on a cold load: shows a pending placeholder, then the real panel once the token lands',
+    async ({ tab, panel, card }) => {
+      window.location.hash = `#tab=${tab}`;
+
+      render(<TicketingSettingsTabs />);
+
+      // The deep-linked sub-tab survives the unresolved window (nothing here
+      // rewrites the hash), but its body cannot render yet. Rather than an
+      // indefinite blank area, say the answer is still pending — that is the
+      // ONLY thing distinguishing 'unresolved' from a settled 'denied'.
+      expect(await screen.findByTestId('ticketing-tab-panel-pending')).toBeInTheDocument();
+      expect(screen.queryByTestId(panel)).toBeNull();
+      expect(screen.queryByTestId(card)).toBeNull();
+      expect(window.location.hash).toBe(`#tab=${tab}`);
+
+      tokenArrives({ scope: 'partner', partnerId: 'partner-1' });
+
+      await waitFor(() => expect(screen.getByTestId(panel)).toBeInTheDocument());
+      expect(screen.getByTestId(card)).toBeInTheDocument();
+      expect(screen.queryByTestId('ticketing-tab-panel-pending')).toBeNull();
+    },
+  );
+
+  it('M365 consent return (initialTab=inbound, embedded): pending, then the inbound card', async () => {
+    // PartnerSettingsPage passes initialTab='inbound' when it sees the
+    // ?ticketMailbox= deep link. That is a full-page navigation back from
+    // Microsoft, so it is always a cold load — the worst case for the old memo,
+    // which left the user staring at an empty Ticketing tab.
+    render(<TicketingSettingsTabs syncHash={false} initialTab="inbound" />);
+
+    expect(await screen.findByTestId('ticketing-tab-panel-pending')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-inbound-email-card')).toBeNull();
+
+    tokenArrives({ scope: 'partner', partnerId: 'partner-1' });
+
+    await waitFor(() => expect(screen.getByTestId('stub-inbound-email-card')).toBeInTheDocument());
+    expect(screen.queryByTestId('ticketing-tab-panel-pending')).toBeNull();
+    // The separate ticket_mailbox:read gate is unaffected by the scope fix.
+    expect(screen.queryByTestId('m365-mailbox-card')).toBeNull();
+  });
+
+  it('org scope arriving after first paint keeps the partner-only tabs hidden, and stops saying "pending"', async () => {
+    window.location.hash = '#tab=inbound';
+
+    render(<TicketingSettingsTabs />);
+    expect(await screen.findByTestId('ticketing-tab-panel-pending')).toBeInTheDocument();
+
+    tokenArrives({ scope: 'organization', orgId: 'org-1' });
+
+    // Settled denial: the placeholder goes away (we are no longer waiting for an
+    // answer) and nothing partner-only is offered. Reactivity must not become a
+    // grant for the wrong scope — this is the other direction of the fix.
+    await waitFor(() => expect(screen.queryByTestId('ticketing-tab-panel-pending')).toBeNull());
+    for (const { tab, panel } of PARTNER_ONLY) {
+      expect(screen.queryByTestId(`ticketing-tab-${tab}`)).toBeNull();
+      expect(screen.queryByTestId(panel)).toBeNull();
+    }
+    expect(screen.getByTestId('ticketing-tab-statuses')).toBeInTheDocument();
+  });
+
+  it('a present-but-undecodable token is a settled denial, not a permanent "pending"', async () => {
+    window.location.hash = '#tab=canned';
+    render(<TicketingSettingsTabs />);
+    expect(await screen.findByTestId('ticketing-tab-panel-pending')).toBeInTheDocument();
+
+    act(() => {
+      useAuthStore.setState({ tokens: { accessToken: 'not-a-jwt', expiresInSeconds: 900 } });
+    });
+
+    // We looked and the answer is "no claims" — resolved, and fails closed. The
+    // server rejects such a token with a 401 rather than degrading the page, so
+    // the user is on their way out anyway; what matters is that we do not spin.
+    await waitFor(() => expect(screen.queryByTestId('ticketing-tab-panel-pending')).toBeNull());
+    expect(screen.queryByTestId('ticketing-tab-canned')).toBeNull();
+    expect(screen.queryByTestId('ticketing-tab-panel-canned')).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/TicketingSettingsTabs.coldLoad.test.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.coldLoad.test.tsx
@@ -155,6 +155,55 @@ describe('TicketingSettingsTabs vs. late-arriving JWT scope (#4013)', () => {
     expect(screen.getByTestId('ticketing-tab-statuses')).toBeInTheDocument();
   });
 
+  it('a hashchange onto a partner-only sub-tab during the unresolved window defers rather than denies', async () => {
+    // Browser back/forward can land on a partner-only sub-tab before the refresh
+    // round trip has finished. The hashchange listener runs the same parseHash
+    // as mount, so the gate must reach the same pending state that way too.
+    render(<TicketingSettingsTabs />);
+    expect(await screen.findByTestId('ticketing-tab-panel-statuses')).toBeInTheDocument();
+
+    act(() => {
+      window.location.hash = '#tab=canned';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+
+    expect(screen.getByTestId('ticketing-tab-panel-pending')).toBeInTheDocument();
+    expect(screen.queryByTestId('ticketing-tab-canned')).toBeNull();
+    expect(window.location.hash).toBe('#tab=canned');
+
+    tokenArrives({ scope: 'partner', partnerId: 'partner-1' });
+
+    await waitFor(() => expect(screen.getByTestId('stub-canned-responses-card')).toBeInTheDocument());
+    expect(window.location.hash).toBe('#tab=canned');
+  });
+
+  it('a token going away again re-hides the partner-only tabs instead of keeping the stale grant', async () => {
+    // #4013 was a "this value never updates" bug, so pin the reverse direction
+    // too. In practice the only path that nulls an in-memory token mid-session
+    // is logout (stores/auth.ts — a failed or throttled refresh never calls
+    // setTokens(null)), and every logout path navigates away; this is a guard
+    // against a future regression, not a live sequence.
+    window.location.hash = '#tab=inbound';
+    render(<TicketingSettingsTabs />);
+
+    tokenArrives({ scope: 'partner', partnerId: 'partner-1' });
+    await waitFor(() => expect(screen.getByTestId('stub-inbound-email-card')).toBeInTheDocument());
+
+    act(() => {
+      useAuthStore.setState({ tokens: null });
+    });
+
+    // Back to pending, NOT to a denial we were never told about — and the
+    // deep-linked sub-tab is still in the URL, so the grant restores in place.
+    await waitFor(() => expect(screen.getByTestId('ticketing-tab-panel-pending')).toBeInTheDocument());
+    expect(screen.queryByTestId('stub-inbound-email-card')).toBeNull();
+    expect(screen.queryByTestId('ticketing-tab-inbound')).toBeNull();
+    expect(window.location.hash).toBe('#tab=inbound');
+
+    tokenArrives({ scope: 'partner', partnerId: 'partner-1' });
+    await waitFor(() => expect(screen.getByTestId('stub-inbound-email-card')).toBeInTheDocument());
+  });
+
   it('a present-but-undecodable token is a settled denial, not a permanent "pending"', async () => {
     window.location.hash = '#tab=canned';
     render(<TicketingSettingsTabs />);

--- a/apps/web/src/components/settings/TicketingSettingsTabs.test.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.test.tsx
@@ -2,7 +2,17 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { grantedActions } = vi.hoisted(() => ({ grantedActions: new Set<string>() }));
-vi.mock('../../lib/authScope', () => ({ getJwtClaims: () => ({ scope: 'partner' }) }));
+// Every case in this file describes an already-WARM page: the partner scope is
+// known before the group renders. The cold-load window (`status: 'unresolved'`,
+// which is where every direct landing on this surface actually starts) is what
+// TicketingSettingsTabs.coldLoad.test.tsx covers, driving the real auth store.
+vi.mock('../../lib/authScope', () => {
+  const claims = { scope: 'partner' as const, orgId: null, partnerId: 'partner-1' };
+  return {
+    getJwtClaims: () => claims,
+    useJwtClaims: () => ({ status: 'resolved' as const, claims }),
+  };
+});
 vi.mock('../../lib/permissions', () => ({
   usePermissions: () => ({
     can: (resource: string, action: string) => grantedActions.has(`${resource}:${action}`),

--- a/apps/web/src/components/settings/TicketingSettingsTabs.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.tsx
@@ -9,11 +9,15 @@ import InboundEmailCard from './InboundEmailCard';
 import M365MailboxCard from './M365MailboxCard';
 import CannedResponsesCard from './CannedResponsesCard';
 import TicketFormsCard from './TicketFormsCard';
-import { getJwtClaims } from '../../lib/authScope';
+import { useJwtClaims } from '../../lib/authScope';
 import { usePermissions } from '../../lib/permissions';
 
 const VALID_TABS = ['statuses', 'priorities', 'categories', 'forms', 'export', 'inbound', 'canned'] as const;
 type Tab = (typeof VALID_TABS)[number];
+
+// The sub-tabs that only exist for partner-scoped users. Declared once so the
+// tab list, the panel gates and the "still resolving" placeholder can't drift.
+const PARTNER_ONLY_TABS: readonly Tab[] = ['forms', 'inbound', 'canned'];
 
 // Inbound email settings + queue are a partner-scoped surface (the queue routes
 // are additionally admin-gated server-side). The mailbox card has a separate
@@ -77,7 +81,26 @@ export default function TicketingSettingsTabs({
   // Render the Inbound Email tab only for partner-scoped users (matches how the
   // Sidebar gates other partner-only settings surfaces). Decoded client-side as
   // a UX hint only — the server re-checks every request.
-  const canManageInbound = useMemo(() => getJwtClaims().scope === 'partner', []);
+  //
+  // THREE states, not two (#4013). Access tokens are deliberately never
+  // persisted (`partialize` in stores/auth.ts keeps only `user` +
+  // `isAuthenticated`), so on every cold load the store is empty and EVERY user
+  // decodes as `scope: null`. `'unresolved'` therefore means "not known yet",
+  // never "denied". It also has to stay REACTIVE: this was a
+  // `useMemo(() => getJwtClaims().scope === 'partner', [])`, which froze the
+  // empty-store answer for the life of the mount and so hid all three
+  // partner-only tabs, permanently, from any partner user who landed here
+  // directly — which is exactly what the permanent `/settings/ticketing` → 301
+  // and the M365 consent return both do.
+  const jwt = useJwtClaims();
+  const inboundAccess: 'unresolved' | 'allowed' | 'denied' =
+    jwt.status === 'unresolved' ? 'unresolved' : jwt.claims.scope === 'partner' ? 'allowed' : 'denied';
+  // Both non-'allowed' states fail closed for rendering — an unknown scope is
+  // never treated as a grant. What they must NOT share is the *explanation*:
+  // 'denied' is a settled answer, 'unresolved' is a pending one, and only the
+  // latter gets the placeholder below. Nothing here writes the URL or discards
+  // state, so there is no #4010-style destructive branch to defer.
+  const canManageInbound = inboundAccess === 'allowed';
   // Canned responses + intake forms (like inbound) are partner-scoped surfaces —
   // the CRUD routes require partner scope server-side, and intake forms can be
   // authored partner-wide ("All orgs"). The standalone TicketingSettingsTabs
@@ -132,6 +155,17 @@ export default function TicketingSettingsTabs({
           </button>
         ))}
       </div>
+
+      {/* Deep-linked onto a partner-only sub-tab before the scope is known: say
+          the answer is pending instead of leaving an indefinite blank body. The
+          M365 consent return lands here (`initialTab='inbound'` from
+          PartnerSettingsPage) on a cold load, as does a `#tab=` deep link. A
+          settled 'denied' deliberately renders nothing, as before. */}
+      {inboundAccess === 'unresolved' && PARTNER_ONLY_TABS.includes(activeTab) && (
+        <div data-testid="ticketing-tab-panel-pending" className="text-sm text-muted-foreground">
+          {t('ticketingSettingsTabs.checkingAccess')}
+        </div>
+      )}
 
       {activeTab === 'statuses' && (
         <div data-testid="ticketing-tab-panel-statuses">

--- a/apps/web/src/components/settings/TicketingSettingsTabs.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.tsx
@@ -15,11 +15,15 @@ import { usePermissions } from '../../lib/permissions';
 const VALID_TABS = ['statuses', 'priorities', 'categories', 'forms', 'export', 'inbound', 'canned'] as const;
 type Tab = (typeof VALID_TABS)[number];
 
-// The sub-tabs that only exist for partner-scoped users. The tab list below is
-// BUILT from this and the pending-placeholder gate reads its ids, so those two
-// cannot drift. The three panel bodies are still written out individually —
-// each mounts a different card — and share the one `canManageInbound` gate
-// rather than this list.
+// The sub-tabs that only exist for partner-scoped users. The tab list is BUILT
+// from this and the pending-placeholder gate reads its ids, so those two cannot
+// drift. The three panel bodies are still written out individually — each
+// mounts a different card — and share the one `canManageInbound` gate rather
+// than this list.
+//
+// Inbound email settings + queue are a partner-scoped surface (the queue routes
+// are additionally admin-gated server-side). The mailbox card has a separate
+// ticket_mailbox:read UX gate; every API route remains authoritative.
 const PARTNER_ONLY_TABS: Array<{ id: Tab; labelKey: string }> = [
   { id: 'forms', labelKey: 'ticketingSettingsTabs.intakeForms' },
   { id: 'inbound', labelKey: 'ticketingSettingsTabs.inboundEmail' },
@@ -27,9 +31,7 @@ const PARTNER_ONLY_TABS: Array<{ id: Tab; labelKey: string }> = [
 ];
 const PARTNER_ONLY_TAB_IDS: readonly Tab[] = PARTNER_ONLY_TABS.map((tab) => tab.id);
 
-// Inbound email settings + queue are a partner-scoped surface (the queue routes
-// are additionally admin-gated server-side). The mailbox card has a separate
-// ticket_mailbox:read UX gate; every API route remains authoritative.
+// Shown to every scope. The partner-only tabs above are appended to these.
 const BASE_TABS: Array<{ id: Tab; labelKey: string }> = [
   { id: 'statuses', labelKey: 'ticketingSettingsTabs.statuses' },
   { id: 'priorities', labelKey: 'ticketingSettingsTabs.prioritiesSLAs' },

--- a/apps/web/src/components/settings/TicketingSettingsTabs.tsx
+++ b/apps/web/src/components/settings/TicketingSettingsTabs.tsx
@@ -15,9 +15,17 @@ import { usePermissions } from '../../lib/permissions';
 const VALID_TABS = ['statuses', 'priorities', 'categories', 'forms', 'export', 'inbound', 'canned'] as const;
 type Tab = (typeof VALID_TABS)[number];
 
-// The sub-tabs that only exist for partner-scoped users. Declared once so the
-// tab list, the panel gates and the "still resolving" placeholder can't drift.
-const PARTNER_ONLY_TABS: readonly Tab[] = ['forms', 'inbound', 'canned'];
+// The sub-tabs that only exist for partner-scoped users. The tab list below is
+// BUILT from this and the pending-placeholder gate reads its ids, so those two
+// cannot drift. The three panel bodies are still written out individually —
+// each mounts a different card — and share the one `canManageInbound` gate
+// rather than this list.
+const PARTNER_ONLY_TABS: Array<{ id: Tab; labelKey: string }> = [
+  { id: 'forms', labelKey: 'ticketingSettingsTabs.intakeForms' },
+  { id: 'inbound', labelKey: 'ticketingSettingsTabs.inboundEmail' },
+  { id: 'canned', labelKey: 'ticketingSettingsTabs.cannedResponses' }
+];
+const PARTNER_ONLY_TAB_IDS: readonly Tab[] = PARTNER_ONLY_TABS.map((tab) => tab.id);
 
 // Inbound email settings + queue are a partner-scoped surface (the queue routes
 // are additionally admin-gated server-side). The mailbox card has a separate
@@ -78,9 +86,14 @@ export default function TicketingSettingsTabs({
   const { can } = usePermissions();
   const canReadMailbox = can('ticket_mailbox', 'read');
 
-  // Render the Inbound Email tab only for partner-scoped users (matches how the
-  // Sidebar gates other partner-only settings surfaces). Decoded client-side as
-  // a UX hint only — the server re-checks every request.
+  // Gate Inbound Email, Intake Forms and Canned Responses on partner scope
+  // (matching how the Sidebar gates other partner-only settings surfaces): all
+  // three have CRUD routes that require partner scope server-side, and intake
+  // forms can be authored partner-wide ("All orgs"). BASE_TABS renders for any
+  // scope, so these three are added on top rather than gated out of it.
+  // Decoded client-side as a UX hint only — the server re-checks every request,
+  // and org-owned forms are still creatable here via the form editor's org
+  // selector.
   //
   // THREE states, not two (#4013). Access tokens are deliberately never
   // persisted (`partialize` in stores/auth.ts keeps only `user` +
@@ -101,22 +114,12 @@ export default function TicketingSettingsTabs({
   // latter gets the placeholder below. Nothing here writes the URL or discards
   // state, so there is no #4010-style destructive branch to defer.
   const canManageInbound = inboundAccess === 'allowed';
-  // Canned responses + intake forms (like inbound) are partner-scoped surfaces —
-  // the CRUD routes require partner scope server-side, and intake forms can be
-  // authored partner-wide ("All orgs"). The standalone TicketingSettingsTabs
-  // renders BASE_TABS for any scope, so gate these on partner scope rather than
-  // leaving them in BASE_TABS. Org-owned forms are still creatable here via the
-  // form editor's org selector.
   const TABS = useMemo(
     () =>
-      canManageInbound
-        ? [
-            ...BASE_TABS.map((tab) => ({ ...tab, label: t(/* i18n-dynamic */ tab.labelKey) })),
-            { id: 'forms' as Tab, labelKey: 'ticketingSettingsTabs.intakeForms', label: t('ticketingSettingsTabs.intakeForms') },
-            { id: 'inbound' as Tab, labelKey: 'ticketingSettingsTabs.inboundEmail', label: t('ticketingSettingsTabs.inboundEmail') },
-            { id: 'canned' as Tab, labelKey: 'ticketingSettingsTabs.cannedResponses', label: t('ticketingSettingsTabs.cannedResponses') }
-          ]
-        : BASE_TABS.map((tab) => ({ ...tab, label: t(/* i18n-dynamic */ tab.labelKey) })),
+      [...BASE_TABS, ...(canManageInbound ? PARTNER_ONLY_TABS : [])].map((tab) => ({
+        ...tab,
+        label: t(/* i18n-dynamic */ tab.labelKey)
+      })),
     [canManageInbound, t]
   );
 
@@ -156,12 +159,23 @@ export default function TicketingSettingsTabs({
         ))}
       </div>
 
-      {/* Deep-linked onto a partner-only sub-tab before the scope is known: say
-          the answer is pending instead of leaving an indefinite blank body. The
-          M365 consent return lands here (`initialTab='inbound'` from
-          PartnerSettingsPage) on a cold load, as does a `#tab=` deep link. A
-          settled 'denied' deliberately renders nothing, as before. */}
-      {inboundAccess === 'unresolved' && PARTNER_ONLY_TABS.includes(activeTab) && (
+      {/* Deep-linked onto a partner-only sub-tab before the scope is known (a
+          `#tab=` link, or `initialTab='inbound'` from PartnerSettingsPage on the
+          M365 consent return): say the answer is pending rather than render an
+          unexplained blank body.
+          On an ordinary cold load this is rarely what the user is looking at —
+          AuthOverlay masks the whole window while the access token is absent
+          (`shouldHide` requires `tokens?.accessToken`). Keep it regardless: it
+          is the ONLY DOM difference between 'unresolved' and 'denied', so
+          without it nothing would notice a future "simplification" back to a
+          boolean; and it is the sole cue on the one path AuthOverlay does not
+          re-arm for — a token cleared after the overlay has already faded out
+          for this mount.
+          A settled 'denied' still renders nothing, as before. That leaves a
+          pre-existing gap (an org user who hand-crafts `#tab=inbound` gets a
+          blank body rather than "no access"), deliberately untouched here: it
+          is not what #4013 broke. */}
+      {inboundAccess === 'unresolved' && PARTNER_ONLY_TAB_IDS.includes(activeTab) && (
         <div data-testid="ticketing-tab-panel-pending" className="text-sm text-muted-foreground">
           {t('ticketingSettingsTabs.checkingAccess')}
         </div>

--- a/apps/web/src/locales/de-DE/patches.json
+++ b/apps/web/src/locales/de-DE/patches.json
@@ -37,7 +37,8 @@
       "selectedOrganization": "der ausgewählten Organisation",
       "messageOne": "Patch auf {{count}} Gerät in {{org}} freigeben?",
       "messageMany": "Patch auf {{count}} Geräten in {{org}} freigeben?"
-    }
+    },
+    "checkingAccess": "Zugriff wird geprüft..."
   },
   "patchComplianceView": {
     "unknownDevice": "Unbekannt",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -2419,7 +2419,8 @@
     "categories": "Kategorien",
     "export": "Exportieren",
     "inboundEmail": "Eingehende E-Mail",
-    "cannedResponses": "Vorgefertigte Antworten"
+    "cannedResponses": "Vorgefertigte Antworten",
+    "checkingAccess": "Zugriff wird geprüft..."
   },
   "ticketFormsCard": {
     "heading": "Aufnahmeformulare",

--- a/apps/web/src/locales/en/patches.json
+++ b/apps/web/src/locales/en/patches.json
@@ -37,7 +37,8 @@
       "selectedOrganization": "the selected organization",
       "messageOne": "Approve patch on {{count}} device in {{org}}?",
       "messageMany": "Approve patch on {{count}} devices in {{org}}?"
-    }
+    },
+    "checkingAccess": "Checking your access..."
   },
   "patchComplianceView": {
     "unknownDevice": "Unknown",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -2472,7 +2472,8 @@
     "categories": "Categories",
     "export": "Export",
     "inboundEmail": "Inbound Email",
-    "cannedResponses": "Canned responses"
+    "cannedResponses": "Canned responses",
+    "checkingAccess": "Checking your access..."
   },
   "ticketFormsCard": {
     "heading": "Intake forms",

--- a/apps/web/src/locales/es-419/patches.json
+++ b/apps/web/src/locales/es-419/patches.json
@@ -37,7 +37,8 @@
       "selectedOrganization": "la organización seleccionada",
       "messageOne": "¿Aprobar el parche en el dispositivo {{count}} en {{org}}?",
       "messageMany": "¿Aprobar el parche en dispositivos {{count}} en {{org}}?"
-    }
+    },
+    "checkingAccess": "Verificando tu acceso..."
   },
   "patchComplianceView": {
     "unknownDevice": "Desconocido",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -2419,7 +2419,8 @@
     "categories": "Categorías",
     "export": "Exportar",
     "inboundEmail": "Correo electrónico entrante",
-    "cannedResponses": "Respuestas enlatadas"
+    "cannedResponses": "Respuestas enlatadas",
+    "checkingAccess": "Verificando tu acceso..."
   },
   "ticketFormsCard": {
     "heading": "Formularios de admisión",

--- a/apps/web/src/locales/fr-CA/patches.json
+++ b/apps/web/src/locales/fr-CA/patches.json
@@ -37,7 +37,8 @@
       "selectedOrganization": "l’organisation sélectionnée",
       "messageOne": "Approuver le correctif sur {{count}} appareil dans {{org}} ?",
       "messageMany": "Approuver le correctif sur {{count}} appareils dans {{org}} ?"
-    }
+    },
+    "checkingAccess": "Vérification de votre accès..."
   },
   "patchComplianceView": {
     "unknownDevice": "Inconnu",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -2467,7 +2467,8 @@
     "categories": "Catégories",
     "export": "Exporter",
     "inboundEmail": "Courriel entrant",
-    "cannedResponses": "Réponses préfabriquées"
+    "cannedResponses": "Réponses préfabriquées",
+    "checkingAccess": "Vérification de votre accès..."
   },
   "ticketFormsCard": {
     "heading": "Formulaires d’admission",

--- a/apps/web/src/locales/fr-FR/patches.json
+++ b/apps/web/src/locales/fr-FR/patches.json
@@ -37,7 +37,8 @@
       "selectedOrganization": "l’organisation sélectionnée",
       "messageOne": "Approuver le correctif sur {{count}} appareil dans {{org}} ?",
       "messageMany": "Approuver le correctif sur {{count}} appareils dans {{org}} ?"
-    }
+    },
+    "checkingAccess": "Vérification de votre accès..."
   },
   "patchComplianceView": {
     "unknownDevice": "Inconnu",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -2419,7 +2419,8 @@
     "categories": "Catégories",
     "export": "Exporter",
     "inboundEmail": "Email entrant",
-    "cannedResponses": "Réponses préfabriquées"
+    "cannedResponses": "Réponses préfabriquées",
+    "checkingAccess": "Vérification de votre accès..."
   },
   "ticketFormsCard": {
     "heading": "Formulaires d’admission",

--- a/apps/web/src/locales/it-IT/patches.json
+++ b/apps/web/src/locales/it-IT/patches.json
@@ -37,7 +37,8 @@
       "selectedOrganization": "l'organizzazione selezionata",
       "messageOne": "Approvare la patch su {{count}} dispositivo in {{org}}?",
       "messageMany": "Approvare la patch su {{count}} dispositivi in {{org}}?"
-    }
+    },
+    "checkingAccess": "Verifica dell’accesso in corso..."
   },
   "patchComplianceView": {
     "unknownDevice": "Sconosciuto",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -2467,7 +2467,8 @@
     "categories": "Categorie",
     "export": "Esporta",
     "inboundEmail": "Email in ingresso",
-    "cannedResponses": "Risposte predefinite"
+    "cannedResponses": "Risposte predefinite",
+    "checkingAccess": "Verifica dell’accesso in corso..."
   },
   "ticketFormsCard": {
     "heading": "Moduli di raccolta",

--- a/apps/web/src/locales/pt-BR/patches.json
+++ b/apps/web/src/locales/pt-BR/patches.json
@@ -37,7 +37,8 @@
       "selectedOrganization": "a organização selecionada",
       "messageOne": "Aprovar patch em {{count}} dispositivo em {{org}}?",
       "messageMany": "Aprovar patch em {{count}} dispositivos em {{org}}?"
-    }
+    },
+    "checkingAccess": "Verificando seu acesso..."
   },
   "patchComplianceView": {
     "unknownDevice": "Desconhecido",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -2472,7 +2472,8 @@
     "categories": "Categorias",
     "export": "Exportar",
     "inboundEmail": "E-mail de entrada",
-    "cannedResponses": "Respostas prontas"
+    "cannedResponses": "Respostas prontas",
+    "checkingAccess": "Verificando seu acesso..."
   },
   "ticketFormsCard": {
     "heading": "Formulários de abertura",

--- a/apps/web/src/locales/tr-TR/patches.json
+++ b/apps/web/src/locales/tr-TR/patches.json
@@ -37,7 +37,8 @@
       "selectedOrganization": "seçilen kuruluş",
       "messageOne": "{{count}} cihazındaki yamayı {{org}}'de onaylasın mı?",
       "messageMany": "{{count}} cihazlarda {{org}} içindeki yama onaylansın mı?"
-    }
+    },
+    "checkingAccess": "Erişiminiz kontrol ediliyor..."
   },
   "patchComplianceView": {
     "unknownDevice": "Bilinmiyor",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -2472,7 +2472,8 @@
     "categories": "Kategoriler",
     "export": "Dışa aktar",
     "inboundEmail": "Gelen E-posta",
-    "cannedResponses": "Hazır yanıtlar"
+    "cannedResponses": "Hazır yanıtlar",
+    "checkingAccess": "Erişiminiz kontrol ediliyor..."
   },
   "ticketFormsCard": {
     "heading": "Başvuru formları",


### PR DESCRIPTION
## Problem

Two components read the JWT scope into a `useMemo` with an **empty dependency array**, so the value is computed once, on the component's first render. Access tokens are deliberately never persisted (`partialize` in `stores/auth.ts` keeps only `user` and `isAuthenticated`), so on every cold load that first render happens with an empty store and **every** user decodes as `scope: null`. The memo never recomputes, so the empty-store answer is pinned for the life of the mount.

`grep -rn "useMemo(() => getJwtClaims" apps/web/src` returns exactly these two, across 31 `getJwtClaims()` call sites. Both are fixed here.

### 1. `TicketingSettingsTabs.tsx:80` — confirmed live, and it fails in the user's face

`canManageInbound` pinned `false` hides **Intake Forms**, **Inbound Email** and **Canned Responses** from partner users — not just the panels, the tab bar entries too. A reload does not help; only navigating in from an already-warm session does.

Two entry points land there cold by design:

- `pages/settings/ticketing.astro` is a permanent 301 to `/settings/partner#ticketing` (#1327), so every old bookmark is a cold load;
- `PartnerSettingsPage.tsx:684` passes `initialTab='inbound'` on the M365 consent return (`?ticketMailbox=…`), which is a full-page navigation back from Microsoft — i.e. always cold. That user landed on the Inbound sub-tab with an **empty body and no error**.

To be precise about *when* the user sees this: `AuthOverlay` masks the whole window while the access token is absent, so the unresolved window itself is generally hidden. The harm is what is on screen **after** the overlay lifts — the memo has already frozen by then and never recomputes, so the tabs are missing for the rest of the mount. Review round 1 corrected an earlier version of this section that implied users watch a blank body during the token round trip.

### 2. `PatchApprovalModal.tsx:87` — the issue graded this "probably not reachable". It is reachable.

The comment on #4013 reasoned that a modal only opens after interaction, by which point the token has arrived. That is true of the *open*, but not of the *mount*: `PatchesPage.tsx:902` renders `<PatchApprovalModal>` **unconditionally** — it sits in the page body, not behind `{modalOpen && ...}` — and PatchesPage has no early return in front of it (one `return (` at `:737`). `patches/index.astro` hydrates it `client:load`, and `DashboardLayout` puts `AuthOverlay` beside the slot rather than wrapping it. `if (!patch) return null` sits *after* the hooks, so they run anyway.

So the modal's first render is the page's cold load, and that is where the memo froze. For an org-scoped user who cold-loads `/patches`, `isOrgScope` stays `false` for the life of the page: `canSubmit` (`:90`) enables Approve, the partner-level explainer (`:240`) never renders, and the disabled-button tooltip (`:266`) is absent. They are offered an Approve button, click through the scope-naming confirm dialog, and only then get told no.

**It is not an authorization hole.** `handleSubmit` re-reads the scope live and blocks the submit, and the server re-checks every request. The damage is that the refusal arrives as an error after the click instead of as an explanation before it.

This is demonstrated end-to-end, not argued: the new `PatchesPage.scopeResolution.test.tsx` case drives the real page with the real auth store and **fails against the current code**.

## Fix

Both sites move to `useJwtClaims()` — added by #4012 (`lib/authScope.ts`) for exactly this failure mode. It subscribes to the access token and returns a discriminated `{ status: 'unresolved' } | { status: 'resolved'; claims }`. `getJwtClaims()` is untouched (~30 other callers), and no second reactive-claims abstraction was introduced.

Neither site collapses the three states back to two, and they resolve the unknown window **differently**, because what they gate is different:

**`TicketingSettingsTabs`** keeps `inboundAccess: 'unresolved' | 'allowed' | 'denied'`, and the partner-only tab list is now *built* from one `PARTNER_ONLY_TABS` constant that the placeholder gate also reads. Both non-`'allowed'` states fail closed for *rendering* — an unknown scope is never a grant, so the partner-only tabs stay out of the tab bar either way. What they do not share is the *explanation*: when the active sub-tab is partner-only and the scope is still unresolved, a small "Checking your access..." placeholder renders instead of a blank body. Given the AuthOverlay note above, that placeholder is mostly a backstop rather than a common sight — it is kept because it is the only DOM difference between `'unresolved'` and `'denied'`, without which nothing would notice a future collapse back to a boolean. A settled `'denied'` renders nothing, exactly as before. Nothing in this component writes the URL or discards state, so there is no #4010-style destructive branch that needs deferring — the hash survives the unresolved window untouched, which the tests pin.

**`PatchApprovalModal`** keeps `approvalAccess: 'unresolved' | 'allowed' | 'denied'` (named for parity with `ringAccess` and `inboundAccess`).

- `'unresolved'` **disables submit** — an unknown scope is not a grant, so we do not offer an Approve the API would refuse;
- `'unresolved'` **does not** show the "managed at the partner level" banner. It gets a neutral "Checking your access..." one in the same slot instead — we have not been told no, and asserting a denial we have not received is the same class of mistake as #4010 in the other direction. Both non-`'allowed'` states get a *visible* reason rather than a `title` tooltip alone, since a disabled button is out of the tab order and has no hover on touch (review round 1).
- Only a *resolved* org scope is a denial. That keeps the render gate byte-identical to the predicate `handleSubmit` and the server enforce (`scope === 'organization'`).

A present-but-undecodable token is `'resolved'` with all-null claims, so it stays `'allowed'` here — deliberately unchanged, and deliberately the opposite of what `ringAccess` does with the same input (a cross-reference comment now records why, so the two are not "harmonized" by mistake). Telling someone whose token cannot be decoded that "approvals are managed at the partner level" would be the wrong explanation for what is really a 401 on their next request; the server refuses it either way. Pinned by a test so the choice is visible rather than incidental.

`getJwtClaims()` stays in `handleSubmit`, which is where a one-shot read is the *correct* shape — an event handler wants the scope as of the click and the answer cannot outlive the call.

### Not widened

The sweep also turns up render-time reads that are not memoized (`CatalogItemsTab.tsx:66`, `CatalogSettingsPage.tsx:13`, `SsoProvidersPage.tsx:42`, …). Those recompute on every render, so they are a weaker shape than this one — they self-heal on any incidental re-render rather than freezing forever. They are worth a separate pass, not a silent widening of this PR.

Also left alone: a **pre-existing** gap where a settled `'denied'` on a partner-only sub-tab renders a blank body (an org user who hand-crafts `#tab=inbound`). Raised in review, and real — but it is not what #4013 broke, and it needs its own copy decision. Recorded in a code comment.

## Tests

Two new suites plus two cases on an existing one. All three mock **neither** `authScope` nor the auth store — they drive the real `useJwtClaims` against the real store so the token genuinely arrives after mount, which is the only way to reproduce this. (The pre-existing suites for both components mock `authScope` with a scope that is *already known on the first render*, i.e. the one state a cold load never starts in. That is why the bug shipped past them.)

- **`TicketingSettingsTabs.coldLoad.test.tsx`** (9 cases) — partner scope arriving after first paint reveals all three tabs; `#tab=forms|inbound|canned` deep links show the pending placeholder and then the real panel; the M365 `initialTab='inbound'` path; org scope arriving after first paint keeps the tabs hidden *and* stops saying "pending"; a `hashchange` onto a partner-only sub-tab during the unresolved window defers rather than denies; a token going away again re-hides rather than keeping a stale grant; an undecodable token is a settled denial rather than a permanent spinner.
- **`PatchApprovalModal.coldLoad.test.tsx`** (5 cases) — each mounts the modal **closed with `patch={null}` first** and opens it later, which is the sequence the page actually produces. Covers org-after-mount, partner-after-mount, the unresolved window (disabled but not denied, with a *visible* reason), a token going away again, and the undecodable token.
- **`PatchesPage.scopeResolution.test.tsx`** (+2 cases) — the reachability proof: cold-load the real page, let the token land, click Review, assert what the modal offers.

**Revert probe** (restore both `useMemo(..., [])` lines, keep the tests):

| Suite | Result against reverted code |
|---|---|
| `TicketingSettingsTabs.coldLoad` | **9 of 9 fail** |
| `PatchApprovalModal.coldLoad` | **4 of 5 fail** |
| `PatchesPage.scopeResolution` (new cases) | **1 of 2 fails** |

The one that passes either way in each of those suites is the partner-scope-arrives case, and that is expected rather than a gap: a frozen `false` and a correctly-resolved partner scope reach the *same* final state (Approve enabled, no banner). Their job is the other direction — proving the fix does not over-correct into blocking legitimate partner users. The unresolved window itself, which is the only place those two differ, is covered by its own discriminating case.

## Verification

- full `apps/web` suite → **640 files, 6506 tests passed**
- `astro check` → **0 errors** (1684 files)
- `eslint` on all changed/added `.tsx` files → clean

Rebased onto current `main` (`1fd01dbb9`). The branch was originally cut at `9ff8b0f1a`, which predates #4023's fix for `DevicesPage.test.tsx` — the two failures that file showed locally reproduce with this PR's changes reverted, so they were inherited from the stale base, not caused here. Green across the board after the rebase.

Locale parity: the new `checkingAccess` key is added to `settings.json` and `patches.json` in all 8 locales (en, de-DE, es-419, fr-CA, fr-FR, it-IT, pt-BR, tr-TR); `localeParity.test.ts` passes.

Closes #4013

🤖 Generated with [Claude Code](https://claude.com/claude-code)
