### PR TITLE
fix(web): stop the grid DeviceCard offering agent actions for network assets (#4014)

### DIFF
--- a/apps/web/src/components/devices/DeviceCard.networkClass.test.tsx
+++ b/apps/web/src/components/devices/DeviceCard.networkClass.test.tsx
@@ -1,0 +1,163 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceCard from './DeviceCard';
+import type { Device } from './DeviceList';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown): Response =>
+  ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+const agentDevice: Device = {
+  id: '11111111-1111-1111-1111-111111111111',
+  deviceClass: 'agent',
+  hostname: 'edge-01',
+  os: 'windows',
+  osVersion: '11',
+  status: 'online',
+  cpuPercent: 58,
+  ramPercent: 71,
+  lastSeen: '2026-02-09T10:00:00.000Z',
+  orgId: 'org-1',
+  orgName: 'Org One',
+  siteId: 'site-1',
+  siteName: 'HQ',
+  agentVersion: '1.0.0',
+  tags: []
+};
+
+// Shaped exactly like DevicesPage's `transformedNetworkDevices` mapping: the
+// `id` is a `discovered_assets.id`, os/agentVersion are blank, and cpu/ram are
+// filled with a placeholder 0 that must never be presented as a reading.
+const networkPrinter: Device = {
+  id: '22222222-2222-2222-2222-222222222222',
+  deviceClass: 'network',
+  assetType: 'printer',
+  hostname: 'Lobby Printer',
+  os: '' as Device['os'],
+  osVersion: '',
+  status: 'online',
+  cpuPercent: 0,
+  ramPercent: 0,
+  lastSeen: '2026-02-09T10:00:00.000Z',
+  orgId: 'org-1',
+  orgName: 'Org One',
+  siteId: 'site-1',
+  siteName: 'HQ',
+  agentVersion: '',
+  tags: [],
+  manufacturer: 'HP',
+  model: 'LaserJet',
+  monitoringEnabled: true
+};
+
+// #4014: DeviceCard had no `deviceClass` handling at all, so the grid offered
+// Terminal / Run Script / Reboot / Settings / Remove for network-discovered
+// assets. A network row's `id` is a `discovered_assets.id`, NOT a `devices.id`
+// (#1322) — every one of those actions posts a foreign id at a /devices/:id
+// endpoint. The list row already collapses to a single "View" button
+// (DeviceList.tsx), and the grid card must match it.
+describe('DeviceCard network-class guard (#4014)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ metrics: [] }));
+  });
+
+  it('renders a View button instead of the actions kebab for a network row', () => {
+    render(<DeviceCard device={networkPrinter} />);
+
+    expect(screen.getByTestId(`device-${networkPrinter.id}-open-network`)).toBeInTheDocument();
+    // The kebab trigger itself must be gone — not merely emptied — so there is
+    // no path to the agent menu at all.
+    expect(screen.queryByTestId(`device-${networkPrinter.id}-actions-menu`)).toBeNull();
+    expect(screen.queryByLabelText(`Actions for ${networkPrinter.hostname}`)).toBeNull();
+  });
+
+  it('reuses the list row\'s "View" copy (deviceList.view), not a new string', () => {
+    render(<DeviceCard device={networkPrinter} />);
+
+    expect(screen.getByTestId(`device-${networkPrinter.id}-open-network`).textContent?.trim()).toBe('View');
+  });
+
+  it('routes the View button to onClick (the network detail page) with the device', () => {
+    const onClick = vi.fn();
+    render(<DeviceCard device={networkPrinter} onClick={onClick} />);
+
+    fireEvent.click(screen.getByTestId(`device-${networkPrinter.id}-open-network`));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledWith(networkPrinter);
+  });
+
+  it('exposes exactly one control on a network card, and it is View — never an agent action', () => {
+    const onAction = vi.fn();
+    render(<DeviceCard device={networkPrinter} onAction={onAction} />);
+
+    // Asserting the *count and identity* of controls (rather than the absence
+    // of the menu items) keeps this non-vacuous: before the fix there is also
+    // exactly one button, but it is the kebab trigger, not View.
+    const controls = screen.getAllByRole('button');
+    expect(controls).toHaveLength(1);
+    expect(controls[0]).toHaveAttribute('data-testid', `device-${networkPrinter.id}-open-network`);
+
+    // The one control that does exist cannot dispatch an agent action.
+    fireEvent.click(controls[0]);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch /devices/:id/metrics with a discovered_assets id', async () => {
+    render(<DeviceCard device={networkPrinter} />);
+
+    // Give the mount effect a turn to fire before asserting it did not.
+    await waitFor(() => {
+      expect(screen.getByTestId(`device-${networkPrinter.id}-open-network`)).toBeInTheDocument();
+    });
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('renders CPU/RAM as an em-dash for a network row instead of a fabricated 0%', () => {
+    render(<DeviceCard device={networkPrinter} />);
+
+    expect(screen.queryByText('0%')).toBeNull();
+    expect(screen.getAllByText('—')).toHaveLength(2);
+    expect(screen.queryByTestId(`cpu-sparkline-${networkPrinter.id}`)).toBeNull();
+    expect(screen.queryByTestId(`ram-sparkline-${networkPrinter.id}`)).toBeNull();
+    // No "Loading trend..." limbo either — the fetch never starts.
+    expect(screen.queryByText('Loading trend...')).toBeNull();
+  });
+
+  it('leaves the agent card untouched: full kebab, no View button, metrics still fetched', async () => {
+    render(<DeviceCard device={agentDevice} onAction={vi.fn()} />);
+
+    expect(screen.queryByTestId(`device-${agentDevice.id}-open-network`)).toBeNull();
+    fireEvent.click(screen.getByLabelText(`Actions for ${agentDevice.hostname}`));
+
+    expect(screen.getByRole('button', { name: /remote terminal/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /run script/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^reboot/i })).toBeInTheDocument();
+    expect(screen.getByTestId(`device-${agentDevice.id}-action-remove`)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(`/devices/${agentDevice.id}/metrics?range=1h`);
+    });
+  });
+
+  it('treats a row with no deviceClass as an agent (default), keeping the kebab', () => {
+    const legacy: Device = { ...agentDevice, deviceClass: undefined };
+    render(<DeviceCard device={legacy} onAction={vi.fn()} />);
+
+    expect(screen.queryByTestId(`device-${legacy.id}-open-network`)).toBeNull();
+    expect(screen.getByTestId(`device-${legacy.id}-actions-menu`)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/devices/DeviceCard.networkClass.test.tsx
+++ b/apps/web/src/components/devices/DeviceCard.networkClass.test.tsx
@@ -153,6 +153,42 @@ describe('DeviceCard network-class guard (#4014)', () => {
     });
   });
 
+  // Review finding: with the kebab and the metrics gone, nothing on the card
+  // said WHY it looked different from its siblings — a printer rendered the
+  // generic monitor glyph, a blank OS line and two dashes, which reads as a
+  // broken agent. The list answers that with a Class badge; the grid now does
+  // too, with the same copy and testid.
+  it('explains itself with the list\'s own Network class badge', () => {
+    render(<DeviceCard device={networkPrinter} />);
+
+    const badge = screen.getByTestId(`device-${networkPrinter.id}-class-badge`);
+    expect(badge.textContent?.trim()).toBe('Network');
+    expect(badge).toHaveAttribute('title', 'Network-discovered device');
+  });
+
+  it('does not badge an agent card', () => {
+    render(<DeviceCard device={agentDevice} />);
+
+    expect(screen.queryByTestId(`device-${agentDevice.id}-class-badge`)).toBeNull();
+    // The agent card keeps the OS version line the badge replaces.
+    expect(screen.getByText('11')).toBeInTheDocument();
+  });
+
+  // The metrics effect gained `isNetwork` in its dependency array. Cards are
+  // keyed by device.id so this transition does not happen in the real grid,
+  // but dropping the dep would leave the fetch permanently skipped for a
+  // component that later becomes an agent — silent and invisible.
+  it('starts fetching metrics if the same card instance becomes an agent', async () => {
+    const { rerender } = render(<DeviceCard device={networkPrinter} />);
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+
+    rerender(<DeviceCard device={{ ...networkPrinter, deviceClass: 'agent' }} />);
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(`/devices/${networkPrinter.id}/metrics?range=1h`);
+    });
+  });
+
   it('treats a row with no deviceClass as an agent (default), keeping the kebab', () => {
     const legacy: Device = { ...agentDevice, deviceClass: undefined };
     render(<DeviceCard device={legacy} onAction={vi.fn()} />);

--- a/apps/web/src/components/devices/DeviceCard.tsx
+++ b/apps/web/src/components/devices/DeviceCard.tsx
@@ -152,7 +152,20 @@ export default function DeviceCard({
   const effectiveTimezone =
     timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
 
+  // #4014: this card had no `deviceClass` handling at all, so the grid offered
+  // the full agent kebab for network-discovered assets. A `network` row's `id`
+  // is a `discovered_assets.id`, NOT a `devices.id` (#1322) — every action here
+  // posts that foreign id at a `/devices/:id` endpoint, where it resolves to no
+  // row and 404s. The list row already collapses to a single "View"
+  // (DeviceList.tsx); the grid card mirrors that treatment exactly, reusing the
+  // same `deviceList.view` copy and `-open-network` test id.
+  const isNetwork = (device.deviceClass ?? "agent") === "network";
+
   useEffect(() => {
+    // A discovered asset has no agent and no metric history; firing the request
+    // anyway is a guaranteed 404 on every card mount.
+    if (isNetwork) return;
+
     let isCancelled = false;
 
     const loadHistory = async () => {
@@ -189,7 +202,7 @@ export default function DeviceCard({
     return () => {
       isCancelled = true;
     };
-  }, [device.id]);
+  }, [device.id, isNetwork]);
 
   const cpuHistory =
     historyState === "ready" ? metricHistory.map((point) => point.cpu) : [];
@@ -240,204 +253,241 @@ export default function DeviceCard({
             <p className="text-xs text-muted-foreground">{device.osVersion}</p>
           </div>
         </div>
-        <div className="relative">
+        {isNetwork ? (
+          // Mirrors DeviceList.tsx's network row: the whole action surface
+          // collapses to one "View", which opens the read-only network detail
+          // page (DevicesPage.handleSelectDevice routes `network` there).
           <button
             type="button"
-            data-testid={`device-${device.id}-actions-menu`}
+            data-testid={`device-${device.id}-open-network`}
             onClick={(e) => {
               e.stopPropagation();
-              setMenuOpen(!menuOpen);
+              onClick?.(device);
             }}
-            aria-label={`Actions for ${device.hostname}`}
-            className="flex h-8 w-8 items-center justify-center rounded-md opacity-40 transition hover:bg-muted hover:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            className="rounded-md border px-2.5 py-1 text-xs font-medium text-muted-foreground hover:bg-muted"
           >
-            <MoreVertical className="h-4 w-4" />
+            {t("deviceList.view")}
           </button>
-          {menuOpen && (
-            <div className="absolute right-0 top-full z-10 mt-1 w-48 rounded-md border bg-card shadow-lg">
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onAction?.("terminal", device);
-                  setMenuOpen(false);
-                }}
-                disabled={!online}
-                title={liveSessionTitle}
-                aria-describedby={!online ? gateHintId : undefined}
-                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
-              >
-                <Terminal className="h-4 w-4" />
-                {t("deviceCard.remoteTerminal")}{" "}
-              </button>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onAction?.("run-script", device);
-                  setMenuOpen(false);
-                }}
-                disabled={!commandQueueable}
-                title={queuedCommandTitle}
-                aria-describedby={!commandQueueable ? gateHintId : undefined}
-                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
-              >
-                <FileCode className="h-4 w-4" />
-                {t("deviceCard.runScript")}{" "}
-              </button>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onAction?.("reboot", device);
-                  setMenuOpen(false);
-                }}
-                disabled={!commandQueueable}
-                title={queuedCommandTitle}
-                aria-describedby={!commandQueueable ? gateHintId : undefined}
-                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
-              >
-                <RotateCcw className="h-4 w-4" />
-                {t("deviceCard.reboot")}{" "}
-              </button>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onAction?.("settings", device);
-                  setMenuOpen(false);
-                }}
-                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted"
-              >
-                <Settings className="h-4 w-4" />
-                {t("deviceCard.settings")}{" "}
-              </button>
-              <hr className="my-1" />
-              {device.status === "decommissioned" ? (
-                <>
+        ) : (
+          <div className="relative">
+            <button
+              type="button"
+              data-testid={`device-${device.id}-actions-menu`}
+              onClick={(e) => {
+                e.stopPropagation();
+                setMenuOpen(!menuOpen);
+              }}
+              aria-label={`Actions for ${device.hostname}`}
+              className="flex h-8 w-8 items-center justify-center rounded-md opacity-40 transition hover:bg-muted hover:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <MoreVertical className="h-4 w-4" />
+            </button>
+            {menuOpen && (
+              <div className="absolute right-0 top-full z-10 mt-1 w-48 rounded-md border bg-card shadow-lg">
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAction?.("terminal", device);
+                    setMenuOpen(false);
+                  }}
+                  disabled={!online}
+                  title={liveSessionTitle}
+                  aria-describedby={!online ? gateHintId : undefined}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
+                >
+                  <Terminal className="h-4 w-4" />
+                  {t("deviceCard.remoteTerminal")}{" "}
+                </button>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAction?.("run-script", device);
+                    setMenuOpen(false);
+                  }}
+                  disabled={!commandQueueable}
+                  title={queuedCommandTitle}
+                  aria-describedby={!commandQueueable ? gateHintId : undefined}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
+                >
+                  <FileCode className="h-4 w-4" />
+                  {t("deviceCard.runScript")}{" "}
+                </button>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAction?.("reboot", device);
+                    setMenuOpen(false);
+                  }}
+                  disabled={!commandQueueable}
+                  title={queuedCommandTitle}
+                  aria-describedby={!commandQueueable ? gateHintId : undefined}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
+                >
+                  <RotateCcw className="h-4 w-4" />
+                  {t("deviceCard.reboot")}{" "}
+                </button>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAction?.("settings", device);
+                    setMenuOpen(false);
+                  }}
+                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-muted"
+                >
+                  <Settings className="h-4 w-4" />
+                  {t("deviceCard.settings")}{" "}
+                </button>
+                <hr className="my-1" />
+                {device.status === "decommissioned" ? (
+                  <>
+                    <button
+                      type="button"
+                      data-testid={`device-${device.id}-action-restore`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onAction?.("restore", device);
+                        setMenuOpen(false);
+                      }}
+                      className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-success hover:bg-success/10"
+                    >
+                      <RotateCcw className="h-4 w-4" />
+                      {t("deviceCard.restore")}{" "}
+                    </button>
+                    <button
+                      type="button"
+                      data-testid={`device-${device.id}-action-permanent-delete`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onAction?.("permanent-delete", device);
+                        setMenuOpen(false);
+                      }}
+                      className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-destructive hover:bg-destructive/10"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      {t("deviceCard.permanentlyDelete")}
+                    </button>
+                  </>
+                ) : (
                   <button
                     type="button"
-                    data-testid={`device-${device.id}-action-restore`}
+                    data-testid={`device-${device.id}-action-remove`}
                     onClick={(e) => {
                       e.stopPropagation();
-                      onAction?.("restore", device);
-                      setMenuOpen(false);
-                    }}
-                    className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-success hover:bg-success/10"
-                  >
-                    <RotateCcw className="h-4 w-4" />
-                    {t("deviceCard.restore")}{" "}
-                  </button>
-                  <button
-                    type="button"
-                    data-testid={`device-${device.id}-action-permanent-delete`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onAction?.("permanent-delete", device);
+                      onAction?.("decommission", device);
                       setMenuOpen(false);
                     }}
                     className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-destructive hover:bg-destructive/10"
                   >
                     <Trash2 className="h-4 w-4" />
-                    {t("deviceCard.permanentlyDelete")}
+                    {t("deviceCard.decommission")}{" "}
                   </button>
-                </>
-              ) : (
-                <button
-                  type="button"
-                  data-testid={`device-${device.id}-action-remove`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onAction?.("decommission", device);
-                    setMenuOpen(false);
-                  }}
-                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-destructive hover:bg-destructive/10"
-                >
-                  <Trash2 className="h-4 w-4" />
-                  {t("deviceCard.decommission")}{" "}
-                </button>
-              )}
-              {gateHint && (
-                // Visible so the reason survives touch (no hover) and does not
-                // depend on focusing a disabled button, which is impossible.
-                <>
-                  <hr className="my-1" />
-                  <p
-                    id={gateHintId}
-                    data-testid={`device-${device.id}-action-gate-hint`}
-                    className="px-4 py-2 text-xs text-muted-foreground"
-                  >
-                    {gateHint}
-                  </p>
-                </>
-              )}
-            </div>
-          )}
-        </div>
+                )}
+                {gateHint && (
+                  // Visible so the reason survives touch (no hover) and does not
+                  // depend on focusing a disabled button, which is impossible.
+                  <>
+                    <hr className="my-1" />
+                    <p
+                      id={gateHintId}
+                      data-testid={`device-${device.id}-action-gate-hint`}
+                      className="px-4 py-2 text-xs text-muted-foreground"
+                    >
+                      {gateHint}
+                    </p>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
-      <div className="mt-4 grid grid-cols-2 gap-4">
-        <div>
-          <div className="mb-1 flex items-center justify-between text-xs">
-            <span className="text-muted-foreground">CPU</span>
-            <span className="font-medium">{device.cpuPercent}%</span>
-          </div>
-          {historyState === "ready" ? (
+      {isNetwork ? (
+        // A discovered asset reports no CPU/RAM — DevicesPage fills those
+        // fields with a placeholder 0, which would render as a confident
+        // "0%" reading for a printer. The list already shows "—" in those
+        // columns for exactly this reason (DeviceList.tsx agentCell).
+        <div className="mt-4 grid grid-cols-2 gap-4">
+          {(["CPU", "RAM"] as const).map((label) => (
             <div
-              className={
-                device.cpuPercent > 80
-                  ? "text-destructive"
-                  : device.cpuPercent > 60
-                    ? "text-warning"
-                    : "text-success"
-              }
+              key={label}
+              className="flex items-center justify-between text-xs"
             >
-              <MiniSparkline
-                testId={`cpu-sparkline-${device.id}`}
-                data={cpuHistory}
-              />
+              <span className="text-muted-foreground">{label}</span>
+              <span className="font-medium text-muted-foreground">
+                {t("deviceList.text")}
+              </span>
             </div>
-          ) : (
-            <div className="flex h-8 items-center chart-legend-xs text-muted-foreground">
-              {historyState === "loading"
-                ? t("deviceCard.loadingTrend")
-                : historyState === "error"
-                  ? t("deviceCard.trendUnavailable")
-                  : t("deviceCard.noTrendData")}
-            </div>
-          )}
+          ))}
         </div>
-        <div>
-          <div className="mb-1 flex items-center justify-between text-xs">
-            <span className="text-muted-foreground">RAM</span>
-            <span className="font-medium">{device.ramPercent}%</span>
+      ) : (
+        <div className="mt-4 grid grid-cols-2 gap-4">
+          <div>
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span className="text-muted-foreground">CPU</span>
+              <span className="font-medium">{device.cpuPercent}%</span>
+            </div>
+            {historyState === "ready" ? (
+              <div
+                className={
+                  device.cpuPercent > 80
+                    ? "text-destructive"
+                    : device.cpuPercent > 60
+                      ? "text-warning"
+                      : "text-success"
+                }
+              >
+                <MiniSparkline
+                  testId={`cpu-sparkline-${device.id}`}
+                  data={cpuHistory}
+                />
+              </div>
+            ) : (
+              <div className="flex h-8 items-center chart-legend-xs text-muted-foreground">
+                {historyState === "loading"
+                  ? t("deviceCard.loadingTrend")
+                  : historyState === "error"
+                    ? t("deviceCard.trendUnavailable")
+                    : t("deviceCard.noTrendData")}
+              </div>
+            )}
           </div>
-          {historyState === "ready" ? (
-            <div
-              className={
-                device.ramPercent > 80
-                  ? "text-destructive"
-                  : device.ramPercent > 60
-                    ? "text-warning"
-                    : "text-success"
-              }
-            >
-              <MiniSparkline
-                testId={`ram-sparkline-${device.id}`}
-                data={ramHistory}
-              />
+          <div>
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span className="text-muted-foreground">RAM</span>
+              <span className="font-medium">{device.ramPercent}%</span>
             </div>
-          ) : (
-            <div className="flex h-8 items-center chart-legend-xs text-muted-foreground">
-              {historyState === "loading"
-                ? t("deviceCard.loadingTrend")
-                : historyState === "error"
-                  ? t("deviceCard.trendUnavailable")
-                  : t("deviceCard.noTrendData")}
-            </div>
-          )}
+            {historyState === "ready" ? (
+              <div
+                className={
+                  device.ramPercent > 80
+                    ? "text-destructive"
+                    : device.ramPercent > 60
+                      ? "text-warning"
+                      : "text-success"
+                }
+              >
+                <MiniSparkline
+                  testId={`ram-sparkline-${device.id}`}
+                  data={ramHistory}
+                />
+              </div>
+            ) : (
+              <div className="flex h-8 items-center chart-legend-xs text-muted-foreground">
+                {historyState === "loading"
+                  ? t("deviceCard.loadingTrend")
+                  : historyState === "error"
+                    ? t("deviceCard.trendUnavailable")
+                    : t("deviceCard.noTrendData")}
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="mt-4 flex items-center justify-between text-xs text-muted-foreground">
         <span>{device.siteName}</span>

--- a/apps/web/src/components/devices/DeviceCard.tsx
+++ b/apps/web/src/components/devices/DeviceCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import {
   Monitor,
   MoreVertical,
+  Network,
   Terminal,
   RotateCcw,
   FileCode,
@@ -237,7 +238,14 @@ export default function DeviceCard({
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-            {osIcons[device.os] || <Monitor className="h-5 w-5" />}
+            {isNetwork ? (
+              // A discovered asset has no OS, so `osIcons[""]` would fall back
+              // to the generic monitor glyph — the same one a workstation gets.
+              // The list uses a Network glyph on these rows; match it.
+              <Network className="h-5 w-5" />
+            ) : (
+              osIcons[device.os] || <Monitor className="h-5 w-5" />
+            )}
           </div>
           <div>
             <div className="flex items-center gap-2">
@@ -250,7 +258,22 @@ export default function DeviceCard({
                 {t(/* i18n-dynamic */ statusFullLabelKeys[device.status])}
               </span>
             </div>
-            <p className="text-xs text-muted-foreground">{device.osVersion}</p>
+            {isNetwork ? (
+              // Nothing else on the card says WHY this one has no actions and
+              // no metrics. The list answers that with a Class badge; without
+              // it the grid card just looks like a broken agent. Same copy,
+              // same testid, same palette as DeviceList's class column.
+              <span
+                data-testid={`device-${device.id}-class-badge`}
+                title={t("deviceList.networkDiscoveredDevice")}
+                className="mt-0.5 inline-flex items-center gap-1 rounded-full border border-info/30 bg-info/15 px-2 py-0.5 text-[10px] font-medium text-info"
+              >
+                <Network className="h-3 w-3" />
+                {t("deviceList.network")}
+              </span>
+            ) : (
+              <p className="text-xs text-muted-foreground">{device.osVersion}</p>
+            )}
           </div>
         </div>
         {isNetwork ? (

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -110,7 +110,10 @@ vi.mock('./ScriptPickerModal', () => ({
       </button>
     ) : null,
 }));
-vi.mock('./DeviceSettingsModal', () => ({ default: () => null }));
+// A spy, not a bare stub: the modal renders null either way, so the ONLY way a
+// test can observe whether runDeviceAction's `settings` branch ran is whether
+// this component was invoked at all (#4014).
+vi.mock('./DeviceSettingsModal', () => ({ default: vi.fn(() => null) }));
 vi.mock('./AddDeviceModal', () => ({ default: () => null }));
 vi.mock('./CreateGroupModal', () => ({ default: () => null }));
 vi.mock('../filters/DeviceFilterBar', () => ({ DeviceFilterBar: () => null }));
@@ -139,6 +142,22 @@ vi.mock('./DeviceCard', () => ({
         aria-label="card decommission"
         data-testid={`card-decommission-${device.id}`}
         onClick={() => onAction?.('decommission', device)}
+      />
+      {/* The two non-confirm-gated kebab actions, so the #4014 network guard
+          can be proven for an action that does NOT pass through the #4009
+          confirm dialog — a guard that only held for confirm-gated actions
+          would look green here while leaving run-script and settings open. */}
+      <button
+        type="button"
+        aria-label="card run script"
+        data-testid={`card-run-script-${device.id}`}
+        onClick={() => onAction?.('run-script', device)}
+      />
+      <button
+        type="button"
+        aria-label="card settings"
+        data-testid={`card-settings-${device.id}`}
+        onClick={() => onAction?.('settings', device)}
       />
     </div>
   ),
@@ -1605,7 +1624,7 @@ describe('DevicesPage — decommission from the row/grid kebab is confirm-gated 
 // point behind the list kebab, the grid card and DeviceSettingsModal — took any
 // device it was handed. The real DeviceCard (stubbed in this file) had no
 // deviceClass branch at all, so the grid kebab offered Terminal / Run Script /
-// Reboot / Settings / Decommission for a network-discovered asset, whose id is
+// Reboot / Settings / Remove for a network-discovered asset, whose id is
 // a `discovered_assets.id` and NOT a `devices.id`. The card now collapses to a
 // "View" button (pinned against the real component in
 // DeviceCard.networkClass.test.tsx); this pins the handler's backstop, so a
@@ -1690,6 +1709,41 @@ describe('DevicesPage — single-device actions refuse network rows (#4014)', ()
       );
     });
     expect(vi.mocked(sendDeviceCommand)).not.toHaveBeenCalled();
+  });
+
+  // The guard is a single early return with no per-action branching, but it
+  // sits in front of BOTH the confirm-gated and the ungated paths. reboot and
+  // decommission above only exercise the confirm-gated one; these two prove the
+  // ungated actions (which reach runDeviceAction directly) are refused as well.
+  it('refuses run-script — the script picker never opens on an asset id', async () => {
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByLabelText('Grid view'));
+    fireEvent.click(await screen.findByTestId(`card-run-script-${NET_1}`));
+
+    await waitFor(async () => {
+      expect(await toastMessages()).toContainEqual(
+        expect.stringMatching(/applies to agent devices only/i)
+      );
+    });
+    expect(screen.queryByTestId('pick-script')).toBeNull();
+  });
+
+  it('refuses settings — the device settings modal never opens on an asset id', async () => {
+    const settingsModal = await import('./DeviceSettingsModal');
+    const settingsSpy = vi.mocked(settingsModal.default);
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByLabelText('Grid view'));
+    fireEvent.click(await screen.findByTestId(`card-settings-${NET_1}`));
+
+    await waitFor(async () => {
+      expect(await toastMessages()).toContainEqual(
+        expect.stringMatching(/applies to agent devices only/i)
+      );
+    });
+    // DeviceSettingsModal is only rendered once settingsDevice is set, which
+    // only runDeviceAction's `settings` branch does.
+    expect(settingsSpy).not.toHaveBeenCalled();
   });
 
   it('still runs the action for an agent row (the guard is not a blanket block)', async () => {

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -1567,12 +1567,12 @@ describe('DevicesPage — decommission from the row/grid kebab is confirm-gated 
   // it — the same follow-up Todd flagged as gated-but-untested on #3698.
   //
   // Scope, so this is not read as a clean bill of health for the grid kebab:
-  // it proves the CONFIRM gate reaches the card, nothing more. DeviceCard has
-  // no deviceClass branch at all, where DeviceList swaps the whole actions cell
-  // for a "View" button on network rows (their id is a discovered_assets.id,
-  // not a devices.id — #1322). So the grid kebab still offers decommission,
-  // reboot and terminal for a network asset. That predates #4009 and is filed
-  // as #4014; the confirm added here at least puts a dialog in front of it.
+  // it proves the CONFIRM gate reaches the card, nothing more. The separate
+  // network-class gap this note used to flag — DeviceCard having no
+  // deviceClass branch, where DeviceList swaps the whole actions cell for a
+  // "View" button — was #4014 and is now fixed. Note that DeviceCard is
+  // STUBBED in this file, so no test here can vet the real card's kebab; that
+  // lives in DeviceCard.networkClass.test.tsx against the real component.
   it('grid card decommission is gated on the same terms as the list row', async () => {
     const decommissionDevice = await mockedDecommission();
 
@@ -1599,6 +1599,118 @@ describe('DevicesPage — decommission from the row/grid kebab is confirm-gated 
     expect(screen.queryByTestId('confirm-device-action')).toBeNull();
   });
 });
+
+// #4014: the SINGLE-device funnel had no network guard. `handleBulkAction` has
+// dropped network rows since #1322, but `handleDeviceAction` — the shared entry
+// point behind the list kebab, the grid card and DeviceSettingsModal — took any
+// device it was handed. The real DeviceCard (stubbed in this file) had no
+// deviceClass branch at all, so the grid kebab offered Terminal / Run Script /
+// Reboot / Settings / Decommission for a network-discovered asset, whose id is
+// a `discovered_assets.id` and NOT a `devices.id`. The card now collapses to a
+// "View" button (pinned against the real component in
+// DeviceCard.networkClass.test.tsx); this pins the handler's backstop, so a
+// future surface that wires `onAction` cannot silently re-open the hole.
+describe('DevicesPage — single-device actions refuse network rows (#4014)', () => {
+  const NET_1 = '44444444-4444-4444-4444-444444444444';
+
+  beforeEach(async () => {
+    const { decodeFilterFromHash } = await import('./filterUrl');
+    vi.mocked(decodeFilterFromHash).mockReturnValue(null); // no advanced filter
+    vi.mocked(fetchAllDevices).mockResolvedValue({ data: [] } as never);
+    vi.mocked(fetchAllNetworkDevices).mockResolvedValue({
+      data: [{
+        id: NET_1,
+        deviceClass: 'network',
+        assetType: 'printer',
+        hostname: 'Lobby Printer',
+        status: 'online',
+        lastSeenAt: new Date().toISOString(),
+        orgId: 'org-1',
+        siteId: 'site-1',
+        tags: [],
+        ipAddress: '192.168.1.55',
+      }],
+      total: 1,
+      pagesWalked: 1,
+    } as never);
+  });
+
+  async function toastMessages(): Promise<string[]> {
+    const { showToast } = await import('../shared/Toast');
+    return vi.mocked(showToast).mock.calls.map(c => c[0].message ?? '');
+  }
+
+  it('refuses reboot from the grid card — no command queued on the asset id', async () => {
+    const { sendDeviceCommand } = await import('../../services/deviceActions');
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByLabelText('Grid view'));
+    fireEvent.click(await screen.findByTestId(`card-reboot-${NET_1}`));
+
+    await waitFor(async () => {
+      expect(await toastMessages()).toContainEqual(
+        expect.stringMatching(/applies to agent devices only/i)
+      );
+    });
+    expect(vi.mocked(sendDeviceCommand)).not.toHaveBeenCalled();
+    // Refused outright, NOT merely put behind the #4009 confirm dialog — a
+    // dialog here would still end in a 404 once the operator said yes.
+    expect(screen.queryByTestId('confirm-device-action')).toBeNull();
+  });
+
+  it('refuses decommission from the grid card — no undo toast, no DELETE', async () => {
+    const { decommissionDevice } = await import('../../services/deviceActions');
+    const { showToast } = await import('../shared/Toast');
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByLabelText('Grid view'));
+    fireEvent.click(await screen.findByTestId(`card-decommission-${NET_1}`));
+
+    await waitFor(async () => {
+      expect(await toastMessages()).toContainEqual(
+        expect.stringMatching(/applies to agent devices only/i)
+      );
+    });
+    expect(vi.mocked(decommissionDevice)).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('confirm-device-action')).toBeNull();
+    // runDeviceAction's decommission branch raises the 5s undo toast the moment
+    // it is entered, so its absence proves the branch was never reached.
+    expect(vi.mocked(showToast).mock.calls.map(c => c[0].type)).not.toContain('undo');
+  });
+
+  it('refuses the same action from the list row kebab (one guard, both surfaces)', async () => {
+    const { sendDeviceCommand } = await import('../../services/deviceActions');
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByTestId(`row-reboot-${NET_1}`));
+
+    await waitFor(async () => {
+      expect(await toastMessages()).toContainEqual(
+        expect.stringMatching(/applies to agent devices only/i)
+      );
+    });
+    expect(vi.mocked(sendDeviceCommand)).not.toHaveBeenCalled();
+  });
+
+  it('still runs the action for an agent row (the guard is not a blanket block)', async () => {
+    const { sendDeviceCommand } = await import('../../services/deviceActions');
+    vi.mocked(sendDeviceCommand).mockResolvedValue(undefined as never);
+    vi.mocked(fetchAllDevices).mockResolvedValue({
+      data: [{ ...rawDevice(DEV_1, 'host-alpha'), status: 'online' }],
+    } as never);
+
+    render(<DevicesPage />);
+    fireEvent.click(await screen.findByLabelText('Grid view'));
+    fireEvent.click(await screen.findByTestId(`card-reboot-${DEV_1}`));
+
+    // reboot is confirm-gated (#4009), so the dialog is the correct next step.
+    fireEvent.click(await screen.findByTestId('confirm-device-action'));
+    await waitFor(() => {
+      expect(vi.mocked(sendDeviceCommand)).toHaveBeenCalledWith(DEV_1, 'reboot');
+    });
+  });
+});
+
 
 // The #1322 network-row filter and the #2465 decommissioned gate run back-to-back
 // over the same selection and had never been exercised TOGETHER. Ordering is

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -688,6 +688,18 @@ export default function DevicesPage() {
 
   const handleDeviceAction = async (action: string, device: Device) => {
     if (actionInProgress) return;
+    // #4014: every branch of runDeviceAction below addresses an enrolled agent
+    // through a `/devices/:id` endpoint, but a network row's `id` is a
+    // `discovered_assets.id`, NOT a `devices.id` (#1322) — it matches no device
+    // row and 404s. handleBulkAction has filtered these out since #1322; this
+    // is the single-device funnel every kebab and card shares, so enforce the
+    // same invariant once here instead of once per calling component. Both
+    // surfaces already hide the actions for network rows (DeviceList's actions
+    // cell, DeviceCard's kebab), so this is the backstop, not the gate.
+    if ((device.deviceClass ?? 'agent') === 'network') {
+      showToast({ type: 'error', message: t('devicesPage.toasts.agentOnlyAction') });
+      return;
+    }
     if (CONFIRM_REQUIRED_ACTIONS.has(action)) {
       setPendingDeviceAction({ action, device });
       return;

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -691,11 +691,14 @@ export default function DevicesPage() {
     // #4014: every branch of runDeviceAction below addresses an enrolled agent
     // through a `/devices/:id` endpoint, but a network row's `id` is a
     // `discovered_assets.id`, NOT a `devices.id` (#1322) — it matches no device
-    // row and 404s. handleBulkAction has filtered these out since #1322; this
-    // is the single-device funnel every kebab and card shares, so enforce the
-    // same invariant once here instead of once per calling component. Both
-    // surfaces already hide the actions for network rows (DeviceList's actions
-    // cell, DeviceCard's kebab), so this is the backstop, not the gate.
+    // row and 404s. handleBulkAction has filtered these out since #1322.
+    //
+    // Stated as an invariant rather than as a claim about today's UI: this
+    // funnel must refuse network rows on its own, because nothing guarantees
+    // that every present and future caller hides the actions first. #4014 was
+    // exactly that failure — DeviceList hid them, DeviceCard did not, and the
+    // handler trusted its callers. A guard here cannot be re-opened by adding
+    // a third surface.
     if ((device.deviceClass ?? 'agent') === 'network') {
       showToast({ type: 'error', message: t('devicesPage.toasts.agentOnlyAction') });
       return;


### PR DESCRIPTION
## Why

`DeviceCard.tsx` (grid view) had **no `deviceClass` handling anywhere in the file**. Its kebab unconditionally offered Remote Terminal, Run Script, Reboot, Settings and Remove — including for `deviceClass === 'network'` rows, which are discovered assets with no agent. A network row's `id` is a **`discovered_assets.id`, not a `devices.id`** (#1322), so every one of those actions posts a foreign id at a `/devices/:id` endpoint.

The list view has handled this since #1322: `DeviceList.tsx` replaces the entire actions cell with a single **View** button for network rows. The grid had no equivalent branch, so the same printer showed a View button in list view and a full agent action menu one toggle away in grid view. `DevicesPage.tsx` routes network rows into `<DeviceCard>` with full `onAction` wiring whenever the class segment filter is **All**, so this is reachable in normal use.

## What the API actually does — verified per path, not assumed

The issue called decommission "the worst case". It is, but it is a dead end, not a destruction. Every affected path was traced to its handler:

| Kebab action | Endpoint | Result with a `discovered_assets.id` |
|---|---|---|
| Reboot | `POST /devices/:id/commands` | **404** `Device not found` — no `device_commands` row inserted |
| Run Script | `POST /scripts/:id/execute` | **400** `No valid devices found` — validated before enqueue, nothing queued |
| Remote Terminal | client nav → `GET /devices/:id` | **404** — dead-end "device not found" page, session component never mounts |
| Remove (decommission) | `DELETE /devices/:id` | **404** — no row touched |
| Settings | modal open is client-only; Save → `PATCH /devices/:id` | **404** on save |
| *(card mount)* metrics | `GET /devices/:id/metrics?range=1h` | **404** on every network card mount, swallowed into `historyState='error'` |

**Could a `discovered_assets.id` collide with a `devices.id` and hit an unrelated real device? No.** Both primary keys are independent `uuid('id').primaryKey().defaultRandom()` (`db/schema/devices.ts:14`, `db/schema/discovery.ts:129`), neither `insert(devices)` call site supplies an explicit `id`, and there is no promotion/conversion path that copies an asset id into a device row — the only cross-reference is the separate nullable `discoveredAssets.linkedDeviceId` FK. Every handler re-resolves the id against `devices` before any side effect, so all six paths fail closed.

**So this is a UX/noise bug, not a tenant-safety or data-loss one.** Worth stating plainly rather than leaving implied.

## What changed

**1. `DeviceCard` mirrors the list rather than inventing a new treatment.** The kebab collapses to the same **View** button `DeviceList` renders, reusing its `deviceList.view` copy and `device-<id>-open-network` test id, wired to `onClick` (which `DevicesPage.handleSelectDevice` already routes to `/devices/network/:id`). **No new strings, so no locale parity work** — `deviceList.view` and `deviceList.text` already exist in all 8 locales.

**2. Same file, same root cause:** the card no longer fires `GET /devices/:id/metrics` with a discovered-asset id on mount, and renders CPU/RAM as `—` rather than the placeholder `0%` `DevicesPage` fills in for network rows. That is the dash the list already shows for agent-only columns (`DeviceList.tsx` `agentCell`).

**3. A backstop in `handleDeviceAction`.** `handleBulkAction` has filtered network rows since #1322; the single-device funnel — shared by the list kebab, the grid card and `DeviceSettingsModal` — had no such guard. Enforcing the invariant once there (reusing the existing `devicesPage.toasts.agentOnlyAction` copy) means a future surface that wires `onAction` cannot silently re-open the hole. The UI branch is the gate; this is the backstop.

## Tests

New `DeviceCard.networkClass.test.tsx` drives the **real** component. Worth noting: `DeviceCard` is *stubbed* in `DevicesPage.test.tsx`, which is exactly why no test there could ever have caught this — #4011's grid-card test was scoped in a comment for that reason.

**Revert probe** (implementation reverted to the base commit, tests kept): **8 of 11** new `DeviceCard` tests fail, and **5 of 6** of the new `DevicesPage` guard tests fail. The 4 that pass are the deliberate regression guards (agent card keeps its kebab, is not badged, still fetches metrics; a row with no `deviceClass` still defaults to agent) and are meant to hold in both states. One assertion was deliberately reshaped after the first probe — asserting the *count and identity* of controls rather than the absence of menu items, because the menu is closed by default and "no agent buttons in the DOM" passed vacuously against the unfixed code.

Six tests in `DevicesPage.test.tsx` pin the handler backstop from both surfaces and across **both** the confirm-gated actions (reboot, decommission) and the ungated ones (run-script, settings) — a guard that only held on the confirm-gated path would otherwise have looked green. One asserts an agent row still runs its action, so the guard is not a blanket block.

**Verification:** `apps/web` suite green — devices 58 files / 702 tests, and every other `src/**` directory run in batches; `tsc --noEmit` clean; `eslint` clean on all changed files.


## Review round 1

`/pr-review-toolkit:review-pr` — code-reviewer, pr-test-analyzer, comment-analyzer, silent-failure-hunter. **6 findings, 5 acted on, 2 declined.** The follow-up commit carries the detail; the substantive ones:

- **The card did not explain itself** (silent-failure-hunter, MEDIUM). With the kebab and metrics gone, a printer rendered the generic monitor glyph, a blank OS line and two dashes — indistinguishable from a broken agent. The list answers that with a Class badge; it is now ported, same copy/testid/palette, plus the list's Network glyph. Still no new strings.
- **A comment said "Decommission"** (comment-analyzer, CRITICAL) — #3994 renamed that label to "Remove" before this branch existed.
- **A comment asserted a snapshot of today's UI** rather than the invariant. Reframed: this handler must refuse network rows on its own, because nothing guarantees every future caller hides the actions first — which is precisely how #4014 happened.
- **The guard was proven only for confirm-gated actions** (pr-test-analyzer, 6/10) — widened, see above.
- **The metrics effect's new `isNetwork` dependency was unpinned** (3/10) — now tested.

Declined: reusing the bulk `agentOnlyAction` copy for a single device (plural phrasing, but the alternative is a new string in 8 locales for no gain), and a cosmetic trailing-space difference from the list.

**Also caught by review:** this branch originally carried its own fix for the same `main`-red that #4023 fixed 25 minutes after this branch's base was cut. That duplicate commit has been dropped and the branch rebased onto current `origin/main`, so only the #4014 work remains.

Closes #4014

🤖 Generated with [Claude Code](https://claude.com/claude-code)
