### PR TITLE
fix(api): recheck the tenant precondition under the repair's own lock (#4022)

### DIFF
--- a/apps/api/src/__tests__/integration/offboardingRepairRecheck.integration.test.ts
+++ b/apps/api/src/__tests__/integration/offboardingRepairRecheck.integration.test.ts
@@ -1,0 +1,326 @@
+import './setup';
+
+import { describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { withSystemDbAccessContext } from '../../db';
+import { auditLogs, deviceCommands, devices, enrollmentKeys, organizations, partners } from '../../db/schema';
+import {
+  abortOrganizationOffboarding,
+  repairIncompleteEntry,
+} from '../../services/tenantOffboarding';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+/**
+ * #4022 — the offboarding sweep selects candidates in one system context and
+ * repairs each in a separate one, keying on the SNAPSHOTTED `startedAt`. An
+ * operator can abort the tenant in between, and that abort is a legitimate
+ * no-op when the stamp is null: its UPDATE guards on
+ * `isNotNull(offboardingStartedAt)` and returns before cancelling anything.
+ *
+ * So the repair could arrive at a tenant that is back to `active`, take its
+ * lock on `eq(id)` alone, and queue fresh `self_uninstall` rows plus a live
+ * stamp. Because the tenant is no longer `offboarding`, `getAgentTenantState`
+ * stops returning `'draining'` and the claim runs with no type allowlist — the
+ * fleet collects those uninstalls as ordinary commands on the next heartbeat.
+ * The audit row records `offboarding_entry_repaired` with a success result, so
+ * nothing about it looks wrong afterwards.
+ *
+ * This drives the real service against real Postgres, staging the race by
+ * calling the repair with a snapshotted candidate — the sweep's own select
+ * would not return the tenant once the abort has committed.
+ *
+ * Scope, deliberately: this pins the RECHECK, not the lock. Every abort here
+ * commits before the repair starts, so removing `.for('update')` leaves all of
+ * these green. Holding an uncommitted `active` UPDATE open in one transaction
+ * while the repair runs in another WOULD pin the lock — see the
+ * `pg_stat_activity` barrier in `orgCurrencyCreationBarrier.integration.test.ts`
+ * — and would also remove the need to export the function.
+ */
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function seedDevice(orgId: string, siteId: string, label: string): Promise<string> {
+  const [row] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `agent-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      hostname: `host-${label}`,
+      osType: 'windows',
+      osVersion: '11',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+    })
+    .returning({ id: devices.id });
+  return row!.id;
+}
+
+/**
+ * `prepareAgentDrainForOrgIds` expires every unexpired enrollment key for the
+ * org (`expiresAt = now`). Seeding one with a far-future expiry gives the
+ * abandon path a DB-observable probe: if the early return were placed AFTER
+ * drain prep instead of before it, this key would come back stamped to ~now
+ * even though nothing was queued and no stamp was written. The audit row alone
+ * cannot cover this — it is emitted only after prep, queue and stamp, and
+ * `writeAuditEvent` is fire-and-forget, so its absence proves neither.
+ */
+const FAR_FUTURE = new Date('2099-01-01T00:00:00Z');
+
+async function seedEnrollmentKey(orgId: string, label: string): Promise<string> {
+  const [row] = await getTestDb()
+    .insert(enrollmentKeys)
+    .values({
+      orgId,
+      name: `key-${label}`,
+      key: `k-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      expiresAt: FAR_FUTURE,
+    })
+    .returning({ id: enrollmentKeys.id });
+  return row!.id;
+}
+
+async function keyStillUnexpired(keyId: string): Promise<boolean> {
+  const [row] = await getTestDb()
+    .select({ expiresAt: enrollmentKeys.expiresAt })
+    .from(enrollmentKeys)
+    .where(eq(enrollmentKeys.id, keyId));
+  return row?.expiresAt?.getTime() === FAR_FUTURE.getTime();
+}
+
+async function repairAudits(orgId: string): Promise<number> {
+  const rows = await getTestDb()
+    .select({ id: auditLogs.id })
+    .from(auditLogs)
+    .where(
+      and(
+        eq(auditLogs.orgId, orgId),
+        eq(auditLogs.action, 'organization.offboarding_entry_repaired')
+      )
+    );
+  return rows.length;
+}
+
+async function pendingUninstalls(deviceId: string): Promise<number> {
+  const rows = await getTestDb()
+    .select({ id: deviceCommands.id })
+    .from(deviceCommands)
+    .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.type, 'self_uninstall')));
+  return rows.length;
+}
+
+describe('#4022 — repairIncompleteEntry rechecks the precondition under its lock', () => {
+  runDb(
+    'abandons an organization that was aborted back to active between snapshot and repair',
+    async () => {
+      const partner = await createPartner({ status: 'active' });
+      const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+      const site = await createSite({ orgId: org.id });
+      const orgId = org.id;
+      const deviceId = await seedDevice(orgId, site.id, 'org-abort');
+      const keyId = await seedEnrollmentKey(orgId, 'org-abort');
+
+      await withSystemDbAccessContext(async () => {
+        // The torn state the sweep looks for: offboarding, no drain stamp.
+        await getTestDb()
+          .update(organizations)
+          .set({ status: 'offboarding', offboardingStartedAt: null })
+          .where(eq(organizations.id, orgId));
+      });
+
+      // The sweep snapshots {id, startedAt: null} at this point; the repair
+      // below is called with exactly that stale candidate.
+
+      // The operator aborts. With a null stamp this is correctly a no-op on the
+      // command rows — which is precisely why nothing downstream notices.
+      await withSystemDbAccessContext(async () => {
+        await getTestDb()
+          .update(organizations)
+          .set({ status: 'active' })
+          .where(eq(organizations.id, orgId));
+      });
+      const abortResult = await abortOrganizationOffboarding(orgId);
+      expect(abortResult.aborted).toBe(false);
+
+      // The repair now runs against the rescued tenant.
+      await withSystemDbAccessContext(() =>
+        repairIncompleteEntry('organization', orgId, [orgId], new Date())
+      );
+
+      expect(await pendingUninstalls(deviceId)).toBe(0);
+      // Not just "no rows": the repair must not have run its side effects at
+      // all. prepareAgentDrainForOrgIds invalidates caches, expires enrollment
+      // keys and can restore agent tokens, so a predicate placed AFTER it would
+      // still satisfy a rows-only assertion.
+      expect(await repairAudits(orgId)).toBe(0);
+      // The real proof that drain prep never ran.
+      expect(await keyStillUnexpired(keyId)).toBe(true);
+
+      const [after] = await getTestDb()
+        .select({ status: organizations.status, startedAt: organizations.offboardingStartedAt })
+        .from(organizations)
+        .where(eq(organizations.id, orgId));
+      expect(after?.status).toBe('active');
+      expect(after?.startedAt).toBeNull();
+    }
+  );
+
+  runDb('still repairs an organization that is genuinely still torn', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+    const site = await createSite({ orgId: org.id });
+    const orgId = org.id;
+    const deviceId = await seedDevice(orgId, site.id, 'org-torn');
+
+    await withSystemDbAccessContext(async () => {
+      await getTestDb()
+        .update(organizations)
+        .set({ status: 'offboarding', offboardingStartedAt: null })
+        .where(eq(organizations.id, orgId));
+    });
+
+    // No abort this time: the precondition still holds under the lock.
+    await withSystemDbAccessContext(() =>
+      repairIncompleteEntry('organization', orgId, [orgId], new Date())
+    );
+
+    expect(await pendingUninstalls(deviceId)).toBeGreaterThan(0);
+
+    const [after] = await getTestDb()
+      .select({ startedAt: organizations.offboardingStartedAt })
+      .from(organizations)
+      .where(eq(organizations.id, orgId));
+    expect(after?.startedAt).not.toBeNull();
+  });
+
+  // Pins the STAMP half of the predicate. Without it, deleting
+  // `offboardingStartedAt === null` from the check still passes every other test.
+  runDb('abandons a tenant that is still offboarding but has already been stamped', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+    const site = await createSite({ orgId: org.id });
+    const orgId = org.id;
+    const deviceId = await seedDevice(orgId, site.id, 'org-stamped');
+
+    const alreadyStamped = new Date(Date.now() - 60_000);
+    await withSystemDbAccessContext(async () => {
+      await getTestDb()
+        .update(organizations)
+        .set({ status: 'offboarding', offboardingStartedAt: alreadyStamped })
+        .where(eq(organizations.id, orgId));
+    });
+
+    // `offboarding` + a stamp is the completion marker: entry paths commit the
+    // stamp and the queued commands together, so a stamped tenant has already
+    // been handled. This fixture stamps the marker WITHOUT queueing, so it pins
+    // the marker check itself rather than reproducing a completed repair.
+    await withSystemDbAccessContext(() =>
+      repairIncompleteEntry('organization', orgId, [orgId], new Date())
+    );
+
+    expect(await pendingUninstalls(deviceId)).toBe(0);
+    expect(await repairAudits(orgId)).toBe(0);
+
+    const [after] = await getTestDb()
+      .select({ startedAt: organizations.offboardingStartedAt })
+      .from(organizations)
+      .where(eq(organizations.id, orgId));
+    expect(after?.startedAt?.getTime()).toBe(alreadyStamped.getTime());
+  });
+
+  // Partner POSITIVE control. Without it, making the partner branch an
+  // unconditional no-op passes the partner abandon test.
+  runDb('still repairs a partner that is genuinely still torn', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+    const site = await createSite({ orgId: org.id });
+    const deviceId = await seedDevice(org.id, site.id, 'partner-torn');
+
+    await withSystemDbAccessContext(async () => {
+      await getTestDb()
+        .update(partners)
+        .set({ status: 'offboarding', offboardingStartedAt: null })
+        .where(eq(partners.id, partner.id));
+    });
+
+    await withSystemDbAccessContext(() =>
+      repairIncompleteEntry('partner', partner.id, [org.id], new Date())
+    );
+
+    expect(await pendingUninstalls(deviceId)).toBeGreaterThan(0);
+
+    const [after] = await getTestDb()
+      .select({ startedAt: partners.offboardingStartedAt })
+      .from(partners)
+      .where(eq(partners.id, partner.id));
+    expect(after?.startedAt).not.toBeNull();
+  });
+
+  // Pins the stamp conjunct on the PARTNER branch specifically. Removing it
+  // from the org branch alone is caught by the org case above; removing it from
+  // the partner branch alone was not caught by anything until this existed.
+  runDb('abandons a partner that is still offboarding but has already been stamped', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+    const site = await createSite({ orgId: org.id });
+    const deviceId = await seedDevice(org.id, site.id, 'partner-stamped');
+    const keyId = await seedEnrollmentKey(org.id, 'partner-stamped');
+
+    const alreadyStamped = new Date(Date.now() - 60_000);
+    await withSystemDbAccessContext(async () => {
+      await getTestDb()
+        .update(partners)
+        .set({ status: 'offboarding', offboardingStartedAt: alreadyStamped })
+        .where(eq(partners.id, partner.id));
+    });
+
+    await withSystemDbAccessContext(() =>
+      repairIncompleteEntry('partner', partner.id, [org.id], new Date())
+    );
+
+    expect(await pendingUninstalls(deviceId)).toBe(0);
+    expect(await keyStillUnexpired(keyId)).toBe(true);
+
+    const [after] = await getTestDb()
+      .select({ startedAt: partners.offboardingStartedAt })
+      .from(partners)
+      .where(eq(partners.id, partner.id));
+    expect(after?.startedAt?.getTime()).toBe(alreadyStamped.getTime());
+  });
+
+  runDb('abandons a partner that was aborted back to active between snapshot and repair', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+    const site = await createSite({ orgId: org.id });
+    const partnerId = partner.id;
+    const orgId = org.id;
+    const deviceId = await seedDevice(orgId, site.id, 'partner-abort');
+
+    await withSystemDbAccessContext(async () => {
+      await getTestDb()
+        .update(partners)
+        .set({ status: 'offboarding', offboardingStartedAt: null })
+        .where(eq(partners.id, partnerId));
+    });
+
+    await withSystemDbAccessContext(async () => {
+      await getTestDb()
+        .update(partners)
+        .set({ status: 'active' })
+        .where(eq(partners.id, partnerId));
+    });
+
+    await withSystemDbAccessContext(() =>
+      repairIncompleteEntry('partner', partnerId, [orgId], new Date())
+    );
+
+    expect(await pendingUninstalls(deviceId)).toBe(0);
+
+    const [after] = await getTestDb()
+      .select({ startedAt: partners.offboardingStartedAt })
+      .from(partners)
+      .where(eq(partners.id, partnerId));
+    expect(after?.startedAt).toBeNull();
+  });
+});

--- a/apps/api/src/services/tenantOffboarding.test.ts
+++ b/apps/api/src/services/tenantOffboarding.test.ts
@@ -623,7 +623,7 @@ describe('sweepOffboardingTenants', () => {
   // indistinguishable from a clean drain (the #2774 false-confidence bug).
   it('repairs an incomplete entry (queues uninstalls) instead of finalizing it', async () => {
     queueCandidates([{ id: 'org-1', startedAt: null }], []);
-    queueSelect([{ id: 'org-1' }]); // tenant row FOR UPDATE (lock-order guard, #2877)
+    queueSelect([{ status: 'offboarding', startedAt: null }]); // tenant row FOR UPDATE — now also the #4022 precondition recheck
     queueSelect([{ id: 'd1' }]); // devices to queue
     queueSelect([]); // no existing uninstalls
 
@@ -650,7 +650,7 @@ describe('sweepOffboardingTenants', () => {
       return { enrollmentKeysInvalidated: 0, agentTokensRestored: 0 };
     });
     queueCandidates([{ id: 'org-1', startedAt: null }], []);
-    queueSelect([{ id: 'org-1' }]); // tenant row FOR UPDATE (lock-order guard, #2877)
+    queueSelect([{ status: 'offboarding', startedAt: null }]); // tenant row FOR UPDATE — now also the #4022 precondition recheck
     queueSelect([{ id: 'd1' }]); // devices to queue
     queueSelect([]); // no existing uninstalls
 

--- a/apps/api/src/services/tenantOffboarding.ts
+++ b/apps/api/src/services/tenantOffboarding.ts
@@ -633,15 +633,24 @@ export async function finalizePartnerOffboarding(
  * Queueing is idempotent (dedupes against in-flight uninstalls), so re-running
  * it is safe; the stamp write is the marker that the entry is now complete.
  */
-async function repairIncompleteEntry(
+/**
+ * Exported for the integration test that pins #4022: the sweep calls this from a
+ * SNAPSHOTTED candidate taken in an earlier, already-committed context, and by
+ * the time an abort has committed the sweep own select no longer returns the
+ * tenant. A lock-barrier test that holds an uncommitted UPDATE open across the
+ * repair could drive it through sweepOffboardingTenants instead, and would pin
+ * the FOR UPDATE as well as the recheck; this export is the cost of not doing
+ * that here.
+ */
+export async function repairIncompleteEntry(
   scope: 'organization' | 'partner',
   scopeId: string,
   orgIds: string[],
   now: Date
 ): Promise<void> {
-  console.warn(
-    `[tenantOffboarding] ${scope} ${scopeId} is offboarding with no drain stamp — completing the entry`
-  );
+  // Logged AFTER the recheck below, not here: the candidate was snapshotted in
+  // an earlier committed context, so at this point we do not yet own the row
+  // and do not know the entry is still incomplete.
   // Take the TENANT ROW lock first, matching the request path's acquisition
   // order (route UPDATE on organizations/partners, then key/device work).
   // Without this, a repair racing an operator's PATCH retry on the same torn
@@ -651,19 +660,53 @@ async function repairIncompleteEntry(
   // the same cross-connection cycle Postgres cannot detect (#2877). Row lock
   // first means whichever side wins the tenant row proceeds while the other
   // waits holding nothing.
+  //
+  // The lock is also what makes the precondition trustworthy, so re-read the
+  // status and stamp WITH it and abandon if they have moved (#4022). The
+  // sweep selects candidates in one system context and repairs each in a
+  // separate one, and the repair branch keys on the SNAPSHOTTED `startedAt`,
+  // so an operator can abort the tenant in between. Abort with a null stamp is
+  // a legitimate no-op — its UPDATE guards on `isNotNull(offboardingStartedAt)`
+  // and returns before cancelling — so nothing downstream would notice, and
+  // the stamp write's own `isNull` guard still matches. Without this recheck
+  // the repair queues fresh self_uninstall rows against a tenant that is now
+  // active or trial, where `getAgentTenantState` no longer returns 'draining'
+  // and the claim runs with no type allowlist: the fleet collects them as
+  // ordinary commands on the next heartbeat. The audit row would then record
+  // `offboarding_entry_repaired` with a success result, so nothing about it
+  // looks wrong afterwards.
+  let stillIncomplete: boolean;
   if (scope === 'organization') {
-    await db
-      .select({ id: organizations.id })
+    const [row] = await db
+      .select({ status: organizations.status, startedAt: organizations.offboardingStartedAt })
       .from(organizations)
       .where(eq(organizations.id, scopeId))
       .for('update');
+    stillIncomplete = row?.status === 'offboarding' && row.startedAt === null;
   } else {
-    await db
-      .select({ id: partners.id })
+    const [row] = await db
+      .select({ status: partners.status, startedAt: partners.offboardingStartedAt })
       .from(partners)
       .where(eq(partners.id, scopeId))
       .for('update');
+    stillIncomplete = row?.status === 'offboarding' && row.startedAt === null;
   }
+
+  if (!stillIncomplete) {
+    // Deliberately not an error: losing this race is the CORRECT outcome. The
+    // usual cause is an operator aborting the offboarding, but another repair
+    // winning the row first leaves `offboarding` + stamped and lands here too.
+    // Logged because a steady stream means the sweep is routinely racing.
+    console.warn(
+      `[tenantOffboarding] ${scope} ${scopeId} left the incomplete-entry state before the repair took its lock — abandoning`
+    );
+    return;
+  }
+
+  console.warn(
+    `[tenantOffboarding] ${scope} ${scopeId} is offboarding with no drain stamp — completing the entry`
+  );
+
   // Drain prep FIRST, matching begin*Offboarding: #2785 made this step the one
   // that lifts a superseded token suspension, so queueing before it would leave
   // a window where the uninstall exists but the fleet is still 401ing.


### PR DESCRIPTION
Closes #4022. Traced on #3996, filed by you, and this is the fix plus the deterministic test you asked for.

### The defect

`repairIncompleteEntry` took its row lock on `eq(id)` alone and never rechecked what it had locked. The sweep selects candidates in one system context and repairs each in a **separate** one, keying on the snapshotted `startedAt`, so an operator can abort the tenant in between — and that abort is a legitimate no-op when the stamp is null, because its UPDATE guards on `isNotNull(offboardingStartedAt)` and returns before cancelling anything.

The repair then arrived at a rescued tenant, queued fresh `self_uninstall` rows and stamped it. With the tenant no longer `offboarding`, `getAgentTenantState` stops returning `'draining'` and the claim runs with no type allowlist, so the fleet collects those uninstalls as ordinary commands on the next heartbeat.

### The fix

The `.for('update')` select now returns `status` and `offboardingStartedAt`, and the repair abandons unless `status = 'offboarding' AND offboarding_started_at IS NULL` still holds under the lock. Both the organization and partner branches. As you noted, the lock was already taken in the right order — it just was not being used to validate the precondition it was taken for.

Abandoning is deliberately not an error: losing that race is the correct outcome. The `warn` moved **after** the recheck, because the old message said "completing the entry" before the row was owned or the precondition confirmed, directly above the branch that now abandons. Its comment also names repair-vs-repair, not just operator-abort — another repair winning the row first leaves `offboarding` + stamped and lands in the same branch.

### The test

`offboardingRepairRecheck.integration.test.ts`, six cases against real Postgres. Each was controlled by breaking the fix and confirming **only** the intended case reds:

| control | expected | observed |
|---|---|---|
| baseline, fix in place | all pass | `6 passed` |
| drop the stamp conjunct (both branches) | only the org already-stamped case red | `1 failed \| 4 passed` |
| partner branch never repairs | only the partner positive control red | `1 failed \| 4 passed` |
| move the early return **below** `prepareAgentDrainForOrgIds` | only the two enrollment-key cases red | `2 failed \| 4 passed` |
| drop the stamp conjunct on the **partner branch only** | only the partner already-stamped case red | `1 failed \| 5 passed` |

The last two rows exist because review caught the first pair proving less than I claimed.

**The audit assertion did not prove drain prep was skipped.** `offboarding_entry_repaired` is written only *after* prep, queue and stamp, and `writeAuditEvent` is fire-and-forget, so its absence proves neither. Moving the early return below `prepareAgentDrainForOrgIds` left every test green while the abandoned tenant still had its enrollment keys expired and its sockets dropped. Each abandon case now seeds a key with a far-future expiry and asserts it is untouched, since prep sets `expiresAt = now` on every unexpired key for the org.

**The partner branch was unpinned.** The original mutation removed the stamp conjunct from *both* branches, so it demonstrated org sensitivity and nothing about the partner path — removing it from the partner side alone went undetected. There is now a partner stamp-negative case, and the control targets that branch specifically.

Worth recording how the mis-aimed control was caught: it red the *org*-named test while claiming to mutate the partner branch. The first `.from(partners)` in this file is at `:527`, well above `repairIncompleteEntry`, so a naive index search landed on the org predicate at `:685` instead of the partner one at `:692`. The rerun targets the line and asserts a `.from(partners)` appears above it before running. A red control proves nothing until you have confirmed the mutation landed where you meant.

An earlier version of the suite also failed all three cases at once, which looked like a successful control and was not — a setup bug of mine (`createOrganization` takes an options object; I had passed a bare id, so partner rows went into `organizations`). The positive controls are what caught it.

### Two limits, stated rather than implied

**The test pins the recheck, not the lock.** Every abort in it commits before the repair starts, so removing `.for('update')` leaves all five green. Pinning the lock needs a backend observably blocked before the abort commits — the `pg_stat_activity` barrier at `orgCurrencyCreationBarrier.integration.test.ts:102` is the pattern for it. I did not build that here because you said this needs no concurrency harness, and it is a bigger change than the guard; happy to add it if you want the lock pinned too.

**I exported `repairIncompleteEntry`** to stage the race. The sweep's own select would no longer return the tenant once the abort has landed, so the interleaving is unreachable through the public entry point. That barrier approach would also remove the need for the export, which is the other argument for it.

### Verification

Full API gate, local:

- `tsc --noEmit` clean
- unit **25263 passed / 19 skipped / 0 failed**
- `eslint src` clean
- integration **2418 passed / 3 skipped**, with 2 failures in `patchCanonicalExportParity.integration.test.ts`

Those two are **not from this change**: they fail identically with this diff stashed on clean `origin/main` (four `schema defaults` assertions, e.g. `expected { …(2) } to deeply equal { autoApproveDeferralDays: +0, …(1) }`). That looks like an existing red on main worth its own issue — say the word and I will file it with the baseline evidence.

Two existing unit fixtures in `tenantOffboarding.test.ts` needed updating: the mocked lock select is now read rather than ignored, so `{ id }` had to become `{ status, startedAt }`. Intent unchanged.
