### PR TITLE
fix(auth): let passwordless SSO accounts enroll a first MFA factor via IdP re-authentication (#4018)

### DIFF
--- a/apps/api/migrations/2026-08-25-sso-sessions-reauth-user-id.sql
+++ b/apps/api/migrations/2026-08-25-sso-sessions-reauth-user-id.sql
@@ -1,0 +1,26 @@
+-- #4018: third sso_sessions mode. A "reauth" transaction proves a passwordless
+-- SSO account's identity through a fresh IdP round-trip so the user can enroll
+-- a FIRST MFA factor. Mirrors link mode (link_user_id + the three initiating_*
+-- binding columns), which this reuses as-is.
+--
+-- ON DELETE CASCADE for the same reason link_user_id has it: sso_sessions has
+-- no org_id/partner_id, so the tenant-erasure sweep never reaches it by tenancy
+-- and an abandoned transaction must not block a hard user delete.
+ALTER TABLE sso_sessions
+  ADD COLUMN IF NOT EXISTS reauth_user_id uuid REFERENCES users(id) ON DELETE CASCADE;
+
+-- A session is exactly one of: login (both NULL), link, or reauth. Both set is
+-- a programming error that would make the callback's mode discriminator
+-- ambiguous, so refuse it in the database rather than ordering the checks.
+DO $$
+BEGIN
+  ALTER TABLE sso_sessions
+    ADD CONSTRAINT sso_sessions_single_mode_chk
+    CHECK (link_user_id IS NULL OR reauth_user_id IS NULL);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS sso_sessions_reauth_user_id_idx
+  ON sso_sessions (reauth_user_id)
+  WHERE reauth_user_id IS NOT NULL;

--- a/apps/api/src/db/schema/sso.ts
+++ b/apps/api/src/db/schema/sso.ts
@@ -125,6 +125,12 @@ export const ssoSessions = pgTable('sso_sessions', {
   // has no partner_id/org_id, so the tenant-cascade sweep never reaches it.
   linkUserId: uuid('link_user_id').references(() => users.id, { onDelete: 'cascade' }),
 
+  // Reauth-mode marker (#4018): when set, the callback mints a single-use
+  // enrollment step-up grant for this user instead of logging in or linking.
+  // Same ON DELETE CASCADE rationale as linkUserId above. Mutually exclusive
+  // with linkUserId (sso_sessions_single_mode_chk).
+  reauthUserId: uuid('reauth_user_id').references(() => users.id, { onDelete: 'cascade' }),
+
   // SR2-11 pending-transaction binding.
   //
   // providerVersion: sso_providers.config_version at creation. NULL only for

--- a/apps/api/src/db/schema/sso.ts
+++ b/apps/api/src/db/schema/sso.ts
@@ -137,12 +137,18 @@ export const ssoSessions = pgTable('sso_sessions', {
   // rows written before this column existed — the callback REJECTS those.
   providerVersion: integer('provider_version'),
 
-  // The three initiating_* columns are LINK-MODE ONLY (set by
-  // POST /sso/link/start alongside linkUserId). A login session has no
+  // The three initiating_* columns are set by BOTH user-initiated modes — link
+  // (POST /sso/link/start, alongside linkUserId) and reauth (POST
+  // /sso/reauth/start, alongside reauthUserId). A login session has no
   // initiating user, so they stay NULL there — which is why they are nullable.
-  // The link callback requires all three to be present AND to still match live
-  // state, which is what makes logout / password reset / MFA reset / suspension
-  // / global revocation invalidate a pending link.
+  // Both callbacks require all three to be present AND to still match live
+  // state (validateSessionBinding), which is what makes logout / password reset
+  // / MFA reset / suspension / global revocation invalidate a pending
+  // transaction in either mode.
+  //
+  // Reauth leans on them twice: once for that binding check, and again to stamp
+  // the minted step-up grant with the epochs and sid the transaction STARTED
+  // under, so a grant cannot outlive the session that authorized it.
   initiatingAuthEpoch: integer('initiating_auth_epoch'),
   initiatingMfaEpoch: integer('initiating_mfa_epoch'),
   // = refresh_token_families.family_id == the initiating access token's `sid`.

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -98,7 +98,7 @@ vi.mock('../db/schema', () => ({
 }));
 
 import { Hono } from 'hono';
-import { authMiddleware, requireScope, requirePermission, requireMfa, requireOrg, requirePartner, requireOrgAccess, resolveOrgAccess, AuthContext } from './auth';
+import { authMiddleware, requireScope, requirePermission, requireMfa, requireOrg, requirePartner, requireOrgAccess, resolveOrgAccess, isMfaEnrollmentExemptPath, AuthContext } from './auth';
 import { verifyToken } from '../services/jwt';
 import { isTokenIssuedBeforePasswordChange, isUserTokenRevoked } from '../services/tokenRevocation';
 import { db, withDbAccessContext } from '../db';
@@ -547,6 +547,19 @@ describe('authMiddleware', () => {
     expect(res.status).not.toBe(428);
     expect(res.status).toBe(200);
     expect(vi.mocked(getEffectiveMfaPolicy)).not.toHaveBeenCalled();
+  });
+
+  it('exempts /sso/reauth/* from forced MFA enrollment', () => {
+    // A policy-required, unenrolled, passwordless SSO user is the entire target
+    // population. Without this exemption authMiddleware 428s them before the
+    // handler runs and the enrollment flow can never start.
+    expect(isMfaEnrollmentExemptPath('/api/v1/sso/reauth/start')).toBe(true);
+    expect(isMfaEnrollmentExemptPath('/sso/reauth/start')).toBe(true);
+  });
+
+  it('does not exempt other /sso paths', () => {
+    expect(isMfaEnrollmentExemptPath('/api/v1/sso/providers')).toBe(false);
+    expect(isMfaEnrollmentExemptPath('/api/v1/sso/link/start/abc')).toBe(false);
   });
 
   it('permits an enrolled user without consulting the resolver at all', async () => {

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -197,7 +197,7 @@ export function siteAccessCheck(
  *
  * Path is the API path *after* the `/api/v1` mount, e.g. `/auth/mfa/setup`.
  */
-function isMfaEnrollmentExemptPath(path: string): boolean {
+export function isMfaEnrollmentExemptPath(path: string): boolean {
   // Strip the /api/v1 prefix if present so the check works whether Hono
   // gives us the absolute path or a sub-app path.
   const rel = path.startsWith('/api/v1') ? path.slice('/api/v1'.length) : path;
@@ -217,6 +217,11 @@ function isMfaEnrollmentExemptPath(path: string): boolean {
   // phishing-resistant factor). Without this, a policy-required-but-unenrolled
   // user is 428'd on /auth/passkeys/register/* and can never enroll a passkey.
   if (rel.startsWith('/auth/passkeys/')) return true;
+  // Starting an IdP re-authentication is an enrollment action for a
+  // PASSWORDLESS SSO account (#4018) — it is how such a user proves identity
+  // to install a first factor, since they have no password to prove. The route
+  // changes no account state on its own; it only begins an OIDC round trip.
+  if (rel.startsWith('/sso/reauth/')) return true;
   return false;
 }
 

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -459,6 +459,12 @@ describe('passkey MFA auth routes', () => {
   it('returns registration options only after the current password is verified', async () => {
     vi.mocked(verifyPassword).mockResolvedValueOnce(true);
     dbState.selectQueue.push([{ passwordHash: '$argon2id$hash' }]);
+    // enforceExistingFactorStepUp's userIsMfaProtected probe. Previously
+    // omitted: the empty queue fell through to `[]` and the helper's
+    // `row?.mfaEnabled` reported the account unprotected, so this test passed
+    // through a branch it never modelled. userIsMfaProtected now raises on a
+    // missing row (that answer is the permissive one), so the row is explicit.
+    dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]);
 
     const res = await app.request('/auth/passkeys/register/options', {
       method: 'POST',

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -535,6 +535,97 @@ describe('passkey MFA auth routes', () => {
     });
   });
 
+  // #4018 review finding 2: nothing at the route level proved the SSO
+  // re-auth road actually works end to end (only sso.reauth.test.ts and
+  // schemas.test.ts referenced ssoReauthGrantId, and neither calls these
+  // routes). A passwordless account (no `currentPassword` field sent, no
+  // password on the account) with zero existing factors and a fresh
+  // `enroll_first_factor` grant from GET /sso/callback (reauth mode) must be
+  // able to register a passkey as its first MFA factor; an invalid/expired
+  // grant must be rejected with the same opaque 401 the password road uses.
+  describe('#4018 SSO re-auth road on passkey registration', () => {
+    it('register/options SUCCEEDS for a passwordless, zero-factor account with a valid enrollment grant (validates, does not consume)', async () => {
+      dbState.selectQueue.push([{ passwordHash: null }]); // resolveEnrollmentStepUp probe
+      dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]); // resolveEnrollmentStepUp's userIsMfaProtected
+      dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]); // enforceExistingFactorStepUp's own userIsMfaProtected
+      dbState.selectQueue.push([]); // listActivePasskeys
+      vi.mocked(validateStepUpGrant).mockResolvedValueOnce(true);
+
+      const res = await app.request('/auth/passkeys/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+        body: JSON.stringify({ ssoReauthGrantId: '11111111-1111-4111-8111-111111111111' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(verifyPassword).not.toHaveBeenCalled();
+      expect(validateStepUpGrant).toHaveBeenCalledWith(
+        '11111111-1111-4111-8111-111111111111',
+        expect.objectContaining({ userId: 'user-123', operation: 'enroll_first_factor' }),
+      );
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+      expect(passkeyMocks.generatePasskeyRegistrationOptions).toHaveBeenCalled();
+    });
+
+    it('register/options returns the opaque 401 for a passwordless account with an invalid/expired grant', async () => {
+      dbState.selectQueue.push([{ passwordHash: null }]); // resolveEnrollmentStepUp probe
+      dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]); // resolveEnrollmentStepUp's userIsMfaProtected
+      vi.mocked(validateStepUpGrant).mockResolvedValueOnce(false);
+
+      const res = await app.request('/auth/passkeys/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+        body: JSON.stringify({ ssoReauthGrantId: '11111111-1111-4111-8111-111111111111' }),
+      });
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: 'Invalid credentials' });
+      expect(passkeyMocks.generatePasskeyRegistrationOptions).not.toHaveBeenCalled();
+    });
+
+    it('register/verify SUCCEEDS for a passwordless, zero-factor account with a valid enrollment grant (consumes it)', async () => {
+      dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]); // enforceExistingFactorStepUp's userIsMfaProtected
+      dbState.selectQueue.push([{ passwordHash: null }]); // resolveEnrollmentStepUp probe
+      dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]); // resolveEnrollmentStepUp's userIsMfaProtected
+      dbState.selectQueue.push([{ mfaSecret: null, mfaMethod: null }]); // tx hasExistingFactor check — no factor yet
+      vi.mocked(consumeStepUpGrant).mockResolvedValueOnce(true);
+
+      const res = await app.request('/auth/passkeys/register/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+        body: JSON.stringify({
+          credential: { id: 'credential-1' },
+          ssoReauthGrantId: '11111111-1111-4111-8111-111111111111',
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(consumeStepUpGrant).toHaveBeenCalledWith(
+        '11111111-1111-4111-8111-111111111111',
+        expect.objectContaining({ userId: 'user-123', operation: 'enroll_first_factor' }),
+      );
+    });
+
+    it('register/verify returns the opaque 401 for a passwordless account with an invalid/expired grant (no passkey written)', async () => {
+      dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]); // enforceExistingFactorStepUp's userIsMfaProtected
+      dbState.selectQueue.push([{ passwordHash: null }]); // resolveEnrollmentStepUp probe
+      dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]); // resolveEnrollmentStepUp's userIsMfaProtected
+      vi.mocked(consumeStepUpGrant).mockResolvedValueOnce(false);
+
+      const res = await app.request('/auth/passkeys/register/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+        body: JSON.stringify({
+          credential: { id: 'credential-1' },
+          ssoReauthGrantId: '11111111-1111-4111-8111-111111111111',
+        }),
+      });
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: 'Invalid credentials' });
+    });
+  });
+
   it('rejects invalid or expired passkey registration challenges', async () => {
     passkeyMocks.verifyPasskeyRegistration.mockRejectedValueOnce(
       new PasskeyChallengeError('Passkey challenge is missing or expired'),

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -1099,9 +1099,12 @@ describe('passkey MFA auth routes', () => {
   it('does not overwrite an existing TOTP factor method when registering a passkey', async () => {
     // SR2-20: this account is already MFA-protected (has TOTP), so
     // register/verify requires a fresh existing-factor step-up grant.
-    // Query order: userIsMfaProtected (gate) first, then the transaction's
-    // own "current MFA" read (hasExistingFactor check) second.
+    // Query order: userIsMfaProtected (gate) first, then #4018's
+    // resolveEnrollmentStepUp terminal read (passwordHash — this is a password
+    // account, so it is a no-op), then the transaction's own "current MFA" read
+    // (hasExistingFactor check).
     dbState.selectQueue.push([{ mfaEnabled: true, passkeyCount: 0 }]);
+    dbState.selectQueue.push([{ passwordHash: '$argon2id$hash' }]);
     dbState.selectQueue.push([{ mfaSecret: 'enc-secret', mfaMethod: 'totp' }]);
     vi.mocked(consumeStepUpGrant).mockResolvedValueOnce(true);
 
@@ -1140,8 +1143,10 @@ describe('passkey MFA auth routes', () => {
 
   it('makes passkey the primary MFA method when the user has no existing factor', async () => {
     // SR2-20: no-factor account — initial enrollment stays password-only, no
-    // step-up grant required.
+    // step-up grant required. #4018 adds the passwordHash read between the
+    // gate and the transaction's own "current MFA" read.
     dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]);
+    dbState.selectQueue.push([{ passwordHash: '$argon2id$hash' }]);
     dbState.selectQueue.push([{ mfaSecret: null, mfaMethod: null }]);
 
     const res = await app.request('/auth/passkeys/register/verify', {

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1498,10 +1498,14 @@ describe('auth routes', () => {
       };
       vi.mocked(getRedis).mockReturnValue(mockRedis as any);
       vi.mocked(consumeMFAToken).mockResolvedValue(true);
+      // One row satisfies both reads on this path: userIsMfaProtected sees no
+      // mfaEnabled/passkeyCount (no factor yet), and #4018's
+      // resolveEnrollmentStepUp sees a passwordHash — i.e. an ordinary password
+      // account, whose enrollment road is unchanged.
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([])
+            limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash' }])
           })
         })
       } as any);
@@ -1554,7 +1558,7 @@ describe('auth routes', () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{ mfaEnabled: true, passkeyCount: 0 }])
+            limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash', mfaEnabled: true, passkeyCount: 0 }])
           })
         })
       } as any);
@@ -1576,7 +1580,7 @@ describe('auth routes', () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{ mfaEnabled: true, passkeyCount: 0 }])
+            limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash', mfaEnabled: true, passkeyCount: 0 }])
           })
         })
       } as any);
@@ -1602,7 +1606,7 @@ describe('auth routes', () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{ mfaEnabled: true, passkeyCount: 0 }])
+            limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash', mfaEnabled: true, passkeyCount: 0 }])
           })
         })
       } as any);
@@ -2476,7 +2480,10 @@ describe('auth routes', () => {
       vi.mocked(getRedis).mockReturnValue(mockRedis as any);
       vi.mocked(consumeMFAToken).mockResolvedValue(true);
       vi.mocked(verifyPassword).mockResolvedValue(true);
-      // Password-reprompt select runs first, then enable's own select
+      // Password-reprompt select runs first, then enable's own selects. The
+      // fallback row carries passwordHash so #4018's terminal
+      // resolveEnrollmentStepUp still sees a password account (it reads nothing
+      // else, and userIsMfaProtected reads only mfaEnabled/passkeyCount).
       vi.mocked(db.select)
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
@@ -2488,7 +2495,7 @@ describe('auth routes', () => {
         .mockReturnValue({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([])
+              limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash' }])
             })
           })
         } as any);
@@ -2536,7 +2543,7 @@ describe('auth routes', () => {
         .mockReturnValue({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([{ mfaEnabled: true, passkeyCount: 0 }])
+              limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash', mfaEnabled: true, passkeyCount: 0 }])
             })
           })
         } as any);
@@ -2585,21 +2592,21 @@ describe('auth routes', () => {
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([{ mfaEnabled: true, passkeyCount: 0 }])
+              limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash', mfaEnabled: true, passkeyCount: 0 }])
             })
           })
         } as any)
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([{ mfaEnabled: true, passkeyCount: 0 }])
+              limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash', mfaEnabled: true, passkeyCount: 0 }])
             })
           })
         } as any)
         .mockReturnValue({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([])
+              limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash' }])
             })
           })
         } as any);
@@ -2719,7 +2726,19 @@ describe('auth routes', () => {
       expect(consumeMFAToken).not.toHaveBeenCalled();
     });
 
+    // #4018: BOTH enrollment proofs are optional in the schema now, so "no
+    // proof at all" is resolveEnrollmentStepUp's opaque 401 rather than a 400
+    // from zod. That is the point: the shape of the rejection must not tell an
+    // attacker whether this account has a password.
     it('POST /auth/mfa/enable should reject missing currentPassword (G1)', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash' }])
+          })
+        })
+      } as any);
+
       const res = await app.request('/auth/mfa/enable', {
         method: 'POST',
         headers: {
@@ -2729,7 +2748,9 @@ describe('auth routes', () => {
         body: JSON.stringify({ code: '123456' })
       });
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: 'Invalid credentials' });
+      expect(db.transaction).not.toHaveBeenCalled();
     });
 
     it('POST /auth/mfa/enable should return 401 on wrong password (G1)', async () => {
@@ -2754,7 +2775,17 @@ describe('auth routes', () => {
       expect(res.status).toBe(401);
     });
 
+    // #4018: see the /mfa/enable G1 note above — no proof at all is now an
+    // opaque 401, not a 400.
     it('POST /auth/mfa/setup should reject missing currentPassword (G1)', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash' }])
+          })
+        })
+      } as any);
+
       const res = await app.request('/auth/mfa/setup', {
         method: 'POST',
         headers: {
@@ -2764,7 +2795,8 @@ describe('auth routes', () => {
         body: JSON.stringify({})
       });
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: 'Invalid credentials' });
     });
 
     it('POST /auth/mfa/setup should return 401 on wrong password (G1)', async () => {

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -2524,6 +2524,13 @@ describe('auth routes', () => {
       // SR2-24: /mfa/enable must use the consuming verifier so the accepted
       // step is recorded and cannot be replayed at login.
       expect(consumeMFAToken).toHaveBeenCalledWith('MFASECRET123', '123456', 'user-123');
+      // Regression for the mfa.ts:746 bug: the terminal resolveEnrollmentStepUp
+      // call must NOT re-pass currentPassword (only the gate call above
+      // should). If it did, resolveEnrollmentStepUp's road-1 short-circuit
+      // would re-run requireCurrentPasswordStepUp — a second verifyPassword
+      // call that double-charges the per-user step-up rate limit and runs
+      // argon2 twice for every successful enable.
+      expect(verifyPassword).toHaveBeenCalledTimes(1);
     });
 
     // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -2828,6 +2828,184 @@ describe('auth routes', () => {
       expect(res.status).toBe(401);
     });
 
+    // #4018 review finding 2: no route-level test proved the SSO re-auth road
+    // actually works end to end for /mfa/setup or /mfa/enable — only
+    // sso.reauth.test.ts and schemas.test.ts referenced ssoReauthGrantId, and
+    // neither calls these routes. A passwordless account (no `currentPassword`
+    // sent, `passwordHash: null` on the account) with zero existing factors
+    // and a fresh `enroll_first_factor` grant from GET /sso/callback (reauth
+    // mode) must be able to complete the whole setup -> enable flow; an
+    // invalid/expired grant must be rejected with the same opaque 401 the
+    // password road uses.
+    describe('#4018 SSO re-auth road on /mfa/setup and /mfa/enable', () => {
+      it('POST /auth/mfa/setup SUCCEEDS for a passwordless, zero-factor account with a valid enrollment grant (validates, does not consume)', async () => {
+        const mockRedis = { get: vi.fn(), setex: vi.fn(), del: vi.fn() };
+        vi.mocked(getRedis).mockReturnValue(mockRedis as any);
+        vi.mocked(validateStepUpGrant).mockResolvedValueOnce(true);
+        vi.mocked(db.select)
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ passwordHash: null }]) // resolveEnrollmentStepUp probe
+              })
+            })
+          } as any)
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ mfaEnabled: false, passkeyCount: 0 }]) // resolveEnrollmentStepUp's userIsMfaProtected
+              })
+            })
+          } as any)
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ mfaEnabled: false }]) // handler's own "already enabled?" check
+              })
+            })
+          } as any);
+
+        const res = await app.request('/auth/mfa/setup', {
+          method: 'POST',
+          headers: {
+            'Authorization': 'Bearer valid-token',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ ssoReauthGrantId: '11111111-1111-4111-8111-111111111111' })
+        });
+
+        expect(res.status).toBe(200);
+        expect(verifyPassword).not.toHaveBeenCalled();
+        expect(validateStepUpGrant).toHaveBeenCalledWith(
+          '11111111-1111-4111-8111-111111111111',
+          expect.objectContaining({ userId: 'user-123', operation: 'enroll_first_factor' })
+        );
+        expect(consumeStepUpGrant).not.toHaveBeenCalled();
+        expect(mockRedis.setex).toHaveBeenCalled();
+      });
+
+      it('POST /auth/mfa/setup returns the opaque 401 for a passwordless account with an invalid/expired grant', async () => {
+        vi.mocked(validateStepUpGrant).mockResolvedValueOnce(false);
+        vi.mocked(db.select)
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ passwordHash: null }]) // resolveEnrollmentStepUp probe
+              })
+            })
+          } as any)
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ mfaEnabled: false, passkeyCount: 0 }]) // resolveEnrollmentStepUp's userIsMfaProtected
+              })
+            })
+          } as any);
+
+        const res = await app.request('/auth/mfa/setup', {
+          method: 'POST',
+          headers: {
+            'Authorization': 'Bearer valid-token',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ ssoReauthGrantId: '11111111-1111-4111-8111-111111111111' })
+        });
+
+        expect(res.status).toBe(401);
+        expect(await res.json()).toEqual({ error: 'Invalid credentials' });
+      });
+
+      it('POST /auth/mfa/enable SUCCEEDS for a passwordless, zero-factor account with a valid enrollment grant (consumes it at the terminal write)', async () => {
+        const setupRecoveryCodes = ['CODE-0001', 'CODE-0002'];
+        const mockRedis = {
+          get: vi.fn().mockResolvedValue(JSON.stringify({
+            secret: 'MFASECRET123',
+            recoveryCodes: setupRecoveryCodes
+          })),
+          setex: vi.fn(),
+          del: vi.fn().mockResolvedValue(1)
+        };
+        vi.mocked(getRedis).mockReturnValue(mockRedis as any);
+        vi.mocked(consumeMFAToken).mockResolvedValue(true);
+        stubTx();
+        useGrantStore(['11111111-1111-4111-8111-111111111111']);
+        // Zero-factor account: every userIsMfaProtected read (both from
+        // enforceExistingFactorStepUp and from resolveEnrollmentStepUp) sees
+        // no factor yet, and every passwordHash probe sees a passwordless
+        // account, so the same two row shapes repeat across all six reads on
+        // this path (gate: probe + protected; enforceExistingFactorStepUp
+        // non-consuming + consuming: protected x2; terminal gate: probe +
+        // protected).
+        vi.mocked(db.select)
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ passwordHash: null }])
+              })
+            })
+          } as any)
+          .mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ mfaEnabled: false, passkeyCount: 0 }])
+              })
+            })
+          } as any);
+
+        const res = await app.request('/auth/mfa/enable', {
+          method: 'POST',
+          headers: { 'Authorization': 'Bearer valid-token', 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code: '123456', ssoReauthGrantId: '11111111-1111-4111-8111-111111111111' })
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.success).toBe(true);
+        expect(consumeStepUpGrant).toHaveBeenCalledWith(
+          '11111111-1111-4111-8111-111111111111',
+          expect.objectContaining({ userId: 'user-123', operation: 'enroll_first_factor' })
+        );
+      });
+
+      it('POST /auth/mfa/enable returns the opaque 401 for a passwordless account with an invalid/expired grant (no factor written)', async () => {
+        const mockRedis = {
+          get: vi.fn().mockResolvedValue(JSON.stringify({
+            secret: 'MFASECRET123',
+            recoveryCodes: ['CODE-0001', 'CODE-0002']
+          })),
+          setex: vi.fn(),
+          del: vi.fn().mockResolvedValue(1)
+        };
+        vi.mocked(getRedis).mockReturnValue(mockRedis as any);
+        vi.mocked(validateStepUpGrant).mockResolvedValueOnce(false);
+        vi.mocked(db.select)
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ passwordHash: null }]) // resolveEnrollmentStepUp probe
+              })
+            })
+          } as any)
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ mfaEnabled: false, passkeyCount: 0 }]) // resolveEnrollmentStepUp's userIsMfaProtected
+              })
+            })
+          } as any);
+
+        const res = await app.request('/auth/mfa/enable', {
+          method: 'POST',
+          headers: { 'Authorization': 'Bearer valid-token', 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code: '123456', ssoReauthGrantId: '11111111-1111-4111-8111-111111111111' })
+        });
+
+        expect(res.status).toBe(401);
+        expect(await res.json()).toEqual({ error: 'Invalid credentials' });
+        expect(consumeMFAToken).not.toHaveBeenCalled();
+      });
+    });
+
     it('POST /auth/mfa/disable should reject missing currentPassword (G1)', async () => {
       const res = await app.request('/auth/mfa/disable', {
         method: 'POST',

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1529,6 +1529,138 @@ describe('auth routes', () => {
     });
   });
 
+  // #4018: the PASSWORDLESS road through Case 2. Every other test in this file
+  // hard-codes `passwordHash: '$argon2id$hash'` on the shared db.select mock, so
+  // the branch resolveEnrollmentStepUp takes for `password_hash IS NULL` had
+  // ZERO coverage in either direction — and this is the caller that matters
+  // most, because it is the one with no ambient DB access context (the
+  // `await authMiddleware(c, async () => {})` above tears it down when its empty
+  // `next` returns).
+  describe('POST /auth/mfa/verify — setup confirmation on a PASSWORDLESS account (#4018)', () => {
+    // One row answers every read on this path: resolveEnrollmentStepUp's
+    // passwordHash probe AND both userIsMfaProtected probes (no factor yet).
+    function mockPasswordlessPendingSetup(row: Record<string, unknown> = {}) {
+      const mockRedis = {
+        get: vi.fn().mockResolvedValue(JSON.stringify({
+          secret: 'SETUPSECRET123',
+          recoveryCodes: ['CODE-0001', 'CODE-0002']
+        })),
+        del: vi.fn().mockResolvedValue(1),
+        setex: vi.fn(),
+      };
+      vi.mocked(getRedis).mockReturnValue(mockRedis as any);
+      vi.mocked(consumeMFAToken).mockResolvedValue(true);
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              { passwordHash: null, mfaEnabled: false, passkeyCount: 0, ...row }
+            ])
+          })
+        })
+      } as any);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) })
+      } as any);
+    }
+
+    // mfaVerifySchema types ssoReauthGrantId as z.string().uuid() — mintStepUpGrant
+    // returns randomUUID(), so anything else is a 400 before the road is reached.
+    const SSO_GRANT_ID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+
+    function confirm(body: Record<string, unknown>) {
+      return app.request('/auth/mfa/verify', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+    }
+
+    it('enrolls the first factor with a valid SSO re-auth grant, consuming it exactly once', async () => {
+      mockPasswordlessPendingSetup();
+      const grants = useGrantStore([SSO_GRANT_ID]);
+
+      const res = await confirm({ code: '123456', ssoReauthGrantId: SSO_GRANT_ID });
+
+      expect(res.status).toBe(200);
+      expect(consumeStepUpGrant).toHaveBeenCalledWith(
+        SSO_GRANT_ID,
+        expect.objectContaining({ userId: 'user-123', operation: 'enroll_first_factor' })
+      );
+      expect(grants.has(SSO_GRANT_ID)).toBe(false);
+    });
+
+    // The dead end review finding 7 is about, seen from the server: a client
+    // that lost its single-use grant sends nothing, and a generic
+    // `Invalid credentials` would render on a screen with no password field.
+    it('answers enrollment_proof_required — not a generic 401 — when NO proof is sent', async () => {
+      mockPasswordlessPendingSetup();
+
+      const res = await confirm({ code: '123456' });
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toMatchObject({
+        error: 'enrollment_proof_required',
+        reauthUrl: '/sso/reauth/start',
+      });
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('401s a grant that no longer validates (replayed, wrong session, bumped epoch)', async () => {
+      mockPasswordlessPendingSetup();
+      useGrantStore([]); // empty store: the grant is gone
+
+      const res = await confirm({ code: '123456', ssoReauthGrantId: SSO_GRANT_ID });
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toMatchObject({ error: 'Invalid credentials' });
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    // enroll_first_factor authorizes a FIRST factor and nothing else. A
+    // passwordless account that already holds one must go the SR2-20 road.
+    it('refuses the SSO road outright for a passwordless account that ALREADY has a factor', async () => {
+      mockPasswordlessPendingSetup({ mfaEnabled: true });
+      const grants = useGrantStore([SSO_GRANT_ID]);
+
+      const res = await confirm({ code: '123456', ssoReauthGrantId: SSO_GRANT_ID });
+
+      // enforceExistingFactorStepUp (SR2-20) fires first for this shape — the
+      // point is that the enroll_first_factor grant does NOT satisfy it, and is
+      // not spent trying.
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ error: 'existing_factor_step_up_required' });
+      expect(grants.has(SSO_GRANT_ID)).toBe(true);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    // The password road through this same endpoint must be byte-for-byte
+    // unchanged: an account WITH a password never needs (or may use) a grant.
+    it('leaves the password road alone — a password account needs no grant here', async () => {
+      mockPasswordlessPendingSetup({ passwordHash: '$argon2id$hash' });
+
+      const res = await confirm({ code: '123456' });
+
+      expect(res.status).toBe(200);
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    // ...and must be REFUSED the SSO road, so two proofs of differing strength
+    // can never reach the same door.
+    it('refuses an SSO grant offered by an account that HAS a password', async () => {
+      mockPasswordlessPendingSetup({ passwordHash: '$argon2id$hash' });
+      const grants = useGrantStore([SSO_GRANT_ID]);
+
+      const res = await confirm({ code: '123456', ssoReauthGrantId: SSO_GRANT_ID });
+
+      // passwordAlreadyProven short-circuits the password road for a password
+      // account, so the grant is simply never consulted.
+      expect(res.status).toBe(200);
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+      expect(grants.has(SSO_GRANT_ID)).toBe(true);
+    });
+  });
+
   // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
   // requires a fresh existing-factor step-up grant. A no-factor account's
   // initial enrollment (default db.select mock = []) stays password-only,

--- a/apps/api/src/routes/auth/helpers.enrollmentStepUp.test.ts
+++ b/apps/api/src/routes/auth/helpers.enrollmentStepUp.test.ts
@@ -16,6 +16,7 @@ const {
   getUserEpochs,
   validateStepUpGrant,
   consumeStepUpGrant,
+  withSystemDbAccessContext,
 } = vi.hoisted(() => {
   const selectLimit = vi.fn();
   const db = {
@@ -37,12 +38,22 @@ const {
     getUserEpochs: vi.fn(),
     validateStepUpGrant: vi.fn(),
     consumeStepUpGrant: vi.fn(),
+    // #4018 review finding 3: this MUST be a real, observable spy — not
+    // `undefined`. `runWithSystemDbAccess` in helpers.ts falls back to
+    // calling `fn()` directly whenever `withSystemDbAccessContext` is not a
+    // function, so `undefined` here made the wrapper's presence or absence
+    // invisible to every test in this file: removing it from the
+    // implementation would not fail a single assertion. A `vi.fn` that
+    // passes through to `fn()` preserves the exact same runtime behaviour
+    // (still a no-op passthrough) while making "was the read wrapped"
+    // observable via `toHaveBeenCalled()`.
+    withSystemDbAccessContext: vi.fn(),
   };
 });
 
 vi.mock('../../db', () => ({
   db,
-  withSystemDbAccessContext: undefined,
+  withSystemDbAccessContext,
 }));
 
 vi.mock('../../db/schema', () => ({
@@ -151,6 +162,10 @@ describe('resolveEnrollmentStepUp', () => {
     getRedis.mockReturnValue({} as any);
     rateLimiter.mockResolvedValue({ allowed: true, resetAt: new Date(Date.now() + 60_000) });
     getUserEpochs.mockResolvedValue({ authEpoch: 3, mfaEpoch: 1 });
+    // Passthrough, matching production's real withSystemDbAccessContext: runs
+    // the callback and returns its result. Runtime behaviour is unchanged from
+    // the old `undefined` stub — only the call is now observable.
+    withSystemDbAccessContext.mockImplementation((fn: () => Promise<unknown>) => fn());
   });
 
   describe('password road (unchanged, and always evaluated first)', () => {
@@ -259,6 +274,26 @@ describe('resolveEnrollmentStepUp', () => {
 
       expect(rateLimiter).not.toHaveBeenCalled();
       expect(verifyPassword).not.toHaveBeenCalled();
+    });
+
+    // #4018 review finding 3: production bug this wrapper fixes — GET
+    // /auth/mfa/verify Case 2 runs with NO ambient DB access context (its own
+    // `authMiddleware(c, async () => {})` tears the context down when the
+    // empty `next` returns), and a contextless read under forced RLS as
+    // `breeze_app` matches ZERO rows rather than erroring. An unwrapped probe
+    // would therefore read `!user` and opaque-401 EVERY caller of that path,
+    // password accounts included — not just the passwordless SSO road this
+    // describe block is about. Both system-context reads on this road (the
+    // passwordHash road-decision probe, then userIsMfaProtected's factor
+    // check) must go through the wrapper.
+    it('runs both SSO-road reads under a system DB access context (I3: no ambient context on /mfa/verify Case 2)', async () => {
+      queuePasswordlessNoFactor();
+      consumeStepUpGrant.mockResolvedValue(true);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
+
+      expect(res).toBeNull();
+      expect(withSystemDbAccessContext).toHaveBeenCalledTimes(2);
     });
 
     it('401s a grant that fails to validate (wrong session, bumped epoch, replay)', async () => {

--- a/apps/api/src/routes/auth/helpers.enrollmentStepUp.test.ts
+++ b/apps/api/src/routes/auth/helpers.enrollmentStepUp.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { AuthContext } from '../../middleware/auth';
+
+// --- Mocks must be declared before importing the unit under test ---
+// Mirrors the vi.hoisted/vi.mock harness in helpers.registerStepUp.test.ts:
+// getUserEpochs + validateStepUpGrant/consumeStepUpGrant are needed because
+// resolveEnrollmentStepUp exercises both grant phases, and verifyPassword +
+// rateLimiter because the password road delegates to
+// requireCurrentPasswordStepUp for real (this file does NOT mock ./helpers).
+const {
+  selectLimit,
+  db,
+  getRedis,
+  rateLimiter,
+  verifyPassword,
+  getUserEpochs,
+  validateStepUpGrant,
+  consumeStepUpGrant,
+} = vi.hoisted(() => {
+  const selectLimit = vi.fn();
+  const db = {
+    // db.select(...).from(...).where(...).limit(...) chain returning the mocked user row.
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: selectLimit,
+        })),
+      })),
+    })),
+  };
+  return {
+    selectLimit,
+    db,
+    getRedis: vi.fn(),
+    rateLimiter: vi.fn(),
+    verifyPassword: vi.fn(),
+    getUserEpochs: vi.fn(),
+    validateStepUpGrant: vi.fn(),
+    consumeStepUpGrant: vi.fn(),
+  };
+});
+
+vi.mock('../../db', () => ({
+  db,
+  withSystemDbAccessContext: undefined,
+}));
+
+vi.mock('../../db/schema', () => ({
+  users: { id: 'id', mfaEnabled: 'mfa_enabled', passwordHash: 'password_hash' },
+  userPasskeys: { id: 'id', userId: 'user_id', disabledAt: 'disabled_at' },
+  partnerUsers: {},
+  organizationUsers: {},
+  organizations: {},
+}));
+
+vi.mock('../../services', () => ({
+  verifyToken: vi.fn(),
+  isUserTokenRevoked: vi.fn(),
+  revokeRefreshTokenJti: vi.fn(),
+  getTrustedClientIp: vi.fn(() => 'unknown'),
+  getRedis,
+  rateLimiter,
+  verifyPassword,
+  getUserEpochs,
+}));
+
+vi.mock('../../services/mfa', () => ({ consumeMFAToken: vi.fn() }));
+
+vi.mock('../../services/mfaSecretCrypto', () => ({
+  decryptMfaTotpSecret: vi.fn(),
+  decryptMfaTotpSecretForMigration: vi.fn(),
+  encryptMfaTotpSecret: vi.fn(),
+}));
+
+vi.mock('../../services/mfaStepUpGrant', () => ({
+  mintStepUpGrant: vi.fn(),
+  validateStepUpGrant,
+  consumeStepUpGrant,
+}));
+
+vi.mock('../../services/auditService', () => ({ createAuditLogAsync: vi.fn() }));
+vi.mock('../../services/anomalyMetrics', () => ({ recordFailedLogin: vi.fn() }));
+vi.mock('../../services/corsOrigins', () => ({
+  DEFAULT_ALLOWED_ORIGINS: [],
+  shouldIncludeDefaultOrigins: vi.fn(() => false),
+}));
+vi.mock('../../services/tenantStatus', () => ({ assertActiveTenantContext: vi.fn() }));
+
+import { resolveEnrollmentStepUp } from './helpers';
+
+// Minimal Hono Context stub: only c.json is exercised by the helper.
+function ctx() {
+  const json = vi.fn((body: unknown, status?: number) => ({
+    __body: body,
+    __status: status ?? 200,
+    status: status ?? 200,
+    json: async () => body,
+  }));
+  const req = { header: vi.fn(() => undefined) };
+  return { json, req } as any;
+}
+
+const USER_ID = 'user-123';
+const SID = 'family-abc';
+const HASH = '$argon2id$hash';
+const GRANT = 'grant-abc';
+
+// Minimal AuthContext stub: only auth.user.id and auth.token.sid are read.
+function authCtx(tokenOverrides: { sid?: string } = { sid: SID }): AuthContext {
+  return {
+    user: { id: USER_ID, email: 'user@example.com', name: 'Test User', isPlatformAdmin: false },
+    token: { sub: USER_ID, type: 'access', sid: tokenOverrides.sid },
+    partnerId: null,
+    orgId: null,
+    scope: 'organization',
+  } as unknown as AuthContext;
+}
+
+// Queue-based stand-in for the SEQUENTIAL db.select(...).limit() resolutions
+// resolveEnrollmentStepUp performs: (1) the passwordHash road decision, then
+// on the SSO road (2) userIsMfaProtected's factor probe, and on the password
+// road (2') requireCurrentPasswordStepUp's own passwordHash lookup.
+const dbState = { selectQueue: [] as unknown[][] };
+
+/** Passwordless account with NO existing factor — the only shape the SSO road accepts. */
+function queuePasswordlessNoFactor() {
+  dbState.selectQueue.push([{ passwordHash: null }]);
+  dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]);
+}
+
+/** Passwordless account that is ALREADY protected by `factor`. */
+function queuePasswordlessWithFactor(factor: { mfaEnabled?: boolean; passkeyCount?: number }) {
+  dbState.selectQueue.push([{ passwordHash: null }]);
+  dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0, ...factor }]);
+}
+
+/** Account WITH a password. Both the road decision and the password verify read it. */
+function queuePasswordAccount() {
+  dbState.selectQueue.push([{ passwordHash: HASH }]);
+  dbState.selectQueue.push([{ passwordHash: HASH }]);
+}
+
+const GATE = { keyPrefix: 'mfa:pwd', consume: false } as const;
+const TERMINAL = { keyPrefix: 'mfa:pwd', consume: true } as const;
+
+describe('resolveEnrollmentStepUp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState.selectQueue = [];
+    selectLimit.mockImplementation(() => Promise.resolve(dbState.selectQueue.shift() ?? []));
+    getRedis.mockReturnValue({} as any);
+    rateLimiter.mockResolvedValue({ allowed: true, resetAt: new Date(Date.now() + 60_000) });
+    getUserEpochs.mockResolvedValue({ authEpoch: 3, mfaEpoch: 1 });
+  });
+
+  describe('password road (unchanged, and always evaluated first)', () => {
+    it('takes the password path when a password is supplied', async () => {
+      queuePasswordAccount();
+      verifyPassword.mockResolvedValue(true);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { currentPassword: 'pw' }, TERMINAL);
+
+      expect(res).toBeNull();
+      expect(verifyPassword).toHaveBeenCalledWith(HASH, 'pw');
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+      expect(validateStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('401s a wrong password without ever reaching the SSO road', async () => {
+      queuePasswordAccount();
+      verifyPassword.mockResolvedValue(false);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { currentPassword: 'nope' }, TERMINAL);
+
+      expect((res as any).__status).toBe(401);
+      expect((res as any).__body).toEqual({ error: 'Invalid credentials' });
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('rate-limits the password road through the supplied keyPrefix', async () => {
+      queuePasswordAccount();
+      verifyPassword.mockResolvedValue(true);
+
+      await resolveEnrollmentStepUp(ctx(), authCtx(), { currentPassword: 'pw' }, { keyPrefix: 'passkey:pwd', consume: false });
+
+      expect(rateLimiter).toHaveBeenCalledWith(expect.anything(), `passkey:pwd:${USER_ID}`, 5, 5 * 60);
+    });
+
+    it('rejects an SSO grant when the account HAS a password', async () => {
+      queuePasswordAccount();
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
+
+      expect((res as any).__status).toBe(401);
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+      expect(validateStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('passwordAlreadyProven short-circuits ONLY the password road, never the SSO road', async () => {
+      queuePasswordAccount();
+
+      const res = await resolveEnrollmentStepUp(
+        ctx(),
+        authCtx(),
+        {},
+        { keyPrefix: 'mfa:pwd', consume: true, passwordAlreadyProven: true },
+      );
+
+      expect(res).toBeNull();
+      // No second lookup, no verify, no rate-limit charge: the gate did that.
+      expect(verifyPassword).not.toHaveBeenCalled();
+      expect(rateLimiter).not.toHaveBeenCalled();
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('SSO road (passwordless accounts only)', () => {
+    it('accepts a valid SSO grant for a passwordless account and consumes it', async () => {
+      queuePasswordlessNoFactor();
+      consumeStepUpGrant.mockResolvedValue(true);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
+
+      expect(res).toBeNull();
+      // The bind tuple must reconstruct routes/sso.ts's mint site MEMBER FOR
+      // MEMBER — bindsMatch fails closed on any difference.
+      expect(consumeStepUpGrant).toHaveBeenCalledWith(GRANT, {
+        userId: USER_ID,
+        operation: 'enroll_first_factor',
+        authEpoch: 3,
+        mfaEpoch: 1,
+        sid: SID,
+      });
+      expect(validateStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('validates without consuming when consume is false', async () => {
+      queuePasswordlessNoFactor();
+      validateStepUpGrant.mockResolvedValue(true);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, { keyPrefix: 'passkey:pwd', consume: false });
+
+      expect(res).toBeNull();
+      expect(validateStepUpGrant).toHaveBeenCalledWith(GRANT, {
+        userId: USER_ID,
+        operation: 'enroll_first_factor',
+        authEpoch: 3,
+        mfaEpoch: 1,
+        sid: SID,
+      });
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('never charges the password rate limiter on the SSO road', async () => {
+      queuePasswordlessNoFactor();
+      consumeStepUpGrant.mockResolvedValue(true);
+
+      await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
+
+      expect(rateLimiter).not.toHaveBeenCalled();
+      expect(verifyPassword).not.toHaveBeenCalled();
+    });
+
+    it('401s a grant that fails to validate (wrong session, bumped epoch, replay)', async () => {
+      queuePasswordlessNoFactor();
+      consumeStepUpGrant.mockResolvedValue(false);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
+
+      expect((res as any).__status).toBe(401);
+      expect((res as any).__body).toEqual({ error: 'Invalid credentials' });
+    });
+
+    it('401s when neither proof is supplied', async () => {
+      dbState.selectQueue.push([{ passwordHash: null }]);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), {}, TERMINAL);
+
+      expect((res as any).__status).toBe(401);
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('503s when the live epochs are unavailable', async () => {
+      queuePasswordlessNoFactor();
+      getUserEpochs.mockResolvedValue(null);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
+
+      expect((res as any).__status).toBe(503);
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('503s when the session carries no sid to bind against', async () => {
+      queuePasswordlessNoFactor();
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx({}), { ssoReauthGrantId: GRANT }, TERMINAL);
+
+      expect((res as any).__status).toBe(503);
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('401s an unknown user without distinguishing it from any other rejection', async () => {
+      dbState.selectQueue.push([]);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
+
+      expect((res as any).__status).toBe(401);
+      expect((res as any).__body).toEqual({ error: 'Invalid credentials' });
+    });
+  });
+
+  // The gap two reviewers flagged in the plan: `enroll_first_factor` authorizes
+  // a FIRST factor and nothing else. Without the userIsMfaProtected check a
+  // passwordless account that ALREADY holds a factor could re-auth at its IdP
+  // and use the grant to add a SECOND one, side-stepping
+  // enforceExistingFactorStepUp (SR2-20).
+  describe('FIRST factor only — the SSO road is refused for an already-protected account', () => {
+    it('allows a passwordless account with ZERO factors', async () => {
+      queuePasswordlessNoFactor();
+      consumeStepUpGrant.mockResolvedValue(true);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
+
+      expect(res).toBeNull();
+      expect(consumeStepUpGrant).toHaveBeenCalledTimes(1);
+    });
+
+    it('REFUSES a passwordless account that already has TOTP', async () => {
+      queuePasswordlessWithFactor({ mfaEnabled: true });
+      consumeStepUpGrant.mockResolvedValue(true);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
+
+      expect((res as any).__status).toBe(401);
+      expect((res as any).__body).toEqual({ error: 'Invalid credentials' });
+      // Refused BEFORE the grant is touched: a rejected enrollment must not
+      // burn the caller's single-use grant.
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+      expect(validateStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('REFUSES a passwordless account that already has a non-disabled passkey', async () => {
+      queuePasswordlessWithFactor({ passkeyCount: 1 });
+      consumeStepUpGrant.mockResolvedValue(true);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
+
+      expect((res as any).__status).toBe(401);
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+      expect(validateStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('REFUSES at the non-consuming gate too, not just the terminal write', async () => {
+      queuePasswordlessWithFactor({ mfaEnabled: true });
+      validateStepUpGrant.mockResolvedValue(true);
+
+      const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, GATE);
+
+      expect((res as any).__status).toBe(401);
+      expect(validateStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('REFUSES even when passwordAlreadyProven is set (that flag never opens the SSO road)', async () => {
+      queuePasswordlessWithFactor({ passkeyCount: 2 });
+      consumeStepUpGrant.mockResolvedValue(true);
+
+      const res = await resolveEnrollmentStepUp(
+        ctx(),
+        authCtx(),
+        { ssoReauthGrantId: GRANT },
+        { keyPrefix: 'passkey:pwd', consume: true, passwordAlreadyProven: true },
+      );
+
+      expect((res as any).__status).toBe(401);
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/routes/auth/helpers.mfaStepUp.test.ts
+++ b/apps/api/src/routes/auth/helpers.mfaStepUp.test.ts
@@ -27,7 +27,12 @@ const { selectLimit, db, getRedis, rateLimiter, consumeMFAToken, decryptMfaTotpS
 
 vi.mock('../../db', () => ({
   db,
-  withSystemDbAccessContext: undefined,
+  // Passthrough, matching production's real withSystemDbAccessContext when it
+  // is nested inside an existing context. NOT `undefined`: runWithSystemDbAccess
+  // now THROWS rather than silently running the probe contextless, because that
+  // fallback degraded a security read into a zero-row read whose answer is the
+  // permissive one (see the helper's doc comment).
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/auth/helpers.registerStepUp.test.ts
+++ b/apps/api/src/routes/auth/helpers.registerStepUp.test.ts
@@ -47,7 +47,12 @@ const {
 
 vi.mock('../../db', () => ({
   db,
-  withSystemDbAccessContext: undefined,
+  // Passthrough, matching production's real withSystemDbAccessContext when it
+  // is nested inside an existing context. NOT `undefined`: runWithSystemDbAccess
+  // now THROWS rather than silently running the probe contextless, because that
+  // fallback degraded a security read into a zero-row read whose answer is the
+  // permissive one (see the helper's doc comment).
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/routes/auth/helpers.systemDbAccess.test.ts
+++ b/apps/api/src/routes/auth/helpers.systemDbAccess.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { AuthContext } from '../../middleware/auth';
+
+/**
+ * The two fail-OPEN holes in the system-DB-access probe chain, pinned.
+ *
+ * 1. `runWithSystemDbAccess` used to read
+ *    `typeof dbModule.withSystemDbAccessContext === 'function' ? withSystem(fn) : fn()`.
+ *    That `: fn()` is not a graceful fallback — it is a CONTEXTLESS query.
+ *    Under forced RLS as `breeze_app` a contextless read matches ZERO rows
+ *    rather than erroring, so the probe answers "nothing found" and the caller
+ *    reaches for its default.
+ * 2. `userIsMfaProtected` used to end `return row?.mfaEnabled === true || …`.
+ *    Zero rows -> `false` -> "this account has no MFA factor" -> the
+ *    PERMISSIVE answer on every gate that consumes it. Combined with (1), a
+ *    lost DB access context would report an account that actually holds TOTP
+ *    or a passkey as unprotected, opening the first-factor-enrollment road
+ *    that {@link resolveEnrollmentStepUp} exists to close.
+ *
+ * Both must now raise instead of answering. The `withSystemDbAccessContext`
+ * export is behind a live getter so this file can exercise BOTH the
+ * "wrapper missing entirely" case and the "wrapper present, row missing" case
+ * without a second module graph.
+ */
+const dbState = vi.hoisted(() => ({
+  // Swapped per test: undefined simulates a ../../db that does not export the
+  // wrapper (the only situation the old typeof check ever fired in).
+  withSystem: undefined as undefined | ((fn: () => Promise<unknown>) => Promise<unknown>),
+  selectQueue: [] as unknown[][],
+}));
+
+const { selectLimit, db, getRedis, rateLimiter, verifyPassword, getUserEpochs, validateStepUpGrant, consumeStepUpGrant } =
+  vi.hoisted(() => {
+    const selectLimit = vi.fn();
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({ limit: selectLimit })),
+        })),
+      })),
+    };
+    return {
+      selectLimit,
+      db,
+      getRedis: vi.fn(),
+      rateLimiter: vi.fn(),
+      verifyPassword: vi.fn(),
+      getUserEpochs: vi.fn(),
+      validateStepUpGrant: vi.fn(),
+      consumeStepUpGrant: vi.fn(),
+    };
+  });
+
+vi.mock('../../db', () => ({
+  db,
+  // Live getter, mirroring the ENABLE_2FA getter in helpers.registerStepUp.test.ts:
+  // helpers.ts reads `dbModule.withSystemDbAccessContext` at CALL time, so this
+  // flips per test without re-importing the module under test.
+  get withSystemDbAccessContext() {
+    return dbState.withSystem;
+  },
+}));
+
+vi.mock('../../db/schema', () => ({
+  users: { id: 'id', mfaEnabled: 'mfa_enabled', passwordHash: 'password_hash' },
+  userPasskeys: { id: 'id', userId: 'user_id', disabledAt: 'disabled_at' },
+  partnerUsers: {},
+  organizationUsers: {},
+  organizations: {},
+}));
+
+vi.mock('../../services', () => ({
+  verifyToken: vi.fn(),
+  isUserTokenRevoked: vi.fn(),
+  revokeRefreshTokenJti: vi.fn(),
+  getTrustedClientIp: vi.fn(() => 'unknown'),
+  getRedis,
+  rateLimiter,
+  verifyPassword,
+  getUserEpochs,
+}));
+
+vi.mock('../../services/mfa', () => ({ consumeMFAToken: vi.fn() }));
+vi.mock('../../services/mfaSecretCrypto', () => ({
+  decryptMfaTotpSecret: vi.fn(),
+  decryptMfaTotpSecretForMigration: vi.fn(),
+  encryptMfaTotpSecret: vi.fn(),
+}));
+vi.mock('../../services/mfaStepUpGrant', () => ({
+  mintStepUpGrant: vi.fn(),
+  validateStepUpGrant,
+  consumeStepUpGrant,
+}));
+vi.mock('../../services/auditService', () => ({ createAuditLogAsync: vi.fn() }));
+vi.mock('../../services/anomalyMetrics', () => ({ recordFailedLogin: vi.fn() }));
+vi.mock('../../services/corsOrigins', () => ({
+  DEFAULT_ALLOWED_ORIGINS: [],
+  shouldIncludeDefaultOrigins: vi.fn(() => false),
+}));
+vi.mock('../../services/tenantStatus', () => ({ assertActiveTenantContext: vi.fn() }));
+
+import { runWithSystemDbAccess, userIsMfaProtected, resolveEnrollmentStepUp } from './helpers';
+
+const USER_ID = 'user-123';
+const SID = 'family-abc';
+const GRANT = 'grant-abc';
+
+const passthrough = (fn: () => Promise<unknown>) => fn();
+
+function ctx() {
+  const json = vi.fn((body: unknown, status?: number) => ({
+    __body: body,
+    __status: status ?? 200,
+    status: status ?? 200,
+    json: async () => body,
+  }));
+  return { json, req: { header: vi.fn(() => undefined) } } as any;
+}
+
+function authCtx(): AuthContext {
+  return {
+    user: { id: USER_ID, email: 'user@example.com', name: 'Test User', isPlatformAdmin: false },
+    token: { sub: USER_ID, type: 'access', sid: SID },
+    partnerId: null,
+    orgId: null,
+    scope: 'organization',
+  } as unknown as AuthContext;
+}
+
+describe('runWithSystemDbAccess — fails CLOSED when the wrapper is unavailable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState.selectQueue = [];
+    selectLimit.mockImplementation(() => Promise.resolve(dbState.selectQueue.shift() ?? []));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('throws instead of running the callback with no DB access context', async () => {
+    dbState.withSystem = undefined;
+    const probe = vi.fn(async () => 'never');
+
+    await expect(runWithSystemDbAccess(probe)).rejects.toThrow(/withSystemDbAccessContext is unavailable/);
+    // The point of the change: the read does NOT happen contextlessly.
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('logs the refusal so a lost context is not silent in production', async () => {
+    dbState.withSystem = undefined;
+
+    await expect(runWithSystemDbAccess(async () => 'never')).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('withSystemDbAccessContext is unavailable')
+    );
+  });
+
+  it('still delegates to the wrapper when it IS available (the nested-context case is unchanged)', async () => {
+    const withSystem = vi.fn(passthrough);
+    dbState.withSystem = withSystem as any;
+
+    await expect(runWithSystemDbAccess(async () => 'ok')).resolves.toBe('ok');
+    expect(withSystem).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('userIsMfaProtected — a missing row is an ERROR, never "unprotected"', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState.selectQueue = [];
+    dbState.withSystem = passthrough as any;
+    selectLimit.mockImplementation(() => Promise.resolve(dbState.selectQueue.shift() ?? []));
+    getRedis.mockReturnValue({} as any);
+    rateLimiter.mockResolvedValue({ allowed: true, resetAt: new Date(Date.now() + 60_000) });
+    getUserEpochs.mockResolvedValue({ authEpoch: 3, mfaEpoch: 1 });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('throws on zero rows rather than reporting the account unprotected', async () => {
+    dbState.selectQueue.push([]);
+
+    await expect(userIsMfaProtected(USER_ID)).rejects.toThrow(/no users row/);
+  });
+
+  it('throws — rather than answering false — when the wrapper itself is unavailable', async () => {
+    dbState.withSystem = undefined;
+
+    await expect(userIsMfaProtected(USER_ID)).rejects.toThrow(/withSystemDbAccessContext is unavailable/);
+  });
+
+  it('still answers normally for a real row', async () => {
+    dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]);
+    await expect(userIsMfaProtected(USER_ID)).resolves.toBe(false);
+
+    dbState.selectQueue.push([{ mfaEnabled: true, passkeyCount: 0 }]);
+    await expect(userIsMfaProtected(USER_ID)).resolves.toBe(true);
+
+    dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 2 }]);
+    await expect(userIsMfaProtected(USER_ID)).resolves.toBe(true);
+  });
+
+  // The end-to-end shape of the old hole: the SSO enrollment road consults
+  // userIsMfaProtected to refuse an account that already holds a factor. With
+  // both fail-opens in place, a lost DB context turned that refusal into a
+  // pass. It must now propagate (the route's error path -> 500), never return
+  // `null` (= step-up satisfied, enroll away).
+  it('propagates out of resolveEnrollmentStepUp instead of opening the SSO road', async () => {
+    dbState.selectQueue.push([{ passwordHash: null }]); // road decision: passwordless
+    dbState.selectQueue.push([]);                       // factor probe: row vanished
+    consumeStepUpGrant.mockResolvedValue(true);
+
+    await expect(
+      resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, { keyPrefix: 'mfa:pwd', consume: true })
+    ).rejects.toThrow(/no users row/);
+
+    expect(consumeStepUpGrant).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -346,7 +346,9 @@ export async function enforceExistingFactorStepUp(
  * (SR2-20), which exists precisely to require proving an EXISTING factor
  * before adding a new one. The predicate is {@link userIsMfaProtected} — the
  * same one SR2-20 uses — so the two gates can never drift apart. A protected
- * account simply falls through to the unchanged step-up requirements.
+ * passwordless account is REFUSED this road outright (401); it does not fall
+ * through to any other step-up here. Its route back in is the SR2-20 path,
+ * proving the factor it already holds.
  *
  * Every rejection is the same opaque `Invalid credentials` 401 the password
  * path already returns, so the response never reveals whether the account has

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -321,6 +321,132 @@ export async function enforceExistingFactorStepUp(
   return null;
 }
 
+// ============================================
+// First-factor enrollment step-up (#4018)
+// ============================================
+
+/**
+ * The single decision point for "may this caller install a FIRST MFA factor?".
+ *
+ * Two roads, never both:
+ *   - password — the historical path, unchanged, and evaluated FIRST.
+ *   - SSO re-auth grant — for accounts with `password_hash IS NULL`, which have
+ *     no password to prove and previously could not enroll at all (#4018). The
+ *     grant is minted only by the SSO re-auth callback (`GET /sso/callback`,
+ *     reauth mode) after a forced, fresh IdP authentication.
+ *
+ * The SSO road is refused outright for an account that HAS a password: two
+ * roads of differing strength to the same door is how a step-up gets bypassed.
+ *
+ * It is ALSO refused for a passwordless account that already holds any factor.
+ * The grant's operation is `enroll_first_factor` and that is all it may ever
+ * do: without this check a passwordless account with a TOTP secret or a
+ * registered passkey could re-auth at its IdP and use the resulting grant to
+ * install a SECOND factor, side-stepping {@link enforceExistingFactorStepUp}
+ * (SR2-20), which exists precisely to require proving an EXISTING factor
+ * before adding a new one. The predicate is {@link userIsMfaProtected} — the
+ * same one SR2-20 uses — so the two gates can never drift apart. A protected
+ * account simply falls through to the unchanged step-up requirements.
+ *
+ * Every rejection is the same opaque `Invalid credentials` 401 the password
+ * path already returns, so the response never reveals whether the account has
+ * a password, has a factor, or exists at all.
+ *
+ * `opts.consume` mirrors the {@link validateStepUpGrant}/{@link consumeStepUpGrant}
+ * split the SR2-20 grant already uses: `false` at the gate of a two-step flow
+ * (`/mfa/setup`, `/passkeys/register/options`), `true` at the terminal factor
+ * write (`/mfa/enable`, `/passkeys/register/verify`), so one SSO round-trip
+ * yields exactly one enrollment and a fat-fingered TOTP code does not burn the
+ * grant.
+ *
+ * `opts.passwordAlreadyProven` is for the TERMINAL call of such a two-step
+ * flow, whose GATE already ran this function and satisfied the password road
+ * (re-verifying there would double-charge the per-user step-up rate limit, and
+ * `/passkeys/register/verify` carries no password field at all). It ONLY
+ * short-circuits the password road; the SSO road still consumes the grant.
+ * Never set it on an endpoint that is not downstream of such a gate.
+ */
+export async function resolveEnrollmentStepUp(
+  c: Context,
+  auth: AuthContext,
+  input: { currentPassword?: string; ssoReauthGrantId?: string },
+  opts: { keyPrefix: string; consume: boolean; passwordAlreadyProven?: boolean },
+): Promise<Response | null> {
+  // Road 1, FIRST and byte-for-byte the historical path: a password was
+  // offered, so a password is what must check out. requireCurrentPasswordStepUp
+  // already returns the same opaque 401 when the account has no hash at all, so
+  // a passwordless account that offers a password is rejected here rather than
+  // sliding onto the SSO road — one request, one road, chosen by what it sent.
+  if (input.currentPassword) {
+    return requireCurrentPasswordStepUp(c, auth.user.id, input.currentPassword, opts.keyPrefix);
+  }
+
+  // No password offered. Decide whether this account is even eligible for the
+  // SSO road before looking at the grant.
+  //
+  // System DB access, same idiom and same reason as {@link userIsMfaProtected}:
+  // the `/mfa/verify` Case-2 caller runs with NO ambient access context (its
+  // `await authMiddleware(c, async () => {})` tears the context down when that
+  // empty `next` returns — see the I3 note there). A contextless read under
+  // forced RLS as `breeze_app` matches ZERO rows rather than erroring, so an
+  // unwrapped probe would land on `!user` and 401 EVERY caller of that path,
+  // password accounts included. Nested inside a request context this is a
+  // no-op, so the other callers are unaffected.
+  const [user] = await runWithSystemDbAccess(() =>
+    db
+      .select({ passwordHash: users.passwordHash })
+      .from(users)
+      .where(eq(users.id, auth.user.id))
+      .limit(1)
+  );
+  if (!user) return c.json({ error: 'Invalid credentials' }, 401);
+
+  if (user.passwordHash != null) {
+    // The gate of this flow already verified the password; nothing is left for
+    // the terminal call to do. Deliberately still a live DB read rather than an
+    // assumption that the gate ran — this must fail CLOSED for a passwordless
+    // account that reaches a terminal write with no grant.
+    if (opts.passwordAlreadyProven) return null;
+    return c.json({ error: 'Invalid credentials' }, 401);
+  }
+
+  if (!input.ssoReauthGrantId) {
+    return c.json({ error: 'Invalid credentials' }, 401);
+  }
+
+  // FIRST factor only — see the doc comment above. Checked BEFORE the grant is
+  // consumed so a refused enrollment never burns the caller's grant.
+  if (await userIsMfaProtected(auth.user.id)) {
+    return c.json({ error: 'Invalid credentials' }, 401);
+  }
+
+  const epochs = await getUserEpochs(auth.user.id);
+  const sid = auth.token?.sid;
+  if (!epochs || !sid) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+
+  // Must reconstruct the mint-site tuple in `routes/sso.ts` (reauth branch)
+  // MEMBER FOR MEMBER: bindsMatch fails closed on any difference, so a
+  // divergence here would silently reject every legitimate grant.
+  const bind = {
+    userId: auth.user.id,
+    operation: 'enroll_first_factor' as const,
+    authEpoch: epochs.authEpoch,
+    mfaEpoch: epochs.mfaEpoch,
+    sid,
+  };
+
+  const ok = opts.consume
+    ? await consumeStepUpGrant(input.ssoReauthGrantId, bind)
+    : await validateStepUpGrant(input.ssoReauthGrantId, bind);
+  if (!ok) {
+    return c.json({ error: 'Invalid credentials' }, 401);
+  }
+
+  return null;
+}
+
 /**
  * True when the account holds a re-auth factor STRONGER than a password that
  * the browser register UI can actually exercise: TOTP MFA or an active

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -390,7 +390,14 @@ export async function enforceExistingFactorStepUp(
  *
  * Every rejection is the same opaque `Invalid credentials` 401 the password
  * path already returns, so the response never reveals whether the account has
- * a password, has a factor, or exists at all.
+ * a password, has a factor, or exists at all — with ONE deliberate exception:
+ * a passwordless account that offered NO proof at all gets
+ * `enrollment_proof_required`. That case is not a failed authentication
+ * attempt, it is a client that has lost its single-use grant (a reload while
+ * the QR was on screen, a restored session, a second tab), and a generic
+ * `Invalid credentials` renders on a screen with no password field and no way
+ * to retry. It discloses nothing: the caller is already authenticated AS this
+ * account and `/users/me` already tells them `hasPassword`.
  *
  * `opts.consume` mirrors the {@link validateStepUpGrant}/{@link consumeStepUpGrant}
  * split the SR2-20 grant already uses: `false` at the gate of a two-step flow
@@ -451,7 +458,10 @@ export async function resolveEnrollmentStepUp(
   }
 
   if (!input.ssoReauthGrantId) {
-    return c.json({ error: 'Invalid credentials' }, 401);
+    // Distinguishable ON PURPOSE — see the doc comment. `reauthUrl` mirrors the
+    // `stepUpUrl` affordance enforceExistingFactorStepUp already returns, so a
+    // client can offer the one action that resolves this.
+    return c.json({ error: 'enrollment_proof_required', reauthUrl: '/sso/reauth/start' }, 401);
   }
 
   // FIRST factor only — see the doc comment above. Checked BEFORE the grant is

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -46,9 +46,32 @@ import {
 
 const { db } = dbModule;
 
+/**
+ * Run `fn` inside the SYSTEM DB access context.
+ *
+ * FAILS CLOSED when the wrapper is unavailable. This used to degrade silently
+ * to a bare `fn()`, which is not a graceful fallback — it is a CONTEXTLESS
+ * query, the exact bug class the callers below exist to avoid. Under forced
+ * RLS as `breeze_app` a contextless read matches ZERO rows rather than
+ * erroring, so the caller sees "no such user / no factors" and hands back the
+ * PERMISSIVE answer. {@link userIsMfaProtected} answering `false` that way
+ * would open the first-factor-enrollment gate for an account that actually
+ * holds factors.
+ *
+ * The `typeof` check only ever fired under a test mock of `../../db` that
+ * omitted the wrapper; production always exports it. Nested inside an existing
+ * request context the real `withSystemDbAccessContext` short-circuits on its
+ * own — that legitimate case is unchanged, it never reached this branch.
+ */
 export const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   const withSystem = dbModule.withSystemDbAccessContext;
-  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+  if (typeof withSystem !== 'function') {
+    const message =
+      '[auth] runWithSystemDbAccess: withSystemDbAccessContext is unavailable; refusing to run a security probe with no DB access context';
+    console.error(message);
+    throw new Error(message);
+  }
+  return withSystem(fn);
 };
 
 // Shared floor-the-clock timing equalizer for pre-auth endpoints whose latency
@@ -253,6 +276,16 @@ export async function requireFreshMfaStepUp(
  * `/passkeys/register/*`) call this from within their own request-scoped
  * (user-id-scoped) RLS context, where it would still resolve correctly, but
  * system context keeps this probe uniform regardless of caller context.
+ *
+ * THROWS when the row is missing rather than reporting `false`. Every caller
+ * is authenticated, so the row must exist; a zero-row read means the probe did
+ * not run as intended (lost DB access context, a row vanishing mid-request),
+ * and `false` is the PERMISSIVE answer on every gate that consumes this — it
+ * says "no factor yet, initial enrollment, password-only is enough" for an
+ * account that may hold factors. Failing loud pushes those gates onto their
+ * error path (a 500) instead of silently waving the caller through. Today the
+ * `!user -> 401` probe in {@link resolveEnrollmentStepUp} happens to fire
+ * first, but that is call ordering, not a designed control.
  */
 export async function userIsMfaProtected(userId: string): Promise<boolean> {
   const [row] = await runWithSystemDbAccess(() =>
@@ -265,7 +298,12 @@ export async function userIsMfaProtected(userId: string): Promise<boolean> {
       .where(eq(users.id, userId))
       .limit(1)
   );
-  return row?.mfaEnabled === true || Number(row?.passkeyCount ?? 0) > 0;
+  if (!row) {
+    const message = `[auth] userIsMfaProtected: no users row for ${userId}; refusing to report the account unprotected`;
+    console.error(message);
+    throw new Error(message);
+  }
+  return row.mfaEnabled === true || Number(row.passkeyCount ?? 0) > 0;
 }
 
 /**

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -737,13 +737,20 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithSt
 
   // #4018: same terminal burn for the passwordless SSO road — one
   // enroll_first_factor grant installs exactly one factor. `passwordAlreadyProven`
-  // because the password road was already satisfied at the gate above; without
-  // it this second call would re-verify the password and double-charge the
-  // per-user step-up rate limit.
+  // because the password road was already satisfied at the gate above.
+  //
+  // Deliberately omit `currentPassword` here (unlike the gate call above,
+  // which needs it to pick a road). resolveEnrollmentStepUp's road-1
+  // short-circuit (`if (input.currentPassword)`) runs BEFORE the
+  // `passwordAlreadyProven` check, so passing it again would re-run
+  // requireCurrentPasswordStepUp — a second argon2 verify and a second charge
+  // against the 5-per-5-minutes step-up rate limit for every successful
+  // enable, and a user on their 4th attempt would take a 429 here AFTER
+  // consumeMFAToken already burned their TOTP time-step above.
   const enrollmentConsumeError = await resolveEnrollmentStepUp(
     c,
     auth,
-    { currentPassword, ssoReauthGrantId },
+    { ssoReauthGrantId },
     { keyPrefix: 'mfa:pwd', consume: true, passwordAlreadyProven: true }
   );
   if (enrollmentConsumeError) return enrollmentConsumeError;

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -44,6 +44,7 @@ import {
   auditLogin,
   userRequiresSetup,
   requireCurrentPasswordStepUp,
+  resolveEnrollmentStepUp,
   enforceExistingFactorStepUp,
   parsePendingMfa,
   evaluatePendingMfa,
@@ -59,8 +60,20 @@ const { db, withSystemDbAccessContext, runOutsideDbContext } = dbModule;
 const passwordOnlySchema = z.object({
   currentPassword: z.string().min(1).max(256)
 });
-const mfaEnableWithPasswordSchema = mfaEnableSchema.extend({
-  currentPassword: z.string().min(1).max(256),
+
+// #4018: the FIRST-FACTOR ENROLLMENT endpoints accept either proof. Both are
+// optional HERE and resolveEnrollmentStepUp decides which road this account is
+// allowed to take — "neither supplied" must be its opaque 401, not a 400 from
+// this schema, because the shape of the rejection must not tell an attacker
+// whether the account has a password. `passwordOnlySchema` above stays
+// password-only: /mfa/recovery-codes is not an enrollment.
+const enrollmentStepUpSchema = z.object({
+  currentPassword: z.string().min(1).max(256).optional(),
+  ssoReauthGrantId: z.string().uuid().optional()
+});
+const mfaEnableWithStepUpSchema = mfaEnableSchema.extend({
+  currentPassword: z.string().min(1).max(256).optional(),
+  ssoReauthGrantId: z.string().uuid().optional(),
   // SR2-20: existing-factor step-up grant required when the account is
   // already MFA-protected (see enforceExistingFactorStepUp in ./helpers).
   stepUpGrantId: z.string().optional()
@@ -72,19 +85,30 @@ const mfaDisableSchema = mfaVerifySchema.extend({
 export const mfaRoutes = new Hono();
 
 // MFA setup (requires auth + current-password re-prompt)
-mfaRoutes.post('/mfa/setup', authMiddleware, zValidator('json', passwordOnlySchema), async (c) => {
+mfaRoutes.post('/mfa/setup', authMiddleware, zValidator('json', enrollmentStepUpSchema), async (c) => {
   if (!ENABLE_2FA) {
     return mfaDisabledResponse(c);
   }
 
   const auth = c.get('auth');
-  const { currentPassword } = c.req.valid('json');
+  const { currentPassword, ssoReauthGrantId } = c.req.valid('json');
 
-  // Re-verify password before allowing MFA factor installation. A stolen
-  // access token is not sufficient — the user must prove possession of
-  // the password to attach a new TOTP secret.
-  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd');
-  if (passwordError) return passwordError;
+  // Re-verify identity before allowing MFA factor installation. A stolen
+  // access token is not sufficient — the user must prove possession of the
+  // password, or (passwordless SSO accounts only, #4018) present a grant from
+  // a fresh forced re-authentication at their IdP.
+  //
+  // NON-consuming: this endpoint only stashes a candidate secret in Redis. The
+  // single-use burn happens at the terminal factor write that confirms it
+  // (/mfa/verify case 2, or /mfa/enable), so one SSO round-trip covers the
+  // whole setup -> confirm flow.
+  const stepUpError = await resolveEnrollmentStepUp(
+    c,
+    auth,
+    { currentPassword, ssoReauthGrantId },
+    { keyPrefix: 'mfa:pwd', consume: false }
+  );
+  if (stepUpError) return stepUpError;
 
   // Check if MFA is already enabled
   const [user] = await db
@@ -442,6 +466,20 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
   const stepUpConsumeError = await enforceExistingFactorStepUp(c, auth, stepUpGrantId, { consume: true });
   if (stepUpConsumeError) return stepUpConsumeError;
 
+  // #4018: terminal burn for the passwordless SSO road. This is the confirm
+  // half of the /mfa/setup flow whose gate validated the grant non-consumingly,
+  // so ONE enroll_first_factor grant installs exactly one factor.
+  // `passwordAlreadyProven` because this branch never had a password gate of
+  // its own — /mfa/setup holds it — and must stay unchanged for password
+  // accounts.
+  const enrollmentConsumeError = await resolveEnrollmentStepUp(
+    c,
+    auth,
+    { ssoReauthGrantId: c.req.valid('json').ssoReauthGrantId },
+    { keyPrefix: 'mfa:pwd', consume: true, passwordAlreadyProven: true }
+  );
+  if (enrollmentConsumeError) return enrollmentConsumeError;
+
   // SR2-07/SR2-19: fold the factor write into the atomic epoch-bump +
   // refresh-family-revoke transaction, then best-effort post-commit cleanup +
   // remote-session teardown — enabling MFA is a security-relevant factor
@@ -610,17 +648,26 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
 });
 
 // MFA enable compatibility endpoint for frontend settings flow
-mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithPasswordSchema), async (c) => {
+mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithStepUpSchema), async (c) => {
   if (!ENABLE_2FA) {
     return mfaDisabledResponse(c);
   }
 
   const auth = c.get('auth');
-  const { code, currentPassword, stepUpGrantId } = c.req.valid('json');
+  const { code, currentPassword, ssoReauthGrantId, stepUpGrantId } = c.req.valid('json');
 
-  // Re-verify password before flipping mfaEnabled=true on the user row.
-  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd');
-  if (passwordError) return passwordError;
+  // Re-verify identity before flipping mfaEnabled=true on the user row:
+  // password, or (passwordless SSO accounts only, #4018) a fresh SSO re-auth
+  // grant. Same two-phase idiom as the SR2-20 grant below — VALIDATE here,
+  // CONSUME after the TOTP code proves out — so a mistyped code does not burn
+  // the user's single-use grant and force another IdP round-trip.
+  const enrollmentError = await resolveEnrollmentStepUp(
+    c,
+    auth,
+    { currentPassword, ssoReauthGrantId },
+    { keyPrefix: 'mfa:pwd', consume: false }
+  );
+  if (enrollmentError) return enrollmentError;
 
   // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
   // requires a fresh existing-factor proof (no-op for initial enrollment).
@@ -687,6 +734,19 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithPa
   // not written.
   const stepUpConsumeError = await enforceExistingFactorStepUp(c, auth, stepUpGrantId, { consume: true });
   if (stepUpConsumeError) return stepUpConsumeError;
+
+  // #4018: same terminal burn for the passwordless SSO road — one
+  // enroll_first_factor grant installs exactly one factor. `passwordAlreadyProven`
+  // because the password road was already satisfied at the gate above; without
+  // it this second call would re-verify the password and double-charge the
+  // per-user step-up rate limit.
+  const enrollmentConsumeError = await resolveEnrollmentStepUp(
+    c,
+    auth,
+    { currentPassword, ssoReauthGrantId },
+    { keyPrefix: 'mfa:pwd', consume: true, passwordAlreadyProven: true }
+  );
+  if (enrollmentConsumeError) return enrollmentConsumeError;
 
   const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'mfa-enable', async (tx) => {
     await tx

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -38,6 +38,7 @@ import {
   type PendingMfaRecord,
   requireCurrentPasswordStepUp,
   resolveCurrentUserTokenContext,
+  resolveEnrollmentStepUp,
   setRefreshTokenCookie,
   toPublicTokens,
   userRequiresSetup,
@@ -60,8 +61,15 @@ const webAuthnCredentialSchema = z
   );
 
 const passkeyNameSchema = z.string().trim().min(1).max(255);
+// #4018: BOTH enrollment proofs are optional HERE — resolveEnrollmentStepUp
+// decides which road this account may take, and "neither supplied" must be its
+// opaque 401 rather than a 400 from this schema, so the rejection never reveals
+// whether the account has a password. `deletePasskeySchema` below is untouched:
+// deleting a factor is not a first-factor enrollment and an
+// enroll_first_factor grant must never authorize it.
 const registerOptionsSchema = z.object({
-  currentPassword: z.string().min(1).max(256),
+  currentPassword: z.string().min(1).max(256).optional(),
+  ssoReauthGrantId: z.string().uuid().optional(),
   name: passkeyNameSchema.optional(),
   // SR2-20: existing-factor step-up grant required when the account is
   // already MFA-protected (see enforceExistingFactorStepUp in ./helpers).
@@ -70,6 +78,7 @@ const registerOptionsSchema = z.object({
 const registerVerifySchema = z.object({
   credential: webAuthnCredentialSchema,
   name: passkeyNameSchema.optional(),
+  ssoReauthGrantId: z.string().uuid().optional(),
   stepUpGrantId: z.string().optional()
 });
 const passkeyMfaOptionsSchema = z.object({
@@ -116,10 +125,18 @@ passkeyRoutes.post('/passkeys/register/options', authMiddleware, zValidator('jso
   }
 
   const auth = c.get('auth');
-  const { currentPassword, stepUpGrantId } = c.req.valid('json');
+  const { currentPassword, ssoReauthGrantId, stepUpGrantId } = c.req.valid('json');
 
-  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'passkey:pwd');
-  if (passwordError) return passwordError;
+  // Password, or (passwordless SSO accounts only, #4018) a grant from a fresh
+  // forced re-authentication at the IdP. Non-consuming — this is the gate; the
+  // SAME grant is consumed at /passkeys/register/verify below.
+  const enrollmentError = await resolveEnrollmentStepUp(
+    c,
+    auth,
+    { currentPassword, ssoReauthGrantId },
+    { keyPrefix: 'passkey:pwd', consume: false }
+  );
+  if (enrollmentError) return enrollmentError;
 
   // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
   // requires a fresh existing-factor proof. Non-consuming here — the SAME
@@ -142,7 +159,7 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
   }
 
   const auth = c.get('auth');
-  const { credential, name, stepUpGrantId } = c.req.valid('json');
+  const { credential, name, ssoReauthGrantId, stepUpGrantId } = c.req.valid('json');
 
   let verification;
   try {
@@ -177,6 +194,19 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
   // terminal factor write.
   const stepUpError = await enforceExistingFactorStepUp(c, auth, stepUpGrantId, { consume: true });
   if (stepUpError) return stepUpError;
+
+  // #4018: terminal burn for the passwordless SSO road — one
+  // enroll_first_factor grant registers exactly one passkey. `passwordAlreadyProven`
+  // because this endpoint carries no password field at all: the password road
+  // was satisfied at /passkeys/register/options, and re-demanding it here would
+  // break every existing password-account registration.
+  const enrollmentConsumeError = await resolveEnrollmentStepUp(
+    c,
+    auth,
+    { ssoReauthGrantId },
+    { keyPrefix: 'passkey:pwd', consume: true, passwordAlreadyProven: true }
+  );
+  if (enrollmentConsumeError) return enrollmentConsumeError;
 
   // SR2-07/SR2-19: the insert AND the users.mfaEnabled flip are folded into
   // ONE transaction with the epoch bump + refresh-family revoke — registering

--- a/apps/api/src/routes/auth/password.test.ts
+++ b/apps/api/src/routes/auth/password.test.ts
@@ -690,3 +690,59 @@ describe('password reset eligibility (#719)', () => {
     });
   });
 });
+
+// #4018: an SSO-provisioned account has no password, so the profile UI must be
+// able to tell "password step-up is possible" from "offer the IdP road". The
+// hash is selected only to derive the boolean and must never be serialized.
+describe('GET /auth/me — hasPassword (#4018)', () => {
+  const ME_ROW = {
+    id: 'u-1',
+    email: 'user@example.test',
+    name: 'Sample User',
+    avatarUrl: null,
+    mfaEnabled: false,
+    mfaMethod: null,
+    phoneNumber: null,
+    phoneVerified: false,
+    status: 'active',
+    lastLoginAt: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+  };
+
+  function mockMe(passwordHash: string | null) {
+    vi.mocked(db.select).mockReturnValue(
+      selectChain([{ ...ME_ROW, passwordHash }]) as never,
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+  });
+
+  it('reports hasPassword false for an SSO-provisioned user', async () => {
+    mockMe(null);
+    const res = await passwordRoutes.request('/me');
+    expect(res.status).toBe(200);
+    const body = await res.json() as { user: { hasPassword: boolean } };
+    expect(body.user.hasPassword).toBe(false);
+  });
+
+  it('reports hasPassword true for a password user and never leaks the hash', async () => {
+    mockMe('$argon2id$v=19$m=65536,t=3,p=4$abc');
+    const res = await passwordRoutes.request('/me');
+    expect(res.status).toBe(200);
+    const body = await res.json() as { user: Record<string, unknown> };
+    expect(body.user.hasPassword).toBe(true);
+    expect(body.user).not.toHaveProperty('passwordHash');
+    // The whole envelope, not just the user object: a future refactor that
+    // spreads the row at any level would land the hash somewhere in here.
+    expect(JSON.stringify(body)).not.toContain('argon2id');
+  });
+
+  it('404s when the user row is gone', async () => {
+    vi.mocked(db.select).mockReturnValue(selectChain([]) as never);
+    const res = await passwordRoutes.request('/me');
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/api/src/routes/auth/password.ts
+++ b/apps/api/src/routes/auth/password.ts
@@ -377,7 +377,12 @@ passwordRoutes.get('/me', authMiddleware, async (c) => {
       phoneVerified: users.phoneVerified,
       status: users.status,
       lastLoginAt: users.lastLoginAt,
-      createdAt: users.createdAt
+      createdAt: users.createdAt,
+      // #4018: selected ONLY to derive the `hasPassword` boolean below. It is
+      // destructured out of the response object in the same statement that
+      // computes the flag, exactly as `phoneNumber` is, so the hash itself is
+      // never serialized. Asserted by password.test.ts.
+      passwordHash: users.passwordHash
     })
     .from(users)
     .where(eq(users.id, auth.user.id))
@@ -387,11 +392,15 @@ passwordRoutes.get('/me', authMiddleware, async (c) => {
     return c.json({ error: 'User not found' }, 404);
   }
 
-  const { phoneNumber: rawPhone, ...userWithoutPhone } = user;
+  const { phoneNumber: rawPhone, passwordHash, ...userWithoutPhone } = user;
   const effectiveMfaEnabled = ENABLE_2FA ? user.mfaEnabled : false;
   return c.json({
     user: {
       ...userWithoutPhone,
+      // Whether a password step-up is even possible for this account. An
+      // SSO-provisioned (JIT) user has no password, so the profile UI must
+      // offer the IdP re-authentication road instead of a password prompt.
+      hasPassword: passwordHash != null,
       mfaEnabled: effectiveMfaEnabled,
       mfaMethod: effectiveMfaEnabled ? (user.mfaMethod || 'totp') : null,
       phoneLast4: ENABLE_2FA ? (rawPhone?.slice(-4) || null) : null

--- a/apps/api/src/routes/auth/schemas.test.ts
+++ b/apps/api/src/routes/auth/schemas.test.ts
@@ -81,4 +81,18 @@ describe('mfaStepUpSchema operation field', () => {
       mfaStepUpSchema.parse({ method: 'totp', code: '123456', operation: 'admin_takeover' })
     ).toThrow();
   });
+
+  // #4018: enroll_first_factor is a REAL StepUpOperation, so the `satisfies`
+  // constraint on STEP_UP_OPERATIONS would happily accept it being added to
+  // the client-requestable list — nothing in the type system stops that. But
+  // it is minted ONLY by the SSO re-auth callback, after a forced IdP
+  // round-trip proves identity for a passwordless account. If a client could
+  // request it here, anyone who can already satisfy step-up could mint one
+  // without ever re-authenticating. This test is the guard the type system
+  // does not provide.
+  it('rejects enroll_first_factor — SSO-reauth-mint only, never client-requestable', () => {
+    expect(() =>
+      mfaStepUpSchema.parse({ method: 'totp', code: '123456', operation: 'enroll_first_factor' })
+    ).toThrow();
+  });
 });

--- a/apps/api/src/routes/auth/schemas.ts
+++ b/apps/api/src/routes/auth/schemas.ts
@@ -123,12 +123,19 @@ const stepUpAssertion = z.object({ id: z.string().min(1) }).passthrough();
 // existing clients are untouched; register_approver_device gates the
 // /authenticator register routes (#2707).
 //
-// `satisfies readonly StepUpOperation[]` compile-time-links this literal
-// array to the service's StepUpOperation union — if the two ever diverge
-// (a new operation added to one but not the other), this fails typecheck
-// instead of silently letting a grant type this schema doesn't know about
-// slip through validation, or letting a value this schema accepts fail to
-// match any real operation.
+// `satisfies readonly StepUpOperation[]` compile-time-links this literal array
+// to the service's StepUpOperation union in ONE direction only: every value
+// here must be a real operation, so this schema can never accept a value that
+// matches no grant type. It is deliberately NOT exhaustive — it is the
+// CLIENT-REQUESTABLE allowlist, and the union is legitimately wider.
+//
+// #4018: `enroll_first_factor` is intentionally absent. That grant is the sole
+// output of the SSO re-auth callback, which mints it only after a forced IdP
+// round-trip proves identity for a PASSWORDLESS account. Adding it here would
+// let any caller who can already satisfy step-up mint one on demand, turning a
+// re-authentication proof into a checkbox. `schemas.test.ts` locks the
+// exclusion — adding an operation to the union must stay a no-op here unless
+// clients are genuinely meant to ask for it.
 const STEP_UP_OPERATIONS = ['add_factor', 'register_approver_device'] as const satisfies readonly StepUpOperation[];
 const stepUpOperation = z
   .enum(STEP_UP_OPERATIONS)

--- a/apps/api/src/routes/auth/schemas.ts
+++ b/apps/api/src/routes/auth/schemas.ts
@@ -58,6 +58,11 @@ export const mfaVerifySchema = z.object({
   // already-protected account's TOTP-add can satisfy the existing-factor
   // step-up gate. Ignored on Case 1 (login completion).
   stepUpGrantId: z.string().optional(),
+  // #4018: presented on setup-confirm (Case 2) by a PASSWORDLESS SSO account,
+  // which has no password to satisfy the enrollment step-up. Consumed there as
+  // the terminal write of the /mfa/setup flow. Ignored on Case 1 (login
+  // completion — that path is pre-auth and mints no factor).
+  ssoReauthGrantId: z.string().uuid().optional(),
 });
 
 export const phoneVerifySchema = z.object({

--- a/apps/api/src/routes/auth/schemas.ts
+++ b/apps/api/src/routes/auth/schemas.ts
@@ -128,20 +128,26 @@ const stepUpAssertion = z.object({ id: z.string().min(1) }).passthrough();
 // existing clients are untouched; register_approver_device gates the
 // /authenticator register routes (#2707).
 //
-// `satisfies readonly StepUpOperation[]` compile-time-links this literal array
-// to the service's StepUpOperation union in ONE direction only: every value
-// here must be a real operation, so this schema can never accept a value that
-// matches no grant type. It is deliberately NOT exhaustive — it is the
-// CLIENT-REQUESTABLE allowlist, and the union is legitimately wider.
+// This is the CLIENT-REQUESTABLE allowlist; the service's StepUpOperation union
+// is legitimately wider, so this array is deliberately NOT exhaustive. The
+// `satisfies` target links it to that union so a value here can never be one
+// that matches no grant type.
 //
-// #4018: `enroll_first_factor` is intentionally absent. That grant is the sole
-// output of the SSO re-auth callback, which mints it only after a forced IdP
-// round-trip proves identity for a PASSWORDLESS account. Adding it here would
-// let any caller who can already satisfy step-up mint one on demand, turning a
-// re-authentication proof into a checkbox. `schemas.test.ts` locks the
-// exclusion — adding an operation to the union must stay a no-op here unless
-// clients are genuinely meant to ask for it.
-const STEP_UP_OPERATIONS = ['add_factor', 'register_approver_device'] as const satisfies readonly StepUpOperation[];
+// #4018: `enroll_first_factor` is excluded BY THE COMPILER, not by convention.
+// That grant is the sole output of the SSO re-auth callback, which mints it
+// only after a forced IdP round-trip proves identity for a PASSWORDLESS
+// account; letting a client request one here would turn a re-authentication
+// proof into a checkbox for anyone who can already satisfy step-up.
+//
+// A plain `satisfies readonly StepUpOperation[]` would NOT have stopped that —
+// it only constrains membership, so appending 'enroll_first_factor' still
+// typechecks and the exclusion would rest entirely on schemas.test.ts catching
+// it. Narrowing the target with `Exclude<>` makes appending it a compile error.
+// The test stays as the readable statement of intent.
+const STEP_UP_OPERATIONS = [
+  'add_factor',
+  'register_approver_device',
+] as const satisfies readonly Exclude<StepUpOperation, 'enroll_first_factor'>[];
 const stepUpOperation = z
   .enum(STEP_UP_OPERATIONS)
   .default('add_factor');

--- a/apps/api/src/routes/sso.reauth.test.ts
+++ b/apps/api/src/routes/sso.reauth.test.ts
@@ -89,6 +89,12 @@ vi.mock('../services/sso', () => ({
     }
     return { ok: true };
   }),
+  // Real logic (not a stub), same reasoning as above: this is the conversion
+  // that puts the session's created_at on the same clock as the id_token's
+  // auth_time. A stub returning `undefined` would make the freshness bound
+  // NaN-ish and the timezone test below meaningless.
+  utcMsFromOffsetlessTimestamp: (value: Date) =>
+    value.getTime() - value.getTimezoneOffset() * 60_000,
   mapUserAttributes: vi.fn(),
   discoverOIDCConfig: vi.fn(),
   // Real logic (not a stub) — getOIDCConfig (defined in sso.ts, not mocked)
@@ -218,6 +224,7 @@ import {
 import { mintStepUpGrant } from '../services/mfaStepUpGrant';
 import { writeRouteAudit } from '../services/auditEvents';
 import { authMiddleware } from '../middleware/auth';
+import { pgOffsetlessTimestamp } from '../testUtils/pgOffsetlessTimestamp';
 
 const USER_ID = '00000000-0000-4000-8000-000000000020';
 const OTHER_USER_ID = '00000000-0000-4000-8000-0000000000aa';
@@ -495,7 +502,13 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
   //   4. userSsoIdentities      (reauth branch: (provider, sub) ownership)
   // Every test funnels through here so that ordering lives in one place.
   const primeReauthCallback = (opts: {
-    sessionCreatedAt?: Date;
+    // A TRUE epoch. It is deliberately not a Date: the row's created_at is
+    // built from it via pgOffsetlessTimestamp so that every test in this suite
+    // sees the session exactly as postgres.js delivers it from a `timestamp
+    // without time zone` column, rather than the true-instant Date a hand-rolled
+    // `new Date(...)` would produce. Handing in a Date here is what let the
+    // freshness bound be compared on the wrong clock with the suite still green.
+    sessionCreatedAtMs?: number;
     idClaims?: Record<string, unknown>;
     sessionOverrides?: Record<string, unknown>;
     // undefined = healthy user; null = simulate "user gone" (no row).
@@ -507,7 +520,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
     provider?: Record<string, unknown>;
   } = {}) => {
     const {
-      sessionCreatedAt = new Date(),
+      sessionCreatedAtMs = Date.now(),
       sessionOverrides = {},
       reauthUser = ACTIVE_REAUTH_USER,
       membership = [{ userId: USER_ID }],
@@ -544,7 +557,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
       initiatingAuthEpoch: 3,
       initiatingMfaEpoch: 1,
       initiatingSessionId: SID,
-      createdAt: sessionCreatedAt,
+      createdAt: pgOffsetlessTimestamp(sessionCreatedAtMs),
       expiresAt: new Date(Date.now() + 10 * 60 * 1000),
       ...sessionOverrides,
     };
@@ -620,28 +633,30 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
   // (both auth_times below are comfortably "recent", only one post-dates the
   // click), and the call-argument assertion pins the contract exactly.
   it('bounds freshness from the session created_at, not from now (accepts an auth_time after the click)', async () => {
-    const sessionCreatedAt = new Date(Date.now() - 9 * 60 * 1000);
+    const sessionCreatedAtMs = Date.now() - 9 * 60 * 1000;
     const { idClaims } = primeReauthCallback({
-      sessionCreatedAt,
+      sessionCreatedAtMs,
       idClaims: { sub: EXTERNAL_ID, email: 'tech@acme.example', auth_time: secondsAgo(30) }
     });
 
     const res = await doCallback();
 
-    expect(assertFreshIdpAuthentication).toHaveBeenCalledWith(idClaims, sessionCreatedAt.getTime());
+    // The TRUE epoch of the click — not `createdAt.getTime()`, which is that
+    // epoch plus the host's UTC offset (see the timezone test below).
+    expect(assertFreshIdpAuthentication).toHaveBeenCalledWith(idClaims, sessionCreatedAtMs);
     expect(res.headers.get('location')).toBe('/settings/profile#ssoReauthGrant=grant-abc');
   });
 
   it('bounds freshness from the session created_at, not from now (rejects an auth_time that predates the click)', async () => {
-    const sessionCreatedAt = new Date(Date.now() - 9 * 60 * 1000);
+    const sessionCreatedAtMs = Date.now() - 9 * 60 * 1000;
     primeReauthCallback({
-      sessionCreatedAt,
+      sessionCreatedAtMs,
       idClaims: {
         sub: EXTERNAL_ID,
         email: 'tech@acme.example',
         // ~14 minutes ago: still "recent" by any now-relative window, but it
         // predates the /reauth/start click by 5 minutes.
-        auth_time: Math.floor(sessionCreatedAt.getTime() / 1000) - 300,
+        auth_time: Math.floor(sessionCreatedAtMs / 1000) - 300,
       }
     });
 
@@ -649,6 +664,39 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
 
     expect(res.headers.get('location')).toContain('error=reauth_not_fresh');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  // sso_sessions.created_at is `timestamp without time zone`, and postgres.js
+  // parses an offsetless value as LOCAL time — so `createdAt.getTime()` is the
+  // true epoch plus the HOST's UTC offset, while the id_token's auth_time is a
+  // true UTC epoch. Comparing the two directly is dead on arrival west of UTC
+  // (bound lands in the future, every attempt reads stale) and silently
+  // permissive east of it (window widens by the offset, so a cached IdP session
+  // that old is accepted as fresh).
+  //
+  // This test is the reason the fixture takes an epoch rather than a Date: it
+  // only has teeth when the session row is built the way the driver builds it.
+  // Under TZ=UTC the offset is zero and it passes either way — which is exactly
+  // how this shipped past a green CI run.
+  it('compares auth_time against the click on the SAME clock, whatever the host timezone', async () => {
+    const sessionCreatedAtMs = Date.now() - 60_000;
+    primeReauthCallback({
+      sessionCreatedAtMs,
+      // 30s after the click: unambiguously fresh on a correct clock.
+      idClaims: { sub: EXTERNAL_ID, email: 'tech@acme.example', auth_time: Math.floor(sessionCreatedAtMs / 1000) + 30 }
+    });
+
+    const res = await doCallback();
+
+    const [, boundMs] = vi.mocked(assertFreshIdpAuthentication).mock.calls.at(-1)!;
+    expect(boundMs).toBe(sessionCreatedAtMs);
+    // Pins that the offset was actually neutralised rather than the fixture
+    // having handed over a true-instant Date all along.
+    const naive = pgOffsetlessTimestamp(sessionCreatedAtMs);
+    expect(naive.getTime() - boundMs).toBe(naive.getTimezoneOffset() * 60_000);
+
+    expect(assertFreshIdpAuthentication).toHaveLastReturnedWith({ ok: true });
+    expect(res.headers.get('location')).toBe('/settings/profile#ssoReauthGrant=grant-abc');
   });
 
   // ── Identity: stricter than link mode's email comparison ─────────────────

--- a/apps/api/src/routes/sso.reauth.test.ts
+++ b/apps/api/src/routes/sso.reauth.test.ts
@@ -126,7 +126,13 @@ vi.mock('../middleware/auth', () => ({
   }),
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
   requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
-  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  // #4018 Finding 1: unconditionally reject, mirroring the real
+  // requireMfa()'s unsatisfied-session response shape exactly
+  // (middleware/auth.ts:862). /reauth/start must NEVER be wired to this —
+  // if someone adds requireMfa() to its middleware chain, this mock makes
+  // every request through it 403, which is what the dedicated regression
+  // test below asserts against.
+  requireMfa: vi.fn(() => async (c: any) => c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403)),
   dbAccessContextFromAuth: vi.fn((auth: any) => ({
     scope: auth.scope,
     orgId: auth.orgId ?? null,
@@ -138,7 +144,7 @@ vi.mock('../middleware/auth', () => ({
   withAuthDbAccessContext: vi.fn((_auth: any, fn: () => any) => fn())
 }));
 
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { getUserEpochs, rateLimiter } from '../services';
 import { authMiddleware } from '../middleware/auth';
 
@@ -293,6 +299,40 @@ describe('POST /sso/reauth/start', () => {
     }));
     const insertedArg = insertValues.mock.calls[0][0];
     expect(insertedArg.linkUserId).toBeUndefined();
+
+    // #4018 Finding 2: sso_sessions is system-scope-only under RLS. Dropping
+    // this wrapping from the insert is the silent-RLS-drop bug (the write
+    // would be discarded by RLS at runtime with no error) and this suite
+    // would otherwise stay green — assert both wrappers actually ran, mirroring
+    // the precedent at sso.test.ts:1082-1083.
+    expect(runOutsideDbContext).toHaveBeenCalled();
+    expect(withSystemDbAccessContext).toHaveBeenCalled();
+  });
+
+  // #4018 Finding 1: the entire plan hinges on this route NOT being gated by
+  // requireMfa() — a passwordless SSO user cannot satisfy it, which is why
+  // this route exists. The requireMfa mock above (module-level) is wired to
+  // unconditionally 403 "the way the real requireMfa() does for an
+  // unsatisfied session" (middleware/auth.ts:862); since the route registers
+  // only `authMiddleware` (never requireMfa()), that rejecting middleware is
+  // never part of this route's chain, so a fully valid happy-path request
+  // must still succeed. If requireMfa() were ever added to the route's
+  // middleware chain, this would 403 instead and the test would fail.
+  it('never invokes requireMfa() — a happy-path request succeeds even though the requireMfa mock unconditionally rejects', async () => {
+    mockUserRow({ id: USER_ID, passwordHash: null });
+    mockSsoIdentityRows([{ providerId: PROVIDER_ID }]);
+    mockProviderRow(ACTIVE_OIDC_PROVIDER);
+    captureInsert();
+    vi.mocked(getUserEpochs).mockResolvedValueOnce({ authEpoch: 3, mfaEpoch: 1 } as any);
+
+    const res = await app.request('/sso/reauth/start', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    const { authUrl } = await res.json();
+    expect(authUrl).toBeTruthy();
   });
 
   it('503s when the caller has no sid or epochs are unavailable', async () => {

--- a/apps/api/src/routes/sso.reauth.test.ts
+++ b/apps/api/src/routes/sso.reauth.test.ts
@@ -93,8 +93,15 @@ vi.mock('../services/sso', () => ({
   // that puts the session's created_at on the same clock as the id_token's
   // auth_time. A stub returning `undefined` would make the freshness bound
   // NaN-ish and the timezone test below meaningless.
-  utcMsFromOffsetlessTimestamp: (value: Date) =>
-    value.getTime() - value.getTimezoneOffset() * 60_000,
+  //
+  // Wrapped in vi.fn() so the CALL ITSELF is observable. Every value-based
+  // assertion about this conversion is vacuous under TZ=UTC — the offset is 0,
+  // so the converted bound and a naive `.getTime()` are the SAME number and a
+  // reverted call site still passes. That is exactly how the missing conversion
+  // shipped past a green (UTC) CI run. Asserting that the route CALLED this,
+  // with the session's own createdAt, has teeth in every host timezone.
+  utcMsFromOffsetlessTimestamp: vi.fn((value: Date) =>
+    value.getTime() - value.getTimezoneOffset() * 60_000),
   mapUserAttributes: vi.fn(),
   discoverOIDCConfig: vi.fn(),
   // Real logic (not a stub) — getOIDCConfig (defined in sso.ts, not mocked)
@@ -219,6 +226,7 @@ import {
   exchangeCodeForTokens,
   getUserInfo,
   mapUserAttributes,
+  utcMsFromOffsetlessTimestamp,
   verifyIdTokenSignature,
 } from '../services/sso';
 import { mintStepUpGrant } from '../services/mfaStepUpGrant';
@@ -676,11 +684,19 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
   //
   // This test is the reason the fixture takes an epoch rather than a Date: it
   // only has teeth when the session row is built the way the driver builds it.
-  // Under TZ=UTC the offset is zero and it passes either way — which is exactly
-  // how this shipped past a green CI run.
+  //
+  // It is deliberately NOT written as an arithmetic comparison of the bound
+  // against `createdAt.getTime()`. Under TZ=UTC the host offset is zero, so
+  // those two numbers are identical and every such assertion passes with or
+  // without the conversion — which is exactly how this shipped past a green CI
+  // run on UTC runners. The load-bearing assertions here are therefore about
+  // the CALL: the route must hand the raw `createdAt` Date to
+  // utcMsFromOffsetlessTimestamp and use that function's return value as the
+  // bound. Deleting the conversion at the call site fails this in every
+  // timezone, UTC included.
   it('compares auth_time against the click on the SAME clock, whatever the host timezone', async () => {
     const sessionCreatedAtMs = Date.now() - 60_000;
-    primeReauthCallback({
+    const { session } = primeReauthCallback({
       sessionCreatedAtMs,
       // 30s after the click: unambiguously fresh on a correct clock.
       idClaims: { sub: EXTERNAL_ID, email: 'tech@acme.example', auth_time: Math.floor(sessionCreatedAtMs / 1000) + 30 }
@@ -688,12 +704,21 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
 
     const res = await doCallback();
 
+    // TZ-independent teeth #1: the conversion ran, on the session's OWN
+    // created_at Date (not on `Date.now()`, not on a pre-converted number).
+    expect(utcMsFromOffsetlessTimestamp).toHaveBeenCalledWith(session.createdAt);
+
     const [, boundMs] = vi.mocked(assertFreshIdpAuthentication).mock.calls.at(-1)!;
+    // TZ-independent teeth #2: the bound the freshness check received is the
+    // value that conversion RETURNED — so the two calls are wired together
+    // rather than coincidentally agreeing on a UTC host.
+    const converted = vi.mocked(utcMsFromOffsetlessTimestamp).mock.results.at(-1)!;
+    expect(converted.type).toBe('return');
+    expect(boundMs).toBe(converted.value);
+
+    // And, on a correct clock, that bound is the true epoch of the click.
     expect(boundMs).toBe(sessionCreatedAtMs);
-    // Pins that the offset was actually neutralised rather than the fixture
-    // having handed over a true-instant Date all along.
-    const naive = pgOffsetlessTimestamp(sessionCreatedAtMs);
-    expect(naive.getTime() - boundMs).toBe(naive.getTimezoneOffset() * 60_000);
+    expect(session.createdAt.getTime() - boundMs).toBe(session.createdAt.getTimezoneOffset() * 60_000);
 
     expect(assertFreshIdpAuthentication).toHaveLastReturnedWith({ ok: true });
     expect(res.headers.get('location')).toBe('/settings/profile#ssoReauthGrant=grant-abc');

--- a/apps/api/src/routes/sso.reauth.test.ts
+++ b/apps/api/src/routes/sso.reauth.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHmac } from 'crypto';
 import { Hono } from 'hono';
 import { ssoRoutes } from './sso';
 
@@ -7,7 +8,20 @@ import { ssoRoutes } from './sso';
 // brief), trimmed to what POST /sso/reauth/start actually exercises:
 // provider lookup + getOIDCConfig (needs assertSafeOidcEndpoint's real logic),
 // authorization-URL building, epoch/session binding, and the system-context
-// insert.
+// insert. Task 4 extends the same blocks with what GET /sso/callback's reauth
+// branch exercises (token exchange, id_token verification, userinfo, grant
+// minting).
+
+// Mirrors the route's signed binding-cookie derivation
+// (HMAC-SHA256 of `sso-login-state:<state>` keyed by the cookie secret) —
+// same helper as ./sso.test.ts:8-14.
+const SSO_STATE_COOKIE_SECRET = 'test-sso-cookie-secret';
+function ssoStateCookieHeader(state: string): string {
+  const value = createHmac('sha256', SSO_STATE_COOKIE_SECRET)
+    .update(`sso-login-state:${state}`)
+    .digest('hex');
+  return `breeze_sso_state=${encodeURIComponent(value)}`;
+}
 
 vi.mock('../services/sso', () => ({
   generateState: vi.fn().mockReturnValue('state'),
@@ -38,8 +52,43 @@ vi.mock('../services/sso', () => ({
   exchangeCodeForTokens: vi.fn(),
   getUserInfo: vi.fn(),
   verifyIdTokenSignature: vi.fn(),
-  readEmailVerifiedClaim: vi.fn(),
+  // Real logic (not a stub), same mirror as ./sso.test.ts:37-42 — an
+  // always-undefined stub would make the callback's email_verified gate
+  // unconditionally pass, hiding it from the reauth callback tests.
+  readEmailVerifiedClaim: (source: Record<string, unknown> | null | undefined) => {
+    const ev = source?.email_verified;
+    if (ev === true || ev === 'true') return 'true';
+    if (ev === false || ev === 'false') return 'false';
+    return 'absent';
+  },
   idpAssertedMfa: vi.fn(),
+  // Real logic (not a stub) — a faithful mirror of services/sso.ts:295-313
+  // (Task 1; independently unit-tested in services/sso.test.ts:633). A plain
+  // vi.fn() stub would return `undefined` and let the callback's freshness
+  // gate be deleted with the auth_time tests below still green, which is
+  // exactly the revert-probe this suite has to survive. Wrapped in vi.fn() so
+  // the suite can ALSO assert the route bounds it from the sso_sessions row's
+  // own created_at rather than a window measured from now.
+  assertFreshIdpAuthentication: vi.fn((
+    claims: { auth_time?: unknown } | null | undefined,
+    startedAtMs: number,
+    nowMs: number = Date.now(),
+  ) => {
+    const AUTH_TIME_SKEW_SECONDS = 120;
+    const authTime = claims?.auth_time;
+    if (typeof authTime !== 'number' || !Number.isFinite(authTime)) {
+      return { ok: false, reason: 'auth_time_missing' };
+    }
+    const nowSeconds = Math.floor(nowMs / 1000);
+    const startedAtSeconds = Math.floor(startedAtMs / 1000);
+    if (authTime > nowSeconds + AUTH_TIME_SKEW_SECONDS) {
+      return { ok: false, reason: 'auth_time_future' };
+    }
+    if (authTime < startedAtSeconds - AUTH_TIME_SKEW_SECONDS) {
+      return { ok: false, reason: 'auth_time_stale' };
+    }
+    return { ok: true };
+  }),
   mapUserAttributes: vi.fn(),
   discoverOIDCConfig: vi.fn(),
   // Real logic (not a stub) — getOIDCConfig (defined in sso.ts, not mocked)
@@ -67,7 +116,13 @@ vi.mock('../services', () => ({
   mintRefreshTokenFamily: vi.fn(),
   bindRefreshJtiToFamily: vi.fn(),
   getUserEpochs: vi.fn().mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 }),
-  getRefreshFamily: vi.fn(),
+  // The reauth callback re-checks the initiating refresh family is still live
+  // via validateSessionBinding. Default: healthy + far-future, so only the
+  // dedicated revocation test sees a dead one.
+  getRefreshFamily: vi.fn().mockResolvedValue({
+    revokedAt: null,
+    absoluteExpiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+  }),
   rateLimiter: vi.fn().mockResolvedValue({ allowed: true, remaining: 4, resetAt: new Date(Date.now() + 60_000) }),
   getRedis: vi.fn().mockReturnValue({})
 }));
@@ -104,6 +159,13 @@ vi.mock('../db', () => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => any) => fn()),
   getCurrentDbAccessContext: vi.fn(() => ({ scope: 'system' }))
+}));
+
+// The reauth callback's ONLY output on success. Mocked so the suite can assert
+// the exact bind (userId/operation/epochs/sid) and prove the grant is never
+// minted on any rejection path.
+vi.mock('../services/mfaStepUpGrant', () => ({
+  mintStepUpGrant: vi.fn()
 }));
 
 vi.mock('../services/auditEvents', async (importOriginal) => ({
@@ -145,11 +207,22 @@ vi.mock('../middleware/auth', () => ({
 }));
 
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { getUserEpochs, rateLimiter } from '../services';
+import { createTokenPair, getRefreshFamily, getUserEpochs, rateLimiter } from '../services';
+import {
+  assertFreshIdpAuthentication,
+  exchangeCodeForTokens,
+  getUserInfo,
+  mapUserAttributes,
+  verifyIdTokenSignature,
+} from '../services/sso';
+import { mintStepUpGrant } from '../services/mfaStepUpGrant';
+import { writeRouteAudit } from '../services/auditEvents';
 import { authMiddleware } from '../middleware/auth';
 
 const USER_ID = '00000000-0000-4000-8000-000000000020';
+const OTHER_USER_ID = '00000000-0000-4000-8000-0000000000aa';
 const PROVIDER_ID = '00000000-0000-4000-8000-000000000001';
+const ORG_ID = '00000000-0000-4000-8000-000000000010';
 const SID = '00000000-0000-4000-8000-0000000000fa';
 
 const ACTIVE_OIDC_PROVIDER = {
@@ -297,7 +370,7 @@ describe('POST /sso/reauth/start', () => {
       initiatingMfaEpoch: 1,
       initiatingSessionId: SID
     }));
-    const insertedArg = insertValues.mock.calls[0][0];
+    const insertedArg = insertValues.mock.calls[0]![0];
     expect(insertedArg.linkUserId).toBeUndefined();
 
     // #4018 Finding 2: sso_sessions is system-scope-only under RLS. Dropping
@@ -377,5 +450,344 @@ describe('POST /sso/reauth/start', () => {
     });
 
     expect(res.status).toBe(429);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════
+// #4018 Task 4: GET /sso/callback — reauth mode.
+//
+// A passwordless SSO user who has just proved identity through a FORCED IdP
+// round-trip (`prompt=login&max_age=0`, stamped by POST /sso/reauth/start) is
+// handed a single-use step-up grant so they can enroll a FIRST MFA factor.
+//
+// The branch sits after the full id_token signature/nonce verification, the
+// atomic session claim and the userinfo `sub` cross-check — the same position
+// link mode occupies — and it mints NO login tokens, creates NO users and
+// links NO identities. Everything below exists to keep it that way.
+// ══════════════════════════════════════════════════════════════════════════
+describe('GET /sso/callback — reauth mode (#4018)', () => {
+  let app: Hono;
+
+  const EXTERNAL_ID = 'external-user-1';
+
+  const sel = (rows: unknown[]) => ({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) })
+    })
+  } as any);
+
+  const ACTIVE_REAUTH_USER = {
+    id: USER_ID,
+    email: 'tech@acme.example',
+    name: 'Tech',
+    status: 'active',
+    orgId: null,
+    passwordHash: null,
+  };
+
+  const secondsAgo = (n: number) => Math.floor(Date.now() / 1000) - n;
+
+  // Primes ONE reauth callback round-trip. db.select is consumed in exactly
+  // this order by the branch under test:
+  //   1. ssoProviders           (callback: provider by id)
+  //   2. users                  (validateSessionBinding: the bound user)
+  //   3. organizationUsers      (validateSessionBinding: org-axis membership)
+  //   4. userSsoIdentities      (reauth branch: (provider, sub) ownership)
+  // Every test funnels through here so that ordering lives in one place.
+  const primeReauthCallback = (opts: {
+    sessionCreatedAt?: Date;
+    idClaims?: Record<string, unknown>;
+    sessionOverrides?: Record<string, unknown>;
+    // undefined = healthy user; null = simulate "user gone" (no row).
+    reauthUser?: Record<string, unknown> | null;
+    // undefined = live membership row; [] = membership lost.
+    membership?: unknown[];
+    // undefined = the identity belongs to the reauth user; [] = no identity.
+    identityRows?: Array<{ userId: string }>;
+    provider?: Record<string, unknown>;
+  } = {}) => {
+    const {
+      sessionCreatedAt = new Date(),
+      sessionOverrides = {},
+      reauthUser = ACTIVE_REAUTH_USER,
+      membership = [{ userId: USER_ID }],
+      identityRows = [{ userId: USER_ID }],
+      provider = ACTIVE_OIDC_PROVIDER,
+    } = opts;
+    const idClaims = opts.idClaims ?? {
+      sub: EXTERNAL_ID,
+      email: 'tech@acme.example',
+      auth_time: secondsAgo(5),
+    };
+
+    vi.mocked(exchangeCodeForTokens).mockResolvedValue({
+      access_token: 'a', refresh_token: 'r', expires_in: 3600, id_token: 'h.p.s'
+    } as any);
+    vi.mocked(verifyIdTokenSignature).mockResolvedValue(idClaims as any);
+    vi.mocked(getUserInfo).mockResolvedValue({
+      sub: EXTERNAL_ID, email: 'tech@acme.example', name: 'Tech'
+    } as any);
+    vi.mocked(mapUserAttributes).mockReturnValue({
+      email: 'tech@acme.example', name: 'Tech'
+    } as any);
+
+    const session = {
+      id: 'sso-session-reauth',
+      providerId: PROVIDER_ID,
+      state: 'state',
+      nonce: 'nonce',
+      codeVerifier: 'verifier',
+      redirectUrl: '/settings/profile',
+      linkUserId: null,
+      reauthUserId: USER_ID,
+      providerVersion: 7,
+      initiatingAuthEpoch: 3,
+      initiatingMfaEpoch: 1,
+      initiatingSessionId: SID,
+      createdAt: sessionCreatedAt,
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+      ...sessionOverrides,
+    };
+
+    vi.mocked(db.delete).mockReturnValueOnce({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([session])
+      })
+    } as any);
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce(sel([provider]))
+      .mockReturnValueOnce(sel(reauthUser ? [reauthUser] : []))
+      .mockReturnValueOnce(sel(membership))
+      .mockReturnValueOnce(sel(identityRows));
+
+    return { session, idClaims };
+  };
+
+  const doCallback = () => app.request('/sso/callback?code=oidc-code&state=state', {
+    method: 'GET',
+    headers: { cookie: ssoStateCookieHeader('state') }
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset().mockReturnValue(sel([]));
+    vi.mocked(db.insert).mockReset().mockReturnValue({
+      values: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) }))
+    } as any);
+    vi.mocked(db.delete).mockReset().mockReturnValue({
+      where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) }))
+    } as any);
+    vi.mocked(getUserEpochs).mockReset().mockResolvedValue({ authEpoch: 3, mfaEpoch: 1 } as any);
+    vi.mocked(getRefreshFamily).mockReset().mockResolvedValue({
+      revokedAt: null,
+      absoluteExpiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    } as any);
+    vi.mocked(mintStepUpGrant).mockReset().mockResolvedValue('grant-abc');
+    process.env.APP_ENCRYPTION_KEY = SSO_STATE_COOKIE_SECRET;
+    app = new Hono();
+    app.route('/sso', ssoRoutes);
+  });
+
+  // ── Freshness: the IdP must have ACTUALLY re-authenticated ───────────────
+
+  it('rejects when the id_token has no auth_time (fails closed)', async () => {
+    primeReauthCallback({ idClaims: { sub: EXTERNAL_ID, email: 'tech@acme.example' } });
+
+    const res = await doCallback();
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('error=reauth_not_fresh');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale auth_time — the IdP replayed a cached session', async () => {
+    primeReauthCallback({
+      idClaims: { sub: EXTERNAL_ID, email: 'tech@acme.example', auth_time: secondsAgo(3600) }
+    });
+
+    const res = await doCallback();
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('error=reauth_not_fresh');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  // The load-bearing half of the freshness contract: the lower bound is the
+  // sso_sessions row's own created_at, NOT a window measured from now. An
+  // authentication that predates the user's click is a cached session however
+  // recent it looks in wall-clock terms — this pair discriminates the two
+  // (both auth_times below are comfortably "recent", only one post-dates the
+  // click), and the call-argument assertion pins the contract exactly.
+  it('bounds freshness from the session created_at, not from now (accepts an auth_time after the click)', async () => {
+    const sessionCreatedAt = new Date(Date.now() - 9 * 60 * 1000);
+    const { idClaims } = primeReauthCallback({
+      sessionCreatedAt,
+      idClaims: { sub: EXTERNAL_ID, email: 'tech@acme.example', auth_time: secondsAgo(30) }
+    });
+
+    const res = await doCallback();
+
+    expect(assertFreshIdpAuthentication).toHaveBeenCalledWith(idClaims, sessionCreatedAt.getTime());
+    expect(res.headers.get('location')).toBe('/settings/profile#ssoReauthGrant=grant-abc');
+  });
+
+  it('bounds freshness from the session created_at, not from now (rejects an auth_time that predates the click)', async () => {
+    const sessionCreatedAt = new Date(Date.now() - 9 * 60 * 1000);
+    primeReauthCallback({
+      sessionCreatedAt,
+      idClaims: {
+        sub: EXTERNAL_ID,
+        email: 'tech@acme.example',
+        // ~14 minutes ago: still "recent" by any now-relative window, but it
+        // predates the /reauth/start click by 5 minutes.
+        auth_time: Math.floor(sessionCreatedAt.getTime() / 1000) - 300,
+      }
+    });
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toContain('error=reauth_not_fresh');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  // ── Identity: stricter than link mode's email comparison ─────────────────
+
+  it('rejects when the asserted sub belongs to a different user', async () => {
+    // Same asserted email as the reauth user — an email comparison (link
+    // mode's rule) would WAVE THIS THROUGH. Only (providerId, externalSub)
+    // ownership catches it.
+    primeReauthCallback({ identityRows: [{ userId: OTHER_USER_ID }] });
+
+    const res = await doCallback();
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('error=identity_mismatch');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the asserted sub has no identity row at all (never creates one)', async () => {
+    primeReauthCallback({ identityRows: [] });
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toContain('error=identity_mismatch');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  // ── Binding: live re-check of the /reauth/start snapshot ─────────────────
+
+  it('rejects when the initiating session was revoked since /reauth/start', async () => {
+    primeReauthCallback();
+    vi.mocked(getRefreshFamily).mockResolvedValueOnce({
+      revokedAt: new Date(),
+      absoluteExpiresAt: new Date(Date.now() + 1e9),
+    } as any);
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects an auth-epoch bump since /reauth/start', async () => {
+    primeReauthCallback();
+    vi.mocked(getUserEpochs).mockResolvedValueOnce({ authEpoch: 4, mfaEpoch: 1 } as any);
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects an mfa-epoch bump since /reauth/start', async () => {
+    primeReauthCallback();
+    vi.mocked(getUserEpochs).mockResolvedValueOnce({ authEpoch: 3, mfaEpoch: 2 } as any);
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects a suspended user', async () => {
+    primeReauthCallback({ reauthUser: { ...ACTIVE_REAUTH_USER, status: 'suspended' } });
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects lost org-axis membership since /reauth/start', async () => {
+    primeReauthCallback({ membership: [] });
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects a NULL binding column — pre-deploy row', async () => {
+    primeReauthCallback({ sessionOverrides: { initiatingSessionId: null } });
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  // ── Belt-and-braces: a password set mid-flight ───────────────────────────
+
+  it('rejects when a password was set between /reauth/start and the callback', async () => {
+    primeReauthCallback({ reauthUser: { ...ACTIVE_REAUTH_USER, passwordHash: 'argon2id$...' } });
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toContain('error=password_set');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  // ── Success ──────────────────────────────────────────────────────────────
+
+  it('mints an enroll_first_factor grant and redirects with it in the fragment', async () => {
+    primeReauthCallback();
+
+    const res = await doCallback();
+
+    expect(mintStepUpGrant).toHaveBeenCalledWith({
+      userId: USER_ID,
+      operation: 'enroll_first_factor',
+      authEpoch: 3,
+      mfaEpoch: 1,
+      sid: SID,
+    });
+    expect(res.status).toBe(302);
+    // Fragment, not query: never sent to the server, never in an access log.
+    expect(res.headers.get('location')).toBe('/settings/profile#ssoReauthGrant=grant-abc');
+    expect(writeRouteAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'sso.reauth.completed' })
+    );
+  });
+
+  it('fails closed with reauth_unavailable when the grant cannot be minted (Redis down)', async () => {
+    primeReauthCallback();
+    vi.mocked(mintStepUpGrant).mockResolvedValueOnce(null);
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toBe('/settings/profile?error=reauth_unavailable');
+  });
+
+  it('never mints login tokens, creates users, or links identities in reauth mode', async () => {
+    primeReauthCallback();
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toBe('/settings/profile#ssoReauthGrant=grant-abc');
+    expect(createTokenPair).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/sso.reauth.test.ts
+++ b/apps/api/src/routes/sso.reauth.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { ssoRoutes } from './sso';
+
+// Mirrors the mocking style established in ./sso.test.ts — copied verbatim
+// for the ../db, ../services, and ../middleware/auth blocks (per the Task 3
+// brief), trimmed to what POST /sso/reauth/start actually exercises:
+// provider lookup + getOIDCConfig (needs assertSafeOidcEndpoint's real logic),
+// authorization-URL building, epoch/session binding, and the system-context
+// insert.
+
+vi.mock('../services/sso', () => ({
+  generateState: vi.fn().mockReturnValue('state'),
+  generateNonce: vi.fn().mockReturnValue('nonce'),
+  generatePKCEChallenge: vi.fn().mockReturnValue({
+    codeVerifier: 'verifier',
+    codeChallenge: 'challenge',
+    codeChallengeMethod: 'S256'
+  }),
+  // Real logic (not a stub): asserts the route actually threads prompt/maxAge
+  // through to the built URL.
+  buildAuthorizationUrl: vi.fn(
+    ({ config, state, nonce, redirectUri, pkce, prompt, maxAge }: any) => {
+      const url = new URL(config.authorizationUrl);
+      url.searchParams.set('client_id', config.clientId);
+      url.searchParams.set('redirect_uri', redirectUri);
+      url.searchParams.set('response_type', 'code');
+      url.searchParams.set('scope', config.scopes);
+      url.searchParams.set('state', state);
+      url.searchParams.set('nonce', nonce);
+      url.searchParams.set('code_challenge', pkce.codeChallenge);
+      url.searchParams.set('code_challenge_method', pkce.codeChallengeMethod);
+      if (prompt != null) url.searchParams.set('prompt', prompt);
+      if (maxAge != null) url.searchParams.set('max_age', String(maxAge));
+      return url.toString();
+    }
+  ),
+  exchangeCodeForTokens: vi.fn(),
+  getUserInfo: vi.fn(),
+  verifyIdTokenSignature: vi.fn(),
+  readEmailVerifiedClaim: vi.fn(),
+  idpAssertedMfa: vi.fn(),
+  mapUserAttributes: vi.fn(),
+  discoverOIDCConfig: vi.fn(),
+  // Real logic (not a stub) — getOIDCConfig (defined in sso.ts, not mocked)
+  // calls this to validate the persisted provider endpoints.
+  assertSafeOidcEndpoint: (label: string, urlStr: string | null | undefined, allowPrivateNetwork = false) => {
+    if (!urlStr) throw new Error(`OIDC endpoint missing: ${label}`);
+    let u: URL;
+    try { u = new URL(urlStr); } catch { throw new Error(`OIDC endpoint rejected: ${label}`); }
+    const isHttps = u.protocol === 'https:';
+    const isHttp = u.protocol === 'http:';
+    if (!isHttps && !(allowPrivateNetwork && isHttp)) throw new Error(`OIDC endpoint rejected (must be HTTPS): ${label}`);
+    const host = u.hostname.replace(/^\[|\]$/g, '');
+    if (host === 'localhost') throw new Error(`OIDC endpoint rejected (internal): ${label}`);
+    const literalIp = /^[0-9.]+$/.test(host) || host.includes(':');
+    if (literalIp && /^(127\.|10\.|192\.168\.|169\.254\.|0\.|172\.(1[6-9]|2\d|3[01])\.|::1|::$|fc|fd|fe80)/i.test(host)) {
+      throw new Error(`OIDC endpoint rejected (internal): ${label}`);
+    }
+  },
+  PROVIDER_PRESETS: {}
+}));
+
+vi.mock('../services', () => ({
+  createTokenPair: vi.fn(),
+  createSession: vi.fn(),
+  mintRefreshTokenFamily: vi.fn(),
+  bindRefreshJtiToFamily: vi.fn(),
+  getUserEpochs: vi.fn().mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 }),
+  getRefreshFamily: vi.fn(),
+  rateLimiter: vi.fn().mockResolvedValue({ allowed: true, remaining: 4, resetAt: new Date(Date.now() + 60_000) }),
+  getRedis: vi.fn().mockReturnValue({})
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([])),
+          orderBy: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) }))
+        }))
+      }))
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(() => Promise.resolve([]))
+      }))
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve([]))
+        }))
+      }))
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn(() => ({
+        returning: vi.fn(() => Promise.resolve([]))
+      }))
+    }))
+  },
+  runOutsideDbContext: vi.fn((fn: () => any) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => any) => fn()),
+  getCurrentDbAccessContext: vi.fn(() => ({ scope: 'system' }))
+}));
+
+vi.mock('../services/auditEvents', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/auditEvents')>()),
+  writeRouteAudit: vi.fn()
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      scope: 'organization',
+      orgId: '00000000-0000-4000-8000-000000000010',
+      partnerId: null,
+      accessibleOrgIds: ['00000000-0000-4000-8000-000000000010'],
+      canAccessOrg: () => true,
+      user: { id: USER_ID, email: 'test@example.com' },
+      token: { sid: SID }
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  dbAccessContextFromAuth: vi.fn((auth: any) => ({
+    scope: auth.scope,
+    orgId: auth.orgId ?? null,
+    accessibleOrgIds: auth.accessibleOrgIds ?? null,
+    accessiblePartnerIds: auth.partnerId ? [auth.partnerId] : [],
+    userId: auth.user?.id ?? null,
+    currentPartnerId: auth.partnerId ?? null
+  })),
+  withAuthDbAccessContext: vi.fn((_auth: any, fn: () => any) => fn())
+}));
+
+import { db } from '../db';
+import { getUserEpochs, rateLimiter } from '../services';
+import { authMiddleware } from '../middleware/auth';
+
+const USER_ID = '00000000-0000-4000-8000-000000000020';
+const PROVIDER_ID = '00000000-0000-4000-8000-000000000001';
+const SID = '00000000-0000-4000-8000-0000000000fa';
+
+const ACTIVE_OIDC_PROVIDER = {
+  id: PROVIDER_ID,
+  orgId: '00000000-0000-4000-8000-000000000010',
+  partnerId: null,
+  status: 'active',
+  configVersion: 7,
+  type: 'oidc',
+  name: 'Okta',
+  issuer: 'https://issuer.example.com',
+  authorizationUrl: 'https://issuer.example.com/auth',
+  tokenUrl: 'https://issuer.example.com/token',
+  userInfoUrl: 'https://issuer.example.com/userinfo',
+  jwksUrl: 'https://issuer.example.com/jwks',
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  scopes: 'openid profile email',
+  attributeMapping: { email: 'email', name: 'name' },
+  defaultRoleId: null
+};
+
+describe('POST /sso/reauth/start', () => {
+  let app: Hono;
+
+  // Mock db.select() sequenced per the route's query order:
+  //   1. users (passwordHash)
+  //   2. userSsoIdentities (providerId)
+  //   3. ssoProviders (full row)
+  const mockUserRow = (row: { id: string; passwordHash: string | null } | null) => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(row ? [row] : []) })
+      })
+    } as any);
+  };
+
+  const mockSsoIdentityRows = (rows: Array<{ providerId: string }>) => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) })
+        })
+      })
+    } as any);
+  };
+
+  const mockProviderRow = (row: Record<string, unknown> | null) => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(row ? [row] : []) })
+      })
+    } as any);
+  };
+
+  let insertValues: ReturnType<typeof vi.fn>;
+  const captureInsert = () => {
+    insertValues = vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) }));
+    vi.mocked(db.insert).mockReturnValueOnce({ values: insertValues } as any);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset().mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([])),
+          orderBy: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) }))
+        }))
+      }))
+    } as any);
+    vi.mocked(db.insert).mockReset().mockReturnValue({
+      values: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([])) }))
+    } as any);
+    vi.mocked(getUserEpochs).mockReset().mockResolvedValue({ authEpoch: 3, mfaEpoch: 1 } as any);
+    vi.mocked(rateLimiter).mockReset().mockResolvedValue({
+      allowed: true,
+      remaining: 4,
+      resetAt: new Date(Date.now() + 60_000)
+    } as any);
+    vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+      c.set('auth', {
+        scope: 'organization',
+        orgId: '00000000-0000-4000-8000-000000000010',
+        partnerId: null,
+        accessibleOrgIds: ['00000000-0000-4000-8000-000000000010'],
+        canAccessOrg: () => true,
+        user: { id: USER_ID, email: 'test@example.com' },
+        token: { sid: SID }
+      });
+      return next();
+    });
+    process.env.APP_ENCRYPTION_KEY = 'test-sso-cookie-secret';
+    app = new Hono();
+    app.route('/sso', ssoRoutes);
+  });
+
+  it('refuses when the account has a password', async () => {
+    mockUserRow({ id: USER_ID, passwordHash: 'argon2id$...' });
+
+    const res = await app.request('/sso/reauth/start', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Account has a password' });
+  });
+
+  it('404s when the user has no linked SSO identity', async () => {
+    mockUserRow({ id: USER_ID, passwordHash: null });
+    mockSsoIdentityRows([]);
+
+    const res = await app.request('/sso/reauth/start', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('inserts a reauth-mode session bound to the caller and returns an authUrl with prompt=login and max_age=0', async () => {
+    mockUserRow({ id: USER_ID, passwordHash: null });
+    mockSsoIdentityRows([{ providerId: PROVIDER_ID }]);
+    mockProviderRow(ACTIVE_OIDC_PROVIDER);
+    captureInsert();
+    vi.mocked(getUserEpochs).mockResolvedValueOnce({ authEpoch: 3, mfaEpoch: 1 } as any);
+
+    const res = await app.request('/sso/reauth/start', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    const { authUrl } = await res.json();
+    const url = new URL(authUrl);
+    expect(url.searchParams.get('prompt')).toBe('login');
+    expect(url.searchParams.get('max_age')).toBe('0');
+
+    expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({
+      providerId: PROVIDER_ID,
+      reauthUserId: USER_ID,
+      providerVersion: 7,
+      initiatingAuthEpoch: 3,
+      initiatingMfaEpoch: 1,
+      initiatingSessionId: SID
+    }));
+    const insertedArg = insertValues.mock.calls[0][0];
+    expect(insertedArg.linkUserId).toBeUndefined();
+  });
+
+  it('503s when the caller has no sid or epochs are unavailable', async () => {
+    mockUserRow({ id: USER_ID, passwordHash: null });
+    mockSsoIdentityRows([{ providerId: PROVIDER_ID }]);
+    mockProviderRow(ACTIVE_OIDC_PROVIDER);
+    vi.mocked(getUserEpochs).mockResolvedValueOnce(null);
+
+    const res = await app.request('/sso/reauth/start', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(503);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('refuses a provider whose status is inactive', async () => {
+    mockUserRow({ id: USER_ID, passwordHash: null });
+    mockSsoIdentityRows([{ providerId: PROVIDER_ID }]);
+    mockProviderRow({ ...ACTIVE_OIDC_PROVIDER, status: 'inactive' });
+
+    const res = await app.request('/sso/reauth/start', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rate-limits repeated attempts per caller', async () => {
+    mockUserRow({ id: USER_ID, passwordHash: null });
+    vi.mocked(rateLimiter).mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAt: new Date(Date.now() + 60_000)
+    } as any);
+
+    const res = await app.request('/sso/reauth/start', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(429);
+  });
+});

--- a/apps/api/src/routes/sso.reauth.test.ts
+++ b/apps/api/src/routes/sso.reauth.test.ts
@@ -618,7 +618,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
     const res = await doCallback();
 
     expect(res.status).toBe(302);
-    expect(res.headers.get('location')).toContain('error=reauth_not_fresh');
+    expect(res.headers.get('location')).toContain('ssoReauthError=reauth_not_fresh');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
   });
 
@@ -630,7 +630,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
     const res = await doCallback();
 
     expect(res.status).toBe(302);
-    expect(res.headers.get('location')).toContain('error=reauth_not_fresh');
+    expect(res.headers.get('location')).toContain('ssoReauthError=reauth_not_fresh');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
   });
 
@@ -670,7 +670,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
 
     const res = await doCallback();
 
-    expect(res.headers.get('location')).toContain('error=reauth_not_fresh');
+    expect(res.headers.get('location')).toContain('ssoReauthError=reauth_not_fresh');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
   });
 
@@ -735,7 +735,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
     const res = await doCallback();
 
     expect(res.status).toBe(302);
-    expect(res.headers.get('location')).toContain('error=identity_mismatch');
+    expect(res.headers.get('location')).toContain('ssoReauthError=identity_mismatch');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
   });
 
@@ -744,7 +744,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
 
     const res = await doCallback();
 
-    expect(res.headers.get('location')).toContain('error=identity_mismatch');
+    expect(res.headers.get('location')).toContain('ssoReauthError=identity_mismatch');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
     expect(db.insert).not.toHaveBeenCalled();
   });
@@ -760,7 +760,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
 
     const res = await doCallback();
 
-    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(res.headers.get('location')).toContain('ssoReauthError=session_invalid');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
   });
 
@@ -770,7 +770,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
 
     const res = await doCallback();
 
-    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(res.headers.get('location')).toContain('ssoReauthError=session_invalid');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
   });
 
@@ -780,7 +780,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
 
     const res = await doCallback();
 
-    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(res.headers.get('location')).toContain('ssoReauthError=session_invalid');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
   });
 
@@ -789,7 +789,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
 
     const res = await doCallback();
 
-    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(res.headers.get('location')).toContain('ssoReauthError=session_invalid');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
   });
 
@@ -798,7 +798,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
 
     const res = await doCallback();
 
-    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(res.headers.get('location')).toContain('ssoReauthError=session_invalid');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
   });
 
@@ -807,7 +807,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
 
     const res = await doCallback();
 
-    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(res.headers.get('location')).toContain('ssoReauthError=session_invalid');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
   });
 
@@ -818,7 +818,7 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
 
     const res = await doCallback();
 
-    expect(res.headers.get('location')).toContain('error=password_set');
+    expect(res.headers.get('location')).toContain('ssoReauthError=password_set');
     expect(mintStepUpGrant).not.toHaveBeenCalled();
   });
 
@@ -851,7 +851,97 @@ describe('GET /sso/callback — reauth mode (#4018)', () => {
 
     const res = await doCallback();
 
-    expect(res.headers.get('location')).toBe('/settings/profile?error=reauth_unavailable');
+    expect(res.headers.get('location')).toBe('/settings/profile?ssoReauthError=reauth_unavailable');
+  });
+
+  // A mint failure is an INFRASTRUCTURE outcome, not a user decision. Without a
+  // terminal audit row a Redis outage looks exactly like the user closing the
+  // IdP tab: `sso.reauth.started` and then nothing. Every other terminal
+  // outcome on this road writes one.
+  it('audits a mint failure as grant_mint_failed rather than going silent', async () => {
+    primeReauthCallback();
+    vi.mocked(mintStepUpGrant).mockResolvedValueOnce(null);
+
+    await doCallback();
+
+    expect(writeRouteAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'sso.reauth.rejected',
+        result: 'denied',
+        details: expect.objectContaining({ mode: 'reauth', reason: 'grant_mint_failed', userId: USER_ID }),
+      })
+    );
+    expect(writeRouteAudit).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'sso.reauth.completed' })
+    );
+  });
+
+  // ── Reauth is NOT a login: failures stay on /settings/profile ────────────
+  //
+  // Both sites below used to discriminate on `callbackMode === 'link'`, which
+  // drops reauth into the login-mode `else`. An already-signed-in user
+  // re-authenticating was then redirected to /login with SSO-LOGIN copy, on a
+  // page whose error handler for these codes does not exist. The generation
+  // site is live in normal operation: `config_version` bumps on ANY provider
+  // edit — including this feature's own trustsIdpMfa toggle — and a bump inside
+  // the 10-minute state TTL lands here.
+
+  it('keeps a config_version bump mid-flight on the profile page, namespaced', async () => {
+    // Session snapshot 7 vs a provider the admin has since edited to 8.
+    primeReauthCallback({ provider: { ...ACTIVE_OIDC_PROVIDER, configVersion: 8 } });
+
+    const res = await doCallback();
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('/settings/profile?ssoReauthError=config_changed');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('keeps a disabled provider on the profile page, namespaced', async () => {
+    primeReauthCallback({ provider: { ...ACTIVE_OIDC_PROVIDER, status: 'inactive' } });
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toBe('/settings/profile?ssoReauthError=provider_inactive');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('keeps an email_verified=false assertion on the profile page, namespaced', async () => {
+    primeReauthCallback({
+      idClaims: {
+        sub: EXTERNAL_ID,
+        email: 'tech@acme.example',
+        email_verified: false,
+        auth_time: secondsAgo(5),
+      }
+    });
+
+    const res = await doCallback();
+
+    expect(res.headers.get('location')).toBe('/settings/profile?ssoReauthError=email_unverified');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  // Pins the CURRENT mint-site contract, deliberately without changing it.
+  // Neither /sso/reauth/start nor this callback consults userIsMfaProtected, so
+  // a passwordless account that already holds TOTP still gets a live grant; only
+  // resolveEnrollmentStepUp refuses to spend it. That is safe today because
+  // there is exactly one redemption site. A SECOND redemption site added later
+  // would inherit a grant that should never have existed — this test is here so
+  // that change has to be deliberate.
+  it('mints even for an already-protected account: the refusal lives at redemption, not here', async () => {
+    primeReauthCallback({
+      reauthUser: { ...ACTIVE_REAUTH_USER, mfaEnabled: true },
+    });
+
+    const res = await doCallback();
+
+    expect(mintStepUpGrant).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID, operation: 'enroll_first_factor' })
+    );
+    expect(res.headers.get('location')).toBe('/settings/profile#ssoReauthGrant=grant-abc');
   });
 
   it('never mints login tokens, creates users, or links identities in reauth mode', async () => {

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -677,12 +677,24 @@ async function validateSessionBinding(
   session: typeof ssoSessions.$inferSelect,
   provider: typeof ssoProviders.$inferSelect,
   boundUserId: string,
-): Promise<{ ok: true; user: typeof users.$inferSelect } | { ok: false; reason: LinkRejectReason }> {
-  if (
-    session.initiatingAuthEpoch == null ||
-    session.initiatingMfaEpoch == null ||
-    session.initiatingSessionId == null
-  ) {
+): Promise<
+  | {
+      ok: true;
+      user: typeof users.$inferSelect;
+      // The three binding columns, NARROWED. They are nullable on the row, and
+      // the null check that makes them safe lives here — so hand the proven
+      // values back rather than making every caller re-assert them with `!`.
+      // A caller asserting instead would mint a step-up grant with an undefined
+      // member: JSON.stringify drops it, bindsMatch then fails forever, and the
+      // user is told `Invalid credentials` after a SUCCESSFUL IdP round trip.
+      initiating: { authEpoch: number; mfaEpoch: number; sid: string };
+    }
+  | { ok: false; reason: LinkRejectReason }
+> {
+  const initiatingAuthEpoch = session.initiatingAuthEpoch;
+  const initiatingMfaEpoch = session.initiatingMfaEpoch;
+  const initiatingSessionId = session.initiatingSessionId;
+  if (initiatingAuthEpoch == null || initiatingMfaEpoch == null || initiatingSessionId == null) {
     return { ok: false, reason: 'link_binding_missing' };
   }
 
@@ -696,14 +708,14 @@ async function validateSessionBinding(
 
   const liveEpochs = await getUserEpochs(linkingUser.id);
   if (!liveEpochs) return { ok: false, reason: 'link_epochs_unavailable' };
-  if (liveEpochs.authEpoch !== session.initiatingAuthEpoch) {
+  if (liveEpochs.authEpoch !== initiatingAuthEpoch) {
     return { ok: false, reason: 'link_auth_epoch_mismatch' };
   }
-  if (liveEpochs.mfaEpoch !== session.initiatingMfaEpoch) {
+  if (liveEpochs.mfaEpoch !== initiatingMfaEpoch) {
     return { ok: false, reason: 'link_mfa_epoch_mismatch' };
   }
 
-  const family = await getRefreshFamily(session.initiatingSessionId);
+  const family = await getRefreshFamily(initiatingSessionId);
   if (!family) return { ok: false, reason: 'link_family_missing' };
   if (family.revokedAt) return { ok: false, reason: 'link_family_revoked' };
   if (family.absoluteExpiresAt.getTime() <= Date.now()) {
@@ -737,7 +749,15 @@ async function validateSessionBinding(
     return { ok: false, reason: 'link_axis_membership_lost' };
   }
 
-  return { ok: true, user: linkingUser };
+  return {
+    ok: true,
+    user: linkingUser,
+    initiating: {
+      authEpoch: initiatingAuthEpoch,
+      mfaEpoch: initiatingMfaEpoch,
+      sid: initiatingSessionId,
+    },
+  };
 }
 
 function getOIDCConfig(provider: typeof ssoProviders.$inferSelect): OIDCConfig {
@@ -2274,17 +2294,26 @@ ssoRoutes.get('/callback', async (c) => {
       },
     });
     clearStateCookie();
-    if (callbackMode === 'link') {
+    // Discriminate on `login`, not on `link`. Both non-login modes belong to an
+    // ALREADY-AUTHENTICATED user sitting on /settings/profile; a `callbackMode
+    // === 'link'` test drops reauth into the login branch and dumps a signed-in
+    // user on /login with SSO-LOGIN copy, where the profile page's error handler
+    // never runs. This branch is live for reauth: `config_version` bumps on any
+    // provider edit — and this same feature ships the trustsIdpMfa toggle, which
+    // makes such edits more frequent — so a bump inside the 10-minute state TTL
+    // reaches here.
+    const staleOrDisabled =
+      generation.reason === 'provider_inactive' || generation.reason === 'provider_not_usable';
+    if (callbackMode === 'login') {
       return c.redirect(
-        generation.reason === 'provider_inactive' || generation.reason === 'provider_not_usable'
-          ? '/settings/profile?ssoLinkError=provider_inactive'
-          : '/settings/profile?ssoLinkError=config_changed',
+        staleOrDisabled ? '/login?error=sso_provider_inactive' : '/login?error=sso_config_changed',
       );
     }
+    const generationErrorParam = callbackMode === 'reauth' ? 'ssoReauthError' : 'ssoLinkError';
     return c.redirect(
-      generation.reason === 'provider_inactive' || generation.reason === 'provider_not_usable'
-        ? '/login?error=sso_provider_inactive'
-        : '/login?error=sso_config_changed',
+      staleOrDisabled
+        ? `/settings/profile?${generationErrorParam}=provider_inactive`
+        : `/settings/profile?${generationErrorParam}=config_changed`,
     );
   }
 
@@ -2423,9 +2452,17 @@ ssoRoutes.get('/callback', async (c) => {
         },
       });
       clearStateCookie();
-      return callbackMode === 'link'
-        ? c.redirect('/settings/profile?ssoLinkError=email_unverified')
-        : c.redirect('/login?error=sso_email_unverified');
+      // Discriminate on `login`, same reasoning as the provider-generation
+      // rejection above: reauth is an authenticated user on /settings/profile,
+      // not a login attempt, and must not be bounced to /login.
+      if (callbackMode === 'login') {
+        return c.redirect('/login?error=sso_email_unverified');
+      }
+      return c.redirect(
+        callbackMode === 'reauth'
+          ? '/settings/profile?ssoReauthError=email_unverified'
+          : '/settings/profile?ssoLinkError=email_unverified',
+      );
     }
 
     // Check allowed domains. An address whose mailbox domain cannot be parsed is
@@ -2483,7 +2520,7 @@ ssoRoutes.get('/callback', async (c) => {
           details: { mode: 'reauth', reason: freshness.reason, userId: reauthUserId }
         });
         clearStateCookie();
-        return c.redirect('/settings/profile?error=reauth_not_fresh');
+        return c.redirect('/settings/profile?ssoReauthError=reauth_not_fresh');
       }
 
       // NOTE on the shape: every variant carries an explicit `ok` literal
@@ -2520,11 +2557,19 @@ ssoRoutes.get('/callback', async (c) => {
           return { ok: false as const, error: 'password_set' as const };
         }
 
+        // Taken from the binding result, NOT re-read off the session row with
+        // `!`. validateSessionBinding is where the null check lives (it rejects
+        // `link_binding_missing` -> the public `session_invalid`), so consuming
+        // its narrowed values keeps the guarantee in one place. A `session.
+        // initiatingAuthEpoch!` here would compile even if that check were ever
+        // moved or reordered, and would then mint a grant with an undefined
+        // member — JSON.stringify drops it, bindsMatch fails forever, and the
+        // user is told `Invalid credentials` after a SUCCESSFUL IdP round trip.
         return {
           ok: true as const,
-          authEpoch: session.initiatingAuthEpoch!,
-          mfaEpoch: session.initiatingMfaEpoch!,
-          sid: session.initiatingSessionId!,
+          authEpoch: binding.initiating.authEpoch,
+          mfaEpoch: binding.initiating.mfaEpoch,
+          sid: binding.initiating.sid,
         };
       });
 
@@ -2546,7 +2591,7 @@ ssoRoutes.get('/callback', async (c) => {
             userId: reauthUserId
           }
         });
-        return c.redirect(`/settings/profile?error=${outcome.error}`);
+        return c.redirect(`/settings/profile?ssoReauthError=${outcome.error}`);
       }
 
       const grantId = await mintStepUpGrant({
@@ -2557,7 +2602,22 @@ ssoRoutes.get('/callback', async (c) => {
         sid: outcome.sid,
       });
       if (!grantId) {
-        return c.redirect('/settings/profile?error=reauth_unavailable');
+        // A mint failure is an INFRASTRUCTURE outcome (Redis down, write
+        // rejected), not a user decision. Without a terminal audit row it is
+        // indistinguishable from the user abandoning at the IdP: the trail
+        // shows `sso.reauth.started` and then nothing at all. Every other
+        // terminal outcome on this road writes one; so does this.
+        console.error(`[sso] reauth grant mint failed for user ${reauthUserId} (provider ${provider.id})`);
+        writeRouteAudit(c, {
+          orgId: provider.orgId,
+          action: 'sso.reauth.rejected',
+          resourceType: 'sso_provider',
+          resourceId: provider.id,
+          resourceName: provider.name,
+          result: 'denied',
+          details: { mode: 'reauth', reason: 'grant_mint_failed', userId: reauthUserId, partnerId: provider.partnerId }
+        });
+        return c.redirect('/settings/profile?ssoReauthError=reauth_unavailable');
       }
 
       writeRouteAudit(c, {

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -31,10 +31,12 @@ import {
   mapUserAttributes,
   discoverOIDCConfig,
   assertSafeOidcEndpoint,
+  assertFreshIdpAuthentication,
   PROVIDER_PRESETS,
   type OIDCConfig,
   type EmailVerifiedClaim
 } from '../services/sso';
+import { mintStepUpGrant } from '../services/mfaStepUpGrant';
 import { createTokenPair, createSession, mintRefreshTokenFamily, bindRefreshJtiToFamily, getUserEpochs, getRefreshFamily, rateLimiter, getRedis } from '../services';
 import { writeRouteAudit } from '../services/auditEvents';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
@@ -589,7 +591,7 @@ async function revalidateSsoDefaultRole(params: {
     : { ok: true, roleId: role.id, orgPartnerId };
 }
 
-type SsoCallbackMode = 'login' | 'link';
+type SsoCallbackMode = 'login' | 'link' | 'reauth';
 
 /**
  * SR2-11: a pending SSO transaction is valid only against the provider
@@ -601,6 +603,10 @@ type SsoCallbackMode = 'login' | 'link';
  * provider may be linked). Neither was checked at the callback before this
  * change — a provider disabled inside the <=10-minute state TTL still completed
  * a full login or link.
+ *
+ * #4018: reauth mode shares LINK's rule — /reauth/start also admits a
+ * `testing` provider and refuses only `inactive` — so it deliberately falls
+ * outside the `mode === 'login'` branch below, which needs no change.
  *
  * A NULL providerVersion (a row written before the column existed) is a REJECT,
  * not a pass: those are exactly the unbound sessions this change invalidates.
@@ -644,11 +650,15 @@ type LinkRejectReason =
   | 'link_axis_membership_lost';
 
 /**
- * SR2-11b: re-check a pending LINK session against LIVE state before it is
- * allowed to bind an external identity to a Breeze account.
+ * SR2-11b: re-check a pending user-bound SSO session against LIVE state before
+ * it is allowed to act on behalf of that user — binding an external identity
+ * (link mode) or minting an enrollment step-up grant (#4018 reauth mode). Both
+ * modes need the IDENTICAL set of conditions, so they share one validator;
+ * `boundUserId` is whichever of link_user_id / reauth_user_id the session
+ * carries (the DB CHECK guarantees at most one is set).
  *
- * The session snapshotted {authEpoch, mfaEpoch, sid} at /link/start. Any of the
- * following since then must kill it:
+ * The session snapshotted {authEpoch, mfaEpoch, sid} at /link/start or
+ * /reauth/start. Any of the following since then must kill it:
  *   - the user was suspended/deleted            -> status / user_gone
  *   - password reset, email change, membership
  *     change, platform-privilege change         -> auth_epoch bump
@@ -662,9 +672,10 @@ type LinkRejectReason =
  * MUST be called inside withSystemDbAccessContext (/sso/callback is
  * unauthenticated; getRefreshFamily establishes its own system context).
  */
-async function validateLinkBinding(
+async function validateSessionBinding(
   session: typeof ssoSessions.$inferSelect,
   provider: typeof ssoProviders.$inferSelect,
+  boundUserId: string,
 ): Promise<{ ok: true; user: typeof users.$inferSelect } | { ok: false; reason: LinkRejectReason }> {
   if (
     session.initiatingAuthEpoch == null ||
@@ -677,7 +688,7 @@ async function validateLinkBinding(
   const [linkingUser] = await db
     .select()
     .from(users)
-    .where(eq(users.id, session.linkUserId!))
+    .where(eq(users.id, boundUserId))
     .limit(1);
   if (!linkingUser) return { ok: false, reason: 'link_user_gone' };
   if (linkingUser.status !== 'active') return { ok: false, reason: 'link_user_inactive' };
@@ -2240,7 +2251,8 @@ ssoRoutes.get('/callback', async (c) => {
   // mode, or whose snapshot no longer matches the provider's live generation.
   // Runs BEFORE any default-role/ceiling work below — a stale or disabled
   // transaction must never reach JIT logic at all.
-  const callbackMode: SsoCallbackMode = session.linkUserId ? 'link' : 'login';
+  const callbackMode: SsoCallbackMode =
+    session.reauthUserId ? 'reauth' : session.linkUserId ? 'link' : 'login';
 
   const generation = checkProviderGeneration(provider, session, callbackMode);
   if (!generation.ok) {
@@ -2440,6 +2452,120 @@ ssoRoutes.get('/callback', async (c) => {
       return c.redirect('/login?error=sso_no_subject');
     }
 
+    // #4018 reauth mode: an already-authenticated, PASSWORDLESS user proving
+    // identity through a fresh IdP round-trip so they can enroll a first MFA
+    // factor. Mints NO tokens, creates NO users, links NO identities — its only
+    // output is a single-use step-up grant.
+    if (session.reauthUserId) {
+      const reauthUserId = session.reauthUserId;
+
+      // The IdP must have ACTUALLY re-authenticated for THIS transaction.
+      // Bounded from the session's own created_at, not from now: an auth_time
+      // that predates the user's click is a cached session, however recent it
+      // looks. Fails closed on a missing auth_time.
+      const freshness = assertFreshIdpAuthentication(idClaims, session.createdAt.getTime());
+      if (!freshness.ok) {
+        writeRouteAudit(c, {
+          orgId: provider.orgId,
+          action: 'sso.reauth.rejected',
+          resourceType: 'sso_provider',
+          resourceId: provider.id,
+          resourceName: provider.name,
+          result: 'denied',
+          details: { mode: 'reauth', reason: freshness.reason, userId: reauthUserId }
+        });
+        clearStateCookie();
+        return c.redirect('/settings/profile?error=reauth_not_fresh');
+      }
+
+      // NOTE on the shape: every variant carries an explicit `ok` literal
+      // rather than relying on `'ok' in outcome`. TS normalizes a union of
+      // object literals by adding the missing members back as optional
+      // `undefined`, which makes an `in` check narrow NOTHING here — the
+      // success payload would silently degrade to `number | undefined` and the
+      // grant would be minted with undefined epochs.
+      const outcome = await withSystemDbAccessContext(async () => {
+        const binding = await validateSessionBinding(session, provider, reauthUserId);
+        if (!binding.ok) {
+          return { ok: false as const, error: 'session_invalid' as const, auditReason: binding.reason };
+        }
+
+        // STRICTER than link mode's email comparison: the asserted (provider,
+        // sub) must ALREADY be this user's identity. An IdP where users can
+        // change their own email would otherwise let one user re-auth as
+        // another by matching an address.
+        const [identity] = await db
+          .select({ userId: userSsoIdentities.userId })
+          .from(userSsoIdentities)
+          .where(and(
+            eq(userSsoIdentities.providerId, provider.id),
+            eq(userSsoIdentities.externalId, externalSub)
+          ))
+          .limit(1);
+        if (!identity || identity.userId !== reauthUserId) {
+          return { ok: false as const, error: 'identity_mismatch' as const };
+        }
+
+        // Belt-and-braces: the account must still be passwordless. A password
+        // set between /reauth/start and here means the ordinary step-up applies.
+        if (binding.user.passwordHash != null) {
+          return { ok: false as const, error: 'password_set' as const };
+        }
+
+        return {
+          ok: true as const,
+          authEpoch: session.initiatingAuthEpoch!,
+          mfaEpoch: session.initiatingMfaEpoch!,
+          sid: session.initiatingSessionId!,
+        };
+      });
+
+      clearStateCookie();
+
+      if (!outcome.ok) {
+        writeRouteAudit(c, {
+          orgId: provider.orgId,
+          action: 'sso.reauth.rejected',
+          resourceType: 'sso_provider',
+          resourceId: provider.id,
+          resourceName: provider.name,
+          result: 'denied',
+          details: {
+            // The PUBLIC code stays coarse; the precise binding reason is
+            // audit-only, exactly as in link mode above.
+            mode: 'reauth',
+            reason: outcome.auditReason ?? outcome.error,
+            userId: reauthUserId
+          }
+        });
+        return c.redirect(`/settings/profile?error=${outcome.error}`);
+      }
+
+      const grantId = await mintStepUpGrant({
+        userId: reauthUserId,
+        operation: 'enroll_first_factor',
+        authEpoch: outcome.authEpoch,
+        mfaEpoch: outcome.mfaEpoch,
+        sid: outcome.sid,
+      });
+      if (!grantId) {
+        return c.redirect('/settings/profile?error=reauth_unavailable');
+      }
+
+      writeRouteAudit(c, {
+        orgId: provider.orgId,
+        action: 'sso.reauth.completed',
+        resourceType: 'sso_provider',
+        resourceId: provider.id,
+        resourceName: provider.name,
+        details: { partnerId: provider.partnerId, userId: reauthUserId }
+      });
+
+      // Fragment, not query: never sent to the server, never in an access log.
+      // Same channel the login path already uses for #ssoCode.
+      return c.redirect(`/settings/profile#ssoReauthGrant=${grantId}`);
+    }
+
     // ── Link mode (#2183 Connect SSO): this round-trip belongs to an
     // already-authenticated user connecting their identity — never a login.
     // Placed AFTER the full id_token signature/nonce verification, the atomic
@@ -2449,7 +2575,7 @@ ssoRoutes.get('/callback', async (c) => {
     if (session.linkUserId) {
       const outcome = await withSystemDbAccessContext(async () => {
         // SR2-11b: live re-check of the binding captured at /link/start.
-        const binding = await validateLinkBinding(session, provider);
+        const binding = await validateSessionBinding(session, provider, session.linkUserId!);
         if (!binding.ok) {
           return { error: 'session_invalid' as const, auditReason: binding.reason };
         }

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -1791,6 +1791,130 @@ ssoRoutes.post(
   }
 );
 
+// Start a REAUTH-mode IdP round-trip (#4018).
+//
+// Deliberately NOT behind requireMfa(): this route exists precisely because a
+// passwordless SSO account cannot satisfy requireMfa() yet — gating it the way
+// /link/start is gated would reproduce the deadlock it fixes.
+//
+// The provider is resolved from the caller's OWN linked identity, never from a
+// request parameter, so this can only ever re-authenticate against an IdP the
+// user already has a binding with.
+ssoRoutes.post('/reauth/start', authMiddleware, async (c) => {
+  const auth = c.get('auth') as AuthContext;
+
+  const redis = getRedis();
+  const rateCheck = await rateLimiter(redis, `sso:reauth:${auth.user.id}`, 5, 15 * 60);
+  if (!rateCheck.allowed) {
+    return c.json({
+      error: 'Too many attempts. Please try again later.',
+      retryAfter: Math.ceil((rateCheck.resetAt.getTime() - Date.now()) / 1000)
+    }, 429);
+  }
+
+  // An account WITH a password uses the existing password step-up. Allowing
+  // both would make this a weaker parallel road to factor enrollment.
+  const [userRow] = await db
+    .select({ passwordHash: users.passwordHash })
+    .from(users)
+    .where(eq(users.id, auth.user.id))
+    .limit(1);
+  if (!userRow) return c.json({ error: 'User not found' }, 404);
+  if (userRow.passwordHash != null) {
+    return c.json({ error: 'Account has a password' }, 400);
+  }
+
+  const [identity] = await db
+    .select({ providerId: userSsoIdentities.providerId })
+    .from(userSsoIdentities)
+    .where(eq(userSsoIdentities.userId, auth.user.id))
+    .orderBy(userSsoIdentities.createdAt, userSsoIdentities.id)
+    .limit(1);
+  if (!identity) {
+    return c.json({ error: 'No linked SSO identity' }, 404);
+  }
+
+  const [provider] = await db
+    .select()
+    .from(ssoProviders)
+    .where(eq(ssoProviders.id, identity.providerId))
+    .limit(1);
+  if (!provider || provider.status === 'inactive') {
+    return c.json({ error: 'Provider not found' }, 404);
+  }
+  if (provider.type !== 'oidc') {
+    return c.json({ error: 'Only OIDC re-authentication is currently supported' }, 400);
+  }
+
+  let config: OIDCConfig;
+  try {
+    config = getOIDCConfig(provider);
+  } catch (err) {
+    console.warn(`[sso] provider ${provider.id} has an invalid configuration:`, err);
+    return c.json({ error: 'SSO provider configuration is invalid' }, 400);
+  }
+
+  const initiatorEpochs = await getUserEpochs(auth.user.id);
+  const initiatingSid = auth.token?.sid;
+  if (!initiatorEpochs || !initiatingSid) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+
+  const pkce = generatePKCEChallenge();
+  const state = generateState();
+  const nonce = generateNonce();
+
+  // sso_sessions is system-scope-only under RLS: this insert must not run in
+  // the authenticated request's org/partner-scoped context. Mirrors
+  // /link/start's insert (see the comment there for the full rationale).
+  await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () =>
+      db.insert(ssoSessions).values({
+        providerId: provider.id,
+        state,
+        nonce,
+        codeVerifier: pkce.codeVerifier,
+        redirectUrl: '/settings/profile',
+        reauthUserId: auth.user.id,
+        providerVersion: provider.configVersion,
+        initiatingAuthEpoch: initiatorEpochs.authEpoch,
+        initiatingMfaEpoch: initiatorEpochs.mfaEpoch,
+        initiatingSessionId: initiatingSid,
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000)
+      })
+    )
+  );
+
+  const authUrl = buildAuthorizationUrl({
+    config,
+    state,
+    nonce,
+    redirectUri: buildSsoCallbackUri(),
+    pkce,
+    // Force a real re-authentication. max_age=0 is the load-bearing half:
+    // prompt=login alone is advisory and several IdPs honour it inconsistently.
+    prompt: 'login',
+    maxAge: 0,
+  });
+
+  const stateCookie = buildSsoStateCookie(state);
+  if (!stateCookie) {
+    return c.json({ error: 'SSO login binding secret is not configured on this instance' }, 500);
+  }
+  c.header('Set-Cookie', stateCookie, { append: true });
+
+  writeRouteAudit(c, {
+    orgId: provider.orgId,
+    action: 'sso.reauth.started',
+    resourceType: 'sso_provider',
+    resourceId: provider.id,
+    resourceName: provider.name,
+    details: { partnerId: provider.partnerId, userId: auth.user.id }
+  });
+
+  return c.json({ authUrl });
+});
+
 // ============================================
 // SSO Login Flow (Public)
 // ============================================

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -32,6 +32,7 @@ import {
   discoverOIDCConfig,
   assertSafeOidcEndpoint,
   assertFreshIdpAuthentication,
+  utcMsFromOffsetlessTimestamp,
   PROVIDER_PRESETS,
   type OIDCConfig,
   type EmailVerifiedClaim
@@ -2463,7 +2464,14 @@ ssoRoutes.get('/callback', async (c) => {
       // Bounded from the session's own created_at, not from now: an auth_time
       // that predates the user's click is a cached session, however recent it
       // looks. Fails closed on a missing auth_time.
-      const freshness = assertFreshIdpAuthentication(idClaims, session.createdAt.getTime());
+      //
+      // created_at is `timestamp without time zone`, so a bare .getTime() is
+      // off by the HOST's UTC offset and cannot be compared to the id_token's
+      // auth_time epoch — see utcMsFromOffsetlessTimestamp.
+      const freshness = assertFreshIdpAuthentication(
+        idClaims,
+        utcMsFromOffsetlessTimestamp(session.createdAt),
+      );
       if (!freshness.ok) {
         writeRouteAudit(c, {
           orgId: provider.orgId,

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -602,6 +602,61 @@ describe('user routes', () => {
       expect(body.isPlatformAdmin).toBe(true);
     });
 
+    // #4018: this endpoint is what populates the WEB AUTH STORE's user object
+    // (stores/auth.ts completeBootstrapLogin + fetchAndApplyPreferences), so
+    // `hasPassword` here is the ONLY thing that makes
+    // `useAuthStore(s => s.user?.hasPassword) === false` reachable in
+    // production. Without it the SSO branches in the UI are dead code that
+    // still passes a unit test which injects the store value directly.
+    const meRow = (overrides: Record<string, unknown> = {}) => ({
+      id: 'user-123',
+      email: 'admin@example.com',
+      name: 'Admin',
+      avatarUrl: null,
+      status: 'active',
+      mfaEnabled: false,
+      isPlatformAdmin: false,
+      createdAt: new Date(),
+      lastLoginAt: new Date(),
+      setupCompletedAt: new Date(),
+      passwordChangedAt: new Date(),
+      preferences: {},
+      ...overrides,
+    });
+
+    const mockMeRow = (row: Record<string, unknown>) => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row])
+          })
+        })
+      } as any);
+    };
+
+    it('reports hasPassword false for an SSO-provisioned (passwordless) user', async () => {
+      mockMeRow(meRow({ passwordHash: null }));
+
+      const res = await app.request('/users/me', {
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ hasPassword: false });
+    });
+
+    it('reports hasPassword true for a password user and never leaks the hash', async () => {
+      mockMeRow(meRow({ passwordHash: '$argon2id$v=19$m=65536$abc' }));
+
+      const res = await app.request('/users/me', {
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.hasPassword).toBe(true);
+      expect(body).not.toHaveProperty('passwordHash');
+      expect(JSON.stringify(body)).not.toContain('argon2id');
+    });
+
     // The web app hides billing nav and action buttons off this list. If /me
     // stops surfacing the user's grants, gated controls would render for users
     // who lack the permission (server still 403s, but it's a UX regression).

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -332,7 +332,11 @@ userRoutes.get('/me', async (c) => {
       lastLoginAt: users.lastLoginAt,
       setupCompletedAt: users.setupCompletedAt,
       passwordChangedAt: users.passwordChangedAt,
-      preferences: users.preferences
+      preferences: users.preferences,
+      // #4018: selected ONLY to derive the `hasPassword` boolean below. It is
+      // destructured OUT of the spread that builds this response, so the hash
+      // itself is never serialized — asserted by users.test.ts.
+      passwordHash: users.passwordHash
     })
     .from(users)
     .where(eq(users.id, auth.user.id))
@@ -341,6 +345,10 @@ userRoutes.get('/me', async (c) => {
   if (!user) {
     return c.json({ error: 'User not found' }, 404);
   }
+
+  // Never spread `user` directly into the response from here on: it carries the
+  // password hash. `userWithoutSecrets` is the only safe shape.
+  const { passwordHash, ...userWithoutSecrets } = user;
 
   const requiresSetup = userRequiresSetup(user);
 
@@ -389,7 +397,12 @@ userRoutes.get('/me', async (c) => {
   });
 
   return c.json({
-    ...user,
+    ...userWithoutSecrets,
+    // #4018: whether a password step-up is even possible for this account.
+    // False for an SSO-provisioned (JIT) user, which has no password — the web
+    // auth store carries this through so UI that today says "set up MFA and
+    // sign in again" can offer the IdP road instead of a dead end.
+    hasPassword: passwordHash != null,
     partnerId: auth.partnerId,
     orgId: auth.orgId,
     scope: auth.scope,

--- a/apps/api/src/services/mfaStepUpGrant.ts
+++ b/apps/api/src/services/mfaStepUpGrant.ts
@@ -6,12 +6,13 @@ import { getRedis } from './redis';
  * an ALREADY-PROTECTED account, OR registering an authenticator device as an
  * approver.
  *
- * Minted by THREE sources: (1) `POST /auth/mfa/step-up`, after the caller
+ * Minted by FOUR sources: (1) `POST /auth/mfa/step-up`, after the caller
  * proves an existing factor (TOTP/SMS/passkey); (2)
  * `POST /authenticator/register-grant`, the password-proof fallback for
  * accounts with no stronger factor; (3) `mintLoginRegisterGrant`
  * (`routes/auth/helpers.ts`), a best-effort login-time mint for mobile
- * clients only.
+ * clients only; (4) the SSO re-auth callback (`GET /sso/callback`, reauth
+ * mode), the passwordless equivalent of (2) — see #4018.
  *
  * Grants from (1) are presented back to a factor-addition endpoint
  * (`/mfa/enable`, setup-confirm, `/mfa/sms/enable`, `/passkeys/register/*`) as
@@ -30,7 +31,7 @@ import { getRedis } from './redis';
  */
 /** Operations a step-up grant can authorize. A grant minted for one operation
  * can never validate/consume for another (bindsMatch checks equality). */
-export type StepUpOperation = 'add_factor' | 'register_approver_device';
+export type StepUpOperation = 'add_factor' | 'register_approver_device' | 'enroll_first_factor';
 
 export interface StepUpGrant {
   id: string;

--- a/apps/api/src/services/mfaStepUpGrant.ts
+++ b/apps/api/src/services/mfaStepUpGrant.ts
@@ -64,12 +64,20 @@ function bindsMatch(record: GrantBind, bind: GrantBind): boolean {
  */
 export async function mintStepUpGrant(bind: GrantBind): Promise<string | null> {
   const redis = getRedis();
-  if (!redis) return null;
+  if (!redis) {
+    console.error(`[mfaStepUpGrant] mint declined for user ${bind.userId} (${bind.operation}): Redis unavailable`);
+    return null;
+  }
   try {
     const id = randomUUID();
     await redis.setex(key(id), TTL_SECONDS, JSON.stringify(bind));
     return id;
-  } catch {
+  } catch (err) {
+    // Still fails closed (null), but no longer silently: a bare `catch {}` here
+    // made a Redis outage indistinguishable from a user abandoning the flow —
+    // the caller redirects with an opaque code and the cause never reaches a
+    // log. Callers add their own audit row; this is the technical cause.
+    console.error(`[mfaStepUpGrant] mint failed for user ${bind.userId} (${bind.operation}):`, err);
     return null;
   }
 }

--- a/apps/api/src/services/sso.test.ts
+++ b/apps/api/src/services/sso.test.ts
@@ -632,6 +632,39 @@ describe('buildAuthorizationUrl re-auth params', () => {
   });
 });
 
+/**
+ * The Date postgres.js hands back for a `timestamp without time zone` column on
+ * a host whose UTC offset is `offsetMinutes`, using Date's own sign convention
+ * (positive = WEST of UTC, e.g. 360 for America/Denver in summer; negative =
+ * east, e.g. -120 for Europe/Berlin in summer).
+ *
+ * This exists because {@link pgOffsetlessTimestamp} — faithful as it is — is
+ * WORTHLESS as a regression guard on a UTC runner, and CI runners are UTC. With
+ * offset 0, `utcMsFromOffsetlessTimestamp(d)` and `d.getTime()` are the same
+ * number, so every arithmetic assertion about the conversion passes whether or
+ * not the conversion exists. Overriding `getTimezoneOffset` simulates a non-UTC
+ * host regardless of the real one, so these tests have identical teeth under
+ * TZ=UTC and TZ=America/Denver.
+ */
+function offsetlessTimestampFromHostAt(trueUtcMs: number, offsetMinutes: number): Date {
+  // Postgres emits the UTC wall clock; a host `offsetMinutes` west of UTC reads
+  // that wall clock as a local time that is `offsetMinutes` later in real terms.
+  const naive = new Date(trueUtcMs + offsetMinutes * 60_000);
+  Object.defineProperty(naive, 'getTimezoneOffset', {
+    value: () => offsetMinutes,
+    configurable: true,
+  });
+  return naive;
+}
+
+const SIMULATED_HOSTS = [
+  { label: 'UTC', offsetMinutes: 0 },
+  { label: 'America/Denver (west of UTC, MDT)', offsetMinutes: 360 },
+  { label: 'America/Los_Angeles (west of UTC, PDT)', offsetMinutes: 420 },
+  { label: 'Europe/Berlin (east of UTC, CEST)', offsetMinutes: -120 },
+  { label: 'Asia/Kathmandu (east of UTC, :45 offset)', offsetMinutes: -345 },
+];
+
 describe('assertFreshIdpAuthentication', () => {
   const NOW = 1_800_000_000_000;        // fixed clock, ms
   const STARTED = NOW - 30_000;         // transaction began 30s ago
@@ -704,10 +737,28 @@ describe('assertFreshIdpAuthentication', () => {
     // in the FUTURE and every attempt is stale (feature dead on arrival); east
     // of UTC it slides into the PAST and a cached IdP session that old is
     // accepted as fresh — a real weakening of the only control this feature has.
-    it('is not skewed by the host timezone the way a bare .getTime() is', () => {
-      const offsetMs = sessionStartedAt.getTimezoneOffset() * 60_000;
-      expect(utcMsFromOffsetlessTimestamp(sessionStartedAt)).toBe(STARTED);
-      expect(sessionStartedAt.getTime()).toBe(STARTED + offsetMs);
+    //
+    // Written against SIMULATED host offsets, not the runner's own: on a UTC
+    // runner the real offset is 0 and this whole contract collapses to `x === x`.
+    it('a bare .getTime() bound is dead on arrival west of UTC and permissive east of it', () => {
+      const during = Math.floor(STARTED / 1000) + 5;
+      const cachedAnHourBeforeTheClick = Math.floor(STARTED / 1000) - 3600;
+
+      // West (UTC-6): naive bound is 6h in the future, so a genuine
+      // during-the-round-trip auth_time reads stale — 100% of attempts fail.
+      const west = offsetlessTimestampFromHostAt(STARTED, 360);
+      expect(assertFreshIdpAuthentication({ auth_time: during }, west.getTime(), NOW))
+        .toEqual({ ok: false, reason: 'auth_time_stale' });
+      expect(assertFreshIdpAuthentication({ auth_time: during }, utcMsFromOffsetlessTimestamp(west), NOW))
+        .toEqual({ ok: true });
+
+      // East (UTC+2): naive bound is 2h in the past, so an IdP session cached an
+      // hour BEFORE the click is waved through as a fresh re-authentication.
+      const east = offsetlessTimestampFromHostAt(STARTED, -120);
+      expect(assertFreshIdpAuthentication({ auth_time: cachedAnHourBeforeTheClick }, east.getTime(), NOW))
+        .toEqual({ ok: true });
+      expect(assertFreshIdpAuthentication({ auth_time: cachedAnHourBeforeTheClick }, utcMsFromOffsetlessTimestamp(east), NOW))
+        .toEqual({ ok: false, reason: 'auth_time_stale' });
     });
   });
 });
@@ -718,13 +769,20 @@ describe('utcMsFromOffsetlessTimestamp', () => {
     expect(utcMsFromOffsetlessTimestamp(pgOffsetlessTimestamp(instant))).toBe(instant);
   });
 
-  it('is a no-op under UTC, which is why hosted production never saw this', () => {
-    const instant = Date.UTC(2026, 7, 25, 18, 34, 15, 123);
-    const fromDb = pgOffsetlessTimestamp(instant);
-    if (fromDb.getTimezoneOffset() === 0) {
-      expect(utcMsFromOffsetlessTimestamp(fromDb)).toBe(fromDb.getTime());
-    } else {
-      expect(utcMsFromOffsetlessTimestamp(fromDb)).not.toBe(fromDb.getTime());
+  // The row that actually guards the conversion. The UTC row documents WHY this
+  // defect reached production green (the conversion is a no-op there); every
+  // other row fails if the offset subtraction is removed, so the suite has teeth
+  // on a UTC CI runner and on a US developer's machine alike.
+  it.each(SIMULATED_HOSTS)(
+    'recovers the true epoch on a host at $label',
+    ({ offsetMinutes }) => {
+      const instant = Date.UTC(2026, 7, 25, 18, 34, 15, 123);
+      const fromDb = offsetlessTimestampFromHostAt(instant, offsetMinutes);
+
+      expect(utcMsFromOffsetlessTimestamp(fromDb)).toBe(instant);
+      // And the naive read really is wrong by exactly the host offset — the
+      // reason the conversion has to exist at all.
+      expect(fromDb.getTime()).toBe(instant + offsetMinutes * 60_000);
     }
-  });
+  );
 });

--- a/apps/api/src/services/sso.test.ts
+++ b/apps/api/src/services/sso.test.ts
@@ -6,6 +6,8 @@ import {
   assertEmailVerified,
   readEmailVerifiedClaim,
   idpAssertedMfa,
+  buildAuthorizationUrl,
+  assertFreshIdpAuthentication,
   discoverOIDCConfig,
   isInternalUrl,
   assertSafeOidcEndpoint,
@@ -594,5 +596,77 @@ describe('SSRF-safe OIDC transport (SR2-13/14)', () => {
 
     const config: OIDCConfig = { ...baseConfig, jwksUrl: 'https://idp.example.com/jwks' };
     await expect(verifyIdTokenSignature(rs256Token(), config, 'nonce')).rejects.toThrow(/safeFetch/);
+  });
+});
+
+describe('buildAuthorizationUrl re-auth params', () => {
+  const CONFIG = {
+    issuer: 'https://idp.example.com',
+    authorizationUrl: 'https://idp.example.com/authorize',
+    tokenUrl: 'https://idp.example.com/token',
+    jwksUrl: 'https://idp.example.com/jwks',
+    clientId: 'client-123',
+    clientSecret: 'secret',
+    scopes: 'openid email profile',
+  } as any;
+
+  it('omits prompt and max_age when not requested', () => {
+    const url = new URL(buildAuthorizationUrl({
+      config: CONFIG, state: 's', nonce: 'n', redirectUri: 'https://app/cb',
+    }));
+    expect(url.searchParams.has('prompt')).toBe(false);
+    expect(url.searchParams.has('max_age')).toBe(false);
+  });
+
+  it('sets prompt=login and max_age=0 when requested', () => {
+    const url = new URL(buildAuthorizationUrl({
+      config: CONFIG, state: 's', nonce: 'n', redirectUri: 'https://app/cb',
+      prompt: 'login', maxAge: 0,
+    }));
+    expect(url.searchParams.get('prompt')).toBe('login');
+    // max_age=0 must survive: a falsy-check bug would drop it and silently
+    // turn a forced re-auth into an ordinary (cache-satisfiable) login.
+    expect(url.searchParams.get('max_age')).toBe('0');
+  });
+});
+
+describe('assertFreshIdpAuthentication', () => {
+  const NOW = 1_800_000_000_000;        // fixed clock, ms
+  const STARTED = NOW - 30_000;         // transaction began 30s ago
+
+  it('rejects a missing auth_time (IdP ignored prompt=login)', () => {
+    expect(assertFreshIdpAuthentication({}, STARTED, NOW))
+      .toEqual({ ok: false, reason: 'auth_time_missing' });
+  });
+
+  it('rejects an auth_time from BEFORE the transaction started', () => {
+    // The cached-session replay this check exists for: the IdP returns a
+    // perfectly recent auth_time that nonetheless predates the user's click.
+    const beforeStart = Math.floor(STARTED / 1000) - 121;
+    expect(assertFreshIdpAuthentication({ auth_time: beforeStart }, STARTED, NOW))
+      .toEqual({ ok: false, reason: 'auth_time_stale' });
+  });
+
+  it('rejects an auth_time in the future beyond clock skew', () => {
+    const future = Math.floor(NOW / 1000) + 121;
+    expect(assertFreshIdpAuthentication({ auth_time: future }, STARTED, NOW))
+      .toEqual({ ok: false, reason: 'auth_time_future' });
+  });
+
+  it('accepts an auth_time from during the round trip', () => {
+    const during = Math.floor(STARTED / 1000) + 5;
+    expect(assertFreshIdpAuthentication({ auth_time: during }, STARTED, NOW))
+      .toEqual({ ok: true });
+  });
+
+  it('accepts an auth_time slightly before the start, inside skew tolerance', () => {
+    const justBefore = Math.floor(STARTED / 1000) - 30;
+    expect(assertFreshIdpAuthentication({ auth_time: justBefore }, STARTED, NOW))
+      .toEqual({ ok: true });
+  });
+
+  it('never accepts iat as a substitute for auth_time', () => {
+    expect(assertFreshIdpAuthentication({ iat: Math.floor(NOW / 1000) } as any, STARTED, NOW))
+      .toEqual({ ok: false, reason: 'auth_time_missing' });
   });
 });

--- a/apps/api/src/services/sso.test.ts
+++ b/apps/api/src/services/sso.test.ts
@@ -8,6 +8,7 @@ import {
   idpAssertedMfa,
   buildAuthorizationUrl,
   assertFreshIdpAuthentication,
+  utcMsFromOffsetlessTimestamp,
   discoverOIDCConfig,
   isInternalUrl,
   assertSafeOidcEndpoint,
@@ -24,6 +25,7 @@ import {
 import { createRemoteJWKSet, customFetch } from 'jose';
 import { safeFetch, SsrfBlockedError } from './urlSafety';
 import { assertOutsideHeldDbContext } from '../db';
+import { pgOffsetlessTimestamp } from '../testUtils/pgOffsetlessTimestamp';
 
 // SR2-13/14: mock the outbound-HTTP + jose transport so the SSRF-safe wiring
 // can be asserted without a network. `safeFetch` DEFAULTS to the real
@@ -668,5 +670,61 @@ describe('assertFreshIdpAuthentication', () => {
   it('never accepts iat as a substitute for auth_time', () => {
     expect(assertFreshIdpAuthentication({ iat: Math.floor(NOW / 1000) } as any, STARTED, NOW))
       .toEqual({ ok: false, reason: 'auth_time_missing' });
+  });
+
+  // The bound above is only meaningful if `startedAtMs` is a TRUE epoch. Every
+  // test in this describe hands one in as a plain number, which is exactly how
+  // the timezone defect below stayed invisible: the route derives that number
+  // from a `timestamp without time zone` column, and these tests never exercise
+  // that derivation.
+  describe('the startedAtMs bound, as the route actually derives it', () => {
+    // sso_sessions.created_at as postgres.js really returns it.
+    const sessionStartedAt = pgOffsetlessTimestamp(STARTED);
+
+    it('accepts an auth_time from during the round trip, in ANY host timezone', () => {
+      const during = Math.floor(STARTED / 1000) + 5;
+      expect(assertFreshIdpAuthentication(
+        { auth_time: during },
+        utcMsFromOffsetlessTimestamp(sessionStartedAt),
+        NOW,
+      )).toEqual({ ok: true });
+    });
+
+    it('still rejects a cached-session auth_time from before the click, in ANY host timezone', () => {
+      const beforeStart = Math.floor(STARTED / 1000) - 121;
+      expect(assertFreshIdpAuthentication(
+        { auth_time: beforeStart },
+        utcMsFromOffsetlessTimestamp(sessionStartedAt),
+        NOW,
+      )).toEqual({ ok: false, reason: 'auth_time_stale' });
+    });
+
+    // Pins the two failure modes a bare `.getTime()` produces, so a revert
+    // cannot pass by loosening one direction. West of UTC the naive bound lands
+    // in the FUTURE and every attempt is stale (feature dead on arrival); east
+    // of UTC it slides into the PAST and a cached IdP session that old is
+    // accepted as fresh — a real weakening of the only control this feature has.
+    it('is not skewed by the host timezone the way a bare .getTime() is', () => {
+      const offsetMs = sessionStartedAt.getTimezoneOffset() * 60_000;
+      expect(utcMsFromOffsetlessTimestamp(sessionStartedAt)).toBe(STARTED);
+      expect(sessionStartedAt.getTime()).toBe(STARTED + offsetMs);
+    });
+  });
+});
+
+describe('utcMsFromOffsetlessTimestamp', () => {
+  it('round-trips an offsetless DB timestamp back to its true epoch', () => {
+    const instant = Date.UTC(2026, 7, 25, 18, 34, 15, 123);
+    expect(utcMsFromOffsetlessTimestamp(pgOffsetlessTimestamp(instant))).toBe(instant);
+  });
+
+  it('is a no-op under UTC, which is why hosted production never saw this', () => {
+    const instant = Date.UTC(2026, 7, 25, 18, 34, 15, 123);
+    const fromDb = pgOffsetlessTimestamp(instant);
+    if (fromDb.getTimezoneOffset() === 0) {
+      expect(utcMsFromOffsetlessTimestamp(fromDb)).toBe(fromDb.getTime());
+    } else {
+      expect(utcMsFromOffsetlessTimestamp(fromDb)).not.toBe(fromDb.getTime());
+    }
   });
 });

--- a/apps/api/src/services/sso.ts
+++ b/apps/api/src/services/sso.ts
@@ -276,6 +276,39 @@ export function idpAssertedMfa(claims: Pick<IDTokenClaims, 'amr'>): boolean {
 const AUTH_TIME_SKEW_SECONDS = 120;
 
 /**
+ * Convert a Date that postgres.js produced from a `timestamp without time
+ * zone` column into a true UTC epoch in milliseconds.
+ *
+ * postgres.js parses OIDs 1082/1114/1184 with a bare `new Date(x)`
+ * (postgres/src/types.js). For an offsetless column (1114) the wire value is
+ * `2026-08-25 18:34:15.123` — no zone marker — and V8 reads an offsetless
+ * date-time as LOCAL time. So on a host running America/Denver the resulting
+ * Date sits SIX HOURS from the instant the row actually records. Drizzle does
+ * have a UTC-correct path for exactly this (`value + '+0000'`), but it only
+ * fires when the driver hands it a string; postgres.js has already produced a
+ * Date by then, so the value passes straight through unconverted.
+ *
+ * Everywhere else in this codebase that is invisible, because DB-derived
+ * timestamps are only ever compared against other DB-derived timestamps and
+ * the offset cancels on both sides. It stops being invisible the moment one is
+ * compared against an epoch that originated OUTSIDE the database — an OIDC
+ * `auth_time`, say — which is what `assertFreshIdpAuthentication` does below.
+ * Under UTC (every container, hence all hosted production) the offset is zero
+ * and the defect is dormant; a US host then fails 100% closed, and an EU host
+ * silently WIDENS the freshness window by its offset.
+ *
+ * PRECONDITION: the column holds a UTC wall clock. That is true here because
+ * the row is written by `now()` against a Postgres whose TimeZone is UTC, and
+ * any Date the API writes is serialized by Drizzle as `toISOString()`.
+ *
+ * Do NOT use this on a `timestamptz` (1184) column: postgres.js resolves those
+ * to the correct instant already, and this would corrupt them.
+ */
+export function utcMsFromOffsetlessTimestamp(value: Date): number {
+  return value.getTime() - value.getTimezoneOffset() * 60_000;
+}
+
+/**
  * Verify the IdP actually re-authenticated the user for THIS transaction.
  *
  * Two independent bounds, both required:

--- a/apps/api/src/services/sso.ts
+++ b/apps/api/src/services/sso.ts
@@ -89,10 +89,14 @@ export interface AuthorizationUrlParams {
   nonce: string;
   redirectUri: string;
   pkce?: PKCEChallenge;
+  /** OIDC `prompt`. Pass 'login' to force the IdP to re-authenticate. */
+  prompt?: string;
+  /** OIDC `max_age` in seconds. 0 demands a fresh authentication. */
+  maxAge?: number;
 }
 
 export function buildAuthorizationUrl(params: AuthorizationUrlParams): string {
-  const { config, state, nonce, redirectUri, pkce } = params;
+  const { config, state, nonce, redirectUri, pkce, prompt, maxAge } = params;
 
   const url = new URL(config.authorizationUrl);
   url.searchParams.set('client_id', config.clientId);
@@ -105,6 +109,15 @@ export function buildAuthorizationUrl(params: AuthorizationUrlParams): string {
   if (pkce) {
     url.searchParams.set('code_challenge', pkce.codeChallenge);
     url.searchParams.set('code_challenge_method', pkce.codeChallengeMethod);
+  }
+
+  if (prompt) {
+    url.searchParams.set('prompt', prompt);
+  }
+  // `!= null`, NOT a truthy check: max_age=0 is the value that actually forces
+  // a re-authentication, and `if (maxAge)` would silently drop it.
+  if (maxAge != null) {
+    url.searchParams.set('max_age', String(maxAge));
   }
 
   return url.toString();
@@ -242,6 +255,9 @@ export interface IDTokenClaims {
   // authentication methods the IdP used; `mfa` means multi-factor was performed.
   amr?: string[];
   acr?: string;
+  /** OIDC Core §2: seconds since epoch of the END-USER's authentication.
+   * Required in the id_token whenever the request carried `max_age`. */
+  auth_time?: number;
   [key: string]: unknown;
 }
 
@@ -254,6 +270,46 @@ export interface IDTokenClaims {
  */
 export function idpAssertedMfa(claims: Pick<IDTokenClaims, 'amr'>): boolean {
   return Array.isArray(claims.amr) && claims.amr.includes('mfa');
+}
+
+/** Tolerance for an IdP clock running ahead of ours. */
+const AUTH_TIME_SKEW_SECONDS = 120;
+
+/**
+ * Verify the IdP actually re-authenticated the user for THIS transaction.
+ *
+ * Two independent bounds, both required:
+ *
+ *  - `auth_time` must EXIST. OIDC Core requires the claim whenever the
+ *    authorization request carried `max_age`, but real IdPs vary: some ignore
+ *    `prompt=login` and replay a cached session, and one that does so while
+ *    omitting `auth_time` would otherwise mint an enrollment grant off a
+ *    months-old browser session. Absent claim === no proof of freshness.
+ *  - `auth_time` must be at or after `startedAtMs` (the sso_sessions row's
+ *    created_at), minus skew. A window measured from NOW would happily accept
+ *    an authentication that predates the user's click — precisely the cached
+ *    session this is meant to reject.
+ *
+ * `iat` is never a substitute: a fresh token can be minted from an old login.
+ */
+export function assertFreshIdpAuthentication(
+  claims: Pick<IDTokenClaims, 'auth_time'>,
+  startedAtMs: number,
+  nowMs: number = Date.now(),
+): { ok: true } | { ok: false; reason: 'auth_time_missing' | 'auth_time_stale' | 'auth_time_future' } {
+  const authTime = claims.auth_time;
+  if (typeof authTime !== 'number' || !Number.isFinite(authTime)) {
+    return { ok: false, reason: 'auth_time_missing' };
+  }
+  const nowSeconds = Math.floor(nowMs / 1000);
+  const startedAtSeconds = Math.floor(startedAtMs / 1000);
+  if (authTime > nowSeconds + AUTH_TIME_SKEW_SECONDS) {
+    return { ok: false, reason: 'auth_time_future' };
+  }
+  if (authTime < startedAtSeconds - AUTH_TIME_SKEW_SECONDS) {
+    return { ok: false, reason: 'auth_time_stale' };
+  }
+  return { ok: true };
 }
 
 export function decodeIdToken(idToken: string): IDTokenClaims {

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -432,8 +432,8 @@ const ASSOCIATED_SYSTEM_SCOPED_TABLES: ReadonlyArray<{
          OR user_id IN (SELECT id FROM users WHERE org_id = ${orgId})
     `,
   },
-  // sso_sessions.link_user_id already cascades on user delete; the provider
-  // FK does not.
+  // sso_sessions.link_user_id and .reauth_user_id both cascade on user delete;
+  // the provider FK does not — which is what this provider-keyed clear is for.
   {
     table: 'sso_sessions',
     clearSql: (orgId) => sql`

--- a/apps/api/src/testUtils/pgOffsetlessTimestamp.test.ts
+++ b/apps/api/src/testUtils/pgOffsetlessTimestamp.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { pgOffsetlessTimestamp } from './pgOffsetlessTimestamp';
+
+/**
+ * Guards the SIMULATION itself. If this helper stopped reproducing the driver's
+ * behaviour, every timezone test built on it would go quietly vacuous, so the
+ * two load-bearing properties are asserted directly rather than round-tripped
+ * through the function under test (which would be circular).
+ */
+describe('pgOffsetlessTimestamp', () => {
+  const INSTANT = Date.UTC(2026, 7, 25, 18, 34, 15, 123);
+
+  it('reproduces the exact wire format Postgres emits for an offsetless column', () => {
+    // Reconstruct the string the helper parsed, in the host's own zone: it must
+    // be the UTC wall clock of the instant, with no zone marker.
+    const d = pgOffsetlessTimestamp(INSTANT);
+    const pad = (n: number, w = 2) => String(n).padStart(w, '0');
+    const wire =
+      `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+      `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`;
+
+    expect(wire).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$/);
+    expect(wire).toBe('2026-08-25 18:34:15.123');
+  });
+
+  it('carries the UTC wall clock in LOCAL fields, which is the whole defect', () => {
+    const d = pgOffsetlessTimestamp(INSTANT);
+    // Local fields read back as the UTC wall clock...
+    expect(d.getHours()).toBe(18);
+    // ...so the epoch is wrong by exactly the host offset. Under UTC that is
+    // zero, which is precisely why CI cannot see this class of bug.
+    expect(d.getTime() - INSTANT).toBe(d.getTimezoneOffset() * 60_000);
+  });
+});

--- a/apps/api/src/testUtils/pgOffsetlessTimestamp.ts
+++ b/apps/api/src/testUtils/pgOffsetlessTimestamp.ts
@@ -1,0 +1,34 @@
+/**
+ * Build the Date that postgres.js ACTUALLY hands back for a `timestamp without
+ * time zone` column holding a given instant.
+ *
+ * Tests that fabricate a DB timestamp as `new Date(Date.now() - 60_000)` are
+ * unfaithful: that Date carries the true instant, whereas a Date that came off
+ * the wire from an offsetless column carries the UTC wall clock re-read as
+ * LOCAL time. The two are identical only when the host runs UTC — which is why
+ * a whole class of timezone defect can sit under a fully green suite on CI (UTC
+ * containers) and be 100% broken on a US developer's machine.
+ *
+ * The simulation is exactly the driver's own path:
+ *   1. Postgres emits the UTC wall clock with no zone marker
+ *      (`2026-08-25 18:34:15.123`), because the column has no offset to send.
+ *   2. postgres.js parses OIDs 1082/1114/1184 with a bare `new Date(x)`
+ *      (postgres/src/types.js) — no UTC hint.
+ *   3. V8 reads an offsetless date-time as local time.
+ *   4. Drizzle's UTC-correct path (`value + '+0000'`) never fires, because it
+ *      is guarded on `typeof value === 'string'` and postgres.js already
+ *      produced a Date.
+ *
+ * Verified against a live Postgres 16 through the real postgres.js client: for
+ * one instant, `.getTime()` came back +6h under America/Denver, -2h under
+ * Europe/Berlin, and exact under UTC.
+ *
+ * Pair this with `utcMsFromOffsetlessTimestamp` (services/sso.ts), which is the
+ * production-side inverse.
+ */
+export function pgOffsetlessTimestamp(trueUtcMs: number): Date {
+  // '2026-08-25T18:34:15.123Z' -> '2026-08-25 18:34:15.123'
+  const wire = new Date(trueUtcMs).toISOString().slice(0, 23).replace('T', ' ');
+  // Offsetless, so V8 applies the host's local zone — exactly as the driver does.
+  return new Date(wire);
+}

--- a/apps/docs/src/content/docs/reference/sso.mdx
+++ b/apps/docs/src/content/docs/reference/sso.mdx
@@ -310,6 +310,7 @@ When Breeze auto-discovers a provider's endpoints from its issuer URL, it refuse
 | `defaultRoleId` | `uuid` | No | -- | Role assigned to auto-provisioned users. Must be an org-scoped role in the target org (or, for partner providers, a partner-scoped role belonging to your partner). |
 | `allowedDomains` | `string` | No | -- | Comma-separated email domains. Empty means all domains are allowed. |
 | `enforceSSO` | `boolean` | No | `false` | Disable password login for the organization. |
+| `trustsIdpMfa` | `boolean` | No | `false` | Treat the IdP's own MFA assertion (`amr: mfa` in the id_token) as satisfying Breeze's MFA-gated routes. See [Satisfying Breeze MFA with your IdP](#satisfying-breeze-mfa-with-your-idp). |
 
 <Aside type="caution">
   The `clientSecret` is encrypted before storage using the server's encryption key. It is never returned in API responses. The `hasClientSecret` boolean field indicates whether a secret is configured.
@@ -417,6 +418,15 @@ When a partner provider has `enforceSSO: true`, the login page **collapses** the
 ### Password Reset and SSO Enforcement
 
 The forgot-password and reset-password flows honor SSO enforcement. A partner-scoped technician whose partner provider has `enforceSSO: true` cannot reset a password: the request still returns the generic success response (so account existence is never revealed), but **no reset email is sent**. The same rule applies to organization users under an enforcing organization provider.
+
+### Satisfying Breeze MFA with your IdP
+
+By default, Breeze never accepts an IdP's own multi-factor authentication as satisfying its own MFA-gated routes (mutating SSO provider config, PAM checkouts, and similar sensitive actions) — every account, SSO-provisioned or not, must separately satisfy Breeze's own MFA requirement on those routes. Set `trustsIdpMfa: true` on a provider (organization or partner-owned) to change that: when the id_token from that provider's login includes `amr: mfa` — an [RFC 8176](https://www.rfc-editor.org/rfc/rfc8176) Authentication Method Reference claim meaning the user completed multi-factor authentication at the IdP — Breeze treats MFA as satisfied for that sign-in.
+
+Two things to know before turning this on:
+
+- **Your IdP must actually send the claim.** Most identity providers only include `amr` in the id_token when explicitly configured to (an app-registration or claims-mapping setting on the IdP side, not a Breeze setting). Consult your IdP's documentation. If the claim is absent, `trustsIdpMfa` has no effect and Breeze continues to require its own MFA step.
+- **This is fail-safe, not fail-open.** `trustsIdpMfa` defaults to `false` on every provider, and a missing or unrecognized `amr` value is treated as "MFA not satisfied" rather than being assumed. Enabling it is always an explicit, reviewable opt-in per provider.
 
 ---
 

--- a/apps/web/src/components/devices/AddDeviceModal.test.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.test.tsx
@@ -17,8 +17,19 @@ import { fetchWithAuth } from '../../stores/auth';
 
 // --- Mocks ---
 
+// #4018: the modal reads `user.hasPassword` off the auth store to choose the
+// MFA_REQUIRED copy. Kept as a MUTABLE hoisted object so a test can flip the
+// flag between renders without re-mocking the module.
+const { authState } = vi.hoisted(() => ({
+  authState: { user: null as { hasPassword?: boolean } | null },
+}));
+
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (state: typeof authState) => unknown) => selector(authState),
+    { getState: () => authState },
+  ),
 }));
 
 vi.mock('../../stores/orgStore', () => ({
@@ -101,6 +112,7 @@ describe('AddDeviceModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setOrgStore();
+    authState.user = { hasPassword: true };
   });
 
   afterEach(() => {
@@ -408,6 +420,75 @@ describe('AddDeviceModal', () => {
     });
   });
 
+  // #4018: "set up MFA in your profile settings and sign in again" is a DEAD
+  // END for an SSO-provisioned account — it has no password, so the profile
+  // enrollment flow rejects it. Those users get the identity-provider road.
+  describe('MFA_REQUIRED copy for a passwordless SSO account (#4018)', () => {
+    async function failWithMfaRequired(trigger: () => void) {
+      fetchWithAuthMock.mockResolvedValue(
+        makeJsonResponse({ error: 'MFA required' }, false, 403)
+      );
+      render(<AddDeviceModal isOpen onClose={vi.fn()} />);
+      trigger();
+    }
+
+    it('points the installer download at the identity provider, not the password flow', async () => {
+      authState.user = { hasPassword: false };
+      await failWithMfaRequired(() => fireEvent.click(getDownloadButton()));
+
+      const banner = await screen.findByTestId('download-mfa-required');
+      expect(banner.textContent).toContain('signs you in through an identity provider');
+      // The dead-end instruction must be GONE, not merely supplemented.
+      expect(banner.textContent).not.toContain('and sign in again');
+      expect(banner.querySelector('a')).toBeNull();
+    });
+
+    it('points link generation at the identity provider', async () => {
+      authState.user = { hasPassword: false };
+      await failWithMfaRequired(() => fireEvent.click(screen.getByText('Generate Link')));
+
+      const banner = await screen.findByTestId('link-mfa-required');
+      expect(banner.textContent).toContain('required to generate links');
+      expect(banner.textContent).toContain('signs you in through an identity provider');
+      expect(banner.textContent).not.toContain('and sign in again');
+    });
+
+    it('points CLI token generation at the identity provider', async () => {
+      authState.user = { hasPassword: false };
+      fetchWithAuthMock.mockResolvedValue(
+        makeJsonResponse({ error: 'MFA required' }, false, 403)
+      );
+      render(<AddDeviceModal isOpen onClose={vi.fn()} />);
+      fireEvent.click(screen.getByText('CLI Commands'));
+
+      const banner = await screen.findByTestId('token-mfa-required');
+      expect(banner.textContent).toContain('required to generate installation tokens');
+      expect(banner.textContent).toContain('signs you in through an identity provider');
+    });
+
+    it('keeps the password-account copy when hasPassword is true', async () => {
+      authState.user = { hasPassword: true };
+      await failWithMfaRequired(() => fireEvent.click(getDownloadButton()));
+
+      const banner = await screen.findByTestId('download-mfa-required');
+      expect(banner.textContent).toContain('Set up MFA in your profile settings');
+      expect(banner.textContent).not.toContain('identity provider');
+      expect(banner.querySelector('a')?.getAttribute('href')).toBe('/settings/profile');
+    });
+
+    // Absent is UNKNOWN (a session persisted before /users/me carried the
+    // field), and unknown must NOT silently take the SSO road — a password
+    // user would then be told to go ask their admin about an IdP they don't use.
+    it('keeps the password-account copy when hasPassword is absent', async () => {
+      authState.user = {};
+      await failWithMfaRequired(() => fireEvent.click(getDownloadButton()));
+
+      const banner = await screen.findByTestId('download-mfa-required');
+      expect(banner.textContent).toContain('Set up MFA in your profile settings');
+      expect(banner.textContent).not.toContain('identity provider');
+    });
+  });
+
   it('shows error when link generation fails', async () => {
     fetchWithAuthMock.mockImplementation(async (input) => {
       const url = String(input);
@@ -582,6 +663,7 @@ describe('AddDeviceModal — resolved enrollment defaults (#2776)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setOrgStore();
+    authState.user = { hasPassword: true };
   });
 
   it('pre-selects the partner/org default TTL and count, and hides options above the cap', async () => {

--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Download, Copy, Loader2, Check, Link } from "lucide-react";
 import { Dialog } from "../shared/Dialog";
 import { showToast } from "../shared/Toast";
-import { fetchWithAuth } from "../../stores/auth";
+import { fetchWithAuth, useAuthStore } from "../../stores/auth";
 import { useOrgStore } from "../../stores/orgStore";
 import { formatDateTime } from "@/lib/dateTimeFormat";
 import {
@@ -103,6 +103,17 @@ export default function AddDeviceModal({
 }: AddDeviceModalProps) {
   const { t } = useTranslation("devices");
   const userOS = detectUserOS();
+  // #4018: the MFA_REQUIRED copy below tells the user to set MFA up in their
+  // profile and sign in again. For an SSO-provisioned account that is a dead
+  // end — it has no password, and the profile enrollment flow demands one — so
+  // those users get copy that names the road they can actually take.
+  //
+  // `hasPassword` is populated by GET /users/me (routes/users.ts), which is
+  // what the auth store hydrates from on the SSO bootstrap and on every login
+  // refresh. Compared with `=== false` on purpose: absent means UNKNOWN (a
+  // session persisted before the field existed), and unknown must keep the
+  // original copy rather than assume passwordless.
+  const isSsoOnlyAccount = useAuthStore((s) => s.user?.hasPassword) === false;
   // Sites are fetched lazily now (the switcher no longer preloads them), so the
   // modal has to distinguish "still loading", "load failed", and "genuinely no
   // sites" — otherwise a failed fetch looks identical to an unconfigured org and
@@ -957,15 +968,24 @@ export default function AddDeviceModal({
 
                 {/* Link errors */}
                 {linkError === "MFA_REQUIRED" && (
-                  <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700">
-                    {t("addDeviceModal.multiFactorAuthenticationIsRequiredTo")}{" "}
-                    <a
-                      href="/settings/profile"
-                      className="font-medium underline hover:no-underline"
-                    >
-                      {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
-                    </a>{" "}
-                    {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
+                  <div
+                    className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700"
+                    data-testid="link-mfa-required"
+                  >
+                    {isSsoOnlyAccount ? (
+                      t("addDeviceModal.mfaRequiredSsoLinks")
+                    ) : (
+                      <>
+                        {t("addDeviceModal.multiFactorAuthenticationIsRequiredTo")}{" "}
+                        <a
+                          href="/settings/profile"
+                          className="font-medium underline hover:no-underline"
+                        >
+                          {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
+                        </a>{" "}
+                        {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
+                      </>
+                    )}
                   </div>
                 )}
 
@@ -984,15 +1004,24 @@ export default function AddDeviceModal({
 
                 {/* MFA error */}
                 {downloadError === "MFA_REQUIRED" && (
-                  <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700">
-                    {t("addDeviceModal.multiFactorAuthenticationIsRequiredTo2")}{" "}
-                    <a
-                      href="/settings/profile"
-                      className="font-medium underline hover:no-underline"
-                    >
-                      {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
-                    </a>{" "}
-                    {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
+                  <div
+                    className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700"
+                    data-testid="download-mfa-required"
+                  >
+                    {isSsoOnlyAccount ? (
+                      t("addDeviceModal.mfaRequiredSsoInstallers")
+                    ) : (
+                      <>
+                        {t("addDeviceModal.multiFactorAuthenticationIsRequiredTo2")}{" "}
+                        <a
+                          href="/settings/profile"
+                          className="font-medium underline hover:no-underline"
+                        >
+                          {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
+                        </a>{" "}
+                        {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
+                      </>
+                    )}
                   </div>
                 )}
 
@@ -1062,15 +1091,24 @@ export default function AddDeviceModal({
                     </span>
                   </div>
                 ) : tokenError === "MFA_REQUIRED" ? (
-                  <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700">
-                    {t("addDeviceModal.multiFactorAuthenticationIsRequiredTo3")}{" "}
-                    <a
-                      href="/settings/profile"
-                      className="font-medium underline hover:no-underline"
-                    >
-                      {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
-                    </a>{" "}
-                    {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
+                  <div
+                    className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700"
+                    data-testid="token-mfa-required"
+                  >
+                    {isSsoOnlyAccount ? (
+                      t("addDeviceModal.mfaRequiredSsoTokens")
+                    ) : (
+                      <>
+                        {t("addDeviceModal.multiFactorAuthenticationIsRequiredTo3")}{" "}
+                        <a
+                          href="/settings/profile"
+                          className="font-medium underline hover:no-underline"
+                        >
+                          {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
+                        </a>{" "}
+                        {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
+                      </>
+                    )}
                   </div>
                 ) : tokenError ? (
                   <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">

--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Download, Copy, Loader2, Check, Link } from "lucide-react";
 import { Dialog } from "../shared/Dialog";
 import { showToast } from "../shared/Toast";
-import { fetchWithAuth } from "../../stores/auth";
+import { fetchWithAuth, useAuthStore } from "../../stores/auth";
 import { useOrgStore } from "../../stores/orgStore";
 import { formatDateTime } from "@/lib/dateTimeFormat";
 import {
@@ -103,6 +103,14 @@ export default function AddDeviceModal({
 }: AddDeviceModalProps) {
   const { t } = useTranslation("devices");
   const userOS = detectUserOS();
+  // #4018: MFA_REQUIRED copy below branches on whether this is an SSO session,
+  // since "set up MFA in your profile settings" is a dead end for an
+  // SSO-provisioned account that has no password (profile MFA setup rejects
+  // it). `hasPassword` isn't populated on this store today (see the field's
+  // comment in stores/auth.ts) — until it is, this reads as `undefined` and
+  // the password-session copy renders, matching current behavior. Compare
+  // with `=== false`, never `!hasPassword`, so "unknown" doesn't misread as SSO.
+  const isSsoSession = useAuthStore((s) => s.user?.hasPassword) === false;
   // Sites are fetched lazily now (the switcher no longer preloads them), so the
   // modal has to distinguish "still loading", "load failed", and "genuinely no
   // sites" — otherwise a failed fetch looks identical to an unconfigured org and
@@ -959,13 +967,19 @@ export default function AddDeviceModal({
                 {linkError === "MFA_REQUIRED" && (
                   <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700">
                     {t("addDeviceModal.multiFactorAuthenticationIsRequiredTo")}{" "}
-                    <a
-                      href="/settings/profile"
-                      className="font-medium underline hover:no-underline"
-                    >
-                      {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
-                    </a>{" "}
-                    {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
+                    {isSsoSession ? (
+                      t("addDeviceModal.ssoMfaTrustGuidance")
+                    ) : (
+                      <>
+                        <a
+                          href="/settings/profile"
+                          className="font-medium underline hover:no-underline"
+                        >
+                          {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
+                        </a>{" "}
+                        {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
+                      </>
+                    )}
                   </div>
                 )}
 
@@ -986,13 +1000,19 @@ export default function AddDeviceModal({
                 {downloadError === "MFA_REQUIRED" && (
                   <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700">
                     {t("addDeviceModal.multiFactorAuthenticationIsRequiredTo2")}{" "}
-                    <a
-                      href="/settings/profile"
-                      className="font-medium underline hover:no-underline"
-                    >
-                      {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
-                    </a>{" "}
-                    {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
+                    {isSsoSession ? (
+                      t("addDeviceModal.ssoMfaTrustGuidance")
+                    ) : (
+                      <>
+                        <a
+                          href="/settings/profile"
+                          className="font-medium underline hover:no-underline"
+                        >
+                          {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
+                        </a>{" "}
+                        {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
+                      </>
+                    )}
                   </div>
                 )}
 
@@ -1064,13 +1084,19 @@ export default function AddDeviceModal({
                 ) : tokenError === "MFA_REQUIRED" ? (
                   <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700">
                     {t("addDeviceModal.multiFactorAuthenticationIsRequiredTo3")}{" "}
-                    <a
-                      href="/settings/profile"
-                      className="font-medium underline hover:no-underline"
-                    >
-                      {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
-                    </a>{" "}
-                    {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
+                    {isSsoSession ? (
+                      t("addDeviceModal.ssoMfaTrustGuidance")
+                    ) : (
+                      <>
+                        <a
+                          href="/settings/profile"
+                          className="font-medium underline hover:no-underline"
+                        >
+                          {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
+                        </a>{" "}
+                        {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
+                      </>
+                    )}
                   </div>
                 ) : tokenError ? (
                   <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">

--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Download, Copy, Loader2, Check, Link } from "lucide-react";
 import { Dialog } from "../shared/Dialog";
 import { showToast } from "../shared/Toast";
-import { fetchWithAuth, useAuthStore } from "../../stores/auth";
+import { fetchWithAuth } from "../../stores/auth";
 import { useOrgStore } from "../../stores/orgStore";
 import { formatDateTime } from "@/lib/dateTimeFormat";
 import {
@@ -103,14 +103,6 @@ export default function AddDeviceModal({
 }: AddDeviceModalProps) {
   const { t } = useTranslation("devices");
   const userOS = detectUserOS();
-  // #4018: MFA_REQUIRED copy below branches on whether this is an SSO session,
-  // since "set up MFA in your profile settings" is a dead end for an
-  // SSO-provisioned account that has no password (profile MFA setup rejects
-  // it). `hasPassword` isn't populated on this store today (see the field's
-  // comment in stores/auth.ts) — until it is, this reads as `undefined` and
-  // the password-session copy renders, matching current behavior. Compare
-  // with `=== false`, never `!hasPassword`, so "unknown" doesn't misread as SSO.
-  const isSsoSession = useAuthStore((s) => s.user?.hasPassword) === false;
   // Sites are fetched lazily now (the switcher no longer preloads them), so the
   // modal has to distinguish "still loading", "load failed", and "genuinely no
   // sites" — otherwise a failed fetch looks identical to an unconfigured org and
@@ -967,19 +959,13 @@ export default function AddDeviceModal({
                 {linkError === "MFA_REQUIRED" && (
                   <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700">
                     {t("addDeviceModal.multiFactorAuthenticationIsRequiredTo")}{" "}
-                    {isSsoSession ? (
-                      t("addDeviceModal.ssoMfaTrustGuidance")
-                    ) : (
-                      <>
-                        <a
-                          href="/settings/profile"
-                          className="font-medium underline hover:no-underline"
-                        >
-                          {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
-                        </a>{" "}
-                        {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
-                      </>
-                    )}
+                    <a
+                      href="/settings/profile"
+                      className="font-medium underline hover:no-underline"
+                    >
+                      {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
+                    </a>{" "}
+                    {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
                   </div>
                 )}
 
@@ -1000,19 +986,13 @@ export default function AddDeviceModal({
                 {downloadError === "MFA_REQUIRED" && (
                   <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700">
                     {t("addDeviceModal.multiFactorAuthenticationIsRequiredTo2")}{" "}
-                    {isSsoSession ? (
-                      t("addDeviceModal.ssoMfaTrustGuidance")
-                    ) : (
-                      <>
-                        <a
-                          href="/settings/profile"
-                          className="font-medium underline hover:no-underline"
-                        >
-                          {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
-                        </a>{" "}
-                        {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
-                      </>
-                    )}
+                    <a
+                      href="/settings/profile"
+                      className="font-medium underline hover:no-underline"
+                    >
+                      {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
+                    </a>{" "}
+                    {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
                   </div>
                 )}
 
@@ -1084,19 +1064,13 @@ export default function AddDeviceModal({
                 ) : tokenError === "MFA_REQUIRED" ? (
                   <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700">
                     {t("addDeviceModal.multiFactorAuthenticationIsRequiredTo3")}{" "}
-                    {isSsoSession ? (
-                      t("addDeviceModal.ssoMfaTrustGuidance")
-                    ) : (
-                      <>
-                        <a
-                          href="/settings/profile"
-                          className="font-medium underline hover:no-underline"
-                        >
-                          {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
-                        </a>{" "}
-                        {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
-                      </>
-                    )}
+                    <a
+                      href="/settings/profile"
+                      className="font-medium underline hover:no-underline"
+                    >
+                      {t("addDeviceModal.setUpMfaInYourProfile")}{" "}
+                    </a>{" "}
+                    {t("addDeviceModal.andSignInAgainThenRetry")}{" "}
                   </div>
                 ) : tokenError ? (
                   <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">

--- a/apps/web/src/components/settings/MFASettings.test.tsx
+++ b/apps/web/src/components/settings/MFASettings.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import MFASettings from './MFASettings';
+
+/**
+ * #4018 review finding 7: the SSO enrollment road's terminal write needs the
+ * single-use grant, and the component must not issue the request without one.
+ *
+ * Pinned HERE rather than through ProfilePage because ProfilePage cannot
+ * currently produce the state: it sets `ssoSetupReady` and `ssoReauthGrantId`
+ * in the same mount effect and clears them together, and the passwordless
+ * confirm-identity view's only action is a full-page navigation to the IdP.
+ * MFASettings takes the two as INDEPENDENT props, so the combination is one a
+ * caller can hand it — and the component owes a sane answer either way rather
+ * than posting a proofless request and rendering the 401 on a screen with no
+ * password field and no re-verify button.
+ */
+describe('MFASettings — passwordless enrollment with no re-auth grant', () => {
+  const baseProps = {
+    enabled: false,
+    hasPassword: false,
+    ssoSetupReady: true,
+    qrCodeDataUrl: 'data:image/png;base64,abc',
+  } as const;
+
+  function fillCode() {
+    const digits = document.querySelectorAll<HTMLInputElement>('input[inputmode="numeric"]');
+    expect(digits.length).toBe(6);
+    digits.forEach((input, index) => {
+      fireEvent.change(input, { target: { value: String(index + 1) } });
+    });
+  }
+
+  it('offers IdP re-verification instead of Verify, and never calls onEnable', async () => {
+    const onEnable = vi.fn();
+    const onSsoReauth = vi.fn();
+
+    render(
+      <MFASettings
+        {...baseProps}
+        ssoReauthGrantAvailable={false}
+        onEnable={onEnable}
+        onSsoReauth={onSsoReauth}
+      />
+    );
+
+    await screen.findByText(/Set up authenticator/i);
+    fillCode();
+
+    expect(screen.getByTestId('mfa-sso-grant-lost')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Verify and enable/i })).toBeNull();
+
+    fireEvent.click(screen.getByTestId('mfa-sso-reauth-retry'));
+
+    await waitFor(() => expect(onSsoReauth).toHaveBeenCalledTimes(1));
+    expect(onEnable).not.toHaveBeenCalled();
+  });
+
+  it('keeps the ordinary Verify button when the grant IS available', async () => {
+    const onEnable = vi.fn();
+
+    render(
+      <MFASettings {...baseProps} ssoReauthGrantAvailable onEnable={onEnable} />
+    );
+
+    await screen.findByText(/Set up authenticator/i);
+    fillCode();
+
+    expect(screen.queryByTestId('mfa-sso-grant-lost')).toBeNull();
+    expect(screen.queryByTestId('mfa-sso-reauth-retry')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /Verify and enable/i }));
+
+    // A passwordless account sends no password — the parent attaches the grant.
+    await waitFor(() => expect(onEnable).toHaveBeenCalledWith('123456', ''));
+  });
+
+  // The prop defaults to true so the password road and any caller that predates
+  // it are untouched: a password account must never see the SSO CTA.
+  it('leaves a password account alone', async () => {
+    const onEnable = vi.fn();
+
+    render(
+      <MFASettings
+        enabled={false}
+        hasPassword
+        ssoSetupReady
+        qrCodeDataUrl="data:image/png;base64,abc"
+        onEnable={onEnable}
+      />
+    );
+
+    await screen.findByText(/Set up authenticator/i);
+    fillCode();
+
+    expect(screen.queryByTestId('mfa-sso-grant-lost')).toBeNull();
+    expect(screen.getByRole('button', { name: /Verify and enable/i })).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/settings/MFASettings.tsx
+++ b/apps/web/src/components/settings/MFASettings.tsx
@@ -1,7 +1,7 @@
 import '@/lib/i18n';
 import { useTranslation } from 'react-i18next';
 import type { ClipboardEvent, KeyboardEvent } from 'react';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { MfaMethod } from '../../stores/auth';
 
 const DIGIT_COUNT = 6;
@@ -9,6 +9,25 @@ const DIGIT_COUNT = 6;
 type MFASettingsProps = {
   enabled?: boolean;
   mfaMethod?: MfaMethod | null;
+  /**
+   * #4018: whether this account has a password at all. `false` means an
+   * SSO-provisioned (JIT) account that can never satisfy the password step-up,
+   * so the enrollment gate offers a fresh IdP round-trip instead of a password
+   * prompt. `undefined` is UNKNOWN (a session persisted before /users/me
+   * carried the field) and must keep the password prompt — hence every check
+   * below is an explicit `=== false`.
+   */
+  hasPassword?: boolean;
+  /** Starts the IdP re-authentication round-trip. Only reachable when
+   *  `hasPassword === false`. */
+  onSsoReauth?: () => void | Promise<void>;
+  /**
+   * The parent already completed `/mfa/setup` out-of-band using an SSO
+   * re-auth grant it picked up from the redirect fragment, so jump straight to
+   * the QR/verify view rather than re-prompting for a proof that was already
+   * spent on this page load.
+   */
+  ssoSetupReady?: boolean;
   phoneVerified?: boolean;
   phoneLast4?: string;
   smsAllowed?: boolean;
@@ -38,6 +57,9 @@ type MFAView =
 export default function MFASettings({
   enabled = false,
   mfaMethod,
+  hasPassword,
+  onSsoReauth,
+  ssoSetupReady = false,
   phoneVerified = false,
   phoneLast4,
   smsAllowed = false,
@@ -80,6 +102,19 @@ export default function MFASettings({
   const code = digits.join('');
   const phoneCode = phoneDigits.join('');
   const currentMethod = mfaMethod || (enabled ? 'totp' : null);
+  // #4018: only `false` takes the SSO road. `undefined` (unknown) keeps the
+  // password prompt, which is the fail-safe direction: the server rejects a
+  // wrong password, whereas wrongly hiding the prompt would strand a password
+  // user with a button their account cannot use.
+  const isPasswordless = hasPassword === false;
+
+  // The parent consumed an `#ssoReauthGrant=` fragment and already ran
+  // /mfa/setup with it. Open the QR view directly. Deliberately keyed on the
+  // prop only: once the user cancels back to 'status' this must not re-open,
+  // and it won't — the effect doesn't re-run while the prop stays true.
+  useEffect(() => {
+    if (ssoSetupReady) setView('setup');
+  }, [ssoSetupReady]);
 
   const resetDigits = () => {
     setDigits(Array(DIGIT_COUNT).fill(''));
@@ -187,7 +222,11 @@ export default function MFASettings({
   };
 
   const handleEnableSubmit = async () => {
-    if (isLoading || isSubmitting || code.length !== DIGIT_COUNT || !currentPassword) {
+    // A passwordless account has no password to carry from the gate above —
+    // the parent supplies the SSO re-auth grant instead, so requiring a
+    // non-empty password here would make the Verify button permanently inert.
+    if (isLoading || isSubmitting || code.length !== DIGIT_COUNT
+      || (!isPasswordless && !currentPassword)) {
       return;
     }
     try {
@@ -553,6 +592,7 @@ export default function MFASettings({
           ) : !enabled ? (
             <button
               type="button"
+              data-testid="mfa-setup-start"
               onClick={() => {
                 setCurrentPassword('');
                 setLocalError(undefined);
@@ -660,30 +700,42 @@ export default function MFASettings({
     return (
       <div className="space-y-6 rounded-lg border bg-card p-6 shadow-xs">
         <div className="space-y-1">
-          <h2 className="text-lg font-semibold">{t('mFASettings.confirmYourPassword')}</h2>
+          <h2 className="text-lg font-semibold">
+            {isPasswordless
+              ? t('mFASettings.verifyYourIdentity')
+              : t('mFASettings.confirmYourPassword')}
+          </h2>
           <p className="text-sm text-muted-foreground">
-            {t('mFASettings.reEnterYourAccountPasswordToStartSettingUpAnAuthenticato')}</p>
+            {isPasswordless
+              ? t('mFASettings.thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw')
+              : t('mFASettings.reEnterYourAccountPasswordToStartSettingUpAnAuthenticato')}
+          </p>
         </div>
 
-        <div className="space-y-2">
-          <label className="text-sm font-medium" htmlFor="mfa-confirm-password">
-            {t('mFASettings.currentPassword')}</label>
-          <input
-            id="mfa-confirm-password"
-            type="password"
-            autoComplete="current-password"
-            autoFocus
-            value={currentPassword}
-            onChange={e => setCurrentPassword(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === 'Enter' && currentPassword && !isLoading && !isSubmitting) {
-                handleConfirmPasswordSetup();
-              }
-            }}
-            className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            disabled={isLoading || isSubmitting}
-          />
-        </div>
+        {/* #4018: a passwordless SSO account proves identity with a fresh,
+            forced IdP round-trip instead of a password it does not have. */}
+        {!isPasswordless && (
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="mfa-confirm-password">
+              {t('mFASettings.currentPassword')}</label>
+            <input
+              id="mfa-confirm-password"
+              data-testid="mfa-current-password"
+              type="password"
+              autoComplete="current-password"
+              autoFocus
+              value={currentPassword}
+              onChange={e => setCurrentPassword(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && currentPassword && !isLoading && !isSubmitting) {
+                  handleConfirmPasswordSetup();
+                }
+              }}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              disabled={isLoading || isSubmitting}
+            />
+          </div>
+        )}
 
         {renderError()}
 
@@ -698,14 +750,26 @@ export default function MFASettings({
             className="h-10 rounded-md border px-4 text-sm font-medium text-muted-foreground transition hover:text-foreground"
           >
             {t('mFASettings.cancel')}</button>
-          <button
-            type="button"
-            onClick={handleConfirmPasswordSetup}
-            disabled={isLoading || isSubmitting || !currentPassword}
-            className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isLoading ? t('mFASettings.verifying') : t('mFASettings.continue')}
-          </button>
+          {isPasswordless ? (
+            <button
+              type="button"
+              data-testid="mfa-sso-reauth"
+              onClick={() => { void onSsoReauth?.(); }}
+              disabled={isLoading || isSubmitting}
+              className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {t('mFASettings.verifyWithYourIdentityProvider')}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={handleConfirmPasswordSetup}
+              disabled={isLoading || isSubmitting || !currentPassword}
+              className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isLoading ? t('mFASettings.verifying') : t('mFASettings.continue')}
+            </button>
+          )}
         </div>
       </div>
     );

--- a/apps/web/src/components/settings/MFASettings.tsx
+++ b/apps/web/src/components/settings/MFASettings.tsx
@@ -28,6 +28,19 @@ type MFASettingsProps = {
    * spent on this page load.
    */
   ssoSetupReady?: boolean;
+  /**
+   * #4018: is the parent still holding the single-use SSO re-auth grant that
+   * the terminal `/mfa/enable` call has to present?
+   *
+   * It lives only in the parent's React state and the `#ssoReauthGrant=`
+   * fragment is stripped at mount, so a reload while the QR is on screen — or
+   * a session restore, or opening the page in a second tab — loses it. Without
+   * this the Verify button would post no proof at all, the server would 401,
+   * and the user would be staring at that error on a screen with no password
+   * field and no way to re-verify. Defaults to `true` so the password road and
+   * any caller that does not pass it are unaffected.
+   */
+  ssoReauthGrantAvailable?: boolean;
   phoneVerified?: boolean;
   phoneLast4?: string;
   smsAllowed?: boolean;
@@ -60,6 +73,7 @@ export default function MFASettings({
   hasPassword,
   onSsoReauth,
   ssoSetupReady = false,
+  ssoReauthGrantAvailable = true,
   phoneVerified = false,
   phoneLast4,
   smsAllowed = false,
@@ -107,6 +121,11 @@ export default function MFASettings({
   // wrong password, whereas wrongly hiding the prompt would strand a password
   // user with a button their account cannot use.
   const isPasswordless = hasPassword === false;
+  // #4018: a passwordless account whose grant has been lost cannot complete the
+  // terminal write. It is not an error state to report AFTER the fact — there
+  // is nothing the user can type that would fix it — so the enable action is
+  // withheld and replaced by a fresh IdP round-trip.
+  const needsSsoReVerify = isPasswordless && !ssoReauthGrantAvailable;
 
   // The parent consumed an `#ssoReauthGrant=` fragment and already ran
   // /mfa/setup with it. Open the QR view directly. Deliberately keyed on the
@@ -225,7 +244,11 @@ export default function MFASettings({
     // A passwordless account has no password to carry from the gate above —
     // the parent supplies the SSO re-auth grant instead, so requiring a
     // non-empty password here would make the Verify button permanently inert.
+    // But a passwordless account with NO grant left has no proof at all, and
+    // firing the request anyway just buys a 401 on a screen with nothing to
+    // retry with. Refuse to issue it; the view offers re-verification instead.
     if (isLoading || isSubmitting || code.length !== DIGIT_COUNT
+      || needsSsoReVerify
       || (!isPasswordless && !currentPassword)) {
       return;
     }
@@ -804,6 +827,15 @@ export default function MFASettings({
             {t('mFASettings.enterThe6DigitCodeGeneratedByYourAuthenticatorApp')}</p>
         </div>
 
+        {/* #4018: the single-use grant is gone (reload, restored session, or a
+            second tab), so there is no proof left to send. Say so and offer the
+            only thing that fixes it rather than letting the submit 401. */}
+        {needsSsoReVerify && (
+          <p data-testid="mfa-sso-grant-lost" className="text-sm text-muted-foreground">
+            {t('mFASettings.ssoReauthProofExpired')}
+          </p>
+        )}
+
         {renderError()}
 
         <div className="flex flex-wrap items-center justify-end gap-3">
@@ -816,14 +848,26 @@ export default function MFASettings({
             className="h-10 rounded-md border px-4 text-sm font-medium text-muted-foreground transition hover:text-foreground"
           >
             {t('mFASettings.cancel')}</button>
-          <button
-            type="button"
-            onClick={handleEnableSubmit}
-            disabled={isLoading || code.length !== DIGIT_COUNT}
-            className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isLoading ? t('mFASettings.verifying') : t('mFASettings.verifyAndEnable')}
-          </button>
+          {needsSsoReVerify ? (
+            <button
+              type="button"
+              data-testid="mfa-sso-reauth-retry"
+              onClick={() => { void onSsoReauth?.(); }}
+              disabled={isLoading || isSubmitting}
+              className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {t('mFASettings.verifyWithYourIdentityProvider')}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={handleEnableSubmit}
+              disabled={isLoading || code.length !== DIGIT_COUNT}
+              className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isLoading ? t('mFASettings.verifying') : t('mFASettings.verifyAndEnable')}
+            </button>
+          )}
         </div>
       </div>
     );

--- a/apps/web/src/components/settings/ProfilePage.passkeys.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.passkeys.test.tsx
@@ -150,4 +150,163 @@ describe('ProfilePage passkey management', () => {
       }),
     ]);
   });
+
+  // #4018: a passwordless SSO account has no password to prove, so it proves
+  // identity with a fresh forced IdP round-trip instead. The API accepted
+  // `ssoReauthGrantId` on both register endpoints from the start and had no
+  // caller — a passwordless user simply could not register a passkey.
+  describe('passwordless SSO account (#4018)', () => {
+    // Both endpoints type it as z.string().uuid() (mintStepUpGrant returns
+    // randomUUID()), so a non-UUID fixture would 400 before the road is reached.
+    const GRANT = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+
+    const REGISTRATION_OPTIONS = {
+      challenge: 'register-challenge',
+      rp: { name: 'Breeze' },
+      user: { id: 'user-1', name: 'casey@example.com', displayName: 'Casey Admin' },
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+    };
+    const CREDENTIAL = {
+      id: 'credential-1',
+      rawId: 'credential-1',
+      type: 'public-key',
+      response: { attestationObject: 'attestation', clientDataJSON: 'client-data' },
+    };
+
+    const passwordlessUser = {
+      id: 'user-1',
+      name: 'Casey Admin',
+      email: 'casey@example.com',
+      mfaEnabled: false,
+      hasPassword: false,
+    };
+
+    function callTo(url: string) {
+      return fetchWithAuthMock.mock.calls.filter(([u]) => String(u) === url);
+    }
+
+    it('sends the SAME grant to BOTH register/options and register/verify', async () => {
+      // Arriving back from the IdP: the callback hands the grant over in the
+      // fragment, and ProfilePage holds it for whichever road spends it first.
+      window.history.replaceState(null, '', `/settings/profile#ssoReauthGrant=${GRANT}`);
+
+      fetchWithAuthMock.mockImplementation(async (url: string) => {
+        const u = String(url);
+        if (u === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+        if (u === '/auth/mfa/setup') return makeJsonResponse({ qrCodeDataUrl: 'data:image/png;base64,abc' });
+        if (u === '/auth/passkeys/register/options') return makeJsonResponse({ options: REGISTRATION_OPTIONS });
+        if (u === '/auth/passkeys/register/verify') {
+          return makeJsonResponse({ passkey: { id: 'credential-1', name: 'YubiKey' } });
+        }
+        return makeJsonResponse({});
+      });
+      createPasskeyCredentialMock.mockResolvedValueOnce(CREDENTIAL);
+
+      render(<ProfilePage initialUser={passwordlessUser} />);
+
+      await screen.findByText(/No passkeys are registered/i);
+      // No password field at all for an account that has no password.
+      expect(document.querySelector('#passkey-password')).toBeNull();
+
+      fireEvent.change(screen.getByLabelText(/Passkey name/i), { target: { value: 'YubiKey' } });
+      fireEvent.click(screen.getByTestId('passkey-add'));
+
+      await screen.findByText('Passkey added');
+
+      // BOTH call sites, asserted independently: register/options only
+      // VALIDATES the grant, register/verify CONSUMES it. Sending it to one and
+      // not the other yields a 401 after a successful WebAuthn ceremony.
+      const optionsCalls = callTo('/auth/passkeys/register/options');
+      expect(optionsCalls).toHaveLength(1);
+      expect(JSON.parse(String(optionsCalls[0][1]?.body)))
+        .toEqual({ ssoReauthGrantId: GRANT, name: 'YubiKey' });
+
+      const verifyCalls = callTo('/auth/passkeys/register/verify');
+      expect(verifyCalls).toHaveLength(1);
+      const verifyBody = JSON.parse(String(verifyCalls[0][1]?.body));
+      expect(verifyBody.ssoReauthGrantId).toBe(GRANT);
+      expect(verifyBody).toMatchObject({ name: 'YubiKey', credential: CREDENTIAL });
+
+      // The SAME id, not a second one minted in between: a fresh grant would be
+      // bound to different epochs and the consume would fail closed.
+      expect(JSON.parse(String(optionsCalls[0][1]?.body)).ssoReauthGrantId)
+        .toBe(verifyBody.ssoReauthGrantId);
+
+      // Neither call carries a password — there is none.
+      expect(JSON.parse(String(optionsCalls[0][1]?.body)).currentPassword).toBeUndefined();
+      expect(verifyBody.currentPassword).toBeUndefined();
+    });
+
+    it('issues NO request and offers IdP re-verification when the grant is missing', async () => {
+      window.history.replaceState(null, '', '/settings/profile');
+      fetchWithAuthMock.mockImplementation(async (url: string) => {
+        if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+        return makeJsonResponse({});
+      });
+
+      render(<ProfilePage initialUser={passwordlessUser} />);
+
+      await screen.findByText(/No passkeys are registered/i);
+
+      // The submit is replaced by the CTA that can actually resolve this.
+      expect(screen.getByTestId('passkey-sso-reauth')).toBeTruthy();
+      expect(screen.queryByTestId('passkey-add')).toBeNull();
+      expect(document.querySelector('#passkey-password')).toBeNull();
+
+      // And nothing proofless is ever sent.
+      expect(callTo('/auth/passkeys/register/options')).toHaveLength(0);
+      expect(callTo('/auth/passkeys/register/verify')).toHaveLength(0);
+      expect(createPasskeyCredentialMock).not.toHaveBeenCalled();
+    });
+
+    it('starts the IdP round-trip from the passkey card', async () => {
+      window.history.replaceState(null, '', '/settings/profile');
+      const assignMock = vi.fn();
+      const realLocation = window.location;
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { assign: assignMock, hash: '', search: '', pathname: '/settings/profile' },
+      });
+
+      fetchWithAuthMock.mockImplementation(async (url: string) => {
+        const u = String(url);
+        if (u === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+        if (u === '/sso/reauth/start') {
+          return makeJsonResponse({ authUrl: 'https://idp.example.com/authorize?prompt=login' });
+        }
+        return makeJsonResponse({});
+      });
+
+      render(<ProfilePage initialUser={passwordlessUser} />);
+      await screen.findByText(/No passkeys are registered/i);
+      fireEvent.click(screen.getByTestId('passkey-sso-reauth'));
+
+      await waitFor(() => {
+        expect(assignMock).toHaveBeenCalledWith('https://idp.example.com/authorize?prompt=login');
+      });
+      expect(callTo('/sso/reauth/start')).toHaveLength(1);
+
+      Object.defineProperty(window, 'location', { configurable: true, value: realLocation });
+    });
+
+    // hasPassword absent is UNKNOWN, not passwordless — the password road must
+    // survive a session persisted before /users/me carried the field.
+    it('keeps the password road for an account whose hasPassword is unknown', async () => {
+      window.history.replaceState(null, '', '/settings/profile');
+      fetchWithAuthMock.mockImplementation(async (url: string) => {
+        if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+        return makeJsonResponse({});
+      });
+
+      render(
+        <ProfilePage
+          initialUser={{ id: 'user-1', name: 'Casey Admin', email: 'casey@example.com', mfaEnabled: false }}
+        />,
+      );
+
+      await screen.findByText(/No passkeys are registered/i);
+      expect(document.querySelector('#passkey-password')).toBeTruthy();
+      expect(screen.queryByTestId('passkey-sso-reauth')).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/components/settings/ProfilePage.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.test.tsx
@@ -14,7 +14,7 @@ vi.mock('../../stores/auth', () => ({
   )
 }));
 
-// #4018: the SSO re-auth callback's `?error=` codes surface as toasts, and
+// #4018: the SSO re-auth callback's `?ssoReauthError=` codes surface as toasts, and
 // runAction toasts its own failures. Mocked here (this component and runAction
 // resolve to the SAME Toast module) so the assertions are on the call rather
 // than on a container these tests never mount.
@@ -618,7 +618,7 @@ describe('ProfilePage — SSO re-authentication enrollment (#4018)', () => {
   });
 
   it('toasts actionable copy for the reauth_not_fresh callback error', async () => {
-    window.history.replaceState(null, '', '/settings/profile?error=reauth_not_fresh');
+    window.history.replaceState(null, '', '/settings/profile?ssoReauthError=reauth_not_fresh');
 
     render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
 
@@ -634,8 +634,14 @@ describe('ProfilePage — SSO re-authentication enrollment (#4018)', () => {
     ['session_invalid', 'Your session changed while you were verifying'],
     ['password_set', 'This account now has a password'],
     ['reauth_unavailable', 'temporarily unavailable'],
+    // Reachable only since the callback stopped bouncing reauth to /login: a
+    // provider disabled, or its config_version bumped by an admin edit,
+    // mid-flight.
+    ['provider_inactive', 'no longer available for this account'],
+    ['config_changed', 'settings changed while you were verifying'],
+    ['email_unverified', 'email address is not verified'],
   ])('toasts a specific message for the %s callback error', async (code, fragment) => {
-    window.history.replaceState(null, '', `/settings/profile?error=${code}`);
+    window.history.replaceState(null, '', `/settings/profile?ssoReauthError=${code}`);
 
     render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
 
@@ -647,7 +653,7 @@ describe('ProfilePage — SSO re-authentication enrollment (#4018)', () => {
   // A code this build doesn't know must still say something — silence here
   // leaves the user staring at an unchanged page after a failed IdP trip.
   it('toasts a generic message for an unrecognized callback error code', async () => {
-    window.history.replaceState(null, '', '/settings/profile?error=some_new_code');
+    window.history.replaceState(null, '', '/settings/profile?ssoReauthError=some_new_code');
 
     render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
 
@@ -661,4 +667,85 @@ describe('ProfilePage — SSO re-authentication enrollment (#4018)', () => {
     await screen.findByTestId('mfa-setup-start');
     expect(showToastMock).not.toHaveBeenCalled();
   });
+
+  // The param was previously a bare `error`, read but never removed, on an
+  // effect that depended on `[t]`. showToast has no dedupe by design, so when
+  // react-i18next swapped `t`'s identity after its async resource load the user
+  // saw the SAME toast twice; and because the param stayed in the URL, every
+  // reload (or a shared link) re-toasted forever.
+  it('strips ssoReauthError from the URL so a reload cannot re-toast', async () => {
+    window.history.replaceState(null, '', '/settings/profile?ssoReauthError=reauth_not_fresh');
+
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledTimes(1));
+    expect(window.location.search).toBe('');
+  });
+
+  it('preserves other query params and the fragment when stripping its own', async () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/settings/profile?tab=security&ssoReauthError=session_invalid&ref=email#passkeys',
+    );
+
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledTimes(1));
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get('ssoReauthError')).toBeNull();
+    expect(params.get('tab')).toBe('security');
+    expect(params.get('ref')).toBe('email');
+    expect(window.location.hash).toBe('#passkeys');
+  });
+
+  // The param is namespaced for the same reason ConnectSsoCard's is: a bare
+  // `error` is a name any feature on this page could reasonably claim, and this
+  // handler would then toast SSO copy for something else entirely.
+  it('ignores a bare ?error= param that is not ours', async () => {
+    window.history.replaceState(null, '', '/settings/profile?error=reauth_not_fresh');
+
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+    await screen.findByTestId('mfa-setup-start');
+
+    expect(showToastMock).not.toHaveBeenCalled();
+    // And it is left alone — it belongs to whoever put it there.
+    expect(window.location.search).toBe('?error=reauth_not_fresh');
+  });
+
+  // ProfilePage's `if (ok)` guard on the mount-time /mfa/setup call. Without it
+  // an unconditional setSsoSetupReady(true) still passed every other test in
+  // this file, and production would open a QR view with no QR in it.
+  it('stays on the status card when the grant-backed /auth/mfa/setup fails', async () => {
+    window.history.replaceState(null, '', '/settings/profile#ssoReauthGrant=grant-abc');
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+      if (String(url) === '/auth/mfa/setup') {
+        return makeJsonResponse({ error: 'Invalid credentials' }, false, 401);
+      }
+      return undefined as unknown as Response;
+    });
+
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+
+    // Wait on the error banner, which the SAME .then chain sets. Anything that
+    // flipped the view would have flipped it by now, so the assertion below is
+    // not a race: dropping the `if (ok)` makes this test fail rather than pass
+    // on ordering luck.
+    await screen.findByText('Invalid credentials');
+
+    // The retry affordance lives on the status card, so that is where the user
+    // must stay — and the QR view must NOT open with an empty frame in it.
+    expect(screen.getByTestId('mfa-setup-start')).toBeTruthy();
+    expect(screen.queryByText(/Set up authenticator/i)).toBeNull();
+    expect(screen.queryByText(/QR code unavailable/i)).toBeNull();
+  });
+
+  // NOTE: the "grant lost" dead end (review finding 7) is NOT reachable from
+  // this component today, so it is pinned in MFASettings.test.tsx instead where
+  // the state combination is directly expressible. ProfilePage sets
+  // `ssoSetupReady` and `ssoReauthGrantId` in the SAME mount effect and clears
+  // them together, and the passwordless confirm view's only action is a
+  // full-page navigation to the IdP — so a reload drops the user on the status
+  // card rather than on a QR screen with a dead Verify button. See the report.
 });

--- a/apps/web/src/components/settings/ProfilePage.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.test.tsx
@@ -14,6 +14,13 @@ vi.mock('../../stores/auth', () => ({
   )
 }));
 
+// #4018: the SSO re-auth callback's `?error=` codes surface as toasts, and
+// runAction toasts its own failures. Mocked here (this component and runAction
+// resolve to the SAME Toast module) so the assertions are on the call rather
+// than on a container these tests never mount.
+const { showToastMock } = vi.hoisted(() => ({ showToastMock: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: showToastMock }));
+
 // The avatar blob hook fetches /api/v1/users/<id>/avatar through fetchWithAuth
 // when an avatarUrl is present. The tests below are about the upload/delete
 // flow on /users/me/avatar; mocking the hook keeps the fetch mock consumption
@@ -447,5 +454,211 @@ describe('ProfilePage MFA setup', () => {
     const [, init] = setupCall!;
     expect(init?.method).toBe('POST');
     expect(JSON.parse(String(init?.body))).toEqual({ currentPassword: 'hunter2-pw' });
+  });
+});
+
+// ── #4018: MFA enrollment for a PASSWORDLESS, SSO-provisioned account ────────
+// Such an account cannot satisfy the password step-up the enrollment endpoints
+// normally demand, so it proves identity with a fresh, forced IdP round-trip
+// and hands the resulting grant to /auth/mfa/setup and /auth/mfa/enable.
+describe('ProfilePage — SSO re-authentication enrollment (#4018)', () => {
+  const BASE_USER = {
+    id: 'user-1',
+    name: 'Casey Admin',
+    email: 'casey@example.com',
+    mfaEnabled: false,
+  };
+
+  const realLocation = window.location;
+
+  function restoreLocation() {
+    Object.defineProperty(window, 'location', { configurable: true, value: realLocation });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restoreLocation();
+    // Real jsdom location + history so the hash-consumption assertions below
+    // exercise the actual replaceState behaviour rather than a stub's.
+    window.history.replaceState(null, '', '/settings/profile');
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') {
+        return makeJsonResponse({ passkeys: [] });
+      }
+      if (String(url) === '/auth/mfa/setup') {
+        return makeJsonResponse({ qrCodeDataUrl: 'data:image/png;base64,abc' });
+      }
+      return undefined as unknown as Response;
+    });
+  });
+
+  it('offers the IdP verification button instead of the password prompt for a passwordless account', async () => {
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+
+    fireEvent.click(screen.getByTestId('mfa-setup-start'));
+
+    expect(await screen.findByTestId('mfa-sso-reauth')).toBeTruthy();
+    expect(screen.getByTestId('mfa-sso-reauth').textContent)
+      .toContain('Verify with your identity provider');
+    expect(screen.queryByTestId('mfa-current-password')).toBeNull();
+  });
+
+  it('keeps the password prompt for an account that has a password', async () => {
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: true }} />);
+
+    fireEvent.click(screen.getByTestId('mfa-setup-start'));
+
+    expect(await screen.findByTestId('mfa-current-password')).toBeTruthy();
+    expect(screen.queryByTestId('mfa-sso-reauth')).toBeNull();
+  });
+
+  // Absent is UNKNOWN, not "passwordless": a session persisted before
+  // /users/me carried the field must keep the road the server will accept.
+  it('keeps the password prompt when hasPassword is absent', async () => {
+    render(<ProfilePage initialUser={{ ...BASE_USER }} />);
+
+    fireEvent.click(screen.getByTestId('mfa-setup-start'));
+
+    expect(await screen.findByTestId('mfa-current-password')).toBeTruthy();
+    expect(screen.queryByTestId('mfa-sso-reauth')).toBeNull();
+  });
+
+  it('POSTs /sso/reauth/start and navigates to the returned authUrl', async () => {
+    const assignMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        assign: assignMock,
+        hash: '',
+        search: '',
+        pathname: '/settings/profile',
+        href: 'http://localhost/settings/profile',
+      },
+    });
+
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+      if (String(url) === '/sso/reauth/start') {
+        return makeJsonResponse({ authUrl: 'https://idp.example.com/authorize?prompt=login' });
+      }
+      return undefined as unknown as Response;
+    });
+
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+    fireEvent.click(screen.getByTestId('mfa-setup-start'));
+    fireEvent.click(await screen.findByTestId('mfa-sso-reauth'));
+
+    await waitFor(() => {
+      expect(assignMock).toHaveBeenCalledWith('https://idp.example.com/authorize?prompt=login');
+    });
+
+    const startCall = fetchWithAuthMock.mock.calls.find(
+      ([url]) => String(url) === '/sso/reauth/start'
+    );
+    expect(startCall).toBeDefined();
+    expect(startCall![1]?.method).toBe('POST');
+
+    restoreLocation();
+  });
+
+  it('consumes the #ssoReauthGrant fragment, calls /auth/mfa/setup with it, and clears the hash', async () => {
+    window.history.replaceState(null, '', '/settings/profile#ssoReauthGrant=grant-abc');
+    expect(window.location.hash).toBe('#ssoReauthGrant=grant-abc');
+
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+
+    await waitFor(() => {
+      const setupCall = fetchWithAuthMock.mock.calls.find(
+        ([url]) => String(url) === '/auth/mfa/setup'
+      );
+      expect(setupCall).toBeDefined();
+      expect(JSON.parse(String(setupCall![1]?.body))).toEqual({ ssoReauthGrantId: 'grant-abc' });
+    });
+
+    // The grant is single-use — leaving it in the address bar invites a
+    // confusing second attempt after it has already been consumed.
+    expect(window.location.hash).toBe('');
+    // And the user lands straight on the QR screen; re-prompting for a proof
+    // already spent on this page load would be a dead end.
+    await screen.findByText(/Set up authenticator/i);
+  });
+
+  it('sends the grant, not a password, on the terminal /auth/mfa/enable write', async () => {
+    window.history.replaceState(null, '', '/settings/profile#ssoReauthGrant=grant-abc');
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+      if (String(url) === '/auth/mfa/setup') {
+        return makeJsonResponse({ qrCodeDataUrl: 'data:image/png;base64,abc' });
+      }
+      if (String(url) === '/auth/mfa/enable') {
+        return makeJsonResponse({ recoveryCodes: ['AAAA-BBBB'] });
+      }
+      return undefined as unknown as Response;
+    });
+
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+    await screen.findByText(/Set up authenticator/i);
+
+    const digitInputs = document.querySelectorAll<HTMLInputElement>('input[inputmode="numeric"]');
+    expect(digitInputs.length).toBe(6);
+    digitInputs.forEach((input, index) => {
+      fireEvent.change(input, { target: { value: String(index + 1) } });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Verify and enable/i }));
+
+    await waitFor(() => {
+      const enableCall = fetchWithAuthMock.mock.calls.find(
+        ([url]) => String(url) === '/auth/mfa/enable'
+      );
+      expect(enableCall).toBeDefined();
+      expect(JSON.parse(String(enableCall![1]?.body)))
+        .toEqual({ code: '123456', ssoReauthGrantId: 'grant-abc' });
+    });
+  });
+
+  it('toasts actionable copy for the reauth_not_fresh callback error', async () => {
+    window.history.replaceState(null, '', '/settings/profile?error=reauth_not_fresh');
+
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalled());
+    expect(showToastMock).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'Your identity provider did not re-verify your sign-in. Try again, or ask your administrator to allow re-authentication prompts.',
+    });
+  });
+
+  it.each([
+    ['identity_mismatch', 'not the one linked to this profile'],
+    ['session_invalid', 'Your session changed while you were verifying'],
+    ['password_set', 'This account now has a password'],
+    ['reauth_unavailable', 'temporarily unavailable'],
+  ])('toasts a specific message for the %s callback error', async (code, fragment) => {
+    window.history.replaceState(null, '', `/settings/profile?error=${code}`);
+
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalled());
+    expect(showToastMock.mock.calls[0][0].type).toBe('error');
+    expect(showToastMock.mock.calls[0][0].message).toContain(fragment);
+  });
+
+  // A code this build doesn't know must still say something — silence here
+  // leaves the user staring at an unchanged page after a failed IdP trip.
+  it('toasts a generic message for an unrecognized callback error code', async () => {
+    window.history.replaceState(null, '', '/settings/profile?error=some_new_code');
+
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalled());
+    expect(showToastMock.mock.calls[0][0].message)
+      .toBe('Could not verify with your identity provider. Please try again.');
+  });
+
+  it('stays silent when there is no callback error', async () => {
+    render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+    await screen.findByTestId('mfa-setup-start');
+    expect(showToastMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -40,8 +40,14 @@ type User = {
 };
 
 // Typed reason codes the SSO re-auth callback redirects back with
-// (`/settings/profile?error=<code>`). Anything not listed falls back to the
-// generic copy — the server is free to add codes without this going silent.
+// (`/settings/profile?ssoReauthError=<code>`). Anything not listed falls back
+// to the generic copy — the server is free to add codes without this going
+// silent.
+//
+// NAMESPACED, matching ConnectSsoCard's `ssoLinkError`. A bare `error` param is
+// a name every other feature on this page could reasonably claim, and this
+// handler would toast SSO copy for any of them.
+const SSO_REAUTH_ERROR_PARAM = 'ssoReauthError';
 const SSO_REAUTH_ERROR_KEYS: Record<string, string> = {
   // The IdP answered without honouring prompt=login / max_age=0, so nothing was
   // actually re-verified. This is the one an admin can fix, so it says so.
@@ -50,7 +56,36 @@ const SSO_REAUTH_ERROR_KEYS: Record<string, string> = {
   session_invalid: 'profilePage.ssoReauthSessionInvalid',
   password_set: 'profilePage.ssoReauthPasswordSet',
   reauth_unavailable: 'profilePage.ssoReauthUnavailable',
+  // Reached when the provider is disabled, or its config_version is bumped by
+  // an admin edit mid-flight — both now land here instead of on /login.
+  provider_inactive: 'profilePage.ssoReauthProviderInactive',
+  config_changed: 'profilePage.ssoReauthConfigChanged',
+  email_unverified: 'profilePage.ssoReauthEmailUnverified',
 };
+
+/** Reads and CONSUMES `?ssoReauthError=<code>` from the query string.
+ *
+ *  Stripping is not cosmetic: `showToast` has no dedupe by design, so a handler
+ *  that leaves the param in place re-toasts on every reload and on every shared
+ *  link — and, because react-i18next swaps `t`'s identity once its resources
+ *  finish loading, fires TWICE on a single page load. Consuming the param makes
+ *  the effect idempotent regardless of how often it runs. Same pattern as
+ *  M365MailboxCard's `ticketMailbox`. The fragment and every other query param
+ *  are preserved — only ours is removed. */
+function takeSsoReauthErrorFromQuery(): string | null {
+  if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get(SSO_REAUTH_ERROR_PARAM);
+  if (!code) return null;
+  params.delete(SSO_REAUTH_ERROR_PARAM);
+  const qs = params.toString();
+  window.history.replaceState(
+    null,
+    '',
+    `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`,
+  );
+  return code;
+}
 
 /** Reads and CONSUMES the `#ssoReauthGrant=<id>` fragment the SSO callback
  *  redirects back with. The grant is single-use, so the fragment is stripped in
@@ -462,10 +497,16 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
     // a second /mfa/setup call for nothing.
   }, []);
 
-  // Surface the callback's failure codes (`/settings/profile?error=<code>`).
+  // Surface the callback's failure codes
+  // (`/settings/profile?ssoReauthError=<code>`), exactly once.
+  //
+  // Mount-only, and the param is consumed as it is read. Both matter: this used
+  // to depend on `[t]`, and react-i18next hands back a NEW `t` identity once its
+  // resources finish loading async, so the effect re-ran and — showToast having
+  // no dedupe — the user saw the same error toast twice. Leaving the param in
+  // the URL also re-toasted on every reload, forever.
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const code = new URLSearchParams(window.location.search).get('error');
+    const code = takeSsoReauthErrorFromQuery();
     if (!code) return;
     const key = SSO_REAUTH_ERROR_KEYS[code];
     // An unrecognized code must still say SOMETHING — a silent no-op here would
@@ -474,7 +515,10 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       type: 'error',
       message: key ? t(/* i18n-dynamic */ key) : t('profilePage.ssoReauthFailed'),
     });
-  }, [t]);
+    // Empty deps ON PURPOSE — see above. `t` is read at first render, which is
+    // the correct language for a toast fired at mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleSsoReauthStart = async () => {
     setMfaError(undefined);
@@ -507,6 +551,14 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
     try {
       setMfaLoading(true);
       // Mirror the setup call: send whichever proof this account actually has.
+      // A passwordless account with no grant left has NOTHING to send, and the
+      // server answers `enrollment_proof_required`. MFASettings withholds the
+      // submit in that state (it shows the IdP re-verify CTA instead), so this
+      // is the belt-and-braces half of the same rule.
+      if (!currentPassword && !ssoReauthGrantId && user?.hasPassword === false) {
+        setMfaError(t('profilePage.ssoReauthProofExpired'));
+        return;
+      }
       const proof = currentPassword
         ? { currentPassword }
         : ssoReauthGrantId
@@ -877,6 +929,7 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
         hasPassword={user?.hasPassword}
         onSsoReauth={handleSsoReauthStart}
         ssoSetupReady={ssoSetupReady}
+        ssoReauthGrantAvailable={ssoReauthGrantId !== null}
         qrCodeDataUrl={qrCodeDataUrl}
         recoveryCodes={recoveryCodes}
         onRequestSetup={handleMfaRequestSetup}

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -477,6 +477,18 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
   const handleMfaRequestSetup = (currentPassword: string): Promise<boolean> =>
     requestMfaSetup({ currentPassword });
 
+  // #4018, ONE source of truth for both enrollment roads on this page (TOTP via
+  // MFASettings, passkeys via the card below). `undefined` is UNKNOWN — a
+  // session persisted before /users/me carried the field — and must keep the
+  // password road, which is the fail-safe direction: the server rejects a wrong
+  // password, whereas wrongly hiding the prompt strands a password user.
+  const isPasswordless = user?.hasPassword === false;
+  // The grant is minted by the SSO re-auth callback and held only here. Both
+  // register/options (validate, non-consuming) and register/verify (consume)
+  // take the SAME id, so one IdP round-trip installs exactly one factor —
+  // whichever road spends it first.
+  const hasSsoReauthGrant = ssoReauthGrantId !== null;
+
   // Consume an `#ssoReauthGrant=<id>` handed back by the SSO callback: the user
   // has just re-proved their identity at the IdP, so run /mfa/setup with the
   // grant and drop them straight on the QR screen. Mount-only by design — the
@@ -555,7 +567,7 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       // server answers `enrollment_proof_required`. MFASettings withholds the
       // submit in that state (it shows the IdP re-verify CTA instead), so this
       // is the belt-and-braces half of the same rule.
-      if (!currentPassword && !ssoReauthGrantId && user?.hasPassword === false) {
+      if (!currentPassword && !ssoReauthGrantId && isPasswordless) {
         setMfaError(t('profilePage.ssoReauthProofExpired'));
         return;
       }
@@ -646,15 +658,44 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
   };
 
   const handleAddPasskey = async () => {
-    if (!passkeyPassword || isAddingPasskey) return;
+    if (isAddingPasskey) return;
+    // #4018: a passwordless SSO account proves identity with a fresh forced IdP
+    // round-trip instead of a password it does not have. Without this the
+    // handler hard-returned on `!passkeyPassword` and a passwordless user could
+    // never register a passkey at all — the exact dead end this feature exists
+    // to remove, with the API side already accepting the grant and no caller.
+    if (isPasswordless) {
+      if (!ssoReauthGrantId) {
+        // Belt-and-braces: the card renders the re-verify CTA instead of a
+        // submit in this state, so this is only reachable programmatically.
+        setPasskeyError(t('profilePage.passkeyIdpVerificationRequired'));
+        return;
+      }
+    } else if (!passkeyPassword) {
+      return;
+    }
     setPasskeyError(undefined);
     setPasskeySuccess(undefined);
     try {
       setIsAddingPasskey(true);
       const label = passkeyName.trim() || 'Passkey';
+      // The SAME grant id goes to BOTH calls: register/options only VALIDATES
+      // it, register/verify CONSUMES it. Minting a second grant in between
+      // would fail the consume — each is bound to the epochs + sid captured at
+      // mint time — and burn the user's round trip for nothing.
+      //
+      // The password road is deliberately asymmetric: it proves itself ONCE at
+      // register/options. registerVerifySchema carries no password field at all
+      // (the server calls resolveEnrollmentStepUp there with
+      // `passwordAlreadyProven`), so re-sending the plaintext password would be
+      // a second exposure buying nothing.
+      const optionsProof = isPasswordless
+        ? { ssoReauthGrantId }
+        : { currentPassword: passkeyPassword };
+      const verifyProof = isPasswordless ? { ssoReauthGrantId } : {};
       const optionsResponse = await fetchWithAuth('/auth/passkeys/register/options', {
         method: 'POST',
-        body: JSON.stringify({ currentPassword: passkeyPassword, name: label })
+        body: JSON.stringify({ ...optionsProof, name: label })
       });
 
       const optionsData = await optionsResponse.json().catch(() => ({}));
@@ -668,7 +709,7 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       const credential = await createPasskeyCredential(optionsJSON);
       const verifyResponse = await fetchWithAuth('/auth/passkeys/register/verify', {
         method: 'POST',
-        body: JSON.stringify({ name: label, credential })
+        body: JSON.stringify({ name: label, credential, ...verifyProof })
       });
 
       const verifyData = await verifyResponse.json().catch(() => ({}));
@@ -681,6 +722,11 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       setUser(prev => (prev ? { ...prev, mfaEnabled: true } : null));
       setPasskeyName('');
       setPasskeyPassword('');
+      // register/verify is the terminal write that BURNS the grant. Drop it so
+      // a later action on this page can't retry with a proof the server has
+      // already spent — same rule as the TOTP terminal write.
+      setSsoReauthGrantId(null);
+      setSsoSetupReady(false);
       if (Array.isArray(verifyData.recoveryCodes)) {
         setRecoveryCodes(verifyData.recoveryCodes);
       }
@@ -929,7 +975,7 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
         hasPassword={user?.hasPassword}
         onSsoReauth={handleSsoReauthStart}
         ssoSetupReady={ssoSetupReady}
-        ssoReauthGrantAvailable={ssoReauthGrantId !== null}
+        ssoReauthGrantAvailable={hasSsoReauthGrant}
         qrCodeDataUrl={qrCodeDataUrl}
         recoveryCodes={recoveryCodes}
         onRequestSetup={handleMfaRequestSetup}
@@ -1037,7 +1083,9 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
           <div className="space-y-1">
             <h3 className="text-sm font-medium">{t('profilePage.addPasskey')}</h3>
             <p className="text-xs text-muted-foreground">
-              {t('profilePage.reEnterYourAccountPasswordBeforeAddingOrDeletingAPasskey')}</p>
+              {isPasswordless
+                ? t('profilePage.thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey')
+                : t('profilePage.reEnterYourAccountPasswordBeforeAddingOrDeletingAPasskey')}</p>
           </div>
           <div className="space-y-2">
             <label className="text-sm font-medium" htmlFor="passkey-name">
@@ -1052,27 +1100,44 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
               disabled={isAddingPasskey}
             />
           </div>
-          <div className="space-y-2">
-            <label className="text-sm font-medium" htmlFor="passkey-password">
-              {t('profilePage.currentPassword')}</label>
-            <input
-              id="passkey-password"
-              type="password"
-              autoComplete="current-password"
-              value={passkeyPassword}
-              onChange={event => setPasskeyPassword(event.target.value)}
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              disabled={isAddingPasskey}
-            />
-          </div>
-          <button
-            type="button"
-            onClick={handleAddPasskey}
-            disabled={isAddingPasskey || !passkeyPassword}
-            className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isAddingPasskey ? t('profilePage.adding') : t('profilePage.addPasskey')}
-          </button>
+          {/* #4018: no password field for an account that has no password —
+              the proof is a fresh IdP round-trip instead. */}
+          {!isPasswordless && (
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="passkey-password">
+                {t('profilePage.currentPassword')}</label>
+              <input
+                id="passkey-password"
+                type="password"
+                autoComplete="current-password"
+                value={passkeyPassword}
+                onChange={event => setPasskeyPassword(event.target.value)}
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                disabled={isAddingPasskey}
+              />
+            </div>
+          )}
+          {isPasswordless && !hasSsoReauthGrant ? (
+            <button
+              type="button"
+              data-testid="passkey-sso-reauth"
+              onClick={() => { void handleSsoReauthStart(); }}
+              disabled={isAddingPasskey || isStartingSsoReauth}
+              className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {t('profilePage.verifyWithYourIdentityProvider')}
+            </button>
+          ) : (
+            <button
+              type="button"
+              data-testid="passkey-add"
+              onClick={handleAddPasskey}
+              disabled={isAddingPasskey || (!isPasswordless && !passkeyPassword)}
+              className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isAddingPasskey ? t('profilePage.adding') : t('profilePage.addPasskey')}
+            </button>
+          )}
         </div>
 
         {passkeySuccess && (

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -16,6 +16,8 @@ import type { PasskeyRegistrationOptions, UserPreferences } from '../../stores/a
 import { navigateTo } from '@/lib/navigation';
 import { useAvatarBlobUrl } from '@/lib/avatarBlobCache';
 import { formatNumber } from '@/lib/i18n/format';
+import { runAction } from '@/lib/runAction';
+import { showToast } from '../shared/Toast';
 
 const createProfileSchema = (t: TFunction) => z.object({
   name: z.string().min(2, t('profilePage.nameMustBeAtLeast2Characters')),
@@ -30,8 +32,40 @@ type User = {
   avatarUrl?: string;
   mfaEnabled?: boolean;
   mfaMethod?: string | null;
+  // #4018: surfaced by GET /users/me. `false` means an SSO-provisioned account
+  // with no password, which cannot satisfy the password step-up the MFA
+  // enrollment endpoints normally demand. Absent = unknown → password road.
+  hasPassword?: boolean;
   preferences?: UserPreferences;
 };
+
+// Typed reason codes the SSO re-auth callback redirects back with
+// (`/settings/profile?error=<code>`). Anything not listed falls back to the
+// generic copy — the server is free to add codes without this going silent.
+const SSO_REAUTH_ERROR_KEYS: Record<string, string> = {
+  // The IdP answered without honouring prompt=login / max_age=0, so nothing was
+  // actually re-verified. This is the one an admin can fix, so it says so.
+  reauth_not_fresh: 'profilePage.ssoReauthNotFresh',
+  identity_mismatch: 'profilePage.ssoReauthIdentityMismatch',
+  session_invalid: 'profilePage.ssoReauthSessionInvalid',
+  password_set: 'profilePage.ssoReauthPasswordSet',
+  reauth_unavailable: 'profilePage.ssoReauthUnavailable',
+};
+
+/** Reads and CONSUMES the `#ssoReauthGrant=<id>` fragment the SSO callback
+ *  redirects back with. The grant is single-use, so the fragment is stripped in
+ *  the same tick it is read: leaving it in the address bar invites a confusing
+ *  second attempt against a proof that has already been spent (a reload would
+ *  replay it and fail). The query string is preserved — only the fragment is
+ *  ours to clear. */
+function takeSsoReauthGrantFromHash(): string | null {
+  if (typeof window === 'undefined') return null;
+  const match = /^#ssoReauthGrant=(.+)$/.exec(window.location.hash);
+  if (!match) return null;
+  const grantId = decodeURIComponent(match[1]);
+  window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`);
+  return grantId;
+}
 
 type PasskeySummary = {
   id: string;
@@ -86,6 +120,13 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
   const [isUpdatingProfile, setIsUpdatingProfile] = useState(false);
   const [isChangingPassword, setIsChangingPassword] = useState(false);
   const [mfaLoading, setMfaLoading] = useState(false);
+  // #4018: the SSO re-auth grant picked up from the redirect fragment. Held for
+  // the rest of the enrollment flow because /mfa/setup consumes it
+  // non-destructively and the terminal /mfa/enable burns it — one IdP
+  // round-trip covers both calls.
+  const [ssoReauthGrantId, setSsoReauthGrantId] = useState<string | null>(null);
+  const [ssoSetupReady, setSsoSetupReady] = useState(false);
+  const [isStartingSsoReauth, setIsStartingSsoReauth] = useState(false);
 
   // Avatar upload state
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
@@ -363,33 +404,100 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
     }
   };
 
-  const handleMfaRequestSetup = async (currentPassword: string): Promise<boolean> => {
+  // The enrollment endpoints accept EITHER proof (#4018): a password, or an
+  // SSO re-auth grant for an account that has no password. Exactly one is sent.
+  const requestMfaSetup = useCallback(
+    async (proof: { currentPassword: string } | { ssoReauthGrantId: string }): Promise<boolean> => {
+      setMfaError(undefined);
+      setMfaSuccess(undefined);
+      // Clear any QR code from a prior aborted attempt before issuing a new one.
+      setQrCodeDataUrl(undefined);
+      try {
+        setMfaLoading(true);
+        const response = await fetchWithAuth('/auth/mfa/setup', {
+          method: 'POST',
+          body: JSON.stringify(proof)
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(
+            errorData.error ?? errorData.message ?? t('profilePage.failedToStartMfaHttp', { status: response.status })
+          );
+        }
+
+        const data = await response.json();
+        setQrCodeDataUrl(data.qrCodeDataUrl);
+        return true;
+      } catch (error) {
+        setMfaError(error instanceof Error ? error.message : t('profilePage.failedToStartMFASetup'));
+        return false;
+      } finally {
+        setMfaLoading(false);
+      }
+    },
+    [t]
+  );
+
+  const handleMfaRequestSetup = (currentPassword: string): Promise<boolean> =>
+    requestMfaSetup({ currentPassword });
+
+  // Consume an `#ssoReauthGrant=<id>` handed back by the SSO callback: the user
+  // has just re-proved their identity at the IdP, so run /mfa/setup with the
+  // grant and drop them straight on the QR screen. Mount-only by design — the
+  // fragment is stripped as it is read, so this can never fire twice.
+  useEffect(() => {
+    const grantId = takeSsoReauthGrantFromHash();
+    if (!grantId) return;
+    setSsoReauthGrantId(grantId);
+    void requestMfaSetup({ ssoReauthGrantId: grantId }).then((ok) => {
+      // Only open the QR view when the server actually issued a secret. On
+      // failure the error banner is already set and the user stays on the
+      // status card, which is where the retry button lives.
+      if (ok) setSsoSetupReady(true);
+    });
+    // Empty deps ON PURPOSE: `requestMfaSetup` is deliberately excluded so a
+    // re-created callback identity can never re-fire this. It is safe either
+    // way — the fragment is stripped as it is read — but re-running would burn
+    // a second /mfa/setup call for nothing.
+  }, []);
+
+  // Surface the callback's failure codes (`/settings/profile?error=<code>`).
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const code = new URLSearchParams(window.location.search).get('error');
+    if (!code) return;
+    const key = SSO_REAUTH_ERROR_KEYS[code];
+    // An unrecognized code must still say SOMETHING — a silent no-op here would
+    // leave the user staring at an unchanged page after a failed IdP trip.
+    showToast({
+      type: 'error',
+      message: key ? t(/* i18n-dynamic */ key) : t('profilePage.ssoReauthFailed'),
+    });
+  }, [t]);
+
+  const handleSsoReauthStart = async () => {
     setMfaError(undefined);
     setMfaSuccess(undefined);
-    // Clear any QR code from a prior aborted attempt before issuing a new one.
-    setQrCodeDataUrl(undefined);
+    setIsStartingSsoReauth(true);
     try {
-      setMfaLoading(true);
-      const response = await fetchWithAuth('/auth/mfa/setup', {
-        method: 'POST',
-        body: JSON.stringify({ currentPassword })
+      const body = await runAction<{ authUrl: string }>({
+        request: () => fetchWithAuth('/sso/reauth/start', { method: 'POST' }),
+        errorFallback: t('profilePage.couldNotStartIdentityProviderVerification'),
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(
-          errorData.error ?? errorData.message ?? t('profilePage.failedToStartMfaHttp', { status: response.status })
-        );
+      if (body?.authUrl) {
+        // External IdP URL — a full-page navigation, not the SPA router (which
+        // rejects an off-origin path as an open redirect).
+        window.location.assign(body.authUrl);
+        return;
       }
-
-      const data = await response.json();
-      setQrCodeDataUrl(data.qrCodeDataUrl);
-      return true;
-    } catch (error) {
-      setMfaError(error instanceof Error ? error.message : t('profilePage.failedToStartMFASetup'));
-      return false;
-    } finally {
-      setMfaLoading(false);
+      // 200 with no authUrl: nothing to navigate to, and runAction saw a
+      // success. Say so rather than leaving the button spinning silently.
+      showToast({ type: 'error', message: t('profilePage.couldNotStartIdentityProviderVerification') });
+      setIsStartingSsoReauth(false);
+    } catch {
+      // runAction already toasted the failure.
+      setIsStartingSsoReauth(false);
     }
   };
 
@@ -398,9 +506,15 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
     setMfaSuccess(undefined);
     try {
       setMfaLoading(true);
+      // Mirror the setup call: send whichever proof this account actually has.
+      const proof = currentPassword
+        ? { currentPassword }
+        : ssoReauthGrantId
+          ? { ssoReauthGrantId }
+          : {};
       const response = await fetchWithAuth('/auth/mfa/enable', {
         method: 'POST',
-        body: JSON.stringify({ code, currentPassword })
+        body: JSON.stringify({ code, ...proof })
       });
 
       if (!response.ok) {
@@ -415,6 +529,11 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       setRecoveryCodes(data.recoveryCodes);
       setMfaSuccess(t('profilePage.multiFactorAuthenticationEnabledSuccessfully'));
       setQrCodeDataUrl(undefined);
+      // /mfa/enable is the terminal write that BURNS the grant. Drop it so a
+      // later action on this page can't retry with a proof the server has
+      // already spent.
+      setSsoReauthGrantId(null);
+      setSsoSetupReady(false);
     } catch (error) {
       setMfaError(error instanceof Error ? error.message : t('profilePage.failedToEnableMFA'));
     } finally {
@@ -755,6 +874,9 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       {/* MFA Settings */}
       <MFASettings
         enabled={user?.mfaEnabled ?? false}
+        hasPassword={user?.hasPassword}
+        onSsoReauth={handleSsoReauthStart}
+        ssoSetupReady={ssoSetupReady}
         qrCodeDataUrl={qrCodeDataUrl}
         recoveryCodes={recoveryCodes}
         onRequestSetup={handleMfaRequestSetup}
@@ -763,7 +885,7 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
         onGenerateRecoveryCodes={handleGenerateRecoveryCodes}
         errorMessage={mfaError}
         successMessage={mfaSuccess}
-        loading={mfaLoading}
+        loading={mfaLoading || isStartingSsoReauth}
       />
 
       {/* Connect SSO (self-service identity linking, #2183) */}

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -528,8 +528,10 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       message: key ? t(/* i18n-dynamic */ key) : t('profilePage.ssoReauthFailed'),
     });
     // Empty deps ON PURPOSE — see above. `t` is read at first render, which is
-    // the correct language for a toast fired at mount.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // the correct language for a toast fired at mount. No eslint-disable here:
+    // this repo's web eslint config carries no react-hooks plugin, so a
+    // directive for `exhaustive-deps` is itself an error ("Definition for rule
+    // ... was not found") and fails the Lint job.
   }, []);
 
   const handleSsoReauthStart = async () => {

--- a/apps/web/src/components/settings/SsoProviderForm.tsx
+++ b/apps/web/src/components/settings/SsoProviderForm.tsx
@@ -29,7 +29,12 @@ const createSsoProviderSchema = (t: TFunction) => z.object({
   autoProvision: z.boolean(),
   defaultRoleId: z.string().optional(),
   allowedDomains: z.string().optional(),
-  enforceSSO: z.boolean()
+  enforceSSO: z.boolean(),
+  // #4018: whether Breeze accepts the IdP's own MFA assertion (`amr: mfa` in
+  // the id_token) as satisfying MFA-gated routes. Off by default — the API
+  // schemas (createProviderSchema/updateProviderSchema) already mark it
+  // optional and default it to false; this mirrors that on the client.
+  trustsIdpMfa: z.boolean()
 });
 
 export type SsoProviderFormValues = z.infer<ReturnType<typeof createSsoProviderSchema>>;
@@ -132,6 +137,7 @@ export default function SsoProviderForm({
       defaultRoleId: '',
       allowedDomains: '',
       enforceSSO: false,
+      trustsIdpMfa: false,
       ownerScope: 'organization',
       ...defaultValues
     }
@@ -470,6 +476,20 @@ export default function SsoProviderForm({
             </div>
           </label>
 
+          <label className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              data-testid="provider-trusts-idp-mfa"
+              className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
+              {...register('trustsIdpMfa')}
+            />
+            <div>
+              <span className="text-sm font-medium">{t('ssoProviderForm.trustThisProvidersMFA')}</span>
+              <p className="text-xs text-muted-foreground">
+                {t('ssoProviderForm.trustThisProvidersMFAHelperText')}</p>
+            </div>
+          </label>
+
           {enforceSSO && (
             <div className="rounded-md border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950">
               <div className="flex gap-3">
@@ -526,6 +546,7 @@ export default function SsoProviderForm({
             {t('ssoProviderForm.cancel')}</button>
           <button
             type="submit"
+            data-testid="provider-save"
             disabled={isLoading}
             className="flex h-11 w-full items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto sm:px-6"
           >

--- a/apps/web/src/components/settings/SsoProvidersPage.test.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.test.tsx
@@ -172,4 +172,72 @@ describe('SsoProvidersPage partner-axis behavior', () => {
       expect(body).not.toHaveProperty('ownerScope');
     });
   });
+
+  // #4018: sso_providers.trustsIdpMfa lets an org opt into treating the IdP's
+  // own MFA assertion as satisfying Breeze's MFA-gated routes. Off by default.
+  function routeEditableProvider(trustsIdpMfa: boolean) {
+    fetchWithAuth.mockImplementation((url: string, opts?: { method?: string }) => {
+      if (url === '/sso/providers') return Promise.resolve(jsonRes({ data: [PARTNER_PROVIDER] }));
+      if (url === '/sso/providers?scope=partner') return Promise.resolve(jsonRes({ data: [] }));
+      if (url === '/sso/presets') return Promise.resolve(jsonRes({ data: [] }));
+      if (url === '/roles') return Promise.resolve(jsonRes({ data: [] }));
+      if (url === '/sso/providers/pp-1' && (!opts || !opts.method)) {
+        return Promise.resolve(
+          jsonRes({
+            data: {
+              name: 'Team Login',
+              type: 'oidc',
+              preset: '',
+              issuer: 'https://idp.example.com',
+              clientId: 'client-1',
+              scopes: 'openid profile email',
+              attributeMapping: { email: 'email', name: 'name' },
+              autoProvision: true,
+              defaultRoleId: '',
+              allowedDomains: '',
+              enforceSSO: false,
+              trustsIdpMfa,
+              hasClientSecret: true,
+            },
+          })
+        );
+      }
+      if (url === '/sso/providers/pp-1' && opts?.method === 'PATCH') {
+        return Promise.resolve(jsonRes({ data: PARTNER_PROVIDER }));
+      }
+      return Promise.resolve(jsonRes({ data: [] }));
+    });
+  }
+
+  it('renders the trust-IdP-MFA toggle reflecting the provider value', async () => {
+    routeEditableProvider(false);
+    render(<SsoProvidersPage />);
+
+    await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const toggle = await screen.findByTestId('provider-trusts-idp-mfa');
+    expect((toggle as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('PATCHes trustsIdpMfa when the toggle is turned on', async () => {
+    routeEditableProvider(false);
+    render(<SsoProvidersPage />);
+
+    await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const toggle = await screen.findByTestId('provider-trusts-idp-mfa');
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByTestId('provider-save'));
+
+    await waitFor(() => {
+      const patchCall = fetchWithAuth.mock.calls.find(
+        (c) => c[0] === '/sso/providers/pp-1' && (c[1] as { method?: string })?.method === 'PATCH'
+      );
+      expect(patchCall).toBeTruthy();
+      const body = JSON.parse((patchCall![1] as { body: string }).body);
+      expect(body.trustsIdpMfa).toBe(true);
+    });
+  });
 });

--- a/apps/web/src/components/settings/SsoProvidersPage.test.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.test.tsx
@@ -240,4 +240,43 @@ describe('SsoProvidersPage partner-axis behavior', () => {
       expect(body.trustsIdpMfa).toBe(true);
     });
   });
+
+  // The `false` cases above are indistinguishable from the form's own fallback
+  // (`selectedProviderDetails.trustsIdpMfa ?? false`), so deleting the mapping
+  // at SsoProvidersPage.tsx failed nothing. Only a `true` provider proves the
+  // stored value is actually threaded into the form — and getting this wrong is
+  // a SECURITY regression in the quiet direction: the toggle would read "off"
+  // for an org whose IdP MFA assertion is in fact being trusted.
+  it('reflects a provider that ALREADY trusts IdP MFA', async () => {
+    routeEditableProvider(true);
+    render(<SsoProvidersPage />);
+
+    await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const toggle = await screen.findByTestId('provider-trusts-idp-mfa');
+    expect((toggle as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('PATCHes trustsIdpMfa=false when an already-trusting provider is turned OFF', async () => {
+    routeEditableProvider(true);
+    render(<SsoProvidersPage />);
+
+    await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const toggle = await screen.findByTestId('provider-trusts-idp-mfa');
+    expect((toggle as HTMLInputElement).checked).toBe(true);
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByTestId('provider-save'));
+
+    await waitFor(() => {
+      const patchCall = fetchWithAuth.mock.calls.find(
+        (c) => c[0] === '/sso/providers/pp-1' && (c[1] as { method?: string })?.method === 'PATCH'
+      );
+      expect(patchCall).toBeTruthy();
+      const body = JSON.parse((patchCall![1] as { body: string }).body);
+      expect(body.trustsIdpMfa).toBe(false);
+    });
+  });
 });

--- a/apps/web/src/components/settings/SsoProvidersPage.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.tsx
@@ -394,7 +394,8 @@ export default function SsoProvidersPage() {
                       autoProvision: selectedProviderDetails.autoProvision ?? true,
                       defaultRoleId: selectedProviderDetails.defaultRoleId || '',
                       allowedDomains: selectedProviderDetails.allowedDomains || '',
-                      enforceSSO: selectedProviderDetails.enforceSSO ?? false
+                      enforceSSO: selectedProviderDetails.enforceSSO ?? false,
+                      trustsIdpMfa: selectedProviderDetails.trustsIdpMfa ?? false
                     }
                   : undefined
               }

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -111,7 +111,10 @@
     "expiryMinutes_one": "in etwa {{count}} Minute",
     "expiryMinutes_other": "in etwa {{count}} Minuten",
     "expiryHours_one": "in etwa {{count}} Stunde",
-    "expiryHours_other": "in etwa {{count}} Stunden"
+    "expiryHours_other": "in etwa {{count}} Stunden",
+    "mfaRequiredSsoLinks": "Zum Generieren von Links ist eine Multi-Faktor-Authentifizierung erforderlich. Ihre Organisation meldet Sie über einen Identitätsanbieter an – bitten Sie Ihren Administrator, MFA-Vertrauen dafür zu aktivieren, oder registrieren Sie einen Faktor in Ihren Profileinstellungen.",
+    "mfaRequiredSsoInstallers": "Zum Generieren von Installationsprogrammen ist eine Multi-Faktor-Authentifizierung erforderlich. Ihre Organisation meldet Sie über einen Identitätsanbieter an – bitten Sie Ihren Administrator, MFA-Vertrauen dafür zu aktivieren, oder registrieren Sie einen Faktor in Ihren Profileinstellungen.",
+    "mfaRequiredSsoTokens": "Zum Generieren von Installationstoken ist eine Multi-Faktor-Authentifizierung erforderlich. Ihre Organisation meldet Sie über einen Identitätsanbieter an – bitten Sie Ihren Administrator, MFA-Vertrauen dafür zu aktivieren, oder registrieren Sie einen Faktor in Ihren Profileinstellungen."
   },
   "changeSiteModal": {
     "failedToLoadSites": "Standorte konnten nicht geladen werden",

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -82,6 +82,7 @@
     "multiFactorAuthenticationIsRequiredTo": "Zum Generieren von Links ist eine Multi-Faktor-Authentifizierung erforderlich.",
     "setUpMfaInYourProfile": "MFA in den Profileinstellungen einrichten",
     "andSignInAgainThenRetry": "und erneut anmelden, anschließend wiederholen.",
+    "ssoMfaTrustGuidance": "Ihre Organisation meldet Sie über einen Identitätsanbieter an — bitten Sie Ihren Administrator, das MFA-Vertrauen dafür zu aktivieren, oder richten Sie einen Faktor in Ihren Profileinstellungen ein.",
     "retry": "Erneut versuchen",
     "multiFactorAuthenticationIsRequiredTo2": "Zum Generieren von Installern ist eine Multi-Faktor-Authentifizierung erforderlich.",
     "installerDownloadedRunItOn": "Installer heruntergeladen. Ausführen auf",

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -82,7 +82,6 @@
     "multiFactorAuthenticationIsRequiredTo": "Zum Generieren von Links ist eine Multi-Faktor-Authentifizierung erforderlich.",
     "setUpMfaInYourProfile": "MFA in den Profileinstellungen einrichten",
     "andSignInAgainThenRetry": "und erneut anmelden, anschließend wiederholen.",
-    "ssoMfaTrustGuidance": "Ihre Organisation meldet Sie über einen Identitätsanbieter an — bitten Sie Ihren Administrator, das MFA-Vertrauen dafür zu aktivieren, oder richten Sie einen Faktor in Ihren Profileinstellungen ein.",
     "retry": "Erneut versuchen",
     "multiFactorAuthenticationIsRequiredTo2": "Zum Generieren von Installern ist eine Multi-Faktor-Authentifizierung erforderlich.",
     "installerDownloadedRunItOn": "Installer heruntergeladen. Ausführen auf",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1959,6 +1959,9 @@
     "ssoReauthConfigChanged": "Ihre Single-Sign-on-Einstellungen haben sich während der Überprüfung geändert. Starten Sie die Überprüfung erneut.",
     "ssoReauthEmailUnverified": "Ihr Identitätsanbieter meldet, dass Ihre E-Mail-Adresse nicht bestätigt ist. Bestätigen Sie sie dort und versuchen Sie es erneut.",
     "ssoReauthProofExpired": "Ihre Überprüfung durch den Identitätsanbieter ist abgelaufen. Führen Sie sie erneut durch, um die Einrichtung der Multi-Faktor-Authentifizierung abzuschließen.",
+    "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Dieses Konto meldet sich über einen Identitätsanbieter an und hat kein Passwort. Bestätigen Sie sich erneut bei Ihrem Anbieter, bevor Sie einen Passkey hinzufügen.",
+    "verifyWithYourIdentityProvider": "Mit Ihrem Identitätsanbieter bestätigen",
+    "passkeyIdpVerificationRequired": "Bestätigen Sie sich bei Ihrem Identitätsanbieter, bevor Sie einen Passkey hinzufügen.",
     "ssoReauthFailed": "Die Bestätigung bei Ihrem Identitätsanbieter ist fehlgeschlagen. Bitte versuchen Sie es erneut.",
     "couldNotStartIdentityProviderVerification": "Die Überprüfung durch den Identitätsanbieter konnte nicht gestartet werden."
   },

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1858,7 +1858,10 @@
     "disabling": "Deaktivieren...",
     "generating": "Generieren...",
     "regenerateCodes": "Codes neu generieren",
-    "showRecoveryCodes": "Wiederherstellungscodes anzeigen"
+    "showRecoveryCodes": "Wiederherstellungscodes anzeigen",
+    "verifyYourIdentity": "Bestätigen Sie Ihre Identität",
+    "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Dieses Konto meldet sich über einen Identitätsanbieter an und hat kein Passwort. Bestätigen Sie sich erneut bei Ihrem Anbieter, um die Einrichtung einer Authenticator-App zu starten.",
+    "verifyWithYourIdentityProvider": "Mit Ihrem Identitätsanbieter bestätigen"
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Import aus Pax8",
@@ -1945,7 +1948,14 @@
     "failedToEnableMfaHttp": "Fehler beim Aktivieren von MFA (HTTP {{status}})",
     "failedToDisableMfaHttp": "MFA konnte nicht deaktiviert werden (HTTP {{status}})",
     "failedToStartPasskeyHttp": "Das Einrichten des Passkeys konnte nicht gestartet werden (HTTP {{status}})",
-    "failedToSavePasskeyHttp": "Passkey konnte nicht gespeichert werden (HTTP {{status}})"
+    "failedToSavePasskeyHttp": "Passkey konnte nicht gespeichert werden (HTTP {{status}})",
+    "ssoReauthNotFresh": "Ihr Identitätsanbieter hat Ihre Anmeldung nicht erneut überprüft. Versuchen Sie es erneut oder bitten Sie Ihren Administrator, Aufforderungen zur erneuten Authentifizierung zuzulassen.",
+    "ssoReauthIdentityMismatch": "Dieses Konto beim Identitätsanbieter ist nicht mit diesem Profil verknüpft. Melden Sie sich mit Ihrem eigenen Konto an und versuchen Sie es erneut.",
+    "ssoReauthSessionInvalid": "Ihre Sitzung hat sich während der Überprüfung geändert. Melden Sie sich erneut an und versuchen Sie es dann noch einmal.",
+    "ssoReauthPasswordSet": "Dieses Konto hat jetzt ein Passwort. Verwenden Sie es, um die Multi-Faktor-Authentifizierung einzurichten.",
+    "ssoReauthUnavailable": "Die Überprüfung durch den Identitätsanbieter ist vorübergehend nicht verfügbar. Bitte versuchen Sie es in Kürze erneut.",
+    "ssoReauthFailed": "Die Bestätigung bei Ihrem Identitätsanbieter ist fehlgeschlagen. Bitte versuchen Sie es erneut.",
+    "couldNotStartIdentityProviderVerification": "Die Überprüfung durch den Identitätsanbieter konnte nicht gestartet werden."
   },
   "roleManager": {
     "roles": "Rollen",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1861,7 +1861,8 @@
     "showRecoveryCodes": "Wiederherstellungscodes anzeigen",
     "verifyYourIdentity": "Bestätigen Sie Ihre Identität",
     "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Dieses Konto meldet sich über einen Identitätsanbieter an und hat kein Passwort. Bestätigen Sie sich erneut bei Ihrem Anbieter, um die Einrichtung einer Authenticator-App zu starten.",
-    "verifyWithYourIdentityProvider": "Mit Ihrem Identitätsanbieter bestätigen"
+    "verifyWithYourIdentityProvider": "Mit Ihrem Identitätsanbieter bestätigen",
+    "ssoReauthProofExpired": "Ihre Überprüfung durch den Identitätsanbieter ist abgelaufen. Führen Sie sie erneut durch, um die Einrichtung Ihrer Authenticator-App abzuschließen."
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Import aus Pax8",
@@ -1954,6 +1955,10 @@
     "ssoReauthSessionInvalid": "Ihre Sitzung hat sich während der Überprüfung geändert. Melden Sie sich erneut an und versuchen Sie es dann noch einmal.",
     "ssoReauthPasswordSet": "Dieses Konto hat jetzt ein Passwort. Verwenden Sie es, um die Multi-Faktor-Authentifizierung einzurichten.",
     "ssoReauthUnavailable": "Die Überprüfung durch den Identitätsanbieter ist vorübergehend nicht verfügbar. Bitte versuchen Sie es in Kürze erneut.",
+    "ssoReauthProviderInactive": "Single Sign-on ist für dieses Konto nicht mehr verfügbar. Wenden Sie sich an Ihren Administrator und versuchen Sie es erneut.",
+    "ssoReauthConfigChanged": "Ihre Single-Sign-on-Einstellungen haben sich während der Überprüfung geändert. Starten Sie die Überprüfung erneut.",
+    "ssoReauthEmailUnverified": "Ihr Identitätsanbieter meldet, dass Ihre E-Mail-Adresse nicht bestätigt ist. Bestätigen Sie sie dort und versuchen Sie es erneut.",
+    "ssoReauthProofExpired": "Ihre Überprüfung durch den Identitätsanbieter ist abgelaufen. Führen Sie sie erneut durch, um die Einrichtung der Multi-Faktor-Authentifizierung abzuschließen.",
     "ssoReauthFailed": "Die Bestätigung bei Ihrem Identitätsanbieter ist fehlgeschlagen. Bitte versuchen Sie es erneut.",
     "couldNotStartIdentityProviderVerification": "Die Überprüfung durch den Identitätsanbieter konnte nicht gestartet werden."
   },

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -2110,6 +2110,8 @@
     "securitySettings": "Sicherheitseinstellungen",
     "enforceSSOOnlyLogin": "Erzwingen Sie die Anmeldung nur für SSO",
     "usersMustUseSSOToSignInPasswordLoginWillBeDisabled": "Benutzer müssen SSO verwenden, um sich anzumelden. Die Passwortanmeldung wird deaktiviert.",
+    "trustThisProvidersMFA": "Diesem Anbieter bei MFA vertrauen",
+    "trustThisProvidersMFAHelperText": "Wenn Ihr Identitätsanbieter meldet, dass eine Multi-Faktor-Authentifizierung verwendet wurde (`amr: mfa`), wird MFA in Breeze als erfüllt betrachtet. Ihr IdP muss den Anspruch `amr` in seinem ID-Token enthalten — die meisten erfordern, dass dies ausdrücklich aktiviert wird. Standardmäßig deaktiviert.",
     "warningSSOEnforcementEnabled": "Warnung: Durchsetzung von SSO aktiviert",
     "usersWillNotBeAbleToSignInWithPasswordsMakeSureYourSSOCo": "Benutzer können sich nicht mit Passwörtern anmelden. Stellen Sie sicher, dass Ihre SSO-Konfiguration ordnungsgemäß funktioniert, bevor Sie diese Option aktivieren. Erwägen Sie, mindestens ein Administratorkonto zu haben, das SSO für den Notfallzugriff umgehen kann.",
     "testing": "Testen...",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -111,7 +111,10 @@
     "expiryMinutes_one": "in about {{count}} minute",
     "expiryMinutes_other": "in about {{count}} minutes",
     "expiryHours_one": "in about {{count}} hour",
-    "expiryHours_other": "in about {{count}} hours"
+    "expiryHours_other": "in about {{count}} hours",
+    "mfaRequiredSsoLinks": "Multi-factor authentication is required to generate links. Your organization signs you in through an identity provider — ask your administrator to enable MFA trust for it, or enroll a factor in your profile settings.",
+    "mfaRequiredSsoInstallers": "Multi-factor authentication is required to generate installers. Your organization signs you in through an identity provider — ask your administrator to enable MFA trust for it, or enroll a factor in your profile settings.",
+    "mfaRequiredSsoTokens": "Multi-factor authentication is required to generate installation tokens. Your organization signs you in through an identity provider — ask your administrator to enable MFA trust for it, or enroll a factor in your profile settings."
   },
   "changeSiteModal": {
     "failedToLoadSites": "Failed to load sites",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -82,6 +82,7 @@
     "multiFactorAuthenticationIsRequiredTo": "Multi-factor authentication is required to generate links.",
     "setUpMfaInYourProfile": "Set up MFA in your profile settings",
     "andSignInAgainThenRetry": "and sign in again, then retry.",
+    "ssoMfaTrustGuidance": "Your organization signs you in through an identity provider — ask your administrator to enable MFA trust for it, or enroll a factor in your profile settings.",
     "retry": "Retry",
     "multiFactorAuthenticationIsRequiredTo2": "Multi-factor authentication is required to generate installers.",
     "installerDownloadedRunItOn": "Installer downloaded. Run it on",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -82,7 +82,6 @@
     "multiFactorAuthenticationIsRequiredTo": "Multi-factor authentication is required to generate links.",
     "setUpMfaInYourProfile": "Set up MFA in your profile settings",
     "andSignInAgainThenRetry": "and sign in again, then retry.",
-    "ssoMfaTrustGuidance": "Your organization signs you in through an identity provider — ask your administrator to enable MFA trust for it, or enroll a factor in your profile settings.",
     "retry": "Retry",
     "multiFactorAuthenticationIsRequiredTo2": "Multi-factor authentication is required to generate installers.",
     "installerDownloadedRunItOn": "Installer downloaded. Run it on",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1959,6 +1959,9 @@
     "ssoReauthConfigChanged": "Your single sign-on settings changed while you were verifying. Start the verification again.",
     "ssoReauthEmailUnverified": "Your identity provider reports that your email address is not verified. Verify it there, then try again.",
     "ssoReauthProofExpired": "Your identity provider verification has expired. Verify again to finish setting up multi-factor authentication.",
+    "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "This account signs in through an identity provider and has no password. Re-verify with your provider before adding a passkey.",
+    "verifyWithYourIdentityProvider": "Verify with your identity provider",
+    "passkeyIdpVerificationRequired": "Verify with your identity provider before adding a passkey.",
     "ssoReauthFailed": "Could not verify with your identity provider. Please try again.",
     "couldNotStartIdentityProviderVerification": "Could not start identity provider verification."
   },

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -2110,6 +2110,8 @@
     "securitySettings": "Security Settings",
     "enforceSSOOnlyLogin": "Enforce SSO-only login",
     "usersMustUseSSOToSignInPasswordLoginWillBeDisabled": "Users must use SSO to sign in. Password login will be disabled.",
+    "trustThisProvidersMFA": "Trust this provider's MFA",
+    "trustThisProvidersMFAHelperText": "When your identity provider reports that multi-factor authentication was used (`amr: mfa`), treat MFA as satisfied in Breeze. Your IdP must include the `amr` claim in its ID token — most require this to be enabled explicitly. Off by default.",
     "warningSSOEnforcementEnabled": "Warning: SSO enforcement enabled",
     "usersWillNotBeAbleToSignInWithPasswordsMakeSureYourSSOCo": "Users will not be able to sign in with passwords. Make sure your SSO configuration is working correctly before enabling this option. Consider having at least one admin account that can bypass SSO for emergency access.",
     "testing": "Testing...",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1858,7 +1858,10 @@
     "disabling": "Disabling...",
     "generating": "Generating...",
     "regenerateCodes": "Regenerate codes",
-    "showRecoveryCodes": "Show recovery codes"
+    "showRecoveryCodes": "Show recovery codes",
+    "verifyYourIdentity": "Verify your identity",
+    "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "This account signs in through an identity provider and has no password. Re-verify with your provider to start setting up an authenticator app.",
+    "verifyWithYourIdentityProvider": "Verify with your identity provider"
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Import from Pax8",
@@ -1945,7 +1948,14 @@
     "failedToEnableMfaHttp": "Failed to enable MFA (HTTP {{status}})",
     "failedToDisableMfaHttp": "Failed to disable MFA (HTTP {{status}})",
     "failedToStartPasskeyHttp": "Failed to start passkey setup (HTTP {{status}})",
-    "failedToSavePasskeyHttp": "Failed to save passkey (HTTP {{status}})"
+    "failedToSavePasskeyHttp": "Failed to save passkey (HTTP {{status}})",
+    "ssoReauthNotFresh": "Your identity provider did not re-verify your sign-in. Try again, or ask your administrator to allow re-authentication prompts.",
+    "ssoReauthIdentityMismatch": "That identity provider account is not the one linked to this profile. Sign in with your own account and try again.",
+    "ssoReauthSessionInvalid": "Your session changed while you were verifying. Sign in again, then retry.",
+    "ssoReauthPasswordSet": "This account now has a password. Use it to set up multi-factor authentication.",
+    "ssoReauthUnavailable": "Identity provider verification is temporarily unavailable. Please try again shortly.",
+    "ssoReauthFailed": "Could not verify with your identity provider. Please try again.",
+    "couldNotStartIdentityProviderVerification": "Could not start identity provider verification."
   },
   "roleManager": {
     "roles": "Roles",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1861,7 +1861,8 @@
     "showRecoveryCodes": "Show recovery codes",
     "verifyYourIdentity": "Verify your identity",
     "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "This account signs in through an identity provider and has no password. Re-verify with your provider to start setting up an authenticator app.",
-    "verifyWithYourIdentityProvider": "Verify with your identity provider"
+    "verifyWithYourIdentityProvider": "Verify with your identity provider",
+    "ssoReauthProofExpired": "Your identity provider verification has expired. Verify again to finish setting up your authenticator app."
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Import from Pax8",
@@ -1954,6 +1955,10 @@
     "ssoReauthSessionInvalid": "Your session changed while you were verifying. Sign in again, then retry.",
     "ssoReauthPasswordSet": "This account now has a password. Use it to set up multi-factor authentication.",
     "ssoReauthUnavailable": "Identity provider verification is temporarily unavailable. Please try again shortly.",
+    "ssoReauthProviderInactive": "Single sign-on is no longer available for this account. Ask your administrator, then try again.",
+    "ssoReauthConfigChanged": "Your single sign-on settings changed while you were verifying. Start the verification again.",
+    "ssoReauthEmailUnverified": "Your identity provider reports that your email address is not verified. Verify it there, then try again.",
+    "ssoReauthProofExpired": "Your identity provider verification has expired. Verify again to finish setting up multi-factor authentication.",
     "ssoReauthFailed": "Could not verify with your identity provider. Please try again.",
     "couldNotStartIdentityProviderVerification": "Could not start identity provider verification."
   },

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -111,7 +111,10 @@
     "expiryMinutes_one": "en aproximadamente {{count}} minuto",
     "expiryMinutes_other": "en aproximadamente {{count}} minutos",
     "expiryHours_one": "en aproximadamente {{count}} hora",
-    "expiryHours_other": "en aproximadamente {{count}} horas"
+    "expiryHours_other": "en aproximadamente {{count}} horas",
+    "mfaRequiredSsoLinks": "Se requiere autenticación multifactor para generar enlaces. Tu organización te inicia sesión mediante un proveedor de identidad: pide a tu administrador que habilite la confianza de MFA para él o inscribe un factor en la configuración de tu perfil.",
+    "mfaRequiredSsoInstallers": "Se requiere autenticación multifactor para generar instaladores. Tu organización te inicia sesión mediante un proveedor de identidad: pide a tu administrador que habilite la confianza de MFA para él o inscribe un factor en la configuración de tu perfil.",
+    "mfaRequiredSsoTokens": "Se requiere autenticación multifactor para generar tokens de instalación. Tu organización te inicia sesión mediante un proveedor de identidad: pide a tu administrador que habilite la confianza de MFA para él o inscribe un factor en la configuración de tu perfil."
   },
   "changeSiteModal": {
     "failedToLoadSites": "No se pudieron cargar los sitios",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -82,7 +82,6 @@
     "multiFactorAuthenticationIsRequiredTo": "Se requiere autenticación multifactor para generar enlaces.",
     "setUpMfaInYourProfile": "Configure MFA en la configuración de su perfil",
     "andSignInAgainThenRetry": "e inicie sesión nuevamente, luego vuelva a intentarlo.",
-    "ssoMfaTrustGuidance": "Su organización lo autentica mediante un proveedor de identidad. Pídale a su administrador que habilite la confianza en MFA para él, o registre un factor en la configuración de su perfil.",
     "retry": "Reintentar",
     "multiFactorAuthenticationIsRequiredTo2": "Se requiere autenticación multifactor para generar instaladores.",
     "installerDownloadedRunItOn": "Instalador descargado. Ejecútelo",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -82,6 +82,7 @@
     "multiFactorAuthenticationIsRequiredTo": "Se requiere autenticación multifactor para generar enlaces.",
     "setUpMfaInYourProfile": "Configure MFA en la configuración de su perfil",
     "andSignInAgainThenRetry": "e inicie sesión nuevamente, luego vuelva a intentarlo.",
+    "ssoMfaTrustGuidance": "Su organización lo autentica mediante un proveedor de identidad. Pídale a su administrador que habilite la confianza en MFA para él, o registre un factor en la configuración de su perfil.",
     "retry": "Reintentar",
     "multiFactorAuthenticationIsRequiredTo2": "Se requiere autenticación multifactor para generar instaladores.",
     "installerDownloadedRunItOn": "Instalador descargado. Ejecútelo",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1858,7 +1858,10 @@
     "disabling": "Desactivando...",
     "generating": "Generando...",
     "regenerateCodes": "Regenerar códigos",
-    "showRecoveryCodes": "Mostrar códigos de recuperación"
+    "showRecoveryCodes": "Mostrar códigos de recuperación",
+    "verifyYourIdentity": "Verifica tu identidad",
+    "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Esta cuenta inicia sesión mediante un proveedor de identidad y no tiene contraseña. Vuelve a verificarte con tu proveedor para comenzar a configurar una aplicación de autenticación.",
+    "verifyWithYourIdentityProvider": "Verificar con tu proveedor de identidad"
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Importar desde Pax8",
@@ -1945,7 +1948,14 @@
     "failedToEnableMfaHttp": "No se pudo habilitar MFA (HTTP {{status}})",
     "failedToDisableMfaHttp": "No se pudo desactivar MFA (HTTP {{status}})",
     "failedToStartPasskeyHttp": "No se pudo iniciar la configuración de la clave de acceso (HTTP {{status}})",
-    "failedToSavePasskeyHttp": "No se pudo guardar la clave de acceso (HTTP {{status}})"
+    "failedToSavePasskeyHttp": "No se pudo guardar la clave de acceso (HTTP {{status}})",
+    "ssoReauthNotFresh": "Tu proveedor de identidad no volvió a verificar tu inicio de sesión. Inténtalo de nuevo o pide a tu administrador que permita las solicitudes de reautenticación.",
+    "ssoReauthIdentityMismatch": "Esa cuenta del proveedor de identidad no es la vinculada a este perfil. Inicia sesión con tu propia cuenta e inténtalo de nuevo.",
+    "ssoReauthSessionInvalid": "Tu sesión cambió mientras te verificabas. Inicia sesión de nuevo y vuelve a intentarlo.",
+    "ssoReauthPasswordSet": "Esta cuenta ahora tiene una contraseña. Úsala para configurar la autenticación multifactor.",
+    "ssoReauthUnavailable": "La verificación con el proveedor de identidad no está disponible temporalmente. Inténtalo de nuevo en unos momentos.",
+    "ssoReauthFailed": "No se pudo verificar con tu proveedor de identidad. Inténtalo de nuevo.",
+    "couldNotStartIdentityProviderVerification": "No se pudo iniciar la verificación con el proveedor de identidad."
   },
   "roleManager": {
     "roles": "Roles",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1861,7 +1861,8 @@
     "showRecoveryCodes": "Mostrar códigos de recuperación",
     "verifyYourIdentity": "Verifica tu identidad",
     "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Esta cuenta inicia sesión mediante un proveedor de identidad y no tiene contraseña. Vuelve a verificarte con tu proveedor para comenzar a configurar una aplicación de autenticación.",
-    "verifyWithYourIdentityProvider": "Verificar con tu proveedor de identidad"
+    "verifyWithYourIdentityProvider": "Verificar con tu proveedor de identidad",
+    "ssoReauthProofExpired": "Tu verificación con el proveedor de identidad venció. Verifícate de nuevo para terminar de configurar tu aplicación de autenticación."
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Importar desde Pax8",
@@ -1954,6 +1955,10 @@
     "ssoReauthSessionInvalid": "Tu sesión cambió mientras te verificabas. Inicia sesión de nuevo y vuelve a intentarlo.",
     "ssoReauthPasswordSet": "Esta cuenta ahora tiene una contraseña. Úsala para configurar la autenticación multifactor.",
     "ssoReauthUnavailable": "La verificación con el proveedor de identidad no está disponible temporalmente. Inténtalo de nuevo en unos momentos.",
+    "ssoReauthProviderInactive": "El inicio de sesión único ya no está disponible para esta cuenta. Consulta a tu administrador e inténtalo de nuevo.",
+    "ssoReauthConfigChanged": "Tu configuración de inicio de sesión único cambió mientras te verificabas. Comienza la verificación otra vez.",
+    "ssoReauthEmailUnverified": "Tu proveedor de identidad indica que tu dirección de correo no está verificada. Verifícala allí y vuelve a intentarlo.",
+    "ssoReauthProofExpired": "Tu verificación con el proveedor de identidad venció. Verifícate de nuevo para terminar de configurar la autenticación multifactor.",
     "ssoReauthFailed": "No se pudo verificar con tu proveedor de identidad. Inténtalo de nuevo.",
     "couldNotStartIdentityProviderVerification": "No se pudo iniciar la verificación con el proveedor de identidad."
   },

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1959,6 +1959,9 @@
     "ssoReauthConfigChanged": "Tu configuración de inicio de sesión único cambió mientras te verificabas. Comienza la verificación otra vez.",
     "ssoReauthEmailUnverified": "Tu proveedor de identidad indica que tu dirección de correo no está verificada. Verifícala allí y vuelve a intentarlo.",
     "ssoReauthProofExpired": "Tu verificación con el proveedor de identidad venció. Verifícate de nuevo para terminar de configurar la autenticación multifactor.",
+    "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Esta cuenta inicia sesión mediante un proveedor de identidad y no tiene contraseña. Vuelve a verificarte con tu proveedor antes de agregar una clave de acceso.",
+    "verifyWithYourIdentityProvider": "Verificar con tu proveedor de identidad",
+    "passkeyIdpVerificationRequired": "Verifícate con tu proveedor de identidad antes de agregar una clave de acceso.",
     "ssoReauthFailed": "No se pudo verificar con tu proveedor de identidad. Inténtalo de nuevo.",
     "couldNotStartIdentityProviderVerification": "No se pudo iniciar la verificación con el proveedor de identidad."
   },

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -2110,6 +2110,8 @@
     "securitySettings": "Configuración de seguridad",
     "enforceSSOOnlyLogin": "Aplicar el inicio de sesión SSO-only",
     "usersMustUseSSOToSignInPasswordLoginWillBeDisabled": "Los usuarios deben usar SSO para iniciar sesión. El inicio de sesión con contraseña estará deshabilitado.",
+    "trustThisProvidersMFA": "Confiar en el MFA de este proveedor",
+    "trustThisProvidersMFAHelperText": "Cuando su proveedor de identidad informa que se usó autenticación multifactor (`amr: mfa`), se considera que el MFA está satisfecho en Breeze. Su IdP debe incluir la reclamación `amr` en su token de ID; la mayoría requiere habilitar esto explícitamente. Desactivado de forma predeterminada.",
     "warningSSOEnforcementEnabled": "Advertencia: aplicación de SSO habilitada",
     "usersWillNotBeAbleToSignInWithPasswordsMakeSureYourSSOCo": "Los usuarios no podrán iniciar sesión con contraseñas. Asegúrese de que su configuración SSO esté funcionando correctamente antes de habilitar esta opción. Considere tener al menos una cuenta de administrador que pueda omitir SSO para acceso de emergencia.",
     "testing": "Probando...",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -111,7 +111,10 @@
     "expiryMinutes_one": "Dans environ {{count}} minute",
     "expiryMinutes_other": "Dans environ {{count}} minutes",
     "expiryHours_one": "Dans environ {{count}} heure",
-    "expiryHours_other": "Dans environ {{count}} heures"
+    "expiryHours_other": "Dans environ {{count}} heures",
+    "mfaRequiredSsoLinks": "L'authentification multifacteur est requise pour générer des liens. Votre organisation vous ouvre une session par l'entremise d'un fournisseur d'identité — demandez à votre administrateur d'activer la confiance MFA pour celui-ci, ou inscrivez un facteur dans les paramètres de votre profil.",
+    "mfaRequiredSsoInstallers": "L'authentification multifacteur est requise pour générer des programmes d'installation. Votre organisation vous ouvre une session par l'entremise d'un fournisseur d'identité — demandez à votre administrateur d'activer la confiance MFA pour celui-ci, ou inscrivez un facteur dans les paramètres de votre profil.",
+    "mfaRequiredSsoTokens": "L'authentification multifacteur est requise pour générer des jetons d'installation. Votre organisation vous ouvre une session par l'entremise d'un fournisseur d'identité — demandez à votre administrateur d'activer la confiance MFA pour celui-ci, ou inscrivez un facteur dans les paramètres de votre profil."
   },
   "changeSiteModal": {
     "failedToLoadSites": "Impossible de charger les sites",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -82,6 +82,7 @@
     "multiFactorAuthenticationIsRequiredTo": "L’authentification multifactorielle est nécessaire pour générer des liens.",
     "setUpMfaInYourProfile": "Configurez MFA dans les paramètres de votre profil",
     "andSignInAgainThenRetry": "puis ouvrez une nouvelle session et réessayez.",
+    "ssoMfaTrustGuidance": "Votre organisation vous connecte par l’entremise d’un fournisseur d’identité — demandez à votre administrateur d’activer la confiance MFA pour celui-ci, ou inscrivez un facteur dans les paramètres de votre profil.",
     "retry": "Réessayer",
     "multiFactorAuthenticationIsRequiredTo2": "L’authentification multifactorielle est nécessaire pour générer des installateurs.",
     "installerDownloadedRunItOn": "Programme d’installation téléchargé. Exécutez-le sur",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -82,7 +82,6 @@
     "multiFactorAuthenticationIsRequiredTo": "L’authentification multifactorielle est nécessaire pour générer des liens.",
     "setUpMfaInYourProfile": "Configurez MFA dans les paramètres de votre profil",
     "andSignInAgainThenRetry": "puis ouvrez une nouvelle session et réessayez.",
-    "ssoMfaTrustGuidance": "Votre organisation vous connecte par l’entremise d’un fournisseur d’identité — demandez à votre administrateur d’activer la confiance MFA pour celui-ci, ou inscrivez un facteur dans les paramètres de votre profil.",
     "retry": "Réessayer",
     "multiFactorAuthenticationIsRequiredTo2": "L’authentification multifactorielle est nécessaire pour générer des installateurs.",
     "installerDownloadedRunItOn": "Programme d’installation téléchargé. Exécutez-le sur",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1856,7 +1856,8 @@
     "showRecoveryCodes": "Afficher les codes de récupération",
     "verifyYourIdentity": "Vérifiez votre identité",
     "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Ce compte ouvre une session par l'entremise d'un fournisseur d'identité et n'a pas de mot de passe. Vérifiez de nouveau votre identité auprès de votre fournisseur pour commencer à configurer une application d'authentification.",
-    "verifyWithYourIdentityProvider": "Vérifier avec votre fournisseur d'identité"
+    "verifyWithYourIdentityProvider": "Vérifier avec votre fournisseur d'identité",
+    "ssoReauthProofExpired": "Votre vérification auprès du fournisseur d'identité est expirée. Vérifiez de nouveau pour terminer la configuration de votre application d'authentification."
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Importation depuis Pax8",
@@ -1949,6 +1950,10 @@
     "ssoReauthSessionInvalid": "Votre session a changé pendant la vérification. Ouvrez une session de nouveau, puis réessayez.",
     "ssoReauthPasswordSet": "Ce compte possède maintenant un mot de passe. Utilisez-le pour configurer l'authentification multifacteur.",
     "ssoReauthUnavailable": "La vérification par le fournisseur d'identité est temporairement indisponible. Veuillez réessayer sous peu.",
+    "ssoReauthProviderInactive": "L'authentification unique n'est plus offerte pour ce compte. Communiquez avec votre administrateur, puis réessayez.",
+    "ssoReauthConfigChanged": "Vos paramètres d'authentification unique ont changé pendant la vérification. Recommencez la vérification.",
+    "ssoReauthEmailUnverified": "Votre fournisseur d'identité indique que votre adresse courriel n'est pas vérifiée. Vérifiez-la auprès de lui, puis réessayez.",
+    "ssoReauthProofExpired": "Votre vérification auprès du fournisseur d'identité est expirée. Vérifiez de nouveau pour terminer la configuration de l'authentification multifacteur.",
     "ssoReauthFailed": "Impossible de vérifier avec votre fournisseur d'identité. Veuillez réessayer.",
     "couldNotStartIdentityProviderVerification": "Impossible de lancer la vérification par le fournisseur d'identité."
   },

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -2105,6 +2105,8 @@
     "securitySettings": "Paramètres de sécurité",
     "enforceSSOOnlyLogin": "Imposer la connexion SSO uniquement",
     "usersMustUseSSOToSignInPasswordLoginWillBeDisabled": "Les utilisateurs doivent utiliser SSO pour se connecter. La connexion par mot de passe sera désactivée.",
+    "trustThisProvidersMFA": "Faire confiance au MFA de ce fournisseur",
+    "trustThisProvidersMFAHelperText": "Lorsque votre fournisseur d'identité indique que l'authentification multifacteur a été utilisée (`amr: mfa`), le MFA est considéré comme satisfait dans Breeze. Votre IdP doit inclure la revendication `amr` dans son jeton d'ID — la plupart exigent une activation explicite. Désactivé par défaut.",
     "warningSSOEnforcementEnabled": "Avertissement : application obligatoire du SSO activée",
     "usersWillNotBeAbleToSignInWithPasswordsMakeSureYourSSOCo": "Les utilisateurs ne pourront pas se connecter avec des mots de passe. Assurez-vous que votre configuration SSO fonctionne correctement avant d’activer cette option. Envisagez d’avoir au moins un compte administrateur capable de contourner SSO pour un accès d’urgence.",
     "testing": "Test...",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1954,6 +1954,9 @@
     "ssoReauthConfigChanged": "Vos paramètres d'authentification unique ont changé pendant la vérification. Recommencez la vérification.",
     "ssoReauthEmailUnverified": "Votre fournisseur d'identité indique que votre adresse courriel n'est pas vérifiée. Vérifiez-la auprès de lui, puis réessayez.",
     "ssoReauthProofExpired": "Votre vérification auprès du fournisseur d'identité est expirée. Vérifiez de nouveau pour terminer la configuration de l'authentification multifacteur.",
+    "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Ce compte ouvre une session par un fournisseur d'identité et n'a pas de mot de passe. Vérifiez de nouveau auprès de votre fournisseur avant d'ajouter une clé d'accès.",
+    "verifyWithYourIdentityProvider": "Vérifier auprès de votre fournisseur d'identité",
+    "passkeyIdpVerificationRequired": "Vérifiez auprès de votre fournisseur d'identité avant d'ajouter une clé d'accès.",
     "ssoReauthFailed": "Impossible de vérifier avec votre fournisseur d'identité. Veuillez réessayer.",
     "couldNotStartIdentityProviderVerification": "Impossible de lancer la vérification par le fournisseur d'identité."
   },

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1853,7 +1853,10 @@
     "disabling": "Désactivant...",
     "generating": "Générer...",
     "regenerateCodes": "Régénération des codes",
-    "showRecoveryCodes": "Afficher les codes de récupération"
+    "showRecoveryCodes": "Afficher les codes de récupération",
+    "verifyYourIdentity": "Vérifiez votre identité",
+    "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Ce compte ouvre une session par l'entremise d'un fournisseur d'identité et n'a pas de mot de passe. Vérifiez de nouveau votre identité auprès de votre fournisseur pour commencer à configurer une application d'authentification.",
+    "verifyWithYourIdentityProvider": "Vérifier avec votre fournisseur d'identité"
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Importation depuis Pax8",
@@ -1940,7 +1943,14 @@
     "failedToEnableMfaHttp": "Impossible d’activer MFA (HTTP {{status}})",
     "failedToDisableMfaHttp": "Impossible de désactiver MFA (HTTP {{status}})",
     "failedToStartPasskeyHttp": "Impossible de démarrer la configuration de la clé d’accès (HTTP {{status}})",
-    "failedToSavePasskeyHttp": "Impossible d’enregistrer la clé d’accès (HTTP {{status}})"
+    "failedToSavePasskeyHttp": "Impossible d’enregistrer la clé d’accès (HTTP {{status}})",
+    "ssoReauthNotFresh": "Votre fournisseur d'identité n'a pas vérifié de nouveau votre ouverture de session. Réessayez ou demandez à votre administrateur d'autoriser les invites de réauthentification.",
+    "ssoReauthIdentityMismatch": "Ce compte de fournisseur d'identité n'est pas celui lié à ce profil. Ouvrez une session avec votre propre compte, puis réessayez.",
+    "ssoReauthSessionInvalid": "Votre session a changé pendant la vérification. Ouvrez une session de nouveau, puis réessayez.",
+    "ssoReauthPasswordSet": "Ce compte possède maintenant un mot de passe. Utilisez-le pour configurer l'authentification multifacteur.",
+    "ssoReauthUnavailable": "La vérification par le fournisseur d'identité est temporairement indisponible. Veuillez réessayer sous peu.",
+    "ssoReauthFailed": "Impossible de vérifier avec votre fournisseur d'identité. Veuillez réessayer.",
+    "couldNotStartIdentityProviderVerification": "Impossible de lancer la vérification par le fournisseur d'identité."
   },
   "roleManager": {
     "roles": "Rôles",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -111,7 +111,10 @@
     "expiryMinutes_one": "Dans environ {{count}} minute",
     "expiryMinutes_other": "Dans environ {{count}} minutes",
     "expiryHours_one": "Dans environ {{count}} heure",
-    "expiryHours_other": "Dans environ {{count}} heures"
+    "expiryHours_other": "Dans environ {{count}} heures",
+    "mfaRequiredSsoLinks": "L'authentification multifacteur est requise pour générer des liens. Votre organisation vous connecte via un fournisseur d'identité — demandez à votre administrateur d'activer la confiance MFA pour celui-ci, ou enregistrez un facteur dans les paramètres de votre profil.",
+    "mfaRequiredSsoInstallers": "L'authentification multifacteur est requise pour générer des programmes d'installation. Votre organisation vous connecte via un fournisseur d'identité — demandez à votre administrateur d'activer la confiance MFA pour celui-ci, ou enregistrez un facteur dans les paramètres de votre profil.",
+    "mfaRequiredSsoTokens": "L'authentification multifacteur est requise pour générer des jetons d'installation. Votre organisation vous connecte via un fournisseur d'identité — demandez à votre administrateur d'activer la confiance MFA pour celui-ci, ou enregistrez un facteur dans les paramètres de votre profil."
   },
   "changeSiteModal": {
     "failedToLoadSites": "Impossible de charger les sites",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -82,6 +82,7 @@
     "multiFactorAuthenticationIsRequiredTo": "L’authentification multifactorielle est nécessaire pour générer des liens.",
     "setUpMfaInYourProfile": "Configurez MFA dans les paramètres de votre profil",
     "andSignInAgainThenRetry": "puis reconnectez-vous et réessayez.",
+    "ssoMfaTrustGuidance": "Votre organisation vous connecte via un fournisseur d’identité — demandez à votre administrateur d’activer la confiance MFA pour ce fournisseur, ou inscrivez un facteur dans les paramètres de votre profil.",
     "retry": "Réessayer",
     "multiFactorAuthenticationIsRequiredTo2": "L’authentification multifactorielle est nécessaire pour générer des installateurs.",
     "installerDownloadedRunItOn": "Programme d’installation téléchargé. Exécutez-le sur",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -82,7 +82,6 @@
     "multiFactorAuthenticationIsRequiredTo": "L’authentification multifactorielle est nécessaire pour générer des liens.",
     "setUpMfaInYourProfile": "Configurez MFA dans les paramètres de votre profil",
     "andSignInAgainThenRetry": "puis reconnectez-vous et réessayez.",
-    "ssoMfaTrustGuidance": "Votre organisation vous connecte via un fournisseur d’identité — demandez à votre administrateur d’activer la confiance MFA pour ce fournisseur, ou inscrivez un facteur dans les paramètres de votre profil.",
     "retry": "Réessayer",
     "multiFactorAuthenticationIsRequiredTo2": "L’authentification multifactorielle est nécessaire pour générer des installateurs.",
     "installerDownloadedRunItOn": "Programme d’installation téléchargé. Exécutez-le sur",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1861,7 +1861,8 @@
     "showRecoveryCodes": "Afficher les codes de récupération",
     "verifyYourIdentity": "Vérifiez votre identité",
     "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Ce compte se connecte via un fournisseur d'identité et n'a pas de mot de passe. Vérifiez-vous à nouveau auprès de votre fournisseur pour commencer à configurer une application d'authentification.",
-    "verifyWithYourIdentityProvider": "Vérifier avec votre fournisseur d'identité"
+    "verifyWithYourIdentityProvider": "Vérifier avec votre fournisseur d'identité",
+    "ssoReauthProofExpired": "Votre vérification auprès du fournisseur d'identité a expiré. Vérifiez de nouveau pour terminer la configuration de votre application d'authentification."
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Importation depuis Pax8",
@@ -1954,6 +1955,10 @@
     "ssoReauthSessionInvalid": "Votre session a changé pendant la vérification. Reconnectez-vous, puis réessayez.",
     "ssoReauthPasswordSet": "Ce compte possède désormais un mot de passe. Utilisez-le pour configurer l'authentification multifacteur.",
     "ssoReauthUnavailable": "La vérification par le fournisseur d'identité est temporairement indisponible. Veuillez réessayer sous peu.",
+    "ssoReauthProviderInactive": "L'authentification unique n'est plus disponible pour ce compte. Contactez votre administrateur, puis réessayez.",
+    "ssoReauthConfigChanged": "Vos paramètres d'authentification unique ont changé pendant la vérification. Relancez la vérification.",
+    "ssoReauthEmailUnverified": "Votre fournisseur d'identité indique que votre adresse e-mail n'est pas vérifiée. Vérifiez-la chez lui, puis réessayez.",
+    "ssoReauthProofExpired": "Votre vérification auprès du fournisseur d'identité a expiré. Vérifiez de nouveau pour terminer la configuration de l'authentification multifacteur.",
     "ssoReauthFailed": "Impossible de vérifier avec votre fournisseur d'identité. Veuillez réessayer.",
     "couldNotStartIdentityProviderVerification": "Impossible de démarrer la vérification par le fournisseur d'identité."
   },

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1858,7 +1858,10 @@
     "disabling": "Désactivant...",
     "generating": "Générer...",
     "regenerateCodes": "Régénération des codes",
-    "showRecoveryCodes": "Afficher les codes de récupération"
+    "showRecoveryCodes": "Afficher les codes de récupération",
+    "verifyYourIdentity": "Vérifiez votre identité",
+    "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Ce compte se connecte via un fournisseur d'identité et n'a pas de mot de passe. Vérifiez-vous à nouveau auprès de votre fournisseur pour commencer à configurer une application d'authentification.",
+    "verifyWithYourIdentityProvider": "Vérifier avec votre fournisseur d'identité"
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Importation depuis Pax8",
@@ -1945,7 +1948,14 @@
     "failedToEnableMfaHttp": "Impossible d’activer MFA (HTTP {{status}})",
     "failedToDisableMfaHttp": "Impossible de désactiver MFA (HTTP {{status}})",
     "failedToStartPasskeyHttp": "Impossible de démarrer la configuration de la clé d’accès (HTTP {{status}})",
-    "failedToSavePasskeyHttp": "Impossible d’enregistrer la clé d’accès (HTTP {{status}})"
+    "failedToSavePasskeyHttp": "Impossible d’enregistrer la clé d’accès (HTTP {{status}})",
+    "ssoReauthNotFresh": "Votre fournisseur d'identité n'a pas revérifié votre connexion. Réessayez ou demandez à votre administrateur d'autoriser les invites de réauthentification.",
+    "ssoReauthIdentityMismatch": "Ce compte du fournisseur d'identité n'est pas celui associé à ce profil. Connectez-vous avec votre propre compte et réessayez.",
+    "ssoReauthSessionInvalid": "Votre session a changé pendant la vérification. Reconnectez-vous, puis réessayez.",
+    "ssoReauthPasswordSet": "Ce compte possède désormais un mot de passe. Utilisez-le pour configurer l'authentification multifacteur.",
+    "ssoReauthUnavailable": "La vérification par le fournisseur d'identité est temporairement indisponible. Veuillez réessayer sous peu.",
+    "ssoReauthFailed": "Impossible de vérifier avec votre fournisseur d'identité. Veuillez réessayer.",
+    "couldNotStartIdentityProviderVerification": "Impossible de démarrer la vérification par le fournisseur d'identité."
   },
   "roleManager": {
     "roles": "Rôles",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1959,6 +1959,9 @@
     "ssoReauthConfigChanged": "Vos paramètres d'authentification unique ont changé pendant la vérification. Relancez la vérification.",
     "ssoReauthEmailUnverified": "Votre fournisseur d'identité indique que votre adresse e-mail n'est pas vérifiée. Vérifiez-la chez lui, puis réessayez.",
     "ssoReauthProofExpired": "Votre vérification auprès du fournisseur d'identité a expiré. Vérifiez de nouveau pour terminer la configuration de l'authentification multifacteur.",
+    "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Ce compte se connecte via un fournisseur d'identité et n'a pas de mot de passe. Vérifiez de nouveau auprès de votre fournisseur avant d'ajouter une clé d'accès.",
+    "verifyWithYourIdentityProvider": "Vérifier auprès de votre fournisseur d'identité",
+    "passkeyIdpVerificationRequired": "Vérifiez auprès de votre fournisseur d'identité avant d'ajouter une clé d'accès.",
     "ssoReauthFailed": "Impossible de vérifier avec votre fournisseur d'identité. Veuillez réessayer.",
     "couldNotStartIdentityProviderVerification": "Impossible de démarrer la vérification par le fournisseur d'identité."
   },

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -2110,6 +2110,8 @@
     "securitySettings": "Paramètres de sécurité",
     "enforceSSOOnlyLogin": "Imposer la connexion SSO uniquement",
     "usersMustUseSSOToSignInPasswordLoginWillBeDisabled": "Les utilisateurs doivent utiliser SSO pour se connecter. La connexion par mot de passe sera désactivée.",
+    "trustThisProvidersMFA": "Faire confiance au MFA de ce fournisseur",
+    "trustThisProvidersMFAHelperText": "Lorsque votre fournisseur d'identité signale que l'authentification multifactorielle a été utilisée (`amr: mfa`), le MFA est considéré comme satisfait dans Breeze. Votre IdP doit inclure la revendication `amr` dans son jeton d'ID — la plupart nécessitent une activation explicite. Désactivé par défaut.",
     "warningSSOEnforcementEnabled": "Avertissement : application obligatoire du SSO activée",
     "usersWillNotBeAbleToSignInWithPasswordsMakeSureYourSSOCo": "Les utilisateurs ne pourront pas se connecter avec des mots de passe. Assurez-vous que votre configuration SSO fonctionne correctement avant d’activer cette option. Envisagez d’avoir au moins un compte administrateur capable de contourner SSO pour un accès d’urgence.",
     "testing": "Test...",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -111,7 +111,10 @@
     "expiryMinutes_one": "tra circa {{count}} minuto",
     "expiryMinutes_other": "tra circa {{count}} minuti",
     "expiryHours_one": "tra circa {{count}} ora",
-    "expiryHours_other": "tra circa {{count}} ore"
+    "expiryHours_other": "tra circa {{count}} ore",
+    "mfaRequiredSsoLinks": "Per generare i collegamenti è richiesta l'autenticazione a più fattori. La tua organizzazione ti fa accedere tramite un provider di identità: chiedi all'amministratore di abilitare l'attendibilità MFA per quel provider oppure registra un fattore nelle impostazioni del profilo.",
+    "mfaRequiredSsoInstallers": "Per generare i programmi di installazione è richiesta l'autenticazione a più fattori. La tua organizzazione ti fa accedere tramite un provider di identità: chiedi all'amministratore di abilitare l'attendibilità MFA per quel provider oppure registra un fattore nelle impostazioni del profilo.",
+    "mfaRequiredSsoTokens": "Per generare i token di installazione è richiesta l'autenticazione a più fattori. La tua organizzazione ti fa accedere tramite un provider di identità: chiedi all'amministratore di abilitare l'attendibilità MFA per quel provider oppure registra un fattore nelle impostazioni del profilo."
   },
   "changeSiteModal": {
     "failedToLoadSites": "Impossibile caricare i siti",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -82,6 +82,7 @@
     "multiFactorAuthenticationIsRequiredTo": "Per generare link è necessaria l'autenticazione a più fattori.",
     "setUpMfaInYourProfile": "Configura l'MFA nelle impostazioni del profilo",
     "andSignInAgainThenRetry": "quindi accedi di nuovo e riprova.",
+    "ssoMfaTrustGuidance": "La tua organizzazione ti autentica tramite un provider di identità: chiedi al tuo amministratore di abilitare l'attendibilità MFA per questo provider, oppure registra un fattore nelle impostazioni del profilo.",
     "retry": "Riprova",
     "multiFactorAuthenticationIsRequiredTo2": "Per generare programmi di installazione è necessaria l'autenticazione a più fattori.",
     "installerDownloadedRunItOn": "Programma di installazione scaricato. Eseguilo sul",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -82,7 +82,6 @@
     "multiFactorAuthenticationIsRequiredTo": "Per generare link è necessaria l'autenticazione a più fattori.",
     "setUpMfaInYourProfile": "Configura l'MFA nelle impostazioni del profilo",
     "andSignInAgainThenRetry": "quindi accedi di nuovo e riprova.",
-    "ssoMfaTrustGuidance": "La tua organizzazione ti autentica tramite un provider di identità: chiedi al tuo amministratore di abilitare l'attendibilità MFA per questo provider, oppure registra un fattore nelle impostazioni del profilo.",
     "retry": "Riprova",
     "multiFactorAuthenticationIsRequiredTo2": "Per generare programmi di installazione è necessaria l'autenticazione a più fattori.",
     "installerDownloadedRunItOn": "Programma di installazione scaricato. Eseguilo sul",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1853,7 +1853,10 @@
     "disabling": "Disabilitazione...",
     "generating": "Generazione...",
     "regenerateCodes": "Rigenera codici",
-    "showRecoveryCodes": "Mostra codici di recupero"
+    "showRecoveryCodes": "Mostra codici di recupero",
+    "verifyYourIdentity": "Verifica la tua identità",
+    "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Questo account accede tramite un provider di identità e non ha una password. Verificati nuovamente presso il tuo provider per iniziare a configurare un'app di autenticazione.",
+    "verifyWithYourIdentityProvider": "Verifica con il tuo provider di identità"
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Importa da Pax8",
@@ -1940,7 +1943,14 @@
     "failedToEnableMfaHttp": "Abilitazione MFA non riuscita (HTTP {{status}})",
     "failedToDisableMfaHttp": "Disabilitazione MFA non riuscita (HTTP {{status}})",
     "failedToStartPasskeyHttp": "Avvio configurazione passkey non riuscito (HTTP {{status}})",
-    "failedToSavePasskeyHttp": "Salvataggio passkey non riuscito (HTTP {{status}})"
+    "failedToSavePasskeyHttp": "Salvataggio passkey non riuscito (HTTP {{status}})",
+    "ssoReauthNotFresh": "Il tuo provider di identità non ha verificato nuovamente il tuo accesso. Riprova oppure chiedi all'amministratore di consentire le richieste di riautenticazione.",
+    "ssoReauthIdentityMismatch": "Quell'account del provider di identità non è quello collegato a questo profilo. Accedi con il tuo account e riprova.",
+    "ssoReauthSessionInvalid": "La tua sessione è cambiata durante la verifica. Accedi di nuovo, quindi riprova.",
+    "ssoReauthPasswordSet": "Questo account ora ha una password. Usala per configurare l'autenticazione a più fattori.",
+    "ssoReauthUnavailable": "La verifica tramite il provider di identità non è temporaneamente disponibile. Riprova tra poco.",
+    "ssoReauthFailed": "Non è stato possibile verificare con il tuo provider di identità. Riprova.",
+    "couldNotStartIdentityProviderVerification": "Non è stato possibile avviare la verifica tramite il provider di identità."
   },
   "roleManager": {
     "roles": "Ruoli",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1856,7 +1856,8 @@
     "showRecoveryCodes": "Mostra codici di recupero",
     "verifyYourIdentity": "Verifica la tua identità",
     "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Questo account accede tramite un provider di identità e non ha una password. Verificati nuovamente presso il tuo provider per iniziare a configurare un'app di autenticazione.",
-    "verifyWithYourIdentityProvider": "Verifica con il tuo provider di identità"
+    "verifyWithYourIdentityProvider": "Verifica con il tuo provider di identità",
+    "ssoReauthProofExpired": "La verifica tramite il provider di identità è scaduta. Eseguila di nuovo per completare la configurazione dell'app di autenticazione."
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Importa da Pax8",
@@ -1949,6 +1950,10 @@
     "ssoReauthSessionInvalid": "La tua sessione è cambiata durante la verifica. Accedi di nuovo, quindi riprova.",
     "ssoReauthPasswordSet": "Questo account ora ha una password. Usala per configurare l'autenticazione a più fattori.",
     "ssoReauthUnavailable": "La verifica tramite il provider di identità non è temporaneamente disponibile. Riprova tra poco.",
+    "ssoReauthProviderInactive": "L'accesso Single Sign-On non è più disponibile per questo account. Rivolgiti all'amministratore e riprova.",
+    "ssoReauthConfigChanged": "Le impostazioni di Single Sign-On sono cambiate durante la verifica. Avvia di nuovo la verifica.",
+    "ssoReauthEmailUnverified": "Il tuo provider di identità segnala che il tuo indirizzo e-mail non è verificato. Verificalo lì, quindi riprova.",
+    "ssoReauthProofExpired": "La verifica tramite il provider di identità è scaduta. Eseguila di nuovo per completare la configurazione dell'autenticazione a più fattori.",
     "ssoReauthFailed": "Non è stato possibile verificare con il tuo provider di identità. Riprova.",
     "couldNotStartIdentityProviderVerification": "Non è stato possibile avviare la verifica tramite il provider di identità."
   },

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -2105,6 +2105,8 @@
     "securitySettings": "Impostazioni sicurezza",
     "enforceSSOOnlyLogin": "Imponi accesso solo SSO",
     "usersMustUseSSOToSignInPasswordLoginWillBeDisabled": "Gli utenti devono usare SSO per accedere. L'accesso con password verrà disabilitato.",
+    "trustThisProvidersMFA": "Considera attendibile l'MFA di questo provider",
+    "trustThisProvidersMFAHelperText": "Quando il tuo provider di identità segnala che è stata usata l'autenticazione a più fattori (`amr: mfa`), l'MFA viene considerata soddisfatta in Breeze. Il tuo IdP deve includere il claim `amr` nel suo token ID — la maggior parte richiede che questo sia abilitato esplicitamente. Disattivato per impostazione predefinita.",
     "warningSSOEnforcementEnabled": "Avviso: imposizione SSO abilitata",
     "usersWillNotBeAbleToSignInWithPasswordsMakeSureYourSSOCo": "Gli utenti non potranno accedere con password. Assicurati che la configurazione SSO funzioni correttamente prima di abilitare questa opzione. Valuta di mantenere almeno un account amministratore che possa bypassare SSO per accesso di emergenza.",
     "testing": "Test in corso...",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1954,6 +1954,9 @@
     "ssoReauthConfigChanged": "Le impostazioni di Single Sign-On sono cambiate durante la verifica. Avvia di nuovo la verifica.",
     "ssoReauthEmailUnverified": "Il tuo provider di identità segnala che il tuo indirizzo e-mail non è verificato. Verificalo lì, quindi riprova.",
     "ssoReauthProofExpired": "La verifica tramite il provider di identità è scaduta. Eseguila di nuovo per completare la configurazione dell'autenticazione a più fattori.",
+    "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Questo account accede tramite un provider di identità e non ha una password. Esegui di nuovo la verifica presso il provider prima di aggiungere una passkey.",
+    "verifyWithYourIdentityProvider": "Verifica con il tuo provider di identità",
+    "passkeyIdpVerificationRequired": "Verifica con il tuo provider di identità prima di aggiungere una passkey.",
     "ssoReauthFailed": "Non è stato possibile verificare con il tuo provider di identità. Riprova.",
     "couldNotStartIdentityProviderVerification": "Non è stato possibile avviare la verifica tramite il provider di identità."
   },

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -111,7 +111,10 @@
     "expiryMinutes_one": "em cerca de {{count}} minuto",
     "expiryMinutes_other": "em cerca de {{count}} minutos",
     "expiryHours_one": "em cerca de {{count}} hora",
-    "expiryHours_other": "em cerca de {{count}} horas"
+    "expiryHours_other": "em cerca de {{count}} horas",
+    "mfaRequiredSsoLinks": "A autenticação multifator é necessária para gerar links. Sua organização faz seu login por meio de um provedor de identidade — peça ao administrador para habilitar a confiança de MFA para ele ou registre um fator nas configurações do seu perfil.",
+    "mfaRequiredSsoInstallers": "A autenticação multifator é necessária para gerar instaladores. Sua organização faz seu login por meio de um provedor de identidade — peça ao administrador para habilitar a confiança de MFA para ele ou registre um fator nas configurações do seu perfil.",
+    "mfaRequiredSsoTokens": "A autenticação multifator é necessária para gerar tokens de instalação. Sua organização faz seu login por meio de um provedor de identidade — peça ao administrador para habilitar a confiança de MFA para ele ou registre um fator nas configurações do seu perfil."
   },
   "changeSiteModal": {
     "failedToLoadSites": "Falha ao carregar os sites",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -82,6 +82,7 @@
     "multiFactorAuthenticationIsRequiredTo": "A autenticação multifator é obrigatória para gerar links.",
     "setUpMfaInYourProfile": "Configure a MFA nas configurações do seu perfil",
     "andSignInAgainThenRetry": "e entre novamente. Depois, tente de novo.",
+    "ssoMfaTrustGuidance": "Sua organização autentica você por meio de um provedor de identidade — peça ao seu administrador para habilitar a confiança de MFA para ele, ou registre um fator nas configurações do seu perfil.",
     "retry": "Tentar novamente",
     "multiFactorAuthenticationIsRequiredTo2": "A autenticação multifator é obrigatória para gerar instaladores.",
     "installerDownloadedRunItOn": "Instalador baixado. Execute-o no",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -82,7 +82,6 @@
     "multiFactorAuthenticationIsRequiredTo": "A autenticação multifator é obrigatória para gerar links.",
     "setUpMfaInYourProfile": "Configure a MFA nas configurações do seu perfil",
     "andSignInAgainThenRetry": "e entre novamente. Depois, tente de novo.",
-    "ssoMfaTrustGuidance": "Sua organização autentica você por meio de um provedor de identidade — peça ao seu administrador para habilitar a confiança de MFA para ele, ou registre um fator nas configurações do seu perfil.",
     "retry": "Tentar novamente",
     "multiFactorAuthenticationIsRequiredTo2": "A autenticação multifator é obrigatória para gerar instaladores.",
     "installerDownloadedRunItOn": "Instalador baixado. Execute-o no",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -2110,6 +2110,8 @@
     "securitySettings": "Configurações de segurança",
     "enforceSSOOnlyLogin": "Aplicar login somente SSO",
     "usersMustUseSSOToSignInPasswordLoginWillBeDisabled": "Os usuários devem usar o SSO para fazer login. O login com senha será desativado.",
+    "trustThisProvidersMFA": "Confiar na MFA deste provedor",
+    "trustThisProvidersMFAHelperText": "Quando seu provedor de identidade informa que a autenticação multifator foi usada (`amr: mfa`), a MFA é considerada satisfeita no Breeze. Seu IdP deve incluir a declaração `amr` em seu token de ID — a maioria exige que isso seja habilitado explicitamente. Desativado por padrão.",
     "warningSSOEnforcementEnabled": "Aviso: aplicação de SSO ativada",
     "usersWillNotBeAbleToSignInWithPasswordsMakeSureYourSSOCo": "Os usuários não poderão fazer login com senhas. Certifique-se de que sua configuração de SSO esteja funcionando corretamente antes de ativar esta opção. Considere ter pelo menos uma conta de administrador que possa ignorar o SSO para acesso de emergência.",
     "testing": "Testando...",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1959,6 +1959,9 @@
     "ssoReauthConfigChanged": "Suas configurações de logon único mudaram durante a verificação. Inicie a verificação novamente.",
     "ssoReauthEmailUnverified": "Seu provedor de identidade informa que seu endereço de e-mail não foi verificado. Verifique-o lá e tente de novo.",
     "ssoReauthProofExpired": "Sua verificação com o provedor de identidade expirou. Verifique novamente para concluir a configuração da autenticação multifator.",
+    "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Esta conta faz login por um provedor de identidade e não tem senha. Verifique novamente com o provedor antes de adicionar uma chave de acesso.",
+    "verifyWithYourIdentityProvider": "Verificar com seu provedor de identidade",
+    "passkeyIdpVerificationRequired": "Verifique com seu provedor de identidade antes de adicionar uma chave de acesso.",
     "ssoReauthFailed": "Não foi possível verificar com seu provedor de identidade. Tente novamente.",
     "couldNotStartIdentityProviderVerification": "Não foi possível iniciar a verificação pelo provedor de identidade."
   },

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1861,7 +1861,8 @@
     "showRecoveryCodes": "Mostrar códigos de recuperação",
     "verifyYourIdentity": "Verifique sua identidade",
     "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Esta conta faz login por meio de um provedor de identidade e não tem senha. Verifique-se novamente com seu provedor para começar a configurar um aplicativo autenticador.",
-    "verifyWithYourIdentityProvider": "Verificar com seu provedor de identidade"
+    "verifyWithYourIdentityProvider": "Verificar com seu provedor de identidade",
+    "ssoReauthProofExpired": "Sua verificação com o provedor de identidade expirou. Verifique novamente para concluir a configuração do seu aplicativo autenticador."
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Importar do Pax8",
@@ -1954,6 +1955,10 @@
     "ssoReauthSessionInvalid": "Sua sessão mudou durante a verificação. Faça login novamente e tente de novo.",
     "ssoReauthPasswordSet": "Esta conta agora tem uma senha. Use-a para configurar a autenticação multifator.",
     "ssoReauthUnavailable": "A verificação pelo provedor de identidade está temporariamente indisponível. Tente novamente em instantes.",
+    "ssoReauthProviderInactive": "O logon único não está mais disponível para esta conta. Fale com o administrador e tente de novo.",
+    "ssoReauthConfigChanged": "Suas configurações de logon único mudaram durante a verificação. Inicie a verificação novamente.",
+    "ssoReauthEmailUnverified": "Seu provedor de identidade informa que seu endereço de e-mail não foi verificado. Verifique-o lá e tente de novo.",
+    "ssoReauthProofExpired": "Sua verificação com o provedor de identidade expirou. Verifique novamente para concluir a configuração da autenticação multifator.",
     "ssoReauthFailed": "Não foi possível verificar com seu provedor de identidade. Tente novamente.",
     "couldNotStartIdentityProviderVerification": "Não foi possível iniciar a verificação pelo provedor de identidade."
   },

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1858,7 +1858,10 @@
     "disabling": "Desativando...",
     "generating": "Gerando...",
     "regenerateCodes": "Regenerar códigos",
-    "showRecoveryCodes": "Mostrar códigos de recuperação"
+    "showRecoveryCodes": "Mostrar códigos de recuperação",
+    "verifyYourIdentity": "Verifique sua identidade",
+    "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Esta conta faz login por meio de um provedor de identidade e não tem senha. Verifique-se novamente com seu provedor para começar a configurar um aplicativo autenticador.",
+    "verifyWithYourIdentityProvider": "Verificar com seu provedor de identidade"
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Importar do Pax8",
@@ -1945,7 +1948,14 @@
     "failedToEnableMfaHttp": "Falha ao ativar MFA (HTTP {{status}})",
     "failedToDisableMfaHttp": "Falha ao desativar MFA (HTTP {{status}})",
     "failedToStartPasskeyHttp": "Falha ao iniciar a configuração da chave de acesso (HTTP {{status}})",
-    "failedToSavePasskeyHttp": "Falha ao salvar a chave de acesso (HTTP {{status}})"
+    "failedToSavePasskeyHttp": "Falha ao salvar a chave de acesso (HTTP {{status}})",
+    "ssoReauthNotFresh": "Seu provedor de identidade não verificou seu login novamente. Tente de novo ou peça ao administrador para permitir solicitações de reautenticação.",
+    "ssoReauthIdentityMismatch": "Essa conta do provedor de identidade não é a vinculada a este perfil. Faça login com sua própria conta e tente de novo.",
+    "ssoReauthSessionInvalid": "Sua sessão mudou durante a verificação. Faça login novamente e tente de novo.",
+    "ssoReauthPasswordSet": "Esta conta agora tem uma senha. Use-a para configurar a autenticação multifator.",
+    "ssoReauthUnavailable": "A verificação pelo provedor de identidade está temporariamente indisponível. Tente novamente em instantes.",
+    "ssoReauthFailed": "Não foi possível verificar com seu provedor de identidade. Tente novamente.",
+    "couldNotStartIdentityProviderVerification": "Não foi possível iniciar a verificação pelo provedor de identidade."
   },
   "roleManager": {
     "roles": "Funções",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -111,7 +111,10 @@
     "expiryMinutes_one": "yaklaşık {{count}} dakika içinde",
     "expiryMinutes_other": "yaklaşık {{count}} dakika içinde",
     "expiryHours_one": "yaklaşık {{count}} saat içinde",
-    "expiryHours_other": "yaklaşık {{count}} saat içinde"
+    "expiryHours_other": "yaklaşık {{count}} saat içinde",
+    "mfaRequiredSsoLinks": "Bağlantı oluşturmak için çok faktörlü kimlik doğrulama gereklidir. Kuruluşunuz sizi bir kimlik sağlayıcısı üzerinden oturuma alıyor — yöneticinizden bunun için MFA güvenini etkinleştirmesini isteyin ya da profil ayarlarınızdan bir faktör kaydedin.",
+    "mfaRequiredSsoInstallers": "Yükleyici oluşturmak için çok faktörlü kimlik doğrulama gereklidir. Kuruluşunuz sizi bir kimlik sağlayıcısı üzerinden oturuma alıyor — yöneticinizden bunun için MFA güvenini etkinleştirmesini isteyin ya da profil ayarlarınızdan bir faktör kaydedin.",
+    "mfaRequiredSsoTokens": "Kurulum belirteci oluşturmak için çok faktörlü kimlik doğrulama gereklidir. Kuruluşunuz sizi bir kimlik sağlayıcısı üzerinden oturuma alıyor — yöneticinizden bunun için MFA güvenini etkinleştirmesini isteyin ya da profil ayarlarınızdan bir faktör kaydedin."
   },
   "changeSiteModal": {
     "failedToLoadSites": "Siteler yüklenemedi",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -82,6 +82,7 @@
     "multiFactorAuthenticationIsRequiredTo": "Bağlantı oluşturmak için çok faktörlü kimlik doğrulama gereklidir.",
     "setUpMfaInYourProfile": "Profil ayarlarınızda MFA'yı kurun",
     "andSignInAgainThenRetry": "ve tekrar oturum açın, ardından tekrar deneyin.",
+    "ssoMfaTrustGuidance": "Kuruluşunuz sizi bir kimlik sağlayıcı üzerinden oturum açtırıyor — yöneticinizden bunun için MFA güvenini etkinleştirmesini isteyin veya profil ayarlarınızda bir faktör kaydedin.",
     "retry": "Tekrar dene",
     "multiFactorAuthenticationIsRequiredTo2": "Yükleyici oluşturmak için çok faktörlü kimlik doğrulama gereklidir.",
     "installerDownloadedRunItOn": "Yükleyici indirildi. Çalıştır",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -82,7 +82,6 @@
     "multiFactorAuthenticationIsRequiredTo": "Bağlantı oluşturmak için çok faktörlü kimlik doğrulama gereklidir.",
     "setUpMfaInYourProfile": "Profil ayarlarınızda MFA'yı kurun",
     "andSignInAgainThenRetry": "ve tekrar oturum açın, ardından tekrar deneyin.",
-    "ssoMfaTrustGuidance": "Kuruluşunuz sizi bir kimlik sağlayıcı üzerinden oturum açtırıyor — yöneticinizden bunun için MFA güvenini etkinleştirmesini isteyin veya profil ayarlarınızda bir faktör kaydedin.",
     "retry": "Tekrar dene",
     "multiFactorAuthenticationIsRequiredTo2": "Yükleyici oluşturmak için çok faktörlü kimlik doğrulama gereklidir.",
     "installerDownloadedRunItOn": "Yükleyici indirildi. Çalıştır",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1858,7 +1858,10 @@
     "disabling": "Devre dışı bırakılıyor...",
     "generating": "Oluşturuluyor...",
     "regenerateCodes": "Kodları yeniden oluştur",
-    "showRecoveryCodes": "Kurtarma kodlarını göster"
+    "showRecoveryCodes": "Kurtarma kodlarını göster",
+    "verifyYourIdentity": "Kimliğinizi doğrulayın",
+    "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Bu hesap bir kimlik sağlayıcısı üzerinden oturum açar ve parolası yoktur. Kimlik doğrulayıcı uygulama kurulumuna başlamak için sağlayıcınızda kimliğinizi yeniden doğrulayın.",
+    "verifyWithYourIdentityProvider": "Kimlik sağlayıcınızla doğrulayın"
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Pax8'den içe aktar",
@@ -1945,7 +1948,14 @@
     "failedToEnableMfaHttp": "MFA etkinleştirilemedi (HTTP {{status}})",
     "failedToDisableMfaHttp": "MFA devre dışı bırakılamadı (HTTP {{status}})",
     "failedToStartPasskeyHttp": "Şifre kurulumu başlatılamadı (HTTP {{status}})",
-    "failedToSavePasskeyHttp": "Şifre kaydedilemedi (HTTP {{status}})"
+    "failedToSavePasskeyHttp": "Şifre kaydedilemedi (HTTP {{status}})",
+    "ssoReauthNotFresh": "Kimlik sağlayıcınız oturum açmanızı yeniden doğrulamadı. Tekrar deneyin veya yöneticinizden yeniden kimlik doğrulama istemlerine izin vermesini isteyin.",
+    "ssoReauthIdentityMismatch": "Bu kimlik sağlayıcısı hesabı bu profile bağlı olan hesap değil. Kendi hesabınızla oturum açıp tekrar deneyin.",
+    "ssoReauthSessionInvalid": "Doğrulama sırasında oturumunuz değişti. Yeniden oturum açıp tekrar deneyin.",
+    "ssoReauthPasswordSet": "Bu hesabın artık bir parolası var. Çok faktörlü kimlik doğrulamayı kurmak için onu kullanın.",
+    "ssoReauthUnavailable": "Kimlik sağlayıcısı doğrulaması geçici olarak kullanılamıyor. Lütfen kısa süre sonra tekrar deneyin.",
+    "ssoReauthFailed": "Kimlik sağlayıcınızla doğrulanamadı. Lütfen tekrar deneyin.",
+    "couldNotStartIdentityProviderVerification": "Kimlik sağlayıcısı doğrulaması başlatılamadı."
   },
   "roleManager": {
     "roles": "Roller",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -2110,6 +2110,8 @@
     "securitySettings": "Güvenlik Ayarları",
     "enforceSSOOnlyLogin": "Yalnızca SSO oturum açmayı zorunlu kıl",
     "usersMustUseSSOToSignInPasswordLoginWillBeDisabled": "Kullanıcılar oturum açmak için SSO'yu kullanmalıdır. Şifreyle oturum açma devre dışı bırakılacaktır.",
+    "trustThisProvidersMFA": "Bu sağlayıcının MFA'sına güven",
+    "trustThisProvidersMFAHelperText": "Kimlik sağlayıcınız çok faktörlü kimlik doğrulamanın kullanıldığını bildirdiğinde (`amr: mfa`), Breeze'de MFA karşılanmış sayılır. IdP'niz, kimlik belirtecinde `amr` talebini içermelidir — çoğu bunun açıkça etkinleştirilmesini gerektirir. Varsayılan olarak kapalıdır.",
     "warningSSOEnforcementEnabled": "Uyarı: SSO uygulaması etkinleştirildi",
     "usersWillNotBeAbleToSignInWithPasswordsMakeSureYourSSOCo": "Kullanıcılar şifrelerle oturum açamayacaktır. Bu seçeneği etkinleştirmeden önce SSO yapılandırmanızın doğru çalıştığından emin olun. Acil durum erişimi için SSO'yu atlayabilecek en az bir yönetici hesabına sahip olmayı düşünün.",
     "testing": "Test ediliyor...",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1959,6 +1959,9 @@
     "ssoReauthConfigChanged": "Doğrulama sırasında çoklu oturum açma ayarlarınız değişti. Doğrulamayı yeniden başlatın.",
     "ssoReauthEmailUnverified": "Kimlik sağlayıcınız e-posta adresinizin doğrulanmadığını bildiriyor. Adresi orada doğrulayıp tekrar deneyin.",
     "ssoReauthProofExpired": "Kimlik sağlayıcısı doğrulamanızın süresi doldu. Çok faktörlü kimlik doğrulama kurulumunu tamamlamak için yeniden doğrulayın.",
+    "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Bu hesap bir kimlik sağlayıcı üzerinden oturum açıyor ve parolası yok. Geçiş anahtarı eklemeden önce sağlayıcınızda yeniden doğrulayın.",
+    "verifyWithYourIdentityProvider": "Kimlik sağlayıcınızla doğrulayın",
+    "passkeyIdpVerificationRequired": "Geçiş anahtarı eklemeden önce kimlik sağlayıcınızla doğrulayın.",
     "ssoReauthFailed": "Kimlik sağlayıcınızla doğrulanamadı. Lütfen tekrar deneyin.",
     "couldNotStartIdentityProviderVerification": "Kimlik sağlayıcısı doğrulaması başlatılamadı."
   },

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1861,7 +1861,8 @@
     "showRecoveryCodes": "Kurtarma kodlarını göster",
     "verifyYourIdentity": "Kimliğinizi doğrulayın",
     "thisAccountSignsInThroughAnIdentityProviderAndHasNoPassw": "Bu hesap bir kimlik sağlayıcısı üzerinden oturum açar ve parolası yoktur. Kimlik doğrulayıcı uygulama kurulumuna başlamak için sağlayıcınızda kimliğinizi yeniden doğrulayın.",
-    "verifyWithYourIdentityProvider": "Kimlik sağlayıcınızla doğrulayın"
+    "verifyWithYourIdentityProvider": "Kimlik sağlayıcınızla doğrulayın",
+    "ssoReauthProofExpired": "Kimlik sağlayıcısı doğrulamanızın süresi doldu. Kimlik doğrulayıcı uygulamanızın kurulumunu tamamlamak için yeniden doğrulayın."
   },
   "pax8CatalogDrawer": {
     "importFromPax8": "Pax8'den içe aktar",
@@ -1954,6 +1955,10 @@
     "ssoReauthSessionInvalid": "Doğrulama sırasında oturumunuz değişti. Yeniden oturum açıp tekrar deneyin.",
     "ssoReauthPasswordSet": "Bu hesabın artık bir parolası var. Çok faktörlü kimlik doğrulamayı kurmak için onu kullanın.",
     "ssoReauthUnavailable": "Kimlik sağlayıcısı doğrulaması geçici olarak kullanılamıyor. Lütfen kısa süre sonra tekrar deneyin.",
+    "ssoReauthProviderInactive": "Çoklu oturum açma bu hesap için artık kullanılamıyor. Yöneticinize danışın, sonra tekrar deneyin.",
+    "ssoReauthConfigChanged": "Doğrulama sırasında çoklu oturum açma ayarlarınız değişti. Doğrulamayı yeniden başlatın.",
+    "ssoReauthEmailUnverified": "Kimlik sağlayıcınız e-posta adresinizin doğrulanmadığını bildiriyor. Adresi orada doğrulayıp tekrar deneyin.",
+    "ssoReauthProofExpired": "Kimlik sağlayıcısı doğrulamanızın süresi doldu. Çok faktörlü kimlik doğrulama kurulumunu tamamlamak için yeniden doğrulayın.",
     "ssoReauthFailed": "Kimlik sağlayıcınızla doğrulanamadı. Lütfen tekrar deneyin.",
     "couldNotStartIdentityProviderVerification": "Kimlik sağlayıcısı doğrulaması başlatılamadı."
   },

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -1392,6 +1392,85 @@ describe('fetchAndApplyPreferences locale wiring', () => {
     const [message] = warnSpy.mock.calls[0] as [string];
     expect(message).toContain('locale resolution skipped');
   });
+
+  // #4018: this is the proof that `useAuthStore(s => s.user?.hasPassword)`
+  // is a REAL runtime signal and not a branch only a test can enter. A prior
+  // attempt at the AddDeviceModal SSO copy was correctly reverted precisely
+  // because nothing populated this field: /users/me did not return it, so the
+  // branch was unreachable in production while a unit test that set the store
+  // value directly still went green. These two cases drive the actual
+  // hydration path (GET /users/me -> updateUser) end to end.
+  it('hydrates hasPassword=false from /users/me for a passwordless SSO account', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      makeResponse({
+        id: 'user-1',
+        email: 'user@example.com',
+        name: 'User One',
+        preferences: {},
+        partnerId: 'partner-1',
+        orgId: null,
+        scope: 'partner',
+        partnerDefaultLocale: null,
+        permissions: [],
+        hasPassword: false,
+        requiresSetup: false
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(useAuthStore.getState().user?.hasPassword).toBeUndefined();
+    await fetchAndApplyPreferences();
+
+    expect(useAuthStore.getState().user?.hasPassword).toBe(false);
+  });
+
+  it('hydrates hasPassword=true from /users/me for a password account', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      makeResponse({
+        id: 'user-1',
+        email: 'user@example.com',
+        name: 'User One',
+        preferences: {},
+        partnerId: 'partner-1',
+        orgId: null,
+        scope: 'partner',
+        partnerDefaultLocale: null,
+        permissions: [],
+        hasPassword: true,
+        requiresSetup: false
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchAndApplyPreferences();
+
+    expect(useAuthStore.getState().user?.hasPassword).toBe(true);
+  });
+
+  // A server that has not shipped the field yet must leave the store value
+  // ABSENT (unknown), never coerce it to false — false is what flips the UI
+  // onto the identity-provider road.
+  it('leaves hasPassword absent when /users/me omits it', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      makeResponse({
+        id: 'user-1',
+        email: 'user@example.com',
+        name: 'User One',
+        preferences: {},
+        partnerId: 'partner-1',
+        orgId: null,
+        scope: 'partner',
+        partnerDefaultLocale: null,
+        permissions: [],
+        requiresSetup: false
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchAndApplyPreferences();
+
+    expect(useAuthStore.getState().user?.hasPassword).toBeUndefined();
+  });
 });
 
 describe('apiRegisterPartner recovery action', () => {

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -66,6 +66,13 @@ export interface User {
   // sessions persisted before this field (treat absent as capable; the server
   // enforces regardless).
   canManagePartnerWide?: boolean;
+  // #4018: whether the account has a password set (false for an SSO-provisioned
+  // account that was JIT-created without one). A companion plan task wires
+  // `hasPassword` into `GET /auth/me` for the profile page; nothing currently
+  // populates it on THIS store's `/users/me`-backed user object, so it reads as
+  // absent (undefined) here today. Treat absent as UNKNOWN, never as "has a
+  // password": always compare with `=== false`, never `!user?.hasPassword`.
+  hasPassword?: boolean;
   preferences?: UserPreferences;
 }
 

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -66,6 +66,18 @@ export interface User {
   // sessions persisted before this field (treat absent as capable; the server
   // enforces regardless).
   canManagePartnerWide?: boolean;
+  // #4018: whether the account has a password set. False for an SSO-provisioned
+  // (JIT) account, which therefore cannot satisfy any password step-up — UI that
+  // would otherwise tell such a user to "set up MFA and sign in again" has to
+  // point them at their identity provider instead.
+  //
+  // Populated by `GET /users/me` (routes/users.ts), which is what
+  // completeBootstrapLogin stores wholesale and what fetchAndApplyPreferences
+  // merges below. Still OPTIONAL because a session persisted before the field
+  // existed has no value until its next /users/me refresh: treat absent as
+  // UNKNOWN, never as "has a password" — always compare with `=== false`, never
+  // `!user?.hasPassword`.
+  hasPassword?: boolean;
   preferences?: UserPreferences;
 }
 
@@ -1416,6 +1428,14 @@ export async function fetchAndApplyPreferences(): Promise<void> {
     // the field existed still pick up their grants without a re-login.
     if (Array.isArray(data.permissions)) {
       useAuthStore.getState().updateUser({ permissions: data.permissions });
+    }
+    // #4018: same rationale — the password-login path stores `data.user` from
+    // /auth/login, which carries no hasPassword, and sessions persisted before
+    // the field existed carry none either. This refresh (run on every login and
+    // on the SSO bootstrap) is what makes `user.hasPassword === false` a real
+    // runtime signal rather than a permanently-absent field.
+    if (typeof data.hasPassword === 'boolean') {
+      useAuthStore.getState().updateUser({ hasPassword: data.hasPassword });
     }
     if (typeof data.canManagePartnerWide === 'boolean') {
       useAuthStore.getState().updateUser({ canManagePartnerWide: data.canManagePartnerWide });

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -66,13 +66,6 @@ export interface User {
   // sessions persisted before this field (treat absent as capable; the server
   // enforces regardless).
   canManagePartnerWide?: boolean;
-  // #4018: whether the account has a password set (false for an SSO-provisioned
-  // account that was JIT-created without one). A companion plan task wires
-  // `hasPassword` into `GET /auth/me` for the profile page; nothing currently
-  // populates it on THIS store's `/users/me`-backed user object, so it reads as
-  // absent (undefined) here today. Treat absent as UNKNOWN, never as "has a
-  // password": always compare with `=== false`, never `!user?.hasPassword`.
-  hasPassword?: boolean;
   preferences?: UserPreferences;
 }
 

--- a/docs/superpowers/plans/2026-08-25-sso-reauth-enrollment-grant.md
+++ b/docs/superpowers/plans/2026-08-25-sso-reauth-enrollment-grant.md
@@ -1,0 +1,1266 @@
+# SSO Re-Authentication Enrollment Grant Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a passwordless, SSO-provisioned user prove identity through a fresh IdP round-trip and use that proof — instead of a password — to enroll their first MFA factor or passkey, unblocking `requireMfa()`, the approval-assurance ladder, and L4 re-auth (#4018).
+
+**Architecture:** A third `sso_sessions` mode ("reauth") alongside the existing `login` and `link` modes. `POST /sso/reauth/start` snapshots the caller's `{authEpoch, mfaEpoch, sid}` exactly as `/sso/link/start` does and sends them to their own IdP with `prompt=login&max_age=0`. The callback re-checks that binding against live state, requires the returned `id_token` to carry a **fresh** `auth_time` and a `sub` that already belongs to this user, and mints a single-use `mfa:stepup` grant with a new operation, `enroll_first_factor`. The MFA/passkey enrollment endpoints accept that grant in place of `currentPassword` — and **only** for accounts with `password_hash IS NULL`.
+
+**Tech Stack:** Hono + TypeScript (apps/api), Drizzle ORM, Postgres, Redis (ioredis), Vitest, Astro + React (apps/web), Starlight (apps/docs).
+
+## Global Constraints
+
+- **The re-auth start route MUST NOT be behind `requireMfa()`.** `/sso/link/start` is (`apps/api/src/routes/sso.ts:1680-1683`); copying that would recreate the exact deadlock #4018 describes. It is behind `authMiddleware` only.
+- **`auth_time` absent is a REJECT, not a pass.** An IdP that ignores `prompt=login`/`max_age=0` and replays a cached session must not be able to mint an enrollment grant. Fail closed.
+- **`auth_time` must be at or after the moment this transaction started** (`sso_sessions.created_at`, minus clock skew) — not merely "recent". A window measured from *now* would accept an IdP authentication that happened before the user ever clicked the button, which is the cached-session replay this whole check exists to stop. Never substitute `iat` for `auth_time`: a fresh token can be minted from an old login.
+- **The grant is only honoured for accounts with `password_hash IS NULL`.** An account that has a password uses the existing password step-up; the SSO path must never become a weaker parallel road to factor enrollment.
+- **The grant only authorizes a FIRST factor.** `enforceExistingFactorStepUp` (`apps/api/src/routes/auth/helpers.ts:245+`) is untouched: adding a second factor to an already-protected account still requires proving the existing one.
+- **Every new `sso_sessions` DB touch runs in system context.** The table is system-scope-only under RLS (2026-07-16 migration). Inside an authenticated request, call `runOutsideDbContext(() => withSystemDbAccessContext(...))` — the pattern at `apps/api/src/routes/sso.ts:1745-1760`.
+- **Migration naming:** `apps/api/migrations/2026-08-25-<slug>.sql`. Idempotent (`ADD COLUMN IF NOT EXISTS`, `DO $$ ... EXCEPTION`). **No inner `BEGIN;`/`COMMIT;`** — `autoMigrate` wraps each file. Never add to the closed `2026-08-06-*` block.
+- **Reasoning effort for reviewers:** this is auth code. Every task ends with its tests actually run, not assumed.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `apps/api/src/services/sso.ts` | `buildAuthorizationUrl` gains `prompt`/`maxAge`; `IDTokenClaims.auth_time`; new `assertFreshIdpAuthentication` | 1 |
+| `apps/api/migrations/2026-08-25-sso-sessions-reauth-user-id.sql` | `reauth_user_id` column + XOR check + index | 2 |
+| `apps/api/src/db/schema/sso.ts` | `reauthUserId` on `ssoSessions` | 2 |
+| `apps/api/src/services/tenantCascade.ts` | comment correction only (provider-keyed SQL unchanged) | 2 |
+| `apps/api/src/services/mfaStepUpGrant.ts` | `'enroll_first_factor'` added to `StepUpOperation` | 4 |
+| `apps/api/src/routes/sso.ts` | `POST /sso/reauth/start`; callback reauth branch; `SsoCallbackMode` widened | 3, 4 |
+| `apps/api/src/routes/auth/mfa.ts` | `/mfa/setup` + `/mfa/enable` accept `ssoReauthGrantId` | 5 |
+| `apps/api/src/routes/auth/passkeys.ts` | `/passkeys/register/options` + `/verify` accept `ssoReauthGrantId` | 5 |
+| `apps/api/src/routes/auth/helpers.ts` | `resolveEnrollmentStepUp` — the single decision point | 5 |
+| `apps/api/src/routes/auth/password.ts` | `/auth/me` returns `hasPassword` | 6 |
+| `apps/web/src/components/settings/ProfilePage.tsx` | passwordless branch + `#ssoReauthGrant` fragment handling | 6 |
+| `apps/web/src/components/settings/SsoProvidersPage.tsx` | `trustsIdpMfa` toggle | 7 |
+| `apps/web/src/components/devices/AddDeviceModal.tsx` | SSO-aware MFA copy | 7 |
+| `apps/docs/src/content/docs/reference/sso.mdx` | document both the flag and the re-auth flow | 7 |
+
+---
+
+### Task 1: OIDC re-authentication primitives
+
+The authorization-URL builder cannot currently ask for a forced re-auth, and `auth_time` is untyped. Both are pure functions with no DB — do them first so later tasks can rely on them.
+
+**Files:**
+- Modify: `apps/api/src/services/sso.ts:94-111` (`buildAuthorizationUrl`), `:231-246` (`IDTokenClaims`)
+- Test: `apps/api/src/services/sso.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `buildAuthorizationUrl(params: AuthorizationUrlParams & { prompt?: string; maxAge?: number }): string`
+  - `IDTokenClaims.auth_time?: number`
+  - `assertFreshIdpAuthentication(claims: Pick<IDTokenClaims, 'auth_time'>, startedAtMs: number, nowMs?: number): { ok: true } | { ok: false; reason: 'auth_time_missing' | 'auth_time_stale' | 'auth_time_future' }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/api/src/services/sso.test.ts`:
+
+```ts
+import { buildAuthorizationUrl, assertFreshIdpAuthentication } from './sso';
+
+const CONFIG = {
+  issuer: 'https://idp.example.com',
+  authorizationUrl: 'https://idp.example.com/authorize',
+  tokenUrl: 'https://idp.example.com/token',
+  jwksUrl: 'https://idp.example.com/jwks',
+  clientId: 'client-123',
+  clientSecret: 'secret',
+  scopes: 'openid email profile',
+} as any;
+
+describe('buildAuthorizationUrl re-auth params', () => {
+  it('omits prompt and max_age when not requested', () => {
+    const url = new URL(buildAuthorizationUrl({
+      config: CONFIG, state: 's', nonce: 'n', redirectUri: 'https://app/cb',
+    }));
+    expect(url.searchParams.has('prompt')).toBe(false);
+    expect(url.searchParams.has('max_age')).toBe(false);
+  });
+
+  it('sets prompt=login and max_age=0 when requested', () => {
+    const url = new URL(buildAuthorizationUrl({
+      config: CONFIG, state: 's', nonce: 'n', redirectUri: 'https://app/cb',
+      prompt: 'login', maxAge: 0,
+    }));
+    expect(url.searchParams.get('prompt')).toBe('login');
+    // max_age=0 must survive: a falsy-check bug would drop it and silently
+    // turn a forced re-auth into an ordinary (cache-satisfiable) login.
+    expect(url.searchParams.get('max_age')).toBe('0');
+  });
+});
+
+describe('assertFreshIdpAuthentication', () => {
+  const NOW = 1_800_000_000_000;        // fixed clock, ms
+  const STARTED = NOW - 30_000;         // transaction began 30s ago
+
+  it('rejects a missing auth_time (IdP ignored prompt=login)', () => {
+    expect(assertFreshIdpAuthentication({}, STARTED, NOW))
+      .toEqual({ ok: false, reason: 'auth_time_missing' });
+  });
+
+  it('rejects an auth_time from BEFORE the transaction started', () => {
+    // The cached-session replay this check exists for: the IdP returns a
+    // perfectly recent auth_time that nonetheless predates the user's click.
+    const beforeStart = Math.floor(STARTED / 1000) - 121;
+    expect(assertFreshIdpAuthentication({ auth_time: beforeStart }, STARTED, NOW))
+      .toEqual({ ok: false, reason: 'auth_time_stale' });
+  });
+
+  it('rejects an auth_time in the future beyond clock skew', () => {
+    const future = Math.floor(NOW / 1000) + 121;
+    expect(assertFreshIdpAuthentication({ auth_time: future }, STARTED, NOW))
+      .toEqual({ ok: false, reason: 'auth_time_future' });
+  });
+
+  it('accepts an auth_time from during the round trip', () => {
+    const during = Math.floor(STARTED / 1000) + 5;
+    expect(assertFreshIdpAuthentication({ auth_time: during }, STARTED, NOW))
+      .toEqual({ ok: true });
+  });
+
+  it('accepts an auth_time slightly before the start, inside skew tolerance', () => {
+    const justBefore = Math.floor(STARTED / 1000) - 30;
+    expect(assertFreshIdpAuthentication({ auth_time: justBefore }, STARTED, NOW))
+      .toEqual({ ok: true });
+  });
+
+  it('never accepts iat as a substitute for auth_time', () => {
+    expect(assertFreshIdpAuthentication({ iat: Math.floor(NOW / 1000) } as any, STARTED, NOW))
+      .toEqual({ ok: false, reason: 'auth_time_missing' });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @breeze/api test -- --run src/services/sso.test.ts`
+Expected: FAIL — `assertFreshIdpAuthentication is not a function`, and the `prompt`/`max_age` assertions fail.
+
+- [ ] **Step 3: Implement**
+
+In `apps/api/src/services/sso.ts`, extend the params interface used by `buildAuthorizationUrl` (find `AuthorizationUrlParams` directly above line 94) with:
+
+```ts
+  /** OIDC `prompt`. Pass 'login' to force the IdP to re-authenticate. */
+  prompt?: string;
+  /** OIDC `max_age` in seconds. 0 demands a fresh authentication. */
+  maxAge?: number;
+```
+
+and inside the function, after the `nonce` line (`apps/api/src/services/sso.ts:103`):
+
+```ts
+  if (params.prompt) {
+    url.searchParams.set('prompt', params.prompt);
+  }
+  // `!= null`, NOT a truthy check: max_age=0 is the value that actually forces
+  // a re-authentication, and `if (maxAge)` would silently drop it.
+  if (params.maxAge != null) {
+    url.searchParams.set('max_age', String(params.maxAge));
+  }
+```
+
+Add to `IDTokenClaims` (after `acr?: string;`, `apps/api/src/services/sso.ts:244`):
+
+```ts
+  /** OIDC Core §2: seconds since epoch of the END-USER's authentication.
+   * Required in the id_token whenever the request carried `max_age`. */
+  auth_time?: number;
+```
+
+Add the new helper next to `idpAssertedMfa` (`apps/api/src/services/sso.ts:255`):
+
+```ts
+/** Tolerance for an IdP clock running ahead of ours. */
+const AUTH_TIME_SKEW_SECONDS = 120;
+
+/**
+ * Verify the IdP actually re-authenticated the user for THIS transaction.
+ *
+ * Two independent bounds, both required:
+ *
+ *  - `auth_time` must EXIST. OIDC Core requires the claim whenever the
+ *    authorization request carried `max_age`, but real IdPs vary: some ignore
+ *    `prompt=login` and replay a cached session, and one that does so while
+ *    omitting `auth_time` would otherwise mint an enrollment grant off a
+ *    months-old browser session. Absent claim === no proof of freshness.
+ *  - `auth_time` must be at or after `startedAtMs` (the sso_sessions row's
+ *    created_at), minus skew. A window measured from NOW would happily accept
+ *    an authentication that predates the user's click — precisely the cached
+ *    session this is meant to reject.
+ *
+ * `iat` is never a substitute: a fresh token can be minted from an old login.
+ */
+export function assertFreshIdpAuthentication(
+  claims: Pick<IDTokenClaims, 'auth_time'>,
+  startedAtMs: number,
+  nowMs: number = Date.now(),
+): { ok: true } | { ok: false; reason: 'auth_time_missing' | 'auth_time_stale' | 'auth_time_future' } {
+  const authTime = claims.auth_time;
+  if (typeof authTime !== 'number' || !Number.isFinite(authTime)) {
+    return { ok: false, reason: 'auth_time_missing' };
+  }
+  const nowSeconds = Math.floor(nowMs / 1000);
+  const startedAtSeconds = Math.floor(startedAtMs / 1000);
+  if (authTime > nowSeconds + AUTH_TIME_SKEW_SECONDS) {
+    return { ok: false, reason: 'auth_time_future' };
+  }
+  if (authTime < startedAtSeconds - AUTH_TIME_SKEW_SECONDS) {
+    return { ok: false, reason: 'auth_time_stale' };
+  }
+  return { ok: true };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @breeze/api test -- --run src/services/sso.test.ts`
+Expected: PASS, and no other test in that file regresses.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/sso.ts apps/api/src/services/sso.test.ts
+git commit -m "feat(api): OIDC forced re-auth params and auth_time freshness check (#4018)"
+```
+
+---
+
+### Task 2: `sso_sessions.reauth_user_id` — the third mode
+
+**Files:**
+- Create: `apps/api/migrations/2026-08-25-sso-sessions-reauth-user-id.sql`
+- Modify: `apps/api/src/db/schema/sso.ts:112-146` (`ssoSessions`), `apps/api/src/services/tenantCascade.ts:434-435` (comment only)
+- Test: `apps/api/src/db/autoMigrate.test.ts` (already asserts ordering/naming — just run it)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `ssoSessions.reauthUserId: uuid | null`, mutually exclusive with `linkUserId`.
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/2026-08-25-sso-sessions-reauth-user-id.sql`:
+
+```sql
+-- #4018: third sso_sessions mode. A "reauth" transaction proves a passwordless
+-- SSO account's identity through a fresh IdP round-trip so the user can enroll
+-- a FIRST MFA factor. Mirrors link mode (link_user_id + the three initiating_*
+-- binding columns), which this reuses as-is.
+--
+-- ON DELETE CASCADE for the same reason link_user_id has it: sso_sessions has
+-- no org_id/partner_id, so the tenant-erasure sweep never reaches it by tenancy
+-- and an abandoned transaction must not block a hard user delete.
+ALTER TABLE sso_sessions
+  ADD COLUMN IF NOT EXISTS reauth_user_id uuid REFERENCES users(id) ON DELETE CASCADE;
+
+-- A session is exactly one of: login (both NULL), link, or reauth. Both set is
+-- a programming error that would make the callback's mode discriminator
+-- ambiguous, so refuse it in the database rather than ordering the checks.
+DO $$
+BEGIN
+  ALTER TABLE sso_sessions
+    ADD CONSTRAINT sso_sessions_single_mode_chk
+    CHECK (link_user_id IS NULL OR reauth_user_id IS NULL);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS sso_sessions_reauth_user_id_idx
+  ON sso_sessions (reauth_user_id)
+  WHERE reauth_user_id IS NOT NULL;
+```
+
+- [ ] **Step 2: Verify the migration applies and re-applies cleanly**
+
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:migrate
+pnpm db:migrate   # second run must be a no-op, not an error
+pnpm --filter @breeze/api test -- --run src/db/autoMigrate.test.ts
+```
+Expected: both migrate runs succeed; `autoMigrate.test.ts` PASSES (it asserts naming + ordering + that every referenced migration path resolves).
+
+- [ ] **Step 3: Add the Drizzle column**
+
+In `apps/api/src/db/schema/sso.ts`, immediately after the `linkUserId` block (line 126):
+
+```ts
+  // Reauth-mode marker (#4018): when set, the callback mints a single-use
+  // enrollment step-up grant for this user instead of logging in or linking.
+  // Same ON DELETE CASCADE rationale as linkUserId above. Mutually exclusive
+  // with linkUserId (sso_sessions_single_mode_chk).
+  reauthUserId: uuid('reauth_user_id').references(() => users.id, { onDelete: 'cascade' }),
+```
+
+Correct the now-stale comment in `apps/api/src/services/tenantCascade.ts:434`:
+
+```ts
+  // sso_sessions.link_user_id and .reauth_user_id both cascade on user delete;
+  // the provider FK does not — which is what this provider-keyed clear is for.
+```
+
+- [ ] **Step 4: Verify no drift and no cascade obligation was missed**
+
+```bash
+pnpm db:check-drift
+grep -n "sso_sessions" apps/api/src/services/tenantCascade.ts
+grep -n "sso_sessions" apps/api/src/services/tenantExportPolicyRegistry.ts
+```
+Expected: no drift. `tenantCascade.ts` shows the two provider-keyed clears (org + partner axis) — both key on `provider_id`, so **neither statement changes**. `tenantExportPolicyRegistry.ts` shows **no** match, which is correct: `sso_sessions` has no `org_id`, so it is not in `CORE_ORG_CASCADE_DELETE_ORDER` and needs no export-policy entry. Record that you checked — this is the step CLAUDE.md flags as the one that gets missed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-08-25-sso-sessions-reauth-user-id.sql apps/api/src/db/schema/sso.ts apps/api/src/services/tenantCascade.ts
+git commit -m "feat(api): sso_sessions reauth mode column (#4018)"
+```
+
+---
+
+### Task 3: `POST /sso/reauth/start`
+
+**Files:**
+- Modify: `apps/api/src/routes/sso.ts` — add the route immediately after the `/link/start/:providerId` handler (ends `apps/api/src/routes/sso.ts:1816`)
+- Modify: `apps/api/src/middleware/auth.ts:192-213` (`isMfaEnrollmentExemptPath`)
+- Test: `apps/api/src/routes/sso.reauth.test.ts` (new), `apps/api/src/middleware/auth.test.ts`
+
+**Interfaces:**
+- Consumes: `assertFreshIdpAuthentication` is not used here (callback only); uses `ssoSessions.reauthUserId` from Task 2.
+- Produces: `POST /api/v1/sso/reauth/start` → `200 { authUrl: string }` | `400 { error: 'Account has a password' }` | `404 { error: 'No linked SSO identity' }` | `429` | `503`.
+
+**Design notes the implementer must not "simplify" away:**
+- No client-supplied `providerId`. The provider is resolved from the caller's own `user_sso_identities` row, so a caller can never point the flow at a provider they do not already have an identity with.
+- **No `requireMfa()`.** See Global Constraints.
+- Refuse when the account HAS a password — those users already have a working step-up.
+- **`isMfaEnrollmentExemptPath` must learn about this route, or the whole feature is dead on arrival.** `authMiddleware` 428s an unenrolled user under a policy that requires MFA on every path outside a tight allowlist — currently `/auth/mfa/*`, `/auth/phone/*`, `/auth/passkeys/*`, `/users/me`, `/auth/logout` (`apps/api/src/middleware/auth.ts:205-212`). A policy-required, unenrolled, passwordless SSO user — the exact population this plan serves — would be bounced off `/sso/reauth/start` before the handler ran. Adding the exemption is safe for the same reason the passkey entry is: the route performs no account change of its own, it only starts an IdP round-trip.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/api/src/routes/sso.reauth.test.ts`, following the mocking style already used in `apps/api/src/routes/sso.test.ts` (copy its `vi.mock` block for `../db`, `../services`, and `../middleware/auth` verbatim, then add):
+
+```ts
+describe('POST /sso/reauth/start', () => {
+  it('refuses when the account has a password', async () => {
+    mockUserRow({ id: USER_ID, passwordHash: 'argon2id$...' });
+    const res = await app.request('/sso/reauth/start', { method: 'POST' }, ENV);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Account has a password' });
+  });
+
+  it('404s when the user has no linked SSO identity', async () => {
+    mockUserRow({ id: USER_ID, passwordHash: null });
+    mockSsoIdentityRows([]);
+    const res = await app.request('/sso/reauth/start', { method: 'POST' }, ENV);
+    expect(res.status).toBe(404);
+  });
+
+  it('inserts a reauth-mode session bound to the caller and returns an authUrl with prompt=login and max_age=0', async () => {
+    mockUserRow({ id: USER_ID, passwordHash: null });
+    mockSsoIdentityRows([{ providerId: PROVIDER_ID }]);
+    mockProviderRow({ id: PROVIDER_ID, status: 'active', type: 'oidc', configVersion: 7 });
+    mockUserEpochs({ authEpoch: 3, mfaEpoch: 1 });
+
+    const res = await app.request('/sso/reauth/start', { method: 'POST' }, ENV);
+    expect(res.status).toBe(200);
+
+    const { authUrl } = await res.json();
+    const url = new URL(authUrl);
+    expect(url.searchParams.get('prompt')).toBe('login');
+    expect(url.searchParams.get('max_age')).toBe('0');
+
+    expect(insertedSsoSession()).toMatchObject({
+      providerId: PROVIDER_ID,
+      reauthUserId: USER_ID,
+      linkUserId: undefined,
+      providerVersion: 7,
+      initiatingAuthEpoch: 3,
+      initiatingMfaEpoch: 1,
+      initiatingSessionId: SID,
+    });
+  });
+
+  it('503s when the caller has no sid or epochs are unavailable', async () => {
+    mockUserRow({ id: USER_ID, passwordHash: null });
+    mockSsoIdentityRows([{ providerId: PROVIDER_ID }]);
+    mockProviderRow({ id: PROVIDER_ID, status: 'active', type: 'oidc', configVersion: 7 });
+    mockUserEpochs(null);
+    const res = await app.request('/sso/reauth/start', { method: 'POST' }, ENV);
+    expect(res.status).toBe(503);
+  });
+
+  it('refuses a provider whose status is inactive', async () => {
+    mockUserRow({ id: USER_ID, passwordHash: null });
+    mockSsoIdentityRows([{ providerId: PROVIDER_ID }]);
+    mockProviderRow({ id: PROVIDER_ID, status: 'inactive', type: 'oidc', configVersion: 7 });
+    const res = await app.request('/sso/reauth/start', { method: 'POST' }, ENV);
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+Add to `apps/api/src/middleware/auth.test.ts` — this is the test that proves the feature is reachable at all:
+
+```ts
+it('exempts /sso/reauth/* from forced MFA enrollment', () => {
+  // A policy-required, unenrolled, passwordless SSO user is the entire target
+  // population. Without this exemption authMiddleware 428s them before the
+  // handler runs and the enrollment flow can never start.
+  expect(isMfaEnrollmentExemptPath('/api/v1/sso/reauth/start')).toBe(true);
+  expect(isMfaEnrollmentExemptPath('/sso/reauth/start')).toBe(true);
+});
+
+it('does not exempt other /sso paths', () => {
+  expect(isMfaEnrollmentExemptPath('/api/v1/sso/providers')).toBe(false);
+  expect(isMfaEnrollmentExemptPath('/api/v1/sso/link/start/abc')).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @breeze/api test -- --run src/routes/sso.reauth.test.ts`
+Expected: FAIL — 404 from Hono for an unregistered route.
+
+- [ ] **Step 3: Implement the route**
+
+Insert into `apps/api/src/routes/sso.ts` directly after the `/link/start/:providerId` handler:
+
+```ts
+// Start a REAUTH-mode IdP round-trip (#4018).
+//
+// Deliberately NOT behind requireMfa(): this route exists precisely because a
+// passwordless SSO account cannot satisfy requireMfa() yet — gating it the way
+// /link/start is gated would reproduce the deadlock it fixes.
+//
+// The provider is resolved from the caller's OWN linked identity, never from a
+// request parameter, so this can only ever re-authenticate against an IdP the
+// user already has a binding with.
+ssoRoutes.post('/reauth/start', authMiddleware, async (c) => {
+  const auth = c.get('auth') as AuthContext;
+
+  const redis = getRedis();
+  const rateCheck = await rateLimiter(redis, `sso:reauth:${auth.user.id}`, 5, 15 * 60);
+  if (!rateCheck.allowed) {
+    return c.json({
+      error: 'Too many attempts. Please try again later.',
+      retryAfter: Math.ceil((rateCheck.resetAt.getTime() - Date.now()) / 1000)
+    }, 429);
+  }
+
+  // An account WITH a password uses the existing password step-up. Allowing
+  // both would make this a weaker parallel road to factor enrollment.
+  const [userRow] = await db
+    .select({ passwordHash: users.passwordHash })
+    .from(users)
+    .where(eq(users.id, auth.user.id))
+    .limit(1);
+  if (!userRow) return c.json({ error: 'User not found' }, 404);
+  if (userRow.passwordHash != null) {
+    return c.json({ error: 'Account has a password' }, 400);
+  }
+
+  const [identity] = await db
+    .select({ providerId: userSsoIdentities.providerId })
+    .from(userSsoIdentities)
+    .where(eq(userSsoIdentities.userId, auth.user.id))
+    .orderBy(userSsoIdentities.createdAt, userSsoIdentities.id)
+    .limit(1);
+  if (!identity) {
+    return c.json({ error: 'No linked SSO identity' }, 404);
+  }
+
+  const [provider] = await db
+    .select()
+    .from(ssoProviders)
+    .where(eq(ssoProviders.id, identity.providerId))
+    .limit(1);
+  if (!provider || provider.status === 'inactive') {
+    return c.json({ error: 'Provider not found' }, 404);
+  }
+  if (provider.type !== 'oidc') {
+    return c.json({ error: 'Only OIDC re-authentication is currently supported' }, 400);
+  }
+
+  let config: OIDCConfig;
+  try {
+    config = getOIDCConfig(provider);
+  } catch (err) {
+    console.warn(`[sso] provider ${provider.id} has an invalid configuration:`, err);
+    return c.json({ error: 'SSO provider configuration is invalid' }, 400);
+  }
+
+  const initiatorEpochs = await getUserEpochs(auth.user.id);
+  const initiatingSid = auth.token?.sid;
+  if (!initiatorEpochs || !initiatingSid) {
+    return c.json({ error: 'Service temporarily unavailable' }, 503);
+  }
+
+  const pkce = generatePKCEChallenge();
+  const state = generateState();
+  const nonce = generateNonce();
+
+  await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () =>
+      db.insert(ssoSessions).values({
+        providerId: provider.id,
+        state,
+        nonce,
+        codeVerifier: pkce.codeVerifier,
+        redirectUrl: '/settings/profile',
+        reauthUserId: auth.user.id,
+        providerVersion: provider.configVersion,
+        initiatingAuthEpoch: initiatorEpochs.authEpoch,
+        initiatingMfaEpoch: initiatorEpochs.mfaEpoch,
+        initiatingSessionId: initiatingSid,
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000)
+      })
+    )
+  );
+
+  const authUrl = buildAuthorizationUrl({
+    config,
+    state,
+    nonce,
+    redirectUri: buildSsoCallbackUri(),
+    pkce,
+    // Force a real re-authentication. max_age=0 is the load-bearing half:
+    // prompt=login alone is advisory and several IdPs honour it inconsistently.
+    prompt: 'login',
+    maxAge: 0,
+  });
+
+  const stateCookie = buildSsoStateCookie(state);
+  if (!stateCookie) {
+    return c.json({ error: 'SSO login binding secret is not configured on this instance' }, 500);
+  }
+  c.header('Set-Cookie', stateCookie, { append: true });
+
+  writeRouteAudit(c, {
+    orgId: provider.orgId,
+    action: 'sso.reauth.started',
+    resourceType: 'sso_provider',
+    resourceId: provider.id,
+    resourceName: provider.name,
+    details: { partnerId: provider.partnerId, userId: auth.user.id }
+  });
+
+  return c.json({ authUrl });
+});
+```
+
+Add `users` and `userSsoIdentities` to the schema import at the top of the file if they are not already imported.
+
+Then add the exemption in `apps/api/src/middleware/auth.ts`, immediately after the `/auth/passkeys/` line (`:211`):
+
+```ts
+  // Starting an IdP re-authentication is an enrollment action for a
+  // PASSWORDLESS SSO account (#4018) — it is how such a user proves identity
+  // to install a first factor, since they have no password to prove. The route
+  // changes no account state on its own; it only begins an OIDC round trip.
+  if (rel.startsWith('/sso/reauth/')) return true;
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @breeze/api test -- --run src/routes/sso.reauth.test.ts src/routes/sso.test.ts src/middleware/auth.test.ts`
+Expected: PASS. Run `sso.test.ts` too — the new route sits in the same Hono instance and route-ordering regressions surface there.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/sso.ts apps/api/src/middleware/auth.ts apps/api/src/routes/sso.reauth.test.ts apps/api/src/middleware/auth.test.ts
+git commit -m "feat(api): POST /sso/reauth/start for passwordless SSO accounts (#4018)"
+```
+
+---
+
+### Task 4: Callback reauth branch + grant mint
+
+**Files:**
+- Modify: `apps/api/src/services/mfaStepUpGrant.ts:33` (`StepUpOperation`)
+- Modify: `apps/api/src/routes/sso.ts:592` (`SsoCallbackMode`), `:2119` (mode discriminator), `:665-...` (`validateLinkBinding` generalization), and the callback body just before the link branch at `:2325`
+- Test: `apps/api/src/routes/sso.reauth.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `assertFreshIdpAuthentication` (Task 1), `ssoSessions.reauthUserId` (Task 2), the route from Task 3.
+- Produces: on success, a redirect to `/settings/profile#ssoReauthGrant=<grantId>`; a `StepUpGrant` in Redis with `operation: 'enroll_first_factor'`.
+
+**Design notes:**
+- The reauth binding re-check is the *same* set of conditions as link mode. Generalize `validateLinkBinding` to read whichever user column is set rather than duplicating it.
+- Identity match is **stricter than link mode**: link mode compares the asserted email (`apps/api/src/routes/sso.ts:2337`) because it is *creating* the binding. Re-auth requires the `(providerId, sub)` identity row to **already belong to this user** — an email comparison alone would let an IdP that lets users change their own email address re-auth as someone else.
+- The grant is bound to `{userId, operation, authEpoch, mfaEpoch, sid}` by `mintStepUpGrant`, so it is already single-use, session-bound, and invalidated by any epoch bump.
+- Returning the grant id in the URL fragment mirrors the existing `#ssoCode` exchange the callback already uses for login. Fragments are not sent to the server or logged in access logs.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/api/src/routes/sso.reauth.test.ts`:
+
+```ts
+describe('GET /sso/callback — reauth mode', () => {
+  it('rejects when the id_token has no auth_time', async () => {
+    mockReauthSession({ reauthUserId: USER_ID });
+    mockIdToken({ sub: EXTERNAL_ID, email: 'tech@acme.example' }); // no auth_time
+    const res = await app.request(`/sso/callback?code=c&state=${STATE}`, {}, ENV);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('error=reauth_not_fresh');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale auth_time (IdP replayed a cached session)', async () => {
+    mockReauthSession({ reauthUserId: USER_ID });
+    mockIdToken({ sub: EXTERNAL_ID, auth_time: Math.floor(Date.now() / 1000) - 3600 });
+    const res = await app.request(`/sso/callback?code=c&state=${STATE}`, {}, ENV);
+    expect(res.headers.get('location')).toContain('error=reauth_not_fresh');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the asserted sub belongs to a different user', async () => {
+    mockReauthSession({ reauthUserId: USER_ID });
+    mockIdToken({ sub: EXTERNAL_ID, auth_time: Math.floor(Date.now() / 1000) - 5 });
+    mockSsoIdentityOwner(OTHER_USER_ID);
+    const res = await app.request(`/sso/callback?code=c&state=${STATE}`, {}, ENV);
+    expect(res.headers.get('location')).toContain('error=identity_mismatch');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the initiating session was revoked since /reauth/start', async () => {
+    mockReauthSession({ reauthUserId: USER_ID, initiatingAuthEpoch: 3 });
+    mockUserEpochs({ authEpoch: 4, mfaEpoch: 1 }); // bumped since start
+    mockIdToken({ sub: EXTERNAL_ID, auth_time: Math.floor(Date.now() / 1000) - 5 });
+    mockSsoIdentityOwner(USER_ID);
+    const res = await app.request(`/sso/callback?code=c&state=${STATE}`, {}, ENV);
+    expect(res.headers.get('location')).toContain('error=session_invalid');
+    expect(mintStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('mints an enroll_first_factor grant and redirects with it in the fragment', async () => {
+    mockReauthSession({ reauthUserId: USER_ID, initiatingAuthEpoch: 3, initiatingMfaEpoch: 1, initiatingSessionId: SID });
+    mockUserEpochs({ authEpoch: 3, mfaEpoch: 1 });
+    mockIdToken({ sub: EXTERNAL_ID, auth_time: Math.floor(Date.now() / 1000) - 5 });
+    mockSsoIdentityOwner(USER_ID);
+    mintStepUpGrant.mockResolvedValue('grant-abc');
+
+    const res = await app.request(`/sso/callback?code=c&state=${STATE}`, {}, ENV);
+
+    expect(mintStepUpGrant).toHaveBeenCalledWith({
+      userId: USER_ID,
+      operation: 'enroll_first_factor',
+      authEpoch: 3,
+      mfaEpoch: 1,
+      sid: SID,
+    });
+    expect(res.headers.get('location')).toBe('/settings/profile#ssoReauthGrant=grant-abc');
+  });
+
+  it('never mints login tokens in reauth mode', async () => {
+    mockReauthSession({ reauthUserId: USER_ID });
+    mockUserEpochs({ authEpoch: 3, mfaEpoch: 1 });
+    mockIdToken({ sub: EXTERNAL_ID, auth_time: Math.floor(Date.now() / 1000) - 5 });
+    mockSsoIdentityOwner(USER_ID);
+    await app.request(`/sso/callback?code=c&state=${STATE}`, {}, ENV);
+    expect(createTokenPair).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @breeze/api test -- --run src/routes/sso.reauth.test.ts`
+Expected: FAIL — the callback treats a reauth session as a login and mints tokens.
+
+- [ ] **Step 3: Implement**
+
+`apps/api/src/services/mfaStepUpGrant.ts:33`:
+
+```ts
+export type StepUpOperation = 'add_factor' | 'register_approver_device' | 'enroll_first_factor';
+```
+
+Update that file's doc comment to add a fourth minting source: *"(4) the SSO re-auth callback (`GET /sso/callback`, reauth mode), the passwordless equivalent of (2) — see #4018."*
+
+`apps/api/src/routes/sso.ts:592`:
+
+```ts
+type SsoCallbackMode = 'login' | 'link' | 'reauth';
+```
+
+`apps/api/src/routes/sso.ts:2119`:
+
+```ts
+  const callbackMode: SsoCallbackMode =
+    session.reauthUserId ? 'reauth' : session.linkUserId ? 'link' : 'login';
+```
+
+In `checkProviderGeneration` (`apps/api/src/routes/sso.ts:612-632`), reauth follows link's rule — a `testing` provider is acceptable, `inactive` is not — so the existing `mode === 'login'` branch already gives the right behaviour. Leave it, but extend the doc comment above it to say reauth shares link's rule.
+
+Generalize the binding validator. Rename nothing; change its signature to take the bound user id explicitly and update the two call sites:
+
+```ts
+async function validateSessionBinding(
+  session: typeof ssoSessions.$inferSelect,
+  provider: typeof ssoProviders.$inferSelect,
+  boundUserId: string,
+): Promise<{ ok: true; user: typeof users.$inferSelect } | { ok: false; reason: LinkRejectReason }> {
+```
+
+(The body is unchanged apart from using `boundUserId` where it used `session.linkUserId`. Keep the existing `LinkRejectReason` union — the reasons are identical.) The link branch now calls `validateSessionBinding(session, provider, session.linkUserId)`.
+
+Add the reauth branch in the callback **immediately before** the `if (session.linkUserId) {` block (`apps/api/src/routes/sso.ts:2325`), so it sits after the full id_token signature/nonce verification, the atomic session claim, and the userinfo `sub` binding — the same position link mode occupies:
+
+```ts
+    // #4018 reauth mode: an already-authenticated, PASSWORDLESS user proving
+    // identity through a fresh IdP round-trip so they can enroll a first MFA
+    // factor. Mints NO tokens, creates NO users, links NO identities — its only
+    // output is a single-use step-up grant.
+    if (session.reauthUserId) {
+      const reauthUserId = session.reauthUserId;
+
+      // The IdP must have ACTUALLY re-authenticated for THIS transaction.
+      // Bounded from the session's own created_at, not from now: an auth_time
+      // that predates the user's click is a cached session, however recent it
+      // looks. Fails closed on a missing auth_time.
+      const freshness = assertFreshIdpAuthentication(idClaims, session.createdAt.getTime());
+      if (!freshness.ok) {
+        writeRouteAudit(c, {
+          orgId: provider.orgId,
+          action: 'sso.reauth.rejected',
+          resourceType: 'sso_provider',
+          resourceId: provider.id,
+          resourceName: provider.name,
+          result: 'denied',
+          details: { mode: 'reauth', reason: freshness.reason, userId: reauthUserId }
+        });
+        clearStateCookie();
+        return c.redirect('/settings/profile?error=reauth_not_fresh');
+      }
+
+      const outcome = await withSystemDbAccessContext(async () => {
+        const binding = await validateSessionBinding(session, provider, reauthUserId);
+        if (!binding.ok) {
+          return { error: 'session_invalid' as const, auditReason: binding.reason };
+        }
+
+        // STRICTER than link mode's email comparison: the asserted (provider,
+        // sub) must ALREADY be this user's identity. An IdP where users can
+        // change their own email would otherwise let one user re-auth as
+        // another by matching an address.
+        const [identity] = await db
+          .select({ userId: userSsoIdentities.userId })
+          .from(userSsoIdentities)
+          .where(and(
+            eq(userSsoIdentities.providerId, provider.id),
+            // `externalSub` is the verified id_token `sub`, declared at
+            // sso.ts:2313 — already cross-checked against userinfo's `sub` at
+            // :2220. Insert this branch BELOW that line so it is in scope.
+            eq(userSsoIdentities.externalId, externalSub)
+          ))
+          .limit(1);
+        if (!identity || identity.userId !== reauthUserId) {
+          return { error: 'identity_mismatch' as const };
+        }
+
+        // Belt-and-braces: the account must still be passwordless. A password
+        // set between /reauth/start and here means the ordinary step-up applies.
+        if (binding.user.passwordHash != null) {
+          return { error: 'password_set' as const };
+        }
+
+        return {
+          ok: true as const,
+          authEpoch: session.initiatingAuthEpoch!,
+          mfaEpoch: session.initiatingMfaEpoch!,
+          sid: session.initiatingSessionId!,
+        };
+      });
+
+      clearStateCookie();
+
+      if (!('ok' in outcome)) {
+        writeRouteAudit(c, {
+          orgId: provider.orgId,
+          action: 'sso.reauth.rejected',
+          resourceType: 'sso_provider',
+          resourceId: provider.id,
+          resourceName: provider.name,
+          result: 'denied',
+          details: {
+            mode: 'reauth',
+            reason: 'auditReason' in outcome ? outcome.auditReason : outcome.error,
+            userId: reauthUserId
+          }
+        });
+        return c.redirect(`/settings/profile?error=${outcome.error}`);
+      }
+
+      const grantId = await mintStepUpGrant({
+        userId: reauthUserId,
+        operation: 'enroll_first_factor',
+        authEpoch: outcome.authEpoch,
+        mfaEpoch: outcome.mfaEpoch,
+        sid: outcome.sid,
+      });
+      if (!grantId) {
+        return c.redirect('/settings/profile?error=reauth_unavailable');
+      }
+
+      writeRouteAudit(c, {
+        orgId: provider.orgId,
+        action: 'sso.reauth.completed',
+        resourceType: 'sso_provider',
+        resourceId: provider.id,
+        resourceName: provider.name,
+        details: { partnerId: provider.partnerId, userId: reauthUserId }
+      });
+
+      // Fragment, not query: never sent to the server, never in an access log.
+      // Same channel the login path already uses for #ssoCode.
+      return c.redirect(`/settings/profile#ssoReauthGrant=${grantId}`);
+    }
+```
+
+Import `assertFreshIdpAuthentication` from `../services/sso` and `mintStepUpGrant` from `../services/mfaStepUpGrant`. No new TTL constant is needed: the transaction's own `expiresAt` (10 minutes, set at `/reauth/start`) already bounds how long the round trip may take, and `created_at` supplies the lower bound for `auth_time`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @breeze/api test -- --run src/routes/sso.reauth.test.ts src/routes/sso.test.ts src/services/mfaStepUpGrant.test.ts`
+Expected: PASS. The existing link-mode tests in `sso.test.ts` must still pass — they exercise the validator you renamed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/sso.ts apps/api/src/services/mfaStepUpGrant.ts apps/api/src/routes/sso.reauth.test.ts
+git commit -m "feat(api): mint enroll_first_factor grant from a fresh SSO re-auth (#4018)"
+```
+
+---
+
+### Task 5: Enrollment endpoints accept the grant
+
+**Files:**
+- Create: `resolveEnrollmentStepUp` in `apps/api/src/routes/auth/helpers.ts` (next to `requireCurrentPasswordStepUp`, line 148)
+- Modify: `apps/api/src/routes/auth/mfa.ts:58-61` (`passwordOnlySchema`), `:75` (`/mfa/setup`), `:613` (`/mfa/enable`)
+- Modify: `apps/api/src/routes/auth/passkeys.ts:64,86` (schemas), `:119` (`register/options`), `:555`
+- Test: `apps/api/src/routes/auth/helpers.enrollmentStepUp.test.ts` (new), plus additions to `apps/api/src/routes/auth/mfa.test.ts` and `apps/api/src/routes/auth/passkeys.test.ts`
+
+**Interfaces:**
+- Consumes: `consumeStepUpGrant` / `validateStepUpGrant` with `operation: 'enroll_first_factor'`.
+- Produces:
+
+```ts
+export async function resolveEnrollmentStepUp(
+  c: Context,
+  auth: AuthContext,
+  input: { currentPassword?: string; ssoReauthGrantId?: string },
+  opts: { keyPrefix: string; consume: boolean },
+): Promise<Response | null>
+```
+
+Returns `null` when the caller proved identity, or the error `Response` to return.
+
+**Design notes:**
+- Password path unchanged and still first. The SSO path is only reachable when `password_hash IS NULL`.
+- `consume: false` for `passkeys/register/options`; `consume: true` for every terminal write (`/mfa/setup` confirm, `/mfa/enable`, `passkeys/register/verify`) — the same split `validateStepUpGrant`/`consumeStepUpGrant` already uses.
+- Do **not** touch `enforceExistingFactorStepUp`. Adding a second factor still requires the first.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/api/src/routes/auth/helpers.enrollmentStepUp.test.ts`:
+
+```ts
+describe('resolveEnrollmentStepUp', () => {
+  it('takes the password path when a password is supplied', async () => {
+    mockUser({ passwordHash: HASH });
+    mockVerifyPassword(true);
+    const res = await resolveEnrollmentStepUp(ctx, auth, { currentPassword: 'pw' }, { keyPrefix: 'mfa:pwd', consume: true });
+    expect(res).toBeNull();
+    expect(consumeStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects an SSO grant when the account HAS a password', async () => {
+    mockUser({ passwordHash: HASH });
+    const res = await resolveEnrollmentStepUp(ctx, auth, { ssoReauthGrantId: 'g' }, { keyPrefix: 'mfa:pwd', consume: true });
+    expect(res?.status).toBe(401);
+    expect(consumeStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid SSO grant for a passwordless account and consumes it', async () => {
+    mockUser({ passwordHash: null });
+    mockUserEpochs({ authEpoch: 3, mfaEpoch: 1 });
+    consumeStepUpGrant.mockResolvedValue(true);
+    const res = await resolveEnrollmentStepUp(ctx, auth, { ssoReauthGrantId: 'g' }, { keyPrefix: 'mfa:pwd', consume: true });
+    expect(res).toBeNull();
+    expect(consumeStepUpGrant).toHaveBeenCalledWith('g', {
+      userId: auth.user.id, operation: 'enroll_first_factor', authEpoch: 3, mfaEpoch: 1, sid: auth.token.sid,
+    });
+  });
+
+  it('validates without consuming when consume is false', async () => {
+    mockUser({ passwordHash: null });
+    mockUserEpochs({ authEpoch: 3, mfaEpoch: 1 });
+    validateStepUpGrant.mockResolvedValue(true);
+    const res = await resolveEnrollmentStepUp(ctx, auth, { ssoReauthGrantId: 'g' }, { keyPrefix: 'passkey:pwd', consume: false });
+    expect(res).toBeNull();
+    expect(consumeStepUpGrant).not.toHaveBeenCalled();
+  });
+
+  it('401s a grant that fails to validate (wrong session, bumped epoch, replay)', async () => {
+    mockUser({ passwordHash: null });
+    mockUserEpochs({ authEpoch: 3, mfaEpoch: 1 });
+    consumeStepUpGrant.mockResolvedValue(false);
+    const res = await resolveEnrollmentStepUp(ctx, auth, { ssoReauthGrantId: 'g' }, { keyPrefix: 'mfa:pwd', consume: true });
+    expect(res?.status).toBe(401);
+  });
+
+  it('401s when neither proof is supplied', async () => {
+    mockUser({ passwordHash: null });
+    const res = await resolveEnrollmentStepUp(ctx, auth, {}, { keyPrefix: 'mfa:pwd', consume: true });
+    expect(res?.status).toBe(401);
+  });
+});
+```
+
+Add to `apps/api/src/routes/auth/mfa.test.ts`:
+
+```ts
+it('POST /auth/mfa/setup accepts ssoReauthGrantId for a passwordless account', async () => {
+  mockUser({ passwordHash: null, mfaEnabled: false });
+  mockUserEpochs({ authEpoch: 3, mfaEpoch: 1 });
+  consumeStepUpGrant.mockResolvedValue(true);
+  const res = await app.request('/auth/mfa/setup', {
+    method: 'POST',
+    body: JSON.stringify({ ssoReauthGrantId: 'grant-abc' }),
+    headers: { 'content-type': 'application/json' },
+  }, ENV);
+  expect(res.status).toBe(200);
+  expect((await res.json()).secret).toBeTruthy();
+});
+
+it('POST /auth/mfa/setup still 401s a passwordless account with no proof at all', async () => {
+  mockUser({ passwordHash: null, mfaEnabled: false });
+  const res = await app.request('/auth/mfa/setup', {
+    method: 'POST', body: JSON.stringify({}), headers: { 'content-type': 'application/json' },
+  }, ENV);
+  expect(res.status).toBe(401);
+});
+```
+
+Add the mirror test for `POST /auth/passkeys/register/options` in `apps/api/src/routes/auth/passkeys.test.ts`, asserting `validateStepUpGrant` (not `consume`) was called.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @breeze/api test -- --run src/routes/auth/helpers.enrollmentStepUp.test.ts src/routes/auth/mfa.test.ts src/routes/auth/passkeys.test.ts`
+Expected: FAIL — `resolveEnrollmentStepUp` is not exported; the routes reject the body because `currentPassword` is required.
+
+- [ ] **Step 3: Implement**
+
+Add to `apps/api/src/routes/auth/helpers.ts` after `requireCurrentPasswordStepUp` (line 183):
+
+```ts
+/**
+ * The single decision point for "may this caller install a FIRST MFA factor?".
+ *
+ * Two roads, never both:
+ *   - password   — the historical path, unchanged.
+ *   - SSO re-auth grant — for accounts with password_hash IS NULL, which have
+ *     no password to prove and previously could not enroll at all (#4018).
+ *
+ * The SSO road is refused outright for an account that HAS a password: two
+ * roads of differing strength to the same door is how a step-up gets bypassed.
+ */
+export async function resolveEnrollmentStepUp(
+  c: Context,
+  auth: AuthContext,
+  input: { currentPassword?: string; ssoReauthGrantId?: string },
+  opts: { keyPrefix: string; consume: boolean },
+): Promise<Response | null> {
+  const [user] = await db
+    .select({ passwordHash: users.passwordHash })
+    .from(users)
+    .where(eq(users.id, auth.user.id))
+    .limit(1);
+  if (!user) return c.json({ error: 'Invalid credentials' }, 401);
+
+  if (user.passwordHash != null) {
+    if (!input.currentPassword) return c.json({ error: 'Invalid credentials' }, 401);
+    return requireCurrentPasswordStepUp(c, auth.user.id, input.currentPassword, opts.keyPrefix);
+  }
+
+  if (!input.ssoReauthGrantId) {
+    return c.json({ error: 'Invalid credentials' }, 401);
+  }
+
+  const epochs = await getUserEpochs(auth.user.id);
+  const sid = auth.token?.sid;
+  if (!epochs || !sid) return c.json({ error: 'Service temporarily unavailable' }, 503);
+
+  const bind = {
+    userId: auth.user.id,
+    operation: 'enroll_first_factor' as const,
+    authEpoch: epochs.authEpoch,
+    mfaEpoch: epochs.mfaEpoch,
+    sid,
+  };
+  const ok = opts.consume
+    ? await consumeStepUpGrant(input.ssoReauthGrantId, bind)
+    : await validateStepUpGrant(input.ssoReauthGrantId, bind);
+  if (!ok) return c.json({ error: 'Invalid credentials' }, 401);
+
+  return null;
+}
+```
+
+In `apps/api/src/routes/auth/mfa.ts`, replace `passwordOnlySchema` (line 58-61) with:
+
+```ts
+// Either proof is acceptable; resolveEnrollmentStepUp decides WHICH is allowed
+// for this account. Both absent is a 401 there, not a 400 here — the shape of
+// the rejection must not tell an attacker whether the account has a password.
+const enrollmentStepUpSchema = z.object({
+  currentPassword: z.string().min(1).max(256).optional(),
+  ssoReauthGrantId: z.string().uuid().optional(),
+});
+```
+
+Update `/mfa/setup` (line 75) and `/mfa/enable` (line 613) to validate against the new schema (for `/mfa/enable`, extend rather than replace — it also carries `stepUpGrantId` and the TOTP code) and replace their `requireCurrentPasswordStepUp(...)` call with:
+
+```ts
+  const stepUpError = await resolveEnrollmentStepUp(c, auth, body, { keyPrefix: 'mfa:pwd', consume: true });
+  if (stepUpError) return stepUpError;
+```
+
+Do the same in `apps/api/src/routes/auth/passkeys.ts` at line 119 (`consume: false`, `keyPrefix: 'passkey:pwd'`) and line 561 (`consume: true`). Extend the two schemas at lines 64 and 86 the same way.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @breeze/api test -- --run src/routes/auth/`
+Expected: PASS — the whole auth directory, not just the three files, since the schemas changed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/auth/helpers.ts apps/api/src/routes/auth/mfa.ts apps/api/src/routes/auth/passkeys.ts apps/api/src/routes/auth/helpers.enrollmentStepUp.test.ts apps/api/src/routes/auth/mfa.test.ts apps/api/src/routes/auth/passkeys.test.ts
+git commit -m "feat(api): accept SSO re-auth grant in place of a password for first-factor enrollment (#4018)"
+```
+
+---
+
+### Task 6: `/auth/me` exposes `hasPassword`; web offers the SSO path
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/password.ts:365-399` (`/auth/me`)
+- Modify: `apps/web/src/components/settings/ProfilePage.tsx`
+- Test: `apps/api/src/routes/auth/password.test.ts`, `apps/web/src/components/settings/ProfilePage.test.tsx`
+
+**Interfaces:**
+- Consumes: `POST /api/v1/sso/reauth/start` (Task 3), the `#ssoReauthGrant=<id>` fragment (Task 4), `ssoReauthGrantId` on the enrollment endpoints (Task 5).
+- Produces: `GET /auth/me` → `user.hasPassword: boolean`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/api/src/routes/auth/password.test.ts`:
+
+```ts
+it('GET /auth/me reports hasPassword false for an SSO-provisioned user', async () => {
+  mockUser({ passwordHash: null });
+  const res = await app.request('/auth/me', {}, ENV);
+  expect((await res.json()).user.hasPassword).toBe(false);
+});
+
+it('GET /auth/me reports hasPassword true for a password user and never leaks the hash', async () => {
+  mockUser({ passwordHash: 'argon2id$abc' });
+  const body = await (await app.request('/auth/me', {}, ENV)).json();
+  expect(body.user.hasPassword).toBe(true);
+  expect(JSON.stringify(body)).not.toContain('argon2id');
+});
+```
+
+`apps/web/src/components/settings/ProfilePage.test.tsx`:
+
+```tsx
+it('shows the IdP verification button instead of the password prompt for a passwordless account', async () => {
+  renderProfile({ user: { hasPassword: false, mfaEnabled: false } });
+  await userEvent.click(screen.getByTestId('mfa-setup-start'));
+  expect(screen.getByTestId('mfa-sso-reauth')).toBeTruthy();
+  expect(screen.queryByTestId('mfa-current-password')).toBeNull();
+});
+
+it('shows the password prompt for an account that has a password', async () => {
+  renderProfile({ user: { hasPassword: true, mfaEnabled: false } });
+  await userEvent.click(screen.getByTestId('mfa-setup-start'));
+  expect(screen.getByTestId('mfa-current-password')).toBeTruthy();
+  expect(screen.queryByTestId('mfa-sso-reauth')).toBeNull();
+});
+
+it('consumes the #ssoReauthGrant fragment and clears it from the URL', async () => {
+  window.location.hash = '#ssoReauthGrant=grant-abc';
+  renderProfile({ user: { hasPassword: false, mfaEnabled: false } });
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+    expect.stringContaining('/auth/mfa/setup'),
+    expect.objectContaining({ body: JSON.stringify({ ssoReauthGrantId: 'grant-abc' }) }),
+  ));
+  // The grant is single-use — leaving it in the address bar invites a
+  // confusing second attempt after it has already been consumed.
+  expect(window.location.hash).toBe('');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pnpm --filter @breeze/api test -- --run src/routes/auth/password.test.ts
+pnpm --filter @breeze/web test -- --run src/components/settings/ProfilePage.test.tsx
+```
+Expected: FAIL — `hasPassword` undefined; no `mfa-sso-reauth` testid.
+
+- [ ] **Step 3: Implement**
+
+In `apps/api/src/routes/auth/password.ts`, add `passwordHash: users.passwordHash` to the select at line 369, then destructure it out of the response exactly as `phoneNumber` already is:
+
+```ts
+  const { phoneNumber: rawPhone, passwordHash, ...userWithoutPhone } = user;
+  ...
+    user: {
+      ...userWithoutPhone,
+      // Whether a password step-up is even possible for this account. The hash
+      // itself is destructured away above and never serialized.
+      hasPassword: passwordHash != null,
+      mfaEnabled: effectiveMfaEnabled,
+```
+
+In `ProfilePage.tsx`: when `user.hasPassword === false`, render a button (`data-testid="mfa-sso-reauth"`) reading *"Verify with your identity provider"* that POSTs to `/api/v1/sso/reauth/start` via `runAction` and sets `window.location.href = authUrl`. On mount, read `window.location.hash`; if it matches `#ssoReauthGrant=<id>`, call the enrollment endpoint with `{ ssoReauthGrantId }` instead of `{ currentPassword }`, then clear the hash with `history.replaceState(null, '', window.location.pathname)`. Handle `?error=` values from the callback (`reauth_not_fresh`, `identity_mismatch`, `session_invalid`, `password_set`, `reauth_unavailable`) with a toast; `reauth_not_fresh` gets specific copy: *"Your identity provider did not re-verify your sign-in. Try again, or ask your administrator to allow re-authentication prompts."*
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pnpm --filter @breeze/api test -- --run src/routes/auth/password.test.ts
+pnpm --filter @breeze/web test -- --run src/components/settings/ProfilePage.test.tsx
+pnpm --filter @breeze/web test -- --run src/lib/__tests__/no-silent-mutations.test.ts
+```
+Expected: PASS. The `no-silent-mutations` guard is included because Task 6 adds a mutation handler — it must go through `runAction`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/auth/password.ts apps/api/src/routes/auth/password.test.ts apps/web/src/components/settings/ProfilePage.tsx apps/web/src/components/settings/ProfilePage.test.tsx
+git commit -m "feat(web): enroll MFA via IdP re-verification on passwordless accounts (#4018)"
+```
+
+---
+
+### Task 7: Expose `trustsIdpMfa`, fix the misleading copy, document both
+
+The other half of #4018: the setting that would let an IdP's MFA satisfy `requireMfa()` exists but has no UI and no docs, and the error message sends SSO users somewhere that cannot help them.
+
+**Files:**
+- Modify: `apps/web/src/components/settings/SsoProvidersPage.tsx`
+- Modify: `apps/web/src/components/devices/AddDeviceModal.tsx:959-1000,1064-1075`
+- Modify: `apps/web/src/locales/en/devices.json` (the three `multiFactorAuthenticationIsRequiredTo*` keys)
+- Modify: `apps/docs/src/content/docs/reference/sso.mdx` (§ Partner-Wide SSO, and the `sso_providers` field table)
+- Test: `apps/web/src/components/settings/SsoProvidersPage.test.tsx`, `apps/web/src/components/devices/AddDeviceModal.test.tsx`
+
+**Interfaces:**
+- Consumes: `trustsIdpMfa` already exists on `createProviderSchema`/`updateProviderSchema` (`apps/api/src/routes/sso.ts:180,189`) and is already returned by `GET /sso/providers` (`:872,896`). **No API change is needed** — verify this before writing any.
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// SsoProvidersPage.test.tsx
+it('renders the trust-IdP-MFA toggle reflecting the provider value', () => {
+  renderPage({ providers: [{ id: P, name: 'Entra', trustsIdpMfa: false }] });
+  expect((screen.getByTestId('provider-trusts-idp-mfa') as HTMLInputElement).checked).toBe(false);
+});
+
+it('PATCHes trustsIdpMfa when toggled', async () => {
+  renderPage({ providers: [{ id: P, name: 'Entra', trustsIdpMfa: false }] });
+  await userEvent.click(screen.getByTestId('provider-trusts-idp-mfa'));
+  await userEvent.click(screen.getByTestId('provider-save'));
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.stringContaining(`/sso/providers/${P}`),
+    expect.objectContaining({ method: 'PATCH', body: expect.stringContaining('"trustsIdpMfa":true') }),
+  );
+});
+
+// AddDeviceModal.test.tsx
+it('gives SSO sessions provider-specific guidance instead of the profile-settings dead end', () => {
+  renderModal({ linkError: 'MFA_REQUIRED', authMethod: 'sso' });
+  expect(screen.getByText(/identity provider/i)).toBeTruthy();
+  expect(screen.queryByText(/Set up MFA in your profile settings/i)).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pnpm --filter @breeze/web test -- --run src/components/settings/SsoProvidersPage.test.tsx src/components/devices/AddDeviceModal.test.tsx
+```
+Expected: FAIL — no `provider-trusts-idp-mfa` testid; the modal renders the old copy unconditionally.
+
+- [ ] **Step 3: Implement**
+
+Add the toggle to the provider form in `SsoProvidersPage.tsx`, labelled **"Trust this provider's MFA"** with helper text: *"When your identity provider reports that multi-factor authentication was used (`amr: mfa`), treat MFA as satisfied in Breeze. Your IdP must include the `amr` claim in its ID token — most require this to be enabled explicitly. Off by default."*
+
+In `AddDeviceModal.tsx`, branch the three `MFA_REQUIRED` blocks on whether the session came from SSO (read it from the auth store — the token's `method`/`amr` context already available to the web client; if it is not exposed, use `hasPassword === false` from Task 6 as the discriminator and say so in a comment). SSO copy: *"Multi-factor authentication is required to generate links. Your organization signs you in through an identity provider — ask your administrator to enable MFA trust for it, or enroll a factor in your profile settings."* Keep the existing copy for password sessions. Add the new strings to `apps/web/src/locales/en/devices.json`; leave the existing keys in place for the password branch.
+
+In `sso.mdx`, document `trustsIdpMfa` in the provider field table, add a short **"Satisfying Breeze MFA with your IdP"** subsection under Partner-Wide SSO covering the `amr` requirement and the fail-safe default, and add **"Enrolling MFA on a passwordless SSO account"** describing the Task 3-6 flow.
+
+- [ ] **Step 4: Run the tests and the docs build**
+
+```bash
+pnpm --filter @breeze/web test -- --run src/components/settings/SsoProvidersPage.test.tsx src/components/devices/AddDeviceModal.test.tsx
+pnpm --filter @breeze/web test -- --run src/i18n
+pnpm --filter @breeze/docs build
+```
+Expected: PASS, and the docs build succeeds. The i18n run catches the locale-parity failure a new `en` key causes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/settings/SsoProvidersPage.tsx apps/web/src/components/devices/AddDeviceModal.tsx apps/web/src/locales/en/devices.json apps/docs/src/content/docs/reference/sso.mdx apps/web/src/components/settings/SsoProvidersPage.test.tsx apps/web/src/components/devices/AddDeviceModal.test.tsx
+git commit -m "feat(web): expose IdP MFA trust, fix SSO MFA copy, document both (#4018)"
+```
+
+---
+
+## Pre-PR verification
+
+Run before opening the PR — not per task:
+
+```bash
+pnpm --filter @breeze/api test
+pnpm --filter @breeze/web test
+pnpm lint
+pnpm build
+# Tenancy/cascade code was touched (schema + tenantCascade comment), so the
+# contract suites are mandatory. They need a live database.
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm --filter @breeze/api test:rls
+pnpm --filter @breeze/api test:integration
+```
+
+Then verify the loop is actually broken, end to end, against a real stack:
+
+1. Create an SSO provider, `trustsIdpMfa` off, and sign in as a JIT-provisioned user.
+2. Add Device → Generate Link → confirm the 403 and the new SSO-specific copy.
+3. Profile → Set up MFA → confirm the IdP button appears (not a password prompt).
+4. Complete the IdP round-trip; confirm you land on `/settings/profile` with the TOTP secret shown and the hash cleared.
+5. Enroll, sign out, sign in via SSO again, retry Generate Link. **Expect it to still fail** — the `mfa` claim is a login-time property and `trustsIdpMfa` is still off. That is correct behaviour, and exactly why Task 7 exists.
+6. Turn on the new toggle, sign in via SSO again, retry. Confirm success **and** confirm the `user.login` audit row now records `mfa: true`.
+7. Negative test: point a provider at an IdP that omits `auth_time`, run the re-auth flow, and confirm `error=reauth_not_fresh` with no grant minted.
+
+Step 5 is the one worth being explicit about with reviewers: enrolling a factor does not retroactively satisfy an existing session's claim, and nothing in this plan changes that.
+
+---
+
+## Deliberately out of scope — file as follow-ups
+
+These surfaced while scoping and are real, but each is its own change. Do not let them grow this PR.
+
+1. **A passkey alone still cannot reach L4.** `requireFreshMfaStepUp` allowlists `mfaMethod === 'totp'` and nothing else (`apps/api/src/routes/auth/helpers.ts:218-223`). After this plan a passwordless SSO user can enroll a passkey and satisfy L2/L3, but critical-tier approvals would still refuse them. If passkey-first onboarding is meant to unlock the full ladder, fresh *passkey* re-authentication for L4 needs its own design.
+2. **No client ever sends the L4 re-auth fields.** `reauthPassword` / `reauthMfaCode` have zero references in `apps/web/src` and `apps/mobile/src`; mobile's `approveRequest` sends only a step-up proof (`apps/mobile/src/services/approvals.ts:97`). So `riskTier: 'critical'` approvals are unapprovable from every UI today. AI never hits it (Tier 4 is refused before an intent exists, `apps/api/src/services/actionIntents/intentService.ts:348`), so it currently only affects PAM (`apps/api/src/routes/pam.ts:432`).
+3. **Optional `acr` pinning.** A tenant that needs a specific IdP assurance class (phishing-resistant, say) has no way to demand it. `assertFreshIdpAuthentication` proves *freshness*, not *strength*. A per-provider `required_acr` would close that, and would also give `trustsIdpMfa` a sharper meaning than RFC 8176's deliberately context-dependent `amr: mfa`.
+4. **Stale comment at `apps/api/src/routes/sso.ts:69`.** It attributes the state-cookie protection to `SameSite=Lax` omitting the cookie on the callback; `Lax` cookies *are* sent on cross-site top-level GET navigations. The real protection is the HMAC binding to the unpredictable single-use state, which is sound — only the explanation is wrong. Worth correcting so nobody "simplifies" the HMAC away on the strength of it.


### PR DESCRIPTION
## Summary

A passwordless, SSO-provisioned user can now prove identity through a forced IdP re-authentication and use that proof — instead of a password — to enroll a first MFA factor. This also exposes `trustsIdpMfa`, which existed in the API but had no UI and no docs.

Before this, such accounts could enroll **nothing**. Every enrollment surface (`/auth/mfa/setup`, `/auth/passkeys/register/*`) requires the current password, and JIT-provisioned SSO users have `password_hash IS NULL`, so `requireCurrentPasswordStepUp` returned `401 Invalid credentials` for a password they never had. That locked them out of ~509 `requireMfa()`-gated handlers with no in-product remedy — the reported symptom was "Generate Link" in Add Device returning 403 and the UI advising a profile-settings flow that cannot work.

Closes #4018.

## How it works

```
POST /sso/reauth/start          authMiddleware only, NOT requireMfa()
  → provider resolved from the caller's OWN user_sso_identities row
  → sso_sessions row in reauth mode, snapshotting {authEpoch, mfaEpoch, sid, providerVersion}
  → IdP with prompt=login & max_age=0

GET /sso/callback  (reauth branch)
  → auth_time must exist, and be >= the transaction's own created_at
  → (provider_id, sub) must ALREADY belong to this user
  → account must still be passwordless
  → mints a single-use Redis grant, operation: 'enroll_first_factor'
  → 302 /settings/profile#ssoReauthGrant=<id>          (mints NO tokens)

/mfa/setup · /mfa/enable · /passkeys/register/*
  → resolveEnrollmentStepUp accepts that grant in place of currentPassword,
    ONLY for password_hash IS NULL AND zero existing factors
```

## Reviewer notes — please read these five

1. **New column + CHECK on `sso_sessions`** (`apps/api/migrations/2026-08-25-sso-sessions-reauth-user-id.sql`): `reauth_user_id uuid REFERENCES users(id) ON DELETE CASCADE`, plus `sso_sessions_single_mode_chk` making link and reauth mutually exclusive. **No cascade or export-policy registration is owed** — `sso_sessions` has no `org_id`, so it is not in `CORE_ORG_CASCADE_DELETE_ORDER` and needs no `CORE_TENANT_EXPORT_POLICY` entry. `tenantCascade.ts` already clears it provider-keyed on both axes; only its comment changed. Flagging this explicitly so nobody re-derives it.

2. **`enroll_first_factor` is deliberately absent from `STEP_UP_OPERATIONS`** (`routes/auth/schemas.ts`). Adding it would let anyone who can satisfy an ordinary `/auth/mfa/step-up` mint an enrollment grant with **no** IdP re-authentication. A test locks the exclusion. Note the neighbouring `satisfies readonly StepUpOperation[]` comment previously claimed the type would catch divergence — it does not, and that comment has been corrected.

3. **13 machine-drafted locale keys across 8 locales need native review — including `tr-TR`**, which no commit body names. The commit bodies carry review notes for pt-BR, es-419, fr-FR, fr-CA, de-DE and it-IT only. Key parity itself is clean (0 missing / 0 extra across all 8 catalogs).

4. **Sessions already signed in when this deploys keep `hasPassword: undefined`** until their next `/users/me` refresh, and degrade to the previous AddDeviceModal copy. Correct behaviour (unknown → old copy), but the SSO-only user who most needs the fix is also least likely to re-login soon.

5. **`/auth/me`'s new `hasPassword` currently has no consumer** — ProfilePage reads `/users/me`. It is implemented and tested for API symmetry; drop it if you would rather not carry it.

## The bug this nearly shipped with

The freshness check originally bounded `auth_time` using `session.createdAt.getTime()`. `sso_sessions.created_at` is `timestamp without time zone`; postgres.js parses OID 1114 with a bare `new Date(x)`, so V8 reads the offsetless string as **local** time, while `auth_time` is a true UTC epoch. Drizzle *has* a UTC-correct path, but it is guarded on `typeof value === 'string'` and postgres.js hands it a pre-parsed `Date`, so it falls through — which is why the codebase looks like it handles this.

- Host behind UTC (any US dev box or self-hoster): bound lands hours in the future → `auth_time_stale` on **100%** of attempts. Feature dead on arrival.
- Host ahead of UTC: window *loosens* by the offset → a cached IdP session hours old passes as "fresh", weakening the only control this feature rests on.
- Containers run UTC, so hosted production was unaffected — which is exactly why it survived 25,500 passing tests.

Fixed via `utcMsFromOffsetlessTimestamp` (`services/sso.ts`), applied at the single call site. Measured against a live pg16: the same instant returned **+6h** under `America/Denver`, **−2h** under `Europe/Berlin`, exact under UTC. The route fixture previously fabricated `createdAt` as `new Date(Date.now() - n)` — a true instant, not what the driver produces — which is why the tests were blind; it now simulates the real driver path, and 14 route tests fail on revert.

## Verification

| Suite | Result |
|---|---|
| API unit (full) | 1,473 files / 25,530 tests, exit 0 |
| Web unit (full) | 644 files / 6,573 tests, exit 0 |
| `vitest.config.rls.ts` | 22 passed, exit 0 |
| `vitest.config.rls-coverage.ts` | 75 passed, exit 0 |
| `tenantCascade` + `tenant-export-policy` integration | 7 passed, exit 0 |
| `tsc --noEmit` (api, web) | exit 0 |
| Targeted suites under `TZ=America/Denver` | 92 passed — the host TZ that would have failed before |
| Migration | applies from zero on an empty DB, and re-applies as a no-op |
| Targeted suites under `TZ=UTC` **and** `TZ=America/Denver` | 99 each — the guard now bites in both |

Every task went through an independent task review, then a five-lens PR review (tests, silent failures, code, comments, types) which found two further Criticals and nine Importants — all fixed and re-reviewed. Reviews — not tests — caught every serious defect on this branch, including: a double-charged password step-up on `/mfa/enable` (two rate-limit slots and two argon2 verifies per call, with a possible 429 landing *after* `consumeMFAToken` burned the TOTP time-step), a security fix that had no test guarding it, a fail-open probe chain where a missing DB context made `userIsMfaProtected` answer "unprotected" for an account that holds factors, and — most instructively — **the timezone guard itself was vacuous on CI**: its assertion collapsed to `0 === 0` under UTC, no `TZ` is pinned anywhere, and GitHub runners are UTC, so deleting the timezone fix kept CI green. It only ever bit on a non-UTC developer machine. The assertions are now spy-based and simulate offsets from −345 to +420.

## Known gaps — follow-ups, not blockers

- **Three silent dead ends, newly reachable now that these accounts can enroll:** `/mfa/recovery-codes`, `DELETE /auth/passkeys/:id` and `POST /auth/mfa/disable` are still password-only, and the client greys the control rather than issuing a request — so there is no error, just a button that never works. These are removal/rotation operations, so an `enroll_first_factor` grant must **not** authorize them; they need the SR2-20 existing-factor road, which such a user can now take because they finally hold a factor.
- Post-IdP intent is not routed: the passkey card's re-verify CTA returns the user to the TOTP QR view and leaves a stale pending TOTP setup in Redis. Not a dead end (the grant is still held), but a confusing detour.
- The offsetless-timestamp trap is neutralised at this call site only. Every other `timestamp without time zone` column still parses as local time, and the next external-epoch comparison reintroduces it invisibly to UTC-based CI. A lint rule or contract test would close the class.
- Grant TTL is 300s, which spans a scan-QR-then-type `/mfa/setup` flow; expiry surfaces as `Invalid credentials`.
- No real-Postgres integration coverage for the reauth callback branch (same pre-existing gap as link mode).
- `mfaDisableSchema` inherits `ssoReauthGrantId` via `mfaVerifySchema.extend`; `/mfa/disable` never reads it. Not exploitable, but a disable endpoint silently accepting an enrollment-grant field is a poor shape.

## History note

Two `Revert` commits neutralize an unsanctioned commit from a concurrent session that briefly wrote into this worktree. `efc797048`'s message says fixture fixes are "addressed in the next commit" — they are in that same commit; the message is stale, the code is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
