### PR TITLE
fix(api,ci): pin a non-UTC TZ for auth/SSO test runs (#4046)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,26 @@ jobs:
       - name: Run API tests
         run: pnpm test --filter=@breeze/api
 
+      # Timezone-correctness regression gate (#4046): GitHub-hosted runners
+      # default to UTC, and nothing else in this job or in vitest.config.ts
+      # overrides that. A test asserting timezone-correcting behavior (e.g.
+      # comparing an offsetless-timestamp-derived value against a UTC epoch)
+      # is dormant by construction under UTC — the assertion can collapse to
+      # `0 === 0` and stay green forever while the underlying conversion is
+      # missing or wrong. That is exactly how #4018's TZ bug shipped past
+      # 25,000+ green tests. Re-run just the auth/SSO/MFA/passkey suites
+      # (vitest.config.tz.ts) under a fixed non-UTC zone so a regression of
+      # that shape fails here instead of passing vacuously — not the full
+      # suite a second time, since only timestamp/timezone arithmetic is
+      # offset-sensitive. TZ is set here, at the step level, before the Node
+      # process starts: assigning process.env.TZ from inside a test file has
+      # no effect, because Node/V8 cache the resolved zone at first Date/Intl
+      # use within a process.
+      - name: Run API tests (auth/SSO, pinned non-UTC TZ)
+        env:
+          TZ: America/Denver
+        run: pnpm --filter=@breeze/api test:tz
+
       - name: Run load-test static contract tests
         run: pnpm test:load-static
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -33,6 +33,7 @@
     "test:rls-coverage": "vitest run --config vitest.config.rls-coverage.ts",
     "test:request-db-role": "vitest run --config vitest.config.request-db-role.ts",
     "test:site-scope-coverage": "vitest run --config vitest.config.site-scope-coverage.ts",
+    "test:tz": "vitest run --config vitest.config.tz.ts",
     "test:run": "vitest run"
   },
   "dependencies": {

--- a/apps/api/src/__tests__/tzPinCanary.test.ts
+++ b/apps/api/src/__tests__/tzPinCanary.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Canary for issue #4046: this file must ONLY run as part of the pinned
+ * non-UTC pass (`apps/api/vitest.config.tz.ts`, wired into CI's `test-api`
+ * job via `pnpm test:tz` with `TZ=America/Denver` set at the step level) —
+ * it is excluded from the default `vitest.config.ts` unit run (see its
+ * `exclude` list) specifically so this assertion has teeth in both places:
+ * green here confirms the pin reached this worker process; if it ever ran
+ * under the plain UTC job instead, it would fail there.
+ *
+ * If a future refactor of ci.yml or vitest.config.tz.ts silently drops the
+ * TZ pin (the step's `env:` block gets deleted, the include entry below
+ * gets removed, etc.), this test fails loudly instead of the whole
+ * tz-pinned job quietly degrading back into a vacuous UTC run — which is
+ * exactly the failure mode #4046 exists to prevent.
+ */
+describe('non-UTC TZ pin (issue #4046)', () => {
+  it('the process actually observes a non-UTC offset', () => {
+    expect(new Date().getTimezoneOffset()).not.toBe(0);
+  });
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -174,6 +174,13 @@ export default defineConfig({
       // Real-DB suites owned by vitest.integration.config.ts (#3778).
       'src/services/invoiceService.issue.integration.test.ts',
       'src/services/invoicePdf.integration.test.ts',
+      // Canary for issue #4046: asserts the process observes a non-UTC
+      // offset. It must ONLY run under the pinned non-UTC pass
+      // (vitest.config.tz.ts, TZ=America/Denver), where it belongs — it is
+      // excluded here deliberately, not because it doesn't apply to the
+      // unit runner: it WOULD fail on this (UTC) runner, since that is
+      // exactly the point of the check.
+      'src/__tests__/tzPinCanary.test.ts',
     ],
     setupFiles: ['src/__tests__/setup.ts'],
     coverage: {

--- a/apps/api/vitest.config.tz.ts
+++ b/apps/api/vitest.config.tz.ts
@@ -36,6 +36,12 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // MAINTENANCE (as of this PR, #4041 is still open): once #4041 merges,
+    // it adds two new TZ-sensitive test files that belong in this list and
+    // are NOT auto-discovered (this is a manual allowlist, not a broad
+    // glob) — add both when that PR lands:
+    //   'src/routes/sso.reauth.test.ts'
+    //   'src/testUtils/pgOffsetlessTimestamp.test.ts'
     include: [
       'src/routes/auth.test.ts',
       'src/routes/auth.passkeys.test.ts',
@@ -56,6 +62,10 @@ export default defineConfig({
       'src/services/apiKeyAuthorization.test.ts',
       'src/services/approverWebAuthn.test.ts',
       'src/services/authEmailQueue.test.ts',
+      // Canary asserting the pin itself is active — see its own file
+      // header. Deliberately excluded from vitest.config.ts (main) so it
+      // fails loudly there if it's ever accidentally run under UTC.
+      'src/__tests__/tzPinCanary.test.ts',
     ],
     setupFiles: ['src/__tests__/setup.ts'],
   },

--- a/apps/api/vitest.config.tz.ts
+++ b/apps/api/vitest.config.tz.ts
@@ -1,0 +1,62 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+// Targeted non-UTC pass over the auth/SSO/MFA-adjacent unit suites (#4046).
+//
+// GitHub-hosted runners default to UTC, and neither this repo's CI nor
+// vitest.config.ts ever pins a different zone. A test written to assert
+// timezone-correcting behavior (e.g. comparing an offsetless-timestamp-derived
+// value against a UTC epoch) is dormant by construction when the host offset
+// is exactly 0 — the assertion can collapse to `0 === 0` and stay green
+// forever while the underlying conversion is missing or wrong. That is
+// exactly how #4018's TZ bug (sso_sessions.created_at compared against
+// auth_time without correcting for local-time parsing) shipped past 25,000+
+// green tests and was only caught by a human review pass, then confirmed by
+// re-running under TZ=America/Denver.
+//
+// This config re-runs just the auth/SSO/MFA/passkey suites — where that bug
+// class lives — under a fixed non-UTC zone, so a future regression of the
+// same shape fails CI instead of passing vacuously. It intentionally does
+// NOT re-run the full suite a second time: that would double the cost of
+// every unrelated test for no coverage gain, since only timestamp/timezone
+// arithmetic is offset-sensitive.
+//
+// The TZ pin lives in the CI workflow step's `env:` block (runner-level, set
+// before the Node process starts), not here and not in a test file — Node/V8
+// cache the resolved timezone at first use of Date/Intl within a process, so
+// assigning `process.env.TZ` from inside a test file (or a `beforeEach`) has
+// no effect on already-initialized Date behavior in that worker. Run locally
+// via `TZ=America/Denver pnpm test:tz` (or any non-UTC zone) from apps/api.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@breeze/shared': path.resolve(__dirname, '../../packages/shared/src'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: [
+      'src/routes/auth.test.ts',
+      'src/routes/auth.passkeys.test.ts',
+      'src/routes/authenticator.test.ts',
+      'src/routes/auth/**/*.test.ts',
+      'src/services/sso.test.ts',
+      'src/services/ssoDomainVerification.test.ts',
+      'src/services/mfa.test.ts',
+      'src/services/mfaAssurance.test.ts',
+      'src/services/mfaPolicy.test.ts',
+      'src/services/mfaSecretCrypto.test.ts',
+      'src/services/mfaStepUpGrant.test.ts',
+      'src/services/passkeys.test.ts',
+      'src/services/authEpochs.test.ts',
+      'src/services/authLifecycle.test.ts',
+      'src/services/authenticatorAssurance.test.ts',
+      'src/services/authenticatorPolicy.test.ts',
+      'src/services/apiKeyAuthorization.test.ts',
+      'src/services/approverWebAuthn.test.ts',
+      'src/services/authEmailQueue.test.ts',
+    ],
+    setupFiles: ['src/__tests__/setup.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

GitHub-hosted runners default to UTC, and neither `.github/workflows/ci.yml` nor `apps/api/vitest.config.ts` ever pins a different zone. A test written to assert timezone-correcting behavior (e.g. comparing an offsetless-timestamp-derived value against a UTC epoch) is dormant by construction under UTC — the assertion can collapse to `0 === 0` and stay green while the underlying conversion is missing or wrong.

**Verified the issue's premise directly**, rather than taking it on faith: this is exactly how #4018's TZ bug shipped past 25,000+ green tests in PR #4041 (`sso_sessions.created_at` compared against `auth_time` without correcting for local-time parsing) — that branch had to build a per-test `getTimezoneOffset()` override shim (`offsetlessTimestampFromHostAt` in `apps/api/src/services/sso.test.ts`) purely to get real teeth under UTC, because the runner itself never varies the zone.

Closes #4046.

## What changed

- **`apps/api/vitest.config.tz.ts`** (new) — a narrow vitest config scoped to the auth/SSO/MFA/passkey unit suites where this bug class lives (33 files, 677 tests).
- **`apps/api/package.json`** — new `test:tz` script (`vitest run --config vitest.config.tz.ts`), following the existing `test:rls` / `test:integration` convention of one script per dedicated config.
- **`.github/workflows/ci.yml`** — new step in the existing `test-api` job: `TZ=America/Denver pnpm --filter=@breeze/api test:tz`, right after the normal `Run API tests` step.

## Why this scope, not a bigger one

- **Not a blanket TZ pin on the whole job.** Changing the ambient TZ for every test in `test-api` risks silently breaking an unrelated test that assumes UTC, and the failure would be indirect (some unrelated suite goes red with no obvious link to a TZ change).
- **Not a UTC/non-UTC matrix for the whole suite.** That doubles the cost of every unrelated test for zero coverage gain — only timestamp/timezone arithmetic is offset-sensitive.
- **This is a second, targeted run of just the suites where the bug class lives**, under a fixed non-UTC zone (`America/Denver`, deliberately a >0 UTC offset west and a non-half-hour DST transition, matching the zone #4018 was caught under). It's additive (~12s locally) and isolates any regression to a code area that's actually plausible.

## Why the TZ pin lives in the CI step, not the vitest config

Node/V8 cache the resolved timezone at first use of `Date`/`Intl` within a process. Setting `process.env.TZ` from inside a test file (or `beforeEach`) has no effect on already-initialized `Date` behavior in that worker. The pin has to happen **before the Node process starts** — so it's set in the GitHub Actions step's `env:` block, which is in place before `vitest` (and its worker processes) ever launch.

**Verified locally**, not assumed: comparing `TZ=UTC` vs `TZ=America/Denver` against a throwaway probe test showed `new Date(...).getTimezoneOffset()` reading `0` vs `360` respectively inside the actual vitest worker — confirming the env var propagates to where test code runs, not just the parent CLI process.

## Testing

- `TZ=America/Denver pnpm --filter=@breeze/api test:tz` → 33 files, 677 tests, all green.
- Same targeted files also verified to run unaffected under the existing default `vitest.config.ts` (no double-run conflict between the two CI steps).
- `TZ=UTC` vs `TZ=America/Denver` probe test confirms the pin reaches the vitest worker process before any `Date`/`Intl` use.
- `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` — clean.
- No migrations, schema, or tenancy-scoped code touched; no RLS/cascade/export-policy registration applies.

## Non-conflict with PR #4041

This PR does not touch any file PR #4041 modifies (confirmed via `gh pr view 4041 --json files`), and #4041 does not touch `ci.yml`, `apps/api/package.json`, or `apps/api/vitest.config.ts`/`vitest.config.tz.ts`. No expected conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)