### PR TITLE
fix(config,api): pass DB password vars through turbo + fail fast on skipped breeze_app bootstrap (#4048)

### DIFF
--- a/apps/api/src/db/autoMigrate.test.ts
+++ b/apps/api/src/db/autoMigrate.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, it, expect } from 'vitest';
 import {
   detectState,
+  assertAppRoleBootstrapped,
   hashSql,
   hasNoTransactionDirective,
   splitSqlStatements,
@@ -85,6 +86,23 @@ describe('autoMigrate', () => {
 
     it('should return "normal" when both users and breeze_migrations exist', () => {
       expect(detectState(true, true)).toBe('normal');
+    });
+  });
+
+  describe('assertAppRoleBootstrapped', () => {
+    it('does not throw when ensureAppRole succeeded', () => {
+      expect(() => assertAppRoleBootstrapped(true, false)).not.toThrow();
+      expect(() => assertAppRoleBootstrapped(true, true)).not.toThrow();
+    });
+
+    it('does not throw when ensureAppRole was skipped but breeze_app already exists (e.g. compose-provisioned dev DB)', () => {
+      expect(() => assertAppRoleBootstrapped(false, true)).not.toThrow();
+    });
+
+    it('throws a pointed error when ensureAppRole was skipped AND breeze_app does not exist (#4048)', () => {
+      expect(() => assertAppRoleBootstrapped(false, false)).toThrow(
+        /BREEZE_APP_DB_PASSWORD.*POSTGRES_PASSWORD.*globalPassThroughEnv/s,
+      );
     });
   });
 

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -551,7 +551,33 @@ export async function autoMigrate(): Promise<void> {
     //        role isn't created first. Idempotent — safe on every run. We
     //        still call ensureAppRole again at step 7b so any tables created
     //        in this loop receive the privilege grants.
-    await ensureAppRole();
+    //
+    //        If ensureAppRole was skipped (no password env var reached this
+    //        process — e.g. turbo stripped it) AND breeze_app doesn't already
+    //        exist (e.g. a fresh/scratch DB that compose didn't pre-provision),
+    //        fail fast here with a pointed error instead of letting the
+    //        migration loop run ~135 files deep and die on the opaque
+    //        Postgres 42704 `role "breeze_app" does not exist` (#4048).
+    const roleEnsured = await ensureAppRole();
+    if (!roleEnsured) {
+      const roleRow = await client`
+        SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'breeze_app') AS exists
+      `;
+      const breezeAppRoleExists = Boolean(roleRow[0]?.exists);
+      if (!breezeAppRoleExists) {
+        throw new Error(
+          '[auto-migrate] Refusing to proceed: the `breeze_app` role does not exist and ' +
+            'ensureAppRole() could not create it because neither BREEZE_APP_DB_PASSWORD nor ' +
+            'POSTGRES_PASSWORD is set in this process\'s environment. Set one of those two ' +
+            'variables. If you invoked this via `pnpm db:migrate` (which runs through turbo), ' +
+            'confirm the variable is listed in turbo.json\'s `globalPassThroughEnv` — turbo ' +
+            'silently strips any env var not declared there or in a task-level `env`/' +
+            '`passThroughEnv`, and a plain DATABASE_URL connection will otherwise proceed as ' +
+            'the admin/superuser and fail confusingly, many migration files later, with ' +
+            'Postgres error 42704.',
+        );
+      }
+    }
 
     // ── 7. Apply pending migrations ──────────────────────────────────────
     let appliedCount = 0;

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -316,6 +316,37 @@ export function detectState(
   return 'normal';
 }
 
+/**
+ * Decide whether autoMigrate should abort because the unprivileged
+ * `breeze_app` role is not going to exist when the migration loop runs.
+ *
+ * `ensureAppRole()` returning `false` means it was skipped (neither
+ * BREEZE_APP_DB_PASSWORD nor POSTGRES_PASSWORD reached this process — most
+ * commonly because turbo stripped the var; see #4048). That's only a
+ * problem if `breeze_app` doesn't already exist some other way (e.g. a
+ * docker-compose dev DB that pre-creates it) — in that case, proceeding
+ * anyway lets the migration loop run ~135 files deep before dying on the
+ * opaque Postgres 42704 `role "breeze_app" does not exist`. Pulled out as a
+ * pure function so the decision is unit-testable without a live database.
+ */
+export function assertAppRoleBootstrapped(
+  roleEnsured: boolean,
+  breezeAppRoleExists: boolean,
+): void {
+  if (roleEnsured || breezeAppRoleExists) return;
+  throw new Error(
+    '[auto-migrate] Refusing to proceed: the `breeze_app` role does not exist and ' +
+      "ensureAppRole() could not create it because neither BREEZE_APP_DB_PASSWORD nor " +
+      "POSTGRES_PASSWORD is set in this process's environment. Set one of those two " +
+      'variables. If you invoked this via `pnpm db:migrate` (which runs through turbo), ' +
+      "confirm the variable is listed in turbo.json's `globalPassThroughEnv` — turbo " +
+      'silently strips any env var not declared there or in a task-level `env`/' +
+      '`passThroughEnv`, and a plain DATABASE_URL connection will otherwise proceed as ' +
+      'the admin/superuser and fail confusingly, many migration files later, with ' +
+      'Postgres error 42704.',
+  );
+}
+
 /** Resolve the directory containing numbered .sql migration files. */
 function resolveMigrationsDir(): string {
   try {
@@ -563,20 +594,7 @@ export async function autoMigrate(): Promise<void> {
       const roleRow = await client`
         SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'breeze_app') AS exists
       `;
-      const breezeAppRoleExists = Boolean(roleRow[0]?.exists);
-      if (!breezeAppRoleExists) {
-        throw new Error(
-          '[auto-migrate] Refusing to proceed: the `breeze_app` role does not exist and ' +
-            'ensureAppRole() could not create it because neither BREEZE_APP_DB_PASSWORD nor ' +
-            'POSTGRES_PASSWORD is set in this process\'s environment. Set one of those two ' +
-            'variables. If you invoked this via `pnpm db:migrate` (which runs through turbo), ' +
-            'confirm the variable is listed in turbo.json\'s `globalPassThroughEnv` — turbo ' +
-            'silently strips any env var not declared there or in a task-level `env`/' +
-            '`passThroughEnv`, and a plain DATABASE_URL connection will otherwise proceed as ' +
-            'the admin/superuser and fail confusingly, many migration files later, with ' +
-            'Postgres error 42704.',
-        );
-      }
+      assertAppRoleBootstrapped(roleEnsured, Boolean(roleRow[0]?.exists));
     }
 
     // ── 7. Apply pending migrations ──────────────────────────────────────

--- a/apps/api/src/db/ensureAppRole.test.ts
+++ b/apps/api/src/db/ensureAppRole.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ensureAppRole } from './ensureAppRole';
+
+// ensureAppRole() returns `false` and skips all DDL *before* opening a
+// Postgres connection when neither password env var is set — see
+// ensureAppRole.ts:23-28. That early-return means this test needs no
+// database and no mocking of the `postgres` client: it only has to control
+// the two env vars ensureAppRole() reads.
+describe('ensureAppRole', () => {
+  let originalBreezeAppDbPassword: string | undefined;
+  let originalPostgresPassword: string | undefined;
+
+  beforeEach(() => {
+    originalBreezeAppDbPassword = process.env.BREEZE_APP_DB_PASSWORD;
+    originalPostgresPassword = process.env.POSTGRES_PASSWORD;
+    delete process.env.BREEZE_APP_DB_PASSWORD;
+    delete process.env.POSTGRES_PASSWORD;
+  });
+
+  afterEach(() => {
+    if (originalBreezeAppDbPassword === undefined) {
+      delete process.env.BREEZE_APP_DB_PASSWORD;
+    } else {
+      process.env.BREEZE_APP_DB_PASSWORD = originalBreezeAppDbPassword;
+    }
+    if (originalPostgresPassword === undefined) {
+      delete process.env.POSTGRES_PASSWORD;
+    } else {
+      process.env.POSTGRES_PASSWORD = originalPostgresPassword;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('returns false and warns, without attempting a database connection, when neither password env var is set (#4048)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(ensureAppRole()).resolves.toBe(false);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Neither BREEZE_APP_DB_PASSWORD nor POSTGRES_PASSWORD is set',
+      ),
+    );
+  });
+});

--- a/apps/api/src/db/ensureAppRole.ts
+++ b/apps/api/src/db/ensureAppRole.ts
@@ -11,8 +11,15 @@ import { selectAppRolePassword } from './requestDatabaseConfig';
  * This runs from autoMigrate (which connects as the admin) because that is the
  * one place at startup where we have an admin connection and can afford to do
  * DDL. It is idempotent and safe to re-run.
+ *
+ * Returns `true` if the role was created/updated, `false` if the call was
+ * skipped because neither password env var is set. Callers that need
+ * `breeze_app` to exist (e.g. autoMigrate, before applying RLS-policy
+ * migrations) should check the return value and fail fast with a pointed
+ * error rather than let Postgres surface an unrelated-looking
+ * `role "breeze_app" does not exist` failure many files later.
  */
-export async function ensureAppRole(): Promise<void> {
+export async function ensureAppRole(): Promise<boolean> {
   const connectionString =
     process.env.DATABASE_URL || 'postgresql://breeze:breeze@localhost:5432/breeze';
 
@@ -24,7 +31,7 @@ export async function ensureAppRole(): Promise<void> {
     console.warn(
       '[ensure-app-role] Neither BREEZE_APP_DB_PASSWORD nor POSTGRES_PASSWORD is set — skipping breeze_app role setup. RLS will NOT be enforced against the admin connection.',
     );
-    return;
+    return false;
   }
 
   const client = postgres(connectionString, { max: 1 });
@@ -157,6 +164,7 @@ export async function ensureAppRole(): Promise<void> {
     `);
 
     console.log('[ensure-app-role] breeze_app role ensured (NOSUPERUSER, NOBYPASSRLS)');
+    return true;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`[ensure-app-role] failed: ${message}`);

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,9 @@
   "globalPassThroughEnv": [
     "DATABASE_URL",
     "REDIS_URL",
-    "NODE_ENV"
+    "NODE_ENV",
+    "BREEZE_APP_DB_PASSWORD",
+    "POSTGRES_PASSWORD"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

`turbo.json` declared `globalPassThroughEnv: [DATABASE_URL, REDIS_URL, NODE_ENV]` but not `BREEZE_APP_DB_PASSWORD`/`POSTGRES_PASSWORD`. Turbo strips any env var not in that list (or a task's own `env`) before invoking the script, so `pnpm db:migrate` (run through turbo) never received either password var — even when correctly set in the calling shell.

Because `DATABASE_URL` *was* pass-through-listed, the connection still worked, which made the failure deceptive: `ensureAppRole()` silently warned and skipped `breeze_app` bootstrap, migrations then ran ~135 files deep as the admin/superuser, and finally died on Postgres `42704: role "breeze_app" does not exist` — an error naming an RLS grant, not the missing env var. Affects any DB compose didn't already provision with `breeze_app` (fresh dev DBs, scratch containers, restored dumps).

## Fix decision (per the issue's ask)

- **turbo.json fix — done.** Added `BREEZE_APP_DB_PASSWORD` and `POSTGRES_PASSWORD` to `globalPassThroughEnv`, matching the existing `DATABASE_URL`/`REDIS_URL` pattern.
- **Cache-invalidation check — done, no concern.** Verified empirically with `turbo run <task> --dry-run=json`: the hash for a cacheable task (`lint`) was byte-identical whether the two vars were unset, or set to two different values. `passThroughEnv`/`globalPassThroughEnv` vars are excluded from turbo's cache key by design (unlike `globalEnv`, which would have poisoned every cached task's key on every local password rotation). `db:migrate` itself also already has `cache: false`, so this was moot for that task specifically, but the global list applies to every task.
- **CLAUDE.md doc change — not done, and not needed.** The documented `pnpm db:migrate` command becomes correct again once the env var actually reaches the process; there's no remaining gap to caveat or a workaround to record.
- **Extra hardening (from the issue's "suggested approach"), done:** `ensureAppRole()` now returns whether it actually ran (`false` when both password vars are absent). `autoMigrate()` checks that against whether `breeze_app` already exists — a compose-provisioned DB with the role pre-created still skips harmlessly — and fails fast with a message naming the missing env vars and turbo's `globalPassThroughEnv`, instead of letting the migration loop run ~135 files deep into an opaque `42704`. This closes the failure mode for any *future* pass-through gap too, not just this one.

## Files changed

- `turbo.json` — added the two vars to `globalPassThroughEnv`.
- `apps/api/src/db/ensureAppRole.ts` — `ensureAppRole()` now returns `Promise<boolean>` (ran vs. skipped) instead of `Promise<void>`.
- `apps/api/src/db/autoMigrate.ts` — checks the return value before applying RLS-policy migrations; fails fast with a pointed error if `breeze_app` doesn't exist and bootstrap was skipped.

## Verification

- `npx tsc --noEmit` (apps/api, with increased heap — the default OOMs on this codebase) — clean.
- `vitest run src/db/autoMigrate.test.ts` — 58/58 passed.
- **Real end-to-end run against a disposable Postgres 16 container** with no pre-existing `breeze_app` role (verifying, not just inspecting config):
  - **Pre-fix repro** (`git stash` on `turbo.json` only): `pnpm db:migrate` via turbo reproduces the silent skip → now hits the new fail-fast error immediately, naming the real cause, instead of a downstream `42704`.
  - **Post-fix**: `pnpm db:migrate` via turbo bootstraps `breeze_app` (confirmed `rolsuper=f`, `rolbypassrls=f`) and completes all 567 migrations + seed successfully.

Closes #4048

🤖 Generated with [Claude Code](https://claude.com/claude-code)