### PR TITLE
fix(agent): stop macOS capture errors from guessing at their own cause (#4042)

### DIFF
--- a/agent/internal/remote/desktop/capture_darwin.go
+++ b/agent/internal/remote/desktop/capture_darwin.go
@@ -53,8 +53,14 @@ static int loadDisplayFromShareableContent(id content, int displayIndex, id *out
     if (content == nil || outDisplay == nil) return 2;
 
     NSArray *displays = [content valueForKey:@"displays"];
-    if (displays == nil || displays.count == 0) {
+    if (displays == nil) {
         return 2;
+    }
+    // #4042: zero displays is NOT the same failure as a content request that
+    // errored. Nothing is attached to capture — no permission change can fix
+    // it. Reporting 2 here made the two indistinguishable in the Go error.
+    if (displays.count == 0) {
+        return 11;
     }
 
     NSUInteger idx = (NSUInteger)displayIndex;
@@ -258,6 +264,13 @@ void releaseCapture(void) {
     g_config = nil;
 }
 
+// activeDisplayCount reports how many displays the window server currently
+// has. One integer separates "nothing is attached" from "permission problem"
+// (#4042) — the distinction that took four rounds to establish on #3380.
+int activeDisplayCount(void) {
+    return (int)[NSScreen screens].count;
+}
+
 // getScreenBounds returns the bounds of the specified display
 void getScreenBounds(int displayIndex, int* width, int* height, int* error) {
     *error = 0;
@@ -332,8 +345,12 @@ func newPlatformCapturer(config CaptureConfig) (ScreenCapturer, error) {
 	if hasSCScreenshotManager() {
 		cap, sckErr := newSCKCapturer(config)
 		if sckErr != nil {
+			// Log the display count alongside the error: a zero here means the
+			// fallback is also doomed and the cause is a missing framebuffer,
+			// not a permission (#4042).
 			slog.Warn("ScreenCaptureKit init failed, falling back to CoreGraphics",
-				"error", sckErr.Error(), "darwinVersion", macOSMajorVersion)
+				"error", sckErr.Error(), "darwinVersion", macOSMajorVersion,
+				"activeDisplayCount", int(C.activeDisplayCount()))
 			cgCap, cgErr := newCGCapturer(config)
 			if cgErr != nil {
 				return nil, fmt.Errorf("SCK failed (%v); CG fallback also failed: %w", sckErr, cgErr)
@@ -466,32 +483,12 @@ func getScreenBoundsC(displayIndex int) (int, int, error) {
 	return int(cWidth), int(cHeight), nil
 }
 
-// translateDarwinError converts C error codes to Go errors
+// translateDarwinError forwards to the platform-neutral mapping in
+// capture_errors.go. That file carries no build tag on purpose: this one is
+// `darwin && cgo`, and the Test Agent CI job runs on ubuntu-latest, so a test
+// living beside this function would compile out and never run (#4042).
 func translateDarwinError(code int) error {
-	switch code {
-	case 1:
-		return fmt.Errorf("failed to get display list")
-	case 2:
-		return ErrDisplayNotFound
-	case 3:
-		return ErrPermissionDenied
-	case 4:
-		return fmt.Errorf("memory allocation failed")
-	case 5:
-		return fmt.Errorf("failed to create bitmap context")
-	case 6:
-		return fmt.Errorf("capturer not initialized — call initCapture first")
-	case 7:
-		return fmt.Errorf("ScreenCaptureKit timed out — process may lack Screen Recording permission (check System Settings > Privacy > Screen Recording)")
-	case 8:
-		return fmt.Errorf("macOS capture backend not available")
-	case 9:
-		return fmt.Errorf("failed to create CGDisplayStream")
-	case 10:
-		return fmt.Errorf("failed to start CGDisplayStream")
-	default:
-		return fmt.Errorf("unknown error: %d", code)
-	}
+	return translateCaptureError(code)
 }
 
 var _ ScreenCapturer = (*darwinCapturer)(nil)

--- a/agent/internal/remote/desktop/capture_errors.go
+++ b/agent/internal/remote/desktop/capture_errors.go
@@ -1,0 +1,77 @@
+package desktop
+
+import "fmt"
+
+// Capture error codes returned by the macOS C shims (capture_darwin.go,
+// capture_darwin_cg.go, capture_darwin_displaystream.go).
+//
+// Deliberately in a platform-NEUTRAL file. The shims are behind
+// `//go:build darwin && cgo`, and the Test Agent CI job runs on ubuntu-latest,
+// so anything tagged darwin compiles out and its tests never execute. Keeping
+// the code→message mapping here is what lets it be covered by CI at all.
+const (
+	captureErrDisplayList        = 1
+	captureErrContentUnavailable = 2
+	captureErrPermissionDenied   = 3
+	captureErrAllocFailed        = 4
+	captureErrBitmapContext      = 5
+	captureErrNotInitialized     = 6
+	captureErrTimeout            = 7
+	captureErrBackendUnavailable = 8
+	captureErrStreamCreate       = 9
+	captureErrStreamStart        = 10
+	// captureErrNoDisplayAttached is distinct from captureErrContentUnavailable
+	// on purpose (#4042). Both used to be code 2, so "there is no display to
+	// capture" and "the content request failed, e.g. Screen Recording denied"
+	// produced the same error — with opposite remediations. That cost four
+	// rounds of production intervention on #3380: the operator was told to
+	// check permissions on a host whose grants were correct and whose real
+	// problem was an Apple Silicon Mac with no framebuffer after its Screen
+	// Sharing session ended.
+	captureErrNoDisplayAttached = 11
+)
+
+// translateCaptureError converts a C shim error code into a Go error.
+//
+// Rule for every message here: report what was OBSERVED, and enumerate the
+// causes that produce it. Do not name a single cause. A message that guesses
+// sends every reader down that path, including the ones it is wrong for.
+func translateCaptureError(code int) error {
+	switch code {
+	case captureErrDisplayList:
+		return fmt.Errorf("failed to get display list")
+	case captureErrNoDisplayAttached:
+		return fmt.Errorf("%w: the system reported zero displays — nothing is attached to capture "+
+			"(on a headless Mac this is normal once a Screen Sharing session ends; "+
+			"attach a display or a dummy plug). This is NOT a permissions failure",
+			ErrDisplayNotFound)
+	case captureErrContentUnavailable:
+		return fmt.Errorf("%w: the shareable-content request failed. Causes: Screen Recording "+
+			"not granted to this process; the requested display index no longer exists; "+
+			"the window server rejected the request", ErrDisplayNotFound)
+	case captureErrPermissionDenied:
+		return ErrPermissionDenied
+	case captureErrAllocFailed:
+		return fmt.Errorf("memory allocation failed")
+	case captureErrBitmapContext:
+		return fmt.Errorf("failed to create bitmap context")
+	case captureErrNotInitialized:
+		return fmt.Errorf("capturer not initialized — call initCapture first")
+	case captureErrTimeout:
+		// Previously asserted "process may lack Screen Recording permission
+		// (check System Settings > Privacy > Screen Recording)". It is a plain
+		// semaphore expiry; a no-display host and a wedged window server produce
+		// it too. Naming one cause is what sent #3380 into System Settings.
+		return fmt.Errorf("ScreenCaptureKit did not answer within the timeout. Causes: no display " +
+			"attached; Screen Recording not granted to this process; the window server is not " +
+			"responding. Check the attached display count before changing any permission")
+	case captureErrBackendUnavailable:
+		return fmt.Errorf("macOS capture backend not available")
+	case captureErrStreamCreate:
+		return fmt.Errorf("failed to create CGDisplayStream")
+	case captureErrStreamStart:
+		return fmt.Errorf("failed to start CGDisplayStream")
+	default:
+		return fmt.Errorf("unknown error: %d", code)
+	}
+}

--- a/agent/internal/remote/desktop/capture_errors_test.go
+++ b/agent/internal/remote/desktop/capture_errors_test.go
@@ -1,0 +1,91 @@
+package desktop
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// No build tag, on purpose. The macOS shims are `darwin && cgo` and the
+// Test Agent CI job runs on ubuntu-latest, so a test placed beside them would
+// compile out and never execute (#4042).
+
+// causeAsserting matches phrasing that names ONE cause for a symptom that has
+// several. "may lack Screen Recording permission (check System Settings...)"
+// on a plain timeout is what sent #3380 into the permissions UI four times.
+var causeAsserting = regexp.MustCompile(`(?i)\b(probably|most likely|may lack|check System Settings)\b`)
+
+func TestNoDisplayAttachedIsDistinctFromContentUnavailable(t *testing.T) {
+	noDisplay := translateCaptureError(captureErrNoDisplayAttached)
+	contentFailed := translateCaptureError(captureErrContentUnavailable)
+
+	if noDisplay.Error() == contentFailed.Error() {
+		t.Fatalf("no-display and content-unavailable must not produce the same message; both were %q", noDisplay)
+	}
+	// Both are still display-resolution failures for existing callers.
+	for name, err := range map[string]error{"noDisplay": noDisplay, "contentFailed": contentFailed} {
+		if !errors.Is(err, ErrDisplayNotFound) {
+			t.Errorf("%s: expected errors.Is(..., ErrDisplayNotFound) to hold, got %v", name, err)
+		}
+	}
+	// The whole point of the split: the remediations are opposite, so each
+	// message must point at its own one.
+	if !strings.Contains(noDisplay.Error(), "zero displays") {
+		t.Errorf("no-display message should say the display count was zero, got %q", noDisplay)
+	}
+	if strings.Contains(noDisplay.Error(), "Screen Recording not granted") {
+		t.Errorf("no-display message must not blame permissions, got %q", noDisplay)
+	}
+	if !strings.Contains(contentFailed.Error(), "Screen Recording") {
+		t.Errorf("content-unavailable message should list Screen Recording among its causes, got %q", contentFailed)
+	}
+}
+
+func TestTimeoutDoesNotAssertACause(t *testing.T) {
+	err := translateCaptureError(captureErrTimeout)
+	if got := causeAsserting.FindString(err.Error()); got != "" {
+		t.Fatalf("timeout message asserts a cause (%q) for a symptom with several: %q", got, err)
+	}
+	if !strings.Contains(err.Error(), "Causes:") {
+		t.Errorf("timeout message should enumerate causes, got %q", err)
+	}
+}
+
+// Guards the rule for the whole table, so a future code added with a guessing
+// message fails here rather than in a customer's support thread.
+func TestNoCaptureErrorMessageAssertsACause(t *testing.T) {
+	for code := 0; code <= 12; code++ {
+		err := translateCaptureError(code)
+		if err == nil {
+			t.Fatalf("code %d returned a nil error", code)
+		}
+		if got := causeAsserting.FindString(err.Error()); got != "" {
+			t.Errorf("code %d asserts a cause (%q): %q", code, got, err)
+		}
+	}
+}
+
+func TestEveryCodeHasADistinctMessage(t *testing.T) {
+	codes := []int{
+		captureErrDisplayList, captureErrContentUnavailable, captureErrPermissionDenied,
+		captureErrAllocFailed, captureErrBitmapContext, captureErrNotInitialized,
+		captureErrTimeout, captureErrBackendUnavailable, captureErrStreamCreate,
+		captureErrStreamStart, captureErrNoDisplayAttached,
+	}
+	seen := make(map[string]int, len(codes))
+	for _, code := range codes {
+		msg := translateCaptureError(code).Error()
+		if prev, dup := seen[msg]; dup {
+			t.Errorf("codes %d and %d share the message %q — a caller cannot tell them apart", prev, code, msg)
+		}
+		seen[msg] = code
+	}
+}
+
+func TestUnknownCodeReportsTheCode(t *testing.T) {
+	err := translateCaptureError(99)
+	if !strings.Contains(err.Error(), "99") {
+		t.Errorf("unknown-code error should name the code, got %q", err)
+	}
+}


### PR DESCRIPTION
Closes #4042. Surfaced while diagnosing #3380, where a customer spent four follow-ups changing System Settings on a production canary gating a 0.107.0 unlock — against error text that named a cause it had not established.

### Error code 2 meant two unrelated things

`loadDisplayFromShareableContent` returned **2** for an **empty display list** — nothing attached to capture, which on an Apple Silicon Mac is exactly what happens once a Screen Sharing session ends. `fetchShareableContentDisplay` returned **2** when the content request errored — the shape of a TCC denial. Both became `ErrDisplayNotFound`.

The remediations are opposites: *attach a display* versus *grant Screen Recording*. Zero displays is now code 11 with its own message. Both still satisfy `errors.Is(err, ErrDisplayNotFound)`, so existing callers are unaffected.

### Code 7 asserted a cause for a generic timeout

It is a plain 10-second `dispatch_semaphore_wait` expiry, and it said *"process may lack Screen Recording permission (check System Settings > Privacy > Screen Recording)"*. A no-display host and an unresponsive window server produce the same timeout. It now reports what expired and enumerates the causes.

### One integer that would have ended #3380 on day one

The SCK→CoreGraphics fallback warning now carries `activeDisplayCount`. A zero means the fallback is doomed too — the CG path has no framebuffer either — which is how a no-display host presents as a session that starts, streams nothing, and ends, with no actionable error anywhere.

### Why the mapping moved to an untagged file

The shims are `//go:build darwin && cgo` and **Test Agent runs on `ubuntu-latest`**. A test placed beside them compiles out and never runs — it would have looked like coverage while executing nowhere, which is the same defect class as the messages themselves. `capture_errors.go` carries no build tag, so the table is covered by CI rather than only on a maintainer's Mac.

### Tests

Five, four behavioural rather than golden-string:

- no-display and content-unavailable must not share a message, and each must point at its own remediation;
- the timeout must not assert a cause;
- **no code in the table may assert one** — so a future code added with a guessing message fails here instead of in a support thread;
- every code must be distinguishable from every other;
- unknown codes name the code.

**Controls, each confirmed to red only its intended tests:** restoring the old cause-asserting timeout string reds the timeout and table-wide tests; collapsing code 11 back onto code 2 reds the two distinctness tests.

The first control **did not land on the first attempt** — `gofmt` had reflowed the string concatenation, so the anchor no longer matched and the mutation silently changed nothing while the suite stayed green. Caught only because the script asserted the mutation applied before running. Recording it because a red control proves nothing until you know it landed where you aimed.

---

**Verified:** `go test -race` on the package; `go vet` clean; builds for `darwin/arm64`, `darwin/amd64` (both `CGO_ENABLED=1`), `linux/amd64`, `windows/amd64`.

**Not verified:** the on-device behaviour this predicts for #3380. Whether that host's Viewer failure really is a missing framebuffer is still waiting on `system_profiler SPDisplaysDataType` from the reporter. This change makes the answer legible either way — it does not assume it.

**Not addressed:** #4038, the same "cannot distinguish causes" defect on the helper's `probe` subcommand. Separate surface, separate fix; @SemoTech has offered to beta a build that prints session and responsible-process context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
