### PR TITLE
docs(release-skill): pre-tag What's New entry step so the upgrade splash actually fires

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -41,6 +41,43 @@ If migrations are listed, you're committing prod to those migrations the moment 
 
 **Smoke-test privileged migrations as a NON-SUPERUSER role (learned the hard way, v0.95.0→v0.95.1).** CI and the local docker-compose test DB both migrate as the Postgres **superuser** (`POSTGRES_USER=breeze`), which silently passes statements a least-privilege role would be *denied*. Prod is DO-managed **`doadmin` — NOT a superuser**, so a migration that only a superuser can run passes every test and then **crash-loops the API on deploy** (this is exactly what took EU down on v0.95.0: `ALTER FUNCTION ... OWNER TO <role>` requires the *new owner* to hold `CREATE` on the schema; a superuser bypasses that check, doadmin does not → `permission denied for schema public`). So: any migration in the range that does `CREATE ROLE`, `ALTER ... OWNER TO`, `GRANT`/`REVOKE` on a schema, `CREATE EXTENSION`, or a `SECURITY DEFINER` function — **run it against a non-superuser role before tagging.** Two ways: pipe the migration to a real managed DB (or a droplet's `doadmin`) inside `BEGIN; ...; ROLLBACK;` with `ON_ERROR_STOP=1`, or `SET ROLE <nosuperuser-createrole-role>` on a local DB that already has the full schema. If it only works as a superuser, fix it forward (grant the owning role the privilege for the one statement, then revoke) **before** it reaches prod.
 
+## Step 0.4 — Author the in-app "What's New" entry (BEFORE tagging)
+
+The post-upgrade splash (`WhatsNewSplash`, shown on dashboard load) renders an entry from
+`WHATS_NEW_ENTRIES` in `apps/web/src/lib/whatsNew.ts` — a list **bundled into the web image
+at build time**. No entry for the release = no splash after the upgrade, regardless of what
+the server version says. This got skipped for 0.106.0 and 0.107.x, so the splash never fired
+in prod even though the feature shipped in 0.105.0.
+
+Ordering is the whole point: this is the **one comms artifact that is pre-tag**. The entry
+must be merged to `main` before the tag is pushed, or the build won't contain it. Everything
+else (release body, marketing notes, docs, Discord) happens after.
+
+Add a new entry at the **top** of `WHATS_NEW_ENTRIES` (newest-first):
+
+```ts
+{
+  version: '0.X.Y',   // bare semver — must equal the tag minus the 'v'
+  date: 'YYYY-MM-DD', // release date
+  title: '<one-line theme — same theme as the release body>',
+  highlights: [
+    // 2–5 short, user-facing bullets. Technician/MSP language, not commit
+    // subjects. Same audience as the marketing notes, tighter than both.
+  ],
+  learnMoreUrl: 'https://breezermm.com/release-notes',
+},
+```
+
+- Source the bullets from the same `$PREV..HEAD` sweep as Step 1 — the 2–5 things a
+  technician would actually notice in the UI. Skip infra, deps, internal refactors. A
+  mostly-internal release can honestly say "hardening and reliability" — or skip the entry
+  entirely (skipping is a valid choice, just a deliberate one).
+- Sanity-check: `cd apps/web && npx vitest run src/lib/whatsNewState.test.ts src/components/whatsNew/WhatsNewSplash.test.tsx`
+- **Already tagged without an entry? Do NOT backdate.** Users' `lastSeenVersion` floor in
+  localStorage is already baselined at the version they're running, so an entry versioned at
+  or below the shipped release will never auto-show for them. Version the entry as the *next*
+  release and fold the missed highlights into it.
+
 ## Step 0.5 — After tagging: WAIT for the build, confirm ALL artifacts exist
 
 Pushing the tag kicks off `release.yml`, which is a **long, multi-job build** (~20–40 min): api/web/portal GHCR images, agent binaries for every platform, the **signed** Windows MSI, the **notarized** macOS agent/viewer/helper, watchdog + user-helper, and the signed `release-artifact-manifest.json` (+ `.ed25519`/`.minisig`) and `checksums.txt`. The GitHub Release is created by the **final** job — you cannot `gh release edit` the body until then, and **you must not roll out until every artifact is present**.
@@ -379,6 +416,7 @@ and per-severity clocks: `internal/security-disclosure-policy.md`.
 - [ ] **Advisory-debt pre-flight run** (`gh api ... select(.state=="draft")`) — any draft whose patched version already rolled out is **published before this release proceeds**
 - [ ] `docs/release-notes/next-release-draft.md` read and folded into the body — then cleared
 - [ ] `git diff $PREV..HEAD --stat` + migrations reviewed — blast radius understood
+- [ ] In-app What's New entry added to `WHATS_NEW_ENTRIES` (`apps/web/src/lib/whatsNew.ts`) and **merged to main BEFORE the tag** — version = bare semver of this release (or deliberately skipped for an internal-only release)
 - [ ] Tag pushed (off main for full release / off $PREV for surgical hotfix)
 - [ ] **Abuse-asset gate** (Step 0.6): agent-family exes/MSI verified unsigned at the byte level, manifest all `edition=self-host`, checksums spot-checked
 - [ ] **Hosted signing lane dispatched and green** (private repo — see `internal/ops/release-infra.md`), with Todd's explicit go; draft stays unpublished until the droplet flip completes


### PR DESCRIPTION
## Why

The post-upgrade What's New splash (shipped in v0.105.0, #3317) has never fired in prod: `WHATS_NEW_ENTRIES` (`apps/web/src/lib/whatsNew.ts`) still only contains the 0.105.0 entry — nothing was authored for 0.106.0 or 0.107.x because the /release flow never mentioned it. On top of that, v0.105.0 carried bug #3646 (fixed in #3650/v0.106.0) which silently baselined everyone's `lastSeenVersion` floor, so nothing below the current version can ever auto-show.

## What

Adds to `.claude/skills/release/SKILL.md`:

- **Step 0.4 — Author the in-app What's New entry (BEFORE tagging).** The entry is bundled into the web image at build time, making it the one comms artifact that must merge to main *before* the tag (everything else — release body, marketing notes, docs, Discord — is post-tag). Covers the entry format, sourcing bullets from the same `$PREV..HEAD` sweep as Step 1, and the **no-backdating rule**: a missed release's highlights get folded into the *next* release's entry, since already-baselined floors mean a backdated entry never auto-shows.
- A **Quick checklist** item ahead of "Tag pushed".

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)