### PR TITLE
feat(api,web): lockout preflight + confirm-through before Enforce SSO goes live (#4068)

### DIFF
--- a/apps/api/src/__tests__/integration/ssoEnforcementPreflight.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoEnforcementPreflight.integration.test.ts
@@ -77,12 +77,30 @@ async function linkIdentity(userId: string, providerId: string) {
 }
 
 describe('enforce-SSO lockout preflight population (#4068)', () => {
-  it('org axis: effective-provider linkage, partner-membership exclusion, status filtering', async () => {
+  it('org axis: effective-provider linkage, partner-membership exclusion, status filtering, tenant isolation', async () => {
     const db = getTestDb();
     const partner = await createPartner();
     const org = await createOrganization({ partnerId: partner.id });
     const orgRole = await createRole({ scope: 'organization', orgId: org.id, partnerId: partner.id });
     const partnerRole = await createRole({ scope: 'partner', partnerId: partner.id });
+
+    // Tenant-isolation discriminator: a SIBLING org under the same partner
+    // with its own active unlinked member and its own provider. If any of the
+    // org_id filters were dropped, this user/provider would leak into the
+    // result — this is a system-context read that returns email addresses.
+    const otherOrg = await createOrganization({ partnerId: partner.id });
+    const otherOrgRole = await createRole({ scope: 'organization', orgId: otherOrg.id, partnerId: partner.id });
+    const outsider = await createUser({
+      partnerId: partner.id,
+      orgId: otherOrg.id,
+      email: `outsider-${uniq()}@example.com`,
+      name: 'outsider',
+      status: 'active'
+    });
+    await assignUserToOrganization(outsider.id, otherOrg.id, otherOrgRole.id);
+    // Older than every provider in the org under test: if the provider-axis
+    // filter leaked, THIS would be picked as the effective login provider.
+    await seedProvider({ orgId: otherOrg.id, status: 'active', createdAt: new Date(Date.now() - 120_000) });
 
     // Two ACTIVE providers: pOld is the one the login entry actually uses.
     const pOld = await seedProvider({ orgId: org.id, status: 'active', createdAt: new Date(Date.now() - 60_000) });
@@ -136,27 +154,33 @@ describe('enforce-SSO lockout preflight population (#4068)', () => {
       disabledAt: new Date()
     });
 
+    // Self = CAROL, whose email sorts AFTER alice's: the self-first assertion
+    // below only discriminates the isSelf sort term if the email tiebreak
+    // alone would order self last.
     const result = await computeEnforcementLockoutPreflight(
       { scope: 'organization', orgId: org.id },
       pNew.id,
-      alice.id
+      carol.id
     );
 
     // Active org-axis members: alice, bob, carol (dave partner-wins out,
-    // eve/frank not active).
+    // eve/frank not active, outsider belongs to the sibling org).
     expect(result.totalActiveUsers).toBe(3);
     expect(result.loginProvider?.id).toBe(pOld.id);
     const emails = result.unlinked.map((u) => u.email).sort();
     expect(emails).toEqual([alice.email, carol.email].sort());
     expect(result.unlinkedCount).toBe(2);
-    expect(result.selfLockedOut).toBe(true); // self = alice
+    expect(result.unlinked.some((u) => u.email === outsider.email)).toBe(false);
+    expect(result.selfLockedOut).toBe(true); // self = carol
 
     const aliceRow = result.unlinked.find((u) => u.id === alice.id)!;
-    expect(aliceRow.isSelf).toBe(true);
+    expect(aliceRow.isSelf).toBe(false);
     expect(aliceRow.hasPasskey).toBe(true);
-    // Self sorts first so truncation can never hide the self-lockout.
-    expect(result.unlinked[0]!.id).toBe(alice.id);
+    // Self sorts first (beating the email order) so truncation can never hide
+    // the self-lockout.
+    expect(result.unlinked[0]!.id).toBe(carol.id);
     const carolRow = result.unlinked.find((u) => u.id === carol.id)!;
+    expect(carolRow.isSelf).toBe(true);
     expect(carolRow.hasPasskey).toBe(false);
   });
 
@@ -180,12 +204,20 @@ describe('enforce-SSO lockout preflight population (#4068)', () => {
     const orgUser = await createUser({ partnerId: partner.id, orgId: org.id, email: `orguser-${uniq()}@example.com`, name: 'orguser', status: 'active' });
     await assignUserToOrganization(orgUser.id, org.id, orgRole.id);
 
+    // Tenant-isolation discriminator: a SECOND partner with its own unlinked
+    // staff — must not appear in this partner's population.
+    const otherPartner = await createPartner();
+    const otherPartnerRole = await createRole({ scope: 'partner', partnerId: otherPartner.id });
+    const otherTech = await createUser({ partnerId: otherPartner.id, email: `othertech-${uniq()}@example.com`, name: 'othertech', status: 'active' });
+    await assignUserToPartner(otherTech.id, otherPartner.id, otherPartnerRole.id, 'all');
+
     const result = await computeEnforcementLockoutPreflight(
       { scope: 'partner', partnerId: partner.id },
       target.id,
       tech2.id
     );
 
+    expect(result.unlinked.some((u) => u.email === otherTech.email)).toBe(false);
     expect(result.totalActiveUsers).toBe(2);
     expect(result.loginProvider?.id).toBe(target.id);
     expect(result.unlinkedCount).toBe(1);

--- a/apps/api/src/__tests__/integration/ssoEnforcementPreflight.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoEnforcementPreflight.integration.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Enforce-SSO lockout preflight (#4068) — population SQL against real Postgres.
+ *
+ * computeEnforcementLockoutPreflight (routes/sso.ts) computes who would be
+ * locked out when SSO enforcement goes live on an axis. The unit suite
+ * (sso.test.ts) pins the route contract with mocked chains, which cannot prove
+ * the SQL — and this query family is exactly the class where mocks have lied
+ * before (NOT/EXISTS over membership joins). The load-bearing semantics proven
+ * here:
+ *
+ *   - Membership comes from organization_users / partner_users, NOT
+ *     users.org_id — and partner membership WINS the axis (a user with both a
+ *     partner_users row and an organization_users row resolves to the partner
+ *     axis at login, so an org-axis provider never gates them).
+ *   - "Linked" means linked to the EFFECTIVE login provider — the oldest
+ *     (createdAt, id) provider that will be active once the change is live —
+ *     because the pre-auth login entries pick exactly that one. A link to a
+ *     newer active provider is unusable at login and must NOT count.
+ *   - Only status='active' users count; invited/disabled are already unable to
+ *     log in.
+ *   - identities/passkeys are user-id-scoped under RLS, so the whole read runs
+ *     in a system DB context — from a plain test context it must still see
+ *     every user's links.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { getTestDb } from './setup';
+import {
+  ssoProviders,
+  userSsoIdentities,
+  userPasskeys
+} from '../../db/schema';
+import {
+  createOrganization,
+  createPartner,
+  createRole,
+  createUser,
+  assignUserToOrganization,
+  assignUserToPartner
+} from './db-utils';
+import { computeEnforcementLockoutPreflight } from '../../routes/sso';
+
+const uniq = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+async function seedProvider(opts: {
+  orgId?: string | null;
+  partnerId?: string | null;
+  status: 'active' | 'inactive' | 'testing';
+  type?: 'oidc' | 'saml';
+  createdAt: Date;
+  enforceSSO?: boolean;
+}) {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(ssoProviders)
+    .values({
+      orgId: opts.orgId ?? null,
+      partnerId: opts.partnerId ?? null,
+      name: `preflight-${uniq()}`,
+      type: opts.type ?? 'oidc',
+      status: opts.status,
+      enforceSSO: opts.enforceSSO ?? false,
+      createdAt: opts.createdAt
+    })
+    .returning();
+  return row!;
+}
+
+async function linkIdentity(userId: string, providerId: string) {
+  const db = getTestDb();
+  await db.insert(userSsoIdentities).values({
+    userId,
+    providerId,
+    externalId: `ext-${uniq()}`,
+    email: `ext-${uniq()}@example.com`
+  });
+}
+
+describe('enforce-SSO lockout preflight population (#4068)', () => {
+  it('org axis: effective-provider linkage, partner-membership exclusion, status filtering', async () => {
+    const db = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const orgRole = await createRole({ scope: 'organization', orgId: org.id, partnerId: partner.id });
+    const partnerRole = await createRole({ scope: 'partner', partnerId: partner.id });
+
+    // Two ACTIVE providers: pOld is the one the login entry actually uses.
+    const pOld = await seedProvider({ orgId: org.id, status: 'active', createdAt: new Date(Date.now() - 60_000) });
+    const pNew = await seedProvider({ orgId: org.id, status: 'active', createdAt: new Date() });
+
+    const mkOrgUser = async (label: string, status: 'active' | 'invited' | 'disabled' = 'active') => {
+      const u = await createUser({
+        partnerId: partner.id,
+        orgId: org.id,
+        email: `${label}-${uniq()}@example.com`,
+        name: label,
+        status
+      });
+      await assignUserToOrganization(u.id, org.id, orgRole.id);
+      return u;
+    };
+
+    const alice = await mkOrgUser('alice'); // unlinked → locked out
+    const bob = await mkOrgUser('bob'); // linked to pOld → safe
+    await linkIdentity(bob.id, pOld.id);
+    const carol = await mkOrgUser('carol'); // linked ONLY to pNew → still locked out
+    await linkIdentity(carol.id, pNew.id);
+    const eve = await mkOrgUser('eve', 'disabled'); // excluded (not active)
+    const frank = await mkOrgUser('frank', 'invited'); // excluded (not active)
+
+    // dave: org membership AND partner membership — partner wins the axis, so
+    // the org preflight must not report him even though he's unlinked.
+    const dave = await createUser({
+      partnerId: partner.id,
+      orgId: org.id,
+      email: `dave-${uniq()}@example.com`,
+      name: 'dave',
+      status: 'active'
+    });
+    await assignUserToOrganization(dave.id, org.id, orgRole.id);
+    await assignUserToPartner(dave.id, partner.id, partnerRole.id, 'all');
+
+    // Passkey annotation: alice keeps a passkey path; a DISABLED passkey must
+    // not count (carol's).
+    await db.insert(userPasskeys).values({
+      userId: alice.id,
+      credentialId: `cred-${uniq()}`,
+      publicKey: 'pk',
+      deviceType: 'platform'
+    });
+    await db.insert(userPasskeys).values({
+      userId: carol.id,
+      credentialId: `cred-${uniq()}`,
+      publicKey: 'pk',
+      deviceType: 'platform',
+      disabledAt: new Date()
+    });
+
+    const result = await computeEnforcementLockoutPreflight(
+      { scope: 'organization', orgId: org.id },
+      pNew.id,
+      alice.id
+    );
+
+    // Active org-axis members: alice, bob, carol (dave partner-wins out,
+    // eve/frank not active).
+    expect(result.totalActiveUsers).toBe(3);
+    expect(result.loginProvider?.id).toBe(pOld.id);
+    const emails = result.unlinked.map((u) => u.email).sort();
+    expect(emails).toEqual([alice.email, carol.email].sort());
+    expect(result.unlinkedCount).toBe(2);
+    expect(result.selfLockedOut).toBe(true); // self = alice
+
+    const aliceRow = result.unlinked.find((u) => u.id === alice.id)!;
+    expect(aliceRow.isSelf).toBe(true);
+    expect(aliceRow.hasPasskey).toBe(true);
+    // Self sorts first so truncation can never hide the self-lockout.
+    expect(result.unlinked[0]!.id).toBe(alice.id);
+    const carolRow = result.unlinked.find((u) => u.id === carol.id)!;
+    expect(carolRow.hasPasskey).toBe(false);
+  });
+
+  it('partner axis: partner_users population, inactive target counts as the future login provider', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const partnerRole = await createRole({ scope: 'partner', partnerId: partner.id });
+    const orgRole = await createRole({ scope: 'organization', orgId: org.id, partnerId: partner.id });
+
+    // The target is INACTIVE (freshly created) and the only provider on the
+    // axis — it still becomes the effective login provider once activated.
+    const target = await seedProvider({ partnerId: partner.id, status: 'inactive', enforceSSO: true, createdAt: new Date() });
+
+    const tech1 = await createUser({ partnerId: partner.id, email: `tech1-${uniq()}@example.com`, name: 'tech1', status: 'active' });
+    await assignUserToPartner(tech1.id, partner.id, partnerRole.id, 'all');
+    const tech2 = await createUser({ partnerId: partner.id, email: `tech2-${uniq()}@example.com`, name: 'tech2', status: 'active' });
+    await assignUserToPartner(tech2.id, partner.id, partnerRole.id, 'all');
+    await linkIdentity(tech2.id, target.id);
+
+    // Org-axis member of the same partner — NOT partner-axis population.
+    const orgUser = await createUser({ partnerId: partner.id, orgId: org.id, email: `orguser-${uniq()}@example.com`, name: 'orguser', status: 'active' });
+    await assignUserToOrganization(orgUser.id, org.id, orgRole.id);
+
+    const result = await computeEnforcementLockoutPreflight(
+      { scope: 'partner', partnerId: partner.id },
+      target.id,
+      tech2.id
+    );
+
+    expect(result.totalActiveUsers).toBe(2);
+    expect(result.loginProvider?.id).toBe(target.id);
+    expect(result.unlinkedCount).toBe(1);
+    expect(result.unlinked[0]!.id).toBe(tech1.id);
+    expect(result.selfLockedOut).toBe(false); // self = tech2, who is linked
+  });
+
+  it('a SAML effective provider gives nobody a pre-auth path — links to it do not count', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const orgRole = await createRole({ scope: 'organization', orgId: org.id, partnerId: partner.id });
+
+    // Oldest active provider is SAML: the login entry 400s on it instead of
+    // falling through, so even a user LINKED to it is locked out.
+    const saml = await seedProvider({ orgId: org.id, status: 'active', type: 'saml', createdAt: new Date(Date.now() - 60_000) });
+
+    const user = await createUser({ partnerId: partner.id, orgId: org.id, email: `saml-user-${uniq()}@example.com`, name: 'saml-user', status: 'active' });
+    await assignUserToOrganization(user.id, org.id, orgRole.id);
+    await linkIdentity(user.id, saml.id);
+
+    const result = await computeEnforcementLockoutPreflight(
+      { scope: 'organization', orgId: org.id },
+      saml.id,
+      user.id
+    );
+
+    expect(result.loginProvider?.type).toBe('saml');
+    expect(result.unlinkedCount).toBe(1);
+    expect(result.selfLockedOut).toBe(true);
+  });
+
+  it('no provider on the axis at all (create flow): every active member is unlinked, loginProvider null', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const orgRole = await createRole({ scope: 'organization', orgId: org.id, partnerId: partner.id });
+    const user = await createUser({ partnerId: partner.id, orgId: org.id, email: `solo-${uniq()}@example.com`, name: 'solo', status: 'active' });
+    await assignUserToOrganization(user.id, org.id, orgRole.id);
+
+    const result = await computeEnforcementLockoutPreflight(
+      { scope: 'organization', orgId: org.id },
+      null,
+      user.id
+    );
+
+    expect(result.loginProvider).toBeNull();
+    expect(result.totalActiveUsers).toBe(1);
+    expect(result.unlinkedCount).toBe(1);
+  });
+});

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -199,9 +199,16 @@ vi.mock('../db/schema', () => ({
     userId: 'userId',
     providerId: 'providerId'
   },
+  // #4068: the enforcement preflight annotates users who keep a passkey
+  // sign-in path.
+  userPasskeys: {
+    id: 'id',
+    userId: 'userId'
+  },
   users: {
     id: 'id',
     email: 'email',
+    name: 'name',
     orgId: 'orgId',
     partnerId: 'partnerId',
     // SR2-10: the JIT ceiling re-check reads the configurer's live status —
@@ -4221,6 +4228,339 @@ describe('sso routes', () => {
       expect(res.status).toBe(302);
       expect(res.headers.get('location')).toContain('/login?error=sso_error');
       expect(db.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  // #4068: Enforce-SSO lockout preflight + confirm-through guard. The mocked
+  // db chains can't prove the population SQL is axis-correct (that's
+  // ssoEnforcementPreflight.integration.test.ts, against real Postgres) —
+  // these tests pin the route contract: authority checks, the 409
+  // confirm-through on the two live transitions, ack passthrough, and that
+  // acknowledgeLockout never reaches db.update().set().
+  describe('enforce-SSO lockout preflight (#4068)', () => {
+    const OLDER_PROVIDER_UUID = '00000000-0000-4000-8000-000000000002';
+
+    // Chain shapes the preflight helper consumes, in call order:
+    //   1..2. exists() subquery builders (linked, passkey) — never awaited,
+    //         but they DO consume db.select calls, so every queue below must
+    //         account for them.
+    // The helper's awaited selects:
+    //   providers: select().from().where().orderBy() -> Promise<rows>
+    //   members:   select().from().innerJoin().where() -> Promise<rows>
+    const providersChain = (rows: any[]) => ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ orderBy: vi.fn().mockResolvedValue(rows) })
+      })
+    });
+    const membersChain = (rows: any[]) => ({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(rows) })
+      })
+    });
+    // Subquery builders (exists()/notExists() args): only need to be chainable.
+    const subqueryChain = () => ({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({}) })
+    });
+    const providerLookupChain = (rows: any[]) => ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) })
+      })
+    });
+
+    // Queue the helper's internal db.select calls IN CALL ORDER:
+    //   1. axis providers (awaited)
+    //   2. linked-subquery builder — ONLY when an OIDC login provider is
+    //      picked (loginCapableProviderId non-null)
+    //   3. passkey-subquery builder (always)
+    //   4. members outer select (awaited) — fluent chain STARTS before its
+    //      .where() args are evaluated, so...
+    //   5. ...the org-axis partner-membership notExists builder consumes the
+    //      NEXT queue slot, after the members chain.
+    const queuePreflightSelects = (opts: {
+      providers: any[];
+      members: any[];
+      orgAxis?: boolean;
+      hasLoginProvider?: boolean;
+      first?: any[] | null; // provider-row lookup for the providerId flow
+    }) => {
+      const sel = vi.mocked(db.select).mockReset();
+      if (opts.first !== undefined && opts.first !== null) {
+        sel.mockReturnValueOnce(providerLookupChain(opts.first) as any);
+      }
+      sel.mockReturnValueOnce(providersChain(opts.providers) as any);
+      if (opts.hasLoginProvider) sel.mockReturnValueOnce(subqueryChain() as any);
+      sel.mockReturnValueOnce(subqueryChain() as any);
+      sel.mockReturnValueOnce(membersChain(opts.members) as any);
+      if (opts.orgAxis) sel.mockReturnValueOnce(subqueryChain() as any);
+      return sel;
+    };
+
+    const UNLINKED_SELF = { id: USER_UUID, email: 'test@example.com', name: 'Admin', linked: false, hasPasskey: false };
+    const UNLINKED_OTHER = { id: '00000000-0000-4000-8000-000000000021', email: 'alice@example.com', name: 'Alice', linked: false, hasPasskey: true };
+    const LINKED_OTHER = { id: '00000000-0000-4000-8000-000000000022', email: 'bob@example.com', name: 'Bob', linked: true, hasPasskey: false };
+
+    describe('POST /providers/enforcement-preflight', () => {
+      it('create flow (org axis, no providers yet): every active member is unlinked, loginProvider null', async () => {
+        queuePreflightSelects({ providers: [], members: [UNLINKED_SELF, UNLINKED_OTHER], orgAxis: true });
+
+        const res = await app.request('/sso/providers/enforcement-preflight', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({})
+        });
+
+        expect(res.status).toBe(200);
+        const { data } = await res.json();
+        expect(data.totalActiveUsers).toBe(2);
+        expect(data.unlinkedCount).toBe(2);
+        expect(data.selfLockedOut).toBe(true);
+        expect(data.loginProvider).toBeNull();
+        // Self sorts first so the guaranteed-self-lockout case survives truncation.
+        expect(data.unlinked[0]).toMatchObject({ id: USER_UUID, isSelf: true });
+        expect(data.unlinked[1]).toMatchObject({ email: 'alice@example.com', isSelf: false, hasPasskey: true });
+      });
+
+      it('edit flow (providerId): linked members are excluded and the effective login provider is reported', async () => {
+        queuePreflightSelects({
+          first: [{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null }],
+          providers: [
+            { id: OLDER_PROVIDER_UUID, name: 'Okta (old)', type: 'oidc', status: 'active' },
+            { id: PROVIDER_UUID, name: 'Entra (new)', type: 'oidc', status: 'active' }
+          ],
+          members: [LINKED_OTHER, UNLINKED_OTHER],
+          orgAxis: true,
+          hasLoginProvider: true
+        });
+
+        const res = await app.request('/sso/providers/enforcement-preflight', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ providerId: PROVIDER_UUID })
+        });
+
+        expect(res.status).toBe(200);
+        const { data } = await res.json();
+        expect(data.totalActiveUsers).toBe(2);
+        expect(data.unlinkedCount).toBe(1);
+        expect(data.selfLockedOut).toBe(false);
+        // The pre-auth login entry picks the OLDEST active provider — links to
+        // the newer target don't matter, and the preflight must say which
+        // provider actually gates sign-in.
+        expect(data.loginProvider).toMatchObject({ id: OLDER_PROVIDER_UUID, type: 'oidc' });
+        expect(data.unlinked).toHaveLength(1);
+        expect(data.unlinked[0].email).toBe('alice@example.com');
+      });
+
+      it('404s an unknown providerId', async () => {
+        queuePreflightSelects({ first: [], providers: [], members: [] });
+        const res = await app.request('/sso/providers/enforcement-preflight', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ providerId: PROVIDER_UUID })
+        });
+        expect(res.status).toBe(404);
+      });
+
+      it("403s a caller without write access to the provider's axis", async () => {
+        setAuthContext({ canAccessOrg: () => false });
+        queuePreflightSelects({ first: [{ id: PROVIDER_UUID, orgId: ORG_UUID_OTHER, partnerId: null }], providers: [], members: [] });
+        const res = await app.request('/sso/providers/enforcement-preflight', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ providerId: PROVIDER_UUID })
+        });
+        expect(res.status).toBe(403);
+      });
+
+      it('403s a partner-axis preflight from a partner caller without full org access', async () => {
+        setAuthContext({ scope: 'partner', orgId: null, partnerId: PARTNER_UUID, accessibleOrgIds: [], partnerOrgAccess: 'selected' });
+        const res = await app.request('/sso/providers/enforcement-preflight', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ownerScope: 'partner' })
+        });
+        expect(res.status).toBe(403);
+        expect((await res.json()).error).toBe(PARTNER_WIDE_WRITE_DENIED_MESSAGE);
+      });
+
+      it('partner-axis create flow uses the partner membership population', async () => {
+        setAuthContext({ scope: 'partner', orgId: null, partnerId: PARTNER_UUID, accessibleOrgIds: [], partnerOrgAccess: 'all' });
+        queuePreflightSelects({ providers: [], members: [UNLINKED_OTHER] });
+        const res = await app.request('/sso/providers/enforcement-preflight', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ownerScope: 'partner' })
+        });
+        expect(res.status).toBe(200);
+        const { data } = await res.json();
+        expect(data.unlinkedCount).toBe(1);
+        expect(data.selfLockedOut).toBe(false);
+      });
+
+      it('a SAML effective login provider gives nobody a pre-auth path', async () => {
+        queuePreflightSelects({
+          first: [{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null }],
+          providers: [{ id: OLDER_PROVIDER_UUID, name: 'ADFS', type: 'saml', status: 'active' }],
+          // The linked flag comes from the SQL `false` literal in the real
+          // query; the mock mirrors that: nobody counts as linked.
+          members: [{ ...LINKED_OTHER, linked: false }],
+          orgAxis: true
+        });
+        const res = await app.request('/sso/providers/enforcement-preflight', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ providerId: PROVIDER_UUID })
+        });
+        expect(res.status).toBe(200);
+        const { data } = await res.json();
+        expect(data.unlinkedCount).toBe(1);
+        expect(data.loginProvider).toMatchObject({ type: 'saml' });
+      });
+    });
+
+    describe('PATCH /providers/:id confirm-through guard', () => {
+      const patchProvider = (body: Record<string, unknown>) =>
+        app.request(`/sso/providers/${PROVIDER_UUID}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+
+      const ACTIVE_UNENFORCED = {
+        id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null,
+        issuer: 'https://issuer.example.com', type: 'oidc', status: 'active', enforceSSO: false
+      };
+
+      it('409s enabling enforceSSO on an active provider when users would be locked out', async () => {
+        queuePreflightSelects({
+          first: [ACTIVE_UNENFORCED],
+          providers: [{ id: PROVIDER_UUID, name: 'Okta', type: 'oidc', status: 'active' }],
+          members: [UNLINKED_OTHER],
+          orgAxis: true,
+          hasLoginProvider: true
+        });
+
+        const res = await patchProvider({ enforceSSO: true });
+
+        expect(res.status).toBe(409);
+        const bodyJson = await res.json();
+        expect(bodyJson.code).toBe('sso_enforcement_lockout_confirmation_required');
+        expect(bodyJson.preflight.unlinkedCount).toBe(1);
+        expect(bodyJson.preflight.unlinked[0].email).toBe('alice@example.com');
+        expect(db.update).not.toHaveBeenCalled();
+      });
+
+      it('proceeds with acknowledgeLockout: true — and never writes it as a column', async () => {
+        vi.mocked(db.select).mockReset().mockReturnValueOnce(providerLookupChain([ACTIVE_UNENFORCED]) as any);
+        const setMock = vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...ACTIVE_UNENFORCED, enforceSSO: true, clientSecret: null }])
+          })
+        });
+        vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+
+        const res = await patchProvider({ enforceSSO: true, acknowledgeLockout: true });
+
+        expect(res.status).toBe(200);
+        expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ enforceSSO: true }));
+        expect(setMock).not.toHaveBeenCalledWith(expect.objectContaining({ acknowledgeLockout: expect.anything() }));
+      });
+
+      it('proceeds without acknowledgement when nobody would be locked out', async () => {
+        queuePreflightSelects({
+          first: [ACTIVE_UNENFORCED],
+          providers: [{ id: PROVIDER_UUID, name: 'Okta', type: 'oidc', status: 'active' }],
+          members: [LINKED_OTHER],
+          orgAxis: true,
+          hasLoginProvider: true
+        });
+        const setMock = vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...ACTIVE_UNENFORCED, enforceSSO: true, clientSecret: null }])
+          })
+        });
+        vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+
+        const res = await patchProvider({ enforceSSO: true });
+        expect(res.status).toBe(200);
+      });
+
+      it('does not gate enabling enforceSSO on an INACTIVE provider (activation is the guarded moment)', async () => {
+        vi.mocked(db.select).mockReset().mockReturnValueOnce(
+          providerLookupChain([{ ...ACTIVE_UNENFORCED, status: 'inactive' }]) as any
+        );
+        const setMock = vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...ACTIVE_UNENFORCED, status: 'inactive', enforceSSO: true, clientSecret: null }])
+          })
+        });
+        vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+
+        const res = await patchProvider({ enforceSSO: true });
+        expect(res.status).toBe(200);
+        // Only the provider lookup ran — no preflight population reads.
+        expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('POST /providers/:id/status confirm-through guard', () => {
+      const postStatus = (body: Record<string, unknown>) =>
+        app.request(`/sso/providers/${PROVIDER_UUID}/status`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+
+      const INACTIVE_ENFORCING = {
+        id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null, status: 'inactive', enforceSSO: true
+      };
+
+      it('409s activating an enforcing provider when users would be locked out', async () => {
+        queuePreflightSelects({
+          first: [INACTIVE_ENFORCING],
+          providers: [{ id: PROVIDER_UUID, name: 'Okta', type: 'oidc', status: 'inactive' }],
+          members: [UNLINKED_OTHER],
+          orgAxis: true,
+          hasLoginProvider: true
+        });
+
+        const res = await postStatus({ status: 'active' });
+
+        expect(res.status).toBe(409);
+        expect((await res.json()).code).toBe('sso_enforcement_lockout_confirmation_required');
+        expect(db.update).not.toHaveBeenCalled();
+      });
+
+      it('activates with acknowledgeLockout: true', async () => {
+        vi.mocked(db.select).mockReset().mockReturnValueOnce(providerLookupChain([INACTIVE_ENFORCING]) as any);
+        const setMock = vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...INACTIVE_ENFORCING, status: 'active' }])
+          })
+        });
+        vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+
+        const res = await postStatus({ status: 'active', acknowledgeLockout: true });
+        expect(res.status).toBe(200);
+        expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'active' }));
+        expect(setMock).not.toHaveBeenCalledWith(expect.objectContaining({ acknowledgeLockout: expect.anything() }));
+      });
+
+      it('does not gate activating a NON-enforcing provider', async () => {
+        vi.mocked(db.select).mockReset().mockReturnValueOnce(
+          providerLookupChain([{ ...INACTIVE_ENFORCING, enforceSSO: false }]) as any
+        );
+        const setMock = vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...INACTIVE_ENFORCING, enforceSSO: false, status: 'active' }])
+          })
+        });
+        vi.mocked(db.update).mockReturnValue({ set: setMock } as any);
+
+        const res = await postStatus({ status: 'active' });
+        expect(res.status).toBe(200);
+        expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/apps/api/src/routes/sso.test.ts
+++ b/apps/api/src/routes/sso.test.ts
@@ -4282,10 +4282,17 @@ describe('sso routes', () => {
       orgAxis?: boolean;
       hasLoginProvider?: boolean;
       first?: any[] | null; // provider-row lookup for the providerId flow
+      // The create flow's org branch runs an RLS-visibility probe on
+      // organizations BEFORE the population read (no provider row proves
+      // authority there).
+      orgProbe?: boolean;
     }) => {
       const sel = vi.mocked(db.select).mockReset();
       if (opts.first !== undefined && opts.first !== null) {
         sel.mockReturnValueOnce(providerLookupChain(opts.first) as any);
+      }
+      if (opts.orgProbe) {
+        sel.mockReturnValueOnce(providerLookupChain([{ id: ORG_UUID }]) as any);
       }
       sel.mockReturnValueOnce(providersChain(opts.providers) as any);
       if (opts.hasLoginProvider) sel.mockReturnValueOnce(subqueryChain() as any);
@@ -4301,7 +4308,7 @@ describe('sso routes', () => {
 
     describe('POST /providers/enforcement-preflight', () => {
       it('create flow (org axis, no providers yet): every active member is unlinked, loginProvider null', async () => {
-        queuePreflightSelects({ providers: [], members: [UNLINKED_SELF, UNLINKED_OTHER], orgAxis: true });
+        queuePreflightSelects({ providers: [], members: [UNLINKED_SELF, UNLINKED_OTHER], orgAxis: true, orgProbe: true });
 
         const res = await app.request('/sso/providers/enforcement-preflight', {
           method: 'POST',
@@ -4397,6 +4404,62 @@ describe('sso routes', () => {
         expect(data.selfLockedOut).toBe(false);
       });
 
+      // The preflight discloses active-user emails axis-wide — its auth chain
+      // must be exactly as hard as the writes it fronts. The global
+      // recordedPermissionGuards assertion can't tell which route carries
+      // which guard, so pin authMiddleware and requireMfa here directly.
+      it('401s without authentication (no population read)', async () => {
+        vi.mocked(authMiddleware).mockImplementation((c: any) => c.json({ error: 'Unauthorized' }, 401));
+        const res = await app.request('/sso/providers/enforcement-preflight', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({})
+        });
+        expect(res.status).toBe(401);
+        expect(db.select).not.toHaveBeenCalled();
+      });
+
+      it('403s without MFA (no population read)', async () => {
+        mfaGate.deny = true;
+        const res = await app.request('/sso/providers/enforcement-preflight', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({})
+        });
+        expect(res.status).toBe(403);
+        expect(db.select).not.toHaveBeenCalled();
+      });
+
+      it('caps the unlinked list at 200 with exact counts, self surviving the cut', async () => {
+        // 201 unlinked users; self's email sorts LAST alphabetically, so a
+        // slice-before-sort regression would drop the guaranteed-self-lockout
+        // row — the one the cap must never hide.
+        const many = Array.from({ length: 200 }, (_, i) => ({
+          id: `00000000-0000-4000-8000-${String(100000 + i).padStart(12, '0')}`,
+          email: `user-${String(i).padStart(3, '0')}@example.com`,
+          name: `User ${i}`,
+          linked: false,
+          hasPasskey: false
+        }));
+        const self = { id: USER_UUID, email: 'zzz-self@example.com', name: 'Self', linked: false, hasPasskey: false };
+        queuePreflightSelects({ providers: [], members: [...many, self], orgAxis: true, orgProbe: true });
+
+        const res = await app.request('/sso/providers/enforcement-preflight', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({})
+        });
+
+        expect(res.status).toBe(200);
+        const { data } = await res.json();
+        expect(data.unlinkedCount).toBe(201);
+        expect(data.totalActiveUsers).toBe(201);
+        expect(data.truncated).toBe(true);
+        expect(data.unlinked).toHaveLength(200);
+        expect(data.unlinked[0]).toMatchObject({ id: USER_UUID, isSelf: true });
+        expect(data.selfLockedOut).toBe(true);
+      });
+
       it('a SAML effective login provider gives nobody a pre-auth path', async () => {
         queuePreflightSelects({
           first: [{ id: PROVIDER_UUID, orgId: ORG_UUID, partnerId: null }],
@@ -4450,8 +4513,16 @@ describe('sso routes', () => {
         expect(db.update).not.toHaveBeenCalled();
       });
 
-      it('proceeds with acknowledgeLockout: true — and never writes it as a column', async () => {
-        vi.mocked(db.select).mockReset().mockReturnValueOnce(providerLookupChain([ACTIVE_UNENFORCED]) as any);
+      it('proceeds with acknowledgeLockout: true, never writes it as a column, and audits the accepted lockout', async () => {
+        // The preflight runs on the acknowledged path too — the accepted
+        // lockout must be as auditable as the rejected one.
+        queuePreflightSelects({
+          first: [ACTIVE_UNENFORCED],
+          providers: [{ id: PROVIDER_UUID, name: 'Okta', type: 'oidc', status: 'active' }],
+          members: [UNLINKED_OTHER],
+          orgAxis: true,
+          hasLoginProvider: true
+        });
         const setMock = vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             returning: vi.fn().mockResolvedValue([{ ...ACTIVE_UNENFORCED, enforceSSO: true, clientSecret: null }])
@@ -4464,6 +4535,37 @@ describe('sso routes', () => {
         expect(res.status).toBe(200);
         expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ enforceSSO: true }));
         expect(setMock).not.toHaveBeenCalledWith(expect.objectContaining({ acknowledgeLockout: expect.anything() }));
+        // The executed lockout is distinguishable from an ordinary enforce flip.
+        expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+          action: 'sso.provider.update',
+          details: expect.objectContaining({
+            acknowledgedLockout: true,
+            lockedOutCount: 1,
+            selfLockedOut: false
+          })
+        }));
+      });
+
+      it('409s a PARTNER-axis provider the same way (technician-login axis)', async () => {
+        setAuthContext({ scope: 'partner', orgId: null, partnerId: PARTNER_UUID, accessibleOrgIds: [], partnerOrgAccess: 'all' });
+        queuePreflightSelects({
+          first: [{ ...ACTIVE_UNENFORCED, orgId: null, partnerId: PARTNER_UUID }],
+          providers: [{ id: PROVIDER_UUID, name: 'Team IdP', type: 'oidc', status: 'active' }],
+          // partner axis: no org-side notExists slot
+          members: [UNLINKED_OTHER],
+          hasLoginProvider: true
+        });
+
+        const res = await patchProvider({ enforceSSO: true });
+
+        expect(res.status).toBe(409);
+        expect((await res.json()).code).toBe('sso_enforcement_lockout_confirmation_required');
+        expect(db.update).not.toHaveBeenCalled();
+        expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+          action: 'sso.provider.update.rejected',
+          orgId: null,
+          details: expect.objectContaining({ partnerId: PARTNER_UUID })
+        }));
       });
 
       it('proceeds without acknowledgement when nobody would be locked out', async () => {
@@ -4531,8 +4633,14 @@ describe('sso routes', () => {
         expect(db.update).not.toHaveBeenCalled();
       });
 
-      it('activates with acknowledgeLockout: true', async () => {
-        vi.mocked(db.select).mockReset().mockReturnValueOnce(providerLookupChain([INACTIVE_ENFORCING]) as any);
+      it('activates with acknowledgeLockout: true and audits the accepted lockout', async () => {
+        queuePreflightSelects({
+          first: [INACTIVE_ENFORCING],
+          providers: [{ id: PROVIDER_UUID, name: 'Okta', type: 'oidc', status: 'inactive' }],
+          members: [UNLINKED_OTHER],
+          orgAxis: true,
+          hasLoginProvider: true
+        });
         const setMock = vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             returning: vi.fn().mockResolvedValue([{ ...INACTIVE_ENFORCING, status: 'active' }])
@@ -4544,6 +4652,10 @@ describe('sso routes', () => {
         expect(res.status).toBe(200);
         expect(setMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'active' }));
         expect(setMock).not.toHaveBeenCalledWith(expect.objectContaining({ acknowledgeLockout: expect.anything() }));
+        expect(writeRouteAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+          action: 'sso.provider.status.update',
+          details: expect.objectContaining({ acknowledgedLockout: true, lockedOutCount: 1 })
+        }));
       });
 
       it('does not gate activating a NON-enforcing provider', async () => {

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
-import { eq, and, gt, ne, isNull, inArray, sql } from 'drizzle-orm';
+import { eq, and, gt, ne, isNull, inArray, exists, notExists, sql } from 'drizzle-orm';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { nanoid } from 'nanoid';
 import { db, runOutsideDbContext, withSystemDbAccessContext, getCurrentDbAccessContext } from '../db';
@@ -14,7 +14,8 @@ import {
   organizations,
   organizationUsers,
   partnerUsers,
-  roles
+  roles,
+  userPasskeys
 } from '../db/schema';
 import { createPendingDomain, verifyDomain, recordNameFor, recordValueFor, isSsoProvisioningBlocked, isDomainVerifiedForOrg } from '../services/ssoDomainVerification';
 import { authMiddleware, requireMfa, requirePermission, requireScope, withAuthDbAccessContext, type AuthContext } from '../middleware/auth';
@@ -191,7 +192,11 @@ const createProviderSchema = z.object({
 // anyway — omit it. (Same class as the ownerScope omit above.)
 const updateProviderSchema = createProviderSchema
   .omit({ orgId: true, ownerScope: true, preset: true })
-  .partial();
+  .partial()
+  // #4068: confirm-through for the lockout guard. NOT a column — must be
+  // stripped before the `...body` spread into db.update().set() (same class
+  // as the `preset` omit above).
+  .extend({ acknowledgeLockout: z.boolean().optional() });
 const tokenExchangeSchema = z.object({
   code: z.string().min(1)
 });
@@ -1127,7 +1132,9 @@ ssoRoutes.patch(
   async (c) => {
   const auth = c.get('auth') as AuthContext;
   const { id: providerId } = c.req.valid('param');
-  const body = c.req.valid('json');
+  // acknowledgeLockout is a request-level confirmation, not a column — keep it
+  // out of `body`, which is spread straight into db.update().set().
+  const { acknowledgeLockout, ...body } = c.req.valid('json');
 
   const existing = await withAuthDbAccessContext(auth, async () => {
     const [row] = await db
@@ -1136,7 +1143,9 @@ ssoRoutes.patch(
         orgId: ssoProviders.orgId,
         partnerId: ssoProviders.partnerId,
         issuer: ssoProviders.issuer,
-        type: ssoProviders.type
+        type: ssoProviders.type,
+        status: ssoProviders.status,
+        enforceSSO: ssoProviders.enforceSSO
       })
       .from(ssoProviders)
       .where(eq(ssoProviders.id, providerId))
@@ -1150,6 +1159,39 @@ ssoRoutes.patch(
 
   if (!canWriteProviderRow(auth, existing)) {
     return c.json({ error: 'Access denied' }, 403);
+  }
+
+  // #4068: this PATCH is one of the two transitions that make enforcement live
+  // (the other is activating an already-enforcing provider — see the status
+  // route). Enabling enforceSSO on an ACTIVE provider immediately blocks
+  // password login axis-wide, so if that would lock out users with no usable
+  // SSO link, require the caller to explicitly confirm through with
+  // acknowledgeLockout: true. The 409 carries the preflight payload so raw API
+  // callers see exactly who is affected — the same data the web UI shows.
+  if (body.enforceSSO === true && !existing.enforceSSO && existing.status === 'active') {
+    const lockoutScope = providerScopeContext(existing);
+    if (lockoutScope && !acknowledgeLockout) {
+      const preflight = await computeEnforcementLockoutPreflight(lockoutScope, existing.id, auth.user.id);
+      if (preflight.unlinkedCount > 0) {
+        writeRouteAudit(c, {
+          orgId: existing.orgId,
+          action: 'sso.provider.update.rejected',
+          resourceType: 'sso_provider',
+          resourceId: existing.id,
+          details: {
+            reason: 'enforcement_lockout_unacknowledged',
+            unlinkedCount: preflight.unlinkedCount,
+            partnerId: existing.partnerId
+          }
+        });
+        return c.json({
+          error: `Enabling Enforce SSO would lock out ${preflight.unlinkedCount} active user(s) who have no usable SSO link. `
+            + 'Review the preflight payload and resend with acknowledgeLockout: true to proceed.',
+          code: 'sso_enforcement_lockout_confirmation_required',
+          preflight
+        }, 409);
+      }
+    }
   }
 
   // SR2-10: axis-aware. This was partner-only (`existing.partnerId && ...`), so
@@ -1373,14 +1415,24 @@ ssoRoutes.post(
   requirePermission(PERMISSIONS.SSO_ADMIN.resource, PERMISSIONS.SSO_ADMIN.action),
   requireMfa(),
   zValidator('param', providerIdParamSchema),
-  zValidator('json', z.object({ status: z.enum(['active', 'inactive', 'testing']) })),
+  zValidator('json', z.object({
+    status: z.enum(['active', 'inactive', 'testing']),
+    // #4068: confirm-through for the lockout guard below.
+    acknowledgeLockout: z.boolean().optional()
+  })),
   async (c) => {
   const auth = c.get('auth') as AuthContext;
   const { id: providerId } = c.req.valid('param');
-  const { status } = c.req.valid('json');
+  const { status, acknowledgeLockout } = c.req.valid('json');
 
   const [existing] = await db
-    .select({ id: ssoProviders.id, orgId: ssoProviders.orgId, partnerId: ssoProviders.partnerId })
+    .select({
+      id: ssoProviders.id,
+      orgId: ssoProviders.orgId,
+      partnerId: ssoProviders.partnerId,
+      status: ssoProviders.status,
+      enforceSSO: ssoProviders.enforceSSO
+    })
     .from(ssoProviders)
     .where(eq(ssoProviders.id, providerId))
     .limit(1);
@@ -1391,6 +1443,36 @@ ssoRoutes.post(
 
   if (!canWriteProviderRow(auth, existing)) {
     return c.json({ error: 'Access denied' }, 403);
+  }
+
+  // #4068: activating a provider that already has enforceSSO set is the second
+  // transition that makes enforcement live (the first is PATCHing enforceSSO
+  // onto an active provider). Same confirm-through contract: a lockout-causing
+  // activation without acknowledgeLockout gets a 409 carrying the preflight.
+  if (status === 'active' && existing.status !== 'active' && existing.enforceSSO && !acknowledgeLockout) {
+    const lockoutScope = providerScopeContext(existing);
+    if (lockoutScope) {
+      const preflight = await computeEnforcementLockoutPreflight(lockoutScope, existing.id, auth.user.id);
+      if (preflight.unlinkedCount > 0) {
+        writeRouteAudit(c, {
+          orgId: existing.orgId,
+          action: 'sso.provider.status.update.rejected',
+          resourceType: 'sso_provider',
+          resourceId: existing.id,
+          details: {
+            reason: 'enforcement_lockout_unacknowledged',
+            unlinkedCount: preflight.unlinkedCount,
+            partnerId: existing.partnerId
+          }
+        });
+        return c.json({
+          error: `Activating this provider enforces SSO and would lock out ${preflight.unlinkedCount} active user(s) who have no usable SSO link. `
+            + 'Review the preflight payload and resend with acknowledgeLockout: true to proceed.',
+          code: 'sso_enforcement_lockout_confirmation_required',
+          preflight
+        }, 409);
+      }
+    }
   }
 
   const [updated] = await db
@@ -1420,6 +1502,236 @@ ssoRoutes.post(
   });
 
     return c.json({ data: updated });
+  }
+);
+
+// ============================================
+// Enforce-SSO lockout preflight (#4068)
+// ============================================
+//
+// Enabling Enforce SSO blocks password login for EVERY user on the provider's
+// axis (routes/auth/ssoPolicy.ts), and unlinked users are bounced by SSO too
+// (`sso_link_required` — password-holding accounts are never auto-linked, the
+// #2183 guard). So the moment enforcement goes live, any active user without a
+// linked identity is locked out with no self-recovery. This preflight computes
+// that population BEFORE the admin commits, so the UI can demand an explicit
+// confirmation naming the users who will lose access.
+//
+// Population semantics: the pre-auth login entries (GET /sso/login/:orgId and
+// GET /sso/login/partner/:partnerId below) always route through the OLDEST
+// active provider on the axis (`orderBy(createdAt, id).limit(1)`, #2195) — a
+// user's only pre-auth SSO path is a link to THAT provider. So "locked out" =
+// no identity link to the provider the login entry will select once the
+// preflighted change is live: the oldest of (currently-active providers ∪ the
+// target provider). The target joins the candidate set whatever its current
+// status, because enforcement only bites once it's active and the admin's
+// intent is exactly that end state. Counting links to any active provider
+// would UNDER-report — a link to a newer active provider is unusable at login.
+// Membership mirrors resolveCurrentUserTokenContext (routes/auth/helpers.ts):
+// partner_users wins over organization_users, so an org-axis preflight
+// excludes users who also hold a partner membership — they resolve to the
+// partner axis and an org provider never gates them.
+const enforcementPreflightSchema = z.object({
+  // Present for the edit/activate flows; omitted for the create flow (the
+  // provider doesn't exist yet — the axis comes from ownerScope/orgId exactly
+  // like POST /providers derives it).
+  providerId: z.string().guid().optional(),
+  ownerScope: z.enum(['organization', 'partner']).default('organization'),
+  orgId: z.string().guid().optional()
+});
+
+// Response list cap. Counts stay exact; only the listed emails truncate. Self
+// sorts first so the guaranteed-total-lockout case (the admin locking THEMSELF
+// out) is always visible even when truncated.
+const ENFORCEMENT_PREFLIGHT_LIST_CAP = 200;
+
+type EnforcementPreflightResult = {
+  totalActiveUsers: number;
+  unlinkedCount: number;
+  selfLockedOut: boolean;
+  truncated: boolean;
+  // The provider the pre-auth login entry will select once the change is live
+  // (see population semantics above). null: no login-capable provider at all.
+  loginProvider: { id: string; name: string; type: 'oidc' | 'saml' } | null;
+  unlinked: Array<{ id: string; email: string; name: string; isSelf: boolean; hasPasskey: boolean }>;
+};
+
+// Exported for ssoEnforcementPreflight.integration.test.ts — the population
+// SQL (axis membership, partner-wins exclusion, effective-provider linkage)
+// only proves out against real Postgres.
+export async function computeEnforcementLockoutPreflight(
+  axis: ScopeContext,
+  targetProviderId: string | null,
+  selfUserId: string
+): Promise<EnforcementPreflightResult> {
+  // user_sso_identities is user-id-scoped and user_passkeys self-scoped under
+  // RLS — an admin's tenant context reads 0 rows from both, which would make
+  // every user look unlinked. Callers prove the caller's authority over the
+  // axis under RLS BEFORE invoking this; the population read is then a
+  // legitimate system operation (same justification as the provider-delete
+  // cleanup above).
+  const { population, loginProvider } = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const axisProviderCondition = axis.scope === 'partner'
+        ? eq(ssoProviders.partnerId, axis.partnerId)
+        : eq(ssoProviders.orgId, axis.orgId);
+      const axisProviders = await db
+        .select({ id: ssoProviders.id, name: ssoProviders.name, type: ssoProviders.type, status: ssoProviders.status })
+        .from(ssoProviders)
+        .where(axisProviderCondition)
+        .orderBy(ssoProviders.createdAt, ssoProviders.id);
+      // Same pick the login entries make: oldest by (createdAt, id) among the
+      // providers that will be usable once the change is live.
+      const picked = axisProviders
+        .find((p) => p.status === 'active' || p.id === targetProviderId) ?? null;
+
+      // The login entry 400s on a SAML pick ("Only OIDC login is currently
+      // supported") — it does NOT fall through to the next provider. A SAML
+      // effective provider therefore gives nobody a pre-auth SSO path, same as
+      // no provider at all (create flow with no active siblings). `false`
+      // keeps the query well-formed in both cases.
+      const loginCapableProviderId = picked && picked.type === 'oidc' ? picked.id : null;
+      const linkedColumn = loginCapableProviderId
+        ? exists(db
+            .select({ one: sql`1` })
+            .from(userSsoIdentities)
+            .where(and(
+              eq(userSsoIdentities.userId, users.id),
+              eq(userSsoIdentities.providerId, loginCapableProviderId)
+            )))
+        : sql<boolean>`false`;
+      // Passkey login never consults the SSO enforcement gate, so a passkey
+      // holder keeps a sign-in path — surfaced as an annotation, not an
+      // exclusion (the passkey may live on a lost device).
+      const passkeyColumn = exists(db
+        .select({ one: sql`1` })
+        .from(userPasskeys)
+        .where(and(
+          eq(userPasskeys.userId, users.id),
+          isNull(userPasskeys.disabledAt)
+        )));
+
+      const memberColumns = {
+        id: users.id,
+        email: users.email,
+        name: users.name,
+        linked: linkedColumn,
+        hasPasskey: passkeyColumn
+      };
+      const members = axis.scope === 'partner'
+        ? await db
+            .select(memberColumns)
+            .from(partnerUsers)
+            .innerJoin(users, eq(partnerUsers.userId, users.id))
+            .where(and(
+              eq(partnerUsers.partnerId, axis.partnerId),
+              eq(users.status, 'active')
+            ))
+        : await db
+            .select(memberColumns)
+            .from(organizationUsers)
+            .innerJoin(users, eq(organizationUsers.userId, users.id))
+            .where(and(
+              eq(organizationUsers.orgId, axis.orgId),
+              eq(users.status, 'active'),
+              notExists(db
+                .select({ one: sql`1` })
+                .from(partnerUsers)
+                .where(eq(partnerUsers.userId, users.id)))
+            ));
+      return { population: members, loginProvider: picked };
+    })
+  );
+
+  const unlinked = population
+    .filter((m) => !m.linked)
+    .map((m) => ({
+      id: m.id,
+      email: m.email,
+      name: m.name,
+      isSelf: m.id === selfUserId,
+      hasPasskey: Boolean(m.hasPasskey)
+    }))
+    .sort((a, b) => Number(b.isSelf) - Number(a.isSelf) || a.email.localeCompare(b.email));
+
+  return {
+    totalActiveUsers: population.length,
+    unlinkedCount: unlinked.length,
+    selfLockedOut: unlinked.some((u) => u.isSelf),
+    truncated: unlinked.length > ENFORCEMENT_PREFLIGHT_LIST_CAP,
+    loginProvider: loginProvider
+      ? { id: loginProvider.id, name: loginProvider.name, type: loginProvider.type }
+      : null,
+    unlinked: unlinked.slice(0, ENFORCEMENT_PREFLIGHT_LIST_CAP)
+  };
+}
+
+ssoRoutes.post(
+  '/providers/enforcement-preflight',
+  authMiddleware,
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.SSO_ADMIN.resource, PERMISSIONS.SSO_ADMIN.action),
+  requireMfa(),
+  zValidator('json', enforcementPreflightSchema),
+  async (c) => {
+    const auth = c.get('auth') as AuthContext;
+    const body = c.req.valid('json');
+
+    // Resolve the axis under the caller's own RLS context, with the same
+    // authority checks as the corresponding write route — the preflight
+    // discloses user emails, so it must be exactly as hard to reach as the
+    // write it fronts.
+    let axis: ScopeContext;
+    let targetProviderId: string | null = null;
+    if (body.providerId) {
+      const [existing] = await db
+        .select({ id: ssoProviders.id, orgId: ssoProviders.orgId, partnerId: ssoProviders.partnerId })
+        .from(ssoProviders)
+        .where(eq(ssoProviders.id, body.providerId))
+        .limit(1);
+      if (!existing) {
+        return c.json({ error: 'Provider not found' }, 404);
+      }
+      if (!canWriteProviderRow(auth, existing)) {
+        return c.json({ error: 'Access denied' }, 403);
+      }
+      const scopeContext = providerScopeContext(existing);
+      if (!scopeContext) {
+        return c.json({ error: 'Provider has no owning organization or partner' }, 400);
+      }
+      axis = scopeContext;
+      targetProviderId = existing.id;
+    } else if (body.ownerScope === 'partner') {
+      if (auth.scope !== 'partner' || !auth.partnerId) {
+        return c.json({ error: 'Partner scope required for a partner-axis SSO provider' }, 400);
+      }
+      if (!canManagePartnerWidePolicies(auth)) {
+        return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+      }
+      axis = { scope: 'partner', partnerId: auth.partnerId };
+    } else {
+      const orgResult = resolveOrgIdForProviderRoute(auth, body.orgId);
+      if ('error' in orgResult) {
+        return c.json({ error: orgResult.error }, orgResult.status);
+      }
+      axis = { scope: 'organization', orgId: orgResult.orgId };
+    }
+
+    const preflight = await computeEnforcementLockoutPreflight(axis, targetProviderId, auth.user.id);
+
+    writeRouteAudit(c, {
+      orgId: axis.scope === 'organization' ? axis.orgId : null,
+      action: 'sso.provider.enforcement_preflight',
+      resourceType: 'sso_provider',
+      resourceId: targetProviderId ?? undefined,
+      details: {
+        partnerId: axis.scope === 'partner' ? axis.partnerId : null,
+        totalActiveUsers: preflight.totalActiveUsers,
+        unlinkedCount: preflight.unlinkedCount
+      }
+    });
+
+    return c.json({ data: preflight });
   }
 );
 

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -1168,11 +1168,21 @@ ssoRoutes.patch(
   // SSO link, require the caller to explicitly confirm through with
   // acknowledgeLockout: true. The 409 carries the preflight payload so raw API
   // callers see exactly who is affected — the same data the web UI shows.
+  // The confirmed-through lockout must be as auditable as the rejected one, so
+  // the preflight runs on the acknowledged path too and its outcome is stamped
+  // into the success audit below — an acknowledged first-request lockout must
+  // not be indistinguishable from an ordinary enforceSSO flip.
+  let lockoutAudit: { acknowledgedLockout: true; lockedOutCount: number; selfLockedOut: boolean } | null = null;
   if (body.enforceSSO === true && !existing.enforceSSO && existing.status === 'active') {
     const lockoutScope = providerScopeContext(existing);
-    if (lockoutScope && !acknowledgeLockout) {
-      const preflight = await computeEnforcementLockoutPreflight(lockoutScope, existing.id, auth.user.id);
-      if (preflight.unlinkedCount > 0) {
+    if (!lockoutScope) {
+      // Impossible under sso_providers_one_owner_chk — but a malformed row must
+      // fail the safety check loudly (like the preflight route), never waive it.
+      return c.json({ error: 'Provider has no owning organization or partner' }, 400);
+    }
+    const preflight = await computeEnforcementLockoutPreflight(lockoutScope, existing.id, auth.user.id);
+    if (preflight.unlinkedCount > 0) {
+      if (!acknowledgeLockout) {
         writeRouteAudit(c, {
           orgId: existing.orgId,
           action: 'sso.provider.update.rejected',
@@ -1191,6 +1201,11 @@ ssoRoutes.patch(
           preflight
         }, 409);
       }
+      lockoutAudit = {
+        acknowledgedLockout: true,
+        lockedOutCount: preflight.unlinkedCount,
+        selfLockedOut: preflight.selfLockedOut
+      };
     }
   }
 
@@ -1323,7 +1338,7 @@ ssoRoutes.patch(
     resourceType: 'sso_provider',
     resourceId: updated.id,
     resourceName: updated.name,
-    details: { changedFields: Object.keys(body), partnerId: updated.partnerId }
+    details: { changedFields: Object.keys(body), partnerId: updated.partnerId, ...(lockoutAudit ?? {}) }
   });
 
     const { clientSecret, ...safeProvider } = updated;
@@ -1448,12 +1463,20 @@ ssoRoutes.post(
   // #4068: activating a provider that already has enforceSSO set is the second
   // transition that makes enforcement live (the first is PATCHing enforceSSO
   // onto an active provider). Same confirm-through contract: a lockout-causing
-  // activation without acknowledgeLockout gets a 409 carrying the preflight.
-  if (status === 'active' && existing.status !== 'active' && existing.enforceSSO && !acknowledgeLockout) {
+  // activation without acknowledgeLockout gets a 409 carrying the preflight,
+  // and an ACKNOWLEDGED lockout is stamped into the success audit so it is
+  // never indistinguishable from an ordinary activation.
+  let lockoutAudit: { acknowledgedLockout: true; lockedOutCount: number; selfLockedOut: boolean } | null = null;
+  if (status === 'active' && existing.status !== 'active' && existing.enforceSSO) {
     const lockoutScope = providerScopeContext(existing);
-    if (lockoutScope) {
-      const preflight = await computeEnforcementLockoutPreflight(lockoutScope, existing.id, auth.user.id);
-      if (preflight.unlinkedCount > 0) {
+    if (!lockoutScope) {
+      // Impossible under sso_providers_one_owner_chk — but a malformed row must
+      // fail the safety check loudly, never waive it.
+      return c.json({ error: 'Provider has no owning organization or partner' }, 400);
+    }
+    const preflight = await computeEnforcementLockoutPreflight(lockoutScope, existing.id, auth.user.id);
+    if (preflight.unlinkedCount > 0) {
+      if (!acknowledgeLockout) {
         writeRouteAudit(c, {
           orgId: existing.orgId,
           action: 'sso.provider.status.update.rejected',
@@ -1472,6 +1495,11 @@ ssoRoutes.post(
           preflight
         }, 409);
       }
+      lockoutAudit = {
+        acknowledgedLockout: true,
+        lockedOutCount: preflight.unlinkedCount,
+        selfLockedOut: preflight.selfLockedOut
+      };
     }
   }
 
@@ -1498,7 +1526,7 @@ ssoRoutes.post(
     resourceType: 'sso_provider',
     resourceId: updated.id,
     resourceName: updated.name,
-    details: { status, partnerId: updated.partnerId }
+    details: { status, partnerId: updated.partnerId, ...(lockoutAudit ?? {}) }
   });
 
     return c.json({ data: updated });
@@ -1643,7 +1671,11 @@ export async function computeEnforcementLockoutPreflight(
     })
   );
 
-  const unlinked = population
+  // Neither membership table carries a unique (tenant, user) constraint, so a
+  // duplicated membership row must not double-count a user.
+  const uniquePopulation = Array.from(new Map(population.map((m) => [m.id, m])).values());
+
+  const unlinked = uniquePopulation
     .filter((m) => !m.linked)
     .map((m) => ({
       id: m.id,
@@ -1655,7 +1687,7 @@ export async function computeEnforcementLockoutPreflight(
     .sort((a, b) => Number(b.isSelf) - Number(a.isSelf) || a.email.localeCompare(b.email));
 
   return {
-    totalActiveUsers: population.length,
+    totalActiveUsers: uniquePopulation.length,
     unlinkedCount: unlinked.length,
     selfLockedOut: unlinked.some((u) => u.isSelf),
     truncated: unlinked.length > ENFORCEMENT_PREFLIGHT_LIST_CAP,
@@ -1713,6 +1745,18 @@ ssoRoutes.post(
       const orgResult = resolveOrgIdForProviderRoute(auth, body.orgId);
       if ('error' in orgResult) {
         return c.json({ error: orgResult.error }, orgResult.status);
+      }
+      // Every other branch proves authority against an RLS-visible row before
+      // the system-context PII read below. This branch's checks are app-layer
+      // only (canAccessOrg), so add the DB-enforced equivalent: the org must
+      // be visible under the caller's own RLS context.
+      const [visibleOrg] = await db
+        .select({ id: organizations.id })
+        .from(organizations)
+        .where(eq(organizations.id, orgResult.orgId))
+        .limit(1);
+      if (!visibleOrg) {
+        return c.json({ error: 'Access to this organization denied' }, 403);
       }
       axis = { scope: 'organization', orgId: orgResult.orgId };
     }

--- a/apps/web/src/components/settings/SsoProviderForm.tsx
+++ b/apps/web/src/components/settings/SsoProviderForm.tsx
@@ -466,6 +466,7 @@ export default function SsoProviderForm({
           <label className="flex items-start gap-3">
             <input
               type="checkbox"
+              data-testid="provider-enforce-sso"
               className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
               {...register('enforceSSO')}
             />

--- a/apps/web/src/components/settings/SsoProvidersPage.test.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.test.tsx
@@ -258,6 +258,180 @@ describe('SsoProvidersPage partner-axis behavior', () => {
     expect((toggle as HTMLInputElement).checked).toBe(true);
   });
 
+  // #4068: enabling Enforce SSO preflights the lockout population and demands
+  // an explicit acknowledged confirmation naming the users who lose access.
+  describe('enforce-SSO lockout confirm-through', () => {
+    const PREFLIGHT_URL = '/sso/providers/enforcement-preflight';
+
+    const preflightPayload = (unlinked: Array<{ id: string; email: string; name: string; isSelf?: boolean; hasPasskey?: boolean }>) => ({
+      data: {
+        totalActiveUsers: 5,
+        unlinkedCount: unlinked.length,
+        selfLockedOut: unlinked.some(u => u.isSelf),
+        truncated: false,
+        loginProvider: { id: 'pp-1', name: 'Team Login', type: 'oidc' },
+        unlinked: unlinked.map(u => ({ isSelf: false, hasPasskey: false, ...u }))
+      }
+    });
+
+    function routeWithPreflight(opts: {
+      provider?: Partial<Provider> & { enforceSSO: boolean };
+      preflight: ReturnType<typeof preflightPayload>;
+    }) {
+      const provider = { ...PARTNER_PROVIDER, ...opts.provider };
+      fetchWithAuth.mockImplementation((url: string, reqOpts?: { method?: string }) => {
+        if (url === '/sso/providers') return Promise.resolve(jsonRes({ data: [provider] }));
+        if (url === '/sso/providers?scope=partner') return Promise.resolve(jsonRes({ data: [] }));
+        if (url === '/sso/presets') return Promise.resolve(jsonRes({ data: [] }));
+        if (url === '/roles') return Promise.resolve(jsonRes({ data: [] }));
+        if (url === PREFLIGHT_URL) return Promise.resolve(jsonRes(opts.preflight));
+        if (url === '/sso/providers/pp-1' && (!reqOpts || !reqOpts.method)) {
+          return Promise.resolve(
+            jsonRes({
+              data: {
+                name: 'Team Login',
+                type: 'oidc',
+                preset: '',
+                issuer: 'https://idp.example.com',
+                clientId: 'client-1',
+                scopes: 'openid profile email',
+                attributeMapping: { email: 'email', name: 'name' },
+                autoProvision: true,
+                defaultRoleId: '',
+                allowedDomains: '',
+                enforceSSO: provider.enforceSSO,
+                hasClientSecret: true,
+              },
+            })
+          );
+        }
+        if (url === '/sso/providers/pp-1' && reqOpts?.method === 'PATCH') {
+          return Promise.resolve(jsonRes({ data: provider }));
+        }
+        if (url === '/sso/providers/pp-1/status' && reqOpts?.method === 'POST') {
+          return Promise.resolve(jsonRes({ data: provider }));
+        }
+        return Promise.resolve(jsonRes({ data: [] }));
+      });
+    }
+
+    const enforceToggle = () => {
+      // The enforce checkbox is the first checkbox in the Security section —
+      // find it via its label text association.
+      const label = screen.getByText('Enforce SSO-only login');
+      return label.closest('label')!.querySelector('input') as HTMLInputElement;
+    };
+
+    it('shows the lockout confirm with the unlinked users, gates on the checkbox, then PATCHes with acknowledgeLockout', async () => {
+      routeWithPreflight({
+        provider: { enforceSSO: false },
+        preflight: preflightPayload([
+          { id: 'u-1', email: 'a@example.com', name: 'A', isSelf: true },
+          { id: 'u-2', email: 'b@example.com', name: 'B', hasPasskey: true }
+        ])
+      });
+      render(<SsoProvidersPage />);
+
+      await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+      const toggle = await waitFor(() => enforceToggle());
+      fireEvent.click(toggle);
+      fireEvent.click(screen.getByTestId('provider-save'));
+
+      // The confirm overlay names both users; no PATCH yet.
+      const modal = await screen.findByTestId('enforce-lockout-modal');
+      expect(modal.textContent).toContain('a@example.com');
+      expect(modal.textContent).toContain('b@example.com');
+      const patchBefore = fetchWithAuth.mock.calls.find(
+        (c) => c[0] === '/sso/providers/pp-1' && (c[1] as { method?: string })?.method === 'PATCH'
+      );
+      expect(patchBefore).toBeUndefined();
+
+      // Confirm is disabled until acknowledged.
+      const confirm = screen.getByTestId('enforce-lockout-confirm') as HTMLButtonElement;
+      expect(confirm.disabled).toBe(true);
+      fireEvent.click(screen.getByTestId('enforce-lockout-ack'));
+      expect(confirm.disabled).toBe(false);
+      fireEvent.click(confirm);
+
+      await waitFor(() => {
+        const patchCall = fetchWithAuth.mock.calls.find(
+          (c) => c[0] === '/sso/providers/pp-1' && (c[1] as { method?: string })?.method === 'PATCH'
+        );
+        expect(patchCall).toBeTruthy();
+        const body = JSON.parse((patchCall![1] as { body: string }).body);
+        expect(body.enforceSSO).toBe(true);
+        expect(body.acknowledgeLockout).toBe(true);
+      });
+    });
+
+    it('saves straight through (no modal, no acknowledgeLockout) when nobody would be locked out', async () => {
+      routeWithPreflight({ provider: { enforceSSO: false }, preflight: preflightPayload([]) });
+      render(<SsoProvidersPage />);
+
+      await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+      const toggle = await waitFor(() => enforceToggle());
+      fireEvent.click(toggle);
+      fireEvent.click(screen.getByTestId('provider-save'));
+
+      await waitFor(() => {
+        const patchCall = fetchWithAuth.mock.calls.find(
+          (c) => c[0] === '/sso/providers/pp-1' && (c[1] as { method?: string })?.method === 'PATCH'
+        );
+        expect(patchCall).toBeTruthy();
+        const body = JSON.parse((patchCall![1] as { body: string }).body);
+        expect(body).not.toHaveProperty('acknowledgeLockout');
+      });
+      expect(screen.queryByTestId('enforce-lockout-modal')).toBeNull();
+    });
+
+    it('does not preflight an edit that keeps enforcement already on', async () => {
+      routeWithPreflight({
+        provider: { enforceSSO: true },
+        preflight: preflightPayload([{ id: 'u-1', email: 'a@example.com', name: 'A' }])
+      });
+      render(<SsoProvidersPage />);
+
+      await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+      await screen.findByRole('button', { name: /save changes/i });
+      fireEvent.click(screen.getByTestId('provider-save'));
+
+      await waitFor(() => {
+        const patchCall = fetchWithAuth.mock.calls.find(
+          (c) => c[0] === '/sso/providers/pp-1' && (c[1] as { method?: string })?.method === 'PATCH'
+        );
+        expect(patchCall).toBeTruthy();
+      });
+      expect(fetchWithAuth.mock.calls.find((c) => c[0] === PREFLIGHT_URL)).toBeUndefined();
+    });
+
+    it('activating an enforcing provider preflights and sends acknowledgeLockout on confirm', async () => {
+      routeWithPreflight({
+        provider: { enforceSSO: true, status: 'inactive' },
+        preflight: preflightPayload([{ id: 'u-1', email: 'a@example.com', name: 'A' }])
+      });
+      render(<SsoProvidersPage />);
+
+      await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+      fireEvent.click(screen.getByRole('button', { name: 'Activate' }));
+
+      await screen.findByTestId('enforce-lockout-modal');
+      fireEvent.click(screen.getByTestId('enforce-lockout-ack'));
+      fireEvent.click(screen.getByTestId('enforce-lockout-confirm'));
+
+      await waitFor(() => {
+        const statusCall = fetchWithAuth.mock.calls.find(
+          (c) => c[0] === '/sso/providers/pp-1/status' && (c[1] as { method?: string })?.method === 'POST'
+        );
+        expect(statusCall).toBeTruthy();
+        const body = JSON.parse((statusCall![1] as { body: string }).body);
+        expect(body).toMatchObject({ status: 'active', acknowledgeLockout: true });
+      });
+    });
+  });
+
   it('PATCHes trustsIdpMfa=false when an already-trusting provider is turned OFF', async () => {
     routeEditableProvider(true);
     render(<SsoProvidersPage />);

--- a/apps/web/src/components/settings/SsoProvidersPage.test.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.test.tsx
@@ -300,6 +300,7 @@ describe('SsoProvidersPage partner-axis behavior', () => {
                 defaultRoleId: '',
                 allowedDomains: '',
                 enforceSSO: provider.enforceSSO,
+                status: provider.status,
                 hasClientSecret: true,
               },
             })
@@ -536,6 +537,31 @@ describe('SsoProvidersPage partner-axis behavior', () => {
           (c) => c[0] === '/sso/providers' && (c[1] as { method?: string })?.method === 'POST'
         );
         expect(createCall).toBeTruthy();
+      });
+      expect(fetchWithAuth.mock.calls.find((c) => c[0] === PREFLIGHT_URL)).toBeUndefined();
+      expect(screen.queryByTestId('enforce-lockout-modal')).toBeNull();
+    });
+
+    it('does not preflight or warn when enabling enforcement on an INACTIVE provider (activation is the guarded moment)', async () => {
+      routeWithPreflight({
+        provider: { enforceSSO: false, status: 'inactive' },
+        preflight: preflightPayload([{ id: 'u-1', email: 'a@example.com', name: 'A' }])
+      });
+      render(<SsoProvidersPage />);
+
+      await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+      const toggle = await waitFor(() => enforceToggle());
+      fireEvent.click(toggle);
+      fireEvent.click(screen.getByTestId('provider-save'));
+
+      await waitFor(() => {
+        const patchCall = fetchWithAuth.mock.calls.find(
+          (c) => c[0] === '/sso/providers/pp-1' && (c[1] as { method?: string })?.method === 'PATCH'
+        );
+        expect(patchCall).toBeTruthy();
+        const body = JSON.parse((patchCall![1] as { body: string }).body);
+        expect(body).not.toHaveProperty('acknowledgeLockout');
       });
       expect(fetchWithAuth.mock.calls.find((c) => c[0] === PREFLIGHT_URL)).toBeUndefined();
       expect(screen.queryByTestId('enforce-lockout-modal')).toBeNull();

--- a/apps/web/src/components/settings/SsoProvidersPage.test.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.test.tsx
@@ -315,12 +315,7 @@ describe('SsoProvidersPage partner-axis behavior', () => {
       });
     }
 
-    const enforceToggle = () => {
-      // The enforce checkbox is the first checkbox in the Security section —
-      // find it via its label text association.
-      const label = screen.getByText('Enforce SSO-only login');
-      return label.closest('label')!.querySelector('input') as HTMLInputElement;
-    };
+    const enforceToggle = () => screen.getByTestId('provider-enforce-sso') as HTMLInputElement;
 
     it('shows the lockout confirm with the unlinked users, gates on the checkbox, then PATCHes with acknowledgeLockout', async () => {
       routeWithPreflight({
@@ -383,6 +378,166 @@ describe('SsoProvidersPage partner-axis behavior', () => {
         const body = JSON.parse((patchCall![1] as { body: string }).body);
         expect(body).not.toHaveProperty('acknowledgeLockout');
       });
+      expect(screen.queryByTestId('enforce-lockout-modal')).toBeNull();
+    });
+
+    it('cancel closes the overlay, fires no mutation, and keeps the edit form (with its state) open', async () => {
+      routeWithPreflight({
+        provider: { enforceSSO: false },
+        preflight: preflightPayload([{ id: 'u-1', email: 'a@example.com', name: 'A' }])
+      });
+      render(<SsoProvidersPage />);
+
+      await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+      const toggle = await waitFor(() => enforceToggle());
+      fireEvent.click(toggle);
+      fireEvent.click(screen.getByTestId('provider-save'));
+
+      await screen.findByTestId('enforce-lockout-modal');
+      fireEvent.click(screen.getByTestId('enforce-lockout-cancel'));
+
+      // Overlay gone; NO PATCH fired; the edit form is still mounted and the
+      // toggle still reflects the admin's in-progress change.
+      expect(screen.queryByTestId('enforce-lockout-modal')).toBeNull();
+      expect(fetchWithAuth.mock.calls.find(
+        (c) => c[0] === '/sso/providers/pp-1' && (c[1] as { method?: string })?.method === 'PATCH'
+      )).toBeUndefined();
+      expect(enforceToggle().checked).toBe(true);
+    });
+
+    it('opens the confirm from the SERVER 409 payload when the preflight read fails (backstop path)', async () => {
+      const provider = { ...PARTNER_PROVIDER, enforceSSO: false };
+      const serverPreflight = preflightPayload([{ id: 'u-9', email: 'server@example.com', name: 'S' }]);
+      let patchCount = 0;
+      fetchWithAuth.mockImplementation((url: string, reqOpts?: { method?: string }) => {
+        if (url === '/sso/providers') return Promise.resolve(jsonRes({ data: [provider] }));
+        if (url === '/sso/providers?scope=partner') return Promise.resolve(jsonRes({ data: [] }));
+        if (url === '/sso/presets') return Promise.resolve(jsonRes({ data: [] }));
+        if (url === '/roles') return Promise.resolve(jsonRes({ data: [] }));
+        // Preflight endpoint is down.
+        if (url === '/sso/providers/enforcement-preflight') return Promise.resolve(jsonRes({ error: 'boom' }, false, 500));
+        if (url === '/sso/providers/pp-1' && (!reqOpts || !reqOpts.method)) {
+          return Promise.resolve(jsonRes({
+            data: {
+              name: 'Team Login', type: 'oidc', preset: '', issuer: 'https://idp.example.com',
+              clientId: 'client-1', scopes: 'openid profile email',
+              attributeMapping: { email: 'email', name: 'name' },
+              autoProvision: true, defaultRoleId: '', allowedDomains: '',
+              enforceSSO: false, hasClientSecret: true
+            }
+          }));
+        }
+        if (url === '/sso/providers/pp-1' && reqOpts?.method === 'PATCH') {
+          patchCount += 1;
+          if (patchCount === 1) {
+            // Server backstop refuses the unacknowledged lockout.
+            return Promise.resolve(jsonRes({
+              error: 'would lock out 1 user(s)',
+              code: 'sso_enforcement_lockout_confirmation_required',
+              preflight: serverPreflight.data
+            }, false, 409));
+          }
+          return Promise.resolve(jsonRes({ data: provider }));
+        }
+        return Promise.resolve(jsonRes({ data: [] }));
+      });
+
+      render(<SsoProvidersPage />);
+      await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+      const toggle = await waitFor(() => enforceToggle());
+      fireEvent.click(toggle);
+      fireEvent.click(screen.getByTestId('provider-save'));
+
+      // The 409's own payload feeds the confirm dialog.
+      const modal = await screen.findByTestId('enforce-lockout-modal');
+      expect(modal.textContent).toContain('server@example.com');
+
+      fireEvent.click(screen.getByTestId('enforce-lockout-ack'));
+      fireEvent.click(screen.getByTestId('enforce-lockout-confirm'));
+
+      await waitFor(() => {
+        expect(patchCount).toBe(2);
+        const secondPatch = fetchWithAuth.mock.calls.filter(
+          (c) => c[0] === '/sso/providers/pp-1' && (c[1] as { method?: string })?.method === 'PATCH'
+        )[1];
+        const body = JSON.parse((secondPatch![1] as { body: string }).body);
+        expect(body.acknowledgeLockout).toBe(true);
+      });
+    });
+
+    it('opens the confirm from the status route 409 when activating with the preflight down', async () => {
+      const provider = { ...PARTNER_PROVIDER, enforceSSO: true, status: 'inactive' as const };
+      const serverPreflight = preflightPayload([{ id: 'u-9', email: 'server@example.com', name: 'S' }]);
+      let statusCount = 0;
+      fetchWithAuth.mockImplementation((url: string, reqOpts?: { method?: string }) => {
+        if (url === '/sso/providers') return Promise.resolve(jsonRes({ data: [provider] }));
+        if (url === '/sso/providers?scope=partner') return Promise.resolve(jsonRes({ data: [] }));
+        if (url === '/sso/presets') return Promise.resolve(jsonRes({ data: [] }));
+        if (url === '/roles') return Promise.resolve(jsonRes({ data: [] }));
+        if (url === '/sso/providers/enforcement-preflight') return Promise.resolve(jsonRes({ error: 'boom' }, false, 500));
+        if (url === '/sso/providers/pp-1/status' && reqOpts?.method === 'POST') {
+          statusCount += 1;
+          if (statusCount === 1) {
+            return Promise.resolve(jsonRes({
+              error: 'would lock out 1 user(s)',
+              code: 'sso_enforcement_lockout_confirmation_required',
+              preflight: serverPreflight.data
+            }, false, 409));
+          }
+          return Promise.resolve(jsonRes({ data: provider }));
+        }
+        return Promise.resolve(jsonRes({ data: [] }));
+      });
+
+      render(<SsoProvidersPage />);
+      await waitFor(() => expect(screen.getByText('Team Login')).toBeTruthy());
+      fireEvent.click(screen.getByRole('button', { name: 'Activate' }));
+
+      const modal = await screen.findByTestId('enforce-lockout-modal');
+      expect(modal.textContent).toContain('server@example.com');
+
+      fireEvent.click(screen.getByTestId('enforce-lockout-ack'));
+      fireEvent.click(screen.getByTestId('enforce-lockout-confirm'));
+
+      await waitFor(() => {
+        expect(statusCount).toBe(2);
+        const second = fetchWithAuth.mock.calls.filter(
+          (c) => c[0] === '/sso/providers/pp-1/status' && (c[1] as { method?: string })?.method === 'POST'
+        )[1];
+        const body = JSON.parse((second![1] as { body: string }).body);
+        expect(body).toMatchObject({ status: 'active', acknowledgeLockout: true });
+      });
+    });
+
+    it('does not preflight or warn on CREATE (providers are born inactive — activation is the guarded moment)', async () => {
+      routes({ org: jsonRes({ data: [] }), partner: jsonRes({ data: [] }) });
+      fetchWithAuth.mockImplementation((url: string, reqOpts?: { method?: string }) => {
+        if (url === '/sso/providers' && reqOpts?.method === 'POST') return Promise.resolve(jsonRes({ data: { id: 'new-1' } }));
+        if (url === '/sso/providers') return Promise.resolve(jsonRes({ data: [] }));
+        if (url === '/sso/providers?scope=partner') return Promise.resolve(jsonRes({ data: [] }));
+        if (url === '/sso/presets') return Promise.resolve(jsonRes({ data: [] }));
+        if (url === '/roles') return Promise.resolve(jsonRes({ data: [] }));
+        return Promise.resolve(jsonRes({ data: [] }));
+      });
+      render(<SsoProvidersPage />);
+
+      await waitFor(() => expect(screen.getByText('Add provider')).toBeTruthy());
+      fireEvent.click(screen.getByText('Add provider'));
+
+      const nameInput = await screen.findByLabelText(/provider name/i);
+      fireEvent.change(nameInput, { target: { value: 'New IdP' } });
+      fireEvent.click(enforceToggle());
+      fireEvent.click(screen.getByTestId('provider-save'));
+
+      await waitFor(() => {
+        const createCall = fetchWithAuth.mock.calls.find(
+          (c) => c[0] === '/sso/providers' && (c[1] as { method?: string })?.method === 'POST'
+        );
+        expect(createCall).toBeTruthy();
+      });
+      expect(fetchWithAuth.mock.calls.find((c) => c[0] === PREFLIGHT_URL)).toBeUndefined();
       expect(screen.queryByTestId('enforce-lockout-modal')).toBeNull();
     });
 

--- a/apps/web/src/components/settings/SsoProvidersPage.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.tsx
@@ -11,6 +11,21 @@ import { runAction, handleActionError } from '../../lib/runAction';
 
 type ModalMode = 'closed' | 'add' | 'edit' | 'delete' | 'test';
 
+// #4068: lockout preflight for enabling Enforce SSO. Mirrors the API's
+// POST /sso/providers/enforcement-preflight response.
+type EnforcementPreflight = {
+  totalActiveUsers: number;
+  unlinkedCount: number;
+  selfLockedOut: boolean;
+  truncated: boolean;
+  loginProvider: { id: string; name: string; type: 'oidc' | 'saml' } | null;
+  unlinked: Array<{ id: string; email: string; name: string; isSelf: boolean; hasPasskey: boolean }>;
+};
+
+type PendingEnforceAction =
+  | { kind: 'save'; values: SsoProviderFormValues }
+  | { kind: 'activate'; provider: SsoProvider };
+
 type TestResult = {
   success: boolean;
   message?: string;
@@ -36,6 +51,12 @@ export default function SsoProvidersPage() {
   const [submitting, setSubmitting] = useState(false);
   const [testingConnection, setTestingConnection] = useState(false);
   const [testResult, setTestResult] = useState<TestResult | null>(null);
+  // #4068: the lockout confirm renders as an OVERLAY on top of whatever is
+  // open (the add/edit form keeps its state underneath; the activate toggle
+  // has no modal at all), so it's independent of modalMode.
+  const [enforcePreflight, setEnforcePreflight] = useState<EnforcementPreflight | null>(null);
+  const [pendingEnforceAction, setPendingEnforceAction] = useState<PendingEnforceAction | null>(null);
+  const [lockoutAcknowledged, setLockoutAcknowledged] = useState(false);
 
   // Partner-scope viewers additionally own partner-wide (technician-login)
   // providers. Gate on the JWT scope, never partners.length (known-broken).
@@ -189,11 +210,46 @@ export default function SsoProvidersPage() {
     }
   };
 
-  const handleToggleStatus = async (provider: SsoProvider, newStatus: 'active' | 'inactive') => {
+  // #4068: who loses sign-in if enforcement goes live for this change. A
+  // failed preflight read returns null and the caller falls through to the
+  // save — the API's own confirm-through guard (409) is the backstop, so a
+  // broken preflight can never silently skip the protection OR wedge saving.
+  const fetchEnforcementPreflight = useCallback(async (body: Record<string, unknown>): Promise<EnforcementPreflight | null> => {
+    try {
+      const response = await fetchWithAuth('/sso/providers/enforcement-preflight', {
+        method: 'POST',
+        body: JSON.stringify(body)
+      });
+      if (response.status === 401) {
+        void navigateTo('/login', { replace: true });
+        return null;
+      }
+      if (response.ok) {
+        return (await response.json()).data ?? null;
+      }
+    } catch {
+      // fall through — server guard still applies
+    }
+    return null;
+  }, []);
+
+  const openLockoutConfirm = (preflight: EnforcementPreflight, action: PendingEnforceAction) => {
+    setEnforcePreflight(preflight);
+    setPendingEnforceAction(action);
+    setLockoutAcknowledged(false);
+  };
+
+  const closeLockoutConfirm = () => {
+    setEnforcePreflight(null);
+    setPendingEnforceAction(null);
+    setLockoutAcknowledged(false);
+  };
+
+  const performToggleStatus = async (provider: SsoProvider, newStatus: 'active' | 'inactive', acknowledgeLockout: boolean) => {
     try {
       const response = await fetchWithAuth(`/sso/providers/${provider.id}/status`, {
         method: 'POST',
-        body: JSON.stringify({ status: newStatus })
+        body: JSON.stringify({ status: newStatus, ...(acknowledgeLockout ? { acknowledgeLockout: true } : {}) })
       });
 
       if (!response.ok) {
@@ -204,6 +260,18 @@ export default function SsoProvidersPage() {
     } catch (err) {
       setError(err instanceof Error ? err.message : t('ssoProvidersPage.anErrorOccurred'));
     }
+  };
+
+  const handleToggleStatus = async (provider: SsoProvider, newStatus: 'active' | 'inactive') => {
+    // Activating an enforcing provider is a lockout moment — preflight it.
+    if (newStatus === 'active' && provider.enforceSSO) {
+      const preflight = await fetchEnforcementPreflight({ providerId: provider.id });
+      if (preflight && preflight.unlinkedCount > 0) {
+        openLockoutConfirm(preflight, { kind: 'activate', provider });
+        return;
+      }
+    }
+    await performToggleStatus(provider, newStatus, false);
   };
 
   const handleDelete = (provider: SsoProvider) => {
@@ -241,6 +309,26 @@ export default function SsoProvidersPage() {
   };
 
   const handleSubmit = async (values: SsoProviderFormValues) => {
+    // #4068: enabling Enforce SSO (newly — an edit that keeps it on isn't a
+    // transition) can lock out every unlinked user on the axis. Preflight and
+    // demand explicit confirmation naming them before the save goes out.
+    const newlyEnforcing = values.enforceSSO
+      && !(modalMode === 'edit' && selectedProviderDetails?.enforceSSO);
+    if (newlyEnforcing) {
+      const preflight = await fetchEnforcementPreflight(
+        modalMode === 'edit' && selectedProvider
+          ? { providerId: selectedProvider.id }
+          : { ownerScope: values.ownerScope ?? 'organization' }
+      );
+      if (preflight && preflight.unlinkedCount > 0) {
+        openLockoutConfirm(preflight, { kind: 'save', values });
+        return;
+      }
+    }
+    await submitProvider(values, false);
+  };
+
+  const submitProvider = async (values: SsoProviderFormValues, acknowledgeLockout: boolean) => {
     setSubmitting(true);
     try {
       const url = modalMode === 'edit' && selectedProvider
@@ -249,11 +337,15 @@ export default function SsoProvidersPage() {
       const method = modalMode === 'edit' ? 'PATCH' : 'POST';
 
       // Don't send empty client secret on edit
-      const payload = { ...values };
+      const payload: Record<string, unknown> = { ...values };
       if (modalMode === 'edit') {
         if (!payload.clientSecret) delete payload.clientSecret;
         // ownerScope is create-only (the update schema omits it); never PATCH it.
         delete payload.ownerScope;
+        // #4068: confirm-through for the API's lockout guard. Only PATCH (and
+        // the status route) accept it — a create can't lock anyone out because
+        // providers are born inactive.
+        if (acknowledgeLockout) payload.acknowledgeLockout = true;
       }
 
       // A blank optional field (e.g. defaultRoleId reset to "Select a role",
@@ -274,6 +366,17 @@ export default function SsoProvidersPage() {
       handleActionError(err, t('ssoProvidersPage.anErrorOccurred'));
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const handleConfirmEnforceLockout = async () => {
+    if (!pendingEnforceAction || !lockoutAcknowledged) return;
+    const action = pendingEnforceAction;
+    closeLockoutConfirm();
+    if (action.kind === 'save') {
+      await submitProvider(action.values, true);
+    } else {
+      await performToggleStatus(action.provider, 'active', true);
     }
   };
 
@@ -529,6 +632,79 @@ export default function SsoProvidersPage() {
                 className="h-10 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
               >
                 {t('ssoProvidersPage.close')}</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* #4068: Enforce-SSO lockout confirmation. Rendered ABOVE any open
+          modal (z-60 > z-50) so the add/edit form keeps its state when the
+          admin cancels. */}
+      {enforcePreflight && pendingEnforceAction && (
+        <div className="fixed inset-0 z-60 flex items-center justify-center bg-background/80 px-4 py-8">
+          <div className="w-full max-w-lg rounded-lg border bg-card p-6 shadow-xs" data-testid="enforce-lockout-modal">
+            <h2 className="text-lg font-semibold text-destructive">
+              {t('ssoProvidersPage.enforceLockoutTitle')}</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {t('ssoProvidersPage.enforceLockoutSummary', {
+                unlinked: enforcePreflight.unlinkedCount,
+                total: enforcePreflight.totalActiveUsers
+              })}
+            </p>
+
+            <ul className="mt-4 max-h-56 space-y-1 overflow-y-auto rounded-md border bg-muted/40 p-3 text-sm">
+              {enforcePreflight.unlinked.map(user => (
+                <li key={user.id} data-testid="enforce-lockout-user" className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium">{user.email}</span>
+                  {user.isSelf && (
+                    <span className="rounded bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive">
+                      {t('ssoProvidersPage.enforceLockoutSelfBadge')}</span>
+                  )}
+                  {user.hasPasskey && (
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                      {t('ssoProvidersPage.enforceLockoutHasPasskey')}</span>
+                  )}
+                </li>
+              ))}
+              {enforcePreflight.truncated && (
+                <li className="text-xs text-muted-foreground">{t('ssoProvidersPage.enforceLockoutTruncated')}</li>
+              )}
+            </ul>
+
+            {enforcePreflight.selfLockedOut && (
+              <div className="mt-4 rounded-md border border-destructive/40 bg-destructive/10 p-3">
+                <p className="text-sm font-medium text-destructive">
+                  {t('ssoProvidersPage.enforceLockoutSelfWarning')}</p>
+              </div>
+            )}
+
+            <label className="mt-4 flex items-start gap-3">
+              <input
+                type="checkbox"
+                data-testid="enforce-lockout-ack"
+                checked={lockoutAcknowledged}
+                onChange={e => setLockoutAcknowledged(e.target.checked)}
+                className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
+              />
+              <span className="text-sm">{t('ssoProvidersPage.enforceLockoutAcknowledge')}</span>
+            </label>
+
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                data-testid="enforce-lockout-cancel"
+                onClick={closeLockoutConfirm}
+                className="h-10 rounded-md border px-4 text-sm font-medium text-muted-foreground transition hover:text-foreground"
+              >
+                {t('ssoProvidersPage.cancel')}</button>
+              <button
+                type="button"
+                data-testid="enforce-lockout-confirm"
+                onClick={handleConfirmEnforceLockout}
+                disabled={!lockoutAcknowledged || submitting}
+                className="inline-flex h-10 items-center justify-center rounded-md bg-destructive px-4 text-sm font-medium text-destructive-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {t('ssoProvidersPage.enforceLockoutConfirm')}</button>
             </div>
           </div>
         </div>

--- a/apps/web/src/components/settings/SsoProvidersPage.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.tsx
@@ -7,7 +7,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { getJwtClaims } from '../../lib/authScope';
 import { getOrgScope, useOrgScope } from '@/hooks/useOrgScope';
 import { navigateTo } from '@/lib/navigation';
-import { runAction, handleActionError } from '../../lib/runAction';
+import { runAction, handleActionError, ActionError } from '../../lib/runAction';
 
 type ModalMode = 'closed' | 'add' | 'edit' | 'delete' | 'test';
 
@@ -210,11 +210,15 @@ export default function SsoProvidersPage() {
     }
   };
 
-  // #4068: who loses sign-in if enforcement goes live for this change. A
-  // failed preflight read returns null and the caller falls through to the
-  // save — the API's own confirm-through guard (409) is the backstop, so a
-  // broken preflight can never silently skip the protection OR wedge saving.
-  const fetchEnforcementPreflight = useCallback(async (body: Record<string, unknown>): Promise<EnforcementPreflight | null> => {
+  // #4068: who loses sign-in if enforcement goes live for this change.
+  // Three-valued: 'aborted' (session dead — the caller must NOT fire the
+  // mutation, the redirect is the feedback), 'unavailable' (preflight read
+  // failed — the caller falls through to the save, because the API's own
+  // confirm-through 409 is the backstop and both mutation paths route that
+  // 409 back into this same confirm dialog), or the population itself.
+  const fetchEnforcementPreflight = useCallback(async (
+    body: Record<string, unknown>
+  ): Promise<EnforcementPreflight | 'unavailable' | 'aborted'> => {
     try {
       const response = await fetchWithAuth('/sso/providers/enforcement-preflight', {
         method: 'POST',
@@ -222,15 +226,19 @@ export default function SsoProvidersPage() {
       });
       if (response.status === 401) {
         void navigateTo('/login', { replace: true });
-        return null;
+        return 'aborted';
       }
       if (response.ok) {
-        return (await response.json()).data ?? null;
+        const data = (await response.json()).data;
+        if (data) return data as EnforcementPreflight;
       }
-    } catch {
-      // fall through — server guard still applies
+      // A persistently broken preflight silently degrades the UX to
+      // raw-409-driven confirms — leave a trace of why.
+      console.error('[sso] enforcement preflight unavailable', response.status);
+    } catch (err) {
+      console.error('[sso] enforcement preflight failed', err);
     }
-    return null;
+    return 'unavailable';
   }, []);
 
   const openLockoutConfirm = (preflight: EnforcementPreflight, action: PendingEnforceAction) => {
@@ -253,7 +261,17 @@ export default function SsoProvidersPage() {
       });
 
       if (!response.ok) {
-        throw new Error(t('ssoProvidersPage.failedToUpdateProviderStatus'));
+        const body = await response.json().catch(() => null) as { error?: unknown; code?: unknown; preflight?: EnforcementPreflight } | null;
+        // The server backstop refused an unconfirmed lockout (the preflight
+        // read failed, or someone became unlinked between preflight and save):
+        // converge on the same confirm dialog, fed by the 409's own payload.
+        if (response.status === 409 && body?.code === 'sso_enforcement_lockout_confirmation_required' && body.preflight) {
+          openLockoutConfirm(body.preflight, { kind: 'activate', provider });
+          return;
+        }
+        // Surface the server's reason, not a generic label — a 403/400 must be
+        // distinguishable from "it would lock people out".
+        throw new Error(typeof body?.error === 'string' ? body.error : t('ssoProvidersPage.failedToUpdateProviderStatus'));
       }
 
       await fetchProviders();
@@ -266,7 +284,8 @@ export default function SsoProvidersPage() {
     // Activating an enforcing provider is a lockout moment — preflight it.
     if (newStatus === 'active' && provider.enforceSSO) {
       const preflight = await fetchEnforcementPreflight({ providerId: provider.id });
-      if (preflight && preflight.unlinkedCount > 0) {
+      if (preflight === 'aborted') return;
+      if (preflight !== 'unavailable' && preflight.unlinkedCount > 0) {
         openLockoutConfirm(preflight, { kind: 'activate', provider });
         return;
       }
@@ -309,18 +328,22 @@ export default function SsoProvidersPage() {
   };
 
   const handleSubmit = async (values: SsoProviderFormValues) => {
-    // #4068: enabling Enforce SSO (newly — an edit that keeps it on isn't a
+    // #4068: enabling Enforce SSO on an EDIT (newly — keeping it on isn't a
     // transition) can lock out every unlinked user on the axis. Preflight and
     // demand explicit confirmation naming them before the save goes out.
+    // Deliberately NOT on create: providers are born inactive, so a create
+    // cannot lock anyone out — the warning fires at the activation toggle,
+    // where it's true. Warning on create would cry lockout (including a false
+    // self-lockout) on 100% of first-time setups.
     const newlyEnforcing = values.enforceSSO
-      && !(modalMode === 'edit' && selectedProviderDetails?.enforceSSO);
-    if (newlyEnforcing) {
-      const preflight = await fetchEnforcementPreflight(
-        modalMode === 'edit' && selectedProvider
-          ? { providerId: selectedProvider.id }
-          : { ownerScope: values.ownerScope ?? 'organization' }
-      );
-      if (preflight && preflight.unlinkedCount > 0) {
+      && modalMode === 'edit'
+      && !selectedProviderDetails?.enforceSSO;
+    if (newlyEnforcing && selectedProvider) {
+      setSubmitting(true);
+      const preflight = await fetchEnforcementPreflight({ providerId: selectedProvider.id });
+      setSubmitting(false);
+      if (preflight === 'aborted') return;
+      if (preflight !== 'unavailable' && preflight.unlinkedCount > 0) {
         openLockoutConfirm(preflight, { kind: 'save', values });
         return;
       }
@@ -357,12 +380,29 @@ export default function SsoProvidersPage() {
       await runAction({
         request: () => fetchWithAuth(url, { method, body: JSON.stringify(payload) }),
         errorFallback: t('ssoProvidersPage.failedToSaveProvider'),
+        // The raw 409 message is written for API callers ("resend with
+        // acknowledgeLockout: true") — the web user gets the confirm dialog
+        // instead (below), so soften the toast to match.
+        friendly: (code) => code === 'sso_enforcement_lockout_confirmation_required'
+          ? t('ssoProvidersPage.enforceLockoutConfirmationNeeded')
+          : undefined,
         onUnauthorized: () => navigateTo('/login', { replace: true })
       });
 
       await fetchProviders();
       handleCloseModal();
     } catch (err) {
+      // Server backstop refused an unconfirmed lockout (preflight was
+      // unavailable, or the population changed between preflight and save):
+      // open the same confirm dialog from the 409's own payload so the admin
+      // can actually proceed — never leave them looping on a toast.
+      if (err instanceof ActionError && err.code === 'sso_enforcement_lockout_confirmation_required') {
+        const preflight = (err.body as { preflight?: EnforcementPreflight } | undefined)?.preflight;
+        if (preflight) {
+          openLockoutConfirm(preflight, { kind: 'save', values });
+          return;
+        }
+      }
       handleActionError(err, t('ssoProvidersPage.anErrorOccurred'));
     } finally {
       setSubmitting(false);

--- a/apps/web/src/components/settings/SsoProvidersPage.tsx
+++ b/apps/web/src/components/settings/SsoProvidersPage.tsx
@@ -331,13 +331,16 @@ export default function SsoProvidersPage() {
     // #4068: enabling Enforce SSO on an EDIT (newly — keeping it on isn't a
     // transition) can lock out every unlinked user on the axis. Preflight and
     // demand explicit confirmation naming them before the save goes out.
-    // Deliberately NOT on create: providers are born inactive, so a create
-    // cannot lock anyone out — the warning fires at the activation toggle,
-    // where it's true. Warning on create would cry lockout (including a false
+    // Deliberately NOT on create, and NOT on an INACTIVE provider: providers
+    // are born inactive and enforcement only bites while status is 'active'
+    // (the server guard has the same status term), so neither transition can
+    // lock anyone out — the warning fires at the activation toggle, where
+    // it's true. Warning earlier would cry lockout (including a false
     // self-lockout) on 100% of first-time setups.
     const newlyEnforcing = values.enforceSSO
       && modalMode === 'edit'
-      && !selectedProviderDetails?.enforceSSO;
+      && !selectedProviderDetails?.enforceSSO
+      && (selectedProviderDetails?.status ?? selectedProvider?.status) === 'active';
     if (newlyEnforcing && selectedProvider) {
       setSubmitting(true);
       const preflight = await fetchEnforcementPreflight({ providerId: selectedProvider.id });

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -2202,7 +2202,15 @@
     "unableToConnectToTheIdentityProvider": "Es kann keine Verbindung zum Identitätsanbieter hergestellt werden.",
     "testFailed": "Test fehlgeschlagen",
     "createProvider": "Anbieter erstellen",
-    "saveChanges": "Änderungen speichern"
+    "saveChanges": "Änderungen speichern",
+    "enforceLockoutTitle": "Benutzer werden ausgesperrt",
+    "enforceLockoutSummary": "{{unlinked}} von {{total}} aktiven Benutzern haben SSO nicht verbunden und können sich nicht mehr anmelden, sobald die SSO-Erzwingung aktiv ist:",
+    "enforceLockoutSelfBadge": "Ihr Konto",
+    "enforceLockoutHasPasskey": "hat einen Passkey",
+    "enforceLockoutTruncated": "…und weitere, die nicht angezeigt werden.",
+    "enforceLockoutSelfWarning": "Ihr eigenes Konto ist nicht verbunden — Sie würden sich selbst aussperren.",
+    "enforceLockoutAcknowledge": "Ich verstehe, dass sich diese Benutzer nicht anmelden können, bis sie SSO verbinden",
+    "enforceLockoutConfirm": "Erzwingung aktivieren"
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Kosten in {{currency}} — Marge nicht verfügbar",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -2210,7 +2210,8 @@
     "enforceLockoutTruncated": "…und weitere, die nicht angezeigt werden.",
     "enforceLockoutSelfWarning": "Ihr eigenes Konto ist nicht verbunden — Sie würden sich selbst aussperren.",
     "enforceLockoutAcknowledge": "Ich verstehe, dass sich diese Benutzer nicht anmelden können, bis sie SSO verbinden",
-    "enforceLockoutConfirm": "Erzwingung aktivieren"
+    "enforceLockoutConfirm": "Erzwingung aktivieren",
+    "enforceLockoutConfirmationNeeded": "Bestätigen Sie die Aussperr-Warnung, um die SSO-Erzwingung zu aktivieren."
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Kosten in {{currency}} — Marge nicht verfügbar",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -2202,7 +2202,15 @@
     "unableToConnectToTheIdentityProvider": "Unable to connect to the identity provider.",
     "testFailed": "Test failed",
     "createProvider": "Create provider",
-    "saveChanges": "Save changes"
+    "saveChanges": "Save changes",
+    "enforceLockoutTitle": "Users will be locked out",
+    "enforceLockoutSummary": "{{unlinked}} of {{total}} active users have not connected SSO and will not be able to sign in once SSO enforcement is active:",
+    "enforceLockoutSelfBadge": "your account",
+    "enforceLockoutHasPasskey": "has a passkey",
+    "enforceLockoutTruncated": "…and more not shown.",
+    "enforceLockoutSelfWarning": "Your own account is not connected — you would lock yourself out.",
+    "enforceLockoutAcknowledge": "I understand these users will be unable to sign in until they connect SSO",
+    "enforceLockoutConfirm": "Enable enforcement"
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Cost in {{currency}} — margin unavailable",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -2210,7 +2210,8 @@
     "enforceLockoutTruncated": "…and more not shown.",
     "enforceLockoutSelfWarning": "Your own account is not connected — you would lock yourself out.",
     "enforceLockoutAcknowledge": "I understand these users will be unable to sign in until they connect SSO",
-    "enforceLockoutConfirm": "Enable enforcement"
+    "enforceLockoutConfirm": "Enable enforcement",
+    "enforceLockoutConfirmationNeeded": "Confirm the lockout warning to enable SSO enforcement."
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Cost in {{currency}} — margin unavailable",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -2210,7 +2210,8 @@
     "enforceLockoutTruncated": "…y más que no se muestran.",
     "enforceLockoutSelfWarning": "Tu propia cuenta no está conectada — te bloquearías a ti mismo.",
     "enforceLockoutAcknowledge": "Entiendo que estos usuarios no podrán iniciar sesión hasta que conecten SSO",
-    "enforceLockoutConfirm": "Habilitar aplicación obligatoria"
+    "enforceLockoutConfirm": "Habilitar aplicación obligatoria",
+    "enforceLockoutConfirmationNeeded": "Confirma la advertencia de bloqueo para habilitar la aplicación obligatoria de SSO."
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Costo en {{currency}} — margen no disponible",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -2202,7 +2202,15 @@
     "unableToConnectToTheIdentityProvider": "No se puede conectar con el proveedor de identidad.",
     "testFailed": "Prueba fallida",
     "createProvider": "Crear proveedor",
-    "saveChanges": "Guardar cambios"
+    "saveChanges": "Guardar cambios",
+    "enforceLockoutTitle": "Se bloqueará el acceso a usuarios",
+    "enforceLockoutSummary": "{{unlinked}} de {{total}} usuarios activos no han conectado SSO y no podrán iniciar sesión cuando la aplicación obligatoria de SSO esté activa:",
+    "enforceLockoutSelfBadge": "tu cuenta",
+    "enforceLockoutHasPasskey": "tiene una llave de acceso",
+    "enforceLockoutTruncated": "…y más que no se muestran.",
+    "enforceLockoutSelfWarning": "Tu propia cuenta no está conectada — te bloquearías a ti mismo.",
+    "enforceLockoutAcknowledge": "Entiendo que estos usuarios no podrán iniciar sesión hasta que conecten SSO",
+    "enforceLockoutConfirm": "Habilitar aplicación obligatoria"
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Costo en {{currency}} — margen no disponible",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -2197,7 +2197,15 @@
     "unableToConnectToTheIdentityProvider": "Impossible de se connecter au fournisseur d’identité.",
     "testFailed": "Test échoué",
     "createProvider": "Créer un fournisseur",
-    "saveChanges": "Enregistrer les modifications"
+    "saveChanges": "Enregistrer les modifications",
+    "enforceLockoutTitle": "Des utilisateurs seront bloqués",
+    "enforceLockoutSummary": "{{unlinked}} des {{total}} utilisateurs actifs n'ont pas connecté l'authentification unique et ne pourront plus se connecter une fois l'application obligatoire de l'authentification unique activée :",
+    "enforceLockoutSelfBadge": "votre compte",
+    "enforceLockoutHasPasskey": "possède une clé d'accès",
+    "enforceLockoutTruncated": "…et d'autres non affichés.",
+    "enforceLockoutSelfWarning": "Votre propre compte n'est pas connecté — vous vous bloqueriez vous-même.",
+    "enforceLockoutAcknowledge": "Je comprends que ces utilisateurs ne pourront pas se connecter tant qu'ils n'auront pas connecté l'authentification unique",
+    "enforceLockoutConfirm": "Activer l'application obligatoire"
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Coût en {{currency}} — marge indisponible",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -2205,7 +2205,8 @@
     "enforceLockoutTruncated": "…et d'autres non affichés.",
     "enforceLockoutSelfWarning": "Votre propre compte n'est pas connecté — vous vous bloqueriez vous-même.",
     "enforceLockoutAcknowledge": "Je comprends que ces utilisateurs ne pourront pas se connecter tant qu'ils n'auront pas connecté l'authentification unique",
-    "enforceLockoutConfirm": "Activer l'application obligatoire"
+    "enforceLockoutConfirm": "Activer l'application obligatoire",
+    "enforceLockoutConfirmationNeeded": "Confirmez l'avertissement de blocage pour activer l'application obligatoire de l'authentification unique."
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Coût en {{currency}} — marge indisponible",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -2202,7 +2202,15 @@
     "unableToConnectToTheIdentityProvider": "Impossible de se connecter au fournisseur d’identité.",
     "testFailed": "Test échoué",
     "createProvider": "Créer un fournisseur",
-    "saveChanges": "Enregistrer les modifications"
+    "saveChanges": "Enregistrer les modifications",
+    "enforceLockoutTitle": "Des utilisateurs seront bloqués",
+    "enforceLockoutSummary": "{{unlinked}} des {{total}} utilisateurs actifs n'ont pas connecté l'authentification unique et ne pourront plus se connecter une fois l'application obligatoire de l'authentification unique activée :",
+    "enforceLockoutSelfBadge": "votre compte",
+    "enforceLockoutHasPasskey": "possède une clé d'accès",
+    "enforceLockoutTruncated": "…et d'autres non affichés.",
+    "enforceLockoutSelfWarning": "Votre propre compte n'est pas connecté — vous vous bloqueriez vous-même.",
+    "enforceLockoutAcknowledge": "Je comprends que ces utilisateurs ne pourront pas se connecter tant qu'ils n'auront pas connecté l'authentification unique",
+    "enforceLockoutConfirm": "Activer l'application obligatoire"
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Coût en {{currency}} — marge indisponible",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -2210,7 +2210,8 @@
     "enforceLockoutTruncated": "…et d'autres non affichés.",
     "enforceLockoutSelfWarning": "Votre propre compte n'est pas connecté — vous vous bloqueriez vous-même.",
     "enforceLockoutAcknowledge": "Je comprends que ces utilisateurs ne pourront pas se connecter tant qu'ils n'auront pas connecté l'authentification unique",
-    "enforceLockoutConfirm": "Activer l'application obligatoire"
+    "enforceLockoutConfirm": "Activer l'application obligatoire",
+    "enforceLockoutConfirmationNeeded": "Confirmez l'avertissement de blocage pour activer l'application obligatoire de l'authentification unique."
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Coût en {{currency}} — marge indisponible",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -2205,7 +2205,8 @@
     "enforceLockoutTruncated": "…e altri non mostrati.",
     "enforceLockoutSelfWarning": "Il tuo account non è collegato — bloccheresti te stesso.",
     "enforceLockoutAcknowledge": "Comprendo che questi utenti non potranno accedere finché non collegheranno l'SSO",
-    "enforceLockoutConfirm": "Abilita applicazione obbligatoria"
+    "enforceLockoutConfirm": "Abilita applicazione obbligatoria",
+    "enforceLockoutConfirmationNeeded": "Conferma l'avviso di blocco per abilitare l'applicazione obbligatoria dell'SSO."
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Costo in {{currency}} — margine non disponibile",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -2197,7 +2197,15 @@
     "unableToConnectToTheIdentityProvider": "Impossibile connettersi al provider di identità.",
     "testFailed": "Test non riuscito",
     "createProvider": "Crea provider",
-    "saveChanges": "Salva modifiche"
+    "saveChanges": "Salva modifiche",
+    "enforceLockoutTitle": "Alcuni utenti verranno bloccati",
+    "enforceLockoutSummary": "{{unlinked}} di {{total}} utenti attivi non hanno collegato l'SSO e non potranno più accedere una volta attivata l'applicazione obbligatoria dell'SSO:",
+    "enforceLockoutSelfBadge": "il tuo account",
+    "enforceLockoutHasPasskey": "ha una passkey",
+    "enforceLockoutTruncated": "…e altri non mostrati.",
+    "enforceLockoutSelfWarning": "Il tuo account non è collegato — bloccheresti te stesso.",
+    "enforceLockoutAcknowledge": "Comprendo che questi utenti non potranno accedere finché non collegheranno l'SSO",
+    "enforceLockoutConfirm": "Abilita applicazione obbligatoria"
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Costo in {{currency}} — margine non disponibile",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -2210,7 +2210,8 @@
     "enforceLockoutTruncated": "…e mais não exibidos.",
     "enforceLockoutSelfWarning": "Sua própria conta não está conectada — você bloquearia a si mesmo.",
     "enforceLockoutAcknowledge": "Entendo que esses usuários não poderão entrar até conectarem o SSO",
-    "enforceLockoutConfirm": "Ativar imposição"
+    "enforceLockoutConfirm": "Ativar imposição",
+    "enforceLockoutConfirmationNeeded": "Confirme o aviso de bloqueio para ativar a imposição de SSO."
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Custo em {{currency}} — margem indisponível",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -2202,7 +2202,15 @@
     "unableToConnectToTheIdentityProvider": "Não é possível conectar-se ao provedor de identidade.",
     "testFailed": "Falha no teste",
     "createProvider": "Criar provedor",
-    "saveChanges": "Salvar alterações"
+    "saveChanges": "Salvar alterações",
+    "enforceLockoutTitle": "Usuários ficarão bloqueados",
+    "enforceLockoutSummary": "{{unlinked}} de {{total}} usuários ativos não conectaram o SSO e não poderão entrar quando a imposição de SSO estiver ativa:",
+    "enforceLockoutSelfBadge": "sua conta",
+    "enforceLockoutHasPasskey": "tem uma chave de acesso",
+    "enforceLockoutTruncated": "…e mais não exibidos.",
+    "enforceLockoutSelfWarning": "Sua própria conta não está conectada — você bloquearia a si mesmo.",
+    "enforceLockoutAcknowledge": "Entendo que esses usuários não poderão entrar até conectarem o SSO",
+    "enforceLockoutConfirm": "Ativar imposição"
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Custo em {{currency}} — margem indisponível",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -2210,7 +2210,8 @@
     "enforceLockoutTruncated": "…ve gösterilmeyen diğerleri.",
     "enforceLockoutSelfWarning": "Kendi hesabınız bağlı değil — kendinizi kilitlemiş olursunuz.",
     "enforceLockoutAcknowledge": "Bu kullanıcıların SSO bağlantısı yapana kadar oturum açamayacağını anlıyorum",
-    "enforceLockoutConfirm": "Zorunluluğu etkinleştir"
+    "enforceLockoutConfirm": "Zorunluluğu etkinleştir",
+    "enforceLockoutConfirmationNeeded": "SSO zorunluluğunu etkinleştirmek için kilitleme uyarısını onaylayın."
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Maliyet {{currency}} cinsinden — marj kullanılamıyor",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -2202,7 +2202,15 @@
     "unableToConnectToTheIdentityProvider": "Kimlik sağlayıcıya bağlanılamıyor.",
     "testFailed": "Test başarısız oldu",
     "createProvider": "Sağlayıcı oluştur",
-    "saveChanges": "Değişiklikleri kaydet"
+    "saveChanges": "Değişiklikleri kaydet",
+    "enforceLockoutTitle": "Kullanıcıların erişimi engellenecek",
+    "enforceLockoutSummary": "{{total}} etkin kullanıcıdan {{unlinked}} tanesi SSO bağlantısı yapmadı ve SSO zorunluluğu etkinleştiğinde oturum açamayacak:",
+    "enforceLockoutSelfBadge": "sizin hesabınız",
+    "enforceLockoutHasPasskey": "geçiş anahtarı var",
+    "enforceLockoutTruncated": "…ve gösterilmeyen diğerleri.",
+    "enforceLockoutSelfWarning": "Kendi hesabınız bağlı değil — kendinizi kilitlemiş olursunuz.",
+    "enforceLockoutAcknowledge": "Bu kullanıcıların SSO bağlantısı yapana kadar oturum açamayacağını anlıyorum",
+    "enforceLockoutConfirm": "Zorunluluğu etkinleştir"
   },
   "tdSynnexCatalogPanel": {
     "marginUnavailableCostIn": "Maliyet {{currency}} cinsinden — marj kullanılamıyor",


### PR DESCRIPTION
Closes #4068

## Problem

Enabling **Enforce SSO** blocks password login for every user on the provider's axis (`assertPasswordAuthAllowedBySso`), and any active user without a linked identity bounces off SSO with `sso_link_required` (password accounts are never auto-linked, per the #2183 guard) — total lockout with no self-recovery. Two full-tenant lockouts on hosted (2026-08-17 and 2026-08-26) were remediated with manual prod UPDATEs. The form's amber warning never said *who* would lose access.

## What this adds

### API

**`POST /sso/providers/enforcement-preflight`** — computes the lockout population before the admin commits:

- **Membership**: active members of the provider's axis via `organization_users` / `partner_users` — **partner membership wins the axis** (mirrors `resolveCurrentUserTokenContext`), so an org-axis preflight excludes users who also hold a partner membership.
- **Linkage**: a user is safe only if linked to the **effective login provider** — the oldest `(createdAt, id)` provider that will be active once the change is live, because the pre-auth login entries (`GET /sso/login/:orgId`, `/sso/login/partner/:partnerId`) route through exactly that one. Links to a newer active provider are unusable at login and do not count. (This deliberately deviates from the issue's per-target-provider sketch — that shape both over- and under-reports.)
- A **SAML** effective provider counts as *no path* (the login entry 400s on it rather than falling through).
- Passkey holders keep a sign-in path (passkey routes never consult the SSO gate) — annotated `hasPasskey`, not excluded; disabled passkeys don't count.
- Same auth surface as the writes it fronts: `sso:admin` + MFA + `canWriteProviderRow` / partner-wide gates. Population read runs in a system DB context (identities/passkeys are user-id-scoped under RLS — an admin context would read 0 rows and report everyone unlinked).
- Response: exact counts, capped list (200) with self sorted first, `selfLockedOut`, `loginProvider`, `truncated`.

**Server-side confirm-through** on the two transitions that actually make enforcement live:

1. `PATCH /providers/:id` setting `enforceSSO: true` on an **active** provider
2. `POST /providers/:id/status` activating an **already-enforcing** provider

Either returns **409** `sso_enforcement_lockout_confirmation_required` *with the preflight payload* unless the body carries `acknowledgeLockout: true` — raw API callers get the same guard as the UI. Zero-lockout transitions proceed unchanged, so existing automation only breaks where it was about to lock a tenant out. `acknowledgeLockout` is stripped before the update spread (the `preset`-omit trap). Both refusals are audited.

### Web

`SsoProvidersPage` preflights on save-with-enforcement-newly-on and on activate-of-an-enforcing-provider, then shows a type-checked acknowledgement dialog listing affected users (self called out separately — the guaranteed self-lockout case, per the issue) and resends with `acknowledgeLockout`. Rendered as an overlay above the form modal so form state survives cancel. A failed preflight read falls through to the save — the server 409 is the backstop, so a broken preflight can neither skip the protection nor wedge saving. New `enforceLockout*` strings in all 8 locales.

## Design notes

- **Confirm-through over hard-block** (issue's recommendation): an MSP may intentionally cut off a departed user; default answer is No (checkbox-gated).
- Create flow shows the warning too, but the server guard sits on the *live* transitions only — providers are born `inactive`, so create can't lock anyone out; activation is guarded.
- Design cross-checked with an independent codex consult (xhigh): it independently flagged the oldest-active-provider login selection and the status-activation path, both incorporated.

## Tests

- `sso.test.ts` (+14): route contract — authority checks (403/404, partner-wide gate), 409/ack/zero-lockout matrix on PATCH and status, `acknowledgeLockout` never reaches `set()`, SAML/no-provider shapes.
- `ssoEnforcementPreflight.integration.test.ts` (new, real Postgres): axis membership, partner-wins exclusion, linked-to-newer-provider still locked out, invited/disabled excluded, inactive target as future login provider, SAML, passkey/disabled-passkey annotation.
- `SsoProvidersPage.test.tsx` (+4): confirm flow gating, straight-through on zero, no preflight when enforcement already on, activate path.
- `tsc --noEmit` clean (api, web); i18n parity/key-usage/no-silent-mutations suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)