### PR TITLE
fix(agent,api): self-host→hosted update transition + edition-aware offer gating (#4072)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -137,9 +137,11 @@ type HeartbeatPayload struct {
 	// written unconditionally server-side (the outboundNetworkPolicyVersion
 	// self-healing pattern, NOT the sticky isVirtual pattern) so a resolved
 	// condition clears a dashboard migration banner on the next beat.
-	// omitempty on both: a self-host build (the only build in this repo
-	// today) reports "" / false — both omitempty fields drop out — so the
-	// wire payload is byte-identical to pre-Task-8 agents.
+	// Since #4072 BOTH build editions report a value ("self-host"/"hosted") —
+	// a reported edition doubles as the server's signal that this build can
+	// accept hosted-edition update artifacts (see migrationSignal). omitempty
+	// is retained so MigrationRequired=false stays off the wire; AgentEdition
+	// is never empty from this build.
 	AgentEdition      string `json:"agentEdition,omitempty"`
 	MigrationRequired bool   `json:"migrationRequired,omitempty"`
 }
@@ -150,12 +152,19 @@ type HeartbeatPayload struct {
 // nothing is persisted to violate the allowlist when there is no backup.
 // Pure; independent of hostpolicy.Strict() — reporting is telemetry, not
 // enforcement, so it fires the same in gap and strict hosted builds.
-// Self-host returns ("", false) — NOT "self-host" — because the
-// AgentEdition field is omitempty: only the empty string drops out of the
-// wire payload, preserving byte-identity with pre-Task-8 agents.
+//
+// Self-host builds report "self-host" explicitly (#4072). This is the
+// server's edition-transition capability signal: a build that reports an
+// edition — either value — also carries the one-way self-host → hosted
+// allowance in updater.editionAllowed (both shipped in the same binary),
+// while a silent build ≥0.105.0 is a self-host build that hard-refuses
+// hosted-edition artifacts, so the server withholds those offers rather
+// than wedging it in a permanent retry loop. Regressing this to the empty
+// string would re-strand every future self-host agent that migrates to a
+// hosted control plane.
 func migrationSignal(server, backup string) (edition string, migrationRequired bool) {
 	if !hostpolicy.Enforced() {
-		return "", false
+		return "self-host", false
 	}
 	if hostpolicy.AllowedURL(server) != nil {
 		return "hosted", true

--- a/agent/internal/heartbeat/migration_signal_test.go
+++ b/agent/internal/heartbeat/migration_signal_test.go
@@ -7,11 +7,13 @@ import (
 )
 
 func TestMigrationSignal(t *testing.T) {
-	// Self-host build: empty edition (omitempty drops it from the wire
-	// payload, keeping byte-identity with pre-Task-8 agents), never
-	// migration-needed.
-	if e, m := migrationSignal("https://anything.example", ""); e != "" || m {
-		t.Fatalf("self-host: want (\"\",false), got (%s,%v)", e, m)
+	// Self-host build: reports its edition explicitly (#4072 — the server
+	// withholds hosted-edition update offers from agents that never report an
+	// edition, because a silent self-host build ≥0.105.0 would hard-refuse
+	// them; reporting "self-host" marks this build as transition-capable),
+	// never migration-needed.
+	if e, m := migrationSignal("https://anything.example", ""); e != "self-host" || m {
+		t.Fatalf("self-host: want (\"self-host\",false), got (%s,%v)", e, m)
 	}
 
 	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")

--- a/agent/internal/heartbeat/migration_signal_wire_test.go
+++ b/agent/internal/heartbeat/migration_signal_wire_test.go
@@ -8,17 +8,19 @@ import (
 	"github.com/breeze-rmm/agent/internal/hostpolicy"
 )
 
-// TestHeartbeatPayloadWireByteIdentity pins the omitempty contract on the
+// TestHeartbeatPayloadWireSelfHostSignal pins the wire contract on the
 // build-edition telemetry fields at the JSON layer, which is the only layer
 // where it actually matters.
 //
-// TestMigrationSignal asserts migrationSignal() returns ("", false) for a
-// self-host build, but that is a Go-level claim: dropping `omitempty` from
-// either struct tag would leave it green while every self-hosted agent in
-// the field silently starts sending two new keys. The whole point of the
-// zero values is that the wire payload stays byte-identical to pre-edition
-// agents, so assert on the marshalled bytes.
-func TestHeartbeatPayloadWireByteIdentity(t *testing.T) {
+// Since #4072 a self-host build MUST put agentEdition:"self-host" on the
+// wire: the server treats a reported edition (either value) as "this build
+// can accept hosted-edition artifacts" and withholds hosted update offers
+// from agents that stay silent (a silent self-host build ≥0.105.0 would
+// hard-refuse them and wedge in a permanent retry loop). A regression back
+// to the empty string would silently re-strand every future self-host agent
+// that later migrates to a hosted control plane. migrationRequired keeps the
+// old omitempty contract — false must stay off the wire.
+func TestHeartbeatPayloadWireSelfHostSignal(t *testing.T) {
 	var payload HeartbeatPayload
 	payload.AgentEdition, payload.MigrationRequired = migrationSignal("https://selfhosted.example", "")
 
@@ -26,11 +28,17 @@ func TestHeartbeatPayloadWireByteIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal self-host payload: %v", err)
 	}
-	for _, key := range []string{`"agentEdition"`, `"migrationRequired"`} {
-		if strings.Contains(string(body), key) {
-			t.Errorf("self-host heartbeat payload must not carry %s on the wire "+
-				"(omitempty dropped from the struct tag?)", key)
-		}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal self-host payload: %v", err)
+	}
+	if decoded["agentEdition"] != "self-host" {
+		t.Errorf("self-host build: agentEdition = %v, want %q (#4072 transition-capability signal)",
+			decoded["agentEdition"], "self-host")
+	}
+	if strings.Contains(string(body), `"migrationRequired"`) {
+		t.Errorf("self-host heartbeat payload must not carry \"migrationRequired\" on the wire " +
+			"(omitempty dropped from the struct tag?)")
 	}
 }
 

--- a/agent/internal/updater/edition.go
+++ b/agent/internal/updater/edition.go
@@ -14,10 +14,32 @@ import (
 // agent built before this check existed never calls editionAllowed at all,
 // so old agents can still upgrade cleanly into edition-stamped manifests.
 //
-// A non-empty edition must match this build's own edition family: "hosted"
-// when hostpolicy.Enforced() (an allowlist-injected hosted build), or
-// "self-host" when it is not (the unrestricted repo-default build). Any
-// other value — including a typo or a future edition this build predates —
+// A non-empty edition is accepted one-way (#4072):
+//
+//   - A hosted build (hostpolicy.Enforced(), allowlist-injected) accepts ONLY
+//     "hosted". Accepting a "self-host" artifact would swap the running binary
+//     for one with no host-policy allowlist — enforcement removal — so that
+//     direction stays a hard refusal.
+//   - A self-host build (the unrestricted repo-default) accepts "self-host"
+//     AND "hosted". Both call sites consult editionAllowed strictly AFTER the
+//     manifest's Ed25519 signature verified against the trust roots, and a
+//     hosted build only ADDS enforcement, so the transition grants nothing an
+//     attacker could not already get from a signed self-host manifest. Without
+//     this, a self-host build whose control plane cut over to hosted-edition
+//     artifacts wedges in a permanent download-refusal loop with no
+//     server-side escape hatch (agents 0.105.0–0.106.x in the field).
+//
+//     Accepted residual risk: a control plane that substitutes a signed
+//     STRICT-hostpolicy hosted artifact for a self-hoster's update can move
+//     the agent onto a build that refuses the self-hoster's own server URL,
+//     losing management connectivity. That requires a malicious or
+//     compromised control plane — which can already run arbitrary scripts on
+//     enrolled devices — so the transition adds no new attacker capability;
+//     server-side, offers are edition-scoped to the deployment's own edition
+//     (apps/api resolvePinnedUpgradeTarget), so a healthy self-host server
+//     never offers one.
+//
+// Any other value — including a typo or a future edition this build predates —
 // fails closed rather than being silently accepted.
 func editionAllowed(assetEdition string) bool {
 	assetEdition = strings.TrimSpace(assetEdition)
@@ -27,5 +49,17 @@ func editionAllowed(assetEdition string) bool {
 	if hostpolicy.Enforced() {
 		return assetEdition == "hosted"
 	}
-	return assetEdition == "self-host"
+	switch assetEdition {
+	case "self-host":
+		return true
+	case "hosted":
+		// One-way self-host → hosted transition. Logged because the next
+		// binary this agent runs will enforce the hosted host-policy
+		// allowlist — visible, deliberate, and only reachable via a
+		// signature-verified manifest.
+		log.Info("accepting hosted-edition update artifact from this self-host build (one-way edition transition)")
+		return true
+	default:
+		return false
+	}
 }

--- a/agent/internal/updater/edition.go
+++ b/agent/internal/updater/edition.go
@@ -53,11 +53,14 @@ func editionAllowed(assetEdition string) bool {
 	case "self-host":
 		return true
 	case "hosted":
-		// One-way self-host → hosted transition. Logged because the next
-		// binary this agent runs will enforce the hosted host-policy
-		// allowlist — visible, deliberate, and only reachable via a
-		// signature-verified manifest.
-		log.Info("accepting hosted-edition update artifact from this self-host build (one-way edition transition)")
+		// One-way self-host → hosted transition. Logged at Warn because the
+		// log shipper's default MinLevel is warn (config.go) — Info would
+		// exist only in the device-local file, and if the transitioned build
+		// ever loses management connectivity (the documented residual risk
+		// above), server-side logs are the only forensic record of when the
+		// transition happened. Fires at most once per component transition,
+		// and only via a signature-verified manifest.
+		log.Warn("accepting hosted-edition update artifact from this self-host build (one-way edition transition)")
 		return true
 	default:
 		return false

--- a/agent/internal/updater/edition.go
+++ b/agent/internal/updater/edition.go
@@ -20,6 +20,7 @@ import (
 //     "hosted". Accepting a "self-host" artifact would swap the running binary
 //     for one with no host-policy allowlist — enforcement removal — so that
 //     direction stays a hard refusal.
+//
 //   - A self-host build (the unrestricted repo-default) accepts "self-host"
 //     AND "hosted". Both call sites consult editionAllowed strictly AFTER the
 //     manifest's Ed25519 signature verified against the trust roots, and a

--- a/agent/internal/updater/edition_test.go
+++ b/agent/internal/updater/edition_test.go
@@ -98,9 +98,15 @@ func TestEditionAllowed_SelfHostRejectedInHostedBuild(t *testing.T) {
 	}
 }
 
-func TestEditionAllowed_HostedRejectedInSelfHostBuild(t *testing.T) {
-	if editionAllowed("hosted") {
-		t.Fatal("edition=hosted must be rejected in a self-host build")
+func TestEditionAllowed_HostedAcceptedInSelfHostBuild(t *testing.T) {
+	// One-way self-host → hosted transition (#4072). Both call sites only
+	// consult editionAllowed AFTER the manifest's Ed25519 signature verified
+	// against the trust roots, and moving onto a hosted build only ADDS
+	// enforcement (the hostpolicy allowlist) — so a self-host build accepts
+	// a hosted-edition artifact rather than wedging in a permanent refusal
+	// loop the moment its control plane cuts over to hosted artifacts.
+	if !editionAllowed("hosted") {
+		t.Fatal("edition=hosted must be accepted in a self-host build (one-way transition, #4072)")
 	}
 }
 
@@ -175,14 +181,14 @@ func TestVerifyUpdateManifest_ReleaseArtifact_SelfHostEdition_RejectedInHostedBu
 	}
 }
 
-func TestVerifyUpdateManifest_ReleaseArtifact_HostedEdition_RejectedInSelfHostBuild(t *testing.T) {
+func TestVerifyUpdateManifest_ReleaseArtifact_HostedEdition_AcceptedInSelfHostBuild(t *testing.T) {
 	assetName := agentAssetName()
 	content := []byte("fake binary edition hosted")
 	info := signedReleaseArtifactDownloadInfoWithEdition(t, "1.0.0", assetName, "hosted", "http://example/"+assetName, content)
 
 	u := &Updater{config: &Config{Component: "agent"}}
-	if _, err := u.verifyUpdateManifest(info, "1.0.0"); err == nil {
-		t.Fatal("edition=hosted must be rejected in a self-host build")
+	if _, err := u.verifyUpdateManifest(info, "1.0.0"); err != nil {
+		t.Fatalf("edition=hosted must be accepted in a self-host build (one-way transition, #4072): %v", err)
 	}
 }
 
@@ -248,13 +254,13 @@ func TestPkgAssetChecksum_SelfHostEdition_RejectedInHostedBuild(t *testing.T) {
 	}
 }
 
-func TestPkgAssetChecksum_HostedEdition_RejectedInSelfHostBuild(t *testing.T) {
+func TestPkgAssetChecksum_HostedEdition_AcceptedInSelfHostBuild(t *testing.T) {
 	pkgName := "breeze-agent-darwin-" + runtime.GOARCH + ".pkg"
 	payload := buildReleaseManifest(t, "v1.2.3", []releaseArtifactAsset{
 		{Name: pkgName, SHA256: strings.Repeat("a", 64), Size: 20, Edition: "hosted"},
 	})
-	if _, err := pkgAssetChecksum(payload, "1.2.3"); err == nil {
-		t.Fatal("edition=hosted must be rejected in a self-host build")
+	if _, err := pkgAssetChecksum(payload, "1.2.3"); err != nil {
+		t.Fatalf("edition=hosted must be accepted in a self-host build (one-way transition, #4072): %v", err)
 	}
 }
 

--- a/agent/internal/watchdog/failover.go
+++ b/agent/internal/watchdog/failover.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
 	"github.com/breeze-rmm/agent/internal/netcache"
 )
 
@@ -122,11 +123,21 @@ func (c *FailoverClient) setHeaders(req *http.Request) {
 // and silently strips it, so shipping it was dead wire data. Diagnostic
 // journal entries reach the server via ShipLogs / the /logs endpoint instead.
 func (c *FailoverClient) SendHeartbeat(watchdogVersion, currentState string, restartStats RestartStats) (*HeartbeatResponse, error) {
+	// Build-edition capability signal (#4072): a reported edition tells the
+	// server this binary carries the one-way self-host → hosted allowance in
+	// updater.editionAllowed (both ship in the same build), so it may be
+	// offered this deployment's artifact edition. Silent (older) watchdogs
+	// fall back to server-side version-band inference.
+	edition := "self-host"
+	if hostpolicy.Enforced() {
+		edition = "hosted"
+	}
 	body := map[string]any{
 		"role":                     "watchdog",
 		"watchdogState":            currentState,
 		"status":                   "ok",
 		"agentVersion":             watchdogVersion,
+		"agentEdition":             edition,
 		"timestamp":                time.Now().UTC().Format(time.RFC3339),
 		"mainAgentRestartCount24h": restartStats.Count24h,
 		"flapDetected":             restartStats.FlapDetected,

--- a/agent/internal/watchdog/failover_test.go
+++ b/agent/internal/watchdog/failover_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
 )
 
 // TestFailoverHeartbeat verifies that SendHeartbeat sets X-Breeze-Role: watchdog,
@@ -164,6 +166,46 @@ func TestSendHeartbeatIncludesRestartStats(t *testing.T) {
 	}
 	if got := captured["flapDetected"]; got != false {
 		t.Errorf("flapDetected: want false, got %v", got)
+	}
+}
+
+// TestSendHeartbeatReportsAgentEdition pins the #4072 edition-capability
+// signal on the failover heartbeat: the server withholds update offers from
+// watchdogs that would refuse the served artifact edition, and a REPORTED
+// edition (either value) is what marks this binary as carrying the one-way
+// self-host → hosted allowance. A silent watchdog falls back to server-side
+// version-band inference, so dropping this field would make every future
+// self-host watchdog look transition-incapable during failover.
+func TestSendHeartbeatReportsAgentEdition(t *testing.T) {
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &captured); err != nil {
+			t.Fatalf("server: unmarshal body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{}`)) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	fc := NewFailoverClient(server.URL, "agent-xyz", "token", nil)
+
+	// Repo-default build: hostpolicy not enforced → self-host.
+	if _, err := fc.SendHeartbeat("0.109.0", StateFailover, RestartStats{}); err != nil {
+		t.Fatalf("SendHeartbeat: %v", err)
+	}
+	if got, _ := captured["agentEdition"].(string); got != "self-host" {
+		t.Errorf("self-host build: agentEdition = %v, want %q", captured["agentEdition"], "self-host")
+	}
+
+	// Allowlist-injected hosted build.
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+	if _, err := fc.SendHeartbeat("0.109.0", StateFailover, RestartStats{}); err != nil {
+		t.Fatalf("SendHeartbeat (hosted): %v", err)
+	}
+	if got, _ := captured["agentEdition"].(string); got != "hosted" {
+		t.Errorf("hosted build: agentEdition = %v, want %q", captured["agentEdition"], "hosted")
 	}
 }
 

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -1855,6 +1855,65 @@ describe('POST /agents/:id/heartbeat — artifact-edition offer gate (#4072)', (
         errorSpy.mockRestore();
       }
     });
+
+    it('a MAIN-agent beat re-arms the recovery error — a second wedge weeks later must alert again', async () => {
+      const { agentAcceptsServedEdition } = await import('./helpers');
+      vi.mocked(agentAcceptsServedEdition).mockImplementation(() => false);
+      const { __resetEditionWithheldWarnCacheForTests } = await import('./heartbeat');
+      __resetEditionWithheldWarnCacheForTests();
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        primeWatchdog();
+        await watchdogBeat(); // wedge #1 → recovery error
+        // Main agent comes back and beats (proof of recovery) — clears the entry.
+        prime([{ version: '0.66.0' }]);
+        await beat();
+        primeWatchdog();
+        await watchdogBeat(); // wedge #2 → must error AGAIN
+        const recoveryErrors = errorSpy.mock.calls.filter(
+          (c) => String(c[0]).includes('#4072') && String(c[0]).toLowerCase().includes('recovery'),
+        );
+        expect(recoveryErrors).toHaveLength(2);
+      } finally {
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('a silent watchdog whose withhold came from the STORED edition reports that stored value in the log, not "none"', async () => {
+      const { agentAcceptsServedEdition } = await import('./helpers');
+      vi.mocked(agentAcceptsServedEdition).mockImplementation(() => false);
+      const { __resetEditionWithheldWarnCacheForTests } = await import('./heartbeat');
+      __resetEditionWithheldWarnCacheForTests();
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        selectMock.mockReturnValueOnce(
+          selectChainResolving([
+            {
+              id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+              architecture: 'amd64', agentVersion: '0.107.1', watchdogVersion: '0.107.1',
+              agentEdition: 'hosted',
+              lastSeenAt: sixteenMinutesAgo, mainAgentSilentSince: new Date(),
+            },
+          ]),
+        );
+        selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+        const resp = await buildWatchdogApp().request('/agents/device-1/heartbeat', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ role: 'watchdog', agentVersion: '0.107.1', watchdogState: 'FAILOVER' }),
+        });
+        expect(resp.status).toBe(200);
+        const recoveryErrors = errorSpy.mock.calls.filter((c) => String(c[0]).includes('#4072'));
+        expect(recoveryErrors.length).toBeGreaterThan(0);
+        // The decision used the stored 'hosted' fallback — the log must print
+        // the value that decided, not the silent payload.
+        expect(String(recoveryErrors[0]?.[0])).toContain('reported edition=hosted');
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
   });
 });
 

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -1707,6 +1707,49 @@ describe('POST /agents/:id/heartbeat — artifact-edition offer gate (#4072)', (
     }
   });
 
+  it('routes the withhold to Sentry once per process (fleet-freeze observability parity with the pin-miss path)', async () => {
+    const { agentAcceptsServedEdition } = await import('./helpers');
+    const { captureException } = await import('../../services/sentry');
+    vi.mocked(agentAcceptsServedEdition).mockImplementation(() => false);
+    const { __resetEditionWithheldWarnCacheForTests } = await import('./heartbeat');
+    __resetEditionWithheldWarnCacheForTests();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      prime([{ version: '0.66.0' }]);
+      await beat();
+      prime([{ version: '0.66.0' }]);
+      await beat();
+      const withheldCaptures = vi
+        .mocked(captureException)
+        .mock.calls.filter((c) => String((c[0] as Error)?.message ?? c[0]).includes('#4072'));
+      expect(withheldCaptures).toHaveLength(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('re-arms the per-device warn once the device accepts again (a later regression must re-log)', async () => {
+    const { agentAcceptsServedEdition } = await import('./helpers');
+    vi.mocked(agentAcceptsServedEdition).mockImplementation(() => false);
+    const { __resetEditionWithheldWarnCacheForTests } = await import('./heartbeat');
+    __resetEditionWithheldWarnCacheForTests();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      prime([{ version: '0.66.0' }]);
+      await beat(); // withheld → warns
+      vi.mocked(agentAcceptsServedEdition).mockImplementation(() => true);
+      prime([{ version: '0.66.0' }]);
+      await beat(); // accepting → clears the dedupe entry
+      vi.mocked(agentAcceptsServedEdition).mockImplementation(() => false);
+      prime([{ version: '0.66.0' }]);
+      await beat(); // regressed → must warn AGAIN
+      const withheldWarns = warnSpy.mock.calls.filter((c) => String(c[0]).includes('#4072'));
+      expect(withheldWarns).toHaveLength(2);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   describe('watchdog failover branch', () => {
     const sixteenMinutesAgo = new Date(Date.now() - 16 * 60 * 1000);
 
@@ -1758,6 +1801,59 @@ describe('POST /agents/:id/heartbeat — artifact-edition offer gate (#4072)', (
       const body = (await resp.json()) as OfferBody;
       expect(body.watchdogUpgradeTo).toBe('0.66.0');
       expect(body.upgradeTo).toBe('0.66.0');
+    });
+
+    it('a SILENT watchdog falls back to the device row’s stored agentEdition — deployed watchdogs predate edition reporting, and withholding recovery from the whole hosted fleet would be the regression', async () => {
+      const { agentAcceptsServedEdition } = await import('./helpers');
+      selectMock.mockReturnValueOnce(
+        selectChainResolving([
+          {
+            id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+            architecture: 'amd64', agentVersion: '0.107.1', watchdogVersion: '0.107.1',
+            agentEdition: 'hosted',
+            lastSeenAt: sixteenMinutesAgo, mainAgentSilentSince: new Date(),
+          },
+        ]),
+      );
+      selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+
+      // Watchdog beat WITHOUT agentEdition — every watchdog in the field today.
+      const resp = await buildWatchdogApp().request('/agents/device-1/heartbeat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ role: 'watchdog', agentVersion: '0.107.1', watchdogState: 'FAILOVER' }),
+      });
+      expect(resp.status).toBe(200);
+      expect(vi.mocked(agentAcceptsServedEdition)).toHaveBeenCalledWith({
+        reportedEdition: 'hosted',
+        agentVersion: '0.107.1',
+      });
+    });
+
+    it('a withheld RECOVERY (main agent silent) logs at error level and captures to Sentry — a device stuck offline must never be silent', async () => {
+      const { agentAcceptsServedEdition } = await import('./helpers');
+      const { captureException } = await import('../../services/sentry');
+      vi.mocked(agentAcceptsServedEdition).mockImplementation(() => false);
+      const { __resetEditionWithheldWarnCacheForTests } = await import('./heartbeat');
+      __resetEditionWithheldWarnCacheForTests();
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        primeWatchdog();
+        await watchdogBeat();
+        primeWatchdog();
+        await watchdogBeat();
+        const recoveryErrors = errorSpy.mock.calls.filter(
+          (c) => String(c[0]).includes('#4072') && String(c[0]).toLowerCase().includes('recovery'),
+        );
+        // Deduped per device per process — once, not per failover beat.
+        expect(recoveryErrors).toHaveLength(1);
+        const recoveryCaptures = vi
+          .mocked(captureException)
+          .mock.calls.filter((c) => String((c[0] as Error)?.message ?? c[0]).includes('recovery withheld'));
+        expect(recoveryCaptures).toHaveLength(1);
+      } finally {
+        errorSpy.mockRestore();
+      }
     });
   });
 });

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -171,6 +171,10 @@ vi.mock('./helpers', () => ({
   // upgrade tests: the resolver returns the candidate target version, and the
   // gate + compareAgentVersions (default 0 = no newer) decide whether to send it.
   resolvePinnedUpgradeTarget: vi.fn(async () => '0.66.0'),
+  // #4072 — permissive default so the edition gate is transparent to tests
+  // that don't exercise it. The edition-gate describe overrides per-test and
+  // restores this implementation in afterEach (clearAllMocks does not).
+  agentAcceptsServedEdition: vi.fn(() => true),
 }));
 
 vi.mock('../../services/auditEvents', () => ({
@@ -1559,6 +1563,202 @@ describe('POST /agents/:id/heartbeat — controlled fleet rollout (promotion gat
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as { upgradeTo?: string | null };
     expect(body.upgradeTo).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------
+// #4072 — artifact-edition offer gate. An agent build that would refuse the
+// served artifact edition (updater-side check, post-download) must not be
+// OFFERED the version at all: the refusal loop retries every ~60s forever
+// with the device stuck in 'updating'. These tests pin the wiring — every
+// offer path consults agentAcceptsServedEdition with THIS beat's payload
+// values and withholds on false. The predicate's own logic is unit-tested in
+// helpers.agentUpdatePolicy.test.ts.
+// ---------------------------------------------------------------------
+describe('POST /agents/:id/heartbeat — artifact-edition offer gate (#4072)', () => {
+  const agentDeviceRow = {
+    id: 'device-1',
+    orgId: 'org-1',
+    siteId: 'site-1',
+    hostname: 'host-1',
+    osType: 'windows',
+    osVersion: 'Windows 11',
+    osBuild: null,
+    architecture: 'amd64',
+    agentVersion: '0.105.1',
+    deviceRole: 'workstation',
+    deviceRoleSource: 'auto',
+    agentTokenHash: 'hash',
+    tokenIssuedAt: new Date(),
+    mainAgentSilentSince: null,
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    selectMock.mockReset();
+    updateMock.mockReset();
+    insertMock.mockReset();
+    getActiveTrustKeysetMock.mockReset();
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+    updateMock.mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) })),
+    });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+    const { agentAcceptsServedEdition, compareAgentVersions } = await import('./helpers');
+    vi.mocked(agentAcceptsServedEdition).mockImplementation(() => true);
+    vi.mocked(compareAgentVersions).mockReturnValue(1); // target > reported everywhere
+  });
+
+  afterEach(async () => {
+    // Restore the permissive default for the rest of the file — clearAllMocks
+    // clears calls, not implementations, so a leaked `false` would silently
+    // withhold offers in every later upgrade test.
+    const { agentAcceptsServedEdition, compareAgentVersions } = await import('./helpers');
+    vi.mocked(agentAcceptsServedEdition).mockImplementation(() => true);
+    vi.mocked(compareAgentVersions).mockReturnValue(0);
+  });
+
+  function prime(versionRows: unknown[]) {
+    selectMock.mockReturnValueOnce(selectChainResolving([agentDeviceRow]));
+    selectMock.mockReturnValue(selectChainResolving(versionRows));
+  }
+
+  async function beat(extra: Record<string, unknown> = {}) {
+    return buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...minimalHeartbeatBody, agentVersion: '0.105.1', ...extra }),
+    });
+  }
+
+  type OfferBody = { upgradeTo?: string; helperUpgradeTo?: string; watchdogUpgradeTo?: string };
+
+  it('withholds the agent upgrade offer when the build cannot accept the served edition', async () => {
+    const { agentAcceptsServedEdition } = await import('./helpers');
+    vi.mocked(agentAcceptsServedEdition).mockImplementation(() => false);
+    prime([{ version: '0.66.0' }]);
+
+    const resp = await beat();
+    expect(resp.status).toBe(200);
+    // Main-branch "no offer" serializes as null (matching the un-promoted
+    // rollout contract above), which agents treat the same as absent.
+    const body = (await resp.json()) as OfferBody;
+    expect(body.upgradeTo).toBeFalsy();
+  });
+
+  it('withholds the helper offer — including the ungated bootstrap install (no helperVersion reported)', async () => {
+    const { agentAcceptsServedEdition } = await import('./helpers');
+    vi.mocked(agentAcceptsServedEdition).mockImplementation(() => false);
+    prime([{ version: '0.66.0' }]);
+
+    const resp = await beat(); // no helperVersion → would bootstrap-offer latest
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as OfferBody;
+    expect(body.helperUpgradeTo).toBeUndefined();
+  });
+
+  it('withholds the watchdog offer — including the ungated bootstrap install', async () => {
+    const { agentAcceptsServedEdition } = await import('./helpers');
+    vi.mocked(agentAcceptsServedEdition).mockImplementation(() => false);
+    prime([{ version: '0.66.0' }]); // watchdogVersion absent on row + beat → bootstrap path
+
+    const resp = await beat();
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as OfferBody;
+    expect(body.watchdogUpgradeTo).toBeUndefined();
+  });
+
+  it('offers normally when the build accepts the served edition (gate true)', async () => {
+    prime([{ version: '0.66.0' }]);
+
+    const resp = await beat();
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as OfferBody;
+    expect(body.upgradeTo).toBe('0.66.0');
+  });
+
+  it('consults the gate with THIS beat’s payload values (reported edition + version), not stored columns', async () => {
+    const { agentAcceptsServedEdition } = await import('./helpers');
+    prime([{ version: '0.66.0' }]);
+
+    const resp = await beat({ agentEdition: 'self-host' });
+    expect(resp.status).toBe(200);
+    expect(vi.mocked(agentAcceptsServedEdition)).toHaveBeenCalledWith({
+      reportedEdition: 'self-host',
+      agentVersion: '0.105.1',
+    });
+  });
+
+  it('logs the withhold once per device per process, not per heartbeat', async () => {
+    const { agentAcceptsServedEdition } = await import('./helpers');
+    vi.mocked(agentAcceptsServedEdition).mockImplementation(() => false);
+    const { __resetEditionWithheldWarnCacheForTests } = await import('./heartbeat');
+    __resetEditionWithheldWarnCacheForTests();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      prime([{ version: '0.66.0' }]);
+      await beat();
+      prime([{ version: '0.66.0' }]);
+      await beat();
+      const withheldWarns = warnSpy.mock.calls.filter((c) => String(c[0]).includes('#4072'));
+      expect(withheldWarns).toHaveLength(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  describe('watchdog failover branch', () => {
+    const sixteenMinutesAgo = new Date(Date.now() - 16 * 60 * 1000);
+
+    function primeWatchdog() {
+      selectMock.mockReturnValueOnce(
+        selectChainResolving([
+          {
+            id: 'device-1', orgId: 'org-1', hostname: 'host', osType: 'windows',
+            architecture: 'amd64', agentVersion: '0.65.10', watchdogVersion: '0.65.20',
+            lastSeenAt: sixteenMinutesAgo, mainAgentSilentSince: new Date(),
+          },
+        ]),
+      );
+      selectMock.mockReturnValue(selectChainResolving([{ version: '0.66.0' }]));
+    }
+
+    async function watchdogBeat() {
+      return buildWatchdogApp().request('/agents/device-1/heartbeat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          role: 'watchdog', agentVersion: '0.65.20', agentEdition: 'hosted', watchdogState: 'FAILOVER',
+        }),
+      });
+    }
+
+    it('withholds BOTH the watchdog self-update and the agent recovery offer when the watchdog build cannot accept the served edition', async () => {
+      const { agentAcceptsServedEdition } = await import('./helpers');
+      vi.mocked(agentAcceptsServedEdition).mockImplementation(() => false);
+      primeWatchdog();
+
+      const resp = await watchdogBeat();
+      expect(resp.status).toBe(200);
+      const body = (await resp.json()) as OfferBody;
+      expect(body.watchdogUpgradeTo).toBeUndefined();
+      expect(body.upgradeTo).toBeUndefined();
+    });
+
+    it('consults the gate with the WATCHDOG’s own payload (it is the binary that downloads in failover)', async () => {
+      const { agentAcceptsServedEdition } = await import('./helpers');
+      primeWatchdog();
+
+      const resp = await watchdogBeat();
+      expect(resp.status).toBe(200);
+      expect(vi.mocked(agentAcceptsServedEdition)).toHaveBeenCalledWith({
+        reportedEdition: 'hosted',
+        agentVersion: '0.65.20',
+      });
+      const body = (await resp.json()) as OfferBody;
+      expect(body.watchdogUpgradeTo).toBe('0.66.0');
+      expect(body.upgradeTo).toBe('0.66.0');
+    });
   });
 });
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -1,12 +1,11 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { zValidator } from '../../lib/validation';
-import { and, desc, eq, notInArray } from 'drizzle-orm';
+import { and, eq, notInArray } from 'drizzle-orm';
 import { db, runOutsideDbContext, withDbAccessContext, withSystemDbAccessContext } from '../../db';
 import {
   devices,
   deviceMetrics,
-  agentVersions,
   agentLogs,
   onedriveDeviceState,
 } from '../../db/schema';
@@ -77,28 +76,88 @@ export function detectWatchdogStateCollapse(
 
 // #4072 — one withhold warn per device per process. The edition gate fires on
 // every heartbeat of an affected device (~60s apart) for as long as it stays
-// on an incompatible build, so an undeduped warn is log spam at fleet scale;
-// bounded by fleet size, same shape as the pin-miss/malformed-window caches.
+// on an incompatible build, so an undeduped warn is log spam at fleet scale.
+// Uncapped Set, deliberately: growth is bounded by the count of affected
+// devices (each entry is one device id), unlike the per-beat watchdog restart
+// cache that needs eviction.
+// The entry is REMOVED when the device accepts again (heartbeat main branch),
+// so a later regression to an incompatible build re-warns instead of being
+// permanently consumed by the first episode.
 const warnedEditionWithheldDevices = new Set<string>();
+// Separate dedupe for the far more severe failover-recovery withhold (device
+// stuck OFFLINE, not idling) — its error must not be suppressed by an earlier
+// routine offer-withhold warn for the same device.
+const warnedEditionRecoveryWithheldDevices = new Set<string>();
+// One aggregate Sentry event per process for routine offer withholds. Console
+// lines rotate out of droplet docker logs; this is the same "invisible
+// fleet-wide freeze must reach Sentry" bar the pin-miss path documents.
+let editionWithheldCaptured = false;
 
 export function __resetEditionWithheldWarnCacheForTests(): void {
   warnedEditionWithheldDevices.clear();
+  warnedEditionRecoveryWithheldDevices.clear();
+  editionWithheldCaptured = false;
 }
 
-function warnEditionOfferWithheld(args: {
+type EditionWithheldContext = {
   deviceId: string;
   reportedEdition: string | null | undefined;
   agentVersion: string | null | undefined;
-}): void {
+};
+
+// The message states the OBSERVED facts and keeps every remediation
+// conditional — agentAcceptsServedEdition returns false for several distinct
+// states (silent post-cutover self-host build, hosted build on a self-host
+// server, unusable version) and asserting one cause for all of them sends an
+// operator down the wrong path.
+function editionWithheldDetail(args: EditionWithheldContext): string {
+  return (
+    `this server serves ${getBinaryEdition()}-edition artifacts and the downloading build ` +
+    `(reported edition=${args.reportedEdition ?? 'none'}, version=${args.agentVersion ?? 'unknown'}) ` +
+    `cannot be confirmed to accept them — the agent-side edition check refuses a mismatched ` +
+    `artifact AFTER download and retries every heartbeat forever, so the server withholds instead. ` +
+    `If the build is a silent ≥0.105.0 self-host agent, recover it with a ` +
+    `${getBinaryEdition()}-edition installer or an agent release that reports its edition; ` +
+    `if it reports the other edition, it is enrolled against a server of the wrong edition.`
+  );
+}
+
+function warnEditionOfferWithheld(args: EditionWithheldContext): void {
   if (warnedEditionWithheldDevices.has(args.deviceId)) return;
   warnedEditionWithheldDevices.add(args.deviceId);
   console.warn(
-    `[agents] update offers withheld for device ${args.deviceId} (#4072): this deployment serves ` +
-      `artifacts the device's build would refuse after download (reported edition=` +
-      `${args.reportedEdition ?? 'none'}, version=${args.agentVersion ?? 'unknown'}). ` +
-      `The device idles on its current version instead of wedging in an update-retry loop; ` +
-      `recover it with an installer of the served edition, or an agent release that can ` +
-      `accept the transition.`,
+    `[agents] update offers withheld for device ${args.deviceId} (#4072): ${editionWithheldDetail(args)} ` +
+      `The device idles on its current version.`,
+  );
+  if (!editionWithheldCaptured) {
+    editionWithheldCaptured = true;
+    captureException(
+      new Error(
+        `Update offers withheld by the artifact-edition gate (#4072) for at least one device ` +
+          `(first: ${args.deviceId}). Affected devices idle on their current version until ` +
+          `recovered; see per-device [agents] warns for details.`,
+      ),
+    );
+  }
+}
+
+// Failover-branch variant: the watchdog is the ONLY recovery path for a
+// wedged main agent (#1104), so withholding it means the device stays DOWN,
+// not merely un-upgraded. Error level + per-device Sentry, deduped.
+function warnEditionRecoveryWithheld(args: EditionWithheldContext): void {
+  if (warnedEditionRecoveryWithheldDevices.has(args.deviceId)) return;
+  warnedEditionRecoveryWithheldDevices.add(args.deviceId);
+  console.error(
+    `[agents] agent RECOVERY withheld for device ${args.deviceId} (#4072): the main agent is ` +
+      `silent and the watchdog — the only recovery path — would refuse the recovery artifact: ` +
+      `${editionWithheldDetail(args)} This device stays down until manually recovered.`,
+  );
+  captureException(
+    new Error(
+      `Agent recovery withheld by the artifact-edition gate for device ${args.deviceId} ` +
+        `(#4072): main agent silent, watchdog cannot accept the served artifact edition. ` +
+        `Manual recovery required.`,
+    ),
   );
 }
 
@@ -523,8 +582,22 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     // edition. A watchdog build that would refuse the served artifact edition
     // after download must not be offered it — the refusal just re-arms every
     // failover beat.
+    //
+    // A SILENT watchdog is NOT evidence of a self-host build the way a silent
+    // main agent is: watchdog edition reporting first ships alongside this
+    // gate, so every watchdog in the field today is silent — including the
+    // hosted fleet's, whose recovery path (#1104) must not be withheld. Fall
+    // back to the device row's agentEdition, written unconditionally from
+    // every MAIN-agent beat: agent and watchdog install and upgrade from the
+    // same lane, so the main agent's build edition identifies the watchdog's.
+    // If both are silent (the stranded pre-telemetry band), the version-band
+    // inference inside the predicate takes over. Known imprecision: a device
+    // whose main agent already reports 'self-host' (transition-capable) but
+    // whose watchdog is still an older self-host build gets a hosted offer
+    // its watchdog refuses — failover-only, self-heals once the watchdog
+    // catches up via the main branch.
     const watchdogAcceptsServedEdition = agentAcceptsServedEdition({
-      reportedEdition: data.agentEdition,
+      reportedEdition: data.agentEdition ?? device.agentEdition,
       agentVersion: data.agentVersion,
     });
 
@@ -575,6 +648,26 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     // agent (which self-updates from its own heartbeat) and the watchdog never
     // both write the same binary.
     let agentUpgradeTo: string | undefined;
+    if (
+      mainAgentSilent &&
+      normalizedArch &&
+      device.agentVersion &&
+      !device.agentVersion.startsWith('dev-') &&
+      !watchdogAcceptsServedEdition
+    ) {
+      // #4072 — the ONLY recovery path for this wedged main agent is being
+      // withheld by the edition gate. That leaves the device DOWN, so it must
+      // be loudly observable — not folded into the routine withhold warn
+      // (which may have fired weeks earlier from the upgrade branch, or never,
+      // when no watchdog target resolves).
+      warnEditionRecoveryWithheld({
+        deviceId: device.id,
+        reportedEdition: data.agentEdition,
+        agentVersion: data.agentVersion,
+      });
+    } else if (mainAgentSilent && watchdogAcceptsServedEdition) {
+      warnedEditionRecoveryWithheldDevices.delete(device.id);
+    }
     if (
       mainAgentSilent &&
       normalizedArch &&
@@ -1075,6 +1168,11 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       reportedEdition: data.agentEdition,
       agentVersion: data.agentVersion,
     });
+  } else if (acceptsServedEdition) {
+    // Re-arm the per-device withhold warn: if this device later regresses to
+    // an incompatible build (same process), that is a fresh episode and must
+    // log again rather than being consumed by the first one.
+    warnedEditionWithheldDevices.delete(device.id);
   }
 
   if (normalizedArch && acceptsServedEdition) {
@@ -1120,30 +1218,26 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   // care why the download started) (#4072).
   if (normalizedArch && acceptsServedEdition) {
     try {
-      const [latestHelper] = await db
-        .select({ version: agentVersions.version })
-        .from(agentVersions)
-        .where(
-          and(
-            eq(agentVersions.platform, device.osType),
-            eq(agentVersions.architecture, normalizedArch),
-            eq(agentVersions.component, 'helper'),
-            eq(agentVersions.isLatest, true),
-            // Each server only serves its own build edition (#4072).
-            eq(agentVersions.edition, getBinaryEdition())
-          )
-        )
-        .orderBy(desc(agentVersions.createdAt))
-        .limit(1);
+      // Global latest for the helper via the same edition-scoped resolver as
+      // the agent/watchdog channels (#4072 — replaces an inline query that
+      // was not edition-scoped). The helper channel is unpinnable, hence
+      // pin: null — which is exactly the isLatest lookup the inline query did.
+      const latestHelperVersion = await resolvePinnedUpgradeTarget({
+        component: 'helper',
+        platform: device.osType,
+        architecture: normalizedArch,
+        pin: null,
+        agentId,
+      });
 
-if (latestHelper) {
+      if (latestHelperVersion) {
         // If agent reports no helper version, always upgrade (bootstraps first install
         // or recovers from broken helper that never wrote its status file) — bootstrap
         // is NOT subject to the org update policy. Version-to-version upgrades are.
         if (!data.helperVersion) {
-          helperUpgradeTo = latestHelper.version;
-        } else if (updateGateAllows && compareAgentVersions(latestHelper.version, data.helperVersion) > 0) {
-          helperUpgradeTo = latestHelper.version;
+          helperUpgradeTo = latestHelperVersion;
+        } else if (updateGateAllows && compareAgentVersions(latestHelperVersion, data.helperVersion) > 0) {
+          helperUpgradeTo = latestHelperVersion;
         }
       }
     } catch (err) {

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -28,6 +28,7 @@ import {
   buildPatchSourceConfigUpdate,
   getOrgAgentUpdateConfig,
   resolvePinnedUpgradeTarget,
+  agentAcceptsServedEdition,
   type AgentVersionPins,
   type OnedriveConfigUpdate,
   type HelperSettings,
@@ -50,6 +51,7 @@ import { decryptClaimedCommandsForDelivery } from '../../services/commandDeliver
 import { normalizeReportedScriptSecretEnvVersion } from '../../services/scriptSecretDelivery';
 import { redactSecretsDeep } from '../../services/secretRedaction';
 import { recordAgentHeartbeat, resolveResponseStatus } from '../metrics';
+import { getBinaryEdition } from '../../services/binaryEdition';
 
 /**
  * #1121 — pure collapse detector for the watchdogState tolerance gap.
@@ -71,6 +73,33 @@ export function detectWatchdogStateCollapse(
       ? rawState.slice(0, 100)
       : JSON.stringify(rawState)?.slice(0, 100);
   return { field: 'watchdogState', rawValue };
+}
+
+// #4072 — one withhold warn per device per process. The edition gate fires on
+// every heartbeat of an affected device (~60s apart) for as long as it stays
+// on an incompatible build, so an undeduped warn is log spam at fleet scale;
+// bounded by fleet size, same shape as the pin-miss/malformed-window caches.
+const warnedEditionWithheldDevices = new Set<string>();
+
+export function __resetEditionWithheldWarnCacheForTests(): void {
+  warnedEditionWithheldDevices.clear();
+}
+
+function warnEditionOfferWithheld(args: {
+  deviceId: string;
+  reportedEdition: string | null | undefined;
+  agentVersion: string | null | undefined;
+}): void {
+  if (warnedEditionWithheldDevices.has(args.deviceId)) return;
+  warnedEditionWithheldDevices.add(args.deviceId);
+  console.warn(
+    `[agents] update offers withheld for device ${args.deviceId} (#4072): this deployment serves ` +
+      `artifacts the device's build would refuse after download (reported edition=` +
+      `${args.reportedEdition ?? 'none'}, version=${args.agentVersion ?? 'unknown'}). ` +
+      `The device idles on its current version instead of wedging in an update-retry loop; ` +
+      `recover it with an installer of the served edition, or an agent release that can ` +
+      `accept the transition.`,
+  );
 }
 
 const WATCHDOG_RESTART_LOG_INTERVAL_MS = 60 * 60 * 1000;
@@ -487,6 +516,18 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       agent?.claimTypeAllowlist
     );
 
+    // #4072 — in FAILOVER the WATCHDOG is the binary that downloads (its own
+    // self-update and the doUpdateAgent recovery path both run its updater),
+    // so the edition gate keys on the watchdog's payload: data.agentVersion
+    // is the watchdog's version here, and new watchdog builds report their
+    // edition. A watchdog build that would refuse the served artifact edition
+    // after download must not be offered it — the refusal just re-arms every
+    // failover beat.
+    const watchdogAcceptsServedEdition = agentAcceptsServedEdition({
+      reportedEdition: data.agentEdition,
+      agentVersion: data.agentVersion,
+    });
+
     // Check for watchdog upgrade. Honors the tenant's watchdog pin (issue
     // #2124) via the same resolver as the main path; fail-closed to no upgrade
     // when the pinned version has no build for this platform/arch.
@@ -505,13 +546,19 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
           agentId,
         });
 
-        if (targetWatchdog) {
+        if (targetWatchdog && watchdogAcceptsServedEdition) {
           if (!data.agentVersion.startsWith('dev-')) {
             const cmp = compareAgentVersions(targetWatchdog, data.agentVersion);
             if (cmp > 0) {
               watchdogUpgradeTo = targetWatchdog;
             }
           }
+        } else if (targetWatchdog) {
+          warnEditionOfferWithheld({
+            deviceId: device.id,
+            reportedEdition: data.agentEdition,
+            agentVersion: data.agentVersion,
+          });
         }
       } catch (err) {
         console.error(`[agents] failed to evaluate watchdog upgrade target for ${agentId}:`, err);
@@ -532,6 +579,9 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       mainAgentSilent &&
       normalizedArch &&
       pinsResolved &&
+      // #4072 — the watchdog downloads the recovery binary, so ITS edition
+      // capability gates this offer (not the wedged main agent's).
+      watchdogAcceptsServedEdition &&
       device.agentVersion &&
       !device.agentVersion.startsWith('dev-')
     ) {
@@ -1007,7 +1057,27 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   // component bootstrap branches never do, so a first install is never gated.
   let upgradeTo: string | null = null;
   const normalizedArch = normalizeAgentArchitecture(device.architecture);
-  if (normalizedArch) {
+  // #4072 — the main agent's updater performs EVERY download on this branch
+  // (its own binary, the helper, the watchdog), and since v0.105.0 it refuses
+  // an artifact whose signed-manifest edition mismatches its build — AFTER
+  // download, retrying every heartbeat forever. Offer nothing this build
+  // would refuse; the device then idles quietly on its current version.
+  // Keyed on THIS beat's payload (not stored columns): the stored edition is
+  // one beat stale, exactly wrong on the first beat after a swap.
+  const acceptsServedEdition = agentAcceptsServedEdition({
+    reportedEdition: data.agentEdition,
+    agentVersion: data.agentVersion,
+  });
+
+  if (normalizedArch && !acceptsServedEdition) {
+    warnEditionOfferWithheld({
+      deviceId: device.id,
+      reportedEdition: data.agentEdition,
+      agentVersion: data.agentVersion,
+    });
+  }
+
+  if (normalizedArch && acceptsServedEdition) {
     try {
       // Resolve the effective target: the tenant's agent pin (issue #2124) when
       // set, else the globally promoted latest. Fails closed if the pinned
@@ -1043,8 +1113,12 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
 
   let helperUpgradeTo: string | null = null;
   // Check for helper upgrade even if agent doesn't report a version yet
-  // (bootstraps the first install or recovers from a broken helper that never wrote status)
-  if (normalizedArch) {
+  // (bootstraps the first install or recovers from a broken helper that never
+  // wrote status). Gated on acceptsServedEdition like the agent offer above —
+  // the MAIN AGENT downloads the helper artifact, so its edition capability is
+  // what matters, and bootstrap is not exempt (the download refusal doesn't
+  // care why the download started) (#4072).
+  if (normalizedArch && acceptsServedEdition) {
     try {
       const [latestHelper] = await db
         .select({ version: agentVersions.version })
@@ -1054,7 +1128,9 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
             eq(agentVersions.platform, device.osType),
             eq(agentVersions.architecture, normalizedArch),
             eq(agentVersions.component, 'helper'),
-            eq(agentVersions.isLatest, true)
+            eq(agentVersions.isLatest, true),
+            // Each server only serves its own build edition (#4072).
+            eq(agentVersions.edition, getBinaryEdition())
           )
         )
         .orderBy(desc(agentVersions.createdAt))
@@ -1076,7 +1152,9 @@ if (latestHelper) {
   }
 
   let watchdogUpgradeTo: string | null = null;
-  if (normalizedArch) {
+  // acceptsServedEdition: the main agent downloads the watchdog artifact too,
+  // bootstrap included — same gate rationale as the helper block above (#4072).
+  if (normalizedArch && acceptsServedEdition) {
     try {
       // Effective watchdog target: the tenant's watchdog pin (issue #2124) when
       // set, else the globally promoted latest. Independent of the agent pin.

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -122,12 +122,18 @@ function editionWithheldDetail(args: EditionWithheldContext): string {
   );
 }
 
-function warnEditionOfferWithheld(args: EditionWithheldContext): void {
-  if (warnedEditionWithheldDevices.has(args.deviceId)) return;
-  warnedEditionWithheldDevices.add(args.deviceId);
+// Dedupe entries are keyed per (device, reporting role): the main-agent and
+// watchdog branches gate on DIFFERENT binaries' capabilities, and a device
+// whose two verdicts persistently disagree (e.g. main agent pre-band, watchdog
+// inside it) must not have the watchdog's warn re-added by every failover beat
+// and deleted by every main beat — that would defeat the dedupe entirely.
+function warnEditionOfferWithheld(args: EditionWithheldContext & { role: 'agent' | 'watchdog' }): void {
+  const key = `${args.deviceId}:${args.role}`;
+  if (warnedEditionWithheldDevices.has(key)) return;
+  warnedEditionWithheldDevices.add(key);
   console.warn(
-    `[agents] update offers withheld for device ${args.deviceId} (#4072): ${editionWithheldDetail(args)} ` +
-      `The device idles on its current version.`,
+    `[agents] update offers withheld for device ${args.deviceId} (${args.role} path, #4072): ` +
+      `${editionWithheldDetail(args)} The device idles on its current version.`,
   );
   if (!editionWithheldCaptured) {
     editionWithheldCaptured = true;
@@ -141,22 +147,27 @@ function warnEditionOfferWithheld(args: EditionWithheldContext): void {
   }
 }
 
-// Failover-branch variant: the watchdog is the ONLY recovery path for a
-// wedged main agent (#1104), so withholding it means the device stays DOWN,
-// not merely un-upgraded. Error level + per-device Sentry, deduped.
+// Failover-branch variant: the binary-replacement recovery (#1104) is the
+// fallback for a wedged main-agent BINARY, so withholding it can leave the
+// device down if the watchdog's restart-based recovery is also failing.
+// Error level + per-device Sentry, deduped; the entry is cleared by any live
+// main-agent beat (proof of recovery), so a later wedge alerts again.
+// Wording stays hedged like editionWithheldDetail: the gate establishes
+// non-confirmation, not a certain refusal.
 function warnEditionRecoveryWithheld(args: EditionWithheldContext): void {
   if (warnedEditionRecoveryWithheldDevices.has(args.deviceId)) return;
   warnedEditionRecoveryWithheldDevices.add(args.deviceId);
   console.error(
     `[agents] agent RECOVERY withheld for device ${args.deviceId} (#4072): the main agent is ` +
-      `silent and the watchdog — the only recovery path — would refuse the recovery artifact: ` +
-      `${editionWithheldDetail(args)} This device stays down until manually recovered.`,
+      `silent and the watchdog's binary-replacement recovery path is being withheld because ` +
+      `${editionWithheldDetail(args)} If the watchdog's restart-based recovery also fails, ` +
+      `this device may stay down until manually recovered.`,
   );
   captureException(
     new Error(
       `Agent recovery withheld by the artifact-edition gate for device ${args.deviceId} ` +
-        `(#4072): main agent silent, watchdog cannot accept the served artifact edition. ` +
-        `Manual recovery required.`,
+        `(#4072): main agent silent, watchdog cannot be confirmed to accept the served ` +
+        `artifact edition. Manual recovery may be required.`,
     ),
   );
 }
@@ -596,8 +607,13 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     // whose watchdog is still an older self-host build gets a hosted offer
     // its watchdog refuses — failover-only, self-heals once the watchdog
     // catches up via the main branch.
+    // Hoisted so the warn calls below print the value that actually DECIDED
+    // (the fallback included) — logging the silent payload as "none" when the
+    // stored edition drove the withhold would steer the operator to the wrong
+    // remediation.
+    const effectiveWatchdogEdition = data.agentEdition ?? device.agentEdition;
     const watchdogAcceptsServedEdition = agentAcceptsServedEdition({
-      reportedEdition: data.agentEdition ?? device.agentEdition,
+      reportedEdition: effectiveWatchdogEdition,
       agentVersion: data.agentVersion,
     });
 
@@ -629,7 +645,8 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
         } else if (targetWatchdog) {
           warnEditionOfferWithheld({
             deviceId: device.id,
-            reportedEdition: data.agentEdition,
+            role: 'watchdog',
+            reportedEdition: effectiveWatchdogEdition,
             agentVersion: data.agentVersion,
           });
         }
@@ -662,10 +679,14 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
       // when no watchdog target resolves).
       warnEditionRecoveryWithheld({
         deviceId: device.id,
-        reportedEdition: data.agentEdition,
+        reportedEdition: effectiveWatchdogEdition,
         agentVersion: data.agentVersion,
       });
-    } else if (mainAgentSilent && watchdogAcceptsServedEdition) {
+    } else if (watchdogAcceptsServedEdition) {
+      // Residual re-arm path (manual watchdog reinstall while the main agent
+      // stays silent). The PRIMARY re-arm is any live main-agent beat — see
+      // the main branch — because a main-agent beat both proves recovery and
+      // is what refreshes lastSeenAt, ending mainAgentSilent.
       warnedEditionRecoveryWithheldDevices.delete(device.id);
     }
     if (
@@ -1162,17 +1183,23 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     agentVersion: data.agentVersion,
   });
 
+  // A live main-agent beat is proof the agent is not wedged: re-arm the
+  // failover-recovery error so a LATER wedge (same process, possibly weeks
+  // on) alerts again instead of being consumed by the first episode.
+  warnedEditionRecoveryWithheldDevices.delete(device.id);
+
   if (normalizedArch && !acceptsServedEdition) {
     warnEditionOfferWithheld({
       deviceId: device.id,
+      role: 'agent',
       reportedEdition: data.agentEdition,
       agentVersion: data.agentVersion,
     });
   } else if (acceptsServedEdition) {
-    // Re-arm the per-device withhold warn: if this device later regresses to
-    // an incompatible build (same process), that is a fresh episode and must
-    // log again rather than being consumed by the first one.
-    warnedEditionWithheldDevices.delete(device.id);
+    // Re-arm THIS branch's withhold warn: if the device later regresses to an
+    // incompatible build (same process), that is a fresh episode and must log
+    // again. Only the agent-role key — the watchdog branch owns its own.
+    warnedEditionWithheldDevices.delete(`${device.id}:agent`);
   }
 
   if (normalizedArch && acceptsServedEdition) {

--- a/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
+++ b/apps/api/src/routes/agents/helpers.agentUpdatePolicy.test.ts
@@ -20,13 +20,14 @@
  * the module references at load time. The lookup is a single org⋈partner joined
  * SELECT, so each `_set(...)` seeds the one row that join returns.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — vi.hoisted() must run before any import.
 // ---------------------------------------------------------------------------
 const { dbMock } = vi.hoisted(() => {
   let nextResult: unknown[] = [];
+  const chains: any[] = [];
 
   const makeSelectChain = () => {
     const chain: any = {
@@ -37,6 +38,7 @@ const { dbMock } = vi.hoisted(() => {
       limit: vi.fn(() => Promise.resolve(nextResult)),
     };
     chain.then = (resolve: any, reject: any) => Promise.resolve(nextResult).then(resolve, reject);
+    chains.push(chain);
     return chain;
   };
 
@@ -44,6 +46,11 @@ const { dbMock } = vi.hoisted(() => {
     select: vi.fn(() => makeSelectChain()),
     _setResult(rows: unknown[]) {
       nextResult = rows;
+    },
+    /** The `.where()` argument of the most recent select chain. */
+    _lastWhereArg(): unknown {
+      const chain = chains[chains.length - 1];
+      return chain?.where.mock.calls[0]?.[0];
     },
   };
 
@@ -100,6 +107,7 @@ vi.mock('../../db/schema', () => ({
     component: 'av.component',
     isLatest: 'av.is_latest',
     createdAt: 'av.created_at',
+    edition: 'av.edition',
   },
 }));
 
@@ -136,8 +144,10 @@ import {
   getOrgAgentUpdatePolicy,
   getOrgAgentUpdateConfig,
   resolvePinnedUpgradeTarget,
+  agentAcceptsServedEdition,
   __resetMalformedWindowWarnCache,
 } from './helpers';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 const ORG_ID = '00000000-0000-4000-8000-000000000001';
 
@@ -462,5 +472,118 @@ describe('resolvePinnedUpgradeTarget', () => {
     dbMock._setResult([]);
     await resolvePinnedUpgradeTarget({ ...base, pin: '0.85.0', agentId: 'device-2' });
     expect(vi.mocked(captureException)).toHaveBeenCalledTimes(1);
+  });
+
+  // #4072 — both resolver queries (latest-promoted and exact-pin) must be
+  // scoped to THIS server's own edition, like every other serving path
+  // (download, register, promote). An unscoped query can resolve a row of the
+  // OTHER edition when both are registered for the same version, offering an
+  // artifact the agent will hard-refuse after download. Compiled via PgDialect
+  // (mock columns become bound params) so the assertion pins the actual WHERE
+  // structure, not a substring.
+  describe('edition scoping (#4072)', () => {
+    const OLD_ENV = process.env.BINARY_EDITION;
+    afterEach(() => {
+      if (OLD_ENV === undefined) delete process.env.BINARY_EDITION;
+      else process.env.BINARY_EDITION = OLD_ENV;
+    });
+
+    function compiledWhere() {
+      return new PgDialect().sqlToQuery(dbMock._lastWhereArg() as never);
+    }
+
+    it('latest-promoted lookup (pin=null) filters on agent_versions.edition = this server edition', async () => {
+      process.env.BINARY_EDITION = 'hosted';
+      dbMock._setResult([{ version: '0.88.0' }]);
+      await resolvePinnedUpgradeTarget({ ...base, pin: null });
+      const { params } = compiledWhere();
+      const editionColIdx = params.indexOf('av.edition');
+      expect(editionColIdx).toBeGreaterThanOrEqual(0);
+      expect(params[editionColIdx + 1]).toBe('hosted');
+    });
+
+    it('exact-pin lookup filters on agent_versions.edition = this server edition', async () => {
+      delete process.env.BINARY_EDITION; // default self-host
+      dbMock._setResult([{ version: '0.85.0' }]);
+      await resolvePinnedUpgradeTarget({ ...base, pin: '0.85.0' });
+      const { params } = compiledWhere();
+      const editionColIdx = params.indexOf('av.edition');
+      expect(editionColIdx).toBeGreaterThanOrEqual(0);
+      expect(params[editionColIdx + 1]).toBe('self-host');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agentAcceptsServedEdition (#4072) — can the binary doing the download apply
+// an artifact of THIS server's edition? The updater's edition check (agent
+// v0.105.0+) runs client-side after download; offering a version the build
+// will refuse wedges the device in a permanent ~60s retry loop. A reported
+// agentEdition (either value) also marks the build as carrying the one-way
+// self-host → hosted allowance, since both shipped in the same agent release.
+// ---------------------------------------------------------------------------
+describe('agentAcceptsServedEdition (#4072)', () => {
+  const OLD_ENV = process.env.BINARY_EDITION;
+  afterEach(() => {
+    if (OLD_ENV === undefined) delete process.env.BINARY_EDITION;
+    else process.env.BINARY_EDITION = OLD_ENV;
+  });
+
+  describe('serving hosted artifacts (BINARY_EDITION=hosted)', () => {
+    beforeEach(() => {
+      process.env.BINARY_EDITION = 'hosted';
+    });
+
+    it('accepts when the agent reports edition hosted', () => {
+      expect(agentAcceptsServedEdition({ reportedEdition: 'hosted', agentVersion: '0.107.1' })).toBe(true);
+    });
+
+    it('accepts when the agent reports edition self-host (build carries the one-way transition allowance)', () => {
+      expect(agentAcceptsServedEdition({ reportedEdition: 'self-host', agentVersion: '0.109.0' })).toBe(true);
+    });
+
+    it('accepts a silent agent OLDER than 0.105.0 (predates the edition check entirely)', () => {
+      expect(agentAcceptsServedEdition({ reportedEdition: undefined, agentVersion: '0.104.9' })).toBe(true);
+      expect(agentAcceptsServedEdition({ reportedEdition: null, agentVersion: '0.94.0' })).toBe(true);
+    });
+
+    it('withholds from a silent agent in the stranded band [0.105.0, 0.107.0) — it would hard-refuse the download', () => {
+      expect(agentAcceptsServedEdition({ reportedEdition: undefined, agentVersion: '0.105.0' })).toBe(false);
+      expect(agentAcceptsServedEdition({ reportedEdition: undefined, agentVersion: '0.105.1' })).toBe(false);
+      expect(agentAcceptsServedEdition({ reportedEdition: null, agentVersion: '0.106.5' })).toBe(false);
+    });
+
+    it('withholds from ANY silent agent ≥0.105.0 (a silent newer build is a self-host build without the transition allowance)', () => {
+      expect(agentAcceptsServedEdition({ reportedEdition: undefined, agentVersion: '0.107.1' })).toBe(false);
+      expect(agentAcceptsServedEdition({ reportedEdition: undefined, agentVersion: '0.108.0' })).toBe(false);
+    });
+
+    it('withholds from a silent 0.105.0 PRERELEASE — it carries the check even though semver orders it below 0.105.0', () => {
+      expect(agentAcceptsServedEdition({ reportedEdition: undefined, agentVersion: '0.105.0-rc.1' })).toBe(false);
+      // …while a prerelease of an OLDER core version predates the check.
+      expect(agentAcceptsServedEdition({ reportedEdition: undefined, agentVersion: '0.104.9-rc.1' })).toBe(true);
+    });
+
+    it('withholds when the version is missing or unparseable (fail closed; offer resumes once the agent reports)', () => {
+      expect(agentAcceptsServedEdition({ reportedEdition: undefined, agentVersion: undefined })).toBe(false);
+      expect(agentAcceptsServedEdition({ reportedEdition: undefined, agentVersion: null })).toBe(false);
+      expect(agentAcceptsServedEdition({ reportedEdition: undefined, agentVersion: 'dev-abc123' })).toBe(false);
+    });
+  });
+
+  describe('serving self-host artifacts (BINARY_EDITION unset/self-host)', () => {
+    beforeEach(() => {
+      delete process.env.BINARY_EDITION;
+    });
+
+    it('accepts self-host and silent agents of any version', () => {
+      expect(agentAcceptsServedEdition({ reportedEdition: 'self-host', agentVersion: '0.109.0' })).toBe(true);
+      expect(agentAcceptsServedEdition({ reportedEdition: undefined, agentVersion: '0.105.1' })).toBe(true);
+      expect(agentAcceptsServedEdition({ reportedEdition: null, agentVersion: '0.94.0' })).toBe(true);
+    });
+
+    it('withholds from a hosted-build agent — hosted builds hard-refuse self-host artifacts by design', () => {
+      expect(agentAcceptsServedEdition({ reportedEdition: 'hosted', agentVersion: '0.107.1' })).toBe(false);
+    });
   });
 });

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -58,6 +58,7 @@ import { resolvePatchConfigForDevice } from '../../services/featureConfigResolve
 import { policyOwnershipCondition, withPartnerWideVisibility } from '../../services/configPolicyOwnership';
 import { resolveUserGroupMembershipCached } from '../../services/onedriveGraph';
 import { captureException } from '../../services/sentry';
+import { getBinaryEdition } from '../../services/binaryEdition';
 import { redactSecretsDeep, redactOptionalSecretText } from '../../services/secretRedaction';
 import { CloudflareMtlsService } from '../../services/cloudflareMtls';
 import { normalizeCertificateSerial } from '../../services/agentCertificateBinding';
@@ -333,6 +334,67 @@ export function compareAgentVersions(leftRaw: string, rightRaw: string): number 
   if (!left.prerelease) return 1;
   if (!right.prerelease) return -1;
   return left.prerelease.localeCompare(right.prerelease);
+}
+
+/**
+ * The agent release that introduced the client-side artifact-edition check
+ * (updater.editionAllowed, #3349). Builds older than this never consult the
+ * manifest's edition field and can apply artifacts of either edition; builds
+ * from this version on refuse a mismatched edition AFTER download, so the
+ * server must not offer them one (#4072).
+ */
+export const AGENT_EDITION_CHECK_INTRODUCED = '0.105.0';
+
+/**
+ * Can the binary that would perform a download apply an artifact of THIS
+ * server's edition (#4072)?
+ *
+ * The updater's edition check runs agent-side after the download, so offering
+ * a version the build will refuse does not fail once — it wedges the device in
+ * a permanent ~60s retry loop (`status='updating'`, never converges, no
+ * server-side escape hatch). This predicate is the server-side gate: withhold
+ * the offer instead, and the device idles quietly on its current version.
+ *
+ * Inference, in order:
+ *  - A REPORTED agentEdition (either value) means the build both knows its
+ *    edition and — because the heartbeat reporting and the one-way
+ *    self-host → hosted allowance in updater.editionAllowed shipped in the
+ *    same agent release — can apply a hosted artifact. So when serving hosted,
+ *    any reporter is accepted; when serving self-host, a 'hosted' reporter is
+ *    refused (hosted builds hard-refuse self-host artifacts by design — that
+ *    direction would strip the host-policy allowlist and is never relaxed).
+ *  - A SILENT agent (no reported edition) is either a pre-0.105.0 build (no
+ *    edition check at all → accepts anything) or a self-host build without
+ *    the transition allowance (the stranded 0.105.0–0.106.x band, plus any
+ *    unfixed self-host build pointed at a hosted control plane → refuses
+ *    hosted). Split on the version that introduced the check. A missing or
+ *    unparseable version fails closed — the offer resumes on the next beat
+ *    once the agent reports something usable.
+ *
+ * `reportedEdition`/`agentVersion` must describe the binary that DOWNLOADS
+ * (this beat's payload values): the main agent for agent/helper/watchdog
+ * offers on the main branch, the watchdog itself on the failover branch.
+ */
+export function agentAcceptsServedEdition(args: {
+  reportedEdition: string | null | undefined;
+  agentVersion: string | null | undefined;
+}): boolean {
+  const served = getBinaryEdition();
+  if (served === 'self-host') {
+    return args.reportedEdition !== 'hosted';
+  }
+  if (args.reportedEdition === 'hosted' || args.reportedEdition === 'self-host') {
+    return true;
+  }
+  const version = args.agentVersion?.trim();
+  if (!version) return false;
+  // Compare the CORE version only: semver orders `0.105.0-rc.1` BELOW
+  // `0.105.0`, but a prerelease of the introducing version already carries
+  // the check. A prerelease of an older core (0.104.x-rc) predates it.
+  // (`dev-*` builds strip to an unparseable core and fail closed, same as
+  // any other unparseable version — compareAgentVersions returns 0.)
+  const core = version.split('-')[0] ?? version;
+  return compareAgentVersions(core, AGENT_EDITION_CHECK_INTRODUCED) < 0;
 }
 
 // ============================================
@@ -2347,6 +2409,11 @@ export async function resolvePinnedUpgradeTarget(args: {
           eq(agentVersions.architecture, architecture),
           eq(agentVersions.component, component),
           eq(agentVersions.isLatest, true),
+          // Each server only serves its own build edition (#4072) — same
+          // scoping as the download/register/promote paths. Without this, a
+          // row registered for the OTHER edition could be resolved and
+          // offered, and the agent would hard-refuse it after download.
+          eq(agentVersions.edition, getBinaryEdition()),
         ),
       )
       .orderBy(desc(agentVersions.createdAt)) // newest first if multiple isLatest rows exist
@@ -2363,6 +2430,8 @@ export async function resolvePinnedUpgradeTarget(args: {
         eq(agentVersions.architecture, architecture),
         eq(agentVersions.component, component),
         eq(agentVersions.version, pin),
+        // Edition-scoped like the latest-promoted lookup above (#4072).
+        eq(agentVersions.edition, getBinaryEdition()),
       ),
     )
     .limit(1);

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -2445,7 +2445,9 @@ export async function resolvePinnedUpgradeTarget(args: {
     // version) so a persistent misconfig captures ONCE per process, not per beat.
     console.warn(
       `[agents] update withheld for ${agentId ?? 'device'}: pinned ${component} version ` +
-        `"${pin}" has no registered build for ${platform}/${architecture} (fail closed)`,
+        `"${pin}" has no registered ${getBinaryEdition()}-edition build for ` +
+        `${platform}/${architecture} (fail closed; a build registered under the other ` +
+        `edition does not count — #4072)`,
     );
     const key = `${component}:${platform}:${architecture}:${pin}`;
     if (!warnedMissingPinBuilds.has(key)) {
@@ -2453,8 +2455,8 @@ export async function resolvePinnedUpgradeTarget(args: {
       captureException(
         new Error(
           `Agent update withheld (#2124): pinned ${component} version "${pin}" has no ` +
-            `registered build for ${platform}/${architecture}; fleet freeze until a build ` +
-            `is published or the pin is corrected.`,
+            `registered ${getBinaryEdition()}-edition build for ${platform}/${architecture}; ` +
+            `fleet freeze until a build is published under this edition or the pin is corrected.`,
         ),
       );
     }

--- a/apps/api/src/routes/agents/schemas.heartbeatTolerance.test.ts
+++ b/apps/api/src/routes/agents/schemas.heartbeatTolerance.test.ts
@@ -526,3 +526,29 @@ describe('desktopAccess Linux reasons', () => {
     expect(parsed.desktopAccess?.reason).toBeUndefined();
   });
 });
+
+// #4072 — agentEdition is offer-load-bearing: a reported edition is the
+// capability signal agentAcceptsServedEdition keys on, and a value swallowed
+// at this layer makes the agent look silent (offers withheld from ≥0.105.0
+// builds on a hosted server). Pin both directions of the wire contract here,
+// where the REAL schema runs (heartbeat.test.ts stubs the validator).
+describe('heartbeatSchema — agentEdition passthrough (#4072)', () => {
+  const minimal = {
+    status: 'ok' as const,
+    agentVersion: '0.109.0',
+  };
+
+  it.each(['self-host', 'hosted'] as const)('passes agentEdition %s through parse', (edition) => {
+    const result = heartbeatSchema.safeParse({ ...minimal, agentEdition: edition });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.agentEdition).toBe(edition);
+  });
+
+  it('coerces an unknown edition to undefined WITHOUT rejecting the heartbeat (future edition must degrade to silent)', () => {
+    const result = heartbeatSchema.safeParse({ ...minimal, agentEdition: 'enterprise' });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.agentEdition).toBeUndefined();
+  });
+});

--- a/apps/api/src/routes/agents/schemas.ts
+++ b/apps/api/src/routes/agents/schemas.ts
@@ -263,8 +263,13 @@ export const heartbeatSchema = z.object({
     scriptSecretEnvVersion: z.number().int().optional().catch(undefined),
   }).optional().catch(undefined),
   // Migration-banner Task 2 — self-reported install edition + whether the
-  // agent believes it needs to migrate hosted↔self-host. Informational: a bad
-  // value drops (.catch) rather than 400-ing the heartbeat.
+  // agent believes it needs to migrate hosted↔self-host. Since #4072 this is
+  // NOT merely informational: a reported edition is the capability signal
+  // that gates update-offer delivery (agentAcceptsServedEdition), and a
+  // value swallowed here makes the agent look silent — which on a hosted
+  // server means offers are withheld from a ≥0.105.0 build. The .catch is
+  // still correct (a future third edition must degrade to "silent", not
+  // 400 the heartbeat), but changes here are offer-load-bearing.
   agentEdition: z.enum(['hosted', 'self-host']).optional().catch(undefined),
   migrationRequired: z.boolean().optional().catch(undefined),
 });


### PR DESCRIPTION
Closes #4072

## Problem

An agent built as the **self-host** edition that also carries the manifest edition check (field band **0.105.0–0.106.x**) can never auto-update to a **hosted**-edition artifact. `updater.editionAllowed` rejects the artifact *after* download, the device wedges at `status='updating'`, and retries every ~60s indefinitely. Pinning doesn't help (the refusal is agent-side), and agents on both sides of the band update fine, so a two-sample canary reads green.

## What this changes

**Agent (`agent/internal/…`)**
- `updater/edition.go` — one-way **self-host → hosted** acceptance. Both call sites run strictly after Ed25519 manifest verification against the trust roots, and a hosted build only *adds* enforcement (the hostpolicy allowlist), so the transition grants nothing an attacker could not already get from a signed self-host manifest. The reverse (hosted build accepting a self-host artifact) stays a hard refusal — that direction would strip the allowlist. The cross-edition acceptance is logged.
- `heartbeat.go` `migrationSignal` — self-host builds now report `agentEdition:"self-host"` (previously silent). Because the reporting and the allowance ship in the same binary, a reported edition — either value — doubles as the server's "this build can accept hosted artifacts" capability signal. The zod schema already accepted both values.
- `watchdog/failover.go` — the failover heartbeat reports `agentEdition` too (the watchdog is the binary that downloads during failover).

**API (`apps/api/src/routes/agents/…`)**
- `helpers.ts` — `resolvePinnedUpgradeTarget` (both queries) and the heartbeat helper-latest query are now **edition-scoped** (`eq(agentVersions.edition, getBinaryEdition())`), matching the download/register/promote paths; previously a row of the other edition could be resolved and offered.
- `helpers.ts` — new `agentAcceptsServedEdition` predicate: reported edition ⇒ capable; silent + core version `< 0.105.0` ⇒ predates the check; silent + `≥ 0.105.0` ⇒ would refuse hosted (**fail closed**, incl. `0.105.0-rc.*` and unparseable versions). Serving self-host: only a `'hosted'` reporter is refused (symmetric protection for hosted builds pointed at a self-host server).
- `heartbeat.ts` — every offer path (agent / helper / watchdog on the main branch, bootstrap included; watchdog self-update + agent recovery on the failover branch) consults the predicate with **this beat's payload** and withholds offers the build would refuse, with a once-per-device deduped warn. Wedged devices drop back to `online` on the next beat after the offer disappears (verified in the field by reverting the pin: ~2 min).

## What this does NOT do

- **It does not recover the already-stranded band by itself.** Those 35 devices run old code and can't receive this fix OTA; this PR stops the wedge loop (they idle at their current version) and gives every *future* self-host build a transition path. Recovery for the existing band = per-device reinstall with a hosted installer, or a one-off bridge release decision (discussed in the issue).
- The user-helper 404 noise on hosted upgrades (hosted lane registers no `user-helper` rows) is a separate defect and untouched.
- AI/manual one-shot update commands (`aiToolsAgentMgmt`, WS) don't loop and are not gated here — follow-up candidate to share the same predicate.

## Accepted risk (documented in `edition.go`)

A malicious/compromised control plane could substitute a signed strict-hostpolicy hosted artifact and cut a self-hoster's agents off from their own server. Such a control plane can already run arbitrary scripts on enrolled devices, so no new attacker capability is added; server-side, offers are edition-scoped to the deployment's own edition, so a healthy self-host server never offers one. An independent design review (codex, xhigh-adjacent) confirmed no signature bypass and this residual risk.

## Tests

- Agent: full `go test -race ./...` green. Flipped edition-matrix tests (3 sites), new wire-contract tests for `agentEdition` (main heartbeat + watchdog failover).
- API: `helpers.agentUpdatePolicy.test.ts` — predicate matrix (12 cases incl. prerelease + fail-closed) and PgDialect compiled-SQL assertions pinning the edition filter params in both resolver queries. `heartbeat.test.ts` — 8 wiring tests: withhold per offer path (bootstrap included), payload-not-column sourcing, failover-branch gating on the watchdog's own payload, once-per-device warn dedupe.
- `tsc --noEmit` clean; all 47 `src/routes/agents/` test files (847 tests) + `aiToolsAgentMgmt.test.ts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Thjb1KChG8kqpt2fUFT71J