### PR TITLE
docs: land the 2026-08-24 UI QA sweep, the #2994 catalog spike, and the docs-citation rule

### DIFF
--- a/.claude/skills/gh-queue/SKILL.md
+++ b/.claude/skills/gh-queue/SKILL.md
@@ -156,6 +156,8 @@ gh api graphql -f query='mutation($id:ID!,$body:String!){addDiscussionComment(in
 
 **Handles (from `feedback_never_invent_github_handles`):** NEVER @-mention a handle you didn't see verbatim in the thread. Verify with `gh issue view --json author,comments` / the discussion query first.
 
+**Cite docs by PUBLISHED URL, code by repo path.** `file:line` is the right currency for *code* — a reader can find `apps/api/src/config/validate.ts:1198` on GitHub. It is the wrong currency for *documentation*: `apps/docs/src/content/docs/deploy/upgrades.mdx:326` is unusable to the self-hoster who asked. That tree publishes to **https://docs.breezermm.com**, mapping `apps/docs/src/content/docs/<path>.mdx` → `https://docs.breezermm.com/<path>/` (Starlight, `site` set in `apps/docs/astro.config.*`, no `base`). Link the page, not the source file, and **curl each URL for a 200 before posting** — a dead link in a public answer is worse than a repo path. Repo docs *outside* that tree (`docs/operations/*.md`, `docs/registers/*.md`) are not published; name them as repo files and say so. Internal issues we file for ourselves are the exception — a dev fixing `backup.mdx` wants the file path.
+
 **Always verify the post landed** (count comments / re-read last comment). The discussion mutation can succeed while a follow-up verify query errors on a missing-`first`/`last` pagination boundary — that's a query bug, not a post failure; check before re-posting or you'll double-comment (happened on #982; deleted the dup via `deleteDiscussionComment(input:{id:"DC_..."})`).
 
 ### 5. Closing — rules differ by type

--- a/docs/superpowers/specs/vuln-patch/2026-08-14-org-scoped-software-catalog-design.md
+++ b/docs/superpowers/specs/vuln-patch/2026-08-14-org-scoped-software-catalog-design.md
@@ -1,0 +1,457 @@
+# Org-Scoped Cross-Platform Software Catalog with AI-Assisted Version Research — Design Spike
+
+**Date:** 2026-08-14
+**Status:** Proposed (design spike deliverable for #2994; no code)
+**Issue:** #2994 (SemoTech follow-up comment is the source model)
+**Related:** #2135 (partner-wide epic), #3381 (blast-radius lesson), spec
+`2026-08-04-third-party-update-ring-auto-approve-design.md` (ring composition target), spec
+`2026-07-08-vuln-displayname-cpe-resolver-design.md` (global resolution-cache precedent)
+
+## 1. Problem + scope
+
+Breeze's third-party patching today is package-manager-shaped: the agent's `PatchProvider`
+implementations (`agent/internal/patching/`: `winget_system.go`, `chocolatey.go`, `homebrew.go`,
+`apt.go`, `yum.go`, `apple_softwareupdate.go`) can only see and update software their manager
+installed. Everything else is invisible to the update loop even though it is fully visible to
+*inventory* — the agent already collects the complete installed-app list every 15 minutes
+(`heartbeat.go:1721` `sendInventory` → `collectors/software.go`) into `software_inventory`.
+
+Gaps this design closes:
+
+- **macOS beyond Homebrew** — Sparkle-updating and direct-download `.app`s (the majority of a
+  typical Mac fleet; `system_profiler SPApplicationsDataType` sees them, nothing tracks their
+  latest versions), Microsoft 365/Office (`msupdate`, no driver today), Adobe CC
+  (`RemoteUpdateManager`, no driver today). Confirmed no `msupdate`/`RemoteUpdateManager`/Sparkle
+  string exists anywhere in `agent/`.
+- **Windows per-user installs** — `software_windows.go` reads HKLM (both views) plus
+  `registry.CURRENT_USER`, but the agent runs as SYSTEM, so per-user apps in real users' HKCU
+  hives are invisible to both inventory and winget-system patching. (Inventory fix is in scope;
+  per-user *install* execution is Phase-3+.)
+- **Linux repo apps** — apt/yum patch scans already report updates; the catalog unifies them into
+  the same per-app cross-platform view instead of a wall of package rows.
+- **The reporting gap** — "which orgs run outdated VLC/Zoom/AnyDesk anywhere, on any OS" is
+  unanswerable today. Phase 1 answers it with zero new install mechanics.
+
+**Out of scope:** Mac App Store / VPP management (MDM territory — Todd's #2994 answer stands; at
+most `mas`-based *detection* later), mobile, license management, and replacing the Software
+Deployment package repository (`software_catalog`/`software_versions` — the *push installers*
+feature keeps its name and role; the new tables use distinct names to avoid collision).
+
+## 2. Data model
+
+Follows the existing three-layer split already proven by patching: **global identity facts**
+(`patches` is globally deduped by `(source, external_id)`; `third_party_package_catalog` and the
+CPE resolver's `software_product_resolutions` are intentionally-unscoped global tables) →
+**partner-scoped decisions** (`patch_approvals`, `patch_policies` rings are partner-axis) →
+**org/device-scoped state** (`device_patches`, `software_inventory`).
+
+### 2a. `software_app_identities` — global, intentionally unscoped
+
+The cross-platform app identity: one row per real-world application, unioned across platforms.
+
+| column | type | notes |
+|---|---|---|
+| id | uuid PK | |
+| canonical_name | varchar(255) | normalized display name |
+| vendor | varchar(255) | |
+| platform_keys | jsonb | per-platform matchers: winget id, brew cask/formula, apt/yum package names, macOS bundle id + app name patterns, Windows DisplayName patterns |
+| category | varchar(64) | |
+| homepage_url | text | |
+| identity_source | varchar(32) | `seeded` \| `deterministic` \| `ai` \| `manual` |
+| created_at / updated_at | timestamptz | |
+
+Unique partial indexes per extracted key (e.g. `(platform_keys->>'wingetId')`) to keep
+deterministic matching O(1).
+
+**Tenancy treatment:** shape "intentionally unscoped", registered in
+`rls-coverage.integration.test.ts` with a justification comment exactly like line 89's
+`third_party_package_catalog` entry. **Isolation contract:** rows may contain only public
+software identifiers — never org ids, device ids, counts, or tenant-derived strings. Row
+*creation* is triggered by some org's inventory, but the row records nothing about which org;
+tenant reads always go through their own `org_software_catalog` join, so no tenant can enumerate
+this table via app routes. Writes happen only in system-context workers and platform-admin routes
+(same gate as `third_party_package_catalog`). No org/device/partner cascade entries needed; no
+export-policy entry needed (no `org_id`).
+
+### 2b. `software_version_research` — global, intentionally unscoped (the shared cache)
+
+One row per `(app_identity_id, platform, channel)` — research done **once**, shared across every
+org that runs the app. This is the cost-bounding mechanism and mirrors decision #1 of the CPE
+resolver spec ("DisplayNames repeat fleet-wide, so a global cache is compact, cross-org,
+auditable, and cheap to re-run").
+
+| column | type | notes |
+|---|---|---|
+| id | uuid PK | |
+| app_identity_id | uuid FK → software_app_identities (ON DELETE CASCADE) | |
+| platform | varchar(16) | `windows` \| `macos` \| `linux` |
+| channel | varchar(32) | default `stable` |
+| latest_version | varchar(100) | |
+| release_date | date | |
+| source | varchar(32) | `winget` \| `brew` \| `distro_repo` \| `sparkle_appcast` \| `vendor_cli` \| `vendor_api` \| `ai_web_research` |
+| confidence | varchar(8) | `high` \| `medium` \| `low` — see §3 rules |
+| evidence | jsonb | source URLs, appcast URL, download URL, expected hash/signature identity |
+| status | varchar(16) | `fresh` \| `stale` \| `failed` \| `unresolvable` |
+| researched_at / stale_after | timestamptz | TTL drives re-research |
+| failure_count | integer | backoff; `unresolvable` after N |
+
+**Tenancy treatment:** same as 2a — intentionally unscoped, allowlisted with comment, system-write
+only, no cascades, no export-policy entry. **Shared-cache isolation implications, addressed
+head-on:** (1) contents are public facts about public software, no tenant data can enter — the
+research worker's inputs are only identity-row fields, enforced by construction and stated in the
+allowlist comment; (2) timing side-channel ("row created ⇒ some org installed X") is only
+observable to platform admins / system context, not to any tenant; (3) an org can never poison
+another org's results directly — orgs cannot write these tables; poisoning via *inventory* (a
+crafted DisplayName steering identity matching) is mitigated by the deterministic matcher rules
+(§3) and by AI results being capped at `medium` confidence and therefore never auto-installed.
+
+### 2c. `org_software_catalog` — org-scoped (shape 1, direct `org_id`)
+
+The per-org catalog: "apps this org actually runs", derived from `software_inventory`.
+
+| column | type | notes |
+|---|---|---|
+| id | uuid PK | |
+| org_id | uuid NOT NULL FK → organizations | |
+| app_identity_id | uuid FK → software_app_identities | nullable — unmatched apps still get a row (`identity_confidence='none'`) and ARE the research backlog |
+| display_name | varchar(500) | as seen in this org's inventory |
+| vendor | varchar(255) | |
+| platforms | jsonb | `["windows","macos"]` — which OSes this org runs it on |
+| identity_confidence | varchar(8) | `high` \| `medium` \| `low` \| `none` |
+| tracking_status | varchar(16) | `tracked` \| `ignored` (org-local mute) |
+| device_count / outdated_device_count | integer | denormalized rollup, refreshed by reconcile |
+| lowest_installed_version | varchar(100) | rollup for the list view |
+| first_seen_at / last_seen_at / retired_at | timestamptz | |
+
+Unique `(org_id, app_identity_id)` where identity is set; unique
+`(org_id, lower(display_name), vendor)` for unmatched rows. **Deliberately no FK to
+`software_inventory`** — ingest is delete+reinsert per report (`routes/agents/inventory.ts`), so
+inventory row ids are ephemeral; the reconcile worker joins by normalized name/vendor exactly as
+the vuln relink does.
+
+**Partner-Wide First, resolved head-on:** this table is **org-scoped by design and that is the
+justified exception CLAUDE.md requires.** It is not a config/policy/template table — it is
+*derived observation state* ("what this org's devices run"), the same class as `device_patches`
+and worker-created findings, which the epic-#2135 playbook itself says "always take the DEVICE's
+org" (CLAUDE.md rule 5). A partner-axis or dual-axis shape here would be semantically wrong: the
+same app has different device counts, versions, and staleness per org. The MSP-tech need — one
+partner-level review/approval surface across all orgs — is real but is a *decision*, not an
+*observation*, and lives in 2d, exactly as `patches` (facts) vs `patch_approvals` (partner
+decisions) already split. A partner roll-up *view* ("Chrome: outdated in 7 of 12 orgs") is a
+read-time aggregation across org rows under a partner token, needing no new tenancy shape. PR
+description must carry this justification explicitly.
+
+**Cascade/export registration (the full checklist):**
+- `CORE_ORG_CASCADE_DELETE_ORDER` (`services/tenantCascade.ts`) — has `org_id`; insert
+  alphabetically (`org_software_catalog` sorts after `oauth_*`, before `organizations`); verify FK
+  direction (only parents are `organizations` + two global tables → no child-ordering hazard).
+- `CORE_TENANT_EXPORT_POLICY` (`services/tenantExportPolicyRegistry.ts`) — every column
+  classified: `platforms` jsonb → **`excludedOpen`**; all other columns `included` (no
+  SUSPICIOUS_NAME_PARTS hits).
+- NOT in `CORE_DEVICE_CASCADE_DELETE_TABLES` / `CORE_DEVICE_ORG_DENORMALIZED_TABLES` (no
+  `device_id` column).
+- RLS in the same migration: shape 1, `breeze_has_org_access(org_id)`, enabled + forced; run
+  contract suites locally (they only fail in the Integration Tests CI job — stale-base hazard per
+  CLAUDE.md).
+
+### 2d. `software_catalog_approvals` — partner-axis (shape 3)
+
+The MSP-tech review/approval state, one decision per `(partner, app_identity)`, optionally per
+ring — the exact shape of `patch_approvals` (`partner_id NOT NULL`, unique
+`(partner_id, app_identity_id, COALESCE(ring_id, zero-uuid))`).
+
+| column | type | notes |
+|---|---|---|
+| id | uuid PK | |
+| partner_id | uuid NOT NULL FK → partners | |
+| app_identity_id | uuid NOT NULL FK → software_app_identities | |
+| ring_id | uuid FK → patch_policies | NULL = partner-wide blanket |
+| status | varchar(16) | `approved` \| `blocked` \| `pending` |
+| pinned_version | varchar(100) | optional hold |
+| decided_by / decided_at / notes | | |
+
+**Tenancy treatment:** register in `PARTNER_TENANT_TABLES`
+(`rls-coverage.integration.test.ts`), policy `breeze_has_partner_access(partner_id)` (flat, no
+tree traversal). No `org_id` → **no org-cascade entry and no export-policy entry required**
+(CLAUDE.md: "A table with no org_id needs no entry"); partner deletion handled by the partner
+cascade path like `patch_approvals`. Write routes gate on the same partner-scope authz as update
+rings. This is deliberately **not** dual-ownership: an org-scoped Breeze customer (self-hosted
+single-org) still has a partner row, so partner-scoped decisions degrade gracefully — the same
+argument that made update rings pure partner-axis (spec 2026-06-21).
+
+### 2e. No new execution tables
+
+Phase-2 execution flows through the existing `patches` / `device_patches` / `patch_jobs`
+pipeline (§5). Per-device staleness for Phase 1 is computed at read time
+(`software_inventory` version vs `software_version_research.latest_version` via the org catalog
+join) — no per-device table, no new agent write path, nothing new to cascade.
+
+### Config-policy linkage
+
+None in Phases 1–2. The catalog does not become a `PARTNER_LINKABLE_FEATURE_TYPES` entry:
+execution rides the existing `patch` feature link (config-policy sources gate + ring dual
+consent). If a later phase adds a linkable "software update settings" feature, it follows the
+epic-#2135 playbook then.
+
+## 3. Catalog lifecycle
+
+**Discovery — no new agent collection for Phase 1.** A new BullMQ worker
+`softwareCatalogReconcileWorker` (pattern: `cveEnrichmentWorker.ts` — singleton queue, system DB
+context via `withSystemDbAccessContext`, `attachWorkerObservability`) runs daily per org
+(staggered), reading only `software_inventory` (already refreshed every 15 min by the agent):
+
+1. Aggregate distinct `(lower(trim(name)), lower(trim(vendor)), platform-from-device-os)` with
+   device counts and min/max versions.
+2. **Deterministic identity matching, in strict priority order:** (a) exact package-manager key —
+   winget/brew/apt package ids are already present on `patches.package_id` rows for
+   manager-installed apps, and macOS `installLocation` + Windows registry keys give bundle-path
+   hints; (b) exact `(normalized_name, vendor)` against `platform_keys` patterns; (c) the CPE
+   resolver's token-set logic (port of the Layer-B guardrail approach — deterministic, no fuzzy
+   scores, misses are withheld not guessed). Confidence: (a)=`high`, (b)=`high`, (c)=`medium`.
+3. Unmatched names get an identity-less org row (`identity_confidence='none'`) — these ARE the
+   AI identity-resolution backlog, same "NULL rows are the unmatched log" trick as
+   `software_product_resolutions`.
+4. Upsert `org_software_catalog`; refresh rollups; stamp `last_seen_at`; rows unseen for 30 days
+   → `retired_at` (kept for history, excluded from lists).
+5. Enqueue version-research jobs for identities whose research row is missing or past
+   `stale_after`.
+
+**Cadence:** org reconcile daily; research TTL 7 days for deterministic sources, 14 days for AI
+rows (matches SemoTech's "weekly reconcile"; both env-tunable).
+
+**Dedup/normalization across platforms:** the identity row is the join point — "Google Chrome"
+(HKLM DisplayName), `Google.Chrome` (winget), `google-chrome` (brew cask), `google-chrome-stable`
+(apt) all map to one `software_app_identities` row via `platform_keys`. Seed the initial identity
+set from the existing `third_party_package_catalog` (~curated winget rows, vendor + friendly name
++ homepage already present) plus a small vendored mapping fixture (FleetDM-style, MIT, with
+attribution — same sourcing decision as the CPE spec).
+
+**Confidence model (two independent axes, both surfaced in UI):**
+- *Identity confidence* (is this inventory row really that app): high/medium/low/none per matcher
+  above; AI-proposed identity links are always `medium` until a human confirms.
+- *Version confidence* (is `latest_version` really the latest): `high` only from deterministic
+  sources (winget manifest, brew JSON API, distro repo via the device's own patch scan, Sparkle
+  appcast fetched from a signed feed URL, vendor CLI output); `medium` for AI research with
+  corroborating evidence URLs; `low` for AI without corroboration.
+- Effective confidence = min(identity, version). **Only `high` is ever eligible for
+  auto-anything** (§6).
+
+## 4. Version research
+
+**Deterministic first, per platform:**
+- **Windows:** winget — the agent's winget scan already reports available upgrades for
+  manager-visible apps; for catalog-only apps, server-side lookup of the winget community
+  manifest (static JSON, free). Chocolatey feed as secondary.
+- **macOS:** brew — `formulae.brew.sh` JSON API (free, no auth) covers casks even for apps NOT
+  installed via brew (a cask version is a valid latest-version signal for the same bundle id);
+  Sparkle — fetch the app's appcast XML server-side; the feed URL (`SUFeedURL`) lives in the
+  app's `Info.plist`, which requires a **small agent inventory addition** (read
+  `SUFeedURL`/`CFBundleIdentifier` for each app path during the existing `system_profiler` pass —
+  flagged as the one exception to "no new agent collection", Phase 1b); vendor CLIs — `msupdate
+  --list` and `RemoteUpdateManager --action=list` run on-device via the new providers (§5) and
+  are authoritative.
+- **Linux:** no research needed — the distro repo already answers via the existing apt/yum patch
+  scan; the catalog just links those `patches` rows to identities.
+
+**AI fallback — `softwareVersionResearchWorker` (BullMQ):**
+- Job unit: one `(app_identity_id, platform)`; enqueued only when every deterministic resolver
+  missed. Runs in system context; **once globally, results shared across all orgs** via 2b.
+- Implementation pattern: `catalogEnrichmentService.ts` — direct Anthropic SDK call with the
+  server `web_search` tool, strict JSON-only contract
+  (`{latestVersion, releaseDate, downloadUrl, publisher, evidenceUrls[], confidence, notes}`),
+  parse-or-fail with `AI_PARSE`-style error codes, Sentry capture. Model: current Haiku tier
+  (cheapest; this is extraction, not reasoning), id resolved via `resolveDefaultModel`-style
+  helper, priced in `aiCostTracker.ts` `MODEL_PRICING`.
+- Prompt inputs are ONLY identity-row fields (canonical name, vendor, platform, homepage) —
+  never anything org-derived; this is the enforcement point for the shared-cache isolation
+  contract in §2b.
+- **Cost bounding:** research once per identity+platform, TTL re-research; per-run job cap
+  (default 50/day) + hard daily token budget from env (`SOFTWARE_RESEARCH_AI_DAILY_BUDGET_CENTS`)
+  tracked through `recordUsage` under a **platform-level system ledger, not per-org `ai_budgets`**
+  — costs are shared, attributing them to the org that happened to trigger discovery is wrong and
+  leaks tenant activity into billing rows. Kill switch env var. `failure_count` backoff →
+  `unresolvable` after 3 attempts (re-tried monthly).
+- **Never-auto-install-low-confidence rule, mechanically:** AI-sourced rows are capped at
+  `medium` confidence *in the schema contract* (worker clamps), and §5's evaluator gate requires
+  `high` — so AI results can, by construction, only ever produce report-level staleness and
+  human-approvable suggestions, never an unattended install.
+
+## 5. Update execution
+
+**Phase 1 — detect/report only (no installs, no agent changes):** org catalog UI tab
+(Software → Catalog): app list with identity/version confidence badges, outdated-device counts,
+drill-down to devices, partner roll-up view, CSV export, optional alert rule ("new app appeared
+in org", "app outdated > N days"). All value ships without touching install mechanics.
+
+**Phase 2 — high-confidence auto-update via the EXISTING pipeline:**
+- **New agent providers** implementing the existing `PatchProvider` interface
+  (`agent/internal/patching/types.go:43` — `ID/Name/Scan/Install/Uninstall/GetInstalled`),
+  registered in `defaults_darwin.go`:
+  - `msupdate` — wraps `/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/
+    Contents/MacOS/msupdate`; `Scan` = `--list` parsed to `AvailablePatch` rows; `Install` =
+    `--install --apps <id>`. Follows the homebrew.go pattern for console-user execution quirks
+    (msupdate must run as the console user, exactly the problem homebrew.go already solves).
+  - `adobe_rum` — wraps `RemoteUpdateManager` (root, so simpler); `Scan` = `--action=list`;
+    `Install` = `--action=install --productVersions=<sap>`.
+- Their scans flow through the untouched agent→API patch ingestion (`routes/agents/patches.ts`)
+  into `patches` (global dedup by `(source, external_id)`; `source='third_party'`, externalId
+  namespaced `msupdate:<appId>` / `adobe_rum:<sap>`, provider in `metadata`) and `device_patches`
+  (device-org-scoped) — the existing patch_catalog/device_patches split needs zero schema change.
+- **Ring/policy composition:** they inherit the 2026-08-04 spec's dual-consent model verbatim —
+  config-policy `sources` must include third-party (outer gate) AND the ring's `thirdPartyApps`
+  toggle (ring consent). The catalog adds a third gate for catalog-derived candidates: a
+  `software_catalog_approvals` row (`approved`, matching ring or blanket) with effective
+  confidence `high`. Enforced in `patchApprovalEvaluator.ts` alongside the existing app
+  block/pin rules.
+- **Sparkle/direct-download installs are NOT in Phase 2.** Phase 2 auto-updates only
+  provider-backed apps (winget/choco/brew/apt/yum/msupdate/adobe_rum). Direct-download apps stay
+  report-only until a Phase-3 verified-download driver exists (download from research-evidence
+  URL → hash + codesign/Team-ID verification → install via the Software Deployment execution
+  path, reusing `software_versions`' checksum/detection-rules machinery).
+- Windows per-user inventory (HKU enumeration under SYSTEM) lands as an agent inventory
+  improvement in Phase 2; per-user *installs* (`winget --scope user` impersonation) are Phase 3+.
+
+## 6. Safety
+
+- **Verification:** provider-backed installs inherit each manager's own trust chain (winget
+  hashes/signatures, brew checksums, apt/yum GPG, msupdate/RUM are vendor-signed channels) — no
+  new verification surface in Phase 2. The Phase-3 direct-download driver requires expected hash
+  + publisher signature identity (Authenticode subject / Apple Team ID) recorded in
+  `software_version_research.evidence` at research time and verified on-device before install;
+  mismatch = hard fail + alert, never fall through.
+- **Confidence gate:** auto-approval requires effective confidence `high`; `high` is unreachable
+  for AI-sourced versions and AI-proposed identities by construction (§3, §4).
+- **Blast radius (the #3381 lesson applied):** any action that turns on catalog-driven
+  auto-update for a scope (ring toggle + approval blanket) presents a **scope preview before
+  commit** — device count, org count, exact app list, and what would install *today* — with an
+  explicit typed confirmation for partner-wide blankets, mirroring what #3381 demands for
+  allowlist mode. Approvals default per-app, not "approve all". Global kill switch
+  (`SOFTWARE_CATALOG_AUTOUPDATE_DISABLED`) plus the existing per-source ring controls.
+- **Audit:** `writeAuditEvent` (`services/auditEvents.ts`) on every mutation: identity
+  create/merge, research result write (system actor), org-catalog tracking-status change,
+  approval create/change/delete (with scope snapshot), every synthesized auto-approval, every
+  install decision (already audited via patch jobs). Research rows keep `evidence` for
+  after-the-fact "why did we think this was latest".
+
+## 7. Phasing (PR-by-PR, each ships standalone value)
+
+| PR | Contents | Effort |
+|---|---|---|
+| 1 | Tables 2a–2c + migrations/RLS/cascade/export registration + reconcile worker + deterministic matchers + seed from `third_party_package_catalog` | M (4–6 d) |
+| 2 | Org catalog UI (read-only list, confidence badges, device drill-down) + partner roll-up view | M (3–5 d) |
+| 3 | Deterministic version research (winget manifest + brew JSON + apt/yum passthrough) + staleness computation + outdated counts in UI | M (4–6 d) |
+| 4 | AI fallback worker + platform budget ledger + kill switch + identity-suggestion review UI | M (4–6 d) |
+| 5 | Agent providers `msupdate` + `adobe_rum`, **Scan-only** first (report through patches pipeline) | M–L (5–8 d, needs macOS fixtures/hardware) |
+| 6 | Table 2d approvals + evaluator third gate + ring UI + scope preview/confirmation → **Phase 2 auto-update live** for provider-backed apps | M (4–6 d) |
+| 7 | Sparkle: agent `SUFeedURL`/bundle-id collection + server appcast fetch → report-only staleness for direct-download apps | S–M (3–4 d) |
+| 8+ | Windows per-user inventory; verified-download install driver; `mas` detection | later |
+
+PRs 1–4 are pure API/worker/UI (no agent release); 5 and 7 ride the agent release train.
+
+## Alternatives considered
+
+- **Global curated every-app DB** — rejected. Unbounded curation cost (MacUpdater tracks ~10k
+  apps with a paid team); Breeze's own curated table (`third_party_package_catalog`) works
+  precisely because it is small and test-focused. Org-scoping bounds work to apps customers
+  actually run; the global *identity* table grows organically to the union of real fleets, which
+  is orders of magnitude smaller than "every app on earth".
+- **MacUpdater-style licensed data bootstrap** — honestly assessed: it would give day-one Mac
+  version coverage and high-quality Sparkle metadata, and SemoTech is right that it de-risks the
+  research layer. Rejected as a core dependency for three reasons: (1) Breeze is self-hostable —
+  redistributing licensed proprietary data to self-hosted instances is almost certainly
+  contractually impossible, forking the product into cloud-only-accurate; (2) Mac-only, so the
+  cross-platform identity/research machinery must exist anyway; (3) it substitutes for exactly
+  the layer (2b) that is cheapest to build given deterministic sources + bounded AI. Viable
+  later as an optional cloud-side enrichment source writing into `software_version_research`
+  with `source='vendor_api'` — the schema accommodates it without redesign.
+- **No catalog: just add vendor CLI drivers (msupdate, RUM, brew bootstrap)** — the cheap path
+  (~PR 5 alone). It genuinely closes the two highest-value named gaps (M365 + Adobe ≈ the bulk
+  of *managed-software* update pain) and should ship regardless — which is why it is PR 5, not
+  an alternative. What it loses without the catalog: any answer for the Sparkle/direct-download
+  long tail (typically 40–70% of the 60–120 apps `system_profiler` reports per Mac have no
+  manager and no vendor CLI); no cross-platform unified app view or partner roll-up; no
+  "outdated anywhere" reporting for unmanaged apps; no substrate for the phase-3 verified
+  direct-download driver. It answers "update what we manage" but not SemoTech's actual ask,
+  "know what's outdated across everything we see".
+
+## 8. Advisor quorum outcome (2026-08-14)
+
+Independent codex review (read-only, xhigh): **proceed with amendments.** Decisions 2 (org-scoped
+catalog), 3 (partner-axis approvals), and 4 (reuse patch pipeline) confirmed. Accepted amendments,
+to be folded into the PRs:
+
+1. **Decision 1 amended — hybrid identity flow.** Direct global writes from reconcile are too
+   trusting: org-scoped identity *proposals* first, promotion into the global tables only after
+   deterministic validation or human curation. Global tables copy the CPE resolver's **forced
+   system-only RLS** (`2026-07-08-vuln-product-resolutions.sql`), NOT the RLS-less
+   `third_party_package_catalog` precedent this spec originally cited.
+2. **Decision 5 overturned — enforce the confidence cap in the schema, not the worker.** DB CHECK
+   (`source='ai_web_research'` ⇒ confidence ≠ 'high'), an `identity_match_source` provenance
+   column on org rows, and an explicit patch→identity link + confidence inputs in
+   `patchApprovalEvaluator` (today's `PatchCandidate` has neither). Snapshot effective confidence
+   + research row version into the job/audit record at dispatch.
+3. **Decision 6 overturned — re-order phasing fail-closed.** Corrections to this spec's claims:
+   the agent carries provider identity in namespaced `externalId`/`packageId`, not
+   `patches.metadata`; unknown providers map to `custom` (not `third_party`) in
+   `mapPatchProviderSource`; and "PR 6 = auto-update live" was incoherent while PR 5 was
+   scan-only. New order: capability/confidence gate first, then scan-only providers (explicitly
+   registered, install methods present but refusing), then approvals + real install support
+   shipping together.
+4. **Version dimensions widened** where the source demands it: architecture, distro/release, and
+   per-feed channel join the research key; `pinned_version` becomes per-platform. Version
+   comparison must be source-specific; unknown formats withhold rather than guess.
+5. **Sparkle PR 7 is a security boundary, not data collection.** Appcast signing is optional in
+   Sparkle (archives are what's signed); `SUFeedURL` is untrusted device-supplied input. Server
+   fetch needs HTTPS-only, redirect revalidation, private-address blocking, size/time limits, and
+   evidence sanitization. Appcast URLs may be private/secret-bearing.
+6. **AI research hardening:** deterministic BullMQ job IDs + atomic budget reservation (unique
+   rows dedupe storage, not paid calls); inventory-derived prompt inputs treated as
+   injection-bearing; evidence/download URLs never trusted for execution without the Phase-3
+   verification chain.
+7. **Identity merge semantics** need aliases, transactional conflict reconciliation with the
+   `(org_id, app_identity_id)` unique key, and immutable merge history before any auto-merge.
+
+**Pre-existing finding surfaced by the review (independent of this design):** the agent patch
+ingestion upsert (`routes/agents/patches.ts`) lets any tenant's agent overwrite global `patches`
+row metadata via `(source, external_id)` collision — being handled separately; PR 1 must not
+widen that surface and the identity link must key on server-validated fields only.
+
+## 9. Open questions for the owner
+
+> **Recommended answers (Claude, 2026-08-14; owner to confirm/override):**
+> 1. Platform-admin-gated curation until Phase 2; auto-created identities visible with confidence
+>    badges but not editable by tenants (matches `third_party_package_catalog` governance).
+> 2. Platform-level COGS budget, env-capped; self-hosted gates the AI fallback on
+>    `ANTHROPIC_API_KEY` presence with its own cap — deterministic sources work without it.
+> 3. Defer the Sparkle `Info.plist` agent read (PR 7) until Phases 1–3 prove out; it's the only
+>    agent-side inventory change and nothing earlier depends on it.
+> 4. Partner-only approvals for v1; add the org-exception overlay only on demonstrated demand.
+> 5. Reap retired rows after 180 days; keeps history through a couple of quarters without
+>    unbounded growth.
+> 6. Let PR 5 (msupdate/RUM scan-only) lead — it is independent, closes the two highest-pain
+>    gaps (M365 + Adobe on Mac), and per the quorum re-order must ship with the fail-closed
+>    source-registration gate either way.
+> 7. Seed top-50; grow organically from unmatched-row volume rather than curating speculatively.
+> 8. Yes — invite SemoTech to the Phase-1 beta once the read-only catalog exists.
+
+1. **Identity-table governance:** platform-admin-only curation UI (like
+   `third_party_package_catalog` today), or accept AI/deterministic auto-creation with
+   partner-visible confidence and no human gate until Phase 2?
+2. **AI research spend:** confirm platform-level budget (absorbed as COGS, env-capped) vs any
+   per-partner metering — the shared cache makes per-org attribution wrong, but self-hosters
+   need their own Anthropic key and cap; is `ANTHROPIC_API_KEY`-present the feature gate for
+   self-hosted AI fallback?
+3. **Sparkle agent collection:** is the `Info.plist` read (PR 7) acceptable agent scope-creep
+   for Phase 1b, or defer until after auto-update proves out?
+4. **Approvals granularity:** is partner-scoped-only (2d) acceptable for v1, or do MSPs need
+   per-org overrides ("approved everywhere except org X") on day one? (Schema extends via a
+   nullable org exception table later; starting dual-granularity doubles evaluator complexity.)
+5. **`retired_at` retention:** keep retired org-catalog rows indefinitely for history, or reap
+   after N days (export-policy implications either way are handled)?
+6. **Does PR 5 (msupdate/RUM Scan) ship before or after PR 1–3?** It is independent and
+   arguably the highest immediate customer value; sequencing above assumes catalog-first per the
+   issue's framing, but the drivers could lead.
+7. **Seeding scale:** how large a vendored identity fixture do we want at launch (top-500 apps
+   vs top-50)? Larger = better day-one match rates, more curation surface.
+8. **SemoTech beta:** loop in the reporter for Phase-1 beta on the mixed Intel/AS fleet as
+   offered?

--- a/docs/testing/FEATURE_TEST_LOG.md
+++ b/docs/testing/FEATURE_TEST_LOG.md
@@ -4750,3 +4750,301 @@ guard; covered by its own integration tests, no browser surface exercised here.
    reboot toast does fire; "API 0.82.0" in the footer came from the stale local `.env`.
 
 **Backward-PR pass reached #3494** (2026-08-13). Older PRs were not re-verified — resume there.
+
+---
+
+## UI QA Sweep — 2026-08-24
+
+**Env**: per-worktree stack (`pnpm wt-stack up`) on branch `fix/3836-manifest-asset-name`
+(f580cb580), `baseUrl=http://localhost:32797`, seeded `e2e-tests/seed-fixtures.sql`
+(1 org "Default Partner", 2 offline device fixtures). Browser: ego-browser (Chromium).
+Login `admin@breeze.local` / `BreezeAdmin123!` — works. `E2E_MODE` is **unset** in the API
+container, so rate limiters are production-representative.
+
+### Auth / session — FAIL (blocker-class)
+- ❌ **BUG: 11 ordinary sidebar navigations inside ~20s force-logs the user out.**
+  Repro (clean login, then navigate in order): `/devices`, `/alerts`, `/scripts`,
+  `/patches`, `/reports`, `/analytics`, `/audit`, `/logs`, `/settings/users`,
+  `/settings/roles`, `/integrations` — the 11th lands on
+  `/login?next=%2Fintegrations&reason=session-expired` showing *"Your session expired.
+  Please sign in again to continue."* Elapsed: **20 seconds**. Nothing was idle, nothing
+  expired: the access token TTL is 900s and was ~19 min from issue.
+  - Mechanism: the access token lives **in memory only**, and the web app is Astro MPA, so
+    *every full page navigation* re-bootstraps by trading the refresh cookie at
+    `POST /api/v1/auth/refresh`. That endpoint is limited to **10 per user per 60s**
+    (`apps/api/src/routes/auth/login.ts:759`, `rateLimiter(redis, 'refresh:'+sub, 10, 60)`).
+    Navigation #11 in a minute gets 429.
+  - The client *does* classify 429 as transient (`apps/web/src/stores/auth.ts:383`) and
+    retries — but with `MAX_TRANSIENT_REFRESH_RETRIES = 2` and
+    `TRANSIENT_REFRESH_BASE_DELAY_MS = 300`, the whole retry budget is **~0.9s**, spent
+    entirely *inside* a 60-second limiter window. Every retry is guaranteed to 429 too.
+    The backoff cannot ever help against a windowed limiter; it only helps a one-off 502
+    (the case #3041/#3041-era work was aimed at).
+  - The limiter key is **per user, not per session**, so multiple tabs share one budget and
+    reach the cap ~N× faster.
+- ❌ **Second, worse symptom of the same cause: pages that render but are silently empty.**
+  Mid-trip (`/integrations`, `/incidents`) the page did *not* redirect — it rendered its
+  chrome with **every** data call 401'd (`/webhooks`, `/orgs/organizations`,
+  `/orgs/partners/me`, `/system/version`, `/extensions/registry`, `/incidents/feed`) and
+  showed no error, no toast, no retry affordance. This is the classic silent-failure class:
+  a user sees an "empty" Integrations page and concludes they have no integrations.
+- ⚠️ UI/UX: the eviction copy says "Your session expired", which is actively misleading —
+  the session had ~19 minutes left; the user was rate-limited, not expired.
+- Consequence for the rest of this sweep: all subsequent navigation is paced ≥7s apart to
+  stay under the limiter. Noted because it makes the defect hard to miss in real use.
+
+### Phase 2 — Nav crawl (53 sidebar destinations) — PASS with papercuts
+- ✅ All 53 sidebar destinations render, correct `<title>`, no JS exceptions, no unhandled
+  rejections, no 4xx/5xx on primary data calls (once navigation is paced under the refresh
+  limiter). Nav surface is larger than the skill's list — it now also includes Tickets,
+  Vulnerabilities, OneDrive, DNS Security, PAM, User Risk, Quotes, Invoices, Contracts,
+  Timesheets, Product Catalog, Device Groups, Fleet Posture, Variables, SSO, Access Reviews,
+  AI Agents.
+- ⚠️ UI/UX: five pages still show only a spinner at 3s and need ~8–12s to paint:
+  `/discovery` ("Loading discovered assets..."), `/pam` ("Loading overview…"),
+  `/timesheet` ("Loading…"), `/reports` ("Loading reports..."),
+  `/settings/ai-agents` ("Loading agents…"). All resolve correctly; on a 2-device seed
+  this is slower than it should be.
+- ⚠️ UI/UX: `/cis-hardening` fires two `AbortError: signal is aborted without reason`
+  fetch rejections on every load (`/cis/compliance?limit=1`, `/cis/baselines?active=true&limit=1`) —
+  double-effect abort noise, harmless but pollutes the console.
+
+### i18n rendering defects — FAIL (2 distinct systemic classes, both user-visible)
+- ❌ **BUG (class A): `<Trans>` misparses literal angle brackets — Enrollment Keys page shows
+  raw `&lt;key>`.** `/settings/enrollment-keys` subtitle renders literally as
+  *"Use these keys with breeze-agent enroll &lt;key>"*. DOM proof:
+  `innerHTML === "…breeze-agent enroll &amp;lt;key&gt;"`.
+  Root cause: `EnrollmentKeyManager.tsx:497` renders the string through
+  `<Trans i18nKey="enrollmentKeys.description" components={{ code: … }} />`. The en string
+  (`locales/en/settings.json:538`) is plain text containing `<key>`; i18next's `Trans` parses
+  it as markup, finds a `<key>` tag with no matching entry in `components`, and escapes it.
+  Two bugs in one line: the `components={{ code }}` map is also **dead** — no locale variant
+  of this string contains a `<code>` tag. Affects all 8 locales (all carry plain `<key>`).
+- ❌ **BUG (class B): i18n codemod dropped the space between a label key and the following
+  expression — 14 call sites render glued text.** Confirmed visually on `/settings/sso`:
+  *"0 of0 providers"* (`SsoProviderList.tsx:87` — `{t('ssoProviderList.of')}{providers.length}`,
+  and en value is `"of"` with no trailing space). Same shape at:
+  `AccessReviewPage.tsx:668` ("Due{date}"), `:701` ("N of{total} reviewed"),
+  `:756` ("Showing{N} of{M} users"), `AccessReviewForm.tsx:135` ("Step{n} of{total}"),
+  `AccessReviewList.tsx:138`, `ApiKeyList.tsx:103` + `:237` ("Page{n} of{total}"),
+  `CatalogItemsTab.tsx:539` ("Showing the first{100}"), `RoleManager.tsx:395`
+  ("Permissions for{role}"), `TdSynnexEcExpressPanel.tsx:428` ("SYNNEX SKU{sku}"),
+  `SsoProviderForm.tsx:277`, `MFASettings.tsx:584`, `FileManager.tsx:1218` ("Activity{n}").
+  (Method: regex for `{t('KEY')}{expr` excluding `{' '}`, then resolve KEY against
+  `locales/en/*.json` and keep only values with no trailing space/punctuation. 21 raw
+  suspects, 7 were false positives where the following template literal begins with a space.)
+- ❌ **BUG (class B, related): 9 en locale strings contain raw HTML entities** that React
+  renders literally: `alerts.json` `suppressAlertDialog.howLongShould` (`&ldquo;`) and
+  `staySuppressed` (`&rdquo;`), `createTicketFromAlertDialog.*` (`&apos;` ×2),
+  `backup.json` `recoveryBootstrapTab…` (`&lt;token&gt;`, `&lt;api-server&gt;`),
+  `integrations.json` `unifiIntegration.*` (`&nbsp;` ×2),
+  `policies.json` `configurationPolicies.featureTabs.patchTab.times` (`&times;`),
+  `security.json` `sensitiveDataCreateScanModal.form.deviceIdsPlaceholder` (`&#10;`).
+
+### Phase 3 — Alerts (ack / resolve / suppress) — PARTIAL
+- ✅ **Suppress**: row "Mute" → dialog → pick "1 hour" → Suppress. Toast
+  `"E2E fixture: high CPU" suppressed` **with an Undo affordance**, row STATUS → `Suppressed`,
+  ACTIVE ALERTS counter 2 → 1, row actions correctly collapse to just `Dismiss`. Good pattern.
+- ✅ **Acknowledge**: toast `Alert Acknowledged`, STATUS → `Acknowledged`, `Ack` button removed
+  from the row.
+- ✅ **Resolve**: row `Resolve` opens the detail drawer → drawer `Resolve` reveals an inline
+  "Resolution Note" confirm with `Cancel` / `Resolve Alert` →
+  `POST /api/v1/alerts/{id}/resolve` 200, list refetched, STATUS → `Resolved`, drawer closed.
+- ❌ **BUG: alert detail drawer prints a raw user UUID instead of a name.** The drawer shows
+  *"Acknowledged  8/24/2026, 5:00:19 PM by 9cea2f85-2da1-445d-88cc-7c404d7504c4"*.
+  `AlertDetails.tsx:259` and `AlertDetailPage.tsx:435` render `{alert.acknowledgedBy}` verbatim
+  and the API returns the user id, not a display name. Two render sites, same defect.
+- ❌ **BUG (see i18n class B above, confirmed live): the Suppress dialog prints raw HTML
+  entities.** Rendered text is literally
+  *How long should &ldquo;E2E fixture: high CPU&rdquo; stay suppressed?*
+  DOM proof: `<p …>How long should &amp;ldquo;E2E fixture: high CPU&amp;rdquo; stay suppressed?</p>`.
+- ✅ Resolve **does** toast (`alertsPage.alertResolved`) — `AlertsPage.tsx:268` routes it through
+  `runAction` with a `successMessage`. An earlier reading here recorded "Resolve fires no toast";
+  that was a measurement artifact (see the toast-timing note below), not a defect.
+- ⚠️ QA note (methodology, not a product bug): the alert drawer is a `fixed inset-0 z-50` div
+  with **no `role="dialog"`**, and the row-level `Resolve` button sits *underneath* it at
+  overlapping coordinates. `document.querySelectorAll('button')` picking "the last Resolve"
+  selects the **table's** button, not the drawer's, and `elementFromPoint` at its centre
+  returns the drawer's scroll container. This produced a false "Resolve silently does nothing"
+  reading on the first pass. Scope button lookups to the drawer element.
+
+### Phase 3 — Devices (list, filters, detail, actions) — PASS
+- ✅ Quick-filter chips work and write state to the URL **hash** (`#filtersV2=<base64>`), matching
+  the repo's URL-state convention. `Offline` → "Showing 1 to 2 of 2"; `Online` → "0 of 2 devices",
+  "Advanced filter active", and a real empty state ("No devices found. Try adjusting your search
+  or filters.") rather than a blank table.
+- ✅ Dashboard/device-list consistency **verified, not a bug**: dashboard tiles read
+  `Online 0 / 0%`, `Fleet Status 0/2 online`, and the API agrees
+  (`/devices/stats` → `{"total":2,"online":0,"offline":2}`). (An early-crawl reading of
+  "Online 2 100%" was taken seconds after seeding while both fixtures were still inside the
+  online window — same false positive noted in the previous sweep. Dismissed again.)
+- ✅ Device detail tabs all render and are hash-routed: `#details`, `#performance`, `#alerts`,
+  `#anomalies`, `#tickets`, `#eventlog`. Details shows OS/agent/enrollment; Event Log shows a
+  proper empty state with source explanations.
+- ✅ **Offline-device action handling is exemplary.** `Run Script`, `Connect Desktop`,
+  `Remote Tools`, `Power` are all `disabled` **and** carry `title="Device is offline"`.
+  `Wake` is enabled, POSTs `/devices/{id}/commands` → **412**, and surfaces a precise toast:
+  *"e2e-windows.local: No MAC address on file. The agent must check in at least once before
+  Wake-on-LAN is available."* This is the behaviour the rest of the app should copy.
+- ⚠️ UI/UX: `GET /api/v1/reliability/{deviceId}` returns **404** on every device-detail tab
+  switch. The UI degrades correctly ("No reliability snapshot available yet."), but "no snapshot
+  yet" is being modelled as 404 rather than 200-with-empty, so every tab click logs a failed
+  request.
+- ⚠️ QA note: the device tab bar labels (`Alerts`, `Tickets`, `Event Log`) collide by text with
+  **sidebar** nav links. An unscoped `querySelectorAll('button,a')` lookup clicks the sidebar and
+  navigates away from the device — scope to `main`.
+
+### Phase 4 — Notification channels (create + Test) — PASS
+- ✅ `/alerts/channels` create flow: `New Channel` → inline form carrying the **partner/org
+  `ownerScope` radio pair** (`notification-channel-owner-partner` / `-org`, defaulting to org),
+  which is the Partner-Wide-First contract. Filled name + recipient →
+  `POST /api/v1/alerts/channels` **201**, toast `Channel Created`, list refreshed to
+  "1 of 1 channels", row shows `Active` / `Never Tested`.
+- ✅ **Channel `Test` surfaces the real failure reason.** `POST /alerts/channels/{id}/test`
+  returns **HTTP 200** with `{"testResult":{"success":false,"message":"Resend error: Invalid \`to\`
+  field. Please use our testing email address instead of domains like \`example.com\`…"}}`, and the
+  UI toasts **that exact message** while flipping the row to `Failed` / `Last test: Just Now`.
+  This is the 200-with-failure-body case CLAUDE.md's `runAction` contract exists for, and it is
+  handled correctly (`runChannelTest` in `NotificationChannelsPage.tsx`).
+- ⚠️ UI/UX: with zero channels and no filter applied, the empty state reads *"No notification
+  channels found. Try adjusting your search or filters."* — it blames filters for what is really
+  a first-run empty state. Compare `/software` ("No software packages yet. Add one to get
+  started.") and `/scripts` ("No scripts yet — create your first script…"), which get this right.
+
+### ⚠️ METHODOLOGY WARNING for future sweeps — toasts auto-dismiss in well under 8s
+Two "silent failure" findings on this sweep were **false**, both from probing the DOM too late.
+A `wait(8)` after an action finds no toast even when one fired at t+0.2s. Probe at **t+1–2s**, or
+install a `MutationObserver` on `document.body` before the click and read the recorded log
+afterwards:
+```js
+window.__toastLog=[]; new MutationObserver(ms=>{for(const m of ms)for(const n of m.addedNodes)
+  if(n.nodeType===1){const t=(n.innerText||'').trim(); if(t&&t.length<400) window.__toastLog.push(t)}})
+  .observe(document.body,{childList:true,subtree:true})
+```
+Then confirm against the source (`runAction({ successMessage })`) before filing. Combined with the
+`role="dialog"`-less overlay trap already in this skill, **selector scope + probe timing** are the
+two ways this sweep manufactures fake bugs.
+
+### Phase 4 — Organizations & Sites — PARTIAL
+- ✅ Create org: slug **auto-derives** from the name as you type ("QA Sweep Org" → `qa-sweep-org`).
+  `POST /orgs/organizations` 201, org appears in the list and is auto-selected.
+- ✅ Validation on empty submit is correct and readable: inline **and** toasted
+  *"Organization name is required"* / *"Slug is required"*, and **no API call is fired**.
+  No `[object Object]`, no silence.
+- ✅ The guided first-site flow is genuinely good: after creating an org the right pane shows
+  *"Add the first site for QA Sweep Org — Organizations need at least one site, this is where
+  devices will live. You can add more later."* with a `Skip for now` escape and the hint
+  *"Only the site name is required."* `Create first site` → `POST /orgs/sites` 201, list → "1 of 1 sites".
+- ❌ **BUG: organization `slug` is declared UNIQUE in the Drizzle model but has no unique index in
+  the database — duplicate slugs are accepted.** Repro: create "QA Sweep Org" with slug
+  `qa-sweep-org`, then create "QA Sweep Org Dup" with the **same** slug → `POST
+  /api/v1/orgs/organizations` returns **201**, and `GET /orgs/organizations` then lists two orgs
+  under one partner both carrying `slug: "qa-sweep-org"`.
+  - Model says unique: `apps/api/src/db/schema/orgs.ts:21` —
+    `slug: varchar('slug', { length: 100 }).notNull().unique()`.
+  - Database disagrees: `\d organizations` shows only `organizations_pkey (id)`,
+    `organizations_id_partner_id_unique (id, partner_id)`, `organizations_id_partner_uq (id, partner_id)`
+    and the partial `organizations_partner_quick_support_uniq (partner_id) WHERE type='quick_support'`.
+    **There is no index on `slug` at all.**
+  - No app-layer guard either: the `POST /organizations` handler (`routes/orgs.ts:37`) and the
+    update path (`:386`) write `data.slug` straight through with no pre-existence check.
+  - Blast radius **today is limited** — `organizations.slug` is only ever projected into responses
+    (`routes/orgs.ts:1174`, `routes/partnerApi/organizations.ts:268`, `services/aiToolsOrgs.ts`),
+    never used in a `WHERE`, except `db/seed.ts:1095`. So this is a data-integrity/API-contract bug
+    rather than a live tenant-isolation break — but the partner API hands slugs to external
+    consumers as if they were stable identifiers, and any future slug-based lookup would silently
+    become cross-tenant.
+  - `pnpm db:check-drift` does **not** catch this class (it does not diff the Drizzle model against
+    the live database), which is why a model-only `.unique()` has survived.
+
+### Environment correction mid-sweep — the first stack was 47 commits stale
+Phases 2–4 above ran against the worktree branch `fix/3836-manifest-asset-name` (f580cb580),
+which is **47 commits behind `origin/main`**. None of #3921/#3923/#3924/#3926/#3929/#3931/#3953
+were in it. Every finding above was therefore re-checked against `origin/main` by source before
+filing, and the two cheapest were re-confirmed **in a browser** on a second stack built at
+`origin/main` (`6ec30b06a`, `http://localhost:32802`): the Enrollment Keys `&lt;key>` string and
+the SSO `0 of0 providers` count both still render wrong there.
+
+**Lesson for this skill:** check `git rev-list --count HEAD..origin/main` *before* Phase 2. A
+worktree stack tests the worktree, and the backward-PR pass is meaningless on a stale base.
+
+### Phase 5 — Backward-through-PRs pass (on the `origin/main` stack)
+- ✅ **#3926** *fix(web,api): persist and show WHY a notification channel test failed (#3697)* —
+  **verified, and the before/after is visible across the two stacks.** On the stale branch the
+  failure reason existed only in a transient toast and the row showed just `Failed`. On `main` the
+  row now reads:
+  `QA Main Email | Email | Active | qa-main@example.com | Failed | Last test: Just Now | Reason:
+  Resend error: Invalid \`to\` field. Please use our testing email address instead of domains like
+  \`example.com\`…` — persisted, not just toasted.
+- ✅ **#3877** *in-app approval notifications + /approvals inbox* — `/approvals` renders, correct
+  empty state ("No approvals waiting — New requests will appear here when your decision is needed.").
+- ✅ **#3914** *per-partner LLM BYOK wave 4 — AI Provider settings tab* — Partner Settings now lists
+  **"AI Provider — Bring your own Anthropic key"** alongside AI Budgets.
+- ✅ **#3878 / #3806** *quotes revision lineage* — `/billing/quotes` status filter includes
+  **`Superseded`**, the status those waves added.
+- ✅ **#3805** *public invoice pay link* — `/billing/invoices` renders with its empty state.
+- ⚠️ **#3923** *alert rule "Test" reports the real evaluation verdict* — **NOT VERIFIED.**
+  `/alerts/rules` redirects to `/configuration-policies`; alert rules now live behind a
+  Configuration Policy feature link, so reaching a rule's `Test` button needs a policy created and
+  a feature linked first. Out of budget this pass — re-test needs: create policy → link alert-rules
+  feature → add rule → Test.
+- ⚠️ **#3929** *stop a double-click on a confirm dialog hit-testing through to the list* —
+  **INCONCLUSIVE.** Attempted via the Organizations delete confirm, but the guided first-site modal
+  overlays the same region after an org is created and the probe kept landing in that form instead
+  of the confirm button. Needs a cleaner fixture (an org that already has a site).
+- Not reached this pass: #3924, #3921, #3953, #3931, #3912, #3915, #3911, #3913, #3883/#3882/#3874
+  (multi-currency), #3814 (portal Guest Ledger), #3790, #3771.
+
+**Backward-PR pass reached #3805 (2026-08-22)** on this run, verifying the UI-affecting subset
+above. The previous sweep reached #3494 — the window between #3494 and #3805 is still unswept.
+
+---
+
+## UI QA Sweep 2026-08-24 — Summary
+
+| Area | Result |
+|---|---|
+| Environment / stack bring-up | PASS (2 stacks: worktree branch, then `origin/main`) |
+| Auth / session under normal navigation | **FAIL** — forced logout in 20s (#3696, still open) |
+| Nav crawl, 53 destinations | PASS |
+| i18n rendering | **FAIL** — 2 systemic classes, 23 sites (#3964, #3965) |
+| Alerts — ack / resolve / suppress | PARTIAL — flows correct, drawer shows raw UUID (#3966) |
+| Devices — list, filters, detail, actions | PASS (offline-action handling is exemplary) |
+| Notification channels — create + Test | PASS |
+| Organizations & Sites — create / guided site / delete | PARTIAL — duplicate slugs accepted (#3967) |
+| Backward-PR pass | PARTIAL — 5 verified, 2 inconclusive, rest not reached |
+
+**Filed:** #3964 (i18n entities/markup), #3965 (i18n missing spaces), #3966 (raw UUID),
+#3967 (org slug uniqueness). **Commented:** #3696 with a tighter repro + a second symptom.
+
+### Top findings
+
+1. **The session bug is the only blocker, and it has a second face nobody has filed.** #3696
+   already documents the forced logout. What today added is that the *more common* outcome is not
+   a redirect at all — it's a page that renders completely and silently 401s every data call. A
+   fix that only stops the hard logout leaves users staring at an Integrations page that looks
+   empty. Fix option 2 in that issue (don't spend the retry budget inside the limiter window) is a
+   prerequisite for option 1, not an alternative — the current 0.9s backoff can never survive a
+   60s window.
+2. **One i18n codemod is still producing user-visible damage across three distinct symptom
+   classes.** #3964 (entities + angle brackets), #3965 (missing spaces), and the older #2649
+   (humanized key names as copy) are all the same extraction pass. 23 confirmed sites between the
+   two new issues. None are individually severe; collectively they make settings screens look
+   unfinished, and they are cheap to guard against with two assertions over `locales/**`.
+3. **The good news is real and worth protecting.** `runAction` adoption is visibly paying off:
+   the channel Test surfaces an HTTP-200-with-failure-body reason verbatim, org validation is
+   inline *and* toasted with no API call fired, the Wake button on an offline device returns 412
+   with a precise explanation, and every disabled device action carries
+   `title="Device is offline"`. The empty states on `/scripts`, `/software`, `/approvals` and
+   `/billing/*` are specific and actionable. This app degrades well.
+4. **Two of my own "silent failure" findings were false**, both from probing the DOM 5–8s after a
+   click when the toast had already dismissed, plus one from an unscoped selector clicking a
+   sidebar link instead of a device tab. Both traps are now written up above. Any future run of
+   this skill should assume its first "X does nothing" reading is a measurement error until it has
+   checked the source for `runAction({ successMessage })`.
+5. **Smaller, unfiled papercuts** (recorded above, not worth individual issues): `/discovery`,
+   `/pam`, `/timesheet`, `/reports`, `/settings/ai-agents` need 8–12s to paint on a 2-device seed;
+   `/cis-hardening` throws two `AbortError` fetch rejections per load; `GET /reliability/{id}`
+   404s on every device-tab switch to mean "no data yet"; the channels empty state blames filters
+   when there is simply nothing yet.
+


### PR DESCRIPTION
Three doc artifacts that were written but never committed. They were sitting uncommitted in a worktree still parked on the pre-squash commit of #4029 (which itself merged as `bbbd69c66`), so they would have been lost with the worktree.

**Docs only — no code, no migration, no schema change.**

## What's here

### `docs/testing/FEATURE_TEST_LOG.md` (+298)
The 2026-08-24 UI QA sweep record. The four issues it filed — #3964, #3965, #3966, #3967 — plus #3696 are all **closed**, so the findings themselves already landed. What only lives in this log:

- **The resume bookmark.** The backward-PR pass reached #3805; the window **#3494..#3805 is still unswept**. The next sweep reads this line to know where to start.
- **Two methodology traps** that each produced a false "silent failure" finding: probing the DOM 5–8s after a click when the toast had already auto-dismissed, and an unscoped selector clicking a sidebar link instead of a device tab. Both are written up so the next run doesn't re-derive them.
- **Unfiled papercuts** judged not worth individual issues: five pages need 8–12s to paint on a 2-device seed; `/cis-hardening` throws two `AbortError` fetch rejections per load; `GET /reliability/{id}` 404s on every device-tab switch to mean "no data yet"; the channels empty state blames filters when there is simply nothing yet.

### `docs/superpowers/specs/vuln-patch/2026-08-14-org-scoped-software-catalog-design.md` (+457)
The design-spike deliverable for **#2994, which is still open**. Covers macOS software beyond Homebrew — Sparkle and direct-download `.app`s, `msupdate`, `RemoteUpdateManager` — none of which have a driver in `agent/` today, despite all of it being visible to inventory already.

### `.claude/skills/gh-queue/SKILL.md` (+2)
Cite documentation by its published `docs.breezermm.com` URL, not the `apps/docs/**.mdx` source path, and curl for a 200 before posting. A repo path is the right currency for *code* and useless to the self-hoster who asked the question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)