### PR TITLE
fix(api): recover webhook deliveries recorded but never enqueued (#4095)

### DIFF
--- a/apps/api/migrations/2026-09-11-d-webhook-delivery-recovery.sql
+++ b/apps/api/migrations/2026-09-11-d-webhook-delivery-recovery.sql
@@ -1,0 +1,39 @@
+-- #4095: recovery path for webhook deliveries recorded but never enqueued.
+--
+-- `webhook_deliveries` rows are committed to Postgres BEFORE `queueDelivery`,
+-- which is a bare `redis.lpush` onto a non-durable list. If that LPUSH throws,
+-- or the process dies between the commit and the LPUSH, the row sits at
+-- `status = 'pending'` with no job anywhere and nothing ever looks at it again.
+-- Latent while delivery is at-most-once; once wave 3.5c (#4085) makes it
+-- at-least-once, the redelivered event hits the (webhook_id, event_id) unique
+-- index from 2026-09-11-a, the '*' subscriber skips, and that pair is
+-- suppressed forever.
+--
+-- Two additions, both driving `jobs/webhookDeliveryRecovery.ts`.
+
+-- 1. A dedicated recovery counter.
+--
+-- The sweep needs a bounded number of attempts per row, and it cannot borrow
+-- `attempts`: that column is the HTTP attempt count the delivery callback
+-- overwrites (`SET attempts = result.attempts`) and the UI renders as such.
+-- Counting enqueue recoveries in it would both misreport the delivery history
+-- and lose the count on the first completed callback.
+ALTER TABLE webhook_deliveries
+  ADD COLUMN IF NOT EXISTS recovery_attempts integer NOT NULL DEFAULT 0;
+
+-- 2. A PARTIAL index over the candidate set.
+--
+-- The sweep runs every five minutes forever, and `webhook_deliveries` has no
+-- retention job anywhere — it grows without bound. A plain index on
+-- (status, created_at) would grow with the table; this one only ever holds
+-- rows in a TRANSIENT state, so in a healthy fleet it stays at approximately
+-- zero entries no matter how large the table gets, and the sweep is an index
+-- scan over nothing rather than a sequential scan over everything.
+--
+-- `pending` and `retrying` are both indexed because both are unresolved:
+-- `pending` = never claimed by a worker (safe to re-drive), `retrying` =
+-- claimed but never completed (outcome unknown, resolved terminally rather
+-- than re-POSTed). `delivered` and `failed` are terminal and excluded.
+CREATE INDEX IF NOT EXISTS webhook_deliveries_unresolved_idx
+  ON webhook_deliveries (status, created_at)
+  WHERE status IN ('pending', 'retrying');

--- a/apps/api/migrations/2026-09-11-d-webhook-delivery-recovery.sql
+++ b/apps/api/migrations/2026-09-11-d-webhook-delivery-recovery.sql
@@ -34,6 +34,13 @@ ALTER TABLE webhook_deliveries
 -- `pending` = never claimed by a worker (safe to re-drive), `retrying` =
 -- claimed but never completed (outcome unknown, resolved terminally rather
 -- than re-POSTed). `delivered` and `failed` are terminal and excluded.
+-- Keyed on created_at ALONE, not (status, created_at). The partial predicate
+-- already restricts the index to the two unresolved statuses, so carrying
+-- `status` as the leading key buys nothing and actively costs: with a 2-value
+-- IN, a (status, created_at) index yields two separately-ordered runs, so the
+-- sweep's `ORDER BY created_at` needs a sort (or a merge) on top. Keyed on
+-- created_at the index IS the order, oldest-first, which is exactly how the
+-- sweep drains its bounded batch. Same number of entries either way.
 CREATE INDEX IF NOT EXISTS webhook_deliveries_unresolved_idx
-  ON webhook_deliveries (status, created_at)
+  ON webhook_deliveries (created_at)
   WHERE status IN ('pending', 'retrying');

--- a/apps/api/src/__tests__/integration/webhookDeliveryRecovery.integration.test.ts
+++ b/apps/api/src/__tests__/integration/webhookDeliveryRecovery.integration.test.ts
@@ -250,8 +250,19 @@ describe('webhook delivery recovery against real Postgres', () => {
     // so the same event legitimately gets one row per webhook.
     expect(mine.created).toBe(true);
     expect(theirs.created).toBe(true);
-    expect(mine.created === true && theirs.created === true
-      && mine.deliveryId !== theirs.deliveryId).toBe(true);
+    const myId = mine.created === true ? mine.deliveryId : null;
+    const theirId = theirs.created === true ? theirs.deliveryId : null;
+    expect(myId).not.toBe(theirId);
+
+    // Now force the READ-BACK, which the two winning inserts above never reach.
+    // With a sibling row present under the SAME event_id, a lookup keyed only
+    // on event_id could return either row — and Postgres is free to hand back
+    // the sibling's. It must name THIS webhook's delivery.
+    const again = await recordWebhookDelivery({ id: webhookId } as never, event as never);
+
+    expect(again.created).toBe(false);
+    expect(again.created === false && again.existing?.id).toBe(myId);
+    expect(again.created === false && again.existing?.id).not.toBe(theirId);
   });
 
   it('the execution claim lets exactly ONE popped copy of a job deliver', async () => {
@@ -265,7 +276,11 @@ describe('webhook delivery recovery against real Postgres', () => {
       claimDeliveryForExecution(job)
     ]);
 
-    expect([a, b].filter(Boolean)).toHaveLength(1);
+    expect([a, b].filter((r) => r.claimed)).toHaveLength(1);
+    // The loser must be able to say WHY: the winner moved the row to
+    // `retrying`, which is "already claimed", not "no row" or "already done".
+    const loser = [a, b].find((r) => !r.claimed);
+    expect(loser).toMatchObject({ claimed: false, observedStatus: 'retrying' });
 
     const [row] = await withSystemDbAccessContext(() =>
       db
@@ -282,7 +297,16 @@ describe('webhook delivery recovery against real Postgres', () => {
   it('the execution claim refuses a row that has already resolved', async () => {
     const deliveryId = await insertDelivery(webhookId, { status: 'delivered' });
 
-    expect(await claimDeliveryForExecution({ id: deliveryId } as never)).toBe(false);
+    expect(await claimDeliveryForExecution({ id: deliveryId } as never))
+      .toMatchObject({ claimed: false, observedStatus: 'delivered' });
+  });
+
+  it('the execution claim reports a MISSING row distinctly from a lost race', async () => {
+    // A DLQ replay's minted id has no row at all. Collapsing that to the same
+    // "duplicate" verdict as a lost race sends triage after a race that never
+    // happened.
+    expect(await claimDeliveryForExecution({ id: randomUUID() } as never))
+      .toMatchObject({ claimed: false, observedStatus: null });
   });
 
   it('the partial index the sweep depends on exists and is partial', async () => {

--- a/apps/api/src/__tests__/integration/webhookDeliveryRecovery.integration.test.ts
+++ b/apps/api/src/__tests__/integration/webhookDeliveryRecovery.integration.test.ts
@@ -1,0 +1,305 @@
+/**
+ * #4095, against real Postgres: prove the recovery predicates actually select
+ * and actually serialise.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * The sweep is pinned by a mock-based unit suite and by compiled-SQL assertions
+ * (`jobs/webhookDeliveryRecovery.sql.test.ts`), and neither can prove the two
+ * things that decide whether this fix works in production:
+ *
+ *   1. that `next_retry_at IS NULL OR next_retry_at <= now` really matches a
+ *      never-leased row. This repo has shipped a compiled-SQL assertion that
+ *      was *correct* while only real Postgres caught the bug — `NOT (...)` over
+ *      a nullable column silently dropping exactly the rows a sweep existed to
+ *      find. Every orphan starts with `next_retry_at IS NULL`, so if that arm
+ *      does not match, the sweep recovers NOTHING and #4095 is simply back.
+ *
+ *   2. that the claim CAS serialises. Two API instances sweep the same table on
+ *      the same schedule; if both claims can win, the customer's endpoint is
+ *      POSTed once per instance. That is a property of Postgres's concurrent
+ *      UPDATE recheck, not of our SQL text, and a mock cannot exhibit it.
+ *
+ * The migration's partial index is also asserted to EXIST here, because the
+ * sweep's cost argument depends on it and nothing else in CI checks it.
+ *
+ * FIXTURES ARE PER-TEST. The shared integration setup TRUNCATEs the core tenant
+ * tables in a global `beforeEach`.
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { and, eq, sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { partners, organizations, webhooks, webhookDeliveries } from '../../db/schema';
+import {
+  STALE_PENDING_MS,
+  buildRecoveryClaimCas,
+  buildUnresolvedScope
+} from '../../jobs/webhookDeliveryRecovery';
+import {
+  claimDeliveryForExecution,
+  recordWebhookDelivery
+} from '../../services/webhookDeliveryRecord';
+
+const NOW = new Date('2026-09-11T12:00:00.000Z');
+/** Comfortably past the staleness cut-off. */
+const AGED = new Date(NOW.getTime() - STALE_PENDING_MS - 60_000);
+
+async function seedWebhook(): Promise<string> {
+  const sfx = randomUUID().slice(0, 8);
+  return withSystemDbAccessContext(async () => {
+    const [partner] = await db
+      .insert(partners)
+      .values({ name: `Recovery Partner ${sfx}`, slug: `recovery-${sfx}` })
+      .returning({ id: partners.id });
+    const [org] = await db
+      .insert(organizations)
+      .values({
+        currencyCode: 'USD',
+        partnerId: partner!.id,
+        name: 'Recovery Org',
+        slug: `recovery-org-${sfx}`
+      })
+      .returning({ id: organizations.id });
+    const [webhook] = await db
+      .insert(webhooks)
+      .values({
+        orgId: org!.id,
+        name: 'Recovery Hook',
+        url: 'https://example.test/hook',
+        events: ['alert.triggered']
+      })
+      .returning({ id: webhooks.id });
+    return webhook!.id;
+  });
+}
+
+async function insertDelivery(
+  webhookId: string,
+  overrides: Partial<typeof webhookDeliveries.$inferInsert> = {}
+): Promise<string> {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .insert(webhookDeliveries)
+      .values({
+        webhookId,
+        eventType: 'alert.triggered',
+        eventId: randomUUID(),
+        payload: {},
+        status: 'pending',
+        createdAt: AGED,
+        ...overrides
+      })
+      .returning({ id: webhookDeliveries.id });
+    return row!.id;
+  });
+}
+
+const scan = (webhookId: string) =>
+  withSystemDbAccessContext(() =>
+    db
+      .select({ id: webhookDeliveries.id })
+      .from(webhookDeliveries)
+      .where(and(eq(webhookDeliveries.webhookId, webhookId), buildUnresolvedScope(NOW)))
+  );
+
+describe('webhook delivery recovery against real Postgres', () => {
+  let webhookId: string;
+
+  beforeEach(async () => {
+    webhookId = await seedWebhook();
+  });
+
+  it('selects the never-leased orphan — the NULL arm is not dropped', async () => {
+    const orphanId = await insertDelivery(webhookId); // next_retry_at IS NULL
+
+    const rows = await scan(webhookId);
+
+    // If `or(isNull(...), lte(...))` were ever written as a negation, this row
+    // would vanish and the sweep would recover nothing at all.
+    expect(rows.map((r) => r.id)).toEqual([orphanId]);
+  });
+
+  it('ignores rows that are fresh, leased, or already resolved', async () => {
+    await insertDelivery(webhookId, { createdAt: NOW }); // too fresh
+    await insertDelivery(webhookId, {
+      nextRetryAt: new Date(NOW.getTime() + 60_000)     // leased by someone else
+    });
+    await insertDelivery(webhookId, { status: 'delivered' });
+    await insertDelivery(webhookId, { status: 'failed' });
+    const orphanId = await insertDelivery(webhookId);
+
+    const rows = await scan(webhookId);
+
+    // Terminal rows especially: re-driving a `delivered` row would POST to the
+    // customer's endpoint a second time for an event they already received.
+    expect(rows.map((r) => r.id)).toEqual([orphanId]);
+  });
+
+  it('picks up a `retrying` row whose execution lease has expired', async () => {
+    const abandonedId = await insertDelivery(webhookId, {
+      status: 'retrying',
+      nextRetryAt: new Date(NOW.getTime() - 1_000) // lease expired
+    });
+
+    const rows = await scan(webhookId);
+
+    expect(rows.map((r) => r.id)).toEqual([abandonedId]);
+  });
+
+  it('the claim CAS lets exactly ONE concurrent sweeper win', async () => {
+    const orphanId = await insertDelivery(webhookId);
+    const lease = new Date(NOW.getTime() + 15 * 60_000);
+
+    const claim = () =>
+      withSystemDbAccessContext(() =>
+        db
+          .update(webhookDeliveries)
+          .set({ recoveryAttempts: 1, nextRetryAt: lease })
+          .where(buildRecoveryClaimCas(orphanId, NOW))
+          .returning({ id: webhookDeliveries.id })
+      );
+
+    // Two instances racing on the same row. Postgres rechecks the predicate
+    // after the first UPDATE commits, so the loser matches nothing.
+    const [a, b] = await Promise.all([claim(), claim()]);
+
+    expect(a.length + b.length).toBe(1);
+
+    // And the winner's lease removes the row from the candidate set, so the
+    // NEXT tick cannot re-queue it either.
+    expect(await scan(webhookId)).toEqual([]);
+  });
+
+  it('a second claim after the lease is taken matches nothing', async () => {
+    const orphanId = await insertDelivery(webhookId);
+    const lease = new Date(NOW.getTime() + 15 * 60_000);
+
+    await withSystemDbAccessContext(() =>
+      db
+        .update(webhookDeliveries)
+        .set({ recoveryAttempts: 1, nextRetryAt: lease })
+        .where(buildRecoveryClaimCas(orphanId, NOW))
+        .returning({ id: webhookDeliveries.id })
+    );
+
+    const second = await withSystemDbAccessContext(() =>
+      db
+        .update(webhookDeliveries)
+        .set({ recoveryAttempts: 99 })
+        .where(buildRecoveryClaimCas(orphanId, NOW))
+        .returning({ id: webhookDeliveries.id })
+    );
+
+    expect(second).toEqual([]);
+    const [row] = await withSystemDbAccessContext(() =>
+      db
+        .select({ recoveryAttempts: webhookDeliveries.recoveryAttempts })
+        .from(webhookDeliveries)
+        .where(eq(webhookDeliveries.id, orphanId))
+    );
+    expect(row!.recoveryAttempts).toBe(1);
+  });
+
+  it('records a delivery, and on the second attempt reports the row that won', async () => {
+    const webhookConfig = { id: webhookId, orgId: 'unused', name: 'n', url: 'u', events: [] };
+    const event = {
+      id: randomUUID(),
+      type: 'alert.triggered',
+      orgId: 'unused',
+      source: 'test',
+      priority: 'normal',
+      payload: { a: 1 },
+      metadata: { timestamp: new Date().toISOString() }
+    };
+
+    const first = await recordWebhookDelivery(webhookConfig as never, event as never);
+    const second = await recordWebhookDelivery(webhookConfig as never, event as never);
+
+    expect(first.created).toBe(true);
+    // The read-back is the whole point of the new contract: without it the skip
+    // has nothing to report and #4095's silent `continue` is back.
+    expect(second.created).toBe(false);
+    expect(second.created === false && second.existing?.id)
+      .toBe(first.created === true ? first.deliveryId : undefined);
+    expect(second.created === false && second.existing?.status).toBe('pending');
+  });
+
+  it('the read-back does not confuse a SIBLING webhook’s delivery for this one', async () => {
+    // One event fans out to every subscribed webhook, so `event_id` alone is
+    // not unique. A read-back keyed only on event_id would report the sibling's
+    // status as this webhook's.
+    const otherWebhookId = await seedWebhook();
+    const sharedEventId = randomUUID();
+    const event = {
+      id: sharedEventId,
+      type: 'alert.triggered',
+      orgId: 'unused',
+      source: 'test',
+      priority: 'normal',
+      payload: {},
+      metadata: { timestamp: new Date().toISOString() }
+    };
+
+    const mine = await recordWebhookDelivery({ id: webhookId } as never, event as never);
+    const theirs = await recordWebhookDelivery({ id: otherWebhookId } as never, event as never);
+
+    // Both must WIN their insert — the unique index is (webhook_id, event_id),
+    // so the same event legitimately gets one row per webhook.
+    expect(mine.created).toBe(true);
+    expect(theirs.created).toBe(true);
+    expect(mine.created === true && theirs.created === true
+      && mine.deliveryId !== theirs.deliveryId).toBe(true);
+  });
+
+  it('the execution claim lets exactly ONE popped copy of a job deliver', async () => {
+    const deliveryId = await insertDelivery(webhookId);
+    const job = { id: deliveryId } as never;
+
+    // Two copies of the same job, popped by two workers at once. If both won,
+    // the customer's endpoint would be POSTed twice for one event.
+    const [a, b] = await Promise.all([
+      claimDeliveryForExecution(job),
+      claimDeliveryForExecution(job)
+    ]);
+
+    expect([a, b].filter(Boolean)).toHaveLength(1);
+
+    const [row] = await withSystemDbAccessContext(() =>
+      db
+        .select({ status: webhookDeliveries.status, nextRetryAt: webhookDeliveries.nextRetryAt })
+        .from(webhookDeliveries)
+        .where(eq(webhookDeliveries.id, deliveryId))
+    );
+    // The winner moved it out of `pending`, which is also what removes it from
+    // the recovery sweep's candidate set.
+    expect(row!.status).toBe('retrying');
+    expect(row!.nextRetryAt).not.toBeNull();
+  });
+
+  it('the execution claim refuses a row that has already resolved', async () => {
+    const deliveryId = await insertDelivery(webhookId, { status: 'delivered' });
+
+    expect(await claimDeliveryForExecution({ id: deliveryId } as never)).toBe(false);
+  });
+
+  it('the partial index the sweep depends on exists and is partial', async () => {
+    // The sweep ticks every five minutes forever and this table has no
+    // retention job, so a full index (or none) would mean a growing scan.
+    const rows = await withSystemDbAccessContext(() =>
+      db.execute(sql`
+        SELECT indexdef FROM pg_indexes
+        WHERE tablename = 'webhook_deliveries'
+          AND indexname = 'webhook_deliveries_unresolved_idx'
+      `)
+    );
+
+    const defs = (rows as unknown as Array<{ indexdef: string }>);
+    expect(defs).toHaveLength(1);
+    expect(defs[0]!.indexdef).toMatch(/WHERE/i);
+    expect(defs[0]!.indexdef).toMatch(/pending/);
+    expect(defs[0]!.indexdef).toMatch(/retrying/);
+  });
+});

--- a/apps/api/src/db/schema/integrations.ts
+++ b/apps/api/src/db/schema/integrations.ts
@@ -1,4 +1,5 @@
-import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, integer, uniqueIndex } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, integer, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 import { organizations, partners } from './orgs';
 import { users } from './users';
 import { alerts } from './alerts';
@@ -85,7 +86,15 @@ export const webhookDeliveries = pgTable('webhook_deliveries', {
   eventId: varchar('event_id', { length: 100 }).notNull(),
   payload: jsonb('payload').notNull(),
   status: webhookDeliveryStatusEnum('status').notNull().default('pending'),
+  /** HTTP delivery attempts. Written by the delivery callback, shown in the UI. */
   attempts: integer('attempts').notNull().default(0),
+  /**
+   * Times the recovery sweep has re-queued this row (#4095). Deliberately NOT
+   * `attempts`: that column is overwritten by the delivery callback, so a
+   * counter kept there would reset on the first completed attempt and would
+   * misreport enqueue recoveries as HTTP attempts in the UI.
+   */
+  recoveryAttempts: integer('recovery_attempts').notNull().default(0),
   nextRetryAt: timestamp('next_retry_at'),
   responseStatus: integer('response_status'),
   responseBody: text('response_body'),
@@ -98,7 +107,15 @@ export const webhookDeliveries = pgTable('webhook_deliveries', {
   // queues an outbound POST per matching webhook, so without this a redelivered
   // event POSTs to the customer's endpoint twice (2026-09-11-a migration).
   webhookEventUq: uniqueIndex('webhook_deliveries_webhook_event_uq')
-    .on(table.webhookId, table.eventId)
+    .on(table.webhookId, table.eventId),
+  // Partial, over the UNRESOLVED statuses only (2026-09-11-d migration). The
+  // recovery sweep ticks every five minutes forever and this table has no
+  // retention job, so the index it scans must not grow with the table —
+  // `pending`/`retrying` are transient, so in a healthy fleet this holds ~0
+  // entries however large `webhook_deliveries` becomes.
+  unresolvedIdx: index('webhook_deliveries_unresolved_idx')
+    .on(table.status, table.createdAt)
+    .where(sql`${table.status} IN ('pending', 'retrying')`)
 }));
 
 export const eventBusEvents = pgTable('event_bus_events', {

--- a/apps/api/src/db/schema/integrations.ts
+++ b/apps/api/src/db/schema/integrations.ts
@@ -114,7 +114,7 @@ export const webhookDeliveries = pgTable('webhook_deliveries', {
   // `pending`/`retrying` are transient, so in a healthy fleet this holds ~0
   // entries however large `webhook_deliveries` becomes.
   unresolvedIdx: index('webhook_deliveries_unresolved_idx')
-    .on(table.status, table.createdAt)
+    .on(table.createdAt)
     .where(sql`${table.status} IN ('pending', 'retrying')`)
 }));
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -206,6 +206,7 @@ import {
 } from './jobs/webhookDeliveryRecovery';
 import {
   claimDeliveryForExecution,
+  recordDeliveryOutcome,
   recordWebhookDelivery
 } from './services/webhookDeliveryRecord';
 import { initializeAgentLogRetention, shutdownAgentLogRetention } from './jobs/agentLogRetention';
@@ -1278,71 +1279,7 @@ async function initializeWebhookDeliveryWorker(): Promise<void> {
   // instant a worker takes it.
   webhookWorker.setDeliveryClaimCallback(claimDeliveryForExecution);
 
-  webhookWorker.setDeliveryCallback(async (result) => {
-    await runWithSystemDbAccess(async () => {
-      const deliveryStatus = result.success ? 'delivered' : 'failed';
-      const deliveredAt = result.success ? new Date(result.deliveredAt ?? new Date().toISOString()) : null;
-      const responseTimeMs = typeof result.responseTimeMs === 'number'
-        ? Math.max(0, Math.round(result.responseTimeMs))
-        : null;
-
-      await db
-        .update(webhookDeliveries)
-        .set({
-          status: deliveryStatus,
-          attempts: result.attempts,
-          responseStatus: result.responseStatus ?? null,
-          responseBody: result.responseBody ?? null,
-          responseTimeMs,
-          errorMessage: result.errorMessage ?? null,
-          deliveredAt,
-          // Release the execution lease taken by the claim above. The row is
-          // leaving the unresolved statuses anyway, but a stale lease would
-          // otherwise surface in the UI as a `nextAttemptAt` that never comes.
-          nextRetryAt: null
-        })
-        // Never overwrite a recorded success (#4095). This used to be keyed on
-        // `id` alone, which was safe while this callback was the ONLY writer.
-        // It no longer is: the recovery sweep also writes terminal outcomes, and
-        // `deliverWebhook` clears its abort timeout once response HEADERS
-        // arrive, so a slow response body can keep an attempt in flight past the
-        // execution lease and land here after the sweep has already resolved the
-        // row. `status` is NOT NULL, so `<>` cannot silently drop rows the way a
-        // negation over a nullable column would.
-        .where(and(
-          eq(webhookDeliveries.id, result.deliveryId),
-          ne(webhookDeliveries.status, 'delivered')
-        ))
-        .returning({ id: webhookDeliveries.id })
-        .then((rows) => {
-          if (rows.length === 0) {
-            console.warn(`[WebhookDelivery] outcome-write-skipped ${JSON.stringify({
-              errorId: 'WEBHOOK_DELIVERY_OUTCOME_WRITE_SKIPPED',
-              deliveryId: result.deliveryId,
-              webhookId: result.webhookId,
-              attemptedStatus: deliveryStatus
-            })}`);
-          }
-          return rows;
-        });
-
-      const aggregateUpdate = result.success
-        ? {
-          successCount: sql`${webhooksTable.successCount} + 1`,
-          lastSuccessAt: new Date(),
-          lastDeliveryAt: new Date()
-        }
-        : {
-          failureCount: sql`${webhooksTable.failureCount} + 1`,
-          lastDeliveryAt: new Date()
-        };
-
-      await db
-        .update(webhooksTable)
-        .set(aggregateUpdate)
-        .where(eq(webhooksTable.id, result.webhookId));
-    });
-  });
+  webhookWorker.setDeliveryCallback(recordDeliveryOutcome);
 
   await initializeWebhookDelivery(
     async (orgId, eventType) => {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -201,10 +201,13 @@ import { initializeOfflineDetector, shutdownOfflineDetector } from './jobs/offli
 import { initializeNotificationDispatcher, shutdownNotificationDispatcher } from './services/notificationDispatcher';
 import { initializeEventLogRetention, shutdownEventLogRetention } from './jobs/eventLogRetention';
 import {
-  EXECUTION_LEASE_MS,
   initializeWebhookDeliveryRecovery,
   shutdownWebhookDeliveryRecovery
 } from './jobs/webhookDeliveryRecovery';
+import {
+  claimDeliveryForExecution,
+  recordWebhookDelivery
+} from './services/webhookDeliveryRecord';
 import { initializeAgentLogRetention, shutdownAgentLogRetention } from './jobs/agentLogRetention';
 import { initializeLogCorrelationWorker, shutdownLogCorrelationWorker } from './jobs/logCorrelation';
 import { initializeAlertCorrelationWorker, shutdownAlertCorrelationWorker } from './jobs/alertCorrelation';
@@ -377,7 +380,7 @@ import {
 import { syncBinaries } from './services/binarySync';
 import * as dbModule from './db';
 import { deviceGroups, devices, securityThreats, webhookDeliveries, webhooks as webhooksTable } from './db/schema';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, ne, sql } from 'drizzle-orm';
 import { envInt } from './utils/envInt';
 import {
   computeWorkersHealthy,
@@ -1273,27 +1276,7 @@ async function initializeWebhookDeliveryWorker(): Promise<void> {
   //
   // It is also what bounds the sweep, since a claimed row leaves `pending` the
   // instant a worker takes it.
-  webhookWorker.setDeliveryClaimCallback(async (job) => {
-    return runWithSystemDbAccess(async () => {
-      const claimed = await db
-        .update(webhookDeliveries)
-        .set({
-          status: 'retrying',
-          // Doubles as the abandonment lease: if this worker dies mid-POST the
-          // sweep can only reconsider the row once this has expired.
-          nextRetryAt: new Date(Date.now() + EXECUTION_LEASE_MS)
-        })
-        .where(
-          and(
-            eq(webhookDeliveries.id, job.id),
-            eq(webhookDeliveries.status, 'pending')
-          )
-        )
-        .returning({ id: webhookDeliveries.id });
-
-      return claimed.length > 0;
-    });
-  });
+  webhookWorker.setDeliveryClaimCallback(claimDeliveryForExecution);
 
   webhookWorker.setDeliveryCallback(async (result) => {
     await runWithSystemDbAccess(async () => {
@@ -1318,7 +1301,30 @@ async function initializeWebhookDeliveryWorker(): Promise<void> {
           // otherwise surface in the UI as a `nextAttemptAt` that never comes.
           nextRetryAt: null
         })
-        .where(eq(webhookDeliveries.id, result.deliveryId));
+        // Never overwrite a recorded success (#4095). This used to be keyed on
+        // `id` alone, which was safe while this callback was the ONLY writer.
+        // It no longer is: the recovery sweep also writes terminal outcomes, and
+        // `deliverWebhook` clears its abort timeout once response HEADERS
+        // arrive, so a slow response body can keep an attempt in flight past the
+        // execution lease and land here after the sweep has already resolved the
+        // row. `status` is NOT NULL, so `<>` cannot silently drop rows the way a
+        // negation over a nullable column would.
+        .where(and(
+          eq(webhookDeliveries.id, result.deliveryId),
+          ne(webhookDeliveries.status, 'delivered')
+        ))
+        .returning({ id: webhookDeliveries.id })
+        .then((rows) => {
+          if (rows.length === 0) {
+            console.warn(`[WebhookDelivery] outcome-write-skipped ${JSON.stringify({
+              errorId: 'WEBHOOK_DELIVERY_OUTCOME_WRITE_SKIPPED',
+              deliveryId: result.deliveryId,
+              webhookId: result.webhookId,
+              attemptedStatus: deliveryStatus
+            })}`);
+          }
+          return rows;
+        });
 
       const aggregateUpdate = result.success
         ? {
@@ -1381,56 +1387,7 @@ async function initializeWebhookDeliveryWorker(): Promise<void> {
           });
       });
     },
-    async (webhook, event) => {
-      return runWithSystemDbAccess(async () => {
-        const [delivery] = await db
-          .insert(webhookDeliveries)
-          .values({
-            webhookId: webhook.id,
-            eventType: event.type,
-            eventId: event.id,
-            payload: event.payload,
-            status: 'pending',
-            attempts: 0
-          })
-          // The insert IS the dedupe. An empty `returning()` means this
-          // (webhook, event) pair is already recorded, and the caller reads
-          // that as "already handled" and skips the outbound POST.
-          // DO NOTHING rather than catching 23505: a unique violation caught
-          // inside the transaction that raised it is a documented trap in this
-          // repo — postgres.js latches the failed statement and rethrows after
-          // the callback returns.
-          .onConflictDoNothing({
-            target: [webhookDeliveries.webhookId, webhookDeliveries.eventId]
-          })
-          .returning({ id: webhookDeliveries.id });
-
-        if (delivery) return { created: true, deliveryId: delivery.id };
-
-        // Read back the row that won, so the skip can be REPORTED rather than
-        // being a bare `continue` (#4095). One extra statement, and only on the
-        // rare dedupe path; it seeks the same unique index the insert conflicted
-        // on. `existing` stays null if the row has since been erased — the
-        // subscriber reports that case too rather than staying silent.
-        const [existing] = await db
-          .select({
-            id: webhookDeliveries.id,
-            status: webhookDeliveries.status,
-            attempts: webhookDeliveries.attempts,
-            createdAt: webhookDeliveries.createdAt
-          })
-          .from(webhookDeliveries)
-          .where(
-            and(
-              eq(webhookDeliveries.webhookId, webhook.id),
-              eq(webhookDeliveries.eventId, event.id)
-            )
-          )
-          .limit(1);
-
-        return { created: false, existing: existing ?? null };
-      });
-    }
+    recordWebhookDelivery
   );
 }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -200,6 +200,11 @@ import { initializeContractWorkers, shutdownContractWorkers } from './jobs/contr
 import { initializeOfflineDetector, shutdownOfflineDetector } from './jobs/offlineDetector';
 import { initializeNotificationDispatcher, shutdownNotificationDispatcher } from './services/notificationDispatcher';
 import { initializeEventLogRetention, shutdownEventLogRetention } from './jobs/eventLogRetention';
+import {
+  EXECUTION_LEASE_MS,
+  initializeWebhookDeliveryRecovery,
+  shutdownWebhookDeliveryRecovery
+} from './jobs/webhookDeliveryRecovery';
 import { initializeAgentLogRetention, shutdownAgentLogRetention } from './jobs/agentLogRetention';
 import { initializeLogCorrelationWorker, shutdownLogCorrelationWorker } from './jobs/logCorrelation';
 import { initializeAlertCorrelationWorker, shutdownAlertCorrelationWorker } from './jobs/alertCorrelation';
@@ -351,8 +356,7 @@ import { initializeInboundEmailWorker, shutdownInboundEmailWorker } from './jobs
 import { initializeTicketMailboxPollWorker } from './jobs/ticketMailboxPollWorker';
 import { initializePolicyAlertBridge } from './services/policyAlertBridge';
 import { getWebhookWorker, initializeWebhookDelivery } from './workers/webhookDelivery';
-import { decryptForColumn } from './services/secretCrypto';
-import { decryptWebhookHeaders } from './services/notificationChannelSecrets';
+import { toWebhookConfig } from './services/webhookConfig';
 import { closeRedis, getRedis, isRedisAvailable } from './services/redis';
 import { shutdownEventDispatcher } from './services/eventDispatcher';
 import { getEventBus } from './services/eventBus';
@@ -1257,37 +1261,39 @@ let server: ReturnType<typeof serve> | null = null;
 let shutdownInProgress = false;
 let auditRetryInterval: NodeJS.Timeout | null = null;
 
-function headersToRecord(headers: unknown): Record<string, string> {
-  if (!headers) return {};
-
-  if (Array.isArray(headers)) {
-    return headers.reduce<Record<string, string>>((acc, header) => {
-      if (
-        header
-        && typeof header === 'object'
-        && typeof (header as { key?: unknown }).key === 'string'
-        && typeof (header as { value?: unknown }).value === 'string'
-      ) {
-        acc[(header as { key: string }).key] = (header as { value: string }).value;
-      }
-      return acc;
-    }, {});
-  }
-
-  if (typeof headers === 'object') {
-    return Object.entries(headers as Record<string, unknown>).reduce<Record<string, string>>((acc, [key, value]) => {
-      if (typeof value === 'string') {
-        acc[key] = value;
-      }
-      return acc;
-    }, {});
-  }
-
-  return {};
-}
-
 async function initializeWebhookDeliveryWorker(): Promise<void> {
   const webhookWorker = getWebhookWorker();
+
+  // EXECUTION CLAIM (#4095). The delivery queue is a plain Redis list with no
+  // job identity, so the same delivery can legitimately appear on it twice —
+  // the recovery sweep re-queues any row that still looks unresolved, and a job
+  // that was only backlogged is indistinguishable from one that was lost. This
+  // CAS is what makes that safe: exactly one popped copy flips `pending` ->
+  // `retrying` and POSTs; every other copy loses and is dropped by the worker.
+  //
+  // It is also what bounds the sweep, since a claimed row leaves `pending` the
+  // instant a worker takes it.
+  webhookWorker.setDeliveryClaimCallback(async (job) => {
+    return runWithSystemDbAccess(async () => {
+      const claimed = await db
+        .update(webhookDeliveries)
+        .set({
+          status: 'retrying',
+          // Doubles as the abandonment lease: if this worker dies mid-POST the
+          // sweep can only reconsider the row once this has expired.
+          nextRetryAt: new Date(Date.now() + EXECUTION_LEASE_MS)
+        })
+        .where(
+          and(
+            eq(webhookDeliveries.id, job.id),
+            eq(webhookDeliveries.status, 'pending')
+          )
+        )
+        .returning({ id: webhookDeliveries.id });
+
+      return claimed.length > 0;
+    });
+  });
 
   webhookWorker.setDeliveryCallback(async (result) => {
     await runWithSystemDbAccess(async () => {
@@ -1306,7 +1312,11 @@ async function initializeWebhookDeliveryWorker(): Promise<void> {
           responseBody: result.responseBody ?? null,
           responseTimeMs,
           errorMessage: result.errorMessage ?? null,
-          deliveredAt
+          deliveredAt,
+          // Release the execution lease taken by the claim above. The row is
+          // leaving the unresolved statuses anyway, but a stale lease would
+          // otherwise surface in the UI as a `nextAttemptAt` that never comes.
+          nextRetryAt: null
         })
         .where(eq(webhookDeliveries.id, result.deliveryId));
 
@@ -1356,23 +1366,10 @@ async function initializeWebhookDeliveryWorker(): Promise<void> {
           // plaintext rows pass through decryptForColumn unchanged.
           .flatMap((webhook) => {
             try {
-              return [{
-                id: webhook.id,
-                orgId: webhook.orgId,
-                name: webhook.name,
-                url: decryptForColumn('webhooks', 'url', webhook.url) ?? webhook.url,
-                secret: webhook.secret
-                  ? decryptForColumn('webhooks', 'secret', webhook.secret) ?? undefined
-                  : undefined,
-                events: webhook.events ?? [],
-                headers: headersToRecord(decryptWebhookHeaders(webhook.headers)),
-                retryPolicy: (webhook.retryPolicy ?? undefined) as {
-                  maxRetries: number;
-                  backoffMultiplier: number;
-                  initialDelayMs: number;
-                  maxDelayMs: number;
-                } | undefined
-              }];
+              // Shared with the recovery sweep (services/webhookConfig): one
+              // decrypt/normalise path, so the two cannot drift the next time an
+              // encrypted column is added to `webhooks`.
+              return [toWebhookConfig(webhook)];
             } catch (err) {
               console.error(
                 `[webhookDelivery] failed to decrypt webhook ${webhook.id} (org ${webhook.orgId}); skipping delivery for this webhook only`,
@@ -1398,7 +1395,7 @@ async function initializeWebhookDeliveryWorker(): Promise<void> {
           })
           // The insert IS the dedupe. An empty `returning()` means this
           // (webhook, event) pair is already recorded, and the caller reads
-          // that NULL as "already handled" and skips the outbound POST.
+          // that as "already handled" and skips the outbound POST.
           // DO NOTHING rather than catching 23505: a unique violation caught
           // inside the transaction that raised it is a documented trap in this
           // repo — postgres.js latches the failed statement and rethrows after
@@ -1408,7 +1405,30 @@ async function initializeWebhookDeliveryWorker(): Promise<void> {
           })
           .returning({ id: webhookDeliveries.id });
 
-        return delivery?.id ?? null;
+        if (delivery) return { created: true, deliveryId: delivery.id };
+
+        // Read back the row that won, so the skip can be REPORTED rather than
+        // being a bare `continue` (#4095). One extra statement, and only on the
+        // rare dedupe path; it seeks the same unique index the insert conflicted
+        // on. `existing` stays null if the row has since been erased — the
+        // subscriber reports that case too rather than staying silent.
+        const [existing] = await db
+          .select({
+            id: webhookDeliveries.id,
+            status: webhookDeliveries.status,
+            attempts: webhookDeliveries.attempts,
+            createdAt: webhookDeliveries.createdAt
+          })
+          .from(webhookDeliveries)
+          .where(
+            and(
+              eq(webhookDeliveries.webhookId, webhook.id),
+              eq(webhookDeliveries.eventId, event.id)
+            )
+          )
+          .limit(1);
+
+        return { created: false, existing: existing ?? null };
       });
     }
   );
@@ -1434,6 +1454,9 @@ async function initializeWorkers(): Promise<void> {
     ['offlineDetector', initializeOfflineDetector],
     ['notificationDispatcher', initializeNotificationDispatcher],
     ['webhookDelivery', initializeWebhookDeliveryWorker],
+    // Must follow webhookDelivery: the sweep re-queues onto that worker's queue
+    // and relies on the execution claim it installs (#4095).
+    ['webhookDeliveryRecovery', initializeWebhookDeliveryRecovery],
     ['policyEvaluationWorker', initializePolicyEvaluationWorker],
     ['softwareComplianceWorker', initializeSoftwareComplianceWorker],
     ['softwareRemediationWorker', initializeSoftwareRemediationWorker],
@@ -1690,6 +1713,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownNetworkBaselineWorker,
     shutdownDiscoveryWorker,
     shutdownEventLogRetention,
+    shutdownWebhookDeliveryRecovery,
     shutdownLogCorrelationWorker,
     shutdownAgentLogRetention,
     shutdownIPHistoryRetention,

--- a/apps/api/src/jobs/webhookDeliveryRecovery.sql.test.ts
+++ b/apps/api/src/jobs/webhookDeliveryRecovery.sql.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import {
+  buildLeaseHeldCas,
+  buildRecoveryClaimCas,
+  buildUnresolvedScope,
+  STALE_PENDING_MS
+} from './webhookDeliveryRecovery';
+
+/**
+ * COMPILED-SQL assertions, in their own file so it imports the REAL drizzle-orm.
+ *
+ * The sibling `webhookDeliveryRecovery.test.ts` mocks the db to exercise the
+ * sweep body; a `where` assertion there can only substring-match column names
+ * and is blind to the mutations that actually matter here:
+ *
+ *   - the claim CAS losing `eq(webhookDeliveries.id, …)` -> the first stale
+ *     row's iteration claims and re-POSTs EVERY unresolved delivery in every
+ *     tenant;
+ *   - `and` -> `or` anywhere in the scope -> the sweep re-delivers rows that
+ *     already succeeded;
+ *   - `or(isNull(nextRetryAt), lte(…))` collapsing to a bare `lte(…)` -> every
+ *     never-leased row (next_retry_at IS NULL) drops out of the candidate set,
+ *     so the sweep recovers NOTHING and #4095 is back, silently;
+ *   - the claim CAS keeping only `eq(id, …)` and trusting the preceding SELECT
+ *     for the rest -> the row can change in the gap between the two statements
+ *     and the claim stops being atomic;
+ *   - the lease CAS matching a RANGE rather than the exact lease instant -> the
+ *     terminal write can land on a row another instance has since re-leased.
+ */
+describe('webhook delivery recovery predicates (compiled SQL)', () => {
+  const dialect = new PgDialect();
+  const now = new Date('2026-09-11T12:00:00.000Z');
+
+  const atMs = (param: unknown) => new Date(param as string | number | Date).getTime();
+
+  it('scopes candidates to unresolved, aged out, and not currently leased', () => {
+    const { sql, params } = dialect.sqlToQuery(buildUnresolvedScope(now));
+
+    expect(sql).toBe(
+      '("webhook_deliveries"."status" in ($1, $2) '
+      + 'and "webhook_deliveries"."created_at" < $3 '
+      + 'and ("webhook_deliveries"."next_retry_at" is null '
+      + 'or "webhook_deliveries"."next_retry_at" <= $4))'
+    );
+
+    // Both unresolved statuses, and ONLY those: `delivered`/`failed` are
+    // terminal and must never be re-driven.
+    expect(params.slice(0, 2)).toEqual(['pending', 'retrying']);
+    // The age cut-off is derived from `now`, not hard-coded.
+    expect(atMs(params[2])).toBe(now.getTime() - STALE_PENDING_MS);
+    expect(atMs(params[3])).toBe(now.getTime());
+  });
+
+  it('claim CAS re-asserts the ENTIRE candidate scope against one id', () => {
+    const { sql, params } = dialect.sqlToQuery(buildRecoveryClaimCas('delivery-1', now));
+
+    // Every conjunct of the scan predicate is repeated here on purpose: only
+    // predicates inside the UPDATE are evaluated atomically with the write.
+    expect(sql).toBe(
+      '("webhook_deliveries"."id" = $1 '
+      + 'and "webhook_deliveries"."status" in ($2, $3) '
+      + 'and "webhook_deliveries"."created_at" < $4 '
+      + 'and ("webhook_deliveries"."next_retry_at" is null '
+      + 'or "webhook_deliveries"."next_retry_at" <= $5))'
+    );
+    expect(params[0]).toBe('delivery-1');
+    expect(params.slice(1, 3)).toEqual(['pending', 'retrying']);
+    expect(atMs(params[3])).toBe(now.getTime() - STALE_PENDING_MS);
+    expect(atMs(params[4])).toBe(now.getTime());
+  });
+
+  it('lease CAS matches the exact lease instant, not a range', () => {
+    const leaseUntil = new Date('2026-09-11T12:15:00.000Z');
+    const { sql, params } = dialect.sqlToQuery(buildLeaseHeldCas('delivery-1', leaseUntil));
+
+    expect(sql).toBe(
+      '("webhook_deliveries"."id" = $1 '
+      + 'and "webhook_deliveries"."status" in ($2, $3) '
+      + 'and "webhook_deliveries"."next_retry_at" = $4)'
+    );
+    expect(params[0]).toBe('delivery-1');
+    expect(params.slice(1, 3)).toEqual(['pending', 'retrying']);
+    expect(atMs(params[3])).toBe(leaseUntil.getTime());
+  });
+});

--- a/apps/api/src/jobs/webhookDeliveryRecovery.test.ts
+++ b/apps/api/src/jobs/webhookDeliveryRecovery.test.ts
@@ -19,8 +19,8 @@ interface UpdateCall {
 const state = vi.hoisted(() => ({
   candidates: [] as Record<string, unknown>[],
   updateCalls: [] as UpdateCall[],
-  /** Queued FIFO of `.returning()` results, one per update. */
-  updateResults: [] as Record<string, unknown>[][],
+  /** Queued FIFO of `.returning()` results, one per update. An Error rejects. */
+  updateResults: [] as Array<Record<string, unknown>[] | Error>,
   queueDelivery: null as ReturnType<typeof vi.fn> | null
 }));
 
@@ -45,7 +45,12 @@ vi.mock('../db', () => ({
         where: (predicate: unknown) => ({
           returning: async () => {
             state.updateCalls.push({ set: values, where: predicate });
-            return state.updateResults.shift() ?? [];
+            // A queued `Error` REJECTS instead of resolving — the only way to
+            // reach the per-candidate catch, since every other failure path is
+            // already caught by an inner block.
+            const next = state.updateResults.shift();
+            if (next instanceof Error) throw next;
+            return next ?? [];
           }
         })
       })
@@ -78,6 +83,8 @@ import {
   MAX_RECOVERY_ATTEMPTS,
   RECOVERY_COOLDOWN_MS,
   STALE_PENDING_MS,
+  buildLeaseHeldCas,
+  buildRecoveryClaimCas,
   runWebhookDeliveryRecoverySweep
 } from './webhookDeliveryRecovery';
 import { toWebhookConfig } from '../services/webhookConfig';
@@ -322,6 +329,80 @@ describe('webhook delivery recovery sweep', () => {
     expect(state.updateCalls[1]!.set).toMatchObject({ status: 'failed' });
     expect(String(state.updateCalls[1]!.set.errorMessage)).toContain('outcome unknown');
     structured(consoleLines(warnSpy), 'WEBHOOK_DELIVERY_RECOVERY_IN_FLIGHT_ABANDONED');
+  });
+
+  it('wires the RIGHT predicate to each call site', async () => {
+    state.candidates = [orphan({ status: 'retrying' })];
+    state.updateResults = [claimWon(1), [{ id: 'delivery-1' }]];
+
+    await runWebhookDeliveryRecoverySweep(NOW);
+
+    const leaseUntil = new Date(NOW.getTime() + RECOVERY_COOLDOWN_MS);
+    // The compiled-SQL suite proves each builder is individually correct, but
+    // nothing there proves the sweep CALLS the right one at the right place.
+    // Swapping these two — claiming with the lease-held predicate, or writing
+    // the terminal row with the claim predicate — reintroduces exactly the
+    // TOCTOU hole the claim exists to close, and every other assertion in this
+    // file would still pass.
+    expect(state.updateCalls[0]!.where)
+      .toEqual(buildRecoveryClaimCas('delivery-1', NOW));
+    expect(state.updateCalls[1]!.where)
+      .toEqual(buildLeaseHeldCas('delivery-1', leaseUntil));
+  });
+
+  it('still requeues at exactly the attempt limit, abandoning only past it', async () => {
+    // Boundary: `> MAX` not `>= MAX`. A `>` -> `>=` slip abandons every row one
+    // recovery cycle early, which looks like the sweep simply not working.
+    state.candidates = [orphan({ recoveryAttempts: MAX_RECOVERY_ATTEMPTS - 1 })];
+    state.updateResults = [claimWon(MAX_RECOVERY_ATTEMPTS)];
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(summary).toMatchObject({ requeued: 1, exhausted: 0 });
+    expect(queueDeliveryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a terminal write that lost the lease instead of counting it resolved', async () => {
+    // The lease CAS matches the exact instant, so a delivery worker that took
+    // the row in between makes this write match nothing. Counting it as
+    // `abandonedInFlight` and logging "outcome unknown" would report a
+    // resolution that never happened — the quiet miscount #4095 is about.
+    state.candidates = [orphan({ status: 'retrying' })];
+    state.updateResults = [claimWon(1), []]; // claim won, terminal write lost
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(summary).toMatchObject({ terminalWriteLost: 1, abandonedInFlight: 0 });
+    const payload = structured(
+      consoleLines(warnSpy),
+      'WEBHOOK_DELIVERY_RECOVERY_TERMINAL_WRITE_LOST'
+    );
+    expect(payload).toMatchObject({ deliveryId: 'delivery-1' });
+    expect(consoleLines(warnSpy).join(' '))
+      .not.toContain('WEBHOOK_DELIVERY_RECOVERY_IN_FLIGHT_ABANDONED');
+  });
+
+  it('a throwing claim does not abort the rest of the batch', async () => {
+    // The per-candidate catch is the sweep's mirror of the fan-out-aborting bug
+    // this PR fixes in the subscriber, and the claim UPDATE is the only way to
+    // reach it — every other failure path has its own inner catch.
+    state.candidates = [
+      orphan({ id: 'delivery-1' }),
+      orphan({ id: 'delivery-2', webhookId: 'webhook-2', eventId: 'event-2' })
+    ];
+    state.updateResults = [new Error('claim blew up'), claimWon(1)];
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(summary).toMatchObject({ scanned: 2, requeued: 1 });
+    expect(queueDeliveryMock).toHaveBeenCalledTimes(1);
+    expect(queueDeliveryMock.mock.calls[0]![2]).toBe('delivery-2');
+    const payload = structured(
+      consoleLines(errorSpy),
+      'WEBHOOK_DELIVERY_RECOVERY_CANDIDATE_FAILED'
+    );
+    expect(payload).toMatchObject({ deliveryId: 'delivery-1' });
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
   });
 
   it('says nothing and does nothing when there is no orphan', async () => {

--- a/apps/api/src/jobs/webhookDeliveryRecovery.test.ts
+++ b/apps/api/src/jobs/webhookDeliveryRecovery.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Behaviour of the stale-pending sweep (#4095).
+ *
+ * The PREDICATES are asserted as compiled SQL in the sibling
+ * `webhookDeliveryRecovery.sql.test.ts` — the db is mocked here, so a `where`
+ * assertion in this file would only see an opaque object and could not tell an
+ * `and` from an `or`. This file asserts what the sweep DOES: which rows get
+ * re-queued, which get a terminal status, and that neither ever happens
+ * silently.
+ */
+
+interface UpdateCall {
+  set: Record<string, unknown>;
+  where: unknown;
+}
+
+const state = vi.hoisted(() => ({
+  candidates: [] as Record<string, unknown>[],
+  updateCalls: [] as UpdateCall[],
+  /** Queued FIFO of `.returning()` results, one per update. */
+  updateResults: [] as Record<string, unknown>[][],
+  queueDelivery: null as ReturnType<typeof vi.fn> | null
+}));
+
+const captureExceptionMock = vi.hoisted(() => vi.fn());
+const queueDeliveryMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({
+          where: () => ({
+            orderBy: () => ({
+              limit: async () => state.candidates
+            })
+          })
+        })
+      })
+    }),
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: (predicate: unknown) => ({
+          returning: async () => {
+            state.updateCalls.push({ set: values, where: predicate });
+            return state.updateResults.shift() ?? [];
+          }
+        })
+      })
+    })
+  },
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  runOutsideDbContext: (fn: () => unknown) => fn()
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: () => ({}),
+  getRedisConnection: () => ({}),
+  createBlockingRedisConnection: () => ({})
+}));
+
+vi.mock('../services/sentry', () => ({ captureException: captureExceptionMock }));
+
+vi.mock('../services/webhookConfig', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/webhookConfig')>();
+  return { ...actual, toWebhookConfig: vi.fn(actual.toWebhookConfig) };
+});
+
+vi.mock('../workers/webhookDelivery', () => ({
+  getWebhookWorker: () => ({ queueDelivery: queueDeliveryMock })
+}));
+
+vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
+
+import {
+  MAX_RECOVERY_ATTEMPTS,
+  RECOVERY_COOLDOWN_MS,
+  STALE_PENDING_MS,
+  runWebhookDeliveryRecoverySweep
+} from './webhookDeliveryRecovery';
+import { toWebhookConfig } from '../services/webhookConfig';
+
+const NOW = new Date('2026-09-11T12:00:00.000Z');
+
+function orphan(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'delivery-1',
+    webhookId: 'webhook-1',
+    eventId: 'event-1',
+    eventType: 'alert.triggered',
+    payload: { alertId: 'a-1' },
+    status: 'pending',
+    recoveryAttempts: 0,
+    createdAt: new Date(NOW.getTime() - STALE_PENDING_MS - 60_000),
+    webhookOrgId: 'org-1',
+    webhookName: 'Ops hook',
+    webhookStatus: 'active',
+    webhookUrl: 'https://example.test/hook',
+    webhookSecret: null,
+    webhookEvents: ['*'],
+    webhookHeaders: null,
+    webhookRetryPolicy: null,
+    ...overrides
+  };
+}
+
+/** A CAS that returns a row = this instance won the claim. */
+function claimWon(recoveryAttempts: number) {
+  return [{ id: 'delivery-1', recoveryAttempts }];
+}
+
+function consoleLines(...spies: Array<{ mock: { calls: unknown[][] } }>): string[] {
+  return spies.flatMap((spy) =>
+    spy.mock.calls.map((call) => call.map((arg) => String(arg)).join(' '))
+  );
+}
+
+function structured(lines: string[], errorId: string): Record<string, unknown> {
+  const line = lines.find((l) => l.includes(errorId));
+  expect(line, `no console line carried ${errorId}`).toBeDefined();
+  return JSON.parse(line!.slice(line!.indexOf('{'))) as Record<string, unknown>;
+}
+
+describe('webhook delivery recovery sweep', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    state.candidates = [];
+    state.updateCalls = [];
+    state.updateResults = [];
+    queueDeliveryMock.mockReset();
+    queueDeliveryMock.mockResolvedValue('delivery-1');
+    captureExceptionMock.mockReset();
+    vi.mocked(toWebhookConfig).mockClear();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('re-queues an orphan under its ORIGINAL delivery id and event id', async () => {
+    state.candidates = [orphan()];
+    state.updateResults = [claimWon(1)];
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(summary).toMatchObject({ scanned: 1, requeued: 1, exhausted: 0, raced: 0 });
+    expect(queueDeliveryMock).toHaveBeenCalledTimes(1);
+
+    const [config, event, deliveryId] = queueDeliveryMock.mock.calls[0]!;
+    // The SAME row is driven, not a new one: the delivery callback updates by
+    // this id, and `event.id` goes out as the customer's X-Breeze-Event-Id
+    // idempotency key.
+    expect(deliveryId).toBe('delivery-1');
+    expect((event as { id: string }).id).toBe('event-1');
+    expect((event as { type: string }).type).toBe('alert.triggered');
+    expect((event as { orgId: string }).orgId).toBe('org-1');
+    expect((event as { payload: unknown }).payload).toEqual({ alertId: 'a-1' });
+    expect((config as { id: string }).id).toBe('webhook-1');
+    expect((config as { url: string }).url).toBe('https://example.test/hook');
+  });
+
+  it('leases the row it claimed so a concurrent sweep cannot re-queue it', async () => {
+    state.candidates = [orphan()];
+    state.updateResults = [claimWon(1)];
+
+    await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(state.updateCalls).toHaveLength(1);
+    // The DEDICATED counter, not `attempts`: the delivery callback overwrites
+    // `attempts` with the HTTP attempt count, which would both lose the recovery
+    // count and misreport enqueue recoveries as delivery attempts in the UI.
+    expect(state.updateCalls[0]!.set).toMatchObject({ recoveryAttempts: 1 });
+    expect(state.updateCalls[0]!.set).not.toHaveProperty('attempts');
+    expect((state.updateCalls[0]!.set.nextRetryAt as Date).getTime())
+      .toBe(NOW.getTime() + RECOVERY_COOLDOWN_MS);
+  });
+
+  it('does not enqueue when the CAS is lost to another instance', async () => {
+    state.candidates = [orphan()];
+    state.updateResults = [[]]; // UPDATE ... RETURNING matched nothing
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    // The whole point of the CAS: N API pods sweep, exactly one POSTs.
+    expect(queueDeliveryMock).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ scanned: 1, requeued: 0, raced: 1 });
+
+    // Losing the race is an ORDINARY outcome, so it must be a clean skip — not
+    // an exception that merely happens to stop short of the enqueue. Without
+    // these two, deleting the `continue` after the failed claim still passes:
+    // the code then dereferences the undefined claim, throws, and the catch
+    // suppresses the enqueue by accident.
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+    expect(consoleLines(errorSpy)).toHaveLength(0);
+  });
+
+  it('announces every recovery rather than re-delivering silently', async () => {
+    state.candidates = [orphan()];
+    state.updateResults = [claimWon(1)];
+
+    await runWebhookDeliveryRecoverySweep(NOW);
+
+    const payload = structured(consoleLines(warnSpy), 'WEBHOOK_DELIVERY_RECOVERED');
+    expect(payload).toMatchObject({
+      deliveryId: 'delivery-1',
+      webhookId: 'webhook-1',
+      orgId: 'org-1',
+      eventId: 'event-1',
+      recoveryAttempt: 1
+    });
+    expect(payload.unresolvedForMs).toBe(STALE_PENDING_MS + 60_000);
+  });
+
+  it('gives up on a row that has burned through its recovery attempts, terminally and loudly', async () => {
+    state.candidates = [orphan({ recoveryAttempts: MAX_RECOVERY_ATTEMPTS })];
+    state.updateResults = [
+      claimWon(MAX_RECOVERY_ATTEMPTS + 1), // the claim
+      [{ id: 'delivery-1' }]               // the terminal write
+    ];
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(queueDeliveryMock).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ exhausted: 1, requeued: 0 });
+
+    // `failed` specifically: it is the only status the existing per-delivery
+    // retry endpoint accepts, so the row stays hand-drivable instead of sitting
+    // pending forever.
+    const terminal = state.updateCalls[1]!;
+    expect(terminal.set).toMatchObject({ status: 'failed', nextRetryAt: null });
+    // Wording matters: a `pending` row proves only that no worker ever CLAIMED
+    // it, so the message says that rather than asserting more than we know.
+    expect(String(terminal.set.errorMessage)).toContain('Never claimed by a delivery worker');
+
+    structured(consoleLines(warnSpy), 'WEBHOOK_DELIVERY_RECOVERY_EXHAUSTED');
+  });
+
+  it('does not POST to a webhook the customer has disabled, but still resolves the row', async () => {
+    state.candidates = [orphan({ webhookStatus: 'disabled' })];
+    state.updateResults = [claimWon(1), [{ id: 'delivery-1' }]];
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(queueDeliveryMock).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ undeliverable: 1 });
+    expect(state.updateCalls[1]!.set).toMatchObject({ status: 'failed' });
+    const payload = structured(consoleLines(warnSpy), 'WEBHOOK_DELIVERY_RECOVERY_WEBHOOK_INACTIVE');
+    expect(payload).toMatchObject({ webhookStatus: 'disabled' });
+  });
+
+  it('leaves the row recoverable when the re-enqueue itself fails', async () => {
+    state.candidates = [orphan()];
+    state.updateResults = [claimWon(1)];
+    queueDeliveryMock.mockRejectedValueOnce(new Error('LPUSH failed again'));
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(summary).toMatchObject({ enqueueFailed: 1, requeued: 0, exhausted: 0 });
+    // Only the claim ran — the row is NOT marked failed, so the lease expires
+    // and the next window reconsiders it.
+    expect(state.updateCalls).toHaveLength(1);
+    structured(consoleLines(errorSpy), 'WEBHOOK_DELIVERY_RECOVERY_REQUEUE_FAILED');
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('one poisonous row does not abort the rest of the batch', async () => {
+    state.candidates = [
+      orphan({ id: 'delivery-1' }),
+      orphan({ id: 'delivery-2', webhookId: 'webhook-2', eventId: 'event-2' })
+    ];
+    state.updateResults = [claimWon(1), claimWon(1)];
+    queueDeliveryMock
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce('delivery-2');
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(summary.scanned).toBe(2);
+    expect(summary.requeued).toBe(1);
+    expect(queueDeliveryMock).toHaveBeenCalledTimes(2);
+    expect(queueDeliveryMock.mock.calls[1]![2]).toBe('delivery-2');
+  });
+
+  it('marks a row terminal when the webhook credentials will not decrypt', async () => {
+    state.candidates = [orphan()];
+    state.updateResults = [claimWon(1), [{ id: 'delivery-1' }]];
+    vi.mocked(toWebhookConfig).mockImplementationOnce(() => {
+      throw new Error('decrypt failed: AAD mismatch');
+    });
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    // Delivering with unusable credentials is worse than not delivering — but
+    // the row must not stay pending forever either.
+    expect(queueDeliveryMock).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ undeliverable: 1 });
+    expect(state.updateCalls[1]!.set).toMatchObject({ status: 'failed' });
+    structured(consoleLines(errorSpy), 'WEBHOOK_DELIVERY_RECOVERY_DECRYPT_FAILED');
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never re-POSTs a delivery a worker had already claimed — outcome unknown', async () => {
+    // `retrying` means a worker won the execution claim and then died. The POST
+    // may or may not have reached the customer, so this is resolved terminally
+    // rather than re-sent: silently repeating a possibly-delivered POST is
+    // worse than surfacing one unknown outcome.
+    state.candidates = [orphan({ status: 'retrying' })];
+    state.updateResults = [claimWon(1), [{ id: 'delivery-1' }]];
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(queueDeliveryMock).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ abandonedInFlight: 1, requeued: 0 });
+    expect(state.updateCalls[1]!.set).toMatchObject({ status: 'failed' });
+    expect(String(state.updateCalls[1]!.set.errorMessage)).toContain('outcome unknown');
+    structured(consoleLines(warnSpy), 'WEBHOOK_DELIVERY_RECOVERY_IN_FLIGHT_ABANDONED');
+  });
+
+  it('says nothing and does nothing when there is no orphan', async () => {
+    state.candidates = [];
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(summary).toMatchObject({ scanned: 0, requeued: 0 });
+    expect(queueDeliveryMock).not.toHaveBeenCalled();
+    // The healthy steady state is silent: this ticks every 5 minutes forever.
+    expect(consoleLines(logSpy, warnSpy, errorSpy)).toHaveLength(0);
+  });
+});

--- a/apps/api/src/jobs/webhookDeliveryRecovery.test.ts
+++ b/apps/api/src/jobs/webhookDeliveryRecovery.test.ts
@@ -80,6 +80,7 @@ vi.mock('../workers/webhookDelivery', () => ({
 vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
 
 import {
+  MAX_RECOVERABLE_AGE_MS,
   MAX_RECOVERY_ATTEMPTS,
   RECOVERY_COOLDOWN_MS,
   STALE_PENDING_MS,
@@ -265,17 +266,70 @@ describe('webhook delivery recovery sweep', () => {
 
   it('leaves the row recoverable when the re-enqueue itself fails', async () => {
     state.candidates = [orphan()];
-    state.updateResults = [claimWon(1)];
+    state.updateResults = [claimWon(1), [{ id: 'delivery-1' }]];
     queueDeliveryMock.mockRejectedValueOnce(new Error('LPUSH failed again'));
 
     const summary = await runWebhookDeliveryRecoverySweep(NOW);
 
     expect(summary).toMatchObject({ enqueueFailed: 1, requeued: 0, exhausted: 0 });
-    // Only the claim ran — the row is NOT marked failed, so the lease expires
-    // and the next window reconsiders it.
-    expect(state.updateCalls).toHaveLength(1);
+    // The row is NOT marked failed, so the lease expires and the next window
+    // reconsiders it.
+    expect(state.updateCalls.some((c) => c.set.status === 'failed')).toBe(false);
     structured(consoleLines(errorSpy), 'WEBHOOK_DELIVERY_RECOVERY_REQUEUE_FAILED');
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('REFUNDS the attempt when the enqueue never used it', async () => {
+    // The claim charges an attempt before the enqueue. If the enqueue then
+    // fails, that attempt bought nothing — and without a refund a Redis outage
+    // spends the whole budget on itself: six consecutive failures (~75 min of
+    // downtime) would terminally fail a delivery that was never attempted,
+    // charging infrastructure downtime against the customer's delivery.
+    state.candidates = [orphan({ recoveryAttempts: 2 })];
+    state.updateResults = [claimWon(3), [{ id: 'delivery-1' }]];
+    queueDeliveryMock.mockRejectedValueOnce(new Error('Redis down'));
+
+    await runWebhookDeliveryRecoverySweep(NOW);
+
+    const refund = state.updateCalls[1]!;
+    expect(refund.set).toMatchObject({ recoveryAttempts: 2 });
+    // The lease is deliberately NOT cleared — the next window should still wait
+    // out the cooldown rather than hot-loop against a dead Redis.
+    expect(refund.set).not.toHaveProperty('nextRetryAt');
+    expect(refund.where)
+      .toEqual(buildLeaseHeldCas('delivery-1', new Date(NOW.getTime() + RECOVERY_COOLDOWN_MS)));
+  });
+
+  it('refuses to send a delivery that is too old, terminally and loudly', async () => {
+    // First-deploy insurance: POSTing a months-old payload to a customer's
+    // endpoint is its own incident. It must be RESOLVED rather than filtered
+    // out of the scan, or it would sit unresolved forever — the bug this file
+    // exists to fix.
+    state.candidates = [orphan({
+      createdAt: new Date(NOW.getTime() - MAX_RECOVERABLE_AGE_MS - 60_000)
+    })];
+    state.updateResults = [claimWon(1), [{ id: 'delivery-1' }]];
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(queueDeliveryMock).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ tooOld: 1, requeued: 0 });
+    expect(state.updateCalls[1]!.set).toMatchObject({ status: 'failed' });
+    expect(String(state.updateCalls[1]!.set.errorMessage)).toContain('too old');
+    structured(consoleLines(warnSpy), 'WEBHOOK_DELIVERY_RECOVERY_TOO_OLD');
+  });
+
+  it('still delivers a row just inside the age ceiling', async () => {
+    // Boundary the other way: an off-by-one here silently stops recovering.
+    state.candidates = [orphan({
+      createdAt: new Date(NOW.getTime() - MAX_RECOVERABLE_AGE_MS + 60_000)
+    })];
+    state.updateResults = [claimWon(1)];
+
+    const summary = await runWebhookDeliveryRecoverySweep(NOW);
+
+    expect(summary).toMatchObject({ requeued: 1, tooOld: 0 });
+    expect(queueDeliveryMock).toHaveBeenCalledTimes(1);
   });
 
   it('one poisonous row does not abort the rest of the batch', async () => {
@@ -283,7 +337,8 @@ describe('webhook delivery recovery sweep', () => {
       orphan({ id: 'delivery-1' }),
       orphan({ id: 'delivery-2', webhookId: 'webhook-2', eventId: 'event-2' })
     ];
-    state.updateResults = [claimWon(1), claimWon(1)];
+    // claim(1) -> enqueue throws -> attempt REFUND -> claim(2).
+    state.updateResults = [claimWon(1), [{ id: 'delivery-1' }], claimWon(1)];
     queueDeliveryMock
       .mockRejectedValueOnce(new Error('boom'))
       .mockResolvedValueOnce('delivery-2');

--- a/apps/api/src/jobs/webhookDeliveryRecovery.ts
+++ b/apps/api/src/jobs/webhookDeliveryRecovery.ts
@@ -53,6 +53,21 @@ export const MAX_RECOVERY_ATTEMPTS = 5;
 export const RECOVERY_BATCH_SIZE = 200;
 
 /**
+ * Age past which a delivery is too stale to send at all.
+ *
+ * Deliberately NOT expressed as a lower bound on the scan: filtering ancient
+ * rows out of the candidate set would leave them unresolved forever, which is
+ * the bug this file exists to fix. They stay in scope and are resolved
+ * TERMINALLY instead, so they are visible and hand-retryable.
+ *
+ * This matters most on the very first deploy of the sweep, which is the one
+ * moment it can encounter rows that predate it by an unbounded margin: POSTing
+ * a months-old payload to a customer's endpoint is its own incident. Prod holds
+ * 0 rows today, so this is insurance rather than a live concern.
+ */
+export const MAX_RECOVERABLE_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
  * Five minutes. Deliberately sub-hourly so it needs no `scheduleRegistry` slot:
  * BullMQ anchors `repeat: { every: N }` to the Unix epoch, which is why coarse
  * intervals must go through the cron registry, and `scheduleRegistry.contract.test.ts`
@@ -99,6 +114,19 @@ export function buildUnresolvedScope(now: Date): SQL {
  * statements, and only predicates inside the UPDATE are evaluated atomically.
  * Of the N API instances sweeping concurrently, only the one whose UPDATE
  * returns a row proceeds.
+ *
+ * Note WHICH conjunct defends WHICH race. Against another SWEEPER, the status
+ * test does nothing — it admits both unresolved statuses, and a rival sweeper
+ * leaves the row unresolved too. It is the LEASE predicate that serialises
+ * them: the winner stamps `next_retry_at = now + RECOVERY_COOLDOWN_MS`, which
+ * is in the future relative to every concurrent sweeper's `now`.
+ *
+ * The same lease is what defends the gap against a DELIVERY WORKER: a worker
+ * claiming the row between our SELECT and our CAS writes
+ * `next_retry_at = now + EXECUTION_LEASE_MS`, so our `next_retry_at <= now`
+ * fails and we correctly leave the row to the worker that is about to POST it.
+ * Drop the lease conjunct and both races reopen even though the status test
+ * still reads as if it were guarding them.
  */
 export function buildRecoveryClaimCas(deliveryId: string, now: Date): SQL {
   return and(
@@ -141,6 +169,8 @@ export interface WebhookRecoverySweepSummary {
   undeliverable: number;
   /** Claimed but the enqueue still failed — stays unresolved for the next window. */
   enqueueFailed: number;
+  /** Older than MAX_RECOVERABLE_AGE_MS — resolved terminally, never sent. */
+  tooOld: number;
   /**
    * A terminal write that matched no row: the lease was lost between the claim
    * and the write (a delivery worker's execution claim only tests `status`, so
@@ -230,6 +260,7 @@ export async function runWebhookDeliveryRecoverySweep(
     raced: 0,
     undeliverable: 0,
     enqueueFailed: 0,
+    tooOld: 0,
     terminalWriteLost: 0
   };
 
@@ -305,6 +336,27 @@ export async function runWebhookDeliveryRecoverySweep(
               orgId: candidate.webhookOrgId,
               eventId: candidate.eventId,
               eventType: candidate.eventType
+            })}`);
+          }
+        );
+        continue;
+      }
+
+      if (now.getTime() - candidate.createdAt.getTime() > MAX_RECOVERABLE_AGE_MS) {
+        await resolveTerminally(
+          summary,
+          candidate,
+          leaseUntil,
+          'Never claimed by a delivery worker and now too old to send; abandoned without delivery',
+          () => {
+            summary.tooOld += 1;
+            console.warn(`[WebhookDeliveryRecovery] too-old-to-deliver ${JSON.stringify({
+              errorId: 'WEBHOOK_DELIVERY_RECOVERY_TOO_OLD',
+              deliveryId: candidate.id,
+              webhookId: candidate.webhookId,
+              orgId: candidate.webhookOrgId,
+              eventId: candidate.eventId,
+              ageMs: now.getTime() - candidate.createdAt.getTime()
             })}`);
           }
         );
@@ -414,8 +466,21 @@ export async function runWebhookDeliveryRecoverySweep(
         // Postgres connection across it is the pattern that exhausts the pool.
         await getWebhookWorker().queueDelivery(config, event, candidate.id);
       } catch (enqueueError) {
-        // Still no job. The lease expires on its own, so the next window
-        // reconsiders the row rather than losing it.
+        // Still no job. Hand the attempt BACK: the claim charged one before the
+        // enqueue, but this enqueue never used it. Without the refund a Redis
+        // outage spends the whole budget on itself — six consecutive failures,
+        // about 75 minutes of downtime, would terminally fail a delivery that
+        // was never actually attempted, charging infrastructure downtime
+        // against the customer's delivery. The lease is deliberately LEFT in
+        // place so the next window still waits out the cooldown instead of
+        // hot-looping against a dead Redis.
+        await runWithSystemDbAccess(async () =>
+          db
+            .update(webhookDeliveries)
+            .set({ recoveryAttempts: candidate.recoveryAttempts })
+            .where(buildLeaseHeldCas(candidate.id, leaseUntil))
+            .returning({ id: webhookDeliveries.id })
+        );
         summary.enqueueFailed += 1;
         captureException(enqueueError instanceof Error ? enqueueError : new Error(String(enqueueError)));
         console.error(`[WebhookDeliveryRecovery] requeue-failed ${JSON.stringify({
@@ -502,6 +567,19 @@ export async function initializeWebhookDeliveryRecovery(): Promise<void> {
 
     console.log('[WebhookDeliveryRecovery] Initialized unresolved-delivery sweep');
   } catch (error) {
+    // Close what we already opened. Without this a throw from `queue.add` (or
+    // the repeatable-job cleanup above) leaves a live BullMQ Worker holding a
+    // Redis connection and polling forever, with no handle left to stop it —
+    // `shutdownWebhookDeliveryRecovery` only sees what the module variable
+    // still points at.
+    if (recoveryWorker) {
+      await recoveryWorker.close().catch(() => {});
+      recoveryWorker = null;
+    }
+    if (recoveryQueue) {
+      await recoveryQueue.close().catch(() => {});
+      recoveryQueue = null;
+    }
     console.error('[WebhookDeliveryRecovery] Failed to initialize:', error);
     throw error;
   }

--- a/apps/api/src/jobs/webhookDeliveryRecovery.ts
+++ b/apps/api/src/jobs/webhookDeliveryRecovery.ts
@@ -1,0 +1,467 @@
+import { Queue, Worker, type Job } from 'bullmq';
+import { and, asc, eq, inArray, isNull, lt, lte, or, type SQL } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { webhookDeliveries, webhooks } from '../db/schema';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import { toWebhookConfig } from '../services/webhookConfig';
+import { getWebhookWorker } from '../workers/webhookDelivery';
+import { attachWorkerObservability } from './workerObservability';
+import type { BreezeEvent, EventType } from '../services/eventBus';
+
+const { db } = dbModule;
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+};
+
+const QUEUE_NAME = 'webhook-delivery-recovery';
+
+/**
+ * How long an unresolved row may sit before the sweep considers it.
+ *
+ * This threshold is a COST control, not the correctness boundary. Re-queueing a
+ * delivery that was merely backlogged is harmless because the worker's
+ * execution claim lets only one copy of a job POST (see
+ * `setDeliveryClaimCallback`); without that claim no threshold would be safe,
+ * since BRPOP's 5s is only its empty-queue wait and the FIFO backlog ahead of a
+ * job is unbounded. Fifteen minutes simply keeps the sweep from manufacturing
+ * duplicate queue entries during an ordinary traffic spike.
+ */
+export const STALE_PENDING_MS = 15 * 60 * 1000;
+
+/**
+ * Lease a delivery worker holds while executing a claimed delivery. Must
+ * comfortably exceed one attempt (`WEBHOOK_TIMEOUT_MS`, 30s) so a live
+ * delivery is never declared abandoned underneath itself.
+ */
+export const EXECUTION_LEASE_MS = 5 * 60 * 1000;
+
+/**
+ * Gap enforced between recovery attempts on one row. Doubles as the sweep's
+ * lease: a claimed row is invisible to the next tick, and to every other API
+ * instance, until it expires.
+ */
+export const RECOVERY_COOLDOWN_MS = 15 * 60 * 1000;
+
+/**
+ * Recovery attempts before a row is abandoned. Reached only when the row keeps
+ * landing back in `pending` — i.e. the delivery worker never even claimed it.
+ */
+export const MAX_RECOVERY_ATTEMPTS = 5;
+
+/**
+ * Rows examined per sweep. Bounded on purpose: `webhook_deliveries` has no
+ * retention job anywhere, so the table grows without limit, and a backlog after
+ * a long Redis outage must not turn one tick into an unbounded fan-out of
+ * outbound POSTs.
+ */
+export const RECOVERY_BATCH_SIZE = 200;
+
+/**
+ * Five minutes. Deliberately sub-hourly so it needs no `scheduleRegistry` slot:
+ * BullMQ anchors `repeat: { every: N }` to the Unix epoch, which is why coarse
+ * intervals must go through the cron registry, and `scheduleRegistry.contract.test.ts`
+ * rejects only intervals of an hour or more.
+ */
+export const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * The two unresolved statuses, and why they are handled differently.
+ *
+ * `pending`  — recorded, never claimed by any delivery worker. Nothing was
+ *              sent, so re-driving it cannot duplicate a POST.
+ * `retrying` — claimed by a worker that then died. The POST may or may not have
+ *              reached the customer, so this is resolved TERMINALLY rather than
+ *              re-sent; auto-repeating a possibly-delivered POST is the one
+ *              failure this system treats as worse than a missed one.
+ */
+const UNRESOLVED_STATUSES = ['pending', 'retrying'] as const;
+
+/**
+ * Candidate scope: unresolved, aged out, and not currently leased.
+ *
+ * `next_retry_at IS NULL OR next_retry_at <= now` is spelled as an explicit
+ * OR-with-IS-NULL rather than a negation. `NOT (next_retry_at > now)` over a
+ * NULLable column evaluates to NULL for every never-leased row and silently
+ * drops exactly the rows this sweep exists to find.
+ */
+export function buildUnresolvedScope(now: Date): SQL {
+  return and(
+    inArray(webhookDeliveries.status, [...UNRESOLVED_STATUSES]),
+    lt(webhookDeliveries.createdAt, new Date(now.getTime() - STALE_PENDING_MS)),
+    or(
+      isNull(webhookDeliveries.nextRetryAt),
+      lte(webhookDeliveries.nextRetryAt, now)
+    )
+  )!;
+}
+
+/**
+ * Compare-and-swap that claims one row for the sweep.
+ *
+ * Re-asserts the ENTIRE candidate scope against this id rather than trusting
+ * the preceding SELECT: the row can change in the gap between the two
+ * statements, and only predicates inside the UPDATE are evaluated atomically.
+ * Of the N API instances sweeping concurrently, only the one whose UPDATE
+ * returns a row proceeds.
+ */
+export function buildRecoveryClaimCas(deliveryId: string, now: Date): SQL {
+  return and(
+    eq(webhookDeliveries.id, deliveryId),
+    inArray(webhookDeliveries.status, [...UNRESOLVED_STATUSES]),
+    lt(webhookDeliveries.createdAt, new Date(now.getTime() - STALE_PENDING_MS)),
+    or(
+      isNull(webhookDeliveries.nextRetryAt),
+      lte(webhookDeliveries.nextRetryAt, now)
+    )
+  )!;
+}
+
+/**
+ * "I still hold the lease I just took."
+ *
+ * Used for the terminal write, which happens AFTER the claim has stamped
+ * `next_retry_at = leaseUntil`. Re-running the claim predicate there would fail
+ * its own `next_retry_at <= now` test; matching the exact lease instant instead
+ * additionally proves no other instance re-leased the row in between.
+ */
+export function buildLeaseHeldCas(deliveryId: string, leaseUntil: Date): SQL {
+  return and(
+    eq(webhookDeliveries.id, deliveryId),
+    inArray(webhookDeliveries.status, [...UNRESOLVED_STATUSES]),
+    eq(webhookDeliveries.nextRetryAt, leaseUntil)
+  )!;
+}
+
+export interface WebhookRecoverySweepSummary {
+  scanned: number;
+  requeued: number;
+  /** `pending` rows abandoned after MAX_RECOVERY_ATTEMPTS. */
+  exhausted: number;
+  /** `retrying` rows whose worker died — resolved terminally, never re-sent. */
+  abandonedInFlight: number;
+  /** Lost the CAS to another instance, or the row moved on mid-sweep. */
+  raced: number;
+  /** Webhook no longer active, or its credentials would not decrypt. */
+  undeliverable: number;
+  /** Claimed but the enqueue still failed — stays unresolved for the next window. */
+  enqueueFailed: number;
+}
+
+/**
+ * Terminal state for a row this sweep will not drive again.
+ *
+ * `failed` rather than a bespoke status on purpose: it is the one status the
+ * existing per-delivery retry endpoint (`routes/webhooks.ts`) accepts, so an
+ * operator can still drive it by hand from the UI. Leaving it unresolved
+ * forever is what #4095 is about.
+ */
+async function markUnrecoverable(
+  deliveryId: string,
+  leaseUntil: Date,
+  errorMessage: string
+): Promise<boolean> {
+  const rows = await db
+    .update(webhookDeliveries)
+    .set({ status: 'failed', errorMessage, nextRetryAt: null })
+    .where(buildLeaseHeldCas(deliveryId, leaseUntil))
+    .returning({ id: webhookDeliveries.id });
+
+  return rows.length > 0;
+}
+
+/**
+ * Reclaim `webhook_deliveries` rows that were committed but never delivered.
+ *
+ * The row is written to Postgres BEFORE `queueDelivery`, which is a bare
+ * `redis.lpush` onto a non-durable list. If that LPUSH throws, or the process
+ * dies between the commit and the LPUSH, the row sits at `status = 'pending'`
+ * with no job anywhere and nothing ever looks at it again (#4095).
+ *
+ * This sweep is the SINGLE owner of re-queueing. The '*' subscriber only
+ * reports its dedupe skips: if it also re-queued stale rows, a redelivered
+ * event and this sweep could both drive the same row.
+ */
+export async function runWebhookDeliveryRecoverySweep(
+  now: Date = new Date()
+): Promise<WebhookRecoverySweepSummary> {
+  const summary: WebhookRecoverySweepSummary = {
+    scanned: 0,
+    requeued: 0,
+    exhausted: 0,
+    abandonedInFlight: 0,
+    raced: 0,
+    undeliverable: 0,
+    enqueueFailed: 0
+  };
+
+  const candidates = await runWithSystemDbAccess(async () =>
+    db
+      .select({
+        id: webhookDeliveries.id,
+        webhookId: webhookDeliveries.webhookId,
+        eventId: webhookDeliveries.eventId,
+        eventType: webhookDeliveries.eventType,
+        payload: webhookDeliveries.payload,
+        status: webhookDeliveries.status,
+        recoveryAttempts: webhookDeliveries.recoveryAttempts,
+        createdAt: webhookDeliveries.createdAt,
+        webhookOrgId: webhooks.orgId,
+        webhookName: webhooks.name,
+        webhookStatus: webhooks.status,
+        webhookUrl: webhooks.url,
+        webhookSecret: webhooks.secret,
+        webhookEvents: webhooks.events,
+        webhookHeaders: webhooks.headers,
+        webhookRetryPolicy: webhooks.retryPolicy
+      })
+      .from(webhookDeliveries)
+      .innerJoin(webhooks, eq(webhooks.id, webhookDeliveries.webhookId))
+      .where(buildUnresolvedScope(now))
+      .orderBy(asc(webhookDeliveries.createdAt))
+      .limit(RECOVERY_BATCH_SIZE)
+  );
+
+  summary.scanned = candidates.length;
+
+  for (const candidate of candidates) {
+    const leaseUntil = new Date(now.getTime() + RECOVERY_COOLDOWN_MS);
+
+    try {
+      // Claim FIRST. Everything past this point has won the row, so a second
+      // instance cannot duplicate the work.
+      const [claimed] = await runWithSystemDbAccess(async () =>
+        db
+          .update(webhookDeliveries)
+          .set({
+            recoveryAttempts: candidate.recoveryAttempts + 1,
+            nextRetryAt: leaseUntil
+          })
+          .where(buildRecoveryClaimCas(candidate.id, now))
+          .returning({
+            id: webhookDeliveries.id,
+            recoveryAttempts: webhookDeliveries.recoveryAttempts
+          })
+      );
+
+      if (!claimed) {
+        summary.raced += 1;
+        continue;
+      }
+
+      // A `retrying` row was claimed by a delivery worker that then died. We
+      // cannot know whether the customer's endpoint was reached, so it is
+      // resolved terminally and never re-sent.
+      if (candidate.status === 'retrying') {
+        await runWithSystemDbAccess(() => markUnrecoverable(
+          candidate.id,
+          leaseUntil,
+          'Delivery was claimed by a worker that stopped before reporting a result; outcome unknown'
+        ));
+        summary.abandonedInFlight += 1;
+        console.warn(`[WebhookDeliveryRecovery] in-flight-abandoned ${JSON.stringify({
+          errorId: 'WEBHOOK_DELIVERY_RECOVERY_IN_FLIGHT_ABANDONED',
+          deliveryId: candidate.id,
+          webhookId: candidate.webhookId,
+          orgId: candidate.webhookOrgId,
+          eventId: candidate.eventId,
+          eventType: candidate.eventType
+        })}`);
+        continue;
+      }
+
+      if (claimed.recoveryAttempts > MAX_RECOVERY_ATTEMPTS) {
+        await runWithSystemDbAccess(() => markUnrecoverable(
+          candidate.id,
+          leaseUntil,
+          `Never claimed by a delivery worker; abandoned after ${MAX_RECOVERY_ATTEMPTS} recovery attempts`
+        ));
+        summary.exhausted += 1;
+        console.warn(`[WebhookDeliveryRecovery] recovery-exhausted ${JSON.stringify({
+          errorId: 'WEBHOOK_DELIVERY_RECOVERY_EXHAUSTED',
+          deliveryId: candidate.id,
+          webhookId: candidate.webhookId,
+          orgId: candidate.webhookOrgId,
+          eventId: candidate.eventId,
+          eventType: candidate.eventType,
+          recoveryAttempts: claimed.recoveryAttempts
+        })}`);
+        continue;
+      }
+
+      // A webhook the customer has since disabled must not receive a late POST,
+      // but the row cannot just be dropped either — mark it terminal so it stays
+      // visible and hand-retryable rather than unresolved forever.
+      if (candidate.webhookStatus !== 'active') {
+        await runWithSystemDbAccess(() => markUnrecoverable(
+          candidate.id,
+          leaseUntil,
+          `Never enqueued for delivery; webhook is ${candidate.webhookStatus}`
+        ));
+        summary.undeliverable += 1;
+        console.warn(`[WebhookDeliveryRecovery] webhook-inactive ${JSON.stringify({
+          errorId: 'WEBHOOK_DELIVERY_RECOVERY_WEBHOOK_INACTIVE',
+          deliveryId: candidate.id,
+          webhookId: candidate.webhookId,
+          orgId: candidate.webhookOrgId,
+          webhookStatus: candidate.webhookStatus
+        })}`);
+        continue;
+      }
+
+      let config;
+      try {
+        config = toWebhookConfig({
+          id: candidate.webhookId,
+          orgId: candidate.webhookOrgId,
+          name: candidate.webhookName,
+          url: candidate.webhookUrl,
+          secret: candidate.webhookSecret,
+          events: candidate.webhookEvents,
+          headers: candidate.webhookHeaders,
+          retryPolicy: candidate.webhookRetryPolicy
+        });
+      } catch (decryptError) {
+        // Delivering with unusable credentials is worse than not delivering.
+        await runWithSystemDbAccess(() => markUnrecoverable(
+          candidate.id,
+          leaseUntil,
+          'Never enqueued for delivery; webhook credentials could not be decrypted'
+        ));
+        summary.undeliverable += 1;
+        captureException(decryptError instanceof Error ? decryptError : new Error(String(decryptError)));
+        console.error(`[WebhookDeliveryRecovery] decrypt-failed ${JSON.stringify({
+          errorId: 'WEBHOOK_DELIVERY_RECOVERY_DECRYPT_FAILED',
+          deliveryId: candidate.id,
+          webhookId: candidate.webhookId,
+          orgId: candidate.webhookOrgId
+        })}`);
+        continue;
+      }
+
+      // The original event, reconstructed from the row. `id` MUST stay the
+      // original `event_id`: it goes out as `X-Breeze-Event-Id`, which is the
+      // customer's own idempotency key, and it is what the unique index dedupes
+      // on. `metadata.timestamp` is NOT stored per delivery, so the row's
+      // `created_at` — the instant the delivery was recorded — stands in for it;
+      // it is the closest recorded approximation of the original event time.
+      const event: BreezeEvent = {
+        id: candidate.eventId,
+        type: candidate.eventType as EventType,
+        orgId: candidate.webhookOrgId,
+        source: 'webhook.recovery',
+        priority: 'normal',
+        payload: (candidate.payload ?? {}) as Record<string, unknown>,
+        metadata: { timestamp: candidate.createdAt.toISOString() }
+      };
+
+      try {
+        // Outside any DB context: this is a Redis LPUSH, and holding a pooled
+        // Postgres connection across it is the pattern that exhausts the pool.
+        await getWebhookWorker().queueDelivery(config, event, candidate.id);
+      } catch (enqueueError) {
+        // Still no job. The lease expires on its own, so the next window
+        // reconsiders the row rather than losing it.
+        summary.enqueueFailed += 1;
+        captureException(enqueueError instanceof Error ? enqueueError : new Error(String(enqueueError)));
+        console.error(`[WebhookDeliveryRecovery] requeue-failed ${JSON.stringify({
+          errorId: 'WEBHOOK_DELIVERY_RECOVERY_REQUEUE_FAILED',
+          deliveryId: candidate.id,
+          webhookId: candidate.webhookId,
+          orgId: candidate.webhookOrgId,
+          error: enqueueError instanceof Error ? enqueueError.message : String(enqueueError)
+        })}`);
+        continue;
+      }
+
+      summary.requeued += 1;
+      console.warn(`[WebhookDeliveryRecovery] delivery-recovered ${JSON.stringify({
+        errorId: 'WEBHOOK_DELIVERY_RECOVERED',
+        deliveryId: candidate.id,
+        webhookId: candidate.webhookId,
+        orgId: candidate.webhookOrgId,
+        eventId: candidate.eventId,
+        eventType: candidate.eventType,
+        recoveryAttempt: claimed.recoveryAttempts,
+        unresolvedForMs: now.getTime() - candidate.createdAt.getTime()
+      })}`);
+    } catch (error) {
+      // One bad row must not abort the batch — that would be the same
+      // fan-out-aborting bug #4095 fixes in the subscriber.
+      captureException(error instanceof Error ? error : new Error(String(error)));
+      console.error(`[WebhookDeliveryRecovery] candidate-failed ${JSON.stringify({
+        errorId: 'WEBHOOK_DELIVERY_RECOVERY_CANDIDATE_FAILED',
+        deliveryId: candidate.id,
+        webhookId: candidate.webhookId,
+        error: error instanceof Error ? error.message : String(error)
+      })}`);
+    }
+  }
+
+  if (summary.scanned > 0) {
+    console.warn(`[WebhookDeliveryRecovery] sweep-complete ${JSON.stringify({
+      errorId: 'WEBHOOK_DELIVERY_RECOVERY_SWEEP',
+      ...summary
+    })}`);
+  }
+
+  return summary;
+}
+
+let recoveryQueue: Queue | null = null;
+let recoveryWorker: Worker | null = null;
+
+export function getWebhookDeliveryRecoveryQueue(): Queue {
+  if (!recoveryQueue) {
+    recoveryQueue = new Queue(QUEUE_NAME, { connection: getBullMQConnection() });
+  }
+  return recoveryQueue;
+}
+
+export function createWebhookDeliveryRecoveryWorker(): Worker {
+  return new Worker(
+    QUEUE_NAME,
+    async (_job: Job) => runWebhookDeliveryRecoverySweep(),
+    { connection: getBullMQConnection(), concurrency: 1 }
+  );
+}
+
+export async function initializeWebhookDeliveryRecovery(): Promise<void> {
+  try {
+    recoveryWorker = createWebhookDeliveryRecoveryWorker();
+    attachWorkerObservability(recoveryWorker, 'webhookDeliveryRecovery');
+    recoveryWorker.on('error', (err) => {
+      console.error('[WebhookDeliveryRecovery] Worker error:', err);
+    });
+
+    const queue = getWebhookDeliveryRecoveryQueue();
+    const existing = await queue.getRepeatableJobs();
+    for (const job of existing) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+
+    await queue.add('sweep', {}, {
+      repeat: { every: SWEEP_INTERVAL_MS },
+      removeOnComplete: { count: 5 },
+      removeOnFail: { count: 10 }
+    });
+
+    console.log('[WebhookDeliveryRecovery] Initialized unresolved-delivery sweep');
+  } catch (error) {
+    console.error('[WebhookDeliveryRecovery] Failed to initialize:', error);
+    throw error;
+  }
+}
+
+export async function shutdownWebhookDeliveryRecovery(): Promise<void> {
+  if (recoveryWorker) {
+    await recoveryWorker.close();
+    recoveryWorker = null;
+  }
+  if (recoveryQueue) {
+    await recoveryQueue.close();
+    recoveryQueue = null;
+  }
+}

--- a/apps/api/src/jobs/webhookDeliveryRecovery.ts
+++ b/apps/api/src/jobs/webhookDeliveryRecovery.ts
@@ -32,13 +32,6 @@ const QUEUE_NAME = 'webhook-delivery-recovery';
 export const STALE_PENDING_MS = 15 * 60 * 1000;
 
 /**
- * Lease a delivery worker holds while executing a claimed delivery. Must
- * comfortably exceed one attempt (`WEBHOOK_TIMEOUT_MS`, 30s) so a live
- * delivery is never declared abandoned underneath itself.
- */
-export const EXECUTION_LEASE_MS = 5 * 60 * 1000;
-
-/**
  * Gap enforced between recovery attempts on one row. Doubles as the sweep's
  * lease: a claimed row is invisible to the next tick, and to every other API
  * instance, until it expires.
@@ -148,6 +141,14 @@ export interface WebhookRecoverySweepSummary {
   undeliverable: number;
   /** Claimed but the enqueue still failed — stays unresolved for the next window. */
   enqueueFailed: number;
+  /**
+   * A terminal write that matched no row: the lease was lost between the claim
+   * and the write (a delivery worker's execution claim only tests `status`, so
+   * it can still take a row this sweep has leased). Counted separately because
+   * folding it into `exhausted`/`undeliverable` would report a resolution that
+   * never happened.
+   */
+  terminalWriteLost: number;
 }
 
 /**
@@ -173,6 +174,40 @@ async function markUnrecoverable(
 }
 
 /**
+ * Apply a terminal write and report whether it actually landed.
+ *
+ * `markUnrecoverable` matches the EXACT lease instant, so it writes nothing if
+ * the row was re-leased in between — which a delivery worker's execution claim
+ * can do, since that CAS only tests `status`. Swallowing the `false` would log
+ * "abandoned" and increment a resolution counter for a row that is still
+ * unresolved: precisely the kind of quiet miscount #4095 is about.
+ */
+async function resolveTerminally(
+  summary: WebhookRecoverySweepSummary,
+  candidate: { id: string; webhookId: string },
+  leaseUntil: Date,
+  errorMessage: string,
+  onLanded: () => void
+): Promise<void> {
+  const landed = await runWithSystemDbAccess(() =>
+    markUnrecoverable(candidate.id, leaseUntil, errorMessage)
+  );
+
+  if (!landed) {
+    summary.terminalWriteLost += 1;
+    console.warn(`[WebhookDeliveryRecovery] terminal-write-lost ${JSON.stringify({
+      errorId: 'WEBHOOK_DELIVERY_RECOVERY_TERMINAL_WRITE_LOST',
+      deliveryId: candidate.id,
+      webhookId: candidate.webhookId,
+      intendedMessage: errorMessage
+    })}`);
+    return;
+  }
+
+  onLanded();
+}
+
+/**
  * Reclaim `webhook_deliveries` rows that were committed but never delivered.
  *
  * The row is written to Postgres BEFORE `queueDelivery`, which is a bare
@@ -194,7 +229,8 @@ export async function runWebhookDeliveryRecoverySweep(
     abandonedInFlight: 0,
     raced: 0,
     undeliverable: 0,
-    enqueueFailed: 0
+    enqueueFailed: 0,
+    terminalWriteLost: 0
   };
 
   const candidates = await runWithSystemDbAccess(async () =>
@@ -255,39 +291,45 @@ export async function runWebhookDeliveryRecoverySweep(
       // cannot know whether the customer's endpoint was reached, so it is
       // resolved terminally and never re-sent.
       if (candidate.status === 'retrying') {
-        await runWithSystemDbAccess(() => markUnrecoverable(
-          candidate.id,
+        await resolveTerminally(
+          summary,
+          candidate,
           leaseUntil,
-          'Delivery was claimed by a worker that stopped before reporting a result; outcome unknown'
-        ));
-        summary.abandonedInFlight += 1;
-        console.warn(`[WebhookDeliveryRecovery] in-flight-abandoned ${JSON.stringify({
-          errorId: 'WEBHOOK_DELIVERY_RECOVERY_IN_FLIGHT_ABANDONED',
-          deliveryId: candidate.id,
-          webhookId: candidate.webhookId,
-          orgId: candidate.webhookOrgId,
-          eventId: candidate.eventId,
-          eventType: candidate.eventType
-        })}`);
+          'Delivery was claimed by a worker that stopped before reporting a result; outcome unknown',
+          () => {
+            summary.abandonedInFlight += 1;
+            console.warn(`[WebhookDeliveryRecovery] in-flight-abandoned ${JSON.stringify({
+              errorId: 'WEBHOOK_DELIVERY_RECOVERY_IN_FLIGHT_ABANDONED',
+              deliveryId: candidate.id,
+              webhookId: candidate.webhookId,
+              orgId: candidate.webhookOrgId,
+              eventId: candidate.eventId,
+              eventType: candidate.eventType
+            })}`);
+          }
+        );
         continue;
       }
 
       if (claimed.recoveryAttempts > MAX_RECOVERY_ATTEMPTS) {
-        await runWithSystemDbAccess(() => markUnrecoverable(
-          candidate.id,
+        await resolveTerminally(
+          summary,
+          candidate,
           leaseUntil,
-          `Never claimed by a delivery worker; abandoned after ${MAX_RECOVERY_ATTEMPTS} recovery attempts`
-        ));
-        summary.exhausted += 1;
-        console.warn(`[WebhookDeliveryRecovery] recovery-exhausted ${JSON.stringify({
-          errorId: 'WEBHOOK_DELIVERY_RECOVERY_EXHAUSTED',
-          deliveryId: candidate.id,
-          webhookId: candidate.webhookId,
-          orgId: candidate.webhookOrgId,
-          eventId: candidate.eventId,
-          eventType: candidate.eventType,
-          recoveryAttempts: claimed.recoveryAttempts
-        })}`);
+          `Never claimed by a delivery worker; abandoned after ${MAX_RECOVERY_ATTEMPTS} recovery attempts`,
+          () => {
+            summary.exhausted += 1;
+            console.warn(`[WebhookDeliveryRecovery] recovery-exhausted ${JSON.stringify({
+              errorId: 'WEBHOOK_DELIVERY_RECOVERY_EXHAUSTED',
+              deliveryId: candidate.id,
+              webhookId: candidate.webhookId,
+              orgId: candidate.webhookOrgId,
+              eventId: candidate.eventId,
+              eventType: candidate.eventType,
+              recoveryAttempts: claimed.recoveryAttempts
+            })}`);
+          }
+        );
         continue;
       }
 
@@ -295,19 +337,26 @@ export async function runWebhookDeliveryRecoverySweep(
       // but the row cannot just be dropped either — mark it terminal so it stays
       // visible and hand-retryable rather than unresolved forever.
       if (candidate.webhookStatus !== 'active') {
-        await runWithSystemDbAccess(() => markUnrecoverable(
-          candidate.id,
+        await resolveTerminally(
+          summary,
+          candidate,
           leaseUntil,
-          `Never enqueued for delivery; webhook is ${candidate.webhookStatus}`
-        ));
-        summary.undeliverable += 1;
-        console.warn(`[WebhookDeliveryRecovery] webhook-inactive ${JSON.stringify({
-          errorId: 'WEBHOOK_DELIVERY_RECOVERY_WEBHOOK_INACTIVE',
-          deliveryId: candidate.id,
-          webhookId: candidate.webhookId,
-          orgId: candidate.webhookOrgId,
-          webhookStatus: candidate.webhookStatus
-        })}`);
+          // "Never CLAIMED", not "never enqueued": an unclaimed row proves only
+          // that no worker took it. It may well have been LPUSHed and then sat
+          // in a backlog, or been lost by a Redis restart. Naming the wrong
+          // subsystem sends the on-call engineer to the wrong place.
+          `Never claimed by a delivery worker; webhook is ${candidate.webhookStatus}`,
+          () => {
+            summary.undeliverable += 1;
+            console.warn(`[WebhookDeliveryRecovery] webhook-inactive ${JSON.stringify({
+              errorId: 'WEBHOOK_DELIVERY_RECOVERY_WEBHOOK_INACTIVE',
+              deliveryId: candidate.id,
+              webhookId: candidate.webhookId,
+              orgId: candidate.webhookOrgId,
+              webhookStatus: candidate.webhookStatus
+            })}`);
+          }
+        );
         continue;
       }
 
@@ -325,19 +374,22 @@ export async function runWebhookDeliveryRecoverySweep(
         });
       } catch (decryptError) {
         // Delivering with unusable credentials is worse than not delivering.
-        await runWithSystemDbAccess(() => markUnrecoverable(
-          candidate.id,
-          leaseUntil,
-          'Never enqueued for delivery; webhook credentials could not be decrypted'
-        ));
-        summary.undeliverable += 1;
         captureException(decryptError instanceof Error ? decryptError : new Error(String(decryptError)));
-        console.error(`[WebhookDeliveryRecovery] decrypt-failed ${JSON.stringify({
-          errorId: 'WEBHOOK_DELIVERY_RECOVERY_DECRYPT_FAILED',
-          deliveryId: candidate.id,
-          webhookId: candidate.webhookId,
-          orgId: candidate.webhookOrgId
-        })}`);
+        await resolveTerminally(
+          summary,
+          candidate,
+          leaseUntil,
+          'Never claimed by a delivery worker; webhook credentials could not be decrypted',
+          () => {
+            summary.undeliverable += 1;
+            console.error(`[WebhookDeliveryRecovery] decrypt-failed ${JSON.stringify({
+              errorId: 'WEBHOOK_DELIVERY_RECOVERY_DECRYPT_FAILED',
+              deliveryId: candidate.id,
+              webhookId: candidate.webhookId,
+              orgId: candidate.webhookOrgId
+            })}`);
+          }
+        );
         continue;
       }
 

--- a/apps/api/src/services/webhookConfig.test.ts
+++ b/apps/api/src/services/webhookConfig.test.ts
@@ -10,10 +10,30 @@ vi.mock('./secretCrypto', () => ({
 }));
 
 vi.mock('./notificationChannelSecrets', () => ({
-  decryptWebhookHeaders: vi.fn((headers: unknown) => headers)
+  // NOT identity. An identity mock cannot tell whether `toWebhookConfig`
+  // actually WRAPS the headers in decryptWebhookHeaders — dropping that wrap
+  // (and shipping still-ENCRYPTED header values to the customer's endpoint)
+  // stayed green. This transforms, so the assertion can see the difference.
+  decryptWebhookHeaders: vi.fn((headers: unknown) => {
+    if (Array.isArray(headers)) {
+      return headers.map((h) => (h && typeof h === 'object' && typeof (h as { value?: unknown }).value === 'string'
+        ? { ...h, value: (h as { value: string }).value.replace(/^enc:/, '') }
+        : h));
+    }
+    if (headers && typeof headers === 'object') {
+      return Object.fromEntries(
+        Object.entries(headers as Record<string, unknown>).map(([k, v]) => [
+          k,
+          typeof v === 'string' ? v.replace(/^enc:/, '') : v
+        ])
+      );
+    }
+    return headers;
+  })
 }));
 
 import { headersToRecord, toWebhookConfig } from './webhookConfig';
+import { decryptWebhookHeaders } from './notificationChannelSecrets';
 
 const base = {
   id: 'webhook-1',
@@ -73,11 +93,23 @@ describe('toWebhookConfig', () => {
     expect(config.secret).toBe('shh');
   });
 
-  it('decrypts headers and normalises them in one step', () => {
+  it('DECRYPTS headers, not merely normalises their shape', () => {
     const config = toWebhookConfig({
       ...base,
-      headers: [{ key: 'X-Token', value: 'abc' }]
+      headers: [{ key: 'X-Token', value: 'enc:abc' }]
     });
+
+    // The `enc:` prefix is gone, which is only true if the decrypt wrap ran.
+    // Shipping the raw stored value here would send an encrypted credential to
+    // the customer's endpoint as a live header.
+    expect(config.headers).toEqual({ 'X-Token': 'abc' });
+    expect(vi.mocked(decryptWebhookHeaders)).toHaveBeenCalledWith([
+      { key: 'X-Token', value: 'enc:abc' }
+    ]);
+  });
+
+  it('decrypts headers in the plain-object shape too', () => {
+    const config = toWebhookConfig({ ...base, headers: { 'X-Token': 'enc:abc' } });
 
     expect(config.headers).toEqual({ 'X-Token': 'abc' });
   });

--- a/apps/api/src/services/webhookConfig.test.ts
+++ b/apps/api/src/services/webhookConfig.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./secretCrypto', () => ({
+  // Mirrors the real contract: returns the plaintext, and THROWS on a value
+  // that looks encrypted but cannot be decrypted.
+  decryptForColumn: vi.fn((_t: string, _c: string, value: string) => {
+    if (value.startsWith('enc:bad')) throw new Error('decrypt failed: AAD mismatch');
+    return value.startsWith('enc:') ? value.slice(4) : value;
+  })
+}));
+
+vi.mock('./notificationChannelSecrets', () => ({
+  decryptWebhookHeaders: vi.fn((headers: unknown) => headers)
+}));
+
+import { headersToRecord, toWebhookConfig } from './webhookConfig';
+
+const base = {
+  id: 'webhook-1',
+  orgId: 'org-1',
+  name: 'Ops hook',
+  url: 'enc:https://example.test/hook',
+  secret: null as string | null,
+  events: ['*'],
+  headers: null as unknown,
+  retryPolicy: null as unknown
+};
+
+describe('headersToRecord', () => {
+  it('flattens the {key,value} array shape the UI editor writes', () => {
+    expect(headersToRecord([
+      { key: 'X-Token', value: 'abc' },
+      { key: 'X-Other', value: 'def' }
+    ])).toEqual({ 'X-Token': 'abc', 'X-Other': 'def' });
+  });
+
+  it('passes through the plain-object shape', () => {
+    expect(headersToRecord({ 'X-Token': 'abc' })).toEqual({ 'X-Token': 'abc' });
+  });
+
+  it('drops entries whose value is not a string rather than coercing them', () => {
+    // A coerced non-string lands in the outbound request as "[object Object]",
+    // which the customer sees and cannot explain.
+    expect(headersToRecord({ ok: 'yes', bad: { nested: true }, alsoBad: 42 }))
+      .toEqual({ ok: 'yes' });
+    expect(headersToRecord([
+      { key: 'ok', value: 'yes' },
+      { key: 'bad', value: { nested: true } },
+      { novalue: 'x' }
+    ])).toEqual({ ok: 'yes' });
+  });
+
+  it('treats absent or non-object headers as empty', () => {
+    expect(headersToRecord(null)).toEqual({});
+    expect(headersToRecord(undefined)).toEqual({});
+    expect(headersToRecord('nonsense')).toEqual({});
+  });
+});
+
+describe('toWebhookConfig', () => {
+  it('decrypts the url and leaves an absent secret undefined', () => {
+    const config = toWebhookConfig({ ...base });
+
+    expect(config.url).toBe('https://example.test/hook');
+    expect(config.secret).toBeUndefined();
+  });
+
+  it('decrypts a present secret', () => {
+    // The truthy `secret` branch: this is the HMAC signing key, and shipping it
+    // still-encrypted would make every signature the customer verifies wrong.
+    const config = toWebhookConfig({ ...base, secret: 'enc:shh' });
+
+    expect(config.secret).toBe('shh');
+  });
+
+  it('decrypts headers and normalises them in one step', () => {
+    const config = toWebhookConfig({
+      ...base,
+      headers: [{ key: 'X-Token', value: 'abc' }]
+    });
+
+    expect(config.headers).toEqual({ 'X-Token': 'abc' });
+  });
+
+  it('falls back to the stored value for legacy plaintext', () => {
+    const config = toWebhookConfig({ ...base, url: 'https://plain.test/hook' });
+
+    expect(config.url).toBe('https://plain.test/hook');
+  });
+
+  it('THROWS on an undecryptable row rather than delivering with bad credentials', () => {
+    // Both callers rely on this to isolate the row: delivering with unusable
+    // credentials is worse than not delivering.
+    expect(() => toWebhookConfig({ ...base, url: 'enc:bad' })).toThrow(/AAD mismatch/);
+  });
+
+  it('normalises a missing events array to empty', () => {
+    expect(toWebhookConfig({ ...base, events: null }).events).toEqual([]);
+  });
+});

--- a/apps/api/src/services/webhookConfig.ts
+++ b/apps/api/src/services/webhookConfig.ts
@@ -1,0 +1,86 @@
+import { decryptForColumn } from './secretCrypto';
+import { decryptWebhookHeaders } from './notificationChannelSecrets';
+import type { WebhookConfig } from '../workers/webhookDelivery';
+
+/**
+ * Row shape this module needs off `webhooks`. Deliberately structural rather
+ * than `typeof webhooks.$inferSelect` so callers can hand over a narrowed
+ * `select({...})` projection (the recovery sweep does) without widening it.
+ */
+export interface WebhookConfigRow {
+  id: string;
+  orgId: string;
+  name: string;
+  url: string;
+  secret: string | null;
+  events: string[] | null;
+  headers: unknown;
+  retryPolicy: unknown;
+}
+
+/**
+ * Normalise the `headers` jsonb into a flat record.
+ *
+ * Two historical shapes are in the column: an array of `{ key, value }` pairs
+ * (what the UI editor writes) and a plain object. Anything whose value is not
+ * a string is dropped rather than coerced — a header with a non-string value
+ * would be stringified into the outbound request as "[object Object]".
+ */
+export function headersToRecord(headers: unknown): Record<string, string> {
+  if (!headers) return {};
+
+  if (Array.isArray(headers)) {
+    return headers.reduce<Record<string, string>>((acc, header) => {
+      if (
+        header
+        && typeof header === 'object'
+        && typeof (header as { key?: unknown }).key === 'string'
+        && typeof (header as { value?: unknown }).value === 'string'
+      ) {
+        acc[(header as { key: string }).key] = (header as { value: string }).value;
+      }
+      return acc;
+    }, {});
+  }
+
+  if (typeof headers === 'object') {
+    return Object.entries(headers as Record<string, unknown>).reduce<Record<string, string>>((acc, [key, value]) => {
+      if (typeof value === 'string') {
+        acc[key] = value;
+      }
+      return acc;
+    }, {});
+  }
+
+  return {};
+}
+
+/**
+ * Decrypt one `webhooks` row into the config the delivery worker POSTs with.
+ *
+ * THROWS on a row that looks encrypted but cannot be decrypted (key/AAD
+ * mismatch, partial migration, corruption) — `decryptForColumn`'s own
+ * behaviour, deliberately not softened here. Delivering with unusable
+ * credentials is worse than not delivering, so every caller must decide what
+ * to do with the failure; both current callers isolate it per row and surface
+ * it to Sentry rather than letting one bad row abort a batch.
+ *
+ * Extracted from `index.ts` for #4095: the recovery sweep needs the exact same
+ * decrypt/normalise path the '*' subscriber uses, and a second copy of it is
+ * how the two would silently diverge the next time an encrypted column is
+ * added to `webhooks`.
+ */
+export function toWebhookConfig(row: WebhookConfigRow): WebhookConfig {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    name: row.name,
+    url: decryptForColumn('webhooks', 'url', row.url) ?? row.url,
+    secret: row.secret
+      ? decryptForColumn('webhooks', 'secret', row.secret) ?? undefined
+      : undefined,
+    events: row.events ?? [],
+    headers: headersToRecord(decryptWebhookHeaders(row.headers)),
+    retryPolicy: (row.retryPolicy ?? undefined) as WebhookConfig['retryPolicy']
+  };
+}

--- a/apps/api/src/services/webhookDeliveryRecord.sql.test.ts
+++ b/apps/api/src/services/webhookDeliveryRecord.sql.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { buildExecutionClaimCas, buildExistingDeliveryLookup } from './webhookDeliveryRecord';
+
+/**
+ * COMPILED-SQL assertions for the two predicates that used to be anonymous
+ * closures inside `index.ts` and were therefore untestable at any level.
+ *
+ * Both are safety-critical and neither is covered by a behavioural suite:
+ *
+ *   - the execution claim is what stops one delivery, present twice on a
+ *     queue with no job identity, from POSTing to the customer TWICE. Losing
+ *     `status = 'pending'` from it turns the claim into an unconditional
+ *     success and every duplicate delivers;
+ *   - the dedupe read-back names the row a skip deferred to. Losing the
+ *     `webhook_id` conjunct makes it report ANOTHER webhook's delivery status
+ *     as this one's, since one event fans out to every subscribed webhook and
+ *     `event_id` alone is not unique.
+ */
+describe('webhook delivery record predicates (compiled SQL)', () => {
+  const dialect = new PgDialect();
+
+  it('execution claim is an AND of the delivery id and a pending marker', () => {
+    const { sql, params } = dialect.sqlToQuery(buildExecutionClaimCas('delivery-1'));
+
+    expect(sql).toBe(
+      '("webhook_deliveries"."id" = $1 and "webhook_deliveries"."status" = $2)'
+    );
+    expect(params).toEqual(['delivery-1', 'pending']);
+  });
+
+  it('dedupe read-back is keyed on BOTH webhook and event', () => {
+    const { sql, params } = dialect.sqlToQuery(
+      buildExistingDeliveryLookup('webhook-1', 'event-1')
+    );
+
+    // Both conjuncts, in the same shape as the unique index the insert
+    // conflicted on.
+    expect(sql).toBe(
+      '("webhook_deliveries"."webhook_id" = $1 and "webhook_deliveries"."event_id" = $2)'
+    );
+    expect(params).toEqual(['webhook-1', 'event-1']);
+  });
+});

--- a/apps/api/src/services/webhookDeliveryRecord.sql.test.ts
+++ b/apps/api/src/services/webhookDeliveryRecord.sql.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { PgDialect } from 'drizzle-orm/pg-core';
-import { buildExecutionClaimCas, buildExistingDeliveryLookup } from './webhookDeliveryRecord';
+import {
+  buildExecutionClaimCas,
+  buildExistingDeliveryLookup,
+  buildOutcomeWriteCas
+} from './webhookDeliveryRecord';
 
 /**
  * COMPILED-SQL assertions for the two predicates that used to be anonymous
@@ -27,6 +31,19 @@ describe('webhook delivery record predicates (compiled SQL)', () => {
       '("webhook_deliveries"."id" = $1 and "webhook_deliveries"."status" = $2)'
     );
     expect(params).toEqual(['delivery-1', 'pending']);
+  });
+
+  it('outcome write refuses to overwrite a recorded success', () => {
+    const { sql, params } = dialect.sqlToQuery(buildOutcomeWriteCas('delivery-1'));
+
+    // The `<> 'delivered'` conjunct is what stops a late-arriving FAILURE from
+    // clobbering a success the customer already received. It lived as an
+    // anonymous closure in coverage-excluded `index.ts`, where deleting it
+    // passed everywhere.
+    expect(sql).toBe(
+      '("webhook_deliveries"."id" = $1 and "webhook_deliveries"."status" <> $2)'
+    );
+    expect(params).toEqual(['delivery-1', 'delivered']);
   });
 
   it('dedupe read-back is keyed on BOTH webhook and event', () => {

--- a/apps/api/src/services/webhookDeliveryRecord.test.ts
+++ b/apps/api/src/services/webhookDeliveryRecord.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Behaviour of the outcome writer.
+ *
+ * This lived as an anonymous closure inside `index.ts`, which is excluded from
+ * coverage — so neither its CAS nor its zero-row branch was reachable by any
+ * test. The predicates themselves are pinned as compiled SQL in the sibling
+ * `.sql.test.ts`; this file covers what the writer DOES.
+ */
+
+interface UpdateCall { table: string; set: Record<string, unknown>; where: unknown }
+
+const state = vi.hoisted(() => ({
+  updateCalls: [] as UpdateCall[],
+  updateResults: [] as Record<string, unknown>[][]
+}));
+
+vi.mock('../db', () => {
+  const makeUpdate = (table: { _: { name?: string } } | unknown) => ({
+    set: (values: Record<string, unknown>) => ({
+      where: (predicate: unknown) => {
+        const record = () => {
+          const name = (table as { [k: symbol]: unknown; _?: { name?: string } })?._?.name
+            ?? 'unknown';
+          state.updateCalls.push({ table: name, set: values, where: predicate });
+          return state.updateResults.shift() ?? [];
+        };
+        // `.returning()` when the caller wants rows back; awaiting the builder
+        // directly when it does not (the aggregate write).
+        return {
+          returning: async () => record(),
+          then: (res: (v: unknown) => unknown) => Promise.resolve(record()).then(res)
+        };
+      }
+    })
+  });
+  return {
+    db: { update: makeUpdate },
+    withSystemDbAccessContext: (fn: () => unknown) => fn(),
+    runOutsideDbContext: (fn: () => unknown) => fn()
+  };
+});
+
+import { recordDeliveryOutcome } from './webhookDeliveryRecord';
+
+const RESULT = {
+  deliveryId: 'delivery-1',
+  webhookId: 'webhook-1',
+  eventId: 'event-1',
+  eventType: 'alert.triggered',
+  success: true,
+  attempts: 1,
+  responseStatus: 200,
+  responseTimeMs: 12,
+  deliveredAt: '2026-09-11T12:00:00.000Z'
+};
+
+const lines = (spy: { mock: { calls: unknown[][] } }) =>
+  spy.mock.calls.map((c) => c.map(String).join(' '));
+
+const structured = (ls: string[], id: string) => {
+  const line = ls.find((l) => l.includes(id));
+  expect(line, `no console line carried ${id}`).toBeDefined();
+  return JSON.parse(line!.slice(line!.indexOf('{'))) as Record<string, unknown>;
+};
+
+describe('recordDeliveryOutcome', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    state.updateCalls = [];
+    state.updateResults = [];
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('writes the outcome and clears the execution lease', async () => {
+    state.updateResults = [[{ id: 'delivery-1' }], []];
+
+    await recordDeliveryOutcome({ ...RESULT } as never);
+
+    expect(state.updateCalls[0]!.set).toMatchObject({
+      status: 'delivered',
+      attempts: 1,
+      responseStatus: 200,
+      nextRetryAt: null
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns when the write matches nothing — someone else resolved the row', async () => {
+    state.updateResults = [[], []];
+
+    await recordDeliveryOutcome({ ...RESULT, success: false } as never);
+
+    const payload = structured(lines(warnSpy), 'WEBHOOK_DELIVERY_OUTCOME_WRITE_SKIPPED');
+    expect(payload).toMatchObject({
+      deliveryId: 'delivery-1',
+      attemptedStatus: 'failed'
+    });
+  });
+
+  it('skips the row write for a DLQ replay, which has no row, and says so', async () => {
+    // Without this branch the zero-row warning fires on EVERY routine replay
+    // with a stated cause that is untrue — voiding the warning for the real
+    // race it exists to catch.
+    state.updateResults = [[]];
+
+    await recordDeliveryOutcome({ ...RESULT, hasDeliveryRow: false } as never);
+
+    // Only the aggregate write ran; no attempt was made against a row that
+    // does not exist.
+    expect(state.updateCalls).toHaveLength(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    const payload = structured(lines(logSpy), 'WEBHOOK_DLQ_REPLAY_COMPLETED');
+    expect(payload).toMatchObject({
+      deliveryId: 'delivery-1',
+      delivered: true,
+      responseStatus: 200
+    });
+  });
+
+  it('still moves the webhook aggregates for a DLQ replay — the POST happened', async () => {
+    state.updateResults = [[]];
+
+    await recordDeliveryOutcome({ ...RESULT, hasDeliveryRow: false } as never);
+
+    expect(state.updateCalls).toHaveLength(1);
+    expect(Object.keys(state.updateCalls[0]!.set)).toContain('successCount');
+  });
+});

--- a/apps/api/src/services/webhookDeliveryRecord.ts
+++ b/apps/api/src/services/webhookDeliveryRecord.ts
@@ -1,11 +1,13 @@
-import { and, eq, type SQL } from 'drizzle-orm';
+import { and, eq, ne, sql, type SQL } from 'drizzle-orm';
 import * as dbModule from '../db';
-import { webhookDeliveries } from '../db/schema';
+import { webhookDeliveries, webhooks as webhooksTable } from '../db/schema';
 import type { BreezeEvent } from './eventBus';
 import type {
   WebhookConfig,
   WebhookDeliveryJob,
-  WebhookDeliveryRecordOutcome
+  WebhookDeliveryRecordOutcome,
+  WebhookDeliveryResult,
+  DeliveryClaimOutcome
 } from '../workers/webhookDelivery';
 
 const { db } = dbModule;
@@ -55,6 +57,27 @@ export function buildExecutionClaimCas(deliveryId: string): SQL {
   return and(
     eq(webhookDeliveries.id, deliveryId),
     eq(webhookDeliveries.status, 'pending')
+  )!;
+}
+
+/**
+ * The OUTCOME WRITE predicate: this row, unless it already succeeded.
+ *
+ * Keying on `id` alone was safe while the delivery callback was the ONLY
+ * writer. It no longer is: the recovery sweep also writes terminal outcomes,
+ * and `deliverWebhook` clears its abort timeout once response HEADERS arrive,
+ * so a slow response body can keep an attempt in flight past the execution
+ * lease and land here after the sweep has already resolved the row. Without
+ * `ne(status, 'delivered')` a late-arriving FAILURE would overwrite a recorded
+ * success and the customer's delivery history would lie.
+ *
+ * `status` is NOT NULL, so `<>` cannot silently drop rows the way a negation
+ * over a nullable column would.
+ */
+export function buildOutcomeWriteCas(deliveryId: string): SQL {
+  return and(
+    eq(webhookDeliveries.id, deliveryId),
+    ne(webhookDeliveries.status, 'delivered')
   )!;
 }
 
@@ -111,10 +134,18 @@ export async function recordWebhookDelivery(
 }
 
 /**
- * Win the delivery row before POSTing. `false` means another copy of this job
- * already owns it (or it has already resolved) and this copy must be dropped.
+ * Win the delivery row before POSTing.
+ *
+ * Returns the OBSERVED STATUS on failure rather than a bare `false`, because
+ * the three ways to lose are operationally different and the worker's log has
+ * to name the right one: `retrying` = another copy of this job is delivering it
+ * right now; `delivered`/`failed` = it already resolved; `null` = there is no
+ * row under this id at all, which is a bug or a hand-crafted job rather than a
+ * race. Collapsing them to "duplicate" mislabels two of the three.
  */
-export async function claimDeliveryForExecution(job: WebhookDeliveryJob): Promise<boolean> {
+export async function claimDeliveryForExecution(
+  job: WebhookDeliveryJob
+): Promise<DeliveryClaimOutcome> {
   return runWithSystemDbAccess(async () => {
     const claimed = await db
       .update(webhookDeliveries)
@@ -127,6 +158,96 @@ export async function claimDeliveryForExecution(job: WebhookDeliveryJob): Promis
       .where(buildExecutionClaimCas(job.id))
       .returning({ id: webhookDeliveries.id });
 
-    return claimed.length > 0;
+    if (claimed.length > 0) return { claimed: true };
+
+    const [row] = await db
+      .select({ status: webhookDeliveries.status })
+      .from(webhookDeliveries)
+      .where(eq(webhookDeliveries.id, job.id))
+      .limit(1);
+
+    return { claimed: false, observedStatus: row?.status ?? null };
+  });
+}
+
+/**
+ * Persist the outcome of one delivery attempt and move the webhook aggregates.
+ *
+ * Extracted from `index.ts` (#4095) so the CAS above is reachable by a test:
+ * as an anonymous closure in a coverage-excluded file, deleting its
+ * `ne(status, 'delivered')` conjunct passed everywhere.
+ */
+export async function recordDeliveryOutcome(result: WebhookDeliveryResult): Promise<void> {
+  await runWithSystemDbAccess(async () => {
+    const deliveryStatus = result.success ? 'delivered' : 'failed';
+    const deliveredAt = result.success
+      ? new Date(result.deliveredAt ?? new Date().toISOString())
+      : null;
+    const responseTimeMs = typeof result.responseTimeMs === 'number'
+      ? Math.max(0, Math.round(result.responseTimeMs))
+      : null;
+
+    // A DLQ replay carries a delivery id that was minted by `retryFromDLQ` and
+    // has NO `webhook_deliveries` row behind it. Attempting the write anyway
+    // would match zero rows and fire the zero-row warning on EVERY routine
+    // replay, with a stated cause ("someone else resolved it first") that is
+    // simply untrue — which would void that warning for the real race it exists
+    // to catch. The POST still happened, so the aggregates below still move.
+    if (result.hasDeliveryRow === false) {
+      console.log(`[WebhookDelivery] dlq-replay-completed ${JSON.stringify({
+        errorId: 'WEBHOOK_DLQ_REPLAY_COMPLETED',
+        deliveryId: result.deliveryId,
+        webhookId: result.webhookId,
+        eventId: result.eventId,
+        delivered: result.success,
+        responseStatus: result.responseStatus ?? null,
+        attempts: result.attempts
+      })}`);
+    } else {
+      const written = await db
+        .update(webhookDeliveries)
+        .set({
+          status: deliveryStatus,
+          attempts: result.attempts,
+          responseStatus: result.responseStatus ?? null,
+          responseBody: result.responseBody ?? null,
+          responseTimeMs,
+          errorMessage: result.errorMessage ?? null,
+          deliveredAt,
+          // Release the execution lease taken by the claim. The row is leaving
+          // the unresolved statuses anyway, but a stale lease would otherwise
+          // surface in the UI as a `nextAttemptAt` that never comes.
+          nextRetryAt: null
+        })
+        .where(buildOutcomeWriteCas(result.deliveryId))
+        .returning({ id: webhookDeliveries.id });
+
+      if (written.length === 0) {
+        // Genuinely surprising now that DLQ replays are routed away: it means
+        // the row was already `delivered` by someone else, or has vanished.
+        console.warn(`[WebhookDelivery] outcome-write-skipped ${JSON.stringify({
+          errorId: 'WEBHOOK_DELIVERY_OUTCOME_WRITE_SKIPPED',
+          deliveryId: result.deliveryId,
+          webhookId: result.webhookId,
+          attemptedStatus: deliveryStatus
+        })}`);
+      }
+    }
+
+    const aggregateUpdate = result.success
+      ? {
+        successCount: sql`${webhooksTable.successCount} + 1`,
+        lastSuccessAt: new Date(),
+        lastDeliveryAt: new Date()
+      }
+      : {
+        failureCount: sql`${webhooksTable.failureCount} + 1`,
+        lastDeliveryAt: new Date()
+      };
+
+    await db
+      .update(webhooksTable)
+      .set(aggregateUpdate)
+      .where(eq(webhooksTable.id, result.webhookId));
   });
 }

--- a/apps/api/src/services/webhookDeliveryRecord.ts
+++ b/apps/api/src/services/webhookDeliveryRecord.ts
@@ -1,0 +1,132 @@
+import { and, eq, type SQL } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { webhookDeliveries } from '../db/schema';
+import type { BreezeEvent } from './eventBus';
+import type {
+  WebhookConfig,
+  WebhookDeliveryJob,
+  WebhookDeliveryRecordOutcome
+} from '../workers/webhookDelivery';
+
+const { db } = dbModule;
+
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const withSystem = dbModule.withSystemDbAccessContext;
+  return typeof withSystem === 'function' ? withSystem(fn) : fn();
+};
+
+/**
+ * Lease a delivery worker holds while executing a claimed delivery. Must
+ * comfortably exceed one attempt (`WEBHOOK_TIMEOUT_MS`, 30s) so a live delivery
+ * is never declared abandoned underneath itself; the recovery sweep will not
+ * reconsider a claimed row until it expires.
+ */
+export const EXECUTION_LEASE_MS = 5 * 60 * 1000;
+
+/**
+ * The dedupe read-back: find the row that already owns a (webhook, event) pair.
+ *
+ * BOTH conjuncts are load-bearing. `event_id` alone is not unique across
+ * webhooks — one event fans out to every webhook subscribed to it — so dropping
+ * `webhook_id` would report another webhook's delivery status as this one's.
+ */
+export function buildExistingDeliveryLookup(webhookId: string, eventId: string): SQL {
+  return and(
+    eq(webhookDeliveries.webhookId, webhookId),
+    eq(webhookDeliveries.eventId, eventId)
+  )!;
+}
+
+/**
+ * The EXECUTION CLAIM predicate: `pending` and this id, nothing else.
+ *
+ * Narrow on purpose. The queue is a plain Redis list with no job identity, so
+ * one delivery can legitimately appear on it twice (the recovery sweep
+ * re-queues any row that still looks unresolved, and a merely backlogged job is
+ * indistinguishable from a lost one). This CAS is what makes that safe: of N
+ * popped copies exactly one flips `pending` -> `retrying` and POSTs.
+ *
+ * It deliberately does NOT test the lease. A row is claimable whenever it is
+ * still `pending`, whoever queued it — the sweep's own lease exists to stop two
+ * SWEEPERS colliding, not to keep a delivery worker away from work it was
+ * handed.
+ */
+export function buildExecutionClaimCas(deliveryId: string): SQL {
+  return and(
+    eq(webhookDeliveries.id, deliveryId),
+    eq(webhookDeliveries.status, 'pending')
+  )!;
+}
+
+/**
+ * Record a delivery, or report the row that already owns the pair.
+ *
+ * The insert IS the dedupe. An empty `returning()` means this (webhook, event)
+ * pair is already recorded, and the caller reads that as "already handled" and
+ * skips the outbound POST. DO NOTHING rather than catching 23505: a unique
+ * violation caught inside the transaction that raised it is a documented trap
+ * in this repo — postgres.js latches the failed statement and rethrows after
+ * the callback returns.
+ */
+export async function recordWebhookDelivery(
+  webhook: WebhookConfig,
+  event: BreezeEvent
+): Promise<WebhookDeliveryRecordOutcome> {
+  return runWithSystemDbAccess(async () => {
+    const [delivery] = await db
+      .insert(webhookDeliveries)
+      .values({
+        webhookId: webhook.id,
+        eventType: event.type,
+        eventId: event.id,
+        payload: event.payload,
+        status: 'pending',
+        attempts: 0
+      })
+      .onConflictDoNothing({
+        target: [webhookDeliveries.webhookId, webhookDeliveries.eventId]
+      })
+      .returning({ id: webhookDeliveries.id });
+
+    if (delivery) return { created: true, deliveryId: delivery.id };
+
+    // Read back the row that won, so the skip can be REPORTED rather than being
+    // a bare `continue` (#4095). One extra statement, and only on the rare
+    // dedupe path; it seeks the same unique index the insert conflicted on.
+    // `existing` stays null if the row has since been erased — the subscriber
+    // reports that case too rather than staying silent.
+    const [existing] = await db
+      .select({
+        id: webhookDeliveries.id,
+        status: webhookDeliveries.status,
+        attempts: webhookDeliveries.attempts,
+        createdAt: webhookDeliveries.createdAt
+      })
+      .from(webhookDeliveries)
+      .where(buildExistingDeliveryLookup(webhook.id, event.id))
+      .limit(1);
+
+    return { created: false, existing: existing ?? null };
+  });
+}
+
+/**
+ * Win the delivery row before POSTing. `false` means another copy of this job
+ * already owns it (or it has already resolved) and this copy must be dropped.
+ */
+export async function claimDeliveryForExecution(job: WebhookDeliveryJob): Promise<boolean> {
+  return runWithSystemDbAccess(async () => {
+    const claimed = await db
+      .update(webhookDeliveries)
+      .set({
+        status: 'retrying',
+        // Doubles as the abandonment lease: if this worker dies mid-POST the
+        // sweep can only reconsider the row once this has expired.
+        nextRetryAt: new Date(Date.now() + EXECUTION_LEASE_MS)
+      })
+      .where(buildExecutionClaimCas(job.id))
+      .returning({ id: webhookDeliveries.id });
+
+    return claimed.length > 0;
+  });
+}

--- a/apps/api/src/workers/webhookDelivery.claim.test.ts
+++ b/apps/api/src/workers/webhookDelivery.claim.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const brpopMock = vi.hoisted(() => vi.fn());
 const lpushMock = vi.hoisted(() => vi.fn(async () => 1));
 const safeFetchMock = vi.hoisted(() => vi.fn());
+const captureExceptionMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../services/eventBus', () => ({
   getEventBus: () => ({ subscribe: vi.fn() }),
@@ -36,7 +37,7 @@ vi.mock('../services/urlSafety', () => ({
   SsrfBlockedError: class SsrfBlockedError extends Error {}
 }));
 
-vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: captureExceptionMock }));
 
 import { getWebhookWorker, type WebhookDeliveryJob } from './webhookDelivery';
 
@@ -71,9 +72,12 @@ function processOnce(): Promise<void> {
 
 describe('webhook delivery execution claim', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     brpopMock.mockReset();
+    captureExceptionMock.mockReset();
+    lpushMock.mockClear();
     safeFetchMock.mockReset();
     safeFetchMock.mockResolvedValue({
       status: 200,
@@ -82,7 +86,7 @@ describe('webhook delivery execution claim', () => {
     });
     vi.spyOn(console, 'log').mockImplementation(() => {});
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -124,6 +128,82 @@ describe('webhook delivery execution claim', () => {
     await processOnce();
 
     expect(claim).toHaveBeenCalledTimes(1);
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('pages when the customer was POSTed but the outcome could not be recorded', async () => {
+    // The two sides of the POST are not equally recoverable. A failure BEFORE
+    // it leaves the row untouched for the sweep to reclaim; a failure HERE
+    // means the customer's endpoint was already called and that fact is now
+    // unrecorded — the sweep will later resolve the row as "outcome unknown"
+    // and can never repair it. Scrolling past that in a log is not enough.
+    brpopMock.mockResolvedValueOnce(['queue', JSON.stringify(JOB)]);
+    getWebhookWorker().setDeliveryClaimCallback(async () => true);
+    getWebhookWorker().setDeliveryCallback(async () => {
+      throw new Error('db write failed');
+    });
+
+    await processOnce();
+
+    expect(safeFetchMock).toHaveBeenCalledTimes(1); // the POST really happened
+    expect(captureExceptionMock).toHaveBeenCalled();
+
+    const line = errorSpy.mock.calls
+      .map((c: unknown[]) => c.map(String).join(' '))
+      .find((l: string) => l.includes('WEBHOOK_DELIVERY_OUTCOME_UNRECORDED'));
+    expect(line, 'an unrecorded customer POST must be reported').toBeDefined();
+    expect(JSON.parse(line!.slice(line!.indexOf('{')))).toMatchObject({
+      deliveryId: 'delivery-1',
+      delivered: true,
+      responseStatus: 200
+    });
+
+  });
+
+  it('does not run the retry ladder when a FAILED outcome could not be recorded', async () => {
+    // The failing half of the same rule. Here the ladder really would fire —
+    // the POST failed and retries remain — so re-queueing on top of an outcome
+    // we could not record would drive a second attempt whose result we also
+    // cannot reconcile. The row stays `retrying` for the sweep to resolve.
+    brpopMock.mockResolvedValueOnce(['queue', JSON.stringify(JOB)]);
+    safeFetchMock.mockResolvedValueOnce({
+      status: 500,
+      ok: false,
+      text: async () => 'server error'
+    });
+    getWebhookWorker().setDeliveryClaimCallback(async () => true);
+    getWebhookWorker().setDeliveryCallback(async () => {
+      throw new Error('db write failed');
+    });
+
+    await processOnce();
+
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+    expect(lpushMock).not.toHaveBeenCalled();
+
+    const line = errorSpy.mock.calls
+      .map((c: unknown[]) => c.map(String).join(' '))
+      .find((l: string) => l.includes('WEBHOOK_DELIVERY_OUTCOME_UNRECORDED'));
+    expect(line).toBeDefined();
+    expect(JSON.parse(line!.slice(line!.indexOf('{')))).toMatchObject({ delivered: false });
+  });
+
+  it('does not claim a DLQ replay, which has no delivery row to claim', async () => {
+    // retryFromDLQ mints a FRESH delivery id with no `webhook_deliveries` row
+    // behind it, so a pending-only CAS can never match. Without the bypass the
+    // operator's replay is dropped and reported as a "duplicate" — eating the
+    // retry and naming the wrong cause.
+    brpopMock.mockResolvedValueOnce([
+      'queue',
+      JSON.stringify({ ...JOB, id: 'brand-new-id', skipExecutionClaim: true })
+    ]);
+    const claim = vi.fn(async () => false);
+    getWebhookWorker().setDeliveryClaimCallback(claim);
+    getWebhookWorker().setDeliveryCallback(async () => {});
+
+    await processOnce();
+
+    expect(claim).not.toHaveBeenCalled();
     expect(safeFetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/api/src/workers/webhookDelivery.claim.test.ts
+++ b/apps/api/src/workers/webhookDelivery.claim.test.ts
@@ -12,7 +12,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  */
 
 const brpopMock = vi.hoisted(() => vi.fn());
-const lpushMock = vi.hoisted(() => vi.fn(async () => 1));
+const lpushMock = vi.hoisted(() => vi.fn(async (_key: string, _payload: string) => 1));
+const lindexMock = vi.hoisted(() => vi.fn());
+const lremMock = vi.hoisted(() => vi.fn(async () => 1));
 const safeFetchMock = vi.hoisted(() => vi.fn());
 const captureExceptionMock = vi.hoisted(() => vi.fn());
 
@@ -29,7 +31,7 @@ vi.mock('../db', () => ({
 
 vi.mock('../services/redis', () => ({
   createBlockingRedisConnection: () => ({ brpop: brpopMock, status: 'ready' }),
-  getRedisConnection: () => ({ lpush: lpushMock })
+  getRedisConnection: () => ({ lpush: lpushMock, lindex: lindexMock, lrem: lremMock })
 }));
 
 vi.mock('../services/urlSafety', () => ({
@@ -78,6 +80,7 @@ describe('webhook delivery execution claim', () => {
     brpopMock.mockReset();
     captureExceptionMock.mockReset();
     lpushMock.mockClear();
+    lindexMock.mockReset();
     safeFetchMock.mockReset();
     safeFetchMock.mockResolvedValue({
       status: 200,
@@ -95,7 +98,7 @@ describe('webhook delivery execution claim', () => {
 
   it('does not POST when the claim is lost to another copy of the job', async () => {
     brpopMock.mockResolvedValueOnce(['queue', JSON.stringify(JOB)]);
-    const claim = vi.fn(async () => false);
+    const claim = vi.fn(async () => ({ claimed: false as const, observedStatus: 'retrying' }));
     const complete = vi.fn(async () => {});
     getWebhookWorker().setDeliveryClaimCallback(claim);
     getWebhookWorker().setDeliveryCallback(complete);
@@ -121,7 +124,7 @@ describe('webhook delivery execution claim', () => {
 
   it('POSTs when the claim is won', async () => {
     brpopMock.mockResolvedValueOnce(['queue', JSON.stringify(JOB)]);
-    const claim = vi.fn(async () => true);
+    const claim = vi.fn(async () => ({ claimed: true as const }));
     getWebhookWorker().setDeliveryClaimCallback(claim);
     getWebhookWorker().setDeliveryCallback(async () => {});
 
@@ -138,7 +141,7 @@ describe('webhook delivery execution claim', () => {
     // unrecorded — the sweep will later resolve the row as "outcome unknown"
     // and can never repair it. Scrolling past that in a log is not enough.
     brpopMock.mockResolvedValueOnce(['queue', JSON.stringify(JOB)]);
-    getWebhookWorker().setDeliveryClaimCallback(async () => true);
+    getWebhookWorker().setDeliveryClaimCallback(async () => ({ claimed: true as const }));
     getWebhookWorker().setDeliveryCallback(async () => {
       throw new Error('db write failed');
     });
@@ -171,7 +174,7 @@ describe('webhook delivery execution claim', () => {
       ok: false,
       text: async () => 'server error'
     });
-    getWebhookWorker().setDeliveryClaimCallback(async () => true);
+    getWebhookWorker().setDeliveryClaimCallback(async () => ({ claimed: true as const }));
     getWebhookWorker().setDeliveryCallback(async () => {
       throw new Error('db write failed');
     });
@@ -188,6 +191,73 @@ describe('webhook delivery execution claim', () => {
     expect(JSON.parse(line!.slice(line!.indexOf('{')))).toMatchObject({ delivered: false });
   });
 
+  it('PRODUCES a DLQ replay job that is marked to bypass the claim', async () => {
+    // Producer-side pin. The consumer test below asserts the bypass is HONORED,
+    // but with nothing asserting it is SET, deleting `skipExecutionClaim: true`
+    // from retryFromDLQ was green repo-wide — and that deletion silently eats
+    // every operator-triggered replay.
+    const entry = JSON.stringify({ job: { ...JOB, id: 'dlq-original' } });
+    lindexMock.mockResolvedValueOnce(entry);
+
+    await getWebhookWorker().retryFromDLQ(0);
+
+    expect(lpushMock).toHaveBeenCalledTimes(1);
+    const queued = JSON.parse(lpushMock.mock.calls[0]![1]);
+    expect(queued.skipExecutionClaim).toBe(true);
+    // A fresh id is exactly WHY the bypass is needed: no row exists under it.
+    expect(queued.id).not.toBe('dlq-original');
+  });
+
+  it('STAMPS the outcome with whether a delivery row exists', async () => {
+    // Producer side of the DLQ fix. The outcome writer branches on
+    // `hasDeliveryRow`, but with nothing asserting the worker SETS it,
+    // hard-coding it to `true` was green — which puts the zero-row warning back
+    // on every routine replay with a cause that is untrue.
+    const seen: Array<boolean | undefined> = [];
+    getWebhookWorker().setDeliveryClaimCallback(async () => ({ claimed: true as const }));
+    getWebhookWorker().setDeliveryCallback(async (r) => { seen.push(r.hasDeliveryRow); });
+
+    brpopMock.mockResolvedValueOnce(['queue', JSON.stringify(JOB)]);
+    await processOnce();
+
+    brpopMock.mockResolvedValueOnce([
+      'queue',
+      JSON.stringify({ ...JOB, id: 'dlq-minted', skipExecutionClaim: true })
+    ]);
+    await processOnce();
+
+    expect(seen).toEqual([true, false]);
+  });
+
+  it('names the real cause when a job loses its claim', async () => {
+    // "duplicate" is only one of three ways to lose. Collapsing them mislabels
+    // the other two — the same mislabeling the DLQ fix removed elsewhere.
+    const cases: Array<[string | null, string]> = [
+      ['retrying', 'already-claimed'],
+      ['delivered', 'already-resolved'],
+      [null, 'no-delivery-row']
+    ];
+
+    for (const [observedStatus, expectedCause] of cases) {
+      warnSpy.mockClear();
+      brpopMock.mockResolvedValueOnce(['queue', JSON.stringify(JOB)]);
+      getWebhookWorker().setDeliveryClaimCallback(async () => ({
+        claimed: false as const,
+        observedStatus
+      }));
+      getWebhookWorker().setDeliveryCallback(async () => {});
+
+      await processOnce();
+
+      const line = warnSpy.mock.calls
+        .map((c: unknown[]) => c.map(String).join(' '))
+        .find((l: string) => l.includes('WEBHOOK_DELIVERY_DUPLICATE_JOB_SKIPPED'));
+      expect(line, `no log for observedStatus=${observedStatus}`).toBeDefined();
+      expect(JSON.parse(line!.slice(line!.indexOf('{'))))
+        .toMatchObject({ observedStatus, cause: expectedCause });
+    }
+  });
+
   it('does not claim a DLQ replay, which has no delivery row to claim', async () => {
     // retryFromDLQ mints a FRESH delivery id with no `webhook_deliveries` row
     // behind it, so a pending-only CAS can never match. Without the bypass the
@@ -197,7 +267,7 @@ describe('webhook delivery execution claim', () => {
       'queue',
       JSON.stringify({ ...JOB, id: 'brand-new-id', skipExecutionClaim: true })
     ]);
-    const claim = vi.fn(async () => false);
+    const claim = vi.fn(async () => ({ claimed: false as const, observedStatus: 'retrying' }));
     getWebhookWorker().setDeliveryClaimCallback(claim);
     getWebhookWorker().setDeliveryCallback(async () => {});
 
@@ -212,7 +282,7 @@ describe('webhook delivery execution claim', () => {
     // previous attempt's callback. Re-running the pending-only CAS would reject
     // every legitimate retry and silently kill the whole backoff ladder.
     brpopMock.mockResolvedValueOnce(['queue', JSON.stringify({ ...JOB, attempts: 2 })]);
-    const claim = vi.fn(async () => false);
+    const claim = vi.fn(async () => ({ claimed: false as const, observedStatus: 'retrying' }));
     getWebhookWorker().setDeliveryClaimCallback(claim);
     getWebhookWorker().setDeliveryCallback(async () => {});
 

--- a/apps/api/src/workers/webhookDelivery.claim.test.ts
+++ b/apps/api/src/workers/webhookDelivery.claim.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The EXECUTION CLAIM (#4095).
+ *
+ * The delivery queue is a plain Redis list with no job identity, so nothing
+ * stops one delivery being enqueued twice — and the recovery sweep does exactly
+ * that whenever a job turns out to have been merely backlogged rather than
+ * lost. Without a claim, recovery would trade a missed POST for a DUPLICATE
+ * POST to the customer's endpoint, which is the one externally-visible failure
+ * this system treats as unrecoverable.
+ */
+
+const brpopMock = vi.hoisted(() => vi.fn());
+const lpushMock = vi.hoisted(() => vi.fn(async () => 1));
+const safeFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../services/eventBus', () => ({
+  getEventBus: () => ({ subscribe: vi.fn() }),
+  EVENT_TYPES: {}
+}));
+
+vi.mock('../db', () => ({
+  db: {},
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+  runOutsideDbContext: (fn: () => unknown) => fn()
+}));
+
+vi.mock('../services/redis', () => ({
+  createBlockingRedisConnection: () => ({ brpop: brpopMock, status: 'ready' }),
+  getRedisConnection: () => ({ lpush: lpushMock })
+}));
+
+vi.mock('../services/urlSafety', () => ({
+  safeFetch: safeFetchMock,
+  SsrfBlockedError: class SsrfBlockedError extends Error {}
+}));
+
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+
+import { getWebhookWorker, type WebhookDeliveryJob } from './webhookDelivery';
+
+const JOB: WebhookDeliveryJob = {
+  id: 'delivery-1',
+  webhookId: 'webhook-1',
+  webhook: {
+    id: 'webhook-1',
+    orgId: 'org-1',
+    name: 'Ops hook',
+    url: 'https://example.test/hook',
+    events: ['*']
+  },
+  event: {
+    id: 'event-1',
+    type: 'alert.triggered',
+    orgId: 'org-1',
+    source: 'test',
+    priority: 'normal',
+    payload: {},
+    metadata: { timestamp: new Date('2026-09-11T12:00:00.000Z').toISOString() }
+  } as WebhookDeliveryJob['event'],
+  attempts: 0,
+  createdAt: new Date('2026-09-11T12:00:00.000Z').toISOString()
+};
+
+/** Reach the private single-iteration pump without starting the infinite loop. */
+function processOnce(): Promise<void> {
+  const worker = getWebhookWorker() as unknown as { processNextJob: () => Promise<void> };
+  return worker.processNextJob();
+}
+
+describe('webhook delivery execution claim', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    brpopMock.mockReset();
+    safeFetchMock.mockReset();
+    safeFetchMock.mockResolvedValue({
+      status: 200,
+      ok: true,
+      text: async () => 'ok'
+    });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not POST when the claim is lost to another copy of the job', async () => {
+    brpopMock.mockResolvedValueOnce(['queue', JSON.stringify(JOB)]);
+    const claim = vi.fn(async () => false);
+    const complete = vi.fn(async () => {});
+    getWebhookWorker().setDeliveryClaimCallback(claim);
+    getWebhookWorker().setDeliveryCallback(complete);
+
+    await processOnce();
+
+    expect(claim).toHaveBeenCalledTimes(1);
+    // The whole point: the customer's endpoint is NOT hit a second time.
+    expect(safeFetchMock).not.toHaveBeenCalled();
+    // And the losing copy must not overwrite the winner's outcome either.
+    expect(complete).not.toHaveBeenCalled();
+
+    const line = warnSpy.mock.calls
+      .map((c: unknown[]) => c.map(String).join(' '))
+      .find((l: string) => l.includes('WEBHOOK_DELIVERY_DUPLICATE_JOB_SKIPPED'));
+    expect(line, 'the dropped duplicate must be reported, not silent').toBeDefined();
+    expect(JSON.parse(line!.slice(line!.indexOf('{')))).toMatchObject({
+      deliveryId: 'delivery-1',
+      webhookId: 'webhook-1',
+      eventId: 'event-1'
+    });
+  });
+
+  it('POSTs when the claim is won', async () => {
+    brpopMock.mockResolvedValueOnce(['queue', JSON.stringify(JOB)]);
+    const claim = vi.fn(async () => true);
+    getWebhookWorker().setDeliveryClaimCallback(claim);
+    getWebhookWorker().setDeliveryCallback(async () => {});
+
+    await processOnce();
+
+    expect(claim).toHaveBeenCalledTimes(1);
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-claim a retry job, whose row has already left `pending`', async () => {
+    // A retry carries attempts > 0 and its row was moved to `failed` by the
+    // previous attempt's callback. Re-running the pending-only CAS would reject
+    // every legitimate retry and silently kill the whole backoff ladder.
+    brpopMock.mockResolvedValueOnce(['queue', JSON.stringify({ ...JOB, attempts: 2 })]);
+    const claim = vi.fn(async () => false);
+    getWebhookWorker().setDeliveryClaimCallback(claim);
+    getWebhookWorker().setDeliveryCallback(async () => {});
+
+    await processOnce();
+
+    expect(claim).not.toHaveBeenCalled();
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/workers/webhookDelivery.dedupe.test.ts
+++ b/apps/api/src/workers/webhookDelivery.dedupe.test.ts
@@ -154,6 +154,30 @@ describe('webhook delivery is one-per-(webhook, event)', () => {
       existingDeliveryId: 'delivery-1',
       existingStatus: 'delivered'
     });
+    // The OTHER half of the severity split. Without this, emptying
+    // BENIGN_DUPLICATE_STATUSES entirely — routing every routine dedupe to warn
+    // and drowning the real signal — stayed green.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('a `failed` original is a benign dedupe too, not a warn', async () => {
+    // `failed` is terminal: the original owns the event's outcome and the retry
+    // ladder (or a hand retry) drives it. Only the UNRESOLVED statuses warn.
+    const createDeliveryRecord = vi.fn().mockResolvedValue(deduped({
+      id: 'delivery-1',
+      status: 'failed',
+      attempts: 3,
+      createdAt: new Date('2026-09-11T00:00:00.000Z')
+    }));
+
+    await initializeWebhookDelivery(async () => [WEBHOOK] as never, createDeliveryRecord as never);
+    handler = subscribeMock.mock.calls[0]![1];
+
+    await handler(EVENT);
+
+    const payload = structured(consoleLines(logSpy), 'WEBHOOK_DELIVERY_DUPLICATE_SKIPPED');
+    expect(payload).toMatchObject({ existingStatus: 'failed' });
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('escalates to warn when the row it deferred to is still pending — that is an orphan, not a dedupe', async () => {
@@ -221,6 +245,49 @@ describe('webhook delivery is one-per-(webhook, event)', () => {
   // already got a row while the rest proceed — permanently dropping the
   // failing one.
   // ---------------------------------------------------------------------------
+
+  it('reports the ONE drop with no recovery path: the whole-event fan-out', async () => {
+    // If the webhook LOOKUP fails, no delivery rows are created — so the
+    // recovery sweep cannot see this event either. It is the only drop in this
+    // file that nothing downstream can repair, which makes it the one that most
+    // needs to reach Sentry and to carry the event's identity.
+    await initializeWebhookDelivery(async () => { throw new Error('db exploded'); });
+    handler = subscribeMock.mock.calls[0]![1];
+
+    await handler(EVENT);
+
+    expect(queueDeliveryMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+
+    const payload = structured(consoleLines(errorSpy), 'WEBHOOK_EVENT_ROUTING_FAILED');
+    expect(payload).toMatchObject({
+      eventId: 'event-1',
+      orgId: 'org-1',
+      eventType: 'alert.triggered',
+      transient: false
+    });
+    expect(String(payload.impact)).toContain('lost');
+  });
+
+  it('does not claim a transient DB error will be retried — this event is gone', async () => {
+    // The old message said "will retry on next event". A LATER event may
+    // succeed; THIS one is lost. Saying otherwise is how a silent drop survives
+    // triage, which is the entire subject of #4095.
+    await initializeWebhookDelivery(async () => {
+      throw new Error('CONNECTION_DESTROYED while querying');
+    });
+    handler = subscribeMock.mock.calls[0]![1];
+
+    await handler(EVENT);
+
+    const payload = structured(consoleLines(errorSpy), 'WEBHOOK_EVENT_ROUTING_FAILED');
+    expect(payload).toMatchObject({ transient: true });
+    // Still reported as a loss, and still surfaced to Sentry, despite being
+    // classified transient.
+    expect(String(payload.impact)).toContain('lost');
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(consoleLines(warnSpy).join(' ')).not.toContain('will retry on next event');
+  });
 
   it('keeps delivering to the remaining webhooks after one webhook fails to record', async () => {
     const createDeliveryRecord = vi.fn()

--- a/apps/api/src/workers/webhookDelivery.dedupe.test.ts
+++ b/apps/api/src/workers/webhookDelivery.dedupe.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const subscribeMock = vi.hoisted(() => vi.fn());
 const queueDeliveryMock = vi.hoisted(() => vi.fn());
 const startMock = vi.hoisted(() => vi.fn(async () => {}));
+const captureExceptionMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../services/eventBus', () => ({
   getEventBus: () => ({ subscribe: subscribeMock }),
@@ -22,6 +23,10 @@ vi.mock('../services/redis', () => ({
   getRedisConnection: () => ({})
 }));
 
+vi.mock('../services/sentry', () => ({
+  captureException: captureExceptionMock
+}));
+
 import { initializeWebhookDelivery, getWebhookWorker } from './webhookDelivery';
 
 const EVENT = {
@@ -35,21 +40,61 @@ const EVENT = {
 };
 
 const WEBHOOK = { id: 'webhook-1', orgId: 'org-1', url: 'https://example.test/hook' };
+const WEBHOOK_B = { id: 'webhook-2', orgId: 'org-1', url: 'https://example.test/hook-b' };
+
+const recorded = (deliveryId: string) => ({ created: true as const, deliveryId });
+const deduped = (existing: {
+  id: string;
+  status: string;
+  attempts: number;
+  createdAt: Date;
+} | null) => ({ created: false as const, existing });
+
+/** Every console line this module emitted, flattened to searchable strings. */
+function consoleLines(...spies: Array<{ mock: { calls: unknown[][] } }>): string[] {
+  return spies.flatMap((spy) =>
+    spy.mock.calls.map((call) => call.map((arg) => String(arg)).join(' '))
+  );
+}
+
+/** The JSON blob out of the one structured line carrying `errorId`. */
+function structured(lines: string[], errorId: string): Record<string, unknown> {
+  const line = lines.find((l) => l.includes(errorId));
+  expect(line, `no console line carried ${errorId}`).toBeDefined();
+  const json = line!.slice(line!.indexOf('{'));
+  return JSON.parse(json) as Record<string, unknown>;
+}
 
 describe('webhook delivery is one-per-(webhook, event)', () => {
   let handler: (event: typeof EVENT) => Promise<void>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
     subscribeMock.mockReset();
     queueDeliveryMock.mockReset();
+    captureExceptionMock.mockReset();
     vi.spyOn(getWebhookWorker(), 'queueDelivery').mockImplementation(queueDeliveryMock);
     vi.spyOn(getWebhookWorker(), 'start').mockImplementation(startMock);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('does not queue a second delivery when the (webhook, event) pair is already recorded', async () => {
     const createDeliveryRecord = vi.fn()
-      .mockResolvedValueOnce('delivery-1')   // first: this call won the insert
-      .mockResolvedValueOnce(null);          // redelivery: unique index rejected it
+      .mockResolvedValueOnce(recorded('delivery-1'))   // first: this call won the insert
+      .mockResolvedValueOnce(deduped({                 // redelivery: unique index rejected it
+        id: 'delivery-1',
+        status: 'delivered',
+        attempts: 1,
+        createdAt: new Date('2026-09-11T00:00:00.000Z')
+      }));
 
     await initializeWebhookDelivery(async () => [WEBHOOK] as never, createDeliveryRecord as never);
     handler = subscribeMock.mock.calls[0]![1];
@@ -72,5 +117,132 @@ describe('webhook delivery is one-per-(webhook, event)', () => {
     // No creator means no dedupe surface exists; skipping here would drop the
     // delivery entirely rather than de-duplicate it.
     expect(queueDeliveryMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // #4095: the skip must be OBSERVABLE. Before this, `continue` emitted nothing,
+  // so in production you could not tell "dedupe working as designed" from
+  // "dedupe eating deliveries" — and once #4085 makes delivery at-least-once
+  // that skip is what suppresses a (webhook, event) pair forever.
+  // ---------------------------------------------------------------------------
+
+  it('reports the skipped duplicate, naming the delivery that already owns the event', async () => {
+    const createDeliveryRecord = vi.fn().mockResolvedValue(deduped({
+      id: 'delivery-1',
+      status: 'delivered',
+      attempts: 1,
+      createdAt: new Date('2026-09-11T00:00:00.000Z')
+    }));
+
+    await initializeWebhookDelivery(async () => [WEBHOOK] as never, createDeliveryRecord as never);
+    handler = subscribeMock.mock.calls[0]![1];
+
+    await handler(EVENT);
+
+    expect(queueDeliveryMock).not.toHaveBeenCalled();
+
+    const payload = structured(
+      consoleLines(logSpy, warnSpy, errorSpy),
+      'WEBHOOK_DELIVERY_DUPLICATE_SKIPPED'
+    );
+    expect(payload).toMatchObject({
+      errorId: 'WEBHOOK_DELIVERY_DUPLICATE_SKIPPED',
+      webhookId: 'webhook-1',
+      orgId: 'org-1',
+      eventId: 'event-1',
+      eventType: 'alert.triggered',
+      existingDeliveryId: 'delivery-1',
+      existingStatus: 'delivered'
+    });
+  });
+
+  it('escalates to warn when the row it deferred to is still pending — that is an orphan, not a dedupe', async () => {
+    const createDeliveryRecord = vi.fn().mockResolvedValue(deduped({
+      id: 'delivery-1',
+      status: 'pending',
+      attempts: 0,
+      createdAt: new Date('2026-09-11T00:00:00.000Z')
+    }));
+
+    await initializeWebhookDelivery(async () => [WEBHOOK] as never, createDeliveryRecord as never);
+    handler = subscribeMock.mock.calls[0]![1];
+
+    await handler(EVENT);
+
+    // A `delivered` original is a benign dedupe; a `pending` one means the
+    // original may never have been enqueued at all, and the recovery sweep —
+    // not this subscriber — has to drive it. Severity is the signal that
+    // separates the two, so it must not collapse to console.log.
+    const warnPayload = structured(consoleLines(warnSpy), 'WEBHOOK_DELIVERY_DUPLICATE_SKIPPED');
+    expect(warnPayload).toMatchObject({ existingStatus: 'pending' });
+  });
+
+  it('reports the skip even when the conflicting row cannot be read back', async () => {
+    // The insert lost the race but the row is gone by the time we look it up
+    // (erasure, or a future retention job). Emitting nothing here would restore
+    // exactly the silent drop #4095 is about.
+    const createDeliveryRecord = vi.fn().mockResolvedValue(deduped(null));
+
+    await initializeWebhookDelivery(async () => [WEBHOOK] as never, createDeliveryRecord as never);
+    handler = subscribeMock.mock.calls[0]![1];
+
+    await handler(EVENT);
+
+    expect(queueDeliveryMock).not.toHaveBeenCalled();
+    const payload = structured(consoleLines(warnSpy), 'WEBHOOK_DELIVERY_DUPLICATE_SKIPPED');
+    expect(payload).toMatchObject({ existingDeliveryId: null, existingStatus: null });
+  });
+
+  // ---------------------------------------------------------------------------
+  // #4095: the try/catch used to sit OUTSIDE the `for (const webhook of webhooks)`
+  // loop, so one webhook's failure aborted delivery for webhooks N+1… of the
+  // same event. Combined with the dedupe, a retry then skips the webhooks that
+  // already got a row while the rest proceed — permanently dropping the
+  // failing one.
+  // ---------------------------------------------------------------------------
+
+  it('keeps delivering to the remaining webhooks after one webhook fails to record', async () => {
+    const createDeliveryRecord = vi.fn()
+      .mockRejectedValueOnce(new Error('insert blew up'))
+      .mockResolvedValueOnce(recorded('delivery-2'));
+
+    await initializeWebhookDelivery(
+      async () => [WEBHOOK, WEBHOOK_B] as never,
+      createDeliveryRecord as never
+    );
+    handler = subscribeMock.mock.calls[0]![1];
+
+    await handler(EVENT);
+
+    expect(createDeliveryRecord).toHaveBeenCalledTimes(2);
+    expect(queueDeliveryMock).toHaveBeenCalledTimes(1);
+    expect((queueDeliveryMock.mock.calls[0]![0] as { id: string }).id).toBe('webhook-2');
+
+    const payload = structured(consoleLines(errorSpy), 'WEBHOOK_DELIVERY_ROUTING_FAILED');
+    expect(payload).toMatchObject({ webhookId: 'webhook-1', eventId: 'event-1' });
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps delivering to the remaining webhooks when one enqueue fails', async () => {
+    const createDeliveryRecord = vi.fn()
+      .mockResolvedValueOnce(recorded('delivery-1'))
+      .mockResolvedValueOnce(recorded('delivery-2'));
+    queueDeliveryMock
+      .mockRejectedValueOnce(new Error('LPUSH failed'))
+      .mockResolvedValueOnce('delivery-2');
+
+    await initializeWebhookDelivery(
+      async () => [WEBHOOK, WEBHOOK_B] as never,
+      createDeliveryRecord as never
+    );
+    handler = subscribeMock.mock.calls[0]![1];
+
+    await handler(EVENT);
+
+    // webhook-1 is now a recorded-but-never-enqueued orphan — that is the
+    // recovery sweep's job. What must NOT happen is webhook-2 losing its
+    // delivery because webhook-1's LPUSH died first.
+    expect(queueDeliveryMock).toHaveBeenCalledTimes(2);
+    expect((queueDeliveryMock.mock.calls[1]![0] as { id: string }).id).toBe('webhook-2');
   });
 });

--- a/apps/api/src/workers/webhookDelivery.dedupe.test.ts
+++ b/apps/api/src/workers/webhookDelivery.dedupe.test.ts
@@ -177,6 +177,27 @@ describe('webhook delivery is one-per-(webhook, event)', () => {
     expect(warnPayload).toMatchObject({ existingStatus: 'pending' });
   });
 
+  it('treats a `retrying` original as unresolved too, not as a benign dedupe', async () => {
+    // `retrying` is one of the two statuses the recovery sweep treats as
+    // UNRESOLVED, so a duplicate deferring to one is deferring to a delivery
+    // that may itself be stuck. Logging it at info would bury it next to
+    // genuinely delivered rows.
+    const createDeliveryRecord = vi.fn().mockResolvedValue(deduped({
+      id: 'delivery-1',
+      status: 'retrying',
+      attempts: 1,
+      createdAt: new Date('2026-09-11T00:00:00.000Z')
+    }));
+
+    await initializeWebhookDelivery(async () => [WEBHOOK] as never, createDeliveryRecord as never);
+    handler = subscribeMock.mock.calls[0]![1];
+
+    await handler(EVENT);
+
+    const payload = structured(consoleLines(warnSpy), 'WEBHOOK_DELIVERY_DUPLICATE_SKIPPED');
+    expect(payload).toMatchObject({ existingStatus: 'retrying' });
+  });
+
   it('reports the skip even when the conflicting row cannot be read back', async () => {
     // The insert lost the race but the row is gone by the time we look it up
     // (erasure, or a future retention job). Emitting nothing here would restore

--- a/apps/api/src/workers/webhookDelivery.ts
+++ b/apps/api/src/workers/webhookDelivery.ts
@@ -50,6 +50,16 @@ export interface WebhookDeliveryJob {
   attempts: number;
   nextRetryAt?: string;
   createdAt: string;
+  /**
+   * Skip the execution claim for this job.
+   *
+   * Set ONLY by `retryFromDLQ`, which mints a fresh delivery id with no
+   * `webhook_deliveries` row behind it. The claim CAS matches on
+   * `id = ? AND status = 'pending'`, so without this an operator-triggered DLQ
+   * replay would match zero rows, be dropped, and be reported as a "duplicate"
+   * — eating the retry and naming the wrong cause.
+   */
+  skipExecutionClaim?: boolean;
 }
 
 export interface WebhookDeliveryResult {
@@ -356,7 +366,7 @@ class WebhookDeliveryWorker {
       // carries attempts > 0 and its row has already been moved out of
       // `pending` by the previous attempt's callback, so re-claiming it would
       // reject every legitimate retry.
-      if (this.onClaimDelivery && job.attempts === 0) {
+      if (this.onClaimDelivery && job.attempts === 0 && !job.skipExecutionClaim) {
         const claimed = await this.onClaimDelivery(job);
         if (!claimed) {
           // Another copy of this job is already delivering it, or it has
@@ -376,9 +386,34 @@ class WebhookDeliveryWorker {
       // Attempt delivery
       const result2 = await deliverWebhook(job);
 
-      // Notify callback
+      // Persist the outcome. This is split out of the outer catch because the
+      // two sides of the POST are NOT equally recoverable: anything that throws
+      // BEFORE `deliverWebhook` leaves the row untouched for the recovery sweep
+      // to reclaim, whereas a throw HERE means the customer's endpoint was
+      // already called and that fact is now unrecorded. The sweep cannot repair
+      // that — it will later see an abandoned `retrying` row and resolve it as
+      // "outcome unknown" — so it has to page rather than scroll past.
       if (this.onDeliveryComplete) {
-        await this.onDeliveryComplete(result2);
+        try {
+          await this.onDeliveryComplete(result2);
+        } catch (persistError) {
+          captureException(
+            persistError instanceof Error ? persistError : new Error(String(persistError))
+          );
+          console.error(`[WebhookWorker] delivery-outcome-unrecorded ${JSON.stringify({
+            errorId: 'WEBHOOK_DELIVERY_OUTCOME_UNRECORDED',
+            deliveryId: job.id,
+            webhookId: job.webhookId,
+            orgId: job.event.orgId,
+            eventId: job.event.id,
+            delivered: result2.success,
+            responseStatus: result2.responseStatus ?? null,
+            error: persistError instanceof Error ? persistError.message : String(persistError)
+          })}`);
+          // Deliberately rethrown into the outer catch: continuing would run the
+          // retry/DLQ ladder below against an outcome we failed to record.
+          throw persistError;
+        }
       }
 
       if (result2.success) {
@@ -414,6 +449,12 @@ class WebhookDeliveryWorker {
       await redis.lpush(WEBHOOK_QUEUE, JSON.stringify(retryJob));
 
     } catch (err) {
+      // The job was already popped by BRPOP and is gone from Redis. When the
+      // failure happened before the POST the delivery row is untouched and the
+      // recovery sweep reclaims it; that is the designed path, but it is still
+      // worth a Sentry event, because a claim or parse that fails on EVERY job
+      // silently converts the whole worker into a 15-minute-latency system.
+      captureException(err instanceof Error ? err : new Error(String(err)));
       console.error('[WebhookWorker] Error processing job:', err);
       await new Promise(resolve => setTimeout(resolve, 1000));
     }
@@ -444,7 +485,9 @@ class WebhookDeliveryWorker {
       id: randomUUID(), // New delivery ID
       attempts: 0,
       nextRetryAt: undefined,
-      createdAt: new Date().toISOString()
+      createdAt: new Date().toISOString(),
+      // No delivery row exists under the new id, so there is nothing to claim.
+      skipExecutionClaim: true
     };
 
     await redis.lpush(WEBHOOK_QUEUE, JSON.stringify(retryJob));
@@ -504,8 +547,16 @@ export type CreateWebhookDeliveryRecord = (
   event: BreezeEvent
 ) => Promise<WebhookDeliveryRecordOutcome>;
 
-/** Statuses whose skip is routine. Anything else is reported at warn. */
-const BENIGN_DUPLICATE_STATUSES = new Set(['delivered', 'failed', 'retrying']);
+/**
+ * Statuses whose skip is routine. Anything else is reported at warn.
+ *
+ * `retrying` is deliberately NOT here: it is one of the two statuses the
+ * recovery sweep treats as UNRESOLVED (`jobs/webhookDeliveryRecovery.ts`), so a
+ * duplicate deferring to a `retrying` row is deferring to a delivery that may
+ * itself be stuck — exactly the case #4095 exists to surface, and logging it at
+ * info would bury it next to genuinely delivered rows.
+ */
+const BENIGN_DUPLICATE_STATUSES = new Set(['delivered', 'failed']);
 
 /**
  * Report a skipped duplicate. This exists because the skip used to be a bare

--- a/apps/api/src/workers/webhookDelivery.ts
+++ b/apps/api/src/workers/webhookDelivery.ts
@@ -62,8 +62,25 @@ export interface WebhookDeliveryJob {
   skipExecutionClaim?: boolean;
 }
 
+/**
+ * Why a popped job did NOT win its execution claim. The three cases are
+ * operationally different and the log has to name the right one — see
+ * `claimDeliveryForExecution`.
+ */
+export type DeliveryClaimOutcome =
+  | { claimed: true }
+  | { claimed: false; observedStatus: string | null };
+
 export interface WebhookDeliveryResult {
   deliveryId: string;
+  /**
+   * `false` when no `webhook_deliveries` row exists under `deliveryId` — only
+   * ever a DLQ replay, which mints a fresh id (`retryFromDLQ`). The outcome
+   * writer skips the row UPDATE in that case; without this it would match zero
+   * rows and fire the zero-row warning on every routine replay, voiding that
+   * warning for the real race it exists to catch.
+   */
+  hasDeliveryRow?: boolean;
   webhookId: string;
   eventId: string;
   eventType: string;
@@ -245,7 +262,7 @@ function calculateRetryDelay(
 class WebhookDeliveryWorker {
   private isRunning = false;
   private onDeliveryComplete?: (result: WebhookDeliveryResult) => Promise<void>;
-  private onClaimDelivery?: (job: WebhookDeliveryJob) => Promise<boolean>;
+  private onClaimDelivery?: (job: WebhookDeliveryJob) => Promise<DeliveryClaimOutcome>;
   /**
    * Dedicated connection for the `BRPOP` in `processNextJob` — see
    * `createBlockingRedisConnection`. Lazily created (never at import time) and
@@ -278,11 +295,14 @@ class WebhookDeliveryWorker {
    * one job exactly one ever reaches the customer's endpoint and the rest are
    * dropped here.
    *
-   * Return `false` to mean "someone else owns this delivery". With no claim
-   * callback configured the worker delivers unguarded, which is the
+   * Return `{ claimed: false, observedStatus }` to mean "someone else owns this
+   * delivery"; the status is what lets the drop name its real cause. With no
+   * claim callback configured the worker delivers unguarded, which is the
    * pre-existing behaviour.
    */
-  setDeliveryClaimCallback(callback: (job: WebhookDeliveryJob) => Promise<boolean>): void {
+  setDeliveryClaimCallback(
+    callback: (job: WebhookDeliveryJob) => Promise<DeliveryClaimOutcome>
+  ): void {
     this.onClaimDelivery = callback;
   }
 
@@ -367,17 +387,25 @@ class WebhookDeliveryWorker {
       // `pending` by the previous attempt's callback, so re-claiming it would
       // reject every legitimate retry.
       if (this.onClaimDelivery && job.attempts === 0 && !job.skipExecutionClaim) {
-        const claimed = await this.onClaimDelivery(job);
-        if (!claimed) {
+        const outcome = await this.onClaimDelivery(job);
+        if (!outcome.claimed) {
           // Another copy of this job is already delivering it, or it has
-          // already resolved. Dropping the duplicate here is the whole point;
-          // it is logged because a silent drop is what #4095 is about.
+          // already resolved, or there is no row at all. Dropping the duplicate
+          // here is the whole point; it is logged because a silent drop is what
+          // #4095 is about — and `observedStatus` is what stops the log from
+          // calling all three "duplicate".
           console.warn(`[WebhookWorker] duplicate-job-skipped ${JSON.stringify({
             errorId: 'WEBHOOK_DELIVERY_DUPLICATE_JOB_SKIPPED',
             deliveryId: job.id,
             webhookId: job.webhookId,
             orgId: job.event.orgId,
-            eventId: job.event.id
+            eventId: job.event.id,
+            observedStatus: outcome.observedStatus,
+            cause: outcome.observedStatus === null
+              ? 'no-delivery-row'
+              : outcome.observedStatus === 'retrying'
+                ? 'already-claimed'
+                : 'already-resolved'
           })}`);
           return;
         }
@@ -385,6 +413,8 @@ class WebhookDeliveryWorker {
 
       // Attempt delivery
       const result2 = await deliverWebhook(job);
+      // A DLQ replay has no backing row; the outcome writer needs to know.
+      result2.hasDeliveryRow = !job.skipExecutionClaim;
 
       // Persist the outcome. This is split out of the outer catch because the
       // two sides of the POST are NOT equally recoverable: anything that throws
@@ -611,12 +641,29 @@ export async function initializeWebhookDelivery(
       // Get webhooks configured for this event type in this org — short DB context.
       webhooks = await runWithSystemDbAccess(() => getWebhooksForEvent(event.orgId, event.type));
     } catch (err) {
+      // This is the ONE drop in this file with no recovery path anywhere.
+      //
+      // The webhook lookup failed, so NO delivery rows were created for this
+      // event — which means the recovery sweep cannot see it either: the sweep
+      // reclaims recorded-but-unenqueued rows, and here there is nothing
+      // recorded. The event's entire fan-out is simply gone, for every webhook
+      // subscribed to it.
+      //
+      // The old message claimed this would "retry on next event". It does not:
+      // a LATER event may succeed, but THIS one is lost. Saying otherwise is
+      // how a silent drop survives triage, which is the whole subject of #4095.
       const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes('CONNECTION_DESTROYED') || msg.includes('CONNECTION_ENDED')) {
-        console.warn('[WebhookDelivery] Transient DB connection error, will retry on next event');
-      } else {
-        console.error('[WebhookDelivery] Error routing event to webhooks:', err);
-      }
+      const transient = msg.includes('CONNECTION_DESTROYED') || msg.includes('CONNECTION_ENDED');
+      captureException(err instanceof Error ? err : new Error(String(err)));
+      console.error(`[WebhookDelivery] event-routing-failed ${JSON.stringify({
+        errorId: 'WEBHOOK_EVENT_ROUTING_FAILED',
+        eventId: event.id,
+        orgId: event.orgId,
+        eventType: event.type,
+        transient,
+        error: msg,
+        impact: 'no delivery rows were created; this event\'s fan-out is lost for every subscribed webhook and no sweep can recover it'
+      })}`);
       return;
     }
 

--- a/apps/api/src/workers/webhookDelivery.ts
+++ b/apps/api/src/workers/webhookDelivery.ts
@@ -7,6 +7,7 @@ import { selfHostAllowsPrivateNetwork } from '../config/env';
 import { sanitizeOutboundHeaders } from '../services/outboundHeaders';
 import { formatHttpFailure } from '../services/httpFailureMessage';
 import { collectChannelSecretStrings } from '../services/notificationChannelSecrets';
+import { captureException } from '../services/sentry';
 import * as dbModule from '../db';
 
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -234,6 +235,7 @@ function calculateRetryDelay(
 class WebhookDeliveryWorker {
   private isRunning = false;
   private onDeliveryComplete?: (result: WebhookDeliveryResult) => Promise<void>;
+  private onClaimDelivery?: (job: WebhookDeliveryJob) => Promise<boolean>;
   /**
    * Dedicated connection for the `BRPOP` in `processNextJob` — see
    * `createBlockingRedisConnection`. Lazily created (never at import time) and
@@ -254,6 +256,24 @@ class WebhookDeliveryWorker {
    */
   setDeliveryCallback(callback: (result: WebhookDeliveryResult) => Promise<void>): void {
     this.onDeliveryComplete = callback;
+  }
+
+  /**
+   * Set the EXECUTION CLAIM: the gate a popped job must win before its POST.
+   *
+   * The queue is a plain Redis list with no job identity, so nothing stops the
+   * same delivery being enqueued twice — the recovery sweep (#4095) does
+   * exactly that whenever a job turns out to have been merely backlogged
+   * rather than lost. The claim is a CAS on the delivery row, so of N copies of
+   * one job exactly one ever reaches the customer's endpoint and the rest are
+   * dropped here.
+   *
+   * Return `false` to mean "someone else owns this delivery". With no claim
+   * callback configured the worker delivers unguarded, which is the
+   * pre-existing behaviour.
+   */
+  setDeliveryClaimCallback(callback: (job: WebhookDeliveryJob) => Promise<boolean>): void {
+    this.onClaimDelivery = callback;
   }
 
   /**
@@ -331,6 +351,27 @@ class WebhookDeliveryWorker {
       }
 
       console.log(`[WebhookWorker] Processing delivery ${job.id} (attempt ${job.attempts + 1})`);
+
+      // Win the row before POSTing. Only the FIRST attempt claims: a retry job
+      // carries attempts > 0 and its row has already been moved out of
+      // `pending` by the previous attempt's callback, so re-claiming it would
+      // reject every legitimate retry.
+      if (this.onClaimDelivery && job.attempts === 0) {
+        const claimed = await this.onClaimDelivery(job);
+        if (!claimed) {
+          // Another copy of this job is already delivering it, or it has
+          // already resolved. Dropping the duplicate here is the whole point;
+          // it is logged because a silent drop is what #4095 is about.
+          console.warn(`[WebhookWorker] duplicate-job-skipped ${JSON.stringify({
+            errorId: 'WEBHOOK_DELIVERY_DUPLICATE_JOB_SKIPPED',
+            deliveryId: job.id,
+            webhookId: job.webhookId,
+            orgId: job.event.orgId,
+            eventId: job.event.id
+          })}`);
+          return;
+        }
+      }
 
       // Attempt delivery
       const result2 = await deliverWebhook(job);
@@ -434,55 +475,147 @@ export function getWebhookWorker(): WebhookDeliveryWorker {
 }
 
 /**
+ * The row that already owned a `(webhook, event)` pair when an insert was
+ * deduped by `webhook_deliveries_webhook_event_uq`.
+ */
+export interface ExistingWebhookDelivery {
+  id: string;
+  status: string;
+  attempts: number;
+  createdAt: Date;
+}
+
+/**
+ * Outcome of recording a delivery, as a discriminated union rather than the
+ * old `string | null`.
+ *
+ * `null` alone could not say WHY there was no id, so the skip below had nothing
+ * to report and emitted nothing at all (#4095). `existing` carries the row that
+ * won, which is what separates a benign dedupe (`delivered`) from a delivery
+ * the dedupe is eating (`pending`).
+ */
+export type WebhookDeliveryRecordOutcome =
+  | { created: true; deliveryId: string }
+  /** `existing` is null when the conflicting row could not be read back. */
+  | { created: false; existing: ExistingWebhookDelivery | null };
+
+export type CreateWebhookDeliveryRecord = (
+  webhook: WebhookConfig,
+  event: BreezeEvent
+) => Promise<WebhookDeliveryRecordOutcome>;
+
+/** Statuses whose skip is routine. Anything else is reported at warn. */
+const BENIGN_DUPLICATE_STATUSES = new Set(['delivered', 'failed', 'retrying']);
+
+/**
+ * Report a skipped duplicate. This exists because the skip used to be a bare
+ * `continue`: in production you could not tell "dedupe working as designed"
+ * from "dedupe eating deliveries", and once #4085 makes delivery at-least-once
+ * that same skip is what suppresses a (webhook, event) pair forever.
+ */
+function reportDuplicateSkip(
+  webhook: WebhookConfig,
+  event: BreezeEvent,
+  existing: ExistingWebhookDelivery | null
+): void {
+  const line = `[WebhookDelivery] duplicate-delivery-skipped ${JSON.stringify({
+    errorId: 'WEBHOOK_DELIVERY_DUPLICATE_SKIPPED',
+    webhookId: webhook.id,
+    orgId: event.orgId,
+    eventId: event.id,
+    eventType: event.type,
+    existingDeliveryId: existing?.id ?? null,
+    existingStatus: existing?.status ?? null,
+    existingAttempts: existing?.attempts ?? null,
+    existingCreatedAt: existing?.createdAt?.toISOString?.() ?? null
+  })}`;
+
+  // A still-`pending` original may never have been enqueued at all, and a row
+  // we cannot read back tells us nothing — both deserve more than an info line.
+  // Neither is re-queued here: the recovery sweep (jobs/webhookDeliveryRecovery)
+  // is the single owner of re-queueing, so that a redelivered event and the
+  // sweep cannot both drive the same row and POST twice.
+  if (existing && BENIGN_DUPLICATE_STATUSES.has(existing.status)) {
+    console.log(line);
+  } else {
+    console.warn(line);
+  }
+}
+
+/**
  * Initialize webhook delivery by subscribing to all events
  * and routing to appropriate webhooks
  */
 export async function initializeWebhookDelivery(
   getWebhooksForEvent: (orgId: string, eventType: string) => Promise<WebhookConfig[]>,
-  createDeliveryRecord?: (webhook: WebhookConfig, event: BreezeEvent) => Promise<string | null>
+  createDeliveryRecord?: CreateWebhookDeliveryRecord
 ): Promise<void> {
   const eventBus = getEventBus();
   const worker = getWebhookWorker();
 
   // Subscribe to all events
   eventBus.subscribe('*', async (event) => {
+    let webhooks: WebhookConfig[];
     try {
       // Get webhooks configured for this event type in this org — short DB context.
-      const webhooks = await runWithSystemDbAccess(() => getWebhooksForEvent(event.orgId, event.type));
-
-      // Queue delivery for each webhook. The delivery record is created in
-      // its own short DB context right before its enqueue ("mark-attempted
-      // before send"); `queueDelivery` itself is a Redis LPUSH and runs
-      // OUTSIDE any DB context (#1105) — looping Redis calls while a pooled
-      // Postgres connection sits idle-in-transaction is exactly the hold
-      // pattern that exhausts the pool under load, and this subscriber fires
-      // on every event fleet-wide.
-      for (const webhook of webhooks) {
-        const deliveryId = createDeliveryRecord
-          ? await runWithSystemDbAccess(() => createDeliveryRecord(webhook, event))
-          : null;
-        // A NULL id from a CONFIGURED creator means the (webhook, event) pair
-        // is already recorded, so the ORIGINAL delivery owns this event's
-        // outcome — delivered, pending, or permanently failed. Queueing again
-        // would POST to the customer's endpoint twice for one event.
-        //
-        // Note a `failed` original is NOT re-driven by redelivery; re-driving
-        // is the retry worker's job. A `pending` original that was recorded but
-        // never enqueued (LPUSH failed) has no recovery path today — tracked
-        // for wave 3.5c (#4085), where at-least-once makes it reachable.
-        //
-        // Only the configured branch may skip: with no creator there is no
-        // dedupe surface at all, so a skip there would drop the delivery
-        // outright rather than de-duplicate it.
-        if (createDeliveryRecord && deliveryId === null) continue;
-        await worker.queueDelivery(webhook, event, deliveryId ?? undefined);
-      }
+      webhooks = await runWithSystemDbAccess(() => getWebhooksForEvent(event.orgId, event.type));
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes('CONNECTION_DESTROYED') || msg.includes('CONNECTION_ENDED')) {
         console.warn('[WebhookDelivery] Transient DB connection error, will retry on next event');
       } else {
         console.error('[WebhookDelivery] Error routing event to webhooks:', err);
+      }
+      return;
+    }
+
+    // Queue delivery for each webhook. The delivery record is created in
+    // its own short DB context right before its enqueue ("mark-attempted
+    // before send"); `queueDelivery` itself is a Redis LPUSH and runs
+    // OUTSIDE any DB context (#1105) — looping Redis calls while a pooled
+    // Postgres connection sits idle-in-transaction is exactly the hold
+    // pattern that exhausts the pool under load, and this subscriber fires
+    // on every event fleet-wide.
+    //
+    // The try/catch is INSIDE the loop (#4095). It used to wrap the whole
+    // loop, so one webhook's failure aborted delivery for webhooks N+1… of the
+    // same event — and combined with the dedupe below, a later retry then
+    // skipped the webhooks that already had a row while the rest proceeded,
+    // making the FAILING webhook the one permanently dropped.
+    for (const webhook of webhooks) {
+      try {
+        let deliveryId: string | undefined;
+
+        if (createDeliveryRecord) {
+          const outcome = await runWithSystemDbAccess(() => createDeliveryRecord(webhook, event));
+          // `created: false` means the (webhook, event) pair is already
+          // recorded, so the ORIGINAL delivery owns this event's outcome.
+          // Queueing again would POST to the customer's endpoint twice for one
+          // event. A recorded-but-never-enqueued original is NOT rescued here —
+          // see reportDuplicateSkip.
+          if (!outcome.created) {
+            reportDuplicateSkip(webhook, event, outcome.existing);
+            continue;
+          }
+          deliveryId = outcome.deliveryId;
+        }
+        // With no creator there is no dedupe surface at all, so this queues
+        // blind rather than skipping — a skip there would drop the delivery
+        // outright rather than de-duplicate it.
+
+        await worker.queueDelivery(webhook, event, deliveryId);
+      } catch (err) {
+        // Recorded-but-not-enqueued is exactly the orphan the recovery sweep
+        // reclaims, so this is loud but not fatal to the rest of the fan-out.
+        captureException(err instanceof Error ? err : new Error(String(err)));
+        console.error(`[WebhookDelivery] webhook-routing-failed ${JSON.stringify({
+          errorId: 'WEBHOOK_DELIVERY_ROUTING_FAILED',
+          webhookId: webhook.id,
+          orgId: event.orgId,
+          eventId: event.id,
+          eventType: event.type,
+          error: err instanceof Error ? err.message : String(err)
+        })}`);
       }
     }
   });


### PR DESCRIPTION
Closes #4095

## The gap

`webhook_deliveries` rows are committed to Postgres **before** `queueDelivery`, which is a bare `redis.lpush` onto a non-durable list. Three states leave a row recorded with no job:

1. the LPUSH throws (Redis down), or the process dies between the commit and the LPUSH;
2. the worker `BRPOP`s the job and dies before delivering;
3. one webhook's failure aborts the fan-out for webhooks N+1… of the same event (the `try/catch` sat **outside** the loop).

All leave `status = 'pending'` with no job. **There was no reaper** — the manual retry endpoint only accepts `status = 'failed'`. And the dedupe skip added by #4083 emitted *nothing*, so you could not tell "dedupe working as designed" from "dedupe eating deliveries".

Latent today. Once #4085 makes delivery at-least-once, the redelivered event hits the `(webhook_id, event_id)` unique index, the subscriber skips — and that pair is suppressed **forever**, silently.

**No #4085 scope is implemented here**: no BullMQ ingress for webhook delivery, no `startConsuming()` activation.

## What changed

**1. A recovery sweep** (`jobs/webhookDeliveryRecovery.ts`) — every 5 min, batch-bounded at 200, backed by a **partial** index over the unresolved statuses only. Each row is taken with a CAS that re-asserts the *whole* candidate scope (not just the id), so N API instances sweep and exactly one drives a given row.

**2. An execution claim on the delivery worker** — the part that makes recovery *safe*. The queue is a plain Redis list with no job identity, so the sweep cannot distinguish a lost job from a merely **backlogged** one and will re-queue both. `BRPOP`'s 5s is only its empty-queue wait; the FIFO backlog ahead of a job is unbounded, so **no stale threshold alone is safe**. Without a claim this fix would have traded a missed POST for a **duplicate POST to the customer's endpoint**. Now one popped copy flips `pending` → `retrying` and delivers; every other copy loses and is dropped (loudly). It also bounds the sweep, since a claimed row leaves `pending` immediately.

Retries (`attempts > 0`) skip the claim — their row already left `pending`, so claiming would kill the backoff ladder. DLQ replays skip it too (`skipExecutionClaim`), since they mint a fresh id with no backing row.

**3. The dedupe skip is now reported**, carrying the status/age of the row it deferred to. Rows the sweep will not drive again become terminal `failed` — the one status the existing per-delivery retry endpoint accepts, so they stay hand-drivable from the UI. A `retrying` row whose worker died is resolved terminally and **never re-sent**: its outcome is genuinely unknown, and repeating a possibly-delivered POST is worse than surfacing one unknown outcome.

**4. The subscriber's `try/catch` moved inside the loop**, so one webhook cannot deny delivery to the others.

## Design calls worth flagging

- **Recovery attempts get their own `recovery_attempts` column** rather than borrowing `attempts`. The delivery callback overwrites `attempts` with the HTTP attempt count and the UI renders it as such, so a counter kept there would reset on the first completed callback and misreport enqueue recoveries as delivery attempts.
- **The sweep re-queues the SAME row**, under the original `event_id` — that id goes out as `X-Breeze-Event-Id`, the customer's own idempotency key, and is what the unique index dedupes on. (The manual retry endpoint mints a fresh UUID; that is not a good precedent for recovery.)
- The decrypt path is extracted to `services/webhookConfig.ts`, and the two `index.ts` CAS closures to `services/webhookDeliveryRecord.ts`, so the sweep and the subscriber cannot drift.

## Evidence

**The partial index is the load-bearing claim** — `webhook_deliveries` is empty in both regions today and has **no retention job anywhere**, so it grows unbounded while the sweep ticks forever. Measured against a 50,000-row fixture on real Postgres 16:

```
 table_size | partial_idx_size
------------+------------------
 6160 kB    | 16 kB

 ->  Index Scan using webhook_deliveries_unresolved_idx on webhook_deliveries
       Index Cond: (created_at < (now() - '00:15:00'::interval))
       Filter: ((next_retry_at IS NULL) OR (next_retry_at <= now()))
 Execution Time: 0.079 ms
```

Index scan, not a seq scan, and the index stays ~0 because `pending`/`retrying` are transient. The migration was applied twice to confirm re-application is a true no-op.

**Predicates are pinned as compiled SQL via `PgDialect`** in files that import the real drizzle-orm — a mocked-drizzle suite can only substring-match column names and cannot tell an `and` from an `or`. `NOT (...)` over the nullable `next_retry_at` is avoided explicitly and asserted against.

**A real-Postgres suite proves what mocks cannot**: that the `IS NULL` arm actually matches a never-leased row (this repo has shipped a *correct* compiled-SQL assertion while only real Postgres caught the bug), that both CAS predicates genuinely serialise two concurrent callers, that the read-back does not confuse a sibling webhook's delivery for this one, and that the partial index exists and is partial.

**21 revert probes**, each mutating the fix and re-running the suites — all 21 red. Two initially passed **vacuously**; the tests that missed them were fixed, not the probes (one assertion was satisfied by a downstream `TypeError` rather than the guard; the other by a success path that returns before the retry ladder it claimed to test).

```
vitest run <unit suites>                    -> 7 files, 49 tests passed
vitest run --config vitest.integration      -> 2 files, 15 tests passed (real Postgres)
tsc --noEmit                                -> clean
eslint <changed files>                      -> clean
scripts/check-migration-naming.sh           -> OK
```

## Review

Three reviewers ran (`code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer`) plus an independent design review before implementation. The second commit is entirely review findings — several were cases where this fix would have introduced the class of bug it removes:

- the catch now covering a real customer POST had no Sentry, and could not distinguish a failure before the POST (recoverable) from one after it (not);
- the outcome write was keyed on `id` alone, which stopped being safe the moment the sweep became a second writer;
- `retrying` was classified as a benign dedupe while the sweep treats it as unresolved;
- `retryFromDLQ` would have been eaten by the new claim and reported as a "duplicate";
- all four terminal writes discarded `markUnrecoverable`'s result, so a lost lease still logged "abandoned";
- "never enqueued" claimed more than the code can prove.

Reviewers independently confirmed the migration ordering, the Drizzle/SQL index parity, the sub-hourly `every:` interval, and that `webhook_deliveries` (no `org_id`) needs no cascade or export-policy registration.

## Out of scope, worth filing

- After a *failed* attempt the row is already `failed`; if the retry LPUSH then dies, the retry is lost and a sweep scoped to unresolved rows never sees it. Same shape as this bug, one hop later — needs #4085's durable retry state.
- `webhook_deliveries` still has no retention job, so the `(webhook_id, event_id)` dedupe index grows without bound with no defined horizon.
- Pre-existing, noticed in review: `webhook_deliveries.webhook_id → webhooks.id` has no `ON DELETE` and the table is in none of the cascade lists, while `webhooks` is a cascade-registered org table. Looks like a latent org-erasure gap; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)