### PR TITLE
fix(api): route every alert-resolve path through the compare-and-swap (#4094)

### DIFF
--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -2806,6 +2806,26 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
                 schema: { $ref: '#/components/schemas/Alert' }
               }
             }
+          },
+          '400': {
+            description: 'Alert is dismissed and cannot be resolved',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Error' }
+              }
+            }
+          },
+          '409': {
+            description:
+              'Alert already reached a terminal status — either before this request, ' +
+              'or because a concurrent resolver won the compare-and-swap. The alert is ' +
+              'resolved; this request simply did not perform the transition, so no ' +
+              'alert.resolved event was published for it.',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Error' }
+              }
+            }
           }
         }
       }

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -2817,10 +2817,11 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
           },
           '409': {
             description:
-              'Alert already reached a terminal status — either before this request, ' +
-              'or because a concurrent resolver won the compare-and-swap. The alert is ' +
-              'resolved; this request simply did not perform the transition, so no ' +
-              'alert.resolved event was published for it.',
+              'The alert already reached a terminal status (resolved or dismissed) — ' +
+              'either before this request, or because a concurrent caller won the ' +
+              'compare-and-swap in between. This request did not perform the transition, ' +
+              'so no alert.resolved event was published on its behalf. Re-read the alert ' +
+              'to see which terminal status it landed in.',
             content: {
               'application/json': {
                 schema: { $ref: '#/components/schemas/Error' }

--- a/apps/api/src/routes/alerts/alerts.resolveCas.test.ts
+++ b/apps/api/src/routes/alerts/alerts.resolveCas.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+/**
+ * POST /alerts/:id/resolve is a compare-and-swap (#4094).
+ *
+ * It used to read the alert's status and then UPDATE by id unconditionally —
+ * textbook check-then-act. Two techs resolving the same alert within the same
+ * second both "won": both stamped the row, both published `alert.resolved`
+ * (cancelling pending escalations twice and handing the `'*'` automation
+ * subscriber the same event twice), and both wrote a cooldown.
+ *
+ * Two kinds of assertion here, deliberately:
+ *
+ *  - BEHAVIOUR — an empty `RETURNING` (exactly what Postgres gives a caller whose
+ *    CAS matched nothing) must produce a 409 and NO fan-out.
+ *  - COMPILED SQL — the predicate the handler actually passed to `.where()`,
+ *    compiled through `PgDialect`. drizzle-orm and ../../db/schema are REAL in this
+ *    file for that reason: a mocked-drizzle `where` assertion can only substring-
+ *    match column NAMES, which cannot tell `and` from `or` and cannot see the
+ *    status list gaining a terminal value. Both of those mutations were verified
+ *    to pass green against exactly that style of test (main 8763a3239).
+ */
+const { dbMock, updateWheres, updateReturns, alertRow } = vi.hoisted(() => {
+  const updateWheres: unknown[] = [];
+  const updateReturns: unknown[][] = [];
+  const alertRow = {
+    id: '11111111-1111-4111-8111-111111111111',
+    orgId: 'org-1',
+    deviceId: 'device-1',
+    ruleId: null as string | null,
+    configPolicyId: null as string | null,
+    context: null as unknown,
+    status: 'active',
+    title: 'Disk almost full',
+  };
+  const dbMock = {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: (predicate: unknown) => {
+          updateWheres.push(predicate);
+          return { returning: () => Promise.resolve(updateReturns.shift() ?? []) };
+        },
+      }),
+    }),
+  };
+  return { dbMock, updateWheres, updateReturns, alertRow };
+});
+
+const publishEvent = vi.fn((..._args: unknown[]) => Promise.resolve('evt'));
+const emitAlertStateFeedback = vi.fn((..._args: unknown[]) => Promise.resolve());
+const writeRouteAudit = vi.fn();
+const setCooldown = vi.fn((..._args: unknown[]) => Promise.resolve());
+const markConfigPolicyRuleCooldown = vi.fn((..._args: unknown[]) => Promise.resolve());
+const getAlertWithOrgCheck = vi.fn();
+
+vi.mock('../../db', () => ({
+  db: dbMock,
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (_c: unknown, next: () => Promise<void>) => next(),
+  requireScope: () => async (c: { set: (k: string, v: unknown) => void }, next: () => Promise<void>) => {
+    c.set('auth', {
+      scope: 'organization',
+      user: { id: 'user-1', name: 'Tech One', email: 'tech@org.example' },
+      partnerId: null,
+      orgId: 'org-1',
+      accessibleOrgIds: null,
+      canAccessOrg: () => true,
+    });
+    await next();
+  },
+  requirePermission: () => async (c: { set: (k: string, v: unknown) => void }, next: () => Promise<void>) => {
+    c.set('permissions', { granted: new Set<string>() });
+    await next();
+  },
+  requireMfa: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  siteAccessCheck: () => () => true,
+}));
+vi.mock('../../services/alertCooldown', () => ({
+  setCooldown: (...args: unknown[]) => setCooldown(...args),
+  markConfigPolicyRuleCooldown: (...args: unknown[]) => markConfigPolicyRuleCooldown(...args),
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: (...a: unknown[]) => writeRouteAudit(...a) }));
+vi.mock('../../services/eventBus', () => ({ publishEvent: (...a: unknown[]) => publishEvent(...a) }));
+vi.mock('../../services/mlFeedbackEmitters', () => ({
+  emitAlertStateFeedback: (...a: unknown[]) => emitAlertStateFeedback(...a),
+  emitCorrelationFeedback: vi.fn(),
+}));
+vi.mock('../../services/ticketService', () => ({
+  createTicketFromAlert: vi.fn(),
+  TicketServiceError: class TicketServiceError extends Error { status = 400; },
+}));
+vi.mock('./helpers', () => ({
+  getPagination: () => ({ page: 1, limit: 50, offset: 0 }),
+  ensureOrgAccess: () => true,
+  getAlertWithOrgCheck: (...args: unknown[]) => getAlertWithOrgCheck(...args),
+  validateNotificationChannelConfig: vi.fn(),
+}));
+
+import { alertsRoutes } from './alerts';
+
+const app = new Hono().route('/alerts', alertsRoutes);
+const dialect = new PgDialect();
+
+const resolveRequest = () =>
+  app.request(`/alerts/${alertRow.id}/resolve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ note: 'cleared by hand' }),
+  });
+
+beforeEach(() => {
+  updateWheres.length = 0;
+  updateReturns.length = 0;
+  vi.clearAllMocks();
+  publishEvent.mockResolvedValue('evt');
+  emitAlertStateFeedback.mockResolvedValue(undefined);
+  setCooldown.mockResolvedValue(undefined);
+  markConfigPolicyRuleCooldown.mockResolvedValue(undefined);
+  // The pre-read always sees a resolvable alert; the race happens after it.
+  getAlertWithOrgCheck.mockResolvedValue({ ...alertRow, status: 'active' });
+});
+
+describe('POST /alerts/:id/resolve — the losing caller', () => {
+  it('answers 409 and does not report a resolution it did not perform', async () => {
+    updateReturns.push([]); // CAS matched nothing: another request got there first
+
+    const res = await resolveRequest();
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Alert was already resolved or dismissed by another request',
+    });
+  });
+
+  it('publishes no alert.resolved event', async () => {
+    updateReturns.push([]);
+
+    await resolveRequest();
+
+    // The whole point of the CAS: escalation cancellation and the '*' automation
+    // subscriber must see one event per real transition, not one per request.
+    expect(publishEvent).not.toHaveBeenCalled();
+  });
+
+  it('writes no cooldown, no ML feedback and no audit entry', async () => {
+    updateReturns.push([]);
+
+    await resolveRequest();
+
+    expect(setCooldown).not.toHaveBeenCalled();
+    expect(markConfigPolicyRuleCooldown).not.toHaveBeenCalled();
+    expect(emitAlertStateFeedback).not.toHaveBeenCalled();
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /alerts/:id/resolve — the winning caller', () => {
+  it('answers 200 with the updated row and publishes exactly once', async () => {
+    updateReturns.push([{ ...alertRow, status: 'resolved' }]);
+
+    const res = await resolveRequest();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ id: alertRow.id, status: 'resolved' });
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent.mock.calls[0]?.[0]).toBe('alert.resolved');
+    expect(emitAlertStateFeedback).toHaveBeenCalledTimes(1);
+    expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+  });
+
+  it('still short-circuits an alert the pre-read already saw as resolved', async () => {
+    getAlertWithOrgCheck.mockResolvedValue({ ...alertRow, status: 'resolved' });
+
+    const res = await resolveRequest();
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({ error: 'Alert is already resolved' });
+    // Same outcome as losing the CAS, so it must carry the same status code — a
+    // 400 here and a 409 there would make one user action return two codes
+    // depending purely on timing.
+    expect(updateWheres).toHaveLength(0);
+  });
+
+  it('keeps dismissed a 400, not a race', async () => {
+    getAlertWithOrgCheck.mockResolvedValue({ ...alertRow, status: 'dismissed' });
+
+    const res = await resolveRequest();
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Cannot resolve a dismissed alert' });
+  });
+});
+
+describe('POST /alerts/:id/resolve — the shipped predicate (compiled SQL)', () => {
+  it('scopes the UPDATE by id AND resolvable status', async () => {
+    updateReturns.push([{ ...alertRow, status: 'resolved' }]);
+
+    await resolveRequest();
+
+    expect(updateWheres).toHaveLength(1);
+    const { sql, params } = dialect.sqlToQuery(updateWheres[0] as SQL);
+
+    // `or` instead of `and` would stamp every active/acknowledged/suppressed alert
+    // in EVERY tenant resolved from one request; dropping the status list makes the
+    // write unconditional again; admitting 'resolved' or 'dismissed' makes the CAS
+    // a no-op. Each of those changes this string or its params.
+    expect(sql).toBe('("alerts"."id" = $1 and "alerts"."status" in ($2, $3, $4))');
+    expect(params).toEqual([alertRow.id, 'active', 'acknowledged', 'suppressed']);
+  });
+});

--- a/apps/api/src/routes/alerts/alerts.resolveCas.test.ts
+++ b/apps/api/src/routes/alerts/alerts.resolveCas.test.ts
@@ -21,11 +21,15 @@ import type { SQL } from 'drizzle-orm';
  *    file for that reason: a mocked-drizzle `where` assertion can only substring-
  *    match column NAMES, which cannot tell `and` from `or` and cannot see the
  *    status list gaining a terminal value. Both of those mutations were verified
- *    to pass green against exactly that style of test (main 8763a3239).
+ *    to pass green against exactly that style of test by the wave-3825 test-
+ *    hardening pass (`8763a3239`) — which is NOT on main, so this file re-proves
+ *    the property for the alert-resolve predicate rather than inheriting it.
  */
-const { dbMock, updateWheres, updateReturns, alertRow } = vi.hoisted(() => {
+const { dbMock, updateWheres, updateReturns, selectRows, alertRow } = vi.hoisted(() => {
   const updateWheres: unknown[] = [];
   const updateReturns: unknown[][] = [];
+  // Feeds the post-CAS cooldown lookups (alert rule, then its template).
+  const selectRows: unknown[][] = [];
   const alertRow = {
     id: '11111111-1111-4111-8111-111111111111',
     orgId: 'org-1',
@@ -38,7 +42,7 @@ const { dbMock, updateWheres, updateReturns, alertRow } = vi.hoisted(() => {
   };
   const dbMock = {
     select: () => ({
-      from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }),
+      from: () => ({ where: () => ({ limit: () => Promise.resolve(selectRows.shift() ?? []) }) }),
     }),
     update: () => ({
       set: () => ({
@@ -49,7 +53,7 @@ const { dbMock, updateWheres, updateReturns, alertRow } = vi.hoisted(() => {
       }),
     }),
   };
-  return { dbMock, updateWheres, updateReturns, alertRow };
+  return { dbMock, updateWheres, updateReturns, selectRows, alertRow };
 });
 
 const publishEvent = vi.fn((..._args: unknown[]) => Promise.resolve('evt'));
@@ -120,6 +124,7 @@ const resolveRequest = () =>
 beforeEach(() => {
   updateWheres.length = 0;
   updateReturns.length = 0;
+  selectRows.length = 0;
   vi.clearAllMocks();
   publishEvent.mockResolvedValue('evt');
   emitAlertStateFeedback.mockResolvedValue(undefined);
@@ -137,7 +142,7 @@ describe('POST /alerts/:id/resolve — the losing caller', () => {
 
     expect(res.status).toBe(409);
     await expect(res.json()).resolves.toEqual({
-      error: 'Alert was already resolved or dismissed by another request',
+      error: 'Alert is no longer resolvable — it already reached a terminal status (resolved or dismissed).',
     });
   });
 
@@ -197,6 +202,53 @@ describe('POST /alerts/:id/resolve — the winning caller', () => {
 
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toEqual({ error: 'Cannot resolve a dismissed alert' });
+  });
+});
+
+/**
+ * The winning-caller fixture above carries `ruleId: null, configPolicyId: null`, so
+ * it never reaches the post-CAS cooldown code. Those two branches are the whole
+ * reason the CAS has to gate the fan-out — a loser writing a cooldown suppresses the
+ * next legitimate alert for that rule — so they get their own fixtures rather than
+ * riding on a uniform one (the blind spot that shipped #3975).
+ */
+describe('POST /alerts/:id/resolve — the winner still writes its cooldown', () => {
+  it('sets the legacy rule cooldown from the rule/template override chain', async () => {
+    const legacy = { ...alertRow, ruleId: 'rule-1', status: 'active' };
+    getAlertWithOrgCheck.mockResolvedValue(legacy);
+    selectRows.push([{ id: 'rule-1', templateId: 'tpl-1', overrideSettings: { cooldownMinutes: 42 } }]);
+    selectRows.push([{ id: 'tpl-1', cooldownMinutes: 15 }]);
+    updateReturns.push([{ ...legacy, status: 'resolved' }]);
+
+    const res = await resolveRequest();
+
+    expect(res.status).toBe(200);
+    // 42 (the rule override), not 15 (the template default) — asserting the value
+    // proves the override chain ran, not merely that something was called.
+    expect(setCooldown).toHaveBeenCalledWith('rule-1', 'device-1', 42);
+    expect(markConfigPolicyRuleCooldown).not.toHaveBeenCalled();
+  });
+
+  it('sets the config-policy cooldown from the alert context snapshot', async () => {
+    const cp = { ...alertRow, configPolicyId: 'cp-1', context: { cooldownMinutes: 7 }, status: 'active' };
+    getAlertWithOrgCheck.mockResolvedValue(cp);
+    updateReturns.push([{ ...cp, status: 'resolved' }]);
+
+    const res = await resolveRequest();
+
+    expect(res.status).toBe(200);
+    expect(markConfigPolicyRuleCooldown).toHaveBeenCalledWith('cp-1', 'device-1', 7);
+    expect(setCooldown).not.toHaveBeenCalled();
+  });
+
+  it('writes NEITHER cooldown when the config-policy alert loses the race', async () => {
+    const cp = { ...alertRow, configPolicyId: 'cp-1', context: { cooldownMinutes: 7 }, status: 'active' };
+    getAlertWithOrgCheck.mockResolvedValue(cp);
+    updateReturns.push([]); // CAS matched nothing
+
+    expect((await resolveRequest()).status).toBe(409);
+    expect(markConfigPolicyRuleCooldown).not.toHaveBeenCalled();
+    expect(setCooldown).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -19,6 +19,7 @@ import {
 } from '../../db/schema';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { setCooldown, markConfigPolicyRuleCooldown } from '../../services/alertCooldown';
+import { buildResolveAlertCas } from '../../services/alertService';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { publishEvent } from '../../services/eventBus';
 import { emitAlertStateFeedback } from '../../services/mlFeedbackEmitters';
@@ -849,14 +850,22 @@ alertsRoutes.post(
       return c.json({ error: 'Alert not found' }, 404);
     }
 
+    // Fast path with a specific message. It is NOT the concurrency control — the
+    // compare-and-swap below is. Two techs on the same alert both clear this check.
     if (alert.status === 'resolved') {
-      return c.json({ error: 'Alert is already resolved' }, 400);
+      return c.json({ error: 'Alert is already resolved' }, 409);
     }
     if (alert.status === 'dismissed') {
       return c.json({ error: 'Cannot resolve a dismissed alert' }, 400);
     }
 
     const resolvedAt = new Date();
+    // Winner-takes-all (#4094). `buildResolveAlertCas` is the SAME predicate
+    // `resolveAlert` uses, so this route cannot drift from the service guarantee:
+    // the status predicate, not the read above, decides who transitioned the row.
+    // Updating by id alone let both callers "win" and both run the fan-out below —
+    // duplicate `alert.resolved` publishes cancel escalations twice and hand the
+    // '*' automation subscriber the same event twice.
     const [updated] = await db
       .update(alerts)
       .set({
@@ -865,10 +874,18 @@ alertsRoutes.post(
         resolvedBy: auth.user.id,
         resolutionNote: data.note
       })
-      .where(eq(alerts.id, alertId))
+      .where(buildResolveAlertCas(alertId))
       .returning();
     if (!updated) {
-      return c.json({ error: 'Failed to resolve alert' }, 500);
+      // The CAS matched nothing between the read above and this write: another
+      // request reached a terminal status first. Everything below (cooldown,
+      // event, ML feedback, audit) belongs to the caller that actually performed
+      // the transition, so report the conflict instead of a resolution that
+      // did not happen.
+      return c.json(
+        { error: 'Alert was already resolved or dismissed by another request' },
+        409
+      );
     }
 
     // Set cooldown to prevent immediate re-trigger by the evaluation worker

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -19,7 +19,7 @@ import {
 } from '../../db/schema';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { setCooldown, markConfigPolicyRuleCooldown } from '../../services/alertCooldown';
-import { buildResolveAlertCas } from '../../services/alertService';
+import { ALERT_CAS_LOST_MESSAGE, buildResolveAlertCas } from '../../services/alertService';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { publishEvent } from '../../services/eventBus';
 import { emitAlertStateFeedback } from '../../services/mlFeedbackEmitters';
@@ -882,10 +882,7 @@ alertsRoutes.post(
       // event, ML feedback, audit) belongs to the caller that actually performed
       // the transition, so report the conflict instead of a resolution that
       // did not happen.
-      return c.json(
-        { error: 'Alert was already resolved or dismissed by another request' },
-        409
-      );
+      return c.json({ error: ALERT_CAS_LOST_MESSAGE }, 409);
     }
 
     // Set cooldown to prevent immediate re-trigger by the evaluation worker

--- a/apps/api/src/routes/alerts/correlations.resolveCas.test.ts
+++ b/apps/api/src/routes/alerts/correlations.resolveCas.test.ts
@@ -22,7 +22,8 @@ import type { SQL } from 'drizzle-orm';
  *    compiled through `PgDialect`, for BOTH the resolve shape (`status IN (...)`)
  *    and the acknowledge shape (`status = 'active'`) — they differ, and a mocked-
  *    drizzle substring match on column names cannot tell either apart from `or`
- *    or from an admitted terminal status (main 8763a3239). drizzle-orm and
+ *    or from an admitted terminal status (the wave-3825 test-hardening pass,
+ *    `8763a3239`, which is not on main). drizzle-orm and
  *    ../../db/schema are REAL in this file for that reason; only the DB
  *    connection module is mocked.
  */
@@ -175,13 +176,23 @@ import { alertCorrelationRoutes } from './correlations';
 const app = new Hono().route('/', alertCorrelationRoutes);
 const dialect = new PgDialect();
 
-const seedGroup = (statusWin: string, statusLose: string) => {
+/**
+ * `reReadRows` is the SECOND `alerts` select — the one `reportUnwrittenAlerts`
+ * issues to work out WHY a member wasn't written. It only runs on a shortfall.
+ * Pass rows carrying a terminal status to model a benign lost race; pass `[]` to
+ * model the row being invisible to this tenant context on re-read, which is the
+ * tenancy bug the exception exists to catch.
+ */
+const seedGroup = (statusWin: string, statusLose: string, reReadRows: unknown[] = []) => {
   selectQueues.clear();
   alertsUpdateWheres.length = 0;
   alertsUpdateReturns.length = 0;
   selectQueues.set('alert_correlation_groups', [[groupRow]]);
   selectQueues.set('alert_correlation_members', [[{ alertId: alertWin.id }, { alertId: alertLose.id }]]);
-  selectQueues.set('alerts', [[{ ...alertWin, status: statusWin }, { ...alertLose, status: statusLose }]]);
+  selectQueues.set('alerts', [
+    [{ ...alertWin, status: statusWin }, { ...alertLose, status: statusLose }],
+    reReadRows,
+  ]);
 };
 
 const resolveGroupRequest = () =>
@@ -216,13 +227,69 @@ describe('POST /correlations/:groupId/resolve — mixed CAS outcome within one g
     expect(emitAlertStateFeedback.mock.calls[0]?.[0]).toMatchObject({ alertId: alertWin.id });
   });
 
-  it('reports the CAS-loser mismatch via captureException rather than pretending it never happened', async () => {
-    seedGroup('active', 'active');
+  it('does NOT page when the re-read shows the member simply lost the race', async () => {
+    // The signal this exception carries is "a tenant-isolation bug may have eaten
+    // a write". Adding the status predicate made an ordinary concurrent resolve
+    // produce the same shortfall, so firing on it would bury the real thing in
+    // routine noise — the detector-fires-for-everything failure mode.
+    seedGroup('active', 'active', [{ id: alertLose.id, status: 'resolved' }]);
+    alertsUpdateReturns.push([{ id: alertWin.id }]);
+
+    await resolveGroupRequest();
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('DOES page when the unwritten member is invisible on re-read', async () => {
+    // Selected moments ago, gone now: the row is not terminal, it is unreachable
+    // from this context. That is an RLS scope mismatch, and under breeze_app the
+    // write raised no error to reveal it.
+    seedGroup('active', 'active', []);
     alertsUpdateReturns.push([{ id: alertWin.id }]);
 
     await resolveGroupRequest();
 
     expect(captureException).toHaveBeenCalledTimes(1);
+    expect(String(captureException.mock.calls[0]?.[0])).toContain('does NOT explain');
+  });
+
+  it('DOES page when the unwritten member is still in a mutable status', async () => {
+    // Visible, non-terminal, and yet the CAS skipped it — neither explanation
+    // fits, so the predicate itself is suspect.
+    seedGroup('active', 'active', [{ id: alertLose.id, status: 'active' }]);
+    alertsUpdateReturns.push([{ id: alertWin.id }]);
+
+    await resolveGroupRequest();
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays silent when every member was written', async () => {
+    seedGroup('active', 'active');
+    alertsUpdateReturns.push([{ id: alertWin.id }, { id: alertLose.id }]);
+
+    await resolveGroupRequest();
+
+    expect(captureException).not.toHaveBeenCalled();
+    expect(publishEvent).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('POST /correlations/:groupId/acknowledge — mixed CAS outcome', () => {
+  it('fans out only for the member the UPDATE returned', async () => {
+    // The acknowledge arm has its own status guard (`= 'active'`, not the
+    // three-way resolvable set) and its own event name, so its winner/loser
+    // behaviour is asserted here rather than inferred from the resolve arm.
+    seedGroup('active', 'active', [{ id: alertLose.id, status: 'acknowledged' }]);
+    alertsUpdateReturns.push([{ id: alertWin.id }]);
+
+    const res = await acknowledgeGroupRequest();
+
+    expect(res.status).toBe(200);
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent.mock.calls[0]?.[0]).toBe('alert.acknowledged');
+    expect(publishEvent.mock.calls[0]?.[2]).toMatchObject({ alertId: alertWin.id });
+    expect(captureException).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/alerts/correlations.resolveCas.test.ts
+++ b/apps/api/src/routes/alerts/correlations.resolveCas.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+/**
+ * POST /correlations/:groupId/{acknowledge,resolve} is a bulk compare-and-swap
+ * (#4094), same family as the single-alert routes: `mutateAlerts` used to UPDATE
+ * by id alone, so a group resolve could re-stamp — and republish `alert.resolved`
+ * for — a member alert a technician or the warranty auto-resolve sweep had
+ * already finished a moment earlier.
+ *
+ * `mutateAlerts` is not exported, so it is driven through the two group routes
+ * that call it, via a real Hono app — same shape as `alerts.resolveCas.test.ts`.
+ *
+ * Two kinds of assertion, deliberately:
+ *
+ *  - BEHAVIOUR — a member alert absent from the UPDATE's `RETURNING` (the CAS
+ *    matched nothing for it) must get no `publishEvent` / `emitAlertStateFeedback`,
+ *    while a sibling that DID come back must get both.
+ *  - COMPILED SQL — the predicate `mutateAlerts` actually passes to `.where()`,
+ *    compiled through `PgDialect`, for BOTH the resolve shape (`status IN (...)`)
+ *    and the acknowledge shape (`status = 'active'`) — they differ, and a mocked-
+ *    drizzle substring match on column names cannot tell either apart from `or`
+ *    or from an admitted terminal status (main 8763a3239). drizzle-orm and
+ *    ../../db/schema are REAL in this file for that reason; only the DB
+ *    connection module is mocked.
+ */
+const {
+  dbMock,
+  selectQueues,
+  alertsUpdateWheres,
+  alertsUpdateReturns,
+  groupRow,
+  alertWin,
+  alertLose,
+} = vi.hoisted(() => {
+  const selectQueues = new Map<string, unknown[][]>();
+  const alertsUpdateWheres: unknown[] = [];
+  const alertsUpdateReturns: unknown[][] = [];
+
+  const groupId = '22222222-2222-4222-8222-222222222222';
+  const groupRow = {
+    id: groupId,
+    orgId: 'org-1',
+    groupKey: 'disk-pressure',
+    rootAlertId: null as string | null,
+    status: 'open',
+    score: null as string | null,
+    noiseReductionPercent: 0,
+    memberCount: 2,
+    firstSeenAt: new Date('2026-08-20T00:00:00Z'),
+    lastSeenAt: new Date('2026-08-20T00:00:00Z'),
+    metadata: {},
+    createdAt: new Date('2026-08-20T00:00:00Z'),
+    updatedAt: new Date('2026-08-20T00:00:00Z'),
+  };
+
+  const alertWin = {
+    id: '33333333-3333-4333-8333-333333333333',
+    orgId: 'org-1',
+    deviceId: 'device-1',
+    ruleId: null as string | null,
+    configPolicyId: null as string | null,
+    status: 'active',
+    severity: 'high',
+    title: 'Disk almost full',
+  };
+  const alertLose = {
+    id: '44444444-4444-4444-8444-444444444444',
+    orgId: 'org-1',
+    deviceId: 'device-2',
+    ruleId: null as string | null,
+    configPolicyId: null as string | null,
+    status: 'active',
+    severity: 'high',
+    title: 'CPU pegged',
+  };
+
+  // Same table-keyed queue as alertService.autoResolveOutcome.test.ts: seeds are
+  // per real Drizzle table (resolved via its Name symbol), not per call order,
+  // so the three selects `getPersistedGroupAlerts` issues (group, members,
+  // alerts) don't have to be threaded by hand.
+  const tableName = (table: unknown): string => {
+    const symbols = Object.getOwnPropertySymbols(table as object);
+    for (const symbol of symbols) {
+      if (symbol.description?.includes('Name')) {
+        const value = (table as Record<symbol, unknown>)[symbol];
+        if (typeof value === 'string') return value;
+      }
+    }
+    return 'unknown';
+  };
+  const take = (table: unknown): unknown[] => selectQueues.get(tableName(table))?.shift() ?? [];
+
+  const dbMock = {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => {
+          const rows = take(table);
+          return {
+            limit: () => Promise.resolve(rows),
+            then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
+              Promise.resolve(rows).then(resolve, reject),
+          };
+        },
+      }),
+    }),
+    update: (table: unknown) => {
+      if (tableName(table) === 'alerts') {
+        return {
+          set: () => ({
+            where: (predicate: unknown) => {
+              alertsUpdateWheres.push(predicate);
+              return { returning: () => Promise.resolve(alertsUpdateReturns.shift() ?? []) };
+            },
+          }),
+        };
+      }
+      // alert_correlation_groups status mirror (updatePersistedGroupStatus): not
+      // under test here, so always "succeeds" without needing its own queue.
+      return {
+        set: () => ({
+          where: () => ({ returning: () => Promise.resolve([{ id: groupRow.id }]) }),
+        }),
+      };
+    },
+  };
+
+  return { dbMock, selectQueues, alertsUpdateWheres, alertsUpdateReturns, groupRow, alertWin, alertLose };
+});
+
+const publishEvent = vi.fn((..._args: unknown[]) => Promise.resolve('evt'));
+const emitAlertStateFeedback = vi.fn((..._args: unknown[]) => Promise.resolve());
+const emitCorrelationFeedback = vi.fn((..._args: unknown[]) => Promise.resolve());
+const emitRcaFeedback = vi.fn((..._args: unknown[]) => Promise.resolve());
+const writeRouteAudit = vi.fn();
+const captureException = vi.fn();
+
+vi.mock('../../db', () => ({ db: dbMock }));
+vi.mock('../../middleware/auth', () => ({
+  // requireScope/requirePermission normally read an `auth` the real
+  // authMiddleware set upstream; that middleware isn't mounted on the isolated
+  // sub-router under test, so — like alerts.resolveCas.test.ts — these mocks
+  // set the context themselves instead of asserting it was already there.
+  requireScope: () => async (c: { set: (k: string, v: unknown) => void }, next: () => Promise<void>) => {
+    c.set('auth', {
+      scope: 'organization',
+      user: { id: 'user-1', name: 'Tech One', email: 'tech@org.example' },
+      partnerId: null,
+      orgId: 'org-1',
+      accessibleOrgIds: null,
+      allowedSiteIds: null,
+      canAccessOrg: () => true,
+    });
+    await next();
+  },
+  requirePermission: () => async (c: { set: (k: string, v: unknown) => void }, next: () => Promise<void>) => {
+    c.set('permissions', { granted: new Set<string>() });
+    await next();
+  },
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: (...a: unknown[]) => writeRouteAudit(...a) }));
+vi.mock('../../services/eventBus', () => ({ publishEvent: (...a: unknown[]) => publishEvent(...a) }));
+vi.mock('../../services/sentry', () => ({ captureException: (...a: unknown[]) => captureException(...a) }));
+vi.mock('../../services/mlFeedbackEmitters', () => ({
+  emitAlertStateFeedback: (...a: unknown[]) => emitAlertStateFeedback(...a),
+  emitCorrelationFeedback: (...a: unknown[]) => emitCorrelationFeedback(...a),
+  emitRcaFeedback: (...a: unknown[]) => emitRcaFeedback(...a),
+}));
+vi.mock('../../services/mlFeatureFlags', () => ({ shouldProduceMlOutput: () => Promise.resolve(false) }));
+
+import { alertCorrelationRoutes } from './correlations';
+
+const app = new Hono().route('/', alertCorrelationRoutes);
+const dialect = new PgDialect();
+
+const seedGroup = (statusWin: string, statusLose: string) => {
+  selectQueues.clear();
+  alertsUpdateWheres.length = 0;
+  alertsUpdateReturns.length = 0;
+  selectQueues.set('alert_correlation_groups', [[groupRow]]);
+  selectQueues.set('alert_correlation_members', [[{ alertId: alertWin.id }, { alertId: alertLose.id }]]);
+  selectQueues.set('alerts', [[{ ...alertWin, status: statusWin }, { ...alertLose, status: statusLose }]]);
+};
+
+const resolveGroupRequest = () =>
+  app.request(`/correlations/${groupRow.id}/resolve`, { method: 'POST' });
+const acknowledgeGroupRequest = () =>
+  app.request(`/correlations/${groupRow.id}/acknowledge`, { method: 'POST' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  publishEvent.mockResolvedValue('evt');
+  emitAlertStateFeedback.mockResolvedValue(undefined);
+  emitCorrelationFeedback.mockResolvedValue(undefined);
+});
+
+describe('POST /correlations/:groupId/resolve — mixed CAS outcome within one group', () => {
+  it('fans out only for the member the UPDATE actually returned', async () => {
+    seedGroup('active', 'active');
+    alertsUpdateReturns.push([{ id: alertWin.id }]); // alert-lose's row is NOT in RETURNING
+
+    const res = await resolveGroupRequest();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ updated: 1, skipped: 1 });
+
+    // The whole point of the CAS: fan-out follows what the UPDATE actually wrote,
+    // not the pre-read `eligible` snapshot — a lost race must stay silent.
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent.mock.calls[0]?.[0]).toBe('alert.resolved');
+    expect(publishEvent.mock.calls[0]?.[2]).toMatchObject({ alertId: alertWin.id });
+
+    expect(emitAlertStateFeedback).toHaveBeenCalledTimes(1);
+    expect(emitAlertStateFeedback.mock.calls[0]?.[0]).toMatchObject({ alertId: alertWin.id });
+  });
+
+  it('reports the CAS-loser mismatch via captureException rather than pretending it never happened', async () => {
+    seedGroup('active', 'active');
+    alertsUpdateReturns.push([{ id: alertWin.id }]);
+
+    await resolveGroupRequest();
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('POST /correlations/:groupId/resolve — the shipped predicate (compiled SQL)', () => {
+  it('scopes the UPDATE by member ids AND the resolvable status set', async () => {
+    seedGroup('active', 'active');
+    alertsUpdateReturns.push([{ id: alertWin.id }, { id: alertLose.id }]);
+
+    await resolveGroupRequest();
+
+    expect(alertsUpdateWheres).toHaveLength(1);
+    const { sql, params } = dialect.sqlToQuery(alertsUpdateWheres[0] as SQL);
+
+    // `or` instead of `and` would stamp every active/acknowledged/suppressed alert
+    // in the id list regardless of status; admitting 'resolved'/'dismissed' turns
+    // the CAS into a no-op. Either mutation changes this string or its params.
+    expect(sql).toBe(
+      '("alerts"."id" in ($1, $2) and "alerts"."status" in ($3, $4, $5))'
+    );
+    expect(params).toEqual([alertWin.id, alertLose.id, 'active', 'acknowledged', 'suppressed']);
+  });
+});
+
+describe('POST /correlations/:groupId/acknowledge — the shipped predicate (compiled SQL)', () => {
+  it('scopes the UPDATE by member ids AND status = active, not the resolve status set', async () => {
+    seedGroup('active', 'active');
+    alertsUpdateReturns.push([{ id: alertWin.id }, { id: alertLose.id }]);
+
+    await acknowledgeGroupRequest();
+
+    expect(alertsUpdateWheres).toHaveLength(1);
+    const { sql, params } = dialect.sqlToQuery(alertsUpdateWheres[0] as SQL);
+
+    // The acknowledge shape is a single equality, not the three-way resolvable
+    // set — swapping in RESOLVABLE_ALERT_STATUSES here would let acknowledge
+    // silently re-ack an already-suppressed alert.
+    expect(sql).toBe('("alerts"."id" in ($1, $2) and "alerts"."status" = $3)');
+    expect(params).toEqual([alertWin.id, alertLose.id, 'active']);
+  });
+});

--- a/apps/api/src/routes/alerts/correlations.ts
+++ b/apps/api/src/routes/alerts/correlations.ts
@@ -7,6 +7,7 @@ import { db } from '../../db';
 import { alertCorrelationGroups, alertCorrelationMembers, alertCorrelations, alerts, devices, mlFeedbackEvents } from '../../db/schema';
 import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
+import { RESOLVABLE_ALERT_STATUSES } from '../../services/alertService';
 import { buildAlertCorrelationRca } from '../../services/alertCorrelationRca';
 import { publishEvent } from '../../services/eventBus';
 import { captureException } from '../../services/sentry';
@@ -580,12 +581,21 @@ async function mutateAlerts(alertRows: AlertRow[], action: 'acknowledge' | 'reso
   }
 
   const alertIds = eligible.map((alert) => alert.id);
+  // The `eligible` filter above reads a snapshot; the status predicate here is what
+  // actually decides who transitioned each row (#4094). Filtering by id alone let a
+  // group resolve re-stamp — and republish `alert.resolved` for — alerts a
+  // technician or the auto-resolve sweep had already finished in between.
   const returned = await db
     .update(alerts)
     .set(action === 'acknowledge'
       ? { status: 'acknowledged', acknowledgedAt: now, acknowledgedBy: userId }
       : { status: 'resolved', resolvedAt: now, resolvedBy: userId })
-    .where(inArray(alerts.id, alertIds))
+    .where(and(
+      inArray(alerts.id, alertIds),
+      action === 'acknowledge'
+        ? eq(alerts.status, 'active')
+        : inArray(alerts.status, [...RESOLVABLE_ALERT_STATUSES])
+    ))
     .returning({ id: alerts.id });
 
   // Under breeze_app RLS a write that matches 0 rows throws no error. Emitting ML feedback
@@ -593,9 +603,15 @@ async function mutateAlerts(alertRows: AlertRow[], action: 'acknowledge' | 'reso
   // acknowledgements. Only emit for alerts the UPDATE actually wrote.
   const writtenIds = new Set(returned.map((row) => row.id));
   if (writtenIds.size !== eligible.length) {
+    // Two causes now, and they are not distinguishable from here: an RLS scope
+    // mismatch (the row is invisible to this tenant context) or a lost race
+    // against a concurrent resolver. The latter is benign and expected under load;
+    // the former is a tenancy bug. Reported as one signal rather than asserting a
+    // cause the code cannot verify.
     captureException(new Error(
-      `[AlertCorrelationRoute] mutateAlerts ${action} RLS scope mismatch: ` +
-      `${eligible.length} eligible alert(s) but only ${writtenIds.size} written; ` +
+      `[AlertCorrelationRoute] mutateAlerts ${action} wrote fewer rows than eligible: ` +
+      `${eligible.length} eligible alert(s) but only ${writtenIds.size} written ` +
+      `(RLS scope mismatch, or a concurrent status change won the compare-and-swap); ` +
       `suppressing feedback for ${eligible.length - writtenIds.size} unwritten alert(s).`
     ));
   }

--- a/apps/api/src/routes/alerts/correlations.ts
+++ b/apps/api/src/routes/alerts/correlations.ts
@@ -570,6 +570,73 @@ async function updatePersistedGroupStatus(
   }
 }
 
+/**
+ * Explain a shortfall between the pre-read `eligible` set and what the UPDATE
+ * actually wrote — and page only for the half that is a bug.
+ *
+ * Before #4094 the UPDATE matched on id alone, so a shortfall had exactly one
+ * plausible cause and this reported it as an RLS scope mismatch with confidence.
+ * Adding the status predicate introduced a SECOND, entirely benign cause: a
+ * technician or the auto-resolve sweep transitioned a member between the read and
+ * the write. That is expected under load on precisely the alerts MSPs act on in
+ * groups, so reporting both as one exception would have turned a high-signal
+ * tenancy alarm into routine noise — the failure mode where an on-call engineer
+ * dismisses the issue on sight and buries the one occurrence that is a real
+ * cross-tenant write.
+ *
+ * So re-read the unwritten rows in the SAME request context and split them:
+ *   - visible + terminal  → the CAS legitimately lost. Debug log, no exception.
+ *   - not visible at all  → the row exists (we just read it) but this context
+ *                           cannot see it on re-read: a tenancy bug. Page.
+ *   - visible + still open→ neither explanation fits. Page; something is wrong
+ *                           with the predicate itself.
+ */
+async function reportUnwrittenAlerts(action: 'acknowledge' | 'resolve', unwrittenIds: string[]) {
+  if (unwrittenIds.length === 0) return;
+
+  let visible: Array<{ id: string; status: string }> = [];
+  try {
+    visible = await db
+      .select({ id: alerts.id, status: alerts.status })
+      .from(alerts)
+      .where(inArray(alerts.id, unwrittenIds));
+  } catch (error) {
+    captureException(error instanceof Error ? error : new Error(String(error)));
+    return;
+  }
+
+  const statusById = new Map(visible.map((row) => [row.id, row.status]));
+  const raced: string[] = [];
+  const unexplained: string[] = [];
+
+  for (const id of unwrittenIds) {
+    const status = statusById.get(id);
+    if (status === undefined) {
+      // Invisible on re-read despite having been selected moments ago.
+      unexplained.push(id);
+      continue;
+    }
+    const terminal = action === 'acknowledge' ? status !== 'active' : status === 'resolved' || status === 'dismissed';
+    (terminal ? raced : unexplained).push(id);
+  }
+
+  if (raced.length > 0) {
+    console.debug(
+      `[AlertCorrelationRoute] mutateAlerts ${action}: ${raced.length} member(s) lost the ` +
+      `compare-and-swap to a concurrent transition; feedback suppressed for them (expected).`
+    );
+  }
+
+  if (unexplained.length > 0) {
+    captureException(new Error(
+      `[AlertCorrelationRoute] mutateAlerts ${action} skipped ${unexplained.length} alert(s) ` +
+      `that a concurrent status change does NOT explain — they are either invisible to this ` +
+      `tenant context on re-read (RLS scope mismatch) or still in a mutable status. ` +
+      `Suppressing feedback for them.`
+    ));
+  }
+}
+
 async function mutateAlerts(alertRows: AlertRow[], action: 'acknowledge' | 'resolve', userId: string) {
   const now = new Date();
   const eligible = action === 'acknowledge'
@@ -603,17 +670,10 @@ async function mutateAlerts(alertRows: AlertRow[], action: 'acknowledge' | 'reso
   // acknowledgements. Only emit for alerts the UPDATE actually wrote.
   const writtenIds = new Set(returned.map((row) => row.id));
   if (writtenIds.size !== eligible.length) {
-    // Two causes now, and they are not distinguishable from here: an RLS scope
-    // mismatch (the row is invisible to this tenant context) or a lost race
-    // against a concurrent resolver. The latter is benign and expected under load;
-    // the former is a tenancy bug. Reported as one signal rather than asserting a
-    // cause the code cannot verify.
-    captureException(new Error(
-      `[AlertCorrelationRoute] mutateAlerts ${action} wrote fewer rows than eligible: ` +
-      `${eligible.length} eligible alert(s) but only ${writtenIds.size} written ` +
-      `(RLS scope mismatch, or a concurrent status change won the compare-and-swap); ` +
-      `suppressing feedback for ${eligible.length - writtenIds.size} unwritten alert(s).`
-    ));
+    await reportUnwrittenAlerts(
+      action,
+      eligible.filter((alert) => !writtenIds.has(alert.id)).map((alert) => alert.id)
+    );
   }
 
   for (const alert of eligible) {

--- a/apps/api/src/routes/mobile.resolveCas.test.ts
+++ b/apps/api/src/routes/mobile.resolveCas.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+/**
+ * POST /mobile/alerts/:id/resolve is a compare-and-swap (#4094).
+ *
+ * The twin of routes/alerts/alerts.ts's handler and it carried the same
+ * check-then-act defect: read the status, then UPDATE by id unconditionally, then
+ * publish. See alerts.resolveCas.test.ts for the full rationale and for why the
+ * predicate is asserted as COMPILED SQL rather than by column name.
+ */
+const { dbMock, updateWheres, updateReturns, selectReturns, alertRow } = vi.hoisted(() => {
+  const updateWheres: unknown[] = [];
+  const updateReturns: unknown[][] = [];
+  const selectReturns: unknown[][] = [];
+  const alertRow = {
+    id: '22222222-2222-4222-8222-222222222222',
+    orgId: 'org-1',
+    deviceId: 'device-1',
+    ruleId: null as string | null,
+    configPolicyId: null as string | null,
+    context: null as unknown,
+    status: 'active',
+    title: 'Agent offline',
+  };
+  const dbMock = {
+    // mobile.ts keeps its OWN `getAlertWithOrgCheck` (it is not the shared
+    // routes/alerts/helpers one), so the pre-read is driven through this queue
+    // rather than by mocking a helper module.
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve(selectReturns.shift() ?? []) }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: (predicate: unknown) => {
+          updateWheres.push(predicate);
+          return { returning: () => Promise.resolve(updateReturns.shift() ?? []) };
+        },
+      }),
+    }),
+  };
+  return { dbMock, updateWheres, updateReturns, selectReturns, alertRow };
+});
+
+const publishEvent = vi.fn((..._args: unknown[]) => Promise.resolve('evt'));
+const emitAlertStateFeedback = vi.fn((..._args: unknown[]) => Promise.resolve());
+const writeRouteAudit = vi.fn();
+const setCooldown = vi.fn((..._args: unknown[]) => Promise.resolve());
+const markConfigPolicyRuleCooldown = vi.fn((..._args: unknown[]) => Promise.resolve());
+vi.mock('../db', () => ({
+  db: dbMock,
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: async (_c: unknown, next: () => Promise<void>) => next(),
+  requireScope: () => async (c: { set: (k: string, v: unknown) => void }, next: () => Promise<void>) => {
+    c.set('auth', {
+      scope: 'organization',
+      user: { id: 'user-1', name: 'Tech One', email: 'tech@org.example' },
+      partnerId: null,
+      orgId: 'org-1',
+      accessibleOrgIds: null,
+      canAccessOrg: () => true,
+    });
+    await next();
+  },
+  requirePermission: () => async (c: { set: (k: string, v: unknown) => void }, next: () => Promise<void>) => {
+    c.set('permissions', { granted: new Set<string>() });
+    await next();
+  },
+  requireMfa: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+vi.mock('../middleware/userRateLimit', () => ({ userRateLimit: () => async (_c: unknown, next: () => Promise<void>) => next() }));
+vi.mock('../services/alertCooldown', () => ({
+  setCooldown: (...args: unknown[]) => setCooldown(...args),
+  markConfigPolicyRuleCooldown: (...args: unknown[]) => markConfigPolicyRuleCooldown(...args),
+}));
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: (...a: unknown[]) => writeRouteAudit(...a) }));
+vi.mock('../services/eventBus', () => ({ publishEvent: (...a: unknown[]) => publishEvent(...a) }));
+vi.mock('../services/mlFeedbackEmitters', () => ({
+  emitAlertStateFeedback: (...a: unknown[]) => emitAlertStateFeedback(...a),
+}));
+vi.mock('../services/wakeOnLan', () => ({ dispatchWake: vi.fn() }));
+vi.mock('../services/scriptExecution', () => ({ executeScriptOnDevices: vi.fn() }));
+
+import { mobileRoutes } from './mobile';
+
+const app = new Hono().route('/mobile', mobileRoutes);
+const dialect = new PgDialect();
+
+const resolveRequest = () =>
+  app.request(`/mobile/alerts/${alertRow.id}/resolve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ note: 'cleared from the phone' }),
+  });
+
+beforeEach(() => {
+  updateWheres.length = 0;
+  updateReturns.length = 0;
+  selectReturns.length = 0;
+  vi.clearAllMocks();
+  publishEvent.mockResolvedValue('evt');
+  emitAlertStateFeedback.mockResolvedValue(undefined);
+  setCooldown.mockResolvedValue(undefined);
+  markConfigPolicyRuleCooldown.mockResolvedValue(undefined);
+  // The pre-read always sees a resolvable alert; the race happens after it.
+  selectReturns.push([{ ...alertRow, status: 'active' }]);
+});
+
+describe('POST /mobile/alerts/:id/resolve — the losing caller', () => {
+  it('answers 409 and fans nothing out', async () => {
+    updateReturns.push([]); // CAS matched nothing
+
+    const res = await resolveRequest();
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Alert was already resolved or dismissed by another request',
+    });
+    expect(publishEvent).not.toHaveBeenCalled();
+    expect(setCooldown).not.toHaveBeenCalled();
+    expect(markConfigPolicyRuleCooldown).not.toHaveBeenCalled();
+    expect(emitAlertStateFeedback).not.toHaveBeenCalled();
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /mobile/alerts/:id/resolve — the winning caller', () => {
+  it('answers 200 and publishes exactly once', async () => {
+    updateReturns.push([{ ...alertRow, status: 'resolved' }]);
+
+    const res = await resolveRequest();
+
+    expect(res.status).toBe(200);
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent.mock.calls[0]?.[0]).toBe('alert.resolved');
+    expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the same 409 the CAS loser gets when the pre-read already sees resolved', async () => {
+    selectReturns[0] = [{ ...alertRow, status: 'resolved' }];
+
+    const res = await resolveRequest();
+
+    expect(res.status).toBe(409);
+    expect(updateWheres).toHaveLength(0);
+  });
+
+  it('keeps dismissed a 400', async () => {
+    selectReturns[0] = [{ ...alertRow, status: 'dismissed' }];
+
+    const res = await resolveRequest();
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /mobile/alerts/:id/resolve — the shipped predicate (compiled SQL)', () => {
+  it('scopes the UPDATE by id AND resolvable status', async () => {
+    updateReturns.push([{ ...alertRow, status: 'resolved' }]);
+
+    await resolveRequest();
+
+    expect(updateWheres).toHaveLength(1);
+    const { sql, params } = dialect.sqlToQuery(updateWheres[0] as SQL);
+
+    expect(sql).toBe('("alerts"."id" = $1 and "alerts"."status" in ($2, $3, $4))');
+    expect(params).toEqual([alertRow.id, 'active', 'acknowledged', 'suppressed']);
+  });
+});

--- a/apps/api/src/routes/mobile.resolveCas.test.ts
+++ b/apps/api/src/routes/mobile.resolveCas.test.ts
@@ -121,7 +121,7 @@ describe('POST /mobile/alerts/:id/resolve — the losing caller', () => {
 
     expect(res.status).toBe(409);
     await expect(res.json()).resolves.toEqual({
-      error: 'Alert was already resolved or dismissed by another request',
+      error: 'Alert is no longer resolvable — it already reached a terminal status (resolved or dismissed).',
     });
     expect(publishEvent).not.toHaveBeenCalled();
     expect(setCooldown).not.toHaveBeenCalled();

--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -1044,7 +1044,10 @@ describe('mobile routes', () => {
         body: JSON.stringify({ note: 'done' })
       });
 
-      expect(res.status).toBe(400);
+      // 409, not 400, since #4094. The identical outcome is also reachable by
+      // LOSING the compare-and-swap a moment later, and one user action must not
+      // return two different status codes depending purely on timing.
+      expect(res.status).toBe(409);
       expect(emitAlertStateFeedbackMock).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -18,7 +18,7 @@ import {
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { userRateLimit } from '../middleware/userRateLimit';
 import { setCooldown, markConfigPolicyRuleCooldown } from '../services/alertCooldown';
-import { buildResolveAlertCas } from '../services/alertService';
+import { ALERT_CAS_LOST_MESSAGE, buildResolveAlertCas } from '../services/alertService';
 import { writeRouteAudit } from '../services/auditEvents';
 import { publishEvent } from '../services/eventBus';
 import { escapeLike } from '../utils/sql';
@@ -1005,10 +1005,7 @@ mobileRoutes.post(
     if (!updated) {
       // Lost the race: another request reached a terminal status first. The
       // cooldown/event/feedback/audit fan-out below belongs to that caller only.
-      return c.json(
-        { error: 'Alert was already resolved or dismissed by another request' },
-        409
-      );
+      return c.json({ error: ALERT_CAS_LOST_MESSAGE }, 409);
     }
 
     try {

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -18,6 +18,7 @@ import {
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { userRateLimit } from '../middleware/userRateLimit';
 import { setCooldown, markConfigPolicyRuleCooldown } from '../services/alertCooldown';
+import { buildResolveAlertCas } from '../services/alertService';
 import { writeRouteAudit } from '../services/auditEvents';
 import { publishEvent } from '../services/eventBus';
 import { escapeLike } from '../utils/sql';
@@ -977,8 +978,10 @@ mobileRoutes.post(
       return c.json({ error: 'Alert not found' }, 404);
     }
 
+    // Fast path with a specific message. It is NOT the concurrency control — the
+    // compare-and-swap below is. A tech racing the auto-resolve sweep clears this.
     if (alert.status === 'resolved') {
-      return c.json({ error: 'Alert is already resolved' }, 400);
+      return c.json({ error: 'Alert is already resolved' }, 409);
     }
     if (alert.status === 'dismissed') {
       // Dismissed is terminal (matches POST /alerts/:id/resolve): resolving it
@@ -987,6 +990,8 @@ mobileRoutes.post(
     }
 
     const resolvedAt = new Date();
+    // Winner-takes-all (#4094) — same predicate as `resolveAlert`. See the twin
+    // handler in routes/alerts/alerts.ts for the full rationale.
     const [updated] = await db
       .update(alerts)
       .set({
@@ -995,8 +1000,16 @@ mobileRoutes.post(
         resolvedBy: auth.user.id,
         resolutionNote: data.note
       })
-      .where(eq(alerts.id, alertId))
+      .where(buildResolveAlertCas(alertId))
       .returning();
+    if (!updated) {
+      // Lost the race: another request reached a terminal status first. The
+      // cooldown/event/feedback/audit fan-out below belongs to that caller only.
+      return c.json(
+        { error: 'Alert was already resolved or dismissed by another request' },
+        409
+      );
+    }
 
     try {
       if (alert.ruleId) {
@@ -1032,7 +1045,7 @@ mobileRoutes.post(
         'alert.resolved',
         alert.orgId,
         {
-          alertId: updated?.id ?? alertId,
+          alertId: updated.id,
           ruleId: alert.ruleId,
           deviceId: alert.deviceId,
           resolvedBy: auth.user.id,
@@ -1047,7 +1060,7 @@ mobileRoutes.post(
 
     await emitAlertStateFeedback({
       orgId: alert.orgId,
-      alertId: updated?.id ?? alertId,
+      alertId: updated.id,
       eventType: 'alert.resolved',
       outcome: 'resolved',
       actorUserId: auth.user.id,
@@ -1063,8 +1076,8 @@ mobileRoutes.post(
       orgId: alert.orgId,
       action: 'mobile.alert.resolve',
       resourceType: 'alert',
-      resourceId: updated?.id ?? alertId,
-      resourceName: updated?.title ?? alert.title,
+      resourceId: updated.id,
+      resourceName: updated.title,
       details: { hasNote: Boolean(data.note) }
     });
 

--- a/apps/api/src/services/aiToolsAlerts.feedback.test.ts
+++ b/apps/api/src/services/aiToolsAlerts.feedback.test.ts
@@ -65,10 +65,23 @@ function mockAlertLookup(row: unknown | null) {
   });
 }
 
-function mockUpdate() {
+/**
+ * `resolve` is a compare-and-swap since #4094: it chains `.returning({id})` and
+ * treats an empty result as "another caller transitioned this alert". The chain
+ * therefore has to offer BOTH endings — `acknowledge`/`suppress` still await the
+ * `where(...)` promise directly, while `resolve` awaits `returning()`.
+ *
+ * `returning` defaults to a one-row winner so every pre-existing caller keeps its
+ * behaviour; pass `[]` to model losing the race.
+ */
+function mockUpdate(returning: unknown[] = [{ id: ALERT.id }]) {
   mocks.dbUpdate.mockReturnValueOnce({
     set: vi.fn(() => ({
-      where: vi.fn().mockResolvedValue(undefined),
+      where: vi.fn(() =>
+        Object.assign(Promise.resolve(undefined), {
+          returning: vi.fn().mockResolvedValue(returning),
+        })
+      ),
     })),
   });
 }

--- a/apps/api/src/services/aiToolsAlerts.resolveCas.test.ts
+++ b/apps/api/src/services/aiToolsAlerts.resolveCas.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+/**
+ * manage_alerts { action: 'resolve' } is a compare-and-swap (#4094), the same
+ * predicate as POST /alerts/:id/resolve (`alerts.resolveCas.test.ts`) and
+ * `resolveAlert` (`alertService.resolveCasSql.test.ts`). Before this PR the tool
+ * did read-status-then-UPDATE-by-id: an AI agent step racing a technician's
+ * resolve (or another agent step — wave 3.5c's at-least-once delivery makes this
+ * likelier than a human double-click) both "won" and both published
+ * `alert.resolved`.
+ *
+ * Two kinds of assertion here, deliberately:
+ *
+ *  - BEHAVIOUR — an empty `RETURNING` (the CAS matched nothing) must produce the
+ *    "already resolved or dismissed by another request" error and NO fan-out.
+ *  - COMPILED SQL — the predicate the handler actually passes to `.where()`,
+ *    compiled through `PgDialect`. drizzle-orm and ../db/schema are REAL in this
+ *    file for that reason: a mocked-drizzle `where` assertion can only substring-
+ *    match column NAMES, which cannot tell `and` from `or` and cannot see the
+ *    status list gaining a terminal value. Both mutations were verified to pass
+ *    green against exactly that style of test (main 8763a3239).
+ */
+const { dbMock, updateWheres, updateReturns, alertRow } = vi.hoisted(() => {
+  const updateWheres: unknown[] = [];
+  const updateReturns: unknown[][] = [];
+  const alertRow = {
+    id: '55555555-5555-4555-8555-555555555555',
+    orgId: 'org-1',
+    deviceId: 'device-1',
+    ruleId: null as string | null,
+    configPolicyId: null as string | null,
+    status: 'active',
+    title: 'Disk almost full',
+  };
+  const dbMock = {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([alertRow]) }) }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: (predicate: unknown) => {
+          updateWheres.push(predicate);
+          return { returning: () => Promise.resolve(updateReturns.shift() ?? []) };
+        },
+      }),
+    }),
+  };
+  return { dbMock, updateWheres, updateReturns, alertRow };
+});
+
+const publishEvent = vi.fn((..._args: unknown[]) => Promise.resolve('evt'));
+const emitAlertStateFeedback = vi.fn((..._args: unknown[]) => Promise.resolve());
+
+vi.mock('../db', () => ({ db: dbMock }));
+vi.mock('./eventBus', () => ({ publishEvent: (...a: unknown[]) => publishEvent(...a) }));
+vi.mock('./mlFeedbackEmitters', () => ({ emitAlertStateFeedback: (...a: unknown[]) => emitAlertStateFeedback(...a) }));
+
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+import { registerAlertTools } from './aiToolsAlerts';
+
+function resolveHandler(): AiTool['handler'] {
+  const registry = new Map<string, AiTool>();
+  registerAlertTools(registry);
+  return registry.get('manage_alerts')!.handler;
+}
+
+// Unrestricted org caller: orgCondition a no-op (mirrors an org-scope RLS
+// context, which already confines the row) and no canAccessSite, so
+// findAlertWithAccess's deviceIdSiteDenied check short-circuits without an
+// extra db call — this file is about the resolve CAS, not the site axis.
+function makeAuth(): AuthContext {
+  return {
+    principal: { kind: 'user_session' },
+    user: { id: '11111111-1111-4111-8111-111111111111', email: 'user@example.com', name: 'User', isPlatformAdmin: false },
+    token: {} as never,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: (orgId) => orgId === 'org-1',
+  } as AuthContext;
+}
+
+const resolve = (overrides: Record<string, unknown> = {}) =>
+  resolveHandler()({ action: 'resolve', alertId: alertRow.id, ...overrides }, makeAuth());
+
+beforeEach(() => {
+  updateWheres.length = 0;
+  updateReturns.length = 0;
+  vi.clearAllMocks();
+  publishEvent.mockResolvedValue('evt');
+  emitAlertStateFeedback.mockResolvedValue(undefined);
+});
+
+describe('manage_alerts resolve — the losing caller', () => {
+  it('answers the CAS-lost error and reports no resolution it did not perform', async () => {
+    updateReturns.push([]); // CAS matched nothing: another request got there first
+
+    const result = JSON.parse(await resolve());
+
+    expect(result).toEqual({
+      error: 'Alert was already resolved or dismissed by another request',
+    });
+  });
+
+  it('publishes no alert.resolved event and emits no ML feedback', async () => {
+    updateReturns.push([]);
+
+    await resolve();
+
+    // The whole point of the CAS: escalation cancellation and the '*' automation
+    // subscriber must see one event per real transition, not one per tool call.
+    expect(publishEvent).not.toHaveBeenCalled();
+    expect(emitAlertStateFeedback).not.toHaveBeenCalled();
+  });
+});
+
+describe('manage_alerts resolve — the winning caller', () => {
+  it('answers success and publishes alert.resolved exactly once', async () => {
+    updateReturns.push([{ id: alertRow.id }]);
+
+    const result = JSON.parse(await resolve({ resolutionNote: 'cleared by hand' }));
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('resolved');
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent.mock.calls[0]?.[0]).toBe('alert.resolved');
+    expect(emitAlertStateFeedback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('manage_alerts resolve — the shipped predicate (compiled SQL)', () => {
+  it('scopes the UPDATE by id AND resolvable status', async () => {
+    updateReturns.push([{ id: alertRow.id }]);
+
+    await resolve();
+
+    expect(updateWheres).toHaveLength(1);
+    const dialect = new PgDialect();
+    const { sql, params } = dialect.sqlToQuery(updateWheres[0] as SQL);
+
+    // `or` instead of `and` would stamp every active/acknowledged/suppressed alert
+    // in EVERY tenant resolved from one call; dropping the status list makes the
+    // write unconditional again; admitting 'resolved' or 'dismissed' makes the CAS
+    // a no-op. Each of those changes this string or its params.
+    expect(sql).toBe('("alerts"."id" = $1 and "alerts"."status" in ($2, $3, $4))');
+    expect(params).toEqual([alertRow.id, 'active', 'acknowledged', 'suppressed']);
+  });
+});

--- a/apps/api/src/services/aiToolsAlerts.resolveCas.test.ts
+++ b/apps/api/src/services/aiToolsAlerts.resolveCas.test.ts
@@ -7,20 +7,22 @@ import type { SQL } from 'drizzle-orm';
  * predicate as POST /alerts/:id/resolve (`alerts.resolveCas.test.ts`) and
  * `resolveAlert` (`alertService.resolveCasSql.test.ts`). Before this PR the tool
  * did read-status-then-UPDATE-by-id: an AI agent step racing a technician's
- * resolve (or another agent step — wave 3.5c's at-least-once delivery makes this
+ * resolve (or another agent step — at-least-once event delivery, tracked for wave
+ * 3.5c in #4085 and not yet shipped, will make this
  * likelier than a human double-click) both "won" and both published
  * `alert.resolved`.
  *
  * Two kinds of assertion here, deliberately:
  *
  *  - BEHAVIOUR — an empty `RETURNING` (the CAS matched nothing) must produce the
- *    "already resolved or dismissed by another request" error and NO fan-out.
+ *    "no longer resolvable" error and NO fan-out.
  *  - COMPILED SQL — the predicate the handler actually passes to `.where()`,
  *    compiled through `PgDialect`. drizzle-orm and ../db/schema are REAL in this
  *    file for that reason: a mocked-drizzle `where` assertion can only substring-
  *    match column NAMES, which cannot tell `and` from `or` and cannot see the
  *    status list gaining a terminal value. Both mutations were verified to pass
- *    green against exactly that style of test (main 8763a3239).
+ *    green against exactly that style of test (the wave-3825 test-hardening
+ *    pass, `8763a3239`, which is not on main).
  */
 const { dbMock, updateWheres, updateReturns, alertRow } = vi.hoisted(() => {
   const updateWheres: unknown[] = [];
@@ -103,7 +105,7 @@ describe('manage_alerts resolve — the losing caller', () => {
     const result = JSON.parse(await resolve());
 
     expect(result).toEqual({
-      error: 'Alert was already resolved or dismissed by another request',
+      error: 'Alert is no longer resolvable — it already reached a terminal status (resolved or dismissed).',
     });
   });
 

--- a/apps/api/src/services/aiToolsAlerts.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsAlerts.siteScope.test.ts
@@ -59,7 +59,13 @@ describe('manage_alerts — per-alert site scoping', () => {
 
   it('resolve unrestricted caller is unaffected', async () => {
     mockDb.select.mockReturnValue({ from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'a1', orgId: 'org-1', deviceId: 'd1', title: 'T' }]) }) }) });
-    mockDb.update.mockReturnValue({ set: () => ({ where: () => Promise.resolve() }) });
+    // `resolve` is a compare-and-swap since #4094 and chains `.returning({id})`;
+    // a non-empty result is the winner. This suite is about the SITE axis, so it
+    // always plays the winner — the CAS outcome itself is covered in
+    // aiToolsAlerts.resolveCas.test.ts.
+    mockDb.update.mockReturnValue({
+      set: () => ({ where: () => ({ returning: () => Promise.resolve([{ id: 'a1' }]) }) }),
+    });
     const r = await handlerFor('manage_alerts')({ action: 'resolve', alertId: 'a1' }, makeAuth(undefined));
     expect(r).not.toContain('access denied');
     expect(mockDb.update).toHaveBeenCalled();

--- a/apps/api/src/services/aiToolsAlerts.ts
+++ b/apps/api/src/services/aiToolsAlerts.ts
@@ -13,6 +13,7 @@ import { eq, and, desc, sql, inArray, ne, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { publishEvent } from './eventBus';
+import { buildResolveAlertCas } from './alertService';
 import { deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 import { emitAlertStateFeedback } from './mlFeedbackEmitters';
 import {
@@ -210,7 +211,9 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
 
         // Mirror POST /alerts/:id/resolve: already-resolved is a no-op error and
         // dismissed is terminal (resolving it would let synthetic evaluators
-        // re-create the alert the user permanently dismissed).
+        // re-create the alert the user permanently dismissed). Like the route's,
+        // this read is a fast path with a specific message, NOT the concurrency
+        // control — the compare-and-swap below is.
         if (alert.status === 'resolved') {
           return JSON.stringify({ error: 'Alert is already resolved' });
         }
@@ -220,7 +223,11 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
 
         const resolvedAt = new Date();
         const resolutionNote = (input.resolutionNote as string) ?? 'Resolved via AI assistant';
-        await db
+        // Winner-takes-all (#4094), same predicate as `resolveAlert` and the two
+        // HTTP resolve routes. An agent racing a technician (or another agent
+        // step, which wave 3.5c's at-least-once delivery makes likelier) must not
+        // republish `alert.resolved` for a transition it did not perform.
+        const resolveWrite = await db
           .update(alerts)
           .set({
             status: 'resolved',
@@ -228,7 +235,14 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
             resolvedBy: auth.user.id,
             resolutionNote
           })
-          .where(eq(alerts.id, input.alertId as string));
+          .where(buildResolveAlertCas(input.alertId as string))
+          .returning({ id: alerts.id });
+
+        if (resolveWrite.length === 0) {
+          return JSON.stringify({
+            error: 'Alert was already resolved or dismissed by another request',
+          });
+        }
 
         let resolveEventWarning: string | undefined;
         try {

--- a/apps/api/src/services/aiToolsAlerts.ts
+++ b/apps/api/src/services/aiToolsAlerts.ts
@@ -13,7 +13,7 @@ import { eq, and, desc, sql, inArray, ne, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { publishEvent } from './eventBus';
-import { buildResolveAlertCas } from './alertService';
+import { ALERT_CAS_LOST_MESSAGE, buildResolveAlertCas } from './alertService';
 import { deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 import { emitAlertStateFeedback } from './mlFeedbackEmitters';
 import {
@@ -224,9 +224,11 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
         const resolvedAt = new Date();
         const resolutionNote = (input.resolutionNote as string) ?? 'Resolved via AI assistant';
         // Winner-takes-all (#4094), same predicate as `resolveAlert` and the two
-        // HTTP resolve routes. An agent racing a technician (or another agent
-        // step, which wave 3.5c's at-least-once delivery makes likelier) must not
-        // republish `alert.resolved` for a transition it did not perform.
+        // HTTP resolve routes. An agent racing a technician — or racing a retried
+        // or duplicated tool call of its own — must not republish `alert.resolved`
+        // for a transition it did not perform. (At-least-once event delivery,
+        // tracked for wave 3.5c in #4085, is not shipped yet; it will raise the
+        // odds further when it lands, but the race is already reachable today.)
         const resolveWrite = await db
           .update(alerts)
           .set({
@@ -239,9 +241,7 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
           .returning({ id: alerts.id });
 
         if (resolveWrite.length === 0) {
-          return JSON.stringify({
-            error: 'Alert was already resolved or dismissed by another request',
-          });
+          return JSON.stringify({ error: ALERT_CAS_LOST_MESSAGE });
         }
 
         let resolveEventWarning: string | undefined;

--- a/apps/api/src/services/alertService.autoResolveOutcome.test.ts
+++ b/apps/api/src/services/alertService.autoResolveOutcome.test.ts
@@ -235,35 +235,100 @@ describe('checkAutoResolveFromConfigPolicy takes the branch the fixture selects'
   });
 });
 
-describe('checkAutoResolve reports the compare-and-swap outcome', () => {
-  const legacyAlert = {
-    id: 'a-legacy',
-    orgId: 'org-1',
-    deviceId: 'device-1',
-    ruleId: 'rule-1',
-    configPolicyId: null,
-    status: 'active',
-  };
-  const rule = { id: 'rule-1', templateId: 'tpl-1', overrideSettings: null };
-  const template = { id: 'tpl-1', autoResolve: true, autoResolveConditions: null, conditions: { all: [] }, cooldownMinutes: 15 };
+/**
+ * `checkAutoResolve` forks on `autoResolveConditions` exactly like the config-policy
+ * sweep above, and the CAS-outcome gate is likewise duplicated in BOTH arms
+ * (alertService.ts ~231-250). Pinning the template to one shape would leave the
+ * other arm free to revert to `await resolveAlert(...); return true;` with this
+ * suite still green — the same uniform-fixture blind spot (#3975) — so both suites
+ * below run against both template shapes.
+ */
+const legacyAlert = {
+  id: 'a-legacy',
+  orgId: 'org-1',
+  deviceId: 'device-1',
+  ruleId: 'rule-1',
+  configPolicyId: null,
+  status: 'active',
+};
+const legacyRule = { id: 'rule-1', templateId: 'tpl-1', overrideSettings: null };
 
-  it('returns false when another resolver won the race', async () => {
+type LegacyTemplate = {
+  id: string;
+  autoResolve: boolean;
+  autoResolveConditions: unknown;
+  conditions: unknown;
+  cooldownMinutes: number;
+};
+
+const legacyTemplateInverseTrigger: LegacyTemplate = {
+  id: 'tpl-1',
+  autoResolve: true,
+  autoResolveConditions: null,
+  conditions: { all: [] },
+  cooldownMinutes: 15,
+};
+
+const legacyTemplateExplicitConditions: LegacyTemplate = {
+  ...legacyTemplateInverseTrigger,
+  autoResolveConditions: { all: [{ metric: 'cpu', op: 'lt', value: 50 }] },
+};
+
+const bothTemplateShapes: Array<[string, LegacyTemplate]> = [
+  ['inverse-trigger branch (autoResolveConditions null)', legacyTemplateInverseTrigger],
+  ['explicit-conditions branch (autoResolveConditions set)', legacyTemplateExplicitConditions],
+];
+
+describe.each(bothTemplateShapes)(
+  'checkAutoResolve reports the compare-and-swap outcome — %s',
+  (_label, template) => {
+    it('returns false when another resolver won the race', async () => {
+      seed('alerts', [legacyAlert]);
+      seed('alert_rules', [legacyRule]);
+      seed('alert_templates', [template]);
+      updateReturns.push([]); // CAS matched nothing
+
+      await expect(checkAutoResolve('a-legacy')).resolves.toBe(false);
+      expect(publishEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns true when this caller performed the transition', async () => {
+      seed('alerts', [legacyAlert]);
+      seed('alert_rules', [legacyRule], [legacyRule]);
+      seed('alert_templates', [template], [template]);
+      updateReturns.push([legacyAlert]);
+
+      await expect(checkAutoResolve('a-legacy')).resolves.toBe(true);
+      expect(publishEvent).toHaveBeenCalledTimes(1);
+    });
+  }
+);
+
+describe('checkAutoResolve takes the branch the fixture selects', () => {
+  // Guards the parameterisation above: if both template fixtures silently routed
+  // through the same arm, every branch-sensitive assertion would be testing one
+  // arm twice.
+  it('evaluates the trigger conditions when autoResolveConditions is null', async () => {
     seed('alerts', [legacyAlert]);
-    seed('alert_rules', [rule]);
-    seed('alert_templates', [template]);
-    updateReturns.push([]); // CAS matched nothing
-
-    await expect(checkAutoResolve('a-legacy')).resolves.toBe(false);
-    expect(publishEvent).not.toHaveBeenCalled();
-  });
-
-  it('returns true when this caller performed the transition', async () => {
-    seed('alerts', [legacyAlert]);
-    seed('alert_rules', [rule], [rule]);
-    seed('alert_templates', [template], [template]);
+    seed('alert_rules', [legacyRule], [legacyRule]);
+    seed('alert_templates', [legacyTemplateInverseTrigger], [legacyTemplateInverseTrigger]);
     updateReturns.push([legacyAlert]);
 
-    await expect(checkAutoResolve('a-legacy')).resolves.toBe(true);
-    expect(publishEvent).toHaveBeenCalledTimes(1);
+    await checkAutoResolve('a-legacy');
+
+    expect(evaluateConditions).toHaveBeenCalledTimes(1);
+    expect(evaluateAutoResolveConditions).not.toHaveBeenCalled();
+  });
+
+  it('evaluates the explicit auto-resolve conditions when they are set', async () => {
+    seed('alerts', [legacyAlert]);
+    seed('alert_rules', [legacyRule], [legacyRule]);
+    seed('alert_templates', [legacyTemplateExplicitConditions], [legacyTemplateExplicitConditions]);
+    updateReturns.push([legacyAlert]);
+
+    await checkAutoResolve('a-legacy');
+
+    expect(evaluateAutoResolveConditions).toHaveBeenCalledTimes(1);
+    expect(evaluateConditions).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/alertService.autoResolveOutcome.test.ts
+++ b/apps/api/src/services/alertService.autoResolveOutcome.test.ts
@@ -104,13 +104,41 @@ const cpAlert = (id: string) => ({
   status: 'active',
 });
 
-const cpRule = {
+/**
+ * `checkAutoResolveFromConfigPolicy` forks on `rule.autoResolveConditions`, and the
+ * CAS-outcome gate is duplicated in BOTH arms. A fixture that pins this field to one
+ * value would leave the other arm free to regress with this suite still green — the
+ * uniform-fixture blind spot that shipped #3975 — so the suites below run against
+ * both, and `bothRuleShapes` exists to make forgetting that awkward.
+ */
+type CpRule = {
+  id: string;
+  autoResolve: boolean;
+  autoResolveConditions: unknown;
+  conditions: unknown;
+  cooldownMinutes: number;
+};
+
+const cpRuleInverseTrigger: CpRule = {
   id: 'cp-rule-1',
   autoResolve: true,
   autoResolveConditions: null,
   conditions: { all: [] },
   cooldownMinutes: 30,
 };
+
+const cpRuleExplicitConditions: CpRule = {
+  ...cpRuleInverseTrigger,
+  autoResolveConditions: { all: [{ metric: 'cpu', op: 'lt', value: 50 }] },
+};
+
+const bothRuleShapes: Array<[string, CpRule]> = [
+  ['inverse-trigger branch (autoResolveConditions null)', cpRuleInverseTrigger],
+  ['explicit-conditions branch (autoResolveConditions set)', cpRuleExplicitConditions],
+];
+
+// Kept for the single-shape suites below that are not branch-sensitive.
+const cpRule = cpRuleInverseTrigger;
 
 beforeEach(() => {
   selectQueues.clear();
@@ -124,57 +152,86 @@ beforeEach(() => {
   publishEvent.mockResolvedValue('evt');
 });
 
-describe('checkAutoResolveFromConfigPolicy counts compare-and-swap winners only', () => {
-  it('does not count an alert another resolver already transitioned', async () => {
-    seed('alerts', [cpAlert('a-win'), cpAlert('a-lose')]);
-    // resolveAlert re-reads the policy rule on the winning path only.
-    seed('config_policy_alert_rules', [cpRule], [cpRule]);
-    updateReturns.push([cpAlert('a-win')]); // CAS matched: this sweep won
-    updateReturns.push([]);                 // CAS matched nothing: someone else won
+describe.each(bothRuleShapes)(
+  'checkAutoResolveFromConfigPolicy counts compare-and-swap winners only — %s',
+  (_label, rule) => {
+    it('does not count an alert another resolver already transitioned', async () => {
+      seed('alerts', [cpAlert('a-win'), cpAlert('a-lose')]);
+      // resolveAlert re-reads the policy rule on the winning path only.
+      seed('config_policy_alert_rules', [rule], [rule]);
+      updateReturns.push([cpAlert('a-win')]); // CAS matched: this sweep won
+      updateReturns.push([]);                 // CAS matched nothing: someone else won
 
-    await expect(checkAutoResolveFromConfigPolicy('device-1')).resolves.toBe(1);
+      await expect(checkAutoResolveFromConfigPolicy('device-1')).resolves.toBe(1);
 
-    // Both alerts were attempted — the count is filtered by the CAS outcome, not
-    // by skipping the attempt.
-    expect(updateCount.current).toBe(2);
-  });
+      // Both alerts were attempted — the count is filtered by the CAS outcome, not
+      // by skipping the attempt.
+      expect(updateCount.current).toBe(2);
+    });
 
-  it('publishes alert.resolved once per real transition, not once per attempt', async () => {
-    seed('alerts', [cpAlert('a-win'), cpAlert('a-lose')]);
-    seed('config_policy_alert_rules', [cpRule], [cpRule]);
-    updateReturns.push([cpAlert('a-win')]);
-    updateReturns.push([]);
+    it('publishes alert.resolved once per real transition, not once per attempt', async () => {
+      seed('alerts', [cpAlert('a-win'), cpAlert('a-lose')]);
+      seed('config_policy_alert_rules', [rule], [rule]);
+      updateReturns.push([cpAlert('a-win')]);
+      updateReturns.push([]);
 
-    await checkAutoResolveFromConfigPolicy('device-1');
+      await checkAutoResolveFromConfigPolicy('device-1');
 
-    expect(publishEvent).toHaveBeenCalledTimes(1);
-    expect(publishEvent.mock.calls[0]?.[0]).toBe('alert.resolved');
-  });
+      expect(publishEvent).toHaveBeenCalledTimes(1);
+      expect(publishEvent.mock.calls[0]?.[0]).toBe('alert.resolved');
+    });
 
-  it('writes the config-policy cooldown exactly once for the winner and never for the loser', async () => {
-    seed('alerts', [cpAlert('a-win'), cpAlert('a-lose')]);
-    seed('config_policy_alert_rules', [cpRule], [cpRule]);
-    updateReturns.push([cpAlert('a-win')]);
-    updateReturns.push([]);
+    it('writes the config-policy cooldown exactly once for the winner and never for the loser', async () => {
+      seed('alerts', [cpAlert('a-win'), cpAlert('a-lose')]);
+      seed('config_policy_alert_rules', [rule], [rule]);
+      updateReturns.push([cpAlert('a-win')]);
+      updateReturns.push([]);
 
-    await checkAutoResolveFromConfigPolicy('device-1');
+      await checkAutoResolveFromConfigPolicy('device-1');
 
-    // One write, from inside resolveAlert's winning path. Two would mean the
-    // caller re-added its own duplicate; zero would mean the winner's cooldown
-    // was lost; any write attributable to `a-lose` suppresses a rule that this
-    // sweep never actually resolved.
-    expect(markConfigPolicyRuleCooldown).toHaveBeenCalledTimes(1);
-    expect(markConfigPolicyRuleCooldown).toHaveBeenCalledWith('cp-rule-1', 'device-1', 30);
-  });
+      // One write, from inside resolveAlert's winning path. Two would mean the
+      // caller re-added its own duplicate; zero would mean the winner's cooldown
+      // was lost; any write attributable to `a-lose` suppresses a rule that this
+      // sweep never actually resolved.
+      expect(markConfigPolicyRuleCooldown).toHaveBeenCalledTimes(1);
+      expect(markConfigPolicyRuleCooldown).toHaveBeenCalledWith('cp-rule-1', 'device-1', 30);
+    });
 
-  it('counts every winner when nobody races the sweep', async () => {
-    seed('alerts', [cpAlert('a-1'), cpAlert('a-2')]);
-    seed('config_policy_alert_rules', [cpRule], [cpRule], [cpRule]);
+    it('counts every winner when nobody races the sweep', async () => {
+      seed('alerts', [cpAlert('a-1'), cpAlert('a-2')]);
+      seed('config_policy_alert_rules', [rule], [rule], [rule]);
+      updateReturns.push([cpAlert('a-1')]);
+      updateReturns.push([cpAlert('a-2')]);
+
+      await expect(checkAutoResolveFromConfigPolicy('device-1')).resolves.toBe(2);
+      expect(publishEvent).toHaveBeenCalledTimes(2);
+    });
+  }
+);
+
+describe('checkAutoResolveFromConfigPolicy takes the branch the fixture selects', () => {
+  // Guards the parameterisation above: if both fixtures silently routed through
+  // the same arm, every branch-sensitive assertion would be testing one arm twice.
+  it('evaluates the trigger conditions when autoResolveConditions is null', async () => {
+    seed('alerts', [cpAlert('a-1')]);
+    seed('config_policy_alert_rules', [cpRuleInverseTrigger], [cpRuleInverseTrigger]);
     updateReturns.push([cpAlert('a-1')]);
-    updateReturns.push([cpAlert('a-2')]);
 
-    await expect(checkAutoResolveFromConfigPolicy('device-1')).resolves.toBe(2);
-    expect(publishEvent).toHaveBeenCalledTimes(2);
+    await checkAutoResolveFromConfigPolicy('device-1');
+
+    expect(evaluateConditions).toHaveBeenCalledTimes(1);
+    expect(evaluateAutoResolveConditions).not.toHaveBeenCalled();
+  });
+
+  it('evaluates the explicit auto-resolve conditions when they are set', async () => {
+    seed('alerts', [cpAlert('a-1')]);
+    seed('config_policy_alert_rules', [cpRuleExplicitConditions], [cpRuleExplicitConditions]);
+    updateReturns.push([cpAlert('a-1')]);
+
+    await checkAutoResolveFromConfigPolicy('device-1');
+
+    expect(evaluateAutoResolveConditions).toHaveBeenCalledTimes(1);
+    expect(evaluateConditions).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/alertService.autoResolveOutcome.test.ts
+++ b/apps/api/src/services/alertService.autoResolveOutcome.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The auto-resolve sweeps must report what `resolveAlert`'s compare-and-swap
+ * ACTUALLY did (#4094).
+ *
+ * Before this suite, `checkAutoResolve` returned a hard-coded `true` and
+ * `checkAutoResolveFromConfigPolicy` incremented `resolvedCount` (and wrote the
+ * config-policy cooldown) unconditionally. A sweep that lost the race to the
+ * monitor worker, a `policy.compliant` redelivery, or a technician therefore
+ * reported a resolution it never performed AND stamped a cooldown that suppresses
+ * the next legitimate alert for that rule.
+ *
+ * Only the CONNECTION is mocked here — drizzle-orm and ../db/schema are real, so
+ * nothing in this file depends on matching a predicate by its column names.
+ */
+const { dbMock, selectQueues, updateReturns, updateCount } = vi.hoisted(() => {
+  const selectQueues = new Map<string, unknown[][]>();
+  const updateReturns: unknown[][] = [];
+  const updateCount = { current: 0 };
+
+  // Queues are keyed by the real Drizzle table object, resolved via its symbol
+  // name, so a test seeds rows per table rather than by call order.
+  const tableName = (table: unknown): string => {
+    const symbols = Object.getOwnPropertySymbols(table as object);
+    for (const symbol of symbols) {
+      if (symbol.description?.includes('Name')) {
+        const value = (table as Record<symbol, unknown>)[symbol];
+        if (typeof value === 'string') return value;
+      }
+    }
+    return 'unknown';
+  };
+
+  const take = (table: unknown): unknown[] => selectQueues.get(tableName(table))?.shift() ?? [];
+
+  const dbMock = {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => {
+          const rows = take(table);
+          return {
+            limit: () => Promise.resolve(rows),
+            then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
+              Promise.resolve(rows).then(resolve, reject),
+          };
+        },
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => ({
+          returning: () => {
+            updateCount.current += 1;
+            return Promise.resolve(updateReturns.shift() ?? []);
+          },
+        }),
+      }),
+    }),
+  };
+
+  return { dbMock, selectQueues, updateReturns, updateCount };
+});
+
+const evaluateConditions = vi.fn();
+const evaluateAutoResolveConditions = vi.fn();
+const markConfigPolicyRuleCooldown = vi.fn((..._args: unknown[]) => Promise.resolve());
+const setCooldown = vi.fn((..._args: unknown[]) => Promise.resolve());
+const publishEvent = vi.fn((..._args: unknown[]) => Promise.resolve('evt'));
+
+vi.mock('../db', () => ({ db: dbMock }));
+vi.mock('./alertConditions', () => ({
+  evaluateConditions: (...args: unknown[]) => evaluateConditions(...args),
+  evaluateAutoResolveConditions: (...args: unknown[]) => evaluateAutoResolveConditions(...args),
+  interpolateTemplate: (t: string) => t,
+}));
+vi.mock('./alertCooldown', () => ({
+  isCooldownActive: vi.fn(() => Promise.resolve(false)),
+  setCooldown: (...args: unknown[]) => setCooldown(...args),
+  isConfigPolicyRuleCooling: vi.fn(() => Promise.resolve(false)),
+  markConfigPolicyRuleCooldown: (...args: unknown[]) => markConfigPolicyRuleCooldown(...args),
+  recordStateTransition: vi.fn(() => Promise.resolve()),
+  isFlapping: vi.fn(() => Promise.resolve(false)),
+}));
+vi.mock('./featureConfigResolver', () => ({
+  resolveAlertRulesForDevice: vi.fn(() => Promise.resolve([])),
+  resolveMaintenanceConfigForDevice: vi.fn(() => Promise.resolve(null)),
+  isInMaintenanceWindow: vi.fn(() => false),
+}));
+vi.mock('./eventBus', () => ({ publishEvent: (...args: unknown[]) => publishEvent(...args) }));
+vi.mock('./deviceSiteResolver', () => ({ resolveDeviceSiteId: vi.fn(() => Promise.resolve('site-1')) }));
+vi.mock('../jobs/alertCorrelation', () => ({ enqueueAlertCorrelation: vi.fn(() => Promise.resolve()) }));
+
+import { checkAutoResolve, checkAutoResolveFromConfigPolicy } from './alertService';
+
+const seed = (table: string, ...batches: unknown[][]) => selectQueues.set(table, batches);
+
+const cpAlert = (id: string) => ({
+  id,
+  orgId: 'org-1',
+  deviceId: 'device-1',
+  ruleId: null,
+  configPolicyId: 'cp-rule-1',
+  status: 'active',
+});
+
+const cpRule = {
+  id: 'cp-rule-1',
+  autoResolve: true,
+  autoResolveConditions: null,
+  conditions: { all: [] },
+  cooldownMinutes: 30,
+};
+
+beforeEach(() => {
+  selectQueues.clear();
+  updateReturns.length = 0;
+  updateCount.current = 0;
+  vi.clearAllMocks();
+  evaluateConditions.mockResolvedValue({ triggered: false });
+  evaluateAutoResolveConditions.mockResolvedValue({ shouldResolve: true, reason: 'cleared' });
+  markConfigPolicyRuleCooldown.mockResolvedValue(undefined);
+  setCooldown.mockResolvedValue(undefined);
+  publishEvent.mockResolvedValue('evt');
+});
+
+describe('checkAutoResolveFromConfigPolicy counts compare-and-swap winners only', () => {
+  it('does not count an alert another resolver already transitioned', async () => {
+    seed('alerts', [cpAlert('a-win'), cpAlert('a-lose')]);
+    // resolveAlert re-reads the policy rule on the winning path only.
+    seed('config_policy_alert_rules', [cpRule], [cpRule]);
+    updateReturns.push([cpAlert('a-win')]); // CAS matched: this sweep won
+    updateReturns.push([]);                 // CAS matched nothing: someone else won
+
+    await expect(checkAutoResolveFromConfigPolicy('device-1')).resolves.toBe(1);
+
+    // Both alerts were attempted — the count is filtered by the CAS outcome, not
+    // by skipping the attempt.
+    expect(updateCount.current).toBe(2);
+  });
+
+  it('publishes alert.resolved once per real transition, not once per attempt', async () => {
+    seed('alerts', [cpAlert('a-win'), cpAlert('a-lose')]);
+    seed('config_policy_alert_rules', [cpRule], [cpRule]);
+    updateReturns.push([cpAlert('a-win')]);
+    updateReturns.push([]);
+
+    await checkAutoResolveFromConfigPolicy('device-1');
+
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent.mock.calls[0]?.[0]).toBe('alert.resolved');
+  });
+
+  it('writes the config-policy cooldown exactly once for the winner and never for the loser', async () => {
+    seed('alerts', [cpAlert('a-win'), cpAlert('a-lose')]);
+    seed('config_policy_alert_rules', [cpRule], [cpRule]);
+    updateReturns.push([cpAlert('a-win')]);
+    updateReturns.push([]);
+
+    await checkAutoResolveFromConfigPolicy('device-1');
+
+    // One write, from inside resolveAlert's winning path. Two would mean the
+    // caller re-added its own duplicate; zero would mean the winner's cooldown
+    // was lost; any write attributable to `a-lose` suppresses a rule that this
+    // sweep never actually resolved.
+    expect(markConfigPolicyRuleCooldown).toHaveBeenCalledTimes(1);
+    expect(markConfigPolicyRuleCooldown).toHaveBeenCalledWith('cp-rule-1', 'device-1', 30);
+  });
+
+  it('counts every winner when nobody races the sweep', async () => {
+    seed('alerts', [cpAlert('a-1'), cpAlert('a-2')]);
+    seed('config_policy_alert_rules', [cpRule], [cpRule], [cpRule]);
+    updateReturns.push([cpAlert('a-1')]);
+    updateReturns.push([cpAlert('a-2')]);
+
+    await expect(checkAutoResolveFromConfigPolicy('device-1')).resolves.toBe(2);
+    expect(publishEvent).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('checkAutoResolve reports the compare-and-swap outcome', () => {
+  const legacyAlert = {
+    id: 'a-legacy',
+    orgId: 'org-1',
+    deviceId: 'device-1',
+    ruleId: 'rule-1',
+    configPolicyId: null,
+    status: 'active',
+  };
+  const rule = { id: 'rule-1', templateId: 'tpl-1', overrideSettings: null };
+  const template = { id: 'tpl-1', autoResolve: true, autoResolveConditions: null, conditions: { all: [] }, cooldownMinutes: 15 };
+
+  it('returns false when another resolver won the race', async () => {
+    seed('alerts', [legacyAlert]);
+    seed('alert_rules', [rule]);
+    seed('alert_templates', [template]);
+    updateReturns.push([]); // CAS matched nothing
+
+    await expect(checkAutoResolve('a-legacy')).resolves.toBe(false);
+    expect(publishEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns true when this caller performed the transition', async () => {
+    seed('alerts', [legacyAlert]);
+    seed('alert_rules', [rule], [rule]);
+    seed('alert_templates', [template], [template]);
+    updateReturns.push([legacyAlert]);
+
+    await expect(checkAutoResolve('a-legacy')).resolves.toBe(true);
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/alertService.resolveCasSql.test.ts
+++ b/apps/api/src/services/alertService.resolveCasSql.test.ts
@@ -1,6 +1,29 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PgDialect } from 'drizzle-orm/pg-core';
-import { buildResolveAlertCas, RESOLVABLE_ALERT_STATUSES } from './alertService';
+import type { SQL } from 'drizzle-orm';
+
+// Only the CONNECTION is mocked. drizzle-orm and ../db/schema stay REAL, so the
+// predicate `resolveAlert` hands to `.where()` is a real `SQL` object that can be
+// compiled — see the note on the `resolveAlert` block below for why that matters.
+const { updateWheres } = vi.hoisted(() => ({ updateWheres: [] as unknown[] }));
+
+vi.mock('../db', () => ({
+  db: {
+    update: () => ({
+      set: () => ({
+        where: (predicate: unknown) => {
+          updateWheres.push(predicate);
+          // Empty RETURNING = the CAS matched nothing, i.e. this caller lost.
+          // resolveAlert then returns early, so no redis/event-bus work runs and
+          // this file needs no further mocks.
+          return { returning: () => Promise.resolve([]) };
+        },
+      }),
+    }),
+  },
+}));
+
+import { buildResolveAlertCas, RESOLVABLE_ALERT_STATUSES, resolveAlert } from './alertService';
 
 /**
  * COMPILED-SQL assertions, deliberately in their own file so it can import the
@@ -34,5 +57,38 @@ describe('resolveAlert compare-and-swap predicate (compiled SQL)', () => {
     // either makes the CAS match an already-finished alert, i.e. no CAS at all.
     expect(RESOLVABLE_ALERT_STATUSES).not.toContain('resolved');
     expect(RESOLVABLE_ALERT_STATUSES).not.toContain('dismissed');
+  });
+});
+
+/**
+ * The two tests above compile the HELPER. Until #4094 that was one step removed
+ * from production: `resolveAlert` built its own copy of the same `and(...)` inline,
+ * so the helper and the shipped predicate could drift apart with this file staying
+ * green. These tests close that gap by compiling the predicate the function
+ * actually passes to `.where()`.
+ */
+describe('resolveAlert ships the compiled CAS, not a lookalike', () => {
+  const dialect = new PgDialect();
+
+  beforeEach(() => {
+    updateWheres.length = 0;
+  });
+
+  it('passes the exact compare-and-swap predicate to the UPDATE', async () => {
+    await resolveAlert('alert-9');
+
+    expect(updateWheres).toHaveLength(1);
+    const { sql, params } = dialect.sqlToQuery(updateWheres[0] as SQL);
+
+    expect(sql).toBe('("alerts"."id" = $1 and "alerts"."status" in ($2, $3, $4))');
+    expect(params).toEqual(['alert-9', 'active', 'acknowledged', 'suppressed']);
+  });
+
+  it('ships the same SQL the helper compiles to', async () => {
+    await resolveAlert('alert-9');
+
+    expect(dialect.sqlToQuery(updateWheres[0] as SQL)).toEqual(
+      dialect.sqlToQuery(buildResolveAlertCas('alert-9')!)
+    );
   });
 });

--- a/apps/api/src/services/alertService.ts
+++ b/apps/api/src/services/alertService.ts
@@ -233,18 +233,19 @@ export async function checkAutoResolve(alertId: string): Promise<boolean> {
     const triggerConditions = (overrides?.conditions as unknown) ?? template.conditions;
     const result = await evaluateConditions(triggerConditions, alert.deviceId);
 
-    // Auto-resolve if trigger conditions are NO LONGER met
+    // Auto-resolve if trigger conditions are NO LONGER met.
+    // Report what resolveAlert's compare-and-swap actually did: returning a bare
+    // `true` here made every caller that LOST the race look like a resolver, which
+    // is what inflates `checkAllAutoResolve`'s count (#4094).
     if (!result.triggered) {
-      await resolveAlert(alertId, 'Auto-resolved: conditions cleared');
-      return true;
+      return await resolveAlert(alertId, 'Auto-resolved: conditions cleared');
     }
   } else {
     // Evaluate specific auto-resolve conditions
     const result = await evaluateAutoResolveConditions(autoResolveConditions, alert.deviceId);
 
     if (result.shouldResolve) {
-      await resolveAlert(alertId, `Auto-resolved: ${result.reason}`);
-      return true;
+      return await resolveAlert(alertId, `Auto-resolved: ${result.reason}`);
     }
   }
 
@@ -264,7 +265,14 @@ export async function checkAutoResolve(alertId: string): Promise<boolean> {
  */
 export const RESOLVABLE_ALERT_STATUSES = ['active', 'acknowledged', 'suppressed'] as const;
 
-/** The compare-and-swap predicate for `resolveAlert`. See the note above. */
+/**
+ * The compare-and-swap predicate for resolving one alert. See the note above.
+ *
+ * This is the SINGLE definition of "this alert is still resolvable", shared by
+ * `resolveAlert` and by every route/tool that stamps an alert resolved on its own
+ * pipeline (#4094). Building a second copy inline is how the predicate and its
+ * compiled-SQL test drifted apart once already.
+ */
 export function buildResolveAlertCas(alertId: string) {
   return and(
     eq(alerts.id, alertId),
@@ -299,10 +307,7 @@ export async function resolveAlert(
       resolvedBy: resolvedBy ?? null,
       resolutionNote: resolutionNote ?? null
     })
-    .where(and(
-      eq(alerts.id, alertId),
-      inArray(alerts.status, ['active', 'acknowledged', 'suppressed'])
-    ))
+    .where(buildResolveAlertCas(alertId))
     .returning();
 
   // Already resolved by someone else (or gone). Not an error — just not ours.
@@ -808,6 +813,15 @@ export async function checkAutoResolveFromConfigPolicy(deviceId: string): Promis
 
   let resolvedCount = 0;
 
+  // Both branches below count — and previously also wrote the config-policy
+  // cooldown — only on `resolveAlert`'s compare-and-swap WINNER (#4094). Doing it
+  // unconditionally meant a caller that lost the race to the monitor worker or a
+  // policy.compliant redelivery still reported a resolution it did not perform and
+  // still stamped a cooldown, suppressing the next legitimate alert for that rule.
+  // The explicit cooldown write is gone rather than merely gated: on the winning
+  // path `resolveAlert` already calls `markConfigPolicyRuleCooldown` with the same
+  // rule id, device and `cooldownMinutes` (see its config-policy branch), so it was
+  // a duplicate of a write the winner performs anyway.
   for (const alert of activeAlerts) {
     try {
       const rule = ruleMap.get(alert.configPolicyId!);
@@ -827,18 +841,14 @@ export async function checkAutoResolveFromConfigPolicy(deviceId: string): Promis
           alert.deviceId
         );
 
-        if (result.shouldResolve) {
-          await resolveAlert(alert.id, `Auto-resolved: ${result.reason}`);
-          await markConfigPolicyRuleCooldown(rule.id, alert.deviceId, rule.cooldownMinutes);
+        if (result.shouldResolve && await resolveAlert(alert.id, `Auto-resolved: ${result.reason}`)) {
           resolvedCount++;
         }
       } else {
         // No specific auto-resolve conditions; use inverse of trigger conditions
         const result = await evaluateConditions(rule.conditions, alert.deviceId);
 
-        if (!result.triggered) {
-          await resolveAlert(alert.id, 'Auto-resolved: conditions cleared');
-          await markConfigPolicyRuleCooldown(rule.id, alert.deviceId, rule.cooldownMinutes);
+        if (!result.triggered && await resolveAlert(alert.id, 'Auto-resolved: conditions cleared')) {
           resolvedCount++;
         }
       }

--- a/apps/api/src/services/alertService.ts
+++ b/apps/api/src/services/alertService.ts
@@ -266,12 +266,32 @@ export async function checkAutoResolve(alertId: string): Promise<boolean> {
 export const RESOLVABLE_ALERT_STATUSES = ['active', 'acknowledged', 'suppressed'] as const;
 
 /**
- * The compare-and-swap predicate for resolving one alert. See the note above.
+ * What a resolve path reports when it LOSES the compare-and-swap.
  *
- * This is the SINGLE definition of "this alert is still resolvable", shared by
- * `resolveAlert` and by every route/tool that stamps an alert resolved on its own
- * pipeline (#4094). Building a second copy inline is how the predicate and its
- * compiled-SQL test drifted apart once already.
+ * Deliberately states only what the code can verify — that the row is no longer in
+ * a resolvable status. It does NOT claim "another request resolved it": an empty
+ * `RETURNING` is also what an RLS-invisible write produces, and naming the benign
+ * cause in user-visible text forecloses the one hypothesis worth chasing when the
+ * cause is not benign.
+ */
+export const ALERT_CAS_LOST_MESSAGE =
+  'Alert is no longer resolvable — it already reached a terminal status (resolved or dismissed).';
+
+/**
+ * The compare-and-swap predicate for resolving ONE alert by id. See the note above.
+ *
+ * This is the single definition of "this alert is still resolvable" for every
+ * single-alert resolve path (#4094): `resolveAlert`, both HTTP resolve routes, the
+ * `manage_alerts` AI tool, and the warranty auto-resolve sweep. Building a second
+ * copy inline is how the predicate and its compiled-SQL test drifted apart once
+ * already.
+ *
+ * Two paths deliberately do NOT use this builder because they write many rows at
+ * once and need `inArray(alerts.id, ...)` rather than an id equality — they compose
+ * `RESOLVABLE_ALERT_STATUSES` directly instead:
+ *   - the correlation-group resolve (`routes/alerts/correlations.ts`);
+ *   - the bulk alert action (`routes/alerts/alerts.ts`), which is stricter still —
+ *     it pins each row to the exact status its snapshot saw.
  */
 export function buildResolveAlertCas(alertId: string) {
   return and(

--- a/apps/api/src/services/policyAlertBridge.ts
+++ b/apps/api/src/services/policyAlertBridge.ts
@@ -1,7 +1,7 @@
 import { and, eq, inArray } from 'drizzle-orm';
 import * as dbModule from '../db';
 import { alerts, alertRules, alertTemplates, automationPolicies, organizations } from '../db/schema';
-import { createAlert, resolveAlert } from './alertService';
+import { createAlert, resolveAlert, RESOLVABLE_ALERT_STATUSES } from './alertService';
 import { getEventBus } from './eventBus';
 
 const { db } = dbModule;
@@ -132,7 +132,7 @@ async function resolvePolicyAlertsForDevice(ruleId: string, deviceId: string): P
       and(
         eq(alerts.ruleId, ruleId),
         eq(alerts.deviceId, deviceId),
-        inArray(alerts.status, ['active', 'acknowledged', 'suppressed'])
+        inArray(alerts.status, [...RESOLVABLE_ALERT_STATUSES])
       )
     );
 

--- a/apps/api/src/services/warrantyAlertEvaluator.resolveCas.test.ts
+++ b/apps/api/src/services/warrantyAlertEvaluator.resolveCas.test.ts
@@ -20,9 +20,10 @@ import type { SQL } from 'drizzle-orm';
  *  - BEHAVIOUR — of two open warranty alerts on the same device, the second
  *    losing its CAS (empty `RETURNING`) must not add a second `publishEvent`
  *    call — exactly one per real transition, matching the winner.
- *  - COMPILED SQL — same predicate shape as the other three CAS sites; a mocked-
+ *  - COMPILED SQL — same predicate shape as the other four single-alert CAS sites; a mocked-
  *    drizzle substring match on column names cannot distinguish `and` from `or`
- *    or catch a terminal status being admitted into the list (main 8763a3239).
+ *    or catch a terminal status being admitted into the list (the wave-3825
+ *    test-hardening pass, `8763a3239`, which is not on main).
  */
 const { dbMock, selectQueues, updateWheres, updateReturns } = vi.hoisted(() => {
   const selectQueues = new Map<string, unknown[][]>();
@@ -90,12 +91,15 @@ const openAlert = (id: string, status: 'active' | 'acknowledged' | 'suppressed' 
   suppressedUntil: null as Date | null,
 });
 
+const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
 beforeEach(() => {
   selectQueues.clear();
   updateWheres.length = 0;
   updateReturns.length = 0;
   vi.clearAllMocks();
   publishEvent.mockResolvedValue('evt');
+  warnSpy.mockImplementation(() => {});
 });
 
 // Drive autoResolveWarrantyAlerts via evaluateWarrantyAlerts' "warranty now
@@ -130,6 +134,51 @@ describe('autoResolveWarrantyAlerts — mixed CAS outcome across two open alerts
     expect(updateWheres).toHaveLength(2); // both alerts were attempted...
     expect(publishEvent).toHaveBeenCalledTimes(1); // ...but only the winner fanned out
     expect(publishEvent.mock.calls[0]?.[2]).toMatchObject({ alertId: 'alert-win' });
+  });
+
+  it('keeps sweeping after a loss instead of abandoning the rest of the batch', async () => {
+    // The loser is FIRST here on purpose. With it last, `continue` and `return`
+    // are indistinguishable — the sweep is over either way — so a `return` typo
+    // would leave every later alert in the batch silently unresolved with the
+    // suite still green.
+    seed('alerts', [openAlert('alert-lose'), openAlert('alert-win-a'), openAlert('alert-win-b')]);
+    updateReturns.push([]);
+    updateReturns.push([{ id: 'alert-win-a' }]);
+    updateReturns.push([{ id: 'alert-win-b' }]);
+
+    await runAutoResolveSweep();
+
+    expect(updateWheres).toHaveLength(3);
+    expect(publishEvent).toHaveBeenCalledTimes(2);
+    expect(publishEvent.mock.calls.map((call) => (call[2] as { alertId: string }).alertId))
+      .toEqual(['alert-win-a', 'alert-win-b']);
+  });
+
+  it('warns once when the sweep transitions none of its candidates', async () => {
+    // Every CAS missing is the shape an RLS write-policy divergence takes, and
+    // under breeze_app such a write raises no error at all — so a total shortfall
+    // must leave a trace, while ordinary single losses stay silent.
+    seed('alerts', [openAlert('alert-1'), openAlert('alert-2')]);
+    updateReturns.push([]);
+    updateReturns.push([]);
+
+    await runAutoResolveSweep();
+
+    expect(publishEvent).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain('transitioned 0 of 2');
+  });
+
+  it('stays silent when at least one candidate really transitioned', async () => {
+    seed('alerts', [openAlert('alert-win'), openAlert('alert-lose')]);
+    updateReturns.push([{ id: 'alert-win' }]);
+    updateReturns.push([]);
+
+    await runAutoResolveSweep();
+
+    // A losing race is expected under load; warning on it would be the noise this
+    // aggregate check exists to avoid.
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/warrantyAlertEvaluator.resolveCas.test.ts
+++ b/apps/api/src/services/warrantyAlertEvaluator.resolveCas.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+/**
+ * `autoResolveWarrantyAlerts`'s per-alert UPDATE is a compare-and-swap (#4094).
+ * It used to update by id alone: a warranty sweep racing a technician's manual
+ * resolve (or a second sweep on the same device) could both "win" and both
+ * publish `alert.resolved` for the same alert.
+ *
+ * Only the CONNECTION is mocked here — drizzle-orm and ../db/schema are real
+ * (unlike the sibling `warrantyAlertEvaluator.test.ts`, which mocks
+ * `../db/schema` with fake string column stand-ins; that file cannot compile a
+ * real predicate, which is exactly why this one exists as a separate suite),
+ * so the predicate `autoResolveWarrantyAlerts` hands `.where()` is a real `SQL`
+ * object that can be compiled through `PgDialect`.
+ *
+ * Two kinds of assertion, deliberately:
+ *
+ *  - BEHAVIOUR — of two open warranty alerts on the same device, the second
+ *    losing its CAS (empty `RETURNING`) must not add a second `publishEvent`
+ *    call — exactly one per real transition, matching the winner.
+ *  - COMPILED SQL — same predicate shape as the other three CAS sites; a mocked-
+ *    drizzle substring match on column names cannot distinguish `and` from `or`
+ *    or catch a terminal status being admitted into the list (main 8763a3239).
+ */
+const { dbMock, selectQueues, updateWheres, updateReturns } = vi.hoisted(() => {
+  const selectQueues = new Map<string, unknown[][]>();
+  const updateWheres: unknown[] = [];
+  const updateReturns: unknown[][] = [];
+
+  // Table-keyed select queue, same technique as
+  // alertService.autoResolveOutcome.test.ts: seeds are per real Drizzle table
+  // (resolved via its Name symbol), not per call order.
+  const tableName = (table: unknown): string => {
+    const symbols = Object.getOwnPropertySymbols(table as object);
+    for (const symbol of symbols) {
+      if (symbol.description?.includes('Name')) {
+        const value = (table as Record<symbol, unknown>)[symbol];
+        if (typeof value === 'string') return value;
+      }
+    }
+    return 'unknown';
+  };
+  const take = (table: unknown): unknown[] => selectQueues.get(tableName(table))?.shift() ?? [];
+
+  const dbMock = {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => {
+          const rows = take(table);
+          return {
+            limit: () => Promise.resolve(rows),
+            then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
+              Promise.resolve(rows).then(resolve, reject),
+          };
+        },
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: (predicate: unknown) => {
+          updateWheres.push(predicate);
+          return { returning: () => Promise.resolve(updateReturns.shift() ?? []) };
+        },
+      }),
+    }),
+  };
+
+  return { dbMock, selectQueues, updateWheres, updateReturns };
+});
+
+const publishEvent = vi.fn((..._args: unknown[]) => Promise.resolve('evt'));
+
+vi.mock('../db', () => ({ db: dbMock }));
+vi.mock('./eventBus', () => ({ publishEvent: (...a: unknown[]) => publishEvent(...a) }));
+
+import { evaluateWarrantyAlerts } from './warrantyAlertEvaluator';
+
+const DEVICE_ID = '66666666-6666-4666-8666-666666666666';
+const ORG_ID = 'org-1';
+
+const seed = (table: string, ...batches: unknown[][]) => selectQueues.set(table, batches);
+
+const openAlert = (id: string, status: 'active' | 'acknowledged' | 'suppressed' = 'active') => ({
+  id,
+  orgId: ORG_ID,
+  deviceId: DEVICE_ID,
+  status,
+  suppressedUntil: null as Date | null,
+});
+
+beforeEach(() => {
+  selectQueues.clear();
+  updateWheres.length = 0;
+  updateReturns.length = 0;
+  vi.clearAllMocks();
+  publishEvent.mockResolvedValue('evt');
+});
+
+// Drive autoResolveWarrantyAlerts via evaluateWarrantyAlerts' "warranty now
+// resolves to disabled" path (settings.enabled === false): the shortest route
+// that reaches the auto-resolve loop without needing to fabricate a full
+// non-expiring-warranty scenario.
+function runAutoResolveSweep() {
+  seed('device_warranty', [{
+    deviceId: DEVICE_ID,
+    orgId: ORG_ID,
+    manufacturer: 'apple',
+    serialNumber: 'ABC123',
+    status: 'expiring',
+    warrantyEndDate: '2099-01-01',
+    isSubscription: false,
+  }]);
+  seed('devices', [{ id: DEVICE_ID, orgId: ORG_ID, siteId: null, displayName: 'Test Mac', hostname: 'test-mac', isEphemeral: false }]);
+  seed('devices', [{ orgId: ORG_ID, siteId: null }]); // resolveWarrantySettings' device lookup
+  seed('device_group_memberships', []); // no group memberships
+  seed('config_policy_feature_links', []); // no warranty policy assigned -> DISABLED_SETTINGS
+  return evaluateWarrantyAlerts(DEVICE_ID);
+}
+
+describe('autoResolveWarrantyAlerts — mixed CAS outcome across two open alerts', () => {
+  it('publishes alert.resolved once per real transition, not once per open alert', async () => {
+    seed('alerts', [openAlert('alert-win'), openAlert('alert-lose')]);
+    updateReturns.push([{ id: 'alert-win' }]); // first UPDATE: CAS matched, this sweep won
+    updateReturns.push([]);                    // second UPDATE: CAS matched nothing, lost the race
+
+    await runAutoResolveSweep();
+
+    expect(updateWheres).toHaveLength(2); // both alerts were attempted...
+    expect(publishEvent).toHaveBeenCalledTimes(1); // ...but only the winner fanned out
+    expect(publishEvent.mock.calls[0]?.[2]).toMatchObject({ alertId: 'alert-win' });
+  });
+});
+
+describe('autoResolveWarrantyAlerts — the shipped predicate (compiled SQL)', () => {
+  it('scopes each UPDATE by id AND resolvable status', async () => {
+    seed('alerts', [openAlert('alert-1')]);
+    updateReturns.push([{ id: 'alert-1' }]);
+
+    await runAutoResolveSweep();
+
+    expect(updateWheres).toHaveLength(1);
+    const dialect = new PgDialect();
+    const { sql, params } = dialect.sqlToQuery(updateWheres[0] as SQL);
+
+    // `or` instead of `and` would stamp every active/acknowledged/suppressed alert
+    // in EVERY tenant from one sweep; dropping the status list makes the write
+    // unconditional again; admitting 'resolved' or 'dismissed' makes the CAS a
+    // no-op. Each of those changes this string or its params.
+    expect(sql).toBe('("alerts"."id" = $1 and "alerts"."status" in ($2, $3, $4))');
+    expect(params).toEqual(['alert-1', 'active', 'acknowledged', 'suppressed']);
+  });
+});

--- a/apps/api/src/services/warrantyAlertEvaluator.test.ts
+++ b/apps/api/src/services/warrantyAlertEvaluator.test.ts
@@ -81,9 +81,24 @@ function captureInsert() {
   return { values, returning };
 }
 
+/**
+ * The auto-resolve UPDATE is a compare-and-swap since #4094: it chains
+ * `.returning({id})` and skips the `alert.resolved` publish when the result is
+ * empty. `where(...)` must therefore still be awaitable (nothing else in this file
+ * chains past it) AND expose `returning`.
+ *
+ * Defaults to a one-row winner so the existing auto-resolve assertions keep
+ * asserting a publish; pass `[]` to model losing the race to another resolver.
+ */
+function casWhere(returning: unknown[] = [{ id: 'alert-1' }]) {
+  return Object.assign(Promise.resolve(undefined), {
+    returning: vi.fn().mockResolvedValue(returning),
+  });
+}
+
 function stubAutoResolve() {
   // autoResolveWarrantyAlerts: select open alerts (resolves to []), then nothing to update.
-  const set = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+  const set = vi.fn().mockReturnValue({ where: vi.fn(() => casWhere()) });
   updateMock.mockReturnValue({ set });
   return set;
 }
@@ -193,7 +208,7 @@ describe('evaluateWarrantyAlerts gating', () => {
     // created under the old enabled-by-default behavior must have it auto-resolved
     // once it resolves to disabled — otherwise the gate at `if (!settings.enabled)`
     // returns BEFORE the cleanup and the alert is stranded active forever.
-    const set = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    const set = vi.fn().mockReturnValue({ where: vi.fn(() => casWhere()) });
     updateMock.mockReturnValue({ set });
 
     // 1: warranty row (expiring, fixed-term) → reaches policy resolution
@@ -261,7 +276,7 @@ describe('evaluateWarrantyAlerts gating', () => {
   });
 
   it('auto-resolves a stale TIMED-SUPPRESSED expiry alert when the device is now a subscription (#1320)', async () => {
-    const set = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    const set = vi.fn().mockReturnValue({ where: vi.fn(() => casWhere()) });
     updateMock.mockReturnValue({ set });
 
     // 1: warranty row flagged as a subscription → short-circuits to autoResolve

--- a/apps/api/src/services/warrantyAlertEvaluator.ts
+++ b/apps/api/src/services/warrantyAlertEvaluator.ts
@@ -16,6 +16,7 @@ import {
   deviceGroupMemberships,
 } from '../db/schema';
 import { eq, and, inArray, isNotNull, or, sql } from 'drizzle-orm';
+import { buildResolveAlertCas } from './alertService';
 import { publishEvent } from './eventBus';
 
 interface WarrantyAlertSettings {
@@ -327,14 +328,21 @@ async function autoResolveWarrantyAlerts(deviceId: string): Promise<void> {
     );
 
   for (const alert of openAlerts) {
-    await db
+    // Winner-takes-all (#4094): the status predicate, not the read above, decides
+    // whether this evaluator performed the transition. Updating by id alone let a
+    // technician's resolve and this sweep both publish `alert.resolved` for one
+    // real transition.
+    const written = await db
       .update(alerts)
       .set({
         status: 'resolved',
         resolvedAt: new Date(),
         resolutionNote: 'Auto-resolved: warranty no longer expiring within threshold',
       })
-      .where(eq(alerts.id, alert.id));
+      .where(buildResolveAlertCas(alert.id))
+      .returning({ id: alerts.id });
+
+    if (written.length === 0) continue;
 
     await publishEvent(
       'alert.resolved',

--- a/apps/api/src/services/warrantyAlertEvaluator.ts
+++ b/apps/api/src/services/warrantyAlertEvaluator.ts
@@ -327,6 +327,8 @@ async function autoResolveWarrantyAlerts(deviceId: string): Promise<void> {
       )
     );
 
+  let lost = 0;
+
   for (const alert of openAlerts) {
     // Winner-takes-all (#4094): the status predicate, not the read above, decides
     // whether this evaluator performed the transition. Updating by id alone let a
@@ -342,7 +344,10 @@ async function autoResolveWarrantyAlerts(deviceId: string): Promise<void> {
       .where(buildResolveAlertCas(alert.id))
       .returning({ id: alerts.id });
 
-    if (written.length === 0) continue;
+    if (written.length === 0) {
+      lost += 1;
+      continue;
+    }
 
     await publishEvent(
       'alert.resolved',
@@ -353,6 +358,20 @@ async function autoResolveWarrantyAlerts(deviceId: string): Promise<void> {
         resolutionNote: 'Auto-resolved: warranty no longer expiring within threshold',
       },
       'warranty-alert-evaluator'
+    );
+  }
+
+  // Losing an individual CAS is normal — a technician got there first — so this
+  // deliberately does NOT log per loss. Losing EVERY candidate is different: this
+  // sweep is the only routine resolver of warranty_expiry alerts, so a total
+  // shortfall is the shape an RLS write-policy divergence would take, and under
+  // `breeze_app` such a write raises no error at all. One aggregate line per
+  // invocation gives that failure somewhere to show up instead of looking
+  // identical to "nothing needed resolving".
+  if (lost > 0 && lost === openAlerts.length) {
+    console.warn(
+      `[WarrantyAlertEvaluator] auto-resolve transitioned 0 of ${openAlerts.length} open ` +
+      `warranty alert(s) for device ${deviceId}; every compare-and-swap matched no rows.`
     );
   }
 }

--- a/apps/web/src/components/alerts/AlertDetailPage.resolveConflict.test.tsx
+++ b/apps/web/src/components/alerts/AlertDetailPage.resolveConflict.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '../../lib/i18n';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Losing the resolve compare-and-swap is a 409, not a broken page (#4094).
+ *
+ * The API's single-alert resolve is now winner-takes-all: when another technician
+ * (or the auto-resolve sweep) transitions the alert first, this request gets a 409
+ * and the server publishes nothing on its behalf. `runAction` already toasts the
+ * server's reason for that. What must NOT happen is the page additionally latching
+ * its persistent red error banner — the alert IS resolved, so framing the race as a
+ * page failure is wrong, and it leaves the header showing a stale open status until
+ * the user reloads by hand.
+ */
+vi.mock('../remediation/RemediationSuggestionsPanel', () => ({ default: () => null }));
+
+const fetchWithAuth = vi.fn();
+const showToast = vi.fn();
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args),
+}));
+vi.mock('../shared/Toast', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, showToast: (...args: unknown[]) => showToast(...args) };
+});
+
+import AlertDetailPage from './AlertDetailPage';
+
+const ALERT_ID = 'a-cas-1';
+
+const openAlert = {
+  id: ALERT_ID,
+  title: 'CPU high',
+  message: 'CPU over 90%',
+  severity: 'critical',
+  status: 'active',
+  deviceId: 'd-1',
+  deviceName: 'web-01',
+  triggeredAt: '2026-08-24T16:00:00Z',
+};
+
+const resolvedAlert = { ...openAlert, status: 'resolved', resolvedAt: '2026-08-24T18:00:00Z' };
+
+/**
+ * First GET returns the alert as open (so the Resolve button renders); the POST
+ * answers 409; the GET that follows returns it resolved — exactly the sequence a
+ * technician sees when someone beats them to it.
+ */
+function mockRaceLostThenRefetch() {
+  let alertReads = 0;
+  fetchWithAuth.mockImplementation((url: string, init?: { method?: string }) => {
+    if (url.endsWith('/tickets')) {
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ data: [] }) });
+    }
+    if (init?.method === 'POST' && url.endsWith('/resolve')) {
+      return Promise.resolve({
+        ok: false,
+        status: 409,
+        json: () => Promise.resolve({ error: 'Alert was already resolved or dismissed by another request' }),
+      });
+    }
+    alertReads += 1;
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(alertReads === 1 ? openAlert : resolvedAlert),
+    });
+  });
+}
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+  showToast.mockReset();
+});
+
+describe('AlertDetailPage — losing the resolve race', () => {
+  it('re-fetches the alert instead of latching the error banner', async () => {
+    mockRaceLostThenRefetch();
+    render(<AlertDetailPage alertId={ALERT_ID} />);
+
+    const resolveButton = await screen.findByRole('button', { name: /resolve/i });
+    await userEvent.click(resolveButton);
+
+    await waitFor(() => {
+      // Two reads: the mount read plus the post-409 refresh. Only one would mean
+      // the page kept rendering a status the server no longer agrees with.
+      const alertReads = fetchWithAuth.mock.calls.filter(
+        ([url, init]) => typeof url === 'string' && url.includes(ALERT_ID)
+          && !url.endsWith('/tickets') && (init as { method?: string } | undefined)?.method !== 'POST'
+      );
+      expect(alertReads.length).toBeGreaterThanOrEqual(2);
+    });
+
+    // The banner text is the raw thrown message; asserting on the server sentence
+    // covers both the `setError(err.message)` path and any re-wording of it.
+    await waitFor(() => {
+      expect(screen.queryByText(/already resolved or dismissed/i)).toBeNull();
+    });
+  });
+
+  it('surfaces the failure to the user rather than swallowing it', async () => {
+    mockRaceLostThenRefetch();
+    render(<AlertDetailPage alertId={ALERT_ID} />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /resolve/i }));
+
+    // Suppressing the banner must not become suppressing the FEEDBACK — a resolve
+    // that silently does nothing is the failure mode `runAction` exists to prevent.
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error' })
+      );
+    });
+  });
+});

--- a/apps/web/src/components/alerts/AlertDetailPage.resolveConflict.test.tsx
+++ b/apps/web/src/components/alerts/AlertDetailPage.resolveConflict.test.tsx
@@ -71,6 +71,32 @@ function mockRaceLostThenRefetch() {
   });
 }
 
+/**
+ * The POST answers a plain 500 — the resolve genuinely failed server-side, the
+ * alert is still open, and there is nothing fresher to fetch.
+ */
+function mockPlainServerError() {
+  fetchWithAuth.mockImplementation((url: string, init?: { method?: string }) => {
+    if (url.endsWith('/tickets')) {
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ data: [] }) });
+    }
+    if (init?.method === 'POST' && url.endsWith('/resolve')) {
+      return Promise.resolve({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'resolve blew up server-side' }),
+      });
+    }
+    return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(openAlert) });
+  });
+}
+
+const countAlertReads = () =>
+  fetchWithAuth.mock.calls.filter(
+    ([url, init]) => typeof url === 'string' && url.includes(ALERT_ID)
+      && !url.endsWith('/tickets') && (init as { method?: string } | undefined)?.method !== 'POST'
+  ).length;
+
 beforeEach(() => {
   fetchWithAuth.mockReset();
   showToast.mockReset();
@@ -87,11 +113,7 @@ describe('AlertDetailPage — losing the resolve race', () => {
     await waitFor(() => {
       // Two reads: the mount read plus the post-409 refresh. Only one would mean
       // the page kept rendering a status the server no longer agrees with.
-      const alertReads = fetchWithAuth.mock.calls.filter(
-        ([url, init]) => typeof url === 'string' && url.includes(ALERT_ID)
-          && !url.endsWith('/tickets') && (init as { method?: string } | undefined)?.method !== 'POST'
-      );
-      expect(alertReads.length).toBeGreaterThanOrEqual(2);
+      expect(countAlertReads()).toBeGreaterThanOrEqual(2);
     });
 
     // The banner text is the raw thrown message; asserting on the server sentence
@@ -114,5 +136,20 @@ describe('AlertDetailPage — losing the resolve race', () => {
         expect.objectContaining({ type: 'error' })
       );
     });
+  });
+
+  it('a plain 500 does NOT take the refetch/suppress path — the branch keys on the 409 status, not "any error"', async () => {
+    mockPlainServerError();
+    render(<AlertDetailPage alertId={ALERT_ID} />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /resolve/i }));
+
+    // A 500 means the alert was NOT resolved, so the persistent banner is the
+    // CORRECT outcome here — widening the `err.status === 409` guard to any
+    // ActionError would silently refetch instead and this banner would vanish.
+    expect(await screen.findByText(/resolve blew up server-side/i)).toBeInTheDocument();
+
+    // ...and there is nothing fresher to fetch: exactly the mount-time read.
+    expect(countAlertReads()).toBe(1);
   });
 });

--- a/apps/web/src/components/alerts/AlertDetailPage.tsx
+++ b/apps/web/src/components/alerts/AlertDetailPage.tsx
@@ -184,6 +184,15 @@ export default function AlertDetailPage({ alertId }: AlertDetailPageProps) {
       await fetchAlert();
     } catch (err) {
       handleActionError(err, t('alertDetailPage.failedToResolveAlert'));
+      // 409 = another technician (or the auto-resolve sweep) won the
+      // compare-and-swap; the alert IS resolved, this request just didn't do it
+      // (#4094). runAction already toasted the server's reason, so a persistent
+      // red banner on top of it would frame a benign race as a broken page.
+      // Re-fetch instead, so the header shows the resolved state.
+      if (err instanceof ActionError && err.status === 409) {
+        await fetchAlert();
+        return;
+      }
       if (!(err instanceof ActionError && err.status === 401)) {
         setError(err instanceof Error ? err.message : t('alertDetailPage.failedToResolveAlert'));
       }

--- a/apps/web/src/components/alerts/AlertDetailPage.tsx
+++ b/apps/web/src/components/alerts/AlertDetailPage.tsx
@@ -190,7 +190,12 @@ export default function AlertDetailPage({ alertId }: AlertDetailPageProps) {
       // red banner on top of it would frame a benign race as a broken page.
       // Re-fetch instead, so the header shows the resolved state.
       if (err instanceof ActionError && err.status === 409) {
-        await fetchAlert();
+        // `fetchAlert` sets its own error state on failure, but a rejection here
+        // would escape this catch entirely (nothing wraps the recovery path) and
+        // become an unhandled rejection with no feedback for the second failure.
+        await fetchAlert().catch(() => {
+          setError(t('alertDetailPage.failedToFetchAlert'));
+        });
         return;
       }
       if (!(err instanceof ActionError && err.status === 401)) {

--- a/apps/web/src/components/alerts/AlertsPage.resolveConflict.test.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.resolveConflict.test.tsx
@@ -1,0 +1,163 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AlertsPage from './AlertsPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+/**
+ * Losing the resolve compare-and-swap from AlertsPage's detail panel (#4094).
+ *
+ * The API's single-alert resolve is winner-takes-all: when another technician
+ * (or the auto-resolve sweep) transitions the alert first, this request gets a
+ * 409 and the server publishes nothing on its behalf. `runAction` already
+ * toasts the server's reason for that before `handleResolve`'s catch even runs.
+ * What the catch's `err.status === 409` branch (AlertsPage.tsx ~288-302) adds on
+ * top is: close the now-stale detail panel and refetch the list, so the row
+ * stops offering Resolve on an alert that is already finished. A plain 500 must
+ * NOT take that extra refetch/close path — the alert is not actually resolved,
+ * so there is nothing to refresh.
+ *
+ * Reuses the mocking approach from the sibling AlertsPage.test.tsx and the
+ * narrative style of AlertDetailPage.resolveConflict.test.tsx.
+ */
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+// The device filter bar issues its own fetches; stub it out so the page's
+// alert/device fetches are the only traffic under test.
+vi.mock('../filters/DeviceFilterBar', () => ({
+  DeviceFilterBar: () => null
+}));
+
+// Pin the org-scope selector so the page doesn't try to read a real store.
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (selector: (s: { orgScope: string; currentOrgId: string | null }) => unknown) =>
+    selector({ orgScope: 'current', currentOrgId: 'org-1' })
+}));
+
+// AlertDetails renders this panel, which fires its own remediation-suggestions
+// fetch. Stub it so that traffic doesn't have to be mocked here — the resolve
+// flow doesn't depend on it (mirrors AlertDetailPage.resolveConflict.test.tsx).
+vi.mock('../remediation/RemediationSuggestionsPanel', () => ({ default: () => null }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const ALERT_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload)
+  }) as unknown as Response;
+
+const activeAlert = {
+  id: ALERT_ID,
+  title: 'High CPU on SRV-01',
+  message: 'CPU above 95% for 5 minutes',
+  severity: 'critical',
+  status: 'active',
+  deviceId: 'device-1',
+  deviceName: 'SRV-01',
+  triggeredAt: new Date().toISOString()
+};
+
+/**
+ * The row's Resolve button does NOT call handleResolve directly — AlertsPage
+ * wires the row's onResolve to `setSelectedAlert; setDetailOpen(true)` (see
+ * AlertsPage.tsx ~617), and it's AlertDetails' own two-step confirm (Resolve ->
+ * reveal note form -> Resolve Alert) that invokes the real onResolve prop,
+ * i.e. the real handleResolve under test here.
+ */
+async function openDetailAndSubmitResolve() {
+  fireEvent.click(await screen.findByRole('button', { name: /Resolve: High CPU on SRV-01/i }));
+  const dialog = await screen.findByRole('dialog');
+  fireEvent.click(within(dialog).getByRole('button', { name: /^Resolve$/i }));
+  fireEvent.click(await within(dialog).findByRole('button', { name: /^Resolve Alert$/i }));
+  return dialog;
+}
+
+/** Mocks the list/device/resolve traffic and returns a getter for how many
+ *  times the alert LIST endpoint (not the single-alert resolve POST) was hit,
+ *  so tests can assert on the extra post-409 refetch precisely. */
+function mockAlerts(resolveResponse: () => Promise<Response>) {
+  let listCalls = 0;
+  fetchMock.mockImplementation((input, init) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    if (url.startsWith('/alerts?') && method === 'GET') {
+      listCalls += 1;
+      return Promise.resolve(makeJsonResponse({ data: [activeAlert] }));
+    }
+    if (url === '/devices' && method === 'GET') {
+      return Promise.resolve(makeJsonResponse({ data: [] }));
+    }
+    if (url === `/alerts/${ALERT_ID}/resolve` && method === 'POST') {
+      return resolveResponse();
+    }
+    return Promise.resolve(makeJsonResponse({ error: 'unexpected' }, false, 404));
+  });
+  return () => listCalls;
+}
+
+describe('AlertsPage — resolve compare-and-swap (#4094)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refetches the list and closes the panel, while still toasting an error, when resolve loses the race (409)', async () => {
+    const getListCalls = mockAlerts(() =>
+      Promise.resolve(
+        makeJsonResponse({ error: 'Alert was already resolved or dismissed by another request' }, false, 409)
+      )
+    );
+
+    render(<AlertsPage />);
+    await openDetailAndSubmitResolve();
+
+    // runAction toasts the server's 409 reason before handleResolve's catch even
+    // runs — suppressing the stale-status banner must not become suppressing
+    // this feedback. This alone doesn't need the `err.status === 409` block (it
+    // would pass even if that block were deleted); it's the guard for the
+    // refetch/close assertions below.
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+
+    // Mutation target: deleting the `if (err.status === 409) { handleCloseDetail();
+    // fetchAlerts(); }` block leaves exactly ONE list call (the initial mount
+    // fetch) and the dialog still open — this assertion catches that.
+    await waitFor(() => {
+      expect(getListCalls()).toBeGreaterThanOrEqual(2); // mount fetch + post-409 refetch
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does NOT trigger the extra refetch/close on a plain 500 (the branch keys on the 409 status, not "any error")', async () => {
+    const getListCalls = mockAlerts(() => Promise.resolve(makeJsonResponse({ error: 'boom' }, false, 500)));
+
+    render(<AlertsPage />);
+    await openDetailAndSubmitResolve();
+
+    // Still gets an error toast — runAction toasts every non-401 ActionError
+    // regardless of status. What must differ from the 409 case is everything
+    // after that: a 500 means the alert was NOT actually resolved, so there is
+    // nothing to refresh or close for.
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    expect(getListCalls()).toBe(1); // only the mount-time list fetch
+    expect(screen.getByRole('dialog')).toBeInTheDocument(); // panel stays open
+  });
+});

--- a/apps/web/src/components/alerts/AlertsPage.tsx
+++ b/apps/web/src/components/alerts/AlertsPage.tsx
@@ -288,6 +288,16 @@ export default function AlertsPage() {
     } catch (err) {
       if (!(err instanceof ActionError)) {
         showToast({ message: t('alertsPage.failedToResolveAlert'), type: 'error' });
+        return;
+      }
+      // 409 = another technician (or the auto-resolve sweep) won the
+      // compare-and-swap; the alert IS resolved, this request just didn't do it
+      // (#4094). runAction already toasted the server's reason. Refresh so the
+      // row stops showing a stale open status — otherwise the list keeps
+      // offering Resolve on an alert that is already finished.
+      if (err.status === 409) {
+        handleCloseDetail();
+        fetchAlerts();
       }
     } finally {
       setSubmitting(false);


### PR DESCRIPTION
Closes #4094

## The gap

#4083 made `resolveAlert()` a compare-and-swap so only one caller can transition an alert, and only the winner publishes `alert.resolved` (which cancels pending escalations and fans out to the `'*'` automation subscriber).

**Five other paths that stamp an alert `resolved` never went through it.** Each read the status, then ran `UPDATE ... WHERE eq(alerts.id, alertId)` unconditionally, then published — textbook check-then-act. Two techs resolving the same alert within the same second both "won": both UPDATEs succeeded, both published, escalation cancellation ran twice, and the automation subscriber saw the event twice.

## What changed

Every path now uses the one exported `buildResolveAlertCas(alertId)` predicate.

| Path | Source |
|---|---|
| `routes/alerts/alerts.ts` — `POST /alerts/:id/resolve` | named in the issue |
| `routes/mobile.ts` — `POST /mobile/alerts/:id/resolve` | named in the issue |
| `services/aiToolsAlerts.ts` — `manage_alerts` `action:"resolve"` | **found by the repo-wide sweep** |
| `routes/alerts/correlations.ts` — group resolve/acknowledge | **found by the repo-wide sweep** |
| `services/warrantyAlertEvaluator.ts` — auto-resolve loop | **found by the repo-wide sweep** |

The three extra sites are the same defect and the same blast radius; the AI-tool one matters more than most, since #4085 makes event delivery at-least-once and an agent racing a technician is exactly the case that gets likelier.

### `resolveAlert` was building a second copy of its own predicate

`buildResolveAlertCas` was exported by 8763a3239 specifically so the CAS could be asserted as compiled SQL, but `resolveAlert` kept an inline duplicate. The compiled-SQL test was therefore one step removed from production and the two could drift apart silently. Demonstrated: narrowing the *inline* list to `['active']` left both pre-existing helper tests green. `resolveAlert` now calls the helper.

### The unconsumed boolean (second half of the issue)

- `alertService.ts:238,246` — `checkAutoResolve` returned a hard-coded `true`, so `checkAllAutoResolve`'s count included every caller that lost the race. Now returns what the CAS did.
- `alertService.ts:811-813,820-822` — `checkAutoResolveFromConfigPolicy` incremented `resolvedCount` **and wrote the config-policy cooldown** unconditionally. A losing sweep reported a resolution it never performed and stamped a cooldown that suppresses the next legitimate alert for that rule. Both now gate on the winner.
  The explicit cooldown write is **removed** rather than gated: `resolveAlert`'s winning path already calls `markConfigPolicyRuleCooldown` with the same rule id, device and `cooldownMinutes`, so it was a duplicate of a write the winner performs anyway.

## API surface change: "already resolved" is 409, not 400

The pre-read check and losing the CAS are the **same outcome** — the alert is terminal and this request did not transition it. Leaving the pre-read at 400 while the race returned 409 would make one user action return two status codes depending purely on timing. Both are now 409. **Dismissed stays 400** — that is a genuine "you can't do that", not a race.

`openapi.ts` previously declared only a `200` for `resolveAlert`; the 400 and 409 are now documented. The only HTTP consumers are two web components (below); `/mobile/alerts/:id/resolve` has **no** client caller today — `apps/mobile` never shipped a resolve affordance.

## Web

Both callers discard the response body and re-fetch, so a 409 needs no body parsing, and `extractApiError` already surfaces the server's `error` sentence into the toast — no new i18n keys.

- `AlertDetailPage` no longer latches its **persistent red banner** on a 409 (framing a benign race as a broken page) and re-fetches so the header stops showing a stale open status.
- `AlertsPage` refreshes the list on a 409 for the same reason — previously it did nothing, leaving the row offering *Resolve* on an already-finished alert.

Feedback is deliberately **not** suppressed: a resolve that silently does nothing is the failure mode `runAction` exists to prevent, and there's a test pinning that the error toast still fires.

## Testing

Per the issue's warning and main 8763a3239: **no test here mocks drizzle-orm wholesale or substring-matches column names.** Every suite keeps `drizzle-orm` and `db/schema` real, mocks only the DB *connection*, captures the predicate the code actually passed to `.where()`, and asserts its **compiled SQL** through `PgDialect` — exact string and exact params.

**Mutation probes run (each confirmed red, then restored):**

| Mutation | Result |
|---|---|
| `buildResolveAlertCas` `and()` → `or()` | **6 tests red across all 5 files** |
| `resolveAlert`'s inline list → `['active']` (pre-fix shape) | 2 new tests red; both pre-existing helper tests stayed **green** — this is the gap being closed |
| `aiToolsAlerts` predicate → `eq(alerts.id, …)` alone | 1 red |
| `correlations` `and(...)` → `or(...)` | 2 red (resolve + acknowledge shapes) |
| `warrantyAlertEvaluator` predicate → `eq(alerts.id, …)` alone | 1 red |
| Revert `alertService.ts` entirely | 3/6 of the new auto-resolve outcome tests red |
| Revert both routes | 6/12 of the new route tests red |
| Revert the `AlertDetailPage` 409 branch | 1 red |

**Two pre-existing suites needed mock updates** (not assertion changes): `aiToolsAlerts.feedback.test.ts` and `warrantyAlertEvaluator.test.ts` stubbed `.where()` as terminal, and the CAS now chains `.returning()`. Both helpers default to a one-row winner so every existing assertion keeps its original meaning, and both can now model a loser. `mobile.test.ts`'s "should reject already resolved alerts" moved 400 → 409 with a comment recording why.

**Commands run:**
```
apps/api  vitest run --pool=forks --fileParallelism=false  (8 service files)   34 passed
apps/api  vitest run --pool=forks --fileParallelism=false  (9 route files)    191 passed, 3 skipped
apps/web  vitest run --fileParallelism=false               (4 files)          140 passed
apps/api  tsc --noEmit                                                        clean
apps/web  tsc --noEmit                                                        clean
eslint    (8 changed production files)                                        clean
```

## Design note — one deliberate divergence from the issue's suggestion

The issue suggested routing both routes *through* `resolveAlert()`. An independent Codex `xhigh` review agreed. **I did not**, for two reasons that only surface once you read the call graph:

1. **It would silently change flapping behaviour.** `resolveAlert` calls `recordStateTransition(...)`; the routes do not. `isFlapping` "counts all recorded events, not only alternations" and, when it trips, **suppresses new alert creation** (`alertService.ts:116-122`). Routing manual resolves through it would push rules toward that threshold and silently stop alerting — a customer-visible behaviour change riding inside a concurrency bugfix.
2. **It cannot cover all five sites.** `correlations.ts` resolves a group in one bulk UPDATE; per-alert `resolveAlert` calls would turn that into N round-trips.

There are also two contract deltas neither function subsumes: the routes publish `resolvedBy` with `{ userId }` metadata, while `resolveAlert` publishes neither but attaches `{ siteId }` — which gates site-restricted WebSocket delivery (`eventWs.ts:419`).

So the fix shares the thing that actually governs correctness — **the predicate** — and leaves the five side-effect pipelines alone. This also matches the repo's own reference shape one file over: the bulk-alert route the issue itself cites does an inline CAS.

## Out of scope (noted, not fixed)

The single-alert **acknowledge** handlers have the same check-then-act shape. Left alone: `alert.acknowledged` carries no escalation cancellation and no `'*'` automation fan-out, so a duplicate is far less harmful. Worth a follow-up issue if you want the symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012o7QB15EFjEvetDAXMxmae
