### PR TITLE
feat: workspace enrichment honors partner BYOK (#3917)

### DIFF
--- a/apps/api/src/__tests__/integration/workspaceEnrichmentByok.integration.test.ts
+++ b/apps/api/src/__tests__/integration/workspaceEnrichmentByok.integration.test.ts
@@ -19,9 +19,10 @@
  *  - the FULL chain (resolver -> rate limit -> budget -> Anthropic call ->
  *    recordUsage) actually lands a real `ai_cost_usage` row tagged
  *    billing_source='partner_key' for a real BYOK partner, with zero calls to
- *    the billing-credit deduction path (recordUsage() never calls it, but the
- *    unit suites mock recordUsage itself, which would hide a regression that
- *    wired deduction into it);
+ *    the billing-credit deduction path — the host DOES draw prepaid credits
+ *    down for platform-funded extension spend, so this proves the partner-key
+ *    branch is excluded from it end to end (the unit suites mock both
+ *    recordUsage and the deduction, so only this one exercises the real wiring);
  *  - flipping the partner's config to status='error' makes the run fail LOUD
  *    (a visible TransientIngestError, mapped by the ingest runner to a
  *    transient release / by the admin route to a 503) instead of quietly
@@ -227,7 +228,12 @@ describe('workspace enrichment honors partner BYOK', () => {
         });
 
         const ai = buildExtensionAiContext();
-        const enrichment = createEnrichmentService(db, { invoke: ai.invoke });
+        // Same narrowing the host applies at registration (`asWorkspaceDatabase`):
+        // ee/workspace types its handle as a schema-less PostgresJsDatabase.
+        const enrichment = createEnrichmentService(
+          db as unknown as Parameters<typeof createEnrichmentService>[0],
+          { invoke: ai.invoke },
+        );
 
         // --- Success: BYOK partner key resolves and bills partner_key ---
         const firstRun = await withDbAccessContext(orgContext(org.id), () =>

--- a/apps/api/src/__tests__/integration/workspaceEnrichmentByok.integration.test.ts
+++ b/apps/api/src/__tests__/integration/workspaceEnrichmentByok.integration.test.ts
@@ -35,8 +35,8 @@ import { randomUUID } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { and, eq, sql } from 'drizzle-orm';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
-import postgres from 'postgres';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import postgres, { type Sql } from 'postgres';
 import Anthropic from '@anthropic-ai/sdk';
 import { createEnrichmentService } from '@breeze/ext-workspace/src/services/enrichmentService';
 import { TransientIngestError } from '@breeze/ext-workspace/src/services/ingestErrors';
@@ -75,6 +75,44 @@ const runDb = it.runIf(!!process.env.DATABASE_URL);
  * is a safe no-op if the real boot step already ran on this DB, and the real
  * boot step re-applying afterwards (recording its own `breeze_migrations`
  * ledger rows) is equally a safe no-op against schema this already created.
+ *
+ * THE LEAK THIS FIXTURE MUST NOT CAUSE (CI run 33031202932, shard 4/4).
+ * The `public` schema of the integration database is a SHARED, CONTRACT-CHECKED
+ * namespace: `tenantCascade.integration.test.ts` enumerates every `org_id`-
+ * columned public BASE TABLE in the live DB and fails when one isn't registered
+ * in `getOrgCascadeDeleteOrder()`. Extension tables are deliberately absent from
+ * that core list — registering them would break the sibling "no entry references
+ * a non-existent table" assertion on every extension-less deployment — so tables
+ * this fixture creates and LEAVES BEHIND red the core cascade contract for the
+ * rest of the vitest run. That is exactly what happened: all eleven relations
+ * below survived into `tenantCascade`'s enumeration and it reported ten of them
+ * (`workspace_sources` was the only one it did not, being already covered).
+ *
+ * The fix is fixture hygiene, not cascade registration: this suite now owns the
+ * full lifecycle of the schema it creates — a defensive drop in `beforeAll`
+ * (so a crashed prior run cannot poison this one) and a mandatory drop in
+ * `afterAll` that ASSERTS nothing survived. `vitest.integration.config.ts` sets
+ * `fileParallelism: false` and `sequence.concurrent: false`, so no other suite
+ * is running while this file holds the schema and an `afterAll` drop is
+ * sufficient; a per-file throwaway database (the approach
+ * `extensions/builtinTableProbe.integration.test.ts` takes) is not, because
+ * unlike that probe this suite needs the FULL core schema — organizations,
+ * partners, devices, ai_sessions, partner_llm_configs, ai_cost_usage, the
+ * `breeze_app` role and the `breeze_has_org_access` helpers — i.e. a complete
+ * 400+ file `autoMigrate()` replay per run, plus a `DATABASE_URL` swap before
+ * the module-level `../../db` handle is constructed.
+ *
+ * WHY THE MIGRATION FILES AND NOT HAND-WRITTEN DDL. This is an integration
+ * PROOF: the real `ee/workspace` enrichment service runs against the real
+ * extension schema. Hand-copying a trimmed subset of the DDL here would let the
+ * fixture drift silently away from the shipped migrations and quietly hollow
+ * the proof out. The file set is already minimal — three of the extension's
+ * eight migrations; the crawler/finder/chunks/ingest-jobs files are NOT applied.
+ * `memory_blocks` and `workspace_file_activity` are unavoidable collateral of
+ * `2026-07-10-workspace-foundation.sql` (which is also the only source of the
+ * `workspace_sources`/`workspace_file_index` the fixtures need), and shipped
+ * migrations must never be edited — so they are created and then dropped like
+ * everything else, rather than skipped.
  */
 const WORKSPACE_MIGRATIONS_DIR = join(
   dirname(fileURLToPath(import.meta.url)),
@@ -86,18 +124,105 @@ const REQUIRED_WORKSPACE_MIGRATIONS = [
   '2026-07-24-org-settings-dlp.sql',
 ];
 
-async function ensureWorkspaceSchema(): Promise<void> {
+/**
+ * EVERY table the three migrations above create — the teardown contract.
+ * Keep in sync when `REQUIRED_WORKSPACE_MIGRATIONS` changes; anything missing
+ * here leaks into `public` and reds `tenantCascade.integration.test.ts`.
+ * Dropped in one statement with CASCADE, so declaration order is irrelevant.
+ */
+const WORKSPACE_FIXTURE_TABLES = [
+  // 2026-07-10-workspace-foundation.sql
+  'workspace_sources',
+  'workspace_file_index',
+  'workspace_file_activity',
+  'memory_blocks',
+  // 2026-07-19-content.sql
+  'workspace_file_content',
+  'workspace_content_entities',
+  'workspace_file_enrichment',
+  'workspace_projects',
+  'workspace_project_crosswalk',
+  'workspace_email_filings',
+  // 2026-07-24-org-settings-dlp.sql
+  'workspace_org_settings',
+] as const;
+
+/**
+ * The enum types those same migrations create. Dropped after the tables so the
+ * next `ensureWorkspaceSchema()` re-runs their `CREATE TYPE` branch from a
+ * clean slate (in particular re-establishing `workspace_content_status`'s
+ * `blocked_dlp` value, which `2026-07-24` adds via `ALTER TYPE ... ADD VALUE`).
+ */
+const WORKSPACE_FIXTURE_TYPES = [
+  'workspace_source_kind',
+  'workspace_source_status',
+  'workspace_file_action',
+  'workspace_content_status',
+  'workspace_filing_status',
+  'workspace_filing_confidence',
+] as const;
+
+async function withWorkspaceAdmin<T>(fn: (admin: Sql) => Promise<T>): Promise<T> {
   const adminUrl =
     process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
-  const admin = postgres(adminUrl, { max: 1 });
+  const admin = postgres(adminUrl, { max: 1, onnotice: () => {} });
   try {
+    return await fn(admin);
+  } finally {
+    await admin.end();
+  }
+}
+
+/** Idempotent teardown of everything `ensureWorkspaceSchema()` creates. */
+async function dropWorkspaceSchema(): Promise<void> {
+  await withWorkspaceAdmin(async (admin) => {
+    await admin.unsafe(
+      `DROP TABLE IF EXISTS ${WORKSPACE_FIXTURE_TABLES.join(', ')} CASCADE`,
+    );
+    await admin.unsafe(`DROP TYPE IF EXISTS ${WORKSPACE_FIXTURE_TYPES.join(', ')} CASCADE`);
+  });
+}
+
+/**
+ * Proves the teardown actually landed. Without this, a silently-failed drop
+ * resurfaces as a baffling failure in a DIFFERENT file (`tenantCascade`)
+ * potentially minutes later; here it names the leaking tables directly.
+ */
+async function assertWorkspaceSchemaGone(): Promise<void> {
+  // Deliberately unparameterised + filtered in JS: binding a `text[]` into this
+  // kind of probe is the exact shape that shipped `malformed array literal` once
+  // before (see extensions/builtinTableProbe.integration.test.ts's header).
+  const present = await withWorkspaceAdmin(
+    (admin) => admin<Array<{ table_name: string }>>`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+    `,
+  );
+  const remaining = new Set(present.map((row) => row.table_name));
+  const survivors = WORKSPACE_FIXTURE_TABLES.filter((table) => remaining.has(table));
+  if (survivors.length > 0) {
+    throw new Error(
+      `workspaceEnrichmentByok teardown leaked ee/workspace tables into the shared ` +
+        `integration database: ${survivors.join(', ')}. ` +
+        `Every org_id-columned public table is enumerated by ` +
+        `tenantCascade.integration.test.ts, so these WILL red the core GDPR cascade ` +
+        `contract for the rest of this run.`,
+    );
+  }
+}
+
+async function ensureWorkspaceSchema(): Promise<void> {
+  // Defensive: a run killed mid-flight (Ctrl-C, CI timeout, an unhandled
+  // rejection before afterAll) leaves the schema behind. Start from a known
+  // state rather than inheriting a half-migrated one.
+  await dropWorkspaceSchema();
+  await withWorkspaceAdmin(async (admin) => {
     for (const filename of REQUIRED_WORKSPACE_MIGRATIONS) {
       const content = readFileSync(join(WORKSPACE_MIGRATIONS_DIR, filename), 'utf8');
       await admin.begin((tx) => tx.unsafe(content));
     }
-  } finally {
-    await admin.end();
-  }
+  });
 }
 
 function orgContext(orgId: string): DbAccessContext {
@@ -148,6 +273,15 @@ describe('workspace enrichment honors partner BYOK', () => {
   beforeAll(async () => {
     if (!process.env.DATABASE_URL) return;
     await ensureWorkspaceSchema();
+  });
+
+  // Registered inside the describe on purpose: suite-level afterAll hooks run
+  // BEFORE the file-level ones `setup.ts` installs, so the shared pools are
+  // still open and the drop cannot race pool teardown.
+  afterAll(async () => {
+    if (!process.env.DATABASE_URL) return;
+    await dropWorkspaceSchema();
+    await assertWorkspaceSchemaGone();
   });
 
   runDb(

--- a/apps/api/src/__tests__/integration/workspaceEnrichmentByok.integration.test.ts
+++ b/apps/api/src/__tests__/integration/workspaceEnrichmentByok.integration.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Integration proof for #3917: `ee/workspace` content enrichment must honor a
+ * partner's BYOK Anthropic key when one is configured, get real cost tracking
+ * for it (billing_source = 'partner_key'), and never silently fall back to
+ * the platform key when the BYOK config breaks.
+ *
+ * This drives the REAL host capability (`buildExtensionAiContext`, the same
+ * function `stageExtension.ts` wires onto `context.ai` for every built-in
+ * extension) into the REAL `ee/workspace` enrichment service against real
+ * Postgres + Redis. Only the Anthropic client is stubbed, at the resolver
+ * boundary (`Anthropic.Messages.prototype.create` — shared across every
+ * `new Anthropic(...)` instance the resolver constructs, platform or partner)
+ * — see `catalogEnrichmentService.ts`/`llmConfigResolver.ts` for why that
+ * class-prototype method is the right seam instead of mocking `@anthropic-ai/sdk`
+ * wholesale (this suite still needs the SDK's real `APIError` etc. elsewhere).
+ *
+ * Two assertions the mocked unit suites (extensionAi.test.ts,
+ * enrichmentService.test.ts) cannot make on their own:
+ *  - the FULL chain (resolver -> rate limit -> budget -> Anthropic call ->
+ *    recordUsage) actually lands a real `ai_cost_usage` row tagged
+ *    billing_source='partner_key' for a real BYOK partner, with zero calls to
+ *    the billing-credit deduction path (recordUsage() never calls it, but the
+ *    unit suites mock recordUsage itself, which would hide a regression that
+ *    wired deduction into it);
+ *  - flipping the partner's config to status='error' makes the run fail LOUD
+ *    (a visible TransientIngestError, mapped by the ingest runner to a
+ *    transient release / by the admin route to a 503) instead of quietly
+ *    reusing the platform key — the phase-1 BYOK invariant this whole feature
+ *    must never violate.
+ */
+import './setup';
+import { readFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { and, eq, sql } from 'drizzle-orm';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import postgres from 'postgres';
+import Anthropic from '@anthropic-ai/sdk';
+import { createEnrichmentService } from '@breeze/ext-workspace/src/services/enrichmentService';
+import { TransientIngestError } from '@breeze/ext-workspace/src/services/ingestErrors';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import { aiCostUsage, partnerLlmConfigs } from '../../db/schema';
+import { buildExtensionAiContext } from '../../services/extensionAi';
+import { columnAad, encryptedColumnRegistry } from '../../services/encryptedColumnRegistry';
+import { encryptSecret, hmacFingerprint } from '../../services/secretCrypto';
+import { createOrganization, createPartner } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+/**
+ * `ee/workspace`'s tables (workspace_sources, workspace_file_content, ...)
+ * are NOT applied by this suite's own `globalSetup` — that runs core
+ * `autoMigrate()` only. In real deployments and in CI, they are created by
+ * `loadBuiltinExtensions()`, which runs exclusively at actual `apps/api`
+ * server boot (`src/index.ts`) with `BREEZE_WORKSPACE_ENABLED=true` — see the
+ * "Boot API once to apply built-in extension migrations (ee)" step in
+ * `.github/workflows/ci.yml`, which runs AFTER this package's own
+ * `test:integration` step, and only for shard 1. This suite's own DB
+ * (whichever shard it lands on, or a bare local `pnpm test-stack up`, which
+ * never boots the server at all) therefore cannot assume those tables exist.
+ *
+ * Rather than depend on CI step ordering (or add a cross-shard dependency
+ * that doesn't exist today), this test applies the three ee/workspace
+ * migration files its own fixtures touch directly against the admin
+ * connection — the exact same idempotent per-file `tx.unsafe(content)`
+ * mechanism `autoMigrate.ts` uses for core migrations. Every migration file
+ * in this repo is written to be idempotent by contract, so re-applying here
+ * is a safe no-op if the real boot step already ran on this DB, and the real
+ * boot step re-applying afterwards (recording its own `breeze_migrations`
+ * ledger rows) is equally a safe no-op against schema this already created.
+ */
+const WORKSPACE_MIGRATIONS_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../../ee/workspace/migrations',
+);
+const REQUIRED_WORKSPACE_MIGRATIONS = [
+  '2026-07-10-workspace-foundation.sql',
+  '2026-07-19-content.sql',
+  '2026-07-24-org-settings-dlp.sql',
+];
+
+async function ensureWorkspaceSchema(): Promise<void> {
+  const adminUrl =
+    process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+  const admin = postgres(adminUrl, { max: 1 });
+  try {
+    for (const filename of REQUIRED_WORKSPACE_MIGRATIONS) {
+      const content = readFileSync(join(WORKSPACE_MIGRATIONS_DIR, filename), 'utf8');
+      await admin.begin((tx) => tx.unsafe(content));
+    }
+  } finally {
+    await admin.end();
+  }
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const API_KEY_SPEC = encryptedColumnRegistry.find(
+  (entry) => entry.table === 'partner_llm_configs' && entry.column === 'api_key_encrypted',
+);
+if (!API_KEY_SPEC) {
+  throw new Error('partner_llm_configs.api_key_encrypted is missing from encryptedColumnRegistry');
+}
+
+// Real column-level encryption (row-bound AAD), mirroring
+// partnerLlmConfig.ts's private encryptPartnerLlmApiKey — this suite needs a
+// key that DECRYPTS successfully so the resolver actually reaches 'partner'
+// source, unlike the RLS-only fixtures elsewhere that use a literal 'enc:...'
+// string and never exercise decryption.
+function encryptTestApiKey(id: string, apiKey: string): string {
+  const encrypted = encryptSecret(apiKey, { aad: columnAad(API_KEY_SPEC!, id) });
+  if (!encrypted) throw new Error('failed to encrypt test Anthropic API key');
+  return encrypted;
+}
+
+function mockClassificationResponse(text: string) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    usage: { input_tokens: 120, output_tokens: 40 },
+  };
+}
+
+const CLASSIFICATION_JSON = JSON.stringify({
+  docType: 'meeting notes',
+  projectKey: null,
+  projectLabel: null,
+  docDate: null,
+  confidence: 'low',
+  people: [],
+});
+
+describe('workspace enrichment honors partner BYOK', () => {
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) return;
+    await ensureWorkspaceSchema();
+  });
+
+  runDb(
+    'BYOK partner: enrichment bills partner_key and never falls back to the platform key on a broken config',
+    async () => {
+      const createSpy = vi
+        .spyOn(Anthropic.Messages.prototype, 'create')
+        // @ts-expect-error - real SDK response type is far richer than this test needs
+        .mockResolvedValue(mockClassificationResponse(CLASSIFICATION_JSON));
+
+      const previousBillingUrl = process.env.BILLING_SERVICE_URL;
+      const previousBillingKey = process.env.BILLING_SERVICE_API_KEY;
+      process.env.BILLING_SERVICE_URL = 'https://billing.internal';
+      process.env.BILLING_SERVICE_API_KEY = 'billing-key';
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({ allowed: true, remainingCredits: 1000, plan: 'pro' }),
+            { status: 200 },
+          ),
+        );
+
+      try {
+        const { org, configId } = await withSystemDbAccessContext(async () => {
+          const partner = await createPartner();
+          const org = await createOrganization({ partnerId: partner.id });
+
+          const configId = randomUUID();
+          const apiKey = 'sk-ant-integration-test-key-0000000000';
+          await db.insert(partnerLlmConfigs).values({
+            id: configId,
+            partnerId: partner.id,
+            apiKeyEncrypted: encryptTestApiKey(configId, apiKey),
+            keyLast4: apiKey.slice(-4),
+            keyFingerprint: hmacFingerprint(apiKey),
+            status: 'active',
+          });
+
+          await db.execute(sql`
+            INSERT INTO workspace_org_settings (org_id, content_enabled)
+            VALUES (${org.id}, true)
+            ON CONFLICT (org_id) DO UPDATE SET content_enabled = true
+          `);
+
+          const sourceRows = (await db.execute(sql`
+            INSERT INTO workspace_sources (org_id, kind, display_name, root_path, status)
+            VALUES (${org.id}, 'local_profile', 'BYOK test source', '/tmp/byok-test', 'active')
+            RETURNING id
+          `)) as unknown as Array<{ id: string }>;
+          const sourceId = sourceRows[0]!.id;
+
+          // Two extracted-but-unenriched files: the first proves the success
+          // path, the second stays pending so the fail-loud run below has
+          // something real to attempt (a run with nothing pending would
+          // trivially "succeed" without ever calling invoke()).
+          const file1Rows = (await db.execute(sql`
+            INSERT INTO workspace_file_index (org_id, source_id, rel_path, parent_path, name, is_dir)
+            VALUES (${org.id}, ${sourceId}, 'a-first.txt', '', 'a-first.txt', false)
+            RETURNING id
+          `)) as unknown as Array<{ id: string }>;
+          await db.execute(sql`
+            INSERT INTO workspace_file_content (org_id, file_index_id, extracted_text, status)
+            VALUES (${org.id}, ${file1Rows[0]!.id}, 'Meeting notes from the site visit on 2026-08-01.', 'extracted')
+          `);
+
+          const file2Rows = (await db.execute(sql`
+            INSERT INTO workspace_file_index (org_id, source_id, rel_path, parent_path, name, is_dir)
+            VALUES (${org.id}, ${sourceId}, 'b-second.txt', '', 'b-second.txt', false)
+            RETURNING id
+          `)) as unknown as Array<{ id: string }>;
+          await db.execute(sql`
+            INSERT INTO workspace_file_content (org_id, file_index_id, extracted_text, status)
+            VALUES (${org.id}, ${file2Rows[0]!.id}, 'Transmittal letter for the second parcel review.', 'extracted')
+          `);
+
+          return { org, configId };
+        });
+
+        const ai = buildExtensionAiContext();
+        const enrichment = createEnrichmentService(db, { invoke: ai.invoke });
+
+        // --- Success: BYOK partner key resolves and bills partner_key ---
+        const firstRun = await withDbAccessContext(orgContext(org.id), () =>
+          enrichment.run(org.id, 1),
+        );
+        expect(firstRun.errors).toEqual([]);
+        expect(firstRun.processed).toBe(1);
+        expect(firstRun.remaining).toBe(1);
+        expect(createSpy).toHaveBeenCalledTimes(1);
+
+        const usageAfterSuccess = await withSystemDbAccessContext(() =>
+          db
+            .select({ billingSource: aiCostUsage.billingSource })
+            .from(aiCostUsage)
+            .where(and(eq(aiCostUsage.orgId, org.id), eq(aiCostUsage.period, 'daily'))),
+        );
+        expect(usageAfterSuccess).toEqual([{ billingSource: 'partner_key' }]);
+
+        const deductCalls = fetchSpy.mock.calls.filter(([url]) =>
+          String(url).includes('/ai-credits/deduct'),
+        );
+        expect(deductCalls).toHaveLength(0);
+
+        // --- Fail-loud: a broken BYOK config aborts the run, never falls
+        // back to the platform key ---
+        await withSystemDbAccessContext(() =>
+          db
+            .update(partnerLlmConfigs)
+            .set({ status: 'error', lastError: 'decrypt_failed' })
+            .where(eq(partnerLlmConfigs.id, configId)),
+        );
+
+        await expect(
+          withDbAccessContext(orgContext(org.id), () => enrichment.run(org.id, 5)),
+        ).rejects.toThrow(TransientIngestError);
+
+        // No fallback Anthropic call was attempted for the second file.
+        expect(createSpy).toHaveBeenCalledTimes(1);
+
+        const usageAfterFailure = await withSystemDbAccessContext(() =>
+          db
+            .select({ billingSource: aiCostUsage.billingSource })
+            .from(aiCostUsage)
+            .where(and(eq(aiCostUsage.orgId, org.id), eq(aiCostUsage.period, 'daily'))),
+        );
+        // Unchanged from the successful run, and critically: no 'platform' row.
+        expect(usageAfterFailure).toEqual([{ billingSource: 'partner_key' }]);
+        expect(usageAfterFailure.some((row) => row.billingSource === 'platform')).toBe(false);
+      } finally {
+        createSpy.mockRestore();
+        fetchSpy.mockRestore();
+        if (previousBillingUrl === undefined) delete process.env.BILLING_SERVICE_URL;
+        else process.env.BILLING_SERVICE_URL = previousBillingUrl;
+        if (previousBillingKey === undefined) delete process.env.BILLING_SERVICE_API_KEY;
+        else process.env.BILLING_SERVICE_API_KEY = previousBillingKey;
+      }
+    },
+  );
+});

--- a/apps/api/src/extensions/stageExtension.test.ts
+++ b/apps/api/src/extensions/stageExtension.test.ts
@@ -51,6 +51,7 @@ describe('defaultStageExtension (v1 contract)', () => {
         observed.dbExecute = typeof context.db?.execute;
         observed.encrypt = typeof context.secrets?.encryptForColumn;
         observed.audit = typeof context.audit;
+        observed.aiInvoke = typeof context.ai?.invoke;
         observed.logIsLevelFirst = (() => {
           // A legacy host passed log(message); v1 log(level, message) must not
           // throw and must accept a fields object.
@@ -66,6 +67,7 @@ describe('defaultStageExtension (v1 contract)', () => {
       dbExecute: 'function',
       encrypt: 'function',
       audit: 'function',
+      aiInvoke: 'function',
       logIsLevelFirst: true,
     });
     expect(staged.routeApp).toBeTruthy();

--- a/apps/api/src/extensions/stageExtension.ts
+++ b/apps/api/src/extensions/stageExtension.ts
@@ -21,6 +21,7 @@ import { hasCoreAiToolName } from '../services/aiTools';
 import { db } from '../db';
 import { createAuditLogAsync } from '../services/auditService';
 import { decryptForColumn, encryptSecret } from '../services/secretCrypto';
+import { buildExtensionAiContext } from '../services/extensionAi';
 
 /**
  * Stage an extension's contributions into an isolated session, through the
@@ -67,6 +68,7 @@ export async function defaultStageExtension(
 
   const context: ExtensionRuntimeContext = {
     db: db as unknown as ExtensionRuntimeContext['db'],
+    ai: buildExtensionAiContext(),
     secrets: {
       encryptForColumn: (table, column, plaintext) =>
         encryptSecret(plaintext, { aad: `${table}.${column}` }) ?? '',

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -33,6 +33,10 @@ const MODEL_PRICING: Record<string, { inputPerMillion: number; outputPerMillion:
   'claude-sonnet-4-5-20250929': { inputPerMillion: 300, outputPerMillion: 1500 }
 };
 
+export function isPricedModel(model: string): boolean {
+  return model in MODEL_PRICING;
+}
+
 // Models a partner may pin as their BYOK default. MODEL_PRICING keeps legacy
 // snapshot ids for cost attribution on old sessions; those must not be offered
 // (or accepted) as new defaults — a retired snapshot pinned partner-wide fails
@@ -107,7 +111,16 @@ export async function checkBillingCredits(
   }
 }
 
-async function deductBillingCredits(orgId: string, costCents: number): Promise<void> {
+/**
+ * Draw platform-funded spend down from the org's prepaid AI credit balance.
+ *
+ * Exported for callers that record usage through `recordUsage` (which does NOT
+ * deduct — see the note on `recordSessionlessSdkUsage`) and therefore have to
+ * make the deduction themselves. Only ever call this for
+ * `billingSource === 'platform'`: partner BYOK spend is billed by Anthropic to
+ * the partner, not against our credits.
+ */
+export async function deductBillingCredits(orgId: string, costCents: number): Promise<void> {
   const billingUrl = process.env.BILLING_SERVICE_URL;
   const billingKey = process.env.BILLING_SERVICE_API_KEY;
   if (!billingUrl || !billingKey) return;
@@ -340,6 +353,31 @@ export async function checkUserAiRateLimit(userId: string): Promise<string | nul
   const userResult = await rateLimiter(redis, `ai:msg:user:${userId}`, 20, 60);
   if (!userResult.allowed) {
     return `Rate limit exceeded. Try again at ${userResult.resetAt.toISOString()}`;
+  }
+  return null;
+}
+
+/**
+ * Org-scoped rate limit for non-interactive AI work driven by a SYSTEM
+ * principal (no acting user) — e.g. an extension's bulk enrichment batch.
+ *
+ * Deliberately skips `checkAiRateLimit`'s per-USER bucket. That bucket is keyed
+ * `ai:msg:user:<id>` with no org component, so a synthetic actor id ("this
+ * surface") would put every tenant's automation in ONE deployment-wide bucket —
+ * one partner's batch would rate-limit everybody else's. Keying the synthetic
+ * actor per org fixes the coupling but still caps automation at the
+ * interactive-chat 20/min, which a legitimate 100-file batch trips. The per-org
+ * HOURLY ceiling is the meaningful bound here, and `checkBudget` bounds spend.
+ */
+export async function checkSystemAiRateLimit(orgId: string): Promise<string | null> {
+  const redis = getRedis();
+  // Self-contexted for the same reason as checkAiRateLimit (#2190).
+  const budget = await withSystemDbAccessContext(() => getEffectiveAiBudget(orgId));
+  const msgsPerHour = budget?.messagesPerHourPerOrg ?? 200;
+
+  const orgResult = await rateLimiter(redis, `ai:msg:org:${orgId}`, msgsPerHour, 3600);
+  if (!orgResult.allowed) {
+    return `Organization rate limit exceeded. Try again at ${orgResult.resetAt.toISOString()}`;
   }
   return null;
 }

--- a/apps/api/src/services/extensionAi.test.ts
+++ b/apps/api/src/services/extensionAi.test.ts
@@ -1,0 +1,385 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ExtensionAiError, type ExtensionAiInvokeInput } from '@breeze/extension-sdk';
+
+const {
+  buildAnthropicClient,
+  calculateCostCents,
+  checkAiRateLimit,
+  checkBudget,
+  checkSystemAiRateLimit,
+  create,
+  deductBillingCredits,
+  markPartnerLlmError,
+  recordUsage,
+  resolveLlmConfigForOrg,
+} = vi.hoisted(() => ({
+  buildAnthropicClient: vi.fn(),
+  calculateCostCents: vi.fn<() => number>(),
+  checkAiRateLimit: vi.fn<() => Promise<string | null>>(),
+  checkBudget: vi.fn<() => Promise<string | null>>(),
+  checkSystemAiRateLimit: vi.fn<() => Promise<string | null>>(),
+  create: vi.fn(),
+  deductBillingCredits: vi.fn<() => Promise<void>>(),
+  markPartnerLlmError: vi.fn<() => Promise<boolean>>(),
+  recordUsage: vi.fn<() => Promise<void>>(),
+  resolveLlmConfigForOrg: vi.fn(),
+}));
+
+vi.mock('./aiCostTracker', () => ({
+  calculateCostCents,
+  checkAiRateLimit,
+  checkBudget,
+  checkSystemAiRateLimit,
+  deductBillingCredits,
+  isPricedModel: (model: string) => [
+    'claude-haiku-4-5',
+    'claude-sonnet-4-6',
+  ].includes(model),
+  recordUsage,
+}));
+
+const { LlmOrgResolutionError } = vi.hoisted(() => ({
+  LlmOrgResolutionError: class LlmOrgResolutionError extends Error {
+    readonly orgId: string;
+    constructor(orgId: string) {
+      super(`Organization ${orgId} could not be resolved for AI configuration.`);
+      this.name = 'LlmOrgResolutionError';
+      this.orgId = orgId;
+    }
+  },
+}));
+
+vi.mock('./llm/llmConfigResolver', () => ({
+  buildAnthropicClient,
+  markPartnerLlmError,
+  resolveLlmConfigForOrg,
+  LlmOrgResolutionError,
+}));
+
+import { buildExtensionAiContext } from './extensionAi';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const PARTNER_ID = '22222222-2222-4222-8222-222222222222';
+const USER_ID = '33333333-3333-4333-8333-333333333333';
+
+const PARTNER_CONFIG = {
+  source: 'partner' as const,
+  partnerId: PARTNER_ID,
+  apiKey: 'partner-key',
+  model: 'claude-sonnet-4-6',
+  configId: 'config-1',
+  configVersion: 3,
+};
+
+const PLATFORM_CONFIG = {
+  source: 'platform' as const,
+  apiKey: 'platform-key',
+  model: 'claude-sonnet-4-6',
+};
+
+const input: ExtensionAiInvokeInput = {
+  orgId: ORG_ID,
+  surface: 'workspace_enrichment',
+  principal: { type: 'user', id: USER_ID },
+  system: 'Return concise prose.',
+  messages: [{ role: 'user', content: 'Summarize this workspace.' }],
+  maxTokens: 512,
+};
+
+const systemInput: ExtensionAiInvokeInput = {
+  ...input,
+  principal: { type: 'system', id: null },
+};
+
+function response(text = 'workspace summary') {
+  return {
+    id: 'msg_test',
+    type: 'message',
+    role: 'assistant',
+    model: 'claude-haiku-4-5',
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    content: [{ type: 'text', text, citations: null }],
+    usage: { input_tokens: 17, output_tokens: 9 },
+  };
+}
+
+/** An Anthropic APIError-shaped rejection (only `status` matters here). */
+function apiError(status: number, message = `HTTP ${status}`) {
+  return Object.assign(new Error(message), { status });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resolveLlmConfigForOrg.mockResolvedValue(PARTNER_CONFIG);
+  buildAnthropicClient.mockReturnValue({ messages: { create } });
+  checkAiRateLimit.mockResolvedValue(null);
+  checkSystemAiRateLimit.mockResolvedValue(null);
+  checkBudget.mockResolvedValue(null);
+  create.mockResolvedValue(response());
+  recordUsage.mockResolvedValue(undefined);
+  deductBillingCredits.mockResolvedValue(undefined);
+  markPartnerLlmError.mockResolvedValue(true);
+  calculateCostCents.mockReturnValue(4);
+});
+
+describe('buildExtensionAiContext', () => {
+  it('meters a BYOK invocation and records partner_key usage', async () => {
+    const result = await buildExtensionAiContext().invoke(input);
+
+    expect(result).toEqual({
+      text: 'workspace summary',
+      model: 'claude-haiku-4-5',
+      billingSource: 'partner_key',
+      usage: { inputTokens: 17, outputTokens: 9 },
+    });
+    expect(resolveLlmConfigForOrg).toHaveBeenCalledWith(ORG_ID);
+    expect(buildAnthropicClient).toHaveBeenCalledWith(PARTNER_CONFIG);
+    expect(checkAiRateLimit).toHaveBeenCalledWith(USER_ID, ORG_ID);
+    expect(checkBudget).toHaveBeenCalledWith(ORG_ID, 'partner_key');
+    expect(create).toHaveBeenCalledWith({
+      model: 'claude-haiku-4-5',
+      max_tokens: 512,
+      system: 'Return concise prose.',
+      messages: [{ role: 'user', content: 'Summarize this workspace.' }],
+    });
+    expect(recordUsage).toHaveBeenCalledWith(
+      null,
+      ORG_ID,
+      'claude-haiku-4-5',
+      17,
+      9,
+      true,
+      'partner_key',
+    );
+    // A partner-funded call must never touch the org's prepaid platform credits.
+    expect(deductBillingCredits).not.toHaveBeenCalled();
+  });
+
+  it('does not resolve until usage recording has completed', async () => {
+    // Discriminating by construction: recordUsage is held open on a deferred, so
+    // `void recordUsage(...)` (accounting skipped) resolves invoke early and fails.
+    let releaseRecordUsage!: () => void;
+    recordUsage.mockReturnValueOnce(new Promise<void>((resolve) => {
+      releaseRecordUsage = () => resolve();
+    }));
+
+    let settled = false;
+    const invocation = buildExtensionAiContext().invoke(input).then((value) => {
+      settled = true;
+      return value;
+    });
+
+    // Drain the microtask queue well past every internal await.
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(settled).toBe(false);
+
+    releaseRecordUsage();
+    await expect(invocation).resolves.toMatchObject({ billingSource: 'partner_key' });
+  });
+
+  it('attributes platform usage to the platform billing source and deducts credits', async () => {
+    resolveLlmConfigForOrg.mockResolvedValueOnce(PLATFORM_CONFIG);
+    calculateCostCents.mockReturnValueOnce(7);
+
+    const result = await buildExtensionAiContext().invoke(input);
+
+    expect(result.billingSource).toBe('platform');
+    expect(recordUsage).toHaveBeenCalledWith(
+      null,
+      ORG_ID,
+      'claude-haiku-4-5',
+      17,
+      9,
+      true,
+      'platform',
+    );
+    expect(calculateCostCents).toHaveBeenCalledWith('claude-haiku-4-5', 17, 9);
+    expect(deductBillingCredits).toHaveBeenCalledWith(ORG_ID, 7);
+  });
+
+  it('rejects an unresolvable organization instead of billing the platform key', async () => {
+    resolveLlmConfigForOrg.mockRejectedValueOnce(new LlmOrgResolutionError(ORG_ID));
+
+    await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+      name: 'ExtensionAiError',
+      code: 'ai_unavailable',
+    });
+    expect(create).not.toHaveBeenCalled();
+    expect(recordUsage).not.toHaveBeenCalled();
+    expect(deductBillingCredits).not.toHaveBeenCalled();
+  });
+
+  it('maps a broken partner BYOK config to ai_unavailable before calling the client', async () => {
+    resolveLlmConfigForOrg.mockResolvedValueOnce({
+      source: 'unavailable',
+      partnerId: PARTNER_ID,
+      reason: 'key_error',
+    });
+
+    await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+      name: 'ExtensionAiError',
+      code: 'ai_unavailable',
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('reports a deployment with no platform key as not_configured, not a failure', async () => {
+    resolveLlmConfigForOrg.mockResolvedValueOnce({
+      source: 'platform',
+      apiKey: '  ',
+      model: 'claude-sonnet-4-6',
+    });
+
+    await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+      name: 'ExtensionAiError',
+      code: 'not_configured',
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects an exceeded budget before calling the client', async () => {
+    checkBudget.mockResolvedValueOnce('Monthly AI budget exceeded');
+
+    await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+      name: 'ExtensionAiError',
+      code: 'budget_exceeded',
+      message: 'Monthly AI budget exceeded',
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a rate-limited invocation before checking budget or calling the client', async () => {
+    checkAiRateLimit.mockResolvedValueOnce('Rate limit exceeded');
+
+    await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+      name: 'ExtensionAiError',
+      code: 'rate_limited',
+      message: 'Rate limit exceeded',
+    });
+    expect(checkBudget).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unpriced model before resolving or enforcing limits', async () => {
+    await expect(buildExtensionAiContext().invoke({
+      ...input,
+      model: 'not-a-real-model',
+    })).rejects.toMatchObject({
+      name: 'ExtensionAiError',
+      code: 'ai_unavailable',
+    });
+
+    expect(resolveLlmConfigForOrg).not.toHaveBeenCalled();
+    expect(checkAiRateLimit).not.toHaveBeenCalled();
+    expect(checkBudget).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+    expect(recordUsage).not.toHaveBeenCalled();
+  });
+
+  it('concatenates all text blocks in order and skips non-text blocks', async () => {
+    create.mockResolvedValueOnce({
+      ...response(),
+      content: [
+        { type: 'text', text: 'foo', citations: null },
+        { type: 'tool_use', id: 'tool-1', name: 'ignored', input: {} },
+        { type: 'text', text: 'bar', citations: null },
+      ],
+    });
+
+    const result = await buildExtensionAiContext().invoke(input);
+
+    expect(result.text).toBe('foobar');
+  });
+
+  describe('provider failure classification', () => {
+    it('treats a 429 as a provider-level ExtensionAiError', async () => {
+      create.mockRejectedValueOnce(apiError(429, 'slow down'));
+
+      await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+        name: 'ExtensionAiError',
+        code: 'rate_limited',
+      });
+      expect(recordUsage).not.toHaveBeenCalled();
+      expect(markPartnerLlmError).not.toHaveBeenCalled();
+    });
+
+    it('treats a 500 as a provider-level ExtensionAiError', async () => {
+      create.mockRejectedValueOnce(apiError(503, 'overloaded'));
+
+      await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+        name: 'ExtensionAiError',
+        code: 'ai_unavailable',
+      });
+      expect(markPartnerLlmError).not.toHaveBeenCalled();
+    });
+
+    it('treats a network error (no status) as a provider-level ExtensionAiError', async () => {
+      create.mockRejectedValueOnce(new Error('socket hang up'));
+
+      await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+        name: 'ExtensionAiError',
+        code: 'ai_unavailable',
+        message: 'socket hang up',
+      });
+    });
+
+    it('records a rejected partner credential and raises ai_unavailable on 401', async () => {
+      create.mockRejectedValueOnce(apiError(401, 'invalid x-api-key'));
+
+      await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+        name: 'ExtensionAiError',
+        code: 'ai_unavailable',
+      });
+      expect(markPartnerLlmError).toHaveBeenCalledWith({
+        configId: 'config-1',
+        configVersion: 3,
+        reason: 'auth_rejected',
+      });
+    });
+
+    it('does not mark a partner config when the platform key is rejected', async () => {
+      resolveLlmConfigForOrg.mockResolvedValueOnce(PLATFORM_CONFIG);
+      create.mockRejectedValueOnce(apiError(403, 'forbidden'));
+
+      await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+        name: 'ExtensionAiError',
+        code: 'ai_unavailable',
+      });
+      expect(markPartnerLlmError).not.toHaveBeenCalled();
+    });
+
+    it('rethrows a permanent per-request 4xx unchanged so the caller can fail soft', async () => {
+      const rejection = apiError(400, 'prompt too long');
+      create.mockRejectedValueOnce(rejection);
+
+      const error = await buildExtensionAiContext().invoke(input).catch((caught) => caught);
+
+      expect(error).toBe(rejection);
+      expect(error).not.toBeInstanceOf(ExtensionAiError);
+      expect(recordUsage).not.toHaveBeenCalled();
+      expect(markPartnerLlmError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rate-limit actor', () => {
+    it('uses the org-scoped system limiter for non-user principals', async () => {
+      await buildExtensionAiContext().invoke(systemInput);
+
+      expect(checkSystemAiRateLimit).toHaveBeenCalledWith(ORG_ID);
+      // The per-user bucket is deployment-global for a synthetic actor id: using
+      // it would couple every tenant's automation to one 20/min ceiling.
+      expect(checkAiRateLimit).not.toHaveBeenCalled();
+    });
+
+    it('surfaces a system rate-limit rejection as rate_limited', async () => {
+      checkSystemAiRateLimit.mockResolvedValueOnce('Organization rate limit exceeded');
+
+      await expect(buildExtensionAiContext().invoke(systemInput)).rejects.toMatchObject({
+        name: 'ExtensionAiError',
+        code: 'rate_limited',
+      });
+      expect(create).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/services/extensionAi.ts
+++ b/apps/api/src/services/extensionAi.ts
@@ -1,0 +1,201 @@
+/**
+ * Host-side metered AI capability handed to extensions as `context.ai`.
+ *
+ * The extension never sees an API key: it hands us a prompt and we resolve the
+ * org's provider (partner BYOK or platform), enforce rate limits and budget,
+ * make the call, and record usage BEFORE resolving. Accounting is therefore not
+ * skippable by construction, and there is never a silent fallback from a
+ * partner key to the platform key.
+ */
+import {
+  ExtensionAiError,
+  type ExtensionAiContext,
+  type ExtensionAiInvokeInput,
+} from '@breeze/extension-sdk';
+import {
+  calculateCostCents,
+  checkAiRateLimit,
+  checkBudget,
+  checkSystemAiRateLimit,
+  deductBillingCredits,
+  isPricedModel,
+  recordUsage,
+} from './aiCostTracker';
+import {
+  buildAnthropicClient,
+  LlmOrgResolutionError,
+  markPartnerLlmError,
+  resolveLlmConfigForOrg,
+  type UsableLlmConfig,
+} from './llm/llmConfigResolver';
+
+const EXTENSION_AI_DEFAULT_MODEL = 'claude-haiku-4-5';
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Anthropic APIError carries the HTTP status; anything else is a transport error. */
+function httpStatusOf(error: unknown): number | null {
+  const status = (error as { status?: unknown } | null | undefined)?.status;
+  return typeof status === 'number' ? status : null;
+}
+
+/**
+ * Turn a provider rejection into either an `ExtensionAiError` (which callers
+ * treat as "abort the whole run") or the original error (which callers treat as
+ * a per-request failure they may fail soft on).
+ *
+ * The distinction is load-bearing and was the pre-BYOK behaviour of
+ * `isRetryableApiError` in the workspace enrichment pass: a 429/5xx/network
+ * failure is about the PROVIDER and retrying the batch later is right, while a
+ * 400/404/413/422 is about THIS request (one oversized or malformed document)
+ * and aborting the run over it would drive an ingest job to `failed` on a single
+ * poison file. 401/403 is a credential problem, so it aborts too — and, for a
+ * partner key, is recorded on the config row so the partner's AI settings stop
+ * reporting a key that Anthropic is rejecting.
+ */
+async function classifyProviderFailure(
+  error: unknown,
+  resolved: UsableLlmConfig,
+): Promise<unknown> {
+  const status = httpStatusOf(error);
+
+  if (status === 401 || status === 403) {
+    if (resolved.source === 'partner') {
+      try {
+        await markPartnerLlmError({
+          configId: resolved.configId,
+          configVersion: resolved.configVersion,
+          reason: 'auth_rejected',
+        });
+      } catch (markError) {
+        // Recording the rejection is best-effort: never mask the original cause.
+        console.error('[extension-ai] failed to mark rejected partner credential', {
+          partnerId: resolved.partnerId,
+          error: markError,
+        });
+      }
+    }
+    return new ExtensionAiError('ai_unavailable', errorMessage(error));
+  }
+
+  if (status === 429) {
+    return new ExtensionAiError('rate_limited', errorMessage(error));
+  }
+
+  // Provider-side (5xx) or transport-level (no status: DNS, socket, timeout).
+  if (status === null || status >= 500) {
+    return new ExtensionAiError('ai_unavailable', errorMessage(error));
+  }
+
+  // Any other 4xx is about this one request — hand it back unchanged.
+  return error;
+}
+
+export function buildExtensionAiContext(): ExtensionAiContext {
+  return {
+    async invoke(input: ExtensionAiInvokeInput) {
+      const model = input.model
+        ?? process.env.WORKSPACE_CONTENT_LLM_MODEL
+        ?? EXTENSION_AI_DEFAULT_MODEL;
+      if (!isPricedModel(model)) {
+        throw new ExtensionAiError(
+          'ai_unavailable',
+          `AI model "${model}" is not available for metered extension use.`,
+        );
+      }
+
+      // Resolve through the ORG (not a re-derived partner id): a missing
+      // organization row must abort, never collapse into "no partner" and get
+      // billed to the platform key — the one fallback BYOK forbids.
+      let resolved;
+      try {
+        resolved = await resolveLlmConfigForOrg(input.orgId);
+      } catch (error) {
+        if (error instanceof LlmOrgResolutionError) {
+          throw new ExtensionAiError('ai_unavailable', error.message);
+        }
+        throw error;
+      }
+
+      if (resolved.source === 'unavailable') {
+        // A partner BYOK config exists but is broken (bad key / unreadable
+        // ciphertext). Fail loud for that partner; do NOT serve them platform AI.
+        throw new ExtensionAiError(
+          'ai_unavailable',
+          'AI is unavailable until the partner Anthropic API key is reconnected.',
+        );
+      }
+
+      if (!resolved.apiKey?.trim()) {
+        // No partner key AND no platform key: this deployment simply has no AI.
+        // Distinct code so features degrade (skip the AI step) instead of
+        // retrying a configuration that is never going to appear on its own.
+        throw new ExtensionAiError(
+          'not_configured',
+          'AI is not configured on this deployment.',
+        );
+      }
+
+      const usable: UsableLlmConfig = resolved;
+      const billingSource = usable.source === 'partner' ? 'partner_key' : 'platform';
+
+      const rateLimitError = input.principal.type === 'user' && input.principal.id
+        ? await checkAiRateLimit(input.principal.id, input.orgId)
+        : await checkSystemAiRateLimit(input.orgId);
+      if (rateLimitError) {
+        throw new ExtensionAiError('rate_limited', rateLimitError);
+      }
+
+      const budgetError = await checkBudget(input.orgId, billingSource);
+      if (budgetError) {
+        throw new ExtensionAiError('budget_exceeded', budgetError);
+      }
+
+      const client = buildAnthropicClient(usable);
+      let response: Awaited<ReturnType<typeof client.messages.create>>;
+      try {
+        response = await client.messages.create({
+          model,
+          max_tokens: input.maxTokens,
+          system: input.system,
+          messages: input.messages,
+        });
+      } catch (error) {
+        throw await classifyProviderFailure(error, usable);
+      }
+
+      const text = response.content
+        .filter((block) => block.type === 'text')
+        .map((block) => block.text)
+        .join('');
+      const inputTokens = response.usage?.input_tokens ?? 0;
+      const outputTokens = response.usage?.output_tokens ?? 0;
+
+      await recordUsage(
+        null,
+        input.orgId,
+        model,
+        inputTokens,
+        outputTokens,
+        true,
+        billingSource,
+      );
+      if (billingSource === 'platform') {
+        // recordUsage only moves counters; the prepaid credit balance that
+        // checkBillingCredits gates on is drawn down here (mirrors what
+        // recordUsageFromSdkResult does for the chat path). Partner-key spend is
+        // billed by Anthropic to the partner, so it is deliberately excluded.
+        await deductBillingCredits(input.orgId, calculateCostCents(model, inputTokens, outputTokens));
+      }
+
+      return {
+        text,
+        model,
+        billingSource,
+        usage: { inputTokens, outputTokens },
+      };
+    },
+  };
+}

--- a/apps/api/src/services/llm/llmConfigResolver.ts
+++ b/apps/api/src/services/llm/llmConfigResolver.ts
@@ -232,14 +232,23 @@ export async function getAnthropicClientForPartner(partnerId: string | null): Pr
     });
     throw error;
   }
-  return {
-    client: resolved.source === 'partner'
-      ? new Anthropic({
-          apiKey: resolved.apiKey,
-          authToken: null,
-          baseURL: 'https://api.anthropic.com',
-        })
-      : new Anthropic({ apiKey: resolved.apiKey }),
-    resolved,
-  };
+  return { client: buildAnthropicClient(resolved), resolved };
+}
+
+/**
+ * Construct the Anthropic client for an already-resolved config. The partner
+ * branch pins `baseURL` and clears `authToken` so a partner key can never be
+ * sent through a proxy base URL or alongside an ambient bearer token — that
+ * pinning is a security control, so callers that resolve for themselves
+ * (`resolveLlmConfigForOrg`) MUST come back through here rather than
+ * constructing their own client.
+ */
+export function buildAnthropicClient(resolved: UsableLlmConfig): Anthropic {
+  return resolved.source === 'partner'
+    ? new Anthropic({
+        apiKey: resolved.apiKey,
+        authToken: null,
+        baseURL: 'https://api.anthropic.com',
+      })
+    : new Anthropic({ apiKey: resolved.apiKey });
 }

--- a/apps/docs/src/content/docs/features/bring-your-own-llm-key.mdx
+++ b/apps/docs/src/content/docs/features/bring-your-own-llm-key.mdx
@@ -16,7 +16,7 @@ If both are configured, a partner's BYOK configuration takes precedence. Instanc
 
 When you connect your own Anthropic API key, all AI features for your partner use that key and are billed directly to your Anthropic account. Breeze AI credits are not consumed.
 
-Workspace content enrichment is currently an exception: it continues to use the Breeze platform key.
+Workspace content enrichment also uses your configured AI provider, so it's billed the same way as your other AI features and appears in your AI usage.
 
 ### Requirements
 

--- a/apps/web/src/components/settings/PartnerAiProviderTab.test.tsx
+++ b/apps/web/src/components/settings/PartnerAiProviderTab.test.tsx
@@ -73,9 +73,9 @@ describe('PartnerAiProviderTab', () => {
     // No model select / disconnect until a key is connected.
     expect(screen.queryByTestId('ai-provider-model-select')).toBeNull();
     expect(screen.queryByTestId('ai-provider-disconnect')).toBeNull();
-    // Spec §3 non-goal disclosure is always visible.
+    // Workspace enrichment disclosure is always visible.
     expect(screen.getByTestId('ai-provider-workspace-note').textContent)
-      .toContain('Workspace content enrichment currently uses the platform key');
+      .toContain('Workspace content enrichment uses your configured AI provider and appears in your AI usage');
   });
 
   it('renders the connected state from GET (last4, verified date, model)', async () => {

--- a/apps/web/src/components/settings/PartnerAiProviderTab.tsx
+++ b/apps/web/src/components/settings/PartnerAiProviderTab.tsx
@@ -303,7 +303,7 @@ export default function PartnerAiProviderTab() {
         </>
       )}
 
-      {/* Spec §3 non-goal disclosure: workspace enrichment stays on the platform key. */}
+      {/* Workspace enrichment now routes through the configured provider (platform key or BYOK) and is metered under the caller's usage. */}
       <p className="text-xs text-muted-foreground" data-testid="ai-provider-workspace-note">
         {t('partnerAiProvider.workspaceDisclosure')}
       </p>

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -159,7 +159,7 @@
     "disconnectFailed": "Der Anthropic-Schlüssel konnte nicht getrennt werden.",
     "permissionDenied": "Zum Verwalten des KI-Anbieters sind Abrechnungsberechtigungen und Zugriff auf alle Organisationen erforderlich.",
     "loadFailed": "Die Konfiguration des KI-Anbieters konnte nicht geladen werden.",
-    "workspaceDisclosure": "Die Workspace-Inhaltsanreicherung verwendet derzeit den Plattform-Schlüssel."
+    "workspaceDisclosure": "Die Workspace-Inhaltsanreicherung verwendet Ihren konfigurierten KI-Anbieter und erscheint in Ihrer KI-Nutzung."
   },
   "partnerDefaults": {
     "notSet": "Nicht festgelegt – Organisationen werden individuell konfiguriert",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -159,7 +159,7 @@
     "disconnectFailed": "Could not disconnect the Anthropic key.",
     "permissionDenied": "Managing the AI provider requires billing permissions and access to all organizations.",
     "loadFailed": "Could not load the AI provider configuration.",
-    "workspaceDisclosure": "Workspace content enrichment currently uses the platform key."
+    "workspaceDisclosure": "Workspace content enrichment uses your configured AI provider and appears in your AI usage."
   },
   "partnerDefaults": {
     "notSet": "Not set — orgs configure individually",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -159,7 +159,7 @@
     "disconnectFailed": "No se pudo desconectar la clave de Anthropic.",
     "permissionDenied": "Administrar el proveedor de IA requiere permisos de facturación y acceso a todas las organizaciones.",
     "loadFailed": "No se pudo cargar la configuración del proveedor de IA.",
-    "workspaceDisclosure": "El enriquecimiento de contenido de Workspace actualmente usa la clave de la plataforma."
+    "workspaceDisclosure": "El enriquecimiento de contenido de Workspace usa tu proveedor de IA configurado y aparece en tu uso de IA."
   },
   "partnerDefaults": {
     "notSet": "No configurado: las organizaciones se configuran individualmente",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -159,7 +159,7 @@
     "disconnectFailed": "Impossible de déconnecter la clé Anthropic.",
     "permissionDenied": "La gestion du fournisseur d'IA nécessite des autorisations de facturation et l'accès à toutes les organisations.",
     "loadFailed": "Impossible de charger la configuration du fournisseur d'IA.",
-    "workspaceDisclosure": "L'enrichissement de contenu Workspace utilise actuellement la clé de la plateforme."
+    "workspaceDisclosure": "L'enrichissement de contenu Workspace utilise votre fournisseur d'IA configuré et apparaît dans votre utilisation de l'IA."
   },
   "partnerDefaults": {
     "notSet": "Non défini — les organisations se configurent individuellement",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -159,7 +159,7 @@
     "disconnectFailed": "Impossible de déconnecter la clé Anthropic.",
     "permissionDenied": "La gestion du fournisseur d'IA nécessite des autorisations de facturation et l'accès à toutes les organisations.",
     "loadFailed": "Impossible de charger la configuration du fournisseur d'IA.",
-    "workspaceDisclosure": "L'enrichissement de contenu Workspace utilise actuellement la clé de la plateforme."
+    "workspaceDisclosure": "L'enrichissement de contenu Workspace utilise votre fournisseur d'IA configuré et apparaît dans votre utilisation de l'IA."
   },
   "partnerDefaults": {
     "notSet": "Non défini — les organisations se configurent individuellement",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -159,7 +159,7 @@
     "disconnectFailed": "Impossibile disconnettere la chiave Anthropic.",
     "permissionDenied": "La gestione del provider IA richiede autorizzazioni di fatturazione e l'accesso a tutte le organizzazioni.",
     "loadFailed": "Impossibile caricare la configurazione del provider IA.",
-    "workspaceDisclosure": "L'arricchimento dei contenuti di Workspace attualmente usa la chiave della piattaforma."
+    "workspaceDisclosure": "L'arricchimento dei contenuti di Workspace utilizza il provider IA configurato e appare nel tuo utilizzo IA."
   },
   "partnerDefaults": {
     "notSet": "Non impostato — le org si configurano singolarmente",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -159,7 +159,7 @@
     "disconnectFailed": "Não foi possível desconectar a chave Anthropic.",
     "permissionDenied": "Gerenciar o provedor de IA exige permissões de faturamento e acesso a todas as organizações.",
     "loadFailed": "Não foi possível carregar a configuração do provedor de IA.",
-    "workspaceDisclosure": "O enriquecimento de conteúdo do Workspace atualmente usa a chave da plataforma."
+    "workspaceDisclosure": "O enriquecimento de conteúdo do Workspace usa o provedor de IA configurado e aparece no seu uso de IA."
   },
   "partnerDefaults": {
     "notSet": "Não definido — as organizações configuram individualmente",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -159,7 +159,7 @@
     "disconnectFailed": "Anthropic anahtarının bağlantısı kesilemedi.",
     "permissionDenied": "Yapay zeka sağlayıcısını yönetmek için faturalama izinleri ve tüm kuruluşlara erişim gerekir.",
     "loadFailed": "Yapay zeka sağlayıcısı yapılandırması yüklenemedi.",
-    "workspaceDisclosure": "Workspace içerik zenginleştirme şu anda platform anahtarını kullanıyor."
+    "workspaceDisclosure": "Workspace içerik zenginleştirme, yapılandırdığınız AI sağlayıcısını kullanır ve AI kullanımınızda görünür."
   },
   "partnerDefaults": {
     "notSet": "Ayarlanmadı — kuruluşlar ayrı ayrı yapılandırılır",

--- a/ee/workspace/package.json
+++ b/ee/workspace/package.json
@@ -13,7 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.112.3",
     "@breeze/extension-sdk": "workspace:*",
     "@breeze/extension-web-sdk": "workspace:*",
     "drizzle-orm": "0.45.2",

--- a/ee/workspace/src/__tests__/dlpIngest.integration.test.ts
+++ b/ee/workspace/src/__tests__/dlpIngest.integration.test.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'node:crypto';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import type { WorkspaceDatabase } from '../hostTypes';
 import { createContentIngestService } from '../services/contentIngestService';
-import { createEnrichmentService, type AnthropicLike } from '../services/enrichmentService';
+import { createEnrichmentService, type EnrichmentInvoke } from '../services/enrichmentService';
 import { FakeEmbedder, EMBEDDING_DIM, type Embedder } from '../content/embedder';
 import type { ContentByteReader, ContentSourceRef } from '../content/byteReader';
 
@@ -92,23 +92,17 @@ class CapturingEmbedder implements Embedder {
   }
 }
 
-/** Anthropic-like client that records the user prompt and returns a valid, minimal result. */
-class CapturingAnthropic implements AnthropicLike {
+/** Fake `invoke` that records the user prompt and returns a valid, minimal result. */
+class CapturingInvoke {
   readonly prompts: string[] = [];
-  messages = {
-    create: async (args: unknown): Promise<{ content: Array<{ type: string; text?: string }> }> => {
-      const msgs = (args as { messages?: Array<{ content?: string }> }).messages ?? [];
-      for (const m of msgs) if (typeof m.content === 'string') this.prompts.push(m.content);
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            docType: 'payment record', projectKey: null, projectLabel: null,
-            docDate: null, confidence: 'low', people: [],
-          }),
-        }],
-      };
-    },
+  invoke: EnrichmentInvoke = async (input) => {
+    for (const m of input.messages) this.prompts.push(m.content);
+    return {
+      text: JSON.stringify({
+        docType: 'payment record', projectKey: null, projectLabel: null,
+        docDate: null, confidence: 'low', people: [],
+      }),
+    };
   };
 }
 
@@ -292,12 +286,12 @@ describe('DLP-on-ingest (real DB)', () => {
   });
 
   it('enrichment case: the LLM prompt is built from redacted text, never the raw value', async () => {
-    const client = new CapturingAnthropic();
-    const res = await withOrgTx((db) => createEnrichmentService(db, { client }).run(org, 10));
+    const capturing = new CapturingInvoke();
+    const res = await withOrgTx((db) => createEnrichmentService(db, { invoke: capturing.invoke }).run(org, 10));
     expect(res.errors).toEqual([]);
     // only the redacted (extracted) file is enrichable; the blocked file is not
-    expect(client.prompts.length).toBe(1);
-    const prompt = client.prompts[0];
+    expect(capturing.prompts.length).toBe(1);
+    const prompt = capturing.prompts[0];
     expect(prompt).toContain('[REDACTED:credit_card]');
     expect(prompt).not.toContain('4111');
     expect(prompt).not.toContain(RAW_CARD_DIGITS);

--- a/ee/workspace/src/hostTypes.ts
+++ b/ee/workspace/src/hostTypes.ts
@@ -25,7 +25,10 @@ export type {
   BreezeExtensionV1,
   ExtensionRegistrar,
   ExtensionRuntimeContext,
+  ExtensionAiContext,
+  ExtensionAiInvokeResult,
 } from '@breeze/extension-sdk';
+export { ExtensionAiError } from '@breeze/extension-sdk';
 
 /**
  * The Drizzle handle every Workspace service actually queries through.

--- a/ee/workspace/src/index.ts
+++ b/ee/workspace/src/index.ts
@@ -1,6 +1,10 @@
 import { Hono } from 'hono';
-import Anthropic from '@anthropic-ai/sdk';
-import { asWorkspaceDatabase, type BreezeExtensionV1, type WorkspaceDatabase } from './hostTypes';
+import {
+  asWorkspaceDatabase,
+  type BreezeExtensionV1,
+  type ExtensionAiContext,
+  type WorkspaceDatabase,
+} from './hostTypes';
 import { createAgentRoutes } from './routes/agent';
 import { createContentRoutes } from './routes/content';
 import { createDashboardRoutes } from './routes/dashboard';
@@ -15,7 +19,7 @@ import { createContentIngestService } from './services/contentIngestService';
 import { createContentSearchService } from './services/contentSearchService';
 import { createCrosswalkService } from './services/crosswalkService';
 import { createDashboardService } from './services/dashboardService';
-import { createEnrichmentService, type AnthropicLike } from './services/enrichmentService';
+import { createEnrichmentService } from './services/enrichmentService';
 import { createFilingService } from './services/filingService';
 import { createCrawlRunsService } from './services/crawlRunsService';
 import { createCredentialService } from './services/credentialService';
@@ -27,18 +31,18 @@ import { createSourcesService } from './services/sourcesService';
 import { getOrgSettings } from './services/orgSettingsService';
 
 /**
- * Enrichment needs an Anthropic key; construct lazily and only when the
- * content layer could ever serve it. Absent key → routes answer 503 rather
- * than crashing registration. Import stays dynamic-free: the SDK reads
- * ANTHROPIC_API_KEY from the environment at construction.
+ * Enrichment needs the host's metered `context.ai` capability; construct only
+ * when the host provides one. Absent capability (older host) → routes answer
+ * 503 rather than crashing registration — same no-op shape as the pre-BYOK
+ * missing-ANTHROPIC_API_KEY case this replaces. The host resolves BYOK vs
+ * platform key, meters, and records usage; the extension never sees a key.
  */
 function buildEnrichmentService(
   db: WorkspaceDatabase,
+  ai: ExtensionAiContext | undefined,
 ): ReturnType<typeof createEnrichmentService> | undefined {
-  if (!process.env.ANTHROPIC_API_KEY) return undefined;
-  return createEnrichmentService(db, {
-    client: new Anthropic() as unknown as AnthropicLike,
-  });
+  if (!ai) return undefined;
+  return createEnrichmentService(db, { invoke: ai.invoke });
 }
 
 const workspaceExtension: BreezeExtensionV1 = {
@@ -74,8 +78,8 @@ const workspaceExtension: BreezeExtensionV1 = {
       // the ingest phase exactly the same either way.
       embedder: buildEmbedder(),
     });
-    const enrichmentService = buildEnrichmentService(db);
-    // Enrichment-absent (no ANTHROPIC_API_KEY) must still let the runner
+    const enrichmentService = buildEnrichmentService(db, context.ai);
+    // Enrichment-absent (no context.ai capability) must still let the runner
     // construct and drive a job through: this no-op stand-in reports the
     // enrich phase already drained, so the pipeline advances straight to
     // crosswalk instead of the runner failing to construct at all. The admin

--- a/ee/workspace/src/routes/content.ts
+++ b/ee/workspace/src/routes/content.ts
@@ -161,6 +161,13 @@ export function createContentRoutes(deps: ContentRouteDeps): Hono<WorkspaceRoute
       }
       throw e;
     }
+    if (result.aiUnavailable) {
+      // The run degraded because this deployment has no AI provider (no
+      // platform key, no partner BYOK key). The ingest pipeline treats that as
+      // a drained phase, but a caller who explicitly asked to enrich gets the
+      // same 503 the pre-BYOK missing-credentials guard returned above.
+      return c.json({ error: 'enrichment unavailable (no model credentials configured)' }, 503);
+    }
     await deps.audit({
       actorType: 'user',
       actorId: auth.user.id,

--- a/ee/workspace/src/services/enrichmentService.test.ts
+++ b/ee/workspace/src/services/enrichmentService.test.ts
@@ -167,6 +167,35 @@ describe('run', () => {
     expect(invoke).toHaveBeenCalledTimes(1);
   });
 
+  it('degrades to a drained phase when the deployment has no AI provider at all', async () => {
+    const pending = [
+      { id: 'f1', rel_path: 'a.md', extracted_text: 'text a' },
+      { id: 'f2', rel_path: 'b.md', extracted_text: 'text b' },
+    ];
+    // count(*) answers non-zero so `remaining: 0` can only come from the
+    // short-circuit, never from the fake happening to report a drained queue.
+    const execute = vi.fn(async (query: unknown) => {
+      const text = sqlText(query);
+      if (text.includes('workspace_projects')) return [];
+      if (text.includes('SELECT fi.id, fi.rel_path')) return pending;
+      if (text.includes('count(*)')) return [{ n: 5 }];
+      return [];
+    });
+    const db = { execute } as unknown as WorkspaceDatabase;
+    const invoke: EnrichmentInvoke = vi.fn(async () => {
+      throw new ExtensionAiError('not_configured', 'AI is not configured on this deployment.');
+    });
+    const svc = createEnrichmentService(db, { invoke });
+
+    const result = await svc.run(ORG, 8);
+
+    // No AI configured is the default self-hosted shape, not a failure: report
+    // the phase drained so the ingest job advances to crosswalk instead of
+    // backing off to max_attempts and killing indexing/crosswalk with it.
+    expect(result).toMatchObject({ processed: 0, remaining: 0, errors: [], aiUnavailable: true });
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
   it('still fail-softs a plain Error from invoke into a per-file error, not an abort', async () => {
     const pending = [{ id: 'f1', rel_path: 'a.md', extracted_text: 'text a' }];
     const db = fakeDb(pending);

--- a/ee/workspace/src/services/enrichmentService.test.ts
+++ b/ee/workspace/src/services/enrichmentService.test.ts
@@ -1,20 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
+import { ExtensionAiError } from '@breeze/extension-sdk';
 import type { WorkspaceDatabase } from '../hostTypes';
 import {
-  buildEnrichmentPrompt, createEnrichmentService, extractJson, type AnthropicLike,
+  buildEnrichmentPrompt, createEnrichmentService, extractJson, type EnrichmentInvoke,
 } from './enrichmentService';
 import { TransientIngestError, isTransientIngestError } from './ingestErrors';
 
 const ORG = '11111111-1111-1111-1111-111111111111';
 
-function fakeClient(reply: string | (() => string)): AnthropicLike {
-  return {
-    messages: {
-      create: vi.fn(async () => ({
-        content: [{ type: 'text', text: typeof reply === 'function' ? reply() : reply }],
-      })),
-    },
-  };
+function fakeInvoke(reply: string | (() => string)): EnrichmentInvoke {
+  return vi.fn(async () => ({
+    text: typeof reply === 'function' ? reply() : reply,
+  }));
 }
 
 const GOOD = JSON.stringify({
@@ -57,49 +54,139 @@ describe('classifyOne', () => {
   const db = {} as unknown as WorkspaceDatabase;
 
   it('returns the validated result for well-formed output', async () => {
-    const svc = createEnrichmentService(db, { client: fakeClient(GOOD), model: 'claude-haiku-4-5' });
-    const r = await svc.classifyOne('Projects/x/scan.md', 'text', []);
+    const svc = createEnrichmentService(db, { invoke: fakeInvoke(GOOD) });
+    const r = await svc.classifyOne(ORG, 'Projects/x/scan.md', 'text', []);
     expect(r).toMatchObject({ docType: 'easement deed', projectKey: '2023-041', confidence: 'high' });
     expect(r?.people).toHaveLength(2);
   });
 
+  it('calls invoke with the org id, surface tag, and system principal', async () => {
+    const invoke = fakeInvoke(GOOD);
+    const svc = createEnrichmentService(db, { invoke });
+    await svc.classifyOne(ORG, 'a.md', 'text', []);
+    expect(invoke).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ORG,
+      surface: 'workspace_enrichment',
+      principal: { type: 'system', id: null },
+      maxTokens: 1024,
+    }));
+  });
+
   it('fails soft (null) on malformed JSON', async () => {
-    const svc = createEnrichmentService(db, { client: fakeClient('not json at all') });
-    expect(await svc.classifyOne('a.md', 'text', [])).toBeNull();
+    const svc = createEnrichmentService(db, { invoke: fakeInvoke('not json at all') });
+    expect(await svc.classifyOne(ORG, 'a.md', 'text', [])).toBeNull();
   });
 
   it('fails soft (null) on schema violations', async () => {
     const svc = createEnrichmentService(db, {
-      client: fakeClient(JSON.stringify({ docType: 'x', confidence: 'very sure', people: [] })),
+      invoke: fakeInvoke(JSON.stringify({ docType: 'x', confidence: 'very sure', people: [] })),
     });
-    expect(await svc.classifyOne('a.md', 'text', [])).toBeNull();
+    expect(await svc.classifyOne(ORG, 'a.md', 'text', [])).toBeNull();
   });
 
-  it('fails soft (null) when the client throws a plain (statusless) error', async () => {
-    const client: AnthropicLike = {
-      messages: { create: vi.fn(async () => { throw new Error('rate limited'); }) },
-    };
-    const svc = createEnrichmentService(db, { client });
-    expect(await svc.classifyOne('a.md', 'text', [])).toBeNull();
+  it('fails soft (null) when invoke throws a plain (non-ExtensionAiError) error', async () => {
+    const invoke: EnrichmentInvoke = vi.fn(async () => { throw new Error('boom'); });
+    const svc = createEnrichmentService(db, { invoke });
+    expect(await svc.classifyOne(ORG, 'a.md', 'text', [])).toBeNull();
   });
 
-  function throwingClient(err: unknown): AnthropicLike {
-    return { messages: { create: vi.fn(async () => { throw err; }) } };
+  it('rethrows ExtensionAiError (ai_unavailable) instead of failing soft', async () => {
+    const invoke: EnrichmentInvoke = vi.fn(async () => {
+      throw new ExtensionAiError('ai_unavailable', 'BYOK key invalid');
+    });
+    const svc = createEnrichmentService(db, { invoke });
+    await expect(svc.classifyOne(ORG, 'a.md', 'text', [])).rejects.toThrow(ExtensionAiError);
+  });
+
+  it('rethrows ExtensionAiError (budget_exceeded) instead of failing soft', async () => {
+    const invoke: EnrichmentInvoke = vi.fn(async () => {
+      throw new ExtensionAiError('budget_exceeded', 'org over budget');
+    });
+    const svc = createEnrichmentService(db, { invoke });
+    await expect(svc.classifyOne(ORG, 'a.md', 'text', [])).rejects.toThrow(ExtensionAiError);
+  });
+
+  it('rethrows ExtensionAiError (rate_limited) instead of failing soft', async () => {
+    const invoke: EnrichmentInvoke = vi.fn(async () => {
+      throw new ExtensionAiError('rate_limited', 'too fast');
+    });
+    const svc = createEnrichmentService(db, { invoke });
+    await expect(svc.classifyOne(ORG, 'a.md', 'text', [])).rejects.toThrow(ExtensionAiError);
+  });
+});
+
+describe('run', () => {
+  // A minimal fake WorkspaceDatabase whose `execute` answers the three shapes
+  // run() issues: the project registry select, the pending-files select, and
+  // everything else (per-file insert / remaining count) as empty/zero.
+  /** Drizzle's `sql` tagged template doesn't stringify usefully via String()
+   * — reassemble the literal text from its queryChunks so the fake can match
+   * on the query shape, same as a real driver would see the SQL text. */
+  function sqlText(query: unknown): string {
+    const chunks = (query as { queryChunks?: unknown[] } | null)?.queryChunks;
+    if (!Array.isArray(chunks)) return '';
+    return chunks
+      .map((c) => (c && typeof c === 'object' && 'value' in (c as object)
+        ? (c as { value: string[] }).value.join('')
+        : ''))
+      .join(' ');
   }
 
-  it('rethrows an APIError 429 as TransientIngestError (rate cap backs the job off)', async () => {
-    const svc = createEnrichmentService(db, { client: throwingClient({ status: 429, message: 'rate' }) });
-    await expect(svc.classifyOne('a.md', 'text', [])).rejects.toThrow(TransientIngestError);
-    await expect(svc.classifyOne('a.md', 'text', [])).rejects.toSatisfy(isTransientIngestError);
+  function fakeDb(pending: Array<{ id: string; rel_path: string; extracted_text: string }>) {
+    const execute = vi.fn(async (query: unknown) => {
+      const text = sqlText(query);
+      if (text.includes('workspace_projects')) return [];
+      if (text.includes('SELECT fi.id, fi.rel_path')) return pending;
+      if (text.includes('count(*)')) return [{ n: 0 }];
+      return []; // INSERT INTO workspace_file_enrichment / workspace_content_entities
+    });
+    return { execute } as unknown as WorkspaceDatabase;
+  }
+
+  it('aborts the run when invoke throws ExtensionAiError, wrapping it as TransientIngestError with zero files errored', async () => {
+    const pending = [
+      { id: 'f1', rel_path: 'a.md', extracted_text: 'text a' },
+      { id: 'f2', rel_path: 'b.md', extracted_text: 'text b' },
+    ];
+    const db = fakeDb(pending);
+    const invoke: EnrichmentInvoke = vi.fn(async () => {
+      throw new ExtensionAiError('ai_unavailable', 'BYOK key invalid');
+    });
+    const svc = createEnrichmentService(db, { invoke });
+
+    let caught: unknown;
+    try {
+      await svc.run(ORG, 8);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(TransientIngestError);
+    expect(isTransientIngestError(caught)).toBe(true);
+    expect((caught as Error).message).toContain('ai_unavailable');
+    // Aborted on the first file: only one invoke call, no per-file error rows.
+    expect(invoke).toHaveBeenCalledTimes(1);
   });
 
-  it('rethrows an APIError >= 500 as TransientIngestError (provider outage)', async () => {
-    const svc = createEnrichmentService(db, { client: throwingClient({ status: 503 }) });
-    await expect(svc.classifyOne('a.md', 'text', [])).rejects.toThrow(TransientIngestError);
+  it('still fail-softs a plain Error from invoke into a per-file error, not an abort', async () => {
+    const pending = [{ id: 'f1', rel_path: 'a.md', extracted_text: 'text a' }];
+    const db = fakeDb(pending);
+    const invoke: EnrichmentInvoke = vi.fn(async () => { throw new Error('transient hiccup'); });
+    const svc = createEnrichmentService(db, { invoke });
+
+    const result = await svc.run(ORG, 8);
+    expect(result.processed).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({ fileIndexId: 'f1', relPath: 'a.md' });
   });
 
-  it('keeps fail-soft null for a non-retryable APIError (e.g. 400)', async () => {
-    const svc = createEnrichmentService(db, { client: throwingClient({ status: 400 }) });
-    expect(await svc.classifyOne('a.md', 'text', [])).toBeNull();
+  it('processes a good invoke reply end to end', async () => {
+    const pending = [{ id: 'f1', rel_path: 'a.md', extracted_text: 'text a' }];
+    const db = fakeDb(pending);
+    const invoke = fakeInvoke(GOOD);
+    const svc = createEnrichmentService(db, { invoke });
+
+    const result = await svc.run(ORG, 8);
+    expect(result.processed).toBe(1);
+    expect(result.errors).toHaveLength(0);
   });
 });

--- a/ee/workspace/src/services/enrichmentService.ts
+++ b/ee/workspace/src/services/enrichmentService.ts
@@ -14,7 +14,9 @@
 // file (an LLM hiccup marks the file unenriched, never throws out of the
 // batch) — EXCEPT for provider/billing problems (ExtensionAiError), which
 // must abort the whole run instead of burning every pending file into a
-// silent null-model row. See the `run()` invoke-loop below.
+// silent null-model row. The one ExtensionAiError that does NOT abort is
+// `not_configured` (no provider on this deployment at all): that degrades to a
+// drained phase, since retrying cannot help. See the `run()` invoke-loop below.
 //
 // DLP invariant (W2): this pass never re-runs DLP. It reads
 // workspace_file_content.extracted_text for status='extracted' rows only, and
@@ -165,6 +167,7 @@ export function createEnrichmentService(db: WorkspaceDatabase, deps: EnrichmentD
       processed: number;
       remaining: number;
       errors: Array<{ fileIndexId: string; relPath: string; error: string }>;
+      aiUnavailable?: true;
     }> {
       const projects = (await d.execute(sql`
         SELECT project_key, label FROM workspace_projects
@@ -209,6 +212,16 @@ export function createEnrichmentService(db: WorkspaceDatabase, deps: EnrichmentD
           // with a visible transient_error release; the admin enrich-run route
           // maps the same shape to a 503.
           if (err instanceof ExtensionAiError) {
+            if (err.code === 'not_configured') {
+              // The deployment has no AI provider at all (no platform key, no
+              // partner BYOK key) — the default self-hosted shape, and exactly
+              // what the pre-BYOK missing-ANTHROPIC_API_KEY guard covered by
+              // handing the runner a no-op enrichment service. Report the phase
+              // DRAINED so the ingest job advances to crosswalk. Retrying would
+              // burn all max_attempts and fail the job, taking indexing and
+              // crosswalk down with a feature that was merely absent.
+              return { processed, remaining: 0, errors, aiUnavailable: true };
+            }
             throw new TransientIngestError(
               `AI provider unavailable for this organization: ${err.code}`,
               { cause: err },

--- a/ee/workspace/src/services/enrichmentService.ts
+++ b/ee/workspace/src/services/enrichmentService.ts
@@ -10,9 +10,11 @@
 // may only ADD person/org entities and never touches regex-origin rows.
 //
 // Pattern follows hive's extractor-model/classifier shape: injectable
-// Anthropic-like client, system prompt + JSON extraction + strict Zod,
-// fail-soft per file (an LLM hiccup marks the file unenriched, never throws
-// out of the batch).
+// invoke() call, system prompt + JSON extraction + strict Zod, fail-soft per
+// file (an LLM hiccup marks the file unenriched, never throws out of the
+// batch) — EXCEPT for provider/billing problems (ExtensionAiError), which
+// must abort the whole run instead of burning every pending file into a
+// silent null-model row. See the `run()` invoke-loop below.
 //
 // DLP invariant (W2): this pass never re-runs DLP. It reads
 // workspace_file_content.extracted_text for status='extracted' rows only, and
@@ -20,6 +22,7 @@
 // once, before persistence). DLP-blocked files never reach status='extracted',
 // so they are never enriched. Every enrichment prompt is therefore built from
 // stored, already-redacted text — no raw sensitive value can reach the LLM here.
+import { ExtensionAiError } from '@breeze/extension-sdk';
 import type { WorkspaceDatabase } from '../hostTypes';
 import { sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
@@ -28,26 +31,23 @@ import { deriveDeclaredProject } from '../content/projects';
 import { TransientIngestError } from './ingestErrors';
 
 /**
- * An Anthropic-style APIError we must treat as transient: a 429 (rate cap) or
- * any 5xx (provider outage). These must back the whole ingest job off with
- * retry — NOT fail-soft into a null-model row on every pending file (which would
- * park those files out of the enrichment queue until a manual re-run). Every
- * other failure (bad JSON, schema miss, 4xx, generic error) stays fail-soft.
+ * The host's metered `context.ai.invoke` capability, narrowed to exactly what
+ * enrichment needs. This is intentionally NOT the full `ExtensionAiInvokeInput`
+ * shape — `model` selection (default + WORKSPACE_CONTENT_LLM_MODEL override) is
+ * the host's job, not this call site's; see `run()`'s local `model` constant,
+ * which mirrors that same resolution purely for the recorded DB column.
  */
-function isRetryableApiError(err: unknown): err is { status: number } {
-  const status = (err as { status?: unknown } | null | undefined)?.status;
-  return typeof status === 'number' && (status === 429 || status >= 500);
-}
-
-export interface AnthropicLike {
-  messages: {
-    create: (args: unknown) => Promise<{ content: Array<{ type: string; text?: string }> }>;
-  };
-}
+export type EnrichmentInvoke = (input: {
+  orgId: string;
+  surface: 'workspace_enrichment';
+  principal: { type: 'system'; id: null };
+  system: string;
+  messages: Array<{ role: 'user'; content: string }>;
+  maxTokens: number;
+}) => Promise<{ text: string }>;
 
 export interface EnrichmentDeps {
-  client: AnthropicLike;
-  model?: string;
+  invoke: EnrichmentInvoke;
 }
 
 const DEFAULT_MODEL = 'claude-haiku-4-5';
@@ -123,28 +123,32 @@ interface PendingEnrichmentRow {
 
 export function createEnrichmentService(db: WorkspaceDatabase, deps: EnrichmentDeps) {
   const d = db;
-  const model = deps.model ?? process.env.WORKSPACE_CONTENT_LLM_MODEL ?? DEFAULT_MODEL;
+  // Recorded (not authoritative) model label: mirrors the same env-var/default
+  // resolution the host's invoke() applies, purely for the DB column — the
+  // host is the single source of truth for which model actually ran.
+  const model = process.env.WORKSPACE_CONTENT_LLM_MODEL ?? DEFAULT_MODEL;
 
   async function classifyOne(
+    orgId: string,
     relPath: string,
     text: string,
     projects: Array<{ key: string; label: string }>,
   ): Promise<EnrichmentResult | null> {
     try {
-      const res = await deps.client.messages.create({
-        model,
-        max_tokens: 1024,
+      const result = await deps.invoke({
+        orgId,
+        surface: 'workspace_enrichment',
+        principal: { type: 'system', id: null },
         system: SYSTEM,
         messages: [{ role: 'user', content: buildEnrichmentPrompt({ relPath, text, projects }) }],
+        maxTokens: 1024,
       });
-      const raw = res.content.find((c) => c.type === 'text')?.text ?? '';
-      return resultSchema.parse(extractJson(raw, 'workspace-enrich'));
+      return resultSchema.parse(extractJson(result.text, 'workspace-enrich'));
     } catch (err) {
-      // Rate cap / provider outage must back the job off (the runner releases it
-      // with backoff), not burn a null-model row into every pending file.
-      if (isRetryableApiError(err)) {
-        throw new TransientIngestError(`enrich_provider_${err.status}`, { cause: err });
-      }
+      // Provider/billing problems (broken BYOK key, exhausted budget, rate cap)
+      // must abort the run, not burn a null-model row into every pending file —
+      // rethrow past this fail-soft catch. `run()` wraps it as TransientIngestError.
+      if (err instanceof ExtensionAiError) throw err;
       return null; // fail-soft: an LLM/parse hiccup never breaks the batch
     }
   }
@@ -194,7 +198,24 @@ export function createEnrichmentService(db: WorkspaceDatabase, deps: EnrichmentD
         const declaredLabel = declared
           ? (declared.label ?? projectByKey.get(declared.key) ?? null)
           : null;
-        const result = await classifyOne(file.rel_path, file.extracted_text, projects);
+        let result: EnrichmentResult | null;
+        try {
+          result = await classifyOne(orgId, file.rel_path, file.extracted_text, projects);
+        } catch (err) {
+          // ExtensionAiError escaped classifyOne's fail-soft catch on purpose
+          // (broken BYOK key / exhausted budget / provider rate cap): abort the
+          // whole run rather than mark the rest of the batch as per-file errors.
+          // The ingest runner's isTransientIngestError catch backs the job off
+          // with a visible transient_error release; the admin enrich-run route
+          // maps the same shape to a 503.
+          if (err instanceof ExtensionAiError) {
+            throw new TransientIngestError(
+              `AI provider unavailable for this organization: ${err.code}`,
+              { cause: err },
+            );
+          }
+          throw err;
+        }
         const inferredKey = result?.projectKey ?? null;
         const inferredLabel = result?.projectLabel
           ?? (inferredKey ? projectByKey.get(inferredKey) ?? null : null);

--- a/ee/workspace/src/services/ingestJobRunner.ts
+++ b/ee/workspace/src/services/ingestJobRunner.ts
@@ -33,6 +33,13 @@ export interface EnrichRunResult {
   processed: number;
   remaining: number;
   errors: Array<{ fileIndexId: string; relPath: string; error: string }>;
+  /**
+   * Set when the run stopped because the deployment has no AI provider at all.
+   * `remaining` is reported as 0 so this phase drains and the job advances; the
+   * flag exists so a caller that asked for enrichment EXPLICITLY (the admin
+   * enrich-run route) can still answer honestly instead of "0 files, all done".
+   */
+  aiUnavailable?: true;
 }
 
 export interface AdvanceResult {

--- a/packages/extension-sdk/src/server.test.ts
+++ b/packages/extension-sdk/src/server.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { ExtensionAiError } from './server';
+
+describe('ExtensionAiError', () => {
+  it('carries the error code, message, and name for extensions to branch on', () => {
+    const err = new ExtensionAiError('budget_exceeded', 'org budget exhausted');
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe('budget_exceeded');
+    expect(err.message).toBe('org budget exhausted');
+    expect(err.name).toBe('ExtensionAiError');
+  });
+});

--- a/packages/extension-sdk/src/server.ts
+++ b/packages/extension-sdk/src/server.ts
@@ -19,8 +19,21 @@ export interface ExtensionRegistrar {
   registerAiTool(name: string, tool: ExtensionAiTool): void;
 }
 
-/** Outcome codes an extension can branch on. Anything else is an unexpected error. */
-export type ExtensionAiErrorCode = 'ai_unavailable' | 'budget_exceeded' | 'rate_limited';
+/**
+ * Outcome codes an extension can branch on. Anything else is an unexpected error.
+ *
+ * `not_configured` is deliberately distinct from `ai_unavailable`: it means the
+ * deployment has no AI provider at all (no platform key, no partner BYOK key) —
+ * the normal self-hosted shape — so a feature should DEGRADE (skip the AI step)
+ * rather than fail and retry. `ai_unavailable` means a provider was configured
+ * but is not usable right now (broken/rejected BYOK key, provider outage), which
+ * must stay visible instead of silently falling back to another billing source.
+ */
+export type ExtensionAiErrorCode =
+  | 'ai_unavailable'
+  | 'not_configured'
+  | 'budget_exceeded'
+  | 'rate_limited';
 
 export class ExtensionAiError extends Error {
   constructor(

--- a/packages/extension-sdk/src/server.ts
+++ b/packages/extension-sdk/src/server.ts
@@ -19,6 +19,49 @@ export interface ExtensionRegistrar {
   registerAiTool(name: string, tool: ExtensionAiTool): void;
 }
 
+/** Outcome codes an extension can branch on. Anything else is an unexpected error. */
+export type ExtensionAiErrorCode = 'ai_unavailable' | 'budget_exceeded' | 'rate_limited';
+
+export class ExtensionAiError extends Error {
+  constructor(
+    public readonly code: ExtensionAiErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ExtensionAiError';
+  }
+}
+
+export interface ExtensionAiInvokeInput {
+  orgId: string;
+  /** Stable surface tag for audit/cost attribution, e.g. 'workspace_enrichment'. */
+  surface: string;
+  /** Acting principal, for rate limiting + audit. 'system' for host-triggered runs. */
+  principal: { type: 'user' | 'agent' | 'system'; id: string | null };
+  system?: string;
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>;
+  maxTokens: number;
+  /** Optional model override; must be a platform-priced model id. Host default applies when omitted. */
+  model?: string;
+}
+
+export interface ExtensionAiInvokeResult {
+  text: string; // concatenated text blocks of the response
+  model: string;
+  billingSource: 'platform' | 'partner_key';
+  usage: { inputTokens: number; outputTokens: number };
+}
+
+export interface ExtensionAiContext {
+  /**
+   * Metered LLM call: the host resolves the org's provider (partner BYOK or
+   * platform), enforces rate limits and org budget, performs the call, and
+   * records usage BEFORE resolving. Throws ExtensionAiError for expected
+   * failure modes; never falls back across billing sources.
+   */
+  invoke(input: ExtensionAiInvokeInput): Promise<ExtensionAiInvokeResult>;
+}
+
 export interface ExtensionRuntimeContext {
   db: Record<string, unknown> & { execute(query: unknown): Promise<unknown> };
   secrets: {
@@ -41,6 +84,8 @@ export interface ExtensionRuntimeContext {
      */
     installedOrgs(): Promise<string[]>;
   };
+  /** Optional metered LLM invocation capability — older hosts may not provide it. */
+  ai?: ExtensionAiContext;
 }
 
 export interface BreezeExtensionV1 {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1188,9 +1188,6 @@ importers:
 
   ee/workspace:
     dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.112.3
-        version: 0.112.5(zod@4.4.3)
       '@breeze/extension-sdk':
         specifier: workspace:*
         version: link:../../packages/extension-sdk
@@ -1429,15 +1426,6 @@ packages:
       '@anthropic-ai/sdk': '>=0.93.0'
       '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
-
-  '@anthropic-ai/sdk@0.112.5':
-    resolution: {integrity: sha512-FaaGkyS4/zW4n+8Pr9jQkyo5zWcBNw+R+heCLXdoKDUEuALbPALBk6zLAlmsU+veREiaATxVG0TwkK/cQ3NZsQ==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@anthropic-ai/sdk@0.115.0':
     resolution: {integrity: sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==}
@@ -12241,13 +12229,6 @@ snapshots:
       '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.181
       '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.181
 
-  '@anthropic-ai/sdk@0.112.5(zod@4.4.3)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-      standardwebhooks: 1.0.0
-    optionalDependencies:
-      zod: 4.4.3
-
   '@anthropic-ai/sdk@0.115.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -17661,7 +17642,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 4.0.5
+      picomatch: 4.0.4
 
   anynum@1.0.1: {}
 


### PR DESCRIPTION
## Summary

Workspace content enrichment (`ee/workspace`) now honors a partner's BYOK LLM configuration instead of always calling the platform Anthropic key, and gets cost tracking it never had. This replaces the phase-1 "always platform key, disclosed exception" carve-out from #3228.

- **`packages/extension-sdk`**: adds an optional metered AI invocation capability on `ExtensionRuntimeContext` (`context.ai.invoke(...)`) — `ExtensionAiError`, `ExtensionAiInvokeInput`/`Result` types. Interface-only, no new deps.
- **`apps/api`**: host-side implementation (`services/extensionAi.ts`) resolves the org's provider via `resolveLlmConfigForOrg` (partner BYOK or platform), enforces rate limits and budget, performs the Anthropic call, and awaits usage recording with the correct `billing_source` before returning only the text — the API key never crosses the extension boundary, and accounting can't be skipped by construction. Wired into `stageExtension.ts`.
- **`ee/workspace`**: drops the boot-time `new Anthropic()` singleton; `enrichmentService` threads `invoke` through instead of holding a client. A typed `ExtensionAiError` aborts the run (via `TransientIngestError`) rather than being swallowed by the per-file fail-soft catch — a broken BYOK config now gets a visible enrichment failure, never a silent fallback to the platform key.
- **`apps/api` integration test**: proves a BYOK partner's enrichment run records `billing_source='partner_key'` usage, and that a broken partner key produces zero platform-key usage rows (the fallback-forbidden assertion).
- **`apps/web` + docs**: retires the static "workspace uses the platform key" disclosure copy in favor of "uses your configured AI provider and appears in your AI usage," across all locales; docs updated to match.

## Review round (10 findings)

A code review pass surfaced 10 findings, all resolved before this PR:

1. **Task 2 was never actually committed on the prior branch state** — `stageExtension.ts` never set `context.ai`, so enrichment was permanently disabled and the integration suite failed at import. Committed for real this round.
2. Resolve through `resolveLlmConfigForOrg` instead of re-deriving the partner id — a missing organization row now aborts instead of collapsing into "no partner" and silently billing the platform key.
3. New `not_configured` error code distinguishing "no platform key and no partner key configured" (the default self-host shape — enrichment degrades gracefully, 503 on the explicit admin route) from a **broken** partner key (still fails loud, no silent fallback).
4. Provider-failure classification restored: 429/5xx/transport errors abort the run; 401/403 abort and mark the partner config `auth_rejected`; any other 4xx rethrows unchanged so one poison file fails soft per-file instead of failing the whole job.
5. System-principal calls now use a new org-scoped `checkSystemAiRateLimit` instead of a synthetic per-surface actor sharing one deployment-global `ai:msg:user:*` 20/min bucket across every tenant's automation.
6. Platform-funded extension spend now draws down prepaid AI credits via `recordUsage` (previously never did), so `checkBillingCredits` no longer sees a stale balance. Partner-key spend is deliberately excluded from credit draw-down.
7. The "recordUsage is awaited before invoke resolves" test was hardened to be discriminating by construction (deferred-promise based) — verified by mutation testing (`void recordUsage` now fails it).
8. `classifyOne`'s per-file fail-soft catch rethrows `ExtensionAiError` (all three/four codes) instead of swallowing it into per-file error noise.
9. `enrichmentService.run` maps `ExtensionAiError` to workspace's `TransientIngestError` so `ingestJobRunner`'s existing transient-error back-off path (not a fatal job failure) picks it up — the partner can fix their key and the job resumes.
10. Locale parity swept across all locale files for the renamed disclosure string, not just `en`.

## Test plan

- [x] `packages/extension-sdk`: `npx tsc --noEmit` — clean
- [x] `apps/api`: `npx vitest run src/services/extensionAi.test.ts` — 18 passed
- [x] `ee/workspace`: `npx vitest run src/services/enrichmentService.test.ts src/services/ingestJobRunner.test.ts` — 27 passed
- [x] `apps/web`: `npx vitest run src/lib/i18n/localeParity.test.ts` — 79 passed
- [ ] Integration test (`apps/api/src/__tests__/integration/workspaceEnrichmentByok.integration.test.ts`) needs a live Postgres to confirm in CI's Integration Tests job — verify it actually RAN in the shard log, not just present in the tree.

Closes #3917

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A592m7suBriiYsU6owVX61
