### PR TITLE
feat(web): org lifecycle wave 3 — merge UI

### DIFF
--- a/apps/web/src/components/settings/MergeOrgModal.test.tsx
+++ b/apps/web/src/components/settings/MergeOrgModal.test.tsx
@@ -338,6 +338,74 @@ describe('MergeOrgModal — submit + progress', () => {
     expect(onMerged).not.toHaveBeenCalled();
   });
 
+  it('drops a merge POST response that resolves after unmount (no phase change, no polling, no onMerged)', async () => {
+    vi.useFakeTimers();
+    const onMerged = vi.fn();
+    let releaseMerge: ((body: unknown, status?: number) => void) | undefined;
+    let pollCalls = 0;
+    fetchMock.mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (init?.method === 'POST' && url.endsWith('/merge-preview')) return jsonResponse(PREVIEW_OK);
+      if (init?.method === 'POST' && /\/organizations\/[^/]+\/merge$/.test(url)) {
+        // The merge POST itself never resolves until the test releases it —
+        // this is the path finding #3's re-review flagged: `startPolling`
+        // mints a FRESH token on every call, so if this resolves after
+        // unmount, the poll-token guard (proven above) never even gets a
+        // chance to catch it — the fix has to stop it before that.
+        return new Promise<Response>((resolve) => {
+          releaseMerge = (body: unknown, status = 202) => resolve(jsonResponse(body, status < 400, status));
+        });
+      }
+      if (url.includes('/merge-runs/')) {
+        pollCalls += 1;
+        return jsonResponse({ state: 'active' });
+      }
+      return jsonResponse({});
+    });
+
+    const { unmount } = render(
+      <MergeOrgModal
+        loserOrg={LOSER}
+        orgs={ALL_ORGS}
+        onClose={vi.fn()}
+        onMerged={onMerged}
+        onDoneClose={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    fireEvent.change(screen.getByTestId('org-merge-confirm-input'), { target: { value: LOSER.name } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('org-merge-submit'));
+      await vi.advanceTimersByTimeAsync(0); // the merge POST itself is held pending
+    });
+
+    // Still on the pick phase — the POST hasn't resolved yet.
+    expect(screen.getByTestId('org-merge-survivor-select')).toBeInTheDocument();
+    expect(releaseMerge).toBeTruthy();
+    expect(pollCalls).toBe(0);
+
+    unmount();
+
+    await act(async () => {
+      releaseMerge!({ jobId: 'job-1' }, 202);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // No phase transition to 'progress' happened — proven by the fact that
+    // startPolling (and therefore pollJob) never ran at all, even after
+    // advancing well past a poll interval.
+    expect(pollCalls).toBe(0);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MERGE_POLL_INTERVAL_MS * 3);
+    });
+    expect(pollCalls).toBe(0);
+    expect(onMerged).not.toHaveBeenCalled();
+  });
+
   it('treats a completed run with no result as a failure, not a fabricated zero-row summary', async () => {
     vi.useFakeTimers();
     const onMerged = vi.fn();

--- a/apps/web/src/components/settings/MergeOrgModal.test.tsx
+++ b/apps/web/src/components/settings/MergeOrgModal.test.tsx
@@ -1,0 +1,353 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MergeOrgModal, { MERGE_POLL_INTERVAL_MS } from './MergeOrgModal';
+import type { Organization } from './OrganizationList';
+import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  handleSessionExpired: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const sessionExpiredMock = vi.mocked(handleSessionExpired);
+const toastMock = vi.mocked(showToast);
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERROR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const LOSER: Organization = {
+  id: 'loser-1111-1111-1111-111111111111',
+  name: 'Acme Legacy',
+  status: 'active',
+  deviceCount: 3,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+const SURVIVOR: Organization = {
+  id: 'survivor-2222-2222-2222-222222222222',
+  name: 'Acme Corp',
+  status: 'active',
+  deviceCount: 40,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+const TRIAL_ORG: Organization = {
+  id: 'trial-3333-3333-3333-333333333333',
+  name: 'Trial Co',
+  status: 'trial',
+  deviceCount: 1,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+const SUSPENDED_ORG: Organization = {
+  id: 'suspended-4444-4444-4444-444444444444',
+  name: 'Suspended Co',
+  status: 'suspended',
+  deviceCount: 1,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+const QUICK_SUPPORT_ORG: Organization = {
+  id: 'qs-5555-5555-5555-555555555555',
+  name: 'Quick Support',
+  status: 'active',
+  type: 'quick_support',
+  deviceCount: 0,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+const ALL_ORGS = [LOSER, SURVIVOR, TRIAL_ORG, SUSPENDED_ORG, QUICK_SUPPORT_ORG];
+
+const PREVIEW_OK = {
+  tables: [
+    { table: 'devices', policy: 'repoint-dedupe', loserRows: 12, wouldDrop: 0 },
+    { table: 'alerts', policy: 'keep-survivor', loserRows: 4, wouldDrop: 1 },
+  ],
+  totalMovableRows: 16,
+  verdict: 'ok' as const,
+  warnings: [
+    'this merge will REVOKE 1 live API key belonging to the merged-away organization',
+    "the merged-away organization's audit and provenance trail is PERMANENTLY DESTROYED by this merge",
+  ],
+};
+
+const PREVIEW_TOO_LARGE = {
+  tables: [],
+  totalMovableRows: 999999,
+  verdict: 'too-large' as const,
+  warnings: [],
+};
+
+interface MergeResponse {
+  payload: unknown;
+  status?: number;
+}
+
+function routeFetch(handlers: {
+  preview?: (body: unknown) => unknown;
+  merge?: (body: unknown) => MergeResponse;
+  poll?: (jobId: string) => unknown;
+}) {
+  fetchMock.mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    if (init?.method === 'POST' && url.endsWith('/merge-preview')) {
+      const body = JSON.parse(String(init.body));
+      return jsonResponse(handlers.preview?.(body) ?? PREVIEW_OK);
+    }
+    if (init?.method === 'POST' && /\/organizations\/[^/]+\/merge$/.test(url)) {
+      const body = JSON.parse(String(init.body));
+      const { payload, status = 202 } = handlers.merge?.(body) ?? { payload: { jobId: 'job-1' } };
+      return jsonResponse(payload, status < 400, status);
+    }
+    if (url.includes('/merge-runs/')) {
+      const jobId = url.split('/merge-runs/')[1];
+      return jsonResponse(handlers.poll?.(jobId) ?? { state: 'active' });
+    }
+    return jsonResponse({});
+  });
+}
+
+async function selectSurvivorAndTypeName() {
+  fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
+  await waitFor(() => screen.getByTestId('org-merge-confirm-input'));
+  fireEvent.change(screen.getByTestId('org-merge-confirm-input'), { target: { value: LOSER.name } });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  sessionExpiredMock.mockReset();
+  toastMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('MergeOrgModal — survivor picker', () => {
+  it('excludes the loser, quick_support orgs, and non-active/trial orgs', () => {
+    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} />);
+
+    const select = screen.getByTestId('org-merge-survivor-select');
+    const optionNames = within(select)
+      .getAllByRole('option')
+      .map((o) => o.textContent);
+
+    expect(optionNames).toContain('Acme Corp');
+    expect(optionNames).toContain('Trial Co');
+    expect(optionNames).not.toContain('Acme Legacy'); // the loser itself
+    expect(optionNames).not.toContain('Suspended Co');
+    expect(optionNames).not.toContain('Quick Support');
+  });
+});
+
+describe('MergeOrgModal — preview', () => {
+  it('fetches and renders the preview on survivor selection', async () => {
+    routeFetch({});
+    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} />);
+
+    fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
+
+    await waitFor(() => expect(screen.getByTestId('org-merge-total-rows')).toHaveTextContent('16'));
+    expect(within(screen.getByTestId('org-merge-tables-list')).getAllByRole('listitem')).toHaveLength(2);
+    for (const warning of PREVIEW_OK.warnings) {
+      expect(screen.getByText(warning)).toBeInTheDocument();
+    }
+
+    const previewCall = fetchMock.mock.calls.find(([url]) => String(url).endsWith('/merge-preview'));
+    expect(previewCall).toBeTruthy();
+    expect(String(previewCall![0])).toContain(LOSER.id);
+    expect(JSON.parse(String((previewCall![1] as RequestInit).body))).toEqual({ survivorId: SURVIVOR.id });
+  });
+
+  it('disables the confirm path and shows refusal copy on a too-large verdict', async () => {
+    routeFetch({ preview: () => PREVIEW_TOO_LARGE });
+    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} />);
+
+    fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
+
+    await waitFor(() => expect(screen.getByTestId('org-merge-too-large')).toBeInTheDocument());
+    expect(screen.queryByTestId('org-merge-confirm-input')).not.toBeInTheDocument();
+    expect(screen.getByTestId('org-merge-submit')).toBeDisabled();
+  });
+});
+
+describe('MergeOrgModal — typed-name confirmation', () => {
+  it('keeps the confirm button disabled until the typed name matches exactly (case-sensitive)', async () => {
+    routeFetch({});
+    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} />);
+    fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
+    await waitFor(() => screen.getByTestId('org-merge-confirm-input'));
+
+    const submit = screen.getByTestId('org-merge-submit');
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('org-merge-confirm-input'), { target: { value: 'acme legacy' } });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('org-merge-confirm-input'), { target: { value: LOSER.name } });
+    expect(submit).not.toBeDisabled();
+  });
+});
+
+describe('MergeOrgModal — submit + progress', () => {
+  it('POSTs the merge with {survivorId, confirmName}, polls until completed, renders the result, and calls onMerged', async () => {
+    vi.useFakeTimers();
+    const onMerged = vi.fn();
+    let pollCalls = 0;
+    routeFetch({
+      poll: () => {
+        pollCalls += 1;
+        return pollCalls < 2
+          ? { state: 'active' }
+          : {
+              state: 'completed',
+              result: {
+                tables: { devices: { moved: 12, dropped: 0 }, alerts: { moved: 3, dropped: 1 } },
+                warnings: ['w1'],
+                mergeEventId: 'evt-1',
+              },
+            };
+      },
+    });
+
+    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={onMerged} />);
+    fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    fireEvent.change(screen.getByTestId('org-merge-confirm-input'), { target: { value: LOSER.name } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('org-merge-submit'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const mergeCall = fetchMock.mock.calls.find(
+      ([url, init]) => /\/organizations\/[^/]+\/merge$/.test(String(url)) && (init as RequestInit)?.method === 'POST',
+    );
+    expect(mergeCall).toBeTruthy();
+    expect(JSON.parse(String((mergeCall![1] as RequestInit).body))).toEqual({
+      survivorId: SURVIVOR.id,
+      confirmName: LOSER.name,
+    });
+    expect(screen.getByTestId('org-merge-progress')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MERGE_POLL_INTERVAL_MS);
+    });
+
+    expect(screen.getByTestId('org-merge-done')).toBeInTheDocument();
+    const summary = screen.getByTestId('org-merge-result-summary');
+    expect(summary).toHaveTextContent('15');
+    expect(summary).toHaveTextContent('1');
+    expect(screen.getByText('w1')).toBeInTheDocument();
+    expect(onMerged).toHaveBeenCalledWith(LOSER.id);
+  });
+
+  it('stops polling on unmount', async () => {
+    vi.useFakeTimers();
+    let pollCalls = 0;
+    routeFetch({
+      poll: () => {
+        pollCalls += 1;
+        return { state: 'active' };
+      },
+    });
+
+    const { unmount } = render(
+      <MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} />,
+    );
+    fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    fireEvent.change(screen.getByTestId('org-merge-confirm-input'), { target: { value: LOSER.name } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('org-merge-submit'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const callsSoFar = pollCalls;
+    expect(callsSoFar).toBeGreaterThan(0);
+
+    unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MERGE_POLL_INTERVAL_MS * 3);
+    });
+    expect(pollCalls).toBe(callsSoFar);
+  });
+
+  it('renders failedReason on a failed run and retries by re-POSTing merge', async () => {
+    vi.useFakeTimers();
+    let mergeCalls = 0;
+    const job2PollCounts: number[] = [];
+    routeFetch({
+      merge: () => {
+        mergeCalls += 1;
+        return { payload: { jobId: `job-${mergeCalls}` } };
+      },
+      poll: (jobId) => {
+        if (jobId === 'job-1') return { state: 'failed', failedReason: 'boom' };
+        job2PollCounts.push(1);
+        return job2PollCounts.length < 2
+          ? { state: 'active' }
+          : { state: 'completed', result: { tables: {}, warnings: [], mergeEventId: 'evt-2' } };
+      },
+    });
+
+    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} />);
+    fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    fireEvent.change(screen.getByTestId('org-merge-confirm-input'), { target: { value: LOSER.name } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('org-merge-submit'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByTestId('org-merge-failed')).toBeInTheDocument();
+    expect(screen.getByTestId('org-merge-failed-reason')).toHaveTextContent('boom');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('org-merge-retry'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mergeCalls).toBe(2);
+    expect(screen.getByTestId('org-merge-progress')).toBeInTheDocument();
+  });
+});
+
+describe('MergeOrgModal — server-side confirmName mismatch', () => {
+  it('surfaces the 400 error without closing the modal', async () => {
+    const onClose = vi.fn();
+    routeFetch({
+      merge: () => ({
+        payload: { error: 'confirmName does not match the organization being merged away' },
+        status: 400,
+      }),
+    });
+    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={onClose} onMerged={vi.fn()} />);
+    await selectSurvivorAndTypeName();
+
+    fireEvent.click(screen.getByTestId('org-merge-submit'));
+
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          message: expect.stringContaining('confirmName does not match'),
+        }),
+      ),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId('org-merge-survivor-select')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/MergeOrgModal.test.tsx
+++ b/apps/web/src/components/settings/MergeOrgModal.test.tsx
@@ -80,7 +80,7 @@ const PREVIEW_TOO_LARGE = {
   tables: [],
   totalMovableRows: 999999,
   verdict: 'too-large' as const,
-  warnings: [],
+  warnings: ['this merge will REVOKE 3 live API keys belonging to the merged-away organization'],
 };
 
 interface MergeResponse {
@@ -130,7 +130,9 @@ afterEach(() => {
 
 describe('MergeOrgModal — survivor picker', () => {
   it('excludes the loser, quick_support orgs, and non-active/trial orgs', () => {
-    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} />);
+    render(
+      <MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} onDoneClose={vi.fn()} />,
+    );
 
     const select = screen.getByTestId('org-merge-survivor-select');
     const optionNames = within(select)
@@ -148,7 +150,9 @@ describe('MergeOrgModal — survivor picker', () => {
 describe('MergeOrgModal — preview', () => {
   it('fetches and renders the preview on survivor selection', async () => {
     routeFetch({});
-    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} />);
+    render(
+      <MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} onDoneClose={vi.fn()} />,
+    );
 
     fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
 
@@ -166,20 +170,31 @@ describe('MergeOrgModal — preview', () => {
 
   it('disables the confirm path and shows refusal copy on a too-large verdict', async () => {
     routeFetch({ preview: () => PREVIEW_TOO_LARGE });
-    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} />);
+    render(
+      <MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} onDoneClose={vi.fn()} />,
+    );
 
     fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
 
     await waitFor(() => expect(screen.getByTestId('org-merge-too-large')).toBeInTheDocument());
     expect(screen.queryByTestId('org-merge-confirm-input')).not.toBeInTheDocument();
     expect(screen.getByTestId('org-merge-submit')).toBeDisabled();
+    // Warnings (audit-trail destruction, key revocation, ...) must still be
+    // visible on a too-large refusal — a self-hosted operator raising the
+    // row limit and retrying, or a partner deciding whether to contact
+    // support, still needs to see what's at stake.
+    for (const warning of PREVIEW_TOO_LARGE.warnings) {
+      expect(screen.getByText(warning)).toBeInTheDocument();
+    }
   });
 });
 
 describe('MergeOrgModal — typed-name confirmation', () => {
   it('keeps the confirm button disabled until the typed name matches exactly (case-sensitive)', async () => {
     routeFetch({});
-    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} />);
+    render(
+      <MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} onDoneClose={vi.fn()} />,
+    );
     fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
     await waitFor(() => screen.getByTestId('org-merge-confirm-input'));
 
@@ -215,7 +230,9 @@ describe('MergeOrgModal — submit + progress', () => {
       },
     });
 
-    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={onMerged} />);
+    render(
+      <MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={onMerged} onDoneClose={vi.fn()} />,
+    );
     fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
@@ -249,18 +266,95 @@ describe('MergeOrgModal — submit + progress', () => {
     expect(onMerged).toHaveBeenCalledWith(LOSER.id);
   });
 
-  it('stops polling on unmount', async () => {
+  it('stops polling on unmount and drops an in-flight poll response that resolves after unmount', async () => {
     vi.useFakeTimers();
+    const onMerged = vi.fn();
     let pollCalls = 0;
-    routeFetch({
-      poll: () => {
+    let releaseSecondPoll: ((body: unknown) => void) | undefined;
+    fetchMock.mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (init?.method === 'POST' && url.endsWith('/merge-preview')) return jsonResponse(PREVIEW_OK);
+      if (init?.method === 'POST' && /\/organizations\/[^/]+\/merge$/.test(url)) {
+        return jsonResponse({ jobId: 'job-1' }, true, 202);
+      }
+      if (url.includes('/merge-runs/')) {
         pollCalls += 1;
-        return { state: 'active' };
-      },
+        if (pollCalls === 1) return jsonResponse({ state: 'active' }); // proves ticking actually happens
+        // The SECOND tick — the one that fires while unmounting is racing
+        // it — is held open so the test can resolve it once the component is
+        // already gone.
+        return new Promise<Response>((resolve) => {
+          releaseSecondPoll = (body: unknown) => resolve(jsonResponse(body));
+        });
+      }
+      return jsonResponse({});
     });
 
     const { unmount } = render(
-      <MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} />,
+      <MergeOrgModal
+        loserOrg={LOSER}
+        orgs={ALL_ORGS}
+        onClose={vi.fn()}
+        onMerged={onMerged}
+        onDoneClose={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    fireEvent.change(screen.getByTestId('org-merge-confirm-input'), { target: { value: LOSER.name } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('org-merge-submit'));
+      await vi.advanceTimersByTimeAsync(0); // the immediate first poll: 'active'
+    });
+    expect(pollCalls).toBe(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MERGE_POLL_INTERVAL_MS); // the second, scheduled tick
+    });
+    expect(pollCalls).toBe(2);
+    expect(releaseSecondPoll).toBeTruthy();
+
+    unmount();
+
+    // No further ticks are ever scheduled post-unmount...
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MERGE_POLL_INTERVAL_MS * 3);
+    });
+    expect(pollCalls).toBe(2);
+
+    // ...and the already-in-flight second request, resolved only now (with a
+    // genuine completed+result payload that WOULD otherwise finish the
+    // merge), must be recognized as stale and dropped rather than updating
+    // state on an unmounted component or firing onMerged late.
+    await act(async () => {
+      releaseSecondPoll!({
+        state: 'completed',
+        result: { tables: { devices: { moved: 1, dropped: 0 } }, warnings: [], mergeEventId: 'evt-late' },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(onMerged).not.toHaveBeenCalled();
+  });
+
+  it('treats a completed run with no result as a failure, not a fabricated zero-row summary', async () => {
+    vi.useFakeTimers();
+    const onMerged = vi.fn();
+    routeFetch({
+      // A `completed` state with no `result` payload at all — a contract
+      // violation the UI must not paper over by inventing a done summary.
+      poll: () => ({ state: 'completed' }),
+    });
+
+    render(
+      <MergeOrgModal
+        loserOrg={LOSER}
+        orgs={ALL_ORGS}
+        onClose={vi.fn()}
+        onMerged={onMerged}
+        onDoneClose={vi.fn()}
+      />,
     );
     fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
     await act(async () => {
@@ -272,14 +366,11 @@ describe('MergeOrgModal — submit + progress', () => {
       await vi.advanceTimersByTimeAsync(0);
     });
 
-    const callsSoFar = pollCalls;
-    expect(callsSoFar).toBeGreaterThan(0);
-
-    unmount();
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(MERGE_POLL_INTERVAL_MS * 3);
-    });
-    expect(pollCalls).toBe(callsSoFar);
+    expect(screen.getByTestId('org-merge-failed')).toBeInTheDocument();
+    expect(screen.queryByTestId('org-merge-done')).not.toBeInTheDocument();
+    expect(screen.getByTestId('org-merge-failed-reason')).toHaveTextContent('returned no result data');
+    expect(screen.getByTestId('org-merge-retry')).toBeInTheDocument();
+    expect(onMerged).not.toHaveBeenCalled();
   });
 
   it('renders failedReason on a failed run and retries by re-POSTing merge', async () => {
@@ -300,7 +391,9 @@ describe('MergeOrgModal — submit + progress', () => {
       },
     });
 
-    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} />);
+    render(
+      <MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={vi.fn()} onMerged={vi.fn()} onDoneClose={vi.fn()} />,
+    );
     fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
@@ -334,7 +427,9 @@ describe('MergeOrgModal — server-side confirmName mismatch', () => {
         status: 400,
       }),
     });
-    render(<MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={onClose} onMerged={vi.fn()} />);
+    render(
+      <MergeOrgModal loserOrg={LOSER} orgs={ALL_ORGS} onClose={onClose} onMerged={vi.fn()} onDoneClose={vi.fn()} />,
+    );
     await selectSurvivorAndTypeName();
 
     fireEvent.click(screen.getByTestId('org-merge-submit'));
@@ -349,5 +444,62 @@ describe('MergeOrgModal — server-side confirmName mismatch', () => {
     );
     expect(onClose).not.toHaveBeenCalled();
     expect(screen.getByTestId('org-merge-survivor-select')).toBeInTheDocument();
+  });
+});
+
+describe('MergeOrgModal — stale preview race', () => {
+  const SURVIVOR_B: Organization = {
+    id: 'survivor-b-6666-6666-6666-666666666666',
+    name: 'Beta Org',
+    status: 'active',
+    deviceCount: 5,
+    createdAt: '2026-01-01T00:00:00Z',
+  };
+  const ORGS_WITH_B = [...ALL_ORGS, SURVIVOR_B];
+  const PREVIEW_B = { ...PREVIEW_OK, totalMovableRows: 999, tables: [], warnings: [] };
+
+  it('drops a stale preview response for a survivor that is no longer selected, even when it resolves last', async () => {
+    let releaseA: ((data: unknown) => void) | undefined;
+    fetchMock.mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (init?.method === 'POST' && url.endsWith('/merge-preview')) {
+        const body = JSON.parse(String(init.body)) as { survivorId: string };
+        if (body.survivorId === SURVIVOR.id) {
+          // Survivor A's request is requested FIRST but held open — it must
+          // not win just because it started first.
+          return new Promise<Response>((resolve) => {
+            releaseA = (data: unknown) => resolve(jsonResponse(data));
+          });
+        }
+        return jsonResponse(PREVIEW_B);
+      }
+      return jsonResponse({});
+    });
+
+    render(
+      <MergeOrgModal
+        loserOrg={LOSER}
+        orgs={ORGS_WITH_B}
+        onClose={vi.fn()}
+        onMerged={vi.fn()}
+        onDoneClose={vi.fn()}
+      />,
+    );
+
+    // Select A, then rapidly reselect B before A's response ever arrives.
+    fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
+    fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR_B.id } });
+
+    // B's (later) request resolves immediately.
+    await waitFor(() => expect(screen.getByTestId('org-merge-total-rows')).toHaveTextContent('999'));
+
+    // Now release A's (earlier) request — it resolves LAST. It must be
+    // dropped rather than clobbering B's already-rendered preview.
+    await act(async () => {
+      releaseA!(PREVIEW_OK);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(screen.getByTestId('org-merge-total-rows')).toHaveTextContent('999');
   });
 });

--- a/apps/web/src/components/settings/MergeOrgModal.tsx
+++ b/apps/web/src/components/settings/MergeOrgModal.tsx
@@ -114,6 +114,16 @@ export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged, onDon
   // earlier POST resolve after a later one, and without a guard the stale
   // response would overwrite the fresher preview already on screen.
   const previewRequestIdRef = useRef(0);
+  // Set false in the unmount cleanup below. Guards `submitMerge`'s
+  // continuation specifically: `pollTokenRef` only protects a poll chain
+  // that has already started, but `startPolling()` itself MINTS a fresh
+  // token on every call (via `invalidatePolling()` bumping, then reading,
+  // the counter) — so if the merge POST resolves after unmount, that fresh
+  // token looks perfectly valid and the pollJob guard above would never
+  // catch it. `submitMerge` checks this BEFORE ever calling `startPolling`,
+  // so a post-unmount POST response never mints a token, never starts a
+  // fetch loop, and never has a chance to fire `onMerged` later.
+  const mountedRef = useRef(true);
 
   const survivors = useMemo(() => eligibleSurvivors(orgs, loserOrg), [orgs, loserOrg]);
 
@@ -138,8 +148,15 @@ export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged, onDon
   }, [stopPolling]);
 
   // Cleanup on unmount — the modal can be dismissed (or the parent can
-  // navigate away) while a merge job is still queued/running.
-  useEffect(() => () => invalidatePolling(), [invalidatePolling]);
+  // navigate away) while a merge job is still queued/running, or while the
+  // merge POST itself is still in flight (see mountedRef above).
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      invalidatePolling();
+    },
+    [invalidatePolling],
+  );
 
   const fetchPreview = useCallback(
     async (survivor: string) => {
@@ -266,16 +283,22 @@ export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged, onDon
         friendly: mfaFriendly,
         onUnauthorized: handleSessionExpired,
       });
+      // The modal can be closed/unmounted while this POST is still in
+      // flight. Dropped entirely here — no phase change, no `startPolling`
+      // (which would otherwise mint a fresh, "valid-looking" poll token and
+      // run a whole polling+onMerged cycle against an unmounted modal).
+      if (!mountedRef.current) return;
       setPhase('progress');
       startPolling(data.jobId);
     } catch (err) {
+      if (!mountedRef.current) return; // ditto — nothing left to update
       // runAction already toasted an ActionError (e.g. the 400 confirmName
       // mismatch, verbatim from the server) — the modal simply stays on the
       // pick phase so the operator can correct it. onUnauthorized handles a
       // 401 redirect. Only a non-ActionError escape needs a fallback toast.
       handleActionError(err, t('organizationsPage.merge.errors.merge'));
     } finally {
-      setSubmitting(false);
+      if (mountedRef.current) setSubmitting(false);
     }
   }, [loserOrg.id, survivorId, confirmName, t, mfaFriendly, startPolling]);
 

--- a/apps/web/src/components/settings/MergeOrgModal.tsx
+++ b/apps/web/src/components/settings/MergeOrgModal.tsx
@@ -4,7 +4,6 @@ import '@/lib/i18n';
 import type { Organization } from './OrganizationList';
 import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
 import { runAction, handleActionError } from '@/lib/runAction';
-import { showToast } from '../shared/Toast';
 
 /** Poll cadence for `GET /orgs/organizations/merge-runs/:jobId` while a merge
  *  job is queued/running. Exported for the test's fake-timer advances. */
@@ -39,8 +38,25 @@ interface MergeRunStatus {
 export interface MergeOrgModalProps {
   loserOrg: Organization;
   orgs: Organization[];
+  /** Dismiss without completing — the pick phase's Cancel button and the
+   *  failed phase's Cancel button. No assumptions about the loser's state. */
   onClose: () => void;
+  /**
+   * Fired exactly once, the moment the merge-runs poll reports a genuine
+   * `completed` result. List-state update ONLY (drop the loser from the
+   * page's org list) — must NOT close the modal or touch the page's
+   * selection. The modal stays open on its own `done` phase so the operator
+   * can see the result summary; closing it is a separate, explicit action
+   * (see `onDoneClose`).
+   */
   onMerged: (loserId: string) => void;
+  /**
+   * The done phase's explicit Close button. Unlike `onClose`, the caller
+   * knows the merge actually completed here, so `loserOrg` now refers to a
+   * defunct, merged-away org — the page clears its stale selection in
+   * addition to closing.
+   */
+  onDoneClose: () => void;
 }
 
 type Phase = 'pick' | 'progress' | 'done' | 'failed';
@@ -75,7 +91,7 @@ function sumMergeResult(tables: Record<string, { moved: number; dropped: number 
   return { moved, dropped };
 }
 
-export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged }: MergeOrgModalProps) {
+export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged, onDoneClose }: MergeOrgModalProps) {
   const { t } = useTranslation('settings');
   const [phase, setPhase] = useState<Phase>('pick');
   const [survivorId, setSurvivorId] = useState('');
@@ -85,7 +101,19 @@ export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged }: Mer
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<OrgMergeRunResult | null>(null);
   const [failedReason, setFailedReason] = useState<string | null>(null);
-  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Bumped whenever a poll chain is superseded (unmount, a fresh
+  // startPolling from retry, or a terminal state) so an in-flight response
+  // that resolves afterward is recognized as stale and dropped rather than
+  // updating state or scheduling a further tick. A plain `clearInterval`
+  // guard is not enough: it stops FUTURE ticks but does nothing about a
+  // fetch that is already in flight when the tick that started it becomes
+  // irrelevant.
+  const pollTokenRef = useRef(0);
+  // Same idea for merge-preview: rapid survivor reselection can make an
+  // earlier POST resolve after a later one, and without a guard the stale
+  // response would overwrite the fresher preview already on screen.
+  const previewRequestIdRef = useRef(0);
 
   const survivors = useMemo(() => eligibleSurvivors(orgs, loserOrg), [orgs, loserOrg]);
 
@@ -94,19 +122,28 @@ export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged }: Mer
     [t],
   );
 
-  const clearPoll = useCallback(() => {
-    if (pollIntervalRef.current !== null) {
-      clearInterval(pollIntervalRef.current);
-      pollIntervalRef.current = null;
+  const stopPolling = useCallback(() => {
+    if (pollTimeoutRef.current !== null) {
+      clearTimeout(pollTimeoutRef.current);
+      pollTimeoutRef.current = null;
     }
   }, []);
 
+  /** Stop any scheduled tick AND invalidate whatever poll chain is currently
+   *  in flight (unmount, retry superseding a prior run, or a terminal state
+   *  reached). */
+  const invalidatePolling = useCallback(() => {
+    stopPolling();
+    pollTokenRef.current += 1;
+  }, [stopPolling]);
+
   // Cleanup on unmount — the modal can be dismissed (or the parent can
   // navigate away) while a merge job is still queued/running.
-  useEffect(() => () => clearPoll(), [clearPoll]);
+  useEffect(() => () => invalidatePolling(), [invalidatePolling]);
 
   const fetchPreview = useCallback(
     async (survivor: string) => {
+      const requestId = ++previewRequestIdRef.current;
       setPreviewLoading(true);
       setPreview(null);
       try {
@@ -120,13 +157,16 @@ export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged }: Mer
           friendly: mfaFriendly,
           onUnauthorized: handleSessionExpired,
         });
-        setPreview(data);
+        // Dropped if a newer survivor selection has already superseded this
+        // request — an out-of-order response must not clobber fresher data.
+        if (previewRequestIdRef.current === requestId) setPreview(data);
       } catch (err) {
+        if (previewRequestIdRef.current !== requestId) return; // superseded
         // runAction already toasted an ActionError; onUnauthorized handles a
         // 401 redirect. Only a non-ActionError escape needs a fallback toast.
         handleActionError(err, t('organizationsPage.merge.errors.preview'));
       } finally {
-        setPreviewLoading(false);
+        if (previewRequestIdRef.current === requestId) setPreviewLoading(false);
       }
     },
     [loserOrg.id, t, mfaFriendly],
@@ -139,44 +179,77 @@ export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged }: Mer
   };
 
   const pollJob = useCallback(
-    async (jobId: string) => {
+    async (jobId: string, token: number) => {
+      const scheduleNextTick = () => {
+        if (pollTokenRef.current !== token) return; // superseded meanwhile
+        pollTimeoutRef.current = setTimeout(() => void pollJob(jobId, token), MERGE_POLL_INTERVAL_MS);
+      };
+
       let response: Response;
       try {
         response = await fetchWithAuth(`/orgs/organizations/merge-runs/${jobId}`);
       } catch {
-        return; // transient network hiccup — the next tick retries
+        if (pollTokenRef.current !== token) return; // unmounted/superseded
+        scheduleNextTick(); // transient network hiccup — the next tick retries
+        return;
       }
+      if (pollTokenRef.current !== token) return; // stale — drop silently
+
       if (response.status === 401) {
-        clearPoll();
+        invalidatePolling();
         handleSessionExpired();
         return;
       }
-      if (!response.ok) return; // transient — the next tick retries
+      if (!response.ok) {
+        scheduleNextTick(); // transient — the next tick retries
+        return;
+      }
       const data = (await response.json().catch(() => null)) as MergeRunStatus | null;
-      if (!data) return;
+      if (pollTokenRef.current !== token) return; // stale — drop silently
+      if (!data) {
+        scheduleNextTick();
+        return;
+      }
 
-      if (data.state === 'completed') {
-        clearPoll();
-        setResult(data.result ?? { tables: {}, warnings: [], mergeEventId: '' });
+      if (data.state === 'completed' && data.result) {
+        invalidatePolling(); // terminal — no further ticks, no late overwrite
+        setResult(data.result);
         setPhase('done');
         onMerged(loserOrg.id);
-      } else if (data.state === 'failed') {
-        clearPoll();
+        return;
+      }
+      if (data.state === 'completed' && !data.result) {
+        // The worker contract is `state: 'completed'` implies `result` is
+        // present. A completed run reported with no result payload is not a
+        // "keep polling" state — surface it as a failure (with the existing
+        // retry affordance) rather than fabricating a zero-row summary and
+        // telling the operator the merge is done when we don't actually know
+        // what it moved.
+        invalidatePolling();
+        setFailedReason(t('organizationsPage.merge.errors.missingResult'));
+        setPhase('failed');
+        return;
+      }
+      if (data.state === 'failed') {
+        invalidatePolling();
         setFailedReason(data.failedReason ?? null);
         setPhase('failed');
+        return;
       }
+
       // 'waiting' | 'active' — keep polling.
+      scheduleNextTick();
     },
-    [clearPoll, loserOrg.id, onMerged],
+    [invalidatePolling, loserOrg.id, onMerged, t],
   );
 
   const startPolling = useCallback(
     (jobId: string) => {
-      clearPoll();
-      void pollJob(jobId);
-      pollIntervalRef.current = setInterval(() => void pollJob(jobId), MERGE_POLL_INTERVAL_MS);
+      invalidatePolling(); // drop/ignore anything from a previous run (retry)
+      const token = pollTokenRef.current;
+      void pollJob(jobId, token);
     },
-    [clearPoll, pollJob],
+    [invalidatePolling, pollJob],
   );
 
   const submitMerge = useCallback(async () => {
@@ -257,6 +330,26 @@ export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged }: Mer
                   {t('organizationsPage.merge.totalMovableRows', { count: preview.totalMovableRows })}
                 </p>
 
+                {/* Warnings (audit-trail destruction, key revocation, ...) render
+                    regardless of verdict — a too-large refusal must not hide
+                    the reasons a self-hosted operator would need after raising
+                    the row limit and retrying, and a partner deciding whether
+                    to contact support still needs to see what's at stake. */}
+                {preview.warnings.length > 0 && (
+                  <div>
+                    <p className="font-medium text-destructive">
+                      {t('organizationsPage.merge.warningsHeading')}
+                    </p>
+                    <ul data-testid="org-merge-warnings-list" className="mt-1 list-disc space-y-0.5 pl-4">
+                      {preview.warnings.map((warning, index) => (
+                        <li key={index} data-testid={`org-merge-warning-${index}`}>
+                          {warning}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
                 {preview.verdict === 'too-large' ? (
                   <p data-testid="org-merge-too-large" className="text-destructive">
                     {t('organizationsPage.merge.tooLarge')}
@@ -277,21 +370,6 @@ export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged }: Mer
                         ))}
                       </ul>
                     </div>
-
-                    {preview.warnings.length > 0 && (
-                      <div>
-                        <p className="font-medium text-destructive">
-                          {t('organizationsPage.merge.warningsHeading')}
-                        </p>
-                        <ul data-testid="org-merge-warnings-list" className="mt-1 list-disc space-y-0.5 pl-4">
-                          {preview.warnings.map((warning, index) => (
-                            <li key={index} data-testid={`org-merge-warning-${index}`}>
-                              {warning}
-                            </li>
-                          ))}
-                        </ul>
-                      </div>
-                    )}
 
                     <div>
                       <label htmlFor="org-merge-confirm-name" className="block text-sm font-medium">
@@ -363,7 +441,7 @@ export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged }: Mer
               <button
                 type="button"
                 data-testid="org-merge-close"
-                onClick={onClose}
+                onClick={onDoneClose}
                 className="h-10 rounded-md border px-4 text-sm font-medium transition hover:bg-muted"
               >
                 {t('organizationsPage.merge.close')}

--- a/apps/web/src/components/settings/MergeOrgModal.tsx
+++ b/apps/web/src/components/settings/MergeOrgModal.tsx
@@ -1,0 +1,407 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import '@/lib/i18n';
+import type { Organization } from './OrganizationList';
+import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
+import { runAction, handleActionError } from '@/lib/runAction';
+import { showToast } from '../shared/Toast';
+
+/** Poll cadence for `GET /orgs/organizations/merge-runs/:jobId` while a merge
+ *  job is queued/running. Exported for the test's fake-timer advances. */
+export const MERGE_POLL_INTERVAL_MS = 2000;
+
+export interface OrgMergePreviewTable {
+  table: string;
+  policy: string;
+  loserRows: number;
+  wouldDrop: number;
+}
+
+export interface OrgMergePreview {
+  tables: OrgMergePreviewTable[];
+  totalMovableRows: number;
+  verdict: 'ok' | 'too-large';
+  warnings: string[];
+}
+
+export interface OrgMergeRunResult {
+  tables: Record<string, { moved: number; dropped: number }>;
+  warnings: string[];
+  mergeEventId: string;
+}
+
+interface MergeRunStatus {
+  state: 'waiting' | 'active' | 'completed' | 'failed';
+  result?: OrgMergeRunResult;
+  failedReason?: string;
+}
+
+export interface MergeOrgModalProps {
+  loserOrg: Organization;
+  orgs: Organization[];
+  onClose: () => void;
+  onMerged: (loserId: string) => void;
+}
+
+type Phase = 'pick' | 'progress' | 'done' | 'failed';
+
+/**
+ * Eligible merge survivors (Global Constraints, org-lifecycle Wave 3): same
+ * partner as the loser (guaranteed here because the launcher button that
+ * mounts this modal is itself gated to partner scope, and the org list it is
+ * fed is already confined to that partner), excluding the loser itself, the
+ * hidden `quick_support` org, and any org not `active`/`trial`. Exported for
+ * the test.
+ */
+export function eligibleSurvivors(orgs: Organization[], loserOrg: Organization): Organization[] {
+  return orgs.filter(
+    (org) =>
+      org.id !== loserOrg.id &&
+      org.type !== 'quick_support' &&
+      (org.status === 'active' || org.status === 'trial'),
+  );
+}
+
+function sumMergeResult(tables: Record<string, { moved: number; dropped: number }>): {
+  moved: number;
+  dropped: number;
+} {
+  let moved = 0;
+  let dropped = 0;
+  for (const row of Object.values(tables)) {
+    moved += row.moved;
+    dropped += row.dropped;
+  }
+  return { moved, dropped };
+}
+
+export default function MergeOrgModal({ loserOrg, orgs, onClose, onMerged }: MergeOrgModalProps) {
+  const { t } = useTranslation('settings');
+  const [phase, setPhase] = useState<Phase>('pick');
+  const [survivorId, setSurvivorId] = useState('');
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [preview, setPreview] = useState<OrgMergePreview | null>(null);
+  const [confirmName, setConfirmName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<OrgMergeRunResult | null>(null);
+  const [failedReason, setFailedReason] = useState<string | null>(null);
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const survivors = useMemo(() => eligibleSurvivors(orgs, loserOrg), [orgs, loserOrg]);
+
+  const mfaFriendly = useCallback(
+    (code: string) => (code === 'MFA_REQUIRED' ? t('organizationsPage.merge.errors.mfaRequired') : undefined),
+    [t],
+  );
+
+  const clearPoll = useCallback(() => {
+    if (pollIntervalRef.current !== null) {
+      clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+  }, []);
+
+  // Cleanup on unmount — the modal can be dismissed (or the parent can
+  // navigate away) while a merge job is still queued/running.
+  useEffect(() => () => clearPoll(), [clearPoll]);
+
+  const fetchPreview = useCallback(
+    async (survivor: string) => {
+      setPreviewLoading(true);
+      setPreview(null);
+      try {
+        const data = await runAction<OrgMergePreview>({
+          request: () =>
+            fetchWithAuth(`/orgs/organizations/${loserOrg.id}/merge-preview`, {
+              method: 'POST',
+              body: JSON.stringify({ survivorId: survivor }),
+            }),
+          errorFallback: t('organizationsPage.merge.errors.preview'),
+          friendly: mfaFriendly,
+          onUnauthorized: handleSessionExpired,
+        });
+        setPreview(data);
+      } catch (err) {
+        // runAction already toasted an ActionError; onUnauthorized handles a
+        // 401 redirect. Only a non-ActionError escape needs a fallback toast.
+        handleActionError(err, t('organizationsPage.merge.errors.preview'));
+      } finally {
+        setPreviewLoading(false);
+      }
+    },
+    [loserOrg.id, t, mfaFriendly],
+  );
+
+  const handleSurvivorChange = (id: string) => {
+    setSurvivorId(id);
+    setPreview(null);
+    if (id) void fetchPreview(id);
+  };
+
+  const pollJob = useCallback(
+    async (jobId: string) => {
+      let response: Response;
+      try {
+        response = await fetchWithAuth(`/orgs/organizations/merge-runs/${jobId}`);
+      } catch {
+        return; // transient network hiccup — the next tick retries
+      }
+      if (response.status === 401) {
+        clearPoll();
+        handleSessionExpired();
+        return;
+      }
+      if (!response.ok) return; // transient — the next tick retries
+      const data = (await response.json().catch(() => null)) as MergeRunStatus | null;
+      if (!data) return;
+
+      if (data.state === 'completed') {
+        clearPoll();
+        setResult(data.result ?? { tables: {}, warnings: [], mergeEventId: '' });
+        setPhase('done');
+        onMerged(loserOrg.id);
+      } else if (data.state === 'failed') {
+        clearPoll();
+        setFailedReason(data.failedReason ?? null);
+        setPhase('failed');
+      }
+      // 'waiting' | 'active' — keep polling.
+    },
+    [clearPoll, loserOrg.id, onMerged],
+  );
+
+  const startPolling = useCallback(
+    (jobId: string) => {
+      clearPoll();
+      void pollJob(jobId);
+      pollIntervalRef.current = setInterval(() => void pollJob(jobId), MERGE_POLL_INTERVAL_MS);
+    },
+    [clearPoll, pollJob],
+  );
+
+  const submitMerge = useCallback(async () => {
+    setSubmitting(true);
+    setFailedReason(null);
+    try {
+      const data = await runAction<{ jobId: string }>({
+        request: () =>
+          fetchWithAuth(`/orgs/organizations/${loserOrg.id}/merge`, {
+            method: 'POST',
+            body: JSON.stringify({ survivorId, confirmName }),
+          }),
+        errorFallback: t('organizationsPage.merge.errors.merge'),
+        friendly: mfaFriendly,
+        onUnauthorized: handleSessionExpired,
+      });
+      setPhase('progress');
+      startPolling(data.jobId);
+    } catch (err) {
+      // runAction already toasted an ActionError (e.g. the 400 confirmName
+      // mismatch, verbatim from the server) — the modal simply stays on the
+      // pick phase so the operator can correct it. onUnauthorized handles a
+      // 401 redirect. Only a non-ActionError escape needs a fallback toast.
+      handleActionError(err, t('organizationsPage.merge.errors.merge'));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [loserOrg.id, survivorId, confirmName, t, mfaFriendly, startPolling]);
+
+  const nameMatches = confirmName === loserOrg.name;
+  const canSubmit = Boolean(survivorId) && Boolean(preview) && preview?.verdict === 'ok' && nameMatches && !submitting;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8">
+      <div
+        className="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-lg border bg-card p-6 shadow-xs"
+        data-testid="org-merge-modal"
+      >
+        <h2 className="text-lg font-semibold">{t('organizationsPage.merge.title')}</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {t('organizationsPage.merge.description', { name: loserOrg.name })}
+        </p>
+
+        {phase === 'pick' && (
+          <>
+            <label htmlFor="org-merge-survivor" className="mt-4 block text-sm font-medium">
+              {t('organizationsPage.merge.survivorLabel')}
+            </label>
+            <select
+              id="org-merge-survivor"
+              data-testid="org-merge-survivor-select"
+              value={survivorId}
+              onChange={(e) => handleSurvivorChange(e.target.value)}
+              className="mt-1 h-10 w-full rounded-md border bg-background px-2.5 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+            >
+              <option value="">{t('organizationsPage.merge.survivorPlaceholder')}</option>
+              {survivors.map((org) => (
+                <option key={org.id} value={org.id}>
+                  {org.name}
+                </option>
+              ))}
+            </select>
+            {survivors.length === 0 && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t('organizationsPage.merge.noEligibleSurvivors')}
+              </p>
+            )}
+
+            {previewLoading && (
+              <p data-testid="org-merge-preview-loading" className="mt-4 text-sm text-muted-foreground">
+                {t('organizationsPage.merge.previewLoading')}
+              </p>
+            )}
+
+            {preview && (
+              <div className="mt-4 space-y-3 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm">
+                <p data-testid="org-merge-total-rows" className="font-medium">
+                  {t('organizationsPage.merge.totalMovableRows', { count: preview.totalMovableRows })}
+                </p>
+
+                {preview.verdict === 'too-large' ? (
+                  <p data-testid="org-merge-too-large" className="text-destructive">
+                    {t('organizationsPage.merge.tooLarge')}
+                  </p>
+                ) : (
+                  <>
+                    <div>
+                      <p className="font-medium">{t('organizationsPage.merge.tablesHeading')}</p>
+                      <ul data-testid="org-merge-tables-list" className="mt-1 list-disc space-y-0.5 pl-4">
+                        {preview.tables.map((row) => (
+                          <li key={row.table} data-testid={`org-merge-table-row-${row.table}`}>
+                            {t('organizationsPage.merge.tableRowSummary', {
+                              table: row.table,
+                              loserRows: row.loserRows,
+                              wouldDrop: row.wouldDrop,
+                            })}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+
+                    {preview.warnings.length > 0 && (
+                      <div>
+                        <p className="font-medium text-destructive">
+                          {t('organizationsPage.merge.warningsHeading')}
+                        </p>
+                        <ul data-testid="org-merge-warnings-list" className="mt-1 list-disc space-y-0.5 pl-4">
+                          {preview.warnings.map((warning, index) => (
+                            <li key={index} data-testid={`org-merge-warning-${index}`}>
+                              {warning}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+
+                    <div>
+                      <label htmlFor="org-merge-confirm-name" className="block text-sm font-medium">
+                        {t('organizationsPage.merge.confirmLabel', { name: loserOrg.name })}
+                      </label>
+                      <input
+                        id="org-merge-confirm-name"
+                        data-testid="org-merge-confirm-input"
+                        type="text"
+                        autoComplete="off"
+                        spellCheck={false}
+                        value={confirmName}
+                        onChange={(e) => setConfirmName(e.target.value)}
+                        placeholder={loserOrg.name}
+                        className="mt-1 h-10 w-full rounded-md border bg-background px-2.5 font-mono text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                      />
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                data-testid="org-merge-cancel"
+                onClick={onClose}
+                disabled={submitting}
+                className="h-10 rounded-md border px-4 text-sm font-medium text-muted-foreground transition hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {t('organizationsPage.merge.cancel')}
+              </button>
+              <button
+                type="button"
+                data-testid="org-merge-submit"
+                onClick={() => void submitMerge()}
+                disabled={!canSubmit}
+                className="inline-flex h-10 items-center justify-center rounded-md bg-destructive px-4 text-sm font-medium text-destructive-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {submitting ? t('organizationsPage.merge.merging') : t('organizationsPage.merge.confirmButton')}
+              </button>
+            </div>
+          </>
+        )}
+
+        {phase === 'progress' && (
+          <div data-testid="org-merge-progress" className="mt-4">
+            <p className="font-medium">{t('organizationsPage.merge.progressTitle')}</p>
+            <p className="mt-1 text-sm text-muted-foreground">{t('organizationsPage.merge.progressDescription')}</p>
+          </div>
+        )}
+
+        {phase === 'done' && result && (
+          <div data-testid="org-merge-done" className="mt-4 space-y-3">
+            <p className="font-medium">{t('organizationsPage.merge.doneTitle')}</p>
+            <p data-testid="org-merge-result-summary" className="text-sm">
+              {t('organizationsPage.merge.resultSummary', sumMergeResult(result.tables))}
+            </p>
+            {result.warnings.length > 0 && (
+              <ul data-testid="org-merge-done-warnings-list" className="list-disc space-y-0.5 pl-4 text-sm">
+                {result.warnings.map((warning, index) => (
+                  <li key={index} data-testid={`org-merge-done-warning-${index}`}>
+                    {warning}
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="flex justify-end">
+              <button
+                type="button"
+                data-testid="org-merge-close"
+                onClick={onClose}
+                className="h-10 rounded-md border px-4 text-sm font-medium transition hover:bg-muted"
+              >
+                {t('organizationsPage.merge.close')}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {phase === 'failed' && (
+          <div data-testid="org-merge-failed" className="mt-4 space-y-3">
+            <p className="font-medium text-destructive">{t('organizationsPage.merge.failedTitle')}</p>
+            {failedReason && (
+              <p data-testid="org-merge-failed-reason" className="text-sm text-destructive">
+                {failedReason}
+              </p>
+            )}
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                data-testid="org-merge-cancel"
+                onClick={onClose}
+                className="h-10 rounded-md border px-4 text-sm font-medium text-muted-foreground transition hover:text-foreground"
+              >
+                {t('organizationsPage.merge.cancel')}
+              </button>
+              <button
+                type="button"
+                data-testid="org-merge-retry"
+                onClick={() => void submitMerge()}
+                disabled={submitting}
+                className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {submitting ? t('organizationsPage.merge.retrying') : t('organizationsPage.merge.retry')}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/OrganizationList.tsx
+++ b/apps/web/src/components/settings/OrganizationList.tsx
@@ -13,7 +13,15 @@ export type Organization = {
    * (id/name/slug/status) because those users reach the route without
    * `organizations:read`. Optional here so the renderer has to decide what to
    * show rather than interpolating `undefined` into a label (#3699).
+   *
+   * Mirrors `org_type` (apps/api/src/db/schema/orgs.ts). The partner/system
+   * branch of `GET /orgs/organizations` spreads the full row so this is
+   * present in practice for that branch; kept optional because the
+   * organization-scoped projection above omits it. Consumers that need to
+   * exclude the hidden `quick_support` org (e.g. the merge survivor picker)
+   * check this rather than assuming the list already filtered it out.
    */
+  type?: 'customer' | 'internal' | 'quick_support';
   deviceCount?: number;
   createdAt: string;
 };

--- a/apps/web/src/components/settings/OrganizationsPage.firstSite.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.firstSite.test.tsx
@@ -14,6 +14,16 @@ vi.mock('../../stores/auth', () => ({
   handleSessionExpired: vi.fn()
 }));
 
+// OrganizationsPage reads useJwtClaims() to gate the merge-org launcher button
+// (partner-scope only). It subscribes to useAuthStore directly, which the
+// mock above does not export — stub the module's own public surface instead
+// of wiring up a fake zustand store. 'unresolved' just hides the button,
+// which is irrelevant to these first-site-nag assertions.
+vi.mock('../../lib/authScope', () => ({
+  useJwtClaims: () => ({ status: 'unresolved' as const }),
+  getJwtClaims: () => ({ scope: null, orgId: null, partnerId: null }),
+}));
+
 const navigateTo = vi.fn();
 vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
 

--- a/apps/web/src/components/settings/OrganizationsPage.merge.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.merge.test.tsx
@@ -1,0 +1,176 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OrganizationsPage from './OrganizationsPage';
+import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  handleSessionExpired: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+const storeFetchOrganizations = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: { getState: () => ({ fetchOrganizations: storeFetchOrganizations }) },
+}));
+
+// Mutable per-test knob for the merge launcher's partner-scope gating.
+// useJwtClaims is reactive in the real module (subscribes to the auth store),
+// but the page only cares about its return shape — a plain stub read fresh on
+// every call is simpler than wiring up a fake zustand store, and each test
+// sets the scope it needs before rendering.
+let mockJwtScope: 'system' | 'partner' | 'organization' | null = 'partner';
+vi.mock('../../lib/authScope', () => ({
+  useJwtClaims: () => ({
+    status: 'resolved' as const,
+    claims: { scope: mockJwtScope, orgId: null, partnerId: 'partner-1' },
+  }),
+  getJwtClaims: () => ({ scope: mockJwtScope, orgId: null, partnerId: 'partner-1' }),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const sessionExpiredMock = vi.mocked(handleSessionExpired);
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERROR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const LOSER = {
+  id: 'loser-1111-1111-1111-111111111111',
+  name: 'Acme Legacy',
+  status: 'active',
+  deviceCount: 3,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+const SURVIVOR = {
+  id: 'survivor-2222-2222-2222-222222222222',
+  name: 'Acme Corp',
+  status: 'active',
+  deviceCount: 40,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+let orgsState: Array<typeof LOSER> = [LOSER, SURVIVOR];
+
+/** Routes every fetch the page (and, once opened, MergeOrgModal) issues.
+ * `poll` defaults to an immediate `completed` so tests don't need to model
+ * multiple ticks unless they care about that. */
+function mockApi(poll?: () => unknown) {
+  fetchMock.mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method;
+
+    if (url.startsWith('/orgs/organizations?') && !method) {
+      return jsonResponse({ data: orgsState });
+    }
+    if (url === '/orgs/partners/me') return jsonResponse({ settings: {} });
+    if (url.startsWith('/orgs/sites?organizationId=')) return jsonResponse({ data: [] });
+    if (method === 'POST' && url.endsWith('/merge-preview')) {
+      return jsonResponse({ tables: [{ table: 'devices', policy: 'repoint-dedupe', loserRows: 4, wouldDrop: 0 }], totalMovableRows: 4, verdict: 'ok', warnings: [] });
+    }
+    if (method === 'POST' && /\/organizations\/[^/]+\/merge$/.test(url)) {
+      return jsonResponse({ jobId: 'job-1' }, true, 202);
+    }
+    if (url.includes('/merge-runs/')) {
+      return jsonResponse(
+        poll?.() ?? {
+          state: 'completed',
+          result: { tables: { devices: { moved: 4, dropped: 0 } }, warnings: [], mergeEventId: 'evt-1' },
+        },
+      );
+    }
+    return jsonResponse({ data: [] });
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+}
+
+async function selectLoser() {
+  fireEvent.click(screen.getByTestId(`org-row-${LOSER.id}`));
+  await flush();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchMock.mockReset();
+  sessionExpiredMock.mockReset();
+  navigateTo.mockReset();
+  storeFetchOrganizations.mockClear();
+  window.location.hash = '';
+  orgsState = [LOSER, SURVIVOR];
+  mockJwtScope = 'partner';
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('OrganizationsPage — merge launcher partner gating', () => {
+  it('hides the merge launcher for a non-partner scope', async () => {
+    mockJwtScope = 'organization';
+    mockApi();
+    render(<OrganizationsPage />);
+    await flush();
+
+    await selectLoser();
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Acme Legacy' })).toBeInTheDocument();
+    expect(screen.queryByTestId('org-merge-open')).not.toBeInTheDocument();
+  });
+
+  it('shows the merge launcher for partner scope', async () => {
+    mockJwtScope = 'partner';
+    mockApi();
+    render(<OrganizationsPage />);
+    await flush();
+
+    await selectLoser();
+
+    expect(screen.getByTestId('org-merge-open')).toBeInTheDocument();
+  });
+});
+
+describe('OrganizationsPage — merge completion stays on the summary until the user closes it', () => {
+  it('keeps the modal open on the done summary, drops the loser from the list, and only clears the selection on Close', async () => {
+    mockApi();
+    render(<OrganizationsPage />);
+    await flush();
+
+    await selectLoser();
+    fireEvent.click(screen.getByTestId('org-merge-open'));
+
+    fireEvent.change(screen.getByTestId('org-merge-survivor-select'), { target: { value: SURVIVOR.id } });
+    await flush();
+
+    fireEvent.change(screen.getByTestId('org-merge-confirm-input'), { target: { value: LOSER.name } });
+    fireEvent.click(screen.getByTestId('org-merge-submit'));
+    await flush(); // merge POST (202) + the immediate first poll: 'completed'
+
+    // The modal did NOT close and unmount out from under the summary — this
+    // is the CRITICAL regression: onMerged used to also close the modal,
+    // unmounting `org-merge-done` the instant it appeared.
+    expect(screen.getByTestId('org-merge-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('org-merge-done')).toBeInTheDocument();
+
+    // onMerged's list-state update DID happen — the loser is out of the left
+    // list — independent of the modal staying open.
+    expect(screen.queryByTestId(`org-row-${LOSER.id}`)).not.toBeInTheDocument();
+    expect(screen.getByTestId(`org-row-${SURVIVOR.id}`)).toBeInTheDocument();
+
+    // Closing the summary is what actually tears the modal down AND clears
+    // the stale (merged-away) selection.
+    fireEvent.click(screen.getByTestId('org-merge-close'));
+    await flush();
+
+    expect(screen.queryByTestId('org-merge-modal')).not.toBeInTheDocument();
+    expect(screen.getByText('No organization selected')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/OrganizationsPage.mutationFeedback.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.mutationFeedback.test.tsx
@@ -10,6 +10,16 @@ vi.mock('../../stores/auth', () => ({
   handleSessionExpired: vi.fn()
 }));
 
+// OrganizationsPage reads useJwtClaims() to gate the merge-org launcher button
+// (partner-scope only). It subscribes to useAuthStore directly, which the
+// mock above does not export — stub the module's own public surface instead
+// of wiring up a fake zustand store. 'unresolved' just hides the button,
+// which is irrelevant to these reorder/redirect assertions.
+vi.mock('../../lib/authScope', () => ({
+  useJwtClaims: () => ({ status: 'unresolved' as const }),
+  getJwtClaims: () => ({ scope: null, orgId: null, partnerId: null }),
+}));
+
 const navigateTo = vi.fn();
 vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
 

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -298,16 +298,34 @@ export default function OrganizationsPage() {
   };
 
   /**
-   * Called by MergeOrgModal once its merge-runs poll reports `completed`.
+   * Called by MergeOrgModal once its merge-runs poll reports a genuine
+   * `completed` result. LIST-STATE UPDATE ONLY — deliberately does not close
+   * the modal or touch `selectedOrg`. MergeOrgModal stays open on its own
+   * `done` phase so the operator can actually see the result summary; if this
+   * closed the modal too, the summary would be unmounted the instant it
+   * appeared (React 18 batches this call with the child's own `setPhase`
+   * update into one render).
+   *
    * NOT a `refreshOrgs()` — the merged-away org is not soft-deleted, it ends
    * up a terminal `status='merging'` shell with `deleted_at IS NULL`
    * (services/orgMerge.ts), so a refetch would still return it. The local
-   * filter is the only way to actually drop it from this screen; mirrors
-   * handleConfirmDelete's selectedOrg-clearing behavior below.
+   * filter is the only way to actually drop it from this screen.
    */
   const handleMergeComplete = (loserId: string) => {
     setOrganizations(prev => prev.filter(o => o.id !== loserId));
-    if (selectedOrg?.id === loserId) setSelectedOrg(null);
+  };
+
+  /**
+   * The done-phase summary's explicit Close button. Unlike a plain
+   * `handleCloseModal()`, `selectedOrg` here is known to be the org that was
+   * JUST merged away (handleMergeComplete already dropped it from the list),
+   * so it's cleared too — mirrors handleConfirmDelete's selectedOrg-clearing
+   * behavior. A plain Cancel out of the pick/failed phases (before anything
+   * merged) must NOT clear it, which is why this is a separate handler
+   * rather than folded into `onClose`.
+   */
+  const handleMergeDoneClose = () => {
+    setSelectedOrg(null);
     handleCloseModal();
   };
 
@@ -1024,6 +1042,7 @@ export default function OrganizationsPage() {
           orgs={organizations}
           onClose={handleCloseModal}
           onMerged={handleMergeComplete}
+          onDoneClose={handleMergeDoneClose}
         />
       )}
 

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -6,15 +6,17 @@ import type { Organization } from './OrganizationList';
 import OrganizationForm from './OrganizationForm';
 import SiteList, { type Site } from './SiteList';
 import SiteForm from './SiteForm';
+import MergeOrgModal from './MergeOrgModal';
 import BulkOrgImport from '../organizations/BulkOrgImport';
 import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
+import { useJwtClaims } from '../../lib/authScope';
 import { extractApiError } from '@/lib/apiError';
 import { runAction, ActionError } from '@/lib/runAction';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 
-type ModalMode = 'closed' | 'add' | 'edit' | 'delete';
+type ModalMode = 'closed' | 'add' | 'edit' | 'delete' | 'merge';
 type SiteModalMode = 'closed' | 'add' | 'edit' | 'delete';
 
 type OrganizationFormValues = {
@@ -78,6 +80,14 @@ import { fetchAllOrganizations } from '../../lib/fetchAllOrganizations';
 
 export default function OrganizationsPage() {
   const { t } = useTranslation('settings');
+  // Merge is a partner-scope-only action (the API's org-merge routes require
+  // `requireScope('partner', 'system')`, and only a partner token's own
+  // partner org list is ever eligible as a survivor). `useJwtClaims()`
+  // (not the one-shot `getJwtClaims()`) so this stays reactive to the token
+  // landing after cold load instead of freezing the pre-token "unresolved"
+  // answer for the life of the mount (#4013's lesson, TicketingSettingsTabs).
+  const jwt = useJwtClaims();
+  const canMergeOrgs = jwt.status === 'resolved' && jwt.claims.scope === 'partner';
   const [organizations, setOrganizations] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -280,6 +290,25 @@ export default function OrganizationsPage() {
   const handleDelete = (org: Organization) => {
     setSelectedOrg(org);
     setModalMode('delete');
+  };
+
+  const handleMerge = (org: Organization) => {
+    setSelectedOrg(org);
+    setModalMode('merge');
+  };
+
+  /**
+   * Called by MergeOrgModal once its merge-runs poll reports `completed`.
+   * NOT a `refreshOrgs()` — the merged-away org is not soft-deleted, it ends
+   * up a terminal `status='merging'` shell with `deleted_at IS NULL`
+   * (services/orgMerge.ts), so a refetch would still return it. The local
+   * filter is the only way to actually drop it from this screen; mirrors
+   * handleConfirmDelete's selectedOrg-clearing behavior below.
+   */
+  const handleMergeComplete = (loserId: string) => {
+    setOrganizations(prev => prev.filter(o => o.id !== loserId));
+    if (selectedOrg?.id === loserId) setSelectedOrg(null);
+    handleCloseModal();
   };
 
   const handleSelectOrg = (org: Organization) => {
@@ -883,6 +912,16 @@ export default function OrganizationsPage() {
                     >
                       {t('common:actions.delete')}
                     </button>
+                    {canMergeOrgs && (
+                      <button
+                        type="button"
+                        data-testid="org-merge-open"
+                        onClick={() => handleMerge(selectedOrg)}
+                        className="rounded-md border border-destructive/40 px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10"
+                      >
+                        {t('organizationsPage.merge.openButton')}
+                      </button>
+                    )}
                   </div>
                 </div>
               </div>
@@ -976,6 +1015,16 @@ export default function OrganizationsPage() {
             </div>
           </div>
         </div>
+      )}
+
+      {/* Org Merge Modal */}
+      {modalMode === 'merge' && selectedOrg && (
+        <MergeOrgModal
+          loserOrg={selectedOrg}
+          orgs={organizations}
+          onClose={handleCloseModal}
+          onMerged={handleMergeComplete}
+        />
       )}
 
       {/* Site Add/Edit Modal */}

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -42,6 +42,10 @@ const TARGET_GLOBS = [
   // cannot by itself stop a handler routing an error back to setError, whose
   // banner renders behind this page's modals.
   'src/components/settings/OrganizationsPage.tsx',
+  // Org merge (org-lifecycle Wave 3): both the preview and the actual merge
+  // POST are advisory-then-destructive mutations against a partner's tenant
+  // tree, so a silent failure here is exactly the class this guard exists for.
+  'src/components/settings/MergeOrgModal.tsx',
   'src/components/settings/LoginBrandingCard.tsx',
   'src/components/settings/ConnectSsoCard.tsx',
   'src/components/patches/PatchesPage.tsx',
@@ -358,8 +362,9 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    // 97 since #3989 added OrganizationsPage.tsx to the guarded set.
-    expect(absoluteFiles.length).toBe(97);
+    // 98: 97 since #3989 added OrganizationsPage.tsx, plus MergeOrgModal.tsx
+    // (org-lifecycle Wave 3).
+    expect(absoluteFiles.length).toBe(98);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -3116,6 +3116,7 @@
       "errors": {
         "preview": "Vorschau der Zusammenführung fehlgeschlagen",
         "merge": "Zusammenführung konnte nicht gestartet werden",
+        "missingResult": "Die Zusammenführung wurde abgeschlossen, lieferte aber keine Ergebnisdaten. Versuchen Sie es erneut.",
         "mfaRequired": "Das Zusammenführen von Organisationen erfordert Multi-Faktor-Authentifizierung. Aktivieren Sie MFA in Ihren Profil-Sicherheitseinstellungen und versuchen Sie es erneut."
       }
     }

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -3087,6 +3087,37 @@
       "title": "Standort löschen",
       "messagePrefix": "Sind Sie sicher, dass Sie löschen möchten?",
       "messageSuffix": "Diese Aktion kann nicht rückgängig gemacht werden."
+    },
+    "merge": {
+      "openButton": "In eine andere Organisation zusammenführen",
+      "title": "Organisation zusammenführen",
+      "description": "Verschieben Sie die Daten von {{name}} in eine bestehende Organisation. {{name}} wird danach dauerhaft stillgelegt und kann nicht wiederhergestellt werden.",
+      "survivorLabel": "Zusammenführen mit",
+      "survivorPlaceholder": "Ziel-Organisation auswählen...",
+      "noEligibleSurvivors": "Keine geeigneten Organisationen zum Zusammenführen.",
+      "previewLoading": "Berechnung, was verschoben würde...",
+      "totalMovableRows": "{{count}} Zeilen werden verschoben",
+      "tablesHeading": "Betroffene Tabellen",
+      "tableRowSummary": "{{table}}: {{loserRows}} Zeile(n), {{wouldDrop}} würden verworfen",
+      "warningsHeading": "Warnungen",
+      "tooLarge": "Dieser Zusammenschluss würde zu viele Zeilen verschieben, um automatisch ausgeführt zu werden. Wenden Sie sich an den Support, um einen manuellen Zusammenschluss zu planen.",
+      "confirmLabel": "Geben Sie \"{{name}}\" ein, um zu bestätigen",
+      "cancel": "Abbrechen",
+      "confirmButton": "Organisation zusammenführen",
+      "merging": "Wird zusammengeführt...",
+      "progressTitle": "Zusammenführung läuft",
+      "progressDescription": "Dies kann einige Minuten dauern.",
+      "doneTitle": "Zusammenführung abgeschlossen",
+      "resultSummary": "{{moved}} Zeile(n) verschoben, {{dropped}} Zeile(n) verworfen",
+      "close": "Schließen",
+      "failedTitle": "Zusammenführung fehlgeschlagen",
+      "retry": "Zusammenführung erneut versuchen",
+      "retrying": "Wird erneut versucht...",
+      "errors": {
+        "preview": "Vorschau der Zusammenführung fehlgeschlagen",
+        "merge": "Zusammenführung konnte nicht gestartet werden",
+        "mfaRequired": "Das Zusammenführen von Organisationen erfordert Multi-Faktor-Authentifizierung. Aktivieren Sie MFA in Ihren Profil-Sicherheitseinstellungen und versuchen Sie es erneut."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -3140,6 +3140,37 @@
       "title": "Delete Site",
       "messagePrefix": "Are you sure you want to delete",
       "messageSuffix": " This action cannot be undone."
+    },
+    "merge": {
+      "openButton": "Merge into another organization",
+      "title": "Merge organization",
+      "description": "Move {{name}}'s data into a surviving organization. {{name}} is retired permanently afterward and cannot be recovered.",
+      "survivorLabel": "Merge into",
+      "survivorPlaceholder": "Select a surviving organization...",
+      "noEligibleSurvivors": "No eligible organizations to merge into.",
+      "previewLoading": "Calculating what would move...",
+      "totalMovableRows": "{{count}} rows will move",
+      "tablesHeading": "Affected tables",
+      "tableRowSummary": "{{table}}: {{loserRows}} row(s), {{wouldDrop}} would be dropped",
+      "warningsHeading": "Warnings",
+      "tooLarge": "This merge would move too many rows to run automatically. Contact support to schedule a manual merge.",
+      "confirmLabel": "Type \"{{name}}\" to confirm",
+      "cancel": "Cancel",
+      "confirmButton": "Merge organization",
+      "merging": "Merging...",
+      "progressTitle": "Merge in progress",
+      "progressDescription": "This can take a few minutes.",
+      "doneTitle": "Merge complete",
+      "resultSummary": "{{moved}} row(s) moved, {{dropped}} row(s) dropped",
+      "close": "Close",
+      "failedTitle": "Merge failed",
+      "retry": "Retry merge",
+      "retrying": "Retrying...",
+      "errors": {
+        "preview": "Failed to preview the merge",
+        "merge": "Failed to start the merge",
+        "mfaRequired": "Merging organizations requires multi-factor authentication. Enable MFA in your profile security settings, then try again."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -3169,6 +3169,7 @@
       "errors": {
         "preview": "Failed to preview the merge",
         "merge": "Failed to start the merge",
+        "missingResult": "The merge finished but returned no result data. Try again.",
         "mfaRequired": "Merging organizations requires multi-factor authentication. Enable MFA in your profile security settings, then try again."
       }
     }

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -3087,6 +3087,37 @@
       "title": "Eliminar sitio",
       "messagePrefix": "¿Está seguro de que desea eliminar?",
       "messageSuffix": "Esta acción no se puede deshacer."
+    },
+    "merge": {
+      "openButton": "Fusionar con otra organización",
+      "title": "Fusionar organización",
+      "description": "Mueva los datos de {{name}} a una organización sobreviviente. {{name}} quedará retirada de forma permanente después y no podrá recuperarse.",
+      "survivorLabel": "Fusionar con",
+      "survivorPlaceholder": "Seleccione una organización sobreviviente...",
+      "noEligibleSurvivors": "No hay organizaciones aptas para fusionar.",
+      "previewLoading": "Calculando lo que se movería...",
+      "totalMovableRows": "Se moverán {{count}} filas",
+      "tablesHeading": "Tablas afectadas",
+      "tableRowSummary": "{{table}}: {{loserRows}} fila(s), se descartarían {{wouldDrop}}",
+      "warningsHeading": "Advertencias",
+      "tooLarge": "Esta fusión movería demasiadas filas para ejecutarse automáticamente. Comuníquese con soporte para programar una fusión manual.",
+      "confirmLabel": "Escriba \"{{name}}\" para confirmar",
+      "cancel": "Cancelar",
+      "confirmButton": "Fusionar organización",
+      "merging": "Fusionando...",
+      "progressTitle": "Fusión en curso",
+      "progressDescription": "Esto puede tardar unos minutos.",
+      "doneTitle": "Fusión completada",
+      "resultSummary": "{{moved}} fila(s) movida(s), {{dropped}} fila(s) descartada(s)",
+      "close": "Cerrar",
+      "failedTitle": "La fusión falló",
+      "retry": "Reintentar fusión",
+      "retrying": "Reintentando...",
+      "errors": {
+        "preview": "No se pudo obtener la vista previa de la fusión",
+        "merge": "No se pudo iniciar la fusión",
+        "mfaRequired": "Fusionar organizaciones requiere autenticación multifactor. Active la MFA en la configuración de seguridad de su perfil y vuelva a intentarlo."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -3116,6 +3116,7 @@
       "errors": {
         "preview": "No se pudo obtener la vista previa de la fusión",
         "merge": "No se pudo iniciar la fusión",
+        "missingResult": "La fusión terminó pero no devolvió datos de resultado. Vuelva a intentarlo.",
         "mfaRequired": "Fusionar organizaciones requiere autenticación multifactor. Active la MFA en la configuración de seguridad de su perfil y vuelva a intentarlo."
       }
     }

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -3135,6 +3135,37 @@
       "title": "Supprimer le site",
       "messagePrefix": "Êtes-vous sûr de vouloir supprimer ?",
       "messageSuffix": " Cette action ne peut être annulée."
+    },
+    "merge": {
+      "openButton": "Fusionner avec une autre organisation",
+      "title": "Fusionner l'organisation",
+      "description": "Déplacez les données de {{name}} vers une organisation survivante. {{name}} est ensuite retirée définitivement et ne peut plus être récupérée.",
+      "survivorLabel": "Fusionner avec",
+      "survivorPlaceholder": "Sélectionnez une organisation survivante...",
+      "noEligibleSurvivors": "Aucune organisation éligible pour la fusion.",
+      "previewLoading": "Calcul de ce qui serait déplacé...",
+      "totalMovableRows": "{{count}} lignes seront déplacées",
+      "tablesHeading": "Tables concernées",
+      "tableRowSummary": "{{table}} : {{loserRows}} ligne(s), {{wouldDrop}} seraient abandonnées",
+      "warningsHeading": "Avertissements",
+      "tooLarge": "Cette fusion déplacerait trop de lignes pour s'exécuter automatiquement. Contactez le support pour planifier une fusion manuelle.",
+      "confirmLabel": "Saisissez « {{name}} » pour confirmer",
+      "cancel": "Annuler",
+      "confirmButton": "Fusionner l'organisation",
+      "merging": "Fusion en cours...",
+      "progressTitle": "Fusion en cours",
+      "progressDescription": "Cela peut prendre quelques minutes.",
+      "doneTitle": "Fusion terminée",
+      "resultSummary": "{{moved}} ligne(s) déplacée(s), {{dropped}} ligne(s) abandonnée(s)",
+      "close": "Fermer",
+      "failedTitle": "Échec de la fusion",
+      "retry": "Réessayer la fusion",
+      "retrying": "Nouvelle tentative...",
+      "errors": {
+        "preview": "Échec de l'aperçu de la fusion",
+        "merge": "Échec du démarrage de la fusion",
+        "mfaRequired": "La fusion d'organisations nécessite l'authentification multifacteur. Activez la MFA dans les paramètres de sécurité de votre profil, puis réessayez."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -3164,6 +3164,7 @@
       "errors": {
         "preview": "Échec de l'aperçu de la fusion",
         "merge": "Échec du démarrage de la fusion",
+        "missingResult": "La fusion s'est terminée mais n'a renvoyé aucune donnée de résultat. Réessayez.",
         "mfaRequired": "La fusion d'organisations nécessite l'authentification multifacteur. Activez la MFA dans les paramètres de sécurité de votre profil, puis réessayez."
       }
     }

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -3087,6 +3087,37 @@
       "title": "Supprimer le site",
       "messagePrefix": "Êtes-vous sûr de vouloir supprimer ?",
       "messageSuffix": " Cette action ne peut être annulée."
+    },
+    "merge": {
+      "openButton": "Fusionner avec une autre organisation",
+      "title": "Fusionner l'organisation",
+      "description": "Déplacez les données de {{name}} vers une organisation survivante. {{name}} est ensuite retirée définitivement et ne peut plus être récupérée.",
+      "survivorLabel": "Fusionner avec",
+      "survivorPlaceholder": "Sélectionnez une organisation survivante...",
+      "noEligibleSurvivors": "Aucune organisation éligible pour la fusion.",
+      "previewLoading": "Calcul de ce qui serait déplacé...",
+      "totalMovableRows": "{{count}} lignes seront déplacées",
+      "tablesHeading": "Tables concernées",
+      "tableRowSummary": "{{table}} : {{loserRows}} ligne(s), {{wouldDrop}} seraient abandonnées",
+      "warningsHeading": "Avertissements",
+      "tooLarge": "Cette fusion déplacerait trop de lignes pour s'exécuter automatiquement. Contactez le support pour planifier une fusion manuelle.",
+      "confirmLabel": "Saisissez « {{name}} » pour confirmer",
+      "cancel": "Annuler",
+      "confirmButton": "Fusionner l'organisation",
+      "merging": "Fusion en cours...",
+      "progressTitle": "Fusion en cours",
+      "progressDescription": "Cela peut prendre quelques minutes.",
+      "doneTitle": "Fusion terminée",
+      "resultSummary": "{{moved}} ligne(s) déplacée(s), {{dropped}} ligne(s) abandonnée(s)",
+      "close": "Fermer",
+      "failedTitle": "Échec de la fusion",
+      "retry": "Réessayer la fusion",
+      "retrying": "Nouvelle tentative...",
+      "errors": {
+        "preview": "Échec de l'aperçu de la fusion",
+        "merge": "Échec du démarrage de la fusion",
+        "mfaRequired": "La fusion d'organisations nécessite l'authentification multifacteur. Activez la MFA dans les paramètres de sécurité de votre profil, puis réessayez."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -3116,6 +3116,7 @@
       "errors": {
         "preview": "Échec de l'aperçu de la fusion",
         "merge": "Échec du démarrage de la fusion",
+        "missingResult": "La fusion s'est terminée mais n'a renvoyé aucune donnée de résultat. Réessayez.",
         "mfaRequired": "La fusion d'organisations nécessite l'authentification multifacteur. Activez la MFA dans les paramètres de sécurité de votre profil, puis réessayez."
       }
     }

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -3164,6 +3164,7 @@
       "errors": {
         "preview": "Anteprima dell'unione non riuscita",
         "merge": "Impossibile avviare l'unione",
+        "missingResult": "L'unione è terminata ma non ha restituito dati di risultato. Riprova.",
         "mfaRequired": "L'unione delle organizzazioni richiede l'autenticazione a più fattori. Attiva l'MFA nelle impostazioni di sicurezza del tuo profilo e riprova."
       }
     }

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -3135,6 +3135,37 @@
       "title": "Elimina sito",
       "messagePrefix": "Vuoi davvero eliminare",
       "messageSuffix": " Questa azione non può essere annullata."
+    },
+    "merge": {
+      "openButton": "Unisci a un'altra organizzazione",
+      "title": "Unisci organizzazione",
+      "description": "Sposta i dati di {{name}} in un'organizzazione superstite. {{name}} viene quindi ritirata permanentemente e non può essere recuperata.",
+      "survivorLabel": "Unisci a",
+      "survivorPlaceholder": "Seleziona un'organizzazione superstite...",
+      "noEligibleSurvivors": "Nessuna organizzazione idonea a cui unire.",
+      "previewLoading": "Calcolo di ciò che verrebbe spostato...",
+      "totalMovableRows": "Verranno spostate {{count}} righe",
+      "tablesHeading": "Tabelle interessate",
+      "tableRowSummary": "{{table}}: {{loserRows}} riga/e, {{wouldDrop}} verrebbero scartate",
+      "warningsHeading": "Avvisi",
+      "tooLarge": "Questa unione sposterebbe troppe righe per essere eseguita automaticamente. Contatta l'assistenza per pianificare un'unione manuale.",
+      "confirmLabel": "Digita \"{{name}}\" per confermare",
+      "cancel": "Annulla",
+      "confirmButton": "Unisci organizzazione",
+      "merging": "Unione in corso...",
+      "progressTitle": "Unione in corso",
+      "progressDescription": "L'operazione può richiedere alcuni minuti.",
+      "doneTitle": "Unione completata",
+      "resultSummary": "{{moved}} riga/e spostate, {{dropped}} riga/e scartate",
+      "close": "Chiudi",
+      "failedTitle": "Unione non riuscita",
+      "retry": "Riprova unione",
+      "retrying": "Nuovo tentativo...",
+      "errors": {
+        "preview": "Anteprima dell'unione non riuscita",
+        "merge": "Impossibile avviare l'unione",
+        "mfaRequired": "L'unione delle organizzazioni richiede l'autenticazione a più fattori. Attiva l'MFA nelle impostazioni di sicurezza del tuo profilo e riprova."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -3169,6 +3169,7 @@
       "errors": {
         "preview": "Falha ao pré-visualizar a mesclagem",
         "merge": "Falha ao iniciar a mesclagem",
+        "missingResult": "A mesclagem terminou, mas não retornou dados de resultado. Tente novamente.",
         "mfaRequired": "Mesclar organizações requer autenticação multifator. Ative o MFA nas configurações de segurança do seu perfil e tente novamente."
       }
     }

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -3140,6 +3140,37 @@
       "title": "Excluir site",
       "messagePrefix": "Tem certeza de que deseja excluir",
       "messageSuffix": "Esta ação não pode ser desfeita."
+    },
+    "merge": {
+      "openButton": "Mesclar com outra organização",
+      "title": "Mesclar organização",
+      "description": "Mova os dados de {{name}} para uma organização sobrevivente. {{name}} é então desativada permanentemente e não pode ser recuperada.",
+      "survivorLabel": "Mesclar com",
+      "survivorPlaceholder": "Selecione uma organização sobrevivente...",
+      "noEligibleSurvivors": "Nenhuma organização elegível para mesclagem.",
+      "previewLoading": "Calculando o que seria movido...",
+      "totalMovableRows": "{{count}} linhas serão movidas",
+      "tablesHeading": "Tabelas afetadas",
+      "tableRowSummary": "{{table}}: {{loserRows}} linha(s), {{wouldDrop}} seriam descartadas",
+      "warningsHeading": "Avisos",
+      "tooLarge": "Esta mesclagem moveria linhas demais para ser executada automaticamente. Entre em contato com o suporte para agendar uma mesclagem manual.",
+      "confirmLabel": "Digite \"{{name}}\" para confirmar",
+      "cancel": "Cancelar",
+      "confirmButton": "Mesclar organização",
+      "merging": "Mesclando...",
+      "progressTitle": "Mesclagem em andamento",
+      "progressDescription": "Isso pode levar alguns minutos.",
+      "doneTitle": "Mesclagem concluída",
+      "resultSummary": "{{moved}} linha(s) movida(s), {{dropped}} linha(s) descartada(s)",
+      "close": "Fechar",
+      "failedTitle": "Falha na mesclagem",
+      "retry": "Repetir mesclagem",
+      "retrying": "Repetindo...",
+      "errors": {
+        "preview": "Falha ao pré-visualizar a mesclagem",
+        "merge": "Falha ao iniciar a mesclagem",
+        "mfaRequired": "Mesclar organizações requer autenticação multifator. Ative o MFA nas configurações de segurança do seu perfil e tente novamente."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -3140,6 +3140,37 @@
       "title": "Siteyi Sil",
       "messagePrefix": "Silmek istediğinizden emin misiniz?",
       "messageSuffix": "Bu işlem geri alınamaz."
+    },
+    "merge": {
+      "openButton": "Başka bir kuruluşla birleştir",
+      "title": "Kuruluşu birleştir",
+      "description": "{{name}} kuruluşunun verilerini hayatta kalan bir kuruluşa taşıyın. {{name}} bundan sonra kalıcı olarak kapatılır ve geri alınamaz.",
+      "survivorLabel": "Şununla birleştir",
+      "survivorPlaceholder": "Hayatta kalan bir kuruluş seçin...",
+      "noEligibleSurvivors": "Birleştirilebilecek uygun kuruluş yok.",
+      "previewLoading": "Neyin taşınacağı hesaplanıyor...",
+      "totalMovableRows": "{{count}} satır taşınacak",
+      "tablesHeading": "Etkilenen tablolar",
+      "tableRowSummary": "{{table}}: {{loserRows}} satır, {{wouldDrop}} satır bırakılacak",
+      "warningsHeading": "Uyarılar",
+      "tooLarge": "Bu birleştirme, otomatik olarak çalıştırılamayacak kadar çok satır taşır. Manuel bir birleştirme planlamak için destek ekibiyle iletişime geçin.",
+      "confirmLabel": "Onaylamak için \"{{name}}\" yazın",
+      "cancel": "İptal",
+      "confirmButton": "Kuruluşu birleştir",
+      "merging": "Birleştiriliyor...",
+      "progressTitle": "Birleştirme devam ediyor",
+      "progressDescription": "Bu işlem birkaç dakika sürebilir.",
+      "doneTitle": "Birleştirme tamamlandı",
+      "resultSummary": "{{moved}} satır taşındı, {{dropped}} satır bırakıldı",
+      "close": "Kapat",
+      "failedTitle": "Birleştirme başarısız oldu",
+      "retry": "Birleştirmeyi yeniden dene",
+      "retrying": "Yeniden deneniyor...",
+      "errors": {
+        "preview": "Birleştirme önizlemesi başarısız oldu",
+        "merge": "Birleştirme başlatılamadı",
+        "mfaRequired": "Kuruluşları birleştirmek çok faktörlü kimlik doğrulama gerektirir. Profil güvenlik ayarlarınızda MFA'yı etkinleştirin ve tekrar deneyin."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -3169,6 +3169,7 @@
       "errors": {
         "preview": "Birleştirme önizlemesi başarısız oldu",
         "merge": "Birleştirme başlatılamadı",
+        "missingResult": "Birleştirme tamamlandı ancak sonuç verisi döndürmedi. Tekrar deneyin.",
         "mfaRequired": "Kuruluşları birleştirmek çok faktörlü kimlik doğrulama gerektirir. Profil güvenlik ayarlarınızda MFA'yı etkinleştirin ve tekrar deneyin."
       }
     }


### PR DESCRIPTION
Wave 3 of the org-lifecycle feature (#4074). Partner admins can merge a duplicate org into its survivor from the Organizations page: survivor picker (same-partner, active/trial, excludes quick_support) → preview with per-table counts, would-drop numbers, and every engine warning (audit-trail destruction, key revocations, too-large refusal) → typed-name confirm → live progress via merge-runs polling → persistent result summary.

**Stacked on #4111 (Wave 2).** No automatic CI — dispatched manually on the branch.

Hardening from review (Codex first-pass + scoped re-reviews): done-summary made reachable in real page wiring (list update decoupled from close/selection cleanup); warnings render independent of verdict; serialized run-token polling with unmount guards covering the merge POST itself; completed-without-result treated as failure with retry; stale preview responses dropped by request id. All mutations via runAction; 8-locale i18n; full web suite 6626/6626.

Spec: docs/superpowers/specs/tenancy-rls/2026-08-26-org-lifecycle-merge-archive-design.md
Plan: docs/superpowers/plans/tenancy-rls/2026-08-26-org-lifecycle-w3-merge-ui.md

Closes #4077

🤖 Generated with [Claude Code](https://claude.com/claude-code)