### PR TITLE
feat(enrollment): default installer keys to 30 days / 50 devices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -399,15 +399,17 @@ MFA_RECOVERY_CODE_PEPPER=generate-a-random-hex-string-for-production
 # Leave it as-is unless you build and sign your own binaries.
 RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=
 # Default TTL (minutes) for newly created enrollment keys when expiresAt is not provided.
-ENROLLMENT_KEY_DEFAULT_TTL_MINUTES=60
+# 43200 = 30 days: downloaded installers are expected to keep working after being
+# staged through deployment tooling, not just on the day of download.
+ENROLLMENT_KEY_DEFAULT_TTL_MINUTES=43200
 # Fresh TTL (minutes) given to a "child" enrollment key minted at installer-download,
 # installer-link, or short-code redemption time. Measured from mint time, independent
 # of the parent key's remaining lifetime.
-CHILD_ENROLLMENT_KEY_TTL_MINUTES=1440
+CHILD_ENROLLMENT_KEY_TTL_MINUTES=43200
 # Base TTL (minutes) for a freshly-issued installer bootstrap token when no explicit
 # ttlMinutes is supplied. The token's own expiry -- not the parent enrollment key's --
 # governs how long an installer has to complete enrollment.
-INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES=1440
+INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES=43200
 # Minimum remaining lifetime (seconds) a parent enrollment key must have to be used as
 # an installer source. Guards against building an installer from a parent that expires
 # before the download reaches the target machine.

--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -467,7 +467,7 @@ describe('device routes', () => {
       }
     });
 
-    it('defaults the token TTL to 60 minutes and honors a supplied ttlMinutes (#1108)', async () => {
+    it('defaults the token TTL to 30 days and honors a supplied ttlMinutes (#1108)', async () => {
       vi.stubEnv('AGENT_ENROLLMENT_SECRET', '');
 
       const captureExpiry = () => {
@@ -488,15 +488,19 @@ describe('device routes', () => {
         return Math.round((expiresAt.getTime() - Date.now()) / 60000);
       };
 
-      // Default (no ttlMinutes) → 60 min.
+      // Default (no ttlMinutes) → the ENROLLMENT_KEY_DEFAULT_TTL_MINUTES
+      // fallback, 30 days. This route mints a real `enrollment_keys` row, so it
+      // moved with the rest of the enrollment defaults: a token pasted into
+      // deployment tooling has to outlive the download day, which the old
+      // 60-minute window did not (US trial mass deploy, 2026-08-26).
       let valuesMock = captureExpiry();
       let res = await app.request('/devices/onboarding-token', {
         method: 'POST',
         headers: { Authorization: 'Bearer token' }
       });
       expect(res.status).toBe(200);
-      expect(expiryMinutesFrom(valuesMock)).toBeGreaterThanOrEqual(59);
-      expect(expiryMinutesFrom(valuesMock)).toBeLessThanOrEqual(61);
+      expect(expiryMinutesFrom(valuesMock)).toBeGreaterThanOrEqual(43_199);
+      expect(expiryMinutesFrom(valuesMock)).toBeLessThanOrEqual(43_201);
 
       // Supplied 1440 → ~24h.
       valuesMock = captureExpiry();
@@ -625,7 +629,7 @@ describe('device routes', () => {
     // `Content-Type: application/json` unconditionally. Under a plain
     // zValidator('json', ...) that combination 400s with a plain-text
     // "Malformed JSON in request body" and onboarding dies at the last step.
-    // The route must still mint a default 60-minute single-use token.
+    // The route must still mint a default-TTL single-use token.
     it('accepts a bodyless POST that still carries a JSON content-type (#2777)', async () => {
       vi.stubEnv('AGENT_ENROLLMENT_SECRET', '');
       const valuesMock = vi.fn().mockResolvedValue(undefined);
@@ -652,8 +656,8 @@ describe('device routes', () => {
       };
       expect(maxUsage).toBe(1);
       const minutes = Math.round((expiresAt.getTime() - Date.now()) / 60000);
-      expect(minutes).toBeGreaterThanOrEqual(59);
-      expect(minutes).toBeLessThanOrEqual(61);
+      expect(minutes).toBeGreaterThanOrEqual(43_199);
+      expect(minutes).toBeLessThanOrEqual(43_201);
     });
 
     // Same shape, but with an explicitly empty string body (what a

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -402,7 +402,7 @@ coreRoutes.post(
     }
 
     const ttlMinutes = explicitTtlMinutes
-      ?? envInt('ENROLLMENT_KEY_DEFAULT_TTL_MINUTES', 60);
+      ?? envInt('ENROLLMENT_KEY_DEFAULT_TTL_MINUTES', 60 * 24 * 30);
 
     const key = `enroll_${randomBytes(24).toString('hex')}`;
     const keyHash = hashEnrollmentKey(key);

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -370,8 +370,11 @@ coreRoutes.post(
     // Optional caller-supplied multi-use / TTL controls (#1108). A copied CLI
     // command is frequently pasted onto several machines during a migration;
     // without these the historical hard-coded single-use token failed on every
-    // machine after the first. Defaults preserve the old single-use, 60-min
-    // behaviour for callers that send no body.
+    // machine after the first. A caller that sends no body still gets a
+    // single-use token, but its TTL now follows the shared enrollment default
+    // (ENROLLMENT_KEY_DEFAULT_TTL_MINUTES, 30 days) rather than the old 60
+    // minutes — this route mints a real `enrollment_keys` row, and a token
+    // staged through deployment tooling has to outlive the download day.
     const data = c.req.valid('json');
     const rawCount = Number((data as { count?: unknown }).count);
     const maxUsage = Number.isFinite(rawCount)

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -319,9 +319,9 @@ describe("POST /enrollment-keys/:id/installer-link", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("child key gets a 24h TTL when parent has enough remaining life", async () => {
+  it("child key gets a 30-day TTL when parent has enough remaining life", async () => {
     // Parent has 1h remaining (plenty) — child insert should fire with a
-    // fresh ~24h expiresAt, independent of parent.
+    // fresh ~30-day expiresAt, independent of parent.
     const parentRow = makeKeyRow({
       expiresAt: new Date(Date.now() + 60 * 60 * 1000), // 1h
     });
@@ -361,10 +361,10 @@ describe("POST /enrollment-keys/:id/installer-link", () => {
     const firstCall = insertValues.mock.calls[0]!;
     const insertedRow = firstCall[0] as { expiresAt: Date };
     const childExpiryMs = insertedRow.expiresAt.getTime();
-    // Child TTL must be at least 23 hours past "before" (well above parent's 1h)
-    expect(childExpiryMs).toBeGreaterThan(before + 23 * 60 * 60 * 1000);
-    // And no more than 25 hours past "after" (guards against runaway values)
-    expect(childExpiryMs).toBeLessThan(after + 25 * 60 * 60 * 1000);
+    // Child TTL must be at least 29 days past "before" (well above parent's 1h)
+    expect(childExpiryMs).toBeGreaterThan(before + 29 * 24 * 60 * 60 * 1000);
+    // And no more than 31 days past "after" (guards against runaway values)
+    expect(childExpiryMs).toBeLessThan(after + 31 * 24 * 60 * 60 * 1000);
     // Explicitly NOT the parent's expiresAt
     expect(childExpiryMs).not.toBe(parentRow.expiresAt.getTime());
   });
@@ -541,7 +541,7 @@ describe("POST /enrollment-keys/:id/installer-link", () => {
   // #2776 final wave — the SEVENTH uncapped mint path. assertTtlWithinCap
   // returns null for `undefined` by design, so OMITTING ttlMinutes used to
   // hand the child key the uncapped CHILD_ENROLLMENT_KEY_TTL_MINUTES server
-  // constant (1440) — 24x a 60-minute partner cap, on one of the two
+  // constant (43200) — 720x a 60-minute partner cap, on one of the two
   // most-used download routes.
   it("clamps the CHILD_ENROLLMENT_KEY_TTL_MINUTES fallback to the partner cap when ttlMinutes is omitted (#2776)", async () => {
     mockEnrollmentDefaults({ maxTtlMinutes: 60 });
@@ -582,8 +582,8 @@ describe("POST /enrollment-keys/:id/installer-link", () => {
 
     expect(res.status).toBe(200);
     // The uncapped server constant is what gets handed to the clamp...
-    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 1440);
-    // ...and the key that actually lands is the 60-minute cap, not 24h.
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 43200);
+    // ...and the key that actually lands is the 60-minute cap, not 30 days.
     expect(capturedChildValues).not.toBeNull();
     const expiresAt = (capturedChildValues as unknown as { expiresAt: Date }).expiresAt;
     expect(expiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
@@ -714,7 +714,7 @@ describe("GET /s/:code", () => {
   });
 
   // Fix round 3 (#2776): this route mints its own download child key via
-  // CHILD_ENROLLMENT_KEY_TTL_MINUTES (default 1440) with no interactive
+  // CHILD_ENROLLMENT_KEY_TTL_MINUTES (default 43200) with no interactive
   // caller (it's the public short-link redemption), so a partner cap below
   // that default must clamp the minted lifetime down, never reject.
   it("clamps the download child key's TTL down when the partner cap is below the default", async () => {
@@ -749,10 +749,10 @@ describe("GET /s/:code", () => {
     expect(res.status).toBe(200);
     expect(insertValues).toHaveBeenCalledTimes(1);
     const insertedRow = insertValues.mock.calls[0]![0] as { expiresAt: Date };
-    // Clamped to the 60-minute cap, NOT the 1440-minute (24h) default.
+    // Clamped to the 60-minute cap, NOT the 43200-minute (30-day) default.
     expect(insertedRow.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
     expect(insertedRow.expiresAt.getTime()).toBeLessThanOrEqual(after + 60 * 60 * 1000 + 5_000);
-    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 1440);
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 43200);
   });
 
   it("does not shorten the download child key's TTL when the partner cap is above the default (no-op clamp)", async () => {
@@ -786,9 +786,9 @@ describe("GET /s/:code", () => {
 
     expect(res.status).toBe(200);
     const insertedRow = insertValues.mock.calls[0]![0] as { expiresAt: Date };
-    // Unchanged: still the full 1440-minute (24h) default.
-    expect(insertedRow.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 1439 * 60 * 1000);
-    expect(insertedRow.expiresAt.getTime()).toBeLessThanOrEqual(after + 1441 * 60 * 1000);
+    // Unchanged: still the full 43200-minute (30-day) default.
+    expect(insertedRow.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 43199 * 60 * 1000);
+    expect(insertedRow.expiresAt.getTime()).toBeLessThanOrEqual(after + 43201 * 60 * 1000);
   });
 
   // #3038: the Windows bootstrap token minted on a short-link download must
@@ -2244,7 +2244,7 @@ describe("GET /:id/installer/macos — app-bundle path", () => {
     const after = Date.now();
 
     expect(res.status).toBe(200);
-    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 1440);
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 43200);
     expect(capturedChildValues).not.toBeNull();
     const expiresAt = (capturedChildValues as unknown as { expiresAt: Date }).expiresAt;
     expect(expiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -94,9 +94,12 @@ function envInt(name: string, defaultValue: number): number {
   return Number.isFinite(parsed) ? parsed : defaultValue;
 }
 
+// 30 days by default: techs stage installers through deploy tooling and expect
+// them to keep working well past the download day. Must stay in step with
+// PRODUCT_DEFAULT_ENROLLMENT_TTL_MINUTES (packages/shared enrollmentDefaults).
 const DEFAULT_ENROLLMENT_KEY_TTL_MINUTES = envInt(
   "ENROLLMENT_KEY_DEFAULT_TTL_MINUTES",
-  60,
+  60 * 24 * 30,
 );
 
 // Child enrollment keys (installer downloads, installer-link downloads, and
@@ -104,10 +107,10 @@ const DEFAULT_ENROLLMENT_KEY_TTL_MINUTES = envInt(
 // the parent's remaining lifetime. The previous "inherit parentKey.expiresAt"
 // behaviour made installers DOA whenever the parent was near expiry at
 // download time — a minute-59 download against a 60-minute parent produced a
-// child good for only 60 seconds. 24h by default, overridable.
+// child good for only 60 seconds. 30 days by default, overridable.
 const CHILD_ENROLLMENT_KEY_TTL_MINUTES = envInt(
   "CHILD_ENROLLMENT_KEY_TTL_MINUTES",
-  60 * 24,
+  60 * 24 * 30,
 );
 
 // Parent keys that are within this window of expiry are refused as installer

--- a/apps/api/src/routes/enrollmentKeys_capClamp.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_capClamp.test.ts
@@ -194,14 +194,14 @@ describe('mintChildEnrollmentKey (fix round 3, #2776)', () => {
       partnerId: PARTNER_ID,
       orgId: ORG_ID,
       siteId: SITE_ID,
-      // no expiresInSeconds — falls back to CHILD_ENROLLMENT_KEY_TTL_MINUTES (1440)
+      // no expiresInSeconds — falls back to CHILD_ENROLLMENT_KEY_TTL_MINUTES (43200)
     });
     const after = Date.now();
 
     expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
     expect(result.expiresAt.getTime()).toBeLessThanOrEqual(after + 60 * 60 * 1000 + 5_000);
     expect(getInserted().expiresAt.getTime()).toBe(result.expiresAt.getTime());
-    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 1440);
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 43200);
   });
 
   // Fix round 4 (#2776): the seconds -> minutes conversion used Math.ceil, which
@@ -304,7 +304,7 @@ describe('redeemShortCode (fix round 3, #2776)', () => {
     const inserted = getInserted();
     expect(inserted.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
     expect(inserted.expiresAt.getTime()).toBeLessThanOrEqual(after + 60 * 60 * 1000 + 5_000);
-    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 1440);
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 43200);
   });
 
   it('does not shorten the invite child key TTL when the partner cap is above the default (no-op clamp)', async () => {
@@ -321,7 +321,7 @@ describe('redeemShortCode (fix round 3, #2776)', () => {
 
     expect(result).not.toBeNull();
     const inserted = getInserted();
-    expect(inserted.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 1439 * 60 * 1000);
-    expect(inserted.expiresAt.getTime()).toBeLessThanOrEqual(after + 1441 * 60 * 1000);
+    expect(inserted.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 43199 * 60 * 1000);
+    expect(inserted.expiresAt.getTime()).toBeLessThanOrEqual(after + 43201 * 60 * 1000);
   });
 });

--- a/apps/api/src/routes/enrollmentKeys_list_create.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_list_create.test.ts
@@ -184,11 +184,11 @@ function mockInsertCapture(rows: any[]): () => any {
 }
 
 // Server default when neither ttlMinutes nor expiresAt is supplied:
-// DEFAULT_ENROLLMENT_KEY_TTL_MINUTES = envInt("ENROLLMENT_KEY_DEFAULT_TTL_MINUTES", 60).
-// The env var is unset in tests, so the literal 60 is the resolved value
+// DEFAULT_ENROLLMENT_KEY_TTL_MINUTES = envInt("ENROLLMENT_KEY_DEFAULT_TTL_MINUTES", 43200).
+// The env var is unset in tests, so the literal 43200 (30 days) is the resolved value
 // (the constant is captured at module import — a later env mutation cannot
 // change it).
-const DEFAULT_TTL_MINUTES = 60;
+const DEFAULT_TTL_MINUTES = 43200;
 
 describe('enrollment key routes — list & create', () => {
   let app: Hono;

--- a/apps/api/src/services/enrollmentDefaults.test.ts
+++ b/apps/api/src/services/enrollmentDefaults.test.ts
@@ -207,7 +207,7 @@ describe('getEnrollmentDefaultsForOrg', () => {
   it('falls back to product defaults when neither org nor partner has settings', async () => {
     mockJoinRow({});
     const r = await getEnrollmentDefaultsForOrg(ORG_ID);
-    expect(r).toEqual({ ttlMinutes: 1440, deviceCount: 1, maxTtlMinutes: 525600 });
+    expect(r).toEqual({ ttlMinutes: 43200, deviceCount: 50, maxTtlMinutes: 525600 });
   });
 
   it('falls back to org-local values when there is no partner row (LEFT JOIN null)', async () => {

--- a/apps/api/src/services/installerBootstrapToken.test.ts
+++ b/apps/api/src/services/installerBootstrapToken.test.ts
@@ -51,8 +51,8 @@ describe('bootstrapTokenExpiresAt', () => {
 
   const minutesOut = (d: Date) => Math.round((d.getTime() - Date.now()) / 60_000);
 
-  it('defaults to 24 hours when the env var is unset', () => {
-    expect(minutesOut(bootstrapTokenExpiresAt())).toBe(1440);
+  it('defaults to 30 days when the env var is unset', () => {
+    expect(minutesOut(bootstrapTokenExpiresAt())).toBe(43200);
   });
 
   // #2776 regression. docker-compose threads this var in as
@@ -62,16 +62,16 @@ describe('bootstrapTokenExpiresAt', () => {
   // `Number(process.env.X ?? 24 * 60)` read gave 0 there (`??` doesn't fire
   // on '', Number('') === 0), so EVERY bootstrap token was minted already
   // expired and agent enrollment stopped working on upgrade.
-  it('falls back to 24 hours when the env var is the EMPTY STRING, not 0 (#2776)', () => {
+  it('falls back to 30 days when the env var is the EMPTY STRING, not 0 (#2776)', () => {
     vi.stubEnv('INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES', '');
     const expiresAt = bootstrapTokenExpiresAt();
-    expect(minutesOut(expiresAt)).toBe(1440);
+    expect(minutesOut(expiresAt)).toBe(43200);
     expect(expiresAt.getTime()).toBeGreaterThan(Date.now());
   });
 
-  it('falls back to 24 hours for a non-numeric value', () => {
+  it('falls back to 30 days for a non-numeric value', () => {
     vi.stubEnv('INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES', 'forever');
-    expect(minutesOut(bootstrapTokenExpiresAt())).toBe(1440);
+    expect(minutesOut(bootstrapTokenExpiresAt())).toBe(43200);
   });
 
   it('honours an explicit override', () => {

--- a/apps/api/src/services/installerBootstrapToken.ts
+++ b/apps/api/src/services/installerBootstrapToken.ts
@@ -25,9 +25,10 @@ export function generateBootstrapToken(): string {
 
 /**
  * Default TTL for a freshly-issued bootstrap token. Tunable via env
- * for testing; production default is 24 hours which matches the
- * "admin downloads installer, sends to user, user runs sometime
- * within a day" mental model.
+ * for testing; production default is 30 days — installers get staged
+ * through deploy tooling (RMM/GPO/Intune) and are expected to keep
+ * working well past the day they were downloaded. Keep in step with
+ * PRODUCT_DEFAULT_ENROLLMENT_TTL_MINUTES (packages/shared).
  *
  * Must go through `envInt`, never `Number(process.env.X ?? default)`:
  * compose threads this in as `${INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES:-}`,
@@ -37,6 +38,6 @@ export function generateBootstrapToken(): string {
  * pulled this release without adding the key to its .env (#2776).
  */
 export function bootstrapTokenExpiresAt(): Date {
-  const ttlMin = envInt('INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES', 24 * 60);
+  const ttlMin = envInt('INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES', 60 * 24 * 30);
   return new Date(Date.now() + ttlMin * 60 * 1000);
 }

--- a/apps/docs/src/content/docs/agents/enrollment-keys.mdx
+++ b/apps/docs/src/content/docs/agents/enrollment-keys.mdx
@@ -102,7 +102,7 @@ Every installer download, installer-link generation, or short-code redemption mi
   Previously, an installer's usable life was capped to its parent enrollment key's *remaining* life, and redemption returned `404` once the parent expired — so a 30-day installer link minted from the Add Device modal's transient ~60-minute parent key died in under an hour. As of this release, the bootstrap token's own `expiresAt` is the sole authority on whether an installer can still enroll a device; the parent key's expiry is no longer checked at redemption time. Revocation still works exactly as before: deleting the parent enrollment key cascade-deletes (`ON DELETE CASCADE`) every outstanding bootstrap token immediately, so a deliberate delete remains an effective kill switch.
 </Aside>
 
-The token's TTL defaults to `INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES` (24 hours) or the admin's chosen link expiry, clamped to the partner's `maxEnrollmentLinkTtlMinutes` cap if one is set — see [Partner & Organization Enrollment Defaults](#partner--organization-enrollment-defaults). The daily purge sweep also will not delete a parent enrollment key while it still has a live, unexhausted bootstrap token outstanding, even past the key's own grace period — see [Automatic Purge of Expired Keys](#automatic-purge-of-expired-keys).
+The token's TTL defaults to `INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES` (30 days) or the admin's chosen link expiry, clamped to the partner's `maxEnrollmentLinkTtlMinutes` cap if one is set — see [Partner & Organization Enrollment Defaults](#partner--organization-enrollment-defaults). The daily purge sweep also will not delete a parent enrollment key while it still has a live, unexhausted bootstrap token outstanding, even past the key's own grace period — see [Automatic Purge of Expired Keys](#automatic-purge-of-expired-keys).
 
 ---
 
@@ -141,12 +141,12 @@ curl -X POST https://breeze.yourdomain.com/api/v1/enrollment-keys \
 | `expiresAt` | `datetime` | No | Now + TTL | ISO 8601 absolute expiration. Mutually exclusive with `ttlMinutes`. |
 | `ttlMinutes` | `integer` | No | Now + TTL | Lifetime in minutes from creation (1 to 525600, i.e. up to 365 days). Mutually exclusive with `expiresAt`. |
 
-When neither `expiresAt` nor `ttlMinutes` is supplied, the key expires after `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` (default 60). Supplying both is rejected so the resolved expiry is unambiguous.
+When neither `expiresAt` nor `ttlMinutes` is supplied, the key expires after `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` (default 43200 — 30 days). Supplying both is rejected so the resolved expiry is unambiguous.
 
 POST and PATCH on `/enrollment-keys` reject any field that isn't in the table above. A typo like `maxUses` (instead of `maxUsage`) now returns `400 Bad Request` with a precise field-name error rather than silently dropping the value — useful when scripting key creation against earlier API examples that used different field names.
 
 <Aside>
-  The default TTL is configurable via the `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` environment variable. If unset, keys expire 60 minutes after creation.
+  The default TTL is configurable via the `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` environment variable. If unset, keys expire 30 days after creation.
 </Aside>
 
 <Aside type="tip">
@@ -373,8 +373,8 @@ Partners and organizations can configure three settings that shape enrollment li
 
 | Setting | Scope | Behavior |
 |---|---|---|
-| `defaultEnrollmentTtlMinutes` | Partner default, **inherit-with-override** by org | Pre-selects the link/installer expiry in the **Add Device** dialog. A partner sets a house default; an individual organization may override it with its own default. |
-| `defaultEnrollmentDeviceCount` | Partner default, **inherit-with-override** by org | Same inherit-with-override pattern, for the default device count on a new link. |
+| `defaultEnrollmentTtlMinutes` | Partner default, **inherit-with-override** by org | Pre-selects the link/installer expiry in the **Add Device** dialog. A partner sets a house default; an individual organization may override it with its own default. The product fallback when neither is set is 30 days. |
+| `defaultEnrollmentDeviceCount` | Partner default, **inherit-with-override** by org | Same inherit-with-override pattern, for the default device count on a new link. The product fallback when neither is set is 50 devices. |
 | `maxEnrollmentLinkTtlMinutes` | **Partner only** | A hard ceiling on enrollment key/installer lifetime for every organization under that partner. An organization cannot raise it — there is no org-level equivalent field. |
 
 Partners configure all three from their partner settings page (`PATCH /partners/me`); organizations override the first two from their own org settings page (`PATCH /orgs/organizations/:id`). See [Partner Management](/reference/partner-management/#updating-partner-settings-self-service) for the general settings-PATCH mechanics.
@@ -412,9 +412,9 @@ There is no option to mint a key or installer link that never expires, by design
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` | `60` | Default time-to-live for new enrollment keys when `expiresAt` is not specified. |
-| `CHILD_ENROLLMENT_KEY_TTL_MINUTES` | `1440` | Fresh TTL (minutes) given to a "child" enrollment key minted at installer-download, installer-link, or short-code redemption time, measured from mint time rather than the parent key's remaining lifetime. Clamped to the partner's `maxEnrollmentLinkTtlMinutes` cap. |
-| `INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES` | `1440` | Base TTL (minutes) for a freshly-issued [installer bootstrap token](#installer-bootstrap-tokens) when no explicit `ttlMinutes` is supplied. The token's own expiry, not the parent enrollment key's, governs how long an installer has to complete enrollment. |
+| `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` | `43200` | Default time-to-live for new enrollment keys when `expiresAt` is not specified. |
+| `CHILD_ENROLLMENT_KEY_TTL_MINUTES` | `43200` | Fresh TTL (minutes) given to a "child" enrollment key minted at installer-download, installer-link, or short-code redemption time, measured from mint time rather than the parent key's remaining lifetime. Clamped to the partner's `maxEnrollmentLinkTtlMinutes` cap. |
+| `INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES` | `43200` | Base TTL (minutes) for a freshly-issued [installer bootstrap token](#installer-bootstrap-tokens) when no explicit `ttlMinutes` is supplied. The token's own expiry, not the parent enrollment key's, governs how long an installer has to complete enrollment. |
 | `INSTALLER_PARENT_MIN_REMAINING_SECONDS` | `60` | Minimum remaining lifetime (seconds) a parent enrollment key must have to be used as an installer source. Guards against building an installer from a parent that expires before the download reaches the target machine. |
 | `ENROLLMENT_KEY_PEPPER` | -- | Pepper used for SHA-256 hashing of enrollment keys. Falls back to `APP_ENCRYPTION_KEY`, `SECRET_ENCRYPTION_KEY`, or `JWT_SECRET`. |
 | `AGENT_ENROLLMENT_SECRET` | -- | Static secret that gates the enrollment endpoint in production. If empty or unset, the gate is skipped in non-production environments. |

--- a/apps/web/src/components/devices/AddDeviceModal.test.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.test.tsx
@@ -217,9 +217,9 @@ describe('AddDeviceModal', () => {
     // the parent POST must NOT carry it (PR #739 review finding #1).
     expect(createBody.ttlMinutes).toBeUndefined();
 
-    // Default 24h (1440) flows to the installer (child) download URL.
+    // Default 30 days (43200) flows to the installer (child) download URL.
     const dlCall = fetchWithAuthMock.mock.calls[1];
-    expect(String(dlCall[0])).toContain('ttlMinutes=1440');
+    expect(String(dlCall[0])).toContain('ttlMinutes=43200');
   });
 
   // #2992 — the parent key must NOT carry the device count. max_usage is an
@@ -338,7 +338,7 @@ describe('AddDeviceModal', () => {
       expect(screen.getByDisplayValue(/public-download/)).toBeDefined();
     });
 
-    expect(screen.getByText(/Valid for 1 download/)).toBeDefined();
+    expect(screen.getByText(/Valid for 50 downloads/)).toBeDefined();
 
     // ttlMinutes goes on the installer-link (child) body, not the parent POST.
     const createCall = fetchWithAuthMock.mock.calls[0];
@@ -525,12 +525,12 @@ describe('AddDeviceModal', () => {
       expect(fetchWithAuthMock).toHaveBeenCalledWith(
         '/devices/onboarding-token',
         // #1108: the request now carries a device count → maxUsage.
-        // #2777: …and an explicit TTL (default 24h) with the JSON content type
+        // #2777: …and an explicit TTL (default 30 days) with the JSON content type
         // the route's strict validator requires.
         expect.objectContaining({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ count: 1, ttlMinutes: 1440 }),
+          body: JSON.stringify({ count: 50, ttlMinutes: 43200 }),
         })
       );
     });
@@ -593,7 +593,7 @@ describe('AddDeviceModal', () => {
         expect.objectContaining({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ count: 5, ttlMinutes: 1440 }),
+          body: JSON.stringify({ count: 5, ttlMinutes: 43200 }),
         })
       );
     });
@@ -687,8 +687,8 @@ describe('AddDeviceModal — resolved enrollment defaults (#2776)', () => {
 
     render(<AddDeviceModal isOpen onClose={vi.fn()} />);
 
-    expect((screen.getByTestId('link-ttl') as HTMLSelectElement).value).toBe('1440');
-    expect((screen.getByTestId('device-count') as HTMLInputElement).value).toBe('1');
+    expect((screen.getByTestId('link-ttl') as HTMLSelectElement).value).toBe('43200');
+    expect((screen.getByTestId('device-count') as HTMLInputElement).value).toBe('50');
     expect(optionLabels('link-ttl')).toEqual([
       '1 hour',
       '24 hours',

--- a/packages/shared/src/validators/enrollmentDefaults.test.ts
+++ b/packages/shared/src/validators/enrollmentDefaults.test.ts
@@ -46,8 +46,8 @@ describe('resolveEnrollmentDefaults', () => {
 
   it('falls back to product defaults when neither level sets anything', () => {
     const r = resolveEnrollmentDefaults({}, {});
-    expect(r.ttlMinutes).toBe(1440);
-    expect(r.deviceCount).toBe(1);
+    expect(r.ttlMinutes).toBe(43200);
+    expect(r.deviceCount).toBe(50);
     expect(r.maxTtlMinutes).toBe(525600);
   });
 

--- a/packages/shared/src/validators/enrollmentDefaults.ts
+++ b/packages/shared/src/validators/enrollmentDefaults.ts
@@ -98,9 +98,17 @@ export function clampTtlToOfferableOption(ttlMinutes: number, maxTtlMinutes: num
   return options[options.length - 1]!;
 }
 
-/** Product fallbacks when neither partner nor org has expressed a preference. */
-export const PRODUCT_DEFAULT_ENROLLMENT_TTL_MINUTES = 1440;
-export const PRODUCT_DEFAULT_ENROLLMENT_DEVICE_COUNT = 1;
+/**
+ * Product fallbacks when neither partner nor org has expressed a preference.
+ *
+ * 30 days / 50 devices (raised from 24h / 1): techs mass-deploy one downloaded
+ * installer through RMM/GPO tooling and expect it to keep working — a 24-hour
+ * single-use default meant any rollout that ran later than the download window
+ * silently enrolled nothing. Partners who want tighter credentials set their
+ * own defaults or cap (`maxEnrollmentLinkTtlMinutes`).
+ */
+export const PRODUCT_DEFAULT_ENROLLMENT_TTL_MINUTES = 43200;
+export const PRODUCT_DEFAULT_ENROLLMENT_DEVICE_COUNT = 50;
 
 export const enrollmentDefaultsSchema = z.object({
   defaultEnrollmentTtlMinutes: z.number().int().min(1).max(MAX_ENROLLMENT_TTL_MINUTES).optional(),


### PR DESCRIPTION
## Why

A US trial tenant mass-deployed agents on 2026-08-26 through their deployment tool and the machines never appeared: the installers' bootstrap credentials were short-lived and single-use, so anything that ran outside the download window silently enrolled nothing. Techs expect a downloaded MSI to keep working — the defaults now match that.

## What changed

| Knob | Before | After |
|---|---|---|
| `PRODUCT_DEFAULT_ENROLLMENT_TTL_MINUTES` (Add Device modal default) | 24 h | 30 d |
| `PRODUCT_DEFAULT_ENROLLMENT_DEVICE_COUNT` | 1 | 50 |
| `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` env fallback | 60 min | 30 d |
| `CHILD_ENROLLMENT_KEY_TTL_MINUTES` env fallback | 24 h | 30 d |
| `INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES` env fallback | 24 h | 30 d |

Not changed: partner/org-configured defaults, the partner cap (`maxEnrollmentLinkTtlMinutes`) and its clamp behavior, explicit per-link picker choices, and any self-host deployment that sets the env vars. 30 days / 50 devices are canonical picker options already (`ENROLLMENT_TTL_OPTIONS`, `MAX_ENROLLMENT_DEVICE_COUNT` = 1000).

## Tests

Red-first on the product-default assertions, then updated every suite pinned to the old values: `enrollmentDefaults` (shared + api service), `enrollmentKeys` / `_capClamp` / `_installer` / `_list_create`, `installerBootstrapToken`, web `AddDeviceModal` + settings editors. 294 API + 31 web modal + 24 shared tests green.

Docs (`agents/enrollment-keys.mdx`) and `.env.example` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULHE5HGkgodex1Z3MvjusT