### PR TITLE
fix(api,workspace): review round 2 — permanent-vs-transient AI errors, billing/stamp telemetry, teardown guard

### DIFF
--- a/apps/api/src/__tests__/integration/workspaceEnrichmentByok.integration.test.ts
+++ b/apps/api/src/__tests__/integration/workspaceEnrichmentByok.integration.test.ts
@@ -125,10 +125,19 @@ const REQUIRED_WORKSPACE_MIGRATIONS = [
 ];
 
 /**
- * EVERY table the three migrations above create — the teardown contract.
- * Keep in sync when `REQUIRED_WORKSPACE_MIGRATIONS` changes; anything missing
- * here leaks into `public` and reds `tenantCascade.integration.test.ts`.
- * Dropped in one statement with CASCADE, so declaration order is irrelevant.
+ * The tables the three migrations above create — the DROP MECHANISM, not the
+ * guard. Dropped in one statement with CASCADE, so declaration order is
+ * irrelevant.
+ *
+ * This list used to be the contract as well, which made the teardown assertion
+ * vacuous in exactly the case that matters: a migration that starts creating a
+ * NEW table is invisible here, so the assertion below would have happily
+ * reported "nothing survived" while the new relation leaked into `public` and
+ * red `tenantCascade.integration.test.ts` minutes later, in another file. The
+ * guard is now a before/after snapshot of every public BASE TABLE (see
+ * `assertPublicSchemaRestored`), which needs no maintenance and catches any
+ * table these migrations grow. Keeping this list current still matters — it is
+ * what actually removes them — but forgetting to now fails HERE, by name.
  */
 const WORKSPACE_FIXTURE_TABLES = [
   // 2026-07-10-workspace-foundation.sql
@@ -183,12 +192,8 @@ async function dropWorkspaceSchema(): Promise<void> {
   });
 }
 
-/**
- * Proves the teardown actually landed. Without this, a silently-failed drop
- * resurfaces as a baffling failure in a DIFFERENT file (`tenantCascade`)
- * potentially minutes later; here it names the leaking tables directly.
- */
-async function assertWorkspaceSchemaGone(): Promise<void> {
+/** Every public BASE TABLE currently in the shared integration database. */
+async function listPublicBaseTables(): Promise<Set<string>> {
   // Deliberately unparameterised + filtered in JS: binding a `text[]` into this
   // kind of probe is the exact shape that shipped `malformed array literal` once
   // before (see extensions/builtinTableProbe.integration.test.ts's header).
@@ -199,24 +204,72 @@ async function assertWorkspaceSchemaGone(): Promise<void> {
       WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
     `,
   );
-  const remaining = new Set(present.map((row) => row.table_name));
-  const survivors = WORKSPACE_FIXTURE_TABLES.filter((table) => remaining.has(table));
-  if (survivors.length > 0) {
+  return new Set(present.map((row) => row.table_name));
+}
+
+/**
+ * The `public` schema this suite inherited, snapshotted before its own
+ * migrations run. `null` when the suite is skipped for want of a DATABASE_URL.
+ *
+ * `vitest.integration.config.ts` sets `fileParallelism: false` and
+ * `sequence.concurrent: false`, so nothing else is creating or dropping tables
+ * between the two snapshots and set-equality is a sound contract.
+ */
+let publicTablesBeforeFixture: Set<string> | null = null;
+
+/**
+ * Proves the teardown actually landed — by COMPARING the schema, not by
+ * re-reading the same hand-maintained list the drop used.
+ *
+ * Without a real comparison, a silently-failed drop resurfaces as a baffling
+ * failure in a DIFFERENT file (`tenantCascade`) potentially minutes later. And
+ * a list-based assertion cannot see the case most likely to happen: one of
+ * these three shipped migrations growing a new `CREATE TABLE`, which would leak
+ * while the assertion reported success. Set-equality against the pre-fixture
+ * snapshot catches any table the migrations create, with no list to maintain,
+ * and reports it here by name.
+ */
+async function assertPublicSchemaRestored(): Promise<void> {
+  if (!publicTablesBeforeFixture) return;
+  const after = await listPublicBaseTables();
+
+  const leaked = [...after].filter((t) => !publicTablesBeforeFixture!.has(t)).sort();
+  const removed = [...publicTablesBeforeFixture].filter((t) => !after.has(t)).sort();
+
+  if (leaked.length > 0) {
     throw new Error(
-      `workspaceEnrichmentByok teardown leaked ee/workspace tables into the shared ` +
-        `integration database: ${survivors.join(', ')}. ` +
-        `Every org_id-columned public table is enumerated by ` +
-        `tenantCascade.integration.test.ts, so these WILL red the core GDPR cascade ` +
-        `contract for the rest of this run.`,
+      `workspaceEnrichmentByok teardown leaked tables into the shared integration ` +
+        `database: ${leaked.join(', ')}. Every org_id-columned public table is ` +
+        `enumerated by tenantCascade.integration.test.ts, so these WILL red the core ` +
+        `GDPR cascade contract for the rest of this run. If a shipped ee/workspace ` +
+        `migration grew a new table, add it to WORKSPACE_FIXTURE_TABLES.`,
+    );
+  }
+  if (removed.length > 0) {
+    throw new Error(
+      `workspaceEnrichmentByok teardown dropped tables it did not create: ` +
+        `${removed.join(', ')}. WORKSPACE_FIXTURE_TABLES names a relation that ` +
+        `belongs to the CORE schema — the CASCADE drop just destroyed it for every ` +
+        `suite that runs after this one.`,
     );
   }
 }
 
+/**
+ * Bring the fixture schema up, snapshotting the inherited `public` schema in
+ * between the defensive drop and the migrations.
+ *
+ * Snapshot ordering is load-bearing: it must come AFTER the defensive drop (a
+ * previous run killed mid-flight leaves workspace tables behind, and baking
+ * those into the baseline would make the teardown assertion accept them) and
+ * BEFORE the migrations (so every relation they create counts as this suite's).
+ */
 async function ensureWorkspaceSchema(): Promise<void> {
   // Defensive: a run killed mid-flight (Ctrl-C, CI timeout, an unhandled
   // rejection before afterAll) leaves the schema behind. Start from a known
   // state rather than inheriting a half-migrated one.
   await dropWorkspaceSchema();
+  publicTablesBeforeFixture = await listPublicBaseTables();
   await withWorkspaceAdmin(async (admin) => {
     for (const filename of REQUIRED_WORKSPACE_MIGRATIONS) {
       const content = readFileSync(join(WORKSPACE_MIGRATIONS_DIR, filename), 'utf8');
@@ -281,7 +334,7 @@ describe('workspace enrichment honors partner BYOK', () => {
   afterAll(async () => {
     if (!process.env.DATABASE_URL) return;
     await dropWorkspaceSchema();
-    await assertWorkspaceSchemaGone();
+    await assertPublicSchemaRestored();
   });
 
   runDb(

--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -4,7 +4,11 @@ import {
   calculateCostCents,
   checkAiRateLimit,
   checkBillingCredits,
+  checkBillingCreditsDetailed,
   checkBudget,
+  checkBudgetDetailed,
+  checkSystemAiRateLimit,
+  deductBillingCredits,
   getUsageSummary,
   recordSessionlessSdkUsage,
   recordUsage,
@@ -14,6 +18,7 @@ import {
 import { db, withSystemDbAccessContext } from '../db';
 import { getEffectiveAiBudget } from './effectiveSettings';
 import { rateLimiter } from './rate-limit';
+import { captureException, captureMessage } from './sentry';
 
 // ============================================
 // Mocks
@@ -72,6 +77,7 @@ vi.mock('../db/schema', () => ({
 vi.mock('./redis', () => ({ getRedis: vi.fn(() => ({})) }));
 vi.mock('./rate-limit', () => ({ rateLimiter: vi.fn() }));
 vi.mock('./effectiveSettings', () => ({ getEffectiveAiBudget: vi.fn() }));
+vi.mock('./sentry', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
 
 const { getLlmBillingSourceForOrgMock } = vi.hoisted(() => ({
   getLlmBillingSourceForOrgMock: vi.fn(),
@@ -1075,5 +1081,335 @@ describe('#2190 self-contexted DB ops', () => {
     // awaited upserts).
     expect(captured.aggregateValues.length).toBe(2);
     expect(vi.mocked(withSystemDbAccessContext).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ============================================
+// checkSystemAiRateLimit — org-scoped bucket for SYSTEM principals
+// ============================================
+//
+// Reached from `buildExtensionAiContext` whenever the acting principal is not a
+// user (an extension's bulk enrichment batch). It deliberately skips the
+// per-USER bucket `checkAiRateLimit` also consults — that bucket is keyed
+// `ai:msg:user:<id>` with no org component, so a synthetic actor id would put
+// every tenant's automation in ONE deployment-wide 20/min bucket. These tests
+// pin the three properties that makes load-bearing: the key it uses, the
+// ceiling it reads, and the fact that it never touches the user bucket.
+
+describe('checkSystemAiRateLimit', () => {
+  const orgBudget = (over: Record<string, unknown> = {}) => ({
+    enabled: true,
+    monthlyBudgetCents: null,
+    dailyBudgetCents: null,
+    maxTurnsPerSession: 50,
+    messagesPerMinutePerUser: 20,
+    messagesPerHourPerOrg: 200,
+    approvalMode: 'per_step',
+    ...over,
+  }) as Awaited<ReturnType<typeof getEffectiveAiBudget>>;
+
+  it('checks exactly one bucket — ai:msg:org:<id> at the org hourly ceiling', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(orgBudget({ messagesPerHourPerOrg: 750 }));
+    vi.mocked(rateLimiter).mockResolvedValue(
+      { allowed: true, resetAt: new Date() } as Awaited<ReturnType<typeof rateLimiter>>,
+    );
+
+    await expect(checkSystemAiRateLimit('org-sys-1')).resolves.toBeNull();
+
+    // Exactly one call: the per-user bucket must NOT be consulted for a system
+    // principal (it is deployment-global for a synthetic actor id).
+    expect(vi.mocked(rateLimiter)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(rateLimiter)).toHaveBeenCalledWith(
+      expect.anything(),
+      'ai:msg:org:org-sys-1',
+      750,
+      3600,
+    );
+  });
+
+  it('falls back to a 200/hr ceiling when no effective budget row is available', async () => {
+    // getEffectiveAiBudget can resolve nullish for an org with no budget row;
+    // the ceiling must not collapse to `undefined` (which rateLimiter would
+    // treat as no limit at all).
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(
+      undefined as unknown as Awaited<ReturnType<typeof getEffectiveAiBudget>>,
+    );
+    vi.mocked(rateLimiter).mockResolvedValue(
+      { allowed: true, resetAt: new Date() } as Awaited<ReturnType<typeof rateLimiter>>,
+    );
+
+    await expect(checkSystemAiRateLimit('org-sys-2')).resolves.toBeNull();
+    expect(vi.mocked(rateLimiter)).toHaveBeenCalledWith(
+      expect.anything(),
+      'ai:msg:org:org-sys-2',
+      200,
+      3600,
+    );
+  });
+
+  it('rejects with the reset time once the org hourly ceiling is exceeded', async () => {
+    const resetAt = new Date('2026-08-27T12:00:00.000Z');
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(orgBudget());
+    vi.mocked(rateLimiter).mockResolvedValue(
+      { allowed: false, resetAt } as Awaited<ReturnType<typeof rateLimiter>>,
+    );
+
+    await expect(checkSystemAiRateLimit('org-sys-3')).resolves.toBe(
+      `Organization rate limit exceeded. Try again at ${resetAt.toISOString()}`,
+    );
+  });
+
+  it('self-contexts its effective-budget read (#2190 — it is NOT Redis-only)', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(orgBudget());
+    vi.mocked(rateLimiter).mockResolvedValue(
+      { allowed: true, resetAt: new Date() } as Awaited<ReturnType<typeof rateLimiter>>,
+    );
+
+    await checkSystemAiRateLimit('org-sys-4');
+
+    // Contextless (the enrichment/agent paths hold no ambient request
+    // transaction) this read RLS-filters to 0 rows and throws a 404.
+    expect(vi.mocked(withSystemDbAccessContext)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(getEffectiveAiBudget)).toHaveBeenCalledWith('org-sys-4');
+  });
+});
+
+// ============================================
+// Permanent-vs-transient AI denials (review round 2)
+// ============================================
+//
+// `checkBudget`/`checkBillingCredits` answer "is this org allowed to spend?" with
+// a human string, which erases WHY. A caller that retries (the workspace ingest
+// job) needs the why: a daily cap rolls over, an org with AI switched off or a
+// partner on a plan without AI never does. Collapsing both into one retryable
+// shape burned every ingest attempt and stalled the whole pipeline behind a
+// feature the tenant had simply turned off.
+
+describe('checkBillingCreditsDetailed', () => {
+  it('classifies the free/starter plan gate as PERMANENT', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValueOnce(billingCreditsResponse({
+      allowed: false, remainingCredits: 0, plan: 'starter',
+    }));
+    setupDbMocks(null);
+
+    await expect(checkBillingCreditsDetailed('org-cd-1', 'platform')).resolves.toEqual({
+      message: 'AI assistant requires the Community plan.',
+      reason: 'plan_gate',
+      permanent: true,
+    });
+  });
+
+  it('classifies exhausted prepaid credits as TRANSIENT (a top-up clears it)', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValueOnce(billingCreditsResponse({
+      allowed: false, remainingCredits: 0, plan: 'community',
+    }));
+    setupDbMocks(null);
+
+    await expect(checkBillingCreditsDetailed('org-cd-2', 'platform')).resolves.toMatchObject({
+      reason: 'credits_exhausted',
+      permanent: false,
+    });
+  });
+
+  it('keeps the legacy string-or-null wrapper in step with the detailed result', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValue(billingCreditsResponse({
+      allowed: false, remainingCredits: 0, plan: 'starter',
+    }));
+    setupDbMocks(null);
+
+    await expect(checkBillingCredits('org-cd-3', 'platform')).resolves.toBe(
+      'AI assistant requires the Community plan.',
+    );
+  });
+});
+
+describe('checkBudgetDetailed', () => {
+  const budget = (over: Record<string, unknown> = {}) => ({
+    enabled: true,
+    monthlyBudgetCents: null,
+    dailyBudgetCents: null,
+    maxTurnsPerSession: 50,
+    messagesPerMinutePerUser: 20,
+    messagesPerHourPerOrg: 200,
+    approvalMode: 'per_step',
+    ...over,
+  }) as Awaited<ReturnType<typeof getEffectiveAiBudget>>;
+
+  it('classifies an org with AI switched off as PERMANENT', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(budget({ enabled: false }));
+    setupDbMocks(null);
+
+    await expect(checkBudgetDetailed('org-bd-1', 'platform')).resolves.toEqual({
+      message: 'AI features are disabled for this organization',
+      reason: 'ai_disabled',
+      permanent: true,
+    });
+  });
+
+  it('classifies a spent daily cap as TRANSIENT (it rolls over at UTC midnight)', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(budget({ dailyBudgetCents: 1000 }));
+    mockDb.select.mockImplementation(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([{ totalCostCents: 1000 }]) })),
+      })),
+    }));
+
+    await expect(checkBudgetDetailed('org-bd-2', 'platform')).resolves.toMatchObject({
+      reason: 'daily_budget',
+      permanent: false,
+    });
+  });
+
+  it('classifies a spent monthly cap as TRANSIENT', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(
+      budget({ dailyBudgetCents: null, monthlyBudgetCents: 5000 }),
+    );
+    mockDb.select.mockImplementation(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([{ totalCostCents: 5000 }]) })),
+      })),
+    }));
+
+    await expect(checkBudgetDetailed('org-bd-3', 'platform')).resolves.toMatchObject({
+      reason: 'monthly_budget',
+      permanent: false,
+    });
+  });
+
+  it('propagates a PERMANENT plan gate from the credit check ahead of any budget read', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValueOnce(billingCreditsResponse({
+      allowed: false, remainingCredits: 0, plan: 'free',
+    }));
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(budget());
+    setupDbMocks(null);
+
+    await expect(checkBudgetDetailed('org-bd-4', 'partner_key')).resolves.toMatchObject({
+      reason: 'plan_gate',
+      permanent: true,
+    });
+    // The plan gate short-circuits — no budget row is read at all.
+    expect(vi.mocked(getEffectiveAiBudget)).not.toHaveBeenCalled();
+  });
+
+  it('resolves null (and the wrapper stays null) when the org is within budget', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(budget({ dailyBudgetCents: 1000 }));
+    mockDb.select.mockImplementation(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([{ totalCostCents: 1 }]) })),
+      })),
+    }));
+
+    await expect(checkBudgetDetailed('org-bd-5', 'platform')).resolves.toBeNull();
+    await expect(checkBudget('org-bd-5', 'platform')).resolves.toBeNull();
+  });
+});
+
+// ============================================
+// Billing-service telemetry (review round 2)
+// ============================================
+//
+// Both billing calls are deliberately FAIL-OPEN: a billing outage must not take
+// AI down for every tenant. The defect was that they were also fail-SILENT —
+// `deductBillingCredits` ignored the HTTP status entirely, so a 500 or a 403
+// from the billing service dropped platform-funded spend on the floor with no
+// console line and no Sentry event, and `checkBillingCredits` returned a bare
+// `null` (= allowed) from four different failure branches. The behaviour stays
+// fail-open; only the silence goes away.
+//
+// Every test uses a DISTINCT org id on purpose: the capture helper throttles to
+// one event per key per hour, and the key is org-scoped, so reusing an id would
+// make a later assertion pass or fail depending on test ORDER.
+
+describe('billing telemetry', () => {
+  it('deductBillingCredits reports a non-2xx billing response with its status, without throwing', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValueOnce(new Response('nope', { status: 502 }));
+    setupDbMocks(null);
+
+    await expect(deductBillingCredits('org-tel-1', 42)).resolves.toBeUndefined();
+
+    expect(vi.mocked(captureMessage)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        eventCode: 'ai_billing_credits_deduct_failed',
+        tags: expect.objectContaining({ ai_billing_http_status: '502' }),
+      }),
+    );
+  });
+
+  it('deductBillingCredits stays silent on a 2xx deduction', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    setupDbMocks(null);
+
+    await deductBillingCredits('org-tel-2', 7);
+
+    expect(vi.mocked(captureMessage)).not.toHaveBeenCalled();
+    expect(vi.mocked(captureException)).not.toHaveBeenCalled();
+  });
+
+  it('deductBillingCredits reports a transport failure and still does not throw', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    setupDbMocks(null);
+
+    await expect(deductBillingCredits('org-tel-3', 42)).resolves.toBeUndefined();
+    expect(vi.mocked(captureException)).toHaveBeenCalled();
+  });
+
+  it('deductBillingCredits reports an org with no partner to bill', async () => {
+    enableBillingService();
+    mockDb.select.mockImplementation(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([]) })), // org row absent
+      })),
+    }));
+
+    await expect(deductBillingCredits('org-tel-4', 42)).resolves.toBeUndefined();
+    expect(vi.mocked(captureMessage)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ eventCode: 'ai_billing_org_partner_missing' }),
+    );
+  });
+
+  it('checkBillingCredits reports a non-2xx credit check but still fails OPEN', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValueOnce(new Response('nope', { status: 500 }));
+    setupDbMocks(null);
+
+    // Fail-open is the point: a billing outage must not block AI for everyone.
+    await expect(checkBillingCredits('org-tel-5', 'platform')).resolves.toBeNull();
+    expect(vi.mocked(captureMessage)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        eventCode: 'ai_billing_credits_check_failed',
+        tags: expect.objectContaining({ ai_billing_http_status: '500' }),
+      }),
+    );
+  });
+
+  it('checkBillingCredits reports a transport failure but still fails OPEN', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockRejectedValueOnce(new Error('socket hang up'));
+    setupDbMocks(null);
+
+    await expect(checkBillingCredits('org-tel-6', 'platform')).resolves.toBeNull();
+    expect(vi.mocked(captureException)).toHaveBeenCalled();
+  });
+
+  it('says nothing when the billing service is simply not configured (self-hosted default)', async () => {
+    delete process.env.BILLING_SERVICE_URL;
+    delete process.env.BILLING_SERVICE_API_KEY;
+    setupDbMocks(null);
+
+    await expect(checkBillingCredits('org-tel-7', 'platform')).resolves.toBeNull();
+    await expect(deductBillingCredits('org-tel-7', 42)).resolves.toBeUndefined();
+    // A deployment mode, not a failure — reporting it would be pure noise.
+    expect(vi.mocked(captureMessage)).not.toHaveBeenCalled();
+    expect(vi.mocked(captureException)).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -12,6 +12,7 @@ import { getRedis } from './redis';
 import { rateLimiter } from './rate-limit';
 import { getEffectiveAiBudget } from './effectiveSettings';
 import { getLlmBillingSourceForOrg } from './llm/llmConfigResolver';
+import { captureException, captureMessage } from './sentry';
 
 export type AiBillingSource = 'platform' | 'partner_key';
 
@@ -22,6 +23,65 @@ export interface CatalogPricingSnapshot {
   outputCentsPerM: number;
   cacheReadCentsPerM: number;
   cacheWriteCentsPerM: number;
+}
+
+/**
+ * Why an org was refused AI spend.
+ *
+ * The split that matters to a retrying caller is `permanent`, not the reason
+ * label: a daily/monthly cap rolls over and prepaid credits can be topped up,
+ * while an org with AI switched off — or a partner on a plan that has no AI —
+ * stays refused until a human changes something. Collapsing both into one
+ * retryable shape is what let a tenant's own "AI off" setting burn every
+ * workspace ingest attempt and stall indexing behind it.
+ */
+export type AiDenialReason =
+  | 'plan_gate'
+  | 'credits_exhausted'
+  | 'ai_disabled'
+  | 'daily_budget'
+  | 'monthly_budget';
+
+export interface AiAccessDenial {
+  /** The user-facing message; identical to what the legacy string API returns. */
+  message: string;
+  reason: AiDenialReason;
+  /** True when retrying cannot clear it — only a config/plan/budget change can. */
+  permanent: boolean;
+}
+
+const PERMANENT_DENIAL_REASONS: ReadonlySet<AiDenialReason> = new Set<AiDenialReason>([
+  'plan_gate',
+  'ai_disabled',
+]);
+
+function denial(reason: AiDenialReason, message: string): AiAccessDenial {
+  return { message, reason, permanent: PERMANENT_DENIAL_REASONS.has(reason) };
+}
+
+// Sentry throttle for the fail-open billing paths below. A billing outage
+// affects EVERY org at once, so an uncapped report would ship one event per AI
+// call across the whole fleet; one per key per hour is enough to alert on.
+// Same shape (and same rationale) as llmConfigResolver's local copy —
+// deliberately duplicated rather than shared, per the repo's helper guidance.
+const BILLING_SENTRY_THROTTLE_MS = 60 * 60 * 1000;
+const billingSentryTimestamps = new Map<string, number>();
+
+/**
+ * Report at most once per key per hour, and NEVER throw: every call site below
+ * sits on a path whose whole contract is that it degrades quietly rather than
+ * failing the caller's AI request.
+ */
+function reportBillingIssueAtMostHourly(key: string, capture: () => void): void {
+  try {
+    const now = Date.now();
+    const last = billingSentryTimestamps.get(key);
+    if (last !== undefined && now - last < BILLING_SENTRY_THROTTLE_MS) return;
+    billingSentryTimestamps.set(key, now);
+    capture();
+  } catch {
+    // Telemetry must never break the fail-open billing path it observes.
+  }
 }
 
 // Cost per million tokens, expressed in cents (USD * 100).
@@ -70,12 +130,26 @@ const DEFAULT_PRICING = { inputPerMillion: 500, outputPerMillion: 2500 };
 const CACHE_READ_INPUT_MULTIPLIER = 0.1;
 const CACHE_WRITE_INPUT_MULTIPLIER = 1.25;
 
+/**
+ * Legacy string-or-null facade over {@link checkBillingCreditsDetailed}, kept
+ * because a dozen call sites branch on `if (creditError) return 402`. New
+ * callers that must decide whether RETRYING can help want the detailed form.
+ */
 export async function checkBillingCredits(
   orgId: string,
   billingSource: AiBillingSource,
 ): Promise<string | null> {
+  return (await checkBillingCreditsDetailed(orgId, billingSource))?.message ?? null;
+}
+
+export async function checkBillingCreditsDetailed(
+  orgId: string,
+  billingSource: AiBillingSource,
+): Promise<AiAccessDenial | null> {
   const billingUrl = process.env.BILLING_SERVICE_URL;
   const billingKey = process.env.BILLING_SERVICE_API_KEY;
+  // No billing service is the self-hosted default, not a failure — deliberately
+  // NOT reported, or every self-hosted instance would ship this hourly forever.
   if (!billingUrl || !billingKey) return null;
 
   // #2190 — self-context this read (and every other DB op in this module's
@@ -94,28 +168,69 @@ export async function checkBillingCredits(
     .where(eq(organizations.id, orgId))
     .limit(1));
 
-  if (!org?.partnerId) return null;
+  // `organizations.partner_id` is NOT NULL, so a falsy value here means the row
+  // was not found at all — a deleted org still being billed against, or a read
+  // that got RLS-filtered to zero rows. Either way the gate silently falls open
+  // for that org, which is worth one event an hour.
+  if (!org?.partnerId) {
+    reportBillingIssueAtMostHourly(`credits-no-partner:${orgId}`, () => {
+      captureMessage('AI credit check skipped: no organization row to bill', {
+        eventCode: 'ai_billing_org_partner_missing',
+        tags: { org_id: orgId, ai_billing_http_status: 'none' },
+      });
+    });
+    return null;
+  }
 
   try {
     const res = await fetch(`${billingUrl}/api/internal/partners/${org.partnerId}/ai-credits`, {
       headers: { 'Authorization': `Bearer ${billingKey}` },
     });
 
-    if (!res.ok) return null;
+    if (!res.ok) {
+      // Fail OPEN on purpose (a billing outage must not take AI down for every
+      // tenant) — but no longer fail SILENT: this branch also swallows a 401
+      // from a rotated BILLING_SERVICE_API_KEY, which looks exactly like
+      // "everyone has credits" from here.
+      console.error(
+        `[AI] Billing credit check returned HTTP ${res.status} for org=${orgId} — allowing the request (fail-open)`,
+      );
+      reportBillingIssueAtMostHourly(`credits-http:${orgId}`, () => {
+        captureMessage('AI credit check failed; gate fell open', {
+          eventCode: 'ai_billing_credits_check_failed',
+          tags: { org_id: orgId, ai_billing_http_status: String(res.status) },
+        });
+      });
+      return null;
+    }
 
     const data = await res.json() as { allowed: boolean; remainingCredits: number; plan: string };
 
     if (!data.allowed) {
       if (['free', 'starter'].includes(data.plan)) {
-        return 'AI assistant requires the Community plan.';
+        // A plan gate, not a spend cap: nothing about waiting changes it.
+        return denial('plan_gate', 'AI assistant requires the Community plan.');
       }
       if (billingSource === 'platform') {
-        return 'You are out of AI credits. Purchase more credits to continue.';
+        return denial(
+          'credits_exhausted',
+          'You are out of AI credits. Purchase more credits to continue.',
+        );
       }
     }
 
     return null;
-  } catch {
+  } catch (err) {
+    console.error(
+      `[AI] Billing credit check failed for org=${orgId} — allowing the request (fail-open):`,
+      err instanceof Error ? err.message : String(err),
+    );
+    reportBillingIssueAtMostHourly(`credits-throw:${orgId}`, () => {
+      captureException(err, undefined, {
+        org_id: orgId,
+        ai_billing_http_status: 'transport_error',
+      });
+    });
     return null;
   }
 }
@@ -147,10 +262,20 @@ export async function deductBillingCredits(orgId: string, costCents: number): Pr
     .where(eq(organizations.id, orgId))
     .limit(1));
 
-  if (!org?.partnerId) return;
+  // NOT NULL column (see checkBillingCreditsDetailed): falsy means no org row
+  // came back, so this spend is about to go unbilled with nothing said.
+  if (!org?.partnerId) {
+    reportBillingIssueAtMostHourly(`deduct-no-partner:${orgId}`, () => {
+      captureMessage('AI credit deduction skipped: no organization row to bill', {
+        eventCode: 'ai_billing_org_partner_missing',
+        tags: { org_id: orgId, ai_billing_http_status: 'none' },
+      });
+    });
+    return;
+  }
 
   try {
-    await fetch(`${billingUrl}/api/internal/partners/${org.partnerId}/ai-credits/deduct`, {
+    const res = await fetch(`${billingUrl}/api/internal/partners/${org.partnerId}/ai-credits/deduct`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${billingKey}`,
@@ -158,8 +283,31 @@ export async function deductBillingCredits(orgId: string, costCents: number): Pr
       },
       body: JSON.stringify({ costCents }),
     });
+
+    // The status was previously discarded entirely: a 4xx/5xx from the billing
+    // service dropped this platform-funded spend on the floor with no log line
+    // and no event, so the credit balance both budget gates read silently
+    // drifted above what was actually consumed. Still non-throwing — usage is
+    // already recorded and the caller's AI response must not fail over billing.
+    if (!res.ok) {
+      console.error(
+        `[AI] Billing credit deduction returned HTTP ${res.status} for org=${orgId}, cost=${costCents} cents — spend not deducted`,
+      );
+      reportBillingIssueAtMostHourly(`deduct-http:${orgId}`, () => {
+        captureMessage('AI credit deduction rejected; platform spend went unbilled', {
+          eventCode: 'ai_billing_credits_deduct_failed',
+          tags: { org_id: orgId, ai_billing_http_status: String(res.status) },
+        });
+      });
+    }
   } catch (err) {
     console.error('[AI] Failed to deduct billing credits:', err instanceof Error ? err.message : String(err));
+    reportBillingIssueAtMostHourly(`deduct-throw:${orgId}`, () => {
+      captureException(err, undefined, {
+        org_id: orgId,
+        ai_billing_http_status: 'transport_error',
+      });
+    });
   }
 }
 
@@ -273,7 +421,20 @@ export async function checkBudget(
   orgId: string,
   billingSource: AiBillingSource,
 ): Promise<string | null> {
-  const creditError = await checkBillingCredits(orgId, billingSource);
+  return (await checkBudgetDetailed(orgId, billingSource))?.message ?? null;
+}
+
+/**
+ * As {@link checkBudget}, but says WHY — and in particular whether retrying can
+ * ever help. Non-interactive callers (ingest job phases, background sweeps)
+ * must use this form: a permanent denial has to degrade the feature, while a
+ * transient one should back off and come back.
+ */
+export async function checkBudgetDetailed(
+  orgId: string,
+  billingSource: AiBillingSource,
+): Promise<AiAccessDenial | null> {
+  const creditError = await checkBillingCreditsDetailed(orgId, billingSource);
   if (creditError) return creditError;
 
   // #2190 — getEffectiveAiBudget reads organizations/partners/aiBudgets; run
@@ -282,7 +443,11 @@ export async function checkBudget(
   // Self-context it; the wrapper reuses any active ambient context (see the
   // rationale on checkBillingCredits above).
   const budget = await withSystemDbAccessContext(() => getEffectiveAiBudget(orgId));
-  if (!budget.enabled) return 'AI features are disabled for this organization';
+  // PERMANENT: the tenant (or their partner) switched AI off. No retry, no
+  // clock rollover and no top-up changes it — only someone flipping it back.
+  if (!budget.enabled) {
+    return denial('ai_disabled', 'AI features are disabled for this organization');
+  }
 
   const now = new Date();
   const dailyKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
@@ -305,7 +470,11 @@ export async function checkBudget(
       .limit(1));
 
     if (dailyUsage && dailyUsage.totalCostCents >= budget.dailyBudgetCents) {
-      return `Daily AI budget exceeded ($${(budget.dailyBudgetCents / 100).toFixed(2)})`;
+      // Transient: the daily period key rolls at UTC midnight.
+      return denial(
+        'daily_budget',
+        `Daily AI budget exceeded ($${(budget.dailyBudgetCents / 100).toFixed(2)})`,
+      );
     }
   }
 
@@ -325,7 +494,11 @@ export async function checkBudget(
       .limit(1));
 
     if (monthlyUsage && monthlyUsage.totalCostCents >= budget.monthlyBudgetCents) {
-      return `Monthly AI budget exceeded ($${(budget.monthlyBudgetCents / 100).toFixed(2)})`;
+      // Transient: the monthly period key rolls at the start of the next month.
+      return denial(
+        'monthly_budget',
+        `Monthly AI budget exceeded ($${(budget.monthlyBudgetCents / 100).toFixed(2)})`,
+      );
     }
   }
 

--- a/apps/api/src/services/extensionAi.test.ts
+++ b/apps/api/src/services/extensionAi.test.ts
@@ -4,8 +4,10 @@ import { ExtensionAiError, type ExtensionAiInvokeInput } from '@breeze/extension
 const {
   buildAnthropicClient,
   calculateCostCents,
+  captureException,
+  captureMessage,
   checkAiRateLimit,
-  checkBudget,
+  checkBudgetDetailed,
   checkSystemAiRateLimit,
   create,
   deductBillingCredits,
@@ -15,8 +17,12 @@ const {
 } = vi.hoisted(() => ({
   buildAnthropicClient: vi.fn(),
   calculateCostCents: vi.fn<() => number>(),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
   checkAiRateLimit: vi.fn<() => Promise<string | null>>(),
-  checkBudget: vi.fn<() => Promise<string | null>>(),
+  checkBudgetDetailed: vi.fn<() => Promise<{
+    message: string; reason: string; permanent: boolean;
+  } | null>>(),
   checkSystemAiRateLimit: vi.fn<() => Promise<string | null>>(),
   create: vi.fn(),
   deductBillingCredits: vi.fn<() => Promise<void>>(),
@@ -28,7 +34,7 @@ const {
 vi.mock('./aiCostTracker', () => ({
   calculateCostCents,
   checkAiRateLimit,
-  checkBudget,
+  checkBudgetDetailed,
   checkSystemAiRateLimit,
   deductBillingCredits,
   isPricedModel: (model: string) => [
@@ -37,6 +43,8 @@ vi.mock('./aiCostTracker', () => ({
   ].includes(model),
   recordUsage,
 }));
+
+vi.mock('./sentry', () => ({ captureException, captureMessage }));
 
 const { LlmOrgResolutionError } = vi.hoisted(() => ({
   LlmOrgResolutionError: class LlmOrgResolutionError extends Error {
@@ -115,7 +123,7 @@ beforeEach(() => {
   buildAnthropicClient.mockReturnValue({ messages: { create } });
   checkAiRateLimit.mockResolvedValue(null);
   checkSystemAiRateLimit.mockResolvedValue(null);
-  checkBudget.mockResolvedValue(null);
+  checkBudgetDetailed.mockResolvedValue(null);
   create.mockResolvedValue(response());
   recordUsage.mockResolvedValue(undefined);
   deductBillingCredits.mockResolvedValue(undefined);
@@ -136,7 +144,7 @@ describe('buildExtensionAiContext', () => {
     expect(resolveLlmConfigForOrg).toHaveBeenCalledWith(ORG_ID);
     expect(buildAnthropicClient).toHaveBeenCalledWith(PARTNER_CONFIG);
     expect(checkAiRateLimit).toHaveBeenCalledWith(USER_ID, ORG_ID);
-    expect(checkBudget).toHaveBeenCalledWith(ORG_ID, 'partner_key');
+    expect(checkBudgetDetailed).toHaveBeenCalledWith(ORG_ID, 'partner_key');
     expect(create).toHaveBeenCalledWith({
       model: 'claude-haiku-4-5',
       max_tokens: 512,
@@ -239,12 +247,18 @@ describe('buildExtensionAiContext', () => {
   });
 
   it('rejects an exceeded budget before calling the client', async () => {
-    checkBudget.mockResolvedValueOnce('Monthly AI budget exceeded');
+    checkBudgetDetailed.mockResolvedValueOnce({
+      message: 'Monthly AI budget exceeded',
+      reason: 'monthly_budget',
+      permanent: false,
+    });
 
     await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
       name: 'ExtensionAiError',
       code: 'budget_exceeded',
       message: 'Monthly AI budget exceeded',
+      // A spend cap rolls over — the caller may retry after the period key does.
+      permanent: false,
     });
     expect(create).not.toHaveBeenCalled();
   });
@@ -257,7 +271,7 @@ describe('buildExtensionAiContext', () => {
       code: 'rate_limited',
       message: 'Rate limit exceeded',
     });
-    expect(checkBudget).not.toHaveBeenCalled();
+    expect(checkBudgetDetailed).not.toHaveBeenCalled();
     expect(create).not.toHaveBeenCalled();
   });
 
@@ -272,7 +286,7 @@ describe('buildExtensionAiContext', () => {
 
     expect(resolveLlmConfigForOrg).not.toHaveBeenCalled();
     expect(checkAiRateLimit).not.toHaveBeenCalled();
-    expect(checkBudget).not.toHaveBeenCalled();
+    expect(checkBudgetDetailed).not.toHaveBeenCalled();
     expect(create).not.toHaveBeenCalled();
     expect(recordUsage).not.toHaveBeenCalled();
   });
@@ -360,6 +374,182 @@ describe('buildExtensionAiContext', () => {
       expect(recordUsage).not.toHaveBeenCalled();
       expect(markPartnerLlmError).not.toHaveBeenCalled();
     });
+  });
+
+  /**
+   * PERMANENT vs TRANSIENT.
+   *
+   * The `code` alone never answered "can retrying help?", and the workspace
+   * ingest job treated every ExtensionAiError as retryable. A deployment whose
+   * WORKSPACE_CONTENT_LLM_MODEL is a typo, or a tenant who simply switched AI
+   * off, therefore burned all `max_attempts`, failed the job, and had a fresh
+   * job repeat it forever — crosswalk never ran. Each of these pins which side
+   * of that line one failure falls on.
+   */
+  describe('permanent-vs-transient classification', () => {
+    it('marks an unpriced model PERMANENT (a deployment typo no retry can fix)', async () => {
+      const error = await buildExtensionAiContext()
+        .invoke({ ...input, model: 'not-a-real-model' })
+        .catch((caught) => caught);
+
+      expect(error).toMatchObject({ code: 'ai_unavailable', permanent: true });
+    });
+
+    it('marks not_configured PERMANENT (no provider exists on this deployment)', async () => {
+      resolveLlmConfigForOrg.mockResolvedValueOnce({
+        source: 'platform',
+        apiKey: '  ',
+        model: 'claude-sonnet-4-6',
+      });
+
+      const error = await buildExtensionAiContext().invoke(input).catch((caught) => caught);
+
+      expect(error).toMatchObject({ code: 'not_configured', permanent: true });
+    });
+
+    it('propagates a PERMANENT budget denial (org has AI switched off)', async () => {
+      checkBudgetDetailed.mockResolvedValueOnce({
+        message: 'AI features are disabled for this organization',
+        reason: 'ai_disabled',
+        permanent: true,
+      });
+
+      const error = await buildExtensionAiContext().invoke(input).catch((caught) => caught);
+
+      expect(error).toMatchObject({ code: 'budget_exceeded', permanent: true });
+      expect(create).not.toHaveBeenCalled();
+    });
+
+    it('propagates a PERMANENT budget denial (partner plan has no AI)', async () => {
+      checkBudgetDetailed.mockResolvedValueOnce({
+        message: 'AI assistant requires the Community plan.',
+        reason: 'plan_gate',
+        permanent: true,
+      });
+
+      const error = await buildExtensionAiContext().invoke(input).catch((caught) => caught);
+
+      expect(error).toMatchObject({ code: 'budget_exceeded', permanent: true });
+    });
+
+    it('propagates a TRANSIENT budget denial (exhausted prepaid credits)', async () => {
+      checkBudgetDetailed.mockResolvedValueOnce({
+        message: 'You are out of AI credits. Purchase more credits to continue.',
+        reason: 'credits_exhausted',
+        permanent: false,
+      });
+
+      const error = await buildExtensionAiContext().invoke(input).catch((caught) => caught);
+
+      expect(error).toMatchObject({ code: 'budget_exceeded', permanent: false });
+    });
+
+    it('keeps rate_limited TRANSIENT', async () => {
+      checkAiRateLimit.mockResolvedValueOnce('Rate limit exceeded');
+
+      const error = await buildExtensionAiContext().invoke(input).catch((caught) => caught);
+
+      expect(error).toMatchObject({ code: 'rate_limited', permanent: false });
+    });
+
+    it('keeps a broken partner BYOK key TRANSIENT so it stays loud', async () => {
+      // Deliberately NOT permanent: a partner whose key stopped working must
+      // keep seeing a visible failure, never a quietly degraded feature (and
+      // never a fallback to the platform key).
+      resolveLlmConfigForOrg.mockResolvedValueOnce({
+        source: 'unavailable',
+        partnerId: PARTNER_ID,
+        reason: 'key_error',
+      });
+
+      const error = await buildExtensionAiContext().invoke(input).catch((caught) => caught);
+
+      expect(error).toMatchObject({ code: 'ai_unavailable', permanent: false });
+    });
+
+    it.each([429, 503])('keeps a provider-side %i TRANSIENT', async (status) => {
+      create.mockRejectedValueOnce(apiError(status));
+
+      const error = await buildExtensionAiContext().invoke(input).catch((caught) => caught);
+
+      expect(error).toMatchObject({ permanent: false });
+    });
+
+    it('keeps an unresolvable organization TRANSIENT', async () => {
+      // A missing/unreadable organization row can be an RLS-context fault, not
+      // a settled configuration state — degrading a feature over it would hide
+      // a real bug.
+      resolveLlmConfigForOrg.mockRejectedValueOnce(new LlmOrgResolutionError(ORG_ID));
+
+      const error = await buildExtensionAiContext().invoke(input).catch((caught) => caught);
+
+      expect(error).toMatchObject({ code: 'ai_unavailable', permanent: false });
+    });
+  });
+
+  describe('partner credential rejection stamping', () => {
+    it('reports a stamping THROW to Sentry without masking the original 401', async () => {
+      create.mockRejectedValueOnce(apiError(401, 'invalid x-api-key'));
+      markPartnerLlmError.mockRejectedValueOnce(new Error('db down'));
+
+      await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+        name: 'ExtensionAiError',
+        code: 'ai_unavailable',
+        message: 'invalid x-api-key',
+      });
+      expect(captureException).toHaveBeenCalled();
+    });
+
+    it('reports a LOST stamp (config version moved) instead of treating it as stamped', async () => {
+      // markPartnerLlmError resolves false when the row id/version no longer
+      // match — the partner rotated the key mid-flight. Nothing was written, so
+      // their AI settings still advertise a key Anthropic is rejecting.
+      create.mockRejectedValueOnce(apiError(401, 'invalid x-api-key'));
+      markPartnerLlmError.mockResolvedValueOnce(false);
+
+      await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+        code: 'ai_unavailable',
+      });
+      expect(captureMessage).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ eventCode: 'ai_partner_key_error_stamp_stale' }),
+      );
+    });
+
+    it('says nothing when the stamp lands', async () => {
+      create.mockRejectedValueOnce(apiError(401, 'invalid x-api-key'));
+      markPartnerLlmError.mockResolvedValueOnce(true);
+
+      await expect(buildExtensionAiContext().invoke(input)).rejects.toMatchObject({
+        code: 'ai_unavailable',
+      });
+      expect(captureMessage).not.toHaveBeenCalled();
+      expect(captureException).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not resolve until the platform credit deduction has completed', async () => {
+    // Same deferred-promise discrimination as the recordUsage test above: a
+    // `void deductBillingCredits(...)` would resolve invoke() before the org's
+    // prepaid balance moved, so a caller could observe a completed, charged
+    // call whose charge had not landed yet.
+    resolveLlmConfigForOrg.mockResolvedValueOnce(PLATFORM_CONFIG);
+    let releaseDeduction!: () => void;
+    deductBillingCredits.mockReturnValueOnce(new Promise<void>((resolve) => {
+      releaseDeduction = () => resolve();
+    }));
+
+    let settled = false;
+    const invocation = buildExtensionAiContext().invoke(input).then((value) => {
+      settled = true;
+      return value;
+    });
+
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(settled).toBe(false);
+
+    releaseDeduction();
+    await expect(invocation).resolves.toMatchObject({ billingSource: 'platform' });
   });
 
   describe('rate-limit actor', () => {

--- a/apps/api/src/services/extensionAi.ts
+++ b/apps/api/src/services/extensionAi.ts
@@ -15,7 +15,7 @@ import {
 import {
   calculateCostCents,
   checkAiRateLimit,
-  checkBudget,
+  checkBudgetDetailed,
   checkSystemAiRateLimit,
   deductBillingCredits,
   isPricedModel,
@@ -28,6 +28,7 @@ import {
   resolveLlmConfigForOrg,
   type UsableLlmConfig,
 } from './llm/llmConfigResolver';
+import { captureException, captureMessage } from './sentry';
 
 const EXTENSION_AI_DEFAULT_MODEL = 'claude-haiku-4-5';
 
@@ -54,6 +55,11 @@ function httpStatusOf(error: unknown): number | null {
  * poison file. 401/403 is a credential problem, so it aborts too — and, for a
  * partner key, is recorded on the config row so the partner's AI settings stop
  * reporting a key that Anthropic is rejecting.
+ *
+ * Every ExtensionAiError raised here is TRANSIENT (`permanent` left false),
+ * including a rejected partner credential: the partner must keep seeing a loud,
+ * visible failure until they reconnect the key, never a feature that has
+ * quietly degraded itself.
  */
 async function classifyProviderFailure(
   error: unknown,
@@ -64,17 +70,34 @@ async function classifyProviderFailure(
   if (status === 401 || status === 403) {
     if (resolved.source === 'partner') {
       try {
-        await markPartnerLlmError({
+        const stamped = await markPartnerLlmError({
           configId: resolved.configId,
           configVersion: resolved.configVersion,
           reason: 'auth_rejected',
         });
+        if (!stamped) {
+          // A compare-and-set miss: the config row's id/version moved (the
+          // partner rotated or removed the key mid-flight), so NOTHING was
+          // written. Treating that as stamped is how a partner's AI settings
+          // keep advertising a key Anthropic is rejecting.
+          console.warn('[extension-ai] rejected partner credential was NOT stamped (config version moved)', {
+            partnerId: resolved.partnerId,
+            configVersion: resolved.configVersion,
+          });
+          captureMessage('Rejected partner AI credential could not be stamped', {
+            eventCode: 'ai_partner_key_error_stamp_stale',
+            tags: { partner_id: resolved.partnerId },
+          });
+        }
       } catch (markError) {
         // Recording the rejection is best-effort: never mask the original cause.
         console.error('[extension-ai] failed to mark rejected partner credential', {
           partnerId: resolved.partnerId,
           error: markError,
         });
+        // Was silent to Sentry entirely — mirrors llmConfigResolver's own
+        // markPartnerLlmError failure path, which does report.
+        captureException(markError, undefined, { partner_id: resolved.partnerId });
       }
     }
     return new ExtensionAiError('ai_unavailable', errorMessage(error));
@@ -100,9 +123,14 @@ export function buildExtensionAiContext(): ExtensionAiContext {
         ?? process.env.WORKSPACE_CONTENT_LLM_MODEL
         ?? EXTENSION_AI_DEFAULT_MODEL;
       if (!isPricedModel(model)) {
+        // PERMANENT: the model id is a deployment constant (a
+        // WORKSPACE_CONTENT_LLM_MODEL typo, or an id retired from the pricing
+        // table). Every retry reproduces it exactly, so a retrying caller must
+        // degrade instead of burning its attempts.
         throw new ExtensionAiError(
           'ai_unavailable',
           `AI model "${model}" is not available for metered extension use.`,
+          { permanent: true },
         );
       }
 
@@ -135,6 +163,7 @@ export function buildExtensionAiContext(): ExtensionAiContext {
         throw new ExtensionAiError(
           'not_configured',
           'AI is not configured on this deployment.',
+          { permanent: true },
         );
       }
 
@@ -148,9 +177,15 @@ export function buildExtensionAiContext(): ExtensionAiContext {
         throw new ExtensionAiError('rate_limited', rateLimitError);
       }
 
-      const budgetError = await checkBudget(input.orgId, billingSource);
-      if (budgetError) {
-        throw new ExtensionAiError('budget_exceeded', budgetError);
+      // Detailed form on purpose: `budget_exceeded` covers both a spend cap
+      // that rolls over (retry later) and an org/plan with AI switched off
+      // (retrying forever is the bug this exists to stop). Only the tracker
+      // knows which, so it is the tracker that decides `permanent`.
+      const budgetDenial = await checkBudgetDetailed(input.orgId, billingSource);
+      if (budgetDenial) {
+        throw new ExtensionAiError('budget_exceeded', budgetDenial.message, {
+          permanent: budgetDenial.permanent,
+        });
       }
 
       const client = buildAnthropicClient(usable);

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -214,6 +214,16 @@ const ALLOWED_TAG_NAMES = new Set([
   // so proving every current and future path passes a hardcoded literal is a
   // real sweep, not a glance. Unproven means not allowlisted.
   'dbContextOpener',
+  // The AI billing calls (services/aiCostTracker.ts) are deliberately
+  // FAIL-OPEN, so the only thing separating "billing said no" from "billing
+  // never answered" is this tag. Its value is either an HTTP status rendered
+  // from `Response.status` (a 3-digit number) or one of two hardcoded literals
+  // — `transport_error` (fetch rejected: DNS, socket, timeout) and `none` (the
+  // failure happened before any request was made). Bounded by construction and
+  // carrying no tenant, partner, URL or credential; `scrubEvent` deletes
+  // `message` and `extra`, so without it a deduction that quietly dropped
+  // platform-funded spend is indistinguishable from one that succeeded.
+  'ai_billing_http_status',
 ]);
 const UNSAFE_TAG_CHARACTERS = /[/?#\r\n]/;
 const SAFE_STRUCTURAL_NAME = /^[A-Za-z_$<][A-Za-z0-9_.$<>:[\] ]{0,127}$/;

--- a/apps/api/src/services/sentryEventCodes.ts
+++ b/apps/api/src/services/sentryEventCodes.ts
@@ -87,6 +87,16 @@ export const SENTRY_EVENT_CODES = [
   /** No usable platform LLM key is configured on this deployment. */
   'llm_platform_key_missing',
 
+  // --- ai spend / billing -----------------------------------------------
+  /** The billing service's AI-credit check failed; the gate fell open. */
+  'ai_billing_credits_check_failed',
+  /** A platform-funded AI deduction did not land — that spend went unbilled. */
+  'ai_billing_credits_deduct_failed',
+  /** An org reached the AI billing path with no partner row to bill. */
+  'ai_billing_org_partner_missing',
+  /** A rejected partner AI key could not be stamped (config moved under us). */
+  'ai_partner_key_error_stamp_stale',
+
   // --- backup -----------------------------------------------------------
   /** A backup result matched no job row (deleted, or invisible under RLS). */
   'backup_result_job_not_found',

--- a/ee/workspace/src/routes/content.test.ts
+++ b/ee/workspace/src/routes/content.test.ts
@@ -227,6 +227,39 @@ describe('content routes — behavior (content enabled)', () => {
     }));
   });
 
+  it('enrich-run answers 503 (not 200) when the run degraded because AI is unavailable', async () => {
+    // The degraded run returns a NORMAL-looking body — processed 0, remaining
+    // 0, no errors — so without the aiUnavailable flag an admin who explicitly
+    // asked to enrich would be told "0 files, all done" about an org whose AI
+    // provider is missing or switched off.
+    const enrichment = {
+      run: vi.fn(async () => ({
+        processed: 0, remaining: 0, errors: [], aiUnavailable: true as const,
+      })),
+    };
+    const { app, deps } = makeApp({
+      enrichmentService: enrichment as unknown as ContentRouteDeps['enrichmentService'],
+    });
+
+    const res = await app.request(`/content/enrich-run?orgId=${ORG_ID}`, { method: 'POST' });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      error: 'enrichment unavailable (no model credentials configured)',
+    });
+    // Audited as a FAILURE, like ingest-run's failure path — an admin action
+    // that produced nothing must still leave a trail.
+    expect(deps.audit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'workspace.content.enrich_run',
+      result: 'failure',
+    }));
+    // ...and never as a success.
+    expect(deps.audit).not.toHaveBeenCalledWith(expect.objectContaining({
+      action: 'workspace.content.enrich_run',
+      result: 'success',
+    }));
+  });
+
   it('enrich-run rethrows a non-transient error (surfaces as 500)', async () => {
     const enrichment = { run: vi.fn(async () => { throw new Error('kaboom'); }) };
     const { app } = makeApp({

--- a/ee/workspace/src/routes/content.ts
+++ b/ee/workspace/src/routes/content.ts
@@ -162,10 +162,23 @@ export function createContentRoutes(deps: ContentRouteDeps): Hono<WorkspaceRoute
       throw e;
     }
     if (result.aiUnavailable) {
-      // The run degraded because this deployment has no AI provider (no
-      // platform key, no partner BYOK key). The ingest pipeline treats that as
-      // a drained phase, but a caller who explicitly asked to enrich gets the
-      // same 503 the pre-BYOK missing-credentials guard returned above.
+      // The run degraded on a permanent AI failure — no provider on this
+      // deployment (no platform key, no partner BYOK key), AI switched off for
+      // the org, a partner plan without AI, or an unpriced model id. The
+      // ingest pipeline treats that as a drained phase, but a caller who
+      // explicitly asked to enrich gets the same 503 the pre-BYOK
+      // missing-credentials guard returned above — and, like ingest-run's
+      // failure path, an audit row: an admin action that produced nothing must
+      // still leave a trail, not vanish.
+      await deps.audit({
+        actorType: 'user',
+        actorId: auth.user.id,
+        orgId,
+        action: 'workspace.content.enrich_run',
+        resourceType: 'workspace_source',
+        result: 'failure',
+        errorMessage: 'enrichment unavailable (no usable AI provider for this organization)',
+      });
       return c.json({ error: 'enrichment unavailable (no model credentials configured)' }, 503);
     }
     await deps.audit({

--- a/ee/workspace/src/services/enrichmentService.test.ts
+++ b/ee/workspace/src/services/enrichmentService.test.ts
@@ -196,6 +196,96 @@ describe('run', () => {
     expect(invoke).toHaveBeenCalledTimes(1);
   });
 
+  /**
+   * PERMANENT AI failures drain the phase; TRANSIENT ones abort it.
+   *
+   * Before this split, every ExtensionAiError became a TransientIngestError:
+   * an org that had simply switched AI off, a partner on a plan without AI, or
+   * a deployment with a typo'd WORKSPACE_CONTENT_LLM_MODEL burned all
+   * `max_attempts`, failed the ingest job, and a fresh job repeated it forever
+   * — so indexing and crosswalk never finished either. The classification now
+   * comes from the HOST (`ExtensionAiError.permanent`), which is the only side
+   * that can tell a rolling daily cap from an "AI is off" switch.
+   */
+  describe('permanent vs transient AI failures', () => {
+    function drainingDb(pending: Array<{ id: string; rel_path: string; extracted_text: string }>) {
+      // count(*) answers NON-zero so a `remaining: 0` in the result can only
+      // come from the drain short-circuit, never from a fake that happens to
+      // report an empty queue.
+      const execute = vi.fn(async (query: unknown) => {
+        const text = sqlText(query);
+        if (text.includes('workspace_projects')) return [];
+        if (text.includes('SELECT fi.id, fi.rel_path')) return pending;
+        if (text.includes('count(*)')) return [{ n: 5 }];
+        return [];
+      });
+      return { execute } as unknown as WorkspaceDatabase;
+    }
+
+    const pending = [
+      { id: 'f1', rel_path: 'a.md', extracted_text: 'text a' },
+      { id: 'f2', rel_path: 'b.md', extracted_text: 'text b' },
+    ];
+
+    it.each([
+      ['budget_exceeded', 'AI features are disabled for this organization'],
+      ['budget_exceeded', 'AI assistant requires the Community plan.'],
+      ['ai_unavailable', 'AI model "claude-hiaku-4-5" is not available for metered extension use.'],
+      ['not_configured', 'AI is not configured on this deployment.'],
+    ] as const)('drains the phase on a PERMANENT %s', async (code, message) => {
+      const db = drainingDb(pending);
+      const invoke: EnrichmentInvoke = vi.fn(async () => {
+        throw new ExtensionAiError(code, message, { permanent: true });
+      });
+      const svc = createEnrichmentService(db, { invoke });
+
+      const result = await svc.run(ORG, 8);
+
+      expect(result).toMatchObject({ processed: 0, remaining: 0, errors: [], aiUnavailable: true });
+      // Aborted on the FIRST file — the rest of the batch is not burned into
+      // model=NULL rows, so they stay re-enrichable if AI comes back.
+      expect(invoke).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ['rate_limited', 'Organization rate limit exceeded'],
+      ['ai_unavailable', 'AI is unavailable until the partner Anthropic API key is reconnected.'],
+      ['budget_exceeded', 'Daily AI budget exceeded ($10.00)'],
+    ] as const)('stays TRANSIENT on %s (retrying can still help)', async (code, message) => {
+      const db = drainingDb(pending);
+      const invoke: EnrichmentInvoke = vi.fn(async () => {
+        throw new ExtensionAiError(code, message);
+      });
+      const svc = createEnrichmentService(db, { invoke });
+
+      const caught = await svc.run(ORG, 8).catch((e: unknown) => e);
+
+      expect(caught).toBeInstanceOf(TransientIngestError);
+      expect(isTransientIngestError(caught)).toBe(true);
+      expect((caught as Error).message).toContain(code);
+      expect(invoke).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats an ExtensionAiError with NO permanent field as transient (older host)', async () => {
+      // Belt and braces for a host built before the flag existed: `permanent`
+      // arriving undefined must never be read as "drain the phase".
+      const db = drainingDb(pending);
+      const legacyError = Object.assign(
+        new Error('BYOK key invalid'),
+        { name: 'ExtensionAiError', code: 'ai_unavailable' },
+      );
+      Object.setPrototypeOf(legacyError, ExtensionAiError.prototype);
+      // The field the current constructor would have set, removed.
+      delete (legacyError as { permanent?: unknown }).permanent;
+
+      const svc = createEnrichmentService(db, {
+        invoke: vi.fn(async () => { throw legacyError; }) as EnrichmentInvoke,
+      });
+
+      await expect(svc.run(ORG, 8)).rejects.toBeInstanceOf(TransientIngestError);
+    });
+  });
+
   it('still fail-softs a plain Error from invoke into a per-file error, not an abort', async () => {
     const pending = [{ id: 'f1', rel_path: 'a.md', extracted_text: 'text a' }];
     const db = fakeDb(pending);

--- a/ee/workspace/src/services/enrichmentService.ts
+++ b/ee/workspace/src/services/enrichmentService.ts
@@ -14,9 +14,15 @@
 // file (an LLM hiccup marks the file unenriched, never throws out of the
 // batch) — EXCEPT for provider/billing problems (ExtensionAiError), which
 // must abort the whole run instead of burning every pending file into a
-// silent null-model row. The one ExtensionAiError that does NOT abort is
-// `not_configured` (no provider on this deployment at all): that degrades to a
-// drained phase, since retrying cannot help. See the `run()` invoke-loop below.
+// silent null-model row.
+//
+// Whether that abort is RETRYABLE is the host's call, carried on
+// `ExtensionAiError.permanent` — not something this file can infer from the
+// code, because `budget_exceeded` and `ai_unavailable` each cover both a
+// condition that clears on its own and one that never does. A PERMANENT error
+// (no provider configured, AI switched off for the org, partner plan without
+// AI, an unpriced model id) degrades to a drained phase; anything else throws
+// a TransientIngestError and backs the job off. See the `run()` invoke-loop.
 //
 // DLP invariant (W2): this pass never re-runs DLP. It reads
 // workspace_file_content.extracted_text for status='extracted' rows only, and
@@ -212,16 +218,26 @@ export function createEnrichmentService(db: WorkspaceDatabase, deps: EnrichmentD
           // with a visible transient_error release; the admin enrich-run route
           // maps the same shape to a 503.
           if (err instanceof ExtensionAiError) {
-            if (err.code === 'not_configured') {
-              // The deployment has no AI provider at all (no platform key, no
-              // partner BYOK key) — the default self-hosted shape, and exactly
-              // what the pre-BYOK missing-ANTHROPIC_API_KEY guard covered by
-              // handing the runner a no-op enrichment service. Report the phase
-              // DRAINED so the ingest job advances to crosswalk. Retrying would
-              // burn all max_attempts and fail the job, taking indexing and
-              // crosswalk down with a feature that was merely absent.
+            // PERMANENT means no retry can clear it: the deployment has no AI
+            // provider at all (`not_configured` — the default self-hosted
+            // shape, exactly what the pre-BYOK missing-ANTHROPIC_API_KEY guard
+            // covered by handing the runner a no-op enrichment service), the
+            // org or its partner's plan has AI switched off, or the configured
+            // model id is not a priced model. Report the phase DRAINED so the
+            // ingest job advances to crosswalk. Retrying instead burns all
+            // max_attempts and fails the job, taking indexing and crosswalk
+            // down with a feature that was merely absent or switched off — and
+            // the next job repeats it forever.
+            //
+            // `=== true` on purpose: an ExtensionAiError from a host built
+            // before the flag existed carries `undefined`, which must read as
+            // transient (retry may help), never as "drain the phase".
+            if (err.code === 'not_configured' || err.permanent === true) {
               return { processed, remaining: 0, errors, aiUnavailable: true };
             }
+            // Everything else — a provider rate cap, an outage, a rejected
+            // partner BYOK key, a spend cap that rolls over — stays LOUD and
+            // retryable.
             throw new TransientIngestError(
               `AI provider unavailable for this organization: ${err.code}`,
               { cause: err },

--- a/ee/workspace/src/services/ingestJobRunner.test.ts
+++ b/ee/workspace/src/services/ingestJobRunner.test.ts
@@ -282,6 +282,46 @@ describe('ingestJobRunner.advance', () => {
     });
   });
 
+  it('records WHY the enrich phase drained when AI is unavailable for the org', async () => {
+    // The drained-AI path used to be indistinguishable from a genuinely empty
+    // queue: enrichment.run reports remaining 0, the phase completes, and the
+    // job's stats say nothing at all. An operator looking at a fleet where no
+    // file ever gets enriched had no signal to follow — so mirror the
+    // enrichSkipped precedent and leave both a log line and a stats crumb.
+    const deps = baseDeps();
+    deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'enrich' }));
+    deps.enrichment.run.mockResolvedValueOnce({
+      processed: 0, remaining: 0, errors: [], aiUnavailable: true,
+    });
+    const runner = createIngestJobRunner(deps as never);
+
+    const res = await runner.advance(ORG);
+
+    expect(res.advanced).toBe(true);
+    expect(deps.jobs.recordProgress).toHaveBeenCalledWith(ORG, JOB, {
+      statsPatch: { enrichSkippedReason: 'ai_unavailable' },
+    });
+    expect(deps.log).toHaveBeenCalledWith(expect.stringContaining('ai_unavailable'));
+    // Still drains: the job must advance to crosswalk, not stall.
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, {
+      kind: 'phase_complete', nextPhase: 'crosswalk',
+    });
+  });
+
+  it('records nothing extra when the enrich phase drains normally', async () => {
+    const deps = baseDeps();
+    deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'enrich' }));
+    deps.enrichment.run.mockResolvedValueOnce({ processed: 4, remaining: 0, errors: [] });
+    const runner = createIngestJobRunner(deps as never);
+
+    await runner.advance(ORG);
+
+    expect(deps.jobs.recordProgress).not.toHaveBeenCalled();
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, {
+      kind: 'phase_complete', nextPhase: 'crosswalk',
+    });
+  });
+
   it('releases fatal_error and does not throw on an unexpected failure', async () => {
     const deps = baseDeps();
     deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'ingest' }));

--- a/ee/workspace/src/services/ingestJobRunner.ts
+++ b/ee/workspace/src/services/ingestJobRunner.ts
@@ -34,10 +34,13 @@ export interface EnrichRunResult {
   remaining: number;
   errors: Array<{ fileIndexId: string; relPath: string; error: string }>;
   /**
-   * Set when the run stopped because the deployment has no AI provider at all.
-   * `remaining` is reported as 0 so this phase drains and the job advances; the
-   * flag exists so a caller that asked for enrichment EXPLICITLY (the admin
-   * enrich-run route) can still answer honestly instead of "0 files, all done".
+   * Set when the run stopped on a PERMANENT AI failure — no provider on this
+   * deployment, AI switched off for the org, a partner plan without AI, or an
+   * unpriced model id. `remaining` is reported as 0 so this phase drains and
+   * the job advances; the flag exists so a caller that asked for enrichment
+   * EXPLICITLY (the admin enrich-run route) can still answer honestly instead
+   * of "0 files, all done", and so `advance()` can leave a stats crumb saying
+   * why the phase produced nothing.
    */
   aiUnavailable?: true;
 }
@@ -140,6 +143,23 @@ export function createIngestJobRunner(deps: {
 
         if (job.phase === 'enrich') {
           const r = await deps.enrichment.run(orgId, batch);
+          if (r.aiUnavailable) {
+            // A drained-because-AI-is-unavailable phase is otherwise
+            // INDISTINGUISHABLE from an empty queue: same remaining 0, same
+            // phase_complete, and nothing on the job saying why not one file
+            // was enriched. Mirror the enrichSkipped crumb below so the
+            // dashboard and an operator reading job stats can tell "nothing to
+            // do" from "this org has no usable AI provider".
+            deps.log(`enrich job ${job.id}: ai_unavailable for this org — draining enrich phase`);
+            await deps.jobs.recordProgress(orgId, job.id, {
+              statsPatch: { enrichSkippedReason: 'ai_unavailable' },
+            });
+            const released = await deps.jobs.release(orgId, job.id, {
+              kind: 'phase_complete',
+              nextPhase: 'crosswalk',
+            });
+            return { advanced: true, job: released };
+          }
           if (r.remaining === 0) {
             const released = await deps.jobs.release(orgId, job.id, {
               kind: 'phase_complete',

--- a/packages/extension-sdk/src/server.test.ts
+++ b/packages/extension-sdk/src/server.test.ts
@@ -10,4 +10,23 @@ describe('ExtensionAiError', () => {
     expect(err.message).toBe('org budget exhausted');
     expect(err.name).toBe('ExtensionAiError');
   });
+
+  it('defaults `permanent` to false so a two-argument construction still means "retry may help"', () => {
+    // Backward compatibility is the point: every pre-existing call site passes
+    // two arguments, and a silent flip to permanent would turn a provider blip
+    // into a drained phase.
+    expect(new ExtensionAiError('rate_limited', 'slow down').permanent).toBe(false);
+  });
+
+  it('carries `permanent: true` when the host says retrying cannot help', () => {
+    // Same CODE, opposite handling: budget_exceeded raised because the org has
+    // AI switched off (or is on a plan without it) never clears on its own,
+    // while budget_exceeded from a daily spend cap does.
+    const err = new ExtensionAiError('budget_exceeded', 'AI features are disabled', {
+      permanent: true,
+    });
+
+    expect(err.permanent).toBe(true);
+    expect(err.code).toBe('budget_exceeded');
+  });
 });

--- a/packages/extension-sdk/src/server.ts
+++ b/packages/extension-sdk/src/server.ts
@@ -35,13 +35,46 @@ export type ExtensionAiErrorCode =
   | 'budget_exceeded'
   | 'rate_limited';
 
+export interface ExtensionAiErrorOptions {
+  /**
+   * `true` when no amount of retrying can clear this failure — only a human
+   * changing configuration, a plan, or a budget will. See the class doc.
+   */
+  permanent?: boolean;
+}
+
+/**
+ * An expected AI failure, carrying BOTH a code (what went wrong) and a
+ * `permanent` flag (whether retrying can ever help).
+ *
+ * The two are deliberately orthogonal, because the code alone does not answer
+ * the retry question and treating it as if it did is what burned an ingest job
+ * to `failed` on a config typo:
+ *
+ *  - `budget_exceeded` is transient when it comes from a daily/monthly spend
+ *    cap (those roll over) and PERMANENT when it comes from the org's AI switch
+ *    being off or the partner being on a plan without AI.
+ *  - `ai_unavailable` is transient for a provider outage or a rejected partner
+ *    key (an operator must see those stay loud) and PERMANENT when the
+ *    configured model id simply is not a priced model — a deployment typo that
+ *    every retry will reproduce exactly.
+ *
+ * Callers that retry (job runners, ingest phases) must branch on `permanent`,
+ * not on the code. `permanent` defaults to `false`: a host built before this
+ * field existed, or any two-argument construction, keeps the old "retry may
+ * help" meaning rather than silently draining a phase.
+ */
 export class ExtensionAiError extends Error {
+  readonly permanent: boolean;
+
   constructor(
     public readonly code: ExtensionAiErrorCode,
     message: string,
+    options: ExtensionAiErrorOptions = {},
   ) {
     super(message);
     this.name = 'ExtensionAiError';
+    this.permanent = options.permanent ?? false;
   }
 }
 


### PR DESCRIPTION
Splits AI spend denials into permanent vs transient so a non-interactive caller can tell whether retrying can ever help: `ExtensionAiError` gains an optional `permanent` flag (defaulting to false, so every existing two-argument construction keeps its "retry may help" meaning), `checkBudget`/`checkBillingCredits` gain `…Detailed` siblings returning `{ message, reason, permanent }` behind unchanged string-or-null facades, and `plan_gate`/`ai_disabled` are classified permanent while `daily_budget`, `monthly_budget` and `credits_exhausted` are not. A rejected partner BYOK key stays deliberately transient — the partner must keep seeing a loud failure rather than a quietly degraded feature. The workspace ingest job now drains the enrich phase on a permanent error instead of burning all `max_attempts` and re-failing forever (an org that had simply switched AI off previously stalled indexing and crosswalk behind it), and records `enrichSkippedReason: 'ai_unavailable'` so the drained path is visible on the job runner. Alongside that, four fail-open billing paths stop failing silently: `deductBillingCredits` now checks `res.ok` (a 4xx/5xx previously dropped platform-funded spend with no log and no event), `checkBillingCredits` reports its HTTP and transport failures, and `markPartnerLlmError` reports both its throw path and its compare-and-set miss — all throttled to one report per key per hour, with four new `SENTRY_EVENT_CODES` and one allowlisted `ai_billing_http_status` tag so the events arrive with content. Finally, the `workspaceEnrichmentByok` teardown assertion was vacuous (it re-read the same hand-maintained table list the drop used); it now snapshots the public BASE TABLE set before the fixture's migrations and asserts set-equality after the drop, verified discriminating by removing one table from the drop list.

Follow-up to #4112 — these review-round-2 fixes were committed after that PR merged.

Cherry-picked onto current `main`; one conflict in `apps/api/src/services/aiCostTracker.ts` (both sides added declarations at the top of the file), resolved by keeping `CatalogPricingSnapshot` from `main` and the new denial/throttle helpers from this commit. Verified: `packages/extension-sdk` server suite, `ee/workspace` enrichmentService/ingestJobRunner/content suites, `apps/api` extensionAi + aiCostTracker + sentry suites, and the `workspaceEnrichmentByok` integration test against a live Postgres test stack — all green, plus clean `tsc --noEmit` on `apps/api`, `ee/workspace` and `packages/extension-sdk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A592m7suBriiYsU6owVX61
