### PR TITLE
fix(api,web): review round 2 — self-managed revisions route, egress-blocked verdicts, authoring audit, listing-gate tests

### DIFF
--- a/apps/api/src/middleware/selfManagedDbContextRoutes.test.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.test.ts
@@ -94,6 +94,13 @@ describe('isSelfManagedDbContextRoute', () => {
     ['POST', '/api/v1/admin/llm-provider-catalog/revisions/rev-1/verify'],
     ['POST', '/api/v1/admin/llm-provider-catalog/revisions/rev-1/verify/'],
     ['post', '/api/v1/admin/llm-provider-catalog/revisions/rev-1/verify'],
+    // Revision authoring resolves the operator-supplied base URL through
+    // assertSafeUrl (a real DNS lookup) BEFORE any DB work — holding the
+    // request transaction across it pins a pooled connection on a resolver
+    // the operator chose the timeout of.
+    ['POST', '/api/v1/admin/llm-provider-catalog/entry-1/revisions'],
+    ['POST', '/api/v1/admin/llm-provider-catalog/entry-1/revisions/'],
+    ['post', '/api/v1/admin/llm-provider-catalog/entry-1/revisions'],
   ];
 
   const NO_MATCH: ReadonlyArray<[string, string, string]> = [
@@ -186,7 +193,9 @@ describe('isSelfManagedDbContextRoute', () => {
     // The other catalog mutations are DB-only and MUST keep the ambient tx.
     ['GET', '/api/v1/admin/llm-provider-catalog', 'catalog listing is DB-only'],
     ['POST', '/api/v1/admin/llm-provider-catalog/entry-1/activate', 'activation is DB-only'],
-    ['POST', '/api/v1/admin/llm-provider-catalog/entry-1/revisions', 'revision create is DB-only'],
+    ['GET', '/api/v1/admin/llm-provider-catalog/entry-1/revisions', 'revision create is POST-only'],
+    ['POST', '/api/v1/admin/llm-provider-catalog//revisions', 'empty entry id must not match'],
+    ['POST', '/api/v1/admin/llm-provider-catalog/entry-1/revisions/extra', 'extra segment must not match'],
     ['GET', '/api/v1/admin/llm-provider-catalog/revisions/rev-1/verify', 'verify is POST-only'],
     ['POST', '/api/v1/admin/llm-provider-catalog/revisions//verify', 'empty revision id must not match'],
     ['POST', '/api/v1/admin/llm-provider-catalog/revisions/rev-1/verify/extra', 'extra segment must not match'],

--- a/apps/api/src/middleware/selfManagedDbContextRoutes.ts
+++ b/apps/api/src/middleware/selfManagedDbContextRoutes.ts
@@ -162,6 +162,17 @@ const SELF_MANAGED_DB_CONTEXT_ROUTES: readonly SelfManagedRoute[] = [
   // and writes the verification through the service's own short
   // `withSystemDbAccessContext` blocks, with the harness call between them.
   { method: 'POST', pattern: /^\/api\/v1\/admin\/llm-provider-catalog\/revisions\/[^/]+\/verify\/?$/ },
+  // #3922 review round 2 — revision AUTHORING is the second network-touching
+  // route on this surface, and the quieter one. `createRevision` runs
+  // `validateBaseUrl` → `assertSafeUrl` on the operator-supplied base URL,
+  // which is a real `dns.lookup` against a host the operator chose, BEFORE any
+  // of its DB work. A blackholed or merely slow resolver therefore held a
+  // pooled connection idle-in-transaction for the whole resolution — the
+  // #1105 pool-poison class without a single byte of payload leaving the box.
+  // `createRevision` wraps its reads and its insert in their own short
+  // `withSystemDbAccessContext` block, run strictly AFTER the URL check, so
+  // the handler needs no ambient transaction at all.
+  { method: 'POST', pattern: /^\/api\/v1\/admin\/llm-provider-catalog\/[^/]+\/revisions\/?$/ },
 ];
 
 /**

--- a/apps/api/src/routes/admin/llmProviderCatalog.test.ts
+++ b/apps/api/src/routes/admin/llmProviderCatalog.test.ts
@@ -27,9 +27,15 @@ vi.mock('../../services/llmProviderCatalog', () => ({
   },
 }));
 
-vi.mock('../../services/llm/providerFidelityHarness', () => ({
-  runFidelityCheck: runFidelityCheckMock,
-}));
+// Only `runFidelityCheck` is stubbed: the route branches on the harness's REAL
+// error classes, so a locally re-declared `LlmEgressViolationError` here would
+// make the instanceof check pass against a class the harness never throws.
+vi.mock('../../services/llm/providerFidelityHarness', async () => {
+  const actual = await vi.importActual<typeof import('../../services/llm/providerFidelityHarness')>(
+    '../../services/llm/providerFidelityHarness',
+  );
+  return { ...actual, runFidelityCheck: runFidelityCheckMock };
+});
 
 const { createAuditLogAsyncMock, captureExceptionMock } = vi.hoisted(() => ({
   createAuditLogAsyncMock: vi.fn(async () => undefined),
@@ -64,6 +70,9 @@ vi.mock('../../middleware/auth', async () => {
 
 import { Hono } from 'hono';
 import { adminRoutes } from './index';
+import { LlmEgressViolationError } from '../../services/llm/providerFidelityHarness';
+import { SsrfBlockedError } from '../../services/urlSafety';
+import { LlmProviderCatalogError } from '../../services/llmProviderCatalog';
 
 type FakeAuth = {
   user: { id: string; email: string; name: string; isPlatformAdmin: boolean };
@@ -390,6 +399,190 @@ describe('admin LLM provider catalog routes', () => {
 
     expect(response.status).toBe(502);
     expect(captureExceptionMock).toHaveBeenCalledWith(harnessError, undefined, expect.any(Object));
+  });
+
+  describe('verify route guards', () => {
+    it('404s without running the harness when the revision does not exist', async () => {
+      serviceMocks.getCatalogRevisionById.mockResolvedValue(null);
+
+      const response = await jsonRequest(
+        buildApp(platformAdmin),
+        `/admin/llm-provider-catalog/revisions/${REVISION_ID}/verify`,
+        'POST',
+        { modelId: 'claude-sonnet-4-6', apiKey: TEST_API_KEY },
+      );
+
+      expect(response.status).toBe(404);
+      // The transient key must not reach an outbound client for a revision the
+      // caller cannot even name.
+      expect(runFidelityCheckMock).not.toHaveBeenCalled();
+      expect(serviceMocks.recordVerification).not.toHaveBeenCalled();
+      expect(await response.text()).not.toContain(TEST_API_KEY);
+    });
+
+    it('400s without running the harness when the model is not mapped by the revision', async () => {
+      const response = await jsonRequest(
+        buildApp(platformAdmin),
+        `/admin/llm-provider-catalog/revisions/${REVISION_ID}/verify`,
+        'POST',
+        { modelId: 'claude-opus-4-8', apiKey: TEST_API_KEY },
+      );
+
+      expect(response.status).toBe(400);
+      // Without this guard the harness would be handed `undefined.providerModel`
+      // — and a verification could be banked against a model the revision never
+      // mapped, which the activation gate would then read as satisfied.
+      expect(runFidelityCheckMock).not.toHaveBeenCalled();
+      expect(serviceMocks.recordVerification).not.toHaveBeenCalled();
+      expect(await response.text()).not.toContain(TEST_API_KEY);
+    });
+  });
+
+  describe('blocked egress verdicts', () => {
+    const egressCases = [
+      [
+        'an origin-pinning refusal from the harness fetch',
+        () => new LlmEgressViolationError(
+          'blocked egress to http://169.254.169.254; this client is pinned to https://llm.example.test',
+        ),
+      ],
+      [
+        'an SSRF policy rejection from safeFetch',
+        () => new SsrfBlockedError(
+          'all resolved IPs for llm.example.test are private/loopback/link-local',
+        ),
+      ],
+    ] as const;
+
+    it.each(egressCases)(
+      'reports %s as a 400 egress_blocked verdict, not a generic upstream 502',
+      async (_label, makeError) => {
+        const error = makeError();
+        runFidelityCheckMock.mockRejectedValue(error);
+
+        const response = await jsonRequest(
+          buildApp(platformAdmin),
+          `/admin/llm-provider-catalog/revisions/${REVISION_ID}/verify`,
+          'POST',
+          { modelId: 'claude-sonnet-4-6', apiKey: TEST_API_KEY },
+        );
+
+        // 502 "the provider failed its fidelity check" sends the operator to
+        // the provider; this is OUR egress policy refusing the base URL, which
+        // is a different diagnosis and their own to fix.
+        expect(response.status).toBe(400);
+        expect(await response.json()).toMatchObject({ code: 'egress_blocked' });
+        expect(serviceMocks.recordVerification).not.toHaveBeenCalled();
+        expect(captureExceptionMock).toHaveBeenCalledWith(
+          error,
+          undefined,
+          expect.objectContaining({ stage: 'egress_blocked' }),
+        );
+        expect(createAuditLogAsyncMock).toHaveBeenCalledWith(expect.objectContaining({
+          action: 'platform_admin.llm_provider_catalog.verify_egress_blocked',
+          resourceId: ENTRY_ID,
+          details: expect.objectContaining({
+            revisionId: REVISION_ID,
+            modelId: 'claude-sonnet-4-6',
+          }),
+        }));
+      },
+    );
+
+    it('redacts the transient key from the egress-blocked response and audit row', async () => {
+      runFidelityCheckMock.mockRejectedValue(
+        new LlmEgressViolationError(`blocked egress while presenting ${TEST_API_KEY}`),
+      );
+
+      const response = await jsonRequest(
+        buildApp(platformAdmin),
+        `/admin/llm-provider-catalog/revisions/${REVISION_ID}/verify`,
+        'POST',
+        { modelId: 'claude-sonnet-4-6', apiKey: TEST_API_KEY },
+      );
+
+      expect(await response.text()).not.toContain(TEST_API_KEY);
+      expect(JSON.stringify(createAuditLogAsyncMock.mock.calls)).not.toContain(TEST_API_KEY);
+    });
+
+    it('still reports an ordinary harness failure as a 502', async () => {
+      runFidelityCheckMock.mockRejectedValue(new Error('upstream returned 500'));
+
+      const response = await jsonRequest(
+        buildApp(platformAdmin),
+        `/admin/llm-provider-catalog/revisions/${REVISION_ID}/verify`,
+        'POST',
+        { modelId: 'claude-sonnet-4-6', apiKey: TEST_API_KEY },
+      );
+
+      expect(response.status).toBe(502);
+      expect(createAuditLogAsyncMock).not.toHaveBeenCalledWith(expect.objectContaining({
+        action: 'platform_admin.llm_provider_catalog.verify_egress_blocked',
+      }));
+    });
+  });
+
+  describe('authoring audit trail', () => {
+    it('audits the slug of a created catalog entry', async () => {
+      await jsonRequest(
+        buildApp(platformAdmin),
+        '/admin/llm-provider-catalog',
+        'POST',
+        { slug: 'openrouter', name: 'OpenRouter' },
+      );
+
+      expect(createAuditLogAsyncMock).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'platform_admin.llm_provider_catalog.entry_created',
+        resourceId: ENTRY_ID,
+        details: expect.objectContaining({ slug: 'openrouter', name: 'OpenRouter' }),
+        result: 'success',
+      }));
+    });
+
+    it('audits the base URL host a new revision points partner prompts at', async () => {
+      await jsonRequest(
+        buildApp(platformAdmin),
+        `/admin/llm-provider-catalog/${ENTRY_ID}/revisions`,
+        'POST',
+        { baseUrl: 'https://llm.example.test/v1', authMode: 'bearer', modelMap },
+      );
+
+      // The base URL is the value that decides where partner prompts go, and
+      // catalog authoring has no four-eyes approval — the middleware's
+      // method+path row cannot tell two revisions apart.
+      expect(createAuditLogAsyncMock).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'platform_admin.llm_provider_catalog.revision_created',
+        resourceId: ENTRY_ID,
+        details: expect.objectContaining({
+          revisionId: REVISION_ID,
+          revision: 1,
+          baseUrlHost: 'llm.example.test',
+        }),
+        result: 'success',
+      }));
+    });
+
+    it.each([
+      ['create entry', '/admin/llm-provider-catalog', { slug: 'x', name: 'X' }, 'createCatalogEntry', 'entry_created'],
+      [
+        'create revision',
+        `/admin/llm-provider-catalog/${ENTRY_ID}/revisions`,
+        { baseUrl: 'https://llm.example.test/v1', authMode: 'bearer', modelMap },
+        'createRevision',
+        'revision_created',
+      ],
+    ] as const)('does not audit a rejected %s as a success', async (_label, path, body, mock, action) => {
+      serviceMocks[mock].mockRejectedValue(
+        new LlmProviderCatalogError('Base URL host is not a permitted egress target.', 400),
+      );
+
+      const response = await jsonRequest(buildApp(platformAdmin), path, 'POST', body);
+
+      expect(response.status).toBe(400);
+      expect(createAuditLogAsyncMock).not.toHaveBeenCalledWith(expect.objectContaining({
+        action: `platform_admin.llm_provider_catalog.${action}`,
+      }));
+    });
   });
 
   it('rejects malformed model pricing before calling the service', async () => {

--- a/apps/api/src/routes/admin/llmProviderCatalog.ts
+++ b/apps/api/src/routes/admin/llmProviderCatalog.ts
@@ -13,7 +13,11 @@ import {
   recordVerification,
   setEntryStatus,
 } from '../../services/llmProviderCatalog';
-import { runFidelityCheck } from '../../services/llm/providerFidelityHarness';
+import {
+  LlmEgressViolationError,
+  runFidelityCheck,
+} from '../../services/llm/providerFidelityHarness';
+import { SsrfBlockedError } from '../../services/urlSafety';
 import { createAuditLogAsync } from '../../services/auditService';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import { captureException } from '../../services/sentry';
@@ -73,6 +77,37 @@ function redactSecret(value: string, secret: string): string {
 }
 
 /**
+ * Our own egress controls refusing to make the request, as opposed to the
+ * provider failing the check.
+ *
+ * `LlmEgressViolationError` is the harness's origin pin (the client was steered
+ * off the revision's own origin); `SsrfBlockedError` is `safeFetch` refusing to
+ * dial a loopback/RFC1918/link-local/metadata address. Both mean the base URL
+ * on the revision is not a legitimate egress target — an operator-fixable 400,
+ * not the 502 "the provider failed its fidelity check" that would send them to
+ * the provider's support desk instead.
+ *
+ * Note on reachability: `runFidelityCheck` currently catches everything the
+ * Anthropic client throws and folds it into a failing STEP, so today an egress
+ * block usually surfaces as `passed:false` with the reason in `steps[].detail`
+ * rather than as a throw. This branch is the correct handling for the throw
+ * path (a guard raised before or around the SDK call, and any future harness
+ * change that stops swallowing), and it must not regress to the generic 502.
+ */
+function isEgressBlocked(error: unknown): error is Error {
+  return error instanceof LlmEgressViolationError || error instanceof SsrfBlockedError;
+}
+
+/** Host only — never the path, query, or anything the operator pasted a key into. */
+function hostOf(value: string): string | null {
+  try {
+    return new URL(value.trim()).host;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * `platformAdminMiddleware` audits every admin request, but only with method +
  * path — which makes list and delist indistinguishable in the trail and records
  * no revision id for an activation. Catalog activation deliberately has no
@@ -114,8 +149,14 @@ llmProviderCatalogMutationRoutes.post(
   '/',
   zValidator('json', createEntrySchema),
   async (c) => {
+    const data = c.req.valid('json');
     try {
-      return c.json(await createCatalogEntry(c.req.valid('json')), 201);
+      const created = await createCatalogEntry(data);
+      auditCatalogMutation(c, 'entry_created', created.id, {
+        slug: data.slug,
+        name: data.name,
+      });
+      return c.json(created, 201);
     } catch (error) {
       return mapCatalogError(error, c);
     }
@@ -131,11 +172,23 @@ llmProviderCatalogMutationRoutes.post(
     const data = c.req.valid('json');
     const auth = c.get('auth');
     try {
-      return c.json(await createRevision({
+      const created = await createRevision({
         entryId,
         ...data,
         createdBy: auth.user.id,
-      }), 201);
+      });
+      // The base URL decides where partner prompts are sent, and catalog
+      // authoring deliberately has no four-eyes approval — so the decisive
+      // value has to be in the trail. Host only: the path is operator-typed
+      // free text and must not become a place a key can land in audit_logs.
+      auditCatalogMutation(c, 'revision_created', entryId, {
+        revisionId: created.id,
+        revision: created.revision,
+        baseUrlHost: hostOf(data.baseUrl),
+        authMode: data.authMode,
+        modelIds: Object.keys(data.modelMap).sort(),
+      });
+      return c.json(created, 201);
     } catch (error) {
       return mapCatalogError(error, c);
     }
@@ -222,6 +275,31 @@ llmProviderCatalogMutationRoutes.post(
         harnessVersion: redactSecret(result.harnessVersion, apiKey),
       };
     } catch (error) {
+      // Our egress controls refusing the target is a different verdict from
+      // the provider failing the check: 502 "Fidelity check failed" points the
+      // operator at the provider, when what actually needs fixing is the base
+      // URL on the revision. It also gets its own audit row — an operator
+      // repeatedly aiming a catalog revision at metadata/RFC1918 space is a
+      // signal worth keeping, and the platform-admin middleware's method+path
+      // row cannot distinguish it from an ordinary failed verification.
+      if (isEgressBlocked(error)) {
+        captureException(error, undefined, {
+          route: 'admin.llm_provider_catalog.verify',
+          stage: 'egress_blocked',
+        });
+        auditCatalogMutation(c, 'verify_egress_blocked', revision.entryId, {
+          revisionId,
+          modelId,
+          baseUrlHost: hostOf(revision.baseUrl),
+          // Bounded: `details` is jsonb, and an error message is not a place to
+          // let an unbounded upstream string into audit_logs.
+          reason: redactSecret(error.message, apiKey).slice(0, 300),
+        });
+        return c.json({
+          error: 'The revision base URL is not a permitted egress target.',
+          code: 'egress_blocked',
+        }, 400);
+      }
       captureException(error, undefined, {
         route: 'admin.llm_provider_catalog.verify',
         stage: 'fidelity_check',

--- a/apps/api/src/routes/backup/configs.test.ts
+++ b/apps/api/src/routes/backup/configs.test.ts
@@ -39,6 +39,10 @@ vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  // `assertSafeUrl` (urlSafety) now carries the #1105 held-context tripwire, and
+  // probeS3Config calls it — without this export the partial mock turns every
+  // S3 "test connection" case into a module error instead of a policy result.
+  assertOutsideHeldDbContext: vi.fn(),
 }));
 
 vi.mock('../../db/schema', () => ({

--- a/apps/api/src/services/llm/providerFidelityHarness.test.ts
+++ b/apps/api/src/services/llm/providerFidelityHarness.test.ts
@@ -343,6 +343,47 @@ describe('runFidelityCheck', () => {
     const queryOptions = (sdkState.query.mock.calls[0]![0] as { options: Record<string, unknown> }).options;
     expect(queryOptions.model).toBe(INPUT.providerModel);
   });
+
+  // Last in the file on purpose: it swaps the agent-SDK mock for a throwing one
+  // on a fresh module graph and restores it in `finally`.
+  it('never passes when the agent SDK module itself cannot be imported', async () => {
+    // The other "skipped" case is a launch failure INSIDE query(); this one is
+    // the earlier `await import('@anthropic-ai/claude-agent-sdk')` rejecting —
+    // an install where the optional dependency is simply absent. Both must
+    // record a FAILING step, because the caller persists these steps as the
+    // verification record and a record with an un-run stage must never read as
+    // a pass.
+    stageOkAnthropic();
+    sdkState.importThrows = new Error("Cannot find module '@anthropic-ai/claude-agent-sdk'");
+    // The hoisted `vi.mock` factory is evaluated once and cached, so it can
+    // never observe a flag set after the first import. Re-registering it here
+    // (against the same state) plus a module reset is what actually exercises
+    // the import-failure branch.
+    vi.doMock('@anthropic-ai/claude-agent-sdk', () => {
+      throw sdkState.importThrows;
+    });
+    vi.resetModules();
+    try {
+      const { runFidelityCheck: runOnFreshGraph } = await import('./providerFidelityHarness');
+
+      const result = await runOnFreshGraph(INPUT);
+
+      const step = stepByName(result, FIDELITY_STEP_NAMES.sdkSubprocess);
+      expect(step.ok).toBe(false);
+      // Wording unique to the import-failure catch — distinct from the
+      // launch-failure skip ("agent SDK subprocess unavailable") and from the
+      // direct-stage skip, so this asserts the branch, not merely "some skip".
+      expect(step.detail).toMatch(/^skipped: agent SDK unavailable/);
+      expect(result.passed).toBe(false);
+      // The direct stage still passed — only the un-runnable stage fails the run.
+      expect(stepByName(result, FIDELITY_STEP_NAMES.directToolUse).ok).toBe(true);
+      expect(stepByName(result, FIDELITY_STEP_NAMES.directToolResult).ok).toBe(true);
+    } finally {
+      sdkState.importThrows = null;
+      vi.doUnmock('@anthropic-ai/claude-agent-sdk');
+      vi.resetModules();
+    }
+  });
 });
 
 describe('buildFidelityChildEnv', () => {

--- a/apps/api/src/services/llmProviderCatalog.test.ts
+++ b/apps/api/src/services/llmProviderCatalog.test.ts
@@ -321,18 +321,111 @@ describe('LLM provider catalog service', () => {
   it('discards an in-flight listed-provider read that a mutation invalidated mid-flight', async () => {
     let release!: () => void;
     dbState.gate = new Promise<void>((resolve) => { release = resolve; });
+    // The gated read is queued the PRE-mutation rows: it will genuinely see the
+    // entry as listed. Emptying the queue instead would make this pass with the
+    // epoch check deleted, because the stale read would return [] on its own.
     queueListedRead();
 
     const inflight = getListedProviders();
-    // The mutation lands while the read is still on the wire; the rows it is
-    // about to see predate the mutation, so they must never become the cache.
+    // The delisting lands while that read is still on the wire.
     invalidateLlmProviderCatalogCache();
-    dbState.selectResults.length = 0;
+    // Appended AFTER the pre-mutation rows, so the parked read still consumes
+    // those and only the post-invalidation retry sees the delisted world.
+    dbState.selectResults.push([]);
     dbState.gate = null;
     release();
 
+    // Neither the caller's own result nor the cache may carry rows that predate
+    // the delisting — returning them would keep a revoked provider offerable.
     await expect(inflight).resolves.toEqual([]);
     expect(await getListedProviders()).toEqual([]);
+  });
+
+  it('lists an entry whose active revision has every mapped model verified', async () => {
+    dbState.selectResults.push(
+      [{ id: ENTRY_ID, activeRevisionId: REVISION_ID }],
+      [{ modelMap }],
+      [
+        { modelId: 'claude-sonnet-4-6', passed: true, createdAt: T0 },
+        { modelId: 'claude-haiku-4-5', passed: true, createdAt: T0 },
+      ],
+    );
+    dbState.updateResults.push([{ id: ENTRY_ID }]);
+
+    await expect(setEntryStatus({ entryId: ENTRY_ID, status: 'listed' }))
+      .resolves.toBeUndefined();
+    expect(dbState.updateSets[0]).toMatchObject({ status: 'listed' });
+
+    // The active revision must be re-read scoped to THIS entry: an activeRevisionId
+    // pointing at another entry's revision would otherwise be gated against that
+    // revision's verifications.
+    const revisionLookup = renderSql(dbState.selectWheres[1]);
+    expect(revisionLookup.sql).toContain('"llm_provider_catalog_revisions"."id" = $');
+    expect(revisionLookup.sql).toContain('"llm_provider_catalog_revisions"."catalog_entry_id" = $');
+    expect(revisionLookup.params).toEqual([REVISION_ID, ENTRY_ID]);
+
+    // Listing re-runs the SAME verification gate activation uses, at the current
+    // harness version — a pass banked under an older harness must not list.
+    const gate = renderSql(dbState.selectWheres[2]);
+    expect(gate.sql).toContain('"llm_provider_verifications"."revision_id" = $');
+    expect(gate.sql).toContain('"llm_provider_verifications"."harness_version" = $');
+    expect(gate.params).toEqual([REVISION_ID, CURRENT_HARNESS_VERSION]);
+  });
+
+  it('blocks listing when the active revision has a model with no passing verification', async () => {
+    dbState.selectResults.push(
+      [{ id: ENTRY_ID, activeRevisionId: REVISION_ID }],
+      [{ modelMap }],
+      [{ modelId: 'claude-sonnet-4-6', passed: true, createdAt: T0 }],
+    );
+
+    await expect(setEntryStatus({ entryId: ENTRY_ID, status: 'listed' }))
+      .rejects.toThrow(/claude-haiku-4-5/);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('blocks listing when the latest attempt for a mapped model failed', async () => {
+    dbState.selectResults.push(
+      [{ id: ENTRY_ID, activeRevisionId: REVISION_ID }],
+      [{ modelMap }],
+      [
+        // A revocation banked after activation must also stop a later listing —
+        // the entry could have been activated while it still passed.
+        { modelId: 'claude-sonnet-4-6', passed: false, createdAt: T1 },
+        { modelId: 'claude-sonnet-4-6', passed: true, createdAt: T0 },
+        { modelId: 'claude-haiku-4-5', passed: true, createdAt: T0 },
+      ],
+    );
+
+    await expect(setEntryStatus({ entryId: ENTRY_ID, status: 'listed' }))
+      .rejects.toThrow(/claude-sonnet-4-6/);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses to list an entry whose activeRevisionId resolves to no revision row', async () => {
+    dbState.selectResults.push(
+      [{ id: ENTRY_ID, activeRevisionId: REVISION_ID }],
+      // Orphaned pointer (revision deleted, or belonging to another entry).
+      [],
+    );
+
+    await expect(setEntryStatus({ entryId: ENTRY_ID, status: 'listed' }))
+      .rejects.toMatchObject({
+        message: expect.stringMatching(/active catalog revision not found/i),
+        status: 409,
+      });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('does not run the verification gate when delisting', async () => {
+    dbState.updateResults.push([{ id: ENTRY_ID }]);
+
+    await expect(setEntryStatus({ entryId: ENTRY_ID, status: 'delisted' }))
+      .resolves.toBeUndefined();
+    // Delisting is the fail-safe direction; it must never be blocked by a
+    // revision that can no longer be verified.
+    expect(db.select).not.toHaveBeenCalled();
+    expect(dbState.updateSets[0]).toMatchObject({ status: 'delisted' });
   });
 
   it('rejects an empty model map before writing', async () => {

--- a/apps/api/src/services/urlSafety.tripwire.test.ts
+++ b/apps/api/src/services/urlSafety.tripwire.test.ts
@@ -9,7 +9,7 @@ vi.mock('../db', () => ({
   assertOutsideHeldDbContext: assertSpy,
 }));
 
-import { safeFetch, SsrfBlockedError } from './urlSafety';
+import { assertSafeUrl, safeFetch, SsrfBlockedError } from './urlSafety';
 
 describe('safeFetch #1105 tripwire', () => {
   beforeEach(() => {
@@ -29,5 +29,41 @@ describe('safeFetch #1105 tripwire', () => {
       throw new Error('safeFetch ran inside a held withDbAccessContext transaction (#1105)');
     });
     await expect(safeFetch('https://example.com/')).rejects.toThrow(/#1105/);
+  });
+});
+
+// `assertSafeUrl` sends nothing, but it still does a real `dns.lookup` against
+// an operator/tenant-supplied hostname — an unbounded network wait on a
+// resolver the caller does not control. Inside a held request transaction that
+// pins a pooled connection idle-in-transaction exactly as an outbound fetch
+// does (#1105), and every caller of it so far reached it from a validation
+// helper deep inside a route handler, where the held context is invisible.
+// Guarding the primitive itself is what makes that class visible rather than
+// relying on each new caller remembering to register its route.
+describe('assertSafeUrl #1105 tripwire', () => {
+  beforeEach(() => {
+    assertSpy.mockClear();
+  });
+
+  it('calls assertOutsideHeldDbContext("assertSafeUrl") before resolving anything', async () => {
+    // A literal private IP is rejected without any DNS work, so reaching the
+    // guard at all proves it fired ahead of the resolve-and-filter step.
+    await expect(assertSafeUrl('https://127.0.0.1/secret')).rejects.toBeInstanceOf(SsrfBlockedError);
+    expect(assertSpy).toHaveBeenCalledTimes(1);
+    expect(assertSpy).toHaveBeenCalledWith('assertSafeUrl');
+  });
+
+  it('fires even for an unsupported scheme, which is rejected before any lookup', async () => {
+    await expect(assertSafeUrl('file:///etc/passwd')).rejects.toBeInstanceOf(SsrfBlockedError);
+    expect(assertSpy).toHaveBeenCalledWith('assertSafeUrl');
+  });
+
+  it('propagates a strict-mode throw from the guard', async () => {
+    assertSpy.mockImplementationOnce(() => {
+      throw new Error('assertSafeUrl ran inside a held withDbAccessContext transaction (#1105)');
+    });
+    // A blocked literal, so the only way this rejects with the guard's message
+    // rather than SsrfBlockedError is if the guard ran first — and no DNS.
+    await expect(assertSafeUrl('https://127.0.0.1/')).rejects.toThrow(/#1105/);
   });
 });

--- a/apps/api/src/services/urlSafety.ts
+++ b/apps/api/src/services/urlSafety.ts
@@ -267,6 +267,17 @@ export async function resolveSafeRecords(
  * window.
  */
 export async function assertSafeUrl(urlStr: string, opts?: SsrfGuardOptions): Promise<void> {
+  // #1105 tripwire, same reasoning as `safeFetch` below. This function sends no
+  // request, but it DOES perform a real `dns.lookup` against a hostname the
+  // caller does not control — an unbounded network wait. Run inside a held
+  // withDbAccessContext transaction it pins a pooled connection
+  // idle-in-transaction for the duration of that resolution, which is the same
+  // pool-poison class as an outbound fetch, only quieter. Guarding the
+  // primitive (rather than trusting each new route to register itself in
+  // middleware/selfManagedDbContextRoutes.ts) is what makes a new violation
+  // visible at all. Warn-only in prod; throws under DB_CONTEXT_TRIPWIRE_STRICT.
+  assertOutsideHeldDbContext('assertSafeUrl');
+
   const u = new URL(urlStr);
   if (u.protocol !== 'https:' && u.protocol !== 'http:') {
     throw new SsrfBlockedError(`unsupported URL scheme: ${u.protocol}`);

--- a/apps/web/src/components/admin/LlmProviderCatalog.test.tsx
+++ b/apps/web/src/components/admin/LlmProviderCatalog.test.tsx
@@ -189,6 +189,51 @@ describe('LlmProviderCatalog', () => {
     expect(body).toEqual({ modelId: 'claude-sonnet-4-6', apiKey: 'sk-transient-test-key' });
   });
 
+  describe('the List button mirrors the activation gate', () => {
+    // The API re-runs assertAllModelsVerified on a `listed` transition, so an
+    // enabled List button on a half-verified active revision is a button whose
+    // only outcome is a 409 toast. It has to read the SAME allVerified rule the
+    // Activate button does, not merely "an active revision exists".
+    const withActiveRevision = (verifiedModels: string[]) => ({
+      ...draftEntry,
+      activeRevisionId: 'rev-1',
+      revisions: [{ ...draftEntry.revisions[0], verifiedModels }],
+    });
+
+    it('disables List when the entry has no active revision at all', async () => {
+      mockApi([draftEntry]);
+      render(<LlmProviderCatalog />);
+      await screen.findByText('OpenRouter');
+
+      const listBtn = screen.getByTestId('llm-catalog-row-entry-1-list') as HTMLButtonElement;
+      expect(listBtn.disabled).toBe(true);
+    });
+
+    it('disables List when the active revision has an unverified mapped model', async () => {
+      mockApi([withActiveRevision([])]);
+      render(<LlmProviderCatalog />);
+      await screen.findByText('OpenRouter');
+
+      const listBtn = screen.getByTestId('llm-catalog-row-entry-1-list') as HTMLButtonElement;
+      expect(listBtn.disabled).toBe(true);
+      // A disabled control with no explanation is the failure mode this
+      // replaces — the operator has to be told to go verify the revision.
+      expect(listBtn.title).toBe(
+        'Every mapped model on the active revision needs a passing verification before this provider can be listed.',
+      );
+    });
+
+    it('enables List once every model on the active revision is verified', async () => {
+      mockApi([withActiveRevision(['claude-sonnet-4-6'])]);
+      render(<LlmProviderCatalog />);
+      await screen.findByText('OpenRouter');
+
+      const listBtn = screen.getByTestId('llm-catalog-row-entry-1-list') as HTMLButtonElement;
+      expect(listBtn.disabled).toBe(false);
+      expect(listBtn.title).toBe('');
+    });
+  });
+
   it('sets status to delisted via runAction after confirm', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     mockApi([draftEntry], {

--- a/apps/web/src/components/admin/LlmProviderCatalog.tsx
+++ b/apps/web/src/components/admin/LlmProviderCatalog.tsx
@@ -86,6 +86,29 @@ type ModelMapDraftRow = {
   cacheWriteCentsPerM: string;
 };
 
+/**
+ * The activation/listing gate, evaluated client-side purely to keep a control
+ * from offering an action the API will reject.
+ *
+ * An empty map is NOT verified: the API's `assertAllModelsVerified` asks "is
+ * every mapped model verified?", which an empty map answers vacuously — the
+ * same trap the server-side `assertOfferableModelMap` closes.
+ */
+function isFullyVerified(revision: CatalogRevision): boolean {
+  const modelIds = Object.keys(revision.modelMap);
+  return modelIds.length > 0
+    && modelIds.every((modelId) => revision.verifiedModels.includes(modelId));
+}
+
+/**
+ * The entry's active revision, or undefined when there is none (or the pointer
+ * is orphaned — which the API also treats as unlistable, with a 409).
+ */
+function activeRevisionOf(entry: CatalogEntry): CatalogRevision | undefined {
+  if (!entry.activeRevisionId) return undefined;
+  return entry.revisions.find((revision) => revision.revisionId === entry.activeRevisionId);
+}
+
 function emptyModelMapDraft(): Record<string, ModelMapDraftRow> {
   return Object.fromEntries(
     OFFERABLE_AI_MODELS.map((modelId) => [
@@ -486,6 +509,12 @@ export default function LlmProviderCatalog() {
             <tbody>
               {entries.map((entry) => {
                 const expanded = expandedId === entry.entryId;
+                // Listing re-runs the verification gate server-side (409 on a
+                // half-verified active revision), so the button must mirror the
+                // Activate button's rule rather than only checking that SOME
+                // revision is active.
+                const activeRevision = activeRevisionOf(entry);
+                const canList = activeRevision !== undefined && isFullyVerified(activeRevision);
                 return (
                   <Fragment key={entry.entryId}>
                     <tr data-testid={`llm-catalog-row-${entry.entryId}`} className="border-b hover:bg-gray-50">
@@ -525,8 +554,9 @@ export default function LlmProviderCatalog() {
                             <button
                               data-testid={`llm-catalog-row-${entry.entryId}-list`}
                               onClick={() => handleSetStatus(entry, 'listed')}
-                              disabled={!entry.activeRevisionId || statusChangingEntryId === entry.entryId}
-                              className="px-2 py-1 text-xs border rounded hover:bg-gray-100 disabled:opacity-50"
+                              disabled={!canList || statusChangingEntryId === entry.entryId}
+                              title={canList ? undefined : t('admin.llmProviderCatalog.revision.listBlocked')}
+                              className="px-2 py-1 text-xs border rounded hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                               {t('admin.llmProviderCatalog.actions.list')}
                             </button>
@@ -553,8 +583,7 @@ export default function LlmProviderCatalog() {
                             ) : (
                               entry.revisions.map((revision) => {
                                 const modelIds = Object.keys(revision.modelMap);
-                                const allVerified = modelIds.length > 0
-                                  && modelIds.every((modelId) => revision.verifiedModels.includes(modelId));
+                                const allVerified = isFullyVerified(revision);
                                 const isActive = entry.activeRevisionId === revision.revisionId;
                                 return (
                                   <div

--- a/apps/web/src/locales/de-DE/admin.json
+++ b/apps/web/src/locales/de-DE/admin.json
@@ -452,7 +452,8 @@
         "createdAt": "Erstellt",
         "notVerified": "Nicht verifiziert",
         "verified": "Verifiziert",
-        "activateBlocked": "Jedes zugeordnete Modell benötigt eine erfolgreiche Verifizierung, bevor diese Revision aktiviert werden kann."
+        "activateBlocked": "Jedes zugeordnete Modell benötigt eine erfolgreiche Verifizierung, bevor diese Revision aktiviert werden kann.",
+        "listBlocked": "Jedes zugeordnete Modell der aktiven Revision benötigt eine erfolgreiche Verifizierung, bevor dieser Anbieter gelistet werden kann."
       },
       "authModeOptions": {
         "x-api-key": "API-Schlüssel-Header",

--- a/apps/web/src/locales/en/admin.json
+++ b/apps/web/src/locales/en/admin.json
@@ -452,7 +452,8 @@
         "createdAt": "Created",
         "notVerified": "Not verified",
         "verified": "Verified",
-        "activateBlocked": "Every mapped model needs a passing verification before this revision can be activated."
+        "activateBlocked": "Every mapped model needs a passing verification before this revision can be activated.",
+        "listBlocked": "Every mapped model on the active revision needs a passing verification before this provider can be listed."
       },
       "authModeOptions": {
         "x-api-key": "API key header",

--- a/apps/web/src/locales/es-419/admin.json
+++ b/apps/web/src/locales/es-419/admin.json
@@ -452,7 +452,8 @@
         "createdAt": "Creado",
         "notVerified": "No verificado",
         "verified": "Verificado",
-        "activateBlocked": "Cada modelo asignado necesita una verificación aprobada antes de poder activar esta revisión."
+        "activateBlocked": "Cada modelo asignado necesita una verificación aprobada antes de poder activar esta revisión.",
+        "listBlocked": "Cada modelo asignado de la revisión activa necesita una verificación aprobada antes de poder listar este proveedor."
       },
       "authModeOptions": {
         "x-api-key": "Encabezado de clave de API",

--- a/apps/web/src/locales/fr-CA/admin.json
+++ b/apps/web/src/locales/fr-CA/admin.json
@@ -452,7 +452,8 @@
         "createdAt": "Créée",
         "notVerified": "Non vérifiée",
         "verified": "Vérifiée",
-        "activateBlocked": "Chaque modèle mappé doit réussir sa vérification avant que cette révision puisse être activée."
+        "activateBlocked": "Chaque modèle mappé doit réussir sa vérification avant que cette révision puisse être activée.",
+        "listBlocked": "Chaque modèle mappé de la révision active doit réussir sa vérification avant que ce fournisseur puisse être répertorié."
       },
       "authModeOptions": {
         "x-api-key": "En-tête de clé API",

--- a/apps/web/src/locales/fr-FR/admin.json
+++ b/apps/web/src/locales/fr-FR/admin.json
@@ -452,7 +452,8 @@
         "createdAt": "Créée",
         "notVerified": "Non vérifiée",
         "verified": "Vérifiée",
-        "activateBlocked": "Chaque modèle mappé doit réussir sa vérification avant que cette révision puisse être activée."
+        "activateBlocked": "Chaque modèle mappé doit réussir sa vérification avant que cette révision puisse être activée.",
+        "listBlocked": "Chaque modèle mappé de la révision active doit réussir sa vérification avant que ce fournisseur puisse être répertorié."
       },
       "authModeOptions": {
         "x-api-key": "En-tête de clé API",

--- a/apps/web/src/locales/it-IT/admin.json
+++ b/apps/web/src/locales/it-IT/admin.json
@@ -452,7 +452,8 @@
         "createdAt": "Creata",
         "notVerified": "Non verificata",
         "verified": "Verificata",
-        "activateBlocked": "Ogni modello mappato deve superare la verifica prima che questa revisione possa essere attivata."
+        "activateBlocked": "Ogni modello mappato deve superare la verifica prima che questa revisione possa essere attivata.",
+        "listBlocked": "Ogni modello mappato della revisione attiva deve superare la verifica prima che questo provider possa essere elencato."
       },
       "authModeOptions": {
         "x-api-key": "Intestazione chiave API",

--- a/apps/web/src/locales/pt-BR/admin.json
+++ b/apps/web/src/locales/pt-BR/admin.json
@@ -452,7 +452,8 @@
         "createdAt": "Criada",
         "notVerified": "Não verificada",
         "verified": "Verificada",
-        "activateBlocked": "Cada modelo mapeado precisa de uma verificação aprovada antes que esta revisão possa ser ativada."
+        "activateBlocked": "Cada modelo mapeado precisa de uma verificação aprovada antes que esta revisão possa ser ativada.",
+        "listBlocked": "Cada modelo mapeado da revisão ativa precisa de uma verificação aprovada antes que este provedor possa ser listado."
       },
       "authModeOptions": {
         "x-api-key": "Cabeçalho de chave de API",

--- a/apps/web/src/locales/tr-TR/admin.json
+++ b/apps/web/src/locales/tr-TR/admin.json
@@ -452,7 +452,8 @@
         "createdAt": "Oluşturuldu",
         "notVerified": "Doğrulanmadı",
         "verified": "Doğrulandı",
-        "activateBlocked": "Bu revizyon etkinleştirilmeden önce eşlenen her modelin doğrulamayı geçmesi gerekir."
+        "activateBlocked": "Bu revizyon etkinleştirilmeden önce eşlenen her modelin doğrulamayı geçmesi gerekir.",
+        "listBlocked": "Bu sağlayıcı listelenmeden önce etkin revizyondaki eşlenen her modelin doğrulamayı geçmesi gerekir."
       },
       "authModeOptions": {
         "x-api-key": "API anahtarı başlığı",


### PR DESCRIPTION
Closes four review findings on the platform-admin LLM provider catalog. Revision **authoring** is registered as a self-managed DB-context route: `createRevision` runs `validateBaseUrl` → `assertSafeUrl` on an operator-supplied base URL — a real `dns.lookup` against a host the operator chose — before any of its DB work, so a blackholed or merely slow resolver previously held a pooled connection idle-in-transaction for the whole resolution (the #1105 pool-poison class, without a byte of payload leaving the box); `assertSafeUrl` itself now carries the `assertOutsideHeldDbContext` tripwire so guarding the primitive, rather than trusting each new route to register itself, is what makes a future violation visible. Verification now distinguishes **our** egress controls refusing the target (`LlmEgressViolationError` / `SsrfBlockedError`) from the provider failing its check: that returns an operator-fixable `400 egress_blocked` plus its own audit row instead of a `502` that would send the operator to the provider's support desk — an operator repeatedly aiming a revision at metadata/RFC1918 space is a signal worth keeping, and the platform-admin middleware's method+path row cannot distinguish it. Catalog **authoring** gains audit rows of its own (`entry_created`, `revision_created`) carrying the decisive values — base URL **host** only, never the operator-typed path, plus auth mode and the mapped model ids — because catalog authoring deliberately has no four-eyes approval. And the UI's List button now mirrors the server's activation gate: listing re-runs `assertAllModelsVerified` (409 on a half-verified active revision) and an empty model map answers that vacuously, so the button checks that the *active* revision exists and has every mapped model verified rather than only that some revision is active.

Follow-up to #4113 — these review-round-2 fixes were committed after that PR merged.

Cherry-picked onto current `main` with no conflicts. Verified: `apps/api` selfManagedDbContextRoutes, admin/llmProviderCatalog, backup/configs, llm/providerFidelityHarness, llmProviderCatalog and urlSafety.tripwire suites (268 tests); `apps/web` LlmProviderCatalog.test.tsx (12) and the full i18n suite — localeParity, translationCoverage, keyUsage, terminologyQuality, extractionQuality (111) — all green, plus clean `tsc --noEmit` on `apps/api` and `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A592m7suBriiYsU6owVX61
