### PR TITLE
feat(web): org lifecycle wave 5 — archive UI

### DIFF
--- a/apps/web/src/components/settings/ArchiveOrgModal.test.tsx
+++ b/apps/web/src/components/settings/ArchiveOrgModal.test.tsx
@@ -104,6 +104,21 @@ describe('ArchiveOrgModal — retention picker', () => {
     expect(screen.queryByTestId('org-archive-custom-error')).not.toBeInTheDocument();
     expect(submit).not.toBeDisabled();
   });
+
+  it('accepts the boundary values 1 and 3650', () => {
+    renderModal();
+    fireEvent.click(screen.getByTestId('org-archive-retention-custom'));
+    const input = screen.getByTestId('org-archive-custom-days-input');
+    const submit = screen.getByTestId('org-archive-submit');
+
+    fireEvent.change(input, { target: { value: '1' } });
+    expect(screen.queryByTestId('org-archive-custom-error')).not.toBeInTheDocument();
+    expect(submit).not.toBeDisabled();
+
+    fireEvent.change(input, { target: { value: '3650' } });
+    expect(screen.queryByTestId('org-archive-custom-error')).not.toBeInTheDocument();
+    expect(submit).not.toBeDisabled();
+  });
 });
 
 describe('ArchiveOrgModal — consequences copy', () => {
@@ -183,7 +198,69 @@ describe('ArchiveOrgModal — submit', () => {
     );
   });
 
-  it('renders the draining-copy done state and purge date for an offboarding response', async () => {
+  it('POSTs the custom boundary value 1', async () => {
+    routeFetch({});
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('org-archive-retention-custom'));
+    fireEvent.change(screen.getByTestId('org-archive-custom-days-input'), { target: { value: '1' } });
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/orgs/organizations/${ORG.id}/archive`,
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ retentionDays: 1 }) }),
+      ),
+    );
+  });
+
+  it('POSTs the custom boundary value 3650', async () => {
+    routeFetch({});
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('org-archive-retention-custom'));
+    fireEvent.change(screen.getByTestId('org-archive-custom-days-input'), { target: { value: '3650' } });
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/orgs/organizations/${ORG.id}/archive`,
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ retentionDays: 3650 }) }),
+      ),
+    );
+  });
+
+  it('POSTs {retentionDays: 30} for the 30-day preset', async () => {
+    routeFetch({});
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('org-archive-retention-30'));
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/orgs/organizations/${ORG.id}/archive`,
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ retentionDays: 30 }) }),
+      ),
+    );
+  });
+
+  it('POSTs {retentionDays: 365} for the 365-day preset', async () => {
+    routeFetch({});
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('org-archive-retention-365'));
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/orgs/organizations/${ORG.id}/archive`,
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ retentionDays: 365 }) }),
+      ),
+    );
+  });
+
+  it('renders the draining-copy done state, description, and purge date for an offboarding response', async () => {
     routeFetch({ archive: () => ({ payload: { status: 'offboarding', purgeAt: '2026-11-24T00:00:00.000Z' } }) });
     renderModal();
 
@@ -191,10 +268,15 @@ describe('ArchiveOrgModal — submit', () => {
 
     await waitFor(() => expect(screen.getByTestId('org-archive-done')).toBeInTheDocument());
     expect(screen.getByText('Archiving started')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `${ORG.name} is being archived — its agents are being uninstalled now. This finishes automatically within a few minutes.`,
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByTestId('org-archive-purge-summary')).toHaveTextContent('2026');
   });
 
-  it('renders the archived-immediately done state for a suspended-entry response', async () => {
+  it('renders the archived-immediately done state and description for a suspended-entry response', async () => {
     routeFetch({ archive: () => ({ payload: { status: 'archived', purgeAt: null } }) });
     renderModal();
 
@@ -202,6 +284,7 @@ describe('ArchiveOrgModal — submit', () => {
 
     await waitFor(() => expect(screen.getByTestId('org-archive-done')).toBeInTheDocument());
     expect(screen.getByText('Organization archived')).toBeInTheDocument();
+    expect(screen.getByText(`${ORG.name} has been archived.`)).toBeInTheDocument();
     expect(screen.getByTestId('org-archive-purge-summary')).toHaveTextContent('kept until you delete it');
   });
 

--- a/apps/web/src/components/settings/ArchiveOrgModal.test.tsx
+++ b/apps/web/src/components/settings/ArchiveOrgModal.test.tsx
@@ -1,0 +1,249 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ArchiveOrgModal from './ArchiveOrgModal';
+import type { Organization } from './OrganizationList';
+import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  handleSessionExpired: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const sessionExpiredMock = vi.mocked(handleSessionExpired);
+const toastMock = vi.mocked(showToast);
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERROR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const ORG: Organization = {
+  id: 'org-1111-1111-1111-111111111111',
+  name: 'Acme Corp',
+  status: 'active',
+  deviceCount: 5,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+interface ArchiveResponse {
+  payload: unknown;
+  status?: number;
+}
+
+function routeFetch(handlers: { archive?: (body: unknown) => ArchiveResponse }) {
+  fetchMock.mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    if (init?.method === 'POST' && /\/organizations\/[^/]+\/archive$/.test(url)) {
+      const body = JSON.parse(String(init.body));
+      const { payload, status = 202 } =
+        handlers.archive?.(body) ?? { payload: { status: 'offboarding', purgeAt: '2026-11-24T00:00:00.000Z' } };
+      return jsonResponse(payload, status < 400, status);
+    }
+    return jsonResponse({});
+  });
+}
+
+function renderModal(overrides?: Partial<{ onClose: () => void; onArchived: (id: string) => void; onDoneClose: () => void }>) {
+  const onClose = overrides?.onClose ?? vi.fn();
+  const onArchived = overrides?.onArchived ?? vi.fn();
+  const onDoneClose = overrides?.onDoneClose ?? vi.fn();
+  render(<ArchiveOrgModal org={ORG} onClose={onClose} onArchived={onArchived} onDoneClose={onDoneClose} />);
+  return { onClose, onArchived, onDoneClose };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  sessionExpiredMock.mockReset();
+  toastMock.mockReset();
+});
+
+describe('ArchiveOrgModal — retention picker', () => {
+  it('defaults to the 90-day option', () => {
+    renderModal();
+    expect(screen.getByTestId('org-archive-retention-90')).toBeChecked();
+  });
+
+  it('renders every retention option', () => {
+    renderModal();
+    expect(screen.getByTestId('org-archive-retention-30')).toBeInTheDocument();
+    expect(screen.getByTestId('org-archive-retention-90')).toBeInTheDocument();
+    expect(screen.getByTestId('org-archive-retention-365')).toBeInTheDocument();
+    expect(screen.getByTestId('org-archive-retention-never')).toBeInTheDocument();
+    expect(screen.getByTestId('org-archive-retention-custom')).toBeInTheDocument();
+  });
+
+  it('hides the custom day input until Custom is selected', () => {
+    renderModal();
+    expect(screen.queryByTestId('org-archive-custom-days-input')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('org-archive-retention-custom'));
+    expect(screen.getByTestId('org-archive-custom-days-input')).toBeInTheDocument();
+  });
+
+  it('rejects a custom value below 1, above 3650, or non-numeric, and accepts one in range', () => {
+    renderModal();
+    fireEvent.click(screen.getByTestId('org-archive-retention-custom'));
+    const input = screen.getByTestId('org-archive-custom-days-input');
+    const submit = screen.getByTestId('org-archive-submit');
+
+    fireEvent.change(input, { target: { value: '0' } });
+    expect(screen.getByTestId('org-archive-custom-error')).toBeInTheDocument();
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: '3651' } });
+    expect(screen.getByTestId('org-archive-custom-error')).toBeInTheDocument();
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'abc' } });
+    expect(screen.getByTestId('org-archive-custom-error')).toBeInTheDocument();
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: '500' } });
+    expect(screen.queryByTestId('org-archive-custom-error')).not.toBeInTheDocument();
+    expect(submit).not.toBeDisabled();
+  });
+});
+
+describe('ArchiveOrgModal — consequences copy', () => {
+  it('states what archiving does: hidden, read-only, agents uninstalled, billing stops', () => {
+    renderModal();
+    const consequences = screen.getByTestId('org-archive-consequences');
+    expect(consequences).toHaveTextContent('Hidden from your organization list and search');
+    expect(consequences).toHaveTextContent('Existing data stays intact and read-only');
+    expect(consequences).toHaveTextContent('Agents are uninstalled from its devices');
+    expect(consequences).toHaveTextContent('Billing for this organization stops');
+    expect(screen.getByText(/Restoring Acme Corp is the undo for this action/)).toBeInTheDocument();
+  });
+
+  it('shows the auto-purge consequence for a numeric retention option', () => {
+    renderModal();
+    expect(screen.getByTestId('org-archive-purge-consequence')).toHaveTextContent(
+      'Permanently deleted after the retention period, unless you restore it first',
+    );
+  });
+
+  it('shows the kept-indefinitely consequence when Never is selected', () => {
+    renderModal();
+    fireEvent.click(screen.getByTestId('org-archive-retention-never'));
+    expect(screen.getByTestId('org-archive-purge-consequence')).toHaveTextContent(
+      'Kept until you delete it',
+    );
+  });
+
+  it('never claims the action cannot be undone', () => {
+    renderModal();
+    expect(screen.queryByText(/cannot be undone/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('ArchiveOrgModal — submit', () => {
+  it('POSTs {retentionDays: 90} for the default option and calls onArchived on 202', async () => {
+    routeFetch({});
+    const { onArchived } = renderModal();
+
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+
+    await waitFor(() => expect(onArchived).toHaveBeenCalledWith(ORG.id));
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/orgs/organizations/${ORG.id}/archive`,
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ retentionDays: 90 }) }),
+    );
+  });
+
+  it('POSTs {retentionDays: null} when Never is selected', async () => {
+    routeFetch({ archive: () => ({ payload: { status: 'archived', purgeAt: null } }) });
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('org-archive-retention-never'));
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/orgs/organizations/${ORG.id}/archive`,
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ retentionDays: null }) }),
+      ),
+    );
+  });
+
+  it('POSTs the custom day count when Custom is selected', async () => {
+    routeFetch({});
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('org-archive-retention-custom'));
+    fireEvent.change(screen.getByTestId('org-archive-custom-days-input'), { target: { value: '500' } });
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/orgs/organizations/${ORG.id}/archive`,
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ retentionDays: 500 }) }),
+      ),
+    );
+  });
+
+  it('renders the draining-copy done state and purge date for an offboarding response', async () => {
+    routeFetch({ archive: () => ({ payload: { status: 'offboarding', purgeAt: '2026-11-24T00:00:00.000Z' } }) });
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('org-archive-done')).toBeInTheDocument());
+    expect(screen.getByText('Archiving started')).toBeInTheDocument();
+    expect(screen.getByTestId('org-archive-purge-summary')).toHaveTextContent('2026');
+  });
+
+  it('renders the archived-immediately done state for a suspended-entry response', async () => {
+    routeFetch({ archive: () => ({ payload: { status: 'archived', purgeAt: null } }) });
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('org-archive-done')).toBeInTheDocument());
+    expect(screen.getByText('Organization archived')).toBeInTheDocument();
+    expect(screen.getByTestId('org-archive-purge-summary')).toHaveTextContent('kept until you delete it');
+  });
+
+  it('closing the done summary calls onDoneClose', async () => {
+    routeFetch({});
+    const { onDoneClose } = renderModal();
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+    await waitFor(() => expect(screen.getByTestId('org-archive-done')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('org-archive-close'));
+    expect(onDoneClose).toHaveBeenCalled();
+  });
+
+  it('on a server error, toasts and leaves the form open without calling onArchived', async () => {
+    routeFetch({ archive: () => ({ payload: { error: 'Organization cannot be archived from status \'purging\'' }, status: 409 }) });
+    const { onArchived } = renderModal();
+
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+
+    await waitFor(() => expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    expect(onArchived).not.toHaveBeenCalled();
+    expect(screen.getByTestId('org-archive-modal')).toBeInTheDocument();
+    expect(screen.queryByTestId('org-archive-done')).not.toBeInTheDocument();
+    expect(screen.getByTestId('org-archive-submit')).not.toBeDisabled();
+  });
+
+  it('cancel calls onClose without submitting', () => {
+    routeFetch({});
+    const { onClose } = renderModal();
+    fireEvent.click(screen.getByTestId('org-archive-cancel'));
+    expect(onClose).toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects through handleSessionExpired on a 401 without an extra toast', async () => {
+    routeFetch({ archive: () => ({ payload: { error: 'Unauthorized' }, status: 401 }) });
+    const { onArchived } = renderModal();
+
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+
+    await waitFor(() => expect(sessionExpiredMock).toHaveBeenCalled());
+    expect(onArchived).not.toHaveBeenCalled();
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/settings/ArchiveOrgModal.tsx
+++ b/apps/web/src/components/settings/ArchiveOrgModal.tsx
@@ -1,0 +1,271 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import '@/lib/i18n';
+import type { Organization } from './OrganizationList';
+import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
+import { runAction, handleActionError } from '@/lib/runAction';
+
+/** The three fixed-day presets the retention picker offers alongside "Never"
+ *  and "Custom". Exported for the test. */
+export const RETENTION_PRESET_DAYS = ['30', '90', '365'] as const;
+export type RetentionPresetDays = (typeof RETENTION_PRESET_DAYS)[number];
+export type RetentionOption = RetentionPresetDays | 'never' | 'custom';
+
+/** Matches the API's `retentionDays: z.number().int().min(1).max(3650).nullable().optional()`
+ *  (apps/api/src/routes/orgArchive.ts). */
+export const MIN_CUSTOM_RETENTION_DAYS = 1;
+export const MAX_CUSTOM_RETENTION_DAYS = 3650;
+
+export const DEFAULT_RETENTION_OPTION: RetentionOption = '90';
+
+/** Parses the custom-days text input. Returns `null` for anything that isn't
+ *  a plain integer in range — empty string included, so an untouched input
+ *  fails closed rather than silently defaulting to something submittable.
+ *  Exported for the test. */
+export function parseCustomRetentionDays(value: string): number | null {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const days = Number(trimmed);
+  if (!Number.isInteger(days) || days < MIN_CUSTOM_RETENTION_DAYS || days > MAX_CUSTOM_RETENTION_DAYS) {
+    return null;
+  }
+  return days;
+}
+
+/** Resolves the picker's current selection to the exact `retentionDays` value
+ *  the archive POST body carries: `null` for Never, the parsed value for
+ *  Custom (or `null` if it doesn't validate — callers must gate submission on
+ *  this separately), or the preset number otherwise. Exported for the test. */
+export function resolveRetentionDays(option: RetentionOption, customValue: string): number | null {
+  if (option === 'never') return null;
+  if (option === 'custom') return parseCustomRetentionDays(customValue);
+  return Number(option);
+}
+
+interface ArchiveResult {
+  status: 'offboarding' | 'archived';
+  purgeAt: string | null;
+}
+
+export interface ArchiveOrgModalProps {
+  org: Organization;
+  /** Dismiss without archiving — the form phase's Cancel button. */
+  onClose: () => void;
+  /**
+   * Fired exactly once, immediately after the archive POST returns 202.
+   * List-state update ONLY (drop the org from the active list) — must NOT
+   * close the modal, which stays open on its own `done` phase so the operator
+   * can see the purge-date summary. Mirrors MergeOrgModal's `onMerged`.
+   */
+  onArchived: (orgId: string) => void;
+  /** The done phase's explicit Close button. */
+  onDoneClose: () => void;
+}
+
+type Phase = 'form' | 'done';
+
+export default function ArchiveOrgModal({ org, onClose, onArchived, onDoneClose }: ArchiveOrgModalProps) {
+  const { t } = useTranslation('settings');
+  const [phase, setPhase] = useState<Phase>('form');
+  const [option, setOption] = useState<RetentionOption>(DEFAULT_RETENTION_OPTION);
+  const [customValue, setCustomValue] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<ArchiveResult | null>(null);
+
+  const customDays = option === 'custom' ? parseCustomRetentionDays(customValue) : null;
+  const customInvalid = option === 'custom' && customValue.trim() !== '' && customDays === null;
+  const canSubmit = !submitting && (option !== 'custom' || customDays !== null);
+
+  const mfaFriendly = (code: string) =>
+    code === 'MFA_REQUIRED' ? t('organizationsPage.archive.errors.mfaRequired') : undefined;
+
+  const formatPurgeDate = (iso: string) => {
+    const date = new Date(iso);
+    return Number.isNaN(date.getTime()) ? iso : date.toLocaleDateString();
+  };
+
+  const handleSubmit = async () => {
+    const retentionDays = resolveRetentionDays(option, customValue);
+    if (option === 'custom' && retentionDays === null) return; // canSubmit already guards this
+
+    setSubmitting(true);
+    try {
+      const data = await runAction<ArchiveResult>({
+        request: () =>
+          fetchWithAuth(`/orgs/organizations/${org.id}/archive`, {
+            method: 'POST',
+            body: JSON.stringify({ retentionDays }),
+          }),
+        errorFallback: t('organizationsPage.archive.errors.archive'),
+        friendly: mfaFriendly,
+        onUnauthorized: handleSessionExpired,
+      });
+      setResult(data);
+      setPhase('done');
+      onArchived(org.id);
+    } catch (err) {
+      // runAction already toasted an ActionError (e.g. a 409 for a status that
+      // can't be archived) — the modal simply stays on the form phase so the
+      // operator can retry or cancel. onUnauthorized handles a 401 redirect.
+      // Only a non-ActionError escape needs a fallback toast.
+      handleActionError(err, t('organizationsPage.archive.errors.archive'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8">
+      <div
+        className="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-lg border bg-card p-6 shadow-xs"
+        data-testid="org-archive-modal"
+      >
+        {phase === 'form' && (
+          <>
+            <h2 className="text-lg font-semibold">{t('organizationsPage.archive.title')}</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {t('organizationsPage.archive.description', { name: org.name })}
+            </p>
+
+            <div
+              data-testid="org-archive-consequences"
+              className="mt-4 space-y-2 rounded-md border bg-muted/30 p-3 text-sm"
+            >
+              <p className="font-medium">{t('organizationsPage.archive.consequencesHeading')}</p>
+              <ul className="list-disc space-y-1 pl-4">
+                <li>{t('organizationsPage.archive.consequences.hidden')}</li>
+                <li>{t('organizationsPage.archive.consequences.readOnly')}</li>
+                <li>{t('organizationsPage.archive.consequences.agentsUninstalled')}</li>
+                <li>{t('organizationsPage.archive.consequences.billingStops')}</li>
+                <li data-testid="org-archive-purge-consequence">
+                  {option === 'never'
+                    ? t('organizationsPage.archive.consequences.purgeNever')
+                    : t('organizationsPage.archive.consequences.purgeScheduled')}
+                </li>
+              </ul>
+              <p className="text-muted-foreground">
+                {t('organizationsPage.archive.restoreNote', { name: org.name })}
+              </p>
+            </div>
+
+            <fieldset className="mt-4">
+              <legend className="text-sm font-medium">{t('organizationsPage.archive.retentionLabel')}</legend>
+              <div className="mt-2 space-y-2">
+                {RETENTION_PRESET_DAYS.map((preset) => (
+                  <label key={preset} className="flex items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="org-archive-retention"
+                      data-testid={`org-archive-retention-${preset}`}
+                      checked={option === preset}
+                      onChange={() => setOption(preset)}
+                    />
+                    {t(/* i18n-dynamic */ `organizationsPage.archive.retentionOptions.days${preset}`)}
+                  </label>
+                ))}
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    name="org-archive-retention"
+                    data-testid="org-archive-retention-never"
+                    checked={option === 'never'}
+                    onChange={() => setOption('never')}
+                  />
+                  {t('organizationsPage.archive.retentionOptions.never')}
+                </label>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    name="org-archive-retention"
+                    data-testid="org-archive-retention-custom"
+                    checked={option === 'custom'}
+                    onChange={() => setOption('custom')}
+                  />
+                  {t('organizationsPage.archive.retentionOptions.custom')}
+                </label>
+                {option === 'custom' && (
+                  <div className="pl-6">
+                    <label htmlFor="org-archive-custom-days" className="block text-xs text-muted-foreground">
+                      {t('organizationsPage.archive.customDaysLabel')}
+                    </label>
+                    <input
+                      id="org-archive-custom-days"
+                      data-testid="org-archive-custom-days-input"
+                      // Deliberately `type="text"` rather than `number`: a number
+                      // input silently coerces an out-of-pattern paste (e.g.
+                      // "abc") to an empty string at the DOM level, which would
+                      // let invalid input escape our own 1–3650 integer check
+                      // (parseCustomRetentionDays) instead of surfacing it.
+                      type="text"
+                      inputMode="numeric"
+                      autoComplete="off"
+                      value={customValue}
+                      onChange={(e) => setCustomValue(e.target.value)}
+                      className="mt-1 h-9 w-32 rounded-md border bg-background px-2.5 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                    />
+                    {customInvalid && (
+                      <p data-testid="org-archive-custom-error" className="mt-1 text-xs text-destructive">
+                        {t('organizationsPage.archive.customError')}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            </fieldset>
+
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                data-testid="org-archive-cancel"
+                onClick={onClose}
+                disabled={submitting}
+                className="h-10 rounded-md border px-4 text-sm font-medium text-muted-foreground transition hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {t('organizationsPage.archive.cancel')}
+              </button>
+              <button
+                type="button"
+                data-testid="org-archive-submit"
+                onClick={() => void handleSubmit()}
+                disabled={!canSubmit}
+                className="inline-flex h-10 items-center justify-center rounded-md bg-destructive px-4 text-sm font-medium text-destructive-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {submitting ? t('organizationsPage.archive.archiving') : t('organizationsPage.archive.confirmButton')}
+              </button>
+            </div>
+          </>
+        )}
+
+        {phase === 'done' && result && (
+          <div data-testid="org-archive-done" className="space-y-3">
+            <p className="font-medium">
+              {result.status === 'offboarding'
+                ? t('organizationsPage.archive.doneOffboardingTitle')
+                : t('organizationsPage.archive.doneArchivedTitle')}
+            </p>
+            <p className="text-sm">
+              {result.status === 'offboarding'
+                ? t('organizationsPage.archive.doneOffboardingDescription', { name: org.name })
+                : t('organizationsPage.archive.doneArchivedDescription', { name: org.name })}
+            </p>
+            <p data-testid="org-archive-purge-summary" className="text-sm text-muted-foreground">
+              {result.purgeAt
+                ? t('organizationsPage.archive.donePurgeScheduled', { date: formatPurgeDate(result.purgeAt) })
+                : t('organizationsPage.archive.donePurgeNever')}
+            </p>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                data-testid="org-archive-close"
+                onClick={onDoneClose}
+                className="h-10 rounded-md border px-4 text-sm font-medium transition hover:bg-muted"
+              >
+                {t('organizationsPage.archive.close')}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/OrganizationList.tsx
+++ b/apps/web/src/components/settings/OrganizationList.tsx
@@ -24,6 +24,16 @@ export type Organization = {
   type?: 'customer' | 'internal' | 'quick_support';
   deviceCount?: number;
   createdAt: string;
+  /**
+   * Set (`true`) only on rows read through the archived-org list/detail door
+   * (`GET /orgs/organizations?includeArchived=true`, `archivedOrgReads.ts`).
+   * Absent on every ordinary live row — never `false` — so a plain
+   * `org.archived` truthiness check is the same test as `status === 'archived'`
+   * without re-deriving it from the status string at every call site.
+   */
+  archived?: true;
+  /** ISO timestamp, or `null` for "kept indefinitely" — only meaningful when `archived`. */
+  purgeAt?: string | null;
 };
 
 type OrganizationListProps = {

--- a/apps/web/src/components/settings/OrganizationsPage.archive.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.archive.test.tsx
@@ -1,0 +1,174 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OrganizationsPage from './OrganizationsPage';
+import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  handleSessionExpired: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+const storeFetchOrganizations = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: { getState: () => ({ fetchOrganizations: storeFetchOrganizations }) },
+}));
+
+// Archive doesn't gate on scope the way merge does, but OrganizationsPage
+// reads useJwtClaims() unconditionally (for the merge launcher), so it needs
+// a stub regardless — mirrors OrganizationsPage.merge.test.tsx.
+let mockJwtScope: 'system' | 'partner' | 'organization' | null = 'partner';
+vi.mock('../../lib/authScope', () => ({
+  useJwtClaims: () => ({
+    status: 'resolved' as const,
+    claims: { scope: mockJwtScope, orgId: null, partnerId: 'partner-1' },
+  }),
+  getJwtClaims: () => ({ scope: mockJwtScope, orgId: null, partnerId: 'partner-1' }),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERROR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const ORG_A = {
+  id: 'aaaaaaaa-1111-4111-8111-111111111111',
+  name: 'Alpha Ltd',
+  status: 'active',
+  deviceCount: 3,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+const ORG_B = {
+  id: 'bbbbbbbb-2222-4222-8222-222222222222',
+  name: 'Beta Ltd',
+  status: 'active',
+  deviceCount: 5,
+  createdAt: '2026-01-02T00:00:00Z',
+};
+
+let orgsState: Array<typeof ORG_A> = [ORG_A, ORG_B];
+
+/** Routes every fetch the page (and, once opened, ArchiveOrgModal) issues. */
+function mockApi(archiveResponse?: () => unknown) {
+  fetchMock.mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method;
+
+    if (url.startsWith('/orgs/organizations?') && !method) {
+      return jsonResponse({ data: orgsState });
+    }
+    if (url === '/orgs/partners/me') return jsonResponse({ settings: {} });
+    if (url.startsWith('/orgs/sites?organizationId=')) return jsonResponse({ data: [] });
+    if (method === 'POST' && /\/organizations\/[^/]+\/archive$/.test(url)) {
+      return jsonResponse(
+        archiveResponse?.() ?? { status: 'offboarding', purgeAt: '2026-11-24T00:00:00.000Z' },
+        true,
+        202,
+      );
+    }
+    return jsonResponse({ data: [] });
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+}
+
+async function selectOrg(org: typeof ORG_A) {
+  fireEvent.click(screen.getByTestId(`org-row-${org.id}`));
+  await flush();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchMock.mockReset();
+  navigateTo.mockReset();
+  storeFetchOrganizations.mockClear();
+  window.location.hash = '';
+  orgsState = [ORG_A, ORG_B];
+  mockJwtScope = 'partner';
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('OrganizationsPage — archive entry points open the real ArchiveOrgModal', () => {
+  it('opens it from the list-row hover icon, without first selecting the org', async () => {
+    mockApi();
+    render(<OrganizationsPage />);
+    await flush();
+
+    fireEvent.click(screen.getByTestId(`org-archive-open-row-${ORG_A.id}`));
+    await flush();
+
+    expect(screen.getByTestId('org-archive-modal')).toBeInTheDocument();
+  });
+
+  it('opens it from the detail header button once an org is selected', async () => {
+    mockApi();
+    render(<OrganizationsPage />);
+    await flush();
+
+    await selectOrg(ORG_A);
+    fireEvent.click(screen.getByTestId('org-archive-open'));
+    await flush();
+
+    expect(screen.getByTestId('org-archive-modal')).toBeInTheDocument();
+  });
+});
+
+describe('OrganizationsPage — archive completion', () => {
+  it('drops the archived org from the rendered list on 202, keeps the modal open on the done summary, and Close clears the selection', async () => {
+    mockApi(() => ({ status: 'offboarding', purgeAt: '2026-11-24T00:00:00.000Z' }));
+    render(<OrganizationsPage />);
+    await flush();
+
+    fireEvent.click(screen.getByTestId(`org-archive-open-row-${ORG_A.id}`));
+    await flush();
+
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+    await flush(); // archive POST (202)
+
+    // The modal did NOT close and unmount out from under the summary — same
+    // regression class as the merge modal's onMerged/onDoneClose split.
+    expect(screen.getByTestId('org-archive-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('org-archive-done')).toBeInTheDocument();
+
+    // The list-state update already happened, independent of the modal
+    // staying open: the archived org is out of the left list.
+    expect(screen.queryByTestId(`org-row-${ORG_A.id}`)).not.toBeInTheDocument();
+    expect(screen.getByTestId(`org-row-${ORG_B.id}`)).toBeInTheDocument();
+
+    // Closing the summary is what tears the modal down AND clears the stale
+    // (now-archived) selection.
+    fireEvent.click(screen.getByTestId('org-archive-close'));
+    await flush();
+
+    expect(screen.queryByTestId('org-archive-modal')).not.toBeInTheDocument();
+    expect(screen.getByText('No organization selected')).toBeInTheDocument();
+  });
+
+  it('drops the org from the list when archived via the detail header button too', async () => {
+    mockApi(() => ({ status: 'archived', purgeAt: null }));
+    render(<OrganizationsPage />);
+    await flush();
+
+    await selectOrg(ORG_A);
+    fireEvent.click(screen.getByTestId('org-archive-open'));
+    await flush();
+
+    fireEvent.click(screen.getByTestId('org-archive-submit'));
+    await flush();
+
+    expect(screen.queryByTestId(`org-row-${ORG_A.id}`)).not.toBeInTheDocument();
+    expect(screen.getByTestId(`org-row-${ORG_B.id}`)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/OrganizationsPage.archived.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.archived.test.tsx
@@ -5,6 +5,7 @@ import OrganizationsPage from './OrganizationsPage';
 import type { Organization } from './OrganizationList';
 import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
 import { showToast } from '../shared/Toast';
+import { ORGANIZATIONS_PAGE_SIZE } from '../../lib/fetchAllOrganizations';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
@@ -57,6 +58,16 @@ const ARCHIVED_ORG: Organization = {
   purgeAt: '2026-09-26T00:00:00.000Z', // 30 days after the fixed "now" below
 };
 
+const DELTA_ARCHIVED_ORG: Organization = {
+  id: 'dddddddd-4444-4444-8444-444444444444',
+  name: 'Delta Inc',
+  status: 'archived',
+  deviceCount: 0,
+  createdAt: '2026-01-04T00:00:00Z',
+  archived: true,
+  purgeAt: null,
+};
+
 let orgsState: Organization[] = [ORG_A];
 
 interface MockApiOptions {
@@ -67,15 +78,23 @@ interface MockApiOptions {
 }
 
 /** Routes every fetch the page issues, including the Archived section's
- * dedicated `includeArchived=true` GET and the restore POST. */
+ * dedicated `includeArchived=true` GET and the restore POST. The archived
+ * branch mimics the real API's server-side `search` filtering (orgs.ts /
+ * archivedOrgReads.ts both apply the same `search` param to the archived
+ * rows) so tests can prove the param actually narrows what comes back, not
+ * just that it's present on the URL. */
 function mockApi(opts: MockApiOptions = {}) {
   fetchMock.mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
     const url = String(input);
     const method = init?.method;
 
     if (url.includes('includeArchived=true')) {
+      const search = new URL(url, 'http://localhost').searchParams.get('search')?.toLowerCase();
+      const archived = (opts.archivedOrgs ?? []).filter((org) =>
+        search ? org.name.toLowerCase().includes(search) : true,
+      );
       return jsonResponse({
-        data: [...orgsState, ...(opts.archivedOrgs ?? [])],
+        data: [...orgsState, ...archived],
         pagination: { page: 1, limit: 100, total: orgsState.length },
         archivedTruncated: opts.archivedTruncated ?? false,
       });
@@ -185,6 +204,96 @@ describe('OrganizationsPage — Archived section', () => {
 
     expect(screen.queryByTestId('org-archived-truncated-note')).not.toBeInTheDocument();
   });
+
+  it('only appends archived rows from the final page of a multi-page live-org walk', async () => {
+    // A full first page of live orgs (== the page size) so fetchAllOrganizations
+    // continues to a second page instead of stopping after page 1 — proving the
+    // archived section still finds rows that ride along on the LAST page only
+    // (isFinalOrganizationsPage, orgs.ts), not just the trivial one-page case
+    // every other test here exercises.
+    const page1LiveOrgs: Organization[] = Array.from({ length: ORGANIZATIONS_PAGE_SIZE }, (_, i) => ({
+      id: `page1-org-${i}`,
+      name: `Page1 Org ${i}`,
+      status: 'active',
+      deviceCount: 0,
+      createdAt: '2026-01-01T00:00:00Z',
+    }));
+
+    fetchMock.mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method;
+
+      if (url.includes('includeArchived=true')) {
+        const page = new URL(url, 'http://localhost').searchParams.get('page');
+        if (page === '1') return jsonResponse({ data: page1LiveOrgs });
+        // Second (final) page: short (< page size) so the walk stops here,
+        // carrying the archived block per the real API's contract.
+        return jsonResponse({ data: [ARCHIVED_ORG], archivedTruncated: false });
+      }
+      if (url.startsWith('/orgs/organizations?') && !method) return jsonResponse({ data: orgsState });
+      if (url === '/orgs/partners/me') return jsonResponse({ settings: {} });
+      if (url.startsWith('/orgs/sites?organizationId=')) return jsonResponse({ data: [] });
+      return jsonResponse({ data: [] });
+    });
+
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+    await flush();
+
+    expect(screen.getByTestId('org-archived-row')).toBeInTheDocument();
+    expect(within(screen.getByTestId('org-archived-row')).getByText('Gamma LLC')).toBeInTheDocument();
+  });
+});
+
+describe('OrganizationsPage — Archived section search reachability', () => {
+  it('filters already-loaded archived rows by the page search box and forwards the term as the API search param', async () => {
+    mockApi({ archivedOrgs: [ARCHIVED_ORG, DELTA_ARCHIVED_ORG] });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+
+    expect(screen.getAllByTestId('org-archived-row')).toHaveLength(2);
+
+    fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'Gamma' } });
+    await flush();
+
+    // Forwarded as the API's own `search` query param (routes/orgs.ts /
+    // archivedOrgReads.ts both filter archived rows by it server-side).
+    expect(
+      fetchMock.mock.calls.some(
+        (call) => String(call[0]).includes('includeArchived=true') && String(call[0]).includes('search=Gamma'),
+      ),
+    ).toBe(true);
+
+    const rows = screen.getAllByTestId('org-archived-row');
+    expect(rows).toHaveLength(1);
+    expect(within(rows[0]).getByText('Gamma LLC')).toBeInTheDocument();
+  });
+
+  it('shows the no-matches copy (not the empty-section copy) when a search matches no archived org', async () => {
+    mockApi({ archivedOrgs: [ARCHIVED_ORG] });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+
+    fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'Nonexistent Org' } });
+    await flush();
+
+    expect(screen.getByText('No archived organizations match your search.')).toBeInTheDocument();
+    expect(screen.queryByText('No archived organizations.')).not.toBeInTheDocument();
+  });
+
+  it('does not fetch archived orgs at all while the section stays collapsed, even if the search box changes', async () => {
+    mockApi({ archivedOrgs: [ARCHIVED_ORG] });
+    render(<OrganizationsPage />);
+    await flush();
+
+    fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'Gamma' } });
+    await flush();
+
+    expect(archivedFetchWasIssued()).toBe(false);
+  });
 });
 
 describe('OrganizationsPage — archived org detail pane is read-only', () => {
@@ -211,7 +320,7 @@ describe('OrganizationsPage — archived org detail pane is read-only', () => {
 });
 
 describe('OrganizationsPage — restore', () => {
-  it('on 200, moves the org to the active list under its returned status and surfaces recreateRequired', async () => {
+  it('on 200, POSTs the specific org, moves it to the active list under its returned status, and surfaces recreateRequired', async () => {
     mockApi({
       archivedOrgs: [ARCHIVED_ORG],
       restoreResponse: () => ({
@@ -227,8 +336,14 @@ describe('OrganizationsPage — restore', () => {
     fireEvent.click(screen.getByTestId('org-restore'));
     await flush();
 
-    // Moved into the active list under the pre-archive status the API returned.
-    expect(screen.getByTestId(`org-row-${ARCHIVED_ORG.id}`)).toBeInTheDocument();
+    // Pinned to the specific archived org's id — not just "some" restore URL.
+    expect(fetchMock).toHaveBeenCalledWith(`/orgs/organizations/${ARCHIVED_ORG.id}/restore`, { method: 'POST' });
+
+    // Moved into the active list under the pre-archive status the API
+    // returned, and the row itself renders that status (not just present).
+    const row = screen.getByTestId(`org-row-${ARCHIVED_ORG.id}`);
+    expect(within(row).getByText('Trial')).toBeInTheDocument();
+
     // The detail pane switched out of read-only for the now-restored org.
     const panel = screen.getByTestId('org-detail-panel');
     expect(within(panel).queryByTestId('org-restore')).not.toBeInTheDocument();
@@ -242,7 +357,26 @@ describe('OrganizationsPage — restore', () => {
     );
   });
 
-  it('respects a suspended pre-archive status and adds the suspended-restore note', async () => {
+  it('reconciles the global org store (fire-and-forget) after a successful restore', async () => {
+    mockApi({ archivedOrgs: [ARCHIVED_ORG] });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+
+    fireEvent.click(screen.getByTestId('org-archived-row'));
+    await flush();
+    expect(storeFetchOrganizations).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('org-restore'));
+    await flush();
+
+    // The org switcher/sidebar reads this store, not this page's own state —
+    // without this it would keep showing the restored org as archived/absent
+    // until a full reload.
+    expect(storeFetchOrganizations).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects a suspended pre-archive status: the row renders Suspended and the toast adds the suspended-restore note', async () => {
     mockApi({
       archivedOrgs: [ARCHIVED_ORG],
       restoreResponse: () => ({
@@ -258,6 +392,12 @@ describe('OrganizationsPage — restore', () => {
     fireEvent.click(screen.getByTestId('org-restore'));
     await flush();
 
+    expect(fetchMock).toHaveBeenCalledWith(`/orgs/organizations/${ARCHIVED_ORG.id}/restore`, { method: 'POST' });
+
+    // The list itself reflects the suspended status, not just the toast copy.
+    const row = screen.getByTestId(`org-row-${ARCHIVED_ORG.id}`);
+    expect(within(row).getByText('Suspended')).toBeInTheDocument();
+
     expect(showToastMock).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'success',
@@ -266,7 +406,7 @@ describe('OrganizationsPage — restore', () => {
     );
   });
 
-  it('on 410, shows the purging-refusal copy and leaves the org archived', async () => {
+  it('on 410, shows the exact purging-refusal copy and leaves the org archived', async () => {
     mockApi({
       archivedOrgs: [ARCHIVED_ORG],
       restoreResponse: () => ({
@@ -283,6 +423,7 @@ describe('OrganizationsPage — restore', () => {
     fireEvent.click(screen.getByTestId('org-restore'));
     await flush();
 
+    expect(fetchMock).toHaveBeenCalledWith(`/orgs/organizations/${ARCHIVED_ORG.id}/restore`, { method: 'POST' });
     expect(showToastMock).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'error',
@@ -293,9 +434,10 @@ describe('OrganizationsPage — restore', () => {
     const panel = screen.getByTestId('org-detail-panel');
     expect(within(panel).getByTestId('org-restore')).toBeInTheDocument();
     expect(screen.queryByTestId(`org-row-${ARCHIVED_ORG.id}`)).not.toBeInTheDocument();
+    expect(storeFetchOrganizations).not.toHaveBeenCalled();
   });
 
-  it('on 409, shows an error toast and leaves the org archived', async () => {
+  it('on 409, surfaces the raw backend message verbatim and leaves the org archived', async () => {
     mockApi({
       archivedOrgs: [ARCHIVED_ORG],
       restoreResponse: () => ({
@@ -312,11 +454,18 @@ describe('OrganizationsPage — restore', () => {
     fireEvent.click(screen.getByTestId('org-restore'));
     await flush();
 
+    expect(fetchMock).toHaveBeenCalledWith(`/orgs/organizations/${ARCHIVED_ORG.id}/restore`, { method: 'POST' });
+    // No special-cased copy for a plain 409 — the backend's own message
+    // surfaces verbatim (only MFA and the 410 purging text get localized copy).
     expect(showToastMock).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'error' }),
+      expect.objectContaining({
+        type: 'error',
+        message: 'Organization cannot be restored from its current status',
+      }),
     );
     const panel = screen.getByTestId('org-detail-panel');
     expect(within(panel).getByTestId('org-restore')).toBeInTheDocument();
     expect(screen.queryByTestId(`org-row-${ARCHIVED_ORG.id}`)).not.toBeInTheDocument();
+    expect(storeFetchOrganizations).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/settings/OrganizationsPage.archived.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.archived.test.tsx
@@ -115,9 +115,14 @@ function mockApi(opts: MockApiOptions = {}) {
   });
 }
 
-async function flush() {
+// Default advance covers the archived section's search debounce
+// (ARCHIVED_SEARCH_DEBOUNCE_MS = 300ms) plus whatever microtask chain a
+// resolved (non-held) mock fetch needs to settle. Tests that manually hold a
+// fetch open (the race test below) advance by smaller, explicit amounts of
+// their own instead of relying on this default.
+async function flush(ms = 350) {
   await act(async () => {
-    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(ms);
   });
 }
 
@@ -293,6 +298,94 @@ describe('OrganizationsPage — Archived section search reachability', () => {
     await flush();
 
     expect(archivedFetchWasIssued()).toBe(false);
+  });
+
+  it('does not issue a search fetch before the debounce window elapses', async () => {
+    mockApi({ archivedOrgs: [ARCHIVED_ORG] });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+    fetchMock.mockClear();
+
+    fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'Gamma' } });
+    // Well under the 300ms debounce — nothing should have gone out yet.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(archivedFetchWasIssued()).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(archivedFetchWasIssued()).toBe(true);
+  });
+});
+
+describe('OrganizationsPage — Archived section search race safety', () => {
+  it('drops a stale search response that resolves after a newer one, even though it started first (older-resolves-last)', async () => {
+    // Each distinct `search` value gets its own held-open promise, released
+    // explicitly by the test — same technique as
+    // MergeOrgModal.test.tsx's "stale preview race" suite.
+    const held: Record<string, (body: unknown) => void> = {};
+    fetchMock.mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method;
+
+      if (url.includes('includeArchived=true')) {
+        const search = new URL(url, 'http://localhost').searchParams.get('search') ?? '';
+        if (!search) {
+          // The initial (no-search) expand load resolves immediately.
+          return jsonResponse({ data: [...orgsState, ARCHIVED_ORG, DELTA_ARCHIVED_ORG], archivedTruncated: false });
+        }
+        return new Promise<Response>((resolve) => {
+          held[search] = (body: unknown) => resolve(jsonResponse(body));
+        });
+      }
+      if (url.startsWith('/orgs/organizations?') && !method) return jsonResponse({ data: orgsState });
+      if (url === '/orgs/partners/me') return jsonResponse({ settings: {} });
+      if (url.startsWith('/orgs/sites?organizationId=')) return jsonResponse({ data: [] });
+      return jsonResponse({ data: [] });
+    });
+
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+    expect(screen.getAllByTestId('org-archived-row')).toHaveLength(2);
+
+    // Type "Gamma" — the OLDER request. Advance past the debounce so its
+    // fetch actually fires and hangs open (held, not yet resolved).
+    fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'Gamma' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(320);
+    });
+    expect(held.Gamma).toBeDefined();
+
+    // Before it resolves, change the search again — the NEWER request. Its
+    // own debounced fetch fires and is ALSO held open.
+    fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'Delta' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(320);
+    });
+    expect(held.Delta).toBeDefined();
+
+    // Release the NEWER request first.
+    await act(async () => {
+      held.Delta({ data: [...orgsState, DELTA_ARCHIVED_ORG], archivedTruncated: false });
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getAllByTestId('org-archived-row')).toHaveLength(1);
+    expect(screen.getByText('Delta Inc')).toBeInTheDocument();
+
+    // Now release the OLDER ("Gamma") request — it resolves LAST. It must be
+    // dropped by the request-token guard rather than clobbering the newer
+    // (Delta) results already on screen.
+    await act(async () => {
+      held.Gamma({ data: [...orgsState, ARCHIVED_ORG], archivedTruncated: false });
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getAllByTestId('org-archived-row')).toHaveLength(1);
+    expect(screen.getByText('Delta Inc')).toBeInTheDocument();
+    expect(screen.queryByText('Gamma LLC')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/settings/OrganizationsPage.archived.test.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.archived.test.tsx
@@ -1,0 +1,322 @@
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OrganizationsPage from './OrganizationsPage';
+import type { Organization } from './OrganizationList';
+import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  handleSessionExpired: vi.fn(),
+}));
+
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const navigateTo = vi.fn();
+vi.mock('@/lib/navigation', () => ({ navigateTo: (...args: unknown[]) => navigateTo(...args) }));
+
+const storeFetchOrganizations = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: { getState: () => ({ fetchOrganizations: storeFetchOrganizations }) },
+}));
+
+// OrganizationsPage reads useJwtClaims() unconditionally (for the merge
+// launcher's gating) regardless of what this suite exercises — mirrors
+// OrganizationsPage.archive.test.tsx / .merge.test.tsx.
+let mockJwtScope: 'system' | 'partner' | 'organization' | null = 'partner';
+vi.mock('../../lib/authScope', () => ({
+  useJwtClaims: () => ({
+    status: 'resolved' as const,
+    claims: { scope: mockJwtScope, orgId: null, partnerId: 'partner-1' },
+  }),
+  getJwtClaims: () => ({ scope: mockJwtScope, orgId: null, partnerId: 'partner-1' }),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const showToastMock = vi.mocked(showToast);
+
+const jsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERROR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const ORG_A: Organization = {
+  id: 'aaaaaaaa-1111-4111-8111-111111111111',
+  name: 'Alpha Ltd',
+  status: 'active',
+  deviceCount: 3,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+const ARCHIVED_ORG: Organization = {
+  id: 'cccccccc-3333-4333-8333-333333333333',
+  name: 'Gamma LLC',
+  status: 'archived',
+  deviceCount: 0,
+  createdAt: '2026-01-03T00:00:00Z',
+  archived: true,
+  purgeAt: '2026-09-26T00:00:00.000Z', // 30 days after the fixed "now" below
+};
+
+let orgsState: Organization[] = [ORG_A];
+
+interface MockApiOptions {
+  archivedOrgs?: Organization[];
+  archivedTruncated?: boolean;
+  /** Called for every restore POST; defaults to a plain 200 'active' restore. */
+  restoreResponse?: () => { body: unknown; status?: number };
+}
+
+/** Routes every fetch the page issues, including the Archived section's
+ * dedicated `includeArchived=true` GET and the restore POST. */
+function mockApi(opts: MockApiOptions = {}) {
+  fetchMock.mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method;
+
+    if (url.includes('includeArchived=true')) {
+      return jsonResponse({
+        data: [...orgsState, ...(opts.archivedOrgs ?? [])],
+        pagination: { page: 1, limit: 100, total: orgsState.length },
+        archivedTruncated: opts.archivedTruncated ?? false,
+      });
+    }
+    if (url.startsWith('/orgs/organizations?') && !method) {
+      return jsonResponse({ data: orgsState });
+    }
+    if (url === '/orgs/partners/me') return jsonResponse({ settings: {} });
+    if (url.startsWith('/orgs/sites?organizationId=')) return jsonResponse({ data: [] });
+    if (method === 'POST' && /\/organizations\/[^/]+\/restore$/.test(url)) {
+      const result = opts.restoreResponse?.() ?? {
+        body: { status: 'active', recreateRequired: ['Agents that completed the archive uninstall must be re-enrolled.'] },
+      };
+      const status = result.status ?? 200;
+      return jsonResponse(result.body, status < 400, status);
+    }
+    return jsonResponse({ data: [] });
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+}
+
+async function expandArchivedSection() {
+  fireEvent.click(screen.getByTestId('org-archived-toggle'));
+  await flush();
+}
+
+/** Whether any fetch issued so far carried `includeArchived=true` — checked by
+ * scanning the mock's own call args rather than `toHaveBeenCalledWith`, which
+ * compares full argument LISTS: `fetchWithAuth` is called with a single
+ * positional arg here, so a 2-arg matcher (e.g. `..., expect.anything()`)
+ * would never match any real call and silently pass for the wrong reason. */
+function archivedFetchWasIssued(): boolean {
+  return fetchMock.mock.calls.some((call) => String(call[0]).includes('includeArchived=true'));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-27T00:00:00.000Z'));
+  fetchMock.mockReset();
+  navigateTo.mockReset();
+  storeFetchOrganizations.mockClear();
+  showToastMock.mockClear();
+  window.location.hash = '';
+  orgsState = [ORG_A];
+  mockJwtScope = 'partner';
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('OrganizationsPage — Archived section', () => {
+  it('starts collapsed and does not fetch archived orgs until expanded', async () => {
+    mockApi({ archivedOrgs: [ARCHIVED_ORG] });
+    render(<OrganizationsPage />);
+    await flush();
+
+    expect(screen.queryByTestId('org-archived-section')).not.toBeInTheDocument();
+    expect(archivedFetchWasIssued()).toBe(false);
+
+    await expandArchivedSection();
+
+    expect(archivedFetchWasIssued()).toBe(true);
+    expect(screen.getByTestId('org-archived-section')).toBeInTheDocument();
+    expect(screen.getByTestId('org-archived-row')).toBeInTheDocument();
+    expect(within(screen.getByTestId('org-archived-row')).getByText('Gamma LLC')).toBeInTheDocument();
+  });
+
+  it('renders a purge countdown computed from purgeAt against the current fixed time', async () => {
+    mockApi({ archivedOrgs: [ARCHIVED_ORG] });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+
+    // purgeAt is exactly 30 days after the fixed "now" set in beforeEach.
+    expect(within(screen.getByTestId('org-archived-row')).getByText('Purges in 30 days')).toBeInTheDocument();
+  });
+
+  it('renders "kept indefinitely" when purgeAt is null', async () => {
+    mockApi({ archivedOrgs: [{ ...ARCHIVED_ORG, purgeAt: null }] });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+
+    expect(within(screen.getByTestId('org-archived-row')).getByText('Kept indefinitely')).toBeInTheDocument();
+  });
+
+  it('renders a truncation note when the API reports archivedTruncated', async () => {
+    mockApi({ archivedOrgs: [ARCHIVED_ORG], archivedTruncated: true });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+
+    expect(screen.getByTestId('org-archived-truncated-note')).toBeInTheDocument();
+  });
+
+  it('does not render a truncation note when archivedTruncated is false', async () => {
+    mockApi({ archivedOrgs: [ARCHIVED_ORG], archivedTruncated: false });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+
+    expect(screen.queryByTestId('org-archived-truncated-note')).not.toBeInTheDocument();
+  });
+});
+
+describe('OrganizationsPage — archived org detail pane is read-only', () => {
+  it('selecting an archived row hides every mutation button and shows only Restore', async () => {
+    mockApi({ archivedOrgs: [ARCHIVED_ORG] });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+
+    fireEvent.click(screen.getByTestId('org-archived-row'));
+    await flush();
+
+    const panel = screen.getByTestId('org-detail-panel');
+    expect(within(panel).getByTestId('org-restore')).toBeInTheDocument();
+    expect(within(panel).getByTestId('org-archived-readonly-notice')).toBeInTheDocument();
+    expect(within(panel).getByTestId('org-archived-detail-badge')).toBeInTheDocument();
+    expect(within(panel).getByTestId('org-archived-detail-purge')).toBeInTheDocument();
+
+    // No edit/merge/archive affordances — only the Restore button.
+    expect(within(panel).queryByTestId('org-archive-open')).not.toBeInTheDocument();
+    expect(within(panel).queryByTestId('org-merge-open')).not.toBeInTheDocument();
+    expect(within(panel).getAllByRole('button')).toHaveLength(1);
+  });
+});
+
+describe('OrganizationsPage — restore', () => {
+  it('on 200, moves the org to the active list under its returned status and surfaces recreateRequired', async () => {
+    mockApi({
+      archivedOrgs: [ARCHIVED_ORG],
+      restoreResponse: () => ({
+        body: { status: 'trial', recreateRequired: ['Agents that completed the archive uninstall must be re-enrolled.'] },
+      }),
+    });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+
+    fireEvent.click(screen.getByTestId('org-archived-row'));
+    await flush();
+    fireEvent.click(screen.getByTestId('org-restore'));
+    await flush();
+
+    // Moved into the active list under the pre-archive status the API returned.
+    expect(screen.getByTestId(`org-row-${ARCHIVED_ORG.id}`)).toBeInTheDocument();
+    // The detail pane switched out of read-only for the now-restored org.
+    const panel = screen.getByTestId('org-detail-panel');
+    expect(within(panel).queryByTestId('org-restore')).not.toBeInTheDocument();
+    expect(within(panel).getByTestId('org-archive-open')).toBeInTheDocument();
+
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'success',
+        message: expect.stringContaining('re-enrolled'),
+      }),
+    );
+  });
+
+  it('respects a suspended pre-archive status and adds the suspended-restore note', async () => {
+    mockApi({
+      archivedOrgs: [ARCHIVED_ORG],
+      restoreResponse: () => ({
+        body: { status: 'suspended', recreateRequired: ['Agents that completed the archive uninstall must be re-enrolled.'] },
+      }),
+    });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+
+    fireEvent.click(screen.getByTestId('org-archived-row'));
+    await flush();
+    fireEvent.click(screen.getByTestId('org-restore'));
+    await flush();
+
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'success',
+        message: expect.stringContaining('suspended'),
+      }),
+    );
+  });
+
+  it('on 410, shows the purging-refusal copy and leaves the org archived', async () => {
+    mockApi({
+      archivedOrgs: [ARCHIVED_ORG],
+      restoreResponse: () => ({
+        body: { error: 'Organization is already purging and can no longer be restored' },
+        status: 410,
+      }),
+    });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+
+    fireEvent.click(screen.getByTestId('org-archived-row'));
+    await flush();
+    fireEvent.click(screen.getByTestId('org-restore'));
+    await flush();
+
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        message: 'This organization is already being permanently deleted and can no longer be restored.',
+      }),
+    );
+    // Still archived and read-only — the restore never applied.
+    const panel = screen.getByTestId('org-detail-panel');
+    expect(within(panel).getByTestId('org-restore')).toBeInTheDocument();
+    expect(screen.queryByTestId(`org-row-${ARCHIVED_ORG.id}`)).not.toBeInTheDocument();
+  });
+
+  it('on 409, shows an error toast and leaves the org archived', async () => {
+    mockApi({
+      archivedOrgs: [ARCHIVED_ORG],
+      restoreResponse: () => ({
+        body: { error: 'Organization cannot be restored from its current status' },
+        status: 409,
+      }),
+    });
+    render(<OrganizationsPage />);
+    await flush();
+    await expandArchivedSection();
+
+    fireEvent.click(screen.getByTestId('org-archived-row'));
+    await flush();
+    fireEvent.click(screen.getByTestId('org-restore'));
+    await flush();
+
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' }),
+    );
+    const panel = screen.getByTestId('org-detail-panel');
+    expect(within(panel).getByTestId('org-restore')).toBeInTheDocument();
+    expect(screen.queryByTestId(`org-row-${ARCHIVED_ORG.id}`)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -189,6 +189,22 @@ export default function OrganizationsPage() {
     return organizations.filter(org => org.name.toLowerCase().includes(q));
   }, [organizations, searchQuery]);
 
+  /**
+   * Client-side re-filter of whatever archived rows are already loaded, using
+   * the SAME search box as `filteredOrgs` above. This is deliberately in
+   * addition to — not instead of — forwarding `search` to the server fetch
+   * (see `fetchArchivedOrganizations`): the network round trip means
+   * `archivedOrgs` can briefly still hold the previous query's results after a
+   * keystroke, and filtering client-side too avoids flashing those stale rows
+   * before the fresh, server-filtered set lands. Once it lands this filter is
+   * a no-op (the loaded rows already match), so it costs nothing steady-state.
+   */
+  const filteredArchivedOrgs = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return archivedOrgs;
+    return archivedOrgs.filter(org => org.name.toLowerCase().includes(q));
+  }, [archivedOrgs, searchQuery]);
+
   /** Renders an archived org's purge countdown, shared by the row and the
    *  read-only detail pane. `purgeAt: null` (retention "Never") and an
    *  unparseable timestamp both collapse to "kept indefinitely" via
@@ -258,14 +274,24 @@ export default function OrganizationsPage() {
    * (`orgStore.ts`) or `fetchOrganizations` above: both stay on the plain
    * unarchived query every other caller of them expects, and this is the one
    * reader that opts in to `includeArchived=true`.
+   *
+   * `search` is forwarded as the API's own `search` query param (same one
+   * `fetchOrganizations`'s active-list query would use, and the one
+   * `listArchivedOrgs` filters archived rows by server-side — orgs.ts,
+   * archivedOrgReads.ts). Without this, the truncation note's "search to
+   * narrow the list" was a dead end: the page's search box only filtered
+   * whatever was already loaded, so an archived org past the truncation cap
+   * could never be reached by any partner with more archived orgs than the
+   * page limit.
    */
-  const fetchArchivedOrganizations = useCallback(async () => {
+  const fetchArchivedOrganizations = useCallback(async (search: string) => {
     setArchivedLoading(true);
     setArchivedError(undefined);
     let truncated = false;
     try {
       const all = await fetchAllOrganizations<Organization>(async (page, limit) => {
-        const response = await fetchWithAuth(`/orgs/organizations?page=${page}&limit=${limit}&includeArchived=true`);
+        const searchParam = search ? `&search=${encodeURIComponent(search)}` : '';
+        const response = await fetchWithAuth(`/orgs/organizations?page=${page}&limit=${limit}&includeArchived=true${searchParam}`);
         if (!response.ok) {
           if (response.status === 401) {
             handleSessionExpired();
@@ -344,13 +370,16 @@ export default function OrganizationsPage() {
 
   // Fetch-on-expand: the Archived section starts collapsed and empty, and only
   // issues the `includeArchived=true` request the moment it's opened — not on
-  // page mount. Re-fires on every expand (no "already fetched" cache) so a
-  // reopen after a restore/archive elsewhere always shows current data; that
-  // costs one extra request per open, which is cheap next to a stale purge
-  // countdown.
+  // page mount. Also re-fires whenever the page's own search box changes
+  // while expanded, forwarding the term as the API's `search` param — the
+  // same box that filters the active list above doubles as the archived
+  // section's search, so a >100-row partner can still reach an archived org
+  // past the truncation cap. No "already fetched" cache: every expand/search
+  // change re-issues the request, which is cheap next to a stale purge
+  // countdown or an unreachable archived tenant.
   useEffect(() => {
-    if (archivedExpanded) fetchArchivedOrganizations();
-  }, [archivedExpanded, fetchArchivedOrganizations]);
+    if (archivedExpanded) fetchArchivedOrganizations(searchQuery.trim());
+  }, [archivedExpanded, searchQuery, fetchArchivedOrganizations]);
 
   // Load the partner's default timezone once so new sites pre-select it.
   // Best-effort: on any failure we silently fall back to the form's UTC default.
@@ -502,15 +531,26 @@ export default function OrganizationsPage() {
   };
 
   /**
-   * Restores an archived org. LIST-STATE UPDATE ONLY, mirroring the
-   * archive/merge complete handlers above: drop it from `archivedOrgs`, add it
-   * back to the active `organizations` list under the status the API reports
-   * (its PRE-archive status — restoring a suspended org lands it back
-   * suspended, not active), and re-select it so the detail pane switches out
-   * of read-only immediately. No `refreshOrgs()` call: that would re-fetch the
-   * plain (unarchived) list and could race this optimistic update, and
-   * everything the active list needs (id/name/status/deviceCount/createdAt)
-   * already rode along on the archived row itself.
+   * Restores an archived org. This page's OWN list state is updated
+   * synchronously/optimistically, mirroring the archive/merge complete
+   * handlers above: drop it from `archivedOrgs`, add it back to the active
+   * `organizations` list under the status the API reports (its PRE-archive
+   * status — restoring a suspended org lands it back suspended, not active),
+   * and re-select it so the detail pane switches out of read-only
+   * immediately. Deliberately not a `refreshOrgs()` (which also re-fetches
+   * this page's OWN list): that would re-fetch the plain list and could race
+   * this optimistic update, and everything the active list needs
+   * (id/name/status/deviceCount/createdAt) already rode along on the archived
+   * row itself.
+   *
+   * The global org store (`orgStore.ts`, feeds the org-switcher/sidebar) is a
+   * SEPARATE concern from this page's own state and doesn't share that
+   * optimistic update — it has to hear about the restored org from the server
+   * to pick up fields this page never had (partnerId, currencyCode, trial
+   * end date). Fired fire-and-forget, same as `refreshOrgs` does for org
+   * create: it must not block clearing `restoringOrgId` or block/replace the
+   * success toast, and a failure here is a stale switcher entry, not a
+   * failed restore — the restore itself already committed.
    */
   const handleRestore = async (org: Organization) => {
     setRestoringOrgId(org.id);
@@ -528,6 +568,9 @@ export default function OrganizationsPage() {
       setArchivedOrgs(prev => prev.filter(o => o.id !== org.id));
       setOrganizations(prev => [...prev, restoredOrg]);
       setSelectedOrg(restoredOrg);
+      useOrgStore.getState().fetchOrganizations().catch((storeErr) => {
+        console.warn('[OrganizationsPage] org store refresh failed after restore', storeErr);
+      });
 
       const parts = [t('organizationsPage.restore.success', { name: org.name, status: t(/* i18n-dynamic */ statusLabelKeys[restoredStatus]) })];
       if (data.recreateRequired.length > 0) {
@@ -1090,9 +1133,16 @@ export default function OrganizationsPage() {
                   <div className="px-4 py-4 text-sm text-destructive">
                     {archivedError}
                   </div>
-                ) : archivedOrgs.length === 0 ? (
+                ) : filteredArchivedOrgs.length === 0 ? (
                   <div className="px-4 py-6 text-center text-sm text-muted-foreground">
-                    {t('organizationsPage.archived.empty')}
+                    {/* Keyed on whether a search is active, NOT on `archivedOrgs.length`:
+                        once a search term is present, `archivedOrgs` IS the
+                        server-filtered result (see fetchArchivedOrganizations), so an
+                        empty array there no longer means "there are truly zero
+                        archived orgs" — it means "zero matched this search". */}
+                    {searchQuery.trim()
+                      ? t('organizationsPage.archived.noMatches')
+                      : t('organizationsPage.archived.empty')}
                   </div>
                 ) : (
                   <>
@@ -1102,7 +1152,7 @@ export default function OrganizationsPage() {
                       </p>
                     )}
                     <ul className="divide-y">
-                      {archivedOrgs.map(org => (
+                      {filteredArchivedOrgs.map(org => (
                         <li
                           key={org.id}
                           data-testid="org-archived-row"

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -13,7 +13,7 @@ import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import { useJwtClaims } from '../../lib/authScope';
 import { extractApiError } from '@/lib/apiError';
-import { runAction, ActionError } from '@/lib/runAction';
+import { runAction, ActionError, handleActionError } from '@/lib/runAction';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 
@@ -68,6 +68,37 @@ export const statusColors: Record<Organization['status'], string> = {
   purging: 'border-red-400/30 bg-red-400/10 text-red-600 dark:text-red-300',
 };
 
+/**
+ * Days remaining until an archived org's scheduled purge, rounded UP so a
+ * countdown reading "1 day" never flips to "0 days" while any part of that day
+ * remains — the operator's read of "1 day left" must stay true until it
+ * actually is zero. `null` covers both `purgeAt: null` ("kept indefinitely",
+ * `retentionDays` was Never) and an unparseable timestamp, so callers can
+ * treat the two identically instead of rendering `NaN`.
+ *
+ * Exported for test. `now` defaults to `new Date()` — real callers never pass
+ * it; tests pin it (or the global clock via `vi.setSystemTime`) for a
+ * deterministic countdown.
+ */
+export function purgeCountdownDays(purgeAt: string | null | undefined, now: Date = new Date()): number | null {
+  if (!purgeAt) return null;
+  const target = new Date(purgeAt);
+  if (Number.isNaN(target.getTime())) return null;
+  return Math.ceil((target.getTime() - now.getTime()) / (24 * 60 * 60 * 1000));
+}
+
+/**
+ * The archived-org restore route (`apps/api/src/routes/orgArchive.ts`) answers
+ * a purging target with a bare `{ error: '<this text>' }, 410` — no machine
+ * `code` field the way its MFA rejection carries `code: 'MFA_REQUIRED'`. That
+ * makes this literal string the only handle `runAction`'s `friendly` lookup
+ * has to give the purging case its own localized copy instead of the raw
+ * backend sentence; a copy edit to that route's message must update this
+ * constant too, or the match silently stops firing (degrading gracefully back
+ * to the raw — still correct, just unlocalized — backend text).
+ */
+export const RESTORE_PURGING_ERROR_TEXT = 'Organization is already purging and can no longer be restored';
+
 // Walking every page of GET /orgs/organizations moved to lib/ (#3446 follow-up)
 // so the org-switcher store — a second reader with the same first-50 truncation
 // — can share it without importing this page component. Re-exported here to
@@ -115,6 +146,26 @@ export default function OrganizationsPage() {
   const [reorderPending, setReorderPending] = useState(false);
   const [dragOverOrgId, setDragOverOrgId] = useState<string | null>(null);
 
+  // Archived-organizations section state. Collapsed by default and fetched
+  // ONLY on expand (`includeArchived=true`) — deliberately NOT threaded through
+  // `fetchOrganizations`/the org store's own page walk (orgStore.ts), which
+  // stays on the plain unarchived query every other reader of it relies on.
+  // Archived orgs live in their own array rather than merged into
+  // `organizations`, so the active list, its search, drag-reorder, and the
+  // hash-based deep-link effect never have to know archived rows exist.
+  const [archivedExpanded, setArchivedExpanded] = useState(false);
+  const [archivedOrgs, setArchivedOrgs] = useState<Organization[]>([]);
+  const [archivedLoading, setArchivedLoading] = useState(false);
+  const [archivedError, setArchivedError] = useState<string>();
+  // Mirrors the list endpoint's own `archivedTruncated` (archived rows are
+  // capped at the page limit rather than paginated — see orgs.ts) so the
+  // section can say "there are more" instead of silently showing a short list.
+  const [archivedTruncated, setArchivedTruncated] = useState(false);
+  // Which archived org id is mid-restore, so only THAT row's button shows a
+  // busy state — `submitting`/`siteSubmitting` are page/site-modal-scoped and
+  // would incorrectly disable every other control if reused here.
+  const [restoringOrgId, setRestoringOrgId] = useState<string | null>(null);
+
   // Sites state
   const [sites, setSites] = useState<Site[]>([]);
   const [sitesLoading, setSitesLoading] = useState(false);
@@ -137,6 +188,18 @@ export default function OrganizationsPage() {
     if (!q) return organizations;
     return organizations.filter(org => org.name.toLowerCase().includes(q));
   }, [organizations, searchQuery]);
+
+  /** Renders an archived org's purge countdown, shared by the row and the
+   *  read-only detail pane. `purgeAt: null` (retention "Never") and an
+   *  unparseable timestamp both collapse to "kept indefinitely" via
+   *  `purgeCountdownDays` — see its own doc comment for why those two cases
+   *  are deliberately indistinguishable here. */
+  const renderPurgeCountdown = (purgeAt: string | null | undefined): string => {
+    const days = purgeCountdownDays(purgeAt);
+    if (days === null) return t('organizationsPage.archived.keptIndefinitely');
+    if (days <= 0) return t('organizationsPage.archived.purgeToday');
+    return t('organizationsPage.archived.purgeCountdown', { count: days });
+  };
 
   /**
    * `silent` skips the page-level loading flag. `loading` is an EARLY RETURN
@@ -177,6 +240,53 @@ export default function OrganizationsPage() {
       setError(err instanceof Error ? err.message : t('organizationsPage.errors.generic'));
     } finally {
       if (!silent) setLoading(false);
+    }
+  }, [t]);
+
+  /**
+   * Fetches the Archived section's contents. Reuses `fetchAllOrganizations`
+   * (the same page-walking helper `fetchOrganizations` above uses) rather than
+   * a bespoke single-page GET: archived orgs ride along on only the LAST live
+   * page (`isFinalOrganizationsPage`, orgs.ts), so a partner with more than one
+   * page of live orgs would silently see an empty Archived section on a
+   * single-page fetch. Walking every page and filtering to `archived === true`
+   * costs nothing extra for the common case (one page) and stays correct for
+   * the uncommon one, at the cost of one throwaway array per open — cheap next
+   * to a GDPR-relevant tenant silently going missing from its own purge queue.
+   *
+   * Deliberately NOT threaded through the org store's own page walk
+   * (`orgStore.ts`) or `fetchOrganizations` above: both stay on the plain
+   * unarchived query every other caller of them expects, and this is the one
+   * reader that opts in to `includeArchived=true`.
+   */
+  const fetchArchivedOrganizations = useCallback(async () => {
+    setArchivedLoading(true);
+    setArchivedError(undefined);
+    let truncated = false;
+    try {
+      const all = await fetchAllOrganizations<Organization>(async (page, limit) => {
+        const response = await fetchWithAuth(`/orgs/organizations?page=${page}&limit=${limit}&includeArchived=true`);
+        if (!response.ok) {
+          if (response.status === 401) {
+            handleSessionExpired();
+            return null;
+          }
+          throw new Error(t('organizationsPage.archived.errors.fetch'));
+        }
+        const body = await response.json();
+        // Present only on the page that actually carries the archived block
+        // (orgs.ts) — a page that never looked must not overwrite a `true`
+        // already captured from an earlier page in this same walk.
+        if (typeof body?.archivedTruncated === 'boolean') truncated = body.archivedTruncated;
+        return body;
+      });
+      if (all === null) return;
+      setArchivedOrgs(all.filter((org) => org.archived === true));
+      setArchivedTruncated(truncated);
+    } catch (err) {
+      setArchivedError(err instanceof Error ? err.message : t('organizationsPage.errors.generic'));
+    } finally {
+      setArchivedLoading(false);
     }
   }, [t]);
 
@@ -232,6 +342,16 @@ export default function OrganizationsPage() {
     fetchOrganizations();
   }, [fetchOrganizations]);
 
+  // Fetch-on-expand: the Archived section starts collapsed and empty, and only
+  // issues the `includeArchived=true` request the moment it's opened — not on
+  // page mount. Re-fires on every expand (no "already fetched" cache) so a
+  // reopen after a restore/archive elsewhere always shows current data; that
+  // costs one extra request per open, which is cheap next to a stale purge
+  // countdown.
+  useEffect(() => {
+    if (archivedExpanded) fetchArchivedOrganizations();
+  }, [archivedExpanded, fetchArchivedOrganizations]);
+
   // Load the partner's default timezone once so new sites pre-select it.
   // Best-effort: on any failure we silently fall back to the form's UTC default.
   useEffect(() => {
@@ -267,6 +387,15 @@ export default function OrganizationsPage() {
 
   useEffect(() => {
     if (selectedOrg) {
+      // An archived org is outside the request's own accessible-org set by
+      // design (RLS excludes it from `accessibleOrgIds`), so its sites read
+      // would come back an empty array regardless of the real count — reading
+      // that as "confirmed zero sites" would be a lie. The read-only detail
+      // pane has no sites section anyway, so skip the request outright.
+      if (selectedOrg.status === 'archived') {
+        setSites([]);
+        return;
+      }
       // Skip the fetch if org creation already fetched sites for this org
       // synchronously — avoids a redundant concurrent GET per create.
       if (skipSiteFetchForOrgId.current === selectedOrg.id) {
@@ -355,6 +484,67 @@ export default function OrganizationsPage() {
     setSiteModalMode('closed');
     setSelectedSite(null);
     window.location.hash = org.id;
+  };
+
+  const handleToggleArchived = () => {
+    setArchivedExpanded(prev => !prev);
+  };
+
+  /** Maps the restore route's error tokens to localized copy. MFA is a real
+   *  machine `code`; the purging refusal is matched on its literal backend
+   *  text (see `RESTORE_PURGING_ERROR_TEXT`'s comment for why). Anything else
+   *  (e.g. a plain 409 for a status that can't be restored) falls through to
+   *  the raw backend message via `runAction`'s default handling. */
+  const restoreFriendly = (code: string) => {
+    if (code === 'MFA_REQUIRED') return t('organizationsPage.restore.errors.mfaRequired');
+    if (code === RESTORE_PURGING_ERROR_TEXT) return t('organizationsPage.restore.errors.purging');
+    return undefined;
+  };
+
+  /**
+   * Restores an archived org. LIST-STATE UPDATE ONLY, mirroring the
+   * archive/merge complete handlers above: drop it from `archivedOrgs`, add it
+   * back to the active `organizations` list under the status the API reports
+   * (its PRE-archive status — restoring a suspended org lands it back
+   * suspended, not active), and re-select it so the detail pane switches out
+   * of read-only immediately. No `refreshOrgs()` call: that would re-fetch the
+   * plain (unarchived) list and could race this optimistic update, and
+   * everything the active list needs (id/name/status/deviceCount/createdAt)
+   * already rode along on the archived row itself.
+   */
+  const handleRestore = async (org: Organization) => {
+    setRestoringOrgId(org.id);
+    try {
+      const data = await runAction<{ status: string; recreateRequired: string[] }>({
+        request: () => fetchWithAuth(`/orgs/organizations/${org.id}/restore`, { method: 'POST' }),
+        errorFallback: t('organizationsPage.restore.errors.restore'),
+        friendly: restoreFriendly,
+        onUnauthorized: handleSessionExpired,
+      });
+
+      const restoredStatus = data.status as Organization['status'];
+      const restoredOrg: Organization = { ...org, status: restoredStatus, archived: undefined, purgeAt: undefined };
+
+      setArchivedOrgs(prev => prev.filter(o => o.id !== org.id));
+      setOrganizations(prev => [...prev, restoredOrg]);
+      setSelectedOrg(restoredOrg);
+
+      const parts = [t('organizationsPage.restore.success', { name: org.name, status: t(/* i18n-dynamic */ statusLabelKeys[restoredStatus]) })];
+      if (data.recreateRequired.length > 0) {
+        parts.push(t('organizationsPage.restore.recreateRequiredNote', { items: data.recreateRequired.join('; ') }));
+      }
+      if (restoredStatus === 'suspended') {
+        parts.push(t('organizationsPage.restore.suspendedNote'));
+      }
+      showToast({ message: parts.join(' '), type: 'success' });
+    } catch (err) {
+      // runAction already toasted (the friendly copy above for MFA/purging, or
+      // the raw backend message for anything else, e.g. a 409). onUnauthorized
+      // handles a 401 redirect. Only a non-ActionError escape needs a fallback.
+      handleActionError(err, t('organizationsPage.restore.errors.restore'));
+    } finally {
+      setRestoringOrgId(null);
+    }
   };
 
   const persistOrganizationOrder = useCallback(async (orderedIds: string[]) => {
@@ -869,78 +1059,195 @@ export default function OrganizationsPage() {
               </ul>
             )}
           </div>
+
+          {/* Archived organizations — collapsed by default, fetched only on expand */}
+          <div className="border-t">
+            <button
+              type="button"
+              data-testid="org-archived-toggle"
+              onClick={handleToggleArchived}
+              aria-expanded={archivedExpanded}
+              className="flex w-full items-center justify-between px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:bg-muted/50"
+            >
+              <span>{t('organizationsPage.archived.sectionTitle')}</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                className={`transition-transform ${archivedExpanded ? 'rotate-180' : ''}`}
+                aria-hidden="true"
+              >
+                <path d="m6 9 6 6 6-6" />
+              </svg>
+            </button>
+
+            {archivedExpanded && (
+              <div data-testid="org-archived-section" className="max-h-[calc(100vh-320px)] overflow-y-auto">
+                {archivedLoading ? (
+                  <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+                    {t('organizationsPage.archived.loading')}
+                  </div>
+                ) : archivedError ? (
+                  <div className="px-4 py-4 text-sm text-destructive">
+                    {archivedError}
+                  </div>
+                ) : archivedOrgs.length === 0 ? (
+                  <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+                    {t('organizationsPage.archived.empty')}
+                  </div>
+                ) : (
+                  <>
+                    {archivedTruncated && (
+                      <p data-testid="org-archived-truncated-note" className="px-4 py-2 text-xs text-muted-foreground">
+                        {t('organizationsPage.archived.truncatedNote', { count: archivedOrgs.length })}
+                      </p>
+                    )}
+                    <ul className="divide-y">
+                      {archivedOrgs.map(org => (
+                        <li
+                          key={org.id}
+                          data-testid="org-archived-row"
+                          onClick={() => handleSelectOrg(org)}
+                          className={`cursor-pointer px-4 py-3 transition hover:bg-muted/50 ${
+                            selectedOrg?.id === org.id ? 'bg-muted/60 border-l-2 border-l-primary' : 'border-l-2 border-l-transparent'
+                          }`}
+                        >
+                          <p className="truncate text-sm font-medium">{org.name}</p>
+                          <div className="mt-1 flex items-center gap-2">
+                            <span
+                              data-testid="org-archived-badge"
+                              className={`inline-flex items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium leading-none ${statusColors.archived}`}
+                            >
+                              {t('organizationsPage.archived.badge')}
+                            </span>
+                            <span data-testid="org-archived-purge" className="text-xs text-muted-foreground">
+                              {renderPurgeCountdown(org.purgeAt)}
+                            </span>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
         </div>
 
         {/* Right panel - Detail view */}
-        <div className="rounded-lg border bg-card shadow-xs">
+        <div className="rounded-lg border bg-card shadow-xs" data-testid="org-detail-panel">
           {selectedOrg ? (
-            <>
-              {/* Org header */}
-              <div className="border-b px-6 py-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h2 className="text-lg font-semibold">{selectedOrg.name}</h2>
-                    <div className="mt-1 flex items-center gap-3 text-sm text-muted-foreground">
-                      <span
-                        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${statusColors[selectedOrg.status]}`}
-                      >
-                        {t(/* i18n-dynamic */ statusLabelKeys[selectedOrg.status])}
-                      </span>
-                      {shouldShowDeviceCount(selectedOrg.deviceCount) && (
-                        <span>
-                          {t('organizationsPage.deviceCount', { count: selectedOrg.deviceCount })}
+            selectedOrg.status === 'archived' ? (
+              /* Archived org detail — READ-ONLY. No edit/merge/archive buttons: an
+               * archived org is outside the request's own accessible-org set by
+               * design (RLS), so none of those mutations could succeed against it
+               * anyway, and offering them would just produce a confusing 404/409
+               * after the fact. Restore is the only action, and the only way back
+               * to the normal (mutable) detail pane. */
+              <>
+                <div className="border-b px-6 py-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h2 className="text-lg font-semibold">{selectedOrg.name}</h2>
+                      <div className="mt-1 flex items-center gap-3 text-sm text-muted-foreground">
+                        <span
+                          data-testid="org-archived-detail-badge"
+                          className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${statusColors.archived}`}
+                        >
+                          {t('organizationsPage.archived.badge')}
                         </span>
+                        <span data-testid="org-archived-detail-purge">
+                          {renderPurgeCountdown(selectedOrg.purgeAt)}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        data-testid="org-restore"
+                        onClick={() => void handleRestore(selectedOrg)}
+                        disabled={restoringOrgId === selectedOrg.id}
+                        className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {restoringOrgId === selectedOrg.id
+                          ? t('organizationsPage.restore.restoring')
+                          : t('organizationsPage.restore.action')}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div className="p-6 text-sm text-muted-foreground" data-testid="org-archived-readonly-notice">
+                  {t('organizationsPage.archived.readOnlyNotice')}
+                </div>
+              </>
+            ) : (
+              <>
+                {/* Org header */}
+                <div className="border-b px-6 py-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h2 className="text-lg font-semibold">{selectedOrg.name}</h2>
+                      <div className="mt-1 flex items-center gap-3 text-sm text-muted-foreground">
+                        <span
+                          className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${statusColors[selectedOrg.status]}`}
+                        >
+                          {t(/* i18n-dynamic */ statusLabelKeys[selectedOrg.status])}
+                        </span>
+                        {shouldShowDeviceCount(selectedOrg.deviceCount) && (
+                          <span>
+                            {t('organizationsPage.deviceCount', { count: selectedOrg.deviceCount })}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleEdit(selectedOrg)}
+                        className="rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted"
+                      >
+                        {t('common:actions.edit')}
+                      </button>
+                      <button
+                        type="button"
+                        data-testid="org-archive-open"
+                        onClick={() => handleArchive(selectedOrg)}
+                        className="rounded-md border border-destructive/40 px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10"
+                      >
+                        {t('organizationsPage.actions.archiveOrganization')}
+                      </button>
+                      {canMergeOrgs && (
+                        <button
+                          type="button"
+                          data-testid="org-merge-open"
+                          onClick={() => handleMerge(selectedOrg)}
+                          className="rounded-md border border-destructive/40 px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10"
+                        >
+                          {t('organizationsPage.merge.openButton')}
+                        </button>
                       )}
                     </div>
                   </div>
-                  <div className="flex gap-2">
-                    <button
-                      type="button"
-                      onClick={() => handleEdit(selectedOrg)}
-                      className="rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted"
-                    >
-                      {t('common:actions.edit')}
-                    </button>
-                    <button
-                      type="button"
-                      data-testid="org-archive-open"
-                      onClick={() => handleArchive(selectedOrg)}
-                      className="rounded-md border border-destructive/40 px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10"
-                    >
-                      {t('organizationsPage.actions.archiveOrganization')}
-                    </button>
-                    {canMergeOrgs && (
-                      <button
-                        type="button"
-                        data-testid="org-merge-open"
-                        onClick={() => handleMerge(selectedOrg)}
-                        className="rounded-md border border-destructive/40 px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10"
-                      >
-                        {t('organizationsPage.merge.openButton')}
-                      </button>
-                    )}
-                  </div>
                 </div>
-              </div>
 
-              {/* Sites section */}
-              <div className="p-6">
-                {sitesLoading ? (
-                  <div className="flex items-center justify-center py-8">
-                    <div className="h-6 w-6 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-                    <span className="ml-3 text-sm text-muted-foreground">{t('organizationsPage.sites.loading')}</span>
-                  </div>
-                ) : (
-                  <SiteList
-                    sites={sites}
-                    onAddSite={handleAddSite}
-                    onEdit={handleEditSite}
-                    onDelete={handleDeleteSite}
-                    onSiteClick={(site) => void navigateTo(`/settings/sites/${site.id}`)}
-                  />
-                )}
-              </div>
-            </>
+                {/* Sites section */}
+                <div className="p-6">
+                  {sitesLoading ? (
+                    <div className="flex items-center justify-center py-8">
+                      <div className="h-6 w-6 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+                      <span className="ml-3 text-sm text-muted-foreground">{t('organizationsPage.sites.loading')}</span>
+                    </div>
+                  ) : (
+                    <SiteList
+                      sites={sites}
+                      onAddSite={handleAddSite}
+                      onEdit={handleEditSite}
+                      onDelete={handleDeleteSite}
+                      onSiteClick={(site) => void navigateTo(`/settings/sites/${site.id}`)}
+                    />
+                  )}
+                </div>
+              </>
+            )
           ) : (
             /* Empty state */
             <div className="flex flex-col items-center justify-center py-20 text-center">

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -7,6 +7,7 @@ import OrganizationForm from './OrganizationForm';
 import SiteList, { type Site } from './SiteList';
 import SiteForm from './SiteForm';
 import MergeOrgModal from './MergeOrgModal';
+import ArchiveOrgModal from './ArchiveOrgModal';
 import BulkOrgImport from '../organizations/BulkOrgImport';
 import { fetchWithAuth, handleSessionExpired } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
@@ -16,7 +17,7 @@ import { runAction, ActionError } from '@/lib/runAction';
 import { showToast } from '../shared/Toast';
 import { navigateTo } from '@/lib/navigation';
 
-type ModalMode = 'closed' | 'add' | 'edit' | 'delete' | 'merge';
+type ModalMode = 'closed' | 'add' | 'edit' | 'archive' | 'merge';
 type SiteModalMode = 'closed' | 'add' | 'edit' | 'delete';
 
 type OrganizationFormValues = {
@@ -287,9 +288,29 @@ export default function OrganizationsPage() {
     void navigateTo(`/settings/organizations/${org.id}`);
   };
 
-  const handleDelete = (org: Organization) => {
+  const handleArchive = (org: Organization) => {
     setSelectedOrg(org);
-    setModalMode('delete');
+    setModalMode('archive');
+  };
+
+  /**
+   * Called by ArchiveOrgModal the moment its archive POST reports 202.
+   * LIST-STATE UPDATE ONLY — mirrors handleMergeComplete: the modal stays open
+   * on its own `done` phase so the operator can see the purge-date summary,
+   * so this must not close the modal or touch `selectedOrg`.
+   */
+  const handleArchiveComplete = (archivedId: string) => {
+    setOrganizations(prev => prev.filter(o => o.id !== archivedId));
+  };
+
+  /**
+   * The done-phase summary's explicit Close button. `selectedOrg` here is the
+   * org that was just archived (handleArchiveComplete already dropped it from
+   * the active list), so it's cleared too — mirrors handleMergeDoneClose.
+   */
+  const handleArchiveDoneClose = () => {
+    setSelectedOrg(null);
+    handleCloseModal();
   };
 
   const handleMerge = (org: Organization) => {
@@ -319,7 +340,7 @@ export default function OrganizationsPage() {
    * The done-phase summary's explicit Close button. Unlike a plain
    * `handleCloseModal()`, `selectedOrg` here is known to be the org that was
    * JUST merged away (handleMergeComplete already dropped it from the list),
-   * so it's cleared too — mirrors handleConfirmDelete's selectedOrg-clearing
+   * so it's cleared too — mirrors handleArchiveDoneClose's selectedOrg-clearing
    * behavior. A plain Cancel out of the pick/failed phases (before anything
    * merged) must NOT clear it, which is why this is a separate handler
    * rather than folded into `onClose`.
@@ -499,50 +520,6 @@ export default function OrganizationsPage() {
           setGuidingFirstSite(true);
           setSiteModalMode('add');
         }
-      }
-    } catch (err) {
-      // runAction already surfaced an ActionError as a toast, and onUnauthorized
-      // is redirecting on 401 — re-storing either in the page banner would be a
-      // second, INVISIBLE copy (it renders behind this modal). Only a
-      // non-ActionError escaped runAction untoasted, so only that is surfaced.
-      if (!(err instanceof ActionError)) {
-        // A toast, NOT setError. The modal is still open on failure and the
-        // page banner renders behind its `fixed inset-0 z-50` overlay, so
-        // routing an unexpected error there reproduces the exact invisibility
-        // this change removes. Reachable in practice: `runAction` calls
-        // `onUnauthorized` OUTSIDE its request try/catch, so a throw from
-        // handleSessionExpired's logout or location.replace arrives here as a
-        // non-ActionError.
-        showToast({
-          message: err instanceof Error ? err.message : t('organizationsPage.errors.generic'),
-          type: 'error'
-        });
-      }
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  const handleConfirmDelete = async () => {
-    if (!selectedOrg) return;
-
-    setSubmitting(true);
-    try {
-      await runAction({
-        request: () =>
-          fetchWithAuth(`/orgs/organizations/${selectedOrg.id}`, {
-            method: 'DELETE'
-          }),
-        errorFallback: t('organizationsPage.errors.deleteOrganization'),
-        onUnauthorized: handleSessionExpired,
-      });
-
-      const deletedId = selectedOrg.id;
-      await refreshOrgs();
-      handleCloseModal();
-
-      if (selectedOrg?.id === deletedId) {
-        setSelectedOrg(null);
       }
     } catch (err) {
       // runAction already surfaced an ActionError as a toast, and onUnauthorized
@@ -870,17 +847,18 @@ export default function OrganizationsPage() {
                         </button>
                         <button
                           type="button"
+                          data-testid={`org-archive-open-row-${org.id}`}
                           onClick={e => {
                             e.stopPropagation();
-                            handleDelete(org);
+                            handleArchive(org);
                           }}
                           className="rounded p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                          title={t('organizationsPage.actions.deleteOrganization')}
+                          title={t('organizationsPage.actions.archiveOrganization')}
                         >
                           <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                            <path d="M3 6h18" />
-                            <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
-                            <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                            <rect x="2" y="4" width="20" height="5" rx="1" />
+                            <path d="M4 9v9a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9" />
+                            <path d="M10 13h4" />
                           </svg>
                         </button>
                       </div>
@@ -925,10 +903,11 @@ export default function OrganizationsPage() {
                     </button>
                     <button
                       type="button"
-                      onClick={() => handleDelete(selectedOrg)}
+                      data-testid="org-archive-open"
+                      onClick={() => handleArchive(selectedOrg)}
                       className="rounded-md border border-destructive/40 px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10"
                     >
-                      {t('common:actions.delete')}
+                      {t('organizationsPage.actions.archiveOrganization')}
                     </button>
                     {canMergeOrgs && (
                       <button
@@ -1005,34 +984,14 @@ export default function OrganizationsPage() {
         </div>
       )}
 
-      {/* Org Delete Confirmation Modal */}
-      {modalMode === 'delete' && selectedOrg && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 py-8">
-          <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-xs">
-            <h2 className="text-lg font-semibold">{t('organizationsPage.delete.title')}</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              {t('organizationsPage.delete.messagePrefix')} <span className="font-medium">{selectedOrg.name}</span>?
-              {t('organizationsPage.delete.messageSuffix')}
-            </p>
-            <div className="mt-6 flex justify-end gap-3">
-              <button
-                type="button"
-                onClick={handleCloseModal}
-                className="h-10 rounded-md border px-4 text-sm font-medium text-muted-foreground transition hover:text-foreground"
-              >
-                {t('common:actions.cancel')}
-              </button>
-              <button
-                type="button"
-                onClick={handleConfirmDelete}
-                disabled={submitting}
-                className="inline-flex h-10 items-center justify-center rounded-md bg-destructive px-4 text-sm font-medium text-destructive-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {submitting ? t('organizationsPage.actions.deleting') : t('common:actions.delete')}
-              </button>
-            </div>
-          </div>
-        </div>
+      {/* Org Archive Modal */}
+      {modalMode === 'archive' && selectedOrg && (
+        <ArchiveOrgModal
+          org={selectedOrg}
+          onClose={handleCloseModal}
+          onArchived={handleArchiveComplete}
+          onDoneClose={handleArchiveDoneClose}
+        />
       )}
 
       {/* Org Merge Modal */}

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -99,6 +99,17 @@ export function purgeCountdownDays(purgeAt: string | null | undefined, now: Date
  */
 export const RESTORE_PURGING_ERROR_TEXT = 'Organization is already purging and can no longer be restored';
 
+/**
+ * Debounce for the Archived section's search-driven refetch. Mirrors
+ * `DistributorLookup.tsx`'s `NIGHTLY_DEBOUNCE_MS` — a per-keystroke full page
+ * walk (`fetchAllOrganizations`) is expensive enough, and slow enough to
+ * overlap the NEXT keystroke's own fetch, that firing on every change is both
+ * wasteful and (without the request-token guard below) a genuine race: an
+ * older, broader request resolving after a newer, narrower one would clobber
+ * results the user already found. Exported for the test.
+ */
+export const ARCHIVED_SEARCH_DEBOUNCE_MS = 300;
+
 // Walking every page of GET /orgs/organizations moved to lib/ (#3446 follow-up)
 // so the org-switcher store — a second reader with the same first-50 truncation
 // — can share it without importing this page component. Re-exported here to
@@ -165,6 +176,16 @@ export default function OrganizationsPage() {
   // busy state — `submitting`/`siteSubmitting` are page/site-modal-scoped and
   // would incorrectly disable every other control if reused here.
   const [restoringOrgId, setRestoringOrgId] = useState<string | null>(null);
+  // Monotonic request id for the archived fetch. The search-driven refetch
+  // (see the debounced effect below) can overlap: a full page walk is slow
+  // enough that an OLDER (e.g. broader, pre-search) request can still be
+  // in flight when a NEWER (narrower) one is fired, and nothing guarantees
+  // they resolve in request order. Every call captures the id current at its
+  // own start and re-checks it before touching state, so a stale response
+  // — even one that resolves last — can never clobber a newer one's results
+  // (or its loading flag). A `ref`, not state: it's pure bookkeeping and must
+  // never itself trigger a re-render.
+  const archivedRequestIdRef = useRef(0);
 
   // Sites state
   const [sites, setSites] = useState<Site[]>([]);
@@ -285,6 +306,11 @@ export default function OrganizationsPage() {
    * page limit.
    */
   const fetchArchivedOrganizations = useCallback(async (search: string) => {
+    // Claim this call as "current" BEFORE the first await — a later call
+    // (another keystroke) bumps this again and thereby supersedes it. Every
+    // state-touching point below re-checks `requestId === archivedRequestIdRef.current`
+    // so a stale response is inert even if it resolves after the current one.
+    const requestId = ++archivedRequestIdRef.current;
     setArchivedLoading(true);
     setArchivedError(undefined);
     let truncated = false;
@@ -306,13 +332,22 @@ export default function OrganizationsPage() {
         if (typeof body?.archivedTruncated === 'boolean') truncated = body.archivedTruncated;
         return body;
       });
+      // A newer search/expand superseded this request while its page walk was
+      // still in flight. Applying these results now — even though they just
+      // arrived — would clobber whatever the newer request already rendered
+      // (or is about to): the exact race this guard exists to close.
+      if (requestId !== archivedRequestIdRef.current) return;
       if (all === null) return;
       setArchivedOrgs(all.filter((org) => org.archived === true));
       setArchivedTruncated(truncated);
     } catch (err) {
+      if (requestId !== archivedRequestIdRef.current) return;
       setArchivedError(err instanceof Error ? err.message : t('organizationsPage.errors.generic'));
     } finally {
-      setArchivedLoading(false);
+      // Only the current request may clear the busy flag — an old request's
+      // finally firing after a newer one started must not flip the spinner
+      // off out from under the request that's still actually in flight.
+      if (requestId === archivedRequestIdRef.current) setArchivedLoading(false);
     }
   }, [t]);
 
@@ -377,8 +412,20 @@ export default function OrganizationsPage() {
   // past the truncation cap. No "already fetched" cache: every expand/search
   // change re-issues the request, which is cheap next to a stale purge
   // countdown or an unreachable archived tenant.
+  //
+  // Debounced (mirrors `DistributorLookup.tsx`'s nightly search): a full page
+  // walk is real network work, expensive enough to still be in flight when
+  // the next keystroke fires another one. The debounce cuts the number of
+  // overlapping requests way down; the request-token guard inside
+  // `fetchArchivedOrganizations` is what makes an overlap that DOES still
+  // happen (e.g. a slow response outliving the 300ms window) harmless rather
+  // than a race where a stale reply can clobber a fresher one.
   useEffect(() => {
-    if (archivedExpanded) fetchArchivedOrganizations(searchQuery.trim());
+    if (!archivedExpanded) return;
+    const timer = setTimeout(() => {
+      void fetchArchivedOrganizations(searchQuery.trim());
+    }, ARCHIVED_SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
   }, [archivedExpanded, searchQuery, fetchArchivedOrganizations]);
 
   // Load the partner's default timezone once so new sites pre-select it.

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -46,6 +46,10 @@ const TARGET_GLOBS = [
   // POST are advisory-then-destructive mutations against a partner's tenant
   // tree, so a silent failure here is exactly the class this guard exists for.
   'src/components/settings/MergeOrgModal.tsx',
+  // Org archive (org-lifecycle Wave 5), replacing the org delete flow: the
+  // archive POST hides an org, uninstalls its agents, and stops its billing —
+  // a silent failure here is exactly the class this guard exists for.
+  'src/components/settings/ArchiveOrgModal.tsx',
   'src/components/settings/LoginBrandingCard.tsx',
   'src/components/settings/ConnectSsoCard.tsx',
   'src/components/patches/PatchesPage.tsx',
@@ -362,9 +366,9 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    // 98: 97 since #3989 added OrganizationsPage.tsx, plus MergeOrgModal.tsx
-    // (org-lifecycle Wave 3).
-    expect(absoluteFiles.length).toBe(98);
+    // 99: 97 since #3989 added OrganizationsPage.tsx, plus MergeOrgModal.tsx
+    // (org-lifecycle Wave 3), plus ArchiveOrgModal.tsx (org-lifecycle Wave 5).
+    expect(absoluteFiles.length).toBe(99);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -3156,6 +3156,7 @@
       "sectionTitle": "Archiviert",
       "loading": "Archivierte Organisationen werden geladen...",
       "empty": "Keine archivierten Organisationen.",
+      "noMatches": "Keine archivierten Organisationen entsprechen Ihrer Suche.",
       "badge": "Archiviert",
       "keptIndefinitely": "Wird unbegrenzt aufbewahrt",
       "purgeToday": "Wird heute endgültig gelöscht",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -3024,7 +3024,7 @@
       "addOrganization": "Organisation hinzufügen",
       "tryAgain": "Versuchen Sie es erneut",
       "editOrganization": "Organisation bearbeiten",
-      "deleteOrganization": "Organisation löschen",
+      "archiveOrganization": "Organisation archivieren",
       "deleting": "Löschen..."
     },
     "errors": {
@@ -3032,7 +3032,6 @@
       "generic": "Es ist ein Fehler aufgetreten",
       "saveOrder": "Organisationsreihenfolge konnte nicht gespeichert werden",
       "saveOrganization": "Die Organisation konnte nicht gespeichert werden",
-      "deleteOrganization": "Organisation konnte nicht gelöscht werden",
       "saveSite": "Standort konnte nicht gespeichert werden ({{status}})",
       "deleteSite": "Die Standort konnte nicht gelöscht werden"
     },
@@ -3065,11 +3064,6 @@
       "title": "Organisation hinzufügen",
       "description": "Erstellen Sie eine neue Organisation mit den unten aufgeführten Details.",
       "submit": "Organisation schaffen"
-    },
-    "delete": {
-      "title": "Organisation löschen",
-      "messagePrefix": "Sind Sie sicher, dass Sie löschen möchten?",
-      "messageSuffix": "Diese Aktion kann nicht rückgängig gemacht werden."
     },
     "siteModal": {
       "editTitle": "Standort bearbeiten",
@@ -3118,6 +3112,44 @@
         "merge": "Zusammenführung konnte nicht gestartet werden",
         "missingResult": "Die Zusammenführung wurde abgeschlossen, lieferte aber keine Ergebnisdaten. Versuchen Sie es erneut.",
         "mfaRequired": "Das Zusammenführen von Organisationen erfordert Multi-Faktor-Authentifizierung. Aktivieren Sie MFA in Ihren Profil-Sicherheitseinstellungen und versuchen Sie es erneut."
+      }
+    },
+    "archive": {
+      "title": "Organisation archivieren",
+      "description": "Durch das Archivieren wird {{name}} aus Ihrer aktiven Liste ausgeblendet, ohne etwas zu löschen. Sie können die Organisation später wiederherstellen.",
+      "consequencesHeading": "Was beim Archivieren passiert:",
+      "consequences": {
+        "hidden": "Wird aus Ihrer Organisationsliste und der Suche ausgeblendet",
+        "readOnly": "Vorhandene Daten bleiben erhalten und werden schreibgeschützt",
+        "agentsUninstalled": "Agenten werden von den Geräten deinstalliert",
+        "billingStops": "Die Abrechnung für diese Organisation wird eingestellt",
+        "purgeScheduled": "Wird nach der Aufbewahrungsfrist dauerhaft gelöscht, sofern Sie sie nicht vorher wiederherstellen",
+        "purgeNever": "Wird aufbewahrt, bis Sie sie löschen — nie automatisch endgültig gelöscht"
+      },
+      "restoreNote": "Die Wiederherstellung von {{name}} macht diese Aktion rückgängig und ist jederzeit möglich, bevor sie endgültig gelöscht wird.",
+      "retentionLabel": "Archivierte Daten aufbewahren für",
+      "retentionOptions": {
+        "days30": "30 Tage",
+        "days90": "90 Tage (empfohlen)",
+        "days365": "365 Tage",
+        "never": "Nie — unbegrenzt aufbewahren",
+        "custom": "Benutzerdefiniert"
+      },
+      "customDaysLabel": "Anzahl der Tage (1–3650)",
+      "customError": "Geben Sie eine Anzahl von Tagen zwischen 1 und 3650 ein.",
+      "cancel": "Abbrechen",
+      "confirmButton": "Organisation archivieren",
+      "archiving": "Wird archiviert...",
+      "doneOffboardingTitle": "Archivierung gestartet",
+      "doneOffboardingDescription": "{{name}} wird archiviert — die Agenten werden jetzt deinstalliert. Dies wird automatisch innerhalb weniger Minuten abgeschlossen.",
+      "doneArchivedTitle": "Organisation archiviert",
+      "doneArchivedDescription": "{{name}} wurde archiviert.",
+      "donePurgeScheduled": "Wird am {{date}} endgültig gelöscht.",
+      "donePurgeNever": "Die Daten werden aufbewahrt, bis Sie sie löschen.",
+      "close": "Schließen",
+      "errors": {
+        "archive": "Organisation konnte nicht archiviert werden",
+        "mfaRequired": "Das Archivieren von Organisationen erfordert Multi-Faktor-Authentifizierung. Aktivieren Sie MFA in Ihren Profil-Sicherheitseinstellungen und versuchen Sie es erneut."
       }
     }
   },

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -3151,6 +3151,33 @@
         "archive": "Organisation konnte nicht archiviert werden",
         "mfaRequired": "Das Archivieren von Organisationen erfordert Multi-Faktor-Authentifizierung. Aktivieren Sie MFA in Ihren Profil-Sicherheitseinstellungen und versuchen Sie es erneut."
       }
+    },
+    "archived": {
+      "sectionTitle": "Archiviert",
+      "loading": "Archivierte Organisationen werden geladen...",
+      "empty": "Keine archivierten Organisationen.",
+      "badge": "Archiviert",
+      "keptIndefinitely": "Wird unbegrenzt aufbewahrt",
+      "purgeToday": "Wird heute endgültig gelöscht",
+      "purgeCountdown_one": "Wird in {{count}} Tag endgültig gelöscht",
+      "purgeCountdown_other": "Wird in {{count}} Tagen endgültig gelöscht",
+      "truncatedNote": "Zeigt die ersten {{count}} archivierten Organisationen. Suchen Sie, um die Liste einzugrenzen.",
+      "readOnlyNotice": "Diese Organisation ist archiviert und schreibgeschützt. Stellen Sie sie wieder her, um den normalen Zugriff fortzusetzen.",
+      "errors": {
+        "fetch": "Archivierte Organisationen konnten nicht geladen werden"
+      }
+    },
+    "restore": {
+      "action": "Wiederherstellen",
+      "restoring": "Wird wiederhergestellt...",
+      "success": "{{name}} wiederhergestellt — Status: {{status}}.",
+      "recreateRequiredNote": "Bevor sie wieder vollständig nutzbar ist: {{items}}",
+      "suspendedNote": "Sie war vor der Archivierung gesperrt, daher wurde sie als gesperrt wiederhergestellt — beheben Sie dies, bevor sie den normalen Zugriff wieder aufnimmt.",
+      "errors": {
+        "restore": "Die Organisation konnte nicht wiederhergestellt werden",
+        "mfaRequired": "Das Wiederherstellen von Organisationen erfordert Multi-Faktor-Authentifizierung. Aktivieren Sie MFA in Ihren Profil-Sicherheitseinstellungen und versuchen Sie es erneut.",
+        "purging": "Diese Organisation wird bereits endgültig gelöscht und kann nicht mehr wiederhergestellt werden."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -3077,7 +3077,7 @@
       "addOrganization": "Add organization",
       "tryAgain": "Try again",
       "editOrganization": "Edit organization",
-      "deleteOrganization": "Delete organization",
+      "archiveOrganization": "Archive organization",
       "deleting": "Deleting..."
     },
     "errors": {
@@ -3085,7 +3085,6 @@
       "generic": "An error occurred",
       "saveOrder": "Failed to save organization order",
       "saveOrganization": "Failed to save organization",
-      "deleteOrganization": "Failed to delete organization",
       "saveSite": "Failed to save site ({{status}})",
       "deleteSite": "Failed to delete site"
     },
@@ -3118,11 +3117,6 @@
       "title": "Add Organization",
       "description": "Create a new organization with the details below.",
       "submit": "Create organization"
-    },
-    "delete": {
-      "title": "Delete Organization",
-      "messagePrefix": "Are you sure you want to delete",
-      "messageSuffix": " This action cannot be undone."
     },
     "siteModal": {
       "editTitle": "Edit Site",
@@ -3171,6 +3165,44 @@
         "merge": "Failed to start the merge",
         "missingResult": "The merge finished but returned no result data. Try again.",
         "mfaRequired": "Merging organizations requires multi-factor authentication. Enable MFA in your profile security settings, then try again."
+      }
+    },
+    "archive": {
+      "title": "Archive organization",
+      "description": "Archiving {{name}} hides it from your active list without erasing anything. You can restore it later.",
+      "consequencesHeading": "What happens when you archive:",
+      "consequences": {
+        "hidden": "Hidden from your organization list and search",
+        "readOnly": "Existing data stays intact and read-only",
+        "agentsUninstalled": "Agents are uninstalled from its devices",
+        "billingStops": "Billing for this organization stops",
+        "purgeScheduled": "Permanently deleted after the retention period, unless you restore it first",
+        "purgeNever": "Kept until you delete it — never automatically purged"
+      },
+      "restoreNote": "Restoring {{name}} is the undo for this action, available any time before it's purged.",
+      "retentionLabel": "Keep archived data for",
+      "retentionOptions": {
+        "days30": "30 days",
+        "days90": "90 days (recommended)",
+        "days365": "365 days",
+        "never": "Never — keep indefinitely",
+        "custom": "Custom"
+      },
+      "customDaysLabel": "Number of days (1–3650)",
+      "customError": "Enter a number of days between 1 and 3650.",
+      "cancel": "Cancel",
+      "confirmButton": "Archive organization",
+      "archiving": "Archiving...",
+      "doneOffboardingTitle": "Archiving started",
+      "doneOffboardingDescription": "{{name}} is being archived — its agents are being uninstalled now. This finishes automatically within a few minutes.",
+      "doneArchivedTitle": "Organization archived",
+      "doneArchivedDescription": "{{name}} has been archived.",
+      "donePurgeScheduled": "Scheduled to be permanently deleted on {{date}}.",
+      "donePurgeNever": "Its data will be kept until you delete it.",
+      "close": "Close",
+      "errors": {
+        "archive": "Failed to archive the organization",
+        "mfaRequired": "Archiving organizations requires multi-factor authentication. Enable MFA in your profile security settings, then try again."
       }
     }
   },

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -3204,6 +3204,33 @@
         "archive": "Failed to archive the organization",
         "mfaRequired": "Archiving organizations requires multi-factor authentication. Enable MFA in your profile security settings, then try again."
       }
+    },
+    "archived": {
+      "sectionTitle": "Archived",
+      "loading": "Loading archived organizations...",
+      "empty": "No archived organizations.",
+      "badge": "Archived",
+      "keptIndefinitely": "Kept indefinitely",
+      "purgeToday": "Purges today",
+      "purgeCountdown_one": "Purges in {{count}} day",
+      "purgeCountdown_other": "Purges in {{count}} days",
+      "truncatedNote": "Showing the first {{count}} archived organizations. Search to narrow the list.",
+      "readOnlyNotice": "This organization is archived and read-only. Restore it to resume normal access.",
+      "errors": {
+        "fetch": "Failed to load archived organizations"
+      }
+    },
+    "restore": {
+      "action": "Restore",
+      "restoring": "Restoring...",
+      "success": "{{name}} restored — status: {{status}}.",
+      "recreateRequiredNote": "Before it's fully usable again: {{items}}",
+      "suspendedNote": "It was suspended before being archived, so it has been restored as suspended — resolve that before it resumes normal access.",
+      "errors": {
+        "restore": "Failed to restore the organization",
+        "mfaRequired": "Restoring organizations requires multi-factor authentication. Enable MFA in your profile security settings, then try again.",
+        "purging": "This organization is already being permanently deleted and can no longer be restored."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -3209,6 +3209,7 @@
       "sectionTitle": "Archived",
       "loading": "Loading archived organizations...",
       "empty": "No archived organizations.",
+      "noMatches": "No archived organizations match your search.",
       "badge": "Archived",
       "keptIndefinitely": "Kept indefinitely",
       "purgeToday": "Purges today",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -3156,6 +3156,7 @@
       "sectionTitle": "Archivadas",
       "loading": "Cargando organizaciones archivadas...",
       "empty": "No hay organizaciones archivadas.",
+      "noMatches": "Ninguna organización archivada coincide con su búsqueda.",
       "badge": "Archivada",
       "keptIndefinitely": "Se conserva indefinidamente",
       "purgeToday": "Se elimina hoy",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -3024,7 +3024,7 @@
       "addOrganization": "Agregar organización",
       "tryAgain": "Intentar otra vez",
       "editOrganization": "Editar organización",
-      "deleteOrganization": "Eliminar organización",
+      "archiveOrganization": "Archivar organización",
       "deleting": "Eliminando..."
     },
     "errors": {
@@ -3032,7 +3032,6 @@
       "generic": "Se produjo un error",
       "saveOrder": "No se pudo guardar el orden de la organización",
       "saveOrganization": "No se pudo guardar la organización",
-      "deleteOrganization": "No se pudo eliminar la organización",
       "saveSite": "No se pudo guardar el sitio ({{status}})",
       "deleteSite": "No se pudo eliminar el sitio"
     },
@@ -3065,11 +3064,6 @@
       "title": "Agregar organización",
       "description": "Cree una nueva organización con los detalles a continuación.",
       "submit": "Crear organización"
-    },
-    "delete": {
-      "title": "Eliminar organización",
-      "messagePrefix": "¿Está seguro de que desea eliminar?",
-      "messageSuffix": "Esta acción no se puede deshacer."
     },
     "siteModal": {
       "editTitle": "Editar sitio",
@@ -3118,6 +3112,44 @@
         "merge": "No se pudo iniciar la fusión",
         "missingResult": "La fusión terminó pero no devolvió datos de resultado. Vuelva a intentarlo.",
         "mfaRequired": "Fusionar organizaciones requiere autenticación multifactor. Active la MFA en la configuración de seguridad de su perfil y vuelva a intentarlo."
+      }
+    },
+    "archive": {
+      "title": "Archivar organización",
+      "description": "Archivar {{name}} la oculta de su lista activa sin borrar nada. Puede restaurarla más adelante.",
+      "consequencesHeading": "Qué sucede al archivar:",
+      "consequences": {
+        "hidden": "Se oculta de su lista de organizaciones y de la búsqueda",
+        "readOnly": "Los datos existentes se conservan intactos y de solo lectura",
+        "agentsUninstalled": "Los agentes se desinstalan de sus dispositivos",
+        "billingStops": "La facturación de esta organización se detiene",
+        "purgeScheduled": "Se elimina permanentemente después del período de retención, a menos que la restaure antes",
+        "purgeNever": "Se conserva hasta que usted la elimine — nunca se purga automáticamente"
+      },
+      "restoreNote": "Restaurar {{name}} deshace esta acción y está disponible en cualquier momento antes de que se elimine.",
+      "retentionLabel": "Conservar los datos archivados durante",
+      "retentionOptions": {
+        "days30": "30 días",
+        "days90": "90 días (recomendado)",
+        "days365": "365 días",
+        "never": "Nunca — conservar indefinidamente",
+        "custom": "Personalizado"
+      },
+      "customDaysLabel": "Número de días (1–3650)",
+      "customError": "Ingrese un número de días entre 1 y 3650.",
+      "cancel": "Cancelar",
+      "confirmButton": "Archivar organización",
+      "archiving": "Archivando...",
+      "doneOffboardingTitle": "Archivado iniciado",
+      "doneOffboardingDescription": "{{name}} se está archivando — sus agentes se están desinstalando ahora. Esto termina automáticamente en unos minutos.",
+      "doneArchivedTitle": "Organización archivada",
+      "doneArchivedDescription": "{{name}} ha sido archivada.",
+      "donePurgeScheduled": "Programada para eliminarse permanentemente el {{date}}.",
+      "donePurgeNever": "Sus datos se conservarán hasta que usted los elimine.",
+      "close": "Cerrar",
+      "errors": {
+        "archive": "No se pudo archivar la organización",
+        "mfaRequired": "Archivar organizaciones requiere autenticación multifactor. Active la MFA en la configuración de seguridad de su perfil y vuelva a intentarlo."
       }
     }
   },

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -3151,6 +3151,33 @@
         "archive": "No se pudo archivar la organización",
         "mfaRequired": "Archivar organizaciones requiere autenticación multifactor. Active la MFA en la configuración de seguridad de su perfil y vuelva a intentarlo."
       }
+    },
+    "archived": {
+      "sectionTitle": "Archivadas",
+      "loading": "Cargando organizaciones archivadas...",
+      "empty": "No hay organizaciones archivadas.",
+      "badge": "Archivada",
+      "keptIndefinitely": "Se conserva indefinidamente",
+      "purgeToday": "Se elimina hoy",
+      "purgeCountdown_one": "Se elimina en {{count}} día",
+      "purgeCountdown_other": "Se elimina en {{count}} días",
+      "truncatedNote": "Mostrando las primeras {{count}} organizaciones archivadas. Busque para acotar la lista.",
+      "readOnlyNotice": "Esta organización está archivada y es de solo lectura. Restáurela para reanudar el acceso normal.",
+      "errors": {
+        "fetch": "No se pudieron cargar las organizaciones archivadas"
+      }
+    },
+    "restore": {
+      "action": "Restaurar",
+      "restoring": "Restaurando...",
+      "success": "{{name}} restaurada — estado: {{status}}.",
+      "recreateRequiredNote": "Antes de que esté completamente utilizable de nuevo: {{items}}",
+      "suspendedNote": "Estaba suspendida antes de archivarse, así que se restauró como suspendida — resuelva eso antes de que la organización reanude el acceso normal.",
+      "errors": {
+        "restore": "No se pudo restaurar la organización",
+        "mfaRequired": "Restaurar organizaciones requiere autenticación multifactor. Active la MFA en la configuración de seguridad de su perfil y vuelva a intentarlo.",
+        "purging": "Esta organización ya se está eliminando permanentemente y no se puede restaurar."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -3199,6 +3199,33 @@
         "archive": "Échec de l'archivage de l'organisation",
         "mfaRequired": "L'archivage des organisations nécessite l'authentification multifacteur. Activez la MFA dans les paramètres de sécurité de votre profil, puis réessayez."
       }
+    },
+    "archived": {
+      "sectionTitle": "Archivées",
+      "loading": "Chargement des organisations archivées...",
+      "empty": "Aucune organisation archivée.",
+      "badge": "Archivée",
+      "keptIndefinitely": "Conservée indéfiniment",
+      "purgeToday": "Suppression définitive aujourd'hui",
+      "purgeCountdown_one": "Suppression définitive dans {{count}} jour",
+      "purgeCountdown_other": "Suppression définitive dans {{count}} jours",
+      "truncatedNote": "Affichage des {{count}} premières organisations archivées. Effectuez une recherche pour affiner la liste.",
+      "readOnlyNotice": "Cette organisation est archivée et en lecture seule. Restaurez-la pour reprendre un accès normal.",
+      "errors": {
+        "fetch": "Échec du chargement des organisations archivées"
+      }
+    },
+    "restore": {
+      "action": "Restaurer",
+      "restoring": "Restauration...",
+      "success": "{{name}} restaurée — statut : {{status}}.",
+      "recreateRequiredNote": "Avant qu'elle soit à nouveau pleinement utilisable : {{items}}",
+      "suspendedNote": "Elle était suspendue avant son archivage ; elle a donc été restaurée à l'état suspendu — réglez ce point avant qu'elle ne reprenne un accès normal.",
+      "errors": {
+        "restore": "Échec de la restauration de l'organisation",
+        "mfaRequired": "La restauration des organisations nécessite l'authentification multifacteur. Activez la MFA dans les paramètres de sécurité de votre profil, puis réessayez.",
+        "purging": "Cette organisation est déjà en cours de suppression définitive et ne peut plus être restaurée."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -3204,6 +3204,7 @@
       "sectionTitle": "Archivées",
       "loading": "Chargement des organisations archivées...",
       "empty": "Aucune organisation archivée.",
+      "noMatches": "Aucune organisation archivée ne correspond à votre recherche.",
       "badge": "Archivée",
       "keptIndefinitely": "Conservée indéfiniment",
       "purgeToday": "Suppression définitive aujourd'hui",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -3072,7 +3072,7 @@
       "addOrganization": "Ajouter l’organisation",
       "tryAgain": "Réessayer",
       "editOrganization": "Modifier l’organisation",
-      "deleteOrganization": "Supprimer l’organisation",
+      "archiveOrganization": "Archiver l'organisation",
       "deleting": "Suppression…"
     },
     "errors": {
@@ -3080,7 +3080,6 @@
       "generic": "Une erreur s’est produite",
       "saveOrder": "Impossible d’enregistrer l’ordre organisationnel",
       "saveOrganization": "Impossible d’enregistrer l’organisation",
-      "deleteOrganization": "Impossible de supprimer l’organisation",
       "saveSite": "Impossible d’enregistrer le site ({{status}})",
       "deleteSite": "Impossible de supprimer le site"
     },
@@ -3113,11 +3112,6 @@
       "title": "Ajouter l’organisation",
       "description": "Créez une nouvelle organisation avec les détails ci-dessous.",
       "submit": "Créer une organisation"
-    },
-    "delete": {
-      "title": "Supprimer l’organisation",
-      "messagePrefix": "Êtes-vous sûr de vouloir supprimer ?",
-      "messageSuffix": " Cette action ne peut être annulée."
     },
     "siteModal": {
       "editTitle": "Modifier le site",
@@ -3166,6 +3160,44 @@
         "merge": "Échec du démarrage de la fusion",
         "missingResult": "La fusion s'est terminée mais n'a renvoyé aucune donnée de résultat. Réessayez.",
         "mfaRequired": "La fusion d'organisations nécessite l'authentification multifacteur. Activez la MFA dans les paramètres de sécurité de votre profil, puis réessayez."
+      }
+    },
+    "archive": {
+      "title": "Archiver l'organisation",
+      "description": "Archiver {{name}} la masque de votre liste active sans rien supprimer. Vous pourrez la restaurer plus tard.",
+      "consequencesHeading": "Ce qui se passe lors de l'archivage :",
+      "consequences": {
+        "hidden": "Masquée de votre liste d'organisations et de la recherche",
+        "readOnly": "Les données existantes restent intactes et en lecture seule",
+        "agentsUninstalled": "Les agents sont désinstallés de ses appareils",
+        "billingStops": "La facturation de cette organisation s'arrête",
+        "purgeScheduled": "Supprimée définitivement après la période de rétention, sauf si vous la restaurez avant",
+        "purgeNever": "Conservée jusqu’à ce que vous la supprimiez — jamais purgée automatiquement"
+      },
+      "restoreNote": "Restaurer {{name}} annule cette action et reste possible à tout moment avant sa suppression définitive.",
+      "retentionLabel": "Conserver les données archivées pendant",
+      "retentionOptions": {
+        "days30": "30 jours",
+        "days90": "90 jours (recommandé)",
+        "days365": "365 jours",
+        "never": "Jamais — conserver indéfiniment",
+        "custom": "Personnalisé"
+      },
+      "customDaysLabel": "Nombre de jours (1–3650)",
+      "customError": "Saisissez un nombre de jours compris entre 1 et 3650.",
+      "cancel": "Annuler",
+      "confirmButton": "Archiver l'organisation",
+      "archiving": "Archivage...",
+      "doneOffboardingTitle": "Archivage démarré",
+      "doneOffboardingDescription": "{{name}} est en cours d’archivage — ses agents sont désinstallés à présent. Cette opération se termine automatiquement en quelques minutes.",
+      "doneArchivedTitle": "Organisation archivée",
+      "doneArchivedDescription": "{{name}} a été archivée.",
+      "donePurgeScheduled": "Suppression définitive prévue le {{date}}.",
+      "donePurgeNever": "Ses données seront conservées jusqu’à ce que vous les supprimiez.",
+      "close": "Fermer",
+      "errors": {
+        "archive": "Échec de l'archivage de l'organisation",
+        "mfaRequired": "L'archivage des organisations nécessite l'authentification multifacteur. Activez la MFA dans les paramètres de sécurité de votre profil, puis réessayez."
       }
     }
   },

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -3024,7 +3024,7 @@
       "addOrganization": "Ajouter l’organisation",
       "tryAgain": "Réessayer",
       "editOrganization": "Modifier l’organisation",
-      "deleteOrganization": "Supprimer l’organisation",
+      "archiveOrganization": "Archiver l'organisation",
       "deleting": "Suppression…"
     },
     "errors": {
@@ -3032,7 +3032,6 @@
       "generic": "Une erreur s’est produite",
       "saveOrder": "Impossible d’enregistrer l’ordre organisationnel",
       "saveOrganization": "Impossible d’enregistrer l’organisation",
-      "deleteOrganization": "Impossible de supprimer l’organisation",
       "saveSite": "Impossible d’enregistrer le site ({{status}})",
       "deleteSite": "Impossible de supprimer le site"
     },
@@ -3065,11 +3064,6 @@
       "title": "Ajouter l’organisation",
       "description": "Créez une nouvelle organisation avec les détails ci-dessous.",
       "submit": "Créer une organisation"
-    },
-    "delete": {
-      "title": "Supprimer l’organisation",
-      "messagePrefix": "Êtes-vous sûr de vouloir supprimer ?",
-      "messageSuffix": " Cette action ne peut être annulée."
     },
     "siteModal": {
       "editTitle": "Modifier le site",
@@ -3118,6 +3112,44 @@
         "merge": "Échec du démarrage de la fusion",
         "missingResult": "La fusion s'est terminée mais n'a renvoyé aucune donnée de résultat. Réessayez.",
         "mfaRequired": "La fusion d'organisations nécessite l'authentification multifacteur. Activez la MFA dans les paramètres de sécurité de votre profil, puis réessayez."
+      }
+    },
+    "archive": {
+      "title": "Archiver l'organisation",
+      "description": "Archiver {{name}} la masque de votre liste active sans rien supprimer. Vous pourrez la restaurer plus tard.",
+      "consequencesHeading": "Ce qui se passe lors de l'archivage :",
+      "consequences": {
+        "hidden": "Masquée de votre liste d'organisations et de la recherche",
+        "readOnly": "Les données existantes restent intactes et en lecture seule",
+        "agentsUninstalled": "Les agents sont désinstallés de ses appareils",
+        "billingStops": "La facturation de cette organisation s'arrête",
+        "purgeScheduled": "Supprimée définitivement après la période de rétention, sauf si vous la restaurez avant",
+        "purgeNever": "Conservée jusqu’à ce que vous la supprimiez — jamais purgée automatiquement"
+      },
+      "restoreNote": "Restaurer {{name}} annule cette action et reste possible à tout moment avant sa suppression définitive.",
+      "retentionLabel": "Conserver les données archivées pendant",
+      "retentionOptions": {
+        "days30": "30 jours",
+        "days90": "90 jours (recommandé)",
+        "days365": "365 jours",
+        "never": "Jamais — conserver indéfiniment",
+        "custom": "Personnalisé"
+      },
+      "customDaysLabel": "Nombre de jours (1–3650)",
+      "customError": "Saisissez un nombre de jours compris entre 1 et 3650.",
+      "cancel": "Annuler",
+      "confirmButton": "Archiver l'organisation",
+      "archiving": "Archivage...",
+      "doneOffboardingTitle": "Archivage démarré",
+      "doneOffboardingDescription": "{{name}} est en cours d’archivage — ses agents sont désinstallés à présent. Cette opération se termine automatiquement en quelques minutes.",
+      "doneArchivedTitle": "Organisation archivée",
+      "doneArchivedDescription": "{{name}} a été archivée.",
+      "donePurgeScheduled": "Suppression définitive prévue le {{date}}.",
+      "donePurgeNever": "Ses données seront conservées jusqu’à ce que vous les supprimiez.",
+      "close": "Fermer",
+      "errors": {
+        "archive": "Échec de l'archivage de l'organisation",
+        "mfaRequired": "L'archivage des organisations nécessite l'authentification multifacteur. Activez la MFA dans les paramètres de sécurité de votre profil, puis réessayez."
       }
     }
   },

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -3156,6 +3156,7 @@
       "sectionTitle": "Archivées",
       "loading": "Chargement des organisations archivées...",
       "empty": "Aucune organisation archivée.",
+      "noMatches": "Aucune organisation archivée ne correspond à votre recherche.",
       "badge": "Archivée",
       "keptIndefinitely": "Conservée indéfiniment",
       "purgeToday": "Suppression définitive aujourd'hui",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -3151,6 +3151,33 @@
         "archive": "Échec de l'archivage de l'organisation",
         "mfaRequired": "L'archivage des organisations nécessite l'authentification multifacteur. Activez la MFA dans les paramètres de sécurité de votre profil, puis réessayez."
       }
+    },
+    "archived": {
+      "sectionTitle": "Archivées",
+      "loading": "Chargement des organisations archivées...",
+      "empty": "Aucune organisation archivée.",
+      "badge": "Archivée",
+      "keptIndefinitely": "Conservée indéfiniment",
+      "purgeToday": "Suppression définitive aujourd'hui",
+      "purgeCountdown_one": "Suppression définitive dans {{count}} jour",
+      "purgeCountdown_other": "Suppression définitive dans {{count}} jours",
+      "truncatedNote": "Affichage des {{count}} premières organisations archivées. Effectuez une recherche pour affiner la liste.",
+      "readOnlyNotice": "Cette organisation est archivée et en lecture seule. Restaurez-la pour reprendre un accès normal.",
+      "errors": {
+        "fetch": "Échec du chargement des organisations archivées"
+      }
+    },
+    "restore": {
+      "action": "Restaurer",
+      "restoring": "Restauration...",
+      "success": "{{name}} restaurée — statut : {{status}}.",
+      "recreateRequiredNote": "Avant qu'elle soit à nouveau pleinement utilisable : {{items}}",
+      "suspendedNote": "Elle était suspendue avant son archivage ; elle a donc été restaurée à l'état suspendu — réglez ce point avant qu'elle ne reprenne un accès normal.",
+      "errors": {
+        "restore": "Échec de la restauration de l'organisation",
+        "mfaRequired": "La restauration des organisations nécessite l'authentification multifacteur. Activez la MFA dans les paramètres de sécurité de votre profil, puis réessayez.",
+        "purging": "Cette organisation est déjà en cours de suppression définitive et ne peut plus être restaurée."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -3199,6 +3199,33 @@
         "archive": "Impossibile archiviare l'organizzazione",
         "mfaRequired": "L'archiviazione delle organizzazioni richiede l'autenticazione a più fattori. Abilita l'MFA nelle impostazioni di sicurezza del tuo profilo, quindi riprova."
       }
+    },
+    "archived": {
+      "sectionTitle": "Archiviate",
+      "loading": "Caricamento delle organizzazioni archiviate...",
+      "empty": "Nessuna organizzazione archiviata.",
+      "badge": "Archiviata",
+      "keptIndefinitely": "Conservata indefinitamente",
+      "purgeToday": "Eliminata definitivamente oggi",
+      "purgeCountdown_one": "Eliminata definitivamente tra {{count}} giorno",
+      "purgeCountdown_other": "Eliminata definitivamente tra {{count}} giorni",
+      "truncatedNote": "Vengono mostrate le prime {{count}} organizzazioni archiviate. Cerca per restringere l'elenco.",
+      "readOnlyNotice": "Questa organizzazione è archiviata ed è in sola lettura. Ripristinala per riprendere l'accesso normale.",
+      "errors": {
+        "fetch": "Impossibile caricare le organizzazioni archiviate"
+      }
+    },
+    "restore": {
+      "action": "Ripristina",
+      "restoring": "Ripristino in corso...",
+      "success": "{{name}} ripristinata — stato: {{status}}.",
+      "recreateRequiredNote": "Prima che sia di nuovo pienamente utilizzabile: {{items}}",
+      "suspendedNote": "Era sospesa prima dell'archiviazione, quindi è stata ripristinata come sospesa — risolvi questo aspetto prima che riprenda l'accesso normale.",
+      "errors": {
+        "restore": "Impossibile ripristinare l'organizzazione",
+        "mfaRequired": "Il ripristino delle organizzazioni richiede l'autenticazione a più fattori. Abilita l'MFA nelle impostazioni di sicurezza del tuo profilo, quindi riprova.",
+        "purging": "Questa organizzazione è già in fase di eliminazione definitiva e non può più essere ripristinata."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -3072,7 +3072,7 @@
       "addOrganization": "Aggiungi organizzazione",
       "tryAgain": "Riprova",
       "editOrganization": "Modifica organizzazione",
-      "deleteOrganization": "Elimina organizzazione",
+      "archiveOrganization": "Archivia organizzazione",
       "deleting": "Eliminazione..."
     },
     "errors": {
@@ -3080,7 +3080,6 @@
       "generic": "Si è verificato un errore",
       "saveOrder": "Impossibile salvare l'ordine delle organizzazioni",
       "saveOrganization": "Impossibile salvare l'organizzazione",
-      "deleteOrganization": "Impossibile eliminare l'organizzazione",
       "saveSite": "Impossibile salvare il sito ({{status}})",
       "deleteSite": "Impossibile eliminare il sito"
     },
@@ -3113,11 +3112,6 @@
       "title": "Aggiungi organizzazione",
       "description": "Crea una nuova organizzazione con i dettagli qui sotto.",
       "submit": "Crea organizzazione"
-    },
-    "delete": {
-      "title": "Elimina organizzazione",
-      "messagePrefix": "Vuoi davvero eliminare",
-      "messageSuffix": " Questa azione non può essere annullata."
     },
     "siteModal": {
       "editTitle": "Modifica sito",
@@ -3166,6 +3160,44 @@
         "merge": "Impossibile avviare l'unione",
         "missingResult": "L'unione è terminata ma non ha restituito dati di risultato. Riprova.",
         "mfaRequired": "L'unione delle organizzazioni richiede l'autenticazione a più fattori. Attiva l'MFA nelle impostazioni di sicurezza del tuo profilo e riprova."
+      }
+    },
+    "archive": {
+      "title": "Archivia organizzazione",
+      "description": "Archiviando {{name}} la nascondi dal tuo elenco attivo senza eliminare nulla. Potrai ripristinarla in seguito.",
+      "consequencesHeading": "Cosa succede quando archivi:",
+      "consequences": {
+        "hidden": "Nascosta dall'elenco delle organizzazioni e dalla ricerca",
+        "readOnly": "I dati esistenti restano intatti e in sola lettura",
+        "agentsUninstalled": "Gli agenti vengono disinstallati dai suoi dispositivi",
+        "billingStops": "La fatturazione per questa organizzazione si interrompe",
+        "purgeScheduled": "Eliminata definitivamente dopo il periodo di conservazione, a meno che tu non la ripristini prima",
+        "purgeNever": "Conservata finché non la elimini — mai eliminata automaticamente"
+      },
+      "restoreNote": "Ripristinare {{name}} annulla questa azione ed è possibile in qualsiasi momento prima dell'eliminazione definitiva.",
+      "retentionLabel": "Conserva i dati archiviati per",
+      "retentionOptions": {
+        "days30": "30 giorni",
+        "days90": "90 giorni (consigliato)",
+        "days365": "365 giorni",
+        "never": "Mai — conserva indefinitamente",
+        "custom": "Personalizzato"
+      },
+      "customDaysLabel": "Numero di giorni (1–3650)",
+      "customError": "Inserisci un numero di giorni compreso tra 1 e 3650.",
+      "cancel": "Annulla",
+      "confirmButton": "Archivia organizzazione",
+      "archiving": "Archiviazione...",
+      "doneOffboardingTitle": "Archiviazione avviata",
+      "doneOffboardingDescription": "{{name}} è in fase di archiviazione — i suoi agenti vengono disinstallati ora. Il processo si completa automaticamente in pochi minuti.",
+      "doneArchivedTitle": "Organizzazione archiviata",
+      "doneArchivedDescription": "{{name}} è stata archiviata.",
+      "donePurgeScheduled": "Sarà eliminata definitivamente il {{date}}.",
+      "donePurgeNever": "I suoi dati saranno conservati finché non li elimini.",
+      "close": "Chiudi",
+      "errors": {
+        "archive": "Impossibile archiviare l'organizzazione",
+        "mfaRequired": "L'archiviazione delle organizzazioni richiede l'autenticazione a più fattori. Abilita l'MFA nelle impostazioni di sicurezza del tuo profilo, quindi riprova."
       }
     }
   },

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -3204,6 +3204,7 @@
       "sectionTitle": "Archiviate",
       "loading": "Caricamento delle organizzazioni archiviate...",
       "empty": "Nessuna organizzazione archiviata.",
+      "noMatches": "Nessuna organizzazione archiviata corrisponde alla ricerca.",
       "badge": "Archiviata",
       "keptIndefinitely": "Conservata indefinitamente",
       "purgeToday": "Eliminata definitivamente oggi",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -3209,6 +3209,7 @@
       "sectionTitle": "Arquivadas",
       "loading": "Carregando organizações arquivadas...",
       "empty": "Nenhuma organização arquivada.",
+      "noMatches": "Nenhuma organização arquivada corresponde à sua pesquisa.",
       "badge": "Arquivada",
       "keptIndefinitely": "Mantida indefinidamente",
       "purgeToday": "Excluída definitivamente hoje",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -3077,7 +3077,7 @@
       "addOrganization": "Adicionar organização",
       "tryAgain": "Tente novamente",
       "editOrganization": "Editar organização",
-      "deleteOrganization": "Excluir organização",
+      "archiveOrganization": "Arquivar organização",
       "deleting": "Excluindo..."
     },
     "errors": {
@@ -3085,7 +3085,6 @@
       "generic": "Ocorreu um erro",
       "saveOrder": "Falha ao salvar a ordem das organizações",
       "saveOrganization": "Falha ao salvar a organização",
-      "deleteOrganization": "Falha ao excluir a organização",
       "saveSite": "Falha ao salvar site ({{status}})",
       "deleteSite": "Falha ao excluir site"
     },
@@ -3118,11 +3117,6 @@
       "title": "Adicionar organização",
       "description": "Crie uma nova organização com os detalhes abaixo.",
       "submit": "Criar organização"
-    },
-    "delete": {
-      "title": "Excluir organização",
-      "messagePrefix": "Tem certeza de que deseja excluir",
-      "messageSuffix": "Esta ação não pode ser desfeita."
     },
     "siteModal": {
       "editTitle": "Editar site",
@@ -3171,6 +3165,44 @@
         "merge": "Falha ao iniciar a mesclagem",
         "missingResult": "A mesclagem terminou, mas não retornou dados de resultado. Tente novamente.",
         "mfaRequired": "Mesclar organizações requer autenticação multifator. Ative o MFA nas configurações de segurança do seu perfil e tente novamente."
+      }
+    },
+    "archive": {
+      "title": "Arquivar organização",
+      "description": "Arquivar {{name}} a oculta da sua lista ativa sem excluir nada. Você pode restaurá-la depois.",
+      "consequencesHeading": "O que acontece ao arquivar:",
+      "consequences": {
+        "hidden": "Oculta da sua lista de organizações e da busca",
+        "readOnly": "Os dados existentes permanecem intactos e somente leitura",
+        "agentsUninstalled": "Os agentes são desinstalados dos dispositivos dela",
+        "billingStops": "A cobrança dessa organização é interrompida",
+        "purgeScheduled": "Excluída permanentemente após o período de retenção, a menos que você a restaure antes",
+        "purgeNever": "Mantida até que você a exclua — nunca excluída automaticamente"
+      },
+      "restoreNote": "Restaurar {{name}} desfaz essa ação e está disponível a qualquer momento antes da exclusão definitiva.",
+      "retentionLabel": "Manter dados arquivados por",
+      "retentionOptions": {
+        "days30": "30 dias",
+        "days90": "90 dias (recomendado)",
+        "days365": "365 dias",
+        "never": "Nunca — manter indefinidamente",
+        "custom": "Personalizado"
+      },
+      "customDaysLabel": "Número de dias (1–3650)",
+      "customError": "Informe um número de dias entre 1 e 3650.",
+      "cancel": "Cancelar",
+      "confirmButton": "Arquivar organização",
+      "archiving": "Arquivando...",
+      "doneOffboardingTitle": "Arquivamento iniciado",
+      "doneOffboardingDescription": "{{name}} está sendo arquivada — os agentes dela estão sendo desinstalados agora. Isso termina automaticamente em poucos minutos.",
+      "doneArchivedTitle": "Organização arquivada",
+      "doneArchivedDescription": "{{name}} foi arquivada.",
+      "donePurgeScheduled": "Programada para ser excluída permanentemente em {{date}}.",
+      "donePurgeNever": "Os dados dela serão mantidos até que você os exclua.",
+      "close": "Fechar",
+      "errors": {
+        "archive": "Falha ao arquivar a organização",
+        "mfaRequired": "Arquivar organizações requer autenticação multifator. Ative o MFA nas configurações de segurança do seu perfil e tente novamente."
       }
     }
   },

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -3204,6 +3204,33 @@
         "archive": "Falha ao arquivar a organização",
         "mfaRequired": "Arquivar organizações requer autenticação multifator. Ative o MFA nas configurações de segurança do seu perfil e tente novamente."
       }
+    },
+    "archived": {
+      "sectionTitle": "Arquivadas",
+      "loading": "Carregando organizações arquivadas...",
+      "empty": "Nenhuma organização arquivada.",
+      "badge": "Arquivada",
+      "keptIndefinitely": "Mantida indefinidamente",
+      "purgeToday": "Excluída definitivamente hoje",
+      "purgeCountdown_one": "Excluída definitivamente em {{count}} dia",
+      "purgeCountdown_other": "Excluída definitivamente em {{count}} dias",
+      "truncatedNote": "Mostrando as primeiras {{count}} organizações arquivadas. Pesquise para restringir a lista.",
+      "readOnlyNotice": "Esta organização está arquivada e é somente leitura. Restaure-a para retomar o acesso normal.",
+      "errors": {
+        "fetch": "Falha ao carregar as organizações arquivadas"
+      }
+    },
+    "restore": {
+      "action": "Restaurar",
+      "restoring": "Restaurando...",
+      "success": "{{name}} restaurada — status: {{status}}.",
+      "recreateRequiredNote": "Antes que ela esteja totalmente utilizável de novo: {{items}}",
+      "suspendedNote": "Ela estava suspensa antes de ser arquivada, então foi restaurada como suspensa — resolva isso antes que ela retome o acesso normal.",
+      "errors": {
+        "restore": "Falha ao restaurar a organização",
+        "mfaRequired": "Restaurar organizações requer autenticação multifator. Ative o MFA nas configurações de segurança do seu perfil e tente novamente.",
+        "purging": "Esta organização já está sendo excluída definitivamente e não pode mais ser restaurada."
+      }
     }
   },
   "siteDetailPage": {

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -3209,6 +3209,7 @@
       "sectionTitle": "Arşivlenenler",
       "loading": "Arşivlenen kuruluşlar yükleniyor...",
       "empty": "Arşivlenmiş kuruluş yok.",
+      "noMatches": "Aramanızla eşleşen arşivlenmiş kuruluş yok.",
       "badge": "Arşivlendi",
       "keptIndefinitely": "Süresiz olarak saklanıyor",
       "purgeToday": "Bugün kalıcı olarak silinecek",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -3077,7 +3077,7 @@
       "addOrganization": "Organizasyon ekle",
       "tryAgain": "Tekrar deneyin",
       "editOrganization": "Organizasyonu düzenle",
-      "deleteOrganization": "Kuruluşu sil",
+      "archiveOrganization": "Kuruluşu arşivle",
       "deleting": "Siliniyor..."
     },
     "errors": {
@@ -3085,7 +3085,6 @@
       "generic": "Bir hata oluştu",
       "saveOrder": "Organizasyon sırası kaydedilemedi",
       "saveOrganization": "Kuruluş kaydedilemedi",
-      "deleteOrganization": "Kuruluş silinemedi",
       "saveSite": "Site kaydedilemedi ({{status}})",
       "deleteSite": "Site silinemedi"
     },
@@ -3118,11 +3117,6 @@
       "title": "Organizasyon Ekle",
       "description": "Aşağıdaki ayrıntılarla yeni bir organizasyon oluşturun.",
       "submit": "Organizasyon oluştur"
-    },
-    "delete": {
-      "title": "Kuruluşu Sil",
-      "messagePrefix": "Silmek istediğinizden emin misiniz?",
-      "messageSuffix": "Bu işlem geri alınamaz."
     },
     "siteModal": {
       "editTitle": "Siteyi Düzenle",
@@ -3171,6 +3165,44 @@
         "merge": "Birleştirme başlatılamadı",
         "missingResult": "Birleştirme tamamlandı ancak sonuç verisi döndürmedi. Tekrar deneyin.",
         "mfaRequired": "Kuruluşları birleştirmek çok faktörlü kimlik doğrulama gerektirir. Profil güvenlik ayarlarınızda MFA'yı etkinleştirin ve tekrar deneyin."
+      }
+    },
+    "archive": {
+      "title": "Kuruluşu arşivle",
+      "description": "{{name}} kuruluşunu arşivlemek, hiçbir şeyi silmeden onu etkin listenizden gizler. Daha sonra geri yükleyebilirsiniz.",
+      "consequencesHeading": "Arşivlediğinizde neler olur:",
+      "consequences": {
+        "hidden": "Kuruluş listenizden ve aramadan gizlenir",
+        "readOnly": "Mevcut veriler bozulmadan ve salt okunur olarak kalır",
+        "agentsUninstalled": "Cihazlarındaki ajanlar kaldırılır",
+        "billingStops": "Bu kuruluş için faturalandırma durur",
+        "purgeScheduled": "Önce geri yüklemezseniz saklama süresinden sonra kalıcı olarak silinir",
+        "purgeNever": "Siz silene kadar saklanır — asla otomatik olarak temizlenmez"
+      },
+      "restoreNote": "{{name}} kuruluşunu geri yüklemek bu işlemi geri alır ve kalıcı olarak silinmeden önce her zaman kullanılabilir.",
+      "retentionLabel": "Arşivlenen verileri şu süre boyunca sakla",
+      "retentionOptions": {
+        "days30": "30 gün",
+        "days90": "90 gün (önerilen)",
+        "days365": "365 gün",
+        "never": "Asla — süresiz sakla",
+        "custom": "Özel"
+      },
+      "customDaysLabel": "Gün sayısı (1–3650)",
+      "customError": "1 ile 3650 arasında bir gün sayısı girin.",
+      "cancel": "İptal",
+      "confirmButton": "Kuruluşu arşivle",
+      "archiving": "Arşivleniyor...",
+      "doneOffboardingTitle": "Arşivleme başladı",
+      "doneOffboardingDescription": "{{name}} arşivleniyor — ajanları şu anda kaldırılıyor. Bu işlem birkaç dakika içinde otomatik olarak tamamlanır.",
+      "doneArchivedTitle": "Kuruluş arşivlendi",
+      "doneArchivedDescription": "{{name}} arşivlendi.",
+      "donePurgeScheduled": "{{date}} tarihinde kalıcı olarak silinecek şekilde planlandı.",
+      "donePurgeNever": "Verileri siz silene kadar saklanacak.",
+      "close": "Kapat",
+      "errors": {
+        "archive": "Kuruluş arşivlenemedi",
+        "mfaRequired": "Kuruluşları arşivlemek çok faktörlü kimlik doğrulama gerektirir. Profil güvenlik ayarlarınızda MFA'yı etkinleştirin ve tekrar deneyin."
       }
     }
   },

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -3204,6 +3204,33 @@
         "archive": "Kuruluş arşivlenemedi",
         "mfaRequired": "Kuruluşları arşivlemek çok faktörlü kimlik doğrulama gerektirir. Profil güvenlik ayarlarınızda MFA'yı etkinleştirin ve tekrar deneyin."
       }
+    },
+    "archived": {
+      "sectionTitle": "Arşivlenenler",
+      "loading": "Arşivlenen kuruluşlar yükleniyor...",
+      "empty": "Arşivlenmiş kuruluş yok.",
+      "badge": "Arşivlendi",
+      "keptIndefinitely": "Süresiz olarak saklanıyor",
+      "purgeToday": "Bugün kalıcı olarak silinecek",
+      "purgeCountdown_one": "{{count}} gün içinde kalıcı olarak silinecek",
+      "purgeCountdown_other": "{{count}} gün içinde kalıcı olarak silinecek",
+      "truncatedNote": "İlk {{count}} arşivlenmiş kuruluş gösteriliyor. Listeyi daraltmak için arama yapın.",
+      "readOnlyNotice": "Bu kuruluş arşivlendi ve salt okunur durumda. Normal erişimi sürdürmek için geri yükleyin.",
+      "errors": {
+        "fetch": "Arşivlenen kuruluşlar yüklenemedi"
+      }
+    },
+    "restore": {
+      "action": "Geri yükle",
+      "restoring": "Geri yükleniyor...",
+      "success": "{{name}} geri yüklendi — durum: {{status}}.",
+      "recreateRequiredNote": "Tekrar tam olarak kullanılabilir olmadan önce: {{items}}",
+      "suspendedNote": "Arşivlenmeden önce askıya alınmıştı, bu nedenle askıya alınmış olarak geri yüklendi — normal erişimi sürdürmeden önce bunu çözün.",
+      "errors": {
+        "restore": "Kuruluş geri yüklenemedi",
+        "mfaRequired": "Kuruluşları geri yüklemek çok faktörlü kimlik doğrulama gerektirir. Profil güvenlik ayarlarınızda MFA'yı etkinleştirin ve tekrar deneyin.",
+        "purging": "Bu kuruluş zaten kalıcı olarak siliniyor ve artık geri yüklenemez."
+      }
     }
   },
   "siteDetailPage": {


### PR DESCRIPTION
Wave 5 — the final wave of the org-lifecycle feature (#4074). The Organizations page's destructive action becomes **Archive**: retention picker (30/90/365/Never/custom 1–3650 days), honest consequences copy (hidden, data kept read-only, agents uninstalled, billing stops, auto-purge date — restore is the undo; the old "cannot be undone" lie is gone), handling both drain and immediate-archive outcomes. A collapsed **Archived** section lists archived orgs with purge countdowns (searchable server-side — debounced, race-guarded), truncation signaling, a fully read-only detail pane, and **Restore** (returns the org at its pre-archive status, surfaces what needs re-enrollment, syncs the org switcher; purging → clear refusal).

**Stacked on #4128 (W4).** CI dispatched manually.

Review trail: Codex first-pass + scoped re-reviews per task; fixes included search reachability for >100 archived orgs, org-store reconciliation on restore, debounced token-guarded search fetch, and page-level wiring tests with race coverage. Full web suite 6670/6670.

Deferred (noted in ledger): deep-link to an archived org via URL hash; per-expand fetch caching; the 410 friendly-copy string is coupled to the backend literal (degrades gracefully).

Spec: docs/superpowers/specs/tenancy-rls/2026-08-26-org-lifecycle-merge-archive-design.md
Plan: docs/superpowers/plans/tenancy-rls/2026-08-26-org-lifecycle-w5-archive-ui.md

Closes #4079

🤖 Generated with [Claude Code](https://claude.com/claude-code)