### PR TITLE
feat(api): wave 3.5b — socket-affinity command relay (fenced presence + api-role BullMQ relay)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -565,6 +565,13 @@ GRAFANA_ADMIN_PASSWORD=changeme
 # are rejected at boot.
 # EVENT_DISPATCH_QUEUE_SUBSCRIBERS=webhook-delivery,notification-dispatcher
 
+# Process role for the 3.5d socket/worker split (wave 3.5b, #4084). Unset
+# (or 'all') = today's all-in-one process. 'worker' disables socket-local
+# agent dispatch (agentWs sendCommandToAgent/isAgentConnected throw instead
+# of silently reporting every agent offline) — do not set this until the
+# 3.5d rollout actually splits processes.
+# BREEZE_ROLE=all
+
 # Hostname prefixes attributed to abusive hosting, matched against device
 # hostnames (unset = empty list; the repo deliberately ships no indicators,
 # since publishing a prefix just tells an operator which string to rename).

--- a/apps/api/src/__tests__/integration/agentCommandRelay.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentCommandRelay.integration.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Real-Redis integration coverage for the wave-3.5b (#4084) socket-affinity
+ * command relay: fenced presence leases (`agentPresence.ts`), the sealed
+ * relay envelope + at-most-once send claim + ack channel
+ * (`agentCommandRelay.ts`), the api-role consumer (`agentCommandRelayWorker.ts`),
+ * and the `dispatchCommandToAgent` facade's local-vs-relay branching.
+ *
+ * The mocked unit suites (`agentPresence.test.ts`, `agentCommandRelay.test.ts`,
+ * `agentCommandRelayWorker.test.ts`) stub `./redis` and `../routes/agentWs`
+ * wholesale, so they can assert shape and control flow but cannot prove:
+ *   1. The Lua fencing scripts (refresh/delete-if-token-matches) actually
+ *      behave correctly against a real Redis (not a hand-rolled mock of
+ *      `redis.eval`), including real PTTL/PEXPIRE semantics.
+ *   2. A real BullMQ Worker draining a real `agent-command-relay` queue can
+ *      deliver a byte-identical `{id,type,payload}` frame to a real
+ *      "socket" — the actual cross-process proof this wave exists to give
+ *      (a same-process `forceRelay: true` dispatch + real consumer stands in
+ *      for the true two-process split, which arrives with 3.5d's compose
+ *      topology — see the plan's Self-Review Notes).
+ *   3. The AAD-bound (v3) envelope really carries no plaintext into the
+ *      Redis-persisted job payload, and really fails closed on a stale
+ *      binding.
+ *   4. The claim CAS is genuinely at-most-once against real Redis EVAL, and
+ *      owner-mismatch/expiry fail the way the design demands — not just
+ *      what a mocked `getRedis()` was told to return.
+ *
+ * No Postgres fixtures are used (presence/relay state is pure Redis), but
+ * this suite still needs the full rig up because the shared `setup.ts`
+ * unconditionally requires both Postgres and Redis to be reachable before
+ * any file in this config runs (see `mfaStepUpGrant.integration.test.ts`'s
+ * header for the identical note). `setup.ts`'s global `beforeEach` also
+ * `flushdb()`s Redis before every test in this file, so each test starts
+ * from an empty keyspace — this suite still closes every Worker it creates
+ * per test (open BullMQ/ioredis handles don't die on a flushdb) and
+ * namespaces every agentId with a per-run UUID so a shard sharing this
+ * Redis with another run can't collide (#3066).
+ *
+ * Run:
+ *   pnpm test-stack up --force   # or: docker compose -f docker-compose.test.yml up -d
+ *   cd apps/api && npx vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/agentCommandRelay.integration.test.ts
+ */
+import './setup';
+
+import { randomUUID } from 'crypto';
+import type { Worker } from 'bullmq';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+
+import { closeRedis, getRedis } from '../../services/redis';
+import { INSTANCE_ID } from '../../services/instanceIdentity';
+import {
+  AGENT_PRESENCE_TTL_MS,
+  clearAgentPresence,
+  readAgentPresence,
+  refreshAgentPresence,
+  setAgentPresence,
+} from '../../services/agentPresence';
+import {
+  awaitRelayAck,
+  dispatchCommandToAgent,
+  getAgentCommandRelayQueue,
+  markRelaySendComplete,
+  openRelayCommand,
+  sealRelayCommand,
+  shutdownAgentCommandRelayQueue,
+  type RelayEnvelopeBinding,
+  type RelayJobData,
+} from '../../services/agentCommandRelay';
+import { createAgentCommandRelayWorker } from '../../jobs/agentCommandRelayWorker';
+import { __installAgentSocketForTest } from '../../routes/agentWs';
+import type { AgentCommand } from '../../routes/agentWs';
+
+// Namespaced per invocation so a shard sharing this Redis with another
+// concurrent run can never collide on the same agentId (#3066 cleanup
+// discipline — see the header above and the plan's Task 9 note).
+const RUN = randomUUID().slice(0, 8);
+function agentId(label: string): string {
+  return `agent-int-${RUN}-${label}`;
+}
+
+function installFakeSocket(id: string): string[] {
+  const frames: string[] = [];
+  __installAgentSocketForTest(id, { send: (data: string) => frames.push(data) });
+  return frames;
+}
+
+const activeWorkers: Worker<RelayJobData>[] = [];
+function startConsumer(): Worker<RelayJobData> {
+  const worker = createAgentCommandRelayWorker();
+  activeWorkers.push(worker);
+  return worker;
+}
+
+function makeCommand(overrides: Partial<AgentCommand> = {}): AgentCommand {
+  return { id: randomUUID(), type: 'network_ping', payload: { probe: true }, ...overrides };
+}
+
+afterEach(async () => {
+  await Promise.all(activeWorkers.splice(0).map((w) => w.close()));
+  await getAgentCommandRelayQueue().obliterate({ force: true }).catch(() => {});
+});
+
+afterAll(async () => {
+  await shutdownAgentCommandRelayQueue();
+  // Quit the shared BullMQ/ioredis singleton so vitest can exit.
+  await closeRedis();
+});
+
+describe('agent command relay — real Redis (wave 3.5b, #4084)', () => {
+  it('presence lifecycle: set/read roundtrip, token-fenced refresh/clear, PTTL bounds', async () => {
+    const id = agentId('presence-1');
+
+    await setAgentPresence(id, { instanceId: 'inst-a', connectionToken: 'tok-a' });
+    expect(await readAgentPresence(id)).toEqual({ instanceId: 'inst-a', connectionToken: 'tok-a' });
+
+    // Wrong token never refreshes or clears (fencing).
+    expect(await refreshAgentPresence(id, 'wrong-token')).toBe(false);
+    expect(await clearAgentPresence(id, 'wrong-token')).toBe(false);
+    expect(await readAgentPresence(id)).not.toBeNull();
+
+    // Right token refreshes.
+    expect(await refreshAgentPresence(id, 'tok-a')).toBe(true);
+    const redis = getRedis();
+    expect(redis).not.toBeNull();
+    const pttl = await redis!.pttl('agent-presence:' + id);
+    expect(pttl).toBeGreaterThan(0);
+    expect(pttl).toBeLessThanOrEqual(AGENT_PRESENCE_TTL_MS);
+
+    // Right token clears.
+    expect(await clearAgentPresence(id, 'tok-a')).toBe(true);
+    expect(await readAgentPresence(id)).toBeNull();
+  });
+
+  it('forced-relay E2E: exactly one frame reaches the agent, byte-identical to the command', async () => {
+    const id = agentId('e2e-1');
+    const frames = installFakeSocket(id);
+    await setAgentPresence(id, { instanceId: INSTANCE_ID, connectionToken: 't-int' });
+    startConsumer();
+
+    const command = makeCommand();
+    const outcome = await dispatchCommandToAgent(id, command, { forceRelay: true });
+
+    expect(outcome).toEqual({ status: 'sent', via: 'relay' });
+    expect(frames).toHaveLength(1);
+    expect(JSON.parse(frames[0]!)).toEqual(command);
+  }, 10_000);
+
+  it('no plaintext in the queue: the raw job never contains the secret, but openRelayCommand recovers it', async () => {
+    const id = agentId('plaintext-1');
+    const command = makeCommand({ payload: { credential: 'sup3r-s3cret' } });
+    const relayId = randomUUID();
+    const binding: RelayEnvelopeBinding = {
+      agentId: id, commandId: command.id, targetInstanceId: INSTANCE_ID, expiresAt: Date.now() + 5_000,
+    };
+    const sealedCommand = sealRelayCommand(command, binding);
+    const data: RelayJobData = {
+      relayId, agentId: id, commandId: command.id, targetInstanceId: binding.targetInstanceId,
+      connectionToken: 'tok-plain', expiresAt: binding.expiresAt, sealedCommand,
+    };
+    // No consumer running — this asserts the job's AT-REST shape.
+    await getAgentCommandRelayQueue().add('relay-send', data, { jobId: `relay-${relayId}` });
+
+    const job = await getAgentCommandRelayQueue().getJob(`relay-${relayId}`);
+    expect(job).toBeTruthy();
+    expect(JSON.stringify(job!.data)).not.toContain('sup3r-s3cret');
+
+    const opened = openRelayCommand(job!.data.sealedCommand, binding);
+    expect(opened).toEqual(command);
+  });
+
+  it('stale presence (no socket installed) → offline, no frame', async () => {
+    const id = agentId('stale-1');
+    // Presence exists (an admission hint) but no socket was ever installed —
+    // the consumer's own activeConnections map is authoritative.
+    await setAgentPresence(id, { instanceId: INSTANCE_ID, connectionToken: 't-stale' });
+    startConsumer();
+
+    const outcome = await dispatchCommandToAgent(id, makeCommand(), { forceRelay: true });
+    expect(outcome).toEqual({ status: 'offline' });
+  }, 10_000);
+
+  it('owner fencing: presence re-set to a new token between enqueue and consumer start → owner_mismatch, no frame', async () => {
+    const id = agentId('fence-1');
+    const frames = installFakeSocket(id);
+    const command = makeCommand();
+    const relayId = randomUUID();
+    const expiresAt = Date.now() + 5_000;
+
+    // The lease used to build the enqueued job's binding/connectionToken.
+    await setAgentPresence(id, { instanceId: INSTANCE_ID, connectionToken: 'orig-token' });
+    const binding: RelayEnvelopeBinding = { agentId: id, commandId: command.id, targetInstanceId: INSTANCE_ID, expiresAt };
+    const sealedCommand = sealRelayCommand(command, binding);
+    const data: RelayJobData = {
+      relayId, agentId: id, commandId: command.id, targetInstanceId: INSTANCE_ID,
+      connectionToken: 'orig-token', expiresAt, sealedCommand,
+    };
+    await getAgentCommandRelayQueue().add('relay-send', data, { jobId: `relay-${relayId}` });
+
+    // A newer connection takes over the lease AFTER the job was built.
+    await setAgentPresence(id, { instanceId: INSTANCE_ID, connectionToken: 'other-token' });
+
+    startConsumer();
+    const outcome = await awaitRelayAck(relayId, 5_000);
+
+    expect(outcome).toEqual({ status: 'owner_mismatch' });
+    expect(frames).toHaveLength(0);
+  }, 10_000);
+
+  it('expired job: consumer acks expired without sending', async () => {
+    const id = agentId('expired-1');
+    const frames = installFakeSocket(id);
+    const command = makeCommand();
+    const relayId = randomUUID();
+    const binding: RelayEnvelopeBinding = {
+      agentId: id, commandId: command.id, targetInstanceId: INSTANCE_ID, expiresAt: Date.now() - 1_000,
+    };
+    const sealedCommand = sealRelayCommand(command, binding);
+    const data: RelayJobData = {
+      relayId, agentId: id, commandId: command.id, targetInstanceId: INSTANCE_ID,
+      connectionToken: 't-expired', expiresAt: binding.expiresAt, sealedCommand,
+    };
+    await getAgentCommandRelayQueue().add('relay-send', data, { jobId: `relay-${relayId}` });
+
+    startConsumer();
+    const outcome = await awaitRelayAck(relayId, 5_000);
+
+    expect(outcome).toEqual({ status: 'expired' });
+    expect(frames).toHaveLength(0);
+  }, 10_000);
+
+  it('at-most-once: a pre-marked send claim short-circuits — ack sent, ZERO new frames', async () => {
+    const id = agentId('once-1');
+    const frames = installFakeSocket(id);
+    await setAgentPresence(id, { instanceId: INSTANCE_ID, connectionToken: 't-once' });
+    const command = makeCommand();
+    await markRelaySendComplete(id, command.id);
+    startConsumer();
+
+    const outcome = await dispatchCommandToAgent(id, command, { forceRelay: true });
+
+    expect(outcome).toEqual({ status: 'sent', via: 'relay' });
+    expect(frames).toHaveLength(0);
+  }, 10_000);
+
+  it('local-first: a locally-connected agent without forceRelay never touches the queue', async () => {
+    const id = agentId('local-1');
+    const frames = installFakeSocket(id);
+    await setAgentPresence(id, { instanceId: INSTANCE_ID, connectionToken: 't-local' });
+
+    const outcome = await dispatchCommandToAgent(id, makeCommand());
+
+    expect(outcome).toEqual({ status: 'sent', via: 'local' });
+    expect(frames).toHaveLength(1);
+    expect(await getAgentCommandRelayQueue().count()).toBe(0);
+  });
+
+  it('no presence → no enqueue: forced relay on a fresh agentId is offline, queue stays empty', async () => {
+    const id = agentId('nopresence-1');
+
+    const outcome = await dispatchCommandToAgent(id, makeCommand(), { forceRelay: true });
+
+    expect(outcome).toEqual({ status: 'offline' });
+    expect(await getAgentCommandRelayQueue().count()).toBe(0);
+  });
+});

--- a/apps/api/src/__tests__/integration/agentCommandRelay.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentCommandRelay.integration.test.ts
@@ -118,12 +118,22 @@ describe('agent command relay — real Redis (wave 3.5b, #4084)', () => {
     expect(await clearAgentPresence(id, 'wrong-token')).toBe(false);
     expect(await readAgentPresence(id)).not.toBeNull();
 
-    // Right token refreshes.
-    expect(await refreshAgentPresence(id, 'tok-a')).toBe(true);
+    // Shrink the TTL first so a refresh has something to measure — otherwise
+    // the initial setAgentPresence's own PX 90000 would satisfy the same
+    // bounds regardless of whether the refresh's PEXPIRE actually ran.
+    const key = 'agent-presence:' + id;
     const redis = getRedis();
     expect(redis).not.toBeNull();
-    const pttl = await redis!.pttl('agent-presence:' + id);
-    expect(pttl).toBeGreaterThan(0);
+    await redis!.pexpire(key, 3_000);
+
+    // Wrong token must NOT extend the shrunk TTL (fencing survives refresh too).
+    expect(await refreshAgentPresence(id, 'wrong-token')).toBe(false);
+    expect(await redis!.pttl(key)).toBeLessThanOrEqual(3_000);
+
+    // Right token refreshes — and actually extends the lease back out.
+    expect(await refreshAgentPresence(id, 'tok-a')).toBe(true);
+    const pttl = await redis!.pttl(key);
+    expect(pttl).toBeGreaterThan(AGENT_PRESENCE_TTL_MS - 5_000);
     expect(pttl).toBeLessThanOrEqual(AGENT_PRESENCE_TTL_MS);
 
     // Right token clears.

--- a/apps/api/src/config/env.breezeRole.test.ts
+++ b/apps/api/src/config/env.breezeRole.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { breezeRole } from './env';
+
+describe('breezeRole()', () => {
+  const original = process.env.BREEZE_ROLE;
+  afterEach(() => {
+    if (original === undefined) delete process.env.BREEZE_ROLE;
+    else process.env.BREEZE_ROLE = original;
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    [undefined, 'all'],
+    ['', 'all'],
+    ['all', 'all'],
+    ['api', 'api'],
+    ['worker', 'worker'],
+    ['API', 'api'],
+    ['  worker  ', 'worker'],
+  ])('BREEZE_ROLE=%s → %s', (raw, expected) => {
+    if (raw === undefined) delete process.env.BREEZE_ROLE;
+    else process.env.BREEZE_ROLE = raw;
+    expect(breezeRole()).toBe(expected);
+  });
+
+  it('unknown value warns and falls back to all', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.BREEZE_ROLE = 'banana';
+    expect(breezeRole()).toBe('all');
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -233,6 +233,22 @@ export function eventDispatchQueueSubscribers(): ReadonlySet<SubscriberId> {
   return out;
 }
 
+export type BreezeRole = 'all' | 'api' | 'worker';
+
+/**
+ * Process role for the 3.5d split (#4086). `all` (default) = today's
+ * all-in-one process. Introduced in 3.5b (#4084) so socket-local dispatch can
+ * fail LOUDLY in a worker-role process instead of silently reporting every
+ * agent offline.
+ */
+export function breezeRole(): BreezeRole {
+  const raw = (process.env.BREEZE_ROLE ?? '').trim().toLowerCase();
+  if (raw === '' || raw === 'all') return 'all';
+  if (raw === 'api' || raw === 'worker') return raw;
+  console.warn(`[config] BREEZE_ROLE="${raw}" is not all|api|worker — treating as all`);
+  return 'all';
+}
+
 // Recognizes an AFFIRMATIVE self-host declaration: IS_HOSTED explicitly set to
 // a recognized falsey signal ('false'/'0'/'no'/'off'). Unset / empty / garbage /
 // truthy all return false, so security-weakening, self-host-only features stay

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -2661,6 +2661,53 @@ describe('M365_GRAPH_ACTIONS_TOOLS_ENABLED boolean guard (#3374)', () => {
   );
 });
 
+describe('BREEZE_ROLE ↔ APP_ENCRYPTION_KEY_ID pairing (wave 3.5b, #4084)', () => {
+  it.each(['api', 'worker'])(
+    'refuses boot with BREEZE_ROLE=%s and no APP_ENCRYPTION_KEY_ID',
+    (role) => {
+      withEnv({ ...validEnv, BREEZE_ROLE: role }, () => {
+        withoutEnv(['APP_ENCRYPTION_KEY_ID'], () => {
+          expect(() => validateConfig()).toThrow(/APP_ENCRYPTION_KEY_ID/);
+        });
+      });
+    },
+  );
+
+  it.each(['api', 'worker'])(
+    'refuses boot with BREEZE_ROLE=%s and a whitespace-only APP_ENCRYPTION_KEY_ID',
+    (role) => {
+      withEnv({ ...validEnv, BREEZE_ROLE: role, APP_ENCRYPTION_KEY_ID: '   ' }, () => {
+        expect(() => validateConfig()).toThrow(/APP_ENCRYPTION_KEY_ID/);
+      });
+    },
+  );
+
+  it.each(['api', 'worker'])(
+    'passes with BREEZE_ROLE=%s when APP_ENCRYPTION_KEY_ID is set',
+    (role) => {
+      withEnv({ ...validEnv, BREEZE_ROLE: role, APP_ENCRYPTION_KEY_ID: 'current' }, () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    },
+  );
+
+  it('does not require APP_ENCRYPTION_KEY_ID when BREEZE_ROLE is unset (default "all")', () => {
+    withEnv({ ...validEnv }, () => {
+      withoutEnv(['BREEZE_ROLE', 'APP_ENCRYPTION_KEY_ID'], () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    });
+  });
+
+  it('does not require APP_ENCRYPTION_KEY_ID when BREEZE_ROLE=all explicitly', () => {
+    withEnv({ ...validEnv, BREEZE_ROLE: 'all' }, () => {
+      withoutEnv(['APP_ENCRYPTION_KEY_ID'], () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    });
+  });
+});
+
 // `isConfigInitialized()` gates ipAllowlistMode()'s pre-boot fallback. Its unit
 // tests mock the whole config module, so without this the predicate itself is
 // unexercised — and inverting it (`_config !== undefined`, always true for a

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -610,6 +610,13 @@ const envObjectSchema = z
     EVENT_DISPATCH_MODE: z.string().optional(),
     EVENT_DISPATCH_QUEUE_SUBSCRIBERS: z.string().optional(),
 
+    // Process role for the 3.5d socket/worker split (wave 3.5b, #4084). all
+    // (default) = today's all-in-one process. Read at runtime by
+    // breezeRole() in env.ts. Validated here for format only — absence means
+    // 'all', and this is NOT required-in-production in this wave (that lands
+    // with 3.5d once the split is actually exercised in prod topology).
+    BREEZE_ROLE: z.string().optional(),
+
     // M365 Tier-3 write-action AI tools (m365_disable_user, m365_reset_password)
     // and the action-intents release worker's headless dispatch. Dark by
     // default. Read at runtime by writeActionRuntimeConfig.ts; declared here so

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -1739,6 +1739,29 @@ const envSchema = envObjectSchema
       });
     }
 
+    // BREEZE_ROLE ↔ APP_ENCRYPTION_KEY_ID pairing (wave 3.5b, #4084). Once a
+    // process is split into 'api' or 'worker', cross-process agent command
+    // dispatch goes through agentCommandRelay.ts, which seals every relay job
+    // with AAD-bound v3 ciphertext and REFUSES to seal without a configured
+    // key id (sealRelayCommand throws rather than silently degrading to the
+    // AAD-ignoring v1 fallback). Without this check, a 'api'/'worker' split
+    // deployment boots clean and then fails every single relay dispatch at
+    // runtime with zero boot-time signal — turn that into a boot refusal, same
+    // shape as the M365 pairing rule above. 'all' (default) is unaffected: it
+    // never takes the relay branch for a locally-connected agent.
+    const breezeRoleRaw = (data.BREEZE_ROLE ?? '').trim().toLowerCase();
+    if (
+      (breezeRoleRaw === 'api' || breezeRoleRaw === 'worker')
+      && !data.APP_ENCRYPTION_KEY_ID?.trim()
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['APP_ENCRYPTION_KEY_ID'],
+        message:
+          'APP_ENCRYPTION_KEY_ID is required when BREEZE_ROLE is "api" or "worker" (the cross-process agent command relay envelope requires AAD-bound v3 ciphertext).',
+      });
+    }
+
     // --- Native APNs push (all-or-none) ---
     // Push is optional, so an empty APNS_* set is fine. But a partial set
     // (e.g. team + bundle without the signing key) would silently fail to

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -364,6 +364,11 @@ import { closeRedis, getRedis, isRedisAvailable } from './services/redis';
 import { shutdownEventDispatcher } from './services/eventDispatcher';
 import { initializeEventDispatchWorker, shutdownEventDispatchWorker } from './jobs/eventDispatchWorker';
 import { shutdownEventDispatchQueue } from './services/eventDispatchQueue';
+import {
+  initializeAgentCommandRelayWorker,
+  shutdownAgentCommandRelayWorker,
+} from './jobs/agentCommandRelayWorker';
+import { breezeRole } from './config/env';
 import { getEventBus } from './services/eventBus';
 import { writeAuditEvent } from './services/auditEvents';
 import { drainAuditRetryQueue } from './services/auditService';
@@ -1523,6 +1528,22 @@ async function initializeWorkers(): Promise<void> {
     console.error('[CRITICAL] Failed to initialize eventDispatch:', error);
     captureException(error instanceof Error ? error : new Error(String(error)));
   }
+
+  // Wave 3.5b (#4084): the relay CONSUMER only runs on a process that may own
+  // agent sockets. In today's BREEZE_ROLE=all topology this is every process
+  // (zero behavior change — dispatchCommandToAgent's local-first branch means
+  // the relay path is unreachable for an online agent); the 3.5d split
+  // (#4086) is what makes a worker-role process actually skip this.
+  if (breezeRole() !== 'worker') {
+    try {
+      await initializeAgentCommandRelayWorker();
+      workerStatus['agentCommandRelay'] = true;
+    } catch (error) {
+      workerStatus['agentCommandRelay'] = false;
+      console.error('[CRITICAL] Failed to initialize agentCommandRelay:', error);
+      captureException(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
   readiness.invalidate();
 
   if (failed.length === 0) {
@@ -1716,6 +1737,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownEventDispatcher,
     shutdownEventDispatchWorker,
     shutdownEventDispatchQueue,
+    shutdownAgentCommandRelayWorker,
     async () => getEventBus().close(),
     closeRedis,
     async () => {

--- a/apps/api/src/jobs/agentCommandRelayWorker.test.ts
+++ b/apps/api/src/jobs/agentCommandRelayWorker.test.ts
@@ -108,6 +108,8 @@ describe('processAgentCommandRelayJob', () => {
   });
 
   it('acks owner_mismatch when the job target is not THIS instance', async () => {
+    vi.mocked(readAgentPresence).mockResolvedValue({ ...LEASE, instanceId: 'inst-2' });
+
     await processAgentCommandRelayJob(fakeJob({ targetInstanceId: 'inst-2' }));
 
     expect(writeRelayAck).toHaveBeenCalledWith('relay-1', { status: 'owner_mismatch' });

--- a/apps/api/src/jobs/agentCommandRelayWorker.test.ts
+++ b/apps/api/src/jobs/agentCommandRelayWorker.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Wave 3.5b (#4084) — api-role relay consumer. Presence admitted the job onto
+// this queue; this process's in-memory socket map (agentWs) is the actual
+// authority for whether the send can happen at all. These tests drive the
+// exported processor function directly with a fake BullMQ Job — Worker
+// construction / concurrency wiring is not under test here.
+
+vi.mock('../services/instanceIdentity', () => ({ INSTANCE_ID: 'inst-1' }));
+
+vi.mock('../services/agentPresence', () => ({
+  readAgentPresence: vi.fn(),
+}));
+
+vi.mock('../services/agentCommandRelay', () => ({
+  AGENT_COMMAND_RELAY_QUEUE: 'agent-command-relay',
+  claimRelaySend: vi.fn(),
+  markRelaySendComplete: vi.fn(),
+  openRelayCommand: vi.fn(),
+  writeRelayAck: vi.fn(),
+}));
+
+vi.mock('../routes/agentWs', () => ({
+  isAgentConnected: vi.fn(),
+  sendCommandToAgent: vi.fn(),
+}));
+
+import { readAgentPresence } from '../services/agentPresence';
+import {
+  claimRelaySend,
+  markRelaySendComplete,
+  openRelayCommand,
+  writeRelayAck,
+} from '../services/agentCommandRelay';
+import { isAgentConnected, sendCommandToAgent } from '../routes/agentWs';
+import { processAgentCommandRelayJob } from './agentCommandRelayWorker';
+
+const BASE_DATA = {
+  relayId: 'relay-1',
+  agentId: 'agent-1',
+  commandId: 'cmd-1',
+  targetInstanceId: 'inst-1',
+  connectionToken: 'token-1',
+  expiresAt: Date.now() + 5_000,
+  sealedCommand: 'sealed-blob',
+};
+
+function fakeJob(overrides: Partial<typeof BASE_DATA> = {}) {
+  return { data: { ...BASE_DATA, ...overrides } } as any;
+}
+
+const LEASE = { instanceId: 'inst-1', connectionToken: 'token-1' };
+const COMMAND = { id: 'cmd-1', type: 'snmp_poll', payload: { oids: ['1.3.6.1'] } };
+
+describe('processAgentCommandRelayJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isAgentConnected).mockReturnValue(true);
+    vi.mocked(readAgentPresence).mockResolvedValue(LEASE);
+    vi.mocked(claimRelaySend).mockResolvedValue('claimed');
+    vi.mocked(openRelayCommand).mockReturnValue(COMMAND as any);
+    vi.mocked(sendCommandToAgent).mockReturnValue(true);
+  });
+
+  it('acks expired without taking a claim or sending', async () => {
+    await processAgentCommandRelayJob(fakeJob({ expiresAt: Date.now() - 1_000 }));
+
+    expect(writeRelayAck).toHaveBeenCalledWith('relay-1', { status: 'expired' });
+    expect(claimRelaySend).not.toHaveBeenCalled();
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('acks offline when there is no local socket, without taking a claim', async () => {
+    vi.mocked(isAgentConnected).mockReturnValue(false);
+
+    await processAgentCommandRelayJob(fakeJob());
+
+    expect(writeRelayAck).toHaveBeenCalledWith('relay-1', { status: 'offline' });
+    expect(claimRelaySend).not.toHaveBeenCalled();
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('acks owner_mismatch when the presence lease is missing', async () => {
+    vi.mocked(readAgentPresence).mockResolvedValue(null);
+
+    await processAgentCommandRelayJob(fakeJob());
+
+    expect(writeRelayAck).toHaveBeenCalledWith('relay-1', { status: 'owner_mismatch' });
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('acks owner_mismatch when the lease instanceId does not match the job target', async () => {
+    vi.mocked(readAgentPresence).mockResolvedValue({ ...LEASE, instanceId: 'inst-2' });
+
+    await processAgentCommandRelayJob(fakeJob());
+
+    expect(writeRelayAck).toHaveBeenCalledWith('relay-1', { status: 'owner_mismatch' });
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('acks owner_mismatch when the lease connectionToken does not match the job', async () => {
+    vi.mocked(readAgentPresence).mockResolvedValue({ ...LEASE, connectionToken: 'other-token' });
+
+    await processAgentCommandRelayJob(fakeJob());
+
+    expect(writeRelayAck).toHaveBeenCalledWith('relay-1', { status: 'owner_mismatch' });
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('acks owner_mismatch when the job target is not THIS instance', async () => {
+    await processAgentCommandRelayJob(fakeJob({ targetInstanceId: 'inst-2' }));
+
+    expect(writeRelayAck).toHaveBeenCalledWith('relay-1', { status: 'owner_mismatch' });
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('acks sent/relay without a second send when the claim says already-sent', async () => {
+    vi.mocked(claimRelaySend).mockResolvedValue('already-sent');
+
+    await processAgentCommandRelayJob(fakeJob());
+
+    expect(writeRelayAck).toHaveBeenCalledWith('relay-1', { status: 'sent', via: 'relay' });
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('acks indeterminate without sending when the claim is in-flight', async () => {
+    vi.mocked(claimRelaySend).mockResolvedValue('in-flight');
+
+    await processAgentCommandRelayJob(fakeJob());
+
+    expect(writeRelayAck).toHaveBeenCalledWith('relay-1', { status: 'indeterminate' });
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('acks infrastructure_error without sending when the envelope fails to open', async () => {
+    vi.mocked(openRelayCommand).mockImplementation(() => {
+      throw new Error('tamper');
+    });
+
+    await processAgentCommandRelayJob(fakeJob());
+
+    expect(writeRelayAck).toHaveBeenCalledWith('relay-1', {
+      status: 'infrastructure_error',
+      message: expect.stringContaining('tamper or key mismatch'),
+    });
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('sends the decrypted command, marks the claim complete, and acks sent/relay', async () => {
+    await processAgentCommandRelayJob(fakeJob());
+
+    expect(openRelayCommand).toHaveBeenCalledWith('sealed-blob', {
+      agentId: 'agent-1',
+      commandId: 'cmd-1',
+      targetInstanceId: 'inst-1',
+      expiresAt: BASE_DATA.expiresAt,
+    });
+    expect(sendCommandToAgent).toHaveBeenCalledWith('agent-1', COMMAND);
+    expect(markRelaySendComplete).toHaveBeenCalledWith('agent-1', 'cmd-1');
+    expect(writeRelayAck).toHaveBeenCalledWith('relay-1', { status: 'sent', via: 'relay' });
+  });
+
+  it('acks offline and does NOT mark the claim complete when the send itself fails', async () => {
+    vi.mocked(sendCommandToAgent).mockReturnValue(false);
+
+    await processAgentCommandRelayJob(fakeJob());
+
+    expect(markRelaySendComplete).not.toHaveBeenCalled();
+    expect(writeRelayAck).toHaveBeenCalledWith('relay-1', { status: 'offline' });
+  });
+});

--- a/apps/api/src/jobs/agentCommandRelayWorker.ts
+++ b/apps/api/src/jobs/agentCommandRelayWorker.ts
@@ -1,0 +1,107 @@
+import { Worker, type Job } from 'bullmq';
+import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
+import { INSTANCE_ID } from '../services/instanceIdentity';
+import { readAgentPresence } from '../services/agentPresence';
+import {
+  AGENT_COMMAND_RELAY_QUEUE,
+  claimRelaySend,
+  markRelaySendComplete,
+  openRelayCommand,
+  writeRelayAck,
+  type DispatchOutcome,
+  type RelayJobData,
+} from '../services/agentCommandRelay';
+import { isAgentConnected, sendCommandToAgent } from '../routes/agentWs';
+
+/**
+ * Api-role relay consumer (wave 3.5b, #4084).
+ *
+ * Runs ONLY on a process that may own sockets — registration in index.ts is
+ * gated on `breezeRole() !== 'worker'`. Presence merely ADMITTED this job onto
+ * the queue; this process's in-memory socket map (agentWs.isAgentConnected)
+ * is the actual authority for whether the send can happen at all, and the
+ * lease/target-instance checks below re-verify the routing decision wasn't
+ * made against a since-superseded lease.
+ *
+ * The local send path also records `orphanedResultExpectations` HERE — on the
+ * process that will receive the eventual `command_result` — which is why this
+ * consumer calls `sendCommandToAgent` directly and never re-implements the
+ * socket write itself.
+ */
+export async function processAgentCommandRelayJob(job: Job<RelayJobData>): Promise<void> {
+  const d = job.data;
+  const ack = (outcome: DispatchOutcome) => writeRelayAck(d.relayId, outcome);
+
+  if (Date.now() > d.expiresAt) return ack({ status: 'expired' });
+  if (!isAgentConnected(d.agentId)) return ack({ status: 'offline' });
+
+  const lease = await readAgentPresence(d.agentId);
+  if (
+    !lease
+    || lease.instanceId !== d.targetInstanceId
+    || lease.connectionToken !== d.connectionToken
+    || d.targetInstanceId !== INSTANCE_ID
+  ) {
+    return ack({ status: 'owner_mismatch' });
+  }
+
+  let claim: Awaited<ReturnType<typeof claimRelaySend>>;
+  try {
+    claim = await claimRelaySend(d.agentId, d.commandId);
+  } catch (err) {
+    return ack({
+      status: 'infrastructure_error',
+      message: `send claim failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+  if (claim === 'already-sent') return ack({ status: 'sent', via: 'relay' });
+  if (claim === 'in-flight') return ack({ status: 'indeterminate' });
+
+  let command;
+  try {
+    command = openRelayCommand(d.sealedCommand, {
+      agentId: d.agentId, commandId: d.commandId,
+      targetInstanceId: d.targetInstanceId, expiresAt: d.expiresAt,
+    });
+  } catch {
+    return ack({ status: 'infrastructure_error', message: 'relay envelope failed to open (tamper or key mismatch)' });
+  }
+
+  if (!sendCommandToAgent(d.agentId, command)) return ack({ status: 'offline' });
+  await markRelaySendComplete(d.agentId, d.commandId);
+  return ack({ status: 'sent', via: 'relay' });
+}
+
+let relayWorker: Worker<RelayJobData> | null = null;
+
+export function createAgentCommandRelayWorker(): Worker<RelayJobData> {
+  return new Worker<RelayJobData>(AGENT_COMMAND_RELAY_QUEUE, processAgentCommandRelayJob, {
+    connection: getBullMQConnection(),
+    // ws.send is fast; 25 is deliberately conservative — tune from queue-age
+    // measurements after 3.5d rolls out, mirroring eventDispatchWorker's note.
+    concurrency: 25,
+  });
+}
+
+export async function initializeAgentCommandRelayWorker(): Promise<void> {
+  try {
+    relayWorker = createAgentCommandRelayWorker();
+    attachWorkerObservability(relayWorker, 'agentCommandRelay');
+    console.log('[AgentCommandRelayWorker] Initialized');
+  } catch (error) {
+    if (relayWorker) {
+      await relayWorker.close().catch(() => {});
+      relayWorker = null;
+    }
+    console.error('[AgentCommandRelayWorker] Failed to initialize:', error);
+    throw error;
+  }
+}
+
+export async function shutdownAgentCommandRelayWorker(): Promise<void> {
+  if (relayWorker) {
+    await relayWorker.close();
+    relayWorker = null;
+  }
+}

--- a/apps/api/src/jobs/agentDispatchBoundary.contract.test.ts
+++ b/apps/api/src/jobs/agentDispatchBoundary.contract.test.ts
@@ -1,0 +1,48 @@
+// apps/api/src/jobs/agentDispatchBoundary.contract.test.ts
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Wave 3.5b (#4084): BullMQ job modules may run in a worker-role process that
+// holds NO agent sockets. Socket-local dispatch there silently reports every
+// agent offline — the exact incident class this wave exists to prevent. Jobs
+// must use dispatchCommandToAgent/isAgentConnectedAnywhere (agentCommandRelay).
+const JOBS_DIR = fileURLToPath(new URL('.', import.meta.url));
+
+// The relay consumer is the ONE legitimate socket-local caller under jobs/ —
+// its registration is gated to socket-owning roles in index.ts.
+const SOCKET_OWNER_ALLOWLIST = new Set(['agentCommandRelayWorker.ts']);
+
+const FORBIDDEN_PATTERNS: Array<[string, RegExp]> = [
+  ['value import of socket-local agentWs dispatch',
+    /import\s+(?!type\s)\{[^}]*\b(sendCommandToAgent|isAgentConnected|disconnectAgent|broadcastToAgents)\b[^}]*\}\s*from\s*['"][^'"]*agentWs['"]/],
+  ['value import of in-memory agentCommandAwait',
+    /import\s+(?!type\s)\{[^}]*\bsendCommandToAgentAwaitResult\b[^}]*\}\s*from\s*['"][^'"]*agentCommandAwait['"]/],
+];
+
+function productionSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...productionSources(full));
+    else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) out.push(full);
+  }
+  return out;
+}
+
+describe('jobs/** must not use socket-local agent dispatch (#4084)', () => {
+  const files = productionSources(JOBS_DIR)
+    .filter((f) => !SOCKET_OWNER_ALLOWLIST.has(f.slice(JOBS_DIR.length)));
+
+  it('found job modules to scan', () => {
+    expect(files.length).toBeGreaterThan(10);
+  });
+
+  it.each(files.map((f) => [f.slice(JOBS_DIR.length), f]))('%s', (_label, full) => {
+    const src = readFileSync(full, 'utf8');
+    for (const [what, pattern] of FORBIDDEN_PATTERNS) {
+      expect(src, `${what} — route through services/agentCommandRelay instead`).not.toMatch(pattern);
+    }
+  });
+});

--- a/apps/api/src/jobs/backupWorker.dbcontext.test.ts
+++ b/apps/api/src/jobs/backupWorker.dbcontext.test.ts
@@ -1,0 +1,275 @@
+/**
+ * backupWorker DB-context scoping (#1105 class, final-review fix for wave
+ * 3.5b #4084).
+ *
+ * The regression this locks down: the ENTIRE worker-handler switch — every
+ * job type, including `dispatch-backup` — used to run inside one blanket
+ * `runWithSystemDbAccess` wrap. `dispatch-backup`'s per-target loop then
+ * called `recordDispatchedExpectation` (Redis SET) and `dispatchCommandToAgent`
+ * (Redis/WS I/O via the agentCommandRelay facade, with an ack-wait poll loop
+ * up to RELAY_DELIVERY_DEADLINE_MS) once PER TARGET, so a pooled Postgres
+ * connection sat idle-in-transaction for up to `targets.length *
+ * RELAY_DELIVERY_DEADLINE_MS`.
+ *
+ * An identity `fn => fn()` mock of the context helper (what
+ * backupWorker.test.ts uses, since it isn't asserting context depth) can
+ * never catch that, so the mock below tracks real enter/exit depth and the
+ * tests assert WHICH depth each DB read/write and each facade call happened
+ * at — mirroring snmpWorker.dbcontext.test.ts's harness. Exercised directly
+ * against `__testOnly.processDispatchBackup`, same as backupWorker.test.ts's
+ * existing facade-dispatch suite (single-target case only — the fix's own
+ * comment documents that a cancellation flag flipped mid-Phase-4 no longer
+ * aborts remaining sends early, which this file does not re-litigate).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DispatchOutcome } from '../services/agentCommandRelay';
+
+const { mockDb, ctxState } = vi.hoisted(() => ({
+  mockDb: {
+    select: vi.fn(),
+    update: vi.fn(),
+    insert: vi.fn(),
+  },
+  // DB-access-context depth + an ordered event log, so a test can prove which
+  // work runs inside a held transaction and which runs after it closes.
+  ctxState: { depth: 0, events: [] as string[] },
+}));
+
+vi.mock('../db', () => ({
+  db: mockDb,
+  // Real-ish context wrapper: tracks depth around fn so the tests can assert
+  // what runs inside the context vs after it closes. Unlike
+  // backupWorker.test.ts (which sets this to `undefined` for an identity
+  // fallback), this is the whole point of this file.
+  withSystemDbAccessContext: async (fn: () => unknown) => {
+    ctxState.depth++;
+    ctxState.events.push('ctx:enter');
+    try {
+      return await fn();
+    } finally {
+      ctxState.depth--;
+      ctxState.events.push('ctx:exit');
+    }
+  },
+  runOutsideDbContext: <T>(fn: () => T): T => fn(),
+  SYSTEM_DB_ACCESS_CONTEXT: { scope: 'system', orgId: null, partnerId: null },
+}));
+
+vi.mock('./backupRetention', () => ({
+  cleanupExpiredSnapshots: vi.fn(),
+  sweepUnreferencedBackupObjects: vi.fn(),
+}));
+
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+
+vi.mock('../services/backupResultPersistence', () => ({
+  applyBackupCommandResultToJob: vi.fn(async () => ({ applied: true, snapshotDbId: null, providerSnapshotId: null })),
+  markBackupJobFailedIfInFlight: vi.fn(),
+}));
+
+const recordDispatchedExpectationMock = vi.fn(async () => {
+  ctxState.events.push(`recordExpectation@depth${ctxState.depth}`);
+});
+vi.mock('../services/agentWorkExpectation', () => ({
+  recordDispatchedExpectation: recordDispatchedExpectationMock,
+}));
+
+const agentRelayMock = {
+  isAgentConnectedAnywhere: vi.fn(async () => true),
+  dispatchCommandToAgent: vi.fn(async (): Promise<DispatchOutcome> => ({ status: 'sent', via: 'local' })),
+};
+vi.mock('../services/agentCommandRelay', () => ({
+  isAgentConnectedAnywhere: agentRelayMock.isAgentConnectedAnywhere,
+  dispatchCommandToAgent: agentRelayMock.dispatchCommandToAgent,
+}));
+
+const { __testOnly } = await import('./backupWorker');
+
+describe('processDispatchBackup DB-context scoping (final-review fix, #4084/#1105)', () => {
+  const DATA = { type: 'dispatch-backup' as const, jobId: 'job-1', configId: 'config-1', orgId: 'org-1', deviceId: 'device-1' };
+  const CONFIG_ROW = { id: 'config-1', provider: 'local', providerConfig: {}, encryption: false };
+  const JOB_ROW = { featureLinkId: null, backupMode: 'file', modeTargets: { paths: ['/data'] } };
+
+  // Route every db.select() call by the shape of its column-selector argument
+  // (mirrors backupWorker.test.ts's wireSelects), logging the depth each read
+  // ran at. `cancelled` is a live flag so a test can flip mid-run if needed;
+  // none currently do.
+  function wireSelects(opts: { cancelled?: boolean; configFound?: boolean } = {}) {
+    const cancelled = opts.cancelled ?? false;
+    const configFound = opts.configFound ?? true;
+    mockDb.select.mockImplementation(((cols?: Record<string, unknown>) => {
+      const keys = cols ? Object.keys(cols) : [];
+      let rows: unknown[];
+      let label: string;
+      if (keys.length === 0) {
+        rows = configFound ? [CONFIG_ROW] : []; label = 'configSelect'; // config load: db.select() with no arg
+      } else if (keys.length === 1 && keys[0] === 'status') {
+        rows = cancelled ? [{ status: 'cancelled' }] : []; label = 'cancelledSelect'; // isBackupJobCancelled
+      } else if (keys.length === 1 && keys[0] === 'agentId') {
+        rows = [{ agentId: 'agent-1' }]; label = 'deviceSelect'; // device -> agent lookup
+      } else if (keys.includes('featureLinkId')) {
+        rows = [JOB_ROW]; label = 'jobSelect'; // job mode lookup
+      } else {
+        throw new Error(`unexpected select shape: ${JSON.stringify(keys)}`);
+      }
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockImplementation(async () => {
+              ctxState.events.push(`${label}@depth${ctxState.depth}`);
+              return rows;
+            }),
+          }),
+        }),
+      };
+    }) as never);
+  }
+
+  function wireUpdates() {
+    mockDb.update.mockImplementation((() => ({
+      set: (payload: Record<string, unknown>) => ({
+        where: async () => {
+          const label =
+            payload.status === 'running' ? 'statusRunning'
+            : payload.status === 'failed' ? 'markFailed'
+            : 'errorLog' in payload ? 'partialErrorLog'
+            : 'update';
+          ctxState.events.push(`${label}@depth${ctxState.depth}`);
+        },
+      }),
+    })) as never);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctxState.depth = 0;
+    ctxState.events = [];
+    wireSelects();
+    wireUpdates();
+    agentRelayMock.isAgentConnectedAnywhere.mockImplementation(async () => {
+      ctxState.events.push(`isAgentConnected@depth${ctxState.depth}`);
+      return true;
+    });
+    agentRelayMock.dispatchCommandToAgent.mockImplementation(async () => {
+      ctxState.events.push(`wsDispatch@depth${ctxState.depth}`);
+      return { status: 'sent', via: 'local' };
+    });
+  });
+
+  it('runs precheck reads, prepare reads/writes and the final settle in short contexts, with connectivity + dispatch OUTSIDE all of them', async () => {
+    const result = await __testOnly.processDispatchBackup(DATA as any);
+
+    expect(result).toEqual({ dispatched: true });
+    expect(ctxState.events).toEqual([
+      // Phase 1 (precheck): cancellation guard, config load, cancellation
+      // guard again, agent lookup — ONE short context.
+      'ctx:enter',
+      'cancelledSelect@depth1',
+      'configSelect@depth1',
+      'cancelledSelect@depth1',
+      'deviceSelect@depth1',
+      'ctx:exit',
+      // Phase 2: connectivity check, NO context held.
+      'isAgentConnected@depth0',
+      // Phase 3 (prepare): mode resolution, cancellation guards, the
+      // single-target loop's own cancellation check and
+      // recordDispatchedExpectation — ONE short context, closed before any
+      // send.
+      'ctx:enter',
+      'cancelledSelect@depth1',
+      'jobSelect@depth1',
+      'cancelledSelect@depth1',
+      'cancelledSelect@depth1',
+      'recordExpectation@depth1',
+      'ctx:exit',
+      // Phase 4: the actual send, NO context held. This is the #1105 fix —
+      // this call used to run at depth1, pinning a pooled connection across
+      // dispatchCommandToAgent's ack-wait poll.
+      'wsDispatch@depth0',
+      // Phase 5 (settle): final cancellation guard + status flip — ONE short
+      // context.
+      'ctx:enter',
+      'cancelledSelect@depth1',
+      'statusRunning@depth1',
+      'ctx:exit',
+    ]);
+  });
+
+  it('marks the job failed with "Agent not connected" inside its own short context when no agent is connected anywhere, without dispatching', async () => {
+    agentRelayMock.isAgentConnectedAnywhere.mockImplementation(async () => {
+      ctxState.events.push(`isAgentConnected@depth${ctxState.depth}`);
+      return false;
+    });
+
+    const result = await __testOnly.processDispatchBackup(DATA as any);
+
+    expect(result).toEqual({ dispatched: false });
+    expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+    expect(recordDispatchedExpectationMock).not.toHaveBeenCalled();
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'cancelledSelect@depth1',
+      'configSelect@depth1',
+      'cancelledSelect@depth1',
+      'deviceSelect@depth1',
+      'ctx:exit',
+      'isAgentConnected@depth0',
+      // markJobFailed reopens its own short context — it must NOT run inside
+      // Phase 1's (already-closed) context.
+      'ctx:enter',
+      'markFailed@depth1',
+      'ctx:exit',
+    ]);
+  });
+
+  it('holds no context past Phase 1 when the config is missing', async () => {
+    wireSelects({ configFound: false });
+
+    const result = await __testOnly.processDispatchBackup(DATA as any);
+
+    expect(result).toEqual({ dispatched: false });
+    expect(agentRelayMock.isAgentConnectedAnywhere).not.toHaveBeenCalled();
+    expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'cancelledSelect@depth1',
+      'configSelect@depth1',
+      'markFailed@depth1',
+      'ctx:exit',
+    ]);
+  });
+
+  it('marks the job failed in Phase 5 (its own short context) when the outcome is offline', async () => {
+    agentRelayMock.dispatchCommandToAgent.mockImplementation(async () => {
+      ctxState.events.push(`wsDispatch@depth${ctxState.depth}`);
+      return { status: 'offline' };
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await __testOnly.processDispatchBackup(DATA as any);
+
+    expect(result).toEqual({ dispatched: false });
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'cancelledSelect@depth1',
+      'configSelect@depth1',
+      'cancelledSelect@depth1',
+      'deviceSelect@depth1',
+      'ctx:exit',
+      'isAgentConnected@depth0',
+      'ctx:enter',
+      'cancelledSelect@depth1',
+      'jobSelect@depth1',
+      'cancelledSelect@depth1',
+      'cancelledSelect@depth1',
+      'recordExpectation@depth1',
+      'ctx:exit',
+      'wsDispatch@depth0',
+      'ctx:enter',
+      'cancelledSelect@depth1',
+      'markFailed@depth1',
+      'ctx:exit',
+    ]);
+    warn.mockRestore();
+  });
+});

--- a/apps/api/src/jobs/backupWorker.test.ts
+++ b/apps/api/src/jobs/backupWorker.test.ts
@@ -610,6 +610,15 @@ describe('processDispatchBackup (wave 3.5b #4084 — dispatch via facade)', () =
 
     expect(result).toEqual({ dispatched: false });
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/dispatch outcome indeterminate/i));
+    // The persisted job errorLog (not just the console.warn) must name the
+    // outcome so ops/dashboards can distinguish "maybe sent" (indeterminate)
+    // from a genuine "offline" — same distinct-message contract as
+    // discoveryWorker. Single target reuses the original jobId, so the only
+    // observable failure signal is the final markJobFailed UPDATE.
+    expect(
+      updateLog.some((u) => u.payload.errorLog === 'Failed to send command to agent (dispatch outcome indeterminate)')
+    ).toBe(true);
+    expect(updateLog.some((u) => u.payload.errorLog === 'Failed to send command to agent')).toBe(false);
     warn.mockRestore();
   });
 

--- a/apps/api/src/jobs/backupWorker.test.ts
+++ b/apps/api/src/jobs/backupWorker.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DispatchOutcome } from '../services/agentCommandRelay';
 
 // Mock db module — backupWorker uses `import * as dbModule from '../db'`
 // then destructures: `const { db } = dbModule;`
@@ -8,6 +9,7 @@ const mockDb = {
   where: vi.fn().mockReturnThis(),
   limit: vi.fn().mockResolvedValue([]),
   selectDistinct: vi.fn(),
+  update: vi.fn(),
 };
 
 vi.mock('../db', () => ({
@@ -37,6 +39,20 @@ const markBackupJobFailedIfInFlightMock = vi.fn();
 vi.mock('../services/backupResultPersistence', () => ({
   applyBackupCommandResultToJob: applyBackupCommandResultToJobMock,
   markBackupJobFailedIfInFlight: markBackupJobFailedIfInFlightMock,
+}));
+
+const recordDispatchedExpectationMock = vi.fn(async () => undefined);
+vi.mock('../services/agentWorkExpectation', () => ({
+  recordDispatchedExpectation: recordDispatchedExpectationMock,
+}));
+
+const agentRelayMock = {
+  isAgentConnectedAnywhere: vi.fn(async () => true),
+  dispatchCommandToAgent: vi.fn(async (): Promise<DispatchOutcome> => ({ status: 'sent', via: 'local' })),
+};
+vi.mock('../services/agentCommandRelay', () => ({
+  isAgentConnectedAnywhere: agentRelayMock.isAgentConnectedAnywhere,
+  dispatchCommandToAgent: agentRelayMock.dispatchCommandToAgent,
 }));
 
 // Must import AFTER mock so the module-level destructure picks up our mock
@@ -497,5 +513,112 @@ describe('processResults — malformed payload path rendering (#3260)', () => {
     expect(message).toMatch(/^Malformed backup result payload:/);
     expect(message).toContain('filesBackedUp');
     expect(message).not.toContain('<root>');
+  });
+});
+
+describe('processDispatchBackup (wave 3.5b #4084 — dispatch via facade)', () => {
+  const DATA = { type: 'dispatch-backup' as const, jobId: 'job-1', configId: 'config-1', orgId: 'org-1', deviceId: 'device-1' };
+  const CONFIG_ROW = { id: 'config-1', provider: 'local', providerConfig: {}, encryption: false };
+  const updateLog: Array<{ table: unknown; payload: Record<string, unknown> }> = [];
+
+  // Route every db.select() call by the shape of its column-selector argument
+  // (all these queries hit different tables/columns, real schema refs — not
+  // stringly-typed, so we key off which fields were requested).
+  function wireSelects() {
+    mockDb.select.mockImplementation(((cols?: Record<string, unknown>) => {
+      const keys = cols ? Object.keys(cols) : [];
+      let rows: unknown[];
+      if (keys.length === 0) {
+        rows = [CONFIG_ROW]; // config load: db.select() with no arg
+      } else if (keys.length === 1 && keys[0] === 'status') {
+        rows = []; // isBackupJobCancelled: never cancelled
+      } else if (keys.length === 1 && keys[0] === 'agentId') {
+        rows = [{ agentId: 'agent-1' }]; // device -> agent lookup
+      } else if (keys.includes('featureLinkId')) {
+        rows = [{ featureLinkId: null, backupMode: 'file', modeTargets: { paths: ['/data'] } }]; // job mode lookup
+      } else {
+        throw new Error(`unexpected select shape: ${JSON.stringify(keys)}`);
+      }
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(rows),
+          }),
+        }),
+      };
+    }) as never);
+  }
+
+  function wireUpdates() {
+    mockDb.update.mockImplementation(((table: unknown) => ({
+      set: (payload: Record<string, unknown>) => ({
+        where: async () => {
+          updateLog.push({ table, payload });
+        },
+      }),
+    })) as never);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateLog.length = 0;
+    wireSelects();
+    wireUpdates();
+    agentRelayMock.isAgentConnectedAnywhere.mockResolvedValue(true);
+    agentRelayMock.dispatchCommandToAgent.mockResolvedValue({ status: 'sent', via: 'local' });
+  });
+
+  it('marks the job failed with "Agent not connected" (byte-identical to today) when no agent is connected anywhere, without calling dispatch', async () => {
+    agentRelayMock.isAgentConnectedAnywhere.mockResolvedValue(false);
+
+    const result = await __testOnly.processDispatchBackup(DATA as any);
+
+    expect(result).toEqual({ dispatched: false });
+    expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+    expect(updateLog.some((u) => u.payload.errorLog === 'Agent not connected')).toBe(true);
+  });
+
+  it('dispatches normally (sentCount incremented) when the outcome is sent', async () => {
+    const result = await __testOnly.processDispatchBackup(DATA as any);
+
+    expect(result).toEqual({ dispatched: true });
+    // Final status flip to 'running' proves sentCount > 0 took the happy path.
+    expect(updateLog.some((u) => u.payload.status === 'running')).toBe(true);
+    expect(updateLog.some((u) => typeof u.payload.errorLog === 'string' && u.payload.errorLog.includes('Failed to send'))).toBe(false);
+  });
+
+  it('marks the target failed with "Failed to send ... command to agent" (today\'s message) when the outcome is offline', async () => {
+    agentRelayMock.dispatchCommandToAgent.mockResolvedValue({ status: 'offline' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await __testOnly.processDispatchBackup(DATA as any);
+
+    expect(result).toEqual({ dispatched: false });
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/^\[BackupWorker\] Failed to send backup_run command to agent for job/));
+    // Single target reuses the original jobId, so no per-target failed-row
+    // UPDATE fires (that branch only runs when commandJobId !== data.jobId);
+    // the only observable failure signal is the final markJobFailed.
+    expect(updateLog.some((u) => u.payload.errorLog === 'Failed to send command to agent')).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('marks the job failed naming the outcome when indeterminate (still may have been sent)', async () => {
+    agentRelayMock.dispatchCommandToAgent.mockResolvedValue({ status: 'indeterminate' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await __testOnly.processDispatchBackup(DATA as any);
+
+    expect(result).toEqual({ dispatched: false });
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/dispatch outcome indeterminate/i));
+    warn.mockRestore();
+  });
+
+  it('calls recordDispatchedExpectation BEFORE dispatchCommandToAgent (expectation-first, backupWorker.ts:645-651)', async () => {
+    await __testOnly.processDispatchBackup(DATA as any);
+
+    expect(recordDispatchedExpectationMock).toHaveBeenCalledWith('backup', 'device-1', 'job-1');
+    const expectationOrder = recordDispatchedExpectationMock.mock.invocationCallOrder[0] as number;
+    const dispatchOrder = agentRelayMock.dispatchCommandToAgent.mock.invocationCallOrder[0] as number;
+    expect(expectationOrder).toBeLessThan(dispatchOrder);
   });
 });

--- a/apps/api/src/jobs/backupWorker.ts
+++ b/apps/api/src/jobs/backupWorker.ts
@@ -26,11 +26,8 @@ import { recoveryTokens } from '../db/schema/recoveryTokens';
 import { eq, ne, and, sql, isNull, lt, inArray } from 'drizzle-orm';
 import { resolveAllBackupAssignedDevices } from '../services/featureConfigResolver';
 import { getBullMQConnection } from '../services/redis';
-import {
-  sendCommandToAgent,
-  isAgentConnected,
-  type AgentCommand,
-} from '../routes/agentWs';
+import { dispatchCommandToAgent, isAgentConnectedAnywhere } from '../services/agentCommandRelay';
+import type { AgentCommand } from '../routes/agentWs';
 import {
   cleanupExpiredSnapshots,
   sweepUnreferencedBackupObjects,
@@ -499,7 +496,7 @@ async function processDispatchBackup(
     .limit(1);
 
   const agentId = device?.agentId;
-  if (!agentId || !isAgentConnected(agentId)) {
+  if (!agentId || !(await isAgentConnectedAnywhere(agentId))) {
     await markJobFailed(data.jobId, 'Agent not connected');
     return { dispatched: false };
   }
@@ -650,17 +647,19 @@ async function processDispatchBackup(
     // fail-closed on arrival (dropped), not trusted.
     await recordDispatchedExpectation('backup', data.deviceId, commandJobId);
 
-    const sent = sendCommandToAgent(agentId, command);
-    if (sent) {
+    const outcome = await dispatchCommandToAgent(agentId, command);
+    if (outcome.status === 'sent') {
       sentCount++;
     } else {
-      console.warn(`[BackupWorker] Failed to send ${target.commandType} command for job ${commandJobId}`);
+      const detail = outcome.status === 'offline'
+        ? `Failed to send ${target.commandType} command to agent`
+        : `Failed to send ${target.commandType} command to agent (dispatch outcome ${outcome.status})`;
+      console.warn(`[BackupWorker] ${detail} for job ${commandJobId}`);
       failedTargets.push(target.commandType);
-      // Mark the child job as failed so it doesn't stay orphaned in "running"
       if (commandJobId !== data.jobId) {
         await db
           .update(backupJobs)
-          .set({ status: 'failed', completedAt: new Date(), updatedAt: new Date(), errorLog: `Failed to send ${target.commandType} command to agent` })
+          .set({ status: 'failed', completedAt: new Date(), updatedAt: new Date(), errorLog: detail })
           .where(eq(backupJobs.id, commandJobId));
       }
     }
@@ -879,4 +878,6 @@ export const __testOnly = {
   // thing carrying a `partial` run from the queue payload into persistence, and
   // dropping that one argument silently reverts #3000 with nothing going red.
   processResults,
+  // Exposed for the wave 3.5b (#4084) dispatch-facade migration tests.
+  processDispatchBackup,
 };

--- a/apps/api/src/jobs/backupWorker.ts
+++ b/apps/api/src/jobs/backupWorker.ts
@@ -786,15 +786,18 @@ async function processDispatchBackup(
   // Phase 5 — settle per-target failure rows and the final job status: one
   // more short system DB context.
   return runWithSystemDbAccess(async () => {
-    if (await isBackupJobCancelled(data.jobId)) {
-      return { dispatched: false };
-    }
-
+    // Failed-send child rows settle UNCONDITIONALLY, before the cancel check —
+    // a cancel racing the sends must not strand them at status 'running' (the
+    // cancel route only touches the parent id, nothing else sweeps children).
     for (const failure of failedChildJobs) {
       await db
         .update(backupJobs)
         .set({ status: 'failed', completedAt: new Date(), updatedAt: new Date(), errorLog: failure.detail })
         .where(eq(backupJobs.id, failure.commandJobId));
+    }
+
+    if (await isBackupJobCancelled(data.jobId)) {
+      return { dispatched: false };
     }
 
     if (sentCount === 0) {

--- a/apps/api/src/jobs/backupWorker.ts
+++ b/apps/api/src/jobs/backupWorker.ts
@@ -78,8 +78,19 @@ function createBackupWorker(): Worker<BackupQueueJobData> {
   return new Worker<BackupQueueJobData>(
     BACKUP_QUEUE,
     async (job: Job<BackupQueueJobData>) => {
+      const data = parseQueueJobData(BACKUP_QUEUE, job, backupQueueJobDataSchema);
+      // dispatch-backup is handled OUTSIDE the blanket context below (#1105):
+      // it does Redis/WS I/O via the agentCommandRelay facade
+      // (isAgentConnectedAnywhere, recordDispatchedExpectation,
+      // dispatchCommandToAgent — the latter's ack wait is a poll loop up to
+      // RELAY_DELIVERY_DEADLINE_MS), and processDispatchBackup manages its own
+      // short-lived system DB contexts around just its reads/writes so no
+      // pooled connection sits idle-in-transaction across that I/O.
+      if (data.type === 'dispatch-backup') {
+        assertQueueJobName(BACKUP_QUEUE, job, 'dispatch-backup');
+        return await processDispatchBackup(data);
+      }
       return runWithSystemDbAccess(async () => {
-        const data = parseQueueJobData(BACKUP_QUEUE, job, backupQueueJobDataSchema);
         switch (data.type) {
           case 'check-schedules':
             assertQueueJobName(BACKUP_QUEUE, job, 'check-schedules');
@@ -90,9 +101,6 @@ function createBackupWorker(): Worker<BackupQueueJobData> {
           case 'cleanup-expired-snapshots':
             assertQueueJobName(BACKUP_QUEUE, job, 'cleanup-expired-snapshots');
             return await processCleanupExpiredSnapshots();
-          case 'dispatch-backup':
-            assertQueueJobName(BACKUP_QUEUE, job, 'dispatch-backup');
-            return await processDispatchBackup(data);
           case 'process-results':
             assertQueueJobName(BACKUP_QUEUE, job, 'process-results');
             return await processResults(data);
@@ -464,12 +472,53 @@ export async function resolveBackupTargets(
 }
 
 // ── dispatch-backup ───────────────────────────────────────────────────────────
+//
+// #1105 phase split (final-review fix, wave 3.5b #4084): processDispatchBackup
+// used to run entirely inside the worker's blanket `runWithSystemDbAccess`
+// wrap, so `isAgentConnectedAnywhere`, `recordDispatchedExpectation` and
+// `dispatchCommandToAgent` — all Redis/WS I/O via the agentCommandRelay
+// facade, the last with an ack-wait poll loop up to
+// RELAY_DELIVERY_DEADLINE_MS — ran with a pooled Postgres connection pinned
+// idle-in-transaction, multiplied by target count in the per-target loop.
+//
+// Fixed by splitting into short-lived contexts around just the DB work, with
+// every facade call at depth 0:
+//   Phase 1 (context)  loadBackupDispatchPrecheck    — cancellation, config, agent lookup
+//   Phase 2 (no ctx)   isAgentConnectedAnywhere        — connectivity (facade)
+//   Phase 3 (context)  prepareBackupDispatchTargets   — mode/targets, per-target
+//                                                        command build + child job
+//                                                        rows + recordDispatchedExpectation
+//   Phase 4 (no ctx)   dispatchCommandToAgent per target — the actual sends (facade)
+//   Phase 5 (context)  settle child-job failures + final job status
+//
+// recordDispatchedExpectation is a single Redis SET, not the unbounded ack
+// poll — it stays in Phase 3's context deliberately (that's the at-most-once
+// bookkeeping for a send that is about to happen, not the hazard this split
+// exists to remove).
+//
+// Behavior note: cancellation is now checked at the start of each phase and at
+// each Phase-3 loop iteration (as before), but NOT re-checked between
+// individual Phase-4 sends — those all run after Phase 3's context has
+// closed, so there is no DB read to interleave without reopening a context per
+// target. A cancellation that lands mid-Phase-4 no longer aborts the
+// remaining sends early; it still fails the job via the usual result handling
+// once Phase 5 re-checks it.
 
-async function processDispatchBackup(
+type BackupDispatchPrecheck =
+  | { status: 'done'; result: { dispatched: boolean } }
+  | { status: 'ok'; config: typeof backupConfigs.$inferSelect; agentId: string };
+
+/**
+ * Phase 1: cancellation guard, config load and the agent lookup, inside ONE
+ * short system DB context. Deliberately stops short of the connectivity
+ * check — `isAgentConnectedAnywhere` is Redis I/O via the agentCommandRelay
+ * facade and must run with no context held (#1105).
+ */
+async function loadBackupDispatchPrecheck(
   data: DispatchBackupJobData
-): Promise<{ dispatched: boolean }> {
+): Promise<BackupDispatchPrecheck> {
   if (await isBackupJobCancelled(data.jobId)) {
-    return { dispatched: false };
+    return { status: 'done', result: { dispatched: false } };
   }
 
   // Load config for command payload
@@ -481,11 +530,11 @@ async function processDispatchBackup(
 
   if (!config) {
     await markJobFailed(data.jobId, 'Backup config not found');
-    return { dispatched: false };
+    return { status: 'done', result: { dispatched: false } };
   }
 
   if (await isBackupJobCancelled(data.jobId)) {
-    return { dispatched: false };
+    return { status: 'done', result: { dispatched: false } };
   }
 
   // Find the agent for this device
@@ -496,13 +545,42 @@ async function processDispatchBackup(
     .limit(1);
 
   const agentId = device?.agentId;
-  if (!agentId || !(await isAgentConnectedAnywhere(agentId))) {
+  if (!agentId) {
     await markJobFailed(data.jobId, 'Agent not connected');
-    return { dispatched: false };
+    return { status: 'done', result: { dispatched: false } };
   }
 
+  return { status: 'ok', config, agentId };
+}
+
+interface PreparedBackupTarget {
+  commandJobId: string;
+  command: AgentCommand;
+  commandType: string;
+}
+
+type BackupDispatchPrepare =
+  | { status: 'done'; result: { dispatched: boolean } }
+  | {
+      status: 'ok';
+      prepared: PreparedBackupTarget[];
+      preFailedTargets: string[];
+      backupMode: string;
+      targetCount: number;
+    };
+
+/**
+ * Phase 3: resolve the backup mode/targets, build every target's command
+ * payload and record its dispatch expectation — all inside ONE short system
+ * DB context (#1105). Nothing here calls `dispatchCommandToAgent`; that send
+ * happens in Phase 4, after this context has closed.
+ */
+async function prepareBackupDispatchTargets(
+  data: DispatchBackupJobData,
+  config: typeof backupConfigs.$inferSelect,
+): Promise<BackupDispatchPrepare> {
   if (await isBackupJobCancelled(data.jobId)) {
-    return { dispatched: false };
+    return { status: 'done', result: { dispatched: false } };
   }
 
   // Resolve backup mode: fan-out jobs carry their own selection (profile
@@ -543,7 +621,7 @@ async function processDispatchBackup(
   const targets = await resolveBackupTargets(backupMode, modeTargets, data.deviceId);
 
   if (await isBackupJobCancelled(data.jobId)) {
-    return { dispatched: false };
+    return { status: 'done', result: { dispatched: false } };
   }
 
   if (targets.length === 0) {
@@ -557,7 +635,7 @@ async function processDispatchBackup(
         errorLog: `No backup targets resolved (mode=${backupMode}). Ensure discovery has been run for this device.`,
       })
       .where(eq(backupJobs.id, data.jobId));
-    return { dispatched: false };
+    return { status: 'done', result: { dispatched: false } };
   }
 
   const providerConfig = config.providerConfig as Record<string, unknown>;
@@ -568,20 +646,20 @@ async function processDispatchBackup(
   });
   if (encryptionPlan.required && encryptionPlan.status === 'unsupported') {
     await markJobFailed(data.jobId, encryptionPlan.reason);
-    return { dispatched: false };
+    return { status: 'done', result: { dispatched: false } };
   }
 
   const commandProviderConfig =
     encryptionPlan.required && encryptionPlan.status === 'enforced'
       ? { ...providerConfig, ...encryptionPlan.providerConfigPatch }
       : providerConfig;
-  let sentCount = 0;
-  const failedTargets: string[] = [];
-  let lastNonOfflineOutcomeStatus: string | null = null;
+
+  const prepared: PreparedBackupTarget[] = [];
+  const preFailedTargets: string[] = [];
 
   for (let i = 0; i < targets.length; i++) {
     if (await isBackupJobCancelled(data.jobId)) {
-      return { dispatched: false };
+      return { status: 'done', result: { dispatched: false } };
     }
 
     const target = targets[i]!;
@@ -605,14 +683,14 @@ async function processDispatchBackup(
         .returning();
       if (!newJob?.id) {
         console.error(`[BackupWorker] Failed to create child job for target ${i} (${target.commandType}), skipping`);
-        failedTargets.push(`${target.commandType} (job creation failed)`);
+        preFailedTargets.push(`${target.commandType} (job creation failed)`);
         continue;
       }
       commandJobId = newJob.id;
 
       if (await isBackupJobCancelled(data.jobId)) {
         await markBackupJobCancelled(commandJobId, 'Cancelled before dispatch');
-        return { dispatched: false };
+        return { status: 'done', result: { dispatched: false } };
       }
     }
 
@@ -648,67 +726,114 @@ async function processDispatchBackup(
     // fail-closed on arrival (dropped), not trusted.
     await recordDispatchedExpectation('backup', data.deviceId, commandJobId);
 
-    const outcome = await dispatchCommandToAgent(agentId, command);
+    prepared.push({ commandJobId, command, commandType: target.commandType });
+  }
+
+  return { status: 'ok', prepared, preFailedTargets, backupMode, targetCount: targets.length };
+}
+
+async function processDispatchBackup(
+  data: DispatchBackupJobData
+): Promise<{ dispatched: boolean }> {
+  // Phase 1 — cancellation guard, config load, agent lookup: ONE short system
+  // DB context, then it CLOSES.
+  const precheck = await runWithSystemDbAccess(() => loadBackupDispatchPrecheck(data));
+  if (precheck.status === 'done') return precheck.result;
+  const { config, agentId } = precheck;
+
+  // Phase 2 — connectivity check with NO DB context open (#1105).
+  if (!(await isAgentConnectedAnywhere(agentId))) {
+    await runWithSystemDbAccess(() => markJobFailed(data.jobId, 'Agent not connected'));
+    return { dispatched: false };
+  }
+
+  // Phase 3 — resolve targets, build every command payload and record its
+  // dispatch expectation: another short system DB context, then it CLOSES
+  // before any target is actually sent.
+  const prepare = await runWithSystemDbAccess(() => prepareBackupDispatchTargets(data, config));
+  if (prepare.status === 'done') return prepare.result;
+  const { prepared, preFailedTargets, backupMode, targetCount } = prepare;
+
+  // Phase 4 — the actual WS/relay sends, NO DB context open. Each
+  // dispatchCommandToAgent call may poll for a relay ack for up to
+  // RELAY_DELIVERY_DEADLINE_MS; holding a transaction across `targetCount` of
+  // these is exactly the #1105 hold this split removes.
+  let sentCount = 0;
+  const failedTargets: string[] = [...preFailedTargets];
+  let lastNonOfflineOutcomeStatus: string | null = null;
+  const failedChildJobs: Array<{ commandJobId: string; detail: string }> = [];
+
+  for (const target of prepared) {
+    const outcome = await dispatchCommandToAgent(agentId, target.command);
     if (outcome.status === 'sent') {
       sentCount++;
-    } else {
-      const detail = outcome.status === 'offline'
-        ? `Failed to send ${target.commandType} command to agent`
-        : `Failed to send ${target.commandType} command to agent (dispatch outcome ${outcome.status})`;
-      console.warn(`[BackupWorker] ${detail} for job ${commandJobId}`);
-      failedTargets.push(target.commandType);
-      if (outcome.status !== 'offline') {
-        lastNonOfflineOutcomeStatus = outcome.status;
-      }
-      if (commandJobId !== data.jobId) {
-        await db
-          .update(backupJobs)
-          .set({ status: 'failed', completedAt: new Date(), updatedAt: new Date(), errorLog: detail })
-          .where(eq(backupJobs.id, commandJobId));
-      }
+      continue;
+    }
+
+    const detail = outcome.status === 'offline'
+      ? `Failed to send ${target.commandType} command to agent`
+      : `Failed to send ${target.commandType} command to agent (dispatch outcome ${outcome.status})`;
+    console.warn(`[BackupWorker] ${detail} for job ${target.commandJobId}`);
+    failedTargets.push(target.commandType);
+    if (outcome.status !== 'offline') {
+      lastNonOfflineOutcomeStatus = outcome.status;
+    }
+    if (target.commandJobId !== data.jobId) {
+      failedChildJobs.push({ commandJobId: target.commandJobId, detail });
     }
   }
 
-  if (await isBackupJobCancelled(data.jobId)) {
-    return { dispatched: false };
-  }
+  // Phase 5 — settle per-target failure rows and the final job status: one
+  // more short system DB context.
+  return runWithSystemDbAccess(async () => {
+    if (await isBackupJobCancelled(data.jobId)) {
+      return { dispatched: false };
+    }
 
-  if (sentCount === 0) {
-    await markJobFailed(
-      data.jobId,
-      lastNonOfflineOutcomeStatus
-        ? `Failed to send command to agent (dispatch outcome ${lastNonOfflineOutcomeStatus})`
-        : 'Failed to send command to agent',
-    );
-    return { dispatched: false };
-  }
+    for (const failure of failedChildJobs) {
+      await db
+        .update(backupJobs)
+        .set({ status: 'failed', completedAt: new Date(), updatedAt: new Date(), errorLog: failure.detail })
+        .where(eq(backupJobs.id, failure.commandJobId));
+    }
 
-  if (failedTargets.length > 0) {
-    console.warn(
-      `[BackupWorker] Partial dispatch for job ${data.jobId}: ${sentCount}/${targets.length} sent, failed targets: ${failedTargets.join(', ')}`
-    );
+    if (sentCount === 0) {
+      await markJobFailed(
+        data.jobId,
+        lastNonOfflineOutcomeStatus
+          ? `Failed to send command to agent (dispatch outcome ${lastNonOfflineOutcomeStatus})`
+          : 'Failed to send command to agent',
+      );
+      return { dispatched: false };
+    }
+
+    if (failedTargets.length > 0) {
+      console.warn(
+        `[BackupWorker] Partial dispatch for job ${data.jobId}: ${sentCount}/${targetCount} sent, failed targets: ${failedTargets.join(', ')}`
+      );
+      await db
+        .update(backupJobs)
+        .set({ errorLog: `Partial dispatch: ${failedTargets.length} target(s) failed to send (${failedTargets.join(', ')})`, updatedAt: new Date() })
+        .where(eq(backupJobs.id, data.jobId));
+    }
+
     await db
       .update(backupJobs)
-      .set({ errorLog: `Partial dispatch: ${failedTargets.length} target(s) failed to send (${failedTargets.join(', ')})`, updatedAt: new Date() })
-      .where(eq(backupJobs.id, data.jobId));
-  }
+      .set({
+        status: 'running',
+        startedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(backupJobs.id, data.jobId),
+        inArray(backupJobs.status, ['pending', 'running'])
+      ));
 
-  await db
-    .update(backupJobs)
-    .set({
-      status: 'running',
-      startedAt: new Date(),
-      updatedAt: new Date(),
-    })
-    .where(and(
-      eq(backupJobs.id, data.jobId),
-      inArray(backupJobs.status, ['pending', 'running'])
-    ));
-
-  console.log(
-    `[BackupWorker] Dispatched ${sentCount}/${targets.length} ${backupMode} command(s) to agent ${agentId} for job ${data.jobId}`
-  );
-  return { dispatched: true };
+    console.log(
+      `[BackupWorker] Dispatched ${sentCount}/${targetCount} ${backupMode} command(s) to agent ${agentId} for job ${data.jobId}`
+    );
+    return { dispatched: true };
+  });
 }
 
 // ── process-results ───────────────────────────────────────────────────────────

--- a/apps/api/src/jobs/backupWorker.ts
+++ b/apps/api/src/jobs/backupWorker.ts
@@ -577,6 +577,7 @@ async function processDispatchBackup(
       : providerConfig;
   let sentCount = 0;
   const failedTargets: string[] = [];
+  let lastNonOfflineOutcomeStatus: string | null = null;
 
   for (let i = 0; i < targets.length; i++) {
     if (await isBackupJobCancelled(data.jobId)) {
@@ -656,6 +657,9 @@ async function processDispatchBackup(
         : `Failed to send ${target.commandType} command to agent (dispatch outcome ${outcome.status})`;
       console.warn(`[BackupWorker] ${detail} for job ${commandJobId}`);
       failedTargets.push(target.commandType);
+      if (outcome.status !== 'offline') {
+        lastNonOfflineOutcomeStatus = outcome.status;
+      }
       if (commandJobId !== data.jobId) {
         await db
           .update(backupJobs)
@@ -670,7 +674,12 @@ async function processDispatchBackup(
   }
 
   if (sentCount === 0) {
-    await markJobFailed(data.jobId, 'Failed to send command to agent');
+    await markJobFailed(
+      data.jobId,
+      lastNonOfflineOutcomeStatus
+        ? `Failed to send command to agent (dispatch outcome ${lastNonOfflineOutcomeStatus})`
+        : 'Failed to send command to agent',
+    );
     return { dispatched: false };
   }
 

--- a/apps/api/src/jobs/discoveryWorker.dbcontext.test.ts
+++ b/apps/api/src/jobs/discoveryWorker.dbcontext.test.ts
@@ -1,0 +1,261 @@
+/**
+ * discoveryWorker DB-context scoping (#1105 class, final-review fix for wave
+ * 3.5b #4084).
+ *
+ * The regression this locks down: the ENTIRE worker-handler switch — every
+ * job type, including `dispatch-scan` — used to run inside one blanket
+ * `runWithSystemDbAccess` wrap, so `isAgentConnectedAnywhere` and
+ * `dispatchCommandToAgent` (Redis/WS I/O via the agentCommandRelay facade —
+ * the latter with an ack-wait poll loop up to RELAY_DELIVERY_DEADLINE_MS) ran
+ * with a pooled Postgres connection pinned idle-in-transaction.
+ *
+ * An identity `fn => fn()` mock of the context helper can never catch that
+ * (which is exactly what discoveryWorker.test.ts uses, since it isn't
+ * asserting context depth), so the mock below tracks real enter/exit depth
+ * and the tests assert WHICH depth each DB read/write and each facade call
+ * happened at — mirroring snmpWorker.dbcontext.test.ts's harness. Exercised
+ * directly against `__testables.processDispatchScan`, same as
+ * discoveryWorker.test.ts's existing facade-dispatch suite.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DispatchOutcome } from '../services/agentCommandRelay';
+
+const { mockDb, ctxState, agentRelayMock } = vi.hoisted(() => ({
+  mockDb: {
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+  // DB-access-context depth + an ordered event log, so a test can prove which
+  // work runs inside a held transaction and which runs after it closes.
+  ctxState: { depth: 0, events: [] as string[] },
+  agentRelayMock: {
+    isAgentConnectedAnywhere: vi.fn(async () => true),
+    dispatchCommandToAgent: vi.fn(async (): Promise<DispatchOutcome> => ({ status: 'sent', via: 'local' })),
+  },
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {},
+  Worker: class {},
+  Job: class {},
+  UnrecoverableError: class extends Error {},
+}));
+
+vi.mock('../db', () => ({
+  db: mockDb,
+  // Real-ish context wrapper: tracks depth around fn so the tests can assert
+  // what runs inside the context vs after it closes. Unlike
+  // discoveryWorker.test.ts (which sets this to `undefined` for an identity
+  // fallback), this is the whole point of this file.
+  withSystemDbAccessContext: async (fn: () => unknown) => {
+    ctxState.depth++;
+    ctxState.events.push('ctx:enter');
+    try {
+      return await fn();
+    } finally {
+      ctxState.depth--;
+      ctxState.events.push('ctx:exit');
+    }
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  discoveryProfiles: { id: 'discoveryProfiles.id' },
+  discoveryJobs: { id: 'discoveryJobs.id' },
+  discoveredAssets: {
+    id: 'discoveredAssets.id',
+    orgId: 'discoveredAssets.orgId',
+    siteId: 'discoveredAssets.siteId',
+    ipAddress: 'discoveredAssets.ipAddress',
+    linkedDeviceId: 'discoveredAssets.linkedDeviceId',
+    linkSource: 'discoveredAssets.linkSource',
+    typeSource: 'discoveredAssets.typeSource',
+    assetType: 'discoveredAssets.assetType',
+    detectedAssetType: 'discoveredAssets.detectedAssetType',
+    detectedTypeSource: 'discoveredAssets.detectedTypeSource',
+    autoLinkSuppressedAt: 'discoveredAssets.autoLinkSuppressedAt',
+  },
+  networkTopology: {
+    id: 'networkTopology.id',
+    orgId: 'networkTopology.orgId',
+    siteId: 'networkTopology.siteId',
+    sourceType: 'networkTopology.sourceType',
+    targetType: 'networkTopology.targetType',
+    connectionType: 'networkTopology.connectionType',
+  },
+  networkBaselines: {},
+  networkKnownGuests: {},
+  networkChangeEvents: { $inferInsert: {} },
+  organizations: {},
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
+    deviceRoleSource: 'devices.deviceRoleSource',
+    agentId: 'devices.agentId',
+    status: 'devices.status',
+    isEphemeral: 'devices.isEphemeral',
+  },
+  deviceNetwork: {
+    deviceId: 'deviceNetwork.deviceId',
+    macAddress: 'deviceNetwork.macAddress',
+    ipAddress: 'deviceNetwork.ipAddress',
+  },
+}));
+
+vi.mock('../services/assetApproval', () => ({
+  normalizeMac: vi.fn(),
+  buildApprovalDecision: vi.fn(),
+}));
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../services/agentCommandRelay', () => ({
+  isAgentConnectedAnywhere: agentRelayMock.isAgentConnectedAnywhere,
+  dispatchCommandToAgent: agentRelayMock.dispatchCommandToAgent,
+}));
+
+vi.mock('../services/automationRuntime', () => ({
+  isCronDue: vi.fn(),
+}));
+
+vi.mock('../services/macVendorLookup', () => ({
+  lookupMacVendor: vi.fn(),
+  inferAssetTypeFromVendor: vi.fn(),
+}));
+
+vi.mock('../services/networkBaseline', () => ({
+  buildEventFingerprint: vi.fn(() => 'fingerprint'),
+}));
+
+vi.mock('./networkBaselineWorker', () => ({
+  enqueueBaselineComparison: vi.fn(async () => 'enqueued'),
+  getNetworkBaselineQueue: vi.fn(),
+}));
+
+const { __testables } = await import('./discoveryWorker');
+
+/** A `.select().from().where().limit()` chain that logs the depth it ran at. */
+function selectLimitChain(rows: unknown[], label: string) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockImplementation(async () => {
+          ctxState.events.push(`${label}@depth${ctxState.depth}`);
+          return rows;
+        }),
+      }),
+    }),
+  };
+}
+
+/** An `.update().set().where()` chain that logs the depth it ran at. */
+function updateChain(label: string) {
+  return {
+    set: () => ({
+      where: async () => {
+        ctxState.events.push(`${label}@depth${ctxState.depth}`);
+      },
+    }),
+  };
+}
+
+describe('processDispatchScan DB-context scoping (final-review fix, #4084/#1105)', () => {
+  const DATA = {
+    type: 'dispatch-scan' as const,
+    jobId: 'job-1',
+    profileId: 'profile-1',
+    orgId: 'org-1',
+    siteId: 'site-1',
+    agentId: 'agent-1',
+  };
+  const PROFILE_ROW = { id: 'profile-1' };
+  const VALID_AGENT_ROW = { agentId: 'agent-1', orgId: 'org-1', siteId: 'site-1', status: 'online' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctxState.depth = 0;
+    ctxState.events = [];
+
+    agentRelayMock.isAgentConnectedAnywhere.mockImplementation(async () => {
+      ctxState.events.push(`isAgentConnected@depth${ctxState.depth}`);
+      return true;
+    });
+    agentRelayMock.dispatchCommandToAgent.mockImplementation(async () => {
+      ctxState.events.push(`wsDispatch@depth${ctxState.depth}`);
+      return { status: 'sent', via: 'local' };
+    });
+  });
+
+  it('reads profile + validates the requested agent in-context, but checks connectivity, dispatches and flips status OUTSIDE it', async () => {
+    // Requested-agent path: profile select, then validateRequestedAgentForDiscovery's
+    // devices select — exactly two selects, both inside phase 1.
+    mockDb.select
+      .mockReturnValueOnce(selectLimitChain([PROFILE_ROW], 'profileSelect') as never)
+      .mockReturnValueOnce(selectLimitChain([VALID_AGENT_ROW], 'agentValidateSelect') as never);
+    mockDb.update.mockReturnValue(updateChain('statusUpdate') as never);
+
+    const result = await __testables.processDispatchScan(DATA);
+
+    expect(result).toEqual({ dispatched: true, agentId: 'agent-1', durationMs: expect.any(Number) });
+    // Phase 1 (profile + agent-validation reads) shares ONE context; the
+    // connectivity check and the WS dispatch run after it closes; the final
+    // status flip to 'running' gets its own short context.
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'profileSelect@depth1',
+      'agentValidateSelect@depth1',
+      'ctx:exit',
+      'isAgentConnected@depth0',
+      'wsDispatch@depth0',
+      'ctx:enter',
+      'statusUpdate@depth1',
+      'ctx:exit',
+    ]);
+  });
+
+  it('holds no context past phase 1 when the profile is missing', async () => {
+    mockDb.select.mockReturnValueOnce(selectLimitChain([], 'profileSelect') as never);
+    mockDb.update.mockReturnValue(updateChain('markJobFailed') as never);
+
+    const result = await __testables.processDispatchScan(DATA);
+
+    expect(result).toEqual({ dispatched: false, agentId: null, durationMs: expect.any(Number) });
+    expect(agentRelayMock.isAgentConnectedAnywhere).not.toHaveBeenCalled();
+    expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+    // markJobFailed (an UPDATE) shares phase 1's context with the profile read.
+    expect(ctxState.events).toEqual(['ctx:enter', 'profileSelect@depth1', 'markJobFailed@depth1', 'ctx:exit']);
+  });
+
+  it('checks connectivity OUTSIDE any context, then reopens a short context to mark the job failed when the agent is not connected', async () => {
+    mockDb.select
+      .mockReturnValueOnce(selectLimitChain([PROFILE_ROW], 'profileSelect') as never)
+      .mockReturnValueOnce(selectLimitChain([VALID_AGENT_ROW], 'agentValidateSelect') as never);
+    mockDb.update.mockReturnValue(updateChain('markJobFailed') as never);
+    agentRelayMock.isAgentConnectedAnywhere.mockImplementation(async () => {
+      ctxState.events.push(`isAgentConnected@depth${ctxState.depth}`);
+      return false;
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await __testables.processDispatchScan(DATA);
+
+    expect(result).toEqual({ dispatched: false, agentId: null, durationMs: expect.any(Number) });
+    expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'profileSelect@depth1',
+      'agentValidateSelect@depth1',
+      'ctx:exit',
+      'isAgentConnected@depth0',
+      'ctx:enter',
+      'markJobFailed@depth1',
+      'ctx:exit',
+    ]);
+    warn.mockRestore();
+  });
+});

--- a/apps/api/src/jobs/discoveryWorker.dbcontext.test.ts
+++ b/apps/api/src/jobs/discoveryWorker.dbcontext.test.ts
@@ -258,4 +258,33 @@ describe('processDispatchScan DB-context scoping (final-review fix, #4084/#1105)
     ]);
     warn.mockRestore();
   });
+
+  it('reopens a short context for the post-dispatch markJobFailed when the outcome is not sent', async () => {
+    // A contextless UPDATE here would be an RLS-denied silent no-op in prod
+    // (0 rows, no error) — the job would sit 'pending' forever. Lock the
+    // depth-1 requirement down the same way backupWorker.dbcontext.test.ts does.
+    mockDb.select
+      .mockReturnValueOnce(selectLimitChain([PROFILE_ROW], 'profileSelect') as never)
+      .mockReturnValueOnce(selectLimitChain([VALID_AGENT_ROW], 'agentValidateSelect') as never);
+    mockDb.update.mockReturnValue(updateChain('markJobFailed') as never);
+    agentRelayMock.dispatchCommandToAgent.mockImplementation(async () => {
+      ctxState.events.push(`wsDispatch@depth${ctxState.depth}`);
+      return { status: 'indeterminate' };
+    });
+
+    const result = await __testables.processDispatchScan(DATA);
+
+    expect(result).toEqual({ dispatched: false, agentId: 'agent-1', durationMs: expect.any(Number) });
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'profileSelect@depth1',
+      'agentValidateSelect@depth1',
+      'ctx:exit',
+      'isAgentConnected@depth0',
+      'wsDispatch@depth0',
+      'ctx:enter',
+      'markJobFailed@depth1',
+      'ctx:exit',
+    ]);
+  });
 });

--- a/apps/api/src/jobs/discoveryWorker.test.ts
+++ b/apps/api/src/jobs/discoveryWorker.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PgDialect } from 'drizzle-orm/pg-core';
+import type { DispatchOutcome } from '../services/agentCommandRelay';
 
 const { mockDb } = vi.hoisted(() => ({
   mockDb: {
@@ -23,7 +24,7 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
-  discoveryProfiles: {},
+  discoveryProfiles: { id: 'discoveryProfiles.id' },
   discoveryJobs: { id: 'discoveryJobs.id' },
   discoveredAssets: {
     id: 'discoveredAssets.id',
@@ -56,7 +57,10 @@ vi.mock('../db/schema', () => ({
     id: 'devices.id',
     orgId: 'devices.orgId',
     siteId: 'devices.siteId',
-    deviceRoleSource: 'devices.deviceRoleSource'
+    deviceRoleSource: 'devices.deviceRoleSource',
+    agentId: 'devices.agentId',
+    status: 'devices.status',
+    isEphemeral: 'devices.isEphemeral'
   },
   deviceNetwork: {
     deviceId: 'deviceNetwork.deviceId',
@@ -76,9 +80,13 @@ vi.mock('../services/redis', () => ({
   isBullMQAvailable: vi.fn(() => true),
 }));
 
-vi.mock('../routes/agentWs', () => ({
-  sendCommandToAgent: vi.fn(),
-  isAgentConnected: vi.fn()
+const agentRelayMock = {
+  isAgentConnectedAnywhere: vi.fn(async () => true),
+  dispatchCommandToAgent: vi.fn(async (): Promise<DispatchOutcome> => ({ status: 'sent', via: 'local' })),
+};
+vi.mock('../services/agentCommandRelay', () => ({
+  isAgentConnectedAnywhere: agentRelayMock.isAgentConnectedAnywhere,
+  dispatchCommandToAgent: agentRelayMock.dispatchCommandToAgent,
 }));
 
 vi.mock('../services/automationRuntime', () => ({
@@ -105,7 +113,7 @@ import { inferAssetTypeFromVendor } from '../services/macVendorLookup';
 import { devices, discoveredAssets } from '../db/schema';
 import type { DiscoveredHostResult } from './discoveryWorker';
 
-const { cleanupSpeculativeTopologyLinks, processResults } = await import('./discoveryWorker') as typeof import('./discoveryWorker');
+const { cleanupSpeculativeTopologyLinks, processResults, __testables } = await import('./discoveryWorker') as typeof import('./discoveryWorker');
 
 // Helper: build a chainable Drizzle-like mock that resolves to resolveValue
 // when awaited directly (thenable) or via .limit() / .returning().
@@ -798,5 +806,88 @@ describe('cleanupSpeculativeTopologyLinks', () => {
 
     expect(deleted).toBe(2);
     expect(vi.mocked(db.delete)).toHaveBeenCalledWith(expect.anything());
+  });
+});
+
+describe('processDispatchScan (wave 3.5b #4084 — dispatch via facade)', () => {
+  // Requested-agent path: profile select, then validateRequestedAgentForDiscovery's
+  // devices select. Supplying data.agentId means the `if (!agentId)` site-auto
+  // devices lookup never runs, keeping the select queue to exactly these two.
+  const DATA = {
+    type: 'dispatch-scan' as const,
+    jobId: 'job-1',
+    profileId: 'profile-1',
+    orgId: 'org-1',
+    siteId: 'site-1',
+    agentId: 'agent-1',
+  };
+  const PROFILE_ROW = { id: 'profile-1' };
+  const VALID_AGENT_ROW = { agentId: 'agent-1', orgId: 'org-1', siteId: 'site-1', status: 'online' };
+
+  let selectQueue: unknown[][];
+  let selectCallIndex: number;
+  let updateLog: Array<{ payload: Record<string, unknown> }>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectQueue = [[PROFILE_ROW], [VALID_AGENT_ROW]];
+    selectCallIndex = 0;
+    updateLog = [];
+
+    vi.mocked(mockDb.select).mockImplementation(() =>
+      makeSelectChain(selectQueue[selectCallIndex++] ?? [])
+    );
+    vi.mocked(mockDb.update).mockImplementation(() => {
+      const chain: Record<string, unknown> = {};
+      chain.set = (payload: Record<string, unknown>) => {
+        updateLog.push({ payload });
+        return chain;
+      };
+      chain.where = () => Promise.resolve([]);
+      return chain;
+    });
+
+    agentRelayMock.isAgentConnectedAnywhere.mockResolvedValue(true);
+    agentRelayMock.dispatchCommandToAgent.mockResolvedValue({ status: 'sent', via: 'local' });
+  });
+
+  it('marks the job failed with "No online agent available for this site" (byte-identical to today) when no agent is connected anywhere, without calling dispatch', async () => {
+    agentRelayMock.isAgentConnectedAnywhere.mockResolvedValue(false);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await __testables.processDispatchScan(DATA);
+
+    expect(result).toEqual({ dispatched: false, agentId: null, durationMs: expect.any(Number) });
+    expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+    expect(updateLog.some((u) => (u.payload.errors as { message: string } | undefined)?.message === 'No online agent available for this site')).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('flips the job to running when the outcome is sent', async () => {
+    const result = await __testables.processDispatchScan(DATA);
+
+    expect(result).toEqual({ dispatched: true, agentId: 'agent-1', durationMs: expect.any(Number) });
+    expect(updateLog.some((u) => u.payload.status === 'running')).toBe(true);
+  });
+
+  it('marks the job failed with "Failed to send command to agent" (today\'s message) when the outcome is offline', async () => {
+    agentRelayMock.dispatchCommandToAgent.mockResolvedValue({ status: 'offline' });
+
+    const result = await __testables.processDispatchScan(DATA);
+
+    expect(result).toEqual({ dispatched: false, agentId: 'agent-1', durationMs: expect.any(Number) });
+    expect(updateLog.some((u) => (u.payload.errors as { message: string } | undefined)?.message === 'Failed to send command to agent')).toBe(true);
+  });
+
+  it('marks the job failed naming the outcome when indeterminate', async () => {
+    agentRelayMock.dispatchCommandToAgent.mockResolvedValue({ status: 'indeterminate' });
+
+    const result = await __testables.processDispatchScan(DATA);
+
+    expect(result).toEqual({ dispatched: false, agentId: 'agent-1', durationMs: expect.any(Number) });
+    expect(updateLog.some((u) => {
+      const message = (u.payload.errors as { message?: string } | undefined)?.message;
+      return typeof message === 'string' && /dispatch outcome indeterminate/i.test(message);
+    })).toBe(true);
   });
 });

--- a/apps/api/src/jobs/discoveryWorker.ts
+++ b/apps/api/src/jobs/discoveryWorker.ts
@@ -25,7 +25,8 @@ import { normalizeMac, buildApprovalDecision } from '../services/assetApproval';
 import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
 import { attachWorkerObservability } from './workerObservability';
-import { sendCommandToAgent, isAgentConnected, type AgentCommand } from '../routes/agentWs';
+import { dispatchCommandToAgent, isAgentConnectedAnywhere } from '../services/agentCommandRelay';
+import type { AgentCommand } from '../routes/agentWs';
 import { isCronDue } from '../services/automationRuntime';
 import { lookupMacVendor, inferAssetTypeFromVendor } from '../services/macVendorLookup';
 import {
@@ -568,7 +569,7 @@ async function processDispatchScan(data: DispatchScanJobData): Promise<{
     return { dispatched: false, agentId: null, durationMs: Date.now() - startTime };
   }
 
-  if (!isAgentConnected(agentId)) {
+  if (!(await isAgentConnectedAnywhere(agentId))) {
     console.warn(
       `[DiscoveryWorker] Selected agent is not websocket-connected for job ${data.jobId} (agent=${agentId}, requestedAgent=${requestedAgentId ?? 'none'}, source=${selectionSource})`
     );
@@ -603,9 +604,14 @@ async function processDispatchScan(data: DispatchScanJobData): Promise<{
     }
   };
 
-  const sent = sendCommandToAgent(agentId, command);
-  if (!sent) {
-    await markJobFailed(data.jobId, 'Failed to send command to agent');
+  const outcome = await dispatchCommandToAgent(agentId, command);
+  if (outcome.status !== 'sent') {
+    await markJobFailed(
+      data.jobId,
+      outcome.status === 'offline'
+        ? 'Failed to send command to agent'
+        : `Failed to send command to agent (dispatch outcome ${outcome.status})`,
+    );
     return { dispatched: false, agentId, durationMs: Date.now() - startTime };
   }
 
@@ -623,6 +629,13 @@ async function processDispatchScan(data: DispatchScanJobData): Promise<{
   console.log(`[DiscoveryWorker] Scan dispatched to agent ${agentId} for job ${data.jobId}`);
   return { dispatched: true, agentId, durationMs: Date.now() - startTime };
 }
+
+// Exposed for the wave 3.5b (#4084) dispatch-facade migration tests — mirrors
+// snmpWorker.ts's __testables pattern. processDispatchScan opens no outer DB
+// context of its own, so calling it directly is safe from a context standpoint.
+export const __testables = {
+  processDispatchScan,
+};
 
 /**
  * Process discovery results — upsert discovered assets

--- a/apps/api/src/jobs/discoveryWorker.ts
+++ b/apps/api/src/jobs/discoveryWorker.ts
@@ -182,15 +182,22 @@ export function createDiscoveryWorker(): Worker<DiscoveryJobData> {
   return new Worker<DiscoveryJobData>(
     DISCOVERY_QUEUE,
     async (job: Job<DiscoveryJobData>) => {
+      const data = parseQueueJobData(DISCOVERY_QUEUE, job, discoveryQueueJobDataSchema);
+      // dispatch-scan is handled OUTSIDE the blanket context below (final-review
+      // fix, #4084/#1105): processDispatchScan calls the agentCommandRelay
+      // facade (isAgentConnectedAnywhere, dispatchCommandToAgent — Redis/WS
+      // I/O) and manages its own short-lived system DB contexts around just
+      // its reads/writes, so no pooled connection sits idle-in-transaction
+      // across that I/O.
+      if (data.type === 'dispatch-scan') {
+        assertQueueJobName(DISCOVERY_QUEUE, job, 'dispatch-scan');
+        return await processDispatchScan(data);
+      }
       return runWithSystemDbAccess(async () => {
-        const data = parseQueueJobData(DISCOVERY_QUEUE, job, discoveryQueueJobDataSchema);
         switch (data.type) {
           case 'schedule-profiles':
             assertQueueJobName(DISCOVERY_QUEUE, job, 'schedule-profiles');
             return await processScheduleProfiles();
-          case 'dispatch-scan':
-            assertQueueJobName(DISCOVERY_QUEUE, job, 'dispatch-scan');
-            return await processDispatchScan(data);
           case 'process-results':
             assertQueueJobName(DISCOVERY_QUEUE, job, 'process-results');
             return await processResults(data);
@@ -504,16 +511,33 @@ async function processScheduleProfiles(): Promise<{ enqueued: number }> {
 }
 
 /**
- * Dispatch a discovery scan command to an agent
+ * Outcome of the dispatch-scan read/select phase (final-review fix, #4084 /
+ * #1105). Discriminated so each terminal cause (profile missing, requested
+ * agent invalid, no candidate agent) is distinct rather than inferred from
+ * guard order.
  */
-async function processDispatchScan(data: DispatchScanJobData): Promise<{
-  dispatched: boolean;
-  agentId: string | null;
-  durationMs: number;
-}> {
-  const startTime = Date.now();
+type DispatchScanInputs =
+  | { status: 'profile-missing' }
+  | { status: 'invalid-agent' }
+  | { status: 'no-agent' }
+  | {
+      status: 'ok';
+      profile: typeof discoveryProfiles.$inferSelect;
+      agentId: string;
+      requestedAgentId: string | null;
+      selectionSource: 'requested' | 'site-auto';
+    };
 
-  // Load the profile
+/**
+ * Phase 1 of a dispatch-scan job: load the profile and resolve/validate the
+ * execution agent, inside ONE short system DB context. Every early-failure
+ * write (`markJobFailed`) that can be determined from these reads alone
+ * happens here too, since none of it involves Redis or the agent WebSocket.
+ * The connectivity check (`isAgentConnectedAnywhere`) is NOT here — that is
+ * Redis I/O via the agentCommandRelay facade and must run with no context
+ * held (#1105).
+ */
+async function loadDispatchScanInputs(data: DispatchScanJobData): Promise<DispatchScanInputs> {
   const [profile] = await db
     .select()
     .from(discoveryProfiles)
@@ -522,18 +546,18 @@ async function processDispatchScan(data: DispatchScanJobData): Promise<{
 
   if (!profile) {
     await markJobFailed(data.jobId, 'Profile not found');
-    return { dispatched: false, agentId: null, durationMs: Date.now() - startTime };
+    return { status: 'profile-missing' };
   }
 
   // Find an online agent to run the scan
   let agentId = data.agentId;
   const requestedAgentId = data.agentId ?? null;
-  let selectionSource: 'requested' | 'site-auto' = requestedAgentId ? 'requested' : 'site-auto';
+  const selectionSource: 'requested' | 'site-auto' = requestedAgentId ? 'requested' : 'site-auto';
   if (requestedAgentId) {
     const validation = await validateRequestedAgentForDiscovery(requestedAgentId, data.orgId, data.siteId);
     if (!validation.ok) {
       await markJobFailed(data.jobId, validation.message);
-      return { dispatched: false, agentId: null, durationMs: Date.now() - startTime };
+      return { status: 'invalid-agent' };
     }
   }
   if (!agentId) {
@@ -566,20 +590,43 @@ async function processDispatchScan(data: DispatchScanJobData): Promise<{
       `[DiscoveryWorker] No candidate agent found for job ${data.jobId} (profile=${data.profileId}, org=${data.orgId}, site=${data.siteId}, source=${selectionSource})`
     );
     await markJobFailed(data.jobId, 'No online agent available for this site');
+    return { status: 'no-agent' };
+  }
+
+  return { status: 'ok', profile, agentId, requestedAgentId, selectionSource };
+}
+
+/**
+ * Dispatch a discovery scan command to an agent
+ */
+async function processDispatchScan(data: DispatchScanJobData): Promise<{
+  dispatched: boolean;
+  agentId: string | null;
+  durationMs: number;
+}> {
+  const startTime = Date.now();
+
+  // Phase 1 — profile load, agent validation/selection and every terminal
+  // failure write reachable from those reads alone: ONE short system DB
+  // context, which then CLOSES before any Redis or WS I/O.
+  const inputs = await runWithSystemDbAccess(() => loadDispatchScanInputs(data));
+
+  if (inputs.status !== 'ok') {
     return { dispatched: false, agentId: null, durationMs: Date.now() - startTime };
   }
 
+  const { profile, agentId, requestedAgentId, selectionSource: initialSelectionSource } = inputs;
+
+  // Phase 2 — connectivity check with NO DB context open (#1105).
   if (!(await isAgentConnectedAnywhere(agentId))) {
     console.warn(
-      `[DiscoveryWorker] Selected agent is not websocket-connected for job ${data.jobId} (agent=${agentId}, requestedAgent=${requestedAgentId ?? 'none'}, source=${selectionSource})`
+      `[DiscoveryWorker] Selected agent is not websocket-connected for job ${data.jobId} (agent=${agentId}, requestedAgent=${requestedAgentId ?? 'none'}, source=${initialSelectionSource})`
     );
-    await markJobFailed(data.jobId, 'No online agent available for this site');
+    await runWithSystemDbAccess(() => markJobFailed(data.jobId, 'No online agent available for this site'));
     return { dispatched: false, agentId: null, durationMs: Date.now() - startTime };
   }
 
-  if (!requestedAgentId) {
-    selectionSource = 'site-auto';
-  }
+  const selectionSource = requestedAgentId ? initialSelectionSource : 'site-auto';
   console.log(
     `[DiscoveryWorker] Selected agent ${agentId} for job ${data.jobId} (profile=${data.profileId}, org=${data.orgId}, site=${data.siteId}, source=${selectionSource}${requestedAgentId ? `, requestedAgent=${requestedAgentId}` : ''})`
   );
@@ -604,35 +651,41 @@ async function processDispatchScan(data: DispatchScanJobData): Promise<{
     }
   };
 
+  // Phase 3 — the WS/relay dispatch itself, no DB context open (#1105).
   const outcome = await dispatchCommandToAgent(agentId, command);
   if (outcome.status !== 'sent') {
-    await markJobFailed(
-      data.jobId,
-      outcome.status === 'offline'
-        ? 'Failed to send command to agent'
-        : `Failed to send command to agent (dispatch outcome ${outcome.status})`,
+    await runWithSystemDbAccess(() =>
+      markJobFailed(
+        data.jobId,
+        outcome.status === 'offline'
+          ? 'Failed to send command to agent'
+          : `Failed to send command to agent (dispatch outcome ${outcome.status})`,
+      )
     );
     return { dispatched: false, agentId, durationMs: Date.now() - startTime };
   }
 
-  // Update job status to running
-  await db
-    .update(discoveryJobs)
-    .set({
-      status: 'running',
-      agentId,
-      startedAt: new Date(),
-      updatedAt: new Date()
-    })
-    .where(eq(discoveryJobs.id, data.jobId));
+  // Phase 4 — job status flip to running: its own short system DB context.
+  await runWithSystemDbAccess(() =>
+    db
+      .update(discoveryJobs)
+      .set({
+        status: 'running',
+        agentId,
+        startedAt: new Date(),
+        updatedAt: new Date()
+      })
+      .where(eq(discoveryJobs.id, data.jobId))
+  );
 
   console.log(`[DiscoveryWorker] Scan dispatched to agent ${agentId} for job ${data.jobId}`);
   return { dispatched: true, agentId, durationMs: Date.now() - startTime };
 }
 
 // Exposed for the wave 3.5b (#4084) dispatch-facade migration tests — mirrors
-// snmpWorker.ts's __testables pattern. processDispatchScan opens no outer DB
-// context of its own, so calling it directly is safe from a context standpoint.
+// snmpWorker.ts's __testables pattern. Each handler here manages its own
+// short-lived system DB context(s) around just its reads/writes (final-review
+// fix, #1105), so calling it directly is safe from a context standpoint.
 export const __testables = {
   processDispatchScan,
 };

--- a/apps/api/src/jobs/monitorWorker.dbcontext.test.ts
+++ b/apps/api/src/jobs/monitorWorker.dbcontext.test.ts
@@ -1,0 +1,212 @@
+/**
+ * monitorWorker DB-context scoping (#1105 class, final-review fix for wave
+ * 3.5b #4084).
+ *
+ * The regression this locks down: the `check-monitor` job type was wrapped in
+ * `runWithSystemDbAccess` at the worker-handler level, so
+ * `isAgentConnectedAnywhere` and `dispatchCommandToAgent` (Redis/WS I/O via the
+ * agentCommandRelay facade — the latter with an ack-wait poll loop up to
+ * RELAY_DELIVERY_DEADLINE_MS) ran with a pooled Postgres connection pinned
+ * idle-in-transaction.
+ *
+ * An identity `fn => fn()` mock of the context helper can never catch that, so
+ * the mock below tracks real enter/exit depth and the tests assert WHICH depth
+ * each DB read and each facade call happened at — mirroring
+ * snmpWorker.dbcontext.test.ts's harness. Exercised directly against
+ * `processCheckMonitor` (as monitorWorker.test.ts already does): the
+ * worker-handler switch is a one-line passthrough onto it with no wrapping of
+ * its own left to assert.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDb, ctxState, agentRelayMock } = vi.hoisted(() => ({
+  mockDb: {
+    select: vi.fn(),
+  },
+  // DB-access-context depth + an ordered event log, so a test can prove which
+  // work runs inside a held transaction and which runs after it closes.
+  ctxState: { depth: 0, events: [] as string[] },
+  agentRelayMock: {
+    isAgentConnectedAnywhere: vi.fn(async () => true),
+    dispatchCommandToAgent: vi.fn(async () => ({ status: 'sent', via: 'local' })),
+  },
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {},
+  Worker: class {},
+  Job: class {},
+  UnrecoverableError: class extends Error {},
+}));
+
+vi.mock('../db', () => ({
+  db: mockDb,
+  // Real-ish context wrapper: tracks depth around fn so the tests can assert
+  // what runs inside the context vs after it closes.
+  withSystemDbAccessContext: async (fn: () => unknown) => {
+    ctxState.depth++;
+    ctxState.events.push('ctx:enter');
+    try {
+      return await fn();
+    } finally {
+      ctxState.depth--;
+      ctxState.events.push('ctx:exit');
+    }
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  networkMonitors: {
+    id: 'networkMonitors.id',
+    orgId: 'networkMonitors.orgId',
+    assetId: 'networkMonitors.assetId',
+    consecutiveFailures: 'networkMonitors.consecutiveFailures',
+  },
+  networkMonitorResults: { monitorId: 'networkMonitorResults.monitorId' },
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+    siteId: 'devices.siteId',
+    lastSeenAt: 'devices.lastSeenAt',
+    enrolledAt: 'devices.enrolledAt',
+  },
+  networkMonitorAlertRules: {
+    monitorId: 'networkMonitorAlertRules.monitorId',
+    isActive: 'networkMonitorAlertRules.isActive',
+    $inferSelect: {},
+  },
+  alerts: {
+    id: 'alerts.id',
+    orgId: 'alerts.orgId',
+    deviceId: 'alerts.deviceId',
+    status: 'alerts.status',
+    context: 'alerts.context',
+  },
+  discoveredAssets: {
+    id: 'discoveredAssets.id',
+    orgId: 'discoveredAssets.orgId',
+    linkedDeviceId: 'discoveredAssets.linkedDeviceId',
+    siteId: 'discoveredAssets.siteId',
+  },
+}));
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+
+vi.mock('../services/agentCommandRelay', () => ({
+  isAgentConnectedAnywhere: agentRelayMock.isAgentConnectedAnywhere,
+  dispatchCommandToAgent: agentRelayMock.dispatchCommandToAgent,
+}));
+
+vi.mock('../routes/monitors', () => ({
+  buildMonitorCommand: vi.fn(() => ({ id: 'cmd-1', type: 'network_check', payload: {} })),
+}));
+
+vi.mock('../services/alertCooldown', () => ({
+  isCooldownActive: vi.fn(async () => false),
+  setCooldown: vi.fn(async () => undefined),
+}));
+
+vi.mock('../services/alertService', () => ({
+  resolveAlert: vi.fn(async () => undefined),
+}));
+
+vi.mock('./workerObservability', () => ({
+  attachWorkerObservability: vi.fn(),
+}));
+
+import { processCheckMonitor } from './monitorWorker';
+
+/** A `.select().from().where().limit()` chain that logs the depth it ran at. */
+function selectLimitChain(rows: unknown[], label: string) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockImplementation(async () => {
+          ctxState.events.push(`${label}@depth${ctxState.depth}`);
+          return rows;
+        }),
+      }),
+    }),
+  };
+}
+
+describe('processCheckMonitor DB-context scoping (final-review fix, #4084/#1105)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctxState.depth = 0;
+    ctxState.events = [];
+
+    agentRelayMock.isAgentConnectedAnywhere.mockImplementation(async () => {
+      ctxState.events.push(`isAgentConnected@depth${ctxState.depth}`);
+      return true;
+    });
+    agentRelayMock.dispatchCommandToAgent.mockImplementation(async () => {
+      ctxState.events.push(`wsDispatch@depth${ctxState.depth}`);
+      return { status: 'sent', via: 'local' };
+    });
+  });
+
+  it('reads the monitor + agent selection in-context, but checks connectivity and dispatches OUTSIDE it', async () => {
+    mockDb.select
+      .mockReturnValueOnce(
+        selectLimitChain(
+          [{ id: 'monitor-1', orgId: 'org-1', assetId: null, isActive: true, name: 'Edge Ping', target: '8.8.8.8', monitorType: 'icmp_ping' }],
+          'monitorSelect'
+        ) as never
+      )
+      // selectExecutionAgentForMonitor: unbound monitor → org-wide online agent lookup
+      .mockReturnValueOnce(selectLimitChain([{ agentId: 'agent-1' }], 'agentSelect') as never);
+
+    const result = await processCheckMonitor({ type: 'check-monitor', monitorId: 'monitor-1', orgId: 'org-1' });
+
+    expect(result).toEqual({ dispatched: true, agentId: 'agent-1' });
+    // The monitor read and the agent-selection read share ONE context; the
+    // connectivity check and the socket write happen only after it closes.
+    // This is the #1105 fix: a blanket wrap here used to hold a pooled
+    // connection idle-in-transaction across both of those facade calls.
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'monitorSelect@depth1',
+      'agentSelect@depth1',
+      'ctx:exit',
+      'isAgentConnected@depth0',
+      'wsDispatch@depth0',
+    ]);
+  });
+
+  it('does not dispatch — and holds no context open past the read — when the monitor is missing', async () => {
+    mockDb.select.mockReturnValueOnce(selectLimitChain([], 'monitorSelect') as never);
+
+    const result = await processCheckMonitor({ type: 'check-monitor', monitorId: 'gone', orgId: 'org-1' });
+
+    expect(result).toEqual({ dispatched: false, agentId: null });
+    expect(agentRelayMock.isAgentConnectedAnywhere).not.toHaveBeenCalled();
+    expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+    expect(ctxState.events).toEqual(['ctx:enter', 'monitorSelect@depth1', 'ctx:exit']);
+  });
+
+  it('checks connectivity OUTSIDE any context when no agent is selected, and never dispatches', async () => {
+    mockDb.select
+      .mockReturnValueOnce(
+        selectLimitChain(
+          [{ id: 'monitor-1', orgId: 'org-1', assetId: null, isActive: true, name: 'Edge Ping', target: '8.8.8.8', monitorType: 'icmp_ping' }],
+          'monitorSelect'
+        ) as never
+      )
+      .mockReturnValueOnce(selectLimitChain([], 'agentSelect') as never);
+
+    const result = await processCheckMonitor({ type: 'check-monitor', monitorId: 'monitor-1', orgId: 'org-1' });
+
+    expect(result).toEqual({ dispatched: false, agentId: null });
+    // agentId is null here, so the `!agentId ||` short-circuit means
+    // isAgentConnectedAnywhere is never actually called — but critically, no
+    // context is held open into the (skipped) connectivity check either way.
+    expect(agentRelayMock.isAgentConnectedAnywhere).not.toHaveBeenCalled();
+    expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
+    expect(ctxState.events).toEqual(['ctx:enter', 'monitorSelect@depth1', 'agentSelect@depth1', 'ctx:exit']);
+  });
+});

--- a/apps/api/src/jobs/monitorWorker.test.ts
+++ b/apps/api/src/jobs/monitorWorker.test.ts
@@ -94,9 +94,9 @@ vi.mock('../services/redis', () => ({
   isBullMQAvailable: vi.fn(() => true),
 }));
 
-vi.mock('../routes/agentWs', () => ({
-  sendCommandToAgent: vi.fn(),
-  isAgentConnected: vi.fn()
+vi.mock('../services/agentCommandRelay', () => ({
+  dispatchCommandToAgent: vi.fn(),
+  isAgentConnectedAnywhere: vi.fn()
 }));
 
 vi.mock('../routes/monitors', () => ({
@@ -115,6 +115,8 @@ vi.mock('../services/alertService', () => ({
 import { db } from '../db';
 import { isCooldownActive, setCooldown } from '../services/alertCooldown';
 import { resolveAlert } from '../services/alertService';
+import { dispatchCommandToAgent, isAgentConnectedAnywhere } from '../services/agentCommandRelay';
+import { buildMonitorCommand } from '../routes/monitors';
 
 function selectLimitResolved(rows: unknown[]) {
   return {
@@ -146,7 +148,12 @@ function selectWhereOrderLimitResolved(rows: unknown[]) {
   };
 }
 
-const { recordMonitorCheckResult, processScheduler, selectExecutionAgentForMonitor } = await import('./monitorWorker');
+const {
+  recordMonitorCheckResult,
+  processScheduler,
+  selectExecutionAgentForMonitor,
+  processCheckMonitor,
+} = await import('./monitorWorker');
 
 describe('selectExecutionAgentForMonitor (SR5-08 site-bound fallback)', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -400,5 +407,87 @@ describe('recordMonitorCheckResult', () => {
     const stateSet = txUpdateSet.mock.calls[0]![0] as { lastError: string };
     expect(stateSet.lastError).toContain('[PRIVATE_KEY_REDACTED]');
     expect(stateSet.lastError).not.toContain('BEGIN RSA PRIVATE KEY');
+  });
+});
+
+describe('processCheckMonitor (wave 3.5b #4084 — dispatch via facade)', () => {
+  const MONITOR_ROW = {
+    id: 'monitor-1',
+    orgId: 'org-1',
+    assetId: null,
+    isActive: true,
+    name: 'Edge Ping',
+    target: '8.8.8.8',
+    monitorType: 'icmp_ping',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(buildMonitorCommand).mockReturnValue({
+      id: 'cmd-1',
+      type: 'network_check',
+      payload: {},
+    } as never);
+  });
+
+  function wireMonitorAndAgentSelects(agentId: string | null) {
+    vi.mocked(db.select)
+      // monitor row lookup
+      .mockReturnValueOnce(selectLimitResolved([MONITOR_ROW]) as any)
+      // org-wide online agent lookup (assetless monitor)
+      .mockReturnValueOnce(selectLimitResolved(agentId ? [{ agentId }] : []) as any);
+  }
+
+  it('warns and returns not-dispatched when no agent is connected anywhere, without calling dispatch', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    wireMonitorAndAgentSelects(null);
+
+    const result = await processCheckMonitor({ type: 'check-monitor', monitorId: 'monitor-1', orgId: 'org-1' });
+
+    expect(result).toEqual({ dispatched: false, agentId: null });
+    expect(vi.mocked(dispatchCommandToAgent)).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('No online agent'));
+    warn.mockRestore();
+  });
+
+  it('returns dispatched:true on outcome sent, and dispatches with priority "probe"', async () => {
+    wireMonitorAndAgentSelects('agent-1');
+    vi.mocked(isAgentConnectedAnywhere).mockResolvedValue(true);
+    vi.mocked(dispatchCommandToAgent).mockResolvedValue({ status: 'sent', via: 'local' });
+
+    const result = await processCheckMonitor({ type: 'check-monitor', monitorId: 'monitor-1', orgId: 'org-1' });
+
+    expect(result).toEqual({ dispatched: true, agentId: 'agent-1' });
+    expect(vi.mocked(dispatchCommandToAgent)).toHaveBeenCalledWith(
+      'agent-1',
+      expect.anything(),
+      { priority: 'probe' }
+    );
+  });
+
+  it('returns dispatched:false and logs the outcome status when offline', async () => {
+    wireMonitorAndAgentSelects('agent-1');
+    vi.mocked(isAgentConnectedAnywhere).mockResolvedValue(true);
+    vi.mocked(dispatchCommandToAgent).mockResolvedValue({ status: 'offline' });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await processCheckMonitor({ type: 'check-monitor', monitorId: 'monitor-1', orgId: 'org-1' });
+
+    expect(result).toEqual({ dispatched: false, agentId: 'agent-1' });
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('offline'));
+    error.mockRestore();
+  });
+
+  it('returns dispatched:false and WARNS naming "indeterminate" so ops can tell "maybe sent" from "definitely not"', async () => {
+    wireMonitorAndAgentSelects('agent-1');
+    vi.mocked(isAgentConnectedAnywhere).mockResolvedValue(true);
+    vi.mocked(dispatchCommandToAgent).mockResolvedValue({ status: 'indeterminate' });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await processCheckMonitor({ type: 'check-monitor', monitorId: 'monitor-1', orgId: 'org-1' });
+
+    expect(result).toEqual({ dispatched: false, agentId: 'agent-1' });
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('indeterminate'));
+    error.mockRestore();
   });
 });

--- a/apps/api/src/jobs/monitorWorker.ts
+++ b/apps/api/src/jobs/monitorWorker.ts
@@ -12,7 +12,7 @@ import { eq, and, sql, desc, inArray } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
 import { createInstrumentedQueue } from '../services/bullmqQueue';
 import { isReusableState } from '../services/bullmqUtils';
-import { sendCommandToAgent, isAgentConnected } from '../routes/agentWs';
+import { dispatchCommandToAgent, isAgentConnectedAnywhere } from '../services/agentCommandRelay';
 import { buildMonitorCommand } from '../routes/monitors';
 import { isCooldownActive, setCooldown } from '../services/alertCooldown';
 import { resolveAlert } from '../services/alertService';
@@ -137,7 +137,7 @@ function createMonitorWorker(): Worker<MonitorJobData> {
   );
 }
 
-async function processCheckMonitor(data: CheckMonitorJobData): Promise<{
+export async function processCheckMonitor(data: CheckMonitorJobData): Promise<{
   dispatched: boolean;
   agentId: string | null;
 }> {
@@ -159,20 +159,20 @@ async function processCheckMonitor(data: CheckMonitorJobData): Promise<{
 
   const agentId = await selectExecutionAgentForMonitor(monitor);
 
-  if (!agentId || !isAgentConnected(agentId)) {
+  if (!agentId || !(await isAgentConnectedAnywhere(agentId))) {
     console.warn(`[MonitorWorker] No online agent for org ${data.orgId}`);
     return { dispatched: false, agentId: null };
   }
 
   const command = buildMonitorCommand(monitor);
-  const sent = sendCommandToAgent(agentId, command);
+  const outcome = await dispatchCommandToAgent(agentId, command, { priority: 'probe' });
 
-  if (!sent) {
-    console.error(`[MonitorWorker] Failed to send check command to agent ${agentId}`);
+  if (outcome.status !== 'sent') {
+    console.error(`[MonitorWorker] Check dispatch ${outcome.status} for agent ${agentId}`);
     return { dispatched: false, agentId };
   }
 
-  console.log(`[MonitorWorker] Check dispatched to agent ${agentId} for monitor ${data.monitorId}`);
+  console.log(`[MonitorWorker] Check dispatched to agent ${agentId} for monitor ${data.monitorId} (${outcome.via})`);
   return { dispatched: true, agentId };
 }
 

--- a/apps/api/src/jobs/monitorWorker.ts
+++ b/apps/api/src/jobs/monitorWorker.ts
@@ -114,10 +114,13 @@ function createMonitorWorker(): Worker<MonitorJobData> {
           // whole enqueue loop (~20s on the EU fleet), starving the pool (#1105).
           return await processScheduler();
         case 'check-monitor':
-          return await runWithSystemDbAccess(() => {
-            assertQueueJobName(MONITOR_QUEUE, job, 'check-monitor');
-            return processCheckMonitor(data);
-          });
+          // NOT wrapped in runWithSystemDbAccess here (final-review fix,
+          // #4084/#1105): processCheckMonitor calls the agentCommandRelay
+          // facade (isAgentConnectedAnywhere, dispatchCommandToAgent — Redis/WS
+          // I/O), and manages its own short-lived system DB context around
+          // just its reads, closing it before that I/O runs.
+          assertQueueJobName(MONITOR_QUEUE, job, 'check-monitor');
+          return await processCheckMonitor(data);
         case 'process-check-result':
           return await runWithSystemDbAccess(() => {
             assertQueueJobName(MONITOR_QUEUE, job, 'process-check-result');
@@ -137,10 +140,23 @@ function createMonitorWorker(): Worker<MonitorJobData> {
   );
 }
 
-export async function processCheckMonitor(data: CheckMonitorJobData): Promise<{
-  dispatched: boolean;
-  agentId: string | null;
-}> {
+/**
+ * Outcome of the check-monitor read phase (#1105 final-review fix, #4084).
+ * Discriminated so the monitor-missing / inactive / ok branches read the
+ * cause off the type rather than off guard order.
+ */
+type CheckMonitorInputs =
+  | { status: 'monitor-missing' }
+  | { status: 'inactive' }
+  | { status: 'ok'; monitor: typeof networkMonitors.$inferSelect; agentId: string | null };
+
+/**
+ * Phase 1 of a check-monitor job: read the monitor row and select the
+ * execution agent inside ONE short system DB context. Nothing here talks to
+ * Redis or the agent WebSocket, so the pooled connection is released before
+ * the connectivity check and dispatch (#1105).
+ */
+async function loadCheckMonitorInputs(data: CheckMonitorJobData): Promise<CheckMonitorInputs> {
   const [monitor] = await db
     .select()
     .from(networkMonitors)
@@ -148,17 +164,40 @@ export async function processCheckMonitor(data: CheckMonitorJobData): Promise<{
     .limit(1);
 
   if (!monitor) {
-    console.error(`[MonitorWorker] Monitor ${data.monitorId} not found`);
-    return { dispatched: false, agentId: null };
+    return { status: 'monitor-missing' };
   }
 
   if (!monitor.isActive) {
-    console.log(`[MonitorWorker] Monitor ${data.monitorId} is inactive, skipping check`);
-    return { dispatched: false, agentId: null };
+    return { status: 'inactive' };
   }
 
   const agentId = await selectExecutionAgentForMonitor(monitor);
+  return { status: 'ok', monitor, agentId };
+}
 
+export async function processCheckMonitor(data: CheckMonitorJobData): Promise<{
+  dispatched: boolean;
+  agentId: string | null;
+}> {
+  // Phase 1 — the monitor read and agent selection inside ONE short system DB
+  // context, which then CLOSES.
+  const inputs = await runWithSystemDbAccess(() => loadCheckMonitorInputs(data));
+
+  switch (inputs.status) {
+    case 'monitor-missing':
+      console.error(`[MonitorWorker] Monitor ${data.monitorId} not found`);
+      return { dispatched: false, agentId: null };
+    case 'inactive':
+      console.log(`[MonitorWorker] Monitor ${data.monitorId} is inactive, skipping check`);
+      return { dispatched: false, agentId: null };
+  }
+
+  const { monitor, agentId } = inputs;
+
+  // Phase 2 — connectivity check and the agent WebSocket dispatch, both with
+  // NO DB context open (#1105). dispatchCommandToAgent does Redis/WS I/O via
+  // the agentCommandRelay facade; holding a transaction across it is what
+  // pinned pooled connections idle-in-transaction.
   if (!agentId || !(await isAgentConnectedAnywhere(agentId))) {
     console.warn(`[MonitorWorker] No online agent for org ${data.orgId}`);
     return { dispatched: false, agentId: null };

--- a/apps/api/src/jobs/snmpWorker.dbcontext.test.ts
+++ b/apps/api/src/jobs/snmpWorker.dbcontext.test.ts
@@ -12,7 +12,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockDb, ctxState, queueMock, agentWsMock } = vi.hoisted(() => ({
+const { mockDb, ctxState, queueMock, agentRelayMock } = vi.hoisted(() => ({
   mockDb: {
     select: vi.fn(),
     insert: vi.fn(),
@@ -29,9 +29,9 @@ const { mockDb, ctxState, queueMock, agentWsMock } = vi.hoisted(() => ({
     removeRepeatableByKey: vi.fn(async () => undefined),
     close: vi.fn(async () => undefined),
   },
-  agentWsMock: {
-    isAgentConnected: vi.fn(() => true),
-    sendCommandToAgent: vi.fn(() => true),
+  agentRelayMock: {
+    isAgentConnectedAnywhere: vi.fn(async () => true),
+    dispatchCommandToAgent: vi.fn(async () => ({ status: 'sent', via: 'local' })),
   },
 }));
 
@@ -105,9 +105,9 @@ vi.mock('../services/redis', () => ({
   getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
 }));
 
-vi.mock('../routes/agentWs', () => ({
-  isAgentConnected: agentWsMock.isAgentConnected,
-  sendCommandToAgent: agentWsMock.sendCommandToAgent,
+vi.mock('../services/agentCommandRelay', () => ({
+  isAgentConnectedAnywhere: agentRelayMock.isAgentConnectedAnywhere,
+  dispatchCommandToAgent: agentRelayMock.dispatchCommandToAgent,
 }));
 
 vi.mock('../services/snmpSecrets', () => ({
@@ -188,13 +188,13 @@ describe('snmpWorker DB-context scoping (#3215)', () => {
       ctxState.events.push(`enqueue@depth${ctxState.depth}`);
       return { id: 'job-1' };
     });
-    agentWsMock.isAgentConnected.mockImplementation(() => {
+    agentRelayMock.isAgentConnectedAnywhere.mockImplementation(async () => {
       ctxState.events.push(`isAgentConnected@depth${ctxState.depth}`);
       return true;
     });
-    agentWsMock.sendCommandToAgent.mockImplementation(() => {
+    agentRelayMock.dispatchCommandToAgent.mockImplementation(async () => {
       ctxState.events.push(`wsDispatch@depth${ctxState.depth}`);
-      return true;
+      return { status: 'sent', via: 'local' };
     });
     mockDb.update.mockImplementation(updateChain as never);
 
@@ -300,7 +300,7 @@ describe('snmpWorker DB-context scoping (#3215)', () => {
     const result = await runJob({ type: 'poll-device', deviceId: 'gone', orgId: 'o1' });
 
     expect(result).toEqual({ dispatched: false, agentId: null });
-    expect(agentWsMock.sendCommandToAgent).not.toHaveBeenCalled();
+    expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
     // The attempt is still stamped (#3217 — an undispatchable device that stays
     // NULL is re-selected on every 60s tick), but no dispatch count is taken and
     // no second context opens.

--- a/apps/api/src/jobs/snmpWorker.orgAuthority.test.ts
+++ b/apps/api/src/jobs/snmpWorker.orgAuthority.test.ts
@@ -23,8 +23,9 @@
  *                     instead of reused.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DispatchOutcome } from '../services/agentCommandRelay';
 
-const { mockDb, queueMock, agentWsMock, decryptMock, eqCalls } = vi.hoisted(() => ({
+const { mockDb, queueMock, agentRelayMock, decryptMock, eqCalls } = vi.hoisted(() => ({
   mockDb: {
     select: vi.fn(),
     insert: vi.fn(),
@@ -38,9 +39,9 @@ const { mockDb, queueMock, agentWsMock, decryptMock, eqCalls } = vi.hoisted(() =
     removeRepeatableByKey: vi.fn(async () => undefined),
     close: vi.fn(async () => undefined),
   },
-  agentWsMock: {
-    isAgentConnected: vi.fn(() => true),
-    sendCommandToAgent: vi.fn(() => true),
+  agentRelayMock: {
+    isAgentConnectedAnywhere: vi.fn(async () => true),
+    dispatchCommandToAgent: vi.fn(async (): Promise<DispatchOutcome> => ({ status: 'sent', via: 'local' })),
   },
   decryptMock: vi.fn((v: string | null) => v),
   // Records every drizzle `eq(column, value)` so a test can prove WHICH org
@@ -111,9 +112,9 @@ vi.mock('../services/redis', () => ({
   getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
 }));
 
-vi.mock('../routes/agentWs', () => ({
-  isAgentConnected: agentWsMock.isAgentConnected,
-  sendCommandToAgent: agentWsMock.sendCommandToAgent,
+vi.mock('../services/agentCommandRelay', () => ({
+  isAgentConnectedAnywhere: agentRelayMock.isAgentConnectedAnywhere,
+  dispatchCommandToAgent: agentRelayMock.dispatchCommandToAgent,
 }));
 
 vi.mock('../services/snmpSecrets', () => ({
@@ -207,8 +208,8 @@ describe('snmpWorker org authority (#3226)', () => {
     mockDb.select.mockReset();
     mockDb.update.mockReset();
     mockDb.update.mockImplementation(updateChain as never);
-    agentWsMock.isAgentConnected.mockReturnValue(true);
-    agentWsMock.sendCommandToAgent.mockReturnValue(true);
+    agentRelayMock.isAgentConnectedAnywhere.mockResolvedValue(true);
+    agentRelayMock.dispatchCommandToAgent.mockResolvedValue({ status: 'sent', via: 'local' });
     queueMock.getJob.mockResolvedValue(null);
     queueMock.add.mockResolvedValue({ id: 'job-1' });
     await shutdownSnmpWorker();
@@ -235,7 +236,7 @@ describe('snmpWorker org authority (#3226)', () => {
 
       // The whole point of the issue: credentials must never reach the wire.
       expect(decryptMock).not.toHaveBeenCalled();
-      expect(agentWsMock.sendCommandToAgent).not.toHaveBeenCalled();
+      expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
     });
 
     it('stops before the agent lookup, so no agent in either org is even selected', async () => {
@@ -315,7 +316,7 @@ describe('snmpWorker org authority (#3226)', () => {
     it('does not dispatch when the selected agent is no longer connected', async () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       wireDispatchSelects(LIVE_ORG, 'agent-live');
-      agentWsMock.isAgentConnected.mockReturnValue(false);
+      agentRelayMock.isAgentConnectedAnywhere.mockResolvedValue(false);
 
       const result = await processPollDevice({
         type: 'poll-device',
@@ -324,7 +325,7 @@ describe('snmpWorker org authority (#3226)', () => {
       });
 
       expect(result).toEqual({ dispatched: false, agentId: null });
-      expect(agentWsMock.sendCommandToAgent).not.toHaveBeenCalled();
+      expect(agentRelayMock.dispatchCommandToAgent).not.toHaveBeenCalled();
       expect(decryptMock).not.toHaveBeenCalled();
       expect(warn).toHaveBeenCalledWith(expect.stringContaining(LIVE_ORG));
       // A poll that never left the building must not count against the device.
@@ -337,13 +338,67 @@ describe('snmpWorker org authority (#3226)', () => {
 
       await processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: LIVE_ORG });
 
-      expect(agentWsMock.sendCommandToAgent).toHaveBeenCalledTimes(1);
-      const [agentId, command] = agentWsMock.sendCommandToAgent.mock.calls[0] as unknown as [
+      expect(agentRelayMock.dispatchCommandToAgent).toHaveBeenCalledTimes(1);
+      const [agentId, command] = agentRelayMock.dispatchCommandToAgent.mock.calls[0] as unknown as [
         string,
         { type: string },
       ];
       expect(agentId).toBe('agent-live');
       expect(command.type).toBe('snmp_poll');
+    });
+  });
+
+  describe('dispatch outcomes via the cross-process facade (wave 3.5b #4084)', () => {
+    it('returns dispatched:false and logs the outcome status when offline', async () => {
+      wireDispatchSelects(LIVE_ORG, 'agent-live');
+      agentRelayMock.dispatchCommandToAgent.mockResolvedValue({ status: 'offline' });
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: LIVE_ORG });
+
+      expect(result).toEqual({ dispatched: false, agentId: 'agent-live' });
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('offline'));
+      error.mockRestore();
+    });
+
+    it('returns dispatched:false and names "indeterminate" so ops can tell "maybe sent" from "definitely not"', async () => {
+      wireDispatchSelects(LIVE_ORG, 'agent-live');
+      agentRelayMock.dispatchCommandToAgent.mockResolvedValue({ status: 'indeterminate' });
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: LIVE_ORG });
+
+      expect(result).toEqual({ dispatched: false, agentId: 'agent-live' });
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('indeterminate'));
+      error.mockRestore();
+    });
+
+    it('dispatches with priority "probe"', async () => {
+      wireDispatchSelects(LIVE_ORG, 'agent-live');
+
+      await processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: LIVE_ORG });
+
+      expect(agentRelayMock.dispatchCommandToAgent).toHaveBeenCalledWith(
+        'agent-live',
+        expect.anything(),
+        { priority: 'probe' }
+      );
+    });
+
+    it('calls markPollDispatched (2nd db.update: attemptStamp is the 1st) BEFORE dispatchCommandToAgent, so an indeterminate dispatch still counts against the device', async () => {
+      wireDispatchSelects(LIVE_ORG, 'agent-live');
+      agentRelayMock.dispatchCommandToAgent.mockResolvedValue({ status: 'indeterminate' });
+
+      await processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: LIVE_ORG });
+
+      // updateLog confirms WHICH write is which (attemptStamp then dispatchCount);
+      // invocationCallOrder proves the relative order against the dispatch call —
+      // an indeterminate outcome (may have been sent) still leaves the poll
+      // counted, mirroring today's send-false-after-mark semantics.
+      expect(updateLog).toEqual(['attemptStamp', 'dispatchCount']);
+      const dispatchCountOrder = mockDb.update.mock.invocationCallOrder[1];
+      const dispatchCallOrder = agentRelayMock.dispatchCommandToAgent.mock.invocationCallOrder[0];
+      expect(dispatchCountOrder).toBeLessThan(dispatchCallOrder as number);
     });
   });
 

--- a/apps/api/src/jobs/snmpWorker.ts
+++ b/apps/api/src/jobs/snmpWorker.ts
@@ -13,7 +13,8 @@ import { getBullMQConnection } from '../services/redis';
 import { createInstrumentedQueue } from '../services/bullmqQueue';
 import { isReusableState } from '../services/bullmqUtils';
 import { attachWorkerObservability } from './workerObservability';
-import { sendCommandToAgent, isAgentConnected, type AgentCommand } from '../routes/agentWs';
+import { dispatchCommandToAgent, isAgentConnectedAnywhere } from '../services/agentCommandRelay';
+import type { AgentCommand } from '../routes/agentWs';
 import { decryptSnmpSecret } from '../services/snmpSecrets';
 
 const { db } = dbModule;
@@ -391,7 +392,7 @@ async function processPollDevice(data: PollDeviceJobData): Promise<{
 
   const { device, oids, agentId } = inputs;
 
-  if (!isAgentConnected(agentId)) {
+  if (!(await isAgentConnectedAnywhere(agentId))) {
     console.warn(`[SnmpWorker] No online agent for org ${device.orgId}`);
     return { dispatched: false, agentId: null };
   }
@@ -408,14 +409,13 @@ async function processPollDevice(data: PollDeviceJobData): Promise<{
 
   // Build and send the command payload
   const command = buildSnmpPollCommand(data.deviceId, device, oids);
-
-  const sent = sendCommandToAgent(agentId, command);
-  if (!sent) {
-    console.error(`[SnmpWorker] Failed to send poll command to agent ${agentId}`);
+  const outcome = await dispatchCommandToAgent(agentId, command, { priority: 'probe' });
+  if (outcome.status !== 'sent') {
+    console.error(`[SnmpWorker] Poll dispatch ${outcome.status} for agent ${agentId}`);
     return { dispatched: false, agentId };
   }
 
-  console.log(`[SnmpWorker] Poll dispatched to agent ${agentId} for device ${data.deviceId}`);
+  console.log(`[SnmpWorker] Poll dispatched to agent ${agentId} for device ${data.deviceId} (${outcome.via})`);
   return { dispatched: true, agentId };
 }
 

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -313,6 +313,7 @@ import {
   __resetCrossTenantDropsForTest,
   AGENT_WS_CAPABILITIES,
 } from './agentWs';
+import { sendCommandToAgentAwaitResult } from '../services/agentCommandAwait';
 import { applySoftwareInstallResult } from '../services/softwareDeploymentResult';
 import { isRedisAvailable } from '../services/redis';
 import {
@@ -2221,6 +2222,51 @@ describe('presence lifecycle (wave 3.5b #4084)', () => {
     handlers.onError({}, ws as any);
 
     expect(clearAgentPresence).toHaveBeenCalledWith('agent-p7', token);
+  });
+});
+
+// Wave 3.5b (#4084) — socket-local dispatch must fail LOUDLY in the worker
+// role rather than silently returning false/offline (the every-agent-reads-
+// offline failure mode this wave exists to kill). A worker-role process never
+// holds sockets, so these three entry points are unreachable there by design.
+describe('worker-role runtime assertions (wave 3.5b #4084)', () => {
+  const originalRole = process.env.BREEZE_ROLE;
+
+  afterEach(() => {
+    if (originalRole === undefined) delete process.env.BREEZE_ROLE;
+    else process.env.BREEZE_ROLE = originalRole;
+  });
+
+  it('sendCommandToAgent throws (never returns false) in the worker role', () => {
+    process.env.BREEZE_ROLE = 'worker';
+
+    expect(() =>
+      sendCommandToAgent('agent-role-1', { id: 'c1', type: 'ping', payload: {} } as any)
+    ).toThrow(/BREEZE_ROLE/);
+  });
+
+  it('isAgentConnected throws in the worker role', () => {
+    process.env.BREEZE_ROLE = 'worker';
+
+    expect(() => isAgentConnected('agent-role-1')).toThrow(/BREEZE_ROLE/);
+  });
+
+  it('sendCommandToAgentAwaitResult throws (never resolves as offline) in the worker role', () => {
+    process.env.BREEZE_ROLE = 'worker';
+
+    // Not `async` — the guard throws synchronously, before a Promise is ever
+    // constructed, so callers see a real throw rather than a rejected Promise.
+    expect(() =>
+      sendCommandToAgentAwaitResult('agent-role-1', { id: 'c1', type: 'ping', payload: {} }, 1_000)
+    ).toThrow(/BREEZE_ROLE/);
+  });
+
+  it('does not throw for any of the three outside the worker role', () => {
+    process.env.BREEZE_ROLE = 'all';
+    expect(() => isAgentConnected('agent-role-2')).not.toThrow();
+
+    delete process.env.BREEZE_ROLE;
+    expect(() => isAgentConnected('agent-role-2')).not.toThrow();
   });
 });
 

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -193,6 +193,18 @@ vi.mock('../services/redis', () => ({
   getRedis: vi.fn(() => null)
 }));
 
+// Wave 3.5b (#4084): presence lifecycle wiring. Defaults are chosen so every
+// OTHER describe block in this file — which never asserts on presence — sees
+// harmless, non-throwing behaviour: refresh "succeeds" so the self-heal branch
+// never fires unless a test explicitly arms it otherwise.
+vi.mock('../services/agentPresence', () => ({
+  setAgentPresence: vi.fn(async () => {}),
+  refreshAgentPresence: vi.fn(async () => true),
+  clearAgentPresence: vi.fn(async () => true),
+  clearAgentPresenceUnfenced: vi.fn(async () => {}),
+  readAgentPresence: vi.fn(async () => null),
+}));
+
 vi.mock('../services/viewerTokenRevocation', () => ({
   revokeViewerSession: vi.fn(async () => undefined),
   // The real terminalWs ping loop consults this; never revoked in these suites.
@@ -303,6 +315,13 @@ import {
 } from './agentWs';
 import { applySoftwareInstallResult } from '../services/softwareDeploymentResult';
 import { isRedisAvailable } from '../services/redis';
+import {
+  clearAgentPresence,
+  clearAgentPresenceUnfenced,
+  refreshAgentPresence,
+  setAgentPresence,
+} from '../services/agentPresence';
+import { INSTANCE_ID } from '../services/instanceIdentity';
 import { checkAgentCertificateBinding } from '../services/agentCertificateBinding';
 import { claimPendingCommandsForDevice } from '../services/commandDispatch';
 import { writeAuditEvent } from '../services/auditEvents';
@@ -2077,6 +2096,131 @@ describe('Finding #4 — one-socket-per-agent invariant', () => {
     expect(isAgentConnected('agent-orphan')).toBe(true);
     disconnectAgent('agent-orphan');
     expect(ws2.close).toHaveBeenCalled();
+  });
+});
+
+// Wave 3.5b (#4084) — fenced presence leases maintained from the WS lifecycle.
+// A lease is an ADMISSION HINT for the command relay (services/agentCommandRelay.ts);
+// these tests pin only that the lifecycle calls the right presence primitive
+// with the right (agentId, connectionToken) pair — fencing/TTL semantics
+// themselves are covered in agentPresence.test.ts.
+describe('presence lifecycle (wave 3.5b #4084)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(setAgentPresence).mockResolvedValue(undefined);
+    vi.mocked(refreshAgentPresence).mockResolvedValue(true);
+    vi.mocked(clearAgentPresence).mockResolvedValue(true);
+    vi.mocked(clearAgentPresenceUnfenced).mockResolvedValue(undefined);
+    vi.mocked(db.update).mockReturnValue(updateResult() as any);
+    vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
+  });
+
+  function connectionTokenFromSetCall(callIndex = 0): string {
+    const call = vi.mocked(setAgentPresence).mock.calls[callIndex];
+    if (!call) throw new Error(`no setAgentPresence call at index ${callIndex}`);
+    return call[1].connectionToken;
+  }
+
+  it('onOpen sets a fenced presence lease bound to this instance with a fresh token', async () => {
+    const handlers = createAgentWsHandlers('agent-p1', { deviceId: 'device-p1', orgId: 'org-p1' });
+
+    await handlers.onOpen({}, wsMock() as any);
+
+    expect(setAgentPresence).toHaveBeenCalledTimes(1);
+    const [agentId, lease] = vi.mocked(setAgentPresence).mock.calls[0]!;
+    expect(agentId).toBe('agent-p1');
+    expect(lease.instanceId).toBe(INSTANCE_ID);
+    expect(typeof lease.connectionToken).toBe('string');
+    expect(lease.connectionToken.length).toBeGreaterThan(0);
+  });
+
+  it("a pong message refreshes the presence lease with this connection's token", async () => {
+    const handlers = createAgentWsHandlers('agent-p2', { deviceId: 'device-p2', orgId: 'org-p2' });
+    const ws = wsMock();
+    await handlers.onOpen({}, ws as any);
+    const token = connectionTokenFromSetCall();
+
+    await handlers.onMessage({ data: JSON.stringify({ type: 'pong' }) } as any, ws as any);
+
+    expect(refreshAgentPresence).toHaveBeenCalledWith('agent-p2', token);
+  });
+
+  it('a heartbeat message also refreshes the presence lease', async () => {
+    const handlers = createAgentWsHandlers('agent-p2b', { deviceId: 'device-p2b', orgId: 'org-p2b' });
+    const ws = wsMock();
+    await handlers.onOpen({}, ws as any);
+    const token = connectionTokenFromSetCall();
+
+    await handlers.onMessage({ data: JSON.stringify({ type: 'heartbeat' }) } as any, ws as any);
+
+    expect(refreshAgentPresence).toHaveBeenCalledWith('agent-p2b', token);
+  });
+
+  it('self-heals by re-setting the lease when refresh fails but this socket is still live', async () => {
+    vi.mocked(refreshAgentPresence).mockResolvedValue(false);
+    const handlers = createAgentWsHandlers('agent-p3', { deviceId: 'device-p3', orgId: 'org-p3' });
+    const ws = wsMock();
+    await handlers.onOpen({}, ws as any);
+    const token = connectionTokenFromSetCall();
+    vi.mocked(setAgentPresence).mockClear();
+
+    await handlers.onMessage({ data: JSON.stringify({ type: 'pong' }) } as any, ws as any);
+    // the refresh->self-heal chain is fire-and-forget (`void ...then(...)`) —
+    // flush microtasks so its callback has run before asserting.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(setAgentPresence).toHaveBeenCalledWith('agent-p3', { instanceId: INSTANCE_ID, connectionToken: token });
+  });
+
+  it('does NOT self-heal when the pong arrives on a superseded socket', async () => {
+    vi.mocked(refreshAgentPresence).mockResolvedValue(false);
+    const handlers = createAgentWsHandlers('agent-p4', { deviceId: 'device-p4', orgId: 'org-p4' });
+    const ws1 = wsMock();
+    const ws2 = wsMock();
+    await handlers.onOpen({}, ws1 as any);
+    await handlers.onOpen({}, ws2 as any); // supersedes ws1
+    vi.mocked(setAgentPresence).mockClear();
+
+    await handlers.onMessage({ data: JSON.stringify({ type: 'pong' }) } as any, ws1 as any);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(setAgentPresence).not.toHaveBeenCalled();
+  });
+
+  it('onClose clears the presence lease for the current socket', async () => {
+    const handlers = createAgentWsHandlers('agent-p5', { deviceId: 'device-p5', orgId: 'org-p5' });
+    const ws = wsMock();
+    await handlers.onOpen({}, ws as any);
+    const token = connectionTokenFromSetCall();
+
+    await handlers.onClose({}, ws as any);
+
+    expect(clearAgentPresence).toHaveBeenCalledWith('agent-p5', token);
+  });
+
+  it("onClose of a superseded (orphan) socket does NOT clear the live socket's lease", async () => {
+    const handlers = createAgentWsHandlers('agent-p6', { deviceId: 'device-p6', orgId: 'org-p6' });
+    const ws1 = wsMock();
+    const ws2 = wsMock();
+    await handlers.onOpen({}, ws1 as any);
+    await handlers.onOpen({}, ws2 as any); // supersedes ws1
+
+    await handlers.onClose({}, ws1 as any); // orphan's late close
+
+    expect(clearAgentPresence).not.toHaveBeenCalled();
+  });
+
+  it('onError clears the presence lease for the current socket', async () => {
+    const handlers = createAgentWsHandlers('agent-p7', { deviceId: 'device-p7', orgId: 'org-p7' });
+    const ws = wsMock();
+    await handlers.onOpen({}, ws as any);
+    const token = connectionTokenFromSetCall();
+
+    handlers.onError({}, ws as any);
+
+    expect(clearAgentPresence).toHaveBeenCalledWith('agent-p7', token);
   });
 });
 

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -75,6 +75,7 @@ import { commandAcceptsAgentResultCondition } from '../services/commandResultAcc
 import { redactResultAgainstCommandSecrets } from '../services/commandSecretRedaction';
 import { INSTANCE_ID } from '../services/instanceIdentity';
 import { clearAgentPresence, clearAgentPresenceUnfenced, setAgentPresence, refreshAgentPresence } from '../services/agentPresence';
+import { breezeRole } from '../config/env';
 /** Capabilities advertised to agents in the post-connect `connected` message. */
 export const AGENT_WS_CAPABILITIES = ['terminal_output_base64', 'backup_run_async'] as const;
 
@@ -3018,6 +3019,19 @@ export function __resetCrossTenantDropsForTest() {
   crossTenantDrops.clear();
 }
 
+// Test-only: install a fake agent socket directly into `activeConnections`
+// without going through the real WS upgrade/auth handshake. Needed by the
+// wave 3.5b (#4084) relay integration suite, which needs a "locally connected"
+// agent on ONE simulated process while dispatching from another. Never usable
+// in production — a real socket must come through createAgentWsHandlers.
+export function __installAgentSocketForTest(agentId: string, ws: { send(data: string): void }): void {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('__installAgentSocketForTest is test-only');
+  }
+  activeConnections.set(agentId, ws as never);
+  installAgentSocketEpoch(agentId);
+}
+
 /**
  * Create the agent WebSocket routes
  * The upgradeWebSocket function must be passed from the main app
@@ -3085,10 +3099,29 @@ export function createAgentWsRoutes(upgradeWebSocket: Function): Hono {
 }
 
 /**
+ * Wave 3.5b (#4084): a worker-role process never holds agent sockets — this
+ * throws rather than letting a socket-local entry point silently return
+ * false/empty, which would otherwise read as "every agent is offline" instead
+ * of "this process cannot answer that question at all". Callers on a process
+ * that may own sockets (`all`/`api`) must route through
+ * dispatchCommandToAgent/isAgentConnectedAnywhere (services/agentCommandRelay.ts)
+ * once BREEZE_ROLE=worker is actually in use (3.5d, #4086).
+ */
+function assertSocketLocalDispatchAllowed(fn: string): void {
+  if (breezeRole() === 'worker') {
+    throw new Error(
+      `[BREEZE_ROLE] ${fn} is socket-local and cannot run in the worker role — `
+      + 'use dispatchCommandToAgent/isAgentConnectedAnywhere (services/agentCommandRelay.ts)',
+    );
+  }
+}
+
+/**
  * Send a command to a connected agent via WebSocket
  * Returns true if the command was sent, false if agent is not connected
  */
 export function sendCommandToAgent(agentId: string, command: AgentCommand): boolean {
+  assertSocketLocalDispatchAllowed('sendCommandToAgent');
   const ws = activeConnections.get(agentId);
   if (!ws) {
     return false;
@@ -3146,6 +3179,7 @@ export function disconnectAgent(agentId: string, code: number = 4040, reason: st
  * Check if an agent is connected via WebSocket
  */
 export function isAgentConnected(agentId: string): boolean {
+  assertSocketLocalDispatchAllowed('isAgentConnected');
   return activeConnections.has(agentId);
 }
 

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import type { WSContext } from 'hono/ws';
 import { z } from 'zod';
 import { eq, and, notInArray, sql } from 'drizzle-orm';
-import { createHash } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { db, withDbAccessContext, withSystemDbAccessContext, runOutsideDbContext } from '../db';
 import { dbWriteExpectingRows } from '../db/dbWriteExpectingRows';
 import { commandCasPriorStatusTags } from '../services/commandCasDiagnostics';
@@ -73,6 +73,8 @@ import { commandResultHandlers, normalizeDiscoveryHosts } from '../services/comm
 import { terminalPayloadErasureSet } from '../services/sensitiveCommandPayload';
 import { commandAcceptsAgentResultCondition } from '../services/commandResultAcceptance';
 import { redactResultAgainstCommandSecrets } from '../services/commandSecretRedaction';
+import { INSTANCE_ID } from '../services/instanceIdentity';
+import { clearAgentPresence, clearAgentPresenceUnfenced, setAgentPresence, refreshAgentPresence } from '../services/agentPresence';
 /** Capabilities advertised to agents in the post-connect `connected` message. */
 export const AGENT_WS_CAPABILITIES = ['terminal_output_base64', 'backup_run_async'] as const;
 
@@ -224,6 +226,7 @@ function ownsCurrentAgentSocket(agentId: string, ws: WSContext, epoch: number): 
 function evictAgentSocket(agentId: string): void {
   activeConnections.delete(agentId);
   agentSocketEpochs.delete(agentId);
+  void clearAgentPresenceUnfenced(agentId);
 }
 
 // Track per-agent ping/pong state for stale connection detection
@@ -1889,6 +1892,12 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
   // installed. Zero until then, which never matches a live epoch.
   let socketEpoch = 0;
 
+  // Fencing token for this connection's presence lease (wave 3.5b, #4084).
+  // Generated once per handler set so a superseded socket's delayed
+  // onClose/onError can never delete a newer connection's lease — the
+  // server-side Lua compare-and-delete only acts when the token matches.
+  const connectionToken = randomUUID();
+
   return {
     onOpen: async (_event: unknown, ws: WSContext) => {
       // Finding #4: enforce the one-socket-per-agent invariant. A second socket
@@ -1917,6 +1926,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
       // Store connection and stamp this socket's delivery epoch.
       activeConnections.set(agentId, ws);
       socketEpoch = installAgentSocketEpoch(agentId);
+      void setAgentPresence(agentId, { instanceId: INSTANCE_ID, connectionToken });
       console.log(`Agent ${agentId} connected via WebSocket. Active connections: ${activeConnections.size}`);
 
       // Update device status under tenant DB context. Pending commands are
@@ -2075,6 +2085,13 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
           const state = agentPingStates.get(agentId);
           if (state) {
             state.lastPongAt = Date.now();
+            void refreshAgentPresence(agentId, connectionToken).then((refreshed) => {
+              // Self-heal: an evict-path unconditional delete may have raced a
+              // reconnect; if we are still the live socket, re-establish the lease.
+              if (!refreshed && activeConnections.get(agentId) === ws) {
+                return setAgentPresence(agentId, { instanceId: INSTANCE_ID, connectionToken });
+              }
+            });
           }
           return;
         }
@@ -2084,6 +2101,11 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
           const state = agentPingStates.get(agentId);
           if (state) {
             state.lastPongAt = Date.now();
+            void refreshAgentPresence(agentId, connectionToken).then((refreshed) => {
+              if (!refreshed && activeConnections.get(agentId) === ws) {
+                return setAgentPresence(agentId, { instanceId: INSTANCE_ID, connectionToken });
+              }
+            });
           }
         }
 
@@ -2635,6 +2657,7 @@ onClose: async (_event: unknown, ws: WSContext) => {
         if (agentSocketEpochs.get(agentId) === socketEpoch) {
           agentSocketEpochs.delete(agentId);
         }
+        void clearAgentPresence(agentId, connectionToken);
         console.log(`Agent ${agentId} disconnected. Active connections: ${activeConnections.size}`);
 
         // Update device status to offline (but preserve 'updating' — let
@@ -2695,6 +2718,7 @@ if (activeConnections.get(agentId) === ws) {
         if (agentSocketEpochs.get(agentId) === socketEpoch) {
           agentSocketEpochs.delete(agentId);
         }
+        void clearAgentPresence(agentId, connectionToken);
       }
       if (agentDb) {
         void runWithAgentDbAccess('agentWs.onError.markOffline', async () => {

--- a/apps/api/src/services/agentCommandAwait.ts
+++ b/apps/api/src/services/agentCommandAwait.ts
@@ -11,9 +11,19 @@
  * The companion `resolvePendingAgentCommand` is called from the agentWs
  * processCommandResult dispatcher whenever a command_result message arrives,
  * so any in-flight awaited command resolves automatically.
+ *
+ * This module is API-ROLE-AFFINE BY DESIGN (wave 3.5b, #4084): `pending` is an
+ * in-process correlation map keyed by command id, resolved only by a
+ * command_result arriving on THIS process's WebSocket. There is no
+ * cross-process equivalent — a worker-role process could enqueue a relay send
+ * via dispatchCommandToAgent, but it could never observe the result, so this
+ * helper is never given a cross-process path. Its callers never leave the api
+ * role (see the plan's Global Constraints — "no cross-process
+ * agentCommandAwait" is a deliberate scope cut, not an oversight).
  */
 
 import { sendCommandToAgent } from '../routes/agentWs';
+import { breezeRole } from '../config/env';
 
 export type AgentCommandAwaitResult = {
   status: string;
@@ -44,6 +54,17 @@ export function sendCommandToAgentAwaitResult(
   command: { id: string; type: string; payload: Record<string, unknown> },
   timeoutMs: number,
 ): Promise<AgentCommandAwaitResult> {
+  // Wave 3.5b (#4084): fail LOUDLY in the worker role rather than resolving
+  // {status:'failed', error:'agent offline'} for every call — that would be
+  // indistinguishable from a real offline agent and would hide the actual
+  // bug (this helper called from a process with no sockets and no way to
+  // ever see the result).
+  if (breezeRole() === 'worker') {
+    throw new Error(
+      '[BREEZE_ROLE] sendCommandToAgentAwaitResult is socket-local and api-role-affine '
+      + '(its correlation map cannot resolve cross-process) — it cannot run in the worker role',
+    );
+  }
   const sent = sendCommandToAgent(agentId, command);
   if (!sent) {
     return Promise.resolve({ status: 'failed', error: 'agent offline' });

--- a/apps/api/src/services/agentCommandRelay.test.ts
+++ b/apps/api/src/services/agentCommandRelay.test.ts
@@ -7,6 +7,20 @@ vi.mock('./redis', () => ({
   getBullMQConnection: vi.fn(() => redisMock),
 }));
 
+vi.mock('../routes/agentWs', () => ({
+  isAgentConnected: vi.fn(),
+  sendCommandToAgent: vi.fn(),
+}));
+vi.mock('./agentPresence', () => ({
+  readAgentPresence: vi.fn(),
+}));
+vi.mock('./bullmqQueue', () => ({
+  createInstrumentedQueue: vi.fn(),
+}));
+vi.mock('../config/env', () => ({
+  breezeRole: vi.fn(() => 'all'),
+}));
+
 // Key setup so secretCrypto can do real AES roundtrips in unit tests. AAD
 // binding requires v3 (AAD-bound) ciphertext, which only happens when a key
 // id is configured — encryptSecret otherwise silently drops to the v1 fallback
@@ -19,11 +33,20 @@ process.env.APP_ENCRYPTION_KEYRING = JSON.stringify({ current: 'current-key-mate
 import {
   awaitRelayAck,
   claimRelaySend,
+  dispatchCommandToAgent,
+  getAgentCommandRelayQueue,
+  isAgentConnectedAnywhere,
   markRelaySendComplete,
   openRelayCommand,
+  RELAY_DELIVERY_DEADLINE_MS,
   sealRelayCommand,
+  shutdownAgentCommandRelayQueue,
   writeRelayAck,
 } from './agentCommandRelay';
+import { isAgentConnected, sendCommandToAgent } from '../routes/agentWs';
+import { readAgentPresence } from './agentPresence';
+import { createInstrumentedQueue } from './bullmqQueue';
+import { breezeRole } from '../config/env';
 
 const BINDING = {
   agentId: 'agent-1',
@@ -62,7 +85,7 @@ describe('send claims (at-most-once)', () => {
     expect(await claimRelaySend('agent-1', 'cmd-1')).toBe('claimed');
     expect(await claimRelaySend('agent-1', 'cmd-1')).toBe('already-sent');
     expect(await claimRelaySend('agent-1', 'cmd-1')).toBe('in-flight');
-    expect(redisMock.eval.mock.calls[0][2]).toBe('agent-relay-claim:agent-1:cmd-1');
+    expect(redisMock.eval.mock.calls[0]?.[2]).toBe('agent-relay-claim:agent-1:cmd-1');
   });
 
   it('claim helpers throw on Redis failure (the consumer must NOT treat unknown claim state as claimable)', async () => {
@@ -94,5 +117,125 @@ describe('acks', () => {
   it('awaitRelayAck returns indeterminate at the deadline', async () => {
     redisMock.get.mockResolvedValue(null);
     await expect(awaitRelayAck('r-1', 250)).resolves.toEqual({ status: 'indeterminate' });
+  });
+});
+
+describe('dispatchCommandToAgent facade', () => {
+  const command = { id: 'cmd-9', type: 'snmp_poll', payload: { community: 'sup3r-s3cret' } };
+  let fakeQueue: { add: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(breezeRole).mockReturnValue('all');
+    fakeQueue = { add: vi.fn().mockResolvedValue(undefined), close: vi.fn().mockResolvedValue(undefined) };
+    vi.mocked(createInstrumentedQueue).mockReturnValue(fakeQueue as never);
+    // Singleton lives at module scope — force a fresh queue per test so
+    // fakeQueue is actually the one exercised.
+    await shutdownAgentCommandRelayQueue();
+  });
+
+  it('local socket + send ok → sent/local, no presence read, no enqueue', async () => {
+    vi.mocked(isAgentConnected).mockReturnValue(true);
+    vi.mocked(sendCommandToAgent).mockReturnValue(true);
+
+    await expect(dispatchCommandToAgent('agent-1', command)).resolves.toEqual({ status: 'sent', via: 'local' });
+    expect(readAgentPresence).not.toHaveBeenCalled();
+    expect(fakeQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('local socket + sendCommandToAgent false → offline, no enqueue', async () => {
+    vi.mocked(isAgentConnected).mockReturnValue(true);
+    vi.mocked(sendCommandToAgent).mockReturnValue(false);
+
+    await expect(dispatchCommandToAgent('agent-1', command)).resolves.toEqual({ status: 'offline' });
+    expect(fakeQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('no local socket + no presence → offline, no enqueue', async () => {
+    vi.mocked(isAgentConnected).mockReturnValue(false);
+    vi.mocked(readAgentPresence).mockResolvedValue(null);
+
+    await expect(dispatchCommandToAgent('agent-1', command)).resolves.toEqual({ status: 'offline' });
+    expect(fakeQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('no local socket + presence exists → enqueues a sealed relay job and resolves via the ack', async () => {
+    vi.mocked(isAgentConnected).mockReturnValue(false);
+    vi.mocked(readAgentPresence).mockResolvedValue({ instanceId: 'inst-9', connectionToken: 'tok-9' });
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({ status: 'sent', via: 'relay' }));
+
+    const before = Date.now();
+    const result = await dispatchCommandToAgent('agent-1', command, { priority: 'probe' });
+    expect(result).toEqual({ status: 'sent', via: 'relay' });
+
+    expect(fakeQueue.add).toHaveBeenCalledTimes(1);
+    const [jobName, data, jobOpts] = fakeQueue.add.mock.calls[0]!;
+    expect(jobName).toBe('relay-send');
+    expect(jobOpts.jobId).toMatch(/^relay-[0-9a-f-]{36}$/);
+    expect(jobOpts.attempts).toBe(1);
+    expect(jobOpts.priority).toBe(1);
+    expect(data.agentId).toBe('agent-1');
+    expect(data.commandId).toBe('cmd-9');
+    expect(data.targetInstanceId).toBe('inst-9');
+    expect(data.connectionToken).toBe('tok-9');
+    expect(data.sealedCommand).not.toContain('sup3r-s3cret');
+    expect(data.expiresAt).toBeGreaterThanOrEqual(before + RELAY_DELIVERY_DEADLINE_MS);
+    expect(data.expiresAt).toBeLessThanOrEqual(Date.now() + RELAY_DELIVERY_DEADLINE_MS);
+  });
+
+  it('default priority (no opts) enqueues at priority 10', async () => {
+    vi.mocked(isAgentConnected).mockReturnValue(false);
+    vi.mocked(readAgentPresence).mockResolvedValue({ instanceId: 'inst-9', connectionToken: 'tok-9' });
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({ status: 'sent', via: 'relay' }));
+
+    await dispatchCommandToAgent('agent-1', command);
+    expect(fakeQueue.add.mock.calls[0]?.[2].priority).toBe(10);
+  });
+
+  it('queue.add throws → infrastructure_error (not offline)', async () => {
+    vi.mocked(isAgentConnected).mockReturnValue(false);
+    vi.mocked(readAgentPresence).mockResolvedValue({ instanceId: 'inst-9', connectionToken: 'tok-9' });
+    fakeQueue.add.mockRejectedValueOnce(new Error('redis down'));
+
+    const result = await dispatchCommandToAgent('agent-1', command);
+    expect(result.status).toBe('infrastructure_error');
+    expect((result as { message: string }).message).toContain('redis down');
+  });
+
+  it('forceRelay:true skips the local-first branch even when a local socket exists', async () => {
+    vi.mocked(isAgentConnected).mockReturnValue(true);
+    vi.mocked(readAgentPresence).mockResolvedValue({ instanceId: 'inst-9', connectionToken: 'tok-9' });
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({ status: 'sent', via: 'relay' }));
+
+    await dispatchCommandToAgent('agent-1', command, { forceRelay: true });
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+    expect(fakeQueue.add).toHaveBeenCalledTimes(1);
+  });
+
+  describe('isAgentConnectedAnywhere', () => {
+    it('local hit → true, no presence read', async () => {
+      vi.mocked(isAgentConnected).mockReturnValue(true);
+      await expect(isAgentConnectedAnywhere('agent-1')).resolves.toBe(true);
+      expect(readAgentPresence).not.toHaveBeenCalled();
+    });
+
+    it('local miss + presence → true', async () => {
+      vi.mocked(isAgentConnected).mockReturnValue(false);
+      vi.mocked(readAgentPresence).mockResolvedValue({ instanceId: 'i', connectionToken: 't' });
+      await expect(isAgentConnectedAnywhere('agent-1')).resolves.toBe(true);
+    });
+
+    it('both miss → false', async () => {
+      vi.mocked(isAgentConnected).mockReturnValue(false);
+      vi.mocked(readAgentPresence).mockResolvedValue(null);
+      await expect(isAgentConnectedAnywhere('agent-1')).resolves.toBe(false);
+    });
+
+    it('under BREEZE_ROLE=worker skips the socket-local check entirely', async () => {
+      vi.mocked(breezeRole).mockReturnValue('worker');
+      vi.mocked(readAgentPresence).mockResolvedValue({ instanceId: 'i', connectionToken: 't' });
+      await expect(isAgentConnectedAnywhere('agent-1')).resolves.toBe(true);
+      expect(isAgentConnected).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/services/agentCommandRelay.test.ts
+++ b/apps/api/src/services/agentCommandRelay.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redisMock = { set: vi.fn(), get: vi.fn(), eval: vi.fn() };
+vi.mock('./redis', () => ({
+  getRedis: vi.fn(() => redisMock),
+  getRedisConnection: vi.fn(() => redisMock),
+  getBullMQConnection: vi.fn(() => redisMock),
+}));
+
+// Key setup so secretCrypto can do real AES roundtrips in unit tests. AAD
+// binding requires v3 (AAD-bound) ciphertext, which only happens when a key
+// id is configured — encryptSecret otherwise silently drops to the v1 fallback
+// and IGNORES aad entirely (see scriptSecretEnvelope.ts's identical guard).
+// Mirrors sensitiveCommandPayload.test.ts:4-8.
+process.env.APP_ENCRYPTION_KEY = process.env.APP_ENCRYPTION_KEY || 'test-only-app-encryption-key-32chars!';
+process.env.APP_ENCRYPTION_KEY_ID = 'current';
+process.env.APP_ENCRYPTION_KEYRING = JSON.stringify({ current: 'current-key-material' });
+
+import {
+  awaitRelayAck,
+  claimRelaySend,
+  markRelaySendComplete,
+  openRelayCommand,
+  sealRelayCommand,
+  writeRelayAck,
+} from './agentCommandRelay';
+
+const BINDING = {
+  agentId: 'agent-1',
+  commandId: 'cmd-1',
+  targetInstanceId: 'inst-1',
+  expiresAt: 1_700_000_000_000,
+};
+
+describe('relay envelope', () => {
+  const command = {
+    id: 'cmd-1',
+    type: 'snmp_poll',
+    payload: { community: 'sup3r-s3cret', oids: ['1.3.6.1'] },
+  };
+
+  it('roundtrips a command and produces NO plaintext payload in the sealed string', () => {
+    const sealed = sealRelayCommand(command, BINDING);
+    expect(sealed).not.toContain('sup3r-s3cret');
+    expect(sealed).not.toContain('snmp_poll');
+    expect(openRelayCommand(sealed, BINDING)).toEqual(command);
+  });
+
+  it('fails closed when any bound field is tampered', () => {
+    const sealed = sealRelayCommand(command, BINDING);
+    expect(() => openRelayCommand(sealed, { ...BINDING, agentId: 'agent-2' })).toThrow();
+    expect(() => openRelayCommand(sealed, { ...BINDING, expiresAt: BINDING.expiresAt + 1 })).toThrow();
+    expect(() => openRelayCommand(`${sealed}x`, BINDING)).toThrow();
+  });
+});
+
+describe('send claims (at-most-once)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('maps Lua results: fresh claim → claimed, sent marker → already-sent, live claim → in-flight', async () => {
+    redisMock.eval.mockResolvedValueOnce(1).mockResolvedValueOnce(2).mockResolvedValueOnce(0);
+    expect(await claimRelaySend('agent-1', 'cmd-1')).toBe('claimed');
+    expect(await claimRelaySend('agent-1', 'cmd-1')).toBe('already-sent');
+    expect(await claimRelaySend('agent-1', 'cmd-1')).toBe('in-flight');
+    expect(redisMock.eval.mock.calls[0][2]).toBe('agent-relay-claim:agent-1:cmd-1');
+  });
+
+  it('claim helpers throw on Redis failure (the consumer must NOT treat unknown claim state as claimable)', async () => {
+    redisMock.eval.mockRejectedValueOnce(new Error('down'));
+    await expect(claimRelaySend('agent-1', 'cmd-1')).rejects.toThrow();
+  });
+
+  it('markRelaySendComplete promotes the claim to sent with a long TTL', async () => {
+    await markRelaySendComplete('agent-1', 'cmd-1');
+    expect(redisMock.set).toHaveBeenCalledWith('agent-relay-claim:agent-1:cmd-1', 'sent', 'PX', 600_000);
+  });
+});
+
+describe('acks', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('writeRelayAck stores the outcome JSON with a TTL', async () => {
+    await writeRelayAck('r-1', { status: 'sent', via: 'relay' });
+    expect(redisMock.set).toHaveBeenCalledWith(
+      'agent-relay-ack:r-1', JSON.stringify({ status: 'sent', via: 'relay' }), 'PX', 30_000,
+    );
+  });
+
+  it('awaitRelayAck polls GET until the ack appears', async () => {
+    redisMock.get.mockResolvedValueOnce(null).mockResolvedValueOnce(JSON.stringify({ status: 'offline' }));
+    await expect(awaitRelayAck('r-1', 1_000)).resolves.toEqual({ status: 'offline' });
+  });
+
+  it('awaitRelayAck returns indeterminate at the deadline', async () => {
+    redisMock.get.mockResolvedValue(null);
+    await expect(awaitRelayAck('r-1', 250)).resolves.toEqual({ status: 'indeterminate' });
+  });
+});

--- a/apps/api/src/services/agentCommandRelay.test.ts
+++ b/apps/api/src/services/agentCommandRelay.test.ts
@@ -202,6 +202,21 @@ describe('dispatchCommandToAgent facade', () => {
     expect((result as { message: string }).message).toContain('redis down');
   });
 
+  it('sealRelayCommand throws (no APP_ENCRYPTION_KEY_ID) → infrastructure_error, not offline, no enqueue', async () => {
+    vi.mocked(isAgentConnected).mockReturnValue(false);
+    vi.mocked(readAgentPresence).mockResolvedValue({ instanceId: 'inst-9', connectionToken: 'tok-9' });
+    const priorKeyId = process.env.APP_ENCRYPTION_KEY_ID;
+    delete process.env.APP_ENCRYPTION_KEY_ID;
+    try {
+      const result = await dispatchCommandToAgent('agent-1', command);
+      expect(result.status).toBe('infrastructure_error');
+      expect((result as { message: string }).message).toMatch(/seal/i);
+    } finally {
+      process.env.APP_ENCRYPTION_KEY_ID = priorKeyId;
+    }
+    expect(fakeQueue.add).not.toHaveBeenCalled();
+  });
+
   it('forceRelay:true skips the local-first branch even when a local socket exists', async () => {
     vi.mocked(isAgentConnected).mockReturnValue(true);
     vi.mocked(readAgentPresence).mockResolvedValue({ instanceId: 'inst-9', connectionToken: 'tok-9' });

--- a/apps/api/src/services/agentCommandRelay.ts
+++ b/apps/api/src/services/agentCommandRelay.ts
@@ -15,8 +15,14 @@
  *     waitUntilFinished — blocking commands on the shared connection stall
  *     every enqueue, #3299; no repo precedent for QueueEvents)
  */
+import { randomUUID } from 'crypto';
+import type { Queue } from 'bullmq';
 import { getRedis } from './redis';
 import { decryptSecret, encryptSecret, getActiveSecretEncryptionKeyId } from './secretCrypto';
+import { breezeRole } from '../config/env';
+import { createInstrumentedQueue } from './bullmqQueue';
+import { readAgentPresence } from './agentPresence';
+import { isAgentConnected, sendCommandToAgent } from '../routes/agentWs';
 import type { AgentCommand } from '../routes/agentWs';
 
 export const AGENT_COMMAND_RELAY_QUEUE = 'agent-command-relay';
@@ -148,4 +154,76 @@ export async function awaitRelayAck(relayId: string, deadlineMs: number): Promis
     if (Date.now() >= deadline) return { status: 'indeterminate' };
     await new Promise((resolve) => setTimeout(resolve, ACK_POLL_INTERVAL_MS));
   }
+}
+
+let relayQueue: Queue<RelayJobData> | null = null;
+
+export function getAgentCommandRelayQueue(): Queue<RelayJobData> {
+  if (!relayQueue) {
+    relayQueue = createInstrumentedQueue<RelayJobData>(AGENT_COMMAND_RELAY_QUEUE);
+  }
+  return relayQueue;
+}
+
+export async function shutdownAgentCommandRelayQueue(): Promise<void> {
+  if (relayQueue) {
+    await relayQueue.close();
+    relayQueue = null;
+  }
+}
+
+export async function isAgentConnectedAnywhere(agentId: string): Promise<boolean> {
+  if (breezeRole() !== 'worker' && isAgentConnected(agentId)) return true;
+  return (await readAgentPresence(agentId)) !== null;
+}
+
+/**
+ * Cross-process-safe agent command dispatch (wave 3.5b, #4084).
+ *
+ * Local-first: on a process that may own sockets, a locally-connected agent
+ * gets today's direct send — zero Redis, zero behavior change. Otherwise the
+ * presence lease admits (or refuses) a relay enqueue, and the api-role
+ * consumer performs the actual socket write. `sent` means the frame reached
+ * ws.send() successfully — it says nothing about execution; results flow
+ * through device_commands exactly as before.
+ */
+export async function dispatchCommandToAgent(
+  agentId: string,
+  command: AgentCommand,
+  opts: { priority?: 'probe' | 'normal'; forceRelay?: boolean } = {},
+): Promise<DispatchOutcome> {
+  if (!opts.forceRelay && breezeRole() !== 'worker' && isAgentConnected(agentId)) {
+    return sendCommandToAgent(agentId, command)
+      ? { status: 'sent', via: 'local' }
+      : { status: 'offline' };
+  }
+
+  const lease = await readAgentPresence(agentId);
+  if (!lease) return { status: 'offline' };
+
+  const relayId = randomUUID();
+  const expiresAt = Date.now() + RELAY_DELIVERY_DEADLINE_MS;
+  const binding: RelayEnvelopeBinding = {
+    agentId, commandId: command.id, targetInstanceId: lease.instanceId, expiresAt,
+  };
+  const data: RelayJobData = {
+    relayId, agentId, commandId: command.id,
+    targetInstanceId: lease.instanceId, connectionToken: lease.connectionToken,
+    expiresAt, sealedCommand: sealRelayCommand(command, binding),
+  };
+  try {
+    await getAgentCommandRelayQueue().add('relay-send', data, {
+      jobId: `relay-${relayId}`,
+      attempts: 1, // at-most-once: claims (not BullMQ retries) guard the send
+      priority: opts.priority === 'probe' ? 1 : 10,
+      removeOnComplete: true,
+      removeOnFail: 100,
+    });
+  } catch (err) {
+    return {
+      status: 'infrastructure_error',
+      message: `relay enqueue failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  return awaitRelayAck(relayId, RELAY_DELIVERY_DEADLINE_MS);
 }

--- a/apps/api/src/services/agentCommandRelay.ts
+++ b/apps/api/src/services/agentCommandRelay.ts
@@ -206,10 +206,19 @@ export async function dispatchCommandToAgent(
   const binding: RelayEnvelopeBinding = {
     agentId, commandId: command.id, targetInstanceId: lease.instanceId, expiresAt,
   };
+  let sealedCommand: string;
+  try {
+    sealedCommand = sealRelayCommand(command, binding);
+  } catch (err) {
+    return {
+      status: 'infrastructure_error',
+      message: `relay envelope seal failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
   const data: RelayJobData = {
     relayId, agentId, commandId: command.id,
     targetInstanceId: lease.instanceId, connectionToken: lease.connectionToken,
-    expiresAt, sealedCommand: sealRelayCommand(command, binding),
+    expiresAt, sealedCommand,
   };
   try {
     await getAgentCommandRelayQueue().add('relay-send', data, {

--- a/apps/api/src/services/agentCommandRelay.ts
+++ b/apps/api/src/services/agentCommandRelay.ts
@@ -1,0 +1,151 @@
+/**
+ * Cross-process agent command relay (wave 3.5b, #4084).
+ *
+ * A worker process (no local WebSocket) that needs to reach an agent enqueues
+ * a job on `agent-command-relay`; only a process that may own sockets
+ * (`BREEZE_ROLE !== 'worker'`) consumes it (agentCommandRelayWorker.ts) and
+ * performs the actual local send. This module holds the shared primitives:
+ *
+ *   - a sealed, AAD-bound envelope for the relay job payload (SNMP/discovery/
+ *     backup commands carry DECRYPTED credentials — the job persists in Redis,
+ *     AOF/snapshots, and failed-job tooling, so it must never carry plaintext)
+ *   - an at-most-once send claim (Redis CAS) so a BullMQ stalled-job
+ *     redelivery can never double-send
+ *   - a typed ack channel the producer polls (never BRPOP/QueueEvents/
+ *     waitUntilFinished — blocking commands on the shared connection stall
+ *     every enqueue, #3299; no repo precedent for QueueEvents)
+ */
+import { getRedis } from './redis';
+import { decryptSecret, encryptSecret, getActiveSecretEncryptionKeyId } from './secretCrypto';
+import type { AgentCommand } from '../routes/agentWs';
+
+export const AGENT_COMMAND_RELAY_QUEUE = 'agent-command-relay';
+export const RELAY_DELIVERY_DEADLINE_MS = 5_000;
+const ACK_POLL_INTERVAL_MS = 100;
+const ACK_TTL_MS = 30_000;
+const CLAIM_TTL_MS = 60_000;
+const SENT_MARKER_TTL_MS = 600_000; // outlives any BullMQ stalled-job redelivery window
+
+// AAD-bound ciphertext (secretCrypto v3) prefix. encryptSecret silently drops
+// to the un-bound v1 fallback and IGNORES aad entirely when no
+// APP_ENCRYPTION_KEY_ID is configured (see scriptSecretEnvelope.ts's identical
+// guard) — that degradation is unacceptable here, where AAD binding IS the
+// tamper defense the design authority requires.
+const AAD_BOUND_PREFIX = 'enc:v3:';
+
+export type DispatchOutcome =
+  | { status: 'sent'; via: 'local' | 'relay' }
+  | { status: 'offline' }
+  | { status: 'expired' }
+  | { status: 'owner_mismatch' }
+  | { status: 'indeterminate' }
+  | { status: 'infrastructure_error'; message: string };
+
+export interface RelayEnvelopeBinding {
+  agentId: string;
+  commandId: string;
+  targetInstanceId: string;
+  expiresAt: number;
+}
+
+export interface RelayJobData {
+  relayId: string;
+  agentId: string;
+  commandId: string;
+  targetInstanceId: string;
+  connectionToken: string;
+  expiresAt: number;
+  sealedCommand: string;
+}
+
+// The BullMQ payload persists in Redis (and its AOF/snapshots, failed-job
+// tooling) — SNMP/discovery/backup commands carry DECRYPTED credentials, so
+// the whole command is sealed and the AAD binds the routing metadata: any
+// tamper of agentId/commandId/target/expiry makes decryption fail closed.
+function relayAad(b: RelayEnvelopeBinding): string {
+  return `agent_command_relay:${b.agentId}:${b.commandId}:${b.targetInstanceId}:${b.expiresAt}`;
+}
+
+export function sealRelayCommand(command: AgentCommand, binding: RelayEnvelopeBinding): string {
+  // A live command must never ride the v1 fallback — AAD binding is the
+  // entire tamper defense for this envelope.
+  if (!getActiveSecretEncryptionKeyId()) {
+    throw new Error(
+      '[agentCommandRelay] APP_ENCRYPTION_KEY_ID is not configured; AAD-bound (v3) encryption is required to seal a relay command',
+    );
+  }
+  const sealed = encryptSecret(JSON.stringify(command), { aad: relayAad(binding) });
+  if (!sealed || !sealed.startsWith(AAD_BOUND_PREFIX)) {
+    throw new Error('[agentCommandRelay] encryption did not produce an AAD-bound envelope');
+  }
+  return sealed;
+}
+
+export function openRelayCommand(sealed: string, binding: RelayEnvelopeBinding): AgentCommand {
+  if (typeof sealed !== 'string' || !sealed.startsWith(AAD_BOUND_PREFIX)) {
+    throw new Error('[agentCommandRelay] sealed command is not AAD-bound ciphertext');
+  }
+  const plain = decryptSecret(sealed, { aad: relayAad(binding) });
+  if (!plain) {
+    throw new Error('[agentCommandRelay] sealed command decrypted to empty');
+  }
+  return JSON.parse(plain) as AgentCommand;
+}
+
+const CLAIM_LUA = `
+local existing = redis.call('GET', KEYS[1])
+if existing == 'sent' then return 2 end
+if existing then return 0 end
+redis.call('SET', KEYS[1], 'claimed', 'PX', ARGV[1])
+return 1
+`;
+
+function claimKey(agentId: string, commandId: string): string {
+  return `agent-relay-claim:${agentId}:${commandId}`;
+}
+
+export async function claimRelaySend(
+  agentId: string, commandId: string,
+): Promise<'claimed' | 'already-sent' | 'in-flight'> {
+  const redis = getRedis();
+  if (!redis) throw new Error('[AgentRelay] Redis unavailable — cannot take send claim');
+  const res = await redis.eval(CLAIM_LUA, 1, claimKey(agentId, commandId), String(CLAIM_TTL_MS));
+  if (res === 2) return 'already-sent';
+  if (res === 1) return 'claimed';
+  return 'in-flight';
+}
+
+export async function markRelaySendComplete(agentId: string, commandId: string): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  await redis.set(claimKey(agentId, commandId), 'sent', 'PX', SENT_MARKER_TTL_MS);
+}
+
+function ackKey(relayId: string): string {
+  return `agent-relay-ack:${relayId}`;
+}
+
+export async function writeRelayAck(relayId: string, outcome: DispatchOutcome): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  await redis.set(ackKey(relayId), JSON.stringify(outcome), 'PX', ACK_TTL_MS);
+}
+
+// Plain GET polling on the shared connection — deliberately NOT BRPOP /
+// QueueEvents / waitUntilFinished (blocking commands on the shared connection
+// stall every enqueue, #3299; QueueEvents has no repo precedent).
+export async function awaitRelayAck(relayId: string, deadlineMs: number): Promise<DispatchOutcome> {
+  const redis = getRedis();
+  if (!redis) return { status: 'indeterminate' };
+  const deadline = Date.now() + deadlineMs;
+  for (;;) {
+    try {
+      const raw = await redis.get(ackKey(relayId));
+      if (raw) return JSON.parse(raw) as DispatchOutcome;
+    } catch {
+      // transient read failure — keep polling until the deadline
+    }
+    if (Date.now() >= deadline) return { status: 'indeterminate' };
+    await new Promise((resolve) => setTimeout(resolve, ACK_POLL_INTERVAL_MS));
+  }
+}

--- a/apps/api/src/services/agentPresence.test.ts
+++ b/apps/api/src/services/agentPresence.test.ts
@@ -41,7 +41,7 @@ describe('agentPresence', () => {
     redisMock.eval.mockResolvedValueOnce(1).mockResolvedValueOnce(0);
     expect(await refreshAgentPresence('agent-1', 't-1')).toBe(true);
     expect(await refreshAgentPresence('agent-1', 't-2')).toBe(false);
-    const [script, numKeys, key, token, ttl] = redisMock.eval.mock.calls[0];
+    const [script, numKeys, key, token, ttl] = redisMock.eval.mock.calls[0]!;
     expect(script).toContain('PEXPIRE');
     expect(numKeys).toBe(1);
     expect(key).toBe('agent-presence:agent-1');
@@ -52,7 +52,7 @@ describe('agentPresence', () => {
   it('clearAgentPresence deletes only when the token matches (Lua DEL script)', async () => {
     redisMock.eval.mockResolvedValueOnce(1);
     expect(await clearAgentPresence('agent-1', 't-1')).toBe(true);
-    expect(redisMock.eval.mock.calls[0][0]).toContain("redis.call('DEL', KEYS[1])");
+    expect(redisMock.eval.mock.calls[0]![0]).toContain("redis.call('DEL', KEYS[1])");
   });
 
   it('readAgentPresence parses the lease and returns null on missing/corrupt', async () => {

--- a/apps/api/src/services/agentPresence.test.ts
+++ b/apps/api/src/services/agentPresence.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redisMock = {
+  set: vi.fn(),
+  get: vi.fn(),
+  eval: vi.fn(),
+};
+vi.mock('./redis', () => ({ getRedis: vi.fn(() => redisMock) }));
+
+import { getRedis } from './redis';
+import {
+  AGENT_PRESENCE_TTL_MS,
+  clearAgentPresence,
+  readAgentPresence,
+  refreshAgentPresence,
+  setAgentPresence,
+} from './agentPresence';
+
+describe('agentPresence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // clearAllMocks() resets call history but not a prior mockReturnValue —
+    // re-anchor to the live redisMock so the "Redis unavailable" test's
+    // `mockReturnValue(null)` doesn't leak into later tests.
+    vi.mocked(getRedis).mockReturnValue(redisMock as never);
+  });
+
+  it('setAgentPresence SETs JSON with PX TTL', async () => {
+    await setAgentPresence('agent-1', { instanceId: 'i-1', connectionToken: 't-1' });
+    expect(redisMock.set).toHaveBeenCalledWith(
+      'agent-presence:agent-1',
+      JSON.stringify({ instanceId: 'i-1', connectionToken: 't-1' }),
+      'PX',
+      AGENT_PRESENCE_TTL_MS,
+    );
+  });
+
+  it('refreshAgentPresence evals the compare-refresh Lua with token + TTL and maps 1→true, 0→false', async () => {
+    redisMock.eval.mockResolvedValueOnce(1).mockResolvedValueOnce(0);
+    expect(await refreshAgentPresence('agent-1', 't-1')).toBe(true);
+    expect(await refreshAgentPresence('agent-1', 't-2')).toBe(false);
+    const [script, numKeys, key, token, ttl] = redisMock.eval.mock.calls[0];
+    expect(script).toContain('PEXPIRE');
+    expect(numKeys).toBe(1);
+    expect(key).toBe('agent-presence:agent-1');
+    expect(token).toBe('t-1');
+    expect(ttl).toBe(String(AGENT_PRESENCE_TTL_MS));
+  });
+
+  it('clearAgentPresence deletes only when the token matches (Lua DEL script)', async () => {
+    redisMock.eval.mockResolvedValueOnce(1);
+    expect(await clearAgentPresence('agent-1', 't-1')).toBe(true);
+    expect(redisMock.eval.mock.calls[0][0]).toContain("redis.call('DEL', KEYS[1])");
+  });
+
+  it('readAgentPresence parses the lease and returns null on missing/corrupt', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({ instanceId: 'i-1', connectionToken: 't-1' }));
+    expect(await readAgentPresence('agent-1')).toEqual({ instanceId: 'i-1', connectionToken: 't-1' });
+    redisMock.get.mockResolvedValueOnce(null);
+    expect(await readAgentPresence('agent-1')).toBeNull();
+    redisMock.get.mockResolvedValueOnce('{not json');
+    expect(await readAgentPresence('agent-1')).toBeNull();
+  });
+
+  it('every helper is a safe no-op when Redis is unavailable', async () => {
+    vi.mocked(getRedis).mockReturnValue(null as never);
+    await expect(setAgentPresence('a', { instanceId: 'i', connectionToken: 't' })).resolves.toBeUndefined();
+    await expect(refreshAgentPresence('a', 't')).resolves.toBe(false);
+    await expect(clearAgentPresence('a', 't')).resolves.toBe(false);
+    await expect(readAgentPresence('a')).resolves.toBeNull();
+  });
+
+  it('helpers swallow Redis errors (log, never throw)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    redisMock.set.mockRejectedValueOnce(new Error('boom'));
+    await expect(setAgentPresence('a', { instanceId: 'i', connectionToken: 't' })).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/agentPresence.test.ts
+++ b/apps/api/src/services/agentPresence.test.ts
@@ -4,6 +4,7 @@ const redisMock = {
   set: vi.fn(),
   get: vi.fn(),
   eval: vi.fn(),
+  del: vi.fn(),
 };
 vi.mock('./redis', () => ({ getRedis: vi.fn(() => redisMock) }));
 
@@ -11,6 +12,7 @@ import { getRedis } from './redis';
 import {
   AGENT_PRESENCE_TTL_MS,
   clearAgentPresence,
+  clearAgentPresenceUnfenced,
   readAgentPresence,
   refreshAgentPresence,
   setAgentPresence,
@@ -62,12 +64,18 @@ describe('agentPresence', () => {
     expect(await readAgentPresence('agent-1')).toBeNull();
   });
 
+  it('clearAgentPresenceUnfenced unconditionally DELs the key (no token check)', async () => {
+    await clearAgentPresenceUnfenced('agent-1');
+    expect(redisMock.del).toHaveBeenCalledWith('agent-presence:agent-1');
+  });
+
   it('every helper is a safe no-op when Redis is unavailable', async () => {
     vi.mocked(getRedis).mockReturnValue(null as never);
     await expect(setAgentPresence('a', { instanceId: 'i', connectionToken: 't' })).resolves.toBeUndefined();
     await expect(refreshAgentPresence('a', 't')).resolves.toBe(false);
     await expect(clearAgentPresence('a', 't')).resolves.toBe(false);
     await expect(readAgentPresence('a')).resolves.toBeNull();
+    await expect(clearAgentPresenceUnfenced('a')).resolves.toBeUndefined();
   });
 
   it('helpers swallow Redis errors (log, never throw)', async () => {

--- a/apps/api/src/services/agentPresence.ts
+++ b/apps/api/src/services/agentPresence.ts
@@ -1,0 +1,91 @@
+// apps/api/src/services/agentPresence.ts
+import { getRedis } from './redis';
+
+// Fenced presence leases for agent WebSockets (wave 3.5b, #4084).
+// A lease is an ADMISSION HINT for the command relay — the socket-owning
+// process's in-memory map stays authoritative. Fencing: every mutation is
+// token-guarded server-side (Lua), so an old socket's delayed onClose can
+// never delete a newer connection's lease.
+const PRESENCE_KEY_PREFIX = 'agent-presence:';
+export const AGENT_PRESENCE_TTL_MS = 90_000;
+
+export interface AgentPresenceLease {
+  instanceId: string;
+  connectionToken: string;
+}
+
+// Runs server-side in Redis (ioredis Lua API, not JS eval); token comes in as
+// ARGV, never interpolated into the script.
+const REFRESH_IF_TOKEN_MATCHES_LUA = `
+local raw = redis.call('GET', KEYS[1])
+if not raw then return 0 end
+local ok, lease = pcall(cjson.decode, raw)
+if not ok or lease.connectionToken ~= ARGV[1] then return 0 end
+redis.call('PEXPIRE', KEYS[1], ARGV[2])
+return 1
+`;
+
+const DELETE_IF_TOKEN_MATCHES_LUA = `
+local raw = redis.call('GET', KEYS[1])
+if not raw then return 0 end
+local ok, lease = pcall(cjson.decode, raw)
+if not ok or lease.connectionToken ~= ARGV[1] then return 0 end
+redis.call('DEL', KEYS[1])
+return 1
+`;
+
+function presenceKey(agentId: string): string {
+  return `${PRESENCE_KEY_PREFIX}${agentId}`;
+}
+
+export async function setAgentPresence(agentId: string, lease: AgentPresenceLease): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    // Unconditional SET: onOpen installs the newest socket as authoritative
+    // (mirrors the activeConnections/epoch model), so the newest lease wins.
+    await redis.set(presenceKey(agentId), JSON.stringify(lease), 'PX', AGENT_PRESENCE_TTL_MS);
+  } catch (err) {
+    console.warn(`[AgentPresence] set failed for ${agentId.slice(0, 12)}:`, err);
+  }
+}
+
+export async function refreshAgentPresence(agentId: string, connectionToken: string): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  try {
+    const res = await redis.eval(
+      REFRESH_IF_TOKEN_MATCHES_LUA, 1, presenceKey(agentId), connectionToken, String(AGENT_PRESENCE_TTL_MS),
+    );
+    return res === 1;
+  } catch (err) {
+    console.warn(`[AgentPresence] refresh failed for ${agentId.slice(0, 12)}:`, err);
+    return false;
+  }
+}
+
+export async function clearAgentPresence(agentId: string, connectionToken: string): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  try {
+    const res = await redis.eval(DELETE_IF_TOKEN_MATCHES_LUA, 1, presenceKey(agentId), connectionToken);
+    return res === 1;
+  } catch (err) {
+    console.warn(`[AgentPresence] clear failed for ${agentId.slice(0, 12)}:`, err);
+    return false;
+  }
+}
+
+export async function readAgentPresence(agentId: string): Promise<AgentPresenceLease | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+  try {
+    const raw = await redis.get(presenceKey(agentId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as AgentPresenceLease;
+    if (typeof parsed?.instanceId !== 'string' || typeof parsed?.connectionToken !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/services/agentPresence.ts
+++ b/apps/api/src/services/agentPresence.ts
@@ -76,6 +76,22 @@ export async function clearAgentPresence(agentId: string, connectionToken: strin
   }
 }
 
+/**
+ * Unconditional delete — no token fencing. Used only from `evictAgentSocket`
+ * (module-level in agentWs.ts), which has no `connectionToken` in scope. The
+ * pong-branch self-heal in the WS lifecycle bounds the collateral window: a
+ * reconnect racing this delete re-establishes its lease on its next pong.
+ */
+export async function clearAgentPresenceUnfenced(agentId: string): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await redis.del(presenceKey(agentId));
+  } catch (err) {
+    console.warn(`[AgentPresence] unfenced clear failed for ${agentId.slice(0, 12)}:`, err);
+  }
+}
+
 export async function readAgentPresence(agentId: string): Promise<AgentPresenceLease | null> {
   const redis = getRedis();
   if (!redis) return null;

--- a/apps/api/src/services/instanceIdentity.ts
+++ b/apps/api/src/services/instanceIdentity.ts
@@ -1,0 +1,7 @@
+// apps/api/src/services/instanceIdentity.ts
+import { randomUUID } from 'crypto';
+
+// Identity of this process instance (wave 3.5b, #4084). Regenerated every
+// boot — a presence lease naming a dead instance simply ages out via TTL, so
+// there is deliberately no persistence and no bootId beyond this.
+export const INSTANCE_ID = randomUUID();

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -268,6 +268,14 @@ export default defineConfig({
       // already covered by the shared glob above; named here for discoverability
       // only.
       'src/__tests__/integration/alertNotificationSendIdentity.integration.test.ts',
+      // Wave 3.5b (#4084): real-Redis coverage for the socket-affinity command
+      // relay — fenced presence leases, the sealed AAD-bound envelope, the
+      // at-most-once send claim, owner/expiry fencing, and the
+      // dispatchCommandToAgent local-vs-relay facade. No Postgres fixtures;
+      // lives under src/__tests__/integration/** so it's already covered by
+      // the shared glob above; named here for discoverability only (same
+      // pattern staleBackupReaper.integration.test.ts uses).
+      'src/__tests__/integration/agentCommandRelay.integration.test.ts',
     ],
     exclude: [
       // Uses fresh request-pool modules and manages its own temporary role;

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -292,6 +292,9 @@ services:
       # Durable event dispatch (wave 3.5c, #4085; optional, defaults to off).
       EVENT_DISPATCH_MODE: ${EVENT_DISPATCH_MODE:-off}
       EVENT_DISPATCH_QUEUE_SUBSCRIBERS: ${EVENT_DISPATCH_QUEUE_SUBSCRIBERS:-}
+      # Process role for the 3.5d socket/worker split (wave 3.5b, #4084;
+      # optional, defaults to all).
+      BREEZE_ROLE: ${BREEZE_ROLE:-all}
       # Native APNs push for the iOS app (all optional; unset = push disabled).
       # All-or-none: setting ANY of these makes the four credentials required,
       # so a half-configured relay fails at boot instead of silently at first

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,6 +194,9 @@ services:
       # Durable event dispatch (wave 3.5c, #4085; optional, defaults to off).
       EVENT_DISPATCH_MODE: ${EVENT_DISPATCH_MODE:-off}
       EVENT_DISPATCH_QUEUE_SUBSCRIBERS: ${EVENT_DISPATCH_QUEUE_SUBSCRIBERS:-}
+      # Process role for the 3.5d socket/worker split (wave 3.5b, #4084;
+      # optional, defaults to all).
+      BREEZE_ROLE: ${BREEZE_ROLE:-all}
       # Native APNs push for the iOS app (all optional; unset = push disabled).
       # All-or-none: setting ANY of these makes the four credentials required,
       # so a half-configured relay fails at boot instead of silently at first

--- a/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave3.5b-socket-affinity-relay.md
+++ b/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave3.5b-socket-affinity-relay.md
@@ -1,0 +1,1123 @@
+---
+tracking_issue: LanternOps/breeze#3821
+wave: W08 (#4084)
+---
+
+# Wave 3.5b — Socket-Affinity Command Relay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Agent command dispatch that works from a process that does NOT hold the agent's WebSocket — unblocking the 3.5d `BREEZE_ROLE` split — via a fenced Redis presence registry, one api-role-consumed BullMQ relay queue, and a `dispatchCommandToAgent()` facade, with zero behavior change in today's all-in-one topology.
+
+**Architecture:** The WS lifecycle maintains a token-fenced presence lease per agent in Redis (`agent-presence:<agentId>`, 90s TTL, refreshed on pong). Workers call a new facade: local socket → direct send (today's path, unchanged); no local socket → presence check → enqueue an **encrypted** relay job on `agent-command-relay`, consumed only by processes that own sockets (`BREEZE_ROLE !== 'worker'`). The consumer validates owner/expiry, takes an at-most-once send claim (Redis CAS), performs the local send (which keeps `orphanedResultExpectations` on the socket-owning process), and writes a typed ack the producer polls for. Result routing needs no work: `command_result` → DB writes → `waitForCommandResult` DB polling is already cross-process-safe.
+
+**Tech Stack:** Hono/TypeScript, BullMQ (`createInstrumentedQueue`), ioredis Lua CAS (`redis.eval`), `secretCrypto` AAD-bound envelopes, Vitest (unit + real-PG/Redis integration). **No new DB migrations** — presence, claims, and acks live in Redis; commands already persist in `device_commands`.
+
+**Design authority:** Issue #4084 + advisor quorum 2026-08-27 (Claude position "2-lite", codex `xhigh` independent review; both picked the same shape; codex hardenings adopted = "2-lite+"): (1) typed delivery outcomes — enqueue success is NOT "sent"; (2) relay job payloads are sealed with an AAD-bound envelope, never plaintext (SNMP/discovery/backup commands carry decrypted credentials); (3) at-most-once send claims — a BullMQ stalled-job redelivery must not double-send; (4) presence is an admission hint only, the consumer's local socket map is authoritative; (5) ship UNFLAGGED — in `BREEZE_ROLE=all` the relay path is unreachable for online agents, topology is the rollout control, rollback is `BREEZE_ROLE=all` (never a mode that silently reports agents offline). **Do not relitigate:** no worker pinning (defeats 3.5d); no per-instance queue sharding or multi-replica API support (follow-up — compose runs exactly one api container); no cross-process `agentCommandAwait` (its callers never leave the api role); no durable orphaned-result expectations (single API replica keeps them correct).
+
+## Global Constraints
+
+- **No new migrations in this wave.** If you believe you need one, stop — the design keeps all new state in Redis. (For reference, newest committed migration is `2026-09-11-g-drop-event-bus-events.sql`; a new one would need to sort after it.)
+- Every Redis/BullMQ enqueue from a code path that may hold a DB context runs via `runOutsideDbContext` (#1105). Use `createInstrumentedQueue` (`apps/api/src/services/bullmqQueue.ts:41`), never bare `new Queue`. The facade does Redis I/O — callers must invoke it outside held DB contexts (snmpWorker's phase-split comment at `snmpWorker.ts:400-407` is the pattern).
+- BullMQ jobIds are hyphen-only — a `:` in a custom jobId is rejected (`apps/api/src/jobs/aiAgentRunner.ts:54`). Relay jobIds are `relay-<uuid>`.
+- Never call blocking Redis commands on the shared connection (#3299). This plan uses NO blocking commands — ack waiting is a `GET` poll loop; do not "improve" it to BRPOP/`QueueEvents`/`waitUntilFinished` (no repo precedent; `QueueEvents` grep = zero hits).
+- New env vars land in `apps/api/src/config/env.ts` + `apps/api/src/config/validate.ts` + `.env.example` + `docker-compose.yml` api `environment:` + `deploy/docker-compose.prod.yml` in the SAME task (`envComposeParity.test.ts` enforces). This wave adds exactly one: `BREEZE_ROLE` (default `all`).
+- New integration test files MUST be added to the explicit `include` list in `apps/api/vitest.integration.config.ts` (~line 11) — a misplaced file is collected by ZERO CI jobs and reads green.
+- Run single test files as `cd apps/api && npx vitest run <path>` (never `pnpm --filter ... test -- --run <path>`). Integration: `npx vitest run --config vitest.integration.config.ts <path>` with real PG+Redis (`docker compose -f docker-compose.test.yml up`).
+- The agent wire frame is exactly `{id, type, payload}` (`agentWs.ts:3067` comment; `toAgentCommandFrame`, `sensitiveCommandPayload.ts:184`) — the relay must deliver byte-identical frames to what a local send would produce.
+- Stable names (never rename once shipped): queue `agent-command-relay`; Redis key prefixes `agent-presence:`, `agent-relay-claim:`, `agent-relay-ack:`.
+- Commit after every task (checkpoint commits; context loss must be cheap).
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `apps/api/src/services/instanceIdentity.ts` (new) | Leaf module: per-boot `INSTANCE_ID`. No imports. |
+| `apps/api/src/services/agentPresence.ts` (new) | Token-fenced presence leases: set / Lua compare-refresh / Lua compare-delete / read. |
+| `apps/api/src/services/agentCommandRelay.ts` (new) | `DispatchOutcome`, sealed envelope (seal/open), send-claim CAS, ack write/poll, relay queue singleton, `dispatchCommandToAgent()` + `isAgentConnectedAnywhere()` facade. |
+| `apps/api/src/jobs/agentCommandRelayWorker.ts` (new) | Api-role relay consumer: expiry/owner validation → claim → local send → ack. |
+| `apps/api/src/routes/agentWs.ts` (modify) | Presence lifecycle wiring (onOpen/pong/onClose/onError/evict); worker-role runtime assertion on socket-local exports; test-only socket installer. |
+| `apps/api/src/services/agentCommandAwait.ts` (modify) | Worker-role runtime assertion + api-role-affinity doc comment. |
+| `apps/api/src/config/env.ts` / `validate.ts` (modify) | `breezeRole(): 'all'\|'api'\|'worker'`. |
+| `apps/api/src/index.ts` (modify) | Register relay worker gated on `breezeRole() !== 'worker'`. |
+| 4 × `apps/api/src/jobs/{monitor,snmp,backup,discovery}Worker.ts` (modify) | Migrate to the facade; type-only `AgentCommand` imports. |
+| `apps/api/src/jobs/agentDispatchBoundary.contract.test.ts` (new) | Static contract: `jobs/**` may not value-import socket-local dispatch. |
+| `apps/api/src/__tests__/integration/agentCommandRelay.integration.test.ts` (new) | Real-Redis relay E2E, presence lifecycle, fencing, no-plaintext, at-most-once. |
+
+---
+
+### Task 1: `BREEZE_ROLE` env helper + `INSTANCE_ID` leaf module
+
+**Files:**
+- Create: `apps/api/src/services/instanceIdentity.ts`
+- Modify: `apps/api/src/config/env.ts` (append near `eventDispatchMode`, ~line 217)
+- Modify: `apps/api/src/config/validate.ts` (optional enum entry, mirror how `EVENT_DISPATCH_MODE` is declared)
+- Modify: `.env.example`, `docker-compose.yml` (api `environment:`), `deploy/docker-compose.prod.yml` (api `environment:`)
+- Test: `apps/api/src/config/env.breezeRole.test.ts`
+
+**Interfaces:**
+- Produces: `breezeRole(): BreezeRole` (`'all'|'api'|'worker'`, default `'all'`), `INSTANCE_ID: string`.
+
+- [ ] **Step 1: Write the leaf identity module** (const-only, no test):
+
+```ts
+// apps/api/src/services/instanceIdentity.ts
+import { randomUUID } from 'crypto';
+
+// Identity of this process instance (wave 3.5b, #4084). Regenerated every
+// boot — a presence lease naming a dead instance simply ages out via TTL, so
+// there is deliberately no persistence and no bootId beyond this.
+export const INSTANCE_ID = randomUUID();
+```
+
+- [ ] **Step 2: Write the failing env-helper tests**
+
+```ts
+// apps/api/src/config/env.breezeRole.test.ts
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { breezeRole } from './env';
+
+describe('breezeRole()', () => {
+  const original = process.env.BREEZE_ROLE;
+  afterEach(() => {
+    if (original === undefined) delete process.env.BREEZE_ROLE;
+    else process.env.BREEZE_ROLE = original;
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    [undefined, 'all'],
+    ['', 'all'],
+    ['all', 'all'],
+    ['api', 'api'],
+    ['worker', 'worker'],
+    ['API', 'api'],
+    ['  worker  ', 'worker'],
+  ])('BREEZE_ROLE=%s → %s', (raw, expected) => {
+    if (raw === undefined) delete process.env.BREEZE_ROLE;
+    else process.env.BREEZE_ROLE = raw;
+    expect(breezeRole()).toBe(expected);
+  });
+
+  it('unknown value warns and falls back to all', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.BREEZE_ROLE = 'banana';
+    expect(breezeRole()).toBe('all');
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify failure** — `cd apps/api && npx vitest run src/config/env.breezeRole.test.ts` → FAIL (`breezeRole` not exported).
+
+- [ ] **Step 4: Implement in `env.ts`** (mirror `eventDispatchMode`, env.ts:217):
+
+```ts
+export type BreezeRole = 'all' | 'api' | 'worker';
+
+/**
+ * Process role for the 3.5d split (#4086). `all` (default) = today's
+ * all-in-one process. Introduced in 3.5b (#4084) so socket-local dispatch can
+ * fail LOUDLY in a worker-role process instead of silently reporting every
+ * agent offline.
+ */
+export function breezeRole(): BreezeRole {
+  const raw = (process.env.BREEZE_ROLE ?? '').trim().toLowerCase();
+  if (raw === '' || raw === 'all') return 'all';
+  if (raw === 'api' || raw === 'worker') return raw;
+  console.warn(`[config] BREEZE_ROLE="${raw}" is not all|api|worker — treating as all`);
+  return 'all';
+}
+```
+
+Add the matching optional-enum entry in `config/validate.ts` exactly the way `EVENT_DISPATCH_MODE` is declared there (same optionality — absent means `all`; do NOT make it required-in-production in this wave).
+
+- [ ] **Step 5: Env parity plumbing** — add to `.env.example` (`# BREEZE_ROLE=all — process role; 'worker' disables socket-local agent dispatch (wave 3.5d)`), and `BREEZE_ROLE: ${BREEZE_ROLE:-all}` to the api service `environment:` block in `docker-compose.yml` AND `deploy/docker-compose.prod.yml`. Run `cd apps/api && npx vitest run src/config/envComposeParity.test.ts` → PASS.
+
+- [ ] **Step 6: Run tests** — `npx vitest run src/config/env.breezeRole.test.ts` → PASS. Commit: `feat(api): BREEZE_ROLE env helper + per-boot INSTANCE_ID (wave 3.5b #4084)`
+
+---
+
+### Task 2: Fenced presence leases — `agentPresence.ts`
+
+**Files:**
+- Create: `apps/api/src/services/agentPresence.ts`
+- Test: `apps/api/src/services/agentPresence.test.ts` (unit, mocked redis; real-Redis behavior lands in Task 9's integration suite)
+
+**Interfaces:**
+- Produces: `AgentPresenceLease { instanceId: string; connectionToken: string }`, `AGENT_PRESENCE_TTL_MS = 90_000`, `setAgentPresence(agentId, lease): Promise<void>`, `refreshAgentPresence(agentId, connectionToken): Promise<boolean>`, `clearAgentPresence(agentId, connectionToken): Promise<boolean>`, `readAgentPresence(agentId): Promise<AgentPresenceLease | null>`. All best-effort: Redis unavailable → no-op / `null` / `false`, never throw (presence is an admission hint; missing presence fails closed as "offline").
+
+- [ ] **Step 1: Write the failing unit tests** — mock `getRedis` (pattern: existing `services/*.test.ts` that `vi.mock('./redis', ...)`):
+
+```ts
+// apps/api/src/services/agentPresence.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redisMock = {
+  set: vi.fn(),
+  get: vi.fn(),
+  eval: vi.fn(),
+};
+vi.mock('./redis', () => ({ getRedis: vi.fn(() => redisMock) }));
+
+import { getRedis } from './redis';
+import {
+  AGENT_PRESENCE_TTL_MS,
+  clearAgentPresence,
+  readAgentPresence,
+  refreshAgentPresence,
+  setAgentPresence,
+} from './agentPresence';
+
+describe('agentPresence', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('setAgentPresence SETs JSON with PX TTL', async () => {
+    await setAgentPresence('agent-1', { instanceId: 'i-1', connectionToken: 't-1' });
+    expect(redisMock.set).toHaveBeenCalledWith(
+      'agent-presence:agent-1',
+      JSON.stringify({ instanceId: 'i-1', connectionToken: 't-1' }),
+      'PX',
+      AGENT_PRESENCE_TTL_MS,
+    );
+  });
+
+  it('refreshAgentPresence evals the compare-refresh Lua with token + TTL and maps 1→true, 0→false', async () => {
+    redisMock.eval.mockResolvedValueOnce(1).mockResolvedValueOnce(0);
+    expect(await refreshAgentPresence('agent-1', 't-1')).toBe(true);
+    expect(await refreshAgentPresence('agent-1', 't-2')).toBe(false);
+    const [script, numKeys, key, token, ttl] = redisMock.eval.mock.calls[0];
+    expect(script).toContain('PEXPIRE');
+    expect(numKeys).toBe(1);
+    expect(key).toBe('agent-presence:agent-1');
+    expect(token).toBe('t-1');
+    expect(ttl).toBe(String(AGENT_PRESENCE_TTL_MS));
+  });
+
+  it('clearAgentPresence deletes only when the token matches (Lua DEL script)', async () => {
+    redisMock.eval.mockResolvedValueOnce(1);
+    expect(await clearAgentPresence('agent-1', 't-1')).toBe(true);
+    expect(redisMock.eval.mock.calls[0][0]).toContain("redis.call('DEL', KEYS[1])");
+  });
+
+  it('readAgentPresence parses the lease and returns null on missing/corrupt', async () => {
+    redisMock.get.mockResolvedValueOnce(JSON.stringify({ instanceId: 'i-1', connectionToken: 't-1' }));
+    expect(await readAgentPresence('agent-1')).toEqual({ instanceId: 'i-1', connectionToken: 't-1' });
+    redisMock.get.mockResolvedValueOnce(null);
+    expect(await readAgentPresence('agent-1')).toBeNull();
+    redisMock.get.mockResolvedValueOnce('{not json');
+    expect(await readAgentPresence('agent-1')).toBeNull();
+  });
+
+  it('every helper is a safe no-op when Redis is unavailable', async () => {
+    vi.mocked(getRedis).mockReturnValue(null as never);
+    await expect(setAgentPresence('a', { instanceId: 'i', connectionToken: 't' })).resolves.toBeUndefined();
+    await expect(refreshAgentPresence('a', 't')).resolves.toBe(false);
+    await expect(clearAgentPresence('a', 't')).resolves.toBe(false);
+    await expect(readAgentPresence('a')).resolves.toBeNull();
+  });
+
+  it('helpers swallow Redis errors (log, never throw)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    redisMock.set.mockRejectedValueOnce(new Error('boom'));
+    await expect(setAgentPresence('a', { instanceId: 'i', connectionToken: 't' })).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — `npx vitest run src/services/agentPresence.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Implement**:
+
+```ts
+// apps/api/src/services/agentPresence.ts
+import { getRedis } from './redis';
+
+// Fenced presence leases for agent WebSockets (wave 3.5b, #4084).
+// A lease is an ADMISSION HINT for the command relay — the socket-owning
+// process's in-memory map stays authoritative. Fencing: every mutation is
+// token-guarded server-side (Lua), so an old socket's delayed onClose can
+// never delete a newer connection's lease.
+const PRESENCE_KEY_PREFIX = 'agent-presence:';
+export const AGENT_PRESENCE_TTL_MS = 90_000;
+
+export interface AgentPresenceLease {
+  instanceId: string;
+  connectionToken: string;
+}
+
+// Runs server-side in Redis (ioredis Lua API, not JS eval); token comes in as
+// ARGV, never interpolated into the script.
+const REFRESH_IF_TOKEN_MATCHES_LUA = `
+local raw = redis.call('GET', KEYS[1])
+if not raw then return 0 end
+local ok, lease = pcall(cjson.decode, raw)
+if not ok or lease.connectionToken ~= ARGV[1] then return 0 end
+redis.call('PEXPIRE', KEYS[1], ARGV[2])
+return 1
+`;
+
+const DELETE_IF_TOKEN_MATCHES_LUA = `
+local raw = redis.call('GET', KEYS[1])
+if not raw then return 0 end
+local ok, lease = pcall(cjson.decode, raw)
+if not ok or lease.connectionToken ~= ARGV[1] then return 0 end
+redis.call('DEL', KEYS[1])
+return 1
+`;
+
+function presenceKey(agentId: string): string {
+  return `${PRESENCE_KEY_PREFIX}${agentId}`;
+}
+
+export async function setAgentPresence(agentId: string, lease: AgentPresenceLease): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    // Unconditional SET: onOpen installs the newest socket as authoritative
+    // (mirrors the activeConnections/epoch model), so the newest lease wins.
+    await redis.set(presenceKey(agentId), JSON.stringify(lease), 'PX', AGENT_PRESENCE_TTL_MS);
+  } catch (err) {
+    console.warn(`[AgentPresence] set failed for ${agentId.slice(0, 12)}:`, err);
+  }
+}
+
+export async function refreshAgentPresence(agentId: string, connectionToken: string): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  try {
+    const res = await redis.eval(
+      REFRESH_IF_TOKEN_MATCHES_LUA, 1, presenceKey(agentId), connectionToken, String(AGENT_PRESENCE_TTL_MS),
+    );
+    return res === 1;
+  } catch (err) {
+    console.warn(`[AgentPresence] refresh failed for ${agentId.slice(0, 12)}:`, err);
+    return false;
+  }
+}
+
+export async function clearAgentPresence(agentId: string, connectionToken: string): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  try {
+    const res = await redis.eval(DELETE_IF_TOKEN_MATCHES_LUA, 1, presenceKey(agentId), connectionToken);
+    return res === 1;
+  } catch (err) {
+    console.warn(`[AgentPresence] clear failed for ${agentId.slice(0, 12)}:`, err);
+    return false;
+  }
+}
+
+export async function readAgentPresence(agentId: string): Promise<AgentPresenceLease | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+  try {
+    const raw = await redis.get(presenceKey(agentId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as AgentPresenceLease;
+    if (typeof parsed?.instanceId !== 'string' || typeof parsed?.connectionToken !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests** — `npx vitest run src/services/agentPresence.test.ts` → PASS. Commit: `feat(api): fenced agent presence leases in Redis (wave 3.5b #4084)`
+
+---
+
+### Task 3: Wire presence into the agent WS lifecycle
+
+**Files:**
+- Modify: `apps/api/src/routes/agentWs.ts` — onOpen (~1918), pong/heartbeat handler (~2071-2088), onClose/onError (~2615-2698), `evictAgentSocket` (~224)
+- Test: extend the existing agentWs handler test file (find it: `cd apps/api && ls src/routes/agentWs*.test.ts`) with presence-lifecycle assertions using `vi.mock('../services/agentPresence')`
+
+**Interfaces:**
+- Consumes: Task 2's four presence helpers, Task 1's `INSTANCE_ID`.
+- Produces: presence keys maintained for every live agent socket; a per-connection `connectionToken` (closure variable next to `socketEpoch` in `createAgentWsHandlers`).
+
+- [ ] **Step 1: Write failing tests** — mock `../services/agentPresence` and assert, via the existing handler-test harness for `createAgentWsHandlers`:
+  - onOpen calls `setAgentPresence(agentId, { instanceId: INSTANCE_ID, connectionToken: <uuid> })` (capture the token; assert it is a non-empty string).
+  - a `pong` message calls `refreshAgentPresence(agentId, <same token>)`.
+  - when `refreshAgentPresence` resolves `false` AND this ws is still the mapped connection, the handler re-calls `setAgentPresence` with the same token (self-heal after an errant delete).
+  - onClose (current socket) calls `clearAgentPresence(agentId, <same token>)`; onClose for a superseded socket does NOT clear (token mismatch is also guarded server-side, but don't even issue the call when `activeConnections.get(agentId) !== ws`).
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement** — all calls fire-and-forget (`void ...` or `.catch(() => {})` consistent with surrounding style; the handlers must never await Redis on the hot path):
+  - In `createAgentWsHandlers`, next to `socketEpoch`, add `const connectionToken = randomUUID();` (add the `crypto` import if absent).
+  - onOpen, immediately after `activeConnections.set(agentId, ws); socketEpoch = installAgentSocketEpoch(agentId);`:
+    ```ts
+    void setAgentPresence(agentId, { instanceId: INSTANCE_ID, connectionToken });
+    ```
+  - In the pong branch (and the heartbeat liveness branch) after `state.lastPongAt = Date.now();`:
+    ```ts
+    void refreshAgentPresence(agentId, connectionToken).then((refreshed) => {
+      // Self-heal: an evict-path unconditional delete may have raced a
+      // reconnect; if we are still the live socket, re-establish the lease.
+      if (!refreshed && activeConnections.get(agentId) === ws) {
+        return setAgentPresence(agentId, { instanceId: INSTANCE_ID, connectionToken });
+      }
+    });
+    ```
+  - onClose/onError, inside the existing `if (activeConnections.get(agentId) === ws)` block:
+    ```ts
+    void clearAgentPresence(agentId, connectionToken);
+    ```
+  - `evictAgentSocket` (module-level, no token in scope) — clear unconditionally, best-effort; the pong self-heal above bounds the collateral window:
+    ```ts
+    function evictAgentSocket(agentId: string): void {
+      activeConnections.delete(agentId);
+      agentSocketEpochs.delete(agentId);
+      void clearAgentPresenceUnfenced(agentId);
+    }
+    ```
+    Add `clearAgentPresenceUnfenced(agentId)` to `agentPresence.ts` (plain `DEL`, same never-throw contract, one-line unit test in the Task 2 file).
+
+- [ ] **Step 4: Run the agentWs test file(s) + typecheck** — PASS. Commit: `feat(api): maintain fenced presence leases from the agent WS lifecycle (wave 3.5b #4084)`
+
+---
+
+### Task 4: Relay primitives — sealed envelope, send claims, acks (`agentCommandRelay.ts`, part 1)
+
+**Files:**
+- Create: `apps/api/src/services/agentCommandRelay.ts`
+- Test: `apps/api/src/services/agentCommandRelay.test.ts`
+
+**Interfaces:**
+- Consumes: `encryptSecret(value, { aad })` from `./secretCrypto` and its decrypt counterpart — **check the actual export names first** (`grep '^export' apps/api/src/services/secretCrypto.ts`); the code below assumes `encryptSecret`/`decryptSecret(value, { aad })` — adjust to the real signatures, the roundtrip test locks them in.
+- Produces (consumed by Tasks 5-6):
+  - `type DispatchOutcome = { status: 'sent'; via: 'local' | 'relay' } | { status: 'offline' } | { status: 'expired' } | { status: 'owner_mismatch' } | { status: 'indeterminate' } | { status: 'infrastructure_error'; message: string }`
+  - `interface RelayJobData { relayId: string; agentId: string; commandId: string; targetInstanceId: string; connectionToken: string; expiresAt: number; sealedCommand: string }`
+  - `sealRelayCommand(command: AgentCommand, binding: RelayEnvelopeBinding): string` / `openRelayCommand(sealed: string, binding: RelayEnvelopeBinding): AgentCommand` (throws on tamper/wrong key)
+  - `claimRelaySend(agentId, commandId): Promise<'claimed' | 'already-sent' | 'in-flight'>`, `markRelaySendComplete(agentId, commandId): Promise<void>`
+  - `writeRelayAck(relayId, outcome): Promise<void>`, `awaitRelayAck(relayId, deadlineMs): Promise<DispatchOutcome>` (deadline exceeded → `{ status: 'indeterminate' }`)
+  - `AGENT_COMMAND_RELAY_QUEUE = 'agent-command-relay'`, `RELAY_DELIVERY_DEADLINE_MS = 5_000`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// apps/api/src/services/agentCommandRelay.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redisMock = { set: vi.fn(), get: vi.fn(), eval: vi.fn() };
+vi.mock('./redis', () => ({
+  getRedis: vi.fn(() => redisMock),
+  getRedisConnection: vi.fn(() => redisMock),
+  getBullMQConnection: vi.fn(() => redisMock),
+}));
+
+// Key setup so secretCrypto can do real AES roundtrips in unit tests — mirror
+// whatever existing secretCrypto/sensitiveCommandPayload unit tests do for
+// key env vars (see services/remoteAccessLauncher.test.ts:211 for the idiom).
+process.env.APP_ENCRYPTION_KEY ??= 'test-only-app-encryption-key-32chars!';
+
+import {
+  awaitRelayAck,
+  claimRelaySend,
+  markRelaySendComplete,
+  openRelayCommand,
+  sealRelayCommand,
+  writeRelayAck,
+} from './agentCommandRelay';
+
+const BINDING = {
+  agentId: 'agent-1',
+  commandId: 'cmd-1',
+  targetInstanceId: 'inst-1',
+  expiresAt: 1_700_000_000_000,
+};
+
+describe('relay envelope', () => {
+  const command = {
+    id: 'cmd-1',
+    type: 'snmp_poll',
+    payload: { community: 'sup3r-s3cret', oids: ['1.3.6.1'] },
+  };
+
+  it('roundtrips a command and produces NO plaintext payload in the sealed string', () => {
+    const sealed = sealRelayCommand(command, BINDING);
+    expect(sealed).not.toContain('sup3r-s3cret');
+    expect(sealed).not.toContain('snmp_poll');
+    expect(openRelayCommand(sealed, BINDING)).toEqual(command);
+  });
+
+  it('fails closed when any bound field is tampered', () => {
+    const sealed = sealRelayCommand(command, BINDING);
+    expect(() => openRelayCommand(sealed, { ...BINDING, agentId: 'agent-2' })).toThrow();
+    expect(() => openRelayCommand(sealed, { ...BINDING, expiresAt: BINDING.expiresAt + 1 })).toThrow();
+    expect(() => openRelayCommand(`${sealed}x`, BINDING)).toThrow();
+  });
+});
+
+describe('send claims (at-most-once)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('maps Lua results: fresh claim → claimed, sent marker → already-sent, live claim → in-flight', async () => {
+    redisMock.eval.mockResolvedValueOnce(1).mockResolvedValueOnce(2).mockResolvedValueOnce(0);
+    expect(await claimRelaySend('agent-1', 'cmd-1')).toBe('claimed');
+    expect(await claimRelaySend('agent-1', 'cmd-1')).toBe('already-sent');
+    expect(await claimRelaySend('agent-1', 'cmd-1')).toBe('in-flight');
+    expect(redisMock.eval.mock.calls[0][2]).toBe('agent-relay-claim:agent-1:cmd-1');
+  });
+
+  it('claim helpers throw on Redis failure (the consumer must NOT treat unknown claim state as claimable)', async () => {
+    redisMock.eval.mockRejectedValueOnce(new Error('down'));
+    await expect(claimRelaySend('agent-1', 'cmd-1')).rejects.toThrow();
+  });
+
+  it('markRelaySendComplete promotes the claim to sent with a long TTL', async () => {
+    await markRelaySendComplete('agent-1', 'cmd-1');
+    expect(redisMock.set).toHaveBeenCalledWith('agent-relay-claim:agent-1:cmd-1', 'sent', 'PX', 600_000);
+  });
+});
+
+describe('acks', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('writeRelayAck stores the outcome JSON with a TTL', async () => {
+    await writeRelayAck('r-1', { status: 'sent', via: 'relay' });
+    expect(redisMock.set).toHaveBeenCalledWith(
+      'agent-relay-ack:r-1', JSON.stringify({ status: 'sent', via: 'relay' }), 'PX', 30_000,
+    );
+  });
+
+  it('awaitRelayAck polls GET until the ack appears', async () => {
+    redisMock.get.mockResolvedValueOnce(null).mockResolvedValueOnce(JSON.stringify({ status: 'offline' }));
+    await expect(awaitRelayAck('r-1', 1_000)).resolves.toEqual({ status: 'offline' });
+  });
+
+  it('awaitRelayAck returns indeterminate at the deadline', async () => {
+    redisMock.get.mockResolvedValue(null);
+    await expect(awaitRelayAck('r-1', 250)).resolves.toEqual({ status: 'indeterminate' });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — module missing.
+
+- [ ] **Step 3: Implement part 1 of the module** (the facade + queue singleton come in Task 5 — keep this commit to primitives):
+
+```ts
+// apps/api/src/services/agentCommandRelay.ts
+import { getRedis } from './redis';
+import { decryptSecret, encryptSecret } from './secretCrypto'; // adjust to real exports (see Interfaces note)
+import type { AgentCommand } from '../routes/agentWs';
+
+export const AGENT_COMMAND_RELAY_QUEUE = 'agent-command-relay';
+export const RELAY_DELIVERY_DEADLINE_MS = 5_000;
+const ACK_POLL_INTERVAL_MS = 100;
+const ACK_TTL_MS = 30_000;
+const CLAIM_TTL_MS = 60_000;
+const SENT_MARKER_TTL_MS = 600_000; // outlives any BullMQ stalled-job redelivery window
+
+export type DispatchOutcome =
+  | { status: 'sent'; via: 'local' | 'relay' }
+  | { status: 'offline' }
+  | { status: 'expired' }
+  | { status: 'owner_mismatch' }
+  | { status: 'indeterminate' }
+  | { status: 'infrastructure_error'; message: string };
+
+export interface RelayEnvelopeBinding {
+  agentId: string;
+  commandId: string;
+  targetInstanceId: string;
+  expiresAt: number;
+}
+
+export interface RelayJobData {
+  relayId: string;
+  agentId: string;
+  commandId: string;
+  targetInstanceId: string;
+  connectionToken: string;
+  expiresAt: number;
+  sealedCommand: string;
+}
+
+// The BullMQ payload persists in Redis (and its AOF/snapshots, failed-job
+// tooling) — SNMP/discovery/backup commands carry DECRYPTED credentials, so
+// the whole command is sealed and the AAD binds the routing metadata: any
+// tamper of agentId/commandId/target/expiry makes decryption fail closed.
+function relayAad(b: RelayEnvelopeBinding): string {
+  return `agent_command_relay:${b.agentId}:${b.commandId}:${b.targetInstanceId}:${b.expiresAt}`;
+}
+
+export function sealRelayCommand(command: AgentCommand, binding: RelayEnvelopeBinding): string {
+  return encryptSecret(JSON.stringify(command), { aad: relayAad(binding) });
+}
+
+export function openRelayCommand(sealed: string, binding: RelayEnvelopeBinding): AgentCommand {
+  const plain = decryptSecret(sealed, { aad: relayAad(binding) });
+  return JSON.parse(plain) as AgentCommand;
+}
+
+const CLAIM_LUA = `
+local existing = redis.call('GET', KEYS[1])
+if existing == 'sent' then return 2 end
+if existing then return 0 end
+redis.call('SET', KEYS[1], 'claimed', 'PX', ARGV[1])
+return 1
+`;
+
+function claimKey(agentId: string, commandId: string): string {
+  return `agent-relay-claim:${agentId}:${commandId}`;
+}
+
+export async function claimRelaySend(
+  agentId: string, commandId: string,
+): Promise<'claimed' | 'already-sent' | 'in-flight'> {
+  const redis = getRedis();
+  if (!redis) throw new Error('[AgentRelay] Redis unavailable — cannot take send claim');
+  const res = await redis.eval(CLAIM_LUA, 1, claimKey(agentId, commandId), String(CLAIM_TTL_MS));
+  if (res === 2) return 'already-sent';
+  if (res === 1) return 'claimed';
+  return 'in-flight';
+}
+
+export async function markRelaySendComplete(agentId: string, commandId: string): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  await redis.set(claimKey(agentId, commandId), 'sent', 'PX', SENT_MARKER_TTL_MS);
+}
+
+function ackKey(relayId: string): string {
+  return `agent-relay-ack:${relayId}`;
+}
+
+export async function writeRelayAck(relayId: string, outcome: DispatchOutcome): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+  await redis.set(ackKey(relayId), JSON.stringify(outcome), 'PX', ACK_TTL_MS);
+}
+
+// Plain GET polling on the shared connection — deliberately NOT BRPOP /
+// QueueEvents / waitUntilFinished (blocking commands on the shared connection
+// stall every enqueue, #3299; QueueEvents has no repo precedent).
+export async function awaitRelayAck(relayId: string, deadlineMs: number): Promise<DispatchOutcome> {
+  const redis = getRedis();
+  if (!redis) return { status: 'indeterminate' };
+  const deadline = Date.now() + deadlineMs;
+  for (;;) {
+    try {
+      const raw = await redis.get(ackKey(relayId));
+      if (raw) return JSON.parse(raw) as DispatchOutcome;
+    } catch {
+      // transient read failure — keep polling until the deadline
+    }
+    if (Date.now() >= deadline) return { status: 'indeterminate' };
+    await new Promise((resolve) => setTimeout(resolve, ACK_POLL_INTERVAL_MS));
+  }
+}
+```
+
+- [ ] **Step 4: Run tests** — PASS (fix the `decryptSecret` import to the real secretCrypto export if the roundtrip fails to compile). Commit: `feat(api): relay envelope, at-most-once send claims, ack channel (wave 3.5b #4084)`
+
+---
+
+### Task 5: The dispatch facade (`agentCommandRelay.ts`, part 2)
+
+**Files:**
+- Modify: `apps/api/src/services/agentCommandRelay.ts`
+- Test: extend `apps/api/src/services/agentCommandRelay.test.ts`
+
+**Interfaces:**
+- Consumes: Task 2 `readAgentPresence`, Task 1 `breezeRole`, `createInstrumentedQueue` (`services/bullmqQueue.ts:41`), socket-local `isAgentConnected`/`sendCommandToAgent` (`routes/agentWs.ts`).
+- Produces (consumed by the four workers in Tasks 7-8):
+  - `dispatchCommandToAgent(agentId: string, command: AgentCommand, opts?: { priority?: 'probe' | 'normal'; forceRelay?: boolean }): Promise<DispatchOutcome>`
+  - `isAgentConnectedAnywhere(agentId: string): Promise<boolean>`
+  - `getAgentCommandRelayQueue(): Queue<RelayJobData>` / `shutdownAgentCommandRelayQueue(): Promise<void>` (mirror `eventDispatchQueue.ts:55-62`)
+
+- [ ] **Step 1: Write the failing tests** — add a mocked `../routes/agentWs` (`isAgentConnected`, `sendCommandToAgent`), mocked `./agentPresence`, mocked `./bullmqQueue` (capture `queue.add` calls). Cases:
+  - local socket + send ok → `{ status: 'sent', via: 'local' }`, **no** presence read, **no** enqueue.
+  - local socket + `sendCommandToAgent` returns false → `{ status: 'offline' }`, no enqueue (the local map was authoritative and the socket died mid-send).
+  - no local socket + no presence → `{ status: 'offline' }`, no enqueue.
+  - no local socket + presence exists → enqueues one job on `agent-command-relay` with `jobId` matching `/^relay-[0-9a-f-]{36}$/`, `attempts: 1`, sealed payload (assert `job.data.sealedCommand` does not contain the payload secret string), `expiresAt ≈ now + RELAY_DELIVERY_DEADLINE_MS`, priority 1 for `'probe'` / 10 default — then resolves with whatever `awaitRelayAck` yields (stub the ack GET to return `{ status: 'sent', via: 'relay' }`).
+  - `queue.add` throws → `{ status: 'infrastructure_error' }` (message includes the error), and NOT `'offline'`.
+  - `forceRelay: true` skips the local-first branch even when the local socket exists (staging/integration verification hook).
+  - `isAgentConnectedAnywhere`: local hit → true without presence read; local miss + presence → true; both miss → false; under `BREEZE_ROLE=worker` the socket-local check is skipped entirely (assert `isAgentConnected` never called — it would throw in that role after Task 6).
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement** (append to the module):
+
+```ts
+import { randomUUID } from 'crypto';
+import type { Queue } from 'bullmq';
+import { breezeRole } from '../config/env';
+import { createInstrumentedQueue } from './bullmqQueue';
+import { readAgentPresence } from './agentPresence';
+import { isAgentConnected, sendCommandToAgent } from '../routes/agentWs';
+
+let relayQueue: Queue<RelayJobData> | null = null;
+
+export function getAgentCommandRelayQueue(): Queue<RelayJobData> {
+  if (!relayQueue) {
+    relayQueue = createInstrumentedQueue<RelayJobData>(AGENT_COMMAND_RELAY_QUEUE);
+  }
+  return relayQueue;
+}
+
+export async function shutdownAgentCommandRelayQueue(): Promise<void> {
+  if (relayQueue) {
+    await relayQueue.close();
+    relayQueue = null;
+  }
+}
+
+export async function isAgentConnectedAnywhere(agentId: string): Promise<boolean> {
+  if (breezeRole() !== 'worker' && isAgentConnected(agentId)) return true;
+  return (await readAgentPresence(agentId)) !== null;
+}
+
+/**
+ * Cross-process-safe agent command dispatch (wave 3.5b, #4084).
+ *
+ * Local-first: on a process that may own sockets, a locally-connected agent
+ * gets today's direct send — zero Redis, zero behavior change. Otherwise the
+ * presence lease admits (or refuses) a relay enqueue, and the api-role
+ * consumer performs the actual socket write. `sent` means the frame reached
+ * ws.send() successfully — it says nothing about execution; results flow
+ * through device_commands exactly as before.
+ */
+export async function dispatchCommandToAgent(
+  agentId: string,
+  command: AgentCommand,
+  opts: { priority?: 'probe' | 'normal'; forceRelay?: boolean } = {},
+): Promise<DispatchOutcome> {
+  if (!opts.forceRelay && breezeRole() !== 'worker' && isAgentConnected(agentId)) {
+    return sendCommandToAgent(agentId, command)
+      ? { status: 'sent', via: 'local' }
+      : { status: 'offline' };
+  }
+
+  const lease = await readAgentPresence(agentId);
+  if (!lease) return { status: 'offline' };
+
+  const relayId = randomUUID();
+  const expiresAt = Date.now() + RELAY_DELIVERY_DEADLINE_MS;
+  const binding: RelayEnvelopeBinding = {
+    agentId, commandId: command.id, targetInstanceId: lease.instanceId, expiresAt,
+  };
+  const data: RelayJobData = {
+    relayId, agentId, commandId: command.id,
+    targetInstanceId: lease.instanceId, connectionToken: lease.connectionToken,
+    expiresAt, sealedCommand: sealRelayCommand(command, binding),
+  };
+  try {
+    await getAgentCommandRelayQueue().add('relay-send', data, {
+      jobId: `relay-${relayId}`,
+      attempts: 1, // at-most-once: claims (not BullMQ retries) guard the send
+      priority: opts.priority === 'probe' ? 1 : 10,
+      removeOnComplete: true,
+      removeOnFail: 100,
+    });
+  } catch (err) {
+    return {
+      status: 'infrastructure_error',
+      message: `relay enqueue failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  return awaitRelayAck(relayId, RELAY_DELIVERY_DEADLINE_MS);
+}
+```
+
+- [ ] **Step 4: Run tests + typecheck** — PASS. Commit: `feat(api): dispatchCommandToAgent facade — local-first with presence-admitted relay (wave 3.5b #4084)`
+
+---
+
+### Task 6: Relay consumer worker + boot registration + runtime role assertions
+
+**Files:**
+- Create: `apps/api/src/jobs/agentCommandRelayWorker.ts`
+- Modify: `apps/api/src/routes/agentWs.ts` (role assertion + test-only socket installer), `apps/api/src/services/agentCommandAwait.ts` (role assertion), `apps/api/src/index.ts` (registration)
+- Test: `apps/api/src/jobs/agentCommandRelayWorker.test.ts`, plus role-assertion cases appended to the agentWs test file
+
+**Interfaces:**
+- Consumes: Task 4 primitives, Task 2 `readAgentPresence`, Task 1 `INSTANCE_ID`, socket-local `isAgentConnected`/`sendCommandToAgent`.
+- Produces: `createAgentCommandRelayWorker(): Worker`, `initializeAgentCommandRelayWorker(): Promise<void>`; agentWs test-only export `__installAgentSocketForTest(agentId: string, ws: { send(data: string): void }): void`.
+
+- [ ] **Step 1: Write the failing processor tests** (mock agentWs, agentPresence, and the relay primitives; drive the exported processor function directly with a fake `Job`):
+  - expired job (`expiresAt` in the past) → ack `{ status: 'expired' }`, no claim taken, no send.
+  - no local socket → ack `{ status: 'offline' }`, no claim.
+  - lease missing / `instanceId` ≠ job's `targetInstanceId` / `connectionToken` mismatch / `targetInstanceId` ≠ `INSTANCE_ID` → ack `{ status: 'owner_mismatch' }`, no send. (Strict fencing per quorum: a routing decision made against a superseded lease is never executed, even if the agent reconnected here — the caller's next cycle re-routes.)
+  - claim `'already-sent'` → ack `{ status: 'sent', via: 'relay' }`, **no** second send.
+  - claim `'in-flight'` → ack `{ status: 'indeterminate' }`, no send.
+  - claim `'claimed'` + `openRelayCommand` throws → ack `{ status: 'infrastructure_error' }`, no send.
+  - claim `'claimed'` + send ok → `sendCommandToAgent` called with the decrypted command, `markRelaySendComplete` called, ack `{ status: 'sent', via: 'relay' }`.
+  - claim `'claimed'` + `sendCommandToAgent` returns false → ack `{ status: 'offline' }`, `markRelaySendComplete` NOT called.
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement the worker**:
+
+```ts
+// apps/api/src/jobs/agentCommandRelayWorker.ts
+import { Worker, type Job } from 'bullmq';
+import { getBullMQConnection } from '../services/redis';
+import { INSTANCE_ID } from '../services/instanceIdentity';
+import { readAgentPresence } from '../services/agentPresence';
+import {
+  AGENT_COMMAND_RELAY_QUEUE,
+  claimRelaySend,
+  markRelaySendComplete,
+  openRelayCommand,
+  writeRelayAck,
+  type DispatchOutcome,
+  type RelayJobData,
+} from '../services/agentCommandRelay';
+import { isAgentConnected, sendCommandToAgent } from '../routes/agentWs';
+
+// Runs ONLY on socket-owning roles (registration is gated in index.ts).
+// Presence admitted the job; this process's in-memory socket map is the
+// authority. The local send path also records orphanedResultExpectations HERE
+// — the process that will receive the command_result — which is why the
+// consumer must call sendCommandToAgent and never re-implement the send.
+export async function processAgentCommandRelayJob(job: Job<RelayJobData>): Promise<void> {
+  const d = job.data;
+  const ack = (outcome: DispatchOutcome) => writeRelayAck(d.relayId, outcome);
+
+  if (Date.now() > d.expiresAt) return ack({ status: 'expired' });
+  if (!isAgentConnected(d.agentId)) return ack({ status: 'offline' });
+
+  const lease = await readAgentPresence(d.agentId);
+  if (
+    !lease
+    || lease.instanceId !== d.targetInstanceId
+    || lease.connectionToken !== d.connectionToken
+    || d.targetInstanceId !== INSTANCE_ID
+  ) {
+    return ack({ status: 'owner_mismatch' });
+  }
+
+  let claim: Awaited<ReturnType<typeof claimRelaySend>>;
+  try {
+    claim = await claimRelaySend(d.agentId, d.commandId);
+  } catch (err) {
+    return ack({
+      status: 'infrastructure_error',
+      message: `send claim failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+  if (claim === 'already-sent') return ack({ status: 'sent', via: 'relay' });
+  if (claim === 'in-flight') return ack({ status: 'indeterminate' });
+
+  let command;
+  try {
+    command = openRelayCommand(d.sealedCommand, {
+      agentId: d.agentId, commandId: d.commandId,
+      targetInstanceId: d.targetInstanceId, expiresAt: d.expiresAt,
+    });
+  } catch {
+    return ack({ status: 'infrastructure_error', message: 'relay envelope failed to open (tamper or key mismatch)' });
+  }
+
+  if (!sendCommandToAgent(d.agentId, command)) return ack({ status: 'offline' });
+  await markRelaySendComplete(d.agentId, d.commandId);
+  return ack({ status: 'sent', via: 'relay' });
+}
+
+export function createAgentCommandRelayWorker(): Worker {
+  return new Worker(AGENT_COMMAND_RELAY_QUEUE, processAgentCommandRelayJob, {
+    connection: getBullMQConnection(),
+    // ws.send is fast; 25 is deliberately conservative — tune from queue-age
+    // measurements after 3.5d rolls out, mirroring eventDispatchWorker's note.
+    concurrency: 25,
+  });
+}
+```
+
+Add `initializeAgentCommandRelayWorker` following the shape of the sibling `initialize*Worker` functions in whichever module `index.ts` imports them from (grep one, e.g. `initializeEventDispatchWorker`, and mirror its error handling + shutdown hook). If 3.5c's `attachWorkerObservability` (from `services/bullmqQueue.ts`) is what `eventDispatchWorker` uses for Sentry/error reporting, attach it identically here.
+
+- [ ] **Step 4: Boot registration in `index.ts`** — next to the phase-2 event-dispatch start (index.ts:1505-1524), add:
+
+```ts
+if (breezeRole() !== 'worker') {
+  try {
+    await initializeAgentCommandRelayWorker();
+    workerStatus['agentCommandRelay'] = true;
+  } catch (error) {
+    workerStatus['agentCommandRelay'] = false;
+    console.error('[CRITICAL] Failed to initialize agentCommandRelay:', error);
+    captureException(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+```
+
+- [ ] **Step 5: Runtime role assertions** — in `agentWs.ts`, add at the top of `sendCommandToAgent` AND `isAgentConnected` (and export nothing new for it):
+
+```ts
+function assertSocketLocalDispatchAllowed(fn: string): void {
+  if (breezeRole() === 'worker') {
+    throw new Error(
+      `[BREEZE_ROLE] ${fn} is socket-local and cannot run in the worker role — `
+      + 'use dispatchCommandToAgent/isAgentConnectedAnywhere (services/agentCommandRelay.ts)',
+    );
+  }
+}
+```
+
+Same assertion at the top of `sendCommandToAgentAwaitResult` (`services/agentCommandAwait.ts`), plus a doc comment stating the module is api-role-affine by design (its correlation map cannot resolve cross-process). Throwing — not returning false — is the point: a silent false is exactly the every-agent-reads-offline failure this wave exists to kill. Test: with `BREEZE_ROLE=worker` set (and restored) in the agentWs test file, each of the three throws with a message matching `/BREEZE_ROLE/`.
+
+- [ ] **Step 6: Test-only socket installer in `agentWs.ts`** (needed by Task 9's integration suite; mirror `__resetCrossTenantDropsForTest`, agentWs.ts:2993):
+
+```ts
+export function __installAgentSocketForTest(agentId: string, ws: { send(data: string): void }): void {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('__installAgentSocketForTest is test-only');
+  }
+  activeConnections.set(agentId, ws as never);
+  installAgentSocketEpoch(agentId);
+}
+```
+
+- [ ] **Step 7: Run the new tests + full typecheck** — PASS. Commit: `feat(api): api-role relay consumer, boot gating, worker-role dispatch assertions (wave 3.5b #4084)`
+
+---
+
+### Task 7: Migrate the fire-and-forget workers — monitorWorker + snmpWorker
+
+**Files:**
+- Modify: `apps/api/src/jobs/monitorWorker.ts` (import line 15; dispatch block ~150-177), `apps/api/src/jobs/snmpWorker.ts` (import line 16; dispatch block ~385-420)
+- Test: extend the existing `monitorWorker`/`snmpWorker` test files (find them next to the sources)
+
+**Interfaces:**
+- Consumes: `dispatchCommandToAgent`, `isAgentConnectedAnywhere` (Task 5); `import type { AgentCommand } from '../routes/agentWs'` (type-only).
+
+**Behavior contract (both workers):** in `BREEZE_ROLE=all` with a locally-connected agent the observable behavior is IDENTICAL to today (local-first path). The only new behavior is the relay branch, unreachable until 3.5d. Preserve each function's exact return shapes.
+
+- [ ] **Step 1: Write the failing tests** — mock `../services/agentCommandRelay`. Cases per worker:
+  - `isAgentConnectedAnywhere` false → today's "No online agent" warn + `{ dispatched: false, agentId: null }`, and `dispatchCommandToAgent` never called.
+  - outcome `{ status: 'sent', via: 'local' }` → `{ dispatched: true, agentId }`.
+  - outcome `{ status: 'offline' }` → `{ dispatched: false, agentId }` and the error log includes the outcome status.
+  - outcome `{ status: 'indeterminate' }` → `{ dispatched: false, agentId }` (monitor) / `{ dispatched: false, agentId }` (snmp) with a WARN that names `indeterminate` (ops need to distinguish "maybe sent" from "definitely not").
+  - snmp only: `markPollDispatched` is still called after the connectivity check and before dispatch (assert call order via mock invocationCallOrder) — an indeterminate dispatch leaves the poll counted, mirroring today's send-false-after-mark semantics.
+  - monitor only: dispatch is called with `{ priority: 'probe' }`.
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Migrate `monitorWorker.ts`** — replace the import and the block at ~160-177:
+
+```ts
+import { dispatchCommandToAgent, isAgentConnectedAnywhere } from '../services/agentCommandRelay';
+import type { AgentCommand } from '../routes/agentWs';
+```
+
+```ts
+  const agentId = await selectExecutionAgentForMonitor(monitor);
+
+  if (!agentId || !(await isAgentConnectedAnywhere(agentId))) {
+    console.warn(`[MonitorWorker] No online agent for org ${data.orgId}`);
+    return { dispatched: false, agentId: null };
+  }
+
+  const command = buildMonitorCommand(monitor);
+  const outcome = await dispatchCommandToAgent(agentId, command, { priority: 'probe' });
+
+  if (outcome.status !== 'sent') {
+    console.error(`[MonitorWorker] Check dispatch ${outcome.status} for agent ${agentId}`);
+    return { dispatched: false, agentId };
+  }
+
+  console.log(`[MonitorWorker] Check dispatched to agent ${agentId} for monitor ${data.monitorId} (${outcome.via})`);
+  return { dispatched: true, agentId };
+```
+
+(If `monitorWorker.ts` only imported `sendCommandToAgent`/`isAgentConnected` for this block, the agentWs import disappears entirely; keep `AgentCommand` type-only if the file references the type.)
+
+- [ ] **Step 4: Migrate `snmpWorker.ts`** — same substitution at ~394-420: `isAgentConnected(agentId)` → `await isAgentConnectedAnywhere(agentId)`; keep the `markPollDispatched` placement and its #1105 phase-split comment intact (the facade's Redis I/O also relies on running outside a held DB context); then:
+
+```ts
+  const command = buildSnmpPollCommand(data.deviceId, device, oids);
+  const outcome = await dispatchCommandToAgent(agentId, command, { priority: 'probe' });
+  if (outcome.status !== 'sent') {
+    console.error(`[SnmpWorker] Poll dispatch ${outcome.status} for agent ${agentId}`);
+    return { dispatched: false, agentId };
+  }
+
+  console.log(`[SnmpWorker] Poll dispatched to agent ${agentId} for device ${data.deviceId} (${outcome.via})`);
+  return { dispatched: true, agentId };
+```
+
+- [ ] **Step 5: Run both worker test files + typecheck** — PASS. Commit: `refactor(api): monitor + snmp workers dispatch via the cross-process facade (wave 3.5b #4084)`
+
+---
+
+### Task 8: Migrate the job-failing workers — backupWorker + discoveryWorker
+
+**Files:**
+- Modify: `apps/api/src/jobs/backupWorker.ts` (imports 28-33; blocks ~490-515 and ~645-665), `apps/api/src/jobs/discoveryWorker.ts` (import 28; block ~560-615)
+- Test: extend the existing `backupWorker`/`discoveryWorker` test files
+
+**Behavior contract:** offline stays fail-fast (`markJobFailed` with the SAME message strings as today — dashboards and tests key on them). `indeterminate`/`infrastructure_error`/`expired`/`owner_mismatch` mark the job failed with a NEW distinct message naming the outcome — the command may still execute (at-most-once means no duplicate was sent), and a late result hitting a failed-marked job is the same benign race as today's send-succeeded-then-agent-crashed window. Flag this trade-off in the PR body.
+
+- [ ] **Step 1: Write the failing tests** — cases per worker:
+  - `isAgentConnectedAnywhere` false → `markJobFailed(jobId, 'Agent not connected')` (backup) / `markJobFailed(jobId, 'No online agent available for this site')` (discovery) — byte-identical messages.
+  - outcome `sent` → job proceeds exactly as today (backup increments sentCount; discovery flips job to running).
+  - outcome `offline` → backup: the existing per-target failure branch runs (warn + child-job failed row); discovery: `markJobFailed(jobId, 'Failed to send command to agent')` (today's message).
+  - outcome `indeterminate` → failure branch with a message matching `/dispatch outcome indeterminate/i`.
+  - backup only: `recordDispatchedExpectation('backup', deviceId, commandJobId)` still happens BEFORE dispatch (call order assertion) — the expectation-first comment at backupWorker.ts:645-651 stays valid because an unconsumed expectation still just expires via TTL.
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Migrate `backupWorker.ts`**:
+
+```ts
+import { dispatchCommandToAgent, isAgentConnectedAnywhere } from '../services/agentCommandRelay';
+import type { AgentCommand } from '../routes/agentWs';
+```
+
+At ~501: `if (!agentId || !(await isAgentConnectedAnywhere(agentId))) {` (unchanged failure body). At ~653:
+
+```ts
+    await recordDispatchedExpectation('backup', data.deviceId, commandJobId);
+
+    const outcome = await dispatchCommandToAgent(agentId, command);
+    if (outcome.status === 'sent') {
+      sentCount++;
+    } else {
+      const detail = outcome.status === 'offline'
+        ? `Failed to send ${target.commandType} command to agent`
+        : `Failed to send ${target.commandType} command to agent (dispatch outcome ${outcome.status})`;
+      console.warn(`[BackupWorker] ${detail} for job ${commandJobId}`);
+      failedTargets.push(target.commandType);
+      if (commandJobId !== data.jobId) {
+        await db
+          .update(backupJobs)
+          .set({ status: 'failed', completedAt: new Date(), updatedAt: new Date(), errorLog: detail })
+          .where(eq(backupJobs.id, commandJobId));
+      }
+    }
+```
+
+(Keep the surrounding comment block; it remains accurate.)
+
+- [ ] **Step 4: Migrate `discoveryWorker.ts`** — `!isAgentConnected(agentId)` → `!(await isAgentConnectedAnywhere(agentId))` (~571, same failure body); at ~606:
+
+```ts
+  const outcome = await dispatchCommandToAgent(agentId, command);
+  if (outcome.status !== 'sent') {
+    await markJobFailed(
+      data.jobId,
+      outcome.status === 'offline'
+        ? 'Failed to send command to agent'
+        : `Failed to send command to agent (dispatch outcome ${outcome.status})`,
+    );
+    return { dispatched: false, agentId, durationMs: Date.now() - startTime };
+  }
+```
+
+- [ ] **Step 5: Run both worker test files + typecheck** — PASS. Commit: `refactor(api): backup + discovery workers dispatch via the cross-process facade (wave 3.5b #4084)`
+
+---
+
+### Task 9: Integration suite — real-Redis relay E2E
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/agentCommandRelay.integration.test.ts`
+- Modify: `apps/api/vitest.integration.config.ts` (**add the file to the explicit `include` list — a misplaced/unlisted file runs in ZERO CI jobs**)
+
+**Interfaces:**
+- Consumes: everything from Tasks 2-6 against real Redis; `__installAgentSocketForTest` (Task 6). Setup pattern: copy the header of `eventDispatchQueue.integration.test.ts` (`import './setup'`, real `REDIS_URL`, `closeRedis` in afterAll, `docker compose -f docker-compose.test.yml up` run instructions in the top comment).
+
+- [ ] **Step 1: Write the suite** (each test red-then-green against the already-implemented code is fine here — the suite's job is proving the composition against real Redis; assert precisely):
+  1. **Presence lifecycle:** `setAgentPresence` → `readAgentPresence` roundtrip; `refreshAgentPresence` with the right/wrong token → true/false; `clearAgentPresence` with the wrong token leaves the key (fencing); PTTL is ≤ `AGENT_PRESENCE_TTL_MS` and > 0 after a refresh.
+  2. **Forced-relay E2E, exactly once:** install a fake socket capturing `send()` frames via `__installAgentSocketForTest('agent-int-1', ...)`; `setAgentPresence('agent-int-1', { instanceId: INSTANCE_ID, connectionToken: 't-int' })`; start `createAgentCommandRelayWorker()`; call `dispatchCommandToAgent('agent-int-1', { id: <uuid>, type: 'network_ping', payload: { probe: true } }, { forceRelay: true })` → resolves `{ status: 'sent', via: 'relay' }` within 5s; the fake socket received EXACTLY one frame; `JSON.parse(frame)` equals the command verbatim (`{id, type, payload}`, no extra keys).
+  3. **No plaintext in the queue:** enqueue with a payload containing `'sup3r-s3cret'` (no consumer running); fetch the raw job via `getAgentCommandRelayQueue().getJob('relay-<id>')` and assert `JSON.stringify(job.data)` does NOT contain the secret; then assert `openRelayCommand` with the job's own binding fields DOES recover it.
+  4. **Stale presence → offline:** presence set but NO socket installed → forced relay resolves `{ status: 'offline' }`, no frame sent.
+  5. **Owner fencing:** presence lease has `connectionToken: 'other-token'` (≠ the enqueued job's token — simulate by setting presence AFTER capturing the lease used for enqueue, i.e. re-set presence with a new token between enqueue and consumer start) → `{ status: 'owner_mismatch' }`, no frame.
+  6. **Expired job:** enqueue a job whose `expiresAt` is already past (build `RelayJobData` by hand and `queue.add` it directly), start the consumer → the ack written for that relayId is `{ status: 'expired' }`, no frame.
+  7. **At-most-once:** pre-mark `markRelaySendComplete(agentId, commandId)`, then run a relay job for the same `(agentId, commandId)` → ack `{ status: 'sent', via: 'relay' }` and ZERO new frames on the socket.
+  8. **Local-first does not touch the queue:** with the fake socket installed and NO `forceRelay`, `dispatchCommandToAgent` resolves `{ status: 'sent', via: 'local' }` and `getAgentCommandRelayQueue().count()` stays 0.
+  9. **No presence → no enqueue:** clear all presence for a fresh agentId, `forceRelay: true` → `{ status: 'offline' }` and queue count stays 0.
+
+  Cleanup discipline (3.5c lesson — the integration-DB pollution incident): `afterEach` obliterates the relay queue (`queue.obliterate({ force: true })`), deletes every `agent-presence:*` / `agent-relay-*` key the suite created, closes workers; `afterAll` runs `closeRedis()`. Keys must be namespaced per-test-run (`agent-int-<runUUID>-…` agentIds) so parallel shards can't collide.
+
+- [ ] **Step 2: Run** — `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/agentCommandRelay.integration.test.ts` with the test stack up → ALL PASS. Verify the file count in the output is 1 and the suite actually RAN (not skipped).
+
+- [ ] **Step 3: Commit** — `test(api): agent command relay integration suite (wave 3.5b #4084)`
+
+---
+
+### Task 10: Static dispatch-boundary contract test
+
+**Files:**
+- Create: `apps/api/src/jobs/agentDispatchBoundary.contract.test.ts`
+
+**Interfaces:** none produced — this is the guard #4084's "done when" demands: a test that FAILS if a future change gives a `jobs/**` module socket-local dispatch.
+
+- [ ] **Step 1: Write the test** (mechanism mirrors `eventSubscribers.contract.test.ts:1-60` — source-text scan):
+
+```ts
+// apps/api/src/jobs/agentDispatchBoundary.contract.test.ts
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Wave 3.5b (#4084): BullMQ job modules may run in a worker-role process that
+// holds NO agent sockets. Socket-local dispatch there silently reports every
+// agent offline — the exact incident class this wave exists to prevent. Jobs
+// must use dispatchCommandToAgent/isAgentConnectedAnywhere (agentCommandRelay).
+const JOBS_DIR = fileURLToPath(new URL('.', import.meta.url));
+
+// The relay consumer is the ONE legitimate socket-local caller under jobs/ —
+// its registration is gated to socket-owning roles in index.ts.
+const SOCKET_OWNER_ALLOWLIST = new Set(['agentCommandRelayWorker.ts']);
+
+const FORBIDDEN_PATTERNS: Array<[string, RegExp]> = [
+  ['value import of socket-local agentWs dispatch',
+    /import\s+(?!type\s)\{[^}]*\b(sendCommandToAgent|isAgentConnected|disconnectAgent|broadcastToAgents)\b[^}]*\}\s*from\s*['"][^'"]*agentWs['"]/],
+  ['value import of in-memory agentCommandAwait',
+    /import\s+(?!type\s)\{[^}]*\bsendCommandToAgentAwaitResult\b[^}]*\}\s*from\s*['"][^'"]*agentCommandAwait['"]/],
+];
+
+function productionSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...productionSources(full));
+    else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) out.push(full);
+  }
+  return out;
+}
+
+describe('jobs/** must not use socket-local agent dispatch (#4084)', () => {
+  const files = productionSources(JOBS_DIR)
+    .filter((f) => !SOCKET_OWNER_ALLOWLIST.has(f.slice(JOBS_DIR.length)));
+
+  it('found job modules to scan', () => {
+    expect(files.length).toBeGreaterThan(10);
+  });
+
+  it.each(files.map((f) => [f.slice(JOBS_DIR.length), f]))('%s', (_label, full) => {
+    const src = readFileSync(full, 'utf8');
+    for (const [what, pattern] of FORBIDDEN_PATTERNS) {
+      expect(src, `${what} — route through services/agentCommandRelay instead`).not.toMatch(pattern);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Prove it discriminates** — temporarily re-add `import { sendCommandToAgent } from '../routes/agentWs';` to `monitorWorker.ts`, run the test → FAIL naming monitorWorker; revert → PASS. (This is the red step for a guard test.)
+
+- [ ] **Step 3: Commit** — `test(api): static contract — jobs may not import socket-local dispatch (wave 3.5b #4084)`
+
+---
+
+### Task 11: Full verification + PR
+
+- [ ] **Step 1: Repo-wide sweep** — `grep -rn "sendCommandToAgent\|isAgentConnected" apps/api/src/jobs/` → only the allowlisted relay worker (and type-only `AgentCommand` imports). `grep -rn "BREEZE_ROLE" apps/api/src docker-compose.yml deploy/ .env.example` → env helper + validate + compose parity all present.
+- [ ] **Step 2: Full unit suite** — `cd apps/api && npx vitest run` → 0 failures. Typecheck via the repo's turbo/CI-equivalent (`pnpm --filter @breeze/api exec tsc --noEmit` if no script exists — match what CI runs).
+- [ ] **Step 3: Contract + integration suites** (tenancy untouched, but the wave's own integration file must run): RLS coverage + the new relay suite against the test stack — `npx vitest run --config vitest.integration.config.ts` (confirm `agentCommandRelay.integration.test.ts` appears in the run output).
+- [ ] **Step 4: Update this plan doc's checkboxes**, commit any stragglers.
+- [ ] **Step 5: Open the PR** — branch `feature/3821-ai-agents/wave-4084` → `main`, body must include: `Closes #4084`; the quorum decision summary (2-lite+ and why pinning was rejected); "Behavior changes in `all` mode: none for locally-connected agents — new code paths are presence bookkeeping (additive) and the relay branch (unreachable until 3.5d)"; the failed-job message trade-off from Task 8; deferred follow-ups to file as issues: per-instance queue sharding + multi-consumer topology guard (multi-replica API), durable orphaned-result expectations, relay queue-age/owner-mismatch alerting, presence-write load measurement at 10k agents. **Stop after opening the PR** (auto-merge is handled by the run driver, not the implementer).
+
+## Self-Review Notes
+
+- **Spec coverage vs #4084 "done when":** decision recorded (this doc + PR body) ✓; dispatch proven from a non-socket process (Task 9 forced-relay E2E — same-process BullMQ consumer stands in for the api process; the true two-process proof arrives with 3.5d's compose split, noted as accepted scope) ✓; a test fails if a socket-affine call site moves off the socket-owning role (Task 10 static contract + Task 6 runtime assertions) ✓.
+- **Type consistency:** `DispatchOutcome`/`RelayJobData`/`RelayEnvelopeBinding` defined once in Task 4 and consumed by name in Tasks 5-9; presence helpers defined in Task 2, consumed in Tasks 3/5/6/9; `__installAgentSocketForTest` defined Task 6, consumed Task 9.
+- **Known intentional gaps (do not "fix" during implementation):** `agentCommandAwait` stays api-role-affine; `broadcastToAgents`/`getConnectedAgentIds` remain socket-local (api-role callers only); no flag; no migration; multi-replica API out of scope.

--- a/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave3.5b-socket-affinity-relay.md
+++ b/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave3.5b-socket-affinity-relay.md
@@ -727,6 +727,8 @@ export async function dispatchCommandToAgent(
 
 - [ ] **Step 4: Run tests + typecheck** — PASS. Commit: `feat(api): dispatchCommandToAgent facade — local-first with presence-admitted relay (wave 3.5b #4084)`
 
+**Post-landing review fix (Tasks 4/5, `fix(api): review fixes for wave 3.5b relay-core (#4084)`):** `sealRelayCommand` throws when `APP_ENCRYPTION_KEY_ID` is unset (the AAD binding is the tamper defense, so it must never silently fall back to unbound v1 ciphertext) — but that made the whole relay path boot-time-invisible-dead on a stock deployment (`.env.example` ships the key id empty). Fixed by (a) moving the seal call inside the facade's guarded region so a throw maps to `{ status: 'infrastructure_error' }` instead of escaping as an unhandled exception, and (b) a new `validate.ts` superRefine pairing rule: `BREEZE_ROLE` of `api`/`worker` now requires a non-blank `APP_ENCRYPTION_KEY_ID` at boot. **Task 6 does not need to add this pairing rule — it already exists.**
+
 ---
 
 ### Task 6: Relay consumer worker + boot registration + runtime role assertions

--- a/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave3.5b-socket-affinity-relay.md
+++ b/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave3.5b-socket-affinity-relay.md
@@ -58,7 +58,7 @@ wave: W08 (#4084)
 **Interfaces:**
 - Produces: `breezeRole(): BreezeRole` (`'all'|'api'|'worker'`, default `'all'`), `INSTANCE_ID: string`.
 
-- [ ] **Step 1: Write the leaf identity module** (const-only, no test):
+- [x] **Step 1: Write the leaf identity module** (const-only, no test):
 
 ```ts
 // apps/api/src/services/instanceIdentity.ts
@@ -70,7 +70,7 @@ import { randomUUID } from 'crypto';
 export const INSTANCE_ID = randomUUID();
 ```
 
-- [ ] **Step 2: Write the failing env-helper tests**
+- [x] **Step 2: Write the failing env-helper tests**
 
 ```ts
 // apps/api/src/config/env.breezeRole.test.ts
@@ -108,9 +108,9 @@ describe('breezeRole()', () => {
 });
 ```
 
-- [ ] **Step 3: Run to verify failure** — `cd apps/api && npx vitest run src/config/env.breezeRole.test.ts` → FAIL (`breezeRole` not exported).
+- [x] **Step 3: Run to verify failure** — `cd apps/api && npx vitest run src/config/env.breezeRole.test.ts` → FAIL (`breezeRole` not exported).
 
-- [ ] **Step 4: Implement in `env.ts`** (mirror `eventDispatchMode`, env.ts:217):
+- [x] **Step 4: Implement in `env.ts`** (mirror `eventDispatchMode`, env.ts:217):
 
 ```ts
 export type BreezeRole = 'all' | 'api' | 'worker';
@@ -132,9 +132,9 @@ export function breezeRole(): BreezeRole {
 
 Add the matching optional-enum entry in `config/validate.ts` exactly the way `EVENT_DISPATCH_MODE` is declared there (same optionality — absent means `all`; do NOT make it required-in-production in this wave).
 
-- [ ] **Step 5: Env parity plumbing** — add to `.env.example` (`# BREEZE_ROLE=all — process role; 'worker' disables socket-local agent dispatch (wave 3.5d)`), and `BREEZE_ROLE: ${BREEZE_ROLE:-all}` to the api service `environment:` block in `docker-compose.yml` AND `deploy/docker-compose.prod.yml`. Run `cd apps/api && npx vitest run src/config/envComposeParity.test.ts` → PASS.
+- [x] **Step 5: Env parity plumbing** — add to `.env.example` (`# BREEZE_ROLE=all — process role; 'worker' disables socket-local agent dispatch (wave 3.5d)`), and `BREEZE_ROLE: ${BREEZE_ROLE:-all}` to the api service `environment:` block in `docker-compose.yml` AND `deploy/docker-compose.prod.yml`. Run `cd apps/api && npx vitest run src/config/envComposeParity.test.ts` → PASS.
 
-- [ ] **Step 6: Run tests** — `npx vitest run src/config/env.breezeRole.test.ts` → PASS. Commit: `feat(api): BREEZE_ROLE env helper + per-boot INSTANCE_ID (wave 3.5b #4084)`
+- [x] **Step 6: Run tests** — `npx vitest run src/config/env.breezeRole.test.ts` → PASS. Commit: `feat(api): BREEZE_ROLE env helper + per-boot INSTANCE_ID (wave 3.5b #4084)`
 
 ---
 
@@ -147,7 +147,7 @@ Add the matching optional-enum entry in `config/validate.ts` exactly the way `EV
 **Interfaces:**
 - Produces: `AgentPresenceLease { instanceId: string; connectionToken: string }`, `AGENT_PRESENCE_TTL_MS = 90_000`, `setAgentPresence(agentId, lease): Promise<void>`, `refreshAgentPresence(agentId, connectionToken): Promise<boolean>`, `clearAgentPresence(agentId, connectionToken): Promise<boolean>`, `readAgentPresence(agentId): Promise<AgentPresenceLease | null>`. All best-effort: Redis unavailable → no-op / `null` / `false`, never throw (presence is an admission hint; missing presence fails closed as "offline").
 
-- [ ] **Step 1: Write the failing unit tests** — mock `getRedis` (pattern: existing `services/*.test.ts` that `vi.mock('./redis', ...)`):
+- [x] **Step 1: Write the failing unit tests** — mock `getRedis` (pattern: existing `services/*.test.ts` that `vi.mock('./redis', ...)`):
 
 ```ts
 // apps/api/src/services/agentPresence.test.ts
@@ -226,9 +226,9 @@ describe('agentPresence', () => {
 });
 ```
 
-- [ ] **Step 2: Run to verify failure** — `npx vitest run src/services/agentPresence.test.ts` → FAIL (module missing).
+- [x] **Step 2: Run to verify failure** — `npx vitest run src/services/agentPresence.test.ts` → FAIL (module missing).
 
-- [ ] **Step 3: Implement**:
+- [x] **Step 3: Implement**:
 
 ```ts
 // apps/api/src/services/agentPresence.ts
@@ -324,7 +324,7 @@ export async function readAgentPresence(agentId: string): Promise<AgentPresenceL
 }
 ```
 
-- [ ] **Step 4: Run tests** — `npx vitest run src/services/agentPresence.test.ts` → PASS. Commit: `feat(api): fenced agent presence leases in Redis (wave 3.5b #4084)`
+- [x] **Step 4: Run tests** — `npx vitest run src/services/agentPresence.test.ts` → PASS. Commit: `feat(api): fenced agent presence leases in Redis (wave 3.5b #4084)`
 
 ---
 
@@ -338,15 +338,15 @@ export async function readAgentPresence(agentId: string): Promise<AgentPresenceL
 - Consumes: Task 2's four presence helpers, Task 1's `INSTANCE_ID`.
 - Produces: presence keys maintained for every live agent socket; a per-connection `connectionToken` (closure variable next to `socketEpoch` in `createAgentWsHandlers`).
 
-- [ ] **Step 1: Write failing tests** — mock `../services/agentPresence` and assert, via the existing handler-test harness for `createAgentWsHandlers`:
+- [x] **Step 1: Write failing tests** — mock `../services/agentPresence` and assert, via the existing handler-test harness for `createAgentWsHandlers`:
   - onOpen calls `setAgentPresence(agentId, { instanceId: INSTANCE_ID, connectionToken: <uuid> })` (capture the token; assert it is a non-empty string).
   - a `pong` message calls `refreshAgentPresence(agentId, <same token>)`.
   - when `refreshAgentPresence` resolves `false` AND this ws is still the mapped connection, the handler re-calls `setAgentPresence` with the same token (self-heal after an errant delete).
   - onClose (current socket) calls `clearAgentPresence(agentId, <same token>)`; onClose for a superseded socket does NOT clear (token mismatch is also guarded server-side, but don't even issue the call when `activeConnections.get(agentId) !== ws`).
 
-- [ ] **Step 2: Run to verify failure.**
+- [x] **Step 2: Run to verify failure.**
 
-- [ ] **Step 3: Implement** — all calls fire-and-forget (`void ...` or `.catch(() => {})` consistent with surrounding style; the handlers must never await Redis on the hot path):
+- [x] **Step 3: Implement** — all calls fire-and-forget (`void ...` or `.catch(() => {})` consistent with surrounding style; the handlers must never await Redis on the hot path):
   - In `createAgentWsHandlers`, next to `socketEpoch`, add `const connectionToken = randomUUID();` (add the `crypto` import if absent).
   - onOpen, immediately after `activeConnections.set(agentId, ws); socketEpoch = installAgentSocketEpoch(agentId);`:
     ```ts
@@ -376,7 +376,7 @@ export async function readAgentPresence(agentId: string): Promise<AgentPresenceL
     ```
     Add `clearAgentPresenceUnfenced(agentId)` to `agentPresence.ts` (plain `DEL`, same never-throw contract, one-line unit test in the Task 2 file).
 
-- [ ] **Step 4: Run the agentWs test file(s) + typecheck** — PASS. Commit: `feat(api): maintain fenced presence leases from the agent WS lifecycle (wave 3.5b #4084)`
+- [x] **Step 4: Run the agentWs test file(s) + typecheck** — PASS. Commit: `feat(api): maintain fenced presence leases from the agent WS lifecycle (wave 3.5b #4084)`
 
 ---
 
@@ -396,7 +396,7 @@ export async function readAgentPresence(agentId: string): Promise<AgentPresenceL
   - `writeRelayAck(relayId, outcome): Promise<void>`, `awaitRelayAck(relayId, deadlineMs): Promise<DispatchOutcome>` (deadline exceeded → `{ status: 'indeterminate' }`)
   - `AGENT_COMMAND_RELAY_QUEUE = 'agent-command-relay'`, `RELAY_DELIVERY_DEADLINE_MS = 5_000`
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```ts
 // apps/api/src/services/agentCommandRelay.test.ts
@@ -496,9 +496,9 @@ describe('acks', () => {
 });
 ```
 
-- [ ] **Step 2: Run to verify failure** — module missing.
+- [x] **Step 2: Run to verify failure** — module missing.
 
-- [ ] **Step 3: Implement part 1 of the module** (the facade + queue singleton come in Task 5 — keep this commit to primitives):
+- [x] **Step 3: Implement part 1 of the module** (the facade + queue singleton come in Task 5 — keep this commit to primitives):
 
 ```ts
 // apps/api/src/services/agentCommandRelay.ts
@@ -614,7 +614,7 @@ export async function awaitRelayAck(relayId: string, deadlineMs: number): Promis
 }
 ```
 
-- [ ] **Step 4: Run tests** — PASS (fix the `decryptSecret` import to the real secretCrypto export if the roundtrip fails to compile). Commit: `feat(api): relay envelope, at-most-once send claims, ack channel (wave 3.5b #4084)`
+- [x] **Step 4: Run tests** — PASS (fix the `decryptSecret` import to the real secretCrypto export if the roundtrip fails to compile). Commit: `feat(api): relay envelope, at-most-once send claims, ack channel (wave 3.5b #4084)`
 
 ---
 
@@ -631,7 +631,7 @@ export async function awaitRelayAck(relayId: string, deadlineMs: number): Promis
   - `isAgentConnectedAnywhere(agentId: string): Promise<boolean>`
   - `getAgentCommandRelayQueue(): Queue<RelayJobData>` / `shutdownAgentCommandRelayQueue(): Promise<void>` (mirror `eventDispatchQueue.ts:55-62`)
 
-- [ ] **Step 1: Write the failing tests** — add a mocked `../routes/agentWs` (`isAgentConnected`, `sendCommandToAgent`), mocked `./agentPresence`, mocked `./bullmqQueue` (capture `queue.add` calls). Cases:
+- [x] **Step 1: Write the failing tests** — add a mocked `../routes/agentWs` (`isAgentConnected`, `sendCommandToAgent`), mocked `./agentPresence`, mocked `./bullmqQueue` (capture `queue.add` calls). Cases:
   - local socket + send ok → `{ status: 'sent', via: 'local' }`, **no** presence read, **no** enqueue.
   - local socket + `sendCommandToAgent` returns false → `{ status: 'offline' }`, no enqueue (the local map was authoritative and the socket died mid-send).
   - no local socket + no presence → `{ status: 'offline' }`, no enqueue.
@@ -640,9 +640,9 @@ export async function awaitRelayAck(relayId: string, deadlineMs: number): Promis
   - `forceRelay: true` skips the local-first branch even when the local socket exists (staging/integration verification hook).
   - `isAgentConnectedAnywhere`: local hit → true without presence read; local miss + presence → true; both miss → false; under `BREEZE_ROLE=worker` the socket-local check is skipped entirely (assert `isAgentConnected` never called — it would throw in that role after Task 6).
 
-- [ ] **Step 2: Run to verify failure.**
+- [x] **Step 2: Run to verify failure.**
 
-- [ ] **Step 3: Implement** (append to the module):
+- [x] **Step 3: Implement** (append to the module):
 
 ```ts
 import { randomUUID } from 'crypto';
@@ -725,7 +725,7 @@ export async function dispatchCommandToAgent(
 }
 ```
 
-- [ ] **Step 4: Run tests + typecheck** — PASS. Commit: `feat(api): dispatchCommandToAgent facade — local-first with presence-admitted relay (wave 3.5b #4084)`
+- [x] **Step 4: Run tests + typecheck** — PASS. Commit: `feat(api): dispatchCommandToAgent facade — local-first with presence-admitted relay (wave 3.5b #4084)`
 
 **Post-landing review fix (Tasks 4/5, `fix(api): review fixes for wave 3.5b relay-core (#4084)`):** `sealRelayCommand` throws when `APP_ENCRYPTION_KEY_ID` is unset (the AAD binding is the tamper defense, so it must never silently fall back to unbound v1 ciphertext) — but that made the whole relay path boot-time-invisible-dead on a stock deployment (`.env.example` ships the key id empty). Fixed by (a) moving the seal call inside the facade's guarded region so a throw maps to `{ status: 'infrastructure_error' }` instead of escaping as an unhandled exception, and (b) a new `validate.ts` superRefine pairing rule: `BREEZE_ROLE` of `api`/`worker` now requires a non-blank `APP_ENCRYPTION_KEY_ID` at boot. **Task 6 does not need to add this pairing rule — it already exists.**
 
@@ -742,7 +742,7 @@ export async function dispatchCommandToAgent(
 - Consumes: Task 4 primitives, Task 2 `readAgentPresence`, Task 1 `INSTANCE_ID`, socket-local `isAgentConnected`/`sendCommandToAgent`.
 - Produces: `createAgentCommandRelayWorker(): Worker`, `initializeAgentCommandRelayWorker(): Promise<void>`; agentWs test-only export `__installAgentSocketForTest(agentId: string, ws: { send(data: string): void }): void`.
 
-- [ ] **Step 1: Write the failing processor tests** (mock agentWs, agentPresence, and the relay primitives; drive the exported processor function directly with a fake `Job`):
+- [x] **Step 1: Write the failing processor tests** (mock agentWs, agentPresence, and the relay primitives; drive the exported processor function directly with a fake `Job`):
   - expired job (`expiresAt` in the past) → ack `{ status: 'expired' }`, no claim taken, no send.
   - no local socket → ack `{ status: 'offline' }`, no claim.
   - lease missing / `instanceId` ≠ job's `targetInstanceId` / `connectionToken` mismatch / `targetInstanceId` ≠ `INSTANCE_ID` → ack `{ status: 'owner_mismatch' }`, no send. (Strict fencing per quorum: a routing decision made against a superseded lease is never executed, even if the agent reconnected here — the caller's next cycle re-routes.)
@@ -752,9 +752,9 @@ export async function dispatchCommandToAgent(
   - claim `'claimed'` + send ok → `sendCommandToAgent` called with the decrypted command, `markRelaySendComplete` called, ack `{ status: 'sent', via: 'relay' }`.
   - claim `'claimed'` + `sendCommandToAgent` returns false → ack `{ status: 'offline' }`, `markRelaySendComplete` NOT called.
 
-- [ ] **Step 2: Run to verify failure.**
+- [x] **Step 2: Run to verify failure.**
 
-- [ ] **Step 3: Implement the worker**:
+- [x] **Step 3: Implement the worker**:
 
 ```ts
 // apps/api/src/jobs/agentCommandRelayWorker.ts
@@ -834,7 +834,7 @@ export function createAgentCommandRelayWorker(): Worker {
 
 Add `initializeAgentCommandRelayWorker` following the shape of the sibling `initialize*Worker` functions in whichever module `index.ts` imports them from (grep one, e.g. `initializeEventDispatchWorker`, and mirror its error handling + shutdown hook). If 3.5c's `attachWorkerObservability` (from `services/bullmqQueue.ts`) is what `eventDispatchWorker` uses for Sentry/error reporting, attach it identically here.
 
-- [ ] **Step 4: Boot registration in `index.ts`** — next to the phase-2 event-dispatch start (index.ts:1505-1524), add:
+- [x] **Step 4: Boot registration in `index.ts`** — next to the phase-2 event-dispatch start (index.ts:1505-1524), add:
 
 ```ts
 if (breezeRole() !== 'worker') {
@@ -849,7 +849,7 @@ if (breezeRole() !== 'worker') {
 }
 ```
 
-- [ ] **Step 5: Runtime role assertions** — in `agentWs.ts`, add at the top of `sendCommandToAgent` AND `isAgentConnected` (and export nothing new for it):
+- [x] **Step 5: Runtime role assertions** — in `agentWs.ts`, add at the top of `sendCommandToAgent` AND `isAgentConnected` (and export nothing new for it):
 
 ```ts
 function assertSocketLocalDispatchAllowed(fn: string): void {
@@ -864,7 +864,7 @@ function assertSocketLocalDispatchAllowed(fn: string): void {
 
 Same assertion at the top of `sendCommandToAgentAwaitResult` (`services/agentCommandAwait.ts`), plus a doc comment stating the module is api-role-affine by design (its correlation map cannot resolve cross-process). Throwing — not returning false — is the point: a silent false is exactly the every-agent-reads-offline failure this wave exists to kill. Test: with `BREEZE_ROLE=worker` set (and restored) in the agentWs test file, each of the three throws with a message matching `/BREEZE_ROLE/`.
 
-- [ ] **Step 6: Test-only socket installer in `agentWs.ts`** (needed by Task 9's integration suite; mirror `__resetCrossTenantDropsForTest`, agentWs.ts:2993):
+- [x] **Step 6: Test-only socket installer in `agentWs.ts`** (needed by Task 9's integration suite; mirror `__resetCrossTenantDropsForTest`, agentWs.ts:2993):
 
 ```ts
 export function __installAgentSocketForTest(agentId: string, ws: { send(data: string): void }): void {
@@ -876,7 +876,7 @@ export function __installAgentSocketForTest(agentId: string, ws: { send(data: st
 }
 ```
 
-- [ ] **Step 7: Run the new tests + full typecheck** — PASS. Commit: `feat(api): api-role relay consumer, boot gating, worker-role dispatch assertions (wave 3.5b #4084)`
+- [x] **Step 7: Run the new tests + full typecheck** — PASS. Commit: `feat(api): api-role relay consumer, boot gating, worker-role dispatch assertions (wave 3.5b #4084)`
 
 ---
 
@@ -891,7 +891,7 @@ export function __installAgentSocketForTest(agentId: string, ws: { send(data: st
 
 **Behavior contract (both workers):** in `BREEZE_ROLE=all` with a locally-connected agent the observable behavior is IDENTICAL to today (local-first path). The only new behavior is the relay branch, unreachable until 3.5d. Preserve each function's exact return shapes.
 
-- [ ] **Step 1: Write the failing tests** — mock `../services/agentCommandRelay`. Cases per worker:
+- [x] **Step 1: Write the failing tests** — mock `../services/agentCommandRelay`. Cases per worker:
   - `isAgentConnectedAnywhere` false → today's "No online agent" warn + `{ dispatched: false, agentId: null }`, and `dispatchCommandToAgent` never called.
   - outcome `{ status: 'sent', via: 'local' }` → `{ dispatched: true, agentId }`.
   - outcome `{ status: 'offline' }` → `{ dispatched: false, agentId }` and the error log includes the outcome status.
@@ -899,9 +899,9 @@ export function __installAgentSocketForTest(agentId: string, ws: { send(data: st
   - snmp only: `markPollDispatched` is still called after the connectivity check and before dispatch (assert call order via mock invocationCallOrder) — an indeterminate dispatch leaves the poll counted, mirroring today's send-false-after-mark semantics.
   - monitor only: dispatch is called with `{ priority: 'probe' }`.
 
-- [ ] **Step 2: Run to verify failure.**
+- [x] **Step 2: Run to verify failure.**
 
-- [ ] **Step 3: Migrate `monitorWorker.ts`** — replace the import and the block at ~160-177:
+- [x] **Step 3: Migrate `monitorWorker.ts`** — replace the import and the block at ~160-177:
 
 ```ts
 import { dispatchCommandToAgent, isAgentConnectedAnywhere } from '../services/agentCommandRelay';
@@ -930,7 +930,7 @@ import type { AgentCommand } from '../routes/agentWs';
 
 (If `monitorWorker.ts` only imported `sendCommandToAgent`/`isAgentConnected` for this block, the agentWs import disappears entirely; keep `AgentCommand` type-only if the file references the type.)
 
-- [ ] **Step 4: Migrate `snmpWorker.ts`** — same substitution at ~394-420: `isAgentConnected(agentId)` → `await isAgentConnectedAnywhere(agentId)`; keep the `markPollDispatched` placement and its #1105 phase-split comment intact (the facade's Redis I/O also relies on running outside a held DB context); then:
+- [x] **Step 4: Migrate `snmpWorker.ts`** — same substitution at ~394-420: `isAgentConnected(agentId)` → `await isAgentConnectedAnywhere(agentId)`; keep the `markPollDispatched` placement and its #1105 phase-split comment intact (the facade's Redis I/O also relies on running outside a held DB context); then:
 
 ```ts
   const command = buildSnmpPollCommand(data.deviceId, device, oids);
@@ -944,7 +944,7 @@ import type { AgentCommand } from '../routes/agentWs';
   return { dispatched: true, agentId };
 ```
 
-- [ ] **Step 5: Run both worker test files + typecheck** — PASS. Commit: `refactor(api): monitor + snmp workers dispatch via the cross-process facade (wave 3.5b #4084)`
+- [x] **Step 5: Run both worker test files + typecheck** — PASS. Commit: `refactor(api): monitor + snmp workers dispatch via the cross-process facade (wave 3.5b #4084)`
 
 ---
 
@@ -956,16 +956,16 @@ import type { AgentCommand } from '../routes/agentWs';
 
 **Behavior contract:** offline stays fail-fast (`markJobFailed` with the SAME message strings as today — dashboards and tests key on them). `indeterminate`/`infrastructure_error`/`expired`/`owner_mismatch` mark the job failed with a NEW distinct message naming the outcome — the command may still execute (at-most-once means no duplicate was sent), and a late result hitting a failed-marked job is the same benign race as today's send-succeeded-then-agent-crashed window. Flag this trade-off in the PR body.
 
-- [ ] **Step 1: Write the failing tests** — cases per worker:
+- [x] **Step 1: Write the failing tests** — cases per worker:
   - `isAgentConnectedAnywhere` false → `markJobFailed(jobId, 'Agent not connected')` (backup) / `markJobFailed(jobId, 'No online agent available for this site')` (discovery) — byte-identical messages.
   - outcome `sent` → job proceeds exactly as today (backup increments sentCount; discovery flips job to running).
   - outcome `offline` → backup: the existing per-target failure branch runs (warn + child-job failed row); discovery: `markJobFailed(jobId, 'Failed to send command to agent')` (today's message).
   - outcome `indeterminate` → failure branch with a message matching `/dispatch outcome indeterminate/i`.
   - backup only: `recordDispatchedExpectation('backup', deviceId, commandJobId)` still happens BEFORE dispatch (call order assertion) — the expectation-first comment at backupWorker.ts:645-651 stays valid because an unconsumed expectation still just expires via TTL.
 
-- [ ] **Step 2: Run to verify failure.**
+- [x] **Step 2: Run to verify failure.**
 
-- [ ] **Step 3: Migrate `backupWorker.ts`**:
+- [x] **Step 3: Migrate `backupWorker.ts`**:
 
 ```ts
 import { dispatchCommandToAgent, isAgentConnectedAnywhere } from '../services/agentCommandRelay';
@@ -997,7 +997,7 @@ At ~501: `if (!agentId || !(await isAgentConnectedAnywhere(agentId))) {` (unchan
 
 (Keep the surrounding comment block; it remains accurate.)
 
-- [ ] **Step 4: Migrate `discoveryWorker.ts`** — `!isAgentConnected(agentId)` → `!(await isAgentConnectedAnywhere(agentId))` (~571, same failure body); at ~606:
+- [x] **Step 4: Migrate `discoveryWorker.ts`** — `!isAgentConnected(agentId)` → `!(await isAgentConnectedAnywhere(agentId))` (~571, same failure body); at ~606:
 
 ```ts
   const outcome = await dispatchCommandToAgent(agentId, command);
@@ -1012,7 +1012,7 @@ At ~501: `if (!agentId || !(await isAgentConnectedAnywhere(agentId))) {` (unchan
   }
 ```
 
-- [ ] **Step 5: Run both worker test files + typecheck** — PASS. Commit: `refactor(api): backup + discovery workers dispatch via the cross-process facade (wave 3.5b #4084)`
+- [x] **Step 5: Run both worker test files + typecheck** — PASS. Commit: `refactor(api): backup + discovery workers dispatch via the cross-process facade (wave 3.5b #4084)`
 
 ---
 
@@ -1025,7 +1025,7 @@ At ~501: `if (!agentId || !(await isAgentConnectedAnywhere(agentId))) {` (unchan
 **Interfaces:**
 - Consumes: everything from Tasks 2-6 against real Redis; `__installAgentSocketForTest` (Task 6). Setup pattern: copy the header of `eventDispatchQueue.integration.test.ts` (`import './setup'`, real `REDIS_URL`, `closeRedis` in afterAll, `docker compose -f docker-compose.test.yml up` run instructions in the top comment).
 
-- [ ] **Step 1: Write the suite** (each test red-then-green against the already-implemented code is fine here — the suite's job is proving the composition against real Redis; assert precisely):
+- [x] **Step 1: Write the suite** (each test red-then-green against the already-implemented code is fine here — the suite's job is proving the composition against real Redis; assert precisely):
   1. **Presence lifecycle:** `setAgentPresence` → `readAgentPresence` roundtrip; `refreshAgentPresence` with the right/wrong token → true/false; `clearAgentPresence` with the wrong token leaves the key (fencing); PTTL is ≤ `AGENT_PRESENCE_TTL_MS` and > 0 after a refresh.
   2. **Forced-relay E2E, exactly once:** install a fake socket capturing `send()` frames via `__installAgentSocketForTest('agent-int-1', ...)`; `setAgentPresence('agent-int-1', { instanceId: INSTANCE_ID, connectionToken: 't-int' })`; start `createAgentCommandRelayWorker()`; call `dispatchCommandToAgent('agent-int-1', { id: <uuid>, type: 'network_ping', payload: { probe: true } }, { forceRelay: true })` → resolves `{ status: 'sent', via: 'relay' }` within 5s; the fake socket received EXACTLY one frame; `JSON.parse(frame)` equals the command verbatim (`{id, type, payload}`, no extra keys).
   3. **No plaintext in the queue:** enqueue with a payload containing `'sup3r-s3cret'` (no consumer running); fetch the raw job via `getAgentCommandRelayQueue().getJob('relay-<id>')` and assert `JSON.stringify(job.data)` does NOT contain the secret; then assert `openRelayCommand` with the job's own binding fields DOES recover it.
@@ -1038,9 +1038,9 @@ At ~501: `if (!agentId || !(await isAgentConnectedAnywhere(agentId))) {` (unchan
 
   Cleanup discipline (3.5c lesson — the integration-DB pollution incident): `afterEach` obliterates the relay queue (`queue.obliterate({ force: true })`), deletes every `agent-presence:*` / `agent-relay-*` key the suite created, closes workers; `afterAll` runs `closeRedis()`. Keys must be namespaced per-test-run (`agent-int-<runUUID>-…` agentIds) so parallel shards can't collide.
 
-- [ ] **Step 2: Run** — `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/agentCommandRelay.integration.test.ts` with the test stack up → ALL PASS. Verify the file count in the output is 1 and the suite actually RAN (not skipped).
+- [x] **Step 2: Run** — `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/agentCommandRelay.integration.test.ts` with the test stack up → ALL PASS. Verify the file count in the output is 1 and the suite actually RAN (not skipped).
 
-- [ ] **Step 3: Commit** — `test(api): agent command relay integration suite (wave 3.5b #4084)`
+- [x] **Step 3: Commit** — `test(api): agent command relay integration suite (wave 3.5b #4084)`
 
 ---
 
@@ -1051,7 +1051,7 @@ At ~501: `if (!agentId || !(await isAgentConnectedAnywhere(agentId))) {` (unchan
 
 **Interfaces:** none produced — this is the guard #4084's "done when" demands: a test that FAILS if a future change gives a `jobs/**` module socket-local dispatch.
 
-- [ ] **Step 1: Write the test** (mechanism mirrors `eventSubscribers.contract.test.ts:1-60` — source-text scan):
+- [x] **Step 1: Write the test** (mechanism mirrors `eventSubscribers.contract.test.ts:1-60` — source-text scan):
 
 ```ts
 // apps/api/src/jobs/agentDispatchBoundary.contract.test.ts
@@ -1104,18 +1104,18 @@ describe('jobs/** must not use socket-local agent dispatch (#4084)', () => {
 });
 ```
 
-- [ ] **Step 2: Prove it discriminates** — temporarily re-add `import { sendCommandToAgent } from '../routes/agentWs';` to `monitorWorker.ts`, run the test → FAIL naming monitorWorker; revert → PASS. (This is the red step for a guard test.)
+- [x] **Step 2: Prove it discriminates** — temporarily re-add `import { sendCommandToAgent } from '../routes/agentWs';` to `monitorWorker.ts`, run the test → FAIL naming monitorWorker; revert → PASS. (This is the red step for a guard test.)
 
-- [ ] **Step 3: Commit** — `test(api): static contract — jobs may not import socket-local dispatch (wave 3.5b #4084)`
+- [x] **Step 3: Commit** — `test(api): static contract — jobs may not import socket-local dispatch (wave 3.5b #4084)`
 
 ---
 
 ### Task 11: Full verification + PR
 
-- [ ] **Step 1: Repo-wide sweep** — `grep -rn "sendCommandToAgent\|isAgentConnected" apps/api/src/jobs/` → only the allowlisted relay worker (and type-only `AgentCommand` imports). `grep -rn "BREEZE_ROLE" apps/api/src docker-compose.yml deploy/ .env.example` → env helper + validate + compose parity all present.
-- [ ] **Step 2: Full unit suite** — `cd apps/api && npx vitest run` → 0 failures. Typecheck via the repo's turbo/CI-equivalent (`pnpm --filter @breeze/api exec tsc --noEmit` if no script exists — match what CI runs).
-- [ ] **Step 3: Contract + integration suites** (tenancy untouched, but the wave's own integration file must run): RLS coverage + the new relay suite against the test stack — `npx vitest run --config vitest.integration.config.ts` (confirm `agentCommandRelay.integration.test.ts` appears in the run output).
-- [ ] **Step 4: Update this plan doc's checkboxes**, commit any stragglers.
+- [x] **Step 1: Repo-wide sweep** — `grep -rn "sendCommandToAgent\|isAgentConnected" apps/api/src/jobs/` → only the allowlisted relay worker (and type-only `AgentCommand` imports). `grep -rn "BREEZE_ROLE" apps/api/src docker-compose.yml deploy/ .env.example` → env helper + validate + compose parity all present.
+- [x] **Step 2: Full unit suite** — `cd apps/api && npx vitest run` → 0 failures. Typecheck via the repo's turbo/CI-equivalent (`pnpm --filter @breeze/api exec tsc --noEmit` if no script exists — match what CI runs).
+- [x] **Step 3: Contract + integration suites** (tenancy untouched, but the wave's own integration file must run): RLS coverage + the new relay suite against the test stack — `npx vitest run --config vitest.integration.config.ts` (confirm `agentCommandRelay.integration.test.ts` appears in the run output).
+- [x] **Step 4: Update this plan doc's checkboxes**, commit any stragglers.
 - [ ] **Step 5: Open the PR** — branch `feature/3821-ai-agents/wave-4084` → `main`, body must include: `Closes #4084`; the quorum decision summary (2-lite+ and why pinning was rejected); "Behavior changes in `all` mode: none for locally-connected agents — new code paths are presence bookkeeping (additive) and the relay branch (unreachable until 3.5d)"; the failed-job message trade-off from Task 8; deferred follow-ups to file as issues: per-instance queue sharding + multi-consumer topology guard (multi-replica API), durable orphaned-result expectations, relay queue-age/owner-mismatch alerting, presence-write load measurement at 10k agents. **Stop after opening the PR** (auto-merge is handled by the run driver, not the implementer).
 
 ## Self-Review Notes


### PR DESCRIPTION
Closes #4084

Agent command dispatch no longer depends on the API process's in-memory connection map — the release blocker for the 3.5d `BREEZE_ROLE` split. Design: **"2-lite+"** per advisor quorum 2026-08-27 (Claude position + independent codex `xhigh` review converged; plan doc `docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave3.5b-socket-affinity-relay.md` is the ADR).

## What ships

- **Fenced presence leases** (`agent-presence:<agentId>`, 90s TTL): written by the WS lifecycle, token-fenced via server-side Lua compare-and-refresh/delete so a superseded socket's delayed close can never delete a live lease; pong-driven refresh with self-heal.
- **`dispatchCommandToAgent()` facade** (`services/agentCommandRelay.ts`): local socket → today's direct send, byte-identical; otherwise presence-admitted enqueue on the `agent-command-relay` BullMQ queue with a **typed delivery outcome** (`sent | offline | expired | owner_mismatch | indeterminate | infrastructure_error`) — enqueue success is never conflated with "sent".
- **Encrypted relay envelopes**: SNMP/discovery/backup commands carry decrypted credentials, so the whole command is sealed (AAD binds agentId/commandId/target instance/expiry; v3 keyed encryption enforced — the v1 no-AAD fallback is refused). No plaintext ever reaches Redis/BullMQ payloads.
- **At-most-once sends**: Redis claim CAS (`claimed → sent`) so a BullMQ stalled-job redelivery can never double-send; ambiguous states resolve to `indeterminate`, never a resend.
- **Api-role relay consumer** (`jobs/agentCommandRelayWorker.ts`): validates expiry + owner fencing against the live lease, performs the local send (keeping `orphanedResultExpectations` on the socket-owning process), acks the producer.
- **`BREEZE_ROLE` env helper** (default `all`) + **runtime assertions**: `sendCommandToAgent`/`isAgentConnected`/`sendCommandToAgentAwaitResult` THROW in a worker-role process — the silent every-agent-offline failure mode is now impossible.
- **Four workers migrated** to the facade (monitor, SNMP, backup, discovery), preserving byte-identical offline failure messages and return shapes, with the #1105 phase-split (no DB context held across the facade's Redis I/O).
- **Guards** (#4084 "done when"): static contract test — `jobs/**` cannot value-import socket-local dispatch (relay consumer allowlisted); runtime role assertions; real-Redis integration suite (9 cases: forced-relay exactly-once E2E, fencing, no-plaintext, at-most-once, local-first-no-enqueue).

Result routing needed **no work**: `command_result` → DB writes → `waitForCommandResult` polling was already cross-process-safe (exploration finding that shrank this wave's scope vs. the issue's original estimate).

## Behavior changes in `BREEZE_ROLE=all` (today's topology)

**None for locally-connected agents** — the local-first branch is today's exact code path with zero Redis I/O (integration-asserted: queue count stays 0). Additive only: presence-lease bookkeeping on the WS lifecycle (fire-and-forget), and the relay branch, unreachable until 3.5d flips a role.

## Trade-offs made deliberately (flagged per run authorization)

- **`indeterminate`/`expired`/`owner_mismatch` dispatch outcomes mark backup/discovery jobs failed with a distinct message** while the command may still execute (at-most-once = we never resend). A late result hitting a failed-marked job is the same benign race as today's send-succeeded-then-agent-crashed window.
- **Strict owner fencing**: a relay job routed against a superseded lease is refused even if the agent reconnected to the same process — the caller's next cycle re-routes.
- **Unflagged** (quorum): a command relay can't be meaningfully shadowed (double-send = double device work). Topology is the rollout control; rollback is `BREEZE_ROLE=all`, never a mode that silently reports agents offline.

## Review provenance

6 staged implement→review rounds (opus on ws-wiring/relay-core/consumer/test-suites), 5 blocking findings caught and fixed at stage level (incl. a provably-vacuous consumer-suite assertion and a non-discriminating PTTL assertion); final whole-branch opus review at xhigh found 1 blocking finding (three workers called the facade inside a held `withSystemDbAccessContext` — fixed via snmpWorker's phase-split pattern in 3ec0439d2, then independently re-reviewed). Full unit suite: 26,133 passed / 0 failed; `tsc --noEmit` clean (with the documented heap bump); integration suite ran against a real PG+Redis stack (9/9, registered in `vitest.integration.config.ts`).

## Follow-ups to file on merge

- Per-instance relay queue sharding + multi-consumer topology guard (required before multi-replica API; single api container today).
- Durable (Redis-backed) `orphanedResultExpectations` for multi-replica.
- Relay queue-age / owner-mismatch / indeterminate alerting.
- Presence-write load measurement at 10k agents (~333 Redis ops/s inferred, unmeasured).

## For 3.5d (#4086)

The relay consumer + WS route stay on `api`-role processes; heavy workers move to `worker` role and dispatch through the facade. `BREEZE_ROLE` is already mapped in both compose files (default `all`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012o7QB15EFjEvetDAXMxmae
