### PR TITLE
fix(api): ordered graceful shutdown — sequential phases, EventBus stops quitting the shared Redis connection (3.5d part A)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1798,10 +1798,13 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     { name: 'sentry', tasks: [() => flushSentry()], timeoutMs: 5_000 },
   ]);
   const failed = report.failures.length > 0;
+  const timedOutSuffix = report.timedOutPhases.length > 0
+    ? ` (timed-out phase(s): ${report.timedOutPhases.join(', ')})`
+    : '';
   if (failed) {
-    console.error(`[shutdown] Completed with ${report.failures.length} failure(s)`);
+    console.error(`[shutdown] Completed with ${report.failures.length} failure(s)${timedOutSuffix}`);
   } else {
-    console.log('[shutdown] Complete');
+    console.log(`[shutdown] Complete${timedOutSuffix}`);
   }
   process.exit(failed ? 1 : 0);
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -372,6 +372,7 @@ import { breezeRole } from './config/env';
 import { getEventBus } from './services/eventBus';
 import { writeAuditEvent } from './services/auditEvents';
 import { drainAuditRetryQueue } from './services/auditService';
+import { runShutdownPhases } from './services/shutdownPhases';
 import { createCorsOriginResolver } from './services/corsOrigins';
 import { validateConfig } from './config/validate';
 import { initializeDatabaseForStartup } from './db/databaseStartup';
@@ -1625,15 +1626,23 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     auditRetryInterval = null;
   }
 
-  const shutdownTasks: Array<() => Promise<void>> = [
-    // Best-effort final drain of pending audit retries. Bounded by a hard
-    // 5s timeout so a stuck DB doesn't block the rest of shutdown.
-    async () => {
-      await Promise.race([
-        drainAuditRetryQueue().then(() => undefined),
-        new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
-      ]);
-    },
+  // Best-effort final drain of pending audit retries. Bounded by a hard
+  // 5s timeout so a stuck DB doesn't block the rest of shutdown.
+  const boundedAuditDrainTask = async () => {
+    await Promise.race([
+      drainAuditRetryQueue().then(() => undefined),
+      new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
+    ]);
+  };
+
+  const dbCloseTask = async () => {
+    const closeDb = dbModule.closeDb;
+    if (typeof closeDb === 'function') {
+      await closeDb();
+    }
+  };
+
+  const workerShutdownTasks: Array<() => Promise<void>> = [
     shutdownLogForwardingWorker,
     shutdownPatchJobWorkers,
     shutdownBackupWorker,
@@ -1737,21 +1746,6 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownTicketMailboxPollWorker,
     shutdownInvoiceWorkers,
     shutdownContractWorkers,
-    shutdownEventDispatcher,
-    shutdownEventDispatchWorker,
-    shutdownEventDispatchQueue,
-    shutdownAgentCommandRelayWorker,
-    async () => getEventBus().close(),
-    closeRedis,
-    async () => {
-      const closeDb = dbModule.closeDb;
-      if (typeof closeDb === 'function') {
-        await closeDb();
-      }
-    },
-    // Drain any buffered Sentry events before the process exits (no-op if
-    // Sentry is disabled). Bounded internally by a 2s flush timeout.
-    () => flushSentry(),
   ];
 
   // Stop accepting requests BEFORE tearing down workers/Redis/DB. Otherwise a
@@ -1778,27 +1772,53 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     }
   }
 
-  const shutdownResults = await Promise.allSettled(shutdownTasks.map((task) => task()));
-  const shutdownFailures = shutdownResults.filter((result) => result.status === 'rejected');
-
-  if (shutdownFailures.length > 0) {
-    console.error(`[shutdown] Completed with ${shutdownFailures.length} failure(s)`);
-    process.exit(1);
-    return;
+  const report = await runShutdownPhases([
+    // 1. Final local drains that need DB/Redis still up.
+    { name: 'drain', tasks: [boundedAuditDrainTask] },
+    // 2. Every worker/consumer close — concurrent, as today, but now
+    //    guaranteed to fully settle before shared infrastructure goes away.
+    { name: 'workers', tasks: workerShutdownTasks },
+    // 3. Producer queues + dispatchers (they enqueue INTO Redis; workers are gone).
+    {
+      name: 'queues',
+      tasks: [
+        shutdownEventDispatcher,
+        shutdownEventDispatchWorker,
+        shutdownEventDispatchQueue,
+        shutdownAgentCommandRelayWorker,
+      ],
+    },
+    // 4. Event bus releases its borrowed connection reference (no quit — Task 2).
+    { name: 'eventbus', tasks: [async () => getEventBus().close()] },
+    // 5. The ONLY owner of the Redis quits.
+    { name: 'redis', tasks: [closeRedis] },
+    // 6. DB pool.
+    { name: 'db', tasks: [dbCloseTask] },
+    // 7. Sentry flush (bounded internally at 2s).
+    { name: 'sentry', tasks: [() => flushSentry()], timeoutMs: 5_000 },
+  ]);
+  const failed = report.failures.length > 0;
+  if (failed) {
+    console.error(`[shutdown] Completed with ${report.failures.length} failure(s)`);
+  } else {
+    console.log('[shutdown] Complete');
   }
-
-  console.log('[shutdown] Complete');
-  process.exit(0);
+  process.exit(failed ? 1 : 0);
 }
 
 function installSignalHandlers(): void {
-  process.once('SIGINT', () => {
-    void shutdownRuntime('SIGINT');
-  });
-
-  process.once('SIGTERM', () => {
-    void shutdownRuntime('SIGTERM');
-  });
+  const onSignal = (signal: NodeJS.Signals) => {
+    // Second signal while a graceful shutdown is running: operator (or
+    // orchestrator) wants out NOW. Deterministic force-exit beats Node's
+    // default handler ambiguity.
+    process.once(signal, () => {
+      console.error(`[shutdown] Second ${signal} — forcing exit`);
+      process.exit(130);
+    });
+    void shutdownRuntime(signal);
+  };
+  process.once('SIGINT', () => onSignal('SIGINT'));
+  process.once('SIGTERM', () => onSignal('SIGTERM'));
 
   // Guard against unhandled rejections from the Claude Agent SDK's
   // fire-and-forget handleControlRequest. When a session is closed while

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -283,8 +283,8 @@ import { initializeDiscoveryWorker, shutdownDiscoveryWorker } from './jobs/disco
 import { initializeNetworkBaselineWorker, shutdownNetworkBaselineWorker } from './jobs/networkBaselineWorker';
 import { initializeSnmpWorker, shutdownSnmpWorker } from './jobs/snmpWorker';
 import { initializeMonitorWorker, shutdownMonitorWorker } from './jobs/monitorWorker';
-import { initializeUnifiWorker } from './jobs/unifiWorker';
-import { initializeUnifiTelemetryWorker } from './jobs/unifiTelemetryWorker';
+import { initializeUnifiWorker, shutdownUnifiWorker } from './jobs/unifiWorker';
+import { initializeUnifiTelemetryWorker, shutdownUnifiTelemetryWorker } from './jobs/unifiTelemetryWorker';
 import { initializeSnmpRetention, shutdownSnmpRetention } from './jobs/snmpRetention';
 import { initializeReliabilityRetention, shutdownReliabilityRetention } from './jobs/reliabilityRetention';
 import { initializeProcessSampleRetention, shutdownProcessSampleRetention } from './jobs/processSampleRetention';
@@ -356,7 +356,7 @@ import { initializeSuppressionExpiryReaper, shutdownSuppressionExpiryReaper } fr
 import { initializeTicketNotifyWorker, shutdownTicketNotifyWorker } from './jobs/ticketNotifyWorker';
 import { initializeTicketSlaWorker, shutdownTicketSlaWorker } from './jobs/ticketSlaWorker';
 import { initializeInboundEmailWorker, shutdownInboundEmailWorker } from './jobs/inboundEmailWorker';
-import { initializeTicketMailboxPollWorker } from './jobs/ticketMailboxPollWorker';
+import { initializeTicketMailboxPollWorker, shutdownTicketMailboxPollWorker } from './jobs/ticketMailboxPollWorker';
 import { getWebhookWorker, initializeWebhookDelivery, type WebhookFanoutDeps } from './workers/webhookDelivery';
 import { registerAllEventSubscribers } from './services/eventSubscribers';
 import { toWebhookConfig } from './services/webhookConfig';
@@ -1665,6 +1665,8 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownBackupVerificationJobs,
     shutdownSnmpRetention,
     shutdownMonitorWorker,
+    shutdownUnifiWorker,
+    shutdownUnifiTelemetryWorker,
     shutdownSnmpWorker,
     shutdownNetworkBaselineWorker,
     shutdownDiscoveryWorker,
@@ -1732,6 +1734,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownTicketNotifyWorker,
     shutdownTicketSlaWorker,
     shutdownInboundEmailWorker,
+    shutdownTicketMailboxPollWorker,
     shutdownInvoiceWorkers,
     shutdownContractWorkers,
     shutdownEventDispatcher,

--- a/apps/api/src/jobs/ticketMailboxPollWorker.test.ts
+++ b/apps/api/src/jobs/ticketMailboxPollWorker.test.ts
@@ -9,6 +9,33 @@ vi.mock('../db', () => ({
   withSystemDbAccessContext: (fn: () => any) => fn(),
 }));
 
+const { workerCloseMock, workerConstructorMock, queueConstructorMock, queueAddMock, queueCloseMock } = vi.hoisted(() => ({
+  workerCloseMock: vi.fn(),
+  workerConstructorMock: vi.fn(),
+  queueConstructorMock: vi.fn(),
+  queueAddMock: vi.fn(),
+  queueCloseMock: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Worker: class {
+    close = workerCloseMock;
+    on = vi.fn();
+    constructor(...args: unknown[]) {
+      workerConstructorMock(...args);
+    }
+  },
+  Queue: class {
+    add = queueAddMock;
+    close = queueCloseMock;
+    constructor(...args: unknown[]) {
+      queueConstructorMock(...args);
+    }
+  },
+}));
+
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
+
 vi.mock('../services/ticketMailbox/connectionService', () => ({
   isConnectedMailboxSnapshotCurrent: vi.fn(async () => true),
   listConnectedMailboxes: vi.fn(),
@@ -40,7 +67,11 @@ import {
 import { getMailboxToken } from '../services/ticketMailbox/mailboxToken';
 import { listInboxDelta, markRead } from '../services/ticketMailbox/graphMailClient';
 import { enqueueInboundEmail } from '../services/inboundEmailQueue';
-import { runMailboxSweep } from './ticketMailboxPollWorker';
+import {
+  runMailboxSweep,
+  initializeTicketMailboxPollWorker,
+  shutdownTicketMailboxPollWorker,
+} from './ticketMailboxPollWorker';
 
 const conn = (over: Partial<any> = {}) => ({
   id: 'c1', partnerId: 'p1', tenantId: '11111111-1111-1111-1111-111111111111',
@@ -174,5 +205,34 @@ describe('runMailboxSweep', () => {
     expect(markRead).not.toHaveBeenCalled();
     expect(enqueueInboundEmail).toHaveBeenCalledTimes(1);
     expect(updateDeltaCursor).not.toHaveBeenCalled();
+  });
+});
+
+describe('shutdownTicketMailboxPollWorker', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('closes the worker and queue exactly once after initialize', async () => {
+    await initializeTicketMailboxPollWorker();
+
+    await shutdownTicketMailboxPollWorker();
+
+    expect(workerCloseMock).toHaveBeenCalledTimes(1);
+    expect(queueCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a second shutdown call is a no-op (handles already nulled)', async () => {
+    await initializeTicketMailboxPollWorker();
+
+    await shutdownTicketMailboxPollWorker();
+    await shutdownTicketMailboxPollWorker();
+
+    expect(workerCloseMock).toHaveBeenCalledTimes(1);
+    expect(queueCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves without throwing when called before initialize', async () => {
+    await expect(shutdownTicketMailboxPollWorker()).resolves.toBeUndefined();
+    expect(workerCloseMock).not.toHaveBeenCalled();
+    expect(queueCloseMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/jobs/ticketMailboxPollWorker.ts
+++ b/apps/api/src/jobs/ticketMailboxPollWorker.ts
@@ -126,3 +126,14 @@ export async function initializeTicketMailboxPollWorker(): Promise<void> {
   });
   console.log('[mailboxPoll] worker initialized');
 }
+
+export async function shutdownTicketMailboxPollWorker(): Promise<void> {
+  if (worker) {
+    await worker.close();
+    worker = null;
+  }
+  if (queue) {
+    await queue.close();
+    queue = null;
+  }
+}

--- a/apps/api/src/jobs/unifiTelemetryWorker.test.ts
+++ b/apps/api/src/jobs/unifiTelemetryWorker.test.ts
@@ -1,19 +1,40 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { workerCloseMock, workerConstructorMock, queueCloseMock, createInstrumentedQueueMock } = vi.hoisted(() => ({
+  workerCloseMock: vi.fn(),
+  workerConstructorMock: vi.fn(),
+  queueCloseMock: vi.fn(),
+  createInstrumentedQueueMock: vi.fn(() => ({ close: queueCloseMock })),
+}));
+
 vi.mock('../db', () => ({
   db: {},
   withSystemDbAccessContext: vi.fn((fn: () => unknown) => fn()),
   runOutsideDbContext: (fn: () => unknown) => fn(),
 }));
-vi.mock('../services/bullmqQueue', () => ({ createInstrumentedQueue: vi.fn() }));
+vi.mock('../services/bullmqQueue', () => ({ createInstrumentedQueue: createInstrumentedQueueMock }));
 vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn() }));
+vi.mock('bullmq', () => ({
+  Worker: class {
+    close = workerCloseMock;
+    on = vi.fn();
+    constructor(...args: unknown[]) {
+      workerConstructorMock(...args);
+    }
+  },
+}));
 vi.mock('../services/unifi/unifiTelemetryService', () => ({ reconcileTelemetry: vi.fn(async () => ({})) }));
 vi.mock('../services/unifi/unifiCollectorService', () => ({
   getCollectorOwnerDeviceId: vi.fn(),
   markCollectorPoll: vi.fn(async () => undefined),
 }));
 
-import { processIngest } from './unifiTelemetryWorker';
+import {
+  processIngest,
+  getUnifiTelemetryQueue,
+  initializeUnifiTelemetryWorker,
+  shutdownUnifiTelemetryWorker,
+} from './unifiTelemetryWorker';
 import * as telemetrySvc from '../services/unifi/unifiTelemetryService';
 import * as collectorSvc from '../services/unifi/unifiCollectorService';
 import * as dbModule from '../db';
@@ -94,5 +115,48 @@ describe('processIngest reconcile-failure status (rollback-safe)', () => {
     (telemetrySvc.reconcileTelemetry as any).mockRejectedValueOnce(new Error('should not run'));
     await processIngest({ ...basePayload, deviceId: 'dev-attacker' });
     expect(collectorSvc.markCollectorPoll).not.toHaveBeenCalled();
+  });
+});
+
+describe('shutdownUnifiTelemetryWorker', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('closes the worker and the lazily-created queue exactly once after initialize', async () => {
+    await initializeUnifiTelemetryWorker();
+    // The worker only initializes its own Worker handle — the queue is
+    // created lazily via getUnifiTelemetryQueue() (enqueue path). Peek it
+    // here so shutdown has something to close.
+    getUnifiTelemetryQueue();
+
+    await shutdownUnifiTelemetryWorker();
+
+    expect(workerCloseMock).toHaveBeenCalledTimes(1);
+    expect(queueCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a second shutdown call is a no-op (handles already nulled)', async () => {
+    await initializeUnifiTelemetryWorker();
+    getUnifiTelemetryQueue();
+
+    await shutdownUnifiTelemetryWorker();
+    await shutdownUnifiTelemetryWorker();
+
+    expect(workerCloseMock).toHaveBeenCalledTimes(1);
+    expect(queueCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves without throwing when called before initialize or queue creation', async () => {
+    await expect(shutdownUnifiTelemetryWorker()).resolves.toBeUndefined();
+    expect(workerCloseMock).not.toHaveBeenCalled();
+    expect(queueCloseMock).not.toHaveBeenCalled();
+  });
+
+  it('closes the queue when it was created lazily via getUnifiTelemetryQueue() without ever initializing the worker', async () => {
+    getUnifiTelemetryQueue();
+
+    await shutdownUnifiTelemetryWorker();
+
+    expect(workerCloseMock).not.toHaveBeenCalled();
+    expect(queueCloseMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/jobs/unifiTelemetryWorker.ts
+++ b/apps/api/src/jobs/unifiTelemetryWorker.ts
@@ -88,3 +88,14 @@ export async function initializeUnifiTelemetryWorker(): Promise<void> {
   workerInstance.on('failed', (job, e) => console.error(`[UnifiTelemetryWorker] job ${job?.id} failed:`, e));
   console.log('[UnifiTelemetryWorker] initialized');
 }
+
+export async function shutdownUnifiTelemetryWorker(): Promise<void> {
+  if (workerInstance) {
+    await workerInstance.close();
+    workerInstance = null;
+  }
+  if (queue) {
+    await queue.close();
+    queue = null;
+  }
+}

--- a/apps/api/src/jobs/unifiWorker.test.ts
+++ b/apps/api/src/jobs/unifiWorker.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { workerCloseMock, workerConstructorMock, queueCloseMock, queueConstructorMock } = vi.hoisted(() => ({
+  workerCloseMock: vi.fn(),
+  workerConstructorMock: vi.fn(),
+  queueCloseMock: vi.fn(),
+  queueConstructorMock: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Worker: class {
+    close = workerCloseMock;
+    on = vi.fn();
+    constructor(...args: unknown[]) {
+      workerConstructorMock(...args);
+    }
+  },
+}));
+
+vi.mock('../services/bullmqQueue', () => ({
+  createInstrumentedQueue: vi.fn(() => {
+    queueConstructorMock();
+    return {
+      close: queueCloseMock,
+      getRepeatableJobs: vi.fn(async () => []),
+      removeRepeatableByKey: vi.fn(async () => {}),
+      add: vi.fn(async () => {}),
+    };
+  }),
+}));
+
+vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
+vi.mock('../db', () => ({
+  db: {},
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+vi.mock('../db/schema', () => ({ unifiIntegrations: {}, unifiSiteMappings: {} }));
+vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
+vi.mock('../services/unifi/unifiClient', () => ({ createUnifiClient: vi.fn() }));
+vi.mock('../services/unifi/unifiConnectionService', () => ({
+  getSyncCredentials: vi.fn(),
+  markStatus: vi.fn(),
+  markSynced: vi.fn(),
+}));
+vi.mock('../services/unifi/unifiSyncService', () => ({
+  collectSyncData: vi.fn(),
+  applySyncData: vi.fn(),
+}));
+
+import {
+  getUnifiSyncQueue,
+  initializeUnifiWorker,
+  shutdownUnifiWorker,
+} from './unifiWorker';
+
+describe('shutdownUnifiWorker', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('closes the worker and the lazily-created sync queue exactly once after initialize', async () => {
+    await initializeUnifiWorker();
+
+    await shutdownUnifiWorker();
+
+    expect(workerCloseMock).toHaveBeenCalledTimes(1);
+    expect(queueCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a second shutdown call is a no-op (handles already nulled)', async () => {
+    await initializeUnifiWorker();
+
+    await shutdownUnifiWorker();
+    await shutdownUnifiWorker();
+
+    expect(workerCloseMock).toHaveBeenCalledTimes(1);
+    expect(queueCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves without throwing when called before initialize or queue creation', async () => {
+    await expect(shutdownUnifiWorker()).resolves.toBeUndefined();
+    expect(workerCloseMock).not.toHaveBeenCalled();
+    expect(queueCloseMock).not.toHaveBeenCalled();
+  });
+
+  it('closes the sync queue when it was created lazily via getUnifiSyncQueue() without ever initializing the worker', async () => {
+    getUnifiSyncQueue();
+
+    await shutdownUnifiWorker();
+
+    expect(workerCloseMock).not.toHaveBeenCalled();
+    expect(queueCloseMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/jobs/unifiWorker.ts
+++ b/apps/api/src/jobs/unifiWorker.ts
@@ -205,3 +205,14 @@ export async function initializeUnifiWorker(): Promise<void> {
   await scheduleUnifiSync();
   console.log('[UnifiWorker] UniFi sync worker initialized');
 }
+
+export async function shutdownUnifiWorker(): Promise<void> {
+  if (unifiWorker) {
+    await unifiWorker.close();
+    unifiWorker = null;
+  }
+  if (unifiSyncQueue) {
+    await unifiSyncQueue.close();
+    unifiSyncQueue = null;
+  }
+}

--- a/apps/api/src/services/eventBus.test.ts
+++ b/apps/api/src/services/eventBus.test.ts
@@ -48,7 +48,9 @@ describe('eventBus service', () => {
       xadd: vi.fn().mockResolvedValue('0-0'),
       publish: vi.fn().mockResolvedValue(1),
       xack: vi.fn().mockResolvedValue(1),
-      lpush: vi.fn().mockResolvedValue(1)
+      lpush: vi.fn().mockResolvedValue(1),
+      quit: vi.fn().mockResolvedValue('OK'),
+      status: 'ready'
     };
 
     eventBusModule = await import('./eventBus');
@@ -606,5 +608,36 @@ describe('eventBus service', () => {
     ).resolves.toEqual(expect.any(String));
 
     vi.restoreAllMocks();
+  });
+
+  describe('EventBus.close() — must not quit the shared connection (#4086)', () => {
+    it('does not call .quit() on the borrowed getRedisConnection() singleton', async () => {
+      const { getEventBus, EVENT_TYPES } = eventBusModule;
+      const bus = getEventBus();
+
+      // Drive getOrCreateRedis() so the bus holds a reference to the shared
+      // connection before closing it.
+      await bus.publish(EVENT_TYPES.DEVICE_ENROLLED, 'org-1', { deviceId: 'dev-1' }, 'unit-test');
+      expect(mockRedis.publish as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+
+      await bus.close();
+
+      // closeRedis() is the sole owner of the shared connection's .quit() —
+      // EventBus.close() only releases its own reference.
+      expect(mockRedis.quit).not.toHaveBeenCalled();
+    });
+
+    it('re-acquires the connection via getRedisConnection() on the next publish after close()', async () => {
+      const { getEventBus, EVENT_TYPES } = eventBusModule;
+      const bus = getEventBus();
+
+      await bus.publish(EVENT_TYPES.DEVICE_ENROLLED, 'org-1', { deviceId: 'dev-1' }, 'unit-test');
+      const callsBeforeClose = (getRedisConnection as ReturnType<typeof vi.fn>).mock.calls.length;
+
+      await bus.close();
+      await bus.publish(EVENT_TYPES.DEVICE_ENROLLED, 'org-1', { deviceId: 'dev-2' }, 'unit-test');
+
+      expect((getRedisConnection as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(callsBeforeClose);
+    });
   });
 });

--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -204,13 +204,16 @@ class EventBus {
   }
 
   /**
-   * Close the persistent Redis connection and clean up resources.
+   * Release this bus's reference to the shared Redis connection.
+   *
+   * Deliberately does NOT call `.quit()`: `getOrCreateRedis()` borrows the
+   * module-singleton BullMQ connection (`getRedisConnection()`), which every
+   * BullMQ Worker/Queue in the process shares. Quitting it here tore the
+   * connection out from under consumers still draining in the same shutdown
+   * pass — `closeRedis()` is the sole owner of that quit (wave 3.5d-a, #4086).
    */
   async close(): Promise<void> {
-    if (this.redisClient) {
-      await this.redisClient.quit();
-      this.redisClient = null;
-    }
+    this.redisClient = null;
   }
 
   /**

--- a/apps/api/src/services/shutdownPhases.test.ts
+++ b/apps/api/src/services/shutdownPhases.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runShutdownPhases, type ShutdownPhase } from './shutdownPhases';
+
+describe('runShutdownPhases', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('runs phases strictly sequentially — no phase B task starts before every phase A task settles', async () => {
+    const log: string[] = [];
+
+    let resolveA0: () => void = () => {};
+    const phases: ShutdownPhase[] = [
+      {
+        name: 'A',
+        tasks: [
+          () =>
+            new Promise<void>((resolve) => {
+              log.push('A0-start');
+              resolveA0 = () => {
+                log.push('A0-end');
+                resolve();
+              };
+            }),
+          async () => {
+            log.push('A1-start');
+            log.push('A1-end');
+          },
+        ],
+      },
+      {
+        name: 'B',
+        tasks: [
+          async () => {
+            log.push('B0-start');
+            log.push('B0-end');
+          },
+        ],
+      },
+    ];
+
+    const promise = runShutdownPhases(phases);
+    // Let the microtask queue drain so A1 (sync-ish) settles but A0 is still
+    // pending on its manual resolve.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(log).toEqual(['A0-start', 'A1-start', 'A1-end']);
+    expect(log).not.toContain('B0-start');
+
+    resolveA0();
+    await promise;
+
+    expect(log).toEqual(['A0-start', 'A1-start', 'A1-end', 'A0-end', 'B0-start', 'B0-end']);
+  });
+
+  it('runs tasks within a phase concurrently — both start before either resolves', async () => {
+    const log: string[] = [];
+    let resolve0: () => void = () => {};
+    let resolve1: () => void = () => {};
+
+    const phases: ShutdownPhase[] = [
+      {
+        name: 'A',
+        tasks: [
+          () =>
+            new Promise<void>((resolve) => {
+              log.push('task0-start');
+              resolve0 = () => {
+                log.push('task0-end');
+                resolve();
+              };
+            }),
+          () =>
+            new Promise<void>((resolve) => {
+              log.push('task1-start');
+              resolve1 = () => {
+                log.push('task1-end');
+                resolve();
+              };
+            }),
+        ],
+      },
+    ];
+
+    const promise = runShutdownPhases(phases);
+    await vi.advanceTimersByTimeAsync(0);
+    // Both tasks must have started before either resolved.
+    expect(log).toEqual(['task0-start', 'task1-start']);
+
+    resolve0();
+    resolve1();
+    await promise;
+
+    expect(log).toContain('task0-end');
+    expect(log).toContain('task1-end');
+  });
+
+  it('isolates a rejected task — records the failure, phase B still runs', async () => {
+    const log: string[] = [];
+    const phases: ShutdownPhase[] = [
+      {
+        name: 'A',
+        tasks: [
+          async () => {
+            throw new Error('task0 boom');
+          },
+          async () => {
+            log.push('task1-ran');
+          },
+        ],
+      },
+      {
+        name: 'B',
+        tasks: [
+          async () => {
+            log.push('B-ran');
+          },
+        ],
+      },
+    ];
+
+    const report = await runShutdownPhases(phases);
+
+    expect(report.failures).toHaveLength(1);
+    expect(report.failures[0]!.phase).toBe('A');
+    expect(report.failures[0]!.index).toBe(0);
+    expect(report.failures[0]!.error).toBeInstanceOf(Error);
+    expect((report.failures[0]!.error as Error).message).toBe('task0 boom');
+    expect(log).toEqual(['task1-ran', 'B-ran']);
+  });
+
+  it('continues to the next phase on timeout, records timedOutPhases, and never produces an unhandled rejection from the straggler', async () => {
+    let rejectStraggler: (err: unknown) => void = () => {};
+    const phases: ShutdownPhase[] = [
+      {
+        name: 'A',
+        timeoutMs: 50,
+        tasks: [
+          () =>
+            new Promise<void>((_resolve, reject) => {
+              rejectStraggler = reject;
+            }),
+        ],
+      },
+      {
+        name: 'B',
+        tasks: [async () => {}],
+      },
+    ];
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (err: unknown) => unhandled.push(err);
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      const promise = runShutdownPhases(phases);
+      await vi.advanceTimersByTimeAsync(50);
+      const report = await promise;
+
+      expect(report.timedOutPhases).toEqual(['A']);
+
+      // Now let the straggler reject — after the phase (and the whole run)
+      // has already moved on. It must be handled, not unhandled.
+      rejectStraggler(new Error('straggler boom'));
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('captures a synchronous throw the same as a rejection', async () => {
+    const phases: ShutdownPhase[] = [
+      {
+        name: 'A',
+        tasks: [
+          () => {
+            throw new Error('sync boom');
+          },
+        ],
+      },
+    ];
+
+    const report = await runShutdownPhases(phases);
+
+    expect(report.failures).toHaveLength(1);
+    expect(report.failures[0]!.phase).toBe('A');
+    expect(report.failures[0]!.index).toBe(0);
+    expect((report.failures[0]!.error as Error).message).toBe('sync boom');
+  });
+
+  it('skips empty phases silently', async () => {
+    const log: string[] = [];
+    const phases: ShutdownPhase[] = [
+      { name: 'empty', tasks: [] },
+      {
+        name: 'nonempty-phase',
+        tasks: [
+          async () => {
+            log.push('ran');
+          },
+        ],
+      },
+    ];
+
+    const logFn = vi.fn();
+    const report = await runShutdownPhases(phases, { log: logFn });
+
+    expect(log).toEqual(['ran']);
+    expect(report.failures).toEqual([]);
+    expect(report.timedOutPhases).toEqual([]);
+    // The empty phase must never be logged as running.
+    expect(logFn.mock.calls.some((call) => String(call[0]).includes('phase empty'))).toBe(false);
+  });
+});

--- a/apps/api/src/services/shutdownPhases.test.ts
+++ b/apps/api/src/services/shutdownPhases.test.ts
@@ -132,8 +132,9 @@ describe('runShutdownPhases', () => {
     expect(log).toEqual(['task1-ran', 'B-ran']);
   });
 
-  it('continues to the next phase on timeout, records timedOutPhases, and never produces an unhandled rejection from the straggler', async () => {
+  it('continues to the next phase on timeout, records timedOutPhases, actually runs phase B, and never produces an unhandled rejection from the straggler', async () => {
     let rejectStraggler: (err: unknown) => void = () => {};
+    const log: string[] = [];
     const phases: ShutdownPhase[] = [
       {
         name: 'A',
@@ -147,7 +148,11 @@ describe('runShutdownPhases', () => {
       },
       {
         name: 'B',
-        tasks: [async () => {}],
+        tasks: [
+          async () => {
+            log.push('B-ran');
+          },
+        ],
       },
     ];
 
@@ -161,6 +166,11 @@ describe('runShutdownPhases', () => {
       const report = await promise;
 
       expect(report.timedOutPhases).toEqual(['A']);
+      // The headline safety property: a stuck phase A task must not prevent
+      // phase B from actually running.
+      expect(log).toEqual(['B-ran']);
+      // A timed-out phase must not itself be recorded as a failure.
+      expect(report.failures).toEqual([]);
 
       // Now let the straggler reject — after the phase (and the whole run)
       // has already moved on. It must be handled, not unhandled.

--- a/apps/api/src/services/shutdownPhases.ts
+++ b/apps/api/src/services/shutdownPhases.ts
@@ -43,6 +43,7 @@ export async function runShutdownPhases(
       results.forEach((result, index) => {
         if (result.status === 'rejected') {
           report.failures.push({ phase: phase.name, index, error: result.reason });
+          log(`[shutdown] phase ${phase.name} task ${index} failed: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`);
         }
       });
     });

--- a/apps/api/src/services/shutdownPhases.ts
+++ b/apps/api/src/services/shutdownPhases.ts
@@ -1,0 +1,65 @@
+/**
+ * Sequential, bounded-timeout shutdown phase runner.
+ *
+ * Phases run strictly one after another; within a phase, all tasks start
+ * together and are awaited via `Promise.allSettled`, raced against a
+ * per-phase timeout. A stuck task in one phase must never prevent later
+ * phases (in particular Redis/DB close) from running — so a timeout logs,
+ * records the phase as timed out, and moves on. The straggler keeps running
+ * detached; its eventual settlement is still captured (never left as an
+ * unhandled rejection), it's just recorded after the fact.
+ *
+ * wave 3.5d-a (#4086).
+ */
+
+export interface ShutdownPhase {
+  name: string;
+  tasks: Array<() => Promise<void> | void>;
+  timeoutMs?: number;
+}
+
+export interface ShutdownReport {
+  failures: Array<{ phase: string; index: number; error: unknown }>;
+  timedOutPhases: string[];
+}
+
+export async function runShutdownPhases(
+  phases: ShutdownPhase[],
+  opts: { defaultTimeoutMs?: number; log?: (msg: string) => void } = {},
+): Promise<ShutdownReport> {
+  const log = opts.log ?? ((msg: string) => console.log(msg));
+  const defaultTimeoutMs = opts.defaultTimeoutMs ?? 20_000;
+  const report: ShutdownReport = { failures: [], timedOutPhases: [] };
+
+  for (const phase of phases) {
+    if (phase.tasks.length === 0) continue;
+    log(`[shutdown] phase ${phase.name} (${phase.tasks.length} task(s))`);
+    // Start all tasks and attach the settlement handler FIRST, so a straggler
+    // that rejects after a phase timeout is already handled (no unhandled
+    // rejection from a detached phase).
+    const settled = Promise.allSettled(
+      phase.tasks.map(async (task) => task()),
+    ).then((results) => {
+      results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          report.failures.push({ phase: phase.name, index, error: result.reason });
+        }
+      });
+    });
+    const timeoutMs = phase.timeoutMs ?? defaultTimeoutMs;
+    let timer: NodeJS.Timeout | undefined;
+    const timedOut = await Promise.race([
+      settled.then(() => false),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(true), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+    if (timedOut) {
+      report.timedOutPhases.push(phase.name);
+      log(`[shutdown] phase ${phase.name} timed out after ${timeoutMs}ms — continuing`);
+    }
+  }
+  return report;
+}

--- a/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave3.5d-a-ordered-shutdown.md
+++ b/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave3.5d-a-ordered-shutdown.md
@@ -47,9 +47,9 @@ wave: W10 (#4086) — Part A (prerequisite PR)
 **Interfaces:**
 - Produces: `shutdownTicketMailboxPollWorker(): Promise<void>`, `shutdownUnifiWorker(): Promise<void>`, `shutdownUnifiTelemetryWorker(): Promise<void>`.
 
-- [ ] **Step 1: Write the failing tests** — for each module, mock `bullmq` (Worker/Queue classes with `close: vi.fn()`) and `../services/redis`; assert: after `initialize*()` then `shutdown*()`, every created Worker/Queue handle got exactly one `close()` call; a second `shutdown*()` call is a no-op (handles nulled); `shutdown*()` before `initialize*()` resolves without throwing. For `unifiWorker`, the queue is created lazily via `getUnifiSyncQueue()` — shutdown must close it only if it was created (peek the module's lazy handle by calling the getter in the test's arrange step for the created-case).
-- [ ] **Step 2: Run to verify failure** (functions don't exist).
-- [ ] **Step 3: Implement** — mirror `shutdownEventDispatchWorker` exactly:
+- [x] **Step 1: Write the failing tests** — for each module, mock `bullmq` (Worker/Queue classes with `close: vi.fn()`) and `../services/redis`; assert: after `initialize*()` then `shutdown*()`, every created Worker/Queue handle got exactly one `close()` call; a second `shutdown*()` call is a no-op (handles nulled); `shutdown*()` before `initialize*()` resolves without throwing. For `unifiWorker`, the queue is created lazily via `getUnifiSyncQueue()` — shutdown must close it only if it was created (peek the module's lazy handle by calling the getter in the test's arrange step for the created-case).
+- [x] **Step 2: Run to verify failure** (functions don't exist).
+- [x] **Step 3: Implement** — mirror `shutdownEventDispatchWorker` exactly:
 
 ```ts
 // ticketMailboxPollWorker.ts
@@ -67,7 +67,7 @@ export async function shutdownTicketMailboxPollWorker(): Promise<void> {
 
 `unifiWorker.ts`: close `unifiWorker` (null-check/null-out) and the lazy sync queue — add a module-level `let syncQueue` capture inside `getUnifiSyncQueue()` if the current implementation constructs it inline, so shutdown can reach it. `unifiTelemetryWorker.ts`: close `workerInstance` and the lazy telemetry queue the same way.
 
-- [ ] **Step 4: Wire into `index.ts` shutdownTasks** (three bare function refs, placed with their subsystems), run the three test files → PASS, typecheck. Commit: `fix(api): shutdown exports for ticket-mailbox, unifi, unifi-telemetry workers (#4086)`
+- [x] **Step 4: Wire into `index.ts` shutdownTasks** (three bare function refs, placed with their subsystems), run the three test files → PASS, typecheck. Commit: `fix(api): shutdown exports for ticket-mailbox, unifi, unifi-telemetry workers (#4086)`
 
 ---
 
@@ -77,9 +77,9 @@ export async function shutdownTicketMailboxPollWorker(): Promise<void> {
 - Modify: `apps/api/src/services/eventBus.ts:209-214`
 - Test: extend the eventBus test file (find: `ls apps/api/src/services/eventBus*.test.ts`)
 
-- [ ] **Step 1: Write the failing test** — mock `./redis`'s `getRedisConnection` to return a spy client `{ quit: vi.fn(), status: 'ready', xadd: vi.fn(), publish: vi.fn() }`; drive the bus so `getOrCreateRedis()` runs (publish an event or call close after a publish); assert `close()` does NOT call `quit()` on it, and that after `close()` a subsequent publish re-acquires via `getRedisConnection()` (the nulled reference is re-fetched — `getOrCreateRedis()` at eventBus.ts:198-203 already handles this).
-- [ ] **Step 2: Run to verify failure** (current code quits).
-- [ ] **Step 3: Implement**:
+- [x] **Step 1: Write the failing test** — mock `./redis`'s `getRedisConnection` to return a spy client `{ quit: vi.fn(), status: 'ready', xadd: vi.fn(), publish: vi.fn() }`; drive the bus so `getOrCreateRedis()` runs (publish an event or call close after a publish); assert `close()` does NOT call `quit()` on it, and that after `close()` a subsequent publish re-acquires via `getRedisConnection()` (the nulled reference is re-fetched — `getOrCreateRedis()` at eventBus.ts:198-203 already handles this).
+- [x] **Step 2: Run to verify failure** (current code quits).
+- [x] **Step 3: Implement**:
 
 ```ts
   /**
@@ -96,7 +96,7 @@ export async function shutdownTicketMailboxPollWorker(): Promise<void> {
   }
 ```
 
-- [ ] **Step 4: Run the eventBus tests + typecheck** → PASS. Commit: `fix(api): EventBus.close() no longer quits the shared BullMQ connection (#4086)`
+- [x] **Step 4: Run the eventBus tests + typecheck** → PASS. Commit: `fix(api): EventBus.close() no longer quits the shared BullMQ connection (#4086)`
 
 ---
 
@@ -113,15 +113,15 @@ export async function shutdownTicketMailboxPollWorker(): Promise<void> {
 
 **Semantics (the tests pin all of these):** phases run strictly sequentially; a phase's tasks all start together and the phase waits for `Promise.allSettled` of them, raced against its timeout (default `defaultTimeoutMs`, default 20_000); on timeout the runner logs, records the phase in `timedOutPhases`, and PROCEEDS to the next phase (a stuck worker must never prevent Redis/DB close — but note the straggler keeps running detached; its eventual rejection is captured, never unhandled); task rejections are recorded per task with phase + index and never abort anything; a task that throws synchronously is captured identically; empty phases are skipped silently.
 
-- [ ] **Step 1: Write the failing tests** — use fake timers where the timeout cases need them:
+- [x] **Step 1: Write the failing tests** — use fake timers where the timeout cases need them:
   1. Order: tasks push to a log; phase B's tasks never start before every phase-A task settled.
   2. Concurrency within a phase: two tasks in one phase both start before either resolves (start-log asserted before resolution).
   3. Failure isolation: task 0 rejects, task 1 resolves — report lists one failure `{phase, index: 0}`, phase B still runs.
   4. Timeout: a never-resolving task in phase A (timeoutMs 50) — phase B runs, `timedOutPhases: ['A']`; when the straggler later rejects, no unhandled rejection (attach the allSettled handler before racing).
   5. Sync throw captured.
   6. Empty phase skipped.
-- [ ] **Step 2: Run to verify failure.**
-- [ ] **Step 3: Implement** (~50 lines):
+- [x] **Step 2: Run to verify failure.**
+- [x] **Step 3: Implement** (~50 lines):
 
 ```ts
 export async function runShutdownPhases(
@@ -166,7 +166,7 @@ export async function runShutdownPhases(
 }
 ```
 
-- [ ] **Step 4: Run tests + typecheck** → PASS. Commit: `feat(api): sequential shutdown phase runner (#4086)`
+- [x] **Step 4: Run tests + typecheck** → PASS. Commit: `feat(api): sequential shutdown phase runner (#4086)`
 
 ---
 
@@ -178,7 +178,7 @@ export async function runShutdownPhases(
 **Interfaces:**
 - Consumes: `runShutdownPhases` (Task 3), the three Task 1 exports.
 
-- [ ] **Step 1: Partition the existing shutdownTasks array into phases**, preserving every entry and every comment, in the array's existing relative order. The preamble (webhook worker stop, monitors, audit interval clear) and the HTTP-close block (:1755-1777) stay exactly where they are, BEFORE the phases. Phase membership:
+- [x] **Step 1: Partition the existing shutdownTasks array into phases**, preserving every entry and every comment, in the array's existing relative order. The preamble (webhook worker stop, monitors, audit interval clear) and the HTTP-close block (:1755-1777) stay exactly where they are, BEFORE the phases. Phase membership:
 
 ```ts
   const report = await runShutdownPhases([
@@ -209,7 +209,7 @@ export async function runShutdownPhases(
 
 Note: `shutdownEventDispatchWorker` currently sits with the queue/dispatcher cluster in the existing array tail (:1743-1747) — keep the cluster together in `queues`. Timed-out phases alone do NOT flip the exit code (their real failures, if any, land in `failures` when the straggler settles — usually after exit; acceptable, matches today's "failures we saw" semantics).
 
-- [ ] **Step 2: Second-signal force-exit** in `installSignalHandlers`:
+- [x] **Step 2: Second-signal force-exit** in `installSignalHandlers`:
 
 ```ts
 function installSignalHandlers(): void {
@@ -228,15 +228,15 @@ function installSignalHandlers(): void {
 }
 ```
 
-- [ ] **Step 3: Typecheck + run the full unit suite** (`cd apps/api && npx vitest run`) — the suite must be as green as on the base commit (report exact totals). Manual smoke: `grep -c 'shutdown' src/index.ts` sanity, and verify no shutdownTasks entry was dropped — `git diff` must show every removed array entry reappearing in exactly one phase (reviewer will diff-count them: state the count in the commit body).
-- [ ] **Step 4: Commit** — `refactor(api): shutdown runs in ordered phases; second signal force-exits (#4086)` with the entry count in the body.
+- [x] **Step 3: Typecheck + run the full unit suite** (`cd apps/api && npx vitest run`) — the suite must be as green as on the base commit (report exact totals). Manual smoke: `grep -c 'shutdown' src/index.ts` sanity, and verify no shutdownTasks entry was dropped — `git diff` must show every removed array entry reappearing in exactly one phase (reviewer will diff-count them: state the count in the commit body).
+- [x] **Step 4: Commit** — `refactor(api): shutdown runs in ordered phases; second signal force-exits (#4086)` with the entry count in the body.
 
 ---
 
 ### Task 5: Verification + PR
 
-- [ ] Full unit suite + typecheck (heap bump if tsc OOMs: `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit`).
-- [ ] Tick this plan's checkboxes, commit.
+- [x] Full unit suite + typecheck (heap bump if tsc OOMs: `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit`).
+- [x] Tick this plan's checkboxes, commit.
 - [ ] Open PR: branch `feature/3821-ai-agents/wave-4086-shutdown` → `main`. Body: "Part A (prerequisite) of #4086 — do NOT close the issue" (no `Closes`), the two verified defects (concurrent allSettled ordering illusion; EventBus quitting the shared connection), phase semantics (sequential, bounded, continue-past-timeout), and the exit-code contract. **Stop after opening the PR.**
 
 ## Self-Review Notes

--- a/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave3.5d-a-ordered-shutdown.md
+++ b/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave3.5d-a-ordered-shutdown.md
@@ -1,0 +1,246 @@
+---
+tracking_issue: LanternOps/breeze#3821
+wave: W10 (#4086) — Part A (prerequisite PR)
+---
+
+# Wave 3.5d Part A — Ordered Shutdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make graceful shutdown actually ordered — sequential phases with bounded time, concurrency only WITHIN a phase — and stop `EventBus.close()` from quitting the shared Redis singleton mid-drain. Prerequisite PR for the BREEZE_ROLE split (#4086): the worker container makes clean SIGTERM handling load-bearing (every deploy restarts it).
+
+**Architecture:** Extract a small, unit-testable phase runner (`runShutdownPhases`) that executes named phases sequentially, runs each phase's tasks via `Promise.allSettled` with a per-phase bounded timeout, and reports failures without aborting later phases (Redis/DB must still close after a stuck worker). `index.ts` partitions its existing ~95 `shutdownTasks` function refs into phases matching the array's already-written comment ordering. `EventBus.close()` stops calling `.quit()` on the borrowed `getRedisConnection()` singleton — `closeRedis()` is the sole owner of that quit. The three workers that leak BullMQ handles on shutdown (ticketMailboxPoll, unifi, unifiTelemetry) gain standard `shutdown*` exports. A second signal after shutdown has begun force-exits deterministically instead of falling to Node's default kill.
+
+**Tech Stack:** TypeScript, Vitest (unit only — no integration/migration surface). **No migrations, no env vars, no compose changes.**
+
+**Design authority:** #4086 + advisor quorum 2026-08-27 (both advisors: ship this as its own PR before the split). Verified defects this fixes: `Promise.allSettled(shutdownTasks.map(t => t()))` at `index.ts:1778` runs ALL tasks concurrently — the array's careful ordering is an illusion; `EventBus.close()` (`eventBus.ts:209-214`) quits the shared module-singleton BullMQ connection (`getRedisConnection()`) that every Worker/Queue shares, while their own closes are mid-drain, and `closeRedis()` then quits it again; `process.once` handlers mean a second SIGTERM hits Node's default handler; three workers have initializers but no shutdown exports. **Do not relitigate:** no global BullMQ `pause()` (would pause the other process's consumption too — `Worker.close()` is the local stop+drain); phase timeout continues to later phases, never aborts them.
+
+## Global Constraints
+
+- Run single test files as `cd apps/api && npx vitest run <path>` (never `pnpm --filter ... test -- --run <path>`).
+- Repo shutdown convention (mirror exactly): `await handle.close()` with no `force` arg, null-check before, null out after — see `shutdownEventDispatchWorker` (`jobs/eventDispatchWorker.ts:919-932`).
+- `shutdownRuntime` and `installSignalHandlers` are module-private closures in `index.ts` (NOT exported, zero existing tests). The phase runner is extracted precisely so ordering logic is testable without booting `index.ts`.
+- Behavior contracts that must survive: exit code 0 on clean shutdown, 1 when any task failed (`index.ts:1778-1789`); the HTTP-close-before-teardown ordering and its comment (`index.ts:1755-1777` — heartbeat-mid-shutdown wedge); `closeRedis()`'s swallow-EPIPE semantics (`redis.ts:157-187`) unchanged.
+- Commit after every task with the trailers:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+  `Claude-Session: https://claude.ai/code/session_012o7QB15EFjEvetDAXMxmae`
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `apps/api/src/services/shutdownPhases.ts` (new) | `runShutdownPhases()` — sequential named phases, allSettled + bounded timeout within each, failure report. |
+| `apps/api/src/services/shutdownPhases.test.ts` (new) | Order, phase barrier, failure isolation, timeout-continues, empty-phase tolerance. |
+| `apps/api/src/services/eventBus.ts` (modify) | `close()` releases its reference without quitting the shared connection. |
+| `apps/api/src/jobs/ticketMailboxPollWorker.ts`, `jobs/unifiWorker.ts`, `jobs/unifiTelemetryWorker.ts` (modify) | Standard `shutdown*` exports. |
+| `apps/api/src/index.ts` (modify) | shutdownTasks → named phases via the runner; second-signal force-exit. |
+
+---
+
+### Task 1: Shutdown exports for the three orphan workers
+
+**Files:**
+- Modify: `apps/api/src/jobs/ticketMailboxPollWorker.ts` (module handles `queue`/`worker`, init at :98-128), `apps/api/src/jobs/unifiWorker.ts` (handle `unifiWorker`, init :195-207; queue via `getUnifiSyncQueue()` :35), `apps/api/src/jobs/unifiTelemetryWorker.ts` (handle `workerInstance`, init :80-90; queue via `getUnifiTelemetryQueue()` :11)
+- Modify: `apps/api/src/index.ts` — add the three new functions to the shutdownTasks list next to their subsystem neighbors (same comment style)
+- Test: co-located `*.test.ts` for each (extend existing files if present, else create)
+
+**Interfaces:**
+- Produces: `shutdownTicketMailboxPollWorker(): Promise<void>`, `shutdownUnifiWorker(): Promise<void>`, `shutdownUnifiTelemetryWorker(): Promise<void>`.
+
+- [ ] **Step 1: Write the failing tests** — for each module, mock `bullmq` (Worker/Queue classes with `close: vi.fn()`) and `../services/redis`; assert: after `initialize*()` then `shutdown*()`, every created Worker/Queue handle got exactly one `close()` call; a second `shutdown*()` call is a no-op (handles nulled); `shutdown*()` before `initialize*()` resolves without throwing. For `unifiWorker`, the queue is created lazily via `getUnifiSyncQueue()` — shutdown must close it only if it was created (peek the module's lazy handle by calling the getter in the test's arrange step for the created-case).
+- [ ] **Step 2: Run to verify failure** (functions don't exist).
+- [ ] **Step 3: Implement** — mirror `shutdownEventDispatchWorker` exactly:
+
+```ts
+// ticketMailboxPollWorker.ts
+export async function shutdownTicketMailboxPollWorker(): Promise<void> {
+  if (worker) {
+    await worker.close();
+    worker = null;
+  }
+  if (queue) {
+    await queue.close();
+    queue = null;
+  }
+}
+```
+
+`unifiWorker.ts`: close `unifiWorker` (null-check/null-out) and the lazy sync queue — add a module-level `let syncQueue` capture inside `getUnifiSyncQueue()` if the current implementation constructs it inline, so shutdown can reach it. `unifiTelemetryWorker.ts`: close `workerInstance` and the lazy telemetry queue the same way.
+
+- [ ] **Step 4: Wire into `index.ts` shutdownTasks** (three bare function refs, placed with their subsystems), run the three test files → PASS, typecheck. Commit: `fix(api): shutdown exports for ticket-mailbox, unifi, unifi-telemetry workers (#4086)`
+
+---
+
+### Task 2: `EventBus.close()` must not quit the shared connection
+
+**Files:**
+- Modify: `apps/api/src/services/eventBus.ts:209-214`
+- Test: extend the eventBus test file (find: `ls apps/api/src/services/eventBus*.test.ts`)
+
+- [ ] **Step 1: Write the failing test** — mock `./redis`'s `getRedisConnection` to return a spy client `{ quit: vi.fn(), status: 'ready', xadd: vi.fn(), publish: vi.fn() }`; drive the bus so `getOrCreateRedis()` runs (publish an event or call close after a publish); assert `close()` does NOT call `quit()` on it, and that after `close()` a subsequent publish re-acquires via `getRedisConnection()` (the nulled reference is re-fetched — `getOrCreateRedis()` at eventBus.ts:198-203 already handles this).
+- [ ] **Step 2: Run to verify failure** (current code quits).
+- [ ] **Step 3: Implement**:
+
+```ts
+  /**
+   * Release this bus's reference to the shared Redis connection.
+   *
+   * Deliberately does NOT call `.quit()`: `getOrCreateRedis()` borrows the
+   * module-singleton BullMQ connection (`getRedisConnection()`), which every
+   * BullMQ Worker/Queue in the process shares. Quitting it here tore the
+   * connection out from under consumers still draining in the same shutdown
+   * pass — `closeRedis()` is the sole owner of that quit (wave 3.5d-a, #4086).
+   */
+  async close(): Promise<void> {
+    this.redisClient = null;
+  }
+```
+
+- [ ] **Step 4: Run the eventBus tests + typecheck** → PASS. Commit: `fix(api): EventBus.close() no longer quits the shared BullMQ connection (#4086)`
+
+---
+
+### Task 3: The phase runner — `shutdownPhases.ts`
+
+**Files:**
+- Create: `apps/api/src/services/shutdownPhases.ts`, `apps/api/src/services/shutdownPhases.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface ShutdownPhase { name: string; tasks: Array<() => Promise<void> | void>; timeoutMs?: number }`
+  - `interface ShutdownReport { failures: Array<{ phase: string; index: number; error: unknown }>; timedOutPhases: string[] }`
+  - `runShutdownPhases(phases: ShutdownPhase[], opts?: { defaultTimeoutMs?: number; log?: (msg: string) => void }): Promise<ShutdownReport>`
+
+**Semantics (the tests pin all of these):** phases run strictly sequentially; a phase's tasks all start together and the phase waits for `Promise.allSettled` of them, raced against its timeout (default `defaultTimeoutMs`, default 20_000); on timeout the runner logs, records the phase in `timedOutPhases`, and PROCEEDS to the next phase (a stuck worker must never prevent Redis/DB close — but note the straggler keeps running detached; its eventual rejection is captured, never unhandled); task rejections are recorded per task with phase + index and never abort anything; a task that throws synchronously is captured identically; empty phases are skipped silently.
+
+- [ ] **Step 1: Write the failing tests** — use fake timers where the timeout cases need them:
+  1. Order: tasks push to a log; phase B's tasks never start before every phase-A task settled.
+  2. Concurrency within a phase: two tasks in one phase both start before either resolves (start-log asserted before resolution).
+  3. Failure isolation: task 0 rejects, task 1 resolves — report lists one failure `{phase, index: 0}`, phase B still runs.
+  4. Timeout: a never-resolving task in phase A (timeoutMs 50) — phase B runs, `timedOutPhases: ['A']`; when the straggler later rejects, no unhandled rejection (attach the allSettled handler before racing).
+  5. Sync throw captured.
+  6. Empty phase skipped.
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Implement** (~50 lines):
+
+```ts
+export async function runShutdownPhases(
+  phases: ShutdownPhase[],
+  opts: { defaultTimeoutMs?: number; log?: (msg: string) => void } = {},
+): Promise<ShutdownReport> {
+  const log = opts.log ?? ((msg) => console.log(msg));
+  const defaultTimeoutMs = opts.defaultTimeoutMs ?? 20_000;
+  const report: ShutdownReport = { failures: [], timedOutPhases: [] };
+
+  for (const phase of phases) {
+    if (phase.tasks.length === 0) continue;
+    log(`[shutdown] phase ${phase.name} (${phase.tasks.length} task(s))`);
+    // Start all tasks and attach the settlement handler FIRST, so a straggler
+    // that rejects after a phase timeout is already handled (no unhandled
+    // rejection from a detached phase).
+    const settled = Promise.allSettled(
+      phase.tasks.map(async (task) => task()),
+    ).then((results) => {
+      results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          report.failures.push({ phase: phase.name, index, error: result.reason });
+        }
+      });
+    });
+    const timeoutMs = phase.timeoutMs ?? defaultTimeoutMs;
+    let timer: NodeJS.Timeout | undefined;
+    const timedOut = await Promise.race([
+      settled.then(() => false),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(true), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+    if (timedOut) {
+      report.timedOutPhases.push(phase.name);
+      log(`[shutdown] phase ${phase.name} timed out after ${timeoutMs}ms — continuing`);
+    }
+  }
+  return report;
+}
+```
+
+- [ ] **Step 4: Run tests + typecheck** → PASS. Commit: `feat(api): sequential shutdown phase runner (#4086)`
+
+---
+
+### Task 4: Wire `index.ts` onto phases + second-signal force-exit
+
+**Files:**
+- Modify: `apps/api/src/index.ts` — `shutdownRuntime` (:1605-1789) and `installSignalHandlers` (:1791-1799)
+
+**Interfaces:**
+- Consumes: `runShutdownPhases` (Task 3), the three Task 1 exports.
+
+- [ ] **Step 1: Partition the existing shutdownTasks array into phases**, preserving every entry and every comment, in the array's existing relative order. The preamble (webhook worker stop, monitors, audit interval clear) and the HTTP-close block (:1755-1777) stay exactly where they are, BEFORE the phases. Phase membership:
+
+```ts
+  const report = await runShutdownPhases([
+    // 1. Final local drains that need DB/Redis still up.
+    { name: 'drain', tasks: [boundedAuditDrainTask] },
+    // 2. Every worker/consumer close — concurrent, as today, but now
+    //    guaranteed to fully settle before shared infrastructure goes away.
+    { name: 'workers', tasks: [/* the ~90 shutdown* refs, unchanged order */] },
+    // 3. Producer queues + dispatchers (they enqueue INTO Redis; workers are gone).
+    { name: 'queues', tasks: [shutdownEventDispatcher, shutdownEventDispatchWorker, shutdownEventDispatchQueue, shutdownAgentCommandRelayWorker] },
+    // 4. Event bus releases its borrowed connection reference (no quit — Task 2).
+    { name: 'eventbus', tasks: [async () => getEventBus().close()] },
+    // 5. The ONLY owner of the Redis quits.
+    { name: 'redis', tasks: [closeRedis] },
+    // 6. DB pool.
+    { name: 'db', tasks: [dbCloseTask] },
+    // 7. Sentry flush (bounded internally at 2s).
+    { name: 'sentry', tasks: [() => flushSentry()], timeoutMs: 5_000 },
+  ]);
+  const failed = report.failures.length > 0;
+  if (failed) {
+    console.error(`[shutdown] Completed with ${report.failures.length} failure(s)`);
+  } else {
+    console.log('[shutdown] Complete');
+  }
+  process.exit(failed ? 1 : 0);
+```
+
+Note: `shutdownEventDispatchWorker` currently sits with the queue/dispatcher cluster in the existing array tail (:1743-1747) — keep the cluster together in `queues`. Timed-out phases alone do NOT flip the exit code (their real failures, if any, land in `failures` when the straggler settles — usually after exit; acceptable, matches today's "failures we saw" semantics).
+
+- [ ] **Step 2: Second-signal force-exit** in `installSignalHandlers`:
+
+```ts
+function installSignalHandlers(): void {
+  const onSignal = (signal: NodeJS.Signals) => {
+    // Second signal while a graceful shutdown is running: operator (or
+    // orchestrator) wants out NOW. Deterministic force-exit beats Node's
+    // default handler ambiguity.
+    process.once(signal, () => {
+      console.error(`[shutdown] Second ${signal} — forcing exit`);
+      process.exit(130);
+    });
+    void shutdownRuntime(signal);
+  };
+  process.once('SIGINT', () => onSignal('SIGINT'));
+  process.once('SIGTERM', () => onSignal('SIGTERM'));
+}
+```
+
+- [ ] **Step 3: Typecheck + run the full unit suite** (`cd apps/api && npx vitest run`) — the suite must be as green as on the base commit (report exact totals). Manual smoke: `grep -c 'shutdown' src/index.ts` sanity, and verify no shutdownTasks entry was dropped — `git diff` must show every removed array entry reappearing in exactly one phase (reviewer will diff-count them: state the count in the commit body).
+- [ ] **Step 4: Commit** — `refactor(api): shutdown runs in ordered phases; second signal force-exits (#4086)` with the entry count in the body.
+
+---
+
+### Task 5: Verification + PR
+
+- [ ] Full unit suite + typecheck (heap bump if tsc OOMs: `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit`).
+- [ ] Tick this plan's checkboxes, commit.
+- [ ] Open PR: branch `feature/3821-ai-agents/wave-4086-shutdown` → `main`. Body: "Part A (prerequisite) of #4086 — do NOT close the issue" (no `Closes`), the two verified defects (concurrent allSettled ordering illusion; EventBus quitting the shared connection), phase semantics (sequential, bounded, continue-past-timeout), and the exit-code contract. **Stop after opening the PR.**
+
+## Self-Review Notes
+
+- Scope deliberately excludes: worker registry, entrypoints, readiness, compose — all Part B. No behavior change to any individual `shutdown*` function; only ordering, the eventBus quit removal, and the three new exports.
+- Type consistency: `ShutdownPhase`/`ShutdownReport` defined once (Task 3), consumed in Task 4.
+- Known accepted semantics: a phase timeout detaches stragglers (they keep running until exit); failures recorded after `process.exit` are lost — same as today.


### PR DESCRIPTION
**Part A (prerequisite) of #4086 — do NOT close the issue.** The BREEZE_ROLE split (Part B) makes the worker container's SIGTERM handling load-bearing; this PR fixes the shutdown lifecycle it will rely on. Plan/ADR: `docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave3.5d-a-ordered-shutdown.md` (quorum 2026-08-27: both advisors independently called for this as its own PR).

## Two verified defects fixed

1. **The shutdown ordering was an illusion.** `shutdownRuntime` built a carefully ordered+commented array of ~109 close tasks, then ran `Promise.allSettled(shutdownTasks.map(t => t()))` — every task started concurrently. Now: a small unit-tested phase runner (`services/shutdownPhases.ts`) executes named phases **sequentially** — `drain → workers → queues → eventbus → redis → db → sentry` — with `allSettled` concurrency only *within* a phase and a bounded per-phase timeout that logs, records, and **continues** (a stuck worker can no longer prevent Redis/DB close). All 109 original entries are preserved in the same relative order (independently re-counted in review: 100 unchanged + 9 relocated to their proper phases).
2. **`EventBus.close()` quit a connection it didn't own.** It called `.quit()` on the shared module-singleton BullMQ connection (`getRedisConnection()`) that every BullMQ Worker/Queue uses — tearing it out from under consumers mid-drain, with `closeRedis()` then quitting it again. `close()` now releases its reference only; `closeRedis()` (phase `redis`, strictly after all worker/queue closes) is the sole quit owner. Publish-after-close still re-acquires correctly (test-asserted).

## Also

- `shutdownTicketMailboxPollWorker` / `shutdownUnifiWorker` / `shutdownUnifiTelemetryWorker`: three workers had initializers but no shutdown exports (leaked BullMQ handles); added following the repo close convention, wired into the `workers` phase.
- Second SIGTERM/SIGINT after graceful shutdown began now force-exits deterministically (130) instead of falling to Node's default handler.
- Final shutdown log surfaces timed-out phases; the runner logs each task failure with its error.

## Semantics preserved

Exit 0 clean / 1 on failures; HTTP-close-before-teardown (the heartbeat-wedge guard) untouched ahead of the phases; `closeRedis()` EPIPE-swallow unchanged; no migrations, no env vars, no compose changes. Accepted (documented in plan): a phase timeout detaches stragglers and alone doesn't flip the exit code — matches today's "failures we saw" semantics.

## Review provenance

2 staged implement→review rounds (1 blocking finding fixed: the original timeout test didn't discriminate a break-on-timeout implementation) + opus whole-branch review: **approve, zero blocking**; entry accounting reproduced programmatically. Full unit suite 26,308 passed / 0 failed; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012o7QB15EFjEvetDAXMxmae
