### PR TITLE
feat(api): wave 4 part A — act-mode foundations (execution ledger, agent attribution, durable notify, caps v2, device pinning)

### DIFF
--- a/apps/api/src/__tests__/integration/aiAgentEffectivePolicy.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiAgentEffectivePolicy.integration.test.ts
@@ -92,7 +92,7 @@ describe('resolveEffectiveAgent under real RLS', () => {
     expect(resolved!.effective.mode).toBe('shadow');            // org asked for 'act'
     expect(resolved!.effective.toolAllowlist).toEqual(['run_script']); // intersection
     expect(resolved!.effective.limits.maxDevicesPerRun).toBe(10);      // org asked for 50
-    expect(resolved!.schemaVersion).toBe(1);
+    expect(resolved!.schemaVersion).toBe(2);
   });
 
   it('the platform kill switch forces every resolved agent off', async () => {

--- a/apps/api/src/__tests__/multi-tenant-isolation.test.ts
+++ b/apps/api/src/__tests__/multi-tenant-isolation.test.ts
@@ -59,6 +59,7 @@ vi.mock('../db/schema', () => ({
   alertNotifications:       { id: 'id' },
   escalationPolicies:       { id: 'id', orgId: 'orgId' },
   organizations:            { id: 'id' },
+  users:                    { id: 'id' },
   partnerUsers:             {},
   organizationUsers:        {},
   patchPolicies: {},

--- a/apps/api/src/jobs/agentNotifyRetryWorker.test.ts
+++ b/apps/api/src/jobs/agentNotifyRetryWorker.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const RUN_ID = '00000000-0000-4000-8000-0000000000f1';
+
+const shared = vi.hoisted(() => ({
+  addMock: vi.fn<(name: string, data: unknown, opts: unknown) => Promise<{ id: string }>>(
+    async () => ({ id: 'job-1' })),
+  closeQueueMock: vi.fn(async () => undefined),
+  workerOnMock: vi.fn(),
+  workerCloseMock: vi.fn(async () => undefined),
+  captureExceptionMock: vi.fn(),
+  deliverRunFinishedNotificationsMock: vi.fn(async () => undefined),
+  lastWorkerProcessor: undefined as ((job: unknown) => Promise<void>) | undefined,
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    add = shared.addMock;
+    close = shared.closeQueueMock;
+  },
+  Worker: class {
+    constructor(_name: string, processor: (job: unknown) => Promise<void>) {
+      shared.lastWorkerProcessor = processor;
+    }
+    on = shared.workerOnMock;
+    close = shared.workerCloseMock;
+  },
+}));
+
+vi.mock('../services/bullmqQueue', () => ({
+  // The real createInstrumentedQueue wraps a real bullmq Queue with the #1105
+  // tripwire — covered by bullmqQueue's own tests, not this suite's concern.
+  // A lightweight fake exposing just what this worker calls is enough here.
+  createInstrumentedQueue: vi.fn(() => ({
+    add: shared.addMock,
+    close: shared.closeQueueMock,
+  })),
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}));
+
+vi.mock('../services/sentry', () => ({ captureException: shared.captureExceptionMock }));
+
+vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
+
+vi.mock('../services/aiAgents/runFinishedNotify', () => ({
+  deliverRunFinishedNotifications: shared.deliverRunFinishedNotificationsMock,
+}));
+
+import {
+  AGENT_NOTIFY_RETRY_JOB_NAME,
+  AGENT_NOTIFY_RETRY_QUEUE,
+  enqueueAgentNotifyRetry,
+  getAgentNotifyRetryJobId,
+  initializeAgentNotifyRetryWorker,
+  processAgentNotifyRetryJob,
+  shutdownAgentNotifyRetryWorker,
+} from './agentNotifyRetryWorker';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  shared.deliverRunFinishedNotificationsMock.mockResolvedValue(undefined);
+});
+
+describe('getAgentNotifyRetryJobId', () => {
+  it('is hyphen-only (repo rule #1101) and one job per run', () => {
+    const id = getAgentNotifyRetryJobId(RUN_ID);
+    expect(id).toBe(`agent-notify-${RUN_ID}`);
+    expect(id).not.toContain(':');
+  });
+});
+
+describe('enqueueAgentNotifyRetry', () => {
+  it('adds a job with 5 attempts, exponential backoff starting 30s, and the stable jobId', async () => {
+    await enqueueAgentNotifyRetry(RUN_ID);
+
+    expect(shared.addMock).toHaveBeenCalledTimes(1);
+    const [jobName, data, opts] = shared.addMock.mock.calls[0]!;
+    expect(jobName).toBe(AGENT_NOTIFY_RETRY_JOB_NAME);
+    expect(data).toEqual({ runId: RUN_ID });
+    expect(opts).toMatchObject({
+      jobId: `agent-notify-${RUN_ID}`,
+      attempts: 5,
+      backoff: { type: 'exponential', delay: 30_000 },
+    });
+  });
+
+  it('NEVER throws — a second failure on top of an already-failed notify must not surface', async () => {
+    shared.addMock.mockRejectedValueOnce(new Error('redis down'));
+
+    await expect(enqueueAgentNotifyRetry(RUN_ID)).resolves.toBeUndefined();
+
+    expect(shared.captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('processAgentNotifyRetryJob', () => {
+  function job(overrides: Record<string, unknown> = {}) {
+    return { id: 'job-1', name: AGENT_NOTIFY_RETRY_JOB_NAME, data: { runId: RUN_ID }, ...overrides };
+  }
+
+  it('calls deliverRunFinishedNotifications with the run id from the job payload', async () => {
+    await processAgentNotifyRetryJob(job() as never);
+
+    expect(shared.deliverRunFinishedNotificationsMock).toHaveBeenCalledWith(RUN_ID);
+  });
+
+  it('lets a repeat failure PROPAGATE so BullMQ applies its own attempts/backoff', async () => {
+    shared.deliverRunFinishedNotificationsMock.mockRejectedValueOnce(new Error('still down'));
+
+    await expect(processAgentNotifyRetryJob(job() as never)).rejects.toThrow('still down');
+  });
+
+  it('rejects a job with the wrong name rather than silently no-oping', async () => {
+    await expect(processAgentNotifyRetryJob(job({ name: 'wrong-name' }) as never)).rejects.toThrow();
+    expect(shared.deliverRunFinishedNotificationsMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed payload (missing runId) without calling the notify body', async () => {
+    await expect(processAgentNotifyRetryJob(job({ data: {} }) as never)).rejects.toThrow();
+    expect(shared.deliverRunFinishedNotificationsMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('worker lifecycle', () => {
+  it('initialize is idempotent and shutdown closes both the worker and the queue', async () => {
+    initializeAgentNotifyRetryWorker();
+    initializeAgentNotifyRetryWorker();
+
+    // Only enqueueAgentNotifyRetry constructs the queue (lazily); the worker's
+    // own construction doesn't touch it, so build one to prove shutdown closes it.
+    await enqueueAgentNotifyRetry(RUN_ID);
+
+    await shutdownAgentNotifyRetryWorker();
+
+    expect(shared.workerCloseMock).toHaveBeenCalledTimes(1);
+    expect(shared.closeQueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('the constructed worker processes jobs via processAgentNotifyRetryJob', async () => {
+    initializeAgentNotifyRetryWorker();
+
+    expect(shared.lastWorkerProcessor).toBeDefined();
+    await shared.lastWorkerProcessor!(job());
+    expect(shared.deliverRunFinishedNotificationsMock).toHaveBeenCalledWith(RUN_ID);
+
+    await shutdownAgentNotifyRetryWorker();
+  });
+
+  function job(overrides: Record<string, unknown> = {}) {
+    return { id: 'job-2', name: AGENT_NOTIFY_RETRY_JOB_NAME, data: { runId: RUN_ID }, ...overrides };
+  }
+});
+
+describe('queue identity', () => {
+  it('has a stable queue name', () => {
+    expect(AGENT_NOTIFY_RETRY_QUEUE).toBe('agent-notify-retry');
+  });
+});

--- a/apps/api/src/jobs/agentNotifyRetryWorker.ts
+++ b/apps/api/src/jobs/agentNotifyRetryWorker.ts
@@ -1,0 +1,135 @@
+/**
+ * agentNotifyRetryWorker — durable retry lane for run-finished notifications
+ * (AI agents wave 4a, Task 6, #3826).
+ *
+ * `deliverRunFinishedNotifications` (services/aiAgents/runFinishedNotify.ts)
+ * is the SAME notify body both paths call: `runLoop.ts`'s `finishRun`, right
+ * after the run's terminal status commits, calls it in-process first — most
+ * runs notify synchronously and this queue never sees them. Only a FAILURE
+ * there (recipient resolution, or a notification write) enqueues a job here.
+ * Delivery is idempotent even across an in-process attempt plus a later
+ * retry: `createNotification`'s `(userId, dedupeKey)` conflict-ignore
+ * (`services/userNotifications.ts`) makes re-delivery a no-op for any
+ * recipient who was already notified before the failure.
+ *
+ * Deliberately its OWN tiny queue/worker rather than another job name on the
+ * `ai-agent` queue (`jobs/aiAgentRunner.ts`): that queue explicitly carries
+ * NO retries (a crashed agent run must never be replayed — see its header
+ * comment), while this one is retries-only by design (`attempts: 5`,
+ * exponential backoff). Mixing the two semantics onto one queue would make
+ * one of them silently wrong.
+ *
+ * The job processor lets a repeat failure PROPAGATE (no internal catch) so
+ * BullMQ's own `attempts`/backoff — set once, at enqueue time in
+ * `enqueueAgentNotifyRetry` — is what retries it. `enqueueAgentNotifyRetry`
+ * itself never throws: it is the LAST line of defense after an in-process
+ * notify already failed once, so a second failure here (e.g. Redis also
+ * down) must not become a third failure mode stacked on top — logged +
+ * captured instead. Either way, the run's own terminal status already
+ * committed and is unaffected.
+ */
+import { Worker, type Job } from 'bullmq';
+import type { Queue } from 'bullmq';
+import { createInstrumentedQueue } from '../services/bullmqQueue';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import { assertQueueJobName, parseQueueJobData } from '../services/bullmqValidation';
+import { attachWorkerObservability } from './workerObservability';
+import { deliverRunFinishedNotifications } from '../services/aiAgents/runFinishedNotify';
+import { agentNotifyRetryQueueJobDataSchema, type AgentNotifyRetryQueueJobData } from './queueSchemas';
+
+export const AGENT_NOTIFY_RETRY_QUEUE = 'agent-notify-retry';
+export const AGENT_NOTIFY_RETRY_JOB_NAME = 'notify-run-finished';
+
+/** '-' separator only (repo rule, #1101) — never ':'. One job per run: a
+ *  second failure for the SAME run before the first retry has fired reuses
+ *  the same id rather than stacking duplicate retry jobs. */
+export function getAgentNotifyRetryJobId(runId: string): string {
+  return `agent-notify-${runId}`;
+}
+
+let notifyRetryQueue: Queue<AgentNotifyRetryQueueJobData> | null = null;
+
+function getAgentNotifyRetryQueue(): Queue<AgentNotifyRetryQueueJobData> {
+  if (!notifyRetryQueue) {
+    // createInstrumentedQueue wires the #1105 held-context tripwire into
+    // `add()` — this is called from `finishRun`, outside any held DB context
+    // (the status CAS transaction already committed by the time notify runs).
+    notifyRetryQueue = createInstrumentedQueue<AgentNotifyRetryQueueJobData>(AGENT_NOTIFY_RETRY_QUEUE);
+  }
+  return notifyRetryQueue;
+}
+
+/**
+ * Best-effort enqueue: NEVER throws. See the header comment for why.
+ */
+export async function enqueueAgentNotifyRetry(runId: string): Promise<void> {
+  try {
+    await getAgentNotifyRetryQueue().add(
+      AGENT_NOTIFY_RETRY_JOB_NAME,
+      { runId } satisfies AgentNotifyRetryQueueJobData,
+      {
+        jobId: getAgentNotifyRetryJobId(runId),
+        attempts: 5,
+        backoff: { type: 'exponential', delay: 30_000 },
+        removeOnComplete: { count: 200 },
+        removeOnFail: { count: 500 },
+      },
+    );
+  } catch (error) {
+    console.error('[AgentNotifyRetryWorker] failed to enqueue notify retry', { runId, error });
+    captureException(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
+/** The job body, exported for unit tests — the Worker below is a thin wrapper. */
+export async function processAgentNotifyRetryJob(job: Job<AgentNotifyRetryQueueJobData>): Promise<void> {
+  assertQueueJobName(AGENT_NOTIFY_RETRY_QUEUE, job, AGENT_NOTIFY_RETRY_JOB_NAME);
+  const data = parseQueueJobData(AGENT_NOTIFY_RETRY_QUEUE, job, agentNotifyRetryQueueJobDataSchema);
+  // No try/catch here on purpose — see the header comment: a repeat failure
+  // must propagate so BullMQ's own attempts/backoff (set at enqueue time)
+  // retries it, rather than this function silently swallowing it.
+  await deliverRunFinishedNotifications(data.runId);
+}
+
+let notifyRetryWorker: Worker<AgentNotifyRetryQueueJobData> | null = null;
+
+export function initializeAgentNotifyRetryWorker(): void {
+  if (notifyRetryWorker) return;
+
+  notifyRetryWorker = new Worker<AgentNotifyRetryQueueJobData>(
+    AGENT_NOTIFY_RETRY_QUEUE,
+    processAgentNotifyRetryJob,
+    {
+      connection: getBullMQConnection(),
+      concurrency: 3,
+    },
+  );
+  attachWorkerObservability(notifyRetryWorker, 'agentNotifyRetry');
+
+  notifyRetryWorker.on('error', (error) => {
+    console.error('[AgentNotifyRetryWorker] Worker error:', error);
+  });
+  notifyRetryWorker.on('failed', (job, error) => {
+    // All 5 attempts exhausted: the recipients for this run never learned it
+    // finished. Loud on purpose — this is the operator-side trail.
+    console.error('[AgentNotifyRetryWorker] notify retry exhausted', {
+      jobId: job?.id,
+      runId: (job?.data as { runId?: string } | undefined)?.runId,
+      error,
+    });
+  });
+
+  console.log('[AgentNotifyRetryWorker] initialized');
+}
+
+export async function shutdownAgentNotifyRetryWorker(): Promise<void> {
+  if (notifyRetryWorker) {
+    await notifyRetryWorker.close();
+    notifyRetryWorker = null;
+  }
+  if (notifyRetryQueue) {
+    await notifyRetryQueue.close();
+    notifyRetryQueue = null;
+  }
+}

--- a/apps/api/src/jobs/queueSchemas.ts
+++ b/apps/api/src/jobs/queueSchemas.ts
@@ -300,6 +300,17 @@ export const aiAgentQueueJobDataSchema = z.discriminatedUnion('type', [
   }).strict(),
 ]);
 
+/**
+ * The `agent-notify-retry` queue's only payload (AI agents wave 4a, Task 6,
+ * #3826). Carries the run id and nothing else — same reasoning as the
+ * `ai-agent` queue above: `deliverRunFinishedNotifications` re-reads the run,
+ * agent, and policy snapshot fresh from the DB, so a stale copy in the job
+ * payload can never drift from what actually got committed.
+ */
+export const agentNotifyRetryQueueJobDataSchema = z.object({
+  runId: z.string().min(1),
+}).strict();
+
 export const sensitiveDataQueueJobDataSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('dispatch-scan'),
@@ -396,6 +407,7 @@ export type AutomationQueueJobData = z.infer<typeof automationQueueJobDataSchema
 export type AutomationAssignmentLevel = z.infer<typeof automationAssignmentLevelSchema>;
 export type SensitiveDataQueueJobData = z.infer<typeof sensitiveDataQueueJobDataSchema>;
 export type AiAgentQueueJobData = z.infer<typeof aiAgentQueueJobDataSchema>;
+export type AgentNotifyRetryQueueJobData = z.infer<typeof agentNotifyRetryQueueJobDataSchema>;
 export type DrExecutionQueueJobData = z.infer<typeof drExecutionQueueJobDataSchema>;
 export type RecoveryMediaQueueJobData = z.infer<typeof recoveryMediaQueueJobDataSchema>;
 export type RecoveryBootMediaQueueJobData = z.infer<typeof recoveryBootMediaQueueJobDataSchema>;

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -146,6 +146,18 @@ export interface AuthContext {
   canAccessSite?: (siteId: string | null | undefined) => boolean;
 
   /**
+   * Device-axis allowlist — pins a caller to an EXACT set of device ids,
+   * tighter than `allowedSiteIds` (which admits every device in the site).
+   * `undefined` = no device restriction. Set only for a device-bound AI
+   * agent run (`agentAuthContext.buildAgentAuthContext`); every other
+   * AuthContext construction site never sets it, so behavior for
+   * interactive/user/helper/MCP callers is unchanged. Enforced in
+   * `verifyDeviceAccess` (services/aiTools.ts) — the chokepoint every
+   * per-deviceId tool call routes through.
+   */
+  allowedDeviceIds?: readonly string[];
+
+  /**
    * Set ONLY for Breeze Helper sessions (helperAuth). When present, the
    * AI-tools executeTool gate forces every tool's device input to this device
    * id and denies org-wide tools — the Helper can act only on its own device.

--- a/apps/api/src/services/aiAgents/agentAuthContext.test.ts
+++ b/apps/api/src/services/aiAgents/agentAuthContext.test.ts
@@ -70,6 +70,21 @@ describe('buildAgentAuthContext', () => {
     ).toThrow(AgentRunOwnershipError);
   });
 
+  it('pins a device-bound run to the exact device, not just its site', () => {
+    const deviceRun = { id: 'run-2', orgId: 'org-1', deviceId: 'device-1', deviceSiteId: 'site-A' };
+    const auth = buildAgentAuthContext(agentOrg, deviceRun, org1);
+
+    expect(auth.allowedDeviceIds).toEqual(['device-1']);
+    // The existing site-level pin stays in place alongside the new device pin.
+    expect(auth.allowedSiteIds).toEqual(['site-A']);
+  });
+
+  it('does not set allowedDeviceIds for a non-device-bound (org-wide) run', () => {
+    const auth = buildAgentAuthContext(agentOrg, run, org1);
+
+    expect(auth.allowedDeviceIds).toBeUndefined();
+  });
+
   it('never carries a user id in either DB access-context path', () => {
     const auth = buildAgentAuthContext(agentPartner, run, org1);
     const expected = {

--- a/apps/api/src/services/aiAgents/agentAuthContext.ts
+++ b/apps/api/src/services/aiAgents/agentAuthContext.ts
@@ -96,10 +96,16 @@ export function buildAgentAuthContext(
     // skipped entirely and a device-bound agent could target any device in the
     // org. A run with a device pins to that device's site; a run with no device
     // pins to the empty set rather than to "unrestricted".
+    //
+    // The site pin alone is not exact: it admits every SIBLING device in the
+    // same site, not just the one device the run targets. `allowedDeviceIds`
+    // is the tightening on top — `verifyDeviceAccess` (aiTools.ts) enforces
+    // it as an exact-match allowlist alongside the site check.
     ...(run.deviceId
       ? {
           allowedSiteIds: run.deviceSiteId ? [run.deviceSiteId] : [],
           canAccessSite: siteAccessCheck(run.deviceSiteId ? [run.deviceSiteId] : []),
+          allowedDeviceIds: [run.deviceId],
         }
       : {}),
   };

--- a/apps/api/src/services/aiAgents/effectivePolicy.test.ts
+++ b/apps/api/src/services/aiAgents/effectivePolicy.test.ts
@@ -282,6 +282,14 @@ describe('mergeAgentPolicies — tighten only', () => {
       .toBe('org-model');
   });
 
+  it('mergeLimits min-wins on maxActionsPerRun: partner 5 + org 2 -> 2', () => {
+    const partner = policy({ limits: { ...AI_AGENT_LIMIT_DEFAULTS, maxActionsPerRun: 5 } });
+    const org = policy({ limits: { ...AI_AGENT_LIMIT_DEFAULTS, maxActionsPerRun: 2 } });
+
+    expect(mergeAgentPolicies(partner, org, { allowedModels: null }).effective.limits.maxActionsPerRun)
+      .toBe(2);
+  });
+
   it('fills JSONB defaults when normalizing a sparse row', () => {
     const normalized = normalizeAgentPolicy({
       enabled: false,

--- a/apps/api/src/services/aiAgents/executionLedger.test.ts
+++ b/apps/api/src/services/aiAgents/executionLedger.test.ts
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+const RUN_ID = '00000000-0000-4000-8000-0000000000c1';
+const AGENT_ID = '00000000-0000-4000-8000-0000000000c2';
+const ORG_ID = '00000000-0000-4000-8000-0000000000c3';
+const DEVICE_ID = '00000000-0000-4000-8000-0000000000c4';
+const SESSION_ID = '00000000-0000-4000-8000-0000000000c5';
+const EXISTING_SESSION_ID = '00000000-0000-4000-8000-0000000000c6';
+const EXECUTION_ID = '00000000-0000-4000-8000-0000000000c7';
+
+interface CapturedInsert {
+  table: string;
+  values: Record<string, unknown>;
+}
+interface CapturedUpdate {
+  table: string;
+  values: Record<string, unknown>;
+  where?: SQL;
+}
+interface CapturedSelect {
+  table: string;
+  where?: SQL;
+}
+
+const dbMockState = vi.hoisted(() => ({
+  inserts: [] as CapturedInsert[],
+  /** FIFO of rows returned by the NEXT insert().returning() for a table. */
+  insertReturningQueues: {} as Record<string, unknown[][]>,
+  updates: [] as CapturedUpdate[],
+  /** FIFO of rows returned by the NEXT update().returning() for a table. */
+  updateReturningQueues: {} as Record<string, unknown[][]>,
+  selects: [] as CapturedSelect[],
+  /** FIFO of rows returned by the NEXT select() for a table. */
+  selectQueues: {} as Record<string, unknown[][]>,
+  systemContextDepth: 0,
+  ambientContext: undefined as { scope: string } | undefined,
+  contextDuringWrites: [] as string[],
+}));
+
+function shift(queues: Record<string, unknown[][]>, table: string): unknown[] {
+  const q = queues[table];
+  if (!q || q.length === 0) throw new Error(`No queued rows for ${table}`);
+  return q.shift() as unknown[];
+}
+
+function tableName(table: unknown): string {
+  return String((table as Record<symbol, unknown>)[Symbol.for('drizzle:Name')]);
+}
+
+vi.mock('../../db', () => ({
+  db: {
+    insert: vi.fn((table: unknown) => {
+      const name = tableName(table);
+      return {
+        values: vi.fn((values: Record<string, unknown>) => {
+          dbMockState.inserts.push({ table: name, values });
+          dbMockState.contextDuringWrites.push(
+            dbMockState.systemContextDepth > 0 ? 'system' : 'none',
+          );
+          return {
+            returning: vi.fn(async () => shift(dbMockState.insertReturningQueues, name)),
+          };
+        }),
+      };
+    }),
+    update: vi.fn((table: unknown) => {
+      const name = tableName(table);
+      return {
+        set: vi.fn((values: Record<string, unknown>) => {
+          dbMockState.contextDuringWrites.push(
+            dbMockState.systemContextDepth > 0 ? 'system' : 'none',
+          );
+          return {
+            where: vi.fn((cond: SQL) => {
+              dbMockState.updates.push({ table: name, values, where: cond });
+              return {
+                returning: vi.fn(async () => shift(dbMockState.updateReturningQueues, name)),
+                // Plain updates (completeToolExecution, closeAgentRunSession)
+                // don't call .returning() — awaiting the builder itself resolves.
+                then: (resolve: (v: unknown) => unknown) => Promise.resolve().then(() => resolve(undefined)),
+              };
+            }),
+          };
+        }),
+      };
+    }),
+    select: vi.fn((cols: unknown) => ({
+      from: vi.fn((table: unknown) => {
+        const name = tableName(table);
+        const captured: CapturedSelect = { table: name };
+        dbMockState.selects.push(captured);
+        void cols;
+        const builder = {
+          where: vi.fn((cond: SQL) => {
+            captured.where = cond;
+            return builder;
+          }),
+          limit: vi.fn(() => Promise.resolve(shift(dbMockState.selectQueues, name))),
+        };
+        return builder;
+      }),
+    })),
+  },
+  getCurrentDbAccessContext: vi.fn(() => dbMockState.ambientContext),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+    const previous = dbMockState.ambientContext;
+    dbMockState.ambientContext = { scope: 'system' };
+    dbMockState.systemContextDepth += 1;
+    try {
+      return await fn();
+    } finally {
+      dbMockState.systemContextDepth -= 1;
+      dbMockState.ambientContext = previous;
+    }
+  }),
+}));
+
+import {
+  closeAgentRunSession,
+  completeToolExecution,
+  createAgentRunSession,
+  reconcileHungExecutions,
+  startToolExecution,
+} from './executionLedger';
+
+const dialect = new PgDialect();
+function compiled(cond: SQL | undefined): string {
+  if (!cond) return '';
+  return dialect.sqlToQuery(cond).sql;
+}
+
+beforeEach(() => {
+  dbMockState.inserts = [];
+  dbMockState.insertReturningQueues = {};
+  dbMockState.updates = [];
+  dbMockState.updateReturningQueues = {};
+  dbMockState.selects = [];
+  dbMockState.selectQueues = {};
+  dbMockState.systemContextDepth = 0;
+  dbMockState.ambientContext = undefined;
+  dbMockState.contextDuringWrites = [];
+  vi.clearAllMocks();
+});
+
+describe('createAgentRunSession', () => {
+  it('inserts an ai_sessions row with type agent, agentId, and no userId, then CAS-links the run', async () => {
+    dbMockState.insertReturningQueues.ai_sessions = [[{ id: SESSION_ID }]];
+    dbMockState.updateReturningQueues.ai_agent_runs = [[{ id: RUN_ID }]];
+
+    const result = await createAgentRunSession({
+      runId: RUN_ID,
+      agentId: AGENT_ID,
+      orgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      model: 'claude-sonnet-4-5-20250929',
+      maxTurns: 40,
+    });
+
+    expect(result).toBe(SESSION_ID);
+    expect(dbMockState.inserts).toHaveLength(1);
+    const insertedValues = dbMockState.inserts[0]!.values;
+    expect(insertedValues).toMatchObject({
+      orgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      agentId: AGENT_ID,
+      type: 'agent',
+      model: 'claude-sonnet-4-5-20250929',
+      maxTurns: 40,
+      status: 'active',
+    });
+    expect(insertedValues).not.toHaveProperty('userId');
+
+    // Exactly one update against ai_agent_runs — the CAS.
+    const casUpdate = dbMockState.updates.find((u) => u.table === 'ai_agent_runs');
+    expect(casUpdate).toBeDefined();
+    expect(casUpdate!.values).toEqual({ sessionId: SESSION_ID });
+    const casSql = compiled(casUpdate!.where);
+    expect(casSql).toContain('session_id');
+
+    // All writes ran under a system db context.
+    expect(dbMockState.contextDuringWrites.every((c) => c === 'system')).toBe(true);
+  });
+
+  it('on a CAS miss, closes the orphaned session and returns the run\'s EXISTING session id', async () => {
+    dbMockState.insertReturningQueues.ai_sessions = [[{ id: SESSION_ID }]];
+    // CAS update returns zero rows: some other attempt already stamped session_id.
+    dbMockState.updateReturningQueues.ai_agent_runs = [[]];
+    dbMockState.selectQueues.ai_agent_runs = [[{ sessionId: EXISTING_SESSION_ID }]];
+
+    const result = await createAgentRunSession({
+      runId: RUN_ID,
+      agentId: AGENT_ID,
+      orgId: ORG_ID,
+      deviceId: null,
+      model: 'claude-sonnet-4-5-20250929',
+      maxTurns: 40,
+    });
+
+    expect(result).toBe(EXISTING_SESSION_ID);
+
+    // The just-inserted orphan session was closed, not left dangling active.
+    const sessionClose = dbMockState.updates.find(
+      (u) => u.table === 'ai_sessions' && u.values.status === 'closed',
+    );
+    expect(sessionClose).toBeDefined();
+  });
+});
+
+describe('startToolExecution / completeToolExecution round-trip', () => {
+  it('inserts an executing row and returns its id, then completes it', async () => {
+    dbMockState.insertReturningQueues.ai_tool_executions = [[{ id: EXECUTION_ID }]];
+
+    const id = await startToolExecution({
+      sessionId: SESSION_ID,
+      toolName: 'get_device_details',
+      toolInput: { deviceId: DEVICE_ID },
+    });
+    expect(id).toBe(EXECUTION_ID);
+
+    const insertedValues = dbMockState.inserts[0]!.values;
+    expect(insertedValues).toMatchObject({
+      sessionId: SESSION_ID,
+      toolName: 'get_device_details',
+      toolInput: { deviceId: DEVICE_ID },
+      status: 'executing',
+    });
+    // Output is never written at start.
+    expect(insertedValues).not.toHaveProperty('toolOutput');
+
+    await completeToolExecution({ executionId: EXECUTION_ID, isError: false, durationMs: 120 });
+
+    const completion = dbMockState.updates.find((u) => u.table === 'ai_tool_executions');
+    expect(completion).toBeDefined();
+    expect(completion!.values).toMatchObject({ status: 'completed', durationMs: 120 });
+    expect(completion!.values.completedAt).toBeInstanceOf(Date);
+    // Tool output is deliberately never persisted (redaction lands in Part B).
+    expect(completion!.values).not.toHaveProperty('toolOutput');
+  });
+
+  it('marks a failed call with status failed', async () => {
+    await completeToolExecution({ executionId: EXECUTION_ID, isError: true, durationMs: 50 });
+    const completion = dbMockState.updates.find((u) => u.table === 'ai_tool_executions');
+    expect(completion!.values).toMatchObject({ status: 'failed', durationMs: 50 });
+  });
+});
+
+describe('reconcileHungExecutions', () => {
+  it('only touches in-flight (executing) rows of the given session', async () => {
+    dbMockState.updateReturningQueues.ai_tool_executions = [[{ id: EXECUTION_ID }, { id: 'exec-2' }]];
+
+    const count = await reconcileHungExecutions(SESSION_ID);
+
+    expect(count).toBe(2);
+    const update = dbMockState.updates.find((u) => u.table === 'ai_tool_executions');
+    expect(update!.values).toMatchObject({
+      status: 'failed',
+      errorMessage: 'run finished with execution unresolved',
+    });
+    const sql = compiled(update!.where);
+    expect(sql).toContain('session_id');
+    expect(sql).toContain('status');
+  });
+
+  it('returns 0 when nothing was in-flight', async () => {
+    dbMockState.updateReturningQueues.ai_tool_executions = [[]];
+    const count = await reconcileHungExecutions(SESSION_ID);
+    expect(count).toBe(0);
+  });
+});
+
+describe('closeAgentRunSession', () => {
+  it('closes the session for a completed run', async () => {
+    await closeAgentRunSession(SESSION_ID, 'completed');
+    const update = dbMockState.updates.find((u) => u.table === 'ai_sessions');
+    expect(update!.values).toMatchObject({ status: 'closed' });
+  });
+
+  it('closes the session for a failed run (same terminal DB state — no failed status on ai_sessions)', async () => {
+    await closeAgentRunSession(SESSION_ID, 'failed');
+    const update = dbMockState.updates.find((u) => u.table === 'ai_sessions');
+    expect(update!.values).toMatchObject({ status: 'closed' });
+  });
+});

--- a/apps/api/src/services/aiAgents/executionLedger.ts
+++ b/apps/api/src/services/aiAgents/executionLedger.ts
@@ -1,0 +1,204 @@
+/**
+ * The execution ledger (AI agents wave 4a, Task 1).
+ *
+ * Every agent run gets exactly one `ai_sessions` row (`type: 'agent'`), and
+ * every ALLOWED tool call within that run gets a real `ai_tool_executions`
+ * row — replacing the `'(inline)'` placeholder `runLoop.ts` has written since
+ * wave 3. This module is pure persistence: it has no opinion on whether a
+ * call was allowed. Authorization is decided entirely by
+ * `checkAgentGuardrails` before any of these functions are ever called — see
+ * `runLoop.ts`'s pre-tool-use hook. A ledger write failing must never block a
+ * tool call; the caller (Task 2) is responsible for treating these functions
+ * as best-effort.
+ *
+ * Tool OUTPUT is deliberately not persisted here: `ai_tool_executions.tool_output`
+ * stays NULL. Redaction rules for what is safe to store land with Part B's
+ * closed operation manifest — storing raw outputs now would put unredacted
+ * command results into a table with no redaction contract yet.
+ *
+ * All writes run in a SYSTEM db context (matching the pattern already used by
+ * `runService.transitionRunStatus`): `ai_tool_executions` has no `org_id` of
+ * its own (tenancy is derived through `session_id → ai_sessions`, registered
+ * as such in `rls-coverage.integration.test.ts`), so an ambient request
+ * context would be the wrong scope to write these rows under even when one is
+ * open, and the run loop generally holds none at all (see the DB-context note
+ * atop `runLoop.ts`).
+ */
+import { and, eq, isNull } from 'drizzle-orm';
+import {
+  db,
+  getCurrentDbAccessContext,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+} from '../../db';
+import { aiSessions, aiToolExecutions } from '../../db/schema/ai';
+import { aiAgentRuns } from '../../db/schema/aiAgents';
+
+/**
+ * Same skip-if-already-system shape as `runService.inSystemDbContext` /
+ * `runLoop.inSystemDbContext`: a bare system wrapper is a no-op inside an
+ * ambient request context (so exit first), and re-entering from an
+ * already-system context would take a SECOND pooled connection while the
+ * first is still held.
+ */
+function inSystemDbContext<T>(fn: () => Promise<T>): Promise<T> {
+  if (getCurrentDbAccessContext()?.scope === 'system') return fn();
+  return runOutsideDbContext(() => withSystemDbAccessContext(fn));
+}
+
+export interface CreateAgentRunSessionArgs {
+  runId: string;
+  agentId: string;
+  orgId: string;
+  deviceId: string | null;
+  model: string;
+  /** The run's policy-snapshot `maxTurnsPerRun`; `ai_sessions.max_turns` has no meaningful default for an agent run. */
+  maxTurns: number;
+}
+
+/**
+ * Creates the run's `ai_sessions` row and CAS-links it onto
+ * `ai_agent_runs.session_id` (`WHERE session_id IS NULL`).
+ *
+ * The CAS exists because a crashed run can be re-delivered by the queue
+ * (`executeAgentRun`'s own `transitionRunStatus(runId, 'queued', 'running')`
+ * CAS is the first line of defense, but a run already in `running` when the
+ * process died is re-entered by a reaper, not by that CAS) — a second call for
+ * the same run must not orphan a second session row. On a CAS miss the
+ * just-inserted session is immediately closed (nothing will ever write to it)
+ * and the run's EXISTING session id is returned instead, so ledger rows from
+ * this attempt land where a reviewer already expects them.
+ */
+export async function createAgentRunSession(args: CreateAgentRunSessionArgs): Promise<string> {
+  return inSystemDbContext(async () => {
+    const [inserted] = await db
+      .insert(aiSessions)
+      .values({
+        orgId: args.orgId,
+        deviceId: args.deviceId,
+        agentId: args.agentId,
+        type: 'agent',
+        model: args.model,
+        maxTurns: args.maxTurns,
+        status: 'active',
+      })
+      .returning({ id: aiSessions.id });
+    if (!inserted) throw new Error('createAgentRunSession: ai_sessions insert returned no row');
+    const sessionId = inserted.id;
+
+    const cas = await db
+      .update(aiAgentRuns)
+      .set({ sessionId })
+      .where(and(eq(aiAgentRuns.id, args.runId), isNull(aiAgentRuns.sessionId)))
+      .returning({ id: aiAgentRuns.id });
+
+    if (cas.length > 0) return sessionId;
+
+    console.warn('[executionLedger] session CAS missed — a session already exists for this run', {
+      runId: args.runId, orphanedSessionId: sessionId,
+    });
+
+    // ai_sessions has no terminal-outcome column (status is only
+    // 'active'|'closed'|'expired' — 2026-09-02 baseline). The orphan is simply
+    // closed, matching the existing close-on-done convention elsewhere in the
+    // codebase (e.g. routes/clientAi/sessions.ts).
+    await db.update(aiSessions).set({ status: 'closed' }).where(eq(aiSessions.id, sessionId));
+
+    const [existing] = await db
+      .select({ sessionId: aiAgentRuns.sessionId })
+      .from(aiAgentRuns)
+      .where(eq(aiAgentRuns.id, args.runId))
+      .limit(1);
+
+    if (!existing?.sessionId) {
+      // Unreachable barring a concurrent hard-delete of the run row: the CAS
+      // predicate `session_id IS NULL` returned zero rows, which means the
+      // column is non-null right now. Thrown loudly rather than silently
+      // falling back to the orphan, which would defeat the whole CAS.
+      throw new Error(
+        `createAgentRunSession: CAS miss for run ${args.runId} but no existing session id was found`,
+      );
+    }
+    return existing.sessionId;
+  });
+}
+
+export interface StartToolExecutionArgs {
+  sessionId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+}
+
+/** Inserts an in-flight `ai_tool_executions` row for an ALLOWED tool call. */
+export async function startToolExecution(args: StartToolExecutionArgs): Promise<string> {
+  return inSystemDbContext(async () => {
+    const [inserted] = await db
+      .insert(aiToolExecutions)
+      .values({
+        sessionId: args.sessionId,
+        toolName: args.toolName,
+        toolInput: args.toolInput,
+        status: 'executing',
+      })
+      .returning({ id: aiToolExecutions.id });
+    if (!inserted) throw new Error('startToolExecution: ai_tool_executions insert returned no row');
+    return inserted.id;
+  });
+}
+
+export interface CompleteToolExecutionArgs {
+  executionId: string;
+  isError: boolean;
+  durationMs: number;
+}
+
+/** Terminal-marks a tool-execution row. `tool_output` is deliberately never written — see module docstring. */
+export async function completeToolExecution(args: CompleteToolExecutionArgs): Promise<void> {
+  await inSystemDbContext(async () => {
+    await db
+      .update(aiToolExecutions)
+      .set({
+        status: args.isError ? 'failed' : 'completed',
+        durationMs: args.durationMs,
+        completedAt: new Date(),
+      })
+      .where(eq(aiToolExecutions.id, args.executionId));
+  });
+}
+
+/**
+ * Terminal-marks every execution still `executing` for this session. Called
+ * once at run finish so a process that died mid-tool-call (or a bug in the
+ * pre/post hook pairing) never leaves a row stuck in-flight forever. Returns
+ * the number of rows reconciled, for logging.
+ */
+export async function reconcileHungExecutions(sessionId: string): Promise<number> {
+  return inSystemDbContext(async () => {
+    const rows = await db
+      .update(aiToolExecutions)
+      .set({
+        status: 'failed',
+        errorMessage: 'run finished with execution unresolved',
+        completedAt: new Date(),
+      })
+      .where(and(eq(aiToolExecutions.sessionId, sessionId), eq(aiToolExecutions.status, 'executing')))
+      .returning({ id: aiToolExecutions.id });
+    return rows.length;
+  });
+}
+
+/**
+ * Closes the run's session. `status` reflects the RUN's outcome for callers
+ * and future logging, but `ai_sessions.status` only ever lands on `'closed'`
+ * here — the enum has no completed/failed distinction, and that distinction
+ * already lives durably on `ai_agent_runs.status`.
+ */
+export async function closeAgentRunSession(
+  sessionId: string,
+  status: 'completed' | 'failed',
+): Promise<void> {
+  console.info('[executionLedger] closing agent run session', { sessionId, runOutcome: status });
+  await inSystemDbContext(async () => {
+    await db.update(aiSessions).set({ status: 'closed' }).where(eq(aiSessions.id, sessionId));
+  });
+}

--- a/apps/api/src/services/aiAgents/redTeam.contract.test.ts
+++ b/apps/api/src/services/aiAgents/redTeam.contract.test.ts
@@ -570,6 +570,8 @@ describe('F. a device-less run never proposes', () => {
         outcome,
         intentIds,
         allowedPending,
+        sessionId: null,
+        executionIdPending: new Map(),
       });
 
       for (const toolName of Object.keys(TOOL_TIERS)) {
@@ -722,6 +724,8 @@ describe('I. the runner pre-hook never touches user RBAC', () => {
       outcome,
       intentIds,
       allowedPending,
+      sessionId: null,
+      executionIdPending: new Map(),
     });
 
     for (const toolName of Object.keys(TOOL_TIERS)) {
@@ -738,6 +742,8 @@ describe('I. the runner pre-hook never touches user RBAC', () => {
       outcome,
       intentIds,
       allowedPending,
+      sessionId: null,
+      executionIdPending: new Map(),
     });
     const hostileSystemPrompt = buildAgentRunSystemPrompt(hostilePromptContext());
     expect(hostileSystemPrompt).toContain('ignore the allowlist');
@@ -759,6 +765,8 @@ describe('I. the runner pre-hook never touches user RBAC', () => {
       outcome,
       intentIds,
       allowedPending,
+      sessionId: null,
+      executionIdPending: new Map(),
     });
     const callsBeforeExplicitProposal = createActionIntentMock.mock.calls.length;
     const proposed = await proposeHook('manage_services', { action: 'restart' });

--- a/apps/api/src/services/aiAgents/runFinishedNotify.test.ts
+++ b/apps/api/src/services/aiAgents/runFinishedNotify.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const RUN_ID = '00000000-0000-4000-8000-0000000000e1';
+const ORG_ID = '00000000-0000-4000-8000-0000000000e2';
+const AGENT_ID = '00000000-0000-4000-8000-0000000000e3';
+const PARTNER_ID = '00000000-0000-4000-8000-0000000000e4';
+const USER_A = '00000000-0000-4000-8000-0000000000e5';
+const USER_B = '00000000-0000-4000-8000-0000000000e6';
+const INTENT_ID = '00000000-0000-4000-8000-0000000000e7';
+
+// ---------------------------------------------------------------------------
+// db mock (same harness shape as runLoop.test.ts / runService.test.ts)
+// ---------------------------------------------------------------------------
+const dbMockState = vi.hoisted(() => ({
+  rowQueues: {} as Record<string, unknown[][]>,
+  ambientContext: undefined as { scope: string } | undefined,
+}));
+
+function nextRows(table: string): unknown[] {
+  const queue = dbMockState.rowQueues[table];
+  if (!queue || queue.length === 0) throw new Error(`No queued rows for table ${table}`);
+  return queue.shift() as unknown[];
+}
+
+vi.mock('../../db', () => {
+  const makeSelect = () => ({
+    from: vi.fn((table: unknown) => {
+      const tableName = String((table as Record<symbol, unknown>)[Symbol.for('drizzle:Name')]);
+      const builder: Record<string, unknown> = {
+        where: vi.fn(() => builder),
+        limit: vi.fn(() => builder),
+        then: (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+          Promise.resolve().then(() => nextRows(tableName)).then(resolve, reject),
+      };
+      return builder;
+    }),
+  });
+
+  return {
+    db: { select: vi.fn(() => makeSelect()) },
+    getCurrentDbAccessContext: vi.fn(() => dbMockState.ambientContext),
+    runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+      const previous = dbMockState.ambientContext;
+      dbMockState.ambientContext = { scope: 'system' };
+      try {
+        return await fn();
+      } finally {
+        dbMockState.ambientContext = previous;
+      }
+    }),
+  };
+});
+
+const resolveRecipientUserIds = vi.hoisted(() =>
+  vi.fn<(agent: unknown, orgId: string) => Promise<string[]>>());
+vi.mock('./recipients', () => ({ resolveRecipientUserIds }));
+
+const createNotification = vi.hoisted(() =>
+  vi.fn<(input: Record<string, unknown>) => Promise<string | null>>());
+vi.mock('../userNotifications', () => ({ createNotification }));
+
+import { deliverRunFinishedNotifications } from './runFinishedNotify';
+
+function queueRows(table: string, rows: unknown[]): void {
+  dbMockState.rowQueues[table] = dbMockState.rowQueues[table] ?? [];
+  dbMockState.rowQueues[table]!.push(rows);
+}
+
+const baseRun = {
+  id: RUN_ID,
+  orgId: ORG_ID,
+  agentId: AGENT_ID,
+  status: 'completed',
+  summary: 'Investigated the disk alert.\nFreed 12GB on C:.',
+  outcome: { toolExecutionCount: 2 },
+  intentIds: [] as string[],
+  policySnapshot: { effective: { recipients: { userIds: [], roleIds: [] } } },
+};
+
+const baseAgent = { id: AGENT_ID, orgId: ORG_ID, partnerId: PARTNER_ID, name: 'Front Desk Triage' };
+
+beforeEach(() => {
+  dbMockState.rowQueues = {};
+  dbMockState.ambientContext = undefined;
+  resolveRecipientUserIds.mockReset().mockResolvedValue([]);
+  createNotification.mockReset().mockResolvedValue('notification-1');
+});
+
+describe('deliverRunFinishedNotifications', () => {
+  it('creates one notification per resolved recipient with the structured metadata shape', async () => {
+    queueRows('ai_agent_runs', [baseRun]);
+    queueRows('ai_agents', [baseAgent]);
+    resolveRecipientUserIds.mockResolvedValue([USER_A, USER_B]);
+
+    await deliverRunFinishedNotifications(RUN_ID);
+
+    expect(createNotification).toHaveBeenCalledTimes(2);
+    expect(createNotification.mock.calls.map(([input]) => (input as { userId: string }).userId))
+      .toEqual([USER_A, USER_B]);
+    const [firstInput] = createNotification.mock.calls[0]!;
+    expect(firstInput).toMatchObject({
+      userId: USER_A,
+      orgId: ORG_ID,
+      type: 'ai',
+      title: 'Agent run finished',
+      message: 'Front Desk Triage: Investigated the disk alert.',
+      link: null,
+      dedupeKey: `agent-run:${RUN_ID}`,
+      metadata: {
+        runId: RUN_ID,
+        agentId: AGENT_ID,
+        intentIds: [],
+        status: 'completed',
+        executedActionCount: 2,
+        verdict: null,
+      },
+    });
+  });
+
+  it('links to /approvals only when the run left intents pending', async () => {
+    queueRows('ai_agent_runs', [{ ...baseRun, status: 'awaiting_approval', intentIds: [INTENT_ID] }]);
+    queueRows('ai_agents', [baseAgent]);
+    resolveRecipientUserIds.mockResolvedValue([USER_A]);
+
+    await deliverRunFinishedNotifications(RUN_ID);
+
+    const [input] = createNotification.mock.calls[0]!;
+    expect((input as { link: string | null }).link).toBe('/approvals');
+    expect((input as { metadata: { status: string } }).metadata.status).toBe('awaiting_approval');
+  });
+
+  it('resolves recipients from the run policy snapshot, not the agent row', async () => {
+    queueRows('ai_agent_runs', [{
+      ...baseRun,
+      policySnapshot: { effective: { recipients: { userIds: [USER_A, USER_B], roleIds: [] } } },
+    }]);
+    queueRows('ai_agents', [baseAgent]);
+    resolveRecipientUserIds.mockResolvedValue([USER_A, USER_B]);
+
+    await deliverRunFinishedNotifications(RUN_ID);
+
+    expect(resolveRecipientUserIds).toHaveBeenCalledWith(
+      { orgId: ORG_ID, partnerId: PARTNER_ID, recipients: { userIds: [USER_A, USER_B], roleIds: [] } },
+      ORG_ID,
+    );
+  });
+
+  it('is a silent no-op when the run no longer exists', async () => {
+    queueRows('ai_agent_runs', []);
+    await expect(deliverRunFinishedNotifications(RUN_ID)).resolves.toBeUndefined();
+    expect(resolveRecipientUserIds).not.toHaveBeenCalled();
+    expect(createNotification).not.toHaveBeenCalled();
+  });
+
+  it('is a silent no-op when the run is not (yet) in a terminal status', async () => {
+    queueRows('ai_agent_runs', [{ ...baseRun, status: 'running' }]);
+    queueRows('ai_agents', [baseAgent]);
+
+    await expect(deliverRunFinishedNotifications(RUN_ID)).resolves.toBeUndefined();
+
+    expect(resolveRecipientUserIds).not.toHaveBeenCalled();
+  });
+
+  it('is a silent no-op when zero recipients resolve', async () => {
+    queueRows('ai_agent_runs', [baseRun]);
+    queueRows('ai_agents', [baseAgent]);
+    resolveRecipientUserIds.mockResolvedValue([]);
+
+    await expect(deliverRunFinishedNotifications(RUN_ID)).resolves.toBeUndefined();
+
+    expect(createNotification).not.toHaveBeenCalled();
+  });
+
+  it('THROWS when recipient resolution fails — the caller decides retry policy', async () => {
+    queueRows('ai_agent_runs', [baseRun]);
+    queueRows('ai_agents', [baseAgent]);
+    resolveRecipientUserIds.mockRejectedValue(new Error('membership lookup failed'));
+
+    await expect(deliverRunFinishedNotifications(RUN_ID)).rejects.toThrow('membership lookup failed');
+  });
+
+  it('THROWS when a notification write fails', async () => {
+    queueRows('ai_agent_runs', [baseRun]);
+    queueRows('ai_agents', [baseAgent]);
+    resolveRecipientUserIds.mockResolvedValue([USER_A]);
+    createNotification.mockRejectedValue(new Error('notifications table unavailable'));
+
+    await expect(deliverRunFinishedNotifications(RUN_ID)).rejects.toThrow('notifications table unavailable');
+  });
+});

--- a/apps/api/src/services/aiAgents/runFinishedNotify.ts
+++ b/apps/api/src/services/aiAgents/runFinishedNotify.ts
@@ -1,0 +1,194 @@
+/**
+ * runFinishedNotify — the run-finished notification delivery body (AI agents
+ * wave 4a, Task 6, #3826).
+ *
+ * Pulled out of `runLoop.ts`'s old inline `notifyRunFinished` into its own
+ * leaf module for two reasons:
+ *
+ * 1. Both the normal in-loop path (`runLoop.ts`'s `finishRun`, immediately
+ *    after the run's terminal status CAS commits) and the durable BullMQ
+ *    retry lane (`jobs/agentNotifyRetryWorker.ts`) need to call the SAME
+ *    notify body by `runId` alone — the retry worker has no in-memory
+ *    `RunContext`, only the id its job payload carries, so it re-reads the
+ *    run + agent + policy snapshot from the DB fresh. The run row is
+ *    immutable by the time either caller reaches this: `finishRun`'s status
+ *    CAS has already committed.
+ * 2. `runLoop.ts`'s own header explicitly keeps BullMQ out of its module
+ *    graph ("so that the guardrail hooks it builds can be driven by
+ *    service-level tests ... without dragging BullMQ and Redis into their
+ *    module graph"). A module imported by BOTH `runLoop.ts` and the BullMQ
+ *    worker must itself stay BullMQ-free, or the two files become circular
+ *    imports of each other (the worker needs the notify body FROM the loop;
+ *    the loop needs the enqueue function FROM the worker). This module has
+ *    zero BullMQ/Redis dependency, which is also what keeps
+ *    `agentNotifyRetryWorker`'s import closure short enough to land
+ *    `placement: 'global'` in the worker registry (see
+ *    `workerEntrypointClosure.contract.test.ts`) instead of inheriting
+ *    `runLoop.ts`'s full SDK-tool `socket-owner` graph.
+ *
+ * Throws on ANY failure (DB read, recipient resolution, notification write)
+ * — deliberately, unlike the old inline `notifyRunFinished`, which caught
+ * everything itself. The two callers now own that decision differently:
+ * `finishRun` catches it and enqueues ONE durable retry job (a notify
+ * failure must never redefine the run's terminal status); the retry
+ * worker's job processor lets it propagate so BullMQ's own `attempts` +
+ * backoff (set at enqueue time) handles repeated failures — no manual
+ * re-enqueue loop here.
+ */
+import { eq } from 'drizzle-orm';
+import type { AiAgentPolicySnapshot } from '@breeze/shared';
+import {
+  db,
+  getCurrentDbAccessContext,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+} from '../../db';
+// Direct module imports, not the schema barrel — same note as runLoop.ts.
+import { aiAgents, aiAgentRuns } from '../../db/schema/aiAgents';
+import { createNotification } from '../userNotifications';
+import { resolveRecipientUserIds } from './recipients';
+
+/** The only statuses `finishRun` ever commits before calling this. A run
+ *  read back in any other status (e.g. a stale/duplicate retry-job delivery
+ *  racing an as-yet-uncommitted transition) has nothing to notify about yet. */
+const TERMINAL_STATUSES = new Set(['completed', 'awaiting_approval', 'failed']);
+
+interface FinishedRunRow {
+  id: string;
+  orgId: string;
+  agentId: string;
+  status: string;
+  summary: string | null;
+  outcome: Record<string, unknown>;
+  intentIds: string[];
+  policySnapshot: AiAgentPolicySnapshot;
+}
+
+interface NotifyAgentRow {
+  id: string;
+  orgId: string | null;
+  partnerId: string | null;
+  name: string;
+}
+
+/**
+ * Same skip-if-already-system shape as `runLoop.ts`'s own `inSystemDbContext`
+ * — duplicated rather than imported so this module's only DB dependency stays
+ * `../../db` itself (see the header comment on why this file must not import
+ * `runLoop.ts`).
+ */
+function inSystemDbContext<T>(fn: () => Promise<T>): Promise<T> {
+  if (getCurrentDbAccessContext()?.scope === 'system') return fn();
+  return runOutsideDbContext(() => withSystemDbAccessContext(fn));
+}
+
+async function loadFinishedRun(
+  runId: string,
+): Promise<{ run: FinishedRunRow; agent: NotifyAgentRow } | null> {
+  return inSystemDbContext(async () => {
+    const [run] = await db
+      .select({
+        id: aiAgentRuns.id,
+        orgId: aiAgentRuns.orgId,
+        agentId: aiAgentRuns.agentId,
+        status: aiAgentRuns.status,
+        summary: aiAgentRuns.summary,
+        outcome: aiAgentRuns.outcome,
+        intentIds: aiAgentRuns.intentIds,
+        policySnapshot: aiAgentRuns.policySnapshot,
+      })
+      .from(aiAgentRuns)
+      .where(eq(aiAgentRuns.id, runId))
+      .limit(1);
+    if (!run) return null;
+
+    const [agent] = await db
+      .select({
+        id: aiAgents.id,
+        orgId: aiAgents.orgId,
+        partnerId: aiAgents.partnerId,
+        name: aiAgents.name,
+      })
+      .from(aiAgents)
+      .where(eq(aiAgents.id, run.agentId))
+      .limit(1);
+    if (!agent) return null;
+
+    return { run: run as FinishedRunRow, agent: agent as NotifyAgentRow };
+  });
+}
+
+/**
+ * Delivers the "agent run finished" notification to every resolved recipient
+ * of the given run, re-reading the run/agent/policy snapshot from the DB.
+ *
+ * Silent (logged, not thrown) no-ops: the run or its agent no longer exists,
+ * the run is not (yet) in a terminal status, or zero recipients resolve —
+ * none of these are failures the durable retry lane exists for. Anything
+ * else THROWS; see the header comment for why callers must not swallow it
+ * inside this function.
+ */
+export async function deliverRunFinishedNotifications(runId: string): Promise<void> {
+  const loaded = await loadFinishedRun(runId);
+  if (!loaded) {
+    console.warn('[runFinishedNotify] run or its agent no longer exists — nothing to notify', { runId });
+    return;
+  }
+  const { run, agent } = loaded;
+
+  if (!TERMINAL_STATUSES.has(run.status)) {
+    console.warn('[runFinishedNotify] run is not (yet) in a terminal status — skipping', {
+      runId, status: run.status,
+    });
+    return;
+  }
+
+  // The run's immutable snapshot, NOT the agent row's raw `recipients`
+  // column — see `mergeAgentPolicies`/`resolveRecipientUserIds` for why the
+  // merged, RUN-org-derived set is the correct input (the agent row loaded
+  // by `run.agent_id` is always the PARTNER BASELINE and silently drops any
+  // recipient an organization added through its own override).
+  const userIds = await resolveRecipientUserIds(
+    {
+      orgId: agent.orgId,
+      partnerId: agent.partnerId,
+      recipients: run.policySnapshot.effective.recipients,
+    },
+    run.orgId,
+  );
+  if (userIds.length === 0) {
+    console.warn('[runFinishedNotify] no recipients resolved for finished run', { runId });
+    return;
+  }
+
+  const firstLine = (run.summary ?? '').split('\n')[0]?.trim() ?? '';
+  const executedActionCount =
+    typeof run.outcome?.toolExecutionCount === 'number' ? (run.outcome.toolExecutionCount as number) : 0;
+
+  // AFTER the status commit and outside any held transaction (#1105).
+  await inSystemDbContext(async () => {
+    for (const userId of userIds) {
+      await createNotification({
+        userId,
+        orgId: run.orgId,
+        type: 'ai',
+        title: 'Agent run finished',
+        message: `${agent.name}: ${firstLine || run.status}`,
+        // There is no run-detail page until wave 6; link to the approvals
+        // queue only when there is actually something waiting there.
+        link: run.intentIds.length > 0 ? '/approvals' : null,
+        metadata: {
+          runId: run.id,
+          agentId: agent.id,
+          intentIds: run.intentIds,
+          status: run.status,
+          executedActionCount,
+          // Part B fills this in with the verification verdict; nothing
+          // populates it yet.
+          verdict: null,
+        },
+        dedupeKey: `agent-run:${run.id}`,
+      });
+    }
+  });
+}

--- a/apps/api/src/services/aiAgents/runLoop.test.ts
+++ b/apps/api/src/services/aiAgents/runLoop.test.ts
@@ -31,15 +31,58 @@ interface Hooks {
 // ---------------------------------------------------------------------------
 const dbMockState = vi.hoisted(() => ({
   rowQueues: {} as Record<string, unknown[][]>,
+  // The most recently shifted row for a table, keyed by table name — lets
+  // `nextRows` synthesize a SECOND read below (wave 4a Task 6, #3826:
+  // `deliverRunFinishedNotifications` re-reads `ai_agent_runs`/`ai_agents`
+  // from `finishRun`, after `seedRows()`'s one queued row-set for each has
+  // already been consumed by the loop's own initial `loadRunContext`).
+  lastRow: {} as Record<string, unknown>,
   selects: [] as Array<{ table: string; where?: SQL }>,
   systemContextDepth: 0,
   ambientContext: undefined as { scope: string } | undefined,
 }));
 
+/**
+ * `ai_agent_runs`/`ai_agents` are read TWICE per completed run under real
+ * code: once by `loadRunContext` at the top of `executeAgentRun`, and again
+ * by `deliverRunFinishedNotifications` inside `finishRun` (Task 6). Only the
+ * first read is ever explicitly queued (`seedRows()`); rather than force
+ * every existing test to queue an identical second copy, a table that runs
+ * dry synthesizes its second read from what it already knows:
+ *  - `ai_agents`: the agent row never changes mid-run — reuse the last one.
+ *  - `ai_agent_runs`: overlay the LAST `transitionRunStatus` call's
+ *    `to`/`patch` (status, summary, outcome, intentIds) onto the seeded row,
+ *    since `transitionRunStatus` is mocked and never actually mutates it —
+ *    this is what makes the synthesized re-read reflect the run's real
+ *    terminal outcome instead of the stale pre-run seed.
+ * Every OTHER table still throws on a second, un-queued read (unchanged
+ * strictness) — only these two are ever legitimately read twice.
+ */
 function nextRows(table: string): unknown[] {
   const queue = dbMockState.rowQueues[table];
-  if (!queue || queue.length === 0) throw new Error(`No queued rows for table ${table}`);
-  return queue.shift() as unknown[];
+  if (queue && queue.length > 0) {
+    const rows = queue.shift() as unknown[];
+    if (rows.length > 0) dbMockState.lastRow[table] = rows[0];
+    return rows;
+  }
+  if (table === 'ai_agent_runs' && dbMockState.lastRow.ai_agent_runs) {
+    const base = dbMockState.lastRow.ai_agent_runs as Record<string, unknown>;
+    const calls = transitionRunStatus.mock.calls;
+    const last = calls[calls.length - 1];
+    if (!last) return [base];
+    const patch = (last[3] ?? {}) as Record<string, unknown>;
+    return [{
+      ...base,
+      status: last[2],
+      summary: (patch.summary as string | null | undefined) ?? null,
+      outcome: patch.outcome ?? {},
+      intentIds: patch.intentIds ?? [],
+    }];
+  }
+  if (table === 'ai_agents' && dbMockState.lastRow.ai_agents) {
+    return [dbMockState.lastRow.ai_agents];
+  }
+  throw new Error(`No queued rows for table ${table}`);
 }
 
 vi.mock('../../db', () => {
@@ -136,6 +179,16 @@ vi.mock('./recipients', () => ({ resolveRecipientUserIds }));
 const createNotification = vi.hoisted(() =>
   vi.fn<(input: Record<string, unknown>) => Promise<string | null>>(async () => 'notification-1'));
 vi.mock('../userNotifications', () => ({ createNotification }));
+
+// `deliverRunFinishedNotifications` (Task 6) lives in `./runFinishedNotify`,
+// NOT this file — it resolves `./recipients`/`../userNotifications` from the
+// SAME directory as runLoop.ts, so the two mocks above still intercept its
+// calls even though it's a different module making them (Vitest mocks by
+// resolved module path, not by importer). Only the retry-enqueue side needs
+// its own mock here.
+const enqueueAgentNotifyRetry = vi.hoisted(() =>
+  vi.fn<(runId: string) => Promise<void>>(async () => undefined));
+vi.mock('../../jobs/agentNotifyRetryWorker', () => ({ enqueueAgentNotifyRetry }));
 
 const resolveLlmConfigForOrg = vi.hoisted(() =>
   vi.fn<(orgId: string) => Promise<{ source: string; apiKey?: string; model: string }>>());
@@ -308,6 +361,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.stubEnv('BREEZE_AI_AGENTS_ENABLED', 'true');
   dbMockState.rowQueues = {};
+  dbMockState.lastRow = {};
   dbMockState.selects.length = 0;
   dbMockState.systemContextDepth = 0;
   dbMockState.ambientContext = undefined;
@@ -323,6 +377,7 @@ beforeEach(() => {
   closeAgentRunSession.mockResolvedValue(undefined);
   resolveLlmConfigForOrg.mockResolvedValue({ source: 'platform', apiKey: 'sk-test', model: 'claude-fallback' });
   resolveRecipientUserIds.mockResolvedValue([]);
+  enqueueAgentNotifyRetry.mockResolvedValue(undefined);
   createActionIntent.mockResolvedValue({ id: INTENT_ID, status: 'pending_approval' });
   createBreezeMcpServer.mockImplementation((getAuth: () => unknown, pre: Hooks['pre'], post: Hooks['post']) => {
     hooks.getAuth = getAuth;
@@ -607,6 +662,34 @@ describe('executeAgentRun', () => {
     }
     expect(createNotification.mock.calls.map(([i]) => (i as { userId: string }).userId))
       .toEqual([USER_A, USER_B]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Durable notify retry lane (wave 4a, Task 6)
+  // -------------------------------------------------------------------------
+
+  it('a notify failure enqueues exactly one durable retry job and does not fail the run', async () => {
+    seedRows({ recipients: { userIds: [], roleIds: [] } });
+    resolveRecipientUserIds.mockResolvedValue([USER_A]);
+    createNotification.mockRejectedValueOnce(new Error('notifications db down'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await executeAgentRun(RUN_ID);
+
+    expect(enqueueAgentNotifyRetry).toHaveBeenCalledTimes(1);
+    expect(enqueueAgentNotifyRetry).toHaveBeenCalledWith(RUN_ID);
+    // The notify failure must never redefine the run's own terminal status —
+    // it already committed 'completed' before notify ran at all.
+    expect(finalTransition()!.to).toBe('completed');
+  });
+
+  it('a normal successful notify never enqueues a retry job', async () => {
+    seedRows();
+    resolveRecipientUserIds.mockResolvedValue([USER_A]);
+
+    await executeAgentRun(RUN_ID);
+
+    expect(enqueueAgentNotifyRetry).not.toHaveBeenCalled();
   });
 
   it('builds the agent AuthContext from the RUN row, pinned to the device site', async () => {

--- a/apps/api/src/services/aiAgents/runLoop.test.ts
+++ b/apps/api/src/services/aiAgents/runLoop.test.ts
@@ -86,6 +86,24 @@ const transitionRunStatus = vi.hoisted(() =>
   ) => Promise<boolean>>());
 vi.mock('./runService', () => ({ transitionRunStatus }));
 
+const createAgentRunSession = vi.hoisted(() =>
+  vi.fn<(args: Record<string, unknown>) => Promise<string>>());
+const startToolExecution = vi.hoisted(() =>
+  vi.fn<(args: Record<string, unknown>) => Promise<string>>());
+const completeToolExecution = vi.hoisted(() =>
+  vi.fn<(args: Record<string, unknown>) => Promise<void>>());
+const reconcileHungExecutions = vi.hoisted(() =>
+  vi.fn<(sessionId: string) => Promise<number>>());
+const closeAgentRunSession = vi.hoisted(() =>
+  vi.fn<(sessionId: string, status: 'completed' | 'failed') => Promise<void>>());
+vi.mock('./executionLedger', () => ({
+  createAgentRunSession,
+  startToolExecution,
+  completeToolExecution,
+  reconcileHungExecutions,
+  closeAgentRunSession,
+}));
+
 const resolveEffectiveAgentSystem = vi.hoisted(() =>
   vi.fn<(orgId: string, kind: string) => Promise<AiAgentPolicySnapshot | null>>());
 vi.mock('./effectivePolicy', () => ({ resolveEffectiveAgentSystem }));
@@ -297,6 +315,12 @@ beforeEach(() => {
   preVerdicts.length = 0;
   lastQueryOptions = undefined;
   transitionRunStatus.mockResolvedValue(true);
+  let execCounter = 0;
+  createAgentRunSession.mockResolvedValue('session-1');
+  startToolExecution.mockImplementation(async () => `exec-${++execCounter}`);
+  completeToolExecution.mockResolvedValue(undefined);
+  reconcileHungExecutions.mockResolvedValue(0);
+  closeAgentRunSession.mockResolvedValue(undefined);
   resolveLlmConfigForOrg.mockResolvedValue({ source: 'platform', apiKey: 'sk-test', model: 'claude-fallback' });
   resolveRecipientUserIds.mockResolvedValue([]);
   createActionIntent.mockResolvedValue({ id: INTENT_ID, status: 'pending_approval' });
@@ -847,6 +871,130 @@ describe('executeAgentRun', () => {
     await executeAgentRun(RUN_ID);
 
     expect(finalTransition()!.to).toBe('completed');
+  });
+
+  // -------------------------------------------------------------------------
+  // Execution ledger wiring (wave 4a, Task 2)
+  // -------------------------------------------------------------------------
+
+  it('creates exactly one execution-ledger session per run, with the snapshot model + turn ceiling', async () => {
+    seedRows({
+      effective: policy({ model: 'claude-agent-model', limits: { ...AI_AGENT_LIMIT_DEFAULTS, maxTurnsPerRun: 9 } as AiAgentLimits }),
+    });
+
+    await executeAgentRun(RUN_ID);
+
+    expect(createAgentRunSession).toHaveBeenCalledTimes(1);
+    expect(createAgentRunSession).toHaveBeenCalledWith(expect.objectContaining({
+      runId: RUN_ID,
+      agentId: AGENT_ID,
+      orgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      model: 'claude-agent-model',
+      maxTurns: 9,
+    }));
+  });
+
+  it('falls back to the resolved LLM model when the snapshot has none', async () => {
+    seedRows({ effective: policy({ model: null }) });
+
+    await executeAgentRun(RUN_ID);
+
+    expect(createAgentRunSession).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'claude-fallback' }),
+    );
+  });
+
+  it('an allowed tool call gets a real ledger execution id, threaded onto the outcome', async () => {
+    seedRows();
+    scriptQuery({
+      toolCalls: [{ tool: 'query_devices', input: { status: 'online' } }],
+      assistantText: 'done',
+    });
+
+    await executeAgentRun(RUN_ID);
+
+    expect(startToolExecution).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-1',
+      toolName: 'query_devices',
+      toolInput: { status: 'online' },
+    }));
+    expect(completeToolExecution).toHaveBeenCalledWith(expect.objectContaining({
+      executionId: 'exec-1',
+      isError: false,
+      durationMs: 5,
+    }));
+
+    const final = finalTransition()!;
+    const outcome = final.patch.outcome as { executedActions: Array<{ executionId: string }> };
+    expect(outcome.executedActions[0]!.executionId).toBe('exec-1');
+  });
+
+  it('a ledger write failure never blocks the tool call — falls back to (inline)', async () => {
+    seedRows();
+    startToolExecution.mockRejectedValueOnce(new Error('db unavailable'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    scriptQuery({
+      toolCalls: [{ tool: 'query_devices', input: { status: 'online' } }],
+      assistantText: 'done',
+    });
+
+    await executeAgentRun(RUN_ID);
+
+    // The gate still allowed the call — the ledger write is observability
+    // only, never authorization.
+    expect(preVerdicts[0]).toEqual({ allowed: true });
+    expect(completeToolExecution).not.toHaveBeenCalled();
+
+    const final = finalTransition()!;
+    expect(final.to).toBe('completed');
+    const outcome = final.patch.outcome as { executedActions: Array<{ executionId: string; result: string }> };
+    expect(outcome.executedActions[0]).toMatchObject({ executionId: '(inline)', result: 'ok' });
+  });
+
+  it('reconciles hung executions and closes the session on finish', async () => {
+    seedRows();
+
+    await executeAgentRun(RUN_ID);
+
+    expect(reconcileHungExecutions).toHaveBeenCalledWith('session-1');
+    expect(closeAgentRunSession).toHaveBeenCalledWith('session-1', 'completed');
+  });
+
+  it('closes the session as failed when the run itself fails', async () => {
+    seedRows();
+    scriptQuery({
+      results: [resultMessage({ subtype: 'error_during_execution', is_error: true, result: undefined, errors: ['boom'] })],
+    });
+
+    await executeAgentRun(RUN_ID);
+
+    expect(finalTransition()!.to).toBe('failed');
+    expect(closeAgentRunSession).toHaveBeenCalledWith('session-1', 'failed');
+  });
+
+  it('a denied call never reaches the ledger — no execution row is started', async () => {
+    seedRows({ effective: policy({ toolAllowlist: [] }) });
+    scriptQuery({
+      toolCalls: [{ tool: 'manage_services', input: { action: 'restart', deviceId: DEVICE_ID, serviceName: 'Spooler' } }],
+      assistantText: 'denied',
+    });
+
+    await executeAgentRun(RUN_ID);
+
+    expect(startToolExecution).not.toHaveBeenCalled();
+  });
+
+  it('a proposed (shadow) call never reaches the ledger — no execution row is started', async () => {
+    seedRows({ effective: policy({ toolAllowlist: ['manage_services'] }) });
+    scriptQuery({
+      toolCalls: [{ tool: 'manage_services', input: { action: 'restart', deviceId: DEVICE_ID, serviceName: 'Spooler' } }],
+      assistantText: 'proposed',
+    });
+
+    await executeAgentRun(RUN_ID);
+
+    expect(startToolExecution).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/aiAgents/runLoop.test.ts
+++ b/apps/api/src/services/aiAgents/runLoop.test.ts
@@ -973,6 +973,36 @@ describe('executeAgentRun', () => {
     expect(closeAgentRunSession).toHaveBeenCalledWith('session-1', 'failed');
   });
 
+  it('still reconciles and closes the session when finishRun loses the CAS (!moved)', async () => {
+    seedRows();
+    // First call is the queued->running CAS (must succeed so a session gets
+    // created); the second is finishRun's running->completed CAS, which loses
+    // to a competing executor (or reapStalledAgentRuns) here.
+    transitionRunStatus.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await executeAgentRun(RUN_ID);
+
+    expect(transitionRunStatus).toHaveBeenCalledTimes(2);
+    expect(reconcileHungExecutions).toHaveBeenCalledWith('session-1');
+    expect(closeAgentRunSession).toHaveBeenCalledWith('session-1', 'completed');
+  });
+
+  it('still reconciles and closes the session when something throws after session creation', async () => {
+    seedRows();
+    createBreezeMcpServer.mockImplementationOnce(() => {
+      throw new Error('boom — mcp server construction failed');
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await executeAgentRun(RUN_ID);
+
+    // The run still ends up `failed` via executeAgentRun's outer catch, and
+    // the session created just before the throw is still cleaned up.
+    expect(finalTransition()!.to).toBe('failed');
+    expect(reconcileHungExecutions).toHaveBeenCalledWith('session-1');
+    expect(closeAgentRunSession).toHaveBeenCalledWith('session-1', 'failed');
+  });
+
   it('a denied call never reaches the ledger — no execution row is started', async () => {
     seedRows({ effective: policy({ toolAllowlist: [] }) });
     scriptQuery({

--- a/apps/api/src/services/aiAgents/runLoop.ts
+++ b/apps/api/src/services/aiAgents/runLoop.ts
@@ -78,6 +78,13 @@ import { createNotification } from '../userNotifications';
 import type { AuthContext } from '../../middleware/auth';
 import { AgentRunOwnershipError, buildAgentAuthContext } from './agentAuthContext';
 import { resolveEffectiveAgentSystem } from './effectivePolicy';
+import {
+  closeAgentRunSession,
+  completeToolExecution,
+  createAgentRunSession,
+  reconcileHungExecutions,
+  startToolExecution,
+} from './executionLedger';
 import { resolveRecipientUserIds } from './recipients';
 import { transitionRunStatus } from './runService';
 import {
@@ -122,9 +129,13 @@ export interface OutcomeExecutedAction {
   tool: string;
   action?: string;
   /**
-   * '(inline)' for wave 3: an agent tool call executes inside the MCP handler
-   * and has no `ai_tool_executions` row of its own yet (that ledger is written
-   * by the chat session path). Wave 6's transcript work gives these real ids.
+   * The real `ai_tool_executions` row id (wave 4a's execution ledger), or
+   * `'(inline)'` when the ledger write itself failed — a ledger failure must
+   * never block the tool call, so the call still executes and is recorded
+   * with the placeholder id (see `executionLedger.ts` and the pre/post hooks
+   * below). Correlation between the pre and post hook is per-tool FIFO order
+   * (same assumption `allowedPending` already made) — genuine per-invocation
+   * ids need SDK hook support the loop doesn't have yet.
    */
   executionId: string;
   result: 'ok' | 'failed';
@@ -188,6 +199,14 @@ interface RunContext {
   orgPartnerId: string;
   device: { id: string; siteId: string; hostname: string; osType: string } | null;
   alert: { title: string; severity: string; message: string | null } | null;
+  /**
+   * The execution-ledger `ai_sessions` row for this run (Task 1/2). Set once,
+   * inside `driveSdkLoop`, right after the model is resolved — `null` until
+   * then, and stays `null` for the lifetime of the run if session creation
+   * itself failed (a best-effort write: see `driveSdkLoop`). `finishRun` reads
+   * it back to reconcile/close the session.
+   */
+  sessionId: string | null;
 }
 
 /**
@@ -301,7 +320,14 @@ async function loadRunContext(runId: string): Promise<RunContext | null> {
       }
     }
 
-    return { run: run as RunRow, agent: agent as AgentRow, orgPartnerId: org.partnerId, device, alert };
+    return {
+      run: run as RunRow,
+      agent: agent as AgentRow,
+      orgPartnerId: org.partnerId,
+      device,
+      alert,
+      sessionId: null,
+    };
   });
 }
 
@@ -326,8 +352,19 @@ export function createAgentRunPreToolUse(args: {
   intentIds: string[];
   /** Per-tool count of calls the gate ALLOWED, consumed by the post hook. */
   allowedPending: Map<string, number>;
+  /** The run's execution-ledger session, or `null` if session creation itself failed. */
+  sessionId: string | null;
+  /**
+   * Per-tool FIFO of `ai_tool_executions` ids (or `null` sentinels for a
+   * failed/skipped ledger write), shifted by the post hook. Same ordering
+   * assumption as `allowedPending`.
+   */
+  executionIdPending: Map<string, Array<string | null>>;
 }): PreToolUseCallback {
-  const { run, agentName, agentAuth, guardrailPolicy, outcome, intentIds, allowedPending } = args;
+  const {
+    run, agentName, agentAuth, guardrailPolicy, outcome, intentIds, allowedPending, sessionId,
+    executionIdPending,
+  } = args;
 
   return async (toolName, input) => {
     const check = checkAgentGuardrails(toolName, input, guardrailPolicy);
@@ -401,6 +438,27 @@ export function createAgentRunPreToolUse(args: {
     }
 
     allowedPending.set(toolName, (allowedPending.get(toolName) ?? 0) + 1);
+
+    // Ledger write is best-effort: the tool call is already decided ALLOWED
+    // above, and a failure here must never turn that into a denial. A failed
+    // (or skipped, when the session itself never got created) write pushes a
+    // `null` sentinel so the post hook's FIFO stays aligned with the calls
+    // that actually happened.
+    let executionId: string | null = null;
+    if (sessionId) {
+      try {
+        executionId = await startToolExecution({ sessionId, toolName, toolInput: input });
+      } catch (error) {
+        console.error('[aiAgentRunLoop] execution-ledger write failed — tool call still executes', {
+          runId: run.id, toolName, error,
+        });
+        executionId = null;
+      }
+    }
+    const pending = executionIdPending.get(toolName) ?? [];
+    pending.push(executionId);
+    executionIdPending.set(toolName, pending);
+
     return { allowed: true };
   };
 }
@@ -414,19 +472,35 @@ export function createAgentRunPreToolUse(args: {
 export function createAgentRunPostToolUse(args: {
   outcome: AgentRunOutcome;
   allowedPending: Map<string, number>;
+  executionIdPending: Map<string, Array<string | null>>;
 }): PostToolUseCallback {
-  const { outcome, allowedPending } = args;
+  const { outcome, allowedPending, executionIdPending } = args;
 
   return async (toolName, input, _output, isError, durationMs) => {
     const remaining = allowedPending.get(toolName) ?? 0;
     if (remaining <= 0) return;
     allowedPending.set(toolName, remaining - 1);
 
+    let executionId: string | null = null;
+    const pending = executionIdPending.get(toolName);
+    if (pending && pending.length > 0) {
+      executionId = pending.shift() ?? null;
+    }
+    if (executionId) {
+      try {
+        await completeToolExecution({ executionId, isError, durationMs });
+      } catch (error) {
+        console.error('[aiAgentRunLoop] failed to complete execution-ledger row (non-fatal)', {
+          toolName, executionId, error,
+        });
+      }
+    }
+
     const action = readToolAction(toolName, input);
     outcome.executedActions.push({
       tool: toolName,
       ...(action ? { action } : {}),
-      executionId: '(inline)',
+      executionId: executionId ?? '(inline)',
       result: isError ? 'failed' : 'ok',
       durationMs,
     });
@@ -636,6 +710,30 @@ async function driveSdkLoop(ctx: RunContext, effective: AiAgentPolicy): Promise<
     { id: run.orgId, partnerId: ctx.orgPartnerId },
   );
 
+  // Execution-ledger session: created here — AFTER the ownership check above
+  // can no longer throw, so an ownership_mismatch failure never leaks an
+  // orphaned `active` session row nothing will ever close (that failure path
+  // returns straight to `executeAgentRun`'s catch block, not `finishRun`).
+  // Stored on `ctx` so `finishRun` can reconcile and close it once the loop
+  // below is done. Best-effort: a failure here must not fail the run — it
+  // just means every tool call below skips its ledger row (see the pre-hook's
+  // `sessionId` guard) and falls back to the `'(inline)'` executionId, same as
+  // before wave 4a.
+  try {
+    ctx.sessionId = await createAgentRunSession({
+      runId: run.id,
+      agentId: ctx.agent.id,
+      orgId: run.orgId,
+      deviceId: run.deviceId,
+      model,
+      maxTurns: Math.max(1, limits.maxTurnsPerRun),
+    });
+  } catch (error) {
+    console.error('[aiAgentRunLoop] failed to create the execution-ledger session', {
+      runId: run.id, error,
+    });
+  }
+
   const outcome: AgentRunOutcome = {
     findings: [],
     proposedActions: [],
@@ -645,11 +743,13 @@ async function driveSdkLoop(ctx: RunContext, effective: AiAgentPolicy): Promise<
   };
   const intentIds: string[] = [];
   const allowedPending = new Map<string, number>();
+  const executionIdPending = new Map<string, Array<string | null>>();
 
   const preToolUse = createAgentRunPreToolUse({
     run, agentName: ctx.agent.name, agentAuth, guardrailPolicy, outcome, intentIds, allowedPending,
+    sessionId: ctx.sessionId, executionIdPending,
   });
-  const postToolUse = createAgentRunPostToolUse({ outcome, allowedPending });
+  const postToolUse = createAgentRunPostToolUse({ outcome, allowedPending, executionIdPending });
 
   // No getActiveSession: a headless run has no ActiveSession, and the
   // session-aware tools (M365/Google) correctly refuse without one.
@@ -966,6 +1066,34 @@ async function finishRun(
     costCents: result.costCents,
     ...(errorCode ? { errorCode } : {}),
   });
+
+  // Ledger cleanup — best-effort, and never allowed to change the run's
+  // already-committed terminal status above. `completed`/`awaiting_approval`
+  // both close the session as `completed` (a human owning the follow-up on an
+  // awaiting_approval run is not the SESSION continuing — the agent is done
+  // thinking); anything else is `failed`.
+  if (ctx.sessionId) {
+    const sessionId = ctx.sessionId;
+    try {
+      const hungCount = await reconcileHungExecutions(sessionId);
+      if (hungCount > 0) {
+        console.warn('[aiAgentRunLoop] reconciled tool executions left in-flight at run finish', {
+          runId: ctx.run.id, sessionId, hungCount,
+        });
+      }
+    } catch (error) {
+      console.error('[aiAgentRunLoop] failed to reconcile hung executions (non-fatal)', {
+        runId: ctx.run.id, sessionId, error,
+      });
+    }
+    try {
+      await closeAgentRunSession(sessionId, status === 'failed' ? 'failed' : 'completed');
+    } catch (error) {
+      console.error('[aiAgentRunLoop] failed to close the execution-ledger session (non-fatal)', {
+        runId: ctx.run.id, sessionId, error,
+      });
+    }
+  }
 
   await notifyRunFinished(ctx, {
     status,

--- a/apps/api/src/services/aiAgents/runLoop.ts
+++ b/apps/api/src/services/aiAgents/runLoop.ts
@@ -972,6 +972,11 @@ export async function executeAgentRun(runId: string): Promise<void> {
 
   const effective = run.policySnapshot.effective;
 
+  // Tracks what to log the ledger session as closing under (see
+  // `cleanupExecutionLedger`) — defaults to 'failed' so a throw anywhere below,
+  // including one before this is ever reassigned, closes it correctly.
+  let ledgerOutcome: 'completed' | 'failed' = 'failed';
+
   try {
     const result = await driveSdkLoop(ctx, effective);
     const { outcome, intentIds } = result;
@@ -1008,6 +1013,7 @@ export async function executeAgentRun(runId: string): Promise<void> {
     // Awaiting approval is a REAL terminal-ish state for the run: the agent is
     // done thinking and a human now owns the decision. Release of an approved
     // intent is 3b's machinery, not a continuation of this run.
+    ledgerOutcome = 'completed';
     await finishRun(ctx, intentIds.length > 0 ? 'awaiting_approval' : 'completed', null, result);
   } catch (error) {
     const errorCode = error instanceof AgentRunError
@@ -1025,6 +1031,13 @@ export async function executeAgentRun(runId: string): Promise<void> {
         runId, agentId: run.agentId, errorCode,
       });
     }
+  } finally {
+    // Fires on every path that got far enough to create a session — the
+    // normal finish, the `!moved` early return inside `finishRun`, AND a throw
+    // between session creation and `finishRun` (see `cleanupExecutionLedger`'s
+    // docstring). A crashed process (SIGKILL) is the one path this cannot
+    // cover; `reapStalledAgentRuns` (`runService.ts`) covers that one instead.
+    await cleanupExecutionLedger(ctx, ledgerOutcome);
   }
 }
 
@@ -1067,39 +1080,59 @@ async function finishRun(
     ...(errorCode ? { errorCode } : {}),
   });
 
-  // Ledger cleanup — best-effort, and never allowed to change the run's
-  // already-committed terminal status above. `completed`/`awaiting_approval`
-  // both close the session as `completed` (a human owning the follow-up on an
-  // awaiting_approval run is not the SESSION continuing — the agent is done
-  // thinking); anything else is `failed`.
-  if (ctx.sessionId) {
-    const sessionId = ctx.sessionId;
-    try {
-      const hungCount = await reconcileHungExecutions(sessionId);
-      if (hungCount > 0) {
-        console.warn('[aiAgentRunLoop] reconciled tool executions left in-flight at run finish', {
-          runId: ctx.run.id, sessionId, hungCount,
-        });
-      }
-    } catch (error) {
-      console.error('[aiAgentRunLoop] failed to reconcile hung executions (non-fatal)', {
-        runId: ctx.run.id, sessionId, error,
-      });
-    }
-    try {
-      await closeAgentRunSession(sessionId, status === 'failed' ? 'failed' : 'completed');
-    } catch (error) {
-      console.error('[aiAgentRunLoop] failed to close the execution-ledger session (non-fatal)', {
-        runId: ctx.run.id, sessionId, error,
-      });
-    }
-  }
+  // Ledger cleanup happens in `executeAgentRun`'s `finally`, not here — this
+  // function is skipped entirely on the `!moved` branch above (another
+  // executor or `reapStalledAgentRuns` already owns this run), which is
+  // exactly the case the ledger cleanup exists for. See the note there.
 
   await notifyRunFinished(ctx, {
     status,
     summary: result.summary,
     intentIds: result.intentIds,
   });
+}
+
+/**
+ * Best-effort execution-ledger cleanup, called from `executeAgentRun`'s
+ * `finally` so it fires on EVERY path out of a run that got as far as
+ * creating a session — not just the happy in-process finish. Covers:
+ *  - `finishRun`'s `!moved` branch (another executor, or `reapStalledAgentRuns`,
+ *    already transitioned this run out of `running`);
+ *  - a throw between session creation and `finishRun` (e.g. `createBreezeMcpServer`
+ *    or `transitionRunStatus` itself throwing), caught by `executeAgentRun`'s
+ *    own catch block;
+ *  - the normal path, where `finishRun` already committed the terminal status.
+ *
+ * `outcome` only distinguishes 'completed'/'failed' for `closeAgentRunSession`'s
+ * log line — the same two-way collapse `finishRun` used to do inline
+ * (`awaiting_approval` reads as 'completed': the agent is done thinking either
+ * way, a human owning the follow-up is not the session continuing).
+ */
+async function cleanupExecutionLedger(
+  ctx: RunContext,
+  outcome: 'completed' | 'failed',
+): Promise<void> {
+  if (!ctx.sessionId) return;
+  const sessionId = ctx.sessionId;
+  try {
+    const hungCount = await reconcileHungExecutions(sessionId);
+    if (hungCount > 0) {
+      console.warn('[aiAgentRunLoop] reconciled tool executions left in-flight at run finish', {
+        runId: ctx.run.id, sessionId, hungCount,
+      });
+    }
+  } catch (error) {
+    console.error('[aiAgentRunLoop] failed to reconcile hung executions (non-fatal)', {
+      runId: ctx.run.id, sessionId, error,
+    });
+  }
+  try {
+    await closeAgentRunSession(sessionId, outcome);
+  } catch (error) {
+    console.error('[aiAgentRunLoop] failed to close the execution-ledger session (non-fatal)', {
+      runId: ctx.run.id, sessionId, error,
+    });
+  }
 }
 
 /**

--- a/apps/api/src/services/aiAgents/runLoop.ts
+++ b/apps/api/src/services/aiAgents/runLoop.ts
@@ -74,7 +74,6 @@ import { publishEvent } from '../eventBus';
 import { resolveLlmConfigForOrg } from '../llm/llmConfigResolver';
 import type { UsableLlmConfig } from '../llm/llmConfigResolver';
 import { buildClaudeSdkChildEnv } from '../streamingSessionManager';
-import { createNotification } from '../userNotifications';
 import type { AuthContext } from '../../middleware/auth';
 import { AgentRunOwnershipError, buildAgentAuthContext } from './agentAuthContext';
 import { resolveEffectiveAgentSystem } from './effectivePolicy';
@@ -85,8 +84,14 @@ import {
   reconcileHungExecutions,
   startToolExecution,
 } from './executionLedger';
-import { resolveRecipientUserIds } from './recipients';
+import { deliverRunFinishedNotifications } from './runFinishedNotify';
 import { transitionRunStatus } from './runService';
+// jobs/, not services/ — the durable retry lane for a notify failure (Task 6,
+// #3826). BullMQ-touching but harmless to import here: `enqueueAgentNotifyRetry`
+// itself lazily constructs its Queue only when actually called (services/redis.ts
+// never connects at import time), and this module does NOT import runLoop.ts
+// back — see runFinishedNotify.ts's header for why that direction would cycle.
+import { enqueueAgentNotifyRetry } from '../../jobs/agentNotifyRetryWorker';
 import {
   buildAgentRunSystemPrompt,
   buildAgentRunTaskPrompt,
@@ -598,60 +603,6 @@ function promptContext(ctx: RunContext, effective: AiAgentPolicy): AgentRunPromp
   };
 }
 
-async function notifyRunFinished(
-  ctx: RunContext,
-  finished: { status: string; summary: string; intentIds: string[] },
-): Promise<void> {
-  try {
-    // The run's immutable snapshot, NOT `ctx.agent.recipients`. The agent row
-    // loaded by `run.agent_id` is always the PARTNER BASELINE
-    // (resolveEffectiveAgentSystem pins `agentId: partnerRow.id`), so its raw
-    // recipients column silently drops every recipient an organization added
-    // through its override — and notifies nobody at all when only the override
-    // configured any. `mergeAgentPolicies` already unions the two sets into
-    // `effective.recipients`, and `resolveRecipientUserIds` re-derives
-    // membership against the RUN org, so the merged set is the correct input.
-    const userIds = await resolveRecipientUserIds(
-      {
-        orgId: ctx.agent.orgId,
-        partnerId: ctx.agent.partnerId,
-        recipients: ctx.run.policySnapshot.effective.recipients,
-      },
-      ctx.run.orgId,
-    );
-    if (userIds.length === 0) return;
-
-    const firstLine = finished.summary.split('\n')[0]?.trim() ?? '';
-    // AFTER the status commit and outside any held transaction (#1105).
-    await inSystemDbContext(async () => {
-      for (const userId of userIds) {
-        await createNotification({
-          userId,
-          orgId: ctx.run.orgId,
-          type: 'ai',
-          title: 'Agent run finished',
-          message: `${ctx.agent.name}: ${firstLine || finished.status}`,
-          // There is no run-detail page until wave 6; link to the approvals
-          // queue only when there is actually something waiting there.
-          link: finished.intentIds.length > 0 ? '/approvals' : null,
-          metadata: {
-            runId: ctx.run.id,
-            agentId: ctx.agent.id,
-            intentIds: finished.intentIds,
-            status: finished.status,
-          },
-          dedupeKey: `agent-run:${ctx.run.id}`,
-        });
-      }
-    });
-  } catch (error) {
-    // A notification failure must never redefine the run's outcome.
-    console.error('[aiAgentRunLoop] failed to notify run recipients', {
-      runId: ctx.run.id, error,
-    });
-  }
-}
-
 interface LoopResult {
   summary: string;
   costCents: number;
@@ -1085,11 +1036,20 @@ async function finishRun(
   // executor or `reapStalledAgentRuns` already owns this run), which is
   // exactly the case the ledger cleanup exists for. See the note there.
 
-  await notifyRunFinished(ctx, {
-    status,
-    summary: result.summary,
-    intentIds: result.intentIds,
-  });
+  // `deliverRunFinishedNotifications` re-reads the run row it just committed
+  // above (Task 6, #3826) rather than taking `status`/`result` in-process —
+  // see runFinishedNotify.ts's header for why the retry worker needs the
+  // SAME by-id entry point. A failure here must never redefine the run's
+  // terminal status, so it's caught here and durably retried instead of
+  // left to just fail silently as the old inline version did.
+  try {
+    await deliverRunFinishedNotifications(ctx.run.id);
+  } catch (error) {
+    console.error('[aiAgentRunLoop] failed to notify run recipients — enqueuing durable retry', {
+      runId: ctx.run.id, error,
+    });
+    await enqueueAgentNotifyRetry(ctx.run.id);
+  }
 }
 
 /**

--- a/apps/api/src/services/aiAgents/runService.test.ts
+++ b/apps/api/src/services/aiAgents/runService.test.ts
@@ -153,6 +153,12 @@ vi.mock('../deploymentEngine', () => ({ isDeviceInMaintenanceWindow }));
 const publishEvent = vi.hoisted(() => vi.fn());
 vi.mock('../eventBus', () => ({ publishEvent }));
 
+const reconcileHungExecutions = vi.hoisted(() =>
+  vi.fn<(sessionId: string) => Promise<number>>());
+const closeAgentRunSession = vi.hoisted(() =>
+  vi.fn<(sessionId: string, status: 'completed' | 'failed') => Promise<void>>());
+vi.mock('./executionLedger', () => ({ reconcileHungExecutions, closeAgentRunSession }));
+
 import {
   createAndEnqueueAgentRun,
   evaluateAgentTriggerFilters,
@@ -788,6 +794,42 @@ describe('createAndEnqueueAgentRun review findings (wave 3c)', () => {
   it('reapStalledAgentRuns returns the ids it failed', async () => {
     dbMockState.updateRows = [{ id: RUN_ID }];
     await expect(reapStalledAgentRuns({ agentId: AGENT_ID, orgId: ORG_ID })).resolves.toEqual([RUN_ID]);
+  });
+
+  it('reapStalledAgentRuns repairs the execution ledger for a reaped run that has a session', async () => {
+    // A SIGKILLed worker predates the ledger entirely: nothing in the
+    // in-process runLoop.ts cleanup ever ran for this run, so the reap itself
+    // has to reconcile the hung ai_tool_executions rows and close ai_sessions.
+    dbMockState.updateRows = [{ id: RUN_ID, sessionId: 'session-1' }];
+    reconcileHungExecutions.mockResolvedValue(2);
+    closeAgentRunSession.mockResolvedValue(undefined);
+
+    await expect(reapStalledAgentRuns({ agentId: AGENT_ID, orgId: ORG_ID })).resolves.toEqual([RUN_ID]);
+
+    expect(reconcileHungExecutions).toHaveBeenCalledWith('session-1');
+    expect(closeAgentRunSession).toHaveBeenCalledWith('session-1', 'failed');
+  });
+
+  it('reapStalledAgentRuns skips ledger cleanup for a reaped run with no session', async () => {
+    dbMockState.updateRows = [{ id: RUN_ID, sessionId: null }];
+
+    await expect(reapStalledAgentRuns({ agentId: AGENT_ID, orgId: ORG_ID })).resolves.toEqual([RUN_ID]);
+
+    expect(reconcileHungExecutions).not.toHaveBeenCalled();
+    expect(closeAgentRunSession).not.toHaveBeenCalled();
+  });
+
+  it('reapStalledAgentRuns tolerates a ledger cleanup failure — the reap result is unaffected', async () => {
+    dbMockState.updateRows = [{ id: RUN_ID, sessionId: 'session-1' }];
+    reconcileHungExecutions.mockRejectedValueOnce(new Error('db unavailable'));
+    closeAgentRunSession.mockResolvedValue(undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(reapStalledAgentRuns({ agentId: AGENT_ID, orgId: ORG_ID })).resolves.toEqual([RUN_ID]);
+
+    // Even though reconcile failed, close is still attempted (best-effort, not
+    // short-circuited).
+    expect(closeAgentRunSession).toHaveBeenCalledWith('session-1', 'failed');
   });
 
   it('device_not_in_org when the device does not belong to the run org', async () => {

--- a/apps/api/src/services/aiAgents/runService.ts
+++ b/apps/api/src/services/aiAgents/runService.ts
@@ -48,6 +48,10 @@ import { closeAgentRunSession, reconcileHungExecutions } from './executionLedger
  *                            per-day distinct-device count against org fleet
  *                            size, which only means something once an agent can
  *                            touch more than one device.
+ *  - maxActionsPerRun      — DEFERRED to Part B (#3826): the field ships in
+ *                            wave 4a so partners can pre-configure it and
+ *                            snapshots carry it; Part B's run loop is what
+ *                            enforces it.
  */
 
 export interface CreateAgentRunInput {

--- a/apps/api/src/services/aiAgents/runService.ts
+++ b/apps/api/src/services/aiAgents/runService.ts
@@ -27,6 +27,7 @@ import { publishEvent } from '../eventBus';
 import { getLlmBillingSourceForOrg } from '../llm/llmConfigResolver';
 import { AgentRunOwnershipError, assertRunOwnership } from './agentAuthContext';
 import { resolveEffectiveAgentSystem } from './effectivePolicy';
+import { closeAgentRunSession, reconcileHungExecutions } from './executionLedger';
 
 /**
  * Which `AiAgentLimits` field is enforced where. Every field must appear in
@@ -203,6 +204,13 @@ const STALLED_RUN_AFTER_SECONDS = 1800 + 900;
  * advisory lock and a system context, and it runs exactly when someone is
  * trying to get past the jam. The transition is a CAS, so a run that IS still
  * alive and finishes normally between the two statements is not clobbered.
+ *
+ * A reaped run predates the execution ledger (wave 4a): the SIGKILLed worker
+ * that owned it died before `runLoop.ts`'s own cleanup could ever run, so
+ * without repairing the ledger here too, a reaped run's `ai_sessions` row (if
+ * it has one) is stuck 'active' and its `ai_tool_executions` rows stuck
+ * 'executing' forever — nothing else in the codebase reaps them. Best-effort,
+ * same as every other ledger write: never allowed to fail the reap itself.
  */
 export async function reapStalledAgentRuns(scope: {
   agentId: string;
@@ -229,11 +237,31 @@ export async function reapStalledAgentRuns(scope: {
           and(isNull(aiAgentRuns.startedAt), lt(aiAgentRuns.queuedAt, cutoff)),
         ),
       ))
-      .returning({ id: aiAgentRuns.id });
+      .returning({ id: aiAgentRuns.id, sessionId: aiAgentRuns.sessionId });
     if (rows.length > 0) {
       console.warn('[aiAgentRunService] reaped stalled agent runs', {
         agentId: scope.agentId, orgId: scope.orgId, runIds: rows.map((r) => r.id),
       });
+      for (const row of rows) {
+        if (!row.sessionId) continue;
+        const sessionId = row.sessionId;
+        try {
+          await reconcileHungExecutions(sessionId);
+        } catch (error) {
+          console.error(
+            '[aiAgentRunService] failed to reconcile hung executions for a reaped run (non-fatal)',
+            { agentId: scope.agentId, orgId: scope.orgId, runId: row.id, sessionId, error },
+          );
+        }
+        try {
+          await closeAgentRunSession(sessionId, 'failed');
+        } catch (error) {
+          console.error(
+            '[aiAgentRunService] failed to close the execution-ledger session for a reaped run (non-fatal)',
+            { agentId: scope.agentId, orgId: scope.orgId, runId: row.id, sessionId, error },
+          );
+        }
+      }
     }
     return rows.map((r) => r.id);
   });

--- a/apps/api/src/services/aiTools.ts
+++ b/apps/api/src/services/aiTools.ts
@@ -144,6 +144,11 @@ export async function verifyDeviceAccess(
   if (auth.helperDeviceId && deviceId !== auth.helperDeviceId) {
     return { error: 'Device not found or access denied' };
   }
+  // Device-exact axis (device-bound agent runs): tighter than canAccessSite
+  // below, which admits every sibling device in the same site.
+  if (auth.allowedDeviceIds && !auth.allowedDeviceIds.includes(deviceId)) {
+    return { error: 'Device not found or access denied' };
+  }
   const conditions: SQL[] = [eq(devices.id, deviceId)];
   const orgCond = auth.orgCondition(devices.orgId);
   if (orgCond) conditions.push(orgCond);

--- a/apps/api/src/services/aiTools.verifyDeviceAccess.test.ts
+++ b/apps/api/src/services/aiTools.verifyDeviceAccess.test.ts
@@ -87,3 +87,34 @@ describe('verifyDeviceAccess — site scoping', () => {
     expect(result).toEqual({ device: row });
   });
 });
+
+describe('verifyDeviceAccess — device-exact pinning (allowedDeviceIds)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('denies a SIBLING device in the SAME site when the caller is pinned to one exact device', async () => {
+    // The verified gap: a device-bound agent run today pins only to the
+    // device's SITE (allowedSiteIds), so a sibling device sharing that site
+    // passes the site check even though the run is scoped to one device.
+    const row = { id: 'sibling-device', orgId: 'org-1', siteId: 'site-A', hostname: 'h', status: 'online' };
+    mockDeviceRow(row);
+    const auth = makeAuth({ allowedSiteIds: ['site-A'], allowedDeviceIds: ['pinned-device'] });
+    const result = await verifyDeviceAccess('sibling-device', auth);
+    expect(result).toEqual({ error: 'Device not found or access denied' });
+  });
+
+  it('allows the exact pinned device', async () => {
+    const row = { id: 'pinned-device', orgId: 'org-1', siteId: 'site-A', hostname: 'h', status: 'online' };
+    mockDeviceRow(row);
+    const auth = makeAuth({ allowedSiteIds: ['site-A'], allowedDeviceIds: ['pinned-device'] });
+    const result = await verifyDeviceAccess('pinned-device', auth);
+    expect(result).toEqual({ device: row });
+  });
+
+  it('does not narrow an unrestricted (no allowedDeviceIds) caller — no regression', async () => {
+    const row = { id: 'any-device', orgId: 'org-1', siteId: 'site-A', hostname: 'h', status: 'online' };
+    mockDeviceRow(row);
+    const auth = makeAuth({ allowedSiteIds: ['site-A'] }); // allowedDeviceIds undefined
+    const result = await verifyDeviceAccess('any-device', auth);
+    expect(result).toEqual({ device: row });
+  });
+});

--- a/apps/api/src/services/aiToolsPlaybooks.test.ts
+++ b/apps/api/src/services/aiToolsPlaybooks.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * #3826 Wave 4A Task 3: `playbook_executions.triggered_by_user_id` FK-
+ * references `users.id` (schema/playbooks.ts:118), but an `ai_agent`
+ * principal's `auth.user.id` is the agent's `ai_agents.id` — see
+ * services/aiAgents/agentAuthContext.ts. `execute_playbook` passed
+ * `auth.user.id` straight into that FK column, which would die on a 23503 the
+ * first time an agent-released run reached here. This suite pins the
+ * users-row probe-and-degrade fix (mirrors the shipped
+ * commandQueue.ts:855-889 precedent): a non-resolving id degrades to NULL,
+ * the existing `triggered_by: 'ai'` varchar tag is untouched, and a
+ * real-user id stays byte-identical.
+ */
+
+vi.mock('../db', () => ({ db: { select: vi.fn(), insert: vi.fn() } }));
+
+import { db } from '../db';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+import { registerPlaybookTools } from './aiToolsPlaybooks';
+
+function toolMap(): Map<string, AiTool> {
+  const map = new Map<string, AiTool>();
+  registerPlaybookTools(map);
+  return map;
+}
+
+const ORG_ID = 'org-a';
+const DEVICE_ID = 'device-1';
+const PLAYBOOK_ID = 'playbook-1';
+
+function makeAuth(overrides: Partial<AuthContext> = {}): AuthContext {
+  return {
+    principal: { kind: 'user_session' },
+    user: { id: 'user-1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: ORG_ID,
+    scope: 'organization',
+    accessibleOrgIds: [ORG_ID],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    ...overrides,
+  } as unknown as AuthContext;
+}
+
+const playbookRow = (o: Record<string, unknown> = {}) => ({
+  id: PLAYBOOK_ID,
+  orgId: ORG_ID,
+  isActive: true,
+  isBuiltIn: false,
+  name: 'Fix disk space',
+  description: 'desc',
+  category: 'disk',
+  requiredPermissions: [],
+  steps: [],
+  ...o,
+});
+
+const deviceRow = (o: Record<string, unknown> = {}) => ({
+  id: DEVICE_ID,
+  orgId: ORG_ID,
+  siteId: null,
+  status: 'online',
+  hostname: 'host-1',
+  ...o,
+});
+
+// Queues a `.select().from().where().limit()` chain resolving to `rows`,
+// consumed by exactly ONE db.select() call.
+function queueSelect(rows: unknown[]) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+    }),
+  } as any);
+}
+
+function mockInsert(rows: unknown[]) {
+  vi.mocked(db.insert).mockReturnValue({
+    values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue(rows) }),
+  } as any);
+}
+
+function insertedValues(): Record<string, unknown> {
+  return vi.mocked(db.insert).mock.results[0]!.value.values.mock.calls[0]![0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('execute_playbook — users-FK probe-and-degrade (#3826)', () => {
+  it('degrades an agent-shaped auth.user.id to triggeredByUserId: null, keeping the "ai" tag', async () => {
+    const tools = toolMap();
+    const execute = tools.get('execute_playbook')!;
+
+    queueSelect([playbookRow()]); // playbook lookup
+    queueSelect([deviceRow()]); // verifyDeviceAccess
+    queueSelect([]); // users probe: no row -> not a real user
+    mockInsert([{ id: 'exec-1', status: 'pending', currentStepIndex: 0, createdAt: new Date() }]);
+
+    const auth = makeAuth({
+      principal: { kind: 'ai_agent', agentId: 'agent-shaped-id-1', runId: 'run-1' },
+      user: { id: 'agent-shaped-id-1', email: 'agent+x@breeze.internal', name: 'Agent', isPlatformAdmin: false },
+    });
+
+    const result = await execute.handler(
+      { playbookId: PLAYBOOK_ID, deviceId: DEVICE_ID },
+      auth,
+    );
+    const parsed = JSON.parse(result);
+    expect(parsed.error).toBeUndefined();
+
+    const values = insertedValues();
+    expect(values.triggeredByUserId).toBeNull();
+    expect(values.triggeredBy).toBe('ai');
+  });
+
+  it('keeps triggeredByUserId when auth.user.id resolves to a real users row (byte-identical real-user path)', async () => {
+    const tools = toolMap();
+    const execute = tools.get('execute_playbook')!;
+
+    queueSelect([playbookRow()]);
+    queueSelect([deviceRow()]);
+    queueSelect([{ id: 'user-1' }]); // users probe: real row
+    mockInsert([{ id: 'exec-2', status: 'pending', currentStepIndex: 0, createdAt: new Date() }]);
+
+    const auth = makeAuth(); // default user_session, user.id: 'user-1'
+    const result = await execute.handler(
+      { playbookId: PLAYBOOK_ID, deviceId: DEVICE_ID },
+      auth,
+    );
+    const parsed = JSON.parse(result);
+    expect(parsed.error).toBeUndefined();
+
+    const values = insertedValues();
+    expect(values.triggeredByUserId).toBe('user-1');
+    expect(values.triggeredBy).toBe('ai');
+  });
+
+  it('probes exactly once: playbook lookup, device lookup, users probe, then insert', async () => {
+    const tools = toolMap();
+    const execute = tools.get('execute_playbook')!;
+
+    queueSelect([playbookRow()]);
+    queueSelect([deviceRow()]);
+    queueSelect([{ id: 'user-1' }]);
+    mockInsert([{ id: 'exec-3', status: 'pending', currentStepIndex: 0, createdAt: new Date() }]);
+
+    await execute.handler({ playbookId: PLAYBOOK_ID, deviceId: DEVICE_ID }, makeAuth());
+
+    expect(db.select).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/api/src/services/aiToolsPlaybooks.ts
+++ b/apps/api/src/services/aiToolsPlaybooks.ts
@@ -12,6 +12,7 @@ import {
   devices,
   playbookDefinitions,
   playbookExecutions,
+  users,
 } from '../db/schema';
 import { eq, and, desc, sql, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
@@ -174,6 +175,23 @@ registerTool({
           ? (extraContext.variables as Record<string, unknown>)
           : {};
 
+      // #3826 Wave 4A Task 3: `playbook_executions.triggered_by_user_id`
+      // FK-references users.id (schema/playbooks.ts:118), but an `ai_agent`
+      // principal's `auth.user.id` is the agent's `ai_agents.id`, not a
+      // users row (services/aiAgents/agentAuthContext.ts) — inserting it
+      // verbatim would die on a 23503. Mirrors the shipped
+      // commandQueue.ts:855-889 probe precedent: one indexed PK lookup, and
+      // a non-resolving id degrades the FK column to NULL. The existing
+      // `triggeredBy: 'ai'` varchar tag is untouched either way — it already
+      // flags every AI-originated execution regardless of which principal
+      // triggered it.
+      const [userRow] = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.id, auth.user.id))
+        .limit(1);
+      const safeTriggeredByUserId = userRow ? auth.user.id : null;
+
       const [execution] = await db
         .insert(playbookExecutions)
         .values({
@@ -189,7 +207,7 @@ registerTool({
             },
           },
           triggeredBy: 'ai',
-          triggeredByUserId: auth.user.id,
+          triggeredByUserId: safeTriggeredByUserId,
         })
         .returning();
 

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -123,6 +123,21 @@ const mockLiveDeviceStatus = (status: string | undefined) => {
   } as any);
 };
 
+// Mocks the users-row existence probe (#3826 Wave 4A Task 3): a single
+// `db.select({id}).from(users).where(eq(users.id, candidate)).limit(1)`
+// query. Pass `found: true` to model a real users row (real-user path,
+// unchanged behavior) or `found: false` to model an agent-shaped id that
+// does not resolve to any users row (degrade path).
+const mockUsersProbe = (found: boolean) => {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(found ? [{ id: 'probed' }] : []),
+      }),
+    }),
+  } as any);
+};
+
 // Extracts the actually-BOUND query parameters (column name + literal value)
 // from a drizzle SQL condition tree, e.g. `and(eq(id, 'exec-1'), eq(status,
 // 'pending'))` -> [{ column: 'id', value: 'exec-1' }, { column: 'status',
@@ -266,6 +281,7 @@ describe('dispatchScriptToDevice — invariants', () => {
 
 describe('dispatchScriptToDevice — rows and payload', () => {
   it('saved: creates an execution row with the DEVICE org and passes executionId in payload', async () => {
+    mockUsersProbe(true); // 'user-1' resolves to a real users row — real-user path.
     const r = await dispatchScriptToDevice({
       device: device(), source: { kind: 'saved', script: savedScript(), automationRunId: null },
       parameters: { a: '1' }, triggeredBy: 'user-1', triggerType: 'manual',
@@ -273,6 +289,8 @@ describe('dispatchScriptToDevice — rows and payload', () => {
     expect(r.ok).toBe(true);
     const execValues = vi.mocked(db.insert).mock.results[0]!.value.values.mock.calls[0]![0];
     expect(execValues).toMatchObject({ scriptId: 'script-1', deviceId: 'device-1', orgId: 'org-a', triggeredBy: 'user-1', status: 'pending' });
+    // Real-user path must stay byte-identical: no $actor sidecar.
+    expect(execValues.parameters).not.toHaveProperty('$actor');
     const [, , payload] = vi.mocked(queueCommand).mock.calls[0]!;
     expect(payload).toMatchObject({ scriptId: 'script-1', executionId: 'exec-1', language: 'bash', content: 'echo hi', timeoutSeconds: 60, runAs: 'system' });
   });
@@ -395,6 +413,86 @@ describe('dispatchScriptToDevice — rows and payload', () => {
     await expect(dispatchScriptToDevice({ device: device(), source: { kind: 'saved', script: savedScript() } })).rejects.toThrow('payload boom');
     expect(db.delete).toHaveBeenCalled();
     expect(queueCommand).not.toHaveBeenCalled();
+  });
+});
+
+// #3826 Wave 4A Task 3: agent principals reach dispatchScriptToDevice through
+// the same handlers humans use (auth.user.id is an ai_agents id, not a
+// users.id, for an ai_agent principal — see agentAuthContext.ts). Both
+// `script_executions.triggered_by` and (via queueCommand) `device_commands
+// .created_by` FK-reference users.id, so an agent-shaped id must degrade to
+// NULL before either insert — mirrors the shipped commandQueue.ts:855-889
+// precedent exactly.
+describe('dispatchScriptToDevice — users-FK probe-and-degrade (#3826)', () => {
+  it('degrades an agent-shaped triggeredBy/createdBy to null on BOTH columns and stashes actor metadata', async () => {
+    mockUsersProbe(false); // agent id does not resolve to a users row
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'saved', script: savedScript() },
+      triggeredBy: 'agent-shaped-id-1',
+      createdBy: 'agent-shaped-id-1',
+    });
+    expect(r.ok).toBe(true);
+    const execValues = vi.mocked(db.insert).mock.results[0]!.value.values.mock.calls[0]![0];
+    expect(execValues.triggeredBy).toBeNull();
+    expect(execValues.parameters).toMatchObject({
+      $actor: { actorType: 'ai_agent', actorId: 'agent-shaped-id-1' },
+    });
+    const [, , , userId] = vi.mocked(queueCommand).mock.calls[0]!;
+    expect(userId).toBeUndefined();
+  });
+
+  it('single probe covers BOTH columns: exactly one users select when triggeredBy === createdBy', async () => {
+    mockUsersProbe(true);
+    await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'saved', script: savedScript() },
+      triggeredBy: 'user-1',
+      createdBy: 'user-1',
+    });
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('real-user path stays byte-identical: createdBy passes through to queueCommand verbatim', async () => {
+    mockUsersProbe(true);
+    await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'saved', script: savedScript() },
+      triggeredBy: 'user-1',
+      createdBy: 'user-1',
+    });
+    const [, , , userId] = vi.mocked(queueCommand).mock.calls[0]!;
+    expect(userId).toBe('user-1');
+  });
+
+  it('does not probe at all when neither triggeredBy nor createdBy is supplied (no behavior change)', async () => {
+    await dispatchScriptToDevice({ device: device(), source: { kind: 'saved', script: savedScript() } });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('raw source: degrades an agent-shaped createdBy for queueCommand (no execution row to stash metadata in)', async () => {
+    mockUsersProbe(false);
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'raw', content: 'ipconfig', language: 'powershell', provenance: 'automation:auto-1' },
+      createdBy: 'agent-shaped-id-2',
+    });
+    expect(r.ok).toBe(true);
+    expect(db.insert).not.toHaveBeenCalled();
+    const [, , , userId] = vi.mocked(queueCommand).mock.calls[0]!;
+    expect(userId).toBeUndefined();
+  });
+
+  it('does not add an $actor key when the script has no bound parameters and the actor IS real', async () => {
+    mockUsersProbe(true);
+    await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'saved', script: savedScript() },
+      triggeredBy: 'user-1',
+      createdBy: 'user-1',
+    });
+    const execValues = vi.mocked(db.insert).mock.results[0]!.value.values.mock.calls[0]![0];
+    expect(execValues.parameters).not.toHaveProperty('$actor');
   });
 });
 

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SQL, Param } from 'drizzle-orm';
 
-vi.mock('../db', () => ({ db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() } }));
+vi.mock('../db', () => ({
+  db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
 vi.mock('./commandQueue', () => ({ queueCommand: vi.fn() }));
 vi.mock('./commandDispatch', () => ({
   claimPendingCommandForDelivery: vi.fn().mockResolvedValue(null),

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 import { canonicalizeScriptParameters, hasVariableTokens } from '@breeze/shared';
 
-import { db } from '../db';
+import { db, withSystemDbAccessContext } from '../db';
 import { devices, organizations, scriptExecutions, scripts, sites, users } from '../db/schema';
 import {
   claimPendingCommandForDelivery,
@@ -340,9 +340,12 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
   // schema/scripts.ts:126) and `createdBy` (forwarded to queueCommand, whose
   // `device_commands.created_by` is the SAME FK shape) would otherwise die on
   // a 23503 the first time an agent-released run reaches here. Mirrors the
-  // shipped `commandQueue.ts:855-889` probe precedent exactly: one indexed
-  // PK lookup on whichever id is present, and any id that isn't a users row
-  // degrades to NULL on both columns rather than aborting the dispatch.
+  // shipped `commandQueue.ts:855-889` probe precedent: one indexed PK lookup
+  // on whichever id is present, run inside `withSystemDbAccessContext` (same
+  // as the precedent) since `users` is an RLS-forced dual-axis table and a
+  // contextless read DENIES rather than bypassing — any id that isn't a
+  // users row degrades to NULL on both columns rather than aborting the
+  // dispatch.
   //
   // Single probe for both columns: every real caller passes the SAME id for
   // triggeredBy and createdBy (or supplies only one — automation's raw
@@ -351,15 +354,16 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
   // preferred as the probe candidate since it is the one that always reaches
   // queueCommand.
   const actorCandidateId = input.createdBy ?? input.triggeredBy ?? null;
-  let actorIsRealUser = true;
-  if (actorCandidateId) {
-    const [userRow] = await db
-      .select({ id: users.id })
-      .from(users)
-      .where(eq(users.id, actorCandidateId))
-      .limit(1);
-    actorIsRealUser = Boolean(userRow);
-  }
+  const actorIsRealUser = actorCandidateId
+    ? await withSystemDbAccessContext(async () => {
+        const [userRow] = await db
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.id, actorCandidateId))
+          .limit(1);
+        return Boolean(userRow);
+      })
+    : true;
   const safeTriggeredBy = actorIsRealUser ? input.triggeredBy ?? null : null;
   const safeCreatedBy = actorIsRealUser ? input.createdBy ?? null : null;
   // Attribution for a degraded id survives in the execution record's

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -3,7 +3,7 @@ import { and, eq } from 'drizzle-orm';
 import { canonicalizeScriptParameters, hasVariableTokens } from '@breeze/shared';
 
 import { db } from '../db';
-import { devices, organizations, scriptExecutions, scripts, sites } from '../db/schema';
+import { devices, organizations, scriptExecutions, scripts, sites, users } from '../db/schema';
 import {
   claimPendingCommandForDelivery,
   releaseClaimedCommandDelivery,
@@ -332,6 +332,40 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
     }
   }
 
+  // #3826 Wave 4A Task 3: agent principals reach dispatch through the SAME
+  // handlers humans use (an `ai_agent` AuthContext's `auth.user.id` is the
+  // agent's `ai_agents.id`, not a `users.id` — see
+  // services/aiAgents/agentAuthContext.ts). Both `triggeredBy` (inserted
+  // below into `script_executions.triggered_by`, FK -> users.id,
+  // schema/scripts.ts:126) and `createdBy` (forwarded to queueCommand, whose
+  // `device_commands.created_by` is the SAME FK shape) would otherwise die on
+  // a 23503 the first time an agent-released run reaches here. Mirrors the
+  // shipped `commandQueue.ts:855-889` probe precedent exactly: one indexed
+  // PK lookup on whichever id is present, and any id that isn't a users row
+  // degrades to NULL on both columns rather than aborting the dispatch.
+  //
+  // Single probe for both columns: every real caller passes the SAME id for
+  // triggeredBy and createdBy (or supplies only one — automation's raw
+  // command action has no execution row and so no triggeredBy at all), so
+  // one lookup on whichever is present settles both writes. `createdBy` is
+  // preferred as the probe candidate since it is the one that always reaches
+  // queueCommand.
+  const actorCandidateId = input.createdBy ?? input.triggeredBy ?? null;
+  let actorIsRealUser = true;
+  if (actorCandidateId) {
+    const [userRow] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, actorCandidateId))
+      .limit(1);
+    actorIsRealUser = Boolean(userRow);
+  }
+  const safeTriggeredBy = actorIsRealUser ? input.triggeredBy ?? null : null;
+  const safeCreatedBy = actorIsRealUser ? input.createdBy ?? null : null;
+  // Attribution for a degraded id survives in the execution record's
+  // `parameters` sidecar (below) — never on the users-FK column itself.
+  const degradedActorId = actorIsRealUser ? null : actorCandidateId;
+
   let executionId: string | null = null;
   if (source.kind === 'saved') {
     // Child rows always take the DEVICE's org (partner-wide fan-out rule).
@@ -341,7 +375,7 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
         scriptId: source.script.id,
         deviceId: device.id,
         orgId: device.orgId,
-        triggeredBy: input.triggeredBy ?? null,
+        triggeredBy: safeTriggeredBy,
         triggerType: input.triggerType ?? 'manual',
         ...(source.automationRunId ? { automationRunId: source.automationRunId } : {}),
         // #3409 PR3 P4: the CALLER's raw parameters, never the resolved map.
@@ -352,7 +386,7 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
         // (`{key, source, variableId?, ownerScope?, version?}`), so history
         // can answer "which variable fed this run" without carrying what it
         // was worth.
-        parameters: buildExecutionParameters(parameters, parameterBindings),
+        parameters: buildExecutionParameters(parameters, parameterBindings, degradedActorId),
         status: 'pending',
       })
       .returning({ id: scriptExecutions.id });
@@ -440,7 +474,7 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
       ...(input.targetSessionId != null ? { targetSessionId: input.targetSessionId } : {}),
     }, { commandId: reservedCommandId, deviceId: device.id });
     stage = 'queueCommand';
-    command = await queueCommand(device.id, 'script', payload, input.createdBy ?? undefined, {
+    command = await queueCommand(device.id, 'script', payload, safeCreatedBy ?? undefined, {
       commandId: reservedCommandId,
     });
   } catch (err) {
@@ -564,10 +598,20 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
   return { ok: true, commandId: command.id, executionId, delivered, deliveryOutcome, executedAt, ignoredParameters };
 }
 
+// #3826 Wave 4A Task 3: reserved sidecar key for the users-FK probe-and-degrade
+// above. Same rationale as EXECUTION_PARAMETER_BINDINGS_KEY (no migration, no
+// new column) — `$` can never start a real parameter name, so this can never
+// collide with caller-supplied data. Written ONLY when the probe actually
+// degraded an id, so a real-user dispatch never gains this key.
+const EXECUTION_PARAMETER_ACTOR_KEY = '$actor';
+
 /**
  * The value written to `script_executions.parameters` — the caller's raw
  * parameters, plus the binding descriptors under a reserved `$bindings` key
- * when there are any (#3409 PR3 P4).
+ * when there are any (#3409 PR3 P4), plus a reserved `$actor` key when the
+ * users-FK probe above degraded `triggeredBy`/`createdBy` to NULL (#3826 Wave
+ * 4A Task 3) — attribution for the agent that actually ran this survives here
+ * instead of on the users-FK column.
  *
  * The descriptors ride INSIDE the existing jsonb rather than in a new sibling
  * column because PR3 ships no migration: `script_executions` carries an
@@ -576,15 +620,25 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
  * bugs on five times), and a `jsonb` column would land in `excludedOpen`
  * anyway. `$` can never start a parameter name
  * (`SCRIPT_PARAMETER_KEY_PATTERN`), so the reserved key cannot collide with a
- * real one; when there are no bindings the stored value is byte-identical to
- * what PR2 wrote.
+ * real one; when there are no bindings and no degraded actor, the stored
+ * value is byte-identical to what PR2 wrote.
  */
 function buildExecutionParameters(
   callerParameters: Record<string, unknown>,
   bindings: ScriptParameterBindingDescriptor[],
+  degradedActorId: string | null,
 ): Record<string, unknown> {
-  if (bindings.length === 0) return callerParameters;
-  return { ...callerParameters, [EXECUTION_PARAMETER_BINDINGS_KEY]: bindings };
+  let result = callerParameters;
+  if (bindings.length > 0) {
+    result = { ...result, [EXECUTION_PARAMETER_BINDINGS_KEY]: bindings };
+  }
+  if (degradedActorId) {
+    result = {
+      ...result,
+      [EXECUTION_PARAMETER_ACTOR_KEY]: { actorType: 'ai_agent', actorId: degradedActorId },
+    };
+  }
+  return result;
 }
 
 /**

--- a/apps/api/src/services/workerEntrypointClosure.contract.test.ts
+++ b/apps/api/src/services/workerEntrypointClosure.contract.test.ts
@@ -264,16 +264,17 @@ function parseRegistrySource(): RegistryEntrySource[] {
   }));
 }
 
-// The 104 names WORKER_REGISTRY must contain, in `index.ts`'s original order
-// (deliberately duplicated here, not imported from workerRegistry.test.ts —
-// see Task 5 in the plan doc: this is an independent contract, not a shared
-// fixture, so an edit that silently drops/renames an entry can't slip past
-// both suites at once).
+// The names WORKER_REGISTRY must contain, in `index.ts`'s original order plus
+// every entry added since (deliberately duplicated here, not imported from
+// workerRegistry.test.ts — see Task 5 in the plan doc: this is an independent
+// contract, not a shared fixture, so an edit that silently drops/renames an
+// entry can't slip past both suites at once).
 const EXPECTED_NAMES = [
   'alertWorkers', 'alertCorrelationWorker', 'metricRollupsWorker', 'metricRollupMaintenance',
   'metricAnomaliesWorker', 'fleetFindingsWorker', 'fleetRemediationDispatchWorker', 'mlOutputRetention',
   'offlineDetector', 'notificationDispatcher', 'webhookDelivery', 'webhookDeliveryRecovery',
   'policyEvaluationWorker', 'softwareComplianceWorker', 'softwareRemediationWorker', 'aiAgentRunner',
+  'agentNotifyRetry',
   'auditBaselineJobs', 'cisJobs', 'automationWorker', 'securityPostureWorker',
   'reliabilityWorker', 'userRiskWorker', 'abuseSignalsWorker', 'userRiskRetention',
   'backupVerificationJobs', 'eventLogRetention', 'logCorrelationWorker', 'agentLogRetention',
@@ -439,7 +440,7 @@ describe('workerEntrypointClosure contract (#4086 Task 5)', () => {
     });
   });
 
-  it('registry losslessness: WORKER_REGISTRY names set-equal the 104-name list', () => {
+  it('registry losslessness: WORKER_REGISTRY names set-equal the expected-name list', () => {
     const actual = WORKER_REGISTRY.map((e) => e.name);
     expect(new Set(actual)).toEqual(new Set(EXPECTED_NAMES));
     expect(actual.length).toBe(EXPECTED_NAMES.length);
@@ -447,7 +448,7 @@ describe('workerEntrypointClosure contract (#4086 Task 5)', () => {
 
   describe('global-placement entries never reach socket-local dispatch', () => {
     const entries = parseRegistrySource();
-    expect(entries.length).toBe(105); // sanity: the source-parsing regex itself must find all 105
+    expect(entries.length).toBe(106); // sanity: the source-parsing regex itself must find all 106
 
     const globalEntries = entries.filter((e) => e.placement === 'global');
     expect(globalEntries.length).toBeGreaterThan(0);

--- a/apps/api/src/services/workerRegistry.test.ts
+++ b/apps/api/src/services/workerRegistry.test.ts
@@ -10,16 +10,18 @@ import {
   type WorkerRegistration,
 } from './workerRegistry';
 
-// The canonical 104 names, in today's `index.ts:1305-1433` order (see the
-// plan doc, Task 1). This list is duplicated here deliberately — the whole
+// The canonical names, in today's `index.ts:1305-1433` order (see the plan
+// doc, Task 1) plus every entry added since (e.g. `agentNotifyRetry`, wave 4a
+// Task 6, #3826). This list is duplicated here deliberately — the whole
 // point of the test is to catch drift between the plan's documented contract
 // and the actual registry, so it must not import the list from the module
 // under test.
-const EXPECTED_105_NAMES = [
+const EXPECTED_106_NAMES = [
   'alertWorkers', 'alertCorrelationWorker', 'metricRollupsWorker', 'metricRollupMaintenance',
   'metricAnomaliesWorker', 'fleetFindingsWorker', 'fleetRemediationDispatchWorker', 'mlOutputRetention',
   'offlineDetector', 'notificationDispatcher', 'webhookDelivery', 'webhookDeliveryRecovery',
   'policyEvaluationWorker', 'softwareComplianceWorker', 'softwareRemediationWorker', 'aiAgentRunner',
+  'agentNotifyRetry',
   'auditBaselineJobs', 'cisJobs', 'automationWorker', 'securityPostureWorker',
   'reliabilityWorker', 'userRiskWorker', 'abuseSignalsWorker', 'userRiskRetention',
   'backupVerificationJobs', 'eventLogRetention', 'logCorrelationWorker', 'agentLogRetention',
@@ -45,12 +47,12 @@ const EXPECTED_105_NAMES = [
 ];
 
 describe('workerRegistry: losslessness', () => {
-  it('contains exactly the 104 known names, in order', () => {
-    expect(WORKER_REGISTRY.map((e) => e.name)).toEqual(EXPECTED_105_NAMES);
+  it('contains exactly the 106 known names, in order', () => {
+    expect(WORKER_REGISTRY.map((e) => e.name)).toEqual(EXPECTED_106_NAMES);
   });
 
-  it('has exactly 104 entries', () => {
-    expect(WORKER_REGISTRY.length).toBe(105);
+  it('has exactly 106 entries', () => {
+    expect(WORKER_REGISTRY.length).toBe(106);
   });
 
   it('every entry has a well-formed shape', () => {
@@ -70,14 +72,14 @@ describe('workerRegistry: losslessness', () => {
 
 describe('workerRegistry: selectWorkers', () => {
   it("'all' selects every entry", () => {
-    expect(selectWorkers('all').length).toBe(105);
+    expect(selectWorkers('all').length).toBe(106);
     expect(selectWorkers('all')).toEqual(WORKER_REGISTRY);
   });
 
   it("'api' and 'worker' partition the set with no overlap and no loss", () => {
     const api = selectWorkers('api');
     const worker = selectWorkers('worker');
-    expect(api.length + worker.length).toBe(105);
+    expect(api.length + worker.length).toBe(106);
 
     const apiNames = new Set(api.map((e) => e.name));
     const workerNames = new Set(worker.map((e) => e.name));
@@ -85,7 +87,7 @@ describe('workerRegistry: selectWorkers', () => {
       expect(workerNames.has(name)).toBe(false);
     }
     const union = new Set([...apiNames, ...workerNames]);
-    expect(union.size).toBe(105);
+    expect(union.size).toBe(106);
   });
 
   it("'api' selects only socket-owner placements", () => {

--- a/apps/api/src/services/workerRegistry.ts
+++ b/apps/api/src/services/workerRegistry.ts
@@ -219,6 +219,19 @@ export const WORKER_REGISTRY: readonly WorkerRegistration[] = [
     },
   },
   {
+    // Durable retry lane for run-finished notifications (wave 4a Task 6,
+    // #3826). Its only real dependency is `services/aiAgents/runFinishedNotify.ts`
+    // (db + recipients + userNotifications) — deliberately NOT `runLoop.ts`'s
+    // full SDK-tool graph, so its closure stays `global` (verified by
+    // workerEntrypointClosure.contract.test.ts) unlike `aiAgentRunner` above.
+    name: 'agentNotifyRetry',
+    placement: 'global',
+    load: async () => {
+      const m = await import('../jobs/agentNotifyRetryWorker');
+      return { init: m.initializeAgentNotifyRetryWorker, shutdown: m.shutdownAgentNotifyRetryWorker };
+    },
+  },
+  {
     name: 'auditBaselineJobs',
     placement: 'socket-owner',
     load: async () => {

--- a/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave4-a-foundations.md
+++ b/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave4-a-foundations.md
@@ -54,8 +54,8 @@ wave: W05 (#3826) — Part A (inert foundations)
 - `reconcileHungExecutions(sessionId: string): Promise<number>` — terminal-marks (status failed, errorMessage `'run finished with execution unresolved'`) every row still in-flight for the session; returns count.
 - `closeAgentRunSession(sessionId: string, status: 'completed' | 'failed'): Promise<void>`.
 
-- [ ] **Step 1: failing unit tests** (Drizzle mock pattern per `breeze-testing`): session insert carries `type:'agent'` + agentId + no userId; CAS second-session behavior; start/complete round-trip; reconcile only touches in-flight rows of THAT session; all writes run under the provided db handle (no ambient pool).
-- [ ] **Step 2: verify fail → Step 3: implement → Step 4: green + typecheck. Commit:** `feat(api): agent run execution ledger — session per run + real tool-execution rows (#3826)`
+- [x] **Step 1: failing unit tests** (Drizzle mock pattern per `breeze-testing`): session insert carries `type:'agent'` + agentId + no userId; CAS second-session behavior; start/complete round-trip; reconcile only touches in-flight rows of THAT session; all writes run under the provided db handle (no ambient pool).
+- [x] **Step 2: verify fail → Step 3: implement → Step 4: green + typecheck. Commit:** `feat(api): agent run execution ledger — session per run + real tool-execution rows (#3826)`
 
 ---
 
@@ -72,8 +72,8 @@ wave: W05 (#3826) — Part A (inert foundations)
 - `finishRun`: after the status CAS succeeds, `reconcileHungExecutions` + `closeAgentRunSession` (completed for `completed|awaiting_approval`, failed otherwise) — both best-effort (log, never change the run's terminal status).
 - Denied/proposed calls create NO ledger rows (they never execute).
 
-- [ ] **Step 1: failing tests** — session created once per run with the snapshot's model; executedActions carry real UUIDs; ledger failure doesn't block the call (tool still executes, executionId `'(inline)'`); reconcile invoked on finish; proposals produce no rows.
-- [ ] **Step 2-4: red → implement → green + typecheck. Commit:** `feat(api): run loop writes the execution ledger (#3826)`
+- [x] **Step 1: failing tests** — session created once per run with the snapshot's model; executedActions carry real UUIDs; ledger failure doesn't block the call (tool still executes, executionId `'(inline)'`); reconcile invoked on finish; proposals produce no rows.
+- [x] **Step 2-4: red → implement → green + typecheck. Commit:** `feat(api): run loop writes the execution ledger (#3826)`
 
 ---
 
@@ -89,8 +89,8 @@ wave: W05 (#3826) — Part A (inert foundations)
 - Audit: where these paths call `createAuditLog`, pass `actorType: 'ai_agent'` when the auth principal kind is `ai_agent` (`auth.principal.kind` — verify the field shape in `agentAuthContext.ts:71-105`), instead of the default `'user'` derivation.
 - Do NOT touch `routes/remediationSuggestions.ts` (human-only route; agents can't reach it — Part B builds the agent-safe service).
 
-- [ ] **Step 1: failing tests** — agent-shaped id (not a users row) → columns written null + metadata carries actorType/actorId; real user id → unchanged behavior byte-for-byte; audit actorType asserted via mock.
-- [ ] **Step 2-4: red → implement → green + typecheck. Commit:** `fix(api): agent principals no longer write synthetic ids into users-FK attribution columns (#3826)`
+- [x] **Step 1: failing tests** — agent-shaped id (not a users row) → columns written null + metadata carries actorType/actorId; real user id → unchanged behavior byte-for-byte; audit actorType asserted via mock.
+- [x] **Step 2-4: red → implement → green + typecheck. Commit:** `fix(api): agent principals no longer write synthetic ids into users-FK attribution columns (#3826)`
 
 ---
 
@@ -103,7 +103,7 @@ wave: W05 (#3826) — Part A (inert foundations)
 
 **Contract:** `maxActionsPerRun: number` — default **3**, validator `int().min(1).max(10)`. The `mergeLimits` loop (`effectivePolicy.ts:67-97`) handles new numeric fields generically (min-wins) — add a merge test proving partner 5 + org 2 → 2. NOTHING enforces the cap in this PR (Part B's loop does); the field exists so partners can pre-configure and snapshots carry it.
 
-- [ ] **Steps: red → implement → `pnpm --filter @breeze/shared test` + api effectivePolicy/runService tests + typecheck → green. Commit:** `feat(shared,api): maxActionsPerRun limit + agent policy snapshot v2 (#3826)`
+- [x] **Steps: red → implement → `pnpm --filter @breeze/shared test` + api effectivePolicy/runService tests + typecheck → green. Commit:** `feat(shared,api): maxActionsPerRun limit + agent policy snapshot v2 (#3826)`
 
 ---
 
@@ -116,7 +116,7 @@ wave: W05 (#3826) — Part A (inert foundations)
 
 **Contract:** device-bound agent run + sibling device in the SAME site → denied (today it passes — the site-level pin is the verified gap, `agentAuthContext.ts:71`). Interactive/user AuthContexts never set the field → zero behavior change. Non-device-bound agent runs (org-wide triage) don't set it either — their scoping stays org+site rules.
 
-- [ ] **Steps: red (the sibling-device test MUST fail against current code — that's the proof the gap is real) → implement → green + typecheck. Commit:** `fix(api): device-bound agent runs are pinned to the exact device, not the site (#3826)`
+- [x] **Steps: red (the sibling-device test MUST fail against current code — that's the proof the gap is real) → implement → green + typecheck. Commit:** `fix(api): device-bound agent runs are pinned to the exact device, not the site (#3826)`
 
 ---
 
@@ -132,15 +132,15 @@ wave: W05 (#3826) — Part A (inert foundations)
 - The worker re-loads the run + agent + snapshot from the DB and re-runs the same notify logic (extract the body into an exported `deliverRunFinishedNotifications(runId)` both paths call). Idempotent by construction: `createNotification`'s `(userId, dedupeKey)` conflict-ignore (`userNotifications.ts:78-94`) makes duplicate delivery a no-op.
 - Zero-recipients stays a silent return here (act-activation prerequisites are Part B) — but now logged at warn with the runId.
 
-- [ ] **Steps: red → implement → green (incl. registry snapshot updates: 105 → 106 names — update BOTH literals + counts, run the closure contract test for the placement verdict) + typecheck. Commit:** `feat(api): durable agent run-finished notifications via retry lane (#3826)`
+- [x] **Steps: red → implement → green (incl. registry snapshot updates: 105 → 106 names — update BOTH literals + counts, run the closure contract test for the placement verdict) + typecheck. Commit:** `feat(api): durable agent run-finished notifications via retry lane (#3826)`
 
 ---
 
 ### Task 7: Verification + PR
 
-- [ ] Full api unit suite (exact totals) + `pnpm --filter @breeze/shared test` + typecheck (heap bump).
-- [ ] Contract tests explicitly: workerEntrypointClosure + workerRegistry + agentDispatchBoundary + envComposeParity — green.
-- [ ] Repo-wide grep: no remaining `'(inline)'` writes outside the documented ledger-failure fallback; no new `auth.user.id` writes into users-FK columns in the three touched services.
+- [x] Full api unit suite (exact totals) + `pnpm --filter @breeze/shared test` + typecheck (heap bump).
+- [x] Contract tests explicitly: workerEntrypointClosure + workerRegistry + agentDispatchBoundary + envComposeParity — green.
+- [x] Repo-wide grep: no remaining `'(inline)'` writes outside the documented ledger-failure fallback; no new `auth.user.id` writes into users-FK columns in the three touched services.
 - [ ] Tick plan checkboxes. **Open the PR**: branch `feature/3821-ai-agents/wave-3826` → main, title `feat(api): wave 4 part A — act-mode foundations (execution ledger, attribution, durable notify, caps v2, device pinning)`, body: inertness statement (modes still off|shadow), the quorum pointer, per-task summary, and "Part A of #3826 — do NOT close the issue". **Stop after opening the PR.**
 
 ## Self-Review Notes

--- a/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave4-a-foundations.md
+++ b/docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave4-a-foundations.md
@@ -1,0 +1,150 @@
+---
+tracking_issue: LanternOps/breeze#3821
+wave: W05 (#3826) — Part A (inert foundations)
+---
+
+# Wave 4 Part A — Act-Mode Foundations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The inert groundwork act mode (Part B) will stand on: a real execution ledger for agent runs (ai_sessions + ai_tool_executions rows instead of the `'(inline)'` placeholder), agent attribution that survives users-FK columns, durable run-finished notifications, the `maxActionsPerRun` cap + policy snapshot v2, and device-exact pinning of the agent principal. **Zero behavior change for what agents may DO** — modes stay `off|shadow`; every change here is ledger/attribution/plumbing that shadow runs exercise immediately.
+
+**Architecture:** Each agent run gets one `ai_sessions` row (`type: 'agent'` — the schema shipped this in wave 1: `ai_sessions.agent_id`, `ai_sessions_agent_type_check`, single-principal CHECK, `ai_agent_runs.session_id` FK) created at run start; the run-loop pre-hook inserts a real `ai_tool_executions` row (UUID, status `executing`) per allowed call and the post-hook completes it (per-tool FIFO correlation — same ordering assumption as today's `Map<toolName, count>`, now with durable rows); run finish reconciles any row left `executing`. Script/playbook writers stop writing synthetic agent ids into users-FK columns (probe-and-degrade, the `commandQueue.ts:855-889` precedent) while preserving agent attribution in metadata. `notifyRunFinished` failures enqueue a BullMQ retry (safe: `createNotification` is dedupe-idempotent). `maxActionsPerRun` joins `AiAgentLimits`; snapshot version bumps 1→2 with read-side tolerance for 1. `AuthContext` gains optional `allowedDeviceIds`; the agent context pins device-bound runs to THE device, not its whole site.
+
+**Tech Stack:** TypeScript, Drizzle, BullMQ, Vitest. **No DB migrations** (all new state fits existing columns; `maxActionsPerRun` lives inside the `limits` jsonb; ledger rows use existing tables).
+
+**Design authority:** Program spec `docs/superpowers/specs/ai-mcp/2026-08-22-ai-agents-program-and-wave1-design.md` + wave-4 advisor quorum 2026-08-27 (Fable position + codex xhigh — codex amendments adopted; full decision record in the run memory + PR body). **Do not relitigate:** no blanket Tier-2 execution ever (Part B uses a closed operation manifest); this PR changes no guardrail dispositions; `execute_command` stays excluded from any act path; attribution for agent commands lives on the run/intent linkage, never on users-FK columns.
+
+## Global Constraints
+
+- **Inertness is the safety story**: `SUPPORTED_AGENT_MODES` stays `['off','shadow']` in this PR. A shadow run behaves identically except: it now has a session row, real tool-execution rows, device-exact pinning (a *tightening*), and durable notifications. Nothing new executes.
+- Run single test files as `cd apps/api && npx vitest run <path>`; typecheck `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit`.
+- No new env vars, no compose changes, NO migrations. If you believe you need a migration, stop and re-read the schema — `ai_sessions.agent_id`/`type` and `ai_agent_runs.session_id` shipped in `2026-09-02-ai-agents.sql`.
+- New columns are NOT being added, so the tenant-export-policy registry needs no edits. If any task drifts into adding a column, that's a plan violation — stop.
+- BullMQ queues via `createInstrumentedQueue` only; enqueues outside held DB contexts (#1105); jobIds hyphen-only.
+- `ai_tool_executions` has no `org_id` (tenancy via `session_id → ai_sessions`, registered as derived in rls-coverage `:562-563`). Writing rows requires the run's system DB context (same context the loop already holds for outcome writes — verify with the existing patterns in `runLoop.ts`).
+- Shared-package edits (`packages/shared`) ripple: run `pnpm --filter @breeze/shared test` AND the api suite after Task 4.
+- Commit after every task with trailers:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+  `Claude-Session: https://claude.ai/code/session_012o7QB15EFjEvetDAXMxmae`
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `apps/api/src/services/aiAgents/executionLedger.ts` (new) | Session-per-run + tool-execution row lifecycle + crash reconcile. |
+| `apps/api/src/services/aiAgents/runLoop.ts` (modify) | Create session at start; hooks write/complete ledger rows; reconcile in finish; notify retry enqueue. |
+| `apps/api/src/jobs/agentNotifyRetryWorker.ts` (new) | Tiny BullMQ retry lane for failed run-finished notifications. |
+| `apps/api/src/services/scriptDispatch.ts` + `services/aiToolsScripts.ts` + `services/aiToolsPlaybooks.ts` (modify) | Users-FK probe-and-degrade + agent attribution metadata. |
+| `packages/shared/src/types/aiAgents.ts` + `validators/aiAgents.ts` (modify) | `maxActionsPerRun`, snapshot v2. |
+| `apps/api/src/services/aiAgents/agentAuthContext.ts` + the shared `AuthContext` type + device-access helper (modify) | `allowedDeviceIds` device-exact pinning. |
+| `apps/api/src/services/workerRegistry.ts` + `index.ts`/`worker.ts` shutdown (modify) | Register the notify-retry worker (global placement). |
+
+---
+
+### Task 1: Execution ledger service
+
+**Files:**
+- Create: `apps/api/src/services/aiAgents/executionLedger.ts`, `executionLedger.test.ts`
+
+**Interfaces (produced):**
+- `createAgentRunSession(args: { runId: string; agentId: string; orgId: string; deviceId: string | null; model: string }): Promise<string>` — inserts `ai_sessions` (`type: 'agent'`, `agentId`, `orgId`, `deviceId`, `model`, `status: 'active'`, `maxTurns` from caller) and CAS-updates `ai_agent_runs.session_id` WHERE `session_id IS NULL` (re-run of a crashed run must not orphan a second session: on CAS miss, mark the just-created session `status: 'completed'` and return the run's existing sessionId).
+- `startToolExecution(args: { sessionId: string; toolName: string; toolInput: Record<string, unknown> }): Promise<string>` — inserts `ai_tool_executions` (status `'executing'`... check the `aiToolStatusEnum` values first and use the correct in-flight value; if only `pending|approved|executing|completed|failed|denied`-style values exist, pick the in-flight one) and returns the row id.
+- `completeToolExecution(args: { executionId: string; isError: boolean; durationMs: number }): Promise<void>` — sets terminal status + `durationMs` + `completedAt`. Tool OUTPUT is deliberately NOT stored in this PR (redaction rules land with Part B's manifest; storing raw outputs now would leak command results into an exportable table — `toolOutput` stays null).
+- `reconcileHungExecutions(sessionId: string): Promise<number>` — terminal-marks (status failed, errorMessage `'run finished with execution unresolved'`) every row still in-flight for the session; returns count.
+- `closeAgentRunSession(sessionId: string, status: 'completed' | 'failed'): Promise<void>`.
+
+- [ ] **Step 1: failing unit tests** (Drizzle mock pattern per `breeze-testing`): session insert carries `type:'agent'` + agentId + no userId; CAS second-session behavior; start/complete round-trip; reconcile only touches in-flight rows of THAT session; all writes run under the provided db handle (no ambient pool).
+- [ ] **Step 2: verify fail → Step 3: implement → Step 4: green + typecheck. Commit:** `feat(api): agent run execution ledger — session per run + real tool-execution rows (#3826)`
+
+---
+
+### Task 2: Wire the ledger into the run loop
+
+**Files:**
+- Modify: `apps/api/src/services/aiAgents/runLoop.ts` (`executeAgentRun` ~:836-929; `createAgentRunPreToolUse` :320-401; `createAgentRunPostToolUse` :414-435; `finishRun` :937-975)
+- Test: extend `runLoop`'s existing test files
+
+**Contract:**
+- After the CAS `queued→running`, create the session (Task 1) with the run's policy-snapshot model + maxTurns; store `sessionId` in the RunContext.
+- Pre-hook: for an ALLOWED call, `startToolExecution` and push the returned id into a per-toolName FIFO (replacing nothing — the `allowedPending` count map stays for the post-hook gate). A ledger-write failure must NOT block the tool call (log + push a sentinel `null`): the ledger is observability, not authorization — authorization stays entirely in `checkAgentGuardrails`.
+- Post-hook: shift the FIFO; when an id is present, `completeToolExecution`; `outcome.executedActions[].executionId` becomes the real UUID (falls back to `'(inline)'` on sentinel). Same-ordering caveat documented: per-tool FIFO correlation matches today's count-map assumption; genuine per-invocation ids need SDK hook support (out of scope).
+- `finishRun`: after the status CAS succeeds, `reconcileHungExecutions` + `closeAgentRunSession` (completed for `completed|awaiting_approval`, failed otherwise) — both best-effort (log, never change the run's terminal status).
+- Denied/proposed calls create NO ledger rows (they never execute).
+
+- [ ] **Step 1: failing tests** — session created once per run with the snapshot's model; executedActions carry real UUIDs; ledger failure doesn't block the call (tool still executes, executionId `'(inline)'`); reconcile invoked on finish; proposals produce no rows.
+- [ ] **Step 2-4: red → implement → green + typecheck. Commit:** `feat(api): run loop writes the execution ledger (#3826)`
+
+---
+
+### Task 3: Agent attribution — users-FK probe-and-degrade
+
+**Files:**
+- Modify: `apps/api/src/services/scriptDispatch.ts` (`dispatchScriptToDevice` — find where `triggeredBy`/`createdBy` land in `script_executions.triggered_by` (FK → users, `schema/scripts.ts:126`)), `apps/api/src/services/aiToolsScripts.ts` (:445-454 passes `auth.user.id` verbatim), `apps/api/src/services/aiToolsPlaybooks.ts` (:180-193 `triggeredByUserId: auth.user.id`)
+- Test: extend the three services' test files
+
+**Contract (mirror `commandQueue.ts:855-889` — the shipped precedent):**
+- `dispatchScriptToDevice` gains an internal users-row probe for its `triggeredBy`/`createdBy` values (single probe, both columns): a value that is not a real `users.id` degrades to `null` before insert, and the dispatch metadata/details JSON records `{ actorType: 'ai_agent', actorId: <original id> }` so attribution survives. Callers unchanged.
+- `aiToolsPlaybooks`: same probe for `triggeredByUserId`; the existing `triggeredBy: 'ai'` varchar tag stays.
+- Audit: where these paths call `createAuditLog`, pass `actorType: 'ai_agent'` when the auth principal kind is `ai_agent` (`auth.principal.kind` — verify the field shape in `agentAuthContext.ts:71-105`), instead of the default `'user'` derivation.
+- Do NOT touch `routes/remediationSuggestions.ts` (human-only route; agents can't reach it — Part B builds the agent-safe service).
+
+- [ ] **Step 1: failing tests** — agent-shaped id (not a users row) → columns written null + metadata carries actorType/actorId; real user id → unchanged behavior byte-for-byte; audit actorType asserted via mock.
+- [ ] **Step 2-4: red → implement → green + typecheck. Commit:** `fix(api): agent principals no longer write synthetic ids into users-FK attribution columns (#3826)`
+
+---
+
+### Task 4: `maxActionsPerRun` + policy snapshot v2
+
+**Files:**
+- Modify: `packages/shared/src/types/aiAgents.ts` (`AiAgentLimits` + `AI_AGENT_LIMIT_DEFAULTS` :22-42; `AI_AGENT_POLICY_SNAPSHOT_VERSION` :93), `packages/shared/src/validators/aiAgents.ts` (`limitsFields` :31-45)
+- Modify: every snapshot-version consumer — `grep -rn "AI_AGENT_POLICY_SNAPSHOT_VERSION\|schemaVersion" apps/api/src packages/shared/src` and make every read-side check accept `1 | 2` (an in-flight run enqueued before deploy carries v1; it must still execute — write-side always stamps 2)
+- Test: shared validator tests + effectivePolicy merge tests
+
+**Contract:** `maxActionsPerRun: number` — default **3**, validator `int().min(1).max(10)`. The `mergeLimits` loop (`effectivePolicy.ts:67-97`) handles new numeric fields generically (min-wins) — add a merge test proving partner 5 + org 2 → 2. NOTHING enforces the cap in this PR (Part B's loop does); the field exists so partners can pre-configure and snapshots carry it.
+
+- [ ] **Steps: red → implement → `pnpm --filter @breeze/shared test` + api effectivePolicy/runService tests + typecheck → green. Commit:** `feat(shared,api): maxActionsPerRun limit + agent policy snapshot v2 (#3826)`
+
+---
+
+### Task 5: Device-exact pinning of the agent principal
+
+**Files:**
+- Modify: the `AuthContext` type (find it: `grep -rn "interface AuthContext" apps/api/src packages/shared/src` — add OPTIONAL `allowedDeviceIds?: readonly string[]`), `apps/api/src/services/aiAgents/agentAuthContext.ts` (:71-105 — set `allowedDeviceIds: [run.deviceId]` for device-bound runs alongside the existing site pinning)
+- Modify: the device-access resolution helper the AI tools use (find the single chokepoint: grep how `aiTools*` resolve `access.device` — likely a `resolveDeviceAccess`/`requireDeviceAccess` in a shared aiTools helper; enforce `allowedDeviceIds` there when present: a device not in the list → the same "not found/no access" error shape the helper already returns)
+- Test: agentAuthContext tests + the device-access helper's tests
+
+**Contract:** device-bound agent run + sibling device in the SAME site → denied (today it passes — the site-level pin is the verified gap, `agentAuthContext.ts:71`). Interactive/user AuthContexts never set the field → zero behavior change. Non-device-bound agent runs (org-wide triage) don't set it either — their scoping stays org+site rules.
+
+- [ ] **Steps: red (the sibling-device test MUST fail against current code — that's the proof the gap is real) → implement → green + typecheck. Commit:** `fix(api): device-bound agent runs are pinned to the exact device, not the site (#3826)`
+
+---
+
+### Task 6: Durable run-finished notifications
+
+**Files:**
+- Create: `apps/api/src/jobs/agentNotifyRetryWorker.ts` (+ test)
+- Modify: `apps/api/src/services/aiAgents/runLoop.ts` (`notifyRunFinished` :527-579), `apps/api/src/services/workerRegistry.ts` (+ its two snapshot lists in `workerRegistry.test.ts` / `workerEntrypointClosure.contract.test.ts` — registry entry `agentNotifyRetry`, placement will be verdicted by the closure contract test; expect `global`)
+- Test: extend runLoop notify tests
+
+**Contract:**
+- `notifyRunFinished` structure unchanged (recipients from the immutable snapshot, re-resolved at notify time), but: (a) the notification `metadata` gains the structured shape Part B will fill — `{ runId, agentId, intentIds, status, executedActionCount: outcome.toolExecutionCount, verdict: null }` (verdict stays null until Part B); (b) on ANY failure (resolve or create), enqueue ONE `agent-notify-retry` job carrying `{ runId }` — job options `attempts: 5`, exponential backoff starting 30s, `jobId: 'agent-notify-<runId>'` (hyphen-only).
+- The worker re-loads the run + agent + snapshot from the DB and re-runs the same notify logic (extract the body into an exported `deliverRunFinishedNotifications(runId)` both paths call). Idempotent by construction: `createNotification`'s `(userId, dedupeKey)` conflict-ignore (`userNotifications.ts:78-94`) makes duplicate delivery a no-op.
+- Zero-recipients stays a silent return here (act-activation prerequisites are Part B) — but now logged at warn with the runId.
+
+- [ ] **Steps: red → implement → green (incl. registry snapshot updates: 105 → 106 names — update BOTH literals + counts, run the closure contract test for the placement verdict) + typecheck. Commit:** `feat(api): durable agent run-finished notifications via retry lane (#3826)`
+
+---
+
+### Task 7: Verification + PR
+
+- [ ] Full api unit suite (exact totals) + `pnpm --filter @breeze/shared test` + typecheck (heap bump).
+- [ ] Contract tests explicitly: workerEntrypointClosure + workerRegistry + agentDispatchBoundary + envComposeParity — green.
+- [ ] Repo-wide grep: no remaining `'(inline)'` writes outside the documented ledger-failure fallback; no new `auth.user.id` writes into users-FK columns in the three touched services.
+- [ ] Tick plan checkboxes. **Open the PR**: branch `feature/3821-ai-agents/wave-3826` → main, title `feat(api): wave 4 part A — act-mode foundations (execution ledger, attribution, durable notify, caps v2, device pinning)`, body: inertness statement (modes still off|shadow), the quorum pointer, per-task summary, and "Part A of #3826 — do NOT close the issue". **Stop after opening the PR.**
+
+## Self-Review Notes
+
+- Inertness check per task: T1/T2 add rows shadow runs write anyway; T3 tightens attribution (agent ids stop hitting users FKs — strictly fewer 23503 risks); T4 adds an unenforced field; T5 is a pure tightening; T6 retries something that previously just failed. No guardrail disposition changes anywhere.
+- Type consistency: ledger fn names (T1) consumed in T2; `deliverRunFinishedNotifications` (T6) shared by loop + worker; `allowedDeviceIds` optional so no other AuthContext construction site changes.
+- Known deferred (Part B): manifest + executors + act guardrail branch + revalidation + verification verdicts + notification verdict content + act-activation prerequisites + UI + `maxActionsPerRun` enforcement + agent-safe remediation-suggestion service + deterministic playbook executor.

--- a/packages/shared/src/types/aiAgents.ts
+++ b/packages/shared/src/types/aiAgents.ts
@@ -28,6 +28,13 @@ export interface AiAgentLimits {
   maxBudgetCentsPerDay: number;
   wallClockSeconds: number;
   maxFleetPercentPerDay: number;
+  /**
+   * Cap on the number of act-mode tool executions a single run may perform.
+   * Unenforced in this PR (Part B's run loop enforces it) — the field exists
+   * now so partners/orgs can pre-configure it and every policy snapshot from
+   * this point on carries it.
+   */
+  maxActionsPerRun: number;
 }
 
 export const AI_AGENT_LIMIT_DEFAULTS: Readonly<AiAgentLimits> = Object.freeze({
@@ -39,6 +46,7 @@ export const AI_AGENT_LIMIT_DEFAULTS: Readonly<AiAgentLimits> = Object.freeze({
   maxBudgetCentsPerDay: 1000,
   wallClockSeconds: 600,
   maxFleetPercentPerDay: 5,
+  maxActionsPerRun: 3,
 });
 
 export interface AiAgentTriggers {
@@ -89,11 +97,18 @@ export type AiAgentPolicyProvenance = Record<keyof AiAgentPolicy, 'partner' | 'o
  * is append-only ledger data that outlives this type, so a v1 row must stay
  * distinguishable from a v2 row — there is no backfill for a run that already
  * happened.
+ *
+ * v2 (this bump): `effective.limits` gained `maxActionsPerRun`. An in-flight
+ * run enqueued before deploy still carries a v1 snapshot (no `maxActionsPerRun`
+ * in `effective.limits`) and MUST still execute — every read site that
+ * touches `schemaVersion` or `effective.limits` has to tolerate a v1 row,
+ * never reject it. Write side always stamps the current version.
  */
-export const AI_AGENT_POLICY_SNAPSHOT_VERSION = 1 as const;
+export const AI_AGENT_POLICY_SNAPSHOT_VERSION = 2 as const;
 
 export interface AiAgentPolicySnapshot {
-  schemaVersion: number;
+  /** 1 (pre-maxActionsPerRun) or 2 (current). Read sites must tolerate both. */
+  schemaVersion: 1 | 2;
   agentId: string;
   kind: AiAgentKind;
   effective: AiAgentPolicy;

--- a/packages/shared/src/validators/aiAgents.test.ts
+++ b/packages/shared/src/validators/aiAgents.test.ts
@@ -15,6 +15,16 @@ describe('aiAgents validators', () => {
     expect(aiAgentLimitsSchema.safeParse({ maxDevicesPerRun: 0 }).success).toBe(false);
   });
 
+  it('maxActionsPerRun defaults to 3 and clamps to [1,10]', () => {
+    expect(AI_AGENT_LIMIT_DEFAULTS.maxActionsPerRun).toBe(3);
+    expect(aiAgentLimitsSchema.parse({}).maxActionsPerRun).toBe(3);
+    expect(aiAgentLimitsSchema.safeParse({ maxActionsPerRun: 1 }).success).toBe(true);
+    expect(aiAgentLimitsSchema.safeParse({ maxActionsPerRun: 10 }).success).toBe(true);
+    expect(aiAgentLimitsSchema.safeParse({ maxActionsPerRun: 0 }).success).toBe(false);
+    expect(aiAgentLimitsSchema.safeParse({ maxActionsPerRun: 11 }).success).toBe(false);
+    expect(aiAgentLimitsSchema.safeParse({ maxActionsPerRun: 2.5 }).success).toBe(false);
+  });
+
   it('rejects instructions over 2000 chars and unknown allowlist shapes', () => {
     expect(aiAgentPolicyFieldsSchema.safeParse({ instructions: 'x'.repeat(2001) }).success).toBe(false);
     expect(aiAgentPolicyFieldsSchema.safeParse({ toolAllowlist: ['run_script', 'manage_services:restart'] }).success).toBe(true);

--- a/packages/shared/src/validators/aiAgents.ts
+++ b/packages/shared/src/validators/aiAgents.ts
@@ -37,6 +37,7 @@ const limitsFields = z.object({
   maxBudgetCentsPerDay: z.number().int().min(1).max(100000),
   wallClockSeconds: z.number().int().min(30).max(1800),
   maxFleetPercentPerDay: z.number().int().min(1).max(100),
+  maxActionsPerRun: z.number().int().min(1).max(10),
 });
 export const aiAgentLimitsPatchSchema = limitsFields.partial();
 export const aiAgentLimitsSchema = aiAgentLimitsPatchSchema.transform((v) => ({


### PR DESCRIPTION
**Part A (inert foundations) of #3826 — do NOT close the issue.** Wave 4 gives agents act mode; this PR ships everything act mode will stand on while **changing nothing about what agents may do**: `SUPPORTED_AGENT_MODES` stays `off|shadow`, no guardrail disposition changes, no migrations, no new columns. Plan: `docs/superpowers/plans/ai-mcp/2026-08-27-ai-agents-wave4-a-foundations.md`; design authority = program spec + wave-4 advisor quorum 2026-08-27 (act mode will be a closed operation manifest — full decision record in the plan header and Part B).

## What ships

- **Execution ledger** (`services/aiAgents/executionLedger.ts`): every agent run now gets one `ai_sessions` row (`type: 'agent'` — the wave-1 schema anticipated this) and every allowed tool call a real `ai_tool_executions` row (UUID before dispatch, completed by the post-hook, crash-reconciled at run finish) — replacing the `'(inline)'` placeholder. Ledger failures never block a tool call (observability, not authorization); tool output deliberately not stored until Part B's redaction rules.
- **Agent attribution** — agent principals no longer write synthetic ids into users-FK columns (`script_executions.triggered_by`, playbook `triggered_by_user_id`): probe-and-degrade mirroring the shipped `commandQueue` precedent (wrapped in a system DB context — review-caught), with the agent identity preserved in execution metadata and audit rows stamped `actorType: 'ai_agent'`.
- **Device-exact pinning** — a device-bound agent run was pinned to the device's *site*, not the device (a sibling same-site device passed access checks — proven by a red test against the base). `AuthContext` gains optional `allowedDeviceIds`; the agent principal sets it; the AI-tool device-access chokepoint enforces it. Interactive sessions and org-wide runs unaffected.
- **Durable run-finished notifications** — `notifyRunFinished` failures now enqueue a bounded BullMQ retry (`agent-notify-retry`, attempts 5, backoff; idempotent via the existing `(userId, dedupeKey)` conflict-ignore). Registry gains the worker (global placement, snapshots at 106).
- **`maxActionsPerRun`** joins `AiAgentLimits` (default 3, max 10, min-wins partner/org merge) and the policy snapshot bumps to **v2** with read-side tolerance for in-flight v1 runs. Deliberately unenforced here — Part B's run loop enforces it (documented in the runService limits-coverage list, review-caught).

## Review provenance

4 staged implement→review rounds (opus on ledger/attribution/caps-pinning; 1 blocking finding fixed in-stage) + whole-branch opus review at xhigh (2 blockers fixed: the limits-coverage doc omission and the probe's missing system-DB-context wrapper — the latter latent-only but the failure mode was a human action durably recorded as an AI agent's). Full unit suite **27,081 passed / 0 failed** (one branch-caused test-mock gap found by the suite and fixed), shared package 2,069/0, typecheck clean, contract suites 226/0.

## Known accepted caveats (flagged per run authorization)

- Per-tool FIFO correlation can swap `durationMs`/`isError` between two *concurrent same-tool* calls (same assumption as the pre-existing count map, now durable); true per-invocation ids need SDK hook support.
- The pre-hook now awaits one DB insert on the allow path (bounded by the run's wall-clock abort).
- Playbook path records the probe-degrade but not an agent-id sidecar (scripts do); Part B's manifest executor supersedes this path for act.

Part B (next PR): the operation manifest + per-op executors + guardrail act branch + revalidation + verification verdicts + `SUPPORTED_AGENT_MODES` + UI + activation prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012o7QB15EFjEvetDAXMxmae
