### PR TITLE
feat(api,web): wave 5 part B — policy-satisfied unattended Tier-3 (dark): the policy-decide lane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -972,6 +972,14 @@ MANAGED_SOFTWARE_POLICY_MODE=compat
 # unattended until a later release even when true.
 # BREEZE_AI_AGENTS_ENABLED=false
 
+# Wave 5 Part B (#3827) sub-flag of BREEZE_AI_AGENTS_ENABLED above. Gates
+# attemptPolicyDecision: an agent-originated, supervised-scope action-intent
+# whose operation is in the operator's per-agent actAssets.supervisedActionKeys
+# (⊆ POLICY_DECIDABLE_TIER3) is authorized by policy — no human approval —
+# instead of the normal human-decide fanout. Default false (dark-ship): when
+# false, resolvePolicyDecisionState behaves exactly as before this wave.
+# BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED=false
+
 # --------------------------------------------
 # Docker Deployment
 # --------------------------------------------

--- a/apps/api/src/config/env.policyDecideEnabled.test.ts
+++ b/apps/api/src/config/env.policyDecideEnabled.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { policyDecideEnabled } from './env';
+
+// Wave 5 Part B (#3827). Sub-flag of BREEZE_AI_AGENTS_ENABLED gating
+// attemptPolicyDecision — see the Global Constraints dark-ship statement in
+// the plan header. Read at CALL time (not a module-scope const) so a test can
+// flip it per-case without vi.resetModules(), same as isHosted()/breezeRole().
+describe('policyDecideEnabled()', () => {
+  const original = process.env.BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED;
+  afterEach(() => {
+    if (original === undefined) delete process.env.BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED;
+    else process.env.BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED = original;
+  });
+
+  it.each([
+    [undefined, false],
+    ['', false],
+    ['false', false],
+    ['0', false],
+    ['no', false],
+    ['off', false],
+    ['garbage', false],
+    ['true', true],
+    ['1', true],
+    ['yes', true],
+    ['on', true],
+    ['TRUE', true],
+    ['  true  ', true],
+  ])('BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED=%s → %s', (raw, expected) => {
+    if (raw === undefined) delete process.env.BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED;
+    else process.env.BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED = raw;
+    expect(policyDecideEnabled()).toBe(expected);
+  });
+
+  it('is read at call time — flipping the env var changes the very next call, no reimport needed', () => {
+    delete process.env.BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED;
+    expect(policyDecideEnabled()).toBe(false);
+    process.env.BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED = 'true';
+    expect(policyDecideEnabled()).toBe(true);
+    process.env.BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED = 'false';
+    expect(policyDecideEnabled()).toBe(false);
+  });
+});

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -99,6 +99,19 @@ export const GOOGLE_WORKSPACE_ENABLED = envFlag('GOOGLE_WORKSPACE_ENABLED', fals
 // Default OFF until the wave-3 runner ships.
 export const AI_AGENTS_ENABLED = envFlag('BREEZE_AI_AGENTS_ENABLED', false);
 
+// Wave 5 Part B (#3827). Sub-flag of BREEZE_AI_AGENTS_ENABLED: gates
+// attemptPolicyDecision (policyDecide.ts) — an agent-originated, supervised-
+// scope action-intent whose operation is in the operator's per-agent
+// actAssets.supervisedActionKeys ⊆ POLICY_DECIDABLE_TIER3 is authorized by
+// policy instead of human fanout. Default OFF (dark-ship): when false,
+// resolvePolicyDecisionState returns 'human_required' exactly as Part A —
+// byte-identical to the merged behavior before this wave (Global
+// Constraints, plan header). Read at CALL time, like isHosted()/breezeRole()
+// above, so a test can flip it per-case without vi.resetModules().
+export function policyDecideEnabled(): boolean {
+  return envFlag('BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED', false);
+}
+
 // Microsoft 365 identity tools. Defaults OFF everywhere; an org must also have
 // an explicit m365_connections row before any tool is usable. Gates tool
 // registration (aiAgentSdkTools.ts) and the connect routes.

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -2922,3 +2922,53 @@ describe('EVENT_DISPATCH_MODE / EVENT_DISPATCH_QUEUE_SUBSCRIBERS guard', () => {
     warn.mockRestore();
   });
 });
+
+// Wave 5 Part B (#3827) sub-flag. Same guard, same reasoning as
+// AGENT_AUTO_PROMOTE/ABUSE_SIGNALS_ENABLED above: this silently governs
+// whether attemptPolicyDecision ever runs, so a typo must be caught at boot
+// rather than silently reading as off at the envFlag reader.
+describe('BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED boolean guard', () => {
+  it('is declared in the schema, so the superRefine rule actually runs', () => {
+    expect(ENV_SCHEMA_KEYS).toContain('BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED');
+    expect(
+      buildEnvParseInput({ BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED: 'sentinel' })
+        .BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED,
+    ).toBe('sentinel');
+  });
+
+  it.each(['true', 'false', '1', '0', 'yes', 'no', 'on', 'off', 'FALSE', ' off '])(
+    'accepts the recognized boolean %j',
+    (value) => {
+      withEnv({ ...validEnv, BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED: value }, () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    },
+  );
+
+  it('leaves the value unset when unset', () => {
+    withEnv(validEnv, () => {
+      withoutEnv(['BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED'], () => {
+        expect(validateConfig().BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED).toBeUndefined();
+      });
+    });
+  });
+
+  // Both compose api-env anchors map this as
+  // `${BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED:-false}` — a default-bearing
+  // interpolation, so the key reaches the container but the .env.example
+  // documents it commented-out. Either way "" must never refuse boot.
+  it.each(['', '   '])('treats an empty value (%j) as unset', (value) => {
+    withEnv({ ...validEnv, BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED: value }, () => {
+      expect(() => validateConfig()).not.toThrow();
+    });
+  });
+
+  it.each(['ture', 'enabled', 'disabled', 'TRUE!', 'y'])(
+    'refuses boot on the near-miss value %s',
+    (value) => {
+      withEnv({ ...validEnv, BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED: value }, () => {
+        expect(() => validateConfig()).toThrow(/BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED/);
+      });
+    },
+  );
+});

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -610,6 +610,12 @@ const envObjectSchema = z
     EVENT_DISPATCH_MODE: z.string().optional(),
     EVENT_DISPATCH_QUEUE_SUBSCRIBERS: z.string().optional(),
 
+    // Wave 5 Part B (#3827) sub-flag of BREEZE_AI_AGENTS_ENABLED. Gates
+    // attemptPolicyDecision — read at runtime by policyDecideEnabled() in
+    // env.ts. Validated here for boolean format only, same class as
+    // AGENT_AUTO_PROMOTE above.
+    BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED: z.string().optional(),
+
     // Process role for the 3.5d socket/worker split (wave 3.5b, #4084). all
     // (default) = today's all-in-one process. Read at runtime by
     // breezeRole() in env.ts. Validated here for format only — absence means
@@ -1701,6 +1707,23 @@ const envSchema = envObjectSchema
       console.warn(
         '[config] EVENT_DISPATCH_MODE=enforce but EVENT_DISPATCH_QUEUE_SUBSCRIBERS is empty — no subscriber will deliver via the queue.',
       );
+    }
+
+    // BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED (wave 5 Part B, #3827). Sub-flag
+    // of BREEZE_AI_AGENTS_ENABLED gating attemptPolicyDecision — unattended
+    // policy-decided authorization of a supervised-scope action-intent, no
+    // human fanout. Same treatment as AGENT_AUTO_PROMOTE/ABUSE_SIGNALS_ENABLED
+    // above: a typo must be caught at boot rather than silently reading as
+    // off at the envFlag reader. Empty/unset is allowed (defaults to false —
+    // dark-ship). Mirrors policyDecideEnabled() in env.ts.
+    const policyDecideRaw = (data.BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED ?? '').trim().toLowerCase();
+    if (policyDecideRaw && !boolValues.has(policyDecideRaw)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED'],
+        message:
+          'BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED must be a boolean (true/false, 1/0, yes/no, on/off) when set. Defaults to false (unattended policy-decided authorization is dark).',
+      });
     }
 
     // TRUST_CF_CONNECTING_IP. Same class as the two flags above: the runtime

--- a/apps/api/src/jobs/aiUnattendedExposureRetention.test.ts
+++ b/apps/api/src/jobs/aiUnattendedExposureRetention.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  addMock,
+  getRepeatableJobsMock,
+  removeRepeatableByKeyMock,
+  queueCloseMock,
+  workerCloseMock,
+  withSystemDbAccessContextMock,
+  dbExecuteMock,
+  attachWorkerObservabilityMock,
+  capturedWorkerProcessor,
+} = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  getRepeatableJobsMock: vi.fn(),
+  removeRepeatableByKeyMock: vi.fn(),
+  queueCloseMock: vi.fn(),
+  workerCloseMock: vi.fn(),
+  withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  dbExecuteMock: vi.fn(),
+  attachWorkerObservabilityMock: vi.fn(),
+  capturedWorkerProcessor: { current: null as null | ((job: { data: Record<string, unknown> }) => Promise<unknown>) },
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    add = (...args: unknown[]) => addMock(...(args as []));
+    getRepeatableJobs = () => getRepeatableJobsMock();
+    removeRepeatableByKey = (...args: unknown[]) => removeRepeatableByKeyMock(...(args as []));
+    close = () => queueCloseMock();
+  },
+  Worker: class {
+    constructor(_name: string, processor: (job: { data: Record<string, unknown> }) => Promise<unknown>) {
+      capturedWorkerProcessor.current = processor;
+    }
+    on = vi.fn();
+    close = () => workerCloseMock();
+  },
+  Job: class {},
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    execute: (...args: unknown[]) => dbExecuteMock(...(args as [])),
+  },
+  withSystemDbAccessContext: (fn: () => Promise<unknown>) => withSystemDbAccessContextMock(fn),
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}));
+
+vi.mock('./workerObservability', () => ({
+  attachWorkerObservability: (...args: unknown[]) => attachWorkerObservabilityMock(...(args as [])),
+}));
+
+import {
+  RETENTION_HOURS,
+  createAiUnattendedExposureRetentionWorker,
+  extractRowCount,
+  initializeAiUnattendedExposureRetention,
+  pruneAiUnattendedExposure,
+  shutdownAiUnattendedExposureRetention,
+} from './aiUnattendedExposureRetention';
+
+describe('AI unattended-exposure ledger retention worker (#3827 Task 4)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+    getRepeatableJobsMock.mockResolvedValue([]);
+    removeRepeatableByKeyMock.mockResolvedValue(undefined);
+    addMock.mockResolvedValue(undefined);
+    queueCloseMock.mockResolvedValue(undefined);
+    workerCloseMock.mockResolvedValue(undefined);
+    dbExecuteMock.mockResolvedValue({ rowCount: 0 });
+    capturedWorkerProcessor.current = null;
+  });
+
+  afterEach(async () => {
+    await shutdownAiUnattendedExposureRetention();
+  });
+
+  it('extracts row counts from supported driver result shapes', () => {
+    expect(extractRowCount({ rowCount: 4, count: 2 })).toBe(4);
+    expect(extractRowCount({ count: 3 })).toBe(3);
+    expect(extractRowCount([{}, {}])).toBe(2);
+    expect(extractRowCount({})).toBe(0);
+  });
+
+  it('the retention window is a fixed 48h', () => {
+    expect(RETENTION_HOURS).toBe(48);
+  });
+
+  it('registers a repeatable pruning job at the scheduleRegistry-allocated daily slot', async () => {
+    await initializeAiUnattendedExposureRetention();
+
+    expect(attachWorkerObservabilityMock).toHaveBeenCalledWith(expect.anything(), 'aiUnattendedExposureRetention');
+    expect(addMock).toHaveBeenCalledWith(
+      'ai-unattended-exposure-retention',
+      {},
+      expect.objectContaining({
+        jobId: 'ai-unattended-exposure-retention',
+        // Staggered daily slot, not an epoch-anchored interval (scheduleRegistry.ts).
+        repeat: { pattern: '8 18 * * *' },
+      }),
+    );
+  });
+
+  it('clears any stale repeatable jobs before registering the current one', async () => {
+    getRepeatableJobsMock.mockResolvedValue([{ key: 'stale-key-1' }, { key: 'stale-key-2' }]);
+    await initializeAiUnattendedExposureRetention();
+    expect(removeRepeatableByKeyMock).toHaveBeenCalledWith('stale-key-1');
+    expect(removeRepeatableByKeyMock).toHaveBeenCalledWith('stale-key-2');
+  });
+
+  it('deletes rows older than the 48h cutoff, inside system DB context', async () => {
+    dbExecuteMock.mockResolvedValueOnce({ rowCount: 7 });
+    createAiUnattendedExposureRetentionWorker();
+
+    const result = await capturedWorkerProcessor.current!({ data: {} });
+
+    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    expect(dbExecuteMock).toHaveBeenCalledTimes(1);
+
+    const sqlCall = JSON.stringify(dbExecuteMock.mock.calls[0]);
+    expect(sqlCall).toContain('DELETE FROM ai_unattended_exposure');
+    expect(sqlCall).toContain('reserved_at <');
+
+    expect(result).toEqual({ deletedCount: 7, durationMs: expect.any(Number) });
+  });
+
+  it('pruneAiUnattendedExposure reports zero rows deleted without throwing when nothing is due', async () => {
+    dbExecuteMock.mockResolvedValueOnce({ rowCount: 0 });
+    const result = await pruneAiUnattendedExposure();
+    expect(result.deletedCount).toBe(0);
+  });
+});

--- a/apps/api/src/jobs/aiUnattendedExposureRetention.ts
+++ b/apps/api/src/jobs/aiUnattendedExposureRetention.ts
@@ -1,0 +1,131 @@
+/**
+ * AI Unattended-Exposure Ledger Retention Worker (wave 5B, #3827 Task 4).
+ *
+ * `ai_unattended_exposure` is the org-wide blast-cap ledger both the act
+ * lane (`actRevalidation.ts`) and the policy-decide lane (`policyDecide.ts`)
+ * write to and read from — every fleet-percent check reads only the
+ * TRAILING 24 HOURS of rows (`gt(reservedAt, now() - interval '24 hours')`),
+ * so nothing outside that window is ever consulted again. This sweep prunes
+ * rows older than 48h — double the live-read window, not the window itself
+ * — so a row is never deleted while any in-flight cap check could still be
+ * reading it, without needing to reason precisely about clock skew or a
+ * check that started just before the boundary.
+ *
+ * Retention is a FIXED 48h, not an operator-configurable knob (unlike the
+ * data-retention-policy jobs this file's shape otherwise mirrors, e.g.
+ * `ipHistoryRetention.ts`): the window is load-bearing for the safety
+ * contract's cap math, not a storage/compliance choice an operator should be
+ * able to widen or narrow.
+ */
+
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { getBullMQConnection } from '../services/redis';
+import { attachWorkerObservability } from './workerObservability';
+import { jobSchedule } from './scheduleRegistry';
+
+const { db } = dbModule;
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof dbModule.withSystemDbAccessContext !== 'function') {
+    throw new Error('[AiUnattendedExposureRetention] withSystemDbAccessContext is not available — DB module may not have loaded correctly');
+  }
+  return dbModule.withSystemDbAccessContext(fn);
+};
+
+const QUEUE_NAME = 'ai-unattended-exposure-retention';
+const JOB_NAME = 'ai-unattended-exposure-retention';
+const REPEAT_JOB_ID = 'ai-unattended-exposure-retention';
+
+/** Fixed — see module header. Not env-configurable. */
+export const RETENTION_HOURS = 48;
+
+type RetentionJobResult = { deletedCount: number; durationMs: number };
+
+/**
+ * postgres-js / node-postgres row-count extraction — same shape as every
+ * other retention worker's own local copy (processSampleRetention.ts,
+ * mlOutputRetention.ts, ipHistoryRetention.ts).
+ */
+export function extractRowCount(result: unknown): number {
+  const raw = result as { rowCount?: number; count?: number };
+  if (typeof raw.rowCount === 'number') return raw.rowCount;
+  if (typeof raw.count === 'number') return raw.count;
+  return Array.isArray(result) ? result.length : 0;
+}
+
+export async function pruneAiUnattendedExposure(): Promise<RetentionJobResult> {
+  const startedAt = Date.now();
+  // postgres-js does not coerce JS Date in template-literal params; pass an
+  // ISO string, same convention every sibling retention worker follows.
+  const cutoff = new Date(Date.now() - RETENTION_HOURS * 60 * 60 * 1000).toISOString();
+
+  const result = await db.execute(sql`
+    DELETE FROM ai_unattended_exposure
+    WHERE reserved_at < ${cutoff}::timestamptz
+  `);
+  const deletedCount = extractRowCount(result);
+  const durationMs = Date.now() - startedAt;
+
+  console.log(`[AiUnattendedExposureRetention] Pruned ${deletedCount} exposure-ledger rows older than ${RETENTION_HOURS}h in ${durationMs}ms`);
+  return { deletedCount, durationMs };
+}
+
+let retentionQueue: Queue | null = null;
+let retentionWorker: Worker | null = null;
+
+export function getAiUnattendedExposureRetentionQueue(): Queue {
+  if (!retentionQueue) {
+    retentionQueue = new Queue(QUEUE_NAME, { connection: getBullMQConnection() });
+  }
+  return retentionQueue;
+}
+
+export function createAiUnattendedExposureRetentionWorker(): Worker {
+  return new Worker(
+    QUEUE_NAME,
+    async (_job: Job) => runWithSystemDbAccess(() => pruneAiUnattendedExposure()),
+    { connection: getBullMQConnection(), concurrency: 1 },
+  );
+}
+
+export async function initializeAiUnattendedExposureRetention(): Promise<void> {
+  retentionWorker = createAiUnattendedExposureRetentionWorker();
+  // attachWorkerObservability already routes 'error'/'failed' to Sentry
+  // (#1379) — no separate console-only handlers needed (mlOutputRetention.ts's
+  // convention).
+  attachWorkerObservability(retentionWorker, 'aiUnattendedExposureRetention');
+
+  const queue = getAiUnattendedExposureRetentionQueue();
+  const existing = await queue.getRepeatableJobs();
+  for (const job of existing) {
+    await queue.removeRepeatableByKey(job.key);
+  }
+
+  await queue.add(
+    JOB_NAME,
+    {},
+    {
+      jobId: REPEAT_JOB_ID,
+      // Daily at a registry-allocated slot. NOT `every: 24h` — BullMQ
+      // anchors `every` to the Unix epoch, so every 24h job fires at
+      // 00:00:00.000 UTC together (see jobs/scheduleRegistry.ts).
+      repeat: { pattern: jobSchedule('ai-unattended-exposure-retention') },
+      removeOnComplete: { count: 5 },
+      removeOnFail: { count: 10 },
+    },
+  );
+
+  console.log('[AiUnattendedExposureRetention] Retention worker initialized');
+}
+
+export async function shutdownAiUnattendedExposureRetention(): Promise<void> {
+  if (retentionWorker) {
+    await retentionWorker.close();
+    retentionWorker = null;
+  }
+  if (retentionQueue) {
+    await retentionQueue.close();
+    retentionQueue = null;
+  }
+}

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -943,14 +943,32 @@ describe('releaseApprovedIntent', () => {
   // before dispatch — a SEPARATE `readAiKillState()` call from the one
   // `checkAgentReleaseAuthority` already makes during revalidation, covering
   // the gap between revalidation finishing and the tool actually dispatching
-  // (effect-digest recompute I/O, scheduling jitter, …). Applies to EVERY
-  // release, human-approved or agent-originated alike — this suite's default
-  // fixture (`baseIntent()`) is a human/chat-originated intent, proving the
-  // check is not agent-specific.
+  // (effect-digest recompute I/O, scheduling jitter, …). Review fix: scoped
+  // to AGENT-ORIGINATED releases only (`intent.requestingAgentRunId` set) —
+  // an earlier version ran this unconditionally, which reached human-
+  // approved chat/mcp_api releases that have never consulted the kill switch
+  // and broke flag-off/human-lane inertness. This suite's default fixture
+  // (`baseIntent()`) is human/chat-originated, so it now proves the OPPOSITE
+  // of what it originally proved: the check does NOT fire for that lane.
   describe('final pre-dispatch kill read (wave 5b, #3827)', () => {
-    it('pauses (executing -> approved), never dispatches executeTool, when the pre-dispatch read comes back killed', async () => {
-      const intent = baseIntent();
-      primeThroughRevalidation(intent);
+    /** Same shape as `primeAgentIntentThroughClaim` above, duplicated at this
+     *  narrower scope: gets an agent-originated intent through revalidation
+     *  (actor + org + checkAgentReleaseAuthority) up to the pre-dispatch read. */
+    function primeAgentIntentThroughClaim(intent: ActionIntent) {
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // approved -> executing
+      dbState.selectActionIntentsResults.push([intent]);
+      dbState.selectApprovalRequestsResults.push([
+        { id: 'approval-1', status: 'approved', boundArgumentDigest: intent.argumentDigest },
+      ]);
+      aiToolsMock.getToolTier.mockReturnValue(intent.riskTier);
+      actorContextMock.buildAuthContextForIntent.mockResolvedValueOnce(fakeAuth);
+      tenantStatusMock.getActiveOrgTenant.mockResolvedValueOnce({ orgId: intent.orgId, partnerId: 'partner-1' });
+      toolTimeoutsMock.getToolTimeout.mockReturnValue(60_000);
+    }
+
+    it('pauses (executing -> approved), never dispatches executeTool, when the pre-dispatch read comes back killed for an agent-originated release', async () => {
+      const intent = baseIntent({ requestingAgentRunId: 'run-1' } as Partial<ActionIntent>);
+      primeAgentIntentThroughClaim(intent);
       killStateMock.readAiKillState.mockResolvedValueOnce({ killed: true, epoch: 9 });
       intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> approved
 
@@ -969,8 +987,8 @@ describe('releaseApprovedIntent', () => {
     });
 
     it('a lost CAS on the pre-dispatch pause is a silent no-op, matching the other kill-derived pause path', async () => {
-      const intent = baseIntent();
-      primeThroughRevalidation(intent);
+      const intent = baseIntent({ requestingAgentRunId: 'run-1' } as Partial<ActionIntent>);
+      primeAgentIntentThroughClaim(intent);
       killStateMock.readAiKillState.mockResolvedValueOnce({ killed: true, epoch: 9 });
       intentServiceMock.transitionIntent.mockResolvedValueOnce(false); // lost race
 
@@ -980,15 +998,42 @@ describe('releaseApprovedIntent', () => {
       expect(auditMock.writeAuditEvent).not.toHaveBeenCalled();
     });
 
-    it('dispatches normally when the pre-dispatch read is not killed (the default fixture)', async () => {
-      const intent = baseIntent();
-      primeThroughRevalidation(intent);
+    it('dispatches normally for an agent-originated release when the pre-dispatch read is not killed', async () => {
+      const intent = baseIntent({ requestingAgentRunId: 'run-1' } as Partial<ActionIntent>);
+      primeAgentIntentThroughClaim(intent);
       aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ ok: true }));
       intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
 
       await releaseApprovedIntent(intent.id);
 
       expect(killStateMock.readAiKillState).toHaveBeenCalled();
+      expect(aiToolsMock.executeTool).toHaveBeenCalledWith(intent.actionName, intent.arguments, fakeAuth);
+      expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+        intent.id, 'executing', 'completed', expect.anything(),
+      );
+    });
+
+    // Review fix: this is the load-bearing test for the fix itself. Before
+    // it, this exact scenario (a human/chat-originated release, killed:
+    // true) would have PAUSED a human's already-approved action on a lane
+    // that has never consulted the kill switch — breaking BOTH flag-off
+    // inertness (a new, unflagged path became reachable on the human lane)
+    // and durability (a transient DB blip on this shared, fail-closed read
+    // could silently strand an approved human action until the expiry
+    // reaper terminalises it).
+    it('does NOT consult the kill switch, and dispatches normally, for a human/chat-originated release even when the (unread) kill state would report killed', async () => {
+      const intent = baseIntent(); // default: human/chat-originated, no requestingAgentRunId
+      primeThroughRevalidation(intent);
+      // If the worker read this at all for a human intent, it would pause —
+      // proving the assertions below actually distinguish "not called" from
+      // "called and happened to come back not-killed".
+      killStateMock.readAiKillState.mockResolvedValueOnce({ killed: true, epoch: 9 });
+      aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ ok: true }));
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(killStateMock.readAiKillState).not.toHaveBeenCalled();
       expect(aiToolsMock.executeTool).toHaveBeenCalledWith(intent.actionName, intent.arguments, fakeAuth);
       expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
         intent.id, 'executing', 'completed', expect.anything(),

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { canonicalizeArguments, computeArgumentDigest } from '@breeze/shared/canonicalize';
 import type { AgentReleaseAuthority } from '../services/actionIntents/agentReleaseAuthority';
 
@@ -6,7 +6,7 @@ import type { AgentReleaseAuthority } from '../services/actionIntents/agentRelea
 // Hoisted shared mock state
 // ---------------------------------------------------------------------------
 
-const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, aiToolsMock, aiGuardrailsMock, agentReleaseAuthorityMock, authMock, auditMock, metricsMock, sentryMock, toolTimeoutsMock, googleHeadlessMock, m365HeadlessMock, effectDigestMock, notifyMock, recipientsMock } = vi.hoisted(() => {
+const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, aiToolsMock, aiGuardrailsMock, agentReleaseAuthorityMock, authMock, auditMock, metricsMock, sentryMock, toolTimeoutsMock, googleHeadlessMock, m365HeadlessMock, effectDigestMock, notifyMock, recipientsMock, policyDecideMock } = vi.hoisted(() => {
   const col = (name: string) => ({ name });
   const actionIntentsTbl = { id: col('id') };
   const approvalRequestsTbl = { id: col('id'), intentId: col('intent_id'), status: col('status') };
@@ -62,6 +62,7 @@ const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, 
       recordActionIntentMetric: vi.fn(),
     },
     sentryMock: { captureException: vi.fn() },
+    policyDecideMock: { attemptPolicyDecision: vi.fn(async () => {}) },
     // getToolTimeout is mocked (per-test override); withToolTimeout is kept
     // REAL (see vi.mock below) so the timeout test's timer actually fires.
     toolTimeoutsMock: { getToolTimeout: vi.fn() },
@@ -164,6 +165,9 @@ vi.mock('../services/actionIntents/metrics', () => ({
 }));
 vi.mock('../services/actionIntents/intentService', () => ({
   transitionIntent: intentServiceMock.transitionIntent,
+}));
+vi.mock('../services/actionIntents/policyDecide', () => ({
+  attemptPolicyDecision: policyDecideMock.attemptPolicyDecision,
 }));
 vi.mock('../services/actionIntents/actorContext', () => ({
   buildAuthContextForIntent: actorContextMock.buildAuthContextForIntent,
@@ -1464,6 +1468,43 @@ describe('processIntentReleaseJob', () => {
 
     expect(result).toEqual({ released: false });
     expect(intentServiceMock.transitionIntent).not.toHaveBeenCalled();
+  });
+
+  // Wave 5 Part B (#3827) — the intent_created outbox recovery branch.
+  describe('intent_created — policy-decide recovery (#3827)', () => {
+    const FLAG = 'BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED';
+    const original = process.env[FLAG];
+    afterEach(() => {
+      if (original === undefined) delete process.env[FLAG];
+      else process.env[FLAG] = original;
+    });
+
+    it('flag off: never even calls attemptPolicyDecision — byte-identical to the pre-existing no-op', async () => {
+      delete process.env[FLAG];
+      const result = await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' });
+
+      expect(result).toEqual({ released: false });
+      expect(policyDecideMock.attemptPolicyDecision).not.toHaveBeenCalled();
+      expect(intentServiceMock.transitionIntent).not.toHaveBeenCalled();
+    });
+
+    it('flag on: calls attemptPolicyDecision with the intent id and still reports a no-op release', async () => {
+      process.env[FLAG] = 'true';
+      const result = await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' });
+
+      expect(result).toEqual({ released: false });
+      expect(policyDecideMock.attemptPolicyDecision).toHaveBeenCalledWith('intent-1');
+    });
+
+    it('flag on: a thrown attemptPolicyDecision failure is swallowed (logged to Sentry), never thrown to the caller', async () => {
+      process.env[FLAG] = 'true';
+      policyDecideMock.attemptPolicyDecision.mockRejectedValueOnce(new Error('db blip'));
+
+      await expect(
+        processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' }),
+      ).resolves.toEqual({ released: false });
+      expect(sentryMock.captureException).toHaveBeenCalled();
+    });
   });
 
   it('THE LIE GUARD: an intent that did NOT run is never reported as running', async () => {

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -1471,6 +1471,13 @@ describe('processIntentReleaseJob', () => {
   });
 
   // Wave 5 Part B (#3827) — the intent_created outbox recovery branch.
+  //
+  // Review fix (#3827): the call site is deliberately NOT flag-gated —
+  // `attemptPolicyDecision` is the ONLY durable caller (the creation-time
+  // trigger is fire-and-forget and does not survive a restart), so gating
+  // here too would strand every intent left `unattempted` forever once an
+  // operator flips the flag off. `attemptPolicyDecision` itself owns
+  // flag-off behavior now (see policyDecide.test.ts).
   describe('intent_created — policy-decide recovery (#3827)', () => {
     const FLAG = 'BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED';
     const original = process.env[FLAG];
@@ -1479,12 +1486,12 @@ describe('processIntentReleaseJob', () => {
       else process.env[FLAG] = original;
     });
 
-    it('flag off: never even calls attemptPolicyDecision — byte-identical to the pre-existing no-op', async () => {
+    it('flag off: STILL calls attemptPolicyDecision — the call site is unconditional; flag-off inertness lives inside attemptPolicyDecision itself', async () => {
       delete process.env[FLAG];
       const result = await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' });
 
       expect(result).toEqual({ released: false });
-      expect(policyDecideMock.attemptPolicyDecision).not.toHaveBeenCalled();
+      expect(policyDecideMock.attemptPolicyDecision).toHaveBeenCalledWith('intent-1');
       expect(intentServiceMock.transitionIntent).not.toHaveBeenCalled();
     });
 
@@ -1496,8 +1503,7 @@ describe('processIntentReleaseJob', () => {
       expect(policyDecideMock.attemptPolicyDecision).toHaveBeenCalledWith('intent-1');
     });
 
-    it('flag on: a thrown attemptPolicyDecision failure is swallowed (logged to Sentry), never thrown to the caller', async () => {
-      process.env[FLAG] = 'true';
+    it('a thrown attemptPolicyDecision failure is swallowed (logged to Sentry), never thrown to the caller', async () => {
       policyDecideMock.attemptPolicyDecision.mockRejectedValueOnce(new Error('db blip'));
 
       await expect(

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -6,7 +6,7 @@ import type { AgentReleaseAuthority } from '../services/actionIntents/agentRelea
 // Hoisted shared mock state
 // ---------------------------------------------------------------------------
 
-const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, aiToolsMock, aiGuardrailsMock, agentReleaseAuthorityMock, authMock, auditMock, metricsMock, sentryMock, toolTimeoutsMock, googleHeadlessMock, m365HeadlessMock, effectDigestMock, notifyMock, recipientsMock, policyDecideMock } = vi.hoisted(() => {
+const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, aiToolsMock, aiGuardrailsMock, agentReleaseAuthorityMock, authMock, auditMock, metricsMock, sentryMock, toolTimeoutsMock, googleHeadlessMock, m365HeadlessMock, effectDigestMock, notifyMock, recipientsMock, policyDecideMock, killStateMock } = vi.hoisted(() => {
   const col = (name: string) => ({ name });
   const actionIntentsTbl = { id: col('id') };
   const approvalRequestsTbl = { id: col('id'), intentId: col('intent_id'), status: col('status') };
@@ -63,6 +63,15 @@ const { schema, dbState, intentServiceMock, actorContextMock, tenantStatusMock, 
     },
     sentryMock: { captureException: vi.fn() },
     policyDecideMock: { attemptPolicyDecision: vi.fn(async () => {}) },
+    // Wave 5 Part B (#3827) final pre-effect kill read: mocked wholesale
+    // (same treatment as agentReleaseAuthorityMock above) so the worker's
+    // OWN `readAiKillState()` call before dispatch doesn't need this file's
+    // narrow per-table db mock to also cover `ai_kill_state` — and so a real
+    // module-level TTL-cache read failure in one test can never poison every
+    // later test's dispatch to fail-closed `killed: true` (aiKillState.ts's
+    // own fail-closed contract). Default not-killed; the dedicated
+    // "final pre-dispatch kill read" describe block below overrides per test.
+    killStateMock: { readAiKillState: vi.fn(async () => ({ killed: false, epoch: 0 })) },
     // getToolTimeout is mocked (per-test override); withToolTimeout is kept
     // REAL (see vi.mock below) so the timeout test's timer actually fires.
     toolTimeoutsMock: { getToolTimeout: vi.fn() },
@@ -193,6 +202,9 @@ vi.mock('../services/aiGuardrails', () => ({
 // db mock to also cover ai_agent_runs/ai_agents/organizations/devices/ai_kill_state.
 vi.mock('../services/actionIntents/agentReleaseAuthority', () => ({
   checkAgentReleaseAuthority: agentReleaseAuthorityMock.checkAgentReleaseAuthority,
+}));
+vi.mock('../services/aiKillState', () => ({
+  readAiKillState: killStateMock.readAiKillState,
 }));
 vi.mock('../middleware/auth', () => ({
   dbAccessContextFromAuth: authMock.dbAccessContextFromAuth,
@@ -924,6 +936,63 @@ describe('releaseApprovedIntent', () => {
         expect.objectContaining({ errorCode: 'agent_policy_denied' }),
       );
       expect(auditMock.writeAuditEvent).toHaveBeenCalled();
+    });
+  });
+
+  // Wave 5 Part B (#3827): the FINAL pre-effect kill read, immediately
+  // before dispatch — a SEPARATE `readAiKillState()` call from the one
+  // `checkAgentReleaseAuthority` already makes during revalidation, covering
+  // the gap between revalidation finishing and the tool actually dispatching
+  // (effect-digest recompute I/O, scheduling jitter, …). Applies to EVERY
+  // release, human-approved or agent-originated alike — this suite's default
+  // fixture (`baseIntent()`) is a human/chat-originated intent, proving the
+  // check is not agent-specific.
+  describe('final pre-dispatch kill read (wave 5b, #3827)', () => {
+    it('pauses (executing -> approved), never dispatches executeTool, when the pre-dispatch read comes back killed', async () => {
+      const intent = baseIntent();
+      primeThroughRevalidation(intent);
+      killStateMock.readAiKillState.mockResolvedValueOnce({ killed: true, epoch: 9 });
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> approved
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+      expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+        intent.id,
+        'executing',
+        'approved',
+      );
+      expect(intentServiceMock.transitionIntent).not.toHaveBeenCalledWith(
+        intent.id, 'executing', 'failed', expect.anything(),
+      );
+      expect(auditMock.writeAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('a lost CAS on the pre-dispatch pause is a silent no-op, matching the other kill-derived pause path', async () => {
+      const intent = baseIntent();
+      primeThroughRevalidation(intent);
+      killStateMock.readAiKillState.mockResolvedValueOnce({ killed: true, epoch: 9 });
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(false); // lost race
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(aiToolsMock.executeTool).not.toHaveBeenCalled();
+      expect(auditMock.writeAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('dispatches normally when the pre-dispatch read is not killed (the default fixture)', async () => {
+      const intent = baseIntent();
+      primeThroughRevalidation(intent);
+      aiToolsMock.executeTool.mockResolvedValueOnce(JSON.stringify({ ok: true }));
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(true); // executing -> completed
+
+      await releaseApprovedIntent(intent.id);
+
+      expect(killStateMock.readAiKillState).toHaveBeenCalled();
+      expect(aiToolsMock.executeTool).toHaveBeenCalledWith(intent.actionName, intent.arguments, fakeAuth);
+      expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
+        intent.id, 'executing', 'completed', expect.anything(),
+      );
     });
   });
 

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -175,9 +175,27 @@ vi.mock('../services/actionIntents/metrics', () => ({
 vi.mock('../services/actionIntents/intentService', () => ({
   transitionIntent: intentServiceMock.transitionIntent,
 }));
-vi.mock('../services/actionIntents/policyDecide', () => ({
-  attemptPolicyDecision: policyDecideMock.attemptPolicyDecision,
-}));
+vi.mock('../services/actionIntents/policyDecide', () => {
+  // A local (not imported-from-real) `PolicyDecisionTransientError` — the
+  // real module pulls in the full db/schema graph transitively, which this
+  // test file mocks only partially elsewhere, so `importOriginal` here blows
+  // up on an unrelated missing export deep in that chain. Defining the class
+  // locally is sufficient: every import of '../services/actionIntents/
+  // policyDecide' in this test run (both intentReleaseWorker.ts's source
+  // import and this file's own top-level import) resolves to THIS mocked
+  // module, so they share the same class reference and `instanceof` works.
+  class PolicyDecisionTransientError extends Error {
+    constructor(intentId: string, cause: unknown) {
+      super(`attemptPolicyDecision transient failure for intent ${intentId}: ${cause instanceof Error ? cause.message : String(cause)}`);
+      this.name = 'PolicyDecisionTransientError';
+      this.cause = cause;
+    }
+  }
+  return {
+    attemptPolicyDecision: policyDecideMock.attemptPolicyDecision,
+    PolicyDecisionTransientError,
+  };
+});
 vi.mock('../services/actionIntents/actorContext', () => ({
   buildAuthContextForIntent: actorContextMock.buildAuthContextForIntent,
 }));
@@ -290,6 +308,7 @@ import { db as mockedDb, runOutsideDbContext as mockedRunOutside } from '../db';
 import type { ActionIntent } from '../db/schema/actionIntents';
 import { GoogleConnectionUnavailableError } from '../services/googleToolsHeadless';
 import { M365ConnectionUnavailableError } from '../services/m365ToolsHeadless';
+import { PolicyDecisionTransientError } from '../services/actionIntents/policyDecide';
 // Deliberately REAL (not mocked) — assertNoPlaintextSecret is the exact guard
 // the worker calls on both persistence paths; testing it directly here pins
 // the invariant the worker relies on without inventing a parallel harness.
@@ -1617,13 +1636,30 @@ describe('processIntentReleaseJob', () => {
       expect(policyDecideMock.attemptPolicyDecision).toHaveBeenCalledWith('intent-1');
     });
 
-    it('a thrown attemptPolicyDecision failure is swallowed (logged to Sentry), never thrown to the caller', async () => {
+    it('a non-discriminated thrown failure (not PolicyDecisionTransientError) is swallowed (logged to Sentry), never thrown to the caller — defensive fallback for a shape attemptPolicyDecision should never actually produce', async () => {
       policyDecideMock.attemptPolicyDecision.mockRejectedValueOnce(new Error('db blip'));
 
       await expect(
         processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' }),
       ).resolves.toEqual({ released: false });
       expect(sentryMock.captureException).toHaveBeenCalled();
+    });
+
+    it('review fix (#3827): a PolicyDecisionTransientError IS rethrown — real at-least-once relies on this so BullMQ redelivers the job', async () => {
+      const transientErr = new PolicyDecisionTransientError('intent-1', new Error('connection terminated'));
+      policyDecideMock.attemptPolicyDecision.mockRejectedValueOnce(transientErr);
+
+      await expect(
+        processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' }),
+      ).rejects.toBe(transientErr);
+    });
+
+    it('a DETERMINISTIC outcome (attemptPolicyDecision resolves normally) still acks — released: false, no throw', async () => {
+      policyDecideMock.attemptPolicyDecision.mockResolvedValueOnce(undefined);
+
+      await expect(
+        processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' }),
+      ).resolves.toEqual({ released: false });
     });
   });
 

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -12,7 +12,7 @@ import { recordActionIntentEvent, recordActionIntentMetric } from '../services/a
 import { createNotification } from '../services/userNotifications';
 import { resolveRecipientUserIds } from '../services/aiAgents/recipients';
 import { transitionIntent } from '../services/actionIntents/intentService';
-import { attemptPolicyDecision } from '../services/actionIntents/policyDecide';
+import { attemptPolicyDecision, PolicyDecisionTransientError } from '../services/actionIntents/policyDecide';
 import { revalidateApprovedIntentForRelease } from '../services/actionIntents/revalidateRelease';
 import { readAiKillState } from '../services/aiKillState';
 import { computeEffectDigestForRelease, hasPinnedDigest } from '../services/actionIntents/effectDigest';
@@ -951,10 +951,15 @@ async function notifyRequesterOfOutcome(
  *
  * `intent_approved` is the release trigger AND an outcome to report.
  * `intent_rejected` / `intent_expired` are outcome-only. `intent_created` is
- * the policy-decide recovery hook (wave 5 Part B, #3827) — flag-gated,
- * always acknowledged as a no-op rather than thrown on either way, so it
- * doesn't retry forever (intentOutboxPublisher.ts shares this queue but not
- * this consumer role).
+ * the policy-decide recovery hook (wave 5 Part B, #3827) — deliberately NOT
+ * flag-gated at this call site (see the comment on that branch below for
+ * why) and NOT unconditionally acknowledged: a DETERMINISTIC outcome from
+ * `attemptPolicyDecision` (it returns normally either way) always acks, but
+ * a TRANSIENT failure (it throws `PolicyDecisionTransientError`, review fix
+ * #3827) is rethrown so BullMQ redelivers the job — this queue's outbox
+ * publisher (intentOutboxPublisher.ts) is a separate producer role, not this
+ * consumer's retry policy, but this IS the branch that relies on BullMQ's
+ * own per-job retry policy to make that redelivery real.
  */
 export async function processIntentReleaseJob(data: IntentReleaseJobData): Promise<{ released: boolean }> {
   if (data.eventType === 'intent_rejected' || data.eventType === 'intent_expired') {
@@ -983,12 +988,31 @@ export async function processIntentReleaseJob(data: IntentReleaseJobData): Promi
   // precondition itself (status === 'pending_approval', agent-originated),
   // so a human-authored or already-decided intent's `intent_created` event
   // reaches it and no-ops — this call site does not need to duplicate those
-  // checks. Acknowledged as a no-op either way (never thrown on), exactly
-  // like the pre-existing `intent_created` handling below.
+  // checks.
+  //
+  // Review fix (#3827): a DETERMINISTIC outcome (every no-op above, a
+  // degrade-to-human, or a clean authorize — `attemptPolicyDecision` returns
+  // normally in all of them) still acks unconditionally, same as before. A
+  // TRANSIENT failure now throws `PolicyDecisionTransientError` instead of
+  // being swallowed — rethrown here rather than acked, this is what turns
+  // "left `unattempted`" into REAL at-least-once recovery: BullMQ redelivers
+  // the job per this job's retry policy instead of the event being marked
+  // processed and gone forever. Any OTHER error shape reaching this catch
+  // would mean `attemptPolicyDecision` grew an exit path that neither
+  // returns nor throws the discriminated signal — a bug in that function,
+  // not something retrying here can fix — so it stays logged-and-acked
+  // rather than retried forever.
   if (data.eventType === 'intent_created') {
     try {
       await attemptPolicyDecision(data.intentId);
     } catch (err) {
+      if (err instanceof PolicyDecisionTransientError) {
+        console.error(
+          `[IntentReleaseWorker] attemptPolicyDecision transient failure for intent ${data.intentId} — rethrowing for BullMQ retry:`,
+          err,
+        );
+        throw err;
+      }
       console.error(`[IntentReleaseWorker] attemptPolicyDecision failed for intent ${data.intentId}:`, err);
       captureException(err instanceof Error ? err : new Error(String(err)));
     }

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -14,6 +14,7 @@ import { resolveRecipientUserIds } from '../services/aiAgents/recipients';
 import { transitionIntent } from '../services/actionIntents/intentService';
 import { attemptPolicyDecision } from '../services/actionIntents/policyDecide';
 import { revalidateApprovedIntentForRelease } from '../services/actionIntents/revalidateRelease';
+import { readAiKillState } from '../services/aiKillState';
 import { computeEffectDigestForRelease, hasPinnedDigest } from '../services/actionIntents/effectDigest';
 import type { ToolExecutionContext } from '../services/toolExecutionContext';
 import { executeTool, requiresLiveSession } from '../services/aiTools';
@@ -330,6 +331,14 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
   // (DB-only work gets its own short context; the network/tool-execution
   // step below runs in its own, entirely separate, context boundary so a
   // slow external call never pins a pooled connection idle-in-transaction).
+  //
+  // `intentRow` is a bare `select()` — every column rides along, including
+  // Wave 5 Part B's (#3827) `policy_*` provenance columns and `decided_via`.
+  // For a policy-decided intent `approvalRow` comes back null (there is no
+  // `approval_requests` row by construction — see revalidateRelease.ts's
+  // header), which is exactly what `revalidateApprovedIntentForRelease`
+  // reads off `intent` itself to take its policy-evidence branch; no second
+  // query is needed to "load the policy columns" separately.
   const { intent, winningApproval } = await withSystemDbAccessContext(async () => {
     const [intentRow] = await db
       .select()
@@ -488,6 +497,30 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
   // 2026-07-19-action-intents-phase2-google-headless-design.md.
   if (isSessionRequiredForRelease(intent.actionName)) {
     await failIntent(intent, 'session_required', { details: { actionName: intent.actionName } });
+    return;
+  }
+
+  // Wave 5 Part B (#3827) final pre-effect kill read: one more fresh
+  // `readAiKillState()` immediately before dispatch, for EVERY released
+  // intent — human-approved or policy-decided alike. Everything above this
+  // line (revalidation, the effect-digest recompute, its own I/O) can take
+  // real wall-clock time, during which an operator's emergency kill can land
+  // — `checkAgentReleaseAuthority`'s own kill read (agentReleaseAuthority.ts)
+  // only covers the window up through step 2's revalidation, not the gap
+  // between there and the tool actually dispatching. Same pause semantics as
+  // that read: a real kill (or a transient read failure, which
+  // `readAiKillState` maps fail-closed to `killed: true`) PAUSES the intent
+  // back to `approved` rather than terminally failing it — see
+  // `pauseIntentForKillSwitch`'s header. Runs for every release, not only
+  // agent-originated ones: a human-owned intent's tool call is just as real
+  // an unattended-from-here-on effect once this worker is the one dispatching
+  // it, and the read itself is cheap (TTL-cached, ≤5s stale).
+  const preDispatchKillState = await readAiKillState();
+  if (preDispatchKillState.killed) {
+    await pauseIntentForKillSwitch(intent, {
+      epoch: preDispatchKillState.epoch,
+      stage: 'pre_dispatch',
+    });
     return;
   }
 

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -12,6 +12,8 @@ import { recordActionIntentEvent, recordActionIntentMetric } from '../services/a
 import { createNotification } from '../services/userNotifications';
 import { resolveRecipientUserIds } from '../services/aiAgents/recipients';
 import { transitionIntent } from '../services/actionIntents/intentService';
+import { attemptPolicyDecision } from '../services/actionIntents/policyDecide';
+import { policyDecideEnabled } from '../config/env';
 import { revalidateApprovedIntentForRelease } from '../services/actionIntents/revalidateRelease';
 import { computeEffectDigestForRelease, hasPinnedDigest } from '../services/actionIntents/effectDigest';
 import type { ToolExecutionContext } from '../services/toolExecutionContext';
@@ -54,9 +56,10 @@ import {
  * categorized `error_code` and skips execution entirely. Never a silent
  * no-op, never a downgrade to "execute anyway."
  *
- * Job data: `{ intentId, eventType }`. Only `eventType === 'intent_approved'`
- * is acted on; anything else is acknowledged as a no-op (forward-compat with
- * `intent_created`, which this worker does not consume).
+ * Job data: `{ intentId, eventType }`. `eventType === 'intent_approved'` is
+ * the release trigger; `intent_created` is the wave 5 Part B (#3827)
+ * policy-decide recovery hook (flag-gated, otherwise a no-op); anything else
+ * is acknowledged as a no-op.
  *
  * CAS-idempotent by construction: the `approved -> executing` transition at
  * step 1 is a single-use release guard (mirrors the PAM `actuating` pattern).
@@ -909,12 +912,39 @@ async function notifyRequesterOfOutcome(
  *
  * `intent_approved` is the release trigger AND an outcome to report.
  * `intent_rejected` / `intent_expired` are outcome-only. `intent_created` is
- * acknowledged as a no-op rather than thrown on, so it doesn't retry forever
- * (intentOutboxPublisher.ts shares this queue but not this consumer role).
+ * the policy-decide recovery hook (wave 5 Part B, #3827) — flag-gated,
+ * always acknowledged as a no-op rather than thrown on either way, so it
+ * doesn't retry forever (intentOutboxPublisher.ts shares this queue but not
+ * this consumer role).
  */
 export async function processIntentReleaseJob(data: IntentReleaseJobData): Promise<{ released: boolean }> {
   if (data.eventType === 'intent_rejected' || data.eventType === 'intent_expired') {
     await notifyRequesterOfOutcome(data.intentId, data.eventType);
+    return { released: false };
+  }
+
+  // Wave 5 Part B (#3827) — the outbox at-least-once recovery branch for a
+  // policy-decide attempt that never ran (the creation-time fire-and-forget
+  // trigger was dropped by a crash/restart) or that only got as far as a
+  // TRANSIENT failure (left `unattempted` on purpose — see
+  // policyDecide.ts's header). Flag-gated here too, not just inside
+  // `attemptPolicyDecision` itself: flag off must not even attempt the call,
+  // for byte-identical dark-ship inertness with every other `intent_created`
+  // delivery. `attemptPolicyDecision` re-derives every precondition itself
+  // (state === 'unattempted', status === 'pending_approval', agent-originated),
+  // so a human-authored or already-decided intent's `intent_created` event
+  // reaches it and no-ops — this call site does not need to duplicate those
+  // checks. Acknowledged as a no-op either way (never thrown on), exactly
+  // like the pre-existing `intent_created` handling below.
+  if (data.eventType === 'intent_created') {
+    if (policyDecideEnabled()) {
+      try {
+        await attemptPolicyDecision(data.intentId);
+      } catch (err) {
+        console.error(`[IntentReleaseWorker] attemptPolicyDecision failed for intent ${data.intentId}:`, err);
+        captureException(err instanceof Error ? err : new Error(String(err)));
+      }
+    }
     return { released: false };
   }
 

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -13,7 +13,6 @@ import { createNotification } from '../services/userNotifications';
 import { resolveRecipientUserIds } from '../services/aiAgents/recipients';
 import { transitionIntent } from '../services/actionIntents/intentService';
 import { attemptPolicyDecision } from '../services/actionIntents/policyDecide';
-import { policyDecideEnabled } from '../config/env';
 import { revalidateApprovedIntentForRelease } from '../services/actionIntents/revalidateRelease';
 import { computeEffectDigestForRelease, hasPinnedDigest } from '../services/actionIntents/effectDigest';
 import type { ToolExecutionContext } from '../services/toolExecutionContext';
@@ -58,8 +57,9 @@ import {
  *
  * Job data: `{ intentId, eventType }`. `eventType === 'intent_approved'` is
  * the release trigger; `intent_created` is the wave 5 Part B (#3827)
- * policy-decide recovery hook (flag-gated, otherwise a no-op); anything else
- * is acknowledged as a no-op.
+ * policy-decide recovery hook (NOT flag-gated at this call site —
+ * `attemptPolicyDecision` itself is the single source of truth for flag-off
+ * inertness, see its own header); anything else is acknowledged as a no-op.
  *
  * CAS-idempotent by construction: the `approved -> executing` transition at
  * step 1 is a single-use release guard (mirrors the PAM `actuating` pattern).
@@ -925,25 +925,33 @@ export async function processIntentReleaseJob(data: IntentReleaseJobData): Promi
 
   // Wave 5 Part B (#3827) — the outbox at-least-once recovery branch for a
   // policy-decide attempt that never ran (the creation-time fire-and-forget
-  // trigger was dropped by a crash/restart) or that only got as far as a
+  // trigger was dropped by a crash/restart), that only got as far as a
   // TRANSIENT failure (left `unattempted` on purpose — see
-  // policyDecide.ts's header). Flag-gated here too, not just inside
-  // `attemptPolicyDecision` itself: flag off must not even attempt the call,
-  // for byte-identical dark-ship inertness with every other `intent_created`
-  // delivery. `attemptPolicyDecision` re-derives every precondition itself
-  // (state === 'unattempted', status === 'pending_approval', agent-originated),
+  // policyDecide.ts's header), or that never got attempted because the flag
+  // was off at creation and has since been flipped back on.
+  //
+  // Deliberately NOT flag-gated here (review fix, #3827): this is the ONLY
+  // durable caller of `attemptPolicyDecision` — the creation-time trigger is
+  // fire-and-forget and does not survive a restart — so gating the call site
+  // too would strand every intent left `unattempted` by an operator's
+  // emergency flag-off: with nothing left to move it out of `unattempted`,
+  // it would sit with zero `approval_requests` rows and zero notifications,
+  // invisible until the expiry reaper eventually cancels it.
+  // `attemptPolicyDecision` itself is the single source of truth for flag-off
+  // behavior: it checks the intent is genuinely `unattempted` BEFORE reading
+  // the flag, and degrades a flag-off `unattempted` intent to human review
+  // rather than leaving it stranded. It also re-derives every other
+  // precondition itself (status === 'pending_approval', agent-originated),
   // so a human-authored or already-decided intent's `intent_created` event
   // reaches it and no-ops — this call site does not need to duplicate those
   // checks. Acknowledged as a no-op either way (never thrown on), exactly
   // like the pre-existing `intent_created` handling below.
   if (data.eventType === 'intent_created') {
-    if (policyDecideEnabled()) {
-      try {
-        await attemptPolicyDecision(data.intentId);
-      } catch (err) {
-        console.error(`[IntentReleaseWorker] attemptPolicyDecision failed for intent ${data.intentId}:`, err);
-        captureException(err instanceof Error ? err : new Error(String(err)));
-      }
+    try {
+      await attemptPolicyDecision(data.intentId);
+    } catch (err) {
+      console.error(`[IntentReleaseWorker] attemptPolicyDecision failed for intent ${data.intentId}:`, err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
     }
     return { released: false };
   }

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -501,9 +501,16 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
   }
 
   // Wave 5 Part B (#3827) final pre-effect kill read: one more fresh
-  // `readAiKillState()` immediately before dispatch, for EVERY released
-  // intent — human-approved or policy-decided alike. Everything above this
-  // line (revalidation, the effect-digest recompute, its own I/O) can take
+  // `readAiKillState()` immediately before dispatch, for AGENT-ORIGINATED
+  // releases only (review fix: an earlier version ran this unconditionally,
+  // which reached human-approved chat/mcp_api releases that have never
+  // consulted the kill switch and made the flag-off/human lane non-inert —
+  // see the plan's dark-ship constraint). The kill switch governs autonomous
+  // agent action (`checkAgentReleaseAuthority` is agent-only, and is the
+  // only OTHER caller of `readAiKillState` on this path); a human who
+  // clicked Approve is not "the agent" and this read must not be able to
+  // pause their release. Scoped this way, everything above this line
+  // (revalidation, the effect-digest recompute, its own I/O) can still take
   // real wall-clock time, during which an operator's emergency kill can land
   // — `checkAgentReleaseAuthority`'s own kill read (agentReleaseAuthority.ts)
   // only covers the window up through step 2's revalidation, not the gap
@@ -511,17 +518,16 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
   // that read: a real kill (or a transient read failure, which
   // `readAiKillState` maps fail-closed to `killed: true`) PAUSES the intent
   // back to `approved` rather than terminally failing it — see
-  // `pauseIntentForKillSwitch`'s header. Runs for every release, not only
-  // agent-originated ones: a human-owned intent's tool call is just as real
-  // an unattended-from-here-on effect once this worker is the one dispatching
-  // it, and the read itself is cheap (TTL-cached, ≤5s stale).
-  const preDispatchKillState = await readAiKillState();
-  if (preDispatchKillState.killed) {
-    await pauseIntentForKillSwitch(intent, {
-      epoch: preDispatchKillState.epoch,
-      stage: 'pre_dispatch',
-    });
-    return;
+  // `pauseIntentForKillSwitch`'s header.
+  if (intent.requestingAgentRunId) {
+    const preDispatchKillState = await readAiKillState();
+    if (preDispatchKillState.killed) {
+      await pauseIntentForKillSwitch(intent, {
+        epoch: preDispatchKillState.epoch,
+        stage: 'pre_dispatch',
+      });
+      return;
+    }
   }
 
   // Step 3: execute with the rebuilt context. Escape any inherited DB context,

--- a/apps/api/src/jobs/scheduleRegistry.ts
+++ b/apps/api/src/jobs/scheduleRegistry.ts
@@ -115,6 +115,7 @@ export const JOB_SCHEDULES = {
   'winget-index-sync': '3 16 * * *',
   'sso-domain-recheck': '23 16 * * *',
   'exchange-rate-sync': '13 17 * * *',
+  'ai-unattended-exposure-retention': '8 18 * * *',
 
   // ------------------------------------------------------------ sub-daily tier
   // Minutes ≡ 2 (mod 5), plus three legacy slots on :00 / :15 / :35. Minute 0

--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -326,6 +326,40 @@ describe('POST /ai-agents/:id/runs', () => {
   });
 });
 
+describe('GET /ai-agents/policy-decidable-keys (Task 5, #3827)', () => {
+  it('returns the POLICY_DECIDABLE_TIER3 registry, one entry per headless-compatible key', async () => {
+    const res = await buildApp().request('/ai-agents/policy-decidable-keys');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Array<{ key: string; toolName: string; action: string | null }> };
+    expect(body.data.length).toBeGreaterThan(0);
+    // Every real registry entry, not a filtered/renamed subset — e.g. the
+    // multiplexed manage_services actions must be present with their real
+    // tool:action key, exactly what the client needs to group by tool and
+    // POST back into actAssets.supervisedActionKeys unchanged.
+    expect(body.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'manage_services:restart', toolName: 'manage_services', action: 'restart' }),
+        expect.objectContaining({ key: 'security_scan:quarantine', toolName: 'security_scan', action: 'quarantine' }),
+      ]),
+    );
+    // No internal registry-review fields (maxTargetCardinality,
+    // requiresEffectPin, headlessCompatible) leak onto the wire — those are
+    // implementation notes for whoever edits policyDecidable.ts, not client
+    // data.
+    for (const entry of body.data) {
+      expect(entry).not.toHaveProperty('maxTargetCardinality');
+      expect(entry).not.toHaveProperty('requiresEffectPin');
+      expect(entry).not.toHaveProperty('headlessCompatible');
+    }
+  });
+
+  it('is gated on ai_agents:read like every other agent-config read', async () => {
+    hasPermMock.mockReturnValue(false);
+    const res = await buildApp().request('/ai-agents/policy-decidable-keys');
+    expect(res.status).toBe(403);
+  });
+});
+
 describe('mapError — act-mode activation prerequisites (Task 6, #3826)', () => {
   it('maps ActPrerequisitesNotMetError to a 422 naming exactly what is missing', async () => {
     const jsonMock = vi.fn((body: unknown, status: number) => ({ body, status }));

--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -39,11 +39,17 @@ vi.mock('../middleware/auth', () => ({
   ),
 }));
 
-const { ActPrerequisitesNotMetError } = vi.hoisted(() => ({
+const { ActPrerequisitesNotMetError, InvalidSupervisedActionKeysError } = vi.hoisted(() => ({
   ActPrerequisitesNotMetError: class ActPrerequisitesNotMetError extends Error {
     readonly code = 'act_prerequisites_not_met';
     constructor(public missing: string[]) {
       super(`act_prerequisites_not_met: ${missing.join(', ')}`);
+    }
+  },
+  InvalidSupervisedActionKeysError: class InvalidSupervisedActionKeysError extends Error {
+    readonly code = 'invalid_supervised_action_keys';
+    constructor(public rejected: Array<{ key: string; reason: string }>) {
+      super(`invalid_supervised_action_keys: ${rejected.map((r) => r.key).join(', ')}`);
     }
   },
 }));
@@ -53,6 +59,7 @@ vi.mock('../services/aiAgents/agentService', () => ({
   AgentKindConflictError: class AgentKindConflictError extends Error {},
   UnsupportedAgentModeError: class UnsupportedAgentModeError extends Error {},
   ActPrerequisitesNotMetError,
+  InvalidSupervisedActionKeysError,
   createAgent: vi.fn(),
   updateAgent: vi.fn(),
   disableAgent: vi.fn(),
@@ -330,6 +337,24 @@ describe('mapError — act-mode activation prerequisites (Task 6, #3826)', () =>
       expect.objectContaining({
         code: 'act_prerequisites_not_met',
         missing: ['recipient', 'act_eligible_tool'],
+      }),
+      422,
+    );
+  });
+});
+
+describe('mapError — supervisedActionKeys write-time rejection (wave 5 Part B, #3827)', () => {
+  it('maps InvalidSupervisedActionKeysError to a 422 naming exactly which keys were rejected and why', async () => {
+    const jsonMock = vi.fn((body: unknown, status: number) => ({ body, status }));
+    const ctx = { json: jsonMock } as unknown as Parameters<typeof mapError>[0];
+    const rejected = [{ key: 'bogus_key', reason: 'not registered in POLICY_DECIDABLE_TIER3' }];
+
+    mapError(ctx, new InvalidSupervisedActionKeysError(rejected));
+
+    expect(jsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'invalid_supervised_action_keys',
+        rejected,
       }),
       422,
     );

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -21,6 +21,7 @@ import {
   InvalidSupervisedActionKeysError, UnsupportedAgentModeError,
 } from '../services/aiAgents/agentService';
 import { resolveEffectiveAgent } from '../services/aiAgents/effectivePolicy';
+import { POLICY_DECIDABLE_TIER3 } from '../services/actionIntents/policyDecidable';
 import { createAndEnqueueAgentRun } from '../services/aiAgents/runService';
 import { InvalidAgentRecipientsError } from '../services/aiAgents/recipients';
 import { SUPPORTED_AGENT_MODES } from '../services/aiAgents/constants';
@@ -190,6 +191,26 @@ aiAgentsRoutes.get(
     return c.json({ data: resolved });
   },
 );
+
+/**
+ * Wave 5 Part B (#3827) — the read-only, static POLICY_DECIDABLE_TIER3
+ * registry, for the web `supervisedActionKeys` editor (Task 5) to render a
+ * multi-select grouped by tool. Registered ahead of GET /:id, same reason as
+ * /effective and /runs/:runId above — a literal path segment must not fall
+ * into the `:id` param route. Only the wire-relevant fields are projected:
+ * `maxTargetCardinality`/`requiresEffectPin` are policyDecidable.ts's own
+ * review notes, not client data, and `headlessCompatible` is filtered on
+ * (never surfaced) — v1 happens to be all-true, but a future non-headless
+ * entry must never be offered as a selectable key here (it structurally can
+ * never be policy-decided; see registryCheck in policyDecide.ts).
+ */
+aiAgentsRoutes.get('/policy-decidable-keys', scopes, requireAiRead, async (c) => {
+  return c.json({
+    data: POLICY_DECIDABLE_TIER3
+      .filter((entry) => entry.headlessCompatible)
+      .map((entry) => ({ key: entry.key, toolName: entry.toolName, action: entry.action, note: entry.note })),
+  });
+});
 
 aiAgentsRoutes.get('/runs/:runId', scopes, requireAiRead, async (c) => {
   const runId = uuidParam(c, 'runId');

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -17,7 +17,8 @@ import { PARTNER_WIDE_WRITE_DENIED_MESSAGE, PartnerWideWriteDeniedError } from '
 import { AgentAccessDeniedError } from '../services/aiAgents/access';
 import {
   createAgent, disableAgent, getAgent, listAgents, updateAgent,
-  ActPrerequisitesNotMetError, AgentInvariantError, AgentKindConflictError, UnsupportedAgentModeError,
+  ActPrerequisitesNotMetError, AgentInvariantError, AgentKindConflictError,
+  InvalidSupervisedActionKeysError, UnsupportedAgentModeError,
 } from '../services/aiAgents/agentService';
 import { resolveEffectiveAgent } from '../services/aiAgents/effectivePolicy';
 import { createAndEnqueueAgentRun } from '../services/aiAgents/runService';
@@ -116,6 +117,13 @@ export function mapError(c: Context, err: unknown) {
   // client (Task 8's form) can render an actionable message.
   if (err instanceof ActPrerequisitesNotMetError) {
     return c.json({ error: err.message, code: err.code, missing: err.missing }, 422);
+  }
+  // Wave 5 Part B (#3827): actAssets.supervisedActionKeys failed write-time
+  // registry validation (validateAuthorizationKeys, policyDecidable.ts).
+  // `rejected` names exactly which keys and why, same shape as `missing`
+  // above, so the client (Task 5's editor) can render an actionable message.
+  if (err instanceof InvalidSupervisedActionKeysError) {
+    return c.json({ error: err.message, code: err.code, rejected: err.rejected }, 422);
   }
   if (err instanceof AgentKindConflictError) {
     return c.json({ error: err.message, code: err.code }, 409);

--- a/apps/api/src/services/actionIntents/agentReleaseAuthority.test.ts
+++ b/apps/api/src/services/actionIntents/agentReleaseAuthority.test.ts
@@ -425,6 +425,11 @@ describe('checkAgentReleaseAuthority', () => {
         arguments: policyArgs,
         decidedVia: 'policy',
         policyAuthorizationKey: POLICY_KEY,
+        // Matches `dbState.killStateRows`'s default epoch (0, set in
+        // `beforeEach`) so every pre-existing test in this block that does
+        // NOT specifically exercise the epoch-sanity veto below keeps
+        // passing through it unaffected.
+        policyKillEpoch: 0,
         ...overrides,
       });
     }
@@ -509,6 +514,38 @@ describe('checkAgentReleaseAuthority', () => {
       const result = await checkAgentReleaseAuthority(policyIntent());
 
       expect(result).toMatchObject({ ok: false, errorCode: 'kill_switch_engaged' });
+    });
+
+    // Review fix: kill-epoch sanity. `killState.killed` alone misses a
+    // kill-then-clear cycle that happened entirely between authorization and
+    // release — the flag is back to false by the time this runs, but the
+    // epoch the operator's emergency stop advanced never comes back down to
+    // what the intent was authorized under.
+    it('vetoes policy_authorization_revoked when the CURRENT kill epoch has advanced past the authorized one, even though killed is false', async () => {
+      // Authorized at epoch 4; the current (post kill-then-clear) epoch is 6
+      // and NOT killed — proves this is a genuinely separate veto from the
+      // kill_switch_engaged path above, not a restatement of it.
+      dbState.killStateRows = [{ killed: false, epoch: 6 }];
+      seedHappyRows({ run: runRow(actPolicy()) });
+      policyState.resolveEffectiveAgent.mockResolvedValue(resolvedAgent(actPolicy()));
+
+      const result = await checkAgentReleaseAuthority(policyIntent({ policyKillEpoch: 4 }));
+
+      expect(result).toMatchObject({
+        ok: false,
+        errorCode: 'policy_authorization_revoked',
+        details: { reason: 'kill epoch advanced since authorization', authorizedEpoch: 4, currentEpoch: 6 },
+      });
+    });
+
+    it('passes when the current kill epoch matches the epoch the intent was authorized under', async () => {
+      dbState.killStateRows = [{ killed: false, epoch: 4 }];
+      seedHappyRows({ run: runRow(actPolicy()) });
+      policyState.resolveEffectiveAgent.mockResolvedValue(resolvedAgent(actPolicy()));
+
+      const result = await checkAgentReleaseAuthority(policyIntent({ policyKillEpoch: 4 }));
+
+      expect(result).toEqual({ ok: true });
     });
   });
 });

--- a/apps/api/src/services/actionIntents/agentReleaseAuthority.test.ts
+++ b/apps/api/src/services/actionIntents/agentReleaseAuthority.test.ts
@@ -395,4 +395,120 @@ describe('checkAgentReleaseAuthority', () => {
       expect(result).toMatchObject({ ok: false, errorCode: 'agent_policy_denied' });
     });
   });
+
+  // ---------------------------------------------------------------------
+  // Wave 5 Part B (#3827): the stricter predicate for a policy-decided
+  // intent — `checkAgentGuardrails` returning 'propose' (not 'deny') must
+  // NOT be treated as authorization once no human is in the loop.
+  // `manage_startup_items:disable` is deliberately used here rather than
+  // `manage_services:restart` (this file's default fixture): the latter IS
+  // matched by ACT_MANIFEST (actManifest.ts), so under mode 'act' it would
+  // yield disposition 'act', not the 'propose' this block exists to probe —
+  // POLICY_DECIDABLE_TIER3 and ACT_MANIFEST are disjoint asset classes on
+  // purpose (policyDecidable.ts's header).
+  // ---------------------------------------------------------------------
+
+  describe('policy-decided stricter predicate (wave 5b, #3827)', () => {
+    const POLICY_KEY = 'manage_startup_items:disable';
+    const policyArgs = { deviceId: 'dev-1', action: 'disable', itemId: 'startup-1' };
+
+    const actPolicy = (overrides: Partial<AiAgentPolicy> = {}): AiAgentPolicy => effectivePolicy({
+      mode: 'act',
+      toolAllowlist: ['manage_startup_items'],
+      actAssets: { scriptIds: [], supervisedActionKeys: [POLICY_KEY] },
+      ...overrides,
+    });
+
+    function policyIntent(overrides: Partial<ActionIntent> = {}): ActionIntent {
+      return intentFixture({
+        actionName: 'manage_startup_items',
+        arguments: policyArgs,
+        decidedVia: 'policy',
+        policyAuthorizationKey: POLICY_KEY,
+        ...overrides,
+      });
+    }
+
+    it('passes when BOTH snapshot and current policy authorize the exact key under mode act', async () => {
+      seedHappyRows({ run: runRow(actPolicy()) });
+      policyState.resolveEffectiveAgent.mockResolvedValue(resolvedAgent(actPolicy()));
+
+      const result = await checkAgentReleaseAuthority(policyIntent());
+
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('a HUMAN-approved intent for the identical call still passes on propose alone (decidedVia !== policy is untouched)', async () => {
+      // Same mode/allowlist/actAssets as the passing case above, but WITHOUT
+      // supervisedActionKeys covering the key AND WITHOUT decidedVia: 'policy'
+      // — proves the new predicate is opt-in per intent, not a global
+      // tightening of the guardrail-disposition check.
+      seedHappyRows({ run: runRow(actPolicy({ actAssets: { scriptIds: [] } })) });
+      policyState.resolveEffectiveAgent.mockResolvedValue(
+        resolvedAgent(actPolicy({ actAssets: { scriptIds: [] } })),
+      );
+
+      const result = await checkAgentReleaseAuthority(
+        intentFixture({ actionName: 'manage_startup_items', arguments: policyArgs }),
+      );
+
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('vetoes policy_authorization_revoked when the CURRENT policy no longer lists the key (operator revoked it)', async () => {
+      seedHappyRows({ run: runRow(actPolicy()) });
+      policyState.resolveEffectiveAgent.mockResolvedValue(
+        resolvedAgent(actPolicy({ actAssets: { scriptIds: [] } })),
+      );
+
+      const result = await checkAgentReleaseAuthority(policyIntent());
+
+      expect(result).toMatchObject({
+        ok: false,
+        errorCode: 'policy_authorization_revoked',
+        details: { policy: 'current', key: POLICY_KEY },
+      });
+    });
+
+    it('vetoes policy_authorization_revoked when the SNAPSHOT never listed the key (defense-in-depth on stored provenance)', async () => {
+      seedHappyRows({ run: runRow(actPolicy({ actAssets: { scriptIds: [] } })) });
+      policyState.resolveEffectiveAgent.mockResolvedValue(resolvedAgent(actPolicy()));
+
+      const result = await checkAgentReleaseAuthority(policyIntent());
+
+      expect(result).toMatchObject({
+        ok: false,
+        errorCode: 'policy_authorization_revoked',
+        details: { policy: 'snapshot', key: POLICY_KEY },
+      });
+    });
+
+    it('vetoes policy_authorization_revoked when the CURRENT mode downgraded to shadow, even though the key is still listed', async () => {
+      // A mutating call under shadow ALSO yields disposition 'propose', not
+      // 'deny' — this proves the predicate is mode-aware, not merely a key
+      // membership check that a downgrade-to-shadow could sail past.
+      seedHappyRows({ run: runRow(actPolicy()) });
+      policyState.resolveEffectiveAgent.mockResolvedValue(
+        resolvedAgent(actPolicy({ mode: 'shadow' })),
+      );
+
+      const result = await checkAgentReleaseAuthority(policyIntent());
+
+      expect(result).toMatchObject({
+        ok: false,
+        errorCode: 'policy_authorization_revoked',
+        details: { policy: 'current', mode: 'shadow' },
+      });
+    });
+
+    it('a real kill-switch veto still wins over the stricter predicate (kill_switch_engaged, not policy_authorization_revoked)', async () => {
+      dbState.killStateRows = [{ killed: true, epoch: 3 }];
+      seedHappyRows({ run: runRow(actPolicy()) });
+      policyState.resolveEffectiveAgent.mockResolvedValue(resolvedAgent(actPolicy()));
+
+      const result = await checkAgentReleaseAuthority(policyIntent());
+
+      expect(result).toMatchObject({ ok: false, errorCode: 'kill_switch_engaged' });
+    });
+  });
 });

--- a/apps/api/src/services/actionIntents/agentReleaseAuthority.ts
+++ b/apps/api/src/services/actionIntents/agentReleaseAuthority.ts
@@ -189,6 +189,21 @@ export async function checkAgentReleaseAuthority(
   // `readAiKillState()` that bypasses the TTL — not implemented here.
   const killState = await readAiKillState();
 
+  // Wave 5 Part B (#3827): for a policy-decided intent, "not denied" is not
+  // the bar release must clear — no human ever reviewed this call, so the
+  // ONLY thing standing in for a decision is the operator's own
+  // `supervisedActionKeys` opt-in, re-checked here exactly like Task 2's
+  // `attemptPolicyDecision` re-checked it at decision time (mode === 'act'
+  // AND the stored key still listed). `checkAgentGuardrails` returns
+  // 'propose' — not 'deny' — for a POLICY_DECIDABLE_TIER3 key that isn't
+  // also matched by the (disjoint) act-mode manifest, and 'propose' for a
+  // mutating call under `mode: 'shadow'` too; both mean "record a proposal
+  // for a human", which is meaningless with no human in the loop. Treating
+  // either as an ok verdict here would let a downgrade to shadow, or an
+  // operator opting a key back out, execute unattended anyway as long as
+  // guardrails merely declined to hard-deny it.
+  const isPolicyDecided = intent.decidedVia === 'policy';
+
   const candidates = [
     { policy: 'snapshot' as const, effective: run.policySnapshot?.effective },
     { policy: 'current' as const, effective: resolved.effective },
@@ -235,6 +250,26 @@ export async function checkAgentReleaseAuthority(
         errorCode: 'agent_policy_denied',
         details: { policy, reason: verdict.reason ?? 'denied' },
       };
+    }
+
+    if (isPolicyDecided) {
+      const authorizedKeys = effective?.actAssets?.supervisedActionKeys ?? [];
+      const keyStillAuthorized = effective?.mode === 'act'
+        && !!intent.policyAuthorizationKey
+        && authorizedKeys.includes(intent.policyAuthorizationKey);
+      if (!keyStillAuthorized) {
+        // Terminal, like `agent_policy_denied` (never the kill-derived,
+        // pausable code) — a revoked opt-in is a real, durable decision
+        // change, not a transient blip. `revalidateApprovedIntentForRelease`
+        // uses this SAME errorCode for its own registry/provenance/flag
+        // checks (see revalidateRelease.ts) so every "the authorization
+        // behind this decision no longer holds" failure reads as one thing.
+        return {
+          ok: false,
+          errorCode: 'policy_authorization_revoked',
+          details: { policy, key: intent.policyAuthorizationKey, mode: effective?.mode },
+        };
+      }
     }
   }
 

--- a/apps/api/src/services/actionIntents/agentReleaseAuthority.ts
+++ b/apps/api/src/services/actionIntents/agentReleaseAuthority.ts
@@ -273,5 +273,36 @@ export async function checkAgentReleaseAuthority(
     }
   }
 
+  // Review fix: kill-epoch sanity. `intent.policyKillEpoch` is the epoch
+  // `runAuthorizeTransaction` stamped into the intent, atomically, at
+  // authorization time (policyDecide.ts) — the plan's architecture line
+  // calls this check out by name ("kill-epoch sanity") specifically because
+  // `killState.killed` alone is NOT enough: an operator can hit the
+  // emergency kill (epoch N -> N+1) and then CLEAR it (epoch N+1 -> N+2)
+  // before this unattended release is delivered, and `killState.killed`
+  // would read false throughout. Comparing the epoch instead of the flag
+  // means ANY kill-and-clear cycle since authorization revokes it, exactly
+  // as the durable epoch — rather than a boolean — is supposed to.
+  // Deliberately placed AFTER the candidates loop above, not alongside the
+  // `killState.killed` read: a genuinely LIVE kill must still surface as
+  // `kill_switch_engaged` (pausable) via that loop, never get preempted by
+  // this terminal epoch check — an epoch bump caused by the kill itself
+  // would otherwise race this comparison and misreport a live pause as a
+  // stale, non-recoverable revocation. This only fires once every candidate
+  // has already cleared cleanly. Terminal, not kill-derived-pausable: the
+  // agent re-proposes fresh on its next run rather than sitting `approved`
+  // waiting for an epoch that will never come back down.
+  if (isPolicyDecided && killState.epoch !== intent.policyKillEpoch) {
+    return {
+      ok: false,
+      errorCode: 'policy_authorization_revoked',
+      details: {
+        reason: 'kill epoch advanced since authorization',
+        authorizedEpoch: intent.policyKillEpoch,
+        currentEpoch: killState.epoch,
+      },
+    };
+  }
+
   return { ok: true };
 }

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -7,7 +7,7 @@ import type { EffectDigestOutcome } from './effectDigest';
 // Hoisted shared mock state
 // ---------------------------------------------------------------------------
 
-const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushState, notifyState, metricsMock, intentApproversState, effectDigestState } = vi.hoisted(() => {
+const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushState, notifyState, metricsMock, intentApproversState, effectDigestState, envMock, policyDecideMock } = vi.hoisted(() => {
   const col = (name: string) => ({ name });
   const actionIntentsTbl = {
     id: col('id'),
@@ -105,6 +105,15 @@ const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushS
     effectDigestState: {
       computeEffectDigestOutcome: vi.fn(async () => ({ kind: 'not_applicable' }) as EffectDigestOutcome),
     },
+    // Wave 5 Part B (#3827): defaults OFF, matching the real flag's default —
+    // most of this suite must stay behaviorally identical whether or not
+    // policyDecideEnabled is even imported, proving flag-off inertness.
+    envMock: { policyDecideEnabled: vi.fn(() => false) },
+    // The dynamic import() inside triggerPolicyDecisionAttempt resolves
+    // through this mock exactly like a static import would — vi.mock
+    // intercepts both. A no-op async fn by default so a triggered attempt
+    // never rejects unhandled in a test that doesn't care about it.
+    policyDecideMock: { attemptPolicyDecision: vi.fn(async () => {}) },
   };
 });
 
@@ -248,6 +257,14 @@ vi.mock('./effectDigest', () => ({
   computeEffectDigestOutcome: effectDigestState.computeEffectDigestOutcome,
 }));
 
+vi.mock('../../config/env', () => ({
+  policyDecideEnabled: envMock.policyDecideEnabled,
+}));
+
+vi.mock('./policyDecide', () => ({
+  attemptPolicyDecision: policyDecideMock.attemptPolicyDecision,
+}));
+
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn((...args: unknown[]) => ({ op: 'eq', args })),
   and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
@@ -275,6 +292,7 @@ import {
   cancelActionIntent,
   transitionIntent,
   waitForIntentDecision,
+  runDeferredHumanFanout,
   ActionIntentError,
   ActionIntentTierError,
   ActionIntentNotFoundError,
@@ -492,6 +510,8 @@ beforeEach(() => {
   // mockResolvedValueOnce.
   intentApproversState.resolveIntentApprovers.mockResolvedValue([]);
   effectDigestState.computeEffectDigestOutcome.mockResolvedValue({ kind: 'not_applicable' });
+  envMock.policyDecideEnabled.mockReturnValue(false);
+  policyDecideMock.attemptPolicyDecision.mockResolvedValue(undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -1125,6 +1145,241 @@ describe('createActionIntent — policy decision state (Wave 5 Part A, inert)', 
     // no second insert happens.
     expect(dbState.insertedActionIntentValues).toHaveLength(1);
     expect(dbState.updateActionIntentsSets).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave 5 Part B (#3827) — the REAL resolvePolicyDecisionState + post-commit
+// trigger. The suite above (Part A, inert) covers flag-OFF byte-identical
+// behavior implicitly (envMock.policyDecideEnabled defaults false in
+// beforeEach) — these tests cover flag-ON.
+// ---------------------------------------------------------------------------
+
+describe('createActionIntent — resolvePolicyDecisionState (Wave 5 Part B, real)', () => {
+  it('flag on + agent-originated + supervised -> unattempted, skips fan-out, still writes outbox, triggers the attempt post-commit', async () => {
+    envMock.policyDecideEnabled.mockReturnValue(true);
+    guardrailMock.checkGuardrails.mockReturnValue({
+      tier: 3,
+      allowed: true,
+      requiresApproval: true,
+      description: 'Manage services on a device',
+      approvalScope: 'supervised',
+    });
+    queueAgentContext();
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-unattempted' }));
+
+    const snap = await createActionIntent(makeAgentAuth(), agentInput());
+
+    expect(dbState.insertedActionIntentValues[0]?.policyDecisionState).toBe('unattempted');
+    expect(snap.status).toBe('pending_approval');
+    // No human fan-out: resolveAgentIntentApprovers/resolveIntentTargetScope
+    // are never even consulted for the fan-out decision when the state is
+    // 'unattempted' (they ARE still called upstream for target validation —
+    // see intentService.ts — but no approval_requests rows are inserted).
+    expect(dbState.insertedApprovalRequestsValues).toHaveLength(0);
+    // Outbox intent_created is unconditional regardless of decisionState.
+    expect(dbState.insertedOutboxValues).toHaveLength(1);
+    expect(dbState.insertedOutboxValues[0]).toMatchObject({ intentId: 'intent-unattempted' });
+
+    await vi.waitFor(() => {
+      expect(policyDecideMock.attemptPolicyDecision).toHaveBeenCalledWith('intent-unattempted');
+    });
+  });
+
+  it('flag on + agent-originated + four_eyes -> human_required, ordinary fan-out runs, no attempt triggered', async () => {
+    envMock.policyDecideEnabled.mockReturnValue(true);
+    guardrailMock.checkGuardrails.mockReturnValue({
+      tier: 3,
+      allowed: true,
+      requiresApproval: true,
+      description: 'Manage services on a device',
+      approvalScope: 'four_eyes',
+    });
+    queueAgentContext();
+    intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([APPROVER_1]);
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-fe-agent' }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-fe-agent' }]);
+
+    const snap = await createActionIntent(makeAgentAuth(), agentInput());
+
+    expect(dbState.insertedActionIntentValues[0]?.policyDecisionState).toBe('human_required');
+    expect(snap.status).toBe('pending_approval');
+    expect(dbState.insertedApprovalRequestsValues).toHaveLength(1);
+    expect(policyDecideMock.attemptPolicyDecision).not.toHaveBeenCalled();
+  });
+
+  it('flag on + human-originated (chat) + supervised -> human_required (agent-origination is required, not just scope)', async () => {
+    envMock.policyDecideEnabled.mockReturnValue(true);
+    guardrailMock.checkGuardrails.mockReturnValue({
+      tier: 3,
+      allowed: true,
+      requiresApproval: true,
+      description: 'Run a script on one or more devices',
+      approvalScope: 'supervised',
+    });
+    intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([]);
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-human-sv' }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-human-sv' }]);
+
+    await createActionIntent(makeAuth(), baseInput());
+
+    expect(dbState.insertedActionIntentValues[0]?.policyDecisionState).toBe('human_required');
+    expect(policyDecideMock.attemptPolicyDecision).not.toHaveBeenCalled();
+  });
+
+  it('flag off + agent-originated + supervised -> human_required, byte-identical to Part A (attempt never triggered)', async () => {
+    envMock.policyDecideEnabled.mockReturnValue(false);
+    guardrailMock.checkGuardrails.mockReturnValue({
+      tier: 3,
+      allowed: true,
+      requiresApproval: true,
+      description: 'Manage services on a device',
+      approvalScope: 'supervised',
+    });
+    queueAgentContext();
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValueOnce([APPROVER_1]);
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-flag-off' }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-flag-off' }]);
+
+    await createActionIntent(makeAgentAuth(), agentInput());
+
+    expect(dbState.insertedActionIntentValues[0]?.policyDecisionState).toBe('human_required');
+    expect(dbState.insertedApprovalRequestsValues).toHaveLength(1);
+    expect(policyDecideMock.attemptPolicyDecision).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger an attempt on an idempotent replay, even with the flag on', async () => {
+    envMock.policyDecideEnabled.mockReturnValue(true);
+    guardrailMock.checkGuardrails.mockReturnValue({
+      tier: 3,
+      allowed: true,
+      requiresApproval: true,
+      description: 'Manage services on a device',
+      approvalScope: 'supervised',
+    });
+    dbState.insertActionIntentsResults.push([]);
+    const agentArgs = { deviceId: DEVICE_ID, action: 'restart', serviceName: 'spooler' };
+    const existing = makeIntentRow({
+      id: 'existing-unattempted',
+      source: 'ai_agent',
+      requestedByUserId: null,
+      requestingAgentRunId: RUN_ID,
+      actionName: 'manage_services',
+      arguments: agentArgs,
+      argumentDigest: computeArgumentDigest(canonicalizeArguments(agentArgs)),
+      approvalScope: 'supervised',
+      policyDecisionState: 'unattempted',
+    });
+    dbState.selectActionIntentsResults.push([existing]);
+    dbState.selectApprovalRequestsResults.push([]);
+    queueAgentContext();
+
+    const snap = await createActionIntent(makeAgentAuth(), agentInput({ idempotencyKey: 'fixed-agent-key' }));
+
+    expect(snap.id).toBe('existing-unattempted');
+    expect(policyDecideMock.attemptPolicyDecision).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave 5 Part B (#3827) — runDeferredHumanFanout, the unattempted ->
+// human_required degrade path attemptPolicyDecision (policyDecide.ts) calls
+// for every deterministic refusal. Unit-tested directly here (not only
+// through createActionIntent) since it is its own exported entry point with
+// its own CAS/idempotence contract.
+// ---------------------------------------------------------------------------
+
+describe('runDeferredHumanFanout', () => {
+  function queuedDeferredIntent(overrides?: Record<string, unknown>) {
+    return makeIntentRow({
+      id: 'intent-deferred',
+      source: 'ai_agent',
+      requestedByUserId: null,
+      requestingAgentRunId: RUN_ID,
+      approvalScope: 'supervised',
+      policyDecisionState: 'unattempted',
+      requestingClientLabel: 'Patch agent',
+      ...overrides,
+    });
+  }
+
+  it('CASes unattempted -> human_required and fans out to action-and-target-eligible humans', async () => {
+    dbState.selectActionIntentsResults.push([queuedDeferredIntent()]);
+    dbState.selectAgentRunsResults.push([makeRunRow()]);
+    intentApproversState.resolveIntentTargetScope.mockResolvedValueOnce({ kind: 'devices', siteIds: [SITE_ID] });
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValueOnce([APPROVER_1, APPROVER_2]);
+    dbState.updateActionIntentsResults.push([
+      queuedDeferredIntent({ policyDecisionState: 'human_required' }),
+    ]);
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-d1' }, { id: 'approval-d2' }]);
+
+    await runDeferredHumanFanout('intent-deferred');
+
+    expect(dbState.updateActionIntentsSets[0]).toEqual({ policyDecisionState: 'human_required' });
+    const insertedRows = dbState.insertedApprovalRequestsValues[0] as Array<{ userId: string }>;
+    expect(insertedRows.map((r) => r.userId)).toEqual([APPROVER_1, APPROVER_2]);
+    expect(notifyState.createNotification).toHaveBeenCalledTimes(2);
+    expect(metricsMock.recordActionIntentEvent).not.toHaveBeenCalled();
+  });
+
+  it('cancels no_eligible_approvers when nobody is eligible, and notifies nobody', async () => {
+    dbState.selectActionIntentsResults.push([queuedDeferredIntent()]);
+    dbState.selectAgentRunsResults.push([makeRunRow()]);
+    intentApproversState.resolveIntentTargetScope.mockResolvedValueOnce({ kind: 'devices', siteIds: [SITE_ID] });
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValueOnce([]);
+    dbState.updateActionIntentsResults.push([
+      queuedDeferredIntent({ policyDecisionState: 'human_required' }),
+    ]);
+    dbState.updateActionIntentsResults.push([
+      queuedDeferredIntent({ status: 'cancelled', errorCode: 'no_eligible_approvers' }),
+    ]);
+
+    await runDeferredHumanFanout('intent-deferred');
+
+    expect(dbState.insertedApprovalRequestsValues).toHaveLength(0);
+    expect(notifyState.createNotification).not.toHaveBeenCalled();
+    expect(metricsMock.recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: 'cancelled',
+        actorType: 'ai_agent',
+        details: expect.objectContaining({ errorCode: 'no_eligible_approvers' }),
+      }),
+    );
+  });
+
+  it('double-attempt idempotence: a lost CAS writes nothing and notifies nobody', async () => {
+    dbState.selectActionIntentsResults.push([queuedDeferredIntent()]);
+    dbState.selectAgentRunsResults.push([makeRunRow()]);
+    intentApproversState.resolveIntentTargetScope.mockResolvedValueOnce({ kind: 'devices', siteIds: [SITE_ID] });
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValueOnce([APPROVER_1]);
+    // Empty .returning() — a concurrent caller already won the CAS.
+    dbState.updateActionIntentsResults.push([]);
+
+    await runDeferredHumanFanout('intent-deferred');
+
+    expect(dbState.insertedApprovalRequestsValues).toHaveLength(0);
+    expect(notifyState.createNotification).not.toHaveBeenCalled();
+    expect(metricsMock.recordActionIntentEvent).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the intent no longer exists', async () => {
+    dbState.selectActionIntentsResults.push([]);
+
+    await runDeferredHumanFanout('intent-gone');
+
+    expect(dbState.updateActionIntentsSets).toHaveLength(0);
+    expect(dbState.insertedApprovalRequestsValues).toHaveLength(0);
+  });
+
+  it('no-ops on a non-agent-originated intent (structural guard)', async () => {
+    dbState.selectActionIntentsResults.push([
+      queuedDeferredIntent({ requestingAgentRunId: null, requestedByUserId: REQUESTER_ID }),
+    ]);
+
+    await runDeferredHumanFanout('intent-deferred');
+
+    expect(dbState.updateActionIntentsSets).toHaveLength(0);
+    expect(dbState.insertedApprovalRequestsValues).toHaveLength(0);
   });
 });
 

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -478,6 +478,26 @@ function queueAgentContext(opts?: { run?: Record<string, unknown>; agent?: Recor
   }
 }
 
+/**
+ * A full run row (same shape `makeRunRow` returns) with the policy snapshot's
+ * `effective.mode` overridden. `makeRunRow`'s own `overrides` param is a
+ * shallow spread, so passing `{ policySnapshot: {...} }` there would REPLACE
+ * the whole snapshot rather than patch one field — this deep-clones instead.
+ * Used by the Wave 5 Part B (#3827) mode-gate tests below, which need
+ * `effective.mode` to actually be `'act'` — `makeRunRow`'s own default is
+ * `'shadow'` (the wave-3b baseline every OTHER test in this file relies on).
+ */
+function agentRunRowWithMode(mode: string, overrides?: Record<string, unknown>) {
+  const base = makeRunRow(overrides);
+  return {
+    ...base,
+    policySnapshot: {
+      ...base.policySnapshot,
+      effective: { ...base.policySnapshot.effective, mode },
+    },
+  };
+}
+
 beforeEach(() => {
   resetDbState();
   vi.clearAllMocks();
@@ -1165,7 +1185,10 @@ describe('createActionIntent — resolvePolicyDecisionState (Wave 5 Part B, real
       description: 'Manage services on a device',
       approvalScope: 'supervised',
     });
-    queueAgentContext();
+    // Task 5 (#3827): policy-decide requires the run's OWN policy snapshot to
+    // read mode 'act' — makeRunRow's default ('shadow') is deliberately used
+    // by every other test in this file, so this is the one case that opts in.
+    queueAgentContext({ run: agentRunRowWithMode('act') });
     dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-unattempted' }));
 
     const snap = await createActionIntent(makeAgentAuth(), agentInput());
@@ -1199,6 +1222,33 @@ describe('createActionIntent — resolvePolicyDecisionState (Wave 5 Part B, real
     intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([APPROVER_1]);
     dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-fe-agent' }));
     dbState.insertApprovalRequestsResults.push([{ id: 'approval-fe-agent' }]);
+
+    const snap = await createActionIntent(makeAgentAuth(), agentInput());
+
+    expect(dbState.insertedActionIntentValues[0]?.policyDecisionState).toBe('human_required');
+    expect(snap.status).toBe('pending_approval');
+    expect(dbState.insertedApprovalRequestsValues).toHaveLength(1);
+    expect(policyDecideMock.attemptPolicyDecision).not.toHaveBeenCalled();
+  });
+
+  it("flag on + agent-originated + supervised + run's mode is 'shadow' (not 'act') -> human_required, ordinary fan-out runs, no attempt triggered (locked quorum decision, Task 5 #3827)", async () => {
+    // The primary enforcement point is policyDecide.ts's own live re-check
+    // (defense in depth, since the operator can flip act->shadow AFTER
+    // creation); this is the creation-time half — an intent whose run was
+    // never even in act mode must never reach 'unattempted' in the first
+    // place. makeRunRow's default mode is 'shadow', so this needs no override.
+    envMock.policyDecideEnabled.mockReturnValue(true);
+    guardrailMock.checkGuardrails.mockReturnValue({
+      tier: 3,
+      allowed: true,
+      requiresApproval: true,
+      description: 'Manage services on a device',
+      approvalScope: 'supervised',
+    });
+    queueAgentContext();
+    intentApproversState.resolveAgentIntentApprovers.mockResolvedValueOnce([APPROVER_1]);
+    dbState.insertActionIntentsResults.push(echoInsertedIntent({ id: 'intent-shadow-mode' }));
+    dbState.insertApprovalRequestsResults.push([{ id: 'approval-shadow-mode' }]);
 
     const snap = await createActionIntent(makeAgentAuth(), agentInput());
 

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -4,6 +4,7 @@ import type { AssuranceLevel } from '@breeze/shared';
 import { db, runOutsideDbContext, withDbAccessContext, withSystemDbAccessContext, type Database, type DbAccessContext } from '../../db';
 import { createNotification } from '../userNotifications';
 import { captureException } from '../sentry';
+import { policyDecideEnabled } from '../../config/env';
 import {
   actionIntents,
   intentOutbox,
@@ -313,21 +314,23 @@ interface CreationResult {
 }
 
 /**
- * Wave 5 Part A (#3827) — PR-A STUB. Always returns 'human_required': the
- * unattended policy-decide path does not exist yet in this PR, so every
- * intent gets exactly the treatment it always got — fanned out for human
- * approval. This makes the createActionIntent refactor around it (deferring
- * `runHumanFanout` behind this call) behaviorally INERT: the full
- * intentService + approvals suites pass unchanged because this function's
- * output never varies.
+ * Wave 5 Part B (#3827) — the real decision-state gate. `'unattempted'` iff
+ * ALL THREE hold: the sub-flag is on, the intent is agent-originated (a
+ * human-authored chat/MCP intent means a human already decided — there is
+ * nothing for policy to authorize), and the intent classified `supervised`
+ * (four_eyes requires a SECOND human by definition; policy is a mechanism,
+ * not a principal, and cannot stand in for that reviewer — locked quorum
+ * decision, plan header). Every other case returns `'human_required'`,
+ * exactly Part A's stub output — so flag-off is BYTE-IDENTICAL to Part A: no
+ * other condition below is even evaluated once the flag check fails.
  *
- * The signature is already shaped for what Part B's real
- * `attemptPolicyDecision` will need to read: the guardrail verdict + scope,
- * the loaded/verified agent run (only an agent-originated proposal is ever a
- * policy-decision candidate — a human-authored chat/MCP intent means a human
- * already decided), and the tool/action pair to check against
- * POLICY_DECIDABLE_TIER3 (see policyDecidable.ts). Part B replaces this
- * function's BODY only — no call-site change in createActionIntent below.
+ * Deliberately NOT checked here (Task 5, #3827 — a later task in this same
+ * plan): the run's `mode`. `attemptPolicyDecision` (policyDecide.ts) is the
+ * only consumer of the `'unattempted'` state this function produces, and it
+ * re-verifies the LIVE effective policy (registry membership, per-agent
+ * authorization, guardrails, kill state, caps) before ever authorizing
+ * anything — an `'unattempted'` intent from a shadow-mode run degrades to
+ * `human_required` there, it does not execute unattended.
  */
 function resolvePolicyDecisionState(args: {
   guardrail: GuardrailCheck;
@@ -336,8 +339,13 @@ function resolvePolicyDecisionState(args: {
   toolName: string;
   input: Record<string, unknown>;
 }): ActionIntentPolicyDecisionState {
-  void args;
-  return 'human_required';
+  void args.guardrail;
+  void args.toolName;
+  void args.input;
+  if (!policyDecideEnabled()) return 'human_required';
+  if (!args.agentRun) return 'human_required';
+  if (args.approvalScope !== 'supervised') return 'human_required';
+  return 'unattempted';
 }
 
 interface HumanFanoutArgs {
@@ -501,6 +509,106 @@ async function runHumanFanout(args: HumanFanoutArgs): Promise<HumanFanoutResult>
   }
 
   return { approvalRequestIds, requesterApprovalRequestId, fanOutUserIds, finalIntent };
+}
+
+interface NotifyFannedOutApproversArgs {
+  orgId: string;
+  intentId: string;
+  approvalRequestIds: string[];
+  fanOutUserIds: string[];
+  requestingClientLabel: string;
+  targetSummary: string;
+  /** Passed to `withDbAccessContext` for the push-token read only — the
+   *  in-app notification always runs system-scoped (see the call below).
+   *  `userId` on it may be null (agent-originated fan-out has no requester);
+   *  the token read is keyed on the loop's OWN `userId` param, not this
+   *  context's — see db/index.ts's `DbAccessContext.userId` doc comment. */
+  dbContext: DbAccessContext;
+}
+
+/**
+ * Best-effort in-app + push notification for a just-fanned-out set of
+ * approval rows, AFTER whatever transaction created them commits (#1105) —
+ * never hold a DB transaction open across the push network round-trip.
+ * Extracted (wave 5 Part B, #3827) so `runDeferredHumanFanout` below can
+ * deliver the SAME notifications a normal creation-time human fan-out would
+ * have, instead of a second, drifting copy of this loop.
+ */
+async function notifyFannedOutApprovers(args: NotifyFannedOutApproversArgs): Promise<void> {
+  const { orgId, intentId, approvalRequestIds, fanOutUserIds, requestingClientLabel, targetSummary, dbContext } = args;
+  for (let i = 0; i < approvalRequestIds.length; i++) {
+    const approvalId = approvalRequestIds[i];
+    const userId = fanOutUserIds[i];
+    if (!approvalId || !userId) continue;
+    // In-app FIRST, then push. getUserPushTokens reads mobile_devices
+    // exclusively, so before wave 2 an approver with no enrolled phone was
+    // notified by NOTHING — no row, no email, no event — while the push
+    // failure was swallowed to console.error. The in-app row is the channel
+    // that always exists, so it must not be downstream of the phone lookup.
+    try {
+      // runOutsideDbContext first: a bare system wrapper inside an ambient
+      // request context is a passthrough (db/index.ts ~440), and this
+      // cross-user insert would then 42501 into the catch below.
+      await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+        createNotification({
+          userId,
+          orgId,
+          type: 'approval',
+          priority: 'high',
+          title: 'Approval requested',
+          message: `${requestingClientLabel}: ${targetSummary}`,
+          link: '/approvals',
+          metadata: { approvalId, intentId },
+          // Survives outbox/BullMQ redelivery: one approver, one intent, one
+          // row in the bell.
+          dedupeKey: `intent-approval:${intentId}`,
+        })));
+    } catch (err) {
+      // Sentry, not just console.error. This is the highest-stakes swallow in
+      // the wave: it is the ONLY channel a phoneless approver has, and the
+      // wave exists because the equivalent push failure was console.error-only
+      // and nobody found out for months. Every neighbouring file in this
+      // subsystem pairs the log with captureException; this one must too.
+      captureException(err instanceof Error ? err : new Error(String(err)));
+      console.error(
+        `[intentService] in-app approval notification failed ` +
+          `(intent=${intentId} approval=${approvalId} user=${userId})`,
+        err,
+      );
+    }
+
+    try {
+      const tokens = await withDbAccessContext(dbContext, () => getUserPushTokens(userId));
+      await dispatchApprovalPushToTokens(tokens, {
+        approvalId,
+        actionLabel: targetSummary,
+        requestingClientLabel,
+      });
+    } catch (err) {
+      console.error('[intentService] approval push dispatch failed', approvalId, err);
+    }
+  }
+}
+
+/**
+ * Fire-and-forget trigger for a freshly-`'unattempted'` intent (wave 5 Part
+ * B, #3827). Dynamic `import()` — NOT a static import of `./policyDecide` —
+ * is load-bearing, not stylistic: `policyDecide.ts` statically imports
+ * `runDeferredHumanFanout` from THIS file (its deterministic-failure degrade
+ * path), so a static import here in the other direction would be a genuine
+ * circular module dependency between the two. Resolved lazily, inside a
+ * function body, after both modules have finished evaluating, this never
+ * cycles. Errors are swallowed here (never rejected back to the caller) —
+ * the outbox's `intent_created` recovery branch (intentReleaseWorker.ts) is
+ * the at-least-once safety net for a dropped/failed attempt, not this call.
+ */
+function triggerPolicyDecisionAttempt(intentId: string): void {
+  import('./policyDecide')
+    .then((mod) => mod.attemptPolicyDecision(intentId))
+    .catch((err) => {
+      captureException(err instanceof Error ? err : new Error(String(err)));
+      console.error(`[intentService] attemptPolicyDecision failed for intent ${intentId}:`, err);
+    });
 }
 
 export async function createActionIntent(
@@ -997,6 +1105,19 @@ export async function createActionIntent(
   // isNew below); the final `return toSnapshot(...)` covers it identically to
   // the new-intent path.
 
+  // Wave 5 Part B (#3827): a freshly `'unattempted'` intent has no fan-out to
+  // notify (runHumanFanout above was skipped entirely) — instead, kick off
+  // the policy-decide attempt AFTER the creation transaction has committed
+  // (never inside it: the attempt does its own DB work under its own
+  // transaction). Fire-and-forget by design (see triggerPolicyDecisionAttempt's
+  // doc comment) — the caller (chat SDK / MCP / agent run loop) gets back the
+  // `pending_approval` snapshot exactly as it always did; the attempt's
+  // outcome surfaces later via the intent's own state, not this call's return
+  // value.
+  if (creation.isNew && creation.intent.policyDecisionState === 'unattempted') {
+    triggerPolicyDecisionAttempt(creation.intent.id);
+  }
+
   // Best-effort push AFTER the creation transaction commits (#1105) — never
   // hold a DB transaction open across the push network round-trip. Token
   // reads happen inside a fresh context per approver; the sends happen after.
@@ -1005,63 +1126,23 @@ export async function createActionIntent(
   // that created it. Agent intents notify at EVERY scope (wave 3b): the
   // proposal is headless — nobody is watching a chat pane, so without this
   // widened gate a supervised agent proposal would notify NOBODY (gap 4).
+  // An `'unattempted'` intent has empty approvalRequestIds/fanOutUserIds
+  // (fan-out was skipped), so this loop naturally no-ops for it without any
+  // extra gating — see notifyFannedOutApprovers.
   if (
     creation.isNew &&
     creation.intent.status === 'pending_approval' &&
     (creation.intent.approvalScope === 'four_eyes' || creation.intent.source === 'ai_agent')
   ) {
-    for (let i = 0; i < creation.approvalRequestIds.length; i++) {
-      const approvalId = creation.approvalRequestIds[i];
-      const userId = creation.fanOutUserIds[i];
-      if (!approvalId || !userId) continue;
-      // In-app FIRST, then push. getUserPushTokens reads mobile_devices
-      // exclusively, so before wave 2 an approver with no enrolled phone was
-      // notified by NOTHING — no row, no email, no event — while the push
-      // failure was swallowed to console.error. The in-app row is the channel
-      // that always exists, so it must not be downstream of the phone lookup.
-      try {
-        // runOutsideDbContext first: a bare system wrapper inside an ambient
-        // request context is a passthrough (db/index.ts ~440), and this
-        // cross-user insert would then 42501 into the catch below.
-        await runOutsideDbContext(() => withSystemDbAccessContext(() =>
-          createNotification({
-            userId,
-            orgId,
-            type: 'approval',
-            priority: 'high',
-            title: 'Approval requested',
-            message: `${requestingClientLabel}: ${targetSummary}`,
-            link: '/approvals',
-            metadata: { approvalId, intentId: creation.intent.id },
-            // Survives outbox/BullMQ redelivery: one approver, one intent, one
-            // row in the bell.
-            dedupeKey: `intent-approval:${creation.intent.id}`,
-          })));
-      } catch (err) {
-        // Sentry, not just console.error. This is the highest-stakes swallow in
-        // the wave: it is the ONLY channel a phoneless approver has, and the
-        // wave exists because the equivalent push failure was console.error-only
-        // and nobody found out for months. Every neighbouring file in this
-        // subsystem pairs the log with captureException; this one must too.
-        captureException(err instanceof Error ? err : new Error(String(err)));
-        console.error(
-          `[intentService] in-app approval notification failed ` +
-            `(intent=${creation.intent.id} approval=${approvalId} user=${userId})`,
-          err,
-        );
-      }
-
-      try {
-        const tokens = await withDbAccessContext(dbContext, () => getUserPushTokens(userId));
-        await dispatchApprovalPushToTokens(tokens, {
-          approvalId,
-          actionLabel: targetSummary,
-          requestingClientLabel,
-        });
-      } catch (err) {
-        console.error('[intentService] approval push dispatch failed', approvalId, err);
-      }
-    }
+    await notifyFannedOutApprovers({
+      orgId,
+      intentId: creation.intent.id,
+      approvalRequestIds: creation.approvalRequestIds,
+      fanOutUserIds: creation.fanOutUserIds,
+      requestingClientLabel,
+      targetSummary,
+      dbContext,
+    });
   }
 
   // An intent that SHOULD have been pinned but wasn't (a resolver exists for
@@ -1130,6 +1211,172 @@ export async function createActionIntent(
   }
 
   return toSnapshot(creation.intent, creation.approvalRequestIds, creation.requesterApprovalRequestId, creation.fanOutUserIds);
+}
+
+// ---------------------------------------------------------------------------
+// runDeferredHumanFanout — the human-fallback degrade path (wave 5 Part B, #3827)
+// ---------------------------------------------------------------------------
+
+/** Mirrors createActionIntent's own tier→riskTier mapping (line ~666 above) —
+ *  kept as a private one-liner rather than a shared export because the two
+ *  call sites take DIFFERENT inputs (a live `GuardrailCheck.tier` at creation
+ *  vs. a persisted `action_intents.risk_tier` column here) and the shared
+ *  formula is a single ternary, not enough surface to be worth a public seam. */
+function riskTierLabel(tier: number): 'medium' | 'high' | 'critical' {
+  return tier >= 4 ? 'critical' : tier >= 3 ? 'high' : 'medium';
+}
+
+/**
+ * The `unattempted → human_required` degrade path (wave 5 Part B, #3827):
+ * `attemptPolicyDecision` (policyDecide.ts) calls this for every DETERMINISTIC
+ * reason a policy decision cannot authorize an intent (key not registry-
+ * decidable, not agent-authorized, guardrail/kill denial, caps exhausted, or
+ * the intent expired before an attempt landed). It re-derives the SAME
+ * approver pool and produces the SAME approval_requests rows + notifications
+ * `runHumanFanout` would have produced at creation time, had the stub (or a
+ * flag-off `resolvePolicyDecisionState`) sent this intent straight to
+ * `'human_required'` in the first place — the agent's proposal still gets a
+ * human decision, just a turn late.
+ *
+ * CAS-guarded (`policyDecisionState: 'unattempted' -> 'human_required'`,
+ * inside the SAME transaction as the fan-out) against double-attempt: the
+ * post-commit fire-and-forget trigger and the outbox `intent_created`
+ * recovery branch can both reach this for the same intent. Whichever call
+ * wins the CAS performs the fan-out; the loser's `db.update(...).returning()`
+ * comes back empty and this function returns having written nothing and
+ * notified nobody — exactly the "no double-fanout" property the plan's
+ * design-authority section requires.
+ *
+ * No-op (silently) when the intent no longer exists, is not agent-originated,
+ * or the CAS is lost — every one of those is "someone/something else already
+ * has this intent," never a caller error to surface.
+ */
+export async function runDeferredHumanFanout(intentId: string): Promise<void> {
+  // Pre-transaction reads (system-scoped; released before opening the write
+  // transaction below — #1105): the intent + its run, so the eligible-approver
+  // resolvers (which manage their own system contexts and must NOT be called
+  // from inside a held transaction) can run first, exactly like
+  // createActionIntent itself does.
+  const loaded = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const [intent] = await db.select().from(actionIntents).where(eq(actionIntents.id, intentId)).limit(1);
+      if (!intent || !intent.requestingAgentRunId) return null;
+      const [run] = await db
+        .select({
+          id: aiAgentRuns.id,
+          agentId: aiAgentRuns.agentId,
+          orgId: aiAgentRuns.orgId,
+          deviceId: aiAgentRuns.deviceId,
+        })
+        .from(aiAgentRuns)
+        .where(eq(aiAgentRuns.id, intent.requestingAgentRunId))
+        .limit(1);
+      if (!run || run.orgId !== intent.orgId) return null;
+      return { intent, run };
+    }),
+  );
+  if (!loaded) return;
+  const { intent, run } = loaded;
+
+  let targetScope: IntentTargetScope;
+  try {
+    targetScope = await resolveIntentTargetScope(
+      intent.actionName,
+      intent.arguments as Record<string, unknown>,
+      { deviceId: run.deviceId },
+      intent.orgId,
+    );
+  } catch {
+    // A cited device that no longer exists (deleted/moved since the intent
+    // was proposed): fail closed to the same 'indirect' rule
+    // resolveIntentTargetScope itself uses for an unresolvable target — only
+    // site-unrestricted approvers qualify, never "nobody at all can decide."
+    targetScope = { kind: 'indirect' };
+  }
+
+  const agentEligibleApprovers = await resolveAgentIntentApprovers({
+    orgId: intent.orgId,
+    toolName: intent.actionName,
+    input: intent.arguments as Record<string, unknown>,
+    targetScope,
+  });
+
+  const agentRun: AgentRunRef = { id: run.id, agentId: run.agentId, orgId: run.orgId, deviceId: run.deviceId };
+
+  const fanoutResult = await withSystemDbAccessContext(async (): Promise<HumanFanoutResult | null> => {
+    // The CAS: only the caller that actually flips unattempted -> human_required
+    // gets to fan out. `.returning()` empty means a concurrent caller already
+    // won (or the intent moved on some other way) — this transaction commits
+    // having written nothing.
+    const [updated] = await db
+      .update(actionIntents)
+      .set({ policyDecisionState: 'human_required' })
+      .where(and(eq(actionIntents.id, intentId), eq(actionIntents.policyDecisionState, 'unattempted')))
+      .returning();
+    if (!updated) return null;
+
+    return runHumanFanout({
+      db,
+      inserted: updated,
+      toolName: updated.actionName,
+      actionArguments: updated.arguments as Record<string, unknown>,
+      argumentDigest: updated.argumentDigest,
+      requestingClientLabel: updated.requestingClientLabel ?? 'AI Agent',
+      targetSummary: updated.targetSummary,
+      riskTier: riskTierLabel(updated.riskTier),
+      impactSummary: updated.impactSummary,
+      // The SAME deadline creation stamped — not a freshly recomputed one; a
+      // punted-to-human intent keeps whatever approval window it always had,
+      // it does not get a new one for having been attempted first.
+      expiresAt: updated.approvalExpiresAt ?? updated.expiresAt,
+      agentRun,
+      approvalScope: updated.approvalScope,
+      // resolvePolicyDecisionState only ever admits approvalScope ===
+      // 'supervised' into 'unattempted' — the four_eyes pool is structurally
+      // unreachable here, but threaded through (empty) so runHumanFanout's
+      // signature doesn't need a narrower agent-only variant.
+      eligibleApprovers: [],
+      agentEligibleApprovers,
+      requesterEligible: false,
+      // Agent-originated intents are requester-less by construction
+      // (requestedByUserId is NULL) — runHumanFanout's `agentRun` branch
+      // never reads this value, but the field is non-optional on
+      // HumanFanoutArgs so a placeholder is threaded through rather than
+      // widening that type for one caller.
+      requesterId: '',
+    });
+  });
+  if (!fanoutResult) return;
+
+  if (fanoutResult.finalIntent.status === 'cancelled') {
+    // Same audit shape as createActionIntent's own no-eligible-approver
+    // branch — this IS that branch, reached a turn later.
+    recordActionIntentEvent({
+      orgId: intent.orgId,
+      intentId: intent.id,
+      actionName: intent.actionName,
+      argumentDigest: intent.argumentDigest,
+      source: intent.source,
+      outcome: 'cancelled',
+      actorType: 'ai_agent',
+      details: {
+        errorCode: fanoutResult.finalIntent.errorCode ?? 'no_eligible_approvers',
+        agentId: run.agentId,
+        agentRunId: run.id,
+      },
+    });
+    return;
+  }
+
+  await notifyFannedOutApprovers({
+    orgId: intent.orgId,
+    intentId: intent.id,
+    approvalRequestIds: fanoutResult.approvalRequestIds,
+    fanOutUserIds: fanoutResult.fanOutUserIds,
+    requestingClientLabel: intent.requestingClientLabel ?? 'AI Agent',
+    targetSummary: intent.targetSummary,
+    dbContext: { scope: 'organization', orgId: intent.orgId, accessibleOrgIds: [intent.orgId], userId: null },
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -612,9 +612,16 @@ async function notifyFannedOutApprovers(args: NotifyFannedOutApproversArgs): Pro
  * path), so a static import here in the other direction would be a genuine
  * circular module dependency between the two. Resolved lazily, inside a
  * function body, after both modules have finished evaluating, this never
- * cycles. Errors are swallowed here (never rejected back to the caller) —
- * the outbox's `intent_created` recovery branch (intentReleaseWorker.ts) is
- * the at-least-once safety net for a dropped/failed attempt, not this call.
+ * cycles. Errors — INCLUDING `PolicyDecisionTransientError`, the
+ * discriminated signal `attemptPolicyDecision` throws for a transient
+ * DB/Redis fault (review fix, #3827) — are deliberately swallowed here
+ * (never rejected back to this call's own caller, and never retried from
+ * this end): this trigger is fire-and-forget and does not survive a
+ * crash/restart, so it cannot be the retry lane. The outbox's
+ * `intent_created` recovery branch (intentReleaseWorker.ts) is that lane —
+ * it's the one durable caller that rethrows `PolicyDecisionTransientError`
+ * so BullMQ redelivers the job; this call site logging-and-dropping the same
+ * error is correct, not a gap.
  */
 function triggerPolicyDecisionAttempt(intentId: string): void {
   import('./policyDecide')

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -338,6 +338,19 @@ function resolvePolicyDecisionState(args: {
   agentRun: AgentRunRef;
   toolName: string;
   input: Record<string, unknown>;
+  /**
+   * The run's OWN policy-snapshot mode (loaded.run.policySnapshot?.effective
+   * ?.mode above), NOT re-resolved from the agent's current live policy —
+   * this is the creation-time half of the LOCKED quorum decision "policy-
+   * decide requires mode === 'act'" (plan header, Task 5, #3827).
+   * policyDecide.ts's attemptPolicyDecision re-checks the CURRENT live mode
+   * again at attempt time (an operator can flip act -> shadow as a brake
+   * between creation and attempt) and keeps its own check even after this
+   * one ships, as defense in depth — see its comment. Undefined for a
+   * malformed/legacy snapshot; anything but the literal string 'act' fails
+   * closed to human_required, same as every other branch here.
+   */
+  agentMode: string | undefined;
 }): ActionIntentPolicyDecisionState {
   void args.guardrail;
   void args.toolName;
@@ -345,6 +358,7 @@ function resolvePolicyDecisionState(args: {
   if (!policyDecideEnabled()) return 'human_required';
   if (!args.agentRun) return 'human_required';
   if (args.approvalScope !== 'supervised') return 'human_required';
+  if (args.agentMode !== 'act') return 'human_required';
   return 'unattempted';
 }
 
@@ -685,6 +699,13 @@ export async function createActionIntent(
   // -------------------------------------------------------------------------
   let agentRun: AgentRunRef = null;
   let agentRow: { id: string; name: string } | null = null;
+  // Task 5 (#3827): the run's own policy-snapshot mode, captured alongside
+  // `effective` below — resolvePolicyDecisionState's creation-time act-mode
+  // gate reads this, never a fresh live-policy lookup (that re-check is
+  // policyDecide.ts's job, at attempt time). Stays undefined for every
+  // human-originated intent (agentRun stays null, which already forces
+  // human_required on its own).
+  let agentRunMode: string | undefined;
   if (auth.principal.kind === 'ai_agent') {
     const principal = auth.principal;
     // runOutsideDbContext is load-bearing: a bare system wrapper inside an
@@ -739,6 +760,7 @@ export async function createActionIntent(
     // checkAgentGuardrails and denies, which is the fail-closed shape we
     // want, hence the cast instead of a hand-rolled validator here).
     const effective = loaded.run.policySnapshot?.effective;
+    agentRunMode = effective?.mode;
     const verdict = checkAgentGuardrails(input.toolName, input.input, {
       enabled: effective?.enabled,
       mode: effective?.mode,
@@ -900,6 +922,7 @@ export async function createActionIntent(
         agentRun,
         toolName: input.toolName,
         input: input.input,
+        agentMode: agentRunMode,
       });
 
       const [inserted] = await db

--- a/apps/api/src/services/actionIntents/metrics.ts
+++ b/apps/api/src/services/actionIntents/metrics.ts
@@ -134,6 +134,17 @@ export interface ActionIntentAuditInput {
    */
   actorType?: 'user' | 'ai_agent';
   /**
+   * Wave 5 Part B (#3827): override `writeAuditEvent`'s auto-derived
+   * `initiatedBy` (which maps an omitted actorType to `'schedule'`, meant
+   * for the reaper/cron family, not an authorization mechanism). A
+   * policy-authorized `'approved'` event passes `'policy'` explicitly here
+   * — the locked design decision that policy is a mechanism, never a
+   * synthetic human decider, has to be readable in the audit trail itself.
+   * Omit for every other caller; the existing 'user'/'system' auto-derivation
+   * is unchanged.
+   */
+  initiatedBy?: import('../auditService').InitiatedByType;
+  /**
    * Extra audit context — ids, decider, assurance, error codes, counts. Must
    * NEVER carry raw tool argument contents, only the digest/summaries already
    * computed (spec §7: "Details carry ids, action name, digest, decider,
@@ -165,6 +176,7 @@ export function recordActionIntentEvent(input: ActionIntentAuditInput): void {
     result: FAILURE_OUTCOMES.has(input.outcome) ? 'failure' : 'success',
     actorType: input.actorType,
     ...(input.actorId ? { actorId: input.actorId } : {}),
+    ...(input.initiatedBy ? { initiatedBy: input.initiatedBy } : {}),
   });
   recordActionIntentMetric(input.source, input.actionName, input.outcome);
 }

--- a/apps/api/src/services/actionIntents/policyDecidable.test.ts
+++ b/apps/api/src/services/actionIntents/policyDecidable.test.ts
@@ -3,6 +3,7 @@ import {
   POLICY_DECIDABLE_TIER3,
   isPolicyDecidableKey,
   validateAuthorizationKeys,
+  rejectionReasonFor,
 } from './policyDecidable';
 import {
   TIER3_FOUR_EYES_ACTIONS,
@@ -149,5 +150,39 @@ describe('validateAuthorizationKeys', () => {
 
   it('empty input yields empty output', () => {
     expect(validateAuthorizationKeys([])).toEqual({ ok: [], rejected: [] });
+  });
+});
+
+describe('rejectionReasonFor — structural headlessCompatible enforcement (review fix, #3827)', () => {
+  // Every REAL entry in POLICY_DECIDABLE_TIER3 already declares
+  // `headlessCompatible: true` (pinned by the "every entry claims
+  // headlessCompatible: true" test above), so `validateAuthorizationKeys`
+  // can never exercise this branch through the public API today — this is
+  // exactly why it's a defense-in-depth structural check, not a live gate,
+  // and why it has to be tested against a synthetic entry directly.
+  it('rejects a synthetic entry that claims headlessCompatible: false', () => {
+    const fakeEntry = {
+      key: 'not_a_real_tool:not_a_real_action',
+      toolName: 'not_a_real_tool',
+      action: 'not_a_real_action',
+      headlessCompatible: false,
+      maxTargetCardinality: 1 as const,
+      requiresEffectPin: true,
+      note: 'synthetic test fixture only — never in the real registry',
+    };
+    expect(rejectionReasonFor(fakeEntry)).toBe('not headless-compatible');
+  });
+
+  it('passes a synthetic entry through to the LATER checks when headlessCompatible: true (does not falsely reject)', () => {
+    const fakeEntry = {
+      key: 'not_a_real_tool:not_a_real_action',
+      toolName: 'not_a_real_tool',
+      action: 'not_a_real_action',
+      headlessCompatible: true,
+      maxTargetCardinality: 1 as const,
+      requiresEffectPin: true,
+      note: 'synthetic test fixture only — never in the real registry',
+    };
+    expect(rejectionReasonFor(fakeEntry)).toBeNull();
   });
 });

--- a/apps/api/src/services/actionIntents/policyDecidable.ts
+++ b/apps/api/src/services/actionIntents/policyDecidable.ts
@@ -218,6 +218,18 @@ const BY_KEY: ReadonlyMap<string, PolicyDecidableEntry> = new Map(
   POLICY_DECIDABLE_TIER3.map((entry) => [entry.key, entry]),
 );
 
+/**
+ * Version of the POLICY_DECIDABLE_TIER3 registry that produced a given
+ * policy decision, stamped into `action_intents.policy_classification_version`
+ * (Part B, policyDecide.ts) the same way `intentService.ts`'s
+ * `CLASSIFICATION_VERSION` pins the tier3-supervised-four-eyes ruleset. Bump
+ * when the registry's membership or its `rejectionReasonFor` re-classification
+ * logic changes in a materially observable way — a decision made under v1
+ * must stay distinguishable from one made under a future, differently-scoped
+ * v2 (e.g. if `maxTargetCardinality` ever admits >1 or a new tool joins).
+ */
+export const POLICY_DECIDABLE_TIER3_VERSION = 1;
+
 export function isPolicyDecidableKey(key: string): boolean {
   return BY_KEY.has(key);
 }

--- a/apps/api/src/services/actionIntents/policyDecidable.ts
+++ b/apps/api/src/services/actionIntents/policyDecidable.ts
@@ -267,7 +267,13 @@ function isActionMultiplexedTool(toolName: string): boolean {
  * action-multiplexed. This is what keeps a future registry-vs-guardrails
  * drift from silently reopening a four_eyes action to policy decision.
  */
-function rejectionReasonFor(entry: PolicyDecidableEntry): string | null {
+// Exported (not module-private) solely so tests can exercise it directly
+// against a synthetic entry — every REAL entry in the frozen
+// POLICY_DECIDABLE_TIER3 registry already satisfies every one of these
+// checks (pinned by the module-header assertions in policyDecidable.test.ts),
+// so `validateAuthorizationKeys` alone can never hit some of these branches
+// (the `headlessCompatible` one, in particular) through the public API today.
+export function rejectionReasonFor(entry: PolicyDecidableEntry): string | null {
   const { toolName, action } = entry;
 
   if (BLOCKED_TOOLS.has(toolName) || getToolTier(toolName) === 4) {
@@ -275,6 +281,17 @@ function rejectionReasonFor(entry: PolicyDecidableEntry): string | null {
   }
   if (isSecretBearingTool(toolName)) {
     return 'tool is secret-bearing';
+  }
+  // Review fix (#3827): structural enforcement of the module-header claim
+  // ("every entry claims headlessCompatible: true") — previously only
+  // asserted by policyDecidable.test.ts, never enforced by
+  // `validateAuthorizationKeys` itself. `attemptPolicyDecision` runs fully
+  // unattended with no live interactive session, so an entry that ever
+  // regressed to `headlessCompatible: false` (e.g. a copy-paste of an
+  // M365/Google/computer-control entry) must be rejected here directly, not
+  // rely solely on `requiresLiveSession` below staying in sync with it.
+  if (!entry.headlessCompatible) {
+    return 'not headless-compatible';
   }
   if (action === null && isActionMultiplexedTool(toolName)) {
     return 'bare-tool key for an action-multiplexed tool';

--- a/apps/api/src/services/actionIntents/policyDecide.test.ts
+++ b/apps/api/src/services/actionIntents/policyDecide.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
 import type { AiAgentPolicySnapshot } from '@breeze/shared';
+
+const dialect = new PgDialect();
+const renderSql = (value: unknown) => dialect.sqlToQuery(value as SQL).sql;
 
 // ---------------------------------------------------------------------------
 // DB mock — generic, table-name-keyed (mirrors runService.test.ts's pattern):
@@ -14,8 +19,17 @@ const dbMockState = vi.hoisted(() => ({
   insertValues: {} as Record<string, Record<string, unknown>[]>,
   updateSets: {} as Record<string, Record<string, unknown>[]>,
   updateWheres: {} as Record<string, unknown[]>,
-  systemContextDepth: 0,
   ambientContext: undefined as { scope: string } | undefined,
+  // Per-invocation "which withSystemDbAccessContext call did this write
+  // happen inside" tracking — lets a test assert that a set of writes shared
+  // ONE real transaction rather than merely counting them. `txCounter`
+  // increments once per NEW (non-nested) withSystemDbAccessContext call;
+  // `currentTxId` is that call's id for the duration of its callback.
+  txCounter: 0,
+  currentTxId: null as number | null,
+  executedTx: [] as (number | null)[],
+  insertTx: {} as Record<string, (number | null)[]>,
+  updateTx: {} as Record<string, (number | null)[]>,
 }));
 
 function tableNameOf(table: unknown): string {
@@ -40,8 +54,12 @@ function resetDbMock(): void {
   dbMockState.insertValues = {};
   dbMockState.updateSets = {};
   dbMockState.updateWheres = {};
-  dbMockState.systemContextDepth = 0;
   dbMockState.ambientContext = undefined;
+  dbMockState.txCounter = 0;
+  dbMockState.currentTxId = null;
+  dbMockState.executedTx = [];
+  dbMockState.insertTx = {};
+  dbMockState.updateTx = {};
 }
 
 vi.mock('../../db', () => {
@@ -64,6 +82,7 @@ vi.mock('../../db', () => {
       select: vi.fn(() => makeSelect()),
       execute: vi.fn(async (statement: unknown) => {
         dbMockState.executed.push(statement);
+        dbMockState.executedTx.push(dbMockState.currentTxId);
         return [];
       }),
       insert: vi.fn((table: unknown) => {
@@ -71,6 +90,7 @@ vi.mock('../../db', () => {
         return {
           values: vi.fn((values: Record<string, unknown>) => {
             (dbMockState.insertValues[tableName] ??= []).push(values);
+            (dbMockState.insertTx[tableName] ??= []).push(dbMockState.currentTxId);
             // intent_outbox is awaited directly (no .returning() chain) —
             // matches policyDecide.ts's own call shape.
             if (tableName === 'intent_outbox') return Promise.resolve(undefined);
@@ -83,6 +103,7 @@ vi.mock('../../db', () => {
         return {
           set: vi.fn((values: Record<string, unknown>) => {
             (dbMockState.updateSets[tableName] ??= []).push(values);
+            (dbMockState.updateTx[tableName] ??= []).push(dbMockState.currentTxId);
             return {
               where: vi.fn((cond: unknown) => {
                 (dbMockState.updateWheres[tableName] ??= []).push(cond);
@@ -95,15 +116,26 @@ vi.mock('../../db', () => {
     },
     getCurrentDbAccessContext: vi.fn(() => dbMockState.ambientContext),
     runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+    // Each call opens a NEW numbered "transaction" (mirrors the real
+    // withSystemDbAccessContext opening one real Postgres transaction per
+    // call — db/index.ts) unless already nested inside one (matches
+    // inSystemDbContext's own skip-if-already-system behavior in
+    // policyDecide.ts, so a nested call reuses its parent's txId rather than
+    // minting a spurious new one).
     withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
-      const previous = dbMockState.ambientContext;
+      const previousContext = dbMockState.ambientContext;
+      const previousTxId = dbMockState.currentTxId;
+      const isNested = previousContext?.scope === 'system';
       dbMockState.ambientContext = { scope: 'system' };
-      dbMockState.systemContextDepth += 1;
+      if (!isNested) {
+        dbMockState.txCounter += 1;
+        dbMockState.currentTxId = dbMockState.txCounter;
+      }
       try {
         return await fn();
       } finally {
-        dbMockState.systemContextDepth -= 1;
-        dbMockState.ambientContext = previous;
+        dbMockState.ambientContext = previousContext;
+        dbMockState.currentTxId = previousTxId;
       }
     }),
   };
@@ -341,11 +373,21 @@ describe('attemptPolicyDecision', () => {
     expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
   });
 
-  it('flag off (checked defensively, even though resolvePolicyDecisionState already gates on it at creation): degrades to human_required', async () => {
+  it('flag off + a genuinely unattempted intent: degrades to human_required (review fix, #3827 — the call site in intentReleaseWorker.ts is unconditional now, so this function owns flag-off inertness)', async () => {
     envMock.policyDecideEnabled.mockReturnValue(false);
+    pushRows('action_intents', [makeIntentRow()]);
     await attemptPolicyDecision(INTENT_ID);
     expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
-    // No intent row was even read — the flag gate is the very first check.
+    // The intent IS read (to confirm it's genuinely `unattempted`), but the
+    // flag check short-circuits before the run/agent load or any write.
+    expect(dbMockState.updateSets.action_intents ?? []).toHaveLength(0);
+  });
+
+  it('flag off + an intent NOT in `unattempted` state: true no-op, no writes, no fanout', async () => {
+    envMock.policyDecideEnabled.mockReturnValue(false);
+    pushRows('action_intents', [makeIntentRow({ status: 'approved', policyDecisionState: 'authorized' })]);
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
     expect(dbMockState.updateSets.action_intents ?? []).toHaveLength(0);
   });
 
@@ -386,6 +428,26 @@ describe('attemptPolicyDecision', () => {
     });
     await attemptPolicyDecision(INTENT_ID);
     expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+  });
+
+  it('SAFETY GATE (review fix, #3827): agent CURRENTLY in shadow mode -> human path, never authorized — the live guardrail re-run alone does NOT catch this (checkAgentGuardrails returns `propose`, not `deny`, for a shadow-mode mutation)', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent();
+    effectivePolicyMock.resolveEffectiveAgentSystem.mockResolvedValueOnce({
+      schemaVersion: 3,
+      agentId: AGENT_ID,
+      kind: 'patch',
+      effective: { ...POLICY_SNAPSHOT.effective, mode: 'shadow' },
+      provenance: POLICY_SNAPSHOT.provenance,
+      resolvedAt: POLICY_SNAPSHOT.resolvedAt,
+    });
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+    // Never reached the authorize transaction: no reservation, no CAS.
+    expect(dbMockState.insertValues.ai_unattended_exposure ?? []).toHaveLength(0);
+    expect(dbMockState.updateSets.action_intents ?? []).toHaveLength(0);
+    // Gated BEFORE the guardrail re-run, exactly like the key-authorization gate.
+    expect(guardrailMock.checkAgentGuardrails).not.toHaveBeenCalled();
   });
 
   it('deterministic: key not in the agent\'s CURRENT supervisedActionKeys -> human path', async () => {
@@ -479,8 +541,13 @@ describe('attemptPolicyDecision', () => {
     await attemptPolicyDecision(INTENT_ID);
 
     expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
-    // Advisory lock taken.
+    // Advisory lock taken — exactly one statement, and it's actually the
+    // advisory lock (compiled through the real Postgres dialect, not just
+    // counted), and it ran BEFORE the cap reads that follow it inside the
+    // same transaction.
     expect(dbMockState.executed).toHaveLength(1);
+    expect(renderSql(dbMockState.executed[0])).toMatch(/pg_advisory_xact_lock\(hashtextextended\(/);
+
     // Exposure reservation written.
     expect(dbMockState.insertValues.ai_unattended_exposure?.[0]).toMatchObject({
       orgId: ORG_ID,
@@ -491,6 +558,24 @@ describe('attemptPolicyDecision', () => {
       intentId: INTENT_ID,
       source: 'policy_intent',
     });
+
+    // ATOMICITY (the quorum's central requirement): the advisory lock, the
+    // exposure reservation, the intent CAS, and the outbox write all happened
+    // inside the SAME `withSystemDbAccessContext` invocation — i.e. one real
+    // Postgres transaction — not four separate ones. Splitting
+    // `runAuthorizeTransaction` into multiple `inSystemDbContext` calls would
+    // destroy this and still leave the earlier (weaker) assertions green, so
+    // this checks the transaction BOUNDARY, not just that the writes happened.
+    expect(dbMockState.txCounter).toBeGreaterThanOrEqual(1);
+    const authorizeTxIds = new Set([
+      dbMockState.executedTx[0],
+      dbMockState.insertTx.ai_unattended_exposure?.[0],
+      dbMockState.updateTx.action_intents?.[0],
+      dbMockState.insertTx.intent_outbox?.[0],
+    ]);
+    expect(authorizeTxIds.size).toBe(1);
+    expect([...authorizeTxIds][0]).not.toBeNull();
+
     // Intent CASed to approved with full provenance, NEVER a synthetic human decider.
     const set = dbMockState.updateSets.action_intents?.[0];
     expect(set).toMatchObject({

--- a/apps/api/src/services/actionIntents/policyDecide.test.ts
+++ b/apps/api/src/services/actionIntents/policyDecide.test.ts
@@ -1,0 +1,578 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AiAgentPolicySnapshot } from '@breeze/shared';
+
+// ---------------------------------------------------------------------------
+// DB mock — generic, table-name-keyed (mirrors runService.test.ts's pattern):
+// real drizzle-orm + real schema modules are used, so `where`/`and`/`eq`/`gt`
+// conditions are REAL SQL objects; only what row(s) a given table's next
+// select/insert/update returns is faked, via a per-table FIFO queue.
+// ---------------------------------------------------------------------------
+
+const dbMockState = vi.hoisted(() => ({
+  rowQueues: {} as Record<string, unknown[][]>,
+  executed: [] as unknown[],
+  insertValues: {} as Record<string, Record<string, unknown>[]>,
+  updateSets: {} as Record<string, Record<string, unknown>[]>,
+  updateWheres: {} as Record<string, unknown[]>,
+  systemContextDepth: 0,
+  ambientContext: undefined as { scope: string } | undefined,
+}));
+
+function tableNameOf(table: unknown): string {
+  return String((table as Record<symbol, unknown>)[Symbol.for('drizzle:Name')]);
+}
+
+function nextRows(table: string): unknown[] {
+  const queue = dbMockState.rowQueues[table];
+  if (!queue || queue.length === 0) {
+    throw new Error(`No queued rows for table ${table}`);
+  }
+  return queue.shift() as unknown[];
+}
+
+function pushRows(table: string, rows: unknown[]): void {
+  (dbMockState.rowQueues[table] ??= []).push(rows);
+}
+
+function resetDbMock(): void {
+  dbMockState.rowQueues = {};
+  dbMockState.executed = [];
+  dbMockState.insertValues = {};
+  dbMockState.updateSets = {};
+  dbMockState.updateWheres = {};
+  dbMockState.systemContextDepth = 0;
+  dbMockState.ambientContext = undefined;
+}
+
+vi.mock('../../db', () => {
+  const makeSelect = () => ({
+    from: vi.fn((table: unknown) => {
+      const tableName = tableNameOf(table);
+      const builder: Record<string, unknown> = {
+        where: vi.fn(() => builder),
+        orderBy: vi.fn(() => builder),
+        limit: vi.fn(() => builder),
+        then: (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+          Promise.resolve().then(() => nextRows(tableName)).then(resolve, reject),
+      };
+      return builder;
+    }),
+  });
+
+  return {
+    db: {
+      select: vi.fn(() => makeSelect()),
+      execute: vi.fn(async (statement: unknown) => {
+        dbMockState.executed.push(statement);
+        return [];
+      }),
+      insert: vi.fn((table: unknown) => {
+        const tableName = tableNameOf(table);
+        return {
+          values: vi.fn((values: Record<string, unknown>) => {
+            (dbMockState.insertValues[tableName] ??= []).push(values);
+            // intent_outbox is awaited directly (no .returning() chain) —
+            // matches policyDecide.ts's own call shape.
+            if (tableName === 'intent_outbox') return Promise.resolve(undefined);
+            return { returning: vi.fn(async () => nextRows(tableName)) };
+          }),
+        };
+      }),
+      update: vi.fn((table: unknown) => {
+        const tableName = tableNameOf(table);
+        return {
+          set: vi.fn((values: Record<string, unknown>) => {
+            (dbMockState.updateSets[tableName] ??= []).push(values);
+            return {
+              where: vi.fn((cond: unknown) => {
+                (dbMockState.updateWheres[tableName] ??= []).push(cond);
+                return { returning: vi.fn(async () => nextRows(tableName)) };
+              }),
+            };
+          }),
+        };
+      }),
+    },
+    getCurrentDbAccessContext: vi.fn(() => dbMockState.ambientContext),
+    runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+      const previous = dbMockState.ambientContext;
+      dbMockState.ambientContext = { scope: 'system' };
+      dbMockState.systemContextDepth += 1;
+      try {
+        return await fn();
+      } finally {
+        dbMockState.systemContextDepth -= 1;
+        dbMockState.ambientContext = previous;
+      }
+    }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// External collaborator mocks
+// ---------------------------------------------------------------------------
+
+const envMock = vi.hoisted(() => ({ policyDecideEnabled: vi.fn(() => true) }));
+vi.mock('../../config/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../config/env')>();
+  return { ...actual, policyDecideEnabled: envMock.policyDecideEnabled };
+});
+
+const guardrailMock = vi.hoisted(() => ({ checkAgentGuardrails: vi.fn() }));
+vi.mock('../aiGuardrails', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../aiGuardrails')>();
+  return { ...actual, checkAgentGuardrails: guardrailMock.checkAgentGuardrails };
+});
+
+const killStateMock = vi.hoisted(() => ({ readAiKillState: vi.fn() }));
+vi.mock('../aiKillState', () => ({ readAiKillState: killStateMock.readAiKillState }));
+
+const effectivePolicyMock = vi.hoisted(() => ({ resolveEffectiveAgentSystem: vi.fn() }));
+vi.mock('../aiAgents/effectivePolicy', () => ({
+  resolveEffectiveAgentSystem: effectivePolicyMock.resolveEffectiveAgentSystem,
+}));
+
+const recipientsMock = vi.hoisted(() => ({ resolveRecipientUserIds: vi.fn(async () => [] as string[]) }));
+vi.mock('../aiAgents/recipients', () => ({ resolveRecipientUserIds: recipientsMock.resolveRecipientUserIds }));
+
+const contractMock = vi.hoisted(() => ({ countContractDevices: vi.fn(async () => 100) }));
+vi.mock('../contractQuantities', () => ({ countContractDevices: contractMock.countContractDevices }));
+
+const notifyMock = vi.hoisted(() => ({ createNotification: vi.fn(async () => 'notif-1') }));
+vi.mock('../userNotifications', () => ({ createNotification: notifyMock.createNotification }));
+
+const sentryMock = vi.hoisted(() => ({ captureException: vi.fn() }));
+vi.mock('../sentry', () => ({ captureException: sentryMock.captureException }));
+
+const metricsMock = vi.hoisted(() => ({ recordActionIntentEvent: vi.fn() }));
+vi.mock('./metrics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./metrics')>();
+  return { ...actual, recordActionIntentEvent: metricsMock.recordActionIntentEvent };
+});
+
+const intentServiceMock = vi.hoisted(() => ({
+  runDeferredHumanFanout: vi.fn(async () => {}),
+  RELEASE_LEASE_MS: 10 * 60 * 1000,
+}));
+vi.mock('./intentService', () => ({
+  runDeferredHumanFanout: intentServiceMock.runDeferredHumanFanout,
+  RELEASE_LEASE_MS: intentServiceMock.RELEASE_LEASE_MS,
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { attemptPolicyDecision, computePolicySnapshotDigest } from './policyDecide';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const PARTNER_ID = '55555555-5555-4555-8555-555555555555';
+const AGENT_ID = '66666666-6666-4666-8666-666666666666';
+const RUN_ID = '77777777-7777-4777-8777-777777777777';
+const DEVICE_ID = '99999999-9999-4999-8999-999999999999';
+const SITE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const INTENT_ID = 'intent-attempt-1';
+
+const POLICY_SNAPSHOT: AiAgentPolicySnapshot = {
+  schemaVersion: 3,
+  agentId: AGENT_ID,
+  kind: 'patch',
+  effective: {
+    enabled: true,
+    mode: 'act',
+    model: null,
+    toolAllowlist: ['manage_services'],
+    protectedResources: { services: [], paths: [], registryKeys: [], deviceTags: [] },
+    limits: {
+      maxDevicesPerRun: 1,
+      maxConcurrentRuns: 1,
+      maxRunsPerHour: 20,
+      maxTurnsPerRun: 25,
+      maxBudgetCentsPerRun: 50,
+      maxBudgetCentsPerDay: 1000,
+      wallClockSeconds: 600,
+      maxFleetPercentPerDay: 5,
+      maxActionsPerRun: 3,
+      maxPolicyDecisionsPerDay: 10,
+    },
+    triggers: { alertSeverities: [], respectMaintenanceWindows: false },
+    recipients: { userIds: ['recipient-1'], roleIds: [] },
+    actAssets: { scriptIds: [], supervisedActionKeys: ['manage_services:restart'] },
+    instructions: null,
+    cooldownSeconds: 900,
+  },
+  provenance: {} as AiAgentPolicySnapshot['provenance'],
+  resolvedAt: new Date().toISOString(),
+};
+
+function makeIntentRow(overrides?: Record<string, unknown>) {
+  return {
+    id: INTENT_ID,
+    orgId: ORG_ID,
+    partnerId: PARTNER_ID,
+    requestedByUserId: null,
+    requestingAgentRunId: RUN_ID,
+    source: 'ai_agent',
+    actionName: 'manage_services',
+    arguments: { deviceId: DEVICE_ID, action: 'restart', serviceName: 'spooler' },
+    argumentDigest: 'digest-1',
+    targetSummary: 'manage_services(action=restart, ...)',
+    riskTier: 3,
+    status: 'pending_approval',
+    policyDecisionState: 'unattempted',
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    approvalExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    ...overrides,
+  };
+}
+
+function makeRunRow(overrides?: Record<string, unknown>) {
+  return {
+    id: RUN_ID,
+    agentId: AGENT_ID,
+    orgId: ORG_ID,
+    deviceId: DEVICE_ID,
+    policySnapshot: POLICY_SNAPSHOT,
+    ...overrides,
+  };
+}
+
+function makeAgentRow(overrides?: Record<string, unknown>) {
+  return { id: AGENT_ID, name: 'Patch agent', kind: 'patch', ...overrides };
+}
+
+/** Queues the loadRunAndAgent reads in the exact order policyDecide.ts performs them. */
+function queueRunAndAgent(opts?: {
+  run?: Record<string, unknown>;
+  agent?: Record<string, unknown>;
+  org?: Record<string, unknown>;
+  device?: Record<string, unknown> | null;
+}): void {
+  const run = makeRunRow(opts?.run);
+  pushRows('ai_agent_runs', [run]);
+  pushRows('ai_agents', [makeAgentRow(opts?.agent)]);
+  pushRows('organizations', [{ partnerId: PARTNER_ID, ...opts?.org }]);
+  if (opts?.device !== null) {
+    pushRows('devices', [{ siteId: SITE_ID, ...opts?.device }]);
+  }
+}
+
+/** Queues the cap-check + reservation + CAS + outbox reads/writes for a
+ *  successful authorize transaction. */
+function queueSuccessfulAuthorize(opts?: { exposedDeviceIds?: string[]; dayCount?: number }): void {
+  pushRows('ai_unattended_exposure', (opts?.exposedDeviceIds ?? []).map((deviceId) => ({ deviceId })));
+  pushRows('ai_unattended_exposure', [{ n: opts?.dayCount ?? 0 }]);
+  pushRows('ai_unattended_exposure', [{ id: 'reservation-1' }]);
+  pushRows('action_intents', [{ id: INTENT_ID }]);
+}
+
+beforeEach(() => {
+  resetDbMock();
+  vi.clearAllMocks();
+  envMock.policyDecideEnabled.mockReturnValue(true);
+  guardrailMock.checkAgentGuardrails.mockReturnValue({
+    tier: 3,
+    allowed: false,
+    requiresApproval: false,
+    disposition: 'propose',
+    description: 'Manage services on a device',
+  });
+  killStateMock.readAiKillState.mockResolvedValue({ killed: false, epoch: 3 });
+  effectivePolicyMock.resolveEffectiveAgentSystem.mockResolvedValue({
+    schemaVersion: 3,
+    agentId: AGENT_ID,
+    kind: 'patch',
+    effective: POLICY_SNAPSHOT.effective,
+    provenance: POLICY_SNAPSHOT.provenance,
+    resolvedAt: POLICY_SNAPSHOT.resolvedAt,
+  });
+  contractMock.countContractDevices.mockResolvedValue(100);
+  recipientsMock.resolveRecipientUserIds.mockResolvedValue(['recipient-1']);
+  intentServiceMock.runDeferredHumanFanout.mockResolvedValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// computePolicySnapshotDigest — pure helper
+// ---------------------------------------------------------------------------
+
+describe('computePolicySnapshotDigest', () => {
+  it('is deterministic for the same snapshot content', () => {
+    const a = computePolicySnapshotDigest(POLICY_SNAPSHOT);
+    const b = computePolicySnapshotDigest(JSON.parse(JSON.stringify(POLICY_SNAPSHOT)));
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('changes when the snapshot content changes', () => {
+    const a = computePolicySnapshotDigest(POLICY_SNAPSHOT);
+    const changed = { ...POLICY_SNAPSHOT, effective: { ...POLICY_SNAPSHOT.effective, enabled: false } };
+    expect(computePolicySnapshotDigest(changed)).not.toBe(a);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attemptPolicyDecision — the full pipeline
+// ---------------------------------------------------------------------------
+
+describe('attemptPolicyDecision', () => {
+  it('idempotence preconditions: no-ops (no writes, no fanout) when already resolved, not pending, or not agent-originated', async () => {
+    pushRows('action_intents', [makeIntentRow({ policyDecisionState: 'authorized' })]);
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
+    expect(dbMockState.updateSets.action_intents ?? []).toHaveLength(0);
+
+    pushRows('action_intents', [makeIntentRow({ status: 'cancelled' })]);
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
+
+    pushRows('action_intents', [makeIntentRow({ requestingAgentRunId: null })]);
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
+  });
+
+  it('gone intent: no-op', async () => {
+    pushRows('action_intents', []);
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
+  });
+
+  it('flag off (checked defensively, even though resolvePolicyDecisionState already gates on it at creation): degrades to human_required', async () => {
+    envMock.policyDecideEnabled.mockReturnValue(false);
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+    // No intent row was even read — the flag gate is the very first check.
+    expect(dbMockState.updateSets.action_intents ?? []).toHaveLength(0);
+  });
+
+  it('expired intent -> human path (deterministic failure)', async () => {
+    pushRows('action_intents', [makeIntentRow({ approvalExpiresAt: new Date(Date.now() - 1000) })]);
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+  });
+
+  it('deterministic: agent run invalid (missing/cross-org) -> human path', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    pushRows('ai_agent_runs', []);
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+  });
+
+  it('deterministic: key not registry-decidable (unknown action) -> human path', async () => {
+    pushRows('action_intents', [
+      makeIntentRow({ actionName: 'manage_services', arguments: { deviceId: DEVICE_ID, action: 'list' } }),
+    ]);
+    queueRunAndAgent();
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+    // Never even reached the guardrail re-run or the authorize transaction.
+    expect(guardrailMock.checkAgentGuardrails).not.toHaveBeenCalled();
+  });
+
+  it('deterministic: agent identity changed (current effective agent differs from the run) -> human path', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent();
+    effectivePolicyMock.resolveEffectiveAgentSystem.mockResolvedValueOnce({
+      schemaVersion: 3,
+      agentId: 'a-different-agent',
+      kind: 'patch',
+      effective: POLICY_SNAPSHOT.effective,
+      provenance: POLICY_SNAPSHOT.provenance,
+      resolvedAt: POLICY_SNAPSHOT.resolvedAt,
+    });
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+  });
+
+  it('deterministic: key not in the agent\'s CURRENT supervisedActionKeys -> human path', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent();
+    effectivePolicyMock.resolveEffectiveAgentSystem.mockResolvedValueOnce({
+      schemaVersion: 3,
+      agentId: AGENT_ID,
+      kind: 'patch',
+      effective: { ...POLICY_SNAPSHOT.effective, actAssets: { scriptIds: [], supervisedActionKeys: [] } },
+      provenance: POLICY_SNAPSHOT.provenance,
+      resolvedAt: POLICY_SNAPSHOT.resolvedAt,
+    });
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+    expect(guardrailMock.checkAgentGuardrails).not.toHaveBeenCalled();
+  });
+
+  it('deterministic: live guardrail re-run denies (not kill-switch) -> human path', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent();
+    guardrailMock.checkAgentGuardrails.mockReturnValue({
+      tier: 3, allowed: false, requiresApproval: false, disposition: 'deny', reason: 'Denied: protected resource',
+    });
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+  });
+
+  it('deterministic: kill-switch engaged -> human path, distinguished from a plain guardrail denial', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent();
+    killStateMock.readAiKillState.mockResolvedValue({ killed: true, epoch: 9 });
+    guardrailMock.checkAgentGuardrails.mockReturnValue({
+      tier: 3, allowed: false, requiresApproval: false, disposition: 'deny', reason: 'Autonomous AI agents are kill-switched',
+    });
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+  });
+
+  it('deterministic: fleet-percent cap exhausted -> human path, no exposure row written', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent();
+    // allowance = floor(100 * 5 / 100) = 5; 5 devices already exposed today,
+    // none of them this device -> projected 6 > 5.
+    pushRows('ai_unattended_exposure', [
+      { deviceId: 'd1' }, { deviceId: 'd2' }, { deviceId: 'd3' }, { deviceId: 'd4' }, { deviceId: 'd5' },
+    ]);
+
+    await attemptPolicyDecision(INTENT_ID);
+
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+    expect(dbMockState.insertValues.ai_unattended_exposure ?? []).toHaveLength(0);
+    expect(dbMockState.updateSets.action_intents ?? []).toHaveLength(0);
+  });
+
+  it('a device already exposed today does not count twice against the fleet cap', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent();
+    // Fleet allowance is 5; THIS device is already one of the 5 exposed
+    // today, so authorizing it again must not push the projected count to 6.
+    pushRows('ai_unattended_exposure', [
+      { deviceId: DEVICE_ID }, { deviceId: 'd2' }, { deviceId: 'd3' }, { deviceId: 'd4' }, { deviceId: 'd5' },
+    ]);
+    pushRows('ai_unattended_exposure', [{ n: 0 }]);
+    pushRows('ai_unattended_exposure', [{ id: 'reservation-1' }]);
+    pushRows('action_intents', [{ id: INTENT_ID }]);
+
+    await attemptPolicyDecision(INTENT_ID);
+
+    expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
+    expect(dbMockState.updateSets.action_intents?.[0]).toMatchObject({ status: 'approved' });
+  });
+
+  it('deterministic: day cap exhausted -> human path, no exposure row written', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent();
+    pushRows('ai_unattended_exposure', []); // fleet check passes
+    pushRows('ai_unattended_exposure', [{ n: 10 }]); // >= maxPolicyDecisionsPerDay (10)
+
+    await attemptPolicyDecision(INTENT_ID);
+
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+    expect(dbMockState.insertValues.ai_unattended_exposure ?? []).toHaveLength(0);
+  });
+
+  it('success: all writes happen in one authorize transaction (advisory lock, exposure insert, CAS, outbox)', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent();
+    queueSuccessfulAuthorize();
+
+    await attemptPolicyDecision(INTENT_ID);
+
+    expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
+    // Advisory lock taken.
+    expect(dbMockState.executed).toHaveLength(1);
+    // Exposure reservation written.
+    expect(dbMockState.insertValues.ai_unattended_exposure?.[0]).toMatchObject({
+      orgId: ORG_ID,
+      partnerId: PARTNER_ID,
+      agentId: AGENT_ID,
+      runId: RUN_ID,
+      deviceId: DEVICE_ID,
+      intentId: INTENT_ID,
+      source: 'policy_intent',
+    });
+    // Intent CASed to approved with full provenance, NEVER a synthetic human decider.
+    const set = dbMockState.updateSets.action_intents?.[0];
+    expect(set).toMatchObject({
+      status: 'approved',
+      policyDecisionState: 'authorized',
+      decidedByUserId: null,
+      decidedAssuranceLevel: null,
+      decidedVia: 'policy',
+      policyAuthorizationKey: 'manage_services:restart',
+      policyReservationId: 'reservation-1',
+      policyKillEpoch: 3,
+    });
+    expect(set?.policySnapshotDigest).toMatch(/^[0-9a-f]{64}$/);
+    // Outbox intent_approved written.
+    expect(dbMockState.insertValues.intent_outbox?.[0]).toMatchObject({
+      intentId: INTENT_ID,
+      eventType: 'intent_approved',
+    });
+    // Audit trail: initiatedBy: 'policy', never a person.
+    expect(metricsMock.recordActionIntentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: 'approved',
+        actorType: 'ai_agent',
+        initiatedBy: 'policy',
+        details: expect.objectContaining({ decidedVia: 'policy', policyAuthorizationKey: 'manage_services:restart' }),
+      }),
+    );
+    // Notification to recipients.
+    expect(notifyMock.createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'recipient-1', orgId: ORG_ID }),
+    );
+  });
+
+  it('double-attempt idempotence: a second attempt after authorization sees state !== unattempted and no-ops', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent();
+    queueSuccessfulAuthorize();
+    await attemptPolicyDecision(INTENT_ID);
+    expect(dbMockState.insertValues.ai_unattended_exposure).toHaveLength(1);
+
+    vi.clearAllMocks();
+    envMock.policyDecideEnabled.mockReturnValue(true);
+    pushRows('action_intents', [makeIntentRow({ status: 'approved', policyDecisionState: 'authorized' })]);
+
+    await attemptPolicyDecision(INTENT_ID);
+
+    expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
+    // Still exactly ONE reservation total — the second attempt wrote nothing.
+    expect(dbMockState.insertValues.ai_unattended_exposure).toHaveLength(1);
+  });
+
+  it('never synthesizes a human approval row: no approval_requests writes on the success path', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent();
+    queueSuccessfulAuthorize();
+
+    await attemptPolicyDecision(INTENT_ID);
+
+    expect(dbMockState.insertValues.approval_requests).toBeUndefined();
+  });
+
+  it('transient: a DB read failure leaves the intent unattempted (no degrade, no throw)', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    // ai_agent_runs queue left empty on purpose -> nextRows throws, simulating
+    // a transient DB fault mid-pipeline.
+    await expect(attemptPolicyDecision(INTENT_ID)).resolves.toBeUndefined();
+    expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
+    expect(sentryMock.captureException).toHaveBeenCalled();
+  });
+
+  it('transient: a lost CAS deep inside the authorize transaction is a silent no-op, not a degrade', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent();
+    pushRows('ai_unattended_exposure', []);
+    pushRows('ai_unattended_exposure', [{ n: 0 }]);
+    pushRows('ai_unattended_exposure', [{ id: 'reservation-1' }]);
+    // Empty .returning() on the final CAS — someone else already resolved it.
+    pushRows('action_intents', []);
+
+    await attemptPolicyDecision(INTENT_ID);
+
+    expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
+    expect(sentryMock.captureException).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/actionIntents/policyDecide.test.ts
+++ b/apps/api/src/services/actionIntents/policyDecide.test.ts
@@ -196,7 +196,11 @@ vi.mock('./intentService', () => ({
 // Import under test (after mocks)
 // ---------------------------------------------------------------------------
 
-import { attemptPolicyDecision, computePolicySnapshotDigest } from './policyDecide';
+import {
+  attemptPolicyDecision,
+  computePolicySnapshotDigest,
+  PolicyDecisionTransientError,
+} from './policyDecide';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -352,6 +356,14 @@ describe('computePolicySnapshotDigest', () => {
 // ---------------------------------------------------------------------------
 
 describe('attemptPolicyDecision', () => {
+  it('review fix (#3827): invariant guard — throws immediately, before any read, if called with an already-held DB access context', async () => {
+    dbMockState.ambientContext = { scope: 'system' };
+    await expect(attemptPolicyDecision(INTENT_ID)).rejects.toThrow(/ALREADY-HELD DB access context/);
+    expect(sentryMock.captureException).toHaveBeenCalled();
+    // Never even read the intent — the guard fires before loadIntentForAttempt.
+    expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
+  });
+
   it('idempotence preconditions: no-ops (no writes, no fanout) when already resolved, not pending, or not agent-originated', async () => {
     pushRows('action_intents', [makeIntentRow({ policyDecisionState: 'authorized' })]);
     await attemptPolicyDecision(INTENT_ID);
@@ -464,6 +476,43 @@ describe('attemptPolicyDecision', () => {
     await attemptPolicyDecision(INTENT_ID);
     expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
     expect(guardrailMock.checkAgentGuardrails).not.toHaveBeenCalled();
+  });
+
+  it('review fix (#3827): key authorized on the CURRENT policy but NOT in the run\'s own policySnapshot -> human path (mirrors agentReleaseAuthority.ts checking both)', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    // Current effective policy (the default mock) authorizes the key; the
+    // RUN's own snapshot never opted it in — simulates an operator adding
+    // the key to supervisedActionKeys mid-run, after this run's snapshot was
+    // already taken.
+    queueRunAndAgent({
+      run: {
+        policySnapshot: {
+          ...POLICY_SNAPSHOT,
+          effective: { ...POLICY_SNAPSHOT.effective, actAssets: { scriptIds: [], supervisedActionKeys: [] } },
+        },
+      },
+    });
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+    // Never reached the guardrail re-run or the authorize transaction.
+    expect(guardrailMock.checkAgentGuardrails).not.toHaveBeenCalled();
+    expect(dbMockState.insertValues.ai_unattended_exposure ?? []).toHaveLength(0);
+  });
+
+  it('review fix (#3827): key authorized in the run\'s snapshot but since REMOVED from the CURRENT policy -> human path (the pre-existing current-policy check, unaffected by adding the snapshot check)', async () => {
+    pushRows('action_intents', [makeIntentRow()]);
+    queueRunAndAgent(); // run's snapshot still has the key (default fixture)
+    effectivePolicyMock.resolveEffectiveAgentSystem.mockResolvedValueOnce({
+      schemaVersion: 3,
+      agentId: AGENT_ID,
+      kind: 'patch',
+      effective: { ...POLICY_SNAPSHOT.effective, actAssets: { scriptIds: [], supervisedActionKeys: [] } },
+      provenance: POLICY_SNAPSHOT.provenance,
+      resolvedAt: POLICY_SNAPSHOT.resolvedAt,
+    });
+    await attemptPolicyDecision(INTENT_ID);
+    expect(intentServiceMock.runDeferredHumanFanout).toHaveBeenCalledWith(INTENT_ID);
+    expect(dbMockState.insertValues.ai_unattended_exposure ?? []).toHaveLength(0);
   });
 
   it('deterministic: live guardrail re-run denies (not kill-switch) -> human path', async () => {
@@ -603,9 +652,11 @@ describe('attemptPolicyDecision', () => {
         details: expect.objectContaining({ decidedVia: 'policy', policyAuthorizationKey: 'manage_services:restart' }),
       }),
     );
-    // Notification to recipients.
+    // Notification to recipients. Review fix (#3827): `link: null`, not
+    // '/approvals' — a policy-decided intent has no approval_requests row for
+    // that link to point at; no run-detail page exists yet (wave 6).
     expect(notifyMock.createNotification).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: 'recipient-1', orgId: ORG_ID }),
+      expect.objectContaining({ userId: 'recipient-1', orgId: ORG_ID, link: null }),
     );
   });
 
@@ -637,11 +688,11 @@ describe('attemptPolicyDecision', () => {
     expect(dbMockState.insertValues.approval_requests).toBeUndefined();
   });
 
-  it('transient: a DB read failure leaves the intent unattempted (no degrade, no throw)', async () => {
+  it('transient: a DB read failure leaves the intent unattempted and throws the discriminated PolicyDecisionTransientError (review fix, #3827 — real at-least-once relies on this propagating to the outbox recovery branch)', async () => {
     pushRows('action_intents', [makeIntentRow()]);
     // ai_agent_runs queue left empty on purpose -> nextRows throws, simulating
     // a transient DB fault mid-pipeline.
-    await expect(attemptPolicyDecision(INTENT_ID)).resolves.toBeUndefined();
+    await expect(attemptPolicyDecision(INTENT_ID)).rejects.toBeInstanceOf(PolicyDecisionTransientError);
     expect(intentServiceMock.runDeferredHumanFanout).not.toHaveBeenCalled();
     expect(sentryMock.captureException).toHaveBeenCalled();
   });

--- a/apps/api/src/services/actionIntents/policyDecide.ts
+++ b/apps/api/src/services/actionIntents/policyDecide.ts
@@ -1,0 +1,523 @@
+import { and, eq, gt, count, sql } from 'drizzle-orm';
+import type { AiAgentKind, AiAgentPolicySnapshot } from '@breeze/shared';
+import {
+  db,
+  getCurrentDbAccessContext,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+} from '../../db';
+import { actionIntents, intentOutbox, type ActionIntent } from '../../db/schema/actionIntents';
+import { aiUnattendedExposure } from '../../db/schema/aiUnattendedExposure';
+import { aiAgentRuns, aiAgents } from '../../db/schema/aiAgents';
+import { organizations } from '../../db/schema/orgs';
+import { devices } from '../../db/schema/devices';
+import { policyDecideEnabled } from '../../config/env';
+import { checkAgentGuardrails, resolveActionForTool, type AgentGuardrailPolicy } from '../aiGuardrails';
+import { readAiKillState } from '../aiKillState';
+import { resolveEffectiveAgentSystem } from '../aiAgents/effectivePolicy';
+import { resolveRecipientUserIds } from '../aiAgents/recipients';
+import { countContractDevices } from '../contractQuantities';
+import { createNotification } from '../userNotifications';
+import { captureException } from '../sentry';
+import { validateAuthorizationKeys, POLICY_DECIDABLE_TIER3_VERSION } from './policyDecidable';
+import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
+import { recordActionIntentEvent } from './metrics';
+import { runDeferredHumanFanout, RELEASE_LEASE_MS } from './intentService';
+
+/**
+ * Wave 5 Part B (#3827) — the policy-decide attempt pipeline: the ONE
+ * function that turns an agent-originated, `supervised`, `'unattempted'`
+ * intent into either a durably policy-authorized `approved` intent (no human
+ * ever sees it) or a `human_required` one (the ordinary fan-out runs, just a
+ * turn late). See the plan header's Design authority for the eight
+ * independent gates this enforces and the deterministic-vs-transient
+ * distinction that makes the whole thing safe to retry at least once.
+ *
+ * Deliberately imports `runDeferredHumanFanout` (and `RELEASE_LEASE_MS`)
+ * FROM `intentService.ts` — a real, one-directional static dependency.
+ * `intentService.ts`'s own reference back to `attemptPolicyDecision` (its
+ * post-commit trigger) is a lazy `import()`, precisely so this direction can
+ * stay static without the pair becoming a circular module graph — see
+ * `triggerPolicyDecisionAttempt`'s doc comment there.
+ */
+
+/**
+ * Same skip-if-already-system shape every other leaf module in this
+ * directory duplicates locally (actRevalidation.ts, runFinishedNotify.ts)
+ * rather than importing — see their headers for why.
+ */
+function inSystemDbContext<T>(fn: () => Promise<T>): Promise<T> {
+  if (getCurrentDbAccessContext()?.scope === 'system') return fn();
+  return runOutsideDbContext(() => withSystemDbAccessContext(fn));
+}
+
+/**
+ * Hash of the run's OWN immutable `policy_snapshot` — reuses the SAME
+ * canonicalizer the argument/effect digests use (canonicalize.ts) rather
+ * than a second bespoke JSON-hashing implementation. Provenance only: this
+ * is what authorized the decision, stamped for audit/forensics, not a
+ * revalidation target (the run row is immutable, so recomputing it later
+ * can only ever equal itself).
+ */
+export function computePolicySnapshotDigest(snapshot: AiAgentPolicySnapshot): string {
+  return computeArgumentDigest(canonicalizeArguments(snapshot as unknown as Record<string, unknown>));
+}
+
+/** The canonical POLICY_DECIDABLE_TIER3 key for a stored intent's action —
+ *  derived EXACTLY the way checkGuardrails/checkAgentGuardrails resolve the
+ *  sub-operation (aiGuardrails.ts's `resolveActionForTool`), never a second
+ *  ad hoc parse of `arguments`. */
+function canonicalPolicyKey(actionName: string, args: Record<string, unknown>): string {
+  const action = resolveActionForTool(actionName, args);
+  return action ? `${actionName}:${action}` : actionName;
+}
+
+/** Thrown INSIDE the authorize transaction when the final CAS loses a race
+ *  it should never lose (the top-level precondition already checked
+ *  `policyDecisionState === 'unattempted'`) — forces the transaction
+ *  (including the exposure-row insert) to roll back rather than commit an
+ *  orphaned reservation for an intent some concurrent caller already
+ *  resolved a different way. Caught immediately outside the transaction and
+ *  treated as a silent no-op, never a failure. */
+class PolicyDecisionRaceLostError extends Error {}
+
+type CapCheckFailure = 'fleet_cap_exceeded' | 'day_cap_exceeded';
+
+interface LoadedIntentForAttempt {
+  intent: ActionIntent;
+}
+
+async function loadIntentForAttempt(intentId: string): Promise<LoadedIntentForAttempt | null> {
+  return inSystemDbContext(async () => {
+    const [intent] = await db.select().from(actionIntents).where(eq(actionIntents.id, intentId)).limit(1);
+    return intent ? { intent } : null;
+  });
+}
+
+interface LoadedRunAndAgent {
+  run: { id: string; agentId: string; orgId: string; deviceId: string | null; policySnapshot: AiAgentPolicySnapshot };
+  agent: { id: string; name: string; kind: AiAgentKind };
+  partnerId: string;
+  deviceSiteId: string | null;
+}
+
+async function loadRunAndAgent(runId: string, orgId: string): Promise<LoadedRunAndAgent | null> {
+  return inSystemDbContext(async () => {
+    const [run] = await db
+      .select({
+        id: aiAgentRuns.id,
+        agentId: aiAgentRuns.agentId,
+        orgId: aiAgentRuns.orgId,
+        deviceId: aiAgentRuns.deviceId,
+        policySnapshot: aiAgentRuns.policySnapshot,
+      })
+      .from(aiAgentRuns)
+      .where(eq(aiAgentRuns.id, runId))
+      .limit(1);
+    if (!run || run.orgId !== orgId) return null;
+
+    const [agent] = await db
+      .select({ id: aiAgents.id, name: aiAgents.name, kind: aiAgents.kind })
+      .from(aiAgents)
+      .where(eq(aiAgents.id, run.agentId))
+      .limit(1);
+    if (!agent) return null;
+
+    // The org's OWNING partner (organizations.partner_id is NOT NULL) — needed
+    // for the exposure row's composite (org_id, partner_id) FK, independent of
+    // whether this particular agent is org- or partner-owned.
+    const [org] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+    if (!org) return null;
+
+    // Re-resolve the device's CURRENT site — never the site the run started
+    // under (mirrors agentReleaseAuthority.ts / intentService.ts's own
+    // creation-time lookup).
+    let deviceSiteId: string | null = null;
+    if (run.deviceId) {
+      const [device] = await db
+        .select({ siteId: devices.siteId })
+        .from(devices)
+        .where(eq(devices.id, run.deviceId))
+        .limit(1);
+      deviceSiteId = device?.siteId ?? null;
+    }
+
+    return { run, agent, partnerId: org.partnerId, deviceSiteId };
+  });
+}
+
+/** `errorCode` values this module can degrade an intent with — logged, not
+ *  persisted onto the intent row (a `human_required` intent is not an error
+ *  state; `errorCode` stays reserved for genuinely terminal outcomes,
+ *  matching intentService.ts's existing convention). */
+type DegradeReason =
+  | 'policy_decide_disabled'
+  | 'policy_intent_expired'
+  | 'agent_run_invalid'
+  | 'agent_identity_changed'
+  | 'not_policy_decidable'
+  | 'not_agent_authorized'
+  | 'kill_switch_engaged'
+  | 'agent_policy_denied'
+  | CapCheckFailure;
+
+async function degradeToHumanRequired(intentId: string, reason: DegradeReason, details?: Record<string, unknown>): Promise<void> {
+  console.log(`[policyDecide] intent ${intentId} degraded to human_required: ${reason}`, details ?? {});
+  try {
+    await runDeferredHumanFanout(intentId);
+  } catch (err) {
+    // The degrade decision itself already stands (or will, via the outbox
+    // recovery branch retrying attemptPolicyDecision — which no-ops past the
+    // CAS this call already tried to win). A fan-out failure here must not
+    // propagate as a "transient, retry the WHOLE attempt" signal: retrying
+    // attemptPolicyDecision from scratch would just re-evaluate every gate
+    // for an intent whose state may already be `human_required`, which is
+    // harmless but wasteful — log and move on.
+    captureException(err instanceof Error ? err : new Error(String(err)));
+    console.error(`[policyDecide] runDeferredHumanFanout failed for intent ${intentId}:`, err);
+  }
+}
+
+interface AuthorizeArgs {
+  intent: ActionIntent;
+  run: LoadedRunAndAgent['run'];
+  agentId: string;
+  partnerId: string;
+  key: string;
+  killEpoch: number;
+  maxFleetPercentPerDay: number;
+  maxPolicyDecisionsPerDay: number;
+}
+
+type AuthorizeResult = { ok: true } | { ok: false; reason: CapCheckFailure };
+
+/**
+ * The atomic authorize transaction (plan Global Constraints — one
+ * transaction, DB-backed, never count-then-write): per-org advisory xact
+ * lock -> fleet-percent check -> day-cap check -> exposure reservation
+ * insert -> CAS the intent to `approved` with full provenance -> outbox
+ * `intent_approved`. All six writes/reads share ONE `withSystemDbAccessContext`
+ * call, which itself opens ONE real Postgres transaction (db/index.ts) — the
+ * same pattern createActionIntent's own creation transaction uses.
+ *
+ * Returns `{ok:false, reason}` when a cap is exhausted (nothing was written —
+ * the check runs BEFORE the exposure insert) and throws
+ * `PolicyDecisionRaceLostError` when the final CAS unexpectedly loses (which
+ * rolls the whole transaction, including the exposure insert, back) —
+ * `attemptPolicyDecision` treats that as a silent no-op, not a failure.
+ */
+async function runAuthorizeTransaction(args: AuthorizeArgs): Promise<AuthorizeResult> {
+  const { intent, run, agentId, partnerId, key, killEpoch, maxFleetPercentPerDay, maxPolicyDecisionsPerDay } = args;
+  const deviceId = run.deviceId;
+  if (!deviceId) {
+    // Structurally unreachable: checkAgentGuardrails already denies every
+    // mutating call from a device-less run before attemptPolicyDecision ever
+    // reaches this function (its live-guardrail-re-run step). A genuine
+    // invariant violation, not a cap outcome — surfaced as a thrown error
+    // (caught by attemptPolicyDecision's outer catch as transient, logged to
+    // Sentry) rather than mislabeled with either CapCheckFailure reason.
+    throw new Error(`runAuthorizeTransaction: intent ${intent.id}'s run has no deviceId`);
+  }
+
+  return inSystemDbContext(async (): Promise<AuthorizeResult> => {
+    // Per-org advisory lock (plan Global Constraints): serializes concurrent
+    // policy-decide authorizations for the SAME org so the fleet-percent
+    // check below can't overshoot by more than one device per race.
+    // Released automatically on commit/rollback of this transaction — no
+    // separate unlock call.
+    await db.execute(sql`select pg_advisory_xact_lock(hashtextextended(${`ai-exposure:${intent.orgId}`}, 0))`);
+
+    const windowStart = sql`now() - interval '24 hours'`;
+
+    const exposedDeviceRows = await db
+      .select({ deviceId: aiUnattendedExposure.deviceId })
+      .from(aiUnattendedExposure)
+      .where(and(eq(aiUnattendedExposure.orgId, intent.orgId), gt(aiUnattendedExposure.reservedAt, windowStart)));
+    const exposedDevices = new Set(exposedDeviceRows.map((r) => r.deviceId));
+    const deviceAlreadyExposed = exposedDevices.has(deviceId);
+
+    const contractDeviceCount = await countContractDevices(intent.orgId, null);
+    // floor(), no max(1, ·) — a tiny fleet with a nonzero-but-sub-1-device
+    // allowance gets ZERO unattended authorizations. That is the correct,
+    // intended reading (locked quorum decision): the operator raises
+    // maxFleetPercentPerDay if they want unattended authority on a small
+    // fleet, this function never silently grants "at least one."
+    const allowance = Math.floor((contractDeviceCount * maxFleetPercentPerDay) / 100);
+    const projectedDistinctDevices = exposedDevices.size + (deviceAlreadyExposed ? 0 : 1);
+    if (projectedDistinctDevices > allowance) {
+      return { ok: false, reason: 'fleet_cap_exceeded' };
+    }
+
+    const [dayCountRow] = await db
+      .select({ n: count() })
+      .from(aiUnattendedExposure)
+      .where(
+        and(
+          eq(aiUnattendedExposure.orgId, intent.orgId),
+          eq(aiUnattendedExposure.agentId, agentId),
+          eq(aiUnattendedExposure.source, 'policy_intent'),
+          gt(aiUnattendedExposure.reservedAt, windowStart),
+        ),
+      );
+    const policyDecisionsToday = Number(dayCountRow?.n ?? 0);
+    if (policyDecisionsToday >= maxPolicyDecisionsPerDay) {
+      return { ok: false, reason: 'day_cap_exceeded' };
+    }
+
+    const [reservation] = await db
+      .insert(aiUnattendedExposure)
+      .values({
+        orgId: intent.orgId,
+        partnerId,
+        agentId,
+        runId: run.id,
+        deviceId,
+        intentId: intent.id,
+        source: 'policy_intent',
+      })
+      .returning({ id: aiUnattendedExposure.id });
+    if (!reservation) throw new Error('ai_unattended_exposure insert returned no row');
+
+    const digest = computePolicySnapshotDigest(run.policySnapshot);
+    const [updated] = await db
+      .update(actionIntents)
+      .set({
+        status: 'approved',
+        policyDecisionState: 'authorized',
+        decidedAt: new Date(),
+        decidedByUserId: null,
+        decidedAssuranceLevel: null,
+        decidedVia: 'policy',
+        releaseBy: new Date(Date.now() + RELEASE_LEASE_MS),
+        policyAuthorizationKey: key,
+        policySnapshotDigest: digest,
+        policyClassificationVersion: POLICY_DECIDABLE_TIER3_VERSION,
+        policyReservationId: reservation.id,
+        policyKillEpoch: killEpoch,
+      })
+      .where(
+        and(
+          eq(actionIntents.id, intent.id),
+          eq(actionIntents.status, 'pending_approval'),
+          eq(actionIntents.policyDecisionState, 'unattempted'),
+        ),
+      )
+      .returning({ id: actionIntents.id });
+    if (!updated) {
+      // Lost a race the top-level precondition should have prevented — roll
+      // back the exposure reservation too (see the class doc comment).
+      throw new PolicyDecisionRaceLostError(`intent ${intent.id} CAS lost inside the authorize transaction`);
+    }
+
+    await db.insert(intentOutbox).values({
+      intentId: intent.id,
+      eventType: 'intent_approved',
+      payload: { intentId: intent.id, orgId: intent.orgId },
+    });
+
+    return { ok: true };
+  });
+}
+
+/** Best-effort "authorized automatically by policy" notification to the
+ *  agent's resolved recipients — mirrors runFinishedNotify.ts's own
+ *  recipient-resolution + notify pattern. Never blocks or reverses the
+ *  authorization: a notify failure here is logged, not retried, exactly
+ *  like every other post-commit notification in this subsystem (#1105 —
+ *  outside any held transaction). */
+async function notifyRecipientsOfPolicyAuthorization(args: {
+  orgId: string;
+  partnerId: string | null;
+  recipients: AiAgentPolicySnapshot['effective']['recipients'];
+  agentName: string;
+  intentId: string;
+  targetSummary: string;
+}): Promise<void> {
+  try {
+    const userIds = await resolveRecipientUserIds(
+      { orgId: args.orgId, partnerId: args.partnerId, recipients: args.recipients },
+      args.orgId,
+    );
+    await inSystemDbContext(async () => {
+      for (const userId of userIds) {
+        await createNotification({
+          userId,
+          orgId: args.orgId,
+          type: 'ai',
+          title: `${args.agentName}: authorized automatically by policy`,
+          message: `${args.targetSummary} — executing`,
+          link: '/approvals',
+          metadata: { intentId: args.intentId, decidedVia: 'policy' },
+          dedupeKey: `intent-policy-authorized:${args.intentId}`,
+        });
+      }
+    });
+  } catch (err) {
+    captureException(err instanceof Error ? err : new Error(String(err)));
+    console.error(`[policyDecide] recipient notification failed for intent ${args.intentId}:`, err);
+  }
+}
+
+/**
+ * The policy-decide attempt for one intent. Idempotent by construction (the
+ * `policyDecisionState` CAS is the single-transition guard both this
+ * function's own precondition check and the authorize transaction's final
+ * UPDATE rely on) — safe to call more than once for the same intent, from
+ * the post-commit fire-and-forget trigger AND the outbox `intent_created`
+ * recovery branch, without ever double-authorizing or double-fanning-out.
+ *
+ * Never throws: every failure this function can encounter is either a
+ * DETERMINISTIC refusal (degrades the intent to `human_required` and returns)
+ * or a TRANSIENT one (logs and leaves the intent `unattempted` for the
+ * outbox's at-least-once redelivery to retry). See the plan header's Design
+ * authority for why that distinction is load-bearing.
+ */
+export async function attemptPolicyDecision(intentId: string): Promise<void> {
+  try {
+    if (!policyDecideEnabled()) {
+      // The flag is one of the eight independent gates: an attempt that
+      // somehow reaches this function after the flag flipped off mid-flight
+      // (a live env read, not a cached snapshot) must degrade, not authorize.
+      await degradeToHumanRequired(intentId, 'policy_decide_disabled');
+      return;
+    }
+
+    const loadedIntent = await loadIntentForAttempt(intentId);
+    if (!loadedIntent) return; // gone — nothing to attempt
+    const { intent } = loadedIntent;
+
+    if (intent.policyDecisionState !== 'unattempted') return; // already resolved by another caller
+    if (intent.status !== 'pending_approval') return; // moved on some other way (e.g. manually cancelled)
+    if (!intent.requestingAgentRunId) return; // structurally impossible; defensive no-op
+
+    const deadline = intent.approvalExpiresAt ?? intent.expiresAt;
+    if (deadline.getTime() <= Date.now()) {
+      await degradeToHumanRequired(intentId, 'policy_intent_expired');
+      return;
+    }
+
+    const loadedRun = await loadRunAndAgent(intent.requestingAgentRunId, intent.orgId);
+    if (!loadedRun) {
+      await degradeToHumanRequired(intentId, 'agent_run_invalid');
+      return;
+    }
+    const { run, agent, partnerId, deviceSiteId } = loadedRun;
+
+    // Canonical key -> registry membership + headlessCompatible + the
+    // defense-in-depth reclassification (policyDecidable.ts's
+    // `validateAuthorizationKeys` — re-derives the LIVE approval scope from
+    // aiGuardrails' own tables, so a registry-vs-guardrails drift since v1
+    // was frozen cannot reopen a since-tightened action to policy decision).
+    const key = canonicalPolicyKey(intent.actionName, intent.arguments as Record<string, unknown>);
+    const registryCheck = validateAuthorizationKeys([key]);
+    if (registryCheck.ok.length === 0) {
+      await degradeToHumanRequired(intentId, 'not_policy_decidable', {
+        key,
+        reason: registryCheck.rejected[0]?.reason,
+      });
+      return;
+    }
+
+    // Current effective policy — the operator's LIVE authorization, not the
+    // run's start-of-run snapshot (which may predate the operator ever
+    // opting this key in, or postdate them revoking it).
+    const current = await resolveEffectiveAgentSystem(intent.orgId, agent.kind);
+    if (!current || current.agentId !== run.agentId) {
+      await degradeToHumanRequired(intentId, 'agent_identity_changed');
+      return;
+    }
+
+    const authorizedKeys = current.effective.actAssets.supervisedActionKeys ?? [];
+    if (!authorizedKeys.includes(key)) {
+      await degradeToHumanRequired(intentId, 'not_agent_authorized', { key });
+      return;
+    }
+
+    // Kill state, warmed BEFORE the guardrail re-run so its synchronous cache
+    // (checkAgentGuardrails reads getCachedAiKillStateSnapshot()) reflects
+    // this read, mirroring actRevalidation.ts's / agentReleaseAuthority.ts's
+    // own "refresh immediately before the re-run" pattern. Captured for
+    // provenance (policy_kill_epoch) regardless of outcome.
+    const killState = await readAiKillState();
+
+    const livePolicy: AgentGuardrailPolicy = {
+      enabled: current.effective.enabled,
+      mode: current.effective.mode,
+      toolAllowlist: current.effective.toolAllowlist,
+      protectedResources: current.effective.protectedResources,
+      deviceId: run.deviceId,
+      deviceSiteId,
+    };
+    const verdict = checkAgentGuardrails(intent.actionName, intent.arguments as Record<string, unknown>, livePolicy);
+    if (verdict.disposition === 'deny') {
+      // killState.killed is the only thing that can make checkAgentGuardrails
+      // deny at its FIRST gate — whenever it's true every other candidate
+      // would also deny for the same reason (same distinction
+      // agentReleaseAuthority.ts draws for the human-approved release lane).
+      await degradeToHumanRequired(
+        intentId,
+        killState.killed ? 'kill_switch_engaged' : 'agent_policy_denied',
+        { reason: verdict.reason, epoch: killState.epoch },
+      );
+      return;
+    }
+
+    const authorized = await runAuthorizeTransaction({
+      intent,
+      run,
+      agentId: agent.id,
+      partnerId,
+      key,
+      killEpoch: killState.epoch,
+      maxFleetPercentPerDay: current.effective.limits.maxFleetPercentPerDay,
+      maxPolicyDecisionsPerDay: current.effective.limits.maxPolicyDecisionsPerDay,
+    });
+    if (!authorized.ok) {
+      await degradeToHumanRequired(intentId, authorized.reason);
+      return;
+    }
+
+    recordActionIntentEvent({
+      orgId: intent.orgId,
+      intentId: intent.id,
+      actionName: intent.actionName,
+      argumentDigest: intent.argumentDigest,
+      source: intent.source,
+      outcome: 'approved',
+      actorType: 'ai_agent',
+      initiatedBy: 'policy',
+      details: {
+        decidedVia: 'policy',
+        agentId: agent.id,
+        agentRunId: run.id,
+        policyAuthorizationKey: key,
+      },
+    });
+
+    await notifyRecipientsOfPolicyAuthorization({
+      orgId: intent.orgId,
+      partnerId,
+      recipients: current.effective.recipients,
+      agentName: agent.name,
+      intentId: intent.id,
+      targetSummary: intent.targetSummary,
+    });
+  } catch (err) {
+    if (err instanceof PolicyDecisionRaceLostError) {
+      // Someone else's attempt already won — silent no-op, not a failure.
+      return;
+    }
+    // Everything else reaching here is TRANSIENT (a DB/Redis error from any
+    // of the awaited reads/writes above): log and leave the intent
+    // `unattempted` for the outbox's at-least-once redelivery to retry.
+    // Never degrade to human_required on a transient fault — that would
+    // permanently forfeit the policy-decide path for an intent that might
+    // have authorized cleanly on the next attempt.
+    captureException(err instanceof Error ? err : new Error(String(err)));
+    console.error(`[policyDecide] attemptPolicyDecision transient failure for intent ${intentId} (left unattempted):`, err);
+  }
+}

--- a/apps/api/src/services/actionIntents/policyDecide.ts
+++ b/apps/api/src/services/actionIntents/policyDecide.ts
@@ -81,6 +81,24 @@ function canonicalPolicyKey(actionName: string, args: Record<string, unknown>): 
  *  treated as a silent no-op, never a failure. */
 class PolicyDecisionRaceLostError extends Error {}
 
+/** Review fix (#3827): the discriminated signal `attemptPolicyDecision`
+ *  throws for a TRANSIENT failure (a DB/Redis error from any of its awaited
+ *  reads/writes) — distinct from `PolicyDecisionRaceLostError` (a silent
+ *  no-op) and from every DETERMINISTIC gate above, which degrades to
+ *  `human_required` and returns normally rather than throwing. Callers use
+ *  `instanceof` to decide whether to retry: `intentReleaseWorker.ts`'s
+ *  outbox `intent_created` branch rethrows it so BullMQ redelivers the job
+ *  (real at-least-once recovery); `intentService.ts`'s post-commit
+ *  fire-and-forget trigger still swallows it — the outbox is the retry lane,
+ *  not that call site. */
+export class PolicyDecisionTransientError extends Error {
+  constructor(intentId: string, cause: unknown) {
+    super(`attemptPolicyDecision transient failure for intent ${intentId}: ${cause instanceof Error ? cause.message : String(cause)}`);
+    this.name = 'PolicyDecisionTransientError';
+    this.cause = cause;
+  }
+}
+
 type CapCheckFailure = 'fleet_cap_exceeded' | 'day_cap_exceeded';
 
 interface LoadedIntentForAttempt {
@@ -162,6 +180,7 @@ type DegradeReason =
   | 'agent_mode_not_act'
   | 'not_policy_decidable'
   | 'not_agent_authorized'
+  | 'not_run_snapshot_authorized'
   | 'kill_switch_engaged'
   | 'agent_policy_denied'
   | CapCheckFailure;
@@ -351,7 +370,11 @@ async function notifyRecipientsOfPolicyAuthorization(args: {
           type: 'ai',
           title: `${args.agentName}: authorized automatically by policy`,
           message: `${args.targetSummary} — executing`,
-          link: '/approvals',
+          // Review fix (#3827): a policy-decided intent has NO approval_requests
+          // row (that's the whole point — no human ever reviewed it), so
+          // `/approvals` is a dead end for this notification. No run-detail
+          // page exists yet to link to instead — that lands in wave 6.
+          link: null,
           metadata: { intentId: args.intentId, decidedVia: 'policy' },
           dedupeKey: `intent-policy-authorized:${args.intentId}`,
         });
@@ -371,13 +394,44 @@ async function notifyRecipientsOfPolicyAuthorization(args: {
  * the post-commit fire-and-forget trigger AND the outbox `intent_created`
  * recovery branch, without ever double-authorizing or double-fanning-out.
  *
- * Never throws: every failure this function can encounter is either a
- * DETERMINISTIC refusal (degrades the intent to `human_required` and returns)
- * or a TRANSIENT one (logs and leaves the intent `unattempted` for the
- * outbox's at-least-once redelivery to retry). See the plan header's Design
- * authority for why that distinction is load-bearing.
+ * Every failure this function can encounter is either a DETERMINISTIC
+ * refusal (degrades the intent to `human_required` and returns normally) or
+ * a TRANSIENT one — which now THROWS `PolicyDecisionTransientError` (review
+ * fix, #3827) rather than swallowing it, so the outbox `intent_created`
+ * branch (intentReleaseWorker.ts) can rethrow and let BullMQ redeliver the
+ * job for real at-least-once recovery. See the plan header's Design
+ * authority for why the deterministic/transient distinction is load-bearing.
  */
 export async function attemptPolicyDecision(intentId: string): Promise<void> {
+  // Review fix (#3827) — invariant guard: `inSystemDbContext` (above) SKIPS
+  // opening a fresh `withSystemDbAccessContext` transaction whenever the
+  // ambient context already reads `scope: 'system'`, joining the caller's
+  // transaction instead. That's correct for calls made from a clean
+  // (contextless) stack — this function's own transaction boundaries
+  // (loadIntentForAttempt, loadRunAndAgent, runAuthorizeTransaction) are then
+  // genuinely independent, which is what makes `PolicyDecisionRaceLostError`
+  // safe to roll back on its own: only ITS transaction unwinds, never a
+  // caller's. If this function were ever invoked from INSIDE an
+  // already-held DB access context (of any scope), every one of those
+  // "own transaction" boundaries would silently join the caller's instead —
+  // a caller-side rollback would then also undo this function's exposure
+  // reservation/CAS, and a caller-side commit could otherwise let a lost-CAS
+  // rollback leave an orphaned exposure reservation live past this
+  // function's return. Both current callers (intentService.ts's post-commit
+  // fire-and-forget trigger, intentReleaseWorker.ts's outbox `intent_created`
+  // branch) invoke this from a clean stack — verified unreachable today —
+  // so this is a loud, fail-fast tripwire against that invariant ever
+  // silently regressing, not a currently-reachable bug.
+  const ambientContext = getCurrentDbAccessContext();
+  if (ambientContext) {
+    const invariantErr = new Error(
+      `attemptPolicyDecision invariant violation: called with an ALREADY-HELD DB access context (scope: '${ambientContext.scope}') for intent ${intentId} — this function must always run from a clean (contextless) call stack so its own transaction boundaries stay independent of any caller's.`,
+    );
+    console.error(`[policyDecide] ${invariantErr.message}`);
+    captureException(invariantErr);
+    throw invariantErr;
+  }
+
   try {
     // Load + confirm this intent is genuinely stranded in `unattempted`
     // BEFORE checking the flag, so intentReleaseWorker.ts's `intent_created`
@@ -464,6 +518,25 @@ export async function attemptPolicyDecision(intentId: string): Promise<void> {
       return;
     }
 
+    // Review fix (#3827): decide-time snapshot check, mirroring what release
+    // already enforces (agentReleaseAuthority.ts's `candidates` loop checks
+    // BOTH `run.policySnapshot.effective` and the current effective policy —
+    // see its header comment). Checking ONLY the current policy here left a
+    // gap: an operator who adds a key to `supervisedActionKeys` MID-RUN would
+    // let policy-decide authorize an intent the run never actually started
+    // under — the run's own snapshot never opted this key in. Requiring the
+    // key in BOTH keeps decide-time and release-time symmetric: a key added
+    // after the run started degrades to human review here, exactly like a
+    // key REMOVED after decide-time gets caught by release's own snapshot
+    // check. Defensive optional-chaining on `run.policySnapshot` mirrors
+    // agentReleaseAuthority.ts's own cast — a malformed/legacy snapshot fails
+    // closed (empty array, key never found) rather than throwing.
+    const snapshotAuthorizedKeys = run.policySnapshot?.effective?.actAssets?.supervisedActionKeys ?? [];
+    if (!snapshotAuthorizedKeys.includes(key)) {
+      await degradeToHumanRequired(intentId, 'not_run_snapshot_authorized', { key });
+      return;
+    }
+
     // Kill state, warmed BEFORE the guardrail re-run so its synchronous cache
     // (checkAgentGuardrails reads getCachedAiKillStateSnapshot()) reflects
     // this read, mirroring actRevalidation.ts's / agentReleaseAuthority.ts's
@@ -539,12 +612,18 @@ export async function attemptPolicyDecision(intentId: string): Promise<void> {
       return;
     }
     // Everything else reaching here is TRANSIENT (a DB/Redis error from any
-    // of the awaited reads/writes above): log and leave the intent
-    // `unattempted` for the outbox's at-least-once redelivery to retry.
-    // Never degrade to human_required on a transient fault — that would
-    // permanently forfeit the policy-decide path for an intent that might
-    // have authorized cleanly on the next attempt.
+    // of the awaited reads/writes above): the intent is left `unattempted`
+    // (nothing here writes it any other state) — never degrade to
+    // human_required on a transient fault, that would permanently forfeit
+    // the policy-decide path for an intent that might have authorized
+    // cleanly on the next attempt. Review fix (#3827): THROW the
+    // discriminated signal instead of swallowing it — the outbox
+    // `intent_created` branch (intentReleaseWorker.ts) is what turns this
+    // into REAL at-least-once recovery by rethrowing it for BullMQ to
+    // redeliver; a caller that doesn't care (intentService.ts's post-commit
+    // fire-and-forget trigger) still swallows it on its own end.
     captureException(err instanceof Error ? err : new Error(String(err)));
     console.error(`[policyDecide] attemptPolicyDecision transient failure for intent ${intentId} (left unattempted):`, err);
+    throw new PolicyDecisionTransientError(intentId, err);
   }
 }

--- a/apps/api/src/services/actionIntents/policyDecide.ts
+++ b/apps/api/src/services/actionIntents/policyDecide.ts
@@ -159,6 +159,7 @@ type DegradeReason =
   | 'policy_intent_expired'
   | 'agent_run_invalid'
   | 'agent_identity_changed'
+  | 'agent_mode_not_act'
   | 'not_policy_decidable'
   | 'not_agent_authorized'
   | 'kill_switch_engaged'
@@ -378,6 +379,20 @@ async function notifyRecipientsOfPolicyAuthorization(args: {
  */
 export async function attemptPolicyDecision(intentId: string): Promise<void> {
   try {
+    // Load + confirm this intent is genuinely stranded in `unattempted`
+    // BEFORE checking the flag, so intentReleaseWorker.ts's `intent_created`
+    // handler can call this function unconditionally (not flag-gated at the
+    // call site — see its header comment for why: gating there strands
+    // every `unattempted` intent forever if the flag is later flipped off,
+    // since this is the only durable caller). An already-decided or
+    // human-authored intent's `intent_created` delivery stays a true no-op
+    // regardless of the flag.
+    const loadedIntent = await loadIntentForAttempt(intentId);
+    if (!loadedIntent) return; // gone — nothing to attempt
+    const { intent } = loadedIntent;
+
+    if (intent.policyDecisionState !== 'unattempted') return; // already resolved by another caller
+
     if (!policyDecideEnabled()) {
       // The flag is one of the eight independent gates: an attempt that
       // somehow reaches this function after the flag flipped off mid-flight
@@ -386,11 +401,6 @@ export async function attemptPolicyDecision(intentId: string): Promise<void> {
       return;
     }
 
-    const loadedIntent = await loadIntentForAttempt(intentId);
-    if (!loadedIntent) return; // gone — nothing to attempt
-    const { intent } = loadedIntent;
-
-    if (intent.policyDecisionState !== 'unattempted') return; // already resolved by another caller
     if (intent.status !== 'pending_approval') return; // moved on some other way (e.g. manually cancelled)
     if (!intent.requestingAgentRunId) return; // structurally impossible; defensive no-op
 
@@ -428,6 +438,23 @@ export async function attemptPolicyDecision(intentId: string): Promise<void> {
     const current = await resolveEffectiveAgentSystem(intent.orgId, agent.kind);
     if (!current || current.agentId !== run.agentId) {
       await degradeToHumanRequired(intentId, 'agent_identity_changed');
+      return;
+    }
+
+    // LOCKED quorum decision: policy-decide requires mode === 'act'. This is
+    // the primary enforcement point — the live guardrail re-run below is NOT
+    // a substitute: checkAgentGuardrails only returns `disposition: 'deny'`
+    // for mode 'off' or `enabled: false`; a mutating call under mode
+    // 'shadow' returns `disposition: 'propose'`; and nothing gates
+    // `supervisedActionKeys` on mode either. Without this check an operator
+    // who configures act + keys, then flips the agent to shadow as a brake,
+    // would keep having policy-decide silently authorize on the stored keys.
+    // Checked against the CURRENT live policy (not the run's start-of-run
+    // snapshot) because the policy can change between intent creation and
+    // this attempt — kept even after Task 5's `resolvePolicyDecisionState`
+    // adds its own creation-time mode check, as defense in depth.
+    if (current.effective.mode !== 'act') {
+      await degradeToHumanRequired(intentId, 'agent_mode_not_act', { mode: current.effective.mode });
       return;
     }
 

--- a/apps/api/src/services/actionIntents/revalidateRelease.test.ts
+++ b/apps/api/src/services/actionIntents/revalidateRelease.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { canonicalizeArguments, computeArgumentDigest } from '@breeze/shared/canonicalize';
 
 vi.mock('../aiTools', () => ({ getToolTier: vi.fn(() => 3) }));
@@ -13,10 +13,26 @@ vi.mock('./actorContext', () => ({
     user: { id: 'user-1' }, principal: { kind: 'user_session' },
   })),
 }));
+// Wave 5 Part B (#3827): mocked wholesale, same treatment as
+// checkAgentReleaseAuthority above — `policyDecidable.ts`'s real
+// `validateAuthorizationKeys` transitively imports the FULL `../aiGuardrails`
+// / `../aiTools` module surface (BLOCKED_TOOLS, TIER*_ACTIONS,
+// requiresLiveSession, …), which this file's narrow per-collaborator mocks
+// above don't provide. Its own classification behavior is unit-tested where
+// it lives, policyDecidable.test.ts; this file only needs to prove
+// `revalidateApprovedIntentForRelease` CONSULTS it and reacts to ok/rejected.
+vi.mock('./policyDecidable', () => ({
+  validateAuthorizationKeys: vi.fn((keys: string[]) => ({ ok: keys, rejected: [] })),
+}));
+vi.mock('../../config/env', () => ({
+  policyDecideEnabled: vi.fn(() => true),
+}));
 
 import { revalidateApprovedIntentForRelease } from './revalidateRelease';
 import { checkToolPermission } from '../aiGuardrails';
 import { checkAgentReleaseAuthority } from './agentReleaseAuthority';
+import { validateAuthorizationKeys } from './policyDecidable';
+import { policyDecideEnabled } from '../../config/env';
 
 /** Minimal ActionIntent shape the function actually reads. */
 function intentFixture(overrides: Record<string, unknown> = {}) {
@@ -35,6 +51,7 @@ function intentFixture(overrides: Record<string, unknown> = {}) {
 }
 
 beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.unstubAllEnvs());
 
 describe('revalidateApprovedIntentForRelease digest recompute', () => {
   it('refuses with digest_mismatch when arguments do not hash to argumentDigest', async () => {
@@ -147,6 +164,119 @@ describe('revalidateApprovedIntentForRelease agent branch (wave 3b)', () => {
 
     expect(result.ok).toBe(true);
     expect(checkToolPermission).toHaveBeenCalledTimes(1);
+    expect(checkAgentReleaseAuthority).not.toHaveBeenCalled();
+  });
+});
+
+describe('revalidateApprovedIntentForRelease policy-evidence branch (wave 5b, #3827)', () => {
+  const args = { deviceId: 'dev-1', action: 'disable', itemId: 'startup-1' };
+  const digest = computeArgumentDigest(canonicalizeArguments(args));
+  const POLICY_KEY = 'manage_startup_items:disable';
+
+  const policyIntent = (overrides: Record<string, unknown> = {}) => intentFixture({
+    requestedByUserId: null,
+    requestingAgentRunId: 'run-1',
+    originPrincipalKind: 'ai_agent',
+    originPrincipalId: 'agent-1',
+    source: 'ai_agent',
+    actionName: 'manage_startup_items',
+    arguments: args,
+    argumentDigest: digest,
+    decidedVia: 'policy',
+    policyDecisionState: 'authorized',
+    policyAuthorizationKey: POLICY_KEY,
+    policySnapshotDigest: 'd'.repeat(64),
+    policyClassificationVersion: 1,
+    policyReservationId: 'reservation-1',
+    policyKillEpoch: 0,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.mocked(policyDecideEnabled).mockReturnValue(true);
+    vi.mocked(validateAuthorizationKeys).mockImplementation((keys: string[]) => ({ ok: keys, rejected: [] }));
+  });
+
+  it('routes a policy-decided intent (no winning approval row) to checkAgentReleaseAuthority instead of digest_mismatch', async () => {
+    const result = await revalidateApprovedIntentForRelease(policyIntent(), null);
+
+    expect(result.ok).toBe(true);
+    expect(checkAgentReleaseAuthority).toHaveBeenCalledTimes(1);
+  });
+
+  it('NEVER reads approval_requests state for the policy path — winningApproval stays null throughout', async () => {
+    // The caller (intentReleaseWorker.ts) is what would query approval_requests;
+    // this asserts the revalidation function itself takes no approval-row
+    // shortcut for a policy-decided intent — it must not require, or
+    // synthesize, one.
+    const result = await revalidateApprovedIntentForRelease(policyIntent(), null);
+    expect(result.ok).toBe(true);
+  });
+
+  it('a human-approved agent intent (decidedVia !== policy) with NO approval row still fails digest_mismatch — the branch is not accidentally widened', async () => {
+    const result = await revalidateApprovedIntentForRelease(
+      policyIntent({ decidedVia: null, policyDecisionState: 'human_required' }),
+      null,
+    );
+    expect(result).toEqual({ ok: false, errorCode: 'digest_mismatch' });
+    expect(checkAgentReleaseAuthority).not.toHaveBeenCalled();
+  });
+
+  it('a policy_decision_state that is not yet authorized (e.g. unattempted) with no approval row still fails digest_mismatch', async () => {
+    const result = await revalidateApprovedIntentForRelease(
+      policyIntent({ policyDecisionState: 'unattempted' }),
+      null,
+    );
+    expect(result).toEqual({ ok: false, errorCode: 'digest_mismatch' });
+  });
+
+  it('a policy-decided intent WITH a winning approval row present takes the ordinary human path (defense-in-depth: never both)', async () => {
+    const result = await revalidateApprovedIntentForRelease(policyIntent(), { boundArgumentDigest: digest });
+    expect(result.ok).toBe(true);
+    // isPolicyDecided is false whenever winningApproval is non-null, so the
+    // (a) human check ran on it — proven by checkAgentReleaseAuthority still
+    // being reached via the agent branch below it (requestingAgentRunId is
+    // set), same call either way; the load-bearing assertion is the digest
+    // path above did not throw digest_mismatch.
+    expect(checkAgentReleaseAuthority).toHaveBeenCalledTimes(1);
+  });
+
+  describe('provenance completeness', () => {
+    it.each([
+      ['policyAuthorizationKey', { policyAuthorizationKey: null }],
+      ['policySnapshotDigest', { policySnapshotDigest: null }],
+      ['policyClassificationVersion', { policyClassificationVersion: null }],
+      ['policyReservationId', { policyReservationId: null }],
+      ['policyKillEpoch', { policyKillEpoch: null }],
+    ])('fails policy_authorization_revoked when %s is missing', async (_name, overrides) => {
+      const result = await revalidateApprovedIntentForRelease(policyIntent(overrides), null);
+      expect(result).toMatchObject({ ok: false, errorCode: 'policy_authorization_revoked' });
+      expect(checkAgentReleaseAuthority).not.toHaveBeenCalled();
+    });
+  });
+
+  it('fails policy_authorization_revoked when the flag has since been turned off', async () => {
+    vi.mocked(policyDecideEnabled).mockReturnValue(false);
+
+    const result = await revalidateApprovedIntentForRelease(policyIntent(), null);
+
+    expect(result).toMatchObject({ ok: false, errorCode: 'policy_authorization_revoked' });
+    expect(checkAgentReleaseAuthority).not.toHaveBeenCalled();
+  });
+
+  it('fails policy_authorization_revoked, terminal, when the registry no longer has the key', async () => {
+    vi.mocked(validateAuthorizationKeys).mockReturnValue({
+      ok: [],
+      rejected: [{ key: POLICY_KEY, reason: 'not registered in POLICY_DECIDABLE_TIER3' }],
+    });
+
+    const result = await revalidateApprovedIntentForRelease(policyIntent(), null);
+
+    expect(result).toMatchObject({
+      ok: false,
+      errorCode: 'policy_authorization_revoked',
+      details: { key: POLICY_KEY },
+    });
     expect(checkAgentReleaseAuthority).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/actionIntents/revalidateRelease.test.ts
+++ b/apps/api/src/services/actionIntents/revalidateRelease.test.ts
@@ -253,6 +253,24 @@ describe('revalidateApprovedIntentForRelease policy-evidence branch (wave 5b, #3
       expect(result).toMatchObject({ ok: false, errorCode: 'policy_authorization_revoked' });
       expect(checkAgentReleaseAuthority).not.toHaveBeenCalled();
     });
+
+    // Review fix: `requestingAgentRunId` must be REQUIRED by `isPolicyDecided`,
+    // not merely a side-effect of a real policy decision always setting it.
+    // Without the fix, a row with the three policy-shaped columns set but no
+    // run would skip BOTH the (a) human approval-row gate AND the entire
+    // evidence/authority branch (both live inside
+    // `if (intent.requestingAgentRunId)`), falling all the way through to
+    // plain user RBAC on no approval row and no policy evidence at all —
+    // exactly the tamper shape (a2)'s defense-in-depth exists to catch.
+    it('fails digest_mismatch — NOT the policy-decided branch — when requestingAgentRunId is null despite policy-shaped columns', async () => {
+      const result = await revalidateApprovedIntentForRelease(
+        policyIntent({ requestingAgentRunId: null, originPrincipalKind: 'user_session' }),
+        null,
+      );
+      expect(result).toEqual({ ok: false, errorCode: 'digest_mismatch' });
+      expect(checkAgentReleaseAuthority).not.toHaveBeenCalled();
+      expect(checkToolPermission).not.toHaveBeenCalled();
+    });
   });
 
   it('fails policy_authorization_revoked when the flag has since been turned off', async () => {

--- a/apps/api/src/services/actionIntents/revalidateRelease.ts
+++ b/apps/api/src/services/actionIntents/revalidateRelease.ts
@@ -3,6 +3,8 @@ import type { AuthContext } from '../../middleware/auth';
 import { getToolTier } from '../aiTools';
 import { checkToolPermission } from '../aiGuardrails';
 import { getActiveOrgTenant } from '../tenantStatus';
+import { policyDecideEnabled } from '../../config/env';
+import { validateAuthorizationKeys } from './policyDecidable';
 import { buildAuthContextForIntent } from './actorContext';
 import { checkAgentReleaseAuthority } from './agentReleaseAuthority';
 import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
@@ -38,15 +40,101 @@ export type IntentReleaseRevalidation =
   | { ok: true; auth: AuthContext }
   | { ok: false; errorCode: string; details?: Record<string, unknown> };
 
+/**
+ * Wave 5 Part B (#3827) — the policy-evidence checks specific to a
+ * `decidedVia: 'policy'` intent, run BEFORE the (DB-backed)
+ * `checkAgentReleaseAuthority` call so a cheap, purely-local failure never
+ * pays for the extra round trips. NEVER touches `approval_requests` — a
+ * policy-decided intent has no approval row BY DESIGN (the whole point of
+ * policy-decide is skipping human fanout), and nothing in this module or
+ * `policyDecide.ts` ever inserts one; see the plan header's "NEVER synthesize
+ * a human approval row" constraint.
+ *
+ * All three failure kinds share `policy_authorization_revoked` —
+ * `checkAgentReleaseAuthority`'s own stricter predicate (agentReleaseAuthority.ts)
+ * uses the SAME errorCode for its supervisedActionKeys/mode re-check, so
+ * every "the authorization behind this decision no longer holds" failure
+ * reads as one thing to an operator scanning `error_code`, not four
+ * near-synonyms.
+ */
+function checkPolicyDecisionEvidence(
+  intent: ActionIntent,
+): { ok: true } | { ok: false; errorCode: string; details?: Record<string, unknown> } {
+  // Provenance present: the five columns `runAuthorizeTransaction` stamps
+  // together, atomically, at decision time (policyDecide.ts). Missing any
+  // one is a data-integrity anomaly this branch should never legitimately
+  // reach — fail closed rather than trust a partial record.
+  if (
+    !intent.policyAuthorizationKey
+    || !intent.policySnapshotDigest
+    || intent.policyClassificationVersion === null
+    || !intent.policyReservationId
+    || intent.policyKillEpoch === null
+    || intent.policyKillEpoch === undefined
+  ) {
+    return {
+      ok: false,
+      errorCode: 'policy_authorization_revoked',
+      details: { reason: 'policy decision provenance is incomplete' },
+    };
+  }
+
+  // The mechanism itself must still be live — an operator emergency-flipping
+  // BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED off must stop an already-
+  // authorized-but-not-yet-released intent from executing unattended, same
+  // as it stops a new one from ever being attempted (policyDecide.ts).
+  if (!policyDecideEnabled()) {
+    return {
+      ok: false,
+      errorCode: 'policy_authorization_revoked',
+      details: { reason: 'policy-decide is disabled' },
+    };
+  }
+
+  // The registry entry that authorized this key must still exist AND still
+  // be headlessCompatible/non-four_eyes/non-secret — `validateAuthorizationKeys`
+  // is the SAME defense-in-depth re-classification `attemptPolicyDecision`
+  // ran at decision time (policyDecidable.ts), re-run here against whatever
+  // POLICY_DECIDABLE_TIER3 looks like NOW. A registry drop between decision
+  // and release is exactly what this catches.
+  const registryCheck = validateAuthorizationKeys([intent.policyAuthorizationKey]);
+  if (registryCheck.ok.length === 0) {
+    return {
+      ok: false,
+      errorCode: 'policy_authorization_revoked',
+      details: {
+        key: intent.policyAuthorizationKey,
+        reason: registryCheck.rejected[0]?.reason ?? 'no longer registered in POLICY_DECIDABLE_TIER3',
+      },
+    };
+  }
+
+  return { ok: true };
+}
+
 export async function revalidateApprovedIntentForRelease(
   intent: ActionIntent,
   winningApproval: { boundArgumentDigest: string | null } | null,
 ): Promise<IntentReleaseRevalidation> {
-  // (a) The winning approval row must still exist and must have approved the
-  // SAME content the intent currently carries (action_intents content is
-  // DB-immutable; this is defense-in-depth).
-  if (!winningApproval || winningApproval.boundArgumentDigest !== intent.argumentDigest) {
-    return { ok: false, errorCode: 'digest_mismatch' };
+  // Wave 5 Part B (#3827): a policy-decided intent has NO approval_requests
+  // row by construction — `runAuthorizeTransaction` (policyDecide.ts) CASes
+  // straight to `approved` and NEVER inserts one, so `winningApproval` being
+  // null here is the EXPECTED shape for one of these, not a release-time
+  // integrity failure. Detected off the intent's own columns, immutable
+  // once Part B's decision path writes them (never re-derived, never a
+  // synthetic stand-in for a human decision).
+  const isPolicyDecided = !winningApproval
+    && intent.decidedVia === 'policy'
+    && intent.policyDecisionState === 'authorized';
+
+  if (!isPolicyDecided) {
+    // (a) UNCHANGED — the human-approval-row path, byte-identical to every
+    // release before this wave. The winning approval row must still exist
+    // and must have approved the SAME content the intent currently carries
+    // (action_intents content is DB-immutable; this is defense-in-depth).
+    if (!winningApproval || winningApproval.boundArgumentDigest !== intent.argumentDigest) {
+      return { ok: false, errorCode: 'digest_mismatch' };
+    }
   }
   // (a2) Recompute the digest FROM the stored arguments. The comparison above
   // is two stored strings; it cannot detect a write that changed `arguments`
@@ -94,6 +182,18 @@ export async function revalidateApprovedIntentForRelease(
   // combination of the run's immutable policy_snapshot and the agent's
   // CURRENT effective policy (agentReleaseAuthority.ts).
   if (intent.requestingAgentRunId) {
+    // Wave 5 Part B (#3827): policy-decision evidence FIRST — purely local
+    // (env read + a frozen-array lookup, no I/O), so a stale/revoked
+    // registry entry or a flag flip fails fast without paying for
+    // `checkAgentReleaseAuthority`'s several round trips. A HUMAN-approved
+    // agent intent (decidedVia !== 'policy') skips this entirely and reaches
+    // `checkAgentReleaseAuthority` exactly as it always has.
+    if (isPolicyDecided) {
+      const evidence = checkPolicyDecisionEvidence(intent);
+      if (!evidence.ok) {
+        return evidence;
+      }
+    }
     const authority = await checkAgentReleaseAuthority(intent);
     if (!authority.ok) {
       return authority;

--- a/apps/api/src/services/actionIntents/revalidateRelease.ts
+++ b/apps/api/src/services/actionIntents/revalidateRelease.ts
@@ -123,7 +123,19 @@ export async function revalidateApprovedIntentForRelease(
   // integrity failure. Detected off the intent's own columns, immutable
   // once Part B's decision path writes them (never re-derived, never a
   // synthetic stand-in for a human decision).
+  //
+  // Review fix: `requestingAgentRunId` MUST be part of this predicate.
+  // Policy-decide only ever authorizes agent-originated proposals
+  // (attemptPolicyDecision requires a run), so a row with these three
+  // columns set but no run is exactly the tamper shape defense-in-depth (a2)
+  // above exists to catch (superuser write, disabled immutability trigger,
+  // restore) — without this clause such a row would have BOTH the
+  // approval-row gate below (a) AND the entire evidence/authority branch at
+  // (e) skipped, since both of those only run inside
+  // `if (intent.requestingAgentRunId)`, and fall through to plain user RBAC
+  // with no approval row and no policy evidence at all.
   const isPolicyDecided = !winningApproval
+    && !!intent.requestingAgentRunId
     && intent.decidedVia === 'policy'
     && intent.policyDecisionState === 'authorized';
 

--- a/apps/api/src/services/aiAgents/actRevalidation.test.ts
+++ b/apps/api/src/services/aiAgents/actRevalidation.test.ts
@@ -19,6 +19,10 @@ const dbMockState = vi.hoisted(() => ({
   // describe block below.
   organizationRows: [] as unknown[],
   exposureDeviceRows: [] as unknown[],
+  // Review fixes (#3827 Task 4): fault-injection flags for the "reserve call
+  // is best-effort on flag-off, fail-closed on flag-on" contract.
+  exposureReadShouldThrow: false,
+  insertExposureShouldThrow: false,
   insertedExposureRows: [] as Record<string, unknown>[],
   advisoryLockCalls: 0,
   ambientContext: undefined as { scope: string } | undefined,
@@ -46,7 +50,10 @@ vi.mock('../../db', () => ({
           // (it reads every exposed device row in the trailing window) — the
           // `where(...)` result itself must be awaitable.
           then: (resolve: (value: unknown[]) => void) => {
-            if (tableName === 'ai_unattended_exposure') return resolve(dbMockState.exposureDeviceRows);
+            if (tableName === 'ai_unattended_exposure') {
+              if (dbMockState.exposureReadShouldThrow) throw new Error('ai_unattended_exposure read failed (test)');
+              return resolve(dbMockState.exposureDeviceRows);
+            }
             throw new Error(`Unexpected table (awaited without limit): ${tableName}`);
           },
         };
@@ -58,6 +65,7 @@ vi.mock('../../db', () => ({
       return {
         values: vi.fn(async (values: Record<string, unknown>) => {
           if (tableName === 'ai_unattended_exposure') {
+            if (dbMockState.insertExposureShouldThrow) throw new Error('ai_unattended_exposure insert failed (test)');
             dbMockState.insertedExposureRows.push(values);
             return [];
           }
@@ -188,6 +196,8 @@ beforeEach(() => {
   dbMockState.killStateShouldThrow = false;
   dbMockState.organizationRows = [{ partnerId: PARTNER_ID }];
   dbMockState.exposureDeviceRows = [];
+  dbMockState.exposureReadShouldThrow = false;
+  dbMockState.insertExposureShouldThrow = false;
   dbMockState.insertedExposureRows = [];
   dbMockState.advisoryLockCalls = 0;
   dbMockState.ambientContext = undefined;
@@ -733,5 +743,32 @@ describe('revalidateActExecution — step 5.5: unattended-exposure ledger accoun
     expect(result).toEqual({ ok: false, downgrade: 'propose' });
     expect(dbMockState.advisoryLockCalls).toBe(0);
     expect(dbMockState.insertedExposureRows).toEqual([]);
+  });
+
+  it('review fix: flag off + ledger insert throws → accounting failure is best-effort, the act call still executes and reserves its slot', async () => {
+    dbMockState.insertExposureShouldThrow = true;
+    const reserved = reservation(0);
+    const result = await revalidateActExecution({
+      run: runArgs(), op: restartOp, toolName: 'manage_services',
+      input: { deviceId: DEVICE_ID, action: 'restart', serviceName: 'Spooler' },
+      reserved,
+    });
+    expect(result.ok).toBe(true);
+    expect(reserved.count).toBe(1);
+    expect(dbMockState.insertedExposureRows).toEqual([]);
+  });
+
+  it('review fix: flag on + fleet-cap read throws → fails CLOSED (downgrades to a proposal), writes no row, and never grants capacity', async () => {
+    vi.stubEnv('BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED', 'true');
+    dbMockState.exposureReadShouldThrow = true;
+    const reserved = reservation(0);
+    const result = await revalidateActExecution({
+      run: runArgs(), op: restartOp, toolName: 'manage_services',
+      input: { deviceId: DEVICE_ID, action: 'restart', serviceName: 'Spooler' },
+      reserved,
+    });
+    expect(result).toEqual({ ok: false, downgrade: 'propose' });
+    expect(dbMockState.insertedExposureRows).toEqual([]);
+    expect(reserved.count).toBe(0);
   });
 });

--- a/apps/api/src/services/aiAgents/actRevalidation.test.ts
+++ b/apps/api/src/services/aiAgents/actRevalidation.test.ts
@@ -13,6 +13,14 @@ const dbMockState = vi.hoisted(() => ({
   // describe block below.
   killStateRows: [{ killed: false, epoch: 0 }] as unknown[],
   killStateShouldThrow: false,
+  // Wave 5B Task 4 (#3827): `organizations` (partnerId lookup) and
+  // `ai_unattended_exposure` (fleet-percent cap read) table branches for
+  // `reserveActUnattendedExposure` — see the "exposure ledger accounting"
+  // describe block below.
+  organizationRows: [] as unknown[],
+  exposureDeviceRows: [] as unknown[],
+  insertedExposureRows: [] as Record<string, unknown>[],
+  advisoryLockCalls: 0,
   ambientContext: undefined as { scope: string } | undefined,
 }));
 
@@ -31,12 +39,36 @@ vi.mock('../../db', () => ({
               if (dbMockState.killStateShouldThrow) throw new Error('ai_kill_state read failed (test)');
               return dbMockState.killStateRows;
             }
-            throw new Error(`Unexpected table: ${tableName}`);
+            if (tableName === 'organizations') return dbMockState.organizationRows;
+            throw new Error(`Unexpected table (with limit): ${tableName}`);
           }),
+          // `ai_unattended_exposure`'s fleet-check select has no `.limit()`
+          // (it reads every exposed device row in the trailing window) — the
+          // `where(...)` result itself must be awaitable.
+          then: (resolve: (value: unknown[]) => void) => {
+            if (tableName === 'ai_unattended_exposure') return resolve(dbMockState.exposureDeviceRows);
+            throw new Error(`Unexpected table (awaited without limit): ${tableName}`);
+          },
         };
         return builder;
       }),
     })),
+    insert: vi.fn((table: unknown) => {
+      const tableName = String((table as Record<symbol, unknown>)[Symbol.for('drizzle:Name')]);
+      return {
+        values: vi.fn(async (values: Record<string, unknown>) => {
+          if (tableName === 'ai_unattended_exposure') {
+            dbMockState.insertedExposureRows.push(values);
+            return [];
+          }
+          throw new Error(`Unexpected insert table: ${tableName}`);
+        }),
+      };
+    }),
+    execute: vi.fn(async () => {
+      dbMockState.advisoryLockCalls += 1;
+      return { rows: [] };
+    }),
   },
   getCurrentDbAccessContext: vi.fn(() => dbMockState.ambientContext),
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
@@ -61,6 +93,12 @@ const computeEffectDigestForRelease = vi.hoisted(() =>
   >>());
 vi.mock('../actionIntents/effectDigest', () => ({ computeEffectDigestForRelease }));
 
+// `countContractDevices` mocked at the module boundary (like effectivePolicy/
+// effectDigest above) rather than growing the hand-rolled `../../db` mock to
+// cover the `devices` table's own aggregate-count query shape.
+const countContractDevices = vi.hoisted(() => vi.fn<(orgId: string, siteId: string | null) => Promise<number>>());
+vi.mock('../contractQuantities', () => ({ countContractDevices }));
+
 import { ACT_MANIFEST } from './actManifest';
 import { ACT_DISK_CLEANUP_MAX_BYTES_V1, revalidateActExecution, type ActReservationState } from './actRevalidation';
 // Real (unmocked) module — `revalidateActExecution` imports it for real, and
@@ -77,6 +115,7 @@ const SITE_ID = '00000000-0000-4000-8000-0000000000f4';
 const RUN_ID = '00000000-0000-4000-8000-0000000000f5';
 const SCRIPT_ID = '00000000-0000-4000-8000-0000000000f6';
 const PLAYBOOK_ID = '00000000-0000-4000-8000-0000000000f7';
+const PARTNER_ID = '00000000-0000-4000-8000-0000000000f8';
 
 const restartOp = ACT_MANIFEST.find((op) => op.key === 'manage_services.restart')!;
 const diskCleanupOp = ACT_MANIFEST.find((op) => op.key === 'disk_cleanup.execute')!;
@@ -138,10 +177,19 @@ function reservation(count = 0): ActReservationState {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.stubEnv('BREEZE_AI_AGENTS_ENABLED', 'true');
+  // Default OFF — matches production default (dark-ship) and keeps every
+  // pre-existing test in this file exercising wave-4 behavior (no fleet-cap
+  // enforcement) unless a test in the "exposure ledger accounting" block
+  // below explicitly stubs it on.
+  vi.stubEnv('BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED', 'false');
   dbMockState.cleanupRunRows = [];
   dbMockState.playbookRows = [];
   dbMockState.killStateRows = [{ killed: false, epoch: 0 }];
   dbMockState.killStateShouldThrow = false;
+  dbMockState.organizationRows = [{ partnerId: PARTNER_ID }];
+  dbMockState.exposureDeviceRows = [];
+  dbMockState.insertedExposureRows = [];
+  dbMockState.advisoryLockCalls = 0;
   dbMockState.ambientContext = undefined;
   // A prior test's kill state must never leak into the next one via the 5s
   // in-process TTL cache — `readAiKillState` is a real module-level
@@ -149,6 +197,11 @@ beforeEach(() => {
   _resetAiKillStateCacheForTest();
   resolveEffectiveAgentSystem.mockReset().mockResolvedValue(liveSnapshot(basePolicy()));
   computeEffectDigestForRelease.mockReset();
+  // Large enough that the default AI_AGENT_LIMIT_DEFAULTS.maxFleetPercentPerDay
+  // (5%) never exhausts in a pre-existing test even when a test opts the
+  // flag on without overriding this — see the ledger describe block for
+  // deliberately small values.
+  countContractDevices.mockReset().mockResolvedValue(1000);
 });
 
 afterEach(() => {
@@ -514,7 +567,7 @@ describe('revalidateActExecution — step 4: execute_playbook asset pin', () => 
 });
 
 describe('revalidateActExecution — step 4: manage_services.restart needs no extra pin', () => {
-  it('restart: no ASSET-PIN DB read (the only select is the wave-5A kill-state refresh, step 2)', async () => {
+  it('restart: no ASSET-PIN DB read (the only selects are the wave-5A kill-state refresh, step 2, and the wave-5B exposure-ledger org lookup, step 5.5)', async () => {
     const { db } = await import('../../db');
     const result = await revalidateActExecution({
       run: runArgs(), op: restartOp, toolName: 'manage_services',
@@ -525,10 +578,12 @@ describe('revalidateActExecution — step 4: manage_services.restart needs no ex
       ok: true,
       pin: { op: restartOp, target: { kind: 'service', serviceName: 'Spooler' } },
     });
-    // Exactly one — the kill-state read (#3827 Task 2). A 'service' target
-    // needs no asset pin (see pinAsset's 'service' branch), so a second
-    // select here would mean step 4 regressed into doing I/O it doesn't need.
-    expect(db.select).toHaveBeenCalledTimes(1);
+    // Exactly two — the kill-state read (#3827 Task 2) and the exposure-
+    // ledger org/partner lookup (#3827 Task 4, unconditional regardless of
+    // the flag). A 'service' target needs no asset pin (see pinAsset's
+    // 'service' branch), so a third select here would mean step 4
+    // regressed into doing I/O it doesn't need.
+    expect(db.select).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -580,5 +635,103 @@ describe('revalidateActExecution — step 5: maxActionsPerRun reservation', () =
     });
     expect(result.ok).toBe(true);
     expect(reserved.count).toBe(5);
+  });
+});
+
+describe('revalidateActExecution — step 5.5: unattended-exposure ledger accounting (#3827 Task 4)', () => {
+  it('flag off: still writes the exposure row (accounting is truth, flag-independent)', async () => {
+    const reserved = reservation(0);
+    const result = await revalidateActExecution({
+      run: runArgs(), op: restartOp, toolName: 'manage_services',
+      input: { deviceId: DEVICE_ID, action: 'restart', serviceName: 'Spooler' },
+      reserved,
+    });
+    expect(result.ok).toBe(true);
+    expect(dbMockState.insertedExposureRows).toEqual([
+      {
+        orgId: ORG_ID,
+        partnerId: PARTNER_ID,
+        agentId: AGENT_ID,
+        runId: RUN_ID,
+        deviceId: DEVICE_ID,
+        intentId: null,
+        source: 'act',
+      },
+    ]);
+  });
+
+  it('flag off: no fleet-percent cap enforced — a scenario that WOULD exceed it still succeeds, and no advisory lock is taken', async () => {
+    countContractDevices.mockResolvedValue(1); // allowance = floor(1 * 5 / 100) = 0
+    dbMockState.exposureDeviceRows = [{ deviceId: 'already-exposed-device' }];
+    const reserved = reservation(0);
+    const result = await revalidateActExecution({
+      run: runArgs(), op: restartOp, toolName: 'manage_services',
+      input: { deviceId: DEVICE_ID, action: 'restart', serviceName: 'Spooler' },
+      reserved,
+    });
+    expect(result.ok).toBe(true);
+    expect(dbMockState.advisoryLockCalls).toBe(0);
+    expect(dbMockState.insertedExposureRows.length).toBe(1);
+  });
+
+  it('flag on: an exhausted fleet-percent cap downgrades to a proposal, writes no row, and does not consume a maxActionsPerRun slot', async () => {
+    vi.stubEnv('BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED', 'true');
+    countContractDevices.mockResolvedValue(10); // allowance = floor(10 * 5 / 100) = 0
+    const reserved = reservation(0);
+    const result = await revalidateActExecution({
+      run: runArgs(), op: restartOp, toolName: 'manage_services',
+      input: { deviceId: DEVICE_ID, action: 'restart', serviceName: 'Spooler' },
+      reserved,
+    });
+    expect(result).toEqual({ ok: false, downgrade: 'propose' });
+    expect(dbMockState.advisoryLockCalls).toBe(1);
+    expect(dbMockState.insertedExposureRows).toEqual([]);
+    expect(reserved.count).toBe(0);
+  });
+
+  it('flag on: within the fleet-percent cap → the exposure row is written and the call executes', async () => {
+    vi.stubEnv('BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED', 'true');
+    countContractDevices.mockResolvedValue(100); // allowance = floor(100 * 5 / 100) = 5
+    const reserved = reservation(0);
+    const result = await revalidateActExecution({
+      run: runArgs(), op: restartOp, toolName: 'manage_services',
+      input: { deviceId: DEVICE_ID, action: 'restart', serviceName: 'Spooler' },
+      reserved,
+    });
+    expect(result.ok).toBe(true);
+    expect(dbMockState.advisoryLockCalls).toBe(1);
+    expect(dbMockState.insertedExposureRows.length).toBe(1);
+    expect(reserved.count).toBe(1);
+  });
+
+  it('flag on: a device already exposed in the trailing 24h does not double-count against the fleet cap', async () => {
+    vi.stubEnv('BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED', 'true');
+    countContractDevices.mockResolvedValue(20); // allowance = floor(20 * 5 / 100) = 1
+    // This run's OWN device is already in the exposed set — re-exposing it
+    // must not push the projected count to 2 and exhaust a 1-device
+    // allowance.
+    dbMockState.exposureDeviceRows = [{ deviceId: DEVICE_ID }];
+    const result = await revalidateActExecution({
+      run: runArgs(), op: restartOp, toolName: 'manage_services',
+      input: { deviceId: DEVICE_ID, action: 'restart', serviceName: 'Spooler' },
+      reserved: reservation(0),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('an exhausted maxActionsPerRun cap is checked first — the cheap in-memory check never reaches the DB-backed fleet check', async () => {
+    vi.stubEnv('BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED', 'true');
+    resolveEffectiveAgentSystem.mockResolvedValue(liveSnapshot(basePolicy({
+      limits: { ...AI_AGENT_LIMIT_DEFAULTS, maxActionsPerRun: 1 },
+    })));
+    const reserved = reservation(1); // already at the cap
+    const result = await revalidateActExecution({
+      run: runArgs(), op: restartOp, toolName: 'manage_services',
+      input: { deviceId: DEVICE_ID, action: 'restart', serviceName: 'Spooler' },
+      reserved,
+    });
+    expect(result).toEqual({ ok: false, downgrade: 'propose' });
+    expect(dbMockState.advisoryLockCalls).toBe(0);
+    expect(dbMockState.insertedExposureRows).toEqual([]);
   });
 });

--- a/apps/api/src/services/aiAgents/actRevalidation.ts
+++ b/apps/api/src/services/aiAgents/actRevalidation.ts
@@ -495,10 +495,31 @@ export async function revalidateActExecution(
   // cap the policy-decide lane also reads. Exhaustion downgrades to a
   // proposal exactly like an exhausted maxActionsPerRun slot — mode is
   // confirmed 'act' and the call mutates, so a proposal is always available.
-  const exposureReservation = await reserveActUnattendedExposure({
-    run,
-    maxFleetPercentPerDay: current.effective.limits.maxFleetPercentPerDay,
-  });
+  //
+  // The reserve call itself is wrapped: a DB error here (the `organizations`
+  // lookup, the insert, pool exhaustion) must NOT propagate out of this
+  // function — an uncaught throw is turned into a hard tool DENY by the
+  // caller (aiAgentSdkTools.ts) that never lands in `outcome.deniedActions`,
+  // and on the flag-OFF path (production today) this row is pure accounting
+  // with zero enforcement value, so a transient failure must never convert a
+  // previously-succeeding act execution into a denial — same best-effort
+  // contract runLoop.ts's `recordAllowedExecution` uses for its own ledger
+  // write. Flag ON is different: the fleet cap is a LIVE safety gate, so a
+  // failed check must fail closed (degrade to a proposal, the same shape an
+  // exhausted cap already uses) rather than silently grant capacity.
+  let exposureReservation: ExposureReservationResult;
+  try {
+    exposureReservation = await reserveActUnattendedExposure({
+      run,
+      maxFleetPercentPerDay: current.effective.limits.maxFleetPercentPerDay,
+    });
+  } catch (error) {
+    console.error('[actRevalidation] unattended-exposure reservation failed', {
+      runId: run.id, toolName, error,
+    });
+    if (policyDecideEnabled()) return { ok: false, downgrade: 'propose' };
+    exposureReservation = { ok: true };
+  }
   if (!exposureReservation.ok) {
     return { ok: false, downgrade: 'propose' };
   }

--- a/apps/api/src/services/aiAgents/actRevalidation.ts
+++ b/apps/api/src/services/aiAgents/actRevalidation.ts
@@ -35,7 +35,7 @@
  * proposal. This module is where that distinction is actually drawn.
  */
 import { createHash } from 'node:crypto';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, gt, sql } from 'drizzle-orm';
 import type { AiAgentKind } from '@breeze/shared';
 import {
   db,
@@ -45,10 +45,14 @@ import {
 } from '../../db';
 import { deviceFilesystemCleanupRuns } from '../../db/schema/filesystem';
 import { playbookDefinitions } from '../../db/schema/playbooks';
+import { organizations } from '../../db/schema/orgs';
+import { aiUnattendedExposure } from '../../db/schema/aiUnattendedExposure';
 import { readPlanPreviewCandidates } from '../filesystemAnalysis';
 import { computeEffectDigestForRelease } from '../actionIntents/effectDigest';
 import { checkAgentGuardrails, type AgentGuardrailPolicy } from '../aiGuardrails';
 import { readAiKillState } from '../aiKillState';
+import { policyDecideEnabled } from '../../config/env';
+import { countContractDevices } from '../contractQuantities';
 import { resolveEffectiveAgentSystem } from './effectivePolicy';
 import type { ActOperation, ActTarget } from './actManifest';
 import type { ToolExecutionContext } from '../toolExecutionContext';
@@ -270,6 +274,98 @@ async function pinAsset(
   }
 }
 
+type ExposureReservationResult = { ok: true } | { ok: false; reason: 'fleet_cap_exceeded' };
+
+/**
+ * Wave 5 Part B (#3827) — unattended-exposure ledger accounting for the act
+ * lane. Writes ONE `ai_unattended_exposure` row (`source: 'act'`, `intentId:
+ * null`) per act-mode call that actually reserves a slot, and — ONLY while
+ * `BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED` is on — enforces the SAME
+ * org-wide fleet-percent cap `policyDecide.ts`'s `runAuthorizeTransaction`
+ * enforces for the policy-decide lane (advisory-lock + floor, duplicated
+ * locally here rather than imported — this directory's established leaf-
+ * module convention; see `inSystemDbContext`'s own header comment). The two
+ * lanes share ONE ledger table and must agree on how the fleet-wide
+ * numerator (distinct devices exposed org-wide, trailing 24h, act + policy
+ * combined) is computed.
+ *
+ * Flag-independence (plan Task 4): the WRITE is unconditional — an act-mode
+ * execution accounts for itself in the ledger whether or not the
+ * policy-decide flag is on, so the ledger's own 24h trailing window already
+ * has real history the moment an operator flips the flag on, rather than
+ * starting from zero. Only the CAP ENFORCEMENT is flag-gated, which is what
+ * keeps wave-4 act-mode behavior byte-identical (bounded solely by
+ * `maxActionsPerRun`) until wave 5 turns the sub-flag on.
+ *
+ * Called from Step 5 AFTER the `maxActionsPerRun` in-memory check already
+ * passed, so an already-exhausted run never reaches this DB-backed check —
+ * and, symmetrically, a call that fails the fleet cap here never reaches
+ * (never increments) the `maxActionsPerRun` counter either.
+ */
+async function reserveActUnattendedExposure(args: {
+  run: RevalidateActExecutionArgs['run'];
+  maxFleetPercentPerDay: number;
+}): Promise<ExposureReservationResult> {
+  const { run, maxFleetPercentPerDay } = args;
+  const enforceCap = policyDecideEnabled();
+
+  return inSystemDbContext(async (): Promise<ExposureReservationResult> => {
+    if (enforceCap) {
+      // Per-org advisory lock — same key shape as policyDecide.ts's
+      // `runAuthorizeTransaction`, serializing concurrent act+policy
+      // reservations for the SAME org so the check below can't overshoot by
+      // more than one device per race. Released automatically on
+      // commit/rollback of this call's own transaction (withSystemDbAccessContext
+      // opens one) — no separate unlock call.
+      await db.execute(sql`select pg_advisory_xact_lock(hashtextextended(${`ai-exposure:${run.orgId}`}, 0))`);
+
+      const windowStart = sql`now() - interval '24 hours'`;
+      const exposedDeviceRows = await db
+        .select({ deviceId: aiUnattendedExposure.deviceId })
+        .from(aiUnattendedExposure)
+        .where(and(eq(aiUnattendedExposure.orgId, run.orgId), gt(aiUnattendedExposure.reservedAt, windowStart)));
+      const exposedDevices = new Set(exposedDeviceRows.map((r) => r.deviceId));
+      const deviceAlreadyExposed = exposedDevices.has(run.deviceId);
+
+      const contractDeviceCount = await countContractDevices(run.orgId, null);
+      // floor(), no max(1, ·) — same locked quorum decision policyDecide.ts
+      // enforces: a tiny fleet with a sub-1-device allowance gets ZERO
+      // unattended executions, act or policy.
+      const allowance = Math.floor((contractDeviceCount * maxFleetPercentPerDay) / 100);
+      const projectedDistinctDevices = exposedDevices.size + (deviceAlreadyExposed ? 0 : 1);
+      if (projectedDistinctDevices > allowance) {
+        return { ok: false, reason: 'fleet_cap_exceeded' };
+      }
+    }
+
+    // The org's OWNING partner — needed for the exposure row's composite
+    // (org_id, partner_id) FK, independent of whether this particular agent
+    // is org- or partner-owned (mirrors policyDecide.ts's own lookup).
+    const [org] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, run.orgId))
+      .limit(1);
+    if (!org) {
+      // Structurally unreachable: the run's own org row must exist for the
+      // run to have been admitted at all.
+      throw new Error(`reserveActUnattendedExposure: org ${run.orgId} not found`);
+    }
+
+    await db.insert(aiUnattendedExposure).values({
+      orgId: run.orgId,
+      partnerId: org.partnerId,
+      agentId: run.agentId,
+      runId: run.id,
+      deviceId: run.deviceId,
+      intentId: null,
+      source: 'act',
+    });
+
+    return { ok: true };
+  });
+}
+
 /**
  * Revalidate a manifest-matched act-mode call immediately before dispatch,
  * and reserve a `maxActionsPerRun` slot for it. See the module header for the
@@ -381,7 +477,9 @@ export async function revalidateActExecution(
   // Step 5: reserve a maxActionsPerRun slot against the LIVE cap — slotted
   // BEFORE dispatch, and never released: a failed/timeout/unknown dispatch
   // still consumed the slot (Global Constraints), only a read-only call
-  // never reaches this function at all.
+  // never reaches this function at all. The cheap in-memory check runs
+  // first so an already-exhausted run never reaches the DB-backed exposure
+  // accounting below.
   const cap = current.effective.limits.maxActionsPerRun;
   if (reserved.count >= cap) {
     // Exhausted. Mode is confirmed 'act' and the call mutates, so the
@@ -390,6 +488,21 @@ export async function revalidateActExecution(
     // where a proposal is unavailable.
     return { ok: false, downgrade: 'propose' };
   }
+
+  // Step 5.5 (#3827 Task 4): unattended-exposure ledger accounting — writes
+  // the shared `ai_unattended_exposure` row (unconditional) and, only while
+  // the policy-decide sub-flag is on, enforces the org-wide fleet-percent
+  // cap the policy-decide lane also reads. Exhaustion downgrades to a
+  // proposal exactly like an exhausted maxActionsPerRun slot — mode is
+  // confirmed 'act' and the call mutates, so a proposal is always available.
+  const exposureReservation = await reserveActUnattendedExposure({
+    run,
+    maxFleetPercentPerDay: current.effective.limits.maxFleetPercentPerDay,
+  });
+  if (!exposureReservation.ok) {
+    return { ok: false, downgrade: 'propose' };
+  }
+
   reserved.count += 1;
 
   return { ok: true, pin: { op, target: normalized.target, ...pinned.extra } };

--- a/apps/api/src/services/aiAgents/agentService.test.ts
+++ b/apps/api/src/services/aiAgents/agentService.test.ts
@@ -542,6 +542,42 @@ describe('agent mutations', () => {
       expect(state.updatedValues).toMatchObject({ mode: 'act' });
     });
 
+    it("a non-null supervisedActionKeys set alone satisfies act_eligible_tool — a policy-decide-only agent (no run_script/manage_services/disk_cleanup/execute_playbook manifest surface) must still be able to enter act mode (Task 5, #3827)", async () => {
+      // security_scan is POLICY_DECIDABLE_TIER3-eligible but is NOT in
+      // ACT_MANIFEST/ACT_ELIGIBLE_TOOL_NAMES (that set is the wave-4
+      // rule-equivalent-operation manifest, a different lane) — before this
+      // fix, an agent configured ONLY for policy-decide on security_scan/
+      // manage_startup_items/manage_scheduled_tasks (no wave-4 act-lane
+      // surface at all) could never activate act mode: hasActEligibleSurface
+      // would see an empty intersection with ACT_ELIGIBLE_TOOL_NAMES and
+      // reject with act_eligible_tool even though supervisedActionKeys was
+      // correctly configured.
+      const actReady = {
+        ...storedRow,
+        toolAllowlist: ['security_scan'],
+        actAssets: { scriptIds: [], supervisedActionKeys: ['security_scan:quarantine'] },
+      };
+      state.currentRow = actReady;
+      state.returnedRow = { ...actReady, mode: 'act' };
+
+      await updateAgent(auth(), 'a1', { mode: 'act' } as never);
+
+      expect(state.updatedValues).toMatchObject({ mode: 'act' });
+    });
+
+    it('an empty supervisedActionKeys does NOT satisfy act_eligible_tool on its own — still requires a real wave-4 manifest surface', async () => {
+      state.currentRow = {
+        ...storedRow,
+        toolAllowlist: ['security_scan'],
+        actAssets: { scriptIds: [], supervisedActionKeys: [] },
+      };
+
+      const err = await updateAgent(auth(), 'a1', { mode: 'act' } as never).catch((e) => e);
+      expect(err).toBeInstanceOf(ActPrerequisitesNotMetError);
+      expect((err as ActPrerequisitesNotMetError).missing).toEqual(['act_eligible_tool']);
+      expect(state.updatedValues).toBeNull();
+    });
+
     it('refuses an update to act mode with no resolvable recipient', async () => {
       state.hasResolvableAgentRecipient.mockResolvedValue(false);
       state.currentRow = { ...storedRow, toolAllowlist: ['manage_services'] };

--- a/apps/api/src/services/aiAgents/agentService.test.ts
+++ b/apps/api/src/services/aiAgents/agentService.test.ts
@@ -18,6 +18,7 @@ const state = vi.hoisted(() => ({
   ensureManagedTriageAutomation: vi.fn(),
   setManagedAutomationEnabled: vi.fn(),
   syncManagedAutomation: vi.fn(),
+  validateAuthorizationKeys: vi.fn(),
 }));
 
 const schema = vi.hoisted(() => ({
@@ -91,6 +92,17 @@ vi.mock('./recipients', () => {
   };
 });
 
+// Real POLICY_DECIDABLE_TIER3 membership/registry semantics have their own
+// exhaustive suite (policyDecidable.test.ts). Real aiTools.ts/aiGuardrails.ts
+// also pull in the full db/schema barrel (peripheralEventTypeEnum et al.),
+// which this file's minimal `../../db/schema` mock does not provide — so this
+// is isolated the same way ./recipients is above: a controllable stub whose
+// CONTRACT (called with exactly the keys this write is setting, before
+// anything is written) is what agentService.ts owns and this suite asserts.
+vi.mock('../actionIntents/policyDecidable', () => ({
+  validateAuthorizationKeys: state.validateAuthorizationKeys,
+}));
+
 vi.mock('./managedAutomation', () => ({
   ensureManagedTriageAutomation: state.ensureManagedTriageAutomation,
   setManagedAutomationEnabled: state.setManagedAutomationEnabled,
@@ -122,6 +134,7 @@ vi.mock('./effectivePolicy', () => ({
 import {
   ActPrerequisitesNotMetError,
   AgentKindConflictError,
+  InvalidSupervisedActionKeysError,
   UnsupportedAgentModeError,
   createAgent,
   disableAgent,
@@ -221,6 +234,8 @@ beforeEach(() => {
   state.validateRecipients.mockResolvedValue(undefined);
   state.hasResolvableAgentRecipient.mockReset();
   state.hasResolvableAgentRecipient.mockResolvedValue(true);
+  state.validateAuthorizationKeys.mockReset();
+  state.validateAuthorizationKeys.mockImplementation((keys: string[]) => ({ ok: keys, rejected: [] }));
   state.currentRow = null;
   state.listRows = [];
   state.returnedRow = null;
@@ -590,6 +605,109 @@ describe('agent mutations', () => {
       );
 
       expect(state.insertedValues).toMatchObject({ mode: 'act' });
+    });
+  });
+
+  describe('supervisedActionKeys write-time validation (wave 5 Part B, #3827)', () => {
+    it('refuses a create whose supervisedActionKeys is rejected by validateAuthorizationKeys, before the insert runs', async () => {
+      state.returnedRow = storedRow;
+      state.validateAuthorizationKeys.mockReturnValue({
+        ok: [],
+        rejected: [{ key: 'bogus_key', reason: 'not registered in POLICY_DECIDABLE_TIER3' }],
+      });
+
+      const err = await createAgent(
+        auth(),
+        { orgId: 'o1', partnerId: null },
+        { ...createInput, actAssets: { scriptIds: [], supervisedActionKeys: ['bogus_key'] } } as never,
+      ).catch((e) => e);
+
+      expect(err).toBeInstanceOf(InvalidSupervisedActionKeysError);
+      expect((err as InvalidSupervisedActionKeysError).rejected).toEqual([
+        { key: 'bogus_key', reason: 'not registered in POLICY_DECIDABLE_TIER3' },
+      ]);
+      expect(state.validateAuthorizationKeys).toHaveBeenCalledWith(['bogus_key']);
+      expect(state.insertedValues).toBeNull();
+      expect(state.audit).not.toHaveBeenCalled();
+    });
+
+    it('accepts a create whose supervisedActionKeys validateAuthorizationKeys accepts', async () => {
+      state.returnedRow = { ...storedRow, actAssets: { scriptIds: [], supervisedActionKeys: ['manage_services:restart'] } };
+
+      await createAgent(
+        auth(),
+        { orgId: 'o1', partnerId: null },
+        { ...createInput, actAssets: { scriptIds: [], supervisedActionKeys: ['manage_services:restart'] } } as never,
+      );
+
+      expect(state.validateAuthorizationKeys).toHaveBeenCalledWith(['manage_services:restart']);
+      expect(state.insertedValues).toMatchObject({
+        actAssets: { scriptIds: [], supervisedActionKeys: ['manage_services:restart'] },
+      });
+    });
+
+    it('an absent or empty supervisedActionKeys is a no-op — validateAuthorizationKeys is never called', async () => {
+      state.returnedRow = storedRow;
+
+      await createAgent(auth(), { orgId: 'o1', partnerId: null }, createInput as never);
+
+      expect(state.validateAuthorizationKeys).not.toHaveBeenCalled();
+      expect(state.insertedValues).not.toBeNull();
+    });
+
+    it('refuses an update whose supervisedActionKeys patch is rejected, before the update runs', async () => {
+      state.currentRow = storedRow;
+      state.validateAuthorizationKeys.mockReturnValue({
+        ok: [],
+        rejected: [{ key: 'bogus_key', reason: 'not registered in POLICY_DECIDABLE_TIER3' }],
+      });
+
+      const err = await updateAgent(auth(), 'a1', {
+        actAssets: { supervisedActionKeys: ['bogus_key'] },
+      } as never).catch((e) => e);
+
+      expect(err).toBeInstanceOf(InvalidSupervisedActionKeysError);
+      expect(state.updatedValues).toBeNull();
+    });
+
+    it('accepts an update whose supervisedActionKeys patch validateAuthorizationKeys accepts, merged onto stored actAssets', async () => {
+      state.currentRow = { ...storedRow, actAssets: { scriptIds: ['s-1'] } };
+      state.returnedRow = storedRow;
+
+      await updateAgent(auth(), 'a1', {
+        actAssets: { supervisedActionKeys: ['security_scan:quarantine'] },
+      } as never);
+
+      expect(state.validateAuthorizationKeys).toHaveBeenCalledWith(['security_scan:quarantine']);
+      expect(state.updatedValues).toMatchObject({
+        actAssets: { scriptIds: ['s-1'], supervisedActionKeys: ['security_scan:quarantine'] },
+      });
+    });
+
+    it('does NOT re-validate a stored supervisedActionKeys value on an update that never touches actAssets — stored-but-registry-dropped keys are tolerated-but-inert, not write-blocking', async () => {
+      state.currentRow = {
+        ...storedRow,
+        actAssets: { scriptIds: [], supervisedActionKeys: ['now_dropped_from_registry'] },
+      };
+      state.returnedRow = { ...storedRow, instructions: 'Updated' };
+
+      await updateAgent(auth(), 'a1', { instructions: 'Updated' } as never);
+
+      expect(state.validateAuthorizationKeys).not.toHaveBeenCalled();
+      expect(state.updatedValues).toMatchObject({ instructions: 'Updated' });
+    });
+
+    it('an update patch that sets actAssets but omits supervisedActionKeys does not re-validate the untouched stored value', async () => {
+      state.currentRow = {
+        ...storedRow,
+        actAssets: { scriptIds: [], supervisedActionKeys: ['now_dropped_from_registry'] },
+      };
+      state.returnedRow = storedRow;
+
+      await updateAgent(auth(), 'a1', { actAssets: { scriptIds: ['s-2'] } } as never);
+
+      expect(state.validateAuthorizationKeys).not.toHaveBeenCalled();
+      expect(state.updatedValues).not.toBeNull();
     });
   });
 

--- a/apps/api/src/services/aiAgents/agentService.ts
+++ b/apps/api/src/services/aiAgents/agentService.ts
@@ -110,6 +110,19 @@ function hasActEligibleSurface(
   toolAllowlist: string[],
   actAssets: Partial<AiAgentActAssets>,
 ): boolean {
+  // Wave 5 Part B (#3827): a non-empty supervisedActionKeys set is ITSELF a
+  // real act-eligible surface — exactly what makes the agent act unattended
+  // for those keys — independent of the wave-4 ACT_MANIFEST/toolAllowlist
+  // check below. Without this branch, an agent configured ONLY for
+  // policy-decide on a tool ACT_MANIFEST doesn't cover (security_scan,
+  // manage_startup_items, manage_scheduled_tasks all qualify;
+  // manage_services happens to overlap both lanes) could never satisfy this
+  // prerequisite and so could never enter act mode at all — the write-time
+  // key validation (assertSupervisedActionKeysValid) already guarantees any
+  // non-empty value here is genuine POLICY_DECIDABLE_TIER3 membership, so
+  // trusting length alone is safe.
+  if ((actAssets.supervisedActionKeys?.length ?? 0) > 0) return true;
+
   const eligible = new Set(ACT_ELIGIBLE_TOOL_NAMES);
   const baseName = (entry: string): string => entry.split(':', 1)[0] ?? entry;
   const intersecting = toolAllowlist.filter((entry) => eligible.has(baseName(entry)));

--- a/apps/api/src/services/aiAgents/agentService.ts
+++ b/apps/api/src/services/aiAgents/agentService.ts
@@ -6,6 +6,7 @@ import type { AuthContext } from '../../middleware/auth';
 import { createAuditLog } from '../auditService';
 import { captureException } from '../sentry';
 import { getEventBus } from '../eventBus';
+import { type RejectedAuthorizationKey, validateAuthorizationKeys } from '../actionIntents/policyDecidable';
 import { ACT_ELIGIBLE_TOOL_NAMES } from './actManifest';
 import { AgentAccessDeniedError, assertAgentWriteAllowed } from './access';
 import { isSupportedAgentMode } from './constants';
@@ -48,6 +49,24 @@ export class AgentKindConflictError extends Error {
   constructor(kind: string) {
     super(`agent_kind_exists: ${kind}`);
     this.name = 'AgentKindConflictError';
+  }
+}
+
+/**
+ * Wave 5 Part B (#3827). `actAssets.supervisedActionKeys` is the operator's
+ * explicit per-agent authorization for `attemptPolicyDecision` to resolve a
+ * matching Tier-3 intent WITHOUT human fanout — so an unknown, four_eyes,
+ * Tier-4/blocked, or secret-bearing key must never be persisted here. `rejected`
+ * names exactly which keys failed and why (validateAuthorizationKeys,
+ * policyDecidable.ts) so the client (Task 5's editor) can render an actionable
+ * message rather than a bare 422.
+ */
+export class InvalidSupervisedActionKeysError extends Error {
+  readonly code = 'invalid_supervised_action_keys';
+
+  constructor(public rejected: RejectedAuthorizationKey[]) {
+    super(`invalid_supervised_action_keys: ${rejected.map((r) => r.key).join(', ')}`);
+    this.name = 'InvalidSupervisedActionKeysError';
   }
 }
 
@@ -97,6 +116,21 @@ function hasActEligibleSurface(
   if (intersecting.some((entry) => baseName(entry) !== 'run_script')) return true;
   if (!intersecting.some((entry) => baseName(entry) === 'run_script')) return false;
   return (actAssets.scriptIds?.length ?? 0) > 0;
+}
+
+/**
+ * Wave 5 Part B (#3827) write-time gate. Validates exactly the keys THIS
+ * write is setting — never the merged/stored value — so a key the registry
+ * has since dropped stays stored-but-inert (Design authority, plan header:
+ * "stored authorization keys tolerated-but-inert when the registry drops
+ * them") rather than retroactively blocking an unrelated future edit that
+ * never touches actAssets.supervisedActionKeys at all. No-op on an absent or
+ * empty array.
+ */
+function assertSupervisedActionKeysValid(keys: string[] | undefined): void {
+  if (!keys || keys.length === 0) return;
+  const { rejected } = validateAuthorizationKeys(keys);
+  if (rejected.length > 0) throw new InvalidSupervisedActionKeysError(rejected);
 }
 
 /**
@@ -361,6 +395,11 @@ export async function createAgent(
   // silently never hears anything.
   await validateAgentRecipients(owner, input.recipients ?? {});
 
+  // Wave 5 Part B (#3827): a create-supplied supervisedActionKeys set is
+  // validated against POLICY_DECIDABLE_TIER3 before anything is written, same
+  // reason as recipients above — a rejected key must never be persisted.
+  assertSupervisedActionKeysValid(input.actAssets.supervisedActionKeys);
+
   // Task 6 (#3826): a create that would land with mode: 'act' must already
   // have a resolvable recipient and an act-eligible surface — checked against
   // exactly what THIS create will persist (input's own fields are already
@@ -436,6 +475,12 @@ export async function updateAgent(
     : { ...stored.recipients, ...input.recipients };
   if (input.recipients !== undefined) {
     await validateAgentRecipients(owner, mergedRecipients);
+  }
+
+  // Wave 5 Part B (#3827): validate only the keys THIS patch is setting, not
+  // the merged/stored value — see assertSupervisedActionKeysValid's doc.
+  if (input.actAssets?.supervisedActionKeys !== undefined) {
+    assertSupervisedActionKeysValid(input.actAssets.supervisedActionKeys);
   }
 
   // Task 6 (#3826): prerequisites are checked against what the update will

--- a/apps/api/src/services/aiAgents/effectivePolicy.test.ts
+++ b/apps/api/src/services/aiAgents/effectivePolicy.test.ts
@@ -86,6 +86,9 @@ const ORG_AGENT_ID = '00000000-0000-4000-8000-000000000012';
 const SCRIPT_A = '00000000-0000-4000-8000-000000000013';
 const SCRIPT_B = '00000000-0000-4000-8000-000000000014';
 const SCRIPT_C = '00000000-0000-4000-8000-000000000015';
+const KEY_A = 'manage_services:restart';
+const KEY_B = 'manage_services:stop';
+const KEY_C = 'security_scan:quarantine';
 
 function policy(over: Partial<AiAgentPolicy> = {}): AiAgentPolicy {
   return {
@@ -199,7 +202,7 @@ describe('mergeAgentPolicies — tighten only', () => {
         respectMaintenanceWindows: false,
       },
       recipients: { userIds: [PARTNER_USER_ID], roleIds: [PARTNER_ROLE_ID] },
-      actAssets: { scriptIds: [SCRIPT_A, SCRIPT_B] },
+      actAssets: { scriptIds: [SCRIPT_A, SCRIPT_B], supervisedActionKeys: [KEY_A, KEY_B] },
       cooldownSeconds: 300,
     });
     const org = policy({
@@ -222,7 +225,7 @@ describe('mergeAgentPolicies — tighten only', () => {
         respectMaintenanceWindows: true,
       },
       recipients: { userIds: [ORG_USER_ID], roleIds: [ORG_ROLE_ID] },
-      actAssets: { scriptIds: [SCRIPT_B, SCRIPT_C] },
+      actAssets: { scriptIds: [SCRIPT_B, SCRIPT_C], supervisedActionKeys: [KEY_B, KEY_C] },
       instructions: 'org says hi',
       cooldownSeconds: 60,
     });
@@ -254,7 +257,7 @@ describe('mergeAgentPolicies — tighten only', () => {
         userIds: [PARTNER_USER_ID, ORG_USER_ID],
         roleIds: [PARTNER_ROLE_ID, ORG_ROLE_ID],
       },
-      actAssets: { scriptIds: [SCRIPT_B] },
+      actAssets: { scriptIds: [SCRIPT_B], supervisedActionKeys: [KEY_B] },
       instructions:
         '[partner guidance]\npartner says hi\n[/partner guidance]\n\n' +
         '[organization guidance]\norg says hi\n[/organization guidance]',
@@ -324,7 +327,38 @@ describe('mergeAgentPolicies — tighten only', () => {
     expect(normalized.limits).toEqual(AI_AGENT_LIMIT_DEFAULTS);
     expect(normalized.triggers.alertSeverities).toEqual(['critical', 'high']);
     expect(normalized.recipients).toEqual({ userIds: [], roleIds: [] });
-    expect(normalized.actAssets).toEqual({ scriptIds: [] });
+    expect(normalized.actAssets).toEqual({ scriptIds: [], supervisedActionKeys: [] });
+  });
+
+  it('supervisedActionKeys narrows exactly like scriptIds: absent partner field, empty-partner-baseline stands alone', () => {
+    // No org override at all: effective === partner verbatim (the existing
+    // `if (!org) return { effective: partner, ... }` early return) — a
+    // partner-wide baseline row's own supervisedActionKeys is never
+    // intersected against anything.
+    const partnerOnly = policy({ actAssets: { scriptIds: [], supervisedActionKeys: [KEY_A] } });
+    expect(mergeAgentPolicies(partnerOnly, null, { allowedModels: null }).effective.actAssets)
+      .toEqual({ scriptIds: [], supervisedActionKeys: [KEY_A] });
+
+    // Org narrows: intersection, never union — org's KEY_C (not on the
+    // partner baseline) is dropped.
+    const partner = policy({ actAssets: { scriptIds: [], supervisedActionKeys: [KEY_A, KEY_B] } });
+    const org = policy({ actAssets: { scriptIds: [], supervisedActionKeys: [KEY_B, KEY_C] } });
+    expect(mergeAgentPolicies(partner, org, { allowedModels: null }).effective.actAssets)
+      .toEqual({ scriptIds: [], supervisedActionKeys: [KEY_B] });
+
+    // An empty partner baseline narrows the org to empty too — "never
+    // policy-decidable" is the correct default, same as scriptIds/run_script.
+    const emptyPartner = policy({ actAssets: { scriptIds: [], supervisedActionKeys: [] } });
+    const wideOrg = policy({ actAssets: { scriptIds: [], supervisedActionKeys: [KEY_A] } });
+    expect(mergeAgentPolicies(emptyPartner, wideOrg, { allowedModels: null }).effective.actAssets)
+      .toEqual({ scriptIds: [], supervisedActionKeys: [] });
+
+    // A row missing the key entirely (pre-this-deploy jsonb, no version bump)
+    // merges as if it were an empty array, on either side.
+    const legacyPartner = policy({ actAssets: { scriptIds: [] } });
+    const orgWithKeys = policy({ actAssets: { scriptIds: [], supervisedActionKeys: [KEY_A] } });
+    expect(mergeAgentPolicies(legacyPartner, orgWithKeys, { allowedModels: null }).effective.actAssets)
+      .toEqual({ scriptIds: [], supervisedActionKeys: [] });
   });
 });
 

--- a/apps/api/src/services/aiAgents/effectivePolicy.ts
+++ b/apps/api/src/services/aiAgents/effectivePolicy.ts
@@ -195,8 +195,24 @@ export function mergeAgentPolicies(
     // partner's authorized script set, never add a script the partner never
     // opted in — an org intersecting against an empty partner baseline stays
     // empty, which is exactly "run_script never act-eligible" (Task 6).
+    //
+    // supervisedActionKeys (wave 5 Part B, #3827) mirrors scriptIds exactly,
+    // for the same reason: an org may only narrow the partner's authorized
+    // POLICY_DECIDABLE_TIER3 key set, never widen it. `?? []` on both sides is
+    // load-bearing, not defensive — the field is optional on AiAgentActAssets
+    // because AI_AGENT_POLICY_SNAPSHOT_VERSION was NOT bumped for it (v3 is
+    // already tolerant), so a partner or org row written before this deploy
+    // has no `supervisedActionKeys` key in its stored `actAssets` jsonb at
+    // all. `normalizeAgentPolicy` fills the shared-schema default of `[]`
+    // for any row read through it, but `mergeAgentPolicies` is also exported
+    // pure and callable directly with a hand-built AiAgentPolicy (as several
+    // tests here do), so the merge itself must not assume the key is present.
     actAssets: pick('actAssets', {
       scriptIds: intersect(partner.actAssets.scriptIds, org.actAssets.scriptIds),
+      supervisedActionKeys: intersect(
+        partner.actAssets.supervisedActionKeys ?? [],
+        org.actAssets.supervisedActionKeys ?? [],
+      ),
     }, 'merged'),
     instructions: pick(
       'instructions',

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -1209,6 +1209,26 @@ export type GuardrailDisposition = 'allow' | 'propose' | 'deny' | 'act';
 export type AgentGuardrailCheck = GuardrailCheck & { disposition: GuardrailDisposition };
 
 /**
+ * The sub-operation discriminator for a tool call, resolved EXACTLY the way
+ * `checkGuardrails` and `checkAgentGuardrails` each used to do inline (two
+ * byte-identical copies, now one). `TOOL_ACTION_INPUT_KEYS` overrides the
+ * default `action` key for a multiplexer keyed on something else
+ * (`execute_command`'s `commandType`, #3088). A non-string value at that key
+ * resolves to `undefined`, not a coerced string — callers fall back to
+ * whatever "no action" means for them (checkGuardrails: the tool's base
+ * tier; checkAgentGuardrails: a hard deny on a multiplexed tool;
+ * policyDecide.ts: no `tool:action` key, so a bare-tool registry lookup).
+ *
+ * Exported so `policyDecide.ts`'s canonical-key derivation reuses this
+ * instead of a third inline copy (wave 5 Part B, #3827).
+ */
+export function resolveActionForTool(toolName: string, input: Record<string, unknown>): string | undefined {
+  const actionKey = TOOL_ACTION_INPUT_KEYS[toolName] ?? 'action';
+  const actionValue = input[actionKey];
+  return typeof actionValue === 'string' ? actionValue : undefined;
+}
+
+/**
  * Check guardrails for a tool invocation.
  * Returns the effective tier and whether approval is needed.
  */
@@ -1236,13 +1256,9 @@ export function checkGuardrails(
     };
   }
 
-  // Check for action-based tier escalation. The discriminator is `action` for
-  // most tools; a TOOL_ACTION_INPUT_KEYS entry overrides the key (#3088 —
-  // execute_command multiplexes on `commandType`). Non-string values resolve
-  // to undefined, which falls through to the base tier (fail-closed).
-  const actionKey = TOOL_ACTION_INPUT_KEYS[toolName] ?? 'action';
-  const actionValue = input[actionKey];
-  const action = typeof actionValue === 'string' ? actionValue : undefined;
+  // Check for action-based tier escalation. Non-string values resolve to
+  // undefined, which falls through to the base tier (fail-closed).
+  const action = resolveActionForTool(toolName, input);
 
   // Tier 1 downgrade: read-only actions on otherwise-high-tier tools
   if (action && TIER1_ACTIONS[toolName]?.includes(action)) {
@@ -1590,8 +1606,7 @@ export function checkAgentGuardrails(
   if (policy.mode === 'off') return deny('Agent mode is off');
 
   const actionKey = TOOL_ACTION_INPUT_KEYS[toolName] ?? 'action';
-  const actionValue = input[actionKey];
-  const action = typeof actionValue === 'string' ? actionValue : undefined;
+  const action = resolveActionForTool(toolName, input);
 
   // A non-string action (`action: ['write']`) makes checkGuardrails skip its
   // TIER3_ACTIONS escalation and fall back to the tool's REGISTERED BASE TIER —
@@ -1600,7 +1615,7 @@ export function checkAgentGuardrails(
   // allowlist entirely. An unresolvable action on a multiplexed tool denies.
   if (action === undefined && isActionMultiplexedTool(toolName)) {
     return deny(
-      `Tool "${toolName}" requires a string "${actionKey}"; got ${describeType(actionValue)}`,
+      `Tool "${toolName}" requires a string "${actionKey}"; got ${describeType(input[actionKey])}`,
     );
   }
 

--- a/apps/api/src/services/workerEntrypointClosure.contract.test.ts
+++ b/apps/api/src/services/workerEntrypointClosure.contract.test.ts
@@ -297,6 +297,7 @@ const EXPECTED_NAMES = [
   'intentOutboxPublisher', 'intentExpiryReaper', 'intentReleaseWorker', 'stripeReconcileSweep',
   'quoteExpiryReaper', 'suppressionExpiryReaper', 'ticketNotifyWorker', 'ticketSlaWorker',
   'inboundEmailWorker', 'ticketMailboxPollWorker', 'invoiceWorker', 'contractWorker',
+  'aiUnattendedExposureRetention',
 ];
 
 // ---------------------------------------------------------------------------
@@ -448,7 +449,7 @@ describe('workerEntrypointClosure contract (#4086 Task 5)', () => {
 
   describe('global-placement entries never reach socket-local dispatch', () => {
     const entries = parseRegistrySource();
-    expect(entries.length).toBe(106); // sanity: the source-parsing regex itself must find all 106
+    expect(entries.length).toBe(107); // sanity: the source-parsing regex itself must find all 107
 
     const globalEntries = entries.filter((e) => e.placement === 'global');
     expect(globalEntries.length).toBeGreaterThan(0);

--- a/apps/api/src/services/workerRegistry.test.ts
+++ b/apps/api/src/services/workerRegistry.test.ts
@@ -12,11 +12,11 @@ import {
 
 // The canonical names, in today's `index.ts:1305-1433` order (see the plan
 // doc, Task 1) plus every entry added since (e.g. `agentNotifyRetry`, wave 4a
-// Task 6, #3826). This list is duplicated here deliberately — the whole
-// point of the test is to catch drift between the plan's documented contract
-// and the actual registry, so it must not import the list from the module
-// under test.
-const EXPECTED_106_NAMES = [
+// Task 6, #3826; `aiUnattendedExposureRetention`, wave 5B Task 4, #3827).
+// This list is duplicated here deliberately — the whole point of the test is
+// to catch drift between the plan's documented contract and the actual
+// registry, so it must not import the list from the module under test.
+const EXPECTED_107_NAMES = [
   'alertWorkers', 'alertCorrelationWorker', 'metricRollupsWorker', 'metricRollupMaintenance',
   'metricAnomaliesWorker', 'fleetFindingsWorker', 'fleetRemediationDispatchWorker', 'mlOutputRetention',
   'offlineDetector', 'notificationDispatcher', 'webhookDelivery', 'webhookDeliveryRecovery',
@@ -44,15 +44,16 @@ const EXPECTED_106_NAMES = [
   'intentOutboxPublisher', 'intentExpiryReaper', 'intentReleaseWorker', 'stripeReconcileSweep',
   'quoteExpiryReaper', 'suppressionExpiryReaper', 'ticketNotifyWorker', 'ticketSlaWorker',
   'inboundEmailWorker', 'ticketMailboxPollWorker', 'invoiceWorker', 'contractWorker',
+  'aiUnattendedExposureRetention',
 ];
 
 describe('workerRegistry: losslessness', () => {
-  it('contains exactly the 106 known names, in order', () => {
-    expect(WORKER_REGISTRY.map((e) => e.name)).toEqual(EXPECTED_106_NAMES);
+  it('contains exactly the 107 known names, in order', () => {
+    expect(WORKER_REGISTRY.map((e) => e.name)).toEqual(EXPECTED_107_NAMES);
   });
 
-  it('has exactly 106 entries', () => {
-    expect(WORKER_REGISTRY.length).toBe(106);
+  it('has exactly 107 entries', () => {
+    expect(WORKER_REGISTRY.length).toBe(107);
   });
 
   it('every entry has a well-formed shape', () => {
@@ -72,14 +73,14 @@ describe('workerRegistry: losslessness', () => {
 
 describe('workerRegistry: selectWorkers', () => {
   it("'all' selects every entry", () => {
-    expect(selectWorkers('all').length).toBe(106);
+    expect(selectWorkers('all').length).toBe(107);
     expect(selectWorkers('all')).toEqual(WORKER_REGISTRY);
   });
 
   it("'api' and 'worker' partition the set with no overlap and no loss", () => {
     const api = selectWorkers('api');
     const worker = selectWorkers('worker');
-    expect(api.length + worker.length).toBe(106);
+    expect(api.length + worker.length).toBe(107);
 
     const apiNames = new Set(api.map((e) => e.name));
     const workerNames = new Set(worker.map((e) => e.name));
@@ -87,7 +88,7 @@ describe('workerRegistry: selectWorkers', () => {
       expect(workerNames.has(name)).toBe(false);
     }
     const union = new Set([...apiNames, ...workerNames]);
-    expect(union.size).toBe(106);
+    expect(union.size).toBe(107);
   });
 
   it("'api' selects only socket-owner placements", () => {

--- a/apps/api/src/services/workerRegistry.ts
+++ b/apps/api/src/services/workerRegistry.ts
@@ -958,6 +958,18 @@ export const WORKER_REGISTRY: readonly WorkerRegistration[] = [
       return { init: m.initializeContractWorkers, shutdown: m.shutdownContractWorkers };
     },
   },
+  {
+    // Wave 5B (#3827 Task 4): 48h sweep of `ai_unattended_exposure`, the
+    // org-wide blast-cap ledger the act + policy-decide lanes share. No
+    // route graph / socket import anywhere in its closure — `global`, same
+    // placement as every other retention worker above.
+    name: 'aiUnattendedExposureRetention',
+    placement: 'global',
+    load: async () => {
+      const m = await import('../jobs/aiUnattendedExposureRetention');
+      return { init: m.initializeAiUnattendedExposureRetention, shutdown: m.shutdownAiUnattendedExposureRetention };
+    },
+  },
 ];
 
 function placementForRole(role: BreezeRole): WorkerPlacement | null {

--- a/apps/web/src/components/settings/AiAgentForm.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.tsx
@@ -29,6 +29,29 @@ interface RoleOption {
   name: string;
 }
 
+/** GET /ai/agents/policy-decidable-keys — the read-only POLICY_DECIDABLE_TIER3
+ *  registry (wave 5 Part B, #3827). `note` is fetched but not currently
+ *  rendered; kept on the type for parity with the wire shape. */
+interface PolicyDecidableKeyOption {
+  key: string;
+  toolName: string;
+  action: string | null;
+  note: string;
+}
+
+/** Groups registry entries by `toolName`, preserving the server's ordering
+ *  within each group (policyDecidable.ts orders entries deliberately — see
+ *  its module doc). */
+function groupByTool(entries: PolicyDecidableKeyOption[]): Map<string, PolicyDecidableKeyOption[]> {
+  const groups = new Map<string, PolicyDecidableKeyOption[]>();
+  for (const entry of entries) {
+    const list = groups.get(entry.toolName);
+    if (list) list.push(entry);
+    else groups.set(entry.toolName, [entry]);
+  }
+  return groups;
+}
+
 interface Props {
   /** null = create a new agent. */
   agent: AiAgentDto | null;
@@ -59,6 +82,12 @@ const AGENT_ERROR_COPY: Record<string, ((t: (key: string) => string) => string) 
   // structured `missing[]` it carries is rendered as issues below, this is
   // just the toast fallback so the raw machine token never reaches the user.
   act_prerequisites_not_met: (t) => t('aiAgentsPage.errors.actPrerequisitesNotMet'),
+  // Wave 5 Part B (#3827): the server's 422 (agentService.ts's
+  // InvalidSupervisedActionKeysError) carries a structured `rejected[]` —
+  // this is just the toast fallback; the per-key detail is rendered as
+  // issues below via ACT_PREREQUISITE_COPY's sibling handling in save()'s
+  // catch block.
+  invalid_supervised_action_keys: (t) => t('aiAgentsPage.errors.invalidSupervisedActionKeys'),
 };
 
 /**
@@ -131,6 +160,9 @@ interface Draft {
   cooldownSeconds: number;
   roleIds: string[];
   instructions: string;
+  /** Wave 5 Part B (#3827). Operator's per-agent opt-in to unattended
+   *  policy-decided authorization — see actAssets in save() below. */
+  supervisedActionKeys: string[];
 }
 
 function draftFrom(
@@ -156,6 +188,7 @@ function draftFrom(
     cooldownSeconds: agent?.cooldownSeconds ?? 900,
     roleIds: agent?.recipients?.roleIds ?? [],
     instructions: agent?.instructions ?? '',
+    supervisedActionKeys: agent?.actAssets?.supervisedActionKeys ?? [],
   };
 }
 
@@ -205,6 +238,8 @@ export default function AiAgentForm({
   );
   const [roles, setRoles] = useState<RoleOption[]>([]);
   const [rolesFailed, setRolesFailed] = useState(false);
+  const [policyKeys, setPolicyKeys] = useState<PolicyDecidableKeyOption[]>([]);
+  const [policyKeysFailed, setPolicyKeysFailed] = useState(false);
   const [issues, setIssues] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
   const [confirmDisable, setConfirmDisable] = useState(false);
@@ -230,6 +265,32 @@ export default function AiAgentForm({
       } catch (err) {
         console.error('[AiAgentForm] could not load roles', err);
         if (!cancelled) setRolesFailed(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // The POLICY_DECIDABLE_TIER3 registry (wave 5 Part B, #3827) — a static,
+  // read-only list, so no dependency on mode/agent; fetched once per mount
+  // exactly like roles above, and rendered only inside the act-mode section
+  // below. A failure must say so rather than rendering an empty registry,
+  // same "authorization/outage vs. genuinely empty" distinction the roles
+  // fetch above draws (this route needs only ai_agents:read, which this page
+  // is already gated on, so a 403 here is unexpected — but the failure state
+  // still must not lie and claim the registry is empty).
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetchWithAuth('/ai/agents/policy-decidable-keys');
+        if (!response.ok) throw new Error(`GET /ai/agents/policy-decidable-keys ${response.status}`);
+        const body = (await response.json()) as { data?: PolicyDecidableKeyOption[] };
+        if (!cancelled) setPolicyKeys(Array.isArray(body.data) ? body.data : []);
+      } catch (err) {
+        console.error('[AiAgentForm] could not load policy-decidable keys', err);
+        if (!cancelled) setPolicyKeysFailed(true);
       }
     })();
     return () => {
@@ -280,6 +341,14 @@ export default function AiAgentForm({
       cooldownSeconds: draft.cooldownSeconds,
       recipients: { roleIds: draft.roleIds },
       instructions: draft.instructions.trim() ? draft.instructions.trim() : null,
+      // Wave 5 Part B (#3827): scriptIds is not this form's field to send —
+      // omitting it here relies on the SAME one-level PATCH merge the
+      // top-of-function comment already documents (updatePolicyColumns
+      // merges { ...stored.actAssets, ...input.actAssets }), so an existing
+      // scriptIds value survives a save that only ever touches
+      // supervisedActionKeys. On create, the server's createAiAgentSchema
+      // defaults the omitted scriptIds to [].
+      actAssets: { supervisedActionKeys: draft.supervisedActionKeys },
     };
 
     let saved = false;
@@ -325,6 +394,26 @@ export default function AiAgentForm({
           : [];
         setIssues(
           missing.map((entry) => ACT_PREREQUISITE_COPY[entry]?.(t) ?? entry),
+        );
+      }
+      // Wave 5 Part B (#3827): the server's 422 (InvalidSupervisedActionKeysError)
+      // carries a structured `rejected[]` naming exactly which keys failed and
+      // why — same "actionable, not a bare toast" pattern as the prerequisites
+      // branch above.
+      if (err instanceof ActionError && err.code === 'invalid_supervised_action_keys') {
+        const body = err.body as { rejected?: unknown } | undefined;
+        const rejected = Array.isArray(body?.rejected)
+          ? body.rejected.filter(
+              (entry): entry is { key: string; reason: string } =>
+                typeof entry === 'object'
+                && entry !== null
+                && typeof (entry as { key?: unknown }).key === 'string'
+                && typeof (entry as { reason?: unknown }).reason === 'string',
+            )
+          : [];
+        setIssues(
+          rejected.map((entry) =>
+            t('aiAgentsPage.errors.supervisedKeyRejected', { key: entry.key, reason: entry.reason })),
         );
       }
     } finally {
@@ -566,6 +655,51 @@ export default function AiAgentForm({
               </label>
             )}
           </div>
+        )}
+
+        {/* Wave 5 Part B (#3827). Gated the same way as the act-warning block
+            above (draft.mode === 'act' only) — the "act acknowledgement
+            pattern": this is additional unattended authority an operator is
+            opting into only once they are already looking at the act-mode
+            warning, never offered for shadow/off. */}
+        {draft.mode === 'act' && (
+          <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2" data-testid="ai-agent-policy-decide">
+            <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+              {t('aiAgentsPage.sections.policyDecide')}
+            </legend>
+            <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.supervisedActionKeysHint')}</p>
+            {policyKeysFailed ? (
+              <p className="text-sm text-destructive" data-testid="ai-agent-policy-keys-failed">
+                {t('aiAgentsPage.fields.supervisedActionKeysFailed')}
+              </p>
+            ) : policyKeys.length === 0 ? (
+              <p className="text-sm text-muted-foreground" data-testid="ai-agent-policy-keys-empty">
+                {t('aiAgentsPage.fields.supervisedActionKeysEmpty')}
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {[...groupByTool(policyKeys).entries()].map(([toolName, entries]) => (
+                  <div key={toolName}>
+                    <p className="text-xs font-semibold">{toolName}</p>
+                    <div className="flex flex-wrap gap-3">
+                      {entries.map((entry) => (
+                        <label key={entry.key} className="flex items-center gap-1 text-sm">
+                          <input
+                            type="checkbox"
+                            checked={draft.supervisedActionKeys.includes(entry.key)}
+                            onChange={() =>
+                              patch({ supervisedActionKeys: toggle(draft.supervisedActionKeys, entry.key) })}
+                            data-testid={`ai-agent-supervised-key-${entry.key}`}
+                          />
+                          {entry.action ?? entry.toolName}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </fieldset>
         )}
 
         <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">

--- a/apps/web/src/components/settings/AiAgentsPage.test.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.test.tsx
@@ -64,6 +64,11 @@ const ORG_AGENT = {
 
 function mockEndpoints(agents: unknown[] = [PARTNER_AGENT]) {
   fetchMock.mockImplementation((url: string) => {
+    // Registered BEFORE the generic '/ai/agents' prefix check below — that
+    // check's startsWith would otherwise swallow this literal path too and
+    // hand the agents LIST back as the policy-key registry, since
+    // '/ai/agents/policy-decidable-keys'.startsWith('/ai/agents') is true.
+    if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: [] }));
     if (url.startsWith('/ai/agents')) return Promise.resolve(json({ data: agents }));
     // The real route answers { data }, not { roles } — mocking the dead branch
     // is how the production branch stayed untested.
@@ -397,6 +402,97 @@ describe('AiAgentsPage', () => {
     );
     const body = JSON.parse((post?.[1] as RequestInit).body as string);
     expect(Number.isFinite(body.limits.maxDevicesPerRun)).toBe(true);
+  });
+
+  it('renders supervisedActionKeys grouped by tool from the registry, only in act mode, and includes selections in the save body (wave 5 Part B, #3827)', async () => {
+    const actAgent = { ...PARTNER_AGENT, supportedModes: ['off', 'shadow', 'act'] as const };
+    const registry = [
+      { key: 'manage_services:restart', toolName: 'manage_services', action: 'restart', note: 'Restarts a service.' },
+      { key: 'manage_services:stop', toolName: 'manage_services', action: 'stop', note: 'Stops a service.' },
+      { key: 'security_scan:quarantine', toolName: 'security_scan', action: 'quarantine', note: 'Quarantines a threat.' },
+    ];
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: registry }));
+      if (url === '/ai/agents/a1' && init?.method === 'PATCH') return Promise.resolve(json({ data: actAgent }));
+      if (url.startsWith('/ai/agents')) return Promise.resolve(json({ data: [actAgent] }));
+      if (url === '/roles') return Promise.resolve(json({ data: [] }));
+      return Promise.resolve(json({ data: [] }));
+    });
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+
+    // Not offered before the operator has selected act — matches the
+    // existing act-warning gating pattern.
+    expect(screen.queryByTestId('ai-agent-supervised-key-manage_services:restart')).toBeNull();
+
+    fireEvent.change(await screen.findByTestId('ai-agent-mode'), { target: { value: 'act' } });
+
+    expect(await screen.findByTestId('ai-agent-supervised-key-manage_services:restart')).toBeInTheDocument();
+    expect(screen.getByTestId('ai-agent-supervised-key-manage_services:stop')).toBeInTheDocument();
+    expect(screen.getByTestId('ai-agent-supervised-key-security_scan:quarantine')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('ai-agent-supervised-key-manage_services:restart'));
+    fireEvent.click(screen.getByTestId('ai-agent-act-ack'));
+    fireEvent.click(screen.getByTestId('ai-agent-save'));
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'PATCH')).toBe(true),
+    );
+    const patch = fetchMock.mock.calls.find(([, init]) => (init as RequestInit | undefined)?.method === 'PATCH');
+    const body = JSON.parse((patch?.[1] as RequestInit).body as string);
+    expect(body.actAssets).toEqual({ supervisedActionKeys: ['manage_services:restart'] });
+  });
+
+  it('surfaces the invalid_supervised_action_keys 422 body as structured, per-key issues (wave 5 Part B, #3827)', async () => {
+    const actAgent = { ...PARTNER_AGENT, supportedModes: ['off', 'shadow', 'act'] as const };
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: [] }));
+      if (url === '/ai/agents/a1' && init?.method === 'PATCH') {
+        return Promise.resolve(
+          json(
+            {
+              error: 'invalid_supervised_action_keys: bogus_key',
+              code: 'invalid_supervised_action_keys',
+              rejected: [{ key: 'bogus_key', reason: 'not registered in POLICY_DECIDABLE_TIER3' }],
+            },
+            false,
+            422,
+          ),
+        );
+      }
+      if (url.startsWith('/ai/agents')) return Promise.resolve(json({ data: [actAgent] }));
+      if (url === '/roles') return Promise.resolve(json({ data: [] }));
+      return Promise.resolve(json({ data: [] }));
+    });
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.change(await screen.findByTestId('ai-agent-mode'), { target: { value: 'act' } });
+    fireEvent.click(screen.getByTestId('ai-agent-act-ack'));
+    fireEvent.click(screen.getByTestId('ai-agent-save'));
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-issues')).toBeInTheDocument());
+    expect(screen.getByText('bogus_key: not registered in POLICY_DECIDABLE_TIER3')).toBeInTheDocument();
+  });
+
+  it('says the policy-decidable action list could not be loaded rather than rendering an empty registry', async () => {
+    const actAgent = { ...PARTNER_AGENT, supportedModes: ['off', 'shadow', 'act'] as const };
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ error: 'nope' }, false, 500));
+      if (url.startsWith('/ai/agents')) return Promise.resolve(json({ data: [actAgent] }));
+      if (url === '/roles') return Promise.resolve(json({ data: [] }));
+      return Promise.resolve(json({ data: [] }));
+    });
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.change(await screen.findByTestId('ai-agent-mode'), { target: { value: 'act' } });
+
+    expect(await screen.findByTestId('ai-agent-policy-keys-failed')).toBeInTheDocument();
   });
 
   it('requires a confirming second click before disabling an agent', async () => {

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1337,7 +1337,9 @@
       "modeNotSupported": "Dieser Modus ist noch nicht verfügbar. Agenten können derzeit untersuchen und vorschlagen, aber nicht handeln.",
       "actPrerequisitesNotMet": "Dieser Agent ist noch nicht bereit für den Handlungsmodus.",
       "actMissingRecipient": "Fügen Sie mindestens einen Benachrichtigungsempfänger hinzu, bevor Sie den Handlungsmodus aktivieren.",
-      "actMissingTool": "Lassen Sie mindestens ein für den Handlungsmodus geeignetes Tool zu, oder autorisieren Sie ein Skript, bevor Sie ihn aktivieren."
+      "actMissingTool": "Lassen Sie mindestens ein für den Handlungsmodus geeignetes Tool zu, oder autorisieren Sie ein Skript, bevor Sie ihn aktivieren.",
+      "invalidSupervisedActionKeys": "Eine oder mehrere ausgewählte Aktionen können nicht per Richtlinie autorisiert werden.",
+      "supervisedKeyRejected": "{{key}}: {{reason}}"
     },
     "actions": {
       "add": "Neuer Agent",
@@ -1370,6 +1372,7 @@
     "sections": {
       "scope": "Wann er ausgeführt wird",
       "permissions": "Berechtigungen",
+      "policyDecide": "Unbeaufsichtigte Richtlinienautorisierung",
       "limits": "Grenzwerte",
       "notifications": "Benachrichtigungen",
       "instructions": "Anweisungen"
@@ -1423,7 +1426,10 @@
       "recipientRolesEmpty": "Keine Rollen verfügbar.",
       "instructionsHint": "Nur zur Orientierung — Tonfall, was zuerst zu prüfen ist, interne Gepflogenheiten. Es werden dadurch keine Berechtigungen erteilt.",
       "charactersLeft": "Noch {{count}} Zeichen",
-      "recipientRolesFailed": "Rollen konnten nicht geladen werden; Benachrichtigungsempfänger lassen sich derzeit nicht ändern."
+      "recipientRolesFailed": "Rollen konnten nicht geladen werden; Benachrichtigungsempfänger lassen sich derzeit nicht ändern.",
+      "supervisedActionKeysHint": "Vorgänge, die dieser Agent OHNE einen menschlichen Klick auf Genehmigen ausführen darf, wenn eine passende Richtlinie existiert und im Expositionslimit der Organisation noch Spielraum ist. Jeder Vorgang durchläuft zur Ausführungszeit weiterhin die Live-Schutzmechanismen, den Kill-Switch und die Organisationslimits.",
+      "supervisedActionKeysEmpty": "Es sind keine per Richtlinie entscheidbaren Aktionen registriert.",
+      "supervisedActionKeysFailed": "Die Liste der per Richtlinie entscheidbaren Aktionen konnte nicht geladen werden, daher kann die unbeaufsichtigte Autorisierung derzeit nicht geändert werden."
     },
     "loading": "Agenten werden geladen …"
   },

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1337,7 +1337,9 @@
       "modeNotSupported": "That mode is not available yet. Agents can currently investigate and propose, but not act.",
       "actPrerequisitesNotMet": "This agent isn't ready for act mode yet.",
       "actMissingRecipient": "Add at least one notification recipient before enabling act mode.",
-      "actMissingTool": "Allow at least one act-eligible tool, or authorize a script, before enabling act mode."
+      "actMissingTool": "Allow at least one act-eligible tool, or authorize a script, before enabling act mode.",
+      "invalidSupervisedActionKeys": "One or more selected actions can't be authorized by policy.",
+      "supervisedKeyRejected": "{{key}}: {{reason}}"
     },
     "actions": {
       "add": "New agent",
@@ -1370,6 +1372,7 @@
     "sections": {
       "scope": "When it runs",
       "permissions": "Permissions",
+      "policyDecide": "Unattended policy authorization",
       "limits": "Limits",
       "notifications": "Notifications",
       "instructions": "Instructions"
@@ -1423,7 +1426,10 @@
       "recipientRolesEmpty": "No roles available.",
       "instructionsHint": "Guidance only — tone, what to check first, house conventions. It never grants permissions.",
       "charactersLeft": "{{count}} characters left",
-      "recipientRolesFailed": "Couldn't load roles, so notification recipients can't be changed right now."
+      "recipientRolesFailed": "Couldn't load roles, so notification recipients can't be changed right now.",
+      "supervisedActionKeysHint": "Operations this agent may execute WITHOUT a human clicking approve, when a matching policy exists and the org's exposure cap has room. Each one still passes live guardrails, the kill switch, and per-org caps at execution time.",
+      "supervisedActionKeysEmpty": "No policy-decidable actions are registered.",
+      "supervisedActionKeysFailed": "Couldn't load the policy-decidable action list, so unattended authorization can't be changed right now."
     },
     "loading": "Loading agents…"
   },

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1337,7 +1337,9 @@
       "modeNotSupported": "Ese modo aún no está disponible. Por ahora los agentes pueden investigar y proponer, pero no actuar.",
       "actPrerequisitesNotMet": "Este agente aún no está listo para el modo Actuar.",
       "actMissingRecipient": "Agregue al menos un destinatario de notificación antes de habilitar el modo Actuar.",
-      "actMissingTool": "Permita al menos una herramienta apta para el modo Actuar, o autorice un script, antes de habilitarlo."
+      "actMissingTool": "Permita al menos una herramienta apta para el modo Actuar, o autorice un script, antes de habilitarlo.",
+      "invalidSupervisedActionKeys": "Una o más acciones seleccionadas no se pueden autorizar mediante la política.",
+      "supervisedKeyRejected": "{{key}}: {{reason}}"
     },
     "actions": {
       "add": "Nuevo agente",
@@ -1370,6 +1372,7 @@
     "sections": {
       "scope": "Cuándo se ejecuta",
       "permissions": "Permisos",
+      "policyDecide": "Autorización de política no supervisada",
       "limits": "Límites",
       "notifications": "Notificaciones",
       "instructions": "Instrucciones"
@@ -1423,7 +1426,10 @@
       "recipientRolesEmpty": "No hay roles disponibles.",
       "instructionsHint": "Solo orientación: tono, qué revisar primero, convenciones internas. Nunca otorga permisos.",
       "charactersLeft": "Quedan {{count}} caracteres",
-      "recipientRolesFailed": "No se pudieron cargar los roles, así que por ahora no se pueden cambiar los destinatarios de las notificaciones."
+      "recipientRolesFailed": "No se pudieron cargar los roles, así que por ahora no se pueden cambiar los destinatarios de las notificaciones.",
+      "supervisedActionKeysHint": "Operaciones que este agente puede ejecutar SIN que una persona haga clic en aprobar, cuando existe una política coincidente y el límite de exposición de la organización tiene margen. Cada una igual pasa por las protecciones en vivo, el interruptor de apagado y los límites por organización en el momento de la ejecución.",
+      "supervisedActionKeysEmpty": "No hay acciones decidibles por política registradas.",
+      "supervisedActionKeysFailed": "No se pudo cargar la lista de acciones decidibles por política, así que la autorización no supervisada no se puede cambiar en este momento."
     },
     "loading": "Cargando agentes…"
   },

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1337,7 +1337,9 @@
       "modeNotSupported": "Ce mode n’est pas encore disponible. Les agents peuvent pour l’instant enquêter et proposer, mais pas agir.",
       "actPrerequisitesNotMet": "Cet agent n’est pas encore prêt pour le mode Agir.",
       "actMissingRecipient": "Ajoutez au moins un destinataire de notification avant d’activer le mode Agir.",
-      "actMissingTool": "Autorisez au moins un outil éligible au mode Agir, ou autorisez un script, avant de l’activer."
+      "actMissingTool": "Autorisez au moins un outil éligible au mode Agir, ou autorisez un script, avant de l’activer.",
+      "invalidSupervisedActionKeys": "Une ou plusieurs actions sélectionnées ne peuvent pas être autorisées par la politique.",
+      "supervisedKeyRejected": "{{key}}: {{reason}}"
     },
     "actions": {
       "add": "Nouvel agent",
@@ -1370,6 +1372,7 @@
     "sections": {
       "scope": "Quand il s’exécute",
       "permissions": "Autorisations",
+      "policyDecide": "Autorisation de politique sans surveillance",
       "limits": "Limites",
       "notifications": "Notifications",
       "instructions": "Directives"
@@ -1423,7 +1426,10 @@
       "recipientRolesEmpty": "Aucun rôle disponible.",
       "instructionsHint": "Simples consignes — ton, ce qu’il faut vérifier en premier, conventions internes. N’accorde jamais d’autorisations.",
       "charactersLeft": "{{count}} caractères restants",
-      "recipientRolesFailed": "Impossible de charger les rôles ; les destinataires des notifications ne peuvent pas être modifiés pour le moment."
+      "recipientRolesFailed": "Impossible de charger les rôles ; les destinataires des notifications ne peuvent pas être modifiés pour le moment.",
+      "supervisedActionKeysHint": "Opérations que cet agent peut exécuter SANS qu’un humain clique sur approuver, lorsqu’une politique correspondante existe et que le plafond d’exposition de l’organisation le permet. Chacune passe tout de même par les garde-fous en direct, l’interrupteur d’arrêt et les plafonds par organisation au moment de l’exécution.",
+      "supervisedActionKeysEmpty": "Aucune action décidable par politique n’est enregistrée.",
+      "supervisedActionKeysFailed": "Impossible de charger la liste des actions décidables par politique ; l’autorisation sans surveillance ne peut pas être modifiée pour le moment."
     },
     "loading": "Chargement des agents en cours…"
   },

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1337,7 +1337,9 @@
       "modeNotSupported": "Ce mode n’est pas encore disponible. Les agents peuvent pour l’instant enquêter et proposer, mais pas agir.",
       "actPrerequisitesNotMet": "Cet agent n’est pas encore prêt pour le mode Agir.",
       "actMissingRecipient": "Ajoutez au moins un destinataire de notification avant d’activer le mode Agir.",
-      "actMissingTool": "Autorisez au moins un outil éligible au mode Agir, ou autorisez un script, avant de l’activer."
+      "actMissingTool": "Autorisez au moins un outil éligible au mode Agir, ou autorisez un script, avant de l’activer.",
+      "invalidSupervisedActionKeys": "Une ou plusieurs actions sélectionnées ne peuvent pas être autorisées par la politique.",
+      "supervisedKeyRejected": "{{key}}: {{reason}}"
     },
     "actions": {
       "add": "Nouvel agent",
@@ -1370,6 +1372,7 @@
     "sections": {
       "scope": "Quand il s’exécute",
       "permissions": "Autorisations",
+      "policyDecide": "Autorisation de politique sans surveillance",
       "limits": "Limites",
       "notifications": "Notifications",
       "instructions": "Consignes"
@@ -1423,7 +1426,10 @@
       "recipientRolesEmpty": "Aucun rôle disponible.",
       "instructionsHint": "Simples consignes — ton, ce qu’il faut vérifier en premier, conventions internes. N’accorde jamais d’autorisations.",
       "charactersLeft": "{{count}} caractères restants",
-      "recipientRolesFailed": "Impossible de charger les rôles ; les destinataires des notifications ne peuvent pas être modifiés pour le moment."
+      "recipientRolesFailed": "Impossible de charger les rôles ; les destinataires des notifications ne peuvent pas être modifiés pour le moment.",
+      "supervisedActionKeysHint": "Opérations que cet agent peut exécuter SANS qu’un humain clique sur approuver, lorsqu’une politique correspondante existe et que le plafond d’exposition de l’organisation le permet. Chacune passe tout de même par les garde-fous en direct, l’interrupteur d’arrêt et les plafonds par organisation au moment de l’exécution.",
+      "supervisedActionKeysEmpty": "Aucune action décidable par politique n’est enregistrée.",
+      "supervisedActionKeysFailed": "Impossible de charger la liste des actions décidables par politique ; l’autorisation sans surveillance ne peut pas être modifiée pour le moment."
     },
     "loading": "Chargement des agents…"
   },

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1337,7 +1337,9 @@
       "modeNotSupported": "Questa modalità non è ancora disponibile. Per ora gli agenti possono indagare e proporre, ma non agire.",
       "actPrerequisitesNotMet": "Questo agente non è ancora pronto per la modalità Agire.",
       "actMissingRecipient": "Aggiungi almeno un destinatario di notifica prima di attivare la modalità Agire.",
-      "actMissingTool": "Consenti almeno uno strumento idoneo per la modalità Agire, oppure autorizza uno script, prima di attivarla."
+      "actMissingTool": "Consenti almeno uno strumento idoneo per la modalità Agire, oppure autorizza uno script, prima di attivarla.",
+      "invalidSupervisedActionKeys": "Una o più azioni selezionate non possono essere autorizzate dalla policy.",
+      "supervisedKeyRejected": "{{key}}: {{reason}}"
     },
     "actions": {
       "add": "Nuovo agente",
@@ -1370,6 +1372,7 @@
     "sections": {
       "scope": "Quando viene eseguito",
       "permissions": "Autorizzazioni",
+      "policyDecide": "Autorizzazione della policy non presidiata",
       "limits": "Limiti",
       "notifications": "Notifiche",
       "instructions": "Istruzioni"
@@ -1423,7 +1426,10 @@
       "recipientRolesEmpty": "Nessun ruolo disponibile.",
       "instructionsHint": "Solo indicazioni — tono, cosa controllare per primo, convenzioni interne. Non concede mai autorizzazioni.",
       "charactersLeft": "{{count}} caratteri rimasti",
-      "recipientRolesFailed": "Impossibile caricare i ruoli: al momento i destinatari delle notifiche non possono essere modificati."
+      "recipientRolesFailed": "Impossibile caricare i ruoli: al momento i destinatari delle notifiche non possono essere modificati.",
+      "supervisedActionKeysHint": "Operazioni che questo agente può eseguire SENZA che un essere umano clicchi su approva, quando esiste una policy corrispondente e il limite di esposizione dell'organizzazione ha margine. Ognuna passa comunque attraverso le protezioni live, l'interruttore di emergenza e i limiti per organizzazione al momento dell'esecuzione.",
+      "supervisedActionKeysEmpty": "Nessuna azione decidibile tramite policy è registrata.",
+      "supervisedActionKeysFailed": "Impossibile caricare l'elenco delle azioni decidibili tramite policy, quindi l'autorizzazione non presidiata non può essere modificata al momento."
     },
     "loading": "Caricamento degli agenti…"
   },

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1337,7 +1337,9 @@
       "modeNotSupported": "Esse modo ainda não está disponível. Por enquanto os agentes podem investigar e propor, mas não agir.",
       "actPrerequisitesNotMet": "Este agente ainda não está pronto para o modo Agir.",
       "actMissingRecipient": "Adicione pelo menos um destinatário de notificação antes de ativar o modo Agir.",
-      "actMissingTool": "Permita pelo menos uma ferramenta elegível para o modo Agir, ou autorize um script, antes de ativá-lo."
+      "actMissingTool": "Permita pelo menos uma ferramenta elegível para o modo Agir, ou autorize um script, antes de ativá-lo.",
+      "invalidSupervisedActionKeys": "Uma ou mais ações selecionadas não podem ser autorizadas pela política.",
+      "supervisedKeyRejected": "{{key}}: {{reason}}"
     },
     "actions": {
       "add": "Novo agente",
@@ -1370,6 +1372,7 @@
     "sections": {
       "scope": "Quando é executado",
       "permissions": "Permissões",
+      "policyDecide": "Autorização de política não supervisionada",
       "limits": "Limites",
       "notifications": "Notificações",
       "instructions": "Instruções"
@@ -1423,7 +1426,10 @@
       "recipientRolesEmpty": "Nenhuma função disponível.",
       "instructionsHint": "Apenas orientação — tom, o que verificar primeiro, convenções internas. Nunca concede permissões.",
       "charactersLeft": "Restam {{count}} caracteres",
-      "recipientRolesFailed": "Não foi possível carregar as funções, então os destinatários das notificações não podem ser alterados agora."
+      "recipientRolesFailed": "Não foi possível carregar as funções, então os destinatários das notificações não podem ser alterados agora.",
+      "supervisedActionKeysHint": "Operações que este agente pode executar SEM um humano clicar em aprovar, quando existe uma política correspondente e o limite de exposição da organização tem espaço. Cada uma ainda passa pelas proteções em tempo real, pelo interruptor de interrupção e pelos limites por organização no momento da execução.",
+      "supervisedActionKeysEmpty": "Nenhuma ação decidível por política está registrada.",
+      "supervisedActionKeysFailed": "Não foi possível carregar a lista de ações decidíveis por política, então a autorização não supervisionada não pode ser alterada agora."
     },
     "loading": "Carregando agentes…"
   },

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1337,7 +1337,9 @@
       "modeNotSupported": "Bu mod henüz kullanılamıyor. Aracılar şimdilik inceleyip önerebilir, ancak uygulayamaz.",
       "actPrerequisitesNotMet": "Bu aracı uygula modu için henüz hazır değil.",
       "actMissingRecipient": "Uygula modunu etkinleştirmeden önce en az bir bildirim alıcısı ekleyin.",
-      "actMissingTool": "Uygula modunu etkinleştirmeden önce en az bir uygulanabilir aracı izin verin veya bir betiği yetkilendirin."
+      "actMissingTool": "Uygula modunu etkinleştirmeden önce en az bir uygulanabilir aracı izin verin veya bir betiği yetkilendirin.",
+      "invalidSupervisedActionKeys": "Seçilen işlemlerden biri veya birkaçı politika tarafından yetkilendirilemez.",
+      "supervisedKeyRejected": "{{key}}: {{reason}}"
     },
     "actions": {
       "add": "Yeni aracı",
@@ -1370,6 +1372,7 @@
     "sections": {
       "scope": "Ne zaman çalışır",
       "permissions": "İzinler",
+      "policyDecide": "Gözetimsiz politika yetkilendirmesi",
       "limits": "Sınırlar",
       "notifications": "Bildirimler",
       "instructions": "Yönergeler"
@@ -1423,7 +1426,10 @@
       "recipientRolesEmpty": "Kullanılabilir rol yok.",
       "instructionsHint": "Yalnızca yönlendirme — üslup, önce neyin denetleneceği, kurum içi teamüller. Asla izin vermez.",
       "charactersLeft": "{{count}} karakter kaldı",
-      "recipientRolesFailed": "Roller yüklenemedi, bu nedenle bildirim alıcıları şu anda değiştirilemiyor."
+      "recipientRolesFailed": "Roller yüklenemedi, bu nedenle bildirim alıcıları şu anda değiştirilemiyor.",
+      "supervisedActionKeysHint": "Eşleşen bir politika varsa ve kuruluşun maruziyet sınırında yer varsa, bu aracının bir insan onaylamadan gerçekleştirebileceği işlemler. Her biri yürütme anında yine de canlı korumalardan, kapatma anahtarından ve kuruluş başına sınırlardan geçer.",
+      "supervisedActionKeysEmpty": "Politikayla karar verilebilecek işlem kayıtlı değil.",
+      "supervisedActionKeysFailed": "Politikayla karar verilebilecek işlem listesi yüklenemedi, bu nedenle gözetimsiz yetkilendirme şu anda değiştirilemiyor."
     },
     "loading": "Aracılar yükleniyor…"
   },

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -229,6 +229,9 @@ x-api-env: &api-env
   # Durable event dispatch (wave 3.5c, #4085; optional, defaults to off).
   EVENT_DISPATCH_MODE: ${EVENT_DISPATCH_MODE:-off}
   EVENT_DISPATCH_QUEUE_SUBSCRIBERS: ${EVENT_DISPATCH_QUEUE_SUBSCRIBERS:-}
+  # Wave 5 Part B (#3827) sub-flag of BREEZE_AI_AGENTS_ENABLED — gates
+  # attemptPolicyDecision; default off (dark-ship). See .env.example.
+  BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED: ${BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED:-false}
   # Native APNs push for the iOS app (all optional; unset = push disabled).
   # All-or-none: setting ANY of these makes the four credentials required,
   # so a half-configured relay fails at boot instead of silently at first

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -251,6 +251,8 @@ x-api-env: &api-env
   # a pgvector-capable Postgres — see POSTGRES_IMAGE_REF in .env.example.
   BREEZE_WORKSPACE_ENABLED: ${BREEZE_WORKSPACE_ENABLED:-false}
   BREEZE_AI_AGENTS_ENABLED: ${BREEZE_AI_AGENTS_ENABLED:-false}
+  # Wave 5 Part B (#3827) sub-flag — see .env.example for what it gates.
+  BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED: ${BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED:-false}
   # MCP OAuth (off by default, opt-in via env)
   MCP_OAUTH_ENABLED: ${MCP_OAUTH_ENABLED:-false}
   OAUTH_ISSUER: ${OAUTH_ISSUER:-}

--- a/docs/superpowers/plans/ai-mcp/2026-08-28-ai-agents-wave5-b-policy-decide.md
+++ b/docs/superpowers/plans/ai-mcp/2026-08-28-ai-agents-wave5-b-policy-decide.md
@@ -46,7 +46,7 @@ wave: W06 (#3827) — Part B (the policy-decide lane)
 
 - Shared: `AiAgentActAssets` gains `supervisedActionKeys?: string[]` (validator: max 50, each key validated by `validateAuthorizationKeys` from `policyDecidable.ts` — write-time rejection of unknown/four_eyes/T4/secret keys with a structured 422). Effective-policy merge: org may only NARROW partner baseline (set intersection; absent partner field ⇒ org value stands alone iff the agent row IS the partner baseline — mirror how `scriptIds` merges today, grep it and match exactly). Snapshot: rides `actAssets` (v3 already tolerant).
 - Env flag full parity ceremony + `policyDecideEnabled()` helper (eventDispatchMode style).
-- [ ] TDD (validator matrix, intersection merge, flag helper) → commit: `feat(shared,api): supervisedActionKeys authorization set + policy-decide flag (#3827)`
+- [x] TDD (validator matrix, intersection merge, flag helper) → commit: `feat(shared,api): supervisedActionKeys authorization set + policy-decide flag (#3827)`
 
 ---
 
@@ -57,7 +57,7 @@ wave: W06 (#3827) — Part B (the policy-decide lane)
 - `attemptPolicyDecision(intentId)`: load intent (state must be `unattempted`, status `pending_approval`, not expired — else no-op); canonical key from `actionName` + `arguments.action` (multiplexed tools use `tool:action`; derive EXACTLY the way `checkGuardrails` resolves the action — reuse its resolution helper, never re-implement); pipeline per the header. Deterministic failures (key not in registry / not headlessCompatible / not in effective `supervisedActionKeys` / guardrail non-allow / kill engaged / caps exhausted / intent expired) → CAS state `unattempted → human_required` + `runHumanFanout` via a new exported `runDeferredHumanFanout(intentId)` (re-derives the approver pools the way creation did — extract what's needed; the fanout must produce the SAME approval rows + notifications creation would have) + if fanout yields zero approvers, the existing no-eligible-approver cancellation semantics. Transient failures (DB/Redis errors) → log + leave `unattempted`.
 - The authorize transaction (all-or-nothing): `pg_advisory_xact_lock` on the org exposure key → fleet-percent check (distinct exposure devices ∪ {this device} vs `floor(countContractDevices × maxFleetPercentPerDay/100)`) → day-cap check (count policy-authorized intents for this agent's org trailing 24h — count exposure rows `source='policy_intent'`) → insert exposure row (`source:'policy_intent'`, intent_id, run/agent/device/org) → CAS intent `pending_approval → approved` + `policy_decision_state:'authorized'` + `decidedAt` + `decidedVia:'policy'` + NULL decider/assurance + provenance (key, snapshot digest = the run's `policySnapshot` content hash — reuse/extract the digest helper the release evidence will recompute, classification version, reservation id = exposure row id, kill epoch) → outbox `intent_approved`. Audit: `initiatedBy: 'policy'`, actorType `'system'`, agent/run/key in details. Notification to recipients ("authorized automatically by policy — executing").
 - Outbox recovery: `processIntentReleaseJob`'s `intent_created` branch (currently no-op) → when the intent is agent-originated ∧ `policy_decision_state === 'unattempted'` ∧ flag on → `attemptPolicyDecision`; else no-op as today.
-- [ ] TDD: the full matrix (each deterministic failure → human_required + fanout ran; transient → unattempted; success → all six writes in one tx — assert via mock tx capture; double-attempt idempotence: second attempt sees state ≠ unattempted → no-op; expired intent → human path). Commit: `feat(api): attemptPolicyDecision — policy-satisfied supervised authorization with atomic exposure reservation (#3827)`
+- [x] TDD: the full matrix (each deterministic failure → human_required + fanout ran; transient → unattempted; success → all six writes in one tx — assert via mock tx capture; double-attempt idempotence: second attempt sees state ≠ unattempted → no-op; expired intent → human path). Commit: `feat(api): attemptPolicyDecision — policy-satisfied supervised authorization with atomic exposure reservation (#3827)`
 
 ---
 
@@ -65,7 +65,7 @@ wave: W06 (#3827) — Part B (the policy-decide lane)
 
 - `intentReleaseWorker` fetch: when no approved human row exists, load the intent's policy columns; `revalidateApprovedIntentForRelease` gains the branch: `decidedVia === 'policy' ∧ policy_decision_state === 'authorized'` → REQUIRE: digest recompute (existing chain), provenance present, key still in `POLICY_DECIDABLE_TIER3` ∧ headlessCompatible (registry drop ⇒ `policy_authorization_revoked` fail, terminal, notify), key still in BOTH the run snapshot's `actAssets.supervisedActionKeys` AND the agent's CURRENT effective policy, flag still on, kill state re-read not killed. Any human-row path untouched. `checkAgentReleaseAuthority` for policy-decided intents: the guardrail disposition must map to an EXACT current authorization (reuse the same key check — 'propose' is NOT sufficient here, unlike human-approved intents; codex finding).
 - Final pre-effect kill read: immediately before the `executeTool` dispatch in the release worker, one more `readAiKillState()` → killed ⇒ the Part-A `kill_switch_engaged` pause path.
-- [ ] TDD: human-approved intents byte-identical (full release suites); policy intents: each evidence failure → correct terminal/pause; the never-synthesize-human-row property (grep-assert no approval_requests insert in the new code). Commit: `feat(api): policy-evidence release branch — supervised intents execute on durable policy proof (#3827)`
+- [x] TDD: human-approved intents byte-identical (full release suites); policy intents: each evidence failure → correct terminal/pause; the never-synthesize-human-row property (grep-assert no approval_requests insert in the new code). Commit: `feat(api): policy-evidence release branch — supervised intents execute on durable policy proof (#3827)`
 
 ---
 
@@ -73,7 +73,7 @@ wave: W06 (#3827) — Part B (the policy-decide lane)
 
 - `revalidateActExecution` reservation step: also inserts an exposure row (`source:'act'`, intent_id NULL) inside a short system context (NOT held across dispatch — #1105) + gains the same fleet-percent check (advisory-lock + floor) BEFORE reserving; exhaustion → the existing `downgrade` path (proposal). Flag-independent? The exposure WRITE is unconditional post-merge (accounting is truth); the fleet CAP enforcement in the act lane activates with the same sub-flag to keep wave-4 behavior unchanged until wave 5 turns on (document).
 - `aiUnattendedExposureRetention` worker: daily sweep deleting rows `reserved_at < now() - 48h` (registry + both snapshot lists 106 → 107 + closure verdict).
-- [ ] TDD: act path writes rows; cap downgrade; retention query; registry losslessness updated. Commit: `feat(api): act-lane exposure accounting + ledger retention (#3827)`
+- [x] TDD: act path writes rows; cap downgrade; retention query; registry losslessness updated. Commit: `feat(api): act-lane exposure accounting + ledger retention (#3827)`
 
 ---
 
@@ -82,13 +82,13 @@ wave: W06 (#3827) — Part B (the policy-decide lane)
 - Null-decider audit completion: approvals list/detail routes + web approvals components render `decidedVia === 'policy'` as "Authorized automatically by policy" (never a person; never "approved by agent"); exports already classify the columns (Part A). Grep every `decidedByUserId` consumer and prove each tolerates NULL+policy (the codex B-item).
 - Agent form: `supervisedActionKeys` multi-select sourced from the registry (grouped by tool), gated behind the act acknowledgement pattern; 422 surfacing for rejected keys; i18n keys in every locale.
 - Activation prerequisite extension: an agent whose mode is `act` with `supervisedActionKeys` non-empty requires the same recipients prerequisite (already enforced) — verify no new gate needed; policy-decide with mode `shadow`: DECISION (locked, conservative): policy-decide requires `mode === 'act'` — a shadow agent never gets policy-authorized intents (its proposals stay human). Enforce in `resolvePolicyDecisionState` (mode from the run's snapshot) + test.
-- [ ] TDD + web tests + locale parity → commit: `feat(api,web): policy-decision read tolerance, approvals UI, supervisedActionKeys editor (#3827)`
+- [x] TDD + web tests + locale parity → commit: `feat(api,web): policy-decision read tolerance, approvals UI, supervisedActionKeys editor (#3827)`
 
 ---
 
 ### Task 6: Verification + PR
 
-- [ ] Full api + shared + web-touched + typecheck + contract suites + envComposeParity + closure/registry snapshots; grep sweeps: no approval_requests insert in policyDecide/release-evidence code; `runHumanFanout` callers = creation + `runDeferredHumanFanout` only; flag-off inertness proof = full intentService suite + one explicit flag-off e2e test.
+- [x] Full api + shared + web-touched + typecheck + contract suites + envComposeParity + closure/registry snapshots; grep sweeps: no approval_requests insert in policyDecide/release-evidence code; `runHumanFanout` callers = creation + `runDeferredHumanFanout` only; flag-off inertness proof = full intentService suite + one explicit flag-off e2e test.
 - [ ] Tick checkboxes. **Open the PR**: `feature/3821-ai-agents/wave-3827-b` → main, `Closes #3827`, body: locked decisions table, the dark-ship statement, the act-lane cap activation note, rollout guidance (flag on → operator authorizes keys per agent → caps observable in the ledger), follow-ups (admin kill-state surface, per-lane kill-cache isolation, registry growth quorum process). **Stop after opening the PR.**
 
 ## Self-Review Notes

--- a/docs/superpowers/plans/ai-mcp/2026-08-28-ai-agents-wave5-b-policy-decide.md
+++ b/docs/superpowers/plans/ai-mcp/2026-08-28-ai-agents-wave5-b-policy-decide.md
@@ -1,0 +1,98 @@
+---
+tracking_issue: LanternOps/breeze#3821
+wave: W06 (#3827) — Part B (the policy-decide lane)
+---
+
+# Wave 5 Part B — Policy-Decide Lane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bounded unattended Tier-3 goes live (dark): an agent-originated `supervised`-scope intent whose operation the OPERATOR explicitly authorized (per-agent `actAssets.supervisedActionKeys` ⊆ the `POLICY_DECIDABLE_TIER3` registry) is authorized by policy — atomically reserving org-wide blast capacity, stamping durable provenance, skipping human fanout — and executes through the EXISTING release pipeline with a new policy-evidence branch; everything else (unauthorized keys, cap overflow, drift, kill) degrades to the normal human intent. Everything sits behind `BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED` (default off).
+
+**Architecture:** `resolvePolicyDecisionState` (Part A's stub) becomes real: agent-originated + supervised + flag on → state `unattempted`, fanout NOT run, and `attemptPolicyDecision(intentId)` is invoked post-commit (plus at-least-once recovery via the outbox `intent_created` consumer branch for `unattempted` intents). The attempt pipeline: canonical key → registry ∧ headlessCompatible ∧ agent authorization → live guardrail re-run → kill state → caps (`maxFleetPercentPerDay` floor() over `ai_unattended_exposure` distinct devices ∪ act-lane rows, `maxPolicyDecisionsPerDay`) → ONE transaction: exposure reservation insert + CAS `pending_approval → approved` + `decidedVia:'policy'`/NULL user/NULL assurance + provenance columns + `policy_decision_state:'authorized'` + outbox `intent_approved`. Deterministic failure → CAS state `unattempted → human_required` + `runHumanFanout` (the deferred fanout from Part A). Transient failure → leave `unattempted` for redelivery. Release: `revalidateApprovedIntentForRelease` gains a policy-evidence branch (NO human approval row required when `decidedVia === 'policy'` — instead: digest recompute + registry/authorization re-check in BOTH snapshot and current policy + kill-epoch sanity + final pre-effect kill re-read); `checkAgentReleaseAuthority`'s predicate for policy-decided intents requires exact current authorization, not merely not-denied. The wave-4 act lane starts writing exposure rows too (shared accounting) and gains the fleet-percent cap. Approvals UI renders "authorized automatically by policy"; the agent form edits `supervisedActionKeys` with the act-mode acknowledgement pattern.
+
+**Tech Stack:** TypeScript, Drizzle, Vitest (+ web + i18n). **No migrations** (`supervisedActionKeys` extends the existing `act_assets` jsonb; everything else landed in Part A). One new env var (full parity ceremony).
+
+**Design authority — LOCKED quorum decisions (2026-08-28), do not relitigate:** policy is a mechanism, not a principal (`decidedVia:'policy'`, NULL user, NULL assurance — no sentinel, no synthetic human approval row EVER); fanout only after `human_required`; deterministic-vs-transient failure distinction is load-bearing (a crashed attempt must be distinguishable from a rejected one); org-wide exposure numerator = distinct devices across ALL unattended mutating executions (act + policy) trailing 24h; allowance = `floor(fleet × pct/100)` with NO `max(1,·)` (zero allowance for tiny fleets is correct; the operator raises pct) + the absolute day cap as a second ceiling; denominator = `countContractDevices(orgId, null)`; reservation atomic with the approval CAS (DB-backed, never count-then-write); release must re-check authorization in snapshot AND current policy + a final pre-effect kill read; four_eyes/T4/secrets/`decideHandler` untouched; stored authorization keys tolerated-but-inert when the registry drops them; run outcome must distinguish policy-authorized from awaiting_approval.
+
+## Global Constraints
+
+- **Dark-ship**: flag off → `resolvePolicyDecisionState` returns `human_required` exactly as Part A (byte-identical inertness); every new path is unreachable. The flag: `BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED` (bool, default false) — env.ts + validate.ts + `.env.example` + BOTH compose api env anchors (`envComposeParity` enforces).
+- Run tests as `cd apps/api && npx vitest run <path>`; typecheck with heap bump; shared edits: `pnpm --filter @breeze/shared test`; new web strings in every locale (tr-TR parity).
+- The exposure reservation + approval CAS + provenance + outbox MUST be one transaction (the quorum's oversubscription requirement). The fleet count reads inside that transaction (`SELECT count(DISTINCT device_id) FROM ai_unattended_exposure WHERE org_id = … AND reserved_at > now() - interval '24 hours'` FOR the insert-guard — document why plain READ COMMITTED + the reservation insert is race-acceptable: two concurrent attempts can each read N-1 and both insert, overshooting by one device max per race; mitigate with a per-org advisory xact lock `pg_advisory_xact_lock(hashtextextended('ai-exposure:' || org_id, 0))` inside the transaction — cheap, correct, single-row-hot).
+- Do-not-touch inventory (byte-identical): `decideHandler`'s human gate, `createActionIntent` tier guards, TIER3_FOUR_EYES sets, secret-bearing denies, the human decide CAS path.
+- Ledger retention: 48h sweep — extend an EXISTING retention worker family (grep the retention workers registered in `workerRegistry`; add `aiUnattendedExposureRetention` following the closest sibling's shape, registry + snapshots 106 → 107 with the closure contract verdict).
+- Commit after every task with trailers:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+  `Claude-Session: https://claude.ai/code/session_012o7QB15EFjEvetDAXMxmae`
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `apps/api/src/services/actionIntents/policyDecide.ts` (new) | `attemptPolicyDecision` pipeline + the atomic authorize transaction + caps. |
+| `apps/api/src/services/actionIntents/intentService.ts` (modify) | Real `resolvePolicyDecisionState`; post-commit attempt trigger; `human_required` degrade path callable post-creation. |
+| `apps/api/src/jobs/intentReleaseWorker.ts` + `services/actionIntents/revalidateRelease.ts` + `agentReleaseAuthority.ts` (modify) | Policy-evidence release branch + stricter predicate + final pre-effect kill read. |
+| `apps/api/src/services/aiAgents/actRevalidation.ts` (modify) | Act-lane exposure-row writes + fleet-percent cap. |
+| `apps/api/src/jobs/aiUnattendedExposureRetention.ts` (new) + `workerRegistry.ts` | 48h ledger sweep. |
+| `packages/shared` (modify) | `AiAgentActAssets.supervisedActionKeys`, validator (keys validated via `validateAuthorizationKeys`), effective-policy intersection merge. |
+| `apps/api/src/services/aiAgents/agentService.ts` + `routes/aiAgents.ts` (modify) | Write-time key validation + act/policy prerequisites surface. |
+| `apps/api/src/routes/approvals.ts` (read paths) + `apps/web` approvals + agent form (modify) | Null-decider tolerance + "authorized automatically by policy" + `supervisedActionKeys` editor. |
+| env/validate/compose/.env.example (modify) | The sub-flag. |
+
+---
+
+### Task 1: `supervisedActionKeys` + flag + merge semantics
+
+- Shared: `AiAgentActAssets` gains `supervisedActionKeys?: string[]` (validator: max 50, each key validated by `validateAuthorizationKeys` from `policyDecidable.ts` — write-time rejection of unknown/four_eyes/T4/secret keys with a structured 422). Effective-policy merge: org may only NARROW partner baseline (set intersection; absent partner field ⇒ org value stands alone iff the agent row IS the partner baseline — mirror how `scriptIds` merges today, grep it and match exactly). Snapshot: rides `actAssets` (v3 already tolerant).
+- Env flag full parity ceremony + `policyDecideEnabled()` helper (eventDispatchMode style).
+- [ ] TDD (validator matrix, intersection merge, flag helper) → commit: `feat(shared,api): supervisedActionKeys authorization set + policy-decide flag (#3827)`
+
+---
+
+### Task 2: `attemptPolicyDecision` + the real `resolvePolicyDecisionState`
+
+- `resolvePolicyDecisionState(inserted, ctx)`: `'unattempted'` iff flag on ∧ agent-originated ∧ `approvalScope === 'supervised'`; else `'human_required'` (flag off ⇒ Part-A behavior byte-identical — assert with the full intentService suite).
+- `createActionIntent`: when state `unattempted`, skip `runHumanFanout`, still write outbox `intent_created`; post-commit (AFTER the transaction — never inside), fire-and-forget `attemptPolicyDecision(inserted.id)` with error swallow (outbox redelivery is the safety net).
+- `attemptPolicyDecision(intentId)`: load intent (state must be `unattempted`, status `pending_approval`, not expired — else no-op); canonical key from `actionName` + `arguments.action` (multiplexed tools use `tool:action`; derive EXACTLY the way `checkGuardrails` resolves the action — reuse its resolution helper, never re-implement); pipeline per the header. Deterministic failures (key not in registry / not headlessCompatible / not in effective `supervisedActionKeys` / guardrail non-allow / kill engaged / caps exhausted / intent expired) → CAS state `unattempted → human_required` + `runHumanFanout` via a new exported `runDeferredHumanFanout(intentId)` (re-derives the approver pools the way creation did — extract what's needed; the fanout must produce the SAME approval rows + notifications creation would have) + if fanout yields zero approvers, the existing no-eligible-approver cancellation semantics. Transient failures (DB/Redis errors) → log + leave `unattempted`.
+- The authorize transaction (all-or-nothing): `pg_advisory_xact_lock` on the org exposure key → fleet-percent check (distinct exposure devices ∪ {this device} vs `floor(countContractDevices × maxFleetPercentPerDay/100)`) → day-cap check (count policy-authorized intents for this agent's org trailing 24h — count exposure rows `source='policy_intent'`) → insert exposure row (`source:'policy_intent'`, intent_id, run/agent/device/org) → CAS intent `pending_approval → approved` + `policy_decision_state:'authorized'` + `decidedAt` + `decidedVia:'policy'` + NULL decider/assurance + provenance (key, snapshot digest = the run's `policySnapshot` content hash — reuse/extract the digest helper the release evidence will recompute, classification version, reservation id = exposure row id, kill epoch) → outbox `intent_approved`. Audit: `initiatedBy: 'policy'`, actorType `'system'`, agent/run/key in details. Notification to recipients ("authorized automatically by policy — executing").
+- Outbox recovery: `processIntentReleaseJob`'s `intent_created` branch (currently no-op) → when the intent is agent-originated ∧ `policy_decision_state === 'unattempted'` ∧ flag on → `attemptPolicyDecision`; else no-op as today.
+- [ ] TDD: the full matrix (each deterministic failure → human_required + fanout ran; transient → unattempted; success → all six writes in one tx — assert via mock tx capture; double-attempt idempotence: second attempt sees state ≠ unattempted → no-op; expired intent → human path). Commit: `feat(api): attemptPolicyDecision — policy-satisfied supervised authorization with atomic exposure reservation (#3827)`
+
+---
+
+### Task 3: Policy-evidence release branch + stricter predicate + final kill read
+
+- `intentReleaseWorker` fetch: when no approved human row exists, load the intent's policy columns; `revalidateApprovedIntentForRelease` gains the branch: `decidedVia === 'policy' ∧ policy_decision_state === 'authorized'` → REQUIRE: digest recompute (existing chain), provenance present, key still in `POLICY_DECIDABLE_TIER3` ∧ headlessCompatible (registry drop ⇒ `policy_authorization_revoked` fail, terminal, notify), key still in BOTH the run snapshot's `actAssets.supervisedActionKeys` AND the agent's CURRENT effective policy, flag still on, kill state re-read not killed. Any human-row path untouched. `checkAgentReleaseAuthority` for policy-decided intents: the guardrail disposition must map to an EXACT current authorization (reuse the same key check — 'propose' is NOT sufficient here, unlike human-approved intents; codex finding).
+- Final pre-effect kill read: immediately before the `executeTool` dispatch in the release worker, one more `readAiKillState()` → killed ⇒ the Part-A `kill_switch_engaged` pause path.
+- [ ] TDD: human-approved intents byte-identical (full release suites); policy intents: each evidence failure → correct terminal/pause; the never-synthesize-human-row property (grep-assert no approval_requests insert in the new code). Commit: `feat(api): policy-evidence release branch — supervised intents execute on durable policy proof (#3827)`
+
+---
+
+### Task 4: Act-lane shared accounting + retention
+
+- `revalidateActExecution` reservation step: also inserts an exposure row (`source:'act'`, intent_id NULL) inside a short system context (NOT held across dispatch — #1105) + gains the same fleet-percent check (advisory-lock + floor) BEFORE reserving; exhaustion → the existing `downgrade` path (proposal). Flag-independent? The exposure WRITE is unconditional post-merge (accounting is truth); the fleet CAP enforcement in the act lane activates with the same sub-flag to keep wave-4 behavior unchanged until wave 5 turns on (document).
+- `aiUnattendedExposureRetention` worker: daily sweep deleting rows `reserved_at < now() - 48h` (registry + both snapshot lists 106 → 107 + closure verdict).
+- [ ] TDD: act path writes rows; cap downgrade; retention query; registry losslessness updated. Commit: `feat(api): act-lane exposure accounting + ledger retention (#3827)`
+
+---
+
+### Task 5: Read-path tolerance + UI + prerequisites
+
+- Null-decider audit completion: approvals list/detail routes + web approvals components render `decidedVia === 'policy'` as "Authorized automatically by policy" (never a person; never "approved by agent"); exports already classify the columns (Part A). Grep every `decidedByUserId` consumer and prove each tolerates NULL+policy (the codex B-item).
+- Agent form: `supervisedActionKeys` multi-select sourced from the registry (grouped by tool), gated behind the act acknowledgement pattern; 422 surfacing for rejected keys; i18n keys in every locale.
+- Activation prerequisite extension: an agent whose mode is `act` with `supervisedActionKeys` non-empty requires the same recipients prerequisite (already enforced) — verify no new gate needed; policy-decide with mode `shadow`: DECISION (locked, conservative): policy-decide requires `mode === 'act'` — a shadow agent never gets policy-authorized intents (its proposals stay human). Enforce in `resolvePolicyDecisionState` (mode from the run's snapshot) + test.
+- [ ] TDD + web tests + locale parity → commit: `feat(api,web): policy-decision read tolerance, approvals UI, supervisedActionKeys editor (#3827)`
+
+---
+
+### Task 6: Verification + PR
+
+- [ ] Full api + shared + web-touched + typecheck + contract suites + envComposeParity + closure/registry snapshots; grep sweeps: no approval_requests insert in policyDecide/release-evidence code; `runHumanFanout` callers = creation + `runDeferredHumanFanout` only; flag-off inertness proof = full intentService suite + one explicit flag-off e2e test.
+- [ ] Tick checkboxes. **Open the PR**: `feature/3821-ai-agents/wave-3827-b` → main, `Closes #3827`, body: locked decisions table, the dark-ship statement, the act-lane cap activation note, rollout guidance (flag on → operator authorizes keys per agent → caps observable in the ledger), follow-ups (admin kill-state surface, per-lane kill-cache isolation, registry growth quorum process). **Stop after opening the PR.**
+
+## Self-Review Notes
+
+- Safety: policy-decide reachable only via flag ∧ agent-originated ∧ supervised ∧ act-mode ∧ registry ∧ per-agent authorization ∧ live guardrails ∧ kill ∧ caps — eight independent gates, each with a failure test; the human decide path and four_eyes/T4/secrets untouched (do-not-touch greps in Task 6).
+- At-least-once: post-commit attempt + outbox redelivery both funnel through the state CAS — double-authorize impossible (`unattempted → authorized` single transition), double-fanout impossible (`unattempted → human_required` single transition).
+- Type consistency: `runDeferredHumanFanout` (T2) reuses Part A's extraction; provenance digest helper shared by T2 (write) and T3 (verify); exposure insert shape shared by T2/T4.

--- a/packages/shared/src/types/aiAgents.ts
+++ b/packages/shared/src/types/aiAgents.ts
@@ -101,6 +101,24 @@ export interface AiAgentProtectedResources {
  */
 export interface AiAgentActAssets {
   scriptIds: string[];
+  /**
+   * Wave 5 Part B (#3827) — the closed set of `POLICY_DECIDABLE_TIER3`
+   * (apps/api/src/services/actionIntents/policyDecidable.ts) keys an operator
+   * has explicitly authorized for THIS agent to have policy-decided (no human
+   * fanout) when `BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED` is on. Same
+   * tighten-only shape as `scriptIds`: membership here is necessary but never
+   * sufficient — `attemptPolicyDecision` still gates on live guardrails, kill
+   * state, and the exposure caps.
+   *
+   * Optional, unlike `scriptIds`: this field did not exist before this wave,
+   * and `AI_AGENT_POLICY_SNAPSHOT_VERSION` was NOT bumped for it (v3 is
+   * already tolerant of a new key inside `actAssets` — see the version
+   * history below). A run enqueued before this deploy, and a partner/org row
+   * written before this deploy, both carry an `actAssets` object with no
+   * `supervisedActionKeys` key at all — every read site must treat that as
+   * "authorizes nothing" (`?? []`), never throw on its absence.
+   */
+  supervisedActionKeys?: string[];
 }
 
 /** The policy fields that the resolver merges (everything on ai_agents that governs a run). */

--- a/packages/shared/src/validators/aiAgents.test.ts
+++ b/packages/shared/src/validators/aiAgents.test.ts
@@ -102,9 +102,12 @@ describe('aiAgents validators', () => {
   });
 
   describe('actAssets — per-script act authorization', () => {
-    it('defaults to an empty scriptIds list', () => {
-      expect(aiAgentActAssetsSchema.parse({})).toEqual({ scriptIds: [] });
-      expect(aiAgentPolicyFieldsSchema.parse({}).actAssets).toEqual({ scriptIds: [] });
+    it('defaults to an empty scriptIds and supervisedActionKeys list', () => {
+      expect(aiAgentActAssetsSchema.parse({})).toEqual({ scriptIds: [], supervisedActionKeys: [] });
+      expect(aiAgentPolicyFieldsSchema.parse({}).actAssets).toEqual({
+        scriptIds: [],
+        supervisedActionKeys: [],
+      });
     });
 
     it('accepts up to 50 uuid scriptIds and rejects non-uuid entries', () => {
@@ -123,7 +126,37 @@ describe('aiAgents validators', () => {
 
     it('create materializes actAssets with the empty default', () => {
       const created = createAiAgentSchema.parse({ kind: 'triage', name: 'Triage' });
-      expect(created.actAssets).toEqual({ scriptIds: [] });
+      expect(created.actAssets).toEqual({ scriptIds: [], supervisedActionKeys: [] });
+    });
+  });
+
+  describe('actAssets.supervisedActionKeys — wave 5 Part B (#3827) shape only', () => {
+    it('accepts a bare-tool or tool:action key (TOOL_REF format) and rejects a malformed one', () => {
+      expect(aiAgentActAssetsSchema.safeParse({ supervisedActionKeys: ['manage_services:restart'] }).success)
+        .toBe(true);
+      expect(aiAgentActAssetsSchema.safeParse({ supervisedActionKeys: ['security_scan'] }).success).toBe(true);
+      expect(aiAgentActAssetsSchema.safeParse({ supervisedActionKeys: ['Not Valid!'] }).success).toBe(false);
+      expect(aiAgentActAssetsSchema.safeParse({ supervisedActionKeys: ['a:b:c'] }).success).toBe(false);
+    });
+
+    it('caps at 50 entries', () => {
+      const keys = Array(50).fill('manage_services:restart');
+      expect(aiAgentActAssetsSchema.safeParse({ supervisedActionKeys: keys }).success).toBe(true);
+      expect(aiAgentActAssetsSchema.safeParse({ supervisedActionKeys: [...keys, 'security_scan:remove'] }).success)
+        .toBe(false);
+    });
+
+    it('a PATCH of only supervisedActionKeys does not invent scriptIds', () => {
+      expect(updateAiAgentSchema.parse({ actAssets: { supervisedActionKeys: ['security_scan:quarantine'] } }))
+        .toEqual({ actAssets: { supervisedActionKeys: ['security_scan:quarantine'] } });
+    });
+
+    it('does NOT perform registry/four_eyes/secret semantic rejection — that is API-only (agentService.ts)', () => {
+      // Shared has no access to POLICY_DECIDABLE_TIER3 / aiGuardrails.ts, so an
+      // unregistered-but-TOOL_REF-shaped key passes shape validation here; the
+      // write-time 422 comes from validateAuthorizationKeys in the API layer.
+      expect(aiAgentActAssetsSchema.safeParse({ supervisedActionKeys: ['not_a_real_tool:whatever'] }).success)
+        .toBe(true);
     });
   });
 });

--- a/packages/shared/src/validators/aiAgents.ts
+++ b/packages/shared/src/validators/aiAgents.ts
@@ -98,12 +98,23 @@ export const aiAgentProtectedResourcesSchema = aiAgentProtectedResourcesPatchSch
 // run_script op requires before executing ANY particular script unattended
 // (actRevalidation.ts). Max 50 mirrors nothing structural; it is a sane
 // upper bound on a hand-curated allowlist an operator actually reviews.
+// Wave 5 Part B (#3827): the closed set of POLICY_DECIDABLE_TIER3 keys an
+// operator has explicitly opted into unattended policy-decided authorization
+// for this agent. Shape-only here (format + max 50, mirroring toolAllowlist's
+// TOOL_REF pattern since a key is exactly a `tool` or `tool:action` string) —
+// the semantic check (registry membership, not four_eyes/T4/secret-bearing)
+// requires POLICY_DECIDABLE_TIER3 and aiGuardrails.ts, which are API-only
+// modules this package cannot import. That check lives in agentService.ts
+// (validateAuthorizationKeys, apps/api/src/services/actionIntents/
+// policyDecidable.ts) and runs at write time, rejecting with a structured 422.
 const actAssetsFields = z.object({
   scriptIds: z.array(z.string().guid()).max(50),
+  supervisedActionKeys: z.array(z.string().regex(TOOL_REF)).max(50),
 });
 export const aiAgentActAssetsPatchSchema = actAssetsFields.partial();
 export const aiAgentActAssetsSchema = aiAgentActAssetsPatchSchema.transform((v) => ({
   scriptIds: [],
+  supervisedActionKeys: [],
   ...v,
 }));
 


### PR DESCRIPTION
Closes #3827

**Bounded unattended Tier-3 ships, dark.** An agent-originated `supervised`-scope intent whose operation the operator explicitly authorized is approved by policy — atomically reserving org-wide blast capacity and stamping durable provenance — and executes through the existing release pipeline via a new policy-evidence branch. Everything else degrades to the normal human intent. All of it sits behind `BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED` (default off): **flag off = byte-identical to merged Part A** (test-asserted). Part B of wave 5; Part A (#4154) merged first. Plan/ADR: `docs/superpowers/plans/ai-mcp/2026-08-28-ai-agents-wave5-b-policy-decide.md` (quorum decisions locked in its header).

## The eight gates (each with a failing test)

flag ∧ agent-originated ∧ `supervised` scope ∧ agent `mode: 'act'` ∧ key ∈ `POLICY_DECIDABLE_TIER3` (structurally headless-gated) ∧ key ∈ the agent's `actAssets.supervisedActionKeys` in BOTH the run snapshot and current policy ∧ live guardrail re-run + kill state ∧ caps (`floor(fleet × maxFleetPercentPerDay/100)` over the shared exposure ledger + `maxPolicyDecisionsPerDay`, reserved under a per-org advisory xact lock in the SAME transaction as the approval CAS). Any deterministic failure → `policy_decision_state: human_required` + the deferred human fanout (identical rows/notifications creation would have produced). Transient failure → `unattempted`, retried via the outbox `intent_created` lane (rethrow-on-transient).

## Mechanics

- Authorization writes: CAS `pending_approval → approved`, `decidedVia: 'policy'`, NULL decider, NULL assurance (policy is a mechanism, not a principal — no sentinel, and **never a synthetic human approval row**, grep-asserted), six provenance columns (key, snapshot digest, classification version, reservation id, kill epoch), exposure reservation, outbox `intent_approved` — one transaction.
- Release: policy-evidence branch in `revalidateApprovedIntentForRelease` (no human row required for `decidedVia:'policy'`; instead digest recompute + registry ∧ authorization re-check in snapshot AND current policy + flag + kill re-read; registry-dropped keys → terminal `policy_authorization_revoked`), a stricter release predicate (exact authorization — 'propose' is not sufficient, unlike human-approved intents), and a final pre-effect kill read. Human-approved release byte-identical (full suites).
- The wave-4 act lane now writes the same exposure ledger (shared unattended accounting) and gains the fleet-percent cap under the same flag; 48h ledger retention worker (registry snapshots at 107).
- Operator surface: `supervisedActionKeys` editor (registry-sourced, act-acknowledgement-gated, structured 422s, i18n all locales); org may only narrow the partner baseline (intersection merge, mirrors `scriptIds`).

## Flagged deviations & caveats

- Audit rows record `actorType: 'ai_agent'` + `initiatedBy: 'policy'` (the audit type union doesn't admit 'system'; `initiatedBy` carries the distinction) — deviation from the plan's literal 'system'.
- The shared action-intents outbox queue predates this wave with BullMQ default `attempts: 1`: a transient policy-decide failure is now VISIBLE (failed job, Sentry) and manually retriable, but not auto-retried until the queue gains attempts/backoff — follow-up filed on merge.
- No web approvals UI reads `decidedByUserId`/`decidedVia` anywhere (audited absence — approvals are API/notification/authenticator-driven); policy-authorization notifications carry `link: null` until wave 6's run-detail page.

## Review provenance

5 staged implement→review rounds (opus on the decide pipeline, release evidence, accounting — **7 blocking findings fixed at stage level**) + a whole-branch security review at xhigh: walked a policy-authorized intent end-to-end listing every gate, ran 9 adversarial probes (four_eyes policy-decide, flag-off decision, shadow-agent decision, unauthorized key, concurrent cap bypass, dropped-key release, synthetic approval row, kill-flip at release, outbox double-authorize race) — **all fail closed; verdict approve, zero blocking**; its 6 actionable quality findings fixed in `464a88e08` (at-least-once rethrow, decide-time snapshot check, structural headless gate, dead-end link, stale comment, atomicity guard). Full suite 27,445/0 wave-relevant (2 pre-existing env-dependent failures in an untouched 2025 test file, documented), shared 2,080/0, web + locale parity green, contracts 238/0, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012o7QB15EFjEvetDAXMxmae