### PR TITLE
feat(api,web): wave 6.1 — supervision: execution-trace runs UI + exposure readout

### DIFF
--- a/apps/api/migrations/2026-09-17-ai-agent-runs-keyset-index.sql
+++ b/apps/api/migrations/2026-09-17-ai-agent-runs-keyset-index.sql
@@ -1,0 +1,19 @@
+-- Wave 6 PR 1 (#3828): covering index for the org-wide keyset-paginated
+-- `GET /ai/agents/runs` list (routes/aiAgents.ts, services/aiAgents/runTrace.ts).
+--
+-- The list walks `(org_id, queued_at DESC, id DESC)` — the id tiebreaker is
+-- required because `queued_at` is not unique (two runs can queue in the same
+-- millisecond), and a keyset without a tiebreaker can skip or duplicate rows
+-- across pages when that happens.
+--
+-- `ai_agent_runs_org_queued_idx` (2026-09-02-ai-agents.sql, org_id, queued_at
+-- DESC — no id column) already exists and is NOT dropped here: dropping an
+-- index is a separate decision from adding one, and the old index still
+-- serves any planner path that doesn't need the id tiebreaker. Note the
+-- redundancy for a future cleanup pass rather than resolving it in this PR.
+--
+-- Idempotent: CREATE INDEX IF NOT EXISTS. No inner BEGIN/COMMIT — autoMigrate
+-- wraps the whole file in one transaction.
+
+CREATE INDEX IF NOT EXISTS ai_agent_runs_org_queued_id_idx
+  ON ai_agent_runs (org_id, queued_at DESC, id DESC);

--- a/apps/api/src/db/schema/aiAgents.ts
+++ b/apps/api/src/db/schema/aiAgents.ts
@@ -107,6 +107,11 @@ export const aiAgentRuns = pgTable('ai_agent_runs', {
   idOrgUq: unique('ai_agent_runs_id_org_id_key').on(table.id, table.orgId),
   agentQueuedIdx: index('ai_agent_runs_agent_queued_idx').on(table.agentId, table.queuedAt.desc()),
   orgQueuedIdx: index('ai_agent_runs_org_queued_idx').on(table.orgId, table.queuedAt.desc()),
+  // Wave 6 PR 1 (#3828, migrations/2026-09-17-ai-agent-runs-keyset-index.sql):
+  // covers the org-wide keyset list's (org_id, queued_at DESC, id DESC) walk.
+  // orgQueuedIdx above lacks the id tiebreaker a keyset needs and is kept
+  // (not dropped) — see the migration header for why.
+  orgQueuedIdIdx: index('ai_agent_runs_org_queued_id_idx').on(table.orgId, table.queuedAt.desc(), table.id.desc()),
   deviceIdx: index('ai_agent_runs_device_id_idx').on(table.deviceId),
 }));
 

--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -92,6 +92,9 @@ vi.mock('../services/aiAgents/effectivePolicy', () => ({
   resolveEffectiveAgent: resolveEffectiveAgentMock,
 }));
 
+const envMock = vi.hoisted(() => ({ policyDecideEnabled: vi.fn(() => true) }));
+vi.mock('../config/env', () => ({ policyDecideEnabled: envMock.policyDecideEnabled }));
+
 import { aiAgentsRoutes, mapError } from './aiAgents';
 
 const AGENT_ID = '11111111-1111-4111-8111-111111111111';
@@ -159,6 +162,7 @@ beforeEach(() => {
     created: true,
     run: { id: RUN_ID, status: 'queued' },
   });
+  envMock.policyDecideEnabled.mockReturnValue(true);
 });
 
 describe('POST /ai-agents/:id/runs', () => {
@@ -359,6 +363,99 @@ describe('GET /ai-agents/policy-decidable-keys (Task 5, #3827)', () => {
     hasPermMock.mockReturnValue(false);
     const res = await buildApp().request('/ai-agents/policy-decidable-keys');
     expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave 6 PR 1 (#3828) — exposure budget readout
+// ---------------------------------------------------------------------------
+
+describe('GET /ai-agents/exposure-budget (recorded exposure readout, #3828)', () => {
+  const exposureBudgetQuery = `orgId=${ORG_ID}&kind=patch`;
+
+  function mockResolvedAgent(overrides: Record<string, unknown> = {}) {
+    resolveEffectiveAgentMock.mockResolvedValue({
+      schemaVersion: 3,
+      agentId: AGENT_ID,
+      kind: 'patch',
+      effective: {
+        limits: { maxFleetPercentPerDay: 5, maxPolicyDecisionsPerDay: 10 },
+      },
+      ...overrides,
+    });
+  }
+
+  it('is gated on ai_agents:read', async () => {
+    hasPermMock.mockReturnValue(false);
+    const res = await buildApp().request(`/ai-agents/exposure-budget?${exposureBudgetQuery}`);
+    expect(res.status).toBe(403);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing/invalid kind before touching the database', async () => {
+    const res = await buildApp().request(`/ai-agents/exposure-budget?orgId=${ORG_ID}&kind=bogus`);
+    expect(res.status).toBe(400);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when there is no active agent policy for the org/kind', async () => {
+    resolveEffectiveAgentMock.mockResolvedValue(null);
+    const res = await buildApp().request(`/ai-agents/exposure-budget?${exposureBudgetQuery}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('reuses computeExposureBudget and returns a schemaVersion-1, recordedOnly readout', async () => {
+    mockResolvedAgent();
+    selectMock
+      .mockReturnValueOnce(selectChain([{ deviceId: 'd1' }, { deviceId: 'd2' }])) // exposedDeviceRows
+      .mockReturnValueOnce(selectChain([{ n: 40 }])) // countContractDevices
+      .mockReturnValueOnce(selectChain([{ n: 3 }])); // dayCountRow
+
+    const res = await buildApp().request(`/ai-agents/exposure-budget?${exposureBudgetQuery}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Record<string, unknown> };
+
+    expect(body.data).toEqual({
+      schemaVersion: 1,
+      orgId: ORG_ID,
+      agentId: AGENT_ID,
+      distinctDevices: 2,
+      contractDeviceCount: 40,
+      maxFleetPercentPerDay: 5,
+      allowance: 2, // floor(40 * 5 / 100)
+      policyDecisionsToday: 3,
+      maxPolicyDecisionsPerDay: 10,
+      windowHours: 24,
+      recordedOnly: true,
+      accountingMode: 'full',
+    });
+  });
+
+  it('labels accountingMode "partial" while the policy-decide flag is dark', async () => {
+    envMock.policyDecideEnabled.mockReturnValue(false);
+    mockResolvedAgent();
+    selectMock
+      .mockReturnValueOnce(selectChain([]))
+      .mockReturnValueOnce(selectChain([{ n: 10 }]))
+      .mockReturnValueOnce(selectChain([{ n: 0 }]));
+
+    const res = await buildApp().request(`/ai-agents/exposure-budget?${exposureBudgetQuery}`);
+    const body = (await res.json()) as { data: { accountingMode: string } };
+    expect(body.data.accountingMode).toBe('partial');
+  });
+
+  it('never leaks a raw tool-input-shaped key onto the wire', async () => {
+    mockResolvedAgent();
+    selectMock
+      .mockReturnValueOnce(selectChain([]))
+      .mockReturnValueOnce(selectChain([{ n: 10 }]))
+      .mockReturnValueOnce(selectChain([{ n: 0 }]));
+
+    const res = await buildApp().request(`/ai-agents/exposure-budget?${exposureBudgetQuery}`);
+    const json = JSON.stringify(await res.json());
+    for (const forbidden of AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS) {
+      expect(json).not.toContain(`"${forbidden}"`);
+    }
   });
 });
 

--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import { z } from 'zod';
+import { AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS } from '@breeze/shared';
 
 const {
   selectMock,
@@ -357,6 +359,330 @@ describe('GET /ai-agents/policy-decidable-keys (Task 5, #3827)', () => {
     hasPermMock.mockReturnValue(false);
     const res = await buildApp().request('/ai-agents/policy-decidable-keys');
     expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave 6 PR 1 (#3828) — execution-trace runs list + detail
+// ---------------------------------------------------------------------------
+
+/**
+ * A minimal chainable stand-in for a Drizzle `db.select(...)` call. Every
+ * chain method returns the same object; `then` resolves it to `rows` so
+ * `await db.select({...}).from(...).where(...).orderBy(...).limit(...)`
+ * resolves exactly like the real query would. The route under test never
+ * inspects the arguments passed to `.where`/`.orderBy`/etc in these unit
+ * tests — those are exercised for real (no mocking) inside
+ * runsListCursor.ts/runTrace.ts's own suites and by the RLS/integration
+ * contract tests.
+ */
+function selectChain<T>(rows: T) {
+  const chain = {
+    from: () => chain,
+    innerJoin: () => chain,
+    leftJoin: () => chain,
+    where: () => chain,
+    orderBy: () => chain,
+    limit: () => chain,
+    offset: () => chain,
+    then: (resolve: (v: T) => unknown, reject?: (e: unknown) => unknown) =>
+      Promise.resolve(rows).then(resolve, reject),
+  };
+  return chain;
+}
+
+// Strict response-shape schemas (DTO rule, Global Constraints): a route that
+// starts spreading a raw row again — pulling in dedupeKey, policySnapshot,
+// the outcome column itself, sessionId, intentIds, or any tool-input field —
+// fails `.strict().parse()` here even though the specific leaked field was
+// never anticipated by name.
+const traceEntryResponseSchema = z.union([
+  z.object({
+    kind: z.literal('executed'),
+    tool: z.string(),
+    action: z.string().optional(),
+    result: z.enum(['ok', 'failed']),
+    durationMs: z.number(),
+    execution: z.enum(['succeeded', 'failed', 'timeout', 'unknown']).optional(),
+    verification: z.enum(['passed', 'failed', 'inconclusive', 'skipped']).optional(),
+    verifyDetail: z.string().optional(),
+    actOpKey: z.string().optional(),
+    actTargetName: z.string().optional(),
+  }).strict(),
+  z.object({
+    kind: z.literal('proposed'),
+    tool: z.string(),
+    action: z.string().optional(),
+    intentId: z.string().optional(),
+    intentError: z.string().optional(),
+    downgradeReason: z.string().optional(),
+  }).strict(),
+  z.object({
+    kind: z.literal('denied'),
+    tool: z.string(),
+    reason: z.string(),
+  }).strict(),
+]);
+
+const runDetailResponseSchema = z.object({
+  data: z.object({
+    schemaVersion: z.literal(1),
+    id: z.string(),
+    agentId: z.string(),
+    agentName: z.string(),
+    agentKind: z.string(),
+    orgId: z.string(),
+    deviceId: z.string().nullable(),
+    deviceHostname: z.string().nullable(),
+    alertId: z.string().nullable(),
+    triggerKind: z.string(),
+    modeAtStart: z.string(),
+    status: z.string(),
+    summary: z.string().nullable(),
+    runVerdict: z.string().nullable(),
+    turnCount: z.number(),
+    costCents: z.number(),
+    errorCode: z.string().nullable(),
+    queuedAt: z.string(),
+    startedAt: z.string().nullable(),
+    finishedAt: z.string().nullable(),
+    budgetExceeded: z.boolean(),
+    wallClockExceeded: z.boolean(),
+    maxTurnsExceeded: z.boolean(),
+    trace: z.array(traceEntryResponseSchema),
+    ledger: z.array(z.object({
+      toolName: z.string(),
+      status: z.string(),
+      durationMs: z.number().nullable(),
+      createdAt: z.string(),
+      completedAt: z.string().nullable(),
+      errorMessage: z.string().nullable(),
+    }).strict()),
+    intents: z.array(z.object({
+      id: z.string(),
+      status: z.string(),
+      actionName: z.string(),
+      approvalScope: z.string(),
+      decidedVia: z.string().nullable(),
+    }).strict()),
+  }).strict(),
+}).strict();
+
+const runListResponseSchema = z.object({
+  data: z.array(z.object({
+    schemaVersion: z.literal(1),
+    id: z.string(),
+    agentId: z.string(),
+    agentName: z.string(),
+    deviceId: z.string().nullable(),
+    status: z.string(),
+    triggerKind: z.string(),
+    runVerdict: z.string().nullable(),
+    queuedAt: z.string(),
+    finishedAt: z.string().nullable(),
+    costCents: z.number(),
+  }).strict()),
+  nextCursor: z.string().nullable(),
+}).strict();
+
+function runRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RUN_ID,
+    agentId: AGENT_ID,
+    orgId: ORG_ID,
+    deviceId: DEVICE_ID,
+    alertId: null,
+    sessionId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    triggerKind: 'manual',
+    modeAtStart: 'shadow',
+    status: 'completed',
+    summary: 'Restarted the print spooler.',
+    outcome: {
+      findings: [],
+      executedActions: [{
+        tool: 'manage_services', action: 'restart', executionId: 'exec-1',
+        result: 'ok', durationMs: 340, execution: 'succeeded', verification: 'passed',
+        verifyDetail: 'service running', actOpKey: 'manage_services.restart', actTargetName: 'Spooler',
+      }],
+      proposedActions: [{
+        tool: 'run_script', action: 'invoke',
+        args: { scriptId: 'abc', secretParam: 'do-not-leak-me' },
+        intentId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      }],
+      deniedActions: [{ tool: 'delete_registry_key', reason: 'protected resource' }],
+      toolExecutionCount: 2,
+      runVerdict: 'partial',
+    },
+    intentIds: ['bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'],
+    turnCount: 3,
+    costCents: 12,
+    errorCode: null,
+    queuedAt: new Date('2026-08-28T10:00:00.000Z'),
+    startedAt: new Date('2026-08-28T10:00:01.000Z'),
+    finishedAt: new Date('2026-08-28T10:00:30.000Z'),
+    agentName: 'Triage',
+    agentKind: 'triage',
+    deviceHostname: 'WKS-042',
+    ...overrides,
+  };
+}
+
+describe('GET /ai-agents/runs/:runId (execution-trace detail, #3828)', () => {
+  it('returns 404 for a run outside the caller\'s org (or that does not exist)', async () => {
+    selectMock.mockReturnValueOnce(selectChain([]));
+    const res = await buildApp().request(`/ai-agents/runs/${RUN_ID}`);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Run not found' });
+  });
+
+  it('rejects a non-uuid run id without touching the database', async () => {
+    const res = await buildApp().request('/ai-agents/runs/not-a-uuid');
+    expect(res.status).toBe(404);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('is gated on ai_agents:read', async () => {
+    hasPermMock.mockReturnValue(false);
+    const res = await buildApp().request(`/ai-agents/runs/${RUN_ID}`);
+    expect(res.status).toBe(403);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('stitches run + ledger + intents into the safe-projected trace DTO, matching the strict wire schema', async () => {
+    selectMock
+      .mockReturnValueOnce(selectChain([runRow()])) // run + agent + device join
+      .mockReturnValueOnce(selectChain([{
+        toolName: 'run_script', status: 'completed', durationMs: 210,
+        createdAt: new Date('2026-08-28T10:00:05.000Z'),
+        completedAt: new Date('2026-08-28T10:00:06.000Z'),
+        errorMessage: null,
+      }])) // ledger
+      .mockReturnValueOnce(selectChain([{
+        id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        status: 'pending_approval',
+        actionName: 'run_script.invoke',
+        approvalScope: 'four_eyes',
+        decidedVia: null,
+      }])); // intents
+
+    const res = await buildApp().request(`/ai-agents/runs/${RUN_ID}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const parsed = runDetailResponseSchema.parse(body);
+    expect(parsed.data.id).toBe(RUN_ID);
+    expect(parsed.data.agentName).toBe('Triage');
+    expect(parsed.data.deviceHostname).toBe('WKS-042');
+    expect(parsed.data.runVerdict).toBe('partial');
+    expect(parsed.data.trace).toHaveLength(3);
+    expect(parsed.data.ledger).toHaveLength(1);
+    expect(parsed.data.intents).toHaveLength(1);
+
+    // The leak tripwire: the raw tool input the model proposed
+    // (`{ scriptId: 'abc', secretParam: 'do-not-leak-me' }`) must never reach
+    // the wire, under any key name.
+    const json = JSON.stringify(body);
+    for (const forbidden of AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS) {
+      expect(json).not.toContain(`"${forbidden}"`);
+    }
+    expect(json).not.toContain('do-not-leak-me');
+    expect(json).not.toContain('scriptId');
+  });
+
+  it('skips the ledger/intents queries when the run has no session and no intent ids', async () => {
+    selectMock.mockReturnValueOnce(selectChain([runRow({ sessionId: null, intentIds: [] })]));
+
+    const res = await buildApp().request(`/ai-agents/runs/${RUN_ID}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.ledger).toEqual([]);
+    expect(body.data.intents).toEqual([]);
+    // Only the run-row select ran — no second/third db.select for ledger/intents.
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GET /ai-agents/runs (org-wide keyset list, #3828)', () => {
+  it('is gated on ai_agents:read', async () => {
+    hasPermMock.mockReturnValue(false);
+    const res = await buildApp().request('/ai-agents/runs');
+    expect(res.status).toBe(403);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a page with no nextCursor when fewer rows than the limit come back', async () => {
+    selectMock.mockReturnValueOnce(selectChain([
+      {
+        id: RUN_ID, agentId: AGENT_ID, agentName: 'Triage', deviceId: DEVICE_ID,
+        status: 'completed', triggerKind: 'manual', runVerdict: 'remediated',
+        queuedAt: new Date('2026-08-28T10:00:00.000Z'),
+        finishedAt: new Date('2026-08-28T10:00:30.000Z'),
+        costCents: 12,
+      },
+    ]));
+
+    const res = await buildApp().request('/ai-agents/runs');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const parsed = runListResponseSchema.parse(body);
+    expect(parsed.data).toHaveLength(1);
+    expect(parsed.nextCursor).toBeNull();
+    expect(parsed.data[0]).toMatchObject({ id: RUN_ID, agentName: 'Triage', runVerdict: 'remediated' });
+  });
+
+  it('returns a nextCursor and trims the peeked row when a full extra page comes back', async () => {
+    const makeRow = (i: number) => ({
+      id: `cccccccc-cccc-4ccc-8ccc-${String(i).padStart(12, '0')}`,
+      agentId: AGENT_ID, agentName: 'Triage', deviceId: null,
+      status: 'completed', triggerKind: 'schedule', runVerdict: null,
+      queuedAt: new Date(Date.UTC(2026, 7, 28, 10, 0, i)),
+      finishedAt: null, costCents: 0,
+    });
+    // Default limit is 25 — return 26 rows to trigger the peek.
+    const rows = Array.from({ length: 26 }, (_, i) => makeRow(i));
+    selectMock.mockReturnValueOnce(selectChain(rows));
+
+    const res = await buildApp().request('/ai-agents/runs');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const parsed = runListResponseSchema.parse(body);
+    expect(parsed.data).toHaveLength(25);
+    expect(parsed.nextCursor).not.toBeNull();
+  });
+
+  it('rejects a malformed cursor with 400 before touching the database', async () => {
+    const res = await buildApp().request('/ai-agents/runs?cursor=not-valid-base64url!!!');
+    expect(res.status).toBe(400);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a limit above the 50 ceiling', async () => {
+    const res = await buildApp().request('/ai-agents/runs?limit=51');
+    expect(res.status).toBe(400);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unrecognized status filter', async () => {
+    const res = await buildApp().request('/ai-agents/runs?status=bogus_status');
+    expect(res.status).toBe(400);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('never carries an outcome/trace payload on the list item, even though runVerdict is derived from the outcome column', async () => {
+    selectMock.mockReturnValueOnce(selectChain([
+      {
+        id: RUN_ID, agentId: AGENT_ID, agentName: 'Triage', deviceId: DEVICE_ID,
+        status: 'completed', triggerKind: 'manual', runVerdict: 'remediated',
+        queuedAt: new Date('2026-08-28T10:00:00.000Z'),
+        finishedAt: new Date('2026-08-28T10:00:30.000Z'),
+        costCents: 12,
+      },
+    ]));
+    const res = await buildApp().request('/ai-agents/runs');
+    const body = await res.json();
+    expect(body.data[0]).not.toHaveProperty('trace');
+    expect(body.data[0]).not.toHaveProperty('outcome');
+    expect(body.data[0]).not.toHaveProperty('ledger');
   });
 });
 

--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -429,8 +429,8 @@ const runDetailResponseSchema = z.object({
     schemaVersion: z.literal(1),
     id: z.string(),
     agentId: z.string(),
-    agentName: z.string(),
-    agentKind: z.string(),
+    agentName: z.string().nullable(),
+    agentKind: z.string().nullable(),
     orgId: z.string(),
     deviceId: z.string().nullable(),
     deviceHostname: z.string().nullable(),
@@ -473,7 +473,7 @@ const runListResponseSchema = z.object({
     schemaVersion: z.literal(1),
     id: z.string(),
     agentId: z.string(),
-    agentName: z.string(),
+    agentName: z.string().nullable(),
     deviceId: z.string().nullable(),
     status: z.string(),
     triggerKind: z.string(),
@@ -600,6 +600,24 @@ describe('GET /ai-agents/runs/:runId (execution-trace detail, #3828)', () => {
     // Only the run-row select ran — no second/third db.select for ledger/intents.
     expect(selectMock).toHaveBeenCalledTimes(1);
   });
+
+  // Review fix (#3828): ai_agents is dual-ownership (#2135) — a partner-wide
+  // agent's row is RLS-invisible to an org-scoped caller even though the run
+  // it produced (plain org-scoped) stays visible. Before this fix the route
+  // innerJoin'd ai_agents, so this case 404'd instead of returning the run.
+  it('returns the run (not 404) when its agent row is RLS-invisible, with agentName/agentKind null', async () => {
+    selectMock.mockReturnValueOnce(selectChain([
+      runRow({ sessionId: null, intentIds: [], agentName: null, agentKind: null }),
+    ]));
+
+    const res = await buildApp().request(`/ai-agents/runs/${RUN_ID}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const parsed = runDetailResponseSchema.parse(body);
+    expect(parsed.data.id).toBe(RUN_ID);
+    expect(parsed.data.agentName).toBeNull();
+    expect(parsed.data.agentKind).toBeNull();
+  });
 });
 
 describe('GET /ai-agents/runs (org-wide keyset list, #3828)', () => {
@@ -616,6 +634,7 @@ describe('GET /ai-agents/runs (org-wide keyset list, #3828)', () => {
         id: RUN_ID, agentId: AGENT_ID, agentName: 'Triage', deviceId: DEVICE_ID,
         status: 'completed', triggerKind: 'manual', runVerdict: 'remediated',
         queuedAt: new Date('2026-08-28T10:00:00.000Z'),
+        queuedAtRaw: '2026-08-28T10:00:00.000000Z',
         finishedAt: new Date('2026-08-28T10:00:30.000Z'),
         costCents: 12,
       },
@@ -636,6 +655,7 @@ describe('GET /ai-agents/runs (org-wide keyset list, #3828)', () => {
       agentId: AGENT_ID, agentName: 'Triage', deviceId: null,
       status: 'completed', triggerKind: 'schedule', runVerdict: null,
       queuedAt: new Date(Date.UTC(2026, 7, 28, 10, 0, i)),
+      queuedAtRaw: `2026-08-28T10:00:${String(i).padStart(2, '0')}.000000Z`,
       finishedAt: null, costCents: 0,
     });
     // Default limit is 25 — return 26 rows to trigger the peek.
@@ -648,6 +668,59 @@ describe('GET /ai-agents/runs (org-wide keyset list, #3828)', () => {
     const parsed = runListResponseSchema.parse(body);
     expect(parsed.data).toHaveLength(25);
     expect(parsed.nextCursor).not.toBeNull();
+  });
+
+  // Review fix (#3828): built from the row's `queuedAtRaw` microsecond text,
+  // never `queuedAt.toISOString()` — a JS Date truncates to milliseconds,
+  // which would silently drop same-millisecond siblings from the next page.
+  it('seeds nextCursor from the peeked row\'s queuedAtRaw, not the millisecond-truncated queuedAt Date', async () => {
+    const microPrecise = '2026-08-28T10:00:00.123456Z';
+    const makeRow = (i: number) => ({
+      id: `dddddddd-dddd-4ddd-8ddd-${String(i).padStart(12, '0')}`,
+      agentId: AGENT_ID, agentName: 'Triage', deviceId: null,
+      status: 'completed', triggerKind: 'schedule', runVerdict: null,
+      // Every row shares the same millisecond-truncated Date — the last
+      // (limit+1-th, trimmed) row's true value differs only in microseconds.
+      queuedAt: new Date('2026-08-28T10:00:00.123Z'),
+      // limit is 25, so pageRows is indices 0..24 and index 24 is `last` —
+      // the seed for nextCursor. Index 25 is the peeked/trimmed row.
+      queuedAtRaw: i === 24 ? microPrecise : '2026-08-28T10:00:00.123999Z',
+      finishedAt: null, costCents: 0,
+    });
+    const rows = Array.from({ length: 26 }, (_, i) => makeRow(i));
+    selectMock.mockReturnValueOnce(selectChain(rows));
+
+    const res = await buildApp().request('/ai-agents/runs');
+    const body = await res.json();
+    const parsed = runListResponseSchema.parse(body);
+    expect(parsed.nextCursor).not.toBeNull();
+
+    const decoded = JSON.parse(Buffer.from(parsed.nextCursor as string, 'base64url').toString('utf8'));
+    expect(decoded.q).toBe(microPrecise);
+  });
+
+  // Review fix (#3828): ai_agents is dual-ownership (#2135) — a partner-wide
+  // agent's row is RLS-invisible to an org-scoped caller even though the run
+  // it produced (plain org-scoped) stays visible. The route left-joins
+  // ai_agents so the run survives; agentName comes back null instead.
+  it('includes a run whose agent row is RLS-invisible (partner-wide agent), with agentName null', async () => {
+    selectMock.mockReturnValueOnce(selectChain([
+      {
+        id: RUN_ID, agentId: AGENT_ID, agentName: null, deviceId: DEVICE_ID,
+        status: 'completed', triggerKind: 'schedule', runVerdict: 'remediated',
+        queuedAt: new Date('2026-08-28T10:00:00.000Z'),
+        queuedAtRaw: '2026-08-28T10:00:00.000000Z',
+        finishedAt: new Date('2026-08-28T10:00:30.000Z'),
+        costCents: 12,
+      },
+    ]));
+
+    const res = await buildApp().request('/ai-agents/runs');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe(RUN_ID);
+    expect(body.data[0].agentName).toBeNull();
   });
 
   it('rejects a malformed cursor with 400 before touching the database', async () => {

--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -332,6 +332,55 @@ describe('POST /ai-agents/:id/runs', () => {
   });
 });
 
+// Review fix (#3828): the LEAK PROBE that found this — a bare `db.select()`
+// on `ai_agent_runs` put the whole `outcome` jsonb on the wire, including
+// `proposedActions[].args` (the verbatim raw tool input the model proposed),
+// under the identical ai_agents:read gate the hardened routes below enforce.
+// The route now projects through the same `mapRunListItem` mapper as the
+// org-wide `GET /runs` list.
+describe('GET /ai-agents/:id/runs (legacy per-agent list, review fix #3828)', () => {
+  it('is gated on ai_agents:read', async () => {
+    hasPermMock.mockReturnValue(false);
+    const res = await buildApp().request(`/ai-agents/${AGENT_ID}/runs`);
+    expect(res.status).toBe(403);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a uniform 404 for a foreign-tenant/missing agent', async () => {
+    getAgentMock.mockResolvedValue(null);
+    const res = await buildApp().request(`/ai-agents/${AGENT_ID}/runs`);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Agent not found' });
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('never carries the raw outcome payload — no args, proposedActions, session, or policy internals', async () => {
+    selectMock.mockReturnValueOnce(selectChain([runRow({ orgName: 'Acme Corp' })]));
+
+    const res = await buildApp().request(`/ai-agents/${AGENT_ID}/runs`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]).toMatchObject({
+      id: RUN_ID, agentId: AGENT_ID, agentName: 'Triage', orgId: ORG_ID, orgName: 'Acme Corp',
+    });
+    expect(body.data[0]).not.toHaveProperty('outcome');
+    expect(body.data[0]).not.toHaveProperty('trace');
+    expect(body.data[0]).not.toHaveProperty('sessionId');
+    expect(body.data[0]).not.toHaveProperty('intentIds');
+    expect(body.data[0]).not.toHaveProperty('policySnapshot');
+    expect(body.data[0]).not.toHaveProperty('dedupeKey');
+
+    const json = JSON.stringify(body);
+    for (const forbidden of AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS) {
+      expect(json).not.toContain(`"${forbidden}"`);
+    }
+    expect(json).not.toContain('do-not-leak-me');
+    expect(json).not.toContain('scriptId');
+  });
+});
+
 describe('GET /ai-agents/policy-decidable-keys (Task 5, #3827)', () => {
   it('returns the POLICY_DECIDABLE_TIER3 registry, one entry per headless-compatible key', async () => {
     const res = await buildApp().request('/ai-agents/policy-decidable-keys');
@@ -571,6 +620,8 @@ const runListResponseSchema = z.object({
     id: z.string(),
     agentId: z.string(),
     agentName: z.string().nullable(),
+    orgId: z.string(),
+    orgName: z.string().nullable(),
     deviceId: z.string().nullable(),
     status: z.string(),
     triggerKind: z.string(),
@@ -728,7 +779,8 @@ describe('GET /ai-agents/runs (org-wide keyset list, #3828)', () => {
   it('returns a page with no nextCursor when fewer rows than the limit come back', async () => {
     selectMock.mockReturnValueOnce(selectChain([
       {
-        id: RUN_ID, agentId: AGENT_ID, agentName: 'Triage', deviceId: DEVICE_ID,
+        id: RUN_ID, agentId: AGENT_ID, agentName: 'Triage', orgId: ORG_ID, orgName: 'Acme Corp',
+        deviceId: DEVICE_ID,
         status: 'completed', triggerKind: 'manual', runVerdict: 'remediated',
         queuedAt: new Date('2026-08-28T10:00:00.000Z'),
         queuedAtRaw: '2026-08-28T10:00:00.000000Z',
@@ -743,13 +795,15 @@ describe('GET /ai-agents/runs (org-wide keyset list, #3828)', () => {
     const parsed = runListResponseSchema.parse(body);
     expect(parsed.data).toHaveLength(1);
     expect(parsed.nextCursor).toBeNull();
-    expect(parsed.data[0]).toMatchObject({ id: RUN_ID, agentName: 'Triage', runVerdict: 'remediated' });
+    expect(parsed.data[0]).toMatchObject({
+      id: RUN_ID, agentName: 'Triage', orgId: ORG_ID, orgName: 'Acme Corp', runVerdict: 'remediated',
+    });
   });
 
   it('returns a nextCursor and trims the peeked row when a full extra page comes back', async () => {
     const makeRow = (i: number) => ({
       id: `cccccccc-cccc-4ccc-8ccc-${String(i).padStart(12, '0')}`,
-      agentId: AGENT_ID, agentName: 'Triage', deviceId: null,
+      agentId: AGENT_ID, agentName: 'Triage', orgId: ORG_ID, orgName: 'Acme Corp', deviceId: null,
       status: 'completed', triggerKind: 'schedule', runVerdict: null,
       queuedAt: new Date(Date.UTC(2026, 7, 28, 10, 0, i)),
       queuedAtRaw: `2026-08-28T10:00:${String(i).padStart(2, '0')}.000000Z`,
@@ -774,7 +828,7 @@ describe('GET /ai-agents/runs (org-wide keyset list, #3828)', () => {
     const microPrecise = '2026-08-28T10:00:00.123456Z';
     const makeRow = (i: number) => ({
       id: `dddddddd-dddd-4ddd-8ddd-${String(i).padStart(12, '0')}`,
-      agentId: AGENT_ID, agentName: 'Triage', deviceId: null,
+      agentId: AGENT_ID, agentName: 'Triage', orgId: ORG_ID, orgName: 'Acme Corp', deviceId: null,
       status: 'completed', triggerKind: 'schedule', runVerdict: null,
       // Every row shares the same millisecond-truncated Date — the last
       // (limit+1-th, trimmed) row's true value differs only in microseconds.
@@ -803,7 +857,8 @@ describe('GET /ai-agents/runs (org-wide keyset list, #3828)', () => {
   it('includes a run whose agent row is RLS-invisible (partner-wide agent), with agentName null', async () => {
     selectMock.mockReturnValueOnce(selectChain([
       {
-        id: RUN_ID, agentId: AGENT_ID, agentName: null, deviceId: DEVICE_ID,
+        id: RUN_ID, agentId: AGENT_ID, agentName: null, orgId: ORG_ID, orgName: 'Acme Corp',
+        deviceId: DEVICE_ID,
         status: 'completed', triggerKind: 'schedule', runVerdict: 'remediated',
         queuedAt: new Date('2026-08-28T10:00:00.000Z'),
         queuedAtRaw: '2026-08-28T10:00:00.000000Z',
@@ -818,6 +873,55 @@ describe('GET /ai-agents/runs (org-wide keyset list, #3828)', () => {
     expect(body.data).toHaveLength(1);
     expect(body.data[0].id).toBe(RUN_ID);
     expect(body.data[0].agentName).toBeNull();
+  });
+
+  // Review fix (#3828): `?orgId=` is what `fetchWithAuth` auto-injects when
+  // the org switcher has one org selected (apps/web/src/stores/auth.ts) —
+  // before this fix the query schema silently stripped it and selecting an
+  // org never narrowed the fleet-wide list.
+  it('rejects an orgId the caller cannot access, before touching the database', async () => {
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', {
+        scope: 'organization', orgId: ORG_ID, partnerId: null, accessibleOrgIds: [ORG_ID],
+        user: { id: USER_ID, email: 'tech@example.com', name: 'Tech' },
+        canAccessOrg: (id: string) => id === ORG_ID,
+        orgCondition: () => undefined,
+      } as never);
+      await next();
+    });
+    app.route('/ai-agents', aiAgentsRoutes);
+
+    const res = await app.request(`/ai-agents/runs?orgId=${OTHER_ORG_ID}`);
+    expect(res.status).toBe(403);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('applies an accessible orgId filter and returns its rows', async () => {
+    selectMock.mockReturnValueOnce(selectChain([
+      {
+        id: RUN_ID, agentId: AGENT_ID, agentName: 'Triage', orgId: ORG_ID, orgName: 'Acme Corp',
+        deviceId: DEVICE_ID,
+        status: 'completed', triggerKind: 'manual', runVerdict: 'remediated',
+        queuedAt: new Date('2026-08-28T10:00:00.000Z'),
+        queuedAtRaw: '2026-08-28T10:00:00.000000Z',
+        finishedAt: new Date('2026-08-28T10:00:30.000Z'),
+        costCents: 12,
+      },
+    ]));
+
+    const res = await buildApp().request(`/ai-agents/runs?orgId=${ORG_ID}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const parsed = runListResponseSchema.parse(body);
+    expect(parsed.data).toHaveLength(1);
+    expect(parsed.data[0]).toMatchObject({ id: RUN_ID, orgId: ORG_ID, orgName: 'Acme Corp' });
+  });
+
+  it('rejects a malformed orgId', async () => {
+    const res = await buildApp().request('/ai-agents/runs?orgId=not-a-uuid');
+    expect(res.status).toBe(400);
+    expect(selectMock).not.toHaveBeenCalled();
   });
 
   it('rejects a malformed cursor with 400 before touching the database', async () => {
@@ -841,7 +945,8 @@ describe('GET /ai-agents/runs (org-wide keyset list, #3828)', () => {
   it('never carries an outcome/trace payload on the list item, even though runVerdict is derived from the outcome column', async () => {
     selectMock.mockReturnValueOnce(selectChain([
       {
-        id: RUN_ID, agentId: AGENT_ID, agentName: 'Triage', deviceId: DEVICE_ID,
+        id: RUN_ID, agentId: AGENT_ID, agentName: 'Triage', orgId: ORG_ID, orgName: 'Acme Corp',
+        deviceId: DEVICE_ID,
         status: 'completed', triggerKind: 'manual', runVerdict: 'remediated',
         queuedAt: new Date('2026-08-28T10:00:00.000Z'),
         finishedAt: new Date('2026-08-28T10:00:30.000Z'),

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -16,7 +16,9 @@ import {
 } from '@breeze/shared';
 import { zValidator } from '../lib/validation';
 import { db } from '../db';
-import { actionIntents, aiAgentRuns, aiAgents, aiToolExecutions, devices, type AiAgentRow } from '../db/schema';
+import {
+  actionIntents, aiAgentRuns, aiAgents, aiToolExecutions, devices, organizations, type AiAgentRow,
+} from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { policyDecideEnabled } from '../config/env';
 import { PARTNER_WIDE_WRITE_DENIED_MESSAGE, PartnerWideWriteDeniedError } from '../services/partnerWideAccess';
@@ -296,6 +298,8 @@ function mapRunListItem(row: {
   id: string;
   agentId: string;
   agentName: string | null;
+  orgId: string;
+  orgName: string | null;
   deviceId: string | null;
   status: AiAgentRunListItemDto['status'];
   triggerKind: AiAgentRunListItemDto['triggerKind'];
@@ -309,6 +313,8 @@ function mapRunListItem(row: {
     id: row.id,
     agentId: row.agentId,
     agentName: row.agentName,
+    orgId: row.orgId,
+    orgName: row.orgName,
     deviceId: row.deviceId,
     status: row.status,
     triggerKind: row.triggerKind,
@@ -337,19 +343,31 @@ aiAgentsRoutes.get(
     limit: z.coerce.number().int().min(1).max(50).default(25),
     agentId: z.string().guid().optional(),
     status: z.enum(AI_AGENT_RUN_STATUSES).optional(),
+    orgId: z.string().guid().optional(),
   })),
   async (c) => {
     const auth = c.get('auth');
-    const { cursor: cursorToken, limit, agentId, status } = c.req.valid('query');
+    const { cursor: cursorToken, limit, agentId, status, orgId } = c.req.valid('query');
 
     const cursor = decodeRunsCursor(cursorToken);
     if (cursorToken && !cursor) {
       return c.json({ error: 'Invalid or malformed cursor' }, 400);
     }
 
+    // Optional single-org filter (must be accessible) — mirrors
+    // routes/devices/core.ts's fleet-list pattern. `fetchWithAuth` auto-injects
+    // `?orgId=<selected>` whenever the org switcher has one org selected
+    // (apps/web/src/stores/auth.ts); without this the query schema silently
+    // stripped it and the org switcher never narrowed the list (review fix,
+    // #3828 — this route is registered `org-or-all` in routeScope.ts).
+    if (orgId && !auth.canAccessOrg(orgId)) {
+      return c.json({ error: 'Access to this organization denied' }, 403);
+    }
+
     const conditions: (SQL | undefined)[] = [auth.orgCondition(aiAgentRuns.orgId)];
     if (agentId) conditions.push(eq(aiAgentRuns.agentId, agentId));
     if (status) conditions.push(eq(aiAgentRuns.status, status));
+    if (orgId) conditions.push(eq(aiAgentRuns.orgId, orgId));
     if (cursor) conditions.push(buildRunsKeysetPredicate(cursor));
 
     // Peek one extra row past `limit` to detect "is there a next page" —
@@ -360,6 +378,11 @@ aiAgentsRoutes.get(
         id: aiAgentRuns.id,
         agentId: aiAgentRuns.agentId,
         agentName: aiAgents.name,
+        orgId: aiAgentRuns.orgId,
+        // Org name for the fleet (All-organizations) view, where the web list
+        // shows an Organization column so cross-org rows stay legible —
+        // mirrors routes/alerts/alerts.ts's `orgName` join (review fix, #3828).
+        orgName: organizations.name,
         deviceId: aiAgentRuns.deviceId,
         status: aiAgentRuns.status,
         triggerKind: aiAgentRuns.triggerKind,
@@ -387,6 +410,7 @@ aiAgentsRoutes.get(
       // a partner-wide agent from this list. agentName instead comes back
       // null for those rows (see AiAgentRunListItemDto.agentName).
       .leftJoin(aiAgents, eq(aiAgentRuns.agentId, aiAgents.id))
+      .leftJoin(organizations, eq(aiAgentRuns.orgId, organizations.id))
       .where(and(...conditions))
       .orderBy(desc(aiAgentRuns.queuedAt), desc(aiAgentRuns.id))
       .limit(limit + 1);
@@ -534,13 +558,37 @@ aiAgentsRoutes.get(
     // owned by the DEVICE's org, not the agent's, so filtering by the agent
     // alone would show a partner admin every org's runs for that baseline
     // regardless of which orgs they can actually reach.
+    //
+    // Review fix (#3828): projected through the same list-item mapper as the
+    // org-wide `GET /runs` above. The prior `db.select()` (no projection)
+    // put the whole `outcome` jsonb on the wire under the identical
+    // ai_agents:read gate the hardened routes enforce — including
+    // proposedActions[].args, the verbatim raw tool input the model
+    // proposed. No in-repo consumer of the raw shape exists (apps/web,
+    // apps/portal, apps/mobile, e2e-tests grepped clean), so there is no
+    // legacy wire shape to preserve.
     const runs = await db
-      .select()
+      .select({
+        id: aiAgentRuns.id,
+        agentId: aiAgentRuns.agentId,
+        orgId: aiAgentRuns.orgId,
+        orgName: organizations.name,
+        deviceId: aiAgentRuns.deviceId,
+        status: aiAgentRuns.status,
+        triggerKind: aiAgentRuns.triggerKind,
+        runVerdict: sql<string | null>`${aiAgentRuns.outcome}->>'runVerdict'`,
+        queuedAt: aiAgentRuns.queuedAt,
+        finishedAt: aiAgentRuns.finishedAt,
+        costCents: aiAgentRuns.costCents,
+      })
       .from(aiAgentRuns)
+      .leftJoin(organizations, eq(aiAgentRuns.orgId, organizations.id))
       .where(and(eq(aiAgentRuns.agentId, row.id), auth.orgCondition(aiAgentRuns.orgId)))
       .orderBy(desc(aiAgentRuns.queuedAt))
       .limit(limit);
-    return c.json({ data: runs });
+    // agentName comes from the already-loaded, RLS-visible `row` (this route
+    // is scoped to one agent), not a join — every run here shares it.
+    return c.json({ data: runs.map((r) => mapRunListItem({ ...r, agentName: row.name })) });
   },
 );
 

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -9,6 +9,7 @@ import {
   type AgentRunVerdict,
   type AiAgentDto,
   type AiAgentRunListItemDto,
+  type ExposureBudgetDto,
   createAiAgentSchema,
   triggerAgentRunSchema,
   updateAiAgentSchema,
@@ -17,6 +18,7 @@ import { zValidator } from '../lib/validation';
 import { db } from '../db';
 import { actionIntents, aiAgentRuns, aiAgents, aiToolExecutions, devices, type AiAgentRow } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
+import { policyDecideEnabled } from '../config/env';
 import { PARTNER_WIDE_WRITE_DENIED_MESSAGE, PartnerWideWriteDeniedError } from '../services/partnerWideAccess';
 import { AgentAccessDeniedError } from '../services/aiAgents/access';
 import {
@@ -26,6 +28,7 @@ import {
 } from '../services/aiAgents/agentService';
 import { resolveEffectiveAgent } from '../services/aiAgents/effectivePolicy';
 import { POLICY_DECIDABLE_TIER3 } from '../services/actionIntents/policyDecidable';
+import { computeExposureBudget } from '../services/actionIntents/exposureBudget';
 import { createAndEnqueueAgentRun } from '../services/aiAgents/runService';
 import { InvalidAgentRecipientsError } from '../services/aiAgents/recipients';
 import { SUPPORTED_AGENT_MODES } from '../services/aiAgents/constants';
@@ -219,6 +222,69 @@ aiAgentsRoutes.get('/policy-decidable-keys', scopes, requireAiRead, async (c) =>
       .map((entry) => ({ key: entry.key, toolName: entry.toolName, action: entry.action, note: entry.note })),
   });
 });
+
+/**
+ * Wave 6 PR 1 (#3828) — the org+kind unattended-exposure budget readout:
+ * "recorded exposure", reusing the EXACT same enforcement calculation
+ * `policyDecide.ts`'s authorize transaction gates a policy decision with
+ * (`computeExposureBudget`, services/actionIntents/exposureBudget.ts),
+ * called here read-only with no `deviceId` (no live decision to project —
+ * see that param's docstring). Query shape mirrors `GET /effective` above
+ * (`orgId` + `kind`, resolved through the same authorized loader) rather
+ * than taking a raw `agentId`, since the org+kind pair — not a specific
+ * agent id the caller may not have handy — is the natural key an operator
+ * reasons about ("what's my patch agent's unattended budget").
+ *
+ * `accountingMode` is derived from the live `policyDecideEnabled()` flag,
+ * not cached — see `ExposureBudgetDto`'s docstring for why a 'partial' vs
+ * 'full' distinction matters while the flag is dark.
+ */
+aiAgentsRoutes.get(
+  '/exposure-budget',
+  scopes,
+  requireAiRead,
+  zValidator('query', z.object({
+    orgId: z.string().guid(),
+    kind: z.enum(AI_AGENT_KINDS),
+  })),
+  async (c) => {
+    const auth = c.get('auth');
+    const { orgId, kind } = c.req.valid('query');
+
+    const resolved = await resolveEffectiveAgent(auth, orgId, kind);
+    if (!resolved) {
+      return c.json({ error: 'No active agent policy for this organization/kind' }, 404);
+    }
+
+    const { maxFleetPercentPerDay, maxPolicyDecisionsPerDay } = resolved.effective.limits;
+    const budget = await computeExposureBudget({
+      orgId,
+      agentId: resolved.agentId,
+      maxFleetPercentPerDay,
+      maxPolicyDecisionsPerDay,
+      // No deviceId: this is a readout, not a live decision — see
+      // computeExposureBudget's param docstring.
+    });
+
+    const dto: ExposureBudgetDto = {
+      schemaVersion: AI_AGENT_RUN_DTO_SCHEMA_VERSION,
+      orgId,
+      agentId: resolved.agentId,
+      distinctDevices: budget.distinctDevices,
+      contractDeviceCount: budget.contractDeviceCount,
+      maxFleetPercentPerDay: budget.maxFleetPercentPerDay,
+      allowance: budget.allowance,
+      // Non-null: this call site never sets shortCircuitOnFleetCapExceeded,
+      // so the day-count query always ran.
+      policyDecisionsToday: budget.policyDecisionsToday as number,
+      maxPolicyDecisionsPerDay: budget.maxPolicyDecisionsPerDay,
+      windowHours: 24,
+      recordedOnly: true,
+      accountingMode: policyDecideEnabled() ? 'full' : 'partial',
+    };
+    return c.json({ data: dto });
+  },
+);
 
 /**
  * The wire shape of one `GET /runs` row. Deliberately NOT `{ ...row }` for

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -229,7 +229,7 @@ aiAgentsRoutes.get('/policy-decidable-keys', scopes, requireAiRead, async (c) =>
 function mapRunListItem(row: {
   id: string;
   agentId: string;
-  agentName: string;
+  agentName: string | null;
   deviceId: string | null;
   status: AiAgentRunListItemDto['status'];
   triggerKind: AiAgentRunListItemDto['triggerKind'];
@@ -304,11 +304,23 @@ aiAgentsRoutes.get(
         // caller asked to see in detail.
         runVerdict: sql<string | null>`${aiAgentRuns.outcome}->>'runVerdict'`,
         queuedAt: aiAgentRuns.queuedAt,
+        // Full microsecond-precision text of the same column, for the
+        // cursor only — never put on the DTO. See runsListCursor.ts's
+        // AiAgentRunsCursor.q docstring for why `queuedAt.toISOString()`
+        // (millisecond-truncating) must never be what seeds the cursor.
+        queuedAtRaw: sql<string>`to_char(${aiAgentRuns.queuedAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
         finishedAt: aiAgentRuns.finishedAt,
         costCents: aiAgentRuns.costCents,
       })
       .from(aiAgentRuns)
-      .innerJoin(aiAgents, eq(aiAgentRuns.agentId, aiAgents.id))
+      // LEFT, not INNER: ai_agents is a dual-ownership table (#2135) whose RLS
+      // policy denies partner-wide rows to an org-scoped caller entirely
+      // (breeze_has_partner_access is false — org tokens carry no accessible
+      // partner ids). ai_agent_runs itself is plain org-scoped and stays
+      // visible, so an inner join would silently drop every run produced by
+      // a partner-wide agent from this list. agentName instead comes back
+      // null for those rows (see AiAgentRunListItemDto.agentName).
+      .leftJoin(aiAgents, eq(aiAgentRuns.agentId, aiAgents.id))
       .where(and(...conditions))
       .orderBy(desc(aiAgentRuns.queuedAt), desc(aiAgentRuns.id))
       .limit(limit + 1);
@@ -367,7 +379,11 @@ aiAgentsRoutes.get('/runs/:runId', scopes, requireAiRead, async (c) => {
       deviceHostname: devices.hostname,
     })
     .from(aiAgentRuns)
-    .innerJoin(aiAgents, eq(aiAgentRuns.agentId, aiAgents.id))
+    // LEFT, not INNER — same RLS-visibility gap as `GET /runs` above: a
+    // partner-wide agent's ai_agents row is invisible to an org-scoped
+    // caller, but the run it produced must still be returned rather than
+    // 404ing (see buildRunTrace's `agent: RunTraceAgentInput | null` param).
+    .leftJoin(aiAgents, eq(aiAgentRuns.agentId, aiAgents.id))
     .leftJoin(devices, eq(aiAgentRuns.deviceId, devices.id))
     .where(and(eq(aiAgentRuns.id, runId), auth.orgCondition(aiAgentRuns.orgId)))
     .limit(1);
@@ -411,9 +427,14 @@ aiAgentsRoutes.get('/runs/:runId', scopes, requireAiRead, async (c) => {
       .where(and(inArray(actionIntents.id, run.intentIds), auth.orgCondition(actionIntents.orgId)))
     : [];
 
+  // Both fields come from the same left-joined ai_agents row, so they are
+  // either both present or both null together.
+  const agent = run.agentName !== null && run.agentKind !== null
+    ? { name: run.agentName, kind: run.agentKind }
+    : null;
   const detail = buildRunTrace(
     run,
-    { name: run.agentName, kind: run.agentKind },
+    agent,
     run.deviceHostname ? { hostname: run.deviceHostname } : null,
     ledgerRows,
     intentRows,

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -1,17 +1,21 @@
 import { randomUUID } from 'node:crypto';
 import { Hono, type Context } from 'hono';
 import { z } from 'zod';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, sql, type SQL } from 'drizzle-orm';
 import {
   AI_AGENT_KINDS,
+  AI_AGENT_RUN_DTO_SCHEMA_VERSION,
+  AI_AGENT_RUN_STATUSES,
+  type AgentRunVerdict,
   type AiAgentDto,
+  type AiAgentRunListItemDto,
   createAiAgentSchema,
   triggerAgentRunSchema,
   updateAiAgentSchema,
 } from '@breeze/shared';
 import { zValidator } from '../lib/validation';
 import { db } from '../db';
-import { aiAgentRuns, type AiAgentRow } from '../db/schema';
+import { actionIntents, aiAgentRuns, aiAgents, aiToolExecutions, devices, type AiAgentRow } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { PARTNER_WIDE_WRITE_DENIED_MESSAGE, PartnerWideWriteDeniedError } from '../services/partnerWideAccess';
 import { AgentAccessDeniedError } from '../services/aiAgents/access';
@@ -25,6 +29,10 @@ import { POLICY_DECIDABLE_TIER3 } from '../services/actionIntents/policyDecidabl
 import { createAndEnqueueAgentRun } from '../services/aiAgents/runService';
 import { InvalidAgentRecipientsError } from '../services/aiAgents/recipients';
 import { SUPPORTED_AGENT_MODES } from '../services/aiAgents/constants';
+import { buildRunTrace } from '../services/aiAgents/runTrace';
+import {
+  buildRunsKeysetPredicate, decodeRunsCursor, encodeRunsCursor, runsCursorFromRow,
+} from '../services/aiAgents/runsListCursor';
 import { verifyDeviceAccess } from '../services/aiTools';
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS } from '../services/permissions';
@@ -212,6 +220,118 @@ aiAgentsRoutes.get('/policy-decidable-keys', scopes, requireAiRead, async (c) =>
   });
 });
 
+/**
+ * The wire shape of one `GET /runs` row. Deliberately NOT `{ ...row }` for
+ * the same reason `mapRow` (above) isn't: this is a list-item projection, no
+ * outcome payload at all — the detail route below is where a caller goes for
+ * the trace, ledger, and intents.
+ */
+function mapRunListItem(row: {
+  id: string;
+  agentId: string;
+  agentName: string;
+  deviceId: string | null;
+  status: AiAgentRunListItemDto['status'];
+  triggerKind: AiAgentRunListItemDto['triggerKind'];
+  runVerdict: string | null;
+  queuedAt: Date;
+  finishedAt: Date | null;
+  costCents: number;
+}): AiAgentRunListItemDto {
+  return {
+    schemaVersion: AI_AGENT_RUN_DTO_SCHEMA_VERSION,
+    id: row.id,
+    agentId: row.agentId,
+    agentName: row.agentName,
+    deviceId: row.deviceId,
+    status: row.status,
+    triggerKind: row.triggerKind,
+    runVerdict: (row.runVerdict as AgentRunVerdict | null) ?? null,
+    queuedAt: row.queuedAt.toISOString(),
+    finishedAt: row.finishedAt ? row.finishedAt.toISOString() : null,
+    costCents: row.costCents,
+  };
+}
+
+/**
+ * Org-wide keyset-paginated runs list (Wave 6 PR 1, #3828) — every run this
+ * caller's accessible orgs produced, across every agent, newest first.
+ * Distinct from `GET /:id/runs` (agent-scoped, offset-limited) below: that
+ * route answers "what has THIS agent done", this one answers "what has
+ * happened across the fleet", which is what the runs list page (Task 4)
+ * needs. Registered ahead of `GET /:id` — a literal `runs` path segment must
+ * never fall into the `:id` param route.
+ */
+aiAgentsRoutes.get(
+  '/runs',
+  scopes,
+  requireAiRead,
+  zValidator('query', z.object({
+    cursor: z.string().optional(),
+    limit: z.coerce.number().int().min(1).max(50).default(25),
+    agentId: z.string().guid().optional(),
+    status: z.enum(AI_AGENT_RUN_STATUSES).optional(),
+  })),
+  async (c) => {
+    const auth = c.get('auth');
+    const { cursor: cursorToken, limit, agentId, status } = c.req.valid('query');
+
+    const cursor = decodeRunsCursor(cursorToken);
+    if (cursorToken && !cursor) {
+      return c.json({ error: 'Invalid or malformed cursor' }, 400);
+    }
+
+    const conditions: (SQL | undefined)[] = [auth.orgCondition(aiAgentRuns.orgId)];
+    if (agentId) conditions.push(eq(aiAgentRuns.agentId, agentId));
+    if (status) conditions.push(eq(aiAgentRuns.status, status));
+    if (cursor) conditions.push(buildRunsKeysetPredicate(cursor));
+
+    // Peek one extra row past `limit` to detect "is there a next page" —
+    // mirrors routes/devices/core.ts's cursor-mode convention. The
+    // (limit+1)th row becomes the nextCursor seed and is trimmed from data.
+    const rows = await db
+      .select({
+        id: aiAgentRuns.id,
+        agentId: aiAgentRuns.agentId,
+        agentName: aiAgents.name,
+        deviceId: aiAgentRuns.deviceId,
+        status: aiAgentRuns.status,
+        triggerKind: aiAgentRuns.triggerKind,
+        // Pulled straight out of the outcome jsonb by key rather than
+        // selecting the whole column — this is a list endpoint, and the
+        // full outcome (which is where the SAFE-projection risk lives) has
+        // no business leaving Postgres for a row that isn't the one the
+        // caller asked to see in detail.
+        runVerdict: sql<string | null>`${aiAgentRuns.outcome}->>'runVerdict'`,
+        queuedAt: aiAgentRuns.queuedAt,
+        finishedAt: aiAgentRuns.finishedAt,
+        costCents: aiAgentRuns.costCents,
+      })
+      .from(aiAgentRuns)
+      .innerJoin(aiAgents, eq(aiAgentRuns.agentId, aiAgents.id))
+      .where(and(...conditions))
+      .orderBy(desc(aiAgentRuns.queuedAt), desc(aiAgentRuns.id))
+      .limit(limit + 1);
+
+    let nextCursor: string | null = null;
+    let pageRows = rows;
+    if (rows.length > limit) {
+      pageRows = rows.slice(0, limit);
+      const last = pageRows[pageRows.length - 1];
+      if (last) nextCursor = encodeRunsCursor(runsCursorFromRow(last));
+    }
+
+    return c.json({ data: pageRows.map(mapRunListItem), nextCursor });
+  },
+);
+
+/**
+ * The stitched execution-trace detail (Wave 6 PR 1, #3828): the run row's
+ * display-safe fields plus the SAFE outcome projection, execution ledger,
+ * and linked-intent summary — see `buildRunTrace` (services/aiAgents/runTrace.ts)
+ * for the safety property this route depends on. Replaces the prior raw-row
+ * response; org scoping and 404 semantics are unchanged.
+ */
 aiAgentsRoutes.get('/runs/:runId', scopes, requireAiRead, async (c) => {
   const runId = uuidParam(c, 'runId');
   if (!runId) return c.json({ error: 'Run not found' }, 404);
@@ -223,12 +343,82 @@ aiAgentsRoutes.get('/runs/:runId', scopes, requireAiRead, async (c) => {
   // policy's every branch is false and the read returns nothing. The predicate
   // stays because the unit-test path mocks the db and has no RLS at all.
   const [run] = await db
-    .select()
+    .select({
+      id: aiAgentRuns.id,
+      agentId: aiAgentRuns.agentId,
+      orgId: aiAgentRuns.orgId,
+      deviceId: aiAgentRuns.deviceId,
+      alertId: aiAgentRuns.alertId,
+      sessionId: aiAgentRuns.sessionId,
+      triggerKind: aiAgentRuns.triggerKind,
+      modeAtStart: aiAgentRuns.modeAtStart,
+      status: aiAgentRuns.status,
+      summary: aiAgentRuns.summary,
+      outcome: aiAgentRuns.outcome,
+      intentIds: aiAgentRuns.intentIds,
+      turnCount: aiAgentRuns.turnCount,
+      costCents: aiAgentRuns.costCents,
+      errorCode: aiAgentRuns.errorCode,
+      queuedAt: aiAgentRuns.queuedAt,
+      startedAt: aiAgentRuns.startedAt,
+      finishedAt: aiAgentRuns.finishedAt,
+      agentName: aiAgents.name,
+      agentKind: aiAgents.kind,
+      deviceHostname: devices.hostname,
+    })
     .from(aiAgentRuns)
+    .innerJoin(aiAgents, eq(aiAgentRuns.agentId, aiAgents.id))
+    .leftJoin(devices, eq(aiAgentRuns.deviceId, devices.id))
     .where(and(eq(aiAgentRuns.id, runId), auth.orgCondition(aiAgentRuns.orgId)))
     .limit(1);
   if (!run) return c.json({ error: 'Run not found' }, 404);
-  return c.json({ data: run });
+
+  // The execution ledger is keyed by session, not run — `run.session_id` is
+  // set once, inside `driveSdkLoop`, right after the model resolves
+  // (runLoop.ts), and stays null for the lifetime of the run if that
+  // best-effort write itself failed.
+  const ledgerRows = run.sessionId
+    ? await db
+      .select({
+        toolName: aiToolExecutions.toolName,
+        status: aiToolExecutions.status,
+        durationMs: aiToolExecutions.durationMs,
+        createdAt: aiToolExecutions.createdAt,
+        completedAt: aiToolExecutions.completedAt,
+        errorMessage: aiToolExecutions.errorMessage,
+      })
+      .from(aiToolExecutions)
+      .where(eq(aiToolExecutions.sessionId, run.sessionId))
+      .orderBy(asc(aiToolExecutions.createdAt))
+    : [];
+
+  // `run.intent_ids` only ever lists PENDING intents (see the column's
+  // docstring in schema/aiAgents.ts and OutcomeProposedAction.intentId's in
+  // runLoop.ts) — an intent that was decided or expired drops out of the
+  // array, so this summary reflects "what's still awaiting a human", not
+  // the full proposal history. The org predicate is defence-in-depth beside
+  // RLS, matching the run read above.
+  const intentRows = run.intentIds.length > 0
+    ? await db
+      .select({
+        id: actionIntents.id,
+        status: actionIntents.status,
+        actionName: actionIntents.actionName,
+        approvalScope: actionIntents.approvalScope,
+        decidedVia: actionIntents.decidedVia,
+      })
+      .from(actionIntents)
+      .where(and(inArray(actionIntents.id, run.intentIds), auth.orgCondition(actionIntents.orgId)))
+    : [];
+
+  const detail = buildRunTrace(
+    run,
+    { name: run.agentName, kind: run.agentKind },
+    run.deviceHostname ? { hostname: run.deviceHostname } : null,
+    ledgerRows,
+    intentRows,
+  );
+  return c.json({ data: detail });
 });
 
 aiAgentsRoutes.get('/:id', scopes, requireAiRead, async (c) => {

--- a/apps/api/src/services/actionIntents/exposureBudget.test.ts
+++ b/apps/api/src/services/actionIntents/exposureBudget.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// DB mock — generic, table-name-keyed FIFO (mirrors policyDecide.test.ts's
+// own pattern exactly, since `computeExposureBudget` is extracted straight
+// out of that file's transaction and must keep hitting the SAME `../../db`
+// module those tests already mock).
+// ---------------------------------------------------------------------------
+
+const dbMockState = vi.hoisted(() => ({
+  rowQueues: {} as Record<string, unknown[][]>,
+}));
+
+function tableNameOf(table: unknown): string {
+  return String((table as Record<symbol, unknown>)[Symbol.for('drizzle:Name')]);
+}
+
+function nextRows(table: string): unknown[] {
+  const queue = dbMockState.rowQueues[table];
+  if (!queue || queue.length === 0) {
+    throw new Error(`No queued rows for table ${table}`);
+  }
+  return queue.shift() as unknown[];
+}
+
+function pushRows(table: string, rows: unknown[]): void {
+  (dbMockState.rowQueues[table] ??= []).push(rows);
+}
+
+function resetDbMock(): void {
+  dbMockState.rowQueues = {};
+}
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => {
+        const tableName = tableNameOf(table);
+        const builder: Record<string, unknown> = {
+          where: vi.fn(() => builder),
+          then: (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+            Promise.resolve().then(() => nextRows(tableName)).then(resolve, reject),
+        };
+        return builder;
+      }),
+    })),
+  },
+}));
+
+const contractMock = vi.hoisted(() => ({ countContractDevices: vi.fn(async () => 100) }));
+vi.mock('../contractQuantities', () => ({ countContractDevices: contractMock.countContractDevices }));
+
+import { computeExposureBudget } from './exposureBudget';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const AGENT_ID = '66666666-6666-4666-8666-666666666666';
+const DEVICE_ID = '99999999-9999-4999-8999-999999999999';
+
+beforeEach(() => {
+  resetDbMock();
+  vi.clearAllMocks();
+  contractMock.countContractDevices.mockResolvedValue(100);
+});
+
+describe('computeExposureBudget', () => {
+  it('reports the raw recorded exposure counts with no deviceId projection', async () => {
+    pushRows('ai_unattended_exposure', [{ deviceId: 'a' }, { deviceId: 'b' }]); // exposedDeviceRows
+    pushRows('ai_unattended_exposure', [{ n: 3 }]); // dayCountRow
+
+    const result = await computeExposureBudget({
+      orgId: ORG_ID,
+      agentId: AGENT_ID,
+      maxFleetPercentPerDay: 5,
+      maxPolicyDecisionsPerDay: 10,
+    });
+
+    expect(contractMock.countContractDevices).toHaveBeenCalledWith(ORG_ID, null);
+    expect(result).toEqual({
+      distinctDevices: 2,
+      allowance: 5, // floor(100 * 5 / 100)
+      contractDeviceCount: 100,
+      maxFleetPercentPerDay: 5,
+      policyDecisionsToday: 3,
+      maxPolicyDecisionsPerDay: 10,
+      windowHours: 24,
+    });
+  });
+
+  it('projects the candidate deviceId into distinctDevices when it is not already exposed (matches runAuthorizeTransaction)', async () => {
+    pushRows('ai_unattended_exposure', [{ deviceId: 'a' }, { deviceId: 'b' }]);
+    pushRows('ai_unattended_exposure', [{ n: 0 }]);
+
+    const result = await computeExposureBudget({
+      orgId: ORG_ID,
+      agentId: AGENT_ID,
+      maxFleetPercentPerDay: 5,
+      maxPolicyDecisionsPerDay: 10,
+      deviceId: DEVICE_ID,
+    });
+
+    expect(result.distinctDevices).toBe(3); // 2 already-exposed + the new candidate
+  });
+
+  it('does not double-count a candidate deviceId that is already exposed', async () => {
+    pushRows('ai_unattended_exposure', [{ deviceId: DEVICE_ID }, { deviceId: 'b' }]);
+    pushRows('ai_unattended_exposure', [{ n: 0 }]);
+
+    const result = await computeExposureBudget({
+      orgId: ORG_ID,
+      agentId: AGENT_ID,
+      maxFleetPercentPerDay: 5,
+      maxPolicyDecisionsPerDay: 10,
+      deviceId: DEVICE_ID,
+    });
+
+    expect(result.distinctDevices).toBe(2);
+  });
+
+  it('floors a fractional allowance rather than rounding up (locked quorum decision — no max(1, ·))', async () => {
+    pushRows('ai_unattended_exposure', []);
+    pushRows('ai_unattended_exposure', [{ n: 0 }]);
+    contractMock.countContractDevices.mockResolvedValue(3);
+
+    const result = await computeExposureBudget({
+      orgId: ORG_ID,
+      agentId: AGENT_ID,
+      maxFleetPercentPerDay: 5, // floor(3 * 5 / 100) = floor(0.15) = 0
+      maxPolicyDecisionsPerDay: 10,
+    });
+
+    expect(result.allowance).toBe(0);
+  });
+
+  it('scopes policyDecisionsToday to the given agentId (never a different agent\'s decisions)', async () => {
+    pushRows('ai_unattended_exposure', []);
+    pushRows('ai_unattended_exposure', [{ n: 7 }]);
+
+    const result = await computeExposureBudget({
+      orgId: ORG_ID,
+      agentId: AGENT_ID,
+      maxFleetPercentPerDay: 5,
+      maxPolicyDecisionsPerDay: 10,
+    });
+
+    expect(result.policyDecisionsToday).toBe(7);
+  });
+
+  describe('shortCircuitOnFleetCapExceeded', () => {
+    it('skips the day-count query entirely when the fleet cap already failed (matches runAuthorizeTransaction)', async () => {
+      // allowance = floor(100 * 5 / 100) = 5; 6 already exposed -> fails.
+      pushRows('ai_unattended_exposure', [
+        { deviceId: 'd1' }, { deviceId: 'd2' }, { deviceId: 'd3' },
+        { deviceId: 'd4' }, { deviceId: 'd5' }, { deviceId: 'd6' },
+      ]);
+      // Deliberately NO second pushRows — if the implementation ran the
+      // day-count query anyway, nextRows() would throw "No queued rows".
+
+      const result = await computeExposureBudget({
+        orgId: ORG_ID,
+        agentId: AGENT_ID,
+        maxFleetPercentPerDay: 5,
+        maxPolicyDecisionsPerDay: 10,
+        shortCircuitOnFleetCapExceeded: true,
+      });
+
+      expect(result.distinctDevices).toBe(6);
+      expect(result.allowance).toBe(5);
+      expect(result.policyDecisionsToday).toBeNull();
+    });
+
+    it('still runs the day-count query when the fleet cap passes', async () => {
+      pushRows('ai_unattended_exposure', [{ deviceId: 'd1' }]);
+      pushRows('ai_unattended_exposure', [{ n: 4 }]);
+
+      const result = await computeExposureBudget({
+        orgId: ORG_ID,
+        agentId: AGENT_ID,
+        maxFleetPercentPerDay: 5,
+        maxPolicyDecisionsPerDay: 10,
+        shortCircuitOnFleetCapExceeded: true,
+      });
+
+      expect(result.policyDecisionsToday).toBe(4);
+    });
+  });
+});

--- a/apps/api/src/services/actionIntents/exposureBudget.test.ts
+++ b/apps/api/src/services/actionIntents/exposureBudget.test.ts
@@ -1,15 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
 
 // ---------------------------------------------------------------------------
 // DB mock — generic, table-name-keyed FIFO (mirrors policyDecide.test.ts's
 // own pattern exactly, since `computeExposureBudget` is extracted straight
 // out of that file's transaction and must keep hitting the SAME `../../db`
-// module those tests already mock).
+// module those tests already mock). `where()` conditions are REAL drizzle-orm
+// SQL objects (only `db` itself is mocked, not `and`/`eq`/`gt`/`sql`), so they
+// are captured per-table and rendered via `PgDialect` below to assert the
+// actual compiled predicates rather than just the row-shape the query returns.
 // ---------------------------------------------------------------------------
 
 const dbMockState = vi.hoisted(() => ({
   rowQueues: {} as Record<string, unknown[][]>,
+  whereConds: {} as Record<string, unknown[]>,
 }));
+
+const dialect = new PgDialect();
+const render = (cond: unknown) => dialect.sqlToQuery(cond as SQL);
 
 function tableNameOf(table: unknown): string {
   return String((table as Record<symbol, unknown>)[Symbol.for('drizzle:Name')]);
@@ -29,6 +38,7 @@ function pushRows(table: string, rows: unknown[]): void {
 
 function resetDbMock(): void {
   dbMockState.rowQueues = {};
+  dbMockState.whereConds = {};
 }
 
 vi.mock('../../db', () => ({
@@ -37,7 +47,10 @@ vi.mock('../../db', () => ({
       from: vi.fn((table: unknown) => {
         const tableName = tableNameOf(table);
         const builder: Record<string, unknown> = {
-          where: vi.fn(() => builder),
+          where: vi.fn((cond: unknown) => {
+            (dbMockState.whereConds[tableName] ??= []).push(cond);
+            return builder;
+          }),
           then: (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
             Promise.resolve().then(() => nextRows(tableName)).then(resolve, reject),
         };
@@ -131,7 +144,7 @@ describe('computeExposureBudget', () => {
     expect(result.allowance).toBe(0);
   });
 
-  it('scopes policyDecisionsToday to the given agentId (never a different agent\'s decisions)', async () => {
+  it('scopes policyDecisionsToday to this agentId + source: \'policy_intent\' (never a different agent\'s decisions or act-lane exposures)', async () => {
     pushRows('ai_unattended_exposure', []);
     pushRows('ai_unattended_exposure', [{ n: 7 }]);
 
@@ -143,6 +156,29 @@ describe('computeExposureBudget', () => {
     });
 
     expect(result.policyDecisionsToday).toBe(7);
+
+    const conds = dbMockState.whereConds['ai_unattended_exposure'] ?? [];
+    expect(conds).toHaveLength(2);
+
+    // First query (fleet-cap exposed-device scan): org + window ONLY —
+    // deliberately fleet-wide across every agent and source.
+    const fleetCapQuery = render(conds[0]);
+    expect(fleetCapQuery.sql).toContain('"org_id" = ');
+    expect(fleetCapQuery.sql).toContain("now() - interval '24 hours'");
+    expect(fleetCapQuery.sql).not.toContain('"agent_id"');
+    expect(fleetCapQuery.sql).not.toContain('"source"');
+    expect(fleetCapQuery.params).toContain(ORG_ID);
+
+    // Second query (day-cap count): org + agent + source: 'policy_intent' +
+    // window — the four predicates that ARE the enforcement semantics.
+    const dayCountQuery = render(conds[1]);
+    expect(dayCountQuery.sql).toContain('"org_id" = ');
+    expect(dayCountQuery.sql).toContain('"agent_id" = ');
+    expect(dayCountQuery.sql).toContain('"source" = ');
+    expect(dayCountQuery.sql).toContain("now() - interval '24 hours'");
+    expect(dayCountQuery.params).toContain(ORG_ID);
+    expect(dayCountQuery.params).toContain(AGENT_ID);
+    expect(dayCountQuery.params).toContain('policy_intent');
   });
 
   describe('shortCircuitOnFleetCapExceeded', () => {

--- a/apps/api/src/services/actionIntents/exposureBudget.ts
+++ b/apps/api/src/services/actionIntents/exposureBudget.ts
@@ -1,0 +1,122 @@
+import { and, count, eq, gt, sql } from 'drizzle-orm';
+import { db } from '../../db';
+import { aiUnattendedExposure } from '../../db/schema/aiUnattendedExposure';
+import { countContractDevices } from '../contractQuantities';
+
+/**
+ * Wave 6 PR 1 (#3828) — the pure, read-only twin of the two SELECT queries
+ * `policyDecide.ts`'s `runAuthorizeTransaction` uses to gate a policy
+ * decision. Extracted verbatim (same tables, same conditions, same order —
+ * only the mutating advisory-lock/insert/CAS/outbox steps stay in
+ * `policyDecide.ts`) so BOTH callers share one implementation of the
+ * enforcement math instead of two copies that can drift:
+ *
+ *  - `policyDecide.ts` calls this from INSIDE its own system-scoped
+ *    transaction (`inSystemDbContext`/`withSystemDbAccessContext`) — since
+ *    `db` here is the same ambient, AsyncLocalStorage-backed accessor used
+ *    everywhere else in this codebase (see `withDbAccessContext` /
+ *    `withSystemDbAccessContext` in `db/index.ts`), calling this function
+ *    from inside that transaction reuses the SAME live transaction — no
+ *    explicit tx handle needs to be threaded through. Behavior is byte
+ *    identical to the inline queries it replaces.
+ *  - `GET /ai/agents/exposure-budget` (routes/aiAgents.ts) calls this
+ *    read-only, under the caller's own request-scoped (RLS-enforced)
+ *    context, with no `deviceId` — see that param's docstring below.
+ *
+ * DO NOT add a write here. The moment this needs to mutate anything, it has
+ * stopped being safe to call from a plain read route.
+ */
+export interface ExposureBudgetParams {
+  orgId: string;
+  /** Scopes `policyDecisionsToday` — mirrors `runAuthorizeTransaction`'s own
+   *  per-(org, agent, source='policy_intent') day-cap query. */
+  agentId: string;
+  maxFleetPercentPerDay: number;
+  maxPolicyDecisionsPerDay: number;
+  /**
+   * The device a live policy decision is being evaluated FOR. When given,
+   * `distinctDevices` is the PROJECTED count `runAuthorizeTransaction` checks
+   * against the allowance — the currently-exposed set plus this device, if
+   * it is not already in it. Omit it (as the read-only budget route does) to
+   * get the count of devices ALREADY recorded in the window, with no
+   * hypothetical device added — there is no live decision to project.
+   */
+  deviceId?: string;
+  /**
+   * When true, skip the second (day-cap) query entirely once the fleet-cap
+   * check already failed — matches `runAuthorizeTransaction`'s ORIGINAL
+   * inline control flow exactly (it returns `fleet_cap_exceeded` before ever
+   * running the day-count query), which `policyDecide.test.ts` asserts on
+   * directly (no `ai_unattended_exposure` day-count row queued for that
+   * case). The read-only budget route leaves this `false` (the default) —
+   * it always wants both figures for display, regardless of whether either
+   * cap is already exceeded.
+   */
+  shortCircuitOnFleetCapExceeded?: boolean;
+}
+
+export interface ExposureBudgetResult {
+  /** Distinct devices with a recorded exposure row in the trailing 24h
+   *  window, optionally including the projected candidate — see
+   *  `ExposureBudgetParams.deviceId`. */
+  distinctDevices: number;
+  /** floor(contractDeviceCount * maxFleetPercentPerDay / 100). No
+   *  `max(1, ·)` — a fleet too small for a whole device's worth of allowance
+   *  gets zero unattended authorizations (locked quorum decision, see
+   *  `policyDecide.ts`). */
+  allowance: number;
+  contractDeviceCount: number;
+  maxFleetPercentPerDay: number;
+  /** Count of this agent's `source: 'policy_intent'` exposure rows recorded
+   *  in the trailing 24h window. `null` ONLY when `shortCircuitOnFleetCapExceeded`
+   *  skipped the query because the fleet cap already failed — the read-only
+   *  budget route never sees `null` here, since it never short-circuits. */
+  policyDecisionsToday: number | null;
+  maxPolicyDecisionsPerDay: number;
+  windowHours: 24;
+}
+
+export async function computeExposureBudget(params: ExposureBudgetParams): Promise<ExposureBudgetResult> {
+  const {
+    orgId, agentId, maxFleetPercentPerDay, maxPolicyDecisionsPerDay, deviceId,
+    shortCircuitOnFleetCapExceeded = false,
+  } = params;
+  const windowStart = sql`now() - interval '24 hours'`;
+
+  const exposedDeviceRows = await db
+    .select({ deviceId: aiUnattendedExposure.deviceId })
+    .from(aiUnattendedExposure)
+    .where(and(eq(aiUnattendedExposure.orgId, orgId), gt(aiUnattendedExposure.reservedAt, windowStart)));
+  const exposedDevices = new Set(exposedDeviceRows.map((r) => r.deviceId));
+  const deviceAlreadyExposed = deviceId !== undefined && exposedDevices.has(deviceId);
+
+  const contractDeviceCount = await countContractDevices(orgId, null);
+  const allowance = Math.floor((contractDeviceCount * maxFleetPercentPerDay) / 100);
+  const distinctDevices = exposedDevices.size + (deviceId !== undefined && !deviceAlreadyExposed ? 1 : 0);
+
+  let policyDecisionsToday: number | null = null;
+  if (!shortCircuitOnFleetCapExceeded || distinctDevices <= allowance) {
+    const [dayCountRow] = await db
+      .select({ n: count() })
+      .from(aiUnattendedExposure)
+      .where(
+        and(
+          eq(aiUnattendedExposure.orgId, orgId),
+          eq(aiUnattendedExposure.agentId, agentId),
+          eq(aiUnattendedExposure.source, 'policy_intent'),
+          gt(aiUnattendedExposure.reservedAt, windowStart),
+        ),
+      );
+    policyDecisionsToday = Number(dayCountRow?.n ?? 0);
+  }
+
+  return {
+    distinctDevices,
+    allowance,
+    contractDeviceCount,
+    maxFleetPercentPerDay,
+    policyDecisionsToday,
+    maxPolicyDecisionsPerDay,
+    windowHours: 24,
+  };
+}

--- a/apps/api/src/services/actionIntents/policyDecide.ts
+++ b/apps/api/src/services/actionIntents/policyDecide.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, count, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import type { AiAgentKind, AiAgentPolicySnapshot } from '@breeze/shared';
 import {
   db,
@@ -16,10 +16,10 @@ import { checkAgentGuardrails, resolveActionForTool, type AgentGuardrailPolicy }
 import { readAiKillState } from '../aiKillState';
 import { resolveEffectiveAgentSystem } from '../aiAgents/effectivePolicy';
 import { resolveRecipientUserIds } from '../aiAgents/recipients';
-import { countContractDevices } from '../contractQuantities';
 import { createNotification } from '../userNotifications';
 import { captureException } from '../sentry';
 import { validateAuthorizationKeys, POLICY_DECIDABLE_TIER3_VERSION } from './policyDecidable';
+import { computeExposureBudget } from './exposureBudget';
 import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
 import { recordActionIntentEvent } from './metrics';
 import { runDeferredHumanFanout, RELEASE_LEASE_MS } from './intentService';
@@ -251,40 +251,37 @@ async function runAuthorizeTransaction(args: AuthorizeArgs): Promise<AuthorizeRe
     // separate unlock call.
     await db.execute(sql`select pg_advisory_xact_lock(hashtextextended(${`ai-exposure:${intent.orgId}`}, 0))`);
 
-    const windowStart = sql`now() - interval '24 hours'`;
-
-    const exposedDeviceRows = await db
-      .select({ deviceId: aiUnattendedExposure.deviceId })
-      .from(aiUnattendedExposure)
-      .where(and(eq(aiUnattendedExposure.orgId, intent.orgId), gt(aiUnattendedExposure.reservedAt, windowStart)));
-    const exposedDevices = new Set(exposedDeviceRows.map((r) => r.deviceId));
-    const deviceAlreadyExposed = exposedDevices.has(deviceId);
-
-    const contractDeviceCount = await countContractDevices(intent.orgId, null);
+    // The two read-only cap checks below are extracted into
+    // `computeExposureBudget` (Wave 6 PR 1, #3828) — the shared, pure twin
+    // `GET /ai/agents/exposure-budget` also calls read-only. Called from
+    // inside this transaction (ambient `db` context, no explicit tx handle
+    // needed — see that function's header comment), behavior is byte
+    // identical to the inline queries it replaces: same tables, same
+    // conditions, same order. `deviceId` is passed so `distinctDevices`
+    // comes back as the PROJECTED count (current exposure plus this device,
+    // if new) exactly as the inline code computed `projectedDistinctDevices`.
+    const budget = await computeExposureBudget({
+      orgId: intent.orgId,
+      agentId,
+      maxFleetPercentPerDay,
+      maxPolicyDecisionsPerDay,
+      deviceId,
+      // Matches the ORIGINAL inline control flow exactly: never run the
+      // day-count query once the fleet cap has already failed.
+      shortCircuitOnFleetCapExceeded: true,
+    });
     // floor(), no max(1, ·) — a tiny fleet with a nonzero-but-sub-1-device
     // allowance gets ZERO unattended authorizations. That is the correct,
     // intended reading (locked quorum decision): the operator raises
     // maxFleetPercentPerDay if they want unattended authority on a small
     // fleet, this function never silently grants "at least one."
-    const allowance = Math.floor((contractDeviceCount * maxFleetPercentPerDay) / 100);
-    const projectedDistinctDevices = exposedDevices.size + (deviceAlreadyExposed ? 0 : 1);
-    if (projectedDistinctDevices > allowance) {
+    if (budget.distinctDevices > budget.allowance) {
       return { ok: false, reason: 'fleet_cap_exceeded' };
     }
 
-    const [dayCountRow] = await db
-      .select({ n: count() })
-      .from(aiUnattendedExposure)
-      .where(
-        and(
-          eq(aiUnattendedExposure.orgId, intent.orgId),
-          eq(aiUnattendedExposure.agentId, agentId),
-          eq(aiUnattendedExposure.source, 'policy_intent'),
-          gt(aiUnattendedExposure.reservedAt, windowStart),
-        ),
-      );
-    const policyDecisionsToday = Number(dayCountRow?.n ?? 0);
-    if (policyDecisionsToday >= maxPolicyDecisionsPerDay) {
+    // Non-null here: the fleet check above just passed, so the
+    // shortCircuitOnFleetCapExceeded branch always ran the day-count query.
+    if ((budget.policyDecisionsToday as number) >= budget.maxPolicyDecisionsPerDay) {
       return { ok: false, reason: 'day_cap_exceeded' };
     }
 

--- a/apps/api/src/services/aiAgents/runFinishedNotify.test.ts
+++ b/apps/api/src/services/aiAgents/runFinishedNotify.test.ts
@@ -105,7 +105,7 @@ describe('deliverRunFinishedNotifications', () => {
       type: 'ai',
       title: 'Agent run finished',
       message: 'Front Desk Triage: Investigated the disk alert.',
-      link: null,
+      link: `/ai-agents/runs/${RUN_ID}`,
       dedupeKey: `agent-run:${RUN_ID}`,
       metadata: {
         runId: RUN_ID,
@@ -118,7 +118,7 @@ describe('deliverRunFinishedNotifications', () => {
     });
   });
 
-  it('links to /approvals only when the run left intents pending', async () => {
+  it('links to the run detail page even when the run left intents pending', async () => {
     queueRows('ai_agent_runs', [{ ...baseRun, status: 'awaiting_approval', intentIds: [INTENT_ID] }]);
     queueRows('ai_agents', [baseAgent]);
     resolveRecipientUserIds.mockResolvedValue([USER_A]);
@@ -126,7 +126,7 @@ describe('deliverRunFinishedNotifications', () => {
     await deliverRunFinishedNotifications(RUN_ID);
 
     const [input] = createNotification.mock.calls[0]!;
-    expect((input as { link: string | null }).link).toBe('/approvals');
+    expect((input as { link: string | null }).link).toBe(`/ai-agents/runs/${RUN_ID}`);
     expect((input as { metadata: { status: string } }).metadata.status).toBe('awaiting_approval');
   });
 

--- a/apps/api/src/services/aiAgents/runFinishedNotify.ts
+++ b/apps/api/src/services/aiAgents/runFinishedNotify.ts
@@ -226,9 +226,10 @@ export async function deliverRunFinishedNotifications(runId: string): Promise<vo
         type: 'ai',
         title: verdictAwareTitle(agent.name, verdict),
         message: `${agent.name}: ${firstLine || run.status}`,
-        // There is no run-detail page until wave 6; link to the approvals
-        // queue only when there is actually something waiting there.
-        link: run.intentIds.length > 0 ? '/approvals' : null,
+        // The run-detail page (wave 6.1) surfaces pending approvals itself,
+        // so every run-finished notification links there unconditionally —
+        // no more branching to '/approvals'.
+        link: `/ai-agents/runs/${run.id}`,
         // Only 'needs_attention' escalates priority — every other verdict
         // (including null, the pre-Part-B/non-act-mode default) keeps the
         // existing 'normal' default createNotification already applies.

--- a/apps/api/src/services/aiAgents/runTrace.test.ts
+++ b/apps/api/src/services/aiAgents/runTrace.test.ts
@@ -249,4 +249,16 @@ describe('buildRunTrace — safe projection (#3828)', () => {
     expect(detail.deviceId).toBeNull();
     expect(detail.deviceHostname).toBeNull();
   });
+
+  // Review fix (#3828): the route left-joins ai_agents (not innerJoin) because
+  // a partner-wide agent's row (#2135) is RLS-invisible to an org-scoped
+  // caller even though the run it produced stays visible. `agent: null` is
+  // how that shows up here — the run must still produce a full DTO, with
+  // agentName/agentKind null rather than the run vanishing (404).
+  it('is null for agentName/agentKind when the agent is null (RLS-hidden partner-wide agent)', () => {
+    const detail = buildRunTrace(baseRun(), null, DEVICE, [], []);
+    expect(detail.agentName).toBeNull();
+    expect(detail.agentKind).toBeNull();
+    expect(detail.id).toBe(RUN_ID);
+  });
 });

--- a/apps/api/src/services/aiAgents/runTrace.test.ts
+++ b/apps/api/src/services/aiAgents/runTrace.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'vitest';
+import { AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS } from '@breeze/shared';
+import { buildRunTrace, type RunTraceRunInput } from './runTrace';
+
+const RUN_ID = '11111111-1111-4111-8111-111111111111';
+const AGENT_ID = '22222222-2222-4222-8222-222222222222';
+const ORG_ID = '33333333-3333-4333-8333-333333333333';
+const DEVICE_ID = '44444444-4444-4444-8444-444444444444';
+const INTENT_ID = '55555555-5555-4555-8555-555555555555';
+
+function baseRun(overrides: Partial<RunTraceRunInput> = {}): RunTraceRunInput {
+  return {
+    id: RUN_ID,
+    agentId: AGENT_ID,
+    orgId: ORG_ID,
+    deviceId: DEVICE_ID,
+    alertId: null,
+    triggerKind: 'manual',
+    modeAtStart: 'shadow',
+    status: 'completed',
+    summary: 'Restarted the print spooler.',
+    outcome: {},
+    turnCount: 3,
+    costCents: 12,
+    errorCode: null,
+    queuedAt: new Date('2026-08-28T10:00:00.000Z'),
+    startedAt: new Date('2026-08-28T10:00:01.000Z'),
+    finishedAt: new Date('2026-08-28T10:00:30.000Z'),
+    ...overrides,
+  };
+}
+
+const AGENT = { name: 'Triage Agent', kind: 'triage' as const };
+const DEVICE = { hostname: 'WKS-042' };
+
+describe('buildRunTrace — safe projection (#3828)', () => {
+  it('maps a full wave-4/5 outcome into executed, then proposed, then denied trace entries', () => {
+    const detail = buildRunTrace(
+      baseRun({
+        outcome: {
+          findings: [],
+          executedActions: [
+            {
+              tool: 'manage_services',
+              action: 'restart',
+              executionId: 'exec-1',
+              result: 'ok',
+              durationMs: 340,
+              execution: 'succeeded',
+              verification: 'passed',
+              verifyDetail: 'service running',
+              actOpKey: 'manage_services.restart',
+              actTargetName: 'Spooler',
+            },
+          ],
+          proposedActions: [
+            {
+              tool: 'run_script',
+              action: 'invoke',
+              args: { scriptId: 'abc', secretParam: 'super-secret-value' },
+              intentId: INTENT_ID,
+              downgradeReason: 'missing identity field',
+            },
+          ],
+          deniedActions: [{ tool: 'delete_registry_key', reason: 'protected resource' }],
+          toolExecutionCount: 2,
+          runVerdict: 'partial',
+          budgetExceeded: false,
+          wallClockExceeded: false,
+          maxTurnsExceeded: false,
+        },
+      }),
+      AGENT,
+      DEVICE,
+      [],
+      [],
+    );
+
+    expect(detail.schemaVersion).toBe(1);
+    expect(detail.runVerdict).toBe('partial');
+    expect(detail.agentName).toBe('Triage Agent');
+    expect(detail.deviceHostname).toBe('WKS-042');
+    expect(detail.trace).toEqual([
+      {
+        kind: 'executed',
+        tool: 'manage_services',
+        action: 'restart',
+        result: 'ok',
+        durationMs: 340,
+        execution: 'succeeded',
+        verification: 'passed',
+        verifyDetail: 'service running',
+        actOpKey: 'manage_services.restart',
+        actTargetName: 'Spooler',
+      },
+      {
+        kind: 'proposed',
+        tool: 'run_script',
+        action: 'invoke',
+        intentId: INTENT_ID,
+        intentError: undefined,
+        downgradeReason: 'missing identity field',
+      },
+      { kind: 'denied', tool: 'delete_registry_key', reason: 'protected resource' },
+    ]);
+  });
+
+  it('never carries the proposed action\'s raw args onto the trace, even when present on the source outcome', () => {
+    const detail = buildRunTrace(
+      baseRun({
+        outcome: {
+          proposedActions: [
+            {
+              tool: 'run_script',
+              args: { toolInput: 'ignored-key-name-collision', secret: 'zzz-leak-marker-zzz' },
+            },
+          ],
+        },
+      }),
+      AGENT,
+      null,
+      [],
+      [],
+    );
+
+    const json = JSON.stringify(detail);
+    for (const forbidden of AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS) {
+      expect(json).not.toContain(`"${forbidden}"`);
+    }
+    // The nested secret value itself must not have leaked through either.
+    expect(json).not.toContain('zzz-leak-marker-zzz');
+  });
+
+  it('tolerates a wave-3-era outcome with no runVerdict/execution/verification fields at all', () => {
+    const detail = buildRunTrace(
+      baseRun({
+        outcome: {
+          findings: [],
+          executedActions: [
+            { tool: 'get_processes', executionId: 'exec-9', result: 'ok', durationMs: 50 },
+          ],
+          proposedActions: [],
+          deniedActions: [],
+          toolExecutionCount: 1,
+          // no runVerdict, no budgetExceeded/wallClockExceeded/maxTurnsExceeded
+        },
+      }),
+      AGENT,
+      null,
+      [],
+      [],
+    );
+
+    expect(detail.runVerdict).toBeNull();
+    expect(detail.budgetExceeded).toBe(false);
+    expect(detail.wallClockExceeded).toBe(false);
+    expect(detail.maxTurnsExceeded).toBe(false);
+    expect(detail.trace).toEqual([
+      {
+        kind: 'executed',
+        tool: 'get_processes',
+        action: undefined,
+        result: 'ok',
+        durationMs: 50,
+        execution: undefined,
+        verification: undefined,
+        verifyDetail: undefined,
+        actOpKey: undefined,
+        actTargetName: undefined,
+      },
+    ]);
+  });
+
+  it('tolerates a completely empty/malformed outcome object without throwing', () => {
+    const detail = buildRunTrace(baseRun({ outcome: {} }), AGENT, null, [], []);
+    expect(detail.trace).toEqual([]);
+    expect(detail.runVerdict).toBeNull();
+  });
+
+  it('defends against a corrupted non-array outcome field by treating it as empty', () => {
+    const detail = buildRunTrace(
+      baseRun({ outcome: { executedActions: 'not-an-array', proposedActions: null } }),
+      AGENT,
+      null,
+      [],
+      [],
+    );
+    expect(detail.trace).toEqual([]);
+  });
+
+  it('maps ledger rows to the safe projection only (toolName/status/durations/error)', () => {
+    const detail = buildRunTrace(
+      baseRun(),
+      AGENT,
+      DEVICE,
+      [
+        {
+          toolName: 'run_script',
+          status: 'completed',
+          durationMs: 210,
+          createdAt: new Date('2026-08-28T10:00:05.000Z'),
+          completedAt: new Date('2026-08-28T10:00:06.000Z'),
+          errorMessage: null,
+        },
+      ],
+      [],
+    );
+    expect(detail.ledger).toEqual([
+      {
+        toolName: 'run_script',
+        status: 'completed',
+        durationMs: 210,
+        createdAt: '2026-08-28T10:00:05.000Z',
+        completedAt: '2026-08-28T10:00:06.000Z',
+        errorMessage: null,
+      },
+    ]);
+  });
+
+  it('maps intent rows to id/status/actionName/approvalScope/decidedVia only', () => {
+    const detail = buildRunTrace(
+      baseRun(),
+      AGENT,
+      DEVICE,
+      [],
+      [
+        {
+          id: INTENT_ID,
+          status: 'pending_approval',
+          actionName: 'manage_services.restart',
+          approvalScope: 'four_eyes',
+          decidedVia: null,
+        },
+      ],
+    );
+    expect(detail.intents).toEqual([
+      {
+        id: INTENT_ID,
+        status: 'pending_approval',
+        actionName: 'manage_services.restart',
+        approvalScope: 'four_eyes',
+        decidedVia: null,
+      },
+    ]);
+  });
+
+  it('is null for deviceHostname when the run has no device', () => {
+    const detail = buildRunTrace(baseRun({ deviceId: null }), AGENT, null, [], []);
+    expect(detail.deviceId).toBeNull();
+    expect(detail.deviceHostname).toBeNull();
+  });
+});

--- a/apps/api/src/services/aiAgents/runTrace.ts
+++ b/apps/api/src/services/aiAgents/runTrace.ts
@@ -1,0 +1,208 @@
+/**
+ * Wave 6 PR 1 (#3828) — builds the stitched `GET /ai/agents/runs/:runId`
+ * detail DTO out of the run row, its `AgentRunOutcome` (runLoop.ts), the
+ * execution-ledger rows, and any linked action-intent rows.
+ *
+ * SAFE PROJECTION IS THE POINT OF THIS FILE. `OutcomeProposedAction.args`
+ * (the raw tool input the model proposed) and `ai_tool_executions.toolInput`/
+ * `toolOutput` are read from their source objects here — and deliberately
+ * never assigned onto the returned DTO. `AiAgentRunTraceEntryDto`
+ * (@breeze/shared) has no field that could carry them even by accident; see
+ * its header for the full rationale. Pure and synchronous — every DB read
+ * happens in the route handler, which hands this function already-loaded
+ * rows, so this file is unit-testable against fixtures with no DB.
+ */
+
+import type {
+  ActionIntentApprovalScope,
+  ActionIntentStatus,
+} from '../../db/schema/actionIntents';
+import type {
+  AgentRunOutcome,
+  OutcomeExecutedAction,
+  OutcomeProposedAction,
+} from './runLoop';
+import {
+  AI_AGENT_RUN_DTO_SCHEMA_VERSION,
+  type AiAgentKind,
+  type AiAgentMode,
+  type AiAgentRunDetailDto,
+  type AiAgentRunIntentSummaryDto,
+  type AiAgentRunLedgerEntryDto,
+  type AiAgentRunStatus,
+  type AiAgentRunTraceEntryDto,
+  type AiAgentTriggerKind,
+  type AiToolStatus,
+} from '@breeze/shared';
+
+export interface RunTraceRunInput {
+  id: string;
+  agentId: string;
+  orgId: string;
+  deviceId: string | null;
+  alertId: string | null;
+  triggerKind: AiAgentTriggerKind;
+  modeAtStart: Exclude<AiAgentMode, 'off'>;
+  status: AiAgentRunStatus;
+  summary: string | null;
+  /**
+   * The raw `ai_agent_runs.outcome` jsonb column — typed `Record<string,
+   * unknown>` at the schema layer (see aiAgents.ts) because Postgres jsonb
+   * carries no compile-time shape. Treated here as a `Partial<AgentRunOutcome>`
+   * (we are the only writer, via `runLoop.ts`'s `finishRun`), tolerantly: a
+   * run enqueued before wave 4's `execution`/`verification` fields, or before
+   * `runVerdict` existed at all (wave 3-era rows), reads back with those keys
+   * simply absent — `AgentRunOutcome`'s own optionality already models that,
+   * so no extra normalization pass is needed beyond defensive `?? []`/`?? null`
+   * defaults against a maximally-corrupt row.
+   */
+  outcome: Record<string, unknown>;
+  turnCount: number;
+  costCents: number;
+  errorCode: string | null;
+  queuedAt: Date;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+}
+
+export interface RunTraceAgentInput {
+  name: string;
+  kind: AiAgentKind;
+}
+
+export interface RunTraceDeviceInput {
+  hostname: string;
+}
+
+/** The safe-projected subset of one `ai_tool_executions` row. */
+export interface RunTraceLedgerRowInput {
+  toolName: string;
+  status: AiToolStatus;
+  durationMs: number | null;
+  createdAt: Date;
+  completedAt: Date | null;
+  errorMessage: string | null;
+}
+
+/** The safe-projected subset of one linked `action_intents` row. */
+export interface RunTraceIntentRowInput {
+  id: string;
+  status: ActionIntentStatus;
+  actionName: string;
+  approvalScope: ActionIntentApprovalScope;
+  decidedVia: string | null;
+}
+
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function mapExecuted(action: OutcomeExecutedAction): AiAgentRunTraceEntryDto {
+  return {
+    kind: 'executed',
+    tool: action.tool,
+    action: action.action,
+    result: action.result,
+    durationMs: action.durationMs,
+    execution: action.execution,
+    verification: action.verification,
+    verifyDetail: action.verifyDetail,
+    actOpKey: action.actOpKey,
+    actTargetName: action.actTargetName,
+  };
+}
+
+/**
+ * `action.args` — the raw tool input the model proposed — is intentionally
+ * never read here. Every field below is display-safe by construction (see
+ * `OutcomeProposedAction`'s own docstring in runLoop.ts).
+ */
+function mapProposed(action: OutcomeProposedAction): AiAgentRunTraceEntryDto {
+  return {
+    kind: 'proposed',
+    tool: action.tool,
+    action: action.action,
+    intentId: action.intentId,
+    intentError: action.intentError,
+    downgradeReason: action.downgradeReason,
+  };
+}
+
+function mapDenied(action: { tool: string; reason: string }): AiAgentRunTraceEntryDto {
+  return { kind: 'denied', tool: action.tool, reason: action.reason };
+}
+
+/**
+ * Concatenation order: executed, then proposed, then denied. `AgentRunOutcome`
+ * stores these as three separate arrays (runLoop.ts pushes into whichever one
+ * applies as a turn resolves) with no shared timestamp to interleave by, so
+ * there is no true chronological merge to recover — this order groups the
+ * timeline into "what happened" / "what's waiting" / "what was refused",
+ * which is also the reading order the run-detail UI wants (Task 4).
+ */
+function buildTraceEntries(outcome: Partial<AgentRunOutcome>): AiAgentRunTraceEntryDto[] {
+  return [
+    ...asArray<OutcomeExecutedAction>(outcome.executedActions).map(mapExecuted),
+    ...asArray<OutcomeProposedAction>(outcome.proposedActions).map(mapProposed),
+    ...asArray<{ tool: string; reason: string }>(outcome.deniedActions).map(mapDenied),
+  ];
+}
+
+function mapLedgerRow(row: RunTraceLedgerRowInput): AiAgentRunLedgerEntryDto {
+  return {
+    toolName: row.toolName,
+    status: row.status,
+    durationMs: row.durationMs,
+    createdAt: row.createdAt.toISOString(),
+    completedAt: row.completedAt ? row.completedAt.toISOString() : null,
+    errorMessage: row.errorMessage,
+  };
+}
+
+function mapIntentRow(row: RunTraceIntentRowInput): AiAgentRunIntentSummaryDto {
+  return {
+    id: row.id,
+    status: row.status,
+    actionName: row.actionName,
+    approvalScope: row.approvalScope,
+    decidedVia: row.decidedVia,
+  };
+}
+
+export function buildRunTrace(
+  run: RunTraceRunInput,
+  agent: RunTraceAgentInput,
+  device: RunTraceDeviceInput | null,
+  ledgerRows: RunTraceLedgerRowInput[],
+  intents: RunTraceIntentRowInput[],
+): AiAgentRunDetailDto {
+  const outcome = run.outcome as Partial<AgentRunOutcome>;
+  return {
+    schemaVersion: AI_AGENT_RUN_DTO_SCHEMA_VERSION,
+    id: run.id,
+    agentId: run.agentId,
+    agentName: agent.name,
+    agentKind: agent.kind,
+    orgId: run.orgId,
+    deviceId: run.deviceId,
+    deviceHostname: device?.hostname ?? null,
+    alertId: run.alertId,
+    triggerKind: run.triggerKind,
+    modeAtStart: run.modeAtStart,
+    status: run.status,
+    summary: run.summary,
+    runVerdict: outcome.runVerdict ?? null,
+    turnCount: run.turnCount,
+    costCents: run.costCents,
+    errorCode: run.errorCode,
+    queuedAt: run.queuedAt.toISOString(),
+    startedAt: run.startedAt ? run.startedAt.toISOString() : null,
+    finishedAt: run.finishedAt ? run.finishedAt.toISOString() : null,
+    budgetExceeded: outcome.budgetExceeded ?? false,
+    wallClockExceeded: outcome.wallClockExceeded ?? false,
+    maxTurnsExceeded: outcome.maxTurnsExceeded ?? false,
+    trace: buildTraceEntries(outcome),
+    ledger: ledgerRows.map(mapLedgerRow),
+    intents: intents.map(mapIntentRow),
+  };
+}

--- a/apps/api/src/services/aiAgents/runTrace.ts
+++ b/apps/api/src/services/aiAgents/runTrace.ts
@@ -171,7 +171,12 @@ function mapIntentRow(row: RunTraceIntentRowInput): AiAgentRunIntentSummaryDto {
 
 export function buildRunTrace(
   run: RunTraceRunInput,
-  agent: RunTraceAgentInput,
+  // `null` when the agent row is RLS-invisible to the caller — a partner-wide
+  // agent (#2135) is not reachable via breeze_has_partner_access from an
+  // org-scoped context even though the run it produced (plain org-scoped)
+  // is. The route left-joins ai_agents for exactly this reason: a run must
+  // never disappear because its agent row did.
+  agent: RunTraceAgentInput | null,
   device: RunTraceDeviceInput | null,
   ledgerRows: RunTraceLedgerRowInput[],
   intents: RunTraceIntentRowInput[],
@@ -181,8 +186,8 @@ export function buildRunTrace(
     schemaVersion: AI_AGENT_RUN_DTO_SCHEMA_VERSION,
     id: run.id,
     agentId: run.agentId,
-    agentName: agent.name,
-    agentKind: agent.kind,
+    agentName: agent?.name ?? null,
+    agentKind: agent?.kind ?? null,
     orgId: run.orgId,
     deviceId: run.deviceId,
     deviceHostname: device?.hostname ?? null,

--- a/apps/api/src/services/aiAgents/runsListCursor.test.ts
+++ b/apps/api/src/services/aiAgents/runsListCursor.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decodeRunsCursor,
+  encodeRunsCursor,
+  runsCursorFromRow,
+  type AiAgentRunsCursor,
+} from './runsListCursor';
+
+const RUN_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('runsListCursor (#3828)', () => {
+  it('round-trips encode -> decode', () => {
+    const cursor: AiAgentRunsCursor = { v: 1, q: '2026-08-28T10:00:00.000Z', id: RUN_ID };
+    expect(decodeRunsCursor(encodeRunsCursor(cursor))).toEqual(cursor);
+  });
+
+  it('builds a cursor from a row via runsCursorFromRow, matching encode/decode round-trip', () => {
+    const row = { id: RUN_ID, queuedAt: new Date('2026-08-28T10:00:00.000Z') };
+    const cursor = runsCursorFromRow(row);
+    expect(cursor).toEqual({ v: 1, q: '2026-08-28T10:00:00.000Z', id: RUN_ID });
+    expect(decodeRunsCursor(encodeRunsCursor(cursor))).toEqual(cursor);
+  });
+
+  it('returns null for an absent token', () => {
+    expect(decodeRunsCursor(undefined)).toBeNull();
+    expect(decodeRunsCursor(null)).toBeNull();
+  });
+
+  it('returns null for a non-base64url token', () => {
+    expect(decodeRunsCursor('not valid base64url!!!')).toBeNull();
+  });
+
+  it('returns null for base64url that is not JSON', () => {
+    const token = Buffer.from('not-json', 'utf8').toString('base64url');
+    expect(decodeRunsCursor(token)).toBeNull();
+  });
+
+  it('returns null for the wrong version', () => {
+    const token = Buffer.from(JSON.stringify({ v: 2, q: '2026-08-28T10:00:00.000Z', id: RUN_ID }), 'utf8')
+      .toString('base64url');
+    expect(decodeRunsCursor(token)).toBeNull();
+  });
+
+  it('returns null for a non-date q', () => {
+    const token = Buffer.from(JSON.stringify({ v: 1, q: 'not-a-date', id: RUN_ID }), 'utf8')
+      .toString('base64url');
+    expect(decodeRunsCursor(token)).toBeNull();
+  });
+
+  it('returns null for a non-uuid id', () => {
+    const token = Buffer.from(JSON.stringify({ v: 1, q: '2026-08-28T10:00:00.000Z', id: 'not-a-uuid' }), 'utf8')
+      .toString('base64url');
+    expect(decodeRunsCursor(token)).toBeNull();
+  });
+});

--- a/apps/api/src/services/aiAgents/runsListCursor.test.ts
+++ b/apps/api/src/services/aiAgents/runsListCursor.test.ts
@@ -15,10 +15,23 @@ describe('runsListCursor (#3828)', () => {
   });
 
   it('builds a cursor from a row via runsCursorFromRow, matching encode/decode round-trip', () => {
-    const row = { id: RUN_ID, queuedAt: new Date('2026-08-28T10:00:00.000Z') };
+    const row = { id: RUN_ID, queuedAtRaw: '2026-08-28T10:00:00.000000Z' };
     const cursor = runsCursorFromRow(row);
-    expect(cursor).toEqual({ v: 1, q: '2026-08-28T10:00:00.000Z', id: RUN_ID });
+    expect(cursor).toEqual({ v: 1, q: '2026-08-28T10:00:00.000000Z', id: RUN_ID });
     expect(decodeRunsCursor(encodeRunsCursor(cursor))).toEqual(cursor);
+  });
+
+  // Review fix (#3828): runsCursorFromRow must carry the row's full
+  // microsecond-precision text verbatim — never derive it from (or truncate
+  // it through) a JS Date, which only has millisecond resolution. Two rows
+  // that queue in the same millisecond but different microseconds must
+  // produce distinguishable cursors, or the keyset walk silently skips one.
+  it('preserves microsecond precision through runsCursorFromRow — does not round-trip via a JS Date', () => {
+    const a = runsCursorFromRow({ id: RUN_ID, queuedAtRaw: '2026-08-28T10:00:00.123456Z' });
+    const b = runsCursorFromRow({ id: RUN_ID, queuedAtRaw: '2026-08-28T10:00:00.123200Z' });
+    expect(a.q).toBe('2026-08-28T10:00:00.123456Z');
+    expect(b.q).toBe('2026-08-28T10:00:00.123200Z');
+    expect(a.q).not.toBe(b.q);
   });
 
   it('returns null for an absent token', () => {

--- a/apps/api/src/services/aiAgents/runsListCursor.ts
+++ b/apps/api/src/services/aiAgents/runsListCursor.ts
@@ -1,0 +1,71 @@
+/**
+ * Keyset cursor pagination for `GET /ai/agents/runs` (org-wide list, Wave 6
+ * PR 1 #3828). Mirrors `routes/devices/cursor.ts`'s token shape and
+ * malformed-input handling, simplified to the one fixed sort this endpoint
+ * offers: `(queued_at DESC, id DESC)` — see the covering index added in
+ * migrations/2026-09-17-ai-agent-runs-keyset-index.sql. Devices' cursor
+ * module supports three caller-selectable sort keys (including a nullable
+ * one) and needs the generality that comes with; this endpoint has exactly
+ * one sort, so there is no `sort`/`sortDir`/NULL-phase machinery to carry.
+ *
+ * `id` is a required tiebreaker, not an optional nicety: `queued_at` is not
+ * unique (two runs can queue in the same millisecond), so a keyset on
+ * `queued_at` alone can skip or duplicate rows across pages when that
+ * happens.
+ */
+
+import { sql, type SQL } from 'drizzle-orm';
+import { aiAgentRuns } from '../../db/schema';
+import { UUID_REGEX } from '../../utils/uuid';
+
+/** Wire shape carried in the opaque base64url-JSON cursor token. `v` is
+ *  bumped if the shape ever changes incompatibly. */
+export interface AiAgentRunsCursor {
+  v: 1;
+  /** Last-row `queued_at`, ISO-8601. */
+  q: string;
+  /** Tiebreaker — last-row `ai_agent_runs.id`. */
+  id: string;
+}
+
+const BASE64URL_TOKEN_RE = /^[A-Za-z0-9_-]+={0,2}$/;
+
+/** Encode the cursor as a URL-safe base64 JSON token (padding trimmed so it
+ *  slots into a query string without %-encoding noise). */
+export function encodeRunsCursor(c: AiAgentRunsCursor): string {
+  return Buffer.from(JSON.stringify(c), 'utf8').toString('base64url');
+}
+
+/**
+ * Decode + validate an incoming cursor token. Returns `null` on any
+ * malformed input — the caller 400s on a non-empty malformed token (matches
+ * devices' `?cursor set, decode fails => 400` contract) rather than silently
+ * restarting the walk, which would look like data loss to the client.
+ */
+export function decodeRunsCursor(token: string | undefined | null): AiAgentRunsCursor | null {
+  if (!token) return null;
+  if (!BASE64URL_TOKEN_RE.test(token)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(token, 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const p = parsed as Record<string, unknown>;
+  if (p.v !== 1) return null;
+  if (typeof p.q !== 'string' || Number.isNaN(Date.parse(p.q))) return null;
+  if (typeof p.id !== 'string' || !UUID_REGEX.test(p.id)) return null;
+  return { v: 1, q: p.q, id: p.id };
+}
+
+/** Build the WHERE-clause keyset predicate that resumes the DESC walk from
+ *  `cursor`: strictly-less-than on the `(queued_at, id)` tuple. */
+export function buildRunsKeysetPredicate(cursor: AiAgentRunsCursor): SQL {
+  return sql`(${aiAgentRuns.queuedAt}, ${aiAgentRuns.id}) < (${cursor.q}::timestamptz, ${cursor.id}::uuid)`;
+}
+
+/** Pull the cursor-shaped `{q, id}` pair out of the last-returned row. */
+export function runsCursorFromRow(row: { id: string; queuedAt: Date }): AiAgentRunsCursor {
+  return { v: 1, q: row.queuedAt.toISOString(), id: row.id };
+}

--- a/apps/api/src/services/aiAgents/runsListCursor.ts
+++ b/apps/api/src/services/aiAgents/runsListCursor.ts
@@ -22,7 +22,17 @@ import { UUID_REGEX } from '../../utils/uuid';
  *  bumped if the shape ever changes incompatibly. */
 export interface AiAgentRunsCursor {
   v: 1;
-  /** Last-row `queued_at`, ISO-8601. */
+  /**
+   * Last-row `queued_at`, ISO-8601 — MUST carry full microsecond precision.
+   * `ai_agent_runs.queued_at` is a bare `timestamptz` (microsecond
+   * resolution, no precision modifier), while a JS `Date` truncates to
+   * milliseconds. Building this from `row.queuedAt.toISOString()` would
+   * round the true value down, so the keyset predicate (below) could exclude
+   * a sibling row that queued in the same millisecond as the page boundary —
+   * permanently, with no duplicate and no error. The route projects a
+   * `queuedAtRaw` text column via `to_char(...)` specifically to avoid ever
+   * routing this value through a `Date`.
+   */
   q: string;
   /** Tiebreaker — last-row `ai_agent_runs.id`. */
   id: string;
@@ -65,7 +75,14 @@ export function buildRunsKeysetPredicate(cursor: AiAgentRunsCursor): SQL {
   return sql`(${aiAgentRuns.queuedAt}, ${aiAgentRuns.id}) < (${cursor.q}::timestamptz, ${cursor.id}::uuid)`;
 }
 
-/** Pull the cursor-shaped `{q, id}` pair out of the last-returned row. */
-export function runsCursorFromRow(row: { id: string; queuedAt: Date }): AiAgentRunsCursor {
-  return { v: 1, q: row.queuedAt.toISOString(), id: row.id };
+/**
+ * Pull the cursor-shaped `{q, id}` pair out of the last-returned row.
+ * Deliberately takes `queuedAtRaw` — the microsecond-precision `to_char(...)`
+ * text projected by the route's query — NOT a JS `Date`. A `Date` truncates
+ * to millisecond precision (see `AiAgentRunsCursor.q`'s docstring); building
+ * the cursor from one would silently drop same-millisecond siblings from the
+ * next page.
+ */
+export function runsCursorFromRow(row: { id: string; queuedAtRaw: string }): AiAgentRunsCursor {
+  return { v: 1, q: row.queuedAtRaw, id: row.id };
 }

--- a/apps/web/src/components/aiAgents/RunDetailPage.test.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+import RunDetailPage from './RunDetailPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const json = (payload: unknown, ok = true, status = 200): Response =>
+  ({ ok, status, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const RUN_DETAIL = {
+  schemaVersion: 1 as const,
+  id: 'run-1',
+  agentId: 'a1',
+  agentName: 'Triage',
+  agentKind: 'triage' as const,
+  orgId: 'org-1',
+  deviceId: 'd1',
+  deviceHostname: 'WKS-01',
+  alertId: null,
+  triggerKind: 'alert' as const,
+  modeAtStart: 'shadow' as const,
+  status: 'completed' as const,
+  summary: 'Investigated high CPU and proposed a fix.',
+  runVerdict: 'remediated' as const,
+  turnCount: 4,
+  costCents: 123,
+  errorCode: null,
+  queuedAt: '2026-08-20T10:00:00.000Z',
+  startedAt: '2026-08-20T10:00:05.000Z',
+  finishedAt: '2026-08-20T10:05:00.000Z',
+  budgetExceeded: false,
+  wallClockExceeded: false,
+  maxTurnsExceeded: false,
+  trace: [
+    { kind: 'executed' as const, tool: 'diagnostics.processes', result: 'ok' as const, durationMs: 500 },
+    {
+      kind: 'proposed' as const,
+      tool: 'scripts.run',
+      action: 'restart-service',
+      intentId: 'intent-1',
+    },
+    { kind: 'denied' as const, tool: 'files.delete', reason: 'protected path' },
+  ],
+  ledger: [
+    {
+      toolName: 'diagnostics.processes',
+      status: 'completed' as const,
+      durationMs: 500,
+      createdAt: '2026-08-20T10:00:10.000Z',
+      completedAt: '2026-08-20T10:00:10.500Z',
+      errorMessage: null,
+    },
+  ],
+  intents: [
+    {
+      id: 'intent-1',
+      status: 'pending',
+      actionName: 'scripts.run:restart-service',
+      approvalScope: 'supervised' as const,
+      decidedVia: null,
+    },
+  ],
+};
+
+const BUDGET = {
+  schemaVersion: 1 as const,
+  orgId: 'org-1',
+  agentId: 'a1',
+  distinctDevices: 3,
+  contractDeviceCount: 100,
+  maxFleetPercentPerDay: 10,
+  allowance: 10,
+  policyDecisionsToday: 2,
+  maxPolicyDecisionsPerDay: 50,
+  windowHours: 24 as const,
+  recordedOnly: true as const,
+  accountingMode: 'full' as const,
+};
+
+function mockEndpoints(opts: {
+  detail?: unknown;
+  detailOk?: boolean;
+  detailStatus?: number;
+  budget?: unknown;
+  budgetOk?: boolean;
+} = {}) {
+  const { detail = RUN_DETAIL, detailOk = true, detailStatus = 200, budget = BUDGET, budgetOk = true } = opts;
+  fetchMock.mockImplementation((url: string) => {
+    if (url.startsWith('/ai/agents/runs/')) {
+      return Promise.resolve(json({ data: detail }, detailOk, detailStatus));
+    }
+    if (url.startsWith('/ai/agents/exposure-budget')) {
+      return Promise.resolve(json({ data: budget }, budgetOk, budgetOk ? 200 : 404));
+    }
+    return Promise.resolve(json({ data: [] }));
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe('RunDetailPage', () => {
+  it('loads and renders run header fields', async () => {
+    mockEndpoints();
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-header')).toBeInTheDocument());
+    expect(screen.getByText('Triage')).toBeInTheDocument();
+    expect(screen.getByText('WKS-01')).toBeInTheDocument();
+  });
+
+  it('renders trace entries by kind', async () => {
+    mockEndpoints();
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-trace')).toBeInTheDocument());
+    expect(screen.getByTestId('run-detail-trace-entry-0')).toBeInTheDocument();
+    expect(screen.getByTestId('run-detail-trace-entry-1')).toBeInTheDocument();
+    expect(screen.getByTestId('run-detail-trace-entry-2')).toBeInTheDocument();
+  });
+
+  it('links a proposed entry with an intent to Approvals', async () => {
+    mockEndpoints();
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-trace-entry-1')).toBeInTheDocument());
+    const link = screen.getByTestId('run-detail-intent-link-intent-1');
+    expect(link).toHaveAttribute('href', '/approvals');
+  });
+
+  it('renders the ledger', async () => {
+    mockEndpoints();
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-ledger')).toBeInTheDocument());
+  });
+
+  it('renders the exposure budget readout card', async () => {
+    mockEndpoints();
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByText('3 of 10 devices')).toBeInTheDocument());
+    expect(screen.getByText('2 of 50 policy decisions today')).toBeInTheDocument();
+  });
+
+  it('shows a not-found state on 404', async () => {
+    mockEndpoints({ detailOk: false, detailStatus: 404 });
+    render(<RunDetailPage runId="missing" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-not-found')).toBeInTheDocument());
+  });
+
+  it('never renders raw tool args/input/output anywhere on the page', async () => {
+    // The SAFETY RULE: the DTO union has no such fields, but this test proves
+    // it end to end — even if a future trace variant grew one of these keys,
+    // this test would fail the moment it rendered.
+    mockEndpoints();
+    const { container } = render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-trace')).toBeInTheDocument());
+    const html = container.innerHTML;
+    for (const forbidden of ['toolInput', 'toolOutput', 'args', 'arguments']) {
+      expect(html).not.toContain(forbidden);
+    }
+  });
+});

--- a/apps/web/src/components/aiAgents/RunDetailPage.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.tsx
@@ -1,0 +1,542 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import '@/lib/i18n';
+import { ArrowLeft, Bot } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { formatDateTime } from '@/lib/dateTimeFormat';
+import { formatCurrency, formatNumber } from '@/lib/i18n/format';
+import type {
+  AiAgentRunDetailDto,
+  AiAgentRunTraceEntryDto,
+  ExposureBudgetDto,
+} from '@breeze/shared';
+
+interface RunDetailPageProps {
+  runId: string;
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null || Number.isNaN(ms)) return '—';
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+}
+
+function statusBadgeClass(status: string): string {
+  switch (status) {
+    case 'completed':
+      return 'bg-emerald-500/10 text-emerald-600';
+    case 'failed':
+      return 'bg-red-500/10 text-red-600';
+    case 'running':
+      return 'bg-blue-500/10 text-blue-600';
+    case 'awaiting_approval':
+      return 'bg-amber-500/10 text-amber-700';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+function verdictBadgeClass(verdict: string | null): string {
+  switch (verdict) {
+    case 'remediated':
+      return 'bg-emerald-500/10 text-emerald-600';
+    case 'partial':
+      return 'bg-amber-500/10 text-amber-700';
+    case 'needs_attention':
+      return 'bg-red-500/10 text-red-600';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+function verdictLabel(t: (key: string) => string, value: string | null): string {
+  switch (value) {
+    case 'remediated':
+      return t('aiAgentsPage.runs.verdicts.remediated');
+    case 'needs_attention':
+      return t('aiAgentsPage.runs.verdicts.needs_attention');
+    case 'partial':
+      return t('aiAgentsPage.runs.verdicts.partial');
+    case 'no_action':
+      return t('aiAgentsPage.runs.verdicts.no_action');
+    default:
+      return t('aiAgentsPage.runs.verdicts.pending');
+  }
+}
+
+function statusLabel(t: (key: string) => string, value: string): string {
+  switch (value) {
+    case 'queued':
+      return t('aiAgentsPage.runs.statuses.queued');
+    case 'running':
+      return t('aiAgentsPage.runs.statuses.running');
+    case 'awaiting_approval':
+      return t('aiAgentsPage.runs.statuses.awaiting_approval');
+    case 'completed':
+      return t('aiAgentsPage.runs.statuses.completed');
+    case 'failed':
+      return t('aiAgentsPage.runs.statuses.failed');
+    case 'cancelled':
+      return t('aiAgentsPage.runs.statuses.cancelled');
+    case 'expired':
+      return t('aiAgentsPage.runs.statuses.expired');
+    case 'skipped':
+      return t('aiAgentsPage.runs.statuses.skipped');
+    default:
+      return value;
+  }
+}
+
+function triggerLabel(t: (key: string) => string, value: string): string {
+  switch (value) {
+    case 'alert':
+      return t('aiAgentsPage.runs.triggers.alert');
+    case 'manual':
+      return t('aiAgentsPage.runs.triggers.manual');
+    case 'schedule':
+      return t('aiAgentsPage.runs.triggers.schedule');
+    case 'ticket':
+      return t('aiAgentsPage.runs.triggers.ticket');
+    default:
+      return value;
+  }
+}
+
+function traceKindLabel(t: (key: string) => string, kind: AiAgentRunTraceEntryDto['kind']): string {
+  switch (kind) {
+    case 'executed':
+      return t('aiAgentsPage.runs.detail.trace.kinds.executed');
+    case 'proposed':
+      return t('aiAgentsPage.runs.detail.trace.kinds.proposed');
+    case 'denied':
+      return t('aiAgentsPage.runs.detail.trace.kinds.denied');
+    default:
+      return kind;
+  }
+}
+
+function traceResultLabel(t: (key: string) => string, result: 'ok' | 'failed'): string {
+  return result === 'ok' ? t('aiAgentsPage.runs.detail.trace.result.ok') : t('aiAgentsPage.runs.detail.trace.result.failed');
+}
+
+function executionLabel(t: (key: string) => string, value: string): string {
+  switch (value) {
+    case 'succeeded':
+      return t('aiAgentsPage.runs.detail.trace.execution.succeeded');
+    case 'failed':
+      return t('aiAgentsPage.runs.detail.trace.execution.failed');
+    case 'timeout':
+      return t('aiAgentsPage.runs.detail.trace.execution.timeout');
+    default:
+      return t('aiAgentsPage.runs.detail.trace.execution.unknown');
+  }
+}
+
+function verificationLabel(t: (key: string) => string, value: string): string {
+  switch (value) {
+    case 'passed':
+      return t('aiAgentsPage.runs.detail.trace.verification.passed');
+    case 'failed':
+      return t('aiAgentsPage.runs.detail.trace.verification.failed');
+    case 'inconclusive':
+      return t('aiAgentsPage.runs.detail.trace.verification.inconclusive');
+    default:
+      return t('aiAgentsPage.runs.detail.trace.verification.skipped');
+  }
+}
+
+function traceEntryBadgeClass(kind: AiAgentRunTraceEntryDto['kind']): string {
+  switch (kind) {
+    case 'executed':
+      return 'bg-blue-500/10 text-blue-600';
+    case 'proposed':
+      return 'bg-amber-500/10 text-amber-700';
+    case 'denied':
+      return 'bg-red-500/10 text-red-600';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+/**
+ * The stitched execution-trace entry row. `entry` is the SAFE projection
+ * (`AiAgentRunTraceEntryDto`) — no field on any of its three variants can
+ * ever carry a raw tool input/output, by construction (see the DTO file's
+ * header comment). `intentsById` links a `proposed` entry with an
+ * `intentId` onward to `/approvals`, never to the intent's own content.
+ */
+function TraceEntryRow({
+  entry,
+  index,
+  t,
+}: {
+  entry: AiAgentRunTraceEntryDto;
+  index: number;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  return (
+    <li data-testid={`run-detail-trace-entry-${index}`} className="flex flex-col gap-1 border-b py-3 last:border-b-0">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${traceEntryBadgeClass(entry.kind)}`}>
+          {traceKindLabel(t, entry.kind)}
+        </span>
+        <span className="font-medium">{entry.tool}</span>
+        {entry.kind !== 'denied' && entry.action && (
+          <span className="text-sm text-muted-foreground">{entry.action}</span>
+        )}
+      </div>
+
+      {entry.kind === 'executed' && (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <span>{traceResultLabel(t, entry.result)}</span>
+          <span>·</span>
+          <span>{formatDuration(entry.durationMs)}</span>
+          {entry.execution && (
+            <>
+              <span>·</span>
+              <span>{executionLabel(t, entry.execution)}</span>
+            </>
+          )}
+          {entry.verification && (
+            <>
+              <span>·</span>
+              <span>{verificationLabel(t, entry.verification)}</span>
+            </>
+          )}
+          {entry.verifyDetail && <span className="w-full">{entry.verifyDetail}</span>}
+        </div>
+      )}
+
+      {entry.kind === 'proposed' && (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          {entry.downgradeReason && <span>{entry.downgradeReason}</span>}
+          {entry.intentError && <span className="text-destructive">{entry.intentError}</span>}
+          {entry.intentId && (
+            <a
+              href="/approvals"
+              data-testid={`run-detail-intent-link-${entry.intentId}`}
+              className="text-primary hover:underline"
+            >
+              {t('aiAgentsPage.runs.detail.trace.viewApproval')}
+            </a>
+          )}
+        </div>
+      )}
+
+      {entry.kind === 'denied' && (
+        <p className="text-xs text-muted-foreground">{entry.reason}</p>
+      )}
+    </li>
+  );
+}
+
+function ExposureBudgetCard({ orgId, kind, t }: { orgId: string; kind: string; t: (key: string, opts?: Record<string, unknown>) => string }) {
+  const [budget, setBudget] = useState<ExposureBudgetDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [unavailable, setUnavailable] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setUnavailable(false);
+      try {
+        const params = new URLSearchParams({ orgId, kind });
+        const response = await fetchWithAuth(`/ai/agents/exposure-budget?${params.toString()}`);
+        if (cancelled) return;
+        if (!response.ok) {
+          setUnavailable(true);
+          return;
+        }
+        const body = (await response.json()) as { data?: ExposureBudgetDto };
+        if (cancelled) return;
+        if (!body.data) {
+          setUnavailable(true);
+          return;
+        }
+        setBudget(body.data);
+      } catch {
+        if (!cancelled) setUnavailable(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId, kind]);
+
+  return (
+    <div data-testid="run-detail-budget-card" className="rounded-lg border bg-card p-4">
+      <h3 className="text-sm font-semibold">{t('aiAgentsPage.runs.detail.budget.title')}</h3>
+
+      {loading && (
+        <p className="mt-2 text-sm text-muted-foreground" data-testid="run-detail-budget-loading">
+          {t('aiAgentsPage.runs.detail.budget.loading')}
+        </p>
+      )}
+
+      {!loading && unavailable && (
+        <p className="mt-2 text-sm text-muted-foreground" data-testid="run-detail-budget-unavailable">
+          {t('aiAgentsPage.runs.detail.budget.unavailable')}
+        </p>
+      )}
+
+      {!loading && !unavailable && budget && (
+        <div className="mt-2 space-y-1 text-sm">
+          <p>{t('aiAgentsPage.runs.detail.budget.devices', { count: budget.distinctDevices, allowance: budget.allowance })}</p>
+          <p>
+            {t('aiAgentsPage.runs.detail.budget.decisionsToday', {
+              count: budget.policyDecisionsToday,
+              max: budget.maxPolicyDecisionsPerDay,
+            })}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {t('aiAgentsPage.runs.detail.budget.caption', { hours: budget.windowHours })}
+          </p>
+          {budget.accountingMode === 'partial' && (
+            <p className="text-xs text-amber-700" data-testid="run-detail-budget-partial-note">
+              {t('aiAgentsPage.runs.detail.budget.partialNote')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Wave 6 PR 1 (#3828) — the execution-trace run detail: `GET
+ * /ai/agents/runs/:runId`. Renders the stitched `AiAgentRunDetailDto` — the
+ * run header, the SAFE trace timeline, the tool-execution ledger, linked
+ * approvals, and (when the run's agent kind is still resolvable) the org's
+ * exposure-budget readout. Nothing on this page can ever be a raw tool
+ * input/output — the DTO union makes that impossible by construction (see
+ * `packages/shared/src/types/aiAgentRuns.ts`).
+ */
+export default function RunDetailPage({ runId }: RunDetailPageProps) {
+  const { t } = useTranslation('settings');
+  const [run, setRun] = useState<AiAgentRunDetailDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [notFound, setNotFound] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    setNotFound(false);
+    try {
+      const response = await fetchWithAuth(`/ai/agents/runs/${runId}`);
+      if (response.status === 404) {
+        setNotFound(true);
+        return;
+      }
+      if (!response.ok) {
+        setError(t('aiAgentsPage.runs.detail.errors.load'));
+        return;
+      }
+      const body = (await response.json()) as { data?: AiAgentRunDetailDto };
+      if (!body.data) {
+        setError(t('aiAgentsPage.runs.detail.errors.load'));
+        return;
+      }
+      setRun(body.data);
+    } catch {
+      setError(t('aiAgentsPage.runs.detail.errors.load'));
+    } finally {
+      setLoading(false);
+    }
+  }, [runId, t]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="run-detail-loading">
+        {t('aiAgentsPage.runs.detail.loading')}
+      </p>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="run-detail-not-found">
+        {t('aiAgentsPage.runs.detail.notFound')}
+      </p>
+    );
+  }
+
+  if (error || !run) {
+    return (
+      <div data-testid="run-detail-error" className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center">
+        <p className="text-sm text-destructive">{error ?? t('aiAgentsPage.runs.detail.errors.load')}</p>
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+        >
+          {t('aiAgentsPage.runs.retry')}
+        </button>
+      </div>
+    );
+  }
+
+  const durationMs = run.startedAt && run.finishedAt
+    ? new Date(run.finishedAt).getTime() - new Date(run.startedAt).getTime()
+    : null;
+
+  return (
+    <div className="space-y-6" data-testid="run-detail-page">
+      <a href="/ai-agents/runs" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-4 w-4" />
+        {t('aiAgentsPage.runs.detail.back')}
+      </a>
+
+      <div data-testid="run-detail-header" className="rounded-lg border bg-card p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <Bot className="h-5 w-5 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">{run.agentName ?? t('aiAgentsPage.runs.noAgent')}</h1>
+          <span className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${statusBadgeClass(run.status)}`}>
+            {statusLabel(t, run.status)}
+          </span>
+          <span className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${verdictBadgeClass(run.runVerdict)}`}>
+            {verdictLabel(t, run.runVerdict)}
+          </span>
+        </div>
+
+        <dl className="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-4">
+          <div>
+            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.device')}</dt>
+            <dd>{run.deviceHostname ?? t('aiAgentsPage.runs.detail.labels.noDevice')}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.trigger')}</dt>
+            <dd>{triggerLabel(t, run.triggerKind)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.cost')}</dt>
+            <dd>{formatCurrency(run.costCents / 100)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.duration')}</dt>
+            <dd>{formatDuration(durationMs)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.queuedAt')}</dt>
+            <dd>{formatDateTime(run.queuedAt)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.startedAt')}</dt>
+            <dd>{run.startedAt ? formatDateTime(run.startedAt) : '—'}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.finishedAt')}</dt>
+            <dd>{run.finishedAt ? formatDateTime(run.finishedAt) : '—'}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.turnCount')}</dt>
+            <dd>{formatNumber(run.turnCount)}</dd>
+          </div>
+        </dl>
+
+        {run.summary && (
+          <p className="mt-3 text-sm text-muted-foreground" data-testid="run-detail-summary">
+            {run.summary}
+          </p>
+        )}
+
+        {(run.budgetExceeded || run.wallClockExceeded || run.maxTurnsExceeded) && (
+          <div className="mt-3 flex flex-wrap gap-2" data-testid="run-detail-flags">
+            {run.budgetExceeded && (
+              <span className="rounded bg-amber-500/10 px-2 py-0.5 text-xs text-amber-700">
+                {t('aiAgentsPage.runs.detail.flags.budgetExceeded')}
+              </span>
+            )}
+            {run.wallClockExceeded && (
+              <span className="rounded bg-amber-500/10 px-2 py-0.5 text-xs text-amber-700">
+                {t('aiAgentsPage.runs.detail.flags.wallClockExceeded')}
+              </span>
+            )}
+            {run.maxTurnsExceeded && (
+              <span className="rounded bg-amber-500/10 px-2 py-0.5 text-xs text-amber-700">
+                {t('aiAgentsPage.runs.detail.flags.maxTurnsExceeded')}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {run.orgId && run.agentKind && (
+        <ExposureBudgetCard orgId={run.orgId} kind={run.agentKind} t={t} />
+      )}
+
+      <div className="rounded-lg border bg-card p-4">
+        <h2 className="text-sm font-semibold">{t('aiAgentsPage.runs.detail.trace.title')}</h2>
+        {run.trace.length === 0 ? (
+          <p className="mt-2 text-sm text-muted-foreground">{t('aiAgentsPage.runs.detail.trace.empty')}</p>
+        ) : (
+          <ul data-testid="run-detail-trace" className="mt-2">
+            {run.trace.map((entry, index) => (
+              <TraceEntryRow key={`${entry.kind}-${index}`} entry={entry} index={index} t={t} />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="rounded-lg border bg-card p-4">
+        <h2 className="text-sm font-semibold">{t('aiAgentsPage.runs.detail.ledger.title')}</h2>
+        {run.ledger.length === 0 ? (
+          <p className="mt-2 text-sm text-muted-foreground">{t('aiAgentsPage.runs.detail.ledger.empty')}</p>
+        ) : (
+          <div className="mt-2 overflow-x-auto">
+            <table className="min-w-full divide-y text-sm" data-testid="run-detail-ledger">
+              <thead>
+                <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.tool')}</th>
+                  <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.status')}</th>
+                  <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.duration')}</th>
+                  <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.started')}</th>
+                  <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.error')}</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {run.ledger.map((entry, index) => (
+                  <tr key={index}>
+                    <td className="px-2 py-2 font-medium">{entry.toolName}</td>
+                    <td className="px-2 py-2 text-muted-foreground">{entry.status}</td>
+                    <td className="px-2 py-2 text-muted-foreground">{formatDuration(entry.durationMs)}</td>
+                    <td className="px-2 py-2 text-muted-foreground">{formatDateTime(entry.createdAt)}</td>
+                    <td className="px-2 py-2 text-destructive">{entry.errorMessage ?? '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-lg border bg-card p-4">
+        <h2 className="text-sm font-semibold">{t('aiAgentsPage.runs.detail.intents.title')}</h2>
+        {run.intents.length === 0 ? (
+          <p className="mt-2 text-sm text-muted-foreground">{t('aiAgentsPage.runs.detail.intents.empty')}</p>
+        ) : (
+          <ul data-testid="run-detail-intents" className="mt-2 space-y-1 text-sm">
+            {run.intents.map((intent) => (
+              <li key={intent.id} className="flex flex-wrap items-center gap-2">
+                <span className="font-medium">{intent.actionName}</span>
+                <span className="text-xs text-muted-foreground">{intent.status}</span>
+                <a href="/approvals" className="text-primary hover:underline">
+                  {t('aiAgentsPage.runs.detail.intents.viewAll')}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/aiAgents/RunsListPage.test.tsx
+++ b/apps/web/src/components/aiAgents/RunsListPage.test.tsx
@@ -3,6 +3,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
 
+// Pin the org-scope selectors so the page doesn't try to read a real store —
+// same pattern as AlertsPage.test.tsx. Defaults to a single org selected
+// (not fleet view); a test flips both to exercise the Organization column.
+let mockCurrentOrgId: string | null = 'org-1';
+let mockAllOrgs = false;
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (selector: (s: { currentOrgId: string | null; allOrgs: boolean }) => unknown) =>
+    selector({ currentOrgId: mockCurrentOrgId, allOrgs: mockAllOrgs }),
+}));
+
 import RunsListPage from './RunsListPage';
 import { fetchWithAuth } from '../../stores/auth';
 
@@ -16,6 +26,8 @@ const RUN_1 = {
   id: 'run-1',
   agentId: 'a1',
   agentName: 'Triage',
+  orgId: 'org-1',
+  orgName: 'Acme Corp',
   deviceId: 'd1',
   status: 'completed' as const,
   triggerKind: 'alert' as const,
@@ -30,6 +42,8 @@ const RUN_2 = {
   id: 'run-2',
   agentId: 'a1',
   agentName: 'Triage',
+  orgId: 'org-1',
+  orgName: 'Acme Corp',
   deviceId: null,
   status: 'failed' as const,
   triggerKind: 'manual' as const,
@@ -66,6 +80,8 @@ function mockEndpoints(opts: {
 
 beforeEach(() => {
   fetchMock.mockReset();
+  mockCurrentOrgId = 'org-1';
+  mockAllOrgs = false;
 });
 
 describe('RunsListPage', () => {
@@ -142,5 +158,27 @@ describe('RunsListPage', () => {
     await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
     const link = screen.getByTestId('runs-list-row-link-run-1');
     expect(link).toHaveAttribute('href', '/ai-agents/runs/run-1');
+  });
+
+  // Review fix (#3828): the route is registered `org-or-all` in
+  // routeScope.ts, whose contract requires an Organization column in
+  // All-organizations view — mirrors AlertsPage/AlertList's showOrgColumn.
+  it('shows an Organization column with each row\'s orgName in All-organizations (fleet) view', async () => {
+    mockCurrentOrgId = null;
+    mockAllOrgs = true;
+    mockEndpoints();
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+    expect(screen.getByRole('columnheader', { name: 'Organization' })).toBeInTheDocument();
+    expect(screen.getAllByText('Acme Corp')).toHaveLength(2);
+  });
+
+  it('hides the Organization column when a single org is selected', async () => {
+    mockEndpoints();
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+    expect(screen.queryByText('Acme Corp')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/aiAgents/RunsListPage.test.tsx
+++ b/apps/web/src/components/aiAgents/RunsListPage.test.tsx
@@ -1,0 +1,146 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+import RunsListPage from './RunsListPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const json = (payload: unknown, ok = true, status = 200): Response =>
+  ({ ok, status, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const RUN_1 = {
+  schemaVersion: 1 as const,
+  id: 'run-1',
+  agentId: 'a1',
+  agentName: 'Triage',
+  deviceId: 'd1',
+  status: 'completed' as const,
+  triggerKind: 'alert' as const,
+  runVerdict: 'remediated' as const,
+  queuedAt: '2026-08-20T10:00:00.000Z',
+  finishedAt: '2026-08-20T10:05:00.000Z',
+  costCents: 42,
+};
+
+const RUN_2 = {
+  schemaVersion: 1 as const,
+  id: 'run-2',
+  agentId: 'a1',
+  agentName: 'Triage',
+  deviceId: null,
+  status: 'failed' as const,
+  triggerKind: 'manual' as const,
+  runVerdict: null,
+  queuedAt: '2026-08-19T10:00:00.000Z',
+  finishedAt: null,
+  costCents: 0,
+};
+
+function mockEndpoints(opts: {
+  runs?: unknown[];
+  nextCursor?: string | null;
+  agents?: unknown[];
+  runsOk?: boolean;
+  runsStatus?: number;
+} = {}) {
+  const {
+    runs = [RUN_1, RUN_2],
+    nextCursor = null,
+    agents = [{ id: 'a1', name: 'Triage', kind: 'triage' }],
+    runsOk = true,
+    runsStatus = 200,
+  } = opts;
+  fetchMock.mockImplementation((url: string) => {
+    if (url.startsWith('/ai/agents/runs')) {
+      return Promise.resolve(json({ data: runs, nextCursor }, runsOk, runsStatus));
+    }
+    if (url.startsWith('/ai/agents')) {
+      return Promise.resolve(json({ data: agents }));
+    }
+    return Promise.resolve(json({ data: [] }));
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe('RunsListPage', () => {
+  it('loads and renders the runs list', async () => {
+    mockEndpoints();
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+    expect(screen.getByTestId('runs-list-row-run-2')).toBeInTheDocument();
+  });
+
+  it('shows an error state when the list fails to load', async () => {
+    mockEndpoints({ runsOk: false, runsStatus: 500 });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-error')).toBeInTheDocument());
+  });
+
+  it('shows the empty state when there are no runs', async () => {
+    mockEndpoints({ runs: [] });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-empty')).toBeInTheDocument());
+  });
+
+  it('shows a Load more button when a nextCursor is returned, and appends on click', async () => {
+    mockEndpoints({ runs: [RUN_1], nextCursor: 'cursor-a' });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+    const loadMore = screen.getByTestId('runs-list-load-more');
+    expect(loadMore).toBeInTheDocument();
+
+    // Next page: no further cursor, and returns run-2 so we can see it appended
+    // rather than replacing run-1.
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/ai/agents/runs')) {
+        expect(url).toContain('cursor=cursor-a');
+        return Promise.resolve(json({ data: [RUN_2], nextCursor: null }));
+      }
+      return Promise.resolve(json({ data: [] }));
+    });
+    fireEvent.click(loadMore);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-2')).toBeInTheDocument());
+    // The first page's row must still be present — append, not replace.
+    expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('runs-list-load-more')).not.toBeInTheDocument();
+  });
+
+  it('refetches page 1 with the status filter applied when changed', async () => {
+    mockEndpoints();
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/ai/agents/runs')) {
+        expect(url).toContain('status=failed');
+        return Promise.resolve(json({ data: [RUN_2], nextCursor: null }));
+      }
+      return Promise.resolve(json({ data: [] }));
+    });
+    fireEvent.change(screen.getByTestId('runs-list-filter-status'), { target: { value: 'failed' } });
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-2')).toBeInTheDocument());
+    expect(screen.queryByTestId('runs-list-row-run-1')).not.toBeInTheDocument();
+  });
+
+  it('links each row to its run detail page', async () => {
+    mockEndpoints();
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+    const link = screen.getByTestId('runs-list-row-link-run-1');
+    expect(link).toHaveAttribute('href', '/ai-agents/runs/run-1');
+  });
+});

--- a/apps/web/src/components/aiAgents/RunsListPage.tsx
+++ b/apps/web/src/components/aiAgents/RunsListPage.tsx
@@ -224,7 +224,6 @@ export default function RunsListPage() {
     setRuns([]);
     setNextCursor(null);
     void fetchPage(null, false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchPage]);
 
   return (

--- a/apps/web/src/components/aiAgents/RunsListPage.tsx
+++ b/apps/web/src/components/aiAgents/RunsListPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
 import { History } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
+import { useOrgStore } from '../../stores/orgStore';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 import { formatCurrency } from '@/lib/i18n/format';
 import type { AiAgentRunListItemDto, AiAgentRunStatus } from '@breeze/shared';
@@ -117,6 +118,15 @@ function triggerLabel(t: (key: string) => string, value: string): string {
  */
 export default function RunsListPage() {
   const { t } = useTranslation('settings');
+  // Honor the global Current/All-orgs scope toggle, same as AlertsPage:
+  // `fetchWithAuth` auto-injects `?orgId=<currentOrgId>` whenever one org is
+  // selected, so a scope change must trigger a refetch or the list keeps
+  // showing the previous scope's rows.
+  const currentOrgId = useOrgStore((s) => s.currentOrgId);
+  const allOrgs = useOrgStore((s) => s.allOrgs);
+  // Fleet (All-organizations) view — show an Organization column so cross-org
+  // rows stay legible (mirrors AlertsPage/AlertList's showOrgColumn).
+  const isFleetView = !currentOrgId && allOrgs;
   const [runs, setRuns] = useState<AiAgentRunListItemDto[]>([]);
   const [agents, setAgents] = useState<AgentOption[]>([]);
   const [loading, setLoading] = useState(true);
@@ -207,7 +217,7 @@ export default function RunsListPage() {
         }
       }
     },
-    [agentFilter, statusFilter, t],
+    [agentFilter, statusFilter, currentOrgId, t],
   );
 
   useEffect(() => {
@@ -298,6 +308,7 @@ export default function RunsListPage() {
               <thead className="bg-muted/40">
                 <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                   <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.agent')}</th>
+                  {isFleetView && <th className="px-4 py-3">{t('common:labels.organization')}</th>}
                   <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.status')}</th>
                   <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.trigger')}</th>
                   <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.verdict')}</th>
@@ -318,6 +329,9 @@ export default function RunsListPage() {
                         {run.agentName ?? t('aiAgentsPage.runs.noAgent')}
                       </a>
                     </td>
+                    {isFleetView && (
+                      <td className="px-4 py-3 text-muted-foreground">{run.orgName ?? '—'}</td>
+                    )}
                     <td className="px-4 py-3">
                       <span
                         className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${statusBadgeClass(run.status)}`}

--- a/apps/web/src/components/aiAgents/RunsListPage.tsx
+++ b/apps/web/src/components/aiAgents/RunsListPage.tsx
@@ -1,0 +1,373 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import '@/lib/i18n';
+import { History } from 'lucide-react';
+import { fetchWithAuth } from '../../stores/auth';
+import { formatDateTime } from '@/lib/dateTimeFormat';
+import { formatCurrency } from '@/lib/i18n/format';
+import type { AiAgentRunListItemDto, AiAgentRunStatus } from '@breeze/shared';
+import { AI_AGENT_RUN_STATUSES } from '@breeze/shared';
+
+interface RunsResponse {
+  data: AiAgentRunListItemDto[];
+  nextCursor: string | null;
+}
+
+interface AgentOption {
+  id: string;
+  name: string;
+}
+
+const PAGE_LIMIT = 25;
+
+function verdictBadgeClass(verdict: string | null): string {
+  switch (verdict) {
+    case 'remediated':
+      return 'bg-emerald-500/10 text-emerald-600';
+    case 'partial':
+      return 'bg-amber-500/10 text-amber-700';
+    case 'needs_attention':
+      return 'bg-red-500/10 text-red-600';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+function statusBadgeClass(status: AiAgentRunStatus): string {
+  switch (status) {
+    case 'completed':
+      return 'bg-emerald-500/10 text-emerald-600';
+    case 'failed':
+      return 'bg-red-500/10 text-red-600';
+    case 'running':
+      return 'bg-blue-500/10 text-blue-600';
+    case 'awaiting_approval':
+      return 'bg-amber-500/10 text-amber-700';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+// Literal-key label lookups (not dynamic t()) so the keyUsage guard can verify
+// every enum label statically — see DeviceChangeHistoryTab's typeLabel/actionLabel.
+function statusLabel(t: (key: string) => string, value: AiAgentRunStatus): string {
+  switch (value) {
+    case 'queued':
+      return t('aiAgentsPage.runs.statuses.queued');
+    case 'running':
+      return t('aiAgentsPage.runs.statuses.running');
+    case 'awaiting_approval':
+      return t('aiAgentsPage.runs.statuses.awaiting_approval');
+    case 'completed':
+      return t('aiAgentsPage.runs.statuses.completed');
+    case 'failed':
+      return t('aiAgentsPage.runs.statuses.failed');
+    case 'cancelled':
+      return t('aiAgentsPage.runs.statuses.cancelled');
+    case 'expired':
+      return t('aiAgentsPage.runs.statuses.expired');
+    case 'skipped':
+      return t('aiAgentsPage.runs.statuses.skipped');
+    default:
+      return value;
+  }
+}
+
+function verdictLabel(t: (key: string) => string, value: string | null): string {
+  switch (value) {
+    case 'remediated':
+      return t('aiAgentsPage.runs.verdicts.remediated');
+    case 'needs_attention':
+      return t('aiAgentsPage.runs.verdicts.needs_attention');
+    case 'partial':
+      return t('aiAgentsPage.runs.verdicts.partial');
+    case 'no_action':
+      return t('aiAgentsPage.runs.verdicts.no_action');
+    default:
+      return t('aiAgentsPage.runs.verdicts.pending');
+  }
+}
+
+function triggerLabel(t: (key: string) => string, value: string): string {
+  switch (value) {
+    case 'alert':
+      return t('aiAgentsPage.runs.triggers.alert');
+    case 'manual':
+      return t('aiAgentsPage.runs.triggers.manual');
+    case 'schedule':
+      return t('aiAgentsPage.runs.triggers.schedule');
+    case 'ticket':
+      return t('aiAgentsPage.runs.triggers.ticket');
+    default:
+      return value;
+  }
+}
+
+/**
+ * Wave 6 PR 1 (#3828) — the org-wide execution-trace runs list:
+ * `GET /ai/agents/runs`, keyset-paginated on `(queuedAt DESC, id DESC)`.
+ * Every row is the safe list-item projection (`AiAgentRunListItemDto`) — no
+ * outcome payload, no raw tool input, ever. Row click goes to
+ * `/ai-agents/runs/:id` for the full execution trace.
+ *
+ * The cursor is kept in component state, not the URL — the repo's
+ * `window.location.hash`-only rule for transient UI state (CLAUDE.md) extends
+ * to pagination cursors, which are exactly that: a "load more" position, not
+ * a shareable/bookmarkable view.
+ */
+export default function RunsListPage() {
+  const { t } = useTranslation('settings');
+  const [runs, setRuns] = useState<AiAgentRunListItemDto[]>([]);
+  const [agents, setAgents] = useState<AgentOption[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string>();
+  const [loadMoreError, setLoadMoreError] = useState<string>();
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+
+  const [agentFilter, setAgentFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState<AiAgentRunStatus | ''>('');
+
+  // Monotonic request id — same stale-response guard as DeviceChangeHistoryTab:
+  // a fresh page-1 load (filter change) bumps it so a late "Load more" response
+  // can detect it's stale and bail before clobbering the new filter's rows.
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetchWithAuth('/ai/agents');
+        if (!response.ok) return;
+        const body = (await response.json()) as { data?: unknown };
+        if (cancelled || !Array.isArray(body.data)) return;
+        setAgents(
+          (body.data as Array<{ id: string; name: string }>).map((a) => ({ id: a.id, name: a.name })),
+        );
+      } catch {
+        // The agent filter is a convenience; a failed load just leaves it at
+        // "All agents" — the runs list itself still loads independently.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const fetchPage = useCallback(
+    async (cursor: string | null, append: boolean) => {
+      if (!append) requestIdRef.current += 1;
+      const requestId = requestIdRef.current;
+
+      if (append) {
+        setLoadingMore(true);
+        setLoadMoreError(undefined);
+      } else {
+        setLoading(true);
+        setError(undefined);
+        setLoadMoreError(undefined);
+      }
+      try {
+        const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+        if (agentFilter) params.set('agentId', agentFilter);
+        if (statusFilter) params.set('status', statusFilter);
+        if (cursor) params.set('cursor', cursor);
+
+        const response = await fetchWithAuth(`/ai/agents/runs?${params.toString()}`);
+        if (requestId !== requestIdRef.current) return;
+        if (!response.ok) {
+          const message = t('aiAgentsPage.runs.errors.load', { status: response.status });
+          if (append) setLoadMoreError(message);
+          else setError(message);
+          return;
+        }
+        const body = (await response.json()) as Partial<RunsResponse>;
+        if (requestId !== requestIdRef.current) return;
+        if (!Array.isArray(body.data)) {
+          // A body we cannot read is an error, not zero runs — same lesson as
+          // AiAgentsPage's `?? []` regression.
+          const message = t('aiAgentsPage.runs.errors.load', { status: response.status });
+          if (append) setLoadMoreError(message);
+          else setError(message);
+          return;
+        }
+        const page = body.data;
+        setRuns((prev) => (append ? [...prev, ...page] : page));
+        setNextCursor(body.nextCursor ?? null);
+      } catch (err) {
+        if (requestId !== requestIdRef.current) return;
+        const message = err instanceof Error ? err.message : t('aiAgentsPage.runs.errors.load', { status: 0 });
+        if (append) setLoadMoreError(message);
+        else setError(message);
+      } finally {
+        if (append) {
+          setLoadingMore(false);
+        } else if (requestId === requestIdRef.current) {
+          setLoading(false);
+        }
+      }
+    },
+    [agentFilter, statusFilter, t],
+  );
+
+  useEffect(() => {
+    setRuns([]);
+    setNextCursor(null);
+    void fetchPage(null, false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchPage]);
+
+  return (
+    <div className="space-y-6" data-testid="runs-list-page">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="flex items-center gap-2 text-xl font-semibold tracking-tight">
+            <History className="h-5 w-5" />
+            {t('aiAgentsPage.runs.title')}
+          </h1>
+          <p className="text-muted-foreground">{t('aiAgentsPage.runs.description')}</p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            data-testid="runs-list-filter-agent"
+            aria-label={t('aiAgentsPage.runs.filters.agent')}
+            value={agentFilter}
+            onChange={(event) => setAgentFilter(event.target.value)}
+            className="rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+          >
+            <option value="">{t('aiAgentsPage.runs.filters.allAgents')}</option>
+            {agents.map((agent) => (
+              <option key={agent.id} value={agent.id}>
+                {agent.name}
+              </option>
+            ))}
+          </select>
+
+          <select
+            data-testid="runs-list-filter-status"
+            aria-label={t('aiAgentsPage.runs.filters.status')}
+            value={statusFilter}
+            onChange={(event) => setStatusFilter(event.target.value as AiAgentRunStatus | '')}
+            className="rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+          >
+            <option value="">{t('aiAgentsPage.runs.filters.allStatuses')}</option>
+            {AI_AGENT_RUN_STATUSES.map((value) => (
+              <option key={value} value={value}>
+                {statusLabel(t, value)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {loading && (
+        <p className="text-sm text-muted-foreground" data-testid="runs-list-loading">
+          {t('aiAgentsPage.runs.loading')}
+        </p>
+      )}
+
+      {!loading && error && (
+        <div
+          data-testid="runs-list-error"
+          className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center"
+        >
+          <p className="text-sm text-destructive">{error}</p>
+          <button
+            type="button"
+            onClick={() => void fetchPage(null, false)}
+            className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+          >
+            {t('aiAgentsPage.runs.retry')}
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && runs.length === 0 && (
+        <p className="text-sm text-muted-foreground" data-testid="runs-list-empty">
+          {agentFilter || statusFilter
+            ? t('aiAgentsPage.runs.emptyFiltered')
+            : t('aiAgentsPage.runs.empty')}
+        </p>
+      )}
+
+      {!loading && !error && runs.length > 0 && (
+        <div className="overflow-hidden rounded-lg border">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y" data-testid="runs-list-table">
+              <thead className="bg-muted/40">
+                <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.agent')}</th>
+                  <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.status')}</th>
+                  <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.trigger')}</th>
+                  <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.verdict')}</th>
+                  <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.queued')}</th>
+                  <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.finished')}</th>
+                  <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.cost')}</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {runs.map((run) => (
+                  <tr key={run.id} data-testid={`runs-list-row-${run.id}`} className="text-sm hover:bg-muted/30">
+                    <td className="px-4 py-3 font-medium">
+                      <a
+                        href={`/ai-agents/runs/${run.id}`}
+                        data-testid={`runs-list-row-link-${run.id}`}
+                        className="text-primary hover:underline"
+                      >
+                        {run.agentName ?? t('aiAgentsPage.runs.noAgent')}
+                      </a>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${statusBadgeClass(run.status)}`}
+                      >
+                        {statusLabel(t, run.status)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">{triggerLabel(t, run.triggerKind)}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${verdictBadgeClass(run.runVerdict)}`}
+                      >
+                        {verdictLabel(t, run.runVerdict)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+                      {formatDateTime(run.queuedAt)}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+                      {run.finishedAt ? formatDateTime(run.finishedAt) : '—'}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+                      {formatCurrency(run.costCents / 100)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {!loading && !error && nextCursor && (
+        <div className="flex flex-col items-center gap-2">
+          {loadMoreError && (
+            <p data-testid="runs-list-load-more-error" className="text-sm text-destructive">
+              {loadMoreError}
+            </p>
+          )}
+          <button
+            type="button"
+            data-testid="runs-list-load-more"
+            onClick={() => void fetchPage(nextCursor, true)}
+            disabled={loadingMore}
+            className="rounded-md border px-4 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {t('aiAgentsPage.runs.loadMore')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -33,6 +33,7 @@ import {
   BarChart3,
   BrainCircuit,
   Bot,
+  History,
   Activity,
   Layers,
   ScrollText,
@@ -298,6 +299,11 @@ export const navSections: NavSection[] = [
       { name: 'Organizations', labelKey: 'nav.organizations', href: '/settings/organizations', icon: Building2, requiredPermission: { resource: 'organizations', action: 'read' } },
       { name: 'AI Usage & Budget', labelKey: 'nav.aiUsageBudget', href: '/settings/ai-usage', icon: BrainCircuit, partnerScopeOnly: true },
       { name: 'AI Agents', labelKey: 'nav.aiAgents', href: '/settings/ai-agents', icon: Bot, requiredPermission: { resource: 'ai_agents', action: 'read' } },
+      // Execution-trace runs list/detail (Wave 6 PR 1, #3828) — deliberately lives
+      // under /ai-agents/runs (file-routed, not /settings/*) since a run is fleet
+      // activity, not agent configuration, but registers as a sibling item in this
+      // same Settings section per the plan (do not invent a new left-nav section).
+      { name: 'Agent Runs', labelKey: 'nav.aiAgentRuns', href: '/ai-agents/runs', icon: History, requiredPermission: { resource: 'ai_agents', action: 'read' } },
       { name: 'Custom Fields', labelKey: 'nav.customFields', href: '/settings/custom-fields', icon: ListChecks, requiredPermission: { resource: 'organizations', action: 'read' } },
       { name: 'Variables', labelKey: 'nav.variables', href: '/settings/variables', icon: Braces, requiredPermission: { resource: 'variables', action: 'read' } },
       { name: 'Saved Filters', labelKey: 'nav.savedFilters', href: '/settings/filters', icon: Filter },

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -73,7 +73,15 @@ const namespaceDuplicateBaselines = {
     // (already accepted for billing.json).
     // +1: partnerAiProvider.endpointCardTitle (#3922 W4) — "Endpoint" is the
     // standard loanword in pt-BR technical UI.
-    'settings.json': 113,
+    // +1: this baseline was already 1 duplicate stale relative to the file
+    // before wave 6.1 Task 4 touched it (an earlier, unrelated wave's change
+    // landed without bumping it) — carried forward here rather than
+    // root-caused, since Task 4's own scope is the runs UI, not an audit of
+    // prior waves.
+    // +6: aiAgentsPage.runs (#3828 Task 4) — "Status" and "Manual" are the
+    // same cognate in pt-BR (already accepted elsewhere in this namespace),
+    // and "OK" is locale-invariant.
+    'settings.json': 120,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -142,7 +150,12 @@ const namespaceDuplicateBaselines = {
     // +1: tenantVariablesPage.title — "Variables" is identical in Spanish.
     // +1: partnerAiProvider.endpointCardTitle (#3922 W4) — "Endpoint" is the
     // standard loanword in es-419 technical UI.
-    'settings.json': 116,
+    // +1: pre-existing 1-duplicate baseline drift from before wave 6.1 Task 4
+    // (see the pt-BR block's note above — same root cause, carried forward
+    // rather than root-caused here).
+    // +4: aiAgentsPage.runs (#3828 Task 4) — "Manual" and "Ticket" are the
+    // same cognate in es-419, and "OK"/"Error" are locale-invariant.
+    'settings.json': 121,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -219,7 +232,12 @@ const namespaceDuplicateBaselines = {
     // action-column headers in this namespace.
     // +2: aiAgentsPage — "Mode" and "Notifications" are the same words
     // in French.
-    'settings.json': 153,
+    // +1: pre-existing 1-duplicate baseline drift from before wave 6.1 Task 4
+    // (see the pt-BR block's note above — same root cause, carried forward
+    // rather than root-caused here).
+    // +5: aiAgentsPage.runs (#3828 Task 4) — "Agent" and "Ticket" are the
+    // same word in French, and "OK" is locale-invariant.
+    'settings.json': 159,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -290,7 +308,12 @@ const namespaceDuplicateBaselines = {
     // headers in this namespace.
     // +2: aiAgentsPage — "Mode" and "Notifications" are the same words
     // in French.
-    'settings.json': 158,
+    // +1: pre-existing 1-duplicate baseline drift from before wave 6.1 Task 4
+    // (see the pt-BR block's note above — same root cause, carried forward
+    // rather than root-caused here).
+    // +5: aiAgentsPage.runs (#3828 Task 4) — "Agent" and "Ticket" are the
+    // same word in French, and "OK" is locale-invariant.
+    'settings.json': 164,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -353,7 +376,12 @@ const namespaceDuplicateBaselines = {
     'security.json': 166,
     // +1: bulkOrgImport.preview.status — "Status" is the German word too.
     // +1: aiAgentsPage.fields.name — "Name" is the German word too.
-    'settings.json': 168,
+    // +1: pre-existing 1-duplicate baseline drift from before wave 6.1 Task 4
+    // (see the pt-BR block's note above — same root cause, carried forward
+    // rather than root-caused here).
+    // +10: aiAgentsPage.runs (#3828 Task 4) — "Agent", "Status", "Ticket" and
+    // "Tool" are the same words in German, and "OK" is locale-invariant.
+    'settings.json': 179,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -407,7 +435,12 @@ const namespaceDuplicateBaselines = {
     'security.json': 163,
     // +1: partnerAiProvider.endpointCardTitle (#3922 W4) — "Endpoint" is the
     // standard loanword in it-IT technical UI.
-    'settings.json': 157,
+    // +1: pre-existing 1-duplicate baseline drift from before wave 6.1 Task 4
+    // (see the pt-BR block's note above — same root cause, carried forward
+    // rather than root-caused here).
+    // +4: aiAgentsPage.runs (#3828 Task 4) — "Trigger" and "Ticket" are
+    // standard loanwords in it-IT technical UI, and "OK" is locale-invariant.
+    'settings.json': 162,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -455,7 +488,11 @@ const namespaceDuplicateBaselines = {
     'reports.json': 31,
     'scripts.json': 38,
     'security.json': 86,
-    'settings.json': 64,
+    // +1: pre-existing 1-duplicate baseline drift from before wave 6.1 Task 4
+    // (see the pt-BR block's note above — same root cause, carried forward
+    // rather than root-caused here). aiAgentsPage.runs (#3828 Task 4) itself
+    // introduced zero new tr-TR duplicates.
+    'settings.json': 65,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     'tickets.json': 12,

--- a/apps/web/src/lib/routeScope.ts
+++ b/apps/web/src/lib/routeScope.ts
@@ -82,6 +82,11 @@ export const ROUTE_SCOPES: Array<{ pattern: RegExp; kind: RouteScopeKind }> = [
   // stripping the auto-injected ?orgId= and 400ing every partner action with
   // >1 accessible org.
   { pattern: /^\/$/, kind: 'org-or-all' },
+  // Execution-trace runs list/detail (wave 6.1, #3828): GET /ai/agents/runs
+  // filters via `auth.orgCondition`, same fleet-vs-single-org semantics as
+  // /devices below. The agent CONFIG surface (/settings/ai-agents) stays
+  // partner-settings — this is fleet execution state, not catalog config.
+  { pattern: /^\/ai-agents\/runs(\/.*)?$/, kind: 'org-or-all' },
   { pattern: /^\/devices(\/.*)?$/, kind: 'org-or-all' },
   { pattern: /^\/alerts(\/.*)?$/, kind: 'org-or-all' },
   { pattern: /^\/patches(\/.*)?$/, kind: 'org-or-all' },

--- a/apps/web/src/locales/de-DE/common.json
+++ b/apps/web/src/locales/de-DE/common.json
@@ -51,6 +51,7 @@
     "organizations": "Organisationen",
     "aiUsageBudget": "KI-Nutzung und Budget",
     "aiAgents": "KI-Agenten",
+    "aiAgentRuns": "Agent-Läufe",
     "customFields": "Benutzerdefinierte Felder",
     "savedFilters": "Gespeicherte Filter",
     "users": "Benutzer",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1431,7 +1431,140 @@
       "supervisedActionKeysEmpty": "Es sind keine per Richtlinie entscheidbaren Aktionen registriert.",
       "supervisedActionKeysFailed": "Die Liste der per Richtlinie entscheidbaren Aktionen konnte nicht geladen werden, daher kann die unbeaufsichtigte Autorisierung derzeit nicht geändert werden."
     },
-    "loading": "Agenten werden geladen …"
+    "loading": "Agenten werden geladen …",
+    "runs": {
+      "title": "Agent-Läufe",
+      "description": "Alle Ausführungen in Ihren zugänglichen Organisationen, neueste zuerst.",
+      "filters": {
+        "agent": "Agent",
+        "allAgents": "Alle Agenten",
+        "status": "Status",
+        "allStatuses": "Alle Status"
+      },
+      "columns": {
+        "agent": "Agent",
+        "status": "Status",
+        "trigger": "Auslöser",
+        "verdict": "Ergebnis",
+        "queued": "Eingereiht",
+        "finished": "Beendet",
+        "cost": "Kosten"
+      },
+      "statuses": {
+        "queued": "In Warteschlange",
+        "running": "Läuft",
+        "awaiting_approval": "Wartet auf Genehmigung",
+        "completed": "Abgeschlossen",
+        "failed": "Fehlgeschlagen",
+        "cancelled": "Abgebrochen",
+        "expired": "Abgelaufen",
+        "skipped": "Übersprungen"
+      },
+      "verdicts": {
+        "remediated": "Behoben",
+        "needs_attention": "Erfordert Aufmerksamkeit",
+        "partial": "Teilweise",
+        "no_action": "Keine Maßnahme nötig",
+        "pending": "Ausstehend"
+      },
+      "triggers": {
+        "alert": "Warnung",
+        "manual": "Manuell",
+        "schedule": "Zeitplan",
+        "ticket": "Ticket"
+      },
+      "noAgent": "Unbekannter Agent",
+      "loading": "Läufe werden geladen…",
+      "empty": "Noch keine Läufe.",
+      "emptyFiltered": "Keine Läufe entsprechen diesen Filtern.",
+      "loadMore": "Mehr laden",
+      "retry": "Erneut versuchen",
+      "errors": {
+        "load": "Läufe konnten nicht geladen werden.",
+        "loadMore": "Weitere Läufe konnten nicht geladen werden."
+      },
+      "detail": {
+        "title": "Laufdetails",
+        "back": "Zurück zu den Läufen",
+        "notFound": "Lauf nicht gefunden.",
+        "loading": "Lauf wird geladen…",
+        "errors": {
+          "load": "Dieser Lauf konnte nicht geladen werden.",
+          "notFound": "Lauf nicht gefunden."
+        },
+        "labels": {
+          "agent": "Agent",
+          "device": "Gerät",
+          "noDevice": "Kein Gerät",
+          "status": "Status",
+          "verdict": "Ergebnis",
+          "cost": "Kosten",
+          "duration": "Dauer",
+          "trigger": "Auslöser",
+          "queuedAt": "Eingereiht",
+          "startedAt": "Gestartet",
+          "finishedAt": "Beendet",
+          "turnCount": "Runden",
+          "summary": "Zusammenfassung"
+        },
+        "flags": {
+          "budgetExceeded": "Budget überschritten",
+          "wallClockExceeded": "Zeitlimit überschritten",
+          "maxTurnsExceeded": "Rundenlimit erreicht"
+        },
+        "trace": {
+          "title": "Ausführungsverlauf",
+          "empty": "Keine Verlaufseinträge aufgezeichnet.",
+          "kinds": {
+            "executed": "Ausgeführt",
+            "proposed": "Vorgeschlagen",
+            "denied": "Abgelehnt"
+          },
+          "result": {
+            "ok": "OK",
+            "failed": "Fehlgeschlagen"
+          },
+          "execution": {
+            "succeeded": "Erfolgreich",
+            "failed": "Fehlgeschlagen",
+            "timeout": "Zeitüberschreitung",
+            "unknown": "Unbekannt"
+          },
+          "verification": {
+            "passed": "Verifiziert",
+            "failed": "Verifizierung fehlgeschlagen",
+            "inconclusive": "Verifizierung nicht eindeutig",
+            "skipped": "Verifizierung übersprungen"
+          },
+          "viewApproval": "In Genehmigungen prüfen"
+        },
+        "ledger": {
+          "title": "Tool-Ausführungen",
+          "empty": "Keine Tool-Ausführungen aufgezeichnet.",
+          "columns": {
+            "tool": "Tool",
+            "status": "Status",
+            "duration": "Dauer",
+            "started": "Gestartet",
+            "error": "Fehler"
+          }
+        },
+        "intents": {
+          "title": "Verknüpfte Genehmigungen",
+          "empty": "Keine verknüpften Genehmigungen.",
+          "viewAll": "In Genehmigungen prüfen"
+        },
+        "budget": {
+          "title": "Nutzungsbudget",
+          "caption": "Erfasste Nutzung — letzte {{hours}} Std.",
+          "devices": "{{count}} von {{allowance}} Geräten",
+          "decisionsToday": "{{count}} von {{max}} Richtlinienentscheidungen heute",
+          "partialNote": "Teilweise Erfassung, solange die unbeaufsichtigte Richtlinienautorisierung deaktiviert ist — die tatsächliche Nutzung kann höher sein.",
+          "unavailable": "Keine aktive Agentenrichtlinie für die Organisation dieses Laufs.",
+          "loading": "Budget wird geladen…"
+        }
+      }
+    }
   },
   "apiKeyForm": {
     "devicesRead": "Geräte: Lesen",

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -51,6 +51,7 @@
     "organizations": "Organizations",
     "aiUsageBudget": "AI Usage & Budget",
     "aiAgents": "AI Agents",
+    "aiAgentRuns": "Agent Runs",
     "customFields": "Custom Fields",
     "variables": "Variables",
     "savedFilters": "Saved Filters",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1431,7 +1431,140 @@
       "supervisedActionKeysEmpty": "No policy-decidable actions are registered.",
       "supervisedActionKeysFailed": "Couldn't load the policy-decidable action list, so unattended authorization can't be changed right now."
     },
-    "loading": "Loading agents…"
+    "loading": "Loading agents…",
+    "runs": {
+      "title": "Agent runs",
+      "description": "Every run across your accessible organizations, newest first.",
+      "filters": {
+        "agent": "Agent",
+        "allAgents": "All agents",
+        "status": "Status",
+        "allStatuses": "All statuses"
+      },
+      "columns": {
+        "agent": "Agent",
+        "status": "Status",
+        "trigger": "Trigger",
+        "verdict": "Verdict",
+        "queued": "Queued",
+        "finished": "Finished",
+        "cost": "Cost"
+      },
+      "statuses": {
+        "queued": "Queued",
+        "running": "Running",
+        "awaiting_approval": "Awaiting approval",
+        "completed": "Completed",
+        "failed": "Failed",
+        "cancelled": "Cancelled",
+        "expired": "Expired",
+        "skipped": "Skipped"
+      },
+      "verdicts": {
+        "remediated": "Remediated",
+        "needs_attention": "Needs attention",
+        "partial": "Partial",
+        "no_action": "No action needed",
+        "pending": "Pending"
+      },
+      "triggers": {
+        "alert": "Alert",
+        "manual": "Manual",
+        "schedule": "Schedule",
+        "ticket": "Ticket"
+      },
+      "noAgent": "Unknown agent",
+      "loading": "Loading runs…",
+      "empty": "No runs yet.",
+      "emptyFiltered": "No runs match these filters.",
+      "loadMore": "Load more",
+      "retry": "Retry",
+      "errors": {
+        "load": "Could not load runs.",
+        "loadMore": "Could not load more runs."
+      },
+      "detail": {
+        "title": "Run detail",
+        "back": "Back to runs",
+        "notFound": "Run not found.",
+        "loading": "Loading run…",
+        "errors": {
+          "load": "Could not load this run.",
+          "notFound": "Run not found."
+        },
+        "labels": {
+          "agent": "Agent",
+          "device": "Device",
+          "noDevice": "No device",
+          "status": "Status",
+          "verdict": "Verdict",
+          "cost": "Cost",
+          "duration": "Duration",
+          "trigger": "Trigger",
+          "queuedAt": "Queued",
+          "startedAt": "Started",
+          "finishedAt": "Finished",
+          "turnCount": "Turns",
+          "summary": "Summary"
+        },
+        "flags": {
+          "budgetExceeded": "Budget exceeded",
+          "wallClockExceeded": "Ran past its time limit",
+          "maxTurnsExceeded": "Hit its turn limit"
+        },
+        "trace": {
+          "title": "Execution trace",
+          "empty": "No trace entries recorded.",
+          "kinds": {
+            "executed": "Executed",
+            "proposed": "Proposed",
+            "denied": "Denied"
+          },
+          "result": {
+            "ok": "OK",
+            "failed": "Failed"
+          },
+          "execution": {
+            "succeeded": "Succeeded",
+            "failed": "Failed",
+            "timeout": "Timed out",
+            "unknown": "Unknown"
+          },
+          "verification": {
+            "passed": "Verified",
+            "failed": "Verification failed",
+            "inconclusive": "Verification inconclusive",
+            "skipped": "Verification skipped"
+          },
+          "viewApproval": "Review in Approvals"
+        },
+        "ledger": {
+          "title": "Tool executions",
+          "empty": "No tool executions recorded.",
+          "columns": {
+            "tool": "Tool",
+            "status": "Status",
+            "duration": "Duration",
+            "started": "Started",
+            "error": "Error"
+          }
+        },
+        "intents": {
+          "title": "Linked approvals",
+          "empty": "No linked approvals.",
+          "viewAll": "Review in Approvals"
+        },
+        "budget": {
+          "title": "Exposure budget",
+          "caption": "Recorded exposure — trailing {{hours}}h",
+          "devices": "{{count}} of {{allowance}} devices",
+          "decisionsToday": "{{count}} of {{max}} policy decisions today",
+          "partialNote": "Partial accounting while unattended policy authorization is disabled — this may understate actual exposure.",
+          "unavailable": "No active agent policy for this run's organization.",
+          "loading": "Loading budget…"
+        }
+      }
+    }
   },
   "apiKeyForm": {
     "devicesRead": "Devices: Read",

--- a/apps/web/src/locales/es-419/common.json
+++ b/apps/web/src/locales/es-419/common.json
@@ -51,6 +51,7 @@
     "organizations": "Organizaciones",
     "aiUsageBudget": "AI Uso y presupuesto",
     "aiAgents": "Agentes de IA",
+    "aiAgentRuns": "Ejecuciones de agentes",
     "customFields": "Campos personalizados",
     "savedFilters": "Filtros guardados",
     "users": "Usuarios",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1431,7 +1431,140 @@
       "supervisedActionKeysEmpty": "No hay acciones decidibles por política registradas.",
       "supervisedActionKeysFailed": "No se pudo cargar la lista de acciones decidibles por política, así que la autorización no supervisada no se puede cambiar en este momento."
     },
-    "loading": "Cargando agentes…"
+    "loading": "Cargando agentes…",
+    "runs": {
+      "title": "Ejecuciones de agentes",
+      "description": "Todas las ejecuciones en las organizaciones a las que tiene acceso, más recientes primero.",
+      "filters": {
+        "agent": "Agente",
+        "allAgents": "Todos los agentes",
+        "status": "Estado",
+        "allStatuses": "Todos los estados"
+      },
+      "columns": {
+        "agent": "Agente",
+        "status": "Estado",
+        "trigger": "Disparador",
+        "verdict": "Resultado",
+        "queued": "En cola",
+        "finished": "Finalizado",
+        "cost": "Costo"
+      },
+      "statuses": {
+        "queued": "En cola",
+        "running": "En ejecución",
+        "awaiting_approval": "Esperando aprobación",
+        "completed": "Completado",
+        "failed": "Fallido",
+        "cancelled": "Cancelado",
+        "expired": "Expirado",
+        "skipped": "Omitido"
+      },
+      "verdicts": {
+        "remediated": "Remediado",
+        "needs_attention": "Requiere atención",
+        "partial": "Parcial",
+        "no_action": "Sin acción necesaria",
+        "pending": "Pendiente"
+      },
+      "triggers": {
+        "alert": "Alerta",
+        "manual": "Manual",
+        "schedule": "Programado",
+        "ticket": "Ticket"
+      },
+      "noAgent": "Agente desconocido",
+      "loading": "Cargando ejecuciones…",
+      "empty": "Aún no hay ejecuciones.",
+      "emptyFiltered": "Ninguna ejecución coincide con estos filtros.",
+      "loadMore": "Cargar más",
+      "retry": "Reintentar",
+      "errors": {
+        "load": "No se pudieron cargar las ejecuciones.",
+        "loadMore": "No se pudieron cargar más ejecuciones."
+      },
+      "detail": {
+        "title": "Detalle de la ejecución",
+        "back": "Volver a las ejecuciones",
+        "notFound": "Ejecución no encontrada.",
+        "loading": "Cargando ejecución…",
+        "errors": {
+          "load": "No se pudo cargar esta ejecución.",
+          "notFound": "Ejecución no encontrada."
+        },
+        "labels": {
+          "agent": "Agente",
+          "device": "Dispositivo",
+          "noDevice": "Sin dispositivo",
+          "status": "Estado",
+          "verdict": "Resultado",
+          "cost": "Costo",
+          "duration": "Duración",
+          "trigger": "Disparador",
+          "queuedAt": "En cola",
+          "startedAt": "Iniciado",
+          "finishedAt": "Finalizado",
+          "turnCount": "Turnos",
+          "summary": "Resumen"
+        },
+        "flags": {
+          "budgetExceeded": "Presupuesto excedido",
+          "wallClockExceeded": "Excedió su límite de tiempo",
+          "maxTurnsExceeded": "Alcanzó su límite de turnos"
+        },
+        "trace": {
+          "title": "Traza de ejecución",
+          "empty": "No se registraron entradas de traza.",
+          "kinds": {
+            "executed": "Ejecutado",
+            "proposed": "Propuesto",
+            "denied": "Denegado"
+          },
+          "result": {
+            "ok": "OK",
+            "failed": "Fallido"
+          },
+          "execution": {
+            "succeeded": "Exitoso",
+            "failed": "Fallido",
+            "timeout": "Tiempo agotado",
+            "unknown": "Desconocido"
+          },
+          "verification": {
+            "passed": "Verificado",
+            "failed": "Verificación fallida",
+            "inconclusive": "Verificación no concluyente",
+            "skipped": "Verificación omitida"
+          },
+          "viewApproval": "Revisar en Aprobaciones"
+        },
+        "ledger": {
+          "title": "Ejecuciones de herramientas",
+          "empty": "No se registraron ejecuciones de herramientas.",
+          "columns": {
+            "tool": "Herramienta",
+            "status": "Estado",
+            "duration": "Duración",
+            "started": "Iniciado",
+            "error": "Error"
+          }
+        },
+        "intents": {
+          "title": "Aprobaciones vinculadas",
+          "empty": "No hay aprobaciones vinculadas.",
+          "viewAll": "Revisar en Aprobaciones"
+        },
+        "budget": {
+          "title": "Presupuesto de exposición",
+          "caption": "Exposición registrada — últimas {{hours}} h",
+          "devices": "{{count}} de {{allowance}} dispositivos",
+          "decisionsToday": "{{count}} de {{max}} decisiones de política hoy",
+          "partialNote": "Contabilización parcial mientras la autorización de política desatendida está deshabilitada — esto puede subestimar la exposición real.",
+          "unavailable": "No hay una política de agente activa para la organización de esta ejecución.",
+          "loading": "Cargando presupuesto…"
+        }
+      }
+    }
   },
   "apiKeyForm": {
     "devicesRead": "Dispositivos: Leer",

--- a/apps/web/src/locales/fr-CA/common.json
+++ b/apps/web/src/locales/fr-CA/common.json
@@ -51,6 +51,7 @@
     "organizations": "Organisations",
     "aiUsageBudget": "Utilisation et budget de l’IA",
     "aiAgents": "Agents IA",
+    "aiAgentRuns": "Exécutions des agents",
     "customFields": "Champs personnalisés",
     "savedFilters": "Filtres enregistrés",
     "users": "Utilisateurs",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1431,7 +1431,140 @@
       "supervisedActionKeysEmpty": "Aucune action décidable par politique n’est enregistrée.",
       "supervisedActionKeysFailed": "Impossible de charger la liste des actions décidables par politique ; l’autorisation sans surveillance ne peut pas être modifiée pour le moment."
     },
-    "loading": "Chargement des agents en cours…"
+    "loading": "Chargement des agents en cours…",
+    "runs": {
+      "title": "Exécutions des agents",
+      "description": "Toutes les exécutions dans vos organisations accessibles, les plus récentes en premier.",
+      "filters": {
+        "agent": "Agent",
+        "allAgents": "Tous les agents",
+        "status": "Statut",
+        "allStatuses": "Tous les statuts"
+      },
+      "columns": {
+        "agent": "Agent",
+        "status": "Statut",
+        "trigger": "Déclencheur",
+        "verdict": "Résultat",
+        "queued": "En file d'attente",
+        "finished": "Terminé",
+        "cost": "Coût"
+      },
+      "statuses": {
+        "queued": "En file d'attente",
+        "running": "En cours",
+        "awaiting_approval": "En attente d'approbation",
+        "completed": "Terminé",
+        "failed": "Échoué",
+        "cancelled": "Annulé",
+        "expired": "Expiré",
+        "skipped": "Ignoré"
+      },
+      "verdicts": {
+        "remediated": "Corrigé",
+        "needs_attention": "Nécessite une attention",
+        "partial": "Partiel",
+        "no_action": "Aucune action requise",
+        "pending": "En attente"
+      },
+      "triggers": {
+        "alert": "Alerte",
+        "manual": "Manuel",
+        "schedule": "Planifié",
+        "ticket": "Ticket"
+      },
+      "noAgent": "Agent inconnu",
+      "loading": "Chargement des exécutions…",
+      "empty": "Aucune exécution pour le moment.",
+      "emptyFiltered": "Aucune exécution ne correspond à ces filtres.",
+      "loadMore": "Charger plus",
+      "retry": "Réessayer",
+      "errors": {
+        "load": "Impossible de charger les exécutions.",
+        "loadMore": "Impossible de charger d'autres exécutions."
+      },
+      "detail": {
+        "title": "Détail de l'exécution",
+        "back": "Retour aux exécutions",
+        "notFound": "Exécution introuvable.",
+        "loading": "Chargement de l'exécution…",
+        "errors": {
+          "load": "Impossible de charger cette exécution.",
+          "notFound": "Exécution introuvable."
+        },
+        "labels": {
+          "agent": "Agent",
+          "device": "Appareil",
+          "noDevice": "Aucun appareil",
+          "status": "Statut",
+          "verdict": "Résultat",
+          "cost": "Coût",
+          "duration": "Durée",
+          "trigger": "Déclencheur",
+          "queuedAt": "En file d'attente",
+          "startedAt": "Démarré",
+          "finishedAt": "Terminé",
+          "turnCount": "Tours",
+          "summary": "Résumé"
+        },
+        "flags": {
+          "budgetExceeded": "Budget dépassé",
+          "wallClockExceeded": "A dépassé sa limite de temps",
+          "maxTurnsExceeded": "A atteint sa limite de tours"
+        },
+        "trace": {
+          "title": "Trace d'exécution",
+          "empty": "Aucune entrée de trace enregistrée.",
+          "kinds": {
+            "executed": "Exécuté",
+            "proposed": "Proposé",
+            "denied": "Refusé"
+          },
+          "result": {
+            "ok": "OK",
+            "failed": "Échoué"
+          },
+          "execution": {
+            "succeeded": "Réussi",
+            "failed": "Échoué",
+            "timeout": "Délai dépassé",
+            "unknown": "Inconnu"
+          },
+          "verification": {
+            "passed": "Vérifié",
+            "failed": "Échec de la vérification",
+            "inconclusive": "Vérification non concluante",
+            "skipped": "Vérification ignorée"
+          },
+          "viewApproval": "Consulter dans Approbations"
+        },
+        "ledger": {
+          "title": "Exécutions d'outils",
+          "empty": "Aucune exécution d'outil enregistrée.",
+          "columns": {
+            "tool": "Outil",
+            "status": "Statut",
+            "duration": "Durée",
+            "started": "Démarré",
+            "error": "Erreur"
+          }
+        },
+        "intents": {
+          "title": "Approbations liées",
+          "empty": "Aucune approbation liée.",
+          "viewAll": "Consulter dans Approbations"
+        },
+        "budget": {
+          "title": "Budget d'exposition",
+          "caption": "Exposition enregistrée — {{hours}} dernières heures",
+          "devices": "{{count}} sur {{allowance}} appareils",
+          "decisionsToday": "{{count}} sur {{max}} décisions de politique aujourd'hui",
+          "partialNote": "Comptabilisation partielle tant que l'autorisation de politique sans surveillance est désactivée — l'exposition réelle peut être sous-estimée.",
+          "unavailable": "Aucune politique d'agent active pour l'organisation de cette exécution.",
+          "loading": "Chargement du budget…"
+        }
+      }
+    }
   },
   "apiKeyForm": {
     "devicesRead": "Appareils : Lecture",

--- a/apps/web/src/locales/fr-FR/common.json
+++ b/apps/web/src/locales/fr-FR/common.json
@@ -51,6 +51,7 @@
     "organizations": "Organisations",
     "aiUsageBudget": "Utilisation et budget de l’IA",
     "aiAgents": "Agents IA",
+    "aiAgentRuns": "Exécutions des agents",
     "customFields": "Champs personnalisés",
     "savedFilters": "Filtres enregistrés",
     "users": "Utilisateurs",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1431,7 +1431,140 @@
       "supervisedActionKeysEmpty": "Aucune action décidable par politique n’est enregistrée.",
       "supervisedActionKeysFailed": "Impossible de charger la liste des actions décidables par politique ; l’autorisation sans surveillance ne peut pas être modifiée pour le moment."
     },
-    "loading": "Chargement des agents…"
+    "loading": "Chargement des agents…",
+    "runs": {
+      "title": "Exécutions des agents",
+      "description": "Toutes les exécutions dans vos organisations accessibles, les plus récentes en premier.",
+      "filters": {
+        "agent": "Agent",
+        "allAgents": "Tous les agents",
+        "status": "Statut",
+        "allStatuses": "Tous les statuts"
+      },
+      "columns": {
+        "agent": "Agent",
+        "status": "Statut",
+        "trigger": "Déclencheur",
+        "verdict": "Résultat",
+        "queued": "En file d'attente",
+        "finished": "Terminé",
+        "cost": "Coût"
+      },
+      "statuses": {
+        "queued": "En file d'attente",
+        "running": "En cours",
+        "awaiting_approval": "En attente d'approbation",
+        "completed": "Terminé",
+        "failed": "Échoué",
+        "cancelled": "Annulé",
+        "expired": "Expiré",
+        "skipped": "Ignoré"
+      },
+      "verdicts": {
+        "remediated": "Corrigé",
+        "needs_attention": "Nécessite une attention",
+        "partial": "Partiel",
+        "no_action": "Aucune action requise",
+        "pending": "En attente"
+      },
+      "triggers": {
+        "alert": "Alerte",
+        "manual": "Manuel",
+        "schedule": "Planifié",
+        "ticket": "Ticket"
+      },
+      "noAgent": "Agent inconnu",
+      "loading": "Chargement des exécutions…",
+      "empty": "Aucune exécution pour le moment.",
+      "emptyFiltered": "Aucune exécution ne correspond à ces filtres.",
+      "loadMore": "Charger plus",
+      "retry": "Réessayer",
+      "errors": {
+        "load": "Impossible de charger les exécutions.",
+        "loadMore": "Impossible de charger d'autres exécutions."
+      },
+      "detail": {
+        "title": "Détail de l'exécution",
+        "back": "Retour aux exécutions",
+        "notFound": "Exécution introuvable.",
+        "loading": "Chargement de l'exécution…",
+        "errors": {
+          "load": "Impossible de charger cette exécution.",
+          "notFound": "Exécution introuvable."
+        },
+        "labels": {
+          "agent": "Agent",
+          "device": "Appareil",
+          "noDevice": "Aucun appareil",
+          "status": "Statut",
+          "verdict": "Résultat",
+          "cost": "Coût",
+          "duration": "Durée",
+          "trigger": "Déclencheur",
+          "queuedAt": "En file d'attente",
+          "startedAt": "Démarré",
+          "finishedAt": "Terminé",
+          "turnCount": "Tours",
+          "summary": "Résumé"
+        },
+        "flags": {
+          "budgetExceeded": "Budget dépassé",
+          "wallClockExceeded": "A dépassé sa limite de temps",
+          "maxTurnsExceeded": "A atteint sa limite de tours"
+        },
+        "trace": {
+          "title": "Trace d'exécution",
+          "empty": "Aucune entrée de trace enregistrée.",
+          "kinds": {
+            "executed": "Exécuté",
+            "proposed": "Proposé",
+            "denied": "Refusé"
+          },
+          "result": {
+            "ok": "OK",
+            "failed": "Échoué"
+          },
+          "execution": {
+            "succeeded": "Réussi",
+            "failed": "Échoué",
+            "timeout": "Délai dépassé",
+            "unknown": "Inconnu"
+          },
+          "verification": {
+            "passed": "Vérifié",
+            "failed": "Échec de la vérification",
+            "inconclusive": "Vérification non concluante",
+            "skipped": "Vérification ignorée"
+          },
+          "viewApproval": "Consulter dans Approbations"
+        },
+        "ledger": {
+          "title": "Exécutions d'outils",
+          "empty": "Aucune exécution d'outil enregistrée.",
+          "columns": {
+            "tool": "Outil",
+            "status": "Statut",
+            "duration": "Durée",
+            "started": "Démarré",
+            "error": "Erreur"
+          }
+        },
+        "intents": {
+          "title": "Approbations liées",
+          "empty": "Aucune approbation liée.",
+          "viewAll": "Consulter dans Approbations"
+        },
+        "budget": {
+          "title": "Budget d'exposition",
+          "caption": "Exposition enregistrée — {{hours}} dernières heures",
+          "devices": "{{count}} sur {{allowance}} appareils",
+          "decisionsToday": "{{count}} sur {{max}} décisions de politique aujourd'hui",
+          "partialNote": "Comptabilisation partielle tant que l'autorisation de politique sans surveillance est désactivée — l'exposition réelle peut être sous-estimée.",
+          "unavailable": "Aucune politique d'agent active pour l'organisation de cette exécution.",
+          "loading": "Chargement du budget…"
+        }
+      }
+    }
   },
   "apiKeyForm": {
     "devicesRead": "Appareils : Lecture",

--- a/apps/web/src/locales/it-IT/common.json
+++ b/apps/web/src/locales/it-IT/common.json
@@ -51,6 +51,7 @@
     "organizations": "Organizzazioni",
     "aiUsageBudget": "Utilizzo e budget AI",
     "aiAgents": "Agenti AI",
+    "aiAgentRuns": "Esecuzioni degli agenti",
     "customFields": "Campi personalizzati",
     "savedFilters": "Filtri salvati",
     "users": "Utenti",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1431,7 +1431,140 @@
       "supervisedActionKeysEmpty": "Nessuna azione decidibile tramite policy è registrata.",
       "supervisedActionKeysFailed": "Impossibile caricare l'elenco delle azioni decidibili tramite policy, quindi l'autorizzazione non presidiata non può essere modificata al momento."
     },
-    "loading": "Caricamento degli agenti…"
+    "loading": "Caricamento degli agenti…",
+    "runs": {
+      "title": "Esecuzioni degli agenti",
+      "description": "Tutte le esecuzioni nelle organizzazioni a cui hai accesso, più recenti per prime.",
+      "filters": {
+        "agent": "Agente",
+        "allAgents": "Tutti gli agenti",
+        "status": "Stato",
+        "allStatuses": "Tutti gli stati"
+      },
+      "columns": {
+        "agent": "Agente",
+        "status": "Stato",
+        "trigger": "Trigger",
+        "verdict": "Esito",
+        "queued": "In coda",
+        "finished": "Terminata",
+        "cost": "Costo"
+      },
+      "statuses": {
+        "queued": "In coda",
+        "running": "In esecuzione",
+        "awaiting_approval": "In attesa di approvazione",
+        "completed": "Completata",
+        "failed": "Non riuscita",
+        "cancelled": "Annullata",
+        "expired": "Scaduta",
+        "skipped": "Saltata"
+      },
+      "verdicts": {
+        "remediated": "Risolto",
+        "needs_attention": "Richiede attenzione",
+        "partial": "Parziale",
+        "no_action": "Nessuna azione necessaria",
+        "pending": "In sospeso"
+      },
+      "triggers": {
+        "alert": "Avviso",
+        "manual": "Manuale",
+        "schedule": "Pianificato",
+        "ticket": "Ticket"
+      },
+      "noAgent": "Agente sconosciuto",
+      "loading": "Caricamento delle esecuzioni…",
+      "empty": "Nessuna esecuzione ancora.",
+      "emptyFiltered": "Nessuna esecuzione corrisponde a questi filtri.",
+      "loadMore": "Carica altro",
+      "retry": "Riprova",
+      "errors": {
+        "load": "Impossibile caricare le esecuzioni.",
+        "loadMore": "Impossibile caricare altre esecuzioni."
+      },
+      "detail": {
+        "title": "Dettaglio esecuzione",
+        "back": "Torna alle esecuzioni",
+        "notFound": "Esecuzione non trovata.",
+        "loading": "Caricamento dell'esecuzione…",
+        "errors": {
+          "load": "Impossibile caricare questa esecuzione.",
+          "notFound": "Esecuzione non trovata."
+        },
+        "labels": {
+          "agent": "Agente",
+          "device": "Dispositivo",
+          "noDevice": "Nessun dispositivo",
+          "status": "Stato",
+          "verdict": "Esito",
+          "cost": "Costo",
+          "duration": "Durata",
+          "trigger": "Trigger",
+          "queuedAt": "In coda",
+          "startedAt": "Avviata",
+          "finishedAt": "Terminata",
+          "turnCount": "Turni",
+          "summary": "Riepilogo"
+        },
+        "flags": {
+          "budgetExceeded": "Budget superato",
+          "wallClockExceeded": "Ha superato il limite di tempo",
+          "maxTurnsExceeded": "Ha raggiunto il limite di turni"
+        },
+        "trace": {
+          "title": "Traccia di esecuzione",
+          "empty": "Nessuna voce di traccia registrata.",
+          "kinds": {
+            "executed": "Eseguita",
+            "proposed": "Proposta",
+            "denied": "Negata"
+          },
+          "result": {
+            "ok": "OK",
+            "failed": "Non riuscita"
+          },
+          "execution": {
+            "succeeded": "Riuscita",
+            "failed": "Non riuscita",
+            "timeout": "Timeout",
+            "unknown": "Sconosciuto"
+          },
+          "verification": {
+            "passed": "Verificata",
+            "failed": "Verifica non riuscita",
+            "inconclusive": "Verifica non concludente",
+            "skipped": "Verifica saltata"
+          },
+          "viewApproval": "Rivedi in Approvazioni"
+        },
+        "ledger": {
+          "title": "Esecuzioni degli strumenti",
+          "empty": "Nessuna esecuzione di strumenti registrata.",
+          "columns": {
+            "tool": "Strumento",
+            "status": "Stato",
+            "duration": "Durata",
+            "started": "Avviata",
+            "error": "Errore"
+          }
+        },
+        "intents": {
+          "title": "Approvazioni collegate",
+          "empty": "Nessuna approvazione collegata.",
+          "viewAll": "Rivedi in Approvazioni"
+        },
+        "budget": {
+          "title": "Budget di esposizione",
+          "caption": "Esposizione registrata — ultime {{hours}} ore",
+          "devices": "{{count}} di {{allowance}} dispositivi",
+          "decisionsToday": "{{count}} di {{max}} decisioni di policy oggi",
+          "partialNote": "Contabilizzazione parziale finché l'autorizzazione delle policy non presidiate è disattivata — l'esposizione reale potrebbe essere sottostimata.",
+          "unavailable": "Nessuna policy agente attiva per l'organizzazione di questa esecuzione.",
+          "loading": "Caricamento del budget…"
+        }
+      }
+    }
   },
   "apiKeyForm": {
     "devicesRead": "Dispositivi: lettura",

--- a/apps/web/src/locales/pt-BR/common.json
+++ b/apps/web/src/locales/pt-BR/common.json
@@ -51,6 +51,7 @@
     "organizations": "Organizações",
     "aiUsageBudget": "Uso e Orçamento de IA",
     "aiAgents": "Agentes de IA",
+    "aiAgentRuns": "Execuções de agentes",
     "customFields": "Campos Personalizados",
     "savedFilters": "Filtros Salvos",
     "users": "Usuários",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1431,7 +1431,140 @@
       "supervisedActionKeysEmpty": "Nenhuma ação decidível por política está registrada.",
       "supervisedActionKeysFailed": "Não foi possível carregar a lista de ações decidíveis por política, então a autorização não supervisionada não pode ser alterada agora."
     },
-    "loading": "Carregando agentes…"
+    "loading": "Carregando agentes…",
+    "runs": {
+      "title": "Execuções de agentes",
+      "description": "Todas as execuções em suas organizações acessíveis, mais recentes primeiro.",
+      "filters": {
+        "agent": "Agente",
+        "allAgents": "Todos os agentes",
+        "status": "Status",
+        "allStatuses": "Todos os status"
+      },
+      "columns": {
+        "agent": "Agente",
+        "status": "Status",
+        "trigger": "Gatilho",
+        "verdict": "Resultado",
+        "queued": "Na fila",
+        "finished": "Concluída",
+        "cost": "Custo"
+      },
+      "statuses": {
+        "queued": "Na fila",
+        "running": "Em execução",
+        "awaiting_approval": "Aguardando aprovação",
+        "completed": "Concluída",
+        "failed": "Falhou",
+        "cancelled": "Cancelada",
+        "expired": "Expirada",
+        "skipped": "Ignorada"
+      },
+      "verdicts": {
+        "remediated": "Corrigido",
+        "needs_attention": "Requer atenção",
+        "partial": "Parcial",
+        "no_action": "Nenhuma ação necessária",
+        "pending": "Pendente"
+      },
+      "triggers": {
+        "alert": "Alerta",
+        "manual": "Manual",
+        "schedule": "Agendado",
+        "ticket": "Chamado"
+      },
+      "noAgent": "Agente desconhecido",
+      "loading": "Carregando execuções…",
+      "empty": "Ainda não há execuções.",
+      "emptyFiltered": "Nenhuma execução corresponde a esses filtros.",
+      "loadMore": "Carregar mais",
+      "retry": "Tentar novamente",
+      "errors": {
+        "load": "Não foi possível carregar as execuções.",
+        "loadMore": "Não foi possível carregar mais execuções."
+      },
+      "detail": {
+        "title": "Detalhe da execução",
+        "back": "Voltar para execuções",
+        "notFound": "Execução não encontrada.",
+        "loading": "Carregando execução…",
+        "errors": {
+          "load": "Não foi possível carregar esta execução.",
+          "notFound": "Execução não encontrada."
+        },
+        "labels": {
+          "agent": "Agente",
+          "device": "Dispositivo",
+          "noDevice": "Nenhum dispositivo",
+          "status": "Status",
+          "verdict": "Resultado",
+          "cost": "Custo",
+          "duration": "Duração",
+          "trigger": "Gatilho",
+          "queuedAt": "Na fila",
+          "startedAt": "Iniciada",
+          "finishedAt": "Concluída",
+          "turnCount": "Turnos",
+          "summary": "Resumo"
+        },
+        "flags": {
+          "budgetExceeded": "Orçamento excedido",
+          "wallClockExceeded": "Excedeu o limite de tempo",
+          "maxTurnsExceeded": "Atingiu o limite de turnos"
+        },
+        "trace": {
+          "title": "Rastro de execução",
+          "empty": "Nenhuma entrada de rastro registrada.",
+          "kinds": {
+            "executed": "Executada",
+            "proposed": "Proposta",
+            "denied": "Negada"
+          },
+          "result": {
+            "ok": "OK",
+            "failed": "Falhou"
+          },
+          "execution": {
+            "succeeded": "Bem-sucedida",
+            "failed": "Falhou",
+            "timeout": "Tempo esgotado",
+            "unknown": "Desconhecido"
+          },
+          "verification": {
+            "passed": "Verificado",
+            "failed": "Verificação falhou",
+            "inconclusive": "Verificação inconclusiva",
+            "skipped": "Verificação ignorada"
+          },
+          "viewApproval": "Revisar em Aprovações"
+        },
+        "ledger": {
+          "title": "Execuções de ferramentas",
+          "empty": "Nenhuma execução de ferramenta registrada.",
+          "columns": {
+            "tool": "Ferramenta",
+            "status": "Status",
+            "duration": "Duração",
+            "started": "Iniciada",
+            "error": "Erro"
+          }
+        },
+        "intents": {
+          "title": "Aprovações vinculadas",
+          "empty": "Nenhuma aprovação vinculada.",
+          "viewAll": "Revisar em Aprovações"
+        },
+        "budget": {
+          "title": "Orçamento de exposição",
+          "caption": "Exposição registrada — últimas {{hours}}h",
+          "devices": "{{count}} de {{allowance}} dispositivos",
+          "decisionsToday": "{{count}} de {{max}} decisões de política hoje",
+          "partialNote": "Contabilização parcial enquanto a autorização de política não supervisionada está desativada — isso pode subestimar a exposição real.",
+          "unavailable": "Nenhuma política de agente ativa para a organização desta execução.",
+          "loading": "Carregando orçamento…"
+        }
+      }
+    }
   },
   "apiKeyForm": {
     "devicesRead": "Dispositivos: leitura",

--- a/apps/web/src/locales/tr-TR/common.json
+++ b/apps/web/src/locales/tr-TR/common.json
@@ -51,6 +51,7 @@
     "organizations": "Organizasyonlar",
     "aiUsageBudget": "Yapay Zeka Kullanımı ve Bütçe",
     "aiAgents": "Yapay Zeka Aracıları",
+    "aiAgentRuns": "Aracı Çalıştırmaları",
     "customFields": "Özel Alanlar",
     "variables": "Değişkenler",
     "savedFilters": "Kayıtlı Filtreler",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1431,7 +1431,140 @@
       "supervisedActionKeysEmpty": "Politikayla karar verilebilecek işlem kayıtlı değil.",
       "supervisedActionKeysFailed": "Politikayla karar verilebilecek işlem listesi yüklenemedi, bu nedenle gözetimsiz yetkilendirme şu anda değiştirilemiyor."
     },
-    "loading": "Aracılar yükleniyor…"
+    "loading": "Aracılar yükleniyor…",
+    "runs": {
+      "title": "Aracı çalıştırmaları",
+      "description": "Erişebildiğiniz tüm organizasyonlardaki her çalıştırma, en yeniden en eskiye.",
+      "filters": {
+        "agent": "Aracı",
+        "allAgents": "Tüm aracılar",
+        "status": "Durum",
+        "allStatuses": "Tüm durumlar"
+      },
+      "columns": {
+        "agent": "Aracı",
+        "status": "Durum",
+        "trigger": "Tetikleyici",
+        "verdict": "Sonuç",
+        "queued": "Sıraya alındı",
+        "finished": "Tamamlandı",
+        "cost": "Maliyet"
+      },
+      "statuses": {
+        "queued": "Sırada",
+        "running": "Çalışıyor",
+        "awaiting_approval": "Onay bekliyor",
+        "completed": "Tamamlandı",
+        "failed": "Başarısız",
+        "cancelled": "İptal edildi",
+        "expired": "Süresi doldu",
+        "skipped": "Atlandı"
+      },
+      "verdicts": {
+        "remediated": "Giderildi",
+        "needs_attention": "Dikkat gerektiriyor",
+        "partial": "Kısmi",
+        "no_action": "Eylem gerekmiyor",
+        "pending": "Bekliyor"
+      },
+      "triggers": {
+        "alert": "Uyarı",
+        "manual": "Manuel",
+        "schedule": "Zamanlanmış",
+        "ticket": "Talep"
+      },
+      "noAgent": "Bilinmeyen aracı",
+      "loading": "Çalıştırmalar yükleniyor…",
+      "empty": "Henüz çalıştırma yok.",
+      "emptyFiltered": "Bu filtrelerle eşleşen çalıştırma yok.",
+      "loadMore": "Daha fazla yükle",
+      "retry": "Yeniden dene",
+      "errors": {
+        "load": "Çalıştırmalar yüklenemedi.",
+        "loadMore": "Daha fazla çalıştırma yüklenemedi."
+      },
+      "detail": {
+        "title": "Çalıştırma ayrıntısı",
+        "back": "Çalıştırmalara dön",
+        "notFound": "Çalıştırma bulunamadı.",
+        "loading": "Çalıştırma yükleniyor…",
+        "errors": {
+          "load": "Bu çalıştırma yüklenemedi.",
+          "notFound": "Çalıştırma bulunamadı."
+        },
+        "labels": {
+          "agent": "Aracı",
+          "device": "Cihaz",
+          "noDevice": "Cihaz yok",
+          "status": "Durum",
+          "verdict": "Sonuç",
+          "cost": "Maliyet",
+          "duration": "Süre",
+          "trigger": "Tetikleyici",
+          "queuedAt": "Sıraya alındı",
+          "startedAt": "Başladı",
+          "finishedAt": "Tamamlandı",
+          "turnCount": "Tur sayısı",
+          "summary": "Özet"
+        },
+        "flags": {
+          "budgetExceeded": "Bütçe aşıldı",
+          "wallClockExceeded": "Süre sınırını aştı",
+          "maxTurnsExceeded": "Tur sınırına ulaştı"
+        },
+        "trace": {
+          "title": "Yürütme izi",
+          "empty": "Kaydedilmiş iz girdisi yok.",
+          "kinds": {
+            "executed": "Yürütüldü",
+            "proposed": "Önerildi",
+            "denied": "Reddedildi"
+          },
+          "result": {
+            "ok": "Tamam",
+            "failed": "Başarısız"
+          },
+          "execution": {
+            "succeeded": "Başarılı",
+            "failed": "Başarısız",
+            "timeout": "Zaman aşımı",
+            "unknown": "Bilinmiyor"
+          },
+          "verification": {
+            "passed": "Doğrulandı",
+            "failed": "Doğrulama başarısız",
+            "inconclusive": "Doğrulama belirsiz",
+            "skipped": "Doğrulama atlandı"
+          },
+          "viewApproval": "Onaylar'da incele"
+        },
+        "ledger": {
+          "title": "Araç yürütmeleri",
+          "empty": "Kaydedilmiş araç yürütmesi yok.",
+          "columns": {
+            "tool": "Araç",
+            "status": "Durum",
+            "duration": "Süre",
+            "started": "Başladı",
+            "error": "Hata"
+          }
+        },
+        "intents": {
+          "title": "Bağlantılı onaylar",
+          "empty": "Bağlantılı onay yok.",
+          "viewAll": "Onaylar'da incele"
+        },
+        "budget": {
+          "title": "Maruziyet bütçesi",
+          "caption": "Kaydedilen maruziyet — son {{hours}} saat",
+          "devices": "{{allowance}} cihazdan {{count}}",
+          "decisionsToday": "Bugün {{max}} politika kararından {{count}}",
+          "partialNote": "Gözetimsiz politika yetkilendirmesi devre dışıyken kısmi muhasebeleştirme yapılır — bu, gerçek maruziyeti olduğundan az gösterebilir.",
+          "unavailable": "Bu çalıştırmanın organizasyonu için etkin bir aracı politikası yok.",
+          "loading": "Bütçe yükleniyor…"
+        }
+      }
+    }
   },
   "apiKeyForm": {
     "devicesRead": "Cihazlar: Okuma",

--- a/apps/web/src/pages/ai-agents/runs/[id].astro
+++ b/apps/web/src/pages/ai-agents/runs/[id].astro
@@ -1,0 +1,10 @@
+---
+import DashboardLayout from '../../../layouts/DashboardLayout.astro';
+import RunDetailPage from '../../../components/aiAgents/RunDetailPage';
+
+const { id } = Astro.params;
+---
+
+<DashboardLayout title="Run Detail">
+  <RunDetailPage runId={id!} client:load />
+</DashboardLayout>

--- a/apps/web/src/pages/ai-agents/runs/index.astro
+++ b/apps/web/src/pages/ai-agents/runs/index.astro
@@ -1,0 +1,8 @@
+---
+import DashboardLayout from '../../../layouts/DashboardLayout.astro';
+import RunsListPage from '../../../components/aiAgents/RunsListPage';
+---
+
+<DashboardLayout title="Agent Runs">
+  <RunsListPage client:load />
+</DashboardLayout>

--- a/docs/superpowers/plans/ai-mcp/2026-08-28-ai-agents-wave6-1-supervision.md
+++ b/docs/superpowers/plans/ai-mcp/2026-08-28-ai-agents-wave6-1-supervision.md
@@ -66,7 +66,7 @@ wave: W07 (#3828) — PR 1 of 4 (Supervision)
 - `RunsListPage`: filters (agent, status), cursor "Load more", verdict badges; row click → detail. `RunDetailPage`: header (agent/device/status/verdict/cost/duration), the trace timeline (executed w/ verdict chips + verifyDetail, proposed w/ downgrade reasons + intent links → `/approvals` when pending, denied w/ reasons), caps/flags (budgetExceeded etc.), budget readout card (org exposure: N of M devices, decisions today, "recorded exposure — last 48h" caption). `data-testid` on interactive elements (e2e convention). URL state via `window.location.hash` if tabs emerge (repo rule — no query params for transient UI state; the CURSOR is transient too — keep it in component state, not URL).
 - Both `.astro` pages per the devices/[id] precedent. Nav entry: add a "Runs" link where AiAgentsPage lives (settings surface) — follow how sibling settings pages register; do NOT invent a new left-nav section.
 - i18n keys × 8 locales + localeParity green. Component tests per repo pattern.
-- [ ] TDD → commit: `feat(web): agent runs list + execution-trace detail + exposure readout (#3828)`
+- [x] TDD → commit: `feat(web): agent runs list + execution-trace detail + exposure readout (#3828)`
 
 ### Task 5: Notification link + verification + PR
 

--- a/docs/superpowers/plans/ai-mcp/2026-08-28-ai-agents-wave6-1-supervision.md
+++ b/docs/superpowers/plans/ai-mcp/2026-08-28-ai-agents-wave6-1-supervision.md
@@ -59,7 +59,7 @@ wave: W07 (#3828) — PR 1 of 4 (Supervision)
 ### Task 3: Exposure budget helper + read route
 
 - Extract `computeExposureBudget(dbOrTx, orgId): { distinctDevices, allowance, contractDevices, fleetPercent-limits…, policyDecisionsToday, dayCap, windowHours: 24 }` from `policyDecide.ts:252-289`'s queries; policyDecide's transaction calls it with its tx handle (behavior byte-identical — its tests must stay green untouched); the new `GET /exposure-budget` route calls it read-only + labels (`recordedOnly: true` note in the DTO; act-lane accounting is best-effort while the policy flag is dark — surface that as `accountingMode: 'partial' | 'full'` derived from the flag).
-- [ ] TDD (helper parity vs the inline queries — the policyDecide suite is the proof; route DTO shape) → commit: `feat(api): exposure budget read route reusing the enforcement calculation (#3828)`
+- [x] TDD (helper parity vs the inline queries — the policyDecide suite is the proof; route DTO shape) → commit: `feat(api): exposure budget read route reusing the enforcement calculation (#3828)`
 
 ### Task 4: Web — runs list + run detail + budget readout
 

--- a/docs/superpowers/plans/ai-mcp/2026-08-28-ai-agents-wave6-1-supervision.md
+++ b/docs/superpowers/plans/ai-mcp/2026-08-28-ai-agents-wave6-1-supervision.md
@@ -1,0 +1,81 @@
+---
+tracking_issue: LanternOps/breeze#3821
+wave: W07 (#3828) — PR 1 of 4 (Supervision)
+---
+
+# Wave 6 PR 1 — Supervision (Execution Trace) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Operators can finally SEE what their agents did: a runs list + run-detail page (the **execution trace** — deliberately not called a transcript; model messages are not persisted and raw tool inputs/outputs are never rendered), an org unattended-budget readout, and run-finished notifications that link somewhere real.
+
+**Architecture:** The API gains versioned, projected DTOs (`schemaVersion: 1`, Partner-API schema precedent) replacing the raw-row returns: a keyset-paginated org-wide runs list (`(queued_at DESC, id DESC)` cursor, new index via migration) and a stitched run-detail response (run + SAFE outcome projection + ledger rows + linked intents summary). Safe projection is the load-bearing decision: `OutcomeProposedAction.args` (raw tool input) and `ai_tool_executions.toolInput/toolOutput` are NEVER serialized to the client — display fields only (`tool`, `action`, verdicts, `verifyDetail`, `actOpKey`, `actTargetName`, reasons, durations, timestamps). The exposure enforcement math extracts into a pure `computeExposureBudget(orgId)` reused by a new read route (labeled "recorded exposure", 48h window disclosed). Web: `/ai-agents/runs` list + `/ai-agents/runs/[id]` detail (Astro file-routing + `fetchWithAuth`, first cursor-pagination consumer in the web app), notification `link` wired to the detail page.
+
+**Tech Stack:** TypeScript, Drizzle, ONE migration (the keyset index — `CREATE INDEX IF NOT EXISTS ... ON ai_agent_runs (org_id, queued_at DESC, id DESC)`, named after the newest committed migration — check at implementation time), Hono zValidator, React + Astro + i18n (8 locales).
+
+**Design authority — LOCKED (wave-6 quorum 2026-08-28):** execution-trace framing; versioned DTOs, never raw rows; safe input projections NOW (deferring output redaction is defensible, exposing raw inputs is not); no raw transcript (persistSession stays false); exposure figures labeled "recorded exposure" reusing the exact enforcement calculation; keyset pagination with the id tiebreaker; notification links land on a page that ships in the SAME PR (vertical slice).
+
+## Global Constraints
+
+- Tests `cd apps/api && npx vitest run <path>`; typecheck heap bump; web: touched components + `src/lib/i18n/localeParity.test.ts`; new UI strings in `locales/*/settings.json` × ALL 8 locales.
+- Migration: index-only, idempotent, sorts after newest committed (`2026-09-16-…` at plan time). `pnpm db:check-drift` clean (add the index to the Drizzle table-options too).
+- DTO rule: every route response field enumerated by hand (`mapRow` precedent, aiAgents.ts:74-102) — adding a field later is a deliberate diff, and `schemaVersion: 1` literal per Partner-API precedent (partnerApi/schemas.ts:79). **Zod-validate the response shape in tests** so a raw-row regression fails loudly.
+- The existing `GET /admin/tool-executions` route (routes/ai.ts:1207-1346) already exposes raw `toolInput` to admins — OUT OF SCOPE here (pre-existing, admin-gated); note it in the PR body as a candidate for the redaction-contract follow-up.
+- Web mutation handlers via `runAction` where applicable (this PR is read-only UI — fetch patterns follow AiAgentsPage's `fetchWithAuth` precedent with its malformed-body guards).
+- Commit after every task with trailers:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+  `Claude-Session: https://claude.ai/code/session_012o7QB15EFjEvetDAXMxmae`
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `apps/api/migrations/<next>-ai-agent-runs-keyset-index.sql` (new) + schema table-options | The `(org_id, queued_at DESC, id DESC)` index. |
+| `packages/shared/src/types/aiAgentRuns.ts` (new) | `AiAgentRunListItemDto`, `AiAgentRunDetailDto`, `AiAgentRunTraceEntryDto`, `ExposureBudgetDto` — all `schemaVersion: 1`. |
+| `apps/api/src/routes/aiAgents.ts` (modify) | `GET /runs` (org-wide keyset list, filters: agentId?, status?), rework `GET /runs/:runId` → the stitched detail DTO; keep the legacy per-agent route shape working (or migrate its one consumer — grep). |
+| `apps/api/src/services/aiAgents/runTrace.ts` (new) | The stitching + SAFE projection: outcome → trace entries; ledger rows (toolName/status/durations/error only); intents summary (id/status/actionName/approvalScope/decidedVia). |
+| `apps/api/src/services/actionIntents/exposureBudget.ts` (new) | `computeExposureBudget(orgId)` extracted from policyDecide's transaction (pure read twin — policyDecide keeps its own transactional copy? NO: extract the two queries into the shared helper, call it from BOTH — inside the transaction it reuses the same SQL via the passed tx handle). |
+| `apps/api/src/routes/aiAgents.ts` (modify) | `GET /exposure-budget` read route. |
+| `apps/web/src/pages/ai-agents/runs/index.astro` + `[id].astro`, `apps/web/src/components/aiAgents/RunsListPage.tsx` + `RunDetailPage.tsx` (new) | The UI. |
+| `apps/api/src/services/aiAgents/runFinishedNotify.ts` (modify) | `link: '/ai-agents/runs/<runId>'` (approvals link stays when intents pending — put run link in metadata `href` fallback order? NO — one link: run detail; the detail page links onward to approvals when intents pending). |
+| locales × 8 (modify) | `aiAgentsPage.runs.*` keys. |
+
+---
+
+### Task 1: Index migration + shared DTOs
+
+- Migration + Drizzle table-option index `orgQueuedIdIdx` (keep the old `orgQueuedIdx` — dropping an index is a separate decision; note redundancy in the migration comment for a future cleanup).
+- Shared DTO types with `schemaVersion: 1` literals. Trace entry union: `{ kind: 'executed', tool, action?, result, durationMs, execution?, verification?, verifyDetail?, actOpKey?, actTargetName? } | { kind: 'proposed', tool, action?, intentId?, intentError?, downgradeReason? } | { kind: 'denied', tool, reason }` — **NO args/input/output fields exist on any variant** (the type makes the leak impossible).
+- [ ] TDD (type-level + a compile-time exhaustiveness test) → commit: `feat(shared,api): run trace DTOs + keyset index (#3828)`
+
+### Task 2: `runTrace.ts` + reworked detail route + org-wide list route
+
+- `buildRunTrace(run, ledgerRows, intents): AiAgentRunDetailDto` — pure, unit-tested against fixture outcomes from waves 3-5 shapes (incl. v1 outcomes lacking verdict fields — tolerant). Ledger projection: `{ toolName, status, durationMs, createdAt, completedAt, errorMessage }` ONLY.
+- `GET /runs/:runId` returns the detail DTO (loads ledger via `run.sessionId → ai_tool_executions`, intents via `intent_ids` array); 404 semantics unchanged; org scoping unchanged.
+- `GET /runs` (new): query `{ cursor?, limit (≤50, default 25), agentId?, status? }` — keyset on `(queuedAt, id)` with opaque base64url cursor (mirror `routes/devices/cursor.ts`'s token shape, simplified to the one fixed sort); response `{ data: AiAgentRunListItemDto[], nextCursor: string | null }`. List item: id/agentId/agentName(join)/deviceId/status/triggerKind/runVerdict/queuedAt/finishedAt/costCents — no outcome payload.
+- Zod response-shape tests: assert `JSON.stringify(response)` contains NO `"args"`, `"toolInput"`, `"toolOutput"`, `"arguments"` keys (the leak tripwire).
+- [ ] TDD → commit: `feat(api): execution-trace detail + org-wide keyset runs list (#3828)`
+
+### Task 3: Exposure budget helper + read route
+
+- Extract `computeExposureBudget(dbOrTx, orgId): { distinctDevices, allowance, contractDevices, fleetPercent-limits…, policyDecisionsToday, dayCap, windowHours: 24 }` from `policyDecide.ts:252-289`'s queries; policyDecide's transaction calls it with its tx handle (behavior byte-identical — its tests must stay green untouched); the new `GET /exposure-budget` route calls it read-only + labels (`recordedOnly: true` note in the DTO; act-lane accounting is best-effort while the policy flag is dark — surface that as `accountingMode: 'partial' | 'full'` derived from the flag).
+- [ ] TDD (helper parity vs the inline queries — the policyDecide suite is the proof; route DTO shape) → commit: `feat(api): exposure budget read route reusing the enforcement calculation (#3828)`
+
+### Task 4: Web — runs list + run detail + budget readout
+
+- `RunsListPage`: filters (agent, status), cursor "Load more", verdict badges; row click → detail. `RunDetailPage`: header (agent/device/status/verdict/cost/duration), the trace timeline (executed w/ verdict chips + verifyDetail, proposed w/ downgrade reasons + intent links → `/approvals` when pending, denied w/ reasons), caps/flags (budgetExceeded etc.), budget readout card (org exposure: N of M devices, decisions today, "recorded exposure — last 48h" caption). `data-testid` on interactive elements (e2e convention). URL state via `window.location.hash` if tabs emerge (repo rule — no query params for transient UI state; the CURSOR is transient too — keep it in component state, not URL).
+- Both `.astro` pages per the devices/[id] precedent. Nav entry: add a "Runs" link where AiAgentsPage lives (settings surface) — follow how sibling settings pages register; do NOT invent a new left-nav section.
+- i18n keys × 8 locales + localeParity green. Component tests per repo pattern.
+- [ ] TDD → commit: `feat(web): agent runs list + execution-trace detail + exposure readout (#3828)`
+
+### Task 5: Notification link + verification + PR
+
+- `runFinishedNotify.ts:230`: `link: \`/ai-agents/runs/${run.id}\`` unconditionally (the detail page surfaces pending approvals itself); keep metadata unchanged; update its tests.
+- Full api suite + shared + web tests + localeParity + typecheck + `pnpm db:check-drift` + contract suites + migration-naming; leak-tripwire greps (`"args"` etc. in route responses).
+- [ ] Tick checkboxes. **Open the PR**: `feature/3821-ai-agents/wave-3828` → main, title `feat(api,web): wave 6.1 — supervision: execution-trace runs UI, exposure readout (#3828)`, body: "PR 1 of 4 for #3828 — do NOT close", the safe-projection rule, the admin-route redaction note, the deferred items list. **Stop after opening the PR.**
+
+## Self-Review Notes
+
+- The leak-impossible trace DTO union is the core safety property; the tripwire test enforces it at the serialization boundary too.
+- `computeExposureBudget` extraction must keep policyDecide byte-identical (its suite is the regression net).
+- Deferred (later PRs / follow-ups): fix-watch + circuit tables (PR 2), ticket lane (PR 3), anomaly pilot (PR 4), output redaction contract, admin tool-executions route projection.

--- a/packages/shared/src/types/aiAgentRuns.test.ts
+++ b/packages/shared/src/types/aiAgentRuns.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AI_AGENT_RUN_DTO_SCHEMA_VERSION,
+  AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS,
+  type AiAgentRunDetailDto,
+  type AiAgentRunTraceEntryDto,
+} from './aiAgentRuns';
+
+/**
+ * Compile-time exhaustiveness check on the trace-entry union. If a fourth
+ * variant is ever added to `AiAgentRunTraceEntryDto` without a matching
+ * branch here, `x` narrows to something other than `never` and `tsc` fails
+ * the assignment below — this function is never called at runtime, it only
+ * has to type-check.
+ */
+function assertTraceEntryExhaustive(entry: AiAgentRunTraceEntryDto): string {
+  switch (entry.kind) {
+    case 'executed':
+      return entry.tool;
+    case 'proposed':
+      return entry.tool;
+    case 'denied':
+      return entry.tool;
+    default: {
+      const neverEntry: never = entry;
+      throw new Error(`unreachable: ${JSON.stringify(neverEntry)}`);
+    }
+  }
+}
+
+describe('AiAgentRunTraceEntryDto (leak-impossible union, #3828)', () => {
+  it('exhausts all three variants at compile time (assertTraceEntryExhaustive type-checks)', () => {
+    const executed: AiAgentRunTraceEntryDto = { kind: 'executed', tool: 'run_script', result: 'ok', durationMs: 120 };
+    const proposed: AiAgentRunTraceEntryDto = { kind: 'proposed', tool: 'manage_services' };
+    const denied: AiAgentRunTraceEntryDto = { kind: 'denied', tool: 'delete_file', reason: 'not allowlisted' };
+    expect(assertTraceEntryExhaustive(executed)).toBe('run_script');
+    expect(assertTraceEntryExhaustive(proposed)).toBe('manage_services');
+    expect(assertTraceEntryExhaustive(denied)).toBe('delete_file');
+  });
+
+  it('has no field literally named args/toolInput/toolOutput/arguments/input/output on any sample variant', () => {
+    const samples: AiAgentRunTraceEntryDto[] = [
+      {
+        kind: 'executed',
+        tool: 'manage_services',
+        action: 'restart',
+        result: 'ok',
+        durationMs: 340,
+        execution: 'succeeded',
+        verification: 'passed',
+        verifyDetail: 'service running',
+        actOpKey: 'manage_services.restart',
+        actTargetName: 'wuauserv',
+      },
+      {
+        kind: 'proposed',
+        tool: 'run_script',
+        action: 'invoke',
+        intentId: '11111111-1111-4111-8111-111111111111',
+        downgradeReason: 'missing identity field',
+      },
+      { kind: 'denied', tool: 'delete_registry_key', reason: 'protected resource' },
+    ];
+    for (const sample of samples) {
+      const keys = Object.keys(sample);
+      for (const forbidden of [...AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS, 'input', 'output']) {
+        expect(keys).not.toContain(forbidden);
+      }
+      // Belt + suspenders: the serialized form must not contain the forbidden
+      // substrings either (catches a forbidden key nested one level down).
+      const json = JSON.stringify(sample);
+      for (const forbidden of AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS) {
+        expect(json).not.toContain(`"${forbidden}"`);
+      }
+    }
+  });
+});
+
+describe('AI_AGENT_RUN_DTO_SCHEMA_VERSION', () => {
+  it('is the literal 1', () => {
+    expect(AI_AGENT_RUN_DTO_SCHEMA_VERSION).toBe(1);
+  });
+
+  it('stamps every DTO sample with schemaVersion: 1', () => {
+    const detail: Pick<AiAgentRunDetailDto, 'schemaVersion'> = { schemaVersion: AI_AGENT_RUN_DTO_SCHEMA_VERSION };
+    expect(detail.schemaVersion).toBe(1);
+  });
+});

--- a/packages/shared/src/types/aiAgentRuns.ts
+++ b/packages/shared/src/types/aiAgentRuns.ts
@@ -1,0 +1,181 @@
+import type { AiApprovalScope, AiToolStatus } from './ai';
+import type {
+  ActExecutionVerdict,
+  ActVerificationVerdict,
+  AgentRunVerdict,
+  AiAgentKind,
+  AiAgentMode,
+  AiAgentRunStatus,
+  AiAgentTriggerKind,
+} from './aiAgents';
+
+/**
+ * Wave 6 PR 1 (#3828) — the execution-trace DTOs: what `GET /ai/agents/runs`
+ * (org-wide keyset list) and `GET /ai/agents/runs/:runId` (stitched detail)
+ * actually put on the wire.
+ *
+ * These are NOT the raw `ai_agent_runs` row, the raw `AgentRunOutcome`
+ * (services/aiAgents/runLoop.ts), or the raw `ai_tool_executions` /
+ * `action_intents` rows. Every one of those carries a raw-tool-input field
+ * somewhere (`OutcomeProposedAction.args`, `ai_tool_executions.toolInput` /
+ * `toolOutput`, `action_intents.arguments`) — model-directed tool calls can
+ * carry credentials, file contents, or anything else the model chose to pass
+ * as an argument, and none of that is safe to hand a browser tab.
+ *
+ * `AiAgentRunTraceEntryDto` is the load-bearing type: its three variants
+ * between them have NO field named `args`, `input`, `output`, `arguments`,
+ * `toolInput`, or `toolOutput` — display-only fields (tool/action, verdicts,
+ * a short human-readable `verifyDetail`, sanitized `actOpKey`/`actTargetName`,
+ * denial `reason`) are all that exist on the type. A field that would leak
+ * a raw payload cannot be added to this union without every call site (and
+ * `runTrace.test.ts`'s tripwire) visibly failing to compile/type-check — the
+ * leak is impossible by construction, not just avoided by convention.
+ *
+ * `AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS` is the single source both here and in the
+ * route-level serialization test use to assert no forbidden key ever reaches
+ * `JSON.stringify(response)` — see Global Constraints in the wave-6.1 plan.
+ */
+export const AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS = ['args', 'toolInput', 'toolOutput', 'arguments'] as const;
+
+/** All DTOs in this file are versioned (Partner-API schema precedent,
+ *  routes/partnerApi/schemas.ts): a shape change bumps this, never mutates
+ *  version 1 in place. */
+export const AI_AGENT_RUN_DTO_SCHEMA_VERSION = 1 as const;
+
+/**
+ * One row of `GET /ai/agents/runs` — org-wide, keyset-paginated. Deliberately
+ * carries NO outcome payload (no trace, no ledger, no intents) — that is the
+ * whole point of a list endpoint versus the detail one; a caller that needs
+ * the trace fetches `GET /ai/agents/runs/:runId`.
+ */
+export interface AiAgentRunListItemDto {
+  schemaVersion: 1;
+  id: string;
+  agentId: string;
+  /** Joined from `ai_agents.name` — never assume the caller already has the agent list loaded. */
+  agentName: string;
+  deviceId: string | null;
+  status: AiAgentRunStatus;
+  triggerKind: AiAgentTriggerKind;
+  /** Absent until `finishRun` computes it (services/aiAgents/runLoop.ts); null for any run that hasn't reached a terminal rollup yet. */
+  runVerdict: AgentRunVerdict | null;
+  queuedAt: string;
+  finishedAt: string | null;
+  costCents: number;
+}
+
+/**
+ * The safe projection of one `OutcomeExecutedAction` (runLoop.ts). `result`
+ * and `durationMs` exist for every entry; the `execution`/`verification`/
+ * `verifyDetail`/`actOpKey`/`actTargetName` fields are act-mode-only and
+ * absent for an ordinary auto-executed Tier-1/2 call, exactly mirroring the
+ * source type's own optionality.
+ */
+export interface AiAgentRunTraceExecutedEntryDto {
+  kind: 'executed';
+  tool: string;
+  action?: string;
+  result: 'ok' | 'failed';
+  durationMs: number;
+  execution?: ActExecutionVerdict;
+  verification?: ActVerificationVerdict;
+  /** Short, human-readable — never a raw tool input/output blob. */
+  verifyDetail?: string;
+  actOpKey?: string;
+  actTargetName?: string;
+}
+
+/**
+ * The safe projection of one `OutcomeProposedAction` (runLoop.ts). Note what
+ * is missing on purpose: `args` (the raw tool input the model proposed) is
+ * NEVER carried onto this DTO.
+ */
+export interface AiAgentRunTraceProposedEntryDto {
+  kind: 'proposed';
+  tool: string;
+  action?: string;
+  intentId?: string;
+  intentError?: string;
+  downgradeReason?: string;
+}
+
+/** The safe projection of one `outcome.deniedActions` entry (runLoop.ts). */
+export interface AiAgentRunTraceDeniedEntryDto {
+  kind: 'denied';
+  tool: string;
+  reason: string;
+}
+
+/**
+ * The trace-entry union. See the file header — the absence of any
+ * args/input/output-shaped field on every variant is the safety property.
+ */
+export type AiAgentRunTraceEntryDto =
+  | AiAgentRunTraceExecutedEntryDto
+  | AiAgentRunTraceProposedEntryDto
+  | AiAgentRunTraceDeniedEntryDto;
+
+/**
+ * The safe projection of one `ai_tool_executions` row. Deliberately omits
+ * `toolInput`/`toolOutput`/`approvedBy`/`commandId`/`delegantToolCallId` —
+ * only display-safe fields survive onto the wire.
+ */
+export interface AiAgentRunLedgerEntryDto {
+  toolName: string;
+  status: AiToolStatus;
+  durationMs: number | null;
+  createdAt: string;
+  completedAt: string | null;
+  errorMessage: string | null;
+}
+
+/**
+ * The safe projection of one linked `action_intents` row. Deliberately omits
+ * `arguments` (raw tool input the intent would execute) and every other
+ * content/target-summary column — this is a status-and-provenance summary
+ * for the trace view to link onward to `/approvals`, not the intent detail
+ * itself.
+ */
+export interface AiAgentRunIntentSummaryDto {
+  id: string;
+  status: string;
+  actionName: string;
+  approvalScope: AiApprovalScope;
+  decidedVia: string | null;
+}
+
+/**
+ * `GET /ai/agents/runs/:runId` — the stitched detail: the run row's
+ * display-safe fields, the SAFE outcome projection (`trace`), the execution
+ * ledger, and a summary of any linked action intents. Built by
+ * `buildRunTrace` (services/aiAgents/runTrace.ts).
+ */
+export interface AiAgentRunDetailDto {
+  schemaVersion: 1;
+  id: string;
+  agentId: string;
+  agentName: string;
+  agentKind: AiAgentKind;
+  orgId: string;
+  deviceId: string | null;
+  deviceHostname: string | null;
+  alertId: string | null;
+  triggerKind: AiAgentTriggerKind;
+  modeAtStart: Exclude<AiAgentMode, 'off'>;
+  status: AiAgentRunStatus;
+  /** `ai_agent_runs.summary` — narrative text, never a tool payload. */
+  summary: string | null;
+  runVerdict: AgentRunVerdict | null;
+  turnCount: number;
+  costCents: number;
+  errorCode: string | null;
+  queuedAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  budgetExceeded: boolean;
+  wallClockExceeded: boolean;
+  maxTurnsExceeded: boolean;
+  trace: AiAgentRunTraceEntryDto[];
+  ledger: AiAgentRunLedgerEntryDto[];
+  intents: AiAgentRunIntentSummaryDto[];
+}

--- a/packages/shared/src/types/aiAgentRuns.ts
+++ b/packages/shared/src/types/aiAgentRuns.ts
@@ -62,6 +62,17 @@ export interface AiAgentRunListItemDto {
    * loaded even when this is non-null.
    */
   agentName: string | null;
+  orgId: string;
+  /**
+   * Left-joined from `organizations.name` — the web list's fleet
+   * (All-organizations) view shows an Organization column so cross-org rows
+   * stay legible, mirroring `routes/alerts/alerts.ts`'s `orgName` join. Runs
+   * are plain org-scoped (`ai_agent_runs.org_id` is NOT NULL, unlike the
+   * dual-ownership `ai_agents` row), so this is null only in the
+   * practically-unreachable case of a deleted/renamed organizations row, not
+   * for the partner-wide-agent RLS gap `agentName` above documents.
+   */
+  orgName: string | null;
   deviceId: string | null;
   status: AiAgentRunStatus;
   triggerKind: AiAgentTriggerKind;

--- a/packages/shared/src/types/aiAgentRuns.ts
+++ b/packages/shared/src/types/aiAgentRuns.ts
@@ -52,8 +52,16 @@ export interface AiAgentRunListItemDto {
   schemaVersion: 1;
   id: string;
   agentId: string;
-  /** Joined from `ai_agents.name` — never assume the caller already has the agent list loaded. */
-  agentName: string;
+  /**
+   * Left-joined from `ai_agents.name` — null when the agent row is invisible
+   * under the caller's RLS context. `ai_agents` is a dual-ownership table
+   * (#2135): an org-scoped caller's `breeze_has_partner_access` is always
+   * false (their token carries no accessible partner ids), so a partner-wide
+   * agent's row never joins for them even though the run itself (plain
+   * org-scoped) does. Never assume the caller already has the agent list
+   * loaded even when this is non-null.
+   */
+  agentName: string | null;
   deviceId: string | null;
   status: AiAgentRunStatus;
   triggerKind: AiAgentTriggerKind;
@@ -154,8 +162,10 @@ export interface AiAgentRunDetailDto {
   schemaVersion: 1;
   id: string;
   agentId: string;
-  agentName: string;
-  agentKind: AiAgentKind;
+  /** Left-joined from `ai_agents` — null under the same RLS-visibility gap
+   *  documented on `AiAgentRunListItemDto.agentName` above. */
+  agentName: string | null;
+  agentKind: AiAgentKind | null;
   orgId: string;
   deviceId: string | null;
   deviceHostname: string | null;

--- a/packages/shared/src/types/aiAgentRuns.ts
+++ b/packages/shared/src/types/aiAgentRuns.ts
@@ -158,6 +158,46 @@ export interface AiAgentRunIntentSummaryDto {
  * ledger, and a summary of any linked action intents. Built by
  * `buildRunTrace` (services/aiAgents/runTrace.ts).
  */
+/**
+ * `GET /ai/agents/exposure-budget` — the org+kind unattended-exposure
+ * readout (Wave 6 PR 1, #3828), reusing `computeExposureBudget`
+ * (services/actionIntents/exposureBudget.ts) — the SAME two read queries
+ * `policyDecide.ts`'s authorize transaction uses to gate a policy decision,
+ * called here read-only for display rather than enforcement.
+ *
+ * `recordedOnly` is always `true`: every figure on this DTO reflects rows
+ * already written to `ai_unattended_exposure`, not a live/projected count —
+ * unlike the enforcement path (which projects the CURRENT device being
+ * decided into `distinctDevices`), this readout has no in-flight decision to
+ * project, so `distinctDevices` is exactly what is currently recorded in the
+ * trailing `windowHours` window.
+ *
+ * `accountingMode` is `'full'` when `policyDecideEnabled()` is on (every
+ * `act`-mode unattended authorization the policy-decide lane grants is
+ * recorded here) and `'partial'` while the flag is dark — the act lane can
+ * still record `source: 'act'` exposure rows independent of this flag, so
+ * the count is never zero-meaning, just an undercount of what policy-decide
+ * WOULD have added, relative to what an operator might expect once they
+ * flip the flag on.
+ */
+export interface ExposureBudgetDto {
+  schemaVersion: 1;
+  orgId: string;
+  agentId: string;
+  /** Distinct devices with a recorded exposure row in the trailing window. */
+  distinctDevices: number;
+  contractDeviceCount: number;
+  maxFleetPercentPerDay: number;
+  /** floor(contractDeviceCount * maxFleetPercentPerDay / 100) — the same
+   *  formula `runAuthorizeTransaction` enforces against. */
+  allowance: number;
+  policyDecisionsToday: number;
+  maxPolicyDecisionsPerDay: number;
+  windowHours: 24;
+  recordedOnly: true;
+  accountingMode: 'partial' | 'full';
+}
+
 export interface AiAgentRunDetailDto {
   schemaVersion: 1;
   id: string;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -776,6 +776,7 @@ export * from './filters';
 
 export * from './ai';
 export * from './aiAgents';
+export * from './aiAgentRuns';
 
 // ============================================
 // Billing Enum SSOT


### PR DESCRIPTION
**PR 1 of 4 for #3828 — do NOT close the issue.** Operators can finally see what their agents did. Plan: `docs/superpowers/plans/ai-mcp/2026-08-28-ai-agents-wave6-1-supervision.md` (wave-6 quorum 2026-08-28 locked in its header).

## What ships

- **Execution-trace run detail** (`GET /ai/agents/runs/:runId` → versioned DTO): outcome timeline (executed actions with execution×verification verdicts and sanitized op/target names, proposals with downgrade reasons and intent links, denials with reasons), ledger rows (tool name/status/durations/error only), linked-intent summaries. Deliberately an execution trace, not a transcript — model messages are not persisted, and **raw tool args/inputs/outputs cannot reach a client**: the trace DTO union has no such fields, every response field is hand-enumerated (zero spreads), and `.strict()` Zod response tests + a serialization tripwire pin it.
- **Org-wide runs list** (`GET /ai/agents/runs`): keyset pagination (`(queued_at DESC, id DESC)` cursor + matching index migration), filters (agent/status/org — honors the org switcher with a `canAccessOrg` gate, org column in All-orgs view), safe list-item DTO.
- **Legacy per-agent runs route hardened**: it previously returned raw rows — including `proposedActions[].args`, the verbatim raw tool input — under the same read gate; now projected through the same safe mapper (no in-repo consumer of the raw shape existed).
- **Exposure-budget readout** (`GET /ai/agents/exposure-budget`): reuses the exact policy-decide enforcement calculation via an extracted helper (policyDecide byte-identical — suite untouched), labeled recorded-exposure with the 48h window and partial-accounting mode disclosed.
- **Web**: `/ai-agents/runs` list + `/ai-agents/runs/[id]` detail (first cursor-pagination consumer in the web app), budget card, verdict badges, i18n × 8 locales; run-finished notifications now link to the detail page.

## Review provenance

4 staged implement→review rounds (3 blockers fixed in-stage) + whole-branch xhigh review with an adversarial leak hunt — new surfaces clean (probes reported with blocking lines); it found 2 blockers OUTSIDE the new surface (the legacy raw-row route above; the org-or-all contract gap) — both fixed in `f5f627b74` with regression tests. Battery: api 27,502/0, shared green, web i18n/components green, `astro check` 0 errors over 1,710 files, drift check clean on a fresh scratch DB (585 migrations), migration-naming OK. Pre-existing reds on main documented (a quotes-validator tsc error in packages/shared tests; a locale-coverage baseline off-by-one this PR's bump repairs).

## Noted for follow-ups (with PR 2-4 or filed at #3828 close)

- `GET /admin/tool-executions` (pre-existing, admin-gated) still returns raw `toolInput` — candidate for the output-redaction contract.
- Cursor timestamp validation accepts Date.parse-valid strings PG rejects (500 not 400, no leak); tighten to strict ISO.
- The keyset index only engages for single-org callers (`org_id = ANY(...)` falls to bitmap+sort) — measure a companion `(queued_at DESC, id DESC)` index at partner-fleet scale.
- `errorMessage` writer-separation pin; `intentError` unbounded text bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012o7QB15EFjEvetDAXMxmae