### PR TITLE
fix(api): realign the act-mode integration assertion with wave 4 Part B (main red)

### DIFF
--- a/apps/api/src/__tests__/integration/aiAgents.routes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiAgents.routes.integration.test.ts
@@ -172,7 +172,22 @@ describe('/api/v1/ai/agents', () => {
     expect(effective.data.effective.enabled).toBe(false);
   });
 
-  it("refuses mode 'act' until that mode is supported", async () => {
+  /**
+   * Wave 4 Part B (#4148) flipped SUPPORTED_AGENT_MODES to ['off','shadow','act'],
+   * so the pre-wave-4 contract this test used to assert — a bare
+   * `mode_not_supported` refusal — no longer exists. The payload below is still
+   * refused, but now by the act-ACTIVATION prerequisites
+   * (assertActPrerequisites, agentService.ts): a row that will persist as
+   * `mode: 'act'` needs at least one recipient that currently resolves to a
+   * real user AND at least one act-eligible surface, and this payload declares
+   * neither.
+   *
+   * Asserting `missing` rather than the code alone is what keeps this honest:
+   * the two prerequisites are checked independently, so a regression that
+   * dropped either one would still 422 on the survivor and slip past a
+   * code-only assertion.
+   */
+  it("refuses mode 'act' when neither act prerequisite is met", async () => {
     const app = buildApp();
     const { partnerAdmin } = await createSamePartnerClients(app);
 
@@ -185,8 +200,9 @@ describe('/api/v1/ai/agents', () => {
     });
 
     expect(res.status).toBe(422);
-    const body = await res.json() as { code: string };
-    expect(body.code).toBe('mode_not_supported');
+    const body = await res.json() as { code: string; missing: string[] };
+    expect(body.code).toBe('act_prerequisites_not_met');
+    expect([...body.missing].sort()).toEqual(['act_eligible_tool', 'recipient']);
   });
 
   it('lets an organization tighten a partner baseline to off', async () => {

--- a/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
@@ -220,6 +220,21 @@ const SITE_SCOPE_INPUT_EXEMPT: ReadonlySet<string> = new Set<string>([
   // lookup is constrained (inArray) to the device ids listStatusRows already
   // resolved, so it discloses no device beyond the caller's accessible orgs.
   'routes/security/compliance.ts:GET /encryption',
+  // ---- AI agent RUN reads (wave 6.1, #3828/#4157): org-wide reads that take
+  // NO device-selection input. Flagged only because the run row carries an
+  // `aiAgentRuns.deviceId` column, which is display metadata on an ORG-owned
+  // run row — never a caller-supplied device selector.
+  // Fleet runs list: query is cursor/limit/agentId/status/orgId only; rows are
+  // constrained by auth.orgCondition(aiAgentRuns.orgId) (the routes/devices/
+  // core.ts fleet-list pattern) and an optional orgId filter 403s unless
+  // auth.canAccessOrg, with RLS beneath.
+  'routes/aiAgents.ts:GET /runs',
+  // Run detail: path param is a RUN uuid, not a device; the row is org-scoped
+  // by the same orgCondition predicate + RLS, and 404s when out of scope.
+  'routes/aiAgents.ts:GET /runs/:runId',
+  // Agent-scoped runs list: path param is an AGENT uuid resolved through
+  // getAgent(auth, id) (404 unless accessible); query is `limit` only.
+  'routes/aiAgents.ts:GET /:id/runs',
 ]);
 
 // SITE_SCOPE_INPUT_EXEMPT entries that ARE reached via the user `authMiddleware`
@@ -262,6 +277,16 @@ const SITE_SCOPE_INPUT_EXEMPT_USER_SESSION_OK: ReadonlySet<string> = new Set<str
   // via user auth (requireScope) but exempt because the escrow enrichment is
   // constrained to the org-scoped device set listStatusRows already resolved.
   'routes/security/compliance.ts:GET /encryption',
+  // AI agent run reads (wave 6.1, #3828/#4157). Reached via plain user auth
+  // (requireAiRead), so they carry a `permissions` context and must be listed
+  // here — but they are exempt for the no-device-input reason, not the
+  // non-user-auth one: every query is constrained to the caller's accessible
+  // orgs (auth.orgCondition / getAgent / canAccessOrg) with RLS beneath, no
+  // parameter selects a device, and `deviceId` is display metadata on an
+  // org-owned run row. See the matching note in SITE_SCOPE_INPUT_EXEMPT.
+  'routes/aiAgents.ts:GET /runs',
+  'routes/aiAgents.ts:GET /runs/:runId',
+  'routes/aiAgents.ts:GET /:id/runs',
 ]);
 
 // BASELINE RATCHET — pre-existing handlers flagged at the time this detector

--- a/packages/shared/src/types/aiAgents.ts
+++ b/packages/shared/src/types/aiAgents.ts
@@ -169,9 +169,9 @@ export interface AiAgentPolicySnapshot {
 }
 
 /**
- * Modes the API accepts on WRITE today. `act` is admitted by the DB CHECK and
- * is a member of AI_AGENT_MODES, but the API refuses it with 422
- * `mode_not_supported` until wave 4 ships bounded execution.
+ * Modes the API accepts on WRITE today — all three. `mode_not_supported` is
+ * now reached only by a mode that is not a member of this list at all; it is
+ * no longer the answer for `act`, which wave 4 Part B admitted (see below).
  *
  * This lives in shared rather than in the API because it is a wire contract:
  * the settings form has to know which modes a create will be allowed to pick,


### PR DESCRIPTION
## Root cause

Main has been red since **d394a83d** (PR #4148, *wave 4 Part B — act mode*) on a single stale assertion.

`apps/api/src/__tests__/integration/aiAgents.routes.integration.test.ts:189` still asserted the **pre-wave-4** contract:

```
FAIL src/__tests__/integration/aiAgents.routes.integration.test.ts > /api/v1/ai/agents > refuses mode 'act' until that mode is supported
AssertionError: expected 'act_prerequisites_not_met' to be 'mode_not_supported'
```

#4148 flipped the shared wire contract:

```diff
-export const SUPPORTED_AGENT_MODES: readonly AiAgentMode[] = ['off', 'shadow'] as const;
+export const SUPPORTED_AGENT_MODES: readonly AiAgentMode[] = ['off', 'shadow', 'act'] as const;
```

So `mode: 'act'` is no longer rejected by `isSupportedAgentMode` → `UnsupportedAgentModeError`. It now reaches `assertActPrerequisites` (`services/aiAgents/agentService.ts`), which refuses the same payload with 422 `act_prerequisites_not_met` because it declares neither a resolvable recipient nor an act-eligible surface.

#4148 updated the shared validator test and the route's `mapError` unit test, but **not** this integration suite — which only runs in the Integration Tests job.

**This was not a stale base or a stacked-PR CI gap.** PR #4148 targeted `main` and was **red on Integration Tests shard 4/4** on its own run ([job](https://github.com/LanternOps/breeze/actions/runs/33137412871/job/98741098982)) — plus `CI Success` fail — and was merged anyway. Worth a look at the auto-merge-on-green sweep, which was supposed to gate on exactly that.

### The second failure was already self-healed

Run `33156607954` also showed **Test Web** red — 7 × `translationCoverage.test.ts` `settings.json` duplicate baselines off by exactly +1 (pt-BR, es-419, fr-FR, fr-CA, de-DE, it-IT, tr-TR), introduced by #4155 (`0ee18153`). #4157 (`5988518c6`) subsequently bumped those baselines. **No change needed here** — verified passing locally on this base (15/15).

The first two red runs (`d394a83d`, `e5540a03`) had *only* the aiAgents failure; the i18n one appeared at `0ee18153` and was gone by `5988518c6`. Neither is the known `InvoiceWorkspace.test.tsx` flake (#4033).

## The fix

Realigns the test with the shipped contract, and pins `missing` to **both** prerequisites rather than the code alone — the two checks are independent, so a regression dropping either would still 422 on the survivor and slip past a code-only assertion.

Also corrects the `SUPPORTED_AGENT_MODES` doc comment, whose first paragraph still claimed the API refuses `act` while its last paragraph said the opposite.

No production code changes.

## Test evidence

Ran against a private worktree test stack (`pnpm test-stack up`, Postgres :32868 / Redis :32867):

- **Red-first confirmed** — reverted to the old assertion and reproduced the exact CI failure locally: `1 failed | 13 passed`, same `expected 'act_prerequisites_not_met' to be 'mode_not_supported'`.
- `aiAgents.routes.integration.test.ts` — **14/14 pass** with the fix.
- `apps/api/src/routes/aiAgents.test.ts` — 43/43 pass.
- `packages/shared/src/validators/aiAgents.test.ts` — 19/19 pass.
- `apps/web/src/lib/i18n/translationCoverage.test.ts` — 15/15 pass (confirms the i18n red is already resolved on this base).
- `tsc --noEmit` on `apps/api` — clean (needs `--max-old-space-size`; the known api tsc OOM).
- Repo-wide sweep for other stale `mode_not_supported` assertions: none — remaining hits are the error class itself (still correct for genuinely unknown modes) and the web error-copy mapping.

Pre-existing and unrelated: `packages/shared` typecheck reports 3 errors in `src/validators/quotes.test.ts`, untouched by this PR (my shared edit is comment-only).

Refs #4153

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# Second main red (added after this PR was opened)

A second, unrelated red surfaced on `9e77a4f0e` after this branch was cut. Fixed on the same branch so **#4158 restores green main in one merge**.

**Test API** job — `site-scope-coverage.integration.test.ts` (runs via `vitest.config.site-scope-coverage.ts`):

```
site-scope coverage — input-sourced / list-style
> no NEW handler touches device-scoped data without a site-scope gate
  routes/aiAgents.ts:GET /runs         (line 337)
  routes/aiAgents.ts:GET /runs/:runId  (line 437)
  routes/aiAgents.ts:GET /:id/runs     (line 543)
```

Source: **PR #4157** (wave 6.1, `5988518c6`) — merged with its own CI red, and its main run was cancelled, so the failure only appeared on the next push.

## Why these three are exempt, not fixed

All three are org-wide reads that take **no device-selection input**. The scanner flags them only because the run row carries an `aiAgentRuns.deviceId` column — display metadata on an **org-owned run row**, never a caller-supplied device selector. That is precisely the detector's own documented exempt case ("an org-wide aggregate with no device input").

Verified against the handlers on `main`:

| Route | Input | Constraint |
|---|---|---|
| `GET /runs` | `cursor`/`limit`/`agentId`/`status`/`orgId` | `auth.orgCondition(aiAgentRuns.orgId)` (the `routes/devices/core.ts` fleet-list pattern); optional `orgId` filter 403s unless `auth.canAccessOrg` |
| `GET /runs/:runId` | a **run** uuid | same org predicate; 404 when out of scope |
| `GET /:id/runs` | an **agent** uuid + `limit` | `getAgent(auth, id)` → 404 unless accessible |

RLS sits beneath all three.

Because they use plain user auth (`requireAiRead`) they carry a `permissions` context, so the re-verification test (`every input-exempt entry stays backed by a non-user-session auth guard`) also requires them in `SITE_SCOPE_INPUT_EXEMPT_USER_SESSION_OK` — added there with the same rationale.

`SITE_SCOPE_INPUT_BASELINE` is **untouched** (frozen, shrink-only) and **no handler was modified** — the change is additive to the two allowlists only (25 insertions, 0 deletions).

## Red-then-green evidence

`cd apps/api && npx vitest run --config vitest.config.site-scope-coverage.ts`

- **Red first** (before the edit, on this base): `1 failed | 6 passed (7)` — offenders were exactly the three ids above, each with `touchesDeviceData: true`, `usesSiteScopeGate: false`, `deviceOrSiteUrlParam: false`, `referencesNonUserAuthGuard: false`.
- **Green after**: `7 passed (7)` — including the re-verification test (proves the `_USER_SESSION_OK` entries were genuinely required) and the shrink-only test (proves no entry is stale).
- `tsc --noEmit` on `apps/api` — clean.

No rebase was needed: this branch already contained `9e77a4f0e` (`git merge-base --is-ancestor origin/main HEAD` passes). The diff touches only the site-scope test file, so `aiAgents.routes.integration.test.ts` is byte-identical to the version already verified green above (14/14) and was not re-run.

Refs #4159
