### PR TITLE
fix(web): RemoteTerminal double-init/dead-terminal race + connectedBang locale

### DIFF
--- a/apps/web/src/components/remote/RemoteTerminal.test.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.test.tsx
@@ -31,6 +31,20 @@ const resetTerminalHandlers = () => {
   terminalHandlers.disposeCalls = 0;
 };
 
+// Lifecycle counters for the xterm `Terminal` class itself (construction /
+// `.dispose()`), separate from `terminalHandlers` above which only tracks the
+// onData/onResize listener disposables. Plain counters (not vi.fn) so the
+// suite's clearMocks/restoreMocks can't wipe them between tests.
+const terminalLifecycle = {
+  constructCount: 0,
+  disposeCallCount: 0,
+};
+
+const resetTerminalLifecycle = () => {
+  terminalLifecycle.constructCount = 0;
+  terminalLifecycle.disposeCallCount = 0;
+};
+
 const makeTerminalStub = () => ({
   loadAddon() {},
   open() {},
@@ -54,7 +68,9 @@ const makeTerminalStub = () => ({
       },
     };
   },
-  dispose() {},
+  dispose() {
+    terminalLifecycle.disposeCallCount += 1;
+  },
   focus() {},
   clear() {},
   rows: 24,
@@ -63,6 +79,7 @@ const makeTerminalStub = () => ({
 
 vi.mock('@xterm/xterm', () => ({
   Terminal: function () {
+    terminalLifecycle.constructCount += 1;
     return makeTerminalStub();
   },
 }));
@@ -187,6 +204,7 @@ beforeEach(() => {
   MockWebSocket.instances = [];
   MockWebSocket.autoOpen = true;
   resetTerminalHandlers();
+  resetTerminalLifecycle();
   vi.stubGlobal('WebSocket', MockWebSocket);
   vi.stubGlobal(
     'ResizeObserver',
@@ -515,5 +533,52 @@ describe('RemoteTerminal keepalive & silent-death watchdog (#2871)', () => {
     expect(MockWebSocket.instances).toHaveLength(2);
     expect(sessionPostCount()).toBe(2);
     expect(ticketPostCount()).toBe(2);
+  });
+});
+
+// The real device hostname resolves ~100-300ms after mount, once the parent
+// page's device fetch completes; until then the page passes a placeholder
+// (e.g. "Loading device..."). A prop update carrying only the hostname must
+// never re-run terminal initialization or disturb an in-flight/established
+// connection (issue #4152, half of #4090).
+describe('RemoteTerminal hostname prop lifecycle (#4152)', () => {
+  it('does not construct a second terminal or dispose the existing one when deviceHostname changes after mount', async () => {
+    const { rerender } = render(
+      <RemoteTerminal deviceId="device-1" deviceHostname="Loading device..." />,
+    );
+
+    // Let the initial (real-hostname-unaware) init fully complete: xterm
+    // constructed, terminalReady flipped, auto-connect fired. This is the
+    // steady state the placeholder-hostname page sits in for ~100-300ms
+    // before the real hostname resolves.
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1), { timeout: 2000 });
+    expect(terminalLifecycle.constructCount).toBe(1);
+
+    // The device fetch resolves and the parent re-renders with the real
+    // hostname — this must not re-run terminal initialization.
+    rerender(<RemoteTerminal deviceId="device-1" deviceHostname="workstation-42" />);
+    await act(async () => {});
+
+    expect(terminalLifecycle.constructCount).toBe(1);
+    expect(terminalLifecycle.disposeCallCount).toBe(0);
+  });
+
+  it('does not drop an active connection when deviceHostname flips after connect', async () => {
+    const { rerender } = render(
+      <RemoteTerminal deviceId="device-1" deviceHostname="Loading device..." />,
+    );
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1), { timeout: 2000 });
+    fireConnected(MockWebSocket.instances[0]!);
+    expect(await screen.findByRole('button', { name: /disconnect/i })).toBeInTheDocument();
+
+    rerender(<RemoteTerminal deviceId="device-1" deviceHostname="workstation-42" />);
+    await act(async () => {});
+
+    // The session must still read as connected — not silently torn down and
+    // reset to 'disconnected' just because the hostname prop resolved.
+    expect(await screen.findByRole('button', { name: /disconnect/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('terminal-disconnect-overlay')).not.toBeInTheDocument();
+    expect(MockWebSocket.instances).toHaveLength(1);
   });
 });

--- a/apps/web/src/components/remote/RemoteTerminal.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.tsx
@@ -94,6 +94,28 @@ export default function RemoteTerminal({
   // not drive the UI or the wire.
   const connectAttemptRef = useRef(0);
 
+  // initTerminal must be immune to prop-identity churn (deviceHostname flips
+  // ~100-300ms after mount once the parent's device fetch resolves; onError/t
+  // can also change identity across renders). These refs hold the latest
+  // value for use inside the one-shot init routine without pulling them into
+  // its dependency array — see initTerminal below and issue #4152.
+  const deviceHostnameRef = useRef(deviceHostname);
+  const onErrorRef = useRef(onError);
+  const tRef = useRef(t);
+  deviceHostnameRef.current = deviceHostname;
+  onErrorRef.current = onError;
+  tRef.current = t;
+  // The hostname actually announced in the terminal's "connecting to" line so
+  // far. Compared against the live prop by the effect below to decide whether
+  // to write an updated line — never to decide whether to re-init.
+  const announcedHostnameRef = useRef<string | null>(null);
+  // Set synchronously the instant init starts (before the first await), so a
+  // second invocation can never slip past the guard while the first is still
+  // mid-flight — this is what actually prevents the double-init race, not the
+  // terminalRef null-check alone (that check happens too late: it stays null
+  // until well after the first `await import(...)`).
+  const initStartedRef = useRef(false);
+
   const [status, setStatus] = useState<ConnectionStatus>('disconnected');
   // Tracks whether the one-shot auto-connect has already fired. This gates the
   // auto-connect effect so it runs exactly once, on initial mount: without it,
@@ -110,9 +132,18 @@ export default function RemoteTerminal({
   const [bytesTransferred, setBytesTransferred] = useState({ sent: 0, received: 0 });
   const [terminalReady, setTerminalReady] = useState(false);
 
-  // Initialize xterm.js
+  // Initialize xterm.js. Deliberately has no dependencies: this must run
+  // exactly once per mount, immune to deviceHostname/onError/t identity
+  // changes (issue #4152). Anything that can change after mount is read via
+  // a ref (deviceHostnameRef/onErrorRef/tRef) instead of being captured in
+  // the closure via the dependency array.
   const initTerminal = useCallback(async () => {
-    if (!terminalContainerRef.current || terminalRef.current) return;
+    if (!terminalContainerRef.current || initStartedRef.current) return;
+    // Flip this synchronously, before any await, so a second invocation
+    // triggered while this one is still mid-flight (e.g. a hostname prop
+    // update landing between the dynamic imports below) can never pass the
+    // guard and start a second terminal.
+    initStartedRef.current = true;
 
     try {
       // Dynamic import of xterm.js
@@ -176,18 +207,22 @@ export default function RemoteTerminal({
       });
       resizeObserverRef.current.observe(terminalContainerRef.current);
 
-      // Display welcome message
-      terminal.writeln(`\x1b[1;34m${t('remoteTerminal.welcome')}\x1b[0m`);
-      terminal.writeln(`\x1b[90m${t('remoteTerminal.connectingTo', { hostname: deviceHostname })}\x1b[0m`);
+      // Display welcome message. Read the hostname/translator via refs so
+      // this stays correct even though this callback has no deps: it always
+      // sees the latest value at the moment init actually runs.
+      const hostnameAtInit = deviceHostnameRef.current;
+      terminal.writeln(`\x1b[1;34m${tRef.current('remoteTerminal.welcome')}\x1b[0m`);
+      terminal.writeln(`\x1b[90m${tRef.current('remoteTerminal.connectingTo', { hostname: hostnameAtInit })}\x1b[0m`);
       terminal.writeln('');
+      announcedHostnameRef.current = hostnameAtInit;
 
       // Signal that terminal is ready for connection
       setTerminalReady(true);
     } catch (error) {
       console.error('Failed to initialize terminal:', error);
-      onError?.(t('remoteTerminal.errors.initialize'));
+      onErrorRef.current?.(tRef.current('remoteTerminal.errors.initialize'));
     }
-  }, [deviceHostname, onError, t]);
+  }, []);
 
   // Connect to remote session
   const connect = useCallback(async () => {
@@ -555,22 +590,48 @@ export default function RemoteTerminal({
     }, 100);
   }, []);
 
-  // Initialize terminal on mount
+  // Initialize terminal on mount. initTerminal has no deps (see above), so
+  // this effect's identity never changes across renders and it runs exactly
+  // once per real mount/unmount — a deviceHostname/onError/t prop change
+  // cannot re-trigger it (issue #4152).
   useEffect(() => {
     initTerminal();
 
     return () => {
       if (resizeObserverRef.current) {
         resizeObserverRef.current.disconnect();
+        resizeObserverRef.current = null;
       }
       if (webSocketRef.current) {
         webSocketRef.current.close();
+        webSocketRef.current = null;
       }
       if (terminalRef.current) {
         terminalRef.current.dispose();
+        terminalRef.current = null;
       }
+      fitAddonRef.current = null;
+      // Reset the one-shot init guard and readiness flag so a genuine
+      // remount (a fresh mount of this component, or React StrictMode's
+      // dev-mode mount→cleanup→mount on the same instance) can re-init
+      // cleanly instead of being permanently blocked by stale guard state.
+      initStartedRef.current = false;
+      announcedHostnameRef.current = null;
+      setTerminalReady(false);
     };
   }, [initTerminal]);
+
+  // The device hostname resolves asynchronously after mount (the page starts
+  // with a "Loading device..." placeholder). Once it changes to the real
+  // value, update the terminal's "connecting to" line in place rather than
+  // re-initializing the terminal — the line is display-only and never
+  // affects the guard above.
+  useEffect(() => {
+    if (!terminalReady || !terminalRef.current) return;
+    if (deviceHostname === announcedHostnameRef.current) return;
+    terminalRef.current.writeln(`\x1b[90m${t('remoteTerminal.connectingTo', { hostname: deviceHostname })}\x1b[0m`);
+    announcedHostnameRef.current = deviceHostname;
+  }, [deviceHostname, terminalReady, t]);
 
   // Auto-connect exactly once, on initial mount. The attempt flag is only set
   // when the timer actually fires (not when scheduled), so an effect re-run

--- a/apps/web/src/locales/de-DE/remote.json
+++ b/apps/web/src/locales/de-DE/remote.json
@@ -443,7 +443,7 @@
     "title": "Titel"
   },
   "remoteTerminal": {
-    "connectedBang": "Verbundener Knall",
+    "connectedBang": "Verbunden!",
     "connectingTo": "Verbinden mit {{hostname}}...",
     "copySelection": "Auswahl kopieren",
     "disconnect": "Trennen",

--- a/apps/web/src/locales/en/remote.json
+++ b/apps/web/src/locales/en/remote.json
@@ -443,7 +443,7 @@
     "title": "Title"
   },
   "remoteTerminal": {
-    "connectedBang": "Connected Bang",
+    "connectedBang": "Connected!",
     "connectingTo": "Connecting to {{hostname}}...",
     "copySelection": "Copy Selection",
     "disconnect": "Disconnect",

--- a/apps/web/src/locales/es-419/remote.json
+++ b/apps/web/src/locales/es-419/remote.json
@@ -443,7 +443,7 @@
     "title": "Título"
   },
   "remoteTerminal": {
-    "connectedBang": "Explosión conectada",
+    "connectedBang": "¡Conectado!",
     "connectingTo": "Conectándose a {{hostname}}...",
     "copySelection": "Copiar selección",
     "disconnect": "Desconectar",

--- a/apps/web/src/locales/fr-CA/remote.json
+++ b/apps/web/src/locales/fr-CA/remote.json
@@ -443,7 +443,7 @@
     "title": "Titre"
   },
   "remoteTerminal": {
-    "connectedBang": "Bang connecté",
+    "connectedBang": "Connecté !",
     "connectingTo": "Connexion à {{hostname}}...",
     "copySelection": "Copier la sélection",
     "disconnect": "Déconnecter",

--- a/apps/web/src/locales/fr-FR/remote.json
+++ b/apps/web/src/locales/fr-FR/remote.json
@@ -443,7 +443,7 @@
     "title": "Titre"
   },
   "remoteTerminal": {
-    "connectedBang": "Bang connecté",
+    "connectedBang": "Connecté !",
     "connectingTo": "Connexion à {{hostname}}...",
     "copySelection": "Copier la sélection",
     "disconnect": "Déconnecter",

--- a/apps/web/src/locales/tr-TR/remote.json
+++ b/apps/web/src/locales/tr-TR/remote.json
@@ -443,7 +443,7 @@
     "title": "Başlık"
   },
   "remoteTerminal": {
-    "connectedBang": "Bağlantılı Patlama",
+    "connectedBang": "Bağlandı!",
     "connectingTo": "{{hostname}}'ye bağlanılıyor...",
     "copySelection": "Seçimi Kopyala",
     "disconnect": "Bağlantıyı kes",


### PR DESCRIPTION
## Bug 1 — RemoteTerminal double-init / dead-terminal lifecycle race

**Root cause**: `apps/web/src/pages/remote/terminal/[deviceId].astro` passes a `"Loading device..."` placeholder as `deviceHostname`, which `RemoteToolsPage.tsx` replaces with the real hostname ~100-300ms later. `RemoteTerminal.tsx`'s `initTerminal` was a `useCallback` with deps `[deviceHostname, onError, t]`, and the mount effect was keyed on `[initTerminal]` — so the hostname flip re-ran terminal initialization. The double-init guard checked `terminalRef.current` *before* the `await import('@xterm/xterm')` calls, but the ref is only assigned after `terminal.open()`. Depending on timing this produced either:
- Two xterm instances opened into the same container (duplicate/overlapping rendering, a leaked ResizeObserver, and a resize/SIGWINCH storm), or
- A disposed terminal whose refs were never nulled, permanently blocking re-init — and since the mount effect's cleanup also closed `webSocketRef`, an **already-connected session got silently dropped** the moment the hostname prop resolved (issue #4152's "Terminal won't connect until visiting File Browser and back").

**Fix** (`apps/web/src/components/remote/RemoteTerminal.tsx`):
- `initTerminal` now has **no dependencies** and is guarded by `initStartedRef`, flipped synchronously *before* the first `await` — so a second invocation can never slip past the guard while the first is still mid-flight.
- The values that can change after mount (`deviceHostname`, `onError`, `t`) are read via refs (`deviceHostnameRef`, `onErrorRef`, `tRef`) updated on every render, instead of being captured via the dependency array.
- A separate, small effect updates the terminal's "connecting to" line in place once the real hostname resolves — it does **not** re-create the terminal.
- Cleanup now nulls every ref it disposes (`terminalRef`, `fitAddonRef`, `resizeObserverRef`, `webSocketRef`) and resets `terminalReady`/`initStartedRef`, so a genuine remount (or React StrictMode's dev-mode mount→cleanup→mount) still re-inits correctly.
- Auto-connect/disconnect semantics (#2137) and the keepalive/silence-watchdog (#2871, separate issue awaiting reporter data on #4090) are untouched.

**Tests** (red-first, `apps/web/src/components/remote/RemoteTerminal.test.tsx`): added a `RemoteTerminal hostname prop lifecycle (#4152)` describe block with two tests, confirmed failing against the pre-fix code:
1. `does not construct a second terminal or dispose the existing one when deviceHostname changes after mount` — asserted via the mocked `@xterm/xterm` `Terminal` constructor call count and a `dispose()` counter. Pre-fix: `disposeCallCount` was `1` (expected `0`).
2. `does not drop an active connection when deviceHostname flips after connect` — establishes a connected session, then flips the hostname prop, and asserts the Disconnect button (i.e. `status === 'connected'`) still shows with no disconnect overlay. Pre-fix: the session was silently dropped to `disconnected` with the overlay shown.

Both tests pass after the fix; all 17 tests in the file pass with no regressions.

## Bug 2 — "Connected Bang" locale artifact

`apps/web/src/locales/*/remote.json`'s `connectedBang` key (rendered at `RemoteTerminal.tsx:307`, now ~`:320`) had the auto-derived key name as its value in six locales. Fixed the **values only** (key unchanged, to preserve i18n parity):

| Locale | Before | After |
|---|---|---|
| en | `Connected Bang` | `Connected!` |
| de-DE | `Verbundener Knall` | `Verbunden!` |
| es-419 | `Explosión conectada` | `¡Conectado!` |
| fr-CA | `Bang connecté` | `Connecté !` |
| fr-FR | `Bang connecté` | `Connecté !` |
| tr-TR | `Bağlantılı Patlama` | `Bağlandı!` |

(fr-CA uses a space before `!` to match this repo's existing convention, e.g. `auth.json`'s `copiedBang: "Copié !"`.) it-IT (`Connessione riuscita`) and pt-BR (`Conectado!`) were already correct and left untouched.

Ran `src/lib/i18n/translationCoverage.test.ts` — all 15 tests pass (values-only change, no baseline impact).

## Test evidence

```
$ npx vitest run src/components/remote/RemoteTerminal.test.tsx
 Test Files  1 passed (1)
      Tests  17 passed (17)

$ npx vitest run src/lib/i18n/translationCoverage.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

`tsc --noEmit` and `eslint` on the changed files are both clean.

## Known CI noise (not touched by this PR)

Per repo notes, `main` may still be red pending fix PR #4158 — this PR's CI may show the unrelated `aiAgents.routes.integration.test.ts` failure and the known Trivy base-image finding. Not chased here.

Closes #4152
Refs #4090

🤖 Generated with [Claude Code](https://claude.com/claude-code)
