### PR TITLE
chore(web): What's New entry for v0.109.0

### DIFF
--- a/apps/web/src/lib/whatsNew.ts
+++ b/apps/web/src/lib/whatsNew.ts
@@ -18,6 +18,19 @@ export interface WhatsNewEntry {
  */
 export const WHATS_NEW_ENTRIES: WhatsNewEntry[] = [
   {
+    version: '0.109.0',
+    date: '2026-08-28',
+    title: 'Org archive, guided SSO linking, and 30-day installer keys',
+    highlights: [
+      'Installer and enrollment keys now default to 30 days and 50 devices — staged rollouts no longer die when the download window expires.',
+      'Organizations can now be archived (read-only, with restore) instead of only removed.',
+      'SSO users with an existing password account get a guided "Connect your sign-in" flow instead of a lockout.',
+      'The new AI Agent Runs view shows what an agent did, step by step, with verification results.',
+      'Remote terminal fixes: no more dead Terminal tab until you switch tabs, and the garbled welcome message is gone.',
+    ],
+    learnMoreUrl: 'https://breezermm.com/release-notes',
+  },
+  {
     version: '0.105.0',
     date: '2026-08-12',
     title: 'Faster fleet views and clearer device health',


### PR DESCRIPTION
Adds the in-app What's New content for v0.109.0.
Must merge before the v0.109.0 tag is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)