### PR TITLE
feat(auth): complete MFA clients and enrollment (#2489)

### DIFF
--- a/apps/api/src/__tests__/integration/mfaEnrollmentSession.integration.test.ts
+++ b/apps/api/src/__tests__/integration/mfaEnrollmentSession.integration.test.ts
@@ -27,11 +27,21 @@ async function waitForBlockedBackends(blockerPid: number, expected: number): Pro
   const deadline = Date.now() + 10_000;
   for (;;) {
     const rows = await getTestDb().execute<{ waiting: number }>(sql`
-      SELECT count(*)::int AS waiting
-      FROM pg_catalog.pg_stat_activity
-      WHERE datname = current_database()
-        AND state = 'active'
-        AND ${blockerPid} = ANY(pg_catalog.pg_blocking_pids(pid))
+      WITH RECURSIVE wait_chain(pid) AS (
+        SELECT pid
+        FROM pg_catalog.pg_stat_activity
+        WHERE datname = current_database()
+          AND state = 'active'
+          AND ${blockerPid} = ANY(pg_catalog.pg_blocking_pids(pid))
+        UNION
+        SELECT activity.pid
+        FROM pg_catalog.pg_stat_activity activity
+        JOIN wait_chain blocker
+          ON blocker.pid = ANY(pg_catalog.pg_blocking_pids(activity.pid))
+        WHERE activity.datname = current_database()
+          AND activity.state = 'active'
+      )
+      SELECT count(*)::int AS waiting FROM wait_chain
     `);
     if ((rows[0]?.waiting ?? 0) >= expected) return;
     if (Date.now() > deadline) throw new Error('enrollment completions did not reach the user-row barrier');

--- a/apps/api/src/__tests__/integration/mfaEnrollmentSession.integration.test.ts
+++ b/apps/api/src/__tests__/integration/mfaEnrollmentSession.integration.test.ts
@@ -1,0 +1,225 @@
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { eq, sql } from 'drizzle-orm';
+import postgres, { type Sql } from 'postgres';
+import { describe, expect, it } from 'vitest';
+import { withSystemDbAccessContext } from '../../db';
+import { refreshTokenFamilies, users } from '../../db/schema';
+import { authBindingRoutes } from '../../routes/auth/binding';
+import { beginAuthIssuance } from '../../services/authBrowserTransition';
+import { completeInitialMfaEnrollment } from '../../services/mfaEnrollmentSession';
+import { mintRefreshTokenFamily } from '../../services/refreshTokenFamily';
+import type { UserSessionIdentity } from '../../services/userSession';
+import { createPartner, createUser } from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+const DATABASE_URL = process.env.DATABASE_URL
+  ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+async function waitForBlockedBackends(blockerPid: number, expected: number): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    const rows = await getTestDb().execute<{ waiting: number }>(sql`
+      SELECT count(*)::int AS waiting
+      FROM pg_catalog.pg_stat_activity
+      WHERE datname = current_database()
+        AND state = 'active'
+        AND ${blockerPid} = ANY(pg_catalog.pg_blocking_pids(pid))
+    `);
+    if ((rows[0]?.waiting ?? 0) >= expected) return;
+    if (Date.now() > deadline) throw new Error('enrollment completions did not reach the user-row barrier');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function closeClient(client: Sql): Promise<void> {
+  await client.end({ timeout: 1 });
+}
+
+async function freshBrowserCapability() {
+  const response = await authBindingRoutes.request('/browser-binding/bootstrap', { method: 'POST' });
+  expect(response.status).toBe(204);
+  const cookie = response.headers.get('set-cookie') ?? '';
+  const binding = /(?:^|,\s*)breeze_auth_binding=([0-9a-f]{64})/.exec(cookie)?.[1];
+  if (!binding) throw new Error('bootstrap did not return an auth binding');
+  return beginAuthIssuance({ kind: 'browser', value: binding });
+}
+
+async function fixture() {
+  const partner = await createPartner();
+  const user = await createUser({
+    partnerId: partner.id,
+    withMembership: true,
+    email: `mfa-enrollment-${randomUUID()}@example.test`,
+  });
+  const identity: UserSessionIdentity = {
+    userId: user.id,
+    email: user.email,
+    roleId: null,
+    orgId: null,
+    partnerId: partner.id,
+    scope: 'partner',
+    mfa: true,
+  };
+  const oldFamilyId = await mintRefreshTokenFamily(user.id);
+  return { user, identity, oldFamilyId };
+}
+
+function completeTotpEnrollment(
+  fixtureValue: Awaited<ReturnType<typeof fixture>>,
+  capability: Awaited<ReturnType<typeof freshBrowserCapability>>,
+  secret: string,
+) {
+  return withSystemDbAccessContext(() => completeInitialMfaEnrollment({
+    userId: fixtureValue.user.id,
+    identity: fixtureValue.identity,
+    capability,
+    expectedAuthEpoch: fixtureValue.user.authEpoch,
+    expectedMfaEpoch: fixtureValue.user.mfaEpoch,
+    revokeReason: 'integration-initial-mfa',
+    recoveryCodes: [`code-${secret}`],
+    recoveryCodeHashes: [`hash-${secret}`],
+    persistFactor: async (tx, hashes) => {
+      const rows = await tx.update(users).set({
+        mfaEnabled: true,
+        mfaMethod: 'totp',
+        mfaSecret: secret,
+        mfaRecoveryCodes: [...hashes],
+        updatedAt: new Date(),
+      }).where(eq(users.id, fixtureValue.user.id)).returning({ id: users.id });
+      if (rows.length !== 1) throw new Error('factor write missed user');
+      return secret;
+    },
+  }));
+}
+
+describe('completeInitialMfaEnrollment — real-PG atomicity', () => {
+  runDb('rolls back epoch, family changes, replacement issuance, and factor together', async () => {
+    const value = await fixture();
+    const capability = await freshBrowserCapability();
+
+    await expect(withSystemDbAccessContext(() => completeInitialMfaEnrollment({
+      userId: value.user.id,
+      identity: value.identity,
+      capability,
+      expectedAuthEpoch: value.user.authEpoch,
+      expectedMfaEpoch: value.user.mfaEpoch,
+      revokeReason: 'integration-rollback',
+      recoveryCodes: ['plain-code'],
+      recoveryCodeHashes: ['hash-code'],
+      persistFactor: async (tx, hashes) => {
+        await tx.update(users).set({
+          mfaEnabled: true,
+          mfaMethod: 'totp',
+          mfaSecret: 'must-roll-back',
+          mfaRecoveryCodes: [...hashes],
+        }).where(eq(users.id, value.user.id));
+        throw new Error('injected factor failure');
+      },
+    }))).rejects.toThrow('injected factor failure');
+
+    const [after] = await getTestDb().select().from(users).where(eq(users.id, value.user.id)).limit(1);
+    expect(after).toMatchObject({ mfaEnabled: false, mfaEpoch: value.user.mfaEpoch, mfaSecret: null });
+    const families = await getTestDb().select().from(refreshTokenFamilies)
+      .where(eq(refreshTokenFamilies.userId, value.user.id));
+    expect(families).toHaveLength(1);
+    expect(families[0]).toMatchObject({ familyId: value.oldFamilyId, revokedAt: null });
+  });
+
+  runDb('allows exactly one concurrent initial-factor completion', async () => {
+    const value = await fixture();
+    const [capabilityA, capabilityB] = await Promise.all([
+      freshBrowserCapability(),
+      freshBrowserCapability(),
+    ]);
+    const holder = postgres(DATABASE_URL, { max: 1, onnotice: () => undefined });
+    const holderPid = (await holder<{ pid: number }[]>`SELECT pg_backend_pid()::int AS pid`)[0]?.pid;
+    if (holderPid === undefined) throw new Error('could not determine barrier backend PID');
+    const rowLocked = deferred();
+    const release = deferred();
+    let settled!: PromiseSettledResult<Awaited<ReturnType<typeof completeTotpEnrollment>>>[];
+
+    try {
+      const barrier = holder.begin(async (tx) => {
+        await tx`SELECT id FROM users WHERE id = ${value.user.id} FOR UPDATE`;
+        rowLocked.resolve();
+        await release.promise;
+      });
+      await rowLocked.promise;
+      const completions = Promise.allSettled([
+        completeTotpEnrollment(value, capabilityA, 'secret-a'),
+        completeTotpEnrollment(value, capabilityB, 'secret-b'),
+      ]);
+      await waitForBlockedBackends(holderPid, 2);
+      release.resolve();
+      await barrier;
+      settled = await completions;
+    } finally {
+      release.resolve();
+      await closeClient(holder);
+    }
+
+    expect(settled.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    const losers = settled.filter((result) => result.status === 'rejected');
+    expect(losers).toHaveLength(1);
+    expect(losers[0]?.reason).toMatchObject({ name: 'AuthIssuanceConflictError' });
+
+    const [after] = await getTestDb().select().from(users).where(eq(users.id, value.user.id)).limit(1);
+    expect(after?.mfaEnabled).toBe(true);
+    expect(after?.mfaEpoch).toBe(value.user.mfaEpoch + 1);
+    expect(['secret-a', 'secret-b']).toContain(after?.mfaSecret);
+
+    const families = await getTestDb().select().from(refreshTokenFamilies)
+      .where(eq(refreshTokenFamilies.userId, value.user.id));
+    expect(families.filter((family) => family.revokedAt === null)).toHaveLength(1);
+    expect(families.find((family) => family.familyId === value.oldFamilyId)?.revokedAt).toBeInstanceOf(Date);
+  });
+
+  runDb('rejects enrollment when an auth-epoch cutoff commits while the request is waiting', async () => {
+    const value = await fixture();
+    const capability = await freshBrowserCapability();
+    const holder = postgres(DATABASE_URL, { max: 1, onnotice: () => undefined });
+    const holderPid = (await holder<{ pid: number }[]>`SELECT pg_backend_pid()::int AS pid`)[0]?.pid;
+    if (holderPid === undefined) throw new Error('could not determine barrier backend PID');
+    const rowLocked = deferred();
+    const release = deferred();
+
+    try {
+      const cutoff = holder.begin(async (tx) => {
+        await tx`SELECT id FROM users WHERE id = ${value.user.id} FOR UPDATE`;
+        rowLocked.resolve();
+        await release.promise;
+        await tx`UPDATE users SET auth_epoch = auth_epoch + 1 WHERE id = ${value.user.id}`;
+      });
+      await rowLocked.promise;
+      const enrollment = completeTotpEnrollment(value, capability, 'stale-secret');
+      await waitForBlockedBackends(holderPid, 1);
+      release.resolve();
+      await cutoff;
+
+      await expect(enrollment).rejects.toMatchObject({ name: 'AuthIssuanceConflictError' });
+    } finally {
+      release.resolve();
+      await closeClient(holder);
+    }
+
+    const [after] = await getTestDb().select().from(users).where(eq(users.id, value.user.id)).limit(1);
+    expect(after).toMatchObject({
+      authEpoch: value.user.authEpoch + 1,
+      mfaEpoch: value.user.mfaEpoch,
+      mfaEnabled: false,
+      mfaSecret: null,
+    });
+    const families = await getTestDb().select().from(refreshTokenFamilies)
+      .where(eq(refreshTokenFamilies.userId, value.user.id));
+    expect(families).toHaveLength(1);
+    expect(families[0]).toMatchObject({ familyId: value.oldFamilyId, revokedAt: null });
+  });
+});

--- a/apps/api/src/__tests__/integration/passkeyMfaVerify.integration.test.ts
+++ b/apps/api/src/__tests__/integration/passkeyMfaVerify.integration.test.ts
@@ -103,6 +103,7 @@ describe('POST /auth/mfa/passkey/verify — passkey metadata persists under RLS 
         userId: user.id,
         mfaMethod: 'passkey',
         passkeyAvailable: true,
+        recoveryAvailable: false,
         authEpoch: 1,
         mfaEpoch: 1,
         transitionId: randomUUID(),

--- a/apps/api/src/__tests__/integration/pendingMfaEpoch.integration.test.ts
+++ b/apps/api/src/__tests__/integration/pendingMfaEpoch.integration.test.ts
@@ -67,6 +67,7 @@ describe('POST /auth/mfa/verify — pending session bound to a stale mfa_epoch i
         userId: user.id,
         mfaMethod: 'totp',
         passkeyAvailable: false,
+        recoveryAvailable: false,
         authEpoch: 1,
         mfaEpoch: pendingMfaEpoch, // bound to N
         transitionId: randomUUID(),

--- a/apps/api/src/__tests__/integration/recoveryCode.integration.test.ts
+++ b/apps/api/src/__tests__/integration/recoveryCode.integration.test.ts
@@ -47,6 +47,7 @@ function pendingRecord(userId: string) {
     userId,
     mfaMethod: 'totp',
     passkeyAvailable: false,
+    recoveryAvailable: true,
     authEpoch: 1,
     mfaEpoch: 1,
     transitionId: randomUUID(),

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -520,6 +520,28 @@ describe('authMiddleware', () => {
     expect(vi.mocked(getEffectiveMfaPolicy)).not.toHaveBeenCalled();
   });
 
+  it('allows an unenrolled user to load /auth/mfa/enrollment-options through the 428 gate', async () => {
+    const app = new Hono();
+    app.use(authMiddleware);
+    app.get('/api/v1/auth/mfa/enrollment-options', (c) => c.json({ allowedMethods: {} }));
+
+    vi.mocked(verifyToken).mockResolvedValue({
+      ...basePayload,
+      scope: 'partner',
+      orgId: null,
+    });
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectWithLimit([unenrolledUser]) as any)
+      .mockReturnValueOnce(selectWithLimit([{ orgAccess: 'none', orgIds: null }]) as any);
+
+    const res = await app.request('/api/v1/auth/mfa/enrollment-options', {
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(getEffectiveMfaPolicy)).not.toHaveBeenCalled();
+  });
+
   // I6: passkey registration is an enrollment action (passkey is the always-
   // allowed, phishing-resistant factor). A policy-required-but-unenrolled user
   // MUST be able to reach /auth/passkeys/register/* — otherwise the broadened

--- a/apps/api/src/middleware/cfAccessLogin.ts
+++ b/apps/api/src/middleware/cfAccessLogin.ts
@@ -205,6 +205,13 @@ export async function cfAccessLoginMiddleware(c: Context, next: Next): Promise<R
     // totp/sms. The helper fails closed, so a probe error just hides the
     // alternate rather than blocking this CF-Access MFA challenge.
     const passkeyAvailable = await userHasUsablePasskey(user.id);
+    // Mirror the password /login handler and the SSO handler (sso.ts): a
+    // pending record now requires recoveryAvailable (parsePendingMfa rejects
+    // any record missing it), so this CF-Access issuance path must compute
+    // and carry it too, or every real MFA completion here would be hard
+    // -rejected as a malformed/legacy record.
+    const recoveryAvailable = Array.isArray(user.mfaRecoveryCodes)
+      && user.mfaRecoveryCodes.length > 0;
     // SR2-06: bind the pending record to the live auth/mfa epochs + status +
     // effective allowed methods at issuance — same shape/rationale as the
     // password /login handler (login.ts), so the shared TOTP/SMS/passkey
@@ -244,6 +251,7 @@ export async function cfAccessLoginMiddleware(c: Context, next: Next): Promise<R
         userId: user.id,
         mfaMethod,
         passkeyAvailable,
+        recoveryAvailable,
         authEpoch: pendingEpochs.authEpoch,
         mfaEpoch: pendingEpochs.mfaEpoch,
         statusExpectation: user.status,
@@ -257,6 +265,7 @@ export async function cfAccessLoginMiddleware(c: Context, next: Next): Promise<R
       tempToken,
       mfaMethod,
       passkeyAvailable,
+      recoveryAvailable,
       phoneLast4: user.phoneNumber?.slice(-4) || null,
       user: null,
       tokens: null,

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -92,7 +92,7 @@ vi.mock('../services', () => {
   generateMFASecret: vi.fn(),
   generateOTPAuthURL: vi.fn(),
   generateQRCode: vi.fn(),
-  generateRecoveryCodes: vi.fn(),
+  generateRecoveryCodes: vi.fn(() => ['CODE-0001', 'CODE-0002']),
   createSession: vi.fn(),
   invalidateSession: vi.fn(),
   invalidateAllUserSessions: vi.fn(),
@@ -131,6 +131,39 @@ vi.mock('../services', () => {
   AuthIssuanceConflictError,
   AuthIssuanceCapabilityError,
   issueUserSession: vi.fn(async (identity: any) => issueLegacy(identity)),
+  completeInitialMfaEnrollment: vi.fn(async (input: any) => {
+    const tx: any = {
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve(dbState.insertReturning)),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn((values: Record<string, unknown>) => {
+          dbState.updateSets.push(values);
+          const whereResult: any = Promise.resolve(undefined);
+          whereResult.returning = vi.fn(() => Promise.resolve([{ id: 'user-123' }]));
+          return { where: vi.fn(() => whereResult) };
+        }),
+      })),
+    };
+    const value = await input.persistFactor(tx, input.recoveryCodeHashes);
+    return {
+      value,
+      recoveryCodes: [...input.recoveryCodes],
+      issued: {
+        accessToken: 'replacement-access-token',
+        refreshToken: 'replacement-refresh-token',
+        refreshJti: 'replacement-jti',
+        expiresInSeconds: 900,
+        familyId: 'replacement-family',
+        transitionId: 'transition-1',
+        generation: 1,
+      },
+      mfaEpoch: 2,
+      cleanup: { redisOk: true, permissionCacheOk: true, oauthOk: true, remoteSessionsTerminated: 0 },
+    };
+  }),
   issueUserSessionLegacyDuringTransition: issueLegacy,
   bindIssuedUserSession: vi.fn(async () => undefined),
   authBrowserTransitionsEnforced: vi.fn(() => process.env.AUTH_BROWSER_TRANSITIONS_ENFORCED === 'true'),
@@ -402,6 +435,7 @@ function pendingMfaJson(overrides: Partial<{
   userId: string;
   mfaMethod: string;
   passkeyAvailable: boolean;
+  recoveryAvailable: boolean;
   authEpoch: number;
   mfaEpoch: number;
   statusExpectation: string;
@@ -415,6 +449,7 @@ function pendingMfaJson(overrides: Partial<{
     userId: 'user-123',
     mfaMethod: 'totp',
     passkeyAvailable: false,
+    recoveryAvailable: true,
     authEpoch: 1,
     mfaEpoch: 1,
     statusExpectation: 'active',
@@ -455,6 +490,11 @@ describe('passkey MFA auth routes', () => {
     delete process.env.AUTH_BROWSER_TRANSITIONS_ENFORCED;
     vi.mocked(getUserEpochs).mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
     vi.mocked(rateLimiter).mockResolvedValue({ allowed: true, remaining: 4, resetAt: new Date() });
+    vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+      required: false,
+      allowedMethods: { totp: true, sms: true, passkey: true },
+      source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: false },
+    });
     dbState.selectQueue = [];
     dbState.updateSets = [];
     dbState.insertReturning = [insertedPasskeyRow];
@@ -724,7 +764,11 @@ describe('passkey MFA auth routes', () => {
     // [user] = the login user lookup; the partner-membership row lets
     // resolveCurrentUserTokenContext resolve a partner scope rather than the
     // (now-rejected) membership-less system default. (security review #2)
-    dbState.selectQueue.push([user], [{ partnerId: 'partner-1', roleId: 'role-1' }]);
+    dbState.selectQueue.push(
+      [user],
+      [{ partnerId: 'partner-1', roleId: 'role-1' }],
+      [{ id: 'credential-row-1', userId: 'user-123', disabledAt: null }],
+    );
 
     const res = await app.request('/auth/login', {
       method: 'POST',
@@ -829,16 +873,18 @@ describe('passkey MFA auth routes', () => {
   // method is totp/sms as long as the session flags a passkey as available.
   it('returns passkey options for a TOTP-primary pending session flagged passkeyAvailable', async () => {
     redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'totp', passkeyAvailable: true }));
-    dbState.selectQueue.push([
-      {
+    dbState.selectQueue.push(
+      [user],
+      [{ partnerId: 'partner-123', roleId: 'role-123' }],
+      [{
         id: 'credential-row-1',
         userId: 'user-123',
         credentialId: 'credential-1',
         publicKey: 'public-key',
         counter: 0,
         transports: ['internal'],
-      },
-    ]);
+      }],
+    );
 
     const res = await app.request('/auth/mfa/passkey/options', {
       method: 'POST',
@@ -890,8 +936,12 @@ describe('passkey MFA auth routes', () => {
   // non-passkey session that does not flag a passkey as available. This is the
   // half of pendingAllowsPasskey that mints tokens — regressing it to accept
   // any session would be a bypass, so it needs its own explicit test.
-  it('rejects /mfa/passkey/verify for a TOTP session with no available passkey', async () => {
-    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'totp', passkeyAvailable: false }));
+  it('rejects /mfa/passkey/verify for a challenge that did not authorize passkey', async () => {
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({
+      mfaMethod: 'totp',
+      passkeyAvailable: false,
+      allowedMethods: { totp: true, sms: false, passkey: false },
+    }));
 
     const res = await app.request('/auth/mfa/passkey/verify', {
       method: 'POST',
@@ -902,11 +952,98 @@ describe('passkey MFA auth routes', () => {
       }),
     });
 
-    expect(res.status).toBe(400);
-    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/passkey mfa is not configured/i) });
+    expect(res.status).toBe(401);
     expect(createTokenPair).not.toHaveBeenCalled();
     expect(rateLimiter).not.toHaveBeenCalled();
     expect(redisMock.del).not.toHaveBeenCalled();
+  });
+
+  it('treats allowedMethods.passkey as authoritative even when the legacy compatibility flag is true', async () => {
+    redisMock.get.mockResolvedValue(pendingMfaJson({
+      mfaMethod: 'totp',
+      passkeyAvailable: true,
+      allowedMethods: { totp: true, sms: false, passkey: false },
+    }));
+
+    const options = await app.request('/auth/mfa/passkey/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tempToken: 'temp-token' }),
+    });
+    const verify = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tempToken: 'temp-token',
+        credential: { id: 'credential-1', response: {} },
+      }),
+    });
+
+    expect(options.status).toBe(401);
+    expect(verify.status).toBe(401);
+    expect(passkeyMocks.generatePasskeyAuthenticationOptions).not.toHaveBeenCalled();
+    expect(passkeyMocks.verifyPasskeyAuthentication).not.toHaveBeenCalled();
+    expect(redisMock.del).not.toHaveBeenCalled();
+  });
+
+  it('consumes an epoch-drifted challenge before issuing passkey options', async () => {
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({
+      mfaMethod: 'passkey',
+      allowedMethods: { totp: false, sms: false, passkey: true },
+    }));
+    dbState.selectQueue.push([user]);
+    vi.mocked(getUserEpochs).mockResolvedValueOnce({ authEpoch: 1, mfaEpoch: 2 });
+
+    const res = await app.request('/auth/mfa/passkey/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tempToken: 'temp-token' }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(redisMock.del).toHaveBeenCalledWith('mfa:pending:temp-token');
+    expect(passkeyMocks.generatePasskeyAuthenticationOptions).not.toHaveBeenCalled();
+  });
+
+  it('consumes a challenge when live policy no longer permits passkey verification', async () => {
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({
+      mfaMethod: 'passkey',
+      allowedMethods: { totp: false, sms: false, passkey: true },
+    }));
+    dbState.selectQueue.push(
+      [user],
+      [{
+        id: 'credential-row-1',
+        userId: 'user-123',
+        credentialId: 'credential-1',
+        publicKey: 'public-key',
+        counter: 0,
+        transports: ['internal'],
+        disabledAt: null,
+      }],
+      [{ partnerId: 'partner-123', roleId: 'role-123' }],
+    );
+    vi.mocked(getEffectiveMfaPolicy).mockResolvedValueOnce({
+      required: false,
+      allowedMethods: { totp: true, sms: true, passkey: false },
+      source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: false },
+    });
+
+    const res = await app.request('/auth/mfa/passkey/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tempToken: 'temp-token',
+        credential: { id: 'credential-1', response: {} },
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(redisMock.del).toHaveBeenCalledWith('mfa:pending:temp-token');
+    // Live policy is checked after the local WebAuthn proof so an acquired
+    // capability lease can be cancelled, but before any session is minted.
+    expect(passkeyMocks.verifyPasskeyAuthentication).toHaveBeenCalledOnce();
+    expect(createTokenPair).not.toHaveBeenCalled();
   });
 
   // SR2-06: parsePendingMfa is STRICT — a legacy pre-rollout pending token
@@ -932,16 +1069,18 @@ describe('passkey MFA auth routes', () => {
 
   it('returns passkey authentication options for a pending passkey MFA login', async () => {
     redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'passkey' }));
-    dbState.selectQueue.push([
-      {
+    dbState.selectQueue.push(
+      [user],
+      [{ partnerId: 'partner-123', roleId: 'role-123' }],
+      [{
         id: 'credential-row-1',
         userId: 'user-123',
         credentialId: 'credential-1',
         publicKey: 'public-key',
         counter: 0,
         transports: ['internal'],
-      },
-    ]);
+      }],
+    );
 
     const res = await app.request('/auth/mfa/passkey/options', {
       method: 'POST',
@@ -1204,6 +1343,7 @@ describe('passkey MFA auth routes', () => {
         transports: ['internal'],
         disabledAt: null,
       }],
+      [{ partnerId: 'partner-123', roleId: 'role-123' }],
     );
     passkeyMocks.verifyPasskeyAuthentication.mockResolvedValueOnce({ verified: false });
 
@@ -1310,7 +1450,7 @@ describe('passkey MFA auth routes', () => {
     expect(res.status).toBe(401);
     expect(await res.json()).toMatchObject({ error: expect.stringMatching(/invalid or expired/i) });
     expect(createTokenPair).not.toHaveBeenCalled();
-    expect(redisMock.del).not.toHaveBeenCalled();
+    expect(redisMock.del).toHaveBeenCalledWith('mfa:pending:temp-token');
   });
 
   // SR2-06: a factor change (mfa_epoch bump) during the 5-minute MFA window
@@ -1355,6 +1495,7 @@ describe('passkey MFA auth routes', () => {
         transports: ['internal'],
         disabledAt: null,
       }],
+      [{ partnerId: 'partner-123', roleId: 'role-123' }],
     );
     vi.mocked(finalizeSsoPendingLink).mockResolvedValue({
       ok: true,
@@ -1408,6 +1549,7 @@ describe('passkey MFA auth routes', () => {
         transports: ['internal'],
         disabledAt: null,
       }],
+      [{ partnerId: 'partner-123', roleId: 'role-123' }],
     );
     vi.mocked(finalizeSsoPendingLink).mockResolvedValue({ ok: false, error: 'link_expired' } as any);
 
@@ -1426,8 +1568,12 @@ describe('passkey MFA auth routes', () => {
   });
 
   // (e) /mfa/passkey/options guards.
-  it('returns 400 from passkey options when the pending session is not a passkey session', async () => {
-    redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'totp', passkeyAvailable: false }));
+  it('returns 401 from passkey options when the pending challenge did not authorize passkey', async () => {
+    redisMock.get.mockResolvedValueOnce(pendingMfaJson({
+      mfaMethod: 'totp',
+      passkeyAvailable: false,
+      allowedMethods: { totp: true, sms: false, passkey: false },
+    }));
 
     const res = await app.request('/auth/mfa/passkey/options', {
       method: 'POST',
@@ -1435,14 +1581,17 @@ describe('passkey MFA auth routes', () => {
       body: JSON.stringify({ tempToken: 'temp-token' }),
     });
 
-    expect(res.status).toBe(400);
-    expect(await res.json()).toMatchObject({ error: expect.stringMatching(/passkey mfa is not configured/i) });
+    expect(res.status).toBe(401);
     expect(passkeyMocks.generatePasskeyAuthenticationOptions).not.toHaveBeenCalled();
   });
 
   it('returns 400 from passkey options when the account has no registered passkeys', async () => {
     redisMock.get.mockResolvedValueOnce(pendingMfaJson({ mfaMethod: 'passkey' }));
-    dbState.selectQueue.push([]);
+    dbState.selectQueue.push(
+      [user],
+      [{ partnerId: 'partner-123', roleId: 'role-123' }],
+      [],
+    );
 
     const res = await app.request('/auth/mfa/passkey/options', {
       method: 'POST',
@@ -1461,11 +1610,11 @@ describe('passkey MFA auth routes', () => {
     // register/verify requires a fresh existing-factor step-up grant.
     // Query order: userIsMfaProtected (gate) first, then #4018's
     // resolveEnrollmentStepUp terminal read (passwordHash — this is a password
-    // account, so it is a no-op), then the transaction's own "current MFA" read
-    // (hasExistingFactor check).
+    // account, so it is a no-op), then the terminal route's live enrollment
+    // state read.
     dbState.selectQueue.push([{ mfaEnabled: true, passkeyCount: 0 }]);
     dbState.selectQueue.push([{ passwordHash: '$argon2id$hash' }]);
-    dbState.selectQueue.push([{ mfaSecret: 'enc-secret', mfaMethod: 'totp' }]);
+    dbState.selectQueue.push([{ mfaEnabled: true, mfaSecret: 'enc-secret', mfaMethod: 'totp' }]);
     vi.mocked(consumeStepUpGrant).mockResolvedValueOnce(true);
 
     const res = await app.request('/auth/passkeys/register/verify', {

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -115,6 +115,21 @@ vi.mock('../services', () => {
   RefreshTokenCurrentnessError,
   RecoveryCodeInvalidError,
   issueUserSession: vi.fn(async (identity: any) => issueLegacy(identity)),
+  completeInitialMfaEnrollment: vi.fn(async (input: any) => ({
+    value: undefined,
+    recoveryCodes: [...input.recoveryCodes],
+    issued: {
+      accessToken: 'replacement-access-token',
+      refreshToken: 'replacement-refresh-token',
+      refreshJti: 'replacement-jti',
+      expiresInSeconds: 900,
+      familyId: 'replacement-family',
+      transitionId: 'transition-1',
+      generation: 1,
+    },
+    mfaEpoch: 2,
+    cleanup: { redisOk: true, permissionCacheOk: true, oauthOk: true, remoteSessionsTerminated: 0 },
+  })),
   issueUserSessionLegacyDuringTransition: issueLegacy,
   bindIssuedUserSession: vi.fn(async () => undefined),
   authBrowserTransitionsEnforced: vi.fn(() => process.env.AUTH_BROWSER_TRANSITIONS_ENFORCED === 'true'),
@@ -342,6 +357,7 @@ import {
   issueUserSessionLegacyDuringTransition,
   recordAuthTransitionLegacyIssuer,
   AuthIssuanceCapabilityError,
+  completeInitialMfaEnrollment,
 } from '../services';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
 import { performOrdinaryTerminalLogout } from '../services/terminalLogout';
@@ -355,6 +371,7 @@ import { runPostCommitCleanup } from '../services/authLifecycle';
 import { createAuditLogAsync } from '../services/auditService';
 import { hashRecoveryCode, encryptMfaSecret } from './auth/helpers';
 import { finalizeSsoPendingLink } from './auth/ssoLinkCompletion';
+import * as mfaPolicyModule from '../services/mfaPolicy';
 import { mintStepUpGrant, validateStepUpGrant, consumeStepUpGrant } from '../services/mfaStepUpGrant';
 import { verifyStepUpPasskeyAssertion } from './auth/passkeys';
 import { getTwilioService } from '../services/twilio';
@@ -1333,6 +1350,7 @@ describe('auth routes', () => {
         userId: 'user-1',
         mfaMethod: 'totp',
         passkeyAvailable: false,
+        recoveryAvailable: true,
         authEpoch: 1,
         mfaEpoch: 1,
         statusExpectation: 'active',
@@ -1372,6 +1390,10 @@ describe('auth routes', () => {
       vi.mocked(getRedis).mockReturnValue({ get: getMock, del: delMock, setex: vi.fn() } as any);
       vi.mocked(getUserEpochs).mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
       vi.mocked(consumeMFAToken).mockResolvedValue(true);
+      vi.mocked(getTwilioService).mockReturnValue({
+        sendVerificationCode: vi.fn().mockResolvedValue({ success: true }),
+        checkVerificationCode: vi.fn().mockResolvedValue({ valid: true, serviceError: false }),
+      } as any);
     });
 
     async function postMfaVerify(
@@ -1415,6 +1437,70 @@ describe('auth routes', () => {
         expect.anything(),
       );
       expect(delMock).toHaveBeenCalledWith('mfa:pending:temp-token');
+    });
+
+    it('honors an explicitly authorized SMS switch instead of the pending primary method', async () => {
+      const checkVerificationCode = vi.fn().mockResolvedValue({ valid: true, serviceError: false });
+      vi.mocked(getTwilioService).mockReturnValue({
+        sendVerificationCode: vi.fn(),
+        checkVerificationCode,
+      } as any);
+      liveUserRow = {
+        ...baseLiveUserRow,
+        mfaMethod: 'sms',
+        phoneNumber: '+15550000001',
+      };
+      getMock.mockResolvedValue(pendingRecord({ mfaMethod: 'totp' }));
+
+      const res = await postMfaVerify({
+        tempToken: 'temp-token',
+        code: '654321',
+        method: 'sms',
+      });
+
+      expect(res.status).toBe(200);
+      expect(checkVerificationCode).toHaveBeenCalledWith('+15550000001', '654321');
+      expect(consumeMFAToken).not.toHaveBeenCalled();
+    });
+
+    it('honors an explicitly authorized TOTP switch from an SMS primary', async () => {
+      const checkVerificationCode = vi.fn();
+      vi.mocked(getTwilioService).mockReturnValue({
+        sendVerificationCode: vi.fn(),
+        checkVerificationCode,
+      } as any);
+      liveUserRow = {
+        ...baseLiveUserRow,
+        mfaMethod: 'sms',
+        phoneNumber: '+15550000001',
+      };
+      getMock.mockResolvedValue(pendingRecord({ mfaMethod: 'sms' }));
+
+      const res = await postMfaVerify({
+        tempToken: 'temp-token',
+        code: '123456',
+        method: 'totp',
+      });
+
+      expect(res.status).toBe(200);
+      expect(consumeMFAToken).toHaveBeenCalledWith('PLAINSECRET123', '123456', 'user-1');
+      expect(checkVerificationCode).not.toHaveBeenCalled();
+    });
+
+    it('rejects recovery when the pending challenge did not authorize it without consuming the challenge or a code', async () => {
+      getMock.mockResolvedValue(pendingRecord({ recoveryAvailable: false }));
+
+      const res = await postMfaVerify({
+        tempToken: 'temp-token',
+        code: 'ABCD-2345',
+        method: 'recovery',
+      });
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: 'Invalid MFA code' });
+      expect(consumeRecoveryCode).not.toHaveBeenCalled();
+      expect(consumeMFAToken).not.toHaveBeenCalled();
+      expect(delMock).not.toHaveBeenCalled();
     });
 
     // #4067: pending records carrying ssoLinkTokenHash are the MFA
@@ -1597,6 +1683,7 @@ describe('auth routes', () => {
         userId: 'user-1',
         mfaMethod: 'totp',
         passkeyAvailable: false,
+        recoveryAvailable: true,
         authEpoch: 1,
         mfaEpoch: 1,
         statusExpectation: 'active',
@@ -1711,6 +1798,32 @@ describe('auth routes', () => {
   // the code with the CONSUMING verifier so the accepted time step is
   // recorded and cannot be replayed at login within its validity window.
   describe('POST /auth/mfa/verify — setup confirmation consumes the TOTP step (SR2-24)', () => {
+    it('rejects policy drift before consuming a code or enrollment authority', async () => {
+      const policySpy = vi.spyOn(mfaPolicyModule, 'getEffectiveMfaPolicy').mockResolvedValueOnce({
+        required: true,
+        allowedMethods: { totp: false, sms: false, passkey: true },
+        source: { roleForceMfa: true, settingsRequireMfa: true, killSwitchOff: false },
+      });
+      const mockRedis = {
+        get: vi.fn().mockResolvedValue(JSON.stringify({ secret: 'SETUPSECRET123' })),
+        del: vi.fn(),
+        setex: vi.fn(),
+      };
+      vi.mocked(getRedis).mockReturnValue(mockRedis as any);
+
+      const res = await app.request('/auth/mfa/verify', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: '123456' }),
+      });
+      policySpy.mockRestore();
+
+      expect(res.status).toBe(403);
+      expect(consumeMFAToken).not.toHaveBeenCalled();
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+      expect(completeInitialMfaEnrollment).not.toHaveBeenCalled();
+    });
+
     it('confirms setup via the consuming consumeMFAToken verifier', async () => {
       const mockRedis = {
         get: vi.fn().mockResolvedValue(JSON.stringify({
@@ -2007,14 +2120,14 @@ describe('auth routes', () => {
       expect(first.status).toBe(200);
       expect(consumeStepUpGrant).toHaveBeenCalledTimes(1);
       expect(grants.has('grant-1')).toBe(false);
-      expect(db.transaction).toHaveBeenCalledTimes(1);
+      expect(completeInitialMfaEnrollment).toHaveBeenCalledTimes(1);
 
       const replay = await confirmSetup({ code: '123456', stepUpGrantId: 'grant-1' });
       expect(replay.status).toBe(403);
       expect(await replay.json()).toMatchObject({ error: 'existing_factor_step_up_required' });
       // No second factor write, and the grant was never consumable twice.
       expect(consumeStepUpGrant).toHaveBeenCalledTimes(1);
-      expect(db.transaction).toHaveBeenCalledTimes(1);
+      expect(completeInitialMfaEnrollment).toHaveBeenCalledTimes(1);
     });
 
     it('an INVALID grant still 403s BEFORE the consuming TOTP verifier runs (no burned time-step)', async () => {
@@ -2823,6 +2936,26 @@ describe('auth routes', () => {
       expect(hashPassword).not.toHaveBeenCalled();
     });
 
+    it('GET /auth/mfa/enrollment-options returns live policy choices and phone readiness', async () => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ phoneNumber: '+15551234567', phoneVerified: true }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/auth/mfa/enrollment-options', {
+        headers: { Authorization: 'Bearer valid-token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        allowedMethods: { totp: true, sms: true, passkey: true },
+        phoneConfigured: true,
+      });
+    });
+
     it('POST /auth/mfa/enable should enable MFA and return recovery codes', async () => {
       const setupRecoveryCodes = ['CODE-0001', 'CODE-0002'];
       const mockRedis = {
@@ -2887,6 +3020,39 @@ describe('auth routes', () => {
       // call that double-charges the per-user step-up rate limit and runs
       // argon2 twice for every successful enable.
       expect(verifyPassword).toHaveBeenCalledTimes(1);
+    });
+
+    it('POST /auth/mfa/enable rejects policy drift without consuming enrollment authority', async () => {
+      const policySpy = vi.spyOn(mfaPolicyModule, 'getEffectiveMfaPolicy').mockResolvedValueOnce({
+        required: true,
+        allowedMethods: { totp: false, sms: false, passkey: true },
+        source: { roleForceMfa: true, settingsRequireMfa: true, killSwitchOff: false },
+      });
+      vi.mocked(verifyPassword).mockResolvedValue(true);
+      vi.mocked(getRedis).mockReturnValue({
+        get: vi.fn().mockResolvedValue(JSON.stringify({ secret: 'SETUPSECRET123' })),
+        del: vi.fn(),
+        setex: vi.fn(),
+      } as any);
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash', mfaEnabled: false, passkeyCount: 0 }]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request('/auth/mfa/enable', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: '123456', currentPassword: 'OldStrongPass123' }),
+      });
+      policySpy.mockRestore();
+
+      expect(res.status).toBe(403);
+      expect(consumeMFAToken).not.toHaveBeenCalled();
+      expect(consumeStepUpGrant).not.toHaveBeenCalled();
+      expect(completeInitialMfaEnrollment).not.toHaveBeenCalled();
     });
 
     // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
@@ -3068,14 +3234,14 @@ describe('auth routes', () => {
       expect(first.status).toBe(200);
       expect(consumeStepUpGrant).toHaveBeenCalledTimes(1);
       expect(grants.has('grant-1')).toBe(false);
-      expect(db.transaction).toHaveBeenCalledTimes(1);
+      expect(completeInitialMfaEnrollment).toHaveBeenCalledTimes(1);
 
       const replay = await postMfaEnable({ code: '123456', stepUpGrantId: 'grant-1' });
       expect(replay.status).toBe(403);
       expect(await replay.json()).toMatchObject({ error: 'existing_factor_step_up_required' });
       expect(consumeStepUpGrant).toHaveBeenCalledTimes(1);
       // No second factor write from the replayed grant.
-      expect(db.transaction).toHaveBeenCalledTimes(1);
+      expect(completeInitialMfaEnrollment).toHaveBeenCalledTimes(1);
     });
 
     it('POST /auth/mfa/enable — an INVALID grant still 403s BEFORE the consuming TOTP verifier runs (no burned time-step)', async () => {
@@ -3184,6 +3350,27 @@ describe('auth routes', () => {
       expect(res.status).toBe(401);
     });
 
+    it('POST /auth/mfa/setup rejects a direct TOTP enrollment when policy disallows it', async () => {
+      const policySpy = vi.spyOn(mfaPolicyModule, 'getEffectiveMfaPolicy').mockResolvedValueOnce({
+        required: true,
+        allowedMethods: { totp: false, sms: false, passkey: true },
+        source: { roleForceMfa: true, settingsRequireMfa: true, killSwitchOff: false },
+      });
+      const redis = { get: vi.fn(), setex: vi.fn(), del: vi.fn() };
+      vi.mocked(getRedis).mockReturnValue(redis as any);
+
+      const res = await app.request('/auth/mfa/setup', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currentPassword: 'OldStrongPass123' }),
+      });
+      policySpy.mockRestore();
+
+      expect(res.status).toBe(403);
+      expect(redis.setex).not.toHaveBeenCalled();
+      expect(verifyPassword).not.toHaveBeenCalled();
+    });
+
     // #4018 review finding 2: no route-level test proved the SSO re-auth road
     // actually works end to end for /mfa/setup or /mfa/enable — only
     // sso.reauth.test.ts and schemas.test.ts referenced ssoReauthGrantId, and
@@ -3231,6 +3418,13 @@ describe('auth routes', () => {
         });
 
         expect(res.status).toBe(200);
+        const setupBody = await res.json();
+        expect(setupBody).not.toHaveProperty('recoveryCodes');
+        expect(mockRedis.setex).toHaveBeenCalledWith(
+          'mfa:setup:user-123',
+          600,
+          JSON.stringify({ secret: 'MFASECRET123' }),
+        );
         expect(verifyPassword).not.toHaveBeenCalled();
         expect(validateStepUpGrant).toHaveBeenCalledWith(
           '11111111-1111-4111-8111-111111111111',

--- a/apps/api/src/routes/auth/helpers.test.ts
+++ b/apps/api/src/routes/auth/helpers.test.ts
@@ -6,6 +6,7 @@ import {
   userRequiresSetup,
   parsePendingMfa,
   evaluatePendingMfa,
+  evaluatePendingMfaMethod,
   getClientRateLimitKey,
   isRequestConnectionSecure,
   buildRefreshTokenCookie,
@@ -239,6 +240,7 @@ describe('parsePendingMfa (SR2-06 strict parse)', () => {
     userId: 'user-1',
     mfaMethod: 'totp',
     passkeyAvailable: false,
+    recoveryAvailable: true,
     authEpoch: 3,
     mfaEpoch: 5,
     transitionId: '11111111-1111-4111-8111-111111111111',
@@ -286,9 +288,43 @@ describe('parsePendingMfa (SR2-06 strict parse)', () => {
     expect(parsePendingMfa('{not json')).toBeNull();
   });
 
-  it('defaults a missing per-method allowedMethods flag to true (only explicit false disables)', () => {
-    const parsed = parsePendingMfa(JSON.stringify({ ...fullRecord, allowedMethods: {} }));
-    expect(parsed?.allowedMethods).toEqual({ totp: true, sms: true, passkey: true });
+  it.each([
+    ['totp', { sms: false, passkey: true }],
+    ['sms', { totp: true, passkey: true }],
+    ['passkey', { totp: true, sms: false }],
+  ])('returns null when allowedMethods.%s is missing', (_name, allowedMethods) => {
+    expect(parsePendingMfa(JSON.stringify({ ...fullRecord, allowedMethods }))).toBeNull();
+  });
+
+  it.each([
+    ['totp', 'true'],
+    ['sms', 1],
+    ['passkey', null],
+  ])('returns null when allowedMethods.%s is not boolean', (name, value) => {
+    expect(parsePendingMfa(JSON.stringify({
+      ...fullRecord,
+      allowedMethods: { ...fullRecord.allowedMethods, [name]: value },
+    }))).toBeNull();
+  });
+
+  it.each([
+    ['passkeyAvailable', undefined],
+    ['passkeyAvailable', 'false'],
+    ['recoveryAvailable', undefined],
+    ['recoveryAvailable', 0],
+  ])('returns null when %s is missing or not boolean', (field, value) => {
+    const record = { ...fullRecord, [field]: value };
+    if (value === undefined) delete record[field as keyof typeof record];
+    expect(parsePendingMfa(JSON.stringify(record))).toBeNull();
+  });
+
+  it.each([
+    ['authEpoch', -1],
+    ['mfaEpoch', 1.5],
+    ['browserGeneration', Number.NaN],
+    ['expiresAt', Date.now() - 1],
+  ])('returns null for invalid or expired %s', (field, value) => {
+    expect(parsePendingMfa(JSON.stringify({ ...fullRecord, [field]: value }))).toBeNull();
   });
 });
 
@@ -297,6 +333,7 @@ describe('evaluatePendingMfa (SR2-06)', () => {
     userId: 'user-1',
     mfaMethod: 'totp',
     passkeyAvailable: false,
+    recoveryAvailable: true,
     authEpoch: 3,
     mfaEpoch: 5,
     transitionId: '11111111-1111-4111-8111-111111111111',
@@ -347,6 +384,71 @@ describe('evaluatePendingMfa (SR2-06)', () => {
       ok: false,
       reason: 'expired',
     });
+  });
+});
+
+describe('evaluatePendingMfaMethod (#3853)', () => {
+  const pending: PendingMfaRecord = {
+    userId: 'user-1',
+    mfaMethod: 'totp',
+    passkeyAvailable: false,
+    recoveryAvailable: true,
+    authEpoch: 3,
+    mfaEpoch: 5,
+    transitionId: '11111111-1111-4111-8111-111111111111',
+    browserGeneration: 3,
+    statusExpectation: 'active',
+    allowedMethods: { totp: true, sms: true, passkey: false },
+    expiresAt: Date.now() + 300_000,
+  };
+  const enrolled = {
+    mfaSecret: 'encrypted-secret',
+    mfaMethod: 'sms' as const,
+    phoneNumber: '+15550000001',
+  };
+  const liveAllowed = { totp: true, sms: true, passkey: true };
+
+  it.each(['totp', 'sms', 'recovery'] as const)('authorizes an allowed and enrolled %s switch', (method) => {
+    expect(evaluatePendingMfaMethod(pending, method, enrolled, liveAllowed)).toEqual({ ok: true });
+  });
+
+  it('rejects a method the pending challenge never authorized without making the challenge terminal', () => {
+    expect(evaluatePendingMfaMethod(
+      { ...pending, allowedMethods: { ...pending.allowedMethods, sms: false } },
+      'sms',
+      enrolled,
+      liveAllowed,
+    )).toEqual({ ok: false, reason: 'pending_method_not_allowed', terminal: false });
+  });
+
+  it.each([
+    ['totp', { ...enrolled, mfaSecret: null }],
+    ['sms', { ...enrolled, mfaMethod: 'totp' as const }],
+    ['sms', { ...enrolled, phoneNumber: null }],
+  ] as const)('rejects %s when the live account is not enrolled in that factor', (method, user) => {
+    expect(evaluatePendingMfaMethod(pending, method, user, liveAllowed)).toEqual({
+      ok: false,
+      reason: 'factor_not_enrolled',
+      terminal: false,
+    });
+  });
+
+  it('rejects recovery when the pending record had no recovery code', () => {
+    expect(evaluatePendingMfaMethod(
+      { ...pending, recoveryAvailable: false },
+      'recovery',
+      enrolled,
+      liveAllowed,
+    )).toEqual({ ok: false, reason: 'recovery_not_available', terminal: false });
+  });
+
+  it('marks live policy drift terminal so the caller consumes the pending challenge', () => {
+    expect(evaluatePendingMfaMethod(
+      pending,
+      'totp',
+      enrolled,
+      { ...liveAllowed, totp: false },
+    )).toEqual({ ok: false, reason: 'live_policy_disallowed', terminal: true });
   });
 });
 

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -1121,6 +1121,7 @@ export interface PendingMfaRecord {
   userId: string;
   mfaMethod: 'totp' | 'sms' | 'passkey';
   passkeyAvailable: boolean;
+  recoveryAvailable: boolean;
   authEpoch: number;
   mfaEpoch: number;
   transitionId: string;
@@ -1152,16 +1153,25 @@ export function parsePendingMfa(raw: string): PendingMfaRecord | null {
   }
   const method = parsed.mfaMethod;
   const am = parsed.allowedMethods as Record<string, unknown> | undefined;
+  const isNonNegativeInteger = (value: unknown): value is number =>
+    typeof value === 'number' && Number.isInteger(value) && value >= 0;
   if (
     typeof parsed.userId !== 'string' ||
     (method !== 'totp' && method !== 'sms' && method !== 'passkey') ||
-    typeof parsed.authEpoch !== 'number' ||
-    typeof parsed.mfaEpoch !== 'number' ||
+    typeof parsed.passkeyAvailable !== 'boolean' ||
+    typeof parsed.recoveryAvailable !== 'boolean' ||
+    !isNonNegativeInteger(parsed.authEpoch) ||
+    !isNonNegativeInteger(parsed.mfaEpoch) ||
     typeof parsed.transitionId !== 'string' ||
-    typeof parsed.browserGeneration !== 'number' ||
+    !isNonNegativeInteger(parsed.browserGeneration) ||
     typeof parsed.statusExpectation !== 'string' ||
     typeof parsed.expiresAt !== 'number' ||
-    !am || typeof am !== 'object'
+    !Number.isFinite(parsed.expiresAt) ||
+    parsed.expiresAt <= Date.now() ||
+    !am || typeof am !== 'object' ||
+    typeof am.totp !== 'boolean' ||
+    typeof am.sms !== 'boolean' ||
+    typeof am.passkey !== 'boolean'
   ) {
     return null;
   }
@@ -1176,16 +1186,17 @@ export function parsePendingMfa(raw: string): PendingMfaRecord | null {
   return {
     userId: parsed.userId,
     mfaMethod: method,
-    passkeyAvailable: parsed.passkeyAvailable === true,
+    passkeyAvailable: parsed.passkeyAvailable,
+    recoveryAvailable: parsed.recoveryAvailable,
     authEpoch: parsed.authEpoch,
     mfaEpoch: parsed.mfaEpoch,
     transitionId: parsed.transitionId,
     browserGeneration: parsed.browserGeneration,
     statusExpectation: parsed.statusExpectation,
     allowedMethods: {
-      totp: am.totp !== false,
-      sms: am.sms !== false,
-      passkey: am.passkey !== false,
+      totp: am.totp,
+      sms: am.sms,
+      passkey: am.passkey,
     },
     expiresAt: parsed.expiresAt,
     ...(typeof parsed.ssoLinkTokenHash === 'string' && parsed.ssoLinkTokenHash.length > 0
@@ -1211,6 +1222,56 @@ export function evaluatePendingMfa(
   if (live.status !== 'active' || record.statusExpectation !== live.status) {
     return { ok: false, reason: 'status_changed' };
   }
+  return { ok: true };
+}
+
+export type PendingMfaVerificationMethod = 'totp' | 'sms' | 'recovery';
+
+export type PendingMfaMethodVerdict =
+  | { ok: true }
+  | {
+      ok: false;
+      reason:
+        | 'pending_method_not_allowed'
+        | 'factor_not_enrolled'
+        | 'recovery_not_available'
+        | 'live_policy_disallowed';
+      terminal: boolean;
+    };
+
+/**
+ * Authorize a client-selected MFA continuation against both the immutable
+ * challenge snapshot and live account policy/enrollment. Only live-policy
+ * drift is terminal; an unavailable selection reveals no authority and may
+ * be retried with another method from the same challenge.
+ */
+export function evaluatePendingMfaMethod(
+  pending: PendingMfaRecord,
+  method: PendingMfaVerificationMethod,
+  liveUser: { mfaSecret: string | null; mfaMethod: string | null; phoneNumber: string | null },
+  liveAllowedMethods: PendingMfaRecord['allowedMethods'],
+): PendingMfaMethodVerdict {
+  if (method === 'recovery') {
+    return pending.recoveryAvailable
+      ? { ok: true }
+      : { ok: false, reason: 'recovery_not_available', terminal: false };
+  }
+
+  if (!pending.allowedMethods[method]) {
+    return { ok: false, reason: 'pending_method_not_allowed', terminal: false };
+  }
+
+  const enrolled = method === 'totp'
+    ? Boolean(liveUser.mfaSecret)
+    : liveUser.mfaMethod === 'sms' && Boolean(liveUser.phoneNumber);
+  if (!enrolled) {
+    return { ok: false, reason: 'factor_not_enrolled', terminal: false };
+  }
+
+  if (!liveAllowedMethods[method]) {
+    return { ok: false, reason: 'live_policy_disallowed', terminal: true };
+  }
+
   return { ok: true };
 }
 

--- a/apps/api/src/routes/auth/login.test.ts
+++ b/apps/api/src/routes/auth/login.test.ts
@@ -347,6 +347,7 @@ import {
   clearRefreshTokenCookie,
   revokeCurrentRefreshTokenJti,
   auditUserLoginFailure,
+  userHasUsablePasskey,
 } from './helpers';
 
 function selectChain(rows: unknown[]) {
@@ -826,6 +827,7 @@ describe('POST /login — writes epoch/status-bound pending MFA record (SR2-06)'
       mfaEnabled: true,
       mfaSecret: 'secret',
       mfaMethod: 'totp',
+      mfaRecoveryCodes: ['scrypt$v1$hash-1'],
       phoneNumber: null,
       avatarUrl: null,
     }]) as any);
@@ -846,7 +848,7 @@ describe('POST /login — writes epoch/status-bound pending MFA record (SR2-06)'
     enable2faState.value = false;
   });
 
-  it('writes the live epochs, status, and effective allowed methods onto the pending record', async () => {
+  it('writes the enrolled-and-policy intersection plus recovery availability onto the pending record and response', async () => {
     const setexMock = vi.fn(async (_key: string, _ttlSeconds: number, _value: string) => 'OK');
     vi.mocked(getRedis).mockReturnValue({ setex: setexMock } as any);
 
@@ -869,10 +871,96 @@ describe('POST /login — writes epoch/status-bound pending MFA record (SR2-06)'
       authEpoch: 3,
       mfaEpoch: 5,
       statusExpectation: 'active',
-      allowedMethods: { totp: true, sms: false, passkey: true },
+      allowedMethods: { totp: true, sms: false, passkey: false },
+      recoveryAvailable: true,
     });
     expect(typeof written.expiresAt).toBe('number');
     expect(written.expiresAt as number).toBeGreaterThan(Date.now());
+    expect(body).toMatchObject({
+      mfaRequired: true,
+      mfaMethod: 'totp',
+      allowedMethods: { totp: true, sms: false, passkey: false },
+      recoveryAvailable: true,
+      passkeyAvailable: false,
+      user: null,
+      tokens: null,
+    });
+  });
+
+  it('offers a registered passkey as an allowed alternate only when live policy permits it', async () => {
+    vi.mocked(userHasUsablePasskey).mockResolvedValue(true);
+    const setexMock = vi.fn(async () => 'OK');
+    vi.mocked(getRedis).mockReturnValue({ setex: setexMock } as any);
+
+    const res = await postLogin({ email: 'admin@msp.com', password: 'correct-horse' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      allowedMethods: { totp: true, sms: false, passkey: true },
+      passkeyAvailable: true,
+    });
+
+    vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+      required: false,
+      allowedMethods: { totp: true, sms: false, passkey: false },
+      source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: false },
+    });
+    const denied = await postLogin({ email: 'admin@msp.com', password: 'correct-horse' });
+    expect(await denied.json()).toMatchObject({
+      allowedMethods: { totp: true, sms: false, passkey: false },
+      // Compatibility alias mirrors the authoritative policy intersection so
+      // strict legacy adapters cannot disagree with allowedMethods.
+      passkeyAvailable: false,
+    });
+  });
+
+  it('issues a recovery-only challenge for a new client when the primary is disallowed', async () => {
+    vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+      required: false,
+      allowedMethods: { totp: false, sms: false, passkey: false },
+      source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: false },
+    });
+    vi.mocked(getRedis).mockReturnValue({ setex: vi.fn(async () => 'OK') } as any);
+
+    const res = await postLogin({ email: 'admin@msp.com', password: 'correct-horse' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      mfaRequired: true,
+      mfaMethod: 'totp',
+      allowedMethods: { totp: false, sms: false, passkey: false },
+      recoveryAvailable: true,
+    });
+  });
+
+  it('fails closed without writing a pending record when no challenge method is usable', async () => {
+    vi.mocked(db.select).mockReturnValue(selectChain([{
+      id: 'user-1',
+      email: 'admin@msp.com',
+      name: 'Admin User',
+      passwordHash: 'password-hash',
+      status: 'active',
+      mfaEnabled: true,
+      mfaSecret: 'secret',
+      mfaMethod: 'totp',
+      mfaRecoveryCodes: [],
+      phoneNumber: null,
+      avatarUrl: null,
+    }]) as any);
+    vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+      required: false,
+      allowedMethods: { totp: false, sms: false, passkey: false },
+      source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: false },
+    });
+    const setexMock = vi.fn(async () => 'OK');
+    vi.mocked(getRedis).mockReturnValue({ setex: setexMock } as any);
+
+    const res = await postLogin({ email: 'admin@msp.com', password: 'correct-horse' });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Invalid email or password' });
+    expect(setexMock).not.toHaveBeenCalled();
+    expect(createTokenPair).not.toHaveBeenCalled();
   });
 
   it('fails closed with a generic 401 and mints nothing when the epoch read returns null', async () => {

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -556,6 +556,18 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
     const pendingPolicy = await getEffectiveMfaPolicy({
       scope: context.scope, userId: user.id, orgId: context.orgId, partnerId: context.partnerId,
     });
+    const allowedMethods = {
+      totp: Boolean(user.mfaSecret) && pendingPolicy.allowedMethods.totp,
+      sms: user.mfaMethod === 'sms' && Boolean(user.phoneNumber) && pendingPolicy.allowedMethods.sms,
+      passkey: passkeyAvailable && pendingPolicy.allowedMethods.passkey,
+    };
+    const recoveryAvailable = Array.isArray(user.mfaRecoveryCodes)
+      && user.mfaRecoveryCodes.length > 0;
+    if (!allowedMethods.totp && !allowedMethods.sms && !allowedMethods.passkey && !recoveryAvailable) {
+      if (capability) await cancelAuthIssuance(capability).catch(() => undefined);
+      await floorPromise;
+      return c.json(genericAuthError(), 401);
+    }
     let pendingTransition = { transitionId: 'legacy', browserGeneration: 0 };
     if (capability) {
       const guardedCapability = capability;
@@ -583,11 +595,12 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
       // the client can't self-elevate to the passkey path without an actually
       // registered credential (and /verify still re-checks credential
       // ownership + assertion regardless).
-      passkeyAvailable,
+      passkeyAvailable: allowedMethods.passkey,
+      recoveryAvailable,
       authEpoch: pendingEpochs.authEpoch,
       mfaEpoch: pendingEpochs.mfaEpoch,
       statusExpectation: user.status,
-      allowedMethods: pendingPolicy.allowedMethods,
+      allowedMethods,
       ...pendingTransition,
       expiresAt: Date.now() + PENDING_TTL_SECONDS * 1000,
     };
@@ -614,9 +627,11 @@ loginRoutes.post('/login', cfAccessLoginMiddleware, zValidator('json', loginSche
       mfaRequired: true,
       tempToken,
       mfaMethod,
+      allowedMethods,
+      recoveryAvailable,
       // #2153: lets the login MFA screen offer "use a passkey instead" alongside
       // the primary factor's prompt when the account has a registered passkey.
-      passkeyAvailable,
+      passkeyAvailable: allowedMethods.passkey,
       phoneLast4: user.phoneNumber?.slice(-4) || null,
       user: null,
       tokens: null

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -22,6 +22,7 @@ import {
   AuthIssuanceConflictError,
   AuthIssuanceCapabilityError,
   issueUserSession,
+  completeInitialMfaEnrollment,
   issueUserSessionLegacyDuringTransition,
   bindIssuedUserSession,
   authBrowserTransitionsEnforced,
@@ -34,7 +35,7 @@ import {
 } from '../../services';
 import { getTwilioService } from '../../services/twilio';
 import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
-import { authMiddleware } from '../../middleware/auth';
+import { authMiddleware, type AuthContext } from '../../middleware/auth';
 import { ENABLE_2FA, mfaVerifySchema, mfaEnableSchema, mfaStepUpSchema } from './schemas';
 import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
 import { invalidateMfaAssuranceAfterFactorChange } from '../../services/mfaAssurance';
@@ -62,6 +63,7 @@ import {
   enforceExistingFactorStepUp,
   parsePendingMfa,
   evaluatePendingMfa,
+  evaluatePendingMfaMethod,
   mintLoginRegisterGrant,
   isAuthTransitionV1Request,
   authClientUpgradeRequiredResponse,
@@ -87,6 +89,19 @@ function authIssuanceAdmissionError(c: Context, error: unknown): Response | null
     || error instanceof AuthIssuanceCapabilityError
   ) {
     return c.json({ error: 'Authentication issuance unavailable' }, 409);
+  }
+  return null;
+}
+
+async function enforceTotpEnrollmentPolicy(c: Context, auth: AuthContext): Promise<Response | null> {
+  const policy = await getEffectiveMfaPolicy({
+    scope: auth.scope,
+    userId: auth.user.id,
+    orgId: auth.orgId ?? null,
+    partnerId: auth.partnerId ?? null,
+  }, { failClosed: true });
+  if (!policy.allowedMethods.totp) {
+    return c.json({ error: 'Your organization does not allow authenticator-app MFA' }, 403);
   }
   return null;
 }
@@ -122,6 +137,32 @@ const mfaDisableSchema = mfaVerifySchema.extend({
 
 export const mfaRoutes = new Hono();
 
+// Forced-enrollment discovery. This path is intentionally under /auth/mfa/*,
+// which authMiddleware exempts from the normal 428 enrollment gate.
+mfaRoutes.get('/mfa/enrollment-options', authMiddleware, async (c) => {
+  if (!ENABLE_2FA) return mfaDisabledResponse(c);
+
+  const auth = c.get('auth');
+  const [user] = await db
+    .select({ phoneNumber: users.phoneNumber, phoneVerified: users.phoneVerified })
+    .from(users)
+    .where(eq(users.id, auth.user.id))
+    .limit(1);
+  if (!user) return c.json({ error: 'User not found' }, 404);
+
+  const policy = await getEffectiveMfaPolicy({
+    scope: auth.scope,
+    userId: auth.user.id,
+    orgId: auth.orgId ?? null,
+    partnerId: auth.partnerId ?? null,
+  }, { failClosed: true });
+
+  return c.json({
+    allowedMethods: policy.allowedMethods,
+    phoneConfigured: user.phoneVerified === true && Boolean(user.phoneNumber),
+  });
+});
+
 // MFA setup (requires auth + current-password re-prompt)
 mfaRoutes.post('/mfa/setup', authMiddleware, zValidator('json', enrollmentStepUpSchema), async (c) => {
   if (!ENABLE_2FA) {
@@ -130,6 +171,8 @@ mfaRoutes.post('/mfa/setup', authMiddleware, zValidator('json', enrollmentStepUp
 
   const auth = c.get('auth');
   const { currentPassword, ssoReauthGrantId } = c.req.valid('json');
+  const policyError = await enforceTotpEnrollmentPolicy(c, auth);
+  if (policyError) return policyError;
 
   // Re-verify identity before allowing MFA factor installation. A stolen
   // access token is not sufficient — the user must prove possession of the
@@ -163,8 +206,6 @@ mfaRoutes.post('/mfa/setup', authMiddleware, zValidator('json', enrollmentStepUp
   const secret = generateMFASecret();
   const otpAuthUrl = generateOTPAuthURL(secret, auth.user.email);
   const qrCodeDataUrl = await generateQRCode(otpAuthUrl);
-  const recoveryCodes = generateRecoveryCodes();
-
   // Store secret temporarily (not enabled yet until verified)
   const redis = getRedis();
   if (!redis) {
@@ -173,14 +214,13 @@ mfaRoutes.post('/mfa/setup', authMiddleware, zValidator('json', enrollmentStepUp
   await redis.setex(
     `mfa:setup:${auth.user.id}`,
     600, // 10 min expiry
-    JSON.stringify({ secret, recoveryCodes })
+    JSON.stringify({ secret })
   );
 
   return c.json({
     secret,
     otpAuthUrl,
-    qrCodeDataUrl,
-    recoveryCodes
+    qrCodeDataUrl
   });
 });
 
@@ -261,33 +301,39 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
     // no longer re-resolves it further down).
     const mfaContext = await resolveCurrentUserTokenContext(user.id);
 
-    // Method must still be allowed by current policy (a factor could have been
-    // disallowed since login). Passkey is handled by its own route; here we gate
-    // totp/sms. Use the real scope/org/partner from the resolved context so
-    // org- and partner-scoped policy resolves correctly.
+    // Resolve live policy for the client-selected method. Passkey remains on
+    // its dedicated WebAuthn continuation; this route handles TOTP, SMS, and
+    // recovery only.
     const livePolicy = await getEffectiveMfaPolicy({
       scope: mfaContext.scope,
       userId: user.id,
       orgId: mfaContext.orgId,
       partnerId: mfaContext.partnerId,
     });
-    if ((pendingMfaMethod === 'sms' && !livePolicy.allowedMethods.sms) ||
-        (pendingMfaMethod === 'totp' && !livePolicy.allowedMethods.totp)) {
-      await redis.del(`mfa:pending:${tempToken}`);
-      void auditUserLoginFailure(c, {
-        userId: user.id, email: user.email, name: user.name,
-        reason: 'mfa_method_not_allowed', details: { method: pendingMfaMethod },
-      });
-      return c.json({ error: 'This MFA method is no longer permitted. Please sign in again.' }, 401);
-    }
-
-    // Use the server-stored method only — never allow the client to override
-    const effectiveMethod = pendingMfaMethod;
+    const effectiveMethod = method ?? pendingMfaMethod;
 
     let valid = false;
     let migratedMfaSecret: string | null = null;
     if (effectiveMethod === 'passkey') {
       return c.json({ error: 'Use passkey verification for this MFA session' }, 400);
+    }
+
+    const methodVerdict = evaluatePendingMfaMethod(
+      pending,
+      effectiveMethod,
+      user,
+      livePolicy.allowedMethods,
+    );
+    if (!methodVerdict.ok) {
+      if (methodVerdict.terminal) await redis.del(`mfa:pending:${tempToken}`);
+      void auditUserLoginFailure(c, {
+        userId: user.id,
+        email: user.email,
+        name: user.name,
+        reason: 'mfa_method_not_allowed',
+        details: { method: effectiveMethod, phase: methodVerdict.reason },
+      });
+      return c.json({ error: 'Invalid MFA code' }, 401);
     }
 
     let capability: AuthIssuanceCapability | null = null;
@@ -323,7 +369,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
     //     guard fails against the winner's committed value → rowCount 0 → 401.
     // Single-winner AND no-resurrection are proven against real Postgres (Task 9).
     try {
-      if (method === 'recovery') {
+      if (effectiveMethod === 'recovery') {
         // The authoritative hash check and relative delete occur only inside the
         // guarded finalization below. A logout-pending transition can therefore
         // never burn a recovery code.
@@ -388,7 +434,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
         breezeMfaVerified: true,
         expectedUserId: user.id,
         capability: linkCapability,
-        ...(method === 'recovery' ? { recoveryCode: code } : {}),
+        ...(effectiveMethod === 'recovery' ? { recoveryCode: code } : {}),
       });
       if (!outcome.ok) {
         if (outcome.error === 'invalid_mfa_code') {
@@ -463,7 +509,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
       let issued: AuthorizedUserSession;
       try {
         issued = await finishAuthIssuance(guardedCapability, async (tx) => {
-          if (method === 'recovery') await consumeRecoveryCode(tx, user.id, code);
+          if (effectiveMethod === 'recovery') await consumeRecoveryCode(tx, user.id, code);
           const session = await issueUserSession(identity, {
             tx,
             capability: guardedCapability,
@@ -496,8 +542,8 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
       mfaFamilyId = issued.familyId;
       installSessionCookies = () => installAuthorizedUserSessionCookies(c, issued);
     } else {
-      const issuer = method === 'recovery' ? 'recovery' : effectiveMethod;
-      if (method === 'recovery') {
+      const issuer = effectiveMethod;
+      if (effectiveMethod === 'recovery') {
         try {
           await runOutsideDbContext(() => withSystemDbAccessContext(() =>
             db.transaction((tx) => consumeRecoveryCode(tx, user.id, code))
@@ -530,7 +576,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
     // Consume the pending bearer only after the guarded authority commits.
     await redis.del(`mfa:pending:${tempToken}`);
 
-    if (method === 'recovery') {
+    if (effectiveMethod === 'recovery') {
       const stored = Array.isArray(user.mfaRecoveryCodes) ? user.mfaRecoveryCodes : [];
       writeAuthAudit(c, {
         orgId: undefined,
@@ -580,14 +626,15 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
   }
 
   let secret: string;
-  let recoveryCodes: string[];
   try {
     const parsed = JSON.parse(setupData);
     secret = parsed.secret;
-    recoveryCodes = parsed.recoveryCodes;
+    if (typeof secret !== 'string') throw new Error('Invalid setup data');
   } catch {
     return c.json({ error: 'Invalid MFA setup data' }, 500);
   }
+  const policyError = await enforceTotpEnrollmentPolicy(c, auth);
+  if (policyError) return policyError;
   // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
   // requires a fresh existing-factor proof (no-op for initial enrollment).
   //
@@ -654,22 +701,60 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
   // establish a real system context here; without it the invalidation
   // transaction runs on the bare pool, forced RLS matches 0 rows, and
   // advanceUserEpochs throws → hard 500 with the factor never enabled.
-  const result = await runOutsideDbContext(() =>
-    withSystemDbAccessContext(() =>
-      invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'mfa-setup-confirm', async (tx) => {
-        await tx
+  const recoveryCodes = generateRecoveryCodes();
+  const recoveryCodeHashes = hashRecoveryCodes(recoveryCodes);
+  let capability: AuthIssuanceCapability;
+  try {
+    capability = await beginAuthIssuance(requestAuthBinding(c));
+  } catch (error) {
+    const response = authIssuanceAdmissionError(c, error);
+    if (!response) throw error;
+    return response;
+  }
+  let result;
+  try {
+    result = await completeInitialMfaEnrollment({
+      userId: auth.user.id,
+      identity: {
+        userId: auth.user.id,
+        email: auth.user.email,
+        roleId: auth.token?.roleId ?? null,
+        orgId: auth.orgId ?? null,
+        partnerId: auth.partnerId ?? null,
+        scope: auth.scope,
+        mfa: true,
+        mobileDeviceId: readMobileDeviceId(c) ?? undefined,
+      },
+      capability,
+      expectedAuthEpoch: auth.token?.aep as number,
+      expectedMfaEpoch: auth.token?.mep as number,
+      revokeReason: 'mfa-setup-confirm',
+      recoveryCodes,
+      recoveryCodeHashes,
+      persistFactor: async (tx, hashes) => {
+        const rows = await tx
           .update(users)
           .set({
             mfaSecret: encryptMfaSecret(secret),
             mfaEnabled: true,
             mfaMethod: 'totp',
-            mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
+            mfaRecoveryCodes: [...hashes],
             updatedAt: new Date()
           })
-          .where(eq(users.id, auth.user.id));
-      })
-    )
-  );
+          .where(eq(users.id, auth.user.id))
+          .returning({ id: users.id });
+        if (rows.length !== 1) throw new Error('MFA enrollment user disappeared');
+        return undefined;
+      },
+    });
+  } catch (error) {
+    await cancelAuthIssuance(capability).catch(() => undefined);
+    const response = authIssuanceAdmissionError(c, error);
+    if (!response) throw error;
+    return response;
+  }
+  await bindIssuedUserSession(result.issued);
+  installAuthorizedUserSessionCookies(c, result.issued);
 
   const setupOrgId = await resolveUserAuditOrgId(auth.user.id);
   writeAuthAudit(c, {
@@ -678,12 +763,17 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { method: 'totp', mfaEpoch: result.mfaEpoch, teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED }
+    details: { method: 'totp', mfaEpoch: result.mfaEpoch, teardownFailed: result.cleanup.remoteSessionsTerminated === TEARDOWN_FAILED }
   });
 
   await redis.del(`mfa:setup:${auth.user.id}`);
 
-  return c.json({ success: true, message: 'MFA enabled successfully' });
+  return c.json({
+    success: true,
+    message: 'MFA enabled successfully',
+    recoveryCodes: result.recoveryCodes,
+    tokens: toPublicTokens(result.issued),
+  });
 });
 
 // MFA disable (requires auth + current MFA code + current password)
@@ -857,18 +947,18 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithSt
   }
 
   let secret: string;
-  let recoveryCodes: string[];
   try {
-    const parsed = JSON.parse(setupData) as { secret?: unknown; recoveryCodes?: unknown };
-    if (typeof parsed.secret !== 'string' || !Array.isArray(parsed.recoveryCodes) || parsed.recoveryCodes.some(code => typeof code !== 'string')) {
+    const parsed = JSON.parse(setupData) as { secret?: unknown };
+    if (typeof parsed.secret !== 'string') {
       throw new Error('Invalid setup data');
     }
     secret = parsed.secret;
-    recoveryCodes = parsed.recoveryCodes;
   } catch {
     const message = 'Invalid MFA setup data';
     return c.json({ error: message, message }, 500);
   }
+  const policyError = await enforceTotpEnrollmentPolicy(c, auth);
+  if (policyError) return policyError;
 
   // Consuming verifier: record the accepted time step so it cannot be replayed
   // at login within its ~90s validity window (SR2-24). Fails closed if Redis is
@@ -917,18 +1007,60 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithSt
   );
   if (enrollmentConsumeError) return enrollmentConsumeError;
 
-  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'mfa-enable', async (tx) => {
-    await tx
-      .update(users)
-      .set({
-        mfaSecret: encryptMfaSecret(secret),
-        mfaEnabled: true,
-        mfaMethod: 'totp',
-        mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
-        updatedAt: new Date()
-      })
-      .where(eq(users.id, auth.user.id));
-  });
+  const recoveryCodes = generateRecoveryCodes();
+  const recoveryCodeHashes = hashRecoveryCodes(recoveryCodes);
+  let capability: AuthIssuanceCapability;
+  try {
+    capability = await beginAuthIssuance(requestAuthBinding(c));
+  } catch (error) {
+    const response = authIssuanceAdmissionError(c, error);
+    if (!response) throw error;
+    return response;
+  }
+  let result;
+  try {
+    result = await completeInitialMfaEnrollment({
+      userId: auth.user.id,
+      identity: {
+        userId: auth.user.id,
+        email: auth.user.email,
+        roleId: auth.token?.roleId ?? null,
+        orgId: auth.orgId ?? null,
+        partnerId: auth.partnerId ?? null,
+        scope: auth.scope,
+        mfa: true,
+        mobileDeviceId: readMobileDeviceId(c) ?? undefined,
+      },
+      capability,
+      expectedAuthEpoch: auth.token?.aep as number,
+      expectedMfaEpoch: auth.token?.mep as number,
+      revokeReason: 'mfa-enable',
+      recoveryCodes,
+      recoveryCodeHashes,
+      persistFactor: async (tx, hashes) => {
+        const rows = await tx
+          .update(users)
+          .set({
+            mfaSecret: encryptMfaSecret(secret),
+            mfaEnabled: true,
+            mfaMethod: 'totp',
+            mfaRecoveryCodes: [...hashes],
+            updatedAt: new Date()
+          })
+          .where(eq(users.id, auth.user.id))
+          .returning({ id: users.id });
+        if (rows.length !== 1) throw new Error('MFA enrollment user disappeared');
+        return undefined;
+      },
+    });
+  } catch (error) {
+    await cancelAuthIssuance(capability).catch(() => undefined);
+    const response = authIssuanceAdmissionError(c, error);
+    if (!response) throw error;
+    return response;
+  }
+  await bindIssuedUserSession(result.issued);
+  installAuthorizedUserSessionCookies(c, result.issued);
 
   await redis.del(`mfa:setup:${auth.user.id}`);
 
@@ -939,10 +1071,15 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithSt
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { method: 'totp', mfaEpoch: result.mfaEpoch, teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED }
+    details: { method: 'totp', mfaEpoch: result.mfaEpoch, teardownFailed: result.cleanup.remoteSessionsTerminated === TEARDOWN_FAILED }
   });
 
-  return c.json({ success: true, recoveryCodes, message: 'MFA enabled successfully' });
+  return c.json({
+    success: true,
+    recoveryCodes: result.recoveryCodes,
+    message: 'MFA enabled successfully',
+    tokens: toPublicTokens(result.issued),
+  });
 });
 
 // SR2-20: existing-factor step-up. Proves an EXISTING MFA factor (TOTP, SMS,

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -23,6 +23,8 @@ import {
   bindIssuedUserSession,
   authBrowserTransitionsEnforced,
   recordAuthTransitionLegacyIssuer,
+  completeInitialMfaEnrollment,
+  generateRecoveryCodes,
   type AuthIssuanceCapability,
   type AuthorizedUserSession,
   type UserSessionIdentity,
@@ -40,6 +42,7 @@ import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
 import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
 import { invalidateMfaAssuranceAfterFactorChange } from '../../services/mfaAssurance';
 import { TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
+import type { Tx } from '../../services/authLifecycle';
 import { ENABLE_2FA } from './schemas';
 import {
   auditLogin,
@@ -59,6 +62,7 @@ import {
   writeAuthAudit,
   isAuthTransitionV1Request,
   authClientUpgradeRequiredResponse,
+  hashRecoveryCodes,
 } from './helpers';
 import { installAuthBindingReplacement, requestAuthBinding } from './binding';
 
@@ -138,7 +142,7 @@ const deletePasskeySchema = z.object({
 // so this gate only decides whether the passkey path is OFFERED — it never
 // substitutes for credential/assertion verification.
 function pendingAllowsPasskey(pending: PendingMfaRecord): boolean {
-  return pending.mfaMethod === 'passkey' || pending.passkeyAvailable === true;
+  return pending.allowedMethods.passkey;
 }
 
 type PasskeyRow = typeof userPasskeys.$inferSelect;
@@ -244,13 +248,19 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
   );
   if (enrollmentConsumeError) return enrollmentConsumeError;
 
-  // SR2-07/SR2-19: the insert AND the users.mfaEnabled flip are folded into
-  // ONE transaction with the epoch bump + refresh-family revoke — registering
-  // a new passkey is a factor-add and must invalidate assurance minted before
-  // this factor existed. The inserted row is captured via closure so it can
-  // be used in the response after the transaction commits.
+  const [enrollmentState] = await db
+    .select({
+      mfaEnabled: users.mfaEnabled,
+      mfaSecret: users.mfaSecret,
+      mfaMethod: users.mfaMethod,
+    })
+    .from(users)
+    .where(eq(users.id, auth.user.id))
+    .limit(1);
+  if (!enrollmentState) return c.json({ error: 'User not found' }, 404);
+
   let inserted: PasskeyRow | undefined;
-  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'passkey-register', async (tx) => {
+  const persistPasskey = async (tx: Tx) => {
     const [row] = await tx
       .insert(userPasskeys)
       .values({
@@ -271,28 +281,88 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
       throw new Error('Passkey insert returned no row');
     }
     inserted = row;
+    return row;
+  };
 
-    // Enable MFA, but do NOT overwrite an existing TOTP/SMS factor's method.
-    // `mfaMethod` is single-valued and drives login routing (login.ts/mfa.ts);
-    // clobbering it to 'passkey' would strand a user's working authenticator
-    // and risk lockout if they later lose the passkey device. Only make
-    // passkey the primary method when the user has no other factor configured.
-    const [currentMfa] = await tx
-      .select({ mfaSecret: users.mfaSecret, mfaMethod: users.mfaMethod })
-      .from(users)
-      .where(eq(users.id, auth.user.id))
-      .limit(1);
-    const hasExistingFactor = Boolean(currentMfa?.mfaSecret) || currentMfa?.mfaMethod === 'sms';
+  let mfaEpoch: number;
+  let teardownFailed: boolean;
+  let replacement: { recoveryCodes: string[]; issued: AuthorizedUserSession } | null = null;
+  if (!enrollmentState.mfaEnabled) {
+    const recoveryCodes = generateRecoveryCodes();
+    const recoveryCodeHashes = hashRecoveryCodes(recoveryCodes);
+    let capability: AuthIssuanceCapability;
+    try {
+      capability = await beginAuthIssuance(requestAuthBinding(c));
+    } catch (error) {
+      const response = authIssuanceAdmissionError(c, error);
+      if (!response) throw error;
+      return response;
+    }
+    let result;
+    try {
+      result = await completeInitialMfaEnrollment({
+        userId: auth.user.id,
+        identity: {
+          userId: auth.user.id,
+          email: auth.user.email,
+          roleId: auth.token?.roleId ?? null,
+          orgId: auth.orgId ?? null,
+          partnerId: auth.partnerId ?? null,
+          scope: auth.scope,
+          mfa: true,
+          mobileDeviceId: readMobileDeviceId(c) ?? undefined,
+        },
+        capability,
+        expectedAuthEpoch: auth.token?.aep as number,
+        expectedMfaEpoch: auth.token?.mep as number,
+        revokeReason: 'passkey-register',
+        recoveryCodes,
+        recoveryCodeHashes,
+        persistFactor: async (tx, hashes) => {
+          const enabled = await tx
+            .update(users)
+            .set({
+              mfaEnabled: true,
+              mfaMethod: 'passkey',
+              mfaRecoveryCodes: [...hashes],
+              updatedAt: new Date(),
+            })
+            .where(and(eq(users.id, auth.user.id), eq(users.mfaEnabled, false)))
+            .returning({ id: users.id });
+          if (enabled.length !== 1) throw new Error('MFA enrollment state changed');
+          return persistPasskey(tx);
+        },
+      });
+    } catch (error) {
+      await cancelAuthIssuance(capability).catch(() => undefined);
+      const response = authIssuanceAdmissionError(c, error);
+      if (!response) throw error;
+      return response;
+    }
+    await bindIssuedUserSession(result.issued);
+    installAuthorizedUserSessionCookies(c, result.issued);
+    mfaEpoch = result.mfaEpoch;
+    teardownFailed = result.cleanup.remoteSessionsTerminated === TEARDOWN_FAILED;
+    replacement = { recoveryCodes: result.recoveryCodes, issued: result.issued };
+  } else {
+    // Secondary-factor addition keeps the existing invalidation behavior and
+    // does not rotate recovery codes or replace the already-assured session.
+    const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'passkey-register', async (tx) => {
+      await persistPasskey(tx);
+      const hasExistingFactor = Boolean(enrollmentState.mfaSecret) || enrollmentState.mfaMethod === 'sms';
 
-    await tx
-      .update(users)
-      .set({
-        mfaEnabled: true,
-        ...(hasExistingFactor ? {} : { mfaMethod: 'passkey' }),
-        updatedAt: new Date()
-      })
-      .where(eq(users.id, auth.user.id));
-  });
+      await tx
+        .update(users)
+        .set({
+          mfaEnabled: true,
+          ...(hasExistingFactor ? {} : { mfaMethod: 'passkey' }),
+          updatedAt: new Date()
+        })
+        .where(eq(users.id, auth.user.id));
+    });
+    mfaEpoch = result.mfaEpoch;
+    teardownFailed = result.remoteSessionsTerminated === TEARDOWN_FAILED;
+  }
 
   if (!inserted) {
     throw new Error('Passkey insert returned no row');
@@ -307,14 +377,20 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
     details: {
       method: 'passkey',
       credentialId: fields.credentialId,
-      mfaEpoch: result.mfaEpoch,
-      teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED
+      mfaEpoch,
+      teardownFailed
     }
   });
 
   return c.json({
     success: true,
-    passkey: toPublicPasskey(inserted)
+    passkey: toPublicPasskey(inserted),
+    ...(replacement
+      ? {
+          recoveryCodes: replacement.recoveryCodes,
+          tokens: toPublicTokens(replacement.issued),
+        }
+      : {}),
   });
 });
 
@@ -397,7 +473,7 @@ passkeyRoutes.post('/mfa/passkey/options', zValidator('json', passkeyMfaOptionsS
     return c.json({ error: 'Invalid or expired MFA session' }, 401);
   }
   if (!pendingAllowsPasskey(pending)) {
-    return c.json({ error: 'Passkey MFA is not configured for this session' }, 400);
+    return c.json({ error: 'Invalid MFA code' }, 401);
   }
   // Throttle challenge issuance so it can't be hammered, but on a SEPARATE
   // bucket from /verify. A legitimate retry issues one /options + one /verify;
@@ -412,6 +488,37 @@ passkeyRoutes.post('/mfa/passkey/options', zValidator('json', passkeyMfaOptionsS
   );
   if (!rateCheck.allowed) {
     return c.json({ error: 'Too many MFA attempts' }, 429);
+  }
+
+  const [user] = await withSystemDbAccessContext(() =>
+    db.select().from(users).where(eq(users.id, pending.userId)).limit(1)
+  );
+  if (!user) {
+    return c.json({ error: 'Invalid or expired MFA session' }, 401);
+  }
+  const liveEpochs = await getUserEpochs(user.id);
+  const pendingVerdict = liveEpochs
+    ? evaluatePendingMfa(pending, {
+        status: user.status,
+        authEpoch: liveEpochs.authEpoch,
+        mfaEpoch: liveEpochs.mfaEpoch,
+      })
+    : ({ ok: false, reason: 'epoch_mismatch' } as const);
+  if (!pendingVerdict.ok) {
+    await getRedis()?.del(`mfa:pending:${tempToken}`);
+    return c.json({ error: 'Invalid or expired MFA session' }, 401);
+  }
+
+  const context = await resolveCurrentUserTokenContext(user.id);
+  const livePolicy = await getEffectiveMfaPolicy({
+    scope: context.scope,
+    userId: user.id,
+    orgId: context.orgId,
+    partnerId: context.partnerId,
+  });
+  if (!livePolicy.allowedMethods.passkey) {
+    await getRedis()?.del(`mfa:pending:${tempToken}`);
+    return c.json({ error: 'Invalid MFA code' }, 401);
   }
 
   const passkeys = await withSystemDbAccessContext(() => listActivePasskeys(pending.userId));
@@ -443,7 +550,7 @@ passkeyRoutes.post('/mfa/passkey/verify', zValidator('json', passkeyMfaVerifySch
     return c.json({ error: 'Invalid or expired MFA session' }, 401);
   }
   if (!pendingAllowsPasskey(pending)) {
-    return c.json({ error: 'Passkey MFA is not configured for this session' }, 400);
+    return c.json({ error: 'Invalid MFA code' }, 401);
   }
   const transitionV1 = isAuthTransitionV1Request(c);
   if (!transitionV1 && authBrowserTransitionsEnforced()) {
@@ -466,12 +573,6 @@ passkeyRoutes.post('/mfa/passkey/verify', zValidator('json', passkeyMfaVerifySch
   if (!user) {
     return c.json({ error: 'Invalid MFA configuration' }, 400);
   }
-  // Re-check account status before minting tokens — the user could have been
-  // suspended during the 5-minute MFA window after the pending token was issued.
-  if (user.status !== 'active') {
-    return c.json({ error: 'Invalid or expired MFA session' }, 401);
-  }
-
   // SR2-06: re-check the live epoch/status before minting. A factor change
   // (mfa_epoch) or account-wide security event (auth_epoch) during the
   // 5-minute MFA window must invalidate this in-flight session.
@@ -541,6 +642,24 @@ passkeyRoutes.post('/mfa/passkey/verify', zValidator('json', passkeyMfaVerifySch
     if (capability) await cancelAuthIssuance(capability).catch(() => undefined);
     throw error;
   }
+  let context;
+  try {
+    context = await resolveCurrentUserTokenContext(user.id);
+    const livePolicy = await getEffectiveMfaPolicy({
+      scope: context.scope,
+      userId: user.id,
+      orgId: context.orgId,
+      partnerId: context.partnerId,
+    });
+    if (!livePolicy.allowedMethods.passkey) {
+      if (capability) await cancelAuthIssuance(capability).catch(() => undefined);
+      await redis.del(`mfa:pending:${tempToken}`);
+      return c.json({ error: 'Invalid MFA code' }, 401);
+    }
+  } catch (error) {
+    if (capability) await cancelAuthIssuance(capability).catch(() => undefined);
+    throw error;
+  }
   if (pending.ssoLinkTokenHash) {
     // Preserve mainline's link-on-first-login semantics while the normal
     // password-login path below keeps passkey effects inside its guarded
@@ -597,13 +716,6 @@ passkeyRoutes.post('/mfa/passkey/verify', zValidator('json', passkeyMfaVerifySch
     });
   }
 
-  let context;
-  try {
-    context = await resolveCurrentUserTokenContext(user.id);
-  } catch (error) {
-    if (capability) await cancelAuthIssuance(capability).catch(() => undefined);
-    throw error;
-  }
   const identity: UserSessionIdentity = {
     userId: user.id,
     email: user.email,

--- a/apps/api/src/routes/auth/phone.test.ts
+++ b/apps/api/src/routes/auth/phone.test.ts
@@ -75,11 +75,36 @@ vi.mock('../../services', () => ({
   generateRecoveryCodes: vi.fn(() => ['CODE-1', 'CODE-2']),
   rateLimiter: vi.fn(async () => ({ allowed: true, resetAt: new Date(Date.now() + 60_000) })),
   getRedis: vi.fn(() => ({})),
+  getUserEpochs: vi.fn(async () => ({ authEpoch: 1, mfaEpoch: 1 })),
   smsPhoneVerifyLimiter: { limit: 5, windowSeconds: 300 },
   smsPhoneVerifyUserLimiter: { limit: 5, windowSeconds: 300 },
   smsLoginSendLimiter: { limit: 5, windowSeconds: 300 },
   smsLoginGlobalLimiter: { limit: 100, windowSeconds: 300 },
   phoneConfirmLimiter: { limit: 5, windowSeconds: 300 },
+  beginAuthIssuance: vi.fn(async () => ({ transitionId: 'transition-1', generation: 1 })),
+  cancelAuthIssuance: vi.fn(async () => undefined),
+  bindIssuedUserSession: vi.fn(async () => undefined),
+  completeInitialMfaEnrollment: vi.fn(async (input: any) => ({
+    value: undefined,
+    recoveryCodes: [...input.recoveryCodes],
+    issued: {
+      accessToken: 'replacement-access-token',
+      refreshToken: 'replacement-refresh-token',
+      refreshJti: 'replacement-jti',
+      expiresInSeconds: 900,
+      familyId: 'replacement-family',
+      transitionId: 'transition-1',
+      generation: 1,
+    },
+    mfaEpoch: 2,
+    cleanup: { redisOk: true, permissionCacheOk: true, oauthOk: true, remoteSessionsTerminated: 0 },
+  })),
+  AuthBindingRotationRequiredError: class AuthBindingRotationRequiredError extends Error {
+    constructor(readonly replacement: unknown) { super('rotation required'); }
+  },
+  AuthBindingUnavailableError: class AuthBindingUnavailableError extends Error {},
+  AuthIssuanceConflictError: class AuthIssuanceConflictError extends Error {},
+  AuthIssuanceCapabilityError: class AuthIssuanceCapabilityError extends Error {},
 }));
 
 vi.mock('../../services/twilio', () => ({
@@ -109,7 +134,8 @@ vi.mock('../../middleware/auth', () => ({
   }),
 }));
 
-vi.mock('./helpers', () => ({
+vi.mock('./helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./helpers')>()),
   mfaDisabledResponse: vi.fn((c: any) => c.json({ error: 'Not Found' }, 404)),
   hashRecoveryCodes: vi.fn((codes: string[]) => codes.map((code) => `hashed-${code}`)),
   resolveUserAuditOrgId: vi.fn(async () => 'org-1'),
@@ -119,6 +145,10 @@ vi.mock('./helpers', () => ({
   // this suite's default account state. Individual tests override via
   // mockResolvedValueOnce to exercise the already-protected gate.
   enforceExistingFactorStepUp: vi.fn(async () => null),
+  resolveCurrentUserTokenContext: vi.fn(async () => ({
+    scope: 'organization', roleId: 'role-1', orgId: 'org-1', partnerId: null,
+  })),
+  auditUserLoginFailure: vi.fn(async () => undefined),
 }));
 
 import { phoneRoutes } from './phone';
@@ -126,6 +156,7 @@ import { db } from '../../db';
 import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
 import { getTwilioService } from '../../services/twilio';
 import { writeAuthAudit, enforceExistingFactorStepUp } from './helpers';
+import { completeInitialMfaEnrollment, getRedis, getUserEpochs, rateLimiter } from '../../services';
 
 function selectChain(rows: unknown[]) {
   return {
@@ -196,7 +227,7 @@ describe('phone routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.success).toBe(true);
-      expect(db.update).toHaveBeenCalled();
+      expect(completeInitialMfaEnrollment).toHaveBeenCalledOnce();
     });
 
     // SR2-20: adding SMS as a NEW factor on an ALREADY-PROTECTED account
@@ -308,6 +339,124 @@ describe('phone routes', () => {
         { consume: false }
       );
       expect(db.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /auth/mfa/sms/send', () => {
+    const pending = (overrides: Record<string, unknown> = {}) => JSON.stringify({
+      userId: 'user-1',
+      mfaMethod: 'totp',
+      passkeyAvailable: false,
+      recoveryAvailable: true,
+      authEpoch: 1,
+      mfaEpoch: 1,
+      transitionId: 'transition-1',
+      browserGeneration: 1,
+      statusExpectation: 'active',
+      allowedMethods: { totp: true, sms: true, passkey: false },
+      expiresAt: Date.now() + 300_000,
+      ...overrides,
+    });
+
+    const user = {
+      id: 'user-1',
+      email: 'user@example.test',
+      name: 'Sample User',
+      status: 'active',
+      mfaEnabled: true,
+      mfaMethod: 'sms',
+      phoneNumber: '+15555550100',
+    };
+
+    function arrange(raw: string | null, liveUser: Record<string, unknown> = user) {
+      const redis = {
+        get: vi.fn().mockResolvedValue(raw),
+        del: vi.fn().mockResolvedValue(1),
+      };
+      const sendVerificationCode = vi.fn().mockResolvedValue({ success: true });
+      vi.mocked(getRedis).mockReturnValue(redis as any);
+      vi.mocked(getUserEpochs).mockResolvedValue({ authEpoch: 1, mfaEpoch: 1 });
+      vi.mocked(rateLimiter).mockResolvedValue({
+        allowed: true,
+        remaining: 4,
+        resetAt: new Date(Date.now() + 60_000),
+      } as any);
+      vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+        required: false,
+        allowedMethods: { totp: true, sms: true, passkey: true },
+        source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: false },
+      });
+      vi.mocked(db.select).mockReturnValue(selectChain([liveUser]) as any);
+      vi.mocked(getTwilioService).mockReturnValue({
+        sendVerificationCode,
+        checkVerificationCode: vi.fn(),
+      } as any);
+      return { redis, sendVerificationCode };
+    }
+
+    async function send() {
+      return app.request('/auth/mfa/sms/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tempToken: 'temp-token' }),
+      });
+    }
+
+    it('sends for an SMS-enrolled account when a TOTP-primary challenge authorizes switching to SMS', async () => {
+      const { sendVerificationCode } = arrange(pending());
+
+      const res = await send();
+
+      expect(res.status).toBe(200);
+      expect(sendVerificationCode).toHaveBeenCalledWith('+15555550100');
+    });
+
+    it('rejects malformed pending data before looking up or sending to a phone', async () => {
+      const { sendVerificationCode } = arrange(JSON.stringify({ userId: 'user-1' }));
+
+      const res = await send();
+
+      expect(res.status).toBe(401);
+      expect(db.select).not.toHaveBeenCalled();
+      expect(sendVerificationCode).not.toHaveBeenCalled();
+    });
+
+    it('rejects an SMS method the pending challenge did not authorize without consuming the challenge', async () => {
+      const { redis, sendVerificationCode } = arrange(pending({
+        allowedMethods: { totp: true, sms: false, passkey: false },
+      }));
+
+      const res = await send();
+
+      expect(res.status).toBe(401);
+      expect(redis.del).not.toHaveBeenCalled();
+      expect(sendVerificationCode).not.toHaveBeenCalled();
+    });
+
+    it('consumes an epoch-drifted pending challenge before any SMS is sent', async () => {
+      const { redis, sendVerificationCode } = arrange(pending());
+      vi.mocked(getUserEpochs).mockResolvedValue({ authEpoch: 1, mfaEpoch: 2 });
+
+      const res = await send();
+
+      expect(res.status).toBe(401);
+      expect(redis.del).toHaveBeenCalledWith('mfa:pending:temp-token');
+      expect(sendVerificationCode).not.toHaveBeenCalled();
+    });
+
+    it('consumes the challenge when live policy no longer permits SMS', async () => {
+      const { redis, sendVerificationCode } = arrange(pending());
+      vi.mocked(getEffectiveMfaPolicy).mockResolvedValue({
+        required: false,
+        allowedMethods: { totp: true, sms: false, passkey: true },
+        source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: false },
+      });
+
+      const res = await send();
+
+      expect(res.status).toBe(401);
+      expect(redis.del).toHaveBeenCalledWith('mfa:pending:temp-token');
+      expect(sendVerificationCode).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/auth/phone.ts
+++ b/apps/api/src/routes/auth/phone.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import * as dbModule from '../../db';
@@ -7,12 +7,23 @@ import {
   generateRecoveryCodes,
   rateLimiter,
   getRedis,
+  getUserEpochs,
   smsPhoneVerifyLimiter,
   smsPhoneVerifyUserLimiter,
   smsLoginSendLimiter,
   smsLoginGlobalLimiter,
-  phoneConfirmLimiter
+  phoneConfirmLimiter,
+  beginAuthIssuance,
+  cancelAuthIssuance,
+  bindIssuedUserSession,
+  completeInitialMfaEnrollment,
+  AuthBindingRotationRequiredError,
+  AuthBindingUnavailableError,
+  AuthIssuanceConflictError,
+  AuthIssuanceCapabilityError,
+  type AuthIssuanceCapability,
 } from '../../services';
+import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
 import { getTwilioService } from '../../services/twilio';
 import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
 import { invalidateMfaAssuranceAfterFactorChange } from '../../services/mfaAssurance';
@@ -25,12 +36,35 @@ import {
   resolveUserAuditOrgId,
   writeAuthAudit,
   requireCurrentPasswordStepUp,
-  enforceExistingFactorStepUp
+  enforceExistingFactorStepUp,
+  parsePendingMfa,
+  evaluatePendingMfa,
+  evaluatePendingMfaMethod,
+  resolveCurrentUserTokenContext,
+  auditUserLoginFailure,
+  installAuthorizedUserSessionCookies,
+  toPublicTokens,
 } from './helpers';
+import { installAuthBindingReplacement, requestAuthBinding } from './binding';
 
 const { db, withSystemDbAccessContext } = dbModule;
 
 export const phoneRoutes = new Hono();
+
+function authIssuanceAdmissionError(c: Context, error: unknown): Response | null {
+  if (error instanceof AuthBindingRotationRequiredError) {
+    installAuthBindingReplacement(c, error.replacement);
+    return c.json({ error: error.message, reason: 'auth_binding_rotation_required' }, 428);
+  }
+  if (
+    error instanceof AuthBindingUnavailableError
+    || error instanceof AuthIssuanceConflictError
+    || error instanceof AuthIssuanceCapabilityError
+  ) {
+    return c.json({ error: 'Authentication issuance unavailable' }, 409);
+  }
+  return null;
+}
 
 // Phone verification - send code (authenticated)
 phoneRoutes.post('/phone/verify', authMiddleware, zValidator('json', phoneVerifySchema), async (c) => {
@@ -288,22 +322,60 @@ phoneRoutes.post('/mfa/sms/enable', authMiddleware, zValidator('json', smsMfaEna
   const stepUpConsumeError = await enforceExistingFactorStepUp(c, auth, stepUpGrantId, { consume: true });
   if (stepUpConsumeError) return stepUpConsumeError;
 
-  // Generate recovery codes
   const recoveryCodes = generateRecoveryCodes();
-
-  // Enable SMS MFA
-  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'sms-mfa-enable', async (tx) => {
-    await tx
-      .update(users)
-      .set({
-        mfaEnabled: true,
-        mfaMethod: 'sms',
-        mfaSecret: null,
-        mfaRecoveryCodes: hashRecoveryCodes(recoveryCodes),
-        updatedAt: new Date()
-      })
-      .where(eq(users.id, auth.user.id));
-  });
+  const recoveryCodeHashes = hashRecoveryCodes(recoveryCodes);
+  let capability: AuthIssuanceCapability;
+  try {
+    capability = await beginAuthIssuance(requestAuthBinding(c));
+  } catch (error) {
+    const response = authIssuanceAdmissionError(c, error);
+    if (!response) throw error;
+    return response;
+  }
+  let result;
+  try {
+    result = await completeInitialMfaEnrollment({
+      userId: auth.user.id,
+      identity: {
+        userId: auth.user.id,
+        email: auth.user.email,
+        roleId: auth.token?.roleId ?? null,
+        orgId: auth.orgId ?? null,
+        partnerId: auth.partnerId ?? null,
+        scope: auth.scope,
+        mfa: true,
+        mobileDeviceId: readMobileDeviceId(c) ?? undefined,
+      },
+      capability,
+      expectedAuthEpoch: auth.token?.aep as number,
+      expectedMfaEpoch: auth.token?.mep as number,
+      revokeReason: 'sms-mfa-enable',
+      recoveryCodes,
+      recoveryCodeHashes,
+      persistFactor: async (tx, hashes) => {
+        const rows = await tx
+          .update(users)
+          .set({
+            mfaEnabled: true,
+            mfaMethod: 'sms',
+            mfaSecret: null,
+            mfaRecoveryCodes: [...hashes],
+            updatedAt: new Date()
+          })
+          .where(eq(users.id, auth.user.id))
+          .returning({ id: users.id });
+        if (rows.length !== 1) throw new Error('MFA enrollment user disappeared');
+        return undefined;
+      },
+    });
+  } catch (error) {
+    await cancelAuthIssuance(capability).catch(() => undefined);
+    const response = authIssuanceAdmissionError(c, error);
+    if (!response) throw error;
+    return response;
+  }
+  await bindIssuedUserSession(result.issued);
+  installAuthorizedUserSessionCookies(c, result.issued);
 
   const orgId = await resolveUserAuditOrgId(auth.user.id);
   writeAuthAudit(c, {
@@ -312,10 +384,15 @@ phoneRoutes.post('/mfa/sms/enable', authMiddleware, zValidator('json', smsMfaEna
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { method: 'sms', mfaEpoch: result.mfaEpoch, teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED }
+    details: { method: 'sms', mfaEpoch: result.mfaEpoch, teardownFailed: result.cleanup.remoteSessionsTerminated === TEARDOWN_FAILED }
   });
 
-  return c.json({ success: true, recoveryCodes, message: 'SMS MFA enabled successfully' });
+  return c.json({
+    success: true,
+    recoveryCodes: result.recoveryCodes,
+    message: 'SMS MFA enabled successfully',
+    tokens: toPublicTokens(result.issued),
+  });
 });
 
 // SMS MFA send code during login (unauthenticated, requires tempToken)
@@ -331,39 +408,79 @@ phoneRoutes.post('/mfa/sms/send', zValidator('json', smsSendSchema), async (c) =
     return c.json({ error: 'Service temporarily unavailable' }, 503);
   }
 
-  const twilio = getTwilioService();
-  if (!twilio) {
-    return c.json({ error: 'SMS service not configured' }, 501);
-  }
-
   const pendingRaw = await redis.get(`mfa:pending:${tempToken}`);
   if (!pendingRaw) {
     return c.json({ error: 'Invalid or expired MFA session' }, 401);
   }
 
-  let userId: string;
-  try {
-    const parsed = JSON.parse(pendingRaw);
-    userId = parsed.userId;
-  } catch {
-    return c.json({ error: 'Invalid MFA session data' }, 400);
+  const pending = parsePendingMfa(pendingRaw);
+  if (!pending) {
+    return c.json({ error: 'Invalid or expired MFA session' }, 401);
   }
+  const userId = pending.userId;
 
-  // Look up phone number from DB (never store PII in Redis).
+  // Look up live factor/account state from DB (never store PII in Redis).
   // Pre-auth lookup — wrap in system scope so the `users` RLS policy
   // doesn't deny the read before the real request scope is applied.
   const [smsUser] = await withSystemDbAccessContext(async () =>
     db
-      .select({ phoneNumber: users.phoneNumber })
+      .select({
+        id: users.id,
+        email: users.email,
+        name: users.name,
+        status: users.status,
+        mfaEnabled: users.mfaEnabled,
+        mfaMethod: users.mfaMethod,
+        mfaSecret: users.mfaSecret,
+        phoneNumber: users.phoneNumber,
+      })
       .from(users)
       .where(eq(users.id, userId))
       .limit(1)
   );
 
-  const phoneNumber = smsUser?.phoneNumber;
-  if (!phoneNumber) {
-    return c.json({ error: 'No phone number configured for SMS MFA' }, 400);
+  if (!smsUser) {
+    return c.json({ error: 'Invalid or expired MFA session' }, 401);
   }
+
+  const liveEpochs = await getUserEpochs(userId);
+  const pendingVerdict = liveEpochs
+    ? evaluatePendingMfa(pending, {
+        status: smsUser.status,
+        authEpoch: liveEpochs.authEpoch,
+        mfaEpoch: liveEpochs.mfaEpoch,
+      })
+    : ({ ok: false, reason: 'epoch_mismatch' } as const);
+  if (!pendingVerdict.ok) {
+    await redis.del(`mfa:pending:${tempToken}`);
+    return c.json({ error: 'Invalid or expired MFA session' }, 401);
+  }
+
+  const context = await resolveCurrentUserTokenContext(userId);
+  const livePolicy = await getEffectiveMfaPolicy({
+    scope: context.scope,
+    userId,
+    orgId: context.orgId,
+    partnerId: context.partnerId,
+  });
+  const methodVerdict = evaluatePendingMfaMethod(
+    pending,
+    'sms',
+    smsUser,
+    livePolicy.allowedMethods,
+  );
+  if (!methodVerdict.ok) {
+    if (methodVerdict.terminal) await redis.del(`mfa:pending:${tempToken}`);
+    void auditUserLoginFailure(c, {
+      userId,
+      email: smsUser.email,
+      name: smsUser.name,
+      reason: 'mfa_method_not_allowed',
+      details: { method: 'sms', phase: methodVerdict.reason, continuation: 'send' },
+    });
+    return c.json({ error: 'Invalid MFA code' }, 401);
+  }
+  const phoneNumber = smsUser.phoneNumber!;
 
   // Rate limit per tempToken
   const tokenRate = await rateLimiter(
@@ -385,6 +502,11 @@ phoneRoutes.post('/mfa/sms/send', zValidator('json', smsSendSchema), async (c) =
   );
   if (!phoneRate.allowed) {
     return c.json({ error: 'Too many SMS requests. Try again later.' }, 429);
+  }
+
+  const twilio = getTwilioService();
+  if (!twilio) {
+    return c.json({ error: 'SMS service not configured' }, 501);
   }
 
   const result = await twilio.sendVerificationCode(phoneNumber);

--- a/apps/api/src/routes/auth/ssoLinkCompletion.test.ts
+++ b/apps/api/src/routes/auth/ssoLinkCompletion.test.ts
@@ -102,6 +102,7 @@ vi.mock('../../services/auditEvents', () => ({
 
 vi.mock('../../services/ssoPendingLink', () => ({
   consumeSsoPendingLink: vi.fn(),
+  restoreConsumedSsoPendingLink: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('./helpers', () => ({
@@ -111,7 +112,7 @@ vi.mock('./helpers', () => ({
 import { finalizeSsoPendingLink } from './ssoLinkCompletion';
 import { db } from '../../db';
 import { users, ssoProviders, organizationUsers, userSsoIdentities } from '../../db/schema';
-import { consumeSsoPendingLink } from '../../services/ssoPendingLink';
+import { consumeSsoPendingLink, restoreConsumedSsoPendingLink } from '../../services/ssoPendingLink';
 import { getUserEpochs } from '../../services';
 import { issueUserSession } from '../../services/userSession';
 import { beginAuthIssuanceForStoredTransition, cancelAuthIssuance, finishAuthIssuance } from '../../services/authBrowserTransition';
@@ -261,9 +262,18 @@ describe('finalizeSsoPendingLink — live revalidation guards (#4067)', () => {
     });
 
     expect(outcome).toEqual({ ok: false, error: 'invalid_mfa_code' });
+    expect(restoreConsumedSsoPendingLink).toHaveBeenCalledWith('hash-1', RECORD);
     expect(consumeRecoveryCode).toHaveBeenCalledWith(expect.anything(), USER_ID, 'ABCD-2345');
     expect(issueUserSession).not.toHaveBeenCalled();
     expect(cancelAuthIssuance).toHaveBeenCalledOnce();
+
+    wire();
+    const retry = await finalizeSsoPendingLink(c, 'hash-1', {
+      breezeMfaVerified: true,
+      expectedUserId: USER_ID,
+      recoveryCode: 'CORRECT-1',
+    });
+    expect(retry.ok).toBe(true);
   });
 
   it('returns link_expired when the record is gone (expired / already consumed / store down)', async () => {

--- a/apps/api/src/routes/auth/ssoLinkCompletion.ts
+++ b/apps/api/src/routes/auth/ssoLinkCompletion.ts
@@ -21,7 +21,10 @@ import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
 import { getTrustedClientIp } from '../../services/clientIp';
 import { isSsoProvisioningBlocked, isDomainVerifiedForOrg } from '../../services/ssoDomainVerification';
 import { writeRouteAudit } from '../../services/auditEvents';
-import { consumeSsoPendingLink } from '../../services/ssoPendingLink';
+import {
+  consumeSsoPendingLink,
+  restoreConsumedSsoPendingLink,
+} from '../../services/ssoPendingLink';
 import { consumeRecoveryCode, RecoveryCodeInvalidError } from '../../services/recoveryCodeAuth';
 import { auditLogin } from './helpers';
 
@@ -589,6 +592,12 @@ export async function finalizeSsoPendingLink(
       });
       capability = undefined;
     } catch (err) {
+      if (err instanceof RecoveryCodeInvalidError) {
+        const restored = await restoreConsumedSsoPendingLink(tokenHash, record);
+        if (!restored) {
+          console.warn('[sso/link] invalid recovery code could not restore the retryable pending record');
+        }
+      }
       const reason = err instanceof RecoveryCodeInvalidError
         ? 'invalid_mfa_code'
         : err instanceof SsoCompletionRejected

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -3991,17 +3991,29 @@ ssoRoutes.post('/link/confirm', zValidator('json', ssoLinkConfirmSchema), async 
       orgId: record.providerPartnerId ? null : record.providerOrgId,
       partnerId: record.providerPartnerId,
     });
+    const allowedMethods = {
+      totp: Boolean(user.mfaSecret) && pendingPolicy.allowedMethods.totp,
+      sms: user.mfaMethod === 'sms' && Boolean(user.phoneNumber) && pendingPolicy.allowedMethods.sms,
+      passkey: passkeyAvailable && pendingPolicy.allowedMethods.passkey,
+    };
+    const recoveryAvailable = Array.isArray(user.mfaRecoveryCodes)
+      && user.mfaRecoveryCodes.length > 0;
+    if (!allowedMethods.totp && !allowedMethods.sms && !allowedMethods.passkey && !recoveryAvailable) {
+      await floorPromise;
+      return c.json(genericAuthError(), 401);
+    }
     const PENDING_TTL_SECONDS = 300;
     const pendingRecord: PendingMfaRecord = {
       userId: user.id,
       mfaMethod,
       passkeyAvailable,
+      recoveryAvailable,
       authEpoch: pendingEpochs.authEpoch,
       mfaEpoch: pendingEpochs.mfaEpoch,
       transitionId: record.browserTransitionId,
       browserGeneration: record.browserGeneration,
       statusExpectation: user.status,
-      allowedMethods: pendingPolicy.allowedMethods,
+      allowedMethods,
       expiresAt: Date.now() + PENDING_TTL_SECONDS * 1000,
       ssoLinkTokenHash: tokenHash,
     };
@@ -4016,6 +4028,8 @@ ssoRoutes.post('/link/confirm', zValidator('json', ssoLinkConfirmSchema), async 
       mfaRequired: true,
       tempToken,
       mfaMethod,
+      allowedMethods,
+      recoveryAvailable,
       passkeyAvailable,
       phoneLast4: user.phoneNumber?.slice(-4) || null,
       user: null,

--- a/apps/api/src/services/authLifecycle.ts
+++ b/apps/api/src/services/authLifecycle.ts
@@ -16,6 +16,13 @@ interface EpochRow {
   passwordResetEpoch: number;
 }
 
+export class EpochAdvancePreconditionError extends Error {
+  constructor() {
+    super('User epoch precondition no longer matches');
+    this.name = 'EpochAdvancePreconditionError';
+  }
+}
+
 /**
  * Advance the requested epoch counters for a user INSIDE the caller's
  * transaction and return the post-mutation values. Because the increment and
@@ -48,6 +55,7 @@ export async function advanceUserEpochs(
   tx: Tx,
   userId: string,
   fields: { auth?: boolean; mfa?: boolean; email?: boolean; passwordReset?: boolean },
+  expected?: { authEpoch?: number; mfaEpoch?: number; mfaEnabled?: boolean; status?: 'active' },
 ): Promise<EpochRow> {
   const set: Record<string, unknown> = { updatedAt: new Date() };
   if (fields.auth) set.authEpoch = sql`${users.authEpoch} + 1`;
@@ -55,16 +63,23 @@ export async function advanceUserEpochs(
   if (fields.email) set.emailEpoch = sql`${users.emailEpoch} + 1`;
   if (fields.passwordReset) set.passwordResetEpoch = sql`${users.passwordResetEpoch} + 1`;
 
+  const conditions = [eq(users.id, userId)];
+  if (expected?.authEpoch !== undefined) conditions.push(eq(users.authEpoch, expected.authEpoch));
+  if (expected?.mfaEpoch !== undefined) conditions.push(eq(users.mfaEpoch, expected.mfaEpoch));
+  if (expected?.mfaEnabled !== undefined) conditions.push(eq(users.mfaEnabled, expected.mfaEnabled));
+  if (expected?.status !== undefined) conditions.push(eq(users.status, expected.status));
+
   const [row] = await tx
     .update(users)
     .set(set)
-    .where(eq(users.id, userId))
+    .where(and(...conditions))
     .returning({
       authEpoch: users.authEpoch,
       mfaEpoch: users.mfaEpoch,
       emailEpoch: users.emailEpoch,
       passwordResetEpoch: users.passwordResetEpoch,
     });
+  if (!row && expected) throw new EpochAdvancePreconditionError();
   if (!row) throw new Error(`advanceUserEpochs: user ${userId} not found`);
   return row;
 }

--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -18,6 +18,7 @@ export * from './tokenRevocation';
 export * from './refreshTokenFamily';
 export * from './authBrowserTransition';
 export * from './userSession';
+export * from './mfaEnrollmentSession';
 export * from './recoveryCodeAuth';
 export * from './authTransitionMetrics';
 export * from './clientIp';

--- a/apps/api/src/services/mfaEnrollmentSession.test.ts
+++ b/apps/api/src/services/mfaEnrollmentSession.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  finishAuthIssuanceMock,
+  advanceUserEpochsMock,
+  revokeAllRefreshFamiliesMock,
+  issueUserSessionMock,
+  runPostCommitCleanupMock,
+  terminateUserRemoteSessionsMock,
+} = vi.hoisted(() => ({
+  finishAuthIssuanceMock: vi.fn(),
+  advanceUserEpochsMock: vi.fn(),
+  revokeAllRefreshFamiliesMock: vi.fn(),
+  issueUserSessionMock: vi.fn(),
+  runPostCommitCleanupMock: vi.fn(),
+  terminateUserRemoteSessionsMock: vi.fn(),
+}));
+
+vi.mock('./authBrowserTransition', () => ({
+  finishAuthIssuance: finishAuthIssuanceMock,
+  AuthIssuanceConflictError: class AuthIssuanceConflictError extends Error {
+    constructor() {
+      super('Another authentication issuance operation is in progress');
+      this.name = 'AuthIssuanceConflictError';
+    }
+  },
+}));
+
+vi.mock('./authLifecycle', () => ({
+  advanceUserEpochs: advanceUserEpochsMock,
+  EpochAdvancePreconditionError: class EpochAdvancePreconditionError extends Error {},
+  revokeAllRefreshFamilies: revokeAllRefreshFamiliesMock,
+  runPostCommitCleanup: runPostCommitCleanupMock,
+}));
+
+vi.mock('./userSession', () => ({
+  issueUserSession: issueUserSessionMock,
+}));
+
+vi.mock('./remoteSessionTeardown', () => ({
+  terminateUserRemoteSessions: terminateUserRemoteSessionsMock,
+}));
+
+import { completeInitialMfaEnrollment } from './mfaEnrollmentSession';
+import type { AuthIssuanceCapability } from './authBrowserTransition';
+import { EpochAdvancePreconditionError } from './authLifecycle';
+import type { AuthorizedUserSession, UserSessionIdentity } from './userSession';
+
+describe('completeInitialMfaEnrollment', () => {
+  const tx = { marker: 'transaction' } as never;
+  const capability = { marker: 'capability' } as unknown as AuthIssuanceCapability;
+  const identity: UserSessionIdentity = {
+    userId: 'user-123',
+    email: 'user@example.com',
+    roleId: 'role-123',
+    orgId: 'org-123',
+    partnerId: 'partner-123',
+    scope: 'organization',
+    mfa: true,
+  };
+  const issued = {
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    refreshJti: 'refresh-jti',
+    expiresInSeconds: 900,
+    familyId: 'family-new',
+    transitionId: 'transition-123',
+    generation: 4,
+  } as unknown as AuthorizedUserSession;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    finishAuthIssuanceMock.mockImplementation(
+      async (_capability: unknown, callback: (value: unknown) => Promise<unknown>) => callback(tx),
+    );
+    advanceUserEpochsMock.mockResolvedValue({
+      authEpoch: 3,
+      mfaEpoch: 8,
+      emailEpoch: 1,
+      passwordResetEpoch: 1,
+    });
+    revokeAllRefreshFamiliesMock.mockResolvedValue(undefined);
+    issueUserSessionMock.mockResolvedValue(issued);
+    runPostCommitCleanupMock.mockResolvedValue({ redisOk: true, permissionCacheOk: true, oauthOk: true });
+    terminateUserRemoteSessionsMock.mockResolvedValue(2);
+  });
+
+  it('commits epoch, revocation, replacement session, and factor in the required order', async () => {
+    const order: string[] = [];
+    advanceUserEpochsMock.mockImplementation(async () => {
+      order.push('epoch');
+      return { authEpoch: 3, mfaEpoch: 8, emailEpoch: 1, passwordResetEpoch: 1 };
+    });
+    revokeAllRefreshFamiliesMock.mockImplementation(async () => { order.push('revoke'); });
+    issueUserSessionMock.mockImplementation(async () => { order.push('session'); return issued; });
+    const persistFactor = vi.fn(async (suppliedTx: unknown, hashes: readonly string[]) => {
+      expect(suppliedTx).toBe(tx);
+      expect(hashes).toEqual(['hash-1', 'hash-2']);
+      order.push('factor');
+      return { factorId: 'factor-1' };
+    });
+
+    const result = await completeInitialMfaEnrollment({
+      userId: identity.userId,
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      revokeReason: 'initial-mfa-enrollment',
+      recoveryCodes: ['code-1', 'code-2'],
+      recoveryCodeHashes: ['hash-1', 'hash-2'],
+      persistFactor,
+    });
+
+    expect(order).toEqual(['epoch', 'revoke', 'session', 'factor']);
+    expect(finishAuthIssuanceMock).toHaveBeenCalledWith(capability, expect.any(Function));
+    expect(advanceUserEpochsMock).toHaveBeenCalledWith(
+      tx,
+      identity.userId,
+      { mfa: true },
+      { authEpoch: 3, mfaEpoch: 7, mfaEnabled: false, status: 'active' },
+    );
+    expect(revokeAllRefreshFamiliesMock).toHaveBeenCalledWith(tx, identity.userId, 'initial-mfa-enrollment');
+    expect(issueUserSessionMock).toHaveBeenCalledWith(identity, {
+      tx,
+      capability,
+      expectedEpochs: { authEpoch: 3, mfaEpoch: 8 },
+    });
+    expect(result).toEqual({
+      value: { factorId: 'factor-1' },
+      recoveryCodes: ['code-1', 'code-2'],
+      issued,
+      mfaEpoch: 8,
+      cleanup: {
+        redisOk: true,
+        permissionCacheOk: true,
+        oauthOk: true,
+        remoteSessionsTerminated: 2,
+      },
+    });
+  });
+
+  it('does not run cleanup or expose codes when the factor write rolls back', async () => {
+    const error = new Error('factor write failed');
+    await expect(completeInitialMfaEnrollment({
+      userId: identity.userId,
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      revokeReason: 'initial-mfa-enrollment',
+      recoveryCodes: ['code-1'],
+      recoveryCodeHashes: ['hash-1'],
+      persistFactor: async () => { throw error; },
+    })).rejects.toThrow(error);
+
+    expect(runPostCommitCleanupMock).not.toHaveBeenCalled();
+    expect(terminateUserRemoteSessionsMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects mismatched plaintext/hash counts before opening finalization', async () => {
+    await expect(completeInitialMfaEnrollment({
+      userId: identity.userId,
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      revokeReason: 'initial-mfa-enrollment',
+      recoveryCodes: ['code-1', 'code-2'],
+      recoveryCodeHashes: ['hash-1'],
+      persistFactor: vi.fn(),
+    })).rejects.toThrow(/count/i);
+
+    expect(finishAuthIssuanceMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects identity/user mismatches before opening finalization', async () => {
+    await expect(completeInitialMfaEnrollment({
+      userId: 'different-user',
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      revokeReason: 'initial-mfa-enrollment',
+      recoveryCodes: ['code-1'],
+      recoveryCodeHashes: ['hash-1'],
+      persistFactor: vi.fn(),
+    })).rejects.toThrow(/identity/i);
+
+    expect(finishAuthIssuanceMock).not.toHaveBeenCalled();
+  });
+
+  it('does not persist the factor or run cleanup when replacement issuance fails', async () => {
+    issueUserSessionMock.mockRejectedValueOnce(new Error('epoch mismatch'));
+    const persistFactor = vi.fn();
+
+    await expect(completeInitialMfaEnrollment({
+      userId: identity.userId,
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      revokeReason: 'initial-mfa-enrollment',
+      recoveryCodes: ['code-1'],
+      recoveryCodeHashes: ['hash-1'],
+      persistFactor,
+    })).rejects.toThrow('epoch mismatch');
+
+    expect(persistFactor).not.toHaveBeenCalled();
+    expect(runPostCommitCleanupMock).not.toHaveBeenCalled();
+    expect(terminateUserRemoteSessionsMock).not.toHaveBeenCalled();
+  });
+
+  it('fails a stale or concurrent initial enrollment before family/session writes', async () => {
+    advanceUserEpochsMock.mockRejectedValueOnce(new EpochAdvancePreconditionError());
+    const persistFactor = vi.fn();
+
+    await expect(completeInitialMfaEnrollment({
+      userId: identity.userId,
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      revokeReason: 'initial-mfa-enrollment',
+      recoveryCodes: ['code-1'],
+      recoveryCodeHashes: ['hash-1'],
+      persistFactor,
+    })).rejects.toMatchObject({ name: 'AuthIssuanceConflictError' });
+
+    expect(revokeAllRefreshFamiliesMock).not.toHaveBeenCalled();
+    expect(issueUserSessionMock).not.toHaveBeenCalled();
+    expect(persistFactor).not.toHaveBeenCalled();
+    expect(runPostCommitCleanupMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/mfaEnrollmentSession.ts
+++ b/apps/api/src/services/mfaEnrollmentSession.ts
@@ -1,0 +1,113 @@
+import {
+  finishAuthIssuance,
+  AuthIssuanceConflictError,
+  type AuthIssuanceCapability,
+} from './authBrowserTransition';
+import {
+  advanceUserEpochs,
+  EpochAdvancePreconditionError,
+  revokeAllRefreshFamilies,
+  runPostCommitCleanup,
+  type PostCommitCleanupResult,
+  type Tx,
+} from './authLifecycle';
+import { terminateUserRemoteSessions } from './remoteSessionTeardown';
+import {
+  issueUserSession,
+  type AuthorizedUserSession,
+  type UserSessionIdentity,
+} from './userSession';
+
+export type MfaAssuranceCleanup = PostCommitCleanupResult & {
+  remoteSessionsTerminated: number;
+};
+
+export interface CompleteInitialMfaEnrollmentInput<T> {
+  userId: string;
+  identity: UserSessionIdentity;
+  capability: AuthIssuanceCapability;
+  expectedAuthEpoch: number;
+  expectedMfaEpoch: number;
+  revokeReason: string;
+  recoveryCodes: readonly string[];
+  recoveryCodeHashes: readonly string[];
+  persistFactor: (tx: Tx, recoveryCodeHashes: readonly string[]) => Promise<T>;
+}
+
+export interface CompletedInitialMfaEnrollment<T> {
+  value: T;
+  recoveryCodes: string[];
+  issued: AuthorizedUserSession;
+  mfaEpoch: number;
+  cleanup: MfaAssuranceCleanup;
+}
+
+/**
+ * Atomically replaces a pre-enrollment session with an MFA-assured session.
+ * Expensive recovery-code generation and hashing belong before this call;
+ * every authority-bearing write happens inside finishAuthIssuance's supplied
+ * transaction and plaintext codes are returned only after it commits.
+ */
+export async function completeInitialMfaEnrollment<T>(
+  input: CompleteInitialMfaEnrollmentInput<T>,
+): Promise<CompletedInitialMfaEnrollment<T>> {
+  if (input.identity.userId !== input.userId) {
+    throw new Error('Enrollment identity does not match the target user');
+  }
+  if (input.identity.mfa !== true) {
+    throw new Error('Replacement enrollment identity must be MFA-assured');
+  }
+  if (
+    !Number.isInteger(input.expectedAuthEpoch)
+    || input.expectedAuthEpoch < 0
+    || !Number.isInteger(input.expectedMfaEpoch)
+    || input.expectedMfaEpoch < 0
+    || input.recoveryCodes.length === 0
+    || input.recoveryCodes.length !== input.recoveryCodeHashes.length
+  ) {
+    throw new Error('Expected auth/MFA epochs and recovery-code counts must be valid');
+  }
+
+  const committed = await finishAuthIssuance(input.capability, async (tx) => {
+    // Global order: transition (finishAuthIssuance), user, old families, new
+    // family/session, factor-specific rows.
+    let epochs;
+    try {
+      epochs = await advanceUserEpochs(
+        tx,
+        input.userId,
+        { mfa: true },
+        {
+          authEpoch: input.expectedAuthEpoch,
+          mfaEpoch: input.expectedMfaEpoch,
+          mfaEnabled: false,
+          status: 'active',
+        },
+      );
+    } catch (error) {
+      if (error instanceof EpochAdvancePreconditionError) {
+        throw new AuthIssuanceConflictError();
+      }
+      throw error;
+    }
+    await revokeAllRefreshFamilies(tx, input.userId, input.revokeReason);
+    const issued = await issueUserSession(input.identity, {
+      tx,
+      capability: input.capability,
+      expectedEpochs: { authEpoch: epochs.authEpoch, mfaEpoch: epochs.mfaEpoch },
+    });
+    const value = await input.persistFactor(tx, input.recoveryCodeHashes);
+    return { value, issued, mfaEpoch: epochs.mfaEpoch };
+  });
+
+  const [cleanup, remoteSessionsTerminated] = await Promise.all([
+    runPostCommitCleanup(input.userId),
+    terminateUserRemoteSessions(input.userId),
+  ]);
+
+  return {
+    ...committed,
+    recoveryCodes: [...input.recoveryCodes],
+    cleanup: { ...cleanup, remoteSessionsTerminated },
+  };
+}

--- a/apps/api/src/services/ssoPendingLink.test.ts
+++ b/apps/api/src/services/ssoPendingLink.test.ts
@@ -17,6 +17,7 @@ import {
   createSsoPendingLink,
   peekSsoPendingLink,
   consumeSsoPendingLink,
+  restoreConsumedSsoPendingLink,
   deleteSsoPendingLink,
   hashSsoPendingLinkToken,
   SSO_PENDING_LINK_TTL_SECONDS,
@@ -134,6 +135,25 @@ describe('consumeSsoPendingLink', () => {
     expect(winner?.userId).toBe('user-1');
     expect(loser).toBeNull();
     expect(redisMock.getdel).toHaveBeenCalledWith('sso:pendinglink:h');
+  });
+});
+
+describe('restoreConsumedSsoPendingLink', () => {
+  it('restores a retryable record only for the unexpired remainder of its window', async () => {
+    const record = { ...RECORD, createdAt: Date.now() - 60_000 };
+    await expect(restoreConsumedSsoPendingLink('h', record)).resolves.toBe(true);
+    expect(redisMock.setex).toHaveBeenCalledWith(
+      'sso:pendinglink:h',
+      expect.any(Number),
+      JSON.stringify(record),
+    );
+    expect(redisMock.setex.mock.calls.at(-1)?.[1]).toBeLessThanOrEqual(240);
+  });
+
+  it('does not revive an expired record', async () => {
+    const record = { ...RECORD, createdAt: Date.now() - 301_000 };
+    await expect(restoreConsumedSsoPendingLink('h', record)).resolves.toBe(false);
+    expect(redisMock.setex).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/ssoPendingLink.ts
+++ b/apps/api/src/services/ssoPendingLink.ts
@@ -202,6 +202,22 @@ export async function consumeSsoPendingLink(tokenHash: string): Promise<SsoPendi
   return parseRecord(await getDelAtomic(redis as RedisWithGetDel, pendingKey(tokenHash)));
 }
 
+/** Restore the single consumed record after a retryable factor failure. The
+ * original window is preserved, so wrong codes cannot extend the ceremony. */
+export async function restoreConsumedSsoPendingLink(
+  tokenHash: string,
+  record: SsoPendingLink,
+): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  const remainingSeconds = Math.ceil(
+    (record.createdAt + SSO_PENDING_LINK_TTL_SECONDS * 1000 - Date.now()) / 1000,
+  );
+  if (remainingSeconds <= 0) return false;
+  await redis.setex(pendingKey(tokenHash), remainingSeconds, JSON.stringify(record));
+  return true;
+}
+
 /**
  * Re-arm the record's TTL to the full window. Called when the password step
  * succeeds and hands off to the MFA continuation, so the factor step gets its
@@ -214,9 +230,13 @@ export async function consumeSsoPendingLink(tokenHash: string): Promise<SsoPendi
 export async function touchSsoPendingLink(tokenHash: string): Promise<void> {
   const redis = getRedis();
   if (!redis) return;
-  const raw = await redis.get(pendingKey(tokenHash));
-  if (!raw) return;
-  await redis.setex(pendingKey(tokenHash), SSO_PENDING_LINK_TTL_SECONDS, raw);
+  const record = parseRecord(await redis.get(pendingKey(tokenHash)));
+  if (!record) return;
+  await redis.setex(
+    pendingKey(tokenHash),
+    SSO_PENDING_LINK_TTL_SECONDS,
+    JSON.stringify({ ...record, createdAt: Date.now() }),
+  );
 }
 
 /** Hard invalidation (attempt exhaustion, stale-state verdicts). Best-effort. */

--- a/apps/api/src/services/userSession.callers.test.ts
+++ b/apps/api/src/services/userSession.callers.test.ts
@@ -21,6 +21,7 @@ const expectedGuardedIssuerFiles = new Map([
   ['routes/auth/cfAccessRedirectLogin.ts', 1],
   ['routes/auth/ssoLinkCompletion.ts', 1],
   ['routes/sso.ts', 1],
+  ['services/mfaEnrollmentSession.ts', 1],
 ]);
 
 const expectedSingleBoundaryFiles = new Map([
@@ -35,8 +36,9 @@ const expectedSingleBoundaryFiles = new Map([
 const expectedLegacyIssuerFiles = new Map(expectedSingleBoundaryFiles);
 const expectedGuardedCookieInstallerFiles = new Map([
   ...expectedSingleBoundaryFiles,
-  ['routes/auth/mfa.ts', 2],
-  ['routes/auth/passkeys.ts', 2],
+  ['routes/auth/mfa.ts', 4],
+  ['routes/auth/passkeys.ts', 3],
+  ['routes/auth/phone.ts', 1],
   ['routes/sso.ts', 1],
 ]);
 const expectedLegacyCookieInstallerFiles = new Map(expectedSingleBoundaryFiles);

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -28,6 +28,7 @@ import { ApprovalGate } from './ApprovalGate';
 import { OnboardingScreen } from '../screens/onboarding/OnboardingScreen';
 import { Spinner } from '../components/Spinner';
 import { palette } from '../theme';
+import { MfaEnrollmentRequiredScreen } from '../screens/auth/MfaEnrollmentRequiredScreen';
 
 /**
  * Upper bound on how long the native splash may stay up waiting for boot.
@@ -39,7 +40,7 @@ const SPLASH_MAX_HOLD_MS = 4000;
 
 export function RootNavigator() {
   const dispatch = useAppDispatch();
-  const { token, user } = useAppSelector((state) => state.auth);
+  const { token, user, mfaEnrollmentRequired } = useAppSelector((state) => state.auth);
   const [isCheckingAuth, setIsCheckingAuth] = useState(true);
   const [blockedReason, setBlockedReason] = useState<string | null>(null);
   const blockedHandledRef = useRef(false);
@@ -96,7 +97,7 @@ export function RootNavigator() {
   // call started for user A can resolve after A signed out and B signed in,
   // writing A's outcome into B's session.
   useEffect(() => {
-    if (!token || !user) return;
+    if (!token || !user || mfaEnrollmentRequired) return;
     let active = true;
     // #2707 read-and-clear: take the login-minted grant OUT of Redux before the
     // async attempt. The grant is deliberately NOT in this effect's deps — the
@@ -126,7 +127,7 @@ export function RootNavigator() {
     return () => {
       active = false;
     };
-  }, [token, user, dispatch]);
+  }, [token, user, mfaEnrollmentRequired, dispatch]);
 
   useEffect(() => {
     /**
@@ -300,7 +301,9 @@ export function RootNavigator() {
 
   return (
     <NavigationContainer theme={navigationTheme}>
-      {token ? (
+      {mfaEnrollmentRequired ? (
+        <MfaEnrollmentRequiredScreen />
+      ) : token ? (
         hasOnboarded ? (
           <ApprovalGate>
             <MainNavigator />

--- a/apps/mobile/src/screens/auth/MfaChallengeScreen.test.ts
+++ b/apps/mobile/src/screens/auth/MfaChallengeScreen.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { MfaChallenge } from '../../services/api';
+import {
+  getInitialNativeMfaMethod,
+  getSupportedNativeMfaMethods,
+  normalizeNativeMfaInput,
+  normalizeNativeMfaSubmission,
+} from './mfaChallengePresentation';
+
+function challenge(overrides: Partial<MfaChallenge> = {}): MfaChallenge {
+  return {
+    tempToken: 'temp-1',
+    mfaMethod: 'totp',
+    methods: ['totp'],
+    allowedMethods: { totp: true, sms: false, passkey: false },
+    recoveryAvailable: false,
+    phoneLast4: null,
+    ...overrides,
+  };
+}
+
+describe('MfaChallengeScreen presentation contract', () => {
+  it('filters passkey from native choices while keeping recovery', () => {
+    expect(getSupportedNativeMfaMethods(challenge({
+      methods: ['totp', 'sms', 'passkey', 'recovery'],
+    }))).toEqual(['totp', 'sms', 'recovery']);
+  });
+
+  it('returns no initial method for a passkey-only challenge', () => {
+    const value = challenge({
+      mfaMethod: 'passkey',
+      methods: ['passkey'],
+      allowedMethods: { totp: false, sms: false, passkey: true },
+    });
+    expect(getInitialNativeMfaMethod(value)).toBeNull();
+  });
+
+  it('falls back from a passkey primary to the first supported native method', () => {
+    const value = challenge({ mfaMethod: 'passkey', methods: ['passkey', 'recovery'] });
+    expect(getInitialNativeMfaMethod(value)).toBe('recovery');
+  });
+
+  it('keeps only six numeric digits for TOTP and SMS', () => {
+    expect(normalizeNativeMfaInput('totp', '12a34 567')).toBe('123456');
+    expect(normalizeNativeMfaInput('sms', '98-76')).toBe('9876');
+  });
+
+  it('preserves recovery separators and trims only outer whitespace on submit', () => {
+    const raw = '  ABCD EFGH-IJKL  ';
+    expect(normalizeNativeMfaInput('recovery', raw)).toBe(raw);
+    expect(normalizeNativeMfaSubmission('recovery', raw)).toBe('ABCD EFGH-IJKL');
+  });
+});

--- a/apps/mobile/src/screens/auth/MfaChallengeScreen.tsx
+++ b/apps/mobile/src/screens/auth/MfaChallengeScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ComponentRef } from 'react';
+import { useEffect, useMemo, useRef, useState, type ComponentRef } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -17,6 +17,13 @@ import { sendMfaSms } from '../../services/api';
 import { useApprovalTheme, palette, radii, spacing, type } from '../../theme';
 import { Spinner } from '../../components/Spinner';
 import { haptic } from '../../lib/motion';
+import {
+  getInitialNativeMfaMethod,
+  getSupportedNativeMfaMethods,
+  normalizeNativeMfaInput,
+  normalizeNativeMfaSubmission,
+  type NativeMfaMethod,
+} from './mfaChallengePresentation';
 
 const RESEND_COOLDOWN_SECONDS = 30;
 
@@ -29,9 +36,24 @@ export function MfaChallengeScreen() {
   const [smsSent, setSmsSent] = useState(false);
   const [smsError, setSmsError] = useState<string | null>(null);
   const [cooldown, setCooldown] = useState(0);
+  const supportedMethods = useMemo(
+    () => getSupportedNativeMfaMethods(mfaChallenge),
+    [mfaChallenge],
+  );
+  const initialMethod = mfaChallenge
+    ? getInitialNativeMfaMethod(mfaChallenge, supportedMethods) ?? 'totp'
+    : 'totp';
+  const [selectedMethod, setSelectedMethod] = useState<NativeMfaMethod>(initialMethod);
   const inputRef = useRef<ComponentRef<typeof TextInput>>(null);
 
-  const isSms = mfaChallenge?.mfaMethod === 'sms';
+  const isSms = selectedMethod === 'sms';
+  const isRecovery = selectedMethod === 'recovery';
+
+  useEffect(() => {
+    if (!mfaChallenge) return;
+    const next = getInitialNativeMfaMethod(mfaChallenge, supportedMethods);
+    if (next) setSelectedMethod(next);
+  }, [mfaChallenge, supportedMethods]);
 
   useEffect(() => {
     if (!isSms || !mfaChallenge?.tempToken || smsSent) return;
@@ -59,15 +81,31 @@ export function MfaChallengeScreen() {
     return null;
   }
 
+  if (supportedMethods.length === 0) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: theme.bg0 }]}>
+        <View style={styles.scrollContent}>
+          <Text style={[type.title, { color: theme.textHi, textAlign: 'center' }]}>Continue on the web</Text>
+          <Text style={[type.body, { color: theme.textMd, textAlign: 'center', marginTop: spacing[3] }]}>
+            This account requires a passkey, which this version of the mobile app cannot complete. Restart sign-in in a web browser.
+          </Text>
+          <Pressable onPress={handleCancel} style={styles.secondaryButton}>
+            <Text style={[type.bodyMd, { color: theme.textHi }]}>Sign in with a different account</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
   function handleChangeCode(value: string) {
-    const digits = value.replace(/\D/g, '').slice(0, 6);
-    setCode(digits);
+    setCode(normalizeNativeMfaInput(selectedMethod, value));
   }
 
   async function handleVerify() {
-    if (!mfaChallenge || code.length !== 6) return;
+    const submittedCode = normalizeNativeMfaSubmission(selectedMethod, code);
+    if (!mfaChallenge || (isRecovery ? submittedCode.length === 0 : submittedCode.length !== 6)) return;
     haptic.tap();
-    dispatch(verifyMfaAsync({ code, tempToken: mfaChallenge.tempToken }));
+    dispatch(verifyMfaAsync({ code: submittedCode, tempToken: mfaChallenge.tempToken, method: selectedMethod }));
   }
 
   async function handleResend() {
@@ -89,8 +127,10 @@ export function MfaChallengeScreen() {
     dispatch(clearMfaChallenge());
   }
 
-  const canSubmit = code.length === 6 && !isLoading;
-  const subtitle = isSms
+  const canSubmit = (isRecovery ? code.trim().length > 0 : code.length === 6) && !isLoading;
+  const subtitle = isRecovery
+    ? 'Enter one of your recovery codes.'
+    : isSms
     ? mfaChallenge.phoneLast4
       ? `We sent a 6-digit code to the phone ending in ${mfaChallenge.phoneLast4}.`
       : 'We sent a 6-digit code to your phone.'
@@ -133,8 +173,30 @@ export function MfaChallengeScreen() {
               { backgroundColor: theme.bg1, borderColor: theme.border },
             ]}
           >
+            {supportedMethods.length > 1 ? (
+              <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing[2], marginBottom: spacing[4] }}>
+                {supportedMethods.map((method) => (
+                  <Pressable
+                    key={method}
+                    testID={`mfa-method-${method}`}
+                    onPress={() => { setSelectedMethod(method); setCode(''); setSmsError(null); }}
+                    style={{
+                      borderWidth: 1,
+                      borderColor: selectedMethod === method ? theme.brand : theme.border,
+                      borderRadius: radii.md,
+                      paddingHorizontal: spacing[3],
+                      paddingVertical: spacing[2],
+                    }}
+                  >
+                    <Text style={[type.meta, { color: theme.textHi }]}>
+                      {{ totp: 'Authenticator', sms: 'Text message', recovery: 'Recovery code' }[method]}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            ) : null}
             <Text style={[type.metaCaps, { color: theme.textLo }]}>
-              VERIFICATION CODE
+              {isRecovery ? 'RECOVERY CODE' : 'VERIFICATION CODE'}
             </Text>
             <View
               style={[
@@ -146,11 +208,11 @@ export function MfaChallengeScreen() {
                 ref={inputRef}
                 value={code}
                 onChangeText={handleChangeCode}
-                keyboardType="number-pad"
+                keyboardType={isRecovery ? 'default' : 'number-pad'}
                 autoComplete="one-time-code"
                 textContentType="oneTimeCode"
-                maxLength={6}
-                placeholder="123456"
+                maxLength={isRecovery ? 64 : 6}
+                placeholder={isRecovery ? 'ABCD-1234' : '123456'}
                 placeholderTextColor={theme.textLo}
                 onSubmitEditing={handleVerify}
                 returnKeyType="go"
@@ -162,7 +224,7 @@ export function MfaChallengeScreen() {
                     minHeight: 48,
                     flex: 1,
                     fontSize: 22,
-                    letterSpacing: 6,
+                    letterSpacing: isRecovery ? 1 : 6,
                     textAlign: 'center',
                   },
                 ]}

--- a/apps/mobile/src/screens/auth/MfaEnrollmentRequiredScreen.test.ts
+++ b/apps/mobile/src/screens/auth/MfaEnrollmentRequiredScreen.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { buildMfaEnrollmentUrl } from './mfaEnrollmentHandoff';
+
+describe('MfaEnrollmentRequiredScreen handoff', () => {
+  it('builds the configured same-server enrollment URL', () => {
+    expect(buildMfaEnrollmentUrl('https://breeze.example.test/', '/auth/mfa/setup'))
+      .toBe('https://breeze.example.test/auth/mfa/setup');
+  });
+
+  it.each([
+    ['javascript:alert(1)', '/auth/mfa/setup'],
+    ['https://breeze.example.test', 'https://evil.example/setup'],
+    ['https://breeze.example.test', '//evil.example/setup'],
+  ])('rejects an unsafe handoff (%s, %s)', (server, path) => {
+    expect(buildMfaEnrollmentUrl(server, path)).toBeNull();
+  });
+});

--- a/apps/mobile/src/screens/auth/MfaEnrollmentRequiredScreen.tsx
+++ b/apps/mobile/src/screens/auth/MfaEnrollmentRequiredScreen.tsx
@@ -24,7 +24,7 @@ export function MfaEnrollmentRequiredScreen() {
     <SafeAreaView style={[styles.container, { backgroundColor: theme.bg0 }]}>
       <View style={[styles.card, { backgroundColor: theme.bg1, borderColor: theme.border }]}>
         <Text style={[type.title, { color: theme.textHi, textAlign: 'center' }]}>MFA setup required</Text>
-        <Text style={[type.body, { color: theme.textMd, textAlign: 'center' }]}> 
+        <Text style={[type.body, { color: theme.textMd, textAlign: 'center' }]}>
           Your administrator requires multi-factor authentication. Complete setup in a web browser before using the mobile app.
         </Text>
         <Pressable testID="mfa-enrollment-open-web" onPress={() => { void openWebEnrollment(); }} style={[styles.primary, { backgroundColor: theme.brand }]}>

--- a/apps/mobile/src/screens/auth/MfaEnrollmentRequiredScreen.tsx
+++ b/apps/mobile/src/screens/auth/MfaEnrollmentRequiredScreen.tsx
@@ -1,0 +1,47 @@
+import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAppDispatch, useAppSelector } from '../../store';
+import { logout } from '../../store/authSlice';
+import { getServerUrl } from '../../services/serverConfig';
+import { palette, radii, spacing, type, useApprovalTheme } from '../../theme';
+import { buildMfaEnrollmentUrl } from './mfaEnrollmentHandoff';
+
+export function MfaEnrollmentRequiredScreen() {
+  const theme = useApprovalTheme('dark');
+  const dispatch = useAppDispatch();
+  const handoff = useAppSelector((state) => state.auth.mfaEnrollmentRequired);
+  if (!handoff) return null;
+
+  async function openWebEnrollment() {
+    const server = await getServerUrl();
+    if (!server) return;
+    const url = buildMfaEnrollmentUrl(server, handoff!.enrollUrl);
+    if (!url) return;
+    await Linking.openURL(url);
+  }
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: theme.bg0 }]}>
+      <View style={[styles.card, { backgroundColor: theme.bg1, borderColor: theme.border }]}>
+        <Text style={[type.title, { color: theme.textHi, textAlign: 'center' }]}>MFA setup required</Text>
+        <Text style={[type.body, { color: theme.textMd, textAlign: 'center' }]}> 
+          Your administrator requires multi-factor authentication. Complete setup in a web browser before using the mobile app.
+        </Text>
+        <Pressable testID="mfa-enrollment-open-web" onPress={() => { void openWebEnrollment(); }} style={[styles.primary, { backgroundColor: theme.brand }]}>
+          <Text style={[type.bodyMd, { color: palette.dark.textHi }]}>Open web setup</Text>
+        </Pressable>
+        <Pressable testID="mfa-enrollment-sign-out" onPress={() => dispatch(logout())} style={[styles.secondary, { borderColor: theme.border }]}>
+          <Text style={[type.bodyMd, { color: theme.textHi }]}>Sign out</Text>
+        </Pressable>
+        <Text style={[type.meta, { color: theme.textLo, textAlign: 'center' }]}>If setup is unavailable, contact your administrator.</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: spacing[5] },
+  card: { borderWidth: 1, borderRadius: radii.lg, padding: spacing[5], gap: spacing[4] },
+  primary: { minHeight: 48, borderRadius: radii.md, alignItems: 'center', justifyContent: 'center' },
+  secondary: { minHeight: 48, borderWidth: 1, borderRadius: radii.md, alignItems: 'center', justifyContent: 'center' },
+});

--- a/apps/mobile/src/screens/auth/mfaChallengePresentation.ts
+++ b/apps/mobile/src/screens/auth/mfaChallengePresentation.ts
@@ -1,0 +1,28 @@
+import type { MfaChallenge, MfaMethod } from '../../services/api';
+
+export type NativeMfaMethod = Exclude<MfaMethod, 'passkey'>;
+
+export function getSupportedNativeMfaMethods(
+  challenge: MfaChallenge | null | undefined,
+): NativeMfaMethod[] {
+  return (challenge?.methods ?? []).filter(
+    (method): method is NativeMfaMethod => method !== 'passkey',
+  );
+}
+
+export function getInitialNativeMfaMethod(
+  challenge: MfaChallenge,
+  supported = getSupportedNativeMfaMethods(challenge),
+): NativeMfaMethod | null {
+  return challenge.mfaMethod !== 'passkey'
+    ? challenge.mfaMethod
+    : supported[0] ?? null;
+}
+
+export function normalizeNativeMfaInput(method: NativeMfaMethod, value: string): string {
+  return method === 'recovery' ? value : value.replace(/\D/g, '').slice(0, 6);
+}
+
+export function normalizeNativeMfaSubmission(method: NativeMfaMethod, value: string): string {
+  return method === 'recovery' ? value.trim() : value;
+}

--- a/apps/mobile/src/screens/auth/mfaEnrollmentHandoff.ts
+++ b/apps/mobile/src/screens/auth/mfaEnrollmentHandoff.ts
@@ -1,0 +1,6 @@
+export function buildMfaEnrollmentUrl(serverUrl: string, enrollUrl: string): string | null {
+  if (!/^https?:\/\//i.test(serverUrl) || !enrollUrl.startsWith('/') || enrollUrl.startsWith('//')) {
+    return null;
+  }
+  return `${serverUrl.replace(/\/$/, '')}${enrollUrl}`;
+}

--- a/apps/mobile/src/services/api.logout.test.ts
+++ b/apps/mobile/src/services/api.logout.test.ts
@@ -76,7 +76,7 @@ describe('native logout generation fencing', () => {
       throw new Error(`stale issuer was sent: ${url}`);
     });
 
-    const staleMfa = verifyMfa('123456', 'temp-old');
+    const staleMfa = verifyMfa('123456', 'temp-old', 'totp');
     await vi.waitFor(() => expect(serverConfig.getServerUrl).toHaveBeenCalledTimes(1));
     await logout();
     releaseServerUrl('https://api.example.test');
@@ -105,7 +105,7 @@ describe('native logout generation fencing', () => {
       }))
       .mockResolvedValueOnce(response(204));
 
-    const staleMfa = verifyMfa('123456', 'temp-old');
+    const staleMfa = verifyMfa('123456', 'temp-old', 'totp');
     await writeStarted;
     const logoutRequest = logout();
     releaseBindingWrite();
@@ -132,10 +132,10 @@ describe('native logout generation fencing', () => {
       throw new Error(`unexpected request ${url}`);
     });
 
-    const staleA = verifyMfa('123456', 'temp-a');
+    const staleA = verifyMfa('123456', 'temp-a', 'totp');
     await vi.waitFor(() => expect(fetchWithTimeout).toHaveBeenCalledTimes(1));
     await logout();
-    await expect(verifyMfa('654321', 'temp-b')).resolves.toMatchObject({ token: 'access-b' });
+    await expect(verifyMfa('654321', 'temp-b', 'totp')).resolves.toMatchObject({ token: 'access-b' });
     releaseA(response(403, { error: 'CSRF token mismatch' }));
 
     await expect(staleA).rejects.toMatchObject({ code: 'session_superseded' });
@@ -163,7 +163,7 @@ describe('native logout generation fencing', () => {
       throw new Error(`unexpected request ${url}`);
     });
 
-    const staleMfa = verifyMfa('123456', 'temp-old');
+    const staleMfa = verifyMfa('123456', 'temp-old', 'totp');
     await vi.waitFor(() => expect(fetchWithTimeout).toHaveBeenCalledTimes(1));
     await logout();
     releaseMfa(new Response(JSON.stringify({ error: 'binding required' }), {

--- a/apps/mobile/src/services/api.mfa.test.ts
+++ b/apps/mobile/src/services/api.mfa.test.ts
@@ -25,8 +25,10 @@ vi.mock('./csrfToken', () => ({
 }));
 
 import {
+  login,
   NATIVE_AUTH_BINDING_KEY,
   NATIVE_AUTH_BINDING_HEADER,
+  parseMfaChallengePayload,
   verifyMfa,
 } from './api';
 
@@ -62,7 +64,7 @@ describe('native MFA transition transport', () => {
         tokens: { accessToken: 'access-1' },
       }));
 
-    await expect(verifyMfa('123456', 'temp-1')).resolves.toMatchObject({ token: 'access-1' });
+    await expect(verifyMfa('123456', 'temp-1', 'totp')).resolves.toMatchObject({ token: 'access-1' });
 
     expect(fetchWithTimeout).toHaveBeenCalledTimes(2);
     expect(requestHeaders(0)).toMatchObject({
@@ -81,7 +83,7 @@ describe('native MFA transition transport', () => {
       tokens: { accessToken: 'access-2' },
     }));
 
-    await verifyMfa('123456', 'temp-2');
+    await verifyMfa('123456', 'temp-2', 'totp');
 
     expect(fetchWithTimeout).toHaveBeenCalledTimes(1);
     expect(requestHeaders(0)).toMatchObject({
@@ -100,9 +102,79 @@ describe('native MFA transition transport', () => {
         [NATIVE_AUTH_BINDING_HEADER]: 'c'.repeat(64),
       }));
 
-    await expect(verifyMfa('123456', 'temp-3')).rejects.toMatchObject({ statusCode: 428 });
+    await expect(verifyMfa('123456', 'temp-3', 'totp')).rejects.toMatchObject({ statusCode: 428 });
 
     expect(fetchWithTimeout).toHaveBeenCalledTimes(2);
     expect(secureValues.get(NATIVE_AUTH_BINDING_KEY)).toBe(replacement);
+  });
+});
+
+describe('mobile MFA response contracts', () => {
+  it('normalizes the strict challenge contract including passkey and recovery', () => {
+    expect(parseMfaChallengePayload({
+      mfaRequired: true,
+      tempToken: 'temp-1',
+      mfaMethod: 'passkey',
+      allowedMethods: { totp: true, sms: false, passkey: true },
+      recoveryAvailable: true,
+      passkeyAvailable: true,
+    })).toEqual({
+      tempToken: 'temp-1',
+      mfaMethod: 'passkey',
+      methods: ['totp', 'passkey', 'recovery'],
+      allowedMethods: { totp: true, sms: false, passkey: true },
+      recoveryAvailable: true,
+      phoneLast4: null,
+    });
+  });
+
+  it('fails closed when strict challenge aliases disagree', () => {
+    expect(parseMfaChallengePayload({
+      tempToken: 'temp-1',
+      mfaMethod: 'totp',
+      methods: ['totp'],
+      allowedMethods: ['sms'],
+      recoveryAvailable: false,
+    })).toBeNull();
+  });
+
+  it('keeps legacy challenges compatible only when both method lists are absent', () => {
+    expect(parseMfaChallengePayload({ mfaRequired: true, tempToken: 'temp-1', mfaMethod: 'sms' })).toEqual({
+      tempToken: 'temp-1',
+      mfaMethod: 'sms',
+      methods: ['sms'],
+      allowedMethods: { totp: false, sms: true, passkey: false },
+      recoveryAvailable: false,
+      phoneLast4: null,
+    });
+  });
+
+  it('treats enrollment-required as unauthenticated even if tokens are present', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(response(200, {
+      mfaEnrollmentRequired: true,
+      enrollUrl: '/auth/mfa/setup',
+      user,
+      tokens: { accessToken: 'must-not-be-used' },
+    }));
+
+    await expect(login('tech@example.test', 'pw')).resolves.toEqual({
+      kind: 'mfaEnrollmentRequired',
+      handoff: { reason: 'mfa_enrollment_required', enrollUrl: '/auth/mfa/setup' },
+    });
+  });
+
+  it('sends the selected method and preserves recovery-code separators', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(response(200, {
+      user,
+      tokens: { accessToken: 'access-recovery' },
+    }));
+
+    await verifyMfa('ABCD EFGH-IJKL', 'temp-recovery', 'recovery');
+
+    expect(JSON.parse(String(fetchWithTimeout.mock.calls[0]![1].body))).toEqual({
+      code: 'ABCD EFGH-IJKL',
+      tempToken: 'temp-recovery',
+      method: 'recovery',
+    });
   });
 });

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -121,17 +121,33 @@ export interface LoginResponse {
   registerGrant: string | null;
 }
 
-export type MfaMethod = 'totp' | 'sms';
+export type MfaMethod = 'totp' | 'sms' | 'passkey' | 'recovery';
+export type MfaPrimaryMethod = Exclude<MfaMethod, 'recovery'>;
+
+export interface MfaAllowedMethods {
+  totp: boolean;
+  sms: boolean;
+  passkey: boolean;
+}
 
 export interface MfaChallenge {
   tempToken: string;
   mfaMethod: MfaMethod;
+  methods: MfaMethod[];
+  allowedMethods: MfaAllowedMethods;
+  recoveryAvailable: boolean;
   phoneLast4: string | null;
+}
+
+export interface MfaEnrollmentRequired {
+  reason: 'mfa_enrollment_required';
+  enrollUrl: string;
 }
 
 export type LoginResult =
   | { kind: 'success'; token: string; user: User; registerGrant: string | null }
-  | { kind: 'mfaRequired'; challenge: MfaChallenge };
+  | { kind: 'mfaRequired'; challenge: MfaChallenge }
+  | { kind: 'mfaEnrollmentRequired'; handoff: MfaEnrollmentRequired };
 
 export interface ApiError {
   message: string;
@@ -162,10 +178,79 @@ interface LoginPayload {
   mfaRequired?: boolean;
   tempToken?: string;
   mfaMethod?: MfaMethod;
+  allowedMethods?: MfaAllowedMethods;
+  recoveryAvailable?: boolean;
+  passkeyAvailable?: boolean;
   phoneLast4?: string | null;
+  mfaEnrollmentRequired?: boolean;
+  enrollUrl?: string;
   error?: string;
   /** #2707: single-use approver-register grant; mobile-header-gated. */
   authenticatorRegisterGrantId?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPrimaryMfaMethod(value: unknown): value is MfaPrimaryMethod {
+  return value === 'totp' || value === 'sms' || value === 'passkey';
+}
+
+export function parseMfaChallengePayload(value: unknown): MfaChallenge | null {
+  if (
+    !isRecord(value)
+    || value.mfaRequired !== true
+    || typeof value.tempToken !== 'string'
+    || !value.tempToken
+    || !isPrimaryMfaMethod(value.mfaMethod)
+  ) {
+    return null;
+  }
+  const phoneLast4 = value.phoneLast4 === undefined || value.phoneLast4 === null
+    ? null
+    : typeof value.phoneLast4 === 'string' ? value.phoneLast4 : undefined;
+  if (phoneLast4 === undefined) return null;
+  const hasAllowed = Object.prototype.hasOwnProperty.call(value, 'allowedMethods');
+  const hasRecovery = Object.prototype.hasOwnProperty.call(value, 'recoveryAvailable');
+  if (hasAllowed !== hasRecovery) return null;
+
+  if (!hasAllowed) {
+    if (value.passkeyAvailable !== undefined && typeof value.passkeyAvailable !== 'boolean') return null;
+    const allowedMethods: MfaAllowedMethods = {
+      totp: value.mfaMethod === 'totp',
+      sms: value.mfaMethod === 'sms',
+      passkey: value.mfaMethod === 'passkey' || value.passkeyAvailable === true,
+    };
+    const methods: MfaMethod[] = [
+      ...(allowedMethods.totp ? ['totp' as const] : []),
+      ...(allowedMethods.sms ? ['sms' as const] : []),
+      ...(allowedMethods.passkey ? ['passkey' as const] : []),
+    ];
+    return { tempToken: value.tempToken, mfaMethod: value.mfaMethod, methods, allowedMethods, recoveryAvailable: false, phoneLast4 };
+  }
+
+  const allowed = value.allowedMethods;
+  if (
+    !isRecord(allowed)
+    || typeof allowed.totp !== 'boolean'
+    || typeof allowed.sms !== 'boolean'
+    || typeof allowed.passkey !== 'boolean'
+    || typeof value.recoveryAvailable !== 'boolean'
+    || typeof value.passkeyAvailable !== 'boolean'
+    || value.passkeyAvailable !== allowed.passkey
+  ) return null;
+  const allowedMethods = { totp: allowed.totp, sms: allowed.sms, passkey: allowed.passkey };
+  const methods: MfaMethod[] = [
+    ...(allowedMethods.totp ? ['totp' as const] : []),
+    ...(allowedMethods.sms ? ['sms' as const] : []),
+    ...(allowedMethods.passkey ? ['passkey' as const] : []),
+    ...(value.recoveryAvailable ? ['recovery' as const] : []),
+  ];
+  if (methods.length === 0) return null;
+  const mfaMethod = allowedMethods[value.mfaMethod] ? value.mfaMethod : methods[0];
+  if (!mfaMethod) return null;
+  return { tempToken: value.tempToken, mfaMethod, methods, allowedMethods, recoveryAvailable: value.recoveryAvailable, phoneLast4 };
 }
 
 type MobileAlertRecord = {
@@ -438,18 +523,26 @@ export async function login(email: string, password: string): Promise<LoginResul
     body: JSON.stringify({ email, password }),
   });
 
-  if (response.mfaRequired) {
-    if (!response.tempToken || !response.mfaMethod) {
-      throw { message: 'Invalid MFA challenge from server' } as ApiError;
-    }
+  // Fail closed even if a server accidentally includes tempting user/token
+  // fields: enrollment-required is a handoff state, never authentication.
+  if (response.mfaEnrollmentRequired === true) {
     return {
-      kind: 'mfaRequired',
-      challenge: {
-        tempToken: response.tempToken,
-        mfaMethod: response.mfaMethod,
-        phoneLast4: response.phoneLast4 ?? null,
+      kind: 'mfaEnrollmentRequired',
+      handoff: {
+        reason: 'mfa_enrollment_required',
+        enrollUrl: typeof response.enrollUrl === 'string' && response.enrollUrl.startsWith('/')
+          ? response.enrollUrl
+          : '/auth/mfa/setup',
       },
     };
+  }
+
+  if (response.mfaRequired) {
+    const challenge = parseMfaChallengePayload(response);
+    if (!challenge) {
+      throw { message: 'Invalid MFA challenge from server' } as ApiError;
+    }
+    return { kind: 'mfaRequired', challenge };
   }
 
   const token = response.tokens?.accessToken || response.accessToken;
@@ -465,10 +558,14 @@ export async function login(email: string, password: string): Promise<LoginResul
   };
 }
 
-export async function verifyMfa(code: string, tempToken: string): Promise<LoginResponse> {
+export async function verifyMfa(
+  code: string,
+  tempToken: string,
+  method: Exclude<MfaMethod, 'passkey'>,
+): Promise<LoginResponse> {
   const response = await requestWithPrefix<LoginPayload>('/auth/mfa/verify', API_CORE_PREFIX, {
     method: 'POST',
-    body: JSON.stringify({ code, tempToken }),
+    body: JSON.stringify({ code, tempToken, method }),
   });
 
   const token = response.tokens?.accessToken || response.accessToken;

--- a/apps/mobile/src/store/authSlice.test.ts
+++ b/apps/mobile/src/store/authSlice.test.ts
@@ -137,6 +137,30 @@ describe('interactive sign-in stamps the app lock as unlocked', () => {
     expect(appLock.markAppLockUnlocked).not.toHaveBeenCalled();
   });
 
+  it('loginAsync stores enrollment handoff without credentials or an unlock stamp', async () => {
+    api.login.mockResolvedValue({
+      kind: 'mfaEnrollmentRequired',
+      handoff: { reason: 'mfa_enrollment_required', enrollUrl: '/auth/mfa/setup' },
+    });
+    const store = makeStore();
+
+    const result = await store.dispatch(loginAsync({ email: fakeUser.email, password: 'pw' }));
+
+    expect(result.type).toBe('auth/login/fulfilled');
+    expect(store.getState().auth).toMatchObject({
+      token: null,
+      user: null,
+      mfaChallenge: null,
+      mfaEnrollmentRequired: {
+        reason: 'mfa_enrollment_required',
+        enrollUrl: '/auth/mfa/setup',
+      },
+    });
+    expect(auth.storeToken).not.toHaveBeenCalled();
+    expect(auth.storeUser).not.toHaveBeenCalled();
+    expect(appLock.markAppLockUnlocked).not.toHaveBeenCalled();
+  });
+
   it('loginAsync does NOT mark unlocked when the API rejects', async () => {
     api.login.mockRejectedValue({ message: 'bad credentials' });
     const store = makeStore();
@@ -150,9 +174,10 @@ describe('interactive sign-in stamps the app lock as unlocked', () => {
     api.verifyMfa.mockResolvedValue({ token: 'tok-2', user: fakeUser });
     const store = makeStore();
 
-    const result = await store.dispatch(verifyMfaAsync({ code: '123456', tempToken: 'tmp' }));
+    const result = await store.dispatch(verifyMfaAsync({ code: '123456', tempToken: 'tmp', method: 'totp' }));
 
     expect(result.type).toBe('auth/verifyMfa/fulfilled');
+    expect(api.verifyMfa).toHaveBeenCalledWith('123456', 'tmp', 'totp');
     expect(appLock.markAppLockUnlocked).toHaveBeenCalledTimes(1);
     expect(auth.storeToken).toHaveBeenCalledWith('tok-2');
   });
@@ -161,7 +186,7 @@ describe('interactive sign-in stamps the app lock as unlocked', () => {
     api.verifyMfa.mockRejectedValue({ message: 'invalid code' });
     const store = makeStore();
 
-    await store.dispatch(verifyMfaAsync({ code: '000000', tempToken: 'tmp' }));
+    await store.dispatch(verifyMfaAsync({ code: '000000', tempToken: 'tmp', method: 'totp' }));
 
     expect(appLock.markAppLockUnlocked).not.toHaveBeenCalled();
   });
@@ -255,7 +280,7 @@ describe('logoutAsync', () => {
     let releaseMfa!: (value: unknown) => void;
     api.verifyMfa.mockImplementation(() => new Promise((resolve) => { releaseMfa = resolve; }));
     const store = makeStore();
-    const staleMfa = store.dispatch(verifyMfaAsync({ code: '123456', tempToken: 'temp-old' }));
+    const staleMfa = store.dispatch(verifyMfaAsync({ code: '123456', tempToken: 'temp-old', method: 'totp' }));
     await vi.waitFor(() => expect(api.verifyMfa).toHaveBeenCalledTimes(1));
 
     await store.dispatch(logoutAsync());
@@ -265,6 +290,25 @@ describe('logoutAsync', () => {
     expect(auth.storeToken).not.toHaveBeenCalled();
     expect(auth.storeUser).not.toHaveBeenCalled();
     expect(store.getState().auth.token).toBeNull();
+  });
+
+  it('fences a delayed enrollment handoff after logout', async () => {
+    let releaseLogin!: (value: unknown) => void;
+    api.login.mockImplementation(() => new Promise((resolve) => { releaseLogin = resolve; }));
+    const store = makeStore();
+    const staleLogin = store.dispatch(loginAsync({ email: fakeUser.email, password: 'pw' }));
+    await vi.waitFor(() => expect(api.login).toHaveBeenCalledTimes(1));
+
+    await store.dispatch(logoutAsync());
+    releaseLogin({
+      kind: 'mfaEnrollmentRequired',
+      handoff: { reason: 'mfa_enrollment_required', enrollUrl: '/auth/mfa/setup' },
+    });
+    await staleLogin;
+
+    expect(store.getState().auth.mfaEnrollmentRequired).toBeNull();
+    expect(store.getState().auth.token).toBeNull();
+    expect(store.getState().auth.user).toBeNull();
   });
 
   it('API ok + wipe ok → fulfilled, wipe runs exactly once', async () => {
@@ -395,7 +439,7 @@ describe('authenticatorRegisterGrantId (#2707)', () => {
 
   it('verifyMfaAsync.fulfilled stores the grant; logout clears it', () => {
     let state = authReducer(undefined, verifyMfaAsync.fulfilled(
-      { token: 't', user: fakeUser, registerGrant: 'grant-2' } as any, '', { code: '123456', tempToken: 'tmp' }
+      { token: 't', user: fakeUser, registerGrant: 'grant-2' } as any, '', { code: '123456', tempToken: 'tmp', method: 'totp' }
     ));
     expect(state.authenticatorRegisterGrantId).toBe('grant-2');
     state = authReducer(state, logout());

--- a/apps/mobile/src/store/authSlice.ts
+++ b/apps/mobile/src/store/authSlice.ts
@@ -6,6 +6,8 @@ import {
   logout as apiLogout,
   verifyMfa as apiVerifyMfa,
   type MfaChallenge,
+  type MfaEnrollmentRequired,
+  type MfaMethod,
   type User,
 } from '../services/api';
 import { storeToken, storeUser } from '../services/auth';
@@ -37,6 +39,7 @@ interface AuthState {
   isLoading: boolean;
   error: string | null;
   mfaChallenge: MfaChallenge | null;
+  mfaEnrollmentRequired: MfaEnrollmentRequired | null;
   pushRegistration: PushRegistrationStatus;
   pushRegistrationReason: string | null;
   approverRegistration: ApproverRegistrationStatus;
@@ -56,6 +59,7 @@ const initialState: AuthState = {
   isLoading: false,
   error: null,
   mfaChallenge: null,
+  mfaEnrollmentRequired: null,
   pushRegistration: 'idle',
   pushRegistrationReason: null,
   approverRegistration: 'idle',
@@ -73,6 +77,10 @@ export const loginAsync = createAsyncThunk(
       if (result.kind === 'mfaRequired') {
         const committed = await commitIfCurrent(generation, async () => result.challenge);
         return committed === undefined ? { superseded: true as const } : { mfa: committed };
+      }
+      if (result.kind === 'mfaEnrollmentRequired') {
+        const committed = await commitIfCurrent(generation, async () => result.handoff);
+        return committed === undefined ? { superseded: true as const } : { enrollment: committed };
       }
 
       const committed = await commitIfCurrent(generation, async () => {
@@ -95,10 +103,14 @@ export const loginAsync = createAsyncThunk(
 
 export const verifyMfaAsync = createAsyncThunk(
   'auth/verifyMfa',
-  async ({ code, tempToken }: { code: string; tempToken: string }, { rejectWithValue }) => {
+  async ({ code, tempToken, method }: {
+    code: string;
+    tempToken: string;
+    method: Exclude<MfaMethod, 'passkey'>;
+  }, { rejectWithValue }) => {
     const generation = currentSessionGeneration();
     try {
-      const response = await apiVerifyMfa(code, tempToken);
+      const response = await apiVerifyMfa(code, tempToken, method);
       const committed = await commitIfCurrent(generation, async () => {
         await storeToken(response.token);
         await storeUser(response.user);
@@ -180,6 +192,7 @@ const authSlice = createSlice({
       state.isLoading = false;
       state.error = null;
       state.mfaChallenge = null;
+      state.mfaEnrollmentRequired = null;
     },
     logout: (state) => {
       state.user = null;
@@ -187,6 +200,7 @@ const authSlice = createSlice({
       state.isLoading = false;
       state.error = null;
       state.mfaChallenge = null;
+      state.mfaEnrollmentRequired = null;
       // Approver registration is per-user, not per-device: leaving it set would
       // show the next user on this phone the previous user's banner.
       state.approverRegistration = 'idle';
@@ -228,6 +242,7 @@ const authSlice = createSlice({
       .addCase(loginAsync.pending, (state) => {
         state.isLoading = true;
         state.error = null;
+        state.mfaEnrollmentRequired = null;
       })
       .addCase(loginAsync.fulfilled, (state, action) => {
         state.isLoading = false;
@@ -237,10 +252,18 @@ const authSlice = createSlice({
           state.mfaChallenge = action.payload.mfa;
           return;
         }
+        if ('enrollment' in action.payload && action.payload.enrollment) {
+          state.user = null;
+          state.token = null;
+          state.mfaChallenge = null;
+          state.mfaEnrollmentRequired = action.payload.enrollment;
+          return;
+        }
         if ('token' in action.payload && 'user' in action.payload) {
           state.token = action.payload.token;
           state.user = action.payload.user;
           state.mfaChallenge = null;
+          state.mfaEnrollmentRequired = null;
           state.authenticatorRegisterGrantId = action.payload.registerGrant ?? null;
         }
       })
@@ -259,6 +282,7 @@ const authSlice = createSlice({
         state.user = action.payload.user;
         state.error = null;
         state.mfaChallenge = null;
+        state.mfaEnrollmentRequired = null;
         state.authenticatorRegisterGrantId = action.payload.registerGrant ?? null;
       })
       .addCase(verifyMfaAsync.rejected, (state, action) => {
@@ -274,6 +298,7 @@ const authSlice = createSlice({
         state.isLoading = false;
         state.error = null;
         state.mfaChallenge = null;
+        state.mfaEnrollmentRequired = null;
         // Reset push status too — leaving the previous account's 'ok'/'failed'
         // behind briefly shows stale copy in Settings after the next sign-in.
         state.pushRegistration = 'idle';
@@ -288,6 +313,7 @@ const authSlice = createSlice({
         state.isLoading = false;
         state.error = null;
         state.mfaChallenge = null;
+        state.mfaEnrollmentRequired = null;
         state.pushRegistration = 'idle';
         state.pushRegistrationReason = null;
         state.approverRegistration = 'idle';

--- a/apps/web/src/components/auth/ConnectSsoLoginPage.test.tsx
+++ b/apps/web/src/components/auth/ConnectSsoLoginPage.test.tsx
@@ -79,10 +79,14 @@ describe('ConnectSsoLoginPage (#4067)', () => {
   it('hands off to the MFA step when confirm returns mfaRequired, then completes via mfa verify', async () => {
     vi.mocked(apiSsoLinkConfirm).mockResolvedValue({
       state: 'mfa',
-      tempToken: 'temp-1',
-      mfaMethod: 'totp',
-      passkeyAvailable: false,
-      phoneLast4: null,
+      challenge: {
+        tempToken: 'temp-1',
+        primary: 'totp',
+        methods: ['totp'],
+        allowedMethods: { totp: true, sms: false, passkey: false },
+        recoveryAvailable: false,
+        phoneLast4: null,
+      },
     });
     vi.mocked(apiVerifyMFA).mockResolvedValue({
       success: true,

--- a/apps/web/src/components/auth/ConnectSsoLoginPage.tsx
+++ b/apps/web/src/components/auth/ConnectSsoLoginPage.tsx
@@ -10,7 +10,7 @@ import {
   apiSendSmsMfaCode,
   fetchAndApplyPreferences
 } from '../../stores/auth';
-import type { MfaMethod } from '../../stores/auth';
+import type { MfaChallenge, MfaMethod } from '../../stores/auth';
 import { navigateTo } from '../../lib/navigation';
 // Initializes the shared i18next singleton (this page's layout has no Sidebar).
 import '../../lib/i18n';
@@ -40,10 +40,8 @@ export default function ConnectSsoLoginPage() {
   const [loading, setLoading] = useState(false);
 
   const [mfaRequired, setMfaRequired] = useState(false);
-  const [tempToken, setTempToken] = useState<string>();
+  const [mfaChallenge, setMfaChallenge] = useState<MfaChallenge>();
   const [mfaMethod, setMfaMethod] = useState<MfaMethod>('totp');
-  const [passkeyAvailable, setPasskeyAvailable] = useState(false);
-  const [phoneLast4, setPhoneLast4] = useState<string>();
   const [smsSending, setSmsSending] = useState(false);
   const [smsSent, setSmsSent] = useState(false);
 
@@ -114,10 +112,8 @@ export default function ConnectSsoLoginPage() {
         return;
       case 'mfa':
         setMfaRequired(true);
-        setTempToken(result.tempToken);
-        setMfaMethod(result.mfaMethod);
-        setPasskeyAvailable(result.passkeyAvailable);
-        setPhoneLast4(result.phoneLast4 ?? undefined);
+        setMfaChallenge(result.challenge);
+        setMfaMethod(result.challenge.primary);
         setSmsSent(false);
         setLoading(false);
         return;
@@ -129,11 +125,11 @@ export default function ConnectSsoLoginPage() {
   };
 
   const handleMfaVerify = async (code: string) => {
-    if (!tempToken) return;
+    if (!mfaChallenge || mfaMethod === 'passkey') return;
     setLoading(true);
     setError(undefined);
 
-    const result = await apiVerifyMFA(code, tempToken, mfaMethod);
+    const result = await apiVerifyMFA(code, mfaChallenge.tempToken, mfaMethod);
     if (!result.success) {
       if (result.error === 'sso_link_expired') {
         // The factor was fine — the ceremony died underneath it. Retrying the
@@ -154,11 +150,11 @@ export default function ConnectSsoLoginPage() {
   };
 
   const handlePasskeyMfaVerify = async () => {
-    if (!tempToken) return;
+    if (!mfaChallenge) return;
     setLoading(true);
     setError(undefined);
 
-    const result = await apiVerifyPasskeyMFA(tempToken);
+    const result = await apiVerifyPasskeyMFA(mfaChallenge.tempToken);
     if (!result.success) {
       if (result.error === 'sso_link_expired') {
         setExpired(true);
@@ -177,16 +173,19 @@ export default function ConnectSsoLoginPage() {
   };
 
   const handleSendSmsCode = async () => {
-    if (!tempToken) return;
+    if (!mfaChallenge) return false;
     setSmsSending(true);
     setError(undefined);
-    const result = await apiSendSmsMfaCode(tempToken);
+    const result = await apiSendSmsMfaCode(mfaChallenge.tempToken);
     if (!result.success) {
       setError(result.error);
+      setSmsSending(false);
+      return false;
     } else {
       setSmsSent(true);
     }
     setSmsSending(false);
+    return true;
   };
 
   if (checking) {
@@ -255,8 +254,10 @@ export default function ConnectSsoLoginPage() {
           errorMessage={error}
           loading={loading}
           mfaMethod={mfaMethod}
-          passkeyAvailable={passkeyAvailable}
-          phoneLast4={phoneLast4}
+          methods={mfaChallenge?.methods}
+          onMethodChange={setMfaMethod}
+          passkeyAvailable={mfaChallenge?.allowedMethods.passkey}
+          phoneLast4={mfaChallenge?.phoneLast4 ?? undefined}
           onSendSmsCode={handleSendSmsCode}
           smsSending={smsSending}
           smsSent={smsSent}

--- a/apps/web/src/components/auth/ForcedMfaSetupPage.test.tsx
+++ b/apps/web/src/components/auth/ForcedMfaSetupPage.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const commitMfaEnrollmentIfCurrent = vi.fn();
+const authState = {
+  commitMfaEnrollmentIfCurrent,
+  isAuthenticated: true,
+  tokens: { accessToken: 'existing', expiresInSeconds: 900 },
+  user: { id: 'user-1', email: 'user@example.com', name: 'User', mfaEnabled: false },
+  sessionGeneration: 1,
+};
+
+vi.mock('../../stores/auth', () => ({
+  AuthSessionExpiredError: class AuthSessionExpiredError extends Error {},
+  AuthThrottledError: class AuthThrottledError extends Error {},
+  apiEnableSmsMfa: vi.fn(),
+  apiEnableTotpMfa: vi.fn(),
+  apiEnrollPasskey: vi.fn(),
+  apiGetMfaEnrollmentOptions: vi.fn(),
+  fetchWithAuth: vi.fn(),
+  restoreAccessTokenFromCookie: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (state: typeof authState) => unknown) => selector(authState),
+    { getState: () => authState },
+  ),
+}));
+
+vi.mock('../../lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+vi.mock('./MFASetupForm', () => ({
+  default: ({ onSubmit }: { onSubmit: (code: string) => void }) => (
+    <button data-testid="confirm-totp" onClick={() => onSubmit('123456')}>Confirm TOTP</button>
+  ),
+}));
+
+import ForcedMfaSetupPage from './ForcedMfaSetupPage';
+import {
+  apiEnableSmsMfa,
+  apiEnableTotpMfa,
+  apiEnrollPasskey,
+  apiGetMfaEnrollmentOptions,
+  fetchWithAuth,
+} from '../../stores/auth';
+import { navigateTo } from '../../lib/navigation';
+
+const replacement = {
+  success: true as const,
+  recoveryCodes: ['RC-ONE', 'RC-TWO'],
+  tokens: { accessToken: 'replacement', expiresInSeconds: 900 },
+};
+
+function options(totp: boolean, sms: boolean, passkey: boolean, phoneConfigured = true) {
+  return {
+    success: true as const,
+    options: { allowedMethods: { totp, sms, passkey }, phoneConfigured },
+  };
+}
+
+async function enterPasswordAndContinue() {
+  await waitFor(() => screen.getByLabelText(/current password/i));
+  fireEvent.change(screen.getByLabelText(/current password/i), { target: { value: 'correct horse' } });
+  fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.sessionGeneration = 1;
+  commitMfaEnrollmentIfCurrent.mockImplementation((generation: number) => generation === authState.sessionGeneration);
+  vi.mocked(apiGetMfaEnrollmentOptions).mockResolvedValue(options(true, false, true));
+  vi.mocked(fetchWithAuth).mockResolvedValue(new Response(JSON.stringify({ qrCodeDataUrl: 'data:image/png;base64,qr' }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  }));
+});
+
+describe('ForcedMfaSetupPage policy-driven enrollment', () => {
+  it('fails closed when options cannot load', async () => {
+    vi.mocked(apiGetMfaEnrollmentOptions).mockResolvedValue({ success: false, error: 'Policy unavailable' });
+
+    render(<ForcedMfaSetupPage />);
+
+    expect(await screen.findByTestId('mfa-options-error')).toHaveTextContent(/contact your administrator/i);
+    expect(screen.queryByLabelText(/current password/i)).not.toBeInTheDocument();
+  });
+
+  it('fails closed when policy has no usable enrollment method', async () => {
+    vi.mocked(apiGetMfaEnrollmentOptions).mockResolvedValue(options(false, true, false, false));
+
+    render(<ForcedMfaSetupPage />);
+
+    expect(await screen.findByTestId('mfa-options-empty')).toHaveTextContent(/contact your administrator/i);
+  });
+
+  it('shows permitted choices but disables SMS until a phone is configured', async () => {
+    vi.mocked(apiGetMfaEnrollmentOptions).mockResolvedValue(options(true, true, true, false));
+
+    render(<ForcedMfaSetupPage />);
+
+    expect(await screen.findByTestId('enroll-method-totp')).toBeEnabled();
+    expect(screen.getByTestId('enroll-method-sms')).toBeDisabled();
+    expect(screen.getByTestId('enroll-method-passkey')).toBeEnabled();
+    expect(screen.getByText(/add and verify a phone number/i)).toBeInTheDocument();
+  });
+
+  it('does not expose recovery codes during TOTP setup or after failed confirmation', async () => {
+    vi.mocked(apiEnableTotpMfa).mockResolvedValue({ success: false, error: 'Incorrect code' });
+    render(<ForcedMfaSetupPage />);
+
+    await enterPasswordAndContinue();
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledWith('/auth/mfa/setup', expect.any(Object)));
+    expect(screen.queryByTestId('enrollment-recovery-codes')).not.toBeInTheDocument();
+
+    fireEvent.click(await screen.findByTestId('confirm-totp'));
+    await waitFor(() => expect(apiEnableTotpMfa).toHaveBeenCalledWith('123456', 'correct horse'));
+    expect(commitMfaEnrollmentIfCurrent).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('enrollment-recovery-codes')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['sms', apiEnableSmsMfa],
+    ['passkey', apiEnrollPasskey],
+  ] as const)('adopts the replacement session only after successful %s enrollment', async (method, terminal) => {
+    vi.mocked(terminal).mockResolvedValue(replacement);
+    vi.mocked(apiGetMfaEnrollmentOptions).mockResolvedValue(
+      method === 'sms' ? options(false, true, false) : options(false, false, true),
+    );
+    render(<ForcedMfaSetupPage />);
+
+    await enterPasswordAndContinue();
+
+    await waitFor(() => expect(terminal).toHaveBeenCalledWith('correct horse'));
+    expect(commitMfaEnrollmentIfCurrent).toHaveBeenCalledWith(1, replacement.tokens);
+    expect(screen.getByTestId('enrollment-recovery-codes')).toHaveTextContent('RC-ONE');
+    expect(navigateTo).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('enrollment-continue'));
+    expect(navigateTo).toHaveBeenCalledWith('/');
+  });
+
+  it.each(['logout', 'replacement login'])('ignores a delayed enrollment response after %s', async () => {
+    let resolveEnrollment!: (value: typeof replacement) => void;
+    const delayed = new Promise<typeof replacement>((resolve) => { resolveEnrollment = resolve; });
+    vi.mocked(apiEnableSmsMfa).mockReturnValue(delayed);
+    vi.mocked(apiGetMfaEnrollmentOptions).mockResolvedValue(options(false, true, false));
+    render(<ForcedMfaSetupPage />);
+
+    await enterPasswordAndContinue();
+    await waitFor(() => expect(apiEnableSmsMfa).toHaveBeenCalled());
+    authState.sessionGeneration += 1;
+    resolveEnrollment(replacement);
+
+    await waitFor(() => expect(commitMfaEnrollmentIfCurrent).toHaveBeenCalledWith(1, replacement.tokens));
+    expect(screen.queryByTestId('enrollment-recovery-codes')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('enrollment-continue')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/auth/ForcedMfaSetupPage.tsx
+++ b/apps/web/src/components/auth/ForcedMfaSetupPage.tsx
@@ -1,11 +1,17 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import MFASetupForm from './MFASetupForm';
 import {
   AuthSessionExpiredError,
   AuthThrottledError,
+  apiEnableSmsMfa,
+  apiEnableTotpMfa,
+  apiEnrollPasskey,
+  apiGetMfaEnrollmentOptions,
   fetchWithAuth,
   restoreAccessTokenFromCookie,
+  type MfaEnrollmentCompletion,
+  type MfaEnrollmentOptions,
   useAuthStore,
 } from '../../stores/auth';
 import { extractApiError } from '../../lib/apiError';
@@ -16,6 +22,7 @@ import { navigateTo } from '../../lib/navigation';
 import '../../lib/i18n';
 
 type Step = 'password' | 'enroll' | 'done';
+type EnrollmentMethod = 'totp' | 'sms' | 'passkey';
 
 export default function ForcedMfaSetupPage() {
   const { t } = useTranslation('auth');
@@ -27,14 +34,56 @@ export default function ForcedMfaSetupPage() {
   const [qrCodeDataUrl, setQrCodeDataUrl] = useState<string | undefined>();
   const [recoveryCodes, setRecoveryCodes] = useState<string[] | undefined>();
   const [forced, setForced] = useState(false);
+  const [options, setOptions] = useState<MfaEnrollmentOptions>();
+  const [optionsError, setOptionsError] = useState<string>();
+  const [selectedMethod, setSelectedMethod] = useState<EnrollmentMethod>();
 
-  const updateUser = useAuthStore((state) => state.updateUser);
+  const commitMfaEnrollmentIfCurrent = useAuthStore((state) => state.commitMfaEnrollmentIfCurrent);
+  const mountedRef = useRef(true);
+
+  useEffect(() => () => { mountedRef.current = false; }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const params = new URLSearchParams(window.location.search);
     setForced(params.get('forced') === '1');
   }, []);
+
+  useEffect(() => {
+    let current = true;
+    void apiGetMfaEnrollmentOptions().then((result) => {
+      if (!current) return;
+      if (!result.success) {
+        setOptionsError(result.error);
+        return;
+      }
+      setOptions(result.options);
+      const first = result.options.allowedMethods.totp
+        ? 'totp'
+        : result.options.allowedMethods.sms && result.options.phoneConfigured
+          ? 'sms'
+          : result.options.allowedMethods.passkey
+            ? 'passkey'
+            : undefined;
+      setSelectedMethod(first);
+    });
+    return () => { current = false; };
+  }, []);
+
+  const finishEnrollment = (result: MfaEnrollmentCompletion, generation: number) => {
+    if (!mountedRef.current) return false;
+    if (!result.success) {
+      setError(result.error);
+      return false;
+    }
+    // The refresh/CSRF cookies were installed by the terminal API response;
+    // adopt only its replacement access metadata before leaving the gate.
+    if (!commitMfaEnrollmentIfCurrent(generation, result.tokens)) return false;
+    setRecoveryCodes(result.recoveryCodes);
+    setStep('done');
+    setInfo(t('forcedMfa.done.saveCodes', { defaultValue: 'MFA is enabled. Save your recovery codes before continuing.' }));
+    return true;
+  };
 
   // NOTE: AuthLayout mounts no AuthOverlay, so the refresh-throttle mask that
   // covers the dashboard (#3696) does NOT appear here. This page therefore has
@@ -57,10 +106,20 @@ export default function ForcedMfaSetupPage() {
   // Step 1: re-prompt for the current password and start TOTP enrollment.
   const handleStart = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!currentPassword) return;
+    if (!currentPassword || !selectedMethod) return;
     setLoading(true);
     setError(undefined);
     try {
+      if (selectedMethod === 'sms') {
+        const generation = useAuthStore.getState().sessionGeneration;
+        finishEnrollment(await apiEnableSmsMfa(currentPassword), generation);
+        return;
+      }
+      if (selectedMethod === 'passkey') {
+        const generation = useAuthStore.getState().sessionGeneration;
+        finishEnrollment(await apiEnrollPasskey(currentPassword), generation);
+        return;
+      }
       const response = await fetchWithAuth('/auth/mfa/setup', {
         method: 'POST',
         body: JSON.stringify({ currentPassword })
@@ -71,7 +130,6 @@ export default function ForcedMfaSetupPage() {
         return;
       }
       setQrCodeDataUrl(data.qrCodeDataUrl);
-      setRecoveryCodes(data.recoveryCodes);
       setStep('enroll');
     } catch (err) {
       // Session died and fetchWithAuth is already redirecting to /login — don't
@@ -98,23 +156,8 @@ export default function ForcedMfaSetupPage() {
     setLoading(true);
     setError(undefined);
     try {
-      const response = await fetchWithAuth('/auth/mfa/enable', {
-        method: 'POST',
-        body: JSON.stringify({ code, currentPassword })
-      });
-      const data = await response.json().catch(() => ({}));
-      if (!response.ok) {
-        setError(extractApiError(data, t('forcedMfa.errors.invalidCode', { defaultValue: 'Invalid verification code' })));
-        return;
-      }
-      updateUser({ mfaEnabled: true });
-      setStep('done');
-      setInfo(t('forcedMfa.done.redirecting', { defaultValue: 'MFA enabled. Redirecting...' }));
-      setTimeout(() => {
-        navigateTo('/').catch(() => {
-          window.location.href = '/';
-        });
-      }, 1500);
+      const generation = useAuthStore.getState().sessionGeneration;
+      finishEnrollment(await apiEnableTotpMfa(code, currentPassword), generation);
     } catch (err) {
       if (err instanceof AuthSessionExpiredError) return;
       // A rate-limited /auth/refresh is not a network error and not an expiry —
@@ -132,6 +175,27 @@ export default function ForcedMfaSetupPage() {
       setLoading(false);
     }
   };
+
+  if (optionsError) {
+    return (
+      <div data-testid="mfa-options-error" className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+        {optionsError}. {t('forcedMfa.contactAdmin', { defaultValue: 'Contact your administrator for help.' })}
+      </div>
+    );
+  }
+  if (!options) {
+    return <div data-testid="mfa-options-loading" className="text-sm text-muted-foreground">Loading MFA options…</div>;
+  }
+  const hasUsableMethod = options.allowedMethods.totp
+    || (options.allowedMethods.sms && options.phoneConfigured)
+    || options.allowedMethods.passkey;
+  if (!hasUsableMethod || !selectedMethod) {
+    return (
+      <div data-testid="mfa-options-empty" className="rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">
+        {t('forcedMfa.noMethods', { defaultValue: 'No MFA enrollment method is available. Contact your administrator.' })}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -162,13 +226,33 @@ export default function ForcedMfaSetupPage() {
           className="space-y-4 rounded-lg border bg-card p-6 shadow-xs"
         >
           <div className="space-y-1">
-            <h2 className="text-lg font-semibold">{t('forcedMfa.password.title', { defaultValue: 'Confirm your password' })}</h2>
+            <h2 className="text-lg font-semibold">{t('forcedMfa.method.title', { defaultValue: 'Choose an MFA method' })}</h2>
             <p className="text-sm text-muted-foreground">
               {t('forcedMfa.password.description', {
-                defaultValue: 'Re-enter your account password to start setting up an authenticator app.',
+                defaultValue: 'Choose a permitted method, then re-enter your password to continue.',
               })}
             </p>
           </div>
+          <div className="grid gap-2 sm:grid-cols-3">
+            {options.allowedMethods.totp && (
+              <button type="button" data-testid="enroll-method-totp" onClick={() => setSelectedMethod('totp')} className={`rounded-md border px-3 py-2 text-sm ${selectedMethod === 'totp' ? 'border-primary bg-primary/10' : ''}`}>
+                Authenticator app
+              </button>
+            )}
+            {options.allowedMethods.sms && (
+              <button type="button" data-testid="enroll-method-sms" disabled={!options.phoneConfigured} onClick={() => setSelectedMethod('sms')} className={`rounded-md border px-3 py-2 text-sm disabled:opacity-50 ${selectedMethod === 'sms' ? 'border-primary bg-primary/10' : ''}`}>
+                Text message
+              </button>
+            )}
+            {options.allowedMethods.passkey && (
+              <button type="button" data-testid="enroll-method-passkey" onClick={() => setSelectedMethod('passkey')} className={`rounded-md border px-3 py-2 text-sm ${selectedMethod === 'passkey' ? 'border-primary bg-primary/10' : ''}`}>
+                Passkey
+              </button>
+            )}
+          </div>
+          {options.allowedMethods.sms && !options.phoneConfigured && (
+            <p className="text-xs text-muted-foreground">Add and verify a phone number before choosing text-message MFA.</p>
+          )}
           <div className="space-y-2">
             <label htmlFor="forced-mfa-password" className="text-sm font-medium">
               {t('fields.currentPassword', { defaultValue: 'Current password' })}
@@ -228,9 +312,26 @@ export default function ForcedMfaSetupPage() {
         </>
       )}
 
-      {step === 'done' && info && (
-        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-600">
-          {info}
+      {step === 'done' && (
+        <div className="space-y-4">
+          {info && (
+            <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-600">
+              {info}
+            </div>
+          )}
+          {recoveryCodes && recoveryCodes.length > 0 && (
+            <div data-testid="enrollment-recovery-codes" className="grid grid-cols-2 gap-2 rounded-md border bg-muted/30 p-3 font-mono text-xs">
+              {recoveryCodes.map((code, index) => <div key={`done-recovery-${index}`} className="text-center">{code}</div>)}
+            </div>
+          )}
+          <button
+            type="button"
+            data-testid="enrollment-continue"
+            onClick={() => { void navigateTo('/'); }}
+            className="flex h-11 w-full items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground"
+          >
+            I saved these codes — continue
+          </button>
         </div>
       )}
     </div>

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -11,10 +11,11 @@ import {
   apiSendSmsMfaCode,
   fetchAndApplyPreferences
 } from '../../stores/auth';
-import type { MfaMethod } from '../../stores/auth';
+import type { MfaChallenge, MfaMethod } from '../../stores/auth';
 import { navigateTo } from '../../lib/navigation';
 import { getSafeNext } from '../../lib/authNext';
 import { getLoginContext } from '../../lib/loginContext';
+import { parseMfaChallengeResponse } from '../../lib/mfaChallenge';
 // Initializes the shared i18next singleton. This page's layout has no Sidebar
 // (which is what pulls i18n in elsewhere), so without this every t() call here
 // renders its raw key.
@@ -156,8 +157,7 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
   // rather than stacked.
   const sessionExpiredNotice = ssoLoginNotice ? undefined : getSessionExpiredNotice(t);
   const [loading, setLoading] = useState(false);
-  const [mfaRequired, setMfaRequired] = useState(false);
-  const [tempToken, setTempToken] = useState<string>();
+  const [mfaChallenge, setMfaChallenge] = useState<MfaChallenge>();
   const [mfaMethod, setMfaMethod] = useState<MfaMethod>('totp');
   const [passkeyAvailable, setPasskeyAvailable] = useState(false);
   const [phoneLast4, setPhoneLast4] = useState<string>();
@@ -247,11 +247,19 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
     }
 
     if (result.mfaRequired) {
-      setMfaRequired(true);
-      setTempToken(result.tempToken);
-      setMfaMethod(result.mfaMethod || 'totp');
-      setPasskeyAvailable(result.passkeyAvailable === true);
-      setPhoneLast4(result.phoneLast4);
+      const challenge = result.challenge ?? parseMfaChallengeResponse({
+        ...result,
+        mfaRequired: true,
+      });
+      if (!challenge) {
+        setError('Invalid MFA challenge response');
+        setLoading(false);
+        return;
+      }
+      setMfaChallenge(challenge);
+      setMfaMethod(challenge.primary);
+      setPasskeyAvailable(challenge.allowedMethods.passkey);
+      setPhoneLast4(challenge.phoneLast4 ?? undefined);
       setSmsSent(false);
       setLoading(false);
       return;
@@ -269,12 +277,12 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
   };
 
   const handleMfaVerify = async (code: string) => {
-    if (!tempToken) return;
+    if (!mfaChallenge || mfaMethod === 'passkey') return;
 
     setLoading(true);
     setError(undefined);
 
-    const result = await apiVerifyMFA(code, tempToken, mfaMethod);
+    const result = await apiVerifyMFA(code, mfaChallenge.tempToken, mfaMethod);
 
     if (!result.success) {
       setError(result.error);
@@ -283,6 +291,7 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
     }
 
     if (result.user && result.tokens) {
+      setMfaChallenge(undefined);
       login(result.user, result.tokens);
       fetchAndApplyPreferences();
       // Setup wizard wins over `next` — user can't do anything useful before setup completes.
@@ -294,12 +303,12 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
   };
 
   const handlePasskeyMfaVerify = async () => {
-    if (!tempToken) return;
+    if (!mfaChallenge) return;
 
     setLoading(true);
     setError(undefined);
 
-    const result = await apiVerifyPasskeyMFA(tempToken);
+    const result = await apiVerifyPasskeyMFA(mfaChallenge.tempToken);
 
     if (!result.success) {
       setError(result.error);
@@ -308,6 +317,7 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
     }
 
     if (result.user && result.tokens) {
+      setMfaChallenge(undefined);
       login(result.user, result.tokens);
       fetchAndApplyPreferences();
       await navigateTo(result.requiresSetup ? '/setup' : safeNext);
@@ -318,20 +328,23 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
   };
 
   const handleSendSmsCode = async () => {
-    if (!tempToken) return;
+    if (!mfaChallenge) return false;
 
     setSmsSending(true);
     setError(undefined);
 
-    const result = await apiSendSmsMfaCode(tempToken);
+    const result = await apiSendSmsMfaCode(mfaChallenge.tempToken);
 
     if (!result.success) {
       setError(result.error);
+      setSmsSending(false);
+      return false;
     } else {
       setSmsSent(true);
     }
 
     setSmsSending(false);
+    return true;
   };
 
   const handlePartnerSso = async () => {
@@ -353,7 +366,7 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
     return <div data-testid="login-cf-access-check" className="u-min-h-px-160" />;
   }
 
-  if (mfaRequired) {
+  if (mfaChallenge) {
     return (
       <div>
         <div className="mb-8">
@@ -366,6 +379,12 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
           errorMessage={error}
           loading={loading}
           mfaMethod={mfaMethod}
+          methods={mfaChallenge.methods}
+          onMethodChange={(method) => {
+            setMfaMethod(method);
+            setError(undefined);
+            if (method !== 'sms') setSmsSent(false);
+          }}
           passkeyAvailable={passkeyAvailable}
           phoneLast4={phoneLast4}
           onSendSmsCode={handleSendSmsCode}

--- a/apps/web/src/components/auth/MFAVerifyForm.test.tsx
+++ b/apps/web/src/components/auth/MFAVerifyForm.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import MFAVerifyForm from './MFAVerifyForm';
+
+describe('MFAVerifyForm', () => {
+  it('hides the selector for one method and shows every authorized choice for multiple methods', () => {
+    const { rerender } = render(<MFAVerifyForm mfaMethod="totp" methods={['totp']} />);
+    expect(screen.queryByTestId('mfa-method-select')).toBeNull();
+
+    rerender(<MFAVerifyForm mfaMethod="totp" methods={['totp', 'sms', 'passkey', 'recovery']} />);
+    const options = Array.from((screen.getByTestId('mfa-method-select') as HTMLSelectElement).options);
+    expect(options.map((option) => option.value)).toEqual(['totp', 'sms', 'passkey', 'recovery']);
+  });
+
+  it('preserves recovery-code separators and trims only outer whitespace', async () => {
+    const onSubmit = vi.fn();
+    render(<MFAVerifyForm mfaMethod="recovery" methods={['recovery']} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByTestId('mfa-recovery-code'), { target: { value: '  abcd - 1234  ' } });
+    fireEvent.click(screen.getByTestId('mfa-submit'));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('abcd - 1234'));
+  });
+
+  it('notifies the parent when selecting an alternate method', () => {
+    const onMethodChange = vi.fn();
+    render(
+      <MFAVerifyForm
+        mfaMethod="totp"
+        methods={['totp', 'recovery']}
+        onMethodChange={onMethodChange}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('mfa-method-select'), { target: { value: 'recovery' } });
+    expect(onMethodChange).toHaveBeenCalledWith('recovery');
+  });
+
+  it('automatically sends SMS once when SMS becomes selected', async () => {
+    const onSendSmsCode = vi.fn(async () => true);
+    const { rerender } = render(
+      <MFAVerifyForm mfaMethod="totp" methods={['totp', 'sms']} onSendSmsCode={onSendSmsCode} />,
+    );
+    rerender(<MFAVerifyForm mfaMethod="sms" methods={['totp', 'sms']} onSendSmsCode={onSendSmsCode} />);
+    await waitFor(() => expect(onSendSmsCode).toHaveBeenCalledOnce());
+    rerender(<MFAVerifyForm mfaMethod="sms" methods={['totp', 'sms']} onSendSmsCode={onSendSmsCode} />);
+    expect(onSendSmsCode).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/auth/MFAVerifyForm.tsx
+++ b/apps/web/src/components/auth/MFAVerifyForm.tsx
@@ -12,6 +12,8 @@ type MFAVerifyFormProps = {
   submitLabel?: string;
   loading?: boolean;
   mfaMethod?: MfaMethod;
+  methods?: MfaMethod[];
+  onMethodChange?: (method: MfaMethod) => void;
   /**
    * #2153: true when the account has a passkey registered as an ALTERNATE
    * second factor while the primary method is totp/sms. Surfaces a "use a
@@ -19,7 +21,7 @@ type MFAVerifyFormProps = {
    */
   passkeyAvailable?: boolean;
   phoneLast4?: string;
-  onSendSmsCode?: () => Promise<void>;
+  onSendSmsCode?: () => Promise<boolean | void>;
   smsSending?: boolean;
   smsSent?: boolean;
 };
@@ -31,6 +33,8 @@ export default function MFAVerifyForm({
   submitLabel,
   loading,
   mfaMethod = 'totp',
+  methods = [mfaMethod],
+  onMethodChange,
   passkeyAvailable = false,
   phoneLast4,
   onSendSmsCode,
@@ -39,14 +43,17 @@ export default function MFAVerifyForm({
 }: MFAVerifyFormProps) {
   const { t } = useTranslation('auth');
   const [digits, setDigits] = useState<string[]>(Array(DIGIT_COUNT).fill(''));
+  const [recoveryCode, setRecoveryCode] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [resendCooldown, setResendCooldown] = useState(0);
   const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
+  const smsAutoSent = useRef(false);
 
   const isLoading = useMemo(() => loading ?? isSubmitting, [loading, isSubmitting]);
   const code = digits.join('');
   const isSms = mfaMethod === 'sms';
   const isPasskey = mfaMethod === 'passkey';
+  const isRecovery = mfaMethod === 'recovery';
   // #2153: offer the passkey as an alternate factor when the primary method is
   // the code-based totp/sms flow but the account also has a passkey.
   const showPasskeyAlternate = !isPasskey && passkeyAvailable && Boolean(onPasskeyVerify);
@@ -57,6 +64,19 @@ export default function MFAVerifyForm({
     const timer = setTimeout(() => setResendCooldown(resendCooldown - 1), 1000);
     return () => clearTimeout(timer);
   }, [resendCooldown]);
+
+  useEffect(() => {
+    if (!isSms) {
+      smsAutoSent.current = false;
+      return;
+    }
+    if (smsSent || smsSending || smsAutoSent.current || !onSendSmsCode) return;
+    smsAutoSent.current = true;
+    void onSendSmsCode().then((sent) => {
+      if (sent !== false) setResendCooldown(60);
+      else smsAutoSent.current = false;
+    });
+  }, [isSms, onSendSmsCode, smsSending, smsSent]);
 
   const focusIndex = (index: number) => {
     inputRefs.current[index]?.focus();
@@ -100,12 +120,13 @@ export default function MFAVerifyForm({
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (isLoading || code.length !== DIGIT_COUNT) {
+    const submittedCode = isRecovery ? recoveryCode.trim() : code;
+    if (isLoading || (isRecovery ? submittedCode.length === 0 : submittedCode.length !== DIGIT_COUNT)) {
       return;
     }
     try {
       setIsSubmitting(true);
-      await onSubmit?.(code);
+      await onSubmit?.(submittedCode);
     } finally {
       setIsSubmitting(false);
     }
@@ -113,8 +134,8 @@ export default function MFAVerifyForm({
 
   const handleSendSms = async () => {
     if (smsSending || resendCooldown > 0) return;
-    await onSendSmsCode?.();
-    setResendCooldown(60);
+    const sent = await onSendSmsCode?.();
+    if (sent !== false) setResendCooldown(60);
   };
 
   const handlePasskeyVerify = async () => {
@@ -127,9 +148,29 @@ export default function MFAVerifyForm({
     }
   };
 
+  const methodSelector = methods.length > 1 ? (
+    <label className="block space-y-2 text-sm font-medium">
+      <span>{t('mfaVerify.method.label', { defaultValue: 'Verification method' })}</span>
+      <select
+        data-testid="mfa-method-select"
+        value={mfaMethod}
+        onChange={(event) => onMethodChange?.(event.target.value as MfaMethod)}
+        disabled={isLoading}
+        className="h-11 w-full rounded-md border bg-background px-3"
+      >
+        {methods.map((method) => (
+          <option key={method} value={method}>
+            {{ totp: 'Authenticator app', sms: 'Text message', passkey: 'Passkey', recovery: 'Recovery code' }[method]}
+          </option>
+        ))}
+      </select>
+    </label>
+  ) : null;
+
   if (isPasskey) {
     return (
       <div className="space-y-6">
+        {methodSelector}
         <div className="space-y-2">
           <h2 className="text-lg font-semibold">{t('mfaVerify.passkey.title', { defaultValue: 'Use your passkey' })}</h2>
           <p className="text-sm text-muted-foreground">
@@ -161,10 +202,13 @@ export default function MFAVerifyForm({
       onSubmit={handleSubmit}
       className="space-y-6"
     >
+      {methodSelector}
       <div className="space-y-2">
         <h2 className="text-lg font-semibold">{t('mfaVerify.code.title', { defaultValue: 'Enter your verification code' })}</h2>
         <p className="text-sm text-muted-foreground">
-          {isSms
+          {isRecovery
+            ? t('mfaVerify.recovery.description', { defaultValue: 'Enter one of your recovery codes.' })
+            : isSms
             ? smsSent
               ? t('mfaVerify.sms.sentDescription', {
                   defaultValue: `Enter the 6-digit code sent to your phone ending in ${phoneLast4 || '****'}.`,
@@ -191,7 +235,25 @@ export default function MFAVerifyForm({
         </button>
       )}
 
-      {(!isSms || smsSent) && (
+      {isRecovery && (
+        <div className="space-y-2">
+          <label htmlFor="mfa-recovery-code" className="text-sm font-medium">
+            {t('mfaVerify.recovery.label', { defaultValue: 'Recovery code' })}
+          </label>
+          <input
+            id="mfa-recovery-code"
+            data-testid="mfa-recovery-code"
+            type="text"
+            autoComplete="one-time-code"
+            value={recoveryCode}
+            onChange={(event) => setRecoveryCode(event.target.value)}
+            disabled={isLoading}
+            className="h-11 w-full rounded-md border bg-background px-3 font-mono uppercase"
+          />
+        </div>
+      )}
+
+      {!isRecovery && (!isSms || smsSent) && (
         <>
           <div className="space-y-2">
             <label className="text-sm font-medium">{t('fields.verificationCode', { defaultValue: 'Verification code' })}</label>
@@ -253,11 +315,11 @@ export default function MFAVerifyForm({
         </div>
       )}
 
-      {(!isSms || smsSent) && (
+      {(isRecovery || !isSms || smsSent) && (
         <button
           type="submit"
           data-testid="mfa-submit"
-          disabled={isLoading || code.length !== DIGIT_COUNT}
+          disabled={isLoading || (isRecovery ? recoveryCode.trim().length === 0 : code.length !== DIGIT_COUNT)}
           className="flex h-11 w-full items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isLoading ? t('common.verifying', { defaultValue: 'Verifying...' }) : submitLabel ?? t('mfaVerify.submit', { defaultValue: 'Verify' })}

--- a/apps/web/src/lib/mfaChallenge.test.ts
+++ b/apps/web/src/lib/mfaChallenge.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { parseMfaChallengeResponse } from './mfaChallenge';
+
+const base = {
+  mfaRequired: true,
+  tempToken: 'temp-token',
+  mfaMethod: 'totp',
+  allowedMethods: { totp: true, sms: false, passkey: true },
+  recoveryAvailable: true,
+  passkeyAvailable: true,
+  phoneLast4: null,
+};
+
+describe('parseMfaChallengeResponse', () => {
+  it('normalizes the authoritative method set', () => {
+    expect(parseMfaChallengeResponse(base)).toEqual({
+      tempToken: 'temp-token',
+      primary: 'totp',
+      methods: ['totp', 'passkey', 'recovery'],
+      allowedMethods: { totp: true, sms: false, passkey: true },
+      recoveryAvailable: true,
+      phoneLast4: null,
+    });
+  });
+
+  it('selects recovery for a recovery-only new challenge', () => {
+    expect(parseMfaChallengeResponse({
+      ...base,
+      allowedMethods: { totp: false, sms: false, passkey: false },
+      recoveryAvailable: true,
+      passkeyAvailable: false,
+    })?.primary).toBe('recovery');
+  });
+
+  it.each([
+    { ...base, allowedMethods: undefined },
+    { ...base, recoveryAvailable: undefined },
+    { ...base, allowedMethods: { totp: 1, sms: false, passkey: true } },
+    { ...base, recoveryAvailable: 'yes' },
+    { ...base, passkeyAvailable: false },
+    { ...base, mfaMethod: 'recovery' },
+    { ...base, allowedMethods: { totp: false, sms: false, passkey: false }, recoveryAvailable: false, passkeyAvailable: false },
+  ])('rejects malformed or unusable new contracts', (value) => {
+    expect(parseMfaChallengeResponse(value)).toBeNull();
+  });
+
+  it.each([
+    [{ mfaRequired: true, tempToken: 't', mfaMethod: 'totp' }, ['totp']],
+    [{ mfaRequired: true, tempToken: 't', mfaMethod: 'sms', phoneLast4: '1234' }, ['sms']],
+    [{ mfaRequired: true, tempToken: 't', mfaMethod: 'passkey', passkeyAvailable: true }, ['passkey']],
+    [{ mfaRequired: true, tempToken: 't', mfaMethod: 'totp', passkeyAvailable: true }, ['totp', 'passkey']],
+  ])('supports a well-formed legacy response', (value, methods) => {
+    expect(parseMfaChallengeResponse(value)?.methods).toEqual(methods);
+  });
+});

--- a/apps/web/src/lib/mfaChallenge.ts
+++ b/apps/web/src/lib/mfaChallenge.ts
@@ -1,0 +1,105 @@
+export type MfaMethod = 'totp' | 'sms' | 'passkey' | 'recovery';
+export type MfaPrimaryMethod = Exclude<MfaMethod, 'recovery'>;
+
+export interface MfaAllowedMethods {
+  totp: boolean;
+  sms: boolean;
+  passkey: boolean;
+}
+
+export interface MfaChallenge {
+  tempToken: string;
+  primary: MfaMethod;
+  methods: MfaMethod[];
+  allowedMethods: MfaAllowedMethods;
+  recoveryAvailable: boolean;
+  phoneLast4: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPrimaryMethod(value: unknown): value is MfaPrimaryMethod {
+  return value === 'totp' || value === 'sms' || value === 'passkey';
+}
+
+function parsePhoneLast4(value: unknown): string | null | undefined {
+  if (value === undefined || value === null) return null;
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function parseMfaChallengeResponse(value: unknown): MfaChallenge | null {
+  if (!isRecord(value) || value.mfaRequired !== true || typeof value.tempToken !== 'string' || !value.tempToken) {
+    return null;
+  }
+  if (!isPrimaryMethod(value.mfaMethod)) return null;
+  const phoneLast4 = parsePhoneLast4(value.phoneLast4);
+  if (phoneLast4 === undefined) return null;
+
+  const hasAllowedMethods = Object.prototype.hasOwnProperty.call(value, 'allowedMethods');
+  const hasRecoveryAvailable = Object.prototype.hasOwnProperty.call(value, 'recoveryAvailable');
+  if (hasAllowedMethods !== hasRecoveryAvailable) return null;
+
+  if (!hasAllowedMethods) {
+    if (value.passkeyAvailable !== undefined && typeof value.passkeyAvailable !== 'boolean') return null;
+    const allowedMethods: MfaAllowedMethods = {
+      totp: value.mfaMethod === 'totp',
+      sms: value.mfaMethod === 'sms',
+      passkey: value.mfaMethod === 'passkey' || value.passkeyAvailable === true,
+    };
+    const methods: MfaMethod[] = [
+      ...(allowedMethods.totp ? ['totp' as const] : []),
+      ...(allowedMethods.sms ? ['sms' as const] : []),
+      ...(allowedMethods.passkey ? ['passkey' as const] : []),
+    ];
+    return {
+      tempToken: value.tempToken,
+      primary: value.mfaMethod,
+      methods,
+      allowedMethods,
+      recoveryAvailable: false,
+      phoneLast4,
+    };
+  }
+
+  const allowed = value.allowedMethods;
+  if (
+    !isRecord(allowed)
+    || typeof allowed.totp !== 'boolean'
+    || typeof allowed.sms !== 'boolean'
+    || typeof allowed.passkey !== 'boolean'
+    || typeof value.recoveryAvailable !== 'boolean'
+    || typeof value.passkeyAvailable !== 'boolean'
+    || value.passkeyAvailable !== allowed.passkey
+  ) {
+    return null;
+  }
+
+  const allowedMethods: MfaAllowedMethods = {
+    totp: allowed.totp,
+    sms: allowed.sms,
+    passkey: allowed.passkey,
+  };
+  const methods: MfaMethod[] = [
+    ...(allowedMethods.totp ? ['totp' as const] : []),
+    ...(allowedMethods.sms ? ['sms' as const] : []),
+    ...(allowedMethods.passkey ? ['passkey' as const] : []),
+    ...(value.recoveryAvailable ? ['recovery' as const] : []),
+  ];
+  if (methods.length === 0) return null;
+
+  const primary = allowedMethods[value.mfaMethod]
+    ? value.mfaMethod
+    : methods[0];
+  if (!primary) return null;
+
+  return {
+    tempToken: value.tempToken,
+    primary,
+    methods,
+    allowedMethods,
+    recoveryAvailable: value.recoveryAvailable,
+    phoneLast4,
+  };
+}

--- a/apps/web/src/locales/de-DE/auth.json
+++ b/apps/web/src/locales/de-DE/auth.json
@@ -110,13 +110,19 @@
   "forcedMfa": {
     "done": {
       "redirecting": "MFA aktiviert. Weiterleitung...",
+      "saveCodes": "MFA ist aktiviert. Speichern Sie Ihre Wiederherstellungscodes, bevor Sie fortfahren.",
       "title": "MFA aktiviert"
     },
     "errors": {
       "invalidCode": "Ungültiger Bestätigungscode",
       "startFailed": "MFA-Einrichtung konnte nicht gestartet werden"
     },
+    "contactAdmin": "Wenden Sie sich an Ihren Administrator, um Hilfe zu erhalten.",
     "eyebrow": "Kontosicherheit",
+    "method": {
+      "title": "MFA-Methode auswählen"
+    },
+    "noMethods": "Es ist keine MFA-Registrierungsmethode verfügbar. Wenden Sie sich an Ihren Administrator.",
     "password": {
       "description": "Geben Sie Ihr Kontopasswort erneut ein, um mit der Einrichtung einer Authenticator-App zu beginnen.",
       "title": "Passwort bestätigen"
@@ -182,10 +188,17 @@
     "code": {
       "title": "Bestätigungscode eingeben"
     },
+    "method": {
+      "label": "Bestätigungsmethode"
+    },
     "passkey": {
       "description": "Mit dem für Ihr Konto registrierten Passkey fortfahren.",
       "title": "Passkey verwenden",
       "useInstead": "Stattdessen Passkey verwenden"
+    },
+    "recovery": {
+      "description": "Geben Sie einen Ihrer Wiederherstellungscodes ein.",
+      "label": "Wiederherstellungscode"
     },
     "sms": {
       "readyDescription": "Ein Code wird an Ihre Telefonnummer mit der Endung {{phoneLast4}} gesendet.",

--- a/apps/web/src/locales/en/auth.json
+++ b/apps/web/src/locales/en/auth.json
@@ -110,13 +110,19 @@
   "forcedMfa": {
     "done": {
       "redirecting": "MFA enabled. Redirecting...",
+      "saveCodes": "MFA is enabled. Save your recovery codes before continuing.",
       "title": "MFA enabled"
     },
     "errors": {
       "invalidCode": "Invalid verification code",
       "startFailed": "Could not start MFA setup"
     },
+    "contactAdmin": "Contact your administrator for help.",
     "eyebrow": "Account security",
+    "method": {
+      "title": "Choose an MFA method"
+    },
+    "noMethods": "No MFA enrollment method is available. Contact your administrator.",
     "password": {
       "description": "Re-enter your account password to start setting up an authenticator app.",
       "title": "Confirm your password"
@@ -182,10 +188,17 @@
     "code": {
       "title": "Enter your verification code"
     },
+    "method": {
+      "label": "Verification method"
+    },
     "passkey": {
       "description": "Continue with the passkey registered to your account.",
       "title": "Use your passkey",
       "useInstead": "Use a passkey instead"
+    },
+    "recovery": {
+      "description": "Enter one of your recovery codes.",
+      "label": "Recovery code"
     },
     "sms": {
       "readyDescription": "We'll send a code to your phone ending in {{phoneLast4}}.",

--- a/apps/web/src/locales/es-419/auth.json
+++ b/apps/web/src/locales/es-419/auth.json
@@ -110,13 +110,19 @@
   "forcedMfa": {
     "done": {
       "redirecting": "MFA habilitado. Redirigiendo...",
+      "saveCodes": "MFA está habilitada. Guarde sus códigos de recuperación antes de continuar.",
       "title": "MFA habilitado"
     },
     "errors": {
       "invalidCode": "Código de verificación no válido",
       "startFailed": "No se pudo iniciar la configuración de MFA"
     },
+    "contactAdmin": "Comuníquese con su administrador para obtener ayuda.",
     "eyebrow": "Seguridad de la cuenta",
+    "method": {
+      "title": "Elija un método de MFA"
+    },
+    "noMethods": "No hay ningún método de inscripción de MFA disponible. Comuníquese con su administrador.",
     "password": {
       "description": "Vuelva a ingresar la contraseña de su cuenta para comenzar a configurar una aplicación de autenticación.",
       "title": "Confirme su contraseña"
@@ -182,10 +188,17 @@
     "code": {
       "title": "Ingrese su código de verificación"
     },
+    "method": {
+      "label": "Método de verificación"
+    },
     "passkey": {
       "description": "Continúe con la clave registrada en su cuenta.",
       "title": "Use su clave de acceso",
       "useInstead": "Utilice una clave de acceso en su lugar"
+    },
+    "recovery": {
+      "description": "Ingrese uno de sus códigos de recuperación.",
+      "label": "Código de recuperación"
     },
     "sms": {
       "readyDescription": "Le enviaremos un código a su teléfono que termina en {{phoneLast4}}.",

--- a/apps/web/src/locales/fr-CA/auth.json
+++ b/apps/web/src/locales/fr-CA/auth.json
@@ -110,13 +110,19 @@
   "forcedMfa": {
     "done": {
       "redirecting": "MFA activé. Redirigeant...",
+      "saveCodes": "L’authentification multifacteur est activée. Enregistrez vos codes de récupération avant de continuer.",
       "title": "MFA activé"
     },
     "errors": {
       "invalidCode": "Code de vérification invalide",
       "startFailed": "Impossible de démarrer la configuration MFA"
     },
+    "contactAdmin": "Communiquez avec votre administrateur pour obtenir de l’aide.",
     "eyebrow": "Sécurité du compte",
+    "method": {
+      "title": "Choisissez une méthode d’authentification multifacteur"
+    },
+    "noMethods": "Aucune méthode d’inscription à l’authentification multifacteur n’est disponible. Communiquez avec votre administrateur.",
     "password": {
       "description": "Saisissez à nouveau votre mot de passe de compte pour commencer à configurer une application d’authentification.",
       "title": "Confirmez votre mot de passe"
@@ -182,10 +188,17 @@
     "code": {
       "title": "Saisissez votre code de vérification"
     },
+    "method": {
+      "label": "Méthode de vérification"
+    },
     "passkey": {
       "description": "Continuez avec la clé d’accès enregistrée sur votre compte.",
       "title": "Utilisez votre clé d’accès",
       "useInstead": "Utilisez plutôt une clé d’accès"
+    },
+    "recovery": {
+      "description": "Saisissez l’un de vos codes de récupération.",
+      "label": "Code de récupération"
     },
     "sms": {
       "readyDescription": "Nous enverrons un code sur votre téléphone se terminant par {{phoneLast4}}.",

--- a/apps/web/src/locales/fr-FR/auth.json
+++ b/apps/web/src/locales/fr-FR/auth.json
@@ -110,13 +110,19 @@
   "forcedMfa": {
     "done": {
       "redirecting": "MFA activé. Redirigeant...",
+      "saveCodes": "L’authentification multifacteur est activée. Enregistrez vos codes de récupération avant de continuer.",
       "title": "MFA activé"
     },
     "errors": {
       "invalidCode": "Code de vérification invalide",
       "startFailed": "Impossible de démarrer la configuration MFA"
     },
+    "contactAdmin": "Contactez votre administrateur pour obtenir de l’aide.",
     "eyebrow": "Sécurité du compte",
+    "method": {
+      "title": "Choisissez une méthode d’authentification multifacteur"
+    },
+    "noMethods": "Aucune méthode d’inscription à l’authentification multifacteur n’est disponible. Contactez votre administrateur.",
     "password": {
       "description": "Saisissez à nouveau votre mot de passe de compte pour commencer à configurer une application d’authentification.",
       "title": "Confirmez votre mot de passe"
@@ -182,10 +188,17 @@
     "code": {
       "title": "Saisissez votre code de vérification"
     },
+    "method": {
+      "label": "Méthode de vérification"
+    },
     "passkey": {
       "description": "Continuez avec la clé d’accès enregistrée sur votre compte.",
       "title": "Utilisez votre clé d’accès",
       "useInstead": "Utilisez plutôt une clé d’accès"
+    },
+    "recovery": {
+      "description": "Saisissez l’un de vos codes de récupération.",
+      "label": "Code de récupération"
     },
     "sms": {
       "readyDescription": "Nous enverrons un code sur votre téléphone se terminant par {{phoneLast4}}.",

--- a/apps/web/src/locales/it-IT/auth.json
+++ b/apps/web/src/locales/it-IT/auth.json
@@ -110,13 +110,19 @@
   "forcedMfa": {
     "done": {
       "redirecting": "MFA abilitata. Reindirizzamento...",
+      "saveCodes": "L'MFA è abilitata. Salva i codici di recupero prima di continuare.",
       "title": "MFA abilitata"
     },
     "errors": {
       "invalidCode": "Codice di verifica non valido",
       "startFailed": "Impossibile avviare la configurazione MFA"
     },
+    "contactAdmin": "Contatta l'amministratore per ricevere assistenza.",
     "eyebrow": "Sicurezza dell'account",
+    "method": {
+      "title": "Scegli un metodo MFA"
+    },
+    "noMethods": "Non è disponibile alcun metodo di registrazione MFA. Contatta l'amministratore.",
     "password": {
       "description": "Inserisci di nuovo la password del tuo account per iniziare a configurare un'app di autenticazione.",
       "title": "Conferma la password"
@@ -182,10 +188,17 @@
     "code": {
       "title": "Inserisci il codice di verifica"
     },
+    "method": {
+      "label": "Metodo di verifica"
+    },
     "passkey": {
       "description": "Continua con la passkey registrata sul tuo account.",
       "title": "Usa la tua passkey",
       "useInstead": "Usa invece una passkey"
+    },
+    "recovery": {
+      "description": "Inserisci uno dei tuoi codici di recupero.",
+      "label": "Codice di recupero"
     },
     "sms": {
       "readyDescription": "Invieremo un codice al telefono che termina con {{phoneLast4}}.",

--- a/apps/web/src/locales/pt-BR/auth.json
+++ b/apps/web/src/locales/pt-BR/auth.json
@@ -110,13 +110,19 @@
   "forcedMfa": {
     "done": {
       "redirecting": "MFA ativada. Redirecionando...",
+      "saveCodes": "A MFA está ativada. Salve seus códigos de recuperação antes de continuar.",
       "title": "MFA ativada"
     },
     "errors": {
       "invalidCode": "Código de verificação invalido",
       "startFailed": "Não foi possível iniciar a configuração da MFA"
     },
+    "contactAdmin": "Entre em contato com seu administrador para obter ajuda.",
     "eyebrow": "Seguranca da conta",
+    "method": {
+      "title": "Escolha um método de MFA"
+    },
+    "noMethods": "Nenhum método de cadastro de MFA está disponível. Entre em contato com seu administrador.",
     "password": {
       "description": "Digite novamente a senha da sua conta para começar a configurar um aplicativo autenticador.",
       "title": "Confirme sua senha"
@@ -182,10 +188,17 @@
     "code": {
       "title": "Digite seu código de verificação"
     },
+    "method": {
+      "label": "Método de verificação"
+    },
     "passkey": {
       "description": "Continue com a chave de acesso registrada na sua conta.",
       "title": "Use sua chave de acesso",
       "useInstead": "Usar uma chave de acesso"
+    },
+    "recovery": {
+      "description": "Digite um dos seus códigos de recuperação.",
+      "label": "Código de recuperação"
     },
     "sms": {
       "readyDescription": "Enviaremos um código para o telefone com final {{phoneLast4}}.",

--- a/apps/web/src/locales/tr-TR/auth.json
+++ b/apps/web/src/locales/tr-TR/auth.json
@@ -110,13 +110,19 @@
   "forcedMfa": {
     "done": {
       "redirecting": "MFA etkin. Yönlendiriliyor...",
+      "saveCodes": "MFA etkinleştirildi. Devam etmeden önce kurtarma kodlarınızı kaydedin.",
       "title": "MFA etkin"
     },
     "errors": {
       "invalidCode": "Geçersiz doğrulama kodu",
       "startFailed": "MFA kurulumu başlatılamadı"
     },
+    "contactAdmin": "Yardım için yöneticinizle iletişime geçin.",
     "eyebrow": "Hesap güvenliği",
+    "method": {
+      "title": "Bir MFA yöntemi seçin"
+    },
+    "noMethods": "Kullanılabilir bir MFA kayıt yöntemi yok. Yöneticinizle iletişime geçin.",
     "password": {
       "description": "Kimlik doğrulama uygulaması kurmaya başlamak için hesap şifrenizi yeniden girin.",
       "title": "Şifrenizi doğrulayın"
@@ -182,10 +188,17 @@
     "code": {
       "title": "Doğrulama kodunuzu girin"
     },
+    "method": {
+      "label": "Doğrulama yöntemi"
+    },
     "passkey": {
       "description": "Hesabınıza kayıtlı şifreyle devam edin.",
       "title": "Şifrenizi kullanın",
       "useInstead": "Bunun yerine bir şifre kullanın"
+    },
+    "recovery": {
+      "description": "Kurtarma kodlarınızdan birini girin.",
+      "label": "Kurtarma kodu"
     },
     "sms": {
       "readyDescription": "Telefonunuza {{phoneLast4}} ile biten bir kod göndereceğiz.",

--- a/apps/web/src/stores/auth.passkeys.test.ts
+++ b/apps/web/src/stores/auth.passkeys.test.ts
@@ -63,11 +63,20 @@ describe('auth store passkey MFA helpers', () => {
     expect(result).toEqual({
       success: true,
       mfaRequired: true,
+      challenge: {
+        tempToken: 'temp-passkey',
+        primary: 'passkey',
+        methods: ['passkey'],
+        allowedMethods: { totp: false, sms: false, passkey: true },
+        recoveryAvailable: false,
+        phoneLast4: null,
+      },
       tempToken: 'temp-passkey',
       mfaMethod: 'passkey',
-      // #2153: normalized to false when the login body omits the flag.
-      passkeyAvailable: false,
-      phoneLast4: undefined,
+      // A passkey primary is itself proof that the legacy response authorizes
+      // the dedicated WebAuthn continuation.
+      passkeyAvailable: true,
+      phoneLast4: null,
     });
   });
 

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -3,6 +3,10 @@ import type { Tokens, User } from './auth';
 import { applyResolvedLocalePreferences } from '@/lib/appearance';
 import {
   apiAcceptInvite,
+  apiEnableSmsMfa,
+  apiEnableTotpMfa,
+  apiEnrollPasskey,
+  apiGetMfaEnrollmentOptions,
   apiLogin,
   apiLogout,
   apiPrepareCfTerminalLogout,
@@ -904,7 +908,7 @@ describe('auth API helpers', () => {
 
     const result = await apiLogin('user@example.com', 'password');
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       success: true,
       mfaRequired: true,
       tempToken: 'temp-1',
@@ -1859,5 +1863,94 @@ describe('apiRegisterPartner recovery action', () => {
     const result = await apiRegisterPartner('Acme', 'jane@acme.test', 'pw', 'Jane');
 
     expect(result).toEqual({ success: false, error: 'Registration failed', action: undefined });
+  });
+});
+
+describe('MFA enrollment API bindings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.getState().login(baseUser, baseTokens);
+  });
+
+  it('accepts only a fully typed enrollment-options response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse({
+      allowedMethods: { totp: true, sms: false, passkey: true },
+      phoneConfigured: false,
+    })));
+
+    await expect(apiGetMfaEnrollmentOptions()).resolves.toEqual({
+      success: true,
+      options: {
+        allowedMethods: { totp: true, sms: false, passkey: true },
+        phoneConfigured: false,
+      },
+    });
+  });
+
+  it('rejects terminal enrollment responses without replacement access metadata', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse({
+      success: true,
+      recoveryCodes: ['RC-ONE'],
+    })));
+
+    await expect(apiEnableTotpMfa('123456', 'password')).resolves.toEqual({
+      success: false,
+      error: 'Invalid MFA enrollment response',
+    });
+  });
+
+  it.each([
+    ['totp', () => apiEnableTotpMfa('123456', 'password')],
+    ['sms', () => apiEnableSmsMfa('password')],
+  ] as const)('returns recovery codes and replacement metadata for %s', async (_method, invoke) => {
+    const payload = {
+      success: true,
+      recoveryCodes: ['RC-ONE', 'RC-TWO'],
+      tokens: { accessToken: 'replacement', expiresInSeconds: 900 },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse(payload)));
+
+    await expect(invoke()).resolves.toEqual(payload);
+  });
+
+  it('completes passkey registration through the terminal replacement response', async () => {
+    const payload = {
+      success: true,
+      recoveryCodes: ['RC-PASSKEY'],
+      tokens: { accessToken: 'replacement-passkey', expiresInSeconds: 900 },
+    };
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(makeResponse({ options: { challenge: 'challenge' } }))
+      .mockResolvedValueOnce(makeResponse(payload)));
+
+    await expect(apiEnrollPasskey('password')).resolves.toEqual(payload);
+  });
+});
+
+describe('MFA enrollment session adoption', () => {
+  it('refuses a terminal response after logout', () => {
+    useAuthStore.getState().login(baseUser, baseTokens);
+    const generation = useAuthStore.getState().sessionGeneration;
+    useAuthStore.getState().logout();
+
+    expect(useAuthStore.getState().commitMfaEnrollmentIfCurrent(generation, {
+      accessToken: 'stale',
+      expiresInSeconds: 900,
+    })).toBe(false);
+    expect(useAuthStore.getState()).toMatchObject({ user: null, tokens: null, isAuthenticated: false });
+  });
+
+  it('refuses a terminal response after a newer login, even for the same user', () => {
+    useAuthStore.getState().login(baseUser, baseTokens);
+    const generation = useAuthStore.getState().sessionGeneration;
+    const newerTokens = { accessToken: 'newer', expiresInSeconds: 900 };
+    useAuthStore.getState().login(baseUser, newerTokens);
+
+    expect(useAuthStore.getState().commitMfaEnrollmentIfCurrent(generation, {
+      accessToken: 'stale',
+      expiresInSeconds: 900,
+    })).toBe(false);
+    expect(useAuthStore.getState().tokens).toEqual(newerTokens);
+    expect(useAuthStore.getState().user?.mfaEnabled).toBe(false);
   });
 });

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -13,6 +13,12 @@ import { resetPartnerCurrencyCache } from '@/lib/partnerCurrencyCache';
 import { resetApproximateTotalCache } from '@/lib/approximateTotalCache';
 import { getSafeNext, loginPathWithNext } from '@/lib/authNext';
 import {
+  parseMfaChallengeResponse,
+  type MfaChallenge,
+  type MfaMethod,
+} from '@/lib/mfaChallenge';
+export type { MfaAllowedMethods, MfaChallenge, MfaMethod } from '@/lib/mfaChallenge';
+import {
   applyAppearancePreferences,
   applyResolvedLocalePreferences,
   type Density,
@@ -105,6 +111,7 @@ interface AuthState {
   // never paint as an empty-but-loaded page. NOT persisted: a stale throttle
   // must never survive a reload.
   authThrottledUntil: number | null;
+  sessionGeneration: number;
 
   // Actions
   setUser: (user: User | null) => void;
@@ -114,6 +121,7 @@ interface AuthState {
   login: (user: User, tokens: Tokens) => void;
   logout: () => void;
   updateUser: (user: Partial<User>) => void;
+  commitMfaEnrollmentIfCurrent: (generation: number, tokens: Tokens) => boolean;
   setAuthThrottledUntil: (until: number | null) => void;
 }
 
@@ -135,8 +143,15 @@ export const useAuthStore = create<AuthState>()(
       mfaTempToken: null,
       sessionExpiredReason: null,
       authThrottledUntil: null,
+      sessionGeneration: 0,
 
-      setUser: (user) => set({ user, isAuthenticated: !!user }),
+      setUser: (user) => set((state) => ({
+        user,
+        isAuthenticated: !!user,
+        sessionGeneration: state.user?.id === user?.id
+          ? state.sessionGeneration
+          : state.sessionGeneration + 1,
+      })),
 
       setAuthThrottledUntil: (until) => set({ authThrottledUntil: until }),
 
@@ -153,7 +168,7 @@ export const useAuthStore = create<AuthState>()(
         // Re-login clears any stale expiry state and re-arms
         // handleSessionExpired for the new session.
         sessionExpiryInFlight = false;
-        set({
+        set((state) => ({
           user,
           tokens,
           isAuthenticated: true,
@@ -161,8 +176,9 @@ export const useAuthStore = create<AuthState>()(
           mfaPending: false,
           mfaTempToken: null,
           sessionExpiredReason: null,
-          authThrottledUntil: null
-        });
+          authThrottledUntil: null,
+          sessionGeneration: state.sessionGeneration + 1,
+        }));
       },
 
       // Deliberately does NOT clear `sessionExpiredReason`: handleSessionExpired
@@ -177,7 +193,7 @@ export const useAuthStore = create<AuthState>()(
         // currency (lib/useApproximateTotal), so they must not outlive the
         // session either.
         resetApproximateTotalCache();
-        set({
+        set((state) => ({
           user: null,
           tokens: null,
           isAuthenticated: false,
@@ -185,13 +201,31 @@ export const useAuthStore = create<AuthState>()(
           mfaTempToken: null,
           // An evicted session is not "waiting out a throttle" — drop the mask
           // so the expiry overlay/redirect is what the user sees (#3696).
-          authThrottledUntil: null
-        });
+          authThrottledUntil: null,
+          sessionGeneration: state.sessionGeneration + 1,
+        }));
       },
 
       updateUser: (updates) => set((state) => ({
         user: state.user ? { ...state.user, ...updates } : null
-      }))
+      })),
+
+      commitMfaEnrollmentIfCurrent: (generation, tokens) => {
+        let committed = false;
+        set((state) => {
+          if (
+            state.sessionGeneration !== generation
+            || !state.isAuthenticated
+            || !state.user
+          ) return state;
+          committed = true;
+          return {
+            tokens,
+            user: { ...state.user, mfaEnabled: true },
+          };
+        });
+        return committed;
+      },
     }),
     {
       name: 'breeze-auth',
@@ -1174,8 +1208,6 @@ export async function fetchWithAuth(rawUrl: string, options: FetchWithAuthOption
   return response;
 }
 
-export type MfaMethod = 'totp' | 'sms' | 'passkey';
-
 type ApiAuthSuccess = {
   success: boolean;
   user?: User;
@@ -1207,10 +1239,11 @@ export async function getPasskeyCredential(
 export async function apiLogin(email: string, password: string): Promise<{
   success: boolean;
   mfaRequired?: boolean;
+  challenge?: MfaChallenge;
   tempToken?: string;
   mfaMethod?: MfaMethod;
   passkeyAvailable?: boolean;
-  phoneLast4?: string;
+  phoneLast4?: string | null;
   user?: User;
   tokens?: Tokens;
   requiresSetup?: boolean;
@@ -1231,15 +1264,20 @@ export async function apiLogin(email: string, password: string): Promise<{
     }
 
     if (data.mfaRequired) {
+      const challenge = parseMfaChallengeResponse(data);
+      if (!challenge) {
+        return { success: false, error: 'Invalid MFA challenge response' };
+      }
       return {
         success: true,
         mfaRequired: true,
-        tempToken: data.tempToken,
-        mfaMethod: data.mfaMethod || 'totp',
+        challenge,
+        tempToken: challenge.tempToken,
+        mfaMethod: challenge.primary,
         // #2153: whether a passkey can be used as an alternate factor for this
         // login even when the primary method is totp/sms.
-        passkeyAvailable: data.passkeyAvailable === true,
-        phoneLast4: data.phoneLast4
+        passkeyAvailable: challenge.allowedMethods.passkey,
+        phoneLast4: challenge.phoneLast4
       };
     }
 
@@ -1257,7 +1295,11 @@ export async function apiLogin(email: string, password: string): Promise<{
   }
 }
 
-export async function apiVerifyMFA(code: string, tempToken: string, method?: MfaMethod): Promise<ApiAuthSuccess> {
+export async function apiVerifyMFA(
+  code: string,
+  tempToken: string,
+  method?: Exclude<MfaMethod, 'passkey'>,
+): Promise<ApiAuthSuccess> {
   try {
     const response = await fetchAuthIssuerWithBindingRetry(buildApiUrl('/auth/mfa/verify'), {
       method: 'POST',
@@ -1363,7 +1405,7 @@ export async function apiSsoLinkPending(): Promise<
 }
 
 export type SsoLinkConfirmResult =
-  | { state: 'mfa'; tempToken: string; mfaMethod: MfaMethod; passkeyAvailable: boolean; phoneLast4: string | null }
+  | { state: 'mfa'; challenge: MfaChallenge }
   | { state: 'complete'; user: User; tokens: Tokens; requiresSetup: boolean; redirectPath?: string }
   | { state: 'failed'; reason: 'expired' | 'identity_in_use' | 'completion_failed' | 'other'; error?: string };
 
@@ -1385,16 +1427,11 @@ export async function apiSsoLinkConfirm(password: string): Promise<SsoLinkConfir
     }
 
     if (data.mfaRequired) {
-      if (typeof data.tempToken !== 'string' || data.tempToken.length === 0) {
+      const challenge = parseMfaChallengeResponse(data);
+      if (!challenge) {
         return { state: 'failed', reason: 'other', error: 'Confirmation failed' };
       }
-      return {
-        state: 'mfa',
-        tempToken: data.tempToken,
-        mfaMethod: (data.mfaMethod as MfaMethod) || 'totp',
-        passkeyAvailable: data.passkeyAvailable === true,
-        phoneLast4: typeof data.phoneLast4 === 'string' ? data.phoneLast4 : null
-      };
+      return { state: 'mfa', challenge };
     }
 
     if (data.user && data.tokens) {
@@ -1804,6 +1841,92 @@ export async function apiSendSmsMfaCode(tempToken: string): Promise<{
   }
 }
 
+export interface MfaEnrollmentOptions {
+  allowedMethods: { totp: boolean; sms: boolean; passkey: boolean };
+  phoneConfigured: boolean;
+}
+
+export type MfaEnrollmentCompletion =
+  | { success: true; recoveryCodes: string[]; tokens: Tokens }
+  | { success: false; error: string };
+
+function parseMfaEnrollmentCompletion(data: unknown): MfaEnrollmentCompletion | null {
+  if (!data || typeof data !== 'object') return null;
+  const value = data as Record<string, unknown>;
+  const tokens = value.tokens as Record<string, unknown> | undefined;
+  if (
+    !Array.isArray(value.recoveryCodes)
+    || value.recoveryCodes.some((code) => typeof code !== 'string')
+    || !tokens
+    || typeof tokens.accessToken !== 'string'
+    || typeof tokens.expiresInSeconds !== 'number'
+  ) return null;
+  return { success: true, recoveryCodes: value.recoveryCodes, tokens: tokens as unknown as Tokens };
+}
+
+export async function apiGetMfaEnrollmentOptions(): Promise<
+  | { success: true; options: MfaEnrollmentOptions }
+  | { success: false; error: string }
+> {
+  try {
+    const response = await fetchWithAuth('/auth/mfa/enrollment-options');
+    const data = await response.json().catch(() => null);
+    if (!response.ok) return { success: false, error: extractApiError(data, 'Could not load MFA options') };
+    if (
+      !data
+      || typeof data.allowedMethods?.totp !== 'boolean'
+      || typeof data.allowedMethods?.sms !== 'boolean'
+      || typeof data.allowedMethods?.passkey !== 'boolean'
+      || typeof data.phoneConfigured !== 'boolean'
+    ) return { success: false, error: 'Invalid MFA enrollment options' };
+    return { success: true, options: data as MfaEnrollmentOptions };
+  } catch {
+    return { success: false, error: 'Network error' };
+  }
+}
+
+export async function apiEnableTotpMfa(code: string, currentPassword: string): Promise<MfaEnrollmentCompletion> {
+  try {
+    const response = await fetchWithAuth('/auth/mfa/enable', {
+      method: 'POST',
+      body: JSON.stringify({ code, currentPassword }),
+    });
+    const data = await response.json().catch(() => null);
+    if (!response.ok) return { success: false, error: extractApiError(data, 'Failed to enable MFA') };
+    return parseMfaEnrollmentCompletion(data) ?? { success: false, error: 'Invalid MFA enrollment response' };
+  } catch {
+    return { success: false, error: 'Network error' };
+  }
+}
+
+export async function apiEnrollPasskey(currentPassword: string): Promise<MfaEnrollmentCompletion> {
+  try {
+    const optionsResponse = await fetchWithAuth('/auth/passkeys/register/options', {
+      method: 'POST',
+      body: JSON.stringify({ currentPassword }),
+    });
+    const optionsData = await optionsResponse.json().catch(() => null);
+    if (!optionsResponse.ok) {
+      return { success: false, error: extractApiError(optionsData, 'Failed to start passkey enrollment') };
+    }
+    const credential = await createPasskeyCredential(optionsData.options ?? optionsData.optionsJSON);
+    const verifyResponse = await fetchWithAuth('/auth/passkeys/register/verify', {
+      method: 'POST',
+      body: JSON.stringify({ credential }),
+    });
+    const verifyData = await verifyResponse.json().catch(() => null);
+    if (!verifyResponse.ok) {
+      return { success: false, error: extractApiError(verifyData, 'Failed to enroll passkey') };
+    }
+    return parseMfaEnrollmentCompletion(verifyData) ?? { success: false, error: 'Invalid MFA enrollment response' };
+  } catch (error) {
+    if (error instanceof Error && error.name === 'NotAllowedError') {
+      return { success: false, error: 'Passkey enrollment was canceled or timed out' };
+    }
+    return { success: false, error: 'Network error' };
+  }
+}
+
 export async function apiVerifyPhone(phoneNumber: string, currentPassword: string): Promise<{
   success: boolean;
   error?: string;
@@ -1848,11 +1971,7 @@ export async function apiConfirmPhone(phoneNumber: string, code: string, current
   }
 }
 
-export async function apiEnableSmsMfa(currentPassword: string): Promise<{
-  success: boolean;
-  recoveryCodes?: string[];
-  error?: string;
-}> {
+export async function apiEnableSmsMfa(currentPassword: string): Promise<MfaEnrollmentCompletion> {
   try {
     const response = await fetchWithAuth('/auth/mfa/sms/enable', {
       method: 'POST',
@@ -1865,7 +1984,7 @@ export async function apiEnableSmsMfa(currentPassword: string): Promise<{
       return { success: false, error: extractApiError(data, 'Failed to enable SMS MFA') };
     }
 
-    return { success: true, recoveryCodes: data.recoveryCodes };
+    return parseMfaEnrollmentCompletion(data) ?? { success: false, error: 'Invalid MFA enrollment response' };
   } catch {
     return { success: false, error: 'Network error' };
   }

--- a/docs/superpowers/plans/security-auth/2026-08-28-mfa-client-completion.md
+++ b/docs/superpowers/plans/security-auth/2026-08-28-mfa-client-completion.md
@@ -103,6 +103,8 @@ export interface CompleteInitialMfaEnrollmentInput<T> {
   userId: string;
   identity: UserSessionIdentity;
   capability: AuthIssuanceCapability;
+  expectedAuthEpoch: number;
+  expectedMfaEpoch: number;
   revokeReason: string;
   recoveryCodes: readonly string[];
   recoveryCodeHashes: readonly string[];
@@ -122,7 +124,7 @@ export async function completeInitialMfaEnrollment<T>(
 ): Promise<CompletedInitialMfaEnrollment<T>>;
 ```
 
-Generate and hash recovery codes before beginning guarded finalization; do not expose them unless finalization commits. Implementation order inside `finishAuthIssuance(capability, tx => ...)` is: advance `mfa_epoch` while locking the user, revoke all existing refresh families, issue the replacement family/session with the new epochs, then call `persistFactor` with the precomputed hashes. The transaction rollback removes the new family, factor, recovery hashes, epoch change, and revocations together. After commit, routes bind the issued session, install refresh/CSRF cookies, run best-effort Redis/remote-session cleanup, and return public access metadata plus the precomputed plaintext recovery codes.
+Generate and hash recovery codes before beginning guarded finalization; do not expose them unless finalization commits. Implementation order inside `finishAuthIssuance(capability, tx => ...)` is: conditionally advance `mfa_epoch` while locking the active, still-unenrolled user at both `expectedAuthEpoch` and `expectedMfaEpoch`, revoke all existing refresh families, issue the replacement family/session with the new epochs, then call `persistFactor` with the precomputed hashes. The conditional epoch write makes concurrent terminal enrollments single-winner and prevents a request authenticated before a password/reset/logout cutoff from laundering stale authority into the newer auth epoch. The transaction rollback removes the new family, factor, recovery hashes, epoch change, and revocations together. After commit, routes bind the issued session, install refresh/CSRF cookies, run best-effort Redis/remote-session cleanup, and return public access metadata plus the precomputed plaintext recovery codes.
 
 ---
 

--- a/docs/superpowers/plans/security-auth/2026-08-28-mfa-client-completion.md
+++ b/docs/superpowers/plans/security-auth/2026-08-28-mfa-client-completion.md
@@ -1,0 +1,456 @@
+# MFA Client Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete issue #2489 by making MFA challenges policy-safe and method-aware across the API, web, and mobile clients, while adding policy-driven forced enrollment and fail-closed mobile behavior for enrollment-required responses.
+
+**Architecture:** The API computes one authoritative challenge contract from enrolled factors and the live effective MFA policy, stores the same authorization facts in a strictly parsed pending record, and rechecks enrollment, policy, epochs, and account state at every continuation. Web and mobile adapters normalize that contract before rendering client-specific method selectors. Initial factor enrollment finishes through a shared transactional service that advances `mfa_epoch`, revokes old refresh families, persists the factor and recovery codes, and issues a replacement W07 session atomically.
+
+**Tech Stack:** Hono, TypeScript, Drizzle ORM, PostgreSQL transactions/row locks, Redis pending challenges, Vitest, Astro/React, React Native/Expo, Redux Toolkit.
+
+## Global Constraints
+
+- The approved design at `docs/superpowers/specs/security-auth/2026-08-28-mfa-client-completion-design.md` is normative.
+- Scope is #2489, #3853, and the client-completion portion of #3854. W07 native-binding transport remains deferred, so #3854 stays open after Slice 4.
+- Do not deploy, push, merge, enable `AUTH_BROWSER_TRANSITIONS_ENFORCED`, or add another rollout flag. The only protocol marker in scope is `x-breeze-auth-transition: v1`.
+- Preserve the W07 capability boundary: only `issueUserSession` may mint the replacement session, and issuance must finish under `finishAuthIssuance` with the request binding.
+- Global lock order remains transition, user, refresh families, then factor-specific rows. No network call, WebAuthn verification, SMS send, or password/TOTP computation may run while a database transaction or row lock is held.
+- Every method continuation independently authorizes the pending challenge, requested method, actual enrollment, live policy, current account status, `auth_epoch`, and `mfa_epoch`. A live-policy or epoch mismatch is terminal and deletes the pending challenge.
+- Pending-record booleans are strict. Records missing `allowedMethods` or `recoveryAvailable`, or containing non-boolean values, are rejected rather than defaulted. Existing records may therefore fail closed for at most the current 300-second TTL.
+- Recovery-code consumption moves inside guarded finalization only for the v1 pending-record path. Preserve the legacy path until W07 Phase 2.
+- `passkey` is included in the shared `MfaMethod` type, but native mobile challenge completion supports only TOTP, SMS, and recovery in this work.
+- Recovery codes are returned only after a factor is successfully enabled. A partial setup, canceled registration, failed confirmation, or rolled-back transaction must not create or expose recovery codes.
+- `commitIfCurrent` ordering is mandatory on mobile: advance the generation before logout/account switch, then guard every asynchronous challenge or enrollment result before changing credentials or navigation state.
+- Strict TDD applies to each slice: observe each focused test fail for the intended reason, implement the smallest coherent change, pass the focused suite, then commit the slice.
+
+---
+
+## File and Interface Map
+
+### New files
+
+- `apps/api/src/services/mfaEnrollmentSession.ts` — atomic initial-factor persistence, recovery-code persistence, assurance invalidation, refresh-family revocation, and replacement W07 session issuance.
+- `apps/api/src/services/mfaEnrollmentSession.test.ts` — transaction order, rollback, and result-contract unit tests.
+- `apps/api/src/__tests__/integration/mfaEnrollmentSession.integration.test.ts` — real-database rollback and concurrent-completion barriers.
+- `apps/web/src/lib/mfaChallenge.ts` — strict compatibility adapter for new and legacy login responses.
+- `apps/web/src/lib/mfaChallenge.test.ts` — new-contract, legacy fallback, and malformed-response tests.
+- `apps/web/src/components/auth/MFAVerifyForm.test.tsx` — selector, input-mode, SMS-send, recovery, and passkey behavior.
+- `apps/web/src/components/auth/ForcedMfaSetupPage.test.tsx` — policy-driven enrollment choices and terminal-session response handling.
+- `apps/mobile/src/screens/auth/MfaEnrollmentRequiredScreen.tsx` — actionable web/admin handoff without installing returned credentials.
+- `apps/mobile/src/screens/auth/MfaEnrollmentRequiredScreen.test.tsx` — fail-closed rendering and navigation tests.
+- `apps/mobile/src/screens/auth/MfaChallengeScreen.test.tsx` — native method selection, input, SMS-send, and stale-completion tests.
+
+### Existing files with central changes
+
+- `apps/api/src/routes/auth/{helpers,helpers.test,login,login.test,mfa}.ts`
+- `apps/api/src/routes/auth/{phone,phone.test,passkeys}.ts`
+- `apps/api/src/routes/auth.passkeys.test.ts`
+- `apps/api/src/routes/auth/index.ts`
+- `apps/api/src/routes/auth/schemas.ts`
+- `apps/api/src/routes/auth.test.ts`
+- `apps/api/src/services/{mfaAssurance,mfaAssurance.test,userSession}.ts`
+- `apps/api/src/middleware/{auth,auth.test}.ts`
+- `apps/web/src/stores/{auth,auth.test}.ts`
+- `apps/web/src/components/auth/{LoginPage,LoginPage.test,LoginPage.passkeys.test,MFAVerifyForm,ForcedMfaSetupPage}.tsx`
+- `apps/mobile/src/services/{api,api.mfa.test}.ts`
+- `apps/mobile/src/store/{authSlice,authSlice.test}.ts`
+- `apps/mobile/src/navigation/RootNavigator.tsx`
+- `docs/testing/FEATURE_TEST_LOG.md`
+
+### Stable challenge interfaces
+
+```ts
+export type MfaMethod = 'totp' | 'sms' | 'passkey' | 'recovery';
+
+export interface MfaAllowedMethods {
+  totp: boolean;
+  sms: boolean;
+  passkey: boolean;
+}
+
+export interface MfaRequiredResponse {
+  mfaRequired: true;
+  tempToken: string;
+  mfaMethod: Exclude<MfaMethod, 'recovery'>;
+  allowedMethods: MfaAllowedMethods;
+  recoveryAvailable: boolean;
+  passkeyAvailable: boolean;
+  phoneLast4: string | null;
+  user: null;
+  tokens: null;
+}
+
+export interface PendingMfaRecord {
+  userId: string;
+  mfaMethod: Exclude<MfaMethod, 'recovery'>;
+  allowedMethods: MfaAllowedMethods;
+  recoveryAvailable: boolean;
+  authEpoch: number;
+  mfaEpoch: number;
+  transitionId: string;
+  transitionGeneration: number;
+  expiresAt: number;
+  pendingSsoLink?: PendingSsoLink;
+}
+```
+
+`passkeyAvailable` remains in the response as a compatibility alias for `allowedMethods.passkey`. New clients treat `allowedMethods` and `recoveryAvailable` as authoritative. Legacy clients fall back only when both new fields are absent and the legacy fields are well formed.
+
+### Atomic enrollment-session interface
+
+```ts
+export interface CompleteInitialMfaEnrollmentInput<T> {
+  userId: string;
+  identity: UserSessionIdentity;
+  capability: AuthIssuanceCapability;
+  revokeReason: string;
+  recoveryCodes: readonly string[];
+  recoveryCodeHashes: readonly string[];
+  persistFactor: (tx: Tx, recoveryCodeHashes: readonly string[]) => Promise<T>;
+}
+
+export interface CompletedInitialMfaEnrollment<T> {
+  value: T;
+  recoveryCodes: string[];
+  issued: AuthorizedUserSession;
+  mfaEpoch: number;
+  cleanup: MfaAssuranceCleanup;
+}
+
+export async function completeInitialMfaEnrollment<T>(
+  input: CompleteInitialMfaEnrollmentInput<T>,
+): Promise<CompletedInitialMfaEnrollment<T>>;
+```
+
+Generate and hash recovery codes before beginning guarded finalization; do not expose them unless finalization commits. Implementation order inside `finishAuthIssuance(capability, tx => ...)` is: advance `mfa_epoch` while locking the user, revoke all existing refresh families, issue the replacement family/session with the new epochs, then call `persistFactor` with the precomputed hashes. The transaction rollback removes the new family, factor, recovery hashes, epoch change, and revocations together. After commit, routes bind the issued session, install refresh/CSRF cookies, run best-effort Redis/remote-session cleanup, and return public access metadata plus the precomputed plaintext recovery codes.
+
+---
+
+## Slice 1: API Challenge Contract and Independent Authorization
+
+**Outcome:** Login returns an authoritative method set, all continuations reauthorize that method, forced enrollment exposes live options, and every terminal enrollment replaces the session atomically.
+
+### Task 1.1: Freeze the strict pending-record and response contract
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/helpers.ts`
+- Modify: `apps/api/src/routes/auth/helpers.test.ts`
+- Modify: `apps/api/src/routes/auth/schemas.ts`
+
+- [ ] Add table-driven red tests for a valid v1 record; each missing boolean; string/number/null booleans; invalid `mfaMethod`; invalid epochs; expired records; and a well-formed optional SSO link.
+- [ ] Add schema tests proving `/auth/mfa/verify` accepts exactly `totp`, `sms`, or `recovery`, while passkey remains on its dedicated continuation.
+- [ ] Implement structural validation without truthy/falsy defaults. Return `null` for every malformed or expired record.
+- [ ] Run:
+
+```bash
+pnpm --filter=@breeze/api exec vitest run src/routes/auth/helpers.test.ts src/routes/auth/auth.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+### Task 1.2: Derive and persist the authoritative login challenge
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/login.ts`
+- Modify: `apps/api/src/routes/auth/login.test.ts`
+
+- [ ] Add the full derivation matrix for enrolled TOTP, enrolled/configured SMS, registered passkey, recovery hashes, and effective live policy.
+- [ ] Assert legacy `mfaMethod` selection is deterministic: retain the configured primary when allowed; otherwise use TOTP, then SMS, then passkey; never emit `recovery` as the primary.
+- [ ] Assert no usable primary or recovery method returns the existing generic authentication failure, writes no pending record, and leaks no enrollment/policy detail.
+- [ ] Assert the Redis record and HTTP response contain the same `allowedMethods` and `recoveryAvailable` values, with `user: null` and `tokens: null`.
+- [ ] Implement one pure helper near the login handler:
+
+```ts
+function deriveMfaChallenge(input: {
+  enrolled: { totp: boolean; sms: boolean; passkey: boolean };
+  recoveryAvailable: boolean;
+  allowedByPolicy: MfaAllowedMethods;
+  preferred: Exclude<MfaMethod, 'recovery'>;
+}): { allowedMethods: MfaAllowedMethods; recoveryAvailable: boolean; primary: Exclude<MfaMethod, 'recovery'> } | null;
+```
+
+- [ ] Run the focused login suite and confirm both the old legacy response assertions and new matrix pass.
+
+### Task 1.3: Enforce the normative method-switch algorithm
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/mfa.ts`
+- Modify: `apps/api/src/routes/auth.test.ts`
+
+- [ ] Add the method-switch matrix: pending-primary default, allowed TOTP switch, allowed SMS switch, authorized recovery switch, disallowed switch, missing enrollment, live-policy drift, epoch drift, disabled/locked user, malformed pending record, and replay after terminal failure.
+- [ ] Add a deterministic recovery concurrency test proving one code can finalize one session only; keep the existing legacy-path consumption assertion unchanged.
+- [ ] Implement selection and authorization in this exact order:
+
+```ts
+const requestedMethod = body.method ?? pending.mfaMethod;
+if (requestedMethod === 'recovery') authorizePendingRecovery(pending);
+else authorizePendingMethod(pending, requestedMethod, liveUser, livePolicy);
+```
+
+- [ ] Delete the pending record on policy/epoch/status terminal failures. Preserve it for a wrong TOTP/SMS/recovery value subject to current attempt/rate limits.
+- [ ] Move v1 recovery consumption into the guarded finalization transaction so rollback or a lost transition race does not burn a code.
+- [ ] Run `auth.test.ts` alone until the complete matrix passes.
+
+### Task 1.4: Independently authorize SMS and passkey continuations
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/phone.ts`
+- Modify: `apps/api/src/routes/auth/phone.test.ts`
+- Modify: `apps/api/src/routes/auth/passkeys.ts`
+- Modify: `apps/api/src/routes/auth.passkeys.test.ts`
+
+- [ ] For `/auth/mfa/sms/send`, add red tests for malformed pending data, SMS not authorized, SMS not enrolled/configured, policy drift, epoch drift, disabled/locked account, exhausted rate limit, and a valid method switch from TOTP.
+- [ ] Assert no SMS provider call happens until every pending/live check and rate limit passes.
+- [ ] For `/auth/mfa/passkey/options` and `/auth/mfa/passkey/verify`, add the same authorization cases plus a valid switch from another primary and terminal pending deletion on drift.
+- [ ] Replace `mfaMethod === 'passkey' || passkeyAvailable` with `allowedMethods.passkey` and live enrollment/policy checks on both routes.
+- [ ] Keep WebAuthn option generation and assertion verification outside the guarded database transaction.
+- [ ] Run:
+
+```bash
+pnpm --filter=@breeze/api exec vitest run src/routes/auth/phone.test.ts src/routes/auth/auth.passkeys.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+### Task 1.5: Add forced-enrollment options and atomic terminal enrollment
+
+**Files:**
+- Create: `apps/api/src/services/mfaEnrollmentSession.ts`
+- Create: `apps/api/src/services/mfaEnrollmentSession.test.ts`
+- Create: `apps/api/src/__tests__/integration/mfaEnrollmentSession.integration.test.ts`
+- Modify: `apps/api/src/services/mfaAssurance.ts`
+- Modify: `apps/api/src/services/mfaAssurance.test.ts`
+- Modify: `apps/api/src/routes/auth/mfa.ts`
+- Modify: `apps/api/src/routes/auth/phone.ts`
+- Modify: `apps/api/src/routes/auth/passkeys.ts`
+- Modify: `apps/api/src/routes/auth/index.ts`
+- Modify: `apps/api/src/middleware/auth.test.ts`
+- Modify the same route test files from Tasks 1.3 and 1.4.
+
+- [ ] Add `GET /auth/mfa/enrollment-options`, authenticated and current-user scoped, returning `{ allowedMethods, phoneConfigured }` from the effective policy. Passkey is always allowed by current policy behavior.
+- [ ] Prove the route is reachable while the normal authenticated surface is returning the 428 enrollment gate; retain existing `/auth/mfa/*`, `/auth/phone/*`, and `/auth/passkeys/*` exemptions.
+- [ ] Add service unit tests for success, factor-write failure, session-issuance failure, epoch mismatch, mismatched plaintext/hash counts, and cleanup metadata. Assert all authority-bearing writes share one supplied transaction and recovery-code generation/hashing finishes before it starts.
+- [ ] Add real-DB integration tests with deterministic barriers for two simultaneous terminal completions. Exactly one replacement session/factor commit may win; no test may use sleeps for ordering.
+- [ ] Add route tests proving TOTP setup does not return recovery codes; successful TOTP enable, SMS enable, and first passkey registration each return recovery codes and a replacement access session while installing refresh/CSRF cookies.
+- [ ] Add rollback tests proving none of factor state, recovery hashes, `mfa_epoch`, old-family revocations, or the new family commits alone.
+- [ ] Refactor the existing invalidation primitive only enough to share epoch/revocation/cleanup logic; existing non-enrollment factor changes keep their current behavior.
+- [ ] Bind the issued session and install cookies only after transaction commit. If post-commit Redis/remote cleanup fails, preserve the committed session and log/metric the cleanup failure.
+- [ ] Run:
+
+```bash
+pnpm --filter=@breeze/api exec vitest run src/services/mfaEnrollmentSession.test.ts src/services/mfaAssurance.test.ts src/routes/auth/helpers.test.ts src/routes/auth/login.test.ts src/routes/auth/auth.test.ts src/routes/auth/phone.test.ts src/routes/auth/auth.passkeys.test.ts src/middleware/auth.test.ts --maxWorkers=1 --no-file-parallelism
+pnpm --filter=@breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/mfaEnrollmentSession.integration.test.ts --maxWorkers=1 --no-file-parallelism
+```
+
+- [ ] Commit Slice 1:
+
+```bash
+git add apps/api
+git commit -m "feat(auth): enforce MFA challenge contract (#3853)"
+```
+
+---
+
+## Slice 2: Web Login Method Completion
+
+**Outcome:** The browser renders every authorized challenge method, uses method-correct input behavior, and fails closed on malformed new responses while remaining compatible with old servers.
+
+### Task 2.1: Build the web compatibility adapter
+
+**Files:**
+- Create: `apps/web/src/lib/mfaChallenge.ts`
+- Create: `apps/web/src/lib/mfaChallenge.test.ts`
+- Modify: `apps/web/src/stores/auth.ts`
+- Modify: `apps/web/src/stores/auth.test.ts`
+
+- [ ] Add red tests for a valid new response, each allowed-method combination, recovery-only availability, legacy TOTP/SMS/passkey responses, malformed/empty new fields, `mfaMethod: 'recovery'`, and inconsistent passkey aliases.
+- [ ] Implement `parseMfaChallengeResponse(value): MfaChallenge | null`. Use the legacy fallback only when both `allowedMethods` and `recoveryAvailable` are absent; reject partially present new contracts.
+- [ ] Extend `apiVerifyMFA` to send `{ code, method }` for TOTP/SMS/recovery. Keep passkey on the existing options/verify calls.
+- [ ] Return a typed authentication error for malformed challenge data so LoginPage cannot enter an unusable MFA state.
+- [ ] Run the adapter and auth-store suites.
+
+### Task 2.2: Render the selector and method-correct controls
+
+**Files:**
+- Modify: `apps/web/src/components/auth/MFAVerifyForm.tsx`
+- Create: `apps/web/src/components/auth/MFAVerifyForm.test.tsx`
+- Modify: `apps/web/src/components/auth/LoginPage.tsx`
+- Modify: `apps/web/src/components/auth/LoginPage.test.tsx`
+- Modify: `apps/web/src/components/auth/LoginPage.passkeys.test.tsx`
+
+- [ ] Add component tests proving the selector is hidden for one method and shown for two or more, including recovery as a selectable method.
+- [ ] Assert TOTP and SMS accept exactly six numeric digits; recovery accepts text, trims only outer whitespace, and preserves internal separators; passkey renders its existing continuation.
+- [ ] Assert selecting SMS sends once, does not double-send on rerender, observes the cooldown, and surfaces send failure without silently switching methods.
+- [ ] Assert selecting passkey does not post to `/mfa/verify`; selecting recovery sends the normalized recovery code and explicit method.
+- [ ] Store the full normalized challenge in `LoginPage`, initialize selection from its primary, and clear challenge state on cancel, successful completion, or a terminal server response.
+- [ ] Preserve existing loading, toast, and passkey-browser fallback behavior.
+- [ ] Run:
+
+```bash
+pnpm --filter=@breeze/web exec vitest run src/lib/mfaChallenge.test.ts src/stores/auth.test.ts src/components/auth/MFAVerifyForm.test.tsx src/components/auth/LoginPage.test.tsx src/components/auth/LoginPage.passkeys.test.tsx
+```
+
+- [ ] Commit Slice 2:
+
+```bash
+git add apps/web
+git commit -m "feat(web): complete MFA login methods (#3853)"
+```
+
+---
+
+## Slice 3: Web Forced Enrollment Completion
+
+**Outcome:** The browser offers only policy-permitted initial factors, completes one factor at a time, and adopts the API-issued replacement session only after terminal success.
+
+### Task 3.1: Add enrollment option API bindings
+
+**Files:**
+- Modify: `apps/web/src/stores/auth.ts`
+- Modify: `apps/web/src/stores/auth.test.ts`
+
+- [ ] Add red tests for `apiGetMfaEnrollmentOptions`, TOTP enable, SMS enable, and passkey register responses carrying replacement access metadata and recovery codes.
+- [ ] Type the enrollment response separately from ordinary profile factor changes so callers must handle replacement-session metadata.
+- [ ] Reuse the normal cookie-backed session installation path; do not call `/auth/refresh` after enrollment.
+
+### Task 3.2: Make ForcedMfaSetupPage policy-driven
+
+**Files:**
+- Modify: `apps/web/src/components/auth/ForcedMfaSetupPage.tsx`
+- Create: `apps/web/src/components/auth/ForcedMfaSetupPage.test.tsx`
+
+- [ ] Add tests for TOTP-only, SMS configured, SMS missing phone, passkey-only, multiple methods, option-load failure, no usable method, canceled setup, failed terminal enable, and successful completion for each factor.
+- [ ] Fetch enrollment options on entry. Recovery is never an enrollment choice; SMS is enabled only when both policy and `phoneConfigured` permit it.
+- [ ] Reuse current TOTP setup/enable, phone verify/SMS enable, and passkey registration operations rather than creating parallel factor logic.
+- [ ] Keep recovery codes hidden until the terminal endpoint succeeds; show the returned set once and require the existing acknowledgement behavior before leaving.
+- [ ] Adopt the response access metadata only through the auth store’s current-session guard, then navigate to the originally gated destination. On failure, remain in enrollment and retain no partial client session.
+- [ ] Fail closed with support/admin guidance if options cannot load or no method is usable.
+- [ ] Run:
+
+```bash
+pnpm --filter=@breeze/web exec vitest run src/stores/auth.test.ts src/components/auth/ForcedMfaSetupPage.test.tsx
+```
+
+- [ ] Commit Slice 3:
+
+```bash
+git add apps/web
+git commit -m "feat(web): add policy-driven MFA enrollment (#3853)"
+```
+
+---
+
+## Slice 4: Mobile Challenge Completion and Enrollment Fail-Closed
+
+**Outcome:** Native login supports TOTP, SMS, and recovery method switching, never exposes an unsupported passkey-only dead end as a code form, and never installs credentials from an enrollment-required response.
+
+### Task 4.1: Normalize mobile authentication responses
+
+**Files:**
+- Modify: `apps/mobile/src/services/api.ts`
+- Modify: `apps/mobile/src/services/api.mfa.test.ts`
+
+- [ ] Add `MfaMethod`, `MfaAllowedMethods`, and the same strict new/legacy adapter rules as web; share semantics, not a cross-package runtime import.
+- [ ] Expand `LoginResult` into explicit success, challenge, and enrollment-required variants. The enrollment-required variant contains only display/handoff information, never installable tokens or a user.
+- [ ] Add tests for new challenge combinations, recovery availability, legacy fallback, malformed fields, passkey-only challenge, and 428/`mfaEnrollmentRequired` bodies that contain tempting token-shaped fields.
+- [ ] Change `verifyMfa` to accept an explicit TOTP/SMS/recovery method and preserve internal recovery separators.
+- [ ] Do not change W07 native-binding header generation or transport in this slice.
+
+### Task 4.2: Fence Redux challenge and enrollment state
+
+**Files:**
+- Modify: `apps/mobile/src/store/authSlice.ts`
+- Modify: `apps/mobile/src/store/authSlice.test.ts`
+
+- [ ] Add red tests proving login stores a normalized challenge but no credentials, verification commits only for the current generation, logout/account switch invalidates an in-flight result, and enrollment-required discards every returned token/user field.
+- [ ] Add explicit `mfaEnrollmentRequired` state containing a safe handoff reason/URL and clear it on a new login, logout, account switch, or successful current-generation authentication.
+- [ ] Advance the session generation before clearing credentials on logout/account switch. Route every async login/MFA completion through `commitIfCurrent` before mutating SecureStore or Redux state.
+- [ ] Preserve the challenge on a retryable wrong code; clear it on terminal policy/epoch/status failure.
+
+### Task 4.3: Add the native selector and handoff screen
+
+**Files:**
+- Modify: `apps/mobile/src/screens/auth/MfaChallengeScreen.tsx`
+- Create: `apps/mobile/src/screens/auth/MfaChallengeScreen.test.tsx`
+- Create: `apps/mobile/src/screens/auth/MfaEnrollmentRequiredScreen.tsx`
+- Create: `apps/mobile/src/screens/auth/MfaEnrollmentRequiredScreen.test.tsx`
+- Modify: `apps/mobile/src/navigation/RootNavigator.tsx`
+
+- [ ] Add selector tests for one vs multiple supported methods, TOTP/SMS numeric input, recovery text input, SMS one-send/cooldown behavior, and stale result suppression after navigation/account change.
+- [ ] Filter passkey out of native-selectable methods. If passkey is the only primary and no recovery method is available, show an upgrade/restart-on-web message instead of a numeric form.
+- [ ] Render `MfaEnrollmentRequiredScreen` before every authenticated navigator branch. Provide an explicit open-web/sign-out/admin-contact path, with no route into the app shell.
+- [ ] Assert the approver-registration effect and other authenticated startup effects do not run while enrollment is required.
+- [ ] Run:
+
+```bash
+pnpm --filter=breeze-mobile exec vitest run src/services/api.mfa.test.ts src/store/authSlice.test.ts src/screens/auth/MfaChallengeScreen.test.tsx src/screens/auth/MfaEnrollmentRequiredScreen.test.tsx
+pnpm --filter=breeze-mobile typecheck
+```
+
+- [ ] Commit Slice 4:
+
+```bash
+git add apps/mobile
+git commit -m "feat(mobile): complete MFA challenge handling (#3854)"
+```
+
+---
+
+## Slice 5: Consolidated Security Review and Verification
+
+**Outcome:** One independent review validates the full cross-client implementation, all findings are fixed with targeted tests, and the feature log records evidence without deploying or closing #3854.
+
+### Task 5.1: Run focused and package verification
+
+- [ ] Run the complete focused suites from Slices 1–4 again from a clean worktree.
+- [ ] Run package-level checks:
+
+```bash
+pnpm --filter=@breeze/api test:run
+pnpm --filter=@breeze/api lint
+pnpm --filter=@breeze/api build
+pnpm --filter=@breeze/web exec vitest run
+pnpm --filter=@breeze/web lint
+pnpm --filter=@breeze/web build
+pnpm --filter=breeze-mobile test
+pnpm --filter=breeze-mobile typecheck
+```
+
+- [ ] Run the integration test with the repository test database. If the database is unavailable, record the exact infrastructure failure and do not describe integration coverage as passing.
+- [ ] Run `git diff --check` and inspect `git status --short` for untracked fixtures, snapshots, secrets, or unrelated user changes.
+
+### Task 5.2: Dispatch one independent review
+
+- [ ] Provide the reviewer the approved spec, this plan, the full branch diff from `origin/main`, and these mandatory review questions:
+  - Can any pending-record field, method switch, or continuation bypass live policy or enrollment?
+  - Can recovery codes be consumed without a committed session, or exposed before committed enrollment?
+  - Can factor state, epochs, family revocation, or replacement issuance commit partially or violate the W07 lock order?
+  - Can either client install stale or enrollment-gated credentials?
+  - Did this work add native W07 transport or any deploy/flag behavior outside scope?
+- [ ] Fix every confirmed finding with a reproducing test, then rerun the affected focused suite. Request a second review only if the fix itself changes high-blast auth/session behavior or the user requests high rigor.
+
+### Task 5.3: Record evidence and hand off issues accurately
+
+**Files:**
+- Modify: `docs/testing/FEATURE_TEST_LOG.md`
+
+- [ ] Record exact commands, dates, pass/fail counts, and any unavailable integration dependency.
+- [ ] Confirm #3853 is fully satisfied before using `Closes #3853` in a later PR. Use `Refs #3854` and state that MFA mobile client completion shipped while W07 native-binding transport remains open.
+- [ ] Confirm the branch contains no deployment, flag enablement, release, or issue-close mutation.
+- [ ] Commit Slice 5:
+
+```bash
+git add docs/testing/FEATURE_TEST_LOG.md apps/api apps/web apps/mobile
+git commit -m "test(auth): verify MFA client completion (#2489)"
+```
+
+---
+
+## Completion Checklist
+
+- [ ] Every normative API method-switch combination has a focused test.
+- [ ] Login response and pending record carry identical strict authorization facts.
+- [ ] SMS and passkey continuations independently reauthorize pending state and live state.
+- [ ] TOTP, SMS, and first-passkey enrollment atomically replace the old session and return recovery codes only after success.
+- [ ] Web supports TOTP, SMS, passkey, and recovery login plus policy-driven forced enrollment.
+- [ ] Mobile supports TOTP, SMS, and recovery, handles passkey-only safely, and fails closed on enrollment-required responses.
+- [ ] Mobile W07 native-binding transport remains untouched and #3854 remains open.
+- [ ] One independent review is clean or all confirmed findings have reproducing tests and verified fixes.
+- [ ] Focused, package, integration, lint, build, typecheck, and diff checks have recorded evidence.
+- [ ] Nothing was pushed, merged, deployed, or enabled.

--- a/docs/superpowers/specs/security-auth/2026-08-28-mfa-client-completion-design.md
+++ b/docs/superpowers/specs/security-auth/2026-08-28-mfa-client-completion-design.md
@@ -1,8 +1,8 @@
 # MFA Client Completion Design
 
-**Date:** 2026-08-28  
-**Issues:** #2489, #3853, #3854  
-**Scope:** API challenge negotiation, web MFA completion, and mobile MFA completion  
+**Date:** 2026-08-28
+**Issues:** #2489, #3853, #3854
+**Scope:** API challenge negotiation, web MFA completion, and mobile MFA completion
 **Out of scope:** deployment, production flag changes, W07 Phase 2 compatibility removal, unrelated W03-W06 follow-ups, and the #3854 items that belong to W07 native transport — native-binding bootstrap/retry (`x-breeze-native-auth-binding`) and the mobile v1 transition header. Those are deferred to a W07-native follow-up and are not claimed by this spec; #3854 stays open after slice 4 until they land.
 
 ## Objective

--- a/docs/superpowers/specs/security-auth/2026-08-28-mfa-client-completion-design.md
+++ b/docs/superpowers/specs/security-auth/2026-08-28-mfa-client-completion-design.md
@@ -1,0 +1,163 @@
+# MFA Client Completion Design
+
+**Date:** 2026-08-28  
+**Issues:** #2489, #3853, #3854  
+**Scope:** API challenge negotiation, web MFA completion, and mobile MFA completion  
+**Out of scope:** deployment, production flag changes, W07 Phase 2 compatibility removal, and unrelated W03-W06 follow-ups
+
+## Objective
+
+Complete the MFA client contract so the API, web client, and mobile client agree on which enrolled methods may be used for a login challenge. Users must be able to choose any server-authorized method, including a recovery code, without weakening the durable session authority delivered by W07 Phase 1.
+
+## Constraints
+
+- `AUTH_BROWSER_TRANSITIONS_ENABLED` and `AUTH_BROWSER_TRANSITIONS_ENFORCED` remain unchanged and disabled by default.
+- The server is authoritative for method availability. Clients never infer that a method is permitted merely because they can render it.
+- Existing clients that only understand `mfaMethod`, `passkeyAvailable`, and `phoneLast4` continue to work.
+- Recovery codes remain a fallback credential, not an organization policy enrollment method.
+- A challenge is bound to the user, auth epoch, MFA epoch, browser transition generation, and the server-authorized method set already captured in the pending record.
+- Verification re-checks live policy and enrollment state; the method list returned at password completion is not durable authority.
+- No production deployment or app-store action is part of this implementation.
+
+## Approaches Considered
+
+### 1. Extend the existing challenge response additively — selected
+
+Keep `mfaMethod` as the preferred method and add an `allowedMethods` object plus `recoveryAvailable`. New clients use the richer contract; old clients continue using the existing fields. This minimizes rollout risk and preserves the current endpoint topology.
+
+### 2. Replace the response with a method array
+
+Return only `methods: MfaMethod[]` and force all clients to migrate together. This is cleaner but creates an unnecessary coordinated-release dependency and can strand older mobile builds.
+
+### 3. Add a challenge-description endpoint
+
+Return an opaque challenge from login and require clients to fetch its methods separately. This permits later refreshes but adds a network round trip and another pre-auth endpoint without solving a current requirement.
+
+## API Contract
+
+The MFA-required login response remains backward compatible and gains two fields:
+
+```ts
+type MfaMethod = 'totp' | 'sms' | 'passkey' | 'recovery';
+
+interface MfaAllowedMethods {
+  totp: boolean;
+  sms: boolean;
+  passkey: boolean;
+}
+
+interface MfaRequiredResponse {
+  mfaRequired: true;
+  tempToken: string;
+  mfaMethod: 'totp' | 'sms';
+  allowedMethods: MfaAllowedMethods;
+  recoveryAvailable: boolean;
+  passkeyAvailable: boolean;
+  phoneLast4: string | null;
+  user: null;
+  tokens: null;
+}
+```
+
+`allowedMethods` describes enrolled methods that the effective policy permits for this challenge:
+
+- `totp` is true only when the account's enrolled TOTP method is allowed.
+- `sms` is true only when the account's enrolled SMS method is allowed and a phone number is present.
+- `passkey` is true only when a registered passkey exists and passkey MFA is permitted.
+- `recoveryAvailable` is true only when at least one stored recovery-code hash exists. It is separate because recovery is not a policy enrollment method.
+
+The response must expose at least one usable option. If policy and enrollment drift leave no usable primary, passkey, or recovery method, login fails closed with the existing generic authentication-error shape rather than issuing a challenge that cannot complete.
+
+The pending MFA record stores the authoritative `allowedMethods` and `recoveryAvailable` snapshot. `/auth/mfa/verify` accepts `method: 'recovery'` only when the record permits recovery, and continues to consume exactly one valid code atomically. Passkey verification continues through its dedicated WebAuthn endpoints and must satisfy the pending record's passkey flag.
+
+At verification time, the server re-checks live policy, factor ownership, epochs, and W07 transition authority. A method disabled after password verification fails without consuming the pending challenge or a recovery code unless the current security contract already requires terminal invalidation for that failure class.
+
+## Web Client
+
+The web client parses the additive fields with a backward-compatible adapter:
+
+- When `allowedMethods` is present and valid, it is authoritative.
+- Against an older server, the adapter exposes only the legacy `mfaMethod` and a passkey when `passkeyAvailable` is true; it does not guess recovery availability.
+- A present but malformed or empty new method contract fails closed and shows a restart-sign-in action.
+
+`MFAVerifyForm` renders a method selector only when more than one option is available. TOTP and SMS use a six-digit numeric input. Recovery uses a text input that preserves letters and separators while trimming surrounding whitespace. Passkey invokes the existing WebAuthn path.
+
+Changing to SMS sends a code once for the selected challenge and retains the existing resend cooldown. Switching away from SMS does not invalidate the challenge. Errors stay attached to the selected method without exposing factor inventory before password verification.
+
+Forced enrollment becomes policy-driven:
+
+- The forced-enrollment page calls `GET /auth/mfa/enrollment-options` with its limited authenticated session. The response is `{ allowedMethods: { totp: boolean; sms: boolean; passkey: boolean }, phoneConfigured: boolean }`; it never includes recovery because recovery depends on a primary factor.
+- TOTP reuses the current setup/enable flow.
+- SMS reuses the existing phone verification/enrollment flow.
+- Passkey reuses the current registration-grant/WebAuthn flow.
+- Recovery is never offered as enrollment because it depends on a primary factor.
+- If no enrollment method is available, the page fails closed and directs the user to an administrator instead of defaulting to TOTP.
+
+Successful enrollment updates the authenticated user, preserves W07 generation-safe session handling, displays any newly generated recovery codes exactly once, and returns to the intended destination.
+
+## Mobile Client
+
+Mobile uses the same response adapter and method semantics as web. The challenge state stores `allowedMethods`, `recoveryAvailable`, `passkeyAvailable`, and `phoneLast4` with the existing temp token.
+
+The MFA screen:
+
+- displays a selector for every server-authorized method the mobile client supports;
+- accepts six digits for TOTP/SMS and a trimmed, non-digit-only recovery string;
+- sends SMS only after SMS is selected and retains the resend cooldown;
+- verifies recovery through `/auth/mfa/verify` with `method: 'recovery'`;
+- treats a server-authorized method unsupported by the installed client as unavailable and shows an upgrade/restart path if nothing supported remains.
+
+All successful completions continue through `commitIfCurrent`. Logout, account switch, or a newer login generation prevents stale MFA responses from installing credentials, CSRF state, or native binding state.
+
+Mobile forced enrollment is not added in this change because #3854 scopes login/session completion, while the existing API does not yet expose a native forced-enrollment navigation contract. A mobile login response that requires enrollment must remain fail-closed with an actionable web/admin handoff rather than silently granting normal app access.
+
+## Error Handling and Security Properties
+
+- Unknown method values, malformed method objects, and empty usable-method sets fail closed.
+- Recovery input is never logged, included in telemetry, or retained after completion/cancellation.
+- Recovery codes are consumed only inside the guarded session-finalization transaction.
+- Selecting a method does not mint authority; all existing pending-token, rate-limit, epoch, RLS, and W07 capability checks remain in force.
+- Client error copy does not distinguish nonexistent accounts or disclose factor inventory before a correct password.
+- SMS send failures permit retry or selection of another authorized method without broadening the method set.
+- Passkey cancellation returns to method selection without consuming the challenge.
+
+## Testing
+
+### API
+
+- Contract tests for additive response fields and legacy fields.
+- Allowed-method derivation for TOTP, SMS, passkey, recovery, mixed methods, and no-usable-method failure.
+- Auth/authz and policy tests for `GET /auth/mfa/enrollment-options`, including limited forced-enrollment sessions and cross-tenant policy inheritance.
+- Malformed/stale pending-record rejection.
+- Live-policy disablement between password and verification.
+- Recovery unavailable, invalid, identical-code race, distinct-code race, and no-consumption on failed W07 admission.
+- Cross-user and cross-tenant pending-token rejection.
+
+### Web
+
+- Legacy-response fallback.
+- Server-driven method rendering and empty/malformed fail-closed behavior.
+- TOTP/SMS/recovery submission shapes and passkey dispatch.
+- SMS selection/resend lifecycle.
+- Recovery input formatting and clearing.
+- Forced enrollment choices for TOTP/SMS/passkey and no-method failure.
+- W07 428 retry and session-generation regression coverage.
+
+### Mobile
+
+- Challenge parsing and Redux storage of the method contract.
+- TOTP/SMS/recovery input and request shapes.
+- Unsupported-method and empty-method handling.
+- SMS selection/resend lifecycle.
+- Stale MFA completion after logout, account switch, or newer login generation.
+- Credential and native-binding installation only for the current generation.
+
+## Delivery Slices
+
+1. Additive API challenge contract and server-side authorization tests.
+2. Web login method selection and recovery-code completion.
+3. Web policy-driven forced enrollment.
+4. Mobile login method selection and recovery-code completion.
+5. Consolidated auth/security review and focused API/web/mobile verification.
+
+Each slice is independently reviewable. No slice changes production rollout flags or declares W07 Phase 2 complete.

--- a/docs/superpowers/specs/security-auth/2026-08-28-mfa-client-completion-design.md
+++ b/docs/superpowers/specs/security-auth/2026-08-28-mfa-client-completion-design.md
@@ -109,7 +109,9 @@ Forced enrollment becomes policy-driven:
 - Recovery is never offered as enrollment because it depends on a primary factor.
 - If no enrollment method is available, the page fails closed and directs the user to an administrator instead of defaulting to TOTP.
 
-Enrolling **any one** permitted method satisfies the policy requirement. Completion is atomic per factor: the existing enable/verify endpoint for that factor (TOTP enable, SMS phone verify, passkey registration finish) sets the account enrolled, generates recovery codes once, and clears the enrollment-required state in the same transaction it uses today; the client then re-issues MFA-assured credentials through the existing refresh path so the pre-enrollment `mfa=false` assurance is not reused. A partial or abandoned enrollment (setup started, never enabled) leaves the user in the 428-gated state with no factor recorded; no half-enrolled factor is ever persisted as enabled.
+Enrolling **any one** permitted method satisfies the policy requirement. Completion is atomic per factor: the terminal enable/verify endpoint for that factor (TOTP enable, SMS enable after phone verification, passkey registration finish) sets the account enrolled, generates recovery codes once, advances `mfa_epoch`, revokes the pre-enrollment refresh family, and issues its replacement MFA-assured W07 session in the same database transaction. The endpoint returns the replacement access-token metadata and installs the replacement refresh/CSRF cookies; the client must install that replacement before leaving the enrollment page. A partial or abandoned enrollment (setup started, never enabled) leaves the user in the 428-gated state with no factor recorded; no half-enrolled factor is ever persisted as enabled.
+
+The post-enrollment replacement is not implemented through `/auth/refresh`: `invalidateMfaAssuranceAfterFactorChange` revokes every existing refresh family, including the pre-enrollment family, so that path cannot authorize a replacement. The enrollment routes instead use the W07 issuance capability and `issueUserSession` inside the terminal factor-change transaction. If issuance cannot complete, the factor write and recovery-code write roll back with it; the response never reports enrollment success without a usable replacement session.
 
 Successful enrollment updates the authenticated user, preserves W07 generation-safe session handling, displays any newly generated recovery codes exactly once, and returns to the intended destination.
 
@@ -163,6 +165,7 @@ Mobile forced enrollment UI is not added in this change because #3854 scopes log
 - SMS selection/resend lifecycle.
 - Recovery input formatting and clearing.
 - Forced enrollment choices for TOTP/SMS/passkey and no-method failure.
+- Atomic factor write, recovery-code persistence, refresh-family revocation, and replacement-session issuance for TOTP/SMS/passkey enrollment.
 - W07 428 retry and session-generation regression coverage.
 
 ### Mobile

--- a/docs/superpowers/specs/security-auth/2026-08-28-mfa-client-completion-design.md
+++ b/docs/superpowers/specs/security-auth/2026-08-28-mfa-client-completion-design.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-28  
 **Issues:** #2489, #3853, #3854  
 **Scope:** API challenge negotiation, web MFA completion, and mobile MFA completion  
-**Out of scope:** deployment, production flag changes, W07 Phase 2 compatibility removal, and unrelated W03-W06 follow-ups
+**Out of scope:** deployment, production flag changes, W07 Phase 2 compatibility removal, unrelated W03-W06 follow-ups, and the #3854 items that belong to W07 native transport — native-binding bootstrap/retry (`x-breeze-native-auth-binding`) and the mobile v1 transition header. Those are deferred to a W07-native follow-up and are not claimed by this spec; #3854 stays open after slice 4 until they land.
 
 ## Objective
 
@@ -11,7 +11,7 @@ Complete the MFA client contract so the API, web client, and mobile client agree
 
 ## Constraints
 
-- `AUTH_BROWSER_TRANSITIONS_ENABLED` and `AUTH_BROWSER_TRANSITIONS_ENFORCED` remain unchanged and disabled by default.
+- `AUTH_BROWSER_TRANSITIONS_ENFORCED` (`apps/api/src/config/env.ts`) remains unchanged and disabled by default. There is no `AUTH_BROWSER_TRANSITIONS_ENABLED` flag: client opt-in is the per-request `x-breeze-auth-transition: v1` header (`routes/auth/helpers.ts`, `isAuthTransitionV1Request`), which the web client already sends.
 - The server is authoritative for method availability. Clients never infer that a method is permitted merely because they can render it.
 - Existing clients that only understand `mfaMethod`, `passkeyAvailable`, and `phoneLast4` continue to work.
 - Recovery codes remain a fallback credential, not an organization policy enrollment method.
@@ -49,7 +49,7 @@ interface MfaAllowedMethods {
 interface MfaRequiredResponse {
   mfaRequired: true;
   tempToken: string;
-  mfaMethod: 'totp' | 'sms';
+  mfaMethod: 'totp' | 'sms' | 'passkey'; // today: user.mfaMethod || 'totp'
   allowedMethods: MfaAllowedMethods;
   recoveryAvailable: boolean;
   passkeyAvailable: boolean;
@@ -65,12 +65,27 @@ interface MfaRequiredResponse {
 - `sms` is true only when the account's enrolled SMS method is allowed and a phone number is present.
 - `passkey` is true only when a registered passkey exists and passkey MFA is permitted.
 - `recoveryAvailable` is true only when at least one stored recovery-code hash exists. It is separate because recovery is not a policy enrollment method.
+- `mfaMethod` keeps its current derivation (`user.mfaMethod || 'totp'`, `routes/auth/login.ts`) and may be `'passkey'` for a passkey-only account — legacy clients already handle that value. Legacy behavior is therefore deterministic: a legacy client sees exactly what it sees today (`mfaMethod` + `passkeyAvailable`), and a recovery-only challenge (primary factor disallowed, passkey absent, recovery codes present) is completable only by a new client. `mfaMethod` must always itself be an allowed option or, when the primary factor is disallowed by live policy, the response must still carry a usable `passkey`/`recovery` option — never a `mfaMethod` the record would reject.
 
 The response must expose at least one usable option. If policy and enrollment drift leave no usable primary, passkey, or recovery method, login fails closed with the existing generic authentication-error shape rather than issuing a challenge that cannot complete.
 
-The pending MFA record stores the authoritative `allowedMethods` and `recoveryAvailable` snapshot. `/auth/mfa/verify` accepts `method: 'recovery'` only when the record permits recovery, and continues to consume exactly one valid code atomically. Passkey verification continues through its dedicated WebAuthn endpoints and must satisfy the pending record's passkey flag.
+The pending MFA record (`PendingMfaRecord`, `routes/auth/helpers.ts`, Redis `mfa:pending:<tempToken>`) already stores `allowedMethods: {totp, sms, passkey}`; this change adds `recoveryAvailable`. `parsePendingMfa` stays strict: a record missing or mistyping any `allowedMethods` boolean or `recoveryAvailable` is rejected (401), never defaulted permissively. Records written before deploy lack `recoveryAvailable` and are rejected for at most the 300 s pending TTL; that is accepted.
 
-At verification time, the server re-checks live policy, factor ownership, epochs, and W07 transition authority. A method disabled after password verification fails without consuming the pending challenge or a recovery code unless the current security contract already requires terminal invalidation for that failure class.
+**Method-switch algorithm (normative).** Today `/auth/mfa/verify` ignores the client's `method` for TOTP/SMS and uses only `pending.mfaMethod` ("never allow the client to override"). This change replaces that with server-authorized selection:
+
+1. Parse `method` strictly (`'totp' | 'sms' | 'recovery'`; unknown → 400). Default when absent: `pending.mfaMethod` (legacy clients).
+2. `totp`/`sms`: require `pending.allowedMethods[method] === true` **and** that the account is actually enrolled in that factor (`mfaSecret` present for TOTP; `mfaMethod === 'sms'` with a phone number for SMS) **and** live `getEffectiveMfaPolicy(...).allowedMethods[method]`. Any failure → 401 with the existing generic error; audit `mfa_method_not_allowed`.
+3. `recovery`: require `pending.recoveryAvailable === true`; the hash check and relative jsonb delete stay inside the guarded finalization exactly as today (`consumeRecoveryCode`).
+4. Passkey verification stays on its dedicated WebAuthn routes (`routes/auth/passkeys.ts`) and must additionally require `pending.allowedMethods.passkey === true`.
+
+`POST /auth/mfa/send-sms` (and any other pending-token continuation, including passkey challenge issuance) must independently authorize the pending token, the selected method against the pending record and live policy, epochs/status expectation, and the existing challenge-keyed rate limit. Selecting a method mints no authority.
+
+At verification time, the server re-checks live policy, factor ownership, epochs, and W07 transition authority. Current behavior is normative and unchanged by this spec:
+
+- A method disallowed by live policy after password verification is **terminal**: the pending record is deleted (`redis.del`, `routes/auth/mfa.ts`) and the user must sign in again. It is not a soft failure that returns to method selection, because a client could otherwise probe policy state against a live challenge.
+- Under the W07 v1 header path, a recovery code is consumed only inside `finishAuthIssuance`, so a logout-pending transition never burns a code.
+- On the legacy (non-v1) path the recovery code is consumed in its own transaction **before** session issuance, as today. This spec does not change that; it is retired with the legacy path in W07 Phase 2.
+- Wrong code, unavailable method, and stale-record failures do not delete the pending record beyond what the existing rate limiter and epoch checks already do.
 
 ## Web Client
 
@@ -86,12 +101,15 @@ Changing to SMS sends a code once for the selected challenge and retains the exi
 
 Forced enrollment becomes policy-driven:
 
-- The forced-enrollment page calls `GET /auth/mfa/enrollment-options` with its limited authenticated session. The response is `{ allowedMethods: { totp: boolean; sms: boolean; passkey: boolean }, phoneConfigured: boolean }`; it never includes recovery because recovery depends on a primary factor.
+- Forced enrollment is not a limited session: login mints a full session and `middleware/auth.ts` returns `428 mfa_enrollment_required` on every route outside `isMfaEnrollmentExemptPath`. The forced-enrollment page calls the new `GET /auth/mfa/enrollment-options` (authenticated). Because `/auth/mfa/*`, `/auth/phone/*`, and `/auth/passkeys/*` are already exempt, no middleware change is needed — the implementation must add a test asserting the new route is reachable in the 428-gated state. The response is `{ allowedMethods: { totp: boolean; sms: boolean; passkey: boolean }, phoneConfigured: boolean }`, derived from `getEffectiveMfaPolicy` for the caller's resolved scope/org/partner; it never includes recovery because recovery depends on a primary factor.
+- `getEffectiveMfaPolicy` currently hardcodes `passkey: true` (`services/mfaPolicy.ts`, phishing-resistant factor is always permitted), so the "no method available" server case is unreachable today. The fail-closed rule stays as defense in depth for a future policy that can restrict passkeys.
 - TOTP reuses the current setup/enable flow.
 - SMS reuses the existing phone verification/enrollment flow.
 - Passkey reuses the current registration-grant/WebAuthn flow.
 - Recovery is never offered as enrollment because it depends on a primary factor.
 - If no enrollment method is available, the page fails closed and directs the user to an administrator instead of defaulting to TOTP.
+
+Enrolling **any one** permitted method satisfies the policy requirement. Completion is atomic per factor: the existing enable/verify endpoint for that factor (TOTP enable, SMS phone verify, passkey registration finish) sets the account enrolled, generates recovery codes once, and clears the enrollment-required state in the same transaction it uses today; the client then re-issues MFA-assured credentials through the existing refresh path so the pre-enrollment `mfa=false` assurance is not reused. A partial or abandoned enrollment (setup started, never enabled) leaves the user in the 428-gated state with no factor recorded; no half-enrolled factor is ever persisted as enabled.
 
 Successful enrollment updates the authenticated user, preserves W07 generation-safe session handling, displays any newly generated recovery codes exactly once, and returns to the intended destination.
 
@@ -109,7 +127,9 @@ The MFA screen:
 
 All successful completions continue through `commitIfCurrent`. Logout, account switch, or a newer login generation prevents stale MFA responses from installing credentials, CSRF state, or native binding state.
 
-Mobile forced enrollment is not added in this change because #3854 scopes login/session completion, while the existing API does not yet expose a native forced-enrollment navigation contract. A mobile login response that requires enrollment must remain fail-closed with an actionable web/admin handoff rather than silently granting normal app access.
+Mobile forced enrollment UI is not added in this change because #3854 scopes login/session completion, while the existing API does not yet expose a native forced-enrollment navigation contract. **Today mobile ignores `mfaEnrollmentRequired` entirely** and installs a session that then 428s on every gated route. Slice 4 must add explicit handling: when the login response carries `mfaEnrollmentRequired: true`, mobile does not install the credentials as a normal session and instead shows a fail-closed screen with an actionable web/admin handoff. This is new behavior, not preservation of existing behavior.
+
+`commitIfCurrent` semantics are normative: logout and account switch advance the session generation **before** clearing local state, and installation of tokens, CSRF state, account identity, and the native binding is a single current-generation commit — never partial.
 
 ## Error Handling and Security Properties
 
@@ -129,7 +149,9 @@ Mobile forced enrollment is not added in this change because #3854 scopes login/
 - Allowed-method derivation for TOTP, SMS, passkey, recovery, mixed methods, and no-usable-method failure.
 - Auth/authz and policy tests for `GET /auth/mfa/enrollment-options`, including limited forced-enrollment sessions and cross-tenant policy inheritance.
 - Malformed/stale pending-record rejection.
-- Live-policy disablement between password and verification.
+- Live-policy disablement between password and verification (terminal: pending record deleted).
+- Method-switch matrix: requested method not in pending `allowedMethods`, allowed-but-not-enrolled, allowed-and-enrolled; strict rejection of records missing `recoveryAvailable`.
+- `send-sms` with SMS not in pending `allowedMethods`.
 - Recovery unavailable, invalid, identical-code race, distinct-code race, and no-consumption on failed W07 admission.
 - Cross-user and cross-tenant pending-token rejection.
 
@@ -150,6 +172,7 @@ Mobile forced enrollment is not added in this change because #3854 scopes login/
 - Unsupported-method and empty-method handling.
 - SMS selection/resend lifecycle.
 - Stale MFA completion after logout, account switch, or newer login generation.
+- `mfaEnrollmentRequired` login response does not install a normal session.
 - Credential and native-binding installation only for the current generation.
 
 ## Delivery Slices

--- a/docs/testing/FEATURE_TEST_LOG.md
+++ b/docs/testing/FEATURE_TEST_LOG.md
@@ -5102,3 +5102,25 @@ above. The previous sweep reached #3494 — the window between #3494 and #3805 i
    404s on every device-tab switch to mean "no data yet"; the channels empty state blames filters
    when there is simply nothing yet.
 
+---
+
+## MFA Client Completion — 2026-08-28
+
+Implemented the approved #2489 / #3853 / #3854 client-completion slices on
+`feat/2489-mfa-client-completion` without push, deploy, rollout-flag changes, or W07 native transport.
+
+- API full unit suite: **PASS** — 1,597 files passed, 3 skipped; 28,118 tests passed, 22 skipped.
+- Web full unit suite: **PASS** — 660 files / 6,806 tests passed.
+- Mobile full unit suite: **PASS** — 54 files passed; 648 tests passed, 3 skipped.
+- Auth-focused API regression set: **PASS** — 163 tests, including live TOTP policy checks,
+  auth/MFA epoch CAS behavior, method switching, recovery handling, SMS, passkey, and atomic enrollment.
+- Web MFA/store regressions: **PASS** — delayed enrollment responses cannot overwrite logout or a
+  replacement login; locale parity passes for all supported locales.
+- API and web TypeScript checks, mobile typecheck, API/web lint, and API/web production builds: **PASS**.
+- Independent security review: no critical findings; all three important findings were fixed and
+  covered by regressions. The passkey compatibility alias was also aligned with the policy-filtered
+  method set.
+- Real-Postgres atomicity suite: **NOT RUN (environment unavailable)** — the integration runner could
+  not connect to PostgreSQL at `localhost:5433` (`ECONNREFUSED`). The suite contains rollback,
+  concurrent single-winner enrollment, and concurrent `auth_epoch` cutoff coverage and must run in CI
+  or once the integration database is available.

--- a/docs/testing/FEATURE_TEST_LOG.md
+++ b/docs/testing/FEATURE_TEST_LOG.md
@@ -5119,7 +5119,7 @@ Implemented the approved #2489 / #3853 / #3854 client-completion slices on
 - API and web TypeScript checks, mobile typecheck, API/web lint, and API/web production builds: **PASS**.
 - Independent security review: no critical findings; all three important findings were fixed and
   covered by regressions. The passkey compatibility alias was also aligned with the policy-filtered
-  method set.
+  method set, and invalid SSO-link recovery attempts now preserve the original retry window.
 - Real-Postgres atomicity suite: **NOT RUN (environment unavailable)** — the integration runner could
   not connect to PostgreSQL at `localhost:5433` (`ECONNREFUSED`). The suite contains rollback,
   concurrent single-winner enrollment, and concurrent `auth_epoch` cutoff coverage and must run in CI

--- a/docs/testing/FEATURE_TEST_LOG.md
+++ b/docs/testing/FEATURE_TEST_LOG.md
@@ -5120,7 +5120,6 @@ Implemented the approved #2489 / #3853 / #3854 client-completion slices on
 - Independent security review: no critical findings; all three important findings were fixed and
   covered by regressions. The passkey compatibility alias was also aligned with the policy-filtered
   method set, and invalid SSO-link recovery attempts now preserve the original retry window.
-- Real-Postgres atomicity suite: **NOT RUN (environment unavailable)** — the integration runner could
-  not connect to PostgreSQL at `localhost:5433` (`ECONNREFUSED`). The suite contains rollback,
-  concurrent single-winner enrollment, and concurrent `auth_epoch` cutoff coverage and must run in CI
-  or once the integration database is available.
+- Real-Postgres atomicity suite: **PASS** — 3 tests covering rollback, concurrent single-winner
+  enrollment, and concurrent `auth_epoch` cutoff. The concurrency barrier follows PostgreSQL's full
+  transitive lock-wait chain so queued enrollment transactions are counted deterministically.


### PR DESCRIPTION
## Summary

- Complete policy-filtered browser MFA challenges, strict pending-method switching, independently authorized continuations, and atomic per-factor enrollment completion.
- Add web forced-enrollment and method-selection UX plus mobile fail-closed enrollment handoff with generation-safe session commits.
- Preserve SSO recovery retry ceremony, align passkey compatibility behavior, and add regression/integration coverage for the completed auth flows.

## Linked Issues

Closes #2489

Closes #3853

Refs #3854 — this ships native challenge parsing, method UX, enrollment-required fail-closed handoff, and generation fencing. W07 native-binding transport/bootstrap/retry and the native transition-binding header remain deferred, so #3854 stays open.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other:

## Testing

- [x] Existing tests pass (`pnpm test` / `make test`)
- [x] Added new tests
- [ ] Manual testing (describe below)

- Real-Postgres MFA atomicity integration suite: 3/3 passed (rollback, concurrent single-winner enrollment, concurrent `auth_epoch` cutoff).
- Web: 660 files / 6,806 tests passed; mobile: 54 files / 648 tests passed, 3 skipped.
- API: clean full run before the final test-only barrier adjustment (1,597 files / 28,118 tests), with changed auth regressions and the adjusted integration suite passing. A repeat full run on the shared host hit fixed-timeout failures in unrelated import/filesystem scans under system-wide CPU contention; CI remains the clean full-suite gate.
- API/web lint, API/mobile TypeScript checks, Astro check (0 errors), and API/web production builds passed.
- Independent security review completed; all important findings were fixed and covered by regressions.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included
