### PR TITLE
fix(api): unwrap DrizzleQueryError when reading SQLSTATE in networkBaselines and aiAgents (#4020)

### DIFF
--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -1766,3 +1766,61 @@ describe('mapError — supervisedActionKeys write-time rejection (wave 5 Part B,
     );
   });
 });
+
+/**
+ * Regression for #4020. The create race is settled by the partial unique index,
+ * and the insert that loses it is issued through Drizzle — which catches the
+ * postgres-js `PostgresError` and rethrows a `DrizzleQueryError` whose own
+ * `.code` is undefined, with the SQLSTATE on `.cause`. A flat fixture passes
+ * whether or not the handler unwraps, so the wrapped shape is the one that
+ * actually discriminates.
+ */
+describe('mapError — create-race unique violation (#4020)', () => {
+  const callMapError = (err: unknown) => {
+    const jsonMock = vi.fn((body: unknown, status: number) => ({ body, status }));
+    const ctx = { json: jsonMock } as unknown as Parameters<typeof mapError>[0];
+    let threw: unknown;
+    try {
+      mapError(ctx, err);
+    } catch (e) {
+      threw = e;
+    }
+    return { jsonMock, threw };
+  };
+
+  const CONFLICT = { error: 'An agent of this kind already exists', code: 'agent_kind_exists' };
+
+  it('maps a flat postgres.js 23505 to 409', () => {
+    const { jsonMock } = callMapError(
+      Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' }),
+    );
+
+    expect(jsonMock).toHaveBeenCalledWith(CONFLICT, 409);
+  });
+
+  it('maps a 23505 WRAPPED in a DrizzleQueryError to 409, not a 500', () => {
+    // Faithful to Drizzle: own `.code` undefined, SQLSTATE on `.cause`.
+    const cause = Object.assign(
+      new Error('duplicate key value violates unique constraint "ai_agents_org_kind_uq"'),
+      { code: '23505', constraint_name: 'ai_agents_org_kind_uq' },
+    );
+    const wrapped = Object.assign(new Error('Failed query: insert into "ai_agents" ...'), { cause });
+    wrapped.name = 'DrizzleQueryError';
+
+    const { jsonMock, threw } = callMapError(wrapped);
+
+    expect(threw).toBeUndefined();
+    expect(jsonMock).toHaveBeenCalledWith(CONFLICT, 409);
+  });
+
+  it('rethrows a wrapped SQLSTATE that is not a unique violation', () => {
+    const cause = Object.assign(new Error('null value in column violates not-null constraint'), { code: '23502' });
+    const wrapped = Object.assign(new Error('Failed query: insert into "ai_agents" ...'), { cause });
+    wrapped.name = 'DrizzleQueryError';
+
+    const { jsonMock, threw } = callMapError(wrapped);
+
+    expect(threw).toBe(wrapped);
+    expect(jsonMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -1792,7 +1792,10 @@ describe('mapError — create-race unique violation (#4020)', () => {
 
   it('maps a flat postgres.js 23505 to 409', () => {
     const { jsonMock } = callMapError(
-      Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' }),
+      Object.assign(
+        new Error('duplicate key value violates unique constraint "ai_agents_org_kind_uq"'),
+        { code: '23505', constraint_name: 'ai_agents_org_kind_uq' },
+      ),
     );
 
     expect(jsonMock).toHaveBeenCalledWith(CONFLICT, 409);
@@ -1803,6 +1806,41 @@ describe('mapError — create-race unique violation (#4020)', () => {
     const cause = Object.assign(
       new Error('duplicate key value violates unique constraint "ai_agents_org_kind_uq"'),
       { code: '23505', constraint_name: 'ai_agents_org_kind_uq' },
+    );
+    const wrapped = Object.assign(new Error('Failed query: insert into "ai_agents" ...'), { cause });
+    wrapped.name = 'DrizzleQueryError';
+
+    const { jsonMock, threw } = callMapError(wrapped);
+
+    expect(threw).toBeUndefined();
+    expect(jsonMock).toHaveBeenCalledWith(CONFLICT, 409);
+  });
+
+  /**
+   * The constraint scoping is itself a discriminating property, and needs a
+   * fixture that can tell the difference. A 23505 from some OTHER unique index
+   * does not mean "this kind is taken", so answering `agent_kind_exists` would
+   * be a wrong-but-plausible 409 that nothing logs — strictly worse than the
+   * 500 it would otherwise get, which is loud and reaches Sentry.
+   */
+  it('does not mislabel a 23505 from an unrelated constraint as agent_kind_exists', () => {
+    const cause = Object.assign(
+      new Error('duplicate key value violates unique constraint "some_other_table_uq"'),
+      { code: '23505', constraint_name: 'some_other_table_uq' },
+    );
+    const wrapped = Object.assign(new Error('Failed query: insert into "some_other_table" ...'), { cause });
+    wrapped.name = 'DrizzleQueryError';
+
+    const { jsonMock, threw } = callMapError(wrapped);
+
+    expect(threw).toBe(wrapped);
+    expect(jsonMock).not.toHaveBeenCalled();
+  });
+
+  it('maps a wrapped 23505 on the PARTNER-wide index to 409 too', () => {
+    const cause = Object.assign(
+      new Error('duplicate key value violates unique constraint "ai_agents_partner_kind_uq"'),
+      { code: '23505', constraint_name: 'ai_agents_partner_kind_uq' },
     );
     const wrapped = Object.assign(new Error('Failed query: insert into "ai_agents" ...'), { cause });
     wrapped.name = 'DrizzleQueryError';

--- a/apps/api/src/routes/networkBaselines.ts
+++ b/apps/api/src/routes/networkBaselines.ts
@@ -24,6 +24,7 @@ import {
   mapNetworkChangeRow,
   resolveOrgId
 } from './networkShared';
+import { pgErrorCode } from '../utils/pgErrors';
 
 export const networkBaselineRoutes = new Hono();
 
@@ -539,8 +540,13 @@ networkBaselineRoutes.delete(
           .where(eq(networkBaselines.id, baseline.id));
       }
     } catch (error) {
-      const pgError = error as { code?: string };
-      if (!deleteChanges && pgError.code === '23503') {
+      // Read the SQLSTATE through `pgErrorCode`: drizzle-orm/postgres-js
+      // catches the postgres-js `PostgresError` and rethrows a
+      // `DrizzleQueryError` whose own `.code` is undefined, with the real code
+      // on `.cause`. Reading `error.code` directly (as this did until #4020)
+      // made the branch unreachable for every Drizzle-issued delete, so the
+      // 409 + `hint` below were never actually delivered.
+      if (!deleteChanges && pgErrorCode(error) === '23503') {
         return c.json({
           error: 'Cannot delete baseline without deleting associated change events',
           hint: 'Use ?deleteChanges=true to delete events with the baseline'

--- a/apps/api/src/routes/networkBaselines.ts
+++ b/apps/api/src/routes/networkBaselines.ts
@@ -540,12 +540,19 @@ networkBaselineRoutes.delete(
           .where(eq(networkBaselines.id, baseline.id));
       }
     } catch (error) {
-      // Read the SQLSTATE through `pgErrorCode`: drizzle-orm/postgres-js
-      // catches the postgres-js `PostgresError` and rethrows a
-      // `DrizzleQueryError` whose own `.code` is undefined, with the real code
-      // on `.cause`. Reading `error.code` directly (as this did until #4020)
-      // made the branch unreachable for every Drizzle-issued delete, so the
-      // 409 + `hint` below were never actually delivered.
+      // Read the SQLSTATE through `pgErrorCode` (utils/pgErrors.ts, which owns
+      // the unwrap contract): Drizzle hides the real code behind `.cause`, so
+      // reading `error.code` directly -- as this did until #4020 -- made the
+      // branch unreachable for every Drizzle-issued delete. The 409 and its
+      // `hint` below were never actually delivered.
+      //
+      // Bare code check rather than a constraint-scoped one because
+      // network_change_events.baseline_id is currently the ONLY FK referencing
+      // network_baselines(id), so a 23503 escaping this delete can only mean
+      // what the hint says. If a second table ever references
+      // network_baselines, narrow this to that constraint name -- otherwise the
+      // new violation inherits this hint, `?deleteChanges=true` will not clear
+      // it, and the caller retries into the same wall.
       if (!deleteChanges && pgErrorCode(error) === '23503') {
         return c.json({
           error: 'Cannot delete baseline without deleting associated change events',

--- a/apps/api/src/routes/networkBaselines_changes_delete_multitenant.test.ts
+++ b/apps/api/src/routes/networkBaselines_changes_delete_multitenant.test.ts
@@ -380,6 +380,77 @@ describe('networkBaseline routes', () => {
       expect(body.error).toContain('Cannot delete baseline');
       expect(body.hint).toContain('deleteChanges=true');
     });
+
+    /**
+     * Regression for #4020. The flat fixture above passes whether or not the
+     * handler unwraps, so it never caught that the handler read `err.code` at
+     * the top level. The delete is issued through Drizzle, which catches the
+     * postgres-js `PostgresError` and rethrows a `DrizzleQueryError` whose own
+     * `.code` is undefined — the SQLSTATE lives on `.cause`. This is the shape
+     * production actually throws, so it is the shape that must produce the 409.
+     */
+    it('should return 409 when the 23503 is WRAPPED in a DrizzleQueryError (#4020)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([makeBaseline()]),
+          }),
+        }),
+      } as any);
+
+      // Faithful to Drizzle: own `.code` undefined, SQLSTATE on `.cause`.
+      const cause = Object.assign(
+        new Error('update or delete on table "network_baselines" violates foreign key constraint'),
+        { code: '23503', table_name: 'network_change_events' },
+      );
+      const wrapped = Object.assign(new Error('Failed query: delete from "network_baselines" ...'), { cause });
+      wrapped.name = 'DrizzleQueryError';
+
+      vi.mocked(db.delete).mockReturnValueOnce({
+        where: vi.fn().mockRejectedValue(wrapped),
+      } as any);
+
+      const res = await app.request(`/baselines/${BASELINE_ID}?deleteChanges=false`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toContain('Cannot delete baseline');
+      expect(body.hint).toContain('deleteChanges=true');
+    });
+
+    /**
+     * The unwrap must stay code-specific: a wrapped SQLSTATE that is NOT a
+     * foreign-key violation still has to propagate to the global error handler
+     * rather than being mislabelled as a 409 the caller can "fix" with
+     * ?deleteChanges=true.
+     */
+    it('should propagate a wrapped non-FK SQLSTATE instead of answering 409 (#4020)', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([makeBaseline()]),
+          }),
+        }),
+      } as any);
+
+      const cause = Object.assign(new Error('deadlock detected'), { code: '40P01' });
+      const wrapped = Object.assign(new Error('Failed query: delete from "network_baselines" ...'), { cause });
+      wrapped.name = 'DrizzleQueryError';
+
+      vi.mocked(db.delete).mockReturnValueOnce({
+        where: vi.fn().mockRejectedValue(wrapped),
+      } as any);
+
+      const res = await app.request(`/baselines/${BASELINE_ID}?deleteChanges=false`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(500);
+    });
   });
 
   // ----------------------------------------------------------------


### PR DESCRIPTION
Closes #4020

## The bug

`drizzle-orm/postgres-js` catches the postgres-js `PostgresError` and rethrows a `DrizzleQueryError` whose own `.code` is `undefined` — the SQLSTATE lives on `.cause`. A check that reads `err.code` at the top level therefore returns `false` for **every** Drizzle-issued statement, silently killing the branch.

Two handlers still had that shape. Both are now routed through the existing canonical helpers in `apps/api/src/utils/pgErrors.ts` rather than re-implementing the unwrap.

### 1. `routes/networkBaselines.ts` — the 409 hint was unreachable

```ts
const pgError = error as { code?: string };
if (!deleteChanges && pgError.code === '23503') {
```

The error originates from `db.delete(networkBaselines)` a few lines above. A caller passing `?deleteChanges=false` against a baseline that still has `network_change_events` children got a generic **500** instead of the intended **409** carrying `hint: 'Use ?deleteChanges=true to delete events with the baseline'`. **That hint text has existed since the route was written and has never been delivered.**

Now: `pgErrorCode(error) === '23503'`.

### 2. `routes/aiAgents.ts` — the create-race conflict answer was unreachable

```ts
function isUniqueViolation(err: unknown): boolean {
  return typeof err === 'object' && err !== null && (err as { code?: unknown }).code === '23505';
}
```

Its own comment says it exists for "the create race the pre-check cannot win" — the partial unique index settling a concurrent create. Under Drizzle it never matched, so the race surfaced as a **500** rather than the intended **409 `agent_kind_exists`**.

This was also a re-implementation: `isPgUniqueViolation` in `pgErrors.ts` handles exactly this case, walks the `.cause` chain, and additionally reconciles `constraint` vs `constraint_name` across drivers. The local helper is deleted and the call site now uses it.

## Tests — why the originals didn't catch this

Both sites already had tests. They used a **flat** `PostgresError` fixture (`Object.assign(new Error(...), { code: '23503' })`), which passes whether or not the handler unwraps — it does not discriminate. That is exactly how these bugs survived having coverage.

The new regression tests are built on the **wrapped** shape (own `.code` undefined, SQLSTATE on `.cause`, `name = 'DrizzleQueryError'`), copying the faithful fixture from #3998's `tenantCascade.test.ts`:

- `networkBaselines_changes_delete_multitenant.test.ts` — wrapped `23503` must produce 409 + hint.
- `aiAgents.test.ts` — wrapped `23505` must produce 409 `agent_kind_exists`, plus a flat-shape case so both driver shapes stay covered.

Each site also gains a **control** proving the unwrap stayed code-specific: a wrapped non-matching SQLSTATE (`40P01` / `23502`) must still propagate rather than be mislabelled as a conflict the caller can "fix".

Verified red-first: with the fix reverted, exactly the two new wrapped-shape assertions fail (`expected 500 to be 409`) while the pre-existing flat-fixture tests and both controls pass — proof the new tests discriminate and the old ones never could.

## Repo-wide sweep for the same class

Swept `apps/api/src`, `packages/` and `ee/` for both shapes — top-level-only reads (miss the Drizzle wrapper) and `cause`-only reads (miss a flat error from a raw `sql` template). ~60 SQLSTATE-adjacent sites examined.

**Two remaining BROKEN sites, both in the `ee/workspace` extension — NOT fixed here:**

| Site | Shape | Effect |
|---|---|---|
| `ee/workspace/src/services/ingestJobsService.ts:101-102` | top-level-only `23505` | `d.execute(sql\`INSERT … RETURNING *\`)` on a `PostgresJsDatabase` is Drizzle-wrapped, so the concurrent-insert retry fallback in `ensureJob` (re-select the winner) can never fire — a racer throws instead of falling through. |
| `ee/workspace/src/routes/sources.ts:144-146` | top-level-only `23503` | `sourcesService.create`/`.update` use `d.insert`/`d.update`, so the FK branch never matches: a bad `crawlDeviceId` returns a generic 500 instead of the intended 400 `"crawlDeviceId does not reference a known device"`. |

**Deliberately left out of scope:** `ee/workspace` has no dependency on `apps/api` (`@breeze/ext-workspace` deps are `extension-sdk`, `extension-web-sdk`, `drizzle-orm`, `hono`, `mailparser`, `v9u-smb2`, `zod`). Reaching `utils/pgErrors.ts` from there is not the same one-line change — it needs the helper promoted into a shared package or duplicated into the extension. That is a design call, not a mechanical fix, so it should be its own issue rather than being smuggled into this PR.

**Not bugs (checked, for the record):**
- Five `isRelationNotFoundError()` helpers in `jobs/{alertWorker,automationWorker,offlineDetector,patchSchedulerWorker,policyEvaluationWorker}.ts` read only `.cause?.code === '42P01'`. Every call site traces back to a Drizzle-backed call, so cause-only is *correct* there — just duplicated 5× instead of using the shared helper.
- `partnerApi/provisioning.ts`, `partnerServicePrincipals.ts`, `pax8OrderService.ts`, `pax8SyncService.ts`, `tenantVariables.ts`, `m365ControlPlane/connectionService.ts` all hand-roll a manual cause-chain walk that already covers both shapes correctly.
- `aiToolsFleet.ts`, `aiToolsPolicyPrereqs.ts`, `devices/core.ts`, `backup/profiles.ts`, `softwareInstallMethods.ts` already use `pgErrorCode`.

The issue also suggests a **lint rule or contract test** that greps for `.code === '<5-char SQLSTATE>'` outside `utils/pgErrors.ts`. That would have caught all five instances of this class and is the durable fix — not attempted here to keep this PR to the two in-scope call sites.

## Relationship to #3881

Same bug family. #3881 / PR #3921 (merged 2026-08-24) fixed the two call sites in `softwareInstallMethods.ts`; #3998 fixed `tenantCascade.isUndefinedTable` and `routes/agents/connections.ts`. **No file overlap with this PR** — the branch `fix/3881-drizzle-sqlstate-unwrap` touches only `softwareInstallMethods.{ts,test.ts}`. This is instances 4 and 5 of the class.

## Review follow-up (commit 2)

Four reviewers ran (`code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer`, `comment-analyzer`). Two independently flagged that `isPgUniqueViolation(err)` was called **unscoped**, so it matched any 23505 reaching `mapError`.

**Not a live bug** — every write reachable from `createAgent`/`updateAgent`/`disableAgent` was traced: the only statement that can raise 23505 is the `ai_agents` insert itself (`ensureManagedTriageAutomation` inserts `automations` with `.onConflictDoNothing()`; `audit_logs` has no unique constraint besides its random-UUID PK). Also, `updateAiAgentSchema` drops `kind`/`ownerScope`/`orgId`, so only the create path can reach either index.

**Changed anyway, because the failure modes are asymmetric:**

| | If it regresses | Visibility |
|---|---|---|
| Unscoped | a future unrelated unique constraint gets answered `agent_kind_exists` / 409 | **silent** — wrong but plausible, nothing logs |
| Scoped | an index rename stops the branch matching, race reverts to 500 | **loud** — reaches Sentry |

Prefer the loud failure. It's also the repo convention — `orgs.ts`, `emailVerification.ts`, `officeAddinBindings.ts`, `partnerStripe.ts`, `quoteService.ts`, `ticketConfigService.ts` and `alertVerdicts.ts` all pass a constraint. `ai_agents` is dual-ownership, so the invariant needs one partial index per axis and the branch accepts either.

Tests gained the discriminating case both reviewers asked for (a wrapped 23505 from an unrelated constraint must be **rethrown**, not mislabelled), plus partner-wide index coverage. The flat fixture now carries its constraint name so it exercises the matching path instead of passing by accident.

**Not done, deliberately:** a metric/log on how often each 409 branch fires (`silent-failure-hunter` suggestion 4). Worth doing — this PR's whole premise is that these paths were unmeasured — but it's an observability change, not a bug fix, so it belongs in its own PR.

**Pre-existing gap left alone:** the `deleteChanges=true` transaction path in `networkBaselines.ts` has no error-propagation coverage at all (`pr-test-analyzer` gap 1). Predates this PR and reuses the same unwrap.

## Verification

- `vitest run --pool=threads --maxWorkers=2 src/routes/networkBaselines_changes_delete_multitenant.test.ts src/routes/aiAgents.test.ts src/utils/pgErrors.test.ts` → **3 files, 96 tests passed**.
- `tsc --noEmit` in `apps/api` → **clean, exit 0, 0 errors** on both commits (383s on commit 1, 387s on commit 2). Commit 2's typecheck took three attempts: the first two were killed at a 580s wall with 0 errors emitted while this host had 13 competing `tsc` processes, and it completed cleanly once load dropped. CI's **Type Check** job is the authoritative confirmation.
- No schema, migration, tenancy or cascade surface touched — error-mapping only, no new tables or columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


